### PR TITLE
fix(spelling): keep setup after summary prefs

### DIFF
--- a/tests/server-spelling-engine-parity.test.js
+++ b/tests/server-spelling-engine-parity.test.js
@@ -225,6 +225,44 @@ test('worker spelling command route starts, submits, continues, and completes se
     `).get();
     assert.equal(latest.status, 'completed');
     assert.equal(JSON.parse(latest.summary_json).totalWords, 1);
+
+    step = await postCommand(server, {
+      command: 'save-prefs',
+      requestId: 'spell-save-prefs-after-summary',
+      expectedLearnerRevision: 5,
+      payload: {
+        prefs: {
+          roundLength: '5',
+          yearFilter: 'extra',
+          autoSpeak: false,
+        },
+      },
+    });
+    assert.equal(step.response.status, 200);
+    assert.equal(step.body.subjectReadModel.phase, 'dashboard');
+    assert.equal(step.body.subjectReadModel.summary, null);
+    assert.equal(step.body.subjectReadModel.prefs.roundLength, '5');
+    assert.equal(step.body.subjectReadModel.prefs.yearFilter, 'extra');
+    assert.equal(step.body.subjectReadModel.prefs.autoSpeak, false);
+
+    const subjectAfterPrefs = server.DB.db.prepare(`
+      SELECT ui_json, data_json
+      FROM child_subject_state
+      WHERE learner_id = 'learner-a' AND subject_id = 'spelling'
+    `).get();
+    const uiAfterPrefs = JSON.parse(subjectAfterPrefs.ui_json);
+    const dataAfterPrefs = JSON.parse(subjectAfterPrefs.data_json);
+    assert.equal(uiAfterPrefs.phase, 'dashboard');
+    assert.equal(uiAfterPrefs.summary, null);
+    assert.equal(dataAfterPrefs.prefs.roundLength, '5');
+    assert.equal(dataAfterPrefs.prefs.yearFilter, 'extra');
+
+    const completedCount = server.DB.db.prepare(`
+      SELECT COUNT(*) AS count
+      FROM practice_sessions
+      WHERE learner_id = 'learner-a' AND subject_id = 'spelling' AND status = 'completed'
+    `).get().count;
+    assert.equal(completedCount, 1);
   } finally {
     server.close();
   }

--- a/worker/src/subjects/spelling/engine.js
+++ b/worker/src/subjects/spelling/engine.js
@@ -225,6 +225,11 @@ function staleSessionError(command) {
   });
 }
 
+function stateAfterPreferenceChange(currentState) {
+  if (currentState?.phase === 'session' && currentState.session) return currentState;
+  return createInitialSpellingState();
+}
+
 export function createServerSpellingEngine({
   now = Date.now,
   random = Math.random,
@@ -284,7 +289,7 @@ export function createServerSpellingEngine({
         transition = service.endSession(learnerId, currentState);
       } else if (command === 'save-prefs') {
         const prefs = service.savePrefs(learnerId, payload.prefs || payload);
-        transition = buildTransition(service.initState(currentState, learnerId), { events: [], audio: null });
+        transition = buildTransition(stateAfterPreferenceChange(currentState), { events: [], audio: null });
         transition.prefs = prefs;
       } else if (command === 'reset-learner') {
         service.resetLearner(learnerId);


### PR DESCRIPTION
## Summary
- Reset server-owned spelling UI to the clean setup/dashboard state when preferences are saved after a completed summary.
- Preserve active sessions while still allowing completed practice-session records to remain stored.
- Add regression coverage for saving round length, pool, and option prefs from a stale summary-backed server state.

## Verification
- node --test tests/server-spelling-engine-parity.test.js
- npm test
- npm run check