### PR TITLE
fix(spelling): prefer cached audio before TTS fallback

### DIFF
--- a/src/subjects/spelling/tts.js
+++ b/src/subjects/spelling/tts.js
@@ -307,6 +307,7 @@ export function createPlatformTts({
     if (providerId !== 'gemini') {
       const cached = await speakWithCachedBufferedAudio(payload, bufferedVoiceId, token);
       if (cached) return true;
+      if (token !== playbackId) return false;
     }
     prefetchBufferedAudio(payload, providerId, bufferedVoiceId);
     if (providerId === 'browser') return speakWithBrowser(payload);

--- a/src/subjects/spelling/tts.js
+++ b/src/subjects/spelling/tts.js
@@ -304,7 +304,7 @@ export function createPlatformTts({
     const token = playbackId;
     const providerId = resolveProvider(payload.provider || provider);
     const bufferedVoiceId = resolveBufferedVoice(payload.bufferedGeminiVoice || bufferedVoice);
-    if (providerId !== 'gemini') {
+    if (providerId !== 'gemini' && providerId !== 'browser') {
       const cached = await speakWithCachedBufferedAudio(payload, bufferedVoiceId, token);
       if (cached) return true;
       if (token !== playbackId) return false;

--- a/src/subjects/spelling/tts.js
+++ b/src/subjects/spelling/tts.js
@@ -73,6 +73,10 @@ function playbackKind({ kind = '', slow = false } = {}) {
   return explicit || (slow ? 'slow' : 'normal');
 }
 
+function isProviderTestPayload(payload = {}) {
+  return playbackKind(payload) === 'test';
+}
+
 function remotePromptRequest(payload = {}, providerId = DEFAULT_TTS_PROVIDER, bufferedVoiceId = DEFAULT_BUFFERED_GEMINI_VOICE) {
   const learnerId = typeof payload.learnerId === 'string' ? payload.learnerId : '';
   const promptToken = typeof payload.promptToken === 'string' ? payload.promptToken : '';
@@ -183,6 +187,7 @@ export function createPlatformTts({
   function prefetchBufferedAudio(payload = {}, providerId, bufferedVoiceId) {
     if (
       providerId === 'gemini'
+      || isProviderTestPayload(payload)
       || payload.wordOnly
       || !remoteEnabled
       || typeof fetchFn !== 'function'
@@ -304,7 +309,8 @@ export function createPlatformTts({
     const token = playbackId;
     const providerId = resolveProvider(payload.provider || provider);
     const bufferedVoiceId = resolveBufferedVoice(payload.bufferedGeminiVoice || bufferedVoice);
-    if (providerId !== 'gemini' && providerId !== 'browser') {
+    const providerTest = isProviderTestPayload(payload);
+    if (!providerTest && providerId !== 'gemini' && providerId !== 'browser') {
       const cached = await speakWithCachedBufferedAudio(payload, bufferedVoiceId, token);
       if (cached) return true;
       if (token !== playbackId) return false;

--- a/src/subjects/spelling/tts.js
+++ b/src/subjects/spelling/tts.js
@@ -86,6 +86,7 @@ function remotePromptRequest(payload = {}, providerId = DEFAULT_TTS_PROVIDER, bu
   };
   if (payload.wordOnly) body.wordOnly = true;
   if (payload.cacheOnly) body.cacheOnly = true;
+  if (payload.cacheLookupOnly) body.cacheLookupOnly = true;
   if (typeof payload.slug === 'string' && payload.slug) body.slug = payload.slug;
   if (typeof payload.scope === 'string' && payload.scope) body.scope = payload.scope;
   return body;
@@ -206,7 +207,33 @@ export function createPlatformTts({
     }).catch(() => {});
   }
 
-  async function speakWithRemote(payload = {}, providerId, bufferedVoiceId, token) {
+  async function speakWithCachedBufferedAudio(payload = {}, bufferedVoiceId, token) {
+    if (
+      payload.wordOnly
+      || !remoteEnabled
+      || typeof fetchFn !== 'function'
+      || typeof Audio === 'undefined'
+      || typeof URL === 'undefined'
+      || !payload.promptToken
+    ) {
+      return false;
+    }
+    return await speakWithRemote(
+      { ...payload, cacheLookupOnly: true },
+      'gemini',
+      bufferedVoiceId,
+      token,
+      { emitLoading: false, emitMissEnd: false },
+    );
+  }
+
+  async function speakWithRemote(
+    payload = {},
+    providerId,
+    bufferedVoiceId,
+    token,
+    { emitLoading = true, emitMissEnd = true } = {},
+  ) {
     if (!remoteEnabled || typeof fetchFn !== 'function' || typeof Audio === 'undefined' || typeof URL === 'undefined') {
       return false;
     }
@@ -215,7 +242,7 @@ export function createPlatformTts({
 
     currentAbort = new AbortController();
     const kindId = playbackKind(payload);
-    emit({ type: 'loading', kind: kindId, provider: providerId });
+    if (emitLoading) emit({ type: 'loading', kind: kindId, provider: providerId });
     try {
       const response = await fetchFn(endpoint, {
         method: 'POST',
@@ -227,8 +254,12 @@ export function createPlatformTts({
         signal: currentAbort.signal,
         body: JSON.stringify(requestBody),
       });
+      if (response.status === 204) {
+        if (emitMissEnd && token === playbackId) emit({ type: 'end' });
+        return false;
+      }
       if (!response.ok) {
-        if (token === playbackId) emit({ type: 'end' });
+        if (emitMissEnd && token === playbackId) emit({ type: 'end' });
         return false;
       }
       const blob = await response.blob();
@@ -273,6 +304,10 @@ export function createPlatformTts({
     const token = playbackId;
     const providerId = resolveProvider(payload.provider || provider);
     const bufferedVoiceId = resolveBufferedVoice(payload.bufferedGeminiVoice || bufferedVoice);
+    if (providerId !== 'gemini') {
+      const cached = await speakWithCachedBufferedAudio(payload, bufferedVoiceId, token);
+      if (cached) return true;
+    }
     prefetchBufferedAudio(payload, providerId, bufferedVoiceId);
     if (providerId === 'browser') return speakWithBrowser(payload);
     return await speakWithRemote(payload, providerId, bufferedVoiceId, token);

--- a/tests/spelling-tts.test.js
+++ b/tests/spelling-tts.test.js
@@ -288,10 +288,19 @@ test('platform TTS allows a one-off provider override for profile tests', async 
         url,
         body,
       });
-      if (body.cacheLookupOnly || body.cacheOnly) {
+      if (body.cacheLookupOnly) {
+        return new Response(new Blob([new Uint8Array([9, 8, 7])], { type: 'audio/mpeg' }), {
+          status: 200,
+          headers: {
+            'content-type': 'audio/mpeg',
+            'x-ks2-tts-cache': 'hit',
+          },
+        });
+      }
+      if (body.cacheOnly) {
         return new Response(null, {
           status: 204,
-          headers: { 'x-ks2-tts-cache': body.cacheLookupOnly ? 'miss' : 'stored' },
+          headers: { 'x-ks2-tts-cache': 'stored' },
         });
       }
       return new Response(new Blob([new Uint8Array([1, 2, 3])], { type: 'audio/mpeg' }), {
@@ -313,24 +322,8 @@ test('platform TTS allows a one-off provider override for profile tests', async 
     });
 
     assert.equal(result, true);
-    assert.equal(calls.length, 3);
+    assert.equal(calls.length, 1);
     assert.deepEqual(calls[0].body, {
-      learnerId: 'learner-a',
-      promptToken: 'prompt-token-test',
-      slow: false,
-      provider: 'gemini',
-      bufferedGeminiVoice: 'Iapetus',
-      cacheLookupOnly: true,
-    });
-    assert.deepEqual(calls[1].body, {
-      learnerId: 'learner-a',
-      promptToken: 'prompt-token-test',
-      slow: false,
-      provider: 'gemini',
-      bufferedGeminiVoice: 'Iapetus',
-      cacheOnly: true,
-    });
-    assert.deepEqual(calls[2].body, {
       learnerId: 'learner-a',
       promptToken: 'prompt-token-test',
       slow: false,
@@ -342,6 +335,76 @@ test('platform TTS allows a one-off provider override for profile tests', async 
       ['loading', 'start'],
     );
     assert.equal(events.at(-1).type, 'end');
+  } finally {
+    tts.stop();
+    globalThis.Audio = originalAudio;
+    URL.createObjectURL = originalCreateObjectUrl;
+    URL.revokeObjectURL = originalRevokeObjectUrl;
+  }
+});
+
+test('platform TTS profile tests do not report cached audio as selected provider success', async () => {
+  const originalAudio = globalThis.Audio;
+  const originalCreateObjectUrl = URL.createObjectURL;
+  const originalRevokeObjectUrl = URL.revokeObjectURL;
+
+  globalThis.Audio = class MockAudio {
+    constructor(src) {
+      this.src = src;
+      this.onended = null;
+      this.onerror = null;
+    }
+
+    play() {
+      setTimeout(() => this.onended?.(), 0);
+      return Promise.resolve();
+    }
+
+    pause() {}
+    removeAttribute() {}
+    load() {}
+  };
+  URL.createObjectURL = () => 'blob:cached-gemini-audio';
+  URL.revokeObjectURL = () => {};
+
+  const calls = [];
+  const tts = createPlatformTts({
+    remoteEnabled: true,
+    provider: 'openai',
+    fetchFn: async (url, init = {}) => {
+      const body = JSON.parse(init.body);
+      calls.push({ url, body });
+      if (body.cacheLookupOnly) {
+        return new Response(new Blob([new Uint8Array([9, 8, 7])], { type: 'audio/mpeg' }), {
+          status: 200,
+          headers: {
+            'content-type': 'audio/mpeg',
+            'x-ks2-tts-cache': 'hit',
+          },
+        });
+      }
+      return new Response(JSON.stringify({ error: 'selected provider unavailable' }), { status: 503 });
+    },
+  });
+
+  try {
+    const result = await tts.speak({
+      learnerId: 'learner-a',
+      promptToken: 'prompt-token-test-failure',
+      word: 'early',
+      sentence: 'The birds sang early in the day.',
+      kind: 'test',
+    });
+
+    assert.equal(result, false);
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0].body, {
+      learnerId: 'learner-a',
+      promptToken: 'prompt-token-test-failure',
+      slow: false,
+      provider: 'openai',
+      bufferedGeminiVoice: 'Iapetus',
+    });
   } finally {
     tts.stop();
     globalThis.Audio = originalAudio;

--- a/tests/spelling-tts.test.js
+++ b/tests/spelling-tts.test.js
@@ -192,6 +192,67 @@ test('platform TTS plays cached Gemini audio before the selected provider', asyn
   }
 });
 
+test('platform TTS does not warm or fall back after cancelled cache lookup', async () => {
+  const originalAudio = globalThis.Audio;
+  globalThis.Audio = class MockAudio {};
+
+  let releaseLookup;
+  let lookupStarted;
+  const lookupStartedPromise = new Promise((resolve) => {
+    lookupStarted = resolve;
+  });
+  const calls = [];
+  const tts = createPlatformTts({
+    remoteEnabled: true,
+    provider: 'openai',
+    fetchFn: async (url, init = {}) => {
+      const body = JSON.parse(init.body);
+      calls.push({ url, body });
+      if (body.cacheLookupOnly) {
+        lookupStarted();
+        await new Promise((resolve) => {
+          releaseLookup = resolve;
+        });
+        return new Response(null, {
+          status: 204,
+          headers: { 'x-ks2-tts-cache': 'miss' },
+        });
+      }
+      return new Response(new Blob([new Uint8Array([1, 2, 3])], { type: 'audio/mpeg' }), {
+        status: 200,
+        headers: { 'content-type': 'audio/mpeg' },
+      });
+    },
+  });
+
+  try {
+    const resultPromise = tts.speak({
+      learnerId: 'learner-a',
+      promptToken: 'prompt-token-cancelled',
+      word: 'early',
+      sentence: 'The birds sang early in the day.',
+    });
+    await lookupStartedPromise;
+    tts.stop();
+    releaseLookup();
+    const result = await resultPromise;
+
+    assert.equal(result, false);
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0].body, {
+      learnerId: 'learner-a',
+      promptToken: 'prompt-token-cancelled',
+      slow: false,
+      provider: 'gemini',
+      bufferedGeminiVoice: 'Iapetus',
+      cacheLookupOnly: true,
+    });
+  } finally {
+    tts.stop();
+    globalThis.Audio = originalAudio;
+  }
+});
+
 test('platform TTS allows a one-off provider override for profile tests', async () => {
   const originalAudio = globalThis.Audio;
   const originalCreateObjectUrl = URL.createObjectURL;

--- a/tests/spelling-tts.test.js
+++ b/tests/spelling-tts.test.js
@@ -451,10 +451,7 @@ test('platform TTS can use the local browser voice provider', async () => {
     fetchFn: async (url, init = {}) => {
       const body = JSON.parse(init.body);
       calls.push({ url, body });
-      return new Response(null, {
-        status: body.cacheLookupOnly || body.cacheOnly ? 204 : 500,
-        headers: { 'x-ks2-tts-cache': body.cacheLookupOnly ? 'miss' : 'stored' },
-      });
+      await new Promise(() => {});
     },
   });
 
@@ -472,24 +469,23 @@ test('platform TTS can use the local browser voice provider', async () => {
     assert.equal(spoken[0].voice.name, 'Google UK English Female');
     assert.match(spoken[0].text, /The word is early/);
 
-    const tokenResult = await tts.speak({
-      learnerId: 'learner-a',
-      promptToken: 'prompt-token-browser',
-      word: 'early',
-      sentence: 'The birds sang early in the day.',
-    });
+    let timeoutId;
+    const tokenResult = await Promise.race([
+      tts.speak({
+        learnerId: 'learner-a',
+        promptToken: 'prompt-token-browser',
+        word: 'early',
+        sentence: 'The birds sang early in the day.',
+      }),
+      new Promise((resolve) => {
+        timeoutId = setTimeout(() => resolve('timeout'), 300);
+      }),
+    ]);
+    clearTimeout(timeoutId);
 
     assert.equal(tokenResult, true);
-    assert.equal(calls.length, 2);
+    assert.equal(calls.length, 1);
     assert.deepEqual(calls[0].body, {
-      learnerId: 'learner-a',
-      promptToken: 'prompt-token-browser',
-      slow: false,
-      provider: 'gemini',
-      bufferedGeminiVoice: 'Iapetus',
-      cacheLookupOnly: true,
-    });
-    assert.deepEqual(calls[1].body, {
       learnerId: 'learner-a',
       promptToken: 'prompt-token-browser',
       slow: false,

--- a/tests/spelling-tts.test.js
+++ b/tests/spelling-tts.test.js
@@ -118,6 +118,80 @@ test('platform TTS sends the selected Worker provider', async () => {
   }
 });
 
+test('platform TTS plays cached Gemini audio before the selected provider', async () => {
+  const originalAudio = globalThis.Audio;
+  const originalCreateObjectUrl = URL.createObjectURL;
+  const originalRevokeObjectUrl = URL.revokeObjectURL;
+  const played = [];
+
+  globalThis.Audio = class MockAudio {
+    constructor(src) {
+      this.src = src;
+      this.onended = null;
+      this.onerror = null;
+    }
+
+    play() {
+      played.push(this.src);
+      setTimeout(() => this.onended?.(), 0);
+      return Promise.resolve();
+    }
+
+    pause() {}
+    removeAttribute() {}
+    load() {}
+  };
+  URL.createObjectURL = () => 'blob:cached-gemini-audio';
+  URL.revokeObjectURL = () => {};
+
+  const calls = [];
+  const tts = createPlatformTts({
+    remoteEnabled: true,
+    provider: 'openai',
+    fetchFn: async (url, init = {}) => {
+      calls.push({
+        url,
+        headers: init.headers,
+        body: JSON.parse(init.body),
+      });
+      return new Response(new Blob([new Uint8Array([9, 8, 7])], { type: 'audio/mpeg' }), {
+        status: 200,
+        headers: {
+          'content-type': 'audio/mpeg',
+          'x-ks2-tts-cache': 'hit',
+        },
+      });
+    },
+  });
+
+  try {
+    const result = await tts.speak({
+      learnerId: 'learner-a',
+      promptToken: 'prompt-token-cached',
+      word: 'early',
+      sentence: 'The birds sang early in the day.',
+    });
+
+    assert.equal(result, true);
+    assert.deepEqual(played, ['blob:cached-gemini-audio']);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].headers.accept, 'audio/*');
+    assert.deepEqual(calls[0].body, {
+      learnerId: 'learner-a',
+      promptToken: 'prompt-token-cached',
+      slow: false,
+      provider: 'gemini',
+      bufferedGeminiVoice: 'Iapetus',
+      cacheLookupOnly: true,
+    });
+  } finally {
+    tts.stop();
+    globalThis.Audio = originalAudio;
+    URL.createObjectURL = originalCreateObjectUrl;
+    URL.revokeObjectURL = originalRevokeObjectUrl;
+  }
+});
+
 test('platform TTS allows a one-off provider override for profile tests', async () => {
   const originalAudio = globalThis.Audio;
   const originalCreateObjectUrl = URL.createObjectURL;
@@ -148,10 +222,17 @@ test('platform TTS allows a one-off provider override for profile tests', async 
     remoteEnabled: true,
     provider: 'gemini',
     fetchFn: async (url, init = {}) => {
+      const body = JSON.parse(init.body);
       calls.push({
         url,
-        body: JSON.parse(init.body),
+        body,
       });
+      if (body.cacheLookupOnly || body.cacheOnly) {
+        return new Response(null, {
+          status: 204,
+          headers: { 'x-ks2-tts-cache': body.cacheLookupOnly ? 'miss' : 'stored' },
+        });
+      }
       return new Response(new Blob([new Uint8Array([1, 2, 3])], { type: 'audio/mpeg' }), {
         status: 200,
         headers: { 'content-type': 'audio/mpeg' },
@@ -171,8 +252,16 @@ test('platform TTS allows a one-off provider override for profile tests', async 
     });
 
     assert.equal(result, true);
-    assert.equal(calls.length, 2);
+    assert.equal(calls.length, 3);
     assert.deepEqual(calls[0].body, {
+      learnerId: 'learner-a',
+      promptToken: 'prompt-token-test',
+      slow: false,
+      provider: 'gemini',
+      bufferedGeminiVoice: 'Iapetus',
+      cacheLookupOnly: true,
+    });
+    assert.deepEqual(calls[1].body, {
       learnerId: 'learner-a',
       promptToken: 'prompt-token-test',
       slow: false,
@@ -180,7 +269,7 @@ test('platform TTS allows a one-off provider override for profile tests', async 
       bufferedGeminiVoice: 'Iapetus',
       cacheOnly: true,
     });
-    assert.deepEqual(calls[1].body, {
+    assert.deepEqual(calls[2].body, {
       learnerId: 'learner-a',
       promptToken: 'prompt-token-test',
       slow: false,
@@ -234,8 +323,16 @@ test('platform TTS does not fall back when the selected remote provider fails', 
 
     assert.equal(result, false);
     assert.equal(spoke, false);
-    assert.equal(calls.length, 2);
+    assert.equal(calls.length, 3);
     assert.deepEqual(calls[0].body, {
+      learnerId: 'learner-a',
+      promptToken: 'prompt-token-a',
+      slow: false,
+      provider: 'gemini',
+      bufferedGeminiVoice: 'Iapetus',
+      cacheLookupOnly: true,
+    });
+    assert.deepEqual(calls[1].body, {
       learnerId: 'learner-a',
       promptToken: 'prompt-token-a',
       slow: false,
@@ -243,7 +340,7 @@ test('platform TTS does not fall back when the selected remote provider fails', 
       bufferedGeminiVoice: 'Iapetus',
       cacheOnly: true,
     });
-    assert.deepEqual(calls[1].body, {
+    assert.deepEqual(calls[2].body, {
       learnerId: 'learner-a',
       promptToken: 'prompt-token-a',
       slow: false,
@@ -291,8 +388,12 @@ test('platform TTS can use the local browser voice provider', async () => {
     remoteEnabled: true,
     provider: 'browser',
     fetchFn: async (url, init = {}) => {
-      calls.push({ url, body: JSON.parse(init.body) });
-      return new Response(null, { status: 500 });
+      const body = JSON.parse(init.body);
+      calls.push({ url, body });
+      return new Response(null, {
+        status: body.cacheLookupOnly || body.cacheOnly ? 204 : 500,
+        headers: { 'x-ks2-tts-cache': body.cacheLookupOnly ? 'miss' : 'stored' },
+      });
     },
   });
 
@@ -318,8 +419,16 @@ test('platform TTS can use the local browser voice provider', async () => {
     });
 
     assert.equal(tokenResult, true);
-    assert.equal(calls.length, 1);
+    assert.equal(calls.length, 2);
     assert.deepEqual(calls[0].body, {
+      learnerId: 'learner-a',
+      promptToken: 'prompt-token-browser',
+      slow: false,
+      provider: 'gemini',
+      bufferedGeminiVoice: 'Iapetus',
+      cacheLookupOnly: true,
+    });
+    assert.deepEqual(calls[1].body, {
       learnerId: 'learner-a',
       promptToken: 'prompt-token-browser',
       slow: false,

--- a/tests/worker-tts.test.js
+++ b/tests/worker-tts.test.js
@@ -422,6 +422,45 @@ test('TTS route returns a lookup-only cache miss without generating audio', asyn
   }
 });
 
+test('TTS route rate limits lookup-only cache misses before reading R2', async () => {
+  const originalFetch = globalThis.fetch;
+  let providerCalls = 0;
+  globalThis.fetch = async () => {
+    providerCalls += 1;
+    return geminiAudioResponse();
+  };
+  const bucket = createMemoryR2Bucket();
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      GEMINI_API_KEY: 'test-gemini-key',
+      SPELLING_AUDIO_BUCKET: bucket,
+    },
+  });
+  try {
+    const prompt = await startSpellingPrompt(server);
+    await seedRateLimit(server, 'tts-account', 'adult-a', 120);
+
+    const response = await server.fetch('https://repo.test/api/tts', ttsRequest({
+      learnerId: prompt.learnerId,
+      promptToken: prompt.promptToken,
+      provider: 'openai',
+      bufferedGeminiVoice: 'Sulafat',
+      cacheLookupOnly: true,
+    }));
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.code, 'tts_rate_limited');
+    assert.equal(providerCalls, 0);
+    assert.equal(bucket.gets.length, 0);
+    assert.equal(bucket.puts.length, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+    server.close();
+  }
+});
+
 test('TTS route rate limits cached Gemini audio before reading R2', async () => {
   const originalFetch = globalThis.fetch;
   let providerCalls = 0;

--- a/tests/worker-tts.test.js
+++ b/tests/worker-tts.test.js
@@ -380,6 +380,62 @@ test('TTS route serves cached audio for lookup-only requests before selected pro
     assert.equal(providerCalls, 0);
     assert.equal(bucket.gets.length, 1);
     assert.equal(bucket.puts.length, 0);
+    const limiterRows = server.DB.db.prepare(`
+      SELECT limiter_key, request_count
+      FROM request_limits
+      WHERE limiter_key LIKE 'tts-%'
+    `).all();
+    const limiterCounts = new Map(limiterRows.map((row) => [
+      row.limiter_key.split(':')[0],
+      Number(row.request_count),
+    ]));
+    assert.equal(limiterCounts.get('tts-lookup-account'), 1);
+    assert.equal(limiterCounts.get('tts-lookup-ip'), 1);
+    assert.equal(limiterCounts.get('tts-account'), 1);
+    assert.equal(limiterCounts.get('tts-ip'), 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+    server.close();
+  }
+});
+
+test('TTS route blocks lookup-only cached playback when playback quota is exhausted', async () => {
+  const originalFetch = globalThis.fetch;
+  let providerCalls = 0;
+  globalThis.fetch = async () => {
+    providerCalls += 1;
+    throw new Error('Provider should not be called for cached audio.');
+  };
+  const bucket = createMemoryR2Bucket({
+    hit: {
+      bytes: [6, 5, 4],
+      contentType: 'audio/mpeg',
+    },
+  });
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      SPELLING_AUDIO_BUCKET: bucket,
+    },
+  });
+  try {
+    const prompt = await startSpellingPrompt(server);
+    await seedRateLimit(server, 'tts-account', 'adult-a', 120);
+
+    const response = await server.fetch('https://repo.test/api/tts', ttsRequest({
+      learnerId: prompt.learnerId,
+      promptToken: prompt.promptToken,
+      provider: 'openai',
+      bufferedGeminiVoice: 'Sulafat',
+      cacheLookupOnly: true,
+    }));
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.code, 'tts_rate_limited');
+    assert.equal(providerCalls, 0);
+    assert.equal(bucket.gets.length, 1);
+    assert.equal(bucket.puts.length, 0);
   } finally {
     globalThis.fetch = originalFetch;
     server.close();
@@ -1445,6 +1501,76 @@ test('demo lookup-only cache misses use lookup guards instead of playback guards
       'demo-tts-lookup-account',
       'demo-tts-lookup-ip',
       'demo-tts-lookup-session',
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    server.close();
+  }
+});
+
+test('demo lookup-only cached playback uses lookup and playback guards', async () => {
+  const originalFetch = globalThis.fetch;
+  let providerCalls = 0;
+  globalThis.fetch = async () => {
+    providerCalls += 1;
+    throw new Error('Provider should not be called for cached audio.');
+  };
+  const bucket = createMemoryR2Bucket({
+    hit: {
+      bytes: [6, 5, 4],
+      contentType: 'audio/mpeg',
+    },
+  });
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      AUTH_MODE: 'production',
+      ENVIRONMENT: 'production',
+      APP_HOSTNAME: 'repo.test',
+      SPELLING_AUDIO_BUCKET: bucket,
+    },
+  });
+  try {
+    const prompt = await startDemoSpellingPrompt(server);
+    const response = await server.fetchRaw('https://repo.test/api/tts', {
+      ...ttsRequest({
+        learnerId: prompt.audio.learnerId,
+        promptToken: prompt.audio.promptToken,
+        provider: 'openai',
+        bufferedGeminiVoice: 'Iapetus',
+        cacheLookupOnly: true,
+      }),
+      headers: {
+        'content-type': 'application/json',
+        cookie: prompt.cookie,
+      },
+    });
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    const fallbackMetric = server.DB.db.prepare(`
+      SELECT metric_count
+      FROM demo_operation_metrics
+      WHERE metric_key = 'tts_fallbacks'
+    `).get();
+    const limiterRows = server.DB.db.prepare(`
+      SELECT limiter_key
+      FROM request_limits
+      WHERE limiter_key LIKE 'demo-tts%'
+    `).all();
+    const limiterPrefixes = limiterRows.map((row) => row.limiter_key.split(':')[0]).sort();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual([...bytes], [6, 5, 4]);
+    assert.equal(providerCalls, 0);
+    assert.equal(bucket.gets.length, 1);
+    assert.equal(Number(fallbackMetric?.metric_count), 1);
+    assert.deepEqual(limiterPrefixes, [
+      'demo-tts-account',
+      'demo-tts-fallback-type',
+      'demo-tts-ip',
+      'demo-tts-lookup-account',
+      'demo-tts-lookup-ip',
+      'demo-tts-lookup-session',
+      'demo-tts-session',
     ]);
   } finally {
     globalThis.fetch = originalFetch;

--- a/tests/worker-tts.test.js
+++ b/tests/worker-tts.test.js
@@ -342,6 +342,86 @@ test('TTS route serves pre-cached Gemini audio before provider generation', asyn
   }
 });
 
+test('TTS route serves cached audio for lookup-only requests before selected provider fallback', async () => {
+  const originalFetch = globalThis.fetch;
+  let providerCalls = 0;
+  globalThis.fetch = async () => {
+    providerCalls += 1;
+    throw new Error('Provider should not be called for lookup-only cached audio.');
+  };
+  const bucket = createMemoryR2Bucket({
+    hit: {
+      bytes: [6, 5, 4],
+      contentType: 'audio/mpeg',
+    },
+  });
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      SPELLING_AUDIO_BUCKET: bucket,
+    },
+  });
+  try {
+    const prompt = await startSpellingPrompt(server);
+    const response = await server.fetch('https://repo.test/api/tts', ttsRequest({
+      learnerId: prompt.learnerId,
+      promptToken: prompt.promptToken,
+      provider: 'openai',
+      bufferedGeminiVoice: 'Sulafat',
+      cacheLookupOnly: true,
+    }));
+    const bytes = new Uint8Array(await response.arrayBuffer());
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('content-type'), 'audio/mpeg');
+    assert.equal(response.headers.get('x-ks2-tts-cache'), 'hit');
+    assert.equal(response.headers.get('x-ks2-tts-provider'), 'gemini');
+    assert.deepEqual([...bytes], [6, 5, 4]);
+    assert.equal(providerCalls, 0);
+    assert.equal(bucket.gets.length, 1);
+    assert.equal(bucket.puts.length, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+    server.close();
+  }
+});
+
+test('TTS route returns a lookup-only cache miss without generating audio', async () => {
+  const originalFetch = globalThis.fetch;
+  let providerCalls = 0;
+  globalThis.fetch = async () => {
+    providerCalls += 1;
+    return geminiAudioResponse();
+  };
+  const bucket = createMemoryR2Bucket();
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      GEMINI_API_KEY: 'test-gemini-key',
+      SPELLING_AUDIO_BUCKET: bucket,
+    },
+  });
+  try {
+    const prompt = await startSpellingPrompt(server);
+    const response = await server.fetch('https://repo.test/api/tts', ttsRequest({
+      learnerId: prompt.learnerId,
+      promptToken: prompt.promptToken,
+      provider: 'openai',
+      bufferedGeminiVoice: 'Sulafat',
+      cacheLookupOnly: true,
+    }));
+
+    assert.equal(response.status, 204);
+    assert.equal(response.headers.get('x-ks2-tts-cache'), 'miss');
+    assert.equal(providerCalls, 0);
+    assert.equal(bucket.gets.length, 2);
+    assert.equal(bucket.puts.length, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+    server.close();
+  }
+});
+
 test('TTS route rate limits cached Gemini audio before reading R2', async () => {
   const originalFetch = globalThis.fetch;
   let providerCalls = 0;

--- a/tests/worker-tts.test.js
+++ b/tests/worker-tts.test.js
@@ -422,6 +422,64 @@ test('TTS route returns a lookup-only cache miss without generating audio', asyn
   }
 });
 
+test('TTS route charges cold-cache fallback playback quota only once', async () => {
+  const originalFetch = globalThis.fetch;
+  let providerCalls = 0;
+  globalThis.fetch = async () => {
+    providerCalls += 1;
+    return new Response(new Uint8Array([1, 2, 3]), {
+      status: 200,
+      headers: { 'content-type': 'audio/mpeg' },
+    });
+  };
+  const bucket = createMemoryR2Bucket();
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      OPENAI_API_KEY: 'test-openai-key',
+      SPELLING_AUDIO_BUCKET: bucket,
+    },
+  });
+  try {
+    const prompt = await startSpellingPrompt(server);
+    const lookupResponse = await server.fetch('https://repo.test/api/tts', ttsRequest({
+      learnerId: prompt.learnerId,
+      promptToken: prompt.promptToken,
+      provider: 'openai',
+      bufferedGeminiVoice: 'Sulafat',
+      cacheLookupOnly: true,
+    }));
+    const playbackResponse = await server.fetch('https://repo.test/api/tts', ttsRequest({
+      learnerId: prompt.learnerId,
+      promptToken: prompt.promptToken,
+      provider: 'openai',
+      bufferedGeminiVoice: 'Sulafat',
+    }));
+    const limiterRows = server.DB.db.prepare(`
+      SELECT limiter_key, request_count
+      FROM request_limits
+      WHERE limiter_key LIKE 'tts-%'
+    `).all();
+    const limiterCounts = new Map(limiterRows.map((row) => [
+      row.limiter_key.split(':')[0],
+      Number(row.request_count),
+    ]));
+
+    assert.equal(lookupResponse.status, 204);
+    assert.equal(lookupResponse.headers.get('x-ks2-tts-cache'), 'miss');
+    assert.equal(playbackResponse.status, 200);
+    assert.equal(providerCalls, 1);
+    assert.equal(bucket.gets.length, 2);
+    assert.equal(limiterCounts.get('tts-lookup-account'), 1);
+    assert.equal(limiterCounts.get('tts-lookup-ip'), 1);
+    assert.equal(limiterCounts.get('tts-account'), 1);
+    assert.equal(limiterCounts.get('tts-ip'), 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+    server.close();
+  }
+});
+
 test('TTS route rate limits lookup-only cache misses before reading R2', async () => {
   const originalFetch = globalThis.fetch;
   let providerCalls = 0;
@@ -439,7 +497,7 @@ test('TTS route rate limits lookup-only cache misses before reading R2', async (
   });
   try {
     const prompt = await startSpellingPrompt(server);
-    await seedRateLimit(server, 'tts-account', 'adult-a', 120);
+    await seedRateLimit(server, 'tts-lookup-account', 'adult-a', 240);
 
     const response = await server.fetch('https://repo.test/api/tts', ttsRequest({
       learnerId: prompt.learnerId,
@@ -451,7 +509,7 @@ test('TTS route rate limits lookup-only cache misses before reading R2', async (
     const payload = await response.json();
 
     assert.equal(response.status, 400);
-    assert.equal(payload.code, 'tts_rate_limited');
+    assert.equal(payload.code, 'tts_lookup_rate_limited');
     assert.equal(providerCalls, 0);
     assert.equal(bucket.gets.length, 0);
     assert.equal(bucket.puts.length, 0);
@@ -1328,6 +1386,66 @@ test('demo TTS is blocked by the demo session limiter before provider fetch', as
     assert.equal(providerCalls, 0);
     assert.equal(Number(rateLimitMetric?.metric_count), 1);
     assert.equal(Number(fallbackMetric?.metric_count) || 0, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+    server.close();
+  }
+});
+
+test('demo lookup-only cache misses use lookup guards instead of playback guards', async () => {
+  const originalFetch = globalThis.fetch;
+  let providerCalls = 0;
+  globalThis.fetch = async () => {
+    providerCalls += 1;
+    return geminiAudioResponse();
+  };
+  const bucket = createMemoryR2Bucket();
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      AUTH_MODE: 'production',
+      ENVIRONMENT: 'production',
+      APP_HOSTNAME: 'repo.test',
+      SPELLING_AUDIO_BUCKET: bucket,
+    },
+  });
+  try {
+    const prompt = await startDemoSpellingPrompt(server);
+    const response = await server.fetchRaw('https://repo.test/api/tts', {
+      ...ttsRequest({
+        learnerId: prompt.audio.learnerId,
+        promptToken: prompt.audio.promptToken,
+        provider: 'openai',
+        bufferedGeminiVoice: 'Iapetus',
+        cacheLookupOnly: true,
+      }),
+      headers: {
+        'content-type': 'application/json',
+        cookie: prompt.cookie,
+      },
+    });
+    const fallbackMetric = server.DB.db.prepare(`
+      SELECT metric_count
+      FROM demo_operation_metrics
+      WHERE metric_key = 'tts_fallbacks'
+    `).get();
+    const limiterRows = server.DB.db.prepare(`
+      SELECT limiter_key
+      FROM request_limits
+      WHERE limiter_key LIKE 'demo-tts%'
+    `).all();
+    const limiterPrefixes = limiterRows.map((row) => row.limiter_key.split(':')[0]).sort();
+
+    assert.equal(response.status, 204);
+    assert.equal(response.headers.get('x-ks2-tts-cache'), 'miss');
+    assert.equal(providerCalls, 0);
+    assert.equal(bucket.gets.length, 2);
+    assert.equal(fallbackMetric, undefined);
+    assert.deepEqual(limiterPrefixes, [
+      'demo-tts-lookup-account',
+      'demo-tts-lookup-ip',
+      'demo-tts-lookup-session',
+    ]);
   } finally {
     globalThis.fetch = originalFetch;
     server.close();

--- a/worker/src/demo/sessions.js
+++ b/worker/src/demo/sessions.js
@@ -20,6 +20,9 @@ const DEMO_LIMITS = {
   ttsAccount: 80,
   ttsSession: 60,
   ttsFallbackType: 40,
+  ttsLookupIp: 320,
+  ttsLookupAccount: 160,
+  ttsLookupSession: 120,
 };
 
 function cleanText(value) {
@@ -256,6 +259,29 @@ export async function protectDemoTtsFallback({ env, request, session, payload = 
       limit: DEMO_LIMITS.ttsFallbackType,
     },
   ], now, 'Too many demo dictation audio requests. Please wait a few minutes and try again.');
+}
+
+export async function protectDemoTtsLookup({ env, request, session, now = Date.now() } = {}) {
+  if (!session?.demo) return;
+  const db = requireDatabase(env);
+  await requireActiveDemoAccount(db, session.accountId, now);
+  await enforceDemoRateLimit(db, [
+    {
+      bucket: 'demo-tts-lookup-ip',
+      identifier: clientIp(request),
+      limit: DEMO_LIMITS.ttsLookupIp,
+    },
+    {
+      bucket: 'demo-tts-lookup-account',
+      identifier: session.accountId,
+      limit: DEMO_LIMITS.ttsLookupAccount,
+    },
+    {
+      bucket: 'demo-tts-lookup-session',
+      identifier: demoSessionIdentifier(session),
+      limit: DEMO_LIMITS.ttsLookupSession,
+    },
+  ], now, 'Too many demo dictation audio lookups. Please wait a few minutes and try again.');
 }
 
 export async function cleanupExpiredDemoAccounts(db, now = Date.now(), { accountId = null, limit = 25 } = {}) {

--- a/worker/src/tts.js
+++ b/worker/src/tts.js
@@ -696,10 +696,9 @@ export async function handleTextToSpeechRequest({
 
   async function tryGemini(fallbackFrom = '') {
     if (!payload.wordOnly) {
-      if (!cacheOnly && !cacheLookupOnly) await protectAudioRequest();
+      if (!cacheOnly) await protectAudioRequest();
       const cacheHit = await readBufferedGeminiAudio(env, payload, { model: geminiForPayload.model });
       if (cacheHit?.object) {
-        if (cacheLookupOnly) await protectAudioRequest();
         const output = cacheOnly ? cacheOnlyResponse('hit', cacheHit) : cachedGeminiAudioResponse(cacheHit);
         return cacheOnly ? output : await finish(output, fallbackFrom);
       }

--- a/worker/src/tts.js
+++ b/worker/src/tts.js
@@ -733,6 +733,7 @@ export async function handleTextToSpeechRequest({
       else if (!cacheOnly) await protectAudioRequest();
       const cacheHit = await readBufferedGeminiAudio(env, payload, { model: geminiForPayload.model });
       if (cacheHit?.object) {
+        if (cacheLookupOnly) await protectAudioRequest();
         const output = cacheOnly ? cacheOnlyResponse('hit', cacheHit) : cachedGeminiAudioResponse(cacheHit);
         return cacheOnly ? output : await finish(output, fallbackFrom);
       }

--- a/worker/src/tts.js
+++ b/worker/src/tts.js
@@ -2,7 +2,7 @@ import { sha256 } from './auth.js';
 import { first, requireDatabase } from './d1.js';
 import { BadRequestError, BackendUnavailableError } from './errors.js';
 import { readJson } from './http.js';
-import { protectDemoTtsFallback, recordDemoMetric } from './demo/sessions.js';
+import { protectDemoTtsFallback, protectDemoTtsLookup, recordDemoMetric } from './demo/sessions.js';
 import { resolveSpellingAudioRequest } from './subjects/spelling/audio.js';
 import {
   SPELLING_AUDIO_MODEL,
@@ -17,6 +17,8 @@ const GEMINI_GENERATE_CONTENT_URL = 'https://generativelanguage.googleapis.com/v
 const TTS_WINDOW_MS = 10 * 60 * 1000;
 const TTS_ACCOUNT_LIMIT = 120;
 const TTS_IP_LIMIT = 240;
+const TTS_LOOKUP_ACCOUNT_LIMIT = 240;
+const TTS_LOOKUP_IP_LIMIT = 480;
 const TTS_WARMUP_ACCOUNT_LIMIT = 60;
 const TTS_WARMUP_IP_LIMIT = 180;
 const DEFAULT_MODEL = 'gpt-4o-mini-tts';
@@ -101,6 +103,30 @@ async function protectTts(env, request, session, now) {
   if (!accountLimit.allowed || !ipLimit.allowed) {
     throw new BadRequestError('Too many dictation audio requests. Please wait a few minutes and try again.', {
       code: 'tts_rate_limited',
+      retryAfterSeconds: Math.max(accountLimit.retryAfterSeconds, ipLimit.retryAfterSeconds),
+    });
+  }
+}
+
+async function protectTtsLookup(env, request, session, now) {
+  const accountLimit = await consumeRateLimit(env, {
+    bucket: 'tts-lookup-account',
+    identifier: session.accountId,
+    limit: TTS_LOOKUP_ACCOUNT_LIMIT,
+    windowMs: TTS_WINDOW_MS,
+    now,
+  });
+  const ipLimit = await consumeRateLimit(env, {
+    bucket: 'tts-lookup-ip',
+    identifier: clientIp(request),
+    limit: TTS_LOOKUP_IP_LIMIT,
+    windowMs: TTS_WINDOW_MS,
+    now,
+  });
+
+  if (!accountLimit.allowed || !ipLimit.allowed) {
+    throw new BadRequestError('Too many dictation audio cache lookups. Please wait a few minutes and try again.', {
+      code: 'tts_lookup_rate_limited',
       retryAfterSeconds: Math.max(accountLimit.retryAfterSeconds, ipLimit.retryAfterSeconds),
     });
   }
@@ -683,11 +709,18 @@ export async function handleTextToSpeechRequest({
   };
   if ((cacheOnly || cacheLookupOnly) && payload.wordOnly) return cacheOnlyResponse('uncacheable');
   let protectedRequest = false;
+  let protectedLookup = false;
   async function protectAudioRequest() {
     if (protectedRequest) return;
     await protectTts(env, request, session, now);
     await protectDemoTtsFallback({ env, request, session, payload, now });
     protectedRequest = true;
+  }
+  async function protectLookupRequest() {
+    if (protectedLookup) return;
+    await protectTtsLookup(env, request, session, now);
+    await protectDemoTtsLookup({ env, request, session, now });
+    protectedLookup = true;
   }
 
   async function finish(response, fallbackFrom = '') {
@@ -696,7 +729,8 @@ export async function handleTextToSpeechRequest({
 
   async function tryGemini(fallbackFrom = '') {
     if (!payload.wordOnly) {
-      if (!cacheOnly) await protectAudioRequest();
+      if (cacheLookupOnly) await protectLookupRequest();
+      else if (!cacheOnly) await protectAudioRequest();
       const cacheHit = await readBufferedGeminiAudio(env, payload, { model: geminiForPayload.model });
       if (cacheHit?.object) {
         const output = cacheOnly ? cacheOnlyResponse('hit', cacheHit) : cachedGeminiAudioResponse(cacheHit);

--- a/worker/src/tts.js
+++ b/worker/src/tts.js
@@ -144,6 +144,10 @@ function normaliseTtsCacheOnly(value) {
   return value === true || cleanText(value).toLowerCase() === 'true';
 }
 
+function normaliseTtsCacheLookupOnly(value) {
+  return value === true || cleanText(value).toLowerCase() === 'true';
+}
+
 function ttsInstructions(slow = false, wordOnly = false) {
   if (wordOnly) {
     return 'Use natural British English pronunciation for a KS2 vocabulary preview. Read exactly the supplied word once and do not add extra words.';
@@ -658,6 +662,7 @@ export async function handleTextToSpeechRequest({
 } = {}) {
   const body = await readJson(request);
   const cacheOnly = normaliseTtsCacheOnly(body?.cacheOnly);
+  const cacheLookupOnly = normaliseTtsCacheLookupOnly(body?.cacheLookupOnly);
   const payload = {
     ...(await resolveSpellingAudioRequest({
       repository,
@@ -665,9 +670,10 @@ export async function handleTextToSpeechRequest({
       body,
     })),
     accountId: session.accountId,
-    provider: cacheOnly ? 'gemini' : normaliseRemoteTtsProvider(body?.provider),
+    provider: cacheOnly || cacheLookupOnly ? 'gemini' : normaliseRemoteTtsProvider(body?.provider),
     bufferedGeminiVoice: normaliseBufferedGeminiVoice(body?.bufferedGeminiVoice || body?.cachedVoice),
     cacheOnly,
+    cacheLookupOnly,
   };
   const openAi = openAiConfig(env);
   const gemini = geminiConfig(env);
@@ -675,7 +681,7 @@ export async function handleTextToSpeechRequest({
     ...gemini,
     voice: payload.bufferedGeminiVoice || gemini.voice,
   };
-  if (cacheOnly && payload.wordOnly) return cacheOnlyResponse('uncacheable');
+  if ((cacheOnly || cacheLookupOnly) && payload.wordOnly) return cacheOnlyResponse('uncacheable');
   let protectedRequest = false;
   async function protectAudioRequest() {
     if (protectedRequest) return;
@@ -690,12 +696,16 @@ export async function handleTextToSpeechRequest({
 
   async function tryGemini(fallbackFrom = '') {
     if (!payload.wordOnly) {
-      if (!cacheOnly) await protectAudioRequest();
+      if (!cacheOnly && !cacheLookupOnly) await protectAudioRequest();
       const cacheHit = await readBufferedGeminiAudio(env, payload, { model: geminiForPayload.model });
       if (cacheHit?.object) {
+        if (cacheLookupOnly) await protectAudioRequest();
         const output = cacheOnly ? cacheOnlyResponse('hit', cacheHit) : cachedGeminiAudioResponse(cacheHit);
         return cacheOnly ? output : await finish(output, fallbackFrom);
       }
+      if (cacheLookupOnly && cacheHit?.cacheUnavailable) return cacheOnlyResponse('unavailable', cacheHit);
+      if (cacheLookupOnly && !cacheHit?.metadata) return cacheOnlyResponse('uncacheable');
+      if (cacheLookupOnly) return cacheOnlyResponse('miss', cacheHit);
       if (cacheOnly && cacheHit?.cacheUnavailable) return cacheOnlyResponse('unavailable', cacheHit);
       if (cacheOnly && !cacheHit?.metadata) return cacheOnlyResponse('uncacheable');
       if (cacheOnly) {


### PR DESCRIPTION
## Summary
- Add a cache-lookup-only TTS mode so the client can try R2 cached Gemini dictation audio without generating on a miss.
- Make non-Gemini remote playback use cached audio first, then fall back to the selected OpenAI provider only when no cache exists.
- Force Profile Settings provider tests (`kind: test`) through the selected provider, bypassing cache-first lookup and background warmup so cached Gemini audio cannot mask a broken provider or wrong voice.
- Keep browser TTS offline-resilient by skipping the blocking remote cache lookup for `provider=browser` while still allowing non-blocking cache warmup.
- Guard lookup-only R2 probes with dedicated lookup limiters, not playback quota, so cold-cache fallback spends `tts-account` / `tts-ip` only once.
- Charge normal playback/demo guards on lookup-only cache hits before returning audio, so warmed cached playback cannot bypass playback limits.

## Verification
- `node --check src/subjects/spelling/tts.js && node --test tests/spelling-tts.test.js`
- `node --check worker/src/demo/sessions.js && node --check worker/src/tts.js && node --test tests/spelling-tts.test.js tests/worker-tts.test.js`
- `npm test`
- `npm run check`