### PR TITLE
Stabilise spelling setup controls

### DIFF
--- a/src/subjects/spelling/components/SpellingHeroBackdrop.jsx
+++ b/src/subjects/spelling/components/SpellingHeroBackdrop.jsx
@@ -7,12 +7,14 @@ export function SpellingHeroBackdrop({ url, previousUrl = '' }) {
   const currentUrl = React.useRef(url || '');
   const initialTransitionId = React.useRef(handoffUrl ? 1 : null);
   const [layers, setLayers] = React.useState(() => (
-    url
-      ? [
-        ...(handoffUrl ? [{ id: 0, url: handoffUrl, phase: 'exiting' }] : []),
-        { id: handoffUrl ? 1 : 0, url, phase: handoffUrl ? 'entering' : 'active' },
-      ]
-      : []
+    (() => {
+      if (!url) return [];
+      const panStyle = heroPanDelayStyle();
+      return [
+        ...(handoffUrl ? [{ id: 0, url: handoffUrl, phase: 'exiting', panStyle }] : []),
+        { id: handoffUrl ? 1 : 0, url, phase: handoffUrl ? 'entering' : 'active', panStyle },
+      ];
+    })()
   ));
 
   React.useEffect(() => {
@@ -41,10 +43,11 @@ export function SpellingHeroBackdrop({ url, previousUrl = '' }) {
     currentUrl.current = url;
     layerId.current += 1;
     const nextId = layerId.current;
+    const panStyle = heroPanDelayStyle();
     setLayers((current) => {
       return [
         ...current.slice(-2).map((layer) => ({ ...layer, phase: 'exiting' })),
-        { id: nextId, url, phase: 'entering' },
+        { id: nextId, url, phase: 'entering', panStyle },
       ];
     });
 
@@ -61,14 +64,12 @@ export function SpellingHeroBackdrop({ url, previousUrl = '' }) {
 
   if (!layers.length) return null;
 
-  const panStyle = heroPanDelayStyle();
-
   return (
     <div className="spelling-hero-backdrop" aria-hidden="true">
       {layers.map((layer) => (
         <div
           className={`hero-art pan spelling-hero-layer is-${layer.phase}`}
-          style={{ ...heroBgStyle(layer.url), ...panStyle }}
+          style={{ ...heroBgStyle(layer.url), ...(layer.panStyle || {}) }}
           key={layer.id}
         />
       ))}

--- a/src/subjects/spelling/components/SpellingSetupScene.jsx
+++ b/src/subjects/spelling/components/SpellingSetupScene.jsx
@@ -189,7 +189,7 @@ export function SpellingSetupScene({ learner, service, repositories, subject, pr
                     mode={mode}
                     selected={prefs.mode === mode.id}
                     disabled
-                    description="No trouble words yet — come back after a round."
+                    description="No trouble words yet. Try a round first."
                     badge="NONE YET"
                     actions={actions}
                     key={mode.id}

--- a/src/subjects/spelling/components/spelling-view-model.js
+++ b/src/subjects/spelling/components/spelling-view-model.js
@@ -4,6 +4,7 @@ import { formatElapsedMinutes } from '../../../platform/core/utils.js';
 
 export const SPELLING_ACCENT = '#3E6FA8';
 export const DAY_MS = 24 * 60 * 60 * 1000;
+const HERO_PAN_SECONDS = 96;
 export const MODE_CARDS = Object.freeze([
   {
     id: 'smart',
@@ -100,7 +101,7 @@ export function heroBgStyle(url) {
 
 export function heroPanDelayStyle() {
   if (typeof performance === 'undefined') return {};
-  const elapsed = (performance.now() / 1000) % 144;
+  const elapsed = (performance.now() / 1000) % (HERO_PAN_SECONDS * 2);
   return { '--hero-pan-delay': `-${elapsed.toFixed(3)}s` };
 }
 

--- a/styles/app.css
+++ b/styles/app.css
@@ -3613,9 +3613,11 @@ textarea:focus-visible {
 }
 .setup-main {
   --setup-label-ink: color-mix(in oklab, var(--ink) 72%, black);
-  --setup-label-bg: color-mix(in oklab, var(--panel) 26%, transparent);
-  --setup-label-border: color-mix(in oklab, white 28%, transparent);
-  --setup-label-shadow: color-mix(in oklab, var(--panel) 82%, transparent);
+  --setup-label-shadow: color-mix(in oklab, var(--panel) 72%, transparent);
+  --mode-card-title: var(--ink);
+  --mode-card-copy: color-mix(in oklab, var(--ink) 68%, white);
+  --mode-card-selected-title: var(--brand-ink);
+  --mode-card-selected-copy: color-mix(in oklab, var(--ink) 78%, white);
   padding: 28px 30px;
   border: 1px solid var(--line);
   border-radius: var(--radius-lg);
@@ -3628,9 +3630,11 @@ textarea:focus-visible {
 }
 .setup-main.hero-dark {
   --setup-label-ink: #fff8e9;
-  --setup-label-bg: color-mix(in oklab, black 28%, transparent);
-  --setup-label-border: color-mix(in oklab, white 20%, transparent);
-  --setup-label-shadow: rgba(0, 0, 0, 0.38);
+  --setup-label-shadow: rgba(0, 0, 0, 0.62);
+  --mode-card-title: #fff9ec;
+  --mode-card-copy: rgba(255, 248, 233, 0.84);
+  --mode-card-selected-title: #fffdf6;
+  --mode-card-selected-copy: rgba(255, 248, 233, 0.9);
 }
 /* Thin horizontal divider line under the subject eyebrow,
    matching the v1 hero-paper rule. */
@@ -3658,6 +3662,7 @@ textarea:focus-visible {
 .mode-row {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-auto-rows: minmax(184px, auto);
   gap: 12px;
   margin: 20px 0 0;
 }
@@ -3672,10 +3677,10 @@ textarea:focus-visible {
   backdrop-filter: blur(18px) saturate(1.12);
   -webkit-backdrop-filter: blur(18px) saturate(1.12);
   padding: 18px 16px 18px;
-  min-height: 168px;
+  min-height: 184px;
   cursor: pointer;
   text-align: left;
-  color: var(--ink);
+  color: var(--mode-card-title);
   display: flex;
   flex-direction: column;
   transition: transform var(--dur) var(--ease-out),
@@ -3696,8 +3701,8 @@ textarea:focus-visible {
 }
 .mode-card.is-disabled {
   cursor: not-allowed;
-  filter: saturate(0.65);
-  opacity: 0.78;
+  filter: saturate(0.78);
+  opacity: 0.9;
 }
 .mode-card.is-disabled:hover {
   transform: none;
@@ -3708,7 +3713,9 @@ textarea:focus-visible {
   align-items: flex-start;
   justify-content: space-between;
   gap: 10px;
+  height: 50px;
   min-height: 50px;
+  flex: 0 0 50px;
   margin-bottom: 10px;
 }
 .mode-card .mc-icon {
@@ -3741,16 +3748,24 @@ textarea:focus-visible {
   font-size: 1.08rem;
   font-weight: 500;
   letter-spacing: -0.005em;
-  color: var(--ink);
+  color: var(--mode-card-title);
+  text-shadow: 0 1px 12px rgba(255, 255, 255, 0.2);
 }
-.mode-card.selected h4 { color: var(--brand-ink); font-weight: 600; }
-.mode-card.selected p  { color: var(--ink-2); }
+.setup-main.hero-dark .mode-card h4 {
+  text-shadow: 0 1px 18px rgba(0, 0, 0, 0.52);
+}
+.mode-card.selected h4 { color: var(--mode-card-selected-title); font-weight: 600; }
+.mode-card.selected p  { color: var(--mode-card-selected-copy); }
 .mode-card p {
   margin: 4px 0 0;
-  color: var(--muted);
+  color: var(--mode-card-copy);
   font-size: 0.87rem;
   line-height: 1.4;
-  min-height: calc(0.87rem * 1.4 * 2);
+  min-height: calc(0.87rem * 1.4 * 3);
+  text-shadow: 0 1px 12px rgba(255, 255, 255, 0.18);
+}
+.setup-main.hero-dark .mode-card p {
+  text-shadow: 0 1px 16px rgba(0, 0, 0, 0.56);
 }
 .mode-card .mc-badge {
   font-size: 10px; font-weight: 800; letter-spacing: 0.08em;
@@ -3802,15 +3817,8 @@ textarea:focus-visible {
   border-color: transparent;
 }
 .tool-label {
-  display: inline-flex;
-  align-items: center;
-  min-height: 24px;
-  padding: 2px 7px;
-  border: 1px solid var(--setup-label-border);
-  border-radius: 999px;
-  background: var(--setup-label-bg);
-  backdrop-filter: blur(10px) saturate(1.06);
-  -webkit-backdrop-filter: blur(10px) saturate(1.06);
+  display: inline-block;
+  min-width: 102px;
   font-size: 0.78rem;
   font-weight: 700;
   letter-spacing: 0.04em;
@@ -3932,7 +3940,7 @@ textarea:focus-visible {
    slack under `cover`, so 0% → 100% uses exactly the natural
    room for motion. Skipped on prefers-reduced-motion. */
 .hero-art.pan {
-  animation: hero-pan 72s ease-in-out var(--hero-pan-delay, 0s) infinite alternate;
+  animation: hero-pan 96s ease-in-out var(--hero-pan-delay, 0s) infinite alternate;
   will-change: background-position;
 }
 .spelling-hero-backdrop {
@@ -3954,7 +3962,7 @@ textarea:focus-visible {
   filter: blur(0) saturate(1.02);
   transform: scale(1);
   animation:
-    hero-pan 72s ease-in-out var(--hero-pan-delay, 0s) infinite alternate,
+    hero-pan 96s ease-in-out var(--hero-pan-delay, 0s) infinite alternate,
     spelling-hero-fade-in 880ms var(--ease-in-out) 0s both;
 }
 .spelling-hero-backdrop .spelling-hero-layer.is-active {
@@ -3967,7 +3975,7 @@ textarea:focus-visible {
   filter: blur(14px) saturate(0.9);
   transform: scale(1.014);
   animation:
-    hero-pan 72s ease-in-out var(--hero-pan-delay, 0s) infinite alternate,
+    hero-pan 96s ease-in-out var(--hero-pan-delay, 0s) infinite alternate,
     spelling-hero-fade-out 880ms var(--ease-in-out) 0s both;
 }
 .spelling-in-session > .spelling-hero-backdrop {


### PR DESCRIPTION
## Summary
- stabilise spelling setup mode card height and the empty trouble badge slot
- keep hero pan timing stable across ordinary option updates and slow the pan slightly
- remove label pill backgrounds while preserving adaptive light/dark text variables

## Verification
- npm test
- npm run check