### PR TITLE
Stabilise spelling setup options layout

### DIFF
--- a/src/subjects/spelling/components/SpellingSetupScene.jsx
+++ b/src/subjects/spelling/components/SpellingSetupScene.jsx
@@ -234,7 +234,7 @@ export function SpellingSetupScene({ learner, service, repositories, subject, pr
               <ToggleChip pref="autoSpeak" checked={Boolean(prefs.autoSpeak)} label="Auto-play audio" actions={actions} />
               {showExtraFamilyOption ? (
                 <ToggleChip pref="extraWordFamilies" checked={Boolean(prefs.extraWordFamilies)} label="Word-family variants" actions={actions} />
-              ) : null}
+              ) : <span className="toggle-chip option-placeholder" aria-hidden="true" />}
             </div>
           </div>
           <div className="setup-begin-row">

--- a/styles/app.css
+++ b/styles/app.css
@@ -3915,6 +3915,17 @@ textarea:focus-visible {
               color var(--dur) var(--ease-out),
               transform var(--dur) var(--ease-out);
 }
+.toggle-chip[data-pref="extraWordFamilies"],
+.toggle-chip.option-placeholder {
+  flex: 0 0 184px;
+  min-height: 34px;
+  max-width: 100%;
+  white-space: nowrap;
+}
+.toggle-chip.option-placeholder {
+  visibility: hidden;
+  pointer-events: none;
+}
 .toggle-chip:hover { transform: translateY(-1px); color: var(--ink); }
 .toggle-chip .box {
   width: 14px; height: 14px;


### PR DESCRIPTION
## Summary
- Reserve the Extra word-family option slot when it is hidden so the setup card height stays stable.
- Fix the Word-family variants chip sizing to avoid wrapping-related reflow.

## Verification
- `node --test tests/smoke.test.js tests/react-spelling-surface.test.js`
- `node --test`
- `npm run check`