### PR TITLE
Polish spelling setup to session transition

### DIFF
--- a/src/subjects/spelling/components/SpellingPracticeSurface.jsx
+++ b/src/subjects/spelling/components/SpellingPracticeSurface.jsx
@@ -10,9 +10,34 @@ import {
   heroBgPreloadUrls,
   heroBgForSession,
   heroBgForSetup,
+  selectSpellingSetupTone,
+  spellingHeroTone,
 } from './spelling-view-model.js';
 
-function heroBgForPhase(spelling) {
+function setupToneMemoryKey(learnerId) {
+  return `ks2.spelling.setupTone.${learnerId || 'anonymous'}`;
+}
+
+function readPreviousSetupTone(learnerId) {
+  if (typeof window === 'undefined') return spellingHeroTone(learnerId);
+  try {
+    const storage = window.sessionStorage;
+    return storage?.getItem(setupToneMemoryKey(learnerId)) || spellingHeroTone(learnerId);
+  } catch (_error) {
+    return spellingHeroTone(learnerId);
+  }
+}
+
+function rememberSetupTone(learnerId, tone) {
+  if (!learnerId || !tone || typeof window === 'undefined') return;
+  try {
+    window.sessionStorage?.setItem(setupToneMemoryKey(learnerId), tone);
+  } catch (_error) {
+    /* Ignore unavailable browser storage. */
+  }
+}
+
+function heroBgForPhase(spelling, setupHeroTone) {
   const learnerId = spelling.learner?.id;
   if (!learnerId) return '';
   if (spelling.ui.phase === 'session') return heroBgForSession(learnerId, spelling.ui.session);
@@ -20,7 +45,7 @@ function heroBgForPhase(spelling) {
     return heroBgForSession(learnerId, { mode: spelling.ui.summary?.mode });
   }
   if (spelling.ui.phase === 'word-bank') return heroBgForLearner(learnerId);
-  return heroBgForSetup(learnerId, spelling.prefs);
+  return heroBgForSetup(learnerId, spelling.prefs, { tone: setupHeroTone });
 }
 
 export function SpellingPracticeSurface(props) {
@@ -32,8 +57,29 @@ export function SpellingPracticeSurface(props) {
     actions,
   } = props;
   const spelling = buildSpellingContext({ appState, service, repositories, subject });
-  const heroBg = heroBgForPhase(spelling);
-  const preloadedHeroUrls = heroBgPreloadUrls(spelling.learner?.id, spelling.prefs);
+  const learnerId = spelling.learner?.id || '';
+  const [setupHeroTone, setSetupHeroTone] = React.useState(() => (
+    selectSpellingSetupTone(learnerId, readPreviousSetupTone(learnerId))
+  ));
+  const previousLearnerRef = React.useRef(learnerId);
+  const previousPhaseRef = React.useRef(spelling.ui.phase);
+  React.useEffect(() => {
+    if (previousLearnerRef.current === learnerId) return;
+    previousLearnerRef.current = learnerId;
+    setSetupHeroTone(selectSpellingSetupTone(learnerId, readPreviousSetupTone(learnerId)));
+  }, [learnerId]);
+  React.useEffect(() => {
+    const previousPhase = previousPhaseRef.current;
+    previousPhaseRef.current = spelling.ui.phase;
+    if (learnerId && previousPhase !== 'dashboard' && spelling.ui.phase === 'dashboard') {
+      setSetupHeroTone((current) => selectSpellingSetupTone(learnerId, current));
+    }
+  }, [learnerId, spelling.ui.phase]);
+  React.useEffect(() => {
+    rememberSetupTone(learnerId, setupHeroTone);
+  }, [learnerId, setupHeroTone]);
+  const heroBg = heroBgForPhase(spelling, setupHeroTone);
+  const preloadedHeroUrls = heroBgPreloadUrls(spelling.learner?.id, spelling.prefs, { setupTone: setupHeroTone });
   const preloadKey = preloadedHeroUrls.join('|');
   const previousHeroBgRef = React.useRef('');
   const previousHeroBg = previousHeroBgRef.current && previousHeroBgRef.current !== heroBg
@@ -80,6 +126,7 @@ export function SpellingPracticeSurface(props) {
       service={service}
       repositories={repositories}
       subject={subject}
+      setupHeroTone={setupHeroTone}
       previousHeroBg={previousHeroBg}
       actions={actions}
     />

--- a/src/subjects/spelling/components/SpellingSessionScene.jsx
+++ b/src/subjects/spelling/components/SpellingSessionScene.jsx
@@ -16,6 +16,19 @@ import {
   renderFormAction,
 } from './spelling-view-model.js';
 
+const SESSION_HERO_MORPH_MS = 720;
+const SESSION_PROMPT_SLIDE_MS = 520;
+const SESSION_QUESTION_REVEAL_PAUSE_MS = 500;
+const SESSION_QUESTION_REVEAL_MS = SESSION_HERO_MORPH_MS + SESSION_PROMPT_SLIDE_MS + SESSION_QUESTION_REVEAL_PAUSE_MS;
+
+function shouldDelaySessionQuestionReveal() {
+  if (typeof document === 'undefined') return false;
+  const reducedMotion = typeof window !== 'undefined'
+    && typeof window.matchMedia === 'function'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  return !reducedMotion && document.documentElement.classList.contains('spelling-flow-transition');
+}
+
 export function SpellingSessionScene({ learner, service, ui, accent, actions, previousHeroBg = '' }) {
   const prefs = service.getPrefs(learner.id);
   const session = ui.session;
@@ -62,9 +75,21 @@ export function SpellingSessionScene({ learner, service, ui, accent, actions, pr
     session.promptCount,
     awaitingAdvance ? 'locked' : 'active',
   ].join(':');
+  const [questionRevealed, setQuestionRevealed] = React.useState(() => !shouldDelaySessionQuestionReveal());
+  React.useEffect(() => {
+    if (!shouldDelaySessionQuestionReveal()) {
+      setQuestionRevealed(true);
+      return undefined;
+    }
+    setQuestionRevealed(false);
+    const timer = window.setTimeout(() => setQuestionRevealed(true), SESSION_QUESTION_REVEAL_MS);
+    return () => window.clearTimeout(timer);
+  }, [session.id]);
+  const sessionClasses = ['spelling-in-session'];
+  sessionClasses.push(questionRevealed ? 'is-question-revealed' : 'is-entering-session');
 
   return (
-    <div className="spelling-in-session" style={{ gridColumn: '1/-1', ...heroBgStyle(heroBg) }}>
+    <div className={sessionClasses.join(' ')} style={{ gridColumn: '1/-1', ...heroBgStyle(heroBg) }}>
       <SpellingHeroBackdrop url={heroBg} previousUrl={previousHeroBg} />
       <div className="session">
         <header className="session-head">
@@ -73,86 +98,88 @@ export function SpellingSessionScene({ learner, service, ui, accent, actions, pr
         </header>
 
         <div className="prompt-card">
-          {infoChips.length ? (
-            <div className="info-chip-row">
-              {infoChips.map((value) => <span className="chip" key={value}>{value}</span>)}
-            </div>
-          ) : null}
-          <div className="prompt-instr">{promptInstr}</div>
-          {showCloze ? (
-            <Cloze sentence={card.prompt?.cloze} answer={card.word.word} revealAnswer={showingCorrection} />
-          ) : (
-            <div className="cloze muted"><span className="blank">{'\u00a0'}</span></div>
-          )}
-          {!showCloze ? <p className="prompt-sentence muted">{contextNote}</p> : null}
+          <div className="prompt-card-inner">
+            {infoChips.length ? (
+              <div className="info-chip-row">
+                {infoChips.map((value) => <span className="chip" key={value}>{value}</span>)}
+              </div>
+            ) : null}
+            <div className="prompt-instr">{promptInstr}</div>
+            {showCloze ? (
+              <Cloze sentence={card.prompt?.cloze} answer={card.word.word} revealAnswer={showingCorrection} />
+            ) : (
+              <div className="cloze muted"><span className="blank">{'\u00a0'}</span></div>
+            )}
+            {!showCloze ? <p className="prompt-sentence muted">{contextNote}</p> : null}
 
-          <form
-            data-action="spelling-submit-form"
-            className="session-form"
-            onSubmit={(event) => renderFormAction(actions, event, 'spelling-submit-form')}
-          >
-            <div className="word-input-wrap">
-              <input
-                key={inputKey}
-                className="word-input"
-                name="typed"
-                data-autofocus="true"
-                autoComplete="off"
-                autoCapitalize="none"
-                spellCheck={false}
-                placeholder={inputPlaceholder}
-                aria-label="Type the spelling"
-                disabled={awaitingAdvance}
-              />
-            </div>
-            <div className="audio-row">
-              <button
-                type="button"
-                className="btn icon lg"
-                aria-label="Replay the dictated word"
-                data-action="spelling-replay"
-                onClick={(event) => renderAction(actions, event, 'spelling-replay')}
-              >
-                <SpeakerIcon />
-              </button>
-              <button
-                type="button"
-                className="btn icon lg"
-                aria-label="Replay slowly"
-                data-action="spelling-replay-slow"
-                onClick={(event) => renderAction(actions, event, 'spelling-replay-slow')}
-              >
-                <SpeakerSlowIcon />
-              </button>
-            </div>
-            <div className="action-row">
-              <button className="btn primary lg" style={{ '--btn-accent': accent }} type="submit" disabled={awaitingAdvance}>
-                {submitLabel}{awaitingAdvance ? null : <> <ArrowRightIcon /></>}
-              </button>
-              {awaitingAdvance ? (
+            <form
+              data-action="spelling-submit-form"
+              className="session-form"
+              onSubmit={(event) => renderFormAction(actions, event, 'spelling-submit-form')}
+            >
+              <div className="word-input-wrap">
+                <input
+                  key={inputKey}
+                  className="word-input"
+                  name="typed"
+                  data-autofocus="true"
+                  autoComplete="off"
+                  autoCapitalize="none"
+                  spellCheck={false}
+                  placeholder={inputPlaceholder}
+                  aria-label="Type the spelling"
+                  disabled={awaitingAdvance}
+                />
+              </div>
+              <div className="audio-row">
                 <button
-                  className="btn good lg"
                   type="button"
-                  data-action="spelling-continue"
-                  onClick={(event) => renderAction(actions, event, 'spelling-continue')}
+                  className="btn icon lg"
+                  aria-label="Replay the dictated word"
+                  data-action="spelling-replay"
+                  onClick={(event) => renderAction(actions, event, 'spelling-replay')}
                 >
-                  Continue <ArrowRightIcon />
+                  <SpeakerIcon />
                 </button>
-              ) : null}
-              {session.type !== 'test' && !awaitingAdvance && session.phase === 'question' ? (
                 <button
-                  className="btn ghost lg"
                   type="button"
-                  data-action="spelling-skip"
-                  onClick={(event) => renderAction(actions, event, 'spelling-skip')}
+                  className="btn icon lg"
+                  aria-label="Replay slowly"
+                  data-action="spelling-replay-slow"
+                  onClick={(event) => renderAction(actions, event, 'spelling-replay-slow')}
                 >
-                  Skip for now
+                  <SpeakerSlowIcon />
                 </button>
-              ) : null}
-            </div>
-          </form>
+              </div>
+              <div className="action-row">
+                <button className="btn primary lg" style={{ '--btn-accent': accent }} type="submit" disabled={awaitingAdvance}>
+                  {submitLabel}{awaitingAdvance ? null : <> <ArrowRightIcon /></>}
+                </button>
+                {awaitingAdvance ? (
+                  <button
+                    className="btn good lg"
+                    type="button"
+                    data-action="spelling-continue"
+                    onClick={(event) => renderAction(actions, event, 'spelling-continue')}
+                  >
+                    Continue <ArrowRightIcon />
+                  </button>
+                ) : null}
+                {session.type !== 'test' && !awaitingAdvance && session.phase === 'question' ? (
+                  <button
+                    className="btn ghost lg"
+                    type="button"
+                    data-action="spelling-skip"
+                    onClick={(event) => renderAction(actions, event, 'spelling-skip')}
+                  >
+                    Skip for now
+                  </button>
+                ) : null}
+              </div>
+            </form>
 
-          <FeedbackSlot feedback={ui.feedback} />
+            <FeedbackSlot feedback={ui.feedback} />
+          </div>
         </div>
 
         <footer className="session-footer">

--- a/src/subjects/spelling/components/SpellingSetupScene.jsx
+++ b/src/subjects/spelling/components/SpellingSetupScene.jsx
@@ -9,6 +9,7 @@ import {
   beginLabel,
   heroBgForSetup,
   heroBgStyle,
+  heroToneForBg,
   monsterImageProps,
   renderAction,
 } from './spelling-view-model.js';
@@ -165,17 +166,29 @@ function SetupStatGrid({ stats }) {
   );
 }
 
-export function SpellingSetupScene({ learner, service, repositories, subject, prefs, codex, accent, actions, previousHeroBg = '' }) {
+export function SpellingSetupScene({
+  learner,
+  service,
+  repositories,
+  subject,
+  prefs,
+  codex,
+  accent,
+  actions,
+  setupHeroTone = '',
+  previousHeroBg = '',
+}) {
   const statsFilter = prefs.mode === 'test' ? 'core' : prefs.yearFilter;
   const stats = service.getStats(learner.id, statsFilter);
   const begin = beginLabel(prefs);
-  const heroBg = heroBgForSetup(learner.id, prefs);
+  const heroBg = heroBgForSetup(learner.id, prefs, { tone: setupHeroTone });
   const hideTweaks = prefs.mode === 'test';
   const tweakClass = `tweak-row${hideTweaks ? ' is-placeholder' : ''}`;
   const tweakAria = hideTweaks ? { 'aria-hidden': 'true' } : {};
   const showExtraFamilyOption = !hideTweaks && prefs.yearFilter === 'extra';
   const mergedHeroStyle = { ...heroBgStyle(heroBg) };
   const heroContrast = useSetupHeroContrast(heroBg, prefs.mode);
+  const heroTone = heroContrast.contrast.tone || heroToneForBg(heroBg);
   const setupClasses = ['setup-main'];
   if (heroContrast.contrast.shell === 'light') setupClasses.push('hero-dark');
 
@@ -184,6 +197,7 @@ export function SpellingSetupScene({ learner, service, repositories, subject, pr
       <section
         className={setupClasses.join(' ')}
         data-react-hero-contrast="true"
+        data-hero-tone={heroTone || undefined}
         data-controls-tone={heroContrast.contrast.controls}
         ref={heroContrast.ref}
         style={mergedHeroStyle}

--- a/src/subjects/spelling/components/spelling-view-model.js
+++ b/src/subjects/spelling/components/spelling-view-model.js
@@ -47,8 +47,8 @@ const CONTRAST_DARK = 'dark';
 const CONTRAST_LIGHT = 'light';
 const SPELLING_HERO_CONTRAST_BY_TONE = Object.freeze({
   1: Object.freeze({ shell: CONTRAST_DARK, controls: CONTRAST_DARK, cards: Object.freeze([CONTRAST_DARK, CONTRAST_DARK, CONTRAST_DARK]) }),
-  2: Object.freeze({ shell: CONTRAST_DARK, controls: CONTRAST_DARK, cards: Object.freeze([CONTRAST_DARK, CONTRAST_DARK, CONTRAST_LIGHT]) }),
-  3: Object.freeze({ shell: CONTRAST_DARK, controls: CONTRAST_DARK, cards: Object.freeze([CONTRAST_DARK, CONTRAST_LIGHT, CONTRAST_LIGHT]) }),
+  2: Object.freeze({ shell: CONTRAST_LIGHT, controls: CONTRAST_LIGHT, cards: Object.freeze([CONTRAST_LIGHT, CONTRAST_LIGHT, CONTRAST_LIGHT]) }),
+  3: Object.freeze({ shell: CONTRAST_LIGHT, controls: CONTRAST_LIGHT, cards: Object.freeze([CONTRAST_LIGHT, CONTRAST_LIGHT, CONTRAST_LIGHT]) }),
 });
 const SPELLING_HERO_MODE_INDEX = Object.freeze({ smart: 0, trouble: 1, test: 2 });
 export const SPELLING_HERO_BACKGROUNDS = Object.freeze({
@@ -82,6 +82,22 @@ export function spellingHeroTone(learnerId) {
   return SPELLING_HERO_TONES[index];
 }
 
+export function selectSpellingSetupTone(learnerId, previousTone = '') {
+  if (!SPELLING_HERO_TONES.length) return '1';
+  let entropy = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
+  if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+    const bucket = new Uint32Array(1);
+    crypto.getRandomValues(bucket);
+    entropy = bucket[0];
+  }
+  const index = stableHash(`spelling:setup-tone:${learnerId}:${Date.now()}:${entropy}`) % SPELLING_HERO_TONES.length;
+  const tone = SPELLING_HERO_TONES[index];
+  if (previousTone && tone === previousTone && SPELLING_HERO_TONES.length > 1) {
+    return SPELLING_HERO_TONES[(index + 1) % SPELLING_HERO_TONES.length];
+  }
+  return tone;
+}
+
 export function heroBgForMode(mode, learnerId, options = {}) {
   const heroMode = spellingHeroMode(mode);
   const regions = SPELLING_HERO_REGIONS[heroMode] || SPELLING_HERO_REGIONS.smart;
@@ -95,20 +111,28 @@ export function heroBgForLearner(learnerId, mode = 'smart') {
   return heroBgForMode(mode, learnerId);
 }
 
-export function heroBgForSetup(learnerId, prefs) {
-  return heroBgForMode(prefs?.mode, learnerId);
+export function heroBgForSetup(learnerId, prefs, options = {}) {
+  return heroBgForMode(prefs?.mode, learnerId, options);
 }
 
 export function heroBgForSession(learnerId, session) {
   return heroBgForMode(session?.mode || (session?.type === 'test' ? 'test' : 'smart'), learnerId, { tone: '1' });
 }
 
-export function heroBgPreloadUrls(learnerId, prefs = {}) {
+export function heroBgPreloadUrls(learnerId, prefs = {}, options = {}) {
   if (!learnerId) return [];
   const modes = ['smart', 'trouble', 'test'];
-  const setupUrls = modes.map((mode) => heroBgForMode(mode, learnerId));
+  const setupTone = SPELLING_HERO_TONES.includes(String(options.setupTone))
+    ? String(options.setupTone)
+    : spellingHeroTone(learnerId);
+  const setupUrls = modes.map((mode) => heroBgForMode(mode, learnerId, { tone: setupTone }));
   const sessionUrl = heroBgForMode(prefs?.mode || 'smart', learnerId, { tone: '1' });
   return [...new Set([...setupUrls, sessionUrl].filter(Boolean))];
+}
+
+export function heroToneForBg(url) {
+  const variant = String(url || '').match(/the-scribe-downs-[a-e]([1-3])\.1280\.webp(?:$|[?#])/);
+  return variant?.[1] || '';
 }
 
 export function heroContrastProfileForBg(url, mode = 'smart') {
@@ -117,10 +141,12 @@ export function heroContrastProfileForBg(url, mode = 'smart') {
   const base = SPELLING_HERO_CONTRAST_BY_TONE[variant[2]];
   if (!base) return null;
   const selectedIndex = SPELLING_HERO_MODE_INDEX[spellingHeroMode(mode)];
+  const preferSelectedDark = variant[2] === '1';
   const cards = base.cards.map((tone, index) => (
-    index === selectedIndex ? CONTRAST_DARK : tone
+    index === selectedIndex && preferSelectedDark ? CONTRAST_DARK : tone
   ));
   return {
+    tone: variant[2],
     shell: base.shell,
     controls: base.controls,
     cards,

--- a/src/subjects/spelling/components/useSetupHeroContrast.js
+++ b/src/subjects/spelling/components/useSetupHeroContrast.js
@@ -3,6 +3,7 @@ import { probeHeroTextTones } from '../../../platform/ui/luminance.js';
 import { heroContrastProfileForBg } from './spelling-view-model.js';
 
 const DEFAULT_CONTRAST = Object.freeze({
+  tone: '',
   shell: 'dark',
   controls: 'dark',
   cards: Object.freeze(['dark', 'dark', 'dark']),
@@ -86,6 +87,7 @@ async function runProbe(shell, heroBg) {
   const byKey = new Map(results.map((result) => [result.key, result]));
   const controlResults = results.filter((result) => String(result.key || '').startsWith('control:'));
   return {
+    tone: '',
     shell: byKey.get('shell')?.tone || DEFAULT_CONTRAST.shell,
     cards: cards.map((_, index) => byKey.get(`card:${index}`)?.tone || DEFAULT_CONTRAST.cards[index] || DEFAULT_CONTRAST.shell),
     controls: combinedTone(controlResults) || DEFAULT_CONTRAST.controls,
@@ -129,7 +131,8 @@ function combinedTone(results) {
 }
 
 function sameContrast(left, right) {
-  return left.shell === right.shell
+  return left.tone === right.tone
+    && left.shell === right.shell
     && left.controls === right.controls
     && left.cards.length === right.cards.length
     && left.cards.every((tone, index) => tone === right.cards[index]);

--- a/styles/app.css
+++ b/styles/app.css
@@ -3630,7 +3630,7 @@ textarea:focus-visible {
   position: relative;
   overflow: hidden;
   min-height: 610px;
-  view-transition-name: spelling-practice-card;
+  view-transition-name: spelling-hero-card;
 }
 .setup-main.hero-dark {
   --setup-label-ink: #fff8e9;
@@ -3691,9 +3691,9 @@ textarea:focus-visible {
 }
 .mode-card {
   position: relative;
-  border: 1.5px solid var(--line);
+  border: 1.5px solid var(--mode-card-border, var(--line));
   border-radius: var(--radius);
-  background: color-mix(in oklab, var(--panel) 20%, transparent);
+  background: var(--mode-card-surface, color-mix(in oklab, var(--panel) 20%, transparent));
   backdrop-filter: blur(18px) saturate(1.12);
   -webkit-backdrop-filter: blur(18px) saturate(1.12);
   padding: 18px 16px 18px;
@@ -3708,6 +3708,15 @@ textarea:focus-visible {
               box-shadow var(--dur) var(--ease-out),
               background-color var(--dur) var(--ease-out),
               filter var(--dur) var(--ease-out);
+}
+.setup-main[data-hero-tone="2"],
+.setup-main[data-hero-tone="3"] {
+  --mode-card-border: color-mix(in oklab, white 30%, transparent);
+  --mode-card-surface: color-mix(in oklab, black 26%, transparent);
+  --mode-card-selected-surface: color-mix(in oklab, black 18%, transparent);
+  --mode-card-selected-wash: color-mix(in oklab, black 18%, transparent);
+  --mode-card-heading-shadow: 0 1px 18px rgba(0, 0, 0, 0.68);
+  --mode-card-copy-shadow: 0 1px 16px rgba(0, 0, 0, 0.72);
 }
 .mode-card[data-text-tone="dark"] {
   --mode-card-title: #1d2b3a;
@@ -3767,8 +3776,8 @@ textarea:focus-visible {
   background:
     linear-gradient(180deg,
       color-mix(in oklab, var(--brand-soft) 48%, transparent) 0%,
-      color-mix(in oklab, var(--panel) 20%, transparent) 76%),
-    color-mix(in oklab, var(--panel) 20%, transparent);
+      var(--mode-card-selected-wash, color-mix(in oklab, var(--panel) 20%, transparent)) 76%),
+    var(--mode-card-selected-surface, color-mix(in oklab, var(--panel) 20%, transparent));
   box-shadow: var(--shadow);
 }
 .mode-card.is-disabled {
@@ -4033,31 +4042,22 @@ textarea:focus-visible {
 }
 .spelling-hero-backdrop .spelling-hero-layer {
   opacity: 0;
-  transform: scale(1.012);
-  transition: opacity 880ms var(--ease-in-out),
-              filter 880ms var(--ease-in-out),
-              transform 880ms var(--ease-in-out);
+  transition: opacity 880ms var(--ease-in-out);
 }
 .spelling-hero-backdrop .spelling-hero-layer.is-entering {
   opacity: 1;
-  filter: blur(0) saturate(1.02);
-  transform: scale(1);
   animation:
     hero-pan 96s ease-in-out var(--hero-pan-delay, 0s) infinite alternate,
-    spelling-hero-fade-in 880ms var(--ease-in-out) 0s both;
+    spelling-hero-dissolve-in 880ms var(--ease-in-out) 0s both;
 }
 .spelling-hero-backdrop .spelling-hero-layer.is-active {
   opacity: 1;
-  filter: blur(0) saturate(1.02);
-  transform: scale(1);
 }
 .spelling-hero-backdrop .spelling-hero-layer.is-exiting {
   opacity: 0;
-  filter: blur(14px) saturate(0.9);
-  transform: scale(1.014);
   animation:
     hero-pan 96s ease-in-out var(--hero-pan-delay, 0s) infinite alternate,
-    spelling-hero-fade-out 880ms var(--ease-in-out) 0s both;
+    spelling-hero-dissolve-out 880ms var(--ease-in-out) 0s both;
 }
 .spelling-in-session > .spelling-hero-backdrop {
   z-index: 0;
@@ -4077,29 +4077,13 @@ textarea:focus-visible {
   from { background-position: 0% 42%; }
   to   { background-position: 100% 42%; }
 }
-@keyframes spelling-hero-fade-in {
-  from {
-    opacity: 0;
-    filter: blur(12px) saturate(0.92);
-    transform: scale(1.018);
-  }
-  to {
-    opacity: 1;
-    filter: blur(0) saturate(1.02);
-    transform: scale(1);
-  }
+@keyframes spelling-hero-dissolve-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
-@keyframes spelling-hero-fade-out {
-  from {
-    opacity: 1;
-    filter: blur(0) saturate(1.02);
-    transform: scale(1);
-  }
-  to {
-    opacity: 0;
-    filter: blur(14px) saturate(0.9);
-    transform: scale(1.014);
-  }
+@keyframes spelling-hero-dissolve-out {
+  from { opacity: 1; }
+  to { opacity: 0; }
 }
 @media (prefers-reduced-motion: reduce) {
   .hero-art.pan { animation: none; }
@@ -4245,7 +4229,12 @@ textarea:focus-visible {
   isolation: isolate;
   padding: 28px 24px;
   overflow: hidden;
+  border: 1px solid var(--line);
   border-radius: var(--radius-lg);
+  background: var(--panel);
+  box-shadow: var(--shadow-warm);
+  min-height: 610px;
+  view-transition-name: spelling-hero-card;
   /* Default on-hero tokens assume a light/mid-light backdrop.
      Add `.hero-dark` at runtime if/when luminance detection
      warrants the warm-paper flip. */
@@ -4290,6 +4279,18 @@ textarea:focus-visible {
   gap: 14px;
   padding: 0 4px;
   margin-bottom: 10px;
+}
+.spelling-in-session.is-entering-session .session-head,
+.spelling-in-session.is-entering-session .session-footer,
+.spelling-in-session.is-entering-session .prompt-card-inner {
+  opacity: 0;
+  transform: translateY(10px);
+  pointer-events: none;
+}
+.spelling-in-session.is-question-revealed .session-head,
+.spelling-in-session.is-question-revealed .session-footer,
+.spelling-in-session.is-question-revealed .prompt-card-inner {
+  animation: spelling-session-question-reveal 320ms var(--ease-out) both;
 }
 .spelling-in-session .path {
   flex: 1;
@@ -4357,7 +4358,7 @@ textarea:focus-visible {
   padding: 40px 36px 32px;
   box-shadow: var(--shadow-warm);
   position: relative;
-  view-transition-name: spelling-practice-card;
+  view-transition-name: spelling-session-prompt;
 }
 .spelling-in-session .prompt-card::before {
   content: "";
@@ -4367,16 +4368,36 @@ textarea:focus-visible {
   background: color-mix(in oklab, var(--line-strong) 55%, transparent);
 }
 
-@supports (view-transition-name: spelling-practice-card) {
-  html.spelling-flow-transition::view-transition-group(spelling-practice-card) {
-    animation-duration: 540ms;
+@supports (view-transition-name: spelling-hero-card) {
+  html.spelling-flow-transition::view-transition-group(spelling-hero-card) {
+    animation-duration: 720ms;
     animation-timing-function: var(--ease-in-out);
+    border-radius: var(--radius-lg);
+    overflow: clip;
+    box-shadow: var(--shadow-warm);
   }
-  html.spelling-flow-transition::view-transition-old(spelling-practice-card) {
-    animation: spelling-practice-card-old 540ms var(--ease-in-out) both;
+  html.spelling-flow-transition::view-transition-image-pair(spelling-hero-card) {
+    border-radius: inherit;
+    overflow: clip;
   }
-  html.spelling-flow-transition::view-transition-new(spelling-practice-card) {
-    animation: spelling-practice-card-new 540ms var(--ease-in-out) both;
+  html.spelling-flow-transition::view-transition-old(spelling-hero-card) {
+    animation: spelling-hero-card-old 720ms var(--ease-in-out) both;
+    border-radius: inherit;
+  }
+  html.spelling-flow-transition::view-transition-new(spelling-hero-card) {
+    animation: spelling-hero-card-new 720ms var(--ease-in-out) both;
+    border-radius: inherit;
+  }
+  html.spelling-flow-transition::view-transition-group(spelling-session-prompt) {
+    animation-duration: 520ms;
+    animation-timing-function: var(--ease-out);
+  }
+  html.spelling-flow-transition::view-transition-old(spelling-session-prompt) {
+    animation: none;
+    opacity: 0;
+  }
+  html.spelling-flow-transition::view-transition-new(spelling-session-prompt) {
+    animation: spelling-session-prompt-new 520ms var(--ease-out) 720ms both;
   }
   html.spelling-flow-transition::view-transition-old(spelling-metrics-card) {
     animation: spelling-metrics-card-exit 420ms var(--ease-out) both;
@@ -4385,20 +4406,34 @@ textarea:focus-visible {
     animation: none;
   }
 }
-@keyframes spelling-practice-card-old {
-  from { opacity: 1; filter: blur(0); }
-  to { opacity: 0.45; filter: blur(6px); }
+@keyframes spelling-hero-card-old {
+  from { opacity: 1; }
+  to { opacity: 0; }
 }
-@keyframes spelling-practice-card-new {
+@keyframes spelling-hero-card-new {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+@keyframes spelling-session-prompt-new {
   from {
-    opacity: 0.72;
-    transform: scale(0.96);
-    clip-path: inset(8% 8% round 26px);
+    opacity: 0;
+    filter: blur(10px);
+    transform: translateY(32px) scale(0.985);
   }
   to {
     opacity: 1;
-    transform: scale(1);
-    clip-path: inset(0 round 22px);
+    filter: blur(0);
+    transform: translateY(0) scale(1);
+  }
+}
+@keyframes spelling-session-question-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
 }
 @keyframes spelling-metrics-card-exit {
@@ -4414,8 +4449,10 @@ textarea:focus-visible {
   }
 }
 @media (prefers-reduced-motion: reduce) {
-  html.spelling-flow-transition::view-transition-old(spelling-practice-card),
-  html.spelling-flow-transition::view-transition-new(spelling-practice-card),
+  html.spelling-flow-transition::view-transition-old(spelling-hero-card),
+  html.spelling-flow-transition::view-transition-new(spelling-hero-card),
+  html.spelling-flow-transition::view-transition-old(spelling-session-prompt),
+  html.spelling-flow-transition::view-transition-new(spelling-session-prompt),
   html.spelling-flow-transition::view-transition-old(spelling-metrics-card) {
     animation-duration: 1ms;
   }

--- a/tests/browser-react-migration-smoke.test.js
+++ b/tests/browser-react-migration-smoke.test.js
@@ -81,6 +81,7 @@ test('browser migration smoke covers the React app root and spelling interaction
       ['click', '[data-action="spelling-close-word-bank"]'],
       ['wait', '[data-action="spelling-start"]'],
       ['js', "document.querySelector('[data-action=\"spelling-start\"]')?.click(); 'started spelling';"],
+      ['wait', '.spelling-in-session.is-question-revealed input[name="typed"]'],
       ['text'],
       ['is', 'focused', 'input[name="typed"]'],
       ['fill', 'input[name="typed"]', 'zzzz'],

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -316,19 +316,22 @@ test('spelling setup and session hero backgrounds use mode-specific Scribe Downs
     heroBgForSession('learner-0', { mode: 'test' }),
   ]);
   assert.deepEqual(heroContrastProfileForBg('/assets/regions/the-scribe-downs/the-scribe-downs-a1.1280.webp', 'smart'), {
+    tone: '1',
     shell: 'dark',
     controls: 'dark',
     cards: ['dark', 'dark', 'dark'],
   });
   assert.deepEqual(heroContrastProfileForBg('/assets/regions/the-scribe-downs/the-scribe-downs-c2.1280.webp', 'smart'), {
-    shell: 'dark',
-    controls: 'dark',
-    cards: ['dark', 'dark', 'light'],
+    tone: '2',
+    shell: 'light',
+    controls: 'light',
+    cards: ['light', 'light', 'light'],
   });
   assert.deepEqual(heroContrastProfileForBg('/assets/regions/the-scribe-downs/the-scribe-downs-d3.1280.webp', 'trouble'), {
-    shell: 'dark',
-    controls: 'dark',
-    cards: ['dark', 'dark', 'light'],
+    tone: '3',
+    shell: 'light',
+    controls: 'light',
+    cards: ['light', 'light', 'light'],
   });
   assert.equal(heroContrastProfileForBg('/assets/regions/the-scribe-downs/the-scribe-downs-bg-a1.1280.webp', 'smart'), null);
 


### PR DESCRIPTION
## Summary
- refine the setup-to-session hero morph so the shared card frame, background, and prompt sequence transition cleanly
- use instant precomputed contrast profiles for Scribe Downs day/dusk/night assets
- delay the first question content until after the prompt card has entered

## Verification
- npm test
- npm run check

Note: `npm run test:migration:browser` was previously green for this branch, but the gstack browse daemon timed out while starting during the final rebase verification run.