### PR TITLE
fix(spelling): route auto advance through commands

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -685,6 +685,7 @@ const controller = createAppController({
   subjects: SUBJECTS,
   session: boot.session,
   runtimeBoundary,
+  autoAdvanceDispatchContinue: () => handleRemoteSpellingAction('spelling-continue'),
   tts,
   services,
   cacheSubjectUiWrites: true,
@@ -1848,6 +1849,15 @@ function applySpellingCommandResponse(response) {
   }
 }
 
+const pendingSpellingCommandKeys = new Set();
+
+function spellingCommandDedupeKey(command, appState = store.getState()) {
+  if (command !== 'continue-session') return '';
+  const learnerId = appState.learners?.selectedId || '';
+  const sessionId = appState.subjectUi?.spelling?.session?.id || '';
+  return learnerId && sessionId ? `${command}:${learnerId}:${sessionId}` : '';
+}
+
 function wordBankAnalyticsFromState(appState = store.getState()) {
   return appState.subjectUi?.spelling?.analytics || null;
 }
@@ -1951,11 +1961,17 @@ async function sendSpellingCommand(command, payload = {}) {
 }
 
 function runSpellingCommand(command, payload = {}) {
+  const dedupeKey = spellingCommandDedupeKey(command);
+  if (dedupeKey && pendingSpellingCommandKeys.has(dedupeKey)) return false;
+  if (dedupeKey) pendingSpellingCommandKeys.add(dedupeKey);
   sendSpellingCommand(command, payload).catch((error) => {
     globalThis.console?.warn?.('Spelling command failed.', error);
     const message = error?.payload?.message || error?.message || 'The spelling command could not be completed.';
     setSpellingRuntimeError(message);
+  }).finally(() => {
+    if (dedupeKey) pendingSpellingCommandKeys.delete(dedupeKey);
   });
+  return true;
 }
 
 function handleRemoteSpellingAction(action, data = {}) {

--- a/src/platform/app/create-app-controller.js
+++ b/src/platform/app/create-app-controller.js
@@ -30,6 +30,7 @@ export function createAppController({
   subscribers = null,
   runtimeBoundary = createSubjectRuntimeBoundary(),
   scheduler = null,
+  autoAdvanceDispatchContinue = null,
   tts = createNoopTtsPort(),
   services: extraServices = {},
   ports: portOverrides = {},
@@ -55,7 +56,7 @@ export function createAppController({
     || (typeof globalThis.clearTimeout === 'function' ? globalThis.clearTimeout.bind(globalThis) : null);
   const autoAdvance = createSpellingAutoAdvanceController({
     getState: () => store.getState(),
-    dispatchContinue: () => dispatch('spelling-continue'),
+    dispatchContinue: dispatchAutoAdvanceContinue,
     setTimeoutFn,
     clearTimeoutFn,
   });
@@ -105,6 +106,13 @@ export function createAppController({
       return false;
     }
     return autoAdvance.ensureScheduledFromState(appState.subjectUi.spelling);
+  }
+
+  function dispatchAutoAdvanceContinue() {
+    if (typeof autoAdvanceDispatchContinue === 'function') {
+      return autoAdvanceDispatchContinue();
+    }
+    return dispatch('spelling-continue');
   }
 
   function clearDeferredAudio() {

--- a/src/subjects/spelling/auto-advance.js
+++ b/src/subjects/spelling/auto-advance.js
@@ -1,5 +1,6 @@
 export function spellingAutoAdvanceDelay(state) {
   if (!state || state.phase !== 'session' || !state.awaitingAdvance || !state.session) return null;
+  if (state.error) return null;
   return state.session.type === 'test' ? 320 : 500;
 }
 

--- a/tests/spelling-parity.test.js
+++ b/tests/spelling-parity.test.js
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict';
 import { installMemoryStorage } from './helpers/memory-storage.js';
 import { createAppHarness } from './helpers/app-harness.js';
 import { createManualScheduler } from './helpers/manual-scheduler.js';
+import { createLocalAppController } from '../src/platform/app/create-local-app-controller.js';
 import { createLocalPlatformRepositories } from '../src/platform/core/repositories/index.js';
 import { createSpellingPersistence } from '../src/subjects/spelling/repository.js';
 import { createSpellingService } from '../src/subjects/spelling/service.js';
@@ -288,6 +289,46 @@ test('legacy auto-advance delay is preserved for learning and SATs saves', () =>
     awaitingAdvance: true,
     session: { type: 'test' },
   }), 320);
+
+  assert.equal(spellingAutoAdvanceDelay({
+    phase: 'session',
+    awaitingAdvance: true,
+    error: 'Command failed',
+    session: { type: 'learning' },
+  }), null);
+});
+
+test('auto-advance can delegate continue through an injected command boundary', () => {
+  const storage = installMemoryStorage();
+  const scheduler = createManualScheduler();
+  const repositories = createLocalPlatformRepositories({ storage });
+  let autoContinueCalls = 0;
+  const controller = createLocalAppController({
+    repositories,
+    scheduler,
+    autoAdvanceDispatchContinue: () => {
+      autoContinueCalls += 1;
+      return true;
+    },
+  });
+  const learnerId = controller.store.getState().learners.selectedId;
+
+  controller.services.spelling.savePrefs(learnerId, { mode: 'smart', roundLength: '1' });
+  controller.dispatch('open-subject', { subjectId: 'spelling' });
+  controller.dispatch('spelling-start');
+
+  const answer = controller.store.getState().subjectUi.spelling.session.currentCard.word.word;
+  controller.dispatch('spelling-submit-form', { formData: typedFormData(answer) });
+  controller.services.spelling.continueSession = undefined;
+
+  assert.equal(controller.store.getState().subjectUi.spelling.awaitingAdvance, true);
+  assert.equal(scheduler.count(), 1);
+
+  scheduler.flushAll();
+
+  assert.equal(autoContinueCalls, 1);
+  assert.equal(controller.runtimeBoundary.list().length, 0);
+  assert.equal(controller.store.getState().subjectUi.spelling.awaitingAdvance, true);
 });
 
 test('legacy auto-advance can move a one-word learning round on without a manual continue click', () => {


### PR DESCRIPTION
## Summary
- Route spelling auto-advance through the server subject command boundary in the browser runtime, so remote read-model services are not asked for local `continueSession()`.
- Dedupe in-flight `continue-session` commands per learner/session and stop auto-advance while a subject error is visible.
- Add regression coverage for the injected auto-advance command boundary.

## Verification
- `npm test -- tests/spelling-parity.test.js`
- `npm test`
- `npm run check`