### PR TITLE
Optimise spelling React flow

### DIFF
--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect } from 'react';
+import React, { useLayoutEffect, useMemo } from 'react';
 import { HomeSurface } from '../surfaces/home/HomeSurface.jsx';
 import { CodexSurface } from '../surfaces/home/CodexSurface.jsx';
 import { TopNav } from '../surfaces/shell/TopNav.jsx';
@@ -74,11 +74,11 @@ export function App({ controller, runtime }) {
   const appState = snapshot.appState;
   const screen = appState.route?.screen || 'dashboard';
   const context = runtime.contextFor(appState.route?.subjectId || 'spelling');
-  const actions = runtime.buildSurfaceActions();
+  const actions = useMemo(() => runtime.buildSurfaceActions(), [runtime]);
 
   useLayoutEffect(() => {
-    runtime.afterRender?.(appState, context);
-  }, [appState, context, runtime]);
+    runtime.afterRender?.(appState);
+  }, [appState, runtime]);
 
   return (
     <ErrorBoundary>

--- a/src/main.js
+++ b/src/main.js
@@ -554,8 +554,31 @@ function buildSignedInHubModels(appState) {
   };
 }
 
-function buildHubModels(appState) {
-  return boot.session.signedIn ? buildSignedInHubModels(appState) : buildLocalHubModels(appState);
+function buildLocalShellHubModels(appState) {
+  const selectedLearnerId = appState.learners.selectedId;
+  return {
+    shellAccess: {
+      platformRole: shellPlatformRole,
+      source: 'local-reference',
+    },
+    parentHub: null,
+    parentHubState: { status: 'idle', learnerId: selectedLearnerId || '', error: '', notice: '' },
+    adminHub: null,
+    adminHubState: { status: 'idle', learnerId: selectedLearnerId || '', error: '', notice: '' },
+    activeAdultLearnerContext: null,
+    adultSurfaceNotice: '',
+    adminAccountDirectory,
+  };
+}
+
+function needsFullLocalHubModels(appState) {
+  return appState.route.screen === 'parent-hub' || appState.route.screen === 'admin-hub';
+}
+
+function buildRouteHubModels(appState) {
+  if (boot.session.signedIn) return buildSignedInHubModels(appState);
+  if (needsFullLocalHubModels(appState)) return buildLocalHubModels(appState);
+  return buildLocalShellHubModels(appState);
 }
 
 const runtimeBoundary = createSubjectRuntimeBoundary({
@@ -838,7 +861,8 @@ function contextFor(subjectId = null) {
     tts,
     applySubjectTransition,
     runtimeBoundary,
-    ...buildHubModels(appState),
+    subjects: SUBJECTS,
+    ...buildRouteHubModels(appState),
   };
 }
 
@@ -1015,7 +1039,7 @@ controller.subscribe(() => {
   pendingPreservedFocus = capturePreservedFocus();
 });
 
-function afterReactRender(appState, context) {
+function afterReactRender(appState) {
   const preserved = pendingPreservedFocus;
   pendingPreservedFocus = null;
   const modalWasVisible = previousModalVisible;
@@ -1097,8 +1121,11 @@ function applyHeroDarkProbes() {
   heroes.forEach((element) => {
     const url = extractHeroBgUrl(element.getAttribute('style') || '');
     if (!url) return;
+    if (element.dataset.heroLuminanceUrl === url) return;
+    element.dataset.heroLuminanceUrl = url;
     probeRelLuminance(url).then((luminance) => {
       if (!element.isConnected) return;
+      if (element.dataset.heroLuminanceUrl !== url) return;
       element.classList.toggle('hero-dark', luminance < 0.5);
     }).catch(() => {
       /* probeRelLuminance never rejects, but guard defensively so a

--- a/src/subjects/spelling/components/SpellingWordBankScene.jsx
+++ b/src/subjects/spelling/components/SpellingWordBankScene.jsx
@@ -139,9 +139,19 @@ function WordGroup({ group, words, query, actions }) {
 }
 
 function WordBankCard({ learner, analytics, appState, actions }) {
-  const searchQuery = appState?.transientUi?.spellingAnalyticsWordSearch || '';
+  const persistedSearchQuery = appState?.transientUi?.spellingAnalyticsWordSearch || '';
+  const [draftSearch, setDraftSearch] = React.useState(persistedSearchQuery);
   const statusFilter = appState?.transientUi?.spellingAnalyticsStatusFilter || 'all';
   const yearFilter = appState?.transientUi?.spellingAnalyticsYearFilter || 'all';
+  React.useEffect(() => {
+    setDraftSearch(persistedSearchQuery);
+  }, [persistedSearchQuery]);
+  const commitSearch = React.useCallback((value) => {
+    const nextValue = String(value || '').slice(0, 80);
+    if (nextValue === persistedSearchQuery) return;
+    actions.dispatch('spelling-analytics-search', { value: nextValue });
+  }, [actions, persistedSearchQuery]);
+  const searchQuery = draftSearch;
   const query = normaliseSearchText(searchQuery);
   const activeFilter = WORD_BANK_FILTER_IDS.has(statusFilter) ? statusFilter : 'all';
   const activeYearFilter = WORD_BANK_YEAR_FILTER_IDS.has(yearFilter) ? yearFilter : 'all';
@@ -206,7 +216,13 @@ function WordBankCard({ learner, analytics, appState, actions }) {
               value={searchQuery}
               data-action="spelling-analytics-search"
               aria-label="Search word bank"
-              onChange={(event) => renderAction(actions, event, 'spelling-analytics-search', { value: event.currentTarget.value })}
+              onChange={(event) => setDraftSearch(event.currentTarget.value.slice(0, 80))}
+              onBlur={(event) => commitSearch(event.currentTarget.value)}
+              onKeyDown={(event) => {
+                if (event.key !== 'Enter') return;
+                event.preventDefault();
+                commitSearch(event.currentTarget.value);
+              }}
             />
           </label>
           <div className="wb-filter-stack">

--- a/src/subjects/spelling/components/SpellingWordDetailModal.jsx
+++ b/src/subjects/spelling/components/SpellingWordDetailModal.jsx
@@ -29,11 +29,17 @@ function ExplainBody({ word }) {
 }
 
 function DrillBody({ word, typed, result, accent, actions }) {
+  const [draftTyped, setDraftTyped] = React.useState(typed || '');
+  const [draftResult, setDraftResult] = React.useState(result);
   const sentence = word.sentence || '';
   const drillCloze = sentence ? buildDrillCloze(sentence, word) : '';
-  const showFeedback = result === 'correct' || result === 'incorrect';
-  const feedbackTone = result === 'correct' ? 'good' : 'warn';
-  const inputState = result === 'correct' ? 'is-correct' : result === 'incorrect' ? 'is-wrong' : '';
+  React.useEffect(() => {
+    setDraftTyped(typed || '');
+    setDraftResult(result);
+  }, [result, typed, word.slug]);
+  const showFeedback = draftResult === 'correct' || draftResult === 'incorrect';
+  const feedbackTone = draftResult === 'correct' ? 'good' : 'warn';
+  const inputState = draftResult === 'correct' ? 'is-correct' : draftResult === 'incorrect' ? 'is-wrong' : '';
 
   return (
     <div className="wb-modal-body">
@@ -41,7 +47,7 @@ function DrillBody({ word, typed, result, accent, actions }) {
         <p className="wb-modal-section-label">{sentence ? 'Listen to the sentence, then type the missing word' : 'Listen to the word, then type it'}</p>
         {sentence ? (
           <p className="wb-drill-sentence">
-            <Cloze sentence={drillCloze} answer={word.word} revealAnswer={result === 'correct'} />
+            <Cloze sentence={drillCloze} answer={word.word} revealAnswer={draftResult === 'correct'} />
           </p>
         ) : null}
       </div>
@@ -83,29 +89,32 @@ function DrillBody({ word, typed, result, accent, actions }) {
           autoCapitalize="none"
           spellCheck={false}
           placeholder="Type the word…"
-          value={typed}
+          value={draftTyped}
           data-autofocus="true"
           data-action="spelling-word-bank-drill-input"
           aria-label="Type the drill word"
-          disabled={result === 'correct'}
-          onChange={(event) => renderAction(actions, event, 'spelling-word-bank-drill-input', { value: event.currentTarget.value, slug: word.slug })}
+          disabled={draftResult === 'correct'}
+          onChange={(event) => {
+            setDraftTyped(event.currentTarget.value.slice(0, 80));
+            if (draftResult !== 'correct') setDraftResult(null);
+          }}
         />
-        <button type="submit" className="btn primary" style={{ '--btn-accent': accent }} disabled={result === 'correct'}>
+        <button type="submit" className="btn primary" style={{ '--btn-accent': accent }} disabled={draftResult === 'correct'}>
           Check <ArrowRightIcon />
         </button>
       </form>
       {showFeedback ? (
         <div className={`wb-drill-feedback ${feedbackTone}`} role="status">
-          <span className="wb-drill-feedback-icon" aria-hidden="true">{result === 'correct' ? '✓' : '!'}</span>
+          <span className="wb-drill-feedback-icon" aria-hidden="true">{draftResult === 'correct' ? '✓' : '!'}</span>
           <div>
-            {result === 'correct'
+            {draftResult === 'correct'
               ? <><b>Nice — "{word.word}" is spot on.</b> Browse on, or try another word.</>
               : <><b>Close — the word is "{word.word}".</b> Listen again and have another go.</>}
           </div>
         </div>
       ) : null}
       <div className="wb-modal-actions">
-        {result ? (
+        {draftResult ? (
           <>
             <button
               type="button"
@@ -119,13 +128,13 @@ function DrillBody({ word, typed, result, accent, actions }) {
             </button>
             <button
               type="button"
-              className={result === 'correct' ? 'btn primary' : 'btn ghost'}
-              style={result === 'correct' ? { '--btn-accent': accent } : undefined}
+              className={draftResult === 'correct' ? 'btn primary' : 'btn ghost'}
+              style={draftResult === 'correct' ? { '--btn-accent': accent } : undefined}
               data-action="spelling-word-bank-drill-try-again"
               data-slug={word.slug}
               onClick={(event) => renderAction(actions, event, 'spelling-word-bank-drill-try-again', { slug: word.slug })}
             >
-              Try again {result === 'correct' ? <ArrowRightIcon /> : null}
+              Try again {draftResult === 'correct' ? <ArrowRightIcon /> : null}
             </button>
           </>
         ) : null}

--- a/src/subjects/spelling/engine/legacy-engine.js
+++ b/src/subjects/spelling/engine/legacy-engine.js
@@ -149,12 +149,15 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
         catch (err) { /* quota/private-mode; ignore */ }
       }
     
-      function getProgress(profileId, slug) {
-        var store = loadProgress(profileId);
-        var existing = store[slug];
+      function progressForSlug(store, slug) {
+        var existing = store && store[slug];
         return Object.assign({}, defaultProgress(), existing || {});
       }
     
+      function getProgress(profileId, slug) {
+        return progressForSlug(loadProgress(profileId), slug);
+      }
+
       function setProgress(profileId, slug, record) {
         var store = loadProgress(profileId);
         store[slug] = Object.assign({}, defaultProgress(), record);
@@ -822,13 +825,14 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
     
       // ----- aggregate stats ----------------------------------------------------
     
-      function lifetimeStats(profileId, yearFilter) {
+      function lifetimeStats(profileId, yearFilter, progressStore) {
         var words = filteredWords(yearFilter);
         var today = todayDay();
+        var store = progressStore || loadProgress(profileId);
         var secure = 0, due = 0, fresh = 0, trouble = 0, attempts = 0, correct = 0;
         for (var i = 0; i < words.length; i++) {
           var word = words[i];
-          var p = getProgress(profileId, word.slug);
+          var p = progressForSlug(store, word.slug);
           attempts += p.attempts;
           correct += p.correct;
           if (p.attempts === 0) fresh += 1;
@@ -848,22 +852,24 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
         };
       }
     
-      function statusForWord(profileId, word) {
-        var p = getProgress(profileId, word.slug);
+      function statusForWord(profileId, word, progressStore) {
+        var p = progressStore ? progressForSlug(progressStore, word.slug) : getProgress(profileId, word.slug);
         var total = p.correct + p.wrong;
+        var today = todayDay();
         if (p.attempts === 0) return "new";
-        if (p.wrong > 0 && (p.wrong >= p.correct || (p.dueDay <= todayDay() && total > 0))) return "trouble";
-        if (p.dueDay <= todayDay()) return "due";
+        if (p.wrong > 0 && (p.wrong >= p.correct || (p.dueDay <= today && total > 0))) return "trouble";
+        if (p.dueDay <= today) return "due";
         if (p.stage >= SECURE_STAGE) return "secure";
         return "learning";
       }
     
-      function countMastered(profileId, wordList) {
+      function countMastered(profileId, wordList, progressStore) {
         var list = Array.isArray(wordList) ? wordList : WORDS;
+        var store = progressStore || loadProgress(profileId);
         var count = 0;
         for (var i = 0; i < list.length; i++) {
           var word = list[i];
-          var p = getProgress(profileId, word.slug);
+          var p = progressForSlug(store, word.slug);
           if (p.stage >= SECURE_STAGE) count += 1;
         }
         return count;
@@ -930,6 +936,7 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
         grade: gradeWord,
         normalize: normalize,
         progressFor: progressFor,
+        progressForSlug: progressForSlug,
         getProgress: function (profileId, slug) { return getProgress(profileId, slug); },
         resetProgress: function (profileId) { saveProgress(profileId, {}); },
         lifetimeStats: lifetimeStats,

--- a/src/subjects/spelling/module.js
+++ b/src/subjects/spelling/module.js
@@ -36,6 +36,14 @@ function wordBankDrillResult(word, typed) {
     : 'incorrect';
 }
 
+function wordBankEntryFor(service, learnerId, slug) {
+  if (!slug) return null;
+  if (typeof service.getWordBankEntry === 'function') {
+    return service.getWordBankEntry(learnerId, slug);
+  }
+  return findWordBankEntry(service.getAnalyticsSnapshot(learnerId), slug);
+}
+
 export const spellingModule = {
   id: 'spelling',
   name: 'Spelling',
@@ -227,7 +235,7 @@ export const spellingModule = {
       const slug = data.slug;
       if (!slug) return true;
       const rawMode = data.value === 'drill' ? 'drill' : 'explain';
-      const word = findWordBankEntry(service.getAnalyticsSnapshot(learnerId), slug);
+      const word = wordBankEntryFor(service, learnerId, slug);
       if (word && rawMode === 'drill') {
         tts.speak({ word: word.word, sentence: word.sentence });
       }
@@ -255,7 +263,7 @@ export const spellingModule = {
       const currentMode = appState?.transientUi?.spellingWordDetailMode === 'drill' ? 'drill' : 'explain';
       const modeChanged = rawMode !== currentMode;
       if (rawMode === 'drill' && slug) {
-        const word = findWordBankEntry(service.getAnalyticsSnapshot(learnerId), slug);
+        const word = wordBankEntryFor(service, learnerId, slug);
         if (word) tts.speak({ word: word.word, sentence: word.sentence });
       }
       store.patch((current) => ({
@@ -287,7 +295,7 @@ export const spellingModule = {
     if (action === 'spelling-word-bank-drill-submit') {
       const slug = data.slug || appState?.transientUi?.spellingWordDetailSlug || '';
       if (!slug) return true;
-      const word = findWordBankEntry(service.getAnalyticsSnapshot(learnerId), slug);
+      const word = wordBankEntryFor(service, learnerId, slug);
       if (!word) return true;
       const typed = String(data.formData?.get?.('typed') || '').trim();
       store.patch((current) => ({
@@ -303,7 +311,7 @@ export const spellingModule = {
     if (action === 'spelling-word-bank-drill-try-again') {
       const slug = data.slug || appState?.transientUi?.spellingWordDetailSlug || '';
       if (slug) {
-        const word = findWordBankEntry(service.getAnalyticsSnapshot(learnerId), slug);
+        const word = wordBankEntryFor(service, learnerId, slug);
         if (word) tts.speak({ word: word.word, sentence: word.sentence });
       }
       store.patch((current) => ({
@@ -319,7 +327,7 @@ export const spellingModule = {
     if (action === 'spelling-word-bank-word-replay') {
       const slug = data.slug || appState?.transientUi?.spellingWordDetailSlug || '';
       if (!slug) return true;
-      const word = findWordBankEntry(service.getAnalyticsSnapshot(learnerId), slug);
+      const word = wordBankEntryFor(service, learnerId, slug);
       if (!word) return true;
       tts.speak({
         word: word.word,
@@ -331,7 +339,7 @@ export const spellingModule = {
     if (action === 'spelling-word-bank-drill-replay' || action === 'spelling-word-bank-drill-replay-slow') {
       const slug = data.slug || appState?.transientUi?.spellingWordDetailSlug || '';
       if (!slug) return true;
-      const word = findWordBankEntry(service.getAnalyticsSnapshot(learnerId), slug);
+      const word = wordBankEntryFor(service, learnerId, slug);
       if (!word) return true;
       tts.speak({
         word: word.word,

--- a/src/subjects/spelling/service.js
+++ b/src/subjects/spelling/service.js
@@ -276,12 +276,24 @@ export function createSpellingService({ repository, storage, tts, now, random, c
     return next;
   }
 
-  function getStats(learnerId, yearFilter = 'core') {
-    return normaliseStats(engine.lifetimeStats(learnerId, normaliseYearFilter(yearFilter, 'core')));
+  function progressSnapshot(learnerId) {
+    return typeof engine.progressFor === 'function' ? engine.progressFor(learnerId) : null;
   }
 
-  function analyticsWordRow(learnerId, word) {
-    const progress = engine.getProgress(learnerId, word.slug);
+  function progressForWord(learnerId, word, progressStore = null) {
+    if (progressStore && typeof engine.progressForSlug === 'function') {
+      return engine.progressForSlug(progressStore, word.slug);
+    }
+    return engine.getProgress(learnerId, word.slug);
+  }
+
+  function getStats(learnerId, yearFilter = 'core', progressStore = null) {
+    return normaliseStats(engine.lifetimeStats(learnerId, normaliseYearFilter(yearFilter, 'core'), progressStore || undefined));
+  }
+
+  function analyticsWordRow(learnerId, word, progressStore = null) {
+    const progress = progressForWord(learnerId, word, progressStore);
+    const statusProgressStore = progressStore || { [word.slug]: progress };
     return {
       slug: word.slug,
       word: word.word,
@@ -293,7 +305,7 @@ export function createSpellingService({ repository, storage, tts, now, random, c
       sentence: word.sentence || '',
       explanation: word.explanation || '',
       accepted: Array.isArray(word.accepted) ? [...word.accepted] : [word.slug],
-      status: engine.statusForWord(learnerId, word),
+      status: engine.statusForWord(learnerId, word, statusProgressStore),
       stageLabel: engine.stageLabel(progress.stage),
       progress: {
         stage: progress.stage,
@@ -307,7 +319,7 @@ export function createSpellingService({ repository, storage, tts, now, random, c
     };
   }
 
-  function analyticsWordGroups(learnerId) {
+  function analyticsWordGroups(learnerId, progressStore = null) {
     const groups = [
       { key: 'y3-4', title: 'Years 3-4', spellingPool: 'core', year: '3-4' },
       { key: 'y5-6', title: 'Years 5-6', spellingPool: 'core', year: '5-6' },
@@ -320,22 +332,28 @@ export function createSpellingService({ repository, storage, tts, now, random, c
       year: group.year,
       words: runtimeWords
         .filter((word) => (word.spellingPool === 'extra' ? 'extra' : 'core') === group.spellingPool && word.year === group.year)
-        .map((word) => analyticsWordRow(learnerId, word)),
+        .map((word) => analyticsWordRow(learnerId, word, progressStore)),
     }));
   }
 
+  function getWordBankEntry(learnerId, slug) {
+    if (!isRuntimeKnownSlug(slug)) return null;
+    return analyticsWordRow(learnerId, runtimeWordBySlug[slug], progressSnapshot(learnerId));
+  }
+
   function getAnalyticsSnapshot(learnerId) {
+    const progressStore = progressSnapshot(learnerId);
     return {
       version: SPELLING_SERVICE_STATE_VERSION,
       generatedAt: clock(),
       pools: {
-        all: getStats(learnerId, 'core'),
-        core: getStats(learnerId, 'core'),
-        y34: getStats(learnerId, 'y3-4'),
-        y56: getStats(learnerId, 'y5-6'),
-        extra: getStats(learnerId, 'extra'),
+        all: getStats(learnerId, 'core', progressStore),
+        core: getStats(learnerId, 'core', progressStore),
+        y34: getStats(learnerId, 'y3-4', progressStore),
+        y56: getStats(learnerId, 'y5-6', progressStore),
+        extra: getStats(learnerId, 'extra', progressStore),
       },
-      wordGroups: analyticsWordGroups(learnerId),
+      wordGroups: analyticsWordGroups(learnerId, progressStore),
     };
   }
 
@@ -844,6 +862,7 @@ export function createSpellingService({ repository, storage, tts, now, random, c
     getPrefs,
     savePrefs,
     getStats,
+    getWordBankEntry,
     getAnalyticsSnapshot,
     startSession,
     submitAnswer,

--- a/tests/spelling.test.js
+++ b/tests/spelling.test.js
@@ -20,8 +20,7 @@ function makeSeededRandom(seed = 1) {
   };
 }
 
-function makeService({ now, random } = {}) {
-  const storage = installMemoryStorage();
+function makeService({ now, random, storage = installMemoryStorage() } = {}) {
   const repositories = createLocalPlatformRepositories({ storage });
   const spoken = [];
   const service = createSpellingService({
@@ -37,6 +36,16 @@ function makeService({ now, random } = {}) {
     },
   });
   return { storage, repositories, service, spoken };
+}
+
+function countStorageReads(storage) {
+  const reads = new Map();
+  const originalGetItem = storage.getItem.bind(storage);
+  storage.getItem = (key) => {
+    reads.set(key, (reads.get(key) || 0) + 1);
+    return originalGetItem(key);
+  };
+  return reads;
 }
 
 function continueUntilSummary(service, learnerId, state, answer = 'possess') {
@@ -460,6 +469,33 @@ test('analytics snapshot is explicit and normalised', () => {
   assert.equal(mollusc.word, 'mollusc');
   assert.equal(mollusc.spellingPool, 'extra');
   assert.equal(mollusc.year, 'extra');
+});
+
+test('analytics snapshot reuses one learner progress read', () => {
+  const storage = installMemoryStorage();
+  const repositories = createLocalPlatformRepositories({ storage });
+  const persistence = createSpellingPersistence({ repositories });
+  const reads = countStorageReads(persistence.storage);
+  const service = createSpellingService({
+    repository: persistence,
+    tts: {
+      speak() {},
+      stop() {},
+      warmup() {},
+    },
+  });
+
+  completeSingleWordRoundWithAnswer(service, 'learner-a', 'possess');
+  reads.clear();
+
+  const snapshot = service.getAnalyticsSnapshot('learner-a');
+  assert.equal(snapshot.wordGroups.flatMap((group) => group.words).length > 200, true);
+  assert.equal(reads.get('ks2-spell-progress-learner-a'), 1);
+
+  reads.clear();
+  const entry = service.getWordBankEntry('learner-a', 'possess');
+  assert.equal(entry.word, 'possess');
+  assert.equal(reads.get('ks2-spell-progress-learner-a'), 1);
 });
 
 test('malformed persisted session state falls back safely instead of crashing', () => {


### PR DESCRIPTION
## Summary
- Gate local parent/admin hub read-model construction so spelling subject renders only receive shell-level context unless the hub route is active.
- Reuse one learner progress snapshot across spelling analytics/stats generation, and add a lightweight word-bank entry lookup for modal/detail actions.
- Keep word-bank search and drill typing in React-local state, syncing only committed search or submitted drill results to the global store.
- Reduce global after-render churn by stabilising surface actions/effect dependencies and deduplicating hero luminance probing by hero URL.

## Verification
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/node --test tests/spelling.test.js tests/smoke.test.js tests/react-spelling-scene-spike.test.js`
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm test`
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run check`
- `PATH=/Users/jamesto/.bun/bin:/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run test:migration:browser`