### PR TITLE
Add Extra spelling word-family variants

### DIFF
--- a/content/spelling.seed.json
+++ b/content/spelling.seed.json
@@ -8429,6 +8429,42 @@
         "accepted": [
           "divide"
         ],
+        "variants": [
+          {
+            "word": "division",
+            "accepted": [
+              "division"
+            ],
+            "explanation": "Division is the act of splitting something into parts or groups.",
+            "sentenceEntryIds": [
+              "divide-division__01"
+            ],
+            "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling family extension",
+              "note": "Variant prompt for the divide base word family.",
+              "importedAt": 1776902400000
+            },
+            "sortIndex": 1
+          },
+          {
+            "word": "divisible",
+            "accepted": [
+              "divisible"
+            ],
+            "explanation": "Divisible means able to be divided exactly by a number.",
+            "sentenceEntryIds": [
+              "divide-divisible__01"
+            ],
+            "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling family extension",
+              "note": "Variant prompt for the divide base word family.",
+              "importedAt": 1776902400000
+            },
+            "sortIndex": 2
+          }
+        ],
         "explanation": "To divide is to split something into parts or groups.",
         "sentenceEntryIds": [
           "divide__01"
@@ -8456,6 +8492,25 @@
         ],
         "accepted": [
           "collide"
+        ],
+        "variants": [
+          {
+            "word": "collision",
+            "accepted": [
+              "collision"
+            ],
+            "explanation": "A collision is a crash or strong hit between moving things.",
+            "sentenceEntryIds": [
+              "collide-collision__01"
+            ],
+            "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling family extension",
+              "note": "Variant prompt for the collide base word family.",
+              "importedAt": 1776902400000
+            },
+            "sortIndex": 1
+          }
         ],
         "explanation": "To collide is to crash into something or hit it while moving.",
         "sentenceEntryIds": [
@@ -8485,6 +8540,42 @@
         "accepted": [
           "explode"
         ],
+        "variants": [
+          {
+            "word": "explosion",
+            "accepted": [
+              "explosion"
+            ],
+            "explanation": "An explosion is a sudden burst with force, noise or energy.",
+            "sentenceEntryIds": [
+              "explode-explosion__01"
+            ],
+            "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling family extension",
+              "note": "Variant prompt for the explode base word family.",
+              "importedAt": 1776902400000
+            },
+            "sortIndex": 1
+          },
+          {
+            "word": "explosive",
+            "accepted": [
+              "explosive"
+            ],
+            "explanation": "Explosive means able to burst apart suddenly with force.",
+            "sentenceEntryIds": [
+              "explode-explosive__01"
+            ],
+            "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling family extension",
+              "note": "Variant prompt for the explode base word family.",
+              "importedAt": 1776902400000
+            },
+            "sortIndex": 2
+          }
+        ],
         "explanation": "To explode is to burst apart suddenly with force.",
         "sentenceEntryIds": [
           "explode__01"
@@ -8512,6 +8603,42 @@
         ],
         "accepted": [
           "corrode"
+        ],
+        "variants": [
+          {
+            "word": "corrosion",
+            "accepted": [
+              "corrosion"
+            ],
+            "explanation": "Corrosion is the slow damage caused by a chemical reaction, often rust.",
+            "sentenceEntryIds": [
+              "corrode-corrosion__01"
+            ],
+            "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling family extension",
+              "note": "Variant prompt for the corrode base word family.",
+              "importedAt": 1776902400000
+            },
+            "sortIndex": 1
+          },
+          {
+            "word": "corrosive",
+            "accepted": [
+              "corrosive"
+            ],
+            "explanation": "Corrosive means able to slowly damage a material by chemical action.",
+            "sentenceEntryIds": [
+              "corrode-corrosive__01"
+            ],
+            "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling family extension",
+              "note": "Variant prompt for the corrode base word family.",
+              "importedAt": 1776902400000
+            },
+            "sortIndex": 2
+          }
         ],
         "explanation": "To corrode is to be slowly damaged by a chemical reaction, often rust.",
         "sentenceEntryIds": [
@@ -8541,6 +8668,25 @@
         "accepted": [
           "conclude"
         ],
+        "variants": [
+          {
+            "word": "conclusion",
+            "accepted": [
+              "conclusion"
+            ],
+            "explanation": "A conclusion is the final decision or ending reached after thinking.",
+            "sentenceEntryIds": [
+              "conclude-conclusion__01"
+            ],
+            "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling family extension",
+              "note": "Variant prompt for the conclude base word family.",
+              "importedAt": 1776902400000
+            },
+            "sortIndex": 1
+          }
+        ],
         "explanation": "To conclude is to finish, or to decide after thinking about evidence.",
         "sentenceEntryIds": [
           "conclude__01"
@@ -8568,6 +8714,42 @@
         ],
         "accepted": [
           "extend"
+        ],
+        "variants": [
+          {
+            "word": "extension",
+            "accepted": [
+              "extension"
+            ],
+            "explanation": "An extension is an added part or an increase in length or time.",
+            "sentenceEntryIds": [
+              "extend-extension__01"
+            ],
+            "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling family extension",
+              "note": "Variant prompt for the extend base word family.",
+              "importedAt": 1776902400000
+            },
+            "sortIndex": 1
+          },
+          {
+            "word": "extended",
+            "accepted": [
+              "extended"
+            ],
+            "explanation": "Extended means made longer or lasting for more time.",
+            "sentenceEntryIds": [
+              "extend-extended__01"
+            ],
+            "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling family extension",
+              "note": "Variant prompt for the extend base word family.",
+              "importedAt": 1776902400000
+            },
+            "sortIndex": 2
+          }
         ],
         "explanation": "To extend is to make something longer or reach further.",
         "sentenceEntryIds": [
@@ -8597,6 +8779,25 @@
         "accepted": [
           "comprehend"
         ],
+        "variants": [
+          {
+            "word": "comprehension",
+            "accepted": [
+              "comprehension"
+            ],
+            "explanation": "Comprehension is the ability to understand something.",
+            "sentenceEntryIds": [
+              "comprehend-comprehension__01"
+            ],
+            "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling family extension",
+              "note": "Variant prompt for the comprehend base word family.",
+              "importedAt": 1776902400000
+            },
+            "sortIndex": 1
+          }
+        ],
         "explanation": "To comprehend is to understand something fully.",
         "sentenceEntryIds": [
           "comprehend__01"
@@ -8624,6 +8825,42 @@
         ],
         "accepted": [
           "evade"
+        ],
+        "variants": [
+          {
+            "word": "evasion",
+            "accepted": [
+              "evasion"
+            ],
+            "explanation": "Evasion is the act of avoiding or escaping something.",
+            "sentenceEntryIds": [
+              "evade-evasion__01"
+            ],
+            "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling family extension",
+              "note": "Variant prompt for the evade base word family.",
+              "importedAt": 1776902400000
+            },
+            "sortIndex": 1
+          },
+          {
+            "word": "evasive",
+            "accepted": [
+              "evasive"
+            ],
+            "explanation": "Evasive means trying to avoid something or not answer directly.",
+            "sentenceEntryIds": [
+              "evade-evasive__01"
+            ],
+            "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling family extension",
+              "note": "Variant prompt for the evade base word family.",
+              "importedAt": 1776902400000
+            },
+            "sortIndex": 2
+          }
         ],
         "explanation": "To evade is to avoid or escape from someone or something.",
         "sentenceEntryIds": [
@@ -8653,6 +8890,42 @@
         "accepted": [
           "intrude"
         ],
+        "variants": [
+          {
+            "word": "intrusion",
+            "accepted": [
+              "intrusion"
+            ],
+            "explanation": "An intrusion is an unwanted entry or interruption.",
+            "sentenceEntryIds": [
+              "intrude-intrusion__01"
+            ],
+            "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling family extension",
+              "note": "Variant prompt for the intrude base word family.",
+              "importedAt": 1776902400000
+            },
+            "sortIndex": 1
+          },
+          {
+            "word": "intrusive",
+            "accepted": [
+              "intrusive"
+            ],
+            "explanation": "Intrusive means entering or interrupting where it is not wanted.",
+            "sentenceEntryIds": [
+              "intrude-intrusive__01"
+            ],
+            "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling family extension",
+              "note": "Variant prompt for the intrude base word family.",
+              "importedAt": 1776902400000
+            },
+            "sortIndex": 2
+          }
+        ],
         "explanation": "To intrude is to enter or join in where you are not wanted.",
         "sentenceEntryIds": [
           "intrude__01"
@@ -8681,6 +8954,25 @@
         "accepted": [
           "interlude"
         ],
+        "variants": [
+          {
+            "word": "interludes",
+            "accepted": [
+              "interludes"
+            ],
+            "explanation": "Interludes are short pauses or breaks between parts of something.",
+            "sentenceEntryIds": [
+              "interlude-interludes__01"
+            ],
+            "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling family extension",
+              "note": "Variant prompt for the interlude base word family.",
+              "importedAt": 1776902400000
+            },
+            "sortIndex": 1
+          }
+        ],
         "explanation": "An interlude is a short pause or break between parts of something.",
         "sentenceEntryIds": [
           "interlude__01"
@@ -8707,6 +8999,42 @@
         ],
         "accepted": [
           "classification"
+        ],
+        "variants": [
+          {
+            "word": "classify",
+            "accepted": [
+              "classify"
+            ],
+            "explanation": "To classify is to sort things into groups by shared features.",
+            "sentenceEntryIds": [
+              "classification-classify__01"
+            ],
+            "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling family extension",
+              "note": "Variant prompt for the classification base word family.",
+              "importedAt": 1776902400000
+            },
+            "sortIndex": 1
+          },
+          {
+            "word": "classified",
+            "accepted": [
+              "classified"
+            ],
+            "explanation": "Classified means sorted into groups by type or feature.",
+            "sentenceEntryIds": [
+              "classification-classified__01"
+            ],
+            "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling family extension",
+              "note": "Variant prompt for the classification base word family.",
+              "importedAt": 1776902400000
+            },
+            "sortIndex": 2
+          }
         ],
         "explanation": "Classification is sorting living things or objects into groups by shared features.",
         "sentenceEntryIds": [
@@ -8736,6 +9064,25 @@
         "accepted": [
           "backbone"
         ],
+        "variants": [
+          {
+            "word": "backbones",
+            "accepted": [
+              "backbones"
+            ],
+            "explanation": "Backbones are rows of bones that support the backs of some animals.",
+            "sentenceEntryIds": [
+              "backbone-backbones__01"
+            ],
+            "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling family extension",
+              "note": "Variant prompt for the backbone base word family.",
+              "importedAt": 1776902400000
+            },
+            "sortIndex": 1
+          }
+        ],
         "explanation": "A backbone is the row of bones that supports the back.",
         "sentenceEntryIds": [
           "backbone__01"
@@ -8763,6 +9110,25 @@
         ],
         "accepted": [
           "skeleton"
+        ],
+        "variants": [
+          {
+            "word": "skeletal",
+            "accepted": [
+              "skeletal"
+            ],
+            "explanation": "Skeletal means connected with the skeleton or bones.",
+            "sentenceEntryIds": [
+              "skeleton-skeletal__01"
+            ],
+            "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling family extension",
+              "note": "Variant prompt for the skeleton base word family.",
+              "importedAt": 1776902400000
+            },
+            "sortIndex": 1
+          }
         ],
         "explanation": "A skeleton is the frame of bones that supports a body.",
         "sentenceEntryIds": [
@@ -8821,6 +9187,25 @@
         "accepted": [
           "amphibians"
         ],
+        "variants": [
+          {
+            "word": "amphibian",
+            "accepted": [
+              "amphibian"
+            ],
+            "explanation": "An amphibian is an animal that can live in water and on land.",
+            "sentenceEntryIds": [
+              "amphibians-amphibian__01"
+            ],
+            "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling family extension",
+              "note": "Variant prompt for the amphibians base word family.",
+              "importedAt": 1776902400000
+            },
+            "sortIndex": 1
+          }
+        ],
         "explanation": "Amphibians are animals such as frogs that can live in water and on land.",
         "sentenceEntryIds": [
           "amphibians__01"
@@ -8848,6 +9233,25 @@
         ],
         "accepted": [
           "metamorphosis"
+        ],
+        "variants": [
+          {
+            "word": "metamorphose",
+            "accepted": [
+              "metamorphose"
+            ],
+            "explanation": "To metamorphose is to change into a very different adult form.",
+            "sentenceEntryIds": [
+              "metamorphosis-metamorphose__01"
+            ],
+            "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling family extension",
+              "note": "Variant prompt for the metamorphosis base word family.",
+              "importedAt": 1776902400000
+            },
+            "sortIndex": 1
+          }
         ],
         "explanation": "Metamorphosis is a major change in body form as an animal grows.",
         "sentenceEntryIds": [
@@ -8877,6 +9281,25 @@
         "accepted": [
           "reptiles"
         ],
+        "variants": [
+          {
+            "word": "reptile",
+            "accepted": [
+              "reptile"
+            ],
+            "explanation": "A reptile is a cold-blooded animal with dry scales.",
+            "sentenceEntryIds": [
+              "reptiles-reptile__01"
+            ],
+            "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling family extension",
+              "note": "Variant prompt for the reptiles base word family.",
+              "importedAt": 1776902400000
+            },
+            "sortIndex": 1
+          }
+        ],
         "explanation": "Reptiles are cold-blooded animals with dry scales, such as lizards and snakes.",
         "sentenceEntryIds": [
           "reptiles__01"
@@ -8904,6 +9327,25 @@
         ],
         "accepted": [
           "mammals"
+        ],
+        "variants": [
+          {
+            "word": "mammal",
+            "accepted": [
+              "mammal"
+            ],
+            "explanation": "A mammal is a warm-blooded animal that usually feeds its young milk.",
+            "sentenceEntryIds": [
+              "mammals-mammal__01"
+            ],
+            "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling family extension",
+              "note": "Variant prompt for the mammals base word family.",
+              "importedAt": 1776902400000
+            },
+            "sortIndex": 1
+          }
         ],
         "explanation": "Mammals are warm-blooded animals that usually have hair or fur and feed their young milk.",
         "sentenceEntryIds": [
@@ -8933,6 +9375,25 @@
         "accepted": [
           "arachnid"
         ],
+        "variants": [
+          {
+            "word": "arachnids",
+            "accepted": [
+              "arachnids"
+            ],
+            "explanation": "Arachnids are animals with eight legs, such as spiders and scorpions.",
+            "sentenceEntryIds": [
+              "arachnid-arachnids__01"
+            ],
+            "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling family extension",
+              "note": "Variant prompt for the arachnid base word family.",
+              "importedAt": 1776902400000
+            },
+            "sortIndex": 1
+          }
+        ],
         "explanation": "An arachnid is an animal with eight legs, such as a spider or scorpion.",
         "sentenceEntryIds": [
           "arachnid__01"
@@ -8961,6 +9422,25 @@
         "accepted": [
           "mollusc"
         ],
+        "variants": [
+          {
+            "word": "molluscs",
+            "accepted": [
+              "molluscs"
+            ],
+            "explanation": "Molluscs are soft-bodied animals, often with shells.",
+            "sentenceEntryIds": [
+              "mollusc-molluscs__01"
+            ],
+            "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling family extension",
+              "note": "Variant prompt for the mollusc base word family.",
+              "importedAt": 1776902400000
+            },
+            "sortIndex": 1
+          }
+        ],
         "explanation": "A mollusc is a soft-bodied animal, often with a shell.",
         "sentenceEntryIds": [
           "mollusc__01"
@@ -8988,6 +9468,42 @@
         "accepted": [
           "botanist"
         ],
+        "variants": [
+          {
+            "word": "botany",
+            "accepted": [
+              "botany"
+            ],
+            "explanation": "Botany is the scientific study of plants.",
+            "sentenceEntryIds": [
+              "botanist-botany__01"
+            ],
+            "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling family extension",
+              "note": "Variant prompt for the botanist base word family.",
+              "importedAt": 1776902400000
+            },
+            "sortIndex": 1
+          },
+          {
+            "word": "botanical",
+            "accepted": [
+              "botanical"
+            ],
+            "explanation": "Botanical means connected with plants or the study of plants.",
+            "sentenceEntryIds": [
+              "botanist-botanical__01"
+            ],
+            "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling family extension",
+              "note": "Variant prompt for the botanist base word family.",
+              "importedAt": 1776902400000
+            },
+            "sortIndex": 2
+          }
+        ],
         "explanation": "A botanist is a scientist who studies plants.",
         "sentenceEntryIds": [
           "botanist__01"
@@ -9014,6 +9530,42 @@
         ],
         "accepted": [
           "flowering"
+        ],
+        "variants": [
+          {
+            "word": "flowered",
+            "accepted": [
+              "flowered"
+            ],
+            "explanation": "Flowered means produced flowers or decorated with flowers.",
+            "sentenceEntryIds": [
+              "flowering-flowered__01"
+            ],
+            "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling family extension",
+              "note": "Variant prompt for the flowering base word family.",
+              "importedAt": 1776902400000
+            },
+            "sortIndex": 1
+          },
+          {
+            "word": "flowers",
+            "accepted": [
+              "flowers"
+            ],
+            "explanation": "Flowers are the parts of plants that often make seeds.",
+            "sentenceEntryIds": [
+              "flowering-flowers__01"
+            ],
+            "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling family extension",
+              "note": "Variant prompt for the flowering base word family.",
+              "importedAt": 1776902400000
+            },
+            "sortIndex": 2
+          }
         ],
         "explanation": "Flowering means producing flowers.",
         "sentenceEntryIds": [
@@ -43482,6 +44034,546 @@
           "importedAt": 1776816000000
         },
         "sortIndex": 31
+      },
+      {
+        "id": "divide-division__01",
+        "wordSlug": "divide",
+        "text": "The division of the class into teams was fair.",
+        "variantLabel": "division",
+        "tags": [
+          "extra",
+          "word-family",
+          "variant"
+        ],
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant sentence for the divide base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 32
+      },
+      {
+        "id": "divide-divisible__01",
+        "wordSlug": "divide",
+        "text": "Twenty is divisible by five.",
+        "variantLabel": "divisible",
+        "tags": [
+          "extra",
+          "word-family",
+          "variant"
+        ],
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant sentence for the divide base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 33
+      },
+      {
+        "id": "collide-collision__01",
+        "wordSlug": "collide",
+        "text": "The collision made both balls change direction.",
+        "variantLabel": "collision",
+        "tags": [
+          "extra",
+          "word-family",
+          "variant"
+        ],
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant sentence for the collide base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 34
+      },
+      {
+        "id": "explode-explosion__01",
+        "wordSlug": "explode",
+        "text": "The experiment caused a safe foam explosion.",
+        "variantLabel": "explosion",
+        "tags": [
+          "extra",
+          "word-family",
+          "variant"
+        ],
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant sentence for the explode base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 35
+      },
+      {
+        "id": "explode-explosive__01",
+        "wordSlug": "explode",
+        "text": "The explosive reaction was controlled by the teacher.",
+        "variantLabel": "explosive",
+        "tags": [
+          "extra",
+          "word-family",
+          "variant"
+        ],
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant sentence for the explode base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 36
+      },
+      {
+        "id": "corrode-corrosion__01",
+        "wordSlug": "corrode",
+        "text": "Corrosion weakened the old metal gate.",
+        "variantLabel": "corrosion",
+        "tags": [
+          "extra",
+          "word-family",
+          "variant"
+        ],
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant sentence for the corrode base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 37
+      },
+      {
+        "id": "corrode-corrosive__01",
+        "wordSlug": "corrode",
+        "text": "The corrosive liquid was handled with care.",
+        "variantLabel": "corrosive",
+        "tags": [
+          "extra",
+          "word-family",
+          "variant"
+        ],
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant sentence for the corrode base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 38
+      },
+      {
+        "id": "conclude-conclusion__01",
+        "wordSlug": "conclude",
+        "text": "Her conclusion matched the evidence from the test.",
+        "variantLabel": "conclusion",
+        "tags": [
+          "extra",
+          "word-family",
+          "variant"
+        ],
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant sentence for the conclude base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 39
+      },
+      {
+        "id": "extend-extension__01",
+        "wordSlug": "extend",
+        "text": "The bridge extension reached the other bank.",
+        "variantLabel": "extension",
+        "tags": [
+          "extra",
+          "word-family",
+          "variant"
+        ],
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant sentence for the extend base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 40
+      },
+      {
+        "id": "extend-extended__01",
+        "wordSlug": "extend",
+        "text": "The extended table gave everyone space.",
+        "variantLabel": "extended",
+        "tags": [
+          "extra",
+          "word-family",
+          "variant"
+        ],
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant sentence for the extend base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 41
+      },
+      {
+        "id": "comprehend-comprehension__01",
+        "wordSlug": "comprehend",
+        "text": "Good comprehension helped her answer the questions.",
+        "variantLabel": "comprehension",
+        "tags": [
+          "extra",
+          "word-family",
+          "variant"
+        ],
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant sentence for the comprehend base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 42
+      },
+      {
+        "id": "evade-evasion__01",
+        "wordSlug": "evade",
+        "text": "The quick evasion helped the player dodge the tackle.",
+        "variantLabel": "evasion",
+        "tags": [
+          "extra",
+          "word-family",
+          "variant"
+        ],
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant sentence for the evade base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 43
+      },
+      {
+        "id": "evade-evasive__01",
+        "wordSlug": "evade",
+        "text": "His evasive answer did not explain the mistake.",
+        "variantLabel": "evasive",
+        "tags": [
+          "extra",
+          "word-family",
+          "variant"
+        ],
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant sentence for the evade base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 44
+      },
+      {
+        "id": "intrude-intrusion__01",
+        "wordSlug": "intrude",
+        "text": "The loud noise was an intrusion during the recording.",
+        "variantLabel": "intrusion",
+        "tags": [
+          "extra",
+          "word-family",
+          "variant"
+        ],
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant sentence for the intrude base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 45
+      },
+      {
+        "id": "intrude-intrusive__01",
+        "wordSlug": "intrude",
+        "text": "The intrusive sound disturbed the quiet lesson.",
+        "variantLabel": "intrusive",
+        "tags": [
+          "extra",
+          "word-family",
+          "variant"
+        ],
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant sentence for the intrude base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 46
+      },
+      {
+        "id": "interlude-interludes__01",
+        "wordSlug": "interlude",
+        "text": "The play had two short interludes.",
+        "variantLabel": "interludes",
+        "tags": [
+          "extra",
+          "word-family",
+          "variant"
+        ],
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant sentence for the interlude base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 47
+      },
+      {
+        "id": "classification-classify__01",
+        "wordSlug": "classification",
+        "text": "Scientists classify living things by their features.",
+        "variantLabel": "classify",
+        "tags": [
+          "extra",
+          "word-family",
+          "variant"
+        ],
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant sentence for the classification base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 48
+      },
+      {
+        "id": "classification-classified__01",
+        "wordSlug": "classification",
+        "text": "The leaves were classified by shape and size.",
+        "variantLabel": "classified",
+        "tags": [
+          "extra",
+          "word-family",
+          "variant"
+        ],
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant sentence for the classification base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 49
+      },
+      {
+        "id": "backbone-backbones__01",
+        "wordSlug": "backbone",
+        "text": "The model showed how backbones protect the spinal cord.",
+        "variantLabel": "backbones",
+        "tags": [
+          "extra",
+          "word-family",
+          "variant"
+        ],
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant sentence for the backbone base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 50
+      },
+      {
+        "id": "skeleton-skeletal__01",
+        "wordSlug": "skeleton",
+        "text": "The diagram showed the skeletal system clearly.",
+        "variantLabel": "skeletal",
+        "tags": [
+          "extra",
+          "word-family",
+          "variant"
+        ],
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant sentence for the skeleton base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 51
+      },
+      {
+        "id": "amphibians-amphibian__01",
+        "wordSlug": "amphibians",
+        "text": "A frog is an amphibian with moist skin.",
+        "variantLabel": "amphibian",
+        "tags": [
+          "extra",
+          "word-family",
+          "variant"
+        ],
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant sentence for the amphibians base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 52
+      },
+      {
+        "id": "metamorphosis-metamorphose__01",
+        "wordSlug": "metamorphosis",
+        "text": "Some insects metamorphose before they can fly.",
+        "variantLabel": "metamorphose",
+        "tags": [
+          "extra",
+          "word-family",
+          "variant"
+        ],
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant sentence for the metamorphosis base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 53
+      },
+      {
+        "id": "reptiles-reptile__01",
+        "wordSlug": "reptiles",
+        "text": "A lizard is a reptile that warms itself in sunlight.",
+        "variantLabel": "reptile",
+        "tags": [
+          "extra",
+          "word-family",
+          "variant"
+        ],
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant sentence for the reptiles base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 54
+      },
+      {
+        "id": "mammals-mammal__01",
+        "wordSlug": "mammals",
+        "text": "A whale is a mammal even though it lives in the sea.",
+        "variantLabel": "mammal",
+        "tags": [
+          "extra",
+          "word-family",
+          "variant"
+        ],
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant sentence for the mammals base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 55
+      },
+      {
+        "id": "arachnid-arachnids__01",
+        "wordSlug": "arachnid",
+        "text": "Spiders and scorpions are arachnids.",
+        "variantLabel": "arachnids",
+        "tags": [
+          "extra",
+          "word-family",
+          "variant"
+        ],
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant sentence for the arachnid base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 56
+      },
+      {
+        "id": "mollusc-molluscs__01",
+        "wordSlug": "mollusc",
+        "text": "Snails and clams are molluscs.",
+        "variantLabel": "molluscs",
+        "tags": [
+          "extra",
+          "word-family",
+          "variant"
+        ],
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant sentence for the mollusc base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 57
+      },
+      {
+        "id": "botanist-botany__01",
+        "wordSlug": "botanist",
+        "text": "Botany helped the class understand plant growth.",
+        "variantLabel": "botany",
+        "tags": [
+          "extra",
+          "word-family",
+          "variant"
+        ],
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant sentence for the botanist base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 58
+      },
+      {
+        "id": "botanist-botanical__01",
+        "wordSlug": "botanist",
+        "text": "The botanical garden displayed unusual flowers.",
+        "variantLabel": "botanical",
+        "tags": [
+          "extra",
+          "word-family",
+          "variant"
+        ],
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant sentence for the botanist base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 59
+      },
+      {
+        "id": "flowering-flowered__01",
+        "wordSlug": "flowering",
+        "text": "The plant flowered after several warm days.",
+        "variantLabel": "flowered",
+        "tags": [
+          "extra",
+          "word-family",
+          "variant"
+        ],
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant sentence for the flowering base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 60
+      },
+      {
+        "id": "flowering-flowers__01",
+        "wordSlug": "flowering",
+        "text": "The flowers attracted several bees.",
+        "variantLabel": "flowers",
+        "tags": [
+          "extra",
+          "word-family",
+          "variant"
+        ],
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant sentence for the flowering base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 61
       }
     ]
   },
@@ -71740,15 +72832,7 @@
             "yearLabel": "Extra",
             "familyWords": [
               "divide",
-              "collide",
-              "explode",
-              "corrode",
-              "conclude",
-              "extend",
-              "comprehend",
-              "evade",
-              "intrude",
-              "interlude"
+              "division"
             ],
             "sentence": "We divide the class into teams before the investigation.",
             "sentences": [
@@ -71756,6 +72840,26 @@
             ],
             "accepted": [
               "divide"
+            ],
+            "variants": [
+              {
+                "word": "division",
+                "sentence": "The division of the class into teams was fair.",
+                "sentences": [
+                  "The division of the class into teams was fair."
+                ],
+                "accepted": [
+                  "division"
+                ],
+                "explanation": "Division is the act of splitting something into parts or groups.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the divide base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              }
             ],
             "explanation": "To divide is to split something into parts or groups.",
             "listId": "extra-science-word-building",
@@ -71782,16 +72886,7 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "divide",
-              "collide",
-              "explode",
-              "corrode",
-              "conclude",
-              "extend",
-              "comprehend",
-              "evade",
-              "intrude",
-              "interlude"
+              "collide"
             ],
             "sentence": "The two balls collide in the middle of the table.",
             "sentences": [
@@ -71825,16 +72920,7 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "divide",
-              "collide",
-              "explode",
-              "corrode",
-              "conclude",
-              "extend",
-              "comprehend",
-              "evade",
-              "intrude",
-              "interlude"
+              "explode"
             ],
             "sentence": "The volcano model did not explode until the final step.",
             "sentences": [
@@ -71868,16 +72954,7 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "divide",
-              "collide",
-              "explode",
-              "corrode",
-              "conclude",
-              "extend",
-              "comprehend",
-              "evade",
-              "intrude",
-              "interlude"
+              "corrode"
             ],
             "sentence": "Salt water can corrode metal over time.",
             "sentences": [
@@ -71911,16 +72988,7 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "divide",
-              "collide",
-              "explode",
-              "corrode",
-              "conclude",
-              "extend",
-              "comprehend",
-              "evade",
-              "intrude",
-              "interlude"
+              "conclude"
             ],
             "sentence": "We conclude that shade slows the melting ice.",
             "sentences": [
@@ -71954,16 +73022,7 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "divide",
-              "collide",
-              "explode",
-              "corrode",
-              "conclude",
-              "extend",
-              "comprehend",
-              "evade",
-              "intrude",
-              "interlude"
+              "extend"
             ],
             "sentence": "The bridge can extend across the stream.",
             "sentences": [
@@ -71997,16 +73056,7 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "divide",
-              "collide",
-              "explode",
-              "corrode",
-              "conclude",
-              "extend",
-              "comprehend",
-              "evade",
-              "intrude",
-              "interlude"
+              "comprehend"
             ],
             "sentence": "She could comprehend the instructions after reading them twice.",
             "sentences": [
@@ -72040,16 +73090,7 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "divide",
-              "collide",
-              "explode",
-              "corrode",
-              "conclude",
-              "extend",
-              "comprehend",
-              "evade",
-              "intrude",
-              "interlude"
+              "evade"
             ],
             "sentence": "The beetle tried to evade the torchlight under a leaf.",
             "sentences": [
@@ -72083,16 +73124,7 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "divide",
-              "collide",
-              "explode",
-              "corrode",
-              "conclude",
-              "extend",
-              "comprehend",
-              "evade",
-              "intrude",
-              "interlude"
+              "intrude"
             ],
             "sentence": "Please do not intrude while the group is recording.",
             "sentences": [
@@ -72126,15 +73158,6 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "divide",
-              "collide",
-              "explode",
-              "corrode",
-              "conclude",
-              "extend",
-              "comprehend",
-              "evade",
-              "intrude",
               "interlude"
             ],
             "sentence": "A quiet interlude gave the performers time to reset.",
@@ -72202,8 +73225,7 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "backbone",
-              "skeleton"
+              "backbone"
             ],
             "sentence": "A fish has a backbone inside its body.",
             "sentences": [
@@ -72237,7 +73259,6 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "backbone",
               "skeleton"
             ],
             "sentence": "The skeleton protects important organs.",
@@ -72272,12 +73293,7 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "cold-blooded",
-              "amphibians",
-              "reptiles",
-              "mammals",
-              "arachnid",
-              "mollusc"
+              "cold-blooded"
             ],
             "sentence": "A cold-blooded reptile warms itself on a rock.",
             "sentences": [
@@ -72312,12 +73328,7 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "cold-blooded",
-              "amphibians",
-              "reptiles",
-              "mammals",
-              "arachnid",
-              "mollusc"
+              "amphibians"
             ],
             "sentence": "Many amphibians begin life in water as tadpoles.",
             "sentences": [
@@ -72385,12 +73396,7 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "cold-blooded",
-              "amphibians",
-              "reptiles",
-              "mammals",
-              "arachnid",
-              "mollusc"
+              "reptiles"
             ],
             "sentence": "Reptiles often lay eggs on land.",
             "sentences": [
@@ -72424,12 +73430,7 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "cold-blooded",
-              "amphibians",
-              "reptiles",
-              "mammals",
-              "arachnid",
-              "mollusc"
+              "mammals"
             ],
             "sentence": "Dolphins and bats are both mammals.",
             "sentences": [
@@ -72463,12 +73464,7 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "cold-blooded",
-              "amphibians",
-              "reptiles",
-              "mammals",
-              "arachnid",
-              "mollusc"
+              "arachnid"
             ],
             "sentence": "A spider is an arachnid, not an insect.",
             "sentences": [
@@ -72502,11 +73498,6 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "cold-blooded",
-              "amphibians",
-              "reptiles",
-              "mammals",
-              "arachnid",
               "mollusc"
             ],
             "sentence": "A snail is a mollusc with a coiled shell.",
@@ -72541,8 +73532,7 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "botanist",
-              "flowering"
+              "botanist"
             ],
             "sentence": "The botanist examined the leaves carefully.",
             "sentences": [
@@ -72575,7 +73565,6 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "botanist",
               "flowering"
             ],
             "sentence": "The flowering plant attracted several bees.",
@@ -82014,15 +83003,7 @@
             "yearLabel": "Extra",
             "familyWords": [
               "divide",
-              "collide",
-              "explode",
-              "corrode",
-              "conclude",
-              "extend",
-              "comprehend",
-              "evade",
-              "intrude",
-              "interlude"
+              "division"
             ],
             "sentence": "We divide the class into teams before the investigation.",
             "sentences": [
@@ -82030,6 +83011,26 @@
             ],
             "accepted": [
               "divide"
+            ],
+            "variants": [
+              {
+                "word": "division",
+                "sentence": "The division of the class into teams was fair.",
+                "sentences": [
+                  "The division of the class into teams was fair."
+                ],
+                "accepted": [
+                  "division"
+                ],
+                "explanation": "Division is the act of splitting something into parts or groups.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the divide base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              }
             ],
             "explanation": "To divide is to split something into parts or groups.",
             "listId": "extra-science-word-building",
@@ -82056,16 +83057,7 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "divide",
-              "collide",
-              "explode",
-              "corrode",
-              "conclude",
-              "extend",
-              "comprehend",
-              "evade",
-              "intrude",
-              "interlude"
+              "collide"
             ],
             "sentence": "The two balls collide in the middle of the table.",
             "sentences": [
@@ -82099,16 +83091,7 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "divide",
-              "collide",
-              "explode",
-              "corrode",
-              "conclude",
-              "extend",
-              "comprehend",
-              "evade",
-              "intrude",
-              "interlude"
+              "explode"
             ],
             "sentence": "The volcano model did not explode until the final step.",
             "sentences": [
@@ -82142,16 +83125,7 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "divide",
-              "collide",
-              "explode",
-              "corrode",
-              "conclude",
-              "extend",
-              "comprehend",
-              "evade",
-              "intrude",
-              "interlude"
+              "corrode"
             ],
             "sentence": "Salt water can corrode metal over time.",
             "sentences": [
@@ -82185,16 +83159,7 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "divide",
-              "collide",
-              "explode",
-              "corrode",
-              "conclude",
-              "extend",
-              "comprehend",
-              "evade",
-              "intrude",
-              "interlude"
+              "conclude"
             ],
             "sentence": "We conclude that shade slows the melting ice.",
             "sentences": [
@@ -82228,16 +83193,7 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "divide",
-              "collide",
-              "explode",
-              "corrode",
-              "conclude",
-              "extend",
-              "comprehend",
-              "evade",
-              "intrude",
-              "interlude"
+              "extend"
             ],
             "sentence": "The bridge can extend across the stream.",
             "sentences": [
@@ -82271,16 +83227,7 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "divide",
-              "collide",
-              "explode",
-              "corrode",
-              "conclude",
-              "extend",
-              "comprehend",
-              "evade",
-              "intrude",
-              "interlude"
+              "comprehend"
             ],
             "sentence": "She could comprehend the instructions after reading them twice.",
             "sentences": [
@@ -82314,16 +83261,7 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "divide",
-              "collide",
-              "explode",
-              "corrode",
-              "conclude",
-              "extend",
-              "comprehend",
-              "evade",
-              "intrude",
-              "interlude"
+              "evade"
             ],
             "sentence": "The beetle tried to evade the torchlight under a leaf.",
             "sentences": [
@@ -82357,16 +83295,7 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "divide",
-              "collide",
-              "explode",
-              "corrode",
-              "conclude",
-              "extend",
-              "comprehend",
-              "evade",
-              "intrude",
-              "interlude"
+              "intrude"
             ],
             "sentence": "Please do not intrude while the group is recording.",
             "sentences": [
@@ -82400,15 +83329,6 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "divide",
-              "collide",
-              "explode",
-              "corrode",
-              "conclude",
-              "extend",
-              "comprehend",
-              "evade",
-              "intrude",
               "interlude"
             ],
             "sentence": "A quiet interlude gave the performers time to reset.",
@@ -82476,8 +83396,7 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "backbone",
-              "skeleton"
+              "backbone"
             ],
             "sentence": "A fish has a backbone inside its body.",
             "sentences": [
@@ -82511,7 +83430,6 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "backbone",
               "skeleton"
             ],
             "sentence": "The skeleton protects important organs.",
@@ -82546,12 +83464,7 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "cold-blooded",
-              "amphibians",
-              "reptiles",
-              "mammals",
-              "arachnid",
-              "mollusc"
+              "cold-blooded"
             ],
             "sentence": "A cold-blooded reptile warms itself on a rock.",
             "sentences": [
@@ -82586,12 +83499,7 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "cold-blooded",
-              "amphibians",
-              "reptiles",
-              "mammals",
-              "arachnid",
-              "mollusc"
+              "amphibians"
             ],
             "sentence": "Many amphibians begin life in water as tadpoles.",
             "sentences": [
@@ -82659,12 +83567,7 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "cold-blooded",
-              "amphibians",
-              "reptiles",
-              "mammals",
-              "arachnid",
-              "mollusc"
+              "reptiles"
             ],
             "sentence": "Reptiles often lay eggs on land.",
             "sentences": [
@@ -82698,12 +83601,7 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "cold-blooded",
-              "amphibians",
-              "reptiles",
-              "mammals",
-              "arachnid",
-              "mollusc"
+              "mammals"
             ],
             "sentence": "Dolphins and bats are both mammals.",
             "sentences": [
@@ -82737,12 +83635,7 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "cold-blooded",
-              "amphibians",
-              "reptiles",
-              "mammals",
-              "arachnid",
-              "mollusc"
+              "arachnid"
             ],
             "sentence": "A spider is an arachnid, not an insect.",
             "sentences": [
@@ -82776,11 +83669,6 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "cold-blooded",
-              "amphibians",
-              "reptiles",
-              "mammals",
-              "arachnid",
               "mollusc"
             ],
             "sentence": "A snail is a mollusc with a coiled shell.",
@@ -82815,8 +83703,7 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "botanist",
-              "flowering"
+              "botanist"
             ],
             "sentence": "The botanist examined the leaves carefully.",
             "sentences": [
@@ -82849,7 +83736,6 @@
             "spellingPool": "extra",
             "yearLabel": "Extra",
             "familyWords": [
-              "botanist",
               "flowering"
             ],
             "sentence": "The flowering plant attracted several bees.",
@@ -82877,11 +83763,21553 @@
           }
         }
       }
+    },
+    {
+      "id": "spelling-r3",
+      "state": "published",
+      "version": 3,
+      "title": "Release 3 - Extra word-family variants",
+      "notes": "Published Extra word-family variants with independent explanations and sentences.",
+      "sourceDraftId": "main",
+      "sourceNote": "Legacy spelling seed",
+      "provenance": {
+        "source": "legacy/vendor/*.js",
+        "note": "Initial content seed produced for the content model pass.",
+        "importedAt": 0
+      },
+      "publishedAt": 1776902400000,
+      "snapshot": {
+        "generatedAt": 1776902400000,
+        "words": [
+          {
+            "year": "3-4",
+            "family": "accident(ally)",
+            "word": "accident",
+            "slug": "accident",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "accident",
+              "accidentally"
+            ],
+            "sentence": "We saw an accident on the road.",
+            "sentences": [
+              "We saw an accident on the road.",
+              "The cyclist had an accident near the park.",
+              "We called for help after the accident.",
+              "The accident blocked the road for an hour.",
+              "No one was hurt in the accident.",
+              "The school wrote a report about the accident.",
+              "She saw the accident from the bus.",
+              "The accident happened during the morning rain.",
+              "He learned to stay careful after the accident.",
+              "The driver explained the accident to the police."
+            ],
+            "accepted": [
+              "accident"
+            ],
+            "explanation": "An accident is something that happens by chance, often causing damage or a problem.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 0
+          },
+          {
+            "year": "3-4",
+            "family": "accident(ally)",
+            "word": "accidentally",
+            "slug": "accidentally",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "accident",
+              "accidentally"
+            ],
+            "sentence": "I accidentally knocked the cup over.",
+            "sentences": [
+              "I accidentally knocked the cup over.",
+              "I accidentally knocked over the pencil pot.",
+              "She accidentally sent the message to the wrong class.",
+              "He accidentally stepped in a muddy puddle.",
+              "They accidentally pressed the alarm button.",
+              "Mum accidentally bought two packets of rice.",
+              "We accidentally locked the door before lunch.",
+              "The cat accidentally spilled water on the mat.",
+              "Ben accidentally left his coat on the chair.",
+              "I accidentally mixed the blue paint with green."
+            ],
+            "accepted": [
+              "accidentally"
+            ],
+            "explanation": "If you do something accidentally, you do it by mistake and did not mean to.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 1
+          },
+          {
+            "year": "3-4",
+            "family": "actual(ly)",
+            "word": "actual",
+            "slug": "actual",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "actual",
+              "actually"
+            ],
+            "sentence": "The story is based on actual events.",
+            "sentences": [
+              "The story is based on actual events.",
+              "The actual winner was announced at the end.",
+              "The actual cost was lower than we expected.",
+              "I checked the actual time on my watch.",
+              "She wanted the actual facts, not a rumour.",
+              "We followed the actual path on the map.",
+              "The actual answer was simpler than we first thought.",
+              "The actual size of the box was quite small.",
+              "We saw the actual painting in the museum.",
+              "His actual reason for leaving was never clear."
+            ],
+            "accepted": [
+              "actual"
+            ],
+            "explanation": "Actual means real or true, not guessed or imagined.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 2
+          },
+          {
+            "year": "3-4",
+            "family": "actual(ly)",
+            "word": "actually",
+            "slug": "actually",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "actual",
+              "actually"
+            ],
+            "sentence": "I actually knew the answer.",
+            "sentences": [
+              "I actually knew the answer.",
+              "I actually enjoy rainy walks.",
+              "She actually knew the way home.",
+              "We actually finished early.",
+              "He actually borrowed my ruler yesterday.",
+              "The game was actually quite exciting.",
+              "I actually forgot my lunch today.",
+              "They actually live on the next street.",
+              "It was actually a simple puzzle.",
+              "The puppy actually slept all afternoon."
+            ],
+            "accepted": [
+              "actually"
+            ],
+            "explanation": "Actually is used to say what is really true, especially when it is different from what someone expected.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 3
+          },
+          {
+            "year": "3-4",
+            "family": "address",
+            "word": "address",
+            "slug": "address",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "address"
+            ],
+            "sentence": "Please write your home address clearly.",
+            "sentences": [
+              "Please write your home address clearly.",
+              "Please write your address clearly on the envelope.",
+              "The letter had the wrong address.",
+              "I memorised my address for the trip.",
+              "She checked the address before posting the card.",
+              "The teacher wrote the office address on the board.",
+              "We moved house, so our address changed.",
+              "He read the address out loud to the class.",
+              "The parcel arrived at the correct address.",
+              "They found the address on the invitation."
+            ],
+            "accepted": [
+              "address"
+            ],
+            "explanation": "An address is the details of where a person or place can be found, such as a house number and street.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 4
+          },
+          {
+            "year": "3-4",
+            "family": "answer",
+            "word": "answer",
+            "slug": "answer",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "answer"
+            ],
+            "sentence": "I knew the answer at once.",
+            "sentences": [
+              "I knew the answer at once.",
+              "The answer was hidden in the clue.",
+              "She gave a quick answer in class.",
+              "I checked the answer with my partner.",
+              "His answer made the whole group laugh.",
+              "The answer was correct on the first try.",
+              "We wrote the answer neatly in pencil.",
+              "The teacher praised her answer.",
+              "I could not find the answer at first.",
+              "The answer matched the question exactly."
+            ],
+            "accepted": [
+              "answer"
+            ],
+            "explanation": "An answer is what you say or write in reply to a question.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 5
+          },
+          {
+            "year": "3-4",
+            "family": "appear",
+            "word": "appear",
+            "slug": "appear",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "appear"
+            ],
+            "sentence": "Stars appear when the sky gets dark.",
+            "sentences": [
+              "Stars appear when the sky gets dark.",
+              "A bright star began to appear in the sky.",
+              "The rabbit did not appear from the burrow.",
+              "A smile started to appear on her face.",
+              "Clouds appear quickly before a storm.",
+              "The chalk marks appear after we draw.",
+              "He watched the ship appear on the horizon.",
+              "New flowers appear in the garden each spring.",
+              "The map did not appear on the screen.",
+              "A note will appear beside the score."
+            ],
+            "accepted": [
+              "appear"
+            ],
+            "explanation": "To appear means to come into sight or seem to be a certain way.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 6
+          },
+          {
+            "year": "3-4",
+            "family": "arrive",
+            "word": "arrive",
+            "slug": "arrive",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "arrive"
+            ],
+            "sentence": "We will arrive before lunch.",
+            "sentences": [
+              "We will arrive before lunch.",
+              "We arrive at school before the bell.",
+              "The parcel should arrive tomorrow.",
+              "They arrive home together after football.",
+              "I arrive early for choir practice.",
+              "The train did not arrive on time.",
+              "Birds arrive in the garden at dawn.",
+              "Please arrive with your coat and bag.",
+              "We arrive at the museum after lunch.",
+              "The guests arrive through the side gate."
+            ],
+            "accepted": [
+              "arrive"
+            ],
+            "explanation": "To arrive means to reach the place you were travelling to.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 7
+          },
+          {
+            "year": "3-4",
+            "family": "believe",
+            "word": "believe",
+            "slug": "believe",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "believe"
+            ],
+            "sentence": "I believe you are telling the truth.",
+            "sentences": [
+              "I believe you are telling the truth.",
+              "I believe the story is true.",
+              "She did not believe the rumour.",
+              "We believe he will try his best.",
+              "I believe in working hard.",
+              "They believe the storm will pass.",
+              "Mum and Dad believe the plan will work.",
+              "The class believe the quiz was fair.",
+              "I believe my friend when he speaks.",
+              "Do you believe what you hear?"
+            ],
+            "accepted": [
+              "believe"
+            ],
+            "explanation": "To believe means to think that something is true or to trust someone.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 8
+          },
+          {
+            "year": "3-4",
+            "family": "bicycle",
+            "word": "bicycle",
+            "slug": "bicycle",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "bicycle"
+            ],
+            "sentence": "Her bicycle is leaning against the wall.",
+            "sentences": [
+              "Her bicycle is leaning against the wall.",
+              "My bicycle has a bright red bell.",
+              "He parked his bicycle outside the shop.",
+              "I fixed the tyre on my bicycle.",
+              "Her bicycle is easy to ride.",
+              "The bicycle leaned against the wall.",
+              "We learned to lock the bicycle safely.",
+              "His bicycle lights were very bright.",
+              "I cleaned mud off the bicycle.",
+              "The bicycle basket held my lunch."
+            ],
+            "accepted": [
+              "bicycle"
+            ],
+            "explanation": "A bicycle is a vehicle with two wheels that you ride by pedalling.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 9
+          },
+          {
+            "year": "3-4",
+            "family": "breath",
+            "word": "breath",
+            "slug": "breath",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "breath"
+            ],
+            "sentence": "Take a deep breath before you dive.",
+            "sentences": [
+              "Take a deep breath before you dive.",
+              "She took a deep breath before singing her solo.",
+              "After the sprint, he was out of breath.",
+              "Hold your breath while you go under the water.",
+              "The cold air caught my breath at the gate.",
+              "I could see my breath on the frosty morning.",
+              "The steep climb left us short of breath.",
+              "One slow breath helped me stay calm.",
+              "The singer paused for breath between the verses.",
+              "He took a breath before answering the question."
+            ],
+            "accepted": [
+              "breath"
+            ],
+            "explanation": "A breath is the air you take into or let out of your lungs.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 10
+          },
+          {
+            "year": "3-4",
+            "family": "breathe",
+            "word": "breathe",
+            "slug": "breathe",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "breathe"
+            ],
+            "sentence": "It is easier to breathe in fresh sea air.",
+            "sentences": [
+              "It is easier to breathe in fresh sea air.",
+              "Try to breathe slowly through your nose.",
+              "Breathe deeply and count to four.",
+              "The runner could hardly breathe after the hill.",
+              "Open the window so we can breathe more easily.",
+              "She remembered to breathe before reading aloud.",
+              "Hot air can make it harder to breathe.",
+              "The swimmer turned to breathe between strokes.",
+              "He had to breathe slowly after the sprint.",
+              "We stopped so everyone could breathe again."
+            ],
+            "accepted": [
+              "breathe"
+            ],
+            "explanation": "To breathe means to take air into your lungs and let it out again.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 11
+          },
+          {
+            "year": "3-4",
+            "family": "build",
+            "word": "build",
+            "slug": "build",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "build"
+            ],
+            "sentence": "We used blocks to build a tall tower.",
+            "sentences": [
+              "We used blocks to build a tall tower.",
+              "We build a tower from wooden blocks.",
+              "The workers build a new bridge.",
+              "I build model cars with my brother.",
+              "They build a shelter in the garden.",
+              "The school will build a small library.",
+              "We build confidence through practice.",
+              "Can you build the shape from these pieces?",
+              "The children build a fort in the sand.",
+              "Engineers build strong roads for lorries."
+            ],
+            "accepted": [
+              "build"
+            ],
+            "explanation": "To build means to make something by putting parts together.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 12
+          },
+          {
+            "year": "3-4",
+            "family": "busy/business",
+            "word": "busy",
+            "slug": "busy",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "busy",
+              "business"
+            ],
+            "sentence": "The shop was busy on Saturday morning.",
+            "sentences": [
+              "The shop was busy on Saturday morning.",
+              "The road was busy after school.",
+              "Mum was busy cooking dinner.",
+              "The shop is busy on Saturdays.",
+              "I was busy finishing my homework.",
+              "The station looked busy at rush hour.",
+              "The office was busy all morning.",
+              "Dad is busy mending the bike.",
+              "The park felt busy with families.",
+              "We were busy packing for the trip."
+            ],
+            "accepted": [
+              "busy"
+            ],
+            "explanation": "Busy means having a lot to do or full of activity.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 13
+          },
+          {
+            "year": "3-4",
+            "family": "busy/business",
+            "word": "business",
+            "slug": "business",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "busy",
+              "business"
+            ],
+            "sentence": "The family business sells fresh bread.",
+            "sentences": [
+              "The family business sells fresh bread.",
+              "Her business sells homemade cakes.",
+              "The business opened near the station.",
+              "He wants to start a small business.",
+              "The business pays its workers on Friday.",
+              "Our business plan was very simple.",
+              "The business needs careful money records.",
+              "She visited the business with her aunt.",
+              "The business grew after the festival.",
+              "They shared ideas for the business."
+            ],
+            "accepted": [
+              "business"
+            ],
+            "explanation": "A business is work or an organisation that sells goods or services.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 14
+          },
+          {
+            "year": "3-4",
+            "family": "calendar",
+            "word": "calendar",
+            "slug": "calendar",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "calendar"
+            ],
+            "sentence": "I marked the date on the calendar.",
+            "sentences": [
+              "I marked the date on the calendar.",
+              "I marked the trip on my calendar.",
+              "The calendar shows the school holidays.",
+              "She tore a page from the calendar.",
+              "We checked the calendar for the date.",
+              "The calendar hung above the desk.",
+              "Dad circled his birthday on the calendar.",
+              "I lost my calendar during the move.",
+              "The calendar helps me plan my week.",
+              "Our class calendar has every club day."
+            ],
+            "accepted": [
+              "calendar"
+            ],
+            "explanation": "A calendar shows days, weeks and months of the year.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 15
+          },
+          {
+            "year": "3-4",
+            "family": "caught",
+            "word": "caught",
+            "slug": "caught",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "caught"
+            ],
+            "sentence": "The goalkeeper caught the ball.",
+            "sentences": [
+              "The goalkeeper caught the ball.",
+              "He caught the ball one-handed.",
+              "I caught a glimpse of the fox.",
+              "The teacher caught the mistake quickly.",
+              "We caught the bus after breakfast.",
+              "She caught the ribbon before it fell.",
+              "The net caught the leaves from the drain.",
+              "I caught myself smiling at the joke.",
+              "They caught the last train home.",
+              "The bucket caught the rain from the roof."
+            ],
+            "accepted": [
+              "caught"
+            ],
+            "explanation": "Caught is the past tense of catch; it can mean grabbed, trapped or noticed doing something.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 16
+          },
+          {
+            "year": "3-4",
+            "family": "centre",
+            "word": "centre",
+            "slug": "centre",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "centre"
+            ],
+            "sentence": "We met in the centre of town.",
+            "sentences": [
+              "We met in the centre of town.",
+              "The fountain stands in the centre of the square.",
+              "She drew a dot in the centre of the circle.",
+              "The shop is in the centre of the village.",
+              "Place the box in the centre of the table.",
+              "The park lies in the centre of the estate.",
+              "He walked to the centre of the hall.",
+              "The museum is near the centre of the city.",
+              "Put the star in the centre of the card.",
+              "The school is close to the centre of the community."
+            ],
+            "accepted": [
+              "centre"
+            ],
+            "explanation": "The centre is the middle point or main part of something.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 17
+          },
+          {
+            "year": "3-4",
+            "family": "century",
+            "word": "century",
+            "slug": "century",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "century"
+            ],
+            "sentence": "The castle was built a century ago.",
+            "sentences": [
+              "The castle was built a century ago.",
+              "The castle was built in the twelfth century.",
+              "A century has one hundred years.",
+              "The song sounded like it came from another century.",
+              "The town changed a lot in the last century.",
+              "The library opened in the previous century.",
+              "We read about life in the nineteenth century.",
+              "The bridge has stood for a century.",
+              "The museum shows objects from each century.",
+              "My great-grandad was born last century."
+            ],
+            "accepted": [
+              "century"
+            ],
+            "explanation": "A century is a period of one hundred years.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 18
+          },
+          {
+            "year": "3-4",
+            "family": "certain",
+            "word": "certain",
+            "slug": "certain",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "certain"
+            ],
+            "sentence": "I am certain that this is mine.",
+            "sentences": [
+              "I am certain that this is mine.",
+              "I am certain we locked the door.",
+              "She felt certain about her answer.",
+              "The teacher was certain the class would try.",
+              "We are certain the train is late.",
+              "He was not certain which route to take.",
+              "I am certain my pencil is on the desk.",
+              "They seemed certain before the test began.",
+              "She is certain the cake will rise.",
+              "We were certain of the time."
+            ],
+            "accepted": [
+              "certain"
+            ],
+            "explanation": "Certain means sure, or known to be true.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 19
+          },
+          {
+            "year": "3-4",
+            "family": "circle",
+            "word": "circle",
+            "slug": "circle",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "circle"
+            ],
+            "sentence": "Please draw a neat circle.",
+            "sentences": [
+              "Please draw a neat circle.",
+              "Draw a circle around the missing number.",
+              "The children sat in a circle for the game.",
+              "I made a neat circle with chalk.",
+              "The planet looked like a bright circle.",
+              "Please circle the word that fits.",
+              "The dancers circle the stage at the end.",
+              "We passed the ball in a circle.",
+              "He pinned a circle badge to his coat.",
+              "The coach asked us to form a circle."
+            ],
+            "accepted": [
+              "circle"
+            ],
+            "explanation": "A circle is a round shape where every point on the edge is the same distance from the centre.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 20
+          },
+          {
+            "year": "3-4",
+            "family": "complete",
+            "word": "complete",
+            "slug": "complete",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "complete"
+            ],
+            "sentence": "Try to complete the puzzle.",
+            "sentences": [
+              "Try to complete the puzzle.",
+              "Please complete the map carefully.",
+              "I will complete my reading before bed.",
+              "She wants to complete the craft model.",
+              "We complete the checklist together.",
+              "The task is complete once the lid is on.",
+              "He hopes to complete the course this term.",
+              "Can you complete this final line?",
+              "They complete jobs in pairs.",
+              "The meal is complete with fruit for pudding."
+            ],
+            "accepted": [
+              "complete"
+            ],
+            "explanation": "Complete means finished or with nothing missing.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 21
+          },
+          {
+            "year": "3-4",
+            "family": "consider",
+            "word": "consider",
+            "slug": "consider",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "consider"
+            ],
+            "sentence": "Please consider both sides of the argument.",
+            "sentences": [
+              "Please consider both sides of the argument.",
+              "Please consider my idea carefully.",
+              "We should consider the weather.",
+              "She will consider both choices.",
+              "I consider him a good friend.",
+              "The teacher asked us to consider our work.",
+              "They consider the journey too long.",
+              "I must consider your question.",
+              "We consider safety first.",
+              "He did not consider the noise."
+            ],
+            "accepted": [
+              "consider"
+            ],
+            "explanation": "To consider means to think carefully about something before deciding.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 22
+          },
+          {
+            "year": "3-4",
+            "family": "continue",
+            "word": "continue",
+            "slug": "continue",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "continue"
+            ],
+            "sentence": "We will continue after the break.",
+            "sentences": [
+              "We will continue after the break.",
+              "We continue down the quiet path.",
+              "Please continue until I say stop.",
+              "She will continue practising after school.",
+              "The rain may continue through the afternoon.",
+              "They continue the game after lunch.",
+              "The bus can continue to the next town.",
+              "He decided to continue with his idea.",
+              "We continue reading while the room is silent.",
+              "The lesson will continue when the bell rings."
+            ],
+            "accepted": [
+              "continue"
+            ],
+            "explanation": "To continue means to keep going and not stop.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 23
+          },
+          {
+            "year": "3-4",
+            "family": "decide",
+            "word": "decide",
+            "slug": "decide",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "decide"
+            ],
+            "sentence": "You need to decide which game to play.",
+            "sentences": [
+              "You need to decide which game to play.",
+              "I decide to save my work now.",
+              "We decide after hearing both sides.",
+              "She will decide on the class name.",
+              "They decide which route to take.",
+              "Please decide before the timer ends.",
+              "He will decide to join the reading club.",
+              "The team decide on a fair rule.",
+              "Mum will decide once she checks the list.",
+              "I decide to ask for help."
+            ],
+            "accepted": [
+              "decide"
+            ],
+            "explanation": "To decide means to choose after thinking about the options.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 24
+          },
+          {
+            "year": "3-4",
+            "family": "describe",
+            "word": "describe",
+            "slug": "describe",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "describe"
+            ],
+            "sentence": "Can you describe the animal you saw.",
+            "sentences": [
+              "Can you describe the animal you saw.",
+              "Can you describe the scene in the photo?",
+              "She will describe the animal to the class.",
+              "Please describe what you can hear.",
+              "He tried to describe the smell from the kitchen.",
+              "We describe our route in simple words.",
+              "The guide will describe the castle rooms.",
+              "I can describe how the rain felt.",
+              "They describe their holiday to friends.",
+              "The teacher asked us to describe the map."
+            ],
+            "accepted": [
+              "describe"
+            ],
+            "explanation": "To describe means to say or write what someone or something is like.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 25
+          },
+          {
+            "year": "3-4",
+            "family": "different",
+            "word": "different",
+            "slug": "different",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "different"
+            ],
+            "sentence": "My two socks are different colours.",
+            "sentences": [
+              "My two socks are different colours.",
+              "We chose a different game at break.",
+              "She used a different pen for maths.",
+              "The answer was different from mine.",
+              "I found a different path home.",
+              "They wore different socks for the race.",
+              "His plan looked different after lunch.",
+              "The class had a different target this week.",
+              "Try a different way to fold the paper.",
+              "Our lunch was different from yesterday's."
+            ],
+            "accepted": [
+              "different"
+            ],
+            "explanation": "Different means not the same.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 26
+          },
+          {
+            "year": "3-4",
+            "family": "difficult",
+            "word": "difficult",
+            "slug": "difficult",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "difficult"
+            ],
+            "sentence": "That was a difficult question.",
+            "sentences": [
+              "That was a difficult question.",
+              "The first question was difficult for me.",
+              "It can be difficult to stay patient.",
+              "She found the climb difficult.",
+              "I made a difficult choice at lunch.",
+              "The wind made the journey difficult.",
+              "Maths stays difficult until I practise.",
+              "The lid was difficult to open.",
+              "He had a difficult time in the fog.",
+              "The difficult part came near the end."
+            ],
+            "accepted": [
+              "difficult"
+            ],
+            "explanation": "Difficult means hard to do, understand or deal with.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 27
+          },
+          {
+            "year": "3-4",
+            "family": "disappear",
+            "word": "disappear",
+            "slug": "disappear",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "disappear"
+            ],
+            "sentence": "The rabbit can disappear into its hole quickly.",
+            "sentences": [
+              "The rabbit can disappear into its hole quickly.",
+              "The stars begin to disappear at dawn.",
+              "My shoe seemed to disappear under the bed.",
+              "The paint marks can disappear after rain.",
+              "He watched the kite disappear into the mist.",
+              "The rabbit might disappear behind the shed.",
+              "The sound will disappear when the door closes.",
+              "Her smile started to disappear when she saw the queue.",
+              "The stain should disappear with soap and water.",
+              "The magician can make the coin disappear."
+            ],
+            "accepted": [
+              "disappear"
+            ],
+            "explanation": "To disappear means to stop being seen or to go away.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 28
+          },
+          {
+            "year": "3-4",
+            "family": "early",
+            "word": "early",
+            "slug": "early",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "early"
+            ],
+            "sentence": "We left early to avoid traffic.",
+            "sentences": [
+              "We left early to avoid traffic.",
+              "We arrived early for assembly.",
+              "She woke early on Saturday.",
+              "The bus came early this morning.",
+              "I like to finish early.",
+              "He left early to catch the train.",
+              "The early sun warmed the garden.",
+              "The birds sang early in the day.",
+              "We had an early lunch today.",
+              "The early part of the film was calm."
+            ],
+            "accepted": [
+              "early"
+            ],
+            "explanation": "Early means before the usual or expected time.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 29
+          },
+          {
+            "year": "3-4",
+            "family": "earth",
+            "word": "earth",
+            "slug": "earth",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "earth"
+            ],
+            "sentence": "Plants grow in rich earth.",
+            "sentences": [
+              "Plants grow in rich earth.",
+              "The earth moves around the sun.",
+              "We can protect the earth by recycling.",
+              "The earth felt damp after the rain.",
+              "Seeds grow in the earth.",
+              "The earth looked blue from space.",
+              "Keep the earth loose in the pot.",
+              "The earth shook during the storm.",
+              "There is life all over the earth.",
+              "The earth needs clean air and water."
+            ],
+            "accepted": [
+              "earth"
+            ],
+            "explanation": "Earth can mean the planet we live on, or soil and ground.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 30
+          },
+          {
+            "year": "3-4",
+            "family": "eight/eighth",
+            "word": "eight",
+            "slug": "eight",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "eight",
+              "eighth"
+            ],
+            "sentence": "There were eight apples in the bowl.",
+            "sentences": [
+              "There were eight apples in the bowl.",
+              "I can name eight planets in our solar system.",
+              "Mum bought eight rolls for lunch.",
+              "The class lined up in eight pairs.",
+              "He counted eight shells on the beach.",
+              "We need eight chairs for the concert.",
+              "The trip starts at eight o'clock.",
+              "She drew eight stars on the poster.",
+              "Our team scored eight points before half-time.",
+              "The baker sold eight loaves before noon."
+            ],
+            "accepted": [
+              "eight"
+            ],
+            "explanation": "Eight is the number after seven and before nine.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 31
+          },
+          {
+            "year": "3-4",
+            "family": "eight/eighth",
+            "word": "eighth",
+            "slug": "eighth",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "eight",
+              "eighth"
+            ],
+            "sentence": "She finished eighth in the swimming race.",
+            "sentences": [
+              "She finished eighth in the swimming race.",
+              "His birthday is on the eighth of June.",
+              "We read the eighth chapter today.",
+              "The eighth runner wore a blue vest.",
+              "I placed the eighth sticker in the corner.",
+              "The eighth page was folded over.",
+              "Our classroom is the eighth door along the corridor.",
+              "He was the eighth child to arrive.",
+              "The eighth question was the hardest.",
+              "The band marched eighth in the parade."
+            ],
+            "accepted": [
+              "eighth"
+            ],
+            "explanation": "Eighth means number eight in order.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 32
+          },
+          {
+            "year": "3-4",
+            "family": "enough",
+            "word": "enough",
+            "slug": "enough",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "enough"
+            ],
+            "sentence": "We have enough chairs for everyone.",
+            "sentences": [
+              "We have enough chairs for everyone.",
+              "We have enough pencils for everyone.",
+              "Is there enough milk for tea?",
+              "She worked hard enough to pass.",
+              "The soup is hot enough now.",
+              "I do not feel brave enough yet.",
+              "There was enough time to finish.",
+              "The bag is big enough for books.",
+              "They ran fast enough to win.",
+              "The class had enough chairs."
+            ],
+            "accepted": [
+              "enough"
+            ],
+            "explanation": "Enough means as much or as many as needed.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 33
+          },
+          {
+            "year": "3-4",
+            "family": "exercise",
+            "word": "exercise",
+            "slug": "exercise",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "exercise"
+            ],
+            "sentence": "Daily exercise helps you stay healthy.",
+            "sentences": [
+              "Daily exercise helps you stay healthy.",
+              "Daily exercise helps us stay healthy.",
+              "We did an exercise on fractions.",
+              "She needs more exercise after school.",
+              "The exercise was easy to follow.",
+              "He forgot his exercise book at home.",
+              "Stretching is a good exercise before sport.",
+              "The exercise finished early.",
+              "The teacher set a reading exercise.",
+              "Walk to school for some exercise."
+            ],
+            "accepted": [
+              "exercise"
+            ],
+            "explanation": "Exercise is physical activity that keeps your body healthy, or a task for practice.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 34
+          },
+          {
+            "year": "3-4",
+            "family": "experience",
+            "word": "experience",
+            "slug": "experience",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "experience"
+            ],
+            "sentence": "It was my first experience of camping.",
+            "sentences": [
+              "It was my first experience of camping.",
+              "She has experience of working with children.",
+              "His experience at the camp was fun.",
+              "We learned from experience.",
+              "She gained experience in the kitchen.",
+              "My experience of the trip was exciting.",
+              "The guide has experience with maps.",
+              "I want more experience before I help.",
+              "Their experience taught them to be careful.",
+              "The team shared experience after the match."
+            ],
+            "accepted": [
+              "experience"
+            ],
+            "explanation": "Experience is something that happens to you, or knowledge you gain by doing something.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 35
+          },
+          {
+            "year": "3-4",
+            "family": "experiment",
+            "word": "experiment",
+            "slug": "experiment",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "experiment"
+            ],
+            "sentence": "The class did a science experiment.",
+            "sentences": [
+              "The class did a science experiment.",
+              "We will experiment with different seeds in the school garden.",
+              "The class planned an experiment to test how ice melts.",
+              "Mia recorded every result after the experiment.",
+              "Our science experiment used water, salt, and paper.",
+              "The experiment showed that warm air rises.",
+              "Before the experiment, the teacher checked the safety rules.",
+              "Each group wrote a prediction for the experiment.",
+              "The experiment helped us learn about magnets.",
+              "After the experiment, we cleaned the desks carefully."
+            ],
+            "accepted": [
+              "experiment"
+            ],
+            "explanation": "An experiment is a careful test to find out what happens or whether an idea is true.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 36
+          },
+          {
+            "year": "3-4",
+            "family": "extreme",
+            "word": "extreme",
+            "slug": "extreme",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "extreme"
+            ],
+            "sentence": "The weather was extreme during the storm.",
+            "sentences": [
+              "The weather was extreme during the storm.",
+              "The extreme cold made the pond freeze overnight.",
+              "The extreme heat pushed us to sit in the shade.",
+              "She used extreme care when carrying the glass jar.",
+              "The storm caused extreme waves on the coast.",
+              "Dad checked the road during extreme fog.",
+              "The walk felt extreme because the hill was so steep.",
+              "The mountain pass had extreme weather in winter.",
+              "The runners slowed down in extreme heat.",
+              "We needed coats because the extreme wind was biting."
+            ],
+            "accepted": [
+              "extreme"
+            ],
+            "explanation": "Extreme means very great, strong or far from the usual.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 37
+          },
+          {
+            "year": "3-4",
+            "family": "famous",
+            "word": "famous",
+            "slug": "famous",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "famous"
+            ],
+            "sentence": "That actor is famous around the world.",
+            "sentences": [
+              "That actor is famous around the world.",
+              "The museum is famous for its dinosaur bones.",
+              "The town is famous for its old bridge.",
+              "Our class read about a famous explorer.",
+              "The singer became famous after the concert.",
+              "The castle is famous with visitors from many countries.",
+              "That footballer is famous across the world.",
+              "The school choir sang a song by a famous composer.",
+              "The park is famous for its bright spring flowers.",
+              "We saw a famous painting on the trip."
+            ],
+            "accepted": [
+              "famous"
+            ],
+            "explanation": "Famous means known by many people.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 38
+          },
+          {
+            "year": "3-4",
+            "family": "favourite",
+            "word": "favourite",
+            "slug": "favourite",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "favourite"
+            ],
+            "sentence": "Blue is my favourite colour.",
+            "sentences": [
+              "Blue is my favourite colour.",
+              "My favourite book is on the shelf.",
+              "Jam is my favourite topping on toast.",
+              "Ben chose his favourite seat by the window.",
+              "Sunday is my favourite day of the week.",
+              "That blue jumper is her favourite one.",
+              "Our favourite game is hide and seek.",
+              "The teacher asked for our favourite story.",
+              "Pizza is my favourite dinner on Fridays.",
+              "We visited my favourite park after school."
+            ],
+            "accepted": [
+              "favourite"
+            ],
+            "explanation": "Favourite means liked best.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 39
+          },
+          {
+            "year": "3-4",
+            "family": "February",
+            "word": "February",
+            "slug": "february",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "February"
+            ],
+            "sentence": "My birthday is in February.",
+            "sentences": [
+              "My birthday is in February.",
+              "February is a short month.",
+              "In February, we saw snow on the hill.",
+              "The school trip is planned for February.",
+              "February often brings cold mornings.",
+              "We made cards for February half term.",
+              "Mum checked the calendar for February.",
+              "Our class project starts in February.",
+              "February was busy for the football team.",
+              "The last day of February arrived quickly."
+            ],
+            "accepted": [
+              "february"
+            ],
+            "explanation": "February is the second month of the year.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 40
+          },
+          {
+            "year": "3-4",
+            "family": "forward(s)",
+            "word": "forward",
+            "slug": "forward",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "forward",
+              "forwards"
+            ],
+            "sentence": "Take one step forward.",
+            "sentences": [
+              "Take one step forward.",
+              "Step forward when your name is called.",
+              "The team moved forward after the break.",
+              "She leaned forward to hear the answer.",
+              "Keep the bike moving forward on the path.",
+              "Ben ran forward to catch the ball.",
+              "We looked forward to the school trip.",
+              "The story moved forward to a new day.",
+              "Please push the box forward a little.",
+              "Think forward before you choose."
+            ],
+            "accepted": [
+              "forward"
+            ],
+            "explanation": "Forward means towards the front or ahead.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 41
+          },
+          {
+            "year": "3-4",
+            "family": "forward(s)",
+            "word": "forwards",
+            "slug": "forwards",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "forward",
+              "forwards"
+            ],
+            "sentence": "The duck swam forwards across the pond.",
+            "sentences": [
+              "The duck swam forwards across the pond.",
+              "The class walked forwards in a neat line.",
+              "Please move the chair forwards a little.",
+              "She stepped forwards to read her poem.",
+              "The bus rolled forwards at the stop.",
+              "Tom pushed the tray forwards on the table.",
+              "We edged forwards to see the stage.",
+              "The duck waddled forwards to the pond.",
+              "Keep your hands forwards when you catch the ball.",
+              "The car moved forwards slowly."
+            ],
+            "accepted": [
+              "forwards"
+            ],
+            "explanation": "Forwards means towards the front or ahead.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 42
+          },
+          {
+            "year": "3-4",
+            "family": "fruit",
+            "word": "fruit",
+            "slug": "fruit",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "fruit"
+            ],
+            "sentence": "We packed fresh fruit for the picnic.",
+            "sentences": [
+              "We packed fresh fruit for the picnic.",
+              "Apples are a healthy fruit for lunch.",
+              "The bowl of fruit looked bright and fresh.",
+              "We added fruit to our cereal.",
+              "Mango is my favourite fruit.",
+              "The market sold ripe fruit from local farms.",
+              "She packed fruit in her school bag.",
+              "The smoothie had banana and fruit in it.",
+              "Every child chose a piece of fruit.",
+              "We cut up fruit for the picnic."
+            ],
+            "accepted": [
+              "fruit"
+            ],
+            "explanation": "Fruit is the part of a plant that often has seeds and can be eaten, such as an apple.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 43
+          },
+          {
+            "year": "3-4",
+            "family": "grammar",
+            "word": "grammar",
+            "slug": "grammar",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "grammar"
+            ],
+            "sentence": "Good grammar makes writing clearer.",
+            "sentences": [
+              "Good grammar makes writing clearer.",
+              "Good grammar helps readers understand writing.",
+              "He checked the grammar in his story.",
+              "The class learned a new grammar rule.",
+              "Poor grammar can make a sentence confusing.",
+              "We talked about grammar before writing a letter.",
+              "The book has a section on grammar.",
+              "She used correct grammar in her answer.",
+              "Clear grammar makes the meaning easier to follow.",
+              "The guide explains grammar with simple examples."
+            ],
+            "accepted": [
+              "grammar"
+            ],
+            "explanation": "Grammar is the set of rules for how words fit together in a language.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 44
+          },
+          {
+            "year": "3-4",
+            "family": "group",
+            "word": "group",
+            "slug": "group",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "group"
+            ],
+            "sentence": "Our group worked on the poster together.",
+            "sentences": [
+              "Our group worked on the poster together.",
+              "Our group worked quietly at the table.",
+              "The group shared the art supplies.",
+              "Each group presented a different idea.",
+              "I joined a reading group after school.",
+              "The group walked to the hall together.",
+              "We asked one group to tidy the books.",
+              "A small group waited by the gate.",
+              "The group chose a name for the project.",
+              "The class split into a study group."
+            ],
+            "accepted": [
+              "group"
+            ],
+            "explanation": "A group is a number of people or things together.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 45
+          },
+          {
+            "year": "3-4",
+            "family": "guard",
+            "word": "guard",
+            "slug": "guard",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "guard"
+            ],
+            "sentence": "A guard stood by the gate.",
+            "sentences": [
+              "A guard stood by the gate.",
+              "The guard stood by the gate.",
+              "A guard checked the entrance to the museum.",
+              "We saw a guard outside the castle.",
+              "The guard opened the door for visitors.",
+              "The guard wore a bright coat.",
+              "A night guard kept watch in the car park.",
+              "The guard smiled at the children.",
+              "The guard asked us to stay behind the line.",
+              "The castle guard told a short story."
+            ],
+            "accepted": [
+              "guard"
+            ],
+            "explanation": "To guard means to protect or watch over someone or something.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 46
+          },
+          {
+            "year": "3-4",
+            "family": "guide",
+            "word": "guide",
+            "slug": "guide",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "guide"
+            ],
+            "sentence": "The map will guide us home.",
+            "sentences": [
+              "The map will guide us home.",
+              "Our guide showed us the old church.",
+              "The guide led the class through the gallery.",
+              "A guide explained the rules at the zoo.",
+              "We followed the guide across the bridge.",
+              "The guide pointed to the mountain peak.",
+              "She used a guide to plan the walk.",
+              "The guide spoke clearly and kindly.",
+              "Our guide told us where to meet.",
+              "A guide helped the visitors understand the map."
+            ],
+            "accepted": [
+              "guide"
+            ],
+            "explanation": "A guide is someone or something that shows the way or gives helpful information.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 47
+          },
+          {
+            "year": "3-4",
+            "family": "heard",
+            "word": "heard",
+            "slug": "heard",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "heard"
+            ],
+            "sentence": "I heard thunder after the flash of lightning.",
+            "sentences": [
+              "I heard thunder after the flash of lightning.",
+              "We heard the bell from the playground.",
+              "She heard footsteps in the corridor.",
+              "I heard the birds before I saw them.",
+              "He heard his name across the field.",
+              "We heard the news on the radio.",
+              "Dad heard the door slam downstairs.",
+              "The class heard music from the hall.",
+              "I heard a whisper behind me.",
+              "They heard rain tapping on the roof."
+            ],
+            "accepted": [
+              "heard"
+            ],
+            "explanation": "Heard is the past tense of hear; it means listened to or noticed a sound.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 48
+          },
+          {
+            "year": "3-4",
+            "family": "heart",
+            "word": "heart",
+            "slug": "heart",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "heart"
+            ],
+            "sentence": "The doctor listened to her heart with a stethoscope.",
+            "sentences": [
+              "The doctor listened to her heart with a stethoscope.",
+              "My heart beat faster before the race.",
+              "Exercise helps to keep your heart strong.",
+              "She drew a red heart on the card.",
+              "He placed his hand over his heart.",
+              "The nurse checked his heart after the fall.",
+              "Fear made my heart thump loudly.",
+              "The poster showed how the heart pumps blood.",
+              "A healthy heart needs regular exercise.",
+              "Her heart was pounding at the start line."
+            ],
+            "accepted": [
+              "heart"
+            ],
+            "explanation": "The heart is the organ that pumps blood around the body; it can also mean feelings.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 49
+          },
+          {
+            "year": "3-4",
+            "family": "height",
+            "word": "height",
+            "slug": "height",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "height"
+            ],
+            "sentence": "We measured the height of the plant.",
+            "sentences": [
+              "We measured the height of the plant.",
+              "The height of the tree surprised us.",
+              "We measured the height of the box.",
+              "His height made it easy to reach the shelf.",
+              "The teacher wrote the height on the board.",
+              "The height of the hill made us breathe hard.",
+              "Please check the height before you jump.",
+              "The height of the curtain was just right.",
+              "Her height changed a lot this year.",
+              "We compared the height of the two towers."
+            ],
+            "accepted": [
+              "height"
+            ],
+            "explanation": "Height is how tall or high something is.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 50
+          },
+          {
+            "year": "3-4",
+            "family": "history",
+            "word": "history",
+            "slug": "history",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "history"
+            ],
+            "sentence": "We learned about Roman history.",
+            "sentences": [
+              "We learned about Roman history.",
+              "We learn history on Fridays.",
+              "The lesson on history was interesting.",
+              "Our school museum has local history.",
+              "She wrote a report about history.",
+              "The castle has a long history.",
+              "The class watched a film about history.",
+              "I enjoy history because it tells stories.",
+              "The book covers Roman history.",
+              "We studied history in the library."
+            ],
+            "accepted": [
+              "history"
+            ],
+            "explanation": "History is the study of things that happened in the past.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 51
+          },
+          {
+            "year": "3-4",
+            "family": "imagine",
+            "word": "imagine",
+            "slug": "imagine",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "imagine"
+            ],
+            "sentence": "Imagine living in a tree house.",
+            "sentences": [
+              "Imagine living in a tree house.",
+              "Imagine a castle made of ice.",
+              "Can you imagine living on a farm?",
+              "I imagine the trip will be fun.",
+              "Imagine a dog with bright blue spots.",
+              "We can imagine the answer before we check.",
+              "Try to imagine the view from the hill.",
+              "I imagine the pond is deep.",
+              "Imagine your own story ending.",
+              "Can you imagine a world without books?"
+            ],
+            "accepted": [
+              "imagine"
+            ],
+            "explanation": "To imagine means to make a picture or idea in your mind.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 52
+          },
+          {
+            "year": "3-4",
+            "family": "increase",
+            "word": "increase",
+            "slug": "increase",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "increase"
+            ],
+            "sentence": "The price may increase next month.",
+            "sentences": [
+              "The price may increase next month.",
+              "We saw an increase in bird numbers.",
+              "Please increase the volume a little.",
+              "The class recorded an increase in scores.",
+              "An increase in rain made the path muddy.",
+              "We hope to increase our reading time.",
+              "The school plans to increase the number of clubs.",
+              "A small increase can still help.",
+              "The coach wants to increase our stamina.",
+              "Scientists noticed an increase in daylight."
+            ],
+            "accepted": [
+              "increase"
+            ],
+            "explanation": "To increase means to become bigger in number, size or amount.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 53
+          },
+          {
+            "year": "3-4",
+            "family": "important",
+            "word": "important",
+            "slug": "important",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "important"
+            ],
+            "sentence": "It is important to listen carefully.",
+            "sentences": [
+              "It is important to listen carefully.",
+              "It is important to wear a helmet.",
+              "Reading is important for every child.",
+              "The teacher said water is important on hot days.",
+              "The notice was important for the trip.",
+              "Family time is important to me.",
+              "The instructions are important for safety.",
+              "It is important to finish your work.",
+              "Sleep is important before a busy day.",
+              "The sign gives an important message."
+            ],
+            "accepted": [
+              "important"
+            ],
+            "explanation": "Important means having great value or needing attention.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 54
+          },
+          {
+            "year": "3-4",
+            "family": "interest",
+            "word": "interest",
+            "slug": "interest",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "interest"
+            ],
+            "sentence": "Space is a special interest of his.",
+            "sentences": [
+              "Space is a special interest of his.",
+              "The book caught my interest at once.",
+              "I have a strong interest in science.",
+              "The lesson was full of interest.",
+              "Her interest in birds grew over time.",
+              "The museum display held our interest.",
+              "He showed interest in the football club.",
+              "My interest in maps started last year.",
+              "The class shared interest in space.",
+              "Her interest in music is growing."
+            ],
+            "accepted": [
+              "interest"
+            ],
+            "explanation": "Interest is a feeling of wanting to know or learn more about something.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 55
+          },
+          {
+            "year": "3-4",
+            "family": "island",
+            "word": "island",
+            "slug": "island",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "island"
+            ],
+            "sentence": "They sailed to a small island.",
+            "sentences": [
+              "They sailed to a small island.",
+              "We saw an island in the distance.",
+              "The island has sandy beaches.",
+              "Our map showed a small island.",
+              "We sailed to the island at dawn.",
+              "The island was quiet and green.",
+              "Birds nested on the island.",
+              "The island had one narrow road.",
+              "We read about an island adventure.",
+              "Fishermen lived near the island."
+            ],
+            "accepted": [
+              "island"
+            ],
+            "explanation": "An island is land with water all around it.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 56
+          },
+          {
+            "year": "3-4",
+            "family": "knowledge",
+            "word": "knowledge",
+            "slug": "knowledge",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "knowledge"
+            ],
+            "sentence": "Her knowledge of animals is impressive.",
+            "sentences": [
+              "Her knowledge of animals is impressive.",
+              "Knowledge helps us solve problems.",
+              "The lesson added to my knowledge.",
+              "We shared knowledge about plants.",
+              "Her knowledge of animals is strong.",
+              "Good knowledge comes from reading.",
+              "The quiz tested our knowledge.",
+              "He used his knowledge to fix the bike.",
+              "Our knowledge grew after the trip.",
+              "The teacher valued every bit of knowledge."
+            ],
+            "accepted": [
+              "knowledge"
+            ],
+            "explanation": "Knowledge is what you know and understand.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 57
+          },
+          {
+            "year": "3-4",
+            "family": "learn",
+            "word": "learn",
+            "slug": "learn",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "learn"
+            ],
+            "sentence": "We learn something new every day.",
+            "sentences": [
+              "We learn something new every day.",
+              "We learn new words every week.",
+              "I learn best with pictures.",
+              "The class will learn about rivers.",
+              "Children learn from reading aloud.",
+              "We learn how to stay safe online.",
+              "She wanted to learn a song.",
+              "I learn by asking questions.",
+              "The group can learn together.",
+              "We learn from our mistakes."
+            ],
+            "accepted": [
+              "learn"
+            ],
+            "explanation": "To learn means to gain knowledge or a skill.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 58
+          },
+          {
+            "year": "3-4",
+            "family": "length",
+            "word": "length",
+            "slug": "length",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "length"
+            ],
+            "sentence": "Measure the length of the table.",
+            "sentences": [
+              "Measure the length of the table.",
+              "Measure the length of the ribbon.",
+              "The length of the table is two metres.",
+              "We compared the length of both ropes.",
+              "The teacher asked for the length of the line.",
+              "The length of the journey was tiring.",
+              "Please write the length in centimetres.",
+              "The length of the hall surprised us.",
+              "We checked the length before cutting the paper.",
+              "The length of the scarf was just right."
+            ],
+            "accepted": [
+              "length"
+            ],
+            "explanation": "Length is how long something is from one end to the other.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 59
+          },
+          {
+            "year": "3-4",
+            "family": "library",
+            "word": "library",
+            "slug": "library",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "library"
+            ],
+            "sentence": "We borrowed books from the library.",
+            "sentences": [
+              "We borrowed books from the library.",
+              "The library was quiet after lunch.",
+              "Our class visited the library on Monday.",
+              "The library has a new reading corner.",
+              "She returned her book to the library.",
+              "The library closed early on Friday.",
+              "We found the atlas in the library.",
+              "The library display showed local authors.",
+              "I enjoy the library because it is calm.",
+              "The library shelf held many stories."
+            ],
+            "accepted": [
+              "library"
+            ],
+            "explanation": "A library is a place where books and information are kept for people to use.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 60
+          },
+          {
+            "year": "3-4",
+            "family": "material",
+            "word": "material",
+            "slug": "material",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "material"
+            ],
+            "sentence": "This bag is made from strong material.",
+            "sentences": [
+              "This bag is made from strong material.",
+              "This material feels soft and warm.",
+              "The dress is made from a light material.",
+              "We chose a strong material for the model.",
+              "The roof material keeps out rain.",
+              "The artist used a shiny material.",
+              "The material on the table is waterproof.",
+              "We sorted each material into a box.",
+              "Cotton is a natural material.",
+              "The teacher showed us a new material."
+            ],
+            "accepted": [
+              "material"
+            ],
+            "explanation": "Material is the substance something is made from, such as cotton, wood or metal.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 61
+          },
+          {
+            "year": "3-4",
+            "family": "medicine",
+            "word": "medicine",
+            "slug": "medicine",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "medicine"
+            ],
+            "sentence": "The doctor gave her medicine.",
+            "sentences": [
+              "The doctor gave her medicine.",
+              "The doctor gave me medicine for my cough.",
+              "Keep the medicine in a safe place.",
+              "Mum measured the medicine carefully.",
+              "The medicine tasted bitter.",
+              "A nurse brought the medicine to the ward.",
+              "We read the label on the medicine.",
+              "The medicine helped him feel better.",
+              "The shelf held every medicine in order.",
+              "You must take the medicine after food."
+            ],
+            "accepted": [
+              "medicine"
+            ],
+            "explanation": "Medicine is something used to help treat illness or pain.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 62
+          },
+          {
+            "year": "3-4",
+            "family": "mention",
+            "word": "mention",
+            "slug": "mention",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "mention"
+            ],
+            "sentence": "Please do not mention the surprise.",
+            "sentences": [
+              "Please do not mention the surprise.",
+              "Please mention your answer in the letter.",
+              "I did not mention the problem at first.",
+              "The teacher will mention the trip tomorrow.",
+              "Can you mention my name to the group?",
+              "The report did not mention the rain.",
+              "She wanted to mention the new club.",
+              "He forgot to mention the homework.",
+              "We may mention the book in class.",
+              "The note did mention the meeting time."
+            ],
+            "accepted": [
+              "mention"
+            ],
+            "explanation": "To mention means to say something briefly.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 63
+          },
+          {
+            "year": "3-4",
+            "family": "minute",
+            "word": "minute",
+            "slug": "minute",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "minute"
+            ],
+            "sentence": "Wait a minute while I tie my shoe.",
+            "sentences": [
+              "Wait a minute while I tie my shoe.",
+              "Wait one minute before you open it.",
+              "The clock ticked every minute.",
+              "We took a minute to think.",
+              "The minute hand moved slowly.",
+              "She was late by a minute.",
+              "The task took only a minute.",
+              "In a minute, the bell will ring.",
+              "He checked the time every minute.",
+              "The minute we arrived, it started to rain."
+            ],
+            "accepted": [
+              "minute"
+            ],
+            "explanation": "A minute is a period of sixty seconds.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 64
+          },
+          {
+            "year": "3-4",
+            "family": "natural",
+            "word": "natural",
+            "slug": "natural",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "natural"
+            ],
+            "sentence": "Honey is a natural sweetener.",
+            "sentences": [
+              "Honey is a natural sweetener.",
+              "Fresh air feels natural.",
+              "The leaves had a natural green colour.",
+              "It is natural to ask questions.",
+              "The path looked natural in the wood.",
+              "Her smile looked natural in the photo.",
+              "We used natural light near the window.",
+              "The river followed a natural route.",
+              "He chose a natural voice for the play.",
+              "The field looked natural after the rain."
+            ],
+            "accepted": [
+              "natural"
+            ],
+            "explanation": "Natural means found in nature or not made by people.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 65
+          },
+          {
+            "year": "3-4",
+            "family": "naughty",
+            "word": "naughty",
+            "slug": "naughty",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "naughty"
+            ],
+            "sentence": "The puppy was naughty and chewed the slipper.",
+            "sentences": [
+              "The puppy was naughty and chewed the slipper.",
+              "The naughty puppy hid my shoe.",
+              "A naughty child wrote on the desk.",
+              "The naughty cat jumped on the counter.",
+              "He gave a naughty grin.",
+              "The naughty wind blew my hat away.",
+              "The naughty class giggled during assembly.",
+              "Our naughty dog dug in the garden.",
+              "She played a naughty prank at lunch.",
+              "The naughty rabbit escaped from the pen."
+            ],
+            "accepted": [
+              "naughty"
+            ],
+            "explanation": "Naughty means behaving badly or not following rules.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 66
+          },
+          {
+            "year": "3-4",
+            "family": "notice",
+            "word": "notice",
+            "slug": "notice",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "notice"
+            ],
+            "sentence": "Did you notice the rainbow.",
+            "sentences": [
+              "Did you notice the rainbow.",
+              "I notice the clock on the wall.",
+              "We notice the signs by the path.",
+              "The teacher asked us to notice the details.",
+              "Please notice the change in colour.",
+              "She did not notice the missing pen.",
+              "I notice a star in the sky.",
+              "They notice the quiet room at once.",
+              "We notice how the leaves move.",
+              "He will notice the new display."
+            ],
+            "accepted": [
+              "notice"
+            ],
+            "explanation": "To notice means to see, hear or become aware of something.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 67
+          },
+          {
+            "year": "3-4",
+            "family": "occasion(ally)",
+            "word": "occasion",
+            "slug": "occasion",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "occasion",
+              "occasionally"
+            ],
+            "sentence": "The party was a special occasion.",
+            "sentences": [
+              "The party was a special occasion.",
+              "The picnic was a happy occasion.",
+              "Birthdays are a special occasion.",
+              "We wore smart clothes for the occasion.",
+              "The ceremony was a proud occasion.",
+              "A school concert is a great occasion.",
+              "On this occasion, the team won.",
+              "The occasion called for a speech.",
+              "It was a rare occasion to see snow.",
+              "The cake was made for the occasion."
+            ],
+            "accepted": [
+              "occasion"
+            ],
+            "explanation": "An occasion is a particular time when something happens, often something special.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 68
+          },
+          {
+            "year": "3-4",
+            "family": "occasion(ally)",
+            "word": "occasionally",
+            "slug": "occasionally",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "occasion",
+              "occasionally"
+            ],
+            "sentence": "We occasionally eat dinner in the garden.",
+            "sentences": [
+              "We occasionally eat dinner in the garden.",
+              "We occasionally visit the seaside.",
+              "She occasionally reads in the garden.",
+              "I occasionally forget my water bottle.",
+              "We occasionally hear owls at night.",
+              "Dad occasionally cooks pasta on Fridays.",
+              "The bus is occasionally late.",
+              "They occasionally play chess after school.",
+              "I occasionally help at the library.",
+              "We occasionally watch a film together."
+            ],
+            "accepted": [
+              "occasionally"
+            ],
+            "explanation": "Occasionally means sometimes, but not often.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 69
+          },
+          {
+            "year": "3-4",
+            "family": "often",
+            "word": "often",
+            "slug": "often",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "often"
+            ],
+            "sentence": "We often visit the park after school.",
+            "sentences": [
+              "We often visit the park after school.",
+              "We often walk to school.",
+              "She often reads before bed.",
+              "I often spot deer near the woods.",
+              "I often see rabbits in the field.",
+              "Dad often makes tea after work.",
+              "We often visit the park.",
+              "The dog often sits by the door.",
+              "I often need a second look.",
+              "They often play outside at break time."
+            ],
+            "accepted": [
+              "often"
+            ],
+            "explanation": "Often means many times or frequently.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 70
+          },
+          {
+            "year": "3-4",
+            "family": "opposite",
+            "word": "opposite",
+            "slug": "opposite",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "opposite"
+            ],
+            "sentence": "The shop is opposite the station.",
+            "sentences": [
+              "The shop is opposite the station.",
+              "The shop is opposite the post office.",
+              "We sat opposite the stage.",
+              "Her desk is opposite mine.",
+              "The car stopped opposite the gate.",
+              "I walked opposite the cafe.",
+              "The mirror is opposite the window.",
+              "They live opposite the school.",
+              "The path runs opposite the river.",
+              "Our seats were opposite each other."
+            ],
+            "accepted": [
+              "opposite"
+            ],
+            "explanation": "Opposite means completely different or facing the other way.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 71
+          },
+          {
+            "year": "3-4",
+            "family": "ordinary",
+            "word": "ordinary",
+            "slug": "ordinary",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "ordinary"
+            ],
+            "sentence": "It was an ordinary school day.",
+            "sentences": [
+              "It was an ordinary school day.",
+              "It was an ordinary day at school.",
+              "We ate an ordinary lunch in the hall.",
+              "The box looked ordinary, but it held a prize.",
+              "She wore an ordinary coat to stay warm.",
+              "The story began in an ordinary village.",
+              "He chose an ordinary pencil for the test.",
+              "Our class had an ordinary assembly on Monday.",
+              "They sat at an ordinary wooden table.",
+              "The room seemed ordinary until the lights changed."
+            ],
+            "accepted": [
+              "ordinary"
+            ],
+            "explanation": "Ordinary means normal, usual or not special.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 72
+          },
+          {
+            "year": "3-4",
+            "family": "particular",
+            "word": "particular",
+            "slug": "particular",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "particular"
+            ],
+            "sentence": "She was looking for one particular book.",
+            "sentences": [
+              "She was looking for one particular book.",
+              "She had a particular way of tying her shoes.",
+              "We need a particular size for the box.",
+              "He chose a particular book from the shelf.",
+              "The teacher had a particular rule for tidy work.",
+              "I remember one particular day very well.",
+              "They wanted a particular shade of blue.",
+              "Mum asked for a particular answer.",
+              "The dog likes one particular ball.",
+              "There was a particular smell in the kitchen."
+            ],
+            "accepted": [
+              "particular"
+            ],
+            "explanation": "Particular means a specific one, not just any one.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 73
+          },
+          {
+            "year": "3-4",
+            "family": "peculiar",
+            "word": "peculiar",
+            "slug": "peculiar",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "peculiar"
+            ],
+            "sentence": "There was a peculiar smell in the room.",
+            "sentences": [
+              "There was a peculiar smell in the room.",
+              "The old house had a peculiar sound at night.",
+              "He wore a peculiar hat to the party.",
+              "The cake had a peculiar taste.",
+              "She noticed a peculiar mark on the wall.",
+              "It felt peculiar to walk in silence.",
+              "The bird made a peculiar call.",
+              "He gave a peculiar smile after the joke.",
+              "We found a peculiar stone by the path.",
+              "The room had a peculiar smell of paint."
+            ],
+            "accepted": [
+              "peculiar"
+            ],
+            "explanation": "Peculiar means strange or unusual.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 74
+          },
+          {
+            "year": "3-4",
+            "family": "perhaps",
+            "word": "perhaps",
+            "slug": "perhaps",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "perhaps"
+            ],
+            "sentence": "Perhaps it will snow tonight.",
+            "sentences": [
+              "Perhaps it will snow tonight.",
+              "I think perhaps we should leave earlier.",
+              "The train will perhaps be on time.",
+              "She perhaps forgot her bag at home.",
+              "I can perhaps help after lunch.",
+              "The rain may perhaps stop soon.",
+              "They perhaps chose the wrong path.",
+              "You should perhaps ask the teacher.",
+              "The answer may perhaps be under the book.",
+              "We will perhaps visit the museum tomorrow."
+            ],
+            "accepted": [
+              "perhaps"
+            ],
+            "explanation": "Perhaps means maybe or possibly.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 75
+          },
+          {
+            "year": "3-4",
+            "family": "popular",
+            "word": "popular",
+            "slug": "popular",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "popular"
+            ],
+            "sentence": "Football is popular at our school.",
+            "sentences": [
+              "Football is popular at our school.",
+              "The park is a popular place to play.",
+              "That song is popular with our class.",
+              "Apples are a popular snack at break time.",
+              "The new comic was very popular.",
+              "The library is a popular spot after school.",
+              "Football is a popular game in our town.",
+              "Her ideas became popular quickly.",
+              "The seaside town is popular in summer.",
+              "That shoe style was popular last year."
+            ],
+            "accepted": [
+              "popular"
+            ],
+            "explanation": "Popular means liked or enjoyed by many people.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 76
+          },
+          {
+            "year": "3-4",
+            "family": "position",
+            "word": "position",
+            "slug": "position",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "position"
+            ],
+            "sentence": "Move your chair into position.",
+            "sentences": [
+              "Move your chair into position.",
+              "She moved into position behind the rope.",
+              "The coach changed his position on the team.",
+              "Please hold your position in the line.",
+              "He found a better position near the window.",
+              "The map showed the position of the castle.",
+              "We took our position for the photograph.",
+              "The dancer kept her position with care.",
+              "His position on the chair was uncomfortable.",
+              "They studied the position of the stars."
+            ],
+            "accepted": [
+              "position"
+            ],
+            "explanation": "Position is where something is, or the way it is placed.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 77
+          },
+          {
+            "year": "3-4",
+            "family": "possess(ion)",
+            "word": "possess",
+            "slug": "possess",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "possess",
+              "possession"
+            ],
+            "sentence": "Very few animals possess wings and fur.",
+            "sentences": [
+              "Very few animals possess wings and fur.",
+              "Many people possess a good sense of humour.",
+              "Some birds possess bright feathers.",
+              "You must possess your library card to borrow books.",
+              "A great player must possess skill and patience.",
+              "The castle was said to possess secret tunnels.",
+              "He does not possess a loud voice.",
+              "We all possess different talents.",
+              "The old map may possess clues.",
+              "She seems to possess great confidence."
+            ],
+            "accepted": [
+              "possess"
+            ],
+            "explanation": "To possess something means to own it or have it.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 78
+          },
+          {
+            "year": "3-4",
+            "family": "possess(ion)",
+            "word": "possession",
+            "slug": "possession",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "possess",
+              "possession"
+            ],
+            "sentence": "The medal was his most valued possession.",
+            "sentences": [
+              "The medal was his most valued possession.",
+              "The necklace was in her possession.",
+              "He kept his possession safe in a box.",
+              "The shop returned the lost possession to the child.",
+              "A football is his favourite possession.",
+              "The bag was not in his possession.",
+              "The painting was a precious possession.",
+              "She kept the letter in her possession.",
+              "The key was found in his possession.",
+              "The old watch became a treasured possession."
+            ],
+            "accepted": [
+              "possession"
+            ],
+            "explanation": "A possession is something that you own or have.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 79
+          },
+          {
+            "year": "3-4",
+            "family": "possible",
+            "word": "possible",
+            "slug": "possible",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "possible"
+            ],
+            "sentence": "Is it possible to finish today.",
+            "sentences": [
+              "Is it possible to finish today.",
+              "It is possible to finish before lunch.",
+              "We walked as quietly as possible.",
+              "Please give as much help as possible.",
+              "It is possible that the bus is late.",
+              "Try to make the picture as clear as possible.",
+              "We used every possible clue.",
+              "It is possible to learn from mistakes.",
+              "She made the best possible choice.",
+              "Keep the door open if possible."
+            ],
+            "accepted": [
+              "possible"
+            ],
+            "explanation": "Possible means able to happen or be done.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 80
+          },
+          {
+            "year": "3-4",
+            "family": "potatoes",
+            "word": "potatoes",
+            "slug": "potatoes",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "potatoes"
+            ],
+            "sentence": "We planted potatoes in the garden.",
+            "sentences": [
+              "We planted potatoes in the garden.",
+              "Mum boiled the potatoes for dinner.",
+              "We planted potatoes in the school garden.",
+              "The potatoes were soft and warm.",
+              "He mashed the potatoes with butter.",
+              "Roast potatoes smell delicious.",
+              "The farmer loaded sacks of potatoes onto the cart.",
+              "We ate potatoes with our pie.",
+              "The potatoes grew well after the rain.",
+              "She peeled the potatoes carefully."
+            ],
+            "accepted": [
+              "potatoes"
+            ],
+            "explanation": "Potatoes are round root vegetables that grow underground.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 81
+          },
+          {
+            "year": "3-4",
+            "family": "pressure",
+            "word": "pressure",
+            "slug": "pressure",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "pressure"
+            ],
+            "sentence": "The team felt pressure before the final.",
+            "sentences": [
+              "The team felt pressure before the final.",
+              "The lid came off under pressure.",
+              "She felt pressure before the test.",
+              "The pipe burst because of pressure.",
+              "He stayed calm under pressure.",
+              "Too much pressure can break the glass.",
+              "The team faced pressure to win.",
+              "Air pressure changes with the weather.",
+              "She handled the pressure well.",
+              "Water pressure was low in the morning."
+            ],
+            "accepted": [
+              "pressure"
+            ],
+            "explanation": "Pressure is force pushing on something, or stress caused by demands.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 82
+          },
+          {
+            "year": "3-4",
+            "family": "probably",
+            "word": "probably",
+            "slug": "probably",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "probably"
+            ],
+            "sentence": "It will probably rain later.",
+            "sentences": [
+              "It will probably rain later.",
+              "We will probably leave after tea.",
+              "She will probably join the game.",
+              "The cat is probably under the table.",
+              "He will probably read that book again.",
+              "They are probably on the bus now.",
+              "The work will probably take an hour.",
+              "I will probably choose the blue pen.",
+              "The dog is probably asleep upstairs.",
+              "We should probably check the map."
+            ],
+            "accepted": [
+              "probably"
+            ],
+            "explanation": "Probably means very likely to happen or be true.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 83
+          },
+          {
+            "year": "3-4",
+            "family": "promise",
+            "word": "promise",
+            "slug": "promise",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "promise"
+            ],
+            "sentence": "I promise to be on time.",
+            "sentences": [
+              "I promise to be on time.",
+              "I promise to be ready on time.",
+              "She made a promise to help her brother.",
+              "We promise to keep the gate shut.",
+              "He broke his promise to call.",
+              "My promise is to try my best.",
+              "They promise to finish the job today.",
+              "A promise should be kept.",
+              "She gave her promise in writing.",
+              "I promise to listen carefully."
+            ],
+            "accepted": [
+              "promise"
+            ],
+            "explanation": "A promise is a firm statement that you will do something.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 84
+          },
+          {
+            "year": "3-4",
+            "family": "purpose",
+            "word": "purpose",
+            "slug": "purpose",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "purpose"
+            ],
+            "sentence": "The purpose of the trip was to learn about the coast.",
+            "sentences": [
+              "The purpose of the trip was to learn about the coast.",
+              "The purpose of the sign was to keep people safe.",
+              "Every tool in the box has a purpose.",
+              "She spoke with purpose and confidence.",
+              "The purpose of the meeting was clear from the start.",
+              "We use this room for a special purpose.",
+              "His questions had a clear purpose.",
+              "The purpose of the lesson was to compare the two stories.",
+              "A torch has the simple purpose of giving light.",
+              "The bridge was built for one main purpose."
+            ],
+            "accepted": [
+              "purpose"
+            ],
+            "explanation": "Purpose is the reason something exists or is done.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 85
+          },
+          {
+            "year": "3-4",
+            "family": "quarter",
+            "word": "quarter",
+            "slug": "quarter",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "quarter"
+            ],
+            "sentence": "A quarter of the cake was left.",
+            "sentences": [
+              "A quarter of the cake was left.",
+              "We walked a quarter of the way home.",
+              "The cake was cut into a quarter.",
+              "It is a quarter past three.",
+              "The shop is a quarter mile away.",
+              "She found a quarter of the answer.",
+              "A quarter of the class went swimming.",
+              "He paid with a quarter from his pocket.",
+              "The team scored in the first quarter.",
+              "We waited for a quarter of an hour."
+            ],
+            "accepted": [
+              "quarter"
+            ],
+            "explanation": "A quarter is one of four equal parts.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 86
+          },
+          {
+            "year": "3-4",
+            "family": "question",
+            "word": "question",
+            "slug": "question",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "question"
+            ],
+            "sentence": "She asked a thoughtful question.",
+            "sentences": [
+              "She asked a thoughtful question.",
+              "I had a question about the homework.",
+              "She raised her hand to question the rule.",
+              "The question was harder than it looked.",
+              "We asked a question at the end.",
+              "His question helped the class think.",
+              "The teacher answered every question.",
+              "I wrote one question on my card.",
+              "The next question was about history.",
+              "They discussed the question after lunch."
+            ],
+            "accepted": [
+              "question"
+            ],
+            "explanation": "A question is something you ask to find out information.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 87
+          },
+          {
+            "year": "3-4",
+            "family": "recent",
+            "word": "recent",
+            "slug": "recent",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "recent"
+            ],
+            "sentence": "That is a recent photograph.",
+            "sentences": [
+              "That is a recent photograph.",
+              "A recent storm damaged the fence.",
+              "I read a recent report about the floods.",
+              "Her recent work has been very neat.",
+              "The recent rain filled the pond.",
+              "A recent message arrived on my phone.",
+              "We studied recent events in history.",
+              "My recent visit to the museum was great.",
+              "The recent news surprised everyone.",
+              "He talked about a recent trip to Wales."
+            ],
+            "accepted": [
+              "recent"
+            ],
+            "explanation": "Recent means having happened not long ago.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 88
+          },
+          {
+            "year": "3-4",
+            "family": "regular",
+            "word": "regular",
+            "slug": "regular",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "regular"
+            ],
+            "sentence": "He is a regular visitor to the cafe.",
+            "sentences": [
+              "He is a regular visitor to the cafe.",
+              "She has a regular routine before school.",
+              "We make regular visits to the library.",
+              "He is a regular visitor to the park.",
+              "The bus makes a regular stop here.",
+              "They had regular practice on Fridays.",
+              "A regular shape has clear sides.",
+              "Mum checks the dog on a regular basis.",
+              "We eat at regular times each day.",
+              "The teacher liked the regular pattern."
+            ],
+            "accepted": [
+              "regular"
+            ],
+            "explanation": "Regular means happening again and again in the same pattern, or usual.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 89
+          },
+          {
+            "year": "3-4",
+            "family": "reign",
+            "word": "reign",
+            "slug": "reign",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "reign"
+            ],
+            "sentence": "The queen's reign lasted for many years.",
+            "sentences": [
+              "The queen's reign lasted for many years.",
+              "During his reign, the king built a new palace.",
+              "The queen began her reign at a young age.",
+              "Peace returned before the end of the king's reign.",
+              "We learned about the reign of Queen Victoria.",
+              "The ruler's reign brought many changes to the kingdom.",
+              "Songs were written to celebrate the queen's reign.",
+              "The castle was repaired during the king's reign.",
+              "People remembered her reign as fair and wise.",
+              "A new coin was made at the start of his reign."
+            ],
+            "accepted": [
+              "reign"
+            ],
+            "explanation": "A reign is the time when a king or queen rules.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 90
+          },
+          {
+            "year": "3-4",
+            "family": "remember",
+            "word": "remember",
+            "slug": "remember",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "remember"
+            ],
+            "sentence": "Please remember your lunch box.",
+            "sentences": [
+              "Please remember your lunch box.",
+              "Please remember your coat.",
+              "I remember the trip clearly.",
+              "She will remember his kind words.",
+              "We remember to feed the rabbit.",
+              "He did not remember the answer.",
+              "I remember where I left my bag.",
+              "Please remember to close the door.",
+              "They remember that story every winter.",
+              "She will remember her first day at school."
+            ],
+            "accepted": [
+              "remember"
+            ],
+            "explanation": "To remember means to keep something in your mind or bring it back to mind.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 91
+          },
+          {
+            "year": "3-4",
+            "family": "sentence",
+            "word": "sentence",
+            "slug": "sentence",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "sentence"
+            ],
+            "sentence": "Write each answer in a full sentence.",
+            "sentences": [
+              "Write each answer in a full sentence.",
+              "Write a clear sentence for the test.",
+              "The teacher asked for one sentence.",
+              "He said the sentence aloud.",
+              "Please copy the sentence neatly.",
+              "She joined two ideas in one sentence.",
+              "The sentence was long but simple.",
+              "I underlined the key sentence.",
+              "We built a sentence together.",
+              "The last sentence made everyone smile."
+            ],
+            "accepted": [
+              "sentence"
+            ],
+            "explanation": "A sentence is a group of words that expresses a complete idea.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 92
+          },
+          {
+            "year": "3-4",
+            "family": "separate",
+            "word": "separate",
+            "slug": "separate",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "separate"
+            ],
+            "sentence": "Keep the white socks separate from the dark ones.",
+            "sentences": [
+              "Keep the white socks separate from the dark ones.",
+              "Please separate the red buttons from the blue ones.",
+              "We need to separate the papers.",
+              "The fence helps separate the fields.",
+              "She had to separate the coins by size.",
+              "Try to separate the eggs carefully.",
+              "The river can separate the two villages.",
+              "We separate our shoes from our coats.",
+              "The teacher will separate the class into groups.",
+              "The line helps separate the two lanes."
+            ],
+            "accepted": [
+              "separate"
+            ],
+            "explanation": "Separate means apart, not joined together.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 93
+          },
+          {
+            "year": "3-4",
+            "family": "special",
+            "word": "special",
+            "slug": "special",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "special"
+            ],
+            "sentence": "Today is special because it is your birthday.",
+            "sentences": [
+              "Today is special because it is your birthday.",
+              "Today is a special day for our class.",
+              "She wore a special badge on her coat.",
+              "We made a special card for Mum.",
+              "The cake had a special icing.",
+              "He saved a special seat for his friend.",
+              "The library put on a special display.",
+              "That song has a special meaning for me.",
+              "We used a special pen for the poster.",
+              "The trip was special because we went together."
+            ],
+            "accepted": [
+              "special"
+            ],
+            "explanation": "Special means different from the usual in an important or valued way.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 94
+          },
+          {
+            "year": "3-4",
+            "family": "straight",
+            "word": "straight",
+            "slug": "straight",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "straight"
+            ],
+            "sentence": "Draw a straight line with a ruler.",
+            "sentences": [
+              "Draw a straight line with a ruler.",
+              "Draw a straight line across the page.",
+              "He walked straight to the gate.",
+              "The road ahead is straight and long.",
+              "Please keep the shelves straight.",
+              "She stood up straight for the photo.",
+              "The arrow flew straight to the target.",
+              "We took a straight path through the field.",
+              "Put the books straight on the shelf.",
+              "His hair was brushed straight."
+            ],
+            "accepted": [
+              "straight"
+            ],
+            "explanation": "Straight means not curved, bent or crooked.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 95
+          },
+          {
+            "year": "3-4",
+            "family": "strange",
+            "word": "strange",
+            "slug": "strange",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "strange"
+            ],
+            "sentence": "I heard a strange sound in the attic.",
+            "sentences": [
+              "I heard a strange sound in the attic.",
+              "That was a strange sound in the hall.",
+              "She found a strange shell on the beach.",
+              "It felt strange to be so quiet.",
+              "The sky looked strange before the storm.",
+              "He wore a strange hat to school.",
+              "We noticed a strange smell in the room.",
+              "The story had a strange ending.",
+              "It is strange to see snow in spring.",
+              "She gave me a strange look."
+            ],
+            "accepted": [
+              "strange"
+            ],
+            "explanation": "Strange means unusual or surprising.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 96
+          },
+          {
+            "year": "3-4",
+            "family": "strength",
+            "word": "strength",
+            "slug": "strength",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "strength"
+            ],
+            "sentence": "It takes strength to lift that box.",
+            "sentences": [
+              "It takes strength to lift that box.",
+              "Exercise can build your strength.",
+              "She showed great strength in the race.",
+              "The rope has enough strength to hold us.",
+              "His strength helped the team win.",
+              "We admired her strength and courage.",
+              "The bridge needed more strength.",
+              "Swimming can improve your strength.",
+              "The wall has surprising strength.",
+              "He used all his strength to lift the box."
+            ],
+            "accepted": [
+              "strength"
+            ],
+            "explanation": "Strength is the power to lift, push, resist or keep going.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 97
+          },
+          {
+            "year": "3-4",
+            "family": "suppose",
+            "word": "suppose",
+            "slug": "suppose",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "suppose"
+            ],
+            "sentence": "I suppose we could walk instead.",
+            "sentences": [
+              "I suppose we could walk instead.",
+              "I suppose we could try a new route.",
+              "I suppose the shop is closed now.",
+              "I suppose the answer is wrong.",
+              "I suppose we can ask for help.",
+              "I suppose you will finish early.",
+              "We can suppose that it will rain.",
+              "I suppose the game starts at three.",
+              "I suppose the dog needs water.",
+              "I suppose your idea may work."
+            ],
+            "accepted": [
+              "suppose"
+            ],
+            "explanation": "To suppose means to think something is true, often without being completely sure.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 98
+          },
+          {
+            "year": "3-4",
+            "family": "surprise",
+            "word": "surprise",
+            "slug": "surprise",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "surprise"
+            ],
+            "sentence": "The gift was a lovely surprise.",
+            "sentences": [
+              "The gift was a lovely surprise.",
+              "The party was a surprise for her.",
+              "We wanted to surprise Dad with a card.",
+              "It was no surprise that she won.",
+              "The box held a surprise gift.",
+              "His visit was a surprise to everyone.",
+              "She tried to surprise the class.",
+              "The result came as a surprise.",
+              "We planned a surprise for the teacher.",
+              "The puppy was a happy surprise."
+            ],
+            "accepted": [
+              "surprise"
+            ],
+            "explanation": "A surprise is something unexpected.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 99
+          },
+          {
+            "year": "3-4",
+            "family": "therefore",
+            "word": "therefore",
+            "slug": "therefore",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "therefore"
+            ],
+            "sentence": "It was raining and therefore the match was cancelled.",
+            "sentences": [
+              "It was raining and therefore the match was cancelled.",
+              "It was cold, therefore we wore coats.",
+              "He was late, therefore he ran.",
+              "The road was wet, therefore we walked carefully.",
+              "She studied well, therefore she did well.",
+              "The match was cancelled, therefore we went home.",
+              "The pencil broke, therefore I used a pen.",
+              "The shop was shut, therefore we tried another one.",
+              "He was ill, therefore he stayed indoors.",
+              "The gate was locked, therefore we used the side door."
+            ],
+            "accepted": [
+              "therefore"
+            ],
+            "explanation": "Therefore means for that reason or as a result.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 100
+          },
+          {
+            "year": "3-4",
+            "family": "though/although",
+            "word": "though",
+            "slug": "though",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "though",
+              "although"
+            ],
+            "sentence": "I was tired, though I kept walking.",
+            "sentences": [
+              "I was tired, though I kept walking.",
+              "We played outside, though the wind was cold.",
+              "She smiled, though her hands were shaking.",
+              "He joined the race, though he felt nervous.",
+              "We finished the trip, though the path was muddy.",
+              "The soup was hot, though the bread was cold.",
+              "I liked the book, though it was quite long.",
+              "They kept cheering, though their team was behind.",
+              "Mum came with us, though she was busy.",
+              "The dog barked, though it was friendly."
+            ],
+            "accepted": [
+              "though"
+            ],
+            "explanation": "Though means although, or despite the fact that something is true.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 101
+          },
+          {
+            "year": "3-4",
+            "family": "though/although",
+            "word": "although",
+            "slug": "although",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "though",
+              "although"
+            ],
+            "sentence": "Although it was raining, we still went out.",
+            "sentences": [
+              "Although it was raining, we still went out.",
+              "Although he was tired, he finished the page.",
+              "Although the cake looked plain, it tasted delicious.",
+              "Although the road was busy, we crossed safely.",
+              "Although she felt nervous, she answered clearly.",
+              "Although the box was small, it was very heavy.",
+              "Although the wind was strong, the tent stayed up.",
+              "Although I missed the first clue, I solved the puzzle.",
+              "Although the dog barked, it was friendly.",
+              "Although the lesson was hard, I enjoyed it."
+            ],
+            "accepted": [
+              "although"
+            ],
+            "explanation": "Although means even though or despite the fact that.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 102
+          },
+          {
+            "year": "3-4",
+            "family": "thought",
+            "word": "thought",
+            "slug": "thought",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "thought"
+            ],
+            "sentence": "I thought the answer was on the next page.",
+            "sentences": [
+              "I thought the answer was on the next page.",
+              "She thought carefully before she replied.",
+              "We thought the path would lead to the river.",
+              "He thought about the problem all evening.",
+              "Mum thought the soup needed more salt.",
+              "The class thought the film was funny.",
+              "She thought of a better plan on the bus.",
+              "He thought the box was empty.",
+              "I thought the shop closed at five.",
+              "They thought the test would be easy."
+            ],
+            "accepted": [
+              "thought"
+            ],
+            "explanation": "A thought is an idea in your mind; thought is also the past tense of think.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 103
+          },
+          {
+            "year": "3-4",
+            "family": "through",
+            "word": "through",
+            "slug": "through",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "through"
+            ],
+            "sentence": "We walked through the tunnel to the beach.",
+            "sentences": [
+              "We walked through the tunnel to the beach.",
+              "Sunlight shone through the window.",
+              "She read through the list before speaking.",
+              "The train passed through the station without stopping.",
+              "He squeezed through the narrow gap.",
+              "The river runs through the middle of town.",
+              "I looked through the glass at the fossils.",
+              "They pushed through the crowd to the gate.",
+              "The dog ran through the open field.",
+              "We worked through the clues one by one."
+            ],
+            "accepted": [
+              "through"
+            ],
+            "explanation": "Through means moving in one side and out of the other, or from start to finish.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 104
+          },
+          {
+            "year": "3-4",
+            "family": "various",
+            "word": "various",
+            "slug": "various",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "various"
+            ],
+            "sentence": "The museum has various old coins.",
+            "sentences": [
+              "The museum has various old coins.",
+              "The box held various colours of beads.",
+              "We tried various ways to solve it.",
+              "She visited various towns on holiday.",
+              "The class used various tools in art.",
+              "There were various birds in the tree.",
+              "He read various books about space.",
+              "We tasted various apples at the fair.",
+              "The shop sold various kinds of bread.",
+              "She had various ideas for the poster."
+            ],
+            "accepted": [
+              "various"
+            ],
+            "explanation": "Various means several different kinds.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 105
+          },
+          {
+            "year": "3-4",
+            "family": "weight",
+            "word": "weight",
+            "slug": "weight",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "weight"
+            ],
+            "sentence": "She checked the weight of the parcel before posting it.",
+            "sentences": [
+              "She checked the weight of the parcel before posting it.",
+              "The weight of the box made it hard to lift.",
+              "The scales showed the baby's weight clearly.",
+              "The bridge can carry a great deal of weight.",
+              "He felt the weight of the rucksack on his shoulders.",
+              "The weight of the snow bent the branch.",
+              "We reduced the weight by taking out the bottles.",
+              "The doctor recorded my weight at the appointment.",
+              "The weight of the suitcase surprised Dad.",
+              "The hook could not hold the weight of the bag."
+            ],
+            "accepted": [
+              "weight"
+            ],
+            "explanation": "Weight is how heavy something is.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 106
+          },
+          {
+            "year": "3-4",
+            "family": "woman/women",
+            "word": "woman",
+            "slug": "woman",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "woman",
+              "women"
+            ],
+            "sentence": "The woman was waiting by the ticket office.",
+            "sentences": [
+              "The woman was waiting by the ticket office.",
+              "A woman in a yellow coat waved to us.",
+              "The woman at the desk checked my name.",
+              "One woman carried the banner into the hall.",
+              "The woman beside the gate smiled kindly.",
+              "That woman teaches music at our school.",
+              "The woman on the bus offered me her seat.",
+              "A woman from the library came to read to us.",
+              "The woman holding the umbrella was my aunt.",
+              "The woman in front of us bought the last loaf."
+            ],
+            "accepted": [
+              "woman"
+            ],
+            "explanation": "A woman is an adult female person.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 107
+          },
+          {
+            "year": "3-4",
+            "family": "woman/women",
+            "word": "women",
+            "slug": "women",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "woman",
+              "women"
+            ],
+            "sentence": "The women were waiting by the ticket office.",
+            "sentences": [
+              "The women were waiting by the ticket office.",
+              "Two women ran the cake stall together.",
+              "The women at the desk checked our names.",
+              "Several women sang in the choir.",
+              "The women on the bus were laughing together.",
+              "These women work at the village shop.",
+              "The women carrying the boxes asked for help.",
+              "Many women marched in the parade.",
+              "The women in our story showed great courage.",
+              "The women beside the gate waved to us."
+            ],
+            "accepted": [
+              "women"
+            ],
+            "explanation": "Women is the plural of woman.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 108
+          },
+          {
+            "year": "5-6",
+            "family": "accommodate",
+            "word": "accommodate",
+            "slug": "accommodate",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "accommodate"
+            ],
+            "sentence": "This hotel can accommodate fifty guests.",
+            "sentences": [
+              "This hotel can accommodate fifty guests.",
+              "The hall can accommodate the whole class.",
+              "We must accommodate visitors at sports day.",
+              "The shed can accommodate three bikes.",
+              "The campsite can accommodate many tents.",
+              "The coach will accommodate extra bags.",
+              "The plan should accommodate slow walkers.",
+              "The school can accommodate pupils with hearing aids.",
+              "We need to accommodate a late arrival.",
+              "The museum can accommodate wheelchairs."
+            ],
+            "accepted": [
+              "accommodate"
+            ],
+            "explanation": "To accommodate means to provide space for someone or something, or to fit in with needs.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 109
+          },
+          {
+            "year": "5-6",
+            "family": "accompany",
+            "word": "accompany",
+            "slug": "accompany",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "accompany"
+            ],
+            "sentence": "An adult must accompany you on the trip.",
+            "sentences": [
+              "An adult must accompany you on the trip.",
+              "I will accompany my brother to the concert.",
+              "The teacher will accompany the class on the walk.",
+              "Mum can accompany me to the dentist.",
+              "Two friends will accompany the team.",
+              "The song will accompany the story.",
+              "Dad will accompany us to the station.",
+              "A guide will accompany the visitors.",
+              "The violin will accompany the singer.",
+              "Grandad offered to accompany us home."
+            ],
+            "accepted": [
+              "accompany"
+            ],
+            "explanation": "To accompany means to go somewhere with someone or to happen at the same time.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 110
+          },
+          {
+            "year": "5-6",
+            "family": "according",
+            "word": "according",
+            "slug": "according",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "according"
+            ],
+            "sentence": "According to the map we are nearly there.",
+            "sentences": [
+              "According to the map we are nearly there.",
+              "The score changed according to the rules.",
+              "We sorted the books according to size.",
+              "The class lined up according to height.",
+              "The map was made according to old notes.",
+              "The lesson ran according to the plan.",
+              "We packed our bags according to the list.",
+              "The machines worked according to the timer.",
+              "The answers were marked according to the guide.",
+              "The flowers were grouped according to colour."
+            ],
+            "accepted": [
+              "according"
+            ],
+            "explanation": "According to something means as stated by it, or in a way that agrees with it.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 111
+          },
+          {
+            "year": "5-6",
+            "family": "achieve",
+            "word": "achieve",
+            "slug": "achieve",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "achieve"
+            ],
+            "sentence": "You can achieve your goal with practice.",
+            "sentences": [
+              "You can achieve your goal with practice.",
+              "We work hard to achieve our goals.",
+              "She hopes to achieve a better score.",
+              "The class can achieve more with practice.",
+              "He wants to achieve a high mark.",
+              "We must achieve calm before the show.",
+              "They tried to achieve a fair result.",
+              "The team can achieve success together.",
+              "I will achieve my target this week.",
+              "The runner worked hard to achieve first place."
+            ],
+            "accepted": [
+              "achieve"
+            ],
+            "explanation": "To achieve means to succeed in doing something through effort.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 112
+          },
+          {
+            "year": "5-6",
+            "family": "aggressive",
+            "word": "aggressive",
+            "slug": "aggressive",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "aggressive"
+            ],
+            "sentence": "The aggressive dog barked loudly.",
+            "sentences": [
+              "The aggressive dog barked loudly.",
+              "The dog looked aggressive, so we kept away.",
+              "An aggressive tackle is not allowed.",
+              "His aggressive tone upset the room.",
+              "The game became aggressive near the end.",
+              "She gave an aggressive shout across the field.",
+              "We avoided the aggressive swarm of bees.",
+              "The aggressive dog barked from behind the fence.",
+              "His aggressive words made the room quiet.",
+              "An aggressive tackle can hurt another player."
+            ],
+            "accepted": [
+              "aggressive"
+            ],
+            "explanation": "Aggressive means ready to attack, argue or behave forcefully.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 113
+          },
+          {
+            "year": "5-6",
+            "family": "amateur",
+            "word": "amateur",
+            "slug": "amateur",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "amateur"
+            ],
+            "sentence": "She is an amateur photographer.",
+            "sentences": [
+              "She is an amateur photographer.",
+              "The amateur singer tried her best.",
+              "We joined an amateur drama group.",
+              "The amateur team practised after school.",
+              "He is only an amateur player, not a pro.",
+              "An amateur photographer took the pictures.",
+              "The amateur chess club meets on Friday.",
+              "The amateur chef made soup for dinner.",
+              "Our school show used an amateur band.",
+              "The amateur runner kept a steady pace."
+            ],
+            "accepted": [
+              "amateur"
+            ],
+            "explanation": "An amateur is someone who does an activity for interest, not as a paid job.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 114
+          },
+          {
+            "year": "5-6",
+            "family": "ancient",
+            "word": "ancient",
+            "slug": "ancient",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "ancient"
+            ],
+            "sentence": "We saw ancient ruins on holiday.",
+            "sentences": [
+              "We saw ancient ruins on holiday.",
+              "We visited an ancient castle.",
+              "The museum showed an ancient pot.",
+              "An ancient tree stood by the road.",
+              "The book described an ancient kingdom.",
+              "We studied an ancient map in class.",
+              "The ruins looked ancient and grand.",
+              "An ancient wall surrounded the field.",
+              "The path crossed an ancient bridge.",
+              "We found an ancient coin in the garden."
+            ],
+            "accepted": [
+              "ancient"
+            ],
+            "explanation": "Ancient means very old or from a long time ago.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 115
+          },
+          {
+            "year": "5-6",
+            "family": "apparent",
+            "word": "apparent",
+            "slug": "apparent",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "apparent"
+            ],
+            "sentence": "It was apparent that he was tired.",
+            "sentences": [
+              "It was apparent that he was tired.",
+              "It was apparent that the road was closed.",
+              "The mistake was apparent to the teacher.",
+              "Her happiness was apparent to everyone.",
+              "The damage was apparent after the storm.",
+              "It became apparent that we were late.",
+              "The answer was apparent from the clues.",
+              "His worry was apparent in his voice.",
+              "The pattern was apparent on the wall.",
+              "It soon became apparent that the plan would change."
+            ],
+            "accepted": [
+              "apparent"
+            ],
+            "explanation": "Apparent means easy to see or seeming to be true.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 116
+          },
+          {
+            "year": "5-6",
+            "family": "appreciate",
+            "word": "appreciate",
+            "slug": "appreciate",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "appreciate"
+            ],
+            "sentence": "I appreciate your kind help.",
+            "sentences": [
+              "I appreciate your kind help.",
+              "We appreciate your help.",
+              "I appreciate the extra time.",
+              "The class will appreciate the quiet room.",
+              "We appreciate the clear instructions.",
+              "She stopped to appreciate the view.",
+              "I appreciate the kind note.",
+              "They appreciate a tidy desk.",
+              "We appreciate the work you have done.",
+              "He began to appreciate good manners."
+            ],
+            "accepted": [
+              "appreciate"
+            ],
+            "explanation": "To appreciate means to understand the value of something or be thankful for it.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 117
+          },
+          {
+            "year": "5-6",
+            "family": "attached",
+            "word": "attached",
+            "slug": "attached",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "attached"
+            ],
+            "sentence": "The label was attached to the bag.",
+            "sentences": [
+              "The label was attached to the bag.",
+              "The note was attached with a paper clip.",
+              "The kite was attached to a long string.",
+              "He felt attached to his old teddy.",
+              "A tag was attached to each coat.",
+              "The picture was attached to the wall.",
+              "The trailer was attached to the car.",
+              "The form was attached to the email.",
+              "The ribbon stayed attached to the present.",
+              "The swing was attached to a strong branch."
+            ],
+            "accepted": [
+              "attached"
+            ],
+            "explanation": "Attached means joined, fastened or feeling emotionally close.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 118
+          },
+          {
+            "year": "5-6",
+            "family": "available",
+            "word": "available",
+            "slug": "available",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "available"
+            ],
+            "sentence": "The next seat is available now.",
+            "sentences": [
+              "The next seat is available now.",
+              "The seats are available now.",
+              "Some pens are available in the drawer.",
+              "The hall is available for assembly.",
+              "A coach is available after lunch.",
+              "Fresh water was available at the camp.",
+              "The library books are available to borrow.",
+              "More time was available than we expected.",
+              "The window seat is available today.",
+              "Help was available from the teacher."
+            ],
+            "accepted": [
+              "available"
+            ],
+            "explanation": "Available means ready to be used or free to do something.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 119
+          },
+          {
+            "year": "5-6",
+            "family": "average",
+            "word": "average",
+            "slug": "average",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "average"
+            ],
+            "sentence": "The average score was quite high.",
+            "sentences": [
+              "The average score was quite high.",
+              "Her average score improved this term.",
+              "The average temperature was mild.",
+              "The average lunch time for our class is one o'clock.",
+              "The average child needs plenty of sleep.",
+              "The class found the average number quickly.",
+              "His average speed was steady.",
+              "The average result was better than last year.",
+              "We checked the average height of the plants.",
+              "Their average mark was very high."
+            ],
+            "accepted": [
+              "average"
+            ],
+            "explanation": "Average means typical, ordinary, or the middle amount found by sharing equally.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 120
+          },
+          {
+            "year": "5-6",
+            "family": "awkward",
+            "word": "awkward",
+            "slug": "awkward",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "awkward"
+            ],
+            "sentence": "It was awkward carrying the huge box.",
+            "sentences": [
+              "It was awkward carrying the huge box.",
+              "The chair felt awkward to sit on.",
+              "I felt awkward when I forgot my line.",
+              "An awkward silence filled the room.",
+              "The box was awkward to carry.",
+              "She made an awkward step on the stairs.",
+              "It was awkward to carry the box alone.",
+              "He gave an awkward laugh.",
+              "The suit was awkward and stiff.",
+              "We had an awkward moment at lunch."
+            ],
+            "accepted": [
+              "awkward"
+            ],
+            "explanation": "Awkward means difficult to deal with, clumsy or uncomfortable.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 121
+          },
+          {
+            "year": "5-6",
+            "family": "bargain",
+            "word": "bargain",
+            "slug": "bargain",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "bargain"
+            ],
+            "sentence": "The coat was a real bargain.",
+            "sentences": [
+              "The coat was a real bargain.",
+              "We found a bargain in the market.",
+              "Dad tried to bargain for a lower price.",
+              "The shop had a bargain on trainers.",
+              "Mum said the coat was a good bargain.",
+              "We can bargain with the stall holder.",
+              "The bargain basket was near the till.",
+              "She bought the book as a bargain.",
+              "It was a bargain to pay so little.",
+              "They learned to bargain politely at the market."
+            ],
+            "accepted": [
+              "bargain"
+            ],
+            "explanation": "A bargain is something bought for less than the usual price, or an agreement between people.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 122
+          },
+          {
+            "year": "5-6",
+            "family": "bruise",
+            "word": "bruise",
+            "slug": "bruise",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "bruise"
+            ],
+            "sentence": "He had a bruise on his knee.",
+            "sentences": [
+              "He had a bruise on his knee.",
+              "I got a bruise on my knee.",
+              "The bruise turned blue by evening.",
+              "He showed me a bruise on his arm.",
+              "A bruise can be sore for a while.",
+              "She rubbed the bruise gently.",
+              "The bruise faded after a week of rest.",
+              "I can see a bruise on the apple.",
+              "The football hit left a bruise.",
+              "The nurse checked the bruise carefully."
+            ],
+            "accepted": [
+              "bruise"
+            ],
+            "explanation": "A bruise is a dark mark on skin caused by a bump or injury.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 123
+          },
+          {
+            "year": "5-6",
+            "family": "category",
+            "word": "category",
+            "slug": "category",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "category"
+            ],
+            "sentence": "Place the toy in the correct category.",
+            "sentences": [
+              "Place the toy in the correct category.",
+              "We put the books in each category.",
+              "The animal fit the correct category.",
+              "This game is in a different category.",
+              "The shop has a snack category.",
+              "We chose a category for the quiz.",
+              "Each category has its own label.",
+              "The teacher sorted the words by category.",
+              "That idea belongs in another category.",
+              "The list showed one category at a time."
+            ],
+            "accepted": [
+              "category"
+            ],
+            "explanation": "A category is a group of things that share the same type or feature.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 124
+          },
+          {
+            "year": "5-6",
+            "family": "cemetery",
+            "word": "cemetery",
+            "slug": "cemetery",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "cemetery"
+            ],
+            "sentence": "The old cemetery was very quiet.",
+            "sentences": [
+              "The old cemetery was very quiet.",
+              "We walked quietly through the cemetery.",
+              "The cemetery was calm in the rain.",
+              "An old tree stood near the cemetery gate.",
+              "We left flowers at the cemetery.",
+              "A narrow path led past the cemetery wall.",
+              "She saw birds above the cemetery wall.",
+              "The guide spoke softly in the cemetery.",
+              "A bench stood beside the cemetery.",
+              "The cemetery looked peaceful at dusk."
+            ],
+            "accepted": [
+              "cemetery"
+            ],
+            "explanation": "A cemetery is a place where people are buried.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 125
+          },
+          {
+            "year": "5-6",
+            "family": "committee",
+            "word": "committee",
+            "slug": "committee",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "committee"
+            ],
+            "sentence": "The school committee met after lunch.",
+            "sentences": [
+              "The school committee met after lunch.",
+              "The committee met after school.",
+              "Our committee planned the fair.",
+              "The committee chose a colour theme.",
+              "A small committee checked the rules.",
+              "The committee listened to the pupils' ideas.",
+              "Each committee member had a task.",
+              "The committee agreed on the date.",
+              "The school committee approved the visit.",
+              "The committee wrote a short report."
+            ],
+            "accepted": [
+              "committee"
+            ],
+            "explanation": "A committee is a group of people chosen to discuss or organise something.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 126
+          },
+          {
+            "year": "5-6",
+            "family": "communicate",
+            "word": "communicate",
+            "slug": "communicate",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "communicate"
+            ],
+            "sentence": "We use email to communicate quickly.",
+            "sentences": [
+              "We use email to communicate quickly.",
+              "We need to communicate clearly.",
+              "The flags help birds communicate.",
+              "We communicate by email at school.",
+              "She used sign language to communicate.",
+              "It is hard to communicate in a loud hall.",
+              "The chart helps us communicate the plan.",
+              "We can communicate with the office by phone.",
+              "The robot cannot communicate when the battery is flat.",
+              "Teachers communicate with parents each week."
+            ],
+            "accepted": [
+              "communicate"
+            ],
+            "explanation": "To communicate means to share information, ideas or feelings.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 127
+          },
+          {
+            "year": "5-6",
+            "family": "community",
+            "word": "community",
+            "slug": "community",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "community"
+            ],
+            "sentence": "The whole community joined the parade.",
+            "sentences": [
+              "The whole community joined the parade.",
+              "Our community helped after the flood.",
+              "The community garden needs care.",
+              "She knows many people in the community.",
+              "The community centre opens at nine.",
+              "We joined a community clean-up.",
+              "The festival brought the community together.",
+              "Everyone in the community shared news.",
+              "The community pool is near the park.",
+              "A strong community supports local shops."
+            ],
+            "accepted": [
+              "community"
+            ],
+            "explanation": "A community is a group of people who live near each other or share something in common.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 128
+          },
+          {
+            "year": "5-6",
+            "family": "competition",
+            "word": "competition",
+            "slug": "competition",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "competition"
+            ],
+            "sentence": "She won the art competition.",
+            "sentences": [
+              "She won the art competition.",
+              "The race was a competition between two houses.",
+              "The competition started at noon.",
+              "She entered the art competition.",
+              "There was strong competition for the prize.",
+              "The competition rules were easy to follow.",
+              "He trained hard for the swimming competition.",
+              "The cooking competition smelled wonderful.",
+              "A fun competition filled the school hall.",
+              "They celebrated after the competition."
+            ],
+            "accepted": [
+              "competition"
+            ],
+            "explanation": "A competition is an event where people try to win or do better than others.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 129
+          },
+          {
+            "year": "5-6",
+            "family": "conscience",
+            "word": "conscience",
+            "slug": "conscience",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "conscience"
+            ],
+            "sentence": "His conscience told him to return the lost wallet.",
+            "sentences": [
+              "His conscience told him to return the lost wallet.",
+              "My conscience would not let me keep the extra change.",
+              "She listened to her conscience and told the truth.",
+              "A clear conscience helped him sleep peacefully.",
+              "His conscience reminded him to apologise.",
+              "The thief ignored his conscience and ran away.",
+              "My conscience pricked me after I lied.",
+              "Her conscience told her to share the sweets fairly.",
+              "He followed his conscience even when it was hard.",
+              "We should let our conscience guide our choices."
+            ],
+            "accepted": [
+              "conscience"
+            ],
+            "explanation": "Your conscience is the inner sense that helps you know right from wrong.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 130
+          },
+          {
+            "year": "5-6",
+            "family": "conscious",
+            "word": "conscious",
+            "slug": "conscious",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "conscious"
+            ],
+            "sentence": "She stayed conscious after the fall.",
+            "sentences": [
+              "She stayed conscious after the fall.",
+              "I was conscious of the noise behind me.",
+              "He became conscious a few moments later.",
+              "We were conscious of the time and hurried on.",
+              "The cyclist stayed conscious while the nurse checked him.",
+              "I felt conscious of everyone watching me.",
+              "They were conscious of the danger near the edge.",
+              "Mum was conscious of my worry at once.",
+              "He remained conscious after the bump.",
+              "She was conscious of the slippery floor and stepped carefully."
+            ],
+            "accepted": [
+              "conscious"
+            ],
+            "explanation": "Conscious means awake, aware or able to notice what is happening.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 131
+          },
+          {
+            "year": "5-6",
+            "family": "controversy",
+            "word": "controversy",
+            "slug": "controversy",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "controversy"
+            ],
+            "sentence": "The rule change caused some controversy.",
+            "sentences": [
+              "The rule change caused some controversy.",
+              "The new rule caused controversy.",
+              "The article led to controversy.",
+              "There was controversy about the team names.",
+              "The change sparked controversy at school.",
+              "The film created controversy among parents.",
+              "The speaker avoided controversy.",
+              "The idea brought controversy to the meeting.",
+              "The mistake caused no controversy.",
+              "The budget was at the centre of controversy."
+            ],
+            "accepted": [
+              "controversy"
+            ],
+            "explanation": "A controversy is strong disagreement about an issue.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 132
+          },
+          {
+            "year": "5-6",
+            "family": "convenience",
+            "word": "convenience",
+            "slug": "convenience",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "convenience"
+            ],
+            "sentence": "For convenience, we packed the night before.",
+            "sentences": [
+              "For convenience, we packed the night before.",
+              "The new lift adds convenience for visitors.",
+              "The handle was added for convenience.",
+              "They chose the nearer shop for convenience.",
+              "The side pocket is there for convenience.",
+              "Online booking adds convenience for busy families.",
+              "The timetable was changed for the convenience of parents.",
+              "We met at the gate for convenience.",
+              "The parcel lockers are there for our convenience.",
+              "A second entrance gives extra convenience on busy days."
+            ],
+            "accepted": [
+              "convenience"
+            ],
+            "explanation": "Convenience means ease, usefulness or something that saves time and effort.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 133
+          },
+          {
+            "year": "5-6",
+            "family": "correspond",
+            "word": "correspond",
+            "slug": "correspond",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "correspond"
+            ],
+            "sentence": "The numbers should correspond to the names.",
+            "sentences": [
+              "The numbers should correspond to the names.",
+              "Please correspond with the office by email.",
+              "Our letters correspond to the dates.",
+              "The map marks correspond with the signs.",
+              "The shapes correspond to the clues.",
+              "His answers correspond to the facts.",
+              "The numbers correspond with the chart.",
+              "We correspond by post during the holiday.",
+              "The colours correspond to the house groups.",
+              "Her notes correspond with mine."
+            ],
+            "accepted": [
+              "correspond"
+            ],
+            "explanation": "To correspond means to match, agree or communicate by messages.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 134
+          },
+          {
+            "year": "5-6",
+            "family": "criticise (critic + ise)",
+            "word": "criticise",
+            "slug": "criticise",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "criticise"
+            ],
+            "sentence": "It is easy to criticise from the side-lines.",
+            "sentences": [
+              "It is easy to criticise from the side-lines.",
+              "Do not criticise other people's work.",
+              "The teacher will criticise the draft kindly.",
+              "It is rude to criticise a classmate.",
+              "He can criticise the plan if needed.",
+              "We should not criticise before listening.",
+              "She did not mean to criticise him.",
+              "The coach may criticise our effort.",
+              "Parents should not criticise every mistake.",
+              "He began to criticise the messy table."
+            ],
+            "accepted": [
+              "criticise",
+              "criticize"
+            ],
+            "explanation": "To criticise means to say what is wrong with something or someone.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 135
+          },
+          {
+            "year": "5-6",
+            "family": "curiosity",
+            "word": "curiosity",
+            "slug": "curiosity",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "curiosity"
+            ],
+            "sentence": "Her curiosity made her open the box.",
+            "sentences": [
+              "Her curiosity made her open the box.",
+              "Her curiosity led her to open the box.",
+              "The puppy sniffed with curiosity.",
+              "His curiosity grew during the tour.",
+              "A little curiosity helps us learn new things.",
+              "She looked at the map with curiosity.",
+              "The story stirred my curiosity.",
+              "A little curiosity can be useful.",
+              "The child asked questions with curiosity.",
+              "His curiosity made him explore the attic."
+            ],
+            "accepted": [
+              "curiosity"
+            ],
+            "explanation": "Curiosity is the wish to know, learn or find out about something.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 136
+          },
+          {
+            "year": "5-6",
+            "family": "definite",
+            "word": "definite",
+            "slug": "definite",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "definite"
+            ],
+            "sentence": "There was a definite change in the weather.",
+            "sentences": [
+              "There was a definite change in the weather.",
+              "We need a definite answer.",
+              "The plan has a definite start time.",
+              "I am definite about my choice.",
+              "She gave a definite nod.",
+              "The smell was a definite sign of soup.",
+              "We had a definite goal.",
+              "His face showed a definite smile.",
+              "The result was definite by lunch.",
+              "There is a definite path through the wood."
+            ],
+            "accepted": [
+              "definite"
+            ],
+            "explanation": "Definite means clear, certain and not vague.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 137
+          },
+          {
+            "year": "5-6",
+            "family": "desperate",
+            "word": "desperate",
+            "slug": "desperate",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "desperate"
+            ],
+            "sentence": "We were desperate to find shelter.",
+            "sentences": [
+              "We were desperate to find shelter.",
+              "The lost pup looked desperate.",
+              "We were desperate for water.",
+              "She felt desperate before the test.",
+              "The team made a desperate effort.",
+              "He gave a desperate cry for help.",
+              "I was desperate to finish on time.",
+              "The search became desperate after dark.",
+              "They made a desperate plan to help.",
+              "Mum was desperate for a hot drink."
+            ],
+            "accepted": [
+              "desperate"
+            ],
+            "explanation": "Desperate means feeling that you urgently need something or have little hope.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 138
+          },
+          {
+            "year": "5-6",
+            "family": "determined",
+            "word": "determined",
+            "slug": "determined",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "determined"
+            ],
+            "sentence": "She felt determined to improve.",
+            "sentences": [
+              "She felt determined to improve.",
+              "The runner was determined to win.",
+              "She looked determined in the race.",
+              "We are determined to improve.",
+              "He was determined to finish the book.",
+              "The team stayed determined after the break.",
+              "I felt determined to try again.",
+              "They were determined to reach the hill.",
+              "Our class was determined and focused.",
+              "The dog looked determined to catch the ball."
+            ],
+            "accepted": [
+              "determined"
+            ],
+            "explanation": "Determined means firmly decided to do something and not give up.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 139
+          },
+          {
+            "year": "5-6",
+            "family": "develop",
+            "word": "develop",
+            "slug": "develop",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "develop"
+            ],
+            "sentence": "Seeds develop best in warm soil.",
+            "sentences": [
+              "Seeds develop best in warm soil.",
+              "Plants develop from tiny seeds.",
+              "We develop new skills in class.",
+              "The baby will develop quickly.",
+              "The town may develop by the river.",
+              "Good habits develop over time.",
+              "The class will develop a plan.",
+              "Some films develop slowly.",
+              "We should develop the idea further.",
+              "The story will develop later."
+            ],
+            "accepted": [
+              "develop"
+            ],
+            "explanation": "To develop means to grow, improve or become more advanced.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 140
+          },
+          {
+            "year": "5-6",
+            "family": "dictionary",
+            "word": "dictionary",
+            "slug": "dictionary",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "dictionary"
+            ],
+            "sentence": "Use a dictionary to check the meaning.",
+            "sentences": [
+              "Use a dictionary to check the meaning.",
+              "The dictionary was on the shelf.",
+              "We used the dictionary in class.",
+              "She found the meaning in the dictionary.",
+              "The dictionary helped us choose the right word.",
+              "He opened the dictionary to the next page.",
+              "The dictionary gave a useful example.",
+              "I keep a dictionary by my desk.",
+              "The dictionary showed both forms.",
+              "We shared the dictionary during the task."
+            ],
+            "accepted": [
+              "dictionary"
+            ],
+            "explanation": "A dictionary is a book or resource that explains words, spellings and meanings.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 141
+          },
+          {
+            "year": "5-6",
+            "family": "disastrous",
+            "word": "disastrous",
+            "slug": "disastrous",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "disastrous"
+            ],
+            "sentence": "The flood had disastrous effects on the village.",
+            "sentences": [
+              "The flood had disastrous effects on the village.",
+              "The storm had a disastrous effect.",
+              "The plan ended in a disastrous delay.",
+              "It was disastrous to leave the window open.",
+              "The match was disastrous from the start.",
+              "One small mistake proved disastrous for the game.",
+              "The flood caused disastrous harm to the field.",
+              "The cooking lesson became disastrous after the oven failed.",
+              "The delay had disastrous results for the trip.",
+              "The broken pump was disastrous for the field."
+            ],
+            "accepted": [
+              "disastrous"
+            ],
+            "explanation": "Disastrous means causing great harm, failure or trouble.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 142
+          },
+          {
+            "year": "5-6",
+            "family": "embarrass",
+            "word": "embarrass",
+            "slug": "embarrass",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "embarrass"
+            ],
+            "sentence": "Please do not embarrass your brother.",
+            "sentences": [
+              "Please do not embarrass your brother.",
+              "Do not embarrass your friend.",
+              "Please do not embarrass the speaker.",
+              "The joke might embarrass her.",
+              "I did not want to embarrass my sister.",
+              "Loud comments can embarrass people.",
+              "The question may embarrass him.",
+              "We should not embarrass anyone on stage.",
+              "A mistake can embarrass a pupil.",
+              "He tried to embarrass the actor."
+            ],
+            "accepted": [
+              "embarrass"
+            ],
+            "explanation": "To embarrass someone means to make them feel awkward, ashamed or self-conscious.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 143
+          },
+          {
+            "year": "5-6",
+            "family": "environment",
+            "word": "environment",
+            "slug": "environment",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "environment"
+            ],
+            "sentence": "We should protect the environment.",
+            "sentences": [
+              "We should protect the environment.",
+              "Litter can damage the environment very quickly.",
+              "Trees help the environment by giving shade and shelter.",
+              "A clean river supports a healthy environment.",
+              "Smoke can harm the environment.",
+              "The park group worked to improve the environment near the pond.",
+              "Everyone can help the environment by saving water.",
+              "The class learned how weather affects the environment.",
+              "We want a safe environment for wildlife.",
+              "The school is trying to improve the local environment."
+            ],
+            "accepted": [
+              "environment"
+            ],
+            "explanation": "The environment is the natural world around us, or the conditions in a place.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 144
+          },
+          {
+            "year": "5-6",
+            "family": "equip (-ped, -ment)",
+            "word": "equip",
+            "slug": "equip",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "equip",
+              "equipped",
+              "equipment"
+            ],
+            "sentence": "Good boots equip you for rough ground.",
+            "sentences": [
+              "Good boots equip you for rough ground.",
+              "Please equip the bike with a bell and lights.",
+              "We need to equip the team before the match.",
+              "The shop can equip the shed with shelves.",
+              "You should equip the tent with a ground sheet.",
+              "The school will equip each lab with safety goggles.",
+              "Mum helped equip the picnic bag with plates.",
+              "The workers equip the van with new tools.",
+              "The museum will equip the room with audio guides.",
+              "Dad can equip the toolbox with a hammer and tape measure."
+            ],
+            "accepted": [
+              "equip"
+            ],
+            "explanation": "To equip means to provide the things needed for a task.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 145
+          },
+          {
+            "year": "5-6",
+            "family": "equip (-ped, -ment)",
+            "word": "equipped",
+            "slug": "equipped",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "equip",
+              "equipped",
+              "equipment"
+            ],
+            "sentence": "The classroom was equipped with new computers.",
+            "sentences": [
+              "The classroom was equipped with new computers.",
+              "The sailor was equipped with a life jacket.",
+              "The class was equipped with pencils and rulers.",
+              "The rescue team was equipped with torches.",
+              "The tent was equipped with warm blankets.",
+              "The lab was equipped with safety glasses.",
+              "She felt equipped for the test after revision.",
+              "The car was equipped with new tyres.",
+              "The bag was equipped with a water bottle holder.",
+              "The kitchen was equipped with useful cupboards."
+            ],
+            "accepted": [
+              "equipped"
+            ],
+            "explanation": "Equipped means provided with what is needed.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 146
+          },
+          {
+            "year": "5-6",
+            "family": "equip (-ped, -ment)",
+            "word": "equipment",
+            "slug": "equipment",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "equip",
+              "equipped",
+              "equipment"
+            ],
+            "sentence": "The team packed all the safety equipment.",
+            "sentences": [
+              "The team packed all the safety equipment.",
+              "The sports equipment was stored in the hall.",
+              "We checked the equipment before the lesson.",
+              "The science equipment was clean and ready.",
+              "The coach counted the equipment after training.",
+              "The repair kit was part of the emergency equipment.",
+              "Our equipment must be packed carefully.",
+              "The school bought new equipment for music.",
+              "The camping equipment fitted neatly in the car.",
+              "The safety equipment helped the workers."
+            ],
+            "accepted": [
+              "equipment"
+            ],
+            "explanation": "Equipment is the things needed for a particular job or activity.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 147
+          },
+          {
+            "year": "5-6",
+            "family": "especially",
+            "word": "especially",
+            "slug": "especially",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "especially"
+            ],
+            "sentence": "I especially enjoy reading mystery books.",
+            "sentences": [
+              "I especially enjoy reading mystery books.",
+              "I liked the cake, especially the icing.",
+              "The path was muddy, especially near the gate.",
+              "She enjoyed the book, especially the ending.",
+              "We need to be careful, especially on the stairs.",
+              "The lesson was useful, especially the reading part.",
+              "He was tired, especially after football.",
+              "The hall was noisy, especially at lunchtime.",
+              "The flowers looked bright, especially in the sun.",
+              "I am hungry, especially after swimming."
+            ],
+            "accepted": [
+              "especially"
+            ],
+            "explanation": "Especially means particularly, or more than usual.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 148
+          },
+          {
+            "year": "5-6",
+            "family": "exaggerate",
+            "word": "exaggerate",
+            "slug": "exaggerate",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "exaggerate"
+            ],
+            "sentence": "Do not exaggerate the size of the fish.",
+            "sentences": [
+              "Do not exaggerate the size of the fish.",
+              "Do not exaggerate when you tell the story.",
+              "He likes to exaggerate the size of the wave.",
+              "It is easy to exaggerate a small mistake.",
+              "Try not to exaggerate the number of sweets.",
+              "Some people exaggerate when they are nervous.",
+              "The film did not exaggerate the storm.",
+              "We should not exaggerate our worries.",
+              "She may exaggerate the splash to make us laugh.",
+              "The writer chose not to exaggerate the danger."
+            ],
+            "accepted": [
+              "exaggerate"
+            ],
+            "explanation": "To exaggerate means to describe something as bigger, better or worse than it really is.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 149
+          },
+          {
+            "year": "5-6",
+            "family": "excellent",
+            "word": "excellent",
+            "slug": "excellent",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "excellent"
+            ],
+            "sentence": "You did an excellent job.",
+            "sentences": [
+              "You did an excellent job.",
+              "Your work was excellent today.",
+              "The soup tasted excellent with bread.",
+              "She gave an excellent answer in class.",
+              "The choir made an excellent sound.",
+              "We had an excellent trip to the museum.",
+              "His plan was excellent and clear.",
+              "The dog did an excellent job learning the trick.",
+              "That was an excellent choice for lunch.",
+              "They found an excellent place to sit."
+            ],
+            "accepted": [
+              "excellent"
+            ],
+            "explanation": "Excellent means extremely good.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 150
+          },
+          {
+            "year": "5-6",
+            "family": "existence",
+            "word": "existence",
+            "slug": "existence",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "existence"
+            ],
+            "sentence": "The dinosaur bones proved its existence.",
+            "sentences": [
+              "The dinosaur bones proved its existence.",
+              "Scientists study the existence of tiny creatures.",
+              "The class discussed the existence of planets.",
+              "We learned about the existence of ancient forests.",
+              "The story hinted at the existence of a secret door.",
+              "No one could prove the existence of the monster.",
+              "The map showed the existence of a small island.",
+              "People wonder about the existence of stars far away.",
+              "The lesson explained the existence of fossils.",
+              "Some books explore the existence of hidden worlds."
+            ],
+            "accepted": [
+              "existence"
+            ],
+            "explanation": "Existence is the state of being real or alive.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 151
+          },
+          {
+            "year": "5-6",
+            "family": "explanation",
+            "word": "explanation",
+            "slug": "explanation",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "explanation"
+            ],
+            "sentence": "His explanation made sense to everyone.",
+            "sentences": [
+              "His explanation made sense to everyone.",
+              "Her explanation made the rule clear.",
+              "I listened carefully to the explanation.",
+              "The teacher gave a simple explanation.",
+              "His explanation helped the class understand.",
+              "The chart was useful as an explanation.",
+              "We needed an explanation for the missing book.",
+              "Their explanation sounded honest.",
+              "The video offered an explanation of the process.",
+              "She asked for an explanation of the answer."
+            ],
+            "accepted": [
+              "explanation"
+            ],
+            "explanation": "An explanation gives reasons or details that make something clear.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 152
+          },
+          {
+            "year": "5-6",
+            "family": "familiar",
+            "word": "familiar",
+            "slug": "familiar",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "familiar"
+            ],
+            "sentence": "That tune sounds familiar to me.",
+            "sentences": [
+              "That tune sounds familiar to me.",
+              "The route felt familiar after the first turn.",
+              "The song sounded familiar to me.",
+              "Her face looked familiar in the crowd.",
+              "The room seemed familiar and safe.",
+              "The smell was familiar from the bakery.",
+              "The story was familiar but still fun.",
+              "This game is familiar to many pupils.",
+              "The teacher made the topic familiar with examples.",
+              "The dog was familiar with the family."
+            ],
+            "accepted": [
+              "familiar"
+            ],
+            "explanation": "Familiar means known to you because you have seen or experienced it before.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 153
+          },
+          {
+            "year": "5-6",
+            "family": "foreign",
+            "word": "foreign",
+            "slug": "foreign",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "foreign"
+            ],
+            "sentence": "We tried foreign food at the market.",
+            "sentences": [
+              "We tried foreign food at the market.",
+              "We read a foreign word in the book.",
+              "The museum displayed a foreign coin.",
+              "He heard a foreign accent on the train.",
+              "The market sold a foreign snack.",
+              "They welcomed a foreign visitor to school.",
+              "The flag came from a foreign country.",
+              "I practised a foreign phrase before the trip.",
+              "The class studied a foreign city.",
+              "The package had a foreign stamp."
+            ],
+            "accepted": [
+              "foreign"
+            ],
+            "explanation": "Foreign means from another country or not familiar.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 154
+          },
+          {
+            "year": "5-6",
+            "family": "forty",
+            "word": "forty",
+            "slug": "forty",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "forty"
+            ],
+            "sentence": "There were forty chairs in the hall.",
+            "sentences": [
+              "There were forty chairs in the hall.",
+              "There are forty chairs in the hall.",
+              "She saved forty stickers in her book.",
+              "We counted forty shells on the beach.",
+              "The bus stopped for forty seconds.",
+              "He read forty pages of the novel.",
+              "The jar held forty marbles.",
+              "Our class has forty minutes left.",
+              "They planted forty bulbs in the garden.",
+              "The teacher handed out forty cards."
+            ],
+            "accepted": [
+              "forty"
+            ],
+            "explanation": "Forty is the number after thirty-nine and before forty-one.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 155
+          },
+          {
+            "year": "5-6",
+            "family": "frequently",
+            "word": "frequently",
+            "slug": "frequently",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "frequently"
+            ],
+            "sentence": "We frequently visit our grandparents.",
+            "sentences": [
+              "We frequently visit our grandparents.",
+              "We frequently visit the library after school.",
+              "The dog frequently sleeps by the fire.",
+              "She frequently helps her younger brother.",
+              "We frequently hear birds in the morning.",
+              "The road is frequently busy at rush hour.",
+              "He frequently forgets his water bottle.",
+              "The shop is frequently open on Saturdays.",
+              "I frequently read before bed.",
+              "The river frequently floods after heavy rain."
+            ],
+            "accepted": [
+              "frequently"
+            ],
+            "explanation": "Frequently means often or many times.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 156
+          },
+          {
+            "year": "5-6",
+            "family": "government",
+            "word": "government",
+            "slug": "government",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "government"
+            ],
+            "sentence": "The government announced a new plan.",
+            "sentences": [
+              "The government announced a new plan.",
+              "The government passed a new rule.",
+              "The government supports local schools.",
+              "The government announced the plan yesterday.",
+              "Our government protects public services.",
+              "The government listened to the report.",
+              "The government funded the new park.",
+              "The government set a clear target.",
+              "The government met with the teachers.",
+              "The government changed the law."
+            ],
+            "accepted": [
+              "government"
+            ],
+            "explanation": "A government is the group of people who run a country or area.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 157
+          },
+          {
+            "year": "5-6",
+            "family": "guarantee",
+            "word": "guarantee",
+            "slug": "guarantee",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "guarantee"
+            ],
+            "sentence": "I cannot guarantee sunny weather.",
+            "sentences": [
+              "I cannot guarantee sunny weather.",
+              "The shop offered a guarantee on the bike.",
+              "This kettle has a five year guarantee.",
+              "We kept the receipt for the guarantee.",
+              "The coach could not guarantee a win.",
+              "The card gives a guarantee for repairs.",
+              "No one can guarantee sunny weather.",
+              "The company sent a guarantee by email.",
+              "The toy came with a guarantee against faults.",
+              "I need a guarantee before I sign."
+            ],
+            "accepted": [
+              "guarantee"
+            ],
+            "explanation": "A guarantee is a firm promise that something will happen or work as expected.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 158
+          },
+          {
+            "year": "5-6",
+            "family": "harass",
+            "word": "harass",
+            "slug": "harass",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "harass"
+            ],
+            "sentence": "It is wrong to harass others online.",
+            "sentences": [
+              "It is wrong to harass others online.",
+              "Do not harass other children online.",
+              "Some people harass animals and that is wrong.",
+              "The bully tried to harass the new pupil.",
+              "We must never harass anyone at school.",
+              "The gang tried to harass the shop owner.",
+              "We should not harass the birds in the park.",
+              "It is wrong to harass a classmate.",
+              "The players must not harass the referee.",
+              "The police warned them not to harass the family."
+            ],
+            "accepted": [
+              "harass"
+            ],
+            "explanation": "To harass means to repeatedly trouble, bother or upset someone.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 159
+          },
+          {
+            "year": "5-6",
+            "family": "hindrance",
+            "word": "hindrance",
+            "slug": "hindrance",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "hindrance"
+            ],
+            "sentence": "The broken gate was a hindrance to progress.",
+            "sentences": [
+              "The broken gate was a hindrance to progress.",
+              "A broken fence was a hindrance to the game.",
+              "Rain can be a hindrance to our walk.",
+              "The heavy bag became a hindrance on the stairs.",
+              "Loud noise was a hindrance to my reading.",
+              "The narrow bridge was a hindrance for the truck.",
+              "Fear can be a hindrance when you try new things.",
+              "A missing key was a hindrance to the plan.",
+              "Poor light was a hindrance in the hall.",
+              "The sand was a hindrance to the bike wheels."
+            ],
+            "accepted": [
+              "hindrance"
+            ],
+            "explanation": "A hindrance is something that gets in the way or makes progress harder.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 160
+          },
+          {
+            "year": "5-6",
+            "family": "identity",
+            "word": "identity",
+            "slug": "identity",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "identity"
+            ],
+            "sentence": "Your identity should stay private online.",
+            "sentences": [
+              "Your identity should stay private online.",
+              "The passport proved her identity.",
+              "He kept his identity card in a safe place.",
+              "A name badge can confirm your identity.",
+              "The actor tried to hide his identity behind a mask.",
+              "The coach checked the identity of each player.",
+              "The form asked for proof of identity.",
+              "The detective worked hard to discover the thief's identity.",
+              "The website tells users to protect their identity.",
+              "A uniform can hide identity in a crowd."
+            ],
+            "accepted": [
+              "identity"
+            ],
+            "explanation": "Identity is who a person is, including the qualities that make them unique.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 161
+          },
+          {
+            "year": "5-6",
+            "family": "immediate(ly)",
+            "word": "immediate",
+            "slug": "immediate",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "immediate",
+              "immediately"
+            ],
+            "sentence": "We need an immediate response.",
+            "sentences": [
+              "We need an immediate response.",
+              "The doctor gave immediate help.",
+              "We needed immediate action after the alarm.",
+              "Her immediate answer was correct.",
+              "The storm caused immediate damage.",
+              "Please give immediate attention to the spill.",
+              "The message had immediate effect.",
+              "The teacher asked for immediate silence.",
+              "The team made an immediate start.",
+              "The repair gave immediate results."
+            ],
+            "accepted": [
+              "immediate"
+            ],
+            "explanation": "Immediate means happening now or without delay.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 162
+          },
+          {
+            "year": "5-6",
+            "family": "immediate(ly)",
+            "word": "immediately",
+            "slug": "immediately",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "immediate",
+              "immediately"
+            ],
+            "sentence": "Please come here immediately.",
+            "sentences": [
+              "Please come here immediately.",
+              "She replied immediately.",
+              "We left immediately after lunch.",
+              "He ran immediately to the gate.",
+              "The bell rang immediately before the test.",
+              "The nurse came immediately.",
+              "Please open the window immediately.",
+              "They packed away immediately.",
+              "The car stopped immediately.",
+              "I knew immediately that it was right."
+            ],
+            "accepted": [
+              "immediately"
+            ],
+            "explanation": "Immediately means straight away or without delay.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 163
+          },
+          {
+            "year": "5-6",
+            "family": "individual",
+            "word": "individual",
+            "slug": "individual",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "individual"
+            ],
+            "sentence": "Each individual plant needs water.",
+            "sentences": [
+              "Each individual plant needs water.",
+              "Each individual had a different badge.",
+              "The teacher spoke to each individual pupil.",
+              "An individual choice can change the result.",
+              "Every individual answer was checked.",
+              "The artist painted one individual flower.",
+              "We counted each individual leaf.",
+              "An individual plan may suit one child.",
+              "The doctor met each individual patient.",
+              "The game gave each individual player a turn."
+            ],
+            "accepted": [
+              "individual"
+            ],
+            "explanation": "An individual is one person or thing, separate from a group.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 164
+          },
+          {
+            "year": "5-6",
+            "family": "interfere",
+            "word": "interfere",
+            "slug": "interfere",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "interfere"
+            ],
+            "sentence": "Do not interfere with the experiment.",
+            "sentences": [
+              "Do not interfere with the experiment.",
+              "Do not interfere with the wires.",
+              "I will not interfere in your game.",
+              "Please do not interfere with the experiment.",
+              "The wind can interfere with the signal.",
+              "Her questions did not interfere with the lesson.",
+              "We should not interfere with wildlife.",
+              "The branch might interfere with the window.",
+              "He tried to interfere with the work.",
+              "Noise can interfere with your hearing."
+            ],
+            "accepted": [
+              "interfere"
+            ],
+            "explanation": "To interfere means to get involved in a way that causes problems or is not wanted.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 165
+          },
+          {
+            "year": "5-6",
+            "family": "interrupt",
+            "word": "interrupt",
+            "slug": "interrupt",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "interrupt"
+            ],
+            "sentence": "Please do not interrupt the speaker.",
+            "sentences": [
+              "Please do not interrupt the speaker.",
+              "The phone can interrupt the lesson.",
+              "I hate to interrupt your work.",
+              "A siren may interrupt the quiet night.",
+              "She tried not to interrupt the story.",
+              "Loud laughter can interrupt the reading.",
+              "The rain may interrupt the match.",
+              "He would not interrupt the meeting.",
+              "A sudden knock can interrupt our talk.",
+              "The warning did not interrupt the flow."
+            ],
+            "accepted": [
+              "interrupt"
+            ],
+            "explanation": "To interrupt means to stop someone while they are speaking or doing something.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 166
+          },
+          {
+            "year": "5-6",
+            "family": "language",
+            "word": "language",
+            "slug": "language",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "language"
+            ],
+            "sentence": "French is a beautiful language.",
+            "sentences": [
+              "French is a beautiful language.",
+              "We learn language through listening.",
+              "Her language was kind and clear.",
+              "The book uses simple language.",
+              "He spoke a foreign language at home.",
+              "The teacher explained the language rule.",
+              "Good language helps us understand each other.",
+              "The poem used beautiful language.",
+              "We read language signs on the road.",
+              "The lesson focused on spoken language."
+            ],
+            "accepted": [
+              "language"
+            ],
+            "explanation": "Language is a system of words and signs that people use to communicate.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 167
+          },
+          {
+            "year": "5-6",
+            "family": "leisure",
+            "word": "leisure",
+            "slug": "leisure",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "leisure"
+            ],
+            "sentence": "Reading is one of my leisure activities.",
+            "sentences": [
+              "Reading is one of my leisure activities.",
+              "We spent our leisure in the park.",
+              "Reading is a good leisure activity.",
+              "The village has a leisure centre.",
+              "He enjoyed his leisure after homework.",
+              "The class learned about leisure time.",
+              "They used their leisure to play chess.",
+              "The coach asked about leisure choices.",
+              "The family travelled during their leisure.",
+              "The garden gave us leisure and calm."
+            ],
+            "accepted": [
+              "leisure"
+            ],
+            "explanation": "Leisure is free time when you can rest or enjoy activities.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 168
+          },
+          {
+            "year": "5-6",
+            "family": "lightning",
+            "word": "lightning",
+            "slug": "lightning",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "lightning"
+            ],
+            "sentence": "A flash of lightning lit the sky.",
+            "sentences": [
+              "A flash of lightning lit the sky.",
+              "The storm brought bright lightning.",
+              "We saw lightning over the hill.",
+              "Lightning flashed across the sky.",
+              "The dog hid during the lightning.",
+              "The report warned of lightning tonight.",
+              "Lightning struck the tree near the road.",
+              "We heard thunder after the lightning.",
+              "The field was lit by lightning.",
+              "The pilot watched lightning from above."
+            ],
+            "accepted": [
+              "lightning"
+            ],
+            "explanation": "Lightning is a bright flash of electricity in the sky during a storm.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 169
+          },
+          {
+            "year": "5-6",
+            "family": "marvellous",
+            "word": "marvellous",
+            "slug": "marvellous",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "marvellous"
+            ],
+            "sentence": "We had a marvellous day at the beach.",
+            "sentences": [
+              "We had a marvellous day at the beach.",
+              "The cake tasted marvellous.",
+              "We had a marvellous day at the coast.",
+              "Her drawing looked marvellous.",
+              "The view from the hill was marvellous.",
+              "He gave a marvellous answer.",
+              "The match was marvellous to watch.",
+              "The garden smelled marvellous after rain.",
+              "Your idea is marvellous for the play.",
+              "The show was marvellous from start to finish."
+            ],
+            "accepted": [
+              "marvellous"
+            ],
+            "explanation": "Marvellous means wonderful or very impressive.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 170
+          },
+          {
+            "year": "5-6",
+            "family": "mischievous",
+            "word": "mischievous",
+            "slug": "mischievous",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "mischievous"
+            ],
+            "sentence": "The mischievous cat stole a biscuit.",
+            "sentences": [
+              "The mischievous cat stole a biscuit.",
+              "The mischievous puppy stole a sock.",
+              "A mischievous grin spread across his face.",
+              "The mischievous cat jumped on the shelf.",
+              "Her mischievous trick made us laugh.",
+              "The mischievous child hid the keys.",
+              "We heard a mischievous whisper at the back.",
+              "The mischievous wind blew my hat away.",
+              "His mischievous idea was not very kind.",
+              "The mischievous boy painted the door handle."
+            ],
+            "accepted": [
+              "mischievous"
+            ],
+            "explanation": "Mischievous means playful in a naughty or troublesome way.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 171
+          },
+          {
+            "year": "5-6",
+            "family": "muscle",
+            "word": "muscle",
+            "slug": "muscle",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "muscle"
+            ],
+            "sentence": "You use a muscle to lift your arm.",
+            "sentences": [
+              "You use a muscle to lift your arm.",
+              "The muscle in my arm felt sore.",
+              "Exercise helps build a strong muscle.",
+              "He pulled a muscle during football.",
+              "The doctor checked the muscle in my leg.",
+              "Warm up before you strain a muscle.",
+              "The cat flexed a tiny muscle as it slept.",
+              "The bike ride used every muscle in my legs.",
+              "She stretched the muscle after running.",
+              "A healthy diet helps each muscle grow."
+            ],
+            "accepted": [
+              "muscle"
+            ],
+            "explanation": "A muscle is body tissue that tightens and relaxes to help you move.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 172
+          },
+          {
+            "year": "5-6",
+            "family": "necessary",
+            "word": "necessary",
+            "slug": "necessary",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "necessary"
+            ],
+            "sentence": "A helmet is necessary for safety.",
+            "sentences": [
+              "A helmet is necessary for safety.",
+              "It is necessary to wear a coat.",
+              "Water is necessary for life.",
+              "A map is necessary on this walk.",
+              "Good sleep is necessary before a test.",
+              "It was necessary to stop and rest.",
+              "These tools are necessary for the job.",
+              "A ticket is necessary to enter.",
+              "It is necessary to read the rules.",
+              "The teacher said silence was necessary."
+            ],
+            "accepted": [
+              "necessary"
+            ],
+            "explanation": "Necessary means needed or required.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 173
+          },
+          {
+            "year": "5-6",
+            "family": "neighbour",
+            "word": "neighbour",
+            "slug": "neighbour",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "neighbour"
+            ],
+            "sentence": "Our neighbour brought over some cake.",
+            "sentences": [
+              "Our neighbour brought over some cake.",
+              "Our neighbour brought us apples.",
+              "The neighbour next door has a dog.",
+              "We waved to our neighbour over the fence.",
+              "The neighbour helped carry the bags.",
+              "A kind neighbour fixed the gate.",
+              "The neighbour from across the road smiled.",
+              "We thanked our neighbour for the card.",
+              "The neighbour planted flowers by the wall.",
+              "Our neighbour keeps a tidy garden."
+            ],
+            "accepted": [
+              "neighbour"
+            ],
+            "explanation": "A neighbour is someone who lives near you.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 174
+          },
+          {
+            "year": "5-6",
+            "family": "nuisance",
+            "word": "nuisance",
+            "slug": "nuisance",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "nuisance"
+            ],
+            "sentence": "The dripping tap became a nuisance.",
+            "sentences": [
+              "The dripping tap became a nuisance.",
+              "The broken bell was a nuisance.",
+              "Mud on the floor is a nuisance.",
+              "The loud noise became a nuisance.",
+              "Wasps can be a nuisance in summer.",
+              "A dripping tap is a nuisance.",
+              "The rain was a nuisance during lunch.",
+              "The old alarm proved a nuisance.",
+              "That loose stone is a nuisance on the path.",
+              "The extra delay was a nuisance for everyone."
+            ],
+            "accepted": [
+              "nuisance"
+            ],
+            "explanation": "A nuisance is a person or thing that annoys or causes trouble.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 175
+          },
+          {
+            "year": "5-6",
+            "family": "occupy",
+            "word": "occupy",
+            "slug": "occupy",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "occupy"
+            ],
+            "sentence": "The boxes occupy too much space.",
+            "sentences": [
+              "The boxes occupy too much space.",
+              "The books occupy the whole shelf.",
+              "The team will occupy the hall.",
+              "Our bags occupy the back seat.",
+              "The workers occupy the room all morning.",
+              "Clouds occupy the sky before rain.",
+              "The new boxes occupy too much space.",
+              "The tourists occupy the benches at lunch.",
+              "The lessons occupy most of the day.",
+              "The ants occupy the crack in the wall."
+            ],
+            "accepted": [
+              "occupy"
+            ],
+            "explanation": "To occupy means to take up space, live in a place or keep someone busy.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 176
+          },
+          {
+            "year": "5-6",
+            "family": "occur",
+            "word": "occur",
+            "slug": "occur",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "occur"
+            ],
+            "sentence": "Mistakes can occur when we rush.",
+            "sentences": [
+              "Mistakes can occur when we rush.",
+              "Delays often occur in bad weather.",
+              "Accidents can occur on icy roads.",
+              "Problems can occur with old machines.",
+              "The event will occur next week.",
+              "A sudden change can occur overnight.",
+              "Thunderstorms can occur in summer.",
+              "It may occur to you later.",
+              "Such errors occur quite often.",
+              "Flooding can occur after heavy rain."
+            ],
+            "accepted": [
+              "occur"
+            ],
+            "explanation": "To occur means to happen or take place.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 177
+          },
+          {
+            "year": "5-6",
+            "family": "opportunity",
+            "word": "opportunity",
+            "slug": "opportunity",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "opportunity"
+            ],
+            "sentence": "This trip is a great opportunity.",
+            "sentences": [
+              "This trip is a great opportunity.",
+              "Every child should get an opportunity to learn.",
+              "The trip gave us an opportunity to explore.",
+              "She took the opportunity to ask a question.",
+              "The club offers an opportunity to play chess.",
+              "We had an opportunity to visit the farm.",
+              "The job gave him an opportunity to help others.",
+              "This is a good opportunity to practise.",
+              "They used the opportunity to share ideas.",
+              "The lesson gave me an opportunity to read aloud."
+            ],
+            "accepted": [
+              "opportunity"
+            ],
+            "explanation": "An opportunity is a chance to do something.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 178
+          },
+          {
+            "year": "5-6",
+            "family": "parliament",
+            "word": "parliament",
+            "slug": "parliament",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "parliament"
+            ],
+            "sentence": "Parliament debated the new law.",
+            "sentences": [
+              "Parliament debated the new law.",
+              "We learned how parliament makes laws.",
+              "A question was raised in parliament.",
+              "Members of parliament spoke clearly.",
+              "The guide pointed to the parliament building.",
+              "Parliament voted on the change.",
+              "A speech in parliament can affect the whole country.",
+              "The news showed parliament in session.",
+              "We learned how parliament works.",
+              "Parliament discussed school funding."
+            ],
+            "accepted": [
+              "parliament"
+            ],
+            "explanation": "Parliament is the group of elected people who make laws in the UK and some other countries.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 179
+          },
+          {
+            "year": "5-6",
+            "family": "persuade",
+            "word": "persuade",
+            "slug": "persuade",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "persuade"
+            ],
+            "sentence": "Can you persuade him to join us.",
+            "sentences": [
+              "Can you persuade him to join us.",
+              "I tried to persuade my friend to join the game.",
+              "The poster helped persuade the class to recycle.",
+              "Mum could not persuade me to go to bed early.",
+              "We may need facts to persuade the council.",
+              "The coach tried to persuade everyone to keep going.",
+              "A calm voice can persuade people to listen.",
+              "She used a chart to persuade the group.",
+              "He will persuade his brother to share the seat.",
+              "The letter should persuade the reader to help."
+            ],
+            "accepted": [
+              "persuade"
+            ],
+            "explanation": "To persuade means to convince someone to do or believe something.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 180
+          },
+          {
+            "year": "5-6",
+            "family": "physical",
+            "word": "physical",
+            "slug": "physical",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "physical"
+            ],
+            "sentence": "Swimming gives you physical exercise.",
+            "sentences": [
+              "Swimming gives you physical exercise.",
+              "Swimming is a physical activity.",
+              "The nurse checked my physical health after the race.",
+              "We did a physical warm-up before football.",
+              "The box was too heavy for physical work alone.",
+              "She felt better after some physical exercise.",
+              "The storm caused physical damage to the fence.",
+              "Our lesson included a physical challenge.",
+              "He needed physical rest after the long walk.",
+              "A physical map can help on a hike."
+            ],
+            "accepted": [
+              "physical"
+            ],
+            "explanation": "Physical means connected with the body or with things you can touch.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 181
+          },
+          {
+            "year": "5-6",
+            "family": "prejudice",
+            "word": "prejudice",
+            "slug": "prejudice",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "prejudice"
+            ],
+            "sentence": "We should challenge prejudice when we see it.",
+            "sentences": [
+              "We should challenge prejudice when we see it.",
+              "We should challenge prejudice in the playground.",
+              "The story taught us about prejudice and fairness.",
+              "No one should face prejudice because of their background.",
+              "The class discussed prejudice during assembly.",
+              "She spoke up against prejudice at school.",
+              "Prejudice can stop people from working together.",
+              "The museum display explained prejudice in history.",
+              "We can learn to spot prejudice in jokes.",
+              "The lesson showed how prejudice hurts communities."
+            ],
+            "accepted": [
+              "prejudice"
+            ],
+            "explanation": "Prejudice is an unfair opinion about a person or group formed without enough knowledge.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 182
+          },
+          {
+            "year": "5-6",
+            "family": "privilege",
+            "word": "privilege",
+            "slug": "privilege",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "privilege"
+            ],
+            "sentence": "It was a privilege to meet the author.",
+            "sentences": [
+              "It was a privilege to meet the author.",
+              "Using the science lab is a privilege, not a right.",
+              "She saw the trip as a real privilege.",
+              "It is a privilege to help younger children read.",
+              "He treated the award as a privilege.",
+              "The team felt it was a privilege to represent the school.",
+              "Library time is a privilege when the books are cared for.",
+              "Having that quiet room felt like a privilege.",
+              "For many people, clean water is still a privilege.",
+              "It was a privilege to be invited."
+            ],
+            "accepted": [
+              "privilege"
+            ],
+            "explanation": "A privilege is a special right or advantage.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 183
+          },
+          {
+            "year": "5-6",
+            "family": "profession",
+            "word": "profession",
+            "slug": "profession",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "profession"
+            ],
+            "sentence": "Teaching is a respected profession.",
+            "sentences": [
+              "Teaching is a respected profession.",
+              "Medicine is a profession that needs long training.",
+              "She hopes to choose a profession that helps others.",
+              "Every profession needs skill and practice.",
+              "The doctor spoke about her profession.",
+              "He wants a profession that lets him work outdoors.",
+              "A profession often needs years of study.",
+              "We learned that a profession can change over time.",
+              "The discussion was about which profession might suit each person.",
+              "The careers fair introduced us to each profession in turn."
+            ],
+            "accepted": [
+              "profession"
+            ],
+            "explanation": "A profession is a type of work that needs special training or skill.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 184
+          },
+          {
+            "year": "5-6",
+            "family": "programme",
+            "word": "programme",
+            "slug": "programme",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "programme"
+            ],
+            "sentence": "The school printed a programme for the play.",
+            "sentences": [
+              "The school printed a programme for the play.",
+              "The school printed a programme for the concert.",
+              "We read the programme before the play started.",
+              "The sports programme was on the hall wall.",
+              "She kept the programme as a souvenir.",
+              "The radio programme began after dinner.",
+              "Our class made a programme for parents.",
+              "He checked the programme to find his seat.",
+              "The holiday programme included a boat trip.",
+              "I liked the programme about wild animals."
+            ],
+            "accepted": [
+              "programme"
+            ],
+            "explanation": "A programme is a planned set of activities, or a television or radio show.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 185
+          },
+          {
+            "year": "5-6",
+            "family": "pronunciation",
+            "word": "pronunciation",
+            "slug": "pronunciation",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "pronunciation"
+            ],
+            "sentence": "Her pronunciation was clear and careful.",
+            "sentences": [
+              "Her pronunciation was clear and careful.",
+              "Her pronunciation made the poem easy to follow.",
+              "We practised the pronunciation of each new word.",
+              "The teacher corrected my pronunciation kindly.",
+              "Good pronunciation helps others understand you.",
+              "He asked for help with the pronunciation of choir.",
+              "The app gave tips on pronunciation.",
+              "Our lesson focused on pronunciation and meaning.",
+              "She learned the pronunciation by listening carefully.",
+              "The pronunciation of that word is tricky."
+            ],
+            "accepted": [
+              "pronunciation"
+            ],
+            "explanation": "Pronunciation is the way a word is spoken.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 186
+          },
+          {
+            "year": "5-6",
+            "family": "queue",
+            "word": "queue",
+            "slug": "queue",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "queue"
+            ],
+            "sentence": "We had to queue outside the museum.",
+            "sentences": [
+              "We had to queue outside the museum.",
+              "Please join the queue behind the blue line.",
+              "The queue for ice cream stretched across the playground.",
+              "We waited in a long queue for the tickets.",
+              "He left the queue to fetch his coat.",
+              "The queue moved slowly towards the till.",
+              "Our class formed a neat queue before assembly.",
+              "She stood at the back of the queue.",
+              "The queue grew longer after lunch.",
+              "The family joined the queue for the ferry."
+            ],
+            "accepted": [
+              "queue"
+            ],
+            "explanation": "A queue is a line of people or things waiting for their turn.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 187
+          },
+          {
+            "year": "5-6",
+            "family": "recognise",
+            "word": "recognise",
+            "slug": "recognise",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "recognise"
+            ],
+            "sentence": "I did not recognise him at first.",
+            "sentences": [
+              "I did not recognise him at first.",
+              "I did not recognise her at first.",
+              "The class could recognise the bird by its song.",
+              "You will recognise the sign from yesterday.",
+              "We might recognise the song on the radio.",
+              "He can recognise numbers very quickly.",
+              "I recognise that handwriting from the card.",
+              "The teacher helped us recognise the pattern.",
+              "Some people recognise faces better than others.",
+              "They will recognise the coach by his red coat."
+            ],
+            "accepted": [
+              "recognise",
+              "recognize"
+            ],
+            "explanation": "To recognise means to know someone or something because you have seen it before.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 188
+          },
+          {
+            "year": "5-6",
+            "family": "recommend",
+            "word": "recommend",
+            "slug": "recommend",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "recommend"
+            ],
+            "sentence": "I recommend the chocolate cake.",
+            "sentences": [
+              "I recommend the chocolate cake.",
+              "I recommend the apple pie.",
+              "The nurse will recommend a quiet rest.",
+              "We recommend that you read the map first.",
+              "My teacher can recommend a good book.",
+              "They recommend wearing a coat in winter.",
+              "I recommend this game to my friends.",
+              "The guide will recommend the safest route.",
+              "Can you recommend a film for Friday?",
+              "She would recommend the soup to everyone."
+            ],
+            "accepted": [
+              "recommend"
+            ],
+            "explanation": "To recommend means to say that someone should choose or try something.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 189
+          },
+          {
+            "year": "5-6",
+            "family": "relevant",
+            "word": "relevant",
+            "slug": "relevant",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "relevant"
+            ],
+            "sentence": "Please include only relevant facts.",
+            "sentences": [
+              "Please include only relevant facts.",
+              "Please keep only relevant notes.",
+              "The question was relevant to our lesson.",
+              "We found a relevant page in the book.",
+              "He gave relevant facts about the castle.",
+              "The teacher asked for relevant examples.",
+              "Your answer should stay relevant to the topic.",
+              "She highlighted the relevant part of the report.",
+              "The map was relevant to the trip.",
+              "We listened for relevant clues in the story."
+            ],
+            "accepted": [
+              "relevant"
+            ],
+            "explanation": "Relevant means connected to what is being discussed or needed.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 190
+          },
+          {
+            "year": "5-6",
+            "family": "restaurant",
+            "word": "restaurant",
+            "slug": "restaurant",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "restaurant"
+            ],
+            "sentence": "We ate dinner at a small restaurant.",
+            "sentences": [
+              "We ate dinner at a small restaurant.",
+              "We ate at a small restaurant by the sea.",
+              "The restaurant served soup and bread.",
+              "Our restaurant booking was for six o'clock.",
+              "She liked the restaurant because it was quiet.",
+              "The restaurant menu had a veggie option.",
+              "We met our cousins in the restaurant.",
+              "The restaurant opened early for breakfast.",
+              "I spilled juice in the restaurant and cleaned it up.",
+              "The restaurant had bright lights and soft music."
+            ],
+            "accepted": [
+              "restaurant"
+            ],
+            "explanation": "A restaurant is a place where people pay to sit and eat meals.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 191
+          },
+          {
+            "year": "5-6",
+            "family": "rhyme",
+            "word": "rhyme",
+            "slug": "rhyme",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "rhyme"
+            ],
+            "sentence": "These two words rhyme.",
+            "sentences": [
+              "These two words rhyme.",
+              "The poem had a simple rhyme.",
+              "These two words rhyme well.",
+              "We wrote a short rhyme about rain.",
+              "The rhyme made the song easy to remember.",
+              "Can you hear the rhyme in the last line?",
+              "She practised a rhyme for class.",
+              "The rhyme helped the younger children join in.",
+              "We made a silly rhyme in pairs.",
+              "That rhyme sounds cheerful."
+            ],
+            "accepted": [
+              "rhyme"
+            ],
+            "explanation": "A rhyme is a word or line that has the same ending sound as another.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 192
+          },
+          {
+            "year": "5-6",
+            "family": "rhythm",
+            "word": "rhythm",
+            "slug": "rhythm",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "rhythm"
+            ],
+            "sentence": "The drummer kept a steady rhythm.",
+            "sentences": [
+              "The drummer kept a steady rhythm.",
+              "The drum kept a steady rhythm.",
+              "I could feel the rhythm of the music.",
+              "The class clapped in rhythm.",
+              "She found the rhythm of the song.",
+              "A good rhythm helps dancers stay together.",
+              "The rhythm of the waves was calming.",
+              "He lost the rhythm and started again.",
+              "We practised the rhythm on our desks.",
+              "The runner found a strong rhythm."
+            ],
+            "accepted": [
+              "rhythm"
+            ],
+            "explanation": "Rhythm is a regular pattern of sounds, beats or movements.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 193
+          },
+          {
+            "year": "5-6",
+            "family": "sacrifice",
+            "word": "sacrifice",
+            "slug": "sacrifice",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "sacrifice"
+            ],
+            "sentence": "The team had to sacrifice comfort to win.",
+            "sentences": [
+              "The team had to sacrifice comfort to win.",
+              "We had to sacrifice some free time to finish the model.",
+              "The team made a sacrifice for the final match.",
+              "She did not want to sacrifice her reading time.",
+              "Sometimes you sacrifice comfort for a bigger goal.",
+              "The story showed a brave sacrifice.",
+              "He would sacrifice his break to help a friend.",
+              "We may sacrifice one game to prepare better.",
+              "The charity event was a sacrifice of our Saturday.",
+              "They chose to sacrifice space for more books."
+            ],
+            "accepted": [
+              "sacrifice"
+            ],
+            "explanation": "A sacrifice is giving up something important for a reason or for someone else.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 194
+          },
+          {
+            "year": "5-6",
+            "family": "secretary",
+            "word": "secretary",
+            "slug": "secretary",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "secretary"
+            ],
+            "sentence": "The secretary answered the phone.",
+            "sentences": [
+              "The secretary answered the phone.",
+              "The secretary answered the phone politely.",
+              "Our secretary wrote the meeting notes.",
+              "The secretary kept the records tidy.",
+              "We asked the secretary for the form.",
+              "The school secretary gave me a timetable.",
+              "The secretary checked the appointments list.",
+              "A busy secretary needs good organisation.",
+              "The secretary greeted visitors at the desk.",
+              "She became the club secretary this term."
+            ],
+            "accepted": [
+              "secretary"
+            ],
+            "explanation": "A secretary is a person who organises information, messages and office work.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 195
+          },
+          {
+            "year": "5-6",
+            "family": "shoulder",
+            "word": "shoulder",
+            "slug": "shoulder",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "shoulder"
+            ],
+            "sentence": "She carried the bag on one shoulder.",
+            "sentences": [
+              "She carried the bag on one shoulder.",
+              "The cold wind hit my shoulder.",
+              "He tapped her on the shoulder.",
+              "The jacket slipped off my shoulder.",
+              "He raised one shoulder in a shrug.",
+              "The rucksack rubbed against her shoulder.",
+              "I leaned my shoulder against the wall.",
+              "The nurse looked at his shoulder after the fall.",
+              "A heavy coat hung from my shoulder.",
+              "She rested the tray on her shoulder for a moment."
+            ],
+            "accepted": [
+              "shoulder"
+            ],
+            "explanation": "A shoulder is the part of the body where the arm joins the upper body.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 196
+          },
+          {
+            "year": "5-6",
+            "family": "signature",
+            "word": "signature",
+            "slug": "signature",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "signature"
+            ],
+            "sentence": "Please add your signature at the bottom.",
+            "sentences": [
+              "Please add your signature at the bottom.",
+              "Her signature was neat and small.",
+              "The card needed a signature from a parent.",
+              "He practised his signature on scrap paper.",
+              "The signature proved the letter was real.",
+              "We checked the signature on the form.",
+              "The author wrote a signature in the book.",
+              "The signature matched the one on file.",
+              "She placed her signature beside the date.",
+              "The bank asked for my signature on the form."
+            ],
+            "accepted": [
+              "signature"
+            ],
+            "explanation": "A signature is your name written in your own way to show agreement or identity.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 197
+          },
+          {
+            "year": "5-6",
+            "family": "sincere(ly)",
+            "word": "sincere",
+            "slug": "sincere",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "sincere",
+              "sincerely"
+            ],
+            "sentence": "His apology sounded sincere.",
+            "sentences": [
+              "His apology sounded sincere.",
+              "She gave a sincere smile.",
+              "We were sincere in our thanks.",
+              "That was a sincere effort.",
+              "He made a sincere promise.",
+              "The card had a sincere message.",
+              "I felt sincere concern for my friend.",
+              "Her answer was sincere and thoughtful.",
+              "They offered sincere help after the game.",
+              "The teacher praised his sincere work."
+            ],
+            "accepted": [
+              "sincere"
+            ],
+            "explanation": "Sincere means honest and truly meant.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 198
+          },
+          {
+            "year": "5-6",
+            "family": "sincere(ly)",
+            "word": "sincerely",
+            "slug": "sincerely",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "sincere",
+              "sincerely"
+            ],
+            "sentence": "I sincerely hope you recover soon.",
+            "sentences": [
+              "I sincerely hope you recover soon.",
+              "I sincerely thank you for your help.",
+              "She sincerely hopes to pass the test.",
+              "We sincerely want the garden to grow.",
+              "He sincerely meant every word he said.",
+              "I sincerely agree with your idea.",
+              "They sincerely wished her well.",
+              "She sincerely tried to make it right.",
+              "We sincerely hope for sunshine tomorrow.",
+              "He sincerely listened to the advice."
+            ],
+            "accepted": [
+              "sincerely"
+            ],
+            "explanation": "Sincerely means honestly and truly.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 199
+          },
+          {
+            "year": "5-6",
+            "family": "soldier",
+            "word": "soldier",
+            "slug": "soldier",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "soldier"
+            ],
+            "sentence": "The soldier stood very still.",
+            "sentences": [
+              "The soldier stood very still.",
+              "The soldier stood by the gate.",
+              "We read about a soldier in history.",
+              "The soldier marched across the field.",
+              "The soldier carried a heavy pack.",
+              "She drew a soldier in her sketchbook.",
+              "The soldier helped the villagers after the storm.",
+              "A brave soldier saved the day.",
+              "The soldier saluted the flag.",
+              "The story followed one soldier on patrol."
+            ],
+            "accepted": [
+              "soldier"
+            ],
+            "explanation": "A soldier is a person who serves in an army.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 200
+          },
+          {
+            "year": "5-6",
+            "family": "stomach",
+            "word": "stomach",
+            "slug": "stomach",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "stomach"
+            ],
+            "sentence": "My stomach rumbled before lunch.",
+            "sentences": [
+              "My stomach rumbled before lunch.",
+              "I had a sore stomach after too much cake.",
+              "The roller coaster gave me a nervous stomach.",
+              "She held her stomach and laughed.",
+              "His stomach felt better after rest.",
+              "A warm drink settled my stomach.",
+              "The doctor asked about my stomach pain.",
+              "He felt a flutter in his stomach before the show.",
+              "Too many sweets upset her stomach.",
+              "I used slow breathing to calm my stomach."
+            ],
+            "accepted": [
+              "stomach"
+            ],
+            "explanation": "The stomach is the part inside your body where food begins to be digested.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 201
+          },
+          {
+            "year": "5-6",
+            "family": "sufficient",
+            "word": "sufficient",
+            "slug": "sufficient",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "sufficient"
+            ],
+            "sentence": "We had sufficient time to finish.",
+            "sentences": [
+              "We had sufficient time to finish.",
+              "There was sufficient water for the hike.",
+              "The answer was not sufficient.",
+              "The supplies were sufficient for the class.",
+              "We need sufficient light to read.",
+              "Her proof was sufficient to show the truth.",
+              "The coat was sufficient for the cool day.",
+              "He had sufficient reason to ask again.",
+              "Our budget was sufficient for the trip.",
+              "That explanation was sufficient for me."
+            ],
+            "accepted": [
+              "sufficient"
+            ],
+            "explanation": "Sufficient means enough for what is needed.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 202
+          },
+          {
+            "year": "5-6",
+            "family": "suggest",
+            "word": "suggest",
+            "slug": "suggest",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "suggest"
+            ],
+            "sentence": "I suggest we leave now.",
+            "sentences": [
+              "I suggest we leave now.",
+              "I suggest a shorter route.",
+              "The teacher did not suggest an easy answer.",
+              "We suggest a picnic by the lake.",
+              "Can you suggest a book for me?",
+              "The map may suggest a safer path.",
+              "I suggest we start now.",
+              "She would suggest a game after lunch.",
+              "The clue may suggest the bird is nearby.",
+              "They suggest keeping the door open."
+            ],
+            "accepted": [
+              "suggest"
+            ],
+            "explanation": "To suggest means to put forward an idea or plan.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 203
+          },
+          {
+            "year": "5-6",
+            "family": "symbol",
+            "word": "symbol",
+            "slug": "symbol",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "symbol"
+            ],
+            "sentence": "The crown is a symbol of power.",
+            "sentences": [
+              "The crown is a symbol of power.",
+              "The heart is a symbol of love.",
+              "We learned what each symbol meant.",
+              "The crown was a symbol on the badge.",
+              "A dove can be a symbol of peace.",
+              "The sign uses a simple symbol.",
+              "The flag became a symbol for the town.",
+              "He drew a star symbol on the card.",
+              "The symbol helped us read the chart.",
+              "The key symbol was easy to spot."
+            ],
+            "accepted": [
+              "symbol"
+            ],
+            "explanation": "A symbol is a sign, shape or object that stands for an idea or meaning.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 204
+          },
+          {
+            "year": "5-6",
+            "family": "system",
+            "word": "system",
+            "slug": "system",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "system"
+            ],
+            "sentence": "The school has a new computer system.",
+            "sentences": [
+              "The school has a new computer system.",
+              "Our heating system keeps the hall warm.",
+              "The system for borrowing books is quick.",
+              "The team changed the system for lining up.",
+              "A fair system helps everyone.",
+              "The body uses a system to keep us alive.",
+              "We checked the ticket system at the station.",
+              "The river system runs through the valley.",
+              "The warning system rang loudly.",
+              "The recycling system is simple to follow."
+            ],
+            "accepted": [
+              "system"
+            ],
+            "explanation": "A system is a set of connected parts that work together.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 205
+          },
+          {
+            "year": "5-6",
+            "family": "temperature",
+            "word": "temperature",
+            "slug": "temperature",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "temperature"
+            ],
+            "sentence": "The temperature dropped after sunset.",
+            "sentences": [
+              "The temperature dropped after sunset.",
+              "We checked the temperature of the soup.",
+              "The temperature in the room felt cool.",
+              "A high temperature can make you tired.",
+              "The temperature rose during the afternoon.",
+              "The weather report gave the temperature for today.",
+              "I set the oven temperature carefully.",
+              "The temperature of the water was perfect.",
+              "We measured the temperature outside.",
+              "A steady temperature helped the seedlings grow."
+            ],
+            "accepted": [
+              "temperature"
+            ],
+            "explanation": "Temperature tells how hot or cold something is.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 206
+          },
+          {
+            "year": "5-6",
+            "family": "thorough",
+            "word": "thorough",
+            "slug": "thorough",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "thorough"
+            ],
+            "sentence": "The teacher gave the homework a thorough check.",
+            "sentences": [
+              "The teacher gave the homework a thorough check.",
+              "We made a thorough list before the trip.",
+              "She carried out a thorough search of her school bag.",
+              "The vet gave the puppy a thorough examination.",
+              "A thorough plan helped the day run smoothly.",
+              "He wrote a thorough answer with every step shown.",
+              "The coach asked for a thorough warm-up before the match.",
+              "Dad did a thorough clean of the car.",
+              "The police made a thorough search of the park.",
+              "Our group made a thorough study of the map."
+            ],
+            "accepted": [
+              "thorough"
+            ],
+            "explanation": "Thorough means complete and careful, with nothing important missed.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 207
+          },
+          {
+            "year": "5-6",
+            "family": "twelfth",
+            "word": "twelfth",
+            "slug": "twelfth",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "twelfth"
+            ],
+            "sentence": "His birthday is on the twelfth of June.",
+            "sentences": [
+              "His birthday is on the twelfth of June.",
+              "She finished twelfth in the race.",
+              "We met on the twelfth day of term.",
+              "The twelfth page had the answer.",
+              "He was the twelfth player to arrive.",
+              "The twelfth seat was by the window.",
+              "I wrote the twelfth word on the line.",
+              "The twelfth bell rang at noon.",
+              "Our class is on the twelfth floor.",
+              "The twelfth clue solved the puzzle."
+            ],
+            "accepted": [
+              "twelfth"
+            ],
+            "explanation": "Twelfth means number twelve in order.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 208
+          },
+          {
+            "year": "5-6",
+            "family": "variety",
+            "word": "variety",
+            "slug": "variety",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "variety"
+            ],
+            "sentence": "The market sells a variety of fruit.",
+            "sentences": [
+              "The market sells a variety of fruit.",
+              "We found a variety of shells on the beach.",
+              "The class made a variety of posters.",
+              "A variety of books sat on the shelf.",
+              "The garden had a variety of flowers.",
+              "She chose a variety of snacks for the trip.",
+              "Our menu offers a variety of meals.",
+              "The museum showed a variety of old tools.",
+              "The choir sang a variety of songs.",
+              "He picked a variety of coloured pens."
+            ],
+            "accepted": [
+              "variety"
+            ],
+            "explanation": "Variety means a number of different kinds or a mixture.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 209
+          },
+          {
+            "year": "5-6",
+            "family": "vegetable",
+            "word": "vegetable",
+            "slug": "vegetable",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "vegetable"
+            ],
+            "sentence": "Carrot is my favourite vegetable.",
+            "sentences": [
+              "Carrot is my favourite vegetable.",
+              "We chopped the vegetable for soup.",
+              "The vegetable patch needs water.",
+              "She packed a vegetable in her lunch box.",
+              "A fresh vegetable tasted sweet.",
+              "The shop sold every vegetable we needed.",
+              "He did not like one vegetable at first.",
+              "We grew each vegetable from seed.",
+              "The stew had one vegetable after another.",
+              "My plate included a green vegetable."
+            ],
+            "accepted": [
+              "vegetable"
+            ],
+            "explanation": "A vegetable is a plant or part of a plant eaten as food, such as a carrot.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 210
+          },
+          {
+            "year": "5-6",
+            "family": "vehicle",
+            "word": "vehicle",
+            "slug": "vehicle",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "vehicle"
+            ],
+            "sentence": "The fire engine is a large vehicle.",
+            "sentences": [
+              "The fire engine is a large vehicle.",
+              "We saw a delivery vehicle at the depot.",
+              "The vehicle stopped at the lights.",
+              "Our vehicle took us to the museum.",
+              "The police vehicle flashed its lights.",
+              "A small vehicle can fit on the drive.",
+              "The vehicle rolled slowly down the hill.",
+              "The farmer fixed the vehicle in the shed.",
+              "The vehicle was painted bright yellow.",
+              "They cleaned the vehicle before the trip."
+            ],
+            "accepted": [
+              "vehicle"
+            ],
+            "explanation": "A vehicle is something used to carry people or goods, such as a car, bus or lorry.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 211
+          },
+          {
+            "year": "5-6",
+            "family": "yacht",
+            "word": "yacht",
+            "slug": "yacht",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "yacht"
+            ],
+            "sentence": "We saw a white yacht on the sea.",
+            "sentences": [
+              "We saw a white yacht on the sea.",
+              "The yacht glided across the water.",
+              "A long yacht was moored in the harbour.",
+              "They waved from the yacht.",
+              "The yacht had bright blue sails.",
+              "We counted the windows on the yacht.",
+              "The yacht trip was calm and quiet.",
+              "A small yacht moved near the shore.",
+              "He drew a yacht in his sketchbook.",
+              "The yacht waited by the pier."
+            ],
+            "accepted": [
+              "yacht"
+            ],
+            "explanation": "A yacht is a boat used for sailing or pleasure trips.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 212
+          },
+          {
+            "year": "extra",
+            "family": "Word-building verbs",
+            "word": "divide",
+            "slug": "divide",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "divide",
+              "division",
+              "divisible"
+            ],
+            "sentence": "We divide the class into teams before the investigation.",
+            "sentences": [
+              "We divide the class into teams before the investigation."
+            ],
+            "accepted": [
+              "divide"
+            ],
+            "variants": [
+              {
+                "word": "division",
+                "sentence": "The division of the class into teams was fair.",
+                "sentences": [
+                  "The division of the class into teams was fair."
+                ],
+                "accepted": [
+                  "division"
+                ],
+                "explanation": "Division is the act of splitting something into parts or groups.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the divide base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              },
+              {
+                "word": "divisible",
+                "sentence": "Twenty is divisible by five.",
+                "sentences": [
+                  "Twenty is divisible by five."
+                ],
+                "accepted": [
+                  "divisible"
+                ],
+                "explanation": "Divisible means able to be divided exactly by a number.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the divide base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 2
+              }
+            ],
+            "explanation": "To divide is to split something into parts or groups.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "word",
+              "building",
+              "verbs"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 213
+          },
+          {
+            "year": "extra",
+            "family": "Word-building verbs",
+            "word": "collide",
+            "slug": "collide",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "collide",
+              "collision"
+            ],
+            "sentence": "The two balls collide in the middle of the table.",
+            "sentences": [
+              "The two balls collide in the middle of the table."
+            ],
+            "accepted": [
+              "collide"
+            ],
+            "variants": [
+              {
+                "word": "collision",
+                "sentence": "The collision made both balls change direction.",
+                "sentences": [
+                  "The collision made both balls change direction."
+                ],
+                "accepted": [
+                  "collision"
+                ],
+                "explanation": "A collision is a crash or strong hit between moving things.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the collide base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              }
+            ],
+            "explanation": "To collide is to crash into something or hit it while moving.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "word",
+              "building",
+              "verbs"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 214
+          },
+          {
+            "year": "extra",
+            "family": "Word-building verbs",
+            "word": "explode",
+            "slug": "explode",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "explode",
+              "explosion",
+              "explosive"
+            ],
+            "sentence": "The volcano model did not explode until the final step.",
+            "sentences": [
+              "The volcano model did not explode until the final step."
+            ],
+            "accepted": [
+              "explode"
+            ],
+            "variants": [
+              {
+                "word": "explosion",
+                "sentence": "The experiment caused a safe foam explosion.",
+                "sentences": [
+                  "The experiment caused a safe foam explosion."
+                ],
+                "accepted": [
+                  "explosion"
+                ],
+                "explanation": "An explosion is a sudden burst with force, noise or energy.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the explode base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              },
+              {
+                "word": "explosive",
+                "sentence": "The explosive reaction was controlled by the teacher.",
+                "sentences": [
+                  "The explosive reaction was controlled by the teacher."
+                ],
+                "accepted": [
+                  "explosive"
+                ],
+                "explanation": "Explosive means able to burst apart suddenly with force.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the explode base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 2
+              }
+            ],
+            "explanation": "To explode is to burst apart suddenly with force.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "word",
+              "building",
+              "verbs"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 215
+          },
+          {
+            "year": "extra",
+            "family": "Word-building verbs",
+            "word": "corrode",
+            "slug": "corrode",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "corrode",
+              "corrosion",
+              "corrosive"
+            ],
+            "sentence": "Salt water can corrode metal over time.",
+            "sentences": [
+              "Salt water can corrode metal over time."
+            ],
+            "accepted": [
+              "corrode"
+            ],
+            "variants": [
+              {
+                "word": "corrosion",
+                "sentence": "Corrosion weakened the old metal gate.",
+                "sentences": [
+                  "Corrosion weakened the old metal gate."
+                ],
+                "accepted": [
+                  "corrosion"
+                ],
+                "explanation": "Corrosion is the slow damage caused by a chemical reaction, often rust.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the corrode base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              },
+              {
+                "word": "corrosive",
+                "sentence": "The corrosive liquid was handled with care.",
+                "sentences": [
+                  "The corrosive liquid was handled with care."
+                ],
+                "accepted": [
+                  "corrosive"
+                ],
+                "explanation": "Corrosive means able to slowly damage a material by chemical action.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the corrode base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 2
+              }
+            ],
+            "explanation": "To corrode is to be slowly damaged by a chemical reaction, often rust.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "word",
+              "building",
+              "verbs"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 216
+          },
+          {
+            "year": "extra",
+            "family": "Word-building verbs",
+            "word": "conclude",
+            "slug": "conclude",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "conclude",
+              "conclusion"
+            ],
+            "sentence": "We conclude that shade slows the melting ice.",
+            "sentences": [
+              "We conclude that shade slows the melting ice."
+            ],
+            "accepted": [
+              "conclude"
+            ],
+            "variants": [
+              {
+                "word": "conclusion",
+                "sentence": "Her conclusion matched the evidence from the test.",
+                "sentences": [
+                  "Her conclusion matched the evidence from the test."
+                ],
+                "accepted": [
+                  "conclusion"
+                ],
+                "explanation": "A conclusion is the final decision or ending reached after thinking.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the conclude base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              }
+            ],
+            "explanation": "To conclude is to finish, or to decide after thinking about evidence.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "word",
+              "building",
+              "verbs"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 217
+          },
+          {
+            "year": "extra",
+            "family": "Word-building verbs",
+            "word": "extend",
+            "slug": "extend",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "extend",
+              "extension",
+              "extended"
+            ],
+            "sentence": "The bridge can extend across the stream.",
+            "sentences": [
+              "The bridge can extend across the stream."
+            ],
+            "accepted": [
+              "extend"
+            ],
+            "variants": [
+              {
+                "word": "extension",
+                "sentence": "The bridge extension reached the other bank.",
+                "sentences": [
+                  "The bridge extension reached the other bank."
+                ],
+                "accepted": [
+                  "extension"
+                ],
+                "explanation": "An extension is an added part or an increase in length or time.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the extend base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              },
+              {
+                "word": "extended",
+                "sentence": "The extended table gave everyone space.",
+                "sentences": [
+                  "The extended table gave everyone space."
+                ],
+                "accepted": [
+                  "extended"
+                ],
+                "explanation": "Extended means made longer or lasting for more time.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the extend base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 2
+              }
+            ],
+            "explanation": "To extend is to make something longer or reach further.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "word",
+              "building",
+              "verbs"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 218
+          },
+          {
+            "year": "extra",
+            "family": "Word-building verbs",
+            "word": "comprehend",
+            "slug": "comprehend",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "comprehend",
+              "comprehension"
+            ],
+            "sentence": "She could comprehend the instructions after reading them twice.",
+            "sentences": [
+              "She could comprehend the instructions after reading them twice."
+            ],
+            "accepted": [
+              "comprehend"
+            ],
+            "variants": [
+              {
+                "word": "comprehension",
+                "sentence": "Good comprehension helped her answer the questions.",
+                "sentences": [
+                  "Good comprehension helped her answer the questions."
+                ],
+                "accepted": [
+                  "comprehension"
+                ],
+                "explanation": "Comprehension is the ability to understand something.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the comprehend base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              }
+            ],
+            "explanation": "To comprehend is to understand something fully.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "word",
+              "building",
+              "verbs"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 219
+          },
+          {
+            "year": "extra",
+            "family": "Word-building verbs",
+            "word": "evade",
+            "slug": "evade",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "evade",
+              "evasion",
+              "evasive"
+            ],
+            "sentence": "The beetle tried to evade the torchlight under a leaf.",
+            "sentences": [
+              "The beetle tried to evade the torchlight under a leaf."
+            ],
+            "accepted": [
+              "evade"
+            ],
+            "variants": [
+              {
+                "word": "evasion",
+                "sentence": "The quick evasion helped the player dodge the tackle.",
+                "sentences": [
+                  "The quick evasion helped the player dodge the tackle."
+                ],
+                "accepted": [
+                  "evasion"
+                ],
+                "explanation": "Evasion is the act of avoiding or escaping something.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the evade base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              },
+              {
+                "word": "evasive",
+                "sentence": "His evasive answer did not explain the mistake.",
+                "sentences": [
+                  "His evasive answer did not explain the mistake."
+                ],
+                "accepted": [
+                  "evasive"
+                ],
+                "explanation": "Evasive means trying to avoid something or not answer directly.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the evade base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 2
+              }
+            ],
+            "explanation": "To evade is to avoid or escape from someone or something.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "word",
+              "building",
+              "verbs"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 220
+          },
+          {
+            "year": "extra",
+            "family": "Word-building verbs",
+            "word": "intrude",
+            "slug": "intrude",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "intrude",
+              "intrusion",
+              "intrusive"
+            ],
+            "sentence": "Please do not intrude while the group is recording.",
+            "sentences": [
+              "Please do not intrude while the group is recording."
+            ],
+            "accepted": [
+              "intrude"
+            ],
+            "variants": [
+              {
+                "word": "intrusion",
+                "sentence": "The loud noise was an intrusion during the recording.",
+                "sentences": [
+                  "The loud noise was an intrusion during the recording."
+                ],
+                "accepted": [
+                  "intrusion"
+                ],
+                "explanation": "An intrusion is an unwanted entry or interruption.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the intrude base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              },
+              {
+                "word": "intrusive",
+                "sentence": "The intrusive sound disturbed the quiet lesson.",
+                "sentences": [
+                  "The intrusive sound disturbed the quiet lesson."
+                ],
+                "accepted": [
+                  "intrusive"
+                ],
+                "explanation": "Intrusive means entering or interrupting where it is not wanted.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the intrude base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 2
+              }
+            ],
+            "explanation": "To intrude is to enter or join in where you are not wanted.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "word",
+              "building",
+              "verbs"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 221
+          },
+          {
+            "year": "extra",
+            "family": "Word-building verbs",
+            "word": "interlude",
+            "slug": "interlude",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "interlude",
+              "interludes"
+            ],
+            "sentence": "A quiet interlude gave the performers time to reset.",
+            "sentences": [
+              "A quiet interlude gave the performers time to reset."
+            ],
+            "accepted": [
+              "interlude"
+            ],
+            "variants": [
+              {
+                "word": "interludes",
+                "sentence": "The play had two short interludes.",
+                "sentences": [
+                  "The play had two short interludes."
+                ],
+                "accepted": [
+                  "interludes"
+                ],
+                "explanation": "Interludes are short pauses or breaks between parts of something.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the interlude base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              }
+            ],
+            "explanation": "An interlude is a short pause or break between parts of something.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "word",
+              "building",
+              "verbs"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 222
+          },
+          {
+            "year": "extra",
+            "family": "Science: classification",
+            "word": "classification",
+            "slug": "classification",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "classification",
+              "classify",
+              "classified"
+            ],
+            "sentence": "Classification helps scientists compare animals with similar features.",
+            "sentences": [
+              "Classification helps scientists compare animals with similar features."
+            ],
+            "accepted": [
+              "classification"
+            ],
+            "variants": [
+              {
+                "word": "classify",
+                "sentence": "Scientists classify living things by their features.",
+                "sentences": [
+                  "Scientists classify living things by their features."
+                ],
+                "accepted": [
+                  "classify"
+                ],
+                "explanation": "To classify is to sort things into groups by shared features.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the classification base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              },
+              {
+                "word": "classified",
+                "sentence": "The leaves were classified by shape and size.",
+                "sentences": [
+                  "The leaves were classified by shape and size."
+                ],
+                "accepted": [
+                  "classified"
+                ],
+                "explanation": "Classified means sorted into groups by type or feature.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the classification base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 2
+              }
+            ],
+            "explanation": "Classification is sorting living things or objects into groups by shared features.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "science",
+              "classification"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 223
+          },
+          {
+            "year": "extra",
+            "family": "Science: body structure",
+            "word": "backbone",
+            "slug": "backbone",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "backbone",
+              "backbones"
+            ],
+            "sentence": "A fish has a backbone inside its body.",
+            "sentences": [
+              "A fish has a backbone inside its body."
+            ],
+            "accepted": [
+              "backbone"
+            ],
+            "variants": [
+              {
+                "word": "backbones",
+                "sentence": "The model showed how backbones protect the spinal cord.",
+                "sentences": [
+                  "The model showed how backbones protect the spinal cord."
+                ],
+                "accepted": [
+                  "backbones"
+                ],
+                "explanation": "Backbones are rows of bones that support the backs of some animals.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the backbone base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              }
+            ],
+            "explanation": "A backbone is the row of bones that supports the back.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "science",
+              "body",
+              "structure"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 224
+          },
+          {
+            "year": "extra",
+            "family": "Science: body structure",
+            "word": "skeleton",
+            "slug": "skeleton",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "skeleton",
+              "skeletal"
+            ],
+            "sentence": "The skeleton protects important organs.",
+            "sentences": [
+              "The skeleton protects important organs."
+            ],
+            "accepted": [
+              "skeleton"
+            ],
+            "variants": [
+              {
+                "word": "skeletal",
+                "sentence": "The diagram showed the skeletal system clearly.",
+                "sentences": [
+                  "The diagram showed the skeletal system clearly."
+                ],
+                "accepted": [
+                  "skeletal"
+                ],
+                "explanation": "Skeletal means connected with the skeleton or bones.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the skeleton base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              }
+            ],
+            "explanation": "A skeleton is the frame of bones that supports a body.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "science",
+              "body",
+              "structure"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 225
+          },
+          {
+            "year": "extra",
+            "family": "Science: animal groups",
+            "word": "cold-blooded",
+            "slug": "cold-blooded",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "cold-blooded"
+            ],
+            "sentence": "A cold-blooded reptile warms itself on a rock.",
+            "sentences": [
+              "A cold-blooded reptile warms itself on a rock."
+            ],
+            "accepted": [
+              "cold-blooded",
+              "cold blooded"
+            ],
+            "explanation": "Cold-blooded animals depend on their surroundings to control body temperature.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "science",
+              "animal",
+              "groups"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 226
+          },
+          {
+            "year": "extra",
+            "family": "Science: animal groups",
+            "word": "amphibians",
+            "slug": "amphibians",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "amphibians",
+              "amphibian"
+            ],
+            "sentence": "Many amphibians begin life in water as tadpoles.",
+            "sentences": [
+              "Many amphibians begin life in water as tadpoles."
+            ],
+            "accepted": [
+              "amphibians"
+            ],
+            "variants": [
+              {
+                "word": "amphibian",
+                "sentence": "A frog is an amphibian with moist skin.",
+                "sentences": [
+                  "A frog is an amphibian with moist skin."
+                ],
+                "accepted": [
+                  "amphibian"
+                ],
+                "explanation": "An amphibian is an animal that can live in water and on land.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the amphibians base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              }
+            ],
+            "explanation": "Amphibians are animals such as frogs that can live in water and on land.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "science",
+              "animal",
+              "groups"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 227
+          },
+          {
+            "year": "extra",
+            "family": "Science: life cycles",
+            "word": "metamorphosis",
+            "slug": "metamorphosis",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "metamorphosis",
+              "metamorphose"
+            ],
+            "sentence": "A butterfly goes through metamorphosis before it can fly.",
+            "sentences": [
+              "A butterfly goes through metamorphosis before it can fly."
+            ],
+            "accepted": [
+              "metamorphosis"
+            ],
+            "variants": [
+              {
+                "word": "metamorphose",
+                "sentence": "Some insects metamorphose before they can fly.",
+                "sentences": [
+                  "Some insects metamorphose before they can fly."
+                ],
+                "accepted": [
+                  "metamorphose"
+                ],
+                "explanation": "To metamorphose is to change into a very different adult form.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the metamorphosis base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              }
+            ],
+            "explanation": "Metamorphosis is a major change in body form as an animal grows.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "science",
+              "life",
+              "cycles"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 228
+          },
+          {
+            "year": "extra",
+            "family": "Science: animal groups",
+            "word": "reptiles",
+            "slug": "reptiles",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "reptiles",
+              "reptile"
+            ],
+            "sentence": "Reptiles often lay eggs on land.",
+            "sentences": [
+              "Reptiles often lay eggs on land."
+            ],
+            "accepted": [
+              "reptiles"
+            ],
+            "variants": [
+              {
+                "word": "reptile",
+                "sentence": "A lizard is a reptile that warms itself in sunlight.",
+                "sentences": [
+                  "A lizard is a reptile that warms itself in sunlight."
+                ],
+                "accepted": [
+                  "reptile"
+                ],
+                "explanation": "A reptile is a cold-blooded animal with dry scales.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the reptiles base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              }
+            ],
+            "explanation": "Reptiles are cold-blooded animals with dry scales, such as lizards and snakes.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "science",
+              "animal",
+              "groups"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 229
+          },
+          {
+            "year": "extra",
+            "family": "Science: animal groups",
+            "word": "mammals",
+            "slug": "mammals",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "mammals",
+              "mammal"
+            ],
+            "sentence": "Dolphins and bats are both mammals.",
+            "sentences": [
+              "Dolphins and bats are both mammals."
+            ],
+            "accepted": [
+              "mammals"
+            ],
+            "variants": [
+              {
+                "word": "mammal",
+                "sentence": "A whale is a mammal even though it lives in the sea.",
+                "sentences": [
+                  "A whale is a mammal even though it lives in the sea."
+                ],
+                "accepted": [
+                  "mammal"
+                ],
+                "explanation": "A mammal is a warm-blooded animal that usually feeds its young milk.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the mammals base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              }
+            ],
+            "explanation": "Mammals are warm-blooded animals that usually have hair or fur and feed their young milk.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "science",
+              "animal",
+              "groups"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 230
+          },
+          {
+            "year": "extra",
+            "family": "Science: animal groups",
+            "word": "arachnid",
+            "slug": "arachnid",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "arachnid",
+              "arachnids"
+            ],
+            "sentence": "A spider is an arachnid, not an insect.",
+            "sentences": [
+              "A spider is an arachnid, not an insect."
+            ],
+            "accepted": [
+              "arachnid"
+            ],
+            "variants": [
+              {
+                "word": "arachnids",
+                "sentence": "Spiders and scorpions are arachnids.",
+                "sentences": [
+                  "Spiders and scorpions are arachnids."
+                ],
+                "accepted": [
+                  "arachnids"
+                ],
+                "explanation": "Arachnids are animals with eight legs, such as spiders and scorpions.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the arachnid base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              }
+            ],
+            "explanation": "An arachnid is an animal with eight legs, such as a spider or scorpion.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "science",
+              "animal",
+              "groups"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 231
+          },
+          {
+            "year": "extra",
+            "family": "Science: animal groups",
+            "word": "mollusc",
+            "slug": "mollusc",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "mollusc",
+              "molluscs"
+            ],
+            "sentence": "A snail is a mollusc with a coiled shell.",
+            "sentences": [
+              "A snail is a mollusc with a coiled shell."
+            ],
+            "accepted": [
+              "mollusc"
+            ],
+            "variants": [
+              {
+                "word": "molluscs",
+                "sentence": "Snails and clams are molluscs.",
+                "sentences": [
+                  "Snails and clams are molluscs."
+                ],
+                "accepted": [
+                  "molluscs"
+                ],
+                "explanation": "Molluscs are soft-bodied animals, often with shells.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the mollusc base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              }
+            ],
+            "explanation": "A mollusc is a soft-bodied animal, often with a shell.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "science",
+              "animal",
+              "groups"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 232
+          },
+          {
+            "year": "extra",
+            "family": "Science: plants",
+            "word": "botanist",
+            "slug": "botanist",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "botanist",
+              "botany",
+              "botanical"
+            ],
+            "sentence": "The botanist examined the leaves carefully.",
+            "sentences": [
+              "The botanist examined the leaves carefully."
+            ],
+            "accepted": [
+              "botanist"
+            ],
+            "variants": [
+              {
+                "word": "botany",
+                "sentence": "Botany helped the class understand plant growth.",
+                "sentences": [
+                  "Botany helped the class understand plant growth."
+                ],
+                "accepted": [
+                  "botany"
+                ],
+                "explanation": "Botany is the scientific study of plants.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the botanist base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              },
+              {
+                "word": "botanical",
+                "sentence": "The botanical garden displayed unusual flowers.",
+                "sentences": [
+                  "The botanical garden displayed unusual flowers."
+                ],
+                "accepted": [
+                  "botanical"
+                ],
+                "explanation": "Botanical means connected with plants or the study of plants.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the botanist base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 2
+              }
+            ],
+            "explanation": "A botanist is a scientist who studies plants.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "science",
+              "plants"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 233
+          },
+          {
+            "year": "extra",
+            "family": "Science: plants",
+            "word": "flowering",
+            "slug": "flowering",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "flowering",
+              "flowered",
+              "flowers"
+            ],
+            "sentence": "The flowering plant attracted several bees.",
+            "sentences": [
+              "The flowering plant attracted several bees."
+            ],
+            "accepted": [
+              "flowering"
+            ],
+            "variants": [
+              {
+                "word": "flowered",
+                "sentence": "The plant flowered after several warm days.",
+                "sentences": [
+                  "The plant flowered after several warm days."
+                ],
+                "accepted": [
+                  "flowered"
+                ],
+                "explanation": "Flowered means produced flowers or decorated with flowers.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the flowering base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              },
+              {
+                "word": "flowers",
+                "sentence": "The flowers attracted several bees.",
+                "sentences": [
+                  "The flowers attracted several bees."
+                ],
+                "accepted": [
+                  "flowers"
+                ],
+                "explanation": "Flowers are the parts of plants that often make seeds.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the flowering base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 2
+              }
+            ],
+            "explanation": "Flowering means producing flowers.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "science",
+              "plants"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 234
+          }
+        ],
+        "wordBySlug": {
+          "accident": {
+            "year": "3-4",
+            "family": "accident(ally)",
+            "word": "accident",
+            "slug": "accident",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "accident",
+              "accidentally"
+            ],
+            "sentence": "We saw an accident on the road.",
+            "sentences": [
+              "We saw an accident on the road.",
+              "The cyclist had an accident near the park.",
+              "We called for help after the accident.",
+              "The accident blocked the road for an hour.",
+              "No one was hurt in the accident.",
+              "The school wrote a report about the accident.",
+              "She saw the accident from the bus.",
+              "The accident happened during the morning rain.",
+              "He learned to stay careful after the accident.",
+              "The driver explained the accident to the police."
+            ],
+            "accepted": [
+              "accident"
+            ],
+            "explanation": "An accident is something that happens by chance, often causing damage or a problem.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 0
+          },
+          "accidentally": {
+            "year": "3-4",
+            "family": "accident(ally)",
+            "word": "accidentally",
+            "slug": "accidentally",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "accident",
+              "accidentally"
+            ],
+            "sentence": "I accidentally knocked the cup over.",
+            "sentences": [
+              "I accidentally knocked the cup over.",
+              "I accidentally knocked over the pencil pot.",
+              "She accidentally sent the message to the wrong class.",
+              "He accidentally stepped in a muddy puddle.",
+              "They accidentally pressed the alarm button.",
+              "Mum accidentally bought two packets of rice.",
+              "We accidentally locked the door before lunch.",
+              "The cat accidentally spilled water on the mat.",
+              "Ben accidentally left his coat on the chair.",
+              "I accidentally mixed the blue paint with green."
+            ],
+            "accepted": [
+              "accidentally"
+            ],
+            "explanation": "If you do something accidentally, you do it by mistake and did not mean to.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 1
+          },
+          "actual": {
+            "year": "3-4",
+            "family": "actual(ly)",
+            "word": "actual",
+            "slug": "actual",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "actual",
+              "actually"
+            ],
+            "sentence": "The story is based on actual events.",
+            "sentences": [
+              "The story is based on actual events.",
+              "The actual winner was announced at the end.",
+              "The actual cost was lower than we expected.",
+              "I checked the actual time on my watch.",
+              "She wanted the actual facts, not a rumour.",
+              "We followed the actual path on the map.",
+              "The actual answer was simpler than we first thought.",
+              "The actual size of the box was quite small.",
+              "We saw the actual painting in the museum.",
+              "His actual reason for leaving was never clear."
+            ],
+            "accepted": [
+              "actual"
+            ],
+            "explanation": "Actual means real or true, not guessed or imagined.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 2
+          },
+          "actually": {
+            "year": "3-4",
+            "family": "actual(ly)",
+            "word": "actually",
+            "slug": "actually",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "actual",
+              "actually"
+            ],
+            "sentence": "I actually knew the answer.",
+            "sentences": [
+              "I actually knew the answer.",
+              "I actually enjoy rainy walks.",
+              "She actually knew the way home.",
+              "We actually finished early.",
+              "He actually borrowed my ruler yesterday.",
+              "The game was actually quite exciting.",
+              "I actually forgot my lunch today.",
+              "They actually live on the next street.",
+              "It was actually a simple puzzle.",
+              "The puppy actually slept all afternoon."
+            ],
+            "accepted": [
+              "actually"
+            ],
+            "explanation": "Actually is used to say what is really true, especially when it is different from what someone expected.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 3
+          },
+          "address": {
+            "year": "3-4",
+            "family": "address",
+            "word": "address",
+            "slug": "address",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "address"
+            ],
+            "sentence": "Please write your home address clearly.",
+            "sentences": [
+              "Please write your home address clearly.",
+              "Please write your address clearly on the envelope.",
+              "The letter had the wrong address.",
+              "I memorised my address for the trip.",
+              "She checked the address before posting the card.",
+              "The teacher wrote the office address on the board.",
+              "We moved house, so our address changed.",
+              "He read the address out loud to the class.",
+              "The parcel arrived at the correct address.",
+              "They found the address on the invitation."
+            ],
+            "accepted": [
+              "address"
+            ],
+            "explanation": "An address is the details of where a person or place can be found, such as a house number and street.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 4
+          },
+          "answer": {
+            "year": "3-4",
+            "family": "answer",
+            "word": "answer",
+            "slug": "answer",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "answer"
+            ],
+            "sentence": "I knew the answer at once.",
+            "sentences": [
+              "I knew the answer at once.",
+              "The answer was hidden in the clue.",
+              "She gave a quick answer in class.",
+              "I checked the answer with my partner.",
+              "His answer made the whole group laugh.",
+              "The answer was correct on the first try.",
+              "We wrote the answer neatly in pencil.",
+              "The teacher praised her answer.",
+              "I could not find the answer at first.",
+              "The answer matched the question exactly."
+            ],
+            "accepted": [
+              "answer"
+            ],
+            "explanation": "An answer is what you say or write in reply to a question.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 5
+          },
+          "appear": {
+            "year": "3-4",
+            "family": "appear",
+            "word": "appear",
+            "slug": "appear",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "appear"
+            ],
+            "sentence": "Stars appear when the sky gets dark.",
+            "sentences": [
+              "Stars appear when the sky gets dark.",
+              "A bright star began to appear in the sky.",
+              "The rabbit did not appear from the burrow.",
+              "A smile started to appear on her face.",
+              "Clouds appear quickly before a storm.",
+              "The chalk marks appear after we draw.",
+              "He watched the ship appear on the horizon.",
+              "New flowers appear in the garden each spring.",
+              "The map did not appear on the screen.",
+              "A note will appear beside the score."
+            ],
+            "accepted": [
+              "appear"
+            ],
+            "explanation": "To appear means to come into sight or seem to be a certain way.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 6
+          },
+          "arrive": {
+            "year": "3-4",
+            "family": "arrive",
+            "word": "arrive",
+            "slug": "arrive",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "arrive"
+            ],
+            "sentence": "We will arrive before lunch.",
+            "sentences": [
+              "We will arrive before lunch.",
+              "We arrive at school before the bell.",
+              "The parcel should arrive tomorrow.",
+              "They arrive home together after football.",
+              "I arrive early for choir practice.",
+              "The train did not arrive on time.",
+              "Birds arrive in the garden at dawn.",
+              "Please arrive with your coat and bag.",
+              "We arrive at the museum after lunch.",
+              "The guests arrive through the side gate."
+            ],
+            "accepted": [
+              "arrive"
+            ],
+            "explanation": "To arrive means to reach the place you were travelling to.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 7
+          },
+          "believe": {
+            "year": "3-4",
+            "family": "believe",
+            "word": "believe",
+            "slug": "believe",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "believe"
+            ],
+            "sentence": "I believe you are telling the truth.",
+            "sentences": [
+              "I believe you are telling the truth.",
+              "I believe the story is true.",
+              "She did not believe the rumour.",
+              "We believe he will try his best.",
+              "I believe in working hard.",
+              "They believe the storm will pass.",
+              "Mum and Dad believe the plan will work.",
+              "The class believe the quiz was fair.",
+              "I believe my friend when he speaks.",
+              "Do you believe what you hear?"
+            ],
+            "accepted": [
+              "believe"
+            ],
+            "explanation": "To believe means to think that something is true or to trust someone.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 8
+          },
+          "bicycle": {
+            "year": "3-4",
+            "family": "bicycle",
+            "word": "bicycle",
+            "slug": "bicycle",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "bicycle"
+            ],
+            "sentence": "Her bicycle is leaning against the wall.",
+            "sentences": [
+              "Her bicycle is leaning against the wall.",
+              "My bicycle has a bright red bell.",
+              "He parked his bicycle outside the shop.",
+              "I fixed the tyre on my bicycle.",
+              "Her bicycle is easy to ride.",
+              "The bicycle leaned against the wall.",
+              "We learned to lock the bicycle safely.",
+              "His bicycle lights were very bright.",
+              "I cleaned mud off the bicycle.",
+              "The bicycle basket held my lunch."
+            ],
+            "accepted": [
+              "bicycle"
+            ],
+            "explanation": "A bicycle is a vehicle with two wheels that you ride by pedalling.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 9
+          },
+          "breath": {
+            "year": "3-4",
+            "family": "breath",
+            "word": "breath",
+            "slug": "breath",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "breath"
+            ],
+            "sentence": "Take a deep breath before you dive.",
+            "sentences": [
+              "Take a deep breath before you dive.",
+              "She took a deep breath before singing her solo.",
+              "After the sprint, he was out of breath.",
+              "Hold your breath while you go under the water.",
+              "The cold air caught my breath at the gate.",
+              "I could see my breath on the frosty morning.",
+              "The steep climb left us short of breath.",
+              "One slow breath helped me stay calm.",
+              "The singer paused for breath between the verses.",
+              "He took a breath before answering the question."
+            ],
+            "accepted": [
+              "breath"
+            ],
+            "explanation": "A breath is the air you take into or let out of your lungs.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 10
+          },
+          "breathe": {
+            "year": "3-4",
+            "family": "breathe",
+            "word": "breathe",
+            "slug": "breathe",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "breathe"
+            ],
+            "sentence": "It is easier to breathe in fresh sea air.",
+            "sentences": [
+              "It is easier to breathe in fresh sea air.",
+              "Try to breathe slowly through your nose.",
+              "Breathe deeply and count to four.",
+              "The runner could hardly breathe after the hill.",
+              "Open the window so we can breathe more easily.",
+              "She remembered to breathe before reading aloud.",
+              "Hot air can make it harder to breathe.",
+              "The swimmer turned to breathe between strokes.",
+              "He had to breathe slowly after the sprint.",
+              "We stopped so everyone could breathe again."
+            ],
+            "accepted": [
+              "breathe"
+            ],
+            "explanation": "To breathe means to take air into your lungs and let it out again.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 11
+          },
+          "build": {
+            "year": "3-4",
+            "family": "build",
+            "word": "build",
+            "slug": "build",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "build"
+            ],
+            "sentence": "We used blocks to build a tall tower.",
+            "sentences": [
+              "We used blocks to build a tall tower.",
+              "We build a tower from wooden blocks.",
+              "The workers build a new bridge.",
+              "I build model cars with my brother.",
+              "They build a shelter in the garden.",
+              "The school will build a small library.",
+              "We build confidence through practice.",
+              "Can you build the shape from these pieces?",
+              "The children build a fort in the sand.",
+              "Engineers build strong roads for lorries."
+            ],
+            "accepted": [
+              "build"
+            ],
+            "explanation": "To build means to make something by putting parts together.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 12
+          },
+          "busy": {
+            "year": "3-4",
+            "family": "busy/business",
+            "word": "busy",
+            "slug": "busy",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "busy",
+              "business"
+            ],
+            "sentence": "The shop was busy on Saturday morning.",
+            "sentences": [
+              "The shop was busy on Saturday morning.",
+              "The road was busy after school.",
+              "Mum was busy cooking dinner.",
+              "The shop is busy on Saturdays.",
+              "I was busy finishing my homework.",
+              "The station looked busy at rush hour.",
+              "The office was busy all morning.",
+              "Dad is busy mending the bike.",
+              "The park felt busy with families.",
+              "We were busy packing for the trip."
+            ],
+            "accepted": [
+              "busy"
+            ],
+            "explanation": "Busy means having a lot to do or full of activity.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 13
+          },
+          "business": {
+            "year": "3-4",
+            "family": "busy/business",
+            "word": "business",
+            "slug": "business",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "busy",
+              "business"
+            ],
+            "sentence": "The family business sells fresh bread.",
+            "sentences": [
+              "The family business sells fresh bread.",
+              "Her business sells homemade cakes.",
+              "The business opened near the station.",
+              "He wants to start a small business.",
+              "The business pays its workers on Friday.",
+              "Our business plan was very simple.",
+              "The business needs careful money records.",
+              "She visited the business with her aunt.",
+              "The business grew after the festival.",
+              "They shared ideas for the business."
+            ],
+            "accepted": [
+              "business"
+            ],
+            "explanation": "A business is work or an organisation that sells goods or services.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 14
+          },
+          "calendar": {
+            "year": "3-4",
+            "family": "calendar",
+            "word": "calendar",
+            "slug": "calendar",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "calendar"
+            ],
+            "sentence": "I marked the date on the calendar.",
+            "sentences": [
+              "I marked the date on the calendar.",
+              "I marked the trip on my calendar.",
+              "The calendar shows the school holidays.",
+              "She tore a page from the calendar.",
+              "We checked the calendar for the date.",
+              "The calendar hung above the desk.",
+              "Dad circled his birthday on the calendar.",
+              "I lost my calendar during the move.",
+              "The calendar helps me plan my week.",
+              "Our class calendar has every club day."
+            ],
+            "accepted": [
+              "calendar"
+            ],
+            "explanation": "A calendar shows days, weeks and months of the year.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 15
+          },
+          "caught": {
+            "year": "3-4",
+            "family": "caught",
+            "word": "caught",
+            "slug": "caught",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "caught"
+            ],
+            "sentence": "The goalkeeper caught the ball.",
+            "sentences": [
+              "The goalkeeper caught the ball.",
+              "He caught the ball one-handed.",
+              "I caught a glimpse of the fox.",
+              "The teacher caught the mistake quickly.",
+              "We caught the bus after breakfast.",
+              "She caught the ribbon before it fell.",
+              "The net caught the leaves from the drain.",
+              "I caught myself smiling at the joke.",
+              "They caught the last train home.",
+              "The bucket caught the rain from the roof."
+            ],
+            "accepted": [
+              "caught"
+            ],
+            "explanation": "Caught is the past tense of catch; it can mean grabbed, trapped or noticed doing something.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 16
+          },
+          "centre": {
+            "year": "3-4",
+            "family": "centre",
+            "word": "centre",
+            "slug": "centre",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "centre"
+            ],
+            "sentence": "We met in the centre of town.",
+            "sentences": [
+              "We met in the centre of town.",
+              "The fountain stands in the centre of the square.",
+              "She drew a dot in the centre of the circle.",
+              "The shop is in the centre of the village.",
+              "Place the box in the centre of the table.",
+              "The park lies in the centre of the estate.",
+              "He walked to the centre of the hall.",
+              "The museum is near the centre of the city.",
+              "Put the star in the centre of the card.",
+              "The school is close to the centre of the community."
+            ],
+            "accepted": [
+              "centre"
+            ],
+            "explanation": "The centre is the middle point or main part of something.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 17
+          },
+          "century": {
+            "year": "3-4",
+            "family": "century",
+            "word": "century",
+            "slug": "century",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "century"
+            ],
+            "sentence": "The castle was built a century ago.",
+            "sentences": [
+              "The castle was built a century ago.",
+              "The castle was built in the twelfth century.",
+              "A century has one hundred years.",
+              "The song sounded like it came from another century.",
+              "The town changed a lot in the last century.",
+              "The library opened in the previous century.",
+              "We read about life in the nineteenth century.",
+              "The bridge has stood for a century.",
+              "The museum shows objects from each century.",
+              "My great-grandad was born last century."
+            ],
+            "accepted": [
+              "century"
+            ],
+            "explanation": "A century is a period of one hundred years.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 18
+          },
+          "certain": {
+            "year": "3-4",
+            "family": "certain",
+            "word": "certain",
+            "slug": "certain",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "certain"
+            ],
+            "sentence": "I am certain that this is mine.",
+            "sentences": [
+              "I am certain that this is mine.",
+              "I am certain we locked the door.",
+              "She felt certain about her answer.",
+              "The teacher was certain the class would try.",
+              "We are certain the train is late.",
+              "He was not certain which route to take.",
+              "I am certain my pencil is on the desk.",
+              "They seemed certain before the test began.",
+              "She is certain the cake will rise.",
+              "We were certain of the time."
+            ],
+            "accepted": [
+              "certain"
+            ],
+            "explanation": "Certain means sure, or known to be true.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 19
+          },
+          "circle": {
+            "year": "3-4",
+            "family": "circle",
+            "word": "circle",
+            "slug": "circle",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "circle"
+            ],
+            "sentence": "Please draw a neat circle.",
+            "sentences": [
+              "Please draw a neat circle.",
+              "Draw a circle around the missing number.",
+              "The children sat in a circle for the game.",
+              "I made a neat circle with chalk.",
+              "The planet looked like a bright circle.",
+              "Please circle the word that fits.",
+              "The dancers circle the stage at the end.",
+              "We passed the ball in a circle.",
+              "He pinned a circle badge to his coat.",
+              "The coach asked us to form a circle."
+            ],
+            "accepted": [
+              "circle"
+            ],
+            "explanation": "A circle is a round shape where every point on the edge is the same distance from the centre.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 20
+          },
+          "complete": {
+            "year": "3-4",
+            "family": "complete",
+            "word": "complete",
+            "slug": "complete",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "complete"
+            ],
+            "sentence": "Try to complete the puzzle.",
+            "sentences": [
+              "Try to complete the puzzle.",
+              "Please complete the map carefully.",
+              "I will complete my reading before bed.",
+              "She wants to complete the craft model.",
+              "We complete the checklist together.",
+              "The task is complete once the lid is on.",
+              "He hopes to complete the course this term.",
+              "Can you complete this final line?",
+              "They complete jobs in pairs.",
+              "The meal is complete with fruit for pudding."
+            ],
+            "accepted": [
+              "complete"
+            ],
+            "explanation": "Complete means finished or with nothing missing.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 21
+          },
+          "consider": {
+            "year": "3-4",
+            "family": "consider",
+            "word": "consider",
+            "slug": "consider",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "consider"
+            ],
+            "sentence": "Please consider both sides of the argument.",
+            "sentences": [
+              "Please consider both sides of the argument.",
+              "Please consider my idea carefully.",
+              "We should consider the weather.",
+              "She will consider both choices.",
+              "I consider him a good friend.",
+              "The teacher asked us to consider our work.",
+              "They consider the journey too long.",
+              "I must consider your question.",
+              "We consider safety first.",
+              "He did not consider the noise."
+            ],
+            "accepted": [
+              "consider"
+            ],
+            "explanation": "To consider means to think carefully about something before deciding.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 22
+          },
+          "continue": {
+            "year": "3-4",
+            "family": "continue",
+            "word": "continue",
+            "slug": "continue",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "continue"
+            ],
+            "sentence": "We will continue after the break.",
+            "sentences": [
+              "We will continue after the break.",
+              "We continue down the quiet path.",
+              "Please continue until I say stop.",
+              "She will continue practising after school.",
+              "The rain may continue through the afternoon.",
+              "They continue the game after lunch.",
+              "The bus can continue to the next town.",
+              "He decided to continue with his idea.",
+              "We continue reading while the room is silent.",
+              "The lesson will continue when the bell rings."
+            ],
+            "accepted": [
+              "continue"
+            ],
+            "explanation": "To continue means to keep going and not stop.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 23
+          },
+          "decide": {
+            "year": "3-4",
+            "family": "decide",
+            "word": "decide",
+            "slug": "decide",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "decide"
+            ],
+            "sentence": "You need to decide which game to play.",
+            "sentences": [
+              "You need to decide which game to play.",
+              "I decide to save my work now.",
+              "We decide after hearing both sides.",
+              "She will decide on the class name.",
+              "They decide which route to take.",
+              "Please decide before the timer ends.",
+              "He will decide to join the reading club.",
+              "The team decide on a fair rule.",
+              "Mum will decide once she checks the list.",
+              "I decide to ask for help."
+            ],
+            "accepted": [
+              "decide"
+            ],
+            "explanation": "To decide means to choose after thinking about the options.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 24
+          },
+          "describe": {
+            "year": "3-4",
+            "family": "describe",
+            "word": "describe",
+            "slug": "describe",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "describe"
+            ],
+            "sentence": "Can you describe the animal you saw.",
+            "sentences": [
+              "Can you describe the animal you saw.",
+              "Can you describe the scene in the photo?",
+              "She will describe the animal to the class.",
+              "Please describe what you can hear.",
+              "He tried to describe the smell from the kitchen.",
+              "We describe our route in simple words.",
+              "The guide will describe the castle rooms.",
+              "I can describe how the rain felt.",
+              "They describe their holiday to friends.",
+              "The teacher asked us to describe the map."
+            ],
+            "accepted": [
+              "describe"
+            ],
+            "explanation": "To describe means to say or write what someone or something is like.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 25
+          },
+          "different": {
+            "year": "3-4",
+            "family": "different",
+            "word": "different",
+            "slug": "different",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "different"
+            ],
+            "sentence": "My two socks are different colours.",
+            "sentences": [
+              "My two socks are different colours.",
+              "We chose a different game at break.",
+              "She used a different pen for maths.",
+              "The answer was different from mine.",
+              "I found a different path home.",
+              "They wore different socks for the race.",
+              "His plan looked different after lunch.",
+              "The class had a different target this week.",
+              "Try a different way to fold the paper.",
+              "Our lunch was different from yesterday's."
+            ],
+            "accepted": [
+              "different"
+            ],
+            "explanation": "Different means not the same.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 26
+          },
+          "difficult": {
+            "year": "3-4",
+            "family": "difficult",
+            "word": "difficult",
+            "slug": "difficult",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "difficult"
+            ],
+            "sentence": "That was a difficult question.",
+            "sentences": [
+              "That was a difficult question.",
+              "The first question was difficult for me.",
+              "It can be difficult to stay patient.",
+              "She found the climb difficult.",
+              "I made a difficult choice at lunch.",
+              "The wind made the journey difficult.",
+              "Maths stays difficult until I practise.",
+              "The lid was difficult to open.",
+              "He had a difficult time in the fog.",
+              "The difficult part came near the end."
+            ],
+            "accepted": [
+              "difficult"
+            ],
+            "explanation": "Difficult means hard to do, understand or deal with.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 27
+          },
+          "disappear": {
+            "year": "3-4",
+            "family": "disappear",
+            "word": "disappear",
+            "slug": "disappear",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "disappear"
+            ],
+            "sentence": "The rabbit can disappear into its hole quickly.",
+            "sentences": [
+              "The rabbit can disappear into its hole quickly.",
+              "The stars begin to disappear at dawn.",
+              "My shoe seemed to disappear under the bed.",
+              "The paint marks can disappear after rain.",
+              "He watched the kite disappear into the mist.",
+              "The rabbit might disappear behind the shed.",
+              "The sound will disappear when the door closes.",
+              "Her smile started to disappear when she saw the queue.",
+              "The stain should disappear with soap and water.",
+              "The magician can make the coin disappear."
+            ],
+            "accepted": [
+              "disappear"
+            ],
+            "explanation": "To disappear means to stop being seen or to go away.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 28
+          },
+          "early": {
+            "year": "3-4",
+            "family": "early",
+            "word": "early",
+            "slug": "early",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "early"
+            ],
+            "sentence": "We left early to avoid traffic.",
+            "sentences": [
+              "We left early to avoid traffic.",
+              "We arrived early for assembly.",
+              "She woke early on Saturday.",
+              "The bus came early this morning.",
+              "I like to finish early.",
+              "He left early to catch the train.",
+              "The early sun warmed the garden.",
+              "The birds sang early in the day.",
+              "We had an early lunch today.",
+              "The early part of the film was calm."
+            ],
+            "accepted": [
+              "early"
+            ],
+            "explanation": "Early means before the usual or expected time.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 29
+          },
+          "earth": {
+            "year": "3-4",
+            "family": "earth",
+            "word": "earth",
+            "slug": "earth",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "earth"
+            ],
+            "sentence": "Plants grow in rich earth.",
+            "sentences": [
+              "Plants grow in rich earth.",
+              "The earth moves around the sun.",
+              "We can protect the earth by recycling.",
+              "The earth felt damp after the rain.",
+              "Seeds grow in the earth.",
+              "The earth looked blue from space.",
+              "Keep the earth loose in the pot.",
+              "The earth shook during the storm.",
+              "There is life all over the earth.",
+              "The earth needs clean air and water."
+            ],
+            "accepted": [
+              "earth"
+            ],
+            "explanation": "Earth can mean the planet we live on, or soil and ground.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 30
+          },
+          "eight": {
+            "year": "3-4",
+            "family": "eight/eighth",
+            "word": "eight",
+            "slug": "eight",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "eight",
+              "eighth"
+            ],
+            "sentence": "There were eight apples in the bowl.",
+            "sentences": [
+              "There were eight apples in the bowl.",
+              "I can name eight planets in our solar system.",
+              "Mum bought eight rolls for lunch.",
+              "The class lined up in eight pairs.",
+              "He counted eight shells on the beach.",
+              "We need eight chairs for the concert.",
+              "The trip starts at eight o'clock.",
+              "She drew eight stars on the poster.",
+              "Our team scored eight points before half-time.",
+              "The baker sold eight loaves before noon."
+            ],
+            "accepted": [
+              "eight"
+            ],
+            "explanation": "Eight is the number after seven and before nine.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 31
+          },
+          "eighth": {
+            "year": "3-4",
+            "family": "eight/eighth",
+            "word": "eighth",
+            "slug": "eighth",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "eight",
+              "eighth"
+            ],
+            "sentence": "She finished eighth in the swimming race.",
+            "sentences": [
+              "She finished eighth in the swimming race.",
+              "His birthday is on the eighth of June.",
+              "We read the eighth chapter today.",
+              "The eighth runner wore a blue vest.",
+              "I placed the eighth sticker in the corner.",
+              "The eighth page was folded over.",
+              "Our classroom is the eighth door along the corridor.",
+              "He was the eighth child to arrive.",
+              "The eighth question was the hardest.",
+              "The band marched eighth in the parade."
+            ],
+            "accepted": [
+              "eighth"
+            ],
+            "explanation": "Eighth means number eight in order.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 32
+          },
+          "enough": {
+            "year": "3-4",
+            "family": "enough",
+            "word": "enough",
+            "slug": "enough",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "enough"
+            ],
+            "sentence": "We have enough chairs for everyone.",
+            "sentences": [
+              "We have enough chairs for everyone.",
+              "We have enough pencils for everyone.",
+              "Is there enough milk for tea?",
+              "She worked hard enough to pass.",
+              "The soup is hot enough now.",
+              "I do not feel brave enough yet.",
+              "There was enough time to finish.",
+              "The bag is big enough for books.",
+              "They ran fast enough to win.",
+              "The class had enough chairs."
+            ],
+            "accepted": [
+              "enough"
+            ],
+            "explanation": "Enough means as much or as many as needed.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 33
+          },
+          "exercise": {
+            "year": "3-4",
+            "family": "exercise",
+            "word": "exercise",
+            "slug": "exercise",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "exercise"
+            ],
+            "sentence": "Daily exercise helps you stay healthy.",
+            "sentences": [
+              "Daily exercise helps you stay healthy.",
+              "Daily exercise helps us stay healthy.",
+              "We did an exercise on fractions.",
+              "She needs more exercise after school.",
+              "The exercise was easy to follow.",
+              "He forgot his exercise book at home.",
+              "Stretching is a good exercise before sport.",
+              "The exercise finished early.",
+              "The teacher set a reading exercise.",
+              "Walk to school for some exercise."
+            ],
+            "accepted": [
+              "exercise"
+            ],
+            "explanation": "Exercise is physical activity that keeps your body healthy, or a task for practice.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 34
+          },
+          "experience": {
+            "year": "3-4",
+            "family": "experience",
+            "word": "experience",
+            "slug": "experience",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "experience"
+            ],
+            "sentence": "It was my first experience of camping.",
+            "sentences": [
+              "It was my first experience of camping.",
+              "She has experience of working with children.",
+              "His experience at the camp was fun.",
+              "We learned from experience.",
+              "She gained experience in the kitchen.",
+              "My experience of the trip was exciting.",
+              "The guide has experience with maps.",
+              "I want more experience before I help.",
+              "Their experience taught them to be careful.",
+              "The team shared experience after the match."
+            ],
+            "accepted": [
+              "experience"
+            ],
+            "explanation": "Experience is something that happens to you, or knowledge you gain by doing something.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 35
+          },
+          "experiment": {
+            "year": "3-4",
+            "family": "experiment",
+            "word": "experiment",
+            "slug": "experiment",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "experiment"
+            ],
+            "sentence": "The class did a science experiment.",
+            "sentences": [
+              "The class did a science experiment.",
+              "We will experiment with different seeds in the school garden.",
+              "The class planned an experiment to test how ice melts.",
+              "Mia recorded every result after the experiment.",
+              "Our science experiment used water, salt, and paper.",
+              "The experiment showed that warm air rises.",
+              "Before the experiment, the teacher checked the safety rules.",
+              "Each group wrote a prediction for the experiment.",
+              "The experiment helped us learn about magnets.",
+              "After the experiment, we cleaned the desks carefully."
+            ],
+            "accepted": [
+              "experiment"
+            ],
+            "explanation": "An experiment is a careful test to find out what happens or whether an idea is true.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 36
+          },
+          "extreme": {
+            "year": "3-4",
+            "family": "extreme",
+            "word": "extreme",
+            "slug": "extreme",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "extreme"
+            ],
+            "sentence": "The weather was extreme during the storm.",
+            "sentences": [
+              "The weather was extreme during the storm.",
+              "The extreme cold made the pond freeze overnight.",
+              "The extreme heat pushed us to sit in the shade.",
+              "She used extreme care when carrying the glass jar.",
+              "The storm caused extreme waves on the coast.",
+              "Dad checked the road during extreme fog.",
+              "The walk felt extreme because the hill was so steep.",
+              "The mountain pass had extreme weather in winter.",
+              "The runners slowed down in extreme heat.",
+              "We needed coats because the extreme wind was biting."
+            ],
+            "accepted": [
+              "extreme"
+            ],
+            "explanation": "Extreme means very great, strong or far from the usual.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 37
+          },
+          "famous": {
+            "year": "3-4",
+            "family": "famous",
+            "word": "famous",
+            "slug": "famous",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "famous"
+            ],
+            "sentence": "That actor is famous around the world.",
+            "sentences": [
+              "That actor is famous around the world.",
+              "The museum is famous for its dinosaur bones.",
+              "The town is famous for its old bridge.",
+              "Our class read about a famous explorer.",
+              "The singer became famous after the concert.",
+              "The castle is famous with visitors from many countries.",
+              "That footballer is famous across the world.",
+              "The school choir sang a song by a famous composer.",
+              "The park is famous for its bright spring flowers.",
+              "We saw a famous painting on the trip."
+            ],
+            "accepted": [
+              "famous"
+            ],
+            "explanation": "Famous means known by many people.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 38
+          },
+          "favourite": {
+            "year": "3-4",
+            "family": "favourite",
+            "word": "favourite",
+            "slug": "favourite",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "favourite"
+            ],
+            "sentence": "Blue is my favourite colour.",
+            "sentences": [
+              "Blue is my favourite colour.",
+              "My favourite book is on the shelf.",
+              "Jam is my favourite topping on toast.",
+              "Ben chose his favourite seat by the window.",
+              "Sunday is my favourite day of the week.",
+              "That blue jumper is her favourite one.",
+              "Our favourite game is hide and seek.",
+              "The teacher asked for our favourite story.",
+              "Pizza is my favourite dinner on Fridays.",
+              "We visited my favourite park after school."
+            ],
+            "accepted": [
+              "favourite"
+            ],
+            "explanation": "Favourite means liked best.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 39
+          },
+          "february": {
+            "year": "3-4",
+            "family": "February",
+            "word": "February",
+            "slug": "february",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "February"
+            ],
+            "sentence": "My birthday is in February.",
+            "sentences": [
+              "My birthday is in February.",
+              "February is a short month.",
+              "In February, we saw snow on the hill.",
+              "The school trip is planned for February.",
+              "February often brings cold mornings.",
+              "We made cards for February half term.",
+              "Mum checked the calendar for February.",
+              "Our class project starts in February.",
+              "February was busy for the football team.",
+              "The last day of February arrived quickly."
+            ],
+            "accepted": [
+              "february"
+            ],
+            "explanation": "February is the second month of the year.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 40
+          },
+          "forward": {
+            "year": "3-4",
+            "family": "forward(s)",
+            "word": "forward",
+            "slug": "forward",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "forward",
+              "forwards"
+            ],
+            "sentence": "Take one step forward.",
+            "sentences": [
+              "Take one step forward.",
+              "Step forward when your name is called.",
+              "The team moved forward after the break.",
+              "She leaned forward to hear the answer.",
+              "Keep the bike moving forward on the path.",
+              "Ben ran forward to catch the ball.",
+              "We looked forward to the school trip.",
+              "The story moved forward to a new day.",
+              "Please push the box forward a little.",
+              "Think forward before you choose."
+            ],
+            "accepted": [
+              "forward"
+            ],
+            "explanation": "Forward means towards the front or ahead.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 41
+          },
+          "forwards": {
+            "year": "3-4",
+            "family": "forward(s)",
+            "word": "forwards",
+            "slug": "forwards",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "forward",
+              "forwards"
+            ],
+            "sentence": "The duck swam forwards across the pond.",
+            "sentences": [
+              "The duck swam forwards across the pond.",
+              "The class walked forwards in a neat line.",
+              "Please move the chair forwards a little.",
+              "She stepped forwards to read her poem.",
+              "The bus rolled forwards at the stop.",
+              "Tom pushed the tray forwards on the table.",
+              "We edged forwards to see the stage.",
+              "The duck waddled forwards to the pond.",
+              "Keep your hands forwards when you catch the ball.",
+              "The car moved forwards slowly."
+            ],
+            "accepted": [
+              "forwards"
+            ],
+            "explanation": "Forwards means towards the front or ahead.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 42
+          },
+          "fruit": {
+            "year": "3-4",
+            "family": "fruit",
+            "word": "fruit",
+            "slug": "fruit",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "fruit"
+            ],
+            "sentence": "We packed fresh fruit for the picnic.",
+            "sentences": [
+              "We packed fresh fruit for the picnic.",
+              "Apples are a healthy fruit for lunch.",
+              "The bowl of fruit looked bright and fresh.",
+              "We added fruit to our cereal.",
+              "Mango is my favourite fruit.",
+              "The market sold ripe fruit from local farms.",
+              "She packed fruit in her school bag.",
+              "The smoothie had banana and fruit in it.",
+              "Every child chose a piece of fruit.",
+              "We cut up fruit for the picnic."
+            ],
+            "accepted": [
+              "fruit"
+            ],
+            "explanation": "Fruit is the part of a plant that often has seeds and can be eaten, such as an apple.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 43
+          },
+          "grammar": {
+            "year": "3-4",
+            "family": "grammar",
+            "word": "grammar",
+            "slug": "grammar",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "grammar"
+            ],
+            "sentence": "Good grammar makes writing clearer.",
+            "sentences": [
+              "Good grammar makes writing clearer.",
+              "Good grammar helps readers understand writing.",
+              "He checked the grammar in his story.",
+              "The class learned a new grammar rule.",
+              "Poor grammar can make a sentence confusing.",
+              "We talked about grammar before writing a letter.",
+              "The book has a section on grammar.",
+              "She used correct grammar in her answer.",
+              "Clear grammar makes the meaning easier to follow.",
+              "The guide explains grammar with simple examples."
+            ],
+            "accepted": [
+              "grammar"
+            ],
+            "explanation": "Grammar is the set of rules for how words fit together in a language.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 44
+          },
+          "group": {
+            "year": "3-4",
+            "family": "group",
+            "word": "group",
+            "slug": "group",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "group"
+            ],
+            "sentence": "Our group worked on the poster together.",
+            "sentences": [
+              "Our group worked on the poster together.",
+              "Our group worked quietly at the table.",
+              "The group shared the art supplies.",
+              "Each group presented a different idea.",
+              "I joined a reading group after school.",
+              "The group walked to the hall together.",
+              "We asked one group to tidy the books.",
+              "A small group waited by the gate.",
+              "The group chose a name for the project.",
+              "The class split into a study group."
+            ],
+            "accepted": [
+              "group"
+            ],
+            "explanation": "A group is a number of people or things together.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 45
+          },
+          "guard": {
+            "year": "3-4",
+            "family": "guard",
+            "word": "guard",
+            "slug": "guard",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "guard"
+            ],
+            "sentence": "A guard stood by the gate.",
+            "sentences": [
+              "A guard stood by the gate.",
+              "The guard stood by the gate.",
+              "A guard checked the entrance to the museum.",
+              "We saw a guard outside the castle.",
+              "The guard opened the door for visitors.",
+              "The guard wore a bright coat.",
+              "A night guard kept watch in the car park.",
+              "The guard smiled at the children.",
+              "The guard asked us to stay behind the line.",
+              "The castle guard told a short story."
+            ],
+            "accepted": [
+              "guard"
+            ],
+            "explanation": "To guard means to protect or watch over someone or something.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 46
+          },
+          "guide": {
+            "year": "3-4",
+            "family": "guide",
+            "word": "guide",
+            "slug": "guide",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "guide"
+            ],
+            "sentence": "The map will guide us home.",
+            "sentences": [
+              "The map will guide us home.",
+              "Our guide showed us the old church.",
+              "The guide led the class through the gallery.",
+              "A guide explained the rules at the zoo.",
+              "We followed the guide across the bridge.",
+              "The guide pointed to the mountain peak.",
+              "She used a guide to plan the walk.",
+              "The guide spoke clearly and kindly.",
+              "Our guide told us where to meet.",
+              "A guide helped the visitors understand the map."
+            ],
+            "accepted": [
+              "guide"
+            ],
+            "explanation": "A guide is someone or something that shows the way or gives helpful information.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 47
+          },
+          "heard": {
+            "year": "3-4",
+            "family": "heard",
+            "word": "heard",
+            "slug": "heard",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "heard"
+            ],
+            "sentence": "I heard thunder after the flash of lightning.",
+            "sentences": [
+              "I heard thunder after the flash of lightning.",
+              "We heard the bell from the playground.",
+              "She heard footsteps in the corridor.",
+              "I heard the birds before I saw them.",
+              "He heard his name across the field.",
+              "We heard the news on the radio.",
+              "Dad heard the door slam downstairs.",
+              "The class heard music from the hall.",
+              "I heard a whisper behind me.",
+              "They heard rain tapping on the roof."
+            ],
+            "accepted": [
+              "heard"
+            ],
+            "explanation": "Heard is the past tense of hear; it means listened to or noticed a sound.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 48
+          },
+          "heart": {
+            "year": "3-4",
+            "family": "heart",
+            "word": "heart",
+            "slug": "heart",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "heart"
+            ],
+            "sentence": "The doctor listened to her heart with a stethoscope.",
+            "sentences": [
+              "The doctor listened to her heart with a stethoscope.",
+              "My heart beat faster before the race.",
+              "Exercise helps to keep your heart strong.",
+              "She drew a red heart on the card.",
+              "He placed his hand over his heart.",
+              "The nurse checked his heart after the fall.",
+              "Fear made my heart thump loudly.",
+              "The poster showed how the heart pumps blood.",
+              "A healthy heart needs regular exercise.",
+              "Her heart was pounding at the start line."
+            ],
+            "accepted": [
+              "heart"
+            ],
+            "explanation": "The heart is the organ that pumps blood around the body; it can also mean feelings.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 49
+          },
+          "height": {
+            "year": "3-4",
+            "family": "height",
+            "word": "height",
+            "slug": "height",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "height"
+            ],
+            "sentence": "We measured the height of the plant.",
+            "sentences": [
+              "We measured the height of the plant.",
+              "The height of the tree surprised us.",
+              "We measured the height of the box.",
+              "His height made it easy to reach the shelf.",
+              "The teacher wrote the height on the board.",
+              "The height of the hill made us breathe hard.",
+              "Please check the height before you jump.",
+              "The height of the curtain was just right.",
+              "Her height changed a lot this year.",
+              "We compared the height of the two towers."
+            ],
+            "accepted": [
+              "height"
+            ],
+            "explanation": "Height is how tall or high something is.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 50
+          },
+          "history": {
+            "year": "3-4",
+            "family": "history",
+            "word": "history",
+            "slug": "history",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "history"
+            ],
+            "sentence": "We learned about Roman history.",
+            "sentences": [
+              "We learned about Roman history.",
+              "We learn history on Fridays.",
+              "The lesson on history was interesting.",
+              "Our school museum has local history.",
+              "She wrote a report about history.",
+              "The castle has a long history.",
+              "The class watched a film about history.",
+              "I enjoy history because it tells stories.",
+              "The book covers Roman history.",
+              "We studied history in the library."
+            ],
+            "accepted": [
+              "history"
+            ],
+            "explanation": "History is the study of things that happened in the past.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 51
+          },
+          "imagine": {
+            "year": "3-4",
+            "family": "imagine",
+            "word": "imagine",
+            "slug": "imagine",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "imagine"
+            ],
+            "sentence": "Imagine living in a tree house.",
+            "sentences": [
+              "Imagine living in a tree house.",
+              "Imagine a castle made of ice.",
+              "Can you imagine living on a farm?",
+              "I imagine the trip will be fun.",
+              "Imagine a dog with bright blue spots.",
+              "We can imagine the answer before we check.",
+              "Try to imagine the view from the hill.",
+              "I imagine the pond is deep.",
+              "Imagine your own story ending.",
+              "Can you imagine a world without books?"
+            ],
+            "accepted": [
+              "imagine"
+            ],
+            "explanation": "To imagine means to make a picture or idea in your mind.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 52
+          },
+          "increase": {
+            "year": "3-4",
+            "family": "increase",
+            "word": "increase",
+            "slug": "increase",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "increase"
+            ],
+            "sentence": "The price may increase next month.",
+            "sentences": [
+              "The price may increase next month.",
+              "We saw an increase in bird numbers.",
+              "Please increase the volume a little.",
+              "The class recorded an increase in scores.",
+              "An increase in rain made the path muddy.",
+              "We hope to increase our reading time.",
+              "The school plans to increase the number of clubs.",
+              "A small increase can still help.",
+              "The coach wants to increase our stamina.",
+              "Scientists noticed an increase in daylight."
+            ],
+            "accepted": [
+              "increase"
+            ],
+            "explanation": "To increase means to become bigger in number, size or amount.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 53
+          },
+          "important": {
+            "year": "3-4",
+            "family": "important",
+            "word": "important",
+            "slug": "important",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "important"
+            ],
+            "sentence": "It is important to listen carefully.",
+            "sentences": [
+              "It is important to listen carefully.",
+              "It is important to wear a helmet.",
+              "Reading is important for every child.",
+              "The teacher said water is important on hot days.",
+              "The notice was important for the trip.",
+              "Family time is important to me.",
+              "The instructions are important for safety.",
+              "It is important to finish your work.",
+              "Sleep is important before a busy day.",
+              "The sign gives an important message."
+            ],
+            "accepted": [
+              "important"
+            ],
+            "explanation": "Important means having great value or needing attention.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 54
+          },
+          "interest": {
+            "year": "3-4",
+            "family": "interest",
+            "word": "interest",
+            "slug": "interest",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "interest"
+            ],
+            "sentence": "Space is a special interest of his.",
+            "sentences": [
+              "Space is a special interest of his.",
+              "The book caught my interest at once.",
+              "I have a strong interest in science.",
+              "The lesson was full of interest.",
+              "Her interest in birds grew over time.",
+              "The museum display held our interest.",
+              "He showed interest in the football club.",
+              "My interest in maps started last year.",
+              "The class shared interest in space.",
+              "Her interest in music is growing."
+            ],
+            "accepted": [
+              "interest"
+            ],
+            "explanation": "Interest is a feeling of wanting to know or learn more about something.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 55
+          },
+          "island": {
+            "year": "3-4",
+            "family": "island",
+            "word": "island",
+            "slug": "island",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "island"
+            ],
+            "sentence": "They sailed to a small island.",
+            "sentences": [
+              "They sailed to a small island.",
+              "We saw an island in the distance.",
+              "The island has sandy beaches.",
+              "Our map showed a small island.",
+              "We sailed to the island at dawn.",
+              "The island was quiet and green.",
+              "Birds nested on the island.",
+              "The island had one narrow road.",
+              "We read about an island adventure.",
+              "Fishermen lived near the island."
+            ],
+            "accepted": [
+              "island"
+            ],
+            "explanation": "An island is land with water all around it.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 56
+          },
+          "knowledge": {
+            "year": "3-4",
+            "family": "knowledge",
+            "word": "knowledge",
+            "slug": "knowledge",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "knowledge"
+            ],
+            "sentence": "Her knowledge of animals is impressive.",
+            "sentences": [
+              "Her knowledge of animals is impressive.",
+              "Knowledge helps us solve problems.",
+              "The lesson added to my knowledge.",
+              "We shared knowledge about plants.",
+              "Her knowledge of animals is strong.",
+              "Good knowledge comes from reading.",
+              "The quiz tested our knowledge.",
+              "He used his knowledge to fix the bike.",
+              "Our knowledge grew after the trip.",
+              "The teacher valued every bit of knowledge."
+            ],
+            "accepted": [
+              "knowledge"
+            ],
+            "explanation": "Knowledge is what you know and understand.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 57
+          },
+          "learn": {
+            "year": "3-4",
+            "family": "learn",
+            "word": "learn",
+            "slug": "learn",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "learn"
+            ],
+            "sentence": "We learn something new every day.",
+            "sentences": [
+              "We learn something new every day.",
+              "We learn new words every week.",
+              "I learn best with pictures.",
+              "The class will learn about rivers.",
+              "Children learn from reading aloud.",
+              "We learn how to stay safe online.",
+              "She wanted to learn a song.",
+              "I learn by asking questions.",
+              "The group can learn together.",
+              "We learn from our mistakes."
+            ],
+            "accepted": [
+              "learn"
+            ],
+            "explanation": "To learn means to gain knowledge or a skill.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 58
+          },
+          "length": {
+            "year": "3-4",
+            "family": "length",
+            "word": "length",
+            "slug": "length",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "length"
+            ],
+            "sentence": "Measure the length of the table.",
+            "sentences": [
+              "Measure the length of the table.",
+              "Measure the length of the ribbon.",
+              "The length of the table is two metres.",
+              "We compared the length of both ropes.",
+              "The teacher asked for the length of the line.",
+              "The length of the journey was tiring.",
+              "Please write the length in centimetres.",
+              "The length of the hall surprised us.",
+              "We checked the length before cutting the paper.",
+              "The length of the scarf was just right."
+            ],
+            "accepted": [
+              "length"
+            ],
+            "explanation": "Length is how long something is from one end to the other.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 59
+          },
+          "library": {
+            "year": "3-4",
+            "family": "library",
+            "word": "library",
+            "slug": "library",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "library"
+            ],
+            "sentence": "We borrowed books from the library.",
+            "sentences": [
+              "We borrowed books from the library.",
+              "The library was quiet after lunch.",
+              "Our class visited the library on Monday.",
+              "The library has a new reading corner.",
+              "She returned her book to the library.",
+              "The library closed early on Friday.",
+              "We found the atlas in the library.",
+              "The library display showed local authors.",
+              "I enjoy the library because it is calm.",
+              "The library shelf held many stories."
+            ],
+            "accepted": [
+              "library"
+            ],
+            "explanation": "A library is a place where books and information are kept for people to use.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 60
+          },
+          "material": {
+            "year": "3-4",
+            "family": "material",
+            "word": "material",
+            "slug": "material",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "material"
+            ],
+            "sentence": "This bag is made from strong material.",
+            "sentences": [
+              "This bag is made from strong material.",
+              "This material feels soft and warm.",
+              "The dress is made from a light material.",
+              "We chose a strong material for the model.",
+              "The roof material keeps out rain.",
+              "The artist used a shiny material.",
+              "The material on the table is waterproof.",
+              "We sorted each material into a box.",
+              "Cotton is a natural material.",
+              "The teacher showed us a new material."
+            ],
+            "accepted": [
+              "material"
+            ],
+            "explanation": "Material is the substance something is made from, such as cotton, wood or metal.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 61
+          },
+          "medicine": {
+            "year": "3-4",
+            "family": "medicine",
+            "word": "medicine",
+            "slug": "medicine",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "medicine"
+            ],
+            "sentence": "The doctor gave her medicine.",
+            "sentences": [
+              "The doctor gave her medicine.",
+              "The doctor gave me medicine for my cough.",
+              "Keep the medicine in a safe place.",
+              "Mum measured the medicine carefully.",
+              "The medicine tasted bitter.",
+              "A nurse brought the medicine to the ward.",
+              "We read the label on the medicine.",
+              "The medicine helped him feel better.",
+              "The shelf held every medicine in order.",
+              "You must take the medicine after food."
+            ],
+            "accepted": [
+              "medicine"
+            ],
+            "explanation": "Medicine is something used to help treat illness or pain.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 62
+          },
+          "mention": {
+            "year": "3-4",
+            "family": "mention",
+            "word": "mention",
+            "slug": "mention",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "mention"
+            ],
+            "sentence": "Please do not mention the surprise.",
+            "sentences": [
+              "Please do not mention the surprise.",
+              "Please mention your answer in the letter.",
+              "I did not mention the problem at first.",
+              "The teacher will mention the trip tomorrow.",
+              "Can you mention my name to the group?",
+              "The report did not mention the rain.",
+              "She wanted to mention the new club.",
+              "He forgot to mention the homework.",
+              "We may mention the book in class.",
+              "The note did mention the meeting time."
+            ],
+            "accepted": [
+              "mention"
+            ],
+            "explanation": "To mention means to say something briefly.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 63
+          },
+          "minute": {
+            "year": "3-4",
+            "family": "minute",
+            "word": "minute",
+            "slug": "minute",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "minute"
+            ],
+            "sentence": "Wait a minute while I tie my shoe.",
+            "sentences": [
+              "Wait a minute while I tie my shoe.",
+              "Wait one minute before you open it.",
+              "The clock ticked every minute.",
+              "We took a minute to think.",
+              "The minute hand moved slowly.",
+              "She was late by a minute.",
+              "The task took only a minute.",
+              "In a minute, the bell will ring.",
+              "He checked the time every minute.",
+              "The minute we arrived, it started to rain."
+            ],
+            "accepted": [
+              "minute"
+            ],
+            "explanation": "A minute is a period of sixty seconds.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 64
+          },
+          "natural": {
+            "year": "3-4",
+            "family": "natural",
+            "word": "natural",
+            "slug": "natural",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "natural"
+            ],
+            "sentence": "Honey is a natural sweetener.",
+            "sentences": [
+              "Honey is a natural sweetener.",
+              "Fresh air feels natural.",
+              "The leaves had a natural green colour.",
+              "It is natural to ask questions.",
+              "The path looked natural in the wood.",
+              "Her smile looked natural in the photo.",
+              "We used natural light near the window.",
+              "The river followed a natural route.",
+              "He chose a natural voice for the play.",
+              "The field looked natural after the rain."
+            ],
+            "accepted": [
+              "natural"
+            ],
+            "explanation": "Natural means found in nature or not made by people.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 65
+          },
+          "naughty": {
+            "year": "3-4",
+            "family": "naughty",
+            "word": "naughty",
+            "slug": "naughty",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "naughty"
+            ],
+            "sentence": "The puppy was naughty and chewed the slipper.",
+            "sentences": [
+              "The puppy was naughty and chewed the slipper.",
+              "The naughty puppy hid my shoe.",
+              "A naughty child wrote on the desk.",
+              "The naughty cat jumped on the counter.",
+              "He gave a naughty grin.",
+              "The naughty wind blew my hat away.",
+              "The naughty class giggled during assembly.",
+              "Our naughty dog dug in the garden.",
+              "She played a naughty prank at lunch.",
+              "The naughty rabbit escaped from the pen."
+            ],
+            "accepted": [
+              "naughty"
+            ],
+            "explanation": "Naughty means behaving badly or not following rules.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 66
+          },
+          "notice": {
+            "year": "3-4",
+            "family": "notice",
+            "word": "notice",
+            "slug": "notice",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "notice"
+            ],
+            "sentence": "Did you notice the rainbow.",
+            "sentences": [
+              "Did you notice the rainbow.",
+              "I notice the clock on the wall.",
+              "We notice the signs by the path.",
+              "The teacher asked us to notice the details.",
+              "Please notice the change in colour.",
+              "She did not notice the missing pen.",
+              "I notice a star in the sky.",
+              "They notice the quiet room at once.",
+              "We notice how the leaves move.",
+              "He will notice the new display."
+            ],
+            "accepted": [
+              "notice"
+            ],
+            "explanation": "To notice means to see, hear or become aware of something.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 67
+          },
+          "occasion": {
+            "year": "3-4",
+            "family": "occasion(ally)",
+            "word": "occasion",
+            "slug": "occasion",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "occasion",
+              "occasionally"
+            ],
+            "sentence": "The party was a special occasion.",
+            "sentences": [
+              "The party was a special occasion.",
+              "The picnic was a happy occasion.",
+              "Birthdays are a special occasion.",
+              "We wore smart clothes for the occasion.",
+              "The ceremony was a proud occasion.",
+              "A school concert is a great occasion.",
+              "On this occasion, the team won.",
+              "The occasion called for a speech.",
+              "It was a rare occasion to see snow.",
+              "The cake was made for the occasion."
+            ],
+            "accepted": [
+              "occasion"
+            ],
+            "explanation": "An occasion is a particular time when something happens, often something special.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 68
+          },
+          "occasionally": {
+            "year": "3-4",
+            "family": "occasion(ally)",
+            "word": "occasionally",
+            "slug": "occasionally",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "occasion",
+              "occasionally"
+            ],
+            "sentence": "We occasionally eat dinner in the garden.",
+            "sentences": [
+              "We occasionally eat dinner in the garden.",
+              "We occasionally visit the seaside.",
+              "She occasionally reads in the garden.",
+              "I occasionally forget my water bottle.",
+              "We occasionally hear owls at night.",
+              "Dad occasionally cooks pasta on Fridays.",
+              "The bus is occasionally late.",
+              "They occasionally play chess after school.",
+              "I occasionally help at the library.",
+              "We occasionally watch a film together."
+            ],
+            "accepted": [
+              "occasionally"
+            ],
+            "explanation": "Occasionally means sometimes, but not often.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 69
+          },
+          "often": {
+            "year": "3-4",
+            "family": "often",
+            "word": "often",
+            "slug": "often",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "often"
+            ],
+            "sentence": "We often visit the park after school.",
+            "sentences": [
+              "We often visit the park after school.",
+              "We often walk to school.",
+              "She often reads before bed.",
+              "I often spot deer near the woods.",
+              "I often see rabbits in the field.",
+              "Dad often makes tea after work.",
+              "We often visit the park.",
+              "The dog often sits by the door.",
+              "I often need a second look.",
+              "They often play outside at break time."
+            ],
+            "accepted": [
+              "often"
+            ],
+            "explanation": "Often means many times or frequently.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 70
+          },
+          "opposite": {
+            "year": "3-4",
+            "family": "opposite",
+            "word": "opposite",
+            "slug": "opposite",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "opposite"
+            ],
+            "sentence": "The shop is opposite the station.",
+            "sentences": [
+              "The shop is opposite the station.",
+              "The shop is opposite the post office.",
+              "We sat opposite the stage.",
+              "Her desk is opposite mine.",
+              "The car stopped opposite the gate.",
+              "I walked opposite the cafe.",
+              "The mirror is opposite the window.",
+              "They live opposite the school.",
+              "The path runs opposite the river.",
+              "Our seats were opposite each other."
+            ],
+            "accepted": [
+              "opposite"
+            ],
+            "explanation": "Opposite means completely different or facing the other way.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 71
+          },
+          "ordinary": {
+            "year": "3-4",
+            "family": "ordinary",
+            "word": "ordinary",
+            "slug": "ordinary",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "ordinary"
+            ],
+            "sentence": "It was an ordinary school day.",
+            "sentences": [
+              "It was an ordinary school day.",
+              "It was an ordinary day at school.",
+              "We ate an ordinary lunch in the hall.",
+              "The box looked ordinary, but it held a prize.",
+              "She wore an ordinary coat to stay warm.",
+              "The story began in an ordinary village.",
+              "He chose an ordinary pencil for the test.",
+              "Our class had an ordinary assembly on Monday.",
+              "They sat at an ordinary wooden table.",
+              "The room seemed ordinary until the lights changed."
+            ],
+            "accepted": [
+              "ordinary"
+            ],
+            "explanation": "Ordinary means normal, usual or not special.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 72
+          },
+          "particular": {
+            "year": "3-4",
+            "family": "particular",
+            "word": "particular",
+            "slug": "particular",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "particular"
+            ],
+            "sentence": "She was looking for one particular book.",
+            "sentences": [
+              "She was looking for one particular book.",
+              "She had a particular way of tying her shoes.",
+              "We need a particular size for the box.",
+              "He chose a particular book from the shelf.",
+              "The teacher had a particular rule for tidy work.",
+              "I remember one particular day very well.",
+              "They wanted a particular shade of blue.",
+              "Mum asked for a particular answer.",
+              "The dog likes one particular ball.",
+              "There was a particular smell in the kitchen."
+            ],
+            "accepted": [
+              "particular"
+            ],
+            "explanation": "Particular means a specific one, not just any one.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 73
+          },
+          "peculiar": {
+            "year": "3-4",
+            "family": "peculiar",
+            "word": "peculiar",
+            "slug": "peculiar",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "peculiar"
+            ],
+            "sentence": "There was a peculiar smell in the room.",
+            "sentences": [
+              "There was a peculiar smell in the room.",
+              "The old house had a peculiar sound at night.",
+              "He wore a peculiar hat to the party.",
+              "The cake had a peculiar taste.",
+              "She noticed a peculiar mark on the wall.",
+              "It felt peculiar to walk in silence.",
+              "The bird made a peculiar call.",
+              "He gave a peculiar smile after the joke.",
+              "We found a peculiar stone by the path.",
+              "The room had a peculiar smell of paint."
+            ],
+            "accepted": [
+              "peculiar"
+            ],
+            "explanation": "Peculiar means strange or unusual.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 74
+          },
+          "perhaps": {
+            "year": "3-4",
+            "family": "perhaps",
+            "word": "perhaps",
+            "slug": "perhaps",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "perhaps"
+            ],
+            "sentence": "Perhaps it will snow tonight.",
+            "sentences": [
+              "Perhaps it will snow tonight.",
+              "I think perhaps we should leave earlier.",
+              "The train will perhaps be on time.",
+              "She perhaps forgot her bag at home.",
+              "I can perhaps help after lunch.",
+              "The rain may perhaps stop soon.",
+              "They perhaps chose the wrong path.",
+              "You should perhaps ask the teacher.",
+              "The answer may perhaps be under the book.",
+              "We will perhaps visit the museum tomorrow."
+            ],
+            "accepted": [
+              "perhaps"
+            ],
+            "explanation": "Perhaps means maybe or possibly.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 75
+          },
+          "popular": {
+            "year": "3-4",
+            "family": "popular",
+            "word": "popular",
+            "slug": "popular",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "popular"
+            ],
+            "sentence": "Football is popular at our school.",
+            "sentences": [
+              "Football is popular at our school.",
+              "The park is a popular place to play.",
+              "That song is popular with our class.",
+              "Apples are a popular snack at break time.",
+              "The new comic was very popular.",
+              "The library is a popular spot after school.",
+              "Football is a popular game in our town.",
+              "Her ideas became popular quickly.",
+              "The seaside town is popular in summer.",
+              "That shoe style was popular last year."
+            ],
+            "accepted": [
+              "popular"
+            ],
+            "explanation": "Popular means liked or enjoyed by many people.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 76
+          },
+          "position": {
+            "year": "3-4",
+            "family": "position",
+            "word": "position",
+            "slug": "position",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "position"
+            ],
+            "sentence": "Move your chair into position.",
+            "sentences": [
+              "Move your chair into position.",
+              "She moved into position behind the rope.",
+              "The coach changed his position on the team.",
+              "Please hold your position in the line.",
+              "He found a better position near the window.",
+              "The map showed the position of the castle.",
+              "We took our position for the photograph.",
+              "The dancer kept her position with care.",
+              "His position on the chair was uncomfortable.",
+              "They studied the position of the stars."
+            ],
+            "accepted": [
+              "position"
+            ],
+            "explanation": "Position is where something is, or the way it is placed.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 77
+          },
+          "possess": {
+            "year": "3-4",
+            "family": "possess(ion)",
+            "word": "possess",
+            "slug": "possess",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "possess",
+              "possession"
+            ],
+            "sentence": "Very few animals possess wings and fur.",
+            "sentences": [
+              "Very few animals possess wings and fur.",
+              "Many people possess a good sense of humour.",
+              "Some birds possess bright feathers.",
+              "You must possess your library card to borrow books.",
+              "A great player must possess skill and patience.",
+              "The castle was said to possess secret tunnels.",
+              "He does not possess a loud voice.",
+              "We all possess different talents.",
+              "The old map may possess clues.",
+              "She seems to possess great confidence."
+            ],
+            "accepted": [
+              "possess"
+            ],
+            "explanation": "To possess something means to own it or have it.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 78
+          },
+          "possession": {
+            "year": "3-4",
+            "family": "possess(ion)",
+            "word": "possession",
+            "slug": "possession",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "possess",
+              "possession"
+            ],
+            "sentence": "The medal was his most valued possession.",
+            "sentences": [
+              "The medal was his most valued possession.",
+              "The necklace was in her possession.",
+              "He kept his possession safe in a box.",
+              "The shop returned the lost possession to the child.",
+              "A football is his favourite possession.",
+              "The bag was not in his possession.",
+              "The painting was a precious possession.",
+              "She kept the letter in her possession.",
+              "The key was found in his possession.",
+              "The old watch became a treasured possession."
+            ],
+            "accepted": [
+              "possession"
+            ],
+            "explanation": "A possession is something that you own or have.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 79
+          },
+          "possible": {
+            "year": "3-4",
+            "family": "possible",
+            "word": "possible",
+            "slug": "possible",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "possible"
+            ],
+            "sentence": "Is it possible to finish today.",
+            "sentences": [
+              "Is it possible to finish today.",
+              "It is possible to finish before lunch.",
+              "We walked as quietly as possible.",
+              "Please give as much help as possible.",
+              "It is possible that the bus is late.",
+              "Try to make the picture as clear as possible.",
+              "We used every possible clue.",
+              "It is possible to learn from mistakes.",
+              "She made the best possible choice.",
+              "Keep the door open if possible."
+            ],
+            "accepted": [
+              "possible"
+            ],
+            "explanation": "Possible means able to happen or be done.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 80
+          },
+          "potatoes": {
+            "year": "3-4",
+            "family": "potatoes",
+            "word": "potatoes",
+            "slug": "potatoes",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "potatoes"
+            ],
+            "sentence": "We planted potatoes in the garden.",
+            "sentences": [
+              "We planted potatoes in the garden.",
+              "Mum boiled the potatoes for dinner.",
+              "We planted potatoes in the school garden.",
+              "The potatoes were soft and warm.",
+              "He mashed the potatoes with butter.",
+              "Roast potatoes smell delicious.",
+              "The farmer loaded sacks of potatoes onto the cart.",
+              "We ate potatoes with our pie.",
+              "The potatoes grew well after the rain.",
+              "She peeled the potatoes carefully."
+            ],
+            "accepted": [
+              "potatoes"
+            ],
+            "explanation": "Potatoes are round root vegetables that grow underground.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 81
+          },
+          "pressure": {
+            "year": "3-4",
+            "family": "pressure",
+            "word": "pressure",
+            "slug": "pressure",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "pressure"
+            ],
+            "sentence": "The team felt pressure before the final.",
+            "sentences": [
+              "The team felt pressure before the final.",
+              "The lid came off under pressure.",
+              "She felt pressure before the test.",
+              "The pipe burst because of pressure.",
+              "He stayed calm under pressure.",
+              "Too much pressure can break the glass.",
+              "The team faced pressure to win.",
+              "Air pressure changes with the weather.",
+              "She handled the pressure well.",
+              "Water pressure was low in the morning."
+            ],
+            "accepted": [
+              "pressure"
+            ],
+            "explanation": "Pressure is force pushing on something, or stress caused by demands.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 82
+          },
+          "probably": {
+            "year": "3-4",
+            "family": "probably",
+            "word": "probably",
+            "slug": "probably",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "probably"
+            ],
+            "sentence": "It will probably rain later.",
+            "sentences": [
+              "It will probably rain later.",
+              "We will probably leave after tea.",
+              "She will probably join the game.",
+              "The cat is probably under the table.",
+              "He will probably read that book again.",
+              "They are probably on the bus now.",
+              "The work will probably take an hour.",
+              "I will probably choose the blue pen.",
+              "The dog is probably asleep upstairs.",
+              "We should probably check the map."
+            ],
+            "accepted": [
+              "probably"
+            ],
+            "explanation": "Probably means very likely to happen or be true.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 83
+          },
+          "promise": {
+            "year": "3-4",
+            "family": "promise",
+            "word": "promise",
+            "slug": "promise",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "promise"
+            ],
+            "sentence": "I promise to be on time.",
+            "sentences": [
+              "I promise to be on time.",
+              "I promise to be ready on time.",
+              "She made a promise to help her brother.",
+              "We promise to keep the gate shut.",
+              "He broke his promise to call.",
+              "My promise is to try my best.",
+              "They promise to finish the job today.",
+              "A promise should be kept.",
+              "She gave her promise in writing.",
+              "I promise to listen carefully."
+            ],
+            "accepted": [
+              "promise"
+            ],
+            "explanation": "A promise is a firm statement that you will do something.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 84
+          },
+          "purpose": {
+            "year": "3-4",
+            "family": "purpose",
+            "word": "purpose",
+            "slug": "purpose",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "purpose"
+            ],
+            "sentence": "The purpose of the trip was to learn about the coast.",
+            "sentences": [
+              "The purpose of the trip was to learn about the coast.",
+              "The purpose of the sign was to keep people safe.",
+              "Every tool in the box has a purpose.",
+              "She spoke with purpose and confidence.",
+              "The purpose of the meeting was clear from the start.",
+              "We use this room for a special purpose.",
+              "His questions had a clear purpose.",
+              "The purpose of the lesson was to compare the two stories.",
+              "A torch has the simple purpose of giving light.",
+              "The bridge was built for one main purpose."
+            ],
+            "accepted": [
+              "purpose"
+            ],
+            "explanation": "Purpose is the reason something exists or is done.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 85
+          },
+          "quarter": {
+            "year": "3-4",
+            "family": "quarter",
+            "word": "quarter",
+            "slug": "quarter",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "quarter"
+            ],
+            "sentence": "A quarter of the cake was left.",
+            "sentences": [
+              "A quarter of the cake was left.",
+              "We walked a quarter of the way home.",
+              "The cake was cut into a quarter.",
+              "It is a quarter past three.",
+              "The shop is a quarter mile away.",
+              "She found a quarter of the answer.",
+              "A quarter of the class went swimming.",
+              "He paid with a quarter from his pocket.",
+              "The team scored in the first quarter.",
+              "We waited for a quarter of an hour."
+            ],
+            "accepted": [
+              "quarter"
+            ],
+            "explanation": "A quarter is one of four equal parts.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 86
+          },
+          "question": {
+            "year": "3-4",
+            "family": "question",
+            "word": "question",
+            "slug": "question",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "question"
+            ],
+            "sentence": "She asked a thoughtful question.",
+            "sentences": [
+              "She asked a thoughtful question.",
+              "I had a question about the homework.",
+              "She raised her hand to question the rule.",
+              "The question was harder than it looked.",
+              "We asked a question at the end.",
+              "His question helped the class think.",
+              "The teacher answered every question.",
+              "I wrote one question on my card.",
+              "The next question was about history.",
+              "They discussed the question after lunch."
+            ],
+            "accepted": [
+              "question"
+            ],
+            "explanation": "A question is something you ask to find out information.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 87
+          },
+          "recent": {
+            "year": "3-4",
+            "family": "recent",
+            "word": "recent",
+            "slug": "recent",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "recent"
+            ],
+            "sentence": "That is a recent photograph.",
+            "sentences": [
+              "That is a recent photograph.",
+              "A recent storm damaged the fence.",
+              "I read a recent report about the floods.",
+              "Her recent work has been very neat.",
+              "The recent rain filled the pond.",
+              "A recent message arrived on my phone.",
+              "We studied recent events in history.",
+              "My recent visit to the museum was great.",
+              "The recent news surprised everyone.",
+              "He talked about a recent trip to Wales."
+            ],
+            "accepted": [
+              "recent"
+            ],
+            "explanation": "Recent means having happened not long ago.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 88
+          },
+          "regular": {
+            "year": "3-4",
+            "family": "regular",
+            "word": "regular",
+            "slug": "regular",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "regular"
+            ],
+            "sentence": "He is a regular visitor to the cafe.",
+            "sentences": [
+              "He is a regular visitor to the cafe.",
+              "She has a regular routine before school.",
+              "We make regular visits to the library.",
+              "He is a regular visitor to the park.",
+              "The bus makes a regular stop here.",
+              "They had regular practice on Fridays.",
+              "A regular shape has clear sides.",
+              "Mum checks the dog on a regular basis.",
+              "We eat at regular times each day.",
+              "The teacher liked the regular pattern."
+            ],
+            "accepted": [
+              "regular"
+            ],
+            "explanation": "Regular means happening again and again in the same pattern, or usual.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 89
+          },
+          "reign": {
+            "year": "3-4",
+            "family": "reign",
+            "word": "reign",
+            "slug": "reign",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "reign"
+            ],
+            "sentence": "The queen's reign lasted for many years.",
+            "sentences": [
+              "The queen's reign lasted for many years.",
+              "During his reign, the king built a new palace.",
+              "The queen began her reign at a young age.",
+              "Peace returned before the end of the king's reign.",
+              "We learned about the reign of Queen Victoria.",
+              "The ruler's reign brought many changes to the kingdom.",
+              "Songs were written to celebrate the queen's reign.",
+              "The castle was repaired during the king's reign.",
+              "People remembered her reign as fair and wise.",
+              "A new coin was made at the start of his reign."
+            ],
+            "accepted": [
+              "reign"
+            ],
+            "explanation": "A reign is the time when a king or queen rules.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 90
+          },
+          "remember": {
+            "year": "3-4",
+            "family": "remember",
+            "word": "remember",
+            "slug": "remember",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "remember"
+            ],
+            "sentence": "Please remember your lunch box.",
+            "sentences": [
+              "Please remember your lunch box.",
+              "Please remember your coat.",
+              "I remember the trip clearly.",
+              "She will remember his kind words.",
+              "We remember to feed the rabbit.",
+              "He did not remember the answer.",
+              "I remember where I left my bag.",
+              "Please remember to close the door.",
+              "They remember that story every winter.",
+              "She will remember her first day at school."
+            ],
+            "accepted": [
+              "remember"
+            ],
+            "explanation": "To remember means to keep something in your mind or bring it back to mind.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 91
+          },
+          "sentence": {
+            "year": "3-4",
+            "family": "sentence",
+            "word": "sentence",
+            "slug": "sentence",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "sentence"
+            ],
+            "sentence": "Write each answer in a full sentence.",
+            "sentences": [
+              "Write each answer in a full sentence.",
+              "Write a clear sentence for the test.",
+              "The teacher asked for one sentence.",
+              "He said the sentence aloud.",
+              "Please copy the sentence neatly.",
+              "She joined two ideas in one sentence.",
+              "The sentence was long but simple.",
+              "I underlined the key sentence.",
+              "We built a sentence together.",
+              "The last sentence made everyone smile."
+            ],
+            "accepted": [
+              "sentence"
+            ],
+            "explanation": "A sentence is a group of words that expresses a complete idea.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 92
+          },
+          "separate": {
+            "year": "3-4",
+            "family": "separate",
+            "word": "separate",
+            "slug": "separate",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "separate"
+            ],
+            "sentence": "Keep the white socks separate from the dark ones.",
+            "sentences": [
+              "Keep the white socks separate from the dark ones.",
+              "Please separate the red buttons from the blue ones.",
+              "We need to separate the papers.",
+              "The fence helps separate the fields.",
+              "She had to separate the coins by size.",
+              "Try to separate the eggs carefully.",
+              "The river can separate the two villages.",
+              "We separate our shoes from our coats.",
+              "The teacher will separate the class into groups.",
+              "The line helps separate the two lanes."
+            ],
+            "accepted": [
+              "separate"
+            ],
+            "explanation": "Separate means apart, not joined together.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 93
+          },
+          "special": {
+            "year": "3-4",
+            "family": "special",
+            "word": "special",
+            "slug": "special",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "special"
+            ],
+            "sentence": "Today is special because it is your birthday.",
+            "sentences": [
+              "Today is special because it is your birthday.",
+              "Today is a special day for our class.",
+              "She wore a special badge on her coat.",
+              "We made a special card for Mum.",
+              "The cake had a special icing.",
+              "He saved a special seat for his friend.",
+              "The library put on a special display.",
+              "That song has a special meaning for me.",
+              "We used a special pen for the poster.",
+              "The trip was special because we went together."
+            ],
+            "accepted": [
+              "special"
+            ],
+            "explanation": "Special means different from the usual in an important or valued way.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 94
+          },
+          "straight": {
+            "year": "3-4",
+            "family": "straight",
+            "word": "straight",
+            "slug": "straight",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "straight"
+            ],
+            "sentence": "Draw a straight line with a ruler.",
+            "sentences": [
+              "Draw a straight line with a ruler.",
+              "Draw a straight line across the page.",
+              "He walked straight to the gate.",
+              "The road ahead is straight and long.",
+              "Please keep the shelves straight.",
+              "She stood up straight for the photo.",
+              "The arrow flew straight to the target.",
+              "We took a straight path through the field.",
+              "Put the books straight on the shelf.",
+              "His hair was brushed straight."
+            ],
+            "accepted": [
+              "straight"
+            ],
+            "explanation": "Straight means not curved, bent or crooked.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 95
+          },
+          "strange": {
+            "year": "3-4",
+            "family": "strange",
+            "word": "strange",
+            "slug": "strange",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "strange"
+            ],
+            "sentence": "I heard a strange sound in the attic.",
+            "sentences": [
+              "I heard a strange sound in the attic.",
+              "That was a strange sound in the hall.",
+              "She found a strange shell on the beach.",
+              "It felt strange to be so quiet.",
+              "The sky looked strange before the storm.",
+              "He wore a strange hat to school.",
+              "We noticed a strange smell in the room.",
+              "The story had a strange ending.",
+              "It is strange to see snow in spring.",
+              "She gave me a strange look."
+            ],
+            "accepted": [
+              "strange"
+            ],
+            "explanation": "Strange means unusual or surprising.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 96
+          },
+          "strength": {
+            "year": "3-4",
+            "family": "strength",
+            "word": "strength",
+            "slug": "strength",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "strength"
+            ],
+            "sentence": "It takes strength to lift that box.",
+            "sentences": [
+              "It takes strength to lift that box.",
+              "Exercise can build your strength.",
+              "She showed great strength in the race.",
+              "The rope has enough strength to hold us.",
+              "His strength helped the team win.",
+              "We admired her strength and courage.",
+              "The bridge needed more strength.",
+              "Swimming can improve your strength.",
+              "The wall has surprising strength.",
+              "He used all his strength to lift the box."
+            ],
+            "accepted": [
+              "strength"
+            ],
+            "explanation": "Strength is the power to lift, push, resist or keep going.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 97
+          },
+          "suppose": {
+            "year": "3-4",
+            "family": "suppose",
+            "word": "suppose",
+            "slug": "suppose",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "suppose"
+            ],
+            "sentence": "I suppose we could walk instead.",
+            "sentences": [
+              "I suppose we could walk instead.",
+              "I suppose we could try a new route.",
+              "I suppose the shop is closed now.",
+              "I suppose the answer is wrong.",
+              "I suppose we can ask for help.",
+              "I suppose you will finish early.",
+              "We can suppose that it will rain.",
+              "I suppose the game starts at three.",
+              "I suppose the dog needs water.",
+              "I suppose your idea may work."
+            ],
+            "accepted": [
+              "suppose"
+            ],
+            "explanation": "To suppose means to think something is true, often without being completely sure.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 98
+          },
+          "surprise": {
+            "year": "3-4",
+            "family": "surprise",
+            "word": "surprise",
+            "slug": "surprise",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "surprise"
+            ],
+            "sentence": "The gift was a lovely surprise.",
+            "sentences": [
+              "The gift was a lovely surprise.",
+              "The party was a surprise for her.",
+              "We wanted to surprise Dad with a card.",
+              "It was no surprise that she won.",
+              "The box held a surprise gift.",
+              "His visit was a surprise to everyone.",
+              "She tried to surprise the class.",
+              "The result came as a surprise.",
+              "We planned a surprise for the teacher.",
+              "The puppy was a happy surprise."
+            ],
+            "accepted": [
+              "surprise"
+            ],
+            "explanation": "A surprise is something unexpected.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 99
+          },
+          "therefore": {
+            "year": "3-4",
+            "family": "therefore",
+            "word": "therefore",
+            "slug": "therefore",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "therefore"
+            ],
+            "sentence": "It was raining and therefore the match was cancelled.",
+            "sentences": [
+              "It was raining and therefore the match was cancelled.",
+              "It was cold, therefore we wore coats.",
+              "He was late, therefore he ran.",
+              "The road was wet, therefore we walked carefully.",
+              "She studied well, therefore she did well.",
+              "The match was cancelled, therefore we went home.",
+              "The pencil broke, therefore I used a pen.",
+              "The shop was shut, therefore we tried another one.",
+              "He was ill, therefore he stayed indoors.",
+              "The gate was locked, therefore we used the side door."
+            ],
+            "accepted": [
+              "therefore"
+            ],
+            "explanation": "Therefore means for that reason or as a result.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 100
+          },
+          "though": {
+            "year": "3-4",
+            "family": "though/although",
+            "word": "though",
+            "slug": "though",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "though",
+              "although"
+            ],
+            "sentence": "I was tired, though I kept walking.",
+            "sentences": [
+              "I was tired, though I kept walking.",
+              "We played outside, though the wind was cold.",
+              "She smiled, though her hands were shaking.",
+              "He joined the race, though he felt nervous.",
+              "We finished the trip, though the path was muddy.",
+              "The soup was hot, though the bread was cold.",
+              "I liked the book, though it was quite long.",
+              "They kept cheering, though their team was behind.",
+              "Mum came with us, though she was busy.",
+              "The dog barked, though it was friendly."
+            ],
+            "accepted": [
+              "though"
+            ],
+            "explanation": "Though means although, or despite the fact that something is true.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 101
+          },
+          "although": {
+            "year": "3-4",
+            "family": "though/although",
+            "word": "although",
+            "slug": "although",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "though",
+              "although"
+            ],
+            "sentence": "Although it was raining, we still went out.",
+            "sentences": [
+              "Although it was raining, we still went out.",
+              "Although he was tired, he finished the page.",
+              "Although the cake looked plain, it tasted delicious.",
+              "Although the road was busy, we crossed safely.",
+              "Although she felt nervous, she answered clearly.",
+              "Although the box was small, it was very heavy.",
+              "Although the wind was strong, the tent stayed up.",
+              "Although I missed the first clue, I solved the puzzle.",
+              "Although the dog barked, it was friendly.",
+              "Although the lesson was hard, I enjoyed it."
+            ],
+            "accepted": [
+              "although"
+            ],
+            "explanation": "Although means even though or despite the fact that.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 102
+          },
+          "thought": {
+            "year": "3-4",
+            "family": "thought",
+            "word": "thought",
+            "slug": "thought",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "thought"
+            ],
+            "sentence": "I thought the answer was on the next page.",
+            "sentences": [
+              "I thought the answer was on the next page.",
+              "She thought carefully before she replied.",
+              "We thought the path would lead to the river.",
+              "He thought about the problem all evening.",
+              "Mum thought the soup needed more salt.",
+              "The class thought the film was funny.",
+              "She thought of a better plan on the bus.",
+              "He thought the box was empty.",
+              "I thought the shop closed at five.",
+              "They thought the test would be easy."
+            ],
+            "accepted": [
+              "thought"
+            ],
+            "explanation": "A thought is an idea in your mind; thought is also the past tense of think.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 103
+          },
+          "through": {
+            "year": "3-4",
+            "family": "through",
+            "word": "through",
+            "slug": "through",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "through"
+            ],
+            "sentence": "We walked through the tunnel to the beach.",
+            "sentences": [
+              "We walked through the tunnel to the beach.",
+              "Sunlight shone through the window.",
+              "She read through the list before speaking.",
+              "The train passed through the station without stopping.",
+              "He squeezed through the narrow gap.",
+              "The river runs through the middle of town.",
+              "I looked through the glass at the fossils.",
+              "They pushed through the crowd to the gate.",
+              "The dog ran through the open field.",
+              "We worked through the clues one by one."
+            ],
+            "accepted": [
+              "through"
+            ],
+            "explanation": "Through means moving in one side and out of the other, or from start to finish.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 104
+          },
+          "various": {
+            "year": "3-4",
+            "family": "various",
+            "word": "various",
+            "slug": "various",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "various"
+            ],
+            "sentence": "The museum has various old coins.",
+            "sentences": [
+              "The museum has various old coins.",
+              "The box held various colours of beads.",
+              "We tried various ways to solve it.",
+              "She visited various towns on holiday.",
+              "The class used various tools in art.",
+              "There were various birds in the tree.",
+              "He read various books about space.",
+              "We tasted various apples at the fair.",
+              "The shop sold various kinds of bread.",
+              "She had various ideas for the poster."
+            ],
+            "accepted": [
+              "various"
+            ],
+            "explanation": "Various means several different kinds.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 105
+          },
+          "weight": {
+            "year": "3-4",
+            "family": "weight",
+            "word": "weight",
+            "slug": "weight",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "weight"
+            ],
+            "sentence": "She checked the weight of the parcel before posting it.",
+            "sentences": [
+              "She checked the weight of the parcel before posting it.",
+              "The weight of the box made it hard to lift.",
+              "The scales showed the baby's weight clearly.",
+              "The bridge can carry a great deal of weight.",
+              "He felt the weight of the rucksack on his shoulders.",
+              "The weight of the snow bent the branch.",
+              "We reduced the weight by taking out the bottles.",
+              "The doctor recorded my weight at the appointment.",
+              "The weight of the suitcase surprised Dad.",
+              "The hook could not hold the weight of the bag."
+            ],
+            "accepted": [
+              "weight"
+            ],
+            "explanation": "Weight is how heavy something is.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 106
+          },
+          "woman": {
+            "year": "3-4",
+            "family": "woman/women",
+            "word": "woman",
+            "slug": "woman",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "woman",
+              "women"
+            ],
+            "sentence": "The woman was waiting by the ticket office.",
+            "sentences": [
+              "The woman was waiting by the ticket office.",
+              "A woman in a yellow coat waved to us.",
+              "The woman at the desk checked my name.",
+              "One woman carried the banner into the hall.",
+              "The woman beside the gate smiled kindly.",
+              "That woman teaches music at our school.",
+              "The woman on the bus offered me her seat.",
+              "A woman from the library came to read to us.",
+              "The woman holding the umbrella was my aunt.",
+              "The woman in front of us bought the last loaf."
+            ],
+            "accepted": [
+              "woman"
+            ],
+            "explanation": "A woman is an adult female person.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 107
+          },
+          "women": {
+            "year": "3-4",
+            "family": "woman/women",
+            "word": "women",
+            "slug": "women",
+            "spellingPool": "core",
+            "yearLabel": "Years 3-4",
+            "familyWords": [
+              "woman",
+              "women"
+            ],
+            "sentence": "The women were waiting by the ticket office.",
+            "sentences": [
+              "The women were waiting by the ticket office.",
+              "Two women ran the cake stall together.",
+              "The women at the desk checked our names.",
+              "Several women sang in the choir.",
+              "The women on the bus were laughing together.",
+              "These women work at the village shop.",
+              "The women carrying the boxes asked for help.",
+              "Many women marched in the parade.",
+              "The women in our story showed great courage.",
+              "The women beside the gate waved to us."
+            ],
+            "accepted": [
+              "women"
+            ],
+            "explanation": "Women is the plural of woman.",
+            "listId": "statutory-y3-4",
+            "yearGroups": [
+              "Y3",
+              "Y4"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 108
+          },
+          "accommodate": {
+            "year": "5-6",
+            "family": "accommodate",
+            "word": "accommodate",
+            "slug": "accommodate",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "accommodate"
+            ],
+            "sentence": "This hotel can accommodate fifty guests.",
+            "sentences": [
+              "This hotel can accommodate fifty guests.",
+              "The hall can accommodate the whole class.",
+              "We must accommodate visitors at sports day.",
+              "The shed can accommodate three bikes.",
+              "The campsite can accommodate many tents.",
+              "The coach will accommodate extra bags.",
+              "The plan should accommodate slow walkers.",
+              "The school can accommodate pupils with hearing aids.",
+              "We need to accommodate a late arrival.",
+              "The museum can accommodate wheelchairs."
+            ],
+            "accepted": [
+              "accommodate"
+            ],
+            "explanation": "To accommodate means to provide space for someone or something, or to fit in with needs.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 109
+          },
+          "accompany": {
+            "year": "5-6",
+            "family": "accompany",
+            "word": "accompany",
+            "slug": "accompany",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "accompany"
+            ],
+            "sentence": "An adult must accompany you on the trip.",
+            "sentences": [
+              "An adult must accompany you on the trip.",
+              "I will accompany my brother to the concert.",
+              "The teacher will accompany the class on the walk.",
+              "Mum can accompany me to the dentist.",
+              "Two friends will accompany the team.",
+              "The song will accompany the story.",
+              "Dad will accompany us to the station.",
+              "A guide will accompany the visitors.",
+              "The violin will accompany the singer.",
+              "Grandad offered to accompany us home."
+            ],
+            "accepted": [
+              "accompany"
+            ],
+            "explanation": "To accompany means to go somewhere with someone or to happen at the same time.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 110
+          },
+          "according": {
+            "year": "5-6",
+            "family": "according",
+            "word": "according",
+            "slug": "according",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "according"
+            ],
+            "sentence": "According to the map we are nearly there.",
+            "sentences": [
+              "According to the map we are nearly there.",
+              "The score changed according to the rules.",
+              "We sorted the books according to size.",
+              "The class lined up according to height.",
+              "The map was made according to old notes.",
+              "The lesson ran according to the plan.",
+              "We packed our bags according to the list.",
+              "The machines worked according to the timer.",
+              "The answers were marked according to the guide.",
+              "The flowers were grouped according to colour."
+            ],
+            "accepted": [
+              "according"
+            ],
+            "explanation": "According to something means as stated by it, or in a way that agrees with it.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 111
+          },
+          "achieve": {
+            "year": "5-6",
+            "family": "achieve",
+            "word": "achieve",
+            "slug": "achieve",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "achieve"
+            ],
+            "sentence": "You can achieve your goal with practice.",
+            "sentences": [
+              "You can achieve your goal with practice.",
+              "We work hard to achieve our goals.",
+              "She hopes to achieve a better score.",
+              "The class can achieve more with practice.",
+              "He wants to achieve a high mark.",
+              "We must achieve calm before the show.",
+              "They tried to achieve a fair result.",
+              "The team can achieve success together.",
+              "I will achieve my target this week.",
+              "The runner worked hard to achieve first place."
+            ],
+            "accepted": [
+              "achieve"
+            ],
+            "explanation": "To achieve means to succeed in doing something through effort.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 112
+          },
+          "aggressive": {
+            "year": "5-6",
+            "family": "aggressive",
+            "word": "aggressive",
+            "slug": "aggressive",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "aggressive"
+            ],
+            "sentence": "The aggressive dog barked loudly.",
+            "sentences": [
+              "The aggressive dog barked loudly.",
+              "The dog looked aggressive, so we kept away.",
+              "An aggressive tackle is not allowed.",
+              "His aggressive tone upset the room.",
+              "The game became aggressive near the end.",
+              "She gave an aggressive shout across the field.",
+              "We avoided the aggressive swarm of bees.",
+              "The aggressive dog barked from behind the fence.",
+              "His aggressive words made the room quiet.",
+              "An aggressive tackle can hurt another player."
+            ],
+            "accepted": [
+              "aggressive"
+            ],
+            "explanation": "Aggressive means ready to attack, argue or behave forcefully.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 113
+          },
+          "amateur": {
+            "year": "5-6",
+            "family": "amateur",
+            "word": "amateur",
+            "slug": "amateur",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "amateur"
+            ],
+            "sentence": "She is an amateur photographer.",
+            "sentences": [
+              "She is an amateur photographer.",
+              "The amateur singer tried her best.",
+              "We joined an amateur drama group.",
+              "The amateur team practised after school.",
+              "He is only an amateur player, not a pro.",
+              "An amateur photographer took the pictures.",
+              "The amateur chess club meets on Friday.",
+              "The amateur chef made soup for dinner.",
+              "Our school show used an amateur band.",
+              "The amateur runner kept a steady pace."
+            ],
+            "accepted": [
+              "amateur"
+            ],
+            "explanation": "An amateur is someone who does an activity for interest, not as a paid job.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 114
+          },
+          "ancient": {
+            "year": "5-6",
+            "family": "ancient",
+            "word": "ancient",
+            "slug": "ancient",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "ancient"
+            ],
+            "sentence": "We saw ancient ruins on holiday.",
+            "sentences": [
+              "We saw ancient ruins on holiday.",
+              "We visited an ancient castle.",
+              "The museum showed an ancient pot.",
+              "An ancient tree stood by the road.",
+              "The book described an ancient kingdom.",
+              "We studied an ancient map in class.",
+              "The ruins looked ancient and grand.",
+              "An ancient wall surrounded the field.",
+              "The path crossed an ancient bridge.",
+              "We found an ancient coin in the garden."
+            ],
+            "accepted": [
+              "ancient"
+            ],
+            "explanation": "Ancient means very old or from a long time ago.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 115
+          },
+          "apparent": {
+            "year": "5-6",
+            "family": "apparent",
+            "word": "apparent",
+            "slug": "apparent",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "apparent"
+            ],
+            "sentence": "It was apparent that he was tired.",
+            "sentences": [
+              "It was apparent that he was tired.",
+              "It was apparent that the road was closed.",
+              "The mistake was apparent to the teacher.",
+              "Her happiness was apparent to everyone.",
+              "The damage was apparent after the storm.",
+              "It became apparent that we were late.",
+              "The answer was apparent from the clues.",
+              "His worry was apparent in his voice.",
+              "The pattern was apparent on the wall.",
+              "It soon became apparent that the plan would change."
+            ],
+            "accepted": [
+              "apparent"
+            ],
+            "explanation": "Apparent means easy to see or seeming to be true.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 116
+          },
+          "appreciate": {
+            "year": "5-6",
+            "family": "appreciate",
+            "word": "appreciate",
+            "slug": "appreciate",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "appreciate"
+            ],
+            "sentence": "I appreciate your kind help.",
+            "sentences": [
+              "I appreciate your kind help.",
+              "We appreciate your help.",
+              "I appreciate the extra time.",
+              "The class will appreciate the quiet room.",
+              "We appreciate the clear instructions.",
+              "She stopped to appreciate the view.",
+              "I appreciate the kind note.",
+              "They appreciate a tidy desk.",
+              "We appreciate the work you have done.",
+              "He began to appreciate good manners."
+            ],
+            "accepted": [
+              "appreciate"
+            ],
+            "explanation": "To appreciate means to understand the value of something or be thankful for it.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 117
+          },
+          "attached": {
+            "year": "5-6",
+            "family": "attached",
+            "word": "attached",
+            "slug": "attached",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "attached"
+            ],
+            "sentence": "The label was attached to the bag.",
+            "sentences": [
+              "The label was attached to the bag.",
+              "The note was attached with a paper clip.",
+              "The kite was attached to a long string.",
+              "He felt attached to his old teddy.",
+              "A tag was attached to each coat.",
+              "The picture was attached to the wall.",
+              "The trailer was attached to the car.",
+              "The form was attached to the email.",
+              "The ribbon stayed attached to the present.",
+              "The swing was attached to a strong branch."
+            ],
+            "accepted": [
+              "attached"
+            ],
+            "explanation": "Attached means joined, fastened or feeling emotionally close.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 118
+          },
+          "available": {
+            "year": "5-6",
+            "family": "available",
+            "word": "available",
+            "slug": "available",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "available"
+            ],
+            "sentence": "The next seat is available now.",
+            "sentences": [
+              "The next seat is available now.",
+              "The seats are available now.",
+              "Some pens are available in the drawer.",
+              "The hall is available for assembly.",
+              "A coach is available after lunch.",
+              "Fresh water was available at the camp.",
+              "The library books are available to borrow.",
+              "More time was available than we expected.",
+              "The window seat is available today.",
+              "Help was available from the teacher."
+            ],
+            "accepted": [
+              "available"
+            ],
+            "explanation": "Available means ready to be used or free to do something.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 119
+          },
+          "average": {
+            "year": "5-6",
+            "family": "average",
+            "word": "average",
+            "slug": "average",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "average"
+            ],
+            "sentence": "The average score was quite high.",
+            "sentences": [
+              "The average score was quite high.",
+              "Her average score improved this term.",
+              "The average temperature was mild.",
+              "The average lunch time for our class is one o'clock.",
+              "The average child needs plenty of sleep.",
+              "The class found the average number quickly.",
+              "His average speed was steady.",
+              "The average result was better than last year.",
+              "We checked the average height of the plants.",
+              "Their average mark was very high."
+            ],
+            "accepted": [
+              "average"
+            ],
+            "explanation": "Average means typical, ordinary, or the middle amount found by sharing equally.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 120
+          },
+          "awkward": {
+            "year": "5-6",
+            "family": "awkward",
+            "word": "awkward",
+            "slug": "awkward",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "awkward"
+            ],
+            "sentence": "It was awkward carrying the huge box.",
+            "sentences": [
+              "It was awkward carrying the huge box.",
+              "The chair felt awkward to sit on.",
+              "I felt awkward when I forgot my line.",
+              "An awkward silence filled the room.",
+              "The box was awkward to carry.",
+              "She made an awkward step on the stairs.",
+              "It was awkward to carry the box alone.",
+              "He gave an awkward laugh.",
+              "The suit was awkward and stiff.",
+              "We had an awkward moment at lunch."
+            ],
+            "accepted": [
+              "awkward"
+            ],
+            "explanation": "Awkward means difficult to deal with, clumsy or uncomfortable.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 121
+          },
+          "bargain": {
+            "year": "5-6",
+            "family": "bargain",
+            "word": "bargain",
+            "slug": "bargain",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "bargain"
+            ],
+            "sentence": "The coat was a real bargain.",
+            "sentences": [
+              "The coat was a real bargain.",
+              "We found a bargain in the market.",
+              "Dad tried to bargain for a lower price.",
+              "The shop had a bargain on trainers.",
+              "Mum said the coat was a good bargain.",
+              "We can bargain with the stall holder.",
+              "The bargain basket was near the till.",
+              "She bought the book as a bargain.",
+              "It was a bargain to pay so little.",
+              "They learned to bargain politely at the market."
+            ],
+            "accepted": [
+              "bargain"
+            ],
+            "explanation": "A bargain is something bought for less than the usual price, or an agreement between people.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 122
+          },
+          "bruise": {
+            "year": "5-6",
+            "family": "bruise",
+            "word": "bruise",
+            "slug": "bruise",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "bruise"
+            ],
+            "sentence": "He had a bruise on his knee.",
+            "sentences": [
+              "He had a bruise on his knee.",
+              "I got a bruise on my knee.",
+              "The bruise turned blue by evening.",
+              "He showed me a bruise on his arm.",
+              "A bruise can be sore for a while.",
+              "She rubbed the bruise gently.",
+              "The bruise faded after a week of rest.",
+              "I can see a bruise on the apple.",
+              "The football hit left a bruise.",
+              "The nurse checked the bruise carefully."
+            ],
+            "accepted": [
+              "bruise"
+            ],
+            "explanation": "A bruise is a dark mark on skin caused by a bump or injury.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 123
+          },
+          "category": {
+            "year": "5-6",
+            "family": "category",
+            "word": "category",
+            "slug": "category",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "category"
+            ],
+            "sentence": "Place the toy in the correct category.",
+            "sentences": [
+              "Place the toy in the correct category.",
+              "We put the books in each category.",
+              "The animal fit the correct category.",
+              "This game is in a different category.",
+              "The shop has a snack category.",
+              "We chose a category for the quiz.",
+              "Each category has its own label.",
+              "The teacher sorted the words by category.",
+              "That idea belongs in another category.",
+              "The list showed one category at a time."
+            ],
+            "accepted": [
+              "category"
+            ],
+            "explanation": "A category is a group of things that share the same type or feature.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 124
+          },
+          "cemetery": {
+            "year": "5-6",
+            "family": "cemetery",
+            "word": "cemetery",
+            "slug": "cemetery",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "cemetery"
+            ],
+            "sentence": "The old cemetery was very quiet.",
+            "sentences": [
+              "The old cemetery was very quiet.",
+              "We walked quietly through the cemetery.",
+              "The cemetery was calm in the rain.",
+              "An old tree stood near the cemetery gate.",
+              "We left flowers at the cemetery.",
+              "A narrow path led past the cemetery wall.",
+              "She saw birds above the cemetery wall.",
+              "The guide spoke softly in the cemetery.",
+              "A bench stood beside the cemetery.",
+              "The cemetery looked peaceful at dusk."
+            ],
+            "accepted": [
+              "cemetery"
+            ],
+            "explanation": "A cemetery is a place where people are buried.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 125
+          },
+          "committee": {
+            "year": "5-6",
+            "family": "committee",
+            "word": "committee",
+            "slug": "committee",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "committee"
+            ],
+            "sentence": "The school committee met after lunch.",
+            "sentences": [
+              "The school committee met after lunch.",
+              "The committee met after school.",
+              "Our committee planned the fair.",
+              "The committee chose a colour theme.",
+              "A small committee checked the rules.",
+              "The committee listened to the pupils' ideas.",
+              "Each committee member had a task.",
+              "The committee agreed on the date.",
+              "The school committee approved the visit.",
+              "The committee wrote a short report."
+            ],
+            "accepted": [
+              "committee"
+            ],
+            "explanation": "A committee is a group of people chosen to discuss or organise something.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 126
+          },
+          "communicate": {
+            "year": "5-6",
+            "family": "communicate",
+            "word": "communicate",
+            "slug": "communicate",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "communicate"
+            ],
+            "sentence": "We use email to communicate quickly.",
+            "sentences": [
+              "We use email to communicate quickly.",
+              "We need to communicate clearly.",
+              "The flags help birds communicate.",
+              "We communicate by email at school.",
+              "She used sign language to communicate.",
+              "It is hard to communicate in a loud hall.",
+              "The chart helps us communicate the plan.",
+              "We can communicate with the office by phone.",
+              "The robot cannot communicate when the battery is flat.",
+              "Teachers communicate with parents each week."
+            ],
+            "accepted": [
+              "communicate"
+            ],
+            "explanation": "To communicate means to share information, ideas or feelings.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 127
+          },
+          "community": {
+            "year": "5-6",
+            "family": "community",
+            "word": "community",
+            "slug": "community",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "community"
+            ],
+            "sentence": "The whole community joined the parade.",
+            "sentences": [
+              "The whole community joined the parade.",
+              "Our community helped after the flood.",
+              "The community garden needs care.",
+              "She knows many people in the community.",
+              "The community centre opens at nine.",
+              "We joined a community clean-up.",
+              "The festival brought the community together.",
+              "Everyone in the community shared news.",
+              "The community pool is near the park.",
+              "A strong community supports local shops."
+            ],
+            "accepted": [
+              "community"
+            ],
+            "explanation": "A community is a group of people who live near each other or share something in common.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 128
+          },
+          "competition": {
+            "year": "5-6",
+            "family": "competition",
+            "word": "competition",
+            "slug": "competition",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "competition"
+            ],
+            "sentence": "She won the art competition.",
+            "sentences": [
+              "She won the art competition.",
+              "The race was a competition between two houses.",
+              "The competition started at noon.",
+              "She entered the art competition.",
+              "There was strong competition for the prize.",
+              "The competition rules were easy to follow.",
+              "He trained hard for the swimming competition.",
+              "The cooking competition smelled wonderful.",
+              "A fun competition filled the school hall.",
+              "They celebrated after the competition."
+            ],
+            "accepted": [
+              "competition"
+            ],
+            "explanation": "A competition is an event where people try to win or do better than others.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 129
+          },
+          "conscience": {
+            "year": "5-6",
+            "family": "conscience",
+            "word": "conscience",
+            "slug": "conscience",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "conscience"
+            ],
+            "sentence": "His conscience told him to return the lost wallet.",
+            "sentences": [
+              "His conscience told him to return the lost wallet.",
+              "My conscience would not let me keep the extra change.",
+              "She listened to her conscience and told the truth.",
+              "A clear conscience helped him sleep peacefully.",
+              "His conscience reminded him to apologise.",
+              "The thief ignored his conscience and ran away.",
+              "My conscience pricked me after I lied.",
+              "Her conscience told her to share the sweets fairly.",
+              "He followed his conscience even when it was hard.",
+              "We should let our conscience guide our choices."
+            ],
+            "accepted": [
+              "conscience"
+            ],
+            "explanation": "Your conscience is the inner sense that helps you know right from wrong.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 130
+          },
+          "conscious": {
+            "year": "5-6",
+            "family": "conscious",
+            "word": "conscious",
+            "slug": "conscious",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "conscious"
+            ],
+            "sentence": "She stayed conscious after the fall.",
+            "sentences": [
+              "She stayed conscious after the fall.",
+              "I was conscious of the noise behind me.",
+              "He became conscious a few moments later.",
+              "We were conscious of the time and hurried on.",
+              "The cyclist stayed conscious while the nurse checked him.",
+              "I felt conscious of everyone watching me.",
+              "They were conscious of the danger near the edge.",
+              "Mum was conscious of my worry at once.",
+              "He remained conscious after the bump.",
+              "She was conscious of the slippery floor and stepped carefully."
+            ],
+            "accepted": [
+              "conscious"
+            ],
+            "explanation": "Conscious means awake, aware or able to notice what is happening.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 131
+          },
+          "controversy": {
+            "year": "5-6",
+            "family": "controversy",
+            "word": "controversy",
+            "slug": "controversy",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "controversy"
+            ],
+            "sentence": "The rule change caused some controversy.",
+            "sentences": [
+              "The rule change caused some controversy.",
+              "The new rule caused controversy.",
+              "The article led to controversy.",
+              "There was controversy about the team names.",
+              "The change sparked controversy at school.",
+              "The film created controversy among parents.",
+              "The speaker avoided controversy.",
+              "The idea brought controversy to the meeting.",
+              "The mistake caused no controversy.",
+              "The budget was at the centre of controversy."
+            ],
+            "accepted": [
+              "controversy"
+            ],
+            "explanation": "A controversy is strong disagreement about an issue.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 132
+          },
+          "convenience": {
+            "year": "5-6",
+            "family": "convenience",
+            "word": "convenience",
+            "slug": "convenience",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "convenience"
+            ],
+            "sentence": "For convenience, we packed the night before.",
+            "sentences": [
+              "For convenience, we packed the night before.",
+              "The new lift adds convenience for visitors.",
+              "The handle was added for convenience.",
+              "They chose the nearer shop for convenience.",
+              "The side pocket is there for convenience.",
+              "Online booking adds convenience for busy families.",
+              "The timetable was changed for the convenience of parents.",
+              "We met at the gate for convenience.",
+              "The parcel lockers are there for our convenience.",
+              "A second entrance gives extra convenience on busy days."
+            ],
+            "accepted": [
+              "convenience"
+            ],
+            "explanation": "Convenience means ease, usefulness or something that saves time and effort.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 133
+          },
+          "correspond": {
+            "year": "5-6",
+            "family": "correspond",
+            "word": "correspond",
+            "slug": "correspond",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "correspond"
+            ],
+            "sentence": "The numbers should correspond to the names.",
+            "sentences": [
+              "The numbers should correspond to the names.",
+              "Please correspond with the office by email.",
+              "Our letters correspond to the dates.",
+              "The map marks correspond with the signs.",
+              "The shapes correspond to the clues.",
+              "His answers correspond to the facts.",
+              "The numbers correspond with the chart.",
+              "We correspond by post during the holiday.",
+              "The colours correspond to the house groups.",
+              "Her notes correspond with mine."
+            ],
+            "accepted": [
+              "correspond"
+            ],
+            "explanation": "To correspond means to match, agree or communicate by messages.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 134
+          },
+          "criticise": {
+            "year": "5-6",
+            "family": "criticise (critic + ise)",
+            "word": "criticise",
+            "slug": "criticise",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "criticise"
+            ],
+            "sentence": "It is easy to criticise from the side-lines.",
+            "sentences": [
+              "It is easy to criticise from the side-lines.",
+              "Do not criticise other people's work.",
+              "The teacher will criticise the draft kindly.",
+              "It is rude to criticise a classmate.",
+              "He can criticise the plan if needed.",
+              "We should not criticise before listening.",
+              "She did not mean to criticise him.",
+              "The coach may criticise our effort.",
+              "Parents should not criticise every mistake.",
+              "He began to criticise the messy table."
+            ],
+            "accepted": [
+              "criticise",
+              "criticize"
+            ],
+            "explanation": "To criticise means to say what is wrong with something or someone.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 135
+          },
+          "curiosity": {
+            "year": "5-6",
+            "family": "curiosity",
+            "word": "curiosity",
+            "slug": "curiosity",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "curiosity"
+            ],
+            "sentence": "Her curiosity made her open the box.",
+            "sentences": [
+              "Her curiosity made her open the box.",
+              "Her curiosity led her to open the box.",
+              "The puppy sniffed with curiosity.",
+              "His curiosity grew during the tour.",
+              "A little curiosity helps us learn new things.",
+              "She looked at the map with curiosity.",
+              "The story stirred my curiosity.",
+              "A little curiosity can be useful.",
+              "The child asked questions with curiosity.",
+              "His curiosity made him explore the attic."
+            ],
+            "accepted": [
+              "curiosity"
+            ],
+            "explanation": "Curiosity is the wish to know, learn or find out about something.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 136
+          },
+          "definite": {
+            "year": "5-6",
+            "family": "definite",
+            "word": "definite",
+            "slug": "definite",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "definite"
+            ],
+            "sentence": "There was a definite change in the weather.",
+            "sentences": [
+              "There was a definite change in the weather.",
+              "We need a definite answer.",
+              "The plan has a definite start time.",
+              "I am definite about my choice.",
+              "She gave a definite nod.",
+              "The smell was a definite sign of soup.",
+              "We had a definite goal.",
+              "His face showed a definite smile.",
+              "The result was definite by lunch.",
+              "There is a definite path through the wood."
+            ],
+            "accepted": [
+              "definite"
+            ],
+            "explanation": "Definite means clear, certain and not vague.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 137
+          },
+          "desperate": {
+            "year": "5-6",
+            "family": "desperate",
+            "word": "desperate",
+            "slug": "desperate",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "desperate"
+            ],
+            "sentence": "We were desperate to find shelter.",
+            "sentences": [
+              "We were desperate to find shelter.",
+              "The lost pup looked desperate.",
+              "We were desperate for water.",
+              "She felt desperate before the test.",
+              "The team made a desperate effort.",
+              "He gave a desperate cry for help.",
+              "I was desperate to finish on time.",
+              "The search became desperate after dark.",
+              "They made a desperate plan to help.",
+              "Mum was desperate for a hot drink."
+            ],
+            "accepted": [
+              "desperate"
+            ],
+            "explanation": "Desperate means feeling that you urgently need something or have little hope.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 138
+          },
+          "determined": {
+            "year": "5-6",
+            "family": "determined",
+            "word": "determined",
+            "slug": "determined",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "determined"
+            ],
+            "sentence": "She felt determined to improve.",
+            "sentences": [
+              "She felt determined to improve.",
+              "The runner was determined to win.",
+              "She looked determined in the race.",
+              "We are determined to improve.",
+              "He was determined to finish the book.",
+              "The team stayed determined after the break.",
+              "I felt determined to try again.",
+              "They were determined to reach the hill.",
+              "Our class was determined and focused.",
+              "The dog looked determined to catch the ball."
+            ],
+            "accepted": [
+              "determined"
+            ],
+            "explanation": "Determined means firmly decided to do something and not give up.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 139
+          },
+          "develop": {
+            "year": "5-6",
+            "family": "develop",
+            "word": "develop",
+            "slug": "develop",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "develop"
+            ],
+            "sentence": "Seeds develop best in warm soil.",
+            "sentences": [
+              "Seeds develop best in warm soil.",
+              "Plants develop from tiny seeds.",
+              "We develop new skills in class.",
+              "The baby will develop quickly.",
+              "The town may develop by the river.",
+              "Good habits develop over time.",
+              "The class will develop a plan.",
+              "Some films develop slowly.",
+              "We should develop the idea further.",
+              "The story will develop later."
+            ],
+            "accepted": [
+              "develop"
+            ],
+            "explanation": "To develop means to grow, improve or become more advanced.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 140
+          },
+          "dictionary": {
+            "year": "5-6",
+            "family": "dictionary",
+            "word": "dictionary",
+            "slug": "dictionary",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "dictionary"
+            ],
+            "sentence": "Use a dictionary to check the meaning.",
+            "sentences": [
+              "Use a dictionary to check the meaning.",
+              "The dictionary was on the shelf.",
+              "We used the dictionary in class.",
+              "She found the meaning in the dictionary.",
+              "The dictionary helped us choose the right word.",
+              "He opened the dictionary to the next page.",
+              "The dictionary gave a useful example.",
+              "I keep a dictionary by my desk.",
+              "The dictionary showed both forms.",
+              "We shared the dictionary during the task."
+            ],
+            "accepted": [
+              "dictionary"
+            ],
+            "explanation": "A dictionary is a book or resource that explains words, spellings and meanings.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 141
+          },
+          "disastrous": {
+            "year": "5-6",
+            "family": "disastrous",
+            "word": "disastrous",
+            "slug": "disastrous",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "disastrous"
+            ],
+            "sentence": "The flood had disastrous effects on the village.",
+            "sentences": [
+              "The flood had disastrous effects on the village.",
+              "The storm had a disastrous effect.",
+              "The plan ended in a disastrous delay.",
+              "It was disastrous to leave the window open.",
+              "The match was disastrous from the start.",
+              "One small mistake proved disastrous for the game.",
+              "The flood caused disastrous harm to the field.",
+              "The cooking lesson became disastrous after the oven failed.",
+              "The delay had disastrous results for the trip.",
+              "The broken pump was disastrous for the field."
+            ],
+            "accepted": [
+              "disastrous"
+            ],
+            "explanation": "Disastrous means causing great harm, failure or trouble.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 142
+          },
+          "embarrass": {
+            "year": "5-6",
+            "family": "embarrass",
+            "word": "embarrass",
+            "slug": "embarrass",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "embarrass"
+            ],
+            "sentence": "Please do not embarrass your brother.",
+            "sentences": [
+              "Please do not embarrass your brother.",
+              "Do not embarrass your friend.",
+              "Please do not embarrass the speaker.",
+              "The joke might embarrass her.",
+              "I did not want to embarrass my sister.",
+              "Loud comments can embarrass people.",
+              "The question may embarrass him.",
+              "We should not embarrass anyone on stage.",
+              "A mistake can embarrass a pupil.",
+              "He tried to embarrass the actor."
+            ],
+            "accepted": [
+              "embarrass"
+            ],
+            "explanation": "To embarrass someone means to make them feel awkward, ashamed or self-conscious.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 143
+          },
+          "environment": {
+            "year": "5-6",
+            "family": "environment",
+            "word": "environment",
+            "slug": "environment",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "environment"
+            ],
+            "sentence": "We should protect the environment.",
+            "sentences": [
+              "We should protect the environment.",
+              "Litter can damage the environment very quickly.",
+              "Trees help the environment by giving shade and shelter.",
+              "A clean river supports a healthy environment.",
+              "Smoke can harm the environment.",
+              "The park group worked to improve the environment near the pond.",
+              "Everyone can help the environment by saving water.",
+              "The class learned how weather affects the environment.",
+              "We want a safe environment for wildlife.",
+              "The school is trying to improve the local environment."
+            ],
+            "accepted": [
+              "environment"
+            ],
+            "explanation": "The environment is the natural world around us, or the conditions in a place.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 144
+          },
+          "equip": {
+            "year": "5-6",
+            "family": "equip (-ped, -ment)",
+            "word": "equip",
+            "slug": "equip",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "equip",
+              "equipped",
+              "equipment"
+            ],
+            "sentence": "Good boots equip you for rough ground.",
+            "sentences": [
+              "Good boots equip you for rough ground.",
+              "Please equip the bike with a bell and lights.",
+              "We need to equip the team before the match.",
+              "The shop can equip the shed with shelves.",
+              "You should equip the tent with a ground sheet.",
+              "The school will equip each lab with safety goggles.",
+              "Mum helped equip the picnic bag with plates.",
+              "The workers equip the van with new tools.",
+              "The museum will equip the room with audio guides.",
+              "Dad can equip the toolbox with a hammer and tape measure."
+            ],
+            "accepted": [
+              "equip"
+            ],
+            "explanation": "To equip means to provide the things needed for a task.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 145
+          },
+          "equipped": {
+            "year": "5-6",
+            "family": "equip (-ped, -ment)",
+            "word": "equipped",
+            "slug": "equipped",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "equip",
+              "equipped",
+              "equipment"
+            ],
+            "sentence": "The classroom was equipped with new computers.",
+            "sentences": [
+              "The classroom was equipped with new computers.",
+              "The sailor was equipped with a life jacket.",
+              "The class was equipped with pencils and rulers.",
+              "The rescue team was equipped with torches.",
+              "The tent was equipped with warm blankets.",
+              "The lab was equipped with safety glasses.",
+              "She felt equipped for the test after revision.",
+              "The car was equipped with new tyres.",
+              "The bag was equipped with a water bottle holder.",
+              "The kitchen was equipped with useful cupboards."
+            ],
+            "accepted": [
+              "equipped"
+            ],
+            "explanation": "Equipped means provided with what is needed.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 146
+          },
+          "equipment": {
+            "year": "5-6",
+            "family": "equip (-ped, -ment)",
+            "word": "equipment",
+            "slug": "equipment",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "equip",
+              "equipped",
+              "equipment"
+            ],
+            "sentence": "The team packed all the safety equipment.",
+            "sentences": [
+              "The team packed all the safety equipment.",
+              "The sports equipment was stored in the hall.",
+              "We checked the equipment before the lesson.",
+              "The science equipment was clean and ready.",
+              "The coach counted the equipment after training.",
+              "The repair kit was part of the emergency equipment.",
+              "Our equipment must be packed carefully.",
+              "The school bought new equipment for music.",
+              "The camping equipment fitted neatly in the car.",
+              "The safety equipment helped the workers."
+            ],
+            "accepted": [
+              "equipment"
+            ],
+            "explanation": "Equipment is the things needed for a particular job or activity.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 147
+          },
+          "especially": {
+            "year": "5-6",
+            "family": "especially",
+            "word": "especially",
+            "slug": "especially",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "especially"
+            ],
+            "sentence": "I especially enjoy reading mystery books.",
+            "sentences": [
+              "I especially enjoy reading mystery books.",
+              "I liked the cake, especially the icing.",
+              "The path was muddy, especially near the gate.",
+              "She enjoyed the book, especially the ending.",
+              "We need to be careful, especially on the stairs.",
+              "The lesson was useful, especially the reading part.",
+              "He was tired, especially after football.",
+              "The hall was noisy, especially at lunchtime.",
+              "The flowers looked bright, especially in the sun.",
+              "I am hungry, especially after swimming."
+            ],
+            "accepted": [
+              "especially"
+            ],
+            "explanation": "Especially means particularly, or more than usual.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 148
+          },
+          "exaggerate": {
+            "year": "5-6",
+            "family": "exaggerate",
+            "word": "exaggerate",
+            "slug": "exaggerate",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "exaggerate"
+            ],
+            "sentence": "Do not exaggerate the size of the fish.",
+            "sentences": [
+              "Do not exaggerate the size of the fish.",
+              "Do not exaggerate when you tell the story.",
+              "He likes to exaggerate the size of the wave.",
+              "It is easy to exaggerate a small mistake.",
+              "Try not to exaggerate the number of sweets.",
+              "Some people exaggerate when they are nervous.",
+              "The film did not exaggerate the storm.",
+              "We should not exaggerate our worries.",
+              "She may exaggerate the splash to make us laugh.",
+              "The writer chose not to exaggerate the danger."
+            ],
+            "accepted": [
+              "exaggerate"
+            ],
+            "explanation": "To exaggerate means to describe something as bigger, better or worse than it really is.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 149
+          },
+          "excellent": {
+            "year": "5-6",
+            "family": "excellent",
+            "word": "excellent",
+            "slug": "excellent",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "excellent"
+            ],
+            "sentence": "You did an excellent job.",
+            "sentences": [
+              "You did an excellent job.",
+              "Your work was excellent today.",
+              "The soup tasted excellent with bread.",
+              "She gave an excellent answer in class.",
+              "The choir made an excellent sound.",
+              "We had an excellent trip to the museum.",
+              "His plan was excellent and clear.",
+              "The dog did an excellent job learning the trick.",
+              "That was an excellent choice for lunch.",
+              "They found an excellent place to sit."
+            ],
+            "accepted": [
+              "excellent"
+            ],
+            "explanation": "Excellent means extremely good.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 150
+          },
+          "existence": {
+            "year": "5-6",
+            "family": "existence",
+            "word": "existence",
+            "slug": "existence",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "existence"
+            ],
+            "sentence": "The dinosaur bones proved its existence.",
+            "sentences": [
+              "The dinosaur bones proved its existence.",
+              "Scientists study the existence of tiny creatures.",
+              "The class discussed the existence of planets.",
+              "We learned about the existence of ancient forests.",
+              "The story hinted at the existence of a secret door.",
+              "No one could prove the existence of the monster.",
+              "The map showed the existence of a small island.",
+              "People wonder about the existence of stars far away.",
+              "The lesson explained the existence of fossils.",
+              "Some books explore the existence of hidden worlds."
+            ],
+            "accepted": [
+              "existence"
+            ],
+            "explanation": "Existence is the state of being real or alive.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 151
+          },
+          "explanation": {
+            "year": "5-6",
+            "family": "explanation",
+            "word": "explanation",
+            "slug": "explanation",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "explanation"
+            ],
+            "sentence": "His explanation made sense to everyone.",
+            "sentences": [
+              "His explanation made sense to everyone.",
+              "Her explanation made the rule clear.",
+              "I listened carefully to the explanation.",
+              "The teacher gave a simple explanation.",
+              "His explanation helped the class understand.",
+              "The chart was useful as an explanation.",
+              "We needed an explanation for the missing book.",
+              "Their explanation sounded honest.",
+              "The video offered an explanation of the process.",
+              "She asked for an explanation of the answer."
+            ],
+            "accepted": [
+              "explanation"
+            ],
+            "explanation": "An explanation gives reasons or details that make something clear.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 152
+          },
+          "familiar": {
+            "year": "5-6",
+            "family": "familiar",
+            "word": "familiar",
+            "slug": "familiar",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "familiar"
+            ],
+            "sentence": "That tune sounds familiar to me.",
+            "sentences": [
+              "That tune sounds familiar to me.",
+              "The route felt familiar after the first turn.",
+              "The song sounded familiar to me.",
+              "Her face looked familiar in the crowd.",
+              "The room seemed familiar and safe.",
+              "The smell was familiar from the bakery.",
+              "The story was familiar but still fun.",
+              "This game is familiar to many pupils.",
+              "The teacher made the topic familiar with examples.",
+              "The dog was familiar with the family."
+            ],
+            "accepted": [
+              "familiar"
+            ],
+            "explanation": "Familiar means known to you because you have seen or experienced it before.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 153
+          },
+          "foreign": {
+            "year": "5-6",
+            "family": "foreign",
+            "word": "foreign",
+            "slug": "foreign",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "foreign"
+            ],
+            "sentence": "We tried foreign food at the market.",
+            "sentences": [
+              "We tried foreign food at the market.",
+              "We read a foreign word in the book.",
+              "The museum displayed a foreign coin.",
+              "He heard a foreign accent on the train.",
+              "The market sold a foreign snack.",
+              "They welcomed a foreign visitor to school.",
+              "The flag came from a foreign country.",
+              "I practised a foreign phrase before the trip.",
+              "The class studied a foreign city.",
+              "The package had a foreign stamp."
+            ],
+            "accepted": [
+              "foreign"
+            ],
+            "explanation": "Foreign means from another country or not familiar.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 154
+          },
+          "forty": {
+            "year": "5-6",
+            "family": "forty",
+            "word": "forty",
+            "slug": "forty",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "forty"
+            ],
+            "sentence": "There were forty chairs in the hall.",
+            "sentences": [
+              "There were forty chairs in the hall.",
+              "There are forty chairs in the hall.",
+              "She saved forty stickers in her book.",
+              "We counted forty shells on the beach.",
+              "The bus stopped for forty seconds.",
+              "He read forty pages of the novel.",
+              "The jar held forty marbles.",
+              "Our class has forty minutes left.",
+              "They planted forty bulbs in the garden.",
+              "The teacher handed out forty cards."
+            ],
+            "accepted": [
+              "forty"
+            ],
+            "explanation": "Forty is the number after thirty-nine and before forty-one.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 155
+          },
+          "frequently": {
+            "year": "5-6",
+            "family": "frequently",
+            "word": "frequently",
+            "slug": "frequently",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "frequently"
+            ],
+            "sentence": "We frequently visit our grandparents.",
+            "sentences": [
+              "We frequently visit our grandparents.",
+              "We frequently visit the library after school.",
+              "The dog frequently sleeps by the fire.",
+              "She frequently helps her younger brother.",
+              "We frequently hear birds in the morning.",
+              "The road is frequently busy at rush hour.",
+              "He frequently forgets his water bottle.",
+              "The shop is frequently open on Saturdays.",
+              "I frequently read before bed.",
+              "The river frequently floods after heavy rain."
+            ],
+            "accepted": [
+              "frequently"
+            ],
+            "explanation": "Frequently means often or many times.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 156
+          },
+          "government": {
+            "year": "5-6",
+            "family": "government",
+            "word": "government",
+            "slug": "government",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "government"
+            ],
+            "sentence": "The government announced a new plan.",
+            "sentences": [
+              "The government announced a new plan.",
+              "The government passed a new rule.",
+              "The government supports local schools.",
+              "The government announced the plan yesterday.",
+              "Our government protects public services.",
+              "The government listened to the report.",
+              "The government funded the new park.",
+              "The government set a clear target.",
+              "The government met with the teachers.",
+              "The government changed the law."
+            ],
+            "accepted": [
+              "government"
+            ],
+            "explanation": "A government is the group of people who run a country or area.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 157
+          },
+          "guarantee": {
+            "year": "5-6",
+            "family": "guarantee",
+            "word": "guarantee",
+            "slug": "guarantee",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "guarantee"
+            ],
+            "sentence": "I cannot guarantee sunny weather.",
+            "sentences": [
+              "I cannot guarantee sunny weather.",
+              "The shop offered a guarantee on the bike.",
+              "This kettle has a five year guarantee.",
+              "We kept the receipt for the guarantee.",
+              "The coach could not guarantee a win.",
+              "The card gives a guarantee for repairs.",
+              "No one can guarantee sunny weather.",
+              "The company sent a guarantee by email.",
+              "The toy came with a guarantee against faults.",
+              "I need a guarantee before I sign."
+            ],
+            "accepted": [
+              "guarantee"
+            ],
+            "explanation": "A guarantee is a firm promise that something will happen or work as expected.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 158
+          },
+          "harass": {
+            "year": "5-6",
+            "family": "harass",
+            "word": "harass",
+            "slug": "harass",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "harass"
+            ],
+            "sentence": "It is wrong to harass others online.",
+            "sentences": [
+              "It is wrong to harass others online.",
+              "Do not harass other children online.",
+              "Some people harass animals and that is wrong.",
+              "The bully tried to harass the new pupil.",
+              "We must never harass anyone at school.",
+              "The gang tried to harass the shop owner.",
+              "We should not harass the birds in the park.",
+              "It is wrong to harass a classmate.",
+              "The players must not harass the referee.",
+              "The police warned them not to harass the family."
+            ],
+            "accepted": [
+              "harass"
+            ],
+            "explanation": "To harass means to repeatedly trouble, bother or upset someone.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 159
+          },
+          "hindrance": {
+            "year": "5-6",
+            "family": "hindrance",
+            "word": "hindrance",
+            "slug": "hindrance",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "hindrance"
+            ],
+            "sentence": "The broken gate was a hindrance to progress.",
+            "sentences": [
+              "The broken gate was a hindrance to progress.",
+              "A broken fence was a hindrance to the game.",
+              "Rain can be a hindrance to our walk.",
+              "The heavy bag became a hindrance on the stairs.",
+              "Loud noise was a hindrance to my reading.",
+              "The narrow bridge was a hindrance for the truck.",
+              "Fear can be a hindrance when you try new things.",
+              "A missing key was a hindrance to the plan.",
+              "Poor light was a hindrance in the hall.",
+              "The sand was a hindrance to the bike wheels."
+            ],
+            "accepted": [
+              "hindrance"
+            ],
+            "explanation": "A hindrance is something that gets in the way or makes progress harder.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 160
+          },
+          "identity": {
+            "year": "5-6",
+            "family": "identity",
+            "word": "identity",
+            "slug": "identity",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "identity"
+            ],
+            "sentence": "Your identity should stay private online.",
+            "sentences": [
+              "Your identity should stay private online.",
+              "The passport proved her identity.",
+              "He kept his identity card in a safe place.",
+              "A name badge can confirm your identity.",
+              "The actor tried to hide his identity behind a mask.",
+              "The coach checked the identity of each player.",
+              "The form asked for proof of identity.",
+              "The detective worked hard to discover the thief's identity.",
+              "The website tells users to protect their identity.",
+              "A uniform can hide identity in a crowd."
+            ],
+            "accepted": [
+              "identity"
+            ],
+            "explanation": "Identity is who a person is, including the qualities that make them unique.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 161
+          },
+          "immediate": {
+            "year": "5-6",
+            "family": "immediate(ly)",
+            "word": "immediate",
+            "slug": "immediate",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "immediate",
+              "immediately"
+            ],
+            "sentence": "We need an immediate response.",
+            "sentences": [
+              "We need an immediate response.",
+              "The doctor gave immediate help.",
+              "We needed immediate action after the alarm.",
+              "Her immediate answer was correct.",
+              "The storm caused immediate damage.",
+              "Please give immediate attention to the spill.",
+              "The message had immediate effect.",
+              "The teacher asked for immediate silence.",
+              "The team made an immediate start.",
+              "The repair gave immediate results."
+            ],
+            "accepted": [
+              "immediate"
+            ],
+            "explanation": "Immediate means happening now or without delay.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 162
+          },
+          "immediately": {
+            "year": "5-6",
+            "family": "immediate(ly)",
+            "word": "immediately",
+            "slug": "immediately",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "immediate",
+              "immediately"
+            ],
+            "sentence": "Please come here immediately.",
+            "sentences": [
+              "Please come here immediately.",
+              "She replied immediately.",
+              "We left immediately after lunch.",
+              "He ran immediately to the gate.",
+              "The bell rang immediately before the test.",
+              "The nurse came immediately.",
+              "Please open the window immediately.",
+              "They packed away immediately.",
+              "The car stopped immediately.",
+              "I knew immediately that it was right."
+            ],
+            "accepted": [
+              "immediately"
+            ],
+            "explanation": "Immediately means straight away or without delay.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 163
+          },
+          "individual": {
+            "year": "5-6",
+            "family": "individual",
+            "word": "individual",
+            "slug": "individual",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "individual"
+            ],
+            "sentence": "Each individual plant needs water.",
+            "sentences": [
+              "Each individual plant needs water.",
+              "Each individual had a different badge.",
+              "The teacher spoke to each individual pupil.",
+              "An individual choice can change the result.",
+              "Every individual answer was checked.",
+              "The artist painted one individual flower.",
+              "We counted each individual leaf.",
+              "An individual plan may suit one child.",
+              "The doctor met each individual patient.",
+              "The game gave each individual player a turn."
+            ],
+            "accepted": [
+              "individual"
+            ],
+            "explanation": "An individual is one person or thing, separate from a group.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 164
+          },
+          "interfere": {
+            "year": "5-6",
+            "family": "interfere",
+            "word": "interfere",
+            "slug": "interfere",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "interfere"
+            ],
+            "sentence": "Do not interfere with the experiment.",
+            "sentences": [
+              "Do not interfere with the experiment.",
+              "Do not interfere with the wires.",
+              "I will not interfere in your game.",
+              "Please do not interfere with the experiment.",
+              "The wind can interfere with the signal.",
+              "Her questions did not interfere with the lesson.",
+              "We should not interfere with wildlife.",
+              "The branch might interfere with the window.",
+              "He tried to interfere with the work.",
+              "Noise can interfere with your hearing."
+            ],
+            "accepted": [
+              "interfere"
+            ],
+            "explanation": "To interfere means to get involved in a way that causes problems or is not wanted.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 165
+          },
+          "interrupt": {
+            "year": "5-6",
+            "family": "interrupt",
+            "word": "interrupt",
+            "slug": "interrupt",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "interrupt"
+            ],
+            "sentence": "Please do not interrupt the speaker.",
+            "sentences": [
+              "Please do not interrupt the speaker.",
+              "The phone can interrupt the lesson.",
+              "I hate to interrupt your work.",
+              "A siren may interrupt the quiet night.",
+              "She tried not to interrupt the story.",
+              "Loud laughter can interrupt the reading.",
+              "The rain may interrupt the match.",
+              "He would not interrupt the meeting.",
+              "A sudden knock can interrupt our talk.",
+              "The warning did not interrupt the flow."
+            ],
+            "accepted": [
+              "interrupt"
+            ],
+            "explanation": "To interrupt means to stop someone while they are speaking or doing something.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 166
+          },
+          "language": {
+            "year": "5-6",
+            "family": "language",
+            "word": "language",
+            "slug": "language",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "language"
+            ],
+            "sentence": "French is a beautiful language.",
+            "sentences": [
+              "French is a beautiful language.",
+              "We learn language through listening.",
+              "Her language was kind and clear.",
+              "The book uses simple language.",
+              "He spoke a foreign language at home.",
+              "The teacher explained the language rule.",
+              "Good language helps us understand each other.",
+              "The poem used beautiful language.",
+              "We read language signs on the road.",
+              "The lesson focused on spoken language."
+            ],
+            "accepted": [
+              "language"
+            ],
+            "explanation": "Language is a system of words and signs that people use to communicate.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 167
+          },
+          "leisure": {
+            "year": "5-6",
+            "family": "leisure",
+            "word": "leisure",
+            "slug": "leisure",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "leisure"
+            ],
+            "sentence": "Reading is one of my leisure activities.",
+            "sentences": [
+              "Reading is one of my leisure activities.",
+              "We spent our leisure in the park.",
+              "Reading is a good leisure activity.",
+              "The village has a leisure centre.",
+              "He enjoyed his leisure after homework.",
+              "The class learned about leisure time.",
+              "They used their leisure to play chess.",
+              "The coach asked about leisure choices.",
+              "The family travelled during their leisure.",
+              "The garden gave us leisure and calm."
+            ],
+            "accepted": [
+              "leisure"
+            ],
+            "explanation": "Leisure is free time when you can rest or enjoy activities.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 168
+          },
+          "lightning": {
+            "year": "5-6",
+            "family": "lightning",
+            "word": "lightning",
+            "slug": "lightning",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "lightning"
+            ],
+            "sentence": "A flash of lightning lit the sky.",
+            "sentences": [
+              "A flash of lightning lit the sky.",
+              "The storm brought bright lightning.",
+              "We saw lightning over the hill.",
+              "Lightning flashed across the sky.",
+              "The dog hid during the lightning.",
+              "The report warned of lightning tonight.",
+              "Lightning struck the tree near the road.",
+              "We heard thunder after the lightning.",
+              "The field was lit by lightning.",
+              "The pilot watched lightning from above."
+            ],
+            "accepted": [
+              "lightning"
+            ],
+            "explanation": "Lightning is a bright flash of electricity in the sky during a storm.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 169
+          },
+          "marvellous": {
+            "year": "5-6",
+            "family": "marvellous",
+            "word": "marvellous",
+            "slug": "marvellous",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "marvellous"
+            ],
+            "sentence": "We had a marvellous day at the beach.",
+            "sentences": [
+              "We had a marvellous day at the beach.",
+              "The cake tasted marvellous.",
+              "We had a marvellous day at the coast.",
+              "Her drawing looked marvellous.",
+              "The view from the hill was marvellous.",
+              "He gave a marvellous answer.",
+              "The match was marvellous to watch.",
+              "The garden smelled marvellous after rain.",
+              "Your idea is marvellous for the play.",
+              "The show was marvellous from start to finish."
+            ],
+            "accepted": [
+              "marvellous"
+            ],
+            "explanation": "Marvellous means wonderful or very impressive.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 170
+          },
+          "mischievous": {
+            "year": "5-6",
+            "family": "mischievous",
+            "word": "mischievous",
+            "slug": "mischievous",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "mischievous"
+            ],
+            "sentence": "The mischievous cat stole a biscuit.",
+            "sentences": [
+              "The mischievous cat stole a biscuit.",
+              "The mischievous puppy stole a sock.",
+              "A mischievous grin spread across his face.",
+              "The mischievous cat jumped on the shelf.",
+              "Her mischievous trick made us laugh.",
+              "The mischievous child hid the keys.",
+              "We heard a mischievous whisper at the back.",
+              "The mischievous wind blew my hat away.",
+              "His mischievous idea was not very kind.",
+              "The mischievous boy painted the door handle."
+            ],
+            "accepted": [
+              "mischievous"
+            ],
+            "explanation": "Mischievous means playful in a naughty or troublesome way.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 171
+          },
+          "muscle": {
+            "year": "5-6",
+            "family": "muscle",
+            "word": "muscle",
+            "slug": "muscle",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "muscle"
+            ],
+            "sentence": "You use a muscle to lift your arm.",
+            "sentences": [
+              "You use a muscle to lift your arm.",
+              "The muscle in my arm felt sore.",
+              "Exercise helps build a strong muscle.",
+              "He pulled a muscle during football.",
+              "The doctor checked the muscle in my leg.",
+              "Warm up before you strain a muscle.",
+              "The cat flexed a tiny muscle as it slept.",
+              "The bike ride used every muscle in my legs.",
+              "She stretched the muscle after running.",
+              "A healthy diet helps each muscle grow."
+            ],
+            "accepted": [
+              "muscle"
+            ],
+            "explanation": "A muscle is body tissue that tightens and relaxes to help you move.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 172
+          },
+          "necessary": {
+            "year": "5-6",
+            "family": "necessary",
+            "word": "necessary",
+            "slug": "necessary",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "necessary"
+            ],
+            "sentence": "A helmet is necessary for safety.",
+            "sentences": [
+              "A helmet is necessary for safety.",
+              "It is necessary to wear a coat.",
+              "Water is necessary for life.",
+              "A map is necessary on this walk.",
+              "Good sleep is necessary before a test.",
+              "It was necessary to stop and rest.",
+              "These tools are necessary for the job.",
+              "A ticket is necessary to enter.",
+              "It is necessary to read the rules.",
+              "The teacher said silence was necessary."
+            ],
+            "accepted": [
+              "necessary"
+            ],
+            "explanation": "Necessary means needed or required.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 173
+          },
+          "neighbour": {
+            "year": "5-6",
+            "family": "neighbour",
+            "word": "neighbour",
+            "slug": "neighbour",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "neighbour"
+            ],
+            "sentence": "Our neighbour brought over some cake.",
+            "sentences": [
+              "Our neighbour brought over some cake.",
+              "Our neighbour brought us apples.",
+              "The neighbour next door has a dog.",
+              "We waved to our neighbour over the fence.",
+              "The neighbour helped carry the bags.",
+              "A kind neighbour fixed the gate.",
+              "The neighbour from across the road smiled.",
+              "We thanked our neighbour for the card.",
+              "The neighbour planted flowers by the wall.",
+              "Our neighbour keeps a tidy garden."
+            ],
+            "accepted": [
+              "neighbour"
+            ],
+            "explanation": "A neighbour is someone who lives near you.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 174
+          },
+          "nuisance": {
+            "year": "5-6",
+            "family": "nuisance",
+            "word": "nuisance",
+            "slug": "nuisance",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "nuisance"
+            ],
+            "sentence": "The dripping tap became a nuisance.",
+            "sentences": [
+              "The dripping tap became a nuisance.",
+              "The broken bell was a nuisance.",
+              "Mud on the floor is a nuisance.",
+              "The loud noise became a nuisance.",
+              "Wasps can be a nuisance in summer.",
+              "A dripping tap is a nuisance.",
+              "The rain was a nuisance during lunch.",
+              "The old alarm proved a nuisance.",
+              "That loose stone is a nuisance on the path.",
+              "The extra delay was a nuisance for everyone."
+            ],
+            "accepted": [
+              "nuisance"
+            ],
+            "explanation": "A nuisance is a person or thing that annoys or causes trouble.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 175
+          },
+          "occupy": {
+            "year": "5-6",
+            "family": "occupy",
+            "word": "occupy",
+            "slug": "occupy",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "occupy"
+            ],
+            "sentence": "The boxes occupy too much space.",
+            "sentences": [
+              "The boxes occupy too much space.",
+              "The books occupy the whole shelf.",
+              "The team will occupy the hall.",
+              "Our bags occupy the back seat.",
+              "The workers occupy the room all morning.",
+              "Clouds occupy the sky before rain.",
+              "The new boxes occupy too much space.",
+              "The tourists occupy the benches at lunch.",
+              "The lessons occupy most of the day.",
+              "The ants occupy the crack in the wall."
+            ],
+            "accepted": [
+              "occupy"
+            ],
+            "explanation": "To occupy means to take up space, live in a place or keep someone busy.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 176
+          },
+          "occur": {
+            "year": "5-6",
+            "family": "occur",
+            "word": "occur",
+            "slug": "occur",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "occur"
+            ],
+            "sentence": "Mistakes can occur when we rush.",
+            "sentences": [
+              "Mistakes can occur when we rush.",
+              "Delays often occur in bad weather.",
+              "Accidents can occur on icy roads.",
+              "Problems can occur with old machines.",
+              "The event will occur next week.",
+              "A sudden change can occur overnight.",
+              "Thunderstorms can occur in summer.",
+              "It may occur to you later.",
+              "Such errors occur quite often.",
+              "Flooding can occur after heavy rain."
+            ],
+            "accepted": [
+              "occur"
+            ],
+            "explanation": "To occur means to happen or take place.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 177
+          },
+          "opportunity": {
+            "year": "5-6",
+            "family": "opportunity",
+            "word": "opportunity",
+            "slug": "opportunity",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "opportunity"
+            ],
+            "sentence": "This trip is a great opportunity.",
+            "sentences": [
+              "This trip is a great opportunity.",
+              "Every child should get an opportunity to learn.",
+              "The trip gave us an opportunity to explore.",
+              "She took the opportunity to ask a question.",
+              "The club offers an opportunity to play chess.",
+              "We had an opportunity to visit the farm.",
+              "The job gave him an opportunity to help others.",
+              "This is a good opportunity to practise.",
+              "They used the opportunity to share ideas.",
+              "The lesson gave me an opportunity to read aloud."
+            ],
+            "accepted": [
+              "opportunity"
+            ],
+            "explanation": "An opportunity is a chance to do something.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 178
+          },
+          "parliament": {
+            "year": "5-6",
+            "family": "parliament",
+            "word": "parliament",
+            "slug": "parliament",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "parliament"
+            ],
+            "sentence": "Parliament debated the new law.",
+            "sentences": [
+              "Parliament debated the new law.",
+              "We learned how parliament makes laws.",
+              "A question was raised in parliament.",
+              "Members of parliament spoke clearly.",
+              "The guide pointed to the parliament building.",
+              "Parliament voted on the change.",
+              "A speech in parliament can affect the whole country.",
+              "The news showed parliament in session.",
+              "We learned how parliament works.",
+              "Parliament discussed school funding."
+            ],
+            "accepted": [
+              "parliament"
+            ],
+            "explanation": "Parliament is the group of elected people who make laws in the UK and some other countries.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 179
+          },
+          "persuade": {
+            "year": "5-6",
+            "family": "persuade",
+            "word": "persuade",
+            "slug": "persuade",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "persuade"
+            ],
+            "sentence": "Can you persuade him to join us.",
+            "sentences": [
+              "Can you persuade him to join us.",
+              "I tried to persuade my friend to join the game.",
+              "The poster helped persuade the class to recycle.",
+              "Mum could not persuade me to go to bed early.",
+              "We may need facts to persuade the council.",
+              "The coach tried to persuade everyone to keep going.",
+              "A calm voice can persuade people to listen.",
+              "She used a chart to persuade the group.",
+              "He will persuade his brother to share the seat.",
+              "The letter should persuade the reader to help."
+            ],
+            "accepted": [
+              "persuade"
+            ],
+            "explanation": "To persuade means to convince someone to do or believe something.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 180
+          },
+          "physical": {
+            "year": "5-6",
+            "family": "physical",
+            "word": "physical",
+            "slug": "physical",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "physical"
+            ],
+            "sentence": "Swimming gives you physical exercise.",
+            "sentences": [
+              "Swimming gives you physical exercise.",
+              "Swimming is a physical activity.",
+              "The nurse checked my physical health after the race.",
+              "We did a physical warm-up before football.",
+              "The box was too heavy for physical work alone.",
+              "She felt better after some physical exercise.",
+              "The storm caused physical damage to the fence.",
+              "Our lesson included a physical challenge.",
+              "He needed physical rest after the long walk.",
+              "A physical map can help on a hike."
+            ],
+            "accepted": [
+              "physical"
+            ],
+            "explanation": "Physical means connected with the body or with things you can touch.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 181
+          },
+          "prejudice": {
+            "year": "5-6",
+            "family": "prejudice",
+            "word": "prejudice",
+            "slug": "prejudice",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "prejudice"
+            ],
+            "sentence": "We should challenge prejudice when we see it.",
+            "sentences": [
+              "We should challenge prejudice when we see it.",
+              "We should challenge prejudice in the playground.",
+              "The story taught us about prejudice and fairness.",
+              "No one should face prejudice because of their background.",
+              "The class discussed prejudice during assembly.",
+              "She spoke up against prejudice at school.",
+              "Prejudice can stop people from working together.",
+              "The museum display explained prejudice in history.",
+              "We can learn to spot prejudice in jokes.",
+              "The lesson showed how prejudice hurts communities."
+            ],
+            "accepted": [
+              "prejudice"
+            ],
+            "explanation": "Prejudice is an unfair opinion about a person or group formed without enough knowledge.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 182
+          },
+          "privilege": {
+            "year": "5-6",
+            "family": "privilege",
+            "word": "privilege",
+            "slug": "privilege",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "privilege"
+            ],
+            "sentence": "It was a privilege to meet the author.",
+            "sentences": [
+              "It was a privilege to meet the author.",
+              "Using the science lab is a privilege, not a right.",
+              "She saw the trip as a real privilege.",
+              "It is a privilege to help younger children read.",
+              "He treated the award as a privilege.",
+              "The team felt it was a privilege to represent the school.",
+              "Library time is a privilege when the books are cared for.",
+              "Having that quiet room felt like a privilege.",
+              "For many people, clean water is still a privilege.",
+              "It was a privilege to be invited."
+            ],
+            "accepted": [
+              "privilege"
+            ],
+            "explanation": "A privilege is a special right or advantage.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 183
+          },
+          "profession": {
+            "year": "5-6",
+            "family": "profession",
+            "word": "profession",
+            "slug": "profession",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "profession"
+            ],
+            "sentence": "Teaching is a respected profession.",
+            "sentences": [
+              "Teaching is a respected profession.",
+              "Medicine is a profession that needs long training.",
+              "She hopes to choose a profession that helps others.",
+              "Every profession needs skill and practice.",
+              "The doctor spoke about her profession.",
+              "He wants a profession that lets him work outdoors.",
+              "A profession often needs years of study.",
+              "We learned that a profession can change over time.",
+              "The discussion was about which profession might suit each person.",
+              "The careers fair introduced us to each profession in turn."
+            ],
+            "accepted": [
+              "profession"
+            ],
+            "explanation": "A profession is a type of work that needs special training or skill.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 184
+          },
+          "programme": {
+            "year": "5-6",
+            "family": "programme",
+            "word": "programme",
+            "slug": "programme",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "programme"
+            ],
+            "sentence": "The school printed a programme for the play.",
+            "sentences": [
+              "The school printed a programme for the play.",
+              "The school printed a programme for the concert.",
+              "We read the programme before the play started.",
+              "The sports programme was on the hall wall.",
+              "She kept the programme as a souvenir.",
+              "The radio programme began after dinner.",
+              "Our class made a programme for parents.",
+              "He checked the programme to find his seat.",
+              "The holiday programme included a boat trip.",
+              "I liked the programme about wild animals."
+            ],
+            "accepted": [
+              "programme"
+            ],
+            "explanation": "A programme is a planned set of activities, or a television or radio show.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 185
+          },
+          "pronunciation": {
+            "year": "5-6",
+            "family": "pronunciation",
+            "word": "pronunciation",
+            "slug": "pronunciation",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "pronunciation"
+            ],
+            "sentence": "Her pronunciation was clear and careful.",
+            "sentences": [
+              "Her pronunciation was clear and careful.",
+              "Her pronunciation made the poem easy to follow.",
+              "We practised the pronunciation of each new word.",
+              "The teacher corrected my pronunciation kindly.",
+              "Good pronunciation helps others understand you.",
+              "He asked for help with the pronunciation of choir.",
+              "The app gave tips on pronunciation.",
+              "Our lesson focused on pronunciation and meaning.",
+              "She learned the pronunciation by listening carefully.",
+              "The pronunciation of that word is tricky."
+            ],
+            "accepted": [
+              "pronunciation"
+            ],
+            "explanation": "Pronunciation is the way a word is spoken.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 186
+          },
+          "queue": {
+            "year": "5-6",
+            "family": "queue",
+            "word": "queue",
+            "slug": "queue",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "queue"
+            ],
+            "sentence": "We had to queue outside the museum.",
+            "sentences": [
+              "We had to queue outside the museum.",
+              "Please join the queue behind the blue line.",
+              "The queue for ice cream stretched across the playground.",
+              "We waited in a long queue for the tickets.",
+              "He left the queue to fetch his coat.",
+              "The queue moved slowly towards the till.",
+              "Our class formed a neat queue before assembly.",
+              "She stood at the back of the queue.",
+              "The queue grew longer after lunch.",
+              "The family joined the queue for the ferry."
+            ],
+            "accepted": [
+              "queue"
+            ],
+            "explanation": "A queue is a line of people or things waiting for their turn.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 187
+          },
+          "recognise": {
+            "year": "5-6",
+            "family": "recognise",
+            "word": "recognise",
+            "slug": "recognise",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "recognise"
+            ],
+            "sentence": "I did not recognise him at first.",
+            "sentences": [
+              "I did not recognise him at first.",
+              "I did not recognise her at first.",
+              "The class could recognise the bird by its song.",
+              "You will recognise the sign from yesterday.",
+              "We might recognise the song on the radio.",
+              "He can recognise numbers very quickly.",
+              "I recognise that handwriting from the card.",
+              "The teacher helped us recognise the pattern.",
+              "Some people recognise faces better than others.",
+              "They will recognise the coach by his red coat."
+            ],
+            "accepted": [
+              "recognise",
+              "recognize"
+            ],
+            "explanation": "To recognise means to know someone or something because you have seen it before.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 188
+          },
+          "recommend": {
+            "year": "5-6",
+            "family": "recommend",
+            "word": "recommend",
+            "slug": "recommend",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "recommend"
+            ],
+            "sentence": "I recommend the chocolate cake.",
+            "sentences": [
+              "I recommend the chocolate cake.",
+              "I recommend the apple pie.",
+              "The nurse will recommend a quiet rest.",
+              "We recommend that you read the map first.",
+              "My teacher can recommend a good book.",
+              "They recommend wearing a coat in winter.",
+              "I recommend this game to my friends.",
+              "The guide will recommend the safest route.",
+              "Can you recommend a film for Friday?",
+              "She would recommend the soup to everyone."
+            ],
+            "accepted": [
+              "recommend"
+            ],
+            "explanation": "To recommend means to say that someone should choose or try something.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 189
+          },
+          "relevant": {
+            "year": "5-6",
+            "family": "relevant",
+            "word": "relevant",
+            "slug": "relevant",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "relevant"
+            ],
+            "sentence": "Please include only relevant facts.",
+            "sentences": [
+              "Please include only relevant facts.",
+              "Please keep only relevant notes.",
+              "The question was relevant to our lesson.",
+              "We found a relevant page in the book.",
+              "He gave relevant facts about the castle.",
+              "The teacher asked for relevant examples.",
+              "Your answer should stay relevant to the topic.",
+              "She highlighted the relevant part of the report.",
+              "The map was relevant to the trip.",
+              "We listened for relevant clues in the story."
+            ],
+            "accepted": [
+              "relevant"
+            ],
+            "explanation": "Relevant means connected to what is being discussed or needed.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 190
+          },
+          "restaurant": {
+            "year": "5-6",
+            "family": "restaurant",
+            "word": "restaurant",
+            "slug": "restaurant",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "restaurant"
+            ],
+            "sentence": "We ate dinner at a small restaurant.",
+            "sentences": [
+              "We ate dinner at a small restaurant.",
+              "We ate at a small restaurant by the sea.",
+              "The restaurant served soup and bread.",
+              "Our restaurant booking was for six o'clock.",
+              "She liked the restaurant because it was quiet.",
+              "The restaurant menu had a veggie option.",
+              "We met our cousins in the restaurant.",
+              "The restaurant opened early for breakfast.",
+              "I spilled juice in the restaurant and cleaned it up.",
+              "The restaurant had bright lights and soft music."
+            ],
+            "accepted": [
+              "restaurant"
+            ],
+            "explanation": "A restaurant is a place where people pay to sit and eat meals.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 191
+          },
+          "rhyme": {
+            "year": "5-6",
+            "family": "rhyme",
+            "word": "rhyme",
+            "slug": "rhyme",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "rhyme"
+            ],
+            "sentence": "These two words rhyme.",
+            "sentences": [
+              "These two words rhyme.",
+              "The poem had a simple rhyme.",
+              "These two words rhyme well.",
+              "We wrote a short rhyme about rain.",
+              "The rhyme made the song easy to remember.",
+              "Can you hear the rhyme in the last line?",
+              "She practised a rhyme for class.",
+              "The rhyme helped the younger children join in.",
+              "We made a silly rhyme in pairs.",
+              "That rhyme sounds cheerful."
+            ],
+            "accepted": [
+              "rhyme"
+            ],
+            "explanation": "A rhyme is a word or line that has the same ending sound as another.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 192
+          },
+          "rhythm": {
+            "year": "5-6",
+            "family": "rhythm",
+            "word": "rhythm",
+            "slug": "rhythm",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "rhythm"
+            ],
+            "sentence": "The drummer kept a steady rhythm.",
+            "sentences": [
+              "The drummer kept a steady rhythm.",
+              "The drum kept a steady rhythm.",
+              "I could feel the rhythm of the music.",
+              "The class clapped in rhythm.",
+              "She found the rhythm of the song.",
+              "A good rhythm helps dancers stay together.",
+              "The rhythm of the waves was calming.",
+              "He lost the rhythm and started again.",
+              "We practised the rhythm on our desks.",
+              "The runner found a strong rhythm."
+            ],
+            "accepted": [
+              "rhythm"
+            ],
+            "explanation": "Rhythm is a regular pattern of sounds, beats or movements.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 193
+          },
+          "sacrifice": {
+            "year": "5-6",
+            "family": "sacrifice",
+            "word": "sacrifice",
+            "slug": "sacrifice",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "sacrifice"
+            ],
+            "sentence": "The team had to sacrifice comfort to win.",
+            "sentences": [
+              "The team had to sacrifice comfort to win.",
+              "We had to sacrifice some free time to finish the model.",
+              "The team made a sacrifice for the final match.",
+              "She did not want to sacrifice her reading time.",
+              "Sometimes you sacrifice comfort for a bigger goal.",
+              "The story showed a brave sacrifice.",
+              "He would sacrifice his break to help a friend.",
+              "We may sacrifice one game to prepare better.",
+              "The charity event was a sacrifice of our Saturday.",
+              "They chose to sacrifice space for more books."
+            ],
+            "accepted": [
+              "sacrifice"
+            ],
+            "explanation": "A sacrifice is giving up something important for a reason or for someone else.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 194
+          },
+          "secretary": {
+            "year": "5-6",
+            "family": "secretary",
+            "word": "secretary",
+            "slug": "secretary",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "secretary"
+            ],
+            "sentence": "The secretary answered the phone.",
+            "sentences": [
+              "The secretary answered the phone.",
+              "The secretary answered the phone politely.",
+              "Our secretary wrote the meeting notes.",
+              "The secretary kept the records tidy.",
+              "We asked the secretary for the form.",
+              "The school secretary gave me a timetable.",
+              "The secretary checked the appointments list.",
+              "A busy secretary needs good organisation.",
+              "The secretary greeted visitors at the desk.",
+              "She became the club secretary this term."
+            ],
+            "accepted": [
+              "secretary"
+            ],
+            "explanation": "A secretary is a person who organises information, messages and office work.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 195
+          },
+          "shoulder": {
+            "year": "5-6",
+            "family": "shoulder",
+            "word": "shoulder",
+            "slug": "shoulder",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "shoulder"
+            ],
+            "sentence": "She carried the bag on one shoulder.",
+            "sentences": [
+              "She carried the bag on one shoulder.",
+              "The cold wind hit my shoulder.",
+              "He tapped her on the shoulder.",
+              "The jacket slipped off my shoulder.",
+              "He raised one shoulder in a shrug.",
+              "The rucksack rubbed against her shoulder.",
+              "I leaned my shoulder against the wall.",
+              "The nurse looked at his shoulder after the fall.",
+              "A heavy coat hung from my shoulder.",
+              "She rested the tray on her shoulder for a moment."
+            ],
+            "accepted": [
+              "shoulder"
+            ],
+            "explanation": "A shoulder is the part of the body where the arm joins the upper body.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 196
+          },
+          "signature": {
+            "year": "5-6",
+            "family": "signature",
+            "word": "signature",
+            "slug": "signature",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "signature"
+            ],
+            "sentence": "Please add your signature at the bottom.",
+            "sentences": [
+              "Please add your signature at the bottom.",
+              "Her signature was neat and small.",
+              "The card needed a signature from a parent.",
+              "He practised his signature on scrap paper.",
+              "The signature proved the letter was real.",
+              "We checked the signature on the form.",
+              "The author wrote a signature in the book.",
+              "The signature matched the one on file.",
+              "She placed her signature beside the date.",
+              "The bank asked for my signature on the form."
+            ],
+            "accepted": [
+              "signature"
+            ],
+            "explanation": "A signature is your name written in your own way to show agreement or identity.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 197
+          },
+          "sincere": {
+            "year": "5-6",
+            "family": "sincere(ly)",
+            "word": "sincere",
+            "slug": "sincere",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "sincere",
+              "sincerely"
+            ],
+            "sentence": "His apology sounded sincere.",
+            "sentences": [
+              "His apology sounded sincere.",
+              "She gave a sincere smile.",
+              "We were sincere in our thanks.",
+              "That was a sincere effort.",
+              "He made a sincere promise.",
+              "The card had a sincere message.",
+              "I felt sincere concern for my friend.",
+              "Her answer was sincere and thoughtful.",
+              "They offered sincere help after the game.",
+              "The teacher praised his sincere work."
+            ],
+            "accepted": [
+              "sincere"
+            ],
+            "explanation": "Sincere means honest and truly meant.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 198
+          },
+          "sincerely": {
+            "year": "5-6",
+            "family": "sincere(ly)",
+            "word": "sincerely",
+            "slug": "sincerely",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "sincere",
+              "sincerely"
+            ],
+            "sentence": "I sincerely hope you recover soon.",
+            "sentences": [
+              "I sincerely hope you recover soon.",
+              "I sincerely thank you for your help.",
+              "She sincerely hopes to pass the test.",
+              "We sincerely want the garden to grow.",
+              "He sincerely meant every word he said.",
+              "I sincerely agree with your idea.",
+              "They sincerely wished her well.",
+              "She sincerely tried to make it right.",
+              "We sincerely hope for sunshine tomorrow.",
+              "He sincerely listened to the advice."
+            ],
+            "accepted": [
+              "sincerely"
+            ],
+            "explanation": "Sincerely means honestly and truly.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 199
+          },
+          "soldier": {
+            "year": "5-6",
+            "family": "soldier",
+            "word": "soldier",
+            "slug": "soldier",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "soldier"
+            ],
+            "sentence": "The soldier stood very still.",
+            "sentences": [
+              "The soldier stood very still.",
+              "The soldier stood by the gate.",
+              "We read about a soldier in history.",
+              "The soldier marched across the field.",
+              "The soldier carried a heavy pack.",
+              "She drew a soldier in her sketchbook.",
+              "The soldier helped the villagers after the storm.",
+              "A brave soldier saved the day.",
+              "The soldier saluted the flag.",
+              "The story followed one soldier on patrol."
+            ],
+            "accepted": [
+              "soldier"
+            ],
+            "explanation": "A soldier is a person who serves in an army.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 200
+          },
+          "stomach": {
+            "year": "5-6",
+            "family": "stomach",
+            "word": "stomach",
+            "slug": "stomach",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "stomach"
+            ],
+            "sentence": "My stomach rumbled before lunch.",
+            "sentences": [
+              "My stomach rumbled before lunch.",
+              "I had a sore stomach after too much cake.",
+              "The roller coaster gave me a nervous stomach.",
+              "She held her stomach and laughed.",
+              "His stomach felt better after rest.",
+              "A warm drink settled my stomach.",
+              "The doctor asked about my stomach pain.",
+              "He felt a flutter in his stomach before the show.",
+              "Too many sweets upset her stomach.",
+              "I used slow breathing to calm my stomach."
+            ],
+            "accepted": [
+              "stomach"
+            ],
+            "explanation": "The stomach is the part inside your body where food begins to be digested.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 201
+          },
+          "sufficient": {
+            "year": "5-6",
+            "family": "sufficient",
+            "word": "sufficient",
+            "slug": "sufficient",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "sufficient"
+            ],
+            "sentence": "We had sufficient time to finish.",
+            "sentences": [
+              "We had sufficient time to finish.",
+              "There was sufficient water for the hike.",
+              "The answer was not sufficient.",
+              "The supplies were sufficient for the class.",
+              "We need sufficient light to read.",
+              "Her proof was sufficient to show the truth.",
+              "The coat was sufficient for the cool day.",
+              "He had sufficient reason to ask again.",
+              "Our budget was sufficient for the trip.",
+              "That explanation was sufficient for me."
+            ],
+            "accepted": [
+              "sufficient"
+            ],
+            "explanation": "Sufficient means enough for what is needed.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 202
+          },
+          "suggest": {
+            "year": "5-6",
+            "family": "suggest",
+            "word": "suggest",
+            "slug": "suggest",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "suggest"
+            ],
+            "sentence": "I suggest we leave now.",
+            "sentences": [
+              "I suggest we leave now.",
+              "I suggest a shorter route.",
+              "The teacher did not suggest an easy answer.",
+              "We suggest a picnic by the lake.",
+              "Can you suggest a book for me?",
+              "The map may suggest a safer path.",
+              "I suggest we start now.",
+              "She would suggest a game after lunch.",
+              "The clue may suggest the bird is nearby.",
+              "They suggest keeping the door open."
+            ],
+            "accepted": [
+              "suggest"
+            ],
+            "explanation": "To suggest means to put forward an idea or plan.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 203
+          },
+          "symbol": {
+            "year": "5-6",
+            "family": "symbol",
+            "word": "symbol",
+            "slug": "symbol",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "symbol"
+            ],
+            "sentence": "The crown is a symbol of power.",
+            "sentences": [
+              "The crown is a symbol of power.",
+              "The heart is a symbol of love.",
+              "We learned what each symbol meant.",
+              "The crown was a symbol on the badge.",
+              "A dove can be a symbol of peace.",
+              "The sign uses a simple symbol.",
+              "The flag became a symbol for the town.",
+              "He drew a star symbol on the card.",
+              "The symbol helped us read the chart.",
+              "The key symbol was easy to spot."
+            ],
+            "accepted": [
+              "symbol"
+            ],
+            "explanation": "A symbol is a sign, shape or object that stands for an idea or meaning.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 204
+          },
+          "system": {
+            "year": "5-6",
+            "family": "system",
+            "word": "system",
+            "slug": "system",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "system"
+            ],
+            "sentence": "The school has a new computer system.",
+            "sentences": [
+              "The school has a new computer system.",
+              "Our heating system keeps the hall warm.",
+              "The system for borrowing books is quick.",
+              "The team changed the system for lining up.",
+              "A fair system helps everyone.",
+              "The body uses a system to keep us alive.",
+              "We checked the ticket system at the station.",
+              "The river system runs through the valley.",
+              "The warning system rang loudly.",
+              "The recycling system is simple to follow."
+            ],
+            "accepted": [
+              "system"
+            ],
+            "explanation": "A system is a set of connected parts that work together.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 205
+          },
+          "temperature": {
+            "year": "5-6",
+            "family": "temperature",
+            "word": "temperature",
+            "slug": "temperature",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "temperature"
+            ],
+            "sentence": "The temperature dropped after sunset.",
+            "sentences": [
+              "The temperature dropped after sunset.",
+              "We checked the temperature of the soup.",
+              "The temperature in the room felt cool.",
+              "A high temperature can make you tired.",
+              "The temperature rose during the afternoon.",
+              "The weather report gave the temperature for today.",
+              "I set the oven temperature carefully.",
+              "The temperature of the water was perfect.",
+              "We measured the temperature outside.",
+              "A steady temperature helped the seedlings grow."
+            ],
+            "accepted": [
+              "temperature"
+            ],
+            "explanation": "Temperature tells how hot or cold something is.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 206
+          },
+          "thorough": {
+            "year": "5-6",
+            "family": "thorough",
+            "word": "thorough",
+            "slug": "thorough",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "thorough"
+            ],
+            "sentence": "The teacher gave the homework a thorough check.",
+            "sentences": [
+              "The teacher gave the homework a thorough check.",
+              "We made a thorough list before the trip.",
+              "She carried out a thorough search of her school bag.",
+              "The vet gave the puppy a thorough examination.",
+              "A thorough plan helped the day run smoothly.",
+              "He wrote a thorough answer with every step shown.",
+              "The coach asked for a thorough warm-up before the match.",
+              "Dad did a thorough clean of the car.",
+              "The police made a thorough search of the park.",
+              "Our group made a thorough study of the map."
+            ],
+            "accepted": [
+              "thorough"
+            ],
+            "explanation": "Thorough means complete and careful, with nothing important missed.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 207
+          },
+          "twelfth": {
+            "year": "5-6",
+            "family": "twelfth",
+            "word": "twelfth",
+            "slug": "twelfth",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "twelfth"
+            ],
+            "sentence": "His birthday is on the twelfth of June.",
+            "sentences": [
+              "His birthday is on the twelfth of June.",
+              "She finished twelfth in the race.",
+              "We met on the twelfth day of term.",
+              "The twelfth page had the answer.",
+              "He was the twelfth player to arrive.",
+              "The twelfth seat was by the window.",
+              "I wrote the twelfth word on the line.",
+              "The twelfth bell rang at noon.",
+              "Our class is on the twelfth floor.",
+              "The twelfth clue solved the puzzle."
+            ],
+            "accepted": [
+              "twelfth"
+            ],
+            "explanation": "Twelfth means number twelve in order.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 208
+          },
+          "variety": {
+            "year": "5-6",
+            "family": "variety",
+            "word": "variety",
+            "slug": "variety",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "variety"
+            ],
+            "sentence": "The market sells a variety of fruit.",
+            "sentences": [
+              "The market sells a variety of fruit.",
+              "We found a variety of shells on the beach.",
+              "The class made a variety of posters.",
+              "A variety of books sat on the shelf.",
+              "The garden had a variety of flowers.",
+              "She chose a variety of snacks for the trip.",
+              "Our menu offers a variety of meals.",
+              "The museum showed a variety of old tools.",
+              "The choir sang a variety of songs.",
+              "He picked a variety of coloured pens."
+            ],
+            "accepted": [
+              "variety"
+            ],
+            "explanation": "Variety means a number of different kinds or a mixture.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 209
+          },
+          "vegetable": {
+            "year": "5-6",
+            "family": "vegetable",
+            "word": "vegetable",
+            "slug": "vegetable",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "vegetable"
+            ],
+            "sentence": "Carrot is my favourite vegetable.",
+            "sentences": [
+              "Carrot is my favourite vegetable.",
+              "We chopped the vegetable for soup.",
+              "The vegetable patch needs water.",
+              "She packed a vegetable in her lunch box.",
+              "A fresh vegetable tasted sweet.",
+              "The shop sold every vegetable we needed.",
+              "He did not like one vegetable at first.",
+              "We grew each vegetable from seed.",
+              "The stew had one vegetable after another.",
+              "My plate included a green vegetable."
+            ],
+            "accepted": [
+              "vegetable"
+            ],
+            "explanation": "A vegetable is a plant or part of a plant eaten as food, such as a carrot.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 210
+          },
+          "vehicle": {
+            "year": "5-6",
+            "family": "vehicle",
+            "word": "vehicle",
+            "slug": "vehicle",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "vehicle"
+            ],
+            "sentence": "The fire engine is a large vehicle.",
+            "sentences": [
+              "The fire engine is a large vehicle.",
+              "We saw a delivery vehicle at the depot.",
+              "The vehicle stopped at the lights.",
+              "Our vehicle took us to the museum.",
+              "The police vehicle flashed its lights.",
+              "A small vehicle can fit on the drive.",
+              "The vehicle rolled slowly down the hill.",
+              "The farmer fixed the vehicle in the shed.",
+              "The vehicle was painted bright yellow.",
+              "They cleaned the vehicle before the trip."
+            ],
+            "accepted": [
+              "vehicle"
+            ],
+            "explanation": "A vehicle is something used to carry people or goods, such as a car, bus or lorry.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 211
+          },
+          "yacht": {
+            "year": "5-6",
+            "family": "yacht",
+            "word": "yacht",
+            "slug": "yacht",
+            "spellingPool": "core",
+            "yearLabel": "Years 5-6",
+            "familyWords": [
+              "yacht"
+            ],
+            "sentence": "We saw a white yacht on the sea.",
+            "sentences": [
+              "We saw a white yacht on the sea.",
+              "The yacht glided across the water.",
+              "A long yacht was moored in the harbour.",
+              "They waved from the yacht.",
+              "The yacht had bright blue sails.",
+              "We counted the windows on the yacht.",
+              "The yacht trip was calm and quiet.",
+              "A small yacht moved near the shore.",
+              "He drew a yacht in his sketchbook.",
+              "The yacht waited by the pier."
+            ],
+            "accepted": [
+              "yacht"
+            ],
+            "explanation": "A yacht is a boat used for sailing or pleasure trips.",
+            "listId": "statutory-y5-6",
+            "yearGroups": [
+              "Y5",
+              "Y6"
+            ],
+            "tags": [
+              "statutory",
+              "legacy-seed"
+            ],
+            "sourceNote": "Seeded from preserved legacy spelling word list.",
+            "provenance": {
+              "source": "legacy/vendor/word-list.js",
+              "note": "Legacy vendor seed for Pass 11 content model.",
+              "importedAt": 0
+            },
+            "sortIndex": 212
+          },
+          "divide": {
+            "year": "extra",
+            "family": "Word-building verbs",
+            "word": "divide",
+            "slug": "divide",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "divide",
+              "division",
+              "divisible"
+            ],
+            "sentence": "We divide the class into teams before the investigation.",
+            "sentences": [
+              "We divide the class into teams before the investigation."
+            ],
+            "accepted": [
+              "divide"
+            ],
+            "variants": [
+              {
+                "word": "division",
+                "sentence": "The division of the class into teams was fair.",
+                "sentences": [
+                  "The division of the class into teams was fair."
+                ],
+                "accepted": [
+                  "division"
+                ],
+                "explanation": "Division is the act of splitting something into parts or groups.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the divide base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              },
+              {
+                "word": "divisible",
+                "sentence": "Twenty is divisible by five.",
+                "sentences": [
+                  "Twenty is divisible by five."
+                ],
+                "accepted": [
+                  "divisible"
+                ],
+                "explanation": "Divisible means able to be divided exactly by a number.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the divide base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 2
+              }
+            ],
+            "explanation": "To divide is to split something into parts or groups.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "word",
+              "building",
+              "verbs"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 213
+          },
+          "collide": {
+            "year": "extra",
+            "family": "Word-building verbs",
+            "word": "collide",
+            "slug": "collide",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "collide",
+              "collision"
+            ],
+            "sentence": "The two balls collide in the middle of the table.",
+            "sentences": [
+              "The two balls collide in the middle of the table."
+            ],
+            "accepted": [
+              "collide"
+            ],
+            "variants": [
+              {
+                "word": "collision",
+                "sentence": "The collision made both balls change direction.",
+                "sentences": [
+                  "The collision made both balls change direction."
+                ],
+                "accepted": [
+                  "collision"
+                ],
+                "explanation": "A collision is a crash or strong hit between moving things.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the collide base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              }
+            ],
+            "explanation": "To collide is to crash into something or hit it while moving.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "word",
+              "building",
+              "verbs"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 214
+          },
+          "explode": {
+            "year": "extra",
+            "family": "Word-building verbs",
+            "word": "explode",
+            "slug": "explode",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "explode",
+              "explosion",
+              "explosive"
+            ],
+            "sentence": "The volcano model did not explode until the final step.",
+            "sentences": [
+              "The volcano model did not explode until the final step."
+            ],
+            "accepted": [
+              "explode"
+            ],
+            "variants": [
+              {
+                "word": "explosion",
+                "sentence": "The experiment caused a safe foam explosion.",
+                "sentences": [
+                  "The experiment caused a safe foam explosion."
+                ],
+                "accepted": [
+                  "explosion"
+                ],
+                "explanation": "An explosion is a sudden burst with force, noise or energy.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the explode base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              },
+              {
+                "word": "explosive",
+                "sentence": "The explosive reaction was controlled by the teacher.",
+                "sentences": [
+                  "The explosive reaction was controlled by the teacher."
+                ],
+                "accepted": [
+                  "explosive"
+                ],
+                "explanation": "Explosive means able to burst apart suddenly with force.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the explode base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 2
+              }
+            ],
+            "explanation": "To explode is to burst apart suddenly with force.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "word",
+              "building",
+              "verbs"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 215
+          },
+          "corrode": {
+            "year": "extra",
+            "family": "Word-building verbs",
+            "word": "corrode",
+            "slug": "corrode",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "corrode",
+              "corrosion",
+              "corrosive"
+            ],
+            "sentence": "Salt water can corrode metal over time.",
+            "sentences": [
+              "Salt water can corrode metal over time."
+            ],
+            "accepted": [
+              "corrode"
+            ],
+            "variants": [
+              {
+                "word": "corrosion",
+                "sentence": "Corrosion weakened the old metal gate.",
+                "sentences": [
+                  "Corrosion weakened the old metal gate."
+                ],
+                "accepted": [
+                  "corrosion"
+                ],
+                "explanation": "Corrosion is the slow damage caused by a chemical reaction, often rust.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the corrode base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              },
+              {
+                "word": "corrosive",
+                "sentence": "The corrosive liquid was handled with care.",
+                "sentences": [
+                  "The corrosive liquid was handled with care."
+                ],
+                "accepted": [
+                  "corrosive"
+                ],
+                "explanation": "Corrosive means able to slowly damage a material by chemical action.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the corrode base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 2
+              }
+            ],
+            "explanation": "To corrode is to be slowly damaged by a chemical reaction, often rust.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "word",
+              "building",
+              "verbs"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 216
+          },
+          "conclude": {
+            "year": "extra",
+            "family": "Word-building verbs",
+            "word": "conclude",
+            "slug": "conclude",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "conclude",
+              "conclusion"
+            ],
+            "sentence": "We conclude that shade slows the melting ice.",
+            "sentences": [
+              "We conclude that shade slows the melting ice."
+            ],
+            "accepted": [
+              "conclude"
+            ],
+            "variants": [
+              {
+                "word": "conclusion",
+                "sentence": "Her conclusion matched the evidence from the test.",
+                "sentences": [
+                  "Her conclusion matched the evidence from the test."
+                ],
+                "accepted": [
+                  "conclusion"
+                ],
+                "explanation": "A conclusion is the final decision or ending reached after thinking.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the conclude base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              }
+            ],
+            "explanation": "To conclude is to finish, or to decide after thinking about evidence.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "word",
+              "building",
+              "verbs"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 217
+          },
+          "extend": {
+            "year": "extra",
+            "family": "Word-building verbs",
+            "word": "extend",
+            "slug": "extend",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "extend",
+              "extension",
+              "extended"
+            ],
+            "sentence": "The bridge can extend across the stream.",
+            "sentences": [
+              "The bridge can extend across the stream."
+            ],
+            "accepted": [
+              "extend"
+            ],
+            "variants": [
+              {
+                "word": "extension",
+                "sentence": "The bridge extension reached the other bank.",
+                "sentences": [
+                  "The bridge extension reached the other bank."
+                ],
+                "accepted": [
+                  "extension"
+                ],
+                "explanation": "An extension is an added part or an increase in length or time.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the extend base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              },
+              {
+                "word": "extended",
+                "sentence": "The extended table gave everyone space.",
+                "sentences": [
+                  "The extended table gave everyone space."
+                ],
+                "accepted": [
+                  "extended"
+                ],
+                "explanation": "Extended means made longer or lasting for more time.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the extend base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 2
+              }
+            ],
+            "explanation": "To extend is to make something longer or reach further.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "word",
+              "building",
+              "verbs"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 218
+          },
+          "comprehend": {
+            "year": "extra",
+            "family": "Word-building verbs",
+            "word": "comprehend",
+            "slug": "comprehend",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "comprehend",
+              "comprehension"
+            ],
+            "sentence": "She could comprehend the instructions after reading them twice.",
+            "sentences": [
+              "She could comprehend the instructions after reading them twice."
+            ],
+            "accepted": [
+              "comprehend"
+            ],
+            "variants": [
+              {
+                "word": "comprehension",
+                "sentence": "Good comprehension helped her answer the questions.",
+                "sentences": [
+                  "Good comprehension helped her answer the questions."
+                ],
+                "accepted": [
+                  "comprehension"
+                ],
+                "explanation": "Comprehension is the ability to understand something.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the comprehend base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              }
+            ],
+            "explanation": "To comprehend is to understand something fully.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "word",
+              "building",
+              "verbs"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 219
+          },
+          "evade": {
+            "year": "extra",
+            "family": "Word-building verbs",
+            "word": "evade",
+            "slug": "evade",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "evade",
+              "evasion",
+              "evasive"
+            ],
+            "sentence": "The beetle tried to evade the torchlight under a leaf.",
+            "sentences": [
+              "The beetle tried to evade the torchlight under a leaf."
+            ],
+            "accepted": [
+              "evade"
+            ],
+            "variants": [
+              {
+                "word": "evasion",
+                "sentence": "The quick evasion helped the player dodge the tackle.",
+                "sentences": [
+                  "The quick evasion helped the player dodge the tackle."
+                ],
+                "accepted": [
+                  "evasion"
+                ],
+                "explanation": "Evasion is the act of avoiding or escaping something.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the evade base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              },
+              {
+                "word": "evasive",
+                "sentence": "His evasive answer did not explain the mistake.",
+                "sentences": [
+                  "His evasive answer did not explain the mistake."
+                ],
+                "accepted": [
+                  "evasive"
+                ],
+                "explanation": "Evasive means trying to avoid something or not answer directly.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the evade base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 2
+              }
+            ],
+            "explanation": "To evade is to avoid or escape from someone or something.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "word",
+              "building",
+              "verbs"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 220
+          },
+          "intrude": {
+            "year": "extra",
+            "family": "Word-building verbs",
+            "word": "intrude",
+            "slug": "intrude",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "intrude",
+              "intrusion",
+              "intrusive"
+            ],
+            "sentence": "Please do not intrude while the group is recording.",
+            "sentences": [
+              "Please do not intrude while the group is recording."
+            ],
+            "accepted": [
+              "intrude"
+            ],
+            "variants": [
+              {
+                "word": "intrusion",
+                "sentence": "The loud noise was an intrusion during the recording.",
+                "sentences": [
+                  "The loud noise was an intrusion during the recording."
+                ],
+                "accepted": [
+                  "intrusion"
+                ],
+                "explanation": "An intrusion is an unwanted entry or interruption.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the intrude base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              },
+              {
+                "word": "intrusive",
+                "sentence": "The intrusive sound disturbed the quiet lesson.",
+                "sentences": [
+                  "The intrusive sound disturbed the quiet lesson."
+                ],
+                "accepted": [
+                  "intrusive"
+                ],
+                "explanation": "Intrusive means entering or interrupting where it is not wanted.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the intrude base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 2
+              }
+            ],
+            "explanation": "To intrude is to enter or join in where you are not wanted.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "word",
+              "building",
+              "verbs"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 221
+          },
+          "interlude": {
+            "year": "extra",
+            "family": "Word-building verbs",
+            "word": "interlude",
+            "slug": "interlude",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "interlude",
+              "interludes"
+            ],
+            "sentence": "A quiet interlude gave the performers time to reset.",
+            "sentences": [
+              "A quiet interlude gave the performers time to reset."
+            ],
+            "accepted": [
+              "interlude"
+            ],
+            "variants": [
+              {
+                "word": "interludes",
+                "sentence": "The play had two short interludes.",
+                "sentences": [
+                  "The play had two short interludes."
+                ],
+                "accepted": [
+                  "interludes"
+                ],
+                "explanation": "Interludes are short pauses or breaks between parts of something.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the interlude base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              }
+            ],
+            "explanation": "An interlude is a short pause or break between parts of something.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "word",
+              "building",
+              "verbs"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 222
+          },
+          "classification": {
+            "year": "extra",
+            "family": "Science: classification",
+            "word": "classification",
+            "slug": "classification",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "classification",
+              "classify",
+              "classified"
+            ],
+            "sentence": "Classification helps scientists compare animals with similar features.",
+            "sentences": [
+              "Classification helps scientists compare animals with similar features."
+            ],
+            "accepted": [
+              "classification"
+            ],
+            "variants": [
+              {
+                "word": "classify",
+                "sentence": "Scientists classify living things by their features.",
+                "sentences": [
+                  "Scientists classify living things by their features."
+                ],
+                "accepted": [
+                  "classify"
+                ],
+                "explanation": "To classify is to sort things into groups by shared features.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the classification base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              },
+              {
+                "word": "classified",
+                "sentence": "The leaves were classified by shape and size.",
+                "sentences": [
+                  "The leaves were classified by shape and size."
+                ],
+                "accepted": [
+                  "classified"
+                ],
+                "explanation": "Classified means sorted into groups by type or feature.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the classification base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 2
+              }
+            ],
+            "explanation": "Classification is sorting living things or objects into groups by shared features.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "science",
+              "classification"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 223
+          },
+          "backbone": {
+            "year": "extra",
+            "family": "Science: body structure",
+            "word": "backbone",
+            "slug": "backbone",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "backbone",
+              "backbones"
+            ],
+            "sentence": "A fish has a backbone inside its body.",
+            "sentences": [
+              "A fish has a backbone inside its body."
+            ],
+            "accepted": [
+              "backbone"
+            ],
+            "variants": [
+              {
+                "word": "backbones",
+                "sentence": "The model showed how backbones protect the spinal cord.",
+                "sentences": [
+                  "The model showed how backbones protect the spinal cord."
+                ],
+                "accepted": [
+                  "backbones"
+                ],
+                "explanation": "Backbones are rows of bones that support the backs of some animals.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the backbone base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              }
+            ],
+            "explanation": "A backbone is the row of bones that supports the back.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "science",
+              "body",
+              "structure"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 224
+          },
+          "skeleton": {
+            "year": "extra",
+            "family": "Science: body structure",
+            "word": "skeleton",
+            "slug": "skeleton",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "skeleton",
+              "skeletal"
+            ],
+            "sentence": "The skeleton protects important organs.",
+            "sentences": [
+              "The skeleton protects important organs."
+            ],
+            "accepted": [
+              "skeleton"
+            ],
+            "variants": [
+              {
+                "word": "skeletal",
+                "sentence": "The diagram showed the skeletal system clearly.",
+                "sentences": [
+                  "The diagram showed the skeletal system clearly."
+                ],
+                "accepted": [
+                  "skeletal"
+                ],
+                "explanation": "Skeletal means connected with the skeleton or bones.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the skeleton base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              }
+            ],
+            "explanation": "A skeleton is the frame of bones that supports a body.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "science",
+              "body",
+              "structure"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 225
+          },
+          "cold-blooded": {
+            "year": "extra",
+            "family": "Science: animal groups",
+            "word": "cold-blooded",
+            "slug": "cold-blooded",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "cold-blooded"
+            ],
+            "sentence": "A cold-blooded reptile warms itself on a rock.",
+            "sentences": [
+              "A cold-blooded reptile warms itself on a rock."
+            ],
+            "accepted": [
+              "cold-blooded",
+              "cold blooded"
+            ],
+            "explanation": "Cold-blooded animals depend on their surroundings to control body temperature.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "science",
+              "animal",
+              "groups"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 226
+          },
+          "amphibians": {
+            "year": "extra",
+            "family": "Science: animal groups",
+            "word": "amphibians",
+            "slug": "amphibians",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "amphibians",
+              "amphibian"
+            ],
+            "sentence": "Many amphibians begin life in water as tadpoles.",
+            "sentences": [
+              "Many amphibians begin life in water as tadpoles."
+            ],
+            "accepted": [
+              "amphibians"
+            ],
+            "variants": [
+              {
+                "word": "amphibian",
+                "sentence": "A frog is an amphibian with moist skin.",
+                "sentences": [
+                  "A frog is an amphibian with moist skin."
+                ],
+                "accepted": [
+                  "amphibian"
+                ],
+                "explanation": "An amphibian is an animal that can live in water and on land.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the amphibians base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              }
+            ],
+            "explanation": "Amphibians are animals such as frogs that can live in water and on land.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "science",
+              "animal",
+              "groups"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 227
+          },
+          "metamorphosis": {
+            "year": "extra",
+            "family": "Science: life cycles",
+            "word": "metamorphosis",
+            "slug": "metamorphosis",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "metamorphosis",
+              "metamorphose"
+            ],
+            "sentence": "A butterfly goes through metamorphosis before it can fly.",
+            "sentences": [
+              "A butterfly goes through metamorphosis before it can fly."
+            ],
+            "accepted": [
+              "metamorphosis"
+            ],
+            "variants": [
+              {
+                "word": "metamorphose",
+                "sentence": "Some insects metamorphose before they can fly.",
+                "sentences": [
+                  "Some insects metamorphose before they can fly."
+                ],
+                "accepted": [
+                  "metamorphose"
+                ],
+                "explanation": "To metamorphose is to change into a very different adult form.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the metamorphosis base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              }
+            ],
+            "explanation": "Metamorphosis is a major change in body form as an animal grows.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "science",
+              "life",
+              "cycles"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 228
+          },
+          "reptiles": {
+            "year": "extra",
+            "family": "Science: animal groups",
+            "word": "reptiles",
+            "slug": "reptiles",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "reptiles",
+              "reptile"
+            ],
+            "sentence": "Reptiles often lay eggs on land.",
+            "sentences": [
+              "Reptiles often lay eggs on land."
+            ],
+            "accepted": [
+              "reptiles"
+            ],
+            "variants": [
+              {
+                "word": "reptile",
+                "sentence": "A lizard is a reptile that warms itself in sunlight.",
+                "sentences": [
+                  "A lizard is a reptile that warms itself in sunlight."
+                ],
+                "accepted": [
+                  "reptile"
+                ],
+                "explanation": "A reptile is a cold-blooded animal with dry scales.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the reptiles base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              }
+            ],
+            "explanation": "Reptiles are cold-blooded animals with dry scales, such as lizards and snakes.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "science",
+              "animal",
+              "groups"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 229
+          },
+          "mammals": {
+            "year": "extra",
+            "family": "Science: animal groups",
+            "word": "mammals",
+            "slug": "mammals",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "mammals",
+              "mammal"
+            ],
+            "sentence": "Dolphins and bats are both mammals.",
+            "sentences": [
+              "Dolphins and bats are both mammals."
+            ],
+            "accepted": [
+              "mammals"
+            ],
+            "variants": [
+              {
+                "word": "mammal",
+                "sentence": "A whale is a mammal even though it lives in the sea.",
+                "sentences": [
+                  "A whale is a mammal even though it lives in the sea."
+                ],
+                "accepted": [
+                  "mammal"
+                ],
+                "explanation": "A mammal is a warm-blooded animal that usually feeds its young milk.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the mammals base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              }
+            ],
+            "explanation": "Mammals are warm-blooded animals that usually have hair or fur and feed their young milk.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "science",
+              "animal",
+              "groups"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 230
+          },
+          "arachnid": {
+            "year": "extra",
+            "family": "Science: animal groups",
+            "word": "arachnid",
+            "slug": "arachnid",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "arachnid",
+              "arachnids"
+            ],
+            "sentence": "A spider is an arachnid, not an insect.",
+            "sentences": [
+              "A spider is an arachnid, not an insect."
+            ],
+            "accepted": [
+              "arachnid"
+            ],
+            "variants": [
+              {
+                "word": "arachnids",
+                "sentence": "Spiders and scorpions are arachnids.",
+                "sentences": [
+                  "Spiders and scorpions are arachnids."
+                ],
+                "accepted": [
+                  "arachnids"
+                ],
+                "explanation": "Arachnids are animals with eight legs, such as spiders and scorpions.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the arachnid base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              }
+            ],
+            "explanation": "An arachnid is an animal with eight legs, such as a spider or scorpion.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "science",
+              "animal",
+              "groups"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 231
+          },
+          "mollusc": {
+            "year": "extra",
+            "family": "Science: animal groups",
+            "word": "mollusc",
+            "slug": "mollusc",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "mollusc",
+              "molluscs"
+            ],
+            "sentence": "A snail is a mollusc with a coiled shell.",
+            "sentences": [
+              "A snail is a mollusc with a coiled shell."
+            ],
+            "accepted": [
+              "mollusc"
+            ],
+            "variants": [
+              {
+                "word": "molluscs",
+                "sentence": "Snails and clams are molluscs.",
+                "sentences": [
+                  "Snails and clams are molluscs."
+                ],
+                "accepted": [
+                  "molluscs"
+                ],
+                "explanation": "Molluscs are soft-bodied animals, often with shells.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the mollusc base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              }
+            ],
+            "explanation": "A mollusc is a soft-bodied animal, often with a shell.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "science",
+              "animal",
+              "groups"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 232
+          },
+          "botanist": {
+            "year": "extra",
+            "family": "Science: plants",
+            "word": "botanist",
+            "slug": "botanist",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "botanist",
+              "botany",
+              "botanical"
+            ],
+            "sentence": "The botanist examined the leaves carefully.",
+            "sentences": [
+              "The botanist examined the leaves carefully."
+            ],
+            "accepted": [
+              "botanist"
+            ],
+            "variants": [
+              {
+                "word": "botany",
+                "sentence": "Botany helped the class understand plant growth.",
+                "sentences": [
+                  "Botany helped the class understand plant growth."
+                ],
+                "accepted": [
+                  "botany"
+                ],
+                "explanation": "Botany is the scientific study of plants.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the botanist base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              },
+              {
+                "word": "botanical",
+                "sentence": "The botanical garden displayed unusual flowers.",
+                "sentences": [
+                  "The botanical garden displayed unusual flowers."
+                ],
+                "accepted": [
+                  "botanical"
+                ],
+                "explanation": "Botanical means connected with plants or the study of plants.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the botanist base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 2
+              }
+            ],
+            "explanation": "A botanist is a scientist who studies plants.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "science",
+              "plants"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 233
+          },
+          "flowering": {
+            "year": "extra",
+            "family": "Science: plants",
+            "word": "flowering",
+            "slug": "flowering",
+            "spellingPool": "extra",
+            "yearLabel": "Extra",
+            "familyWords": [
+              "flowering",
+              "flowered",
+              "flowers"
+            ],
+            "sentence": "The flowering plant attracted several bees.",
+            "sentences": [
+              "The flowering plant attracted several bees."
+            ],
+            "accepted": [
+              "flowering"
+            ],
+            "variants": [
+              {
+                "word": "flowered",
+                "sentence": "The plant flowered after several warm days.",
+                "sentences": [
+                  "The plant flowered after several warm days."
+                ],
+                "accepted": [
+                  "flowered"
+                ],
+                "explanation": "Flowered means produced flowers or decorated with flowers.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the flowering base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 1
+              },
+              {
+                "word": "flowers",
+                "sentence": "The flowers attracted several bees.",
+                "sentences": [
+                  "The flowers attracted several bees."
+                ],
+                "accepted": [
+                  "flowers"
+                ],
+                "explanation": "Flowers are the parts of plants that often make seeds.",
+                "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+                "provenance": {
+                  "source": "James Extra spelling family extension",
+                  "note": "Variant prompt for the flowering base word family.",
+                  "importedAt": 1776902400000
+                },
+                "sortIndex": 2
+              }
+            ],
+            "explanation": "Flowering means producing flowers.",
+            "listId": "extra-science-word-building",
+            "yearGroups": [],
+            "tags": [
+              "extra",
+              "science",
+              "plants"
+            ],
+            "sourceNote": "James supplied the initial Extra spelling expansion on 22 April 2026.",
+            "provenance": {
+              "source": "James Extra spelling list",
+              "note": "Initial Extra expansion for spelling practice.",
+              "importedAt": 1776816000000
+            },
+            "sortIndex": 234
+          }
+        }
+      }
     }
   ],
   "publication": {
-    "currentReleaseId": "spelling-r2",
-    "publishedVersion": 2,
-    "updatedAt": 1776816000000
+    "currentReleaseId": "spelling-r3",
+    "publishedVersion": 3,
+    "updatedAt": 1776902400000
   }
 }

--- a/docs/spelling-content-model.md
+++ b/docs/spelling-content-model.md
@@ -97,6 +97,7 @@ They keep pool and year-group metadata explicit and give future operator tooling
   yearGroups,
   tags,
   accepted,
+  variants,
   explanation,
   sentenceEntryIds,
   sourceNote,
@@ -113,6 +114,8 @@ Legacy bundles that pre-date this field are backfilled from the canonical seeded
 
 `spellingPool` is inherited from the word list if omitted. Existing version-one content without pool metadata therefore remains `core` by default.
 Extra words publish with runtime `year: 'extra'`, `yearLabel: 'Extra'`, and no statutory year groups.
+
+Extra words may define `variants` for opt-in word-family practice. A variant supplies its own dictated word, accepted spellings, learner-facing explanation, and sentence references, but it does not publish as a separate runtime word. The learner still secures the base Extra word slug. Core words must continue to model statutory variants as their existing separate word rows, preserving the original KS2 parity.
 
 ### Sentence entries / variants
 
@@ -214,6 +217,8 @@ Runtime words also include `spellingPool`. Current values are:
 - `extra` for expansion spelling content outside the statutory pools
 
 The legacy `all` spelling filter is still accepted by the service, but it aliases to `core`. Extra content has to be requested explicitly through the `extra` filter and is excluded from SATs Test mode.
+
+Extra word-family variants are runtime prompts only. They are used when an Extra session opts in to word-family variants, while aggregate totals, secure counts, reward progress, and word-bank rows stay keyed to the base Extra word.
 
 This keeps the subject engine deterministic and unchanged in its core pedagogy while letting content-management logic live outside it.
 

--- a/docs/spelling-parity.md
+++ b/docs/spelling-parity.md
@@ -97,6 +97,7 @@ The Extra spelling expansion is outside the original statutory baseline.
 - Phaeton remains the Years 3-6 statutory bonus monster, derived only from Inklet and Glimmerbug
 - Vellhorn is the Extra reward path and does not contribute to Phaeton
 - the searchable Word Bank now includes Core, Years 3-4, Years 5-6, and Extra views, with direct drill validation using the published accepted-answer list
+- Extra can opt into word-family variant prompts from the setup screen; variants carry their own explanations and sentences, but share the base Extra word's progress and secure state, so the Extra pool still counts the 22 base words
 - the first 22-word Extra release cannot naturally reach every Vellhorn stage under the 100-word direct-monster thresholds; mature Vellhorn rendering is covered by synthetic render fixtures only
 
 ## Still not directly verified in this pass

--- a/legacy/spelling-engine.source.js
+++ b/legacy/spelling-engine.source.js
@@ -89,6 +89,64 @@
     return "Next review in " + interval + " day" + (interval === 1 ? "" : "s");
   }
 
+  function promptAccepted(value, fallback) {
+    var accepted = Array.isArray(value) && value.length ? value.slice() : [fallback];
+    return accepted.map(function (entry) { return normalize(entry); }).filter(Boolean);
+  }
+
+  function basePromptForm(word) {
+    return {
+      slug: word.slug,
+          promptKey: word.slug,
+          word: word.word,
+          accepted: promptAccepted(word.accepted, word.slug),
+          sentence: word.sentence,
+          sentences: Array.isArray(word.sentences) ? word.sentences.slice() : [],
+          explanation: word.explanation || "",
+        };
+      }
+
+  function promptFormsForWord(word) {
+    var forms = [basePromptForm(word)];
+    if (spellingPoolForWord(word) !== "extra") return forms;
+    if (!Array.isArray(word.variants)) return forms;
+    for (var i = 0; i < word.variants.length; i++) {
+      var variant = word.variants[i];
+      if (!variant || !variant.word) continue;
+      forms.push({
+        slug: word.slug,
+        promptKey: word.slug + "::" + normalize(variant.word),
+            word: variant.word,
+            accepted: promptAccepted(variant.accepted, variant.word),
+            sentence: variant.sentence,
+            sentences: Array.isArray(variant.sentences) ? variant.sentences.slice() : [],
+            explanation: variant.explanation || word.explanation || "",
+          });
+        }
+        return forms;
+  }
+
+  function choosePromptForm(session, word) {
+    if (!session || !session.extraWordFamilies) return basePromptForm(word);
+    var forms = promptFormsForWord(word);
+    if (forms.length <= 1) return forms[0];
+    return forms[Math.floor(Math.random() * forms.length)] || forms[0];
+  }
+
+  function wordForCurrentPrompt(session) {
+    var word = WORD_BY_SLUG[session && session.currentSlug];
+    if (!word) return null;
+    var prompt = session.currentPrompt || {};
+    if (!prompt.word) return word;
+    return Object.assign({}, word, {
+          word: prompt.word,
+          accepted: promptAccepted(prompt.accepted, prompt.word),
+          sentence: prompt.sentence || word.sentence,
+          sentences: prompt.sentence ? [prompt.sentence] : word.sentences,
+          explanation: prompt.explanation || word.explanation || "",
+        });
+      }
+
   // ----- progress persistence (profile-scoped per plan) ---------------------
 
   var PROGRESS_KEY_PREFIX = "ks2-spell-progress-";
@@ -289,14 +347,15 @@
     var sentences = (word.sentences && word.sentences.length) ? word.sentences : [word.sentence].filter(Boolean);
     if (!session || !session.sentenceHistory || !sentences.length) return null;
 
-    var history = session.sentenceHistory[word.slug];
+    var historyKey = word.promptKey || word.slug;
+    var history = session.sentenceHistory[historyKey];
     if (!history || !Array.isArray(history.remaining) || !history.remaining.length) {
       var lastIndex = (history && Number.isInteger(history.lastIndex)) ? history.lastIndex : null;
       history = {
         remaining: shuffledSentenceOrder(sentences.length, lastIndex),
         lastIndex: lastIndex,
       };
-      session.sentenceHistory[word.slug] = history;
+      session.sentenceHistory[historyKey] = history;
     }
     return history;
   }
@@ -312,7 +371,7 @@
     var history = getOrCreateSentenceHistory(session, word);
     var nextIndex = history.remaining.shift();
     history.lastIndex = nextIndex;
-    session.sentenceHistory[word.slug] = history;
+    session.sentenceHistory[word.promptKey || word.slug] = history;
     return sentences[nextIndex];
   }
 
@@ -382,6 +441,7 @@
     }
 
     var practiceOnly = Boolean(options.practiceOnly && actualMode !== MODES.TEST);
+    var extraWordFamilies = Boolean(options.extraWordFamilies && actualMode !== MODES.TEST && yearFilter === "extra");
 
     var session = {
       id: makeSessionId(),
@@ -394,6 +454,7 @@
           : "Smart review",
       practiceOnly: practiceOnly,
       fallbackToSmart: fallback,
+      extraWordFamilies: extraWordFamilies,
       profileId: profileId,
       uniqueWords: selected.map(function (w) { return w.slug; }),
       queue: selected.map(function (w) { return w.slug; }),
@@ -458,13 +519,17 @@
     if (!session) return null;
     var word = WORD_BY_SLUG[slug];
     if (!word) return null;
-    var sentence = choosePromptSentence(session, word);
+    var promptWord = choosePromptForm(session, word);
+    var sentence = choosePromptSentence(session, promptWord);
     session.currentSlug = slug;
     session.currentPrompt = {
       slug: slug,
-      sentence: sentence,
-      cloze: buildCloze(sentence, word.word),
-    };
+          word: promptWord.word,
+          accepted: promptWord.accepted.slice(),
+          explanation: promptWord.explanation || word.explanation || "",
+          sentence: sentence,
+          cloze: buildCloze(sentence, promptWord.word),
+        };
     session.lastFamily = word.family;
     session.lastYear = word.year;
     return session.currentPrompt;
@@ -480,7 +545,7 @@
       if (!session.queue.length) return { done: true };
       var slug = session.queue.shift();
       setCurrentPrompt(session, slug);
-      return { done: false, slug: slug, word: WORD_BY_SLUG[slug], prompt: session.currentPrompt };
+      return { done: false, slug: slug, word: wordForCurrentPrompt(session), prompt: session.currentPrompt };
     }
 
     while (session.queue.length) {
@@ -491,7 +556,7 @@
         return {
           done: false,
           slug: nextSlug,
-          word: WORD_BY_SLUG[nextSlug],
+          word: wordForCurrentPrompt(session),
           prompt: session.currentPrompt,
         };
       }
@@ -572,7 +637,7 @@
   // Legacy parity: preview.html handleLearningSubmit (2713-2827).
   function submitLearning(session, profileId, typed) {
     if (!session || session.type !== "learning") return null;
-    var word = WORD_BY_SLUG[session.currentSlug];
+    var word = wordForCurrentPrompt(session);
     if (!word) return null;
     var info = session.status[word.slug];
     var typedRaw = String(typed == null ? "" : typed).trim();
@@ -712,7 +777,7 @@
   // no phases, results recorded straight into session.results.
   function submitTest(session, profileId, typed) {
     if (!session || session.type !== "test") return null;
-    var word = WORD_BY_SLUG[session.currentSlug];
+    var word = wordForCurrentPrompt(session);
     if (!word) return null;
     var typedRaw = String(typed == null ? "" : typed).trim();
     var grade = gradeWord(word, typedRaw);

--- a/src/subjects/spelling/components/SpellingSetupScene.jsx
+++ b/src/subjects/spelling/components/SpellingSetupScene.jsx
@@ -173,6 +173,7 @@ export function SpellingSetupScene({ learner, service, repositories, subject, pr
   const hideTweaks = prefs.mode === 'test';
   const tweakClass = `tweak-row${hideTweaks ? ' is-placeholder' : ''}`;
   const tweakAria = hideTweaks ? { 'aria-hidden': 'true' } : {};
+  const showExtraFamilyOption = !hideTweaks && prefs.yearFilter === 'extra';
   const mergedHeroStyle = { ...heroBgStyle(heroBg) };
   const heroContrast = useSetupHeroContrast(heroBg, prefs.mode);
   const setupClasses = ['setup-main'];
@@ -231,6 +232,9 @@ export function SpellingSetupScene({ learner, service, repositories, subject, pr
               <span className="tool-label">Options</span>
               <ToggleChip pref="showCloze" checked={Boolean(prefs.showCloze)} label="Show sentence" actions={actions} />
               <ToggleChip pref="autoSpeak" checked={Boolean(prefs.autoSpeak)} label="Auto-play audio" actions={actions} />
+              {showExtraFamilyOption ? (
+                <ToggleChip pref="extraWordFamilies" checked={Boolean(prefs.extraWordFamilies)} label="Word-family variants" actions={actions} />
+              ) : null}
             </div>
           </div>
           <div className="setup-begin-row">

--- a/src/subjects/spelling/components/SpellingWordDetailModal.jsx
+++ b/src/subjects/spelling/components/SpellingWordDetailModal.jsx
@@ -10,6 +10,7 @@ import {
 
 function ExplainBody({ word }) {
   const sentence = (word.sentence || '').replace(/________/g, word.word);
+  const variants = Array.isArray(word.variants) ? word.variants.filter((variant) => variant?.word) : [];
   return (
     <div className="wb-modal-body">
       <div className="wb-modal-section">
@@ -24,6 +25,23 @@ function ExplainBody({ word }) {
           ? <blockquote className="wb-modal-sample">{sentence}</blockquote>
           : <p className="wb-modal-def">No example sentence on file for this word yet.</p>}
       </div>
+      {variants.length ? (
+        <div className="wb-modal-section">
+          <p className="wb-modal-section-label">Word-family variants</p>
+          <div className="wb-variant-list">
+            {variants.map((variant) => {
+              const variantSentence = (variant.sentence || '').replace(/________/g, variant.word);
+              return (
+                <div className="wb-variant-row" key={variant.word}>
+                  <strong className="wb-variant-word">{variant.word}</strong>
+                  {variant.explanation ? <p className="wb-modal-def">{variant.explanation}</p> : null}
+                  {variantSentence ? <blockquote className="wb-modal-sample">{variantSentence}</blockquote> : null}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/subjects/spelling/components/spelling-view-model.js
+++ b/src/subjects/spelling/components/spelling-view-model.js
@@ -198,6 +198,7 @@ export function spellingPoolContextLabel(word) {
 
 export function wordMatchesSearch(word, query) {
   if (!query) return true;
+  const variants = Array.isArray(word.variants) ? word.variants : [];
   const fields = [
     word.slug,
     word.word,
@@ -206,6 +207,14 @@ export function wordMatchesSearch(word, query) {
     spellingPoolLabel(word),
     word.explanation,
     ...(Array.isArray(word.accepted) ? word.accepted : []),
+    ...(Array.isArray(word.familyWords) ? word.familyWords : []),
+    ...variants.flatMap((variant) => [
+      variant?.word,
+      variant?.explanation,
+      variant?.sentence,
+      ...(Array.isArray(variant?.accepted) ? variant.accepted : []),
+      ...(Array.isArray(variant?.sentences) ? variant.sentences : []),
+    ]),
   ].map(normaliseSearchText);
   return fields.some((field) => field.includes(query));
 }

--- a/src/subjects/spelling/content/model.js
+++ b/src/subjects/spelling/content/model.js
@@ -70,6 +70,13 @@ function normaliseTags(value) {
   return uniqueStrings(value, { lowerCase: true });
 }
 
+function normaliseAcceptedSpellings(value, defaultValue = '') {
+  const accepted = uniqueStrings(value, { lowerCase: true });
+  const normalisedDefault = normaliseString(defaultValue).toLowerCase();
+  if (normalisedDefault && !accepted.includes(normalisedDefault)) accepted.unshift(normalisedDefault);
+  return accepted;
+}
+
 function hasUsableWordExplanation(value) {
   return normaliseString(value).length >= MIN_WORD_EXPLANATION_LENGTH;
 }
@@ -122,8 +129,8 @@ function normaliseWordEntry(rawValue, index = 0, wordListsById = new Map()) {
   const slug = normaliseString(raw.slug, slugifyWord(word));
   const listId = normaliseString(raw.listId);
   const listPool = normaliseSpellingPool(wordListsById.get(listId)?.spellingPool);
-  const accepted = uniqueStrings(raw.accepted, { lowerCase: true });
-  if (slug && !accepted.includes(slug)) accepted.unshift(slug);
+  const variants = (Array.isArray(raw.variants) ? raw.variants : [])
+    .map((entry, variantIndex) => normaliseWordVariant(entry, variantIndex));
 
   return {
     slug,
@@ -133,11 +140,26 @@ function normaliseWordEntry(rawValue, index = 0, wordListsById = new Map()) {
     spellingPool: normaliseSpellingPool(raw.spellingPool, listPool),
     yearGroups: normaliseYearGroups(raw.yearGroups),
     tags: normaliseTags(raw.tags),
-    accepted,
+    accepted: normaliseAcceptedSpellings(raw.accepted, slug),
+    ...(variants.length ? { variants } : {}),
     explanation: normaliseString(raw.explanation),
     sentenceEntryIds: uniqueStrings(raw.sentenceEntryIds),
     sourceNote: normaliseString(raw.sourceNote),
     provenance: normaliseProvenance(raw.provenance, raw.sourceNote || 'spelling word'),
+    sortIndex: Number.isInteger(Number(raw.sortIndex)) && Number(raw.sortIndex) >= 0 ? Number(raw.sortIndex) : index,
+  };
+}
+
+function normaliseWordVariant(rawValue, index = 0) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  const word = normaliseString(raw.word);
+  return {
+    word,
+    accepted: normaliseAcceptedSpellings(raw.accepted, word),
+    explanation: normaliseString(raw.explanation),
+    sentenceEntryIds: uniqueStrings(raw.sentenceEntryIds),
+    sourceNote: normaliseString(raw.sourceNote),
+    provenance: normaliseProvenance(raw.provenance, raw.sourceNote || 'spelling word variant'),
     sortIndex: Number.isInteger(Number(raw.sortIndex)) && Number(raw.sortIndex) >= 0 ? Number(raw.sortIndex) : index,
   };
 }
@@ -162,11 +184,11 @@ function normaliseRuntimeWord(rawValue, index = 0) {
   const slug = normaliseString(raw.slug, slugifyWord(word));
   const spellingPool = normaliseSpellingPool(raw.spellingPool, raw.year === 'extra' ? 'extra' : 'core');
   const year = spellingPool === 'extra' ? 'extra' : raw.year === '5-6' ? '5-6' : '3-4';
-  const accepted = uniqueStrings(raw.accepted, { lowerCase: true });
-  if (slug && !accepted.includes(slug)) accepted.unshift(slug);
   const sentences = uniqueStrings(raw.sentences);
   const sentence = normaliseString(raw.sentence, sentences[0] || '');
   if (sentence && !sentences.includes(sentence)) sentences.unshift(sentence);
+  const variants = (Array.isArray(raw.variants) ? raw.variants : [])
+    .map((entry, variantIndex) => normaliseRuntimeWordVariant(entry, variantIndex));
 
   return {
     year,
@@ -178,13 +200,32 @@ function normaliseRuntimeWord(rawValue, index = 0) {
     familyWords: uniqueStrings(raw.familyWords),
     sentence,
     sentences,
-    accepted,
+    accepted: normaliseAcceptedSpellings(raw.accepted, slug),
+    ...(variants.length ? { variants } : {}),
     explanation: normaliseString(raw.explanation),
     listId: normaliseString(raw.listId),
     yearGroups: normaliseYearGroups(raw.yearGroups, spellingPool === 'extra' ? [] : year === '5-6' ? ['Y5', 'Y6'] : ['Y3', 'Y4']),
     tags: normaliseTags(raw.tags),
     sourceNote: normaliseString(raw.sourceNote),
     provenance: normaliseProvenance(raw.provenance, raw.sourceNote || 'published spelling word'),
+    sortIndex: Number.isInteger(Number(raw.sortIndex)) && Number(raw.sortIndex) >= 0 ? Number(raw.sortIndex) : index,
+  };
+}
+
+function normaliseRuntimeWordVariant(rawValue, index = 0) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  const word = normaliseString(raw.word);
+  const sentences = uniqueStrings(raw.sentences);
+  const sentence = normaliseString(raw.sentence, sentences[0] || '');
+  if (sentence && !sentences.includes(sentence)) sentences.unshift(sentence);
+  return {
+    word,
+    sentence,
+    sentences,
+    accepted: normaliseAcceptedSpellings(raw.accepted, word),
+    explanation: normaliseString(raw.explanation),
+    sourceNote: normaliseString(raw.sourceNote),
+    provenance: normaliseProvenance(raw.provenance, raw.sourceNote || 'published spelling word variant'),
     sortIndex: Number.isInteger(Number(raw.sortIndex)) && Number(raw.sortIndex) >= 0 ? Number(raw.sortIndex) : index,
   };
 }
@@ -385,6 +426,21 @@ export function validateSpellingContentBundle(rawBundle) {
     if (!word.sentenceEntryIds.length) {
       errors.push(issue('error', 'broken_sentence_reference', `draft.words[${index}].sentenceEntryIds`, `Word "${word.slug}" must reference at least one sentence entry.`));
     }
+    const variants = Array.isArray(word.variants) ? word.variants : [];
+    if (variants.length && word.spellingPool !== 'extra') {
+      errors.push(issue('error', 'core_variants_not_supported', `draft.words[${index}].variants`, `Word "${word.slug}" can only define variants in the Extra pool.`));
+    }
+    variants.forEach((variant, variantIndex) => {
+      if (!variant.word) {
+        errors.push(issue('error', 'malformed_entry', `draft.words[${index}].variants[${variantIndex}].word`, `Variant ${variantIndex + 1} for word "${word.slug}" must include a word.`));
+      }
+      if (!hasUsableWordExplanation(variant.explanation)) {
+        errors.push(issue('error', 'missing_word_explanation', `draft.words[${index}].variants[${variantIndex}].explanation`, `Variant "${variant.word || variantIndex + 1}" for word "${word.slug}" must include a learner-facing explanation.`));
+      }
+      if (!variant.sentenceEntryIds.length) {
+        errors.push(issue('error', 'broken_sentence_reference', `draft.words[${index}].variants[${variantIndex}].sentenceEntryIds`, `Variant "${variant.word || variantIndex + 1}" for word "${word.slug}" must reference at least one sentence entry.`));
+      }
+    });
   });
 
   bundle.draft.sentences.forEach((sentence, index) => {
@@ -419,6 +475,19 @@ export function validateSpellingContentBundle(rawBundle) {
         errors.push(issue('error', 'broken_sentence_reference', `draft.words[${index}].sentenceEntryIds[${position}]`, `Sentence "${sentenceId}" belongs to word "${sentence.wordSlug}", not "${word.slug}".`));
       }
     });
+    const variants = Array.isArray(word.variants) ? word.variants : [];
+    variants.forEach((variant, variantIndex) => {
+      variant.sentenceEntryIds.forEach((sentenceId, position) => {
+        const sentence = sentencesById.get(sentenceId);
+        if (!sentence) {
+          errors.push(issue('error', 'broken_sentence_reference', `draft.words[${index}].variants[${variantIndex}].sentenceEntryIds[${position}]`, `Variant "${variant.word || variantIndex + 1}" for word "${word.slug}" references missing sentence id "${sentenceId}".`));
+          return;
+        }
+        if (sentence.wordSlug !== word.slug) {
+          errors.push(issue('error', 'broken_sentence_reference', `draft.words[${index}].variants[${variantIndex}].sentenceEntryIds[${position}]`, `Sentence "${sentenceId}" belongs to word "${sentence.wordSlug}", not "${word.slug}".`));
+        }
+      });
+    });
   });
 
   bundle.releases.forEach((release, index) => {
@@ -446,6 +515,18 @@ export function validateSpellingContentBundle(rawBundle) {
       if (word.spellingPool === 'core' && word.year === 'extra') {
         errors.push(issue('error', 'pool_mismatch', `releases[${index}].snapshot.words[${wordIndex}].spellingPool`, `Published core word "${word.slug}" cannot use the Extra runtime year.`));
       }
+      const variants = Array.isArray(word.variants) ? word.variants : [];
+      if (variants.length && word.spellingPool !== 'extra') {
+        errors.push(issue('error', 'core_variants_not_supported', `releases[${index}].snapshot.words[${wordIndex}].variants`, `Published word "${word.slug}" can only define variants in the Extra pool.`));
+      }
+      variants.forEach((variant, variantIndex) => {
+        if (!variant.word || !variant.sentence || !variant.sentences.length) {
+          errors.push(issue('error', 'malformed_entry', `releases[${index}].snapshot.words[${wordIndex}].variants[${variantIndex}]`, `Published variant ${variantIndex + 1} for word "${word.slug}" is incomplete.`));
+        }
+        if (!hasUsableWordExplanation(variant.explanation)) {
+          errors.push(issue('error', 'missing_word_explanation', `releases[${index}].snapshot.words[${wordIndex}].variants[${variantIndex}].explanation`, `Published variant "${variant.word || variantIndex + 1}" for word "${word.slug}" must include a learner-facing explanation.`));
+        }
+      });
     });
   });
 
@@ -512,6 +593,25 @@ export function buildPublishedSnapshotFromDraft(rawDraft, { generatedAt = Date.n
       .filter(Boolean)
       .sort((a, b) => a.sortIndex - b.sortIndex)
       .map((sentence) => sentence.text);
+    const variants = word.spellingPool === 'extra'
+      ? (Array.isArray(word.variants) ? word.variants : []).map((variant) => {
+          const variantSentences = variant.sentenceEntryIds
+            .map((id) => sentenceById.get(id))
+            .filter(Boolean)
+            .sort((a, b) => a.sortIndex - b.sortIndex)
+            .map((sentence) => sentence.text);
+          return {
+            word: variant.word,
+            sentence: variantSentences[0] || '',
+            sentences: variantSentences,
+            accepted: variant.accepted,
+            explanation: variant.explanation,
+            sourceNote: variant.sourceNote,
+            provenance: variant.provenance,
+            sortIndex: variant.sortIndex,
+          };
+        })
+      : [];
     const year = word.spellingPool === 'extra' ? 'extra' : yearBandFromGroups(word.yearGroups);
     const familyKey = `${word.spellingPool}::${year}::${word.family}`;
     if (!familyMap.has(familyKey)) familyMap.set(familyKey, []);
@@ -527,6 +627,7 @@ export function buildPublishedSnapshotFromDraft(rawDraft, { generatedAt = Date.n
       sentence: sentences[0] || '',
       sentences,
       accepted: word.accepted,
+      variants,
       explanation: word.explanation,
       listId: word.listId,
       yearGroups: word.yearGroups,
@@ -539,7 +640,9 @@ export function buildPublishedSnapshotFromDraft(rawDraft, { generatedAt = Date.n
 
   const words = runtimeWords.map((word) => ({
     ...word,
-    familyWords: familyMap.get(familyKeyForRuntime(word)) || [word.word],
+    familyWords: word.spellingPool === 'extra'
+      ? uniqueStrings([word.word, ...(Array.isArray(word.variants) ? word.variants : []).map((variant) => variant.word)])
+      : familyMap.get(familyKeyForRuntime(word)) || [word.word],
   }));
 
   return {
@@ -659,7 +762,12 @@ export function buildSpellingContentSummary(rawBundle) {
     publishedVersion: published?.version || 0,
     publishedAt: published?.publishedAt || 0,
     runtimeWordCount: published?.snapshot?.words?.length || 0,
-    runtimeSentenceCount: published?.snapshot?.words?.reduce((total, word) => total + (Array.isArray(word.sentences) ? word.sentences.length : 0), 0) || 0,
+    runtimeSentenceCount: published?.snapshot?.words?.reduce((total, word) => {
+      const baseCount = Array.isArray(word.sentences) ? word.sentences.length : 0;
+      const variantCount = (Array.isArray(word.variants) ? word.variants : [])
+        .reduce((sum, variant) => sum + (Array.isArray(variant.sentences) ? variant.sentences.length : 0), 0);
+      return total + baseCount + variantCount;
+    }, 0) || 0,
     ok: validation.ok,
   };
 }

--- a/src/subjects/spelling/data/word-data.js
+++ b/src/subjects/spelling/data/word-data.js
@@ -9417,15 +9417,8 @@ export const WORDS = [
     "yearLabel": "Extra",
     "familyWords": [
       "divide",
-      "collide",
-      "explode",
-      "corrode",
-      "conclude",
-      "extend",
-      "comprehend",
-      "evade",
-      "intrude",
-      "interlude"
+      "division",
+      "divisible"
     ],
     "sentence": "We divide the class into teams before the investigation.",
     "sentences": [
@@ -9433,6 +9426,44 @@ export const WORDS = [
     ],
     "accepted": [
       "divide"
+    ],
+    "variants": [
+      {
+        "word": "division",
+        "sentence": "The division of the class into teams was fair.",
+        "sentences": [
+          "The division of the class into teams was fair."
+        ],
+        "accepted": [
+          "division"
+        ],
+        "explanation": "Division is the act of splitting something into parts or groups.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the divide base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      },
+      {
+        "word": "divisible",
+        "sentence": "Twenty is divisible by five.",
+        "sentences": [
+          "Twenty is divisible by five."
+        ],
+        "accepted": [
+          "divisible"
+        ],
+        "explanation": "Divisible means able to be divided exactly by a number.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the divide base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 2
+      }
     ],
     "explanation": "To divide is to split something into parts or groups.",
     "listId": "extra-science-word-building",
@@ -9459,16 +9490,8 @@ export const WORDS = [
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "divide",
       "collide",
-      "explode",
-      "corrode",
-      "conclude",
-      "extend",
-      "comprehend",
-      "evade",
-      "intrude",
-      "interlude"
+      "collision"
     ],
     "sentence": "The two balls collide in the middle of the table.",
     "sentences": [
@@ -9476,6 +9499,26 @@ export const WORDS = [
     ],
     "accepted": [
       "collide"
+    ],
+    "variants": [
+      {
+        "word": "collision",
+        "sentence": "The collision made both balls change direction.",
+        "sentences": [
+          "The collision made both balls change direction."
+        ],
+        "accepted": [
+          "collision"
+        ],
+        "explanation": "A collision is a crash or strong hit between moving things.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the collide base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      }
     ],
     "explanation": "To collide is to crash into something or hit it while moving.",
     "listId": "extra-science-word-building",
@@ -9502,16 +9545,9 @@ export const WORDS = [
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "divide",
-      "collide",
       "explode",
-      "corrode",
-      "conclude",
-      "extend",
-      "comprehend",
-      "evade",
-      "intrude",
-      "interlude"
+      "explosion",
+      "explosive"
     ],
     "sentence": "The volcano model did not explode until the final step.",
     "sentences": [
@@ -9519,6 +9555,44 @@ export const WORDS = [
     ],
     "accepted": [
       "explode"
+    ],
+    "variants": [
+      {
+        "word": "explosion",
+        "sentence": "The experiment caused a safe foam explosion.",
+        "sentences": [
+          "The experiment caused a safe foam explosion."
+        ],
+        "accepted": [
+          "explosion"
+        ],
+        "explanation": "An explosion is a sudden burst with force, noise or energy.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the explode base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      },
+      {
+        "word": "explosive",
+        "sentence": "The explosive reaction was controlled by the teacher.",
+        "sentences": [
+          "The explosive reaction was controlled by the teacher."
+        ],
+        "accepted": [
+          "explosive"
+        ],
+        "explanation": "Explosive means able to burst apart suddenly with force.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the explode base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 2
+      }
     ],
     "explanation": "To explode is to burst apart suddenly with force.",
     "listId": "extra-science-word-building",
@@ -9545,16 +9619,9 @@ export const WORDS = [
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "divide",
-      "collide",
-      "explode",
       "corrode",
-      "conclude",
-      "extend",
-      "comprehend",
-      "evade",
-      "intrude",
-      "interlude"
+      "corrosion",
+      "corrosive"
     ],
     "sentence": "Salt water can corrode metal over time.",
     "sentences": [
@@ -9562,6 +9629,44 @@ export const WORDS = [
     ],
     "accepted": [
       "corrode"
+    ],
+    "variants": [
+      {
+        "word": "corrosion",
+        "sentence": "Corrosion weakened the old metal gate.",
+        "sentences": [
+          "Corrosion weakened the old metal gate."
+        ],
+        "accepted": [
+          "corrosion"
+        ],
+        "explanation": "Corrosion is the slow damage caused by a chemical reaction, often rust.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the corrode base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      },
+      {
+        "word": "corrosive",
+        "sentence": "The corrosive liquid was handled with care.",
+        "sentences": [
+          "The corrosive liquid was handled with care."
+        ],
+        "accepted": [
+          "corrosive"
+        ],
+        "explanation": "Corrosive means able to slowly damage a material by chemical action.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the corrode base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 2
+      }
     ],
     "explanation": "To corrode is to be slowly damaged by a chemical reaction, often rust.",
     "listId": "extra-science-word-building",
@@ -9588,16 +9693,8 @@ export const WORDS = [
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "divide",
-      "collide",
-      "explode",
-      "corrode",
       "conclude",
-      "extend",
-      "comprehend",
-      "evade",
-      "intrude",
-      "interlude"
+      "conclusion"
     ],
     "sentence": "We conclude that shade slows the melting ice.",
     "sentences": [
@@ -9605,6 +9702,26 @@ export const WORDS = [
     ],
     "accepted": [
       "conclude"
+    ],
+    "variants": [
+      {
+        "word": "conclusion",
+        "sentence": "Her conclusion matched the evidence from the test.",
+        "sentences": [
+          "Her conclusion matched the evidence from the test."
+        ],
+        "accepted": [
+          "conclusion"
+        ],
+        "explanation": "A conclusion is the final decision or ending reached after thinking.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the conclude base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      }
     ],
     "explanation": "To conclude is to finish, or to decide after thinking about evidence.",
     "listId": "extra-science-word-building",
@@ -9631,16 +9748,9 @@ export const WORDS = [
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "divide",
-      "collide",
-      "explode",
-      "corrode",
-      "conclude",
       "extend",
-      "comprehend",
-      "evade",
-      "intrude",
-      "interlude"
+      "extension",
+      "extended"
     ],
     "sentence": "The bridge can extend across the stream.",
     "sentences": [
@@ -9648,6 +9758,44 @@ export const WORDS = [
     ],
     "accepted": [
       "extend"
+    ],
+    "variants": [
+      {
+        "word": "extension",
+        "sentence": "The bridge extension reached the other bank.",
+        "sentences": [
+          "The bridge extension reached the other bank."
+        ],
+        "accepted": [
+          "extension"
+        ],
+        "explanation": "An extension is an added part or an increase in length or time.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the extend base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      },
+      {
+        "word": "extended",
+        "sentence": "The extended table gave everyone space.",
+        "sentences": [
+          "The extended table gave everyone space."
+        ],
+        "accepted": [
+          "extended"
+        ],
+        "explanation": "Extended means made longer or lasting for more time.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the extend base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 2
+      }
     ],
     "explanation": "To extend is to make something longer or reach further.",
     "listId": "extra-science-word-building",
@@ -9674,16 +9822,8 @@ export const WORDS = [
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "divide",
-      "collide",
-      "explode",
-      "corrode",
-      "conclude",
-      "extend",
       "comprehend",
-      "evade",
-      "intrude",
-      "interlude"
+      "comprehension"
     ],
     "sentence": "She could comprehend the instructions after reading them twice.",
     "sentences": [
@@ -9691,6 +9831,26 @@ export const WORDS = [
     ],
     "accepted": [
       "comprehend"
+    ],
+    "variants": [
+      {
+        "word": "comprehension",
+        "sentence": "Good comprehension helped her answer the questions.",
+        "sentences": [
+          "Good comprehension helped her answer the questions."
+        ],
+        "accepted": [
+          "comprehension"
+        ],
+        "explanation": "Comprehension is the ability to understand something.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the comprehend base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      }
     ],
     "explanation": "To comprehend is to understand something fully.",
     "listId": "extra-science-word-building",
@@ -9717,16 +9877,9 @@ export const WORDS = [
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "divide",
-      "collide",
-      "explode",
-      "corrode",
-      "conclude",
-      "extend",
-      "comprehend",
       "evade",
-      "intrude",
-      "interlude"
+      "evasion",
+      "evasive"
     ],
     "sentence": "The beetle tried to evade the torchlight under a leaf.",
     "sentences": [
@@ -9734,6 +9887,44 @@ export const WORDS = [
     ],
     "accepted": [
       "evade"
+    ],
+    "variants": [
+      {
+        "word": "evasion",
+        "sentence": "The quick evasion helped the player dodge the tackle.",
+        "sentences": [
+          "The quick evasion helped the player dodge the tackle."
+        ],
+        "accepted": [
+          "evasion"
+        ],
+        "explanation": "Evasion is the act of avoiding or escaping something.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the evade base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      },
+      {
+        "word": "evasive",
+        "sentence": "His evasive answer did not explain the mistake.",
+        "sentences": [
+          "His evasive answer did not explain the mistake."
+        ],
+        "accepted": [
+          "evasive"
+        ],
+        "explanation": "Evasive means trying to avoid something or not answer directly.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the evade base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 2
+      }
     ],
     "explanation": "To evade is to avoid or escape from someone or something.",
     "listId": "extra-science-word-building",
@@ -9760,16 +9951,9 @@ export const WORDS = [
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "divide",
-      "collide",
-      "explode",
-      "corrode",
-      "conclude",
-      "extend",
-      "comprehend",
-      "evade",
       "intrude",
-      "interlude"
+      "intrusion",
+      "intrusive"
     ],
     "sentence": "Please do not intrude while the group is recording.",
     "sentences": [
@@ -9777,6 +9961,44 @@ export const WORDS = [
     ],
     "accepted": [
       "intrude"
+    ],
+    "variants": [
+      {
+        "word": "intrusion",
+        "sentence": "The loud noise was an intrusion during the recording.",
+        "sentences": [
+          "The loud noise was an intrusion during the recording."
+        ],
+        "accepted": [
+          "intrusion"
+        ],
+        "explanation": "An intrusion is an unwanted entry or interruption.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the intrude base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      },
+      {
+        "word": "intrusive",
+        "sentence": "The intrusive sound disturbed the quiet lesson.",
+        "sentences": [
+          "The intrusive sound disturbed the quiet lesson."
+        ],
+        "accepted": [
+          "intrusive"
+        ],
+        "explanation": "Intrusive means entering or interrupting where it is not wanted.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the intrude base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 2
+      }
     ],
     "explanation": "To intrude is to enter or join in where you are not wanted.",
     "listId": "extra-science-word-building",
@@ -9803,16 +10025,8 @@ export const WORDS = [
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "divide",
-      "collide",
-      "explode",
-      "corrode",
-      "conclude",
-      "extend",
-      "comprehend",
-      "evade",
-      "intrude",
-      "interlude"
+      "interlude",
+      "interludes"
     ],
     "sentence": "A quiet interlude gave the performers time to reset.",
     "sentences": [
@@ -9820,6 +10034,26 @@ export const WORDS = [
     ],
     "accepted": [
       "interlude"
+    ],
+    "variants": [
+      {
+        "word": "interludes",
+        "sentence": "The play had two short interludes.",
+        "sentences": [
+          "The play had two short interludes."
+        ],
+        "accepted": [
+          "interludes"
+        ],
+        "explanation": "Interludes are short pauses or breaks between parts of something.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the interlude base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      }
     ],
     "explanation": "An interlude is a short pause or break between parts of something.",
     "listId": "extra-science-word-building",
@@ -9846,7 +10080,9 @@ export const WORDS = [
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "classification"
+      "classification",
+      "classify",
+      "classified"
     ],
     "sentence": "Classification helps scientists compare animals with similar features.",
     "sentences": [
@@ -9854,6 +10090,44 @@ export const WORDS = [
     ],
     "accepted": [
       "classification"
+    ],
+    "variants": [
+      {
+        "word": "classify",
+        "sentence": "Scientists classify living things by their features.",
+        "sentences": [
+          "Scientists classify living things by their features."
+        ],
+        "accepted": [
+          "classify"
+        ],
+        "explanation": "To classify is to sort things into groups by shared features.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the classification base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      },
+      {
+        "word": "classified",
+        "sentence": "The leaves were classified by shape and size.",
+        "sentences": [
+          "The leaves were classified by shape and size."
+        ],
+        "accepted": [
+          "classified"
+        ],
+        "explanation": "Classified means sorted into groups by type or feature.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the classification base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 2
+      }
     ],
     "explanation": "Classification is sorting living things or objects into groups by shared features.",
     "listId": "extra-science-word-building",
@@ -9880,7 +10154,7 @@ export const WORDS = [
     "yearLabel": "Extra",
     "familyWords": [
       "backbone",
-      "skeleton"
+      "backbones"
     ],
     "sentence": "A fish has a backbone inside its body.",
     "sentences": [
@@ -9888,6 +10162,26 @@ export const WORDS = [
     ],
     "accepted": [
       "backbone"
+    ],
+    "variants": [
+      {
+        "word": "backbones",
+        "sentence": "The model showed how backbones protect the spinal cord.",
+        "sentences": [
+          "The model showed how backbones protect the spinal cord."
+        ],
+        "accepted": [
+          "backbones"
+        ],
+        "explanation": "Backbones are rows of bones that support the backs of some animals.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the backbone base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      }
     ],
     "explanation": "A backbone is the row of bones that supports the back.",
     "listId": "extra-science-word-building",
@@ -9914,8 +10208,8 @@ export const WORDS = [
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "backbone",
-      "skeleton"
+      "skeleton",
+      "skeletal"
     ],
     "sentence": "The skeleton protects important organs.",
     "sentences": [
@@ -9923,6 +10217,26 @@ export const WORDS = [
     ],
     "accepted": [
       "skeleton"
+    ],
+    "variants": [
+      {
+        "word": "skeletal",
+        "sentence": "The diagram showed the skeletal system clearly.",
+        "sentences": [
+          "The diagram showed the skeletal system clearly."
+        ],
+        "accepted": [
+          "skeletal"
+        ],
+        "explanation": "Skeletal means connected with the skeleton or bones.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the skeleton base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      }
     ],
     "explanation": "A skeleton is the frame of bones that supports a body.",
     "listId": "extra-science-word-building",
@@ -9949,12 +10263,7 @@ export const WORDS = [
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "cold-blooded",
-      "amphibians",
-      "reptiles",
-      "mammals",
-      "arachnid",
-      "mollusc"
+      "cold-blooded"
     ],
     "sentence": "A cold-blooded reptile warms itself on a rock.",
     "sentences": [
@@ -9989,12 +10298,8 @@ export const WORDS = [
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "cold-blooded",
       "amphibians",
-      "reptiles",
-      "mammals",
-      "arachnid",
-      "mollusc"
+      "amphibian"
     ],
     "sentence": "Many amphibians begin life in water as tadpoles.",
     "sentences": [
@@ -10002,6 +10307,26 @@ export const WORDS = [
     ],
     "accepted": [
       "amphibians"
+    ],
+    "variants": [
+      {
+        "word": "amphibian",
+        "sentence": "A frog is an amphibian with moist skin.",
+        "sentences": [
+          "A frog is an amphibian with moist skin."
+        ],
+        "accepted": [
+          "amphibian"
+        ],
+        "explanation": "An amphibian is an animal that can live in water and on land.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the amphibians base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      }
     ],
     "explanation": "Amphibians are animals such as frogs that can live in water and on land.",
     "listId": "extra-science-word-building",
@@ -10028,7 +10353,8 @@ export const WORDS = [
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "metamorphosis"
+      "metamorphosis",
+      "metamorphose"
     ],
     "sentence": "A butterfly goes through metamorphosis before it can fly.",
     "sentences": [
@@ -10036,6 +10362,26 @@ export const WORDS = [
     ],
     "accepted": [
       "metamorphosis"
+    ],
+    "variants": [
+      {
+        "word": "metamorphose",
+        "sentence": "Some insects metamorphose before they can fly.",
+        "sentences": [
+          "Some insects metamorphose before they can fly."
+        ],
+        "accepted": [
+          "metamorphose"
+        ],
+        "explanation": "To metamorphose is to change into a very different adult form.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the metamorphosis base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      }
     ],
     "explanation": "Metamorphosis is a major change in body form as an animal grows.",
     "listId": "extra-science-word-building",
@@ -10062,12 +10408,8 @@ export const WORDS = [
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "cold-blooded",
-      "amphibians",
       "reptiles",
-      "mammals",
-      "arachnid",
-      "mollusc"
+      "reptile"
     ],
     "sentence": "Reptiles often lay eggs on land.",
     "sentences": [
@@ -10075,6 +10417,26 @@ export const WORDS = [
     ],
     "accepted": [
       "reptiles"
+    ],
+    "variants": [
+      {
+        "word": "reptile",
+        "sentence": "A lizard is a reptile that warms itself in sunlight.",
+        "sentences": [
+          "A lizard is a reptile that warms itself in sunlight."
+        ],
+        "accepted": [
+          "reptile"
+        ],
+        "explanation": "A reptile is a cold-blooded animal with dry scales.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the reptiles base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      }
     ],
     "explanation": "Reptiles are cold-blooded animals with dry scales, such as lizards and snakes.",
     "listId": "extra-science-word-building",
@@ -10101,12 +10463,8 @@ export const WORDS = [
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "cold-blooded",
-      "amphibians",
-      "reptiles",
       "mammals",
-      "arachnid",
-      "mollusc"
+      "mammal"
     ],
     "sentence": "Dolphins and bats are both mammals.",
     "sentences": [
@@ -10114,6 +10472,26 @@ export const WORDS = [
     ],
     "accepted": [
       "mammals"
+    ],
+    "variants": [
+      {
+        "word": "mammal",
+        "sentence": "A whale is a mammal even though it lives in the sea.",
+        "sentences": [
+          "A whale is a mammal even though it lives in the sea."
+        ],
+        "accepted": [
+          "mammal"
+        ],
+        "explanation": "A mammal is a warm-blooded animal that usually feeds its young milk.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the mammals base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      }
     ],
     "explanation": "Mammals are warm-blooded animals that usually have hair or fur and feed their young milk.",
     "listId": "extra-science-word-building",
@@ -10140,12 +10518,8 @@ export const WORDS = [
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "cold-blooded",
-      "amphibians",
-      "reptiles",
-      "mammals",
       "arachnid",
-      "mollusc"
+      "arachnids"
     ],
     "sentence": "A spider is an arachnid, not an insect.",
     "sentences": [
@@ -10153,6 +10527,26 @@ export const WORDS = [
     ],
     "accepted": [
       "arachnid"
+    ],
+    "variants": [
+      {
+        "word": "arachnids",
+        "sentence": "Spiders and scorpions are arachnids.",
+        "sentences": [
+          "Spiders and scorpions are arachnids."
+        ],
+        "accepted": [
+          "arachnids"
+        ],
+        "explanation": "Arachnids are animals with eight legs, such as spiders and scorpions.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the arachnid base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      }
     ],
     "explanation": "An arachnid is an animal with eight legs, such as a spider or scorpion.",
     "listId": "extra-science-word-building",
@@ -10179,12 +10573,8 @@ export const WORDS = [
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "cold-blooded",
-      "amphibians",
-      "reptiles",
-      "mammals",
-      "arachnid",
-      "mollusc"
+      "mollusc",
+      "molluscs"
     ],
     "sentence": "A snail is a mollusc with a coiled shell.",
     "sentences": [
@@ -10192,6 +10582,26 @@ export const WORDS = [
     ],
     "accepted": [
       "mollusc"
+    ],
+    "variants": [
+      {
+        "word": "molluscs",
+        "sentence": "Snails and clams are molluscs.",
+        "sentences": [
+          "Snails and clams are molluscs."
+        ],
+        "accepted": [
+          "molluscs"
+        ],
+        "explanation": "Molluscs are soft-bodied animals, often with shells.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the mollusc base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      }
     ],
     "explanation": "A mollusc is a soft-bodied animal, often with a shell.",
     "listId": "extra-science-word-building",
@@ -10219,7 +10629,8 @@ export const WORDS = [
     "yearLabel": "Extra",
     "familyWords": [
       "botanist",
-      "flowering"
+      "botany",
+      "botanical"
     ],
     "sentence": "The botanist examined the leaves carefully.",
     "sentences": [
@@ -10227,6 +10638,44 @@ export const WORDS = [
     ],
     "accepted": [
       "botanist"
+    ],
+    "variants": [
+      {
+        "word": "botany",
+        "sentence": "Botany helped the class understand plant growth.",
+        "sentences": [
+          "Botany helped the class understand plant growth."
+        ],
+        "accepted": [
+          "botany"
+        ],
+        "explanation": "Botany is the scientific study of plants.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the botanist base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      },
+      {
+        "word": "botanical",
+        "sentence": "The botanical garden displayed unusual flowers.",
+        "sentences": [
+          "The botanical garden displayed unusual flowers."
+        ],
+        "accepted": [
+          "botanical"
+        ],
+        "explanation": "Botanical means connected with plants or the study of plants.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the botanist base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 2
+      }
     ],
     "explanation": "A botanist is a scientist who studies plants.",
     "listId": "extra-science-word-building",
@@ -10252,8 +10701,9 @@ export const WORDS = [
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "botanist",
-      "flowering"
+      "flowering",
+      "flowered",
+      "flowers"
     ],
     "sentence": "The flowering plant attracted several bees.",
     "sentences": [
@@ -10261,6 +10711,44 @@ export const WORDS = [
     ],
     "accepted": [
       "flowering"
+    ],
+    "variants": [
+      {
+        "word": "flowered",
+        "sentence": "The plant flowered after several warm days.",
+        "sentences": [
+          "The plant flowered after several warm days."
+        ],
+        "accepted": [
+          "flowered"
+        ],
+        "explanation": "Flowered means produced flowers or decorated with flowers.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the flowering base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      },
+      {
+        "word": "flowers",
+        "sentence": "The flowers attracted several bees.",
+        "sentences": [
+          "The flowers attracted several bees."
+        ],
+        "accepted": [
+          "flowers"
+        ],
+        "explanation": "Flowers are the parts of plants that often make seeds.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the flowering base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 2
+      }
     ],
     "explanation": "Flowering means producing flowers.",
     "listId": "extra-science-word-building",
@@ -19692,15 +20180,8 @@ export const WORD_BY_SLUG = {
     "yearLabel": "Extra",
     "familyWords": [
       "divide",
-      "collide",
-      "explode",
-      "corrode",
-      "conclude",
-      "extend",
-      "comprehend",
-      "evade",
-      "intrude",
-      "interlude"
+      "division",
+      "divisible"
     ],
     "sentence": "We divide the class into teams before the investigation.",
     "sentences": [
@@ -19708,6 +20189,44 @@ export const WORD_BY_SLUG = {
     ],
     "accepted": [
       "divide"
+    ],
+    "variants": [
+      {
+        "word": "division",
+        "sentence": "The division of the class into teams was fair.",
+        "sentences": [
+          "The division of the class into teams was fair."
+        ],
+        "accepted": [
+          "division"
+        ],
+        "explanation": "Division is the act of splitting something into parts or groups.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the divide base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      },
+      {
+        "word": "divisible",
+        "sentence": "Twenty is divisible by five.",
+        "sentences": [
+          "Twenty is divisible by five."
+        ],
+        "accepted": [
+          "divisible"
+        ],
+        "explanation": "Divisible means able to be divided exactly by a number.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the divide base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 2
+      }
     ],
     "explanation": "To divide is to split something into parts or groups.",
     "listId": "extra-science-word-building",
@@ -19734,16 +20253,8 @@ export const WORD_BY_SLUG = {
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "divide",
       "collide",
-      "explode",
-      "corrode",
-      "conclude",
-      "extend",
-      "comprehend",
-      "evade",
-      "intrude",
-      "interlude"
+      "collision"
     ],
     "sentence": "The two balls collide in the middle of the table.",
     "sentences": [
@@ -19751,6 +20262,26 @@ export const WORD_BY_SLUG = {
     ],
     "accepted": [
       "collide"
+    ],
+    "variants": [
+      {
+        "word": "collision",
+        "sentence": "The collision made both balls change direction.",
+        "sentences": [
+          "The collision made both balls change direction."
+        ],
+        "accepted": [
+          "collision"
+        ],
+        "explanation": "A collision is a crash or strong hit between moving things.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the collide base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      }
     ],
     "explanation": "To collide is to crash into something or hit it while moving.",
     "listId": "extra-science-word-building",
@@ -19777,16 +20308,9 @@ export const WORD_BY_SLUG = {
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "divide",
-      "collide",
       "explode",
-      "corrode",
-      "conclude",
-      "extend",
-      "comprehend",
-      "evade",
-      "intrude",
-      "interlude"
+      "explosion",
+      "explosive"
     ],
     "sentence": "The volcano model did not explode until the final step.",
     "sentences": [
@@ -19794,6 +20318,44 @@ export const WORD_BY_SLUG = {
     ],
     "accepted": [
       "explode"
+    ],
+    "variants": [
+      {
+        "word": "explosion",
+        "sentence": "The experiment caused a safe foam explosion.",
+        "sentences": [
+          "The experiment caused a safe foam explosion."
+        ],
+        "accepted": [
+          "explosion"
+        ],
+        "explanation": "An explosion is a sudden burst with force, noise or energy.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the explode base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      },
+      {
+        "word": "explosive",
+        "sentence": "The explosive reaction was controlled by the teacher.",
+        "sentences": [
+          "The explosive reaction was controlled by the teacher."
+        ],
+        "accepted": [
+          "explosive"
+        ],
+        "explanation": "Explosive means able to burst apart suddenly with force.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the explode base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 2
+      }
     ],
     "explanation": "To explode is to burst apart suddenly with force.",
     "listId": "extra-science-word-building",
@@ -19820,16 +20382,9 @@ export const WORD_BY_SLUG = {
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "divide",
-      "collide",
-      "explode",
       "corrode",
-      "conclude",
-      "extend",
-      "comprehend",
-      "evade",
-      "intrude",
-      "interlude"
+      "corrosion",
+      "corrosive"
     ],
     "sentence": "Salt water can corrode metal over time.",
     "sentences": [
@@ -19837,6 +20392,44 @@ export const WORD_BY_SLUG = {
     ],
     "accepted": [
       "corrode"
+    ],
+    "variants": [
+      {
+        "word": "corrosion",
+        "sentence": "Corrosion weakened the old metal gate.",
+        "sentences": [
+          "Corrosion weakened the old metal gate."
+        ],
+        "accepted": [
+          "corrosion"
+        ],
+        "explanation": "Corrosion is the slow damage caused by a chemical reaction, often rust.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the corrode base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      },
+      {
+        "word": "corrosive",
+        "sentence": "The corrosive liquid was handled with care.",
+        "sentences": [
+          "The corrosive liquid was handled with care."
+        ],
+        "accepted": [
+          "corrosive"
+        ],
+        "explanation": "Corrosive means able to slowly damage a material by chemical action.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the corrode base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 2
+      }
     ],
     "explanation": "To corrode is to be slowly damaged by a chemical reaction, often rust.",
     "listId": "extra-science-word-building",
@@ -19863,16 +20456,8 @@ export const WORD_BY_SLUG = {
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "divide",
-      "collide",
-      "explode",
-      "corrode",
       "conclude",
-      "extend",
-      "comprehend",
-      "evade",
-      "intrude",
-      "interlude"
+      "conclusion"
     ],
     "sentence": "We conclude that shade slows the melting ice.",
     "sentences": [
@@ -19880,6 +20465,26 @@ export const WORD_BY_SLUG = {
     ],
     "accepted": [
       "conclude"
+    ],
+    "variants": [
+      {
+        "word": "conclusion",
+        "sentence": "Her conclusion matched the evidence from the test.",
+        "sentences": [
+          "Her conclusion matched the evidence from the test."
+        ],
+        "accepted": [
+          "conclusion"
+        ],
+        "explanation": "A conclusion is the final decision or ending reached after thinking.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the conclude base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      }
     ],
     "explanation": "To conclude is to finish, or to decide after thinking about evidence.",
     "listId": "extra-science-word-building",
@@ -19906,16 +20511,9 @@ export const WORD_BY_SLUG = {
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "divide",
-      "collide",
-      "explode",
-      "corrode",
-      "conclude",
       "extend",
-      "comprehend",
-      "evade",
-      "intrude",
-      "interlude"
+      "extension",
+      "extended"
     ],
     "sentence": "The bridge can extend across the stream.",
     "sentences": [
@@ -19923,6 +20521,44 @@ export const WORD_BY_SLUG = {
     ],
     "accepted": [
       "extend"
+    ],
+    "variants": [
+      {
+        "word": "extension",
+        "sentence": "The bridge extension reached the other bank.",
+        "sentences": [
+          "The bridge extension reached the other bank."
+        ],
+        "accepted": [
+          "extension"
+        ],
+        "explanation": "An extension is an added part or an increase in length or time.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the extend base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      },
+      {
+        "word": "extended",
+        "sentence": "The extended table gave everyone space.",
+        "sentences": [
+          "The extended table gave everyone space."
+        ],
+        "accepted": [
+          "extended"
+        ],
+        "explanation": "Extended means made longer or lasting for more time.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the extend base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 2
+      }
     ],
     "explanation": "To extend is to make something longer or reach further.",
     "listId": "extra-science-word-building",
@@ -19949,16 +20585,8 @@ export const WORD_BY_SLUG = {
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "divide",
-      "collide",
-      "explode",
-      "corrode",
-      "conclude",
-      "extend",
       "comprehend",
-      "evade",
-      "intrude",
-      "interlude"
+      "comprehension"
     ],
     "sentence": "She could comprehend the instructions after reading them twice.",
     "sentences": [
@@ -19966,6 +20594,26 @@ export const WORD_BY_SLUG = {
     ],
     "accepted": [
       "comprehend"
+    ],
+    "variants": [
+      {
+        "word": "comprehension",
+        "sentence": "Good comprehension helped her answer the questions.",
+        "sentences": [
+          "Good comprehension helped her answer the questions."
+        ],
+        "accepted": [
+          "comprehension"
+        ],
+        "explanation": "Comprehension is the ability to understand something.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the comprehend base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      }
     ],
     "explanation": "To comprehend is to understand something fully.",
     "listId": "extra-science-word-building",
@@ -19992,16 +20640,9 @@ export const WORD_BY_SLUG = {
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "divide",
-      "collide",
-      "explode",
-      "corrode",
-      "conclude",
-      "extend",
-      "comprehend",
       "evade",
-      "intrude",
-      "interlude"
+      "evasion",
+      "evasive"
     ],
     "sentence": "The beetle tried to evade the torchlight under a leaf.",
     "sentences": [
@@ -20009,6 +20650,44 @@ export const WORD_BY_SLUG = {
     ],
     "accepted": [
       "evade"
+    ],
+    "variants": [
+      {
+        "word": "evasion",
+        "sentence": "The quick evasion helped the player dodge the tackle.",
+        "sentences": [
+          "The quick evasion helped the player dodge the tackle."
+        ],
+        "accepted": [
+          "evasion"
+        ],
+        "explanation": "Evasion is the act of avoiding or escaping something.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the evade base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      },
+      {
+        "word": "evasive",
+        "sentence": "His evasive answer did not explain the mistake.",
+        "sentences": [
+          "His evasive answer did not explain the mistake."
+        ],
+        "accepted": [
+          "evasive"
+        ],
+        "explanation": "Evasive means trying to avoid something or not answer directly.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the evade base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 2
+      }
     ],
     "explanation": "To evade is to avoid or escape from someone or something.",
     "listId": "extra-science-word-building",
@@ -20035,16 +20714,9 @@ export const WORD_BY_SLUG = {
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "divide",
-      "collide",
-      "explode",
-      "corrode",
-      "conclude",
-      "extend",
-      "comprehend",
-      "evade",
       "intrude",
-      "interlude"
+      "intrusion",
+      "intrusive"
     ],
     "sentence": "Please do not intrude while the group is recording.",
     "sentences": [
@@ -20052,6 +20724,44 @@ export const WORD_BY_SLUG = {
     ],
     "accepted": [
       "intrude"
+    ],
+    "variants": [
+      {
+        "word": "intrusion",
+        "sentence": "The loud noise was an intrusion during the recording.",
+        "sentences": [
+          "The loud noise was an intrusion during the recording."
+        ],
+        "accepted": [
+          "intrusion"
+        ],
+        "explanation": "An intrusion is an unwanted entry or interruption.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the intrude base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      },
+      {
+        "word": "intrusive",
+        "sentence": "The intrusive sound disturbed the quiet lesson.",
+        "sentences": [
+          "The intrusive sound disturbed the quiet lesson."
+        ],
+        "accepted": [
+          "intrusive"
+        ],
+        "explanation": "Intrusive means entering or interrupting where it is not wanted.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the intrude base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 2
+      }
     ],
     "explanation": "To intrude is to enter or join in where you are not wanted.",
     "listId": "extra-science-word-building",
@@ -20078,16 +20788,8 @@ export const WORD_BY_SLUG = {
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "divide",
-      "collide",
-      "explode",
-      "corrode",
-      "conclude",
-      "extend",
-      "comprehend",
-      "evade",
-      "intrude",
-      "interlude"
+      "interlude",
+      "interludes"
     ],
     "sentence": "A quiet interlude gave the performers time to reset.",
     "sentences": [
@@ -20095,6 +20797,26 @@ export const WORD_BY_SLUG = {
     ],
     "accepted": [
       "interlude"
+    ],
+    "variants": [
+      {
+        "word": "interludes",
+        "sentence": "The play had two short interludes.",
+        "sentences": [
+          "The play had two short interludes."
+        ],
+        "accepted": [
+          "interludes"
+        ],
+        "explanation": "Interludes are short pauses or breaks between parts of something.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the interlude base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      }
     ],
     "explanation": "An interlude is a short pause or break between parts of something.",
     "listId": "extra-science-word-building",
@@ -20121,7 +20843,9 @@ export const WORD_BY_SLUG = {
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "classification"
+      "classification",
+      "classify",
+      "classified"
     ],
     "sentence": "Classification helps scientists compare animals with similar features.",
     "sentences": [
@@ -20129,6 +20853,44 @@ export const WORD_BY_SLUG = {
     ],
     "accepted": [
       "classification"
+    ],
+    "variants": [
+      {
+        "word": "classify",
+        "sentence": "Scientists classify living things by their features.",
+        "sentences": [
+          "Scientists classify living things by their features."
+        ],
+        "accepted": [
+          "classify"
+        ],
+        "explanation": "To classify is to sort things into groups by shared features.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the classification base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      },
+      {
+        "word": "classified",
+        "sentence": "The leaves were classified by shape and size.",
+        "sentences": [
+          "The leaves were classified by shape and size."
+        ],
+        "accepted": [
+          "classified"
+        ],
+        "explanation": "Classified means sorted into groups by type or feature.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the classification base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 2
+      }
     ],
     "explanation": "Classification is sorting living things or objects into groups by shared features.",
     "listId": "extra-science-word-building",
@@ -20155,7 +20917,7 @@ export const WORD_BY_SLUG = {
     "yearLabel": "Extra",
     "familyWords": [
       "backbone",
-      "skeleton"
+      "backbones"
     ],
     "sentence": "A fish has a backbone inside its body.",
     "sentences": [
@@ -20163,6 +20925,26 @@ export const WORD_BY_SLUG = {
     ],
     "accepted": [
       "backbone"
+    ],
+    "variants": [
+      {
+        "word": "backbones",
+        "sentence": "The model showed how backbones protect the spinal cord.",
+        "sentences": [
+          "The model showed how backbones protect the spinal cord."
+        ],
+        "accepted": [
+          "backbones"
+        ],
+        "explanation": "Backbones are rows of bones that support the backs of some animals.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the backbone base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      }
     ],
     "explanation": "A backbone is the row of bones that supports the back.",
     "listId": "extra-science-word-building",
@@ -20189,8 +20971,8 @@ export const WORD_BY_SLUG = {
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "backbone",
-      "skeleton"
+      "skeleton",
+      "skeletal"
     ],
     "sentence": "The skeleton protects important organs.",
     "sentences": [
@@ -20198,6 +20980,26 @@ export const WORD_BY_SLUG = {
     ],
     "accepted": [
       "skeleton"
+    ],
+    "variants": [
+      {
+        "word": "skeletal",
+        "sentence": "The diagram showed the skeletal system clearly.",
+        "sentences": [
+          "The diagram showed the skeletal system clearly."
+        ],
+        "accepted": [
+          "skeletal"
+        ],
+        "explanation": "Skeletal means connected with the skeleton or bones.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the skeleton base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      }
     ],
     "explanation": "A skeleton is the frame of bones that supports a body.",
     "listId": "extra-science-word-building",
@@ -20224,12 +21026,7 @@ export const WORD_BY_SLUG = {
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "cold-blooded",
-      "amphibians",
-      "reptiles",
-      "mammals",
-      "arachnid",
-      "mollusc"
+      "cold-blooded"
     ],
     "sentence": "A cold-blooded reptile warms itself on a rock.",
     "sentences": [
@@ -20264,12 +21061,8 @@ export const WORD_BY_SLUG = {
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "cold-blooded",
       "amphibians",
-      "reptiles",
-      "mammals",
-      "arachnid",
-      "mollusc"
+      "amphibian"
     ],
     "sentence": "Many amphibians begin life in water as tadpoles.",
     "sentences": [
@@ -20277,6 +21070,26 @@ export const WORD_BY_SLUG = {
     ],
     "accepted": [
       "amphibians"
+    ],
+    "variants": [
+      {
+        "word": "amphibian",
+        "sentence": "A frog is an amphibian with moist skin.",
+        "sentences": [
+          "A frog is an amphibian with moist skin."
+        ],
+        "accepted": [
+          "amphibian"
+        ],
+        "explanation": "An amphibian is an animal that can live in water and on land.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the amphibians base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      }
     ],
     "explanation": "Amphibians are animals such as frogs that can live in water and on land.",
     "listId": "extra-science-word-building",
@@ -20303,7 +21116,8 @@ export const WORD_BY_SLUG = {
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "metamorphosis"
+      "metamorphosis",
+      "metamorphose"
     ],
     "sentence": "A butterfly goes through metamorphosis before it can fly.",
     "sentences": [
@@ -20311,6 +21125,26 @@ export const WORD_BY_SLUG = {
     ],
     "accepted": [
       "metamorphosis"
+    ],
+    "variants": [
+      {
+        "word": "metamorphose",
+        "sentence": "Some insects metamorphose before they can fly.",
+        "sentences": [
+          "Some insects metamorphose before they can fly."
+        ],
+        "accepted": [
+          "metamorphose"
+        ],
+        "explanation": "To metamorphose is to change into a very different adult form.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the metamorphosis base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      }
     ],
     "explanation": "Metamorphosis is a major change in body form as an animal grows.",
     "listId": "extra-science-word-building",
@@ -20337,12 +21171,8 @@ export const WORD_BY_SLUG = {
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "cold-blooded",
-      "amphibians",
       "reptiles",
-      "mammals",
-      "arachnid",
-      "mollusc"
+      "reptile"
     ],
     "sentence": "Reptiles often lay eggs on land.",
     "sentences": [
@@ -20350,6 +21180,26 @@ export const WORD_BY_SLUG = {
     ],
     "accepted": [
       "reptiles"
+    ],
+    "variants": [
+      {
+        "word": "reptile",
+        "sentence": "A lizard is a reptile that warms itself in sunlight.",
+        "sentences": [
+          "A lizard is a reptile that warms itself in sunlight."
+        ],
+        "accepted": [
+          "reptile"
+        ],
+        "explanation": "A reptile is a cold-blooded animal with dry scales.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the reptiles base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      }
     ],
     "explanation": "Reptiles are cold-blooded animals with dry scales, such as lizards and snakes.",
     "listId": "extra-science-word-building",
@@ -20376,12 +21226,8 @@ export const WORD_BY_SLUG = {
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "cold-blooded",
-      "amphibians",
-      "reptiles",
       "mammals",
-      "arachnid",
-      "mollusc"
+      "mammal"
     ],
     "sentence": "Dolphins and bats are both mammals.",
     "sentences": [
@@ -20389,6 +21235,26 @@ export const WORD_BY_SLUG = {
     ],
     "accepted": [
       "mammals"
+    ],
+    "variants": [
+      {
+        "word": "mammal",
+        "sentence": "A whale is a mammal even though it lives in the sea.",
+        "sentences": [
+          "A whale is a mammal even though it lives in the sea."
+        ],
+        "accepted": [
+          "mammal"
+        ],
+        "explanation": "A mammal is a warm-blooded animal that usually feeds its young milk.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the mammals base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      }
     ],
     "explanation": "Mammals are warm-blooded animals that usually have hair or fur and feed their young milk.",
     "listId": "extra-science-word-building",
@@ -20415,12 +21281,8 @@ export const WORD_BY_SLUG = {
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "cold-blooded",
-      "amphibians",
-      "reptiles",
-      "mammals",
       "arachnid",
-      "mollusc"
+      "arachnids"
     ],
     "sentence": "A spider is an arachnid, not an insect.",
     "sentences": [
@@ -20428,6 +21290,26 @@ export const WORD_BY_SLUG = {
     ],
     "accepted": [
       "arachnid"
+    ],
+    "variants": [
+      {
+        "word": "arachnids",
+        "sentence": "Spiders and scorpions are arachnids.",
+        "sentences": [
+          "Spiders and scorpions are arachnids."
+        ],
+        "accepted": [
+          "arachnids"
+        ],
+        "explanation": "Arachnids are animals with eight legs, such as spiders and scorpions.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the arachnid base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      }
     ],
     "explanation": "An arachnid is an animal with eight legs, such as a spider or scorpion.",
     "listId": "extra-science-word-building",
@@ -20454,12 +21336,8 @@ export const WORD_BY_SLUG = {
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "cold-blooded",
-      "amphibians",
-      "reptiles",
-      "mammals",
-      "arachnid",
-      "mollusc"
+      "mollusc",
+      "molluscs"
     ],
     "sentence": "A snail is a mollusc with a coiled shell.",
     "sentences": [
@@ -20467,6 +21345,26 @@ export const WORD_BY_SLUG = {
     ],
     "accepted": [
       "mollusc"
+    ],
+    "variants": [
+      {
+        "word": "molluscs",
+        "sentence": "Snails and clams are molluscs.",
+        "sentences": [
+          "Snails and clams are molluscs."
+        ],
+        "accepted": [
+          "molluscs"
+        ],
+        "explanation": "Molluscs are soft-bodied animals, often with shells.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the mollusc base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      }
     ],
     "explanation": "A mollusc is a soft-bodied animal, often with a shell.",
     "listId": "extra-science-word-building",
@@ -20494,7 +21392,8 @@ export const WORD_BY_SLUG = {
     "yearLabel": "Extra",
     "familyWords": [
       "botanist",
-      "flowering"
+      "botany",
+      "botanical"
     ],
     "sentence": "The botanist examined the leaves carefully.",
     "sentences": [
@@ -20502,6 +21401,44 @@ export const WORD_BY_SLUG = {
     ],
     "accepted": [
       "botanist"
+    ],
+    "variants": [
+      {
+        "word": "botany",
+        "sentence": "Botany helped the class understand plant growth.",
+        "sentences": [
+          "Botany helped the class understand plant growth."
+        ],
+        "accepted": [
+          "botany"
+        ],
+        "explanation": "Botany is the scientific study of plants.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the botanist base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      },
+      {
+        "word": "botanical",
+        "sentence": "The botanical garden displayed unusual flowers.",
+        "sentences": [
+          "The botanical garden displayed unusual flowers."
+        ],
+        "accepted": [
+          "botanical"
+        ],
+        "explanation": "Botanical means connected with plants or the study of plants.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the botanist base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 2
+      }
     ],
     "explanation": "A botanist is a scientist who studies plants.",
     "listId": "extra-science-word-building",
@@ -20527,8 +21464,9 @@ export const WORD_BY_SLUG = {
     "spellingPool": "extra",
     "yearLabel": "Extra",
     "familyWords": [
-      "botanist",
-      "flowering"
+      "flowering",
+      "flowered",
+      "flowers"
     ],
     "sentence": "The flowering plant attracted several bees.",
     "sentences": [
@@ -20536,6 +21474,44 @@ export const WORD_BY_SLUG = {
     ],
     "accepted": [
       "flowering"
+    ],
+    "variants": [
+      {
+        "word": "flowered",
+        "sentence": "The plant flowered after several warm days.",
+        "sentences": [
+          "The plant flowered after several warm days."
+        ],
+        "accepted": [
+          "flowered"
+        ],
+        "explanation": "Flowered means produced flowers or decorated with flowers.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the flowering base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 1
+      },
+      {
+        "word": "flowers",
+        "sentence": "The flowers attracted several bees.",
+        "sentences": [
+          "The flowers attracted several bees."
+        ],
+        "accepted": [
+          "flowers"
+        ],
+        "explanation": "Flowers are the parts of plants that often make seeds.",
+        "sourceNote": "Added as an Extra word-family variant on 23 April 2026.",
+        "provenance": {
+          "source": "James Extra spelling family extension",
+          "note": "Variant prompt for the flowering base word family.",
+          "importedAt": 1776902400000
+        },
+        "sortIndex": 2
+      }
     ],
     "explanation": "Flowering means producing flowers.",
     "listId": "extra-science-word-building",

--- a/src/subjects/spelling/engine/legacy-engine.js
+++ b/src/subjects/spelling/engine/legacy-engine.js
@@ -113,6 +113,64 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
         var interval = STAGE_INTERVALS[Math.min(stage, STAGE_INTERVALS.length - 1)];
         return "Next review in " + interval + " day" + (interval === 1 ? "" : "s");
       }
+
+      function promptAccepted(value, fallback) {
+        var accepted = Array.isArray(value) && value.length ? value.slice() : [fallback];
+        return accepted.map(function (entry) { return normalize(entry); }).filter(Boolean);
+      }
+
+      function basePromptForm(word) {
+        return {
+          slug: word.slug,
+          promptKey: word.slug,
+          word: word.word,
+          accepted: promptAccepted(word.accepted, word.slug),
+          sentence: word.sentence,
+          sentences: Array.isArray(word.sentences) ? word.sentences.slice() : [],
+          explanation: word.explanation || "",
+        };
+      }
+
+      function promptFormsForWord(word) {
+        var forms = [basePromptForm(word)];
+        if (spellingPoolForWord(word) !== "extra") return forms;
+        if (!Array.isArray(word.variants)) return forms;
+        for (var i = 0; i < word.variants.length; i++) {
+          var variant = word.variants[i];
+          if (!variant || !variant.word) continue;
+          forms.push({
+            slug: word.slug,
+            promptKey: word.slug + "::" + normalize(variant.word),
+            word: variant.word,
+            accepted: promptAccepted(variant.accepted, variant.word),
+            sentence: variant.sentence,
+            sentences: Array.isArray(variant.sentences) ? variant.sentences.slice() : [],
+            explanation: variant.explanation || word.explanation || "",
+          });
+        }
+        return forms;
+      }
+
+      function choosePromptForm(session, word) {
+        if (!session || !session.extraWordFamilies) return basePromptForm(word);
+        var forms = promptFormsForWord(word);
+        if (forms.length <= 1) return forms[0];
+        return forms[Math.floor(Math.random() * forms.length)] || forms[0];
+      }
+
+      function wordForCurrentPrompt(session) {
+        var word = WORD_BY_SLUG[session && session.currentSlug];
+        if (!word) return null;
+        var prompt = session.currentPrompt || {};
+        if (!prompt.word) return word;
+        return Object.assign({}, word, {
+          word: prompt.word,
+          accepted: promptAccepted(prompt.accepted, prompt.word),
+          sentence: prompt.sentence || word.sentence,
+          sentences: prompt.sentence ? [prompt.sentence] : word.sentences,
+          explanation: prompt.explanation || word.explanation || "",
+        });
+      }
     
       // ----- progress persistence (profile-scoped per plan) ---------------------
     
@@ -317,14 +375,15 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
         var sentences = (word.sentences && word.sentences.length) ? word.sentences : [word.sentence].filter(Boolean);
         if (!session || !session.sentenceHistory || !sentences.length) return null;
     
-        var history = session.sentenceHistory[word.slug];
+        var historyKey = word.promptKey || word.slug;
+        var history = session.sentenceHistory[historyKey];
         if (!history || !Array.isArray(history.remaining) || !history.remaining.length) {
           var lastIndex = (history && Number.isInteger(history.lastIndex)) ? history.lastIndex : null;
           history = {
             remaining: shuffledSentenceOrder(sentences.length, lastIndex),
             lastIndex: lastIndex,
           };
-          session.sentenceHistory[word.slug] = history;
+          session.sentenceHistory[historyKey] = history;
         }
         return history;
       }
@@ -340,7 +399,7 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
         var history = getOrCreateSentenceHistory(session, word);
         var nextIndex = history.remaining.shift();
         history.lastIndex = nextIndex;
-        session.sentenceHistory[word.slug] = history;
+        session.sentenceHistory[word.promptKey || word.slug] = history;
         return sentences[nextIndex];
       }
     
@@ -410,6 +469,7 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
         }
     
         var practiceOnly = Boolean(options.practiceOnly && actualMode !== MODES.TEST);
+        var extraWordFamilies = Boolean(options.extraWordFamilies && actualMode !== MODES.TEST && yearFilter === "extra");
     
         var session = {
           id: makeSessionId(),
@@ -422,6 +482,7 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
               : "Smart review",
           practiceOnly: practiceOnly,
           fallbackToSmart: fallback,
+          extraWordFamilies: extraWordFamilies,
           profileId: profileId,
           uniqueWords: selected.map(function (w) { return w.slug; }),
           queue: selected.map(function (w) { return w.slug; }),
@@ -486,12 +547,16 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
         if (!session) return null;
         var word = WORD_BY_SLUG[slug];
         if (!word) return null;
-        var sentence = choosePromptSentence(session, word);
+        var promptWord = choosePromptForm(session, word);
+        var sentence = choosePromptSentence(session, promptWord);
         session.currentSlug = slug;
         session.currentPrompt = {
           slug: slug,
+          word: promptWord.word,
+          accepted: promptWord.accepted.slice(),
+          explanation: promptWord.explanation || word.explanation || "",
           sentence: sentence,
-          cloze: buildCloze(sentence, word.word),
+          cloze: buildCloze(sentence, promptWord.word),
         };
         session.lastFamily = word.family;
         session.lastYear = word.year;
@@ -508,7 +573,7 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
           if (!session.queue.length) return { done: true };
           var slug = session.queue.shift();
           setCurrentPrompt(session, slug);
-          return { done: false, slug: slug, word: WORD_BY_SLUG[slug], prompt: session.currentPrompt };
+          return { done: false, slug: slug, word: wordForCurrentPrompt(session), prompt: session.currentPrompt };
         }
     
         while (session.queue.length) {
@@ -519,7 +584,7 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
             return {
               done: false,
               slug: nextSlug,
-              word: WORD_BY_SLUG[nextSlug],
+              word: wordForCurrentPrompt(session),
               prompt: session.currentPrompt,
             };
           }
@@ -600,7 +665,7 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
       // Legacy parity: preview.html handleLearningSubmit (2713-2827).
       function submitLearning(session, profileId, typed) {
         if (!session || session.type !== "learning") return null;
-        var word = WORD_BY_SLUG[session.currentSlug];
+        var word = wordForCurrentPrompt(session);
         if (!word) return null;
         var info = session.status[word.slug];
         var typedRaw = String(typed == null ? "" : typed).trim();
@@ -740,7 +805,7 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
       // no phases, results recorded straight into session.results.
       function submitTest(session, profileId, typed) {
         if (!session || session.type !== "test") return null;
-        var word = WORD_BY_SLUG[session.currentSlug];
+        var word = wordForCurrentPrompt(session);
         if (!word) return null;
         var typedRaw = String(typed == null ? "" : typed).trim();
         var grade = gradeWord(word, typedRaw);

--- a/src/subjects/spelling/module.js
+++ b/src/subjects/spelling/module.js
@@ -135,6 +135,7 @@ export const spellingModule = {
         mode: prefs.mode,
         yearFilter: prefs.yearFilter,
         length: prefs.roundLength,
+        extraWordFamilies: prefs.extraWordFamilies,
       }));
     }
 
@@ -152,6 +153,7 @@ export const spellingModule = {
         mode: prefs.mode,
         yearFilter: prefs.yearFilter,
         length: prefs.roundLength,
+        extraWordFamilies: prefs.extraWordFamilies,
       }));
     }
 

--- a/src/subjects/spelling/read-model.js
+++ b/src/subjects/spelling/read-model.js
@@ -310,6 +310,7 @@ export function buildSpellingLearnerReadModel({
       mode: typeof prefs.mode === 'string' ? prefs.mode : 'smart',
       yearFilter: normaliseYearFilter(prefs.yearFilter, 'core'),
       roundLength: typeof prefs.roundLength === 'string' ? prefs.roundLength : '20',
+      extraWordFamilies: Boolean(prefs.extraWordFamilies),
     },
     currentFocus,
     progressSnapshot: {

--- a/src/subjects/spelling/service.js
+++ b/src/subjects/spelling/service.js
@@ -70,6 +70,57 @@ function buildCloze(sentence, word) {
   return String(sentence || '').replace(pattern, blanks);
 }
 
+function acceptedForPrompt(rawAccepted, fallback) {
+  const accepted = normaliseStringArray(rawAccepted);
+  const fallbackText = normaliseString(fallback);
+  if (fallbackText && !accepted.map((entry) => entry.toLowerCase()).includes(fallbackText.toLowerCase())) {
+    return [fallbackText, ...accepted];
+  }
+  return accepted.length ? accepted : (fallbackText ? [fallbackText] : []);
+}
+
+function normaliseWordVariants(variants) {
+  if (!Array.isArray(variants)) return [];
+  return variants
+    .map((variant) => {
+      if (!variant || typeof variant !== 'object' || Array.isArray(variant)) return null;
+      const word = normaliseString(variant.word);
+      if (!word) return null;
+      return {
+        word,
+        accepted: acceptedForPrompt(variant.accepted, word),
+        sentence: normaliseString(variant.sentence),
+        sentences: normaliseStringArray(variant.sentences),
+        explanation: normaliseString(variant.explanation),
+      };
+    })
+    .filter(Boolean);
+}
+
+function explanationForPrompt(baseWord, promptedWord, prompt = null) {
+  const promptExplanation = normaliseString(prompt?.explanation);
+  if (promptExplanation) return promptExplanation;
+  const target = normaliseString(promptedWord, baseWord?.word).toLowerCase();
+  const variants = normaliseWordVariants(baseWord?.variants);
+  const variant = variants.find((entry) => entry.word.toLowerCase() === target);
+  return variant?.explanation || baseWord?.explanation || '';
+}
+
+function wordForPrompt(baseWord, prompt = null) {
+  if (!baseWord) return null;
+  const promptedWord = normaliseString(prompt?.word, baseWord.word);
+  const sentence = normaliseString(prompt?.sentence, baseWord.sentence || '');
+  if (promptedWord === baseWord.word && !prompt?.accepted) return baseWord;
+  return {
+    ...baseWord,
+    word: promptedWord,
+    accepted: acceptedForPrompt(prompt?.accepted, promptedWord),
+    sentence,
+    sentences: sentence ? [sentence] : (Array.isArray(baseWord.sentences) ? [...baseWord.sentences] : []),
+    explanation: explanationForPrompt(baseWord, promptedWord, prompt),
+  };
+}
+
 function isKnownSlug(slug, wordBySlug = DEFAULT_WORD_BY_SLUG) {
   return typeof slug === 'string' && Boolean(wordBySlug[slug]);
 }
@@ -100,6 +151,7 @@ function normalisePrefs(rawPrefs = {}) {
     roundLength: normaliseRoundLength(rawPrefs.roundLength, mode),
     showCloze: normaliseBoolean(rawPrefs.showCloze, true),
     autoSpeak: normaliseBoolean(rawPrefs.autoSpeak, true),
+    extraWordFamilies: normaliseBoolean(rawPrefs.extraWordFamilies, false),
   };
 }
 
@@ -166,10 +218,18 @@ function buildPrompt(engine, session, slug, wordBySlug = DEFAULT_WORD_BY_SLUG) {
   const sentence = current?.slug === slug && typeof current.sentence === 'string'
     ? current.sentence
     : engine.peekPromptSentence(session, slug) || word.sentence || '';
+  const promptedWord = current?.slug === slug && typeof current.word === 'string' && current.word
+    ? current.word
+    : word.word;
   return {
     slug,
+    word: promptedWord,
+    accepted: acceptedForPrompt(current?.slug === slug && current.accepted ? current.accepted : word.accepted, promptedWord),
+    explanation: current?.slug === slug
+      ? explanationForPrompt(word, promptedWord, current)
+      : explanationForPrompt(word, promptedWord),
     sentence,
-    cloze: buildCloze(sentence, word.word),
+    cloze: buildCloze(sentence, promptedWord),
   };
 }
 
@@ -180,10 +240,14 @@ function normalisePromptForSlug(rawPrompt, slug, wordBySlug = DEFAULT_WORD_BY_SL
   if (typeof rawPrompt.sentence !== 'string') return null;
 
   const word = wordBySlug[slug];
+  const promptedWord = normaliseString(rawPrompt.word, word.word);
   return {
     slug,
+    word: promptedWord,
+    accepted: acceptedForPrompt(rawPrompt.accepted || word.accepted, promptedWord),
+    explanation: explanationForPrompt(word, promptedWord, rawPrompt),
     sentence: rawPrompt.sentence,
-    cloze: buildCloze(rawPrompt.sentence, word.word),
+    cloze: buildCloze(rawPrompt.sentence, promptedWord),
   };
 }
 
@@ -198,7 +262,7 @@ function decorateSession(engine, learnerId, session, wordBySlug = DEFAULT_WORD_B
   const currentCard = session.currentSlug && currentPrompt
     ? {
         slug: session.currentSlug,
-        word: wordBySlug[session.currentSlug] || null,
+        word: wordForPrompt(wordBySlug[session.currentSlug], currentPrompt),
         prompt: currentPrompt,
       }
     : null;
@@ -305,6 +369,7 @@ export function createSpellingService({ repository, storage, tts, now, random, c
       sentence: word.sentence || '',
       explanation: word.explanation || '',
       accepted: Array.isArray(word.accepted) ? [...word.accepted] : [word.slug],
+      variants: normaliseWordVariants(word.variants),
       status: engine.statusForWord(learnerId, word, statusProgressStore),
       stageLabel: engine.stageLabel(progress.stage),
       progress: {
@@ -385,6 +450,7 @@ export function createSpellingService({ repository, storage, tts, now, random, c
       label: normaliseString(raw.label, defaultLabelForMode(mode)),
       practiceOnly: normaliseBoolean(raw.practiceOnly, false) && type !== 'test',
       fallbackToSmart: normaliseBoolean(raw.fallbackToSmart, false),
+      extraWordFamilies: normaliseBoolean(raw.extraWordFamilies, false) && type !== 'test',
       profileId: normaliseString(raw.profileId, learnerId || 'default'),
       uniqueWords,
       queue: [],
@@ -589,6 +655,7 @@ export function createSpellingService({ repository, storage, tts, now, random, c
       length,
       words: selectedWords,
       practiceOnly,
+      extraWordFamilies: normaliseBoolean(options.extraWordFamilies, false) && yearFilter === 'extra',
     });
 
     if (!created.ok) {

--- a/styles/app.css
+++ b/styles/app.css
@@ -5478,6 +5478,25 @@ textarea:focus-visible {
   font-weight: 700;
 }
 
+.wb-variant-list {
+  display: grid;
+  gap: 12px;
+}
+
+.wb-variant-row {
+  display: grid;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid color-mix(in srgb, var(--brand) 22%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--panel) 86%, white 14%);
+}
+
+.wb-variant-word {
+  color: var(--brand-ink);
+  font-size: 1.08rem;
+}
+
 .wb-drill-sentence {
   font-family: var(--font-serif);
   font-size: 1.12rem;

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -143,11 +143,13 @@ test('spelling word bank opens from setup and exposes searchable progress with d
   assert.match(html, /aria-label="Spelling pool"/);
   assert.match(html, /value="core"[^>]*>\s*<span>Core<\/span>/);
   assert.match(html, /value="extra"[^>]*>\s*<span>Extra<\/span>/);
+  assert.doesNotMatch(html, /Word-family variants/);
   assert.doesNotMatch(html, />All<\/span>/);
 
   harness.dispatch('spelling-set-pref', { pref: 'yearFilter', value: 'extra' });
   html = harness.render();
   assert.match(html, /value="extra"[^>]*>\s*<span>Extra<\/span>/);
+  assert.match(html, /data-pref="extraWordFamilies"[\s\S]*Word-family variants/);
   assert.match(html, /ss-stat-label">Total spellings<\/div>\s*<div class="ss-stat-value"[^>]*>22<\/div>/);
   assert.match(html, /value="trouble"[^>]*disabled[^>]*>[\s\S]*Trouble Drill/);
 
@@ -346,6 +348,18 @@ test('spelling word bank opens from setup and exposes searchable progress with d
   harness.dispatch('spelling-analytics-search', { value: '' });
   html = harness.render();
   assert.match(html, />accident</);
+
+  harness.dispatch('spelling-analytics-search', { value: 'division' });
+  html = harness.render();
+  assert.match(html, />divide</);
+  assert.match(html, /Showing 1 of 235 tracked spellings/);
+
+  harness.dispatch('spelling-word-detail-open', { slug: 'divide', value: 'explain' });
+  html = harness.render();
+  assert.match(html, /Word-family variants/);
+  assert.match(html, /Division is the act of splitting something into parts or groups/);
+  assert.match(html, /Divisible means able to be divided exactly by a number/);
+  harness.dispatch('spelling-word-detail-close');
 
   harness.dispatch('spelling-analytics-search', { value: 'mollusc' });
   html = harness.render();

--- a/tests/spelling-content.test.js
+++ b/tests/spelling-content.test.js
@@ -149,8 +149,8 @@ test('seeded spelling content validates and round-trips through the portable exp
   assert.equal(validation.ok, true);
   assert.equal(validation.bundle.modelVersion, SPELLING_CONTENT_MODEL_VERSION);
   assert.equal(validation.errors.length, 0);
-  assert.equal(validation.bundle.releases.length, 2);
-  assert.equal(validation.bundle.publication.publishedVersion, 2);
+  assert.equal(validation.bundle.releases.length, 3);
+  assert.equal(validation.bundle.publication.publishedVersion, 3);
   assert.ok(validation.bundle.draft.wordLists
     .filter((list) => list.id.startsWith('statutory-'))
     .every((list) => list.spellingPool === 'core'));
@@ -164,10 +164,10 @@ test('seeded spelling content validates and round-trips through the portable exp
   const exported = content.exportPortable();
   const roundTripped = extractPortableSpellingContent(exported);
   assert.equal(roundTripped.draft.words.length, validation.bundle.draft.words.length);
-  assert.equal(roundTripped.releases.at(-1).version, 2);
+  assert.equal(roundTripped.releases.at(-1).version, 3);
 });
 
-test('seeded spelling content includes the initial Extra expansion in the current release only', () => {
+test('seeded spelling content includes the Extra expansion and current word-family variants', () => {
   const validation = validateSpellingContentBundle(SEEDED_SPELLING_CONTENT_BUNDLE);
   assert.equal(validation.ok, true);
 
@@ -191,6 +191,20 @@ test('seeded spelling content includes the initial Extra expansion in the curren
   assert.equal(runtimeWord.year, 'extra');
   assert.deepEqual(runtimeWord.accepted, ['mollusc']);
   assert.equal(runtimeWord.accepted.includes('mollusk'), false);
+
+  const divide = currentRelease.snapshot.wordBySlug.divide;
+  assert.deepEqual(divide.familyWords, ['divide', 'division', 'divisible']);
+  assert.equal(divide.variants[0].word, 'division');
+  assert.deepEqual(divide.variants[0].accepted, ['division']);
+  assert.equal(divide.variants[0].explanation, 'Division is the act of splitting something into parts or groups.');
+  assert.equal(divide.variants[0].sentence, 'The division of the class into teams was fair.');
+  assert.equal(divide.variants[1].word, 'divisible');
+  assert.equal(divide.variants[1].explanation, 'Divisible means able to be divided exactly by a number.');
+  const currentExtraWords = currentRelease.snapshot.words.filter((word) => word.spellingPool === 'extra');
+  const variantCount = currentExtraWords.reduce((total, word) => total + (word.variants?.length || 0), 0);
+  assert.equal(currentRelease.snapshot.words.filter((word) => word.spellingPool === 'extra').length, 22);
+  assert.equal(variantCount, 30);
+  assert.ok(currentExtraWords.every((word) => (word.variants || []).every((variant) => variant.explanation && variant.sentence)));
 });
 
 test('extra spelling pool validates without statutory year groups and publishes as Extra runtime words', () => {
@@ -227,6 +241,21 @@ test('validation catches spelling-pool mismatches between word lists and words',
   assert.ok(validation.errors.some((issue) => issue.code === 'pool_mismatch'));
 });
 
+test('validation keeps word-family variants out of the core pool', () => {
+  const broken = cloneSerialisable(SEEDED_SPELLING_CONTENT_BUNDLE);
+  const coreWord = broken.draft.words.find((word) => word.slug === 'possess');
+  coreWord.variants = [{
+    word: 'possession',
+    accepted: ['possession'],
+    explanation: 'A possession is something that belongs to someone.',
+    sentenceEntryIds: coreWord.sentenceEntryIds.slice(0, 1),
+  }];
+
+  const validation = validateSpellingContentBundle(broken);
+  assert.equal(validation.ok, false);
+  assert.ok(validation.errors.some((issue) => issue.code === 'core_variants_not_supported'));
+});
+
 test('validation catches duplicate words and broken sentence references', () => {
   const broken = cloneSerialisable(SEEDED_SPELLING_CONTENT_BUNDLE);
   broken.draft.words.push(cloneSerialisable(broken.draft.words[0]));
@@ -252,12 +281,16 @@ test('validation requires learner-facing word explanations in draft and publishe
   const broken = cloneSerialisable(SEEDED_SPELLING_CONTENT_BUNDLE);
   broken.draft.words[0].explanation = '';
   broken.releases[0].snapshot.words[0].explanation = '';
+  broken.draft.words.find((word) => word.slug === 'divide').variants[0].explanation = '';
+  broken.releases.at(-1).snapshot.wordBySlug.divide.variants[0].explanation = '';
+  broken.releases.at(-1).snapshot.words.find((word) => word.slug === 'divide').variants[0].explanation = '';
 
   const validation = validateSpellingContentBundle(broken);
   assert.equal(validation.ok, false);
-  assert.equal(validation.errors.filter((issue) => issue.code === 'missing_word_explanation').length, 2);
+  assert.equal(validation.errors.filter((issue) => issue.code === 'missing_word_explanation').length, 4);
   assert.ok(validation.errors.some((issue) => issue.path === 'draft.words[0].explanation'));
   assert.ok(validation.errors.some((issue) => issue.path === 'releases[0].snapshot.words[0].explanation'));
+  assert.ok(validation.errors.some((issue) => issue.path.includes('variants[0].explanation')));
 });
 
 test('content service backfills seeded explanations for legacy stored bundles', () => {

--- a/tests/spelling.test.js
+++ b/tests/spelling.test.js
@@ -20,6 +20,16 @@ function makeSeededRandom(seed = 1) {
   };
 }
 
+function makeSequenceRandom(values, fallback = 0.99) {
+  let index = 0;
+  return function sequenceRandom() {
+    if (index >= values.length) return fallback;
+    const value = Number(values[index]);
+    index += 1;
+    return Number.isFinite(value) ? value : fallback;
+  };
+}
+
 function makeService({ now, random, storage = installMemoryStorage() } = {}) {
   const repositories = createLocalPlatformRepositories({ storage });
   const spoken = [];
@@ -63,6 +73,26 @@ function continueUntilSummary(service, learnerId, state, answer = 'possess') {
   }
 
   return { state: current, events };
+}
+
+function continueUntilSummaryWithCurrentAnswers(service, learnerId, state) {
+  const events = [];
+  const seenWords = [];
+  let current = state;
+
+  while (current.phase === 'session') {
+    const answer = current.session.currentCard.word.word;
+    seenWords.push(answer);
+    const submitted = service.submitAnswer(learnerId, current, answer);
+    events.push(...submitted.events);
+    current = submitted.state;
+    assert.equal(current.awaitingAdvance, true);
+    const continued = service.continueSession(learnerId, current);
+    events.push(...continued.events);
+    current = continued.state;
+  }
+
+  return { state: current, events, seenWords };
 }
 
 function sessionWords(session) {
@@ -211,6 +241,55 @@ test('Extra spelling accepts UK mollusc only', () => {
   assert.equal(rejectedSubmission.state.session.phase, 'retry');
   assert.equal(rejectedSubmission.state.feedback.kind, 'error');
   assert.equal(rejectedSubmission.state.feedback.attemptedAnswer, 'mollusk');
+});
+
+test('Extra word-family variants are opt-in and share base-word progress', () => {
+  const day = 24 * 60 * 60 * 1000;
+  let nowValue = Date.UTC(2026, 0, 1);
+  const { service } = makeService({
+    now: () => nowValue,
+    random: makeSequenceRandom([0.5, 0.5, 0.5], 0.5),
+  });
+
+  const defaultRound = service.startSession('learner-base', {
+    mode: 'single',
+    words: ['divide'],
+    yearFilter: 'extra',
+    length: 1,
+  });
+  assert.equal(defaultRound.ok, true);
+  assert.equal(defaultRound.state.session.currentCard.slug, 'divide');
+  assert.equal(defaultRound.state.session.currentCard.word.word, 'divide');
+
+  const seenWords = new Set();
+  for (let round = 0; round < 4; round += 1) {
+    const started = service.startSession('learner-family', {
+      mode: 'single',
+      words: ['divide'],
+      yearFilter: 'extra',
+      length: 1,
+      extraWordFamilies: true,
+    }).state;
+    const completed = continueUntilSummaryWithCurrentAnswers(service, 'learner-family', started);
+    completed.seenWords.forEach((word) => seenWords.add(word));
+    nowValue += day * 2;
+  }
+
+  assert.ok(seenWords.has('division'));
+  const stats = service.getStats('learner-family', 'extra');
+  assert.equal(stats.total, 22);
+  assert.equal(stats.secure, 1);
+
+  const extraGroup = service.getAnalyticsSnapshot('learner-family').wordGroups.find((group) => group.key === 'extra');
+  assert.equal(extraGroup.words.length, 22);
+  assert.equal(extraGroup.words.some((word) => word.slug === 'division' || word.word === 'division'), false);
+  const divide = extraGroup.words.find((word) => word.slug === 'divide');
+  assert.equal(divide.word, 'divide');
+  assert.equal(divide.status, 'secure');
+  assert.equal(divide.progress.stage, 4);
+  assert.deepEqual(divide.familyWords, ['divide', 'division', 'divisible']);
+  assert.deepEqual(divide.variants.map((variant) => variant.word), ['division', 'divisible']);
+  assert.equal(divide.variants[0].explanation, 'Division is the act of splitting something into parts or groups.');
 });
 
 test('service state survives JSON round-trips and resumes retry/correction flow', () => {


### PR DESCRIPTION
## Summary
- Add an opt-in Extra spelling word-family variants path while keeping Extra totals keyed to the 22 base words.
- Publish Release 3 with 30 variant prompts, each carrying its own accepted spelling, explanation, and example sentence.
- Show variants in the word bank explainer and include them in word-bank search without changing Core spelling parity.

## Verification
- `PATH=/opt/homebrew/bin:$PATH node scripts/validate-spelling-content.mjs`
- `PATH=/opt/homebrew/bin:$PATH node --test`
- `PATH=/opt/homebrew/bin:$PATH npm run check`