### PR TITLE
Refine spelling setup transitions

### DIFF
--- a/src/subjects/spelling/components/SpellingHeroBackdrop.jsx
+++ b/src/subjects/spelling/components/SpellingHeroBackdrop.jsx
@@ -1,42 +1,73 @@
 import React from 'react';
 import { heroBgStyle, heroPanDelayStyle } from './spelling-view-model.js';
 
-export function SpellingHeroBackdrop({ url }) {
-  const layerId = React.useRef(0);
+export function SpellingHeroBackdrop({ url, previousUrl = '' }) {
+  const handoffUrl = previousUrl && previousUrl !== url ? previousUrl : '';
+  const layerId = React.useRef(handoffUrl ? 1 : 0);
+  const currentUrl = React.useRef(url || '');
+  const initialTransitionId = React.useRef(handoffUrl ? 1 : null);
   const [layers, setLayers] = React.useState(() => (
-    url ? [{ id: 0, url }] : []
+    url
+      ? [
+        ...(handoffUrl ? [{ id: 0, url: handoffUrl, phase: 'exiting' }] : []),
+        { id: handoffUrl ? 1 : 0, url, phase: handoffUrl ? 'entering' : 'active' },
+      ]
+      : []
   ));
 
   React.useEffect(() => {
+    const nextId = initialTransitionId.current;
+    if (nextId == null || !url) return undefined;
+    const transitionUrl = url;
+    const timer = setTimeout(() => {
+      setLayers((current) => {
+        if (currentUrl.current !== transitionUrl) return current;
+        return current
+          .filter((layer) => layer.id === nextId)
+          .map((layer) => ({ ...layer, phase: 'active' }));
+      });
+    }, 920);
+    return () => clearTimeout(timer);
+  }, []);
+
+  React.useEffect(() => {
     if (!url) {
+      currentUrl.current = '';
       setLayers([]);
       return undefined;
     }
 
+    if (currentUrl.current === url) return undefined;
+    currentUrl.current = url;
+    layerId.current += 1;
+    const nextId = layerId.current;
     setLayers((current) => {
-      const latest = current[current.length - 1];
-      if (latest?.url === url) return current;
-      layerId.current += 1;
-      return [...current.slice(-1), { id: layerId.current, url }];
+      return [
+        ...current.slice(-2).map((layer) => ({ ...layer, phase: 'exiting' })),
+        { id: nextId, url, phase: 'entering' },
+      ];
     });
 
     const timer = setTimeout(() => {
-      setLayers((current) => current.slice(-1));
-    }, 780);
+      setLayers((current) => current
+        .filter((layer) => layer.id === nextId)
+        .map((layer) => ({ ...layer, phase: 'active' })));
+    }, 920);
 
-    return () => clearTimeout(timer);
+    return () => {
+      clearTimeout(timer);
+    };
   }, [url]);
 
   if (!layers.length) return null;
 
   const panStyle = heroPanDelayStyle();
-  const activeLayerId = layers[layers.length - 1]?.id;
 
   return (
     <div className="spelling-hero-backdrop" aria-hidden="true">
       {layers.map((layer) => (
         <div
-          className={`hero-art pan spelling-hero-layer${layer.id === activeLayerId ? ' is-active' : ' is-exiting'}`}
+          className={`hero-art pan spelling-hero-layer is-${layer.phase}`}
           style={{ ...heroBgStyle(layer.url), ...panStyle }}
           key={layer.id}
         />

--- a/src/subjects/spelling/components/SpellingPracticeSurface.jsx
+++ b/src/subjects/spelling/components/SpellingPracticeSurface.jsx
@@ -3,7 +3,23 @@ import { SpellingSetupScene } from './SpellingSetupScene.jsx';
 import { SpellingSessionScene } from './SpellingSessionScene.jsx';
 import { SpellingSummaryScene } from './SpellingSummaryScene.jsx';
 import { SpellingWordBankScene } from './SpellingWordBankScene.jsx';
-import { buildSpellingContext } from './spelling-view-model.js';
+import {
+  buildSpellingContext,
+  heroBgForLearner,
+  heroBgForSession,
+  heroBgForSetup,
+} from './spelling-view-model.js';
+
+function heroBgForPhase(spelling) {
+  const learnerId = spelling.learner?.id;
+  if (!learnerId) return '';
+  if (spelling.ui.phase === 'session') return heroBgForSession(learnerId, spelling.ui.session);
+  if (spelling.ui.phase === 'summary') {
+    return heroBgForSession(learnerId, { mode: spelling.ui.summary?.mode });
+  }
+  if (spelling.ui.phase === 'word-bank') return heroBgForLearner(learnerId);
+  return heroBgForSetup(learnerId, spelling.prefs);
+}
 
 export function SpellingPracticeSurface(props) {
   const {
@@ -14,6 +30,14 @@ export function SpellingPracticeSurface(props) {
     actions,
   } = props;
   const spelling = buildSpellingContext({ appState, service, repositories, subject });
+  const heroBg = heroBgForPhase(spelling);
+  const previousHeroBgRef = React.useRef('');
+  const previousHeroBg = previousHeroBgRef.current && previousHeroBgRef.current !== heroBg
+    ? previousHeroBgRef.current
+    : '';
+  React.useEffect(() => {
+    if (heroBg) previousHeroBgRef.current = heroBg;
+  }, [heroBg]);
   React.useEffect(() => {
     if (typeof window === 'undefined') return undefined;
     const frame = window.requestAnimationFrame(() => {
@@ -23,11 +47,11 @@ export function SpellingPracticeSurface(props) {
   }, [spelling.ui.phase]);
 
   if (spelling.ui.phase === 'summary') {
-    return <SpellingSummaryScene {...spelling} actions={actions} />;
+    return <SpellingSummaryScene {...spelling} previousHeroBg={previousHeroBg} actions={actions} />;
   }
 
   if (spelling.ui.phase === 'session') {
-    return <SpellingSessionScene {...spelling} service={service} actions={actions} />;
+    return <SpellingSessionScene {...spelling} previousHeroBg={previousHeroBg} service={service} actions={actions} />;
   }
 
   if (spelling.ui.phase === 'word-bank') {
@@ -37,6 +61,7 @@ export function SpellingPracticeSurface(props) {
         learner={spelling.learner}
         analytics={spelling.analytics}
         accent={spelling.accent}
+        previousHeroBg={previousHeroBg}
         actions={actions}
       />
     );
@@ -48,6 +73,7 @@ export function SpellingPracticeSurface(props) {
       service={service}
       repositories={repositories}
       subject={subject}
+      previousHeroBg={previousHeroBg}
       actions={actions}
     />
   );

--- a/src/subjects/spelling/components/SpellingSessionScene.jsx
+++ b/src/subjects/spelling/components/SpellingSessionScene.jsx
@@ -16,7 +16,7 @@ import {
   renderFormAction,
 } from './spelling-view-model.js';
 
-export function SpellingSessionScene({ learner, service, ui, accent, actions }) {
+export function SpellingSessionScene({ learner, service, ui, accent, actions, previousHeroBg = '' }) {
   const prefs = service.getPrefs(learner.id);
   const session = ui.session;
   const card = session?.currentCard;
@@ -65,7 +65,7 @@ export function SpellingSessionScene({ learner, service, ui, accent, actions }) 
 
   return (
     <div className="spelling-in-session" style={{ gridColumn: '1/-1', ...heroBgStyle(heroBg) }}>
-      <SpellingHeroBackdrop url={heroBg} />
+      <SpellingHeroBackdrop url={heroBg} previousUrl={previousHeroBg} />
       <div className="session">
         <header className="session-head">
           <PathProgress done={pathDone} current={pathCurrent} total={progressTotal} />

--- a/src/subjects/spelling/components/SpellingSetupScene.jsx
+++ b/src/subjects/spelling/components/SpellingSetupScene.jsx
@@ -28,15 +28,17 @@ function ModeCard({ mode, selected, disabled = false, description, badge, action
       aria-disabled={disabled ? 'true' : undefined}
       onClick={(event) => renderAction(actions, event, 'spelling-set-mode', { value: mode.id })}
     >
-      {badge ? <span className="mc-badge">{badge}</span> : null}
-      <div className="mc-icon"><img src={mode.iconSrc} alt="" loading="eager" decoding="async" /></div>
+      <div className="mc-top">
+        <div className="mc-icon"><img src={mode.iconSrc} alt="" loading="eager" decoding="async" /></div>
+        <span className={`mc-badge${badge ? '' : ' is-placeholder'}`}>{badge || 'NONE YET'}</span>
+      </div>
       <h4>{mode.title}</h4>
       <p>{desc}</p>
     </button>
   );
 }
 
-function LengthPicker({ prefs, actions }) {
+function LengthPicker({ prefs, actions, disabled = false }) {
   const selectedValue = String(prefs.roundLength || '10');
   const selectedIndex = Math.max(0, ROUND_LENGTH_OPTIONS.indexOf(selectedValue));
   return (
@@ -59,6 +61,7 @@ function LengthPicker({ prefs, actions }) {
               data-action="spelling-set-pref"
               data-pref="roundLength"
               value={value}
+              disabled={disabled}
               key={value}
               onClick={(event) => renderAction(actions, event, 'spelling-set-pref', { pref: 'roundLength', value })}
             >
@@ -72,7 +75,7 @@ function LengthPicker({ prefs, actions }) {
   );
 }
 
-function YearPicker({ prefs, actions }) {
+function YearPicker({ prefs, actions, disabled = false }) {
   const selectedValue = prefs.yearFilter || 'core';
   const selectedIndex = Math.max(0, YEAR_FILTER_OPTIONS.findIndex((option) => option.value === selectedValue));
   return (
@@ -94,6 +97,7 @@ function YearPicker({ prefs, actions }) {
             data-action="spelling-set-pref"
             data-pref="yearFilter"
             value={value}
+            disabled={disabled}
             key={value}
             onClick={(event) => renderAction(actions, event, 'spelling-set-pref', { pref: 'yearFilter', value })}
           >
@@ -159,7 +163,7 @@ function SetupStatGrid({ stats }) {
   );
 }
 
-export function SpellingSetupScene({ learner, service, repositories, subject, prefs, codex, accent, actions }) {
+export function SpellingSetupScene({ learner, service, repositories, subject, prefs, codex, accent, actions, previousHeroBg = '' }) {
   const statsFilter = prefs.mode === 'test' ? 'core' : prefs.yearFilter;
   const stats = service.getStats(learner.id, statsFilter);
   const begin = beginLabel(prefs);
@@ -172,7 +176,7 @@ export function SpellingSetupScene({ learner, service, repositories, subject, pr
   return (
     <div className="setup-grid" style={{ gridColumn: '1/-1' }}>
       <section className="setup-main" style={mergedHeroStyle}>
-        <SpellingHeroBackdrop url={heroBg} />
+        <SpellingHeroBackdrop url={heroBg} previousUrl={previousHeroBg} />
         <div className="setup-content">
           <p className="eyebrow">Round setup</p>
           <h1 className="title">Choose today’s journey.</h1>
@@ -197,11 +201,11 @@ export function SpellingSetupScene({ learner, service, repositories, subject, pr
           <div className="setup-control-stack">
             <div className={tweakClass} {...tweakAria}>
               <span className="tool-label">Round length</span>
-              <LengthPicker prefs={prefs} actions={actions} />
+              <LengthPicker prefs={prefs} actions={actions} disabled={hideTweaks} />
             </div>
             <div className={tweakClass} {...tweakAria}>
               <span className="tool-label">Pool</span>
-              <YearPicker prefs={prefs} actions={actions} />
+              <YearPicker prefs={prefs} actions={actions} disabled={hideTweaks} />
             </div>
             <div className="tweak-row">
               <span className="tool-label">Options</span>

--- a/src/subjects/spelling/components/SpellingSummaryScene.jsx
+++ b/src/subjects/spelling/components/SpellingSummaryScene.jsx
@@ -23,7 +23,7 @@ function SummaryStatGrid({ cards = [] }) {
   );
 }
 
-export function SpellingSummaryScene({ learner, ui, accent, actions }) {
+export function SpellingSummaryScene({ learner, ui, accent, actions, previousHeroBg = '' }) {
   const summary = ui.summary;
   if (!summary) return null;
   const progressTotal = Math.max(1, summary.totalWords || 1);
@@ -35,7 +35,7 @@ export function SpellingSummaryScene({ learner, ui, accent, actions }) {
 
   return (
     <div className="spelling-in-session summary-shell" style={{ gridColumn: '1/-1', ...heroBgStyle(heroBg) }}>
-      <SpellingHeroBackdrop url={heroBg} />
+      <SpellingHeroBackdrop url={heroBg} previousUrl={previousHeroBg} />
       <div className="session summary">
         <header className="session-head">
           <PathProgress done={progressTotal} current={progressTotal} total={progressTotal} />

--- a/src/subjects/spelling/components/SpellingWordBankScene.jsx
+++ b/src/subjects/spelling/components/SpellingWordBankScene.jsx
@@ -286,7 +286,7 @@ function WordBankAggregates({ analytics }) {
   );
 }
 
-export function SpellingWordBankScene({ appState, learner, analytics, accent, actions }) {
+export function SpellingWordBankScene({ appState, learner, analytics, accent, actions, previousHeroBg = '' }) {
   const detailSlug = appState?.transientUi?.spellingWordDetailSlug || '';
   const detailMode = appState?.transientUi?.spellingWordDetailMode || 'explain';
   const drillTyped = appState?.transientUi?.spellingWordBankDrillTyped || '';
@@ -296,7 +296,7 @@ export function SpellingWordBankScene({ appState, learner, analytics, accent, ac
 
   return (
     <div className="spelling-in-session word-bank-shell" style={{ gridColumn: '1/-1', ...heroBgStyle(heroBg) }}>
-      <SpellingHeroBackdrop url={heroBg} />
+      <SpellingHeroBackdrop url={heroBg} previousUrl={previousHeroBg} />
       <div className="word-bank-scene">
         <header className="word-bank-topbar">
           <button

--- a/src/subjects/spelling/components/spelling-view-model.js
+++ b/src/subjects/spelling/components/spelling-view-model.js
@@ -36,10 +36,16 @@ export const WORD_BANK_YEAR_FILTER_IDS = new Set(['all', 'y3-4', 'y5-6', 'extra'
 
 const SCRIBE_DOWNS_BASE = '/assets/regions/the-scribe-downs';
 const spellingHeroUrl = (variant) => `${SCRIBE_DOWNS_BASE}/the-scribe-downs-${variant}.1280.webp`;
+const SPELLING_HERO_REGIONS = Object.freeze({
+  smart: Object.freeze(['a', 'b', 'c']),
+  trouble: Object.freeze(['d']),
+  test: Object.freeze(['e']),
+});
+const SPELLING_HERO_TONES = Object.freeze(['1', '2', '3']);
 export const SPELLING_HERO_BACKGROUNDS = Object.freeze({
-  smart: Object.freeze(['a1', 'b1', 'c1'].map(spellingHeroUrl)),
-  trouble: Object.freeze([spellingHeroUrl('d1')]),
-  test: Object.freeze([spellingHeroUrl('e1')]),
+  smart: Object.freeze(SPELLING_HERO_REGIONS.smart.flatMap((region) => SPELLING_HERO_TONES.map((tone) => spellingHeroUrl(`${region}${tone}`)))),
+  trouble: Object.freeze(SPELLING_HERO_REGIONS.trouble.flatMap((region) => SPELLING_HERO_TONES.map((tone) => spellingHeroUrl(`${region}${tone}`)))),
+  test: Object.freeze(SPELLING_HERO_REGIONS.test.flatMap((region) => SPELLING_HERO_TONES.map((tone) => spellingHeroUrl(`${region}${tone}`)))),
 });
 
 export function accentFor(subject) {
@@ -62,12 +68,18 @@ export function spellingHeroMode(mode) {
   return 'smart';
 }
 
-export function heroBgForMode(mode, learnerId) {
+export function spellingHeroTone(learnerId) {
+  const index = stableHash(`spelling:tone:${learnerId}`) % SPELLING_HERO_TONES.length;
+  return SPELLING_HERO_TONES[index];
+}
+
+export function heroBgForMode(mode, learnerId, options = {}) {
   const heroMode = spellingHeroMode(mode);
-  const backgrounds = SPELLING_HERO_BACKGROUNDS[heroMode] || SPELLING_HERO_BACKGROUNDS.smart;
-  if (!backgrounds.length) return '';
-  const index = stableHash(`spelling:${heroMode}:${learnerId}`) % backgrounds.length;
-  return backgrounds[index];
+  const regions = SPELLING_HERO_REGIONS[heroMode] || SPELLING_HERO_REGIONS.smart;
+  if (!regions.length) return '';
+  const regionIndex = stableHash(`spelling:region:${heroMode}:${learnerId}`) % regions.length;
+  const tone = SPELLING_HERO_TONES.includes(String(options.tone)) ? String(options.tone) : spellingHeroTone(learnerId);
+  return spellingHeroUrl(`${regions[regionIndex]}${tone}`);
 }
 
 export function heroBgForLearner(learnerId, mode = 'smart') {
@@ -79,7 +91,7 @@ export function heroBgForSetup(learnerId, prefs) {
 }
 
 export function heroBgForSession(learnerId, session) {
-  return heroBgForMode(session?.mode || (session?.type === 'test' ? 'test' : 'smart'), learnerId);
+  return heroBgForMode(session?.mode || (session?.type === 'test' ? 'test' : 'smart'), learnerId, { tone: '1' });
 }
 
 export function heroBgStyle(url) {
@@ -89,7 +101,7 @@ export function heroBgStyle(url) {
 export function heroPanDelayStyle() {
   if (typeof performance === 'undefined') return {};
   const elapsed = (performance.now() / 1000) % 144;
-  return { animationDelay: `-${elapsed.toFixed(3)}s` };
+  return { '--hero-pan-delay': `-${elapsed.toFixed(3)}s` };
 }
 
 export function beginLabel(prefs) {

--- a/styles/app.css
+++ b/styles/app.css
@@ -3612,6 +3612,10 @@ textarea:focus-visible {
   .setup-grid { grid-template-columns: 1fr; }
 }
 .setup-main {
+  --setup-label-ink: color-mix(in oklab, var(--ink) 72%, black);
+  --setup-label-bg: color-mix(in oklab, var(--panel) 26%, transparent);
+  --setup-label-border: color-mix(in oklab, white 28%, transparent);
+  --setup-label-shadow: color-mix(in oklab, var(--panel) 82%, transparent);
   padding: 28px 30px;
   border: 1px solid var(--line);
   border-radius: var(--radius-lg);
@@ -3621,6 +3625,12 @@ textarea:focus-visible {
   overflow: hidden;
   min-height: 610px;
   view-transition-name: spelling-practice-card;
+}
+.setup-main.hero-dark {
+  --setup-label-ink: #fff8e9;
+  --setup-label-bg: color-mix(in oklab, black 28%, transparent);
+  --setup-label-border: color-mix(in oklab, white 20%, transparent);
+  --setup-label-shadow: rgba(0, 0, 0, 0.38);
 }
 /* Thin horizontal divider line under the subject eyebrow,
    matching the v1 hero-paper rule. */
@@ -3666,6 +3676,8 @@ textarea:focus-visible {
   cursor: pointer;
   text-align: left;
   color: var(--ink);
+  display: flex;
+  flex-direction: column;
   transition: transform var(--dur) var(--ease-out),
               border-color var(--dur) var(--ease-out),
               box-shadow var(--dur) var(--ease-out),
@@ -3691,6 +3703,14 @@ textarea:focus-visible {
   transform: none;
   box-shadow: none;
 }
+.mode-card .mc-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+  min-height: 50px;
+  margin-bottom: 10px;
+}
 .mode-card .mc-icon {
   width: 50px; height: 50px;
   border-radius: 16px;
@@ -3699,9 +3719,9 @@ textarea:focus-visible {
   backdrop-filter: blur(14px) saturate(1.08);
   -webkit-backdrop-filter: blur(14px) saturate(1.08);
   display: grid; place-items: center;
-  margin-bottom: 10px;
   color: color-mix(in oklab, var(--brand) 72%, var(--ink));
   box-shadow: inset 0 1px 0 color-mix(in oklab, white 24%, transparent);
+  flex: 0 0 auto;
 }
 .mode-card .mc-icon img {
   width: 46px;
@@ -3730,13 +3750,19 @@ textarea:focus-visible {
   color: var(--muted);
   font-size: 0.87rem;
   line-height: 1.4;
+  min-height: calc(0.87rem * 1.4 * 2);
 }
 .mode-card .mc-badge {
-  position: absolute; top: 10px; right: 10px;
   font-size: 10px; font-weight: 800; letter-spacing: 0.08em;
   text-transform: uppercase;
   padding: 3px 8px; border-radius: 999px;
   background: var(--good-soft); color: var(--good-strong);
+  white-space: nowrap;
+  flex: 0 0 auto;
+  margin-top: 2px;
+}
+.mode-card .mc-badge.is-placeholder {
+  visibility: hidden;
 }
 
 .setup-control-stack {
@@ -3751,6 +3777,13 @@ textarea:focus-visible {
   padding: 18px 0 2px;
   border-top: 1px dashed var(--line);
   margin-top: 0;
+  opacity: 1;
+  filter: blur(0);
+  transform: translateY(0);
+  transition: opacity 320ms var(--ease-out),
+              filter 320ms var(--ease-out),
+              transform 320ms var(--ease-out),
+              border-color 320ms var(--ease-out);
 }
 /* Adjacent rows share a single divider so Options reads as a
    continuation of the previous control cluster. */
@@ -3759,20 +3792,31 @@ textarea:focus-visible {
   padding-top: 4px;
   margin-top: 6px;
 }
-/* Placeholder rows reserve layout height in SATs mode but render nothing and
-   are skipped by assistive tech. `visibility:hidden` preserves the full box
-   (height, padding, margin, borders) so the hero cannot resize between modes.
-   The Options row that follows inherits the normal adjacent-sibling
-   continuation style — no divider reclamation needed. */
+/* Placeholder rows reserve layout height in SATs mode while fading controls
+   out of the visual stack. Buttons inside are disabled by React. */
 .tweak-row.is-placeholder {
-  visibility: hidden;
+  opacity: 0;
+  filter: blur(6px);
+  transform: translateY(-8px);
+  pointer-events: none;
+  border-color: transparent;
 }
 .tool-label {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 2px 7px;
+  border: 1px solid var(--setup-label-border);
+  border-radius: 999px;
+  background: var(--setup-label-bg);
+  backdrop-filter: blur(10px) saturate(1.06);
+  -webkit-backdrop-filter: blur(10px) saturate(1.06);
   font-size: 0.78rem;
   font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: var(--muted);
+  color: var(--setup-label-ink);
+  text-shadow: 0 1px 12px var(--setup-label-shadow);
   margin-right: 4px;
 }
 
@@ -3876,10 +3920,11 @@ textarea:focus-visible {
   text-shadow: 0 1px 2px rgba(0,0,0,0.18);
 }
 .length-unit {
-  color: var(--muted);
+  color: var(--setup-label-ink);
   font-weight: 600;
   font-size: 0.82rem;
   margin: 0 8px 0 0;
+  text-shadow: 0 1px 12px var(--setup-label-shadow);
 }
 
 /* Hero-art horizontal pan.
@@ -3887,7 +3932,7 @@ textarea:focus-visible {
    slack under `cover`, so 0% → 100% uses exactly the natural
    room for motion. Skipped on prefers-reduced-motion. */
 .hero-art.pan {
-  animation: hero-pan 72s ease-in-out infinite alternate;
+  animation: hero-pan 72s ease-in-out var(--hero-pan-delay, 0s) infinite alternate;
   will-change: background-position;
 }
 .spelling-hero-backdrop {
@@ -3899,15 +3944,31 @@ textarea:focus-visible {
 }
 .spelling-hero-backdrop .spelling-hero-layer {
   opacity: 0;
-  transition: opacity 720ms var(--ease-in-out), filter 720ms var(--ease-in-out);
+  transform: scale(1.012);
+  transition: opacity 880ms var(--ease-in-out),
+              filter 880ms var(--ease-in-out),
+              transform 880ms var(--ease-in-out);
+}
+.spelling-hero-backdrop .spelling-hero-layer.is-entering {
+  opacity: 1;
+  filter: blur(0) saturate(1.02);
+  transform: scale(1);
+  animation:
+    hero-pan 72s ease-in-out var(--hero-pan-delay, 0s) infinite alternate,
+    spelling-hero-fade-in 880ms var(--ease-in-out) 0s both;
 }
 .spelling-hero-backdrop .spelling-hero-layer.is-active {
   opacity: 1;
-  filter: saturate(1.02);
+  filter: blur(0) saturate(1.02);
+  transform: scale(1);
 }
 .spelling-hero-backdrop .spelling-hero-layer.is-exiting {
   opacity: 0;
-  filter: saturate(0.92);
+  filter: blur(14px) saturate(0.9);
+  transform: scale(1.014);
+  animation:
+    hero-pan 72s ease-in-out var(--hero-pan-delay, 0s) infinite alternate,
+    spelling-hero-fade-out 880ms var(--ease-in-out) 0s both;
 }
 .spelling-in-session > .spelling-hero-backdrop {
   z-index: 0;
@@ -3927,9 +3988,36 @@ textarea:focus-visible {
   from { background-position: 0% 42%; }
   to   { background-position: 100% 42%; }
 }
+@keyframes spelling-hero-fade-in {
+  from {
+    opacity: 0;
+    filter: blur(12px) saturate(0.92);
+    transform: scale(1.018);
+  }
+  to {
+    opacity: 1;
+    filter: blur(0) saturate(1.02);
+    transform: scale(1);
+  }
+}
+@keyframes spelling-hero-fade-out {
+  from {
+    opacity: 1;
+    filter: blur(0) saturate(1.02);
+    transform: scale(1);
+  }
+  to {
+    opacity: 0;
+    filter: blur(14px) saturate(0.9);
+    transform: scale(1.014);
+  }
+}
 @media (prefers-reduced-motion: reduce) {
   .hero-art.pan { animation: none; }
-  .spelling-hero-backdrop .spelling-hero-layer { transition: none; }
+  .spelling-hero-backdrop .spelling-hero-layer {
+    animation: none;
+    transition: none;
+  }
 }
 
 /* Setup-side ("where you stand") card. */

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -285,11 +285,20 @@ test('spelling setup and session hero backgrounds use mode-specific Scribe Downs
     SPELLING_HERO_BACKGROUNDS,
     heroBgForMode,
     heroBgForSession,
+    spellingHeroTone,
   } = await import('../src/subjects/spelling/components/spelling-view-model.js');
 
-  assert.ok(SPELLING_HERO_BACKGROUNDS.smart.includes(heroBgForMode('smart', 'learner-1')));
-  assert.equal(heroBgForMode('trouble', 'learner-1'), '/assets/regions/the-scribe-downs/the-scribe-downs-d1.1280.webp');
+  const learnerId = 'learner-1';
+  const tone = spellingHeroTone(learnerId);
+  assert.ok(SPELLING_HERO_BACKGROUNDS.smart.includes(heroBgForMode('smart', learnerId)));
+  assert.match(heroBgForMode('smart', learnerId), new RegExp(`/the-scribe-downs-[abc]${tone}\\.1280\\.webp$`));
+  assert.equal(heroBgForMode('trouble', learnerId), `/assets/regions/the-scribe-downs/the-scribe-downs-d${tone}.1280.webp`);
+  assert.equal(heroBgForMode('test', learnerId), `/assets/regions/the-scribe-downs/the-scribe-downs-e${tone}.1280.webp`);
+  assert.equal(heroBgForSession(learnerId, { mode: 'trouble' }), '/assets/regions/the-scribe-downs/the-scribe-downs-d1.1280.webp');
   assert.equal(heroBgForSession('learner-1', { mode: 'test' }), '/assets/regions/the-scribe-downs/the-scribe-downs-e1.1280.webp');
+  assert.equal(spellingHeroTone('learner-0'), '2');
+  assert.match(heroBgForMode('smart', 'learner-0'), /the-scribe-downs-[abc]2\.1280\.webp$/);
+  assert.match(heroBgForSession('learner-0', { mode: 'smart' }), /the-scribe-downs-[abc]1\.1280\.webp$/);
 
   for (const urls of Object.values(SPELLING_HERO_BACKGROUNDS)) {
     for (const url of urls) {


### PR DESCRIPTION
## Summary
- Reserve the mode-card badge slot so the NONE YET badge no longer changes card height.
- Fade SATs-only setup rows out while keeping their layout space and disabled state stable.
- Add dusk/night Scribe Downs setup variants per learner, while session backgrounds resolve smoothly back to the day variant.
- Crossfade spelling hero background handoffs with shared pan timing and adaptive setup-label contrast.

## Verification
- `npm test`
- `npm run check`
- `KS2_BROWSER_SMOKE=1 npm run test:migration:browser`
- Local browser visual probe: mode cards stayed 168/168/168, SATs rows faded to 0 opacity, background layers crossfaded with no console errors.