### PR TITLE
fix(codex): restore monster projections under lockdown

### DIFF
--- a/src/platform/game/monster-system.js
+++ b/src/platform/game/monster-system.js
@@ -47,6 +47,23 @@ function masteredCount(entry) {
   return Number.isFinite(count) && count > 0 ? Math.floor(count) : 0;
 }
 
+function hasMasteryProgress(entry) {
+  return masteredCount(entry) > 0 || entry?.caught === true;
+}
+
+function hasMonsterMasteryProgress(state) {
+  if (!isPlainObject(state)) return false;
+  return SPELLING_MONSTER_IDS.some((monsterId) => hasMasteryProgress(state[monsterId]));
+}
+
+function analyticsHasWordRows(analytics) {
+  const groups = Array.isArray(analytics?.wordGroups) ? analytics.wordGroups : [];
+  return groups.some((group) => {
+    const words = Array.isArray(group?.words) ? group.words : [];
+    return words.some((word) => typeof word?.slug === 'string' && word.slug);
+  });
+}
+
 function pickMonsterBranch(random = Math.random) {
   const raw = typeof random === 'function' ? Number(random()) : Math.random();
   const index = Math.max(0, Math.min(MONSTER_BRANCHES.length - 1, Math.floor((Number.isFinite(raw) ? raw : 0) * MONSTER_BRANCHES.length)));
@@ -231,6 +248,10 @@ export function recordMonsterMastery(learnerId, monsterId, wordSlug, gameStateRe
 
 export function monsterSummary(learnerId, gameStateRepository) {
   const state = ensureMonsterBranches(learnerId, gameStateRepository);
+  return monsterSummaryFromState(state);
+}
+
+export function monsterSummaryFromState(state = {}) {
   return SPELLING_MONSTER_IDS.map((monsterId) => ({
     monster: MONSTERS[monsterId],
     progress: progressForMonster(state, monsterId),
@@ -249,9 +270,11 @@ export function monsterSummaryFromSpellingAnalytics(analytics, {
       ? ensureMonsterBranches(learnerId, gameStateRepository, { random })
       : loadMonsterState(learnerId, gameStateRepository);
   }
+
+  if (!analyticsHasWordRows(analytics) && hasMonsterMasteryProgress(branchState)) {
+    return monsterSummaryFromState(branchState);
+  }
+
   const state = secureWordsFromAnalytics(analytics, branchState);
-  return SPELLING_MONSTER_IDS.map((monsterId) => ({
-    monster: MONSTERS[monsterId],
-    progress: progressForMonster(state, monsterId),
-  }));
+  return monsterSummaryFromState(state);
 }

--- a/tests/monster-system.test.js
+++ b/tests/monster-system.test.js
@@ -256,3 +256,30 @@ test('analytics summaries can project branches without writing during render', (
   assert.equal(summary.find((entry) => entry.monster.id === 'inklet').progress.mastered, 1);
   assert.equal(summary.find((entry) => entry.monster.id === 'vellhorn').progress.mastered, 0);
 });
+
+test('redacted analytics uses public monster projection state without writing during render', () => {
+  const repository = makeGameStateRepository({
+    inklet: { masteredCount: 12, caught: true, branch: 'b1' },
+    glimmerbug: { masteredCount: 4, caught: true, branch: 'b2' },
+    phaeton: { masteredCount: 16, caught: true, branch: 'b1' },
+    vellhorn: { masteredCount: 1, caught: true, branch: 'b2' },
+  });
+  const analytics = {
+    wordGroups: [],
+    wordBank: { source: 'server-read-model-api' },
+  };
+
+  const summary = monsterSummaryFromSpellingAnalytics(analytics, {
+    learnerId: 'learner-a',
+    gameStateRepository: repository,
+    persistBranches: false,
+  });
+
+  assert.equal(repository.writes(), 0);
+  assert.equal(summary.find((entry) => entry.monster.id === 'inklet').progress.mastered, 12);
+  assert.equal(summary.find((entry) => entry.monster.id === 'inklet').progress.stage, 1);
+  assert.equal(summary.find((entry) => entry.monster.id === 'glimmerbug').progress.mastered, 4);
+  assert.equal(summary.find((entry) => entry.monster.id === 'phaeton').progress.mastered, 16);
+  assert.equal(summary.find((entry) => entry.monster.id === 'phaeton').progress.caught, true);
+  assert.equal(summary.find((entry) => entry.monster.id === 'vellhorn').progress.branch, 'b2');
+});

--- a/tests/worker-auth.test.js
+++ b/tests/worker-auth.test.js
@@ -534,6 +534,58 @@ test('production public bootstrap redacts spelling sentinels from subject state,
   server.close();
 });
 
+test('production public bootstrap keeps Codex mastery visible from redacted spelling progress', async () => {
+  const server = productionServer();
+  const register = await postJson(server, '/api/auth/register', {
+    email: 'bootstrap-codex@example.test',
+    password: 'password-1234',
+  });
+  const registerPayload = await register.json();
+  const cookie = cookieFrom(register);
+  const accountId = registerPayload.session.accountId;
+  const now = Date.UTC(2026, 0, 1);
+
+  server.DB.db.prepare(`
+    INSERT INTO learner_profiles (id, name, year_group, avatar_color, goal, daily_minutes, created_at, updated_at, state_revision)
+    VALUES ('learner-codex', 'Ava', 'Y5', '#3E6FA8', 'sats', 15, ?, ?, 0)
+  `).run(now, now);
+  server.DB.db.prepare(`
+    INSERT INTO account_learner_memberships (account_id, learner_id, role, sort_index, created_at, updated_at)
+    VALUES (?, 'learner-codex', 'owner', 0, ?, ?)
+  `).run(accountId, now, now);
+  server.DB.db.prepare('UPDATE adult_accounts SET selected_learner_id = ? WHERE id = ?')
+    .run('learner-codex', accountId);
+  server.DB.db.prepare(`
+    INSERT INTO child_subject_state (learner_id, subject_id, ui_json, data_json, updated_at, updated_by_account_id)
+    VALUES ('learner-codex', 'spelling', ?, ?, ?, ?)
+  `).run(JSON.stringify({ phase: 'dashboard' }), JSON.stringify({
+    progress: {
+      possess: { stage: 4 },
+      accommodate: { stage: 4 },
+      necessary: { stage: 4 },
+      mollusc: { stage: 4 },
+    },
+  }), now, accountId);
+
+  const response = await server.fetchRaw('https://repo.test/api/bootstrap', {
+    headers: { cookie },
+  });
+  const payload = await response.json();
+  const publicSpelling = payload.subjectStates['learner-codex::spelling'];
+  const publicGameState = payload.gameState['learner-codex::monster-codex'];
+
+  assert.equal(response.status, 200, JSON.stringify(payload));
+  assert.equal(publicSpelling.data.progress, undefined);
+  assert.equal(publicGameState.inklet.mastered, undefined);
+  assert.equal(publicGameState.inklet.masteredCount, 1);
+  assert.equal(publicGameState.glimmerbug.masteredCount, 2);
+  assert.equal(publicGameState.phaeton.masteredCount, 3);
+  assert.equal(publicGameState.phaeton.caught, true);
+  assert.equal(publicGameState.vellhorn.masteredCount, 1);
+
+  server.close();
+});
+
 test('social sign-in start is explicit when a provider is not configured', async () => {
   const server = productionServer();
 

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -30,6 +30,7 @@ import {
 } from '../../src/platform/access/roles.js';
 import { buildAdminHubReadModel } from '../../src/platform/hubs/admin-read-model.js';
 import { buildParentHubReadModel } from '../../src/platform/hubs/parent-read-model.js';
+import { monsterIdForSpellingWord } from '../../src/platform/game/monster-system.js';
 import { buildSpellingWordBankReadModel } from './content/spelling-read-models.js';
 import {
   BadRequestError,
@@ -71,7 +72,9 @@ const PUBLIC_EVENT_TYPES = new Set([
 ]);
 const PUBLIC_MONSTER_CODEX_SYSTEM_ID = 'monster-codex';
 const PUBLIC_MONSTER_IDS = new Set(['inklet', 'glimmerbug', 'phaeton', 'vellhorn']);
+const PUBLIC_DIRECT_SPELLING_MONSTER_IDS = ['inklet', 'glimmerbug', 'vellhorn'];
 const PUBLIC_MONSTER_BRANCHES = new Set(['b1', 'b2']);
+const SPELLING_SECURE_STAGE = 4;
 const PUBLIC_EVENT_TEXT_ENUMS = {
   mode: new Set(['smart', 'trouble', 'single', 'test']),
   sessionType: new Set(['learning', 'test']),
@@ -248,6 +251,83 @@ function publicMonsterCodexState(rawState) {
 function publicGameStateRowToRecord(row) {
   if (row.system_id !== PUBLIC_MONSTER_CODEX_SYSTEM_ID) return null;
   return publicMonsterCodexState(gameStateRowToRecord(row));
+}
+
+function secureSpellingProgress(entry) {
+  const stage = Number(entry?.stage);
+  return Number.isFinite(stage) && stage >= SPELLING_SECURE_STAGE;
+}
+
+function spellingProgressFromSubjectRow(row) {
+  const data = safeJsonParse(row?.data_json, {});
+  return isPlainObject(data?.progress) ? data.progress : null;
+}
+
+function publicMonsterCodexStateFromSpellingProgress(progress, snapshot, existingState = {}) {
+  if (!isPlainObject(progress)) return null;
+  const counts = Object.fromEntries(PUBLIC_DIRECT_SPELLING_MONSTER_IDS.map((monsterId) => [monsterId, 0]));
+  const words = Array.isArray(snapshot?.words) ? snapshot.words : [];
+  let knownWordCount = 0;
+
+  for (const word of words) {
+    if (!word?.slug || !isPlainObject(progress[word.slug])) continue;
+    knownWordCount += 1;
+    if (!secureSpellingProgress(progress[word.slug])) continue;
+    const monsterId = monsterIdForSpellingWord(word);
+    if (monsterId in counts) counts[monsterId] += 1;
+  }
+
+  const nextState = {};
+  for (const monsterId of PUBLIC_DIRECT_SPELLING_MONSTER_IDS) {
+    const existing = isPlainObject(existingState?.[monsterId]) ? existingState[monsterId] : {};
+    nextState[monsterId] = {
+      masteredCount: counts[monsterId],
+      caught: counts[monsterId] > 0,
+      ...(PUBLIC_MONSTER_BRANCHES.has(existing.branch) ? { branch: existing.branch } : {}),
+    };
+  }
+
+  const phaetonCount = counts.inklet + counts.glimmerbug;
+  const existingPhaeton = isPlainObject(existingState?.phaeton) ? existingState.phaeton : {};
+  nextState.phaeton = {
+    masteredCount: phaetonCount,
+    caught: phaetonCount >= 3,
+    ...(PUBLIC_MONSTER_BRANCHES.has(existingPhaeton.branch) ? { branch: existingPhaeton.branch } : {}),
+  };
+
+  return {
+    state: publicMonsterCodexState(nextState),
+    knownWordCount,
+  };
+}
+
+function publicMonsterCodexHasMastery(state) {
+  if (!isPlainObject(state)) return false;
+  return Object.values(state).some((entry) => Number(entry?.masteredCount) > 0 || entry?.caught === true);
+}
+
+async function mergePublicSpellingCodexState(db, accountId, subjectRows, gameState) {
+  const spellingRows = subjectRows.filter((row) => row.subject_id === 'spelling');
+  if (!spellingRows.length) return gameState;
+
+  const content = await readSubjectContentBundle(db, accountId, 'spelling');
+  const snapshot = resolveRuntimeSnapshot(content, {
+    referenceBundle: SEEDED_SPELLING_CONTENT_BUNDLE,
+  });
+
+  for (const row of spellingRows) {
+    const progress = spellingProgressFromSubjectRow(row);
+    if (!progress) continue;
+    const key = gameStateKey(row.learner_id, PUBLIC_MONSTER_CODEX_SYSTEM_ID);
+    const existingState = publicMonsterCodexState(gameState[key] || {});
+    const derived = publicMonsterCodexStateFromSpellingProgress(progress, snapshot, existingState);
+    if (!derived) continue;
+    if (derived.knownWordCount > 0 || !publicMonsterCodexHasMastery(existingState)) {
+      gameState[key] = derived.state;
+    }
+  }
+
+  return gameState;
 }
 
 function practiceSessionRowToRecord(row) {
@@ -1170,6 +1250,9 @@ async function bootstrapBundle(db, accountId, { publicReadModels = false } = {})
       : gameStateRowToRecord(row);
     if (record) gameState[gameStateKey(row.learner_id, row.system_id)] = record;
   });
+  if (publicReadModels) {
+    await mergePublicSpellingCodexState(db, accountId, subjectRows, gameState);
+  }
 
   return {
     ...normaliseRepositoryBundle({


### PR DESCRIPTION
## Summary
- Restore Codex/home meadow rendering when production public read models redact spelling analytics word rows.
- Synthesize public monster-codex mastery counts from server-side spelling progress during public bootstrap when reward state is missing.
- Preserve existing redaction guarantees and avoid render-time game-state writes.

## Verification
- npm test
- npm run check
- node --test tests/render.test.js
- node --test tests/worker-backend.test.js
- node --test tests/worker-auth.test.js tests/worker-projections.test.js tests/monster-system.test.js
- deterministic redacted analytics smoke: public monster projection builds non-empty meadow entries
