### PR TITLE
Add profile TTS test control

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -197,6 +197,14 @@ let currentPlayingKind = null;
 let currentLoadingKind = null;
 let audioLoadingStartedAt = 0;
 let audioLoadingTimer = null;
+let profileTtsTestState = {
+  status: 'idle',
+  provider: DEFAULT_TTS_PROVIDER,
+  startedAt: 0,
+  token: 0,
+};
+let profileTtsTestTimer = null;
+let profileTtsTestResetTimer = null;
 
 const NORMAL_REPLAY_SELECTORS = [
   '[data-action="spelling-replay"]',
@@ -244,8 +252,94 @@ function armAudioLoadingTimer() {
   }, 10000);
 }
 
+function clearProfileTtsTestTimers() {
+  if (profileTtsTestTimer) {
+    clearInterval(profileTtsTestTimer);
+    profileTtsTestTimer = null;
+  }
+  if (profileTtsTestResetTimer) {
+    clearTimeout(profileTtsTestResetTimer);
+    profileTtsTestResetTimer = null;
+  }
+}
+
+function syncProfileTtsTestButton() {
+  const buttons = root.querySelectorAll('[data-action="tts-test"]');
+  const status = profileTtsTestState.status;
+  const active = status === 'loading' || status === 'playing';
+  const elapsedMs = profileTtsTestState.startedAt ? Date.now() - profileTtsTestState.startedAt : 0;
+  const waitingLong = status === 'loading' && elapsedMs >= 10000;
+  const label = status === 'loading'
+    ? `${Math.max(0, Math.floor(elapsedMs / 1000))}s`
+    : status === 'playing'
+      ? 'Playing'
+      : status === 'done'
+        ? 'Done'
+        : status === 'failed'
+          ? 'Failed'
+          : 'Test';
+
+  for (const button of buttons) {
+    button.classList.toggle('loading', status === 'loading');
+    button.classList.toggle('waiting-long', waitingLong);
+    button.classList.toggle('playing', status === 'playing');
+    button.classList.toggle('done', status === 'done');
+    button.classList.toggle('failed', status === 'failed');
+    button.toggleAttribute('aria-busy', active);
+    button.disabled = active;
+    const labelNode = button.querySelector('.profile-tts-test-label');
+    if (labelNode) labelNode.textContent = label;
+  }
+}
+
+function resetProfileTtsTestButton(token) {
+  if (token !== profileTtsTestState.token) return;
+  clearProfileTtsTestTimers();
+  profileTtsTestState = {
+    ...profileTtsTestState,
+    status: 'idle',
+    startedAt: 0,
+  };
+  syncProfileTtsTestButton();
+}
+
+function setProfileTtsTestStatus(status, token = profileTtsTestState.token) {
+  if (token !== profileTtsTestState.token) return;
+  if (status !== 'loading' && profileTtsTestTimer) {
+    clearInterval(profileTtsTestTimer);
+    profileTtsTestTimer = null;
+  }
+  profileTtsTestState = {
+    ...profileTtsTestState,
+    status,
+  };
+  syncProfileTtsTestButton();
+}
+
+function beginProfileTtsTest(provider) {
+  clearProfileTtsTestTimers();
+  const token = profileTtsTestState.token + 1;
+  profileTtsTestState = {
+    status: 'loading',
+    provider,
+    startedAt: Date.now(),
+    token,
+  };
+  profileTtsTestTimer = setInterval(syncProfileTtsTestButton, 250);
+  syncProfileTtsTestButton();
+  return token;
+}
+
+function finishProfileTtsTest(token, ok) {
+  if (token !== profileTtsTestState.token) return;
+  setProfileTtsTestStatus(ok ? 'done' : 'failed', token);
+  profileTtsTestResetTimer = setTimeout(() => resetProfileTtsTestButton(token), 1600);
+}
+
 tts.subscribe((event) => {
-  if (event?.type === 'loading') {
+  if (event?.kind === 'test') {
+    if (event?.type === 'start') setProfileTtsTestStatus('playing');
+  } else if (event?.type === 'loading') {
     currentLoadingKind = event.kind === 'slow' ? 'slow' : 'normal';
     currentPlayingKind = null;
     audioLoadingStartedAt = Date.now();
@@ -1172,6 +1266,7 @@ function afterReactRender(appState) {
   queueMicrotask(() => applyHeroDarkProbes());
 
   syncAudioPlayingClass();
+  syncProfileTtsTestButton();
 }
 
 function applyHeroDarkProbes() {
@@ -1379,6 +1474,20 @@ function handleGlobalAction(action, data) {
       dailyMinutes: data.dailyMinutes || current?.dailyMinutes || 15,
       avatarColor: data.avatarColor || current?.avatarColor || '#3E6FA8',
     });
+    return true;
+  }
+
+  if (action === 'tts-test') {
+    const provider = normaliseTtsProvider(data.provider, selectedTtsProvider());
+    const token = beginProfileTtsTest(provider);
+    Promise.resolve(tts.speak({
+      word: 'early',
+      sentence: 'The birds sang early in the day.',
+      provider,
+      kind: 'test',
+    }))
+      .then((ok) => finishProfileTtsTest(token, Boolean(ok)))
+      .catch(() => finishProfileTtsTest(token, false));
     return true;
   }
 

--- a/src/platform/app/create-app-controller.js
+++ b/src/platform/app/create-app-controller.js
@@ -292,6 +292,16 @@ export function createAppController({
       return true;
     }
 
+    if (action === 'tts-test') {
+      tts.speak({
+        word: 'early',
+        sentence: 'The birds sang early in the day.',
+        provider: normaliseTtsProvider(data.provider),
+        kind: 'test',
+      });
+      return true;
+    }
+
     if (action === 'learner-save-form') {
       const formData = data.formData;
       services.spelling?.savePrefs?.(learnerId, {

--- a/src/platform/ui/render.js
+++ b/src/platform/ui/render.js
@@ -752,8 +752,13 @@ function renderLearnerManager(appState, context) {
           </label>
           <div class="profile-form-field profile-form-field-wide">
             <span>Dictation voice</span>
-            <div class="profile-tts-options" role="radiogroup" aria-label="Dictation voice">
-              ${renderTtsProviderOptions(ttsProvider)}
+            <div class="profile-tts-control">
+              <div class="profile-tts-options" role="radiogroup" aria-label="Dictation voice">
+                ${renderTtsProviderOptions(ttsProvider)}
+              </div>
+              <button class="btn secondary profile-tts-test-btn" type="button" data-action="tts-test">
+                <span class="profile-tts-test-label">Test</span>
+              </button>
             </div>
           </div>
         </div>

--- a/src/subjects/spelling/tts.js
+++ b/src/subjects/spelling/tts.js
@@ -61,6 +61,11 @@ function chooseBrowserVoice(speechSynthesis) {
     .sort((a, b) => browserVoiceScore(b) - browserVoiceScore(a))[0] || null;
 }
 
+function playbackKind({ kind = '', slow = false } = {}) {
+  const explicit = String(kind || '').trim();
+  return explicit || (slow ? 'slow' : 'normal');
+}
+
 export function createPlatformTts({
   fetchFn = globalThis.fetch?.bind(globalThis),
   endpoint = '/api/tts',
@@ -124,7 +129,7 @@ export function createPlatformTts({
     emit({ type: 'end' });
   }
 
-  function speakWithBrowser({ word, sentence, slow = false, wordOnly = false } = {}) {
+  function speakWithBrowser({ word, sentence, slow = false, wordOnly = false, kind = '' } = {}) {
     if (!available()) return Promise.resolve(false);
     stopBrowserSpeech();
     const transcript = buildSpeechTranscript({ word, sentence, wordOnly });
@@ -143,18 +148,19 @@ export function createPlatformTts({
         emit({ type: 'end' });
         resolve(false);
       };
-      emit({ type: 'start', kind: slow ? 'slow' : 'normal' });
+      emit({ type: 'start', kind: playbackKind({ kind, slow }) });
       window.speechSynthesis.speak(utterance);
     });
   }
 
-  async function speakWithRemote({ word, sentence, slow = false, wordOnly = false }, providerId, token) {
+  async function speakWithRemote({ word, sentence, slow = false, wordOnly = false, kind = '' }, providerId, token) {
     if (!remoteEnabled || typeof fetchFn !== 'function' || typeof Audio === 'undefined' || typeof URL === 'undefined') {
       return false;
     }
 
     currentAbort = new AbortController();
-    emit({ type: 'loading', kind: slow ? 'slow' : 'normal', provider: providerId });
+    const kindId = playbackKind({ kind, slow });
+    emit({ type: 'loading', kind: kindId, provider: providerId });
     try {
       const requestBody = { word, sentence, slow, provider: providerId };
       if (wordOnly) requestBody.wordOnly = true;
@@ -194,7 +200,7 @@ export function createPlatformTts({
           cleanupAudio();
           resolvePending(false);
         };
-        emit({ type: 'start', kind: slow ? 'slow' : 'normal' });
+        emit({ type: 'start', kind: kindId });
         currentAudio.play().catch(() => {
           emit({ type: 'end' });
           cleanupAudio();
@@ -212,7 +218,7 @@ export function createPlatformTts({
   async function speak(payload = {}) {
     stop();
     const token = playbackId;
-    const providerId = resolveProvider(provider);
+    const providerId = resolveProvider(payload.provider || provider);
     if (providerId === 'browser') return speakWithBrowser(payload);
     return await speakWithRemote(payload, providerId, token);
   }

--- a/src/surfaces/profile/ProfileSettingsSurface.jsx
+++ b/src/surfaces/profile/ProfileSettingsSurface.jsx
@@ -109,6 +109,13 @@ export function ProfileSettingsSurface({ appState, chrome, actions, subjectCount
     event.preventDefault();
     actions.dispatch('learner-save-form', { formData: new FormData(event.currentTarget) });
   };
+  const testVoice = (event) => {
+    const form = event.currentTarget.form;
+    const formData = form ? new FormData(form) : null;
+    actions.dispatch('tts-test', {
+      provider: normaliseTtsProvider(formData?.get('ttsProvider'), ttsProvider),
+    });
+  };
 
   return (
     <div className="app-shell profile-settings-shell">
@@ -200,18 +207,28 @@ export function ProfileSettingsSurface({ appState, chrome, actions, subjectCount
               </label>
               <div className="profile-form-field profile-form-field-wide">
                 <span>Dictation voice</span>
-                <div className="profile-tts-options" role="radiogroup" aria-label="Dictation voice">
-                  {TTS_PROVIDER_OPTIONS.map((option) => (
-                    <label className="profile-tts-option" key={option.value} title={option.title || option.label}>
-                      <input
-                        type="radio"
-                        name="ttsProvider"
-                        value={option.value}
-                        defaultChecked={ttsProvider === option.value}
-                      />
-                      <span>{option.label}</span>
-                    </label>
-                  ))}
+                <div className="profile-tts-control">
+                  <div className="profile-tts-options" role="radiogroup" aria-label="Dictation voice">
+                    {TTS_PROVIDER_OPTIONS.map((option) => (
+                      <label className="profile-tts-option" key={option.value} title={option.title || option.label}>
+                        <input
+                          type="radio"
+                          name="ttsProvider"
+                          value={option.value}
+                          defaultChecked={ttsProvider === option.value}
+                        />
+                        <span>{option.label}</span>
+                      </label>
+                    ))}
+                  </div>
+                  <button
+                    className="btn secondary profile-tts-test-btn"
+                    type="button"
+                    data-action="tts-test"
+                    onClick={testVoice}
+                  >
+                    <span className="profile-tts-test-label">Test</span>
+                  </button>
                 </div>
               </div>
             </div>

--- a/styles/app.css
+++ b/styles/app.css
@@ -2289,6 +2289,13 @@ textarea:focus-visible {
   padding: 7px;
 }
 
+.profile-tts-control {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: stretch;
+}
+
 .profile-tts-options {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -2336,6 +2343,38 @@ textarea:focus-visible {
   box-shadow:
     0 0 0 3px color-mix(in oklab, var(--profile-accent, var(--brand)) 18%, transparent),
     inset 0 0 0 1px color-mix(in oklab, var(--profile-accent, var(--brand)) 34%, transparent);
+}
+
+.profile-tts-test-btn {
+  min-width: 78px;
+  min-height: 44px;
+  align-self: stretch;
+  position: relative;
+  transition:
+    border-color var(--dur) var(--ease-out),
+    color 4s var(--ease-in-out),
+    background var(--dur) var(--ease-out);
+}
+
+.profile-tts-test-btn.loading {
+  color: var(--brand);
+  border-color: color-mix(in oklab, var(--brand) 42%, var(--line));
+}
+
+.profile-tts-test-btn.loading.waiting-long {
+  color: var(--bad);
+  border-color: color-mix(in oklab, var(--bad) 58%, var(--line));
+}
+
+.profile-tts-test-btn.playing,
+.profile-tts-test-btn.done {
+  color: var(--good-strong);
+  border-color: color-mix(in oklab, var(--good) 45%, var(--line));
+}
+
+.profile-tts-test-btn.failed {
+  color: var(--bad-strong);
+  border-color: color-mix(in oklab, var(--bad) 58%, var(--line));
 }
 
 .profile-form-footer {
@@ -3507,6 +3546,9 @@ textarea:focus-visible {
 @media (max-width: 980px) {
   .profile-hero,
   .profile-layout {
+    grid-template-columns: 1fr;
+  }
+  .profile-tts-control {
     grid-template-columns: 1fr;
   }
   .profile-identity {

--- a/tests/app-controller.test.js
+++ b/tests/app-controller.test.js
@@ -177,6 +177,20 @@ test('controller persists profile TTS provider in spelling prefs', () => {
   assert.equal(controller.services.spelling.getPrefs(learnerId).ttsProvider, 'gemini');
 });
 
+test('controller dispatches profile TTS test through the selected provider', () => {
+  installMemoryStorage();
+  const controller = createAppController();
+
+  controller.dispatch('tts-test', { provider: 'browser' });
+
+  assert.deepEqual(controller.tts.spoken.at(-1), {
+    word: 'early',
+    sentence: 'The birds sang early in the day.',
+    provider: 'browser',
+    kind: 'test',
+  });
+});
+
 test('controller dispatches spelling transitions through store, repositories, events, and TTS', () => {
   installMemoryStorage();
   const controller = createAppController();

--- a/tests/react-shared-surfaces.test.js
+++ b/tests/react-shared-surfaces.test.js
@@ -9,6 +9,7 @@ test('React profile settings surface owns learner profile and data actions', asy
   assert.match(html, /Profile settings/);
   assert.match(html, /Learning profile for/);
   assert.match(html, /Dictation voice/);
+  assert.match(html, /profile-tts-test-btn/);
   assert.match(html, /Portable snapshots/);
   assert.match(html, /Save learner profile/);
   assert.doesNotMatch(html, /data-action="learner-save-form"/);

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -79,6 +79,7 @@ test('profile settings learner profile fields declare autofill behaviour explici
   assert.match(html, /<input class="input" type="number"[^>]*name="dailyMinutes"[^>]*autocomplete="off"/);
   assert.match(html, /name="ttsProvider" value="openai"/);
   assert.match(html, /name="ttsProvider" value="browser"/);
+  assert.match(html, /data-action="tts-test"/);
 });
 
 test('codex route mounts the React codex surface', () => {

--- a/tests/spelling-tts.test.js
+++ b/tests/spelling-tts.test.js
@@ -110,6 +110,72 @@ test('platform TTS sends the selected Worker provider', async () => {
   }
 });
 
+test('platform TTS allows a one-off provider override for profile tests', async () => {
+  const originalAudio = globalThis.Audio;
+  const originalCreateObjectUrl = URL.createObjectURL;
+  const originalRevokeObjectUrl = URL.revokeObjectURL;
+  const events = [];
+
+  globalThis.Audio = class MockAudio {
+    constructor(src) {
+      this.src = src;
+      this.onended = null;
+      this.onerror = null;
+    }
+
+    play() {
+      setTimeout(() => this.onended?.(), 0);
+      return Promise.resolve();
+    }
+
+    pause() {}
+    removeAttribute() {}
+    load() {}
+  };
+  URL.createObjectURL = () => 'blob:tts-test-audio';
+  URL.revokeObjectURL = () => {};
+
+  const calls = [];
+  const tts = createPlatformTts({
+    remoteEnabled: true,
+    provider: 'gemini',
+    fetchFn: async (url, init = {}) => {
+      calls.push({
+        url,
+        body: JSON.parse(init.body),
+      });
+      return new Response(new Blob([new Uint8Array([1, 2, 3])], { type: 'audio/mpeg' }), {
+        status: 200,
+        headers: { 'content-type': 'audio/mpeg' },
+      });
+    },
+  });
+  tts.subscribe((event) => events.push(event));
+
+  try {
+    const result = await tts.speak({
+      word: 'early',
+      sentence: 'The birds sang early in the day.',
+      provider: 'openai',
+      kind: 'test',
+    });
+
+    assert.equal(result, true);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].body.provider, 'openai');
+    assert.deepEqual(
+      events.filter((event) => event.kind === 'test').map((event) => event.type),
+      ['loading', 'start'],
+    );
+    assert.equal(events.at(-1).type, 'end');
+  } finally {
+    tts.stop();
+    globalThis.Audio = originalAudio;
+    URL.createObjectURL = originalCreateObjectUrl;
+    URL.revokeObjectURL = originalRevokeObjectUrl;
+  }
+});
+
 test('platform TTS does not fall back when the selected remote provider fails', async () => {
   const originalWindow = globalThis.window;
   const originalAudio = globalThis.Audio;


### PR DESCRIPTION
## Summary
- add a minimal Test button beside the profile TTS provider selector
- show an inline loading timer, then playing/done/failed states without saving the profile first
- allow profile tests to use a one-off provider override for OpenAI, Gemini, or browser voice

## Verification
- npm test
- npm run check