### PR TITLE
Fix spelling word-family toggle

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2359,6 +2359,7 @@ function handleRemoteSpellingAction(action, data = {}) {
       mode: prefs.mode,
       yearFilter: prefs.yearFilter,
       length: prefs.roundLength,
+      extraWordFamilies: prefs.extraWordFamilies,
     });
     return true;
   }
@@ -2378,6 +2379,7 @@ function handleRemoteSpellingAction(action, data = {}) {
         mode: prefs.mode || mode,
         yearFilter: prefs.yearFilter,
         length: prefs.roundLength,
+        extraWordFamilies: prefs.extraWordFamilies,
       });
     })().catch((error) => {
       globalThis.console?.warn?.('Spelling shortcut command failed.', error);

--- a/src/subjects/spelling/client-read-models.js
+++ b/src/subjects/spelling/client-read-models.js
@@ -22,6 +22,7 @@ function defaultPrefs() {
     roundLength: normaliseRoundLength('20', mode),
     showCloze: true,
     autoSpeak: true,
+    extraWordFamilies: false,
     ttsProvider: DEFAULT_TTS_PROVIDER,
     bufferedGeminiVoice: DEFAULT_BUFFERED_GEMINI_VOICE,
   };
@@ -35,6 +36,7 @@ function normalisePrefs(rawPrefs = {}) {
     roundLength: normaliseRoundLength(rawPrefs.roundLength, mode),
     showCloze: normaliseBoolean(rawPrefs.showCloze, true),
     autoSpeak: normaliseBoolean(rawPrefs.autoSpeak, true),
+    extraWordFamilies: normaliseBoolean(rawPrefs.extraWordFamilies, false),
     ttsProvider: normaliseTtsProvider(rawPrefs.ttsProvider),
     bufferedGeminiVoice: normaliseBufferedGeminiVoice(rawPrefs.bufferedGeminiVoice),
   };

--- a/tests/react-spelling-surface.test.js
+++ b/tests/react-spelling-surface.test.js
@@ -5,6 +5,7 @@ import {
   renderSpellingClozeFixture,
   renderSpellingSurfaceFixture,
 } from './helpers/react-render.js';
+import { createSpellingReadModelService } from '../src/subjects/spelling/client-read-models.js';
 
 test('React spelling setup scene renders primary practice controls', async () => {
   const html = await renderSpellingSurfaceFixture({ phase: 'setup' });
@@ -12,6 +13,32 @@ test('React spelling setup scene renders primary practice controls', async () =>
   assert.match(html, /Round setup/);
   assert.match(html, /Begin 20 words/);
   assert.match(html, /data-action="spelling-start"/);
+});
+
+test('client spelling read model preserves word-family variant preference', () => {
+  const service = createSpellingReadModelService({
+    getState: () => ({
+      learners: { selectedId: 'learner-a' },
+      subjectUi: {
+        spelling: {
+          subjectId: 'spelling',
+          learnerId: 'learner-a',
+          version: 1,
+          phase: 'dashboard',
+          prefs: {
+            mode: 'smart',
+            yearFilter: 'extra',
+            roundLength: '20',
+            showCloze: true,
+            autoSpeak: true,
+            extraWordFamilies: true,
+          },
+        },
+      },
+    }),
+  });
+
+  assert.equal(service.getPrefs('learner-a').extraWordFamilies, true);
 });
 
 test('React spelling session scene preserves input, replay, and submit affordances', async () => {

--- a/tests/server-spelling-engine-parity.test.js
+++ b/tests/server-spelling-engine-parity.test.js
@@ -91,6 +91,7 @@ test('server spelling engine preserves deterministic selection and retry progres
     mode: 'smart',
     yearFilter: 'extra',
     length: 5,
+    extraWordFamilies: true,
   });
   const serverStarted = server.apply({
     learnerId,
@@ -101,10 +102,12 @@ test('server spelling engine preserves deterministic selection and retry progres
       mode: 'smart',
       yearFilter: 'extra',
       length: 5,
+      extraWordFamilies: true,
     },
   });
 
   assert.equal(serverStarted.state.session.serverAuthority, SPELLING_SERVER_AUTHORITY);
+  assert.equal(serverStarted.state.session.extraWordFamilies, true);
   assert.deepEqual(serverStarted.state.session.uniqueWords, referenceStarted.state.session.uniqueWords);
   assert.equal(serverStarted.state.session.currentCard.slug, referenceStarted.state.session.currentCard.slug);
 

--- a/worker/src/subjects/spelling/engine.js
+++ b/worker/src/subjects/spelling/engine.js
@@ -199,6 +199,7 @@ function startOptionsFromPayload(payload = {}) {
     length: payload.length ?? payload.roundLength,
     words,
     practiceOnly: payload.practiceOnly,
+    extraWordFamilies: payload.extraWordFamilies,
   };
 }
 


### PR DESCRIPTION
## Summary
- Preserve the spelling extra word-family preference in the client read model so the setup chip stays toggled after server sync.
- Pass the preference through remote spelling start commands and accept it in the Worker command parser.
- Add regression coverage for the client read model and server spelling engine option path.

## Verification
- npm test
- npm run check
- Local /demo browser smoke: Word-family variants toggles to aria-pressed="true" and start-session sends extraWordFamilies: true.