### PR TITLE
fix(deploy): deny direct source fallback paths

### DIFF
--- a/tests/bundle-audit.test.js
+++ b/tests/bundle-audit.test.js
@@ -107,9 +107,21 @@ test('worker spelling runtime imports the shared domain service instead of the b
 });
 
 test('worker-first asset routing keeps demo and source lockdown routes out of SPA fallback', async () => {
+  const expectedRoutes = [
+    '/api/*',
+    '/demo',
+    '/src/*',
+    '/worker/*',
+    '/tests/*',
+    '/docs/*',
+    '/legacy/*',
+    '/migration-plan.md',
+  ];
   for (const configPath of ['wrangler.jsonc', 'worker/wrangler.example.jsonc']) {
     const config = await readFile(configPath, 'utf8');
-    assert.match(config, /"run_worker_first"\s*:\s*\[[\s\S]*"\/api\/\*"[\s\S]*"\/demo"[\s\S]*"\/src\/\*"[\s\S]*\]/, configPath);
+    for (const route of expectedRoutes) {
+      assert.match(config, new RegExp(`"${route.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"`), `${configPath} missing ${route}`);
+    }
   }
 });
 

--- a/tests/worker-backend.test.js
+++ b/tests/worker-backend.test.js
@@ -162,10 +162,16 @@ test('worker denies raw source assets while allowing the built app bundle', asyn
   });
 
   const denied = await server.fetchRaw('https://repo.test/src/subjects/spelling/data/content-data.js');
+  const deniedWorker = await server.fetchRaw('https://repo.test/worker/src/app.js');
+  const deniedTest = await server.fetchRaw('https://repo.test/tests/build-public.test.js');
   const bundle = await server.fetchRaw('https://repo.test/src/bundles/app.bundle.js');
 
   assert.equal(denied.status, 404);
   assert.equal(await denied.text(), 'Not found.');
+  assert.equal(deniedWorker.status, 404);
+  assert.equal(await deniedWorker.text(), 'Not found.');
+  assert.equal(deniedTest.status, 404);
+  assert.equal(await deniedTest.text(), 'Not found.');
   assert.equal(bundle.status, 200);
   assert.equal(await bundle.text(), 'console.log("app bundle");');
   assert.deepEqual(requests, ['/src/bundles/app.bundle.js']);

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -168,6 +168,15 @@ async function publicSourceAssetResponse(request, env = {}) {
   return new Response('Not found.', { status: 404, headers });
 }
 
+function isPublicSourceLockdownPath(pathname) {
+  return pathname.startsWith('/src/')
+    || pathname.startsWith('/worker/')
+    || pathname.startsWith('/tests/')
+    || pathname.startsWith('/docs/')
+    || pathname.startsWith('/legacy/')
+    || pathname === '/migration-plan.md';
+}
+
 export function createWorkerApp({
   now = Date.now,
   fetchFn = (...args) => fetch(...args),
@@ -179,7 +188,7 @@ export function createWorkerApp({
       const auth = createSessionAuthBoundary({ env });
 
       try {
-        if (url.pathname.startsWith('/src/')) {
+        if (isPublicSourceLockdownPath(url.pathname)) {
           return publicSourceAssetResponse(request, env);
         }
 

--- a/worker/wrangler.example.jsonc
+++ b/worker/wrangler.example.jsonc
@@ -13,7 +13,12 @@
     "run_worker_first": [
       "/api/*",
       "/demo",
-      "/src/*"
+      "/src/*",
+      "/worker/*",
+      "/tests/*",
+      "/docs/*",
+      "/legacy/*",
+      "/migration-plan.md"
     ]
   },
   "vars": {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -18,7 +18,12 @@
     "run_worker_first": [
       "/api/*",
       "/demo",
-      "/src/*"
+      "/src/*",
+      "/worker/*",
+      "/tests/*",
+      "/docs/*",
+      "/legacy/*",
+      "/migration-plan.md"
     ]
   },
   "vars": {


### PR DESCRIPTION
## Summary
- route sensitive direct paths through the Worker before Cloudflare Assets SPA fallback
- return explicit 404s for worker, tests, docs, legacy, and migration-plan paths while preserving the built app bundle
- extend deployment and Worker tests for direct source denial

## Verification
- npm test -- tests/bundle-audit.test.js tests/worker-backend.test.js
- npm test
- npm run check