### PR TITLE
Restore word bank status filters

### DIFF
--- a/src/platform/core/store.js
+++ b/src/platform/core/store.js
@@ -141,8 +141,8 @@ const VALID_WORD_DRILL_RESULTS = new Set(['correct', 'incorrect']);
 
 function normaliseTransientUi(rawValue) {
   const raw = rawValue && typeof rawValue === 'object' && !Array.isArray(rawValue) ? rawValue : {};
-  /* Legacy word-bank status filter — retained only to normalise older persisted
-     snapshots. The current word bank filters by category and search only. */
+  /* Word-bank status filter — chips use v1 labels (unseen/weak) while the
+     renderer maps them to production word status values. */
   const rawFilter = typeof raw.spellingAnalyticsStatusFilter === 'string'
     ? raw.spellingAnalyticsStatusFilter
     : 'all';

--- a/src/subjects/spelling/module.js
+++ b/src/subjects/spelling/module.js
@@ -95,9 +95,17 @@ function normaliseSearchText(value) {
   return String(value || '').trim().toLowerCase();
 }
 
-/* Category filters stay intentionally broad: the word colours already describe
-   status, while the toolbar narrows the statutory/extra spelling pools. */
+/* Category filters stay intentionally broad; status chips double as the colour
+   legend and the status filter so the toolbar has one clear source of truth. */
+const WORD_BANK_FILTER_IDS = new Set(['all', 'due', 'weak', 'learning', 'secure', 'unseen']);
 const WORD_BANK_YEAR_FILTER_IDS = new Set(['all', 'y3-4', 'y5-6', 'extra']);
+
+function wordBankFilterMatchesStatus(filter, status) {
+  if (filter === 'all') return true;
+  if (filter === 'weak') return status === 'trouble';
+  if (filter === 'unseen') return status === 'new';
+  return filter === status;
+}
 
 function wordBankYearFilterMatches(filter, word) {
   if (filter === 'all') return true;
@@ -791,9 +799,41 @@ function renderSummary({ learner, ui, subject }) {
 /* --------------------------------------------------------------
    Word bank (standalone browser)
    Category chips narrow the statutory Years 3-4 / Years 5-6 pools
-   and the Extra expansion pool. Word colours keep status visible
-   without adding a second duplicate status toolbar.
+   and the Extra expansion pool. Status chips are also the colour legend,
+   so there is no separate duplicate legend row.
    -------------------------------------------------------------- */
+function renderWordBankStatusChips({ counts, activeFilter }) {
+  const chips = [
+    { id: 'all', label: 'All', swatch: 'all' },
+    { id: 'due', label: 'Due', swatch: 'due' },
+    { id: 'weak', label: 'Trouble', swatch: 'trouble' },
+    { id: 'learning', label: 'Learning', swatch: 'learning' },
+    { id: 'secure', label: 'Secure', swatch: 'secure' },
+    { id: 'unseen', label: 'Unseen', swatch: 'new' },
+  ];
+  return `
+    <div class="wb-chips wb-status-chips" role="group" aria-label="Filter word bank by status">
+      ${chips.map((chip) => {
+        const active = chip.id === activeFilter;
+        const count = counts[chip.id] ?? 0;
+        return `
+          <button
+            type="button"
+            aria-pressed="${active ? 'true' : 'false'}"
+            class="wb-chip wb-chip-status${active ? ' on' : ''}"
+            data-action="spelling-analytics-status-filter"
+            data-value="${escapeHtml(chip.id)}"
+          >
+            <span class="wb-status-swatch ${escapeHtml(chip.swatch)}" aria-hidden="true"></span>
+            <span class="wb-chip-label">${escapeHtml(chip.label)}</span>
+            <span class="wb-chip-count">${count}</span>
+          </button>
+        `;
+      }).join('')}
+    </div>
+  `;
+}
+
 function renderWordBankYearChips({ counts, activeYearFilter }) {
   const chips = [
     { id: 'all', label: 'All' },
@@ -901,7 +941,7 @@ function renderWordBankGroup({ group, words, query }) {
   const summaryText = words.length
     ? `${secureCount} secure out of ${words.length} visible spellings`
     : 'No words match your filters.';
-  const emptyText = query ? 'Try another word or family search.' : 'Try another category filter.';
+  const emptyText = query ? 'Try another word or family search.' : 'Try another category or status filter.';
   return `
     <section class="wb-word-group" aria-label="${escapeHtml(group.title)} spellings">
       <div class="wb-word-group-head">
@@ -917,30 +957,34 @@ function renderWordBankGroup({ group, words, query }) {
   `;
 }
 
-function renderWordBank({ learner, analytics, searchQuery = '', yearFilter = 'all' }) {
+function renderWordBank({ learner, analytics, searchQuery = '', statusFilter = 'all', yearFilter = 'all' }) {
   const query = normaliseSearchText(searchQuery);
+  const activeFilter = WORD_BANK_FILTER_IDS.has(statusFilter) ? statusFilter : 'all';
   const activeYearFilter = WORD_BANK_YEAR_FILTER_IDS.has(yearFilter) ? yearFilter : 'all';
   const groups = Array.isArray(analytics.wordGroups) ? analytics.wordGroups : [];
   const allWords = groups.flatMap((group) => Array.isArray(group.words) ? group.words : []);
   const categoryWords = allWords.filter((word) => wordBankYearFilterMatches(activeYearFilter, word));
 
-  /* Apply the category first, then search. Status remains visible through the
-     word-pill colour and tooltip so stale hidden status filters never change
-     what the learner sees. */
+  /* Apply category, then status, then search. Status chips are the visible
+     legend, so the filtered result and the colour key stay in sync. */
   const visibleGroups = groups
     .filter((group) => activeYearFilter === 'all' ? true : group.key === activeYearFilter)
     .map((group) => {
       const words = (Array.isArray(group.words) ? group.words : [])
+        .filter((word) => wordBankFilterMatchesStatus(activeFilter, word.status))
         .filter((word) => wordMatchesSearch(word, query));
       return { group, words };
     })
-    .filter((entry) => query ? entry.words.length > 0 : true);
+    .filter((entry) => activeFilter === 'all' && !query ? true : entry.words.length > 0);
   const visibleWords = visibleGroups.flatMap((entry) => entry.words);
 
   const counts = {
+    all: categoryWords.length,
     due: countWordBankStatus(categoryWords, 'due'),
     weak: countWordBankStatus(categoryWords, 'trouble'),
+    learning: countWordBankStatus(categoryWords, 'learning'),
     secure: countWordBankStatus(categoryWords, 'secure'),
+    unseen: countWordBankStatus(categoryWords, 'new'),
   };
   const yearCounts = {
     all: allWords.length,
@@ -987,6 +1031,7 @@ function renderWordBank({ learner, analytics, searchQuery = '', yearFilter = 'al
           </label>
           <div class="wb-filter-stack">
             ${renderWordBankYearChips({ counts: yearCounts, activeYearFilter })}
+            ${renderWordBankStatusChips({ counts, activeFilter })}
           </div>
         </div>
 
@@ -1200,6 +1245,7 @@ function renderWordBankScene({ appState, learner, service, subject }) {
   const analytics = service.getAnalyticsSnapshot(learner.id);
   const accent = accentFor(subject);
   const searchQuery = appState?.transientUi?.spellingAnalyticsWordSearch || '';
+  const statusFilter = appState?.transientUi?.spellingAnalyticsStatusFilter || 'all';
   const yearFilter = appState?.transientUi?.spellingAnalyticsYearFilter || 'all';
   const detailSlug = appState?.transientUi?.spellingWordDetailSlug || '';
   const detailMode = appState?.transientUi?.spellingWordDetailMode || 'explain';
@@ -1215,7 +1261,7 @@ function renderWordBankScene({ appState, learner, service, subject }) {
           <h1 class="word-bank-title">${escapeHtml(learner.name)}’s spellings</h1>
         </header>
         ${renderWordBankAggregates(analytics)}
-        ${renderWordBank({ learner, analytics, searchQuery, yearFilter })}
+        ${renderWordBank({ learner, analytics, searchQuery, statusFilter, yearFilter })}
       </div>
       ${detailWord ? renderWordDetailModal({ word: detailWord, mode: detailMode, typed: drillTyped, result: drillResult, accent }) : ''}
     </div>
@@ -1310,6 +1356,18 @@ export const spellingModule = {
         transientUi: {
           ...current.transientUi,
           spellingAnalyticsYearFilter: next,
+        },
+      }));
+      return true;
+    }
+
+    if (action === 'spelling-analytics-status-filter') {
+      const raw = String(data.value || 'all');
+      const next = WORD_BANK_FILTER_IDS.has(raw) ? raw : 'all';
+      store.patch((current) => ({
+        transientUi: {
+          ...current.transientUi,
+          spellingAnalyticsStatusFilter: next,
         },
       }));
       return true;

--- a/styles/app.css
+++ b/styles/app.css
@@ -4688,8 +4688,8 @@ textarea:focus-visible {
 }
 
 /* ---------- Word bank filter chips ---------- */
-/* Interactive category filters on the word-bank toolbar. Status now lives in
-   the word-pill colour itself, avoiding a duplicate second filter row. */
+/* Category chips narrow the pool. Status chips combine filtering and colour
+   legend in one row, avoiding a separate duplicate legend. */
 .wb-chip {
   appearance: none;
   display: inline-flex;
@@ -4751,6 +4751,47 @@ textarea:focus-visible {
   background: color-mix(in oklab, var(--panel) 22%, transparent);
   border-color: color-mix(in oklab, var(--panel) 28%, transparent);
   color: var(--panel);
+}
+.wb-chip-status {
+  gap: 7px;
+}
+.wb-chip-status.on {
+  background: var(--panel);
+  border-color: color-mix(in oklab, var(--ink) 28%, var(--line));
+  color: var(--ink);
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--ink) 10%, transparent);
+}
+.wb-status-swatch {
+  width: 0.78rem;
+  height: 0.78rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: var(--panel-sunken);
+  flex: 0 0 auto;
+}
+.wb-status-swatch.all {
+  background: linear-gradient(135deg, var(--panel-sunken) 0 18%, var(--brand-soft) 18% 38%, var(--warn-soft) 38% 58%, var(--good-soft) 58% 78%, var(--bad-soft) 78% 100%);
+  border-color: var(--line);
+}
+.wb-status-swatch.new {
+  background: var(--panel-sunken);
+  border-color: var(--line);
+}
+.wb-status-swatch.learning {
+  background: var(--brand-soft);
+  border-color: color-mix(in oklab, var(--brand) 24%, var(--line));
+}
+.wb-status-swatch.due {
+  background: var(--warn-soft);
+  border-color: color-mix(in oklab, var(--warn) 34%, var(--line));
+}
+.wb-status-swatch.secure {
+  background: var(--good-soft);
+  border-color: color-mix(in oklab, var(--good) 34%, var(--line));
+}
+.wb-status-swatch.trouble {
+  background: var(--bad-soft);
+  border-color: color-mix(in oklab, var(--bad) 34%, var(--line));
 }
 
 /* ---------- Subject-screen breadcrumb ---------- */

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -169,7 +169,12 @@ test('spelling word bank opens from setup and exposes searchable progress with d
   assert.match(html, /class="wb-chip-label">Years 3-4</);
   assert.match(html, /class="wb-chip-label">Years 5-6</);
   assert.match(html, /class="wb-chip-label">Extra</);
-  assert.doesNotMatch(html, /data-action="spelling-analytics-status-filter"/);
+  assert.match(html, /data-action="spelling-analytics-status-filter"\s+data-value="due"/);
+  assert.match(html, /data-action="spelling-analytics-status-filter"\s+data-value="weak"/);
+  assert.match(html, /data-action="spelling-analytics-status-filter"\s+data-value="learning"/);
+  assert.match(html, /data-action="spelling-analytics-status-filter"\s+data-value="secure"/);
+  assert.match(html, /data-action="spelling-analytics-status-filter"\s+data-value="unseen"/);
+  assert.match(html, /class="wb-status-swatch trouble"/);
   assert.doesNotMatch(html, /Word status colour legend/);
   assert.deepEqual(extractWordBankAggregateStats(html, 'Core statutory progress'), {
     Total: '213',
@@ -260,6 +265,14 @@ test('spelling word bank opens from setup and exposes searchable progress with d
     Unseen: '103',
   });
 
+  harness.dispatch('spelling-analytics-status-filter', { value: 'due' });
+  assert.equal(harness.store.getState().transientUi.spellingAnalyticsStatusFilter, 'due');
+  html = harness.render();
+  assert.match(html, />accommodate</);
+  assert.doesNotMatch(html, />accident</);
+  assert.match(html, /Showing 1 of 104 Years 5-6 spellings/);
+
+  harness.dispatch('spelling-analytics-status-filter', { value: 'all' });
   harness.dispatch('spelling-analytics-year-filter', { value: 'y3-4' });
   html = harness.render();
   assert.match(html, />accident</);
@@ -275,6 +288,13 @@ test('spelling word bank opens from setup and exposes searchable progress with d
     Unseen: '107',
   });
 
+  harness.dispatch('spelling-analytics-status-filter', { value: 'secure' });
+  html = harness.render();
+  assert.match(html, />accident</);
+  assert.doesNotMatch(html, />actual</);
+  assert.match(html, /Showing 1 of 109 Years 3-4 spellings/);
+
+  harness.dispatch('spelling-analytics-status-filter', { value: 'all' });
   harness.dispatch('spelling-analytics-year-filter', { value: 'extra' });
   html = harness.render();
   assert.match(html, />mollusc</);


### PR DESCRIPTION
## Summary
- Restore word-bank status filter chips for All, Due, Trouble, Learning, Secure, and Unseen.
- Combine the colour legend with the status filters so there is no separate duplicate legend row.
- Preserve the category filters for All, Years 3-4, Years 5-6, and Extra, with stable filtered layouts.

## Validation
- `node --test tests/smoke.test.js`
- `node --test tests/render.test.js`
- `git diff --check`
- `npm run check`
- Browser validation on desktop and mobile for category + status filters, drill modal, duplicate legend removal, and stable word-bank height.
- `node --run test` (199 passing)