### PR TITLE
Animate subject entry screens

### DIFF
--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -73,7 +73,8 @@ export function App({ controller, runtime }) {
   const snapshot = usePlatformStore(controller);
   const appState = snapshot.appState;
   const screen = appState.route?.screen || 'dashboard';
-  const context = runtime.contextFor(appState.route?.subjectId || 'spelling');
+  const routedSubjectId = appState.route?.subjectId || 'spelling';
+  const context = runtime.contextFor(routedSubjectId);
   const actions = useMemo(() => runtime.buildSurfaceActions(), [runtime]);
 
   useLayoutEffect(() => {
@@ -99,10 +100,10 @@ export function App({ controller, runtime }) {
       )}
 
       {screen === 'subject' && (
-        <div className="app-shell">
+        <div className="app-shell subject-entry-shell">
           <SubjectTopNav chrome={runtime.buildSurfaceChromeModel(appState)} actions={actions} />
           <PersistenceBanner snapshot={appState.persistence} onRetry={actions.retryPersistence} />
-          <SubjectRoute appState={appState} context={context} actions={actions} />
+          <SubjectRoute key={routedSubjectId} appState={appState} context={context} actions={actions} />
           <SharedOverlays appState={appState} actions={actions} />
         </div>
       )}

--- a/src/platform/ui/render.js
+++ b/src/platform/ui/render.js
@@ -1168,7 +1168,11 @@ export function renderSubjectScreen(context) {
   const subject = resolveSubject(appState.route.subjectId, context);
   const ui = appState.subjectUi[subject.id] || {};
   if (!hasWritableLearner(appState)) {
-    return renderNoWritableLearnerShellCard(context, `${subject.name} stays unavailable without a writable learner in the main shell`);
+    return `
+      <main class="subject-entry-content">
+        ${renderNoWritableLearnerShellCard(context, `${subject.name} stays unavailable without a writable learner in the main shell`)}
+      </main>
+    `;
   }
   /* The redesigned Codex Journal surface routes all subject affordances
      (setup, session, summary, word bank) through the practice renderer and
@@ -1210,13 +1214,15 @@ export function renderSubjectScreen(context) {
      No ancestor pill, no tab row, no outer `shell-grid` — each scene (setup,
      session, summary, word bank) renders its own card shell. */
   return `
-    <nav class="subject-breadcrumb" aria-label="Subject breadcrumb">
-      <button type="button" class="subject-breadcrumb-link" data-action="navigate-home">← Dashboard</button>
-      <span class="subject-breadcrumb-sep" aria-hidden="true">/</span>
-      <span class="subject-breadcrumb-current">${escapeHtml(subject.name)}</span>
-    </nav>
-    ${ui.error ? `<section class="card" style="margin-bottom:18px;"><div class="feedback bad"><strong>Subject message</strong><div>${escapeHtml(ui.error)}</div></div></section>` : ''}
-    ${mainContent}
+    <main class="subject-entry-content">
+      <nav class="subject-breadcrumb" aria-label="Subject breadcrumb">
+        <button type="button" class="subject-breadcrumb-link" data-action="navigate-home">← Dashboard</button>
+        <span class="subject-breadcrumb-sep" aria-hidden="true">/</span>
+        <button type="button" class="subject-breadcrumb-current" data-action="navigate-home">${escapeHtml(subject.name)}</button>
+      </nav>
+      ${ui.error ? `<section class="card" style="margin-bottom:18px;"><div class="feedback bad"><strong>Subject message</strong><div>${escapeHtml(ui.error)}</div></div></section>` : ''}
+      ${mainContent}
+    </main>
   `;
 }
 
@@ -1428,8 +1434,9 @@ export function renderApp(appState, context) {
       : screen === 'admin-hub'
         ? renderAdminHub(context)
         : renderDashboard(context);
+  const shellClassName = screen === 'subject' ? 'app-shell subject-entry-shell' : 'app-shell';
   return `
-    <div class="app-shell">
+    <div class="${shellClassName}">
       ${renderHeader(appState, context)}
       ${renderPersistenceBanner(appState.persistence)}
       ${body}

--- a/src/surfaces/subject/SubjectRoute.jsx
+++ b/src/surfaces/subject/SubjectRoute.jsx
@@ -151,21 +151,27 @@ export function SubjectRoute({ appState, context, actions }) {
   }
 
   if (!learner) {
-    return <NoWritableLearnerCard subject={subject} context={context} actions={actions} />;
+    return (
+      <main className="subject-entry-content">
+        <NoWritableLearnerCard subject={subject} context={context} actions={actions} />
+      </main>
+    );
   }
 
   return (
     <SubjectRouteContext.Provider value={{ appState, context: routeContext, actions, subject, activeTab }}>
-      <SubjectBreadcrumb subjectName={subject.name} onDashboard={actions.navigateHome} />
-      {appState.subjectUi?.[subject.id]?.error ? (
-        <section className="card" style={{ marginBottom: 18 }} role="alert" aria-live="polite">
-          <div className="feedback bad">
-            <strong>Subject message</strong>
-            <div>{appState.subjectUi[subject.id].error}</div>
-          </div>
-        </section>
-      ) : null}
-      {renderPracticeNode({ subject, routeContext, actions, activeTab, runtimeEntry, captureRenderError })}
+      <main className="subject-entry-content">
+        <SubjectBreadcrumb subjectName={subject.name} onDashboard={actions.navigateHome} />
+        {appState.subjectUi?.[subject.id]?.error ? (
+          <section className="card" style={{ marginBottom: 18 }} role="alert" aria-live="polite">
+            <div className="feedback bad">
+              <strong>Subject message</strong>
+              <div>{appState.subjectUi[subject.id].error}</div>
+            </div>
+          </section>
+        ) : null}
+        {renderPracticeNode({ subject, routeContext, actions, activeTab, runtimeEntry, captureRenderError })}
+      </main>
     </SubjectRouteContext.Provider>
   );
 }

--- a/styles/app.css
+++ b/styles/app.css
@@ -5194,6 +5194,37 @@ textarea:focus-visible {
    chrome (hero block + back button) with a single slim wayfinding row.
    Mirrors the v1 breadcrumb pattern (Dashboard / Subject module / <Subject>)
    used across the Codex Journal design. */
+.subject-entry-shell {
+  --subject-entry-distance: 18px;
+}
+.subject-entry-content {
+  animation: subject-entry-content-in 420ms var(--ease-out) both;
+  transform-origin: 50% 24px;
+  will-change: opacity, transform;
+}
+.subject-entry-content > .subject-breadcrumb {
+  animation: subject-entry-breadcrumb-in 320ms var(--ease-out) 80ms both;
+}
+@keyframes subject-entry-content-in {
+  from {
+    opacity: 0;
+    transform: translateY(var(--subject-entry-distance)) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+@keyframes subject-entry-breadcrumb-in {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
 .subject-breadcrumb {
   display: flex;
   flex-wrap: wrap;
@@ -5240,6 +5271,12 @@ textarea:focus-visible {
 .subject-breadcrumb-current:focus-visible {
   outline: 2px solid var(--brand);
   outline-offset: 2px;
+}
+@media (prefers-reduced-motion: reduce) {
+  .subject-entry-content,
+  .subject-entry-content > .subject-breadcrumb {
+    animation: none !important;
+  }
 }
 
 /* ---------- Setup-scene codex link ---------- */

--- a/tests/react-app-shell.test.js
+++ b/tests/react-app-shell.test.js
@@ -17,6 +17,8 @@ test('React app shell renders subject chrome without global subject top-nav moun
 
   assert.match(html, /Round setup/);
   assert.match(html, /KS2 Mastery/);
+  assert.match(html, /class="app-shell subject-entry-shell"/);
+  assert.match(html, /class="subject-entry-content"/);
   assert.match(html, /class="subject-breadcrumb-current"[^>]*>\s*Spelling\s*<\/button>/);
   assert.doesNotMatch(html, /data-subject-topnav-mount/);
 });

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -445,6 +445,9 @@ test('golden-path smoke covers placeholder-subject navigation through the setup 
      phase because they have no engine yet — the subject shell is exercised
      by the fact that opening succeeds without a runtime error. */
   const html = harness.render();
+  assert.match(html, /class="app-shell subject-entry-shell"/);
+  assert.match(html, /class="subject-entry-content"/);
+  assert.match(html, /class="subject-breadcrumb-current" data-action="navigate-home">Reasoning<\/button>/);
   assert.match(html, /Reasoning foundation/);
   assert.match(html, /Extension points already reserved/);
 });


### PR DESCRIPTION
## Summary
- Add a shared subject-entry animation wrapper for React and legacy subject screens
- Replay the subject entry transition when switching subject ids
- Cover React and placeholder subject markup in tests

## Verification
- npm test
- npm run check