### PR TITLE
Fix trouble drill word eligibility

### DIFF
--- a/legacy/spelling-engine.source.js
+++ b/legacy/spelling-engine.source.js
@@ -243,6 +243,12 @@
     return "secure";
   }
 
+  function isTroubleProgress(progress, today) {
+    var current = progress || defaultProgress();
+    var currentDay = typeof today === "number" ? today : todayDay();
+    return current.wrong > 0 && (current.wrong >= current.correct || current.dueDay <= currentDay);
+  }
+
   function weightedPick(items, weightFn) {
     if (!items.length) return null;
     var weights = items.map(function (item) { return Math.max(0, Number(weightFn(item)) || 0); });
@@ -303,7 +309,7 @@
     var today = todayDay();
     var candidates = filteredWords(opts.yearFilter).filter(function (word) {
       var p = getProgress(profileId, word.slug);
-      return p.wrong > 0 || (p.attempts > 0 && p.dueDay <= today && p.stage < SECURE_STAGE);
+      return isTroubleProgress(p, today);
     });
 
     if (!candidates.length) {
@@ -874,7 +880,7 @@
       if (p.attempts === 0) fresh += 1;
       if (p.stage >= SECURE_STAGE) secure += 1;
       if (p.attempts > 0 && p.dueDay <= today) due += 1;
-      if (p.wrong > 0 && (p.wrong >= p.correct || p.stage < SECURE_STAGE)) trouble += 1;
+      if (isTroubleProgress(p, today)) trouble += 1;
     }
     return {
       total: words.length,
@@ -890,9 +896,8 @@
 
   function statusForWord(profileId, word) {
     var p = getProgress(profileId, word.slug);
-    var total = p.correct + p.wrong;
     if (p.attempts === 0) return "new";
-    if (p.wrong > 0 && (p.wrong >= p.correct || (p.dueDay <= todayDay() && total > 0))) return "trouble";
+    if (isTroubleProgress(p, todayDay())) return "trouble";
     if (p.dueDay <= todayDay()) return "due";
     if (p.stage >= SECURE_STAGE) return "secure";
     return "learning";

--- a/src/subjects/spelling/engine/legacy-engine.js
+++ b/src/subjects/spelling/engine/legacy-engine.js
@@ -270,6 +270,12 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
         if (p.stage < SECURE_STAGE) return "growing";
         return "secure";
       }
+
+      function isTroubleProgress(progress, today) {
+        var current = progress || defaultProgress();
+        var currentDay = typeof today === "number" ? today : todayDay();
+        return current.wrong > 0 && (current.wrong >= current.correct || current.dueDay <= currentDay);
+      }
     
       function weightedPick(items, weightFn) {
         if (!items.length) return null;
@@ -331,7 +337,7 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
         var today = todayDay();
         var candidates = filteredWords(opts.yearFilter).filter(function (word) {
           var p = getProgress(profileId, word.slug);
-          return p.wrong > 0 || (p.attempts > 0 && p.dueDay <= today && p.stage < SECURE_STAGE);
+          return isTroubleProgress(p, today);
         });
     
         if (!candidates.length) {
@@ -903,7 +909,7 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
           if (p.attempts === 0) fresh += 1;
           if (p.stage >= SECURE_STAGE) secure += 1;
           if (p.attempts > 0 && p.dueDay <= today) due += 1;
-          if (p.wrong > 0 && (p.wrong >= p.correct || p.stage < SECURE_STAGE)) trouble += 1;
+          if (isTroubleProgress(p, today)) trouble += 1;
         }
         return {
           total: words.length,
@@ -919,10 +925,9 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
     
       function statusForWord(profileId, word, progressStore) {
         var p = progressStore ? progressForSlug(progressStore, word.slug) : getProgress(profileId, word.slug);
-        var total = p.correct + p.wrong;
         var today = todayDay();
         if (p.attempts === 0) return "new";
-        if (p.wrong > 0 && (p.wrong >= p.correct || (p.dueDay <= today && total > 0))) return "trouble";
+        if (isTroubleProgress(p, today)) return "trouble";
         if (p.dueDay <= today) return "due";
         if (p.stage >= SECURE_STAGE) return "secure";
         return "learning";

--- a/src/subjects/spelling/read-model.js
+++ b/src/subjects/spelling/read-model.js
@@ -36,6 +36,10 @@ function accuracyPercent(correct, wrong) {
   return Math.round((Math.max(0, Number(correct) || 0) / attempts) * 100);
 }
 
+function isTroubleProgress(progress, currentDay) {
+  return progress.wrong > 0 && (progress.wrong >= progress.correct || progress.dueDay <= currentDay);
+}
+
 function yearLabel(value) {
   return value === '5-6' ? 'Years 5-6' : 'Years 3-4';
 }
@@ -114,7 +118,7 @@ export function buildSpellingLearnerReadModel({
     };
     const secure = progress.stage >= SECURE_STAGE;
     const due = progress.attempts > 0 && progress.dueDay <= currentDay && !secure;
-    const trouble = progress.wrong > progress.correct || (progress.wrong > 0 && !secure) || progress.lastResult === false;
+    const trouble = isTroubleProgress(progress, currentDay);
     return {
       slug,
       word: word.word,

--- a/tests/hub-read-models.test.js
+++ b/tests/hub-read-models.test.js
@@ -93,6 +93,35 @@ test('parent hub read model summarises due work, recent sessions, strengths, and
   assert.ok(model.misconceptionPatterns.some((entry) => /cycle/i.test(entry.label)));
 });
 
+test('parent hub read model keeps recently missed secure words in the trouble count', () => {
+  const learner = makeLearner();
+  const model = buildParentHubReadModel({
+    learner,
+    platformRole: 'parent',
+    membershipRole: 'owner',
+    subjectStates: {
+      spelling: {
+        ui: { phase: 'dashboard' },
+        data: {
+          prefs: { mode: 'smart', yearFilter: 'all', roundLength: '20' },
+          progress: {
+            accommodate: { stage: 5, attempts: 5, correct: 4, wrong: 1, dueDay: 0, lastDay: 201, lastResult: 'wrong' },
+          },
+        },
+        updatedAt: 2000,
+      },
+    },
+    practiceSessions: [],
+    eventLog: [],
+    runtimeSnapshots: {},
+    now: () => 10 * 24 * 60 * 60 * 1000,
+  });
+
+  assert.equal(model.learnerOverview.troubleWords, 1);
+  assert.equal(model.learnerOverview.dueWords, 0);
+  assert.equal(model.dueWork[0].recommendedMode, 'trouble');
+});
+
 test('admin hub read model reports published release status, validation state, audit stream, and learner diagnostics', () => {
   const learner = makeLearner();
   const model = buildAdminHubReadModel({

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -436,6 +436,43 @@ test('spelling word bank opens from setup and exposes searchable progress with e
   assert.equal(harness.store.getState().subjectUi.spelling.session, null);
 });
 
+test('Extra Trouble Drill unlocks from setup once a recent mistake is marked as trouble', () => {
+  const storage = installMemoryStorage();
+  const harness = createAppHarness({ storage });
+  const learnerId = harness.store.getState().learners.selectedId;
+  const todayDay = Math.floor(Date.now() / (24 * 60 * 60 * 1000));
+
+  harness.repositories.subjectStates.writeData(learnerId, 'spelling', {
+    progress: {
+      mollusc: {
+        stage: 5,
+        attempts: 5,
+        correct: 4,
+        wrong: 1,
+        dueDay: todayDay,
+        lastDay: todayDay - 1,
+        lastResult: 'wrong',
+      },
+    },
+  });
+
+  harness.dispatch('open-subject', { subjectId: 'spelling' });
+  harness.dispatch('spelling-set-pref', { pref: 'yearFilter', value: 'extra' });
+
+  let html = harness.render();
+  assert.doesNotMatch(html, /value="trouble"[^>]*disabled[^>]*>[\s\S]*Trouble Drill/);
+  assert.match(html, /ss-stat-label">Weak spots<\/div>\s*<div class="ss-stat-value"[^>]*>1<\/div>/);
+
+  harness.dispatch('spelling-set-mode', { value: 'trouble' });
+  harness.dispatch('spelling-start');
+
+  const state = harness.store.getState().subjectUi.spelling;
+  assert.equal(state.phase, 'session');
+  assert.equal(state.feedback, null);
+  assert.deepEqual(state.session?.uniqueWords, ['mollusc']);
+  assert.equal(state.session?.currentCard?.word?.spellingPool, 'extra');
+});
+
 test('golden-path smoke covers placeholder-subject navigation through the setup scene', () => {
   const storage = installMemoryStorage();
   const harness = createAppHarness({ storage });

--- a/tests/spelling.test.js
+++ b/tests/spelling.test.js
@@ -188,6 +188,52 @@ test('Trouble Drill stays inside Extra and falls back to Extra Smart Review when
   assert.ok(sessionWords(fallback.state.session).every((word) => word.spellingPool === 'extra'));
 });
 
+test('Trouble Drill follows recent mistakes instead of every due word in the selected pool', () => {
+  const now = () => Date.UTC(2026, 0, 10);
+  const today = Math.floor(now() / (24 * 60 * 60 * 1000));
+  const { service, repositories } = makeService({ now, random: makeSeededRandom(11) });
+
+  repositories.subjectStates.writeData('learner-a', 'spelling', {
+    progress: {
+      possess: {
+        stage: 1,
+        attempts: 1,
+        correct: 1,
+        wrong: 0,
+        dueDay: today - 1,
+        lastDay: today - 2,
+        lastResult: 'correct',
+      },
+      accommodate: {
+        stage: 5,
+        attempts: 5,
+        correct: 4,
+        wrong: 1,
+        dueDay: today,
+        lastDay: today - 1,
+        lastResult: 'wrong',
+      },
+    },
+  });
+
+  const stats = service.getStats('learner-a', 'core');
+  assert.equal(stats.trouble, 1);
+
+  const snapshot = service.getAnalyticsSnapshot('learner-a');
+  const rows = new Map(snapshot.wordGroups.flatMap((group) => group.words).map((word) => [word.slug, word]));
+  assert.equal(rows.get('possess')?.status, 'due');
+  assert.equal(rows.get('accommodate')?.status, 'trouble');
+
+  const trouble = service.startSession('learner-a', {
+    mode: 'trouble',
+    yearFilter: 'core',
+    length: 5,
+  });
+  assert.equal(trouble.ok, true);
+  assert.equal(trouble.state.feedback, null);
+  assert.deepEqual(trouble.state.session.uniqueWords, ['accommodate']);
+});
+
 test('SATs Test ignores Extra filters and stays on core statutory spellings', () => {
   const { service } = makeService({ random: makeSeededRandom(13) });
   const transition = service.startSession('learner-a', {


### PR DESCRIPTION
## Summary
- unify the trouble-word definition used by Trouble Drill selection, analytics, and read models
- restore setup gating so Trouble Drill unlocks only when the selected pool has true trouble words
- add regression coverage for due-vs-trouble behaviour across spelling, smoke, and hub read-model flows

## Testing
- npm test