### PR TITLE
fix(spelling): retry stale subject commands

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -385,6 +385,9 @@ const subjectCommands = createSubjectCommandClient({
   baseUrl: '',
   fetch: credentialFetch,
   getLearnerRevision: (learnerId) => repositories.runtime?.readLearnerRevision?.(learnerId) || 0,
+  onStaleWrite: async () => {
+    await repositories.hydrate({ cacheScope: 'subject-command-stale-write' });
+  },
   onCommandApplied: ({ learnerId, subjectId, response }) => {
     repositories.runtime?.applySubjectCommandResult?.({ learnerId, subjectId, response });
   },

--- a/src/platform/runtime/subject-command-client.js
+++ b/src/platform/runtime/subject-command-client.js
@@ -10,6 +10,12 @@ async function parseJson(response) {
   return response.json().catch(() => ({}));
 }
 
+function isStaleWriteConflict(error) {
+  return error instanceof SubjectCommandClientError
+    && error.status === 409
+    && error.code === 'stale_write';
+}
+
 export class SubjectCommandClientError extends Error {
   constructor({ status = 0, payload = null, message = '' } = {}) {
     super(message || payload?.message || `Subject command failed (${status}).`);
@@ -17,7 +23,7 @@ export class SubjectCommandClientError extends Error {
     this.status = Number(status) || 0;
     this.payload = payload;
     this.code = payload?.code || null;
-    this.retryable = status >= 500 || status === 0;
+    this.retryable = status >= 500 || status === 0 || (status === 409 && this.code === 'stale_write');
   }
 }
 
@@ -26,23 +32,13 @@ export function createSubjectCommandClient({
   fetch: fetchFn = (input, init) => globalThis.fetch(input, init),
   getLearnerRevision = () => 0,
   onCommandApplied = () => {},
+  onStaleWrite = null,
 } = {}) {
   if (typeof fetchFn !== 'function') {
     throw new TypeError('Subject command client requires a fetch implementation.');
   }
 
-  async function send({ subjectId, learnerId, command, payload = {}, requestId = uid('subject-command') } = {}) {
-    const cleanSubjectId = String(subjectId || '').trim();
-    const cleanLearnerId = String(learnerId || '').trim();
-    const cleanCommand = String(command || '').trim();
-    if (!cleanSubjectId || !cleanLearnerId || !cleanCommand) {
-      throw new SubjectCommandClientError({
-        status: 400,
-        payload: { code: 'subject_command_client_invalid' },
-        message: 'Subject command requires subject, learner, and command identifiers.',
-      });
-    }
-
+  async function sendOnce({ cleanSubjectId, cleanLearnerId, cleanCommand, payload, requestId }) {
     const expectedLearnerRevision = Number(getLearnerRevision(cleanLearnerId)) || 0;
     let response;
     try {
@@ -77,6 +73,52 @@ export function createSubjectCommandClient({
       throw new SubjectCommandClientError({
         status: response.status,
         payload: responsePayload,
+      });
+    }
+
+    return responsePayload;
+  }
+
+  async function send({ subjectId, learnerId, command, payload = {}, requestId = uid('subject-command') } = {}) {
+    const cleanSubjectId = String(subjectId || '').trim();
+    const cleanLearnerId = String(learnerId || '').trim();
+    const cleanCommand = String(command || '').trim();
+    if (!cleanSubjectId || !cleanLearnerId || !cleanCommand) {
+      throw new SubjectCommandClientError({
+        status: 400,
+        payload: { code: 'subject_command_client_invalid' },
+        message: 'Subject command requires subject, learner, and command identifiers.',
+      });
+    }
+
+    let responsePayload;
+    try {
+      responsePayload = await sendOnce({
+        cleanSubjectId,
+        cleanLearnerId,
+        cleanCommand,
+        payload,
+        requestId,
+      });
+    } catch (error) {
+      if (!isStaleWriteConflict(error) || typeof onStaleWrite !== 'function') {
+        throw error;
+      }
+
+      await onStaleWrite({
+        error,
+        learnerId: cleanLearnerId,
+        subjectId: cleanSubjectId,
+        command: cleanCommand,
+        payload,
+        requestId,
+      });
+      responsePayload = await sendOnce({
+        cleanSubjectId,
+        cleanLearnerId,
+        cleanCommand,
+        payload,
+        requestId,
       });
     }
 

--- a/tests/persistence.test.js
+++ b/tests/persistence.test.js
@@ -381,3 +381,118 @@ test('subject command responses update the api cache without queuing broad runti
   assert.equal(repositories.eventLog.list('learner-a').length, 1);
   assert.equal(server.requests.some((request) => request.path === '/api/child-subject-state'), false);
 });
+
+test('subject commands rehydrate and retry once after a stale learner revision', async () => {
+  const storage = installMemoryStorage();
+  const server = createMockRepositoryServer({
+    learners: learnerSnapshot(),
+    subjectStates: {
+      'learner-a::spelling': {
+        ui: { phase: 'dashboard' },
+        data: {},
+        updatedAt: 1,
+      },
+    },
+  });
+  const commandBodies = [];
+  let bootstrapCount = 0;
+  const fetch = async (input, init = {}) => {
+    const url = new URL(typeof input === 'string' ? input : input.url, 'https://repo.test');
+    const method = String(init.method || 'GET').toUpperCase();
+    if (url.pathname === '/api/bootstrap' && method === 'GET') {
+      bootstrapCount += 1;
+      const remote = await server.fetch(input, init);
+      const payload = await remote.json();
+      return new Response(JSON.stringify({
+        ...payload,
+        syncState: {
+          policyVersion: 1,
+          accountRevision: 0,
+          learnerRevisions: {
+            'learner-a': bootstrapCount === 1 ? 0 : 1,
+          },
+        },
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    }
+    if (url.pathname === '/api/subjects/spelling/command' && method === 'POST') {
+      const body = JSON.parse(init.body);
+      commandBodies.push(body);
+      if (commandBodies.length === 1) {
+        return new Response(JSON.stringify({
+          ok: false,
+          code: 'stale_write',
+          message: 'Mutation rejected because this state changed in another tab or device.',
+          mutation: {
+            expectedRevision: body.expectedLearnerRevision,
+            currentRevision: 1,
+          },
+        }), { status: 409, headers: { 'content-type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({
+        ok: true,
+        subjectReadModel: {
+          subjectId: 'spelling',
+          learnerId: body.learnerId,
+          version: 1,
+          phase: 'session',
+          session: {
+            id: 'server-session',
+            type: 'learning',
+            mode: 'smart',
+            phase: 'question',
+            progress: { done: 0, total: 1 },
+            currentCard: { prompt: { cloze: 'A ________ prompt.' } },
+            serverAuthority: 'worker',
+          },
+          prefs: { mode: 'smart', yearFilter: 'core', roundLength: '1', showCloze: true, autoSpeak: true },
+          stats: {},
+          analytics: { pools: {}, wordGroups: [] },
+        },
+        projections: {
+          rewards: {
+            systemId: 'monster-codex',
+            state: { caught: ['spark'] },
+            events: [],
+            toastEvents: [],
+          },
+        },
+        mutation: {
+          appliedRevision: 2,
+        },
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    }
+    return server.fetch(input, init);
+  };
+  const repositories = createApiPlatformRepositories({
+    baseUrl: 'https://repo.test',
+    fetch,
+    storage,
+  });
+  await repositories.hydrate();
+
+  const commands = createSubjectCommandClient({
+    baseUrl: 'https://repo.test',
+    fetch,
+    getLearnerRevision: (learnerId) => repositories.runtime.readLearnerRevision(learnerId),
+    onStaleWrite: async () => {
+      await repositories.hydrate({ cacheScope: 'subject-command-stale-write' });
+    },
+    onCommandApplied: ({ learnerId, subjectId, response }) => {
+      repositories.runtime.applySubjectCommandResult({ learnerId, subjectId, response });
+    },
+  });
+
+  await commands.send({
+    subjectId: 'spelling',
+    learnerId: 'learner-a',
+    command: 'start-session',
+    payload: { mode: 'smart', length: 1 },
+    requestId: 'cmd-client-stale',
+  });
+
+  assert.equal(bootstrapCount, 2);
+  assert.deepEqual(commandBodies.map((body) => body.expectedLearnerRevision), [0, 1]);
+  assert.equal(commandBodies[0].requestId, commandBodies[1].requestId);
+  assert.equal(repositories.runtime.readLearnerRevision('learner-a'), 2);
+  assert.equal(repositories.subjectStates.read('learner-a', 'spelling').ui.phase, 'session');
+});


### PR DESCRIPTION
## Summary
- rehydrate the latest repository/bootstrap state when a subject command receives a stale learner revision conflict
- retry the same subject command once with the refreshed learner revision
- add regression coverage for stale subject-command retry semantics

## Verification
- git diff --check
- npm test -- tests/persistence.test.js
- npm test
- npm run check