### PR TITLE
Add Gemini TTS fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The goal is not to polish the old prototype. The goal is to give the product a s
 - `src/subjects/placeholders/*`
   - Clean extension slots for Arithmetic, Reasoning, Grammar, Punctuation and Reading.
 - `worker/*`
-  - A Cloudflare-friendly backend with D1-backed repository routes, account-scoped spelling content, learner ownership checks, production sessions, Worker-side OpenAI TTS proxying, and thin role-aware Parent/Admin hub routes.
+  - A Cloudflare-friendly backend with D1-backed repository routes, account-scoped spelling content, learner ownership checks, production sessions, Worker-side TTS proxying with Gemini fallback, and thin role-aware Parent/Admin hub routes.
 - `docs/*`
   - Audit, architecture, refactor plan, migration map, repository notes, ownership/access notes, state-integrity notes, spelling-service and spelling-content notes, a direct spelling parity audit, operating-surface notes, and the subject-expansion readiness gate.
 - `tests/*`
@@ -32,7 +32,7 @@ English Spelling works in the new structure.
 
 The browser app is now a single React shell. `index.html` loads the built React app bundle, React owns dashboard, Codex, subject, profile, Parent Hub, Admin / Operations, toast and modal surfaces, and the existing controller/store/repository boundary still owns state transitions and side effects. Legacy string renderers remain only as local characterisation helpers while production routes compose React components.
 
-Production on `ks2.eugnel.uk` uses the API adapter by default after sign-in. Direct file/local mode, or `?local=1`, still uses browser storage for development only. The API adapter reports explicit persistence modes (`local-only`, `remote-sync`, `degraded`) so failed remote writes are visible instead of being treated as silent success. The Worker is D1-backed with learner ownership enforcement, atomic account / learner revision checks, idempotent request replay, account-scoped spelling content routes, role-aware Parent/Admin hub read routes, and OpenAI TTS as the production dictation default.
+Production on `ks2.eugnel.uk` uses the API adapter by default after sign-in. Direct file/local mode, or `?local=1`, still uses browser storage for development only. The API adapter reports explicit persistence modes (`local-only`, `remote-sync`, `degraded`) so failed remote writes are visible instead of being treated as silent success. The Worker is D1-backed with learner ownership enforcement, atomic account / learner revision checks, idempotent request replay, account-scoped spelling content routes, role-aware Parent/Admin hub read routes, and OpenAI TTS as the production dictation default with Gemini TTS fallback when the primary provider is slow or unavailable.
 
 Signed-in Parent Hub and Admin / Operations use live Worker hub payloads. Those adult surfaces keep platform role, learner membership role, and writable/read-only access separate. `/api/bootstrap` remains writable-only for the main subject shell, while readable viewer learners are available inside hub surfaces with explicit read-only labels and blocked write affordances.
 

--- a/tests/worker-tts.test.js
+++ b/tests/worker-tts.test.js
@@ -15,6 +15,24 @@ function ttsRequest(body = {}) {
   };
 }
 
+function geminiAudioResponse(bytes = [1, 0, 2, 0]) {
+  return new Response(JSON.stringify({
+    candidates: [{
+      content: {
+        parts: [{
+          inlineData: {
+            mimeType: 'audio/L16;codec=pcm;rate=24000',
+            data: Buffer.from(Uint8Array.from(bytes)).toString('base64'),
+          },
+        }],
+      },
+    }],
+  }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
 test('TTS route requires an authenticated account session', async () => {
   const server = createWorkerRepositoryServer({
     env: { OPENAI_API_KEY: 'test-openai-key' },
@@ -64,6 +82,87 @@ test('TTS route proxies dictation audio through OpenAI without exposing the key'
     assert.equal(calls[0].body.response_format, 'mp3');
     assert.equal(calls[0].body.input, 'The word is early. The birds sang early in the day. The word is early.');
     assert.match(calls[0].body.instructions, /British English pronunciation/);
+  } finally {
+    globalThis.fetch = originalFetch;
+    server.close();
+  }
+});
+
+test('TTS route falls back to Gemini when OpenAI returns a provider error', async () => {
+  const originalFetch = globalThis.fetch;
+  const calls = [];
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({
+      url,
+      headers: init.headers,
+      body: JSON.parse(init.body),
+    });
+    if (url === 'https://api.openai.com/v1/audio/speech') {
+      return new Response(JSON.stringify({ error: 'busy' }), { status: 503 });
+    }
+    return geminiAudioResponse();
+  };
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      OPENAI_API_KEY: 'test-openai-key',
+      GEMINI_API_KEY: 'test-gemini-key',
+    },
+  });
+  try {
+    const response = await server.fetch('https://repo.test/api/tts', ttsRequest());
+    const bytes = new Uint8Array(await response.arrayBuffer());
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('content-type'), 'audio/wav');
+    assert.equal(response.headers.get('x-ks2-tts-provider'), 'gemini');
+    assert.equal(response.headers.get('x-ks2-tts-fallback-from'), 'openai');
+    assert.equal(response.headers.get('x-ks2-tts-model'), 'gemini-3.1-flash-tts-preview');
+    assert.equal(String.fromCharCode(...bytes.slice(0, 4)), 'RIFF');
+    assert.equal(calls.length, 2);
+    assert.equal(calls[1].url, 'https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-tts-preview:generateContent');
+    assert.equal(calls[1].headers['x-goog-api-key'], 'test-gemini-key');
+    assert.equal(calls[1].body.generationConfig.responseModalities[0], 'AUDIO');
+    assert.equal(calls[1].body.generationConfig.speechConfig.languageCode, 'en-GB');
+    assert.equal(calls[1].body.generationConfig.speechConfig.voiceConfig.prebuiltVoiceConfig.voiceName, 'Kore');
+    assert.match(calls[1].body.contents[0].parts[0].text, /The word is early/);
+  } finally {
+    globalThis.fetch = originalFetch;
+    server.close();
+  }
+});
+
+test('TTS route falls back to Gemini when OpenAI exceeds the primary timeout', async () => {
+  const originalFetch = globalThis.fetch;
+  let openAiAborted = false;
+  globalThis.fetch = async (url, init = {}) => {
+    if (url === 'https://api.openai.com/v1/audio/speech') {
+      return await new Promise((resolve, reject) => {
+        init.signal.addEventListener('abort', () => {
+          openAiAborted = true;
+          const error = new Error('aborted');
+          error.name = 'AbortError';
+          reject(error);
+        }, { once: true });
+      });
+    }
+    return geminiAudioResponse([3, 0, 4, 0]);
+  };
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      OPENAI_API_KEY: 'test-openai-key',
+      GEMINI_API_KEY: 'test-gemini-key',
+      TTS_PRIMARY_TIMEOUT_MS: '250',
+    },
+  });
+  try {
+    const response = await server.fetch('https://repo.test/api/tts', ttsRequest());
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('x-ks2-tts-provider'), 'gemini');
+    assert.equal(response.headers.get('x-ks2-tts-fallback-from'), 'openai');
+    assert.equal(openAiAborted, true);
   } finally {
     globalThis.fetch = originalFetch;
     server.close();

--- a/worker/README.md
+++ b/worker/README.md
@@ -5,7 +5,7 @@ This Worker is now a real minimum viable backend for the generic repository cont
 Production browser sessions use the API-backed repository after sign-in.
 Direct file/local mode, or `?local=1`, still uses browser storage for development.
 English Spelling still runs through the same subject/service boundary.
-The Worker now provides durable D1-backed storage for the generic platform collections, account-scoped spelling content, session/auth flows, OpenAI TTS proxying, learner ownership at the API boundary, and thin hub read-model routes for Parent Hub / Admin.
+The Worker now provides durable D1-backed storage for the generic platform collections, account-scoped spelling content, session/auth flows, TTS proxying with OpenAI primary audio and Gemini fallback audio, learner ownership at the API boundary, and thin hub read-model routes for Parent Hub / Admin.
 
 ## What this Worker is now
 
@@ -16,7 +16,7 @@ It is:
 - an adult-account to learner ownership boundary
 - a place where learner-scoped permissions are enforced before repository writes happen
 - a provider-agnostic auth/session seam with production email and social login flows plus a safe development/test stub
-- a Worker-side TTS proxy that keeps the OpenAI API key out of the browser
+- a Worker-side TTS proxy that keeps provider API keys out of the browser and falls back to Gemini when OpenAI is slow or unavailable
 - a read-model boundary for role-aware Parent Hub and Admin / Operations surfaces
 - an admin-only account role management boundary for production platform roles
 - a deployment boundary that still keeps subject UI rules out of the backend

--- a/worker/src/tts.js
+++ b/worker/src/tts.js
@@ -4,17 +4,33 @@ import { BadRequestError, BackendUnavailableError } from './errors.js';
 import { readJson } from './http.js';
 
 const OPENAI_SPEECH_URL = 'https://api.openai.com/v1/audio/speech';
+const GEMINI_GENERATE_CONTENT_URL = 'https://generativelanguage.googleapis.com/v1beta/models';
 const TTS_WINDOW_MS = 10 * 60 * 1000;
 const TTS_ACCOUNT_LIMIT = 120;
 const TTS_IP_LIMIT = 240;
 const DEFAULT_MODEL = 'gpt-4o-mini-tts';
 const DEFAULT_VOICE = 'marin';
 const DEFAULT_FORMAT = 'mp3';
+const DEFAULT_PRIMARY_TIMEOUT_MS = 5000;
+const DEFAULT_GEMINI_MODEL = 'gemini-3.1-flash-tts-preview';
+const DEFAULT_GEMINI_VOICE = 'Kore';
+const DEFAULT_GEMINI_TIMEOUT_MS = 12000;
+const DEFAULT_GEMINI_SAMPLE_RATE = 24000;
 const MAX_WORD_LENGTH = 80;
 const MAX_SENTENCE_LENGTH = 320;
 
 function cleanText(value) {
   return String(value || '').replace(/\s+/g, ' ').trim();
+}
+
+function cleanGeminiModel(value) {
+  return cleanText(value).replace(/^models\//, '');
+}
+
+function positiveInteger(value, fallback, { min = 1, max = 30000 } = {}) {
+  const parsed = Number(cleanText(value));
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.min(max, Math.max(min, Math.round(parsed)));
 }
 
 function clientIp(request) {
@@ -119,43 +135,169 @@ function openAiConfig(env = {}) {
     model: cleanText(env.OPENAI_TTS_MODEL) || DEFAULT_MODEL,
     voice: cleanText(env.OPENAI_TTS_VOICE) || DEFAULT_VOICE,
     responseFormat: cleanText(env.OPENAI_TTS_FORMAT) || DEFAULT_FORMAT,
+    timeoutMs: positiveInteger(env.TTS_PRIMARY_TIMEOUT_MS || env.OPENAI_TTS_TIMEOUT_MS, DEFAULT_PRIMARY_TIMEOUT_MS, {
+      min: 250,
+      max: 30000,
+    }),
   };
 }
 
-export async function handleTextToSpeechRequest({
-  env,
-  request,
-  session,
-  now = Date.now(),
-  fetchFn = fetch,
-} = {}) {
-  const config = openAiConfig(env);
-  if (!config.apiKey) {
-    throw new BackendUnavailableError('OpenAI TTS is not configured.', { code: 'tts_not_configured' });
+function geminiConfig(env = {}) {
+  return {
+    apiKey: cleanText(env.GEMINI_API_KEY),
+    model: cleanGeminiModel(env.GEMINI_TTS_MODEL) || DEFAULT_GEMINI_MODEL,
+    voice: cleanText(env.GEMINI_TTS_VOICE) || DEFAULT_GEMINI_VOICE,
+    timeoutMs: positiveInteger(env.GEMINI_TTS_TIMEOUT_MS, DEFAULT_GEMINI_TIMEOUT_MS, {
+      min: 250,
+      max: 30000,
+    }),
+  };
+}
+
+function providerFailure(provider, message, extra = {}) {
+  const error = new Error(message);
+  error.provider = provider;
+  Object.assign(error, extra);
+  return error;
+}
+
+async function fetchWithTimeout(fetchFn, url, init, timeoutMs) {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return await fetchFn(url, init);
   }
 
-  await protectTts(env, request, session, now);
-  const payload = normaliseTtsPayload(await readJson(request));
-
-  const response = await fetchFn(OPENAI_SPEECH_URL, {
-    method: 'POST',
-    headers: {
-      authorization: `Bearer ${config.apiKey}`,
-      'content-type': 'application/json',
-      accept: 'audio/mpeg',
-    },
-    body: JSON.stringify({
-      model: config.model,
-      voice: config.voice,
-      input: payload.transcript,
-      instructions: ttsInstructions(payload.slow, payload.wordOnly),
-      response_format: config.responseFormat,
-    }),
+  const controller = new AbortController();
+  let timeoutId = null;
+  let timedOut = false;
+  const timeout = new Promise((_, reject) => {
+    timeoutId = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+      reject(providerFailure('provider', 'TTS provider timed out.', { timedOut: true }));
+    }, timeoutMs);
   });
 
+  const request = Promise.resolve()
+    .then(() => fetchFn(url, { ...init, signal: controller.signal }));
+  request.catch(() => {});
+
+  try {
+    return await Promise.race([request, timeout]);
+  } catch (error) {
+    if (timedOut || error?.name === 'AbortError') error.timedOut = timedOut || Boolean(error?.timedOut);
+    throw error;
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+}
+
+function providerAttempt(error) {
+  const attempt = {
+    provider: error?.provider || 'unknown',
+  };
+  if (Number.isFinite(Number(error?.providerStatus))) attempt.status = Number(error.providerStatus);
+  if (error?.timedOut) attempt.timedOut = true;
+  return attempt;
+}
+
+function backendUnavailableFromFailure(error, failures = []) {
+  const attempts = failures.filter(Boolean).map(providerAttempt);
+  const extra = {
+    code: 'tts_provider_error',
+    provider: error?.provider || 'unknown',
+  };
+  if (Number.isFinite(Number(error?.providerStatus))) extra.providerStatus = Number(error.providerStatus);
+  if (error?.timedOut) extra.providerTimedOut = true;
+  if (attempts.length > 1) extra.providerAttempts = attempts;
+  return new BackendUnavailableError(error?.message || 'TTS provider request failed.', extra);
+}
+
+function geminiPrompt({ transcript, slow = false, wordOnly = false }) {
+  if (wordOnly) {
+    return `Read exactly this KS2 spelling word once in natural British English. Do not add any extra words:\n\n${transcript}`;
+  }
+  const pace = slow
+    ? 'slightly slower than normal, with clear pauses between the word and sentence'
+    : 'at a calm classroom pace, with clear pauses between the word and sentence';
+  return `Read exactly this KS2 spelling dictation in natural British English ${pace}. Do not add any extra words:\n\n${transcript}`;
+}
+
+function base64ToBytes(value) {
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+function writeAscii(view, offset, value) {
+  for (let i = 0; i < value.length; i += 1) view.setUint8(offset + i, value.charCodeAt(i));
+}
+
+function pcmToWav(pcm, sampleRate = DEFAULT_GEMINI_SAMPLE_RATE) {
+  const channels = 1;
+  const bytesPerSample = 2;
+  const blockAlign = channels * bytesPerSample;
+  const byteRate = sampleRate * blockAlign;
+  const buffer = new ArrayBuffer(44 + pcm.byteLength);
+  const view = new DataView(buffer);
+
+  writeAscii(view, 0, 'RIFF');
+  view.setUint32(4, 36 + pcm.byteLength, true);
+  writeAscii(view, 8, 'WAVE');
+  writeAscii(view, 12, 'fmt ');
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, channels, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, byteRate, true);
+  view.setUint16(32, blockAlign, true);
+  view.setUint16(34, bytesPerSample * 8, true);
+  writeAscii(view, 36, 'data');
+  view.setUint32(40, pcm.byteLength, true);
+  new Uint8Array(buffer, 44).set(pcm);
+
+  return buffer;
+}
+
+function sampleRateFromMime(mimeType) {
+  const rate = /rate=(\d+)/i.exec(mimeType || '')?.[1];
+  return positiveInteger(rate, DEFAULT_GEMINI_SAMPLE_RATE, {
+    min: 8000,
+    max: 96000,
+  });
+}
+
+function shouldWrapGeminiAudio(mimeType) {
+  return !/audio\/(mpeg|mp3|wav|wave)/i.test(mimeType || '');
+}
+
+async function requestOpenAiSpeech({ config, payload, fetchFn }) {
+  let response;
+  try {
+    response = await fetchWithTimeout(fetchFn, OPENAI_SPEECH_URL, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${config.apiKey}`,
+        'content-type': 'application/json',
+        accept: 'audio/mpeg',
+      },
+      body: JSON.stringify({
+        model: config.model,
+        voice: config.voice,
+        input: payload.transcript,
+        instructions: ttsInstructions(payload.slow, payload.wordOnly),
+        response_format: config.responseFormat,
+      }),
+    }, config.timeoutMs);
+  } catch (error) {
+    throw providerFailure('openai', 'OpenAI TTS request failed.', {
+      timedOut: Boolean(error?.timedOut),
+      cause: error,
+    });
+  }
+
   if (!response.ok) {
-    throw new BackendUnavailableError('OpenAI TTS request failed.', {
-      code: 'tts_provider_error',
+    throw providerFailure('openai', 'OpenAI TTS request failed.', {
       providerStatus: response.status,
     });
   }
@@ -171,4 +313,116 @@ export async function handleTextToSpeechRequest({
       'x-ks2-tts-voice': config.voice,
     },
   });
+}
+
+async function requestGeminiSpeech({ config, payload, fetchFn }) {
+  const url = `${GEMINI_GENERATE_CONTENT_URL}/${encodeURIComponent(config.model)}:generateContent`;
+  let response;
+  try {
+    response = await fetchWithTimeout(fetchFn, url, {
+      method: 'POST',
+      headers: {
+        'x-goog-api-key': config.apiKey,
+        'content-type': 'application/json',
+        accept: 'application/json',
+      },
+      body: JSON.stringify({
+        contents: [{
+          parts: [{
+            text: geminiPrompt(payload),
+          }],
+        }],
+        generationConfig: {
+          responseModalities: ['AUDIO'],
+          speechConfig: {
+            languageCode: 'en-GB',
+            voiceConfig: {
+              prebuiltVoiceConfig: {
+                voiceName: config.voice,
+              },
+            },
+          },
+        },
+      }),
+    }, config.timeoutMs);
+  } catch (error) {
+    throw providerFailure('gemini', 'Gemini TTS request failed.', {
+      timedOut: Boolean(error?.timedOut),
+      cause: error,
+    });
+  }
+
+  if (!response.ok) {
+    throw providerFailure('gemini', 'Gemini TTS request failed.', {
+      providerStatus: response.status,
+    });
+  }
+
+  const json = await response.json().catch(() => null);
+  const part = json?.candidates?.[0]?.content?.parts?.find((candidatePart) => (
+    candidatePart?.inlineData?.data || candidatePart?.inline_data?.data
+  ));
+  const inlineData = part?.inlineData || part?.inline_data;
+  const audioData = inlineData?.data;
+  const sourceMimeType = cleanText(inlineData?.mimeType || inlineData?.mime_type);
+  if (!audioData) {
+    throw providerFailure('gemini', 'Gemini TTS response did not include audio.');
+  }
+
+  const audioBytes = base64ToBytes(audioData);
+  const body = shouldWrapGeminiAudio(sourceMimeType)
+    ? pcmToWav(audioBytes, sampleRateFromMime(sourceMimeType))
+    : audioBytes;
+  const contentType = shouldWrapGeminiAudio(sourceMimeType)
+    ? 'audio/wav'
+    : sourceMimeType || 'audio/wav';
+
+  return new Response(body, {
+    status: 200,
+    headers: {
+      'content-type': contentType,
+      'cache-control': 'no-store',
+      'x-ks2-tts-provider': 'gemini',
+      'x-ks2-tts-model': config.model,
+      'x-ks2-tts-voice': config.voice,
+    },
+  });
+}
+
+export async function handleTextToSpeechRequest({
+  env,
+  request,
+  session,
+  now = Date.now(),
+  fetchFn = fetch,
+} = {}) {
+  const openAi = openAiConfig(env);
+  const gemini = geminiConfig(env);
+  if (!openAi.apiKey && !gemini.apiKey) {
+    throw new BackendUnavailableError('OpenAI TTS is not configured.', { code: 'tts_not_configured' });
+  }
+
+  await protectTts(env, request, session, now);
+  const payload = normaliseTtsPayload(await readJson(request));
+
+  let openAiFailure = null;
+  if (openAi.apiKey) {
+    try {
+      return await requestOpenAiSpeech({ config: openAi, payload, fetchFn });
+    } catch (error) {
+      openAiFailure = error;
+    }
+  }
+
+  if (gemini.apiKey) {
+    try {
+      const response = await requestGeminiSpeech({ config: gemini, payload, fetchFn });
+      if (openAiFailure) response.headers.set('x-ks2-tts-fallback-from', 'openai');
+      return response;
+    } catch (geminiFailure) {
+      throw backendUnavailableFromFailure(geminiFailure, [openAiFailure, geminiFailure]);
+    }
+  }
+
+  throw backendUnavailableFromFailure(openAiFailure, [openAiFailure]);
 }


### PR DESCRIPTION
## Summary
- add a Worker-side Gemini TTS fallback when OpenAI TTS returns an error or exceeds the 5 second primary timeout
- default Gemini fallback to `gemini-3.1-flash-tts-preview`, with `GEMINI_TTS_MODEL` and `GEMINI_TTS_VOICE` overrides
- wrap Gemini PCM output as browser-playable WAV audio and keep provider keys server-side
- document the new TTS fallback behaviour

## Verification
- `node --test tests/worker-tts.test.js tests/spelling-tts.test.js`
- `npm test`
- `npm run check`
- confirmed Worker secret list includes `GEMINI_API_KEY` after adding it through the OAuth-safe Wrangler wrapper