### PR TITLE
Fix Extra spelling runtime for legacy content

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The goal is not to polish the old prototype. The goal is to give the product a s
   - The rebuilt English Spelling slice.
   - The legacy spelling engine is preserved and wrapped behind a clean service.
   - The spelling service now owns an explicit serialisable state contract, deterministic transitions, resume-safe restoration, and domain-event emission.
-  - Spelling content now has a versioned draft/published content model. Learner runtime reads are pinned to the published release snapshot, not live draft rows.
+  - Spelling content now has a versioned draft/published content model. Learner runtime reads are pinned to published release snapshots, not live draft rows, with current seeded additions supplemented for older account-scoped seed releases.
 - `src/subjects/placeholders/*`
   - Clean extension slots for Arithmetic, Reasoning, Grammar, Punctuation and Reading.
 - `worker/*`

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -278,7 +278,7 @@ Current adapters:
   - writes through `PUT /api/content/spelling`
   - tracks account revision because content writes and learner-profile writes share `adult_accounts.repo_revision`
 
-The runtime spelling service receives `spellingContent.getRuntimeSnapshot()` and reads only the published release snapshot. Draft edits do not leak into live learner sessions until the operator publishes the draft.
+The runtime spelling service receives `spellingContent.getRuntimeSnapshot()` and reads published content only. Draft edits do not leak into live learner sessions until the operator publishes the draft. Accounts still pinned to an older seeded published release are supplemented at runtime with missing words from the bundled current seed release, so seed content additions remain available without rewriting account content.
 
 The detailed policy lives in `docs/mutation-policy.md`.
 

--- a/docs/spelling-content-model.md
+++ b/docs/spelling-content-model.md
@@ -190,7 +190,7 @@ It follows the current published release.
 
 - `createSpellingService()` can now receive a `contentSnapshot`.
 - The main shell rebuilds the spelling service from `spellingContent.getRuntimeSnapshot()`.
-- `getRuntimeSnapshot()` resolves the currently published release snapshot only.
+- `getRuntimeSnapshot()` resolves published content only. If an account is still on an older published seed release, the runtime supplements missing words from the bundled current seed release while preserving the account's own published words.
 - If an explicit word is requested and it does not exist in the published snapshot, session start now fails cleanly instead of silently falling back to a different round.
 
 That last rule matters for safety: content-pinning should not quietly drift into a different session than the caller asked for.

--- a/docs/spelling-parity.md
+++ b/docs/spelling-parity.md
@@ -83,7 +83,7 @@ These deltas remain on purpose.
 Pass 11 changes where spelling content lives, not the learner-facing pedagogy.
 
 - statutory word lists, word metadata, accepted answers, and sentence banks now live in a versioned draft/published content bundle
-- learner runtime reads are pinned to the published release snapshot
+- learner runtime reads are pinned to published release snapshots, with current seeded additions supplemented for older account-scoped seed releases
 - draft edits, imports, and resets stay operator-side until the draft is published
 - prompt text and spoken TTS text still come from the same saved prompt, preserving the Pass 10 fix for display/audio mismatch
 - explicit one-word sessions now fail cleanly if the requested slug is not in the published snapshot instead of silently starting a different round

--- a/docs/spelling-service.md
+++ b/docs/spelling-service.md
@@ -143,7 +143,7 @@ Pass 11 moves spelling word lists, words, and sentence banks into a versioned co
 What changed:
 
 - operators edit a draft bundle through import/export, reset, and publish controls
-- learner sessions read the current published release snapshot only
+- learner sessions read published content only; legacy accounts on older seeded releases are supplemented at runtime with missing words from the bundled current seed release
 - the runtime service is rebuilt after content mutations so new published content is picked up without leaking unpublished draft rows
 - explicit word starts fail cleanly if the slug is absent from the published snapshot
 - event metadata now follows the injected content snapshot, so secured-word and retry-cleared events stay aligned with edited content

--- a/src/subjects/spelling/content/model.js
+++ b/src/subjects/spelling/content/model.js
@@ -566,6 +566,51 @@ export function resolvePublishedSnapshot(rawBundle) {
   return release ? cloneSerialisable(release.snapshot) : null;
 }
 
+function mergeRuntimeSnapshots(primarySnapshot, supplementalSnapshot) {
+  const primary = normalisePublishedSnapshot(primarySnapshot);
+  const supplemental = normalisePublishedSnapshot(supplementalSnapshot);
+  const wordsBySlug = new Map(primary.words.map((word) => [word.slug, word]));
+
+  for (const word of supplemental.words) {
+    if (!wordsBySlug.has(word.slug)) {
+      wordsBySlug.set(word.slug, word);
+    }
+  }
+
+  const words = [...wordsBySlug.values()].sort((a, b) => a.sortIndex - b.sortIndex);
+  return {
+    generatedAt: Math.max(primary.generatedAt, supplemental.generatedAt),
+    words,
+    wordBySlug: Object.fromEntries(words.map((word) => [word.slug, word])),
+  };
+}
+
+export function resolveRuntimeSnapshot(rawBundle, { referenceBundle = null } = {}) {
+  const bundle = normaliseSpellingContentBundle(rawBundle);
+  const publishedRelease = resolvePublishedRelease(bundle, { fallbackToLatest: true });
+  const published = publishedRelease ? cloneSerialisable(publishedRelease.snapshot) : null;
+  const reference = referenceBundle ? normaliseSpellingContentBundle(referenceBundle) : null;
+  const referenceRelease = reference ? resolvePublishedRelease(reference, { fallbackToLatest: true }) : null;
+  const referencePublished = referenceRelease ? cloneSerialisable(referenceRelease.snapshot) : null;
+
+  if (!published) return referencePublished ? cloneSerialisable(referencePublished) : null;
+  if (!referencePublished) return cloneSerialisable(published);
+
+  const publishedVersion = bundle.publication.publishedVersion
+    || publishedRelease?.version
+    || 0;
+  const referenceVersion = reference.publication.publishedVersion
+    || referenceRelease?.version
+    || 0;
+  const publishedAt = publishedRelease?.publishedAt || bundle.publication.updatedAt || 0;
+  const referencePublishedAt = referenceRelease?.publishedAt || reference.publication.updatedAt || 0;
+
+  if (publishedVersion >= referenceVersion && publishedAt >= referencePublishedAt) {
+    return cloneSerialisable(published);
+  }
+  return mergeRuntimeSnapshots(published, referencePublished);
+}
+
 function nextReleaseId(bundle, version) {
   return `spelling-r${version}`;
 }

--- a/src/subjects/spelling/content/service.js
+++ b/src/subjects/spelling/content/service.js
@@ -6,7 +6,7 @@ import {
   extractPortableSpellingContent,
   normaliseSpellingContentBundle,
   publishSpellingContentBundle,
-  resolvePublishedSnapshot,
+  resolveRuntimeSnapshot,
   validateSpellingContentBundle,
 } from './model.js';
 import { SEEDED_SPELLING_CONTENT_BUNDLE, SEEDED_SPELLING_PUBLISHED_SNAPSHOT } from '../data/content-data.js';
@@ -41,7 +41,7 @@ export function createSpellingContentService({ repository, seededBundle = SEEDED
 
   function getRuntimeSnapshot() {
     const current = readBundle();
-    const published = resolvePublishedSnapshot(current);
+    const published = resolveRuntimeSnapshot(current, { referenceBundle: seeded });
     if (published?.words?.length) return cloneSerialisable(published);
     return cloneSerialisable(SEEDED_SPELLING_PUBLISHED_SNAPSHOT);
   }

--- a/tests/helpers/spelling-content.js
+++ b/tests/helpers/spelling-content.js
@@ -1,0 +1,28 @@
+import { cloneSerialisable } from '../../src/platform/core/repositories/helpers.js';
+
+export function coreOnlyVersionOneContent(bundle) {
+  const next = cloneSerialisable(bundle);
+  const coreWords = next.draft.words.filter((word) => word.spellingPool !== 'extra');
+  const coreSlugs = new Set(coreWords.map((word) => word.slug));
+  const coreListIds = new Set(coreWords.map((word) => word.listId));
+  next.modelVersion = 1;
+  next.draft.wordLists = next.draft.wordLists
+    .filter((list) => coreListIds.has(list.id))
+    .map(({ spellingPool: _spellingPool, ...list }) => list);
+  next.draft.words = coreWords.map(({ spellingPool: _spellingPool, ...word }) => word);
+  next.draft.sentences = next.draft.sentences.filter((sentence) => coreSlugs.has(sentence.wordSlug));
+
+  const release = cloneSerialisable(next.releases.find((entry) => entry.version === 1) || next.releases[0]);
+  const releaseWords = release.snapshot.words
+    .filter((word) => word.spellingPool !== 'extra')
+    .map(({ spellingPool: _spellingPool, ...word }) => word);
+  release.snapshot.words = releaseWords;
+  release.snapshot.wordBySlug = Object.fromEntries(releaseWords.map((word) => [word.slug, word]));
+  next.releases = [release];
+  next.publication = {
+    currentReleaseId: release.id,
+    publishedVersion: release.version,
+    updatedAt: release.publishedAt,
+  };
+  return next;
+}

--- a/tests/spelling-content-api.test.js
+++ b/tests/spelling-content-api.test.js
@@ -8,6 +8,7 @@ import { cloneSerialisable } from '../src/platform/core/repositories/helpers.js'
 import { createApiSpellingContentRepository } from '../src/subjects/spelling/content/repository.js';
 import { SEEDED_SPELLING_CONTENT_BUNDLE } from '../src/subjects/spelling/data/content-data.js';
 import { installMemoryStorage } from './helpers/memory-storage.js';
+import { coreOnlyVersionOneContent } from './helpers/spelling-content.js';
 import { createWorkerRepositoryServer } from './helpers/worker-server.js';
 
 async function waitForPersistenceIdle(repositories, attempts = 60) {
@@ -92,33 +93,6 @@ function addExtraWordList(bundle) {
     provenance: { source: 'tests', note: 'Added inside tests.' },
     sortIndex: 9999,
   });
-  return next;
-}
-
-function coreOnlyVersionOneContent(bundle) {
-  const next = cloneSerialisable(bundle);
-  const coreWords = next.draft.words.filter((word) => word.spellingPool !== 'extra');
-  const coreSlugs = new Set(coreWords.map((word) => word.slug));
-  const coreListIds = new Set(coreWords.map((word) => word.listId));
-  next.modelVersion = 1;
-  next.draft.wordLists = next.draft.wordLists
-    .filter((list) => coreListIds.has(list.id))
-    .map(({ spellingPool: _spellingPool, ...list }) => list);
-  next.draft.words = coreWords.map(({ spellingPool: _spellingPool, ...word }) => word);
-  next.draft.sentences = next.draft.sentences.filter((sentence) => coreSlugs.has(sentence.wordSlug));
-
-  const release = cloneSerialisable(next.releases.find((entry) => entry.version === 1) || next.releases[0]);
-  const releaseWords = release.snapshot.words
-    .filter((word) => word.spellingPool !== 'extra')
-    .map(({ spellingPool: _spellingPool, ...word }) => word);
-  release.snapshot.words = releaseWords;
-  release.snapshot.wordBySlug = Object.fromEntries(releaseWords.map((word) => [word.slug, word]));
-  next.releases = [release];
-  next.publication = {
-    currentReleaseId: release.id,
-    publishedVersion: release.version,
-    updatedAt: release.publishedAt,
-  };
   return next;
 }
 

--- a/tests/spelling-content.test.js
+++ b/tests/spelling-content.test.js
@@ -15,6 +15,7 @@ import {
   validateSpellingContentBundle,
 } from '../src/subjects/spelling/content/model.js';
 import { SEEDED_SPELLING_CONTENT_BUNDLE } from '../src/subjects/spelling/data/content-data.js';
+import { coreOnlyVersionOneContent } from './helpers/spelling-content.js';
 import { installMemoryStorage } from './helpers/memory-storage.js';
 
 function makeTts() {
@@ -282,6 +283,78 @@ test('content service backfills seeded explanations for legacy stored bundles', 
   assert.equal(draftWord.explanation, 'To possess something means to own it or have it.');
   assert.equal(runtimeWord.explanation, 'To possess something means to own it or have it.');
   assert.equal(content.validate().ok, true);
+});
+
+test('content service supplements legacy published runtime with seeded release additions', () => {
+  let stored = coreOnlyVersionOneContent(SEEDED_SPELLING_CONTENT_BUNDLE);
+  const repository = {
+    read() {
+      return cloneSerialisable(stored);
+    },
+    write(bundle) {
+      stored = cloneSerialisable(bundle);
+      return cloneSerialisable(stored);
+    },
+    clear() {
+      stored = cloneSerialisable(SEEDED_SPELLING_CONTENT_BUNDLE);
+      return cloneSerialisable(stored);
+    },
+  };
+  const content = createSpellingContentService({ repository });
+  const snapshot = content.getRuntimeSnapshot();
+
+  assert.equal(content.readBundle().publication.publishedVersion, 1);
+  assert.equal(snapshot.words.filter((word) => word.spellingPool === 'extra').length, 22);
+  assert.equal(snapshot.wordBySlug.mollusc.spellingPool, 'extra');
+
+  stored.releases[0].version = SEEDED_SPELLING_CONTENT_BUNDLE.publication.publishedVersion + 1;
+  stored.releases[0].publishedAt = 1;
+  stored.publication.publishedVersion = stored.releases[0].version;
+  stored.publication.updatedAt = 1;
+  const higherLocalVersionSnapshot = content.getRuntimeSnapshot();
+
+  assert.equal(content.readBundle().publication.publishedVersion, SEEDED_SPELLING_CONTENT_BUNDLE.publication.publishedVersion + 1);
+  assert.equal(higherLocalVersionSnapshot.words.filter((word) => word.spellingPool === 'extra').length, 22);
+
+  const service = createSpellingService({
+    tts: makeTts(),
+    contentSnapshot: higherLocalVersionSnapshot,
+  });
+  const transition = service.startSession('learner-a', {
+    mode: 'smart',
+    yearFilter: 'extra',
+    length: 10,
+  });
+
+  assert.equal(transition.ok, true);
+  assert.equal(transition.state.session.progress.total, 10);
+  assert.ok(transition.state.session.uniqueWords.every((slug) => higherLocalVersionSnapshot.wordBySlug[slug].spellingPool === 'extra'));
+});
+
+test('content service respects newer published account content that omits seeded additions', () => {
+  let stored = coreOnlyVersionOneContent(SEEDED_SPELLING_CONTENT_BUNDLE);
+  const currentSeedRelease = SEEDED_SPELLING_CONTENT_BUNDLE.releases.at(-1);
+  stored.releases[0].version = currentSeedRelease.version + 1;
+  stored.releases[0].publishedAt = currentSeedRelease.publishedAt + 1;
+  stored.publication.publishedVersion = stored.releases[0].version;
+  stored.publication.updatedAt = stored.releases[0].publishedAt;
+  const repository = {
+    read() {
+      return cloneSerialisable(stored);
+    },
+    write(bundle) {
+      stored = cloneSerialisable(bundle);
+      return cloneSerialisable(stored);
+    },
+    clear() {
+      stored = cloneSerialisable(SEEDED_SPELLING_CONTENT_BUNDLE);
+      return cloneSerialisable(stored);
+    },
+  };
+  const content = createSpellingContentService({ repository });
+  const snapshot = content.getRuntimeSnapshot();
+
+  assert.equal(snapshot.words.filter((word) => word.spellingPool === 'extra').length, 0);
 });
 
 test('runtime stays pinned to the published spelling release until a new draft is published', async () => {

--- a/tests/worker-hubs.test.js
+++ b/tests/worker-hubs.test.js
@@ -2,6 +2,8 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { createApiPlatformRepositories } from '../src/platform/core/repositories/index.js';
+import { SEEDED_SPELLING_CONTENT_BUNDLE } from '../src/subjects/spelling/data/content-data.js';
+import { coreOnlyVersionOneContent } from './helpers/spelling-content.js';
 import { createWorkerRepositoryServer } from './helpers/worker-server.js';
 
 function seedAdultAccount(server, {
@@ -107,6 +109,45 @@ test('worker parent hub allows parent or admin platform roles with readable lear
   assert.equal(adminPayload.parentHub.permissions.platformRole, 'admin');
 
   server.close();
+});
+
+test('worker hubs supplement legacy core-only content with seeded runtime additions', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    await seedLearnerData(server, 'adult-parent', 'parent');
+
+    const initialResponse = await server.fetchAs('adult-parent', 'https://repo.test/api/content/spelling');
+    const initial = await initialResponse.json();
+    const legacy = coreOnlyVersionOneContent(initial.content);
+    const requestId = 'legacy-core-content-runtime-1';
+    const writeResponse = await server.fetchAs('adult-parent', 'https://repo.test/api/content/spelling', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        content: legacy,
+        mutation: {
+          requestId,
+          correlationId: requestId,
+          expectedAccountRevision: initial.mutation.accountRevision,
+        },
+      }),
+    });
+    const written = await writeResponse.json();
+    assert.equal(writeResponse.status, 200);
+    assert.equal(written.content.publication.publishedVersion, 1);
+    assert.equal(written.content.releases[0].snapshot.words.some((word) => word.spellingPool === 'extra'), false);
+
+    const hubResponse = await server.fetchAs('adult-parent', 'https://repo.test/api/hubs/parent?learnerId=learner-a');
+    const hubPayload = await hubResponse.json();
+
+    assert.equal(hubResponse.status, 200);
+    assert.equal(
+      hubPayload.parentHub.progressSnapshots[0].totalPublishedWords,
+      SEEDED_SPELLING_CONTENT_BUNDLE.releases.at(-1).snapshot.words.length,
+    );
+  } finally {
+    server.close();
+  }
 });
 
 test('worker admin account roles are listed and assignable by admins only', async () => {

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -17,7 +17,7 @@ import {
   backfillSpellingWordExplanations,
   buildSpellingContentSummary,
   normaliseSpellingContentBundle,
-  resolvePublishedSnapshot,
+  resolveRuntimeSnapshot,
   validateSpellingContentBundle,
 } from '../../src/subjects/spelling/content/model.js';
 import { SEEDED_SPELLING_CONTENT_BUNDLE } from '../../src/subjects/spelling/data/content-data.js';
@@ -438,7 +438,7 @@ function normaliseRequestedPlatformRole(value) {
 
 function runtimeSnapshotForBundle(bundle) {
   const backfilled = backfillSpellingWordExplanations(bundle, SEEDED_SPELLING_CONTENT_BUNDLE);
-  return resolvePublishedSnapshot(backfilled) || resolvePublishedSnapshot(SEEDED_SPELLING_CONTENT_BUNDLE) || null;
+  return resolveRuntimeSnapshot(backfilled, { referenceBundle: SEEDED_SPELLING_CONTENT_BUNDLE });
 }
 
 function accountDirectoryRowToModel(row) {


### PR DESCRIPTION
## Summary
- supplement older account-scoped spelling runtime snapshots with missing words from the bundled current seed release
- apply the same runtime snapshot policy in the Worker hub read paths
- add regression coverage for legacy core-only content and document the published-runtime behaviour

## Verification
- `/Applications/Codex.app/Contents/Resources/node --test`
- targeted spelling/content/worker hub tests

Note: `npm run check` could not be run in this environment because `npm` is unavailable on PATH.