### PR TITLE
fix(spelling): unify cloze underline rendering

### DIFF
--- a/src/subjects/spelling/components/SpellingCommon.jsx
+++ b/src/subjects/spelling/components/SpellingCommon.jsx
@@ -6,6 +6,8 @@ import {
 } from './spelling-view-model.js';
 
 const useMeasuredLayoutEffect = typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect;
+const CLOZE_BLANK_PATTERN = /_{5,}/;
+
 export const spellingAnswerInputProps = {
   autoComplete: 'off',
   autoCapitalize: 'none',
@@ -35,8 +37,10 @@ export function PathProgress({ done, current, total }) {
 
 export function Cloze({ sentence, answer = '', revealAnswer = false }) {
   const raw = String(sentence || '');
-  if (!raw.includes('________')) return <div className="cloze">{raw}</div>;
-  const [lead, tail = ''] = raw.split('________');
+  const blankMatch = raw.match(CLOZE_BLANK_PATTERN);
+  if (!blankMatch || typeof blankMatch.index !== 'number') return <div className="cloze">{raw}</div>;
+  const lead = raw.slice(0, blankMatch.index);
+  const tail = raw.slice(blankMatch.index + blankMatch[0].length);
   return (
     <div className="cloze">
       {lead}

--- a/tests/helpers/react-render.js
+++ b/tests/helpers/react-render.js
@@ -259,6 +259,23 @@ export function renderSpellingSurfaceFixture({ phase = 'setup' } = {}) {
   `);
 }
 
+export function renderSpellingClozeFixture({ sentence, answer = '', revealAnswer = false } = {}) {
+  return renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { Cloze } from ${JSON.stringify(absoluteSpecifier('src/subjects/spelling/components/SpellingCommon.jsx'))};
+
+    const html = renderToStaticMarkup(
+      <Cloze
+        sentence=${JSON.stringify(sentence || '')}
+        answer=${JSON.stringify(answer)}
+        revealAnswer={${revealAnswer ? 'true' : 'false'}}
+      />
+    );
+    console.log(html);
+  `);
+}
+
 export function renderAppFixture({ route = 'dashboard' } = {}) {
   return renderFixture(`
     import React from 'react';

--- a/tests/react-spelling-surface.test.js
+++ b/tests/react-spelling-surface.test.js
@@ -1,7 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { renderSpellingSurfaceFixture } from './helpers/react-render.js';
+import {
+  renderSpellingClozeFixture,
+  renderSpellingSurfaceFixture,
+} from './helpers/react-render.js';
 
 test('React spelling setup scene renders primary practice controls', async () => {
   const html = await renderSpellingSurfaceFixture({ phase: 'setup' });
@@ -18,6 +21,16 @@ test('React spelling session scene preserves input, replay, and submit affordanc
   assert.match(html, /name="typed"/);
   assert.match(html, /data-action="spelling-replay"/);
   assert.match(html, /data-action="spelling-submit-form"/);
+});
+
+test('React cloze renders one blank for variable-length underscore placeholders', async () => {
+  const html = await renderSpellingClozeFixture({
+    sentence: 'Each group wrote a prediction for the __________.',
+    answer: 'experiment',
+  });
+
+  assert.match(html, /<span class="blank">/);
+  assert.doesNotMatch(html, /__\./);
 });
 
 test('React spelling summary and word bank scenes render migration-critical states', async () => {


### PR DESCRIPTION
This fixes spelling cloze prompts that showed 2 different underline styles for longer answers. The service emits variable-length underscore placeholders, but the React renderer only recognised the fixed 8-underscore form, so leftover underscores leaked into the sentence.

## Summary
- match any 5+ underscore placeholder as a single styled cloze blank
- preserve the existing reveal behaviour while removing leftover plain-text underscores
- add a focused React render regression test for long placeholders

## Testing
- `npm test`
