### PR TITLE
Add glass treatment to word bank cards

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -4472,11 +4472,13 @@ textarea:focus-visible {
 
 /* ---------- Word bank (analytics tab) ---------- */
 .wb-card {
-  background: var(--panel);
-  border: 1px solid var(--line);
+  background: color-mix(in oklab, var(--panel) 80%, transparent);
+  backdrop-filter: blur(8px) saturate(1.05);
+  -webkit-backdrop-filter: blur(8px) saturate(1.05);
+  border: 1px solid color-mix(in oklab, var(--line) 80%, transparent);
   border-radius: var(--radius-lg);
   padding: 28px 32px 24px;
-  box-shadow: var(--shadow);
+  box-shadow: var(--shadow-warm);
   max-width: 920px;
   margin: 0 auto;
 }
@@ -4917,6 +4919,12 @@ textarea:focus-visible {
 .wb-card-compact .stat-grid {
   grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
   gap: 8px;
+}
+.wb-card .stat {
+  background: color-mix(in oklab, var(--panel-soft) 72%, transparent);
+  backdrop-filter: blur(6px) saturate(1.04);
+  -webkit-backdrop-filter: blur(6px) saturate(1.04);
+  border-color: color-mix(in oklab, var(--line) 72%, transparent);
 }
 
 /* ---------- WordDetailModal ---------- */


### PR DESCRIPTION
## Summary
- Apply the same glass treatment style as the spelling question card to word-bank cards: 80% panel opacity with backdrop blur.
- Add a second translucent layer to stat cards inside the word-bank cards.
- Keep dark-theme contrast healthy after the transparency change.

## Validation
- `node --test tests/smoke.test.js`
- `node --test tests/render.test.js`
- `git diff --check`
- `node --run build && node --run assert:build-public`
- `env -u CLOUDFLARE_API_TOKEN ./node_modules/.bin/wrangler deploy --dry-run`
- Browser computed-style validation in dark theme: outer card alpha 0.8 + blur(8px), inner stat alpha 0.72 + blur(6px), stat value contrast 13.29:1, label contrast 5.09:1.
- `node --run test` (199 passing)