### PR TITLE
fix(spelling): restore replay TTS cues

### DIFF
--- a/src/subjects/spelling/module.js
+++ b/src/subjects/spelling/module.js
@@ -19,6 +19,14 @@ function applySpellingTransition(context, transition) {
   return true;
 }
 
+function spellingReplayPayload({ service, learnerId, ui, slow = false } = {}) {
+  const audio = service?.getAudioCue?.(learnerId) || ui?.audio || null;
+  if (audio?.promptToken) return { ...audio, slow };
+  const card = ui?.session?.currentCard;
+  if (!card?.word) return null;
+  return { word: card.word, sentence: card.prompt?.sentence, slow };
+}
+
 function resetWordBankTransientUi(current) {
   return {
     ...current.transientUi,
@@ -174,16 +182,14 @@ export const spellingModule = {
     }
 
     if (action === 'spelling-replay') {
-      if (ui.session?.currentCard?.word) {
-        tts.speak({ word: ui.session.currentCard.word, sentence: ui.session.currentCard.prompt?.sentence });
-      }
+      const payload = spellingReplayPayload({ service, learnerId, ui });
+      if (payload) tts.speak(payload);
       return true;
     }
 
     if (action === 'spelling-replay-slow') {
-      if (ui.session?.currentCard?.word) {
-        tts.speak({ word: ui.session.currentCard.word, sentence: ui.session.currentCard.prompt?.sentence, slow: true });
-      }
+      const payload = spellingReplayPayload({ service, learnerId, ui, slow: true });
+      if (payload) tts.speak(payload);
       return true;
     }
 

--- a/tests/react-spelling-scene-spike.test.js
+++ b/tests/react-spelling-scene-spike.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 
 import { createLocalAppController } from '../src/platform/app/create-local-app-controller.js';
 import { createLocalPlatformRepositories } from '../src/platform/core/repositories/index.js';
+import { spellingModule } from '../src/subjects/spelling/module.js';
 import { installMemoryStorage } from './helpers/memory-storage.js';
 import { createAppHarness } from './helpers/app-harness.js';
 import { renderReactControllerApp } from './helpers/react-app-ssr.js';
@@ -67,6 +68,45 @@ test('spelling session spike preserves hidden answer, replay, submit, and contin
   finishCurrentRound(harness);
   assert.equal(harness.store.getState().subjectUi.spelling.phase, 'summary');
   assert.match(harness.render(), /summary-card/);
+});
+
+test('spelling replay uses a server audio cue when the prompt word is redacted', () => {
+  const spoken = [];
+  const audio = {
+    subjectId: 'spelling',
+    learnerId: 'learner-a',
+    sessionId: 'server-session',
+    promptToken: 'prompt-token-a',
+    wordOnly: false,
+  };
+  const ui = {
+    phase: 'session',
+    audio,
+    session: {
+      currentCard: {
+        prompt: { cloze: 'The birds sang ________ in the day.' },
+      },
+    },
+  };
+
+  const handled = spellingModule.handleAction('spelling-replay-slow', {
+    appState: {
+      learners: { selectedId: 'learner-a' },
+      subjectUi: { spelling: ui },
+    },
+    data: {},
+    store: {},
+    service: {
+      initState() { return ui; },
+      getAudioCue() { return audio; },
+    },
+    tts: {
+      speak(payload) { spoken.push(payload); },
+    },
+  });
+
+  assert.equal(handled, true);
+  assert.deepEqual(spoken, [{ ...audio, slow: true }]);
 });
 
 test('word-bank modal spike keeps drill isolated and Escape closes back to the word bank', () => {

--- a/tests/worker-backend.test.js
+++ b/tests/worker-backend.test.js
@@ -291,6 +291,8 @@ test('public bootstrap redacts spelling runtime state while preserving generic s
   assert.equal(publicSpelling.ui.session.currentCard.word, undefined);
   assert.equal(publicSpelling.ui.session.currentCard.prompt.sentence, undefined);
   assert.equal(publicSpelling.ui.session.currentCard.prompt.cloze, 'Do not expose ________.');
+  assert.ok(publicSpelling.ui.audio?.promptToken);
+  assert.equal(publicSpelling.ui.audio.learnerId, learnerId);
   assert.equal(publicPayload.practiceSessions[0].sessionState, null);
 
   server.close();
@@ -355,6 +357,8 @@ test('production bootstrap redacts spelling runtime state by default', async () 
   assert.equal(publicSpelling.ui.session.currentCard.word, undefined);
   assert.equal(publicSpelling.ui.session.currentCard.prompt.sentence, undefined);
   assert.equal(publicSpelling.ui.session.currentCard.prompt.cloze, 'Do not expose ________.');
+  assert.ok(publicSpelling.ui.audio?.promptToken);
+  assert.equal(publicSpelling.ui.audio.learnerId, 'learner-prod');
   assert.equal(payload.practiceSessions[0].sessionState, null);
 
   server.close();

--- a/tests/worker-tts.test.js
+++ b/tests/worker-tts.test.js
@@ -407,6 +407,116 @@ test('TTS route rejects arbitrary client-supplied transcript text', async () => 
   }
 });
 
+test('production bootstrap returns a redacted replay audio cue for the active spelling prompt', async () => {
+  const originalFetch = globalThis.fetch;
+  const calls = [];
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({
+      url,
+      body: JSON.parse(init.body),
+    });
+    return new Response(new Uint8Array([7, 8, 9]), {
+      status: 200,
+      headers: { 'content-type': 'audio/mpeg' },
+    });
+  };
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      AUTH_MODE: 'production',
+      ENVIRONMENT: 'production',
+      APP_HOSTNAME: 'repo.test',
+      OPENAI_API_KEY: 'test-openai-key',
+    },
+  });
+  try {
+    const prompt = await startDemoSpellingPrompt(server);
+    const bootstrap = await server.fetchRaw('https://repo.test/api/bootstrap', {
+      headers: { cookie: prompt.cookie },
+    });
+    const payload = await bootstrap.json();
+    const spelling = payload.subjectStates[`${prompt.learnerId}::spelling`]?.ui;
+
+    assert.equal(bootstrap.status, 200, JSON.stringify(payload));
+    assert.equal(spelling.session.currentCard.word, undefined);
+    assert.equal(spelling.session.currentCard.prompt.sentence, undefined);
+    assert.ok(spelling.audio?.promptToken);
+    assert.equal(spelling.audio.learnerId, prompt.learnerId);
+    assert.equal(spelling.audio.promptToken, prompt.audio.promptToken);
+    assert.equal(JSON.stringify(spelling).includes('early'), false);
+
+    const replay = await server.fetchRaw('https://repo.test/api/tts', {
+      ...ttsRequest({
+        learnerId: spelling.audio.learnerId,
+        promptToken: spelling.audio.promptToken,
+      }),
+      headers: {
+        'content-type': 'application/json',
+        cookie: prompt.cookie,
+      },
+    });
+    const bytes = new Uint8Array(await replay.arrayBuffer());
+
+    assert.equal(replay.status, 200);
+    assert.deepEqual([...bytes], [7, 8, 9]);
+    assert.equal(calls.length, 1);
+    assert.match(calls[0].body.input, /The word is early\./);
+  } finally {
+    globalThis.fetch = originalFetch;
+    server.close();
+  }
+});
+
+test('spelling commands keep a replay cue when auto-play audio is disabled', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    seedAccountLearner(server.DB);
+    const prefsResponse = await server.fetch('https://repo.test/api/subjects/spelling/command', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        command: 'save-prefs',
+        learnerId: 'learner-a',
+        requestId: 'tts-prefs-autoplay-off',
+        expectedLearnerRevision: 0,
+        payload: {
+          prefs: {
+            autoSpeak: false,
+            mode: 'single',
+            roundLength: '1',
+          },
+        },
+      }),
+    });
+    const prefsPayload = await prefsResponse.json();
+    assert.equal(prefsResponse.status, 200, JSON.stringify(prefsPayload));
+
+    const startResponse = await server.fetch('https://repo.test/api/subjects/spelling/command', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        command: 'start-session',
+        learnerId: 'learner-a',
+        requestId: 'tts-start-autoplay-off',
+        expectedLearnerRevision: 1,
+        payload: {
+          mode: 'single',
+          slug: 'early',
+          length: 1,
+        },
+      }),
+    });
+    const startPayload = await startResponse.json();
+
+    assert.equal(startResponse.status, 200, JSON.stringify(startPayload));
+    assert.equal(startPayload.audio, null);
+    assert.ok(startPayload.subjectReadModel.audio?.promptToken);
+    assert.equal(startPayload.subjectReadModel.audio.learnerId, 'learner-a');
+  } finally {
+    server.close();
+  }
+});
+
 test('demo TTS records fallback usage and demo-scoped limiter buckets', async () => {
   const originalFetch = globalThis.fetch;
   let providerCalls = 0;

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -32,6 +32,7 @@ import { buildAdminHubReadModel } from '../../src/platform/hubs/admin-read-model
 import { buildParentHubReadModel } from '../../src/platform/hubs/parent-read-model.js';
 import { monsterIdForSpellingWord } from '../../src/platform/game/monster-system.js';
 import { buildSpellingWordBankReadModel } from './content/spelling-read-models.js';
+import { buildSpellingAudioCue } from './subjects/spelling/audio.js';
 import {
   BadRequestError,
   ConflictError,
@@ -157,7 +158,7 @@ function safeSpellingSessionProgress(progress) {
   return Object.keys(output).length ? output : null;
 }
 
-function redactSpellingUiForClient(ui, data = {}, learnerId = '') {
+function redactSpellingUiForClient(ui, data = {}, learnerId = '', { audio = null } = {}) {
   const raw = ui && typeof ui === 'object' && !Array.isArray(ui) ? ui : {};
   const session = raw.session && typeof raw.session === 'object' && !Array.isArray(raw.session)
     ? raw.session
@@ -191,16 +192,20 @@ function redactSpellingUiForClient(ui, data = {}, learnerId = '') {
     prefs: cloneSerialisable(data?.prefs) || {},
     stats: {},
     analytics: null,
-    audio: null,
+    audio: audio ? cloneSerialisable(audio) : null,
     content: null,
   };
 }
 
-function publicSubjectStateRowToRecord(row) {
+async function publicSubjectStateRowToRecord(row) {
   const record = subjectStateRowToRecord(row);
   if (row.subject_id !== 'spelling') return record;
+  const audio = await buildSpellingAudioCue({
+    learnerId: row.learner_id,
+    state: record.ui,
+  });
   return normaliseSubjectStateRecord({
-    ui: redactSpellingUiForClient(record.ui, record.data, row.learner_id),
+    ui: redactSpellingUiForClient(record.ui, record.data, row.learner_id, { audio }),
     data: {},
     updatedAt: record.updatedAt,
   });
@@ -1237,11 +1242,11 @@ async function bootstrapBundle(db, accountId, { publicReadModels = false } = {})
   `, learnerIds);
 
   const subjectStates = {};
-  subjectRows.forEach((row) => {
+  for (const row of subjectRows) {
     subjectStates[subjectStateKey(row.learner_id, row.subject_id)] = publicReadModels
-      ? publicSubjectStateRowToRecord(row)
+      ? await publicSubjectStateRowToRecord(row)
       : subjectStateRowToRecord(row);
-  });
+  }
 
   const gameState = {};
   gameRows.forEach((row) => {

--- a/worker/src/subjects/spelling/commands.js
+++ b/worker/src/subjects/spelling/commands.js
@@ -119,11 +119,15 @@ export function createSpellingCommandHandlers({ now, random } = {}) {
       reactionEvents: projectedRewards.rewardEvents,
       existingEvents: projectionState.events,
     });
-    const audioCue = await buildSpellingAudioCue({
+    const replayAudioCue = await buildSpellingAudioCue({
+      learnerId: command.learnerId,
+      state: result.state,
+    });
+    const transitionAudioCue = result.audio ? await buildSpellingAudioCue({
       learnerId: command.learnerId,
       state: result.state,
       audio: result.audio,
-    });
+    }) : null;
 
     const projections = buildCommandProjectionReadModel({
       gameState: projectedRewards.gameState,
@@ -141,7 +145,7 @@ export function createSpellingCommandHandlers({ now, random } = {}) {
         prefs: result.prefs,
         stats: result.stats,
         analytics: clientAnalytics(result.analytics),
-        audio: audioCue,
+        audio: replayAudioCue,
         content: contentMeta(contentResult, snapshot),
       }),
       projections,
@@ -149,7 +153,7 @@ export function createSpellingCommandHandlers({ now, random } = {}) {
       domainEvents: projectedEvents.domainEvents,
       reactionEvents: projectedEvents.reactionEvents,
       toastEvents: projectedEvents.toastEvents,
-      audio: audioCue,
+      audio: transitionAudioCue,
       runtimeWrite: {
         state: result.state,
         data: result.data,


### PR DESCRIPTION
## Summary
- Restore server-authorised spelling audio cues in redacted bootstrap read models so replay works after reloads and PR49 lockdown state.
- Split transition auto-play audio from persistent replay cues, so `autoSpeak=false` is still respected while manual replay remains available.
- Teach the spelling replay action to use the server cue when the hidden prompt word is redacted.

## Verification
- `npm test`
- `npm run check`