### PR TITLE
Open word bank entries in explainer mode

### DIFF
--- a/src/subjects/spelling/components/SpellingWordBankScene.jsx
+++ b/src/subjects/spelling/components/SpellingWordBankScene.jsx
@@ -100,7 +100,7 @@ function WordPill({ word, actions }) {
     `Correct ${Math.max(0, Number(progress.correct) || 0)}`,
     `Wrong ${Math.max(0, Number(progress.wrong) || 0)}`,
     `Next due: ${dueLabel(progress)}`,
-    'Click to drill',
+    'Click to explain',
   ].filter(Boolean).join(' • ');
   return (
     <button
@@ -108,10 +108,10 @@ function WordPill({ word, actions }) {
       className={`wb-word-pill ${wordBankPillClass(word.status)}`}
       data-action="spelling-word-detail-open"
       data-slug={word.slug}
-      data-value="drill"
+      data-value="explain"
       title={title}
-      aria-label={`Drill ${word.word}. ${wordStatusLabel(word.status)}. ${spellingPoolLabel(word)}.`}
-      onClick={(event) => renderAction(actions, event, 'spelling-word-detail-open', { slug: word.slug, value: 'drill' })}
+      aria-label={`Explain ${word.word}. ${wordStatusLabel(word.status)}. ${spellingPoolLabel(word)}.`}
+      onClick={(event) => renderAction(actions, event, 'spelling-word-detail-open', { slug: word.slug, value: 'explain' })}
     >
       {word.word}
     </button>
@@ -203,7 +203,7 @@ function WordBankCard({ learner, analytics, appState, actions }) {
         <header className="wb-head">
           <p className="eyebrow">Word bank progress</p>
           <h1 className="title">{learnerName} word bank</h1>
-          <p className="lede">{ledeBase}{ledeSearch} Tap any word to drill it, then switch to the explainer if you need help.</p>
+          <p className="lede">{ledeBase}{ledeSearch} Tap any word to see its explainer, then switch to drill when you want to practise.</p>
         </header>
 
         <div className="wb-toolbar">

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -133,7 +133,7 @@ test('golden-path smoke covers import/export restore for a live spelling session
   assert.match(harness.render(), /Spell the word you hear|Spell the dictated word/);
 });
 
-test('spelling word bank opens from setup and exposes searchable progress with drill modal', () => {
+test('spelling word bank opens from setup and exposes searchable progress with explainer modal', () => {
   const storage = installMemoryStorage();
   const harness = createAppHarness({ storage });
   const learnerId = harness.store.getState().learners.selectedId;
@@ -214,10 +214,10 @@ test('spelling word bank opens from setup and exposes searchable progress with d
     Unseen: '22',
   });
   // Word-bank entries render as legacy-style colour pills. The tooltip carries
-  // the progress details, while clicking the pill opens the new drill modal.
+  // the progress details, while clicking the pill opens the explainer modal.
   assert.match(html, /class="wb-word-pill new"/);
-  assert.match(html, /data-action="spelling-word-detail-open"\s+data-slug="possess"\s+data-value="drill"/);
-  assert.match(html, /title="possess[^"]*Family: possess\(ion\)[^"]*Next due: Unseen[^"]*Click to drill"/);
+  assert.match(html, /data-action="spelling-word-detail-open"\s+data-slug="possess"\s+data-value="explain"/);
+  assert.match(html, /title="possess[^"]*Family: possess\(ion\)[^"]*Next due: Unseen[^"]*Click to explain"/);
   assert.match(html, />accident</);
   assert.doesNotMatch(html, /wb-meta-label">Family/);
 
@@ -328,7 +328,7 @@ test('spelling word bank opens from setup and exposes searchable progress with d
   assert.equal(harness.store.getState().subjectUi.spelling.analyticsWordSearch, undefined);
   html = harness.render();
   assert.match(html, />possess</);
-  assert.match(html, /title="possess[^"]*Next due: In 3 days[^"]*Click to drill"/);
+  assert.match(html, /title="possess[^"]*Next due: In 3 days[^"]*Click to explain"/);
   assert.doesNotMatch(html, />accident</);
 
   harness.dispatch('spelling-word-detail-open', { slug: 'possess', value: 'explain' });
@@ -364,7 +364,7 @@ test('spelling word bank opens from setup and exposes searchable progress with d
   harness.dispatch('spelling-analytics-search', { value: 'mollusc' });
   html = harness.render();
   assert.match(html, />mollusc</);
-  assert.match(html, /title="mollusc[^"]*Extra[^"]*Click to drill"/);
+  assert.match(html, /title="mollusc[^"]*Extra[^"]*Click to explain"/);
   assert.match(html, /Showing 1 of 235 tracked spellings/);
   assert.doesNotMatch(html, />accident</);
 


### PR DESCRIPTION
## Summary
- Open word bank word pills in Explain mode instead of Drill mode
- Update the learner-facing word bank prompt and smoke contract

## Verification
- npm test
- npm run check