### PR TITLE
fix(spelling): cache open-subject setup reset

### DIFF
--- a/src/platform/core/store.js
+++ b/src/platform/core/store.js
@@ -197,7 +197,7 @@ function isCleanSpellingSetupEntry(spellingUi, transientUi) {
     && !transientUi?.spellingWordBankDrillResult;
 }
 
-function normaliseSubjectEntryForOpen(current, route, repositories) {
+function normaliseSubjectEntryForOpen(current, route, writeSubjectUi) {
   if (route.screen !== 'subject' || route.subjectId !== 'spelling' || route.tab !== 'practice') {
     return current;
   }
@@ -216,9 +216,7 @@ function normaliseSubjectEntryForOpen(current, route, repositories) {
     awaitingAdvance: false,
   };
 
-  if (current.learners.selectedId) {
-    repositories.subjectStates.writeUi(current.learners.selectedId, 'spelling', nextSpellingUi);
-  }
+  if (current.learners.selectedId) writeSubjectUi(current.learners.selectedId, 'spelling', nextSpellingUi);
 
   return {
     ...current,
@@ -311,10 +309,7 @@ export function createStore(subjects, { repositories, cacheSubjectUiWrites = fal
     const nextTree = buildSubjectUiTree(registry);
     if (learnerId) {
       for (const subject of registry) {
-        const writer = cacheSubjectUiWrites && resolvedRepositories.subjectStates.cacheUi
-          ? resolvedRepositories.subjectStates.cacheUi
-          : resolvedRepositories.subjectStates.writeUi;
-        writer.call(resolvedRepositories.subjectStates, learnerId, subject.id, nextTree[subject.id]);
+        writeSubjectUi(learnerId, subject.id, nextTree[subject.id]);
       }
     }
     setState((current) => ({
@@ -322,6 +317,13 @@ export function createStore(subjects, { repositories, cacheSubjectUiWrites = fal
       subjectUi: nextTree,
       monsterCelebrations: emptyMonsterCelebrations(),
     }));
+  }
+
+  function writeSubjectUi(learnerId, subjectId, ui) {
+    const writer = cacheSubjectUiWrites && resolvedRepositories.subjectStates.cacheUi
+      ? resolvedRepositories.subjectStates.cacheUi
+      : resolvedRepositories.subjectStates.writeUi;
+    return writer.call(resolvedRepositories.subjectStates, learnerId, subjectId, ui);
   }
 
   return {
@@ -345,7 +347,7 @@ export function createStore(subjects, { repositories, cacheSubjectUiWrites = fal
       setState((current) => {
         const route = normaliseRoute({ screen: 'subject', subjectId, tab }, registry);
         return {
-          ...normaliseSubjectEntryForOpen(current, route, resolvedRepositories),
+          ...normaliseSubjectEntryForOpen(current, route, writeSubjectUi),
           route,
         };
       });
@@ -458,10 +460,7 @@ export function createStore(subjects, { repositories, cacheSubjectUiWrites = fal
           : { ...previous, ...updater };
 
         if (learnerId) {
-          const writer = cacheSubjectUiWrites && resolvedRepositories.subjectStates.cacheUi
-            ? resolvedRepositories.subjectStates.cacheUi
-            : resolvedRepositories.subjectStates.writeUi;
-          writer.call(resolvedRepositories.subjectStates, learnerId, subjectId, nextEntry);
+          writeSubjectUi(learnerId, subjectId, nextEntry);
         }
 
         return {

--- a/tests/store.test.js
+++ b/tests/store.test.js
@@ -38,6 +38,48 @@ test('shared store can switch subject tabs without losing route context', () => 
   assert.equal(state.route.tab, 'analytics');
 });
 
+test('shared store caches subject setup reset when runtime UI writes are cached', () => {
+  const storage = installMemoryStorage();
+  const repositories = createLocalPlatformRepositories({ storage });
+  let cached = null;
+  const guardedRepositories = {
+    ...repositories,
+    subjectStates: {
+      ...repositories.subjectStates,
+      cacheUi(learnerId, subjectId, ui) {
+        cached = { learnerId, subjectId, ui };
+        return repositories.subjectStates.writeUi(learnerId, subjectId, ui);
+      },
+      writeUi() {
+        throw new Error('openSubject should cache the setup reset instead of queuing a runtime write.');
+      },
+    },
+  };
+  const store = createStore(SUBJECTS, { repositories: guardedRepositories, cacheSubjectUiWrites: true });
+  const learnerId = store.getState().learners.selectedId;
+
+  store.setState((current) => ({
+    ...current,
+    subjectUi: {
+      ...current.subjectUi,
+      spelling: {
+        ...current.subjectUi.spelling,
+        phase: 'word-bank',
+        error: 'stale setup flow',
+      },
+    },
+  }));
+
+  store.openSubject('spelling');
+
+  assert.equal(cached.learnerId, learnerId);
+  assert.equal(cached.subjectId, 'spelling');
+  assert.equal(cached.ui.phase, 'dashboard');
+  assert.equal(cached.ui.error, '');
+  assert.equal(store.getState().subjectUi.spelling.phase, 'dashboard');
+  assert.equal(store.getState().subjectUi.spelling.error, '');
+});
+
 test('shared store can route to adult operating surfaces', () => {
   const storage = installMemoryStorage();
   const repositories = createLocalPlatformRepositories({ storage });


### PR DESCRIPTION
Production Spelling navigation could still hit the legacy subjectStates.put write guard when openSubject reset a stale setup state. This routes that reset through the same cache-aware subject UI writer used by remote command responses, so the browser no longer queues broad runtime writes while opening Spelling.

Verification:
- npm test
- npm run check