### PR TITLE
feat(spelling): cache Gemini dictation audio

### DIFF
--- a/docs/spelling-parity.md
+++ b/docs/spelling-parity.md
@@ -22,7 +22,7 @@ Provider-specific browser/API TTS traffic and exact browser playback timing were
 | Analytics | Aggregate secure/due/trouble/fresh/accuracy stats and year-band splits were present; legacy also exposed searchable word-bank progress and direct bank drill | Aggregate analytics matched, but searchable word bank was not rebuilt | Documented remaining delta only | Partial |
 | Preferences | Mode, year filter, session size, auto-play, cloze toggle, audio provider/model/key/rate controls | Core spelling prefs matched except richer model/key/rate controls | Added a profile-level provider switch for OpenAI, Gemini, and local browser speech | Partial; provider choice is exposed, while model/key/rate controls remain deferred |
 | Resume / abandon / continue | Legacy confirmed before discarding/switching, auto-advanced after marked cards, and did not preserve platform-level resume across learner switches | Manual Continue button and no end-session confirm were real mismatches; platform resume was intentionally broader | Restored end/switch confirmation and auto-advance; kept platform-level resume as an intentional delta | Partial, with key regressions fixed |
-| TTS / audio behaviour | Auto-play, replay, slow replay, audio reset on switch/home/profile change, browser/API provider options, warm-up behaviour | Browser dictation loop existed; provider-specific options and warm-up were not rebuilt | Restored shortcut replay flow, ensured new rounds stop prior audio before starting, and added selected-provider dictation without automatic fallback | Partial; provider choice is restored, while warm-up and detailed voice controls remain deferred |
+| TTS / audio behaviour | Auto-play, replay, slow replay, audio reset on switch/home/profile change, browser/API provider options, warm-up behaviour | Browser dictation loop existed; provider-specific options and warm-up were not rebuilt | Restored shortcut replay flow, ensured new rounds stop prior audio before starting, added selected-provider dictation without automatic fallback, and added cache-first buffered Gemini dictation audio with cache-only warm-up | Partial; provider choice, buffered Gemini voice choice, and cache-only Gemini warm-up are restored, while detailed model/key/rate controls remain deferred |
 | Keyboard / interaction flow | Enter submit, Esc replay, Shift+Esc slow replay, Alt+1/2/3 start modes, Alt+S skip, Alt+K focus, ignore Alt shortcuts while typing in unrelated inputs | Most subject shortcuts were missing | Restored Esc / Shift+Esc / Alt+1/2/3 / Alt+S / Alt+K with guarded typing behaviour | Mostly matched inside active Spelling practice |
 | Live-card hint leakage | Legacy explicitly hid the family during live recall and only surfaced family words after the engine allowed it | Pass 9 leaked family/family-count chips during the live card | Removed live family leakage and restored the hidden-family note | Matched |
 
@@ -71,8 +71,8 @@ These deltas remain on purpose.
 
 3. **Detailed TTS controls are still not restored**
    - The older single-page app exposed keys, model/voice controls, backup Gemini key handling, and warm-up behaviour.
-   - The rebuilt production platform exposes provider choice in Profile Settings and keeps provider keys on the Worker side.
-   - The UI still does not expose model/voice/rate controls.
+   - The rebuilt production platform exposes provider choice and buffered Gemini voice choice in Profile Settings, keeps provider keys on the Worker side, and supports cache-only warm-up for buffered Gemini dictation audio.
+   - The UI still does not expose raw model/key/rate controls.
 
 4. **Searchable word-bank drill UI is still not restored**
    - Legacy exposed searchable word-bank progress and direct single-word drill launch from that bank.

--- a/docs/spelling-service.md
+++ b/docs/spelling-service.md
@@ -102,9 +102,9 @@ Live Spelling command read models no longer expose the current answer, word slug
 }
 ```
 
-The browser sends only `learnerId`, `promptToken`, and playback options to `/api/tts`. The Worker then reloads the current server-owned Spelling session, validates that the token still matches the active prompt, derives the transcript server-side, and only then calls the protected OpenAI TTS fallback. Arbitrary browser-supplied `word` and `sentence` payloads are rejected.
+The browser sends only `learnerId`, `promptToken`, and playback options to `/api/tts`. The Worker then reloads the current server-owned Spelling session, validates that the token still matches the active prompt, derives the transcript server-side, and resolves the selected provider without trusting browser-supplied transcript text. Arbitrary browser-supplied `word` and `sentence` payloads are rejected.
 
-This prepares the hybrid audio path: pre-generated/static audio can be checked first for the same prompt identity, with protected OpenAI fallback retained for prompts that are not ready yet.
+Gemini dictation audio now uses a cache-first buffered path. The Worker derives a deterministic R2 asset key from the active Gemini model, buffered voice, speed, published prompt content key, slug, and sentence index; it serves matching `SPELLING_AUDIO_BUCKET` objects before provider generation and stores newly generated Gemini audio back under the same key. Cache-only warm-up requests can prefill those assets without returning playback bytes, while normal OpenAI requests remain protected behind Worker-side credentials and rate limits.
 
 ## Persisted subject-state invariants
 
@@ -189,7 +189,7 @@ What was brought back into line with the direct legacy baseline:
 What remains intentionally different:
 
 - platform-level resume across learner switches/navigation/reload still stays broader than legacy
-- model/voice/rate TTS controls and warm-up behaviour are still deferred
+- detailed model/voice/rate UI controls remain deferred; buffered Gemini voice choice and cache-only warm-up are available through the Worker-owned audio path
 
 See `docs/spelling-parity.md` for the full matrix and the explicit remaining deltas.
 

--- a/shared/spelling-audio.js
+++ b/shared/spelling-audio.js
@@ -111,21 +111,30 @@ export function buildBufferedSpeechPrompt({ wordText, sentence, slow }) {
 export function buildAudioAssetKey({
   voice,
   speed,
+  contentKey,
   slug,
   sentenceIndex,
   extension = DEFAULT_AUDIO_EXTENSION,
 }) {
   const safeVoice = encodeURIComponent(String(voice || '').trim());
   const safeSpeed = encodeURIComponent(String(speed || '').trim());
+  const safeContentKey = encodeURIComponent(String(contentKey || '').trim());
   const safeSlug = encodeURIComponent(String(slug || '').trim());
   const safeSentenceIndex = Number(sentenceIndex);
   const safeExtension = String(extension || DEFAULT_AUDIO_EXTENSION).replace(/^\./, '');
 
-  if (!safeVoice || !safeSpeed || !safeSlug || !Number.isInteger(safeSentenceIndex) || safeSentenceIndex < 0) {
-    throw new Error('A valid voice, speed, slug, and sentence index are required.');
+  if (
+    !safeVoice
+    || !safeSpeed
+    || !safeContentKey
+    || !safeSlug
+    || !Number.isInteger(safeSentenceIndex)
+    || safeSentenceIndex < 0
+  ) {
+    throw new Error('A valid voice, speed, content key, slug, and sentence index are required.');
   }
 
-  return `${SPELLING_AUDIO_ROOT_PREFIX}/${SPELLING_AUDIO_MODEL}/${safeVoice}/${safeSpeed}/${safeSlug}/${safeSentenceIndex}.${safeExtension}`;
+  return `${SPELLING_AUDIO_ROOT_PREFIX}/${SPELLING_AUDIO_MODEL}/${safeVoice}/${safeSpeed}/${safeContentKey}/${safeSlug}/${safeSentenceIndex}.${safeExtension}`;
 }
 
 export function buildIndexedAudioFilename({

--- a/shared/spelling-audio.js
+++ b/shared/spelling-audio.js
@@ -109,6 +109,7 @@ export function buildBufferedSpeechPrompt({ wordText, sentence, slow }) {
 }
 
 export function buildAudioAssetKey({
+  model = SPELLING_AUDIO_MODEL,
   voice,
   speed,
   contentKey,
@@ -116,6 +117,7 @@ export function buildAudioAssetKey({
   sentenceIndex,
   extension = DEFAULT_AUDIO_EXTENSION,
 }) {
+  const safeModel = encodeURIComponent(String(model || SPELLING_AUDIO_MODEL).trim());
   const safeVoice = encodeURIComponent(String(voice || '').trim());
   const safeSpeed = encodeURIComponent(String(speed || '').trim());
   const safeContentKey = encodeURIComponent(String(contentKey || '').trim());
@@ -124,17 +126,18 @@ export function buildAudioAssetKey({
   const safeExtension = String(extension || DEFAULT_AUDIO_EXTENSION).replace(/^\./, '');
 
   if (
-    !safeVoice
+    !safeModel
+    || !safeVoice
     || !safeSpeed
     || !safeContentKey
     || !safeSlug
     || !Number.isInteger(safeSentenceIndex)
     || safeSentenceIndex < 0
   ) {
-    throw new Error('A valid voice, speed, content key, slug, and sentence index are required.');
+    throw new Error('A valid model, voice, speed, content key, slug, and sentence index are required.');
   }
 
-  return `${SPELLING_AUDIO_ROOT_PREFIX}/${SPELLING_AUDIO_MODEL}/${safeVoice}/${safeSpeed}/${safeContentKey}/${safeSlug}/${safeSentenceIndex}.${safeExtension}`;
+  return `${SPELLING_AUDIO_ROOT_PREFIX}/${safeModel}/${safeVoice}/${safeSpeed}/${safeContentKey}/${safeSlug}/${safeSentenceIndex}.${safeExtension}`;
 }
 
 export function buildIndexedAudioFilename({

--- a/shared/spelling-audio.js
+++ b/shared/spelling-audio.js
@@ -1,0 +1,169 @@
+const DEFAULT_AUDIO_EXTENSION = 'mp3';
+
+export const SUPPORTED_BUFFERED_AUDIO_FORMATS = Object.freeze(['mp3', 'wav']);
+export const SPELLING_AUDIO_VERSION = 'v1';
+export const SPELLING_AUDIO_MODEL = 'gemini-3.1-flash-tts-preview';
+export const SPELLING_AUDIO_ROOT_PREFIX = `spelling-audio/${SPELLING_AUDIO_VERSION}`;
+export const SPELLING_AUDIO_MANIFEST_KEY = `${SPELLING_AUDIO_ROOT_PREFIX}/manifest.json`;
+
+export const BUFFERED_GEMINI_VOICE_OPTIONS = Object.freeze([
+  Object.freeze({
+    id: 'Iapetus',
+    role: 'male',
+    label: 'Pre-cached UK male',
+    blurb: 'Clear',
+  }),
+  Object.freeze({
+    id: 'Sulafat',
+    role: 'female',
+    label: 'Pre-cached UK female',
+    blurb: 'Warm',
+  }),
+]);
+
+export const BUFFERED_AUDIO_SPEED_OPTIONS = Object.freeze([
+  Object.freeze({
+    id: 'standard',
+    label: 'Standard',
+    slow: false,
+  }),
+  Object.freeze({
+    id: 'slow',
+    label: 'Slow',
+    slow: true,
+  }),
+]);
+
+export const DEFAULT_BUFFERED_GEMINI_VOICE = BUFFERED_GEMINI_VOICE_OPTIONS[0].id;
+
+function slugifySentenceFragment(sentence) {
+  return String(sentence || '')
+    .trim()
+    .toLowerCase()
+    .replace(/['"]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64)
+    .replace(/-+$/g, '');
+}
+
+export function bufferedVoiceById(voiceId) {
+  return BUFFERED_GEMINI_VOICE_OPTIONS.find((voice) => voice.id === voiceId) || null;
+}
+
+export function normaliseBufferedGeminiVoice(value, fallback = DEFAULT_BUFFERED_GEMINI_VOICE) {
+  const voiceId = String(value || '').trim();
+  if (bufferedVoiceById(voiceId)) return voiceId;
+  return bufferedVoiceById(fallback) ? fallback : DEFAULT_BUFFERED_GEMINI_VOICE;
+}
+
+export function bufferedSpeedById(speedId) {
+  return BUFFERED_AUDIO_SPEED_OPTIONS.find((speed) => speed.id === speedId) || null;
+}
+
+export function speedIdForSlow(slow = false) {
+  return slow ? 'slow' : 'standard';
+}
+
+export function listWordSentences(word) {
+  if (!word) return [];
+  if (Array.isArray(word.sentences) && word.sentences.length) return word.sentences.slice();
+  if (word.sentence) return [word.sentence];
+  return [];
+}
+
+export function resolveSentenceIndex(word, sentence) {
+  const sentences = listWordSentences(word);
+  if (!sentences.length) return -1;
+  const target = String(sentence || '');
+  const matchIndex = sentences.findIndex((item) => item === target);
+  return matchIndex >= 0 ? matchIndex : 0;
+}
+
+export function buildBufferedDictationTranscript(wordText, sentence) {
+  const cleanWord = String(wordText || '').trim();
+  const cleanSentence = String(sentence || '').trim();
+  if (!cleanWord) return cleanSentence;
+  return cleanSentence
+    ? `The word is ${cleanWord}. ${cleanSentence} The word is ${cleanWord}.`
+    : `The word is ${cleanWord}. The word is ${cleanWord}.`;
+}
+
+export function buildBufferedSpeechPrompt({ wordText, sentence, slow }) {
+  const transcript = buildBufferedDictationTranscript(wordText, sentence);
+  const paceDirection = slow
+    ? 'Speak slowly but crisply, with light spacing between phrases.'
+    : 'Speak clearly at a brisk classroom dictation pace.';
+
+  return [
+    'Generate speech only.',
+    'Do not speak any instructions, headings, or labels.',
+    'Use formal UK English for a KS2 spelling dictation.',
+    'Use a clear, neutral southern British classroom accent with precise enunciation.',
+    'Sound like a careful primary teacher giving a spelling test.',
+    'Avoid casual delivery and avoid American pronunciation.',
+    paceDirection,
+    'TRANSCRIPT:',
+    transcript,
+  ].join('\n');
+}
+
+export function buildAudioAssetKey({
+  voice,
+  speed,
+  slug,
+  sentenceIndex,
+  extension = DEFAULT_AUDIO_EXTENSION,
+}) {
+  const safeVoice = encodeURIComponent(String(voice || '').trim());
+  const safeSpeed = encodeURIComponent(String(speed || '').trim());
+  const safeSlug = encodeURIComponent(String(slug || '').trim());
+  const safeSentenceIndex = Number(sentenceIndex);
+  const safeExtension = String(extension || DEFAULT_AUDIO_EXTENSION).replace(/^\./, '');
+
+  if (!safeVoice || !safeSpeed || !safeSlug || !Number.isInteger(safeSentenceIndex) || safeSentenceIndex < 0) {
+    throw new Error('A valid voice, speed, slug, and sentence index are required.');
+  }
+
+  return `${SPELLING_AUDIO_ROOT_PREFIX}/${SPELLING_AUDIO_MODEL}/${safeVoice}/${safeSpeed}/${safeSlug}/${safeSentenceIndex}.${safeExtension}`;
+}
+
+export function buildIndexedAudioFilename({
+  sentenceIndex,
+  sentence,
+  extension = DEFAULT_AUDIO_EXTENSION,
+}) {
+  const safeSentenceIndex = Number(sentenceIndex);
+  const safeExtension = String(extension || DEFAULT_AUDIO_EXTENSION).replace(/^\./, '');
+
+  if (!Number.isInteger(safeSentenceIndex) || safeSentenceIndex < 0) {
+    throw new Error('Sentence index must be a non-negative integer.');
+  }
+
+  const prefix = String(safeSentenceIndex).padStart(2, '0');
+  const sentenceSlug = slugifySentenceFragment(sentence);
+  return sentenceSlug
+    ? `${prefix}-${sentenceSlug}.${safeExtension}`
+    : `${prefix}.${safeExtension}`;
+}
+
+export function buildStaticSpellingAudioManifest() {
+  return {
+    version: SPELLING_AUDIO_VERSION,
+    model: SPELLING_AUDIO_MODEL,
+    manifestKey: SPELLING_AUDIO_MANIFEST_KEY,
+    defaultFormat: DEFAULT_AUDIO_EXTENSION,
+    supportedFormats: SUPPORTED_BUFFERED_AUDIO_FORMATS.slice(),
+    voices: BUFFERED_GEMINI_VOICE_OPTIONS.map((voice) => ({
+      id: voice.id,
+      role: voice.role,
+      label: voice.label,
+      blurb: voice.blurb,
+    })),
+    speeds: BUFFERED_AUDIO_SPEED_OPTIONS.map((speed) => ({
+      id: speed.id,
+      label: speed.label,
+      slow: speed.slow,
+    })),
+  };
+}

--- a/shared/spelling/service.js
+++ b/shared/spelling/service.js
@@ -7,7 +7,10 @@ import {
   createSpellingSessionCompletedEvent,
   createSpellingWordSecuredEvent,
 } from '../../src/subjects/spelling/events.js';
-import { normaliseTtsProvider } from '../../src/subjects/spelling/tts-providers.js';
+import {
+  normaliseBufferedGeminiVoice,
+  normaliseTtsProvider,
+} from '../../src/subjects/spelling/tts-providers.js';
 import {
   cloneSerialisable,
   createInitialSpellingState,
@@ -154,6 +157,7 @@ function normalisePrefs(rawPrefs = {}) {
     autoSpeak: normaliseBoolean(rawPrefs.autoSpeak, true),
     extraWordFamilies: normaliseBoolean(rawPrefs.extraWordFamilies, false),
     ttsProvider: normaliseTtsProvider(rawPrefs.ttsProvider),
+    bufferedGeminiVoice: normaliseBufferedGeminiVoice(rawPrefs.bufferedGeminiVoice),
   };
 }
 
@@ -930,6 +934,7 @@ export function createSpellingService({ repository, storage, tts, now, random, c
     saveJson(resolvedStorage, prefsKey(learnerId), {
       ...defaultSpellingPrefs(),
       ttsProvider: currentPrefs.ttsProvider,
+      bufferedGeminiVoice: currentPrefs.bufferedGeminiVoice,
     });
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -22,7 +22,12 @@ import { createPracticeStreakSubscriber } from './platform/events/index.js';
 import { createSubjectCommandClient } from './platform/runtime/subject-command-client.js';
 import { createReadModelClient } from './platform/runtime/read-model-client.js';
 import { createPlatformTts } from './subjects/spelling/tts.js';
-import { DEFAULT_TTS_PROVIDER, normaliseTtsProvider } from './subjects/spelling/tts-providers.js';
+import {
+  DEFAULT_BUFFERED_GEMINI_VOICE,
+  DEFAULT_TTS_PROVIDER,
+  normaliseBufferedGeminiVoice,
+  normaliseTtsProvider,
+} from './subjects/spelling/tts-providers.js';
 import { createSpellingReadModelService } from './subjects/spelling/client-read-models.js';
 import { resolveSpellingShortcut } from './subjects/spelling/shortcuts.js';
 import {
@@ -201,9 +206,20 @@ function selectedTtsProvider() {
   }
 }
 
+function selectedBufferedGeminiVoice() {
+  const learnerId = store?.getState?.()?.learners?.selectedId;
+  if (!learnerId) return DEFAULT_BUFFERED_GEMINI_VOICE;
+  try {
+    return normaliseBufferedGeminiVoice(services.spelling?.getPrefs?.(learnerId)?.bufferedGeminiVoice);
+  } catch {
+    return DEFAULT_BUFFERED_GEMINI_VOICE;
+  }
+}
+
 const tts = createPlatformTts({
   fetchFn: credentialFetch,
   provider: selectedTtsProvider,
+  bufferedVoice: selectedBufferedGeminiVoice,
 });
 
 /* Audio replay affordance state — maintained outside the store because it is a
@@ -803,7 +819,7 @@ async function resetServerSyncedLearnerProgress(learnerId) {
   store.reloadFromRepositories({ preserveRoute: true });
 }
 
-async function profileTtsPayload(provider) {
+async function profileTtsPayload(provider, bufferedGeminiVoice = selectedBufferedGeminiVoice()) {
   const learnerId = store.getState().learners.selectedId;
   if (provider === 'browser' || !learnerId) {
     return {
@@ -811,6 +827,7 @@ async function profileTtsPayload(provider) {
       word: 'early',
       sentence: 'The birds sang early in the day.',
       provider,
+      bufferedGeminiVoice,
       kind: 'test',
     };
   }
@@ -831,6 +848,7 @@ async function profileTtsPayload(provider) {
   return {
     ...cue,
     provider,
+    bufferedGeminiVoice,
     kind: 'test',
   };
 }
@@ -1207,6 +1225,7 @@ function buildSurfaceChromeModel(appState) {
     learnerLabel: learner ? `${learner.name} · ${learner.yearGroup}` : 'No learner selected',
     learnerOptions,
     ttsProvider: learnerId ? selectedTtsProvider() : DEFAULT_TTS_PROVIDER,
+    bufferedGeminiVoice: learnerId ? selectedBufferedGeminiVoice() : DEFAULT_BUFFERED_GEMINI_VOICE,
     signedInAs: boot.session.signedIn ? (boot.session.email || '') : null,
     session: boot.session,
     persistence: {
@@ -1596,8 +1615,9 @@ function handleGlobalAction(action, data) {
 
   if (action === 'tts-test') {
     const provider = normaliseTtsProvider(data.provider, selectedTtsProvider());
+    const bufferedGeminiVoice = normaliseBufferedGeminiVoice(data.bufferedGeminiVoice, selectedBufferedGeminiVoice());
     const token = beginProfileTtsTest(provider);
-    profileTtsPayload(provider)
+    profileTtsPayload(provider, bufferedGeminiVoice)
       .then((payload) => tts.speak(payload))
       .then((ok) => finishProfileTtsTest(token, Boolean(ok)))
       .catch(() => finishProfileTtsTest(token, false));
@@ -1610,6 +1630,7 @@ function handleGlobalAction(action, data) {
     runSpellingCommand('save-prefs', {
       prefs: {
         ttsProvider: normaliseTtsProvider(formData.get('ttsProvider')),
+        bufferedGeminiVoice: normaliseBufferedGeminiVoice(formData.get('bufferedGeminiVoice')),
       },
     });
     tts.stop();

--- a/src/platform/app/create-app-controller.js
+++ b/src/platform/app/create-app-controller.js
@@ -3,7 +3,10 @@ import { createSubjectRuntimeBoundary } from '../core/subject-runtime.js';
 import { createEventRuntime, createPracticeStreakSubscriber } from '../events/index.js';
 import { createSpellingAutoAdvanceController } from '../../subjects/spelling/auto-advance.js';
 import { resolveSpellingShortcut } from '../../subjects/spelling/shortcuts.js';
-import { normaliseTtsProvider } from '../../subjects/spelling/tts-providers.js';
+import {
+  normaliseBufferedGeminiVoice,
+  normaliseTtsProvider,
+} from '../../subjects/spelling/tts-providers.js';
 import {
   isMonsterCelebrationEvent,
   shouldDelayMonsterCelebrations,
@@ -303,6 +306,7 @@ export function createAppController({
         word: 'early',
         sentence: 'The birds sang early in the day.',
         provider: normaliseTtsProvider(data.provider),
+        bufferedGeminiVoice: normaliseBufferedGeminiVoice(data.bufferedGeminiVoice),
         kind: 'test',
       });
       return true;
@@ -312,6 +316,7 @@ export function createAppController({
       const formData = data.formData;
       services.spelling?.savePrefs?.(learnerId, {
         ttsProvider: normaliseTtsProvider(formData.get('ttsProvider')),
+        bufferedGeminiVoice: normaliseBufferedGeminiVoice(formData.get('bufferedGeminiVoice')),
       });
       store.updateLearner(learnerId, {
         name: String(formData.get('name') || 'Learner').trim() || 'Learner',

--- a/src/platform/ui/render.js
+++ b/src/platform/ui/render.js
@@ -5,7 +5,11 @@ import { subjectTabLabel } from '../core/subject-runtime.js';
 import { monsterAsset, monsterAssetSrcSet } from '../game/monsters.js';
 import { monsterSummary, monsterSummaryFromSpellingAnalytics } from '../game/monster-system.js';
 import { readOnlyLearnerActionBlockReason } from '../hubs/shell-access.js';
-import { normaliseTtsProvider } from '../../subjects/spelling/tts-providers.js';
+import {
+  BUFFERED_GEMINI_VOICE_OPTIONS,
+  normaliseBufferedGeminiVoice,
+  normaliseTtsProvider,
+} from '../../subjects/spelling/tts-providers.js';
 
 const TTS_PROVIDER_OPTIONS = [
   { value: 'openai', label: 'OpenAI' },
@@ -608,6 +612,13 @@ function renderTtsProviderOptions(provider) {
   `).join('');
 }
 
+function renderBufferedGeminiVoiceOptions(voice) {
+  const selected = normaliseBufferedGeminiVoice(voice);
+  return BUFFERED_GEMINI_VOICE_OPTIONS.map((option) => `
+    <option value="${escapeHtml(option.id)}" ${selected === option.id ? 'selected' : ''}>${escapeHtml(option.label)}</option>
+  `).join('');
+}
+
 function renderProfileLearnerSelect(appState) {
   const learners = appState.learners.allIds.map((id) => appState.learners.byId[id]).filter(Boolean);
   if (!learners.length) {
@@ -683,7 +694,9 @@ function renderLearnerManager(appState, context) {
     `;
   }
   const accent = safeInlineColor(learner.avatarColor);
-  const ttsProvider = normaliseTtsProvider(context.services?.spelling?.getPrefs?.(learner.id)?.ttsProvider);
+  const spellingPrefs = context.services?.spelling?.getPrefs?.(learner.id) || {};
+  const ttsProvider = normaliseTtsProvider(spellingPrefs.ttsProvider);
+  const bufferedGeminiVoice = normaliseBufferedGeminiVoice(spellingPrefs.bufferedGeminiVoice);
   const learnerCount = appState.learners.allIds.length;
   const subjectCount = registeredSubjects(context).length;
   const liveSubjectCount = registeredSubjects(context).filter((subject) => subject.available !== false).length;
@@ -761,6 +774,12 @@ function renderLearnerManager(appState, context) {
               </button>
             </div>
           </div>
+          <label class="profile-form-field profile-form-field-wide">
+            <span>Pre-cached Gemini voice</span>
+            <select class="select" name="bufferedGeminiVoice">
+              ${renderBufferedGeminiVoiceOptions(bufferedGeminiVoice)}
+            </select>
+          </label>
         </div>
         <div class="profile-form-footer">
           <div class="profile-form-danger-actions">

--- a/src/subjects/spelling/client-read-models.js
+++ b/src/subjects/spelling/client-read-models.js
@@ -7,7 +7,12 @@ import {
   normaliseStats,
   normaliseYearFilter,
 } from './service-contract.js';
-import { DEFAULT_TTS_PROVIDER, normaliseTtsProvider } from './tts-providers.js';
+import {
+  DEFAULT_BUFFERED_GEMINI_VOICE,
+  DEFAULT_TTS_PROVIDER,
+  normaliseBufferedGeminiVoice,
+  normaliseTtsProvider,
+} from './tts-providers.js';
 
 function defaultPrefs() {
   const mode = 'smart';
@@ -18,6 +23,7 @@ function defaultPrefs() {
     showCloze: true,
     autoSpeak: true,
     ttsProvider: DEFAULT_TTS_PROVIDER,
+    bufferedGeminiVoice: DEFAULT_BUFFERED_GEMINI_VOICE,
   };
 }
 
@@ -30,6 +36,7 @@ function normalisePrefs(rawPrefs = {}) {
     showCloze: normaliseBoolean(rawPrefs.showCloze, true),
     autoSpeak: normaliseBoolean(rawPrefs.autoSpeak, true),
     ttsProvider: normaliseTtsProvider(rawPrefs.ttsProvider),
+    bufferedGeminiVoice: normaliseBufferedGeminiVoice(rawPrefs.bufferedGeminiVoice),
   };
 }
 

--- a/src/subjects/spelling/read-model.js
+++ b/src/subjects/spelling/read-model.js
@@ -1,6 +1,6 @@
 import { WORD_BY_SLUG as DEFAULT_WORD_BY_SLUG } from './data/word-data.js';
 import { normaliseYearFilter } from './service-contract.js';
-import { normaliseTtsProvider } from './tts-providers.js';
+import { normaliseBufferedGeminiVoice, normaliseTtsProvider } from './tts-providers.js';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const SECURE_STAGE = 4;
@@ -317,6 +317,7 @@ export function buildSpellingLearnerReadModel({
       roundLength: typeof prefs.roundLength === 'string' ? prefs.roundLength : '20',
       extraWordFamilies: Boolean(prefs.extraWordFamilies),
       ttsProvider: normaliseTtsProvider(prefs.ttsProvider),
+      bufferedGeminiVoice: normaliseBufferedGeminiVoice(prefs.bufferedGeminiVoice),
     },
     currentFocus,
     progressSnapshot: {

--- a/src/subjects/spelling/tts-providers.js
+++ b/src/subjects/spelling/tts-providers.js
@@ -1,3 +1,9 @@
+import {
+  BUFFERED_GEMINI_VOICE_OPTIONS,
+  DEFAULT_BUFFERED_GEMINI_VOICE,
+  normaliseBufferedGeminiVoice,
+} from '../../../shared/spelling-audio.js';
+
 export const DEFAULT_TTS_PROVIDER = 'openai';
 
 export const TTS_PROVIDER_IDS = Object.freeze([
@@ -11,3 +17,9 @@ export function normaliseTtsProvider(value, fallback = DEFAULT_TTS_PROVIDER) {
   if (TTS_PROVIDER_IDS.includes(provider)) return provider;
   return TTS_PROVIDER_IDS.includes(fallback) ? fallback : DEFAULT_TTS_PROVIDER;
 }
+
+export {
+  BUFFERED_GEMINI_VOICE_OPTIONS,
+  DEFAULT_BUFFERED_GEMINI_VOICE,
+  normaliseBufferedGeminiVoice,
+};

--- a/src/subjects/spelling/tts.js
+++ b/src/subjects/spelling/tts.js
@@ -1,5 +1,10 @@
 import { clamp } from '../../platform/core/utils.js';
-import { DEFAULT_TTS_PROVIDER, normaliseTtsProvider } from './tts-providers.js';
+import {
+  DEFAULT_BUFFERED_GEMINI_VOICE,
+  DEFAULT_TTS_PROVIDER,
+  normaliseBufferedGeminiVoice,
+  normaliseTtsProvider,
+} from './tts-providers.js';
 
 export function buildDictationTranscript({ word, sentence } = {}) {
   const spokenWord = typeof word === 'string' ? word : word?.word;
@@ -27,6 +32,14 @@ function resolveProvider(provider) {
     return normaliseTtsProvider(typeof provider === 'function' ? provider() : provider);
   } catch {
     return DEFAULT_TTS_PROVIDER;
+  }
+}
+
+function resolveBufferedVoice(bufferedVoice) {
+  try {
+    return normaliseBufferedGeminiVoice(typeof bufferedVoice === 'function' ? bufferedVoice() : bufferedVoice);
+  } catch {
+    return DEFAULT_BUFFERED_GEMINI_VOICE;
   }
 }
 
@@ -60,7 +73,7 @@ function playbackKind({ kind = '', slow = false } = {}) {
   return explicit || (slow ? 'slow' : 'normal');
 }
 
-function remotePromptRequest(payload = {}, providerId = DEFAULT_TTS_PROVIDER) {
+function remotePromptRequest(payload = {}, providerId = DEFAULT_TTS_PROVIDER, bufferedVoiceId = DEFAULT_BUFFERED_GEMINI_VOICE) {
   const learnerId = typeof payload.learnerId === 'string' ? payload.learnerId : '';
   const promptToken = typeof payload.promptToken === 'string' ? payload.promptToken : '';
   if (!learnerId || !promptToken) return null;
@@ -69,8 +82,10 @@ function remotePromptRequest(payload = {}, providerId = DEFAULT_TTS_PROVIDER) {
     promptToken,
     slow: Boolean(payload.slow),
     provider: providerId,
+    bufferedGeminiVoice: normaliseBufferedGeminiVoice(payload.bufferedGeminiVoice, bufferedVoiceId),
   };
   if (payload.wordOnly) body.wordOnly = true;
+  if (payload.cacheOnly) body.cacheOnly = true;
   if (typeof payload.slug === 'string' && payload.slug) body.slug = payload.slug;
   if (typeof payload.scope === 'string' && payload.scope) body.scope = payload.scope;
   return body;
@@ -81,6 +96,7 @@ export function createPlatformTts({
   endpoint = '/api/tts',
   remoteEnabled = shouldUseRemoteTts(),
   provider = DEFAULT_TTS_PROVIDER,
+  bufferedVoice = DEFAULT_BUFFERED_GEMINI_VOICE,
 } = {}) {
   let playbackId = 0;
   let currentAbort = null;
@@ -163,11 +179,38 @@ export function createPlatformTts({
     });
   }
 
-  async function speakWithRemote(payload = {}, providerId, token) {
+  function prefetchBufferedAudio(payload = {}, providerId, bufferedVoiceId) {
+    if (
+      providerId === 'gemini'
+      || payload.wordOnly
+      || !remoteEnabled
+      || typeof fetchFn !== 'function'
+      || !payload.promptToken
+    ) {
+      return;
+    }
+    const requestBody = remotePromptRequest(
+      { ...payload, cacheOnly: true },
+      'gemini',
+      bufferedVoiceId,
+    );
+    if (!requestBody) return;
+    fetchFn(endpoint, {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(requestBody),
+    }).catch(() => {});
+  }
+
+  async function speakWithRemote(payload = {}, providerId, bufferedVoiceId, token) {
     if (!remoteEnabled || typeof fetchFn !== 'function' || typeof Audio === 'undefined' || typeof URL === 'undefined') {
       return false;
     }
-    const requestBody = remotePromptRequest(payload, providerId);
+    const requestBody = remotePromptRequest(payload, providerId, bufferedVoiceId);
     if (!requestBody) return false;
 
     currentAbort = new AbortController();
@@ -178,7 +221,7 @@ export function createPlatformTts({
         method: 'POST',
         credentials: 'include',
         headers: {
-          accept: 'audio/mpeg',
+          accept: 'audio/*',
           'content-type': 'application/json',
         },
         signal: currentAbort.signal,
@@ -229,8 +272,10 @@ export function createPlatformTts({
     stop();
     const token = playbackId;
     const providerId = resolveProvider(payload.provider || provider);
+    const bufferedVoiceId = resolveBufferedVoice(payload.bufferedGeminiVoice || bufferedVoice);
+    prefetchBufferedAudio(payload, providerId, bufferedVoiceId);
     if (providerId === 'browser') return speakWithBrowser(payload);
-    return await speakWithRemote(payload, providerId, token);
+    return await speakWithRemote(payload, providerId, bufferedVoiceId, token);
   }
 
   return {

--- a/src/surfaces/profile/ProfileSettingsSurface.jsx
+++ b/src/surfaces/profile/ProfileSettingsSurface.jsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { TopNav } from '../shell/TopNav.jsx';
 import { PersistenceBanner } from '../shell/PersistenceBanner.jsx';
-import { normaliseTtsProvider } from '../../subjects/spelling/tts-providers.js';
+import {
+  BUFFERED_GEMINI_VOICE_OPTIONS,
+  normaliseBufferedGeminiVoice,
+  normaliseTtsProvider,
+} from '../../subjects/spelling/tts-providers.js';
 
 const TTS_PROVIDER_OPTIONS = [
   { value: 'openai', label: 'OpenAI' },
@@ -180,6 +184,7 @@ export function ProfileSettingsSurface({ appState, chrome, actions, subjectCount
 
   const accent = safeColour(learner.avatarColor);
   const ttsProvider = normaliseTtsProvider(chrome.ttsProvider);
+  const bufferedGeminiVoice = normaliseBufferedGeminiVoice(chrome.bufferedGeminiVoice);
   const submit = (event) => {
     event.preventDefault();
     actions.dispatch('learner-save-form', { formData: new FormData(event.currentTarget) });
@@ -189,6 +194,7 @@ export function ProfileSettingsSurface({ appState, chrome, actions, subjectCount
     const formData = form ? new FormData(form) : null;
     actions.dispatch('tts-test', {
       provider: normaliseTtsProvider(formData?.get('ttsProvider'), ttsProvider),
+      bufferedGeminiVoice: normaliseBufferedGeminiVoice(formData?.get('bufferedGeminiVoice'), bufferedGeminiVoice),
     });
   };
 
@@ -307,6 +313,14 @@ export function ProfileSettingsSurface({ appState, chrome, actions, subjectCount
                   </button>
                 </div>
               </div>
+              <label className="profile-form-field profile-form-field-wide">
+                <span>Pre-cached Gemini voice</span>
+                <select className="select" name="bufferedGeminiVoice" defaultValue={bufferedGeminiVoice} disabled={writeLocked}>
+                  {BUFFERED_GEMINI_VOICE_OPTIONS.map((option) => (
+                    <option value={option.id} key={option.id}>{option.label}</option>
+                  ))}
+                </select>
+              </label>
             </div>
             <div className="profile-form-footer">
               <div className="profile-form-danger-actions">

--- a/tests/app-controller.test.js
+++ b/tests/app-controller.test.js
@@ -178,10 +178,12 @@ test('controller persists profile TTS provider in spelling prefs', () => {
   formData.set('dailyMinutes', '15');
   formData.set('avatarColor', '#3E6FA8');
   formData.set('ttsProvider', 'gemini');
+  formData.set('bufferedGeminiVoice', 'Sulafat');
 
   controller.dispatch('learner-save-form', { formData });
 
   assert.equal(controller.services.spelling.getPrefs(learnerId).ttsProvider, 'gemini');
+  assert.equal(controller.services.spelling.getPrefs(learnerId).bufferedGeminiVoice, 'Sulafat');
 });
 
 test('controller dispatches profile TTS test through the selected provider', () => {
@@ -194,6 +196,7 @@ test('controller dispatches profile TTS test through the selected provider', () 
     word: 'early',
     sentence: 'The birds sang early in the day.',
     provider: 'browser',
+    bufferedGeminiVoice: 'Iapetus',
     kind: 'test',
   });
 });

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -79,6 +79,9 @@ test('profile settings learner profile fields declare autofill behaviour explici
   assert.match(html, /<input class="input" type="number"[^>]*name="dailyMinutes"[^>]*autocomplete="off"/);
   assert.match(html, /name="ttsProvider" value="openai"/);
   assert.match(html, /name="ttsProvider" value="browser"/);
+  assert.match(html, /name="bufferedGeminiVoice"/);
+  assert.match(html, /Pre-cached UK male/);
+  assert.match(html, /Pre-cached UK female/);
   assert.match(html, /data-action="tts-test"/);
 });
 

--- a/tests/spelling-tts.test.js
+++ b/tests/spelling-tts.test.js
@@ -54,6 +54,7 @@ test('platform TTS sends the selected Worker provider', async () => {
   const tts = createPlatformTts({
     remoteEnabled: true,
     provider: () => 'gemini',
+    bufferedVoice: () => 'Sulafat',
     fetchFn: async (url, init = {}) => {
       calls.push({
         url,
@@ -82,12 +83,13 @@ test('platform TTS sends the selected Worker provider', async () => {
     assert.equal(calls.length, 1);
     assert.equal(calls[0].url, '/api/tts');
     assert.equal(calls[0].credentials, 'include');
-    assert.equal(calls[0].headers.accept, 'audio/mpeg');
+    assert.equal(calls[0].headers.accept, 'audio/*');
     assert.deepEqual(calls[0].body, {
       learnerId: 'learner-a',
       promptToken: 'prompt-token-a',
       slow: true,
       provider: 'gemini',
+      bufferedGeminiVoice: 'Sulafat',
     });
 
     const wordOnlyResult = await tts.speak({
@@ -105,6 +107,7 @@ test('platform TTS sends the selected Worker provider', async () => {
       promptToken: 'prompt-token-b',
       slow: false,
       provider: 'gemini',
+      bufferedGeminiVoice: 'Sulafat',
       wordOnly: true,
     });
   } finally {
@@ -168,12 +171,21 @@ test('platform TTS allows a one-off provider override for profile tests', async 
     });
 
     assert.equal(result, true);
-    assert.equal(calls.length, 1);
+    assert.equal(calls.length, 2);
     assert.deepEqual(calls[0].body, {
       learnerId: 'learner-a',
       promptToken: 'prompt-token-test',
       slow: false,
+      provider: 'gemini',
+      bufferedGeminiVoice: 'Iapetus',
+      cacheOnly: true,
+    });
+    assert.deepEqual(calls[1].body, {
+      learnerId: 'learner-a',
+      promptToken: 'prompt-token-test',
+      slow: false,
       provider: 'openai',
+      bufferedGeminiVoice: 'Iapetus',
     });
     assert.deepEqual(
       events.filter((event) => event.kind === 'test').map((event) => event.type),
@@ -222,12 +234,21 @@ test('platform TTS does not fall back when the selected remote provider fails', 
 
     assert.equal(result, false);
     assert.equal(spoke, false);
-    assert.equal(calls.length, 1);
+    assert.equal(calls.length, 2);
     assert.deepEqual(calls[0].body, {
       learnerId: 'learner-a',
       promptToken: 'prompt-token-a',
       slow: false,
+      provider: 'gemini',
+      bufferedGeminiVoice: 'Iapetus',
+      cacheOnly: true,
+    });
+    assert.deepEqual(calls[1].body, {
+      learnerId: 'learner-a',
+      promptToken: 'prompt-token-a',
+      slow: false,
       provider: 'openai',
+      bufferedGeminiVoice: 'Iapetus',
     });
   } finally {
     tts.stop();
@@ -269,8 +290,8 @@ test('platform TTS can use the local browser voice provider', async () => {
   const tts = createPlatformTts({
     remoteEnabled: true,
     provider: 'browser',
-    fetchFn: async () => {
-      calls.push(true);
+    fetchFn: async (url, init = {}) => {
+      calls.push({ url, body: JSON.parse(init.body) });
       return new Response(null, { status: 500 });
     },
   });
@@ -288,6 +309,25 @@ test('platform TTS can use the local browser voice provider', async () => {
     assert.equal(spoken[0].lang, 'en-GB');
     assert.equal(spoken[0].voice.name, 'Google UK English Female');
     assert.match(spoken[0].text, /The word is early/);
+
+    const tokenResult = await tts.speak({
+      learnerId: 'learner-a',
+      promptToken: 'prompt-token-browser',
+      word: 'early',
+      sentence: 'The birds sang early in the day.',
+    });
+
+    assert.equal(tokenResult, true);
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0].body, {
+      learnerId: 'learner-a',
+      promptToken: 'prompt-token-browser',
+      slow: false,
+      provider: 'gemini',
+      bufferedGeminiVoice: 'Iapetus',
+      cacheOnly: true,
+    });
+    assert.equal(spoken.length, 2);
   } finally {
     tts.stop();
     globalThis.window = originalWindow;

--- a/tests/spelling.test.js
+++ b/tests/spelling.test.js
@@ -264,11 +264,12 @@ test('legacy all filter normalises to core stats and excludes Extra progress', (
 
 test('resetting spelling progress preserves the profile TTS provider', () => {
   const { service } = makeService();
-  service.savePrefs('learner-a', { ttsProvider: 'browser' });
+  service.savePrefs('learner-a', { ttsProvider: 'browser', bufferedGeminiVoice: 'Sulafat' });
 
   service.resetLearner('learner-a');
 
   assert.equal(service.getPrefs('learner-a').ttsProvider, 'browser');
+  assert.equal(service.getPrefs('learner-a').bufferedGeminiVoice, 'Sulafat');
 });
 
 test('Extra spelling accepts UK mollusc only', () => {

--- a/tests/worker-tts.test.js
+++ b/tests/worker-tts.test.js
@@ -148,6 +148,41 @@ function geminiAudioResponse(bytes = [1, 0, 2, 0]) {
   });
 }
 
+function createMemoryR2Bucket({ hit = null } = {}) {
+  const objects = new Map();
+  const gets = [];
+  const puts = [];
+  if (hit) {
+    objects.set('*', {
+      bytes: Uint8Array.from(hit.bytes || [9, 8, 7]),
+      contentType: hit.contentType || 'audio/mpeg',
+    });
+  }
+  return {
+    gets,
+    puts,
+    async get(key) {
+      gets.push(key);
+      const item = objects.get(key) || objects.get('*');
+      if (!item) return null;
+      return {
+        body: item.bytes,
+        httpMetadata: { contentType: item.contentType },
+        customMetadata: item.customMetadata || {},
+      };
+    },
+    async put(key, value, options = {}) {
+      const bytes = new Uint8Array(await new Response(value).arrayBuffer());
+      puts.push({ key, bytes, options });
+      objects.set(key, {
+        bytes,
+        contentType: options.httpMetadata?.contentType || 'application/octet-stream',
+        customMetadata: options.customMetadata || {},
+      });
+    },
+  };
+}
+
 test('TTS route requires an authenticated account session', async () => {
   const server = createWorkerRepositoryServer({
     env: { OPENAI_API_KEY: 'test-openai-key' },
@@ -246,8 +281,138 @@ test('TTS route proxies dictation audio through selected Gemini provider', async
     assert.equal(calls[0].headers['x-goog-api-key'], 'test-gemini-key');
     assert.equal(calls[0].body.generationConfig.responseModalities[0], 'AUDIO');
     assert.equal(calls[0].body.generationConfig.speechConfig.languageCode, 'en-GB');
-    assert.equal(calls[0].body.generationConfig.speechConfig.voiceConfig.prebuiltVoiceConfig.voiceName, 'Kore');
-    assert.match(calls[0].body.contents[0].parts[0].text, /The word is early/);
+    assert.equal(calls[0].body.generationConfig.speechConfig.voiceConfig.prebuiltVoiceConfig.voiceName, 'Iapetus');
+    assert.match(calls[0].body.contents[0].parts[0].text, /Generate speech only/);
+  } finally {
+    globalThis.fetch = originalFetch;
+    server.close();
+  }
+});
+
+test('TTS route serves pre-cached Gemini audio before provider generation', async () => {
+  const originalFetch = globalThis.fetch;
+  let providerCalls = 0;
+  globalThis.fetch = async () => {
+    providerCalls += 1;
+    throw new Error('Provider should not be called for cached audio.');
+  };
+  const bucket = createMemoryR2Bucket({
+    hit: {
+      bytes: [9, 8, 7],
+      contentType: 'audio/mpeg',
+    },
+  });
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      SPELLING_AUDIO_BUCKET: bucket,
+    },
+  });
+  try {
+    const prompt = await startSpellingPrompt(server);
+    const response = await server.fetch('https://repo.test/api/tts', ttsRequest({
+      learnerId: prompt.learnerId,
+      promptToken: prompt.promptToken,
+      provider: 'gemini',
+      bufferedGeminiVoice: 'Sulafat',
+    }));
+    const bytes = new Uint8Array(await response.arrayBuffer());
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('content-type'), 'audio/mpeg');
+    assert.equal(response.headers.get('x-ks2-tts-cache'), 'hit');
+    assert.equal(response.headers.get('x-ks2-tts-voice'), 'Sulafat');
+    assert.deepEqual([...bytes], [9, 8, 7]);
+    assert.equal(providerCalls, 0);
+    assert.equal(bucket.gets.length, 1);
+    assert.match(bucket.gets[0], /\/Sulafat\/standard\/early\//);
+    assert.equal(bucket.puts.length, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+    server.close();
+  }
+});
+
+test('TTS route stores generated Gemini audio under the buffered batch key', async () => {
+  const originalFetch = globalThis.fetch;
+  const calls = [];
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({
+      url,
+      headers: init.headers,
+      body: JSON.parse(init.body),
+    });
+    return geminiAudioResponse();
+  };
+  const bucket = createMemoryR2Bucket();
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      GEMINI_API_KEY: 'test-gemini-key',
+      SPELLING_AUDIO_BUCKET: bucket,
+    },
+  });
+  try {
+    const prompt = await startSpellingPrompt(server);
+    const response = await server.fetch('https://repo.test/api/tts', ttsRequest({
+      learnerId: prompt.learnerId,
+      promptToken: prompt.promptToken,
+      provider: 'gemini',
+      bufferedGeminiVoice: 'Sulafat',
+      slow: true,
+    }));
+    const bytes = new Uint8Array(await response.arrayBuffer());
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('content-type'), 'audio/wav');
+    assert.equal(response.headers.get('x-ks2-tts-cache'), 'stored');
+    assert.equal(response.headers.get('x-ks2-tts-voice'), 'Sulafat');
+    assert.equal(String.fromCharCode(...bytes.slice(0, 4)), 'RIFF');
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].headers['x-goog-api-key'], 'test-gemini-key');
+    assert.equal(calls[0].body.generationConfig.speechConfig.voiceConfig.prebuiltVoiceConfig.voiceName, 'Sulafat');
+    assert.match(calls[0].body.contents[0].parts[0].text, /Generate speech only/);
+    assert.equal(bucket.puts.length, 1);
+    assert.match(bucket.puts[0].key, /\/Sulafat\/slow\/early\/\d+\.wav$/);
+    assert.equal(bucket.puts[0].options.httpMetadata.contentType, 'audio/wav');
+  } finally {
+    globalThis.fetch = originalFetch;
+    server.close();
+  }
+});
+
+test('TTS cache-only requests warm Gemini audio without returning playback bytes', async () => {
+  const originalFetch = globalThis.fetch;
+  let providerCalls = 0;
+  globalThis.fetch = async () => {
+    providerCalls += 1;
+    return geminiAudioResponse();
+  };
+  const bucket = createMemoryR2Bucket();
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      GEMINI_API_KEY: 'test-gemini-key',
+      SPELLING_AUDIO_BUCKET: bucket,
+    },
+  });
+  try {
+    const prompt = await startSpellingPrompt(server);
+    const response = await server.fetch('https://repo.test/api/tts', ttsRequest({
+      learnerId: prompt.learnerId,
+      promptToken: prompt.promptToken,
+      provider: 'gemini',
+      bufferedGeminiVoice: 'Iapetus',
+      cacheOnly: true,
+    }));
+    const bytes = new Uint8Array(await response.arrayBuffer());
+
+    assert.equal(response.status, 204);
+    assert.equal(response.headers.get('x-ks2-tts-cache'), 'stored');
+    assert.equal(bytes.length, 0);
+    assert.equal(providerCalls, 1);
+    assert.equal(bucket.puts.length, 1);
+    assert.match(bucket.puts[0].key, /\/Iapetus\/standard\/early\/\d+\.wav$/);
   } finally {
     globalThis.fetch = originalFetch;
     server.close();

--- a/tests/worker-tts.test.js
+++ b/tests/worker-tts.test.js
@@ -398,6 +398,7 @@ test('TTS route stores generated Gemini audio under the buffered batch key', asy
   const server = createWorkerRepositoryServer({
     env: {
       GEMINI_API_KEY: 'test-gemini-key',
+      GEMINI_TTS_MODEL: 'gemini-custom-tts-preview',
       SPELLING_AUDIO_BUCKET: bucket,
     },
   });
@@ -415,15 +416,18 @@ test('TTS route stores generated Gemini audio under the buffered batch key', asy
     assert.equal(response.status, 200);
     assert.equal(response.headers.get('content-type'), 'audio/wav');
     assert.equal(response.headers.get('x-ks2-tts-cache'), 'stored');
+    assert.equal(response.headers.get('x-ks2-tts-model'), 'gemini-custom-tts-preview');
     assert.equal(response.headers.get('x-ks2-tts-voice'), 'Sulafat');
     assert.equal(String.fromCharCode(...bytes.slice(0, 4)), 'RIFF');
     assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, 'https://generativelanguage.googleapis.com/v1beta/models/gemini-custom-tts-preview:generateContent');
     assert.equal(calls[0].headers['x-goog-api-key'], 'test-gemini-key');
     assert.equal(calls[0].body.generationConfig.speechConfig.voiceConfig.prebuiltVoiceConfig.voiceName, 'Sulafat');
     assert.match(calls[0].body.contents[0].parts[0].text, /Generate speech only/);
     assert.equal(bucket.puts.length, 1);
-    assert.match(bucket.puts[0].key, /\/Sulafat\/slow\/[^/]+\/early\/\d+\.wav$/);
+    assert.match(bucket.puts[0].key, /spelling-audio\/v1\/gemini-custom-tts-preview\/Sulafat\/slow\/[^/]+\/early\/\d+\.wav$/);
     assert.equal(bucket.puts[0].options.httpMetadata.contentType, 'audio/wav');
+    assert.equal(bucket.puts[0].options.customMetadata.model, 'gemini-custom-tts-preview');
     assert.ok(bucket.puts[0].options.customMetadata.contentKey);
   } finally {
     globalThis.fetch = originalFetch;

--- a/tests/worker-tts.test.js
+++ b/tests/worker-tts.test.js
@@ -24,14 +24,14 @@ function seedAccountLearner(DB, { accountId = 'adult-a', learnerId = 'learner-a'
   `).run(accountId, learnerId, now, now);
 }
 
-async function startSpellingPrompt(server) {
-  seedAccountLearner(server.DB);
-  const response = await server.fetch('https://repo.test/api/subjects/spelling/command', {
+async function startSpellingPrompt(server, { accountId = 'adult-a', learnerId = 'learner-a' } = {}) {
+  seedAccountLearner(server.DB, { accountId, learnerId });
+  const response = await server.fetchAs(accountId, 'https://repo.test/api/subjects/spelling/command', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({
       command: 'start-session',
-      learnerId: 'learner-a',
+      learnerId,
       requestId: 'tts-start-1',
       expectedLearnerRevision: 0,
       payload: {
@@ -148,7 +148,7 @@ function geminiAudioResponse(bytes = [1, 0, 2, 0]) {
   });
 }
 
-function createMemoryR2Bucket({ hit = null } = {}) {
+function createMemoryR2Bucket({ hit = null, failGet = false } = {}) {
   const objects = new Map();
   const gets = [];
   const puts = [];
@@ -163,6 +163,7 @@ function createMemoryR2Bucket({ hit = null } = {}) {
     puts,
     async get(key) {
       gets.push(key);
+      if (failGet) throw new Error('R2 get failed.');
       const item = objects.get(key) || objects.get('*');
       if (!item) return null;
       return {
@@ -325,8 +326,56 @@ test('TTS route serves pre-cached Gemini audio before provider generation', asyn
     assert.deepEqual([...bytes], [9, 8, 7]);
     assert.equal(providerCalls, 0);
     assert.equal(bucket.gets.length, 1);
-    assert.match(bucket.gets[0], /\/Sulafat\/standard\/early\//);
+    assert.match(bucket.gets[0], /\/Sulafat\/standard\/[^/]+\/early\//);
     assert.equal(bucket.puts.length, 0);
+    const limiterRows = server.DB.db.prepare(`
+      SELECT limiter_key
+      FROM request_limits
+      WHERE limiter_key LIKE 'tts-%'
+    `).all();
+    const limiterPrefixes = limiterRows.map((row) => row.limiter_key.split(':')[0]).sort();
+    assert.deepEqual(limiterPrefixes, ['tts-account', 'tts-ip']);
+  } finally {
+    globalThis.fetch = originalFetch;
+    server.close();
+  }
+});
+
+test('TTS route rate limits cached Gemini audio before reading R2', async () => {
+  const originalFetch = globalThis.fetch;
+  let providerCalls = 0;
+  globalThis.fetch = async () => {
+    providerCalls += 1;
+    throw new Error('Provider should not be called for rate-limited cached audio.');
+  };
+  const bucket = createMemoryR2Bucket({
+    hit: {
+      bytes: [9, 8, 7],
+      contentType: 'audio/mpeg',
+    },
+  });
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      SPELLING_AUDIO_BUCKET: bucket,
+    },
+  });
+  try {
+    const prompt = await startSpellingPrompt(server);
+    await seedRateLimit(server, 'tts-account', 'adult-a', 120);
+
+    const response = await server.fetch('https://repo.test/api/tts', ttsRequest({
+      learnerId: prompt.learnerId,
+      promptToken: prompt.promptToken,
+      provider: 'gemini',
+      bufferedGeminiVoice: 'Sulafat',
+    }));
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.code, 'tts_rate_limited');
+    assert.equal(providerCalls, 0);
+    assert.equal(bucket.gets.length, 0);
   } finally {
     globalThis.fetch = originalFetch;
     server.close();
@@ -373,8 +422,83 @@ test('TTS route stores generated Gemini audio under the buffered batch key', asy
     assert.equal(calls[0].body.generationConfig.speechConfig.voiceConfig.prebuiltVoiceConfig.voiceName, 'Sulafat');
     assert.match(calls[0].body.contents[0].parts[0].text, /Generate speech only/);
     assert.equal(bucket.puts.length, 1);
-    assert.match(bucket.puts[0].key, /\/Sulafat\/slow\/early\/\d+\.wav$/);
+    assert.match(bucket.puts[0].key, /\/Sulafat\/slow\/[^/]+\/early\/\d+\.wav$/);
     assert.equal(bucket.puts[0].options.httpMetadata.contentType, 'audio/wav');
+    assert.ok(bucket.puts[0].options.customMetadata.contentKey);
+  } finally {
+    globalThis.fetch = originalFetch;
+    server.close();
+  }
+});
+
+test('TTS buffered Gemini keys separate accounts sharing the same spelling slug', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => geminiAudioResponse();
+  const bucket = createMemoryR2Bucket();
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      GEMINI_API_KEY: 'test-gemini-key',
+      SPELLING_AUDIO_BUCKET: bucket,
+    },
+  });
+  try {
+    const promptA = await startSpellingPrompt(server, { accountId: 'adult-a', learnerId: 'learner-a' });
+    await server.fetchAs('adult-a', 'https://repo.test/api/tts', ttsRequest({
+      learnerId: promptA.learnerId,
+      promptToken: promptA.promptToken,
+      provider: 'gemini',
+      bufferedGeminiVoice: 'Iapetus',
+    }));
+
+    const promptB = await startSpellingPrompt(server, { accountId: 'adult-b', learnerId: 'learner-b' });
+    await server.fetchAs('adult-b', 'https://repo.test/api/tts', ttsRequest({
+      learnerId: promptB.learnerId,
+      promptToken: promptB.promptToken,
+      provider: 'gemini',
+      bufferedGeminiVoice: 'Iapetus',
+    }));
+
+    assert.equal(bucket.puts.length, 2);
+    assert.match(bucket.puts[0].key, /\/Iapetus\/standard\/[^/]+\/early\/\d+\.wav$/);
+    assert.match(bucket.puts[1].key, /\/Iapetus\/standard\/[^/]+\/early\/\d+\.wav$/);
+    assert.notEqual(bucket.puts[0].key, bucket.puts[1].key);
+  } finally {
+    globalThis.fetch = originalFetch;
+    server.close();
+  }
+});
+
+test('TTS route falls back to provider generation when R2 reads fail', async () => {
+  const originalFetch = globalThis.fetch;
+  let providerCalls = 0;
+  globalThis.fetch = async () => {
+    providerCalls += 1;
+    return geminiAudioResponse();
+  };
+  const bucket = createMemoryR2Bucket({ failGet: true });
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      GEMINI_API_KEY: 'test-gemini-key',
+      SPELLING_AUDIO_BUCKET: bucket,
+    },
+  });
+  try {
+    const prompt = await startSpellingPrompt(server);
+    const response = await server.fetch('https://repo.test/api/tts', ttsRequest({
+      learnerId: prompt.learnerId,
+      promptToken: prompt.promptToken,
+      provider: 'gemini',
+      bufferedGeminiVoice: 'Iapetus',
+    }));
+    const bytes = new Uint8Array(await response.arrayBuffer());
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('x-ks2-tts-cache'), 'unavailable');
+    assert.equal(String.fromCharCode(...bytes.slice(0, 4)), 'RIFF');
+    assert.equal(providerCalls, 1);
+    assert.equal(bucket.puts.length, 0);
   } finally {
     globalThis.fetch = originalFetch;
     server.close();
@@ -412,7 +536,7 @@ test('TTS cache-only requests warm Gemini audio without returning playback bytes
     assert.equal(bytes.length, 0);
     assert.equal(providerCalls, 1);
     assert.equal(bucket.puts.length, 1);
-    assert.match(bucket.puts[0].key, /\/Iapetus\/standard\/early\/\d+\.wav$/);
+    assert.match(bucket.puts[0].key, /\/Iapetus\/standard\/[^/]+\/early\/\d+\.wav$/);
   } finally {
     globalThis.fetch = originalFetch;
     server.close();

--- a/tests/worker-tts.test.js
+++ b/tests/worker-tts.test.js
@@ -323,6 +323,7 @@ test('TTS route serves pre-cached Gemini audio before provider generation', asyn
     assert.equal(response.headers.get('content-type'), 'audio/mpeg');
     assert.equal(response.headers.get('x-ks2-tts-cache'), 'hit');
     assert.equal(response.headers.get('x-ks2-tts-voice'), 'Sulafat');
+    assert.equal(response.headers.get('x-ks2-tts-cache-key'), null);
     assert.deepEqual([...bytes], [9, 8, 7]);
     assert.equal(providerCalls, 0);
     assert.equal(bucket.gets.length, 1);
@@ -418,6 +419,7 @@ test('TTS route stores generated Gemini audio under the buffered batch key', asy
     assert.equal(response.headers.get('x-ks2-tts-cache'), 'stored');
     assert.equal(response.headers.get('x-ks2-tts-model'), 'gemini-custom-tts-preview');
     assert.equal(response.headers.get('x-ks2-tts-voice'), 'Sulafat');
+    assert.equal(response.headers.get('x-ks2-tts-cache-key'), null);
     assert.equal(String.fromCharCode(...bytes.slice(0, 4)), 'RIFF');
     assert.equal(calls.length, 1);
     assert.equal(calls[0].url, 'https://generativelanguage.googleapis.com/v1beta/models/gemini-custom-tts-preview:generateContent');
@@ -552,6 +554,7 @@ test('TTS cache-only requests warm Gemini audio without returning playback bytes
 
     assert.equal(response.status, 204);
     assert.equal(response.headers.get('x-ks2-tts-cache'), 'stored');
+    assert.equal(response.headers.get('x-ks2-tts-cache-key'), null);
     assert.equal(bytes.length, 0);
     assert.equal(providerCalls, 1);
     assert.equal(bucket.puts.length, 1);
@@ -627,6 +630,56 @@ test('TTS cache-only warmups do not spend user playback quota', async () => {
   }
 });
 
+test('TTS cache-only cache hits do not spend warmup quota', async () => {
+  const originalFetch = globalThis.fetch;
+  let providerCalls = 0;
+  globalThis.fetch = async () => {
+    providerCalls += 1;
+    throw new Error('Provider should not be called for cache-only hits.');
+  };
+  const bucket = createMemoryR2Bucket({
+    hit: {
+      bytes: [9, 8, 7],
+      contentType: 'audio/mpeg',
+    },
+  });
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      GEMINI_API_KEY: 'test-gemini-key',
+      SPELLING_AUDIO_BUCKET: bucket,
+    },
+  });
+  try {
+    const prompt = await startSpellingPrompt(server);
+    await seedRateLimit(server, 'tts-warmup-account', 'adult-a', 60);
+
+    const response = await server.fetch('https://repo.test/api/tts', ttsRequest({
+      learnerId: prompt.learnerId,
+      promptToken: prompt.promptToken,
+      provider: 'gemini',
+      bufferedGeminiVoice: 'Iapetus',
+      cacheOnly: true,
+    }));
+    const warmupAccount = server.DB.db.prepare(`
+      SELECT request_count
+      FROM request_limits
+      WHERE limiter_key LIKE 'tts-warmup-account:%'
+    `).get();
+
+    assert.equal(response.status, 204);
+    assert.equal(response.headers.get('x-ks2-tts-cache'), 'hit');
+    assert.equal(response.headers.get('x-ks2-tts-cache-key'), null);
+    assert.equal(providerCalls, 0);
+    assert.equal(bucket.gets.length, 1);
+    assert.equal(bucket.puts.length, 0);
+    assert.equal(Number(warmupAccount?.request_count), 60);
+  } finally {
+    globalThis.fetch = originalFetch;
+    server.close();
+  }
+});
+
 test('TTS cache-only warmups are skipped when the warmup quota is exhausted', async () => {
   const originalFetch = globalThis.fetch;
   let providerCalls = 0;
@@ -657,7 +710,7 @@ test('TTS cache-only warmups are skipped when the warmup quota is exhausted', as
     assert.equal(response.status, 204);
     assert.equal(response.headers.get('x-ks2-tts-cache'), 'skipped_rate_limited');
     assert.equal(providerCalls, 0);
-    assert.equal(bucket.gets.length, 0);
+    assert.equal(bucket.gets.length, 2);
     assert.equal(bucket.puts.length, 0);
   } finally {
     globalThis.fetch = originalFetch;
@@ -1097,6 +1150,127 @@ test('demo TTS is blocked by the demo session limiter before provider fetch', as
     assert.equal(response.status, 400);
     assert.equal(payload.code, 'demo_rate_limited');
     assert.equal(providerCalls, 0);
+    assert.equal(Number(rateLimitMetric?.metric_count), 1);
+    assert.equal(Number(fallbackMetric?.metric_count) || 0, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+    server.close();
+  }
+});
+
+test('demo cache-only warmups use demo TTS guards and metrics', async () => {
+  const originalFetch = globalThis.fetch;
+  let providerCalls = 0;
+  globalThis.fetch = async () => {
+    providerCalls += 1;
+    return geminiAudioResponse();
+  };
+  const bucket = createMemoryR2Bucket();
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      AUTH_MODE: 'production',
+      ENVIRONMENT: 'production',
+      APP_HOSTNAME: 'repo.test',
+      GEMINI_API_KEY: 'test-gemini-key',
+      SPELLING_AUDIO_BUCKET: bucket,
+    },
+  });
+  try {
+    const prompt = await startDemoSpellingPrompt(server);
+    const response = await server.fetchRaw('https://repo.test/api/tts', {
+      ...ttsRequest({
+        learnerId: prompt.audio.learnerId,
+        promptToken: prompt.audio.promptToken,
+        provider: 'gemini',
+        bufferedGeminiVoice: 'Iapetus',
+        cacheOnly: true,
+      }),
+      headers: {
+        'content-type': 'application/json',
+        cookie: prompt.cookie,
+      },
+    });
+    const fallbackMetric = server.DB.db.prepare(`
+      SELECT metric_count
+      FROM demo_operation_metrics
+      WHERE metric_key = 'tts_fallbacks'
+    `).get();
+    const limiterRows = server.DB.db.prepare(`
+      SELECT limiter_key
+      FROM request_limits
+      WHERE limiter_key LIKE 'demo-tts-%'
+    `).all();
+    const limiterPrefixes = limiterRows.map((row) => row.limiter_key.split(':')[0]).sort();
+
+    assert.equal(response.status, 204);
+    assert.equal(response.headers.get('x-ks2-tts-cache'), 'stored');
+    assert.equal(providerCalls, 1);
+    assert.equal(bucket.puts.length, 1);
+    assert.equal(Number(fallbackMetric?.metric_count), 1);
+    assert.deepEqual(limiterPrefixes, [
+      'demo-tts-account',
+      'demo-tts-fallback-type',
+      'demo-tts-ip',
+      'demo-tts-session',
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    server.close();
+  }
+});
+
+test('demo cache-only warmups are blocked by demo limiter before provider fetch', async () => {
+  const originalFetch = globalThis.fetch;
+  let providerCalls = 0;
+  globalThis.fetch = async () => {
+    providerCalls += 1;
+    return geminiAudioResponse();
+  };
+  const bucket = createMemoryR2Bucket();
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      AUTH_MODE: 'production',
+      ENVIRONMENT: 'production',
+      APP_HOSTNAME: 'repo.test',
+      GEMINI_API_KEY: 'test-gemini-key',
+      SPELLING_AUDIO_BUCKET: bucket,
+    },
+  });
+  try {
+    const prompt = await startDemoSpellingPrompt(server);
+    await seedRateLimit(server, 'demo-tts-session', prompt.sessionId, 60);
+
+    const response = await server.fetchRaw('https://repo.test/api/tts', {
+      ...ttsRequest({
+        learnerId: prompt.audio.learnerId,
+        promptToken: prompt.audio.promptToken,
+        provider: 'gemini',
+        bufferedGeminiVoice: 'Iapetus',
+        cacheOnly: true,
+      }),
+      headers: {
+        'content-type': 'application/json',
+        cookie: prompt.cookie,
+      },
+    });
+    const payload = await response.json();
+    const rateLimitMetric = server.DB.db.prepare(`
+      SELECT metric_count
+      FROM demo_operation_metrics
+      WHERE metric_key = 'rate_limit_blocks'
+    `).get();
+    const fallbackMetric = server.DB.db.prepare(`
+      SELECT metric_count
+      FROM demo_operation_metrics
+      WHERE metric_key = 'tts_fallbacks'
+    `).get();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.code, 'demo_rate_limited');
+    assert.equal(providerCalls, 0);
+    assert.equal(bucket.puts.length, 0);
     assert.equal(Number(rateLimitMetric?.metric_count), 1);
     assert.equal(Number(fallbackMetric?.metric_count) || 0, 0);
   } finally {

--- a/tests/worker-tts.test.js
+++ b/tests/worker-tts.test.js
@@ -431,9 +431,13 @@ test('TTS route stores generated Gemini audio under the buffered batch key', asy
   }
 });
 
-test('TTS buffered Gemini keys separate accounts sharing the same spelling slug', async () => {
+test('TTS buffered Gemini cache reuses matching published content across accounts', async () => {
   const originalFetch = globalThis.fetch;
-  globalThis.fetch = async () => geminiAudioResponse();
+  let providerCalls = 0;
+  globalThis.fetch = async () => {
+    providerCalls += 1;
+    return geminiAudioResponse();
+  };
   const bucket = createMemoryR2Bucket();
 
   const server = createWorkerRepositoryServer({
@@ -443,26 +447,37 @@ test('TTS buffered Gemini keys separate accounts sharing the same spelling slug'
     },
   });
   try {
-    const promptA = await startSpellingPrompt(server, { accountId: 'adult-a', learnerId: 'learner-a' });
-    await server.fetchAs('adult-a', 'https://repo.test/api/tts', ttsRequest({
-      learnerId: promptA.learnerId,
-      promptToken: promptA.promptToken,
+    seedAccountLearner(server.DB, { accountId: 'adult-a', learnerId: 'learner-a' });
+    seedAccountLearner(server.DB, { accountId: 'adult-b', learnerId: 'learner-b' });
+    const detailAResponse = await server.fetchAs('adult-a', 'https://repo.test/api/subjects/spelling/word-bank?learnerId=learner-a&detailSlug=early');
+    const detailBResponse = await server.fetchAs('adult-b', 'https://repo.test/api/subjects/spelling/word-bank?learnerId=learner-b&detailSlug=early');
+    const detailA = await detailAResponse.json();
+    const detailB = await detailBResponse.json();
+    const cueA = detailA.wordBank.detail.audio.dictation;
+    const cueB = detailB.wordBank.detail.audio.dictation;
+
+    const responseA = await server.fetchAs('adult-a', 'https://repo.test/api/tts', ttsRequest({
+      learnerId: cueA.learnerId,
+      promptToken: cueA.promptToken,
+      slug: cueA.slug,
+      provider: 'gemini',
+      bufferedGeminiVoice: 'Iapetus',
+    }));
+    const responseB = await server.fetchAs('adult-b', 'https://repo.test/api/tts', ttsRequest({
+      learnerId: cueB.learnerId,
+      promptToken: cueB.promptToken,
+      slug: cueB.slug,
       provider: 'gemini',
       bufferedGeminiVoice: 'Iapetus',
     }));
 
-    const promptB = await startSpellingPrompt(server, { accountId: 'adult-b', learnerId: 'learner-b' });
-    await server.fetchAs('adult-b', 'https://repo.test/api/tts', ttsRequest({
-      learnerId: promptB.learnerId,
-      promptToken: promptB.promptToken,
-      provider: 'gemini',
-      bufferedGeminiVoice: 'Iapetus',
-    }));
-
-    assert.equal(bucket.puts.length, 2);
+    assert.equal(responseA.status, 200);
+    assert.equal(responseA.headers.get('x-ks2-tts-cache'), 'stored');
+    assert.equal(responseB.status, 200);
+    assert.equal(responseB.headers.get('x-ks2-tts-cache'), 'hit');
+    assert.equal(providerCalls, 1);
+    assert.equal(bucket.puts.length, 1);
     assert.match(bucket.puts[0].key, /\/Iapetus\/standard\/[^/]+\/early\/\d+\.wav$/);
-    assert.match(bucket.puts[1].key, /\/Iapetus\/standard\/[^/]+\/early\/\d+\.wav$/);
-    assert.notEqual(bucket.puts[0].key, bucket.puts[1].key);
   } finally {
     globalThis.fetch = originalFetch;
     server.close();
@@ -537,6 +552,109 @@ test('TTS cache-only requests warm Gemini audio without returning playback bytes
     assert.equal(providerCalls, 1);
     assert.equal(bucket.puts.length, 1);
     assert.match(bucket.puts[0].key, /\/Iapetus\/standard\/[^/]+\/early\/\d+\.wav$/);
+  } finally {
+    globalThis.fetch = originalFetch;
+    server.close();
+  }
+});
+
+test('TTS cache-only warmups do not spend user playback quota', async () => {
+  const originalFetch = globalThis.fetch;
+  const calls = [];
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push(String(url));
+    if (String(url).includes('generativelanguage')) return geminiAudioResponse();
+    return new Response(new Uint8Array([1, 2, 3]), {
+      status: 200,
+      headers: { 'content-type': 'audio/mpeg' },
+    });
+  };
+  const bucket = createMemoryR2Bucket();
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      OPENAI_API_KEY: 'test-openai-key',
+      GEMINI_API_KEY: 'test-gemini-key',
+      SPELLING_AUDIO_BUCKET: bucket,
+    },
+  });
+  try {
+    const prompt = await startSpellingPrompt(server);
+    await seedRateLimit(server, 'tts-account', 'adult-a', 119);
+
+    const warmup = await server.fetch('https://repo.test/api/tts', ttsRequest({
+      learnerId: prompt.learnerId,
+      promptToken: prompt.promptToken,
+      provider: 'gemini',
+      bufferedGeminiVoice: 'Iapetus',
+      cacheOnly: true,
+    }));
+    const playback = await server.fetch('https://repo.test/api/tts', ttsRequest({
+      learnerId: prompt.learnerId,
+      promptToken: prompt.promptToken,
+      provider: 'openai',
+      bufferedGeminiVoice: 'Iapetus',
+    }));
+    const bytes = new Uint8Array(await playback.arrayBuffer());
+    const limiterRows = server.DB.db.prepare(`
+      SELECT limiter_key, request_count
+      FROM request_limits
+      WHERE limiter_key LIKE 'tts-%'
+    `).all();
+    const normalAccount = limiterRows.find((row) => row.limiter_key.startsWith('tts-account:'));
+    const prefixes = limiterRows.map((row) => row.limiter_key.split(':')[0]).sort();
+
+    assert.equal(warmup.status, 204);
+    assert.equal(warmup.headers.get('x-ks2-tts-cache'), 'stored');
+    assert.equal(playback.status, 200);
+    assert.deepEqual([...bytes], [1, 2, 3]);
+    assert.equal(Number(normalAccount?.request_count), 120);
+    assert.deepEqual(prefixes, [
+      'tts-account',
+      'tts-ip',
+      'tts-warmup-account',
+      'tts-warmup-ip',
+    ]);
+    assert.equal(calls.filter((url) => url.includes('generativelanguage')).length, 1);
+    assert.equal(calls.filter((url) => url.includes('api.openai.com')).length, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+    server.close();
+  }
+});
+
+test('TTS cache-only warmups are skipped when the warmup quota is exhausted', async () => {
+  const originalFetch = globalThis.fetch;
+  let providerCalls = 0;
+  globalThis.fetch = async () => {
+    providerCalls += 1;
+    return geminiAudioResponse();
+  };
+  const bucket = createMemoryR2Bucket();
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      GEMINI_API_KEY: 'test-gemini-key',
+      SPELLING_AUDIO_BUCKET: bucket,
+    },
+  });
+  try {
+    const prompt = await startSpellingPrompt(server);
+    await seedRateLimit(server, 'tts-warmup-account', 'adult-a', 60);
+
+    const response = await server.fetch('https://repo.test/api/tts', ttsRequest({
+      learnerId: prompt.learnerId,
+      promptToken: prompt.promptToken,
+      provider: 'gemini',
+      bufferedGeminiVoice: 'Iapetus',
+      cacheOnly: true,
+    }));
+
+    assert.equal(response.status, 204);
+    assert.equal(response.headers.get('x-ks2-tts-cache'), 'skipped_rate_limited');
+    assert.equal(providerCalls, 0);
+    assert.equal(bucket.gets.length, 0);
+    assert.equal(bucket.puts.length, 0);
   } finally {
     globalThis.fetch = originalFetch;
     server.close();

--- a/worker/src/subjects/spelling/audio.js
+++ b/worker/src/subjects/spelling/audio.js
@@ -2,6 +2,7 @@ import { sha256 } from '../../auth.js';
 import { BadRequestError } from '../../errors.js';
 import { resolveRuntimeSnapshot } from '../../../../src/subjects/spelling/content/model.js';
 import { SEEDED_SPELLING_CONTENT_BUNDLE } from '../../../../src/subjects/spelling/data/content-data.js';
+import { resolveSentenceIndex } from '../../../../shared/spelling-audio.js';
 
 function cleanText(value) {
   return String(value || '').replace(/\s+/g, ' ').trim();
@@ -19,6 +20,7 @@ function currentPromptParts({ learnerId, state } = {}) {
     slug: word.slug || card.slug || '',
     word: cleanText(word.word),
     sentence,
+    sentenceIndex: resolveSentenceIndex(word, sentence),
   };
 }
 
@@ -100,6 +102,7 @@ async function wordBankPromptParts({ repository, accountId, learnerId, slug } = 
     slug: word.slug,
     word: cleanText(word.word),
     sentence,
+    sentenceIndex: resolveSentenceIndex(word, sentence),
   };
 }
 
@@ -141,6 +144,9 @@ export async function resolveSpellingAudioRequest({
         sessionId: null,
         scope: 'word-bank',
         slug: wordBankParts.slug,
+        word: wordBankParts.word,
+        sentence: wordBankParts.sentence,
+        sentenceIndex: wordBankParts.sentenceIndex,
       };
     }
     throw new BadRequestError('The spelling prompt is no longer active.', {
@@ -168,6 +174,9 @@ export async function resolveSpellingAudioRequest({
         sessionId: null,
         scope: 'word-bank',
         slug: wordBankParts.slug,
+        word: wordBankParts.word,
+        sentence: wordBankParts.sentence,
+        sentenceIndex: wordBankParts.sentenceIndex,
       };
     }
     throw new BadRequestError('The spelling prompt token is no longer valid.', {
@@ -187,5 +196,10 @@ export async function resolveSpellingAudioRequest({
     promptToken: suppliedToken,
     learnerId,
     sessionId: parts.sessionId,
+    scope: 'session',
+    slug: parts.slug,
+    word: parts.word,
+    sentence: parts.sentence,
+    sentenceIndex: parts.sentenceIndex,
   };
 }

--- a/worker/src/tts.js
+++ b/worker/src/tts.js
@@ -291,7 +291,7 @@ function bufferedAudioKey(metadata, extension = 'mp3') {
   });
 }
 
-function bufferedAudioHeaders({ metadata, cacheState, contentType, key }) {
+function bufferedAudioHeaders({ metadata, cacheState, contentType }) {
   return {
     'content-type': contentType,
     'cache-control': 'private, max-age=86400',
@@ -299,7 +299,6 @@ function bufferedAudioHeaders({ metadata, cacheState, contentType, key }) {
     'x-ks2-tts-model': metadata.model || SPELLING_AUDIO_MODEL,
     'x-ks2-tts-voice': metadata.voice,
     'x-ks2-tts-cache': cacheState,
-    'x-ks2-tts-cache-key': key,
   };
 }
 
@@ -366,7 +365,6 @@ function cachedGeminiAudioResponse(cacheHit) {
       metadata: cacheHit.metadata,
       cacheState: 'hit',
       contentType: cacheHit.contentType,
-      key: cacheHit.key,
     }),
   });
 }
@@ -376,7 +374,6 @@ function cacheOnlyResponse(cacheState, cacheHit = null) {
     'cache-control': 'no-store',
     'x-ks2-tts-cache': cacheState,
   });
-  if (cacheHit?.key) headers.set('x-ks2-tts-cache-key', cacheHit.key);
   if (cacheHit?.metadata?.model) headers.set('x-ks2-tts-model', cacheHit.metadata.model);
   if (cacheHit?.metadata?.voice) headers.set('x-ks2-tts-voice', cacheHit.metadata.voice);
   return new Response(null, { status: 204, headers });
@@ -425,7 +422,6 @@ async function storeBufferedGeminiAudio(env, payload, response, options = {}) {
           metadata: cacheSlot.metadata,
           cacheState: 'stored',
           contentType,
-          key: cacheSlot.key,
         }),
       }),
       cacheState: 'stored',
@@ -435,7 +431,6 @@ async function storeBufferedGeminiAudio(env, payload, response, options = {}) {
   } catch {
     const headers = new Headers(response.headers);
     headers.set('x-ks2-tts-cache', 'store_failed');
-    headers.set('x-ks2-tts-cache-key', cacheSlot.key);
     return {
       response: new Response(bytes, { status: 200, headers }),
       cacheState: 'store_failed',
@@ -667,12 +662,7 @@ export async function handleTextToSpeechRequest({
   }
 
   if (payload.provider === 'gemini' && !payload.wordOnly) {
-    if (cacheOnly) {
-      const warmupAllowed = await allowTtsWarmup(env, request, session, now);
-      if (!warmupAllowed) return cacheOnlyResponse('skipped_rate_limited');
-    } else {
-      await protectAudioRequest();
-    }
+    if (!cacheOnly) await protectAudioRequest();
     const cacheHit = await readBufferedGeminiAudio(env, payload, { model: geminiForPayload.model });
     if (cacheHit?.object) {
       const output = cacheOnly ? cacheOnlyResponse('hit', cacheHit) : cachedGeminiAudioResponse(cacheHit);
@@ -680,6 +670,12 @@ export async function handleTextToSpeechRequest({
     }
     if (cacheOnly && cacheHit?.cacheUnavailable) return cacheOnlyResponse('unavailable', cacheHit);
     if (cacheOnly && !cacheHit?.metadata) return cacheOnlyResponse('uncacheable');
+    if (cacheOnly) {
+      if (!geminiForPayload.apiKey) return cacheOnlyResponse('unavailable');
+      const warmupAllowed = await allowTtsWarmup(env, request, session, now);
+      if (!warmupAllowed) return cacheOnlyResponse('skipped_rate_limited');
+      await protectDemoTtsFallback({ env, request, session, payload, now });
+    }
   }
 
   if (payload.provider === 'gemini') {
@@ -694,9 +690,9 @@ export async function handleTextToSpeechRequest({
         ? { response, cacheState: 'uncacheable' }
         : await storeBufferedGeminiAudio(env, payload, response, { model: geminiForPayload.model });
       const output = cacheOnly
-        ? cacheOnlyResponse(stored.cacheState, { key: stored.key, metadata: stored.metadata })
+        ? cacheOnlyResponse(stored.cacheState, { metadata: stored.metadata })
         : stored.response;
-      return cacheOnly ? output : await recordDemoTtsFallback(env, session, now, output);
+      return await recordDemoTtsFallback(env, session, now, output);
     } catch (error) {
       throw backendUnavailableFromFailure(error, [error]);
     }

--- a/worker/src/tts.js
+++ b/worker/src/tts.js
@@ -17,6 +17,8 @@ const GEMINI_GENERATE_CONTENT_URL = 'https://generativelanguage.googleapis.com/v
 const TTS_WINDOW_MS = 10 * 60 * 1000;
 const TTS_ACCOUNT_LIMIT = 120;
 const TTS_IP_LIMIT = 240;
+const TTS_WARMUP_ACCOUNT_LIMIT = 60;
+const TTS_WARMUP_IP_LIMIT = 180;
 const DEFAULT_MODEL = 'gpt-4o-mini-tts';
 const DEFAULT_VOICE = 'marin';
 const DEFAULT_FORMAT = 'mp3';
@@ -102,6 +104,24 @@ async function protectTts(env, request, session, now) {
       retryAfterSeconds: Math.max(accountLimit.retryAfterSeconds, ipLimit.retryAfterSeconds),
     });
   }
+}
+
+async function allowTtsWarmup(env, request, session, now) {
+  const accountLimit = await consumeRateLimit(env, {
+    bucket: 'tts-warmup-account',
+    identifier: session.accountId,
+    limit: TTS_WARMUP_ACCOUNT_LIMIT,
+    windowMs: TTS_WINDOW_MS,
+    now,
+  });
+  const ipLimit = await consumeRateLimit(env, {
+    bucket: 'tts-warmup-ip',
+    identifier: clientIp(request),
+    limit: TTS_WARMUP_IP_LIMIT,
+    windowMs: TTS_WINDOW_MS,
+    now,
+  });
+  return accountLimit.allowed && ipLimit.allowed;
 }
 
 async function recordDemoTtsFallback(env, session, now, response) {
@@ -247,8 +267,7 @@ async function bufferedAudioMetadata(payload = {}) {
   const voice = normaliseBufferedGeminiVoice(payload.bufferedGeminiVoice);
   const speed = speedIdForSlow(payload.slow);
   const contentKey = await sha256([
-    'spelling-audio-content-v1',
-    accountId,
+    'spelling-audio-content-v2',
     slug,
     String(sentenceIndex),
     word,
@@ -635,6 +654,7 @@ export async function handleTextToSpeechRequest({
     ...gemini,
     voice: payload.bufferedGeminiVoice || gemini.voice,
   };
+  if (cacheOnly && payload.wordOnly) return cacheOnlyResponse('uncacheable');
   let protectedRequest = false;
   async function protectAudioRequest() {
     if (protectedRequest) return;
@@ -644,19 +664,27 @@ export async function handleTextToSpeechRequest({
   }
 
   if (payload.provider === 'gemini' && !payload.wordOnly) {
-    await protectAudioRequest();
+    if (cacheOnly) {
+      const warmupAllowed = await allowTtsWarmup(env, request, session, now);
+      if (!warmupAllowed) return cacheOnlyResponse('skipped_rate_limited');
+    } else {
+      await protectAudioRequest();
+    }
     const cacheHit = await readBufferedGeminiAudio(env, payload);
     if (cacheHit?.object) {
       const output = cacheOnly ? cacheOnlyResponse('hit', cacheHit) : cachedGeminiAudioResponse(cacheHit);
-      return await recordDemoTtsFallback(env, session, now, output);
+      return cacheOnly ? output : await recordDemoTtsFallback(env, session, now, output);
     }
     if (cacheOnly && cacheHit?.cacheUnavailable) return cacheOnlyResponse('unavailable', cacheHit);
     if (cacheOnly && !cacheHit?.metadata) return cacheOnlyResponse('uncacheable');
   }
 
   if (payload.provider === 'gemini') {
-    if (!geminiForPayload.apiKey) throw missingProviderConfig('gemini');
-    await protectAudioRequest();
+    if (!geminiForPayload.apiKey) {
+      if (cacheOnly) return cacheOnlyResponse('unavailable');
+      throw missingProviderConfig('gemini');
+    }
+    if (!cacheOnly) await protectAudioRequest();
     try {
       const response = await requestGeminiSpeech({ config: geminiForPayload, payload, fetchFn });
       const stored = payload.wordOnly
@@ -665,7 +693,7 @@ export async function handleTextToSpeechRequest({
       const output = cacheOnly
         ? cacheOnlyResponse(stored.cacheState, { key: stored.key, metadata: stored.metadata })
         : stored.response;
-      return await recordDemoTtsFallback(env, session, now, output);
+      return cacheOnly ? output : await recordDemoTtsFallback(env, session, now, output);
     } catch (error) {
       throw backendUnavailableFromFailure(error, [error]);
     }

--- a/worker/src/tts.js
+++ b/worker/src/tts.js
@@ -256,8 +256,9 @@ function contentTypeForExtension(extension) {
   return extension === 'mp3' ? 'audio/mpeg' : 'audio/wav';
 }
 
-async function bufferedAudioMetadata(payload = {}) {
+async function bufferedAudioMetadata(payload = {}, { model = SPELLING_AUDIO_MODEL } = {}) {
   if (payload.wordOnly) return null;
+  const cacheModel = cleanGeminiModel(model) || SPELLING_AUDIO_MODEL;
   const slug = cleanText(payload.slug).toLowerCase();
   const sentenceIndex = Number(payload.sentenceIndex);
   const accountId = cleanText(payload.accountId);
@@ -274,6 +275,7 @@ async function bufferedAudioMetadata(payload = {}) {
     sentence,
   ].join('|'));
   return {
+    model: cacheModel,
     voice,
     speed,
     contentKey,
@@ -294,7 +296,7 @@ function bufferedAudioHeaders({ metadata, cacheState, contentType, key }) {
     'content-type': contentType,
     'cache-control': 'private, max-age=86400',
     'x-ks2-tts-provider': 'gemini',
-    'x-ks2-tts-model': SPELLING_AUDIO_MODEL,
+    'x-ks2-tts-model': metadata.model || SPELLING_AUDIO_MODEL,
     'x-ks2-tts-voice': metadata.voice,
     'x-ks2-tts-cache': cacheState,
     'x-ks2-tts-cache-key': key,
@@ -309,8 +311,8 @@ function objectContentType(object, extension) {
   ) || contentTypeForExtension(extension);
 }
 
-async function readBufferedGeminiAudio(env, payload) {
-  const metadata = await bufferedAudioMetadata(payload);
+async function readBufferedGeminiAudio(env, payload, options = {}) {
+  const metadata = await bufferedAudioMetadata(payload, options);
   if (!metadata) return null;
   const bucket = spellingAudioBucket(env);
   if (!bucket) {
@@ -375,12 +377,13 @@ function cacheOnlyResponse(cacheState, cacheHit = null) {
     'x-ks2-tts-cache': cacheState,
   });
   if (cacheHit?.key) headers.set('x-ks2-tts-cache-key', cacheHit.key);
+  if (cacheHit?.metadata?.model) headers.set('x-ks2-tts-model', cacheHit.metadata.model);
   if (cacheHit?.metadata?.voice) headers.set('x-ks2-tts-voice', cacheHit.metadata.voice);
   return new Response(null, { status: 204, headers });
 }
 
-async function storeBufferedGeminiAudio(env, payload, response) {
-  const cacheSlot = await readBufferedGeminiAudio(env, payload);
+async function storeBufferedGeminiAudio(env, payload, response, options = {}) {
+  const cacheSlot = await readBufferedGeminiAudio(env, payload, options);
   if (!cacheSlot?.metadata || cacheSlot.cacheUnavailable || !spellingAudioBucket(env)) {
     const headers = new Headers(response.headers);
     headers.set('x-ks2-tts-cache', 'unavailable');
@@ -406,7 +409,7 @@ async function storeBufferedGeminiAudio(env, payload, response) {
     await spellingAudioBucket(env).put(cacheSlot.key, bytes, {
       httpMetadata: { contentType },
       customMetadata: {
-        model: SPELLING_AUDIO_MODEL,
+        model: cacheSlot.metadata.model,
         voice: cacheSlot.metadata.voice,
         speed: cacheSlot.metadata.speed,
         contentKey: cacheSlot.metadata.contentKey,
@@ -670,7 +673,7 @@ export async function handleTextToSpeechRequest({
     } else {
       await protectAudioRequest();
     }
-    const cacheHit = await readBufferedGeminiAudio(env, payload);
+    const cacheHit = await readBufferedGeminiAudio(env, payload, { model: geminiForPayload.model });
     if (cacheHit?.object) {
       const output = cacheOnly ? cacheOnlyResponse('hit', cacheHit) : cachedGeminiAudioResponse(cacheHit);
       return cacheOnly ? output : await recordDemoTtsFallback(env, session, now, output);
@@ -689,7 +692,7 @@ export async function handleTextToSpeechRequest({
       const response = await requestGeminiSpeech({ config: geminiForPayload, payload, fetchFn });
       const stored = payload.wordOnly
         ? { response, cacheState: 'uncacheable' }
-        : await storeBufferedGeminiAudio(env, payload, response);
+        : await storeBufferedGeminiAudio(env, payload, response, { model: geminiForPayload.model });
       const output = cacheOnly
         ? cacheOnlyResponse(stored.cacheState, { key: stored.key, metadata: stored.metadata })
         : stored.response;

--- a/worker/src/tts.js
+++ b/worker/src/tts.js
@@ -4,6 +4,13 @@ import { BadRequestError, BackendUnavailableError } from './errors.js';
 import { readJson } from './http.js';
 import { protectDemoTtsFallback, recordDemoMetric } from './demo/sessions.js';
 import { resolveSpellingAudioRequest } from './subjects/spelling/audio.js';
+import {
+  SPELLING_AUDIO_MODEL,
+  buildAudioAssetKey,
+  buildBufferedSpeechPrompt,
+  normaliseBufferedGeminiVoice,
+  speedIdForSlow,
+} from '../../shared/spelling-audio.js';
 
 const OPENAI_SPEECH_URL = 'https://api.openai.com/v1/audio/speech';
 const GEMINI_GENERATE_CONTENT_URL = 'https://generativelanguage.googleapis.com/v1beta/models';
@@ -18,6 +25,7 @@ const DEFAULT_GEMINI_MODEL = 'gemini-3.1-flash-tts-preview';
 const DEFAULT_GEMINI_VOICE = 'Kore';
 const DEFAULT_GEMINI_TIMEOUT_MS = 12000;
 const DEFAULT_GEMINI_SAMPLE_RATE = 24000;
+const BUFFERED_AUDIO_EXTENSIONS = Object.freeze(['mp3', 'wav']);
 const REMOTE_TTS_PROVIDERS = new Set(['openai', 'gemini']);
 
 function cleanText(value) {
@@ -110,6 +118,10 @@ function normaliseRemoteTtsProvider(value) {
     code: 'tts_provider_unsupported',
     provider,
   });
+}
+
+function normaliseTtsCacheOnly(value) {
+  return value === true || cleanText(value).toLowerCase() === 'true';
 }
 
 function ttsInstructions(slow = false, wordOnly = false) {
@@ -213,9 +225,176 @@ function missingProviderConfig(provider) {
   });
 }
 
-function geminiPrompt({ transcript, slow = false, wordOnly = false }) {
+function spellingAudioBucket(env = {}) {
+  const bucket = env.SPELLING_AUDIO_BUCKET;
+  return bucket && typeof bucket.get === 'function' && typeof bucket.put === 'function'
+    ? bucket
+    : null;
+}
+
+function contentTypeForExtension(extension) {
+  return extension === 'mp3' ? 'audio/mpeg' : 'audio/wav';
+}
+
+function bufferedAudioMetadata(payload = {}) {
+  if (payload.wordOnly) return null;
+  const slug = cleanText(payload.slug).toLowerCase();
+  const sentenceIndex = Number(payload.sentenceIndex);
+  if (!slug || !Number.isInteger(sentenceIndex) || sentenceIndex < 0) return null;
+  const voice = normaliseBufferedGeminiVoice(payload.bufferedGeminiVoice);
+  const speed = speedIdForSlow(payload.slow);
+  return {
+    voice,
+    speed,
+    slug,
+    sentenceIndex,
+  };
+}
+
+function bufferedAudioKey(metadata, extension = 'mp3') {
+  return buildAudioAssetKey({
+    ...metadata,
+    extension,
+  });
+}
+
+function bufferedAudioHeaders({ metadata, cacheState, contentType, key }) {
+  return {
+    'content-type': contentType,
+    'cache-control': 'private, max-age=86400',
+    'x-ks2-tts-provider': 'gemini',
+    'x-ks2-tts-model': SPELLING_AUDIO_MODEL,
+    'x-ks2-tts-voice': metadata.voice,
+    'x-ks2-tts-cache': cacheState,
+    'x-ks2-tts-cache-key': key,
+  };
+}
+
+function objectContentType(object, extension) {
+  return cleanText(
+    object?.httpMetadata?.contentType
+      || object?.httpMetadata?.content_type
+      || object?.customMetadata?.contentType,
+  ) || contentTypeForExtension(extension);
+}
+
+async function readBufferedGeminiAudio(env, payload) {
+  const bucket = spellingAudioBucket(env);
+  const metadata = bufferedAudioMetadata(payload);
+  if (!bucket || !metadata) return null;
+
+  for (const extension of BUFFERED_AUDIO_EXTENSIONS) {
+    const key = bufferedAudioKey(metadata, extension);
+    const object = await bucket.get(key);
+    if (!object) continue;
+    return {
+      object,
+      metadata,
+      key,
+      extension,
+      contentType: objectContentType(object, extension),
+    };
+  }
+  return {
+    object: null,
+    metadata,
+    key: bufferedAudioKey(metadata, 'wav'),
+    extension: 'wav',
+    contentType: 'audio/wav',
+  };
+}
+
+function cachedGeminiAudioResponse(cacheHit) {
+  return new Response(cacheHit.object.body, {
+    status: 200,
+    headers: bufferedAudioHeaders({
+      metadata: cacheHit.metadata,
+      cacheState: 'hit',
+      contentType: cacheHit.contentType,
+      key: cacheHit.key,
+    }),
+  });
+}
+
+function cacheOnlyResponse(cacheState, cacheHit = null) {
+  const headers = new Headers({
+    'cache-control': 'no-store',
+    'x-ks2-tts-cache': cacheState,
+  });
+  if (cacheHit?.key) headers.set('x-ks2-tts-cache-key', cacheHit.key);
+  if (cacheHit?.metadata?.voice) headers.set('x-ks2-tts-voice', cacheHit.metadata.voice);
+  return new Response(null, { status: 204, headers });
+}
+
+async function storeBufferedGeminiAudio(env, payload, response) {
+  const cacheSlot = await readBufferedGeminiAudio(env, payload);
+  if (!cacheSlot?.metadata || !spellingAudioBucket(env)) {
+    const headers = new Headers(response.headers);
+    headers.set('x-ks2-tts-cache', 'unavailable');
+    return {
+      response: new Response(response.body, { status: response.status, headers }),
+      cacheState: 'unavailable',
+      key: '',
+    };
+  }
+  if (cacheSlot.object) {
+    return {
+      response: cachedGeminiAudioResponse(cacheSlot),
+      cacheState: 'hit',
+      key: cacheSlot.key,
+    };
+  }
+
+  const contentType = response.headers.get('content-type') || 'audio/wav';
+  const bytes = await response.arrayBuffer();
+  try {
+    await spellingAudioBucket(env).put(cacheSlot.key, bytes, {
+      httpMetadata: { contentType },
+      customMetadata: {
+        model: SPELLING_AUDIO_MODEL,
+        voice: cacheSlot.metadata.voice,
+        speed: cacheSlot.metadata.speed,
+        slug: cacheSlot.metadata.slug,
+        sentenceIndex: String(cacheSlot.metadata.sentenceIndex),
+        source: 'worker-gemini-tts',
+      },
+    });
+    return {
+      response: new Response(bytes, {
+        status: 200,
+        headers: bufferedAudioHeaders({
+          metadata: cacheSlot.metadata,
+          cacheState: 'stored',
+          contentType,
+          key: cacheSlot.key,
+        }),
+      }),
+      cacheState: 'stored',
+      key: cacheSlot.key,
+    };
+  } catch {
+    const headers = new Headers(response.headers);
+    headers.set('x-ks2-tts-cache', 'store_failed');
+    headers.set('x-ks2-tts-cache-key', cacheSlot.key);
+    return {
+      response: new Response(bytes, { status: 200, headers }),
+      cacheState: 'store_failed',
+      key: cacheSlot.key,
+    };
+  }
+}
+
+function geminiPrompt(payload = {}) {
+  const { transcript, slow = false, wordOnly = false } = payload;
   if (wordOnly) {
     return `Read exactly this KS2 spelling word once in natural British English. Do not add any extra words:\n\n${transcript}`;
+  }
+  if (payload.word && payload.sentence) {
+    return buildBufferedSpeechPrompt({
+      wordText: payload.word,
+      sentence: payload.sentence,
+      slow,
+    });
   }
   const pace = slow
     ? 'slightly slower than normal, with clear pauses between the word and sentence'
@@ -399,31 +578,53 @@ export async function handleTextToSpeechRequest({
   fetchFn = fetch,
 } = {}) {
   const body = await readJson(request);
+  const cacheOnly = normaliseTtsCacheOnly(body?.cacheOnly);
   const payload = {
     ...(await resolveSpellingAudioRequest({
       repository,
       accountId: session.accountId,
       body,
     })),
-    provider: normaliseRemoteTtsProvider(body?.provider),
+    provider: cacheOnly ? 'gemini' : normaliseRemoteTtsProvider(body?.provider),
+    bufferedGeminiVoice: normaliseBufferedGeminiVoice(body?.bufferedGeminiVoice || body?.cachedVoice),
+    cacheOnly,
   };
   const openAi = openAiConfig(env);
   const gemini = geminiConfig(env);
+  const geminiForPayload = {
+    ...gemini,
+    voice: payload.bufferedGeminiVoice || gemini.voice,
+  };
 
-  await protectTts(env, request, session, now);
-  await protectDemoTtsFallback({ env, request, session, payload, now });
+  if (payload.provider === 'gemini' && !payload.wordOnly) {
+    const cacheHit = await readBufferedGeminiAudio(env, payload);
+    if (cacheHit?.object) {
+      return cacheOnly ? cacheOnlyResponse('hit', cacheHit) : cachedGeminiAudioResponse(cacheHit);
+    }
+    if (cacheOnly && !cacheHit?.metadata) return cacheOnlyResponse('uncacheable');
+  }
 
   if (payload.provider === 'gemini') {
-    if (!gemini.apiKey) throw missingProviderConfig('gemini');
+    if (!geminiForPayload.apiKey) throw missingProviderConfig('gemini');
+    await protectTts(env, request, session, now);
+    await protectDemoTtsFallback({ env, request, session, payload, now });
     try {
-      const response = await requestGeminiSpeech({ config: gemini, payload, fetchFn });
-      return await recordDemoTtsFallback(env, session, now, response);
+      const response = await requestGeminiSpeech({ config: geminiForPayload, payload, fetchFn });
+      const stored = payload.wordOnly
+        ? { response, cacheState: 'uncacheable' }
+        : await storeBufferedGeminiAudio(env, payload, response);
+      const output = cacheOnly
+        ? cacheOnlyResponse(stored.cacheState, { key: stored.key, metadata: bufferedAudioMetadata(payload) })
+        : stored.response;
+      return await recordDemoTtsFallback(env, session, now, output);
     } catch (error) {
       throw backendUnavailableFromFailure(error, [error]);
     }
   }
 
   if (!openAi.apiKey) throw missingProviderConfig('openai');
+  await protectTts(env, request, session, now);
+  await protectDemoTtsFallback({ env, request, session, payload, now });
   try {
     const response = await requestOpenAiSpeech({ config: openAi, payload, fetchFn });
     return await recordDemoTtsFallback(env, session, now, response);

--- a/worker/src/tts.js
+++ b/worker/src/tts.js
@@ -236,16 +236,28 @@ function contentTypeForExtension(extension) {
   return extension === 'mp3' ? 'audio/mpeg' : 'audio/wav';
 }
 
-function bufferedAudioMetadata(payload = {}) {
+async function bufferedAudioMetadata(payload = {}) {
   if (payload.wordOnly) return null;
   const slug = cleanText(payload.slug).toLowerCase();
   const sentenceIndex = Number(payload.sentenceIndex);
-  if (!slug || !Number.isInteger(sentenceIndex) || sentenceIndex < 0) return null;
+  const accountId = cleanText(payload.accountId);
+  const word = cleanText(payload.word);
+  const sentence = cleanText(payload.sentence);
+  if (!accountId || !slug || !word || !sentence || !Number.isInteger(sentenceIndex) || sentenceIndex < 0) return null;
   const voice = normaliseBufferedGeminiVoice(payload.bufferedGeminiVoice);
   const speed = speedIdForSlow(payload.slow);
+  const contentKey = await sha256([
+    'spelling-audio-content-v1',
+    accountId,
+    slug,
+    String(sentenceIndex),
+    word,
+    sentence,
+  ].join('|'));
   return {
     voice,
     speed,
+    contentKey,
     slug,
     sentenceIndex,
   };
@@ -279,13 +291,35 @@ function objectContentType(object, extension) {
 }
 
 async function readBufferedGeminiAudio(env, payload) {
+  const metadata = await bufferedAudioMetadata(payload);
+  if (!metadata) return null;
   const bucket = spellingAudioBucket(env);
-  const metadata = bufferedAudioMetadata(payload);
-  if (!bucket || !metadata) return null;
+  if (!bucket) {
+    return {
+      object: null,
+      metadata,
+      key: bufferedAudioKey(metadata, 'wav'),
+      extension: 'wav',
+      contentType: 'audio/wav',
+      cacheUnavailable: true,
+    };
+  }
 
   for (const extension of BUFFERED_AUDIO_EXTENSIONS) {
     const key = bufferedAudioKey(metadata, extension);
-    const object = await bucket.get(key);
+    let object = null;
+    try {
+      object = await bucket.get(key);
+    } catch {
+      return {
+        object: null,
+        metadata,
+        key: bufferedAudioKey(metadata, 'wav'),
+        extension: 'wav',
+        contentType: 'audio/wav',
+        cacheUnavailable: true,
+      };
+    }
     if (!object) continue;
     return {
       object,
@@ -328,13 +362,14 @@ function cacheOnlyResponse(cacheState, cacheHit = null) {
 
 async function storeBufferedGeminiAudio(env, payload, response) {
   const cacheSlot = await readBufferedGeminiAudio(env, payload);
-  if (!cacheSlot?.metadata || !spellingAudioBucket(env)) {
+  if (!cacheSlot?.metadata || cacheSlot.cacheUnavailable || !spellingAudioBucket(env)) {
     const headers = new Headers(response.headers);
     headers.set('x-ks2-tts-cache', 'unavailable');
     return {
       response: new Response(response.body, { status: response.status, headers }),
       cacheState: 'unavailable',
       key: '',
+      metadata: cacheSlot?.metadata || null,
     };
   }
   if (cacheSlot.object) {
@@ -342,6 +377,7 @@ async function storeBufferedGeminiAudio(env, payload, response) {
       response: cachedGeminiAudioResponse(cacheSlot),
       cacheState: 'hit',
       key: cacheSlot.key,
+      metadata: cacheSlot.metadata,
     };
   }
 
@@ -354,6 +390,7 @@ async function storeBufferedGeminiAudio(env, payload, response) {
         model: SPELLING_AUDIO_MODEL,
         voice: cacheSlot.metadata.voice,
         speed: cacheSlot.metadata.speed,
+        contentKey: cacheSlot.metadata.contentKey,
         slug: cacheSlot.metadata.slug,
         sentenceIndex: String(cacheSlot.metadata.sentenceIndex),
         source: 'worker-gemini-tts',
@@ -371,6 +408,7 @@ async function storeBufferedGeminiAudio(env, payload, response) {
       }),
       cacheState: 'stored',
       key: cacheSlot.key,
+      metadata: cacheSlot.metadata,
     };
   } catch {
     const headers = new Headers(response.headers);
@@ -380,6 +418,7 @@ async function storeBufferedGeminiAudio(env, payload, response) {
       response: new Response(bytes, { status: 200, headers }),
       cacheState: 'store_failed',
       key: cacheSlot.key,
+      metadata: cacheSlot.metadata,
     };
   }
 }
@@ -585,6 +624,7 @@ export async function handleTextToSpeechRequest({
       accountId: session.accountId,
       body,
     })),
+    accountId: session.accountId,
     provider: cacheOnly ? 'gemini' : normaliseRemoteTtsProvider(body?.provider),
     bufferedGeminiVoice: normaliseBufferedGeminiVoice(body?.bufferedGeminiVoice || body?.cachedVoice),
     cacheOnly,
@@ -595,26 +635,35 @@ export async function handleTextToSpeechRequest({
     ...gemini,
     voice: payload.bufferedGeminiVoice || gemini.voice,
   };
+  let protectedRequest = false;
+  async function protectAudioRequest() {
+    if (protectedRequest) return;
+    await protectTts(env, request, session, now);
+    await protectDemoTtsFallback({ env, request, session, payload, now });
+    protectedRequest = true;
+  }
 
   if (payload.provider === 'gemini' && !payload.wordOnly) {
+    await protectAudioRequest();
     const cacheHit = await readBufferedGeminiAudio(env, payload);
     if (cacheHit?.object) {
-      return cacheOnly ? cacheOnlyResponse('hit', cacheHit) : cachedGeminiAudioResponse(cacheHit);
+      const output = cacheOnly ? cacheOnlyResponse('hit', cacheHit) : cachedGeminiAudioResponse(cacheHit);
+      return await recordDemoTtsFallback(env, session, now, output);
     }
+    if (cacheOnly && cacheHit?.cacheUnavailable) return cacheOnlyResponse('unavailable', cacheHit);
     if (cacheOnly && !cacheHit?.metadata) return cacheOnlyResponse('uncacheable');
   }
 
   if (payload.provider === 'gemini') {
     if (!geminiForPayload.apiKey) throw missingProviderConfig('gemini');
-    await protectTts(env, request, session, now);
-    await protectDemoTtsFallback({ env, request, session, payload, now });
+    await protectAudioRequest();
     try {
       const response = await requestGeminiSpeech({ config: geminiForPayload, payload, fetchFn });
       const stored = payload.wordOnly
         ? { response, cacheState: 'uncacheable' }
         : await storeBufferedGeminiAudio(env, payload, response);
       const output = cacheOnly
-        ? cacheOnlyResponse(stored.cacheState, { key: stored.key, metadata: bufferedAudioMetadata(payload) })
+        ? cacheOnlyResponse(stored.cacheState, { key: stored.key, metadata: stored.metadata })
         : stored.response;
       return await recordDemoTtsFallback(env, session, now, output);
     } catch (error) {
@@ -623,8 +672,7 @@ export async function handleTextToSpeechRequest({
   }
 
   if (!openAi.apiKey) throw missingProviderConfig('openai');
-  await protectTts(env, request, session, now);
-  await protectDemoTtsFallback({ env, request, session, payload, now });
+  await protectAudioRequest();
   try {
     const response = await requestOpenAiSpeech({ config: openAi, payload, fetchFn });
     return await recordDemoTtsFallback(env, session, now, response);

--- a/worker/wrangler.example.jsonc
+++ b/worker/wrangler.example.jsonc
@@ -32,6 +32,12 @@
       "database_id": "REPLACE_ME"
     }
   ],
+  "r2_buckets": [
+    {
+      "binding": "SPELLING_AUDIO_BUCKET",
+      "bucket_name": "REPLACE_ME"
+    }
+  ],
   "durable_objects": {
     "bindings": [
       {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -41,6 +41,12 @@
       "migrations_dir": "./worker/migrations"
     }
   ],
+  "r2_buckets": [
+    {
+      "binding": "SPELLING_AUDIO_BUCKET",
+      "bucket_name": "ks2-spelling-buffers"
+    }
+  ],
   "durable_objects": {
     "bindings": [
       {


### PR DESCRIPTION
## Summary
- Add a shared Gemini spelling-audio key contract and R2 binding for the buffered audio bucket.
- Serve cached Gemini dictation audio before provider generation, generate-and-store missing Gemini audio, and support cache-only warming when users play OpenAI or browser TTS.
- Add a profile setting for pre-cached Gemini male/female voice selection and persist it through spelling preferences/read models.

## Verification
- npm test
- npm run check