### PR TITLE
feat(grammar): add mastery engine foundation

### DIFF
--- a/docs/brainstorms/2026-04-24-grammar-mastery-region-requirements.md
+++ b/docs/brainstorms/2026-04-24-grammar-mastery-region-requirements.md
@@ -1,0 +1,164 @@
+---
+date: 2026-04-24
+topic: grammar-mastery-region
+---
+
+# Grammar Mastery Region
+
+## Problem Frame
+
+KS2 Mastery needs a real Grammar subject that preserves the learning value of the legacy Grammar engine while fitting the current production platform, subject runtime, and creature-collection reward layer.
+
+The legacy engine is a strong reference for how Grammar mastery should work without the game layer: deterministic question generation, post-attempt feedback, misconception tracking, mixed retrieval, spaced return, worked and faded support, and KS2-style test practice. The new product work should not turn that into a cosmetic quiz. The game layer should sit on top of the learning model as a reward and identity system, not change scoring, scheduling, or evidence of mastery.
+
+The Clause Conservatory is the Grammar region. Existing world, monster, and background assets already make the region visually shippable once the subject engine and reward mapping are ready.
+
+---
+
+## Actors
+
+- A1. KS2 learner: practises Grammar concepts, receives feedback, and sees creature progress.
+- A2. Parent or supervising adult: needs clear evidence of what improved and what still needs review.
+- A3. Grammar subject engine: owns deterministic question generation, marking, scheduling, and mastery evidence.
+- A4. Game and reward layer: derives monster unlocks and evolution from committed learning evidence.
+- A5. Platform runtime: owns persistence, Worker command boundaries, domain events, and production safety.
+
+---
+
+## Key Flows
+
+- F1. Grammar practice without game dependency
+  - **Trigger:** A learner starts Grammar practice from the Grammar subject route.
+  - **Actors:** A1, A3, A5
+  - **Steps:** The learner selects a mode, receives a deterministic item, makes a genuine first attempt, receives post-attempt feedback, and the engine updates skill, template, question-type, item, misconception, retry, and session state.
+  - **Outcome:** The learner has a new evidence point; mastery state changes only through deterministic marking.
+  - **Covered by:** R1, R2, R3, R4, R5, R6, R7, R8, R18, R19
+
+- F2. Monster progress as a derived reward
+  - **Trigger:** A committed Grammar answer changes a concept from not-secured to secured, or advances aggregate Grammar mastery.
+  - **Actors:** A1, A4, A5
+  - **Steps:** The reward layer reads the committed mastery event, maps the secured concept to the relevant monster family, updates caught/evolution state, and returns any celebration as part of the user-visible command response.
+  - **Outcome:** The learner sees monster progress, but the reward layer has not influenced whether the answer was correct or whether the concept is secure.
+  - **Covered by:** R9, R10, R11, R12, R13, R14
+
+- F3. Adult-facing evidence
+  - **Trigger:** A parent or adult reviews Grammar progress.
+  - **Actors:** A2, A3, A5
+  - **Steps:** The system shows secured concepts, due concepts, weak concepts, misconception trends, question-type strength, recent activity, and an explanation of the learning method.
+  - **Outcome:** The adult can see the educational progress separately from the creature rewards.
+  - **Covered by:** R15, R16, R17
+
+---
+
+## Requirements
+
+**Learning model**
+- R1. Grammar must be treated as a concept mastery engine, not a full English writing engine. It should target KS2 Grammar and GPS-style practice, while making clear that paragraph writing transfer is a later capability.
+- R2. The first Grammar implementation should preserve or deliberately route the legacy coverage baseline: 18 concepts, 51 deterministic templates, 31 selected-response templates, 20 constructed-response templates, and the eight question-type families: classify, identify, choose, fill, fix, rewrite, build, and explain.
+- R3. Mastery evidence must be tracked at multiple levels: concept skill, template, question type, generated item, misconception, retry queue, event history, and session summary.
+- R4. Concept progress and the 0-100% Grammar mastery scale should be derived from secured learning evidence, not raw accuracy or session volume. Each node should keep the legacy measurement model unless planning finds a tested reason to change it: start around 25% strength, update from answer quality, and become secured only when it is strong, spaced, and stable.
+- R5. A secured concept should require all of these evidence signals: at least one attempt, strength at or above 82%, review interval at or above 7 days, correct streak at or above 3, not currently weak, and not currently due for review.
+- R6. Practice must preserve the learning science value before adding game rewards: mixed retrieval, interleaving, spaced return, immediate mistake recycling, contrastive examples, minimal post-attempt hints, worked examples, faded support, and no answer leakage before the first attempt.
+- R7. Supported answers must not count the same as independent first-attempt correctness. Worked and faded support may help learning, but should produce lower mastery gain than an unsupported correct response.
+- R8. AI may support enrichment only. It may explain, summarise, or suggest revision cards, but score-bearing questions and marking must remain deterministic and replayable.
+
+**Grammar region and reward layer**
+- R9. The Grammar region should use The Clause Conservatory identity from `docs/plans/james/grammar/grammar-conversation.md` and `assets/regions/the-clause-conservatory/`.
+- R10. The v1 Grammar creature set should contain seven monsters: Bracehart, Glossbloom, Loomrill, Chronalyx, Couronnail, Mirrane, and the aggregate legendary Concordium.
+- R11. The six direct monster families should map to the six Grammar domains already chosen in the design conversation: Sentence / Clause, Word / Phrase, Flow / Linkage, Verb / Mood, Register / Standard, and Voice / Role.
+- R12. Direct monster evolution should be derived from secured concepts or secured sub-skills in its mapped domain, with stage thresholds proportional to that domain's denominator. Concordium should derive from aggregate Grammar-region mastery and should only reach Mega when the full chosen Grammar mastery denominator is secured.
+- R13. Monster state must be derived from committed learning events or read models. The game layer must not mutate Grammar answer correctness, mastery strength, scheduling, retry queues, or concept status.
+- R14. Existing monster assets under `assets/monsters/bracehart/`, `assets/monsters/glossbloom/`, `assets/monsters/loomrill/`, `assets/monsters/chronalyx/`, `assets/monsters/couronnail/`, `assets/monsters/mirrane/`, and `assets/monsters/concordium/` should be reused before requesting new image generation.
+
+**Reporting and product framing**
+- R15. Grammar reporting must separate the education layer from the game layer: first explain what has improved educationally, then show how the creature rewards reflect that progress.
+- R16. Parent-facing summaries should expose concept status, misconception trends, due review, recent activity, and question-type weakness without requiring the adult to understand the monster system.
+- R17. Learner-facing copy may celebrate creatures, but must not imply that monster progress is a substitute for secured Grammar evidence.
+
+**Production boundary**
+- R18. Production Grammar must follow the current subject-expansion and full-lockdown direction: React renders the subject UI and returned read models, while scored session creation, marking, scheduling, progress mutation, and reward projection belong behind Worker subject commands before release.
+- R19. Browser-local Grammar may exist only as a development or reference mode. It must not become the production source of truth for scoring, scheduling, or mastery state.
+- R20. Grammar integration must not regress English Spelling parity, shared subject routing, generic persistence, import/export restoration, learner switching, event publication, or production bundle audit guarantees.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R4, R5, R12.** Given a learner has answered several Sentence / Clause questions correctly but the concept is still due today, when the reward layer calculates Bracehart progress, the concept does not count as secured until the due review is passed.
+- AE2. **Covers R7, R13.** Given a learner uses a worked example and then answers correctly, when the engine updates mastery, the concept may improve but receives lower gain than an independent first-attempt correct answer, and the monster layer simply reflects the committed result.
+- AE3. **Covers R8.** Given AI returns a revision card, when the learner loads a follow-up drill, the score-bearing question must come from an approved deterministic template rather than AI-authored free text.
+- AE4. **Covers R15, R16, R17.** Given a parent opens a progress view, when the report is rendered, it first explains secured and weak Grammar concepts, then separately shows which monsters evolved because of that evidence.
+
+---
+
+## Success Criteria
+
+- Learners improve Grammar through retrieval, discrimination, spaced review, and feedback before any game reward is considered.
+- The Clause Conservatory feels like a complete subject region with existing backgrounds and monster assets, not a pasted-on skin.
+- Concordium and the six direct monsters create motivation without corrupting mastery measurement.
+- A planner can implement Grammar without inventing the education method, reward mapping, or production safety boundary.
+- The implementation can be verified with deterministic template tests, mini-set generation tests, subject conformance tests, and reward derivation tests.
+
+---
+
+## Scope Boundaries
+
+- Do not directly ship the legacy single-file HTML as the production subject.
+- Do not let AI author score-bearing Grammar items or mark free-text scored answers in production.
+- Do not make Grammar rewards depend on session volume alone; progress should reflect secured learning evidence.
+- Do not build paragraph-level writing transfer in the first Grammar slice unless James explicitly expands scope.
+- Do not build a Grammar content CMS in the first slice.
+- Do not alter English Spelling parity or the existing spelling monster rules as part of this work.
+- Do not collapse Bellstorm Coast into The Clause Conservatory. Full Grammar may include punctuation-for-grammar concepts for KS2 GPS mastery, but the Punctuation region should keep a distinct future identity and progression path.
+
+---
+
+## Key Decisions
+
+- Use the legacy Grammar engine as a reference implementation, not as production code: it contains the right pedagogy and coverage, but must fit the current subject runtime.
+- Keep game rewards additional: the reward layer derives from learning evidence and never controls marking or scheduling.
+- Use seven Grammar creatures for the Clause Conservatory: six direct domain monsters plus Concordium as the aggregate legendary.
+- Reuse existing assets first: the required Clause Conservatory backgrounds and Grammar monster stage assets are already present in `assets/`.
+- Full Grammar target includes the legacy 18-concept denominator, including punctuation-for-grammar concepts, while Stage 1 may ship as a smaller production-safe slice with placeholders and progression hooks for the full target.
+
+| Monster | Grammar domain | Legacy concept ids |
+|---|---|---|
+| Bracehart | Sentence / Clause | `sentence_functions`, `clauses`, `relative_clauses` |
+| Glossbloom | Word / Phrase | `word_classes`, `noun_phrases` |
+| Loomrill | Flow / Linkage | `adverbials`, `pronouns_cohesion` |
+| Chronalyx | Verb / Mood | `tense_aspect`, `modal_verbs` |
+| Couronnail | Register / Standard | `standard_english`, `formality` |
+| Mirrane | Voice / Role | `active_passive`, `subject_object` |
+| Concordium | Aggregate legendary | All selected Grammar-region denominator concepts |
+
+The punctuation-for-grammar concepts included in the full Grammar denominator are `parenthesis_commas`, `speech_punctuation`, `apostrophes_possession`, `boundary_punctuation`, and `hyphen_ambiguity`. Bellstorm Coast can still become a richer Punctuation subject later without changing the Grammar engine's GPS-style coverage.
+
+---
+
+## Dependencies / Assumptions
+
+- `docs/subject-expansion.md` is the current contract for adding the first real non-Spelling subject.
+- `docs/plans/2026-04-23-001-feat-full-lockdown-runtime-plan.md` is the current direction for Worker-owned production subject commands and projections.
+- `src/subjects/placeholders/index.js` confirms Grammar and Punctuation are separate placeholder subjects today.
+- `src/platform/game/monsters.js` and `src/platform/game/monster-system.js` provide the existing spelling monster pattern that Grammar should extend rather than replace.
+- The supplied legacy Grammar HTML and review report are accepted as the reference for coverage, measuring logic, and educational method.
+
+---
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+- None. James wants the full Grammar target, delivered in multiple PRs/stages. Stage 1 can be the production-safe v1, but the plan should include full placeholders and a path to the complete 18-concept Grammar region.
+
+### Deferred to Planning
+
+- [Affects R18, R20][Technical] Decide the exact Worker command and read-model shape for Grammar after checking the latest full-lockdown implementation state.
+- [Affects R14][Technical] Decide whether Grammar needs new monster metadata fields or can extend the existing monster system with subject-specific monster lists and thresholds.
+- [Affects R2, R5][Technical] Convert the legacy template smoke tests and mini-set regression tests into repo tests using deterministic fixtures.
+
+---
+
+## Next Steps
+
+-> `/ce-plan` for a staged full Grammar implementation plan.

--- a/docs/plans/2026-04-24-001-feat-grammar-mastery-region-plan.md
+++ b/docs/plans/2026-04-24-001-feat-grammar-mastery-region-plan.md
@@ -1,0 +1,1059 @@
+---
+title: "feat: Full Grammar Mastery Region"
+type: feat
+status: active
+date: 2026-04-24
+origin: docs/brainstorms/2026-04-24-grammar-mastery-region-requirements.md
+deepened: 2026-04-24
+---
+
+# feat: Full Grammar Mastery Region
+
+## Overview
+
+Build The Clause Conservatory as the full Grammar region, delivered in stages. Stage 1 is a production-safe v1, but the architecture, content denominator, monster catalogue, analytics shape, and subject contracts must already point at the full product rather than a throwaway slice.
+
+The full target is the legacy Grammar mastery model: 18 KS2 Grammar / GPS concepts, 51 deterministic templates, misconception-aware feedback, spaced review, KS2-style mini-tests, and seven Grammar monsters. The game layer derives from secured learning evidence only. It must never influence marking, scheduling, retry queues, or mastery status.
+
+This plan assumes the full-lockdown runtime direction continues: React renders UI and submitted form state, while production scored session creation, marking, scheduling, persistence, domain events, reward projection, and read models are Worker-owned.
+
+---
+
+## Problem Frame
+
+James wants the full Grammar subject, not a small experiment that later has to be rebuilt. The practical delivery should still be staged across multiple PRs so each stage can be reviewed, tested, and shipped without blocking on every future capability.
+
+The key product call is now resolved: the full Grammar denominator includes all 18 legacy concepts, including the five punctuation-for-grammar concepts. Bellstorm Coast can still become a richer Punctuation region later, but The Clause Conservatory needs the full KS2 GPS-style Grammar coverage for Concordium and the Grammar mastery claim.
+
+---
+
+## Requirements Trace
+
+- R1. Grammar is a concept mastery engine, not a full English writing engine.
+- R2. Preserve or deliberately route the legacy baseline: 18 concepts, 51 deterministic templates, 31 selected-response templates, 20 constructed-response templates, and classify / identify / choose / fill / fix / rewrite / build / explain question types.
+- R3. Track mastery at concept, template, question-type, generated-item, misconception, retry, event, and session levels.
+- R4. Derive the 0-100% Grammar scale from secured learning evidence, not raw accuracy or session volume.
+- R5. A concept is secured only when strength, spacing, streak, due status, and weak status all support it.
+- R6. Preserve mixed retrieval, interleaving, spaced return, mistake recycling, contrast, minimal hints, worked support, faded support, and no pre-attempt answer leakage.
+- R7. Supported correctness counts less than independent first-attempt correctness.
+- R8. AI stays enrichment-only; score-bearing generation and marking stay deterministic.
+- R9. Use The Clause Conservatory region identity and assets.
+- R10. Use seven Grammar creatures: Bracehart, Glossbloom, Loomrill, Chronalyx, Couronnail, Mirrane, and Concordium.
+- R11. Map six direct monster families to the six Grammar domains.
+- R12. Direct evolution derives from secured domain concepts; Concordium derives from aggregate Grammar mastery and reaches Mega only at full selected denominator.
+- R13. Monster state derives from committed learning events or read models and never mutates learning state.
+- R14. Reuse existing monster assets before requesting new image generation.
+- R15. Reporting separates educational evidence from game rewards.
+- R16. Parent-facing summaries expose concept status, misconception trends, due review, recent activity, and question-type weakness.
+- R17. Learner-facing creature copy must not imply rewards replace mastery evidence.
+- R18. Production Grammar follows the Worker-owned subject command/read-model direction.
+- R19. Browser-local Grammar can exist only as development/reference mode.
+- R20. Do not regress English Spelling parity, routing, persistence, import/export, learner switching, event publication, or bundle audit guarantees.
+
+**Origin actors:** A1 KS2 learner, A2 Parent or supervising adult, A3 Grammar subject engine, A4 Game and reward layer, A5 Platform runtime.
+
+**Origin flows:** F1 Grammar practice without game dependency, F2 Monster progress as a derived reward, F3 Adult-facing evidence.
+
+**Origin acceptance examples:** AE1 due review blocks monster progress, AE2 supported correctness gives lower gain, AE3 AI drill uses deterministic templates, AE4 parent report separates education evidence from rewards.
+
+---
+
+## Scope Boundaries
+
+- Do not directly ship the legacy single-file HTML as the production subject.
+- Do not let AI author scored items or mark scored free-text answers.
+- Do not base monster progression on session volume alone.
+- Do not build a Grammar content CMS in the first stages.
+- Do not alter English Spelling parity or existing spelling monster rules.
+- Do not collapse Bellstorm Coast into The Clause Conservatory. Grammar full includes punctuation-for-grammar concepts; Bellstorm Coast remains a future distinct Punctuation progression.
+- Do not expose production Grammar engine/content authority in the public browser bundle.
+
+### Deferred to Follow-Up Work
+
+- Full paragraph-level writing transfer: ship after the deterministic Grammar engine and reporting are stable.
+- Bellstorm Coast as its own rich Punctuation subject: plan separately after Grammar's punctuation-for-grammar bridge is clear.
+- Grammar content-management workflows: defer until the deterministic content has production evidence.
+- Optional AI tutor/reporting polish: only after deterministic scoring and read models are complete.
+
+### Explicitly Not In This Plan
+
+- Daily Grammar Mission / habit loop: defer until the core Grammar product is on the table and the deterministic engine, Worker boundary, and evidence model have shipped.
+- SATs countdown, weekly digest, and exam coaching flows: defer to a later product pass rather than bundling them into the engine translation and full skeleton work.
+- Gamified streak/ranking mechanics beyond derived monster progress: defer unless they can be proved to reinforce, not replace, secured Grammar evidence.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `docs/brainstorms/2026-04-24-grammar-mastery-region-requirements.md` is the origin product decision.
+- `docs/plans/2026-04-23-001-feat-full-lockdown-runtime-plan.md` defines the Worker-owned subject command/read-model direction.
+- `docs/subject-expansion.md` defines the future-subject harness, React subject module contract, generic persistence boundaries, and production rule that a public subject must not ship its production engine as a browser runtime.
+- `src/platform/core/subject-registry.js` currently registers `grammarModule` as a placeholder subject from `src/subjects/placeholders/index.js`.
+- `worker/src/subjects/runtime.js` registers Worker subject command handlers by subject id. Grammar should plug into the same runtime as Spelling.
+- `worker/src/subjects/spelling/commands.js` is the current pattern for subject command handling, read model building, projection events, rewards, audio cues, and runtime writes.
+- `worker/src/subjects/spelling/read-models.js` is the current safe read-model shape for browser rendering.
+- `src/subjects/spelling/module.js` and `src/subjects/spelling/components/` are the current React subject surface patterns.
+- `src/platform/game/monsters.js`, `src/platform/game/monster-system.js`, and `tests/monster-system.test.js` are the reward pattern to extend.
+- `tests/subject-expansion.test.js` and `tests/helpers/subject-expansion-harness.js` define the subject expansion conformance and golden-path expectations.
+- `tests/worker-subject-runtime.test.js`, `tests/worker-projections.test.js`, and `tests/server-spelling-engine-parity.test.js` show the server runtime and parity test style to mirror.
+- `docs/plans/james/grammar/grammar-conversation.md` records the Clause Conservatory identity, monster names, and asset direction.
+- `assets/regions/the-clause-conservatory/` already contains the Grammar region backgrounds.
+- `assets/monsters/bracehart/`, `assets/monsters/glossbloom/`, `assets/monsters/loomrill/`, `assets/monsters/chronalyx/`, `assets/monsters/couronnail/`, `assets/monsters/mirrane/`, and `assets/monsters/concordium/` already contain stage assets.
+
+### Institutional Learnings
+
+- The previous ks2-mastery release-gate work treated pre-production validation as a real gate: tests, check, production-bundle audit, deterministic smoke checks, and production UI verification when user-facing flows change.
+- Browser/gstack validation can be flaky on this machine, so deterministic HTTP/Node checks should be the fallback evidence path.
+- Current project instructions require package scripts for Cloudflare operations and warn not to regress spelling parity, remote sync, learner state, D1, R2, or deployment paths.
+
+### External References
+
+- External research is not needed for this plan. The core risk is local architecture and pedagogy preservation, and the repo already has strong local patterns for subject command boundaries, read models, deterministic engines, reward projection, and subject expansion testing.
+
+---
+
+## What Already Exists
+
+| Need | Existing foundation | Plan posture |
+|---|---|---|
+| Grammar pedagogy and deterministic content | Reviewed legacy Grammar HTML engine | Use as oracle and translate, do not discard fidelity. |
+| Subject command boundary | `POST /api/subjects/:subjectId/command`, `worker/src/subjects/runtime.js`, command contract tests | Reuse for Grammar; no Grammar-specific endpoint. |
+| Worker subject pattern | `worker/src/subjects/spelling/commands.js`, `worker/src/subjects/spelling/read-models.js` | Mirror command/read-model shape while keeping Grammar engine separate. |
+| Generic persistence | `child_subject_state`, `practice_sessions`, `event_log`, `child_game_state` repository paths | Store Grammar state through the existing generic tables. |
+| Reward projection | `src/platform/game/monsters.js`, `src/platform/game/monster-system.js`, `worker/src/projections/rewards.js` | Extend subject-aware reward helpers without changing Spelling semantics. |
+| Subject UI shell | React subject route, registry, Spelling components, placeholder modules | Replace Grammar placeholder with a real module and reuse shell patterns. |
+| Production bundle lockdown | `tests/build-public.test.js`, `scripts/production-bundle-audit.mjs` | Add Grammar forbidden-path assertions. |
+| Release gate | `npm test`, `npm run check`, production-style smoke posture | Keep package-script verification and logged-in/demo UI verification. |
+
+## Dream State Delta
+
+```text
+CURRENT STATE
+  Spelling is real. Grammar is a placeholder. Legacy Grammar engine exists outside the production platform.
+
+THIS PLAN
+  Grammar becomes the first full non-Spelling mastery subject:
+  deterministic engine, Worker commands, full 18-concept map, evidence read model,
+  derived monsters, bundle lockdown, and staged future modes.
+
+12-MONTH IDEAL
+  KS2 Mastery has multiple real subjects using the same subject command/read-model spine.
+  Parents trust the evidence. Learners see creature progress, but mastery remains auditable.
+  New subjects reuse the platform instead of reopening architecture every time.
+```
+
+## Architecture Fit
+
+```text
+React Grammar Surface
+  |
+  | command intent only
+  v
+POST /api/subjects/grammar/command
+  |
+  | existing subject command contract
+  v
+worker/src/subjects/runtime.js
+  |
+  | dispatch subjectId=grammar
+  v
+worker/src/subjects/grammar/commands.js
+  |
+  +--> worker/src/subjects/grammar/engine.js
+  |      |
+  |      +--> worker/src/subjects/grammar/content.js
+  |
+  +--> worker/src/subjects/grammar/read-models.js
+  |
+  +--> worker/src/projections/rewards.js
+  |
+  v
+D1 generic persistence
+  child_subject_state
+  practice_sessions
+  event_log
+  child_game_state
+```
+
+State machine:
+
+```text
+setup
+  | start-session
+  v
+session
+  | submit-answer
+  v
+feedback
+  | continue-session              | end-session
+  v                               v
+session ----------------------> summary
+  ^                               |
+  | resume/reload read model      | start-session
+  +-------------------------------+
+
+Invalid transitions:
+  submit-answer without active session -> grammar_session_stale
+  worked/faded support in strict mini-test before marking -> grammar_mode_unsupported
+  locked future mode command -> subject_command_not_found or grammar_mode_unsupported
+```
+
+---
+
+## Key Technical Decisions
+
+- **Full target from day one:** Stage 1 may ship as v1, but every durable contract should reference the full 18-concept Grammar denominator and seven-monster progression path.
+- **Stage 1 skeleton is full-product shaped:** Stage 1 may enable only learn, smart mixed review, and KS2-style mini-set modes, but its read models, capability flags, concept map, monster metadata, analytics fields, and locked/future UI states should already represent the full Grammar product.
+- **Worker-first subject authority:** Grammar production scoring, scheduling, session state, persistence, and rewards should be Worker-owned, matching the full-lockdown direction.
+- **Reuse the generic subject command route:** Grammar should plug into the existing `POST /api/subjects/:subjectId/command` route and subject runtime. It should not add a Grammar-specific command endpoint or bypass request ids, expected learner revisions, same-origin checks, replay handling, or stale-write retry semantics.
+- **Legacy engine as source material, not production code:** Extract concepts, templates, state transitions, and tests from the HTML, but do not copy DOM, localStorage, browser AI key handling, or closure-heavy runtime assumptions into production.
+- **Legacy engine as oracle before translation:** Stage 1 should first capture the reviewed HTML engine's observable behaviour as golden fixtures, then translate that behaviour into Worker-safe modules. Fidelity is proven by tests, not by manual interpretation.
+- **Characterisation-first extraction:** Before changing the legacy logic shape, pin template generation, marking, mini-set generation, secured status, and retry scheduling with tests.
+- **Stable replay identity:** Generated items, attempts, and analytics evidence should be replayable by `contentReleaseId`, template id, seed, and learner response data. This lets Stage 1 remain auditable while later stages add modes and accepted-answer improvements.
+- **Multi-skill templates preserve legacy update semantics:** If a template carries multiple `skillIds`, the translated engine should update every listed concept node, matching the legacy engine's `applyLearningUpdate()` behaviour, unless an oracle fixture proves a narrower rule for a specific item.
+- **All 18 concepts are in full Grammar:** The five punctuation-for-grammar concepts count towards the full Grammar denominator and Concordium. Bellstorm Coast remains a future Punctuation subject for richer punctuation identity.
+- **Stage 1 user promise:** Stage 1 should feel like a real Clause Conservatory v1, not an empty placeholder: learner can practise, see concept status, and see locked/full progression. Some advanced modes may be visibly "coming next".
+- **Game layer remains derived:** Grammar monsters evolve from secured concept evidence and aggregate Grammar mastery only. Reward projection never writes Grammar mastery.
+- **Read models are the UI contract:** React components should render the current Grammar read model and submit command payloads. They should not import scoring templates or engine content in production.
+- **Parent evidence before rewards:** Adult reporting should show secured/due/weak/misconception evidence first, then creature progress as a derived motivator.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should this stay v1-only?** No. The product target is full Grammar, staged across PRs.
+- **Should Stage 1 still exist?** Yes. Stage 1 is the first production-safe delivery, but with full placeholders and denominator contracts.
+- **Should punctuation-for-grammar count for full Concordium?** Yes. Full Grammar uses all 18 legacy concepts. Bellstorm Coast remains a future distinct subject/region.
+- **Should the legacy HTML be directly merged?** No. It is a reference implementation and test oracle.
+- **Should AI be part of Stage 1 scoring?** No. AI stays optional enrichment later and never owns scored marking.
+
+### Deferred to Implementation
+
+- **Exact staged feature flag / availability copy:** Choose during React implementation so locked placeholders fit the current subject UI.
+- **Exact Grammar command envelope fields:** Follow the final full-lockdown command contract when implementation starts.
+- **Exact threshold numbers for each direct Grammar monster:** Use proportional thresholds over each domain denominator, then tune with tests and James review.
+- **Exact accepted-answer expansion strategy:** Preserve deterministic marking first, then add accepted variants where tests prove legitimate alternatives.
+
+## Implementation Prerequisites
+
+- The generic Worker subject command route from the full-lockdown work exists and must be reused. U3 should only extend the subject runtime with Grammar handlers and any generic hook that Grammar proves is missing.
+- The supplied legacy Grammar artefacts remain reference inputs only. Extracted production content should live in Worker-safe modules and plan/code references should stay repo-relative.
+- Existing Clause Conservatory region assets and the seven Grammar monster asset folders are available and should be reused before requesting new assets.
+- Stage 1 release decisions must preserve the full 18-concept denominator even if only the core practice modes are enabled.
+- Feature flags or capability fields should distinguish "not enabled yet" from "not part of the full Grammar product" so Stage 1 placeholders do not become product debt.
+
+---
+
+## Phased Delivery
+
+### Stage 1: Production-Safe Grammar v1 With Full Skeleton
+
+- Build a legacy engine translation harness that snapshots generated items, marking results, mini-set generation, secured-status examples, and retry/scheduling transitions from the reviewed HTML engine.
+- Port and test the full 18-concept content catalogue and deterministic engine core.
+- Ship a Worker-owned Grammar subject command/read-model path for core practice.
+- Replace the placeholder Grammar route with a real Clause Conservatory surface.
+- Show full concept map, all seven monsters, locked/coming-next states, and aggregate Concordium path.
+- Include core modes only: learn, smart mixed review, and KS2-style mini-set, unless implementation proves additional modes are cheap and safe.
+
+### Stage 2: Full Legacy Practice Modes
+
+- Add trouble, surgery, builder, worked-example, and faded-support modes.
+- Harden retry scheduling, misconception repair loops, and question-type balancing.
+- Expand analytics to match the educational method in the legacy report.
+
+### Stage 3: Reporting, Parent Evidence, And AI Safe Lane
+
+- Add parent/adult summaries, exportable progress evidence, and richer read models.
+- Add optional AI explanation/revision-card enrichment with deterministic drill whitelisting.
+- Keep AI output non-scored.
+
+### Stage 4: Transfer And Punctuation Bridge
+
+- Add paragraph/sentence-transfer modes as non-scored or explicitly teacher-reviewed workflows.
+- Define how Bellstorm Coast receives richer Punctuation progression without stealing or corrupting the Grammar denominator.
+- Decide whether punctuation monsters remain separate from the Grammar seven or become a cross-region progression.
+
+---
+
+## Output Structure
+
+This expected shape is directional. Implementation may adjust names if a tighter local pattern appears, but the plan expects production authority to live in Worker-side Grammar modules and browser code to render read models only.
+
+```text
+worker/src/subjects/grammar/
+  content.js
+  engine.js
+  commands.js
+  read-models.js
+tests/fixtures/grammar-legacy-oracle/
+src/subjects/grammar/
+  module.js
+  components/
+    GrammarPracticeSurface.jsx
+    GrammarSetupScene.jsx
+    GrammarSessionScene.jsx
+    GrammarSummaryScene.jsx
+    GrammarAnalyticsScene.jsx
+    GrammarMonsterProgress.jsx
+src/platform/game/
+  monsters.js
+  monster-system.js
+tests/
+  grammar-engine.test.js
+  worker-grammar-subject-runtime.test.js
+  react-grammar-surface.test.js
+  grammar-monster-system.test.js
+```
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+sequenceDiagram
+  participant Learner as Learner
+  participant React as Grammar React surface
+  participant Worker as Worker subject command API
+  participant Runtime as Subject runtime
+  participant Engine as Grammar engine
+  participant Projection as Events and rewards
+  participant D1 as D1 repositories
+
+  Learner->>React: Start Grammar practice
+  React->>Worker: grammar start-session command
+  Worker->>Runtime: Dispatch subjectId=grammar
+  Runtime->>Engine: Select deterministic item from 18-concept catalogue
+  Engine-->>Runtime: Session state and read-model data
+  Runtime-->>Worker: Runtime write payload
+  Worker->>D1: Persist subject state and practice session
+  Worker-->>React: Grammar read model
+  Learner->>React: Submit answer
+  React->>Worker: grammar submit-answer command
+  Worker->>Runtime: Dispatch
+  Runtime->>Engine: Mark deterministically and update mastery evidence
+  Runtime->>Projection: Publish grammar domain events
+  Projection->>Projection: Derive monster events from secured concepts
+  Worker->>D1: Commit subject state, session, events, reward state
+  Worker-->>React: Feedback, read model, celebrations
+```
+
+---
+
+## Implementation Units
+
+- [x] U1. **Extract Full Grammar Content And Characterisation Tests**
+
+**Goal:** Convert the legacy Grammar engine into a tested, portable source of Grammar content and expected behaviour before production integration starts.
+
+**Requirements:** R1, R2, R3, R4, R5, R6, R7, R8, AE1, AE2, AE3
+
+**Dependencies:** None.
+
+**Files:**
+- Create: `worker/src/subjects/grammar/content.js`
+- Create: `tests/grammar-engine.test.js`
+- Create: `scripts/extract-grammar-legacy-oracle.mjs`
+- Create: `tests/helpers/grammar-legacy-oracle.js`
+- Create: `tests/fixtures/grammar-legacy-oracle/`
+- Reference: `docs/plans/james/grammar/grammar-conversation.md`
+- Reference: `docs/brainstorms/2026-04-24-grammar-mastery-region-requirements.md`
+
+**Approach:**
+- Treat the reviewed legacy HTML engine as the behavioural oracle for Stage 1 extraction.
+- Build an offline translation harness that captures representative generated questions, expected marking outcomes, mini-set packs, concept status examples, misconception tags, and retry/scheduling transitions from the supplied legacy artefact.
+- Keep the legacy source artefact out of production output. The extraction script may read a local supplied file during development, but committed tests should rely on repo-local fixtures and Worker-safe content modules.
+- Extract the 18 concept definitions, misconception labels, minimal hints, question-type metadata, template metadata, and lexicon/reference items into Worker-safe content.
+- Preserve the full denominator in data, including punctuation-for-grammar concepts.
+- Assign a `contentReleaseId` and replay metadata so every generated item can be traced by release, template id, seed, concept ids, question type, and deterministic answer model.
+- Preserve template `skillIds` arrays and test that multi-skill generated items update every listed concept node in the translated engine.
+- Avoid DOM, localStorage, browser AI settings, or render string assumptions.
+- Add characterisation tests for all 51 templates: deterministic generation, evaluate without runtime errors, item ids, skill ids, question type ids, and accepted-answer behaviour where deterministic.
+- Compare the translated Worker-safe content and engine behaviour against the legacy oracle fixtures before any product UI work depends on it.
+- Add mini-set generation regression tests for mixed plus each concept focus.
+
+**Execution note:** Characterisation-first. Pin behaviour before improving structure.
+
+**Patterns to follow:**
+- `worker/src/subjects/spelling/engine.js`
+- `tests/server-spelling-engine-parity.test.js`
+- `tests/spelling-parity.test.js`
+
+**Test scenarios:**
+- Happy path: legacy oracle fixtures load without browser APIs and document the reviewed legacy content release.
+- Happy path: all 18 concept ids exist and are mapped either to a direct Grammar monster domain or the aggregate-only punctuation-for-grammar bucket.
+- Happy path: all 51 templates generate valid serialisable question data for multiple fixed seeds.
+- Happy path: selected-response and constructed-response template counts match the legacy baseline.
+- Happy path: all template skill ids reference known concepts.
+- Happy path: generated items include stable replay metadata for `contentReleaseId`, template id, seed, concept ids, and question type.
+- Happy path: multi-skill template answers update all listed concept mastery nodes, not only the first skill id.
+- Regression: translated Worker-safe generation and marking match the legacy oracle for the fixed fixture seeds and responses.
+- Error path: constructed-response marking handles empty or malformed learner responses without throwing.
+- Integration: mini-set generation returns target length for mixed plus all 18 focused concept cases.
+- Regression: mini-set generation does not loop indefinitely for narrow concept pools.
+- Regression: template repeat caps and fallback broadening preserve executable test packs.
+
+**Verification:**
+- The full Grammar catalogue is represented in Worker-safe modules.
+- The extracted content is covered by deterministic tests and can be used without browser APIs.
+
+- [x] U2. **Build Grammar Engine State And Mastery Transitions**
+
+**Goal:** Implement the Grammar engine's core state machine: session creation, deterministic marking, learning updates, retry queue, status calculation, and analytics-friendly events.
+
+**Requirements:** R3, R4, R5, R6, R7, R8, R15, R16, AE1, AE2
+
+**Dependencies:** U1.
+
+**Files:**
+- Create: `worker/src/subjects/grammar/engine.js`
+- Modify: `tests/grammar-engine.test.js`
+
+**Approach:**
+- Define serialisable Grammar state: prefs, mastery nodes, retry queue, sessions, current round, recent events, and content release id.
+- Implement the legacy status model: new, learning, weak, due, secured.
+- Preserve answer quality weighting so independent first-attempt correctness gives the strongest gain and worked/faded support gives reduced gain.
+- Use deterministic time/random fixtures in tests; avoid live `Math.random()` inside selection logic once a session seed exists.
+- Store attempt evidence in a replayable shape: content release id, template id, seed, learner response, support level, marker result, misconception tags, and resulting status delta.
+- Emit domain events such as `grammar.answer-submitted`, `grammar.concept-secured`, `grammar.misconception-seen`, and `grammar.session-completed`.
+
+**Patterns to follow:**
+- `worker/src/subjects/spelling/engine.js`
+- `src/subjects/spelling/service-contract.js`
+- `docs/spelling-parity.md`
+
+**Test scenarios:**
+- Happy path: first independent correct answer increases concept/template/question-type/item strength.
+- Covers AE1. Edge case: a concept with high strength but due now is not reported as secured.
+- Covers AE2. Happy path: worked/faded supported correctness improves state less than independent first-attempt correctness.
+- Error path: wrong answers reduce strength, reset correct streak, tag misconception, and enqueue retry.
+- Edge case: partial constructed-response credit schedules shorter review than independent correct.
+- Edge case: a content release mismatch does not silently replay old attempt evidence against new template semantics.
+- Integration: completing a mini-set records a session summary and emits session events.
+- Regression: retry queue de-duplicates repeated misses for the same template/seed.
+
+**Verification:**
+- Grammar state transitions are deterministic, serialisable, and independent of React/browser APIs.
+
+- [x] U3. **Add Worker Grammar Commands And Read Models**
+
+**Goal:** Plug Grammar into the Worker subject runtime so production Grammar sessions use the same command/read-model boundary as Spelling.
+
+**Requirements:** R18, R19, R20, F1, F2, AE3
+
+**Dependencies:** U1, U2, full-lockdown subject command route available.
+
+**Files:**
+- Create: `worker/src/subjects/grammar/commands.js`
+- Create: `worker/src/subjects/grammar/read-models.js`
+- Modify: `worker/src/subjects/runtime.js`
+- Test: `tests/worker-grammar-subject-runtime.test.js`
+- Test: `tests/worker-subject-runtime.test.js`
+
+**Approach:**
+- Register Grammar command handlers behind subject id `grammar`.
+- Support Stage 1 commands: `start-session`, `submit-answer`, `continue-session`, `end-session`, `save-prefs`, and `reset-learner`.
+- Reuse the existing command contract: request id, correlation id, expected learner revision, learner access checks, same-origin production checks, replay receipts, and stale-write retry behaviour.
+- Return a safe Grammar read model containing phase, session, current item view, feedback, summary, prefs, stats, analytics snapshot, concept map, and monster projection inputs.
+- Include capability metadata for enabled Stage 1 modes and locked future modes so React does not infer product scope from missing fields.
+- Ensure runtime writes include subject state, practice-session state, domain events, and reward projection updates.
+- Do not expose template internals in the browser read model beyond what is needed to render the current item.
+
+**Patterns to follow:**
+- `worker/src/subjects/runtime.js`
+- `worker/src/subjects/spelling/commands.js`
+- `worker/src/subjects/spelling/read-models.js`
+- `tests/worker-subject-runtime.test.js`
+
+**Test scenarios:**
+- Happy path: `start-session` returns a Grammar read model with Worker authority metadata.
+- Happy path: `submit-answer` marks deterministically, persists runtime writes, and returns feedback.
+- Covers AE3. Error path: AI/revision drill commands cannot submit AI-authored scored question text.
+- Error path: unknown Grammar command fails closed through `subject_command_not_found`.
+- Error path: cross-origin production command attempts are rejected before Grammar handlers run.
+- Error path: stale learner revision retries once through the existing client/repository path and does not double-apply Grammar mastery or rewards.
+- Integration: valid Grammar command persists `child_subject_state`, `practice_sessions`, and `event_log` through existing repository paths.
+- Integration: command replay/idempotency follows the same semantics as other subject commands.
+
+**Verification:**
+- Grammar is registered in Worker subject runtime and can complete a command lifecycle without client-owned scoring.
+
+- [ ] U4. **Replace Grammar Placeholder With Stage 1 Clause Conservatory Surface**
+
+**Goal:** Make Grammar a real React subject route that renders Worker read models, shows the full future map, and supports Stage 1 practice without importing production engine code.
+
+**Requirements:** R1, R9, R15, R16, R17, R18, R19, R20, F1, F3
+
+**Dependencies:** U3.
+
+**Files:**
+- Create: `src/subjects/grammar/module.js`
+- Create: `src/subjects/grammar/components/GrammarPracticeSurface.jsx`
+- Create: `src/subjects/grammar/components/GrammarSetupScene.jsx`
+- Create: `src/subjects/grammar/components/GrammarSessionScene.jsx`
+- Create: `src/subjects/grammar/components/GrammarSummaryScene.jsx`
+- Create: `src/subjects/grammar/components/GrammarAnalyticsScene.jsx`
+- Modify: `src/platform/core/subject-registry.js`
+- Modify: `src/subjects/placeholders/index.js`
+- Test: `tests/react-grammar-surface.test.js`
+- Test: `tests/subject-expansion.test.js`
+
+**Approach:**
+- Replace the placeholder `grammarModule` with a real module that satisfies the subject registry contract.
+- Use the subject command client to start/submit/continue/end sessions.
+- Render the Clause Conservatory identity using existing region assets.
+- Display all 18 concepts in the full mastery map, with Stage 1 capabilities enabled and future modes visibly locked/coming-next.
+- Show all seven Grammar monsters from the start, including locked direct-domain monsters and Concordium aggregate progress, so the v1 route communicates the full destination.
+- Keep copy in UK English.
+- Keep all scoring/content authority out of production React imports.
+
+**Patterns to follow:**
+- `src/subjects/spelling/module.js`
+- `src/subjects/spelling/components/SpellingPracticeSurface.jsx`
+- `src/surfaces/subject/SubjectRoute.jsx`
+- `src/subjects/placeholders/module-factory.js`
+
+**Test scenarios:**
+- Happy path: dashboard opens Grammar and renders the Clause Conservatory setup scene.
+- Happy path: learner starts a Grammar session, submits an answer, receives feedback, reaches summary, and returns to dashboard.
+- Happy path: all shared subject tabs render without special shell routes.
+- Edge case: locked future modes render as unavailable without dispatching commands.
+- Error path: Worker command failure is contained inside the Grammar subject tab.
+- Integration: learner switching preserves or safely reloads the current Grammar read model.
+- Integration: import/export restore does not break a live Grammar route.
+- Regression: production browser bundle does not import `worker/src/subjects/grammar/engine.js` or full template content.
+
+**Verification:**
+- Grammar is visible as a real subject and passes subject expansion conformance without weakening browser/runtime containment.
+
+- [ ] U5. **Extend Monster System For Grammar Rewards**
+
+**Goal:** Add Grammar monster metadata, domain routing, reward derivation, and celebration events for all seven Grammar creatures.
+
+**Requirements:** R9, R10, R11, R12, R13, R14, R17, F2, AE1, AE2, AE4
+
+**Dependencies:** U2, U3.
+
+**Files:**
+- Modify: `src/platform/game/monsters.js`
+- Modify: `src/platform/game/monster-system.js`
+- Modify: `worker/src/projections/rewards.js`
+- Create: `tests/grammar-monster-system.test.js`
+- Modify: `tests/monster-system.test.js`
+- Reference: `assets/monsters/bracehart/`
+- Reference: `assets/monsters/glossbloom/`
+- Reference: `assets/monsters/loomrill/`
+- Reference: `assets/monsters/chronalyx/`
+- Reference: `assets/monsters/couronnail/`
+- Reference: `assets/monsters/mirrane/`
+- Reference: `assets/monsters/concordium/`
+
+**Approach:**
+- Add Grammar monsters and `MONSTERS_BY_SUBJECT.grammar`.
+- Add subject-aware progress helpers so Spelling and Grammar can coexist without changing Spelling semantics.
+- Extend reward projection through a subject-aware adapter rather than cloning Spelling-only projection logic into a parallel Grammar path.
+- Make branch initialisation subject-aware. Existing Spelling summaries and projections must not start persisting empty Grammar monster entries just because Grammar metadata now exists.
+- Map direct Grammar monsters to domains:
+  - Bracehart: `sentence_functions`, `clauses`, `relative_clauses`
+  - Glossbloom: `word_classes`, `noun_phrases`
+  - Loomrill: `adverbials`, `pronouns_cohesion`
+  - Chronalyx: `tense_aspect`, `modal_verbs`
+  - Couronnail: `standard_english`, `formality`
+  - Mirrane: `active_passive`, `subject_object`
+  - Concordium: all 18 Grammar concepts
+- Include punctuation-for-grammar concepts in Concordium's full denominator and, if needed, route them to aggregate-only progress until Bellstorm Coast gets its own direct progression.
+- Emit caught/evolve/mega/level-up events only when committed Grammar domain events prove new secured concepts.
+
+**Patterns to follow:**
+- `src/platform/game/monsters.js`
+- `src/platform/game/monster-system.js`
+- `tests/monster-system.test.js`
+- `worker/src/projections/rewards.js`
+
+**Test scenarios:**
+- Happy path: each direct Grammar monster catches/evolves from secured concepts in its domain.
+- Happy path: Concordium progresses from all 18 Grammar concepts and reaches Mega only at full denominator.
+- Covers AE1. Edge case: due or weak concepts do not count as secured monster evidence.
+- Edge case: punctuation-for-grammar concepts count for Concordium but do not accidentally mutate a future Bellstorm direct monster state.
+- Regression: loading Spelling monster summaries does not create or persist Grammar monster branches or empty Grammar monster state.
+- Regression: Spelling monsters and Phaeton thresholds are unchanged.
+- Integration: Grammar reward events appear in command projections and toast events after concept-secured events.
+
+**Verification:**
+- Grammar rewards are derived, subject-aware, asset-backed, and non-regressive for existing spelling rewards.
+
+- [ ] U6. **Add Stage 1 Analytics And Parent Evidence Read Models**
+
+**Goal:** Provide educational evidence first and reward progress second for learner and adult-facing Grammar surfaces.
+
+**Requirements:** R3, R4, R5, R15, R16, R17, F3, AE4
+
+**Dependencies:** U2, U3, U4, U5.
+
+**Files:**
+- Modify: `worker/src/subjects/grammar/read-models.js`
+- Modify: `src/subjects/grammar/components/GrammarAnalyticsScene.jsx`
+- Modify: `src/subjects/grammar/components/GrammarSummaryScene.jsx`
+- Test: `tests/worker-grammar-subject-runtime.test.js`
+- Test: `tests/react-grammar-surface.test.js`
+
+**Approach:**
+- Build an analytics snapshot from durable Grammar state and events.
+- Include secured, due, weak, untouched, misconception, recent activity, and question-type summaries.
+- Add learner-facing monster progress as a separate derived panel.
+- Add copy explaining the method: retrieval, contrast, spaced review, misconception repair, and secured evidence.
+- Leave AI parent summary out of Stage 1 unless the deterministic report already exists and the safe lane is easy to add later.
+
+**Patterns to follow:**
+- `worker/src/subjects/spelling/read-models.js`
+- `src/subjects/spelling/components/SpellingSummaryScene.jsx`
+- `src/surfaces/hubs/ParentHubSurface.jsx`
+
+**Test scenarios:**
+- Covers AE4. Happy path: analytics shows concept evidence before monster progress.
+- Happy path: secured/due/weak counts update after answer submission.
+- Edge case: untouched concepts appear as untouched rather than weak.
+- Error path: malformed or missing analytics state renders a safe empty state.
+- Integration: parent/adult read model can consume Grammar analytics without importing engine content client-side.
+
+**Verification:**
+- Grammar progress can be explained without the game layer, and the game layer remains visibly secondary.
+
+- [ ] U7. **Add Full Legacy Practice Modes**
+
+**Goal:** Complete the legacy practice experience beyond Stage 1 core modes.
+
+**Requirements:** R1, R2, R6, R7, R8, R15
+
+**Dependencies:** U2, U3, U4, U6.
+
+**Files:**
+- Modify: `worker/src/subjects/grammar/engine.js`
+- Modify: `worker/src/subjects/grammar/commands.js`
+- Modify: `worker/src/subjects/grammar/read-models.js`
+- Modify: `src/subjects/grammar/components/GrammarPracticeSurface.jsx`
+- Modify: `src/subjects/grammar/components/GrammarSetupScene.jsx`
+- Modify: `src/subjects/grammar/components/GrammarSessionScene.jsx`
+- Test: `tests/grammar-engine.test.js`
+- Test: `tests/worker-grammar-subject-runtime.test.js`
+- Test: `tests/react-grammar-surface.test.js`
+
+**Approach:**
+- Add trouble drill, sentence surgery, sentence builder/transformation, worked examples, and faded guidance.
+- Keep support-level scoring penalties.
+- Keep strict mini-test mode free of early hints and worked support.
+- Ensure template selection balances due, weak, recent wrong, question-type weakness, and repeat penalty.
+
+**Patterns to follow:**
+- Legacy Grammar design conversation in `docs/plans/james/grammar/grammar-conversation.md`
+- Origin requirements in `docs/brainstorms/2026-04-24-grammar-mastery-region-requirements.md`
+- `worker/src/subjects/spelling/engine.js`
+- `tests/spelling.test.js`
+
+**Test scenarios:**
+- Happy path: each mode starts a session with appropriate template filtering.
+- Happy path: worked/faded support changes support level and reduces mastery gain.
+- Edge case: narrow focus pools fall back safely without infinite loops.
+- Error path: strict test mode blocks worked/faded actions until marking.
+- Integration: mode changes persist in prefs and recover after learner switching.
+
+**Verification:**
+- Full legacy practice modes are available through Worker-owned Grammar commands and covered by deterministic tests.
+
+- [ ] U8. **Add AI Enrichment Safe Lane**
+
+**Goal:** Restore the useful legacy AI lane without allowing AI to score, author production items, or bypass deterministic templates.
+
+**Requirements:** R8, R15, R16, AE3
+
+**Dependencies:** U3, U6, U7.
+
+**Files:**
+- Create: `worker/src/subjects/grammar/ai-enrichment.js`
+- Modify: `worker/src/subjects/grammar/commands.js`
+- Modify: `worker/src/subjects/grammar/read-models.js`
+- Modify: `src/subjects/grammar/components/GrammarSessionScene.jsx`
+- Test: `tests/worker-grammar-subject-runtime.test.js`
+- Test: `tests/react-grammar-surface.test.js`
+
+**Approach:**
+- If AI is enabled, expose commands for explanation, revision cards, and parent summary drafts.
+- Validate AI responses server-side: short UK English text, no score-bearing question bodies, drill section may only reference whitelisted deterministic template ids.
+- Return AI enrichment as non-scored read-model content.
+- Keep API keys and model calls server-side; do not bring legacy browser key storage forward.
+
+**Patterns to follow:**
+- `worker/src/tts.js` for protected server-side third-party calls
+- `worker/src/subjects/spelling/commands.js` for command result structure
+
+**Test scenarios:**
+- Covers AE3. Happy path: AI drill suggestion loads only whitelisted deterministic template ids.
+- Error path: AI-authored scored question text is rejected.
+- Error path: malformed AI JSON returns contained enrichment failure and does not mutate Grammar mastery.
+- Integration: AI explanation renders as enrichment and no subject state write is produced unless a deterministic follow-up drill is explicitly started.
+
+**Verification:**
+- AI improves explanation and reporting only; deterministic engine remains the sole score-bearing authority.
+
+- [ ] U9. **Add Transfer And Bellstorm Bridge Placeholders**
+
+**Goal:** Make the full product path explicit without overbuilding paragraph writing or the future Punctuation region in the initial stages.
+
+**Requirements:** R1, R2, R9, R12, R15, R20
+
+**Dependencies:** U4, U5, U6.
+
+**Files:**
+- Modify: `src/subjects/grammar/components/GrammarPracticeSurface.jsx`
+- Modify: `src/subjects/grammar/components/GrammarAnalyticsScene.jsx`
+- Modify: `src/subjects/placeholders/index.js`
+- Test: `tests/react-grammar-surface.test.js`
+
+**Approach:**
+- Add non-scored/coming-next surfaces for paragraph transfer and richer writing application.
+- Show how punctuation-for-grammar concepts are counted in Grammar, while Bellstorm Coast remains a separate future subject.
+- Avoid adding Punctuation engine code in this plan.
+- Ensure copy does not promise teacher-reviewed writing transfer until that capability exists.
+
+**Patterns to follow:**
+- `src/subjects/placeholders/module-factory.js`
+- `docs/plans/james/punctuation/punctuation-conversation.md`
+
+**Test scenarios:**
+- Happy path: transfer and Bellstorm bridge placeholders render as future capabilities.
+- Edge case: locked placeholders cannot submit scoring commands.
+- Regression: Punctuation placeholder subject still appears separately in the subject registry.
+
+**Verification:**
+- Full roadmap is visible in product UI without creating fake functionality or collapsing subject identities.
+
+- [ ] U10. **Release Gate And Production Verification**
+
+**Goal:** Treat Grammar as production-sensitive and verify it without weakening Spelling, bundle lockdown, or deployment safety.
+
+**Requirements:** R18, R19, R20
+
+**Dependencies:** U1 through U9 as applicable for the release stage.
+
+**Files:**
+- Modify: `tests/build-public.test.js`
+- Modify: `tests/browser-react-migration-smoke.test.js`
+- Create: `tests/grammar.playwright.test.mjs`
+- Modify: `scripts/production-bundle-audit.mjs`
+- Test: `tests/worker-grammar-subject-runtime.test.js`
+- Test: `tests/react-grammar-surface.test.js`
+- Test: `tests/grammar-monster-system.test.js`
+
+**Approach:**
+- Treat every staged Grammar release as production-sensitive. Stage 1 should gate U1 through U6 plus U10; later stages repeat the same gate for their added surface.
+- Extend bundle/public-output audit to assert production browser output does not include Worker Grammar engine/content authority.
+- Add browser smoke coverage for dashboard to Grammar to session to summary.
+- Add Playwright coverage through the existing multi-viewport config for the Stage 1 Grammar route: desktop and mobile navigation, start session, answer, feedback, summary, and locked-mode non-dispatch.
+- Keep package-script verification path: `npm test`, `npm run check`, production bundle audit, then production UI verification when deploying.
+- Verify Spelling parity and existing reward tests remain green.
+
+**Patterns to follow:**
+- `scripts/production-bundle-audit.mjs`
+- `tests/build-public.test.js`
+- `tests/browser-react-migration-smoke.test.js`
+- `docs/plans/2026-04-23-001-feat-full-lockdown-runtime-plan.md`
+
+**Test scenarios:**
+- Integration: Grammar production bundle does not expose engine/content authority.
+- Integration: Grammar route works through Worker-backed demo/signed-in session.
+- Integration: Grammar Playwright smoke passes at representative mobile and desktop viewports without text overlap or blocked controls.
+- Regression: Spelling tests, subject expansion tests, monster tests, and build-public tests remain green.
+- Error path: Worker command outage renders contained Grammar degraded state and does not fall back to browser-local scoring.
+
+**Verification:**
+- Grammar is ready for production only when local tests/checks and production-style smoke evidence pass.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Grammar touches subject registry, Worker subject runtime, D1-backed subject state, practice sessions, event log, reward projections, dashboard stats, subject route rendering, and asset loading.
+- **Error propagation:** Worker command failures must surface as contained Grammar route errors. React must not recover by scoring locally.
+- **State lifecycle risks:** Incomplete sessions, learner switching, import/export restore, stale writes, and duplicate command replay must follow the same semantics as current subject runtime work.
+- **API surface parity:** Grammar should use the same conceptual command/read-model boundary as Spelling so future Arithmetic, Reasoning, Punctuation, and Reading can reuse the pattern.
+- **Integration coverage:** Unit tests alone are insufficient. Browser smoke, Worker command tests, subject expansion conformance, bundle audit, and monster reward projection tests are required.
+- **Unchanged invariants:** Spelling parity, existing spelling monsters, OAuth-safe deployment scripts, and generic platform persistence remain unchanged.
+
+---
+
+## Error And Rescue Registry
+
+This registry is part of the implementation contract. New Grammar code should name and test these failures rather than relying on generic catch-all handling.
+
+| Codepath | Failure | Error class / code | Rescue action | User sees | Required test |
+|---|---|---|---|---|---|
+| Subject command contract | Missing subject id, command, learner id, request id, or expected revision | `BadRequestError` with `subject_id_required`, `subject_command_required`, `learner_id_required`, `command_request_id_required`, or `command_revision_required` | Reject before Grammar handler runs | Contained subject error | Worker command validation test |
+| Subject runtime dispatch | Unknown Grammar command | `NotFoundError` with `subject_command_not_found` | Fail closed | Contained subject error | Unknown command test |
+| Worker command route | Cross-origin production command | `ForbiddenError` with `same_origin_required` | Reject before mutation | Contained subject error | Cross-origin route test |
+| Repository mutation | Stale learner revision | `ConflictError` with `stale_write` | Client retries once after reload/rebase path; command must not double-apply events | Retry or contained stale-state message | Stale retry test |
+| Repository mutation | Reused request id with different payload | `ConflictError` with `idempotency_reuse` | Reject replay | Contained subject error | Idempotency collision test |
+| Grammar content read | Missing or empty Grammar content catalogue | `NotFoundError` with `grammar_content_unavailable` | Block session start | "Grammar content is not available yet" style message | Empty content test |
+| Grammar engine | Stale or inactive session submit | `BadRequestError` with `grammar_session_stale` | Reject submit; read model returns setup or recoverable state | Session needs restarting | Stale session test |
+| Grammar engine | Unsupported mode or template id | `BadRequestError` with `grammar_mode_unsupported` or `grammar_template_not_found` | Reject before mutation | Contained subject error | Unsupported mode/template test |
+| Grammar engine | Malformed answer payload | `BadRequestError` with `grammar_answer_invalid` | Reject or normalise to safe empty answer based on question type | Field-level answer error | Nil/empty/wrong-type answer tests |
+| Legacy oracle harness | Fixture cannot be loaded or parsed | Test failure, not production route | Stop implementation before port depends on bad fixture | No production user impact | Fixture load test |
+| Reward projection | Duplicate `grammar.concept-secured` replay | No new error; idempotent no-op | Do not emit duplicate monster/reward events | No duplicate toast | Replay reward test |
+| AI enrichment | Malformed, empty, or score-bearing AI output | `BadRequestError` or contained enrichment failure with `grammar_ai_enrichment_invalid` | Drop enrichment; never mutate mastery | Enrichment unavailable, practice still works | Malformed AI tests |
+
+### Failure Modes Registry
+
+| Codepath | Failure mode | Rescued? | Test? | User sees? | Logged? |
+|---|---|---:|---:|---|---|
+| `start-session` | Grammar content unavailable | Yes | Required | Content unavailable message | Yes, with subject id and learner id |
+| `submit-answer` | Double-click or replayed submit | Yes | Required | Single feedback/result | Yes, via request id |
+| `submit-answer` | Stale revision from another tab | Yes | Required | Retry or stale-state recovery | Yes, via mutation log |
+| `continue-session` | Session already completed | Yes | Required | Summary/setup state | Yes |
+| Reward projection | Due/weak concept passed to monster layer | Yes | Required | No reward change | Yes, if event rejected |
+| React subject surface | Worker command outage | Yes | Required | Contained Grammar degraded state | Yes |
+| Browser bundle | Grammar engine/content imported into production bundle | Yes | Required | Build/check failure, not runtime exposure | Yes, in audit output |
+
+---
+
+## Security And Threat Model
+
+| Threat | Likelihood | Impact | Plan response |
+|---|---:|---:|---|
+| User submits another learner id to a Grammar command | Medium | High | Reuse repository learner access checks and subject command route tests before Grammar handler mutation. |
+| Cross-origin command submission | Medium | High | Reuse production same-origin checks; add Grammar-specific route coverage so the handler is not reachable cross-origin. |
+| Replay or double-click applies mastery/rewards twice | Medium | High | Reuse request ids, mutation receipts, and reward idempotency tests for `grammar.concept-secured`. |
+| Long, malformed, or HTML/script answer payload | Medium | Medium | Validate/normalise per question type; cap answer length; render feedback as text/React nodes, not raw HTML. |
+| AI prompt/output injection becomes scored content | Medium | High | AI enrichment is non-scored; deterministic template ids only; reject score-bearing AI question bodies. |
+| Production bundle exposes Grammar engine/content | Medium | High | Worker-only modules and public-output audit block engine/content in browser output. |
+| Imported/exported state injects malformed Grammar state | Medium | Medium | Subject state normalisation must shrink invalid Grammar payloads to safe defaults before read models render. |
+
+Security-specific test additions:
+
+- `tests/worker-grammar-subject-runtime.test.js`: learner access denial, cross-origin denial, stale retry, idempotency collision, malformed answer payload, unsupported mode/template.
+- `tests/react-grammar-surface.test.js`: feedback and learner answers render as escaped text, command outage is contained, locked modes cannot dispatch scoring commands.
+- `tests/build-public.test.js`: production output does not include `worker/src/subjects/grammar/`, fixture-only oracle code, or full template content.
+- `tests/grammar.playwright.test.mjs`: rendered Grammar route works on mobile and desktop, locked controls do not dispatch commands, and core prompt/answer UI remains usable.
+- `tests/worker-grammar-subject-runtime.test.js` for U8: malformed AI JSON, empty AI response, invalid deterministic template id, and AI-authored scored item rejection.
+
+---
+
+## Test Coverage Map
+
+```text
+NEW UX FLOWS
+  Dashboard -> Grammar setup -> start -> answer -> feedback -> continue -> summary -> dashboard
+  Grammar analytics tab -> concept evidence -> derived monster panel
+  Locked future mode -> no command dispatch
+
+NEW DATA FLOWS
+  Legacy HTML oracle -> fixture snapshots -> Worker-safe content parity tests
+  React command intent -> /api/subjects/grammar/command -> runtime -> engine -> D1 writes -> read model
+  grammar.concept-secured -> subject-aware reward projection -> monster state -> toast/read model
+
+NEW STATEFUL OBJECTS
+  Grammar content release
+  Grammar mastery node
+  Grammar session
+  Grammar retry queue
+  Grammar read model
+  Grammar reward projection state
+
+NEW ERROR PATHS
+  Missing content
+  Malformed answer payload
+  Stale revision
+  Replayed request
+  Unknown command
+  Unsupported mode/template
+  Worker outage
+  Bundle audit failure
+```
+
+Minimum Stage 1 confidence tests:
+
+- Unit: legacy oracle fixture loading, 51-template generation, deterministic marking, status calculation, retry queue, mini-set generation, content release mismatch.
+- Worker integration: command contract validation, start/submit/continue/end/save/reset, stale retry, replay idempotency, D1 batch rollback, projection output.
+- React/system: dashboard to Grammar to summary, locked modes, command failure containment, learner switching, import/export restore, no client-owned scoring.
+- E2E/Playwright: dashboard to Grammar to feedback/summary at mobile and desktop viewports, with locked future modes unable to dispatch commands.
+- Reward: direct Grammar monster progress, Concordium full denominator, due/weak concepts excluded, duplicate secured event no-op, Spelling monsters unchanged.
+- Build/security: production bundle/public-output audit blocks Worker Grammar engine/content and oracle fixtures.
+
+Flakiness controls:
+
+- Use deterministic time and seed fixtures.
+- Do not depend on live AI, live TTS, live browser network, or wall-clock randomness in Stage 1 correctness tests.
+- Run build-sensitive checks sequentially when they touch public output.
+
+---
+
+## Performance, Observability, And Operations
+
+### Performance
+
+- The 18-concept / 51-template catalogue is small enough for Worker memory, but the production browser bundle must not carry full scoring content.
+- Mini-set generation must have hard iteration caps and fallback broadening so narrow concept pools cannot loop indefinitely.
+- Analytics read models should derive from stored Grammar state and recent event/session rows; avoid scanning unbounded event history on every command.
+- Parent/adult summaries should receive compact evidence snapshots, not raw attempt history.
+
+### Observability
+
+Every Grammar command should log or emit enough context to reconstruct a reported bug without exposing child answer text unnecessarily:
+
+- subject id, learner id, command, request id, correlation id, content release id
+- session id, template id, seed, question type, concept ids
+- result class: correct, partial, incorrect, invalid, stale, replayed
+- domain events and reward events emitted
+- mutation expected/applied revision
+
+Metrics to add or derive:
+
+- Grammar command success/error counts by command and error code
+- stale write retry count
+- template generation failure count
+- mini-set fallback-broadening count
+- concept-secured and reward-event counts
+- bundle audit pass/fail for Grammar forbidden paths
+
+### Deployment And Rollback
+
+- Gate each release stage behind existing package-script verification and production bundle audit.
+- Stage 1 should be feature-flag or capability-gated until Worker Grammar commands and read models pass production-style smoke.
+- Rollback should be a code revert or capability disable that leaves existing `child_subject_state` and `practice_sessions` rows readable but not mutable by browser-local scoring.
+- New D1 migrations should be avoided for Stage 1 unless implementation proves existing generic subject tables cannot safely store Grammar state.
+- After deployment, verify a logged-in or demo-backed flow from dashboard to Grammar session to summary, plus a direct bundle/source denial audit.
+
+---
+
+## Implementation Parallelisation Strategy
+
+The first three units are the spine and should stay sequential. Parallel work becomes useful only after the Worker-safe content, engine state, and command/read-model contract are stable.
+
+| Step | Modules touched | Depends on |
+|---|---|---|
+| U1 Legacy oracle and content extraction | `worker/src/subjects/grammar/`, `tests/fixtures/`, `tests/helpers/`, `scripts/` | - |
+| U2 Engine state and mastery transitions | `worker/src/subjects/grammar/`, `tests/` | U1 |
+| U3 Worker commands and read models | `worker/src/subjects/grammar/`, `worker/src/subjects/runtime.js`, `tests/` | U1, U2 |
+| U4 React Grammar surface | `src/subjects/grammar/`, subject registry, React tests | U3 |
+| U5 Grammar rewards | `src/platform/game/`, `worker/src/projections/`, reward tests | U2, U3 |
+| U6 Analytics and evidence read models | `worker/src/subjects/grammar/`, `src/subjects/grammar/` | U2, U3, U4, U5 |
+| U7 Full legacy modes | `worker/src/subjects/grammar/`, `src/subjects/grammar/` | U2, U3, U4, U6 |
+| U8 AI enrichment safe lane | `worker/src/subjects/grammar/`, `src/subjects/grammar/` | U3, U6, U7 |
+| U9 Transfer/Bellstorm placeholders | `src/subjects/grammar/`, `src/subjects/placeholders/` | U4, U5, U6 |
+| U10 Release gate | `tests/`, `scripts/` | Current release stage |
+
+Suggested lanes:
+
+```text
+Lane A: U1 -> U2 -> U3
+  Sequential. This defines the contract everyone else depends on.
+
+Lane B: U4
+  Starts after U3. UI work can run while rewards are implemented.
+
+Lane C: U5
+  Starts after U3. Reward work can run beside U4, but must avoid Spelling state drift.
+
+Lane D: U6 -> U7 -> U8/U9
+  Sequential enough to avoid read-model churn.
+
+Lane E: U10
+  Runs at each release gate, after the relevant stage lands.
+```
+
+Conflict flags:
+
+- U4 and U6 both touch `src/subjects/grammar/`; merge U4 before broad analytics UI work.
+- U5 and U10 both touch reward/bundle tests; coordinate test helper names.
+- U7 and U8 both touch Grammar commands/read models; keep AI enrichment out until full deterministic modes are stable.
+
+---
+
+## Design And UX Guardrails
+
+- The first Grammar screen should be The Clause Conservatory subject surface, not a marketing page or engine explanation.
+- Show the learning task first, concept evidence second, derived monster progress third.
+- Locked future modes must look unavailable and must not dispatch scoring commands.
+- All user-visible copy should be UK English and must not imply monster progress replaces secured Grammar evidence.
+- Render long concept names, question prompts, and learner answers without overflow on mobile and desktop.
+- Avoid raw HTML injection for legacy prompt/feedback text. Translate legacy prompt structures into safe renderable fields or React nodes.
+- Keep future Bellstorm Coast references lightweight so the Grammar route does not feel like an advert for a subject that does not exist yet.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Legacy engine extraction changes pedagogy by accident | Medium | High | Characterisation-first tests before refactor; preserve answer-quality and status thresholds. |
+| Grammar engine leaks into browser bundle | Medium | High | Worker-only engine modules, read-model-only React surface, bundle/public-output audit. |
+| Full denominator makes Stage 1 too large | Medium | Medium | Stage 1 can expose full map and denominator while enabling only core modes; advanced modes land later. |
+| Punctuation overlap confuses product identity | Medium | Medium | State clearly: punctuation-for-grammar counts in Grammar GPS mastery; Bellstorm Coast remains future richer Punctuation. |
+| Monster rewards corrupt mastery incentives | Low | High | Rewards derive only from secured concepts and committed events; tests assert due/weak concepts do not count. |
+| Free-text marking becomes too rigid | Medium | Medium | Preserve deterministic accepted answers first; expand accepted variants through tests, not AI marking. |
+| Full-lockdown work shifts before implementation | Medium | Medium | Treat Worker command/read-model shape as deferred to implementation and align with latest full-lockdown contracts. |
+
+---
+
+## Documentation / Operational Notes
+
+- Update `docs/subject-expansion.md` after Grammar lands if it becomes the first real non-Spelling reference subject.
+- Add a Grammar implementation note documenting the 18-concept denominator, secured definition, and monster mapping.
+- Keep James-facing product copy in UK English.
+- Before deployment, run the existing verification gates from `AGENTS.md`: `npm test` and `npm run check`.
+- For deployment, use package scripts only; do not introduce raw Wrangler commands.
+- After user-facing deployment, verify `https://ks2.eugnel.uk` with a logged-in browser session or deterministic demo-session checks, depending on the stage.
+
+---
+
+## Alternative Approaches Considered
+
+- **Small 13-concept Grammar-only v1:** Rejected as the product target because James wants full. It remains useful only as an internal implementation subset if needed, but the public contract should point at all 18 concepts.
+- **Directly ship the legacy HTML:** Rejected because it bypasses the current React/Worker architecture, localStorage/source-of-truth rules, and full-lockdown production boundary.
+- **Make Punctuation a separate subject before Grammar ships:** Rejected for sequencing. It would delay the full Grammar region and complicate the KS2 GPS denominator. Bellstorm Coast should be planned after Grammar's punctuation-for-grammar bridge is stable.
+- **Client-owned Grammar engine for speed:** Rejected for production because it repeats the subject-runtime authority problem that full-lockdown is solving.
+
+---
+
+## Success Metrics
+
+- A learner can complete a Grammar practice round through Worker-owned commands.
+- The subject dashboard can explain Grammar progress by concept status and misconception evidence.
+- All seven Grammar monsters show correct locked/caught/evolved states from secured evidence.
+- Concordium reaches Mega only when the selected full Grammar denominator is secured.
+- Spelling parity and existing monster tests remain unchanged.
+- Production bundle/public-output audit proves Grammar engine/content authority is not shipped as browser runtime.
+
+---
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/2026-04-24-grammar-mastery-region-requirements.md`
+- `docs/plans/james/grammar/grammar-conversation.md`
+- `docs/plans/james/punctuation/punctuation-conversation.md`
+- `docs/subject-expansion.md`
+- `docs/plans/2026-04-23-001-feat-full-lockdown-runtime-plan.md`
+- `src/platform/core/subject-registry.js`
+- `src/subjects/placeholders/index.js`
+- `worker/src/subjects/runtime.js`
+- `worker/src/subjects/spelling/commands.js`
+- `worker/src/subjects/spelling/read-models.js`
+- `src/platform/game/monsters.js`
+- `src/platform/game/monster-system.js`
+- `tests/monster-system.test.js`
+- `tests/subject-expansion.test.js`
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 1 | clean | mode: HOLD_SCOPE, 0 critical gaps, 1 fidelity proposal accepted, 1 product-loop proposal deferred |
+| Codex Review | `/codex review` | Independent 2nd opinion | 0 | - | Not run for this docs-only planning gate |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | clean | 4 engineering gaps found and folded into this plan |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | - | Deferred until UI implementation has a concrete surface to inspect |
+
+- **UNRESOLVED:** 0
+- **VERDICT:** CEO + ENG CLEARED FOR IMPLEMENTATION PLANNING. Start with U1 to U3 to lock fidelity and Worker contracts before UI/reward work.

--- a/scripts/extract-grammar-legacy-oracle.mjs
+++ b/scripts/extract-grammar-legacy-oracle.mjs
@@ -1,0 +1,434 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+const CONTENT_RELEASE_ID = 'grammar-legacy-reviewed-2026-04-24';
+
+const FUNCTION_NAMES = [
+  'clamp',
+  'randInt',
+  'pick',
+  'shuffle',
+  'sampleMany',
+  'mulberry32',
+  'escapeHtml',
+  'cleanSpaces',
+  'lowerClean',
+  'sentenceBare',
+  'compareAnswerString',
+  'setEq',
+  'mkResult',
+  'markStringAnswer',
+  'makeBaseQuestion',
+  'capFirst',
+  'ensureSentenceEnd',
+  'quoteVariants',
+  'dedupePlain',
+  'proceduralSubjectObject',
+  'buildChoiceOptions',
+  'buildWordOptions',
+  'choiceResult',
+  'generateStandardEnglishCase',
+  'generateTenseCase',
+  'generatePassiveCase',
+  'seededBool',
+  'generateRelativeClauseCase',
+  'generatePronounCohesionCase',
+  'generateSubjectObjectCase',
+  'generateFormalityCase',
+  'generateModalCase',
+  'seededIndex',
+  'isPunctuationSkill',
+];
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const defaultContentPath = path.join(repoRoot, 'worker/src/subjects/grammar/content.js');
+const defaultFixtureDir = path.join(repoRoot, 'tests/fixtures/grammar-legacy-oracle');
+const defaultFixturePath = path.join(defaultFixtureDir, 'legacy-baseline.json');
+
+function usage() {
+  console.error([
+    'Usage: node scripts/extract-grammar-legacy-oracle.mjs --source <legacy-html> [--content-out <path>] [--fixture-out <path>]',
+    '',
+    'The source can also be supplied through GRAMMAR_LEGACY_HTML.',
+  ].join('\n'));
+}
+
+function args(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token.startsWith('--')) continue;
+    out[token.slice(2)] = argv[i + 1];
+    i += 1;
+  }
+  return out;
+}
+
+function extractScript(html) {
+  const match = /<script>([\s\S]*?)<\/script>/i.exec(html);
+  if (!match) throw new Error('Could not find legacy script block.');
+  return match[1].replace(/\binitialise\(\);\s*$/, '');
+}
+
+function findBalancedBlock(source, startIndex) {
+  let depth = 0;
+  let quote = '';
+  let escaped = false;
+  for (let index = startIndex; index < source.length; index += 1) {
+    const char = source[index];
+    const prev = source[index - 1];
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === quote && !(quote === '`' && prev === '$')) {
+        quote = '';
+      }
+      continue;
+    }
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char;
+      continue;
+    }
+    if (char === '{') depth += 1;
+    if (char === '}') {
+      depth -= 1;
+      if (depth === 0) return index + 1;
+    }
+  }
+  throw new Error(`Unbalanced block starting at ${startIndex}.`);
+}
+
+function extractConstRange(source) {
+  const start = source.indexOf('const MISCONCEPTIONS =');
+  const end = source.indexOf('const TEMPLATE_MAP =');
+  if (start < 0 || end < 0 || end <= start) throw new Error('Could not locate legacy content constant range.');
+  return source.slice(start, end).trim();
+}
+
+function extractFunction(source, name) {
+  const start = source.indexOf(`function ${name}`);
+  if (start < 0) throw new Error(`Could not locate function ${name}.`);
+  const next = source.slice(start + 1).search(/\nfunction\s+[A-Za-z0-9_$]+\s*\(/);
+  const end = next >= 0 ? start + 1 + next : findBalancedBlock(source, source.indexOf('{', start));
+  return source.slice(start, end).trim();
+}
+
+function patchWorkerSafeSource(source) {
+  return source
+    .replace('const singular = Math.random() < 0.5;', 'const singular = rng() < 0.5;');
+}
+
+function contentFooter() {
+  return `
+const TEMPLATE_MAP = Object.fromEntries(TEMPLATES.map(template => [template.id, template]));
+
+function stripLegacyHtml(value) {
+  return cleanSpaces(String(value || '')
+    .replace(/<br\\s*\\/?>/gi, ' ')
+    .replace(/<\\/p>/gi, ' ')
+    .replace(/<\\/li>/gi, ' ')
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"'));
+}
+
+function cloneSerialisable(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function serialiseInputSpec(inputSpec) {
+  if (!inputSpec || typeof inputSpec !== 'object' || Array.isArray(inputSpec)) return null;
+  return cloneSerialisable(inputSpec);
+}
+
+export const GRAMMAR_CONTENT_RELEASE_ID = '${CONTENT_RELEASE_ID}';
+export const GRAMMAR_MISCONCEPTIONS = Object.freeze(MISCONCEPTIONS);
+export const GRAMMAR_MINIMAL_HINTS = Object.freeze(MINIMAL_HINTS);
+export const GRAMMAR_QUESTION_TYPES = Object.freeze(QUESTION_TYPES);
+export const GRAMMAR_PUNCTUATION_CONCEPT_IDS = Object.freeze(PUNCTUATION_SKILL_IDS.slice());
+export const GRAMMAR_CONCEPTS = Object.freeze(Object.entries(SKILLS).map(([id, skill]) => Object.freeze({
+  id,
+  domain: skill.domain,
+  name: skill.name,
+  summary: skill.summary,
+  notices: Object.freeze((skill.notices || []).slice()),
+  worked: Object.freeze({ ...(skill.worked || {}) }),
+  contrast: Object.freeze({ ...(skill.contrast || {}) }),
+  punctuationForGrammar: PUNCTUATION_SKILL_IDS.includes(id),
+})));
+export const GRAMMAR_TEMPLATES = Object.freeze(TEMPLATES);
+export const GRAMMAR_TEMPLATE_MAP = Object.freeze(TEMPLATE_MAP);
+
+export function grammarTemplateMetadata(template = {}) {
+  return {
+    id: template.id,
+    label: template.label,
+    domain: template.domain,
+    questionType: template.questionType,
+    difficulty: Number(template.difficulty) || 1,
+    satsFriendly: Boolean(template.satsFriendly),
+    isSelectedResponse: Boolean(template.isSelectedResponse),
+    generative: Boolean(template.generative),
+    tags: Object.freeze((template.tags || []).slice()),
+    skillIds: Object.freeze((template.skillIds || []).slice()),
+  };
+}
+
+export const GRAMMAR_TEMPLATE_METADATA = Object.freeze(GRAMMAR_TEMPLATES.map(grammarTemplateMetadata));
+
+export function grammarConceptById(conceptId) {
+  return GRAMMAR_CONCEPTS.find((concept) => concept.id === conceptId) || null;
+}
+
+export function grammarTemplateById(templateId) {
+  return GRAMMAR_TEMPLATE_MAP[templateId] || null;
+}
+
+export function createGrammarQuestion({ templateId, seed } = {}) {
+  const template = grammarTemplateById(templateId);
+  if (!template || typeof template.generator !== 'function') return null;
+  return template.generator(Number(seed) || 0);
+}
+
+export function evaluateGrammarQuestion(question, response = {}) {
+  if (!question || typeof question.evaluate !== 'function') return null;
+  return question.evaluate(response && typeof response === 'object' && !Array.isArray(response) ? response : {});
+}
+
+export function serialiseGrammarQuestion(question) {
+  if (!question || typeof question !== 'object' || Array.isArray(question)) return null;
+  return {
+    contentReleaseId: GRAMMAR_CONTENT_RELEASE_ID,
+    templateId: question.templateId,
+    templateLabel: question.templateLabel,
+    domain: question.domain,
+    skillIds: (question.skillIds || []).slice(),
+    questionType: question.questionType,
+    seed: Number(question.seed) || 0,
+    itemId: question.itemId,
+    marks: Number(question.marks) || 1,
+    promptText: stripLegacyHtml(question.stemHtml),
+    inputSpec: serialiseInputSpec(question.inputSpec),
+    solutionLines: (question.solutionLines || []).map(stripLegacyHtml),
+    reflectionPrompt: stripLegacyHtml(question.reflectionPrompt || ''),
+    checkLine: stripLegacyHtml(question.checkLine || ''),
+    replay: {
+      contentReleaseId: GRAMMAR_CONTENT_RELEASE_ID,
+      templateId: question.templateId,
+      seed: Number(question.seed) || 0,
+      itemId: question.itemId,
+      conceptIds: (question.skillIds || []).slice(),
+      questionType: question.questionType,
+    },
+  };
+}
+`.trim();
+}
+
+function generatedContentSource(legacyScript) {
+  const constants = extractConstRange(legacyScript);
+  const functions = FUNCTION_NAMES.map((name) => extractFunction(legacyScript, name)).join('\n\n');
+  return `${[
+    '// Generated from the reviewed KS2 Grammar legacy engine.',
+    '// Regenerate with: node scripts/extract-grammar-legacy-oracle.mjs --source <legacy-html>',
+    '',
+    patchWorkerSafeSource(constants),
+    '',
+    patchWorkerSafeSource(functions),
+    '',
+    contentFooter(),
+    '',
+  ].join('\n')}`;
+}
+
+function buildRuntime(legacyScript) {
+  const source = `${patchWorkerSafeSource(legacyScript)}
+globalThis.__grammar = {
+  MISCONCEPTIONS,
+  MINIMAL_HINTS,
+  QUESTION_TYPES,
+  SKILLS,
+  PUNCTUATION_SKILL_IDS,
+  TEMPLATES,
+};
+`;
+  const context = {
+    console,
+    Date,
+    Math: Object.create(Math),
+    localStorage: { getItem() { return null; }, setItem() {}, removeItem() {} },
+    sessionStorage: { getItem() { return null; }, setItem() {}, removeItem() {} },
+  };
+  context.Math.random = () => 0.42;
+  vm.createContext(context);
+  vm.runInContext(source, context, { timeout: 5_000 });
+  return context.__grammar;
+}
+
+function combinations(values) {
+  const out = [[]];
+  for (const value of values) {
+    const size = out.length;
+    for (let index = 0; index < size; index += 1) {
+      out.push([...out[index], value]);
+    }
+  }
+  return out;
+}
+
+function bestResult(question, response) {
+  try {
+    return question.evaluate(response);
+  } catch {
+    return null;
+  }
+}
+
+function findBestResponse(question) {
+  const spec = question.inputSpec || {};
+  let candidates = [{}];
+  if (spec.type === 'single_choice') {
+    candidates = (spec.options || []).map((option) => ({ answer: option.value }));
+  } else if (spec.type === 'checkbox_list') {
+    const values = (spec.options || []).map((option) => option.value).slice(0, 14);
+    candidates = combinations(values).map((selected) => ({ selected }));
+  } else if (spec.type === 'table_choice') {
+    const rows = spec.rows || [];
+    const columns = spec.columns || [];
+    candidates = [{}];
+    for (const row of rows) {
+      candidates = candidates.flatMap((candidate) => columns.map((column) => ({ ...candidate, [row.key]: column })));
+    }
+  } else if (spec.type === 'multi') {
+    candidates = [{}];
+    for (const field of spec.fields || []) {
+      const options = (field.options || []).map((option) => option[0]).filter(Boolean);
+      candidates = candidates.flatMap((candidate) => options.map((option) => ({ ...candidate, [field.key]: option })));
+    }
+  } else if (spec.type === 'text' || spec.type === 'textarea') {
+    const empty = bestResult(question, { answer: '' });
+    candidates = [{ answer: empty?.answerText || '' }];
+  }
+
+  let best = { response: {}, result: bestResult(question, {}) || { score: 0, maxScore: Number(question.marks) || 1 } };
+  for (const response of candidates) {
+    const result = bestResult(question, response);
+    if (!result) continue;
+    if (result.correct) return { response, result };
+    if (Number(result.score) > Number(best.result?.score || 0)) best = { response, result };
+  }
+  return best;
+}
+
+function stripHtml(value) {
+  return String(value || '')
+    .replace(/<br\s*\/?>/gi, ' ')
+    .replace(/<\/p>/gi, ' ')
+    .replace(/<\/li>/gi, ' ')
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/[“”]/g, '"')
+    .replace(/[‘’]/g, "'")
+    .replace(/\s+/g, ' ')
+    .replace(/\s+([,.;:!?])/g, '$1')
+    .trim();
+}
+
+function serialiseQuestion(question) {
+  return {
+    templateId: question.templateId,
+    templateLabel: question.templateLabel,
+    domain: question.domain,
+    skillIds: question.skillIds,
+    questionType: question.questionType,
+    seed: question.seed,
+    itemId: question.itemId,
+    marks: question.marks,
+    promptText: stripHtml(question.stemHtml),
+    inputSpec: question.inputSpec,
+    solutionLines: question.solutionLines?.map(stripHtml) || [],
+  };
+}
+
+function buildFixture(runtime) {
+  const templates = runtime.TEMPLATES.map((template, index) => {
+    const seed = 10_000 + index * 17;
+    const question = template.generator(seed);
+    const correct = findBestResponse(question);
+    const emptyResult = bestResult(question, {}) || null;
+    return {
+      id: template.id,
+      label: template.label,
+      domain: template.domain,
+      questionType: template.questionType,
+      difficulty: Number(template.difficulty) || 1,
+      satsFriendly: Boolean(template.satsFriendly),
+      isSelectedResponse: Boolean(template.isSelectedResponse),
+      generative: Boolean(template.generative),
+      tags: template.tags || [],
+      skillIds: template.skillIds || [],
+      sample: serialiseQuestion(question),
+      correctResponse: correct.response,
+      correctResult: correct.result,
+      emptyResult,
+    };
+  });
+
+  return {
+    contentReleaseId: CONTENT_RELEASE_ID,
+    generatedAt: 'fixture-generated-by-script',
+    conceptCount: Object.keys(runtime.SKILLS).length,
+    templateCount: templates.length,
+    selectedResponseCount: templates.filter((template) => template.isSelectedResponse).length,
+    constructedResponseCount: templates.filter((template) => !template.isSelectedResponse).length,
+    concepts: Object.entries(runtime.SKILLS).map(([id, skill]) => ({
+      id,
+      domain: skill.domain,
+      name: skill.name,
+      punctuationForGrammar: runtime.PUNCTUATION_SKILL_IDS.includes(id),
+    })),
+    misconceptions: runtime.MISCONCEPTIONS,
+    questionTypes: runtime.QUESTION_TYPES,
+    punctuationConceptIds: runtime.PUNCTUATION_SKILL_IDS,
+    templates,
+  };
+}
+
+const options = args(process.argv.slice(2));
+const sourcePath = options.source || process.env.GRAMMAR_LEGACY_HTML;
+if (!sourcePath) {
+  usage();
+  process.exit(1);
+}
+
+const contentOut = path.resolve(options['content-out'] || defaultContentPath);
+const fixtureOut = path.resolve(options['fixture-out'] || defaultFixturePath);
+const legacyHtml = fs.readFileSync(path.resolve(sourcePath), 'utf8');
+const legacyScript = extractScript(legacyHtml);
+const contentSource = generatedContentSource(legacyScript);
+const runtime = buildRuntime(legacyScript);
+const fixture = buildFixture(runtime);
+
+fs.mkdirSync(path.dirname(contentOut), { recursive: true });
+fs.mkdirSync(path.dirname(fixtureOut), { recursive: true });
+fs.writeFileSync(contentOut, contentSource);
+fs.writeFileSync(fixtureOut, `${JSON.stringify(fixture, null, 2)}\n`);
+
+console.log(`Wrote ${path.relative(repoRoot, contentOut)}`);
+console.log(`Wrote ${path.relative(repoRoot, fixtureOut)}`);
+console.log(`Concepts: ${fixture.conceptCount}`);
+console.log(`Templates: ${fixture.templateCount}`);
+console.log(`Selected-response: ${fixture.selectedResponseCount}`);
+console.log(`Constructed-response: ${fixture.constructedResponseCount}`);

--- a/tests/fixtures/grammar-legacy-oracle/legacy-baseline.json
+++ b/tests/fixtures/grammar-legacy-oracle/legacy-baseline.json
@@ -1,0 +1,3957 @@
+{
+  "contentReleaseId": "grammar-legacy-reviewed-2026-04-24",
+  "generatedAt": "fixture-generated-by-script",
+  "conceptCount": 18,
+  "templateCount": 51,
+  "selectedResponseCount": 31,
+  "constructedResponseCount": 20,
+  "concepts": [
+    {
+      "id": "sentence_functions",
+      "domain": "Sentence function",
+      "name": "Sentence functions",
+      "punctuationForGrammar": true
+    },
+    {
+      "id": "word_classes",
+      "domain": "Word classes",
+      "name": "Word classes",
+      "punctuationForGrammar": false
+    },
+    {
+      "id": "noun_phrases",
+      "domain": "Phrases",
+      "name": "Expanded noun phrases",
+      "punctuationForGrammar": false
+    },
+    {
+      "id": "adverbials",
+      "domain": "Adverbials",
+      "name": "Adverbials and fronted adverbials",
+      "punctuationForGrammar": true
+    },
+    {
+      "id": "clauses",
+      "domain": "Clauses",
+      "name": "Subordinate clauses and conjunctions",
+      "punctuationForGrammar": false
+    },
+    {
+      "id": "relative_clauses",
+      "domain": "Clauses",
+      "name": "Relative clauses",
+      "punctuationForGrammar": false
+    },
+    {
+      "id": "tense_aspect",
+      "domain": "Verb forms",
+      "name": "Tense and aspect",
+      "punctuationForGrammar": false
+    },
+    {
+      "id": "standard_english",
+      "domain": "Standard English",
+      "name": "Standard English forms",
+      "punctuationForGrammar": false
+    },
+    {
+      "id": "pronouns_cohesion",
+      "domain": "Cohesion",
+      "name": "Pronouns and cohesion",
+      "punctuationForGrammar": false
+    },
+    {
+      "id": "formality",
+      "domain": "Register",
+      "name": "Formal and informal language",
+      "punctuationForGrammar": false
+    },
+    {
+      "id": "active_passive",
+      "domain": "Sentence structure",
+      "name": "Active and passive voice",
+      "punctuationForGrammar": false
+    },
+    {
+      "id": "subject_object",
+      "domain": "Sentence structure",
+      "name": "Subject and object",
+      "punctuationForGrammar": false
+    },
+    {
+      "id": "modal_verbs",
+      "domain": "Verb forms",
+      "name": "Modal verbs and possibility",
+      "punctuationForGrammar": false
+    },
+    {
+      "id": "parenthesis_commas",
+      "domain": "Punctuation for grammar",
+      "name": "Parenthesis and commas",
+      "punctuationForGrammar": true
+    },
+    {
+      "id": "speech_punctuation",
+      "domain": "Punctuation for grammar",
+      "name": "Direct speech punctuation",
+      "punctuationForGrammar": true
+    },
+    {
+      "id": "apostrophes_possession",
+      "domain": "Punctuation for grammar",
+      "name": "Possession with apostrophes",
+      "punctuationForGrammar": true
+    },
+    {
+      "id": "boundary_punctuation",
+      "domain": "Punctuation for grammar",
+      "name": "Colons, semi-colons and dashes",
+      "punctuationForGrammar": true
+    },
+    {
+      "id": "hyphen_ambiguity",
+      "domain": "Punctuation for grammar",
+      "name": "Hyphens to avoid ambiguity",
+      "punctuationForGrammar": true
+    }
+  ],
+  "misconceptions": {
+    "sentence_function_confusion": "Mixed up sentence functions or punctuation cues",
+    "word_class_confusion": "Confused one word class with another",
+    "noun_phrase_confusion": "Did not build or spot a full noun phrase",
+    "fronted_adverbial_confusion": "Missed the fronted adverbial or its comma",
+    "subordinate_clause_confusion": "Confused main and subordinate clauses",
+    "relative_clause_confusion": "Missed how a relative clause links to a noun",
+    "tense_confusion": "Chose the wrong tense or aspect",
+    "standard_english_confusion": "Used a non-standard spoken form instead of Standard English",
+    "pronoun_cohesion_confusion": "Used a pronoun or noun choice that reduced clarity",
+    "formality_confusion": "Chose language at the wrong level of formality",
+    "active_passive_confusion": "Mixed up active and passive voice",
+    "subject_object_confusion": "Confused the subject and the object",
+    "modal_verb_confusion": "Missed the degree of certainty or possibility",
+    "parenthesis_confusion": "Missed how parenthesis or commas work",
+    "speech_punctuation_confusion": "Placed speech punctuation incorrectly",
+    "apostrophe_possession_confusion": "Confused singular and plural possession",
+    "punctuation_precision": "Grammar idea mostly right, but punctuation or exact form was off",
+    "misread_question": "Answered a different question from the one asked",
+    "boundary_punctuation_confusion": "Chose the wrong punctuation to mark a clause boundary or introduce a list",
+    "hyphen_ambiguity_confusion": "Missed how a hyphen changes the meaning"
+  },
+  "questionTypes": {
+    "identify": "Identify the feature",
+    "choose": "Choose the correct sentence",
+    "fix": "Fix the sentence",
+    "rewrite": "Rewrite the sentence",
+    "build": "Build / transform a sentence",
+    "explain": "Explain why",
+    "classify": "Classify",
+    "fill": "Complete the sentence"
+  },
+  "punctuationConceptIds": [
+    "sentence_functions",
+    "adverbials",
+    "parenthesis_commas",
+    "speech_punctuation",
+    "apostrophes_possession",
+    "boundary_punctuation",
+    "hyphen_ambiguity"
+  ],
+  "templates": [
+    {
+      "id": "sentence_type_table",
+      "label": "Classify sentence functions",
+      "domain": "Sentence function",
+      "questionType": "classify",
+      "difficulty": 1,
+      "satsFriendly": true,
+      "isSelectedResponse": true,
+      "generative": false,
+      "tags": [
+        "identify"
+      ],
+      "skillIds": [
+        "sentence_functions"
+      ],
+      "sample": {
+        "templateId": "sentence_type_table",
+        "templateLabel": "Classify sentence functions",
+        "domain": "Sentence function",
+        "skillIds": [
+          "sentence_functions"
+        ],
+        "questionType": "classify",
+        "seed": 10000,
+        "itemId": "sentence_type_table:10000",
+        "marks": 2,
+        "promptText": "Tick one box in each row to show the sentence function.",
+        "inputSpec": {
+          "type": "table_choice",
+          "columns": [
+            "statement",
+            "question",
+            "command",
+            "exclamation"
+          ],
+          "rows": [
+            {
+              "key": "row0",
+              "label": "Bring your reading record tomorrow."
+            },
+            {
+              "key": "row1",
+              "label": "Our coach arrives at half past nine."
+            },
+            {
+              "key": "row2",
+              "label": "How quickly the rabbit ran!"
+            },
+            {
+              "key": "row3",
+              "label": "Where did you put the compass?"
+            }
+          ]
+        },
+        "solutionLines": [
+          "A statement tells, a question asks, a command instructs, and an exclamation shows strong feeling.",
+          "Judge each whole sentence, not only the punctuation at the end."
+        ]
+      },
+      "correctResponse": {
+        "row0": "command",
+        "row1": "statement",
+        "row2": "exclamation",
+        "row3": "question"
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 2,
+        "maxScore": 2,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "Bring your reading record tomorrow. → command | Our coach arrives at half past nine. → statement | How quickly the rabbit ran! → exclamation | Where did you put the compass? → question",
+        "answerText": "Bring your reading record tomorrow. → command | Our coach arrives at half past nine. → statement | How quickly the rabbit ran! → exclamation | Where did you put the compass? → question",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 2,
+        "misconception": "sentence_function_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "Bring your reading record tomorrow. → command | Our coach arrives at half past nine. → statement | How quickly the rabbit ran! → exclamation | Where did you put the compass? → question",
+        "answerText": "Bring your reading record tomorrow. → command | Our coach arrives at half past nine. → statement | How quickly the rabbit ran! → exclamation | Where did you put the compass? → question",
+        "minimalHint": "Ask what the sentence is doing: telling, asking, ordering, or exclaiming."
+      }
+    },
+    {
+      "id": "question_mark_select",
+      "label": "Find the real questions",
+      "domain": "Sentence function",
+      "questionType": "identify",
+      "difficulty": 1,
+      "satsFriendly": true,
+      "isSelectedResponse": true,
+      "generative": false,
+      "tags": [
+        "identify"
+      ],
+      "skillIds": [
+        "sentence_functions",
+        "speech_punctuation"
+      ],
+      "sample": {
+        "templateId": "question_mark_select",
+        "templateLabel": "Find the real questions",
+        "domain": "Sentence function",
+        "skillIds": [
+          "sentence_functions",
+          "speech_punctuation"
+        ],
+        "questionType": "identify",
+        "seed": 10017,
+        "itemId": "question_mark_select:10017",
+        "marks": 1,
+        "promptText": "Tick all the sentences that must end with a question mark.",
+        "inputSpec": {
+          "type": "checkbox_list",
+          "label": "Sentences",
+          "options": [
+            {
+              "value": "What a long journey this has been",
+              "label": "What a long journey this has been"
+            },
+            {
+              "value": "Can you help me carry the boxes",
+              "label": "Can you help me carry the boxes"
+            },
+            {
+              "value": "Mum wondered whether the parcel had arrived",
+              "label": "Mum wondered whether the parcel had arrived"
+            },
+            {
+              "value": "Did the coach leave on time",
+              "label": "Did the coach leave on time"
+            }
+          ]
+        },
+        "solutionLines": [
+          "A direct question asks for an answer.",
+          "An indirect question like 'Mum wondered whether...' is still a statement."
+        ]
+      },
+      "correctResponse": {
+        "selected": [
+          "Can you help me carry the boxes",
+          "Did the coach leave on time"
+        ]
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 1,
+        "maxScore": 1,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "The sentences needing question marks are: Can you help me carry the boxes; Did the coach leave on time.",
+        "answerText": "Can you help me carry the boxes; Did the coach leave on time",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 1,
+        "misconception": "sentence_function_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "The sentences needing question marks are: Can you help me carry the boxes; Did the coach leave on time.",
+        "answerText": "Can you help me carry the boxes; Did the coach leave on time",
+        "minimalHint": "Ask what the sentence is doing: telling, asking, ordering, or exclaiming."
+      }
+    },
+    {
+      "id": "word_class_underlined_choice",
+      "label": "Identify the word class",
+      "domain": "Word classes",
+      "questionType": "identify",
+      "difficulty": 1,
+      "satsFriendly": true,
+      "isSelectedResponse": true,
+      "generative": false,
+      "tags": [
+        "identify"
+      ],
+      "skillIds": [
+        "word_classes"
+      ],
+      "sample": {
+        "templateId": "word_class_underlined_choice",
+        "templateLabel": "Identify the word class",
+        "domain": "Word classes",
+        "skillIds": [
+          "word_classes"
+        ],
+        "questionType": "identify",
+        "seed": 10034,
+        "itemId": "word_class_underlined_choice:10034",
+        "marks": 1,
+        "promptText": "Which word class is the underlined word in the sentence below? On sunny days, Ben often plays outside before dinner.",
+        "inputSpec": {
+          "type": "single_choice",
+          "options": [
+            {
+              "value": "adverb",
+              "label": "adverb"
+            },
+            {
+              "value": "conjunction",
+              "label": "conjunction"
+            },
+            {
+              "value": "adjective",
+              "label": "adjective"
+            },
+            {
+              "value": "determiner",
+              "label": "determiner"
+            }
+          ]
+        },
+        "solutionLines": [
+          "Work out the underlined word's job in the sentence.",
+          "Here, 'often' is modifying the verb or whole clause."
+        ]
+      },
+      "correctResponse": {
+        "answer": "adverb"
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 1,
+        "maxScore": 1,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "The underlined word is adverb.",
+        "answerText": "adverb",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 1,
+        "misconception": "word_class_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "The underlined word is adverb.",
+        "answerText": "adverb",
+        "minimalHint": "Look at the word’s job in the sentence, not just what it seems to mean on its own."
+      }
+    },
+    {
+      "id": "identify_words_in_sentence",
+      "label": "Select words with the target job",
+      "domain": "Word classes",
+      "questionType": "identify",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": true,
+      "generative": false,
+      "tags": [
+        "identify"
+      ],
+      "skillIds": [
+        "word_classes"
+      ],
+      "sample": {
+        "templateId": "identify_words_in_sentence",
+        "templateLabel": "Select words with the target job",
+        "domain": "Word classes",
+        "skillIds": [
+          "word_classes"
+        ],
+        "questionType": "identify",
+        "seed": 10051,
+        "itemId": "identify_words_in_sentence:10051",
+        "marks": 1,
+        "promptText": "Select all the pronouns in the sentence below. She handed it to them before they left.",
+        "inputSpec": {
+          "type": "checkbox_list",
+          "label": "Pronouns",
+          "asTokens": true,
+          "options": [
+            {
+              "value": "She",
+              "label": "She"
+            },
+            {
+              "value": "handed",
+              "label": "handed"
+            },
+            {
+              "value": "it",
+              "label": "it"
+            },
+            {
+              "value": "to",
+              "label": "to"
+            },
+            {
+              "value": "them",
+              "label": "them"
+            },
+            {
+              "value": "before",
+              "label": "before"
+            },
+            {
+              "value": "they",
+              "label": "they"
+            },
+            {
+              "value": "left",
+              "label": "left"
+            }
+          ]
+        },
+        "solutionLines": [
+          "Find the words that are working as pronouns.",
+          "Correct selection: She, it, them, they."
+        ]
+      },
+      "correctResponse": {
+        "selected": [
+          "She",
+          "it",
+          "them",
+          "they"
+        ]
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 1,
+        "maxScore": 1,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "The correct words are: She, it, them, they.",
+        "answerText": "She, it, them, they",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 1,
+        "misconception": "word_class_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "The correct words are: She, it, them, they.",
+        "answerText": "She, it, them, they",
+        "minimalHint": "Look at the word’s job in the sentence, not just what it seems to mean on its own."
+      }
+    },
+    {
+      "id": "expanded_noun_phrase_choice",
+      "label": "Spot the expanded noun phrase",
+      "domain": "Phrases",
+      "questionType": "choose",
+      "difficulty": 1,
+      "satsFriendly": true,
+      "isSelectedResponse": true,
+      "generative": false,
+      "tags": [
+        "identify"
+      ],
+      "skillIds": [
+        "noun_phrases"
+      ],
+      "sample": {
+        "templateId": "expanded_noun_phrase_choice",
+        "templateLabel": "Spot the expanded noun phrase",
+        "domain": "Phrases",
+        "skillIds": [
+          "noun_phrases"
+        ],
+        "questionType": "choose",
+        "seed": 10068,
+        "itemId": "expanded_noun_phrase_choice:10068",
+        "marks": 1,
+        "promptText": "Which sentence contains an expanded noun phrase?",
+        "inputSpec": {
+          "type": "single_choice",
+          "options": [
+            {
+              "value": "The tired explorers climbed the hill.",
+              "label": "The tired explorers climbed the hill."
+            },
+            {
+              "value": "Across the field, the dog barked.",
+              "label": "Across the field, the dog barked."
+            },
+            {
+              "value": "Because it was late, we hurried.",
+              "label": "Because it was late, we hurried."
+            },
+            {
+              "value": "Please close the shutters.",
+              "label": "Please close the shutters."
+            }
+          ]
+        },
+        "solutionLines": [
+          "A noun phrase must centre on a noun.",
+          "Expanded noun phrases add detail with extra words attached to that noun."
+        ]
+      },
+      "correctResponse": {
+        "answer": "The tired explorers climbed the hill."
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 1,
+        "maxScore": 1,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "The correct answer is: The tired explorers climbed the hill..",
+        "answerText": "The tired explorers climbed the hill.",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 1,
+        "misconception": "noun_phrase_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "The correct answer is: The tired explorers climbed the hill..",
+        "answerText": "The tired explorers climbed the hill.",
+        "minimalHint": "A noun phrase must centre on a noun. Check which words belong with that noun."
+      }
+    },
+    {
+      "id": "build_noun_phrase",
+      "label": "Build a noun phrase",
+      "domain": "Phrases",
+      "questionType": "build",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": false,
+      "generative": false,
+      "tags": [
+        "builder"
+      ],
+      "skillIds": [
+        "noun_phrases"
+      ],
+      "sample": {
+        "templateId": "build_noun_phrase",
+        "templateLabel": "Build a noun phrase",
+        "domain": "Phrases",
+        "skillIds": [
+          "noun_phrases"
+        ],
+        "questionType": "build",
+        "seed": 10085,
+        "itemId": "build_noun_phrase:10085",
+        "marks": 2,
+        "promptText": "Build a noun phrase of at least three words to complete the sentence below. ___ found the silver key.",
+        "inputSpec": {
+          "type": "multi",
+          "fields": [
+            {
+              "key": "part1",
+              "label": "Part 1",
+              "kind": "select",
+              "options": [
+                [
+                  "",
+                  "Choose"
+                ],
+                [
+                  "The nervous young",
+                  "The nervous young"
+                ],
+                [
+                  "Suddenly",
+                  "Suddenly"
+                ],
+                [
+                  "If",
+                  "If"
+                ]
+              ]
+            },
+            {
+              "key": "part2",
+              "label": "Part 2",
+              "kind": "select",
+              "options": [
+                [
+                  "",
+                  "Choose"
+                ],
+                [
+                  "explorer",
+                  "explorer"
+                ],
+                [
+                  "ran",
+                  "ran"
+                ],
+                [
+                  "under",
+                  "under"
+                ]
+              ]
+            },
+            {
+              "key": "part3",
+              "label": "Part 3",
+              "kind": "select",
+              "options": [
+                [
+                  "",
+                  "Choose"
+                ],
+                [
+                  "from our class",
+                  "from our class"
+                ],
+                [
+                  "very carefully",
+                  "very carefully"
+                ],
+                [
+                  "because of the rain",
+                  "because of the rain"
+                ]
+              ]
+            }
+          ]
+        },
+        "solutionLines": [
+          "Choose a sensible determiner/adjective opening, then a noun, then extra detail attached to that noun.",
+          "A strong answer is: The nervous young explorer from our class."
+        ]
+      },
+      "correctResponse": {
+        "part1": "The nervous young",
+        "part2": "explorer",
+        "part3": "from our class"
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 2,
+        "maxScore": 2,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "A strong answer is: The nervous young explorer from our class.",
+        "answerText": "The nervous young explorer from our class",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 2,
+        "misconception": "noun_phrase_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "A strong answer is: The nervous young explorer from our class.",
+        "answerText": "The nervous young explorer from our class",
+        "minimalHint": "A noun phrase must centre on a noun. Check which words belong with that noun."
+      }
+    },
+    {
+      "id": "fronted_adverbial_choose",
+      "label": "Spot the fronted adverbial",
+      "domain": "Adverbials",
+      "questionType": "choose",
+      "difficulty": 1,
+      "satsFriendly": true,
+      "isSelectedResponse": true,
+      "generative": false,
+      "tags": [
+        "identify"
+      ],
+      "skillIds": [
+        "adverbials"
+      ],
+      "sample": {
+        "templateId": "fronted_adverbial_choose",
+        "templateLabel": "Spot the fronted adverbial",
+        "domain": "Adverbials",
+        "skillIds": [
+          "adverbials"
+        ],
+        "questionType": "choose",
+        "seed": 10102,
+        "itemId": "fronted_adverbial_choose:10102",
+        "marks": 1,
+        "promptText": "Which sentence starts with a fronted adverbial?",
+        "inputSpec": {
+          "type": "single_choice",
+          "options": [
+            {
+              "value": "She is feeling tired, so Kal is going to her room.",
+              "label": "She is feeling tired, so Kal is going to her room."
+            },
+            {
+              "value": "After dinner, Kal is going to her room.",
+              "label": "After dinner, Kal is going to her room."
+            },
+            {
+              "value": "Arun told me that Kal is going to her room.",
+              "label": "Arun told me that Kal is going to her room."
+            },
+            {
+              "value": "I wonder when Kal is going to her room.",
+              "label": "I wonder when Kal is going to her room."
+            }
+          ]
+        },
+        "solutionLines": [
+          "A fronted adverbial gives when, where or how information at the start of the sentence.",
+          "In KS2 contexts it is commonly followed by a comma."
+        ]
+      },
+      "correctResponse": {
+        "answer": "After dinner, Kal is going to her room."
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 1,
+        "maxScore": 1,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "The correct answer is: After dinner, Kal is going to her room.",
+        "answerText": "After dinner, Kal is going to her room.",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 1,
+        "misconception": "fronted_adverbial_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "The correct answer is: After dinner, Kal is going to her room.",
+        "answerText": "After dinner, Kal is going to her room.",
+        "minimalHint": "If the sentence opens with when, where or how information, check whether it needs a comma after it."
+      }
+    },
+    {
+      "id": "fix_fronted_adverbial",
+      "label": "Add the comma after a fronted adverbial",
+      "domain": "Adverbials",
+      "questionType": "fix",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": false,
+      "generative": false,
+      "tags": [
+        "surgery"
+      ],
+      "skillIds": [
+        "adverbials"
+      ],
+      "sample": {
+        "templateId": "fix_fronted_adverbial",
+        "templateLabel": "Add the comma after a fronted adverbial",
+        "domain": "Adverbials",
+        "skillIds": [
+          "adverbials"
+        ],
+        "questionType": "fix",
+        "seed": 10119,
+        "itemId": "fix_fronted_adverbial:10119",
+        "marks": 2,
+        "promptText": "Copy the sentence and add the comma after the fronted adverbial. Before sunrise the campers packed their bags.",
+        "inputSpec": {
+          "type": "textarea",
+          "label": "Corrected sentence",
+          "placeholder": "Type the corrected sentence here."
+        },
+        "solutionLines": [
+          "Spot the opening adverbial telling us when.",
+          "Add a comma after that opening phrase.",
+          "Correct answer: Before sunrise, the campers packed their bags."
+        ]
+      },
+      "correctResponse": {
+        "answer": "Before sunrise, the campers packed their bags."
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 2,
+        "maxScore": 2,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "The correct sentence is: Before sunrise, the campers packed their bags.",
+        "answerText": "Before sunrise, the campers packed their bags.",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 2,
+        "misconception": "fronted_adverbial_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "The correct sentence is: Before sunrise, the campers packed their bags.",
+        "answerText": "Before sunrise, the campers packed their bags.",
+        "minimalHint": "If the sentence opens with when, where or how information, check whether it needs a comma after it."
+      }
+    },
+    {
+      "id": "subordinate_clause_choice",
+      "label": "Identify the subordinate clause",
+      "domain": "Clauses",
+      "questionType": "identify",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": true,
+      "generative": false,
+      "tags": [
+        "identify"
+      ],
+      "skillIds": [
+        "clauses"
+      ],
+      "sample": {
+        "templateId": "subordinate_clause_choice",
+        "templateLabel": "Identify the subordinate clause",
+        "domain": "Clauses",
+        "skillIds": [
+          "clauses"
+        ],
+        "questionType": "identify",
+        "seed": 10136,
+        "itemId": "subordinate_clause_choice:10136",
+        "marks": 1,
+        "promptText": "Which option is the subordinate clause in the sentence below? If the path is icy, wear your boots.",
+        "inputSpec": {
+          "type": "single_choice",
+          "options": [
+            {
+              "value": "wear your boots",
+              "label": "wear your boots"
+            },
+            {
+              "value": "If the path is icy",
+              "label": "If the path is icy"
+            },
+            {
+              "value": "the path is icy boots",
+              "label": "the path is icy boots"
+            },
+            {
+              "value": "icy wear",
+              "label": "icy wear"
+            }
+          ]
+        },
+        "solutionLines": [
+          "A subordinate clause often begins with a conjunction such as because, when, if or although.",
+          "It depends on the main clause to complete the full meaning."
+        ]
+      },
+      "correctResponse": {
+        "answer": "If the path is icy"
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 1,
+        "maxScore": 1,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "The subordinate clause is: If the path is icy.",
+        "answerText": "If the path is icy",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 1,
+        "misconception": "subordinate_clause_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "The subordinate clause is: If the path is icy.",
+        "answerText": "If the path is icy",
+        "minimalHint": "A subordinate clause usually depends on the main clause. Ask whether it can stand alone here."
+      }
+    },
+    {
+      "id": "combine_clauses_rewrite",
+      "label": "Combine ideas into one sentence",
+      "domain": "Clauses",
+      "questionType": "rewrite",
+      "difficulty": 3,
+      "satsFriendly": true,
+      "isSelectedResponse": false,
+      "generative": false,
+      "tags": [
+        "builder",
+        "surgery"
+      ],
+      "skillIds": [
+        "clauses"
+      ],
+      "sample": {
+        "templateId": "combine_clauses_rewrite",
+        "templateLabel": "Combine ideas into one sentence",
+        "domain": "Clauses",
+        "skillIds": [
+          "clauses"
+        ],
+        "questionType": "rewrite",
+        "seed": 10153,
+        "itemId": "combine_clauses_rewrite:10153",
+        "marks": 2,
+        "promptText": "Combine the ideas into one sentence using because. Sam wore gloves. It was cold.",
+        "inputSpec": {
+          "type": "textarea",
+          "label": "Combined sentence",
+          "placeholder": "Write one complete sentence."
+        },
+        "solutionLines": [
+          "Use 'because' to show cause.",
+          "Either order can work if the punctuation is correct.",
+          "A strong answer is: Sam wore gloves because it was cold."
+        ]
+      },
+      "correctResponse": {
+        "answer": "Sam wore gloves because it was cold."
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 2,
+        "maxScore": 2,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "A correct answer is: Sam wore gloves because it was cold.",
+        "answerText": "Sam wore gloves because it was cold.",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 2,
+        "misconception": "subordinate_clause_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "A correct answer is: Sam wore gloves because it was cold.",
+        "answerText": "Sam wore gloves because it was cold.",
+        "minimalHint": "A subordinate clause usually depends on the main clause. Ask whether it can stand alone here."
+      }
+    },
+    {
+      "id": "relative_clause_identify",
+      "label": "Spot the relative clause",
+      "domain": "Clauses",
+      "questionType": "choose",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": true,
+      "generative": false,
+      "tags": [
+        "identify"
+      ],
+      "skillIds": [
+        "relative_clauses"
+      ],
+      "sample": {
+        "templateId": "relative_clause_identify",
+        "templateLabel": "Spot the relative clause",
+        "domain": "Clauses",
+        "skillIds": [
+          "relative_clauses"
+        ],
+        "questionType": "choose",
+        "seed": 10170,
+        "itemId": "relative_clause_identify:10170",
+        "marks": 1,
+        "promptText": "Which sentence contains a relative clause?",
+        "inputSpec": {
+          "type": "single_choice",
+          "options": [
+            {
+              "value": "The boy who dropped his hat waved to us.",
+              "label": "The boy who dropped his hat waved to us."
+            },
+            {
+              "value": "When the boy dropped his hat, he waved to us.",
+              "label": "When the boy dropped his hat, he waved to us."
+            },
+            {
+              "value": "The boy dropped his hat and waved to us.",
+              "label": "The boy dropped his hat and waved to us."
+            },
+            {
+              "value": "Waving to us, the boy dropped his hat.",
+              "label": "Waving to us, the boy dropped his hat."
+            }
+          ]
+        },
+        "solutionLines": [
+          "A relative clause gives extra information about a noun.",
+          "It often begins with who, which, that, where, when or whose."
+        ]
+      },
+      "correctResponse": {
+        "answer": "The boy who dropped his hat waved to us."
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 1,
+        "maxScore": 1,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "The correct sentence is: The boy who dropped his hat waved to us.",
+        "answerText": "The boy who dropped his hat waved to us.",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 1,
+        "misconception": "relative_clause_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "The correct sentence is: The boy who dropped his hat waved to us.",
+        "answerText": "The boy who dropped his hat waved to us.",
+        "minimalHint": "A relative clause adds extra information about a noun. Find the noun it is attached to."
+      }
+    },
+    {
+      "id": "relative_clause_complete",
+      "label": "Complete with a relative clause",
+      "domain": "Clauses",
+      "questionType": "build",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": true,
+      "generative": false,
+      "tags": [
+        "builder"
+      ],
+      "skillIds": [
+        "relative_clauses"
+      ],
+      "sample": {
+        "templateId": "relative_clause_complete",
+        "templateLabel": "Complete with a relative clause",
+        "domain": "Clauses",
+        "skillIds": [
+          "relative_clauses"
+        ],
+        "questionType": "build",
+        "seed": 10187,
+        "itemId": "relative_clause_complete:10187",
+        "marks": 1,
+        "promptText": "Complete the sentence with the best relative clause. The teacher ___ helped us with the project.",
+        "inputSpec": {
+          "type": "single_choice",
+          "options": [
+            {
+              "value": "who had visited Egypt",
+              "label": "who had visited Egypt"
+            },
+            {
+              "value": "because she visited Egypt",
+              "label": "because she visited Egypt"
+            },
+            {
+              "value": "after visiting Egypt",
+              "label": "after visiting Egypt"
+            },
+            {
+              "value": "and visited Egypt",
+              "label": "and visited Egypt"
+            }
+          ]
+        },
+        "solutionLines": [
+          "Choose the clause that adds extra information about the noun and fits the sentence smoothly.",
+          "Correct answer: who had visited Egypt"
+        ]
+      },
+      "correctResponse": {
+        "answer": "who had visited Egypt"
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 1,
+        "maxScore": 1,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "The best completion is: who had visited Egypt.",
+        "answerText": "who had visited Egypt",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 1,
+        "misconception": "relative_clause_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "The best completion is: who had visited Egypt.",
+        "answerText": "who had visited Egypt",
+        "minimalHint": "A relative clause adds extra information about a noun. Find the noun it is attached to."
+      }
+    },
+    {
+      "id": "tense_form_choice",
+      "label": "Choose the correct verb form",
+      "domain": "Verb forms",
+      "questionType": "fill",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": true,
+      "generative": false,
+      "tags": [
+        "identify"
+      ],
+      "skillIds": [
+        "tense_aspect"
+      ],
+      "sample": {
+        "templateId": "tense_form_choice",
+        "templateLabel": "Choose the correct verb form",
+        "domain": "Verb forms",
+        "skillIds": [
+          "tense_aspect"
+        ],
+        "questionType": "fill",
+        "seed": 10204,
+        "itemId": "tense_form_choice:10204",
+        "marks": 1,
+        "promptText": "Choose the best verb form to complete the sentence. While we ___ to our friend, his phone started ringing.",
+        "inputSpec": {
+          "type": "single_choice",
+          "options": [
+            {
+              "value": "talked",
+              "label": "talked"
+            },
+            {
+              "value": "have talked",
+              "label": "have talked"
+            },
+            {
+              "value": "were talking",
+              "label": "were talking"
+            },
+            {
+              "value": "had talked",
+              "label": "had talked"
+            }
+          ]
+        },
+        "solutionLines": [
+          "Use the time clues in the sentence.",
+          "Check whether the meaning needs simple, progressive, present perfect or past perfect."
+        ]
+      },
+      "correctResponse": {
+        "answer": "were talking"
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 1,
+        "maxScore": 1,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "The correct form is: were talking.",
+        "answerText": "were talking",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 1,
+        "misconception": "tense_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "The correct form is: were talking.",
+        "answerText": "were talking",
+        "minimalHint": "Check when the action happened and whether the sentence needs a simple, progressive, perfect, or past perfect form."
+      }
+    },
+    {
+      "id": "tense_rewrite",
+      "label": "Rewrite in a different tense",
+      "domain": "Verb forms",
+      "questionType": "rewrite",
+      "difficulty": 3,
+      "satsFriendly": true,
+      "isSelectedResponse": false,
+      "generative": false,
+      "tags": [
+        "surgery",
+        "builder"
+      ],
+      "skillIds": [
+        "tense_aspect"
+      ],
+      "sample": {
+        "templateId": "tense_rewrite",
+        "templateLabel": "Rewrite in a different tense",
+        "domain": "Verb forms",
+        "skillIds": [
+          "tense_aspect"
+        ],
+        "questionType": "rewrite",
+        "seed": 10221,
+        "itemId": "tense_rewrite:10221",
+        "marks": 2,
+        "promptText": "Rewrite the sentence in the past progressive. The dog chases the cat.",
+        "inputSpec": {
+          "type": "textarea",
+          "label": "Rewritten sentence",
+          "placeholder": "Write the full sentence."
+        },
+        "solutionLines": [
+          "Change the simple present verb into the past progressive form.",
+          "Use 'was' with 'chasing'.",
+          "The correct sentence is: The dog was chasing the cat."
+        ]
+      },
+      "correctResponse": {
+        "answer": "The dog was chasing the cat."
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 2,
+        "maxScore": 2,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "A correct answer is: The dog was chasing the cat.",
+        "answerText": "The dog was chasing the cat.",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 2,
+        "misconception": "tense_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "A correct answer is: The dog was chasing the cat.",
+        "answerText": "The dog was chasing the cat.",
+        "minimalHint": "Check when the action happened and whether the sentence needs a simple, progressive, perfect, or past perfect form."
+      }
+    },
+    {
+      "id": "standard_english_pairs",
+      "label": "Choose the Standard English forms",
+      "domain": "Standard English",
+      "questionType": "choose",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": true,
+      "generative": false,
+      "tags": [
+        "identify"
+      ],
+      "skillIds": [
+        "standard_english"
+      ],
+      "sample": {
+        "templateId": "standard_english_pairs",
+        "templateLabel": "Choose the Standard English forms",
+        "domain": "Standard English",
+        "skillIds": [
+          "standard_english"
+        ],
+        "questionType": "choose",
+        "seed": 10238,
+        "itemId": "standard_english_pairs:10238",
+        "marks": 2,
+        "promptText": "Choose the correct verb form in each pair to complete the sentences using Standard English.",
+        "inputSpec": {
+          "type": "multi",
+          "fields": [
+            {
+              "key": "row0",
+              "label": "We was / were going on a school trip.",
+              "kind": "radio",
+              "options": [
+                [
+                  "was",
+                  "was"
+                ],
+                [
+                  "were",
+                  "were"
+                ]
+              ]
+            },
+            {
+              "key": "row1",
+              "label": "The musicians did / done a sound check.",
+              "kind": "radio",
+              "options": [
+                [
+                  "did",
+                  "did"
+                ],
+                [
+                  "done",
+                  "done"
+                ]
+              ]
+            }
+          ]
+        },
+        "solutionLines": [
+          "Standard English uses the accepted written verb forms.",
+          "Be careful not to copy a spoken local form into formal writing."
+        ]
+      },
+      "correctResponse": {
+        "row0": "were",
+        "row1": "did"
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 2,
+        "maxScore": 2,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "Correct choices: were; did.",
+        "answerText": "were; did",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 2,
+        "misconception": "standard_english_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "Correct choices: were; did.",
+        "answerText": "were; did",
+        "minimalHint": "Choose the form you would expect in formal writing, not the spoken form you might hear."
+      }
+    },
+    {
+      "id": "pronoun_cohesion_choice",
+      "label": "Choose the clearest cohesive version",
+      "domain": "Cohesion",
+      "questionType": "choose",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": true,
+      "generative": false,
+      "tags": [
+        "identify"
+      ],
+      "skillIds": [
+        "pronouns_cohesion"
+      ],
+      "sample": {
+        "templateId": "pronoun_cohesion_choice",
+        "templateLabel": "Choose the clearest cohesive version",
+        "domain": "Cohesion",
+        "skillIds": [
+          "pronouns_cohesion"
+        ],
+        "questionType": "choose",
+        "seed": 10255,
+        "itemId": "pronoun_cohesion_choice:10255",
+        "marks": 1,
+        "promptText": "Which version is clearest and avoids awkward repetition without becoming confusing?",
+        "inputSpec": {
+          "type": "single_choice",
+          "options": [
+            {
+              "value": "Arjun gave Arjun's book to Arjun's sister because Arjun had finished Arjun's book.",
+              "label": "Arjun gave Arjun's book to Arjun's sister because Arjun had finished Arjun's book."
+            },
+            {
+              "value": "Arjun gave his book to his sister because he had finished it.",
+              "label": "Arjun gave his book to his sister because he had finished it."
+            },
+            {
+              "value": "Arjun gave his book to his sister because it had finished him.",
+              "label": "Arjun gave his book to his sister because it had finished him."
+            },
+            {
+              "value": "He gave it to her because he had finished her.",
+              "label": "He gave it to her because he had finished her."
+            }
+          ]
+        },
+        "solutionLines": [
+          "Good cohesion reduces repetition without making the meaning unclear.",
+          "A pronoun must clearly point to the right noun."
+        ]
+      },
+      "correctResponse": {
+        "answer": "Arjun gave his book to his sister because he had finished it."
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 1,
+        "maxScore": 1,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "The clearest version is: Arjun gave his book to his sister because he had finished it.",
+        "answerText": "Arjun gave his book to his sister because he had finished it.",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 1,
+        "misconception": "pronoun_cohesion_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "The clearest version is: Arjun gave his book to his sister because he had finished it.",
+        "answerText": "Arjun gave his book to his sister because he had finished it.",
+        "minimalHint": "A pronoun should make the sentence smoother without making the meaning unclear."
+      }
+    },
+    {
+      "id": "formality_pairs",
+      "label": "Choose the more formal option",
+      "domain": "Register",
+      "questionType": "choose",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": true,
+      "generative": false,
+      "tags": [
+        "identify"
+      ],
+      "skillIds": [
+        "formality"
+      ],
+      "sample": {
+        "templateId": "formality_pairs",
+        "templateLabel": "Choose the more formal option",
+        "domain": "Register",
+        "skillIds": [
+          "formality"
+        ],
+        "questionType": "choose",
+        "seed": 10272,
+        "itemId": "formality_pairs:10272",
+        "marks": 2,
+        "promptText": "Circle the most formal option in each underlined pair below to complete the passage.",
+        "inputSpec": {
+          "type": "multi",
+          "fields": [
+            {
+              "key": "row0",
+              "label": "The basketball club was set up / established last year.",
+              "kind": "radio",
+              "options": [
+                [
+                  "set up",
+                  "set up"
+                ],
+                [
+                  "established",
+                  "established"
+                ]
+              ]
+            },
+            {
+              "key": "row1",
+              "label": "They asked for / requested new equipment.",
+              "kind": "radio",
+              "options": [
+                [
+                  "asked for",
+                  "asked for"
+                ],
+                [
+                  "requested",
+                  "requested"
+                ]
+              ]
+            },
+            {
+              "key": "row2",
+              "label": "Now they play / compete in a local league.",
+              "kind": "radio",
+              "options": [
+                [
+                  "play",
+                  "play"
+                ],
+                [
+                  "compete",
+                  "compete"
+                ]
+              ]
+            }
+          ]
+        },
+        "solutionLines": [
+          "Formal language usually uses more precise or less chatty vocabulary.",
+          "The best option depends on the setting and purpose."
+        ]
+      },
+      "correctResponse": {
+        "row0": "established",
+        "row1": "requested",
+        "row2": "compete"
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 2,
+        "maxScore": 2,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "Correct formal choices: established; requested; compete.",
+        "answerText": "established; requested; compete",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 2,
+        "misconception": "formality_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "Correct formal choices: established; requested; compete.",
+        "answerText": "established; requested; compete",
+        "minimalHint": "Match the language to a formal setting, not everyday chat."
+      }
+    },
+    {
+      "id": "active_passive_rewrite",
+      "label": "Transform active and passive voice",
+      "domain": "Sentence structure",
+      "questionType": "rewrite",
+      "difficulty": 3,
+      "satsFriendly": true,
+      "isSelectedResponse": false,
+      "generative": false,
+      "tags": [
+        "builder",
+        "surgery"
+      ],
+      "skillIds": [
+        "active_passive"
+      ],
+      "sample": {
+        "templateId": "active_passive_rewrite",
+        "templateLabel": "Transform active and passive voice",
+        "domain": "Sentence structure",
+        "skillIds": [
+          "active_passive"
+        ],
+        "questionType": "rewrite",
+        "seed": 10289,
+        "itemId": "active_passive_rewrite:10289",
+        "marks": 2,
+        "promptText": "Rewrite the sentence in the passive. Keep the same tense. The team will collect the trophy.",
+        "inputSpec": {
+          "type": "textarea",
+          "label": "Rewritten sentence",
+          "placeholder": "Write the full transformed sentence."
+        },
+        "solutionLines": [
+          "Keep the future tense by using 'will be'.",
+          "Then add the past participle 'collected'.",
+          "A correct answer is: The trophy will be collected by the team."
+        ]
+      },
+      "correctResponse": {
+        "answer": "The trophy will be collected by the team."
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 2,
+        "maxScore": 2,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "A correct answer is: The trophy will be collected by the team.",
+        "answerText": "The trophy will be collected by the team.",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 2,
+        "misconception": "active_passive_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "A correct answer is: The trophy will be collected by the team.",
+        "answerText": "The trophy will be collected by the team.",
+        "minimalHint": "In active voice, the doer comes first. In passive voice, the thing affected comes first."
+      }
+    },
+    {
+      "id": "subject_object_choice",
+      "label": "Identify subject or object",
+      "domain": "Sentence structure",
+      "questionType": "identify",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": true,
+      "generative": false,
+      "tags": [
+        "identify"
+      ],
+      "skillIds": [
+        "subject_object"
+      ],
+      "sample": {
+        "templateId": "subject_object_choice",
+        "templateLabel": "Identify subject or object",
+        "domain": "Sentence structure",
+        "skillIds": [
+          "subject_object"
+        ],
+        "questionType": "identify",
+        "seed": 10306,
+        "itemId": "subject_object_choice:10306",
+        "marks": 1,
+        "promptText": "In the sentence below, what is the object? The noisy gull stole the sandwich from Max.",
+        "inputSpec": {
+          "type": "single_choice",
+          "options": [
+            {
+              "value": "The noisy gull",
+              "label": "The noisy gull"
+            },
+            {
+              "value": "stole",
+              "label": "stole"
+            },
+            {
+              "value": "the sandwich",
+              "label": "the sandwich"
+            },
+            {
+              "value": "from Max",
+              "label": "from Max"
+            }
+          ]
+        },
+        "solutionLines": [
+          "The subject usually does the action; the object usually receives it.",
+          "Ignore opening adverbials when finding the subject or object."
+        ]
+      },
+      "correctResponse": {
+        "answer": "the sandwich"
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 1,
+        "maxScore": 1,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "The object is: the sandwich.",
+        "answerText": "the sandwich",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 1,
+        "misconception": "subject_object_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "The object is: the sandwich.",
+        "answerText": "the sandwich",
+        "minimalHint": "The subject does the action; the object receives it."
+      }
+    },
+    {
+      "id": "modal_verb_choice",
+      "label": "Choose the best modal meaning",
+      "domain": "Verb forms",
+      "questionType": "choose",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": true,
+      "generative": false,
+      "tags": [
+        "identify"
+      ],
+      "skillIds": [
+        "modal_verbs"
+      ],
+      "sample": {
+        "templateId": "modal_verb_choice",
+        "templateLabel": "Choose the best modal meaning",
+        "domain": "Verb forms",
+        "skillIds": [
+          "modal_verbs"
+        ],
+        "questionType": "choose",
+        "seed": 10323,
+        "itemId": "modal_verb_choice:10323",
+        "marks": 1,
+        "promptText": "Which sentence shows the least certainty that the team will win?",
+        "inputSpec": {
+          "type": "single_choice",
+          "options": [
+            {
+              "value": "The team must win.",
+              "label": "The team must win."
+            },
+            {
+              "value": "The team will win.",
+              "label": "The team will win."
+            },
+            {
+              "value": "The team should win.",
+              "label": "The team should win."
+            },
+            {
+              "value": "The team might win.",
+              "label": "The team might win."
+            }
+          ]
+        },
+        "solutionLines": [
+          "Compare how certain, likely or strong each modal verb sounds.",
+          "The best answer depends on the meaning, not just the grammar label."
+        ]
+      },
+      "correctResponse": {
+        "answer": "The team might win."
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 1,
+        "maxScore": 1,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "The correct answer is: The team might win..",
+        "answerText": "The team might win.",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 1,
+        "misconception": "modal_verb_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "The correct answer is: The team might win..",
+        "answerText": "The team might win.",
+        "minimalHint": "Compare how certain each modal verb sounds."
+      }
+    },
+    {
+      "id": "parenthesis_replace_choice",
+      "label": "Choose punctuation for parenthesis",
+      "domain": "Punctuation for grammar",
+      "questionType": "choose",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": true,
+      "generative": false,
+      "tags": [
+        "identify"
+      ],
+      "skillIds": [
+        "parenthesis_commas"
+      ],
+      "sample": {
+        "templateId": "parenthesis_replace_choice",
+        "templateLabel": "Choose punctuation for parenthesis",
+        "domain": "Punctuation for grammar",
+        "skillIds": [
+          "parenthesis_commas"
+        ],
+        "questionType": "choose",
+        "seed": 10340,
+        "itemId": "parenthesis_replace_choice:10340",
+        "marks": 1,
+        "promptText": "What punctuation could be used instead of brackets in the sentence below? Tokyo (the capital of Japan) is one of the largest cities in the world.",
+        "inputSpec": {
+          "type": "single_choice",
+          "options": [
+            {
+              "value": "hyphens",
+              "label": "hyphens"
+            },
+            {
+              "value": "colons",
+              "label": "colons"
+            },
+            {
+              "value": "semi-colons",
+              "label": "semi-colons"
+            },
+            {
+              "value": "dashes",
+              "label": "dashes"
+            }
+          ]
+        },
+        "solutionLines": [
+          "Brackets, dashes and paired commas can all mark parenthesis in many KS2 contexts.",
+          "Here the best replacement from the options is dashes."
+        ]
+      },
+      "correctResponse": {
+        "answer": "dashes"
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 1,
+        "maxScore": 1,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "The correct answer is: dashes.",
+        "answerText": "dashes",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 1,
+        "misconception": "parenthesis_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "The correct answer is: dashes.",
+        "answerText": "dashes",
+        "minimalHint": "Parenthesis adds extra information that could be lifted out."
+      }
+    },
+    {
+      "id": "parenthesis_fix_sentence",
+      "label": "Insert brackets for parenthesis",
+      "domain": "Punctuation for grammar",
+      "questionType": "fix",
+      "difficulty": 3,
+      "satsFriendly": true,
+      "isSelectedResponse": false,
+      "generative": false,
+      "tags": [
+        "surgery"
+      ],
+      "skillIds": [
+        "parenthesis_commas"
+      ],
+      "sample": {
+        "templateId": "parenthesis_fix_sentence",
+        "templateLabel": "Insert brackets for parenthesis",
+        "domain": "Punctuation for grammar",
+        "skillIds": [
+          "parenthesis_commas"
+        ],
+        "questionType": "fix",
+        "seed": 10357,
+        "itemId": "parenthesis_fix_sentence:10357",
+        "marks": 2,
+        "promptText": "Insert a pair of brackets in the correct place. My cousin the youngest in the family won the chess trophy.",
+        "inputSpec": {
+          "type": "textarea",
+          "label": "Corrected sentence",
+          "placeholder": "Type the corrected sentence."
+        },
+        "solutionLines": [
+          "The bracketed words add extra information about 'my cousin'.",
+          "The main sentence still works without them.",
+          "The correct sentence is: My cousin (the youngest in the family) won the chess trophy."
+        ]
+      },
+      "correctResponse": {
+        "answer": "My cousin (the youngest in the family) won the chess trophy."
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 2,
+        "maxScore": 2,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "A correct answer is: My cousin (the youngest in the family) won the chess trophy.",
+        "answerText": "My cousin (the youngest in the family) won the chess trophy.",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 2,
+        "misconception": "parenthesis_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "A correct answer is: My cousin (the youngest in the family) won the chess trophy.",
+        "answerText": "My cousin (the youngest in the family) won the chess trophy.",
+        "minimalHint": "Parenthesis adds extra information that could be lifted out."
+      }
+    },
+    {
+      "id": "speech_punctuation_fix",
+      "label": "Punctuate direct speech",
+      "domain": "Punctuation for grammar",
+      "questionType": "fix",
+      "difficulty": 3,
+      "satsFriendly": true,
+      "isSelectedResponse": false,
+      "generative": false,
+      "tags": [
+        "surgery"
+      ],
+      "skillIds": [
+        "speech_punctuation"
+      ],
+      "sample": {
+        "templateId": "speech_punctuation_fix",
+        "templateLabel": "Punctuate direct speech",
+        "domain": "Punctuation for grammar",
+        "skillIds": [
+          "speech_punctuation"
+        ],
+        "questionType": "fix",
+        "seed": 10374,
+        "itemId": "speech_punctuation_fix:10374",
+        "marks": 2,
+        "promptText": "Punctuate the direct speech correctly. \"Where are you going\" asked Mum.",
+        "inputSpec": {
+          "type": "textarea",
+          "label": "Correctly punctuated sentence",
+          "placeholder": "Type the corrected sentence."
+        },
+        "solutionLines": [
+          "The spoken words are a question.",
+          "The question mark belongs inside the speech marks.",
+          "A correct answer is: \"Where are you going?\" asked Mum."
+        ]
+      },
+      "correctResponse": {
+        "answer": "“Where are you going?” asked Mum."
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 2,
+        "maxScore": 2,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "A correct answer is: “Where are you going?” asked Mum.",
+        "answerText": "“Where are you going?” asked Mum.",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 2,
+        "misconception": "speech_punctuation_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "A correct answer is: “Where are you going?” asked Mum.",
+        "answerText": "“Where are you going?” asked Mum.",
+        "minimalHint": "Check where the spoken words end and where the reporting clause begins."
+      }
+    },
+    {
+      "id": "apostrophe_possession_choice",
+      "label": "Choose the correct possessive apostrophe",
+      "domain": "Punctuation for grammar",
+      "questionType": "choose",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": true,
+      "generative": false,
+      "tags": [
+        "identify"
+      ],
+      "skillIds": [
+        "apostrophes_possession"
+      ],
+      "sample": {
+        "templateId": "apostrophe_possession_choice",
+        "templateLabel": "Choose the correct possessive apostrophe",
+        "domain": "Punctuation for grammar",
+        "skillIds": [
+          "apostrophes_possession"
+        ],
+        "questionType": "choose",
+        "seed": 10391,
+        "itemId": "apostrophe_possession_choice:10391",
+        "marks": 1,
+        "promptText": "Choose the correct phrase to complete the sentence: The ___ coats were hanging by the door.",
+        "inputSpec": {
+          "type": "single_choice",
+          "options": [
+            {
+              "value": "children's",
+              "label": "children's"
+            },
+            {
+              "value": "childrens'",
+              "label": "childrens'"
+            },
+            {
+              "value": "childrens",
+              "label": "childrens"
+            },
+            {
+              "value": "child's",
+              "label": "child's"
+            }
+          ]
+        },
+        "solutionLines": [
+          "Work out who owns the noun.",
+          "Then decide whether the owner is singular or plural."
+        ]
+      },
+      "correctResponse": {
+        "answer": "children's"
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 1,
+        "maxScore": 1,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "The correct answer is: children's.",
+        "answerText": "children's",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 1,
+        "misconception": "apostrophe_possession_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "The correct answer is: children's.",
+        "answerText": "children's",
+        "minimalHint": "Ask who owns the noun, and whether the owner is singular or plural."
+      }
+    },
+    {
+      "id": "explain_reason_choice",
+      "label": "Explain why",
+      "domain": "Explanation",
+      "questionType": "explain",
+      "difficulty": 3,
+      "satsFriendly": true,
+      "isSelectedResponse": true,
+      "generative": false,
+      "tags": [
+        "explain"
+      ],
+      "skillIds": [
+        "adverbials",
+        "standard_english"
+      ],
+      "sample": {
+        "templateId": "explain_reason_choice",
+        "templateLabel": "Explain why",
+        "domain": "Explanation",
+        "skillIds": [
+          "adverbials",
+          "standard_english"
+        ],
+        "questionType": "explain",
+        "seed": 10408,
+        "itemId": "explain_reason_choice:10408",
+        "marks": 1,
+        "promptText": "Why is there a comma after the opening words in this sentence? Before sunrise, the campers packed their bags.",
+        "inputSpec": {
+          "type": "single_choice",
+          "options": [
+            {
+              "value": "Because the opening words are a fronted adverbial.",
+              "label": "Because the opening words are a fronted adverbial."
+            },
+            {
+              "value": "Because every long sentence needs a comma near the start.",
+              "label": "Because every long sentence needs a comma near the start."
+            },
+            {
+              "value": "Because ‘sunrise’ is a noun.",
+              "label": "Because ‘sunrise’ is a noun."
+            },
+            {
+              "value": "Because the sentence is in the past tense.",
+              "label": "Because the sentence is in the past tense."
+            }
+          ]
+        },
+        "solutionLines": [
+          "Focus on the grammar reason, not just a vague comment that it 'sounds better'.",
+          "The best explanation names the right feature and why it matters."
+        ]
+      },
+      "correctResponse": {
+        "answer": "Because the opening words are a fronted adverbial."
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 1,
+        "maxScore": 1,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "The best explanation is: Because the opening words are a fronted adverbial..",
+        "answerText": "Because the opening words are a fronted adverbial.",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 1,
+        "misconception": "fronted_adverbial_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "The best explanation is: Because the opening words are a fronted adverbial..",
+        "answerText": "Because the opening words are a fronted adverbial.",
+        "minimalHint": "If the sentence opens with when, where or how information, check whether it needs a comma after it."
+      }
+    },
+    {
+      "id": "standard_fix_sentence",
+      "label": "Rewrite in Standard English",
+      "domain": "Standard English",
+      "questionType": "fix",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": false,
+      "generative": false,
+      "tags": [
+        "surgery"
+      ],
+      "skillIds": [
+        "standard_english"
+      ],
+      "sample": {
+        "templateId": "standard_fix_sentence",
+        "templateLabel": "Rewrite in Standard English",
+        "domain": "Standard English",
+        "skillIds": [
+          "standard_english"
+        ],
+        "questionType": "fix",
+        "seed": 10425,
+        "itemId": "standard_fix_sentence:10425",
+        "marks": 2,
+        "promptText": "Rewrite the sentence in Standard English. I done my homework before tea.",
+        "inputSpec": {
+          "type": "textarea",
+          "label": "Corrected sentence",
+          "placeholder": "Write the corrected sentence."
+        },
+        "solutionLines": [
+          "Replace the non-standard spoken form.",
+          "Standard English uses 'did' here.",
+          "The correct sentence is: I did my homework before tea."
+        ]
+      },
+      "correctResponse": {
+        "answer": "I did my homework before tea."
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 2,
+        "maxScore": 2,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "A correct answer is: I did my homework before tea.",
+        "answerText": "I did my homework before tea.",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 2,
+        "misconception": "standard_english_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "A correct answer is: I did my homework before tea.",
+        "answerText": "I did my homework before tea.",
+        "minimalHint": "Choose the form you would expect in formal writing, not the spoken form you might hear."
+      }
+    },
+    {
+      "id": "proc_fronted_adverbial_fix",
+      "label": "Fix comma after fronted adverbial",
+      "domain": "Adverbials",
+      "questionType": "fix",
+      "difficulty": 1,
+      "satsFriendly": true,
+      "isSelectedResponse": false,
+      "generative": true,
+      "tags": [
+        "surgery"
+      ],
+      "skillIds": [
+        "adverbials"
+      ],
+      "sample": {
+        "templateId": "proc_fronted_adverbial_fix",
+        "templateLabel": "Fix comma after fronted adverbial",
+        "domain": "Adverbials",
+        "skillIds": [
+          "adverbials"
+        ],
+        "questionType": "fix",
+        "seed": 10442,
+        "itemId": "proc_fronted_adverbial_fix:10442",
+        "marks": 2,
+        "promptText": "Rewrite the sentence with the punctuation corrected. On Friday morning Ruby found the map.",
+        "inputSpec": {
+          "type": "textarea",
+          "label": "Corrected sentence",
+          "placeholder": "Write the corrected sentence."
+        },
+        "solutionLines": [
+          "Spot the opening time, place or manner phrase.",
+          "Because the fronted adverbial comes first, place a comma after it.",
+          "A correct answer is: On Friday morning, Ruby found the map."
+        ]
+      },
+      "correctResponse": {
+        "answer": "On Friday morning, Ruby found the map."
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 2,
+        "maxScore": 2,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "A correct answer is: On Friday morning, Ruby found the map.",
+        "answerText": "On Friday morning, Ruby found the map.",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 2,
+        "misconception": "fronted_adverbial_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "A correct answer is: On Friday morning, Ruby found the map.",
+        "answerText": "On Friday morning, Ruby found the map.",
+        "minimalHint": "If the sentence opens with when, where or how information, check whether it needs a comma after it."
+      }
+    },
+    {
+      "id": "proc_semicolon_choice",
+      "label": "Choose a semi-colon",
+      "domain": "Punctuation for grammar",
+      "questionType": "choose",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": true,
+      "generative": true,
+      "tags": [
+        "identify"
+      ],
+      "skillIds": [
+        "boundary_punctuation"
+      ],
+      "sample": {
+        "templateId": "proc_semicolon_choice",
+        "templateLabel": "Choose a semi-colon",
+        "domain": "Punctuation for grammar",
+        "skillIds": [
+          "boundary_punctuation"
+        ],
+        "questionType": "choose",
+        "seed": 10459,
+        "itemId": "proc_semicolon_choice:10459",
+        "marks": 1,
+        "promptText": "Which punctuation mark best completes the sentence below? The rain stopped ___ the playground began to fill.",
+        "inputSpec": {
+          "type": "single_choice",
+          "label": "Choose one",
+          "options": [
+            {
+              "value": ";",
+              "label": ";"
+            },
+            {
+              "value": ":",
+              "label": ":"
+            },
+            {
+              "value": ",",
+              "label": ","
+            },
+            {
+              "value": "?",
+              "label": "?"
+            }
+          ]
+        },
+        "solutionLines": [
+          "Both parts are complete clauses and closely linked in meaning.",
+          "A semi-colon can join closely related main clauses without a conjunction.",
+          "The best answer is: The rain stopped; the playground began to fill."
+        ]
+      },
+      "correctResponse": {
+        "answer": ";"
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 1,
+        "maxScore": 1,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "The best answer is: The rain stopped; the playground began to fill.",
+        "answerText": ";",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 1,
+        "misconception": "boundary_punctuation_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "The best answer is: The rain stopped; the playground began to fill.",
+        "answerText": ";",
+        "minimalHint": "Ask whether the first part is a complete clause and whether the second part explains it, adds a list, or stands as another clause."
+      }
+    },
+    {
+      "id": "proc_colon_list_fix",
+      "label": "Insert a colon for a list",
+      "domain": "Punctuation for grammar",
+      "questionType": "fix",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": false,
+      "generative": true,
+      "tags": [
+        "surgery"
+      ],
+      "skillIds": [
+        "boundary_punctuation"
+      ],
+      "sample": {
+        "templateId": "proc_colon_list_fix",
+        "templateLabel": "Insert a colon for a list",
+        "domain": "Punctuation for grammar",
+        "skillIds": [
+          "boundary_punctuation"
+        ],
+        "questionType": "fix",
+        "seed": 10476,
+        "itemId": "proc_colon_list_fix:10476",
+        "marks": 2,
+        "promptText": "Rewrite the sentence with a colon in the correct place. The museum displayed four objects a helmet, a shield, a sword, a coin.",
+        "inputSpec": {
+          "type": "textarea",
+          "label": "Corrected sentence",
+          "placeholder": "Write the corrected sentence."
+        },
+        "solutionLines": [
+          "Check that the words before the list make a complete clause.",
+          "A colon can introduce the list that follows.",
+          "A correct answer is: The museum displayed four objects: a helmet, a shield, a sword, a coin."
+        ]
+      },
+      "correctResponse": {
+        "answer": "The museum displayed four objects: a helmet, a shield, a sword, a coin."
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 2,
+        "maxScore": 2,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "A correct answer is: The museum displayed four objects: a helmet, a shield, a sword, a coin.",
+        "answerText": "The museum displayed four objects: a helmet, a shield, a sword, a coin.",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 2,
+        "misconception": "boundary_punctuation_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "A correct answer is: The museum displayed four objects: a helmet, a shield, a sword, a coin.",
+        "answerText": "The museum displayed four objects: a helmet, a shield, a sword, a coin.",
+        "minimalHint": "Ask whether the first part is a complete clause and whether the second part explains it, adds a list, or stands as another clause."
+      }
+    },
+    {
+      "id": "proc_dash_boundary_fix",
+      "label": "Insert a dash to mark a strong break",
+      "domain": "Punctuation for grammar",
+      "questionType": "fix",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": false,
+      "generative": true,
+      "tags": [
+        "surgery"
+      ],
+      "skillIds": [
+        "boundary_punctuation"
+      ],
+      "sample": {
+        "templateId": "proc_dash_boundary_fix",
+        "templateLabel": "Insert a dash to mark a strong break",
+        "domain": "Punctuation for grammar",
+        "skillIds": [
+          "boundary_punctuation"
+        ],
+        "questionType": "fix",
+        "seed": 10493,
+        "itemId": "proc_dash_boundary_fix:10493",
+        "marks": 2,
+        "promptText": "Rewrite the sentence with a dash in the correct place. There was only one answer turn back at once.",
+        "inputSpec": {
+          "type": "textarea",
+          "label": "Corrected sentence",
+          "placeholder": "Write the corrected sentence."
+        },
+        "solutionLines": [
+          "Both parts are strongly linked, and the second part explains or expands the first.",
+          "A dash can mark that strong break.",
+          "A correct answer is: There was only one answer – turn back at once."
+        ]
+      },
+      "correctResponse": {
+        "answer": "There was only one answer – turn back at once."
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 2,
+        "maxScore": 2,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "A correct answer is: There was only one answer – turn back at once.",
+        "answerText": "There was only one answer – turn back at once.",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 2,
+        "misconception": "boundary_punctuation_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "A correct answer is: There was only one answer – turn back at once.",
+        "answerText": "There was only one answer – turn back at once.",
+        "minimalHint": "Ask whether the first part is a complete clause and whether the second part explains it, adds a list, or stands as another clause."
+      }
+    },
+    {
+      "id": "proc_hyphen_ambiguity_choice",
+      "label": "Choose the clearer hyphenated sentence",
+      "domain": "Punctuation for grammar",
+      "questionType": "choose",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": true,
+      "generative": true,
+      "tags": [
+        "identify"
+      ],
+      "skillIds": [
+        "hyphen_ambiguity"
+      ],
+      "sample": {
+        "templateId": "proc_hyphen_ambiguity_choice",
+        "templateLabel": "Choose the clearer hyphenated sentence",
+        "domain": "Punctuation for grammar",
+        "skillIds": [
+          "hyphen_ambiguity"
+        ],
+        "questionType": "choose",
+        "seed": 10510,
+        "itemId": "proc_hyphen_ambiguity_choice:10510",
+        "marks": 1,
+        "promptText": "Which sentence means the shark eats people?",
+        "inputSpec": {
+          "type": "single_choice",
+          "label": "Choose one",
+          "options": [
+            {
+              "value": "We saw a man-eating shark near the rocks.",
+              "label": "We saw a man-eating shark near the rocks."
+            },
+            {
+              "value": "We saw a man eating shark near the rocks.",
+              "label": "We saw a man eating shark near the rocks."
+            },
+            {
+              "value": "We saw a hungry shark near the rocks.",
+              "label": "We saw a hungry shark near the rocks."
+            },
+            {
+              "value": "We saw a shark near a man on the rocks.",
+              "label": "We saw a shark near a man on the rocks."
+            }
+          ]
+        },
+        "solutionLines": [
+          "Read both versions carefully and compare the meaning.",
+          "The hyphen shows that two words are working together as one describing idea.",
+          "The hyphen makes 'man-eating' work as one describing idea."
+        ]
+      },
+      "correctResponse": {
+        "answer": "We saw a man-eating shark near the rocks."
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 1,
+        "maxScore": 1,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "The clearer answer is: We saw a man-eating shark near the rocks.",
+        "answerText": "We saw a man-eating shark near the rocks.",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 1,
+        "misconception": "hyphen_ambiguity_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "The clearer answer is: We saw a man-eating shark near the rocks.",
+        "answerText": "We saw a man-eating shark near the rocks.",
+        "minimalHint": "Say the phrase both ways in your head. Which version makes the meaning clear?"
+      }
+    },
+    {
+      "id": "proc_speech_punctuation_fix",
+      "label": "Fix speech punctuation",
+      "domain": "Punctuation for grammar",
+      "questionType": "fix",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": false,
+      "generative": true,
+      "tags": [
+        "surgery"
+      ],
+      "skillIds": [
+        "speech_punctuation"
+      ],
+      "sample": {
+        "templateId": "proc_speech_punctuation_fix",
+        "templateLabel": "Fix speech punctuation",
+        "domain": "Punctuation for grammar",
+        "skillIds": [
+          "speech_punctuation"
+        ],
+        "questionType": "fix",
+        "seed": 10527,
+        "itemId": "proc_speech_punctuation_fix:10527",
+        "marks": 2,
+        "promptText": "Punctuate the direct speech correctly. \"When does the match begin\" said Dad.",
+        "inputSpec": {
+          "type": "textarea",
+          "label": "Correctly punctuated sentence",
+          "placeholder": "Type the corrected sentence."
+        },
+        "solutionLines": [
+          "The spoken words are a question.",
+          "The question mark belongs inside the speech marks.",
+          "A correct answer is: \"When does the match begin?\" said Dad."
+        ]
+      },
+      "correctResponse": {
+        "answer": "\"When does the match begin?\" said Dad."
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 2,
+        "maxScore": 2,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "A correct answer is: \"When does the match begin?\" said Dad.",
+        "answerText": "\"When does the match begin?\" said Dad.",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 2,
+        "misconception": "speech_punctuation_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "A correct answer is: \"When does the match begin?\" said Dad.",
+        "answerText": "\"When does the match begin?\" said Dad.",
+        "minimalHint": "Check where the spoken words end and where the reporting clause begins."
+      }
+    },
+    {
+      "id": "proc_apostrophe_possession_choice",
+      "label": "Choose the correct possessive apostrophe",
+      "domain": "Punctuation for grammar",
+      "questionType": "choose",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": true,
+      "generative": true,
+      "tags": [
+        "identify"
+      ],
+      "skillIds": [
+        "apostrophes_possession"
+      ],
+      "sample": {
+        "templateId": "proc_apostrophe_possession_choice",
+        "templateLabel": "Choose the correct possessive apostrophe",
+        "domain": "Punctuation for grammar",
+        "skillIds": [
+          "apostrophes_possession"
+        ],
+        "questionType": "choose",
+        "seed": 10544,
+        "itemId": "proc_apostrophe_possession_choice:10544",
+        "marks": 1,
+        "promptText": "Choose the correct phrase for people and their bikes.",
+        "inputSpec": {
+          "type": "single_choice",
+          "label": "Choose one",
+          "options": [
+            {
+              "value": "the peoples bikes",
+              "label": "the peoples bikes"
+            },
+            {
+              "value": "the people's bikes",
+              "label": "the people's bikes"
+            },
+            {
+              "value": "the people' bikes",
+              "label": "the people' bikes"
+            },
+            {
+              "value": "the people bikes",
+              "label": "the people bikes"
+            }
+          ]
+        },
+        "solutionLines": [
+          "Ask who owns the noun.",
+          "Then decide whether the owner is singular, a regular plural ending in s, or an irregular plural.",
+          "The correct answer is: the people's bikes"
+        ]
+      },
+      "correctResponse": {
+        "answer": "the people's bikes"
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 1,
+        "maxScore": 1,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "The correct answer is: the people's bikes",
+        "answerText": "the people's bikes",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 1,
+        "misconception": "apostrophe_possession_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "The correct answer is: the people's bikes",
+        "answerText": "the people's bikes",
+        "minimalHint": "Ask who owns the noun, and whether the owner is singular or plural."
+      }
+    },
+    {
+      "id": "proc2_standard_english_choice",
+      "label": "Choose Standard English",
+      "domain": "Standard English",
+      "questionType": "choose",
+      "difficulty": 1,
+      "satsFriendly": true,
+      "isSelectedResponse": true,
+      "generative": true,
+      "tags": [],
+      "skillIds": [
+        "standard_english"
+      ],
+      "sample": {
+        "templateId": "proc2_standard_english_choice",
+        "templateLabel": "Choose Standard English",
+        "domain": "Standard English",
+        "skillIds": [
+          "standard_english"
+        ],
+        "questionType": "choose",
+        "seed": 10561,
+        "itemId": "proc2_standard_english_choice:10561",
+        "marks": 1,
+        "promptText": "Which sentence is written in Standard English?",
+        "inputSpec": {
+          "type": "single_choice",
+          "label": "Choose one",
+          "options": [
+            {
+              "value": "I done my homework before tea.",
+              "label": "I done my homework before tea."
+            },
+            {
+              "value": "I have did my homework before tea.",
+              "label": "I have did my homework before tea."
+            },
+            {
+              "value": "I did my homework before tea.",
+              "label": "I did my homework before tea."
+            },
+            {
+              "value": "I do my homework before tea.",
+              "label": "I do my homework before tea."
+            }
+          ]
+        },
+        "solutionLines": [
+          "Focus on the verb form that would fit formal written English.",
+          "Standard English uses 'did' here.",
+          "The correct answer is: I did my homework before tea."
+        ]
+      },
+      "correctResponse": {
+        "answer": "I did my homework before tea."
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 1,
+        "maxScore": 1,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "The correct answer is: I did my homework before tea.",
+        "answerText": "I did my homework before tea.",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 1,
+        "misconception": "standard_english_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "The correct answer is: I did my homework before tea.",
+        "answerText": "I did my homework before tea.",
+        "minimalHint": "Choose the form you would expect in formal writing, not the spoken form you might hear."
+      }
+    },
+    {
+      "id": "proc2_standard_english_fix",
+      "label": "Rewrite in Standard English",
+      "domain": "Standard English",
+      "questionType": "fix",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": false,
+      "generative": true,
+      "tags": [
+        "surgery"
+      ],
+      "skillIds": [
+        "standard_english"
+      ],
+      "sample": {
+        "templateId": "proc2_standard_english_fix",
+        "templateLabel": "Rewrite in Standard English",
+        "domain": "Standard English",
+        "skillIds": [
+          "standard_english"
+        ],
+        "questionType": "fix",
+        "seed": 10578,
+        "itemId": "proc2_standard_english_fix:10578",
+        "marks": 2,
+        "promptText": "Rewrite the sentence in Standard English. Amira seen the comet after school.",
+        "inputSpec": {
+          "type": "textarea",
+          "label": "Corrected sentence",
+          "placeholder": "Write the corrected sentence."
+        },
+        "solutionLines": [
+          "Find the non-standard spoken form.",
+          "Replace it with the Standard English verb form.",
+          "A correct answer is: Amira saw the comet after school."
+        ]
+      },
+      "correctResponse": {
+        "answer": "Amira saw the comet after school."
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 2,
+        "maxScore": 2,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "A correct answer is: Amira saw the comet after school.",
+        "answerText": "Amira saw the comet after school.",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 2,
+        "misconception": "standard_english_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "A correct answer is: Amira saw the comet after school.",
+        "answerText": "Amira saw the comet after school.",
+        "minimalHint": "Choose the form you would expect in formal writing, not the spoken form you might hear."
+      }
+    },
+    {
+      "id": "proc2_tense_aspect_choice",
+      "label": "Choose the correct tense or aspect",
+      "domain": "Verb forms",
+      "questionType": "fill",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": true,
+      "generative": true,
+      "tags": [],
+      "skillIds": [
+        "tense_aspect"
+      ],
+      "sample": {
+        "templateId": "proc2_tense_aspect_choice",
+        "templateLabel": "Choose the correct tense or aspect",
+        "domain": "Verb forms",
+        "skillIds": [
+          "tense_aspect"
+        ],
+        "questionType": "fill",
+        "seed": 10595,
+        "itemId": "proc2_tense_aspect_choice:10595",
+        "marks": 1,
+        "promptText": "Choose the verb form that best completes the sentence: By the time the bell rang, The pupils ___ the project.",
+        "inputSpec": {
+          "type": "single_choice",
+          "label": "Choose one",
+          "options": [
+            {
+              "value": "packed",
+              "label": "packed"
+            },
+            {
+              "value": "are packing",
+              "label": "are packing"
+            },
+            {
+              "value": "have packed",
+              "label": "have packed"
+            },
+            {
+              "value": "had packed",
+              "label": "had packed"
+            }
+          ]
+        },
+        "solutionLines": [
+          "Look for the time signal in the sentence.",
+          "The past perfect shows an earlier past action before another past event.",
+          "The correct answer is: had packed"
+        ]
+      },
+      "correctResponse": {
+        "answer": "had packed"
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 1,
+        "maxScore": 1,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "By the time the bell rang, The pupils had packed the project.",
+        "answerText": "had packed",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 1,
+        "misconception": "tense_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "By the time the bell rang, The pupils had packed the project.",
+        "answerText": "had packed",
+        "minimalHint": "Check when the action happened and whether the sentence needs a simple, progressive, perfect, or past perfect form."
+      }
+    },
+    {
+      "id": "proc2_modal_choice",
+      "label": "Choose the modal verb",
+      "domain": "Verb forms",
+      "questionType": "fill",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": true,
+      "generative": true,
+      "tags": [],
+      "skillIds": [
+        "modal_verbs"
+      ],
+      "sample": {
+        "templateId": "proc2_modal_choice",
+        "templateLabel": "Choose the modal verb",
+        "domain": "Verb forms",
+        "skillIds": [
+          "modal_verbs"
+        ],
+        "questionType": "fill",
+        "seed": 10612,
+        "itemId": "proc2_modal_choice:10612",
+        "marks": 1,
+        "promptText": "Choose the modal verb that best fits the meaning: This is a rule on the climbing wall. You ___ wear a helmet.",
+        "inputSpec": {
+          "type": "single_choice",
+          "label": "Choose one",
+          "options": [
+            {
+              "value": "could",
+              "label": "could"
+            },
+            {
+              "value": "might",
+              "label": "might"
+            },
+            {
+              "value": "should",
+              "label": "should"
+            },
+            {
+              "value": "must",
+              "label": "must"
+            }
+          ]
+        },
+        "solutionLines": [
+          "Match the modal verb to the meaning: advice, possibility, certainty or obligation.",
+          "'Must' shows strongest obligation.",
+          "The correct answer is: must"
+        ]
+      },
+      "correctResponse": {
+        "answer": "must"
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 1,
+        "maxScore": 1,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "The correct answer is: must. ‘Must’ shows strongest obligation.",
+        "answerText": "must",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 1,
+        "misconception": "modal_verb_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "The correct answer is: must. ‘Must’ shows strongest obligation.",
+        "answerText": "must",
+        "minimalHint": "Compare how certain each modal verb sounds."
+      }
+    },
+    {
+      "id": "proc2_formality_choice",
+      "label": "Choose the more formal sentence",
+      "domain": "Register",
+      "questionType": "choose",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": true,
+      "generative": true,
+      "tags": [],
+      "skillIds": [
+        "formality"
+      ],
+      "sample": {
+        "templateId": "proc2_formality_choice",
+        "templateLabel": "Choose the more formal sentence",
+        "domain": "Register",
+        "skillIds": [
+          "formality"
+        ],
+        "questionType": "choose",
+        "seed": 10629,
+        "itemId": "proc2_formality_choice:10629",
+        "marks": 1,
+        "promptText": "Choose the sentence that best fits a formal report.",
+        "inputSpec": {
+          "type": "single_choice",
+          "label": "Choose one",
+          "options": [
+            {
+              "value": "Several pupils were absent from the visit.",
+              "label": "Several pupils were absent from the visit."
+            },
+            {
+              "value": "A few pupils were off for the visit.",
+              "label": "A few pupils were off for the visit."
+            },
+            {
+              "value": "Some pupils didn't come on the trip.",
+              "label": "Some pupils didn't come on the trip."
+            },
+            {
+              "value": "Quite a few pupils were missing from it.",
+              "label": "Quite a few pupils were missing from it."
+            }
+          ]
+        },
+        "solutionLines": [
+          "Formal writing avoids chatty wording and uses more precise vocabulary.",
+          "Formal writing often chooses more precise vocabulary and sentence structure.",
+          "The correct answer is: Several pupils were absent from the visit."
+        ]
+      },
+      "correctResponse": {
+        "answer": "Several pupils were absent from the visit."
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 1,
+        "maxScore": 1,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "The correct answer is: Several pupils were absent from the visit.",
+        "answerText": "Several pupils were absent from the visit.",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 1,
+        "misconception": "formality_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "The correct answer is: Several pupils were absent from the visit.",
+        "answerText": "Several pupils were absent from the visit.",
+        "minimalHint": "Match the language to a formal setting, not everyday chat."
+      }
+    },
+    {
+      "id": "proc2_pronoun_cohesion_choice",
+      "label": "Choose the clearer cohesive version",
+      "domain": "Cohesion",
+      "questionType": "choose",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": true,
+      "generative": true,
+      "tags": [],
+      "skillIds": [
+        "pronouns_cohesion"
+      ],
+      "sample": {
+        "templateId": "proc2_pronoun_cohesion_choice",
+        "templateLabel": "Choose the clearer cohesive version",
+        "domain": "Cohesion",
+        "skillIds": [
+          "pronouns_cohesion"
+        ],
+        "questionType": "choose",
+        "seed": 10646,
+        "itemId": "proc2_pronoun_cohesion_choice:10646",
+        "marks": 1,
+        "promptText": "Which version keeps the meaning clearest?",
+        "inputSpec": {
+          "type": "single_choice",
+          "label": "Choose one",
+          "options": [
+            {
+              "value": "Ben gave Amira the glove because Amira needed it for the next lesson.",
+              "label": "Ben gave Amira the glove because Amira needed it for the next lesson."
+            },
+            {
+              "value": "Ben gave Amira the glove because she needed it for the next lesson.",
+              "label": "Ben gave Amira the glove because she needed it for the next lesson."
+            },
+            {
+              "value": "Ben gave Amira it because Amira needed it for the next lesson.",
+              "label": "Ben gave Amira it because Amira needed it for the next lesson."
+            },
+            {
+              "value": "Ben gave the glove to her because Amira needed it for the next lesson.",
+              "label": "Ben gave the glove to her because Amira needed it for the next lesson."
+            }
+          ]
+        },
+        "solutionLines": [
+          "A pronoun should help the sentence flow without making the meaning unclear.",
+          "Good cohesion avoids unnecessary repetition without making the referent unclear.",
+          "The clearest answer is: Ben gave Amira the glove because Amira needed it for the next lesson."
+        ]
+      },
+      "correctResponse": {
+        "answer": "Ben gave Amira the glove because Amira needed it for the next lesson."
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 1,
+        "maxScore": 1,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "The clearest answer is: Ben gave Amira the glove because Amira needed it for the next lesson.",
+        "answerText": "Ben gave Amira the glove because Amira needed it for the next lesson.",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 1,
+        "misconception": "pronoun_cohesion_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "The clearest answer is: Ben gave Amira the glove because Amira needed it for the next lesson.",
+        "answerText": "Ben gave Amira the glove because Amira needed it for the next lesson.",
+        "minimalHint": "A pronoun should make the sentence smoother without making the meaning unclear."
+      }
+    },
+    {
+      "id": "proc2_subject_object_identify",
+      "label": "Identify subject or object",
+      "domain": "Sentence structure",
+      "questionType": "identify",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": true,
+      "generative": true,
+      "tags": [],
+      "skillIds": [
+        "subject_object"
+      ],
+      "sample": {
+        "templateId": "proc2_subject_object_identify",
+        "templateLabel": "Identify subject or object",
+        "domain": "Sentence structure",
+        "skillIds": [
+          "subject_object"
+        ],
+        "questionType": "identify",
+        "seed": 10663,
+        "itemId": "proc2_subject_object_identify:10663",
+        "marks": 1,
+        "promptText": "Which words are the object in this sentence? Before sunrise, Ava washed the trophy before the lesson.",
+        "inputSpec": {
+          "type": "single_choice",
+          "label": "Choose one",
+          "options": [
+            {
+              "value": "Ava",
+              "label": "Ava"
+            },
+            {
+              "value": "the trophy",
+              "label": "the trophy"
+            },
+            {
+              "value": "before the lesson",
+              "label": "before the lesson"
+            },
+            {
+              "value": "Before sunrise",
+              "label": "Before sunrise"
+            }
+          ]
+        },
+        "solutionLines": [
+          "Ask who or what is doing the action. Then ask who or what receives it.",
+          "The object receives the action. The subject does the action.",
+          "The correct answer is: the trophy"
+        ]
+      },
+      "correctResponse": {
+        "answer": "the trophy"
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 1,
+        "maxScore": 1,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "The correct answer is: the trophy",
+        "answerText": "the trophy",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 1,
+        "misconception": "subject_object_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "The correct answer is: the trophy",
+        "answerText": "the trophy",
+        "minimalHint": "The subject does the action; the object receives it."
+      }
+    },
+    {
+      "id": "proc2_passive_to_active",
+      "label": "Rewrite passive as active",
+      "domain": "Sentence structure",
+      "questionType": "rewrite",
+      "difficulty": 3,
+      "satsFriendly": true,
+      "isSelectedResponse": false,
+      "generative": true,
+      "tags": [
+        "builder"
+      ],
+      "skillIds": [
+        "active_passive"
+      ],
+      "sample": {
+        "templateId": "proc2_passive_to_active",
+        "templateLabel": "Rewrite passive as active",
+        "domain": "Sentence structure",
+        "skillIds": [
+          "active_passive"
+        ],
+        "questionType": "rewrite",
+        "seed": 10680,
+        "itemId": "proc2_passive_to_active:10680",
+        "marks": 2,
+        "promptText": "Rewrite the sentence in the active voice. The sketchbook is carried by Sam before lunch.",
+        "inputSpec": {
+          "type": "textarea",
+          "label": "Rewritten sentence",
+          "placeholder": "Write the full sentence."
+        },
+        "solutionLines": [
+          "Find the doer after 'by' in the passive sentence.",
+          "Move that doer into the subject position and keep the tense steady.",
+          "A correct answer is: Sam carries the sketchbook before lunch."
+        ]
+      },
+      "correctResponse": {
+        "answer": "Sam carries the sketchbook before lunch."
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 2,
+        "maxScore": 2,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "A correct answer is: Sam carries the sketchbook before lunch.",
+        "answerText": "Sam carries the sketchbook before lunch.",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 2,
+        "misconception": "active_passive_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "A correct answer is: Sam carries the sketchbook before lunch.",
+        "answerText": "Sam carries the sketchbook before lunch.",
+        "minimalHint": "In active voice, the doer comes first. In passive voice, the thing affected comes first."
+      }
+    },
+    {
+      "id": "proc2_relative_clause_choice",
+      "label": "Choose the sentence with a relative clause",
+      "domain": "Clauses",
+      "questionType": "identify",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": true,
+      "generative": true,
+      "tags": [],
+      "skillIds": [
+        "relative_clauses"
+      ],
+      "sample": {
+        "templateId": "proc2_relative_clause_choice",
+        "templateLabel": "Choose the sentence with a relative clause",
+        "domain": "Clauses",
+        "skillIds": [
+          "relative_clauses"
+        ],
+        "questionType": "identify",
+        "seed": 10697,
+        "itemId": "proc2_relative_clause_choice:10697",
+        "marks": 1,
+        "promptText": "Which sentence contains a relative clause?",
+        "inputSpec": {
+          "type": "single_choice",
+          "label": "Choose one",
+          "options": [
+            {
+              "value": "When everyone wanted the coat, it was easy to spot.",
+              "label": "When everyone wanted the coat, it was easy to spot."
+            },
+            {
+              "value": "The coat that everyone wanted was easy to spot.",
+              "label": "The coat that everyone wanted was easy to spot."
+            },
+            {
+              "value": "The club coat was easy to spot.",
+              "label": "The club coat was easy to spot."
+            },
+            {
+              "value": "The coat was easy to spot outside.",
+              "label": "The coat was easy to spot outside."
+            }
+          ]
+        },
+        "solutionLines": [
+          "A relative clause adds information about a noun.",
+          "A relative clause gives extra information about the noun using words such as 'that' or 'which'.",
+          "The correct answer is: The coat that everyone wanted was easy to spot."
+        ]
+      },
+      "correctResponse": {
+        "answer": "The coat that everyone wanted was easy to spot."
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 1,
+        "maxScore": 1,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "The correct answer is: The coat that everyone wanted was easy to spot.",
+        "answerText": "The coat that everyone wanted was easy to spot.",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 1,
+        "misconception": "relative_clause_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "The correct answer is: The coat that everyone wanted was easy to spot.",
+        "answerText": "The coat that everyone wanted was easy to spot.",
+        "minimalHint": "A relative clause adds extra information about a noun. Find the noun it is attached to."
+      }
+    },
+    {
+      "id": "proc2_fronted_adverbial_build",
+      "label": "Build a sentence with a fronted adverbial",
+      "domain": "Adverbials",
+      "questionType": "build",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": false,
+      "generative": true,
+      "tags": [
+        "builder"
+      ],
+      "skillIds": [
+        "adverbials"
+      ],
+      "sample": {
+        "templateId": "proc2_fronted_adverbial_build",
+        "templateLabel": "Build a sentence with a fronted adverbial",
+        "domain": "Adverbials",
+        "skillIds": [
+          "adverbials"
+        ],
+        "questionType": "build",
+        "seed": 10714,
+        "itemId": "proc2_fronted_adverbial_build:10714",
+        "marks": 2,
+        "promptText": "Use this opening phrase and clause to build one correct sentence. Opening phrase: At the edge of the field Main clause: Noah locked the window",
+        "inputSpec": {
+          "type": "textarea",
+          "label": "Your sentence",
+          "placeholder": "Write one complete sentence."
+        },
+        "solutionLines": [
+          "Put the fronted adverbial first.",
+          "Add a comma after it before the main clause begins.",
+          "A correct answer is: At the edge of the field, Noah locked the window."
+        ]
+      },
+      "correctResponse": {
+        "answer": "At the edge of the field, Noah locked the window."
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 2,
+        "maxScore": 2,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "A correct answer is: At the edge of the field, Noah locked the window.",
+        "answerText": "At the edge of the field, Noah locked the window.",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 2,
+        "misconception": "fronted_adverbial_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "A correct answer is: At the edge of the field, Noah locked the window.",
+        "answerText": "At the edge of the field, Noah locked the window.",
+        "minimalHint": "If the sentence opens with when, where or how information, check whether it needs a comma after it."
+      }
+    },
+    {
+      "id": "proc2_boundary_punctuation_explain",
+      "label": "Explain boundary punctuation",
+      "domain": "Punctuation for grammar",
+      "questionType": "explain",
+      "difficulty": 3,
+      "satsFriendly": true,
+      "isSelectedResponse": true,
+      "generative": true,
+      "tags": [],
+      "skillIds": [
+        "boundary_punctuation"
+      ],
+      "sample": {
+        "templateId": "proc2_boundary_punctuation_explain",
+        "templateLabel": "Explain boundary punctuation",
+        "domain": "Punctuation for grammar",
+        "skillIds": [
+          "boundary_punctuation"
+        ],
+        "questionType": "explain",
+        "seed": 10731,
+        "itemId": "proc2_boundary_punctuation_explain:10731",
+        "marks": 1,
+        "promptText": "Why is the punctuation in this sentence effective? The bus arrived; everyone grabbed their bags.",
+        "inputSpec": {
+          "type": "single_choice",
+          "label": "Choose one",
+          "options": [
+            {
+              "value": "A semi-colon can join two closely related main clauses.",
+              "label": "A semi-colon can join two closely related main clauses."
+            },
+            {
+              "value": "A semi-colon introduces direct speech.",
+              "label": "A semi-colon introduces direct speech."
+            },
+            {
+              "value": "A semi-colon shows possession.",
+              "label": "A semi-colon shows possession."
+            },
+            {
+              "value": "A semi-colon marks a fronted adverbial.",
+              "label": "A semi-colon marks a fronted adverbial."
+            }
+          ]
+        },
+        "solutionLines": [
+          "Look at the relationship between the parts of the sentence.",
+          "Both sides of the semi-colon are complete clauses.",
+          "The best explanation is: A semi-colon can join two closely related main clauses."
+        ]
+      },
+      "correctResponse": {
+        "answer": "A semi-colon can join two closely related main clauses."
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 1,
+        "maxScore": 1,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "The best explanation is: A semi-colon can join two closely related main clauses.",
+        "answerText": "A semi-colon can join two closely related main clauses.",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 1,
+        "misconception": "boundary_punctuation_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "The best explanation is: A semi-colon can join two closely related main clauses.",
+        "answerText": "A semi-colon can join two closely related main clauses.",
+        "minimalHint": "Ask whether the first part is a complete clause and whether the second part explains it, adds a list, or stands as another clause."
+      }
+    },
+    {
+      "id": "proc3_sentence_function_choice",
+      "label": "Choose the sentence function",
+      "domain": "Sentence function",
+      "questionType": "choose",
+      "difficulty": 1,
+      "satsFriendly": true,
+      "isSelectedResponse": true,
+      "generative": true,
+      "tags": [
+        "identify"
+      ],
+      "skillIds": [
+        "sentence_functions"
+      ],
+      "sample": {
+        "templateId": "proc3_sentence_function_choice",
+        "templateLabel": "Choose the sentence function",
+        "domain": "Sentence function",
+        "skillIds": [
+          "sentence_functions"
+        ],
+        "questionType": "choose",
+        "seed": 10748,
+        "itemId": "proc3_sentence_function_choice:10748",
+        "marks": 1,
+        "promptText": "Which sentence is a statement?",
+        "inputSpec": {
+          "type": "single_choice",
+          "label": "Choose one",
+          "options": [
+            {
+              "value": "The path beside the stream was muddy.",
+              "label": "The path beside the stream was muddy."
+            },
+            {
+              "value": "Bring the blue folder to the hall.",
+              "label": "Bring the blue folder to the hall."
+            },
+            {
+              "value": "Who packed the blue folder?",
+              "label": "Who packed the blue folder?"
+            },
+            {
+              "value": "How bright the lantern looked!",
+              "label": "How bright the lantern looked!"
+            }
+          ]
+        },
+        "solutionLines": [
+          "Decide what the whole sentence is doing.",
+          "A statement gives information.",
+          "The correct sentence is: The path beside the stream was muddy."
+        ]
+      },
+      "correctResponse": {
+        "answer": "The path beside the stream was muddy."
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 1,
+        "maxScore": 1,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "The correct sentence is: The path beside the stream was muddy.",
+        "answerText": "The path beside the stream was muddy.",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 1,
+        "misconception": "sentence_function_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "The correct sentence is: The path beside the stream was muddy.",
+        "answerText": "The path beside the stream was muddy.",
+        "minimalHint": "Ask what the sentence is doing: telling, asking, ordering, or exclaiming."
+      }
+    },
+    {
+      "id": "proc3_word_class_contrast_choice",
+      "label": "Choose the correct word class",
+      "domain": "Word classes",
+      "questionType": "choose",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": true,
+      "generative": true,
+      "tags": [
+        "identify"
+      ],
+      "skillIds": [
+        "word_classes"
+      ],
+      "sample": {
+        "templateId": "proc3_word_class_contrast_choice",
+        "templateLabel": "Choose the correct word class",
+        "domain": "Word classes",
+        "skillIds": [
+          "word_classes"
+        ],
+        "questionType": "choose",
+        "seed": 10765,
+        "itemId": "proc3_word_class_contrast_choice:10765",
+        "marks": 1,
+        "promptText": "In the sentence Afterwards, Ben hurried inside., what is the word Afterwards?",
+        "inputSpec": {
+          "type": "single_choice",
+          "label": "Choose one",
+          "options": [
+            {
+              "value": "determiner",
+              "label": "determiner"
+            },
+            {
+              "value": "adverb",
+              "label": "adverb"
+            },
+            {
+              "value": "preposition",
+              "label": "preposition"
+            },
+            {
+              "value": "conjunction",
+              "label": "conjunction"
+            }
+          ]
+        },
+        "solutionLines": [
+          "Focus on the word's job in the sentence, not just its meaning on its own.",
+          "'Afterwards' tells us when Ben hurried, so it is an adverb.",
+          "The correct answer is: adverb."
+        ]
+      },
+      "correctResponse": {
+        "answer": "adverb"
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 1,
+        "maxScore": 1,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "‘Afterwards’ tells us when Ben hurried, so it is an adverb.",
+        "answerText": "adverb",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 1,
+        "misconception": "word_class_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "‘Afterwards’ tells us when Ben hurried, so it is an adverb.",
+        "answerText": "adverb",
+        "minimalHint": "Look at the word’s job in the sentence, not just what it seems to mean on its own."
+      }
+    },
+    {
+      "id": "proc3_noun_phrase_build",
+      "label": "Build an expanded noun phrase",
+      "domain": "Phrases",
+      "questionType": "build",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": false,
+      "generative": true,
+      "tags": [
+        "builder"
+      ],
+      "skillIds": [
+        "noun_phrases"
+      ],
+      "sample": {
+        "templateId": "proc3_noun_phrase_build",
+        "templateLabel": "Build an expanded noun phrase",
+        "domain": "Phrases",
+        "skillIds": [
+          "noun_phrases"
+        ],
+        "questionType": "build",
+        "seed": 10782,
+        "itemId": "proc3_noun_phrase_build:10782",
+        "marks": 2,
+        "promptText": "Use all the words to build an expanded noun phrase that could complete the sentence. Words: the / tiny / striped / trophy ___ was still on the shelf.",
+        "inputSpec": {
+          "type": "text",
+          "label": "Expanded noun phrase",
+          "placeholder": "Type the noun phrase."
+        },
+        "solutionLines": [
+          "Start with the determiner, then add the describing words, then finish with the noun.",
+          "A clear expanded noun phrase is: the tiny striped trophy.",
+          "The whole phrase centres on the noun at the end."
+        ]
+      },
+      "correctResponse": {
+        "answer": "the tiny striped trophy"
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 2,
+        "maxScore": 2,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "A correct expanded noun phrase is: the tiny striped trophy.",
+        "answerText": "the tiny striped trophy",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 2,
+        "misconception": "noun_phrase_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "A correct expanded noun phrase is: the tiny striped trophy.",
+        "answerText": "the tiny striped trophy",
+        "minimalHint": "A noun phrase must centre on a noun. Check which words belong with that noun."
+      }
+    },
+    {
+      "id": "proc3_clause_join_rewrite",
+      "label": "Join clauses with a conjunction",
+      "domain": "Clauses",
+      "questionType": "rewrite",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": false,
+      "generative": true,
+      "tags": [
+        "builder"
+      ],
+      "skillIds": [
+        "clauses"
+      ],
+      "sample": {
+        "templateId": "proc3_clause_join_rewrite",
+        "templateLabel": "Join clauses with a conjunction",
+        "domain": "Clauses",
+        "skillIds": [
+          "clauses"
+        ],
+        "questionType": "rewrite",
+        "seed": 10799,
+        "itemId": "proc3_clause_join_rewrite:10799",
+        "marks": 2,
+        "promptText": "Combine these ideas into one sentence using because. Mia smiled. She had found the missing map.",
+        "inputSpec": {
+          "type": "textarea",
+          "label": "Combined sentence",
+          "placeholder": "Write one combined sentence."
+        },
+        "solutionLines": [
+          "Use the conjunction to join the ideas so the relationship is clear.",
+          "Mia smiled because she had found the missing map.",
+          "Check that the sentence is complete and punctuated as one whole sentence."
+        ]
+      },
+      "correctResponse": {
+        "answer": "Mia smiled because she had found the missing map."
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 2,
+        "maxScore": 2,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "A correct answer is: Mia smiled because she had found the missing map.",
+        "answerText": "Mia smiled because she had found the missing map.",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 2,
+        "misconception": "subordinate_clause_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "A correct answer is: Mia smiled because she had found the missing map.",
+        "answerText": "Mia smiled because she had found the missing map.",
+        "minimalHint": "A subordinate clause usually depends on the main clause. Ask whether it can stand alone here."
+      }
+    },
+    {
+      "id": "proc3_parenthesis_commas_fix",
+      "label": "Add commas for parenthesis",
+      "domain": "Punctuation for grammar",
+      "questionType": "fix",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": false,
+      "generative": true,
+      "tags": [
+        "surgery"
+      ],
+      "skillIds": [
+        "parenthesis_commas"
+      ],
+      "sample": {
+        "templateId": "proc3_parenthesis_commas_fix",
+        "templateLabel": "Add commas for parenthesis",
+        "domain": "Punctuation for grammar",
+        "skillIds": [
+          "parenthesis_commas"
+        ],
+        "questionType": "fix",
+        "seed": 10816,
+        "itemId": "proc3_parenthesis_commas_fix:10816",
+        "marks": 2,
+        "promptText": "Add commas to show the parenthesis. Ben after a short pause opened the gate.",
+        "inputSpec": {
+          "type": "textarea",
+          "label": "Corrected sentence",
+          "placeholder": "Type the corrected sentence."
+        },
+        "solutionLines": [
+          "Find the extra information that could be lifted out.",
+          "The extra phrase 'after a short pause' is parenthesis, so commas mark it off.",
+          "A correct answer is: Ben, after a short pause, opened the gate."
+        ]
+      },
+      "correctResponse": {
+        "answer": "Ben, after a short pause, opened the gate."
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 2,
+        "maxScore": 2,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "A correct answer is: Ben, after a short pause, opened the gate.",
+        "answerText": "Ben, after a short pause, opened the gate.",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 2,
+        "misconception": "parenthesis_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "A correct answer is: Ben, after a short pause, opened the gate.",
+        "answerText": "Ben, after a short pause, opened the gate.",
+        "minimalHint": "Parenthesis adds extra information that could be lifted out."
+      }
+    },
+    {
+      "id": "proc3_hyphen_fix_meaning",
+      "label": "Use a hyphen to make the meaning clear",
+      "domain": "Punctuation for grammar",
+      "questionType": "fix",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": false,
+      "generative": true,
+      "tags": [
+        "surgery"
+      ],
+      "skillIds": [
+        "hyphen_ambiguity"
+      ],
+      "sample": {
+        "templateId": "proc3_hyphen_fix_meaning",
+        "templateLabel": "Use a hyphen to make the meaning clear",
+        "domain": "Punctuation for grammar",
+        "skillIds": [
+          "hyphen_ambiguity"
+        ],
+        "questionType": "fix",
+        "seed": 10833,
+        "itemId": "proc3_hyphen_fix_meaning:10833",
+        "marks": 2,
+        "promptText": "Rewrite the sentence with a hyphen to make the meaning clear. We saw a man eating shark near the rocks.",
+        "inputSpec": {
+          "type": "textarea",
+          "label": "Corrected sentence",
+          "placeholder": "Type the corrected sentence."
+        },
+        "solutionLines": [
+          "Find the words that work together as one describing idea before the noun.",
+          "The hyphen shows that the shark eats people.",
+          "A correct answer is: We saw a man-eating shark near the rocks."
+        ]
+      },
+      "correctResponse": {
+        "answer": "We saw a man-eating shark near the rocks."
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 2,
+        "maxScore": 2,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "A correct answer is: We saw a man-eating shark near the rocks.",
+        "answerText": "We saw a man-eating shark near the rocks.",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 2,
+        "misconception": "punctuation_precision",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "A correct answer is: We saw a man-eating shark near the rocks.",
+        "answerText": "We saw a man-eating shark near the rocks.",
+        "minimalHint": "The grammar idea is close. Check the exact punctuation and wording."
+      }
+    },
+    {
+      "id": "proc3_apostrophe_rewrite",
+      "label": "Rewrite with a possessive apostrophe",
+      "domain": "Punctuation for grammar",
+      "questionType": "rewrite",
+      "difficulty": 2,
+      "satsFriendly": true,
+      "isSelectedResponse": false,
+      "generative": true,
+      "tags": [
+        "builder"
+      ],
+      "skillIds": [
+        "apostrophes_possession"
+      ],
+      "sample": {
+        "templateId": "proc3_apostrophe_rewrite",
+        "templateLabel": "Rewrite with a possessive apostrophe",
+        "domain": "Punctuation for grammar",
+        "skillIds": [
+          "apostrophes_possession"
+        ],
+        "questionType": "rewrite",
+        "seed": 10850,
+        "itemId": "proc3_apostrophe_rewrite:10850",
+        "marks": 2,
+        "promptText": "Rewrite this phrase using the correct possessive apostrophe. the lunchboxes belonging to the people",
+        "inputSpec": {
+          "type": "text",
+          "label": "Rewritten phrase",
+          "placeholder": "Type the rewritten phrase."
+        },
+        "solutionLines": [
+          "Work out who owns the noun.",
+          "An irregular plural owner that does not end in s usually takes apostrophe + s.",
+          "A correct answer is: the people's lunchboxes"
+        ]
+      },
+      "correctResponse": {
+        "answer": "the people's lunchboxes"
+      },
+      "correctResult": {
+        "correct": true,
+        "score": 2,
+        "maxScore": 2,
+        "misconception": null,
+        "feedbackShort": "Correct.",
+        "feedbackLong": "A correct answer is: the people's lunchboxes",
+        "answerText": "the people's lunchboxes",
+        "minimalHint": "Check the sentence structure and the instruction again."
+      },
+      "emptyResult": {
+        "correct": false,
+        "score": 0,
+        "maxScore": 2,
+        "misconception": "apostrophe_possession_confusion",
+        "feedbackShort": "Not quite.",
+        "feedbackLong": "A correct answer is: the people's lunchboxes",
+        "answerText": "the people's lunchboxes",
+        "minimalHint": "Ask who owns the noun, and whether the owner is singular or plural."
+      }
+    }
+  ]
+}

--- a/tests/grammar-engine.test.js
+++ b/tests/grammar-engine.test.js
@@ -172,6 +172,27 @@ test('Grammar retry queue de-duplicates repeated misses for the same template an
   assert.equal(state.retryQueue[0].templateId, 'fronted_adverbial_choose');
 });
 
+test('Grammar attempt history stores bounded response fields only', () => {
+  const state = createInitialGrammarState();
+  const question = createGrammarQuestion({ templateId: 'fix_fronted_adverbial', seed: 1 });
+  const item = serialiseGrammarQuestion(question);
+
+  applyGrammarAttemptToState(state, {
+    learnerId: 'learner-a',
+    item,
+    response: {
+      answer: 'x'.repeat(120_000),
+      extra: 'y'.repeat(120_000),
+      nested: { value: 'not persisted' },
+    },
+    now: 1_777_000_000_000,
+  });
+
+  const persisted = state.recentAttempts[0].response;
+  assert.deepEqual(Object.keys(persisted), ['answer']);
+  assert.equal(persisted.answer.length, 2_000);
+});
+
 test('Grammar server engine creates a session, marks an answer, and records summary events', () => {
   const oracle = readGrammarLegacyOracle();
   const sample = oracle.templates.find((template) => template.id === 'question_mark_select');

--- a/tests/grammar-engine.test.js
+++ b/tests/grammar-engine.test.js
@@ -1,0 +1,218 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  applyGrammarAttemptToState,
+  buildGrammarMiniSet,
+  createInitialGrammarState,
+  createServerGrammarEngine,
+  grammarConceptStatus,
+} from '../worker/src/subjects/grammar/engine.js';
+import {
+  createGrammarQuestion,
+  evaluateGrammarQuestion,
+  GRAMMAR_CONCEPTS,
+  GRAMMAR_CONTENT_RELEASE_ID,
+  GRAMMAR_TEMPLATE_METADATA,
+  serialiseGrammarQuestion,
+} from '../worker/src/subjects/grammar/content.js';
+import { readGrammarLegacyOracle } from './helpers/grammar-legacy-oracle.js';
+
+test('Grammar legacy oracle fixture pins the reviewed content denominator', () => {
+  const oracle = readGrammarLegacyOracle();
+
+  assert.equal(oracle.contentReleaseId, GRAMMAR_CONTENT_RELEASE_ID);
+  assert.equal(oracle.conceptCount, 18);
+  assert.equal(oracle.templateCount, 51);
+  assert.equal(oracle.selectedResponseCount, 31);
+  assert.equal(oracle.constructedResponseCount, 20);
+  assert.equal(GRAMMAR_CONCEPTS.length, 18);
+  assert.equal(GRAMMAR_TEMPLATE_METADATA.length, 51);
+  assert.equal(GRAMMAR_TEMPLATE_METADATA.filter((template) => template.isSelectedResponse).length, 31);
+  assert.equal(GRAMMAR_TEMPLATE_METADATA.filter((template) => !template.isSelectedResponse).length, 20);
+});
+
+test('Grammar content generates serialisable questions matching oracle samples', () => {
+  const oracle = readGrammarLegacyOracle();
+  const conceptIds = new Set(GRAMMAR_CONCEPTS.map((concept) => concept.id));
+  const questionTypes = new Set(Object.keys(oracle.questionTypes));
+
+  for (const sample of oracle.templates) {
+    assert.ok(sample.skillIds.length > 0, sample.id);
+    assert.ok(sample.skillIds.every((conceptId) => conceptIds.has(conceptId)), sample.id);
+    assert.ok(questionTypes.has(sample.questionType), sample.id);
+
+    const question = createGrammarQuestion({
+      templateId: sample.id,
+      seed: sample.sample.seed,
+    });
+    const serialised = serialiseGrammarQuestion(question);
+    assert.equal(serialised.contentReleaseId, oracle.contentReleaseId, sample.id);
+    assert.equal(serialised.templateId, sample.id, sample.id);
+    assert.equal(serialised.itemId, sample.sample.itemId, sample.id);
+    assert.deepEqual(serialised.skillIds, sample.skillIds, sample.id);
+    assert.equal(serialised.promptText, sample.sample.promptText, sample.id);
+    assert.equal(typeof question.evaluate, 'function', sample.id);
+
+    const correct = evaluateGrammarQuestion(question, sample.correctResponse);
+    assert.deepEqual(correct, sample.correctResult, sample.id);
+    assert.doesNotThrow(() => evaluateGrammarQuestion(question, {}), sample.id);
+  }
+});
+
+test('Grammar mini-set generation covers mixed and focused pools without looping', () => {
+  const mixed = buildGrammarMiniSet({ size: 8, seed: 1234 });
+  assert.equal(mixed.length, 8);
+  assert.ok(mixed.every((item) => item.contentReleaseId === GRAMMAR_CONTENT_RELEASE_ID));
+
+  for (const concept of GRAMMAR_CONCEPTS) {
+    const focused = buildGrammarMiniSet({ size: 4, focusConceptId: concept.id, seed: 9001 });
+    assert.equal(focused.length, 4, concept.id);
+    assert.ok(focused.some((item) => item.skillIds.includes(concept.id)), concept.id);
+  }
+});
+
+test('Grammar mastery status blocks secured state when a strong concept is due', () => {
+  const now = 1_777_000_000_000;
+  assert.equal(grammarConceptStatus({
+    attempts: 8,
+    correct: 8,
+    wrong: 0,
+    strength: 0.9,
+    intervalDays: 10,
+    dueAt: now - 1,
+    correctStreak: 5,
+  }, now), 'due');
+});
+
+test('Grammar answer quality gives supported correctness less gain than independent first attempts', () => {
+  const templateId = 'fronted_adverbial_choose';
+  const seed = 100;
+  const question = createGrammarQuestion({ templateId, seed });
+  const item = serialiseGrammarQuestion(question);
+  const answer = { answer: question.inputSpec.options.find((option) => evaluateGrammarQuestion(question, { answer: option.value }).correct).value };
+
+  const independent = createInitialGrammarState();
+  applyGrammarAttemptToState(independent, {
+    learnerId: 'learner-a',
+    item,
+    response: answer,
+    supportLevel: 0,
+    attempts: 1,
+    now: 1_777_000_000_000,
+  });
+
+  const supported = createInitialGrammarState();
+  applyGrammarAttemptToState(supported, {
+    learnerId: 'learner-a',
+    item,
+    response: answer,
+    supportLevel: 1,
+    attempts: 1,
+    now: 1_777_000_000_000,
+  });
+
+  assert.ok(
+    independent.mastery.concepts.adverbials.strength > supported.mastery.concepts.adverbials.strength,
+  );
+});
+
+test('Grammar multi-skill templates update every concept node', () => {
+  const oracle = readGrammarLegacyOracle();
+  const sample = oracle.templates.find((template) => template.skillIds.length > 1);
+  const state = createInitialGrammarState();
+  const item = serialiseGrammarQuestion(createGrammarQuestion({
+    templateId: sample.id,
+    seed: sample.sample.seed,
+  }));
+
+  applyGrammarAttemptToState(state, {
+    learnerId: 'learner-a',
+    item,
+    response: sample.correctResponse,
+    supportLevel: 0,
+    attempts: 1,
+    now: 1_777_000_000_000,
+  });
+
+  for (const conceptId of sample.skillIds) {
+    assert.equal(state.mastery.concepts[conceptId].attempts, 1, conceptId);
+  }
+});
+
+test('Grammar engine rejects stale content release evidence', () => {
+  const question = createGrammarQuestion({ templateId: 'fronted_adverbial_choose', seed: 1 });
+  const item = {
+    ...serialiseGrammarQuestion(question),
+    contentReleaseId: 'old-release',
+  };
+
+  assert.throws(() => applyGrammarAttemptToState(createInitialGrammarState(), {
+    learnerId: 'learner-a',
+    item,
+    response: {},
+  }), (error) => error?.extra?.code === 'grammar_content_release_mismatch');
+});
+
+test('Grammar retry queue de-duplicates repeated misses for the same template and seed', () => {
+  const state = createInitialGrammarState();
+  const question = createGrammarQuestion({ templateId: 'fronted_adverbial_choose', seed: 1 });
+  const item = serialiseGrammarQuestion(question);
+
+  for (let count = 0; count < 2; count += 1) {
+    applyGrammarAttemptToState(state, {
+      learnerId: 'learner-a',
+      item,
+      response: { answer: 'not the answer' },
+      now: 1_777_000_000_000 + count,
+    });
+  }
+
+  assert.equal(state.retryQueue.length, 1);
+  assert.equal(state.retryQueue[0].templateId, 'fronted_adverbial_choose');
+});
+
+test('Grammar server engine creates a session, marks an answer, and records summary events', () => {
+  const oracle = readGrammarLegacyOracle();
+  const sample = oracle.templates.find((template) => template.id === 'question_mark_select');
+  const engine = createServerGrammarEngine({ now: () => 1_777_000_000_000 });
+
+  const start = engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: {},
+    command: 'start-session',
+    requestId: 'start-1',
+    payload: {
+      mode: 'smart',
+      roundLength: 1,
+      templateId: sample.id,
+      seed: sample.sample.seed,
+    },
+  });
+  assert.equal(start.state.phase, 'session');
+  assert.equal(start.practiceSession.status, 'active');
+
+  const submit = engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: { ui: start.state, data: start.data },
+    latestSession: start.practiceSession,
+    command: 'submit-answer',
+    requestId: 'submit-1',
+    payload: { response: sample.correctResponse },
+  });
+  assert.equal(submit.state.phase, 'feedback');
+  assert.equal(submit.state.feedback.result.correct, true);
+  assert.ok(submit.events.some((event) => event.type === 'grammar.answer-submitted'));
+
+  const done = engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: { ui: submit.state, data: submit.data },
+    latestSession: submit.practiceSession,
+    command: 'continue-session',
+    requestId: 'continue-1',
+    payload: {},
+  });
+  assert.equal(done.state.phase, 'summary');
+  assert.equal(done.practiceSession.status, 'completed');
+  assert.ok(done.events.some((event) => event.type === 'grammar.session-completed'));
+});

--- a/tests/helpers/grammar-legacy-oracle.js
+++ b/tests/helpers/grammar-legacy-oracle.js
@@ -1,0 +1,18 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const fixturePath = path.join(rootDir, 'tests/fixtures/grammar-legacy-oracle/legacy-baseline.json');
+
+export function readGrammarLegacyOracle() {
+  return JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
+}
+
+export function oracleTemplateById(templateId) {
+  return readGrammarLegacyOracle().templates.find((template) => template.id === templateId) || null;
+}
+
+export function oracleCorrectResponse(templateId) {
+  return oracleTemplateById(templateId)?.correctResponse || {};
+}

--- a/tests/worker-grammar-subject-runtime.test.js
+++ b/tests/worker-grammar-subject-runtime.test.js
@@ -1,0 +1,254 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createWorkerApp } from '../worker/src/app.js';
+import { createWorkerSubjectRuntime } from '../worker/src/subjects/runtime.js';
+import { readGrammarLegacyOracle } from './helpers/grammar-legacy-oracle.js';
+import { createMigratedSqliteD1Database } from './helpers/sqlite-d1.js';
+
+function seedAccountLearner(DB, { accountId = 'adult-a', learnerId = 'learner-a', revision = 0 } = {}) {
+  const now = Date.now();
+  DB.db.prepare(`
+    INSERT INTO learner_profiles (id, name, year_group, avatar_color, goal, daily_minutes, created_at, updated_at, state_revision)
+    VALUES (?, 'Learner A', 'Y5', '#3E6FA8', 'sats', 15, ?, ?, ?)
+  `).run(learnerId, now, now, revision);
+  DB.db.prepare(`
+    INSERT INTO adult_accounts (id, email, display_name, platform_role, selected_learner_id, created_at, updated_at, repo_revision)
+    VALUES (?, ?, 'Adult A', 'parent', ?, ?, ?, 0)
+  `).run(accountId, `${accountId}@example.test`, learnerId, now, now);
+  DB.db.prepare(`
+    INSERT INTO account_learner_memberships (account_id, learner_id, role, sort_index, created_at, updated_at)
+    VALUES (?, ?, 'owner', 0, ?, ?)
+  `).run(accountId, learnerId, now, now);
+}
+
+async function postCommand(app, DB, body, headers = {}) {
+  const response = await app.fetch(new Request('https://repo.test/api/subjects/grammar/command', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      origin: 'https://repo.test',
+      'x-ks2-dev-account-id': 'adult-a',
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  }), {
+    DB,
+    AUTH_MODE: 'development-stub',
+    ENVIRONMENT: 'test',
+  }, {});
+  return {
+    response,
+    body: await response.json(),
+  };
+}
+
+test('worker subject runtime registers Grammar command handlers', async () => {
+  const runtime = createWorkerSubjectRuntime({
+    grammar: { now: () => 1_777_000_000_000 },
+  });
+  let runtimeReads = 0;
+  const result = await runtime.dispatch({
+    subjectId: 'grammar',
+    command: 'start-session',
+    learnerId: 'learner-a',
+    requestId: 'grammar-start',
+    correlationId: 'grammar-start',
+    expectedLearnerRevision: 0,
+    payload: { mode: 'smart', roundLength: 1, templateId: 'fronted_adverbial_choose', seed: 10 },
+  }, {
+    session: { accountId: 'adult-a' },
+    now: 1_777_000_000_000,
+    repository: {
+      async readSubjectRuntime(accountId, learnerId, subjectId) {
+        runtimeReads += 1;
+        assert.equal(subjectId, 'grammar');
+        return { subjectRecord: { ui: null, data: {} }, latestSession: null };
+      },
+      async readLearnerProjectionState() {
+        return { gameState: {}, events: [] };
+      },
+    },
+  });
+
+  assert.equal(runtimeReads, 1);
+  assert.equal(result.subjectId, 'grammar');
+  assert.equal(result.command, 'start-session');
+  assert.equal(result.subjectReadModel.phase, 'session');
+  assert.equal(result.subjectReadModel.session.currentItem.templateId, 'fronted_adverbial_choose');
+  assert.equal(result.subjectReadModel.session.currentItem.evaluate, undefined);
+  assert.equal(result.subjectReadModel.session.currentItem.promptText.includes('<'), false);
+});
+
+test('Grammar command route persists subject state, practice session, and events', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const app = createWorkerApp({ now: () => 1_777_000_000_000 });
+  const sample = readGrammarLegacyOracle().templates.find((template) => template.id === 'question_mark_select');
+  seedAccountLearner(DB);
+
+  const start = await postCommand(app, DB, {
+    command: 'start-session',
+    learnerId: 'learner-a',
+    requestId: 'grammar-start-1',
+    expectedLearnerRevision: 0,
+    payload: {
+      mode: 'smart',
+      roundLength: 1,
+      templateId: sample.id,
+      seed: sample.sample.seed,
+    },
+  });
+  assert.equal(start.response.status, 200, JSON.stringify(start.body));
+  assert.equal(start.body.ok, true);
+  assert.equal(start.body.subjectId, 'grammar');
+  assert.equal(start.body.subjectReadModel.authority, 'worker');
+  assert.equal(start.body.subjectReadModel.content.conceptCount, 18);
+  assert.equal(start.body.subjectReadModel.content.templateCount, 51);
+  assert.equal(start.body.mutation.kind, 'subject_command.grammar.start-session');
+  assert.equal(start.body.mutation.appliedRevision, 1);
+
+  const submit = await postCommand(app, DB, {
+    command: 'submit-answer',
+    learnerId: 'learner-a',
+    requestId: 'grammar-submit-1',
+    expectedLearnerRevision: 1,
+    payload: { response: sample.correctResponse },
+  });
+  assert.equal(submit.response.status, 200, JSON.stringify(submit.body));
+  assert.equal(submit.body.subjectReadModel.phase, 'feedback');
+  assert.equal(submit.body.subjectReadModel.feedback.result.correct, true);
+  assert.equal(submit.body.mutation.appliedRevision, 2);
+  assert.equal(submit.body.domainEvents.some((event) => event.type === 'grammar.answer-submitted'), true);
+
+  const subject = DB.db.prepare(`
+    SELECT ui_json, data_json
+    FROM child_subject_state
+    WHERE learner_id = 'learner-a' AND subject_id = 'grammar'
+  `).get();
+  const ui = JSON.parse(subject.ui_json);
+  const data = JSON.parse(subject.data_json);
+  assert.equal(ui.phase, 'feedback');
+  assert.equal(data.mastery.concepts.sentence_functions.attempts, 1);
+  assert.equal(data.mastery.concepts.speech_punctuation.attempts, 1);
+  assert.equal(DB.db.prepare("SELECT COUNT(*) AS count FROM practice_sessions WHERE subject_id = 'grammar'").get().count, 1);
+  assert.equal(DB.db.prepare("SELECT COUNT(*) AS count FROM event_log WHERE subject_id = 'grammar' AND event_type = 'grammar.answer-submitted'").get().count, 1);
+
+  DB.close();
+});
+
+test('Grammar command replay is idempotent and does not double-apply events', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const app = createWorkerApp({ now: () => 1_777_000_000_000 });
+  const sample = readGrammarLegacyOracle().templates.find((template) => template.id === 'fronted_adverbial_choose');
+  seedAccountLearner(DB);
+
+  const body = {
+    command: 'start-session',
+    learnerId: 'learner-a',
+    requestId: 'grammar-replay-1',
+    expectedLearnerRevision: 0,
+    payload: {
+      mode: 'smart',
+      roundLength: 1,
+      templateId: sample.id,
+      seed: sample.sample.seed,
+    },
+  };
+  const first = await postCommand(app, DB, body);
+  const replay = await postCommand(app, DB, body);
+
+  assert.equal(first.response.status, 200, JSON.stringify(first.body));
+  assert.equal(replay.response.status, 200, JSON.stringify(replay.body));
+  assert.equal(replay.body.mutation.replayed, true);
+  assert.equal(DB.db.prepare("SELECT COUNT(*) AS count FROM child_subject_state WHERE subject_id = 'grammar'").get().count, 1);
+  assert.equal(DB.db.prepare('SELECT state_revision FROM learner_profiles WHERE id = ?').get('learner-a').state_revision, 1);
+
+  DB.close();
+});
+
+test('Grammar unknown commands and future AI scoring commands fail closed', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const app = createWorkerApp();
+  seedAccountLearner(DB);
+
+  const unknown = await postCommand(app, DB, {
+    command: 'ai-scored-question',
+    learnerId: 'learner-a',
+    requestId: 'grammar-ai-1',
+    expectedLearnerRevision: 0,
+    payload: { questionText: 'AI wrote this scored item.' },
+  });
+
+  assert.equal(unknown.response.status, 404);
+  assert.equal(unknown.body.code, 'subject_command_not_found');
+  assert.equal(DB.db.prepare("SELECT COUNT(*) AS count FROM child_subject_state WHERE subject_id = 'grammar'").get().count, 0);
+
+  DB.close();
+});
+
+test('production Grammar commands require same-origin before handlers run', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const app = createWorkerApp();
+  seedAccountLearner(DB);
+
+  const response = await app.fetch(new Request('https://repo.test/api/subjects/grammar/command', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      origin: 'https://evil.example',
+      'x-ks2-dev-account-id': 'adult-a',
+    },
+    body: JSON.stringify({
+      command: 'start-session',
+      learnerId: 'learner-a',
+      requestId: 'grammar-origin-1',
+      expectedLearnerRevision: 0,
+    }),
+  }), {
+    DB,
+    AUTH_MODE: 'development-stub',
+    ENVIRONMENT: 'test',
+  }, {});
+  const body = await response.json();
+
+  assert.equal(response.status, 403);
+  assert.equal(body.code, 'same_origin_required');
+  assert.equal(DB.db.prepare("SELECT COUNT(*) AS count FROM child_subject_state WHERE subject_id = 'grammar'").get().count, 0);
+
+  DB.close();
+});
+
+test('stale Grammar command revisions do not double-apply mastery or events', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const app = createWorkerApp({ now: () => 1_777_000_000_000 });
+  const sample = readGrammarLegacyOracle().templates.find((template) => template.id === 'fronted_adverbial_choose');
+  seedAccountLearner(DB);
+
+  const start = await postCommand(app, DB, {
+    command: 'start-session',
+    learnerId: 'learner-a',
+    requestId: 'grammar-stale-start',
+    expectedLearnerRevision: 0,
+    payload: {
+      mode: 'smart',
+      roundLength: 1,
+      templateId: sample.id,
+      seed: sample.sample.seed,
+    },
+  });
+  assert.equal(start.response.status, 200, JSON.stringify(start.body));
+
+  const stale = await postCommand(app, DB, {
+    command: 'submit-answer',
+    learnerId: 'learner-a',
+    requestId: 'grammar-stale-submit',
+    expectedLearnerRevision: 0,
+    payload: { response: sample.correctResponse },
+  });
+  assert.equal(stale.response.status, 409);
+  assert.equal(stale.body.code, 'stale_write');
+  assert.equal(DB.db.prepare("SELECT COUNT(*) AS count FROM event_log WHERE subject_id = 'grammar'").get().count, 0);
+  assert.equal(DB.db.prepare('SELECT state_revision FROM learner_profiles WHERE id = ?').get('learner-a').state_revision, 1);
+
+  DB.close();
+});

--- a/tests/worker-grammar-subject-runtime.test.js
+++ b/tests/worker-grammar-subject-runtime.test.js
@@ -250,6 +250,56 @@ test('Grammar command route rejects end-session without an active session', asyn
   DB.close();
 });
 
+test('Grammar command route normalises answer responses before storing read models', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const app = createWorkerApp({ now: () => 1_777_000_000_000 });
+  const sample = readGrammarLegacyOracle().templates.find((template) => template.id === 'fronted_adverbial_choose');
+  seedAccountLearner(DB);
+
+  const start = await postCommand(app, DB, {
+    command: 'start-session',
+    learnerId: 'learner-a',
+    requestId: 'grammar-normalise-start',
+    expectedLearnerRevision: 0,
+    payload: {
+      mode: 'smart',
+      roundLength: 1,
+      templateId: sample.id,
+      seed: sample.sample.seed,
+    },
+  });
+  assert.equal(start.response.status, 200, JSON.stringify(start.body));
+
+  const submit = await postCommand(app, DB, {
+    command: 'submit-answer',
+    learnerId: 'learner-a',
+    requestId: 'grammar-normalise-submit',
+    expectedLearnerRevision: 1,
+    payload: {
+      response: {
+        ...sample.correctResponse,
+        extra: 'x'.repeat(120_000),
+        selected: Array.from({ length: 120 }, () => 'not an option'),
+        nested: { value: 'not persisted' },
+      },
+    },
+  });
+  assert.equal(submit.response.status, 200, JSON.stringify(submit.body));
+  assert.deepEqual(submit.body.subjectReadModel.feedback.response, sample.correctResponse);
+
+  const subject = DB.db.prepare(`
+    SELECT ui_json, data_json
+    FROM child_subject_state
+    WHERE learner_id = 'learner-a' AND subject_id = 'grammar'
+  `).get();
+  const ui = JSON.parse(subject.ui_json);
+  const data = JSON.parse(subject.data_json);
+  assert.deepEqual(ui.feedback.response, sample.correctResponse);
+  assert.deepEqual(data.recentAttempts[0].response, sample.correctResponse);
+
+  DB.close();
+});
+
 test('Grammar save-prefs drops invalid focus concepts so later sessions can start', async () => {
   const DB = createMigratedSqliteD1Database();
   const app = createWorkerApp({ now: () => 1_777_000_000_000 });

--- a/tests/worker-grammar-subject-runtime.test.js
+++ b/tests/worker-grammar-subject-runtime.test.js
@@ -136,6 +136,120 @@ test('Grammar command route persists subject state, practice session, and events
   DB.close();
 });
 
+test('Grammar command route keeps practice sessions learner scoped when clients send session ids', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const app = createWorkerApp({ now: () => 1_777_000_000_000 });
+  const sample = readGrammarLegacyOracle().templates.find((template) => template.id === 'question_mark_select');
+  seedAccountLearner(DB, { accountId: 'adult-a', learnerId: 'learner-a' });
+  seedAccountLearner(DB, { accountId: 'adult-b', learnerId: 'learner-b' });
+
+  const first = await postCommand(app, DB, {
+    command: 'start-session',
+    learnerId: 'learner-a',
+    requestId: 'grammar-shared-session-a',
+    expectedLearnerRevision: 0,
+    payload: {
+      mode: 'smart',
+      roundLength: 1,
+      templateId: sample.id,
+      seed: sample.sample.seed,
+      sessionId: 'shared-session-id',
+    },
+  });
+  assert.equal(first.response.status, 200, JSON.stringify(first.body));
+
+  const second = await postCommand(app, DB, {
+    command: 'start-session',
+    learnerId: 'learner-b',
+    requestId: 'grammar-shared-session-b',
+    expectedLearnerRevision: 0,
+    payload: {
+      mode: 'smart',
+      roundLength: 1,
+      templateId: sample.id,
+      seed: sample.sample.seed,
+      sessionId: 'shared-session-id',
+    },
+  }, { 'x-ks2-dev-account-id': 'adult-b' });
+  assert.equal(second.response.status, 200, JSON.stringify(second.body));
+
+  const sessions = DB.db.prepare(`
+    SELECT id, learner_id
+    FROM practice_sessions
+    WHERE subject_id = 'grammar'
+    ORDER BY learner_id
+  `).all();
+  assert.deepEqual(sessions.map((session) => session.learner_id), ['learner-a', 'learner-b']);
+  assert.equal(new Set(sessions.map((session) => session.id)).size, 2);
+  assert.equal(sessions.some((session) => session.id === 'shared-session-id'), false);
+
+  DB.close();
+});
+
+test('Grammar command route rejects continue before an answer advances the item', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const app = createWorkerApp({ now: () => 1_777_000_000_000 });
+  const sample = readGrammarLegacyOracle().templates.find((template) => template.id === 'fronted_adverbial_choose');
+  seedAccountLearner(DB);
+
+  const start = await postCommand(app, DB, {
+    command: 'start-session',
+    learnerId: 'learner-a',
+    requestId: 'grammar-early-continue-start',
+    expectedLearnerRevision: 0,
+    payload: {
+      mode: 'smart',
+      roundLength: 2,
+      templateId: sample.id,
+      seed: sample.sample.seed,
+    },
+  });
+  assert.equal(start.response.status, 200, JSON.stringify(start.body));
+
+  const early = await postCommand(app, DB, {
+    command: 'continue-session',
+    learnerId: 'learner-a',
+    requestId: 'grammar-early-continue',
+    expectedLearnerRevision: 1,
+    payload: {},
+  });
+  assert.equal(early.response.status, 400);
+  assert.equal(early.body.code, 'grammar_advance_not_ready');
+
+  const subject = DB.db.prepare(`
+    SELECT ui_json
+    FROM child_subject_state
+    WHERE learner_id = 'learner-a' AND subject_id = 'grammar'
+  `).get();
+  const ui = JSON.parse(subject.ui_json);
+  assert.equal(ui.session.currentIndex, 0);
+  assert.equal(ui.session.answered, 0);
+  assert.equal(DB.db.prepare('SELECT state_revision FROM learner_profiles WHERE id = ?').get('learner-a').state_revision, 1);
+
+  DB.close();
+});
+
+test('Grammar command route rejects end-session without an active session', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const app = createWorkerApp({ now: () => 1_777_000_000_000 });
+  seedAccountLearner(DB);
+
+  const ended = await postCommand(app, DB, {
+    command: 'end-session',
+    learnerId: 'learner-a',
+    requestId: 'grammar-end-without-session',
+    expectedLearnerRevision: 0,
+    payload: {},
+  });
+  assert.equal(ended.response.status, 400);
+  assert.equal(ended.body.code, 'grammar_session_stale');
+  assert.equal(DB.db.prepare("SELECT COUNT(*) AS count FROM child_subject_state WHERE subject_id = 'grammar'").get().count, 0);
+  assert.equal(DB.db.prepare("SELECT COUNT(*) AS count FROM practice_sessions WHERE subject_id = 'grammar'").get().count, 0);
+  assert.equal(DB.db.prepare('SELECT state_revision FROM learner_profiles WHERE id = ?').get('learner-a').state_revision, 0);
+
+  DB.close();
+});
+
 test('Grammar command replay is idempotent and does not double-apply events', async () => {
   const DB = createMigratedSqliteD1Database();
   const app = createWorkerApp({ now: () => 1_777_000_000_000 });

--- a/tests/worker-grammar-subject-runtime.test.js
+++ b/tests/worker-grammar-subject-runtime.test.js
@@ -250,6 +250,49 @@ test('Grammar command route rejects end-session without an active session', asyn
   DB.close();
 });
 
+test('Grammar save-prefs drops invalid focus concepts so later sessions can start', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const app = createWorkerApp({ now: () => 1_777_000_000_000 });
+  seedAccountLearner(DB);
+
+  const saved = await postCommand(app, DB, {
+    command: 'save-prefs',
+    learnerId: 'learner-a',
+    requestId: 'grammar-invalid-focus-prefs',
+    expectedLearnerRevision: 0,
+    payload: {
+      prefs: {
+        mode: 'smart',
+        roundLength: 2,
+        focusConceptId: 'not-a-real-concept',
+      },
+    },
+  });
+  assert.equal(saved.response.status, 200, JSON.stringify(saved.body));
+  assert.equal(saved.body.subjectReadModel.prefs.focusConceptId, '');
+
+  const subject = DB.db.prepare(`
+    SELECT data_json
+    FROM child_subject_state
+    WHERE learner_id = 'learner-a' AND subject_id = 'grammar'
+  `).get();
+  const data = JSON.parse(subject.data_json);
+  assert.equal(data.prefs.focusConceptId, '');
+
+  const started = await postCommand(app, DB, {
+    command: 'start-session',
+    learnerId: 'learner-a',
+    requestId: 'grammar-start-after-invalid-focus',
+    expectedLearnerRevision: 1,
+    payload: {},
+  });
+  assert.equal(started.response.status, 200, JSON.stringify(started.body));
+  assert.equal(started.body.subjectReadModel.phase, 'session');
+  assert.equal(started.body.subjectReadModel.session.focusConceptId, '');
+
+  DB.close();
+});
+
 test('Grammar command replay is idempotent and does not double-apply events', async () => {
   const DB = createMigratedSqliteD1Database();
   const app = createWorkerApp({ now: () => 1_777_000_000_000 });

--- a/worker/src/subjects/grammar/commands.js
+++ b/worker/src/subjects/grammar/commands.js
@@ -1,0 +1,83 @@
+import { NotFoundError } from '../../errors.js';
+import { combineCommandEvents } from '../../projections/events.js';
+import { buildCommandProjectionReadModel } from '../../projections/read-models.js';
+import { createServerGrammarEngine } from './engine.js';
+import { buildGrammarReadModel } from './read-models.js';
+
+const GRAMMAR_COMMANDS = Object.freeze([
+  'start-session',
+  'submit-answer',
+  'continue-session',
+  'end-session',
+  'save-prefs',
+  'reset-learner',
+]);
+
+export function createGrammarCommandHandlers({ now } = {}) {
+  async function handleGrammarCommand(command, context) {
+    if (!GRAMMAR_COMMANDS.includes(command.command)) {
+      throw new NotFoundError('Grammar command is not available.', {
+        code: 'subject_command_not_found',
+        subjectId: 'grammar',
+        command: command.command,
+      });
+    }
+
+    const nowValue = Number.isFinite(Number(context.now)) ? Number(context.now) : Date.now();
+    const runtimeRecord = await context.repository.readSubjectRuntime(
+      context.session.accountId,
+      command.learnerId,
+      'grammar',
+    );
+    const engine = createServerGrammarEngine({
+      now: typeof now === 'function' ? now : () => nowValue,
+    });
+    const result = engine.apply({
+      learnerId: command.learnerId,
+      subjectRecord: runtimeRecord.subjectRecord,
+      latestSession: runtimeRecord.latestSession,
+      command: command.command,
+      payload: command.payload,
+      requestId: command.requestId,
+    });
+    const projectionState = await context.repository.readLearnerProjectionState(
+      context.session.accountId,
+      command.learnerId,
+    );
+    const projectedEvents = combineCommandEvents({
+      domainEvents: result.events,
+      reactionEvents: [],
+      existingEvents: projectionState.events,
+    });
+    const projections = buildCommandProjectionReadModel({
+      gameState: projectionState.gameState,
+      domainEvents: projectedEvents.domainEvents,
+      reactionEvents: projectedEvents.reactionEvents,
+      toastEvents: projectedEvents.toastEvents,
+    });
+
+    return {
+      learnerId: command.learnerId,
+      changed: result.changed,
+      subjectReadModel: buildGrammarReadModel({
+        learnerId: command.learnerId,
+        state: result.state,
+        projections,
+        now: nowValue,
+      }),
+      projections,
+      events: projectedEvents.events,
+      domainEvents: projectedEvents.domainEvents,
+      reactionEvents: projectedEvents.reactionEvents,
+      toastEvents: projectedEvents.toastEvents,
+      runtimeWrite: {
+        state: result.state,
+        data: result.data,
+        practiceSession: result.practiceSession,
+        events: projectedEvents.events,
+      },
+    };
+  }
+
+  return Object.fromEntries(GRAMMAR_COMMANDS.map((name) => [name, handleGrammarCommand]));
+}

--- a/worker/src/subjects/grammar/content.js
+++ b/worker/src/subjects/grammar/content.js
@@ -1,0 +1,4304 @@
+// Generated from the reviewed KS2 Grammar legacy engine.
+// Regenerate with: node scripts/extract-grammar-legacy-oracle.mjs --source <legacy-html>
+
+const MISCONCEPTIONS = {
+  sentence_function_confusion: "Mixed up sentence functions or punctuation cues",
+  word_class_confusion: "Confused one word class with another",
+  noun_phrase_confusion: "Did not build or spot a full noun phrase",
+  fronted_adverbial_confusion: "Missed the fronted adverbial or its comma",
+  subordinate_clause_confusion: "Confused main and subordinate clauses",
+  relative_clause_confusion: "Missed how a relative clause links to a noun",
+  tense_confusion: "Chose the wrong tense or aspect",
+  standard_english_confusion: "Used a non-standard spoken form instead of Standard English",
+  pronoun_cohesion_confusion: "Used a pronoun or noun choice that reduced clarity",
+  formality_confusion: "Chose language at the wrong level of formality",
+  active_passive_confusion: "Mixed up active and passive voice",
+  subject_object_confusion: "Confused the subject and the object",
+  modal_verb_confusion: "Missed the degree of certainty or possibility",
+  parenthesis_confusion: "Missed how parenthesis or commas work",
+  speech_punctuation_confusion: "Placed speech punctuation incorrectly",
+  apostrophe_possession_confusion: "Confused singular and plural possession",
+  punctuation_precision: "Grammar idea mostly right, but punctuation or exact form was off",
+  misread_question: "Answered a different question from the one asked",
+  boundary_punctuation_confusion: "Chose the wrong punctuation to mark a clause boundary or introduce a list",
+  hyphen_ambiguity_confusion: "Missed how a hyphen changes the meaning"
+};
+
+const MINIMAL_HINTS = {
+  sentence_function_confusion: "Ask what the sentence is doing: telling, asking, ordering, or exclaiming.",
+  word_class_confusion: "Look at the word’s job in the sentence, not just what it seems to mean on its own.",
+  noun_phrase_confusion: "A noun phrase must centre on a noun. Check which words belong with that noun.",
+  fronted_adverbial_confusion: "If the sentence opens with when, where or how information, check whether it needs a comma after it.",
+  subordinate_clause_confusion: "A subordinate clause usually depends on the main clause. Ask whether it can stand alone here.",
+  relative_clause_confusion: "A relative clause adds extra information about a noun. Find the noun it is attached to.",
+  tense_confusion: "Check when the action happened and whether the sentence needs a simple, progressive, perfect, or past perfect form.",
+  standard_english_confusion: "Choose the form you would expect in formal writing, not the spoken form you might hear.",
+  pronoun_cohesion_confusion: "A pronoun should make the sentence smoother without making the meaning unclear.",
+  formality_confusion: "Match the language to a formal setting, not everyday chat.",
+  active_passive_confusion: "In active voice, the doer comes first. In passive voice, the thing affected comes first.",
+  subject_object_confusion: "The subject does the action; the object receives it.",
+  modal_verb_confusion: "Compare how certain each modal verb sounds.",
+  parenthesis_confusion: "Parenthesis adds extra information that could be lifted out.",
+  speech_punctuation_confusion: "Check where the spoken words end and where the reporting clause begins.",
+  apostrophe_possession_confusion: "Ask who owns the noun, and whether the owner is singular or plural.",
+  punctuation_precision: "The grammar idea is close. Check the exact punctuation and wording.",
+  misread_question: "Read the instruction again. Are you identifying, fixing, rewriting, or explaining?",
+  boundary_punctuation_confusion: "Ask whether the first part is a complete clause and whether the second part explains it, adds a list, or stands as another clause.",
+  hyphen_ambiguity_confusion: "Say the phrase both ways in your head. Which version makes the meaning clear?"
+};
+
+const QUESTION_TYPES = {
+  identify: "Identify the feature",
+  choose: "Choose the correct sentence",
+  fix: "Fix the sentence",
+  rewrite: "Rewrite the sentence",
+  build: "Build / transform a sentence",
+  explain: "Explain why",
+  classify: "Classify",
+  fill: "Complete the sentence"
+};
+
+const SKILLS = {
+  sentence_functions: {
+    domain: "Sentence function",
+    name: "Sentence functions",
+    summary: "Statements tell, questions ask, commands instruct, and exclamations show strong feeling.",
+    notices: [
+      "Look at the whole sentence, not just the final punctuation.",
+      "Questions ask something. Commands tell someone to do something.",
+      "A sentence can sound excited without being a grammatical exclamation."
+    ],
+    worked: {
+      prompt: "Which sentence is a command?",
+      answer: "Close the gate before the dog escapes.",
+      why: "It tells someone to do something."
+    },
+    contrast: {
+      good: "Where is the red scarf?",
+      nearMiss: "I wonder where the red scarf is.",
+      why: "The first is a question. The second is a statement about wondering."
+    }
+  },
+  word_classes: {
+    domain: "Word classes",
+    name: "Word classes",
+    summary: "Spot the job a word is doing in a sentence: noun, verb, adjective, adverb, determiner, pronoun, conjunction or preposition.",
+    notices: [
+      "The same kind of meaning is not enough; focus on the word’s job.",
+      "Determiners often come before nouns. Adverbs often modify verbs, adjectives or whole clauses.",
+      "Conjunctions join clauses or ideas. Prepositions usually show place, time or cause relationships."
+    ],
+    worked: {
+      prompt: "In ‘Ben often walks home’, what is ‘often’?",
+      answer: "An adverb.",
+      why: "It modifies the verb ‘walks’ by telling us how often."
+    },
+    contrast: {
+      good: "after lunch",
+      nearMiss: "afterwards",
+      why: "‘After’ in ‘after lunch’ is a preposition. ‘Afterwards’ is an adverb."
+    }
+  },
+  noun_phrases: {
+    domain: "Phrases",
+    name: "Expanded noun phrases",
+    summary: "A noun phrase has a noun at its heart and can be expanded with adjectives, nouns or preposition phrases.",
+    notices: [
+      "The noun is the key word in the phrase.",
+      "Extra words should belong with the noun and help describe or specify it.",
+      "A whole clause is not the same thing as a noun phrase."
+    ],
+    worked: {
+      prompt: "Build a noun phrase to complete: ___ opened the door.",
+      answer: "The nervous young goalkeeper",
+      why: "It is a group of words centred on the noun ‘goalkeeper’."
+    },
+    contrast: {
+      good: "the tiny silver key",
+      nearMiss: "quickly opened the door",
+      why: "The first is a noun phrase. The second is part of a clause, not a noun phrase."
+    }
+  },
+  adverbials: {
+    domain: "Adverbials",
+    name: "Adverbials and fronted adverbials",
+    summary: "Adverbials often show when, where or how. Fronted adverbials come first and usually take a comma in KS2 contexts.",
+    notices: [
+      "A fronted adverbial is moved to the start for effect or clarity.",
+      "In KS2 GPS questions, a comma is commonly required after the fronted adverbial.",
+      "Not every opening word group is an adverbial: check what it adds."
+    ],
+    worked: {
+      prompt: "Add the comma: After lunch the choir practised.",
+      answer: "After lunch, the choir practised.",
+      why: "‘After lunch’ is a fronted adverbial telling us when."
+    },
+    contrast: {
+      good: "Before sunrise, the campers packed up.",
+      nearMiss: "The campers before sunrise packed up.",
+      why: "The first uses a clear fronted adverbial. The second is clumsy and does not place it properly."
+    }
+  },
+  clauses: {
+    domain: "Clauses",
+    name: "Subordinate clauses and conjunctions",
+    summary: "A subordinate clause adds extra information and usually depends on a main clause. Conjunctions often help introduce it.",
+    notices: [
+      "Look for conjunctions like because, when, if and although.",
+      "A subordinate clause cannot usually stand alone as a full sentence in the intended meaning.",
+      "Joining clauses is about meaning as well as grammar."
+    ],
+    worked: {
+      prompt: "Combine: Mia was tired. Mia finished the race. Use ‘although’.",
+      answer: "Although Mia was tired, she finished the race.",
+      why: "The subordinate clause adds contrast before the main clause."
+    },
+    contrast: {
+      good: "Because it was raining, we stayed inside.",
+      nearMiss: "Because it was raining.",
+      why: "The second is only a subordinate clause; it needs a main clause."
+    }
+  },
+  relative_clauses: {
+    domain: "Clauses",
+    name: "Relative clauses",
+    summary: "A relative clause adds extra information about a noun, often using who, which, that, where, when or whose.",
+    notices: [
+      "Find the noun being explained.",
+      "The clause can often be lifted out and the main sentence still works.",
+      "Be careful not to confuse relative clauses with other subordinate clauses."
+    ],
+    worked: {
+      prompt: "Add a relative clause: The boy waved. (who had lost his hat)",
+      answer: "The boy, who had lost his hat, waved.",
+      why: "The clause gives extra information about ‘the boy’."
+    },
+    contrast: {
+      good: "The book that I borrowed was excellent.",
+      nearMiss: "When I borrowed the book, it was excellent.",
+      why: "The first contains a relative clause linked to ‘book’. The second is a time clause."
+    }
+  },
+  tense_aspect: {
+    domain: "Verb forms",
+    name: "Tense and aspect",
+    summary: "KS2 grammar includes past and present tense, progressive forms, present perfect and past perfect.",
+    notices: [
+      "Present perfect links past action to now: ‘has finished’.",
+      "Progressive forms show an action in progress: ‘was running’.",
+      "Past perfect shows an earlier past action before another past action: ‘had left’."
+    ],
+    worked: {
+      prompt: "Complete with present perfect: She ___ her homework.",
+      answer: "has finished",
+      why: "It links a completed action to the present."
+    },
+    contrast: {
+      good: "He has gone out.",
+      nearMiss: "He went out just now.",
+      why: "The first is present perfect. The second is simple past with a finished time."
+    }
+  },
+  standard_english: {
+    domain: "Standard English",
+    name: "Standard English forms",
+    summary: "KS2 GPS expects standard written forms such as ‘we were’ rather than local spoken forms like ‘we was’.",
+    notices: [
+      "Choose the form you would expect in formal writing.",
+      "Standard English is about accepted written grammar, not about sounding posh.",
+      "Many errors come from everyday speech patterns."
+    ],
+    worked: {
+      prompt: "Choose the standard form: We was / were late.",
+      answer: "were",
+      why: "‘We were’ is the standard written form."
+    },
+    contrast: {
+      good: "I did it yesterday.",
+      nearMiss: "I done it yesterday.",
+      why: "The first is Standard English; the second is a non-standard spoken form."
+    }
+  },
+  pronouns_cohesion: {
+    domain: "Cohesion",
+    name: "Pronouns and cohesion",
+    summary: "Pronouns help avoid repetition, but the reader must still know clearly who or what each pronoun refers to.",
+    notices: [
+      "Replacing every noun with a pronoun can make meaning unclear.",
+      "Good cohesion means smooth writing without confusion.",
+      "Sometimes repeating the noun is clearer than using a pronoun."
+    ],
+    worked: {
+      prompt: "Choose the clearer sentence in a short passage.",
+      answer: "The clearer version keeps the referent obvious.",
+      why: "Cohesion is about flow and clarity together."
+    },
+    contrast: {
+      good: "Amira picked up the map. She folded it carefully.",
+      nearMiss: "Amira picked up the map. It folded it carefully.",
+      why: "The pronouns in the second sentence do not point clearly to the right things."
+    }
+  },
+  formality: {
+    domain: "Register",
+    name: "Formal and informal language",
+    summary: "KS2 tests both formal vocabulary and formal sentence structures, such as avoiding chatty expressions in formal writing.",
+    notices: [
+      "Formal writing often chooses more precise vocabulary.",
+      "Formal structures avoid casual tags and slangy expressions.",
+      "Match the register to the situation."
+    ],
+    worked: {
+      prompt: "Choose the more formal option: ask for / request",
+      answer: "request",
+      why: "It is the more formal vocabulary choice."
+    },
+    contrast: {
+      good: "The club was established last year.",
+      nearMiss: "The club got set up last year.",
+      why: "The first is more formal."
+    }
+  },
+  active_passive: {
+    domain: "Sentence structure",
+    name: "Active and passive voice",
+    summary: "Active voice foregrounds the doer. Passive voice foregrounds the thing affected or hides the doer.",
+    notices: [
+      "Look for a form of ‘be’ plus a past participle in passive constructions.",
+      "Active and passive change emphasis, not basic meaning.",
+      "Keep the tense steady when transforming a sentence."
+    ],
+    worked: {
+      prompt: "Rewrite in the active: The gate was opened by Sam.",
+      answer: "Sam opened the gate.",
+      why: "The doer becomes the subject in the active sentence."
+    },
+    contrast: {
+      good: "The council maintains the park.",
+      nearMiss: "The park maintains the council.",
+      why: "The active version keeps the doer and the thing affected in the right places."
+    }
+  },
+  subject_object: {
+    domain: "Sentence structure",
+    name: "Subject and object",
+    summary: "The subject usually does the action; the object usually receives it.",
+    notices: [
+      "In a simple active sentence, ask ‘who or what is doing the action?’",
+      "Then ask ‘who or what is receiving the action?’",
+      "Be careful when a sentence starts with an adverbial or a long noun phrase."
+    ],
+    worked: {
+      prompt: "In ‘The dog chased the ball’, what is the subject?",
+      answer: "The dog",
+      why: "It performs the action of chasing."
+    },
+    contrast: {
+      good: "The chef tasted the soup.",
+      nearMiss: "The soup tasted the chef.",
+      why: "Switching subject and object changes the meaning completely."
+    }
+  },
+  modal_verbs: {
+    domain: "Verb forms",
+    name: "Modal verbs and possibility",
+    summary: "Modal verbs such as might, should, will and must show different degrees of possibility, certainty, obligation or advice.",
+    notices: [
+      "Compare how strong each modal verb sounds.",
+      "The best choice depends on the meaning, not just the grammar.",
+      "Adverbs like perhaps can also signal possibility, but modal verbs are the main KS2 focus here."
+    ],
+    worked: {
+      prompt: "Which sounds most certain: might, will or must?",
+      answer: "must",
+      why: "It gives the strongest sense of certainty or obligation in common KS2 contrasts."
+    },
+    contrast: {
+      good: "It might rain later.",
+      nearMiss: "It must rain later.",
+      why: "The second sounds much more certain than the first."
+    }
+  },
+  parenthesis_commas: {
+    domain: "Punctuation for grammar",
+    name: "Parenthesis and commas",
+    summary: "Brackets, dashes and paired commas can mark extra information. Commas can also clarify meaning and separate fronted adverbials.",
+    notices: [
+      "Parenthesis adds extra information that the main sentence can survive without.",
+      "Paired commas must come in a pair if they are marking parenthesis in the middle of a sentence.",
+      "Commas can support grammar understanding, not just decoration."
+    ],
+    worked: {
+      prompt: "Add parenthesis: Our class visited York the oldest city on our route first.",
+      answer: "Our class visited York, the oldest city on our route, first.",
+      why: "The extra information is parenthesis."
+    },
+    contrast: {
+      good: "Luca, who was first in line, opened the door.",
+      nearMiss: "Luca who was first in line opened the door.",
+      why: "The commas show the parenthesis clearly."
+    }
+  },
+  speech_punctuation: {
+    domain: "Punctuation for grammar",
+    name: "Direct speech punctuation",
+    summary: "Direct speech punctuation depends on where the spoken words end and where the reporting clause begins.",
+    notices: [
+      "Speech marks go around the spoken words.",
+      "A comma often separates a reporting clause from direct speech.",
+      "Question marks and exclamation marks belong inside the speech marks when they are part of the spoken words."
+    ],
+    worked: {
+      prompt: "Punctuate: “Where are you going” asked Mum.",
+      answer: "“Where are you going?” asked Mum.",
+      why: "The spoken words are a question, so the question mark sits inside the speech marks."
+    },
+    contrast: {
+      good: "“Sit down!” shouted the coach.",
+      nearMiss: "“Sit down”! shouted the coach.",
+      why: "The end punctuation belongs inside the speech marks."
+    }
+  },
+  apostrophes_possession: {
+    domain: "Punctuation for grammar",
+    name: "Possession with apostrophes",
+    summary: "KS2 grammar expects pupils to distinguish singular possession from plural possession.",
+    notices: [
+      "Ask who owns the noun.",
+      "For a regular plural ending in s, the apostrophe usually comes after the s.",
+      "This is different from apostrophes used for omission in contractions."
+    ],
+    worked: {
+      prompt: "Choose the correct phrase for one dog and its bowl.",
+      answer: "the dog’s bowl",
+      why: "One dog owns the bowl, so the apostrophe comes before the s."
+    },
+    contrast: {
+      good: "the girls’ boots",
+      nearMiss: "the girl’s boots",
+      why: "The first means boots belonging to more than one girl; the second belongs to one girl."
+    }
+  },
+  boundary_punctuation: {
+    domain: "Punctuation for grammar",
+    name: "Colons, semi-colons and dashes",
+    summary: "These marks can show clear boundaries between ideas. In KS2, a colon can introduce an explanation or a list, a semi-colon can join closely related clauses, and a dash can create a strong break.",
+    notices: [
+      "A semi-colon joins two closely related main clauses.",
+      "A colon often comes after a complete clause and introduces an explanation or a list.",
+      "A dash creates a strong break and can mark a boundary between linked ideas."
+    ],
+    worked: {
+      prompt: "Choose the best punctuation: I needed only one thing ___ a torch.",
+      answer: "A colon.",
+      why: "The first part is a complete clause and the second part explains exactly what the one thing was."
+    },
+    contrast: {
+      good: "The sky darkened; the gulls flew inland.",
+      nearMiss: "The sky darkened, the gulls flew inland.",
+      why: "A comma is too weak for two full clauses here."
+    }
+  },
+  hyphen_ambiguity: {
+    domain: "Punctuation for grammar",
+    name: "Hyphens to avoid ambiguity",
+    summary: "A hyphen can join words so the reader sees the intended meaning clearly.",
+    notices: [
+      "A hyphen can show that two words work together as one idea.",
+      "Without a hyphen, the meaning can change.",
+      "Read both versions aloud and ask which one matches the meaning."
+    ],
+    worked: {
+      prompt: "Which means a shark that eats people: man eating shark or man-eating shark?",
+      answer: "man-eating shark",
+      why: "The hyphen shows that the shark is the man-eating kind."
+    },
+    contrast: {
+      good: "man-eating shark",
+      nearMiss: "man eating shark",
+      why: "The first describes the shark. The second sounds like a man is eating a shark."
+    }
+  }
+};
+
+const FUNCTION_SENTENCES = {
+  statement: [
+    "The lantern swung in the wind.",
+    "Our coach arrives at half past nine.",
+    "Mia tucked the map into her coat pocket.",
+    "The river flowed past the old bridge."
+  ],
+  question: [
+    "Where did you put the compass?",
+    "Have the tickets arrived yet?",
+    "Can we finish the poster tomorrow?",
+    "Why is the gate still open?"
+  ],
+  command: [
+    "Close the gate before the dog escapes.",
+    "Bring your reading record tomorrow.",
+    "Wait by the hall doors.",
+    "Please fold the letter neatly."
+  ],
+  exclamation: [
+    "What a huge shadow that tree casts!",
+    "How quickly the rabbit ran!",
+    "What an icy wind this is!",
+    "How loudly the drums were beating!"
+  ]
+};
+
+const WORD_CLASS_ITEMS = [
+  {
+    sentence: "On sunny days, Ben often plays outside before dinner.",
+    underlined: "often",
+    correct: "adverb",
+    options: [
+      "adverb",
+      "conjunction",
+      "adjective",
+      "determiner"
+    ]
+  },
+  {
+    sentence: "After the storm, the children followed the muddy path.",
+    underlined: "After",
+    correct: "preposition",
+    options: [
+      "preposition",
+      "adverb",
+      "verb",
+      "noun"
+    ]
+  },
+  {
+    sentence: "Those bright stars lit the whole beach.",
+    underlined: "Those",
+    correct: "determiner",
+    options: [
+      "pronoun",
+      "determiner",
+      "adjective",
+      "conjunction"
+    ]
+  },
+  {
+    sentence: "Luca whispered because the baby was asleep.",
+    underlined: "because",
+    correct: "conjunction",
+    options: [
+      "preposition",
+      "adverb",
+      "conjunction",
+      "verb"
+    ]
+  },
+  {
+    sentence: "The silver trophy gleamed on the shelf.",
+    underlined: "silver",
+    correct: "adjective",
+    options: [
+      "adjective",
+      "noun",
+      "adverb",
+      "verb"
+    ]
+  },
+  {
+    sentence: "Nadia lent it to me yesterday.",
+    underlined: "it",
+    correct: "pronoun",
+    options: [
+      "pronoun",
+      "determiner",
+      "adjective",
+      "preposition"
+    ]
+  },
+  {
+    sentence: "The old oak tree shaded the playground.",
+    underlined: "tree",
+    correct: "noun",
+    options: [
+      "noun",
+      "verb",
+      "adverb",
+      "conjunction"
+    ]
+  },
+  {
+    sentence: "We scrambled carefully over the rocks.",
+    underlined: "scrambled",
+    correct: "verb",
+    options: [
+      "verb",
+      "adjective",
+      "noun",
+      "preposition"
+    ]
+  }
+];
+
+const TOKEN_CLASS_ITEMS = [
+  {
+    targetLabel: "conjunctions",
+    className: "Conjunctions",
+    sentence: "Luca laughed because Maya slipped and nearly dropped the map.",
+    correct: [
+      "because",
+      "and"
+    ],
+    misconception: "word_class_confusion"
+  },
+  {
+    targetLabel: "determiners",
+    className: "Determiners",
+    sentence: "Those small birds built a nest in the tree.",
+    correct: [
+      "Those",
+      "a",
+      "the"
+    ],
+    misconception: "word_class_confusion"
+  },
+  {
+    targetLabel: "adverbs",
+    className: "Adverbs",
+    sentence: "Nina carefully and quietly packed the glass vase.",
+    correct: [
+      "carefully",
+      "quietly"
+    ],
+    misconception: "word_class_confusion"
+  },
+  {
+    targetLabel: "pronouns",
+    className: "Pronouns",
+    sentence: "She handed it to them before they left.",
+    correct: [
+      "She",
+      "it",
+      "them",
+      "they"
+    ],
+    misconception: "word_class_confusion"
+  }
+];
+
+const NOUN_PHRASE_OPTIONS = [
+  {
+    prompt: "Which option is an expanded noun phrase?",
+    options: [
+      "the tall boy with muddy boots",
+      "ran across the yard",
+      "after the storm",
+      "very quickly"
+    ],
+    correct: "the tall boy with muddy boots"
+  },
+  {
+    prompt: "Which option is an expanded noun phrase?",
+    options: [
+      "the silver key under the mat",
+      "jumped over the wall",
+      "before sunrise",
+      "quite suddenly"
+    ],
+    correct: "the silver key under the mat"
+  },
+  {
+    prompt: "Which sentence contains an expanded noun phrase?",
+    options: [
+      "The tired explorers climbed the hill.",
+      "Across the field, the dog barked.",
+      "Because it was late, we hurried.",
+      "Please close the shutters."
+    ],
+    correct: "The tired explorers climbed the hill."
+  }
+];
+
+const FRONTED_OPTIONS = [
+  {
+    options: [
+      "She is feeling tired, so Kal is going to her room.",
+      "After dinner, Kal is going to her room.",
+      "Arun told me that Kal is going to her room.",
+      "I wonder when Kal is going to her room."
+    ],
+    correct: "After dinner, Kal is going to her room."
+  },
+  {
+    options: [
+      "In the morning, the market opens early.",
+      "The market opens early in the morning.",
+      "Could the market open early?",
+      "The market opens and traders hurry in."
+    ],
+    correct: "In the morning, the market opens early."
+  }
+];
+
+const FRONTED_FIX_ITEMS = [
+  {
+    prompt: "Copy the sentence and add the comma after the fronted adverbial.",
+    raw: "Before sunrise the campers packed their bags.",
+    answer: "Before sunrise, the campers packed their bags.",
+    skillId: "adverbials"
+  },
+  {
+    prompt: "Copy the sentence and add the comma after the fronted adverbial.",
+    raw: "After the concert the audience cheered loudly.",
+    answer: "After the concert, the audience cheered loudly.",
+    skillId: "adverbials"
+  },
+  {
+    prompt: "Copy the sentence and add the comma after the fronted adverbial.",
+    raw: "Later that afternoon our team finally scored.",
+    answer: "Later that afternoon, our team finally scored.",
+    skillId: "adverbials"
+  }
+];
+
+const SUBORDINATE_ITEMS = [
+  {
+    sentence: "Although the wind was strong, the boat reached the shore.",
+    options: [
+      "Although the wind was strong",
+      "the boat reached",
+      "the shore",
+      "strong the boat"
+    ],
+    correct: "Although the wind was strong"
+  },
+  {
+    sentence: "When the bell rang, the pupils lined up quietly.",
+    options: [
+      "the pupils lined up quietly",
+      "When the bell rang",
+      "lined up quietly",
+      "the bell"
+    ],
+    correct: "When the bell rang"
+  },
+  {
+    sentence: "If the path is icy, wear your boots.",
+    options: [
+      "wear your boots",
+      "If the path is icy",
+      "the path is icy boots",
+      "icy wear"
+    ],
+    correct: "If the path is icy"
+  }
+];
+
+const CLAUSE_COMBINE_ITEMS = [
+  {
+    instruction: "Combine the ideas into one sentence using <strong>although</strong>.",
+    parts: [
+      "Mia was tired.",
+      "She finished the race."
+    ],
+    accepted: [
+      "Although Mia was tired, she finished the race.",
+      "Mia finished the race although she was tired."
+    ],
+    solution: [
+      "Use ‘although’ to introduce the contrasting subordinate clause.",
+      "Keep both original ideas.",
+      "A strong answer is: Although Mia was tired, she finished the race."
+    ]
+  },
+  {
+    instruction: "Combine the ideas into one sentence using <strong>because</strong>.",
+    parts: [
+      "Sam wore gloves.",
+      "It was cold."
+    ],
+    accepted: [
+      "Sam wore gloves because it was cold.",
+      "Because it was cold, Sam wore gloves."
+    ],
+    solution: [
+      "Use ‘because’ to show cause.",
+      "Either order can work if the punctuation is correct.",
+      "A strong answer is: Sam wore gloves because it was cold."
+    ]
+  },
+  {
+    instruction: "Combine the ideas into one sentence using <strong>when</strong>.",
+    parts: [
+      "The bell rang.",
+      "The pupils lined up."
+    ],
+    accepted: [
+      "When the bell rang, the pupils lined up.",
+      "The pupils lined up when the bell rang."
+    ],
+    solution: [
+      "Use ‘when’ to turn one idea into a subordinate clause of time.",
+      "If the ‘when’ clause comes first, add a comma after it.",
+      "A strong answer is: When the bell rang, the pupils lined up."
+    ]
+  }
+];
+
+const RELATIVE_SENTENCE_OPTIONS = [
+  {
+    options: [
+      "The boy who dropped his hat waved to us.",
+      "When the boy dropped his hat, he waved to us.",
+      "The boy dropped his hat and waved to us.",
+      "Waving to us, the boy dropped his hat."
+    ],
+    correct: "The boy who dropped his hat waved to us."
+  },
+  {
+    options: [
+      "The book that I borrowed was brilliant.",
+      "After I borrowed the book, it was brilliant.",
+      "I borrowed the book and it was brilliant.",
+      "Borrowing the book, I found it brilliant."
+    ],
+    correct: "The book that I borrowed was brilliant."
+  },
+  {
+    options: [
+      "The village, which sits by the sea, is very quiet.",
+      "Because the village sits by the sea, it is quiet.",
+      "The village sits by the sea and is quiet.",
+      "Beside the sea, the village is quiet."
+    ],
+    correct: "The village, which sits by the sea, is very quiet."
+  }
+];
+
+const RELATIVE_COMPLETE_ITEMS = [
+  {
+    stem: "Complete the sentence with the best relative clause.",
+    sentenceStart: "The bicycle",
+    sentenceEnd: "belonged to Zara.",
+    options: [
+      "that was locked outside",
+      "because it was outside",
+      "and it was outside",
+      "after school outside"
+    ],
+    correct: "that was locked outside"
+  },
+  {
+    stem: "Complete the sentence with the best relative clause.",
+    sentenceStart: "The teacher",
+    sentenceEnd: "helped us with the project.",
+    options: [
+      "who had visited Egypt",
+      "because she visited Egypt",
+      "after visiting Egypt",
+      "and visited Egypt"
+    ],
+    correct: "who had visited Egypt"
+  }
+];
+
+const TENSE_FORM_ITEMS = [
+  {
+    prompt: "Choose the best verb form to complete the sentence.",
+    sentence: "By the time we arrived, the play ___ already ___.",
+    options: [
+      "had / started",
+      "has / started",
+      "was / starting",
+      "start / had"
+    ],
+    correct: "had / started",
+    answerText: "had / started"
+  },
+  {
+    prompt: "Choose the best verb form to complete the sentence.",
+    sentence: "While we ___ to our friend, his phone started ringing.",
+    options: [
+      "talked",
+      "have talked",
+      "were talking",
+      "had talked"
+    ],
+    correct: "were talking",
+    answerText: "were talking"
+  },
+  {
+    prompt: "Choose the best verb form to complete the sentence.",
+    sentence: "She cannot play today because she ___ her ankle.",
+    options: [
+      "has twisted",
+      "twisted yesterday",
+      "was twisting",
+      "had twisted before"
+    ],
+    correct: "has twisted",
+    answerText: "has twisted"
+  }
+];
+
+const TENSE_REWRITE_ITEMS = [
+  {
+    instruction: "Rewrite the sentence in the <strong>past progressive</strong>.",
+    raw: "The dog chases the cat.",
+    accepted: [
+      "The dog was chasing the cat."
+    ],
+    solution: [
+      "Change the simple present verb into the past progressive form.",
+      "Use ‘was’ with ‘chasing’.",
+      "The correct sentence is: The dog was chasing the cat."
+    ]
+  },
+  {
+    instruction: "Rewrite the sentence in the <strong>present perfect</strong>.",
+    raw: "I finish my homework.",
+    accepted: [
+      "I have finished my homework."
+    ],
+    solution: [
+      "Use ‘have’ plus the past participle.",
+      "The past participle of ‘finish’ is ‘finished’.",
+      "The correct sentence is: I have finished my homework."
+    ]
+  },
+  {
+    instruction: "Rewrite the sentence in the <strong>past perfect</strong>.",
+    raw: "She packs her bag before the trip.",
+    accepted: [
+      "She had packed her bag before the trip."
+    ],
+    solution: [
+      "Use ‘had’ plus the past participle.",
+      "The past participle of ‘pack’ is ‘packed’.",
+      "The correct sentence is: She had packed her bag before the trip."
+    ]
+  }
+];
+
+const STANDARD_ENGLISH_ITEMS = [
+  {
+    rows: [
+      {
+        label: "We was / were going on a school trip.",
+        correct: "were",
+        options: [
+          "was",
+          "were"
+        ]
+      },
+      {
+        label: "The musicians did / done a sound check.",
+        correct: "did",
+        options: [
+          "did",
+          "done"
+        ]
+      }
+    ]
+  },
+  {
+    rows: [
+      {
+        label: "She seen / saw the poster yesterday.",
+        correct: "saw",
+        options: [
+          "seen",
+          "saw"
+        ]
+      },
+      {
+        label: "I did / done my homework before tea.",
+        correct: "did",
+        options: [
+          "did",
+          "done"
+        ]
+      }
+    ]
+  }
+];
+
+const PRONOUN_COHESION_ITEMS = [
+  {
+    prompt: "Which version is clearest and avoids awkward repetition without becoming confusing?",
+    options: [
+      "Mila put Mila's coat on the chair before Mila zipped Mila's bag.",
+      "Mila put her coat on the chair before she zipped her bag.",
+      "Mila put her coat on the chair before it zipped her bag.",
+      "She put it on the chair before she zipped it."
+    ],
+    correct: "Mila put her coat on the chair before she zipped her bag."
+  },
+  {
+    prompt: "Which version is clearest and avoids awkward repetition without becoming confusing?",
+    options: [
+      "Arjun gave Arjun's book to Arjun's sister because Arjun had finished Arjun's book.",
+      "Arjun gave his book to his sister because he had finished it.",
+      "Arjun gave his book to his sister because it had finished him.",
+      "He gave it to her because he had finished her."
+    ],
+    correct: "Arjun gave his book to his sister because he had finished it."
+  }
+];
+
+const FORMALITY_ITEMS = [
+  {
+    rows: [
+      {
+        label: "The basketball club was set up / established last year.",
+        correct: "established",
+        options: [
+          "set up",
+          "established"
+        ]
+      },
+      {
+        label: "They asked for / requested new equipment.",
+        correct: "requested",
+        options: [
+          "asked for",
+          "requested"
+        ]
+      },
+      {
+        label: "Now they play / compete in a local league.",
+        correct: "compete",
+        options: [
+          "play",
+          "compete"
+        ]
+      }
+    ]
+  },
+  {
+    rows: [
+      {
+        label: "Please find out / discover whether the hall is open.",
+        correct: "discover",
+        options: [
+          "find out",
+          "discover"
+        ]
+      },
+      {
+        label: "Could you go in / enter quietly?",
+        correct: "enter",
+        options: [
+          "go in",
+          "enter"
+        ]
+      },
+      {
+        label: "We need to ask for / request more time.",
+        correct: "request",
+        options: [
+          "ask for",
+          "request"
+        ]
+      }
+    ]
+  }
+];
+
+const ACTIVE_PASSIVE_ITEMS = [
+  {
+    instruction: "Rewrite the sentence in the <strong>active</strong>.",
+    raw: "The local park is maintained by the council.",
+    accepted: [
+      "The council maintains the local park.",
+      "The council maintains the park."
+    ],
+    solution: [
+      "Find the doer in the ‘by ...’ phrase.",
+      "Make the doer the subject of the new sentence.",
+      "A correct answer is: The council maintains the local park."
+    ]
+  },
+  {
+    instruction: "Rewrite the sentence in the <strong>passive</strong>. Keep the same tense.",
+    raw: "The chef baked the bread.",
+    accepted: [
+      "The bread was baked by the chef."
+    ],
+    solution: [
+      "Move the object to the front.",
+      "Use the correct form of ‘be’ plus the past participle.",
+      "A correct answer is: The bread was baked by the chef."
+    ]
+  },
+  {
+    instruction: "Rewrite the sentence in the <strong>passive</strong>. Keep the same tense.",
+    raw: "The team will collect the trophy.",
+    accepted: [
+      "The trophy will be collected by the team."
+    ],
+    solution: [
+      "Keep the future tense by using ‘will be’.",
+      "Then add the past participle ‘collected’.",
+      "A correct answer is: The trophy will be collected by the team."
+    ]
+  }
+];
+
+const SUBJECT_OBJECT_ITEMS = [
+  {
+    ask: "subject",
+    sentence: "After lunch, the tired goalkeeper caught the ball.",
+    options: [
+      "After lunch",
+      "the tired goalkeeper",
+      "caught",
+      "the ball"
+    ],
+    correct: "the tired goalkeeper"
+  },
+  {
+    ask: "object",
+    sentence: "The noisy gull stole the sandwich from Max.",
+    options: [
+      "The noisy gull",
+      "stole",
+      "the sandwich",
+      "from Max"
+    ],
+    correct: "the sandwich"
+  },
+  {
+    ask: "subject",
+    sentence: "On Friday morning, our science club visited the museum.",
+    options: [
+      "On Friday morning",
+      "our science club",
+      "visited",
+      "the museum"
+    ],
+    correct: "our science club"
+  }
+];
+
+const MODAL_ITEMS = [
+  {
+    prompt: "Which sentence shows the <strong>least certainty</strong> that the team will win?",
+    options: [
+      "The team must win.",
+      "The team will win.",
+      "The team should win.",
+      "The team might win."
+    ],
+    correct: "The team might win."
+  },
+  {
+    prompt: "Which modal verb best completes the sentence to show strong advice? <strong>You ___ wear a helmet on this trail.</strong>",
+    options: [
+      "might",
+      "could",
+      "should",
+      "will"
+    ],
+    correct: "should"
+  },
+  {
+    prompt: "Which sentence sounds <strong>most certain</strong>?",
+    options: [
+      "It might snow tonight.",
+      "It should snow tonight.",
+      "It will snow tonight.",
+      "It could snow tonight."
+    ],
+    correct: "It will snow tonight."
+  }
+];
+
+const PARENTHESIS_REPLACE_ITEMS = [
+  {
+    sentence: "Tokyo (the capital of Japan) is one of the largest cities in the world.",
+    options: [
+      "hyphens",
+      "colons",
+      "semi-colons",
+      "dashes"
+    ],
+    correct: "dashes"
+  },
+  {
+    sentence: "The guide (who had visited before) led us through the cave.",
+    options: [
+      "semi-colons",
+      "dashes",
+      "colons",
+      "question marks"
+    ],
+    correct: "dashes"
+  }
+];
+
+const PARENTHESIS_FIX_ITEMS = [
+  {
+    prompt: "Insert a pair of brackets in the correct place.",
+    raw: "Our class visited a castle the oldest in the county to help with our history project.",
+    accepted: [
+      "Our class visited a castle (the oldest in the county) to help with our history project."
+    ],
+    solution: [
+      "Find the extra information that could be lifted out.",
+      "Place the brackets around that extra information.",
+      "The correct sentence is: Our class visited a castle (the oldest in the county) to help with our history project."
+    ]
+  },
+  {
+    prompt: "Insert a pair of brackets in the correct place.",
+    raw: "My cousin the youngest in the family won the chess trophy.",
+    accepted: [
+      "My cousin (the youngest in the family) won the chess trophy."
+    ],
+    solution: [
+      "The bracketed words add extra information about ‘my cousin’.",
+      "The main sentence still works without them.",
+      "The correct sentence is: My cousin (the youngest in the family) won the chess trophy."
+    ]
+  }
+];
+
+const SPEECH_FIX_ITEMS = [
+  {
+    prompt: "Punctuate the direct speech correctly.",
+    raw: "“Where are you going” asked Mum.",
+    accepted: [
+      "“Where are you going?” asked Mum.",
+      "\"Where are you going?\" asked Mum."
+    ],
+    solution: [
+      "The spoken words are a question.",
+      "The question mark belongs inside the speech marks.",
+      "A correct answer is: “Where are you going?” asked Mum."
+    ]
+  },
+  {
+    prompt: "Punctuate the direct speech correctly.",
+    raw: "Dad shouted “Run inside!”",
+    accepted: [
+      "Dad shouted, “Run inside!”",
+      "Dad shouted, \"Run inside!\""
+    ],
+    solution: [
+      "A comma is needed before the direct speech after the reporting clause.",
+      "The exclamation mark stays inside the speech marks.",
+      "A correct answer is: Dad shouted, “Run inside!”"
+    ]
+  },
+  {
+    prompt: "Punctuate the direct speech correctly.",
+    raw: "“Sit down!” said the coach.",
+    accepted: [
+      "“Sit down!” said the coach.",
+      "\"Sit down!\" said the coach."
+    ],
+    solution: [
+      "The spoken words already end with an exclamation mark.",
+      "That punctuation stays inside the speech marks.",
+      "A correct answer is: “Sit down!” said the coach."
+    ]
+  }
+];
+
+const APOSTROPHE_ITEMS = [
+  {
+    stem: "Choose the correct phrase to complete the sentence: The ___ playground was closed after the storm.",
+    options: [
+      "girls",
+      "girl's",
+      "girls'",
+      "girls's"
+    ],
+    correct: "girls'"
+  },
+  {
+    stem: "Choose the correct phrase to complete the sentence: We found the ___ bowl behind the sofa.",
+    options: [
+      "dogs",
+      "dog's",
+      "dogs'",
+      "dogs's"
+    ],
+    correct: "dog's"
+  },
+  {
+    stem: "Choose the correct phrase to complete the sentence: The ___ coats were hanging by the door.",
+    options: [
+      "children's",
+      "childrens'",
+      "childrens",
+      "child's"
+    ],
+    correct: "children's"
+  }
+];
+
+const EXPLAIN_ITEMS = [
+  {
+    stem: "Why is there a comma after the opening words in this sentence?<br><strong>Before sunrise, the campers packed their bags.</strong>",
+    options: [
+      "Because the opening words are a fronted adverbial.",
+      "Because every long sentence needs a comma near the start.",
+      "Because ‘sunrise’ is a noun.",
+      "Because the sentence is in the past tense."
+    ],
+    correct: "Because the opening words are a fronted adverbial.",
+    skillIds: [
+      "adverbials"
+    ]
+  },
+  {
+    stem: "Why is <strong>‘I done my homework’</strong> wrong in Standard English?",
+    options: [
+      "Because Standard English uses ‘did’, not ‘done’, in that sentence.",
+      "Because ‘homework’ cannot be the object.",
+      "Because the sentence should be passive.",
+      "Because all past tense verbs end in -ed."
+    ],
+    correct: "Because Standard English uses ‘did’, not ‘done’, in that sentence.",
+    skillIds: [
+      "standard_english"
+    ]
+  }
+];
+
+const STANDARD_FIX_ITEMS = [
+  {
+    instruction: "Rewrite the sentence in Standard English.",
+    raw: "We was walking to school.",
+    accepted: [
+      "We were walking to school."
+    ],
+    solution: [
+      "Replace the non-standard verb form with the Standard English form.",
+      "‘We were’ is correct in Standard English.",
+      "The correct sentence is: We were walking to school."
+    ]
+  },
+  {
+    instruction: "Rewrite the sentence in Standard English.",
+    raw: "I done my homework before tea.",
+    accepted: [
+      "I did my homework before tea."
+    ],
+    solution: [
+      "Replace the non-standard spoken form.",
+      "Standard English uses ‘did’ here.",
+      "The correct sentence is: I did my homework before tea."
+    ]
+  }
+];
+
+const PUNCTUATION_SKILL_IDS = [
+  "sentence_functions",
+  "adverbials",
+  "parenthesis_commas",
+  "speech_punctuation",
+  "apostrophes_possession",
+  "boundary_punctuation",
+  "hyphen_ambiguity"
+];
+
+const EXTRA_LEXICON = {
+  names: [
+    "Ava",
+    "Ben",
+    "Mia",
+    "Noah",
+    "Elsie",
+    "Zac",
+    "Luca",
+    "Amira",
+    "Jay",
+    "Nora",
+    "Sam",
+    "Ruby"
+  ],
+  pluralOwners: [
+    "girls",
+    "boys",
+    "players",
+    "teachers",
+    "visitors",
+    "farmers"
+  ],
+  irregularPluralOwners: [
+    "children",
+    "people",
+    "men",
+    "women"
+  ],
+  ownedItems: [
+    "boots",
+    "books",
+    "bikes",
+    "bags",
+    "coats",
+    "tickets",
+    "lunchboxes"
+  ],
+  objects: [
+    "the lantern",
+    "the gate",
+    "the map",
+    "the trophy",
+    "the window",
+    "the rucksack",
+    "the picnic basket",
+    "the sketchbook"
+  ],
+  fronted: [
+    "Before sunrise",
+    "After lunch",
+    "Later that day",
+    "At the edge of the field",
+    "Without warning",
+    "With great care",
+    "On Friday morning",
+    "After the final whistle"
+  ],
+  clausePairs: [
+    [
+      "The rain stopped",
+      "the playground began to fill"
+    ],
+    [
+      "The lights went out",
+      "the hall fell silent"
+    ],
+    [
+      "The bell rang",
+      "the pupils hurried inside"
+    ],
+    [
+      "The wind strengthened",
+      "the tent flapped wildly"
+    ],
+    [
+      "The bus arrived",
+      "everyone grabbed their bags"
+    ]
+  ],
+  colonLists: [
+    {
+      intro: "For the picnic we packed three things",
+      items: [
+        "bread",
+        "fruit",
+        "juice"
+      ]
+    },
+    {
+      intro: "The museum displayed four objects",
+      items: [
+        "a helmet",
+        "a shield",
+        "a sword",
+        "a coin"
+      ]
+    },
+    {
+      intro: "We still needed two items for camp",
+      items: [
+        "a torch",
+        "a sleeping bag"
+      ]
+    },
+    {
+      intro: "The club offered three prizes",
+      items: [
+        "a medal",
+        "a certificate",
+        "a book token"
+      ]
+    }
+  ],
+  dashBoundaries: [
+    [
+      "I had one worry",
+      "the batteries were flat"
+    ],
+    [
+      "The plan was simple",
+      "follow the red arrows"
+    ],
+    [
+      "There was only one answer",
+      "turn back at once"
+    ],
+    [
+      "One thought filled my mind",
+      "where had the key gone"
+    ]
+  ],
+  speechQuestions: [
+    "Where is the spare key",
+    "Why are your boots muddy",
+    "Have you packed the torch",
+    "When does the match begin"
+  ],
+  speechCommands: [
+    "Bring the torch with you",
+    "Wait by the hall doors",
+    "Shut the gate behind you",
+    "Hold the ladder steady"
+  ],
+  speechExclaims: [
+    "What a huge wave that was",
+    "Look out for the puddle",
+    "That was a close finish"
+  ],
+  speakers: [
+    "Mum",
+    "Dad",
+    "the coach",
+    "Miss Patel",
+    "Ben",
+    "Ava",
+    "the guide"
+  ],
+  reportingVerbs: [
+    "said",
+    "asked",
+    "shouted",
+    "whispered",
+    "called"
+  ],
+  hyphenPrompts: [
+    {
+      ask: "Which sentence means the shark eats people?",
+      options: [
+        "We saw a man-eating shark near the rocks.",
+        "We saw a man eating shark near the rocks.",
+        "We saw a hungry shark near the rocks.",
+        "We saw a shark near a man on the rocks."
+      ],
+      correct: "We saw a man-eating shark near the rocks.",
+      why: "The hyphen makes ‘man-eating’ work as one describing idea."
+    },
+    {
+      ask: "Which sentence means the hospital treats small animals?",
+      options: [
+        "We visited the small-animal hospital after lunch.",
+        "We visited the small animal hospital after lunch.",
+        "We visited the hospital after lunch with small animals.",
+        "We visited a small hospital for lunch animals."
+      ],
+      correct: "We visited the small-animal hospital after lunch.",
+      why: "The hyphen shows that ‘small-animal’ is one combined idea describing the hospital."
+    }
+  ],
+  verbsRich: [
+    {
+      base: "open",
+      past: "opened",
+      part: "opened",
+      ing: "opening",
+      s: "opens"
+    },
+    {
+      base: "pack",
+      past: "packed",
+      part: "packed",
+      ing: "packing",
+      s: "packs"
+    },
+    {
+      base: "carry",
+      past: "carried",
+      part: "carried",
+      ing: "carrying",
+      s: "carries"
+    },
+    {
+      base: "lift",
+      past: "lifted",
+      part: "lifted",
+      ing: "lifting",
+      s: "lifts"
+    },
+    {
+      base: "paint",
+      past: "painted",
+      part: "painted",
+      ing: "painting",
+      s: "paints"
+    },
+    {
+      base: "clean",
+      past: "cleaned",
+      part: "cleaned",
+      ing: "cleaning",
+      s: "cleans"
+    },
+    {
+      base: "finish",
+      past: "finished",
+      part: "finished",
+      ing: "finishing",
+      s: "finishes"
+    },
+    {
+      base: "start",
+      past: "started",
+      part: "started",
+      ing: "starting",
+      s: "starts"
+    },
+    {
+      base: "wash",
+      past: "washed",
+      part: "washed",
+      ing: "washing",
+      s: "washes"
+    },
+    {
+      base: "visit",
+      past: "visited",
+      part: "visited",
+      ing: "visiting",
+      s: "visits"
+    }
+  ],
+  relativeCommonNouns: [
+    "boy",
+    "girl",
+    "teacher",
+    "runner",
+    "dog",
+    "cat",
+    "book",
+    "bag",
+    "coat",
+    "tent"
+  ],
+  relativeDetails: [
+    "who had lost a glove",
+    "who was first in line",
+    "who wore a blue cap",
+    "which was covered in mud",
+    "which stood by the window",
+    "that everyone wanted to borrow",
+    "that belonged to the club",
+    "which Ben had packed carefully"
+  ],
+  formalFrames: [
+    {
+      prompt: "Which sentence would be most suitable for a formal letter to the headteacher?",
+      correct: "I am writing to request two extra chairs for the hall.",
+      distractors: [
+        "Can we get a couple more chairs for the hall?",
+        "We really need some more chairs for the hall, please.",
+        "I just wanted to ask if we could maybe have extra chairs."
+      ],
+      why: "The formal sentence uses precise vocabulary and avoids chatty phrasing."
+    },
+    {
+      prompt: "Which sentence sounds most formal?",
+      correct: "The club was established last year.",
+      distractors: [
+        "The club got set up last year.",
+        "The club was started up last year, really.",
+        "Last year was when the club got going."
+      ],
+      why: "Formal register avoids casual expressions such as ‘got set up’."
+    },
+    {
+      prompt: "Choose the sentence that best fits a formal report.",
+      correct: "Several pupils were absent from the visit.",
+      distractors: [
+        "A few pupils were off for the visit.",
+        "Some pupils didn't come on the trip.",
+        "Quite a few pupils were missing from it."
+      ],
+      why: "Formal writing often chooses more precise vocabulary and sentence structure."
+    }
+  ],
+  modalFrames: [
+    {
+      prompt: "Choose the modal verb that best fits the meaning: This is a rule on the climbing wall. You ___ wear a helmet.",
+      correct: "must",
+      distractors: [
+        "might",
+        "could",
+        "should"
+      ],
+      why: "‘Must’ shows strongest obligation."
+    },
+    {
+      prompt: "Choose the modal verb that best fits the meaning: The clouds are dark, but the rain has not started. It ___ rain later.",
+      correct: "might",
+      distractors: [
+        "must",
+        "should",
+        "will"
+      ],
+      why: "‘Might’ shows possibility, not certainty."
+    },
+    {
+      prompt: "Choose the modal verb that best fits the meaning: You are giving advice to a friend. You ___ begin with the easier question.",
+      correct: "should",
+      distractors: [
+        "must",
+        "might",
+        "will"
+      ],
+      why: "‘Should’ is the modal of advice here."
+    },
+    {
+      prompt: "Choose the modal verb that best fits the meaning: The timetable is fixed. The coach ___ leave at 9 o'clock.",
+      correct: "will",
+      distractors: [
+        "might",
+        "should",
+        "must"
+      ],
+      why: "‘Will’ fits a definite future event here."
+    }
+  ]
+};
+
+const TEMPLATES = [
+  {
+    id: "sentence_type_table",
+    label: "Classify sentence functions",
+    domain: "Sentence function",
+    questionType: "classify",
+    difficulty: 1,
+    satsFriendly: true,
+    isSelectedResponse: true,
+    tags: [
+      "identify"
+    ],
+    skillIds: [
+      "sentence_functions"
+    ],
+    generator(seed) {
+          const rng = mulberry32(seed);
+          const cats = ["statement","question","command","exclamation"];
+          const rows = shuffle(rng, cats).map(cat => ({ text: pick(rng, FUNCTION_SENTENCES[cat]), answer: cat }));
+          return makeBaseQuestion(this, seed, {
+            marks:2,
+            stemHtml:`<p>Tick one box in each row to show the sentence function.</p>`,
+            inputSpec:{ type:"table_choice", columns:["statement","question","command","exclamation"], rows: rows.map((r,i)=>({ key:`row${i}`, label:r.text })) },
+            solutionLines:[
+              "A statement tells, a question asks, a command instructs, and an exclamation shows strong feeling.",
+              "Judge each whole sentence, not only the punctuation at the end."
+            ],
+            contrastHtml:`<div class="contrast-card"><strong>Useful contrast</strong><p style="margin:8px 0 4px;">Where is the red scarf?</p><p style="margin:0 0 4px;">I wonder where the red scarf is.</p><p style="margin:0;">Only the first is a question.</p></div>`,
+            evaluate:(resp)=>{
+              let correctRows = 0;
+              rows.forEach((row, i) => { if ((resp[`row${i}`] || "") === row.answer) correctRows += 1; });
+              const score = correctRows === 4 ? 2 : correctRows >= 2 ? 1 : 0;
+              const answerText = rows.map(r => `${r.text} → ${r.answer}`).join(" | ");
+              return mkResult({
+                correct: correctRows === 4,
+                score,
+                maxScore:2,
+                misconception: correctRows === 4 ? null : "sentence_function_confusion",
+                feedbackShort: correctRows === 4 ? "Correct." : (score ? "Some are right, but not all." : "Not quite."),
+                feedbackLong: answerText,
+                answerText
+              });
+            }
+          });
+        }
+  },
+  {
+    id: "question_mark_select",
+    label: "Find the real questions",
+    domain: "Sentence function",
+    questionType: "identify",
+    difficulty: 1,
+    satsFriendly: true,
+    isSelectedResponse: true,
+    tags: [
+      "identify"
+    ],
+    skillIds: [
+      "sentence_functions",
+      "speech_punctuation"
+    ],
+    generator(seed) {
+          const rng = mulberry32(seed);
+          const sets = [
+            [
+              "How good it would be if Jay could come",
+              "Is Jay going to come on Tuesday",
+              "Jay asked if we could meet him on Tuesday",
+              "Do you know if Jay is coming on Tuesday"
+            ],
+            [
+              "What a long journey this has been",
+              "Can you help me carry the boxes",
+              "Mum wondered whether the parcel had arrived",
+              "Did the coach leave on time"
+            ]
+          ];
+          const options = pick(rng, sets);
+          const correct = options.filter(x => /^(Is|Do|Did|Can)/.test(x));
+          return makeBaseQuestion(this, seed, {
+            marks:1,
+            stemHtml:`<p>Tick all the sentences that must end with a question mark.</p>`,
+            inputSpec:{ type:"checkbox_list", label:"Sentences", options: options.map(x => ({ value:x, label:x })) },
+            solutionLines:[
+              "A direct question asks for an answer.",
+              "An indirect question like ‘Mum wondered whether...’ is still a statement."
+            ],
+            contrastHtml:`<div class="contrast-card"><strong>Useful contrast</strong><p style="margin:8px 0 4px;">Can you hear the thunder?</p><p style="margin:0 0 4px;">I wonder whether you can hear the thunder.</p><p style="margin:0;">Only the first must end with a question mark.</p></div>`,
+            evaluate:(resp)=>{
+              const picked = resp.selected || [];
+              const exact = setEq(picked, correct);
+              return mkResult({
+                correct: exact,
+                score: exact ? 1 : 0,
+                maxScore:1,
+                misconception: exact ? null : "sentence_function_confusion",
+                feedbackShort: exact ? "Correct." : "Not quite.",
+                feedbackLong:`The sentences needing question marks are: ${correct.join("; ")}.`,
+                answerText: correct.join("; ")
+              });
+            }
+          });
+        }
+  },
+  {
+    id: "word_class_underlined_choice",
+    label: "Identify the word class",
+    domain: "Word classes",
+    questionType: "identify",
+    difficulty: 1,
+    satsFriendly: true,
+    isSelectedResponse: true,
+    tags: [
+      "identify"
+    ],
+    skillIds: [
+      "word_classes"
+    ],
+    generator(seed) {
+          const rng = mulberry32(seed);
+          const item = pick(rng, WORD_CLASS_ITEMS);
+          const sentenceHtml = escapeHtml(item.sentence).replace(item.underlined, `<u>${escapeHtml(item.underlined)}</u>`);
+          return makeBaseQuestion(this, seed, {
+            marks:1,
+            stemHtml:`<p>Which word class is the underlined word in the sentence below?</p><p><strong>${sentenceHtml}</strong></p>`,
+            inputSpec:{ type:"single_choice", options:item.options.map(x=>({ value:x, label:`${x}` })) },
+            solutionLines:[
+              "Work out the underlined word’s job in the sentence.",
+              `Here, ‘${item.underlined}’ is ${item.correct === "adverb" ? "modifying the verb or whole clause" : "working as a " + item.correct}.`
+            ],
+            evaluate:(resp)=>{
+              const ans = resp.answer || "";
+              return mkResult({
+                correct: ans === item.correct,
+                score: ans === item.correct ? 1 : 0,
+                maxScore:1,
+                misconception: ans === item.correct ? null : "word_class_confusion",
+                feedbackShort: ans === item.correct ? "Correct." : "Not quite.",
+                feedbackLong:`The underlined word is ${item.correct}.`,
+                answerText: item.correct
+              });
+            }
+          });
+        }
+  },
+  {
+    id: "identify_words_in_sentence",
+    label: "Select words with the target job",
+    domain: "Word classes",
+    questionType: "identify",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: true,
+    tags: [
+      "identify"
+    ],
+    skillIds: [
+      "word_classes"
+    ],
+    generator(seed) {
+          const rng = mulberry32(seed);
+          const item = pick(rng, TOKEN_CLASS_ITEMS);
+          const tokens = item.sentence.replace(/([.,!?;:])/g, ' $1').split(/\s+/).filter(Boolean).filter(t => !/[.,!?;:]/.test(t));
+          const unique = [...new Set(tokens)];
+          return makeBaseQuestion(this, seed, {
+            marks:1,
+            stemHtml:`<p>Select all the <strong>${item.targetLabel}</strong> in the sentence below.</p><p><strong>${escapeHtml(item.sentence)}</strong></p>`,
+            inputSpec:{ type:"checkbox_list", label:item.className, asTokens:true, options: unique.map(x => ({ value:x, label:x })) },
+            solutionLines:[
+              `Find the words that are working as ${item.targetLabel}.`,
+              `Correct selection: ${item.correct.join(", ")}.`
+            ],
+            evaluate:(resp)=>{
+              const picked = resp.selected || [];
+              const exact = setEq(picked, item.correct);
+              return mkResult({
+                correct: exact,
+                score: exact ? 1 : 0,
+                maxScore:1,
+                misconception: exact ? null : item.misconception,
+                feedbackShort: exact ? "Correct." : "Not quite.",
+                feedbackLong:`The correct words are: ${item.correct.join(", ")}.`,
+                answerText: item.correct.join(", ")
+              });
+            }
+          });
+        }
+  },
+  {
+    id: "expanded_noun_phrase_choice",
+    label: "Spot the expanded noun phrase",
+    domain: "Phrases",
+    questionType: "choose",
+    difficulty: 1,
+    satsFriendly: true,
+    isSelectedResponse: true,
+    tags: [
+      "identify"
+    ],
+    skillIds: [
+      "noun_phrases"
+    ],
+    generator(seed) {
+          const rng = mulberry32(seed);
+          const item = pick(rng, NOUN_PHRASE_OPTIONS);
+          return makeBaseQuestion(this, seed, {
+            marks:1,
+            stemHtml:`<p>${item.prompt}</p>`,
+            inputSpec:{ type:"single_choice", options:item.options.map(x=>({ value:x, label:x })) },
+            solutionLines:[
+              "A noun phrase must centre on a noun.",
+              "Expanded noun phrases add detail with extra words attached to that noun."
+            ],
+            contrastHtml:`<div class="contrast-card"><strong>Useful contrast</strong><p style="margin:8px 0 4px;">the small lantern on the step</p><p style="margin:0 0 4px;">ran down the path</p><p style="margin:0;">Only the first is a noun phrase.</p></div>`,
+            evaluate:(resp)=>{
+              const ans = resp.answer || "";
+              return mkResult({
+                correct: ans === item.correct,
+                score: ans === item.correct ? 1 : 0,
+                maxScore:1,
+                misconception: ans === item.correct ? null : "noun_phrase_confusion",
+                feedbackShort: ans === item.correct ? "Correct." : "Not quite.",
+                feedbackLong:`The correct answer is: ${item.correct}.`,
+                answerText:item.correct
+              });
+            }
+          });
+        }
+  },
+  {
+    id: "build_noun_phrase",
+    label: "Build a noun phrase",
+    domain: "Phrases",
+    questionType: "build",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: false,
+    tags: [
+      "builder"
+    ],
+    skillIds: [
+      "noun_phrases"
+    ],
+    generator(seed) {
+          const variants = [
+            {
+              sentence:"___ opened the door.",
+              fields:[
+                { key:"part1", label:"Part 1", kind:"select", options:[["","Choose"],["The tall","The tall"],["Quickly","Quickly"],["Because","Because"]] },
+                { key:"part2", label:"Part 2", kind:"select", options:[["","Choose"],["captain","captain"],["shouted","shouted"],["after","after"]] },
+                { key:"part3", label:"Part 3", kind:"select", options:[["","Choose"],["with curly hair","with curly hair"],["very loudly","very loudly"],["and waved","and waved"]] }
+              ],
+              answerParts:["The tall","captain","with curly hair"],
+              final:"The tall captain with curly hair"
+            },
+            {
+              sentence:"___ found the silver key.",
+              fields:[
+                { key:"part1", label:"Part 1", kind:"select", options:[["","Choose"],["The nervous young","The nervous young"],["Suddenly","Suddenly"],["If","If"]] },
+                { key:"part2", label:"Part 2", kind:"select", options:[["","Choose"],["explorer","explorer"],["ran","ran"],["under","under"]] },
+                { key:"part3", label:"Part 3", kind:"select", options:[["","Choose"],["from our class","from our class"],["very carefully","very carefully"],["because of the rain","because of the rain"]] }
+              ],
+              answerParts:["The nervous young","explorer","from our class"],
+              final:"The nervous young explorer from our class"
+            }
+          ];
+          const item = variants[seed % variants.length];
+          return makeBaseQuestion(this, seed, {
+            marks:2,
+            stemHtml:`<p>Build a noun phrase of at least three words to complete the sentence below.</p><p><strong>${escapeHtml(item.sentence)}</strong></p>`,
+            inputSpec:{ type:"multi", fields:item.fields },
+            solutionLines:[
+              "Choose a sensible determiner/adjective opening, then a noun, then extra detail attached to that noun.",
+              `A strong answer is: ${item.final}.`
+            ],
+            evaluate:(resp)=>{
+              const got = [resp.part1 || "", resp.part2 || "", resp.part3 || ""];
+              const correctBits = got.filter((x,i)=>x===item.answerParts[i]).length;
+              const score = correctBits === 3 ? 2 : correctBits >= 2 ? 1 : 0;
+              return mkResult({
+                correct: correctBits === 3,
+                score,
+                maxScore:2,
+                misconception: correctBits === 3 ? null : "noun_phrase_confusion",
+                feedbackShort: correctBits === 3 ? "Correct." : (score ? "Close, but not all the parts build a full noun phrase." : "Not quite."),
+                feedbackLong:`A strong answer is: ${item.final}.`,
+                answerText:item.final
+              });
+            }
+          });
+        }
+  },
+  {
+    id: "fronted_adverbial_choose",
+    label: "Spot the fronted adverbial",
+    domain: "Adverbials",
+    questionType: "choose",
+    difficulty: 1,
+    satsFriendly: true,
+    isSelectedResponse: true,
+    tags: [
+      "identify"
+    ],
+    skillIds: [
+      "adverbials"
+    ],
+    generator(seed) {
+          const item = FRONTED_OPTIONS[seed % FRONTED_OPTIONS.length];
+          return makeBaseQuestion(this, seed, {
+            marks:1,
+            stemHtml:`<p>Which sentence starts with a fronted adverbial?</p>`,
+            inputSpec:{ type:"single_choice", options:item.options.map(x=>({ value:x, label:x })) },
+            solutionLines:[
+              "A fronted adverbial gives when, where or how information at the start of the sentence.",
+              "In KS2 contexts it is commonly followed by a comma."
+            ],
+            evaluate:(resp)=> mkResult({
+              correct:(resp.answer||"")===item.correct,
+              score:(resp.answer||"")===item.correct ? 1 : 0,
+              maxScore:1,
+              misconception:(resp.answer||"")===item.correct ? null : "fronted_adverbial_confusion",
+              feedbackShort:(resp.answer||"")===item.correct ? "Correct." : "Not quite.",
+              feedbackLong:`The correct answer is: ${item.correct}`,
+              answerText:item.correct
+            })
+          });
+        }
+  },
+  {
+    id: "fix_fronted_adverbial",
+    label: "Add the comma after a fronted adverbial",
+    domain: "Adverbials",
+    questionType: "fix",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: false,
+    tags: [
+      "surgery"
+    ],
+    skillIds: [
+      "adverbials"
+    ],
+    generator(seed) {
+          const item = FRONTED_FIX_ITEMS[seed % FRONTED_FIX_ITEMS.length];
+          return makeBaseQuestion(this, seed, {
+            marks:2,
+            stemHtml:`<p>${item.prompt}</p><p><strong>${escapeHtml(item.raw)}</strong></p>`,
+            inputSpec:{ type:"textarea", label:"Corrected sentence", placeholder:"Type the corrected sentence here." },
+            solutionLines:[
+              "Spot the opening adverbial telling us when.",
+              "Add a comma after that opening phrase.",
+              `Correct answer: ${item.answer}`
+            ],
+            evaluate:(resp)=>markStringAnswer(resp.answer||"", [item.answer], {
+              maxScore:2,
+              misconception:"fronted_adverbial_confusion",
+              punctuationMisconception:"punctuation_precision",
+              feedbackLong:`The correct sentence is: ${item.answer}`
+            })
+          });
+        }
+  },
+  {
+    id: "subordinate_clause_choice",
+    label: "Identify the subordinate clause",
+    domain: "Clauses",
+    questionType: "identify",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: true,
+    tags: [
+      "identify"
+    ],
+    skillIds: [
+      "clauses"
+    ],
+    generator(seed) {
+          const item = SUBORDINATE_ITEMS[seed % SUBORDINATE_ITEMS.length];
+          return makeBaseQuestion(this, seed, {
+            marks:1,
+            stemHtml:`<p>Which option is the subordinate clause in the sentence below?</p><p><strong>${escapeHtml(item.sentence)}</strong></p>`,
+            inputSpec:{ type:"single_choice", options:item.options.map(x=>({ value:x, label:x })) },
+            solutionLines:[
+              "A subordinate clause often begins with a conjunction such as because, when, if or although.",
+              "It depends on the main clause to complete the full meaning."
+            ],
+            contrastHtml:`<div class="contrast-card"><strong>Useful contrast</strong><p style="margin:8px 0 4px;">Because it was cold, we went inside.</p><p style="margin:0 0 4px;">Because it was cold.</p><p style="margin:0;">The second is only a subordinate clause and cannot stand alone here.</p></div>`,
+            evaluate:(resp)=> mkResult({
+              correct:(resp.answer||"")===item.correct,
+              score:(resp.answer||"")===item.correct ? 1 : 0,
+              maxScore:1,
+              misconception:(resp.answer||"")===item.correct ? null : "subordinate_clause_confusion",
+              feedbackShort:(resp.answer||"")===item.correct ? "Correct." : "Not quite.",
+              feedbackLong:`The subordinate clause is: ${item.correct}.`,
+              answerText:item.correct
+            })
+          });
+        }
+  },
+  {
+    id: "combine_clauses_rewrite",
+    label: "Combine ideas into one sentence",
+    domain: "Clauses",
+    questionType: "rewrite",
+    difficulty: 3,
+    satsFriendly: true,
+    isSelectedResponse: false,
+    tags: [
+      "builder",
+      "surgery"
+    ],
+    skillIds: [
+      "clauses"
+    ],
+    generator(seed) {
+          const item = CLAUSE_COMBINE_ITEMS[seed % CLAUSE_COMBINE_ITEMS.length];
+          return makeBaseQuestion(this, seed, {
+            marks:2,
+            stemHtml:`<p>${item.instruction}</p><p><strong>${item.parts[0]}</strong><br><strong>${item.parts[1]}</strong></p>`,
+            inputSpec:{ type:"textarea", label:"Combined sentence", placeholder:"Write one complete sentence." },
+            solutionLines:item.solution,
+            evaluate:(resp)=>markStringAnswer(resp.answer||"", item.accepted, {
+              maxScore:2,
+              misconception:"subordinate_clause_confusion",
+              punctuationMisconception:"punctuation_precision",
+              feedbackLong:`A correct answer is: ${item.accepted[0]}`
+            })
+          });
+        }
+  },
+  {
+    id: "relative_clause_identify",
+    label: "Spot the relative clause",
+    domain: "Clauses",
+    questionType: "choose",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: true,
+    tags: [
+      "identify"
+    ],
+    skillIds: [
+      "relative_clauses"
+    ],
+    generator(seed) {
+          const item = RELATIVE_SENTENCE_OPTIONS[seed % RELATIVE_SENTENCE_OPTIONS.length];
+          return makeBaseQuestion(this, seed, {
+            marks:1,
+            stemHtml:`<p>Which sentence contains a relative clause?</p>`,
+            inputSpec:{ type:"single_choice", options:item.options.map(x=>({ value:x, label:x })) },
+            solutionLines:[
+              "A relative clause gives extra information about a noun.",
+              "It often begins with who, which, that, where, when or whose."
+            ],
+            evaluate:(resp)=>mkResult({
+              correct:(resp.answer||"")===item.correct,
+              score:(resp.answer||"")===item.correct ? 1 : 0,
+              maxScore:1,
+              misconception:(resp.answer||"")===item.correct ? null : "relative_clause_confusion",
+              feedbackShort:(resp.answer||"")===item.correct ? "Correct." : "Not quite.",
+              feedbackLong:`The correct sentence is: ${item.correct}`,
+              answerText:item.correct
+            })
+          });
+        }
+  },
+  {
+    id: "relative_clause_complete",
+    label: "Complete with a relative clause",
+    domain: "Clauses",
+    questionType: "build",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: true,
+    tags: [
+      "builder"
+    ],
+    skillIds: [
+      "relative_clauses"
+    ],
+    generator(seed) {
+          const item = RELATIVE_COMPLETE_ITEMS[seed % RELATIVE_COMPLETE_ITEMS.length];
+          return makeBaseQuestion(this, seed, {
+            marks:1,
+            stemHtml:`<p>${item.stem}</p><p><strong>${item.sentenceStart} ___ ${item.sentenceEnd}</strong></p>`,
+            inputSpec:{ type:"single_choice", options:item.options.map(x=>({ value:x, label:x })) },
+            solutionLines:[
+              "Choose the clause that adds extra information about the noun and fits the sentence smoothly.",
+              `Correct answer: ${item.correct}`
+            ],
+            evaluate:(resp)=>mkResult({
+              correct:(resp.answer||"")===item.correct,
+              score:(resp.answer||"")===item.correct ? 1 : 0,
+              maxScore:1,
+              misconception:(resp.answer||"")===item.correct ? null : "relative_clause_confusion",
+              feedbackShort:(resp.answer||"")===item.correct ? "Correct." : "Not quite.",
+              feedbackLong:`The best completion is: ${item.correct}.`,
+              answerText:item.correct
+            })
+          });
+        }
+  },
+  {
+    id: "tense_form_choice",
+    label: "Choose the correct verb form",
+    domain: "Verb forms",
+    questionType: "fill",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: true,
+    tags: [
+      "identify"
+    ],
+    skillIds: [
+      "tense_aspect"
+    ],
+    generator(seed) {
+          const item = TENSE_FORM_ITEMS[seed % TENSE_FORM_ITEMS.length];
+          return makeBaseQuestion(this, seed, {
+            marks:1,
+            stemHtml:`<p>${item.prompt}</p><p><strong>${escapeHtml(item.sentence)}</strong></p>`,
+            inputSpec:{ type:"single_choice", options:item.options.map(x=>({ value:x, label:x })) },
+            solutionLines:[
+              "Use the time clues in the sentence.",
+              "Check whether the meaning needs simple, progressive, present perfect or past perfect."
+            ],
+            evaluate:(resp)=>mkResult({
+              correct:(resp.answer||"")===item.correct,
+              score:(resp.answer||"")===item.correct ? 1 : 0,
+              maxScore:1,
+              misconception:(resp.answer||"")===item.correct ? null : "tense_confusion",
+              feedbackShort:(resp.answer||"")===item.correct ? "Correct." : "Not quite.",
+              feedbackLong:`The correct form is: ${item.answerText}.`,
+              answerText:item.answerText
+            })
+          });
+        }
+  },
+  {
+    id: "tense_rewrite",
+    label: "Rewrite in a different tense",
+    domain: "Verb forms",
+    questionType: "rewrite",
+    difficulty: 3,
+    satsFriendly: true,
+    isSelectedResponse: false,
+    tags: [
+      "surgery",
+      "builder"
+    ],
+    skillIds: [
+      "tense_aspect"
+    ],
+    generator(seed) {
+          const item = TENSE_REWRITE_ITEMS[seed % TENSE_REWRITE_ITEMS.length];
+          return makeBaseQuestion(this, seed, {
+            marks:2,
+            stemHtml:`<p>${item.instruction}</p><p><strong>${escapeHtml(item.raw)}</strong></p>`,
+            inputSpec:{ type:"textarea", label:"Rewritten sentence", placeholder:"Write the full sentence." },
+            solutionLines:item.solution,
+            evaluate:(resp)=>markStringAnswer(resp.answer||"", item.accepted, {
+              maxScore:2,
+              misconception:"tense_confusion",
+              punctuationMisconception:"punctuation_precision",
+              feedbackLong:`A correct answer is: ${item.accepted[0]}`
+            })
+          });
+        }
+  },
+  {
+    id: "standard_english_pairs",
+    label: "Choose the Standard English forms",
+    domain: "Standard English",
+    questionType: "choose",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: true,
+    tags: [
+      "identify"
+    ],
+    skillIds: [
+      "standard_english"
+    ],
+    generator(seed) {
+          const item = STANDARD_ENGLISH_ITEMS[seed % STANDARD_ENGLISH_ITEMS.length];
+          return makeBaseQuestion(this, seed, {
+            marks:2,
+            stemHtml:`<p>Choose the correct verb form in each pair to complete the sentences using Standard English.</p>`,
+            inputSpec:{ type:"multi", fields:item.rows.map((r,i)=>({ key:`row${i}`, label:r.label, kind:"radio", options:r.options.map(x=>[x,x]) })) },
+            solutionLines:[
+              "Standard English uses the accepted written verb forms.",
+              "Be careful not to copy a spoken local form into formal writing."
+            ],
+            evaluate:(resp)=>{
+              let correctRows = 0;
+              item.rows.forEach((r,i)=>{ if ((resp[`row${i}`]||"")===r.correct) correctRows += 1; });
+              const score = correctRows === item.rows.length ? 2 : correctRows > 0 ? 1 : 0;
+              const answerText = item.rows.map(r=>r.correct).join("; ");
+              return mkResult({
+                correct: correctRows === item.rows.length,
+                score,
+                maxScore:2,
+                misconception: correctRows === item.rows.length ? null : "standard_english_confusion",
+                feedbackShort: correctRows === item.rows.length ? "Correct." : (score ? "One part is right." : "Not quite."),
+                feedbackLong:`Correct choices: ${answerText}.`,
+                answerText
+              });
+            }
+          });
+        }
+  },
+  {
+    id: "pronoun_cohesion_choice",
+    label: "Choose the clearest cohesive version",
+    domain: "Cohesion",
+    questionType: "choose",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: true,
+    tags: [
+      "identify"
+    ],
+    skillIds: [
+      "pronouns_cohesion"
+    ],
+    generator(seed) {
+          const item = PRONOUN_COHESION_ITEMS[seed % PRONOUN_COHESION_ITEMS.length];
+          return makeBaseQuestion(this, seed, {
+            marks:1,
+            stemHtml:`<p>${item.prompt}</p>`,
+            inputSpec:{ type:"single_choice", options:item.options.map(x=>({ value:x, label:x })) },
+            solutionLines:[
+              "Good cohesion reduces repetition without making the meaning unclear.",
+              "A pronoun must clearly point to the right noun."
+            ],
+            evaluate:(resp)=>mkResult({
+              correct:(resp.answer||"")===item.correct,
+              score:(resp.answer||"")===item.correct ? 1 : 0,
+              maxScore:1,
+              misconception:(resp.answer||"")===item.correct ? null : "pronoun_cohesion_confusion",
+              feedbackShort:(resp.answer||"")===item.correct ? "Correct." : "Not quite.",
+              feedbackLong:`The clearest version is: ${item.correct}`,
+              answerText:item.correct
+            })
+          });
+        }
+  },
+  {
+    id: "formality_pairs",
+    label: "Choose the more formal option",
+    domain: "Register",
+    questionType: "choose",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: true,
+    tags: [
+      "identify"
+    ],
+    skillIds: [
+      "formality"
+    ],
+    generator(seed) {
+          const item = FORMALITY_ITEMS[seed % FORMALITY_ITEMS.length];
+          return makeBaseQuestion(this, seed, {
+            marks:2,
+            stemHtml:`<p>Circle the most formal option in each underlined pair below to complete the passage.</p>`,
+            inputSpec:{ type:"multi", fields:item.rows.map((r,i)=>({ key:`row${i}`, label:r.label, kind:"radio", options:r.options.map(x=>[x,x]) })) },
+            solutionLines:[
+              "Formal language usually uses more precise or less chatty vocabulary.",
+              "The best option depends on the setting and purpose."
+            ],
+            evaluate:(resp)=>{
+              let correctRows = 0;
+              item.rows.forEach((r,i)=>{ if ((resp[`row${i}`]||"")===r.correct) correctRows += 1; });
+              const score = correctRows === item.rows.length ? 2 : correctRows >= 2 ? 1 : 0;
+              const answerText = item.rows.map(r=>r.correct).join("; ");
+              return mkResult({
+                correct: correctRows === item.rows.length,
+                score,
+                maxScore:2,
+                misconception: correctRows === item.rows.length ? null : "formality_confusion",
+                feedbackShort: correctRows === item.rows.length ? "Correct." : (score ? "Some of the formal choices are right." : "Not quite."),
+                feedbackLong:`Correct formal choices: ${answerText}.`,
+                answerText
+              });
+            }
+          });
+        }
+  },
+  {
+    id: "active_passive_rewrite",
+    label: "Transform active and passive voice",
+    domain: "Sentence structure",
+    questionType: "rewrite",
+    difficulty: 3,
+    satsFriendly: true,
+    isSelectedResponse: false,
+    tags: [
+      "builder",
+      "surgery"
+    ],
+    skillIds: [
+      "active_passive"
+    ],
+    generator(seed) {
+          const item = ACTIVE_PASSIVE_ITEMS[seed % ACTIVE_PASSIVE_ITEMS.length];
+          return makeBaseQuestion(this, seed, {
+            marks:2,
+            stemHtml:`<p>${item.instruction}</p><p><strong>${escapeHtml(item.raw)}</strong></p>`,
+            inputSpec:{ type:"textarea", label:"Rewritten sentence", placeholder:"Write the full transformed sentence." },
+            solutionLines:item.solution,
+            evaluate:(resp)=>markStringAnswer(resp.answer||"", item.accepted, {
+              maxScore:2,
+              misconception:"active_passive_confusion",
+              punctuationMisconception:"punctuation_precision",
+              feedbackLong:`A correct answer is: ${item.accepted[0]}`
+            })
+          });
+        }
+  },
+  {
+    id: "subject_object_choice",
+    label: "Identify subject or object",
+    domain: "Sentence structure",
+    questionType: "identify",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: true,
+    tags: [
+      "identify"
+    ],
+    skillIds: [
+      "subject_object"
+    ],
+    generator(seed) {
+          const item = SUBJECT_OBJECT_ITEMS[seed % SUBJECT_OBJECT_ITEMS.length];
+          return makeBaseQuestion(this, seed, {
+            marks:1,
+            stemHtml:`<p>In the sentence below, what is the <strong>${item.ask}</strong>?</p><p><strong>${escapeHtml(item.sentence)}</strong></p>`,
+            inputSpec:{ type:"single_choice", options:item.options.map(x=>({ value:x, label:x })) },
+            solutionLines:[
+              "The subject usually does the action; the object usually receives it.",
+              "Ignore opening adverbials when finding the subject or object."
+            ],
+            evaluate:(resp)=>mkResult({
+              correct:(resp.answer||"")===item.correct,
+              score:(resp.answer||"")===item.correct ? 1 : 0,
+              maxScore:1,
+              misconception:(resp.answer||"")===item.correct ? null : "subject_object_confusion",
+              feedbackShort:(resp.answer||"")===item.correct ? "Correct." : "Not quite.",
+              feedbackLong:`The ${item.ask} is: ${item.correct}.`,
+              answerText:item.correct
+            })
+          });
+        }
+  },
+  {
+    id: "modal_verb_choice",
+    label: "Choose the best modal meaning",
+    domain: "Verb forms",
+    questionType: "choose",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: true,
+    tags: [
+      "identify"
+    ],
+    skillIds: [
+      "modal_verbs"
+    ],
+    generator(seed) {
+          const item = MODAL_ITEMS[seed % MODAL_ITEMS.length];
+          return makeBaseQuestion(this, seed, {
+            marks:1,
+            stemHtml:`<p>${item.prompt}</p>`,
+            inputSpec:{ type:"single_choice", options:item.options.map(x=>({ value:x, label:x })) },
+            solutionLines:[
+              "Compare how certain, likely or strong each modal verb sounds.",
+              "The best answer depends on the meaning, not just the grammar label."
+            ],
+            evaluate:(resp)=>mkResult({
+              correct:(resp.answer||"")===item.correct,
+              score:(resp.answer||"")===item.correct ? 1 : 0,
+              maxScore:1,
+              misconception:(resp.answer||"")===item.correct ? null : "modal_verb_confusion",
+              feedbackShort:(resp.answer||"")===item.correct ? "Correct." : "Not quite.",
+              feedbackLong:`The correct answer is: ${item.correct}.`,
+              answerText:item.correct
+            })
+          });
+        }
+  },
+  {
+    id: "parenthesis_replace_choice",
+    label: "Choose punctuation for parenthesis",
+    domain: "Punctuation for grammar",
+    questionType: "choose",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: true,
+    tags: [
+      "identify"
+    ],
+    skillIds: [
+      "parenthesis_commas"
+    ],
+    generator(seed) {
+          const item = PARENTHESIS_REPLACE_ITEMS[seed % PARENTHESIS_REPLACE_ITEMS.length];
+          return makeBaseQuestion(this, seed, {
+            marks:1,
+            stemHtml:`<p>What punctuation could be used instead of brackets in the sentence below?</p><p><strong>${escapeHtml(item.sentence)}</strong></p>`,
+            inputSpec:{ type:"single_choice", options:item.options.map(x=>({ value:x, label:x })) },
+            solutionLines:[
+              "Brackets, dashes and paired commas can all mark parenthesis in many KS2 contexts.",
+              "Here the best replacement from the options is dashes."
+            ],
+            evaluate:(resp)=>mkResult({
+              correct:(resp.answer||"")===item.correct,
+              score:(resp.answer||"")===item.correct ? 1 : 0,
+              maxScore:1,
+              misconception:(resp.answer||"")===item.correct ? null : "parenthesis_confusion",
+              feedbackShort:(resp.answer||"")===item.correct ? "Correct." : "Not quite.",
+              feedbackLong:`The correct answer is: ${item.correct}.`,
+              answerText:item.correct
+            })
+          });
+        }
+  },
+  {
+    id: "parenthesis_fix_sentence",
+    label: "Insert brackets for parenthesis",
+    domain: "Punctuation for grammar",
+    questionType: "fix",
+    difficulty: 3,
+    satsFriendly: true,
+    isSelectedResponse: false,
+    tags: [
+      "surgery"
+    ],
+    skillIds: [
+      "parenthesis_commas"
+    ],
+    generator(seed) {
+          const item = PARENTHESIS_FIX_ITEMS[seed % PARENTHESIS_FIX_ITEMS.length];
+          return makeBaseQuestion(this, seed, {
+            marks:2,
+            stemHtml:`<p>${item.prompt}</p><p><strong>${escapeHtml(item.raw)}</strong></p>`,
+            inputSpec:{ type:"textarea", label:"Corrected sentence", placeholder:"Type the corrected sentence." },
+            solutionLines:item.solution,
+            evaluate:(resp)=>markStringAnswer(resp.answer||"", item.accepted, {
+              maxScore:2,
+              misconception:"parenthesis_confusion",
+              punctuationMisconception:"punctuation_precision",
+              feedbackLong:`A correct answer is: ${item.accepted[0]}`
+            })
+          });
+        }
+  },
+  {
+    id: "speech_punctuation_fix",
+    label: "Punctuate direct speech",
+    domain: "Punctuation for grammar",
+    questionType: "fix",
+    difficulty: 3,
+    satsFriendly: true,
+    isSelectedResponse: false,
+    tags: [
+      "surgery"
+    ],
+    skillIds: [
+      "speech_punctuation"
+    ],
+    generator(seed) {
+          const item = SPEECH_FIX_ITEMS[seed % SPEECH_FIX_ITEMS.length];
+          return makeBaseQuestion(this, seed, {
+            marks:2,
+            stemHtml:`<p>${item.prompt}</p><p><strong>${escapeHtml(item.raw)}</strong></p>`,
+            inputSpec:{ type:"textarea", label:"Correctly punctuated sentence", placeholder:"Type the corrected sentence." },
+            solutionLines:item.solution,
+            evaluate:(resp)=>markStringAnswer(resp.answer||"", item.accepted, {
+              maxScore:2,
+              misconception:"speech_punctuation_confusion",
+              punctuationMisconception:"punctuation_precision",
+              feedbackLong:`A correct answer is: ${item.accepted[0]}`
+            })
+          });
+        }
+  },
+  {
+    id: "apostrophe_possession_choice",
+    label: "Choose the correct possessive apostrophe",
+    domain: "Punctuation for grammar",
+    questionType: "choose",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: true,
+    tags: [
+      "identify"
+    ],
+    skillIds: [
+      "apostrophes_possession"
+    ],
+    generator(seed) {
+          const item = APOSTROPHE_ITEMS[seed % APOSTROPHE_ITEMS.length];
+          return makeBaseQuestion(this, seed, {
+            marks:1,
+            stemHtml:`<p>${item.stem}</p>`,
+            inputSpec:{ type:"single_choice", options:item.options.map(x=>({ value:x, label:x })) },
+            solutionLines:[
+              "Work out who owns the noun.",
+              "Then decide whether the owner is singular or plural."
+            ],
+            evaluate:(resp)=>mkResult({
+              correct:(resp.answer||"")===item.correct,
+              score:(resp.answer||"")===item.correct ? 1 : 0,
+              maxScore:1,
+              misconception:(resp.answer||"")===item.correct ? null : "apostrophe_possession_confusion",
+              feedbackShort:(resp.answer||"")===item.correct ? "Correct." : "Not quite.",
+              feedbackLong:`The correct answer is: ${item.correct}.`,
+              answerText:item.correct
+            })
+          });
+        }
+  },
+  {
+    id: "explain_reason_choice",
+    label: "Explain why",
+    domain: "Explanation",
+    questionType: "explain",
+    difficulty: 3,
+    satsFriendly: true,
+    isSelectedResponse: true,
+    tags: [
+      "explain"
+    ],
+    skillIds: [
+      "adverbials",
+      "standard_english"
+    ],
+    generator(seed) {
+          const item = EXPLAIN_ITEMS[seed % EXPLAIN_ITEMS.length];
+          return makeBaseQuestion(this, seed, {
+            marks:1,
+            stemHtml:`<p>${item.stem}</p>`,
+            inputSpec:{ type:"single_choice", options:item.options.map(x=>({ value:x, label:x })) },
+            solutionLines:[
+              "Focus on the grammar reason, not just a vague comment that it ‘sounds better’.",
+              "The best explanation names the right feature and why it matters."
+            ],
+            evaluate:(resp)=>mkResult({
+              correct:(resp.answer||"")===item.correct,
+              score:(resp.answer||"")===item.correct ? 1 : 0,
+              maxScore:1,
+              misconception:(resp.answer||"")===item.correct ? null : (item.skillIds[0]==="adverbials" ? "fronted_adverbial_confusion" : "standard_english_confusion"),
+              feedbackShort:(resp.answer||"")===item.correct ? "Correct." : "Not quite.",
+              feedbackLong:`The best explanation is: ${item.correct}.`,
+              answerText:item.correct
+            })
+          });
+        }
+  },
+  {
+    id: "standard_fix_sentence",
+    label: "Rewrite in Standard English",
+    domain: "Standard English",
+    questionType: "fix",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: false,
+    tags: [
+      "surgery"
+    ],
+    skillIds: [
+      "standard_english"
+    ],
+    generator(seed) {
+          const item = STANDARD_FIX_ITEMS[seed % STANDARD_FIX_ITEMS.length];
+          return makeBaseQuestion(this, seed, {
+            marks:2,
+            stemHtml:`<p>${item.instruction}</p><p><strong>${escapeHtml(item.raw)}</strong></p>`,
+            inputSpec:{ type:"textarea", label:"Corrected sentence", placeholder:"Write the corrected sentence." },
+            solutionLines:item.solution,
+            evaluate:(resp)=>markStringAnswer(resp.answer||"", item.accepted, {
+              maxScore:2,
+              misconception:"standard_english_confusion",
+              punctuationMisconception:"punctuation_precision",
+              feedbackLong:`A correct answer is: ${item.accepted[0]}`
+            })
+          });
+        }
+  },
+  {
+    id: "proc_fronted_adverbial_fix",
+    label: "Fix comma after fronted adverbial",
+    domain: "Adverbials",
+    questionType: "fix",
+    difficulty: 1,
+    satsFriendly: true,
+    isSelectedResponse: false,
+    generative: true,
+    tags: [
+      "surgery"
+    ],
+    skillIds: [
+      "adverbials"
+    ],
+    generator(seed) {
+          const rng = mulberry32(seed);
+          const adv = pick(rng, EXTRA_LEXICON.fronted);
+          const clause = proceduralSubjectObject(rng).clause;
+          const raw = ensureSentenceEnd(`${adv} ${clause}`);
+          const accepted = [ensureSentenceEnd(`${adv}, ${clause}`)];
+          return makeBaseQuestion(this, seed, {
+            marks:2,
+            stemHtml:`<p>Rewrite the sentence with the punctuation corrected.</p><p><strong>${escapeHtml(raw)}</strong></p>`,
+            inputSpec:{ type:"textarea", label:"Corrected sentence", placeholder:"Write the corrected sentence." },
+            solutionLines:[
+              "Spot the opening time, place or manner phrase.",
+              "Because the fronted adverbial comes first, place a comma after it.",
+              `A correct answer is: ${accepted[0]}`
+            ],
+            contrastHtml:`<div class="contrast-card"><strong>Useful contrast</strong><p style="margin:8px 0 4px;">${escapeHtml(accepted[0])}</p><p style="margin:0 0 4px;">${escapeHtml(raw)}</p><p style="margin:0;">The comma separates the opening adverbial from the main clause.</p></div>`,
+            evaluate:(resp)=>markStringAnswer(resp.answer || "", accepted, {
+              maxScore:2,
+              misconception:"fronted_adverbial_confusion",
+              punctuationMisconception:"punctuation_precision",
+              feedbackLong:`A correct answer is: ${accepted[0]}`
+            })
+          });
+        }
+  },
+  {
+    id: "proc_semicolon_choice",
+    label: "Choose a semi-colon",
+    domain: "Punctuation for grammar",
+    questionType: "choose",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: true,
+    generative: true,
+    tags: [
+      "identify"
+    ],
+    skillIds: [
+      "boundary_punctuation"
+    ],
+    generator(seed) {
+          const rng = mulberry32(seed);
+          const pair = pick(rng, EXTRA_LEXICON.clausePairs);
+          const correct = ";";
+          const options = [
+            { value:";", label:";" },
+            { value:":", label:":" },
+            { value:",", label:"," },
+            { value:"?", label:"?" }
+          ];
+          return makeBaseQuestion(this, seed, {
+            marks:1,
+            stemHtml:`<p>Which punctuation mark best completes the sentence below?</p><p><strong>${escapeHtml(pair[0])} ___ ${escapeHtml(pair[1])}.</strong></p>`,
+            inputSpec:{ type:"single_choice", label:"Choose one", options },
+            solutionLines:[
+              "Both parts are complete clauses and closely linked in meaning.",
+              "A semi-colon can join closely related main clauses without a conjunction.",
+              `The best answer is: ${pair[0]}; ${pair[1]}.`
+            ],
+            evaluate:(resp)=>mkResult({
+              correct:(resp.answer || "") === correct,
+              score:(resp.answer || "") === correct ? 1 : 0,
+              maxScore:1,
+              misconception:(resp.answer || "") === correct ? null : "boundary_punctuation_confusion",
+              feedbackShort:(resp.answer || "") === correct ? "Correct." : "Not quite.",
+              feedbackLong:`The best answer is: ${pair[0]}; ${pair[1]}.`,
+              answerText:correct
+            })
+          });
+        }
+  },
+  {
+    id: "proc_colon_list_fix",
+    label: "Insert a colon for a list",
+    domain: "Punctuation for grammar",
+    questionType: "fix",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: false,
+    generative: true,
+    tags: [
+      "surgery"
+    ],
+    skillIds: [
+      "boundary_punctuation"
+    ],
+    generator(seed) {
+          const rng = mulberry32(seed);
+          const item = pick(rng, EXTRA_LEXICON.colonLists);
+          const raw = ensureSentenceEnd(`${item.intro} ${item.items.join(", ")}`);
+          const accepted = [ensureSentenceEnd(`${item.intro}: ${item.items.join(", ")}`)];
+          return makeBaseQuestion(this, seed, {
+            marks:2,
+            stemHtml:`<p>Rewrite the sentence with a colon in the correct place.</p><p><strong>${escapeHtml(raw)}</strong></p>`,
+            inputSpec:{ type:"textarea", label:"Corrected sentence", placeholder:"Write the corrected sentence." },
+            solutionLines:[
+              "Check that the words before the list make a complete clause.",
+              "A colon can introduce the list that follows.",
+              `A correct answer is: ${accepted[0]}`
+            ],
+            evaluate:(resp)=>markStringAnswer(resp.answer || "", accepted, {
+              maxScore:2,
+              misconception:"boundary_punctuation_confusion",
+              punctuationMisconception:"punctuation_precision",
+              feedbackLong:`A correct answer is: ${accepted[0]}`
+            })
+          });
+        }
+  },
+  {
+    id: "proc_dash_boundary_fix",
+    label: "Insert a dash to mark a strong break",
+    domain: "Punctuation for grammar",
+    questionType: "fix",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: false,
+    generative: true,
+    tags: [
+      "surgery"
+    ],
+    skillIds: [
+      "boundary_punctuation"
+    ],
+    generator(seed) {
+          const rng = mulberry32(seed);
+          const pair = pick(rng, EXTRA_LEXICON.dashBoundaries);
+          const raw = ensureSentenceEnd(`${pair[0]} ${pair[1]}`);
+          const accepted = dedupePlain([
+            `${pair[0]} – ${pair[1]}.`,
+            `${pair[0]} — ${pair[1]}.`,
+            `${pair[0]} - ${pair[1]}.`
+          ]);
+          return makeBaseQuestion(this, seed, {
+            marks:2,
+            stemHtml:`<p>Rewrite the sentence with a dash in the correct place.</p><p><strong>${escapeHtml(raw)}</strong></p>`,
+            inputSpec:{ type:"textarea", label:"Corrected sentence", placeholder:"Write the corrected sentence." },
+            solutionLines:[
+              "Both parts are strongly linked, and the second part explains or expands the first.",
+              "A dash can mark that strong break.",
+              `A correct answer is: ${accepted[0]}`
+            ],
+            evaluate:(resp)=>markStringAnswer(resp.answer || "", accepted, {
+              maxScore:2,
+              misconception:"boundary_punctuation_confusion",
+              punctuationMisconception:"punctuation_precision",
+              feedbackLong:`A correct answer is: ${accepted[0]}`
+            })
+          });
+        }
+  },
+  {
+    id: "proc_hyphen_ambiguity_choice",
+    label: "Choose the clearer hyphenated sentence",
+    domain: "Punctuation for grammar",
+    questionType: "choose",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: true,
+    generative: true,
+    tags: [
+      "identify"
+    ],
+    skillIds: [
+      "hyphen_ambiguity"
+    ],
+    generator(seed) {
+          const item = EXTRA_LEXICON.hyphenPrompts[seed % EXTRA_LEXICON.hyphenPrompts.length];
+          return makeBaseQuestion(this, seed, {
+            marks:1,
+            stemHtml:`<p>${escapeHtml(item.ask)}</p>`,
+            inputSpec:{ type:"single_choice", label:"Choose one", options:item.options.map(opt => ({ value:opt, label:opt })) },
+            solutionLines:[
+              "Read both versions carefully and compare the meaning.",
+              "The hyphen shows that two words are working together as one describing idea.",
+              item.why
+            ],
+            contrastHtml:`<div class="contrast-card"><strong>Useful contrast</strong><p style="margin:8px 0 4px;">${escapeHtml(item.correct)}</p><p style="margin:0;">${escapeHtml(item.why)}</p></div>`,
+            evaluate:(resp)=>mkResult({
+              correct:(resp.answer || "") === item.correct,
+              score:(resp.answer || "") === item.correct ? 1 : 0,
+              maxScore:1,
+              misconception:(resp.answer || "") === item.correct ? null : "hyphen_ambiguity_confusion",
+              feedbackShort:(resp.answer || "") === item.correct ? "Correct." : "Not quite.",
+              feedbackLong:`The clearer answer is: ${item.correct}`,
+              answerText:item.correct
+            })
+          });
+        }
+  },
+  {
+    id: "proc_speech_punctuation_fix",
+    label: "Fix speech punctuation",
+    domain: "Punctuation for grammar",
+    questionType: "fix",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: false,
+    generative: true,
+    tags: [
+      "surgery"
+    ],
+    skillIds: [
+      "speech_punctuation"
+    ],
+    generator(seed) {
+          const rng = mulberry32(seed);
+          const speaker = pick(rng, EXTRA_LEXICON.speakers);
+          const reporting = pick(rng, EXTRA_LEXICON.reportingVerbs);
+          const mode = seed % 3;
+          let raw = "";
+          let accepted = [];
+          let solutionLines = [];
+          if (mode === 0) {
+            const speech = pick(rng, EXTRA_LEXICON.speechQuestions);
+            raw = `"${speech}" ${reporting} ${speaker}.`;
+            accepted = dedupePlain([`“${speech}?” ${reporting} ${speaker}.`, `"${speech}?" ${reporting} ${speaker}.`]);
+            solutionLines = [
+              "The spoken words are a question.",
+              "The question mark belongs inside the speech marks.",
+              `A correct answer is: ${accepted[0]}`
+            ];
+          } else if (mode === 1) {
+            const speech = pick(rng, EXTRA_LEXICON.speechCommands);
+            raw = `${speaker} ${reporting} "${speech}!"`;
+            accepted = dedupePlain([`${speaker} ${reporting}, “${speech}!”`, `${speaker} ${reporting}, "${speech}!"`]);
+            solutionLines = [
+              "Add a comma before the direct speech after the reporting clause.",
+              "The exclamation mark stays inside the speech marks.",
+              `A correct answer is: ${accepted[0]}`
+            ];
+          } else {
+            const speech = pick(rng, EXTRA_LEXICON.speechExclaims);
+            raw = `"${speech}" ${reporting} ${speaker}.`;
+            accepted = dedupePlain([`“${speech}!” ${reporting} ${speaker}.`, `"${speech}!" ${reporting} ${speaker}.`]);
+            solutionLines = [
+              "The spoken words show strong feeling.",
+              "The exclamation mark belongs inside the speech marks.",
+              `A correct answer is: ${accepted[0]}`
+            ];
+          }
+          return makeBaseQuestion(this, seed, {
+            marks:2,
+            stemHtml:`<p>Punctuate the direct speech correctly.</p><p><strong>${escapeHtml(raw)}</strong></p>`,
+            inputSpec:{ type:"textarea", label:"Correctly punctuated sentence", placeholder:"Type the corrected sentence." },
+            solutionLines,
+            evaluate:(resp)=>markStringAnswer(resp.answer || "", accepted, {
+              maxScore:2,
+              misconception:"speech_punctuation_confusion",
+              punctuationMisconception:"punctuation_precision",
+              feedbackLong:`A correct answer is: ${accepted[0]}`
+            })
+          });
+        }
+  },
+  {
+    id: "proc_apostrophe_possession_choice",
+    label: "Choose the correct possessive apostrophe",
+    domain: "Punctuation for grammar",
+    questionType: "choose",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: true,
+    generative: true,
+    tags: [
+      "identify"
+    ],
+    skillIds: [
+      "apostrophes_possession"
+    ],
+    generator(seed) {
+          const rng = mulberry32(seed);
+          const item = pick(rng, EXTRA_LEXICON.ownedItems);
+          const mode = seed % 3;
+          let options = [];
+          let correct = "";
+          let stem = "";
+          if (mode === 0) {
+            const owner = pick(rng, ["dog","cat","teacher","player","visitor","farmer"]);
+            correct = `the ${owner}'s ${item}`;
+            options = [`the ${owner}s ${item}`, `the ${owner}'s ${item}`, `the ${owner}s' ${item}`, `the ${owner}s's ${item}`];
+            stem = `Choose the correct phrase for one ${owner} and its ${item}.`;
+          } else if (mode === 1) {
+            const owner = pick(rng, EXTRA_LEXICON.pluralOwners);
+            const singular = owner.replace(/s$/, "");
+            correct = `the ${owner}' ${item}`;
+            options = [`the ${singular}'s ${item}`, `the ${owner}' ${item}`, `the ${owner} ${item}`, `the ${owner}'s ${item}`];
+            stem = `Choose the correct phrase for more than one ${singular} and their ${item}.`;
+          } else {
+            const owner = pick(rng, EXTRA_LEXICON.irregularPluralOwners);
+            correct = `the ${owner}'s ${item}`;
+            options = [`the ${owner}s ${item}`, `the ${owner}'s ${item}`, `the ${owner}' ${item}`, `the ${owner} ${item}`];
+            stem = `Choose the correct phrase for ${owner} and their ${item}.`;
+          }
+          options = dedupePlain(options);
+          return makeBaseQuestion(this, seed, {
+            marks:1,
+            stemHtml:`<p>${escapeHtml(stem)}</p>`,
+            inputSpec:{ type:"single_choice", label:"Choose one", options:options.map(opt => ({ value:opt, label:opt })) },
+            solutionLines:[
+              "Ask who owns the noun.",
+              "Then decide whether the owner is singular, a regular plural ending in s, or an irregular plural.",
+              `The correct answer is: ${correct}`
+            ],
+            evaluate:(resp)=>mkResult({
+              correct:(resp.answer || "") === correct,
+              score:(resp.answer || "") === correct ? 1 : 0,
+              maxScore:1,
+              misconception:(resp.answer || "") === correct ? null : "apostrophe_possession_confusion",
+              feedbackShort:(resp.answer || "") === correct ? "Correct." : "Not quite.",
+              feedbackLong:`The correct answer is: ${correct}`,
+              answerText:correct
+            })
+          });
+        }
+  },
+  {
+    id: "proc2_standard_english_choice",
+    label: "Choose Standard English",
+    domain: "Standard English",
+    questionType: "choose",
+    difficulty: 1,
+    satsFriendly: true,
+    isSelectedResponse: true,
+    generative: true,
+    skillIds: [
+      "standard_english"
+    ],
+    generator(seed) {
+          const rng = mulberry32(seed);
+          const item = generateStandardEnglishCase(rng);
+          return makeBaseQuestion(this, seed, {
+            marks:1,
+            stemHtml:`<p>${escapeHtml(item.stem)}</p>`,
+            inputSpec:{ type:"single_choice", label:"Choose one", options:buildChoiceOptions(rng, item.correct, item.distractors) },
+            solutionLines:[
+              "Focus on the verb form that would fit formal written English.",
+              item.why,
+              `The correct answer is: ${item.correct}`
+            ],
+            evaluate:(resp)=>choiceResult(resp, item.correct, 1, `The correct answer is: ${item.correct}`, "standard_english_confusion", item.correct)
+          });
+        }
+  },
+  {
+    id: "proc2_standard_english_fix",
+    label: "Rewrite in Standard English",
+    domain: "Standard English",
+    questionType: "fix",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: false,
+    generative: true,
+    tags: [
+      "surgery"
+    ],
+    skillIds: [
+      "standard_english"
+    ],
+    generator(seed) {
+          const rng = mulberry32(seed);
+          const item = generateStandardEnglishCase(rng);
+          return makeBaseQuestion(this, seed, {
+            marks:2,
+            stemHtml:`<p>Rewrite the sentence in Standard English.</p><p><strong>${escapeHtml(item.raw)}</strong></p>`,
+            inputSpec:{ type:"textarea", label:"Corrected sentence", placeholder:"Write the corrected sentence." },
+            solutionLines:[
+              "Find the non-standard spoken form.",
+              "Replace it with the Standard English verb form.",
+              `A correct answer is: ${item.correct}`
+            ],
+            evaluate:(resp)=>markStringAnswer(resp.answer || "", [item.correct], {
+              maxScore:2,
+              misconception:"standard_english_confusion",
+              feedbackLong:`A correct answer is: ${item.correct}`
+            })
+          });
+        }
+  },
+  {
+    id: "proc2_tense_aspect_choice",
+    label: "Choose the correct tense or aspect",
+    domain: "Verb forms",
+    questionType: "fill",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: true,
+    generative: true,
+    skillIds: [
+      "tense_aspect"
+    ],
+    generator(seed) {
+          const rng = mulberry32(seed);
+          const item = generateTenseCase(rng);
+          return makeBaseQuestion(this, seed, {
+            marks:1,
+            stemHtml:`<p>${escapeHtml(item.stem)}</p>`,
+            inputSpec:{ type:"single_choice", label:"Choose one", options:buildWordOptions(rng, item.correct, item.options.filter(x => x !== item.correct)) },
+            solutionLines:[
+              "Look for the time signal in the sentence.",
+              item.why,
+              `The correct answer is: ${item.correct}`
+            ],
+            evaluate:(resp)=>choiceResult(resp, item.correct, 1, item.answerText, "tense_confusion", item.correct)
+          });
+        }
+  },
+  {
+    id: "proc2_modal_choice",
+    label: "Choose the modal verb",
+    domain: "Verb forms",
+    questionType: "fill",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: true,
+    generative: true,
+    skillIds: [
+      "modal_verbs"
+    ],
+    generator(seed) {
+          const rng = mulberry32(seed);
+          const item = generateModalCase(rng);
+          return makeBaseQuestion(this, seed, {
+            marks:1,
+            stemHtml:`<p>${escapeHtml(item.prompt)}</p>`,
+            inputSpec:{ type:"single_choice", label:"Choose one", options:shuffle(rng, [item.correct].concat(item.distractors)).map(x => ({ value:x, label:x })) },
+            solutionLines:[
+              "Match the modal verb to the meaning: advice, possibility, certainty or obligation.",
+              item.why,
+              `The correct answer is: ${item.correct}`
+            ],
+            evaluate:(resp)=>choiceResult(resp, item.correct, 1, `The correct answer is: ${item.correct}. ${item.why}`, "modal_verb_confusion", item.correct)
+          });
+        }
+  },
+  {
+    id: "proc2_formality_choice",
+    label: "Choose the more formal sentence",
+    domain: "Register",
+    questionType: "choose",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: true,
+    generative: true,
+    skillIds: [
+      "formality"
+    ],
+    generator(seed) {
+          const rng = mulberry32(seed);
+          const item = generateFormalityCase(rng);
+          return makeBaseQuestion(this, seed, {
+            marks:1,
+            stemHtml:`<p>${escapeHtml(item.prompt)}</p>`,
+            inputSpec:{ type:"single_choice", label:"Choose one", options:buildChoiceOptions(rng, item.correct, item.distractors) },
+            solutionLines:[
+              "Formal writing avoids chatty wording and uses more precise vocabulary.",
+              item.why,
+              `The correct answer is: ${item.correct}`
+            ],
+            evaluate:(resp)=>choiceResult(resp, item.correct, 1, `The correct answer is: ${item.correct}`, "formality_confusion", item.correct)
+          });
+        }
+  },
+  {
+    id: "proc2_pronoun_cohesion_choice",
+    label: "Choose the clearer cohesive version",
+    domain: "Cohesion",
+    questionType: "choose",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: true,
+    generative: true,
+    skillIds: [
+      "pronouns_cohesion"
+    ],
+    generator(seed) {
+          const rng = mulberry32(seed);
+          const item = generatePronounCohesionCase(rng);
+          return makeBaseQuestion(this, seed, {
+            marks:1,
+            stemHtml:`<p>${escapeHtml(item.prompt)}</p>`,
+            inputSpec:{ type:"single_choice", label:"Choose one", options:buildChoiceOptions(rng, item.correct, item.distractors) },
+            solutionLines:[
+              "A pronoun should help the sentence flow without making the meaning unclear.",
+              item.why,
+              `The clearest answer is: ${item.correct}`
+            ],
+            evaluate:(resp)=>choiceResult(resp, item.correct, 1, `The clearest answer is: ${item.correct}`, "pronoun_cohesion_confusion", item.correct)
+          });
+        }
+  },
+  {
+    id: "proc2_subject_object_identify",
+    label: "Identify subject or object",
+    domain: "Sentence structure",
+    questionType: "identify",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: true,
+    generative: true,
+    skillIds: [
+      "subject_object"
+    ],
+    generator(seed) {
+          const rng = mulberry32(seed);
+          const item = generateSubjectObjectCase(rng);
+          return makeBaseQuestion(this, seed, {
+            marks:1,
+            stemHtml:`<p>${escapeHtml(item.ask)}</p><p><strong>${escapeHtml(item.sentence)}</strong></p>`,
+            inputSpec:{ type:"single_choice", label:"Choose one", options:shuffle(rng, item.options).map(x => ({ value:x, label:x })) },
+            solutionLines:[
+              "Ask who or what is doing the action. Then ask who or what receives it.",
+              item.why,
+              `The correct answer is: ${item.correct}`
+            ],
+            evaluate:(resp)=>choiceResult(resp, item.correct, 1, `The correct answer is: ${item.correct}`, "subject_object_confusion", item.correct)
+          });
+        }
+  },
+  {
+    id: "proc2_passive_to_active",
+    label: "Rewrite passive as active",
+    domain: "Sentence structure",
+    questionType: "rewrite",
+    difficulty: 3,
+    satsFriendly: true,
+    isSelectedResponse: false,
+    generative: true,
+    tags: [
+      "builder"
+    ],
+    skillIds: [
+      "active_passive"
+    ],
+    generator(seed) {
+          const rng = mulberry32(seed);
+          const item = generatePassiveCase(rng);
+          return makeBaseQuestion(this, seed, {
+            marks:2,
+            stemHtml:`<p>Rewrite the sentence in the active voice.</p><p><strong>${escapeHtml(item.raw)}</strong></p>`,
+            inputSpec:{ type:"textarea", label:"Rewritten sentence", placeholder:"Write the full sentence." },
+            solutionLines:[
+              "Find the doer after ‘by’ in the passive sentence.",
+              "Move that doer into the subject position and keep the tense steady.",
+              `A correct answer is: ${item.accepted[0]}`
+            ],
+            evaluate:(resp)=>markStringAnswer(resp.answer || "", item.accepted, {
+              maxScore:2,
+              misconception:"active_passive_confusion",
+              feedbackLong:`A correct answer is: ${item.accepted[0]}`
+            })
+          });
+        }
+  },
+  {
+    id: "proc2_relative_clause_choice",
+    label: "Choose the sentence with a relative clause",
+    domain: "Clauses",
+    questionType: "identify",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: true,
+    generative: true,
+    skillIds: [
+      "relative_clauses"
+    ],
+    generator(seed) {
+          const rng = mulberry32(seed);
+          const item = generateRelativeClauseCase(rng);
+          return makeBaseQuestion(this, seed, {
+            marks:1,
+            stemHtml:`<p>Which sentence contains a relative clause?</p>`,
+            inputSpec:{ type:"single_choice", label:"Choose one", options:buildChoiceOptions(rng, item.correct, item.distractors) },
+            solutionLines:[
+              "A relative clause adds information about a noun.",
+              item.why,
+              `The correct answer is: ${item.correct}`
+            ],
+            evaluate:(resp)=>choiceResult(resp, item.correct, 1, `The correct answer is: ${item.correct}`, "relative_clause_confusion", item.correct)
+          });
+        }
+  },
+  {
+    id: "proc2_fronted_adverbial_build",
+    label: "Build a sentence with a fronted adverbial",
+    domain: "Adverbials",
+    questionType: "build",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: false,
+    generative: true,
+    tags: [
+      "builder"
+    ],
+    punctStage: "produce",
+    skillIds: [
+      "adverbials"
+    ],
+    generator(seed) {
+          const rng = mulberry32(seed);
+          const adv = pick(rng, EXTRA_LEXICON.fronted);
+          const clause = proceduralSubjectObject(rng).clause;
+          const accepted = [ensureSentenceEnd(`${adv}, ${clause}`)];
+          return makeBaseQuestion(this, seed, {
+            marks:2,
+            stemHtml:`<p>Use this opening phrase and clause to build one correct sentence.</p><p><strong>Opening phrase:</strong> ${escapeHtml(adv)}</p><p><strong>Main clause:</strong> ${escapeHtml(capFirst(clause))}</p>`,
+            inputSpec:{ type:"textarea", label:"Your sentence", placeholder:"Write one complete sentence." },
+            solutionLines:[
+              "Put the fronted adverbial first.",
+              "Add a comma after it before the main clause begins.",
+              `A correct answer is: ${accepted[0]}`
+            ],
+            evaluate:(resp)=>markStringAnswer(resp.answer || "", accepted, {
+              maxScore:2,
+              misconception:"fronted_adverbial_confusion",
+              punctuationMisconception:"punctuation_precision",
+              feedbackLong:`A correct answer is: ${accepted[0]}`
+            })
+          });
+        }
+  },
+  {
+    id: "proc2_boundary_punctuation_explain",
+    label: "Explain boundary punctuation",
+    domain: "Punctuation for grammar",
+    questionType: "explain",
+    difficulty: 3,
+    satsFriendly: true,
+    isSelectedResponse: true,
+    generative: true,
+    punctStage: "produce",
+    skillIds: [
+      "boundary_punctuation"
+    ],
+    generator(seed) {
+          const rng = mulberry32(seed);
+          const mode = seed % 3;
+          let sentence = "";
+          let correct = "";
+          let distractors = [];
+          let why = "";
+          if (mode === 0) {
+            const pair = pick(rng, EXTRA_LEXICON.clausePairs);
+            sentence = `${pair[0]}; ${pair[1]}.`;
+            correct = "A semi-colon can join two closely related main clauses.";
+            distractors = [
+              "A semi-colon introduces direct speech.",
+              "A semi-colon marks a fronted adverbial.",
+              "A semi-colon shows possession."
+            ];
+            why = "Both sides of the semi-colon are complete clauses.";
+          } else if (mode === 1) {
+            const list = pick(rng, EXTRA_LEXICON.colonLists);
+            sentence = `${list.intro}: ${list.items.join(", ")}.`;
+            correct = "The words before the colon make a complete clause and the colon introduces a list.";
+            distractors = [
+              "The colon marks possession.",
+              "The colon shows a question.",
+              "The colon replaces speech marks."
+            ];
+            why = "A colon often comes after a full clause and introduces a list or explanation.";
+          } else {
+            const pair = pick(rng, EXTRA_LEXICON.dashBoundaries);
+            sentence = `${pair[0]} – ${pair[1]}.`;
+            correct = "The dash creates a strong break before an explanation or afterthought.";
+            distractors = [
+              "The dash shows plural possession.",
+              "The dash turns the sentence into a question.",
+              "The dash marks a direct speech tag."
+            ];
+            why = "The dash creates a deliberate strong break in the sentence.";
+          }
+          return makeBaseQuestion(this, seed, {
+            marks:1,
+            stemHtml:`<p>Why is the punctuation in this sentence effective?</p><p><strong>${escapeHtml(sentence)}</strong></p>`,
+            inputSpec:{ type:"single_choice", label:"Choose one", options:buildChoiceOptions(rng, correct, distractors) },
+            solutionLines:[
+              "Look at the relationship between the parts of the sentence.",
+              why,
+              `The best explanation is: ${correct}`
+            ],
+            evaluate:(resp)=>choiceResult(resp, correct, 1, `The best explanation is: ${correct}`, "boundary_punctuation_confusion", correct)
+          });
+        }
+  },
+  {
+    id: "proc3_sentence_function_choice",
+    label: "Choose the sentence function",
+    domain: "Sentence function",
+    questionType: "choose",
+    difficulty: 1,
+    satsFriendly: true,
+    isSelectedResponse: true,
+    generative: true,
+    tags: [
+      "identify"
+    ],
+    skillIds: [
+      "sentence_functions"
+    ],
+    generator(seed) {
+            const rng = mulberry32(seed);
+            const bank = {
+              statement:[
+                "The lantern was still on the bench.",
+                "The choir begins at nine o'clock.",
+                "The path beside the stream was muddy.",
+                "Our team practised in the hall today."
+              ],
+              question:[
+                "Where is the missing torch?",
+                "When does the match begin?",
+                "Why is the gate still open?",
+                "Who packed the blue folder?"
+              ],
+              command:[
+                "Close the gate before the dog runs out.",
+                "Bring the blue folder to the hall.",
+                "Wait by the door for the coach.",
+                "Put the wet boots on the mat."
+              ],
+              exclamation:[
+                "What a noisy drum that is!",
+                "How quickly the clouds moved!",
+                "What an enormous splash that was!",
+                "How bright the lantern looked!"
+              ]
+            };
+            const targets = ["statement","question","command","exclamation"];
+            const target = pick(rng, targets);
+            const targetSentence = pick(rng, bank[target]);
+            const distractors = shuffle(rng, targets.filter(x => x !== target)).map(type => pick(rng, bank[type]));
+            const labels = { statement:"statement", question:"question", command:"command", exclamation:"grammatical exclamation" };
+            return makeBaseQuestion(this, seed, {
+              marks:1,
+              stemHtml:`<p>Which sentence is a <strong>${labels[target]}</strong>?</p>`,
+              inputSpec:{ type:"single_choice", label:"Choose one", options:buildChoiceOptions(rng, targetSentence, distractors) },
+              solutionLines:[
+                "Decide what the whole sentence is doing.",
+                target === "statement" ? "A statement gives information." : target === "question" ? "A question asks something." : target === "command" ? "A command tells someone to do something." : "A grammatical exclamation uses a pattern such as ‘What ...’ or ‘How ...’ to express strong feeling.",
+                `The correct sentence is: ${targetSentence}`
+              ],
+              evaluate:(resp)=>choiceResult(resp, targetSentence, 1, `The correct sentence is: ${targetSentence}`, "sentence_function_confusion", targetSentence)
+            });
+          }
+  },
+  {
+    id: "proc3_word_class_contrast_choice",
+    label: "Choose the correct word class",
+    domain: "Word classes",
+    questionType: "choose",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: true,
+    generative: true,
+    tags: [
+      "identify"
+    ],
+    skillIds: [
+      "word_classes"
+    ],
+    generator(seed) {
+            const rng = mulberry32(seed);
+            const cases = [
+              {
+                stem:"In the sentence <strong>After lunch, Ben hurried inside.</strong>, what is the word <strong>After</strong>?",
+                correct:"preposition",
+                distractors:["adverb","conjunction","determiner"],
+                why:"‘After’ introduces the phrase ‘after lunch’, so it is a preposition."
+              },
+              {
+                stem:"In the sentence <strong>Afterwards, Ben hurried inside.</strong>, what is the word <strong>Afterwards</strong>?",
+                correct:"adverb",
+                distractors:["preposition","conjunction","determiner"],
+                why:"‘Afterwards’ tells us when Ben hurried, so it is an adverb."
+              },
+              {
+                stem:"In the sentence <strong>The muddy boots were by the door.</strong>, what is the word <strong>The</strong>?",
+                correct:"determiner",
+                distractors:["pronoun","adverb","preposition"],
+                why:"‘The’ introduces the noun phrase ‘the muddy boots’, so it is a determiner."
+              },
+              {
+                stem:"In the sentence <strong>Those are muddy.</strong>, what is the word <strong>Those</strong>?",
+                correct:"pronoun",
+                distractors:["determiner","adjective","conjunction"],
+                why:"‘Those’ stands in place of a noun, so it is a pronoun here."
+              },
+              {
+                stem:"In the sentence <strong>We stayed inside because it was raining.</strong>, what is the word <strong>because</strong>?",
+                correct:"conjunction",
+                distractors:["preposition","adverb","determiner"],
+                why:"‘Because’ introduces a subordinate clause, so it is a conjunction."
+              },
+              {
+                stem:"In the sentence <strong>We stayed inside during the storm.</strong>, what is the word <strong>during</strong>?",
+                correct:"preposition",
+                distractors:["conjunction","adverb","pronoun"],
+                why:"‘During’ introduces the phrase ‘during the storm’, so it is a preposition."
+              }
+            ];
+            const item = cases[seed % cases.length];
+            return makeBaseQuestion(this, seed, {
+              marks:1,
+              stemHtml:`<p>${item.stem}</p>`,
+              inputSpec:{ type:"single_choice", label:"Choose one", options:buildChoiceOptions(rng, item.correct, item.distractors) },
+              solutionLines:[
+                "Focus on the word’s job in the sentence, not just its meaning on its own.",
+                item.why,
+                `The correct answer is: ${item.correct}.`
+              ],
+              evaluate:(resp)=>choiceResult(resp, item.correct, 1, item.why, "word_class_confusion", item.correct)
+            });
+          }
+  },
+  {
+    id: "proc3_noun_phrase_build",
+    label: "Build an expanded noun phrase",
+    domain: "Phrases",
+    questionType: "build",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: false,
+    generative: true,
+    tags: [
+      "builder"
+    ],
+    skillIds: [
+      "noun_phrases"
+    ],
+    generator(seed) {
+            const rng = mulberry32(seed);
+            const sizes = ["tiny","large","old","heavy","bright","narrow"];
+            const colours = ["silver","blue","red","green","golden","striped"];
+            const nouns = ["key","lantern","scarf","bucket","trophy","rucksack"];
+            const endings = [
+              "___ was hidden under the bench.",
+              "___ lay beside the tent.",
+              "___ rested near the gate.",
+              "___ was still on the shelf."
+            ];
+            const sizeWord = pick(rng, sizes);
+            const colourWord = pick(rng, colours);
+            const noun = pick(rng, nouns);
+            const sentence = pick(rng, endings);
+            const correct = `the ${sizeWord} ${colourWord} ${noun}`;
+            return makeBaseQuestion(this, seed, {
+              marks:2,
+              stemHtml:`<p>Use all the words to build an <strong>expanded noun phrase</strong> that could complete the sentence.</p><p><strong>Words:</strong> the / ${sizeWord} / ${colourWord} / ${noun}</p><p><strong>${sentence}</strong></p>`,
+              inputSpec:{ type:"text", label:"Expanded noun phrase", placeholder:"Type the noun phrase." },
+              solutionLines:[
+                "Start with the determiner, then add the describing words, then finish with the noun.",
+                `A clear expanded noun phrase is: ${correct}.`,
+                "The whole phrase centres on the noun at the end."
+              ],
+              evaluate:(resp)=>markStringAnswer(resp.answer || "", [correct], {
+                maxScore:2,
+                misconception:"noun_phrase_confusion",
+                punctuationMisconception:"punctuation_precision",
+                feedbackLong:`A correct expanded noun phrase is: ${correct}.`
+              })
+            });
+          }
+  },
+  {
+    id: "proc3_clause_join_rewrite",
+    label: "Join clauses with a conjunction",
+    domain: "Clauses",
+    questionType: "rewrite",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: false,
+    generative: true,
+    tags: [
+      "builder"
+    ],
+    skillIds: [
+      "clauses"
+    ],
+    generator(seed) {
+            const rng = mulberry32(seed);
+            const banks = {
+              because:[
+                ["we stayed inside","it was raining"],
+                ["Ben hurried home","he had forgotten his kit"],
+                ["Mia smiled","she had found the missing map"]
+              ],
+              although:[
+                ["Mia was tired","she finished the race"],
+                ["the path was muddy","the walkers kept going"],
+                ["the room was noisy","Jay carried on reading"]
+              ],
+              when:[
+                ["the bell rang","the pupils lined up"],
+                ["the gate opened","the crowd cheered"],
+                ["the lights went out","everyone fell silent"]
+              ],
+              if:[
+                ["you need help","call the office"],
+                ["the rain starts","go inside the tent"],
+                ["the torch stops working","fetch the spare one"]
+              ]
+            };
+            const conjunction = pick(rng, Object.keys(banks));
+            const pair = pick(rng, banks[conjunction]);
+            const main = pair[0];
+            const sub = pair[1];
+            let accepted;
+            if (conjunction === "because") {
+              accepted = dedupePlain([
+                `${capFirst(main)} because ${sub}.`,
+                `Because ${sub}, ${main}.`
+              ]);
+            } else if (conjunction === "although") {
+              accepted = dedupePlain([
+                `Although ${main}, ${sub}.`,
+                `${capFirst(sub)} although ${main}.`
+              ]);
+            } else if (conjunction === "when") {
+              accepted = dedupePlain([
+                `When ${main}, ${sub}.`,
+                `${capFirst(sub)} when ${main}.`
+              ]);
+            } else {
+              accepted = dedupePlain([
+                `If ${main}, ${sub}.`,
+                `${capFirst(sub)} if ${main}.`
+              ]);
+            }
+            return makeBaseQuestion(this, seed, {
+              marks:2,
+              stemHtml:`<p>Combine these ideas into one sentence using <strong>${conjunction}</strong>.</p><ul><li>${capFirst(main)}.</li><li>${capFirst(sub)}.</li></ul>`,
+              inputSpec:{ type:"textarea", label:"Combined sentence", placeholder:"Write one combined sentence." },
+              solutionLines:[
+                "Use the conjunction to join the ideas so the relationship is clear.",
+                accepted[0],
+                "Check that the sentence is complete and punctuated as one whole sentence."
+              ],
+              evaluate:(resp)=>markStringAnswer(resp.answer || "", accepted, {
+                maxScore:2,
+                misconception:"subordinate_clause_confusion",
+                punctuationMisconception:"punctuation_precision",
+                feedbackLong:`A correct answer is: ${accepted[0]}`
+              })
+            });
+          }
+  },
+  {
+    id: "proc3_parenthesis_commas_fix",
+    label: "Add commas for parenthesis",
+    domain: "Punctuation for grammar",
+    questionType: "fix",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: false,
+    generative: true,
+    punctStage: "repair",
+    tags: [
+      "surgery"
+    ],
+    skillIds: [
+      "parenthesis_commas"
+    ],
+    generator(seed) {
+            const items = [
+              {
+                raw:"Ben after a short pause opened the gate.",
+                accepted:"Ben, after a short pause, opened the gate.",
+                why:"The extra phrase ‘after a short pause’ is parenthesis, so commas mark it off."
+              },
+              {
+                raw:"The map in my opinion needs replacing.",
+                accepted:"The map, in my opinion, needs replacing.",
+                why:"The phrase ‘in my opinion’ is extra information, so commas mark it off."
+              },
+              {
+                raw:"Our new puppy to my surprise slept through the storm.",
+                accepted:"Our new puppy, to my surprise, slept through the storm.",
+                why:"The phrase ‘to my surprise’ adds extra information, so commas show the parenthesis."
+              },
+              {
+                raw:"The coach without any warning changed the teams.",
+                accepted:"The coach, without any warning, changed the teams.",
+                why:"The phrase ‘without any warning’ is inserted as extra information here."
+              }
+            ];
+            const item = items[seed % items.length];
+            return makeBaseQuestion(this, seed, {
+              marks:2,
+              stemHtml:`<p>Add commas to show the <strong>parenthesis</strong>.</p><p><strong>${escapeHtml(item.raw)}</strong></p>`,
+              inputSpec:{ type:"textarea", label:"Corrected sentence", placeholder:"Type the corrected sentence." },
+              solutionLines:[
+                "Find the extra information that could be lifted out.",
+                item.why,
+                `A correct answer is: ${item.accepted}`
+              ],
+              evaluate:(resp)=>markStringAnswer(resp.answer || "", [item.accepted], {
+                maxScore:2,
+                misconception:"parenthesis_confusion",
+                punctuationMisconception:"punctuation_precision",
+                feedbackLong:`A correct answer is: ${item.accepted}`
+              })
+            });
+          }
+  },
+  {
+    id: "proc3_hyphen_fix_meaning",
+    label: "Use a hyphen to make the meaning clear",
+    domain: "Punctuation for grammar",
+    questionType: "fix",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: false,
+    generative: true,
+    punctStage: "produce",
+    tags: [
+      "surgery"
+    ],
+    skillIds: [
+      "hyphen_ambiguity"
+    ],
+    generator(seed) {
+            const items = [
+              {
+                raw:"We visited the small animal hospital after lunch.",
+                accepted:"We visited the small-animal hospital after lunch.",
+                why:"The hyphen shows that the hospital is for small animals."
+              },
+              {
+                raw:"We saw a man eating shark near the rocks.",
+                accepted:"We saw a man-eating shark near the rocks.",
+                why:"The hyphen shows that the shark eats people."
+              },
+              {
+                raw:"The class made a last minute poster for the hall.",
+                accepted:"The class made a last-minute poster for the hall.",
+                why:"The hyphen joins the words into one describing idea before the noun."
+              },
+              {
+                raw:"She bought a sugar free drink for the journey.",
+                accepted:"She bought a sugar-free drink for the journey.",
+                why:"The hyphen joins the words into one describing idea before the noun."
+              }
+            ];
+            const item = items[seed % items.length];
+            return makeBaseQuestion(this, seed, {
+              marks:2,
+              stemHtml:`<p>Rewrite the sentence with a <strong>hyphen</strong> to make the meaning clear.</p><p><strong>${escapeHtml(item.raw)}</strong></p>`,
+              inputSpec:{ type:"textarea", label:"Corrected sentence", placeholder:"Type the corrected sentence." },
+              solutionLines:[
+                "Find the words that work together as one describing idea before the noun.",
+                item.why,
+                `A correct answer is: ${item.accepted}`
+              ],
+              evaluate:(resp)=>markStringAnswer(resp.answer || "", [item.accepted], {
+                maxScore:2,
+                misconception:"punctuation_precision",
+                punctuationMisconception:"punctuation_precision",
+                feedbackLong:`A correct answer is: ${item.accepted}`
+              })
+            });
+          }
+  },
+  {
+    id: "proc3_apostrophe_rewrite",
+    label: "Rewrite with a possessive apostrophe",
+    domain: "Punctuation for grammar",
+    questionType: "rewrite",
+    difficulty: 2,
+    satsFriendly: true,
+    isSelectedResponse: false,
+    generative: true,
+    punctStage: "produce",
+    tags: [
+      "builder"
+    ],
+    skillIds: [
+      "apostrophes_possession"
+    ],
+    generator(seed) {
+            const rng = mulberry32(seed);
+            const item = pick(rng, EXTRA_LEXICON.ownedItems);
+            const kind = randInt(rng, 0, 2);
+            let prompt, accepted, why;
+            if (kind === 0) {
+              const owner = pick(rng, EXTRA_LEXICON.names.filter(name => !/s$/i.test(name)));
+              prompt = `the ${item} belonging to ${owner}`;
+              accepted = `${owner}'s ${item}`;
+              why = "A singular owner usually takes apostrophe + s.";
+            } else if (kind === 1) {
+              const owner = pick(rng, EXTRA_LEXICON.pluralOwners);
+              prompt = `the ${item} belonging to the ${owner}`;
+              accepted = `the ${owner}' ${item}`;
+              why = "A regular plural owner ending in s usually takes an apostrophe after the s.";
+            } else {
+              const owner = pick(rng, EXTRA_LEXICON.irregularPluralOwners);
+              prompt = `the ${item} belonging to the ${owner}`;
+              accepted = `the ${owner}'s ${item}`;
+              why = "An irregular plural owner that does not end in s usually takes apostrophe + s.";
+            }
+            return makeBaseQuestion(this, seed, {
+              marks:2,
+              stemHtml:`<p>Rewrite this phrase using the correct <strong>possessive apostrophe</strong>.</p><p><strong>${escapeHtml(prompt)}</strong></p>`,
+              inputSpec:{ type:"text", label:"Rewritten phrase", placeholder:"Type the rewritten phrase." },
+              solutionLines:[
+                "Work out who owns the noun.",
+                why,
+                `A correct answer is: ${accepted}`
+              ],
+              evaluate:(resp)=>markStringAnswer(resp.answer || "", [accepted], {
+                maxScore:2,
+                misconception:"apostrophe_possession_confusion",
+                punctuationMisconception:"punctuation_precision",
+                feedbackLong:`A correct answer is: ${accepted}`
+              })
+            });
+          }
+  }
+];
+
+function clamp(n, min, max) {
+  return Math.min(max, Math.max(min, n));
+}
+
+function randInt(rng, min, max) {
+  return Math.floor(rng() * (max - min + 1)) + min;
+}
+
+function pick(rng, arr) {
+  return arr[randInt(rng, 0, arr.length - 1)];
+}
+
+function shuffle(rng, arr) {
+  const copy = arr.slice();
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+}
+
+function sampleMany(rng, arr, n) {
+  return shuffle(rng, arr).slice(0, n);
+}
+
+function mulberry32(seed) {
+  let t = seed >>> 0;
+  return function() {
+    t += 0x6D2B79F5;
+    let r = Math.imul(t ^ (t >>> 15), 1 | t);
+    r ^= r + Math.imul(r ^ (r >>> 7), 61 | r);
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function cleanSpaces(value) {
+  return String(value || "")
+    .replace(/[“”]/g, '"')
+    .replace(/[‘’]/g, "'")
+    .replace(/\s+/g, ' ')
+    .replace(/\s+([,.;:!?])/g, '$1')
+    .replace(/\(\s+/g, '(')
+    .replace(/\s+\)/g, ')')
+    .trim();
+}
+
+function lowerClean(value) {
+  return cleanSpaces(value).toLowerCase();
+}
+
+function sentenceBare(value) {
+  return lowerClean(value).replace(/[.,!?;:'"()\-]/g, '');
+}
+
+function compareAnswerString(actual, acceptedList) {
+  const actualNorm = lowerClean(actual);
+  const exact = acceptedList.some(x => lowerClean(x) === actualNorm);
+  const bare = acceptedList.some(x => sentenceBare(x) === sentenceBare(actual));
+  return { exact, bare };
+}
+
+function setEq(a, b) {
+  const A = [...new Set(a)].map(String).sort();
+  const B = [...new Set(b)].map(String).sort();
+  return A.length === B.length && A.every((v,i)=>v===B[i]);
+}
+
+function mkResult({correct, score, maxScore, misconception, feedbackShort, feedbackLong, answerText, minimalHint}) {
+  return {
+    correct: !!correct,
+    score,
+    maxScore,
+    misconception: misconception || null,
+    feedbackShort: feedbackShort || "",
+    feedbackLong: feedbackLong || "",
+    answerText: answerText || "",
+    minimalHint: minimalHint || MINIMAL_HINTS[misconception] || "Check the sentence structure and the instruction again."
+  };
+}
+
+function markStringAnswer(respText, acceptedList, opts = {}) {
+  const cmp = compareAnswerString(respText, acceptedList);
+  const fullMarks = opts.maxScore || 2;
+  const exactText = acceptedList[0];
+  if (cmp.exact) {
+    return mkResult({
+      correct:true,
+      score:fullMarks,
+      maxScore:fullMarks,
+      feedbackShort:"Correct.",
+      feedbackLong: opts.feedbackLong || `Correct answer: ${exactText}`,
+      answerText: exactText
+    });
+  }
+  if (cmp.bare && fullMarks > 1) {
+    return mkResult({
+      correct:false,
+      score:fullMarks - 1,
+      maxScore:fullMarks,
+      misconception: opts.punctuationMisconception || "punctuation_precision",
+      feedbackShort:"The grammar idea is close, but the exact punctuation or wording is not fully correct.",
+      feedbackLong: opts.feedbackLong || `Correct answer: ${exactText}`,
+      answerText: exactText
+    });
+  }
+  return mkResult({
+    correct:false,
+    score:0,
+    maxScore:fullMarks,
+    misconception: opts.misconception || "misread_question",
+    feedbackShort:"Not quite.",
+    feedbackLong: opts.feedbackLong || `Correct answer: ${exactText}`,
+    answerText: exactText
+  });
+}
+
+function makeBaseQuestion(template, seed, data) {
+  return Object.assign({
+    templateId: template.id,
+    templateLabel: template.label,
+    domain: template.domain,
+    skillIds: template.skillIds.slice(),
+    questionType: template.questionType,
+    seed,
+    itemId: `${template.id}:${seed}`,
+    marks: 1,
+    visualHtml: "",
+    reflectionPrompt: "",
+    checkLine: "",
+    contrastHtml: ""
+  }, data || {});
+}
+
+function capFirst(text) {
+  const s = cleanSpaces(text);
+  return s ? s.charAt(0).toUpperCase() + s.slice(1) : s;
+}
+
+function ensureSentenceEnd(text, end = ".") {
+  let s = cleanSpaces(text).replace(/[.?!]+$/, "");
+  return s + end;
+}
+
+function quoteVariants(inner) {
+  const clean = cleanSpaces(inner);
+  return [`“${clean}”`, `"${clean}"`];
+}
+
+function dedupePlain(arr) {
+  const seen = new Set();
+  const out = [];
+  for (const item of arr || []) {
+    const clean = cleanSpaces(item);
+    const key = clean.toLowerCase();
+    if (!clean || seen.has(key)) continue;
+    seen.add(key);
+    out.push(clean);
+  }
+  return out;
+}
+
+function proceduralSubjectObject(rng) {
+  const name = pick(rng, EXTRA_LEXICON.names);
+  const object = pick(rng, EXTRA_LEXICON.objects);
+  const verbs = [
+    { past:"carried", base:"carry" },
+    { past:"opened", base:"open" },
+    { past:"packed", base:"pack" },
+    { past:"dropped", base:"drop" },
+    { past:"found", base:"find" },
+    { past:"lifted", base:"lift" },
+    { past:"cleaned", base:"clean" },
+    { past:"locked", base:"lock" }
+  ];
+  const verb = pick(rng, verbs);
+  return {
+    name,
+    object,
+    verb,
+    clause: `${name} ${verb.past} ${object}`
+  };
+}
+
+function buildChoiceOptions(rng, correct, distractors) {
+  return shuffle(rng, dedupePlain([correct].concat(distractors))).map(text => ({ value:text, label:text }));
+}
+
+function buildWordOptions(rng, correct, distractors) {
+  return shuffle(rng, dedupePlain([correct].concat(distractors))).map(text => ({ value:text, label:text }));
+}
+
+function choiceResult(resp, correct, maxScore, why, misconception, answerText) {
+  const ok = (resp.answer || "") === correct;
+  return mkResult({
+    correct: ok,
+    score: ok ? maxScore : 0,
+    maxScore,
+    misconception: ok ? null : misconception,
+    feedbackShort: ok ? "Correct." : "Not quite.",
+    feedbackLong: why,
+    answerText: answerText || correct
+  });
+}
+
+function generateStandardEnglishCase(rng) {
+  const kind = randInt(rng, 0, 3);
+  if (kind === 0) {
+    const phrase = pick(rng, ["waiting by the gate","walking home after lunch","standing near the hall","ready for the start"]);
+    const subject = pick(rng, ["We","They","The players","The visitors"]);
+    return {
+      stem:"Which sentence is written in Standard English?",
+      correct:`${subject} were ${phrase}.`,
+      distractors:[`${subject} was ${phrase}.`, `${subject} is ${phrase}.`, `${subject} be ${phrase}.`],
+      why:`With this plural subject, Standard English uses ‘were’.`,
+      raw:`${subject} was ${phrase}.`
+    };
+  }
+  if (kind === 1) {
+    const obj = pick(rng, ["my homework","the poster","my reading record","the map work"]);
+    return {
+      stem:"Which sentence is written in Standard English?",
+      correct:`I did ${obj} before tea.`,
+      distractors:[`I done ${obj} before tea.`, `I do ${obj} before tea.`, `I have did ${obj} before tea.`],
+      why:"Standard English uses ‘did’ here.",
+      raw:`I done ${obj} before tea.`
+    };
+  }
+  if (kind === 2) {
+    const name = pick(rng, EXTRA_LEXICON.names);
+    const ending = pick(rng, ["the answer yet","where the hall is","why the gate is locked","how to fold the map"]);
+    return {
+      stem:"Which sentence is written in Standard English?",
+      correct:`${name} doesn't know ${ending}.`,
+      distractors:[`${name} don't know ${ending}.`, `${name} didn't know ${ending}.`, `${name} not know ${ending}.`],
+      why:"With a singular subject in the present, Standard English uses ‘doesn't’.",
+      raw:`${name} don't know ${ending}.`
+    };
+  }
+  const name = pick(rng, EXTRA_LEXICON.names);
+  const thing = pick(rng, ["the comet","the notice","the trophy","the lost glove"]);
+  const time = pick(rng, ["last night","yesterday","on Monday","after school"]);
+  return {
+    stem:"Which sentence is written in Standard English?",
+    correct:`${name} saw ${thing} ${time}.`,
+    distractors:[`${name} seen ${thing} ${time}.`, `${name} has saw ${thing} ${time}.`, `${name} see ${thing} ${time}.`],
+    why:"In Standard English, the simple past form here is ‘saw’.",
+    raw:`${name} seen ${thing} ${time}.`
+  };
+}
+
+function generateTenseCase(rng) {
+  const verb = pick(rng, EXTRA_LEXICON.verbsRich.filter(v => v.base !== "carry"));
+  const object = pick(rng, ["the project","the bag","the poster","the display","the plan"]);
+  const singular = rng() < 0.5;
+  const subject = singular ? pick(rng, [pick(rng, EXTRA_LEXICON.names), "She", "He"]) : pick(rng, ["They","We","The pupils"]);
+  const have = (subject === "They" || subject === "We" || subject === "The pupils") ? "have" : "has";
+  const be = (subject === "They" || subject === "We" || subject === "The pupils") ? "are" : "is";
+  const kind = randInt(rng, 0, 2);
+  if (kind === 0) {
+    const signal = pick(rng, ["already","just","today"]);
+    return {
+      stem:`Choose the verb form that best completes the sentence: ${subject} ___ ${object} ${signal}.`,
+      correct:`${have} ${verb.part}`,
+      options:[`${have} ${verb.part}`, verb.past, `had ${verb.part}`, `${be} ${verb.ing}`],
+      why:"The present perfect links an earlier action to the present.",
+      answerText:`${subject} ${have} ${verb.part} ${object} ${signal}.`
+    };
+  }
+  if (kind === 1) {
+    const time = pick(rng, ["yesterday","last night","on Monday","before lunch yesterday"]);
+    return {
+      stem:`Choose the verb form that best completes the sentence: ${time}, ${subject} ___ ${object}.`,
+      correct:verb.past,
+      options:[verb.past, `${have} ${verb.part}`, `had ${verb.part}`, `${be} ${verb.ing}`],
+      why:"A finished time expression such as ‘yesterday’ calls for the simple past.",
+      answerText:`${capFirst(time)}, ${subject} ${verb.past} ${object}.`
+    };
+  }
+  const laterEvent = pick(rng, ["the bell rang","the coach arrived","the rain started","the lesson began"]);
+  return {
+    stem:`Choose the verb form that best completes the sentence: By the time ${laterEvent}, ${subject} ___ ${object}.`,
+    correct:`had ${verb.part}`,
+    options:[`had ${verb.part}`, verb.past, `${have} ${verb.part}`, `${be} ${verb.ing}`],
+    why:"The past perfect shows an earlier past action before another past event.",
+    answerText:`By the time ${laterEvent}, ${subject} had ${verb.part} ${object}.`
+  };
+}
+
+function generatePassiveCase(rng) {
+  const agent = pick(rng, EXTRA_LEXICON.names);
+  const obj = pick(rng, EXTRA_LEXICON.objects);
+  const verb = pick(rng, EXTRA_LEXICON.verbsRich.filter(v => ["open","pack","carry","lift","paint","clean","wash"].includes(v.base)));
+  const tail = pick(rng, ["", " before lunch", " after the match", " this morning"]);
+  if (seededBool(rng)) {
+    return {
+      raw:`${capFirst(obj)} was ${verb.part} by ${agent}${tail}.`,
+      accepted:[`${agent} ${verb.past} ${obj}${tail}.`],
+      why:"To rewrite in the active, move the doer into the subject position and keep the tense the same."
+    };
+  }
+  return {
+    raw:`${capFirst(obj)} is ${verb.part} by ${agent}${tail}.`,
+    accepted:[`${agent} ${verb.s} ${obj}${tail}.`],
+    why:"Keep the tense steady when moving from passive to active voice."
+  };
+}
+
+function seededBool(rng) { return rng() < 0.5; }
+
+function generateRelativeClauseCase(rng) {
+  const kind = randInt(rng, 0, 1);
+  if (kind === 0) {
+    const noun = pick(rng, ["runner","teacher","boy","girl"]);
+    const detail = pick(rng, ["who wore a blue cap","who was first in line","who had lost a glove","who carried the flag"]);
+    const correct = `The ${noun} ${detail} waved to the crowd.`;
+    const distractors = [
+      `When the ${noun} wore a blue cap, the crowd waved.`,
+      `The ${noun} in a blue cap waved to the crowd.`,
+      `The ${noun} waved to the crowd quickly.`
+    ];
+    return { correct, distractors, why:"A relative clause adds information about a noun, here using ‘who’." };
+  }
+  const noun = pick(rng, ["book","bag","tent","coat"]);
+  const detail = pick(rng, ["that everyone wanted","which Ben packed carefully","that belonged to the club","which stood by the window"]);
+  const correct = `The ${noun} ${detail} was easy to spot.`;
+  const distractors = [
+    `When everyone wanted the ${noun}, it was easy to spot.`,
+    `The club ${noun} was easy to spot.`,
+    `The ${noun} was easy to spot outside.`
+  ];
+  return { correct, distractors, why:"A relative clause gives extra information about the noun using words such as ‘that’ or ‘which’." };
+}
+
+function generatePronounCohesionCase(rng) {
+  const a = pick(rng, EXTRA_LEXICON.names);
+  const b = pick(rng, EXTRA_LEXICON.names.filter(n => n !== a));
+  const item = pick(rng, ["map","torch","ticket","glove","note"]);
+  const reason = pick(rng, [
+    `${b} was leaving first`,
+    `${a} had found it earlier`,
+    `${b} needed it for the next lesson`,
+    `${a} was carrying too many bags`
+  ]);
+  let correct = "";
+  let distractors = [];
+  if (reason.includes(b)) {
+    correct = `${a} gave ${b} the ${item} because ${b} ${reason.split(`${b} `)[1]}.`;
+    distractors = [
+      `${a} gave ${b} the ${item} because she ${reason.split(`${b} `)[1]}.`,
+      `${a} gave ${b} it because ${b} ${reason.split(`${b} `)[1]}.`,
+      `${a} gave the ${item} to her because ${b} ${reason.split(`${b} `)[1]}.`
+    ];
+  } else {
+    correct = `${a} gave ${b} the ${item} because ${a} ${reason.split(`${a} `)[1]}.`;
+    distractors = [
+      `${a} gave ${b} the ${item} because she ${reason.split(`${a} `)[1]}.`,
+      `${a} gave ${b} it because ${a} ${reason.split(`${a} `)[1]}.`,
+      `${a} gave the ${item} to ${b} because she ${reason.split(`${a} `)[1]}.`
+    ];
+  }
+  return { prompt:"Which version keeps the meaning clearest?", correct, distractors, why:"Good cohesion avoids unnecessary repetition without making the referent unclear." };
+}
+
+function generateSubjectObjectCase(rng) {
+  const adv = pick(rng, EXTRA_LEXICON.fronted);
+  const subject = pick(rng, EXTRA_LEXICON.names);
+  const verb = pick(rng, EXTRA_LEXICON.verbsRich.filter(v => ["carry","pack","open","wash","paint","lift","clean"].includes(v.base)));
+  const object = pick(rng, EXTRA_LEXICON.objects);
+  const tail = pick(rng, ["across the yard","before the lesson","after the bell","into the hall"]);
+  const sentence = `${adv}, ${subject} ${verb.past} ${object} ${tail}.`;
+  const askForObject = rng() < 0.5;
+  const correct = askForObject ? object : subject;
+  const options = askForObject
+    ? [object, subject, adv, tail]
+    : [subject, object, adv, tail];
+  return {
+    sentence,
+    ask: askForObject ? "Which words are the object in this sentence?" : "Which word or words are the subject in this sentence?",
+    correct,
+    options,
+    why: askForObject
+      ? "The object receives the action. The subject does the action."
+      : "The subject is the person or thing doing the action."
+  };
+}
+
+function generateFormalityCase(rng) {
+  return EXTRA_LEXICON.formalFrames[seededIndex(rng, EXTRA_LEXICON.formalFrames.length)];
+}
+
+function generateModalCase(rng) {
+  return EXTRA_LEXICON.modalFrames[seededIndex(rng, EXTRA_LEXICON.modalFrames.length)];
+}
+
+function seededIndex(rng, len) { return Math.max(0, Math.min(len - 1, Math.floor(rng() * len))); }
+
+function isPunctuationSkill(skillId) {
+  return PUNCTUATION_SKILL_IDS.includes(skillId);
+}
+
+const TEMPLATE_MAP = Object.fromEntries(TEMPLATES.map(template => [template.id, template]));
+
+function stripLegacyHtml(value) {
+  return cleanSpaces(String(value || '')
+    .replace(/<br\s*\/?>/gi, ' ')
+    .replace(/<\/p>/gi, ' ')
+    .replace(/<\/li>/gi, ' ')
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"'));
+}
+
+function cloneSerialisable(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function serialiseInputSpec(inputSpec) {
+  if (!inputSpec || typeof inputSpec !== 'object' || Array.isArray(inputSpec)) return null;
+  return cloneSerialisable(inputSpec);
+}
+
+export const GRAMMAR_CONTENT_RELEASE_ID = 'grammar-legacy-reviewed-2026-04-24';
+export const GRAMMAR_MISCONCEPTIONS = Object.freeze(MISCONCEPTIONS);
+export const GRAMMAR_MINIMAL_HINTS = Object.freeze(MINIMAL_HINTS);
+export const GRAMMAR_QUESTION_TYPES = Object.freeze(QUESTION_TYPES);
+export const GRAMMAR_PUNCTUATION_CONCEPT_IDS = Object.freeze(PUNCTUATION_SKILL_IDS.slice());
+export const GRAMMAR_CONCEPTS = Object.freeze(Object.entries(SKILLS).map(([id, skill]) => Object.freeze({
+  id,
+  domain: skill.domain,
+  name: skill.name,
+  summary: skill.summary,
+  notices: Object.freeze((skill.notices || []).slice()),
+  worked: Object.freeze({ ...(skill.worked || {}) }),
+  contrast: Object.freeze({ ...(skill.contrast || {}) }),
+  punctuationForGrammar: PUNCTUATION_SKILL_IDS.includes(id),
+})));
+export const GRAMMAR_TEMPLATES = Object.freeze(TEMPLATES);
+export const GRAMMAR_TEMPLATE_MAP = Object.freeze(TEMPLATE_MAP);
+
+export function grammarTemplateMetadata(template = {}) {
+  return {
+    id: template.id,
+    label: template.label,
+    domain: template.domain,
+    questionType: template.questionType,
+    difficulty: Number(template.difficulty) || 1,
+    satsFriendly: Boolean(template.satsFriendly),
+    isSelectedResponse: Boolean(template.isSelectedResponse),
+    generative: Boolean(template.generative),
+    tags: Object.freeze((template.tags || []).slice()),
+    skillIds: Object.freeze((template.skillIds || []).slice()),
+  };
+}
+
+export const GRAMMAR_TEMPLATE_METADATA = Object.freeze(GRAMMAR_TEMPLATES.map(grammarTemplateMetadata));
+
+export function grammarConceptById(conceptId) {
+  return GRAMMAR_CONCEPTS.find((concept) => concept.id === conceptId) || null;
+}
+
+export function grammarTemplateById(templateId) {
+  return GRAMMAR_TEMPLATE_MAP[templateId] || null;
+}
+
+export function createGrammarQuestion({ templateId, seed } = {}) {
+  const template = grammarTemplateById(templateId);
+  if (!template || typeof template.generator !== 'function') return null;
+  return template.generator(Number(seed) || 0);
+}
+
+export function evaluateGrammarQuestion(question, response = {}) {
+  if (!question || typeof question.evaluate !== 'function') return null;
+  return question.evaluate(response && typeof response === 'object' && !Array.isArray(response) ? response : {});
+}
+
+export function serialiseGrammarQuestion(question) {
+  if (!question || typeof question !== 'object' || Array.isArray(question)) return null;
+  return {
+    contentReleaseId: GRAMMAR_CONTENT_RELEASE_ID,
+    templateId: question.templateId,
+    templateLabel: question.templateLabel,
+    domain: question.domain,
+    skillIds: (question.skillIds || []).slice(),
+    questionType: question.questionType,
+    seed: Number(question.seed) || 0,
+    itemId: question.itemId,
+    marks: Number(question.marks) || 1,
+    promptText: stripLegacyHtml(question.stemHtml),
+    inputSpec: serialiseInputSpec(question.inputSpec),
+    solutionLines: (question.solutionLines || []).map(stripLegacyHtml),
+    reflectionPrompt: stripLegacyHtml(question.reflectionPrompt || ''),
+    checkLine: stripLegacyHtml(question.checkLine || ''),
+    replay: {
+      contentReleaseId: GRAMMAR_CONTENT_RELEASE_ID,
+      templateId: question.templateId,
+      seed: Number(question.seed) || 0,
+      itemId: question.itemId,
+      conceptIds: (question.skillIds || []).slice(),
+      questionType: question.questionType,
+    },
+  };
+}

--- a/worker/src/subjects/grammar/engine.js
+++ b/worker/src/subjects/grammar/engine.js
@@ -17,6 +17,9 @@ const SUBJECT_ID = 'grammar';
 const SERVER_AUTHORITY = 'worker';
 const DEFAULT_ROUND_LENGTH = 5;
 const DEFAULT_MINI_SET_LENGTH = 8;
+const SHORT_RESPONSE_TEXT_LIMIT = 512;
+const LONG_RESPONSE_TEXT_LIMIT = 2000;
+const LIST_RESPONSE_LIMIT = 40;
 const ENABLED_MODES = new Set(['learn', 'smart', 'satsset']);
 const LOCKED_MODES = Object.freeze(['trouble', 'surgery', 'builder', 'worked', 'faded']);
 const GRAMMAR_CONCEPT_IDS = new Set(GRAMMAR_CONCEPTS.map((concept) => concept.id));
@@ -40,6 +43,90 @@ function isGrammarConceptId(value) {
 
 function normaliseStoredFocusConceptId(value) {
   return isGrammarConceptId(value) ? value : '';
+}
+
+function cappedString(value, limit = SHORT_RESPONSE_TEXT_LIMIT) {
+  const text = value == null ? '' : String(value);
+  return text.length > limit ? text.slice(0, limit) : text;
+}
+
+function optionValue(option) {
+  if (Array.isArray(option)) return cappedString(option[0]);
+  if (isPlainObject(option)) return cappedString(option.value);
+  return cappedString(option);
+}
+
+function optionValueSet(options) {
+  return new Set(Array.isArray(options) ? options.map(optionValue) : []);
+}
+
+function normaliseChoiceValue(value, allowedValues) {
+  const text = cappedString(value);
+  return allowedValues.size && !allowedValues.has(text) ? '' : text;
+}
+
+function normaliseSelectedValues(value, allowedValues) {
+  if (!Array.isArray(value)) return [];
+  const maxItems = Math.min(
+    LIST_RESPONSE_LIMIT,
+    allowedValues.size || LIST_RESPONSE_LIMIT,
+  );
+  const selected = [];
+  const seen = new Set();
+  for (const item of value.slice(0, LIST_RESPONSE_LIMIT * 2)) {
+    const text = cappedString(item);
+    if ((allowedValues.size && !allowedValues.has(text)) || seen.has(text)) continue;
+    selected.push(text);
+    seen.add(text);
+    if (selected.length >= maxItems) break;
+  }
+  return selected;
+}
+
+function normaliseFieldResponse(field, value) {
+  const allowedValues = optionValueSet(field?.options);
+  if (allowedValues.size) return normaliseChoiceValue(value, allowedValues);
+  return cappedString(value, field?.kind === 'textarea' ? LONG_RESPONSE_TEXT_LIMIT : SHORT_RESPONSE_TEXT_LIMIT);
+}
+
+function normaliseGrammarResponse(inputSpec, response) {
+  const raw = isPlainObject(response) ? response : {};
+  const spec = isPlainObject(inputSpec) ? inputSpec : {};
+
+  if (spec.type === 'single_choice') {
+    return { answer: normaliseChoiceValue(raw.answer, optionValueSet(spec.options)) };
+  }
+
+  if (spec.type === 'checkbox_list') {
+    return { selected: normaliseSelectedValues(raw.selected, optionValueSet(spec.options)) };
+  }
+
+  if (spec.type === 'table_choice') {
+    const allowedValues = optionValueSet(spec.columns);
+    const output = {};
+    for (const row of Array.isArray(spec.rows) ? spec.rows.slice(0, LIST_RESPONSE_LIMIT) : []) {
+      const key = typeof row?.key === 'string' ? row.key : '';
+      if (!key) continue;
+      output[key] = normaliseChoiceValue(raw[key], allowedValues);
+    }
+    return output;
+  }
+
+  if (spec.type === 'multi') {
+    const output = {};
+    for (const field of Array.isArray(spec.fields) ? spec.fields.slice(0, LIST_RESPONSE_LIMIT) : []) {
+      const key = typeof field?.key === 'string' ? field.key : '';
+      if (!key) continue;
+      output[key] = normaliseFieldResponse(field, raw[key]);
+    }
+    return output;
+  }
+
+  if (spec.type === 'text') {
+    return { answer: cappedString(raw.answer, SHORT_RESPONSE_TEXT_LIMIT) };
+  }
+
+  return { answer: cappedString(raw.answer, LONG_RESPONSE_TEXT_LIMIT) };
 }
 
 function stableHash(value) {
@@ -613,7 +700,8 @@ export function applyGrammarAttemptToState(state, {
       templateId: item.templateId,
     });
   }
-  const result = evaluateGrammarQuestion(question, response);
+  const normalisedResponse = normaliseGrammarResponse(question.inputSpec, response);
+  const result = evaluateGrammarQuestion(question, normalisedResponse);
   if (!result) {
     throw new BadRequestError('Grammar answer could not be marked.', {
       code: 'grammar_answer_invalid',
@@ -645,7 +733,7 @@ export function applyGrammarAttemptToState(state, {
     seed: question.seed,
     questionType: question.questionType,
     conceptIds,
-    response: cloneSerialisable(response) || {},
+    response: cloneSerialisable(normalisedResponse) || {},
     result: cloneSerialisable(result) || {},
     supportLevel,
     attempts,
@@ -697,7 +785,7 @@ export function applyGrammarAttemptToState(state, {
       });
     }
   }
-  return { result, quality, events, attempt };
+  return { result, quality, events, attempt, response: normalisedResponse };
 }
 
 function submitAnswer(state, payload, command, nowTs) {
@@ -735,7 +823,7 @@ function submitAnswer(state, payload, command, nowTs) {
     itemId: session.currentItem.itemId,
     templateId: session.currentItem.templateId,
     result: cloneSerialisable(applied.result),
-    response: cloneSerialisable(response) || {},
+    response: cloneSerialisable(applied.response) || {},
     canContinue: session.answered < session.targetCount,
   };
   return applied.events;

--- a/worker/src/subjects/grammar/engine.js
+++ b/worker/src/subjects/grammar/engine.js
@@ -19,6 +19,7 @@ const DEFAULT_ROUND_LENGTH = 5;
 const DEFAULT_MINI_SET_LENGTH = 8;
 const ENABLED_MODES = new Set(['learn', 'smart', 'satsset']);
 const LOCKED_MODES = Object.freeze(['trouble', 'surgery', 'builder', 'worked', 'faded']);
+const GRAMMAR_CONCEPT_IDS = new Set(GRAMMAR_CONCEPTS.map((concept) => concept.id));
 
 function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -31,6 +32,14 @@ function timestamp(now = Date.now) {
 
 function clamp(number, min, max) {
   return Math.min(max, Math.max(min, number));
+}
+
+function isGrammarConceptId(value) {
+  return typeof value === 'string' && GRAMMAR_CONCEPT_IDS.has(value);
+}
+
+function normaliseStoredFocusConceptId(value) {
+  return isGrammarConceptId(value) ? value : '';
 }
 
 function stableHash(value) {
@@ -95,11 +104,15 @@ function normaliseNodeMap(value) {
 
 export function normaliseServerGrammarData(rawValue) {
   const raw = isPlainObject(rawValue) ? rawValue : {};
+  const prefs = isPlainObject(raw.prefs) ? cloneSerialisable(raw.prefs) : {};
   return {
     contentReleaseId: typeof raw.contentReleaseId === 'string' && raw.contentReleaseId
       ? raw.contentReleaseId
       : GRAMMAR_CONTENT_RELEASE_ID,
-    prefs: isPlainObject(raw.prefs) ? cloneSerialisable(raw.prefs) : {},
+    prefs: {
+      ...prefs,
+      focusConceptId: normaliseStoredFocusConceptId(prefs.focusConceptId),
+    },
     mastery: {
       concepts: normaliseNodeMap(raw.mastery?.concepts),
       templates: normaliseNodeMap(raw.mastery?.templates),
@@ -158,6 +171,7 @@ export function createInitialGrammarState(data = {}) {
 function normaliseGrammarState(rawState, data = {}) {
   const fallback = createInitialGrammarState(data);
   if (!isPlainObject(rawState)) return fallback;
+  const rawPrefs = isPlainObject(rawState.prefs) ? cloneSerialisable(rawState.prefs) : {};
   const normalisedData = normaliseServerGrammarData({
     ...data,
     prefs: rawState.prefs || data.prefs,
@@ -175,7 +189,10 @@ function normaliseGrammarState(rawState, data = {}) {
     awaitingAdvance: Boolean(rawState.awaitingAdvance),
     prefs: {
       ...fallback.prefs,
-      ...(isPlainObject(rawState.prefs) ? cloneSerialisable(rawState.prefs) : {}),
+      ...rawPrefs,
+      focusConceptId: Object.prototype.hasOwnProperty.call(rawPrefs, 'focusConceptId')
+        ? normaliseStoredFocusConceptId(rawPrefs.focusConceptId)
+        : fallback.prefs.focusConceptId,
     },
     mastery: normalisedData.mastery,
     retryQueue: normalisedData.retryQueue,
@@ -431,10 +448,14 @@ export function buildGrammarMiniSet({ size = DEFAULT_MINI_SET_LENGTH, focusConce
 
 function startSession(state, payload, nowTs, learnerId) {
   const mode = supportedModeOrThrow(normaliseMode(payload.mode || state.prefs.mode));
-  const focusConceptId = typeof payload.focusConceptId === 'string'
+  const hasPayloadFocusConcept = typeof payload.focusConceptId === 'string' || typeof payload.skillId === 'string';
+  const requestedFocusConceptId = typeof payload.focusConceptId === 'string'
     ? payload.focusConceptId
-    : (typeof payload.skillId === 'string' ? payload.skillId : state.prefs.focusConceptId || '');
-  if (focusConceptId && !GRAMMAR_CONCEPTS.some((concept) => concept.id === focusConceptId)) {
+    : (typeof payload.skillId === 'string' ? payload.skillId : '');
+  const focusConceptId = hasPayloadFocusConcept
+    ? requestedFocusConceptId
+    : normaliseStoredFocusConceptId(state.prefs.focusConceptId);
+  if (focusConceptId && !isGrammarConceptId(focusConceptId)) {
     throw new BadRequestError('Grammar concept is not available.', {
       code: 'grammar_concept_not_found',
       subjectId: SUBJECT_ID,
@@ -723,11 +744,15 @@ function submitAnswer(state, payload, command, nowTs) {
 function savePrefs(state, payload) {
   const prefs = isPlainObject(payload.prefs) ? payload.prefs : payload;
   const nextMode = prefs.mode ? normaliseMode(prefs.mode) : state.prefs.mode;
+  const hasFocusConcept = Object.prototype.hasOwnProperty.call(prefs, 'focusConceptId');
+  const nextFocusConceptId = hasFocusConcept
+    ? normaliseStoredFocusConceptId(prefs.focusConceptId)
+    : normaliseStoredFocusConceptId(state.prefs.focusConceptId);
   state.prefs = {
     ...state.prefs,
     mode: ENABLED_MODES.has(nextMode) ? nextMode : state.prefs.mode,
     roundLength: roundLengthFor(nextMode, prefs, state.prefs),
-    focusConceptId: typeof prefs.focusConceptId === 'string' ? prefs.focusConceptId : state.prefs.focusConceptId,
+    focusConceptId: nextFocusConceptId,
   };
   return [];
 }

--- a/worker/src/subjects/grammar/engine.js
+++ b/worker/src/subjects/grammar/engine.js
@@ -1,0 +1,790 @@
+import {
+  cloneSerialisable,
+  normalisePracticeSessionRecord,
+} from '../../../../src/platform/core/repositories/helpers.js';
+import { BadRequestError, NotFoundError } from '../../errors.js';
+import {
+  createGrammarQuestion,
+  evaluateGrammarQuestion,
+  GRAMMAR_CONCEPTS,
+  GRAMMAR_CONTENT_RELEASE_ID,
+  GRAMMAR_TEMPLATE_METADATA,
+  grammarTemplateById,
+  serialiseGrammarQuestion,
+} from './content.js';
+
+const SUBJECT_ID = 'grammar';
+const SERVER_AUTHORITY = 'worker';
+const DEFAULT_ROUND_LENGTH = 5;
+const DEFAULT_MINI_SET_LENGTH = 8;
+const ENABLED_MODES = new Set(['learn', 'smart', 'satsset']);
+const LOCKED_MODES = Object.freeze(['trouble', 'surgery', 'builder', 'worked', 'faded']);
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function timestamp(now = Date.now) {
+  const value = typeof now === 'function' ? Number(now()) : Number(now);
+  return Number.isFinite(value) ? value : Date.now();
+}
+
+function clamp(number, min, max) {
+  return Math.min(max, Math.max(min, number));
+}
+
+function stableHash(value) {
+  const text = String(value || '');
+  let hash = 2166136261;
+  for (let index = 0; index < text.length; index += 1) {
+    hash ^= text.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function seededRandom(seed) {
+  let t = seed >>> 0;
+  return function random() {
+    t += 0x6D2B79F5;
+    let r = Math.imul(t ^ (t >>> 15), 1 | t);
+    r ^= r + Math.imul(r ^ (r >>> 7), 61 | r);
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function defaultMasteryNode() {
+  return {
+    attempts: 0,
+    correct: 0,
+    wrong: 0,
+    strength: 0.25,
+    intervalDays: 0,
+    dueAt: 0,
+    lastSeenAt: null,
+    lastWrongAt: null,
+    correctStreak: 0,
+  };
+}
+
+function normaliseNode(value) {
+  const raw = isPlainObject(value) ? value : {};
+  const node = defaultMasteryNode();
+  for (const key of Object.keys(node)) {
+    if (key.endsWith('At') && key !== 'dueAt') {
+      node[key] = typeof raw[key] === 'string' ? raw[key] : null;
+    } else {
+      const number = Number(raw[key]);
+      node[key] = Number.isFinite(number) ? number : node[key];
+    }
+  }
+  node.attempts = Math.max(0, Math.floor(node.attempts));
+  node.correct = Math.max(0, Math.floor(node.correct));
+  node.wrong = Math.max(0, Math.floor(node.wrong));
+  node.correctStreak = Math.max(0, Math.floor(node.correctStreak));
+  node.strength = clamp(node.strength, 0.02, 0.99);
+  node.intervalDays = Math.max(0, node.intervalDays);
+  node.dueAt = Math.max(0, node.dueAt);
+  return node;
+}
+
+function normaliseNodeMap(value) {
+  const raw = isPlainObject(value) ? value : {};
+  return Object.fromEntries(Object.entries(raw).map(([key, node]) => [key, normaliseNode(node)]));
+}
+
+export function normaliseServerGrammarData(rawValue) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  return {
+    contentReleaseId: typeof raw.contentReleaseId === 'string' && raw.contentReleaseId
+      ? raw.contentReleaseId
+      : GRAMMAR_CONTENT_RELEASE_ID,
+    prefs: isPlainObject(raw.prefs) ? cloneSerialisable(raw.prefs) : {},
+    mastery: {
+      concepts: normaliseNodeMap(raw.mastery?.concepts),
+      templates: normaliseNodeMap(raw.mastery?.templates),
+      questionTypes: normaliseNodeMap(raw.mastery?.questionTypes),
+      items: normaliseNodeMap(raw.mastery?.items),
+    },
+    retryQueue: Array.isArray(raw.retryQueue)
+      ? raw.retryQueue.filter((entry) => isPlainObject(entry) && entry.templateId && Number.isFinite(Number(entry.seed))).map((entry) => ({
+        templateId: String(entry.templateId),
+        seed: Number(entry.seed),
+        dueAt: Number(entry.dueAt) || 0,
+        conceptIds: Array.from(new Set((entry.conceptIds || entry.skillIds || []).map(String).filter(Boolean))),
+        reason: typeof entry.reason === 'string' ? entry.reason : 'recent-miss',
+      }))
+      : [],
+    misconceptions: isPlainObject(raw.misconceptions) ? cloneSerialisable(raw.misconceptions) : {},
+    recentAttempts: Array.isArray(raw.recentAttempts) ? raw.recentAttempts.slice(-80).map(cloneSerialisable) : [],
+  };
+}
+
+export function grammarConceptStatus(node, now = Date.now()) {
+  const current = Number(now) || Date.now();
+  const value = normaliseNode(node);
+  if (!value.attempts) return 'new';
+  if (value.strength < 0.42 || value.wrong > value.correct + 1) return 'weak';
+  if ((value.dueAt || 0) <= current) return 'due';
+  if (value.strength >= 0.82 && value.intervalDays >= 7 && value.correctStreak >= 3) return 'secured';
+  return 'learning';
+}
+
+export function createInitialGrammarState(data = {}) {
+  const normalisedData = normaliseServerGrammarData(data);
+  return {
+    subjectId: SUBJECT_ID,
+    version: 1,
+    contentReleaseId: normalisedData.contentReleaseId,
+    serverAuthority: SERVER_AUTHORITY,
+    phase: 'dashboard',
+    awaitingAdvance: false,
+    prefs: {
+      mode: normalisedData.prefs.mode || 'smart',
+      roundLength: Number(normalisedData.prefs.roundLength) || DEFAULT_ROUND_LENGTH,
+      focusConceptId: normalisedData.prefs.focusConceptId || '',
+    },
+    mastery: normalisedData.mastery,
+    retryQueue: normalisedData.retryQueue,
+    misconceptions: normalisedData.misconceptions,
+    recentAttempts: normalisedData.recentAttempts,
+    session: null,
+    feedback: null,
+    summary: null,
+    error: '',
+  };
+}
+
+function normaliseGrammarState(rawState, data = {}) {
+  const fallback = createInitialGrammarState(data);
+  if (!isPlainObject(rawState)) return fallback;
+  const normalisedData = normaliseServerGrammarData({
+    ...data,
+    prefs: rawState.prefs || data.prefs,
+    mastery: rawState.mastery || data.mastery,
+    retryQueue: rawState.retryQueue || data.retryQueue,
+    misconceptions: rawState.misconceptions || data.misconceptions,
+    recentAttempts: rawState.recentAttempts || data.recentAttempts,
+  });
+  return {
+    ...fallback,
+    contentReleaseId: typeof rawState.contentReleaseId === 'string' && rawState.contentReleaseId
+      ? rawState.contentReleaseId
+      : normalisedData.contentReleaseId,
+    phase: typeof rawState.phase === 'string' ? rawState.phase : fallback.phase,
+    awaitingAdvance: Boolean(rawState.awaitingAdvance),
+    prefs: {
+      ...fallback.prefs,
+      ...(isPlainObject(rawState.prefs) ? cloneSerialisable(rawState.prefs) : {}),
+    },
+    mastery: normalisedData.mastery,
+    retryQueue: normalisedData.retryQueue,
+    misconceptions: normalisedData.misconceptions,
+    recentAttempts: normalisedData.recentAttempts,
+    session: isPlainObject(rawState.session) ? cloneSerialisable(rawState.session) : null,
+    feedback: isPlainObject(rawState.feedback) ? cloneSerialisable(rawState.feedback) : null,
+    summary: isPlainObject(rawState.summary) ? cloneSerialisable(rawState.summary) : null,
+    error: typeof rawState.error === 'string' ? rawState.error : '',
+    serverAuthority: rawState.serverAuthority === SERVER_AUTHORITY ? SERVER_AUTHORITY : null,
+  };
+}
+
+function stateData(state) {
+  return {
+    contentReleaseId: state.contentReleaseId,
+    prefs: cloneSerialisable(state.prefs) || {},
+    mastery: cloneSerialisable(state.mastery) || {},
+    retryQueue: cloneSerialisable(state.retryQueue) || [],
+    misconceptions: cloneSerialisable(state.misconceptions) || {},
+    recentAttempts: cloneSerialisable(state.recentAttempts) || [],
+  };
+}
+
+function ensureNode(map, key) {
+  if (!map[key]) map[key] = defaultMasteryNode();
+  return map[key];
+}
+
+function updateNodeFromQuality(node, quality, nowTs) {
+  node.attempts += 1;
+  node.lastSeenAt = new Date(nowTs).toISOString();
+  if (quality >= 4.8) {
+    node.correct += 1;
+    node.correctStreak += 1;
+    node.strength = clamp(node.strength + 0.13, 0.05, 0.99);
+    node.intervalDays = node.intervalDays ? Math.min(45, node.intervalDays * 2) : 1;
+    node.dueAt = nowTs + node.intervalDays * 86400000;
+  } else if (quality >= 4) {
+    node.correct += 1;
+    node.correctStreak += 1;
+    node.strength = clamp(node.strength + 0.09, 0.05, 0.98);
+    node.intervalDays = node.intervalDays ? Math.min(28, node.intervalDays * 1.7) : 1;
+    node.dueAt = nowTs + node.intervalDays * 86400000;
+  } else if (quality >= 3) {
+    node.correct += 1;
+    node.correctStreak = Math.max(1, node.correctStreak);
+    node.strength = clamp(node.strength + 0.04, 0.05, 0.95);
+    node.intervalDays = node.intervalDays ? Math.max(0.25, node.intervalDays * 0.9) : 0.25;
+    node.dueAt = nowTs + Math.max(6 * 3600000, node.intervalDays * 86400000);
+  } else {
+    node.wrong += 1;
+    node.correctStreak = 0;
+    node.strength = clamp(node.strength - (quality > 0 ? 0.08 : 0.15), 0.02, 0.95);
+    node.intervalDays = Math.max(0.04, (node.intervalDays || 0.2) * 0.45);
+    node.dueAt = nowTs + (quality > 0 ? 20 : 12) * 60000;
+    node.lastWrongAt = new Date(nowTs).toISOString();
+  }
+}
+
+function answerQuality(result, attempt = {}) {
+  const attempts = Math.max(1, Number(attempt.attempts) || 1);
+  const support = Math.max(0, Number(attempt.supportLevel) || 0);
+  if (result.correct) {
+    if (support >= 2) return 3;
+    if (support === 1) return attempts === 1 ? 3.4 : 3;
+    if (attempts === 1) return 5;
+    if (attempts === 2) return 3.6;
+    return 3.2;
+  }
+  if (Number(result.score) > 0) return 1.5;
+  return 0;
+}
+
+function bumpMisconception(state, tag, nowTs) {
+  if (!tag) return;
+  const current = isPlainObject(state.misconceptions[tag]) ? state.misconceptions[tag] : { count: 0, lastSeenAt: null };
+  state.misconceptions[tag] = {
+    count: (Number(current.count) || 0) + 1,
+    lastSeenAt: new Date(nowTs).toISOString(),
+  };
+}
+
+function enqueueRetry(state, item, result, nowTs) {
+  const dueAt = nowTs + (result.correct ? 6 * 3600000 : 15 * 60000);
+  const key = `${item.templateId}::${item.seed}`;
+  const existing = state.retryQueue.find((entry) => `${entry.templateId}::${entry.seed}` === key);
+  if (existing) {
+    existing.dueAt = Math.min(Number(existing.dueAt) || dueAt, dueAt);
+    existing.conceptIds = Array.from(new Set([...(existing.conceptIds || []), ...(item.skillIds || [])]));
+    if (!result.correct) existing.reason = 'recent-miss';
+  } else {
+    state.retryQueue.push({
+      templateId: item.templateId,
+      seed: item.seed,
+      dueAt,
+      conceptIds: (item.skillIds || []).slice(),
+      reason: result.correct ? 'supported-or-shaky' : 'recent-miss',
+    });
+  }
+  state.retryQueue = state.retryQueue
+    .filter((entry) => entry && entry.templateId)
+    .sort((a, b) => Number(a.dueAt) - Number(b.dueAt))
+    .slice(0, 120);
+}
+
+function templateFits(template, { mode, focusConceptId } = {}) {
+  if (!template) return false;
+  if (mode === 'satsset' && !template.satsFriendly) return false;
+  if (focusConceptId && !(template.skillIds || []).includes(focusConceptId)) return false;
+  return true;
+}
+
+function weightedTemplatePick(state, { mode, focusConceptId, seed, nowTs = Date.now() }) {
+  const rng = seededRandom(seed);
+  const candidates = GRAMMAR_TEMPLATE_METADATA.filter((template) => templateFits(template, { mode, focusConceptId }));
+  const pool = candidates.length ? candidates : GRAMMAR_TEMPLATE_METADATA;
+  const weighted = pool.map((template) => {
+    const conceptNodes = template.skillIds.map((id) => state.mastery.concepts[id] || defaultMasteryNode());
+    const averageStrength = conceptNodes.reduce((sum, node) => sum + (Number(node.strength) || 0.25), 0) / Math.max(1, conceptNodes.length);
+    const statuses = conceptNodes.map((node) => grammarConceptStatus(node, nowTs));
+    let weight = 1 + (1 - averageStrength) * 4;
+    if (statuses.includes('new')) weight += 1.5;
+    if (statuses.includes('weak')) weight += 2;
+    if (statuses.includes('due')) weight += 1.4;
+    if (focusConceptId && template.skillIds.includes(focusConceptId)) weight *= 1.8;
+    if (template.generative) weight *= 1.15;
+    return [template, Math.max(0.05, weight)];
+  });
+  let roll = rng() * weighted.reduce((sum, item) => sum + item[1], 0);
+  for (const [template, weight] of weighted) {
+    roll -= weight;
+    if (roll <= 0) return grammarTemplateById(template.id);
+  }
+  return grammarTemplateById(weighted.at(-1)?.[0]?.id || GRAMMAR_TEMPLATE_METADATA[0].id);
+}
+
+function takeDueRetry(state, { mode, focusConceptId, nowTs }) {
+  const index = state.retryQueue.findIndex((entry) => {
+    if (Number(entry.dueAt) > nowTs) return false;
+    const template = grammarTemplateById(entry.templateId);
+    return templateFits(template, { mode, focusConceptId });
+  });
+  if (index < 0) return null;
+  return state.retryQueue.splice(index, 1)[0] || null;
+}
+
+function itemFromTemplate(template, seed) {
+  const question = createGrammarQuestion({ templateId: template.id, seed });
+  if (!question) {
+    throw new NotFoundError('Grammar template is not available.', {
+      code: 'grammar_template_not_found',
+      subjectId: SUBJECT_ID,
+      templateId: template.id,
+    });
+  }
+  return serialiseGrammarQuestion(question);
+}
+
+function nextItem(state, { mode, focusConceptId, seed, templateId = '', nowTs = Date.now() } = {}) {
+  if (templateId) {
+    const template = grammarTemplateById(templateId);
+    if (!template) {
+      throw new NotFoundError('Grammar template is not available.', {
+        code: 'grammar_template_not_found',
+        subjectId: SUBJECT_ID,
+        templateId,
+      });
+    }
+    return itemFromTemplate(template, seed);
+  }
+  const retry = takeDueRetry(state, { mode, focusConceptId, nowTs });
+  if (retry) return itemFromTemplate(grammarTemplateById(retry.templateId), retry.seed);
+  return itemFromTemplate(weightedTemplatePick(state, { mode, focusConceptId, seed, nowTs }), seed);
+}
+
+function normaliseMode(value) {
+  const mode = String(value || 'smart').trim().toLowerCase().replace(/[\s_]+/g, '-');
+  if (mode === 'mini-set' || mode === 'mini' || mode === 'test') return 'satsset';
+  return mode || 'smart';
+}
+
+function supportedModeOrThrow(mode) {
+  if (ENABLED_MODES.has(mode)) return mode;
+  throw new BadRequestError('This Grammar mode is not enabled yet.', {
+    code: 'grammar_mode_unsupported',
+    subjectId: SUBJECT_ID,
+    mode,
+  });
+}
+
+function roundLengthFor(mode, payload = {}, prefs = {}) {
+  const fallback = mode === 'satsset' ? DEFAULT_MINI_SET_LENGTH : DEFAULT_ROUND_LENGTH;
+  const raw = Number(payload.length ?? payload.roundLength ?? prefs.roundLength ?? fallback);
+  return clamp(Number.isFinite(raw) ? Math.floor(raw) : fallback, 1, mode === 'satsset' ? 20 : 15);
+}
+
+function buildActiveRecord(learnerId, state, nowTs) {
+  if (!state.session || !['session', 'feedback'].includes(state.phase)) return null;
+  return normalisePracticeSessionRecord({
+    id: state.session.id,
+    learnerId,
+    subjectId: SUBJECT_ID,
+    sessionKind: state.session.mode,
+    status: 'active',
+    sessionState: cloneSerialisable(state.session),
+    summary: null,
+    createdAt: state.session.startedAt || nowTs,
+    updatedAt: nowTs,
+  });
+}
+
+function buildCompletedRecord(learnerId, state, latestSession, nowTs) {
+  if (state.phase !== 'summary' || !state.summary) return null;
+  return normalisePracticeSessionRecord({
+    id: state.summary.sessionId || latestSession?.id || `grammar-${nowTs}`,
+    learnerId,
+    subjectId: SUBJECT_ID,
+    sessionKind: state.summary.mode || latestSession?.sessionKind || 'smart',
+    status: 'completed',
+    sessionState: null,
+    summary: cloneSerialisable(state.summary),
+    createdAt: latestSession?.createdAt || state.summary.startedAt || nowTs,
+    updatedAt: nowTs,
+  });
+}
+
+function practiceSessionRecord(learnerId, state, latestSession, nowTs) {
+  return buildActiveRecord(learnerId, state, nowTs) || buildCompletedRecord(learnerId, state, latestSession, nowTs);
+}
+
+function miniSetSeeds(baseSeed, size) {
+  return Array.from({ length: size }, (_, index) => (baseSeed + index * 104729) >>> 0);
+}
+
+export function buildGrammarMiniSet({ size = DEFAULT_MINI_SET_LENGTH, focusConceptId = '', seed = 1 } = {}) {
+  const length = clamp(Math.floor(Number(size) || DEFAULT_MINI_SET_LENGTH), 1, 20);
+  const state = createInitialGrammarState();
+  return miniSetSeeds(Number(seed) || 1, length).map((itemSeed, index) => {
+    const template = weightedTemplatePick(state, {
+      mode: 'satsset',
+      focusConceptId,
+      seed: itemSeed + index,
+    });
+    return itemFromTemplate(template, itemSeed + index);
+  });
+}
+
+function startSession(state, payload, nowTs) {
+  const mode = supportedModeOrThrow(normaliseMode(payload.mode || state.prefs.mode));
+  const focusConceptId = typeof payload.focusConceptId === 'string'
+    ? payload.focusConceptId
+    : (typeof payload.skillId === 'string' ? payload.skillId : state.prefs.focusConceptId || '');
+  if (focusConceptId && !GRAMMAR_CONCEPTS.some((concept) => concept.id === focusConceptId)) {
+    throw new BadRequestError('Grammar concept is not available.', {
+      code: 'grammar_concept_not_found',
+      subjectId: SUBJECT_ID,
+      conceptId: focusConceptId,
+    });
+  }
+  const roundLength = roundLengthFor(mode, payload, state.prefs);
+  const baseSeed = Number.isFinite(Number(payload.seed))
+    ? Number(payload.seed)
+    : stableHash(`${payload.requestId || ''}:${nowTs}:${focusConceptId}:${mode}`);
+  const sessionId = typeof payload.sessionId === 'string' && payload.sessionId
+    ? payload.sessionId
+    : `grammar-${nowTs}-${baseSeed}`;
+  const firstItem = nextItem(state, {
+    mode,
+    focusConceptId,
+    seed: baseSeed,
+    nowTs,
+    templateId: typeof payload.templateId === 'string' ? payload.templateId : '',
+  });
+  state.phase = 'session';
+  state.awaitingAdvance = false;
+  state.feedback = null;
+  state.summary = null;
+  state.error = '';
+  state.prefs = {
+    ...state.prefs,
+    mode,
+    roundLength,
+    focusConceptId,
+  };
+  state.session = {
+    id: sessionId,
+    type: mode === 'satsset' ? 'mini-set' : 'practice',
+    mode,
+    focusConceptId,
+    startedAt: nowTs,
+    targetCount: roundLength,
+    answered: 0,
+    correct: 0,
+    totalScore: 0,
+    totalMarks: 0,
+    seed: baseSeed,
+    currentIndex: 0,
+    currentItem: firstItem,
+    attemptsForCurrent: 0,
+    supportLevel: 0,
+    serverAuthority: SERVER_AUTHORITY,
+  };
+  return [];
+}
+
+function completionSummary(state, nowTs) {
+  const session = state.session || {};
+  return {
+    sessionId: session.id || `grammar-${nowTs}`,
+    mode: session.mode || 'smart',
+    startedAt: session.startedAt || nowTs,
+    completedAt: nowTs,
+    answered: Number(session.answered) || 0,
+    correct: Number(session.correct) || 0,
+    totalScore: Number(session.totalScore) || 0,
+    totalMarks: Number(session.totalMarks) || 0,
+    targetCount: Number(session.targetCount) || 0,
+  };
+}
+
+function completeSession(state, nowTs, command) {
+  const summary = completionSummary(state, nowTs);
+  state.phase = 'summary';
+  state.awaitingAdvance = false;
+  state.summary = summary;
+  state.feedback = null;
+  const event = {
+    id: `grammar.session.${summary.sessionId}.${command.requestId || nowTs}`,
+    type: 'grammar.session-completed',
+    subjectId: SUBJECT_ID,
+    learnerId: command.learnerId,
+    sessionId: summary.sessionId,
+    mode: summary.mode,
+    answered: summary.answered,
+    correct: summary.correct,
+    totalScore: summary.totalScore,
+    totalMarks: summary.totalMarks,
+    createdAt: nowTs,
+  };
+  state.session = null;
+  return [event];
+}
+
+function continueSession(state, nowTs) {
+  const session = state.session;
+  if (!session || !['session', 'feedback'].includes(state.phase)) {
+    throw new BadRequestError('This Grammar session is no longer active.', {
+      code: 'grammar_session_stale',
+      subjectId: SUBJECT_ID,
+    });
+  }
+  if (session.answered >= session.targetCount) return null;
+  const nextIndex = session.currentIndex + 1;
+  const itemSeed = (Number(session.seed) + nextIndex * 104729) >>> 0;
+  session.currentIndex = nextIndex;
+  session.currentItem = nextItem(state, {
+    mode: session.mode,
+    focusConceptId: session.focusConceptId,
+    seed: itemSeed,
+    nowTs,
+  });
+  session.attemptsForCurrent = 0;
+  session.supportLevel = 0;
+  state.phase = 'session';
+  state.awaitingAdvance = false;
+  state.feedback = null;
+  return [];
+}
+
+export function applyGrammarAttemptToState(state, {
+  learnerId = '',
+  item,
+  response = {},
+  supportLevel = 0,
+  attempts = 1,
+  requestId = 'attempt',
+  now = Date.now(),
+} = {}) {
+  if (!item || item.contentReleaseId !== GRAMMAR_CONTENT_RELEASE_ID) {
+    throw new BadRequestError('Grammar content release does not match this attempt.', {
+      code: 'grammar_content_release_mismatch',
+      subjectId: SUBJECT_ID,
+      expected: GRAMMAR_CONTENT_RELEASE_ID,
+      actual: item?.contentReleaseId || null,
+    });
+  }
+  const question = createGrammarQuestion({ templateId: item.templateId, seed: item.seed });
+  if (!question) {
+    throw new NotFoundError('Grammar template is not available.', {
+      code: 'grammar_template_not_found',
+      subjectId: SUBJECT_ID,
+      templateId: item.templateId,
+    });
+  }
+  const result = evaluateGrammarQuestion(question, response);
+  if (!result) {
+    throw new BadRequestError('Grammar answer could not be marked.', {
+      code: 'grammar_answer_invalid',
+      subjectId: SUBJECT_ID,
+    });
+  }
+  const nowTs = timestamp(now);
+  const quality = answerQuality(result, { supportLevel, attempts });
+  const conceptIds = (question.skillIds || []).slice();
+  const statusesBefore = new Map(conceptIds.map((conceptId) => [
+    conceptId,
+    grammarConceptStatus(state.mastery.concepts[conceptId] || defaultMasteryNode(), nowTs),
+  ]));
+
+  for (const conceptId of conceptIds) {
+    updateNodeFromQuality(ensureNode(state.mastery.concepts, conceptId), quality, nowTs);
+  }
+  updateNodeFromQuality(ensureNode(state.mastery.templates, question.templateId), quality, nowTs);
+  updateNodeFromQuality(ensureNode(state.mastery.questionTypes, question.questionType), quality, nowTs);
+  updateNodeFromQuality(ensureNode(state.mastery.items, question.itemId), quality, nowTs);
+
+  if (result.misconception) bumpMisconception(state, result.misconception, nowTs);
+  if (!result.correct || quality < 4) enqueueRetry(state, serialiseGrammarQuestion(question), result, nowTs);
+
+  const attempt = {
+    contentReleaseId: GRAMMAR_CONTENT_RELEASE_ID,
+    templateId: question.templateId,
+    itemId: question.itemId,
+    seed: question.seed,
+    questionType: question.questionType,
+    conceptIds,
+    response: cloneSerialisable(response) || {},
+    result: cloneSerialisable(result) || {},
+    supportLevel,
+    attempts,
+    createdAt: nowTs,
+  };
+  state.recentAttempts = [...(state.recentAttempts || []), attempt].slice(-80);
+
+  const events = [{
+    id: `grammar.answer.${learnerId || 'learner'}.${requestId}.${question.itemId}`,
+    type: 'grammar.answer-submitted',
+    subjectId: SUBJECT_ID,
+    learnerId,
+    templateId: question.templateId,
+    itemId: question.itemId,
+    seed: question.seed,
+    questionType: question.questionType,
+    conceptIds,
+    score: result.score,
+    maxScore: result.maxScore,
+    correct: Boolean(result.correct),
+    misconception: result.misconception || null,
+    supportLevel,
+    attempts,
+    createdAt: nowTs,
+  }];
+  if (result.misconception) {
+    events.push({
+      id: `grammar.misconception.${learnerId || 'learner'}.${requestId}.${question.itemId}`,
+      type: 'grammar.misconception-seen',
+      subjectId: SUBJECT_ID,
+      learnerId,
+      misconception: result.misconception,
+      conceptIds,
+      createdAt: nowTs,
+    });
+  }
+  for (const conceptId of conceptIds) {
+    const after = grammarConceptStatus(state.mastery.concepts[conceptId], nowTs);
+    if (statusesBefore.get(conceptId) !== 'secured' && after === 'secured') {
+      events.push({
+        id: `grammar.secured.${learnerId || 'learner'}.${conceptId}.${requestId}`,
+        type: 'grammar.concept-secured',
+        subjectId: SUBJECT_ID,
+        learnerId,
+        conceptId,
+        templateId: question.templateId,
+        itemId: question.itemId,
+        createdAt: nowTs,
+      });
+    }
+  }
+  return { result, quality, events, attempt };
+}
+
+function submitAnswer(state, payload, command, nowTs) {
+  const session = state.session;
+  if (!session || !session.currentItem || !['session', 'feedback'].includes(state.phase)) {
+    throw new BadRequestError('This Grammar session is no longer active.', {
+      code: 'grammar_session_stale',
+      subjectId: SUBJECT_ID,
+    });
+  }
+  if (state.awaitingAdvance) {
+    throw new BadRequestError('This Grammar item is already awaiting the next question.', {
+      code: 'grammar_session_stale',
+      subjectId: SUBJECT_ID,
+    });
+  }
+  const response = isPlainObject(payload.response) ? payload.response : (isPlainObject(payload.answer) ? payload.answer : { answer: payload.answer ?? '' });
+  session.attemptsForCurrent = Number(session.attemptsForCurrent || 0) + 1;
+  const applied = applyGrammarAttemptToState(state, {
+    learnerId: command.learnerId,
+    item: session.currentItem,
+    response,
+    supportLevel: Number(payload.supportLevel ?? session.supportLevel) || 0,
+    attempts: session.attemptsForCurrent,
+    requestId: command.requestId,
+    now: nowTs,
+  });
+  session.answered += 1;
+  session.correct += applied.result.correct ? 1 : 0;
+  session.totalScore += Number(applied.result.score) || 0;
+  session.totalMarks += Number(applied.result.maxScore) || Number(session.currentItem.marks) || 1;
+  state.phase = 'feedback';
+  state.awaitingAdvance = true;
+  state.feedback = {
+    itemId: session.currentItem.itemId,
+    templateId: session.currentItem.templateId,
+    result: cloneSerialisable(applied.result),
+    response: cloneSerialisable(response) || {},
+    canContinue: session.answered < session.targetCount,
+  };
+  return applied.events;
+}
+
+function savePrefs(state, payload) {
+  const prefs = isPlainObject(payload.prefs) ? payload.prefs : payload;
+  const nextMode = prefs.mode ? normaliseMode(prefs.mode) : state.prefs.mode;
+  state.prefs = {
+    ...state.prefs,
+    mode: ENABLED_MODES.has(nextMode) ? nextMode : state.prefs.mode,
+    roundLength: roundLengthFor(nextMode, prefs, state.prefs),
+    focusConceptId: typeof prefs.focusConceptId === 'string' ? prefs.focusConceptId : state.prefs.focusConceptId,
+  };
+  return [];
+}
+
+function transition(state, { events = [], changed = true } = {}) {
+  return {
+    ok: true,
+    changed,
+    state,
+    data: stateData(state),
+    events,
+  };
+}
+
+export function createServerGrammarEngine({ now = Date.now } = {}) {
+  const clock = () => timestamp(now);
+
+  return {
+    apply({
+      learnerId,
+      subjectRecord = {},
+      latestSession = null,
+      command,
+      payload = {},
+      requestId = '',
+    } = {}) {
+      if (!(typeof learnerId === 'string' && learnerId)) {
+        throw new BadRequestError('Learner id is required for Grammar commands.', {
+          code: 'learner_id_required',
+          subjectId: SUBJECT_ID,
+        });
+      }
+      const nowTs = clock();
+      let state = normaliseGrammarState(subjectRecord.ui, subjectRecord.data);
+      const rawUiWasServerOwned = !subjectRecord.ui
+        || subjectRecord.ui?.serverAuthority === SERVER_AUTHORITY
+        || subjectRecord.ui?.session?.serverAuthority === SERVER_AUTHORITY;
+      const commandContext = { learnerId, requestId };
+      let events = [];
+
+      if (command === 'start-session') {
+        events = startSession(state, { ...payload, requestId }, nowTs);
+      } else if (state.phase === 'session' && !rawUiWasServerOwned) {
+        throw new BadRequestError('This Grammar session is no longer active on the server.', {
+          code: 'grammar_session_stale',
+          subjectId: SUBJECT_ID,
+          command,
+        });
+      } else if (command === 'submit-answer') {
+        events = submitAnswer(state, payload, commandContext, nowTs);
+      } else if (command === 'continue-session') {
+        events = continueSession(state, nowTs) ?? completeSession(state, nowTs, commandContext);
+      } else if (command === 'end-session') {
+        events = completeSession(state, nowTs, commandContext);
+      } else if (command === 'save-prefs') {
+        events = savePrefs(state, payload);
+      } else if (command === 'reset-learner') {
+        state = createInitialGrammarState();
+      } else {
+        throw new BadRequestError('Unsupported Grammar command.', {
+          code: 'grammar_command_unsupported',
+          subjectId: SUBJECT_ID,
+          command,
+        });
+      }
+
+      state.serverAuthority = SERVER_AUTHORITY;
+      if (state.session) state.session.serverAuthority = SERVER_AUTHORITY;
+      return {
+        ...transition(state, { events }),
+        practiceSession: practiceSessionRecord(learnerId, state, latestSession, nowTs),
+      };
+    },
+  };
+}
+
+export {
+  ENABLED_MODES as GRAMMAR_ENABLED_MODES,
+  LOCKED_MODES as GRAMMAR_LOCKED_MODES,
+  SERVER_AUTHORITY as GRAMMAR_SERVER_AUTHORITY,
+};

--- a/worker/src/subjects/grammar/engine.js
+++ b/worker/src/subjects/grammar/engine.js
@@ -373,6 +373,11 @@ function roundLengthFor(mode, payload = {}, prefs = {}) {
   return clamp(Number.isFinite(raw) ? Math.floor(raw) : fallback, 1, mode === 'satsset' ? 20 : 15);
 }
 
+function serverSessionId(learnerId, { requestId = '', nowTs, baseSeed, mode, focusConceptId = '' }) {
+  const discriminator = stableHash(`${learnerId}:${requestId}:${nowTs}:${baseSeed}:${mode}:${focusConceptId}`);
+  return `grammar-${nowTs}-${discriminator}`;
+}
+
 function buildActiveRecord(learnerId, state, nowTs) {
   if (!state.session || !['session', 'feedback'].includes(state.phase)) return null;
   return normalisePracticeSessionRecord({
@@ -424,7 +429,7 @@ export function buildGrammarMiniSet({ size = DEFAULT_MINI_SET_LENGTH, focusConce
   });
 }
 
-function startSession(state, payload, nowTs) {
+function startSession(state, payload, nowTs, learnerId) {
   const mode = supportedModeOrThrow(normaliseMode(payload.mode || state.prefs.mode));
   const focusConceptId = typeof payload.focusConceptId === 'string'
     ? payload.focusConceptId
@@ -440,9 +445,13 @@ function startSession(state, payload, nowTs) {
   const baseSeed = Number.isFinite(Number(payload.seed))
     ? Number(payload.seed)
     : stableHash(`${payload.requestId || ''}:${nowTs}:${focusConceptId}:${mode}`);
-  const sessionId = typeof payload.sessionId === 'string' && payload.sessionId
-    ? payload.sessionId
-    : `grammar-${nowTs}-${baseSeed}`;
+  const sessionId = serverSessionId(learnerId, {
+    requestId: payload.requestId,
+    nowTs,
+    baseSeed,
+    mode,
+    focusConceptId,
+  });
   const firstItem = nextItem(state, {
     mode,
     focusConceptId,
@@ -498,6 +507,12 @@ function completionSummary(state, nowTs) {
 }
 
 function completeSession(state, nowTs, command) {
+  if (!state.session || !['session', 'feedback'].includes(state.phase)) {
+    throw new BadRequestError('This Grammar session is no longer active.', {
+      code: 'grammar_session_stale',
+      subjectId: SUBJECT_ID,
+    });
+  }
   const summary = completionSummary(state, nowTs);
   state.phase = 'summary';
   state.awaitingAdvance = false;
@@ -525,6 +540,12 @@ function continueSession(state, nowTs) {
   if (!session || !['session', 'feedback'].includes(state.phase)) {
     throw new BadRequestError('This Grammar session is no longer active.', {
       code: 'grammar_session_stale',
+      subjectId: SUBJECT_ID,
+    });
+  }
+  if (!state.awaitingAdvance) {
+    throw new BadRequestError('This Grammar item is not awaiting the next question.', {
+      code: 'grammar_advance_not_ready',
       subjectId: SUBJECT_ID,
     });
   }
@@ -748,7 +769,7 @@ export function createServerGrammarEngine({ now = Date.now } = {}) {
       let events = [];
 
       if (command === 'start-session') {
-        events = startSession(state, { ...payload, requestId }, nowTs);
+        events = startSession(state, { ...payload, requestId }, nowTs, learnerId);
       } else if (state.phase === 'session' && !rawUiWasServerOwned) {
         throw new BadRequestError('This Grammar session is no longer active on the server.', {
           code: 'grammar_session_stale',

--- a/worker/src/subjects/grammar/read-models.js
+++ b/worker/src/subjects/grammar/read-models.js
@@ -1,0 +1,175 @@
+import { cloneSerialisable } from '../../../../src/platform/core/repositories/helpers.js';
+import {
+  GRAMMAR_CONCEPTS,
+  GRAMMAR_CONTENT_RELEASE_ID,
+  GRAMMAR_QUESTION_TYPES,
+  GRAMMAR_TEMPLATE_METADATA,
+} from './content.js';
+import {
+  GRAMMAR_ENABLED_MODES,
+  GRAMMAR_LOCKED_MODES,
+  GRAMMAR_SERVER_AUTHORITY,
+  grammarConceptStatus,
+} from './engine.js';
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function safeInputSpec(inputSpec) {
+  if (!isPlainObject(inputSpec)) return null;
+  const clone = cloneSerialisable(inputSpec);
+  if (clone?.options && Array.isArray(clone.options)) {
+    clone.options = clone.options.map((option) => ({
+      value: String(option.value ?? ''),
+      label: String(option.label ?? option.value ?? ''),
+    }));
+  }
+  if (clone?.rows && Array.isArray(clone.rows)) {
+    clone.rows = clone.rows.map((row) => ({
+      key: String(row.key || ''),
+      label: String(row.label || ''),
+    }));
+  }
+  return clone;
+}
+
+function safeCurrentItem(item) {
+  if (!isPlainObject(item)) return null;
+  return {
+    contentReleaseId: item.contentReleaseId === GRAMMAR_CONTENT_RELEASE_ID ? GRAMMAR_CONTENT_RELEASE_ID : '',
+    templateId: typeof item.templateId === 'string' ? item.templateId : '',
+    templateLabel: typeof item.templateLabel === 'string' ? item.templateLabel : '',
+    domain: typeof item.domain === 'string' ? item.domain : '',
+    skillIds: Array.isArray(item.skillIds) ? item.skillIds.filter(Boolean).map(String) : [],
+    questionType: typeof item.questionType === 'string' ? item.questionType : '',
+    seed: Number.isFinite(Number(item.seed)) ? Number(item.seed) : 0,
+    itemId: typeof item.itemId === 'string' ? item.itemId : '',
+    marks: Number.isFinite(Number(item.marks)) ? Number(item.marks) : 1,
+    promptText: typeof item.promptText === 'string' ? item.promptText : '',
+    inputSpec: safeInputSpec(item.inputSpec),
+    reflectionPrompt: typeof item.reflectionPrompt === 'string' ? item.reflectionPrompt : '',
+    checkLine: typeof item.checkLine === 'string' ? item.checkLine : '',
+    replay: isPlainObject(item.replay)
+      ? {
+        contentReleaseId: item.replay.contentReleaseId === GRAMMAR_CONTENT_RELEASE_ID ? GRAMMAR_CONTENT_RELEASE_ID : '',
+        templateId: typeof item.replay.templateId === 'string' ? item.replay.templateId : '',
+        seed: Number.isFinite(Number(item.replay.seed)) ? Number(item.replay.seed) : 0,
+        itemId: typeof item.replay.itemId === 'string' ? item.replay.itemId : '',
+        conceptIds: Array.isArray(item.replay.conceptIds) ? item.replay.conceptIds.filter(Boolean).map(String) : [],
+        questionType: typeof item.replay.questionType === 'string' ? item.replay.questionType : '',
+      }
+      : null,
+  };
+}
+
+function safeSession(session) {
+  if (!isPlainObject(session)) return null;
+  return {
+    id: typeof session.id === 'string' ? session.id : '',
+    type: typeof session.type === 'string' ? session.type : 'practice',
+    mode: typeof session.mode === 'string' ? session.mode : 'smart',
+    focusConceptId: typeof session.focusConceptId === 'string' ? session.focusConceptId : '',
+    startedAt: Number.isFinite(Number(session.startedAt)) ? Number(session.startedAt) : 0,
+    targetCount: Number.isFinite(Number(session.targetCount)) ? Number(session.targetCount) : 0,
+    answered: Number.isFinite(Number(session.answered)) ? Number(session.answered) : 0,
+    correct: Number.isFinite(Number(session.correct)) ? Number(session.correct) : 0,
+    totalScore: Number.isFinite(Number(session.totalScore)) ? Number(session.totalScore) : 0,
+    totalMarks: Number.isFinite(Number(session.totalMarks)) ? Number(session.totalMarks) : 0,
+    currentIndex: Number.isFinite(Number(session.currentIndex)) ? Number(session.currentIndex) : 0,
+    currentItem: safeCurrentItem(session.currentItem),
+    serverAuthority: session.serverAuthority === GRAMMAR_SERVER_AUTHORITY ? GRAMMAR_SERVER_AUTHORITY : null,
+  };
+}
+
+function conceptMap(state, now) {
+  const mastery = isPlainObject(state?.mastery?.concepts) ? state.mastery.concepts : {};
+  return GRAMMAR_CONCEPTS.map((concept) => {
+    const node = mastery[concept.id] || null;
+    return {
+      id: concept.id,
+      name: concept.name,
+      domain: concept.domain,
+      summary: concept.summary,
+      punctuationForGrammar: Boolean(concept.punctuationForGrammar),
+      status: grammarConceptStatus(node, now),
+      attempts: Number(node?.attempts) || 0,
+      correct: Number(node?.correct) || 0,
+      wrong: Number(node?.wrong) || 0,
+      strength: Number.isFinite(Number(node?.strength)) ? Number(node.strength) : 0.25,
+      dueAt: Number(node?.dueAt) || 0,
+      correctStreak: Number(node?.correctStreak) || 0,
+    };
+  });
+}
+
+function statsFromConcepts(concepts) {
+  const counts = { total: concepts.length, new: 0, learning: 0, weak: 0, due: 0, secured: 0 };
+  for (const concept of concepts) {
+    counts[concept.status] = (counts[concept.status] || 0) + 1;
+  }
+  return {
+    concepts: counts,
+    templates: {
+      total: GRAMMAR_TEMPLATE_METADATA.length,
+      selectedResponse: GRAMMAR_TEMPLATE_METADATA.filter((template) => template.isSelectedResponse).length,
+      constructedResponse: GRAMMAR_TEMPLATE_METADATA.filter((template) => !template.isSelectedResponse).length,
+    },
+  };
+}
+
+function capabilityMetadata() {
+  const labels = {
+    learn: 'Learn a concept',
+    smart: 'Smart mixed review',
+    satsset: 'KS2-style mini-set',
+    trouble: 'Weak concepts drill',
+    surgery: 'Sentence surgery',
+    builder: 'Sentence builder',
+    worked: 'Worked examples',
+    faded: 'Faded guidance',
+  };
+  return {
+    enabledModes: Array.from(GRAMMAR_ENABLED_MODES).map((id) => ({ id, label: labels[id] || id })),
+    lockedModes: Array.from(GRAMMAR_LOCKED_MODES).map((id) => ({ id, label: labels[id] || id, reason: 'coming-next' })),
+  };
+}
+
+export function buildGrammarReadModel({
+  learnerId,
+  state,
+  projections = null,
+  now = Date.now(),
+} = {}) {
+  const safeState = cloneSerialisable(state) || {};
+  const concepts = conceptMap(safeState, now);
+  return {
+    subjectId: 'grammar',
+    learnerId,
+    version: 1,
+    authority: GRAMMAR_SERVER_AUTHORITY,
+    content: {
+      releaseId: safeState.contentReleaseId === GRAMMAR_CONTENT_RELEASE_ID
+        ? GRAMMAR_CONTENT_RELEASE_ID
+        : '',
+      conceptCount: GRAMMAR_CONCEPTS.length,
+      templateCount: GRAMMAR_TEMPLATE_METADATA.length,
+      questionTypes: cloneSerialisable(GRAMMAR_QUESTION_TYPES) || {},
+    },
+    phase: typeof safeState.phase === 'string' ? safeState.phase : 'dashboard',
+    awaitingAdvance: Boolean(safeState.awaitingAdvance),
+    session: safeSession(safeState.session),
+    feedback: isPlainObject(safeState.feedback) ? cloneSerialisable(safeState.feedback) : null,
+    summary: isPlainObject(safeState.summary) ? cloneSerialisable(safeState.summary) : null,
+    prefs: isPlainObject(safeState.prefs) ? cloneSerialisable(safeState.prefs) : {},
+    stats: statsFromConcepts(concepts),
+    analytics: {
+      concepts,
+      misconceptionCounts: isPlainObject(safeState.misconceptions) ? cloneSerialisable(safeState.misconceptions) : {},
+      recentAttempts: Array.isArray(safeState.recentAttempts) ? safeState.recentAttempts.slice(-12).map(cloneSerialisable) : [],
+    },
+    capabilities: capabilityMetadata(),
+    projections: projections ? cloneSerialisable(projections) : null,
+    error: typeof safeState.error === 'string' ? safeState.error : '',
+  };
+}

--- a/worker/src/subjects/runtime.js
+++ b/worker/src/subjects/runtime.js
@@ -1,4 +1,5 @@
 import { NotFoundError } from '../errors.js';
+import { createGrammarCommandHandlers } from './grammar/commands.js';
 import { createSpellingCommandHandlers } from './spelling/commands.js';
 
 function handlerFor(handlers, subjectId, command) {
@@ -32,6 +33,7 @@ export function createSubjectRuntime({ handlers = {} } = {}) {
 export function createWorkerSubjectRuntime(options = {}) {
   return createSubjectRuntime({
     handlers: {
+      grammar: createGrammarCommandHandlers(options.grammar || {}),
       spelling: createSpellingCommandHandlers(options.spelling || {}),
       ...(options.handlers || {}),
     },


### PR DESCRIPTION
## Summary

Grammar can now run through the same server-owned subject command boundary as Spelling while preserving the reviewed legacy question engine as the source of truth. This PR ships the first implementation spine for U1-U3: deterministic content extraction, mastery state handling, and Worker runtime integration. U4+ product UI remains intentionally out of scope.

## What changed

- Adds a legacy oracle extractor that turns the reviewed HTML engine into a deterministic content module and fixture, without committing local source paths.
- Adds a Grammar content release with 18 concepts and 51 templates: 31 selected-response and 20 constructed-response templates.
- Adds a server-owned Grammar engine for session commands, preferences, resets, mastery nodes, misconceptions, retry queues, attempts, sessions, and summaries.
- Registers Grammar in the Worker subject runtime with idempotent command writes, event logging, and redacted read models.
- Documents the staged region plan and marks U1-U3 complete.

## Design notes

The Worker regenerates and evaluates questions server-side from release id, template id, and seed. Client-visible read models expose prompt metadata and answer input shape, not executable marking functions or raw generated internals.

Future modes are represented as locked capabilities rather than partially implemented flows. That keeps the full product shape visible without adding placeholder behaviours reviewers cannot validate yet.

## Verification

- `npm test`
- `npm run check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
