### PR TITLE
fix(spelling): serialise subject commands

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1864,6 +1864,14 @@ const SPELLING_COMMAND_ACTIONS = new Set([
   'spelling-drill-single',
 ]);
 
+const SPELLING_IN_FLIGHT_DEDUPE_COMMANDS = new Set([
+  'start-session',
+  'submit-answer',
+  'continue-session',
+  'skip-word',
+  'end-session',
+]);
+
 const SPELLING_UI_LOCAL_ACTIONS = new Set([
   'spelling-back',
   'spelling-replay',
@@ -1951,10 +1959,17 @@ const punctuationCommandActions = createSubjectCommandActionHandler({
 });
 
 function spellingCommandDedupeKey(command, appState = store.getState()) {
-  if (command !== 'continue-session') return '';
+  if (!SPELLING_IN_FLIGHT_DEDUPE_COMMANDS.has(command)) return '';
   const learnerId = appState.learners?.selectedId || '';
-  const sessionId = appState.subjectUi?.spelling?.session?.id || '';
-  return learnerId && sessionId ? `${command}:${learnerId}:${sessionId}` : '';
+  if (!learnerId) return '';
+  if (command === 'start-session') return `${command}:${learnerId}:setup`;
+  const session = appState.subjectUi?.spelling?.session || {};
+  const sessionId = session.id || '';
+  if (!sessionId) return '';
+  const currentSlug = session.currentSlug || 'unknown';
+  const phase = session.phase || 'unknown';
+  const promptCount = Number.isFinite(Number(session.promptCount)) ? Number(session.promptCount) : 0;
+  return `${command}:${learnerId}:${sessionId}:${currentSlug}:${phase}:${promptCount}`;
 }
 
 function wordBankAnalyticsFromState(appState = store.getState()) {

--- a/src/platform/runtime/subject-command-client.js
+++ b/src/platform/runtime/subject-command-client.js
@@ -38,6 +38,21 @@ export function createSubjectCommandClient({
     throw new TypeError('Subject command client requires a fetch implementation.');
   }
 
+  const learnerCommandQueues = new Map();
+
+  function enqueueLearnerCommand(learnerId, task) {
+    const queueKey = learnerId || 'default';
+    const previous = learnerCommandQueues.get(queueKey) || Promise.resolve();
+    let queued;
+    queued = previous.catch(() => {}).then(task).finally(() => {
+      if (learnerCommandQueues.get(queueKey) === queued) {
+        learnerCommandQueues.delete(queueKey);
+      }
+    });
+    learnerCommandQueues.set(queueKey, queued);
+    return queued;
+  }
+
   async function sendOnce({ cleanSubjectId, cleanLearnerId, cleanCommand, payload, requestId }) {
     const expectedLearnerRevision = Number(getLearnerRevision(cleanLearnerId)) || 0;
     let response;
@@ -79,18 +94,7 @@ export function createSubjectCommandClient({
     return responsePayload;
   }
 
-  async function send({ subjectId, learnerId, command, payload = {}, requestId = uid('subject-command') } = {}) {
-    const cleanSubjectId = String(subjectId || '').trim();
-    const cleanLearnerId = String(learnerId || '').trim();
-    const cleanCommand = String(command || '').trim();
-    if (!cleanSubjectId || !cleanLearnerId || !cleanCommand) {
-      throw new SubjectCommandClientError({
-        status: 400,
-        payload: { code: 'subject_command_client_invalid' },
-        message: 'Subject command requires subject, learner, and command identifiers.',
-      });
-    }
-
+  async function sendWithRetry({ cleanSubjectId, cleanLearnerId, cleanCommand, payload, requestId }) {
     let responsePayload;
     try {
       responsePayload = await sendOnce({
@@ -128,6 +132,27 @@ export function createSubjectCommandClient({
       response: responsePayload,
     });
     return responsePayload;
+  }
+
+  async function send({ subjectId, learnerId, command, payload = {}, requestId = uid('subject-command') } = {}) {
+    const cleanSubjectId = String(subjectId || '').trim();
+    const cleanLearnerId = String(learnerId || '').trim();
+    const cleanCommand = String(command || '').trim();
+    if (!cleanSubjectId || !cleanLearnerId || !cleanCommand) {
+      throw new SubjectCommandClientError({
+        status: 400,
+        payload: { code: 'subject_command_client_invalid' },
+        message: 'Subject command requires subject, learner, and command identifiers.',
+      });
+    }
+
+    return enqueueLearnerCommand(cleanLearnerId, () => sendWithRetry({
+      cleanSubjectId,
+      cleanLearnerId,
+      cleanCommand,
+      payload,
+      requestId,
+    }));
   }
 
   return { send };

--- a/tests/subject-command-client.test.js
+++ b/tests/subject-command-client.test.js
@@ -1,0 +1,66 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createSubjectCommandClient } from '../src/platform/runtime/subject-command-client.js';
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+test('subject command client serialises learner commands before reading revisions', async () => {
+  let revision = 0;
+  const firstGate = deferred();
+  const commandBodies = [];
+  const fetch = async (input, init = {}) => {
+    const body = JSON.parse(init.body);
+    commandBodies.push(body);
+    if (body.requestId === 'cmd-1') {
+      await firstGate.promise;
+    }
+    return new Response(JSON.stringify({
+      ok: true,
+      mutation: {
+        appliedRevision: body.expectedLearnerRevision + 1,
+      },
+    }), { status: 200, headers: { 'content-type': 'application/json' } });
+  };
+  const commands = createSubjectCommandClient({
+    fetch,
+    getLearnerRevision: () => revision,
+    onCommandApplied({ response }) {
+      revision = Number(response.mutation?.appliedRevision) || revision;
+    },
+  });
+
+  const first = commands.send({
+    subjectId: 'spelling',
+    learnerId: 'learner-a',
+    command: 'submit-answer',
+    payload: { typed: 'answer' },
+    requestId: 'cmd-1',
+  });
+  const second = commands.send({
+    subjectId: 'spelling',
+    learnerId: 'learner-a',
+    command: 'continue-session',
+    requestId: 'cmd-2',
+  });
+
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(commandBodies.length, 1);
+  assert.equal(commandBodies[0].expectedLearnerRevision, 0);
+
+  firstGate.resolve();
+  await Promise.all([first, second]);
+
+  assert.deepEqual(commandBodies.map((body) => body.requestId), ['cmd-1', 'cmd-2']);
+  assert.deepEqual(commandBodies.map((body) => body.expectedLearnerRevision), [0, 1]);
+  assert.equal(revision, 2);
+});


### PR DESCRIPTION
## Summary
- serialise subject commands per learner so rapid actions read the latest applied revision before hitting the Worker
- dedupe in-flight Spelling start/submit/continue/skip/end commands to avoid double-applying rapid UI actions
- add regression coverage for same-learner command ordering

## Verification
- npm test -- tests/subject-command-client.test.js tests/persistence.test.js
- npm test
- npm run check