### PR TITLE
Harden word bank filters and counts

### DIFF
--- a/src/platform/core/store.js
+++ b/src/platform/core/store.js
@@ -133,6 +133,7 @@ const VALID_SPELLING_WORD_BANK_YEAR_FILTERS = new Set([
   'all',
   'y3-4',
   'y5-6',
+  'extra',
 ]);
 
 const VALID_WORD_DETAIL_MODES = new Set(['explain', 'drill']);
@@ -140,10 +141,8 @@ const VALID_WORD_DRILL_RESULTS = new Set(['correct', 'incorrect']);
 
 function normaliseTransientUi(rawValue) {
   const raw = rawValue && typeof rawValue === 'object' && !Array.isArray(rawValue) ? rawValue : {};
-  /* Word bank status filter — v1 filter tokens (unseen/weak); the word bank
-     renderer translates them to production status values (new/trouble) when
-     filtering. Unknown values collapse to 'all' so a malformed persisted
-     snapshot never traps the learner on an empty view. */
+  /* Legacy word-bank status filter — retained only to normalise older persisted
+     snapshots. The current word bank filters by category and search only. */
   const rawFilter = typeof raw.spellingAnalyticsStatusFilter === 'string'
     ? raw.spellingAnalyticsStatusFilter
     : 'all';

--- a/src/subjects/spelling/module.js
+++ b/src/subjects/spelling/module.js
@@ -88,39 +88,30 @@ function summaryCards(cards = []) {
 
 /* --------------------------------------------------------------
    Word-bank helpers
-   Status vocabulary translates production tokens to the v1 pill
-   tokens ('new' → 'unseen', 'trouble' → 'weak') so the CSS pill
-   palette from the design comp applies directly.
+   Category filters narrow pools; the pill colour itself carries each
+   word's learning status.
    -------------------------------------------------------------- */
 function normaliseSearchText(value) {
   return String(value || '').trim().toLowerCase();
 }
 
-/* Valid word bank filter IDs. Uses v1 tokens on the wire (unseen/weak) so the
-   persisted transientUi value reads naturally and matches the filter chip
-   label. wordBankFilterMatchesStatus() translates back to the production
-   status vocabulary at render time. */
-const WORD_BANK_FILTER_IDS = new Set(['all', 'due', 'weak', 'learning', 'secure', 'unseen']);
-const WORD_BANK_YEAR_FILTER_IDS = new Set(['all', 'y3-4', 'y5-6']);
-
-function wordBankFilterMatchesStatus(filter, status) {
-  if (filter === 'all') return true;
-  if (filter === 'weak') return status === 'trouble';
-  if (filter === 'unseen') return status === 'new';
-  return filter === status;
-}
+/* Category filters stay intentionally broad: the word colours already describe
+   status, while the toolbar narrows the statutory/extra spelling pools. */
+const WORD_BANK_YEAR_FILTER_IDS = new Set(['all', 'y3-4', 'y5-6', 'extra']);
 
 function wordBankYearFilterMatches(filter, word) {
   if (filter === 'all') return true;
   if (filter === 'y3-4') return word.year === '3-4';
   if (filter === 'y5-6') return word.year === '5-6';
+  if (filter === 'extra') return word.spellingPool === 'extra';
   return true;
 }
 
 function wordBankYearFilterLabel(filter) {
   if (filter === 'y3-4') return 'Years 3-4';
   if (filter === 'y5-6') return 'Years 5-6';
-  return 'All years';
+  if (filter === 'extra') return 'Extra';
+  return 'All';
 }
 
 function wordProgressTone(status) {
@@ -798,59 +789,20 @@ function renderSummary({ learner, ui, subject }) {
 }
 
 /* --------------------------------------------------------------
-   Word bank (analytics tab)
-   The status filter chips translate production tokens to the v1
-   visual language ("weak" for trouble, "unseen" for new) on the
-   pill element, while keeping production status names on the
-   underlying data-action button so test pins stay valid.
+   Word bank (standalone browser)
+   Category chips narrow the statutory Years 3-4 / Years 5-6 pools
+   and the Extra expansion pool. Word colours keep status visible
+   without adding a second duplicate status toolbar.
    -------------------------------------------------------------- */
-function renderWordBankFilterChips({ counts, activeFilter }) {
-  /* v1-style filter tabs. Each chip is a real button wired to the
-     spelling-analytics-status-filter dispatch so a click updates the
-     transientUi state and re-renders the list. The count pill next to
-     the label mirrors the approved design. */
-  const chips = [
-    { id: 'all', label: 'All' },
-    { id: 'due', label: 'Due' },
-    { id: 'weak', label: 'Trouble' },
-    { id: 'learning', label: 'Learning' },
-    { id: 'secure', label: 'Secure' },
-    { id: 'unseen', label: 'Unseen' },
-  ];
-  /* Chips are button-role filters, not WAI-ARIA tabs — there's no companion
-     tabpanel, and the design (designs/ks2-redesign-v1.html) treats them as
-     pressable segmented controls. `aria-pressed` communicates the active
-     state to assistive tech without the broken tab contract. */
-  return `
-    <div class="wb-chips" role="group" aria-label="Filter word bank by status">
-      ${chips.map((chip) => {
-        const active = chip.id === activeFilter;
-        const count = counts[chip.id] ?? 0;
-        return `
-          <button
-            type="button"
-            aria-pressed="${active ? 'true' : 'false'}"
-            class="wb-chip${active ? ' on' : ''}"
-            data-action="spelling-analytics-status-filter"
-            data-value="${escapeHtml(chip.id)}"
-          >
-            <span class="wb-chip-label">${escapeHtml(chip.label)}</span>
-            <span class="wb-chip-count">${count}</span>
-          </button>
-        `;
-      }).join('')}
-    </div>
-  `;
-}
-
 function renderWordBankYearChips({ counts, activeYearFilter }) {
   const chips = [
-    { id: 'all', label: 'All years' },
+    { id: 'all', label: 'All' },
     { id: 'y3-4', label: 'Years 3-4' },
     { id: 'y5-6', label: 'Years 5-6' },
+    { id: 'extra', label: 'Extra' },
   ];
   return `
-    <div class="wb-chips wb-year-chips" role="group" aria-label="Filter word bank by year band">
+    <div class="wb-chips wb-year-chips" role="group" aria-label="Filter word bank by category">
       ${chips.map((chip) => {
         const active = chip.id === activeYearFilter;
         const count = counts[chip.id] ?? 0;
@@ -879,25 +831,39 @@ function countWordBankYear(words, year) {
   return words.reduce((count, word) => count + (word.year === year ? 1 : 0), 0);
 }
 
-function renderWordBankLegend({ counts }) {
-  const items = [
-    { token: 'new', label: 'New', count: counts.unseen ?? 0 },
-    { token: 'learning', label: 'Learning', count: counts.learning ?? 0 },
-    { token: 'due', label: 'Due', count: counts.due ?? 0 },
-    { token: 'secure', label: 'Secure', count: counts.secure ?? 0 },
-    { token: 'trouble', label: 'Trouble', count: counts.weak ?? 0 },
+function countWordBankExtra(words) {
+  return words.reduce((count, word) => count + (word.spellingPool === 'extra' ? 1 : 0), 0);
+}
+
+function wordBankAggregateStats(words) {
+  const stats = {
+    total: 0,
+    secure: 0,
+    due: 0,
+    trouble: 0,
+    learning: 0,
+    unseen: 0,
+  };
+  for (const word of Array.isArray(words) ? words : []) {
+    stats.total += 1;
+    if (word.status === 'secure') stats.secure += 1;
+    else if (word.status === 'due') stats.due += 1;
+    else if (word.status === 'trouble') stats.trouble += 1;
+    else if (word.status === 'learning') stats.learning += 1;
+    else if (word.status === 'new') stats.unseen += 1;
+  }
+  return stats;
+}
+
+function wordBankAggregateCards(stats, totalSub) {
+  return [
+    { label: 'Total', value: stats.total, sub: totalSub },
+    { label: 'Secure', value: stats.secure, sub: 'Stable recall' },
+    { label: 'Due now', value: stats.due, sub: 'Due today or overdue' },
+    { label: 'Trouble', value: stats.trouble, sub: 'Weak or fragile' },
+    { label: 'Learning', value: stats.learning, sub: 'Introduced, not secure' },
+    { label: 'Unseen', value: stats.unseen, sub: 'Not yet introduced' },
   ];
-  return `
-    <div class="wb-status-legend" aria-label="Word status colour legend">
-      ${items.map((item) => `
-        <span class="wb-legend-item">
-          <span class="wb-legend-swatch ${escapeHtml(item.token)}" aria-hidden="true"></span>
-          <span class="wb-legend-label">${escapeHtml(item.label)}</span>
-          <span class="wb-legend-count">${item.count}</span>
-        </span>
-      `).join('')}
-    </div>
-  `;
 }
 
 function renderWordBankWordPill(word) {
@@ -909,7 +875,6 @@ function renderWordBankWordPill(word) {
   const title = [
     word.word,
     word.family ? `Family: ${word.family}` : '',
-    word.yearLabel || '',
     poolLabel,
     word.stageLabel || '',
     `Correct ${Math.max(0, Number(progress.correct) || 0)}`,
@@ -936,7 +901,7 @@ function renderWordBankGroup({ group, words, query }) {
   const summaryText = words.length
     ? `${secureCount} secure out of ${words.length} visible spellings`
     : 'No words match your filters.';
-  const emptyText = query ? 'Try another word or family search.' : 'Try another status or year filter.';
+  const emptyText = query ? 'Try another word or family search.' : 'Try another category filter.';
   return `
     <section class="wb-word-group" aria-label="${escapeHtml(group.title)} spellings">
       <div class="wb-word-group-head">
@@ -952,40 +917,36 @@ function renderWordBankGroup({ group, words, query }) {
   `;
 }
 
-function renderWordBank({ learner, analytics, searchQuery = '', statusFilter = 'all', yearFilter = 'all' }) {
+function renderWordBank({ learner, analytics, searchQuery = '', yearFilter = 'all' }) {
   const query = normaliseSearchText(searchQuery);
-  const activeFilter = WORD_BANK_FILTER_IDS.has(statusFilter) ? statusFilter : 'all';
   const activeYearFilter = WORD_BANK_YEAR_FILTER_IDS.has(yearFilter) ? yearFilter : 'all';
   const groups = Array.isArray(analytics.wordGroups) ? analytics.wordGroups : [];
   const allWords = groups.flatMap((group) => Array.isArray(group.words) ? group.words : []);
   const categoryWords = allWords.filter((word) => wordBankYearFilterMatches(activeYearFilter, word));
 
-  /* Apply year band, then status, then search. Status counts are scoped to the
-     active year band so a learner can see what is due or secure inside the
-     selected KS2 pool, while the year-band chips keep whole-list totals. */
+  /* Apply the category first, then search. Status remains visible through the
+     word-pill colour and tooltip so stale hidden status filters never change
+     what the learner sees. */
   const visibleGroups = groups
     .filter((group) => activeYearFilter === 'all' ? true : group.key === activeYearFilter)
     .map((group) => {
       const words = (Array.isArray(group.words) ? group.words : [])
-        .filter((word) => wordBankFilterMatchesStatus(activeFilter, word.status))
         .filter((word) => wordMatchesSearch(word, query));
       return { group, words };
     })
-    .filter((entry) => activeFilter === 'all' && !query ? true : entry.words.length > 0);
+    .filter((entry) => query ? entry.words.length > 0 : true);
   const visibleWords = visibleGroups.flatMap((entry) => entry.words);
 
   const counts = {
-    all: categoryWords.length,
     due: countWordBankStatus(categoryWords, 'due'),
     weak: countWordBankStatus(categoryWords, 'trouble'),
-    learning: countWordBankStatus(categoryWords, 'learning'),
     secure: countWordBankStatus(categoryWords, 'secure'),
-    unseen: countWordBankStatus(categoryWords, 'new'),
   };
   const yearCounts = {
     all: allWords.length,
     'y3-4': countWordBankYear(allWords, '3-4'),
     'y5-6': countWordBankYear(allWords, '5-6'),
+    extra: countWordBankExtra(allWords),
   };
 
   const rows = visibleGroups.length
@@ -1026,11 +987,8 @@ function renderWordBank({ learner, analytics, searchQuery = '', statusFilter = '
           </label>
           <div class="wb-filter-stack">
             ${renderWordBankYearChips({ counts: yearCounts, activeYearFilter })}
-            ${renderWordBankFilterChips({ counts, activeFilter })}
           </div>
         </div>
-
-        ${renderWordBankLegend({ counts })}
 
         <div class="wb-word-groups">
           ${rows}
@@ -1183,51 +1141,35 @@ function renderWordDetailModal({ word, mode = 'explain', typed = '', result = nu
    optional modal overlay when transientUi points at a word.
    -------------------------------------------------------------- */
 function renderWordBankAggregates(analytics) {
-  const emptyStats = { total: 0, secure: 0, due: 0, trouble: 0, fresh: 0, accuracy: null };
-  const core = analytics.pools.core || analytics.pools.all || emptyStats;
-  const y34 = analytics.pools.y34 || emptyStats;
-  const y56 = analytics.pools.y56 || emptyStats;
-  const extra = analytics.pools.extra || emptyStats;
+  const groups = Array.isArray(analytics.wordGroups) ? analytics.wordGroups : [];
+  const allWords = groups.flatMap((group) => Array.isArray(group.words) ? group.words : []);
+  /* The scheduler stats use broader "trouble" semantics for picking review
+     words. These cards must mirror the visible word-bank pill status instead,
+     so a recovered word does not appear as Trouble in the column summary. */
+  const core = wordBankAggregateStats(allWords.filter((word) => word.spellingPool !== 'extra'));
+  const y34 = wordBankAggregateStats(allWords.filter((word) => word.year === '3-4'));
+  const y56 = wordBankAggregateStats(allWords.filter((word) => word.year === '5-6'));
+  const extra = wordBankAggregateStats(allWords.filter((word) => word.spellingPool === 'extra'));
   const cards = [
     {
       eyebrow: 'Core spellings',
       title: 'Core statutory progress',
-      stats: [
-        { label: 'Total', value: core.total, sub: 'Words in core pool' },
-        { label: 'Secure', value: core.secure, sub: 'Stage 4+' },
-        { label: 'Due now', value: core.due, sub: 'Due today or overdue' },
-        { label: 'Accuracy', value: core.accuracy == null ? '—' : `${core.accuracy}%`, sub: 'Across stored attempts' },
-      ],
+      stats: wordBankAggregateCards(core, 'Words in core pool'),
     },
     {
       eyebrow: 'Years 3-4',
       title: 'Lower KS2 spelling pool',
-      stats: [
-        { label: 'Total', value: y34.total, sub: 'Words in pool' },
-        { label: 'Secure', value: y34.secure, sub: 'Stable recall' },
-        { label: 'Trouble', value: y34.trouble, sub: 'Weak or fragile' },
-        { label: 'Unseen', value: y34.fresh, sub: 'Not yet introduced' },
-      ],
+      stats: wordBankAggregateCards(y34, 'Words in pool'),
     },
     {
       eyebrow: 'Years 5-6',
       title: 'Upper KS2 spelling pool',
-      stats: [
-        { label: 'Total', value: y56.total, sub: 'Words in pool' },
-        { label: 'Secure', value: y56.secure, sub: 'Stable recall' },
-        { label: 'Trouble', value: y56.trouble, sub: 'Weak or fragile' },
-        { label: 'Unseen', value: y56.fresh, sub: 'Not yet introduced' },
-      ],
+      stats: wordBankAggregateCards(y56, 'Words in pool'),
     },
     {
       eyebrow: 'Extra',
       title: 'Expansion spelling pool',
-      stats: [
-        { label: 'Total', value: extra.total, sub: 'Words in pool' },
-        { label: 'Secure', value: extra.secure, sub: 'Stable recall' },
-        { label: 'Trouble', value: extra.trouble, sub: 'Weak or fragile' },
-        { label: 'Unseen', value: extra.fresh, sub: 'Not yet introduced' },
-      ],
+      stats: wordBankAggregateCards(extra, 'Words in pool'),
     },
   ];
   return `
@@ -1258,7 +1200,6 @@ function renderWordBankScene({ appState, learner, service, subject }) {
   const analytics = service.getAnalyticsSnapshot(learner.id);
   const accent = accentFor(subject);
   const searchQuery = appState?.transientUi?.spellingAnalyticsWordSearch || '';
-  const statusFilter = appState?.transientUi?.spellingAnalyticsStatusFilter || 'all';
   const yearFilter = appState?.transientUi?.spellingAnalyticsYearFilter || 'all';
   const detailSlug = appState?.transientUi?.spellingWordDetailSlug || '';
   const detailMode = appState?.transientUi?.spellingWordDetailMode || 'explain';
@@ -1274,7 +1215,7 @@ function renderWordBankScene({ appState, learner, service, subject }) {
           <h1 class="word-bank-title">${escapeHtml(learner.name)}’s spellings</h1>
         </header>
         ${renderWordBankAggregates(analytics)}
-        ${renderWordBank({ learner, analytics, searchQuery, statusFilter, yearFilter })}
+        ${renderWordBank({ learner, analytics, searchQuery, yearFilter })}
       </div>
       ${detailWord ? renderWordDetailModal({ word: detailWord, mode: detailMode, typed: drillTyped, result: drillResult, accent }) : ''}
     </div>
@@ -1357,22 +1298,6 @@ export const spellingModule = {
         transientUi: {
           ...current.transientUi,
           spellingAnalyticsWordSearch,
-        },
-      }));
-      return true;
-    }
-
-    if (action === 'spelling-analytics-status-filter') {
-      /* Word bank filter tab — v1 tokens (unseen/weak) are accepted verbatim;
-         normalisation into the validator set happens inside the store on patch.
-         Unknown values collapse to 'all' so the learner always sees the full
-         list rather than a confusing empty state. */
-      const raw = String(data.value || 'all');
-      const next = WORD_BANK_FILTER_IDS.has(raw) ? raw : 'all';
-      store.patch((current) => ({
-        transientUi: {
-          ...current.transientUi,
-          spellingAnalyticsStatusFilter: next,
         },
       }));
       return true;

--- a/styles/app.css
+++ b/styles/app.css
@@ -4538,8 +4538,7 @@ textarea:focus-visible {
 }
 .wb-search-icon svg { display: block; }
 
-.wb-chips,
-.wb-legend {
+.wb-chips {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
@@ -4552,45 +4551,15 @@ textarea:focus-visible {
   min-width: min(100%, 520px);
 }
 
-.wb-status-legend {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px 10px;
-  margin: 0 0 14px;
-  padding: 10px 0 0;
-  border-top: 1px solid var(--line-soft);
-}
-.wb-legend-item {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  color: var(--ink-2);
-  font-size: 0.8rem;
-  font-weight: 700;
-}
-.wb-legend-swatch {
-  width: 0.85rem;
-  height: 0.85rem;
-  border-radius: 999px;
-  border: 1px solid transparent;
-  background: var(--panel-sunken);
-}
-.wb-legend-count {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 20px;
-  padding: 1px 6px;
-  border-radius: 999px;
-  background: var(--panel-soft);
-  color: var(--muted);
-  font-size: 0.7rem;
-  font-variant-numeric: tabular-nums;
-}
-
 .wb-word-groups {
   display: grid;
   gap: 16px;
+  height: clamp(420px, 54vh, 640px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-right: 6px;
+  scrollbar-gutter: stable;
+  align-content: start;
 }
 .wb-word-group {
   padding-top: 14px;
@@ -4657,32 +4626,27 @@ textarea:focus-visible {
   outline: 2px solid var(--brand);
   outline-offset: 2px;
 }
-.wb-word-pill.new,
-.wb-legend-swatch.new {
+.wb-word-pill.new {
   background: var(--panel-sunken);
   color: var(--muted);
   border-color: var(--line);
 }
-.wb-word-pill.learning,
-.wb-legend-swatch.learning {
+.wb-word-pill.learning {
   background: var(--brand-soft);
   color: var(--brand-ink);
   border-color: color-mix(in oklab, var(--brand) 24%, var(--line));
 }
-.wb-word-pill.due,
-.wb-legend-swatch.due {
+.wb-word-pill.due {
   background: var(--warn-soft);
   color: var(--warn-strong);
   border-color: color-mix(in oklab, var(--warn) 34%, var(--line));
 }
-.wb-word-pill.secure,
-.wb-legend-swatch.secure {
+.wb-word-pill.secure {
   background: var(--good-soft);
   color: var(--good-strong);
   border-color: color-mix(in oklab, var(--good) 34%, var(--line));
 }
-.wb-word-pill.trouble,
-.wb-legend-swatch.trouble {
+.wb-word-pill.trouble {
   background: var(--bad-soft);
   color: var(--bad-strong);
   border-color: color-mix(in oklab, var(--bad) 34%, var(--line));
@@ -4720,14 +4684,12 @@ textarea:focus-visible {
 
 @media (max-width: 720px) {
   .wb-card { padding: 22px 20px 20px; border-radius: var(--radius); }
+  .wb-word-groups { height: clamp(360px, 52vh, 560px); }
 }
 
 /* ---------- Word bank filter chips ---------- */
-/* Interactive tabs on the word-bank toolbar. Each chip is a real button that
-   dispatches spelling-analytics-status-filter with a v1 token (all / due /
-   weak / learning / secure / unseen). The palette mirrors the word-pill
-   legend so the filter selection stays visually connected to the spellings
-   it produces. */
+/* Interactive category filters on the word-bank toolbar. Status now lives in
+   the word-pill colour itself, avoiding a duplicate second filter row. */
 .wb-chip {
   appearance: none;
   display: inline-flex;

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -11,6 +11,20 @@ function typedFormData(value) {
   return formData;
 }
 
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function extractWordBankAggregateStats(html, title) {
+  const match = String(html || '').match(new RegExp(
+    `<section class="wb-card wb-card-compact">[\\s\\S]*?<h2 class="section-title">${escapeRegExp(title)}</h2>([\\s\\S]*?)</section>`,
+  ));
+  assert.ok(match, `Missing word-bank aggregate card: ${title}`);
+  return Object.fromEntries([...match[1].matchAll(
+    /<div class="stat-label">([^<]+)<\/div>\s*<div class="stat-value"[^>]*>([^<]+)<\/div>/g,
+  )].map((entry) => [entry[1], entry[2]]));
+}
+
 function completeCurrentSpellingRound(harness) {
   while (harness.store.getState().subjectUi.spelling.phase === 'session') {
     const state = harness.store.getState().subjectUi.spelling;
@@ -147,28 +161,53 @@ test('spelling word bank opens from setup and exposes searchable progress with d
   assert.match(html, /Expansion spelling pool/);
   assert.doesNotMatch(html, /All spellings/);
   assert.match(html, /name="spellingAnalyticsSearch"[^>]*autocomplete="off"/);
-  // Filter tabs — the legend chips have been replaced by interactive
-  // spelling-analytics-status-filter tabs. The status value stays on the wire
-  // in v1 vocabulary ("unseen" / "learning" / "weak"), and each tab carries a
-  // .wb-chip-label span with the visible label. Attribute regexes use `\s+`
-  // because the template emits attrs on separate indented lines for legibility.
-  assert.match(html, /data-action="spelling-analytics-status-filter"\s+data-value="unseen"/);
-  assert.match(html, /data-action="spelling-analytics-status-filter"\s+data-value="learning"/);
-  assert.match(html, /class="wb-chip-label">Unseen</);
-  assert.match(html, /class="wb-chip-label">Learning</);
-  // Category filters sit beside the status filters and use the same transient
-  // UI store path, so combining year band + status + search never mutates the
-  // scheduled spelling session.
+  // Category filters sit beside search and use transient UI only, so browsing
+  // the bank never mutates the scheduled spelling session.
   assert.match(html, /data-action="spelling-analytics-year-filter"\s+data-value="y3-4"/);
   assert.match(html, /data-action="spelling-analytics-year-filter"\s+data-value="y5-6"/);
+  assert.match(html, /data-action="spelling-analytics-year-filter"\s+data-value="extra"/);
   assert.match(html, /class="wb-chip-label">Years 3-4</);
   assert.match(html, /class="wb-chip-label">Years 5-6</);
+  assert.match(html, /class="wb-chip-label">Extra</);
+  assert.doesNotMatch(html, /data-action="spelling-analytics-status-filter"/);
+  assert.doesNotMatch(html, /Word status colour legend/);
+  assert.deepEqual(extractWordBankAggregateStats(html, 'Core statutory progress'), {
+    Total: '213',
+    Secure: '0',
+    'Due now': '0',
+    Trouble: '0',
+    Learning: '0',
+    Unseen: '213',
+  });
+  assert.deepEqual(extractWordBankAggregateStats(html, 'Lower KS2 spelling pool'), {
+    Total: '109',
+    Secure: '0',
+    'Due now': '0',
+    Trouble: '0',
+    Learning: '0',
+    Unseen: '109',
+  });
+  assert.deepEqual(extractWordBankAggregateStats(html, 'Upper KS2 spelling pool'), {
+    Total: '104',
+    Secure: '0',
+    'Due now': '0',
+    Trouble: '0',
+    Learning: '0',
+    Unseen: '104',
+  });
+  assert.deepEqual(extractWordBankAggregateStats(html, 'Expansion spelling pool'), {
+    Total: '22',
+    Secure: '0',
+    'Due now': '0',
+    Trouble: '0',
+    Learning: '0',
+    Unseen: '22',
+  });
   // Word-bank entries render as legacy-style colour pills. The tooltip carries
   // the progress details, while clicking the pill opens the new drill modal.
   assert.match(html, /class="wb-word-pill new"/);
   assert.match(html, /data-action="spelling-word-detail-open"\s+data-slug="possess"\s+data-value="drill"/);
   assert.match(html, /title="possess[^"]*Family: possess\(ion\)[^"]*Next due: Unseen[^"]*Click to drill"/);
-  assert.match(html, /Word status colour legend/);
   assert.match(html, />accident</);
   assert.doesNotMatch(html, /wb-meta-label">Family/);
 
@@ -193,6 +232,15 @@ test('spelling word bank opens from setup and exposes searchable progress with d
         lastDay: todayDay,
         lastResult: true,
       },
+      actual: {
+        stage: 1,
+        attempts: 3,
+        correct: 2,
+        wrong: 1,
+        dueDay: todayDay + 3,
+        lastDay: todayDay,
+        lastResult: true,
+      },
     },
   });
 
@@ -203,28 +251,38 @@ test('spelling word bank opens from setup and exposes searchable progress with d
   assert.doesNotMatch(html, />accident</);
   assert.match(html, /Years 5-6 selected — 104 of 235 words, 0 secure, 1 due today, 0 weak spots/);
   assert.match(html, /Showing 104 of 104 Years 5-6 spellings/);
-
-  harness.dispatch('spelling-analytics-status-filter', { value: 'due' });
-  assert.equal(harness.store.getState().transientUi.spellingAnalyticsStatusFilter, 'due');
-  html = harness.render();
-  assert.match(html, />accommodate</);
-  assert.doesNotMatch(html, />accident</);
-  assert.match(html, /Showing 1 of 104 Years 5-6 spellings/);
+  assert.deepEqual(extractWordBankAggregateStats(html, 'Upper KS2 spelling pool'), {
+    Total: '104',
+    Secure: '0',
+    'Due now': '1',
+    Trouble: '0',
+    Learning: '0',
+    Unseen: '103',
+  });
 
   harness.dispatch('spelling-analytics-year-filter', { value: 'y3-4' });
   html = harness.render();
-  assert.match(html, /No words match your filters/);
-  assert.doesNotMatch(html, />accommodate</);
-  assert.doesNotMatch(html, />accident</);
-
-  harness.dispatch('spelling-analytics-status-filter', { value: 'secure' });
-  html = harness.render();
   assert.match(html, />accident</);
   assert.doesNotMatch(html, />accommodate</);
-  assert.match(html, /Showing 1 of 109 Years 3-4 spellings/);
+  assert.match(html, /Years 3-4 selected — 109 of 235 words, 1 secure, 0 due today, 0 weak spots/);
+  assert.match(html, /Showing 109 of 109 Years 3-4 spellings/);
+  assert.deepEqual(extractWordBankAggregateStats(html, 'Lower KS2 spelling pool'), {
+    Total: '109',
+    Secure: '1',
+    'Due now': '0',
+    Trouble: '0',
+    Learning: '1',
+    Unseen: '107',
+  });
+
+  harness.dispatch('spelling-analytics-year-filter', { value: 'extra' });
+  html = harness.render();
+  assert.match(html, />mollusc</);
+  assert.doesNotMatch(html, />accident</);
+  assert.match(html, /Extra selected — 22 of 235 words, 0 secure, 0 due today, 0 weak spots/);
+  assert.match(html, /Showing 22 of 22 Extra spellings/);
 
   harness.dispatch('spelling-analytics-year-filter', { value: 'all' });
-  harness.dispatch('spelling-analytics-status-filter', { value: 'all' });
 
   harness.repositories.subjectStates.writeData(learnerId, 'spelling', {
     progress: {


### PR DESCRIPTION
## Summary
- Replace duplicate word-bank status controls with category filters for All, Years 3-4, Years 5-6, and Extra.
- Make word-bank aggregate cards count from the same visible word status source as the pills, including Due, Trouble, Learning, and Unseen buckets.
- Stabilise the word-bank list pane height and harden Scribe Downs background asset references.

## Validation
- `node --test tests/smoke.test.js`
- `node --test tests/render.test.js`
- `node --run test`
- `npm run check`
- Desktop and mobile browser validation for filters, aggregate counts, search, drill modal, and layout stability