### PR TITLE
Adapt spelling setup contrast to hero art

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1102,22 +1102,22 @@ function afterReactRender(appState) {
     restoreModalTrigger();
   }
 
-  /* Hero-dark luminance flip — the spelling session + setup surfaces paint
-     a `--hero-bg` image on their outer wrapper. When the backdrop is darker
+  /* Hero-dark luminance flip — the spelling session surface paints
+     a `--hero-bg` image on its outer wrapper. When the backdrop is darker
      than mid-grey, the shell needs a `hero-dark` class so ink tokens flip
      to the light palette (WCAG contrast on dusk / night regions). The
      probe is fire-and-forget: we kick it after layout so the async decode
      runs off the critical path, and only apply the class when the element
-     is still connected (another render may have replaced it). */
+     is still connected (another render may have replaced it). The setup
+     surface owns a more granular React-scoped contrast probe because its
+     text sits over several different parts of the panning artwork. */
   queueMicrotask(() => applyHeroDarkProbes());
 
   syncAudioPlayingClass();
 }
 
 function applyHeroDarkProbes() {
-  const heroes = root.querySelectorAll(
-    '.spelling-in-session[style*="--hero-bg"], .setup-main[style*="--hero-bg"]',
-  );
+  const heroes = root.querySelectorAll('.spelling-in-session[style*="--hero-bg"]');
   heroes.forEach((element) => {
     const url = extractHeroBgUrl(element.getAttribute('style') || '');
     if (!url) return;

--- a/src/platform/ui/luminance.js
+++ b/src/platform/ui/luminance.js
@@ -4,8 +4,10 @@
  * whether the art itself is dark (so ink tokens can flip to light). The
  * React owns the production shell, while the controller still centralises
  * post-render side effects such as focus restoration and audio glow sync.
- * This helper stays framework-neutral so that side-effect layer can kick
- * off a cheap `queueMicrotask` probe after React commits.
+ * This helper stays framework-neutral so the side-effect layer can kick
+ * off a cheap `queueMicrotask` probe after React commits, and React
+ * surfaces can run more granular text-region probes where a single
+ * average is too coarse.
  *
  * Contract — `probeRelLuminance(url)`:
  *   - Resolves to a number in `[0, 1]` representing the WCAG relative
@@ -18,74 +20,309 @@
  *     image 404s, or when `document` is unavailable (SSR / tests).
  *   - Never throws; callers treat it as fire-and-forget.
  *
- * We downsample to 8×8 on purpose — the call runs on every render while
- * the learner is navigating the spelling session, so a smaller grid (vs.
- * the design reference's 32×32) keeps the decode cheap without losing
- * the coarse dark/light signal we care about. */
+ * We downsample to 8×8 on purpose. A smaller grid keeps repeated cached
+ * probes cheap without losing the dark/light signal we care about. */
 
 const LUMINANCE_FALLBACK = 0.7;
 const SAMPLE_SIZE = 8;
-const cache = new Map();
+const TEXT_TONE_THRESHOLD = 0.24;
+const luminanceCache = new Map();
+const imageCache = new Map();
 
 export function probeRelLuminance(url) {
   if (!url) return Promise.resolve(LUMINANCE_FALLBACK);
-  if (cache.has(url)) return Promise.resolve(cache.get(url));
+  if (luminanceCache.has(url)) return Promise.resolve(luminanceCache.get(url));
+
+  const pending = loadProbeImage(url).then((img) => {
+    if (!img) {
+      luminanceCache.set(url, LUMINANCE_FALLBACK);
+      return LUMINANCE_FALLBACK;
+    }
+
+    try {
+      const canvas = document.createElement('canvas');
+      canvas.width = SAMPLE_SIZE;
+      canvas.height = SAMPLE_SIZE;
+      const ctx = canvas.getContext('2d', { willReadFrequently: true });
+      if (!ctx) {
+        luminanceCache.set(url, LUMINANCE_FALLBACK);
+        return LUMINANCE_FALLBACK;
+      }
+      ctx.drawImage(img, 0, 0, SAMPLE_SIZE, SAMPLE_SIZE);
+      const luminance = averageImageDataLuminance(ctx.getImageData(0, 0, SAMPLE_SIZE, SAMPLE_SIZE).data);
+      luminanceCache.set(url, luminance);
+      return luminance;
+    } catch {
+      /* Tainted canvas / security error — treat as light so we stay on
+         the safe-default dark ink. */
+      luminanceCache.set(url, LUMINANCE_FALLBACK);
+      return LUMINANCE_FALLBACK;
+    }
+  });
+
+  luminanceCache.set(url, pending);
+  return pending;
+}
+
+export function preloadImages(urls) {
+  if (!Array.isArray(urls)) return;
+  urls.forEach((url) => {
+    if (url) void loadProbeImage(url);
+  });
+}
+
+export async function probeHeroTextTones(url, container, probes) {
+  if (!container || !Array.isArray(probes) || !probes.length) return [];
+  const fallback = fallbackToneResults(container, probes);
+  if (!url || typeof document === 'undefined' || typeof getComputedStyle === 'undefined') {
+    return fallback;
+  }
+
+  const img = await loadProbeImage(url);
+  if (!img) return fallback;
+
+  try {
+    const containerRect = container.getBoundingClientRect();
+    if (!containerRect.width || !containerRect.height) return fallback;
+
+    const layer = resolveHeroLayer(container, url) || container;
+    const layerStyle = getComputedStyle(layer);
+    const geometry = backgroundGeometry(img, containerRect, layerStyle);
+    if (!geometry) return fallback;
+
+    const canvas = document.createElement('canvas');
+    canvas.width = SAMPLE_SIZE;
+    canvas.height = SAMPLE_SIZE;
+    const ctx = canvas.getContext('2d', { willReadFrequently: true });
+    if (!ctx) return fallback;
+
+    const panelLuminance = cssVarLuminance(container, '--panel') ?? LUMINANCE_FALLBACK;
+    return probes.map((probe, index) => {
+      const element = probe?.element;
+      const rect = element?.getBoundingClientRect?.();
+      const sampleRect = intersectRects(rect, containerRect);
+      if (!sampleRect) return fallback[index];
+
+      const rawLuminance = sampleImageRectLuminance(ctx, img, geometry, sampleRect, containerRect);
+      const centreX = ((sampleRect.left + (sampleRect.width / 2)) - containerRect.left) / containerRect.width;
+      const centreY = ((sampleRect.top + (sampleRect.height / 2)) - containerRect.top) / containerRect.height;
+      const heroLuminance = applyHeroOverlayLuminance(rawLuminance, centreX, centreY, panelLuminance);
+      const glassAlpha = clamp01(Number(probe.glassAlpha) || 0);
+      const backgroundLuminance = blendLuminance(panelLuminance, heroLuminance, glassAlpha);
+      return {
+        key: probe.key,
+        luminance: backgroundLuminance,
+        tone: textToneForLuminance(backgroundLuminance),
+      };
+    });
+  } catch {
+    return fallback;
+  }
+}
+
+export function textToneForLuminance(luminance) {
+  return luminance >= TEXT_TONE_THRESHOLD ? 'dark' : 'light';
+}
+
+function loadProbeImage(url) {
+  if (!url) return Promise.resolve(null);
+  if (imageCache.has(url)) return imageCache.get(url);
 
   if (typeof document === 'undefined' || typeof Image === 'undefined') {
-    cache.set(url, LUMINANCE_FALLBACK);
-    return Promise.resolve(LUMINANCE_FALLBACK);
+    imageCache.set(url, Promise.resolve(null));
+    return imageCache.get(url);
   }
 
   const pending = new Promise((resolve) => {
     const img = new Image();
     img.crossOrigin = 'anonymous';
-
-    img.onload = () => {
-      try {
-        const canvas = document.createElement('canvas');
-        canvas.width = SAMPLE_SIZE;
-        canvas.height = SAMPLE_SIZE;
-        const ctx = canvas.getContext('2d');
-        if (!ctx) {
-          cache.set(url, LUMINANCE_FALLBACK);
-          resolve(LUMINANCE_FALLBACK);
-          return;
-        }
-        ctx.drawImage(img, 0, 0, SAMPLE_SIZE, SAMPLE_SIZE);
-        const { data } = ctx.getImageData(0, 0, SAMPLE_SIZE, SAMPLE_SIZE);
-        let sum = 0;
-        const pixelCount = SAMPLE_SIZE * SAMPLE_SIZE;
-        for (let i = 0; i < data.length; i += 4) {
-          const r = srgbToLinear(data[i] / 255);
-          const g = srgbToLinear(data[i + 1] / 255);
-          const b = srgbToLinear(data[i + 2] / 255);
-          sum += 0.2126 * r + 0.7152 * g + 0.0722 * b;
-        }
-        const luminance = sum / pixelCount;
-        cache.set(url, luminance);
-        resolve(luminance);
-      } catch {
-        /* Tainted canvas / security error — treat as light so we stay on
-           the safe-default dark ink. */
-        cache.set(url, LUMINANCE_FALLBACK);
-        resolve(LUMINANCE_FALLBACK);
-      }
-    };
-
-    img.onerror = () => {
-      cache.set(url, LUMINANCE_FALLBACK);
-      resolve(LUMINANCE_FALLBACK);
-    };
-
+    img.decoding = 'async';
+    img.onload = () => resolve(img);
+    img.onerror = () => resolve(null);
     try {
       img.src = url;
     } catch {
-      cache.set(url, LUMINANCE_FALLBACK);
-      resolve(LUMINANCE_FALLBACK);
+      resolve(null);
     }
   });
-
+  imageCache.set(url, pending);
   return pending;
+}
+
+function fallbackToneResults(container, probes) {
+  const baseLuminance = container
+    ? cssVarLuminance(container, '--panel') ?? LUMINANCE_FALLBACK
+    : LUMINANCE_FALLBACK;
+  const tone = textToneForLuminance(baseLuminance);
+  return probes.map((probe) => ({ key: probe?.key, luminance: baseLuminance, tone }));
+}
+
+function resolveHeroLayer(container, url) {
+  const layers = Array.from(container.querySelectorAll?.('.spelling-hero-layer') || []);
+  if (!layers.length) return null;
+  const reversed = layers.slice().reverse();
+  return reversed.find((layer) => (
+    layer.style?.getPropertyValue('--hero-bg')?.includes(url)
+  )) || reversed[0];
+}
+
+function backgroundGeometry(img, containerRect, style) {
+  const width = img.naturalWidth || img.width;
+  const height = img.naturalHeight || img.height;
+  if (!width || !height) return null;
+  const scale = Math.max(containerRect.width / width, containerRect.height / height);
+  const renderedWidth = width * scale;
+  const renderedHeight = height * scale;
+  const position = backgroundPosition(style);
+  return {
+    scale,
+    offsetX: resolvePosition(position.x, containerRect.width, renderedWidth),
+    offsetY: resolvePosition(position.y, containerRect.height, renderedHeight),
+    width,
+    height,
+  };
+}
+
+function backgroundPosition(style) {
+  const x = style.backgroundPositionX || '';
+  const y = style.backgroundPositionY || '';
+  if (x || y) return { x: x || '50%', y: y || '50%' };
+  const parts = String(style.backgroundPosition || '50% 50%').trim().split(/\s+/);
+  return { x: parts[0] || '50%', y: parts[1] || '50%' };
+}
+
+function resolvePosition(value, containerSize, renderedSize) {
+  const text = String(value || '50%').trim().toLowerCase();
+  if (text === 'left' || text === 'top') return 0;
+  if (text === 'center') return (containerSize - renderedSize) * 0.5;
+  if (text === 'right' || text === 'bottom') return containerSize - renderedSize;
+  if (text.endsWith('%')) return (containerSize - renderedSize) * (Number.parseFloat(text) / 100);
+  if (text.endsWith('px')) return Number.parseFloat(text) || 0;
+  return (containerSize - renderedSize) * 0.5;
+}
+
+function intersectRects(rect, bounds) {
+  if (!rect || !bounds) return null;
+  const left = Math.max(rect.left, bounds.left);
+  const top = Math.max(rect.top, bounds.top);
+  const right = Math.min(rect.right, bounds.right);
+  const bottom = Math.min(rect.bottom, bounds.bottom);
+  if (right <= left || bottom <= top) return null;
+  return { left, top, right, bottom, width: right - left, height: bottom - top };
+}
+
+function sampleImageRectLuminance(ctx, img, geometry, rect, containerRect) {
+  const sourceLeft = ((rect.left - containerRect.left) - geometry.offsetX) / geometry.scale;
+  const sourceTop = ((rect.top - containerRect.top) - geometry.offsetY) / geometry.scale;
+  const sourceWidth = rect.width / geometry.scale;
+  const sourceHeight = rect.height / geometry.scale;
+  const sx = clamp(sourceLeft, 0, geometry.width - 1);
+  const sy = clamp(sourceTop, 0, geometry.height - 1);
+  const sw = Math.max(1, Math.min(sourceWidth, geometry.width - sx));
+  const sh = Math.max(1, Math.min(sourceHeight, geometry.height - sy));
+  try {
+    ctx.clearRect(0, 0, SAMPLE_SIZE, SAMPLE_SIZE);
+    ctx.drawImage(img, sx, sy, sw, sh, 0, 0, SAMPLE_SIZE, SAMPLE_SIZE);
+    return averageImageDataLuminance(ctx.getImageData(0, 0, SAMPLE_SIZE, SAMPLE_SIZE).data);
+  } catch {
+    return LUMINANCE_FALLBACK;
+  }
+}
+
+function applyHeroOverlayLuminance(rawLuminance, x, y, panelLuminance) {
+  const verticalAlpha = y < 0.38
+    ? interpolate(0, 0.38, 0.2, 0, y)
+    : interpolate(0.72, 1, 0, 0.26, y);
+  const horizontalAlpha = interpolateStops([
+    [0, 0.88],
+    [0.32, 0.66],
+    [0.62, 0.28],
+    [1, 0.1],
+  ], x);
+  const vertical = blendLuminance(panelLuminance, rawLuminance, clamp01(verticalAlpha));
+  return blendLuminance(panelLuminance, vertical, clamp01(horizontalAlpha));
+}
+
+function blendLuminance(foreground, background, alpha) {
+  return (foreground * alpha) + (background * (1 - alpha));
+}
+
+function interpolateStops(stops, value) {
+  const point = clamp01(value);
+  for (let i = 1; i < stops.length; i += 1) {
+    const [prevAt, prevValue] = stops[i - 1];
+    const [nextAt, nextValue] = stops[i];
+    if (point <= nextAt) return interpolate(prevAt, nextAt, prevValue, nextValue, point);
+  }
+  return stops[stops.length - 1][1];
+}
+
+function interpolate(fromAt, toAt, fromValue, toValue, at) {
+  if (at <= fromAt) return fromValue;
+  if (at >= toAt) return toValue;
+  const progress = (at - fromAt) / (toAt - fromAt);
+  return fromValue + ((toValue - fromValue) * progress);
+}
+
+function cssVarLuminance(element, property) {
+  if (!element || typeof getComputedStyle === 'undefined') return null;
+  return colorLuminance(getComputedStyle(element).getPropertyValue(property));
+}
+
+function colorLuminance(value) {
+  const rgb = parseCssColor(value);
+  if (!rgb) return null;
+  const r = srgbToLinear(rgb.r / 255);
+  const g = srgbToLinear(rgb.g / 255);
+  const b = srgbToLinear(rgb.b / 255);
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function parseCssColor(value) {
+  const text = String(value || '').trim();
+  const hex = text.match(/^#([0-9a-f]{3}|[0-9a-f]{6})$/i);
+  if (hex) {
+    const digits = hex[1].length === 3
+      ? hex[1].split('').map((char) => `${char}${char}`).join('')
+      : hex[1];
+    return {
+      r: Number.parseInt(digits.slice(0, 2), 16),
+      g: Number.parseInt(digits.slice(2, 4), 16),
+      b: Number.parseInt(digits.slice(4, 6), 16),
+    };
+  }
+
+  const rgb = text.match(/^rgba?\((.+)\)$/i);
+  if (!rgb) return null;
+  const parts = rgb[1]
+    .replace(/\//g, ' ')
+    .replace(/,/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .slice(0, 3)
+    .map((part) => Number.parseFloat(part));
+  if (parts.length < 3 || parts.some((part) => !Number.isFinite(part))) return null;
+  return { r: parts[0], g: parts[1], b: parts[2] };
+}
+
+function averageImageDataLuminance(data) {
+  let sum = 0;
+  const pixelCount = Math.max(1, data.length / 4);
+  for (let i = 0; i < data.length; i += 4) {
+    const r = srgbToLinear(data[i] / 255);
+    const g = srgbToLinear(data[i + 1] / 255);
+    const b = srgbToLinear(data[i + 2] / 255);
+    sum += 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  }
+  return sum / pixelCount;
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function clamp01(value) {
+  return clamp(Number.isFinite(value) ? value : 0, 0, 1);
 }
 
 function srgbToLinear(channel) {

--- a/src/subjects/spelling/components/SpellingPracticeSurface.jsx
+++ b/src/subjects/spelling/components/SpellingPracticeSurface.jsx
@@ -3,9 +3,11 @@ import { SpellingSetupScene } from './SpellingSetupScene.jsx';
 import { SpellingSessionScene } from './SpellingSessionScene.jsx';
 import { SpellingSummaryScene } from './SpellingSummaryScene.jsx';
 import { SpellingWordBankScene } from './SpellingWordBankScene.jsx';
+import { preloadImages } from '../../../platform/ui/luminance.js';
 import {
   buildSpellingContext,
   heroBgForLearner,
+  heroBgPreloadUrls,
   heroBgForSession,
   heroBgForSetup,
 } from './spelling-view-model.js';
@@ -31,6 +33,8 @@ export function SpellingPracticeSurface(props) {
   } = props;
   const spelling = buildSpellingContext({ appState, service, repositories, subject });
   const heroBg = heroBgForPhase(spelling);
+  const preloadedHeroUrls = heroBgPreloadUrls(spelling.learner?.id, spelling.prefs);
+  const preloadKey = preloadedHeroUrls.join('|');
   const previousHeroBgRef = React.useRef('');
   const previousHeroBg = previousHeroBgRef.current && previousHeroBgRef.current !== heroBg
     ? previousHeroBgRef.current
@@ -38,6 +42,9 @@ export function SpellingPracticeSurface(props) {
   React.useEffect(() => {
     if (heroBg) previousHeroBgRef.current = heroBg;
   }, [heroBg]);
+  React.useEffect(() => {
+    preloadImages(preloadedHeroUrls);
+  }, [preloadKey]);
   React.useEffect(() => {
     if (typeof window === 'undefined') return undefined;
     const frame = window.requestAnimationFrame(() => {

--- a/src/subjects/spelling/components/SpellingSetupScene.jsx
+++ b/src/subjects/spelling/components/SpellingSetupScene.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { SpellingHeroBackdrop } from './SpellingHeroBackdrop.jsx';
 import { ArrowRightIcon, CheckIcon } from './spelling-icons.jsx';
+import { useSetupHeroContrast } from './useSetupHeroContrast.js';
 import {
   MODE_CARDS,
   ROUND_LENGTH_OPTIONS,
@@ -12,7 +13,7 @@ import {
   renderAction,
 } from './spelling-view-model.js';
 
-function ModeCard({ mode, selected, disabled = false, description, badge, actions }) {
+function ModeCard({ mode, selected, disabled = false, description, badge, actions, textTone = 'dark' }) {
   const desc = description != null ? description : mode.desc;
   const classes = ['mode-card'];
   if (selected && !disabled) classes.push('selected');
@@ -21,6 +22,7 @@ function ModeCard({ mode, selected, disabled = false, description, badge, action
     <button
       type="button"
       className={classes.join(' ')}
+      data-text-tone={textTone}
       data-action="spelling-set-mode"
       value={mode.id}
       aria-pressed={selected && !disabled ? 'true' : 'false'}
@@ -172,17 +174,26 @@ export function SpellingSetupScene({ learner, service, repositories, subject, pr
   const tweakClass = `tweak-row${hideTweaks ? ' is-placeholder' : ''}`;
   const tweakAria = hideTweaks ? { 'aria-hidden': 'true' } : {};
   const mergedHeroStyle = { ...heroBgStyle(heroBg) };
+  const heroContrast = useSetupHeroContrast(heroBg, prefs.mode);
+  const setupClasses = ['setup-main'];
+  if (heroContrast.contrast.shell === 'light') setupClasses.push('hero-dark');
 
   return (
     <div className="setup-grid" style={{ gridColumn: '1/-1' }}>
-      <section className="setup-main" style={mergedHeroStyle}>
+      <section
+        className={setupClasses.join(' ')}
+        data-react-hero-contrast="true"
+        data-controls-tone={heroContrast.contrast.controls}
+        ref={heroContrast.ref}
+        style={mergedHeroStyle}
+      >
         <SpellingHeroBackdrop url={heroBg} previousUrl={previousHeroBg} />
         <div className="setup-content">
           <p className="eyebrow">Round setup</p>
           <h1 className="title">Choose today’s journey.</h1>
           <p className="lede">Smart Review mixes what’s due, what wobbled last time, and one or two new words. You can go straight to trouble drills or SATs rehearsal if you’d rather.</p>
           <div className="mode-row">
-            {MODE_CARDS.map((mode) => (
+            {MODE_CARDS.map((mode, index) => (
               mode.id === 'trouble' && !stats.trouble
                 ? (
                   <ModeCard
@@ -192,10 +203,19 @@ export function SpellingSetupScene({ learner, service, repositories, subject, pr
                     description="No trouble words yet. Try a round first."
                     badge="NONE YET"
                     actions={actions}
+                    textTone={heroContrast.contrast.cards[index] || heroContrast.contrast.shell}
                     key={mode.id}
                   />
                 )
-                : <ModeCard mode={mode} selected={prefs.mode === mode.id} actions={actions} key={mode.id} />
+                : (
+                  <ModeCard
+                    mode={mode}
+                    selected={prefs.mode === mode.id}
+                    actions={actions}
+                    textTone={heroContrast.contrast.cards[index] || heroContrast.contrast.shell}
+                    key={mode.id}
+                  />
+                )
             ))}
           </div>
           <div className="setup-control-stack">

--- a/src/subjects/spelling/components/spelling-view-model.js
+++ b/src/subjects/spelling/components/spelling-view-model.js
@@ -95,6 +95,14 @@ export function heroBgForSession(learnerId, session) {
   return heroBgForMode(session?.mode || (session?.type === 'test' ? 'test' : 'smart'), learnerId, { tone: '1' });
 }
 
+export function heroBgPreloadUrls(learnerId, prefs = {}) {
+  if (!learnerId) return [];
+  const modes = ['smart', 'trouble', 'test'];
+  const setupUrls = modes.map((mode) => heroBgForMode(mode, learnerId));
+  const sessionUrl = heroBgForMode(prefs?.mode || 'smart', learnerId, { tone: '1' });
+  return [...new Set([...setupUrls, sessionUrl].filter(Boolean))];
+}
+
 export function heroBgStyle(url) {
   return url ? { '--hero-bg': `url('${url}')` } : {};
 }

--- a/src/subjects/spelling/components/useSetupHeroContrast.js
+++ b/src/subjects/spelling/components/useSetupHeroContrast.js
@@ -1,0 +1,129 @@
+import React from 'react';
+import { probeHeroTextTones } from '../../../platform/ui/luminance.js';
+
+const DEFAULT_CONTRAST = Object.freeze({
+  shell: 'dark',
+  controls: 'dark',
+  cards: Object.freeze(['dark', 'dark', 'dark']),
+});
+
+const CARD_GLASS_ALPHA = 0.28;
+const SELECTED_CARD_GLASS_ALPHA = 0.42;
+const CONTROL_REFRESH_MS = 6000;
+
+export function useSetupHeroContrast(heroBg, mode) {
+  const ref = React.useRef(null);
+  const [contrast, setContrast] = React.useState(DEFAULT_CONTRAST);
+
+  React.useEffect(() => {
+    const shell = ref.current;
+    if (!shell || !heroBg || typeof window === 'undefined') {
+      setContrast(DEFAULT_CONTRAST);
+      return undefined;
+    }
+
+    let cancelled = false;
+    let frame = 0;
+    let observer = null;
+
+    const scheduleProbe = () => {
+      if (cancelled || frame) return;
+      frame = window.requestAnimationFrame(() => {
+        frame = 0;
+        runProbe(shell, heroBg).then((nextContrast) => {
+          if (cancelled) return;
+          setContrast((current) => (
+            sameContrast(current, nextContrast) ? current : nextContrast
+          ));
+        });
+      });
+    };
+
+    scheduleProbe();
+    const interval = window.setInterval(scheduleProbe, CONTROL_REFRESH_MS);
+    if (typeof ResizeObserver !== 'undefined') {
+      observer = new ResizeObserver(scheduleProbe);
+      observer.observe(shell);
+      shell.querySelectorAll('.mode-card, .setup-control-stack, .title, .lede').forEach((element) => {
+        observer.observe(element);
+      });
+    }
+
+    return () => {
+      cancelled = true;
+      if (frame) window.cancelAnimationFrame(frame);
+      window.clearInterval(interval);
+      observer?.disconnect();
+    };
+  }, [heroBg, mode]);
+
+  return { ref, contrast };
+}
+
+async function runProbe(shell, heroBg) {
+  const cards = Array.from(shell.querySelectorAll('.mode-card'));
+  const cardProbes = cards.map((card, index) => ({
+    key: `card:${index}`,
+    element: cardTextRegion(card) || card,
+    glassAlpha: card.classList.contains('selected') ? SELECTED_CARD_GLASS_ALPHA : CARD_GLASS_ALPHA,
+  }));
+  const controlElements = Array.from(shell.querySelectorAll('.tool-label, .length-unit'))
+    .filter((element) => visibleForProbe(element));
+  const probes = [
+    { key: 'shell', element: shell.querySelector('.lede') || shell.querySelector('.title') || shell, glassAlpha: 0 },
+    ...cardProbes,
+    ...controlElements.map((element, index) => ({ key: `control:${index}`, element, glassAlpha: 0 })),
+  ];
+
+  const results = await probeHeroTextTones(heroBg, shell, probes);
+  const byKey = new Map(results.map((result) => [result.key, result]));
+  const controlResults = results.filter((result) => String(result.key || '').startsWith('control:'));
+  return {
+    shell: byKey.get('shell')?.tone || DEFAULT_CONTRAST.shell,
+    cards: cards.map((_, index) => byKey.get(`card:${index}`)?.tone || DEFAULT_CONTRAST.cards[index] || DEFAULT_CONTRAST.shell),
+    controls: combinedTone(controlResults) || DEFAULT_CONTRAST.controls,
+  };
+}
+
+function cardTextRegion(card) {
+  const title = card.querySelector('h4');
+  const copy = card.querySelector('p');
+  if (!title && !copy) return null;
+  return {
+    getBoundingClientRect() {
+      const rects = [title, copy]
+        .filter(Boolean)
+        .map((element) => element.getBoundingClientRect())
+        .filter((rect) => rect.width && rect.height);
+      if (!rects.length) return card.getBoundingClientRect();
+      const left = Math.min(...rects.map((rect) => rect.left));
+      const top = Math.min(...rects.map((rect) => rect.top));
+      const right = Math.max(...rects.map((rect) => rect.right));
+      const bottom = Math.max(...rects.map((rect) => rect.bottom));
+      return { left, top, right, bottom, width: right - left, height: bottom - top };
+    },
+  };
+}
+
+function visibleForProbe(element) {
+  const rect = element.getBoundingClientRect();
+  if (!rect.width || !rect.height) return false;
+  for (let current = element; current && current.nodeType === Node.ELEMENT_NODE; current = current.parentElement) {
+    const style = getComputedStyle(current);
+    if (style.visibility === 'hidden' || Number.parseFloat(style.opacity || '1') <= 0.05) return false;
+    if (current.classList?.contains('setup-main')) break;
+  }
+  return true;
+}
+
+function combinedTone(results) {
+  if (!results.length) return '';
+  return results.some((result) => result.tone === 'light') ? 'light' : 'dark';
+}
+
+function sameContrast(left, right) {
+  return left.shell === right.shell
+    && left.controls === right.controls
+    && left.cards.length === right.cards.length
+    && left.cards.every((tone, index) => tone === right.cards[index]);
+}

--- a/styles/app.css
+++ b/styles/app.css
@@ -3612,12 +3612,16 @@ textarea:focus-visible {
   .setup-grid { grid-template-columns: 1fr; }
 }
 .setup-main {
-  --setup-label-ink: color-mix(in oklab, var(--ink) 72%, black);
-  --setup-label-shadow: color-mix(in oklab, var(--panel) 72%, transparent);
-  --mode-card-title: var(--ink);
-  --mode-card-copy: color-mix(in oklab, var(--ink) 68%, white);
-  --mode-card-selected-title: var(--brand-ink);
-  --mode-card-selected-copy: color-mix(in oklab, var(--ink) 78%, white);
+  --setup-label-ink: #213247;
+  --setup-label-shadow: rgba(255, 255, 255, 0.78);
+  --length-option-ink: rgba(29, 43, 58, 0.76);
+  --length-option-hover: #182638;
+  --mode-card-title: #1d2b3a;
+  --mode-card-copy: #35475a;
+  --mode-card-selected-title: #254a75;
+  --mode-card-selected-copy: #2b3e52;
+  --mode-card-heading-shadow: 0 1px 14px rgba(255, 255, 255, 0.72), 0 0 1px rgba(255, 255, 255, 0.86);
+  --mode-card-copy-shadow: 0 1px 12px rgba(255, 255, 255, 0.58);
   padding: 28px 30px;
   border: 1px solid var(--line);
   border-radius: var(--radius-lg);
@@ -3631,10 +3635,26 @@ textarea:focus-visible {
 .setup-main.hero-dark {
   --setup-label-ink: #fff8e9;
   --setup-label-shadow: rgba(0, 0, 0, 0.62);
+  --length-option-ink: rgba(255, 248, 233, 0.78);
+  --length-option-hover: #fffdf6;
   --mode-card-title: #fff9ec;
   --mode-card-copy: rgba(255, 248, 233, 0.84);
   --mode-card-selected-title: #fffdf6;
   --mode-card-selected-copy: rgba(255, 248, 233, 0.9);
+  --mode-card-heading-shadow: 0 1px 18px rgba(0, 0, 0, 0.56);
+  --mode-card-copy-shadow: 0 1px 16px rgba(0, 0, 0, 0.58);
+}
+.setup-main[data-controls-tone="dark"] {
+  --setup-label-ink: #213247;
+  --setup-label-shadow: rgba(255, 255, 255, 0.78);
+  --length-option-ink: rgba(29, 43, 58, 0.76);
+  --length-option-hover: #182638;
+}
+.setup-main[data-controls-tone="light"] {
+  --setup-label-ink: #fff8e9;
+  --setup-label-shadow: rgba(0, 0, 0, 0.62);
+  --length-option-ink: rgba(255, 248, 233, 0.78);
+  --length-option-hover: #fffdf6;
 }
 /* Thin horizontal divider line under the subject eyebrow,
    matching the v1 hero-paper rule. */
@@ -3688,6 +3708,22 @@ textarea:focus-visible {
               box-shadow var(--dur) var(--ease-out),
               background-color var(--dur) var(--ease-out),
               filter var(--dur) var(--ease-out);
+}
+.mode-card[data-text-tone="dark"] {
+  --mode-card-title: #1d2b3a;
+  --mode-card-copy: #35475a;
+  --mode-card-selected-title: #254a75;
+  --mode-card-selected-copy: #2b3e52;
+  --mode-card-heading-shadow: 0 1px 14px rgba(255, 255, 255, 0.72), 0 0 1px rgba(255, 255, 255, 0.86);
+  --mode-card-copy-shadow: 0 1px 12px rgba(255, 255, 255, 0.58);
+}
+.mode-card[data-text-tone="light"] {
+  --mode-card-title: #fff9ec;
+  --mode-card-copy: rgba(255, 248, 233, 0.88);
+  --mode-card-selected-title: #fffdf6;
+  --mode-card-selected-copy: rgba(255, 248, 233, 0.92);
+  --mode-card-heading-shadow: 0 1px 18px rgba(0, 0, 0, 0.56);
+  --mode-card-copy-shadow: 0 1px 16px rgba(0, 0, 0, 0.58);
 }
 .mode-card:hover { transform: translateY(-2px); box-shadow: var(--shadow); }
 .mode-card.selected {
@@ -3749,10 +3785,8 @@ textarea:focus-visible {
   font-weight: 500;
   letter-spacing: -0.005em;
   color: var(--mode-card-title);
-  text-shadow: 0 1px 12px rgba(255, 255, 255, 0.2);
-}
-.setup-main.hero-dark .mode-card h4 {
-  text-shadow: 0 1px 18px rgba(0, 0, 0, 0.52);
+  text-shadow: var(--mode-card-heading-shadow);
+  transition: color var(--dur) var(--ease-out), text-shadow var(--dur) var(--ease-out);
 }
 .mode-card.selected h4 { color: var(--mode-card-selected-title); font-weight: 600; }
 .mode-card.selected p  { color: var(--mode-card-selected-copy); }
@@ -3762,10 +3796,8 @@ textarea:focus-visible {
   font-size: 0.87rem;
   line-height: 1.4;
   min-height: calc(0.87rem * 1.4 * 3);
-  text-shadow: 0 1px 12px rgba(255, 255, 255, 0.18);
-}
-.setup-main.hero-dark .mode-card p {
-  text-shadow: 0 1px 16px rgba(0, 0, 0, 0.56);
+  text-shadow: var(--mode-card-copy-shadow);
+  transition: color var(--dur) var(--ease-out), text-shadow var(--dur) var(--ease-out);
 }
 .mode-card .mc-badge {
   font-size: 10px; font-weight: 800; letter-spacing: 0.08em;
@@ -3826,6 +3858,7 @@ textarea:focus-visible {
   color: var(--setup-label-ink);
   text-shadow: 0 1px 12px var(--setup-label-shadow);
   margin-right: 4px;
+  transition: color var(--dur) var(--ease-out), text-shadow var(--dur) var(--ease-out);
 }
 
 .toggle-chip {
@@ -3914,7 +3947,7 @@ textarea:focus-visible {
   padding: 0 12px;
   border-radius: 999px;
   cursor: pointer;
-  color: color-mix(in oklab, var(--ink) 74%, white);
+  color: var(--length-option-ink);
   font-weight: 700;
   font-size: 0.9rem;
   position: relative;
@@ -3922,7 +3955,7 @@ textarea:focus-visible {
   transition: color var(--dur) var(--ease-out),
               text-shadow var(--dur) var(--ease-out);
 }
-.length-option:hover { color: var(--ink); }
+.length-option:hover { color: var(--length-option-hover); }
 .length-option.selected {
   color: #fff;
   text-shadow: 0 1px 2px rgba(0,0,0,0.18);
@@ -3933,6 +3966,7 @@ textarea:focus-visible {
   font-size: 0.82rem;
   margin: 0 8px 0 0;
   text-shadow: 0 1px 12px var(--setup-label-shadow);
+  transition: color var(--dur) var(--ease-out), text-shadow var(--dur) var(--ease-out);
 }
 
 /* Hero-art horizontal pan.

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -284,6 +284,7 @@ test('spelling setup and session hero backgrounds use mode-specific Scribe Downs
     MODE_CARDS,
     SPELLING_HERO_BACKGROUNDS,
     heroBgForMode,
+    heroBgPreloadUrls,
     heroBgForSession,
     spellingHeroTone,
   } = await import('../src/subjects/spelling/components/spelling-view-model.js');
@@ -299,6 +300,20 @@ test('spelling setup and session hero backgrounds use mode-specific Scribe Downs
   assert.equal(spellingHeroTone('learner-0'), '2');
   assert.match(heroBgForMode('smart', 'learner-0'), /the-scribe-downs-[abc]2\.1280\.webp$/);
   assert.match(heroBgForSession('learner-0', { mode: 'smart' }), /the-scribe-downs-[abc]1\.1280\.webp$/);
+  const learnerOnePreloads = [
+    heroBgForMode('smart', 'learner-1'),
+    heroBgForMode('trouble', 'learner-1'),
+    heroBgForMode('test', 'learner-1'),
+  ];
+  const learnerOneSession = heroBgForSession('learner-1', { mode: 'test' });
+  if (!learnerOnePreloads.includes(learnerOneSession)) learnerOnePreloads.push(learnerOneSession);
+  assert.deepEqual(heroBgPreloadUrls('learner-1', { mode: 'test' }), learnerOnePreloads);
+  assert.deepEqual(heroBgPreloadUrls('learner-0', { mode: 'test' }), [
+    heroBgForMode('smart', 'learner-0'),
+    heroBgForMode('trouble', 'learner-0'),
+    heroBgForMode('test', 'learner-0'),
+    heroBgForSession('learner-0', { mode: 'test' }),
+  ]);
 
   for (const urls of Object.values(SPELLING_HERO_BACKGROUNDS)) {
     for (const url of urls) {


### PR DESCRIPTION
## Summary
- add a React-scoped setup hero contrast probe that samples the active panning artwork under mode cards and control labels
- apply per-card and per-control text tones instead of relying on the global whole-image hero-dark pass
- preload setup mode backgrounds and the selected session day background to reduce first-switch lag on remote

## Verification
- npm test -- tests/render.test.js
- npm run build
- local browser probe on http://127.0.0.1:4173/?local=1 for computed contrast, pan stability, card height, and console errors
- npm run test:migration:browser
- npm test
- npm run check