### PR TITLE
fix(spelling): restore word-bank detail audio

### DIFF
--- a/src/platform/core/store.js
+++ b/src/platform/core/store.js
@@ -1,7 +1,7 @@
 import { uid } from './utils.js';
 import { buildSubjectRegistry } from './subject-contract.js';
 import { validatePlatformRepositories } from './repositories/contract.js';
-import { normaliseLearnersSnapshot } from './repositories/helpers.js';
+import { cloneSerialisable, normaliseLearnersSnapshot } from './repositories/helpers.js';
 import {
   defaultPersistenceSnapshot,
   normalisePersistenceSnapshot,
@@ -158,6 +158,12 @@ function normaliseTransientUi(rawValue) {
   const rawDrillResult = typeof raw.spellingWordBankDrillResult === 'string'
     ? raw.spellingWordBankDrillResult
     : '';
+  const wordDetail = raw.spellingWordDetail
+    && typeof raw.spellingWordDetail === 'object'
+    && !Array.isArray(raw.spellingWordDetail)
+    && typeof raw.spellingWordDetail.slug === 'string'
+    ? cloneSerialisable(raw.spellingWordDetail)
+    : null;
   return {
     spellingAnalyticsWordSearch: typeof raw.spellingAnalyticsWordSearch === 'string'
       ? raw.spellingAnalyticsWordSearch.slice(0, 80)
@@ -172,6 +178,7 @@ function normaliseTransientUi(rawValue) {
       ? raw.spellingWordBankDrillTyped.slice(0, 80)
       : '',
     spellingWordBankDrillResult: VALID_WORD_DRILL_RESULTS.has(rawDrillResult) ? rawDrillResult : null,
+    spellingWordDetail: wordDetail,
   };
 }
 
@@ -180,6 +187,7 @@ function closeSpellingWordDetailTransientUi(transientUi) {
     ...transientUi,
     spellingWordDetailSlug: '',
     spellingWordDetailMode: 'explain',
+    spellingWordDetail: null,
     spellingWordBankDrillTyped: '',
     spellingWordBankDrillResult: null,
   };
@@ -193,6 +201,7 @@ function isCleanSpellingSetupEntry(spellingUi, transientUi) {
     && !spellingUi.error
     && !spellingUi.awaitingAdvance
     && !transientUi?.spellingWordDetailSlug
+    && !transientUi?.spellingWordDetail
     && !transientUi?.spellingWordBankDrillTyped
     && !transientUi?.spellingWordBankDrillResult;
 }

--- a/tests/store.test.js
+++ b/tests/store.test.js
@@ -101,6 +101,39 @@ test('shared store can route to adult operating surfaces', () => {
   assert.equal(store.getState().route.screen, 'dashboard');
 });
 
+test('shared store preserves transient word-bank detail payloads for remote modal replay', () => {
+  const storage = installMemoryStorage();
+  const repositories = createLocalPlatformRepositories({ storage });
+  const store = createStore(SUBJECTS, { repositories });
+
+  store.patch((current) => ({
+    transientUi: {
+      ...current.transientUi,
+      spellingWordDetailSlug: 'century',
+      spellingWordDetail: {
+        slug: 'century',
+        word: 'century',
+        explanation: 'A century is a period of one hundred years.',
+        sentence: 'The castle was built a century ago.',
+        audio: {
+          word: {
+            learnerId: 'learner-a',
+            promptToken: 'word-token',
+            slug: 'century',
+            scope: 'word-bank',
+            wordOnly: true,
+          },
+        },
+      },
+    },
+  }));
+
+  const detail = store.getState().transientUi.spellingWordDetail;
+  assert.equal(detail.word, 'century');
+  assert.equal(detail.explanation, 'A century is a period of one hundred years.');
+  assert.equal(detail.audio.word.promptToken, 'word-token');
+});
+
 test('serialisable spelling state survives store persistence for resume', () => {
   const storage = installMemoryStorage();
   const repositories = createLocalPlatformRepositories({ storage });

--- a/tests/worker-tts.test.js
+++ b/tests/worker-tts.test.js
@@ -2,6 +2,10 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { sha256 } from '../worker/src/auth.js';
+import {
+  buildSpellingWordBankAudioCue,
+  resolveSpellingAudioRequest,
+} from '../worker/src/subjects/spelling/audio.js';
 import { createWorkerRepositoryServer } from './helpers/worker-server.js';
 
 function seedAccountLearner(DB, { accountId = 'adult-a', learnerId = 'learner-a' } = {}) {
@@ -367,6 +371,63 @@ test('TTS route supports server-tokened word bank vocabulary audio', async () =>
     globalThis.fetch = originalFetch;
     server.close();
   }
+});
+
+test('word-bank vocabulary audio tokens do not require example sentences', async () => {
+  const word = {
+    slug: 'century',
+    word: 'century',
+    sentence: '',
+  };
+  const repository = {
+    async readSubjectRuntime() {
+      return { subjectRecord: { ui: { phase: 'dashboard' } } };
+    },
+    async readSpellingRuntimeContent() {
+      return {
+        snapshot: {
+          wordBySlug: { century: word },
+        },
+      };
+    },
+  };
+
+  const wordCue = await buildSpellingWordBankAudioCue({
+    learnerId: 'learner-a',
+    word,
+    wordOnly: true,
+  });
+  const dictationCue = await buildSpellingWordBankAudioCue({
+    learnerId: 'learner-a',
+    word,
+  });
+
+  assert.ok(wordCue.promptToken);
+  assert.ok(dictationCue.promptToken);
+  assert.equal(wordCue.promptToken, dictationCue.promptToken);
+
+  const wordRequest = await resolveSpellingAudioRequest({
+    repository,
+    accountId: 'adult-a',
+    body: {
+      learnerId: 'learner-a',
+      promptToken: wordCue.promptToken,
+      slug: 'century',
+      wordOnly: true,
+    },
+  });
+  const dictationRequest = await resolveSpellingAudioRequest({
+    repository,
+    accountId: 'adult-a',
+    body: {
+      learnerId: 'learner-a',
+      promptToken: dictationCue.promptToken,
+      slug: 'century',
+    },
+  });
+
+  assert.equal(wordRequest.transcript, 'century');
+  assert.equal(dictationRequest.transcript, 'The word is century. The word is century.');
 });
 
 test('TTS route reports missing selected provider configuration clearly', async () => {

--- a/worker/src/subjects/spelling/audio.js
+++ b/worker/src/subjects/spelling/audio.js
@@ -63,7 +63,7 @@ export async function buildSpellingWordBankAudioCue({ learnerId, word, wordOnly 
     word: cleanText(word?.word),
     sentence: cleanText(word?.sentence),
   };
-  if (!parts.learnerId || !parts.slug || !parts.word || !parts.sentence) return null;
+  if (!parts.learnerId || !parts.slug || !parts.word) return null;
   return {
     subjectId: 'spelling',
     learnerId: parts.learnerId,
@@ -76,7 +76,10 @@ export async function buildSpellingWordBankAudioCue({ learnerId, word, wordOnly 
 
 function transcriptFor(parts, { wordOnly = false } = {}) {
   if (wordOnly) return parts.word;
-  return `The word is ${parts.word}. ${parts.sentence} The word is ${parts.word}.`;
+  const sentence = cleanText(parts.sentence);
+  return sentence
+    ? `The word is ${parts.word}. ${sentence} The word is ${parts.word}.`
+    : `The word is ${parts.word}. The word is ${parts.word}.`;
 }
 
 async function wordBankPromptParts({ repository, accountId, learnerId, slug } = {}) {
@@ -91,7 +94,7 @@ async function wordBankPromptParts({ repository, accountId, learnerId, slug } = 
   const word = snapshot?.wordBySlug?.[safeSlug];
   if (!word) return null;
   const sentence = cleanText(word.sentence);
-  if (!word.word || !sentence) return null;
+  if (!word.word) return null;
   return {
     learnerId,
     slug: word.slug,


### PR DESCRIPTION
## Summary
- Preserve remote word-bank detail payloads in transient UI so Explain modal can render server-loaded notes and audio cues.
- Allow word-bank vocabulary TTS tokens to work even when a word has no example sentence.
- Add regression coverage for transient detail preservation and sentence-less vocabulary audio.

## Verification
- node --test tests/store.test.js
- node --test tests/worker-tts.test.js
- npm test
- npm run check