### PR TITLE
fix(spelling): prevent summary TTS replay

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1849,12 +1849,21 @@ function setSpellingRuntimeError(message) {
   store.updateSubjectUi('spelling', { error: message || 'Practice is temporarily unavailable.' });
 }
 
-function applySpellingCommandResponse(response) {
+function shouldStopSpellingTtsForCommandResponse(command, response) {
+  if (response?.audio?.promptToken) return false;
+  const nextPhase = response?.subjectReadModel?.phase || response?.state?.phase || '';
+  return command === 'submit-answer' || (nextPhase && nextPhase !== 'session');
+}
+
+function applySpellingCommandResponse(response, { command = '' } = {}) {
   if (response?.projections?.rewards?.toastEvents?.length) {
     store.pushToasts(response.projections.rewards.toastEvents);
   }
   if (response?.projections?.rewards?.events?.length) {
     store.pushMonsterCelebrations(response.projections.rewards.events);
+  }
+  if (shouldStopSpellingTtsForCommandResponse(command, response)) {
+    tts.stop();
   }
   store.reloadFromRepositories({ preserveRoute: true });
   if (response?.audio?.promptToken) {
@@ -1969,7 +1978,7 @@ async function sendSpellingCommand(command, payload = {}) {
     command,
     payload,
   });
-  applySpellingCommandResponse(response);
+  applySpellingCommandResponse(response, { command });
   return response;
 }
 

--- a/src/platform/app/create-app-controller.js
+++ b/src/platform/app/create-app-controller.js
@@ -132,6 +132,12 @@ export function createAppController({
     return true;
   }
 
+  function shouldStopSpellingAudio(previousSubjectUi, nextSubjectUi, transition) {
+    if (transition?.audio?.word || transition?.audio?.promptToken) return false;
+    if (previousSubjectUi?.phase !== 'session') return nextSubjectUi?.phase && nextSubjectUi.phase !== 'session';
+    return nextSubjectUi?.phase !== 'session' || Boolean(nextSubjectUi?.awaitingAdvance);
+  }
+
   function applySubjectTransition(subjectId, transition) {
     if (!transition) return false;
     const previousSubjectUi = store.getState().subjectUi[subjectId] || null;
@@ -168,6 +174,11 @@ export function createAppController({
       subjectId,
       tab: store.getState().route.tab || 'practice',
     });
+
+    if (subjectId === 'spelling' && shouldStopSpellingAudio(previousSubjectUi, nextSubjectUi, transition)) {
+      clearDeferredAudio();
+      tts.stop();
+    }
 
     if (transition.audio?.word) {
       if (transition.deferAudioUntilFlowTransitionEnd) {

--- a/tests/app-controller.test.js
+++ b/tests/app-controller.test.js
@@ -220,6 +220,35 @@ test('controller dispatches spelling transitions through store, repositories, ev
   assert.ok(controller.repositories.practiceSessions.list(learnerId).length >= 1);
 });
 
+test('controller stops spelling audio when feedback has no auto-speak cue', () => {
+  installMemoryStorage();
+  const tts = {
+    spoken: [],
+    stopCalls: 0,
+    speak(payload) {
+      this.spoken.push(payload);
+    },
+    stop() {
+      this.stopCalls += 1;
+    },
+    warmup() {},
+  };
+  const controller = createLocalAppController({ tts });
+  const learnerId = controller.store.getState().learners.selectedId;
+  controller.services.spelling.savePrefs(learnerId, { mode: 'smart', roundLength: '1' });
+
+  controller.dispatch('open-subject', { subjectId: 'spelling' });
+  controller.dispatch('spelling-start');
+  const stopCallsBeforeAnswer = tts.stopCalls;
+  const answer = controller.store.getState().subjectUi.spelling.session.currentCard.word.word;
+
+  controller.dispatch('spelling-submit-form', { formData: typedFormData(answer) });
+
+  assert.equal(controller.store.getState().subjectUi.spelling.awaitingAdvance, true);
+  assert.equal(tts.spoken.length, 1);
+  assert.equal(tts.stopCalls, stopCallsBeforeAnswer + 1);
+});
+
 test('controller can defer spelling start audio until the flow transition flushes', () => {
   installMemoryStorage();
   const controller = createLocalAppController();

--- a/tests/server-spelling-engine-parity.test.js
+++ b/tests/server-spelling-engine-parity.test.js
@@ -162,6 +162,7 @@ test('worker spelling command route starts, submits, continues, and completes se
     assert.equal(step.body.subjectReadModel.session.currentCard.word, undefined);
     assert.equal(step.body.subjectReadModel.session.currentCard.prompt.sentence, undefined);
     assert.ok(step.body.audio.promptToken);
+    assert.ok(step.body.subjectReadModel.audio.promptToken);
 
     const legacy = server.DB.db.prepare('SELECT status FROM practice_sessions WHERE id = ?').get('legacy-active');
     assert.equal(legacy.status, 'abandoned');
@@ -176,6 +177,8 @@ test('worker spelling command route starts, submits, continues, and completes se
     assert.equal(step.body.subjectReadModel.phase, 'session');
     assert.equal(step.body.subjectReadModel.awaitingAdvance, true);
     assert.equal(step.body.subjectReadModel.feedback.headline, 'Good first hit.');
+    assert.equal(step.body.audio, null);
+    assert.ok(step.body.subjectReadModel.audio.promptToken);
 
     step = await postCommand(server, {
       command: 'continue-session',
@@ -185,6 +188,8 @@ test('worker spelling command route starts, submits, continues, and completes se
     assert.equal(step.response.status, 200);
     assert.equal(step.body.subjectReadModel.phase, 'session');
     assert.equal(step.body.subjectReadModel.awaitingAdvance, false);
+    assert.ok(step.body.audio.promptToken);
+    assert.ok(step.body.subjectReadModel.audio.promptToken);
 
     step = await postCommand(server, {
       command: 'submit-answer',
@@ -195,6 +200,8 @@ test('worker spelling command route starts, submits, continues, and completes se
     assert.equal(step.response.status, 200);
     assert.equal(step.body.subjectReadModel.awaitingAdvance, true);
     assert.equal(step.body.subjectReadModel.feedback.headline, 'Correct.');
+    assert.equal(step.body.audio, null);
+    assert.ok(step.body.subjectReadModel.audio.promptToken);
 
     step = await postCommand(server, {
       command: 'continue-session',
@@ -203,6 +210,8 @@ test('worker spelling command route starts, submits, continues, and completes se
     });
     assert.equal(step.response.status, 200);
     assert.equal(step.body.subjectReadModel.phase, 'summary');
+    assert.equal(step.body.audio, null);
+    assert.equal(step.body.subjectReadModel.audio, null);
     assert.ok(step.body.events.some((event) => event.type === 'spelling.session-completed'));
 
     const subject = server.DB.db.prepare(`


### PR DESCRIPTION
## Summary
- separate spelling replay cues from command auto-speak cues so submit-answer does not replay the current prompt
- stop active spelling TTS when feedback or summary transitions have no new auto-speak cue
- cover the Worker command audio contract and controller TTS stop behaviour

## Verification
- npm test
- npm run check