### PR TITLE
fix(spelling): hydrate setup stats from bootstrap

### DIFF
--- a/tests/worker-auth.test.js
+++ b/tests/worker-auth.test.js
@@ -579,6 +579,9 @@ test('production public bootstrap keeps Codex mastery visible from redacted spel
   assert.ok(publicSpelling.ui.stats.core.total > 0);
   assert.equal(publicSpelling.ui.stats.all.secure, 3);
   assert.equal(publicSpelling.ui.stats.core.secure, 3);
+  assert.equal(publicSpelling.ui.stats.y34.secure, 1);
+  assert.equal(publicSpelling.ui.stats.y56.secure, 2);
+  assert.equal(publicSpelling.ui.stats.extra.total, 23);
   assert.equal(publicSpelling.ui.stats.extra.secure, 1);
   assert.deepEqual(publicSpelling.ui.analytics.wordGroups, []);
   assert.equal(publicSpelling.ui.analytics.pools.core.secure, 3);

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -348,14 +348,11 @@ function publicMonsterCodexHasMastery(state) {
   return Object.values(state).some((entry) => Number(entry?.masteredCount) > 0 || entry?.caught === true);
 }
 
-async function mergePublicSpellingCodexState(db, accountId, subjectRows, gameState) {
+async function mergePublicSpellingCodexState(db, accountId, subjectRows, gameState, { runtimeSnapshot = null } = {}) {
   const spellingRows = subjectRows.filter((row) => row.subject_id === 'spelling');
   if (!spellingRows.length) return gameState;
 
-  const content = await readSubjectContentBundle(db, accountId, 'spelling');
-  const snapshot = resolveRuntimeSnapshot(content, {
-    referenceBundle: SEEDED_SPELLING_CONTENT_BUNDLE,
-  });
+  const snapshot = runtimeSnapshot || runtimeSnapshotForBundle(await readSubjectContentBundle(db, accountId, 'spelling'));
 
   for (const row of spellingRows) {
     const progress = spellingProgressFromSubjectRow(row);
@@ -1353,7 +1350,6 @@ async function bootstrapBundle(db, accountId, { publicReadModels = false } = {})
     WHERE learner_id IN (${placeholders})
     ORDER BY created_at ASC, id ASC
   `, learnerIds);
-
   const publicSpellingContent = publicReadModels && subjectRows.some((row) => row.subject_id === 'spelling')
     ? await readSpellingRuntimeContentBundle(db, accountId, 'spelling')
     : null;
@@ -1376,7 +1372,9 @@ async function bootstrapBundle(db, accountId, { publicReadModels = false } = {})
     if (record) gameState[gameStateKey(row.learner_id, row.system_id)] = record;
   });
   if (publicReadModels) {
-    await mergePublicSpellingCodexState(db, accountId, subjectRows, gameState);
+    await mergePublicSpellingCodexState(db, accountId, subjectRows, gameState, {
+      runtimeSnapshot: publicSpellingContent?.snapshot || null,
+    });
   }
 
   return {


### PR DESCRIPTION
## Summary
- Hydrate redacted spelling bootstrap read models with safe aggregate stats for setup
- Reuse the server spelling service against redacted storage so progress stays private while totals render immediately
- Cover the bootstrap contract so progress remains hidden while setup stats are populated

## Verification
- node --test tests/worker-auth.test.js
- npm test
- npm run check