### PR TITLE
Reset inactive spelling entry to setup

### DIFF
--- a/src/platform/core/store.js
+++ b/src/platform/core/store.js
@@ -176,6 +176,61 @@ function normaliseTransientUi(rawValue) {
   };
 }
 
+function closeSpellingWordDetailTransientUi(transientUi) {
+  return {
+    ...transientUi,
+    spellingWordDetailSlug: '',
+    spellingWordDetailMode: 'explain',
+    spellingWordBankDrillTyped: '',
+    spellingWordBankDrillResult: null,
+  };
+}
+
+function isCleanSpellingSetupEntry(spellingUi, transientUi) {
+  return spellingUi.phase === 'dashboard'
+    && !spellingUi.session
+    && !spellingUi.feedback
+    && !spellingUi.summary
+    && !spellingUi.error
+    && !spellingUi.awaitingAdvance
+    && !transientUi?.spellingWordDetailSlug
+    && !transientUi?.spellingWordBankDrillTyped
+    && !transientUi?.spellingWordBankDrillResult;
+}
+
+function normaliseSubjectEntryForOpen(current, route, repositories) {
+  if (route.screen !== 'subject' || route.subjectId !== 'spelling' || route.tab !== 'practice') {
+    return current;
+  }
+
+  const previous = current.subjectUi?.spelling || DEFAULT_SUBJECT_UI;
+  if (previous.phase === 'session' && previous.session) return current;
+  if (isCleanSpellingSetupEntry(previous, current.transientUi)) return current;
+
+  const nextSpellingUi = {
+    ...previous,
+    phase: 'dashboard',
+    session: null,
+    feedback: null,
+    summary: null,
+    error: '',
+    awaitingAdvance: false,
+  };
+
+  if (current.learners.selectedId) {
+    repositories.subjectStates.writeUi(current.learners.selectedId, 'spelling', nextSpellingUi);
+  }
+
+  return {
+    ...current,
+    subjectUi: {
+      ...current.subjectUi,
+      spelling: nextSpellingUi,
+    },
+    transientUi: closeSpellingWordDetailTransientUi(current.transientUi),
+  };
+}
+
 function stateFromRepositories(subjects, repositories) {
   const learners = ensureLearnersSnapshot(repositories, subjects);
   const selectedId = learners.selectedId;
@@ -285,10 +340,13 @@ export function createStore(subjects, { repositories } = {}) {
       setState((current) => ({ ...current, route: { ...DEFAULT_ROUTE } }));
     },
     openSubject(subjectId, tab = 'practice') {
-      setState((current) => ({
-        ...current,
-        route: normaliseRoute({ screen: 'subject', subjectId, tab }, registry),
-      }));
+      setState((current) => {
+        const route = normaliseRoute({ screen: 'subject', subjectId, tab }, registry);
+        return {
+          ...normaliseSubjectEntryForOpen(current, route, resolvedRepositories),
+          route,
+        };
+      });
     },
     openCodex() {
       setState((current) => ({

--- a/src/surfaces/shell/SubjectBreadcrumb.jsx
+++ b/src/surfaces/shell/SubjectBreadcrumb.jsx
@@ -5,7 +5,9 @@ export function SubjectBreadcrumb({ subjectName = 'Subject', onDashboard }) {
     <nav className="subject-breadcrumb" aria-label="Subject breadcrumb">
       <button type="button" className="subject-breadcrumb-link" onClick={onDashboard}>← Dashboard</button>
       <span className="subject-breadcrumb-sep" aria-hidden="true">/</span>
-      <span className="subject-breadcrumb-current">{subjectName}</span>
+      <button type="button" className="subject-breadcrumb-current" onClick={onDashboard}>
+        {subjectName}
+      </button>
     </nav>
   );
 }

--- a/styles/app.css
+++ b/styles/app.css
@@ -5224,8 +5224,22 @@ textarea:focus-visible {
 .subject-breadcrumb-sep { color: var(--subtle); }
 .subject-breadcrumb-ancestor { color: var(--muted); }
 .subject-breadcrumb-current {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  padding: 4px 2px;
   color: var(--ink);
+  font: inherit;
+  font-size: 0.86rem;
   font-weight: 700;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: color var(--dur) var(--ease-out);
+}
+.subject-breadcrumb-current:hover { color: var(--brand); }
+.subject-breadcrumb-current:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
 }
 
 /* ---------- Setup-scene codex link ---------- */

--- a/tests/react-app-shell.test.js
+++ b/tests/react-app-shell.test.js
@@ -17,5 +17,6 @@ test('React app shell renders subject chrome without global subject top-nav moun
 
   assert.match(html, /Round setup/);
   assert.match(html, /KS2 Mastery/);
+  assert.match(html, /class="subject-breadcrumb-current"[^>]*>\s*Spelling\s*<\/button>/);
   assert.doesNotMatch(html, /data-subject-topnav-mount/);
 });

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -133,6 +133,33 @@ test('golden-path smoke covers import/export restore for a live spelling session
   assert.match(harness.render(), /Spell the word you hear|Spell the dictated word/);
 });
 
+test('opening spelling from home resets inactive word-bank state but preserves active sessions', () => {
+  const storage = installMemoryStorage();
+  const harness = createAppHarness({ storage });
+  const learnerId = harness.store.getState().learners.selectedId;
+
+  harness.dispatch('open-subject', { subjectId: 'spelling' });
+  harness.dispatch('spelling-open-word-bank');
+  assert.equal(harness.store.getState().subjectUi.spelling.phase, 'word-bank');
+
+  harness.dispatch('navigate-home');
+  harness.dispatch('open-subject', { subjectId: 'spelling' });
+  assert.equal(harness.store.getState().subjectUi.spelling.phase, 'dashboard');
+  assert.equal(harness.repositories.subjectStates.read(learnerId, 'spelling').ui.phase, 'dashboard');
+  assert.match(harness.render(), /Round setup/);
+
+  harness.services.spelling.savePrefs(learnerId, { mode: 'smart', roundLength: '1' });
+  harness.dispatch('spelling-start');
+  const activeSession = structuredClone(harness.store.getState().subjectUi.spelling.session);
+
+  harness.dispatch('navigate-home');
+  harness.dispatch('open-subject', { subjectId: 'spelling' });
+  assert.equal(harness.store.getState().subjectUi.spelling.phase, 'session');
+  assert.equal(harness.store.getState().subjectUi.spelling.session.id, activeSession.id);
+  assert.equal(harness.store.getState().subjectUi.spelling.session.currentSlug, activeSession.currentSlug);
+  assert.match(harness.render(), /Spell the word you hear|Spell the dictated word/);
+});
+
 test('spelling word bank opens from setup and exposes searchable progress with explainer modal', () => {
   const storage = installMemoryStorage();
   const harness = createAppHarness({ storage });


### PR DESCRIPTION
## Summary
- Reset Spelling to setup when opening from home unless an active question session exists
- Preserve active spelling sessions when returning from home
- Make the subject breadcrumb title act as a dashboard link

## Verification
- npm test
- npm run check