### PR TITLE
Retire legacy subject practice renderer

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,7 +44,7 @@ handleAction()
 
 This is the main change that turns the product from “Spelling plus placeholders” into an actual platform.
 
-The registry validates this contract at startup. Fail early on missing methods or duplicate ids rather than discovering boundary drift at render time. Legacy `renderPractice()` support is retained only for local characterisation tests and transitional fixtures; production subject routes use React practice components.
+The registry validates this contract at startup. Fail early on missing methods or duplicate ids rather than discovering boundary drift at render time. Legacy `renderPractice()` support has been retired; subject routes use React practice components or an explicit React practice mapping.
 
 Subject presentation metadata such as accent colours belongs on the subject module. Services stay deterministic and presentation-free.
 

--- a/docs/subject-expansion.md
+++ b/docs/subject-expansion.md
@@ -34,7 +34,7 @@ Reusable test assets now live in:
 The fixture subject is **not** a shipped product subject.
 It exists only to prove the platform can carry a second deterministic thin slice without shell redesign.
 
-The browser shell has since moved to a single React root. The harness still keeps a small legacy-render characterisation path for regression coverage, but production subject presentation now flows through `SubjectRoute` and React practice components.
+The browser shell has since moved to a single React root. Subject presentation flows through `SubjectRoute` and React practice components.
 
 ## Thin-slice reference contract
 
@@ -53,7 +53,7 @@ The subject module must still satisfy the existing enforced registry contract:
 - `PracticeComponent` or `renderPracticeComponent()`
 - `handleAction()`
 
-`renderPractice()` is accepted only as a compatibility bridge for old characterisation tests and transitional fixtures. A production subject must expose a React practice component, or be wired through the explicit React subject component map before it can render in the browser shell.
+`renderPractice()` is no longer accepted. A subject must expose a React practice component, or be wired through the explicit React subject component map before it can render in the browser shell.
 
 ### Thin-slice service contract
 

--- a/src/platform/core/subject-contract.js
+++ b/src/platform/core/subject-contract.js
@@ -6,10 +6,9 @@ const REQUIRED_FUNCTION_FIELDS = [
 ];
 const REACT_PRACTICE_FIELDS = ['PracticeComponent', 'renderPracticeComponent'];
 
-function hasPracticeRenderer(candidate) {
+function hasReactPracticeRenderer(candidate) {
   if (candidate.reactPractice === true) return true;
-  return REACT_PRACTICE_FIELDS.some((field) => typeof candidate[field] === 'function')
-    || typeof candidate.renderPractice === 'function';
+  return REACT_PRACTICE_FIELDS.some((field) => typeof candidate[field] === 'function');
 }
 
 function describeCandidate(candidate) {
@@ -37,8 +36,12 @@ export function validateSubjectModule(candidate) {
     }
   }
 
-  if (!hasPracticeRenderer(candidate)) {
-    throw new TypeError(`${label} is missing required React practice component or legacy "renderPractice()" renderer.`);
+  if (typeof candidate.renderPractice === 'function') {
+    throw new TypeError(`${label} uses retired legacy "renderPractice()" rendering. Use "PracticeComponent", "renderPracticeComponent()", or an explicit React practice mapping.`);
+  }
+
+  if (!hasReactPracticeRenderer(candidate)) {
+    throw new TypeError(`${label} is missing required React practice component or explicit React practice mapping.`);
   }
 
   if ('available' in candidate && typeof candidate.available !== 'boolean') {

--- a/src/platform/ui/render.js
+++ b/src/platform/ui/render.js
@@ -328,36 +328,25 @@ function subjectRenderFallback(subject, runtimeEntry, activeTab) {
   `;
 }
 
-function subjectTabContent(subject, activeTab, appState, contentContext, runtimeEntry) {
+function subjectTabContent(subject, activeTab, runtimeEntry) {
   if (runtimeEntry) {
     const fallback = subjectRenderFallback(subject, runtimeEntry, activeTab);
     return fallback;
   }
-  /* renderSubjectScreen pins activeTab to 'practice' after the Codex Journal
-     redesign. The practice renderer internally routes between setup /
-     session / summary / word-bank phases, so every subject surface flows
-     through this single entry point. */
-  return subject.renderPractice(contentContext);
-}
-
-function subjectPracticeRenderMethodName(subject) {
-  if (typeof subject.renderPractice === 'function') return 'renderPractice';
-  if (typeof subject.renderPracticeComponent === 'function') return 'renderPracticeComponent';
-  if (typeof subject.PracticeComponent === 'function' || subject.reactPractice === true) return 'PracticeComponent';
-  return 'renderPractice';
+  return `
+    <section class="card border-top" style="border-top-color:${escapeHtml(subject.accent || '#3E6FA8')};">
+      <div class="eyebrow">React subject route</div>
+      <h2 class="section-title">${escapeHtml(subject.name)} is rendered by React</h2>
+      <p class="subtitle">The static compatibility renderer no longer builds subject practice markup. The browser shell mounts the React App route for this subject.</p>
+      <div id="subject-route-root" data-subject-react-route="true" data-subject-id="${escapeHtml(subject.id)}"></div>
+    </section>
+  `;
 }
 
 
 function renderHeader(appState, context) {
   const routeScreen = appState.route?.screen || 'dashboard';
-  /* Subject route reuses the home TopNav React component. We emit an empty
-     mount node; main.js#mountReactSurfaces renders the component into it.
-     Adult hubs (parent-hub / admin-hub) stay on the legacy template header
-     for now — they still expose the Dashboard / Operations / Parent Hub pill
-     row which the learner-facing TopNav does not. */
-  if (routeScreen === 'subject') {
-    return `<div id="subject-topnav-root" data-subject-topnav-mount="true"></div>`;
-  }
+  if (routeScreen === 'subject') return '';
   const auth = globalThis.KS2_AUTH_SESSION || {};
   const authChip = auth.signedIn
     ? `<span class="profile-signed-in" title="${escapeHtml(auth.email || 'Signed in')}">${escapeHtml(auth.email || 'Signed in')}</span><button type="button" class="topnav-link" data-action="platform-logout">Sign out</button>`
@@ -791,12 +780,9 @@ function renderArchitectureStrip() {
       <article class="card">
         <div class="eyebrow">Subject contract</div>
         <h2 class="section-title">Module per subject</h2>
-        <div class="code-block">renderPractice()
-renderAnalytics()
-renderProfiles()
-renderSettings()
-renderMethod()
-handleAction()</div>
+        <div class="code-block">PracticeComponent
+	renderPracticeComponent()
+	handleAction()</div>
       </article>
       <article class="card">
         <div class="eyebrow">Learning engine boundary</div>
@@ -1179,7 +1165,6 @@ export function renderSubjectScreen(context) {
      manages internal phases via `ui.phase`. Analytics / Profiles / Settings
      / Method tabs have been retired so the top-level tab row is gone. */
   const activeTab = 'practice';
-  const contentContext = subjectContext(subject, context);
   const runtimeEntry = context.runtimeBoundary?.read?.({
     learnerId: appState.learners.selectedId,
     subjectId: subject.id,
@@ -1188,26 +1173,9 @@ export function renderSubjectScreen(context) {
 
   let mainContent = '';
   if (runtimeEntry) {
-    mainContent = subjectTabContent(subject, activeTab, appState, contentContext, runtimeEntry);
+    mainContent = subjectTabContent(subject, activeTab, runtimeEntry);
   } else {
-    try {
-      mainContent = subjectTabContent(subject, activeTab, appState, contentContext, null);
-    } catch (error) {
-      const captured = context.runtimeBoundary?.capture?.({
-        learnerId: appState.learners.selectedId,
-        subject,
-        tab: activeTab,
-        phase: 'render',
-        methodName: subjectPracticeRenderMethodName(subject),
-        error,
-      }) || {
-        message: `${subject.name} could not render right now.`,
-        debugMessage: error?.message || String(error),
-        phase: 'render',
-        methodName: subjectPracticeRenderMethodName(subject),
-      };
-      mainContent = subjectTabContent(subject, activeTab, appState, contentContext, captured);
-    }
+    mainContent = subjectTabContent(subject, activeTab, null);
   }
 
   /* Slim chrome — one breadcrumb row that says "← Dashboard / {subject}".

--- a/src/subjects/placeholders/module-factory.js
+++ b/src/subjects/placeholders/module-factory.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { escapeHtml } from '../../platform/core/utils.js';
 
 function PlaceholderPracticeComponent({ subject }) {
   const meta = subject || {};
@@ -61,34 +60,6 @@ export function createPlaceholderSubject(meta) {
       };
     },
     PracticeComponent: PlaceholderPracticeComponent,
-    renderPractice() {
-      return `
-        <div class="three-col">
-          <section class="card border-top" style="border-top-color:${meta.accent};">
-            <div class="eyebrow">Future subject module</div>
-            <h2 class="section-title">${escapeHtml(meta.name)} foundation</h2>
-            <p class="subtitle">${escapeHtml(meta.blurb)}</p>
-            <div class="callout" style="margin-top:14px;">
-              This rebuild keeps the shell, subject identity, analytics slot, game hooks and API contract ready for <strong>${escapeHtml(meta.name)}</strong>, but leaves the question engine intentionally separate so the next team can build it without touching Spelling.
-            </div>
-          </section>
-          <section class="card">
-            <div class="eyebrow">Extension points already reserved</div>
-            <div class="chip-row">
-              <span class="chip">subject module contract</span>
-              <span class="chip">practice renderer</span>
-              <span class="chip">analytics renderer</span>
-              <span class="chip">game event adapter</span>
-              <span class="chip">Cloudflare API route</span>
-            </div>
-          </section>
-          <section class="card">
-            <div class="eyebrow">Recommended next build slice</div>
-            <div class="code-block">1. Content model\n2. Deterministic engine\n3. Local repository\n4. Subject analytics\n5. Game event mapping\n6. Worker API route</div>
-          </section>
-        </div>
-      `;
-    },
     handleAction() {
       return false;
     },

--- a/src/surfaces/shell/SubjectBreadcrumb.jsx
+++ b/src/surfaces/shell/SubjectBreadcrumb.jsx
@@ -3,9 +3,9 @@ import React from 'react';
 export function SubjectBreadcrumb({ subjectName = 'Subject', onDashboard }) {
   return (
     <nav className="subject-breadcrumb" aria-label="Subject breadcrumb">
-      <button type="button" className="subject-breadcrumb-link" onClick={onDashboard}>← Dashboard</button>
+      <button type="button" className="subject-breadcrumb-link" data-action="navigate-home" onClick={onDashboard}>← Dashboard</button>
       <span className="subject-breadcrumb-sep" aria-hidden="true">/</span>
-      <button type="button" className="subject-breadcrumb-current" onClick={onDashboard}>
+      <button type="button" className="subject-breadcrumb-current" data-action="navigate-home" onClick={onDashboard}>
         {subjectName}
       </button>
     </nav>

--- a/tests/app-controller.test.js
+++ b/tests/app-controller.test.js
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import React from 'react';
 
 import {
   createCredentialFetch,
@@ -39,8 +40,8 @@ function makeBrokenSubject() {
     getDashboardStats() {
       return { pct: 0, due: 0, streak: 0, nextUp: 'Broken fixture' };
     },
-    renderPractice() {
-      return '<button data-action="broken-action-trigger">Break</button>';
+    PracticeComponent() {
+      return React.createElement('button', { type: 'button', onClick: () => {} }, 'Break');
     },
     handleAction(action) {
       if (action === 'broken-action-trigger') throw new Error('handleAction exploded');

--- a/tests/helpers/app-harness.js
+++ b/tests/helpers/app-harness.js
@@ -34,7 +34,7 @@ export function createAppHarness({
 
   function render() {
     const appState = controller.store.getState();
-    if (appState.route.screen === 'subject' && appState.route.subjectId === 'spelling') {
+    if (appState.route.screen === 'subject') {
       const html = renderReactControllerApp(controller);
       controller.ensureSpellingAutoAdvanceFromCurrentState();
       return html;

--- a/tests/helpers/expansion-fixture-subject.js
+++ b/tests/helpers/expansion-fixture-subject.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { createLocalPlatformRepositories, cloneSerialisable, normalisePracticeSessionRecord } from '../../src/platform/core/repositories/index.js';
-import { escapeHtml } from '../../src/platform/core/utils.js';
 import { SUBJECTS } from '../../src/platform/core/subject-registry.js';
 import { createAppHarness } from './app-harness.js';
 
@@ -268,75 +267,6 @@ export function createExpansionFixtureService({ repositories, now = Date.now } =
   };
 }
 
-function renderDashboard(context, learnerId) {
-  const stats = context.service.getStats(learnerId);
-  return `
-    <section class="card">
-      <div class="eyebrow">Candidate subject fixture</div>
-      <h2 class="section-title">Expansion fixture practice</h2>
-      <p class="subtitle">This is a non-production thin slice used only to prove the subject expansion harness. It deliberately uses the same shell, repository, session, and event boundaries as a real future subject.</p>
-      <div class="chip-row" style="margin-top:14px;">
-        <span class="chip">Answered ${stats.attempts}</span>
-        <span class="chip">Accuracy ${stats.accuracy}%</span>
-        <span class="chip">Due ${stats.due}</span>
-      </div>
-      <div class="actions" style="margin-top:16px;">
-        <button class="btn primary" data-action="fixture-start">Start deterministic round</button>
-      </div>
-    </section>
-  `;
-}
-
-function renderSession(context, learnerId, ui) {
-  const question = ui.session?.currentQuestion;
-  return `
-    <section class="card">
-      <div class="eyebrow">Candidate subject fixture</div>
-      <h2 class="section-title">Expansion fixture live round</h2>
-      <p class="subtitle">${escapeHtml(context.appState.learners.byId[learnerId].name)} · deterministic prompt</p>
-      <div class="callout" style="margin-top:14px;">Solve: <strong>${escapeHtml(question.prompt)}</strong></div>
-      <form data-action="fixture-submit-form" style="margin-top:16px; display:grid; gap:12px;">
-        <label class="field">
-          <span>Your answer</span>
-          <input class="input" name="typed" data-autofocus="true" autocomplete="off" />
-        </label>
-        <div class="actions">
-          <button class="btn primary" type="submit">Submit answer</button>
-          <button class="btn secondary" type="button" data-action="fixture-back">End round</button>
-        </div>
-      </form>
-    </section>
-  `;
-}
-
-function renderSummary(ui) {
-  const summary = ui.summary || {};
-  const feedback = ui.feedback || {};
-  return `
-    <section class="card">
-      <div class="eyebrow">Candidate subject fixture</div>
-      <h2 class="section-title">Expansion fixture summary</h2>
-      <p class="subtitle">${escapeHtml(summary.message || '')}</p>
-      <div class="feedback ${feedback.kind === 'success' ? 'good' : 'warn'}" style="margin-top:14px;">
-        <strong>${escapeHtml(feedback.headline || '')}</strong>
-        <div style="margin-top:8px;">${escapeHtml(feedback.body || '')}</div>
-      </div>
-      <div class="stat-grid" style="margin-top:16px;">
-        ${(summary.cards || []).map((card) => `
-          <div class="stat">
-            <div class="stat-label">${escapeHtml(card.label)}</div>
-            <div class="stat-value">${escapeHtml(String(card.value))}</div>
-            <div class="stat-sub">${escapeHtml(card.sub)}</div>
-          </div>
-        `).join('')}
-      </div>
-      <div class="actions" style="margin-top:16px;">
-        <button class="btn secondary" data-action="fixture-back">Back to fixture dashboard</button>
-      </div>
-    </section>
-  `;
-}
-
 function ExpansionFixturePracticeComponent({ appState, service, actions }) {
   const learnerId = appState.learners.selectedId;
   const learner = appState.learners.byId[learnerId];
@@ -460,13 +390,6 @@ export const expansionFixtureModule = {
     };
   },
   PracticeComponent: ExpansionFixturePracticeComponent,
-  renderPractice(context) {
-    const learnerId = context.appState.learners.selectedId;
-    const ui = context.service.initState(context.appState.subjectUi[EXPANSION_FIXTURE_SUBJECT_ID], learnerId);
-    if (ui.phase === 'session') return renderSession(context, learnerId, ui);
-    if (ui.phase === 'summary') return renderSummary(ui);
-    return renderDashboard(context, learnerId);
-  },
   handleAction(action, context) {
     const learnerId = context.appState.learners.selectedId;
     const ui = context.service.initState(context.appState.subjectUi[EXPANSION_FIXTURE_SUBJECT_ID], learnerId);

--- a/tests/helpers/subject-expansion-harness.js
+++ b/tests/helpers/subject-expansion-harness.js
@@ -128,7 +128,6 @@ export function registerSubjectConformanceSuite(spec) {
     };
     const brokenRenderSubject = {
       ...baseSubject,
-      renderPractice: throwRenderError,
       renderPracticeComponent: throwRenderError,
     };
 

--- a/tests/runtime-boundary.test.js
+++ b/tests/runtime-boundary.test.js
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import React from 'react';
 
 import { installMemoryStorage } from './helpers/memory-storage.js';
 import { createAppHarness } from './helpers/app-harness.js';
@@ -28,9 +29,21 @@ function makeBrokenSubject({
       if (throwInDashboardStats) throw new Error('dashboard stats exploded');
       return { pct: 0, due: 0, streak: 0, nextUp: 'Broken fixture' };
     },
-    renderPractice() {
+    renderPracticeComponent() {
       if (throwInPractice) throw new Error('renderPractice exploded');
-      return '<section class="card"><button class="btn" data-action="broken-action-trigger">Trigger broken action</button></section>';
+      return React.createElement(
+        'section',
+        { className: 'card' },
+        React.createElement(
+          'button',
+          {
+            className: 'btn',
+            type: 'button',
+            onClick: () => {},
+          },
+          'Trigger broken action',
+        ),
+      );
     },
     handleAction(action) {
       if (throwInAction && action === 'broken-action-trigger') {
@@ -63,15 +76,12 @@ test('subject render failures are contained to the active tab instead of breakin
   assert.equal(harness.store.getState().route.subjectId, brokenSubject.id);
   assert.match(html, /Practice temporarily unavailable/);
   assert.match(html, /Try this tab again/);
-  /* Shell chrome proxy: the v1 Codex Journal redesign replaced the inline
-     "Current learner" header with a React TopNav mount + breadcrumb. The
-     mount node being present proves the shell survived the practice throw. */
-  assert.match(html, /data-subject-topnav-mount="true"/);
+  assert.match(html, /Subject breadcrumb/);
   assert.equal(harness.runtimeBoundary.read({
     learnerId: harness.store.getState().learners.selectedId,
     subjectId: brokenSubject.id,
     tab: 'practice',
-  }).methodName, 'renderPractice');
+  }).methodName, 'renderPracticeComponent');
 });
 
 test('subject action failures are contained and leave routing, toasts, learner switching and spelling state intact', () => {

--- a/tests/subject-contract.test.js
+++ b/tests/subject-contract.test.js
@@ -18,8 +18,8 @@ function completeSubjectModule(overrides = {}) {
     getDashboardStats() {
       return { pct: 0, due: 0, streak: 0, nextUp: 'Planned' };
     },
-    renderPractice() {
-      return '<div>practice</div>';
+    PracticeComponent() {
+      return null;
     },
     handleAction() {
       return false;
@@ -40,7 +40,6 @@ test('subject registry rejects modules missing required contract functions', () 
 
 test('subject registry accepts a React practice component during subject migration', () => {
   const subject = completeSubjectModule({
-    renderPractice: undefined,
     PracticeComponent() {
       return null;
     },
@@ -54,7 +53,7 @@ test('subject registry accepts a React practice component during subject migrati
 
 test('subject registry accepts a mapped React practice surface without importing JSX in the module', () => {
   const subject = completeSubjectModule({
-    renderPractice: undefined,
+    PracticeComponent: undefined,
     reactPractice: true,
   });
 
@@ -64,12 +63,26 @@ test('subject registry accepts a mapped React practice surface without importing
   assert.equal(registry[0].reactPractice, true);
 });
 
-test('subject registry rejects modules without React or legacy practice rendering', () => {
-  const broken = completeSubjectModule({ renderPractice: undefined });
+test('subject registry rejects modules without React practice rendering', () => {
+  const broken = completeSubjectModule({ PracticeComponent: undefined });
 
   assert.throws(
     () => buildSubjectRegistry([broken]),
-    /missing required React practice component or legacy "renderPractice\(\)" renderer/i,
+    /missing required React practice component/i,
+  );
+});
+
+test('subject registry rejects retired legacy practice rendering', () => {
+  const broken = completeSubjectModule({
+    PracticeComponent: undefined,
+    renderPractice() {
+      return '<div>practice</div>';
+    },
+  });
+
+  assert.throws(
+    () => buildSubjectRegistry([broken]),
+    /retired legacy "renderPractice\(\)" rendering/i,
   );
 });
 


### PR DESCRIPTION
## Summary
- retire the legacy `renderPractice()` subject contract in favour of React practice surfaces
- route all subject harness rendering through the React App path
- remove legacy string-render fixtures and update docs/tests around the full React contract

## Verification
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm test`
- `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run check`