### PR TITLE
fix(codex): restore monsters from reward projection

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -25,10 +25,7 @@ import { createPlatformTts } from './subjects/spelling/tts.js';
 import { DEFAULT_TTS_PROVIDER, normaliseTtsProvider } from './subjects/spelling/tts-providers.js';
 import { createSpellingReadModelService } from './subjects/spelling/client-read-models.js';
 import { resolveSpellingShortcut } from './subjects/spelling/shortcuts.js';
-import {
-  monsterSummary,
-  monsterSummaryFromSpellingAnalytics,
-} from './platform/game/monster-system.js';
+import { buildLearnerMonsterSummary } from './platform/app/surface-models.js';
 import {
   exportLearnerSnapshot,
   exportPlatformSnapshot,
@@ -1151,16 +1148,7 @@ function buildHomeDashboardStats(appState, context) {
 }
 
 function buildHomeMonsterSummary(learnerId, context) {
-  if (!learnerId) return [];
-  const spelling = context.services?.spelling;
-  if (spelling?.getAnalyticsSnapshot) {
-    return monsterSummaryFromSpellingAnalytics(spelling.getAnalyticsSnapshot(learnerId), {
-      learnerId,
-      gameStateRepository: context.repositories?.gameState,
-      persistBranches: false,
-    });
-  }
-  return monsterSummary(learnerId, context.repositories?.gameState);
+  return buildLearnerMonsterSummary(learnerId, context);
 }
 
 function buildHomeDueTotal(learnerId, context) {

--- a/src/platform/app/surface-models.js
+++ b/src/platform/app/surface-models.js
@@ -1,3 +1,56 @@
+import {
+  monsterSummaryFromSpellingAnalytics,
+  monsterSummaryFromState,
+} from '../game/monster-system.js';
+
+const MONSTER_CODEX_SYSTEM_ID = 'monster-codex';
+
+function analyticsHasWordRows(analytics) {
+  return (Array.isArray(analytics?.wordGroups) ? analytics.wordGroups : [])
+    .some((group) => Array.isArray(group?.words) && group.words.length > 0);
+}
+
+function directSecureTotal(summary = []) {
+  return summary
+    .filter((entry) => entry?.monster?.id !== 'phaeton')
+    .reduce((sum, entry) => sum + (Number(entry?.progress?.mastered) || 0), 0);
+}
+
+function readRewardState(context, learnerId) {
+  try {
+    return context?.repositories?.gameState?.read?.(learnerId, MONSTER_CODEX_SYSTEM_ID) || {};
+  } catch {
+    return {};
+  }
+}
+
+export function buildLearnerMonsterSummary(learnerId, context = {}) {
+  if (!learnerId) return [];
+
+  const rewardSummary = monsterSummaryFromState(readRewardState(context, learnerId));
+  const spelling = context?.services?.spelling;
+  if (!spelling?.getAnalyticsSnapshot) return rewardSummary;
+
+  let analytics = null;
+  try {
+    analytics = spelling.getAnalyticsSnapshot(learnerId);
+  } catch {
+    return rewardSummary;
+  }
+
+  if (!analyticsHasWordRows(analytics)) return rewardSummary;
+
+  const analyticsSummary = monsterSummaryFromSpellingAnalytics(analytics, {
+    learnerId,
+    gameStateRepository: context?.repositories?.gameState,
+    persistBranches: false,
+  });
+
+  return directSecureTotal(analyticsSummary) > directSecureTotal(rewardSummary)
+    ? analyticsSummary
+    : rewardSummary;
+}
+
 export function persistenceLabel(snapshot) {
   if (snapshot?.mode === 'remote-sync') return 'Remote sync';
   if (snapshot?.mode === 'degraded') {

--- a/src/platform/game/monster-system.js
+++ b/src/platform/game/monster-system.js
@@ -231,6 +231,11 @@ export function recordMonsterMastery(learnerId, monsterId, wordSlug, gameStateRe
 
 export function monsterSummary(learnerId, gameStateRepository) {
   const state = ensureMonsterBranches(learnerId, gameStateRepository);
+  return monsterSummaryFromState(state);
+}
+
+export function monsterSummaryFromState(rawState = {}) {
+  const state = isPlainObject(rawState) ? rawState : {};
   return SPELLING_MONSTER_IDS.map((monsterId) => ({
     monster: MONSTERS[monsterId],
     progress: progressForMonster(state, monsterId),

--- a/tests/monster-system.test.js
+++ b/tests/monster-system.test.js
@@ -6,6 +6,7 @@ import {
   ensureMonsterBranches,
   monsterIdForSpellingWord,
   monsterSummaryFromSpellingAnalytics,
+  monsterSummaryFromState,
   progressForMonster,
   recordMonsterMastery,
 } from '../src/platform/game/monster-system.js';
@@ -255,4 +256,18 @@ test('analytics summaries can project branches without writing during render', (
   assert.equal(repository.writes(), 0);
   assert.equal(summary.find((entry) => entry.monster.id === 'inklet').progress.mastered, 1);
   assert.equal(summary.find((entry) => entry.monster.id === 'vellhorn').progress.mastered, 0);
+});
+
+test('public monster-codex state projects mastered counts without repository writes', () => {
+  const summary = monsterSummaryFromState({
+    inklet: { masteredCount: 12, caught: true, branch: 'b2' },
+    glimmerbug: { masteredCount: 7, caught: true, branch: 'b1' },
+    vellhorn: { masteredCount: 3, caught: true, branch: 'b2' },
+    phaeton: { branch: 'b1' },
+  });
+
+  assert.equal(summary.find((entry) => entry.monster.id === 'inklet').progress.mastered, 12);
+  assert.equal(summary.find((entry) => entry.monster.id === 'inklet').progress.branch, 'b2');
+  assert.equal(summary.find((entry) => entry.monster.id === 'vellhorn').progress.caught, true);
+  assert.equal(summary.find((entry) => entry.monster.id === 'phaeton').progress.mastered, 19);
 });

--- a/tests/surface-models.test.js
+++ b/tests/surface-models.test.js
@@ -1,0 +1,77 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildLearnerMonsterSummary } from '../src/platform/app/surface-models.js';
+import { buildCodexEntries } from '../src/surfaces/home/data.js';
+
+function makeContext({ rewardState = {}, analytics = null } = {}) {
+  let writes = 0;
+  return {
+    services: {
+      spelling: {
+        getAnalyticsSnapshot() {
+          return analytics;
+        },
+      },
+    },
+    repositories: {
+      gameState: {
+        read() {
+          return rewardState;
+        },
+        write() {
+          writes += 1;
+          throw new Error('render must not write monster reward state');
+        },
+        writes() {
+          return writes;
+        },
+      },
+    },
+  };
+}
+
+test('learner monster summary uses public reward projection when analytics is redacted', () => {
+  const context = makeContext({
+    rewardState: {
+      inklet: { masteredCount: 14, caught: true, branch: 'b2' },
+      glimmerbug: { masteredCount: 11, caught: true, branch: 'b1' },
+      vellhorn: { masteredCount: 8, caught: true, branch: 'b2' },
+    },
+    analytics: { wordGroups: [] },
+  });
+
+  const summary = buildLearnerMonsterSummary('learner-a', context);
+
+  assert.equal(summary.find((entry) => entry.monster.id === 'inklet').progress.mastered, 14);
+  assert.equal(summary.find((entry) => entry.monster.id === 'glimmerbug').progress.branch, 'b1');
+  assert.equal(summary.find((entry) => entry.monster.id === 'vellhorn').progress.caught, true);
+  assert.equal(context.repositories.gameState.writes(), 0);
+
+  const vellhornEntry = buildCodexEntries(summary).find((entry) => entry.id === 'vellhorn');
+  assert.equal(vellhornEntry.displayState, 'egg');
+  assert.match(vellhornEntry.img, /vellhorn-b2-0\.640\.webp/);
+  assert.equal(vellhornEntry.placeholder, '');
+});
+
+test('learner monster summary falls back to analytics when reward projection is empty', () => {
+  const context = makeContext({
+    rewardState: {},
+    analytics: {
+      wordGroups: [
+        {
+          words: [
+            { slug: 'possess', status: 'secure', year: '3-4' },
+            { slug: 'mollusc', status: 'secure', year: 'extra', spellingPool: 'extra' },
+          ],
+        },
+      ],
+    },
+  });
+
+  const summary = buildLearnerMonsterSummary('learner-a', context);
+
+  assert.equal(summary.find((entry) => entry.monster.id === 'inklet').progress.mastered, 1);
+  assert.equal(summary.find((entry) => entry.monster.id === 'vellhorn').progress.mastered, 1);
+  assert.equal(context.repositories.gameState.writes(), 0);
+});


### PR DESCRIPTION
## Summary
- restore Codex/Home monster summaries from the public monster-codex reward projection when spelling analytics is redacted
- keep analytics-derived summaries as a legacy fallback when no reward projection exists
- add regression coverage for public masteredCount projection and the Vellhorn caught entry avoiding the unknown placeholder path

## Verification
- npm test -- tests/surface-models.test.js
- npm test
- npm run check