### PR TITLE
fix(deploy): deny source audit fallback routes

### DIFF
--- a/tests/bundle-audit.test.js
+++ b/tests/bundle-audit.test.js
@@ -109,7 +109,7 @@ test('worker spelling runtime imports the shared domain service instead of the b
 test('worker-first asset routing keeps demo and source lockdown routes out of SPA fallback', async () => {
   for (const configPath of ['wrangler.jsonc', 'worker/wrangler.example.jsonc']) {
     const config = await readFile(configPath, 'utf8');
-    assert.match(config, /"run_worker_first"\s*:\s*\[[\s\S]*"\/api\/\*"[\s\S]*"\/demo"[\s\S]*"\/src\/\*"[\s\S]*\]/, configPath);
+    assert.match(config, /"run_worker_first"\s*:\s*\[[\s\S]*"\/api\/\*"[\s\S]*"\/demo"[\s\S]*"\/src\/\*"[\s\S]*"\/worker\/\*"[\s\S]*"\/tests\/\*"[\s\S]*\]/, configPath);
   }
 });
 

--- a/tests/worker-backend.test.js
+++ b/tests/worker-backend.test.js
@@ -162,10 +162,16 @@ test('worker denies raw source assets while allowing the built app bundle', asyn
   });
 
   const denied = await server.fetchRaw('https://repo.test/src/subjects/spelling/data/content-data.js');
+  const deniedWorker = await server.fetchRaw('https://repo.test/worker/src/app.js');
+  const deniedTest = await server.fetchRaw('https://repo.test/tests/build-public.test.js');
   const bundle = await server.fetchRaw('https://repo.test/src/bundles/app.bundle.js');
 
   assert.equal(denied.status, 404);
   assert.equal(await denied.text(), 'Not found.');
+  assert.equal(deniedWorker.status, 404);
+  assert.equal(await deniedWorker.text(), 'Not found.');
+  assert.equal(deniedTest.status, 404);
+  assert.equal(await deniedTest.text(), 'Not found.');
   assert.equal(bundle.status, 200);
   assert.equal(await bundle.text(), 'console.log("app bundle");');
   assert.deepEqual(requests, ['/src/bundles/app.bundle.js']);

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -179,7 +179,11 @@ export function createWorkerApp({
       const auth = createSessionAuthBoundary({ env });
 
       try {
-        if (url.pathname.startsWith('/src/')) {
+        if (
+          url.pathname.startsWith('/src/')
+          || url.pathname.startsWith('/worker/')
+          || url.pathname.startsWith('/tests/')
+        ) {
           return publicSourceAssetResponse(request, env);
         }
 

--- a/worker/wrangler.example.jsonc
+++ b/worker/wrangler.example.jsonc
@@ -13,7 +13,9 @@
     "run_worker_first": [
       "/api/*",
       "/demo",
-      "/src/*"
+      "/src/*",
+      "/worker/*",
+      "/tests/*"
     ]
   },
   "vars": {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -18,7 +18,9 @@
     "run_worker_first": [
       "/api/*",
       "/demo",
-      "/src/*"
+      "/src/*",
+      "/worker/*",
+      "/tests/*"
     ]
   },
   "vars": {


### PR DESCRIPTION
## Summary
- Route `/worker/*` and `/tests/*` through the Worker before the SPA asset fallback.
- Return the same source-lockdown 404 response for those paths while keeping the built app bundle available.
- Extend the config and Worker tests so the production audit denial paths stay covered.

## Verification
- `npm test -- tests/bundle-audit.test.js tests/worker-backend.test.js`
- `npm test`
- `npm run check`