### PR TITLE
fix(tts): fall back across remote providers

### DIFF
--- a/docs/spelling-service.md
+++ b/docs/spelling-service.md
@@ -102,7 +102,7 @@ Live Spelling command read models no longer expose the current answer, word slug
 }
 ```
 
-The browser sends only `learnerId`, `promptToken`, and playback options to `/api/tts`. The Worker then reloads the current server-owned Spelling session, validates that the token still matches the active prompt, derives the transcript server-side, and resolves the selected provider without trusting browser-supplied transcript text. Arbitrary browser-supplied `word` and `sentence` payloads are rejected.
+The browser sends only `learnerId`, `promptToken`, and playback options to `/api/tts`. The Worker then reloads the current server-owned Spelling session, validates that the token still matches the active prompt, derives the transcript server-side, and tries the selected provider before falling back to the other configured remote provider when needed, without trusting browser-supplied transcript text. Arbitrary browser-supplied `word` and `sentence` payloads are rejected.
 
 Gemini dictation audio now uses a cache-first buffered path. The Worker derives a deterministic R2 asset key from the active Gemini model, buffered voice, speed, published prompt content key, slug, and sentence index; it serves matching `SPELLING_AUDIO_BUCKET` objects before provider generation and stores newly generated Gemini audio back under the same key. Cache-only warm-up requests can prefill those assets without returning playback bytes, while normal OpenAI requests remain protected behind Worker-side credentials and rate limits.
 

--- a/tests/worker-tts.test.js
+++ b/tests/worker-tts.test.js
@@ -718,9 +718,10 @@ test('TTS cache-only warmups are skipped when the warmup quota is exhausted', as
   }
 });
 
-test('TTS route does not fall back when selected OpenAI exceeds the primary timeout', async () => {
+test('TTS route falls back to Gemini when selected OpenAI exceeds the primary timeout', async () => {
   const originalFetch = globalThis.fetch;
   let openAiAborted = false;
+  let geminiCalls = 0;
   globalThis.fetch = async (url, init = {}) => {
     if (url === 'https://api.openai.com/v1/audio/speech') {
       return await new Promise((resolve, reject) => {
@@ -731,6 +732,10 @@ test('TTS route does not fall back when selected OpenAI exceeds the primary time
           reject(error);
         }, { once: true });
       });
+    }
+    if (String(url).includes('generativelanguage.googleapis.com')) {
+      geminiCalls += 1;
+      return geminiAudioResponse();
     }
     throw new Error(`Unexpected provider call: ${url}`);
   };
@@ -749,13 +754,65 @@ test('TTS route does not fall back when selected OpenAI exceeds the primary time
       promptToken: prompt.promptToken,
       provider: 'openai',
     }));
-    const payload = await response.json();
+    const bytes = new Uint8Array(await response.arrayBuffer());
 
-    assert.equal(response.status, 503);
-    assert.equal(payload.code, 'tts_provider_error');
-    assert.equal(payload.provider, 'openai');
-    assert.equal(payload.providerTimedOut, true);
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('content-type'), 'audio/wav');
+    assert.equal(response.headers.get('x-ks2-tts-provider'), 'gemini');
+    assert.equal(response.headers.get('x-ks2-tts-fallback-from'), 'openai');
+    assert.equal(String.fromCharCode(...bytes.slice(0, 4)), 'RIFF');
     assert.equal(openAiAborted, true);
+    assert.equal(geminiCalls, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+    server.close();
+  }
+});
+
+test('TTS route falls back to OpenAI when selected Gemini provider fails', async () => {
+  const originalFetch = globalThis.fetch;
+  let geminiCalls = 0;
+  let openAiCalls = 0;
+  globalThis.fetch = async (url) => {
+    if (String(url).includes('generativelanguage.googleapis.com')) {
+      geminiCalls += 1;
+      return new Response(JSON.stringify({ error: 'temporarily unavailable' }), {
+        status: 503,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    if (url === 'https://api.openai.com/v1/audio/speech') {
+      openAiCalls += 1;
+      return new Response(new Uint8Array([1, 2, 3]), {
+        status: 200,
+        headers: { 'content-type': 'audio/mpeg' },
+      });
+    }
+    throw new Error(`Unexpected provider call: ${url}`);
+  };
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      OPENAI_API_KEY: 'test-openai-key',
+      GEMINI_API_KEY: 'test-gemini-key',
+    },
+  });
+  try {
+    const prompt = await startSpellingPrompt(server);
+    const response = await server.fetch('https://repo.test/api/tts', ttsRequest({
+      learnerId: prompt.learnerId,
+      promptToken: prompt.promptToken,
+      provider: 'gemini',
+    }));
+    const bytes = new Uint8Array(await response.arrayBuffer());
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('content-type'), 'audio/mpeg');
+    assert.equal(response.headers.get('x-ks2-tts-provider'), 'openai');
+    assert.equal(response.headers.get('x-ks2-tts-fallback-from'), 'gemini');
+    assert.deepEqual([...bytes], [1, 2, 3]);
+    assert.equal(geminiCalls, 1);
+    assert.equal(openAiCalls, 1);
   } finally {
     globalThis.fetch = originalFetch;
     server.close();

--- a/worker/README.md
+++ b/worker/README.md
@@ -14,7 +14,7 @@ It is:
 - a place where learner-scoped permissions are enforced before repository writes happen
 - a provider-agnostic auth/session boundary with production email and social login flows, ephemeral demo sessions, and a safe development/test stub
 - a server-authoritative subject command runtime for signed-in and demo practice
-- a Worker-side TTS proxy that keeps provider API keys out of the browser and honours the selected OpenAI or Gemini provider without automatic fallback
+- a Worker-side TTS proxy that keeps provider API keys out of the browser, tries the selected OpenAI or Gemini provider first, and falls back to the other configured remote provider when the selected provider fails
 - a prompt-token audio boundary so dictation text is resolved on the server
 - a read-model boundary for role-aware Parent Hub and Admin / Operations surfaces
 - a read-model boundary for authorised Spelling Word Bank rows and detail

--- a/worker/src/tts.js
+++ b/worker/src/tts.js
@@ -239,10 +239,22 @@ function backendUnavailableFromFailure(error, failures = []) {
 
 function missingProviderConfig(provider) {
   const name = provider === 'gemini' ? 'Gemini' : 'OpenAI';
-  return new BackendUnavailableError(`${name} TTS is not configured.`, {
+  const error = new BackendUnavailableError(`${name} TTS is not configured.`, {
     code: 'tts_not_configured',
     provider,
   });
+  error.provider = provider;
+  return error;
+}
+
+function providerUnavailableError(error, failures = []) {
+  if (error instanceof BackendUnavailableError && failures.length <= 1) return error;
+  return backendUnavailableFromFailure(error, failures.length ? failures : [error]);
+}
+
+function canFallbackProviderError(error) {
+  const status = Number(error?.status);
+  return !Number.isFinite(status) || status >= 500;
 }
 
 function spellingAudioBucket(env = {}) {
@@ -377,6 +389,17 @@ function cacheOnlyResponse(cacheState, cacheHit = null) {
   if (cacheHit?.metadata?.model) headers.set('x-ks2-tts-model', cacheHit.metadata.model);
   if (cacheHit?.metadata?.voice) headers.set('x-ks2-tts-voice', cacheHit.metadata.voice);
   return new Response(null, { status: 204, headers });
+}
+
+function withFallbackHeader(response, fallbackFrom = '') {
+  if (!fallbackFrom) return response;
+  const headers = new Headers(response.headers);
+  headers.set('x-ks2-tts-fallback-from', fallbackFrom);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
 }
 
 async function storeBufferedGeminiAudio(env, payload, response, options = {}) {
@@ -661,49 +684,79 @@ export async function handleTextToSpeechRequest({
     protectedRequest = true;
   }
 
-  if (payload.provider === 'gemini' && !payload.wordOnly) {
-    if (!cacheOnly) await protectAudioRequest();
-    const cacheHit = await readBufferedGeminiAudio(env, payload, { model: geminiForPayload.model });
-    if (cacheHit?.object) {
-      const output = cacheOnly ? cacheOnlyResponse('hit', cacheHit) : cachedGeminiAudioResponse(cacheHit);
-      return cacheOnly ? output : await recordDemoTtsFallback(env, session, now, output);
-    }
-    if (cacheOnly && cacheHit?.cacheUnavailable) return cacheOnlyResponse('unavailable', cacheHit);
-    if (cacheOnly && !cacheHit?.metadata) return cacheOnlyResponse('uncacheable');
-    if (cacheOnly) {
-      if (!geminiForPayload.apiKey) return cacheOnlyResponse('unavailable');
-      const warmupAllowed = await allowTtsWarmup(env, request, session, now);
-      if (!warmupAllowed) return cacheOnlyResponse('skipped_rate_limited');
-      await protectDemoTtsFallback({ env, request, session, payload, now });
-    }
+  async function finish(response, fallbackFrom = '') {
+    return await recordDemoTtsFallback(env, session, now, withFallbackHeader(response, fallbackFrom));
   }
 
-  if (payload.provider === 'gemini') {
+  async function tryGemini(fallbackFrom = '') {
+    if (!payload.wordOnly) {
+      if (!cacheOnly) await protectAudioRequest();
+      const cacheHit = await readBufferedGeminiAudio(env, payload, { model: geminiForPayload.model });
+      if (cacheHit?.object) {
+        const output = cacheOnly ? cacheOnlyResponse('hit', cacheHit) : cachedGeminiAudioResponse(cacheHit);
+        return cacheOnly ? output : await finish(output, fallbackFrom);
+      }
+      if (cacheOnly && cacheHit?.cacheUnavailable) return cacheOnlyResponse('unavailable', cacheHit);
+      if (cacheOnly && !cacheHit?.metadata) return cacheOnlyResponse('uncacheable');
+      if (cacheOnly) {
+        if (!geminiForPayload.apiKey) return cacheOnlyResponse('unavailable');
+        const warmupAllowed = await allowTtsWarmup(env, request, session, now);
+        if (!warmupAllowed) return cacheOnlyResponse('skipped_rate_limited');
+        await protectDemoTtsFallback({ env, request, session, payload, now });
+      }
+    }
     if (!geminiForPayload.apiKey) {
       if (cacheOnly) return cacheOnlyResponse('unavailable');
       throw missingProviderConfig('gemini');
     }
     if (!cacheOnly) await protectAudioRequest();
+    const response = await requestGeminiSpeech({ config: geminiForPayload, payload, fetchFn });
+    const stored = payload.wordOnly
+      ? { response, cacheState: 'uncacheable' }
+      : await storeBufferedGeminiAudio(env, payload, response, { model: geminiForPayload.model });
+    const output = cacheOnly
+      ? cacheOnlyResponse(stored.cacheState, { metadata: stored.metadata })
+      : stored.response;
+    return await finish(output, fallbackFrom);
+  }
+
+  async function tryOpenAi(fallbackFrom = '') {
+    if (!openAi.apiKey) throw missingProviderConfig('openai');
+    await protectAudioRequest();
+    const response = await requestOpenAiSpeech({ config: openAi, payload, fetchFn });
+    return await finish(response, fallbackFrom);
+  }
+
+  function canTryGemini() {
+    if (payload.wordOnly) return Boolean(geminiForPayload.apiKey);
+    return Boolean(geminiForPayload.apiKey || spellingAudioBucket(env));
+  }
+
+  if (payload.provider === 'gemini') {
     try {
-      const response = await requestGeminiSpeech({ config: geminiForPayload, payload, fetchFn });
-      const stored = payload.wordOnly
-        ? { response, cacheState: 'uncacheable' }
-        : await storeBufferedGeminiAudio(env, payload, response, { model: geminiForPayload.model });
-      const output = cacheOnly
-        ? cacheOnlyResponse(stored.cacheState, { metadata: stored.metadata })
-        : stored.response;
-      return await recordDemoTtsFallback(env, session, now, output);
+      return await tryGemini();
     } catch (error) {
-      throw backendUnavailableFromFailure(error, [error]);
+      if (!canFallbackProviderError(error)) throw error;
+      if (cacheOnly || !openAi.apiKey) throw providerUnavailableError(error, [error]);
+      try {
+        return await tryOpenAi('gemini');
+      } catch (fallbackError) {
+        if (!canFallbackProviderError(fallbackError)) throw fallbackError;
+        throw backendUnavailableFromFailure(fallbackError, [error, fallbackError]);
+      }
     }
   }
 
-  if (!openAi.apiKey) throw missingProviderConfig('openai');
-  await protectAudioRequest();
   try {
-    const response = await requestOpenAiSpeech({ config: openAi, payload, fetchFn });
-    return await recordDemoTtsFallback(env, session, now, response);
+    return await tryOpenAi();
   } catch (error) {
-    throw backendUnavailableFromFailure(error, [error]);
+    if (!canFallbackProviderError(error)) throw error;
+    if (!canTryGemini()) throw providerUnavailableError(error, [error]);
+    try {
+      return await tryGemini('openai');
+    } catch (fallbackError) {
+      if (!canFallbackProviderError(fallbackError)) throw fallbackError;
+      throw backendUnavailableFromFailure(fallbackError, [error, fallbackError]);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Keep prompt-token validation, rate limits, and demo guards intact while trying the selected remote TTS provider first.
- Fall back to the other configured remote provider when OpenAI or Gemini times out, returns 5xx, or is unavailable.
- Add regression coverage for OpenAI -> Gemini and Gemini -> OpenAI fallback, and update TTS boundary docs.

## Test Plan
- [x] npm test -- tests/worker-tts.test.js
- [x] npm test
- [x] npm run check