### PR TITLE
Animate subject exit to dashboard

### DIFF
--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { HomeSurface } from '../surfaces/home/HomeSurface.jsx';
 import { CodexSurface } from '../surfaces/home/CodexSurface.jsx';
 import { TopNav } from '../surfaces/shell/TopNav.jsx';
@@ -20,6 +20,14 @@ const REACT_ROUTES = new Set([
   'parent-hub',
   'admin-hub',
 ]);
+
+const SUBJECT_HOME_EXIT_MS = 220;
+
+function prefersReducedMotion() {
+  return typeof window !== 'undefined'
+    && typeof window.matchMedia === 'function'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
 
 function SharedOverlays({ appState, actions }) {
   return (
@@ -75,18 +83,68 @@ export function App({ controller, runtime }) {
   const screen = appState.route?.screen || 'dashboard';
   const routedSubjectId = appState.route?.subjectId || 'spelling';
   const context = runtime.contextFor(routedSubjectId);
-  const actions = useMemo(() => runtime.buildSurfaceActions(), [runtime]);
+  const baseActions = useMemo(() => runtime.buildSurfaceActions(), [runtime]);
+  const [subjectExitPhase, setSubjectExitPhase] = useState('idle');
+  const subjectExitTimer = useRef(null);
+
+  const clearSubjectExitTimer = useCallback(() => {
+    if (subjectExitTimer.current) {
+      clearTimeout(subjectExitTimer.current);
+      subjectExitTimer.current = null;
+    }
+  }, []);
+
+  const navigateHome = useCallback(() => {
+    if (screen === 'subject' && subjectExitPhase === 'idle' && !prefersReducedMotion()) {
+      setSubjectExitPhase('leaving');
+      clearSubjectExitTimer();
+      subjectExitTimer.current = setTimeout(() => {
+        subjectExitTimer.current = null;
+        baseActions.navigateHome();
+        setSubjectExitPhase('idle');
+      }, SUBJECT_HOME_EXIT_MS);
+      return;
+    }
+
+    clearSubjectExitTimer();
+    setSubjectExitPhase('idle');
+    baseActions.navigateHome();
+  }, [baseActions, clearSubjectExitTimer, screen, subjectExitPhase]);
+
+  const actions = useMemo(() => ({
+    ...baseActions,
+    navigateHome,
+  }), [baseActions, navigateHome]);
+
+  useEffect(() => clearSubjectExitTimer, [clearSubjectExitTimer]);
+
+  useLayoutEffect(() => {
+    if (screen !== 'subject' && subjectExitPhase !== 'idle') {
+      clearSubjectExitTimer();
+      setSubjectExitPhase('idle');
+    }
+  }, [clearSubjectExitTimer, screen, subjectExitPhase]);
 
   useLayoutEffect(() => {
     runtime.afterRender?.(appState);
   }, [appState, runtime]);
+
+  const subjectShellClassName = [
+    'app-shell',
+    'subject-entry-shell',
+    subjectExitPhase === 'leaving' ? 'subject-exit-shell' : '',
+  ].filter(Boolean).join(' ');
 
   return (
     <ErrorBoundary>
       {screen === 'dashboard' && (
         <>
           <PersistenceBanner snapshot={appState.persistence} onRetry={actions.retryPersistence} />
-          <HomeSurface model={runtime.buildHomeModel(appState, context)} actions={actions} />
+          <HomeSurface
+            model={runtime.buildHomeModel(appState, context)}
+            actions={actions}
+            shellClassName="app-shell home-entry-shell"
+          />
           <SharedOverlays appState={appState} actions={actions} />
         </>
       )}
@@ -100,7 +158,7 @@ export function App({ controller, runtime }) {
       )}
 
       {screen === 'subject' && (
-        <div className="app-shell subject-entry-shell">
+        <div className={subjectShellClassName}>
           <SubjectTopNav chrome={runtime.buildSurfaceChromeModel(appState)} actions={actions} />
           <PersistenceBanner snapshot={appState.persistence} onRetry={actions.retryPersistence} />
           <SubjectRoute key={routedSubjectId} appState={appState} context={context} actions={actions} />

--- a/src/surfaces/home/HomeSurface.jsx
+++ b/src/surfaces/home/HomeSurface.jsx
@@ -11,7 +11,7 @@ import {
   randomHeroBackground,
 } from './data.js';
 
-export function HomeSurface({ model, actions }) {
+export function HomeSurface({ model, actions, shellClassName = 'app-shell' }) {
   const heroBg = useMemo(() => randomHeroBackground(), [model.learner?.id]);
   const meadowSeed = useMemo(
     () => `${model.learner?.id || 'learner'}:${Math.random().toString(36).slice(2)}`,
@@ -34,7 +34,7 @@ export function HomeSurface({ model, actions }) {
   const companionName = pickCompanionName(model.monsterSummary || []);
 
   return (
-    <div className="app-shell">
+    <div className={shellClassName}>
       <TopNav
         theme={model.theme}
         onToggleTheme={actions.toggleTheme}

--- a/styles/app.css
+++ b/styles/app.css
@@ -5196,6 +5196,7 @@ textarea:focus-visible {
    used across the Codex Journal design. */
 .subject-entry-shell {
   --subject-entry-distance: 18px;
+  --subject-exit-distance: 16px;
 }
 .subject-entry-content {
   animation: subject-entry-content-in 420ms var(--ease-out) both;
@@ -5204,6 +5205,17 @@ textarea:focus-visible {
 }
 .subject-entry-content > .subject-breadcrumb {
   animation: subject-entry-breadcrumb-in 320ms var(--ease-out) 80ms both;
+}
+.subject-exit-shell .subject-entry-content {
+  animation: subject-exit-content-out 220ms cubic-bezier(0.4, 0, 1, 1) both;
+}
+.subject-exit-shell .subject-entry-content > .subject-breadcrumb {
+  animation: subject-exit-breadcrumb-out 180ms cubic-bezier(0.4, 0, 1, 1) both;
+}
+.home-entry-shell {
+  animation: home-dashboard-enter 420ms var(--ease-out) both;
+  transform-origin: 50% 24px;
+  will-change: opacity, transform;
 }
 @keyframes subject-entry-content-in {
   from {
@@ -5223,6 +5235,36 @@ textarea:focus-visible {
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+@keyframes subject-exit-content-out {
+  from {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(var(--subject-exit-distance)) scale(0.985);
+  }
+}
+@keyframes subject-exit-breadcrumb-out {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+}
+@keyframes home-dashboard-enter {
+  from {
+    opacity: 0;
+    transform: translateY(16px) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
   }
 }
 .subject-breadcrumb {
@@ -5273,8 +5315,11 @@ textarea:focus-visible {
   outline-offset: 2px;
 }
 @media (prefers-reduced-motion: reduce) {
+  .home-entry-shell,
   .subject-entry-content,
-  .subject-entry-content > .subject-breadcrumb {
+  .subject-entry-content > .subject-breadcrumb,
+  .subject-exit-shell .subject-entry-content,
+  .subject-exit-shell .subject-entry-content > .subject-breadcrumb {
     animation: none !important;
   }
 }

--- a/tests/react-app-shell.test.js
+++ b/tests/react-app-shell.test.js
@@ -8,6 +8,7 @@ test('React app shell renders dashboard without legacy island mount globals', as
 
   assert.match(html, /Your subjects/);
   assert.match(html, /KS2 Mastery/);
+  assert.match(html, /class="app-shell home-entry-shell"/);
   assert.doesNotMatch(html, /data-home-mount/);
   assert.doesNotMatch(html, /__ks2HomeSurface/);
 });


### PR DESCRIPTION
## Summary
- Delay subject-to-home navigation briefly so the subject screen can play an exit animation
- Add a matching dashboard entry animation on first load and return to home
- Respect reduced-motion preferences by skipping the delayed exit path

## Verification
- npm test -- tests/react-app-shell.test.js
- npm test
- npm run check
- Local browser smoke: dashboard entry, spelling entry, subject exit, dashboard return