### PR TITLE
Fix mobile word-bank explainer modal viewport anchoring

### DIFF
--- a/src/subjects/spelling/components/SpellingWordDetailModal.jsx
+++ b/src/subjects/spelling/components/SpellingWordDetailModal.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { createPortal } from 'react-dom';
 import { ArrowRightIcon, SpeakerIcon, SpeakerSlowIcon } from './spelling-icons.jsx';
 import { Cloze } from './SpellingCommon.jsx';
 import {
@@ -170,7 +171,7 @@ export function SpellingWordDetailModal({ word, mode = 'explain', typed = '', re
     renderAction(actions, event, 'spelling-word-detail-close');
   };
 
-  return (
+  const modal = (
     <div className="wb-modal-scrim" role="dialog" aria-modal="true" aria-labelledby="wb-modal-word" onClick={closeFromScrim}>
       <div className="wb-modal-backdrop" tabIndex="-1" aria-hidden="true" />
       <div className="wb-modal" data-slug={word.slug}>
@@ -239,4 +240,7 @@ export function SpellingWordDetailModal({ word, mode = 'explain', typed = '', re
       </div>
     </div>
   );
+
+  if (typeof document === 'undefined' || !document.body) return modal;
+  return createPortal(modal, document.body);
 }


### PR DESCRIPTION
### Motivation
- Tapping a word on mobile could open the explanation card offset or off-screen because the modal was rendered inside transformed/scrolling ancestors instead of the top-level viewport. This change ensures the explainer appears immediately after tapping a word.

### Description
- Render the word-detail modal via a React portal by importing `createPortal` and mounting the modal into `document.body` in `src/subjects/spelling/components/SpellingWordDetailModal.jsx`.
- Keep a safe non-DOM fallback return for environments without `document` (SSR/tests) so server-side rendering and unit tests remain compatible.
- No copy or interaction behaviour changes other than the modal mounting location.

### Testing
- Ran `npm test -- tests/react-spelling-surface.test.js tests/react-accessibility-contract.test.js` and the two test files passed (all subtests OK).
- An attempted run using `--runInBand` failed because `node --test` does not accept that option, which is an invocation issue rather than a code failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea328ba0148323a90b2d9e8b771a17)