### PR TITLE
chore(deploy): route default deploy through Cloudflare built-in auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,9 @@
     "db:migrations:list:remote:oauth": "npm run db:migrations:list:remote",
     "db:backup:remote": "node ./scripts/d1-backup.mjs --remote",
     "db:reset:remote": "node ./scripts/d1-reset.mjs --remote",
-    "deploy": "npm run build && node ./scripts/wrangler-oauth.mjs deploy",
-    "deploy:oauth": "npm run deploy",
+    "deploy": "npm run build && npx wrangler deploy",
+    "deploy:oauth": "npm run build && node ./scripts/wrangler-oauth.mjs deploy",
+    "deploy:ci": "npm run deploy",
     "ops:tail": "node ./scripts/wrangler-oauth.mjs tail ks2-mastery --format pretty",
     "test": "node --test",
     "verify": "npm test && npm run check"


### PR DESCRIPTION
## Summary
- Swap `deploy` script so Workers Builds non-interactive CI can deploy without `CLOUDFLARE_API_TOKEN`
- Move browser-OAuth path to `deploy:oauth` for local devs who still want it
- Keep `deploy:ci` as an explicit alias of the new default

## Why
Every main push since 2026-04-20 23:44 has failed with

```
In a non-interactive environment, it's necessary to set a
CLOUDFLARE_API_TOKEN environment variable for wrangler to work.
```

because `npm run deploy` was routed through `scripts/wrangler-oauth.mjs`, which deliberately deletes `CLOUDFLARE_API_TOKEN` to force a browser OAuth prompt. Production `ks2.eugnel.uk` is consequently stuck on an older successfully-deployed version (pre-pass-14).

After this PR the dashboard's existing "Deploy command = `npm run deploy`" starts succeeding again automatically — no dashboard edit required. Local devs who relied on browser OAuth run `npm run deploy:oauth` instead.

## Test plan
- [x] `npm test` → 69/69 (no runtime change)
- [x] `npm run build` → OK
- [x] `npm run assert:build-public` → OK
- [x] `npx wrangler deploy --dry-run` → OK
- [ ] Merge → Cloudflare Workers Builds runs `npm run deploy` → success → `ks2.eugnel.uk` updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)