### PR TITLE
Delay spelling audio until question reveal

### DIFF
--- a/src/platform/app/create-app-controller.js
+++ b/src/platform/app/create-app-controller.js
@@ -8,6 +8,10 @@ import { resolveSpellingShortcut } from '../../subjects/spelling/shortcuts.js';
 import { createSpellingService } from '../../subjects/spelling/service.js';
 import { createSpellingPersistence } from '../../subjects/spelling/repository.js';
 import {
+  SPELLING_SESSION_ENTRY_AUDIO_DELAY_MS,
+  shouldDelaySpellingSessionQuestionReveal,
+} from '../../subjects/spelling/session-timing.js';
+import {
   isMonsterCelebrationEvent,
   shouldDelayMonsterCelebrations,
   spellingSessionEnded,
@@ -61,11 +65,15 @@ export function createAppController({
 
   const store = createStore(subjects, { repositories });
   const controllerListeners = new Set();
+  const setTimeoutFn = scheduler?.setTimeout?.bind(scheduler)
+    || (typeof globalThis.setTimeout === 'function' ? globalThis.setTimeout.bind(globalThis) : null);
+  const clearTimeoutFn = scheduler?.clearTimeout?.bind(scheduler)
+    || (typeof globalThis.clearTimeout === 'function' ? globalThis.clearTimeout.bind(globalThis) : null);
   const autoAdvance = createSpellingAutoAdvanceController({
     getState: () => store.getState(),
     dispatchContinue: () => dispatch('spelling-continue'),
-    setTimeoutFn: scheduler?.setTimeout?.bind(scheduler),
-    clearTimeoutFn: scheduler?.clearTimeout?.bind(scheduler),
+    setTimeoutFn,
+    clearTimeoutFn,
   });
 
   store.subscribe(() => {
@@ -114,6 +122,54 @@ export function createAppController({
     return autoAdvance.ensureScheduledFromState(appState.subjectUi.spelling);
   }
 
+  let pendingTransitionAudioTimer = null;
+
+  function clearPendingTransitionAudio() {
+    if (pendingTransitionAudioTimer && clearTimeoutFn) {
+      clearTimeoutFn(pendingTransitionAudioTimer);
+    }
+    pendingTransitionAudioTimer = null;
+  }
+
+  function shouldDelayTransitionAudio(subjectId, previousSubjectUi, nextSubjectUi) {
+    return subjectId === 'spelling'
+      && previousSubjectUi?.phase !== 'session'
+      && nextSubjectUi?.phase === 'session'
+      && shouldDelaySpellingSessionQuestionReveal();
+  }
+
+  function speakDelayedTransitionAudio(subjectId, audio) {
+    try {
+      tts.speak(audio);
+    } catch (error) {
+      const appState = store.getState();
+      runtimeBoundary.capture({
+        learnerId: appState.learners.selectedId,
+        subject: resolveSubject(subjects, subjectId),
+        tab: appState.route.tab || 'practice',
+        phase: 'side-effect',
+        methodName: 'tts.speak',
+        action: 'transition-audio',
+        error,
+      });
+      store.patch(() => ({}));
+    }
+  }
+
+  function speakTransitionAudio(subjectId, transition, previousSubjectUi, nextSubjectUi) {
+    const audio = transition.audio;
+    if (!audio?.word) return;
+    if (!shouldDelayTransitionAudio(subjectId, previousSubjectUi, nextSubjectUi) || !setTimeoutFn) {
+      tts.speak(audio);
+      return;
+    }
+    clearPendingTransitionAudio();
+    pendingTransitionAudioTimer = setTimeoutFn(() => {
+      pendingTransitionAudioTimer = null;
+      speakDelayedTransitionAudio(subjectId, audio);
+    }, SPELLING_SESSION_ENTRY_AUDIO_DELAY_MS);
+  }
+
   function applySubjectTransition(subjectId, transition) {
     if (!transition) return false;
     const previousSubjectUi = store.getState().subjectUi[subjectId] || null;
@@ -151,7 +207,7 @@ export function createAppController({
       tab: store.getState().route.tab || 'practice',
     });
 
-    if (transition.audio?.word) tts.speak(transition.audio);
+    speakTransitionAudio(subjectId, transition, previousSubjectUi, nextSubjectUi);
     if (subjectId === 'spelling') autoAdvance.scheduleFromTransition(transition);
     return true;
   }
@@ -364,6 +420,7 @@ export function createAppController({
   }
 
   function dispatch(action, data = {}) {
+    clearPendingTransitionAudio();
     autoAdvance.clear();
     try {
       if (!handleGlobalAction(action, data)) {

--- a/src/subjects/spelling/components/SpellingSessionScene.jsx
+++ b/src/subjects/spelling/components/SpellingSessionScene.jsx
@@ -10,24 +10,15 @@ import { ArrowRightIcon, SpeakerIcon, SpeakerSlowIcon } from './spelling-icons.j
 import { Cloze, FeedbackSlot, PathProgress } from './SpellingCommon.jsx';
 import { SpellingHeroBackdrop } from './SpellingHeroBackdrop.jsx';
 import {
+  SPELLING_SESSION_QUESTION_REVEAL_MS,
+  shouldDelaySpellingSessionQuestionReveal,
+} from '../session-timing.js';
+import {
   heroBgForSession,
   heroBgStyle,
   renderAction,
   renderFormAction,
 } from './spelling-view-model.js';
-
-const SESSION_HERO_MORPH_MS = 720;
-const SESSION_PROMPT_SLIDE_MS = 520;
-const SESSION_QUESTION_REVEAL_PAUSE_MS = 500;
-const SESSION_QUESTION_REVEAL_MS = SESSION_HERO_MORPH_MS + SESSION_PROMPT_SLIDE_MS + SESSION_QUESTION_REVEAL_PAUSE_MS;
-
-function shouldDelaySessionQuestionReveal() {
-  if (typeof document === 'undefined') return false;
-  const reducedMotion = typeof window !== 'undefined'
-    && typeof window.matchMedia === 'function'
-    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-  return !reducedMotion && document.documentElement.classList.contains('spelling-flow-transition');
-}
 
 export function SpellingSessionScene({ learner, service, ui, accent, actions, previousHeroBg = '' }) {
   const prefs = service.getPrefs(learner.id);
@@ -75,14 +66,14 @@ export function SpellingSessionScene({ learner, service, ui, accent, actions, pr
     session.promptCount,
     awaitingAdvance ? 'locked' : 'active',
   ].join(':');
-  const [questionRevealed, setQuestionRevealed] = React.useState(() => !shouldDelaySessionQuestionReveal());
+  const [questionRevealed, setQuestionRevealed] = React.useState(() => !shouldDelaySpellingSessionQuestionReveal());
   React.useEffect(() => {
-    if (!shouldDelaySessionQuestionReveal()) {
+    if (!shouldDelaySpellingSessionQuestionReveal()) {
       setQuestionRevealed(true);
       return undefined;
     }
     setQuestionRevealed(false);
-    const timer = window.setTimeout(() => setQuestionRevealed(true), SESSION_QUESTION_REVEAL_MS);
+    const timer = window.setTimeout(() => setQuestionRevealed(true), SPELLING_SESSION_QUESTION_REVEAL_MS);
     return () => window.clearTimeout(timer);
   }, [session.id]);
   const sessionClasses = ['spelling-in-session'];

--- a/src/subjects/spelling/session-timing.js
+++ b/src/subjects/spelling/session-timing.js
@@ -1,0 +1,20 @@
+export const SPELLING_SESSION_HERO_MORPH_MS = 720;
+export const SPELLING_SESSION_PROMPT_SLIDE_MS = 520;
+export const SPELLING_SESSION_QUESTION_REVEAL_PAUSE_MS = 100;
+export const SPELLING_SESSION_QUESTION_REVEAL_ANIMATION_MS = 320;
+
+export const SPELLING_SESSION_QUESTION_REVEAL_MS =
+  SPELLING_SESSION_HERO_MORPH_MS + SPELLING_SESSION_PROMPT_SLIDE_MS + SPELLING_SESSION_QUESTION_REVEAL_PAUSE_MS;
+
+export const SPELLING_SESSION_ENTRY_AUDIO_DELAY_MS =
+  SPELLING_SESSION_QUESTION_REVEAL_MS + SPELLING_SESSION_QUESTION_REVEAL_ANIMATION_MS;
+
+export function shouldDelaySpellingSessionQuestionReveal({
+  documentRef = typeof document !== 'undefined' ? document : null,
+  windowRef = typeof window !== 'undefined' ? window : null,
+} = {}) {
+  const flowTransitionActive = documentRef?.documentElement?.classList?.contains?.('spelling-flow-transition');
+  if (!flowTransitionActive) return false;
+  const reducedMotion = Boolean(windowRef?.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches);
+  return !reducedMotion;
+}

--- a/tests/app-controller.test.js
+++ b/tests/app-controller.test.js
@@ -15,6 +15,7 @@ import {
   LOCAL_CODEX_STAGE_REVIEW_LEARNER_IDS,
 } from '../src/platform/core/local-review-profile.js';
 import { SUBJECTS } from '../src/platform/core/subject-registry.js';
+import { SPELLING_SESSION_ENTRY_AUDIO_DELAY_MS } from '../src/subjects/spelling/session-timing.js';
 import { installMemoryStorage } from './helpers/memory-storage.js';
 
 function typedFormData(value) {
@@ -55,6 +56,14 @@ function jsonResponse(ok, payload) {
       return payload;
     },
   };
+}
+
+function restoreGlobal(name, previousValue) {
+  if (typeof previousValue === 'undefined') {
+    delete globalThis[name];
+    return;
+  }
+  globalThis[name] = previousValue;
 }
 
 test('browser bootstrap creates local repositories and recognises codex review URL modes', async () => {
@@ -179,6 +188,62 @@ test('controller dispatches spelling transitions through store, repositories, ev
   controller.dispatch('spelling-submit-form', { formData: typedFormData(answer) });
 
   assert.ok(controller.repositories.practiceSessions.list(learnerId).length >= 1);
+});
+
+test('controller waits for the spelling question reveal before entry auto TTS', () => {
+  const storage = installMemoryStorage();
+  const scheduled = [];
+  const scheduler = {
+    setTimeout(fn, delay) {
+      const id = scheduled.length + 1;
+      scheduled.push({ id, fn, delay, cleared: false });
+      return id;
+    },
+    clearTimeout(id) {
+      const entry = scheduled.find((item) => item.id === id);
+      if (entry) entry.cleared = true;
+    },
+  };
+  const previousDocument = globalThis.document;
+  const previousWindow = globalThis.window;
+
+  globalThis.document = {
+    documentElement: {
+      classList: {
+        contains(className) {
+          return className === 'spelling-flow-transition';
+        },
+      },
+    },
+  };
+  globalThis.window = {
+    matchMedia() {
+      return { matches: false };
+    },
+  };
+
+  try {
+    const controller = createAppController({
+      repositories: createLocalPlatformRepositories({ storage }),
+      scheduler,
+    });
+    const learnerId = controller.store.getState().learners.selectedId;
+    controller.services.spelling.savePrefs(learnerId, { mode: 'smart', roundLength: '1' });
+
+    controller.dispatch('open-subject', { subjectId: 'spelling' });
+    controller.dispatch('spelling-start');
+
+    assert.equal(controller.store.getState().subjectUi.spelling.phase, 'session');
+    assert.equal(controller.tts.spoken.length, 0);
+    assert.equal(scheduled.length, 1);
+    assert.equal(scheduled[0].delay, SPELLING_SESSION_ENTRY_AUDIO_DELAY_MS);
+
+    scheduled[0].fn();
+    assert.equal(controller.tts.spoken.length, 1);
+  } finally {
+    restoreGlobal('document', previousDocument);
+    restoreGlobal('window', previousWindow);
+  }
 });
 
 test('controller retry preserves the current route and clears runtime boundaries', async () => {


### PR DESCRIPTION
## Summary
- Move spelling session entry animation timing into a shared timing module.
- Reduce the first-question reveal pause from 500ms to 100ms.
- Delay entry auto TTS until the question reveal has completed during the setup-to-session view transition, while preserving immediate manual replay.

## Verification
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm test -- tests/app-controller.test.js tests/react-spelling-scene-spike.test.js tests/spelling-parity.test.js tests/react-spelling-surface.test.js tests/render.test.js`
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run check`
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm test`