### PR TITLE
Refine spelling session transitions and defer auto-speak

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -978,6 +978,7 @@ function buildCodexModel(appState, context) {
 function buildSurfaceActions() {
   return {
     dispatch: dispatchAction,
+    flushSpellingDeferredAudio: () => controller.flushDeferredAudio(),
     toggleTheme: () => dispatchAction('toggle-theme'),
     selectLearner: (value) => dispatchAction('learner-select', { value }),
     navigateHome: () => dispatchAction('navigate-home'),

--- a/src/platform/app/create-app-controller.js
+++ b/src/platform/app/create-app-controller.js
@@ -73,6 +73,7 @@ export function createAppController({
   });
 
   let currentSnapshot = null;
+  let deferredAudio = null;
 
   function readSnapshot() {
     return buildControllerSnapshot({
@@ -114,6 +115,23 @@ export function createAppController({
     return autoAdvance.ensureScheduledFromState(appState.subjectUi.spelling);
   }
 
+  function clearDeferredAudio() {
+    deferredAudio = null;
+  }
+
+  function queueDeferredAudio(payload) {
+    deferredAudio = payload?.word ? payload : null;
+    return Boolean(deferredAudio);
+  }
+
+  function flushDeferredAudio() {
+    const payload = deferredAudio;
+    deferredAudio = null;
+    if (!payload?.word) return false;
+    tts.speak(payload);
+    return true;
+  }
+
   function applySubjectTransition(subjectId, transition) {
     if (!transition) return false;
     const previousSubjectUi = store.getState().subjectUi[subjectId] || null;
@@ -151,7 +169,14 @@ export function createAppController({
       tab: store.getState().route.tab || 'practice',
     });
 
-    if (transition.audio?.word) tts.speak(transition.audio);
+    if (transition.audio?.word) {
+      if (transition.deferAudioUntilFlowTransitionEnd) {
+        queueDeferredAudio(transition.audio);
+      } else {
+        clearDeferredAudio();
+        tts.speak(transition.audio);
+      }
+    }
     if (subjectId === 'spelling') autoAdvance.scheduleFromTransition(transition);
     return true;
   }
@@ -364,6 +389,7 @@ export function createAppController({
   }
 
   function dispatch(action, data = {}) {
+    clearDeferredAudio();
     autoAdvance.clear();
     try {
       if (!handleGlobalAction(action, data)) {
@@ -404,5 +430,6 @@ export function createAppController({
     scheduler,
     ensureSpellingAutoAdvanceFromCurrentState,
     applySubjectTransition,
+    flushDeferredAudio,
   };
 }

--- a/src/subjects/spelling/components/SpellingCommon.jsx
+++ b/src/subjects/spelling/components/SpellingCommon.jsx
@@ -5,6 +5,8 @@ import {
   pathProgressDots,
 } from './spelling-view-model.js';
 
+const useMeasuredLayoutEffect = typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect;
+
 export function PathProgress({ done, current, total }) {
   const safeTotal = Math.max(1, Number(total) || 1);
   const dots = pathProgressDots({ done, current, total });
@@ -55,6 +57,53 @@ export function Ribbon({ tone, icon, headline, word, sub }) {
   );
 }
 
+export function AnimatedPromptCard({ className = '', innerClassName = '', children }) {
+  const contentRef = React.useRef(null);
+  const [height, setHeight] = React.useState(null);
+
+  useMeasuredLayoutEffect(() => {
+    const node = contentRef.current;
+    if (!node || typeof window === 'undefined') return undefined;
+
+    let frameId = 0;
+    const measure = () => {
+      frameId = 0;
+      const nextHeight = Math.ceil(node.getBoundingClientRect().height);
+      setHeight((current) => (current === nextHeight ? current : nextHeight));
+    };
+    const scheduleMeasure = () => {
+      if (frameId) return;
+      frameId = window.requestAnimationFrame(measure);
+    };
+
+    scheduleMeasure();
+    window.addEventListener('resize', scheduleMeasure);
+
+    const observer = typeof ResizeObserver === 'function'
+      ? new ResizeObserver(() => scheduleMeasure())
+      : null;
+    observer?.observe(node);
+
+    return () => {
+      if (frameId) window.cancelAnimationFrame(frameId);
+      observer?.disconnect();
+      window.removeEventListener('resize', scheduleMeasure);
+    };
+  }, []);
+
+  const classes = ['prompt-card', 'animated-prompt-card', className].filter(Boolean).join(' ');
+  const innerClasses = ['prompt-card-inner', innerClassName].filter(Boolean).join(' ');
+  const style = height ? { '--prompt-card-height': `${height}px` } : undefined;
+
+  return (
+    <div className={classes} style={style}>
+      <div className={innerClasses} ref={contentRef}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
 function feedbackSub(feedback) {
   const attempt = String(feedback?.attemptedAnswer || '').trim();
   const body = feedback?.body || '';
@@ -64,16 +113,7 @@ function feedbackSub(feedback) {
 }
 
 export function FeedbackSlot({ feedback }) {
-  if (!feedback) {
-    return (
-      <div className="feedback-slot is-placeholder" aria-hidden="true">
-        <div className="ribbon good" role="presentation">
-          <div className="ribbon-ic">{'\u00a0'}</div>
-          <div className="ribbon-body"><b>{'\u00a0'}</b><div className="sub">{'\u00a0'}</div></div>
-        </div>
-      </div>
-    );
-  }
+  if (!feedback) return null;
   const tone = feedbackTone(feedback.kind);
   const icon = tone === 'good' ? <CheckIcon /> : tone === 'warn' ? '!' : '×';
   return (

--- a/src/subjects/spelling/components/SpellingPracticeSurface.jsx
+++ b/src/subjects/spelling/components/SpellingPracticeSurface.jsx
@@ -40,9 +40,17 @@ function rememberSetupTone(learnerId, tone) {
 function heroBgForPhase(spelling, setupHeroTone) {
   const learnerId = spelling.learner?.id;
   if (!learnerId) return '';
-  if (spelling.ui.phase === 'session') return heroBgForSession(learnerId, spelling.ui.session);
+  if (spelling.ui.phase === 'session') {
+    return heroBgForSession(learnerId, spelling.ui.session, {
+      awaitingAdvance: Boolean(spelling.ui.awaitingAdvance),
+    });
+  }
   if (spelling.ui.phase === 'summary') {
-    return heroBgForSession(learnerId, { mode: spelling.ui.summary?.mode });
+    const progressTotal = Math.max(1, spelling.ui.summary?.totalWords || 1);
+    return heroBgForSession(learnerId, {
+      mode: spelling.ui.summary?.mode,
+      progress: { done: progressTotal, total: progressTotal },
+    }, { complete: true });
   }
   if (spelling.ui.phase === 'word-bank') return heroBgForLearner(learnerId);
   return heroBgForSetup(learnerId, spelling.prefs, { tone: setupHeroTone });

--- a/src/subjects/spelling/components/SpellingSessionScene.jsx
+++ b/src/subjects/spelling/components/SpellingSessionScene.jsx
@@ -14,6 +14,7 @@ import {
   heroBgStyle,
   renderAction,
   renderFormAction,
+  spellingSessionProgressIndex,
 } from './spelling-view-model.js';
 
 const SESSION_HERO_MORPH_MS = 720;
@@ -60,10 +61,13 @@ export function SpellingSessionScene({ learner, service, ui, accent, actions, pr
   const infoChips = spellingSessionInfoChips(session);
   const progressTotal = session.progress.total;
   const done = session.progress.done;
-  const progressCurrent = progressTotal <= 0 ? 0 : Math.min(progressTotal, done + 1);
+  const progressCurrent = progressTotal <= 0
+    ? 0
+    : spellingSessionProgressIndex(session, { awaitingAdvance });
   const pathDone = Math.min(progressTotal, done);
   const pathCurrent = Math.min(Math.max(progressCurrent - 1, 0), progressTotal);
-  const heroBg = heroBgForSession(learner.id, session);
+  const heroBg = heroBgForSession(learner.id, session, { awaitingAdvance });
+  const isCompletingRound = awaitingAdvance && progressTotal > 0 && done >= progressTotal;
   const showingCorrection = session.phase === 'correction';
   const promptInstr = session.type === 'test'
     ? 'Type the word dictated by the audio.'
@@ -160,7 +164,9 @@ export function SpellingSessionScene({ learner, service, ui, accent, actions, pr
                     className="btn good lg"
                     type="button"
                     data-action="spelling-continue"
-                    onClick={(event) => renderAction(actions, event, 'spelling-continue')}
+                    onClick={(event) => renderAction(actions, event, 'spelling-continue', {
+                      flowTransition: isCompletingRound,
+                    })}
                   >
                     Continue <ArrowRightIcon />
                   </button>

--- a/src/subjects/spelling/components/SpellingSessionScene.jsx
+++ b/src/subjects/spelling/components/SpellingSessionScene.jsx
@@ -7,7 +7,12 @@ import {
   spellingSessionVoiceNote,
 } from '../session-ui.js';
 import { ArrowRightIcon, SpeakerIcon, SpeakerSlowIcon } from './spelling-icons.jsx';
-import { Cloze, FeedbackSlot, PathProgress } from './SpellingCommon.jsx';
+import {
+  AnimatedPromptCard,
+  Cloze,
+  FeedbackSlot,
+  PathProgress,
+} from './SpellingCommon.jsx';
 import { SpellingHeroBackdrop } from './SpellingHeroBackdrop.jsx';
 import {
   heroBgForSession,
@@ -101,8 +106,7 @@ export function SpellingSessionScene({ learner, service, ui, accent, actions, pr
           <span className="path-count">Word {progressCurrent} of {progressTotal}</span>
         </header>
 
-        <div className="prompt-card">
-          <div className="prompt-card-inner">
+        <AnimatedPromptCard>
             {infoChips.length ? (
               <div className="info-chip-row">
                 {infoChips.map((value) => <span className="chip" key={value}>{value}</span>)}
@@ -185,8 +189,7 @@ export function SpellingSessionScene({ learner, service, ui, accent, actions, pr
             </form>
 
             <FeedbackSlot feedback={ui.feedback} />
-          </div>
-        </div>
+        </AnimatedPromptCard>
 
         <footer className="session-footer">
           <div className="session-footer-left">

--- a/src/subjects/spelling/components/SpellingSummaryScene.jsx
+++ b/src/subjects/spelling/components/SpellingSummaryScene.jsx
@@ -30,7 +30,7 @@ export function SpellingSummaryScene({ learner, ui, accent, actions, previousHer
   const heroBg = heroBgForSession(learner.id, {
     mode: summary.mode,
     progress: { done: progressTotal, total: progressTotal },
-  });
+  }, { complete: true });
   const toneGood = !summary.mistakes.length;
 
   return (

--- a/src/subjects/spelling/components/SpellingSummaryScene.jsx
+++ b/src/subjects/spelling/components/SpellingSummaryScene.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ArrowRightIcon, CheckIcon } from './spelling-icons.jsx';
-import { PathProgress, Ribbon } from './SpellingCommon.jsx';
+import { AnimatedPromptCard, PathProgress, Ribbon } from './SpellingCommon.jsx';
 import { SpellingHeroBackdrop } from './SpellingHeroBackdrop.jsx';
 import {
   heroBgForSession,
@@ -42,7 +42,7 @@ export function SpellingSummaryScene({ learner, ui, accent, actions, previousHer
           <span className="path-count">Round complete</span>
         </header>
 
-        <div className="prompt-card summary-card">
+        <AnimatedPromptCard className="summary-card" innerClassName="summary-card-inner">
           <h3 className="summary-title sr-only">Session summary</h3>
           <Ribbon
             tone={toneGood ? 'good' : 'warn'}
@@ -111,7 +111,7 @@ export function SpellingSummaryScene({ learner, ui, accent, actions, previousHer
               Open word bank <ArrowRightIcon />
             </button>
           </div>
-        </div>
+        </AnimatedPromptCard>
       </div>
     </div>
   );

--- a/src/subjects/spelling/components/spelling-view-model.js
+++ b/src/subjects/spelling/components/spelling-view-model.js
@@ -115,8 +115,41 @@ export function heroBgForSetup(learnerId, prefs, options = {}) {
   return heroBgForMode(prefs?.mode, learnerId, options);
 }
 
-export function heroBgForSession(learnerId, session) {
-  return heroBgForMode(session?.mode || (session?.type === 'test' ? 'test' : 'smart'), learnerId, { tone: '1' });
+function sessionProgressTotal(session) {
+  const rawTotal = Number(session?.progress?.total ?? session?.totalWords ?? 0);
+  return Number.isFinite(rawTotal) && rawTotal > 0 ? Math.floor(rawTotal) : 1;
+}
+
+export function spellingSessionProgressIndex(session, options = {}) {
+  const total = sessionProgressTotal(session);
+  const explicitIndex = Number(options.questionIndex);
+  if (Number.isFinite(explicitIndex) && explicitIndex > 0) {
+    return Math.min(total, Math.max(1, Math.floor(explicitIndex)));
+  }
+
+  const rawDone = Number(session?.progress?.done ?? session?.progress?.checked ?? 0);
+  const done = Number.isFinite(rawDone) && rawDone > 0 ? Math.floor(rawDone) : 0;
+  const current = done + (options.awaitingAdvance ? 0 : 1);
+  return Math.min(total, Math.max(1, current));
+}
+
+export function spellingHeroToneForSessionProgress(session, options = {}) {
+  if (options.complete) return '3';
+  const total = sessionProgressTotal(session);
+  const current = spellingSessionProgressIndex(session, options);
+  const firstLimit = Math.max(1, Math.floor(total / SPELLING_HERO_TONES.length));
+  const secondLimit = Math.max(firstLimit + 1, Math.floor((total * 2) / SPELLING_HERO_TONES.length));
+  if (current <= firstLimit) return '1';
+  if (current <= secondLimit) return '2';
+  return '3';
+}
+
+export function heroBgForSession(learnerId, session, options = {}) {
+  const requestedTone = String(options.tone || '');
+  const tone = SPELLING_HERO_TONES.includes(requestedTone)
+    ? requestedTone
+    : spellingHeroToneForSessionProgress(session, options);
+  return heroBgForMode(session?.mode || (session?.type === 'test' ? 'test' : 'smart'), learnerId, { tone });
 }
 
 export function heroBgPreloadUrls(learnerId, prefs = {}, options = {}) {
@@ -126,8 +159,9 @@ export function heroBgPreloadUrls(learnerId, prefs = {}, options = {}) {
     ? String(options.setupTone)
     : spellingHeroTone(learnerId);
   const setupUrls = modes.map((mode) => heroBgForMode(mode, learnerId, { tone: setupTone }));
-  const sessionUrl = heroBgForMode(prefs?.mode || 'smart', learnerId, { tone: '1' });
-  return [...new Set([...setupUrls, sessionUrl].filter(Boolean))];
+  const sessionMode = prefs?.mode || 'smart';
+  const sessionUrls = SPELLING_HERO_TONES.map((tone) => heroBgForMode(sessionMode, learnerId, { tone }));
+  return [...new Set([...setupUrls, ...sessionUrls].filter(Boolean))];
 }
 
 export function heroToneForBg(url) {
@@ -279,8 +313,11 @@ export function renderAction(actions, event, action, data = {}) {
   const payload = action === 'spelling-word-detail-open' && data && typeof data === 'object'
     ? { ...data, triggerElement: event?.currentTarget || data.triggerElement || null }
     : data;
+  const shouldStartFlowTransition = action === 'spelling-start'
+    || action === 'spelling-start-again'
+    || (action === 'spelling-continue' && Boolean(data?.flowTransition));
   if (
-    (action === 'spelling-start' || action === 'spelling-start-again')
+    shouldStartFlowTransition
     && typeof document !== 'undefined'
     && typeof document.startViewTransition === 'function'
   ) {

--- a/src/subjects/spelling/components/spelling-view-model.js
+++ b/src/subjects/spelling/components/spelling-view-model.js
@@ -307,28 +307,53 @@ export function buildDrillCloze(sentence, word) {
   return '________';
 }
 
+let activeSpellingFlowTransition = null;
+
 export function renderAction(actions, event, action, data = {}) {
   event?.preventDefault?.();
   event?.stopPropagation?.();
-  const payload = action === 'spelling-word-detail-open' && data && typeof data === 'object'
+  const basePayload = action === 'spelling-word-detail-open' && data && typeof data === 'object'
     ? { ...data, triggerElement: event?.currentTarget || data.triggerElement || null }
     : data;
+  const shouldDeferAutoSpeak = action === 'spelling-start' || action === 'spelling-start-again';
   const shouldStartFlowTransition = action === 'spelling-start'
     || action === 'spelling-start-again'
     || (action === 'spelling-continue' && Boolean(data?.flowTransition));
+  const supportsFlowTransition = typeof document !== 'undefined'
+    && typeof document.startViewTransition === 'function';
+  const deferAutoSpeakUntilTransitionEnd = shouldDeferAutoSpeak
+    && shouldStartFlowTransition
+    && supportsFlowTransition;
+  const payload = deferAutoSpeakUntilTransitionEnd
+    ? {
+        ...(basePayload && typeof basePayload === 'object' && !Array.isArray(basePayload) ? basePayload : {}),
+        deferAudioUntilFlowTransitionEnd: true,
+      }
+    : basePayload;
   if (
     shouldStartFlowTransition
-    && typeof document !== 'undefined'
-    && typeof document.startViewTransition === 'function'
+    && supportsFlowTransition
   ) {
+    if (activeSpellingFlowTransition) return;
+    const token = {};
+    activeSpellingFlowTransition = token;
     document.documentElement.classList.add('spelling-flow-transition');
-    const transition = document.startViewTransition(() => {
-      actions.dispatch(action, payload);
-    });
-    transition.finished
+    let transition = null;
+    try {
+      transition = document.startViewTransition(() => {
+        actions.dispatch(action, payload);
+      });
+    } catch (error) {
+      if (activeSpellingFlowTransition === token) activeSpellingFlowTransition = null;
+      document.documentElement.classList.remove('spelling-flow-transition');
+      throw error;
+    }
+    Promise.resolve(transition?.finished)
       .catch(() => {})
       .finally(() => {
+        if (activeSpellingFlowTransition === token) activeSpellingFlowTransition = null;
         document.documentElement.classList.remove('spelling-flow-transition');
+        if (deferAutoSpeakUntilTransitionEnd) actions.flushSpellingDeferredAudio?.();
       });
     return;
   }

--- a/src/subjects/spelling/module.js
+++ b/src/subjects/spelling/module.js
@@ -8,11 +8,14 @@ import {
 
 function applySpellingTransition(context, transition) {
   if (!transition) return true;
+  const nextTransition = context.data?.deferAudioUntilFlowTransitionEnd && transition.audio?.word
+    ? { ...transition, deferAudioUntilFlowTransitionEnd: true }
+    : transition;
   if (typeof context.applySubjectTransition === 'function') {
-    return context.applySubjectTransition('spelling', transition);
+    return context.applySubjectTransition('spelling', nextTransition);
   }
-  context.store.updateSubjectUi('spelling', transition.state);
-  if (transition.audio?.word) context.tts?.speak?.(transition.audio);
+  context.store.updateSubjectUi('spelling', nextTransition.state);
+  if (nextTransition.audio?.word) context.tts?.speak?.(nextTransition.audio);
   return true;
 }
 

--- a/styles/app.css
+++ b/styles/app.css
@@ -4233,7 +4233,7 @@ textarea:focus-visible {
   border-radius: var(--radius-lg);
   background: var(--panel);
   box-shadow: var(--shadow-warm);
-  min-height: 610px;
+  min-height: var(--spelling-shell-min-height);
   view-transition-name: spelling-hero-card;
   /* Default on-hero tokens assume a light/mid-light backdrop.
      Add `.hero-dark` at runtime if/when luminance detection
@@ -4243,12 +4243,10 @@ textarea:focus-visible {
   --on-hero-chip-bg: color-mix(in oklab, var(--panel) 90%, transparent);
   --on-hero-chip-border: color-mix(in oklab, var(--line-strong) 80%, var(--ink));
   --on-hero-chip-ink: color-mix(in oklab, var(--ink) 92%, black);
-  --spelling-prompt-card-height: 680px;
-  --spelling-prompt-card-padding-y: 72px;
+  --spelling-shell-min-height: 860px;
   --spelling-cloze-font-size: 2rem;
   --spelling-cloze-line-height: 1.2;
   --spelling-cloze-lines: 2;
-  --spelling-feedback-slot-height: 164px;
 }
 .spelling-in-session::before {
   content: "";
@@ -4275,6 +4273,7 @@ textarea:focus-visible {
 .spelling-in-session .session {
   max-width: 780px;
   margin: 0 auto;
+  min-height: calc(var(--spelling-shell-min-height) - 96px);
   position: relative;
   z-index: 2;
 }
@@ -4362,16 +4361,21 @@ textarea:focus-visible {
   border: 1px solid color-mix(in oklab, var(--line) 80%, transparent);
   border-radius: var(--radius-lg);
   padding: 40px 36px 32px;
-  height: var(--spelling-prompt-card-height);
-  overflow: hidden;
+  overflow: clip;
   box-shadow: var(--shadow-warm);
   position: relative;
   view-transition-name: spelling-session-prompt;
 }
+.spelling-in-session .prompt-card.animated-prompt-card {
+  height: var(--prompt-card-height, auto);
+  transition: height 320ms var(--ease-out),
+              filter 320ms var(--ease-out),
+              transform 320ms var(--ease-out);
+  will-change: height;
+}
 .spelling-in-session .prompt-card-inner {
   display: flex;
   flex-direction: column;
-  height: calc(var(--spelling-prompt-card-height) - var(--spelling-prompt-card-padding-y));
   min-height: 0;
 }
 .spelling-in-session .prompt-card::before {
@@ -4653,25 +4657,16 @@ textarea:focus-visible {
 }
 
 /* ---------- Feedback ribbon + family chips ---------- */
-/* .feedback-slot wraps either a live ribbon + chips or an
-   invisible placeholder of identical height so the prompt-card
-   doesn't shift between question / correct / wrong states. */
+/* Feedback now contributes its real measured height; the
+   AnimatedPromptCard wrapper interpolates the surrounding card
+   height between question, feedback, and summary states. */
 .spelling-in-session .feedback-slot {
-  margin-top: auto;
-  flex: 0 0 var(--spelling-feedback-slot-height);
-  min-height: 0;
-  overflow-y: auto;
-  overscroll-behavior: contain;
-  padding-top: 18px;
-  scrollbar-width: thin;
+  margin-top: 18px;
 }
-.spelling-in-session .feedback-slot.is-placeholder { visibility: hidden; }
-.spelling-in-session .feedback-slot.is-placeholder * { animation: none !important; }
 .spelling-in-session .feedback-foot {
   margin-top: 8px;
   font-size: 0.86rem;
   line-height: 1.35;
-  min-height: calc(0.86rem * 1.35 * 2);
   color: color-mix(in oklab, var(--ink) 72%, transparent);
   text-align: center;
 }
@@ -4742,13 +4737,9 @@ textarea:focus-visible {
 .spelling-in-session .family-chips {
   display: flex;
   gap: 8px;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   margin-top: 14px;
-  min-height: 32px;
-  overflow-x: auto;
-  overflow-y: hidden;
   padding-left: 4px;
-  scrollbar-width: thin;
 }
 .spelling-in-session .family-chips .flabel {
   font-size: 0.76rem;
@@ -4777,10 +4768,10 @@ textarea:focus-visible {
   position: relative;
   z-index: 3;
 }
-.spelling-in-session .prompt-card.summary-card {
+.spelling-in-session .prompt-card.summary-card { padding-top: 34px; }
+.spelling-in-session .summary-card-inner {
   display: flex;
   flex-direction: column;
-  padding-top: 34px;
 }
 .spelling-in-session .prompt-card.summary-card::before { display: none; }
 .spelling-in-session .prompt-card.summary-card > .ribbon:first-child { margin-top: 0; }
@@ -4837,10 +4828,6 @@ textarea:focus-visible {
   background: color-mix(in oklab, var(--warn-soft) 70%, var(--panel));
   border: 1px solid color-mix(in oklab, var(--warn) 26%, transparent);
   border-radius: var(--radius);
-  max-height: 154px;
-  overflow-y: auto;
-  overscroll-behavior: contain;
-  scrollbar-width: thin;
 }
 .spelling-in-session .summary-drill-head {
   display: flex;
@@ -4869,8 +4856,7 @@ textarea:focus-visible {
   gap: 10px;
   justify-content: center;
   align-items: center;
-  margin-top: auto;
-  padding-top: 28px;
+  margin-top: 28px;
 }
 .spelling-in-session .summary-bank-link {
   appearance: none;
@@ -5792,11 +5778,9 @@ textarea:focus-visible {
 @media (max-width: 640px) {
   .spelling-in-session {
     padding: 16px 12px;
-    --spelling-prompt-card-height: 768px;
-    --spelling-prompt-card-padding-y: 50px;
+    --spelling-shell-min-height: 920px;
     --spelling-cloze-font-size: 1.55rem;
     --spelling-cloze-lines: 3;
-    --spelling-feedback-slot-height: 188px;
   }
   .spelling-in-session .prompt-card { padding: 28px 20px 22px; }
   .spelling-in-session .prompt-card::before { left: 16px; right: 16px; }

--- a/styles/app.css
+++ b/styles/app.css
@@ -4243,6 +4243,12 @@ textarea:focus-visible {
   --on-hero-chip-bg: color-mix(in oklab, var(--panel) 90%, transparent);
   --on-hero-chip-border: color-mix(in oklab, var(--line-strong) 80%, var(--ink));
   --on-hero-chip-ink: color-mix(in oklab, var(--ink) 92%, black);
+  --spelling-prompt-card-height: 680px;
+  --spelling-prompt-card-padding-y: 72px;
+  --spelling-cloze-font-size: 2rem;
+  --spelling-cloze-line-height: 1.2;
+  --spelling-cloze-lines: 2;
+  --spelling-feedback-slot-height: 164px;
 }
 .spelling-in-session::before {
   content: "";
@@ -4356,9 +4362,17 @@ textarea:focus-visible {
   border: 1px solid color-mix(in oklab, var(--line) 80%, transparent);
   border-radius: var(--radius-lg);
   padding: 40px 36px 32px;
+  height: var(--spelling-prompt-card-height);
+  overflow: hidden;
   box-shadow: var(--shadow-warm);
   position: relative;
   view-transition-name: spelling-session-prompt;
+}
+.spelling-in-session .prompt-card-inner {
+  display: flex;
+  flex-direction: column;
+  height: calc(var(--spelling-prompt-card-height) - var(--spelling-prompt-card-padding-y));
+  min-height: 0;
 }
 .spelling-in-session .prompt-card::before {
   content: "";
@@ -4475,10 +4489,11 @@ textarea:focus-visible {
 .spelling-in-session .cloze {
   text-align: center;
   font-family: var(--font-serif);
-  font-size: clamp(1.6rem, 3.2vw, 2.2rem);
+  font-size: var(--spelling-cloze-font-size);
   font-weight: 500;
   letter-spacing: -0.015em;
-  line-height: 1.2;
+  line-height: var(--spelling-cloze-line-height);
+  min-height: calc(var(--spelling-cloze-font-size) * var(--spelling-cloze-line-height) * var(--spelling-cloze-lines));
   margin-bottom: 24px;
   color: color-mix(in oklab, var(--ink) 92%, black);
 }
@@ -4642,13 +4657,21 @@ textarea:focus-visible {
    invisible placeholder of identical height so the prompt-card
    doesn't shift between question / correct / wrong states. */
 .spelling-in-session .feedback-slot {
-  margin-top: 18px;
+  margin-top: auto;
+  flex: 0 0 var(--spelling-feedback-slot-height);
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-top: 18px;
+  scrollbar-width: thin;
 }
 .spelling-in-session .feedback-slot.is-placeholder { visibility: hidden; }
 .spelling-in-session .feedback-slot.is-placeholder * { animation: none !important; }
 .spelling-in-session .feedback-foot {
   margin-top: 8px;
   font-size: 0.86rem;
+  line-height: 1.35;
+  min-height: calc(0.86rem * 1.35 * 2);
   color: color-mix(in oklab, var(--ink) 72%, transparent);
   text-align: center;
 }
@@ -4719,9 +4742,13 @@ textarea:focus-visible {
 .spelling-in-session .family-chips {
   display: flex;
   gap: 8px;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   margin-top: 14px;
+  min-height: 32px;
+  overflow-x: auto;
+  overflow-y: hidden;
   padding-left: 4px;
+  scrollbar-width: thin;
 }
 .spelling-in-session .family-chips .flabel {
   font-size: 0.76rem;
@@ -4750,7 +4777,11 @@ textarea:focus-visible {
   position: relative;
   z-index: 3;
 }
-.spelling-in-session .prompt-card.summary-card { padding-top: 34px; }
+.spelling-in-session .prompt-card.summary-card {
+  display: flex;
+  flex-direction: column;
+  padding-top: 34px;
+}
 .spelling-in-session .prompt-card.summary-card::before { display: none; }
 .spelling-in-session .prompt-card.summary-card > .ribbon:first-child { margin-top: 0; }
 .spelling-in-session .prompt-card.summary-card > .summary-title + .ribbon { margin-top: 0; }
@@ -4806,6 +4837,10 @@ textarea:focus-visible {
   background: color-mix(in oklab, var(--warn-soft) 70%, var(--panel));
   border: 1px solid color-mix(in oklab, var(--warn) 26%, transparent);
   border-radius: var(--radius);
+  max-height: 154px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
 }
 .spelling-in-session .summary-drill-head {
   display: flex;
@@ -4834,7 +4869,8 @@ textarea:focus-visible {
   gap: 10px;
   justify-content: center;
   align-items: center;
-  margin-top: 28px;
+  margin-top: auto;
+  padding-top: 28px;
 }
 .spelling-in-session .summary-bank-link {
   appearance: none;
@@ -5754,7 +5790,14 @@ textarea:focus-visible {
 
 /* 2. Prompt card padding tuned for phones */
 @media (max-width: 640px) {
-  .spelling-in-session { padding: 16px 12px; }
+  .spelling-in-session {
+    padding: 16px 12px;
+    --spelling-prompt-card-height: 768px;
+    --spelling-prompt-card-padding-y: 50px;
+    --spelling-cloze-font-size: 1.55rem;
+    --spelling-cloze-lines: 3;
+    --spelling-feedback-slot-height: 188px;
+  }
   .spelling-in-session .prompt-card { padding: 28px 20px 22px; }
   .spelling-in-session .prompt-card::before { left: 16px; right: 16px; }
 }

--- a/styles/app.css
+++ b/styles/app.css
@@ -4387,6 +4387,11 @@ textarea:focus-visible {
 }
 
 @supports (view-transition-name: spelling-hero-card) {
+  html.spelling-flow-transition [data-action="spelling-start"],
+  html.spelling-flow-transition [data-action="spelling-start-again"],
+  html.spelling-flow-transition [data-action="spelling-continue"] {
+    pointer-events: none;
+  }
   html.spelling-flow-transition::view-transition-group(spelling-hero-card) {
     animation-duration: 720ms;
     animation-timing-function: var(--ease-in-out);

--- a/tests/app-controller.test.js
+++ b/tests/app-controller.test.js
@@ -181,6 +181,24 @@ test('controller dispatches spelling transitions through store, repositories, ev
   assert.ok(controller.repositories.practiceSessions.list(learnerId).length >= 1);
 });
 
+test('controller can defer spelling start audio until the flow transition flushes', () => {
+  installMemoryStorage();
+  const controller = createAppController();
+  const learnerId = controller.store.getState().learners.selectedId;
+  controller.services.spelling.savePrefs(learnerId, { mode: 'smart', roundLength: '1', autoSpeak: true });
+
+  controller.dispatch('open-subject', { subjectId: 'spelling' });
+  controller.dispatch('spelling-start', { deferAudioUntilFlowTransitionEnd: true });
+
+  const state = controller.store.getState();
+  assert.equal(state.subjectUi.spelling.phase, 'session');
+  assert.equal(controller.tts.spoken.length, 0);
+
+  assert.equal(controller.flushDeferredAudio(), true);
+  assert.equal(controller.tts.spoken.length, 1);
+  assert.equal(controller.tts.spoken[0].word.word, state.subjectUi.spelling.session.currentCard.word.word);
+});
+
 test('controller retry preserves the current route and clears runtime boundaries', async () => {
   installMemoryStorage();
   const controller = createAppController();

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -288,6 +288,7 @@ test('spelling setup and session hero backgrounds use mode-specific Scribe Downs
     heroBgPreloadUrls,
     heroBgForSession,
     spellingHeroTone,
+    spellingHeroToneForSessionProgress,
   } = await import('../src/subjects/spelling/components/spelling-view-model.js');
 
   const learnerId = 'learner-1';
@@ -298,6 +299,12 @@ test('spelling setup and session hero backgrounds use mode-specific Scribe Downs
   assert.equal(heroBgForMode('test', learnerId), `/assets/regions/the-scribe-downs/the-scribe-downs-e${tone}.1280.webp`);
   assert.equal(heroBgForSession(learnerId, { mode: 'trouble' }), '/assets/regions/the-scribe-downs/the-scribe-downs-d1.1280.webp');
   assert.equal(heroBgForSession('learner-1', { mode: 'test' }), '/assets/regions/the-scribe-downs/the-scribe-downs-e1.1280.webp');
+  assert.equal(heroBgForSession('learner-1', { mode: 'test', progress: { done: 6, total: 20 } }), '/assets/regions/the-scribe-downs/the-scribe-downs-e2.1280.webp');
+  assert.equal(heroBgForSession('learner-1', { mode: 'test', progress: { done: 13, total: 20 } }), '/assets/regions/the-scribe-downs/the-scribe-downs-e3.1280.webp');
+  assert.equal(heroBgForSession('learner-1', { mode: 'test', progress: { done: 20, total: 20 } }, { complete: true }), '/assets/regions/the-scribe-downs/the-scribe-downs-e3.1280.webp');
+  assert.equal(spellingHeroToneForSessionProgress({ progress: { done: 5, total: 20 } }), '1');
+  assert.equal(spellingHeroToneForSessionProgress({ progress: { done: 6, total: 20 } }), '2');
+  assert.equal(spellingHeroToneForSessionProgress({ progress: { done: 13, total: 20 } }), '3');
   assert.equal(spellingHeroTone('learner-0'), '2');
   assert.match(heroBgForMode('smart', 'learner-0'), /the-scribe-downs-[abc]2\.1280\.webp$/);
   assert.match(heroBgForSession('learner-0', { mode: 'smart' }), /the-scribe-downs-[abc]1\.1280\.webp$/);
@@ -305,15 +312,16 @@ test('spelling setup and session hero backgrounds use mode-specific Scribe Downs
     heroBgForMode('smart', 'learner-1'),
     heroBgForMode('trouble', 'learner-1'),
     heroBgForMode('test', 'learner-1'),
+    heroBgForMode('test', 'learner-1', { tone: '2' }),
+    heroBgForMode('test', 'learner-1', { tone: '3' }),
   ];
-  const learnerOneSession = heroBgForSession('learner-1', { mode: 'test' });
-  if (!learnerOnePreloads.includes(learnerOneSession)) learnerOnePreloads.push(learnerOneSession);
   assert.deepEqual(heroBgPreloadUrls('learner-1', { mode: 'test' }), learnerOnePreloads);
   assert.deepEqual(heroBgPreloadUrls('learner-0', { mode: 'test' }), [
     heroBgForMode('smart', 'learner-0'),
     heroBgForMode('trouble', 'learner-0'),
     heroBgForMode('test', 'learner-0'),
     heroBgForSession('learner-0', { mode: 'test' }),
+    heroBgForMode('test', 'learner-0', { tone: '3' }),
   ]);
   assert.deepEqual(heroContrastProfileForBg('/assets/regions/the-scribe-downs/the-scribe-downs-a1.1280.webp', 'smart'), {
     tone: '1',

--- a/tests/spelling-view-model.test.js
+++ b/tests/spelling-view-model.test.js
@@ -1,0 +1,141 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { renderAction } from '../src/subjects/spelling/components/spelling-view-model.js';
+
+function createEventStub() {
+  return {
+    preventDefaultCalled: 0,
+    stopPropagationCalled: 0,
+    preventDefault() {
+      this.preventDefaultCalled += 1;
+    },
+    stopPropagation() {
+      this.stopPropagationCalled += 1;
+    },
+  };
+}
+
+test('renderAction ignores duplicate spelling flow actions while a view transition is in flight', async () => {
+  const originalDocument = globalThis.document;
+  const classOps = [];
+  const calls = [];
+  let flushCalls = 0;
+  let resolveFinished = null;
+
+  globalThis.document = {
+    documentElement: {
+      classList: {
+        add(token) {
+          classOps.push(['add', token]);
+        },
+        remove(token) {
+          classOps.push(['remove', token]);
+        },
+      },
+    },
+    startViewTransition(callback) {
+      callback();
+      return {
+        finished: new Promise((resolve) => {
+          resolveFinished = resolve;
+        }),
+      };
+    },
+  };
+
+  try {
+    const firstEvent = createEventStub();
+    renderAction({
+      dispatch(action, payload) {
+        calls.push([action, payload]);
+      },
+      flushSpellingDeferredAudio() {
+        flushCalls += 1;
+      },
+    }, firstEvent, 'spelling-start');
+
+    const duplicateEvent = createEventStub();
+    renderAction({
+      dispatch(action, payload) {
+        calls.push([action, payload]);
+      },
+      flushSpellingDeferredAudio() {
+        flushCalls += 1;
+      },
+    }, duplicateEvent, 'spelling-start');
+
+    assert.equal(firstEvent.preventDefaultCalled, 1);
+    assert.equal(firstEvent.stopPropagationCalled, 1);
+    assert.equal(duplicateEvent.preventDefaultCalled, 1);
+    assert.equal(duplicateEvent.stopPropagationCalled, 1);
+    assert.deepEqual(calls.map(([action]) => action), ['spelling-start']);
+    assert.equal(calls[0][1].deferAudioUntilFlowTransitionEnd, true);
+    assert.equal(flushCalls, 0);
+
+    resolveFinished?.();
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.equal(flushCalls, 1);
+
+    renderAction({
+      dispatch(action, payload) {
+        calls.push([action, payload]);
+      },
+      flushSpellingDeferredAudio() {
+        flushCalls += 1;
+      },
+    }, createEventStub(), 'spelling-start-again');
+
+    assert.deepEqual(calls.map(([action]) => action), ['spelling-start', 'spelling-start-again']);
+    assert.deepEqual(classOps, [
+      ['add', 'spelling-flow-transition'],
+      ['remove', 'spelling-flow-transition'],
+      ['add', 'spelling-flow-transition'],
+    ]);
+  } finally {
+    resolveFinished?.();
+    await Promise.resolve();
+    await Promise.resolve();
+    if (originalDocument === undefined) {
+      delete globalThis.document;
+    } else {
+      globalThis.document = originalDocument;
+    }
+  }
+});
+
+test('renderAction keeps spelling start audio immediate when view transitions are unavailable', () => {
+  const originalDocument = globalThis.document;
+  const calls = [];
+
+  globalThis.document = {
+    documentElement: {
+      classList: {
+        add() {},
+        remove() {},
+      },
+    },
+  };
+
+  try {
+    renderAction({
+      dispatch(action, payload) {
+        calls.push([action, payload]);
+      },
+      flushSpellingDeferredAudio() {
+        throw new Error('flush should not run without view transitions');
+      },
+    }, createEventStub(), 'spelling-start');
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0][0], 'spelling-start');
+    assert.equal(calls[0][1]?.deferAudioUntilFlowTransitionEnd, undefined);
+  } finally {
+    if (originalDocument === undefined) {
+      delete globalThis.document;
+    } else {
+      globalThis.document = originalDocument;
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- keep the spelling session shell stable while animating prompt-card height and carrying the hero background through summary
- cross-dissolve day, dusk, and night spelling backdrops across session progress and preserve the seamless question-to-summary transition
- defer spelling auto-speak until the setup-to-question flow transition finishes, with guards against duplicate transition starts

## Testing
- node --test
- node ./scripts/build-bundles.mjs
- node ./scripts/build-public.mjs
- git diff --check