### PR TITLE
Show typed spelling attempts in feedback

### DIFF
--- a/src/subjects/spelling/components/SpellingCommon.jsx
+++ b/src/subjects/spelling/components/SpellingCommon.jsx
@@ -55,6 +55,14 @@ export function Ribbon({ tone, icon, headline, word, sub }) {
   );
 }
 
+function feedbackSub(feedback) {
+  const attempt = String(feedback?.attemptedAnswer || '').trim();
+  const body = feedback?.body || '';
+  if (!attempt) return body;
+  const attemptLead = `You wrote "${attempt}".`;
+  return body ? `${attemptLead} ${body}` : attemptLead;
+}
+
 export function FeedbackSlot({ feedback }) {
   if (!feedback) {
     return (
@@ -75,7 +83,7 @@ export function FeedbackSlot({ feedback }) {
         icon={icon}
         headline={feedback.headline || ''}
         word={feedback.answer || ''}
-        sub={feedback.body || ''}
+        sub={feedbackSub(feedback)}
       />
       {feedback.footer ? <p className="feedback-foot small muted">{feedback.footer}</p> : null}
       <FamilyChips words={feedback.familyWords} />

--- a/src/subjects/spelling/service-contract.js
+++ b/src/subjects/spelling/service-contract.js
@@ -90,12 +90,13 @@ export function normaliseFeedback(value) {
     kind: SPELLING_FEEDBACK_KINDS.includes(value.kind) ? value.kind : 'info',
     headline: normaliseString(value.headline),
     answer: normaliseString(value.answer),
+    attemptedAnswer: normaliseString(value.attemptedAnswer).trim().slice(0, 80),
     body: normaliseString(value.body),
     footer: normaliseString(value.footer),
     familyWords: normaliseStringArray(value.familyWords),
   };
 
-  if (!feedback.headline && !feedback.answer && !feedback.body && !feedback.footer && !feedback.familyWords.length) {
+  if (!feedback.headline && !feedback.answer && !feedback.attemptedAnswer && !feedback.body && !feedback.footer && !feedback.familyWords.length) {
     return null;
   }
 

--- a/src/subjects/spelling/service.js
+++ b/src/subjects/spelling/service.js
@@ -722,7 +722,10 @@ export function createSpellingService({ repository, storage, tts, now, random, c
       version: SPELLING_SERVICE_STATE_VERSION,
       phase: 'session',
       session: decorateSession(engine, learnerId, session, runtimeWordBySlug),
-      feedback: normaliseFeedback(result.feedback),
+      feedback: normaliseFeedback({
+        ...result.feedback,
+        ...(session.type !== 'test' && result.correct === false ? { attemptedAnswer: rawTyped } : {}),
+      }),
       summary: null,
       error: '',
       awaitingAdvance: result.nextAction === 'advance',

--- a/tests/spelling-parity.test.js
+++ b/tests/spelling-parity.test.js
@@ -47,11 +47,13 @@ test('live spelling card keeps family hidden and restores legacy phase-specific 
   harness.dispatch('spelling-submit-form', { formData: typedFormData('wrong') });
   const retryHtml = harness.render();
   assert.match(retryHtml, /Try again/);
+  assert.match(retryHtml, /You wrote &quot;wrong&quot;\./);
   assert.match(retryHtml, /placeholder="Try once more from memory"/);
 
   harness.dispatch('spelling-submit-form', { formData: typedFormData('still wrong') });
   const correctionHtml = harness.render();
   assert.match(correctionHtml, /Lock it in/);
+  assert.match(correctionHtml, /You wrote &quot;still wrong&quot;\./);
   assert.match(correctionHtml, /placeholder="Type the correct spelling once"/);
 });
 

--- a/tests/spelling.test.js
+++ b/tests/spelling.test.js
@@ -210,6 +210,7 @@ test('Extra spelling accepts UK mollusc only', () => {
   assert.equal(rejectedSubmission.state.awaitingAdvance, false);
   assert.equal(rejectedSubmission.state.session.phase, 'retry');
   assert.equal(rejectedSubmission.state.feedback.kind, 'error');
+  assert.equal(rejectedSubmission.state.feedback.attemptedAnswer, 'mollusk');
 });
 
 test('service state survives JSON round-trips and resumes retry/correction flow', () => {
@@ -223,9 +224,11 @@ test('service state survives JSON round-trips and resumes retry/correction flow'
 
   state = JSON.parse(JSON.stringify(service.submitAnswer('learner-a', state, 'wrong').state));
   assert.equal(state.session.phase, 'retry');
+  assert.equal(state.feedback.attemptedAnswer, 'wrong');
 
-  state = JSON.parse(JSON.stringify(service.submitAnswer('learner-a', state, 'wrong').state));
+  state = JSON.parse(JSON.stringify(service.submitAnswer('learner-a', state, 'still wrong').state));
   assert.equal(state.session.phase, 'correction');
+  assert.equal(state.feedback.attemptedAnswer, 'still wrong');
 
   state = JSON.parse(JSON.stringify(service.submitAnswer('learner-a', state, 'possess').state));
   assert.equal(state.awaitingAdvance, true);


### PR DESCRIPTION
## Summary
- Preserve the learner's submitted wrong spelling as feedback metadata.
- Render the typed attempt in the spelling feedback ribbon, matching the redesign reference.
- Cover retry and correction flows with service and parity tests.

## Tests
- `npm test -- tests/spelling.test.js tests/spelling-parity.test.js tests/react-spelling-surface.test.js`
- `npm test`