### PR TITLE
Add selectable TTS provider controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The goal is not to polish the old prototype. The goal is to give the product a s
 - `src/subjects/placeholders/*`
   - Clean extension slots for Arithmetic, Reasoning, Grammar, Punctuation and Reading.
 - `worker/*`
-  - A Cloudflare-friendly backend with D1-backed repository routes, account-scoped spelling content, learner ownership checks, production sessions, Worker-side TTS proxying with Gemini fallback, and thin role-aware Parent/Admin hub routes.
+  - A Cloudflare-friendly backend with D1-backed repository routes, account-scoped spelling content, learner ownership checks, production sessions, selected-provider Worker-side TTS proxying, and thin role-aware Parent/Admin hub routes.
 - `docs/*`
   - Audit, architecture, refactor plan, migration map, repository notes, ownership/access notes, state-integrity notes, spelling-service and spelling-content notes, a direct spelling parity audit, operating-surface notes, and the subject-expansion readiness gate.
 - `tests/*`
@@ -32,7 +32,7 @@ English Spelling works in the new structure.
 
 The browser app is now a single React shell. `index.html` loads the built React app bundle, React owns dashboard, Codex, subject, profile, Parent Hub, Admin / Operations, toast and modal surfaces, and the existing controller/store/repository boundary still owns state transitions and side effects. Legacy string renderers remain only as local characterisation helpers while production routes compose React components.
 
-Production on `ks2.eugnel.uk` uses the API adapter by default after sign-in. Direct file/local mode, or `?local=1`, still uses browser storage for development only. The API adapter reports explicit persistence modes (`local-only`, `remote-sync`, `degraded`) so failed remote writes are visible instead of being treated as silent success. The Worker is D1-backed with learner ownership enforcement, atomic account / learner revision checks, idempotent request replay, account-scoped spelling content routes, role-aware Parent/Admin hub read routes, and OpenAI TTS as the production dictation default with Gemini TTS fallback when the primary provider is slow or unavailable.
+Production on `ks2.eugnel.uk` uses the API adapter by default after sign-in. Direct file/local mode, or `?local=1`, still uses browser storage for development only. The API adapter reports explicit persistence modes (`local-only`, `remote-sync`, `degraded`) so failed remote writes are visible instead of being treated as silent success. The Worker is D1-backed with learner ownership enforcement, atomic account / learner revision checks, idempotent request replay, account-scoped spelling content routes, role-aware Parent/Admin hub read routes, and profile-controlled dictation audio across OpenAI, Gemini, or local browser speech.
 
 Signed-in Parent Hub and Admin / Operations use live Worker hub payloads. Those adult surfaces keep platform role, learner membership role, and writable/read-only access separate. `/api/bootstrap` remains writable-only for the main subject shell, while readable viewer learners are available inside hub surfaces with explicit read-only labels and blocked write affordances.
 

--- a/docs/spelling-parity.md
+++ b/docs/spelling-parity.md
@@ -20,9 +20,9 @@ Provider-specific browser/API TTS traffic and exact browser playback timing were
 | Secure-word progression | New word needs two clean hits in one round; secure threshold remains stage >= 4; due-day scheduling stays legacy | Already matched by preserved engine | No engine change | Matched |
 | Summary output | Learning/test summaries preserve legacy cards, wording, mistake drill, and follow-up drills | Already matched through engine finalise + summary UI | No logic change | Matched |
 | Analytics | Aggregate secure/due/trouble/fresh/accuracy stats and year-band splits were present; legacy also exposed searchable word-bank progress and direct bank drill | Aggregate analytics matched, but searchable word bank was not rebuilt | Documented remaining delta only | Partial |
-| Preferences | Mode, year filter, session size, auto-play, cloze toggle, audio provider/model/key/rate controls | Core spelling prefs matched except richer audio/provider controls | No provider-rate rebuild in this pass | Partial; OpenAI is now the production default, but provider controls are still not exposed in the UI |
+| Preferences | Mode, year filter, session size, auto-play, cloze toggle, audio provider/model/key/rate controls | Core spelling prefs matched except richer model/key/rate controls | Added a profile-level provider switch for OpenAI, Gemini, and local browser speech | Partial; provider choice is exposed, while model/key/rate controls remain deferred |
 | Resume / abandon / continue | Legacy confirmed before discarding/switching, auto-advanced after marked cards, and did not preserve platform-level resume across learner switches | Manual Continue button and no end-session confirm were real mismatches; platform resume was intentionally broader | Restored end/switch confirmation and auto-advance; kept platform-level resume as an intentional delta | Partial, with key regressions fixed |
-| TTS / audio behaviour | Auto-play, replay, slow replay, audio reset on switch/home/profile change, browser/API provider options, warm-up behaviour | Browser dictation loop existed; provider-specific options and warm-up were not rebuilt | Restored shortcut replay flow and ensured new rounds stop prior audio before starting | Partial; production dictation now defaults to OpenAI TTS with browser fallback |
+| TTS / audio behaviour | Auto-play, replay, slow replay, audio reset on switch/home/profile change, browser/API provider options, warm-up behaviour | Browser dictation loop existed; provider-specific options and warm-up were not rebuilt | Restored shortcut replay flow, ensured new rounds stop prior audio before starting, and added selected-provider dictation without automatic fallback | Partial; provider choice is restored, while warm-up and detailed voice controls remain deferred |
 | Keyboard / interaction flow | Enter submit, Esc replay, Shift+Esc slow replay, Alt+1/2/3 start modes, Alt+S skip, Alt+K focus, ignore Alt shortcuts while typing in unrelated inputs | Most subject shortcuts were missing | Restored Esc / Shift+Esc / Alt+1/2/3 / Alt+S / Alt+K with guarded typing behaviour | Mostly matched inside active Spelling practice |
 | Live-card hint leakage | Legacy explicitly hid the family during live recall and only surfaced family words after the engine allowed it | Pass 9 leaked family/family-count chips during the live card | Removed live family leakage and restored the hidden-family note | Matched |
 
@@ -69,10 +69,10 @@ These deltas remain on purpose.
    - The rebuilt platform now contains multiple subject surfaces.
    - Pass 10 therefore scopes restored shortcuts to active Spelling practice to avoid cross-subject collisions.
 
-3. **Provider/API TTS controls are still not restored**
-   - The older single-page app exposed browser/API provider choice, keys, model/voice controls, backup Gemini key handling, and warm-up behaviour.
-   - The rebuilt production platform now uses a Worker-side OpenAI TTS default voice, with browser speech fallback.
-   - The UI still does not expose provider/model/voice/rate controls.
+3. **Detailed TTS controls are still not restored**
+   - The older single-page app exposed keys, model/voice controls, backup Gemini key handling, and warm-up behaviour.
+   - The rebuilt production platform exposes provider choice in Profile Settings and keeps provider keys on the Worker side.
+   - The UI still does not expose model/voice/rate controls.
 
 4. **Searchable word-bank drill UI is still not restored**
    - Legacy exposed searchable word-bank progress and direct single-word drill launch from that bank.

--- a/docs/spelling-service.md
+++ b/docs/spelling-service.md
@@ -114,7 +114,7 @@ These were kept on purpose:
 - skipping only works in learning question phase and pushes the word later in the round
 - marked cards auto-advance after the preserved short delay instead of needing an extra manual confirmation step
 - the preserved shortcut loop remains available inside active Spelling practice (`Esc`, `Shift+Esc`, `Alt+1/2/3`, `Alt+S`, `Alt+K`) while still avoiding cross-subject collisions in the wider shell
-- production dictation audio is generated through the Worker-side OpenAI TTS proxy by default, with browser speech synthesis kept as the client fallback
+- dictation audio honours the learner's selected profile provider: OpenAI, Gemini, or local browser speech
 - stage progression and due-day scheduling still come from the preserved legacy engine
 
 ## Pass 10 parity notes
@@ -132,7 +132,7 @@ What was brought back into line with the direct legacy baseline:
 What remains intentionally different:
 
 - platform-level resume across learner switches/navigation/reload still stays broader than legacy
-- provider/model/voice/rate TTS controls and warm-up behaviour are still deferred
+- model/voice/rate TTS controls and warm-up behaviour are still deferred
 
 See `docs/spelling-parity.md` for the full matrix and the explicit remaining deltas.
 

--- a/src/main.js
+++ b/src/main.js
@@ -25,6 +25,7 @@ import { createPracticeStreakSubscriber } from './platform/events/index.js';
 import { createPlatformTts } from './subjects/spelling/tts.js';
 import { createSpellingService } from './subjects/spelling/service.js';
 import { createSpellingPersistence } from './subjects/spelling/repository.js';
+import { DEFAULT_TTS_PROVIDER, normaliseTtsProvider } from './subjects/spelling/tts-providers.js';
 import {
   createApiSpellingContentRepository,
   createLocalSpellingContentRepository,
@@ -168,14 +169,34 @@ const repositories = boot.repositories;
 globalThis.KS2_AUTH_SESSION = boot.session;
 await repositories.hydrate();
 
-const tts = createPlatformTts({ fetchFn: credentialFetch });
+const services = {
+  spelling: null,
+};
+let store = null;
 
-/* Audio replay glow state — maintained outside the store because it is a
+function selectedTtsProvider() {
+  const learnerId = store?.getState?.()?.learners?.selectedId;
+  if (!learnerId) return DEFAULT_TTS_PROVIDER;
+  try {
+    return normaliseTtsProvider(services.spelling?.getPrefs?.(learnerId)?.ttsProvider);
+  } catch {
+    return DEFAULT_TTS_PROVIDER;
+  }
+}
+
+const tts = createPlatformTts({
+  fetchFn: credentialFetch,
+  provider: selectedTtsProvider,
+});
+
+/* Audio replay affordance state — maintained outside the store because it is a
    transient DOM affordance, not persisted learner state. The render wipes
-   innerHTML on every store update, so we re-apply the `playing` class
-   both inside render() and inside the tts listener to cover both paths
-   (learner clicks mid-render vs audio ending between renders). */
+   innerHTML on every store update, so we re-apply the classes both inside
+   render() and inside the TTS listener to cover both paths. */
 let currentPlayingKind = null;
+let currentLoadingKind = null;
+let audioLoadingStartedAt = 0;
+let audioLoadingTimer = null;
 
 const NORMAL_REPLAY_SELECTORS = [
   '[data-action="spelling-replay"]',
@@ -192,14 +213,52 @@ function syncAudioPlayingClass() {
   const slowNodes = root.querySelectorAll(SLOW_REPLAY_SELECTORS.join(','));
   const normalOn = currentPlayingKind === 'normal';
   const slowOn = currentPlayingKind === 'slow';
-  for (const node of normalNodes) node.classList.toggle('playing', normalOn);
-  for (const node of slowNodes) node.classList.toggle('playing', slowOn);
+  const normalLoading = currentLoadingKind === 'normal';
+  const slowLoading = currentLoadingKind === 'slow';
+  const waitingLong = audioLoadingStartedAt > 0 && (Date.now() - audioLoadingStartedAt) >= 10000;
+  for (const node of normalNodes) {
+    node.classList.toggle('playing', normalOn);
+    node.classList.toggle('loading', normalLoading);
+    node.classList.toggle('waiting-long', normalLoading && waitingLong);
+    node.toggleAttribute('aria-busy', normalLoading);
+  }
+  for (const node of slowNodes) {
+    node.classList.toggle('playing', slowOn);
+    node.classList.toggle('loading', slowLoading);
+    node.classList.toggle('waiting-long', slowLoading && waitingLong);
+    node.toggleAttribute('aria-busy', slowLoading);
+  }
+}
+
+function clearAudioLoadingTimer() {
+  if (!audioLoadingTimer) return;
+  clearTimeout(audioLoadingTimer);
+  audioLoadingTimer = null;
+}
+
+function armAudioLoadingTimer() {
+  clearAudioLoadingTimer();
+  audioLoadingTimer = setTimeout(() => {
+    audioLoadingTimer = null;
+    syncAudioPlayingClass();
+  }, 10000);
 }
 
 tts.subscribe((event) => {
-  if (event?.type === 'start') {
+  if (event?.type === 'loading') {
+    currentLoadingKind = event.kind === 'slow' ? 'slow' : 'normal';
+    currentPlayingKind = null;
+    audioLoadingStartedAt = Date.now();
+    armAudioLoadingTimer();
+  } else if (event?.type === 'start') {
+    clearAudioLoadingTimer();
+    currentLoadingKind = null;
+    audioLoadingStartedAt = 0;
     currentPlayingKind = event.kind === 'slow' ? 'slow' : 'normal';
   } else if (event?.type === 'end') {
+    clearAudioLoadingTimer();
+    currentLoadingKind = null;
+    audioLoadingStartedAt = 0;
     currentPlayingKind = null;
   }
   syncAudioPlayingClass();
@@ -210,9 +269,6 @@ const spellingContentRepository = boot.session.signedIn
   : createLocalSpellingContentRepository({ storage: globalThis.localStorage });
 const spellingContent = createSpellingContentService({ repository: spellingContentRepository });
 await spellingContent.hydrate();
-const services = {
-  spelling: null,
-};
 let shellPlatformRole = normalisePlatformRole(boot.session.platformRole || 'parent');
 let adminAccountDirectory = {
   status: 'idle',
@@ -602,7 +658,7 @@ const controller = createAppController({
     globalThis.console?.error?.('Reward/event subscriber failed.', error);
   },
 });
-const store = controller.store;
+store = controller.store;
 
 function resetLearnerData(learnerId) {
   Object.values(services).forEach((service) => {
@@ -940,6 +996,7 @@ function buildSurfaceChromeModel(appState) {
       : null,
     learnerLabel: learner ? `${learner.name} · ${learner.yearGroup}` : 'No learner selected',
     learnerOptions,
+    ttsProvider: learnerId ? selectedTtsProvider() : DEFAULT_TTS_PROVIDER,
     signedInAs: boot.session.signedIn ? (boot.session.email || '') : null,
     persistence: {
       mode: persistenceSnapshot?.mode || 'local-only',
@@ -1328,6 +1385,10 @@ function handleGlobalAction(action, data) {
   if (action === 'learner-save-form') {
     if (blockReadOnlyAdultAction(action)) return true;
     const formData = data.formData;
+    services.spelling?.savePrefs?.(learnerId, {
+      ttsProvider: normaliseTtsProvider(formData.get('ttsProvider')),
+    });
+    tts.stop();
     store.updateLearner(learnerId, {
       name: String(formData.get('name') || 'Learner').trim() || 'Learner',
       yearGroup: String(formData.get('yearGroup') || 'Y5'),

--- a/src/platform/app/create-app-controller.js
+++ b/src/platform/app/create-app-controller.js
@@ -7,6 +7,7 @@ import { createSpellingAutoAdvanceController } from '../../subjects/spelling/aut
 import { resolveSpellingShortcut } from '../../subjects/spelling/shortcuts.js';
 import { createSpellingService } from '../../subjects/spelling/service.js';
 import { createSpellingPersistence } from '../../subjects/spelling/repository.js';
+import { normaliseTtsProvider } from '../../subjects/spelling/tts-providers.js';
 import {
   isMonsterCelebrationEvent,
   shouldDelayMonsterCelebrations,
@@ -293,6 +294,9 @@ export function createAppController({
 
     if (action === 'learner-save-form') {
       const formData = data.formData;
+      services.spelling?.savePrefs?.(learnerId, {
+        ttsProvider: normaliseTtsProvider(formData.get('ttsProvider')),
+      });
       store.updateLearner(learnerId, {
         name: String(formData.get('name') || 'Learner').trim() || 'Learner',
         yearGroup: String(formData.get('yearGroup') || 'Y5'),

--- a/src/platform/ui/render.js
+++ b/src/platform/ui/render.js
@@ -5,6 +5,13 @@ import { subjectTabLabel } from '../core/subject-runtime.js';
 import { monsterAsset, monsterAssetSrcSet } from '../game/monsters.js';
 import { monsterSummary, monsterSummaryFromSpellingAnalytics } from '../game/monster-system.js';
 import { readOnlyLearnerActionBlockReason } from '../hubs/shell-access.js';
+import { normaliseTtsProvider } from '../../subjects/spelling/tts-providers.js';
+
+const TTS_PROVIDER_OPTIONS = [
+  { value: 'openai', label: 'OpenAI' },
+  { value: 'gemini', label: 'Gemini' },
+  { value: 'browser', label: 'Browser', title: 'Local browser voice, preferring Google UK English female where available' },
+];
 
 function iconGlyph(icon) {
   return {
@@ -591,6 +598,16 @@ function learnerOrdinal(appState) {
   return index >= 0 ? index + 1 : 1;
 }
 
+function renderTtsProviderOptions(provider) {
+  const selected = normaliseTtsProvider(provider);
+  return TTS_PROVIDER_OPTIONS.map((option) => `
+    <label class="profile-tts-option" title="${escapeHtml(option.title || option.label)}">
+      <input type="radio" name="ttsProvider" value="${escapeHtml(option.value)}" ${selected === option.value ? 'checked' : ''} />
+      <span>${escapeHtml(option.label)}</span>
+    </label>
+  `).join('');
+}
+
 function renderProfileLearnerSelect(appState) {
   const learners = appState.learners.allIds.map((id) => appState.learners.byId[id]).filter(Boolean);
   if (!learners.length) {
@@ -666,6 +683,7 @@ function renderLearnerManager(appState, context) {
     `;
   }
   const accent = safeInlineColor(learner.avatarColor);
+  const ttsProvider = normaliseTtsProvider(context.services?.spelling?.getPrefs?.(learner.id)?.ttsProvider);
   const learnerCount = appState.learners.allIds.length;
   const subjectCount = registeredSubjects(context).length;
   const liveSubjectCount = registeredSubjects(context).filter((subject) => subject.available !== false).length;
@@ -732,6 +750,12 @@ function renderLearnerManager(appState, context) {
             <span>Accent colour</span>
             <input class="input" type="color" name="avatarColor" autocomplete="off" value="${escapeHtml(accent)}" />
           </label>
+          <div class="profile-form-field profile-form-field-wide">
+            <span>Dictation voice</span>
+            <div class="profile-tts-options" role="radiogroup" aria-label="Dictation voice">
+              ${renderTtsProviderOptions(ttsProvider)}
+            </div>
+          </div>
         </div>
         <div class="profile-form-footer">
           <div class="profile-form-danger-actions">

--- a/src/subjects/spelling/service.js
+++ b/src/subjects/spelling/service.js
@@ -7,6 +7,7 @@ import {
   createSpellingSessionCompletedEvent,
   createSpellingWordSecuredEvent,
 } from './events.js';
+import { normaliseTtsProvider } from './tts-providers.js';
 import {
   cloneSerialisable,
   createInitialSpellingState,
@@ -152,6 +153,7 @@ function normalisePrefs(rawPrefs = {}) {
     showCloze: normaliseBoolean(rawPrefs.showCloze, true),
     autoSpeak: normaliseBoolean(rawPrefs.autoSpeak, true),
     extraWordFamilies: normaliseBoolean(rawPrefs.extraWordFamilies, false),
+    ttsProvider: normaliseTtsProvider(rawPrefs.ttsProvider),
   };
 }
 
@@ -922,9 +924,13 @@ export function createSpellingService({ repository, storage, tts, now, random, c
   }
 
   function resetLearner(learnerId) {
+    const currentPrefs = getPrefs(learnerId);
     engine.resetProgress(learnerId);
     persistence.resetLearner?.(learnerId);
-    saveJson(resolvedStorage, prefsKey(learnerId), defaultSpellingPrefs());
+    saveJson(resolvedStorage, prefsKey(learnerId), {
+      ...defaultSpellingPrefs(),
+      ttsProvider: currentPrefs.ttsProvider,
+    });
   }
 
   return {

--- a/src/subjects/spelling/tts-providers.js
+++ b/src/subjects/spelling/tts-providers.js
@@ -1,0 +1,13 @@
+export const DEFAULT_TTS_PROVIDER = 'openai';
+
+export const TTS_PROVIDER_IDS = Object.freeze([
+  'openai',
+  'gemini',
+  'browser',
+]);
+
+export function normaliseTtsProvider(value, fallback = DEFAULT_TTS_PROVIDER) {
+  const provider = String(value || '').trim().toLowerCase();
+  if (TTS_PROVIDER_IDS.includes(provider)) return provider;
+  return TTS_PROVIDER_IDS.includes(fallback) ? fallback : DEFAULT_TTS_PROVIDER;
+}

--- a/src/subjects/spelling/tts.js
+++ b/src/subjects/spelling/tts.js
@@ -1,4 +1,5 @@
 import { clamp } from '../../platform/core/utils.js';
+import { DEFAULT_TTS_PROVIDER, normaliseTtsProvider } from './tts-providers.js';
 
 export function buildDictationTranscript({ word, sentence } = {}) {
   const spokenWord = typeof word === 'string' ? word : word?.word;
@@ -27,10 +28,44 @@ function shouldUseRemoteTts() {
   }
 }
 
+function resolveProvider(provider) {
+  try {
+    return normaliseTtsProvider(typeof provider === 'function' ? provider() : provider);
+  } catch {
+    return DEFAULT_TTS_PROVIDER;
+  }
+}
+
+function browserVoiceScore(voice) {
+  if (!voice) return -1;
+  const name = `${voice.name || ''} ${voice.voiceURI || ''}`.toLowerCase();
+  const lang = String(voice.lang || '').toLowerCase();
+  let score = 0;
+  if (lang === 'en-gb') score += 80;
+  else if (lang.startsWith('en-gb')) score += 70;
+  else if (lang.startsWith('en')) score += 35;
+  if (name.includes('google')) score += 30;
+  if (name.includes('uk') || name.includes('british') || name.includes('united kingdom')) score += 20;
+  if (name.includes('female')) score += 15;
+  if (name.includes('english')) score += 5;
+  if (voice.default) score += 1;
+  return score;
+}
+
+function chooseBrowserVoice(speechSynthesis) {
+  const voices = typeof speechSynthesis?.getVoices === 'function'
+    ? speechSynthesis.getVoices()
+    : [];
+  return voices
+    .filter((voice) => browserVoiceScore(voice) > 0)
+    .sort((a, b) => browserVoiceScore(b) - browserVoiceScore(a))[0] || null;
+}
+
 export function createPlatformTts({
   fetchFn = globalThis.fetch?.bind(globalThis),
   endpoint = '/api/tts',
   remoteEnabled = shouldUseRemoteTts(),
+  provider = DEFAULT_TTS_PROVIDER,
 } = {}) {
   let playbackId = 0;
   let currentAbort = null;
@@ -93,8 +128,11 @@ export function createPlatformTts({
     if (!available()) return Promise.resolve(false);
     stopBrowserSpeech();
     const transcript = buildSpeechTranscript({ word, sentence, wordOnly });
-    const utterance = new SpeechSynthesisUtterance(transcript);
+    const Utterance = window.SpeechSynthesisUtterance;
+    const utterance = new Utterance(transcript);
     utterance.lang = 'en-GB';
+    const voice = chooseBrowserVoice(window.speechSynthesis);
+    if (voice) utterance.voice = voice;
     utterance.rate = clamp(slow ? 0.9 : 1.02, 0.8, 1.2);
     return new Promise((resolve) => {
       utterance.onend = () => {
@@ -110,14 +148,15 @@ export function createPlatformTts({
     });
   }
 
-  async function speakWithRemote({ word, sentence, slow = false, wordOnly = false }, token) {
+  async function speakWithRemote({ word, sentence, slow = false, wordOnly = false }, providerId, token) {
     if (!remoteEnabled || typeof fetchFn !== 'function' || typeof Audio === 'undefined' || typeof URL === 'undefined') {
       return false;
     }
 
     currentAbort = new AbortController();
+    emit({ type: 'loading', kind: slow ? 'slow' : 'normal', provider: providerId });
     try {
-      const requestBody = { word, sentence, slow };
+      const requestBody = { word, sentence, slow, provider: providerId };
       if (wordOnly) requestBody.wordOnly = true;
       const response = await fetchFn(endpoint, {
         method: 'POST',
@@ -129,7 +168,10 @@ export function createPlatformTts({
         signal: currentAbort.signal,
         body: JSON.stringify(requestBody),
       });
-      if (!response.ok) return false;
+      if (!response.ok) {
+        if (token === playbackId) emit({ type: 'end' });
+        return false;
+      }
       const blob = await response.blob();
       if (token !== playbackId) return false;
 
@@ -160,6 +202,7 @@ export function createPlatformTts({
         });
       });
     } catch {
+      if (token === playbackId) emit({ type: 'end' });
       return false;
     } finally {
       if (token === playbackId) currentAbort = null;
@@ -169,9 +212,9 @@ export function createPlatformTts({
   async function speak(payload = {}) {
     stop();
     const token = playbackId;
-    const playedRemote = await speakWithRemote(payload, token);
-    if (playedRemote || token !== playbackId) return playedRemote;
-    return speakWithBrowser(payload);
+    const providerId = resolveProvider(provider);
+    if (providerId === 'browser') return speakWithBrowser(payload);
+    return await speakWithRemote(payload, providerId, token);
   }
 
   return {

--- a/src/surfaces/profile/ProfileSettingsSurface.jsx
+++ b/src/surfaces/profile/ProfileSettingsSurface.jsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import { TopNav } from '../shell/TopNav.jsx';
 import { PersistenceBanner } from '../shell/PersistenceBanner.jsx';
+import { normaliseTtsProvider } from '../../subjects/spelling/tts-providers.js';
+
+const TTS_PROVIDER_OPTIONS = [
+  { value: 'openai', label: 'OpenAI' },
+  { value: 'gemini', label: 'Gemini' },
+  { value: 'browser', label: 'Browser', title: 'Local browser voice, preferring Google UK English female where available' },
+];
 
 function safeColour(value, fallback = '#3E6FA8') {
   const colour = String(value || '').trim();
@@ -97,6 +104,7 @@ export function ProfileSettingsSurface({ appState, chrome, actions, subjectCount
   }
 
   const accent = safeColour(learner.avatarColor);
+  const ttsProvider = normaliseTtsProvider(chrome.ttsProvider);
   const submit = (event) => {
     event.preventDefault();
     actions.dispatch('learner-save-form', { formData: new FormData(event.currentTarget) });
@@ -190,6 +198,22 @@ export function ProfileSettingsSurface({ appState, chrome, actions, subjectCount
                 <span>Accent colour</span>
                 <input className="input" type="color" name="avatarColor" autoComplete="off" defaultValue={accent} />
               </label>
+              <div className="profile-form-field profile-form-field-wide">
+                <span>Dictation voice</span>
+                <div className="profile-tts-options" role="radiogroup" aria-label="Dictation voice">
+                  {TTS_PROVIDER_OPTIONS.map((option) => (
+                    <label className="profile-tts-option" key={option.value} title={option.title || option.label}>
+                      <input
+                        type="radio"
+                        name="ttsProvider"
+                        value={option.value}
+                        defaultChecked={ttsProvider === option.value}
+                      />
+                      <span>{option.label}</span>
+                    </label>
+                  ))}
+                </div>
+              </div>
             </div>
             <div className="profile-form-footer">
               <div className="profile-form-danger-actions">

--- a/styles/app.css
+++ b/styles/app.css
@@ -2289,6 +2289,55 @@ textarea:focus-visible {
   padding: 7px;
 }
 
+.profile-tts-options {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.profile-tts-option {
+  position: relative;
+  min-width: 0;
+}
+
+.profile-tts-option input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+}
+
+.profile-tts-option > span {
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  color: var(--ink);
+  font-size: 0.88rem;
+  font-weight: 900;
+  transition:
+    background var(--dur) var(--ease-out),
+    border-color var(--dur) var(--ease-out),
+    color var(--dur) var(--ease-out),
+    box-shadow var(--dur) var(--ease-out);
+}
+
+.profile-tts-option input:checked + span {
+  background: color-mix(in oklab, var(--profile-accent, var(--brand)) 13%, var(--panel));
+  border-color: color-mix(in oklab, var(--profile-accent, var(--brand)) 58%, var(--line));
+  color: color-mix(in oklab, var(--profile-accent, var(--brand)) 72%, var(--ink));
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--profile-accent, var(--brand)) 34%, transparent);
+}
+
+.profile-tts-option input:focus-visible + span {
+  outline: none;
+  box-shadow:
+    0 0 0 3px color-mix(in oklab, var(--profile-accent, var(--brand)) 18%, transparent),
+    inset 0 0 0 1px color-mix(in oklab, var(--profile-accent, var(--brand)) 34%, transparent);
+}
+
 .profile-form-footer {
   display: flex;
   flex-wrap: wrap;
@@ -4706,11 +4755,45 @@ textarea:focus-visible {
   color: var(--ink);
 }
 .btn.icon.lg { width: 52px; height: 52px; }
+.spelling-in-session .audio-row .btn.icon.loading {
+  position: relative;
+  color: var(--brand);
+  border-color: color-mix(in oklab, var(--brand) 38%, var(--line));
+}
+.spelling-in-session .audio-row .btn.icon.loading > svg {
+  opacity: 0;
+  transform: scale(0.78);
+}
+.spelling-in-session .audio-row .btn.icon.loading::before {
+  content: "";
+  position: absolute;
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  border: 2.5px solid color-mix(in oklab, currentColor 24%, transparent);
+  border-top-color: currentColor;
+  animation: audio-spin 0.82s linear infinite;
+  transition:
+    border-color 4s var(--ease-in-out),
+    border-top-color 4s var(--ease-in-out),
+    color 4s var(--ease-in-out);
+}
+.spelling-in-session .audio-row .btn.icon.loading.waiting-long {
+  color: var(--bad);
+  border-color: color-mix(in oklab, var(--bad) 52%, var(--line));
+}
+.spelling-in-session .audio-row .btn.icon.loading.waiting-long::before {
+  border-color: color-mix(in oklab, var(--bad) 34%, transparent);
+  border-top-color: var(--bad);
+}
 .btn.icon.playing {
   background: color-mix(in oklab, var(--brand) 14%, var(--panel));
   border-color: color-mix(in oklab, var(--brand) 45%, var(--line));
   color: var(--brand-ink);
   animation: audio-glow 1.4s var(--ease-in-out) infinite;
+}
+@keyframes audio-spin {
+  to { transform: rotate(360deg); }
 }
 @keyframes audio-glow {
   0%, 100% {
@@ -4725,7 +4808,8 @@ textarea:focus-visible {
   }
 }
 @media (prefers-reduced-motion: reduce) {
-  .btn.icon.playing { animation: none; }
+  .btn.icon.playing,
+  .spelling-in-session .audio-row .btn.icon.loading::before { animation: none; }
 }
 
 /* ---------- Feedback ribbon + family chips ---------- */

--- a/tests/app-controller.test.js
+++ b/tests/app-controller.test.js
@@ -160,6 +160,23 @@ test('controller bootstraps local repositories, store, services, and snapshot wi
   assert.equal(snapshot.ui.adultSurface.parentHub.status, 'idle');
 });
 
+test('controller persists profile TTS provider in spelling prefs', () => {
+  installMemoryStorage();
+  const controller = createAppController();
+  const learnerId = controller.store.getState().learners.selectedId;
+  const formData = new FormData();
+  formData.set('name', 'Ava');
+  formData.set('yearGroup', 'Y5');
+  formData.set('goal', 'sats');
+  formData.set('dailyMinutes', '15');
+  formData.set('avatarColor', '#3E6FA8');
+  formData.set('ttsProvider', 'gemini');
+
+  controller.dispatch('learner-save-form', { formData });
+
+  assert.equal(controller.services.spelling.getPrefs(learnerId).ttsProvider, 'gemini');
+});
+
 test('controller dispatches spelling transitions through store, repositories, events, and TTS', () => {
   installMemoryStorage();
   const controller = createAppController();

--- a/tests/react-shared-surfaces.test.js
+++ b/tests/react-shared-surfaces.test.js
@@ -8,6 +8,7 @@ test('React profile settings surface owns learner profile and data actions', asy
 
   assert.match(html, /Profile settings/);
   assert.match(html, /Learning profile for/);
+  assert.match(html, /Dictation voice/);
   assert.match(html, /Portable snapshots/);
   assert.match(html, /Save learner profile/);
   assert.doesNotMatch(html, /data-action="learner-save-form"/);

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -77,6 +77,8 @@ test('profile settings learner profile fields declare autofill behaviour explici
   assert.match(html, /data-action="learner-save-form"/);
   assert.match(html, /<input class="input" name="name"[^>]*autocomplete="off"/);
   assert.match(html, /<input class="input" type="number"[^>]*name="dailyMinutes"[^>]*autocomplete="off"/);
+  assert.match(html, /name="ttsProvider" value="openai"/);
+  assert.match(html, /name="ttsProvider" value="browser"/);
 });
 
 test('codex route mounts the React codex surface', () => {

--- a/tests/spelling-tts.test.js
+++ b/tests/spelling-tts.test.js
@@ -24,7 +24,7 @@ test('word-only transcript reads vocabulary without the dictation script', () =>
   );
 });
 
-test('platform TTS calls the Worker audio proxy before browser fallback', async () => {
+test('platform TTS sends the selected Worker provider', async () => {
   const originalAudio = globalThis.Audio;
   const originalCreateObjectUrl = URL.createObjectURL;
   const originalRevokeObjectUrl = URL.revokeObjectURL;
@@ -53,6 +53,7 @@ test('platform TTS calls the Worker audio proxy before browser fallback', async 
   const calls = [];
   const tts = createPlatformTts({
     remoteEnabled: true,
+    provider: () => 'gemini',
     fetchFn: async (url, init = {}) => {
       calls.push({
         url,
@@ -84,6 +85,7 @@ test('platform TTS calls the Worker audio proxy before browser fallback', async 
       word: { word: 'early' },
       sentence: 'The birds sang early in the day.',
       slow: true,
+      provider: 'gemini',
     });
 
     const wordOnlyResult = await tts.speak({
@@ -97,6 +99,7 @@ test('platform TTS calls the Worker audio proxy before browser fallback', async 
     assert.deepEqual(calls[1].body, {
       word: 'possess',
       slow: false,
+      provider: 'gemini',
       wordOnly: true,
     });
   } finally {
@@ -104,5 +107,105 @@ test('platform TTS calls the Worker audio proxy before browser fallback', async 
     globalThis.Audio = originalAudio;
     URL.createObjectURL = originalCreateObjectUrl;
     URL.revokeObjectURL = originalRevokeObjectUrl;
+  }
+});
+
+test('platform TTS does not fall back when the selected remote provider fails', async () => {
+  const originalWindow = globalThis.window;
+  const originalAudio = globalThis.Audio;
+  const calls = [];
+  let spoke = false;
+
+  globalThis.Audio = class MockAudio {};
+  globalThis.window = {
+    speechSynthesis: {
+      cancel() {},
+      speak() { spoke = true; },
+    },
+    SpeechSynthesisUtterance: class MockUtterance {},
+  };
+
+  const tts = createPlatformTts({
+    remoteEnabled: true,
+    provider: 'openai',
+    fetchFn: async (url, init = {}) => {
+      calls.push({ url, body: JSON.parse(init.body) });
+      return new Response(JSON.stringify({ error: 'busy' }), { status: 503 });
+    },
+  });
+
+  try {
+    const result = await tts.speak({
+      word: 'early',
+      sentence: 'The birds sang early in the day.',
+    });
+
+    assert.equal(result, false);
+    assert.equal(spoke, false);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].body.provider, 'openai');
+  } finally {
+    tts.stop();
+    globalThis.window = originalWindow;
+    globalThis.Audio = originalAudio;
+  }
+});
+
+test('platform TTS can use the local browser voice provider', async () => {
+  const originalWindow = globalThis.window;
+  const originalAudio = globalThis.Audio;
+  const spoken = [];
+  const voices = [
+    { name: 'Google US English', lang: 'en-US', voiceURI: 'Google US English' },
+    { name: 'Google UK English Female', lang: 'en-GB', voiceURI: 'Google UK English Female' },
+  ];
+
+  globalThis.Audio = class MockAudio {};
+  globalThis.window = {
+    speechSynthesis: {
+      cancel() {},
+      getVoices() { return voices; },
+      speak(utterance) {
+        spoken.push(utterance);
+        setTimeout(() => utterance.onend?.(), 0);
+      },
+    },
+    SpeechSynthesisUtterance: class MockUtterance {
+      constructor(text) {
+        this.text = text;
+        this.lang = '';
+        this.rate = 1;
+        this.voice = null;
+      }
+    },
+  };
+
+  const calls = [];
+  const tts = createPlatformTts({
+    remoteEnabled: true,
+    provider: 'browser',
+    fetchFn: async () => {
+      calls.push(true);
+      return new Response(null, { status: 500 });
+    },
+  });
+
+  try {
+    const result = await tts.speak({
+      word: 'early',
+      sentence: 'The birds sang early in the day.',
+      slow: true,
+    });
+
+    assert.equal(result, true);
+    assert.equal(calls.length, 0);
+    assert.equal(spoken.length, 1);
+    assert.equal(spoken[0].lang, 'en-GB');
+    assert.equal(spoken[0].voice.name, 'Google UK English Female');
+    assert.match(spoken[0].text, /The word is early/);
+  } finally {
+    tts.stop();
+    globalThis.window = originalWindow;
+    globalThis.Audio = originalAudio;
   }
 });

--- a/tests/spelling.test.js
+++ b/tests/spelling.test.js
@@ -262,6 +262,15 @@ test('legacy all filter normalises to core stats and excludes Extra progress', (
   assert.equal(service.getStats('learner-a', 'extra').attempts, 1);
 });
 
+test('resetting spelling progress preserves the profile TTS provider', () => {
+  const { service } = makeService();
+  service.savePrefs('learner-a', { ttsProvider: 'browser' });
+
+  service.resetLearner('learner-a');
+
+  assert.equal(service.getPrefs('learner-a').ttsProvider, 'browser');
+});
+
 test('Extra spelling accepts UK mollusc only', () => {
   const { service } = makeService();
   const accepted = service.startSession('learner-uk', {

--- a/tests/worker-tts.test.js
+++ b/tests/worker-tts.test.js
@@ -73,6 +73,7 @@ test('TTS route proxies dictation audio through OpenAI without exposing the key'
     assert.equal(response.status, 200);
     assert.equal(response.headers.get('content-type'), 'audio/mpeg');
     assert.equal(response.headers.get('cache-control'), 'no-store');
+    assert.equal(response.headers.get('x-ks2-tts-provider'), 'openai');
     assert.deepEqual([...bytes], [1, 2, 3]);
     assert.equal(calls.length, 1);
     assert.equal(calls[0].url, 'https://api.openai.com/v1/audio/speech');
@@ -88,7 +89,7 @@ test('TTS route proxies dictation audio through OpenAI without exposing the key'
   }
 });
 
-test('TTS route falls back to Gemini when OpenAI returns a provider error', async () => {
+test('TTS route proxies dictation audio through selected Gemini provider', async () => {
   const originalFetch = globalThis.fetch;
   const calls = [];
   globalThis.fetch = async (url, init = {}) => {
@@ -97,9 +98,6 @@ test('TTS route falls back to Gemini when OpenAI returns a provider error', asyn
       headers: init.headers,
       body: JSON.parse(init.body),
     });
-    if (url === 'https://api.openai.com/v1/audio/speech') {
-      return new Response(JSON.stringify({ error: 'busy' }), { status: 503 });
-    }
     return geminiAudioResponse();
   };
 
@@ -110,29 +108,29 @@ test('TTS route falls back to Gemini when OpenAI returns a provider error', asyn
     },
   });
   try {
-    const response = await server.fetch('https://repo.test/api/tts', ttsRequest());
+    const response = await server.fetch('https://repo.test/api/tts', ttsRequest({ provider: 'gemini' }));
     const bytes = new Uint8Array(await response.arrayBuffer());
 
     assert.equal(response.status, 200);
     assert.equal(response.headers.get('content-type'), 'audio/wav');
     assert.equal(response.headers.get('x-ks2-tts-provider'), 'gemini');
-    assert.equal(response.headers.get('x-ks2-tts-fallback-from'), 'openai');
+    assert.equal(response.headers.get('x-ks2-tts-fallback-from'), null);
     assert.equal(response.headers.get('x-ks2-tts-model'), 'gemini-3.1-flash-tts-preview');
     assert.equal(String.fromCharCode(...bytes.slice(0, 4)), 'RIFF');
-    assert.equal(calls.length, 2);
-    assert.equal(calls[1].url, 'https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-tts-preview:generateContent');
-    assert.equal(calls[1].headers['x-goog-api-key'], 'test-gemini-key');
-    assert.equal(calls[1].body.generationConfig.responseModalities[0], 'AUDIO');
-    assert.equal(calls[1].body.generationConfig.speechConfig.languageCode, 'en-GB');
-    assert.equal(calls[1].body.generationConfig.speechConfig.voiceConfig.prebuiltVoiceConfig.voiceName, 'Kore');
-    assert.match(calls[1].body.contents[0].parts[0].text, /The word is early/);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, 'https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-tts-preview:generateContent');
+    assert.equal(calls[0].headers['x-goog-api-key'], 'test-gemini-key');
+    assert.equal(calls[0].body.generationConfig.responseModalities[0], 'AUDIO');
+    assert.equal(calls[0].body.generationConfig.speechConfig.languageCode, 'en-GB');
+    assert.equal(calls[0].body.generationConfig.speechConfig.voiceConfig.prebuiltVoiceConfig.voiceName, 'Kore');
+    assert.match(calls[0].body.contents[0].parts[0].text, /The word is early/);
   } finally {
     globalThis.fetch = originalFetch;
     server.close();
   }
 });
 
-test('TTS route falls back to Gemini when OpenAI exceeds the primary timeout', async () => {
+test('TTS route does not fall back when selected OpenAI exceeds the primary timeout', async () => {
   const originalFetch = globalThis.fetch;
   let openAiAborted = false;
   globalThis.fetch = async (url, init = {}) => {
@@ -146,7 +144,7 @@ test('TTS route falls back to Gemini when OpenAI exceeds the primary timeout', a
         }, { once: true });
       });
     }
-    return geminiAudioResponse([3, 0, 4, 0]);
+    throw new Error(`Unexpected provider call: ${url}`);
   };
 
   const server = createWorkerRepositoryServer({
@@ -157,11 +155,13 @@ test('TTS route falls back to Gemini when OpenAI exceeds the primary timeout', a
     },
   });
   try {
-    const response = await server.fetch('https://repo.test/api/tts', ttsRequest());
+    const response = await server.fetch('https://repo.test/api/tts', ttsRequest({ provider: 'openai' }));
+    const payload = await response.json();
 
-    assert.equal(response.status, 200);
-    assert.equal(response.headers.get('x-ks2-tts-provider'), 'gemini');
-    assert.equal(response.headers.get('x-ks2-tts-fallback-from'), 'openai');
+    assert.equal(response.status, 503);
+    assert.equal(payload.code, 'tts_provider_error');
+    assert.equal(payload.provider, 'openai');
+    assert.equal(payload.providerTimedOut, true);
     assert.equal(openAiAborted, true);
   } finally {
     globalThis.fetch = originalFetch;
@@ -200,7 +200,7 @@ test('TTS route supports word-only vocabulary audio', async () => {
   }
 });
 
-test('TTS route reports missing OpenAI configuration clearly', async () => {
+test('TTS route reports missing selected provider configuration clearly', async () => {
   const server = createWorkerRepositoryServer();
   try {
     const response = await server.fetch('https://repo.test/api/tts', ttsRequest());
@@ -208,6 +208,7 @@ test('TTS route reports missing OpenAI configuration clearly', async () => {
 
     assert.equal(response.status, 503);
     assert.equal(payload.code, 'tts_not_configured');
+    assert.equal(payload.provider, 'openai');
   } finally {
     server.close();
   }

--- a/worker/README.md
+++ b/worker/README.md
@@ -5,7 +5,7 @@ This Worker is now a real minimum viable backend for the generic repository cont
 Production browser sessions use the API-backed repository after sign-in.
 Direct file/local mode, or `?local=1`, still uses browser storage for development.
 English Spelling still runs through the same subject/service boundary.
-The Worker now provides durable D1-backed storage for the generic platform collections, account-scoped spelling content, session/auth flows, TTS proxying with OpenAI primary audio and Gemini fallback audio, learner ownership at the API boundary, and thin hub read-model routes for Parent Hub / Admin.
+The Worker now provides durable D1-backed storage for the generic platform collections, account-scoped spelling content, session/auth flows, selected-provider TTS proxying, learner ownership at the API boundary, and thin hub read-model routes for Parent Hub / Admin.
 
 ## What this Worker is now
 
@@ -16,7 +16,7 @@ It is:
 - an adult-account to learner ownership boundary
 - a place where learner-scoped permissions are enforced before repository writes happen
 - a provider-agnostic auth/session seam with production email and social login flows plus a safe development/test stub
-- a Worker-side TTS proxy that keeps provider API keys out of the browser and falls back to Gemini when OpenAI is slow or unavailable
+- a Worker-side TTS proxy that keeps provider API keys out of the browser and honours the selected OpenAI or Gemini provider without automatic fallback
 - a read-model boundary for role-aware Parent Hub and Admin / Operations surfaces
 - an admin-only account role management boundary for production platform roles
 - a deployment boundary that still keeps subject UI rules out of the backend

--- a/worker/src/tts.js
+++ b/worker/src/tts.js
@@ -16,6 +16,7 @@ const DEFAULT_GEMINI_MODEL = 'gemini-3.1-flash-tts-preview';
 const DEFAULT_GEMINI_VOICE = 'Kore';
 const DEFAULT_GEMINI_TIMEOUT_MS = 12000;
 const DEFAULT_GEMINI_SAMPLE_RATE = 24000;
+const REMOTE_TTS_PROVIDERS = new Set(['openai', 'gemini']);
 const MAX_WORD_LENGTH = 80;
 const MAX_SENTENCE_LENGTH = 320;
 
@@ -95,6 +96,15 @@ async function protectTts(env, request, session, now) {
   }
 }
 
+function normaliseRemoteTtsProvider(value) {
+  const provider = cleanText(value).toLowerCase() || 'openai';
+  if (REMOTE_TTS_PROVIDERS.has(provider)) return provider;
+  throw new BadRequestError('Unsupported dictation audio provider.', {
+    code: 'tts_provider_unsupported',
+    provider,
+  });
+}
+
 function normaliseTtsPayload(body) {
   const word = cleanText(typeof body?.word === 'string' ? body.word : body?.word?.word);
   const sentence = cleanText(body?.sentence);
@@ -114,6 +124,7 @@ function normaliseTtsPayload(body) {
 
   return {
     transcript,
+    provider: normaliseRemoteTtsProvider(body?.provider),
     slow: Boolean(body?.slow),
     wordOnly,
   };
@@ -210,6 +221,14 @@ function backendUnavailableFromFailure(error, failures = []) {
   if (error?.timedOut) extra.providerTimedOut = true;
   if (attempts.length > 1) extra.providerAttempts = attempts;
   return new BackendUnavailableError(error?.message || 'TTS provider request failed.', extra);
+}
+
+function missingProviderConfig(provider) {
+  const name = provider === 'gemini' ? 'Gemini' : 'OpenAI';
+  return new BackendUnavailableError(`${name} TTS is not configured.`, {
+    code: 'tts_not_configured',
+    provider,
+  });
 }
 
 function geminiPrompt({ transcript, slow = false, wordOnly = false }) {
@@ -398,31 +417,23 @@ export async function handleTextToSpeechRequest({
 } = {}) {
   const openAi = openAiConfig(env);
   const gemini = geminiConfig(env);
-  if (!openAi.apiKey && !gemini.apiKey) {
-    throw new BackendUnavailableError('OpenAI TTS is not configured.', { code: 'tts_not_configured' });
-  }
 
   await protectTts(env, request, session, now);
   const payload = normaliseTtsPayload(await readJson(request));
 
-  let openAiFailure = null;
-  if (openAi.apiKey) {
+  if (payload.provider === 'gemini') {
+    if (!gemini.apiKey) throw missingProviderConfig('gemini');
     try {
-      return await requestOpenAiSpeech({ config: openAi, payload, fetchFn });
+      return await requestGeminiSpeech({ config: gemini, payload, fetchFn });
     } catch (error) {
-      openAiFailure = error;
+      throw backendUnavailableFromFailure(error, [error]);
     }
   }
 
-  if (gemini.apiKey) {
-    try {
-      const response = await requestGeminiSpeech({ config: gemini, payload, fetchFn });
-      if (openAiFailure) response.headers.set('x-ks2-tts-fallback-from', 'openai');
-      return response;
-    } catch (geminiFailure) {
-      throw backendUnavailableFromFailure(geminiFailure, [openAiFailure, geminiFailure]);
-    }
+  if (!openAi.apiKey) throw missingProviderConfig('openai');
+  try {
+    return await requestOpenAiSpeech({ config: openAi, payload, fetchFn });
+  } catch (error) {
+    throw backendUnavailableFromFailure(error, [error]);
   }
-
-  throw backendUnavailableFromFailure(openAiFailure, [openAiFailure]);
 }


### PR DESCRIPTION
## Summary
- add a Profile Settings dictation voice switch for OpenAI, Gemini, and local browser speech
- route browser and Worker TTS through the selected provider without automatic fallback
- show an audio-row loading spinner that turns red after long waits

## Verification
- npm test
- npm run check