### PR TITLE
fix(sync): drop retired legacy pending writes

### DIFF
--- a/src/platform/core/repositories/api.js
+++ b/src/platform/core/repositories/api.js
@@ -77,9 +77,8 @@ function isLegacyRuntimeOperationKind(kind) {
   return LEGACY_RUNTIME_OPERATION_KINDS.has(String(kind || ''));
 }
 
-function assertLegacyRuntimeWriteAllowed(kind) {
-  if (LEGACY_RUNTIME_WRITES_ENABLED) return;
-  throw new Error(`Runtime writes must use the subject command boundary (${kind}).`);
+function isReplayablePendingOperation(operation, legacyRuntimeWritesEnabled = LEGACY_RUNTIME_WRITES_ENABLED) {
+  return legacyRuntimeWritesEnabled || !isLegacyRuntimeOperationKind(operation?.kind);
 }
 
 function legacyRuntimePath(...segments) {
@@ -886,11 +885,13 @@ export function createApiPlatformRepositories({
   authSession = createNoopRepositoryAuthSession(),
   cacheScopeKey = null,
   publicReadModels = false,
+  legacyRuntimeWritesEnabled = LEGACY_RUNTIME_WRITES_ENABLED,
 } = {}) {
   if (typeof fetchFn !== 'function') {
     throw new TypeError('API repositories require a fetch implementation.');
   }
 
+  const legacyWritesEnabled = legacyRuntimeWritesEnabled === true;
   const resolvedStorage = storage || globalThis.localStorage || createNoopStorage();
   const resolvedCacheScopeKey = typeof cacheScopeKey === 'string' && cacheScopeKey
     ? cacheScopeKey
@@ -898,7 +899,8 @@ export function createApiPlatformRepositories({
   const storageKey = apiCacheStorageKey(resolvedCacheScopeKey);
   const cachedState = loadCachedState(resolvedStorage, storageKey);
   const cache = normaliseRepositoryBundle(cachedState.bundle);
-  let pendingOperations = normalisePendingOperations(cachedState.pendingOperations);
+  let pendingOperations = normalisePendingOperations(cachedState.pendingOperations)
+    .filter((operation) => isReplayablePendingOperation(operation, legacyWritesEnabled));
   let syncState = normaliseSyncState(cachedState.syncState);
   let inFlightWriteCount = 0;
   let lastSyncAt = 0;
@@ -1003,6 +1005,11 @@ export function createApiPlatformRepositories({
   function markRemoteFailure(error) {
     lastRemoteError = error;
     recomputePersistence();
+  }
+
+  function assertRuntimeWriteAllowed(kind) {
+    if (legacyWritesEnabled) return;
+    throw new Error(`Runtime writes must use the subject command boundary (${kind}).`);
   }
 
   function removeOperationById(id) {
@@ -1216,11 +1223,11 @@ export function createApiPlatformRepositories({
         body: JSON.stringify({ learners: cloneSerialisable(operation.snapshot), mutation }),
       }, authSession);
     }
-    if (LEGACY_RUNTIME_WRITES_ENABLED && isLegacyRuntimeOperationKind(operation.kind)) {
+    if (legacyWritesEnabled && isLegacyRuntimeOperationKind(operation.kind)) {
       return sendLegacyRuntimeOperation(operation, mutation, headers);
     }
     if (isLegacyRuntimeOperationKind(operation.kind)) {
-      assertLegacyRuntimeWriteAllowed(operation.kind);
+      assertRuntimeWriteAllowed(operation.kind);
     }
     return null;
   }
@@ -1415,7 +1422,7 @@ export function createApiPlatformRepositories({
       return undefined;
     },
     clearAll() {
-      assertLegacyRuntimeWriteAllowed('debug.reset');
+      assertRuntimeWriteAllowed('debug.reset');
       const operation = createOperation('debug.reset', {}, syncState);
       queueOperation(operation);
       kickQueue();
@@ -1467,7 +1474,7 @@ export function createApiPlatformRepositories({
         return this.writeRecord(learnerId, subjectId, mergeSubjectData(this.read(learnerId, subjectId), data, nowTs()), 'data');
       },
       writeRecord(learnerId, subjectId, record, mergeStrategy = 'replace') {
-        assertLegacyRuntimeWriteAllowed('subjectStates.put');
+        assertRuntimeWriteAllowed('subjectStates.put');
         const operation = createOperation('subjectStates.put', {
           learnerId,
           subjectId,
@@ -1479,13 +1486,13 @@ export function createApiPlatformRepositories({
         return normaliseSubjectStateRecord(cache.subjectStates[subjectStateKey(learnerId, subjectId)]);
       },
       clear(learnerId, subjectId) {
-        assertLegacyRuntimeWriteAllowed('subjectStates.delete');
+        assertRuntimeWriteAllowed('subjectStates.delete');
         const operation = createOperation('subjectStates.delete', { learnerId, subjectId }, syncState);
         queueOperation(operation);
         kickQueue();
       },
       clearLearner(learnerId) {
-        assertLegacyRuntimeWriteAllowed('subjectStates.clearLearner');
+        assertRuntimeWriteAllowed('subjectStates.clearLearner');
         const operation = createOperation('subjectStates.clearLearner', { learnerId }, syncState);
         queueOperation(operation);
         kickQueue();
@@ -1504,7 +1511,7 @@ export function createApiPlatformRepositories({
         });
       },
       write(record) {
-        assertLegacyRuntimeWriteAllowed('practiceSessions.put');
+        assertRuntimeWriteAllowed('practiceSessions.put');
         const operation = createOperation('practiceSessions.put', {
           record: normalisePracticeSessionRecord(record),
         }, syncState);
@@ -1513,7 +1520,7 @@ export function createApiPlatformRepositories({
         return this.latest(operation.record.learnerId, operation.record.subjectId);
       },
       clear(learnerId, subjectId = null) {
-        assertLegacyRuntimeWriteAllowed(subjectId ? 'practiceSessions.delete' : 'practiceSessions.clearLearner');
+        assertRuntimeWriteAllowed(subjectId ? 'practiceSessions.delete' : 'practiceSessions.clearLearner');
         const operation = createOperation(subjectId ? 'practiceSessions.delete' : 'practiceSessions.clearLearner', {
           learnerId,
           subjectId,
@@ -1522,7 +1529,7 @@ export function createApiPlatformRepositories({
         kickQueue();
       },
       clearLearner(learnerId) {
-        assertLegacyRuntimeWriteAllowed('practiceSessions.clearLearner');
+        assertRuntimeWriteAllowed('practiceSessions.clearLearner');
         const operation = createOperation('practiceSessions.clearLearner', { learnerId }, syncState);
         queueOperation(operation);
         kickQueue();
@@ -1543,7 +1550,7 @@ export function createApiPlatformRepositories({
         return output;
       },
       write(learnerId, systemId, state) {
-        assertLegacyRuntimeWriteAllowed('gameState.put');
+        assertRuntimeWriteAllowed('gameState.put');
         const operation = createOperation('gameState.put', {
           learnerId,
           systemId,
@@ -1554,7 +1561,7 @@ export function createApiPlatformRepositories({
         return this.read(learnerId, systemId);
       },
       clear(learnerId, systemId = null) {
-        assertLegacyRuntimeWriteAllowed(systemId ? 'gameState.delete' : 'gameState.clearLearner');
+        assertRuntimeWriteAllowed(systemId ? 'gameState.delete' : 'gameState.clearLearner');
         const operation = createOperation(systemId ? 'gameState.delete' : 'gameState.clearLearner', {
           learnerId,
           systemId,
@@ -1563,7 +1570,7 @@ export function createApiPlatformRepositories({
         kickQueue();
       },
       clearLearner(learnerId) {
-        assertLegacyRuntimeWriteAllowed('gameState.clearLearner');
+        assertRuntimeWriteAllowed('gameState.clearLearner');
         const operation = createOperation('gameState.clearLearner', { learnerId }, syncState);
         queueOperation(operation);
         kickQueue();
@@ -1573,7 +1580,7 @@ export function createApiPlatformRepositories({
       append(event) {
         const next = cloneSerialisable(event) || null;
         if (!next || typeof next !== 'object' || Array.isArray(next)) return null;
-        assertLegacyRuntimeWriteAllowed('eventLog.append');
+        assertRuntimeWriteAllowed('eventLog.append');
         const operation = createOperation('eventLog.append', { event: next }, syncState);
         queueOperation(operation);
         kickQueue();
@@ -1584,7 +1591,7 @@ export function createApiPlatformRepositories({
         return cloneSerialisable(learnerId ? events.filter((event) => event?.learnerId === learnerId) : events);
       },
       clearLearner(learnerId) {
-        assertLegacyRuntimeWriteAllowed('eventLog.clearLearner');
+        assertRuntimeWriteAllowed('eventLog.clearLearner');
         const operation = createOperation('eventLog.clearLearner', { learnerId }, syncState);
         queueOperation(operation);
         kickQueue();

--- a/tests/persistence.test.js
+++ b/tests/persistence.test.js
@@ -10,6 +10,8 @@ import { createAppHarness } from './helpers/app-harness.js';
 import { installMemoryStorage } from './helpers/memory-storage.js';
 import { createMockRepositoryServer } from './helpers/mock-api-server.js';
 
+const DEFAULT_API_CACHE_STORAGE_KEY = 'ks2-platform-v2.api-cache-state:default';
+
 async function waitForPersistenceIdle(repositories, attempts = 25) {
   await Promise.resolve();
   for (let index = 0; index < attempts; index += 1) {
@@ -36,6 +38,109 @@ function learnerSnapshot() {
     selectedId: 'learner-a',
   };
 }
+
+test('retired legacy runtime pending writes are discarded once remote bootstrap succeeds', async () => {
+  const storage = installMemoryStorage();
+  const remoteLearners = learnerSnapshot();
+  const localSubjectState = {
+    ui: { phase: 'dashboard', error: 'local-only marker' },
+    data: { prefs: { mode: 'single' } },
+    updatedAt: 20,
+  };
+  const localSession = {
+    id: 'local-session',
+    learnerId: 'learner-a',
+    subjectId: 'spelling',
+    sessionKind: 'learning',
+    status: 'active',
+    sessionState: { cursor: 3 },
+    summary: null,
+    createdAt: 20,
+    updatedAt: 20,
+  };
+
+  storage.setItem(DEFAULT_API_CACHE_STORAGE_KEY, JSON.stringify({
+    bundle: {
+      learners: remoteLearners,
+      subjectStates: {
+        'learner-a::spelling': localSubjectState,
+      },
+      practiceSessions: [localSession],
+      gameState: {
+        'learner-a::monster-codex': { localOnly: true },
+      },
+      eventLog: [{
+        id: 'local-event',
+        learnerId: 'learner-a',
+        type: 'spelling.word-secured',
+        createdAt: 21,
+      }],
+    },
+    pendingOperations: [
+      {
+        id: 'old-subject-state',
+        kind: 'subjectStates.put',
+        learnerId: 'learner-a',
+        subjectId: 'spelling',
+        record: localSubjectState,
+        expectedRevision: 0,
+        createdAt: 21,
+      },
+      {
+        id: 'old-practice-session',
+        kind: 'practiceSessions.put',
+        record: localSession,
+        expectedRevision: 0,
+        createdAt: 22,
+      },
+      {
+        id: 'old-game-state',
+        kind: 'gameState.put',
+        learnerId: 'learner-a',
+        systemId: 'monster-codex',
+        state: { localOnly: true },
+        expectedRevision: 0,
+        createdAt: 23,
+      },
+    ],
+    syncState: {
+      policyVersion: 1,
+      accountRevision: 0,
+      learnerRevisions: { 'learner-a': 0 },
+    },
+  }));
+
+  const server = createMockRepositoryServer({ learners: remoteLearners });
+  const repositories = createApiPlatformRepositories({
+    baseUrl: 'https://repo.test',
+    fetch: server.fetch.bind(server),
+    storage,
+    legacyRuntimeWritesEnabled: false,
+  });
+
+  await repositories.hydrate();
+
+  const snapshot = repositories.persistence.read();
+  assert.equal(snapshot.mode, 'remote-sync');
+  assert.equal(snapshot.trustedState, 'remote');
+  assert.equal(snapshot.cacheState, 'aligned');
+  assert.equal(snapshot.pendingWriteCount, 0);
+  assert.equal(snapshot.lastError, null);
+  assert.deepEqual(repositories.subjectStates.read('learner-a', 'spelling'), { ui: null, data: {}, updatedAt: 0 });
+  assert.equal(repositories.practiceSessions.latest('learner-a', 'spelling'), null);
+  assert.deepEqual(repositories.gameState.read('learner-a', 'monster-codex'), {});
+  assert.equal(server.requests.some(({ path }) => ['/api/child-subject-state', '/api/practice-sessions', '/api/child-game-state'].includes(path)), false);
+
+  const harness = createAppHarness({ repositories });
+  const html = harness.render();
+  assert.doesNotMatch(html, /Sync degraded/);
+  assert.doesNotMatch(html, /Retry sync/);
+  assert.doesNotMatch(html, /cached changes still need remote sync/i);
+
+  const persisted = JSON.parse(storage.getItem(DEFAULT_API_CACHE_STORAGE_KEY));
+  assert.deepEqual(persisted.pendingOperations, []);
+  assert.deepEqual(persisted.bundle.practiceSessions, []);
+});
 
 test('remote write failure is surfaced as degraded persistence instead of pretending the write succeeded', async () => {
   const storage = installMemoryStorage();


### PR DESCRIPTION
## Summary
- Drop retired broad runtime write operations from cached pending queues when legacy sync is disabled.
- Keep production sessions trusted to the latest remote bootstrap instead of showing Retry sync for unsynchronisable pre-PR49 cache entries.
- Add a persistence regression test for old local pending writes being discarded after remote bootstrap.

## Verification
- `npm test -- tests/persistence.test.js`
- `npm test`
- `npm run check`