### PR TITLE
Disable keyboard suggestions on spelling answer inputs

### DIFF
--- a/src/subjects/spelling/components/SpellingCommon.jsx
+++ b/src/subjects/spelling/components/SpellingCommon.jsx
@@ -5,6 +5,13 @@ import {
   pathProgressDots,
 } from './spelling-view-model.js';
 
+export const spellingAnswerInputProps = {
+  autoComplete: 'off',
+  autoCapitalize: 'none',
+  autoCorrect: 'off',
+  spellCheck: false,
+};
+
 export function PathProgress({ done, current, total }) {
   const safeTotal = Math.max(1, Number(total) || 1);
   const dots = pathProgressDots({ done, current, total });

--- a/src/subjects/spelling/components/SpellingSessionScene.jsx
+++ b/src/subjects/spelling/components/SpellingSessionScene.jsx
@@ -7,7 +7,7 @@ import {
   spellingSessionVoiceNote,
 } from '../session-ui.js';
 import { ArrowRightIcon, SpeakerIcon, SpeakerSlowIcon } from './spelling-icons.jsx';
-import { Cloze, FeedbackSlot, PathProgress } from './SpellingCommon.jsx';
+import { Cloze, FeedbackSlot, PathProgress, spellingAnswerInputProps } from './SpellingCommon.jsx';
 import { SpellingHeroBackdrop } from './SpellingHeroBackdrop.jsx';
 import {
   SPELLING_SESSION_QUESTION_REVEAL_MS,
@@ -114,9 +114,7 @@ export function SpellingSessionScene({ learner, service, ui, accent, actions, pr
                   className="word-input"
                   name="typed"
                   data-autofocus="true"
-                  autoComplete="off"
-                  autoCapitalize="none"
-                  spellCheck={false}
+                  {...spellingAnswerInputProps}
                   placeholder={inputPlaceholder}
                   aria-label="Type the spelling"
                   disabled={awaitingAdvance}

--- a/src/subjects/spelling/components/SpellingWordDetailModal.jsx
+++ b/src/subjects/spelling/components/SpellingWordDetailModal.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { createPortal } from 'react-dom';
 import { ArrowRightIcon, SpeakerIcon, SpeakerSlowIcon } from './spelling-icons.jsx';
-import { Cloze } from './SpellingCommon.jsx';
+import { Cloze, spellingAnswerInputProps } from './SpellingCommon.jsx';
 import {
   buildDrillCloze,
   renderAction,
@@ -104,9 +104,7 @@ function DrillBody({ word, typed, result, accent, actions }) {
           type="text"
           name="typed"
           className={`wb-drill-input ${inputState}`.trim()}
-          autoComplete="off"
-          autoCapitalize="none"
-          spellCheck={false}
+          {...spellingAnswerInputProps}
           placeholder="Type the word…"
           value={draftTyped}
           data-autofocus="true"


### PR DESCRIPTION
### Motivation
- James：關閉 iPhone 鍵盤嘅建議（predictive / autocorrect），以免拼字測驗或 word-checking 時出現提示導致作弊；Disable keyboard suggestions during spelling sessions to protect assessment integrity.

### Description
- Add a shared `spellingAnswerInputProps` in `src/subjects/spelling/components/SpellingCommon.jsx` and apply it via spread (`{...spellingAnswerInputProps}`) to the live session input in `SpellingSessionScene.jsx` and the word-bank drill input in `SpellingWordDetailModal.jsx`, setting `autoComplete: 'off'`, `autoCapitalize: 'none'`, `autoCorrect: 'off'`, and `spellCheck: false`.

### Testing
- Ran `npm test` (all tests passed) and `npm run check` (build and deploy dry-run completed) successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea34ae99288323a6327e61b53c91da)