### PR TITLE
feat(grammar): add stage 1 practice surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,11 @@ The goal is not to polish the old prototype. The goal is to give the product a s
 - `src/subjects/grammar/*`
   - The Stage 1 Grammar practice surface.
   - Grammar runs through the Worker subject command and read-model boundary, with React rendering setup, session, feedback, summary, and analytics states.
+- `src/subjects/punctuation/*`
+  - The first production Punctuation practice slice.
+  - Punctuation runs through the Worker subject command boundary with deterministic marking, spaced scheduling, release-scoped secure-unit progress, and a rollout-gated React surface.
 - `src/subjects/placeholders/*`
-  - Clean extension slots for Arithmetic, Reasoning, Punctuation and Reading.
+  - Clean extension slots for Arithmetic, Reasoning and Reading.
 - `worker/*`
   - A Cloudflare-friendly backend with D1-backed repository routes, ephemeral demo sessions, account-scoped spelling content, learner ownership checks, production sessions, Worker-owned subject commands, selected-provider Worker-side TTS proxying, and thin role-aware Parent/Admin hub routes.
 - `docs/*`
@@ -31,17 +34,17 @@ The goal is not to polish the old prototype. The goal is to give the product a s
 
 ## Status
 
-English Spelling works in the new structure. Grammar now has a Stage 1 Worker-command-backed practice surface, while the wider product/gameplay layer remains deliberately staged.
+English Spelling works in the new structure. Grammar now has a Stage 1 Worker-command-backed practice surface, and Punctuation has a rollout-gated production Worker-command-backed practice slice. The wider product/gameplay layer remains deliberately staged.
 
 The browser app is now a single React shell. `index.html` loads the built React app bundle, React owns dashboard, Codex, subject, profile, Parent Hub, Admin / Operations, toast and modal surfaces, and the existing controller/store/repository boundary still owns state transitions and side effects. Legacy string renderers remain only as local characterisation helpers while production routes compose React components.
 
-Production on `ks2.eugnel.uk` uses Worker-backed auth, ephemeral demo sessions, API repositories, subject commands, server read models, and prompt-token TTS. `?local=1` no longer creates a browser-local product runtime; browser QA should use a signed-in Worker session or `/demo`. The API adapter reports explicit persistence modes (`local-only`, `remote-sync`, `degraded`) so failed remote writes are visible instead of being treated as silent success, but production practice authority stays behind Worker APIs. The Worker is D1-backed with learner ownership enforcement, atomic account / learner revision checks, idempotent request replay, account-scoped spelling content routes, Worker-command-backed Spelling and Grammar practice, role-aware Parent/Admin hub read routes, Word Bank read models, and protected dictation audio across OpenAI or Gemini, with local browser speech reserved for explicit browser-provider use.
+Production on `ks2.eugnel.uk` uses Worker-backed auth, ephemeral demo sessions, API repositories, subject commands, server read models, and prompt-token TTS. `?local=1` no longer creates a browser-local product runtime; browser QA should use a signed-in Worker session or `/demo`. The API adapter reports explicit persistence modes (`local-only`, `remote-sync`, `degraded`) so failed remote writes are visible instead of being treated as silent success, but production practice authority stays behind Worker APIs. The Worker is D1-backed with learner ownership enforcement, atomic account / learner revision checks, idempotent request replay, account-scoped spelling content routes, Worker-command-backed Spelling, Grammar, and Punctuation practice, role-aware Parent/Admin hub read routes, Word Bank read models, and protected dictation audio across OpenAI or Gemini, with local browser speech reserved for explicit browser-provider use.
 
 Signed-in Parent Hub and Admin / Operations use live Worker hub payloads. Those adult surfaces keep platform role, learner membership role, and writable/read-only access separate. `/api/bootstrap` remains writable-only for the main subject shell, while readable viewer learners are available inside hub surfaces with explicit read-only labels and blocked write affordances.
 
 The repo now has a reusable subject-expansion harness and an explicit expansion-readiness gate. The gate is a narrow **GO** for the first Arithmetic thin slice only; it is not a claim that the full multi-subject SaaS is finished.
 
-The remaining four subjects are intentionally placeholders. They already have:
+The remaining three subjects are intentionally placeholders. They already have:
 
 - subject identities
 - dashboard cards
@@ -52,7 +55,7 @@ The remaining four subjects are intentionally placeholders. They already have:
 - reward-layer hooks
 - Cloudflare deployment and API boundaries
 
-What they do not have yet is their own deterministic learning engine. That is deliberate. Grammar has crossed that boundary for its Stage 1 practice surface, but it is not yet a finished full-subject product layer.
+What they do not have yet is their own deterministic learning engine. That is deliberate. Grammar has crossed that boundary for its Stage 1 practice surface, and Punctuation has crossed it for its rollout-gated production slice, but neither is yet a finished full-subject product layer.
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@ The goal is not to polish the old prototype. The goal is to give the product a s
   - The legacy spelling engine is preserved and wrapped behind a clean service.
   - The spelling service now owns an explicit serialisable state contract, deterministic transitions, resume-safe restoration, and domain-event emission.
   - Spelling content now has a versioned draft/published content model. Learner runtime reads are pinned to published release snapshots, not live draft rows, with current seeded additions supplemented for older account-scoped seed releases.
+- `src/subjects/grammar/*`
+  - The Stage 1 Grammar practice surface.
+  - Grammar runs through the Worker subject command and read-model boundary, with React rendering setup, session, feedback, summary, and analytics states.
 - `src/subjects/placeholders/*`
-  - Clean extension slots for Arithmetic, Reasoning, Grammar, Punctuation and Reading.
+  - Clean extension slots for Arithmetic, Reasoning, Punctuation and Reading.
 - `worker/*`
   - A Cloudflare-friendly backend with D1-backed repository routes, ephemeral demo sessions, account-scoped spelling content, learner ownership checks, production sessions, Worker-owned subject commands, selected-provider Worker-side TTS proxying, and thin role-aware Parent/Admin hub routes.
 - `docs/*`
@@ -28,17 +31,17 @@ The goal is not to polish the old prototype. The goal is to give the product a s
 
 ## Status
 
-English Spelling works in the new structure.
+English Spelling works in the new structure. Grammar now has a Stage 1 Worker-command-backed practice surface, while the wider product/gameplay layer remains deliberately staged.
 
 The browser app is now a single React shell. `index.html` loads the built React app bundle, React owns dashboard, Codex, subject, profile, Parent Hub, Admin / Operations, toast and modal surfaces, and the existing controller/store/repository boundary still owns state transitions and side effects. Legacy string renderers remain only as local characterisation helpers while production routes compose React components.
 
-Production on `ks2.eugnel.uk` uses Worker-backed auth, ephemeral demo sessions, API repositories, subject commands, server read models, and prompt-token TTS. `?local=1` no longer creates a browser-local product runtime; browser QA should use a signed-in Worker session or `/demo`. The API adapter reports explicit persistence modes (`local-only`, `remote-sync`, `degraded`) so failed remote writes are visible instead of being treated as silent success, but production practice authority stays behind Worker APIs. The Worker is D1-backed with learner ownership enforcement, atomic account / learner revision checks, idempotent request replay, account-scoped spelling content routes, a shared-domain Spelling runtime imported from `shared/spelling/`, role-aware Parent/Admin hub read routes, Word Bank read models, and protected dictation audio across OpenAI or Gemini, with local browser speech reserved for explicit browser-provider use.
+Production on `ks2.eugnel.uk` uses Worker-backed auth, ephemeral demo sessions, API repositories, subject commands, server read models, and prompt-token TTS. `?local=1` no longer creates a browser-local product runtime; browser QA should use a signed-in Worker session or `/demo`. The API adapter reports explicit persistence modes (`local-only`, `remote-sync`, `degraded`) so failed remote writes are visible instead of being treated as silent success, but production practice authority stays behind Worker APIs. The Worker is D1-backed with learner ownership enforcement, atomic account / learner revision checks, idempotent request replay, account-scoped spelling content routes, Worker-command-backed Spelling and Grammar practice, role-aware Parent/Admin hub read routes, Word Bank read models, and protected dictation audio across OpenAI or Gemini, with local browser speech reserved for explicit browser-provider use.
 
 Signed-in Parent Hub and Admin / Operations use live Worker hub payloads. Those adult surfaces keep platform role, learner membership role, and writable/read-only access separate. `/api/bootstrap` remains writable-only for the main subject shell, while readable viewer learners are available inside hub surfaces with explicit read-only labels and blocked write affordances.
 
 The repo now has a reusable subject-expansion harness and an explicit expansion-readiness gate. The gate is a narrow **GO** for the first Arithmetic thin slice only; it is not a claim that the full multi-subject SaaS is finished.
 
-The other five subjects are intentionally placeholders. They already have:
+The remaining four subjects are intentionally placeholders. They already have:
 
 - subject identities
 - dashboard cards
@@ -49,7 +52,7 @@ The other five subjects are intentionally placeholders. They already have:
 - reward-layer hooks
 - Cloudflare deployment and API boundaries
 
-What they do not have yet is their own deterministic learning engine. That is deliberate.
+What they do not have yet is their own deterministic learning engine. That is deliberate. Grammar has crossed that boundary for its Stage 1 practice surface, but it is not yet a finished full-subject product layer.
 
 ## Quick start
 
@@ -120,7 +123,7 @@ Pass 13 turns "add a second subject" into a controlled engineering change.
 
 - `tests/helpers/subject-expansion-harness.js` provides reusable conformance and golden-path smoke suites.
 - `tests/helpers/expansion-fixture-subject.js` is a non-production fixture proving the shell can carry a second deterministic thin slice.
-- `tests/subject-expansion.test.js` runs the same acceptance path against English Spelling and the fixture.
+- `tests/subject-expansion.test.js` runs the same acceptance path against English Spelling, Grammar, and the fixture.
 - `docs/subject-expansion.md` defines the add-a-subject checklist.
 - `docs/expansion-readiness.md` records the narrow GO decision for the future Arithmetic thin slice.
 

--- a/scripts/audit-client-bundle.mjs
+++ b/scripts/audit-client-bundle.mjs
@@ -16,6 +16,7 @@ const FORBIDDEN_MODULES = [
   { pattern: /^shared\/punctuation\/(content|marking|scheduler|service)\.js$/, reason: 'server-side punctuation engine and content' },
   { pattern: /^worker\/src\/subjects\/punctuation\//, reason: 'server-side punctuation command runtime' },
   { pattern: /^src\/subjects\/punctuation\/(service|repository)\.js$/, reason: 'browser-side import of punctuation runtime service' },
+  { pattern: /^worker\/src\/subjects\/grammar\/(engine|content)\.js$/, reason: 'server-authoritative Grammar engine/content' },
   { pattern: /^src\/platform\/core\/local-review-profile\.js$/, reason: 'local review runtime profile' },
   { pattern: /^src\/platform\/core\/repositories\/local\.js$/, reason: 'browser-local production repository' },
   { pattern: /^src\/platform\/hubs\/(admin|parent)-read-model\.js$/, reason: 'client-side hub read-model aggregation' },

--- a/src/main.js
+++ b/src/main.js
@@ -1160,6 +1160,7 @@ function contextFor(subjectId = null) {
     service: services[resolvedSubject.id] || null,
     spellingContent,
     readModels,
+    subjectCommands,
     tts,
     applySubjectTransition,
     runtimeBoundary,

--- a/src/platform/core/store.js
+++ b/src/platform/core/store.js
@@ -335,6 +335,49 @@ export function createStore(subjects, { repositories, cacheSubjectUiWrites = fal
     return writer.call(resolvedRepositories.subjectStates, learnerId, subjectId, ui);
   }
 
+  function nextSubjectUiEntry(subjectId, currentEntry, updater) {
+    const subject = registry.find((entry) => entry.id === subjectId);
+    if (!subject) return null;
+    const previous = buildSubjectUiState(subject, currentEntry || null);
+    return typeof updater === 'function'
+      ? updater(previous)
+      : { ...previous, ...updater };
+  }
+
+  function updateSubjectUi(subjectId, updater) {
+    const learnerId = state.learners.selectedId;
+    setState((current) => {
+      const nextEntry = nextSubjectUiEntry(subjectId, current.subjectUi[subjectId], updater);
+      if (!nextEntry) return current;
+
+      if (learnerId) {
+        writeSubjectUi(learnerId, subjectId, nextEntry);
+      }
+
+      return {
+        ...current,
+        subjectUi: {
+          ...current.subjectUi,
+          [subjectId]: nextEntry,
+        },
+      };
+    });
+  }
+
+  function updateSubjectUiForLearner(learnerId, subjectId, updater) {
+    if (!learnerId || !state.learners.byId[learnerId]) return false;
+    if (state.learners.selectedId === learnerId) {
+      updateSubjectUi(subjectId, updater);
+      return true;
+    }
+
+    const record = resolvedRepositories.subjectStates.read(learnerId, subjectId);
+    const nextEntry = nextSubjectUiEntry(subjectId, record?.ui, updater);
+    if (!nextEntry) return false;
+    writeSubjectUi(learnerId, subjectId, nextEntry);
+    return true;
+  }
+
   return {
     repositories: resolvedRepositories,
     getState() {
@@ -460,27 +503,8 @@ export function createStore(subjects, { repositories, cacheSubjectUiWrites = fal
       }));
       return true;
     },
-    updateSubjectUi(subjectId, updater) {
-      const learnerId = state.learners.selectedId;
-      setState((current) => {
-        const previous = current.subjectUi[subjectId] || {};
-        const nextEntry = typeof updater === 'function'
-          ? updater(previous)
-          : { ...previous, ...updater };
-
-        if (learnerId) {
-          writeSubjectUi(learnerId, subjectId, nextEntry);
-        }
-
-        return {
-          ...current,
-          subjectUi: {
-            ...current.subjectUi,
-            [subjectId]: nextEntry,
-          },
-        };
-      });
-    },
+    updateSubjectUi,
+    updateSubjectUiForLearner,
     pushToasts(events) {
       const entries = Array.isArray(events) ? events : [events];
       const validEvents = entries.filter((entry) => entry && typeof entry === 'object' && !Array.isArray(entry));

--- a/src/platform/core/subject-registry.js
+++ b/src/platform/core/subject-registry.js
@@ -1,10 +1,10 @@
 import { buildSubjectRegistry } from './subject-contract.js';
 import { punctuationModule } from '../../subjects/punctuation/module.js';
 import { spellingModule } from '../../subjects/spelling/module.js';
+import { grammarModule } from '../../subjects/grammar/module.js';
 import {
   arithmeticModule,
   reasoningModule,
-  grammarModule,
   readingModule,
 } from '../../subjects/placeholders/index.js';
 

--- a/src/subjects/grammar/components/GrammarAnalyticsScene.jsx
+++ b/src/subjects/grammar/components/GrammarAnalyticsScene.jsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import {
+  GRAMMAR_MONSTER_ROUTES,
+  grammarMonsterAsset,
+  groupedGrammarConcepts,
+} from '../metadata.js';
+
+function StatusCount({ label, value, className = '' }) {
+  return (
+    <span className={`grammar-status-count ${className}`}>
+      <strong>{value}</strong>
+      <span>{label}</span>
+    </span>
+  );
+}
+
+function securedCountForRoute(route, conceptsById) {
+  return route.conceptIds.reduce((count, conceptId) => (
+    conceptsById.get(conceptId)?.status === 'secured' ? count + 1 : count
+  ), 0);
+}
+
+export function GrammarAnalyticsScene({ grammar }) {
+  const concepts = grammar.analytics?.concepts || [];
+  const counts = grammar.stats?.concepts || {};
+  const conceptsById = new Map(concepts.map((concept) => [concept.id, concept]));
+  const grouped = groupedGrammarConcepts(concepts);
+  const recentAttempts = Array.isArray(grammar.analytics?.recentAttempts)
+    ? grammar.analytics.recentAttempts.slice(-5).reverse()
+    : [];
+
+  return (
+    <section className="card grammar-analytics" aria-labelledby="grammar-analytics-title">
+      <div className="card-header">
+        <div>
+          <div className="eyebrow">Evidence snapshot</div>
+          <h3 className="section-title" id="grammar-analytics-title">Grammar analytics</h3>
+        </div>
+        <span className="chip">Stage 1</span>
+      </div>
+
+      <div className="grammar-status-strip" aria-label="Concept status counts">
+        <StatusCount label="new" value={counts.new || 0} className="new" />
+        <StatusCount label="learning" value={counts.learning || 0} className="learning" />
+        <StatusCount label="weak" value={counts.weak || 0} className="weak" />
+        <StatusCount label="due" value={counts.due || 0} className="due" />
+        <StatusCount label="secured" value={counts.secured || 0} className="secured" />
+      </div>
+
+      <div className="grammar-analytics-grid">
+        <div className="grammar-evidence-list">
+          {grouped.map((group) => (
+            <div className="grammar-evidence-domain" key={group.domain}>
+              <strong>{group.domain}</strong>
+              <div>
+                {group.concepts.map((concept) => (
+                  <span className={`grammar-mini-concept ${concept.status}`} key={concept.id}>
+                    {concept.name}
+                  </span>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="grammar-route-panel">
+          <div className="eyebrow">Reserved reward routes</div>
+          <div className="grammar-monster-grid">
+            {GRAMMAR_MONSTER_ROUTES.map((route) => {
+              const secured = securedCountForRoute(route, conceptsById);
+              return (
+                <article className="grammar-monster-route" key={route.id}>
+                  <img src={grammarMonsterAsset(route.id)} alt="" loading="lazy" />
+                  <div>
+                    <strong>{route.name}</strong>
+                    <span>{route.route}</span>
+                    <small>{secured}/{route.conceptIds.length} secured</small>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      <div className="grammar-recent">
+        <div className="eyebrow">Recent attempts</div>
+        {recentAttempts.length ? (
+          <ol>
+            {recentAttempts.map((attempt, index) => (
+              <li key={`${attempt.itemId || attempt.templateId || 'attempt'}-${index}`}>
+                <strong>{attempt.templateLabel || attempt.templateId || 'Grammar item'}</strong>
+                <span>{attempt.correct ? 'correct' : 'review'} · score {attempt.score ?? 0}/{attempt.maxScore ?? 1}</span>
+              </li>
+            ))}
+          </ol>
+        ) : (
+          <p className="small muted">No Grammar attempts recorded yet.</p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/subjects/grammar/components/GrammarPracticeSurface.jsx
+++ b/src/subjects/grammar/components/GrammarPracticeSurface.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { GrammarAnalyticsScene } from './GrammarAnalyticsScene.jsx';
+import { GrammarSessionScene } from './GrammarSessionScene.jsx';
+import { GrammarSetupScene } from './GrammarSetupScene.jsx';
+import { GrammarSummaryScene } from './GrammarSummaryScene.jsx';
+import { GRAMMAR_SUBJECT_ID, normaliseGrammarReadModel } from '../metadata.js';
+
+function selectedLearner(appState) {
+  const learnerId = appState?.learners?.selectedId || '';
+  return learnerId ? appState.learners?.byId?.[learnerId] || null : null;
+}
+
+export function GrammarPracticeSurface({
+  appState,
+  subject,
+  actions,
+  runtimeReadOnly = false,
+}) {
+  const learner = selectedLearner(appState);
+  const grammar = normaliseGrammarReadModel(appState.subjectUi?.[GRAMMAR_SUBJECT_ID], learner?.id || '');
+  const shared = {
+    subject,
+    learner,
+    grammar,
+    actions,
+    runtimeReadOnly,
+  };
+
+  if (grammar.phase === 'session' || grammar.phase === 'feedback') {
+    return <GrammarSessionScene {...shared} />;
+  }
+
+  if (grammar.phase === 'summary') {
+    return <GrammarSummaryScene {...shared} />;
+  }
+
+  return (
+    <div className="grammar-surface">
+      <GrammarSetupScene {...shared} />
+      <GrammarAnalyticsScene {...shared} />
+    </div>
+  );
+}

--- a/src/subjects/grammar/components/GrammarSessionScene.jsx
+++ b/src/subjects/grammar/components/GrammarSessionScene.jsx
@@ -1,0 +1,208 @@
+import React from 'react';
+
+function optionLabel(option) {
+  if (Array.isArray(option)) return String(option[1] ?? option[0] ?? '');
+  return String(option?.label ?? option?.value ?? '');
+}
+
+function optionValue(option) {
+  if (Array.isArray(option)) return String(option[0] ?? '');
+  return String(option?.value ?? '');
+}
+
+function ChoiceList({ inputSpec }) {
+  const options = Array.isArray(inputSpec?.options) ? inputSpec.options : [];
+  const type = inputSpec?.type === 'checkbox_list' ? 'checkbox' : 'radio';
+  const name = inputSpec?.type === 'checkbox_list' ? 'selected' : 'answer';
+  return (
+    <div className={`grammar-choice-list ${inputSpec?.asTokens ? 'tokens' : ''}`}>
+      {options.map((option) => {
+        const value = optionValue(option);
+        return (
+          <label className="grammar-choice" key={value}>
+            <input type={type} name={name} value={value} />
+            <span>{optionLabel(option)}</span>
+          </label>
+        );
+      })}
+    </div>
+  );
+}
+
+function TableChoice({ inputSpec }) {
+  const rows = Array.isArray(inputSpec?.rows) ? inputSpec.rows : [];
+  const columns = Array.isArray(inputSpec?.columns) ? inputSpec.columns : [];
+  return (
+    <div className="grammar-table-wrap">
+      <table className="grammar-table-choice">
+        <thead>
+          <tr>
+            <th>Sentence</th>
+            {columns.map((column) => <th key={column}>{column}</th>)}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.key}>
+              <td>{row.label}</td>
+              {columns.map((column) => (
+                <td key={`${row.key}-${column}`}>
+                  <input type="radio" name={row.key} value={column} aria-label={`${row.label}: ${column}`} />
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function MultiField({ field }) {
+  const options = Array.isArray(field?.options) ? field.options : [];
+  if (field?.kind === 'select') {
+    return (
+      <label className="field grammar-field" key={field.key}>
+        <span>{field.label}</span>
+        <select className="input" name={field.key}>
+          {options.map((option) => <option value={optionValue(option)} key={optionValue(option)}>{optionLabel(option)}</option>)}
+        </select>
+      </label>
+    );
+  }
+  if (field?.kind === 'radio') {
+    return (
+      <fieldset className="grammar-fieldset" key={field.key}>
+        <legend>{field.label}</legend>
+        <div className="grammar-choice-list compact">
+          {options.map((option) => (
+            <label className="grammar-choice" key={optionValue(option)}>
+              <input type="radio" name={field.key} value={optionValue(option)} />
+              <span>{optionLabel(option)}</span>
+            </label>
+          ))}
+        </div>
+      </fieldset>
+    );
+  }
+  return (
+    <label className="field grammar-field" key={field.key}>
+      <span>{field.label}</span>
+      <input className="input" name={field.key} autoComplete="off" />
+    </label>
+  );
+}
+
+function GrammarInput({ inputSpec }) {
+  if (inputSpec?.type === 'single_choice' || inputSpec?.type === 'checkbox_list') {
+    return <ChoiceList inputSpec={inputSpec} />;
+  }
+  if (inputSpec?.type === 'table_choice') {
+    return <TableChoice inputSpec={inputSpec} />;
+  }
+  if (inputSpec?.type === 'multi') {
+    const fields = Array.isArray(inputSpec?.fields) ? inputSpec.fields : [];
+    return <div className="grammar-multi-fields">{fields.map((field) => <MultiField field={field} key={field.key} />)}</div>;
+  }
+  if (inputSpec?.type === 'textarea') {
+    return (
+      <label className="field">
+        <span>{inputSpec.label || 'Your answer'}</span>
+        <textarea className="input grammar-textarea" name="answer" placeholder={inputSpec.placeholder || ''} data-autofocus="true" />
+      </label>
+    );
+  }
+  return (
+    <label className="field">
+      <span>{inputSpec?.label || 'Your answer'}</span>
+      <input className="input" name="answer" placeholder={inputSpec?.placeholder || ''} data-autofocus="true" autoComplete="off" />
+    </label>
+  );
+}
+
+function FeedbackPanel({ feedback }) {
+  if (!feedback?.result) return null;
+  const result = feedback.result;
+  return (
+    <div className={`feedback ${result.correct ? 'good' : 'warn'}`} role="status" aria-live="polite">
+      <strong>{result.feedbackShort || (result.correct ? 'Correct.' : 'Not quite.')}</strong>
+      <div>{result.feedbackLong || result.minimalHint || ''}</div>
+      {result.answerText ? <div className="small muted">Answer: {result.answerText}</div> : null}
+    </div>
+  );
+}
+
+export function GrammarSessionScene({ grammar, actions, runtimeReadOnly }) {
+  const session = grammar.session || {};
+  const item = session.currentItem || {};
+  const progressDone = Math.min(Number(session.answered) || 0, Number(session.targetCount) || 0);
+  const progressTotal = Math.max(1, Number(session.targetCount) || 1);
+  const isFeedback = grammar.phase === 'feedback' || grammar.awaitingAdvance;
+  const pending = Boolean(grammar.pendingCommand);
+  const submitDisabled = runtimeReadOnly || pending || isFeedback;
+
+  return (
+    <section className="grammar-session" aria-labelledby="grammar-session-title">
+      <div className="grammar-session-head">
+        <div>
+          <div className="eyebrow">Grammar practice</div>
+          <h2 id="grammar-session-title">{item.templateLabel || 'Worker-marked question'}</h2>
+        </div>
+        <div className="grammar-progress" aria-label="Round progress">
+          <span>{progressDone}</span>
+          <small>of {progressTotal}</small>
+        </div>
+      </div>
+
+      <div className="grammar-prompt-card">
+        <div className="chip-row">
+          {item.domain ? <span className="chip">{item.domain}</span> : null}
+          {item.questionType ? <span className="chip">{item.questionType}</span> : null}
+          {session.serverAuthority ? <span className="chip good">Worker authority</span> : null}
+        </div>
+        <p className="grammar-prompt">{item.promptText || 'Loading the next Grammar item...'}</p>
+        {item.checkLine ? <p className="grammar-check-line">{item.checkLine}</p> : null}
+
+        <form
+          className="grammar-answer-form"
+          onSubmit={(event) => {
+            event.preventDefault();
+            actions.dispatch('grammar-submit-form', { formData: new FormData(event.currentTarget) });
+          }}
+        >
+          <GrammarInput inputSpec={item.inputSpec || { type: 'text' }} />
+          <FeedbackPanel feedback={grammar.feedback} />
+          {grammar.error ? (
+            <div className="feedback bad" role="alert">
+              <strong>Grammar command failed</strong>
+              <div>{grammar.error}</div>
+            </div>
+          ) : null}
+          <div className="actions">
+            <button className="btn primary" type="submit" disabled={submitDisabled}>
+              {pending && grammar.pendingCommand === 'submit-answer' ? 'Checking...' : 'Submit answer'}
+            </button>
+            {isFeedback ? (
+              <button
+                className="btn secondary"
+                type="button"
+                disabled={runtimeReadOnly || pending}
+                onClick={() => actions.dispatch('grammar-continue')}
+              >
+                {progressDone >= progressTotal ? 'Finish round' : 'Next question'}
+              </button>
+            ) : null}
+            <button
+              className="btn ghost"
+              type="button"
+              disabled={pending}
+              onClick={() => actions.dispatch('grammar-end-early')}
+            >
+              End round
+            </button>
+          </div>
+        </form>
+      </div>
+    </section>
+  );
+}

--- a/src/subjects/grammar/components/GrammarSessionScene.jsx
+++ b/src/subjects/grammar/components/GrammarSessionScene.jsx
@@ -20,7 +20,7 @@ function ChoiceList({ inputSpec }) {
         const value = optionValue(option);
         return (
           <label className="grammar-choice" key={value}>
-            <input type={type} name={name} value={value} />
+            <input type={type} name={name} value={value} required={type === 'radio'} />
             <span>{optionLabel(option)}</span>
           </label>
         );
@@ -47,7 +47,7 @@ function TableChoice({ inputSpec }) {
               <td>{row.label}</td>
               {columns.map((column) => (
                 <td key={`${row.key}-${column}`}>
-                  <input type="radio" name={row.key} value={column} aria-label={`${row.label}: ${column}`} />
+                  <input type="radio" name={row.key} value={column} aria-label={`${row.label}: ${column}`} required />
                 </td>
               ))}
             </tr>
@@ -77,7 +77,7 @@ function MultiField({ field }) {
         <div className="grammar-choice-list compact">
           {options.map((option) => (
             <label className="grammar-choice" key={optionValue(option)}>
-              <input type="radio" name={field.key} value={optionValue(option)} />
+              <input type="radio" name={field.key} value={optionValue(option)} required />
               <span>{optionLabel(option)}</span>
             </label>
           ))}
@@ -88,7 +88,7 @@ function MultiField({ field }) {
   return (
     <label className="field grammar-field" key={field.key}>
       <span>{field.label}</span>
-      <input className="input" name={field.key} autoComplete="off" />
+      <input className="input" name={field.key} autoComplete="off" required />
     </label>
   );
 }
@@ -108,14 +108,14 @@ function GrammarInput({ inputSpec }) {
     return (
       <label className="field">
         <span>{inputSpec.label || 'Your answer'}</span>
-        <textarea className="input grammar-textarea" name="answer" placeholder={inputSpec.placeholder || ''} data-autofocus="true" />
+        <textarea className="input grammar-textarea" name="answer" placeholder={inputSpec.placeholder || ''} data-autofocus="true" required />
       </label>
     );
   }
   return (
     <label className="field">
       <span>{inputSpec?.label || 'Your answer'}</span>
-      <input className="input" name="answer" placeholder={inputSpec?.placeholder || ''} data-autofocus="true" autoComplete="off" />
+      <input className="input" name="answer" placeholder={inputSpec?.placeholder || ''} data-autofocus="true" autoComplete="off" required />
     </label>
   );
 }

--- a/src/subjects/grammar/components/GrammarSetupScene.jsx
+++ b/src/subjects/grammar/components/GrammarSetupScene.jsx
@@ -17,8 +17,8 @@ function Stat({ label, value, detail }) {
   );
 }
 
-function ModeButton({ mode, selected, disabled, reason, actions }) {
-  const className = `grammar-mode${selected ? ' selected' : ''}${disabled ? ' locked' : ''}`;
+function ModeButton({ mode, selected, disabled, locked, reason, actions }) {
+  const className = `grammar-mode${selected ? ' selected' : ''}${locked ? ' locked' : ''}`;
   return (
     <button
       className={className}
@@ -38,7 +38,7 @@ export function GrammarSetupScene({ learner, grammar, actions, runtimeReadOnly }
   const selectedMode = grammar.prefs?.mode || 'smart';
   const selectedFocus = grammar.prefs?.focusConceptId || '';
   const groupedConcepts = groupedGrammarConcepts(grammar.analytics?.concepts || []);
-  const startDisabled = runtimeReadOnly || Boolean(grammar.pendingCommand);
+  const setupDisabled = runtimeReadOnly || Boolean(grammar.pendingCommand);
 
   return (
     <section className="grammar-setup" aria-labelledby="grammar-setup-title">
@@ -81,6 +81,7 @@ export function GrammarSetupScene({ learner, grammar, actions, runtimeReadOnly }
                 key={mode.id}
                 mode={mode}
                 selected={mode.id === selectedMode}
+                disabled={setupDisabled}
                 actions={actions}
               />
             ))}
@@ -89,6 +90,7 @@ export function GrammarSetupScene({ learner, grammar, actions, runtimeReadOnly }
                 key={mode.id}
                 mode={mode}
                 disabled
+                locked
                 reason="Coming next"
                 actions={actions}
               />
@@ -101,6 +103,7 @@ export function GrammarSetupScene({ learner, grammar, actions, runtimeReadOnly }
               <select
                 className="input"
                 value={selectedFocus}
+                disabled={setupDisabled}
                 onChange={(event) => actions.dispatch('grammar-set-focus', { value: event.currentTarget.value })}
               >
                 <option value="">Smart mix</option>
@@ -114,6 +117,7 @@ export function GrammarSetupScene({ learner, grammar, actions, runtimeReadOnly }
               <select
                 className="input"
                 value={String(grammar.prefs?.roundLength || 5)}
+                disabled={setupDisabled}
                 onChange={(event) => actions.dispatch('grammar-set-round-length', { value: event.currentTarget.value })}
               >
                 {[3, 5, 8, 10, 15].map((length) => <option value={length} key={length}>{length}</option>)}
@@ -132,7 +136,7 @@ export function GrammarSetupScene({ learner, grammar, actions, runtimeReadOnly }
             <button
               className="btn primary xl"
               type="button"
-              disabled={startDisabled}
+              disabled={setupDisabled}
               onClick={() => actions.dispatch('grammar-start')}
             >
               {grammar.pendingCommand === 'start-session' ? 'Starting...' : 'Start practice'}

--- a/src/subjects/grammar/components/GrammarSetupScene.jsx
+++ b/src/subjects/grammar/components/GrammarSetupScene.jsx
@@ -1,0 +1,165 @@
+import React from 'react';
+import {
+  GRAMMAR_ENABLED_MODES,
+  GRAMMAR_LOCKED_MODES,
+  GRAMMAR_REGION_IMAGE,
+  GRAMMAR_REGION_IMAGE_SMALL,
+  groupedGrammarConcepts,
+} from '../metadata.js';
+
+function Stat({ label, value, detail }) {
+  return (
+    <div className="grammar-stat">
+      <span>{label}</span>
+      <strong>{value}</strong>
+      {detail ? <small>{detail}</small> : null}
+    </div>
+  );
+}
+
+function ModeButton({ mode, selected, disabled, reason, actions }) {
+  const className = `grammar-mode${selected ? ' selected' : ''}${disabled ? ' locked' : ''}`;
+  return (
+    <button
+      className={className}
+      type="button"
+      disabled={disabled}
+      onClick={() => actions.dispatch('grammar-set-mode', { value: mode.id })}
+    >
+      <span>{mode.label}</span>
+      <small>{mode.detail || reason || ''}</small>
+    </button>
+  );
+}
+
+export function GrammarSetupScene({ learner, grammar, actions, runtimeReadOnly }) {
+  const counts = grammar.stats?.concepts || {};
+  const templates = grammar.stats?.templates || {};
+  const selectedMode = grammar.prefs?.mode || 'smart';
+  const selectedFocus = grammar.prefs?.focusConceptId || '';
+  const groupedConcepts = groupedGrammarConcepts(grammar.analytics?.concepts || []);
+  const startDisabled = runtimeReadOnly || Boolean(grammar.pendingCommand);
+
+  return (
+    <section className="grammar-setup" aria-labelledby="grammar-setup-title">
+      <div
+        className="grammar-hero"
+        style={{ '--grammar-hero-bg': `url(${GRAMMAR_REGION_IMAGE})` }}
+      >
+        <picture aria-hidden="true">
+          <source media="(max-width: 720px)" srcSet={GRAMMAR_REGION_IMAGE_SMALL} />
+          <img src={GRAMMAR_REGION_IMAGE} alt="" />
+        </picture>
+        <div className="grammar-hero-copy">
+          <div className="eyebrow">Clause Conservatory</div>
+          <h2 id="grammar-setup-title">Grammar retrieval practice</h2>
+          <p>
+            {learner?.name || 'This learner'} can start with the Stage 1 Worker-marked grammar engine,
+            while the full concept map stays visible for the larger product build.
+          </p>
+          <div className="grammar-hero-stats" aria-label="Grammar coverage">
+            <Stat label="Concepts" value={counts.total || 18} detail="full map" />
+            <Stat label="Templates" value={templates.total || 51} detail="Worker-held" />
+            <Stat label="Secured" value={counts.secured || 0} detail={`${counts.due || 0} due`} />
+          </div>
+        </div>
+      </div>
+
+      <div className="grammar-setup-grid">
+        <section className="card grammar-start-card" aria-labelledby="grammar-start-title">
+          <div className="card-header">
+            <div>
+              <div className="eyebrow">Stage 1 practice</div>
+              <h3 className="section-title" id="grammar-start-title">Start a Grammar round</h3>
+            </div>
+            <span className="chip good">Worker marked</span>
+          </div>
+
+          <div className="grammar-mode-grid" aria-label="Grammar practice mode">
+            {GRAMMAR_ENABLED_MODES.map((mode) => (
+              <ModeButton
+                key={mode.id}
+                mode={mode}
+                selected={mode.id === selectedMode}
+                actions={actions}
+              />
+            ))}
+            {GRAMMAR_LOCKED_MODES.map((mode) => (
+              <ModeButton
+                key={mode.id}
+                mode={mode}
+                disabled
+                reason="Coming next"
+                actions={actions}
+              />
+            ))}
+          </div>
+
+          <div className="grammar-controls">
+            <label className="field">
+              <span>Focus concept</span>
+              <select
+                className="input"
+                value={selectedFocus}
+                onChange={(event) => actions.dispatch('grammar-set-focus', { value: event.currentTarget.value })}
+              >
+                <option value="">Smart mix</option>
+                {(grammar.analytics?.concepts || []).map((concept) => (
+                  <option value={concept.id} key={concept.id}>{concept.name}</option>
+                ))}
+              </select>
+            </label>
+            <label className="field">
+              <span>Round length</span>
+              <select
+                className="input"
+                value={String(grammar.prefs?.roundLength || 5)}
+                onChange={(event) => actions.dispatch('grammar-set-round-length', { value: event.currentTarget.value })}
+              >
+                {[3, 5, 8, 10, 15].map((length) => <option value={length} key={length}>{length}</option>)}
+              </select>
+            </label>
+          </div>
+
+          {grammar.error ? (
+            <div className="feedback bad" role="alert">
+              <strong>Grammar is unavailable right now</strong>
+              <div>{grammar.error}</div>
+            </div>
+          ) : null}
+
+          <div className="actions">
+            <button
+              className="btn primary xl"
+              type="button"
+              disabled={startDisabled}
+              onClick={() => actions.dispatch('grammar-start')}
+            >
+              {grammar.pendingCommand === 'start-session' ? 'Starting...' : 'Start practice'}
+            </button>
+          </div>
+        </section>
+
+        <section className="card grammar-map-card" aria-labelledby="grammar-map-title">
+          <div className="eyebrow">Full placeholder map</div>
+          <h3 className="section-title" id="grammar-map-title">All 18 Grammar concepts</h3>
+          <div className="grammar-domain-list">
+            {groupedConcepts.map((group) => (
+              <div className="grammar-domain" key={group.domain}>
+                <div className="grammar-domain-title">{group.domain}</div>
+                <div className="grammar-concept-list">
+                  {group.concepts.map((concept) => (
+                    <span className={`grammar-concept ${concept.status}`} key={concept.id}>
+                      <span>{concept.name}</span>
+                      <small>{concept.status}</small>
+                    </span>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+    </section>
+  );
+}

--- a/src/subjects/grammar/components/GrammarSummaryScene.jsx
+++ b/src/subjects/grammar/components/GrammarSummaryScene.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { GrammarAnalyticsScene } from './GrammarAnalyticsScene.jsx';
+
+function SummaryStat({ label, value, detail }) {
+  return (
+    <div className="grammar-stat">
+      <span>{label}</span>
+      <strong>{value}</strong>
+      {detail ? <small>{detail}</small> : null}
+    </div>
+  );
+}
+
+export function GrammarSummaryScene({ grammar, actions, learner, runtimeReadOnly }) {
+  const summary = grammar.summary || {};
+  const answered = Number(summary.answered) || 0;
+  const correct = Number(summary.correct) || 0;
+  const accuracy = answered ? Math.round((correct / answered) * 100) : 0;
+  const score = `${Number(summary.totalScore) || 0}/${Number(summary.totalMarks) || Math.max(1, answered)}`;
+
+  return (
+    <div className="grammar-summary-shell">
+      <section className="card grammar-summary-card" aria-labelledby="grammar-summary-title">
+        <div className="eyebrow">Grammar session summary</div>
+        <h2 className="section-title" id="grammar-summary-title">
+          {learner?.name || 'This learner'} completed a Grammar round
+        </h2>
+        <div className="grammar-summary-stats">
+          <SummaryStat label="Answered" value={answered} detail={summary.mode || 'practice'} />
+          <SummaryStat label="Correct" value={correct} detail={`${accuracy}% accuracy`} />
+          <SummaryStat label="Score" value={score} detail="marks" />
+        </div>
+        <div className="actions">
+          <button
+            className="btn primary"
+            type="button"
+            disabled={runtimeReadOnly || Boolean(grammar.pendingCommand)}
+            onClick={() => actions.dispatch('grammar-start-again')}
+          >
+            Start another round
+          </button>
+          <button className="btn secondary" type="button" onClick={() => actions.dispatch('grammar-back')}>
+            Back to Grammar setup
+          </button>
+        </div>
+      </section>
+      <GrammarAnalyticsScene grammar={grammar} actions={actions} learner={learner} runtimeReadOnly={runtimeReadOnly} />
+    </div>
+  );
+}

--- a/src/subjects/grammar/metadata.js
+++ b/src/subjects/grammar/metadata.js
@@ -219,15 +219,20 @@ function mergeConcepts(rawConcepts) {
   const byId = new Map((Array.isArray(rawConcepts) ? rawConcepts : [])
     .filter((concept) => concept && typeof concept === 'object' && !Array.isArray(concept))
     .map((concept) => [concept.id, concept]));
-  return GRAMMAR_CLIENT_CONCEPTS.map((concept) => ({
-    ...conceptFallback(concept),
-    ...(byId.get(concept.id) || {}),
-    id: concept.id,
-    name: concept.name,
-    domain: concept.domain,
-    summary: concept.summary,
-    punctuationForGrammar: Boolean(concept.punctuationForGrammar),
-  }));
+  return GRAMMAR_CLIENT_CONCEPTS.map((concept) => {
+    const workerConcept = byId.get(concept.id) || {};
+    return {
+      ...conceptFallback(concept),
+      ...workerConcept,
+      id: concept.id,
+      name: typeof workerConcept.name === 'string' && workerConcept.name ? workerConcept.name : concept.name,
+      domain: typeof workerConcept.domain === 'string' && workerConcept.domain ? workerConcept.domain : concept.domain,
+      summary: typeof workerConcept.summary === 'string' && workerConcept.summary ? workerConcept.summary : concept.summary,
+      punctuationForGrammar: typeof workerConcept.punctuationForGrammar === 'boolean'
+        ? workerConcept.punctuationForGrammar
+        : Boolean(concept.punctuationForGrammar),
+    };
+  });
 }
 
 function statsFromConcepts(concepts) {

--- a/src/subjects/grammar/metadata.js
+++ b/src/subjects/grammar/metadata.js
@@ -1,0 +1,314 @@
+export const GRAMMAR_SUBJECT_ID = 'grammar';
+export const GRAMMAR_REGION_IMAGE = '/assets/regions/the-clause-conservatory/the-clause-conservatory-cover.1280.webp';
+export const GRAMMAR_REGION_IMAGE_SMALL = '/assets/regions/the-clause-conservatory/the-clause-conservatory-cover.640.webp';
+
+export const GRAMMAR_CLIENT_CONCEPTS = Object.freeze([
+  {
+    id: 'sentence_functions',
+    domain: 'Sentence function',
+    name: 'Sentence functions',
+    summary: 'Statements tell, questions ask, commands instruct, and exclamations show strong feeling.',
+    punctuationForGrammar: true,
+  },
+  {
+    id: 'word_classes',
+    domain: 'Word classes',
+    name: 'Word classes',
+    summary: 'Spot the job a word is doing in a sentence: noun, verb, adjective, adverb, determiner, pronoun, conjunction or preposition.',
+    punctuationForGrammar: false,
+  },
+  {
+    id: 'noun_phrases',
+    domain: 'Phrases',
+    name: 'Expanded noun phrases',
+    summary: 'A noun phrase has a noun at its heart and can be expanded with adjectives, nouns or preposition phrases.',
+    punctuationForGrammar: false,
+  },
+  {
+    id: 'adverbials',
+    domain: 'Adverbials',
+    name: 'Adverbials and fronted adverbials',
+    summary: 'Adverbials often show when, where or how. Fronted adverbials come first and usually take a comma in KS2 contexts.',
+    punctuationForGrammar: true,
+  },
+  {
+    id: 'clauses',
+    domain: 'Clauses',
+    name: 'Subordinate clauses and conjunctions',
+    summary: 'A subordinate clause adds extra information and usually depends on a main clause.',
+    punctuationForGrammar: false,
+  },
+  {
+    id: 'relative_clauses',
+    domain: 'Clauses',
+    name: 'Relative clauses',
+    summary: 'A relative clause adds extra information about a noun, often using who, which, that, where, when or whose.',
+    punctuationForGrammar: false,
+  },
+  {
+    id: 'tense_aspect',
+    domain: 'Verb forms',
+    name: 'Tense and aspect',
+    summary: 'KS2 grammar includes past and present tense, progressive forms, present perfect and past perfect.',
+    punctuationForGrammar: false,
+  },
+  {
+    id: 'standard_english',
+    domain: 'Standard English',
+    name: 'Standard English forms',
+    summary: 'KS2 GPS expects standard written forms such as "we were" rather than local spoken forms like "we was".',
+    punctuationForGrammar: false,
+  },
+  {
+    id: 'pronouns_cohesion',
+    domain: 'Cohesion',
+    name: 'Pronouns and cohesion',
+    summary: 'Pronouns help avoid repetition, but the reader must still know clearly who or what each pronoun refers to.',
+    punctuationForGrammar: false,
+  },
+  {
+    id: 'formality',
+    domain: 'Register',
+    name: 'Formal and informal language',
+    summary: 'KS2 tests both formal vocabulary and formal sentence structures.',
+    punctuationForGrammar: false,
+  },
+  {
+    id: 'active_passive',
+    domain: 'Sentence structure',
+    name: 'Active and passive voice',
+    summary: 'Active voice foregrounds the doer. Passive voice foregrounds the thing affected or hides the doer.',
+    punctuationForGrammar: false,
+  },
+  {
+    id: 'subject_object',
+    domain: 'Sentence structure',
+    name: 'Subject and object',
+    summary: 'The subject usually does the action; the object usually receives it.',
+    punctuationForGrammar: false,
+  },
+  {
+    id: 'modal_verbs',
+    domain: 'Verb forms',
+    name: 'Modal verbs and possibility',
+    summary: 'Modal verbs such as might, should, will and must show different degrees of possibility, certainty, obligation or advice.',
+    punctuationForGrammar: false,
+  },
+  {
+    id: 'parenthesis_commas',
+    domain: 'Punctuation for grammar',
+    name: 'Parenthesis and commas',
+    summary: 'Brackets, dashes and paired commas can mark extra information.',
+    punctuationForGrammar: true,
+  },
+  {
+    id: 'speech_punctuation',
+    domain: 'Punctuation for grammar',
+    name: 'Direct speech punctuation',
+    summary: 'Direct speech punctuation depends on where the spoken words end and where the reporting clause begins.',
+    punctuationForGrammar: true,
+  },
+  {
+    id: 'apostrophes_possession',
+    domain: 'Punctuation for grammar',
+    name: 'Possession with apostrophes',
+    summary: 'KS2 grammar expects pupils to distinguish singular possession from plural possession.',
+    punctuationForGrammar: true,
+  },
+  {
+    id: 'boundary_punctuation',
+    domain: 'Punctuation for grammar',
+    name: 'Colons, semi-colons and dashes',
+    summary: 'These marks can show clear boundaries between ideas.',
+    punctuationForGrammar: true,
+  },
+  {
+    id: 'hyphen_ambiguity',
+    domain: 'Punctuation for grammar',
+    name: 'Hyphens to avoid ambiguity',
+    summary: 'A hyphen can join words so the reader sees the intended meaning clearly.',
+    punctuationForGrammar: true,
+  },
+]);
+
+export const GRAMMAR_ENABLED_MODES = Object.freeze([
+  { id: 'learn', label: 'Learn a concept', detail: 'Focused retrieval on one concept at a time.' },
+  { id: 'smart', label: 'Smart mixed review', detail: 'Worker-selected review across Grammar concepts.' },
+  { id: 'satsset', label: 'KS2-style mini-set', detail: 'A short mixed set with SATs-friendly question shapes.' },
+]);
+
+export const GRAMMAR_LOCKED_MODES = Object.freeze([
+  { id: 'trouble', label: 'Weak concepts drill', reason: 'coming-next' },
+  { id: 'surgery', label: 'Sentence surgery', reason: 'coming-next' },
+  { id: 'builder', label: 'Sentence builder', reason: 'coming-next' },
+  { id: 'worked', label: 'Worked examples', reason: 'coming-next' },
+  { id: 'faded', label: 'Faded guidance', reason: 'coming-next' },
+]);
+
+export const GRAMMAR_MONSTER_ROUTES = Object.freeze([
+  {
+    id: 'bracehart',
+    name: 'Bracehart',
+    route: 'Sentences and clauses',
+    conceptIds: ['sentence_functions', 'clauses', 'relative_clauses'],
+  },
+  {
+    id: 'glossbloom',
+    name: 'Glossbloom',
+    route: 'Words and phrases',
+    conceptIds: ['word_classes', 'noun_phrases'],
+  },
+  {
+    id: 'loomrill',
+    name: 'Loomrill',
+    route: 'Adverbials and cohesion',
+    conceptIds: ['adverbials', 'pronouns_cohesion'],
+  },
+  {
+    id: 'chronalyx',
+    name: 'Chronalyx',
+    route: 'Verb forms',
+    conceptIds: ['tense_aspect', 'modal_verbs'],
+  },
+  {
+    id: 'couronnail',
+    name: 'Couronnail',
+    route: 'Standard English and register',
+    conceptIds: ['standard_english', 'formality'],
+  },
+  {
+    id: 'mirrane',
+    name: 'Mirrane',
+    route: 'Sentence voice',
+    conceptIds: ['active_passive', 'subject_object'],
+  },
+  {
+    id: 'concordium',
+    name: 'Concordium',
+    route: 'Whole Grammar mastery',
+    conceptIds: GRAMMAR_CLIENT_CONCEPTS.map((concept) => concept.id),
+  },
+]);
+
+export const DEFAULT_GRAMMAR_PREFS = Object.freeze({
+  mode: 'smart',
+  roundLength: 5,
+  focusConceptId: '',
+});
+
+export function grammarMonsterAsset(id, size = 320) {
+  const safeId = String(id || '').replace(/[^a-z0-9-]/g, '');
+  const safeSize = [320, 640, 1280].includes(Number(size)) ? Number(size) : 320;
+  return `/assets/monsters/${safeId}/b1/${safeId}-b1-0.${safeSize}.webp`;
+}
+
+function conceptFallback(concept) {
+  return {
+    ...concept,
+    status: 'new',
+    attempts: 0,
+    correct: 0,
+    wrong: 0,
+    strength: 0.25,
+    dueAt: 0,
+    correctStreak: 0,
+  };
+}
+
+function mergeConcepts(rawConcepts) {
+  const byId = new Map((Array.isArray(rawConcepts) ? rawConcepts : [])
+    .filter((concept) => concept && typeof concept === 'object' && !Array.isArray(concept))
+    .map((concept) => [concept.id, concept]));
+  return GRAMMAR_CLIENT_CONCEPTS.map((concept) => ({
+    ...conceptFallback(concept),
+    ...(byId.get(concept.id) || {}),
+    id: concept.id,
+    name: concept.name,
+    domain: concept.domain,
+    summary: concept.summary,
+    punctuationForGrammar: Boolean(concept.punctuationForGrammar),
+  }));
+}
+
+function statsFromConcepts(concepts) {
+  const counts = { total: concepts.length, new: 0, learning: 0, weak: 0, due: 0, secured: 0 };
+  for (const concept of concepts) {
+    const status = ['new', 'learning', 'weak', 'due', 'secured'].includes(concept.status)
+      ? concept.status
+      : 'new';
+    counts[status] += 1;
+  }
+  return {
+    concepts: counts,
+    templates: {
+      total: 51,
+      selectedResponse: 31,
+      constructedResponse: 20,
+    },
+  };
+}
+
+export function normaliseGrammarReadModel(rawValue = {}, learnerId = '') {
+  const raw = rawValue && typeof rawValue === 'object' && !Array.isArray(rawValue) ? rawValue : {};
+  const concepts = mergeConcepts(raw.analytics?.concepts);
+  const stats = raw.stats && typeof raw.stats === 'object' && !Array.isArray(raw.stats)
+    ? {
+      ...statsFromConcepts(concepts),
+      ...raw.stats,
+      concepts: { ...statsFromConcepts(concepts).concepts, ...(raw.stats.concepts || {}) },
+      templates: { ...statsFromConcepts(concepts).templates, ...(raw.stats.templates || {}) },
+    }
+    : statsFromConcepts(concepts);
+  const phase = ['dashboard', 'session', 'feedback', 'summary'].includes(raw.phase)
+    ? raw.phase
+    : 'dashboard';
+
+  return {
+    subjectId: GRAMMAR_SUBJECT_ID,
+    learnerId: raw.learnerId || learnerId,
+    version: Number(raw.version) || 1,
+    authority: raw.authority || 'client-metadata',
+    content: {
+      releaseId: raw.content?.releaseId || '',
+      conceptCount: GRAMMAR_CLIENT_CONCEPTS.length,
+      templateCount: 51,
+      questionTypes: raw.content?.questionTypes || {},
+    },
+    phase,
+    awaitingAdvance: Boolean(raw.awaitingAdvance),
+    session: raw.session && typeof raw.session === 'object' && !Array.isArray(raw.session) ? raw.session : null,
+    feedback: raw.feedback && typeof raw.feedback === 'object' && !Array.isArray(raw.feedback) ? raw.feedback : null,
+    summary: raw.summary && typeof raw.summary === 'object' && !Array.isArray(raw.summary) ? raw.summary : null,
+    prefs: {
+      ...DEFAULT_GRAMMAR_PREFS,
+      ...(raw.prefs && typeof raw.prefs === 'object' && !Array.isArray(raw.prefs) ? raw.prefs : {}),
+    },
+    stats,
+    analytics: {
+      concepts,
+      misconceptionCounts: raw.analytics?.misconceptionCounts || {},
+      recentAttempts: Array.isArray(raw.analytics?.recentAttempts) ? raw.analytics.recentAttempts.slice(-12) : [],
+    },
+    capabilities: {
+      enabledModes: Array.isArray(raw.capabilities?.enabledModes) && raw.capabilities.enabledModes.length
+        ? raw.capabilities.enabledModes
+        : GRAMMAR_ENABLED_MODES,
+      lockedModes: Array.isArray(raw.capabilities?.lockedModes) && raw.capabilities.lockedModes.length
+        ? raw.capabilities.lockedModes
+        : GRAMMAR_LOCKED_MODES,
+    },
+    projections: raw.projections || null,
+    pendingCommand: raw.pendingCommand || '',
+    error: typeof raw.error === 'string' ? raw.error : '',
+  };
+}
+
+export function groupedGrammarConcepts(concepts = []) {
+  const groups = new Map();
+  for (const concept of concepts) {
+    const domain = concept.domain || 'Grammar';
+    if (!groups.has(domain)) groups.set(domain, []);
+    groups.get(domain).push(concept);
+  }
+  return Array.from(groups.entries()).map(([domain, entries]) => ({ domain, concepts: entries }));
+}

--- a/src/subjects/grammar/module.js
+++ b/src/subjects/grammar/module.js
@@ -58,6 +58,8 @@ function applyRemoteReadModel(context, response, { learnerId } = {}) {
 function sendGrammarCommand(context, command, payload = {}) {
   const learnerId = selectedLearnerId(context);
   if (!learnerId) return true;
+  const ui = selectedGrammarUi(context);
+  if (ui.pendingCommand) return true;
   if (context.runtimeReadOnly) {
     setGrammarError(context, 'Practice is read-only while sync is degraded. Retry sync before continuing.');
     return true;

--- a/src/subjects/grammar/module.js
+++ b/src/subjects/grammar/module.js
@@ -13,16 +13,19 @@ function selectedGrammarUi(context) {
   return normaliseGrammarReadModel(context?.appState?.subjectUi?.[GRAMMAR_SUBJECT_ID], learnerId);
 }
 
-function setGrammarError(context, message) {
+function setGrammarError(context, message, { learnerId = selectedLearnerId(context) } = {}) {
+  if (learnerId && selectedLearnerId(context) !== learnerId) return;
   context.store.updateSubjectUi(GRAMMAR_SUBJECT_ID, (current) => ({
-    ...normaliseGrammarReadModel(current, selectedLearnerId(context)),
+    ...normaliseGrammarReadModel(current, learnerId),
     pendingCommand: '',
     error: message || 'Grammar practice is temporarily unavailable.',
   }));
 }
 
-function applyRemoteReadModel(context, response) {
-  const learnerId = selectedLearnerId(context);
+function applyRemoteReadModel(context, response, { learnerId } = {}) {
+  if (!learnerId || selectedLearnerId(context) !== learnerId) return;
+  const responseLearnerId = String(response?.subjectReadModel?.learnerId || learnerId);
+  if (responseLearnerId && responseLearnerId !== learnerId) return;
   if (response?.projections?.rewards?.toastEvents?.length) {
     context.store.pushToasts(response.projections.rewards.toastEvents);
   }
@@ -65,10 +68,10 @@ function sendGrammarCommand(context, command, payload = {}) {
     command,
     payload,
   }).then((response) => {
-    applyRemoteReadModel(context, response);
+    applyRemoteReadModel(context, response, { learnerId });
   }).catch((error) => {
     globalThis.console?.warn?.('Grammar command failed.', error);
-    setGrammarError(context, error?.payload?.message || error?.message || 'The Grammar command could not be completed.');
+    setGrammarError(context, error?.payload?.message || error?.message || 'The Grammar command could not be completed.', { learnerId });
   });
 
   return true;
@@ -103,6 +106,16 @@ function responseFromFormData(formData) {
     response[key] = String(value ?? '');
   }
   return response;
+}
+
+function hasGrammarResponseValue(value) {
+  if (Array.isArray(value)) return value.some((entry) => String(entry || '').trim());
+  return String(value ?? '').trim().length > 0;
+}
+
+function responseHasAnswer(response) {
+  if (!response || typeof response !== 'object' || Array.isArray(response)) return false;
+  return Object.entries(response).some(([, value]) => hasGrammarResponseValue(value));
 }
 
 function resetToDashboard(context) {
@@ -222,6 +235,10 @@ export const grammarModule = {
 
     if (action === 'grammar-submit-form') {
       const response = responseFromFormData(context.data?.formData);
+      if (!responseHasAnswer(response)) {
+        setGrammarError(context, 'Choose or type an answer before submitting.', { learnerId });
+        return true;
+      }
       if (service?.submitAnswer) return applyLocalTransition(context, service.submitAnswer(learnerId, ui, response));
       return sendGrammarCommand(context, 'submit-answer', { response });
     }

--- a/src/subjects/grammar/module.js
+++ b/src/subjects/grammar/module.js
@@ -1,0 +1,242 @@
+import {
+  DEFAULT_GRAMMAR_PREFS,
+  GRAMMAR_SUBJECT_ID,
+  normaliseGrammarReadModel,
+} from './metadata.js';
+
+function selectedLearnerId(context) {
+  return context?.appState?.learners?.selectedId || '';
+}
+
+function selectedGrammarUi(context) {
+  const learnerId = selectedLearnerId(context);
+  return normaliseGrammarReadModel(context?.appState?.subjectUi?.[GRAMMAR_SUBJECT_ID], learnerId);
+}
+
+function setGrammarError(context, message) {
+  context.store.updateSubjectUi(GRAMMAR_SUBJECT_ID, (current) => ({
+    ...normaliseGrammarReadModel(current, selectedLearnerId(context)),
+    pendingCommand: '',
+    error: message || 'Grammar practice is temporarily unavailable.',
+  }));
+}
+
+function applyRemoteReadModel(context, response) {
+  const learnerId = selectedLearnerId(context);
+  if (response?.projections?.rewards?.toastEvents?.length) {
+    context.store.pushToasts(response.projections.rewards.toastEvents);
+  }
+  if (response?.projections?.rewards?.events?.length) {
+    context.store.pushMonsterCelebrations(response.projections.rewards.events);
+  }
+  if (response?.subjectReadModel) {
+    context.store.updateSubjectUi(GRAMMAR_SUBJECT_ID, {
+      ...normaliseGrammarReadModel(response.subjectReadModel, learnerId),
+      pendingCommand: '',
+      error: '',
+    });
+    return;
+  }
+  context.store.reloadFromRepositories?.({ preserveRoute: true });
+}
+
+function sendGrammarCommand(context, command, payload = {}) {
+  const learnerId = selectedLearnerId(context);
+  if (!learnerId) return true;
+  if (context.runtimeReadOnly) {
+    setGrammarError(context, 'Practice is read-only while sync is degraded. Retry sync before continuing.');
+    return true;
+  }
+  const client = context.subjectCommands;
+  if (!client?.send) {
+    setGrammarError(context, 'Grammar practice needs the Worker command boundary.');
+    return true;
+  }
+
+  context.store.updateSubjectUi(GRAMMAR_SUBJECT_ID, (current) => ({
+    ...normaliseGrammarReadModel(current, learnerId),
+    pendingCommand: command,
+    error: '',
+  }));
+
+  client.send({
+    subjectId: GRAMMAR_SUBJECT_ID,
+    learnerId,
+    command,
+    payload,
+  }).then((response) => {
+    applyRemoteReadModel(context, response);
+  }).catch((error) => {
+    globalThis.console?.warn?.('Grammar command failed.', error);
+    setGrammarError(context, error?.payload?.message || error?.message || 'The Grammar command could not be completed.');
+  });
+
+  return true;
+}
+
+function applyLocalTransition(context, transition) {
+  if (!transition) return true;
+  return context.applySubjectTransition(GRAMMAR_SUBJECT_ID, transition);
+}
+
+function grammarStartPayload(ui, data = {}) {
+  const prefs = ui.prefs || DEFAULT_GRAMMAR_PREFS;
+  return {
+    mode: data.mode || prefs.mode || DEFAULT_GRAMMAR_PREFS.mode,
+    roundLength: data.roundLength || prefs.roundLength || DEFAULT_GRAMMAR_PREFS.roundLength,
+    focusConceptId: Object.prototype.hasOwnProperty.call(data, 'focusConceptId')
+      ? data.focusConceptId
+      : prefs.focusConceptId || '',
+    ...(data.payload && typeof data.payload === 'object' && !Array.isArray(data.payload) ? data.payload : {}),
+  };
+}
+
+function responseFromFormData(formData) {
+  if (!formData?.entries) return {};
+  const response = {};
+  for (const [key, value] of formData.entries()) {
+    if (!key || key === '_action') continue;
+    if (key === 'selected') {
+      response.selected = formData.getAll('selected').map((entry) => String(entry));
+      continue;
+    }
+    response[key] = String(value ?? '');
+  }
+  return response;
+}
+
+function resetToDashboard(context) {
+  const learnerId = selectedLearnerId(context);
+  context.store.updateSubjectUi(GRAMMAR_SUBJECT_ID, (current) => ({
+    ...normaliseGrammarReadModel(current, learnerId),
+    phase: 'dashboard',
+    session: null,
+    feedback: null,
+    summary: null,
+    awaitingAdvance: false,
+    pendingCommand: '',
+    error: '',
+  }));
+  return true;
+}
+
+function resetToDashboardWithPrefs(context, prefs) {
+  const learnerId = selectedLearnerId(context);
+  context.store.updateSubjectUi(GRAMMAR_SUBJECT_ID, (current) => {
+    const ui = normaliseGrammarReadModel(current, learnerId);
+    return {
+      ...ui,
+      prefs: { ...ui.prefs, ...(prefs || {}) },
+      phase: 'dashboard',
+      session: null,
+      feedback: null,
+      summary: null,
+      awaitingAdvance: false,
+      pendingCommand: '',
+      error: '',
+    };
+  });
+  return true;
+}
+
+export const grammarModule = {
+  id: GRAMMAR_SUBJECT_ID,
+  name: 'Grammar',
+  blurb: 'Word classes, clauses, tenses and sentence shape.',
+  accent: '#2E8479',
+  accentSoft: '#CFE8E3',
+  accentTint: '#E3F1EE',
+  icon: 'speech',
+  available: true,
+  reactPractice: true,
+  initState() {
+    return normaliseGrammarReadModel();
+  },
+  getDashboardStats(appState) {
+    const learnerId = appState.learners?.selectedId || '';
+    const ui = normaliseGrammarReadModel(appState.subjectUi?.[GRAMMAR_SUBJECT_ID], learnerId);
+    const counts = ui.stats?.concepts || {};
+    const total = Math.max(1, Number(counts.total) || 0);
+    const secured = Number(counts.secured) || 0;
+    const due = (Number(counts.due) || 0) + (Number(counts.weak) || 0);
+    const nextUp = ui.phase === 'session' || ui.phase === 'feedback'
+      ? 'Continue Grammar round'
+      : due
+        ? 'Review due Grammar concepts'
+        : 'Start Grammar retrieval';
+    return {
+      pct: Math.round((secured / total) * 100),
+      due,
+      streak: secured,
+      nextUp,
+    };
+  },
+  handleAction(action, context) {
+    if (!String(action || '').startsWith('grammar-')) return false;
+
+    const learnerId = selectedLearnerId(context);
+    const ui = selectedGrammarUi(context);
+    const service = context.service;
+
+    if (action === 'grammar-back') {
+      if ((ui.phase === 'session' || ui.phase === 'feedback') && ui.session) {
+        if (context.data?.skipConfirm !== true && globalThis.confirm?.('End this Grammar session now?') === false) return true;
+        if (service?.endSession) return applyLocalTransition(context, service.endSession(learnerId, ui));
+        return sendGrammarCommand(context, 'end-session');
+      }
+      return resetToDashboard(context);
+    }
+
+    if (action === 'grammar-set-mode') {
+      const mode = context.data?.value || DEFAULT_GRAMMAR_PREFS.mode;
+      if (service?.savePrefs) {
+        const prefs = service.savePrefs(learnerId, { mode });
+        return resetToDashboardWithPrefs(context, prefs);
+      }
+      return sendGrammarCommand(context, 'save-prefs', { prefs: { mode } });
+    }
+
+    if (action === 'grammar-set-round-length') {
+      const roundLength = Number(context.data?.value) || DEFAULT_GRAMMAR_PREFS.roundLength;
+      if (service?.savePrefs) {
+        const prefs = service.savePrefs(learnerId, { roundLength });
+        return resetToDashboardWithPrefs(context, prefs);
+      }
+      return sendGrammarCommand(context, 'save-prefs', { prefs: { roundLength } });
+    }
+
+    if (action === 'grammar-set-focus') {
+      const focusConceptId = context.data?.value || '';
+      if (service?.savePrefs) {
+        const prefs = service.savePrefs(learnerId, { focusConceptId });
+        return resetToDashboardWithPrefs(context, prefs);
+      }
+      return sendGrammarCommand(context, 'save-prefs', { prefs: { focusConceptId } });
+    }
+
+    if (action === 'grammar-start' || action === 'grammar-start-again') {
+      const payload = grammarStartPayload(ui, context.data || {});
+      if (service?.startSession) return applyLocalTransition(context, service.startSession(learnerId, payload));
+      return sendGrammarCommand(context, 'start-session', payload);
+    }
+
+    if (action === 'grammar-submit-form') {
+      const response = responseFromFormData(context.data?.formData);
+      if (service?.submitAnswer) return applyLocalTransition(context, service.submitAnswer(learnerId, ui, response));
+      return sendGrammarCommand(context, 'submit-answer', { response });
+    }
+
+    if (action === 'grammar-continue') {
+      if (service?.continueSession) return applyLocalTransition(context, service.continueSession(learnerId, ui));
+      return sendGrammarCommand(context, 'continue-session');
+    }
+
+    if (action === 'grammar-end-early') {
+      if (context.data?.skipConfirm !== true && globalThis.confirm?.('End this Grammar session now?') === false) return true;
+      if (service?.endSession) return applyLocalTransition(context, service.endSession(learnerId, ui));
+      return sendGrammarCommand(context, 'end-session');
+    }
+
+    return false;
+  },
+};

--- a/src/subjects/grammar/module.js
+++ b/src/subjects/grammar/module.js
@@ -5,17 +5,27 @@ import {
 } from './metadata.js';
 
 function selectedLearnerId(context) {
-  return context?.appState?.learners?.selectedId || '';
+  return (context?.store?.getState?.() || context?.appState || {})?.learners?.selectedId || '';
 }
 
 function selectedGrammarUi(context) {
+  const appState = context?.store?.getState?.() || context?.appState || {};
   const learnerId = selectedLearnerId(context);
-  return normaliseGrammarReadModel(context?.appState?.subjectUi?.[GRAMMAR_SUBJECT_ID], learnerId);
+  return normaliseGrammarReadModel(appState?.subjectUi?.[GRAMMAR_SUBJECT_ID], learnerId);
+}
+
+function updateGrammarUiForLearner(context, learnerId, updater) {
+  if (!learnerId) return false;
+  if (typeof context?.store?.updateSubjectUiForLearner === 'function') {
+    return context.store.updateSubjectUiForLearner(learnerId, GRAMMAR_SUBJECT_ID, updater);
+  }
+  if (selectedLearnerId(context) !== learnerId) return false;
+  context.store.updateSubjectUi(GRAMMAR_SUBJECT_ID, updater);
+  return true;
 }
 
 function setGrammarError(context, message, { learnerId = selectedLearnerId(context) } = {}) {
-  if (learnerId && selectedLearnerId(context) !== learnerId) return;
-  context.store.updateSubjectUi(GRAMMAR_SUBJECT_ID, (current) => ({
+  updateGrammarUiForLearner(context, learnerId, (current) => ({
     ...normaliseGrammarReadModel(current, learnerId),
     pendingCommand: '',
     error: message || 'Grammar practice is temporarily unavailable.',
@@ -23,23 +33,25 @@ function setGrammarError(context, message, { learnerId = selectedLearnerId(conte
 }
 
 function applyRemoteReadModel(context, response, { learnerId } = {}) {
-  if (!learnerId || selectedLearnerId(context) !== learnerId) return;
+  if (!learnerId) return;
   const responseLearnerId = String(response?.subjectReadModel?.learnerId || learnerId);
   if (responseLearnerId && responseLearnerId !== learnerId) return;
-  if (response?.projections?.rewards?.toastEvents?.length) {
+  const isSelectedLearner = selectedLearnerId(context) === learnerId;
+  if (isSelectedLearner && response?.projections?.rewards?.toastEvents?.length) {
     context.store.pushToasts(response.projections.rewards.toastEvents);
   }
-  if (response?.projections?.rewards?.events?.length) {
+  if (isSelectedLearner && response?.projections?.rewards?.events?.length) {
     context.store.pushMonsterCelebrations(response.projections.rewards.events);
   }
   if (response?.subjectReadModel) {
-    context.store.updateSubjectUi(GRAMMAR_SUBJECT_ID, {
+    updateGrammarUiForLearner(context, learnerId, {
       ...normaliseGrammarReadModel(response.subjectReadModel, learnerId),
       pendingCommand: '',
       error: '',
     });
     return;
   }
+  if (!isSelectedLearner) return;
   context.store.reloadFromRepositories?.({ preserveRoute: true });
 }
 

--- a/src/surfaces/subject/SubjectRoute.jsx
+++ b/src/surfaces/subject/SubjectRoute.jsx
@@ -3,10 +3,12 @@ import { SubjectBreadcrumb } from '../shell/SubjectBreadcrumb.jsx';
 import { SubjectRouteContext } from './SubjectRouteContext.js';
 import { SubjectRuntimeFallback } from './SubjectRuntimeFallback.jsx';
 import { PunctuationPracticeSurface } from '../../subjects/punctuation/components/PunctuationPracticeSurface.jsx';
+import { GrammarPracticeSurface } from '../../subjects/grammar/components/GrammarPracticeSurface.jsx';
 import { SpellingPracticeSurface } from '../../subjects/spelling/components/SpellingPracticeSurface.jsx';
 import { isSubjectExposed } from '../../platform/core/subject-availability.js';
 
 const REACT_SUBJECT_COMPONENTS = Object.freeze({
+  grammar: GrammarPracticeSurface,
   punctuation: PunctuationPracticeSurface,
   spelling: SpellingPracticeSurface,
 });

--- a/styles/app.css
+++ b/styles/app.css
@@ -6146,6 +6146,579 @@ textarea:focus-visible {
   .wb-drill-form { flex-direction: column; align-items: stretch; }
 }
 
+/* ---------- Grammar Stage 1 surface ---------- */
+.grammar-surface,
+.grammar-summary-shell {
+  display: grid;
+  gap: 20px;
+}
+
+.grammar-setup {
+  display: grid;
+  gap: 20px;
+}
+
+.grammar-hero {
+  position: relative;
+  min-height: 360px;
+  overflow: hidden;
+  border-radius: var(--radius);
+  background: #12372f;
+  color: #fff;
+  isolation: isolate;
+}
+
+.grammar-hero picture,
+.grammar-hero img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.grammar-hero img {
+  object-fit: cover;
+  filter: saturate(1.02) brightness(0.74);
+}
+
+.grammar-hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(90deg, rgba(8, 34, 30, 0.88) 0%, rgba(8, 34, 30, 0.64) 46%, rgba(8, 34, 30, 0.1) 100%),
+    linear-gradient(0deg, rgba(0, 0, 0, 0.3), transparent 42%);
+  z-index: 0;
+}
+
+.grammar-hero-copy {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 14px;
+  max-width: 720px;
+  padding: clamp(28px, 5vw, 56px);
+}
+
+.grammar-hero .eyebrow {
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.grammar-hero h2 {
+  margin: 0;
+  font-family: var(--font-serif);
+  font-size: clamp(2.1rem, 5vw, 4rem);
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+.grammar-hero p {
+  max-width: 58ch;
+  margin: 0;
+  color: rgba(255, 255, 255, 0.88);
+  line-height: 1.55;
+}
+
+.grammar-hero-stats,
+.grammar-summary-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.grammar-stat {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  padding: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.12);
+  backdrop-filter: blur(8px);
+}
+
+.grammar-summary-card .grammar-stat,
+.grammar-analytics .grammar-stat {
+  border-color: var(--line);
+  background: var(--panel-soft);
+  backdrop-filter: none;
+}
+
+.grammar-stat span,
+.grammar-stat small {
+  color: inherit;
+  opacity: 0.78;
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.grammar-stat strong {
+  font-size: 1.8rem;
+  line-height: 1;
+}
+
+.grammar-setup-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr);
+  gap: 20px;
+  align-items: start;
+}
+
+.grammar-start-card,
+.grammar-map-card,
+.grammar-analytics,
+.grammar-summary-card {
+  border-top: 4px solid #2e8479;
+}
+
+.grammar-mode-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.grammar-mode {
+  appearance: none;
+  display: grid;
+  gap: 5px;
+  min-height: 92px;
+  padding: 14px;
+  text-align: left;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel-soft);
+  color: var(--ink);
+  cursor: pointer;
+}
+
+.grammar-mode:hover {
+  border-color: #94bdb6;
+}
+
+.grammar-mode.selected {
+  border-color: #2e8479;
+  box-shadow: 0 0 0 2px rgba(46, 132, 121, 0.14);
+}
+
+.grammar-mode.locked {
+  cursor: not-allowed;
+  opacity: 0.64;
+}
+
+.grammar-mode span {
+  font-weight: 900;
+}
+
+.grammar-mode small {
+  color: var(--muted);
+  line-height: 1.35;
+}
+
+.grammar-controls {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(120px, 0.6fr);
+  gap: 12px;
+  margin: 16px 0;
+}
+
+.grammar-domain-list,
+.grammar-evidence-list {
+  display: grid;
+  gap: 14px;
+  margin-top: 16px;
+}
+
+.grammar-domain,
+.grammar-evidence-domain {
+  display: grid;
+  gap: 8px;
+}
+
+.grammar-domain-title,
+.grammar-evidence-domain > strong {
+  color: var(--ink);
+  font-size: 0.92rem;
+  font-weight: 900;
+}
+
+.grammar-concept-list,
+.grammar-evidence-domain > div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.grammar-concept,
+.grammar-mini-concept {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 34px;
+  padding: 7px 10px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel-soft);
+  color: var(--ink-2);
+  font-size: 0.86rem;
+  font-weight: 800;
+}
+
+.grammar-concept small {
+  color: var(--muted);
+  font-size: 0.74rem;
+  text-transform: uppercase;
+}
+
+.grammar-concept.secured,
+.grammar-mini-concept.secured {
+  background: var(--good-soft);
+  border-color: #b8dfca;
+  color: var(--good);
+}
+
+.grammar-concept.due,
+.grammar-mini-concept.due,
+.grammar-concept.weak,
+.grammar-mini-concept.weak {
+  background: var(--warn-soft);
+  border-color: #edd9ae;
+  color: #8f5f16;
+}
+
+.grammar-session {
+  display: grid;
+  gap: 18px;
+}
+
+.grammar-session-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  min-height: 92px;
+  padding: 22px;
+  border-radius: var(--radius);
+  background: linear-gradient(135deg, #12372f, #2e8479);
+  color: #fff;
+}
+
+.grammar-session-head .eyebrow {
+  color: rgba(255, 255, 255, 0.74);
+}
+
+.grammar-session-head h2 {
+  margin: 0;
+  font-family: var(--font-serif);
+  font-size: clamp(1.6rem, 3vw, 2.5rem);
+  line-height: 1.08;
+  letter-spacing: 0;
+}
+
+.grammar-progress {
+  display: grid;
+  place-items: center;
+  flex: 0 0 auto;
+  width: 82px;
+  height: 82px;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.grammar-progress span {
+  font-size: 1.65rem;
+  font-weight: 950;
+  line-height: 1;
+}
+
+.grammar-progress small {
+  opacity: 0.78;
+  font-weight: 800;
+}
+
+.grammar-prompt-card {
+  display: grid;
+  gap: 18px;
+  padding: clamp(22px, 4vw, 34px);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--panel);
+  box-shadow: var(--shadow);
+}
+
+.grammar-prompt {
+  margin: 0;
+  color: var(--ink);
+  font-family: var(--font-serif);
+  font-size: clamp(1.45rem, 3vw, 2.1rem);
+  line-height: 1.22;
+  letter-spacing: 0;
+}
+
+.grammar-check-line {
+  margin: -4px 0 0;
+  color: var(--ink-2);
+  line-height: 1.5;
+}
+
+.grammar-answer-form {
+  display: grid;
+  gap: 16px;
+}
+
+.grammar-choice-list {
+  display: grid;
+  gap: 10px;
+}
+
+.grammar-choice-list.tokens {
+  grid-template-columns: repeat(auto-fit, minmax(100px, max-content));
+}
+
+.grammar-choice-list.compact {
+  grid-template-columns: repeat(auto-fit, minmax(120px, max-content));
+}
+
+.grammar-choice {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 44px;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel-soft);
+  color: var(--ink);
+  font-weight: 800;
+}
+
+.grammar-choice input {
+  flex: 0 0 auto;
+}
+
+.grammar-table-wrap {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.grammar-table-choice {
+  width: 100%;
+  min-width: 640px;
+  border-collapse: collapse;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.grammar-table-choice th,
+.grammar-table-choice td {
+  padding: 10px;
+  border-bottom: 1px solid var(--line);
+  text-align: left;
+  vertical-align: middle;
+}
+
+.grammar-table-choice th:not(:first-child),
+.grammar-table-choice td:not(:first-child) {
+  text-align: center;
+}
+
+.grammar-table-choice thead th {
+  background: var(--panel-soft);
+  color: var(--ink-2);
+  font-size: 0.82rem;
+  text-transform: capitalize;
+}
+
+.grammar-multi-fields {
+  display: grid;
+  gap: 12px;
+}
+
+.grammar-fieldset {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+}
+
+.grammar-fieldset legend {
+  padding: 0 6px;
+  color: var(--ink-2);
+  font-weight: 900;
+}
+
+.grammar-textarea {
+  min-height: 132px;
+  resize: vertical;
+}
+
+.grammar-summary-card {
+  display: grid;
+  gap: 18px;
+}
+
+.grammar-summary-stats {
+  margin-top: 4px;
+}
+
+.grammar-status-strip {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.grammar-status-count {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel-soft);
+}
+
+.grammar-status-count strong {
+  font-size: 1.4rem;
+  line-height: 1;
+}
+
+.grammar-status-count span {
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.grammar-status-count.secured {
+  background: var(--good-soft);
+  color: var(--good);
+  border-color: #b8dfca;
+}
+
+.grammar-status-count.due,
+.grammar-status-count.weak {
+  background: var(--warn-soft);
+  color: #8f5f16;
+  border-color: #edd9ae;
+}
+
+.grammar-analytics-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(280px, 0.9fr);
+  gap: 18px;
+  align-items: start;
+}
+
+.grammar-route-panel {
+  display: grid;
+  gap: 10px;
+}
+
+.grammar-monster-grid {
+  display: grid;
+  gap: 10px;
+}
+
+.grammar-monster-route {
+  display: grid;
+  grid-template-columns: 58px minmax(0, 1fr);
+  gap: 12px;
+  align-items: center;
+  min-height: 72px;
+  padding: 10px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel-soft);
+}
+
+.grammar-monster-route img {
+  width: 58px;
+  height: 58px;
+  object-fit: contain;
+}
+
+.grammar-monster-route div {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.grammar-monster-route strong,
+.grammar-monster-route span,
+.grammar-monster-route small {
+  overflow-wrap: anywhere;
+}
+
+.grammar-monster-route span,
+.grammar-monster-route small {
+  color: var(--muted);
+}
+
+.grammar-recent {
+  margin-top: 18px;
+}
+
+.grammar-recent ol {
+  display: grid;
+  gap: 8px;
+  margin: 10px 0 0;
+  padding-left: 20px;
+}
+
+.grammar-recent li {
+  line-height: 1.45;
+}
+
+.grammar-recent li span {
+  display: block;
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+@media (max-width: 980px) {
+  .grammar-setup-grid,
+  .grammar-analytics-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .grammar-hero {
+    min-height: 430px;
+  }
+  .grammar-hero::after {
+    background: linear-gradient(0deg, rgba(8, 34, 30, 0.9) 0%, rgba(8, 34, 30, 0.58) 70%, rgba(8, 34, 30, 0.16) 100%);
+  }
+  .grammar-hero-copy {
+    padding: 24px;
+    align-content: end;
+    min-height: 430px;
+  }
+  .grammar-hero-stats,
+  .grammar-summary-stats,
+  .grammar-status-strip,
+  .grammar-mode-grid,
+  .grammar-controls {
+    grid-template-columns: 1fr;
+  }
+  .grammar-session-head {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+  .grammar-progress {
+    width: 72px;
+    height: 72px;
+  }
+  .grammar-choice-list.tokens,
+  .grammar-choice-list.compact {
+    grid-template-columns: 1fr;
+  }
+}
+
 /* ---------- Mobile tightening (port-fix) ---------- */
 
 /* 1. Word bank long list: cap scroll within card at phone sizes */

--- a/tests/app-controller.test.js
+++ b/tests/app-controller.test.js
@@ -288,6 +288,54 @@ test('controller keeps late Grammar command responses scoped to their original l
   assert.equal(controller.repositories.subjectStates.read(learnerB, 'grammar').ui, null);
 });
 
+test('controller ignores setup preference commands while Grammar start is pending', async () => {
+  const storage = installMemoryStorage();
+  const repositories = createLocalPlatformRepositories({ storage });
+  let resolveStart;
+  const subjectCommands = {
+    requests: [],
+    send(request) {
+      this.requests.push(request);
+      return new Promise((resolve) => {
+        if (request.command === 'start-session') resolveStart = resolve;
+      });
+    },
+  };
+  const controller = createAppController({
+    repositories,
+    extraContext: {
+      runtimeReadOnly: false,
+      subjectCommands,
+    },
+  });
+  const learnerId = controller.store.getState().learners.selectedId;
+
+  controller.dispatch('open-subject', { subjectId: 'grammar' });
+  controller.dispatch('grammar-start');
+  controller.dispatch('grammar-set-mode', { value: 'learn' });
+  controller.dispatch('grammar-set-round-length', { value: '15' });
+
+  assert.equal(subjectCommands.requests.length, 1);
+  assert.equal(subjectCommands.requests[0].command, 'start-session');
+  assert.equal(controller.store.getState().subjectUi.grammar.pendingCommand, 'start-session');
+
+  resolveStart({
+    subjectReadModel: normaliseGrammarReadModel({
+      learnerId,
+      phase: 'session',
+      session: { id: 'grammar-session-a' },
+      analytics: { concepts: [] },
+    }, learnerId),
+  });
+  await Promise.resolve();
+
+  const grammar = controller.store.getState().subjectUi.grammar;
+  assert.equal(grammar.phase, 'session');
+  assert.equal(grammar.session.id, 'grammar-session-a');
+  assert.equal(grammar.prefs.mode, 'smart');
+  assert.equal(grammar.prefs.roundLength, 5);
+});
+
 test('controller stops spelling audio when feedback has no auto-speak cue', () => {
   installMemoryStorage();
   const tts = {

--- a/tests/app-controller.test.js
+++ b/tests/app-controller.test.js
@@ -17,6 +17,7 @@ import {
   LOCAL_CODEX_STAGE_REVIEW_LEARNER_IDS,
 } from '../src/platform/core/local-review-profile.js';
 import { SUBJECTS } from '../src/platform/core/subject-registry.js';
+import { normaliseGrammarReadModel } from '../src/subjects/grammar/metadata.js';
 import { installMemoryStorage } from './helpers/memory-storage.js';
 
 function typedFormData(value) {
@@ -221,6 +222,70 @@ test('controller dispatches spelling transitions through store, repositories, ev
   controller.dispatch('spelling-submit-form', { formData: typedFormData(answer) });
 
   assert.ok(controller.repositories.practiceSessions.list(learnerId).length >= 1);
+});
+
+test('controller keeps late Grammar command responses scoped to their original learner', async () => {
+  const storage = installMemoryStorage();
+  const repositories = createLocalPlatformRepositories({ storage });
+  let resolveCommand;
+  const subjectCommands = {
+    requests: [],
+    send(request) {
+      this.requests.push(request);
+      return new Promise((resolve) => {
+        resolveCommand = resolve;
+      });
+    },
+  };
+  const controller = createAppController({
+    repositories,
+    extraContext: {
+      runtimeReadOnly: false,
+      subjectCommands,
+    },
+  });
+  const learnerA = controller.store.getState().learners.selectedId;
+  const learnerB = controller.store.createLearner({ name: 'Bryn', yearGroup: 'Y5' }).id;
+
+  controller.dispatch('learner-select', { value: learnerA });
+  controller.dispatch('open-subject', { subjectId: 'grammar' });
+  controller.dispatch('grammar-start');
+
+  assert.equal(subjectCommands.requests.length, 1);
+  assert.equal(subjectCommands.requests[0].learnerId, learnerA);
+  assert.equal(controller.store.getState().subjectUi.grammar.pendingCommand, 'start-session');
+
+  controller.dispatch('learner-select', { value: learnerB });
+  const learnerBUiBeforeResponse = JSON.stringify(controller.store.getState().subjectUi.grammar);
+
+  resolveCommand({
+    subjectReadModel: normaliseGrammarReadModel({
+      learnerId: learnerA,
+      phase: 'summary',
+      summary: { sessionId: 'learner-a-summary' },
+      analytics: { concepts: [] },
+    }, learnerA),
+    projections: {
+      rewards: {
+        toastEvents: [{ id: 'learner-a-toast' }],
+        events: [{ id: 'learner-a-celebration' }],
+      },
+    },
+  });
+  await Promise.resolve();
+
+  const state = controller.store.getState();
+  assert.equal(state.learners.selectedId, learnerB);
+  assert.equal(JSON.stringify(state.subjectUi.grammar), learnerBUiBeforeResponse);
+  assert.equal(state.toasts.length, 0);
+  assert.equal(state.monsterCelebrations.pending.length, 0);
+  assert.equal(state.monsterCelebrations.queue.length, 0);
+
+  const learnerARecord = controller.repositories.subjectStates.read(learnerA, 'grammar');
+  assert.equal(learnerARecord.ui.phase, 'summary');
+  assert.equal(learnerARecord.ui.learnerId, learnerA);
+  assert.equal(learnerARecord.ui.pendingCommand, '');
+  assert.equal(controller.repositories.subjectStates.read(learnerB, 'grammar').ui, null);
 });
 
 test('controller stops spelling audio when feedback has no auto-speak cue', () => {

--- a/tests/bundle-audit.test.js
+++ b/tests/bundle-audit.test.js
@@ -38,6 +38,36 @@ test('client bundle audit fails on forbidden engine, content, and local-mode tok
   }, /Forbidden production-client/);
 });
 
+test('client bundle audit fails when Grammar server engine or content enters the client bundle', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'ks2-runtime-boundary-'));
+  const bundle = path.join(dir, 'app.bundle.js');
+  const metafile = path.join(dir, 'app.bundle.meta.json');
+  const publicDir = path.join(dir, 'public');
+  await mkdir(publicDir, { recursive: true });
+  await writeFile(bundle, 'console.log("grammar surface");\n');
+  await writeFile(metafile, JSON.stringify({
+    inputs: {
+      'src/main.js': { bytes: 1 },
+      'worker/src/subjects/grammar/engine.js': { bytes: 1 },
+    },
+  }));
+
+  assert.throws(() => {
+    execFileSync(process.execPath, [
+      './scripts/audit-client-bundle.mjs',
+      '--bundle',
+      bundle,
+      '--metafile',
+      metafile,
+      '--public-dir',
+      publicDir,
+    ], {
+      cwd: process.cwd(),
+      stdio: 'pipe',
+    });
+  }, /server-authoritative Grammar engine\/content/);
+});
+
 test('client bundle audit permits reviewed endpoint strings without content modules', async () => {
   const dir = await mkdtemp(path.join(tmpdir(), 'ks2-runtime-boundary-'));
   const bundle = path.join(dir, 'app.bundle.js');

--- a/tests/grammar-engine.test.js
+++ b/tests/grammar-engine.test.js
@@ -158,12 +158,13 @@ test('Grammar retry queue de-duplicates repeated misses for the same template an
   const state = createInitialGrammarState();
   const question = createGrammarQuestion({ templateId: 'fronted_adverbial_choose', seed: 1 });
   const item = serialiseGrammarQuestion(question);
+  const wrongAnswer = question.inputSpec.options.find((option) => !evaluateGrammarQuestion(question, { answer: option.value }).correct).value;
 
   for (let count = 0; count < 2; count += 1) {
     applyGrammarAttemptToState(state, {
       learnerId: 'learner-a',
       item,
-      response: { answer: 'not the answer' },
+      response: { answer: wrongAnswer },
       now: 1_777_000_000_000 + count,
     });
   }
@@ -191,6 +192,21 @@ test('Grammar attempt history stores bounded response fields only', () => {
   const persisted = state.recentAttempts[0].response;
   assert.deepEqual(Object.keys(persisted), ['answer']);
   assert.equal(persisted.answer.length, 2_000);
+});
+
+test('Grammar engine rejects empty answers before mastery is mutated', () => {
+  const state = createInitialGrammarState();
+  const question = createGrammarQuestion({ templateId: 'fronted_adverbial_choose', seed: 1 });
+  const item = serialiseGrammarQuestion(question);
+
+  assert.throws(() => applyGrammarAttemptToState(state, {
+    learnerId: 'learner-a',
+    item,
+    response: {},
+    now: 1_777_000_000_000,
+  }), (error) => error?.extra?.code === 'grammar_answer_required');
+  assert.deepEqual(state.mastery.concepts, {});
+  assert.equal(state.recentAttempts.length, 0);
 });
 
 test('Grammar server engine creates a session, marks an answer, and records summary events', () => {
@@ -236,4 +252,56 @@ test('Grammar server engine creates a session, marks an answer, and records summ
   assert.equal(done.state.phase, 'summary');
   assert.equal(done.practiceSession.status, 'completed');
   assert.ok(done.events.some((event) => event.type === 'grammar.session-completed'));
+});
+
+test('Grammar save-prefs clears completed summary state', () => {
+  const oracle = readGrammarLegacyOracle();
+  const sample = oracle.templates.find((template) => template.id === 'question_mark_select');
+  const engine = createServerGrammarEngine({ now: () => 1_777_000_000_000 });
+
+  const start = engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: {},
+    command: 'start-session',
+    requestId: 'start-summary-reset',
+    payload: {
+      mode: 'smart',
+      roundLength: 1,
+      templateId: sample.id,
+      seed: sample.sample.seed,
+    },
+  });
+  const submit = engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: { ui: start.state, data: start.data },
+    latestSession: start.practiceSession,
+    command: 'submit-answer',
+    requestId: 'submit-summary-reset',
+    payload: { response: sample.correctResponse },
+  });
+  const done = engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: { ui: submit.state, data: submit.data },
+    latestSession: submit.practiceSession,
+    command: 'continue-session',
+    requestId: 'continue-summary-reset',
+    payload: {},
+  });
+  assert.equal(done.state.phase, 'summary');
+
+  const saved = engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: { ui: done.state, data: done.data },
+    latestSession: done.practiceSession,
+    command: 'save-prefs',
+    requestId: 'prefs-summary-reset',
+    payload: { prefs: { mode: 'learn' } },
+  });
+
+  assert.equal(saved.state.phase, 'dashboard');
+  assert.equal(saved.state.summary, null);
+  assert.equal(saved.state.session, null);
+  assert.equal(saved.state.awaitingAdvance, false);
+  assert.equal(saved.state.prefs.mode, 'learn');
+  assert.equal(saved.practiceSession, null);
 });

--- a/tests/helpers/grammar-subject-harness.js
+++ b/tests/helpers/grammar-subject-harness.js
@@ -1,0 +1,133 @@
+import { createLocalPlatformRepositories } from '../../src/platform/core/repositories/index.js';
+import { SUBJECTS } from '../../src/platform/core/subject-registry.js';
+import { normaliseGrammarReadModel } from '../../src/subjects/grammar/metadata.js';
+import { createServerGrammarEngine } from '../../worker/src/subjects/grammar/engine.js';
+import { buildGrammarReadModel } from '../../worker/src/subjects/grammar/read-models.js';
+import { createAppHarness } from './app-harness.js';
+import { readGrammarLegacyOracle } from './grammar-legacy-oracle.js';
+
+const SUBJECT_ID = 'grammar';
+
+function timestamp(now = Date.now) {
+  const value = typeof now === 'function' ? Number(now()) : Number(now);
+  return Number.isFinite(value) ? value : Date.now();
+}
+
+function requestId(prefix, learnerId, now) {
+  return `${prefix}-${learnerId || 'learner'}-${timestamp(now)}`;
+}
+
+function readRuntime(repositories, learnerId) {
+  return {
+    subjectRecord: repositories.subjectStates.read(learnerId, SUBJECT_ID),
+    latestSession: repositories.practiceSessions.latest(learnerId, SUBJECT_ID),
+  };
+}
+
+function writeRuntime(repositories, learnerId, result) {
+  if (result?.data) repositories.subjectStates.writeData(learnerId, SUBJECT_ID, result.data);
+  if (result?.practiceSession) repositories.practiceSessions.write(result.practiceSession);
+}
+
+function transitionFromResult(result, learnerId, now) {
+  return {
+    ok: true,
+    changed: result?.changed !== false,
+    state: buildGrammarReadModel({
+      learnerId,
+      state: result.state,
+      now: timestamp(now),
+    }),
+    events: Array.isArray(result?.events) ? result.events : [],
+    audio: null,
+  };
+}
+
+export function createGrammarTestService({ repositories, now = Date.now } = {}) {
+  if (!repositories) {
+    throw new TypeError('Grammar test service requires platform repositories.');
+  }
+
+  function apply(learnerId, command, payload = {}) {
+    const engine = createServerGrammarEngine({ now });
+    const runtime = readRuntime(repositories, learnerId);
+    const result = engine.apply({
+      learnerId,
+      subjectRecord: runtime.subjectRecord,
+      latestSession: runtime.latestSession,
+      command,
+      payload,
+      requestId: requestId(command, learnerId, now),
+    });
+    writeRuntime(repositories, learnerId, result);
+    const transition = transitionFromResult(result, learnerId, now);
+    repositories.subjectStates.writeUi(learnerId, SUBJECT_ID, transition.state);
+    return transition;
+  }
+
+  return {
+    initState(rawState, learnerId) {
+      return normaliseGrammarReadModel(rawState, learnerId);
+    },
+    getPrefs(learnerId) {
+      return normaliseGrammarReadModel(repositories.subjectStates.read(learnerId, SUBJECT_ID).ui, learnerId).prefs;
+    },
+    savePrefs(learnerId, patch = {}) {
+      const transition = apply(learnerId, 'save-prefs', { prefs: patch });
+      return transition.state.prefs;
+    },
+    getStats(learnerId) {
+      return normaliseGrammarReadModel(repositories.subjectStates.read(learnerId, SUBJECT_ID).ui, learnerId).stats.concepts;
+    },
+    getAnalyticsSnapshot(learnerId) {
+      return normaliseGrammarReadModel(repositories.subjectStates.read(learnerId, SUBJECT_ID).ui, learnerId).analytics;
+    },
+    startSession(learnerId, payload = {}) {
+      return apply(learnerId, 'start-session', payload);
+    },
+    submitAnswer(learnerId, _uiState, response = {}) {
+      return apply(learnerId, 'submit-answer', { response });
+    },
+    continueSession(learnerId) {
+      return apply(learnerId, 'continue-session');
+    },
+    endSession(learnerId) {
+      return apply(learnerId, 'end-session');
+    },
+    resetLearner(learnerId) {
+      repositories.subjectStates.clearLearner(learnerId);
+      repositories.practiceSessions.clear(learnerId, SUBJECT_ID);
+    },
+  };
+}
+
+export function grammarResponseFormData(response = {}) {
+  const formData = new FormData();
+  for (const [key, value] of Object.entries(response || {})) {
+    if (Array.isArray(value)) {
+      value.forEach((entry) => formData.append(key, entry));
+    } else {
+      formData.set(key, value);
+    }
+  }
+  return formData;
+}
+
+export function grammarOracleResponseForItem(item) {
+  const oracle = readGrammarLegacyOracle();
+  const match = oracle.templates.find((template) => template.id === item?.templateId);
+  return match?.correctResponse || {};
+}
+
+export function createGrammarHarness({ storage, subjects = SUBJECTS, now = () => 1_777_000_000_000 } = {}) {
+  const repositories = createLocalPlatformRepositories({ storage });
+  return createAppHarness({
+    storage,
+    repositories,
+    subjects,
+    now,
+    extraServices: {
+      grammar: createGrammarTestService({ repositories, now }),
+    },
+  });
+}

--- a/tests/react-grammar-surface.test.js
+++ b/tests/react-grammar-surface.test.js
@@ -8,6 +8,8 @@ import {
 } from './helpers/grammar-subject-harness.js';
 import { readGrammarLegacyOracle } from './helpers/grammar-legacy-oracle.js';
 import { installMemoryStorage } from './helpers/memory-storage.js';
+import { grammarModule } from '../src/subjects/grammar/module.js';
+import { normaliseGrammarReadModel } from '../src/subjects/grammar/metadata.js';
 
 function grammarOracleSample(templateId = 'question_mark_select') {
   return readGrammarLegacyOracle().templates.find((template) => template.id === templateId);
@@ -66,6 +68,126 @@ test('Grammar surface runs from setup to Worker-style feedback and summary', () 
   harness.dispatch('grammar-back');
   assert.equal(harness.store.getState().subjectUi.grammar.phase, 'dashboard');
   assert.match(harness.render(), /Grammar retrieval practice/);
+});
+
+test('Grammar submit requires an answer before recording an attempt', () => {
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+  const sample = grammarOracleSample();
+
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-start', {
+    payload: {
+      roundLength: 1,
+      templateId: sample.id,
+      seed: sample.sample.seed,
+    },
+  });
+
+  harness.dispatch('grammar-submit-form', { formData: new FormData() });
+
+  const grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.phase, 'session');
+  assert.equal(grammar.session.answered, 0);
+  assert.match(grammar.error, /Choose or type an answer/);
+  assert.equal(grammar.analytics.concepts.some((concept) => concept.attempts > 0), false);
+});
+
+test('Grammar command responses are pinned to the learner that sent them', async () => {
+  let resolveCommand;
+  const toasts = [];
+  const celebrations = [];
+  const context = {
+    appState: {
+      learners: { selectedId: 'learner-a' },
+      subjectUi: { grammar: normaliseGrammarReadModel({}, 'learner-a') },
+    },
+    runtimeReadOnly: false,
+    subjectCommands: {
+      send(request) {
+        assert.equal(request.learnerId, 'learner-a');
+        return new Promise((resolve) => {
+          resolveCommand = resolve;
+        });
+      },
+    },
+    store: {
+      updateSubjectUi(subjectId, updater) {
+        const previous = context.appState.subjectUi[subjectId] || {};
+        const next = typeof updater === 'function' ? updater(previous) : { ...previous, ...updater };
+        context.appState = {
+          ...context.appState,
+          subjectUi: {
+            ...context.appState.subjectUi,
+            [subjectId]: next,
+          },
+        };
+      },
+      pushToasts(events) {
+        toasts.push(...events);
+      },
+      pushMonsterCelebrations(events) {
+        celebrations.push(...events);
+      },
+      reloadFromRepositories() {
+        throw new Error('Late Grammar response must not reload the selected learner.');
+      },
+    },
+  };
+
+  grammarModule.handleAction('grammar-start', context);
+  assert.equal(context.appState.subjectUi.grammar.pendingCommand, 'start-session');
+
+  context.appState = {
+    ...context.appState,
+    learners: { selectedId: 'learner-b' },
+    subjectUi: { grammar: normaliseGrammarReadModel({}, 'learner-b') },
+  };
+  resolveCommand({
+    subjectReadModel: normaliseGrammarReadModel({
+      learnerId: 'learner-a',
+      phase: 'summary',
+      summary: { sessionId: 'learner-a-summary' },
+      analytics: { concepts: [] },
+    }, 'learner-a'),
+    projections: {
+      rewards: {
+        toastEvents: [{ id: 'toast-a' }],
+        events: [{ id: 'celebration-a' }],
+      },
+    },
+  });
+  await Promise.resolve();
+
+  const grammar = context.appState.subjectUi.grammar;
+  assert.equal(grammar.learnerId, 'learner-b');
+  assert.equal(grammar.phase, 'dashboard');
+  assert.equal(grammar.summary, null);
+  assert.equal(toasts.length, 0);
+  assert.equal(celebrations.length, 0);
+});
+
+test('Grammar normaliser preserves Worker concept copy over client placeholders', () => {
+  const grammar = normaliseGrammarReadModel({
+    analytics: {
+      concepts: [{
+        id: 'clauses',
+        name: 'Worker clauses',
+        domain: 'Worker domain',
+        summary: 'Worker-authored concept summary.',
+        punctuationForGrammar: false,
+        status: 'learning',
+        attempts: 3,
+      }],
+    },
+  }, 'learner-a');
+
+  const clauses = grammar.analytics.concepts.find((concept) => concept.id === 'clauses');
+  assert.equal(clauses.name, 'Worker clauses');
+  assert.equal(clauses.domain, 'Worker domain');
+  assert.equal(clauses.summary, 'Worker-authored concept summary.');
+  assert.equal(clauses.punctuationForGrammar, false);
+  assert.equal(clauses.attempts, 3);
 });
 
 test('Grammar locked future modes render unavailable without dispatching commands', () => {

--- a/tests/react-grammar-surface.test.js
+++ b/tests/react-grammar-surface.test.js
@@ -93,6 +93,24 @@ test('Grammar submit requires an answer before recording an attempt', () => {
   assert.equal(grammar.analytics.concepts.some((concept) => concept.attempts > 0), false);
 });
 
+test('Grammar setup controls are disabled while a command is pending', () => {
+  const storage = installMemoryStorage();
+  const harness = createAppHarness({ storage });
+  const learnerId = harness.store.getState().learners.selectedId;
+
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.store.updateSubjectUi('grammar', (current) => ({
+    ...normaliseGrammarReadModel(current, learnerId),
+    pendingCommand: 'start-session',
+  }));
+
+  const html = harness.render();
+  assert.match(html, /<button class="grammar-mode selected" type="button" disabled="">/);
+  assert.match(html, /<select class="input" disabled=""[^>]*><option value="" selected="">Smart mix<\/option>/);
+  assert.match(html, /<select class="input" disabled=""[^>]*><option value="3">3<\/option><option value="5" selected="">5<\/option>/);
+  assert.match(html, /<button class="btn primary xl" type="button" disabled="">Starting\.\.\.<\/button>/);
+});
+
 test('Grammar command responses are pinned to the learner that sent them', async () => {
   let resolveCommand;
   const toasts = [];

--- a/tests/react-grammar-surface.test.js
+++ b/tests/react-grammar-surface.test.js
@@ -1,0 +1,81 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createAppHarness } from './helpers/app-harness.js';
+import {
+  createGrammarHarness,
+  grammarResponseFormData,
+} from './helpers/grammar-subject-harness.js';
+import { readGrammarLegacyOracle } from './helpers/grammar-legacy-oracle.js';
+import { installMemoryStorage } from './helpers/memory-storage.js';
+
+function grammarOracleSample(templateId = 'question_mark_select') {
+  return readGrammarLegacyOracle().templates.find((template) => template.id === templateId);
+}
+
+test('Grammar opens as a real Clause Conservatory subject surface', () => {
+  const storage = installMemoryStorage();
+  const harness = createAppHarness({ storage });
+
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  const html = harness.render();
+
+  assert.match(html, /Clause Conservatory/);
+  assert.match(html, /Grammar retrieval practice/);
+  assert.match(html, /All 18 Grammar concepts/);
+  assert.match(html, /Start practice/);
+  assert.match(html, /Bracehart/);
+  assert.match(html, /Concordium/);
+  assert.doesNotMatch(html, /Future subject module/);
+});
+
+test('Grammar surface runs from setup to Worker-style feedback and summary', () => {
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+  const sample = grammarOracleSample();
+
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-start', {
+    payload: {
+      roundLength: 1,
+      templateId: sample.id,
+      seed: sample.sample.seed,
+    },
+  });
+
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'session');
+  let html = harness.render();
+  assert.match(html, /Grammar practice/);
+  assert.match(html, /question mark/i);
+
+  harness.dispatch('grammar-submit-form', {
+    formData: grammarResponseFormData(sample.correctResponse),
+  });
+
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'feedback');
+  html = harness.render();
+  assert.match(html, /Correct\./);
+  assert.match(html, /Finish round/);
+
+  harness.dispatch('grammar-continue');
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'summary');
+  html = harness.render();
+  assert.match(html, /Grammar session summary/);
+  assert.match(html, /1\/1/);
+
+  harness.dispatch('grammar-back');
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'dashboard');
+  assert.match(harness.render(), /Grammar retrieval practice/);
+});
+
+test('Grammar locked future modes render unavailable without dispatching commands', () => {
+  const storage = installMemoryStorage();
+  const harness = createAppHarness({ storage });
+
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  const html = harness.render();
+
+  assert.match(html, /Weak concepts drill[\s\S]*Coming next/);
+  assert.match(html, /Sentence surgery[\s\S]*Coming next/);
+  assert.match(html, /button class="grammar-mode locked" type="button" disabled=""/);
+});

--- a/tests/subject-expansion.test.js
+++ b/tests/subject-expansion.test.js
@@ -12,6 +12,12 @@ import {
   createExpansionFixtureHarness,
   EXPANSION_FIXTURE_SUBJECT_ID,
 } from './helpers/expansion-fixture-subject.js';
+import {
+  createGrammarHarness,
+  grammarOracleResponseForItem,
+  grammarResponseFormData,
+} from './helpers/grammar-subject-harness.js';
+import { readGrammarLegacyOracle } from './helpers/grammar-legacy-oracle.js';
 
 function createSpellingHarness({ storage, subjects } = {}) {
   return createAppHarness({ storage, subjects });
@@ -159,6 +165,68 @@ const expansionFixtureSpec = {
   },
 };
 
+const grammarSample = readGrammarLegacyOracle().templates.find((template) => template.id === 'question_mark_select');
+
+function answerGrammarCorrectly(harness) {
+  while (['session', 'feedback'].includes(harness.store.getState().subjectUi.grammar.phase)) {
+    const ui = harness.store.getState().subjectUi.grammar;
+    if (ui.phase === 'feedback') {
+      harness.dispatch('grammar-continue');
+      continue;
+    }
+    const response = grammarOracleResponseForItem(ui.session?.currentItem);
+    harness.dispatch('grammar-submit-form', {
+      formData: grammarResponseFormData(response),
+    });
+  }
+}
+
+const grammarSpec = {
+  label: 'Grammar Stage 1 subject',
+  subjectId: 'grammar',
+  createHarness: createGrammarHarness,
+  expectReactPractice: true,
+  practiceMatcher: /Grammar retrieval practice/,
+  sessionMatcher: /Grammar practice|question marks/i,
+  summaryMatcher: /Grammar session summary/,
+  getUiState(harness) {
+    return harness.store.getState().subjectUi.grammar;
+  },
+  isSessionState(ui) {
+    return ui.phase === 'session';
+  },
+  isSummaryState(ui) {
+    return ui.phase === 'summary';
+  },
+  startRound(harness) {
+    harness.dispatch('grammar-start', {
+      payload: {
+        roundLength: 1,
+        templateId: grammarSample.id,
+        seed: grammarSample.sample.seed,
+      },
+    });
+  },
+  answerCorrectly: answerGrammarCorrectly,
+  backToDashboard(harness) {
+    harness.dispatch('grammar-back');
+  },
+  triggerActionName: 'grammar-start',
+  triggerAction(harness) {
+    harness.dispatch('grammar-start');
+  },
+  expectedCompletionEventType: 'grammar.session-completed',
+  assertDashboardStats(stats) {
+    assert.ok(stats.pct >= 0 && stats.pct <= 100);
+    assert.equal(typeof stats.streak, 'number');
+  },
+  assertAnalytics(analytics) {
+    assert.equal(Array.isArray(analytics.concepts), true);
+    assert.equal(analytics.concepts.length, 18);
+    assert.ok(analytics.concepts.some((concept) => concept.attempts >= 1));
+  },
+};
+
 const punctuationSpec = {
   label: 'Punctuation production subject',
   subjectId: 'punctuation',
@@ -226,6 +294,8 @@ test('Punctuation stays off the dashboard and route path until its exposure gate
 
 registerSubjectConformanceSuite(spellingSpec);
 registerGoldenPathSmokeSuite(spellingSpec);
+registerSubjectConformanceSuite(grammarSpec);
+registerGoldenPathSmokeSuite(grammarSpec);
 registerSubjectConformanceSuite(expansionFixtureSpec);
 registerGoldenPathSmokeSuite(expansionFixtureSpec);
 registerSubjectConformanceSuite(punctuationSpec);

--- a/worker/README.md
+++ b/worker/README.md
@@ -2,7 +2,7 @@
 
 This Worker is now the production authority for sessions, learner access, subject commands, read models, and protected audio routes.
 
-Production browser sessions use API-backed repositories after sign-in or through an ephemeral demo session. `?local=1` is not a product runtime path. English Spelling and the first Punctuation release run through the Worker subject command boundary, with React acting as the UI shell. The Worker provides durable D1-backed storage for the generic platform collections, account-scoped spelling content, session/auth flows, protected selected-provider TTS, learner ownership at the API boundary, server-side subject runtime, Word Bank read models, and thin hub read-model routes for Parent Hub / Admin.
+Production browser sessions use API-backed repositories after sign-in or through an ephemeral demo session. `?local=1` is not a product runtime path. English Spelling, Stage 1 Grammar, and the first Punctuation release run through the Worker subject command boundary, with React acting as the UI shell. The Worker provides durable D1-backed storage for the generic platform collections, account-scoped spelling content, session/auth flows, protected selected-provider TTS, learner ownership at the API boundary, server-side subject runtime, Word Bank read models, and thin hub read-model routes for Parent Hub / Admin.
 
 ## What this Worker is now
 
@@ -130,11 +130,13 @@ The command boundary validates session ownership, learner access, demo expiry, r
 
 For Spelling, the Worker owns session creation, word queue selection, scoring, correction state, progress mutation, completed session writes, event publication, reward projection, and the returned read model.
 
+For Grammar, the Worker owns session creation, deterministic question generation, answer normalisation, scoring, mastery mutation, completed session writes, event publication, and the returned read model.
+
 For Punctuation, the Worker owns session creation, item selection, deterministic marking, spaced scheduling, misconception events, release-scoped secure-unit progress, completed session writes, Bellstorm Coast reward projection, and the returned read model.
 
 Punctuation remains behind the `PUNCTUATION_SUBJECT_ENABLED` rollout env var. The production default is `false`, so the command route and browser exposure stay unavailable until release verification is accepted and the flag is intentionally changed.
 
-The React client sends user intent and renders the response. It does not use a browser-local Spelling engine as a production fallback.
+The React client sends user intent and renders the response. It does not use browser-local Spelling, Grammar, or Punctuation engines as a production fallback.
 
 The same rule applies to Punctuation: the browser must not ship or fall back to `shared/punctuation/*` as a production engine.
 

--- a/worker/src/subjects/grammar/engine.js
+++ b/worker/src/subjects/grammar/engine.js
@@ -129,6 +129,16 @@ function normaliseGrammarResponse(inputSpec, response) {
   return { answer: cappedString(raw.answer, LONG_RESPONSE_TEXT_LIMIT) };
 }
 
+function hasNormalisedResponseValue(value) {
+  if (Array.isArray(value)) return value.some((entry) => String(entry || '').trim());
+  return String(value ?? '').trim().length > 0;
+}
+
+function hasNormalisedGrammarResponse(response) {
+  if (!isPlainObject(response)) return false;
+  return Object.values(response).some((value) => hasNormalisedResponseValue(value));
+}
+
 function stableHash(value) {
   const text = String(value || '');
   let hash = 2166136261;
@@ -701,6 +711,12 @@ export function applyGrammarAttemptToState(state, {
     });
   }
   const normalisedResponse = normaliseGrammarResponse(question.inputSpec, response);
+  if (!hasNormalisedGrammarResponse(normalisedResponse)) {
+    throw new BadRequestError('Choose or type an answer before submitting.', {
+      code: 'grammar_answer_required',
+      subjectId: SUBJECT_ID,
+    });
+  }
   const result = evaluateGrammarQuestion(question, normalisedResponse);
   if (!result) {
     throw new BadRequestError('Grammar answer could not be marked.', {
@@ -842,6 +858,13 @@ function savePrefs(state, payload) {
     roundLength: roundLengthFor(nextMode, prefs, state.prefs),
     focusConceptId: nextFocusConceptId,
   };
+  if (state.phase === 'summary') {
+    state.phase = 'dashboard';
+    state.session = null;
+    state.feedback = null;
+    state.summary = null;
+    state.awaitingAdvance = false;
+  }
   return [];
 }
 


### PR DESCRIPTION
## Summary
- adds the Stage 1 Grammar practice surface as the real Clause Conservatory subject route
- keeps Grammar execution behind the Worker command boundary while rendering setup, session, feedback, summary, and analytics surfaces in React
- adds full Grammar concept placeholders and reserved reward-route panels without introducing progression mechanics yet
- protects the client bundle from importing server-authoritative Grammar engine/content modules

## Review follow-up
- rebased onto current `origin/main`, preserving PR #69/#72 Punctuation production and hidden comma-flow work
- scopes in-flight Grammar command responses to the learner that sent them through a learner-specific subject UI cache writer, so late responses cannot overwrite another selected learner
- blocks concurrent Grammar setup commands while a Worker command is pending, so late `save-prefs` responses cannot overwrite an active `start-session` result
- disables Grammar mode, focus, round-length, and start controls while setup commands are pending
- splits Punctuation out of README placeholder docs and updates the remaining placeholder count to three
- adds real `createAppController` regression tests for the learner-switch race and start-then-preference command-ordering race
- clears completed Grammar summary state on Worker `save-prefs` so setup changes cannot bounce back to an old summary
- rejects empty Grammar submits before attempts/mastery are recorded, with client and Worker regression coverage
- preserves Worker-provided Grammar concept metadata over client placeholders
- updates operator docs to describe Grammar as Stage 1 Worker-command-backed rather than a placeholder

## Scope
This builds on the merged Grammar engine foundation from PR #68. The subject can now be opened as a real React practice surface, but the wider product/gameplay layer remains intentionally staged.

Spelling is intended to remain untouched; I ran the spelling-focused regression pack below. Punctuation production files from current main are preserved; no files are deleted in `origin/main...HEAD`.

## Verification
- `node --test tests/app-controller.test.js tests/react-grammar-surface.test.js tests/grammar-engine.test.js tests/worker-grammar-subject-runtime.test.js tests/bundle-audit.test.js tests/subject-expansion.test.js tests/punctuation-content.test.js tests/punctuation-marking.test.js tests/punctuation-performance.test.js tests/punctuation-rewards.test.js tests/punctuation-scheduler.test.js tests/punctuation-service.test.js tests/react-punctuation-assets.test.js tests/react-punctuation-scene.test.js tests/subject-command-actions.test.js tests/worker-punctuation-runtime.test.js` (129 pass)
- `node --test tests/server-spelling-engine-parity.test.js tests/worker-subject-runtime.test.js tests/worker-projections.test.js tests/worker-tts.test.js tests/spelling-tts.test.js tests/worker-backend.test.js tests/react-spelling-surface.test.js tests/spelling-parity.test.js` (67 pass)
- `npm test` (434 tests, 433 pass, 1 skipped)
- `npm run check`
- `git diff --check origin/main...HEAD`
- `git diff --name-status origin/main...HEAD | awk '$1 == "D" { print }'` (no output)