### PR TITLE
Lock spelling prompt height per question

### DIFF
--- a/src/subjects/spelling/components/SpellingCommon.jsx
+++ b/src/subjects/spelling/components/SpellingCommon.jsx
@@ -13,6 +13,14 @@ export const spellingAnswerInputProps = {
   spellCheck: false,
 };
 
+function measurePromptCardHeight(cardNode, contentNode) {
+  if (!cardNode || !contentNode || typeof window === 'undefined') return null;
+  const styles = window.getComputedStyle(cardNode);
+  const chromeHeight = ['paddingTop', 'paddingBottom', 'borderTopWidth', 'borderBottomWidth']
+    .reduce((sum, key) => sum + (Number.parseFloat(styles[key] || '0') || 0), 0);
+  return Math.ceil(contentNode.getBoundingClientRect().height + chromeHeight);
+}
+
 export function PathProgress({ done, current, total }) {
   const safeTotal = Math.max(1, Number(total) || 1);
   const dots = pathProgressDots({ done, current, total });
@@ -63,46 +71,69 @@ export function Ribbon({ tone, icon, headline, word, sub }) {
   );
 }
 
-export function AnimatedPromptCard({ className = '', innerClassName = '', children }) {
+export function AnimatedPromptCard({
+  className = '',
+  innerClassName = '',
+  children,
+  heightKey = '',
+  lockHeightToKey = false,
+}) {
+  const cardRef = React.useRef(null);
   const contentRef = React.useRef(null);
   const [height, setHeight] = React.useState(null);
 
   useMeasuredLayoutEffect(() => {
+    const cardNode = cardRef.current;
     const node = contentRef.current;
-    if (!node || typeof window === 'undefined') return undefined;
+    if (!cardNode || !node || typeof window === 'undefined') return undefined;
 
     let frameId = 0;
+    let settleTimerId = 0;
+    let cancelled = false;
     const measure = () => {
       frameId = 0;
-      const nextHeight = Math.ceil(node.getBoundingClientRect().height);
+      const nextHeight = measurePromptCardHeight(cardNode, node);
+      if (!nextHeight) return;
       setHeight((current) => (current === nextHeight ? current : nextHeight));
     };
     const scheduleMeasure = () => {
       if (frameId) return;
       frameId = window.requestAnimationFrame(measure);
     };
+    const scheduleSettle = () => {
+      scheduleMeasure();
+      if (settleTimerId) window.clearTimeout(settleTimerId);
+      settleTimerId = window.setTimeout(scheduleMeasure, 80);
+    };
 
-    scheduleMeasure();
-    window.addEventListener('resize', scheduleMeasure);
+    scheduleSettle();
+    window.addEventListener('resize', scheduleSettle);
 
-    const observer = typeof ResizeObserver === 'function'
+    const observer = !lockHeightToKey && typeof ResizeObserver === 'function'
       ? new ResizeObserver(() => scheduleMeasure())
       : null;
     observer?.observe(node);
+    if (typeof document !== 'undefined' && document.fonts?.ready && typeof document.fonts.ready.then === 'function') {
+      document.fonts.ready.then(() => {
+        if (!cancelled) scheduleMeasure();
+      }).catch(() => {});
+    }
 
     return () => {
+      cancelled = true;
       if (frameId) window.cancelAnimationFrame(frameId);
+      if (settleTimerId) window.clearTimeout(settleTimerId);
       observer?.disconnect();
-      window.removeEventListener('resize', scheduleMeasure);
+      window.removeEventListener('resize', scheduleSettle);
     };
-  }, []);
+  }, [heightKey, lockHeightToKey]);
 
   const classes = ['prompt-card', 'animated-prompt-card', className].filter(Boolean).join(' ');
   const innerClasses = ['prompt-card-inner', innerClassName].filter(Boolean).join(' ');
   const style = height ? { '--prompt-card-height': `${height}px` } : undefined;
 
   return (
-    <div className={classes} style={style}>
+    <div className={classes} style={style} ref={cardRef}>
       <div className={innerClasses} ref={contentRef}>
         {children}
       </div>
@@ -118,8 +149,11 @@ function feedbackSub(feedback) {
   return body ? `${attemptLead} ${body}` : attemptLead;
 }
 
-export function FeedbackSlot({ feedback }) {
-  if (!feedback) return null;
+export function FeedbackSlot({ feedback, reserveSpace = false }) {
+  if (!feedback) {
+    if (!reserveSpace) return null;
+    return <div className="feedback-slot is-placeholder" aria-hidden="true" />;
+  }
   const tone = feedbackTone(feedback.kind);
   const icon = tone === 'good' ? <CheckIcon /> : tone === 'warn' ? '!' : '×';
   return (

--- a/src/subjects/spelling/components/SpellingSessionScene.jsx
+++ b/src/subjects/spelling/components/SpellingSessionScene.jsx
@@ -76,6 +76,13 @@ export function SpellingSessionScene({ learner, service, ui, accent, actions, pr
     session.promptCount,
     awaitingAdvance ? 'locked' : 'active',
   ].join(':');
+  const questionLayoutKey = [
+    session.id,
+    session.currentSlug,
+    session.promptCount,
+    session.type,
+    showCloze ? 'cloze' : 'context',
+  ].join(':');
   const [questionRevealed, setQuestionRevealed] = React.useState(() => !shouldDelaySpellingSessionQuestionReveal());
   React.useEffect(() => {
     if (!shouldDelaySpellingSessionQuestionReveal()) {
@@ -98,7 +105,7 @@ export function SpellingSessionScene({ learner, service, ui, accent, actions, pr
           <span className="path-count">Word {progressCurrent} of {progressTotal}</span>
         </header>
 
-        <AnimatedPromptCard>
+        <AnimatedPromptCard heightKey={questionLayoutKey} lockHeightToKey>
             {infoChips.length ? (
               <div className="info-chip-row">
                 {infoChips.map((value) => <span className="chip" key={value}>{value}</span>)}
@@ -178,7 +185,7 @@ export function SpellingSessionScene({ learner, service, ui, accent, actions, pr
               </div>
             </form>
 
-            <FeedbackSlot feedback={ui.feedback} />
+            <FeedbackSlot feedback={ui.feedback} reserveSpace />
         </AnimatedPromptCard>
 
         <footer className="session-footer">

--- a/styles/app.css
+++ b/styles/app.css
@@ -4247,6 +4247,7 @@ textarea:focus-visible {
   --spelling-cloze-font-size: 2rem;
   --spelling-cloze-line-height: 1.2;
   --spelling-cloze-lines: 2;
+  --spelling-feedback-slot-min-height: 156px;
 }
 .spelling-in-session::before {
   content: "";
@@ -4561,6 +4562,8 @@ textarea:focus-visible {
   display: flex; justify-content: center; gap: 10px;
   margin-top: 26px;
   flex-wrap: wrap;
+  min-height: 52px;
+  align-items: center;
 }
 
 /* Round-end footer sitting below the prompt card. */
@@ -4662,11 +4665,16 @@ textarea:focus-visible {
 }
 
 /* ---------- Feedback ribbon + family chips ---------- */
-/* Feedback now contributes its real measured height; the
-   AnimatedPromptCard wrapper interpolates the surrounding card
-   height between question, feedback, and summary states. */
 .spelling-in-session .feedback-slot {
   margin-top: 18px;
+  min-height: var(--spelling-feedback-slot-min-height);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+}
+.spelling-in-session .feedback-slot.is-placeholder {
+  visibility: hidden;
+  pointer-events: none;
 }
 .spelling-in-session .feedback-foot {
   margin-top: 8px;
@@ -4674,6 +4682,10 @@ textarea:focus-visible {
   line-height: 1.35;
   color: color-mix(in oklab, var(--ink) 72%, transparent);
   text-align: center;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .spelling-in-session .ribbon {
@@ -4737,6 +4749,10 @@ textarea:focus-visible {
   margin-top: 2px;
   color: inherit;
   opacity: 0.85;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .spelling-in-session .family-chips {
@@ -4745,6 +4761,9 @@ textarea:focus-visible {
   flex-wrap: wrap;
   margin-top: 14px;
   padding-left: 4px;
+  min-height: 34px;
+  max-height: 34px;
+  overflow: hidden;
 }
 .spelling-in-session .family-chips .flabel {
   font-size: 0.76rem;

--- a/tests/react-spelling-scene-spike.test.js
+++ b/tests/react-spelling-scene-spike.test.js
@@ -48,6 +48,7 @@ test('spelling session spike preserves hidden answer, replay, submit, and contin
   assert.match(questionHtml, /name="typed"[^>]*data-autofocus="true"/);
   assert.match(questionHtml, /aria-label="Replay the dictated word"/);
   assert.match(questionHtml, /aria-label="Replay slowly"/);
+  assert.match(questionHtml, /feedback-slot is-placeholder/);
   assert.match(questionHtml, /<kbd>Esc<\/kbd> replay/);
   assert.doesNotMatch(questionHtml, new RegExp(`>${escapingRegExp(answer)}<`, 'i'));
 
@@ -61,6 +62,7 @@ test('spelling session spike preserves hidden answer, replay, submit, and contin
   assert.equal(submitted.awaitingAdvance, true);
   assert.match(submittedHtml, /Saved/);
   assert.match(submittedHtml, /data-action="spelling-continue"/);
+  assert.doesNotMatch(submittedHtml, /feedback-slot is-placeholder/);
 
   finishCurrentRound(harness);
   assert.equal(harness.store.getState().subjectUi.spelling.phase, 'summary');


### PR DESCRIPTION
## Summary
- lock spelling prompt card height to the active question so feedback and buttons do not reflow within the same question
- reserve feedback space and stabilise the action row so controls stay visible
- keep the prompt height animation for question-to-question sentence changes only

## Verification
- node --test
- node ./scripts/build-bundles.mjs
- node ./scripts/build-public.mjs
- node ./scripts/assert-build-public.mjs
- git diff --check