### PR TITLE
Fix word bank filters and drill pills

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -90,7 +90,8 @@ function restoreModalTrigger() {
     }
     if (!root) return;
     const escaped = typeof CSS !== 'undefined' && CSS.escape ? CSS.escape(slug) : slug.replace(/"/g, '\\"');
-    const row = root.querySelector(`.wb-row[data-slug="${escaped}"]`)
+    const row = root.querySelector(`.wb-word-pill[data-slug="${escaped}"]`)
+      || root.querySelector(`.wb-row[data-slug="${escaped}"]`)
       || root.querySelector(`[data-action="spelling-word-detail-open"][data-slug="${escaped}"]`);
     if (row && typeof row.focus === 'function') row.focus();
   });

--- a/src/platform/core/store.js
+++ b/src/platform/core/store.js
@@ -129,6 +129,11 @@ const VALID_SPELLING_WORD_BANK_FILTERS = new Set([
   'secure',
   'unseen',
 ]);
+const VALID_SPELLING_WORD_BANK_YEAR_FILTERS = new Set([
+  'all',
+  'y3-4',
+  'y5-6',
+]);
 
 const VALID_WORD_DETAIL_MODES = new Set(['explain', 'drill']);
 const VALID_WORD_DRILL_RESULTS = new Set(['correct', 'incorrect']);
@@ -141,6 +146,9 @@ function normaliseTransientUi(rawValue) {
      snapshot never traps the learner on an empty view. */
   const rawFilter = typeof raw.spellingAnalyticsStatusFilter === 'string'
     ? raw.spellingAnalyticsStatusFilter
+    : 'all';
+  const rawYearFilter = typeof raw.spellingAnalyticsYearFilter === 'string'
+    ? raw.spellingAnalyticsYearFilter
     : 'all';
   /* Word detail modal state — `slug` is the single source of truth for whether
      the modal is open; `mode` toggles between explain/drill inside the modal;
@@ -157,6 +165,7 @@ function normaliseTransientUi(rawValue) {
       ? raw.spellingAnalyticsWordSearch.slice(0, 80)
       : '',
     spellingAnalyticsStatusFilter: VALID_SPELLING_WORD_BANK_FILTERS.has(rawFilter) ? rawFilter : 'all',
+    spellingAnalyticsYearFilter: VALID_SPELLING_WORD_BANK_YEAR_FILTERS.has(rawYearFilter) ? rawYearFilter : 'all',
     spellingWordDetailSlug: typeof raw.spellingWordDetailSlug === 'string'
       ? raw.spellingWordDetailSlug.slice(0, 120)
       : '',

--- a/src/subjects/spelling/module.js
+++ b/src/subjects/spelling/module.js
@@ -96,19 +96,31 @@ function normaliseSearchText(value) {
   return String(value || '').trim().toLowerCase();
 }
 
-const WORD_BANK_STATUS_ORDER = ['due', 'trouble', 'learning', 'new', 'secure'];
-
 /* Valid word bank filter IDs. Uses v1 tokens on the wire (unseen/weak) so the
    persisted transientUi value reads naturally and matches the filter chip
    label. wordBankFilterMatchesStatus() translates back to the production
    status vocabulary at render time. */
 const WORD_BANK_FILTER_IDS = new Set(['all', 'due', 'weak', 'learning', 'secure', 'unseen']);
+const WORD_BANK_YEAR_FILTER_IDS = new Set(['all', 'y3-4', 'y5-6']);
 
 function wordBankFilterMatchesStatus(filter, status) {
   if (filter === 'all') return true;
   if (filter === 'weak') return status === 'trouble';
   if (filter === 'unseen') return status === 'new';
   return filter === status;
+}
+
+function wordBankYearFilterMatches(filter, word) {
+  if (filter === 'all') return true;
+  if (filter === 'y3-4') return word.year === '3-4';
+  if (filter === 'y5-6') return word.year === '5-6';
+  return true;
+}
+
+function wordBankYearFilterLabel(filter) {
+  if (filter === 'y3-4') return 'Years 3-4';
+  if (filter === 'y5-6') return 'Years 5-6';
+  return 'All years';
 }
 
 function wordProgressTone(status) {
@@ -132,9 +144,9 @@ function wordStatusLabel(status) {
 }
 
 function wordBankPillClass(status) {
-  /* Maps production status → v1 pill token used by .wb-pill.{token}. */
-  if (status === 'new') return 'unseen';
-  if (status === 'trouble') return 'weak';
+  /* Maps production status to the legacy word-bank colour tokens. */
+  if (status === 'new') return 'new';
+  if (status === 'trouble') return 'trouble';
   return status;
 }
 
@@ -158,16 +170,8 @@ function wordMatchesSearch(word, query) {
     spellingPoolLabel(word),
     word.explanation,
     ...(Array.isArray(word.accepted) ? word.accepted : []),
-    ...(Array.isArray(word.familyWords) ? word.familyWords : []),
   ].map(normaliseSearchText);
   return fields.some((field) => field.includes(query));
-}
-
-function accuracyPercent(progress) {
-  const attempts = Math.max(0, Number(progress?.attempts) || 0);
-  const correct = Math.max(0, Number(progress?.correct) || 0);
-  if (!attempts) return null;
-  return Math.round((correct / attempts) * 100);
 }
 
 function dueLabel(progress) {
@@ -176,7 +180,9 @@ function dueLabel(progress) {
   if (!attempts) return 'Unseen';
   const dueDay = Number(progress.dueDay);
   if (!Number.isFinite(dueDay)) return 'Unseen';
-  const daysUntilDue = Math.floor(dueDay - Math.floor(Date.now() / DAY_MS));
+  const today = Math.floor(Date.now() / DAY_MS);
+  if (dueDay - today > 3650) return 'Long-term review';
+  const daysUntilDue = Math.floor(dueDay - today);
   if (daysUntilDue <= 0) return 'Today';
   if (daysUntilDue === 1) return 'In 1 day';
   return `In ${daysUntilDue} days`;
@@ -806,7 +812,7 @@ function renderWordBankFilterChips({ counts, activeFilter }) {
   const chips = [
     { id: 'all', label: 'All' },
     { id: 'due', label: 'Due' },
-    { id: 'weak', label: 'Weak' },
+    { id: 'weak', label: 'Trouble' },
     { id: 'learning', label: 'Learning' },
     { id: 'secure', label: 'Secure' },
     { id: 'unseen', label: 'Unseen' },
@@ -837,89 +843,171 @@ function renderWordBankFilterChips({ counts, activeFilter }) {
   `;
 }
 
+function renderWordBankYearChips({ counts, activeYearFilter }) {
+  const chips = [
+    { id: 'all', label: 'All years' },
+    { id: 'y3-4', label: 'Years 3-4' },
+    { id: 'y5-6', label: 'Years 5-6' },
+  ];
+  return `
+    <div class="wb-chips wb-year-chips" role="group" aria-label="Filter word bank by year band">
+      ${chips.map((chip) => {
+        const active = chip.id === activeYearFilter;
+        const count = counts[chip.id] ?? 0;
+        return `
+          <button
+            type="button"
+            aria-pressed="${active ? 'true' : 'false'}"
+            class="wb-chip wb-chip-category${active ? ' on' : ''}"
+            data-action="spelling-analytics-year-filter"
+            data-value="${escapeHtml(chip.id)}"
+          >
+            <span class="wb-chip-label">${escapeHtml(chip.label)}</span>
+            <span class="wb-chip-count">${count}</span>
+          </button>
+        `;
+      }).join('')}
+    </div>
+  `;
+}
+
 function countWordBankStatus(words, status) {
   return words.reduce((count, word) => count + (word.status === status ? 1 : 0), 0);
 }
 
-function sortWordBank(words) {
-  return words.slice().sort((a, b) => {
-    const pa = WORD_BANK_STATUS_ORDER.indexOf(a.status);
-    const pb = WORD_BANK_STATUS_ORDER.indexOf(b.status);
-    const rankA = pa === -1 ? 99 : pa;
-    const rankB = pb === -1 ? 99 : pb;
-    if (rankA !== rankB) return rankA - rankB;
-    return String(a.word).localeCompare(String(b.word));
-  });
+function countWordBankYear(words, year) {
+  return words.reduce((count, word) => count + (word.year === year ? 1 : 0), 0);
 }
 
-function renderWordBankRow(word) {
-  const pillToken = wordBankPillClass(word.status);
-  const statusLabel = wordStatusLabel(word.status);
-  const poolLabel = spellingPoolLabel(word);
-  const accuracy = accuracyPercent(word.progress);
-  const due = dueLabel(word.progress);
-  const attempts = Math.max(0, Number(word.progress?.attempts) || 0);
-  const openExplainLabel = `Open ${word.word} · ${statusLabel}`;
-  const openDrillLabel = `Drill ${word.word} — practice only`;
-  /* The whole row is a button that opens the modal in explain mode. The inner
-     arrow button (the "wb-action" chip on the right) jumps straight to drill
-     mode. `closest('[data-action]')` in the central dispatcher correctly picks
-     the inner button on arrow click and the outer row otherwise. */
+function renderWordBankLegend({ counts }) {
+  const items = [
+    { token: 'new', label: 'New', count: counts.unseen ?? 0 },
+    { token: 'learning', label: 'Learning', count: counts.learning ?? 0 },
+    { token: 'due', label: 'Due', count: counts.due ?? 0 },
+    { token: 'secure', label: 'Secure', count: counts.secure ?? 0 },
+    { token: 'trouble', label: 'Trouble', count: counts.weak ?? 0 },
+  ];
   return `
-    <li class="wb-row" role="button" tabindex="0" data-status="${escapeHtml(pillToken)}" data-action="spelling-word-detail-open" data-slug="${escapeHtml(word.slug)}" data-value="explain" aria-label="${escapeHtml(openExplainLabel)}">
-      <div class="wb-cell-word">
-        <span class="wb-word">${escapeHtml(word.word)}</span>
-        <span class="wb-pill ${escapeHtml(pillToken)}">${escapeHtml(statusLabel)}</span>
-        <span class="wb-pool ${word.spellingPool === 'extra' ? 'extra' : 'core'}">${escapeHtml(poolLabel)}</span>
-      </div>
-      <div class="wb-cell-meta">
-        <span class="wb-meta"><span class="wb-meta-label">Accuracy</span><span class="wb-meta-value">${accuracy == null ? '—' : `${accuracy}%`}</span></span>
-        <span class="wb-meta"><span class="wb-meta-label">Next due</span><span class="wb-meta-value">${escapeHtml(due)}</span></span>
-        <span class="wb-meta"><span class="wb-meta-label">Attempts</span><span class="wb-meta-value">${attempts}</span></span>
-      </div>
-      <button type="button" class="wb-action" data-action="spelling-word-detail-open" data-slug="${escapeHtml(word.slug)}" data-value="drill" aria-label="${escapeHtml(openDrillLabel)}">
-        <span class="wb-action-label">Drill</span>
-        ${ICON_ARROW_RIGHT}
-      </button>
-    </li>
+    <div class="wb-status-legend" aria-label="Word status colour legend">
+      ${items.map((item) => `
+        <span class="wb-legend-item">
+          <span class="wb-legend-swatch ${escapeHtml(item.token)}" aria-hidden="true"></span>
+          <span class="wb-legend-label">${escapeHtml(item.label)}</span>
+          <span class="wb-legend-count">${item.count}</span>
+        </span>
+      `).join('')}
+    </div>
   `;
 }
 
-function renderWordBank({ learner, analytics, searchQuery = '', statusFilter = 'all' }) {
+function renderWordBankWordPill(word) {
+  const pillToken = wordBankPillClass(word.status);
+  const statusLabel = wordStatusLabel(word.status);
+  const poolLabel = spellingPoolLabel(word);
+  const due = dueLabel(word.progress);
+  const progress = word.progress || {};
+  const title = [
+    word.word,
+    word.family ? `Family: ${word.family}` : '',
+    word.yearLabel || '',
+    poolLabel,
+    word.stageLabel || '',
+    `Correct ${Math.max(0, Number(progress.correct) || 0)}`,
+    `Wrong ${Math.max(0, Number(progress.wrong) || 0)}`,
+    `Next due: ${due}`,
+    'Click to drill',
+  ].filter(Boolean).join(' • ');
+  const ariaLabel = `Drill ${word.word}. ${statusLabel}. ${poolLabel}.`;
+  return `
+    <button
+      type="button"
+      class="wb-word-pill ${escapeHtml(pillToken)}"
+      data-action="spelling-word-detail-open"
+      data-slug="${escapeHtml(word.slug)}"
+      data-value="drill"
+      title="${escapeHtml(title)}"
+      aria-label="${escapeHtml(ariaLabel)}"
+    >${escapeHtml(word.word)}</button>
+  `;
+}
+
+function renderWordBankGroup({ group, words, query }) {
+  const secureCount = words.filter((word) => Math.max(0, Number(word.progress?.stage) || 0) >= 4).length;
+  const summaryText = words.length
+    ? `${secureCount} secure out of ${words.length} visible spellings`
+    : 'No words match your filters.';
+  const emptyText = query ? 'Try another word or family search.' : 'Try another status or year filter.';
+  return `
+    <section class="wb-word-group" aria-label="${escapeHtml(group.title)} spellings">
+      <div class="wb-word-group-head">
+        <h2>${escapeHtml(group.title)}</h2>
+        <p>${escapeHtml(summaryText)}</p>
+      </div>
+      <div class="wb-word-bank">
+        ${words.length
+          ? words.map(renderWordBankWordPill).join('')
+          : `<div class="wb-empty">${escapeHtml(emptyText)}</div>`}
+      </div>
+    </section>
+  `;
+}
+
+function renderWordBank({ learner, analytics, searchQuery = '', statusFilter = 'all', yearFilter = 'all' }) {
   const query = normaliseSearchText(searchQuery);
   const activeFilter = WORD_BANK_FILTER_IDS.has(statusFilter) ? statusFilter : 'all';
+  const activeYearFilter = WORD_BANK_YEAR_FILTER_IDS.has(yearFilter) ? yearFilter : 'all';
   const groups = Array.isArray(analytics.wordGroups) ? analytics.wordGroups : [];
   const allWords = groups.flatMap((group) => Array.isArray(group.words) ? group.words : []);
+  const categoryWords = allWords.filter((word) => wordBankYearFilterMatches(activeYearFilter, word));
 
-  /* Apply status filter first, then search. Order matters because the status
-     count pills on the filter tabs always reflect the unfiltered totals; only
-     the list rows respect the combined filter+search. */
-  const statusMatched = allWords.filter((word) => wordBankFilterMatchesStatus(activeFilter, word.status));
-  const visibleWords = sortWordBank(statusMatched.filter((word) => wordMatchesSearch(word, query)));
+  /* Apply year band, then status, then search. Status counts are scoped to the
+     active year band so a learner can see what is due or secure inside the
+     selected KS2 pool, while the year-band chips keep whole-list totals. */
+  const visibleGroups = groups
+    .filter((group) => activeYearFilter === 'all' ? true : group.key === activeYearFilter)
+    .map((group) => {
+      const words = (Array.isArray(group.words) ? group.words : [])
+        .filter((word) => wordBankFilterMatchesStatus(activeFilter, word.status))
+        .filter((word) => wordMatchesSearch(word, query));
+      return { group, words };
+    })
+    .filter((entry) => activeFilter === 'all' && !query ? true : entry.words.length > 0);
+  const visibleWords = visibleGroups.flatMap((entry) => entry.words);
 
   const counts = {
+    all: categoryWords.length,
+    due: countWordBankStatus(categoryWords, 'due'),
+    weak: countWordBankStatus(categoryWords, 'trouble'),
+    learning: countWordBankStatus(categoryWords, 'learning'),
+    secure: countWordBankStatus(categoryWords, 'secure'),
+    unseen: countWordBankStatus(categoryWords, 'new'),
+  };
+  const yearCounts = {
     all: allWords.length,
-    due: countWordBankStatus(allWords, 'due'),
-    weak: countWordBankStatus(allWords, 'trouble'),
-    learning: countWordBankStatus(allWords, 'learning'),
-    secure: countWordBankStatus(allWords, 'secure'),
-    unseen: countWordBankStatus(allWords, 'new'),
+    'y3-4': countWordBankYear(allWords, '3-4'),
+    'y5-6': countWordBankYear(allWords, '5-6'),
   };
 
-  const rows = visibleWords.length
-    ? visibleWords.map(renderWordBankRow).join('')
-    : '<li class="wb-empty">No words match your search.</li>';
+  const rows = visibleGroups.length
+    ? visibleGroups.map((entry) => renderWordBankGroup({ ...entry, query })).join('')
+    : `<div class="wb-empty">${escapeHtml(query ? 'No words match your search and filters.' : 'No words match your filters.')}</div>`;
 
   /* v1 lede format: "{total} words tracked — {secure} secure, {due} due today,
      {weak} weak spots." Switches to the search-narrow variant when the
      learner has typed a query so the line stays informative instead of
      stale. */
   const totalWords = allWords.length;
-  const ledeBase = `${totalWords} word${totalWords === 1 ? '' : 's'} tracked — ${counts.secure} secure, ${counts.due} due today, ${counts.weak} weak spots.`;
+  const categoryTotal = categoryWords.length;
+  const categoryLabel = wordBankYearFilterLabel(activeYearFilter);
+  const ledeBase = activeYearFilter === 'all'
+    ? `${totalWords} word${totalWords === 1 ? '' : 's'} tracked — ${counts.secure} secure, ${counts.due} due today, ${counts.weak} weak spots.`
+    : `${categoryLabel} selected — ${categoryTotal} of ${totalWords} words, ${counts.secure} secure, ${counts.due} due today, ${counts.weak} weak spots.`;
   const ledeSearch = query
     ? ` Showing ${visibleWords.length} match${visibleWords.length === 1 ? '' : 'es'} for "${escapeHtml(searchQuery)}".`
     : '';
-  const footText = `Showing ${visibleWords.length} of ${totalWords} tracked spellings.`;
+  const footText = activeYearFilter === 'all'
+    ? `Showing ${visibleWords.length} of ${totalWords} tracked spellings.`
+    : `Showing ${visibleWords.length} of ${categoryTotal} ${categoryLabel} spellings.`;
   const learnerName = learner?.name ? `${learner.name}’s` : 'Learner';
 
   return `
@@ -928,7 +1016,7 @@ function renderWordBank({ learner, analytics, searchQuery = '', statusFilter = '
         <header class="wb-head">
           <p class="eyebrow">Word bank progress</p>
           <h1 class="title">${escapeHtml(learnerName)} word bank</h1>
-          <p class="lede">${escapeHtml(ledeBase)}${ledeSearch} Tap any word to open the explainer or jump straight to a drill.</p>
+          <p class="lede">${escapeHtml(ledeBase)}${ledeSearch} Tap any word to drill it, then switch to the explainer if you need help.</p>
         </header>
 
         <div class="wb-toolbar">
@@ -936,12 +1024,17 @@ function renderWordBank({ learner, analytics, searchQuery = '', statusFilter = '
             <span class="wb-search-icon" aria-hidden="true">${ICON_SEARCH}</span>
             <input type="search" name="spellingAnalyticsSearch" autocomplete="off" placeholder="Search words…" value="${escapeHtml(searchQuery)}" data-action="spelling-analytics-search" aria-label="Search word bank" />
           </label>
-          ${renderWordBankFilterChips({ counts, activeFilter })}
+          <div class="wb-filter-stack">
+            ${renderWordBankYearChips({ counts: yearCounts, activeYearFilter })}
+            ${renderWordBankFilterChips({ counts, activeFilter })}
+          </div>
         </div>
 
-        <ul class="wb-list">
+        ${renderWordBankLegend({ counts })}
+
+        <div class="wb-word-groups">
           ${rows}
-        </ul>
+        </div>
 
         <div class="wb-foot small muted">${escapeHtml(footText)}</div>
       </div>
@@ -951,11 +1044,11 @@ function renderWordBank({ learner, analytics, searchQuery = '', statusFilter = '
 
 /* --------------------------------------------------------------
    Word-detail modal
-   Opened from the word bank row (explain mode) or the row-arrow
-   button (drill mode). The drill is entirely self-contained: no
-   engine mutation, just a local string comparison against the
-   target word. This keeps "browse" and "practise" conceptually
-   separate from the scheduled-session flow.
+   Opened from the word bank pills, which now launch straight into
+   drill mode. The drill is entirely self-contained: no engine
+   mutation, just a local string comparison against the target word.
+   This keeps "browse" and "practise" conceptually separate from the
+   scheduled-session flow.
    -------------------------------------------------------------- */
 function renderWordDetailExplain(word) {
   const sentence = (word.sentence || '').replace(/________/g, word.word);
@@ -1166,6 +1259,7 @@ function renderWordBankScene({ appState, learner, service, subject }) {
   const accent = accentFor(subject);
   const searchQuery = appState?.transientUi?.spellingAnalyticsWordSearch || '';
   const statusFilter = appState?.transientUi?.spellingAnalyticsStatusFilter || 'all';
+  const yearFilter = appState?.transientUi?.spellingAnalyticsYearFilter || 'all';
   const detailSlug = appState?.transientUi?.spellingWordDetailSlug || '';
   const detailMode = appState?.transientUi?.spellingWordDetailMode || 'explain';
   const drillTyped = appState?.transientUi?.spellingWordBankDrillTyped || '';
@@ -1180,7 +1274,7 @@ function renderWordBankScene({ appState, learner, service, subject }) {
           <h1 class="word-bank-title">${escapeHtml(learner.name)}’s spellings</h1>
         </header>
         ${renderWordBankAggregates(analytics)}
-        ${renderWordBank({ learner, analytics, searchQuery, statusFilter })}
+        ${renderWordBank({ learner, analytics, searchQuery, statusFilter, yearFilter })}
       </div>
       ${detailWord ? renderWordDetailModal({ word: detailWord, mode: detailMode, typed: drillTyped, result: drillResult, accent }) : ''}
     </div>
@@ -1279,6 +1373,18 @@ export const spellingModule = {
         transientUi: {
           ...current.transientUi,
           spellingAnalyticsStatusFilter: next,
+        },
+      }));
+      return true;
+    }
+
+    if (action === 'spelling-analytics-year-filter') {
+      const raw = String(data.value || 'all');
+      const next = WORD_BANK_YEAR_FILTER_IDS.has(raw) ? raw : 'all';
+      store.patch((current) => ({
+        transientUi: {
+          ...current.transientUi,
+          spellingAnalyticsYearFilter: next,
         },
       }));
       return true;

--- a/styles/app.css
+++ b/styles/app.css
@@ -4542,138 +4542,148 @@ textarea:focus-visible {
   flex-wrap: wrap;
   gap: 6px;
 }
-
-.wb-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-  gap: 12px;
-}
-.wb-row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  grid-template-areas:
-    "word   action"
-    "meta   meta";
-  align-items: start;
-  column-gap: 10px;
-  row-gap: 8px;
-  padding: 12px 12px 10px 16px;
-  background: var(--panel-soft);
-  border: 1px solid var(--line-soft);
-  border-left: 4px solid var(--line-strong);
-  border-radius: var(--radius-sm);
-  transition: background var(--dur) var(--ease-out),
-              border-color var(--dur) var(--ease-out);
-}
-.wb-row:hover {
-  background: color-mix(in oklab, var(--panel) 60%, var(--panel-soft));
-  border-color: color-mix(in oklab, var(--brand) 16%, var(--line));
-}
-.wb-row[data-status="due"]      { border-left-color: var(--warn); }
-.wb-row[data-status="weak"]     { border-left-color: var(--bad); }
-.wb-row[data-status="learning"] { border-left-color: var(--brand); }
-.wb-row[data-status="secure"]   { border-left-color: var(--good); }
-.wb-row[data-status="unseen"]   { border-left-color: var(--subtle); }
-
-.wb-cell-word {
-  grid-area: word;
+.wb-filter-stack {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
   gap: 8px;
-  flex-wrap: wrap;
-  row-gap: 4px;
-  min-width: 0;
-  align-self: center;
-}
-.wb-word {
-  font-family: var(--font-display);
-  font-size: 1.1rem;
-  font-weight: 600;
-  letter-spacing: -0.005em;
-  color: var(--ink);
-  overflow-wrap: anywhere;
+  min-width: min(100%, 520px);
 }
 
-.wb-pill {
-  display: inline-flex;
-  align-items: center;
-  padding: 2px 8px;
-  border-radius: 999px;
-  font-size: 0.66rem;
-  font-weight: 700;
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
-  white-space: nowrap;
-}
-
-.wb-pool {
-  display: inline-flex;
-  align-items: center;
-  padding: 2px 8px;
-  border-radius: 999px;
-  border: 1px solid var(--line);
-  background: var(--panel);
-  color: var(--ink-2);
-  font-size: 0.66rem;
-  font-weight: 800;
-  letter-spacing: 0.02em;
-}
-.wb-pool.extra {
-  border-color: color-mix(in oklab, var(--brand) 26%, var(--line));
-  background: var(--brand-soft);
-  color: var(--brand-ink);
-}
-.wb-pill.due      { background: var(--warn-soft);    color: var(--warn-strong); }
-.wb-pill.weak     { background: var(--bad-soft);     color: var(--bad-strong); }
-.wb-pill.learning { background: var(--brand-soft);   color: var(--brand-ink); }
-.wb-pill.secure   { background: var(--good-soft);    color: var(--good-strong); }
-.wb-pill.unseen   { background: var(--panel-sunken); color: var(--muted); }
-
-.wb-cell-meta {
-  grid-area: meta;
+.wb-status-legend {
   display: flex;
-  gap: 4px 12px;
   flex-wrap: wrap;
-  font-size: 0.78rem;
-  line-height: 1.3;
+  gap: 8px 10px;
+  margin: 0 0 14px;
+  padding: 10px 0 0;
+  border-top: 1px solid var(--line-soft);
 }
-.wb-meta {
-  display: inline-flex;
-  align-items: baseline;
-  gap: 4px;
-  min-width: 0;
-}
-.wb-meta-label {
-  font-size: 0.68rem;
-  color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  font-weight: 600;
-}
-.wb-meta-value {
-  color: var(--ink);
-  font-weight: 600;
-  font-variant-numeric: tabular-nums;
-}
-
-/* The action button inside a .wb-row inherits its base styling
-   from the existing .word-progress-pill rule so test pins stay
-   valid; we only pin it into the action grid cell and add a
-   subtle label so the arrow has a readable affordance. */
-.wb-row .word-progress-pill {
-  grid-area: action;
-  align-self: center;
+.wb-legend-item {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-}
-.wb-action-label {
-  font-size: 0.78rem;
+  color: var(--ink-2);
+  font-size: 0.8rem;
   font-weight: 700;
-  letter-spacing: 0.02em;
+}
+.wb-legend-swatch {
+  width: 0.85rem;
+  height: 0.85rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: var(--panel-sunken);
+}
+.wb-legend-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: var(--panel-soft);
+  color: var(--muted);
+  font-size: 0.7rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.wb-word-groups {
+  display: grid;
+  gap: 16px;
+}
+.wb-word-group {
+  padding-top: 14px;
+  border-top: 1px solid var(--line-soft);
+}
+.wb-word-group:first-child {
+  padding-top: 0;
+  border-top: 0;
+}
+.wb-word-group-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 6px 14px;
+  margin-bottom: 10px;
+}
+.wb-word-group-head h2 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1rem;
+  letter-spacing: 0;
+  color: var(--ink);
+}
+.wb-word-group-head p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+.wb-word-bank {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.wb-word-pill {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  min-height: 34px;
+  padding: 7px 11px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: var(--panel-sunken);
+  color: var(--ink-2);
+  font: inherit;
+  font-size: 0.92rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  cursor: pointer;
+  user-select: none;
+  transition: transform var(--dur-fast) var(--ease-out),
+              filter var(--dur) var(--ease-out),
+              box-shadow var(--dur) var(--ease-out);
+}
+.wb-word-pill:hover {
+  filter: brightness(0.98);
+  transform: translateY(-1px);
+}
+.wb-word-pill:active {
+  transform: translateY(0);
+}
+.wb-word-pill:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+}
+.wb-word-pill.new,
+.wb-legend-swatch.new {
+  background: var(--panel-sunken);
+  color: var(--muted);
+  border-color: var(--line);
+}
+.wb-word-pill.learning,
+.wb-legend-swatch.learning {
+  background: var(--brand-soft);
+  color: var(--brand-ink);
+  border-color: color-mix(in oklab, var(--brand) 24%, var(--line));
+}
+.wb-word-pill.due,
+.wb-legend-swatch.due {
+  background: var(--warn-soft);
+  color: var(--warn-strong);
+  border-color: color-mix(in oklab, var(--warn) 34%, var(--line));
+}
+.wb-word-pill.secure,
+.wb-legend-swatch.secure {
+  background: var(--good-soft);
+  color: var(--good-strong);
+  border-color: color-mix(in oklab, var(--good) 34%, var(--line));
+}
+.wb-word-pill.trouble,
+.wb-legend-swatch.trouble {
+  background: var(--bad-soft);
+  color: var(--bad-strong);
+  border-color: color-mix(in oklab, var(--bad) 34%, var(--line));
 }
 
 .wb-empty {
@@ -4701,7 +4711,9 @@ textarea:focus-visible {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .wb-row, .wb-search { transition: none; }
+  .wb-search, .wb-word-pill { transition: none; }
+  .wb-word-pill:hover,
+  .wb-word-pill:active { transform: none; }
 }
 
 @media (max-width: 720px) {
@@ -4711,9 +4723,9 @@ textarea:focus-visible {
 /* ---------- Word bank filter chips ---------- */
 /* Interactive tabs on the word-bank toolbar. Each chip is a real button that
    dispatches spelling-analytics-status-filter with a v1 token (all / due /
-   weak / learning / secure / unseen). The palette mirrors .wb-pill so a
-   "weak" chip reads the same colour as a weak row pill, making the filter
-   selection feel tangibly connected to the rows it produces. */
+   weak / learning / secure / unseen). The palette mirrors the word-pill
+   legend so the filter selection stays visually connected to the spellings
+   it produces. */
 .wb-chip {
   appearance: none;
   display: inline-flex;
@@ -4728,6 +4740,7 @@ textarea:focus-visible {
   font-size: 0.8rem;
   font-weight: 700;
   letter-spacing: 0.01em;
+  white-space: nowrap;
   cursor: pointer;
   transition: background var(--dur) var(--ease-out),
               border-color var(--dur) var(--ease-out),
@@ -4764,6 +4777,16 @@ textarea:focus-visible {
   background: color-mix(in oklab, var(--brand) 18%, var(--panel));
   border-color: color-mix(in oklab, var(--brand) 40%, transparent);
   color: var(--brand-ink);
+}
+.wb-chip-category.on {
+  background: var(--ink);
+  border-color: var(--ink);
+  color: var(--panel);
+}
+.wb-chip-category.on .wb-chip-count {
+  background: color-mix(in oklab, var(--panel) 22%, transparent);
+  border-color: color-mix(in oklab, var(--panel) 28%, transparent);
+  color: var(--panel);
 }
 
 /* ---------- Subject-screen breadcrumb ---------- */
@@ -4862,6 +4885,11 @@ textarea:focus-visible {
   grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
   gap: 14px;
 }
+.wb-aggregates > .wb-card {
+  width: 100%;
+  max-width: none;
+  margin: 0;
+}
 .wb-card-compact {
   padding: 18px 20px 16px;
   border-radius: 18px;
@@ -4882,43 +4910,11 @@ textarea:focus-visible {
   gap: 8px;
 }
 
-/* Chevron button at the right of each .wb-row — jumps straight into
-   drill mode for that word. Inherits the row's click-area but stops
-   propagation inside the dispatcher so tapping the chevron routes to
-   `data-value="drill"` while tapping the row routes to `explain`. */
-.wb-action {
-  appearance: none;
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 8px 12px;
-  border-radius: 999px;
-  border: 1px solid var(--line);
-  background: var(--panel);
-  color: var(--ink-2);
-  font: inherit;
-  font-size: 0.85rem;
-  font-weight: 700;
-  letter-spacing: -0.005em;
-  transition: background var(--dur) var(--ease-out),
-              color var(--dur) var(--ease-out),
-              border-color var(--dur) var(--ease-out),
-              transform var(--dur-fast) var(--ease-out);
-}
-.wb-action:hover {
-  background: var(--brand-soft);
-  color: var(--brand-ink);
-  border-color: color-mix(in oklab, var(--brand) 28%, var(--line));
-}
-.wb-action:active { transform: translateX(1px); }
-.wb-action svg { width: 16px; height: 16px; }
-
 /* ---------- WordDetailModal ---------- */
-/* Opens above the word-bank scene when a row or its drill chevron is
-   tapped. Backdrop is its own absolutely-positioned button behind the
-   modal so click-outside closes cleanly; pressing Escape also routes to
-   `spelling-word-detail-close` via the shortcuts layer. */
+/* Opens above the word-bank scene when a word pill is tapped. Backdrop is its
+   own absolutely-positioned button behind the modal so click-outside closes
+   cleanly; pressing Escape also routes to `spelling-word-detail-close` via the
+   shortcuts layer. */
 .wb-modal-scrim {
   position: fixed; inset: 0;
   display: flex; justify-content: center; align-items: center;
@@ -5287,11 +5283,9 @@ textarea:focus-visible {
   .wb-drill-blank,
   .wb-drill-audio-btn,
   .wb-modal-close,
-  .wb-modal-tab,
-  .wb-action { transition: none; }
+  .wb-modal-tab { transition: none; }
   .wb-modal-speaker:active,
-  .wb-drill-audio-btn:active,
-  .wb-action:active { transform: none; }
+  .wb-drill-audio-btn:active { transform: none; }
   .wb-modal-speaker.playing,
   .wb-drill-audio-btn.playing { animation: none; }
 }
@@ -5310,7 +5304,7 @@ textarea:focus-visible {
 
 /* 1. Word bank long list: cap scroll within card at phone sizes */
 @media (max-width: 720px) {
-  .wb-list {
+  .wb-word-groups {
     max-height: 70vh;
     overflow: auto;
     -webkit-overflow-scrolling: touch;

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -156,15 +156,76 @@ test('spelling word bank opens from setup and exposes searchable progress with d
   assert.match(html, /data-action="spelling-analytics-status-filter"\s+data-value="learning"/);
   assert.match(html, /class="wb-chip-label">Unseen</);
   assert.match(html, /class="wb-chip-label">Learning</);
-  // The word row opens the detail modal in explain mode; the inner arrow chip
-  // jumps to drill mode. Both buttons share the same data-action.
-  assert.match(html, /data-action="spelling-word-detail-open" data-slug="possess" data-value="explain"/);
-  assert.match(html, /data-action="spelling-word-detail-open" data-slug="possess" data-value="drill"/);
+  // Category filters sit beside the status filters and use the same transient
+  // UI store path, so combining year band + status + search never mutates the
+  // scheduled spelling session.
+  assert.match(html, /data-action="spelling-analytics-year-filter"\s+data-value="y3-4"/);
+  assert.match(html, /data-action="spelling-analytics-year-filter"\s+data-value="y5-6"/);
+  assert.match(html, /class="wb-chip-label">Years 3-4</);
+  assert.match(html, /class="wb-chip-label">Years 5-6</);
+  // Word-bank entries render as legacy-style colour pills. The tooltip carries
+  // the progress details, while clicking the pill opens the new drill modal.
+  assert.match(html, /class="wb-word-pill new"/);
+  assert.match(html, /data-action="spelling-word-detail-open"\s+data-slug="possess"\s+data-value="drill"/);
+  assert.match(html, /title="possess[^"]*Family: possess\(ion\)[^"]*Next due: Unseen[^"]*Click to drill"/);
+  assert.match(html, /Word status colour legend/);
   assert.match(html, />accident</);
-  assert.match(html, /wb-meta-label">Next due<\/span><span class="wb-meta-value">Unseen/);
   assert.doesNotMatch(html, /wb-meta-label">Family/);
 
   const todayDay = Math.floor(Date.now() / (24 * 60 * 60 * 1000));
+  harness.repositories.subjectStates.writeData(learnerId, 'spelling', {
+    progress: {
+      accommodate: {
+        stage: 1,
+        attempts: 1,
+        correct: 1,
+        wrong: 0,
+        dueDay: todayDay - 1,
+        lastDay: todayDay - 2,
+        lastResult: true,
+      },
+      accident: {
+        stage: 4,
+        attempts: 4,
+        correct: 4,
+        wrong: 0,
+        dueDay: todayDay + 14,
+        lastDay: todayDay,
+        lastResult: true,
+      },
+    },
+  });
+
+  harness.dispatch('spelling-analytics-year-filter', { value: 'y5-6' });
+  assert.equal(harness.store.getState().transientUi.spellingAnalyticsYearFilter, 'y5-6');
+  html = harness.render();
+  assert.match(html, />accommodate</);
+  assert.doesNotMatch(html, />accident</);
+  assert.match(html, /Years 5-6 selected — 104 of 235 words, 0 secure, 1 due today, 0 weak spots/);
+  assert.match(html, /Showing 104 of 104 Years 5-6 spellings/);
+
+  harness.dispatch('spelling-analytics-status-filter', { value: 'due' });
+  assert.equal(harness.store.getState().transientUi.spellingAnalyticsStatusFilter, 'due');
+  html = harness.render();
+  assert.match(html, />accommodate</);
+  assert.doesNotMatch(html, />accident</);
+  assert.match(html, /Showing 1 of 104 Years 5-6 spellings/);
+
+  harness.dispatch('spelling-analytics-year-filter', { value: 'y3-4' });
+  html = harness.render();
+  assert.match(html, /No words match your filters/);
+  assert.doesNotMatch(html, />accommodate</);
+  assert.doesNotMatch(html, />accident</);
+
+  harness.dispatch('spelling-analytics-status-filter', { value: 'secure' });
+  html = harness.render();
+  assert.match(html, />accident</);
+  assert.doesNotMatch(html, />accommodate</);
+  assert.match(html, /Showing 1 of 109 Years 3-4 spellings/);
+
+  harness.dispatch('spelling-analytics-year-filter', { value: 'all' });
+  harness.dispatch('spelling-analytics-status-filter', { value: 'all' });
+
   harness.repositories.subjectStates.writeData(learnerId, 'spelling', {
     progress: {
       possess: {
@@ -184,7 +245,7 @@ test('spelling word bank opens from setup and exposes searchable progress with d
   assert.equal(harness.store.getState().subjectUi.spelling.analyticsWordSearch, undefined);
   html = harness.render();
   assert.match(html, />possess</);
-  assert.match(html, /wb-meta-label">Next due<\/span><span class="wb-meta-value">In 3 days/);
+  assert.match(html, /title="possess[^"]*Next due: In 3 days[^"]*Click to drill"/);
   assert.doesNotMatch(html, />accident</);
 
   harness.dispatch('spelling-word-detail-open', { slug: 'possess', value: 'explain' });
@@ -208,7 +269,8 @@ test('spelling word bank opens from setup and exposes searchable progress with d
   harness.dispatch('spelling-analytics-search', { value: 'mollusc' });
   html = harness.render();
   assert.match(html, />mollusc</);
-  assert.match(html, /class="wb-pool extra">Extra<\/span>/);
+  assert.match(html, /title="mollusc[^"]*Extra[^"]*Click to drill"/);
+  assert.match(html, /Showing 1 of 235 tracked spellings/);
   assert.doesNotMatch(html, />accident</);
 
   harness.dispatch('spelling-word-detail-open', { slug: 'mollusc', value: 'explain' });


### PR DESCRIPTION
## Summary
- Restore traditional word-bank word pills while preserving tooltip details, colour legend, and click-to-drill behaviour.
- Add Year 3-4 / Year 5-6 word-bank filters and keep status/search filtering scoped correctly.
- Preserve Extra spelling pool visibility in tooltips and drill modal, and tighten search so sibling family words do not inflate results.

## Validation
- `node --test tests/smoke.test.js`
- `node --run test`
- `PATH="/tmp/codex-npm-bin:$PATH" npm run check`
- Built UI browser smoke for word-bank groups, year filters, `mollusc` search, and Extra drill modal.