### PR TITLE
fix: show word-bank tooltip outcome counts

### DIFF
--- a/src/subjects/spelling/components/SpellingWordBankScene.jsx
+++ b/src/subjects/spelling/components/SpellingWordBankScene.jsx
@@ -14,9 +14,11 @@ import {
   heroBgForLearner,
   heroBgStyle,
   normaliseSearchText,
+  progressAccuracyLabel,
+  progressAttemptCount,
+  progressCorrectCount,
+  progressWrongCount,
   renderAction,
-  reviewAccuracyLabel,
-  reviewCount,
   spellingPoolLabel,
   wordBankFilterMatchesStatus,
   wordBankAggregateCards,
@@ -96,13 +98,11 @@ function WordPill({ word, actions }) {
   const categoryLabel = word.yearLabel || spellingPoolLabel(word);
   const title = [
     word.word,
-    word.family ? `Family: ${word.family}` : '',
-    categoryLabel,
-    word.stageLabel || '',
-    `Accuracy: ${reviewAccuracyLabel(progress)}`,
-    `Reviews: ${reviewCount(progress)}`,
+    `Correct: ${progressCorrectCount(progress)}`,
+    `Wrong: ${progressWrongCount(progress)}`,
+    `Attempts: ${progressAttemptCount(progress)}`,
+    `Accuracy: ${progressAccuracyLabel(progress)}`,
     `Next due: ${dueLabel(progress)}`,
-    'Click to explain',
   ].filter(Boolean).join(' • ');
   return (
     <button

--- a/src/subjects/spelling/components/spelling-view-model.js
+++ b/src/subjects/spelling/components/spelling-view-model.js
@@ -293,14 +293,22 @@ export function dueLabel(progress) {
   return `In ${daysUntilDue} days`;
 }
 
-export function reviewCount(progress) {
+export function progressAttemptCount(progress) {
   return Math.max(0, Number(progress?.attempts) || 0);
 }
 
-export function reviewAccuracyLabel(progress) {
-  const attempts = reviewCount(progress);
+export function progressCorrectCount(progress) {
+  return Math.max(0, Number(progress?.correct) || 0);
+}
+
+export function progressWrongCount(progress) {
+  return Math.max(0, Number(progress?.wrong) || 0);
+}
+
+export function progressAccuracyLabel(progress) {
+  const attempts = progressAttemptCount(progress);
   if (!attempts) return '—';
-  const correct = Math.max(0, Number(progress?.correct) || 0);
+  const correct = progressCorrectCount(progress);
   const boundedCorrect = Math.min(correct, attempts);
   return `${Math.round((boundedCorrect / attempts) * 100)}%`;
 }

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -244,10 +244,9 @@ test('spelling word bank opens from setup and exposes searchable progress with e
   // the progress details, while clicking the pill opens the explainer modal.
   assert.match(html, /class="wb-word-pill new"/);
   assert.match(html, /data-action="spelling-word-detail-open"\s+data-slug="possess"\s+data-value="explain"/);
-  assert.match(html, /title="possess[^"]*Family: possess\(ion\)[^"]*Accuracy: —[^"]*Reviews: 0[^"]*Next due: Unseen[^"]*Click to explain"/);
+  assert.match(html, /title="possess[^"]*Correct: 0[^"]*Wrong: 0[^"]*Attempts: 0[^"]*Accuracy: —[^"]*Next due: Unseen"/);
+  assert.doesNotMatch(html, /title="possess[^"]*Family:/);
   assert.doesNotMatch(html, /title="possess[^"]*Years 3-4 • Years 3-4/);
-  assert.doesNotMatch(html, /title="possess[^"]*Correct /);
-  assert.doesNotMatch(html, /title="possess[^"]*Wrong /);
   assert.match(html, />accident</);
   assert.doesNotMatch(html, /wb-meta-label">Family/);
 
@@ -358,7 +357,7 @@ test('spelling word bank opens from setup and exposes searchable progress with e
   assert.equal(harness.store.getState().subjectUi.spelling.analyticsWordSearch, undefined);
   html = harness.render();
   assert.match(html, />possess</);
-  assert.match(html, /title="possess[^"]*Accuracy: 100%[^"]*Reviews: 1[^"]*Next due: In 3 days[^"]*Click to explain"/);
+  assert.match(html, /title="possess[^"]*Correct: 1[^"]*Wrong: 0[^"]*Attempts: 1[^"]*Accuracy: 100%[^"]*Next due: In 3 days"/);
   assert.doesNotMatch(html, />accident</);
 
   harness.dispatch('spelling-word-detail-open', { slug: 'possess', value: 'explain' });
@@ -394,7 +393,7 @@ test('spelling word bank opens from setup and exposes searchable progress with e
   harness.dispatch('spelling-analytics-search', { value: 'mollusc' });
   html = harness.render();
   assert.match(html, />mollusc</);
-  assert.match(html, /title="mollusc[^"]*Extra[^"]*Accuracy: —[^"]*Reviews: 0[^"]*Click to explain"/);
+  assert.match(html, /title="mollusc[^"]*Correct: 0[^"]*Wrong: 0[^"]*Attempts: 0[^"]*Accuracy: —[^"]*Next due: Unseen"/);
   assert.doesNotMatch(html, /title="mollusc[^"]*Extra • Extra/);
   assert.match(html, /Showing 1 of 236 tracked spellings/);
   assert.doesNotMatch(html, />accident</);
@@ -477,7 +476,7 @@ test('Extra Trouble Drill unlocks from setup once a recent mistake is marked as 
   assert.equal(state.session?.currentCard?.word?.spellingPool, 'extra');
 });
 
-test('word-bank tooltip uses review metrics instead of raw correct and wrong counts', () => {
+test('word-bank tooltip uses durable outcome metrics', () => {
   const storage = installMemoryStorage();
   const harness = createAppHarness({ storage });
   const learnerId = harness.store.getState().learners.selectedId;
@@ -501,9 +500,7 @@ test('word-bank tooltip uses review metrics instead of raw correct and wrong cou
   const html = harness.render();
   const escapedAnswer = escapeRegExp(answer);
 
-  assert.match(html, new RegExp(`title="${escapedAnswer}[^"]*Accuracy: 0%[^"]*Reviews: 1[^"]*Next due: Today[^"]*Click to explain"`));
-  assert.doesNotMatch(html, new RegExp(`title="${escapedAnswer}[^"]*Correct `));
-  assert.doesNotMatch(html, new RegExp(`title="${escapedAnswer}[^"]*Wrong `));
+  assert.match(html, new RegExp(`title="${escapedAnswer}[^"]*Correct: 0[^"]*Wrong: 1[^"]*Attempts: 1[^"]*Accuracy: 0%[^"]*Next due: Today"`));
 });
 
 test('golden-path smoke covers placeholder-subject navigation through the setup scene', () => {


### PR DESCRIPTION
## Summary
- show word-bank tooltip progress as Correct, Wrong, Attempts, Accuracy, and Next due
- keep tooltip values aligned with durable scheduler outcome counts where correct + wrong = attempts
- update smoke coverage for unseen, successful, Extra, and retry/correction tooltip cases

## Testing
- node --test tests/smoke.test.js
- npm test
- npm run check