### PR TITLE
fix(spelling): apply setup prefs optimistically

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1883,7 +1883,15 @@ function runtimeIsReadOnly() {
 }
 
 function setSpellingRuntimeError(message) {
-  store.updateSubjectUi('spelling', { error: message || 'Practice is temporarily unavailable.' });
+  store.patch((current) => ({
+    subjectUi: {
+      ...current.subjectUi,
+      spelling: {
+        ...(current.subjectUi?.spelling || {}),
+        error: message || 'Practice is temporarily unavailable.',
+      },
+    },
+  }));
 }
 
 function setPunctuationRuntimeError(message) {

--- a/src/main.js
+++ b/src/main.js
@@ -1619,6 +1619,7 @@ function handleGlobalAction(action, data) {
       tts.stop();
       runtimeBoundary.clearAll();
       store.selectLearner(nextLearnerId);
+      remoteSpellingActions?.reapplyPendingOptimisticPrefs?.();
     }
     if (appState.route.screen === 'admin-hub') loadAdminHub({ learnerId: nextLearnerId, force: true });
     else loadParentHub({ learnerId: nextLearnerId, force: true });
@@ -1636,6 +1637,7 @@ function handleGlobalAction(action, data) {
     tts.stop();
     runtimeBoundary.clearAll();
     store.selectLearner(nextLearnerId);
+    remoteSpellingActions?.reapplyPendingOptimisticPrefs?.();
     if (boot.session.signedIn) {
       if (appState.route.screen === 'parent-hub') loadParentHub({ learnerId: nextLearnerId, force: true });
       if (appState.route.screen === 'admin-hub') loadAdminHub({ learnerId: nextLearnerId, force: true });

--- a/src/subjects/spelling/optimistic-prefs.js
+++ b/src/subjects/spelling/optimistic-prefs.js
@@ -1,0 +1,125 @@
+import {
+  createInitialSpellingState,
+  normaliseBoolean,
+  normaliseMode,
+  normaliseRoundLength,
+  normaliseYearFilter,
+} from './service-contract.js';
+
+const BOOLEAN_PREF_DEFAULTS = Object.freeze({
+  showCloze: true,
+  autoSpeak: true,
+  extraWordFamilies: false,
+});
+
+const DIRECT_PREF_KEYS = new Set([
+  'mode',
+  'yearFilter',
+  'roundLength',
+  'showCloze',
+  'autoSpeak',
+  'extraWordFamilies',
+]);
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function cleanPatchEntry(key, value, currentPrefs, nextPrefs) {
+  if (key === 'mode') return normaliseMode(value, currentPrefs.mode || 'smart');
+  if (key === 'yearFilter') return normaliseYearFilter(value, currentPrefs.yearFilter || 'core');
+  if (key === 'roundLength') return normaliseRoundLength(value, nextPrefs.mode || currentPrefs.mode || 'smart');
+  if (key in BOOLEAN_PREF_DEFAULTS) {
+    return normaliseBoolean(value, BOOLEAN_PREF_DEFAULTS[key]);
+  }
+  return undefined;
+}
+
+export function normaliseOptimisticSpellingPrefsPatch(rawPatch = {}, currentPrefs = {}) {
+  if (!isPlainObject(rawPatch)) return {};
+  const safeCurrent = isPlainObject(currentPrefs) ? currentPrefs : {};
+  const output = {};
+  const nextPrefs = { ...safeCurrent };
+
+  for (const [key, value] of Object.entries(rawPatch)) {
+    if (!DIRECT_PREF_KEYS.has(key)) continue;
+    const cleaned = cleanPatchEntry(key, value, safeCurrent, nextPrefs);
+    if (cleaned === undefined) continue;
+    output[key] = cleaned;
+    nextPrefs[key] = cleaned;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(output, 'mode')) {
+    const nextRoundLength = normaliseRoundLength(nextPrefs.roundLength, nextPrefs.mode);
+    if (nextRoundLength !== nextPrefs.roundLength) {
+      output.roundLength = nextRoundLength;
+      nextPrefs.roundLength = nextRoundLength;
+    }
+  }
+
+  return output;
+}
+
+export function optimisticSpellingPrefsPatchForAction(action, data = {}, currentPrefs = {}) {
+  if (action === 'spelling-set-mode') {
+    return normaliseOptimisticSpellingPrefsPatch({ mode: data.value }, currentPrefs);
+  }
+
+  if (action === 'spelling-set-pref') {
+    const pref = String(data.pref || '');
+    if (!DIRECT_PREF_KEYS.has(pref)) return {};
+    return normaliseOptimisticSpellingPrefsPatch({ [pref]: data.value }, currentPrefs);
+  }
+
+  if (action === 'spelling-toggle-pref') {
+    const pref = String(data.pref || '');
+    if (!(pref in BOOLEAN_PREF_DEFAULTS)) return {};
+    const currentValue = normaliseBoolean(currentPrefs[pref], BOOLEAN_PREF_DEFAULTS[pref]);
+    return normaliseOptimisticSpellingPrefsPatch({ [pref]: !currentValue }, currentPrefs);
+  }
+
+  return {};
+}
+
+export function mergePendingOptimisticSpellingPrefsForLearner(entries = [], learnerId = '') {
+  const targetLearnerId = String(learnerId || '');
+  return (Array.isArray(entries) ? entries : []).reduce((patch, entry) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return patch;
+    if (String(entry.learnerId || '') !== targetLearnerId) return patch;
+    if (!isPlainObject(entry.patch)) return patch;
+    return {
+      ...patch,
+      ...entry.patch,
+    };
+  }, {});
+}
+
+export function applyOptimisticSpellingPrefs(ui = {}, rawPatch = {}) {
+  const initial = createInitialSpellingState();
+  const safeUi = isPlainObject(ui) ? ui : {};
+  const currentPrefs = isPlainObject(safeUi.prefs) ? safeUi.prefs : {};
+  const patch = normaliseOptimisticSpellingPrefsPatch(rawPatch, currentPrefs);
+  if (!Object.keys(patch).length) return safeUi;
+
+  const nextPrefs = { ...currentPrefs, ...patch };
+  if (safeUi.phase === 'session' && safeUi.session) {
+    return {
+      ...safeUi,
+      prefs: nextPrefs,
+      error: '',
+    };
+  }
+
+  return {
+    ...safeUi,
+    version: safeUi.version || initial.version,
+    phase: 'dashboard',
+    session: null,
+    feedback: null,
+    summary: null,
+    error: '',
+    awaitingAdvance: false,
+    audio: null,
+    prefs: nextPrefs,
+  };
+}

--- a/src/subjects/spelling/remote-actions.js
+++ b/src/subjects/spelling/remote-actions.js
@@ -3,6 +3,10 @@ import {
   WORD_BANK_YEAR_FILTER_IDS,
 } from './components/spelling-view-model.js';
 import {
+  applyOptimisticSpellingPrefs,
+  optimisticSpellingPrefsPatchForAction,
+} from './optimistic-prefs.js';
+import {
   normaliseMonsterCelebrationEvents,
   shouldDelayMonsterCelebrations,
   spellingSessionEnded,
@@ -182,6 +186,7 @@ export function createRemoteSpellingActionHandler({
   const preferenceSaveChains = new Map();
   const preferenceIntentCounters = new Map();
   const latestPreferenceIntents = new Map();
+  const scopedRuntimeErrors = new Map();
 
   function appState() {
     return store?.getState?.() || {};
@@ -199,6 +204,80 @@ export function createRemoteSpellingActionHandler({
     } catch {
       return null;
     }
+  }
+
+  function selectedLearnerId() {
+    return appState().learners?.selectedId || '';
+  }
+
+  function safePrefsPatch(prefsPatch = {}) {
+    return prefsPatch && typeof prefsPatch === 'object' && !Array.isArray(prefsPatch) ? prefsPatch : {};
+  }
+
+  function patchSpellingSubjectUiLocally(updater) {
+    store.patch((current) => {
+      const previous = current.subjectUi?.spelling || {};
+      const next = typeof updater === 'function' ? updater(previous) : { ...previous, ...updater };
+      return {
+        subjectUi: {
+          ...current.subjectUi,
+          spelling: next,
+        },
+      };
+    });
+  }
+
+  function applyOptimisticPrefsPatch(patch) {
+    if (!patch || !Object.keys(patch).length) return false;
+    patchSpellingSubjectUiLocally((current) => applyOptimisticSpellingPrefs(current, patch));
+    return true;
+  }
+
+  function pendingOptimisticPrefsForLearner(learnerId) {
+    return latestPreferenceIntents.get(String(learnerId || ''))?.prefs || {};
+  }
+
+  function visiblePrefsForLearner(learnerId, state = appState()) {
+    const persistedPrefs = services?.spelling?.getPrefs?.(learnerId) || {};
+    const visiblePrefs = state.learners?.selectedId === learnerId
+      && state.subjectUi?.spelling?.prefs
+      && typeof state.subjectUi.spelling.prefs === 'object'
+      && !Array.isArray(state.subjectUi.spelling.prefs)
+      ? state.subjectUi.spelling.prefs
+      : {};
+    return {
+      ...persistedPrefs,
+      ...visiblePrefs,
+      ...pendingOptimisticPrefsForLearner(learnerId),
+    };
+  }
+
+  function reapplyPendingOptimisticPrefs() {
+    const learnerId = selectedLearnerId();
+    const appliedPrefs = applyOptimisticPrefsPatch(pendingOptimisticPrefsForLearner(learnerId));
+    const scopedError = scopedRuntimeErrors.get(learnerId);
+    if (scopedError) {
+      patchSpellingSubjectUiLocally({ error: scopedError });
+    }
+    return appliedPrefs || Boolean(scopedError);
+  }
+
+  function setRuntimeErrorForLearner(learnerId, message) {
+    const targetLearnerId = String(learnerId || '');
+    const safeMessage = message || 'Practice is temporarily unavailable.';
+    if (!targetLearnerId) {
+      setRuntimeError(safeMessage);
+      return;
+    }
+    scopedRuntimeErrors.set(targetLearnerId, safeMessage);
+    if (selectedLearnerId() === targetLearnerId) {
+      setRuntimeError(safeMessage);
+    }
+  }
+
+  function clearRuntimeErrorForLearner(learnerId) {
+    const targetLearnerId = String(learnerId || '');
+    if (targetLearnerId) scopedRuntimeErrors.delete(targetLearnerId);
   }
 
   function applyCommandResponse(response, {
@@ -219,7 +298,9 @@ export function createRemoteSpellingActionHandler({
       tts.stop();
     }
     store.reloadFromRepositories({ preserveRoute: true, preserveMonsterCelebrations: true });
+    clearRuntimeErrorForLearner(learnerId);
     reconcilePreferenceSaveResponse({ command, learnerId, preferenceVersion });
+    reapplyPendingOptimisticPrefs();
     const nextState = appState();
     const nextSubjectUi = response?.subjectReadModel || response?.state || nextState.subjectUi?.spelling || null;
     const isSelectedLearner = !learnerId || nextState.learners?.selectedId === learnerId;
@@ -378,21 +459,13 @@ export function createRemoteSpellingActionHandler({
   }
 
   function updateOptimisticPrefs(prefsPatch = {}) {
-    const patch = prefsPatch && typeof prefsPatch === 'object' && !Array.isArray(prefsPatch) ? prefsPatch : {};
-    if (!Object.keys(patch).length) return;
-    store.updateSubjectUi('spelling', (current = {}) => ({
-      ...current,
-      prefs: {
-        ...(current.prefs || {}),
-        ...patch,
-      },
-      error: '',
-    }));
+    return applyOptimisticPrefsPatch(safePrefsPatch(prefsPatch));
   }
 
   function recordPreferenceIntent(learnerId, prefsPatch = {}) {
-    const patch = prefsPatch && typeof prefsPatch === 'object' && !Array.isArray(prefsPatch) ? prefsPatch : {};
+    const patch = safePrefsPatch(prefsPatch);
     if (!learnerId || !Object.keys(patch).length) return null;
+    clearRuntimeErrorForLearner(learnerId);
     const version = (preferenceIntentCounters.get(learnerId) || 0) + 1;
     const previous = latestPreferenceIntents.get(learnerId);
     const intent = {
@@ -413,10 +486,6 @@ export function createRemoteSpellingActionHandler({
     if (!latest) return;
     if (Number(latest.version) <= Number(preferenceVersion)) {
       latestPreferenceIntents.delete(learnerId);
-      return;
-    }
-    if (appState().learners?.selectedId === learnerId) {
-      updateOptimisticPrefs(latest.prefs);
     }
   }
 
@@ -436,6 +505,10 @@ export function createRemoteSpellingActionHandler({
       .then(() => {
         setPendingCommand('save-prefs', { preserveExisting: true });
         return sendCommand('save-prefs', { prefs }, { learnerId, preferenceVersion });
+      })
+      .catch((error) => {
+        handlePreferenceSaveError(error, { learnerId, preferenceVersion });
+        throw error;
       });
     tracked = next.finally(() => {
       if (preferenceSaveChains.get(learnerId) === tracked) {
@@ -458,38 +531,60 @@ export function createRemoteSpellingActionHandler({
     return preferenceSaveChains.get(learnerId) || Promise.resolve(null);
   }
 
-  function handlePreferenceSaveError(error) {
+  function handlePreferenceSaveError(error, { learnerId = '', preferenceVersion = 0 } = {}) {
     globalThis.console?.warn?.('Spelling preference save failed.', error);
-    setRuntimeError(commandErrorMessage(error, 'The spelling options could not be saved.'));
+    const latest = latestPreferenceIntents.get(learnerId);
+    if (latest && Number(latest.version) <= Number(preferenceVersion)) {
+      latestPreferenceIntents.delete(learnerId);
+    }
+    store.reloadFromRepositories({ preserveRoute: true });
+    reapplyPendingOptimisticPrefs();
+    setRuntimeErrorForLearner(learnerId, commandErrorMessage(error, 'The spelling options could not be saved.'));
   }
 
   function schedulePreferenceSave(learnerId, prefsPatch = {}) {
     if (!learnerId) return false;
-    const patch = prefsPatch && typeof prefsPatch === 'object' && !Array.isArray(prefsPatch) ? prefsPatch : {};
+    const patch = safePrefsPatch(prefsPatch);
     if (!Object.keys(patch).length) return true;
     const intent = recordPreferenceIntent(learnerId, patch);
     const current = pendingPreferenceSaves.get(learnerId);
     if (current?.timer) clearTimeout(current.timer);
     const timer = setTimeout(() => {
-      flushPendingPreferenceSave(learnerId).catch(handlePreferenceSaveError);
+      flushPendingPreferenceSave(learnerId).catch(() => {});
     }, preferenceSaveDelayMs());
     pendingPreferenceSaves.set(learnerId, { prefs: intent.prefs, version: intent.version, timer });
     return true;
   }
 
-  function runCommand(command, payload = {}, { learnerId: requestedLearnerId = '', beforeSend = null } = {}) {
+  function runCommand(command, payload = {}, options = {}) {
+    const {
+      learnerId: requestedLearnerId = '',
+      errorLearnerId = '',
+      beforeSend = null,
+      onSuccess = null,
+      onError = null,
+      onSettled = null,
+    } = options;
+    const commandLearnerId = requestedLearnerId || appState().learners?.selectedId || '';
     const pending = beginPendingCommand(command);
     if (!pending.ok) return false;
     const commandPromise = typeof beforeSend === 'function'
       ? Promise.resolve()
         .then(beforeSend)
-        .then((nextPayload) => sendCommand(command, nextPayload || payload, { learnerId: requestedLearnerId }))
-      : sendCommand(command, payload, { learnerId: requestedLearnerId });
-    commandPromise.catch((error) => {
+        .then((nextPayload) => sendCommand(command, nextPayload || payload, { learnerId: commandLearnerId }))
+      : sendCommand(command, payload, { learnerId: commandLearnerId });
+    commandPromise.then((response) => {
+      onSuccess?.(response);
+    }).catch((error) => {
+      onError?.(error);
       globalThis.console?.warn?.('Spelling command failed.', error);
-      setRuntimeError(commandErrorMessage(error, 'The spelling command could not be completed.'));
+      setRuntimeErrorForLearner(
+        errorLearnerId || commandLearnerId,
+        commandErrorMessage(error, 'The spelling command could not be completed.'),
+      );
     }).finally(() => {
       releasePendingCommand(command, pending.dedupeKey);
+      onSettled?.();
     });
     return true;
   }
@@ -744,23 +839,10 @@ export function createRemoteSpellingActionHandler({
       return true;
     }
 
-    if (action === 'spelling-set-pref') {
-      const patch = { [data.pref]: data.value };
-      updateOptimisticPrefs(patch);
-      schedulePreferenceSave(learnerId, patch);
-      return true;
-    }
-
-    if (action === 'spelling-set-mode') {
-      const patch = { mode: data.value };
-      updateOptimisticPrefs(patch);
-      schedulePreferenceSave(learnerId, patch);
-      return true;
-    }
-
-    if (action === 'spelling-toggle-pref') {
-      const current = spelling?.getPrefs?.(learnerId) || {};
-      const patch = { [data.pref]: !current[data.pref] };
+    if (action === 'spelling-set-pref' || action === 'spelling-set-mode' || action === 'spelling-toggle-pref') {
+      const current = visiblePrefsForLearner(learnerId, state);
+      const patch = optimisticSpellingPrefsPatchForAction(action, data, current);
+      if (!Object.keys(patch).length) return true;
       updateOptimisticPrefs(patch);
       schedulePreferenceSave(learnerId, patch);
       return true;
@@ -772,7 +854,7 @@ export function createRemoteSpellingActionHandler({
         learnerId,
         beforeSend: async () => {
           await flushPendingPreferenceSave(learnerId);
-          const prefs = spelling?.getPrefs?.(learnerId) || {};
+          const prefs = visiblePrefsForLearner(learnerId, appState());
           return {
             mode: prefs.mode,
             yearFilter: prefs.yearFilter,
@@ -796,10 +878,17 @@ export function createRemoteSpellingActionHandler({
       tts.stop();
       (async () => {
         await flushPendingPreferenceSave(learnerId);
-        const intent = recordPreferenceIntent(learnerId, { mode });
-        updateOptimisticPrefs({ mode });
-        await sendCommand('save-prefs', { prefs: { mode } }, { learnerId, preferenceVersion: intent?.version || 0 });
-        const prefs = spelling?.getPrefs?.(learnerId) || { mode };
+        const current = visiblePrefsForLearner(learnerId, appState());
+        const patch = optimisticSpellingPrefsPatchForAction('spelling-set-mode', { value: mode }, current);
+        const intent = recordPreferenceIntent(learnerId, patch);
+        updateOptimisticPrefs(patch);
+        try {
+          await sendCommand('save-prefs', { prefs: patch }, { learnerId, preferenceVersion: intent?.version || 0 });
+        } catch (error) {
+          handlePreferenceSaveError(error, { learnerId, preferenceVersion: intent?.version || 0 });
+          throw error;
+        }
+        const prefs = visiblePrefsForLearner(learnerId, appState());
         await sendCommand('start-session', {
           mode: prefs.mode || mode,
           yearFilter: prefs.yearFilter,
@@ -808,7 +897,7 @@ export function createRemoteSpellingActionHandler({
         }, { learnerId });
       })().catch((error) => {
         globalThis.console?.warn?.('Spelling shortcut command failed.', error);
-        setRuntimeError(commandErrorMessage(error, 'The spelling shortcut could not be completed.'));
+        setRuntimeErrorForLearner(learnerId, commandErrorMessage(error, 'The spelling shortcut could not be completed.'));
       }).finally(() => {
         releasePendingCommand('start-session', pending.dedupeKey);
       });
@@ -871,6 +960,7 @@ export function createRemoteSpellingActionHandler({
     applyCommandResponse,
     handle,
     loadWordBank,
+    reapplyPendingOptimisticPrefs,
     runCommand,
     sendCommand,
   };

--- a/tests/spelling-optimistic-prefs.test.js
+++ b/tests/spelling-optimistic-prefs.test.js
@@ -1,0 +1,158 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { installMemoryStorage } from './helpers/memory-storage.js';
+import { SUBJECTS } from '../src/platform/core/subject-registry.js';
+import { createStore } from '../src/platform/core/store.js';
+import { createLocalPlatformRepositories } from '../src/platform/core/repositories/index.js';
+import {
+  applyOptimisticSpellingPrefs,
+  mergePendingOptimisticSpellingPrefsForLearner,
+  optimisticSpellingPrefsPatchForAction,
+} from '../src/subjects/spelling/optimistic-prefs.js';
+
+test('spelling preference actions resolve the optimistic patch immediately', () => {
+  const prefs = {
+    mode: 'smart',
+    yearFilter: 'core',
+    roundLength: '10',
+    showCloze: true,
+    autoSpeak: true,
+    extraWordFamilies: false,
+  };
+
+  assert.deepEqual(
+    optimisticSpellingPrefsPatchForAction('spelling-set-pref', { pref: 'yearFilter', value: 'extra' }, prefs),
+    { yearFilter: 'extra' },
+  );
+  assert.deepEqual(
+    optimisticSpellingPrefsPatchForAction('spelling-toggle-pref', { pref: 'autoSpeak' }, prefs),
+    { autoSpeak: false },
+  );
+  assert.deepEqual(
+    optimisticSpellingPrefsPatchForAction('spelling-set-mode', { value: 'test' }, prefs),
+    { mode: 'test', roundLength: 20 },
+  );
+});
+
+test('optimistic spelling prefs leave completed flows on setup without waiting for the Worker', () => {
+  const next = applyOptimisticSpellingPrefs({
+    subjectId: 'spelling',
+    learnerId: 'learner-a',
+    version: 1,
+    phase: 'summary',
+    session: null,
+    feedback: { kind: 'success', headline: 'Done' },
+    summary: { mode: 'smart', totalWords: 10 },
+    awaitingAdvance: true,
+    audio: { promptToken: 'old-cue' },
+    prefs: {
+      mode: 'smart',
+      yearFilter: 'core',
+      roundLength: '10',
+      autoSpeak: true,
+    },
+    stats: { core: { total: 10 } },
+  }, { yearFilter: 'extra' });
+
+  assert.equal(next.phase, 'dashboard');
+  assert.equal(next.feedback, null);
+  assert.equal(next.summary, null);
+  assert.equal(next.awaitingAdvance, false);
+  assert.equal(next.audio, null);
+  assert.equal(next.prefs.yearFilter, 'extra');
+  assert.deepEqual(next.stats, { core: { total: 10 } });
+});
+
+test('optimistic spelling prefs do not tear down an active session', () => {
+  const next = applyOptimisticSpellingPrefs({
+    phase: 'session',
+    session: { id: 'session-a' },
+    feedback: null,
+    prefs: {
+      mode: 'smart',
+      yearFilter: 'core',
+      roundLength: '10',
+      showCloze: true,
+    },
+  }, { showCloze: false });
+
+  assert.equal(next.phase, 'session');
+  assert.deepEqual(next.session, { id: 'session-a' });
+  assert.equal(next.prefs.showCloze, false);
+});
+
+test('pending optimistic spelling prefs are scoped to the selected learner', () => {
+  const pending = [
+    { id: 1, learnerId: 'learner-a', patch: { autoSpeak: false } },
+    { id: 2, learnerId: 'learner-b', patch: { showCloze: false, yearFilter: 'extra' } },
+    { id: 3, learnerId: 'learner-a', patch: { roundLength: '40' } },
+  ];
+
+  assert.deepEqual(
+    mergePendingOptimisticSpellingPrefsForLearner(pending, 'learner-a'),
+    { autoSpeak: false, roundLength: '40' },
+  );
+  assert.deepEqual(
+    mergePendingOptimisticSpellingPrefsForLearner(pending, 'learner-b'),
+    { showCloze: false, yearFilter: 'extra' },
+  );
+});
+
+test('spelling toggles can be reversed before the first save resolves', () => {
+  const prefs = {
+    mode: 'smart',
+    yearFilter: 'core',
+    roundLength: '10',
+    autoSpeak: true,
+  };
+
+  const firstPatch = optimisticSpellingPrefsPatchForAction('spelling-toggle-pref', { pref: 'autoSpeak' }, prefs);
+  const visible = applyOptimisticSpellingPrefs({ phase: 'dashboard', prefs }, firstPatch).prefs;
+  const secondPatch = optimisticSpellingPrefsPatchForAction('spelling-toggle-pref', { pref: 'autoSpeak' }, visible);
+
+  assert.deepEqual(firstPatch, { autoSpeak: false });
+  assert.deepEqual(secondPatch, { autoSpeak: true });
+});
+
+test('local spelling errors do not cache pending optimistic prefs', () => {
+  const storage = installMemoryStorage();
+  const repositories = createLocalPlatformRepositories({ storage });
+  const store = createStore(SUBJECTS, { repositories, cacheSubjectUiWrites: true });
+  const learnerId = store.getState().learners.selectedId;
+
+  store.updateSubjectUi('spelling', {
+    phase: 'dashboard',
+    error: '',
+    prefs: {
+      mode: 'smart',
+      yearFilter: 'core',
+      roundLength: '10',
+      autoSpeak: true,
+    },
+  });
+
+  store.patch((current) => ({
+    subjectUi: {
+      ...current.subjectUi,
+      spelling: applyOptimisticSpellingPrefs(current.subjectUi.spelling, { autoSpeak: false }),
+    },
+  }));
+  store.patch((current) => ({
+    subjectUi: {
+      ...current.subjectUi,
+      spelling: {
+        ...current.subjectUi.spelling,
+        error: 'Save failed',
+      },
+    },
+  }));
+
+  const visible = store.getState().subjectUi.spelling;
+  const cached = repositories.subjectStates.read(learnerId, 'spelling').ui;
+
+  assert.equal(visible.prefs.autoSpeak, false);
+  assert.equal(visible.error, 'Save failed');
+  assert.equal(cached.prefs.autoSpeak, true);
+  assert.equal(cached.error, '');
+});

--- a/tests/spelling-remote-actions.test.js
+++ b/tests/spelling-remote-actions.test.js
@@ -1083,7 +1083,7 @@ test('remote spelling word-bank drill submit is blocked while read-only', () => 
   assert.match(errors[0], /read-only/i);
 });
 
-test('remote spelling optimistic prefs reapply after learner switches', () => {
+test('remote spelling optimistic prefs reapply after learner switches', async () => {
   const prefsByLearner = {
     'learner-a': { mode: 'smart', yearFilter: 'core', roundLength: '10', extraWordFamilies: false },
     'learner-b': { mode: 'smart', yearFilter: 'core', roundLength: '20', extraWordFamilies: false },
@@ -1098,7 +1098,6 @@ test('remote spelling optimistic prefs reapply after learner switches', () => {
       },
     },
   });
-  const pending = deferred();
   const sent = [];
   const handler = createRemoteSpellingActionHandler({
     store,
@@ -1114,9 +1113,10 @@ test('remote spelling optimistic prefs reapply after learner switches', () => {
     subjectCommands: {
       send(request) {
         sent.push(request);
-        return pending.promise;
+        return Promise.resolve({ subjectReadModel: { phase: request.command === 'start-session' ? 'session' : 'dashboard' } });
       },
     },
+    preferenceSaveDebounceMs: 10_000,
   });
 
   assert.equal(handler.handle('spelling-set-pref', { pref: 'yearFilter', value: 'extra' }), true);
@@ -1153,6 +1153,10 @@ test('remote spelling optimistic prefs reapply after learner switches', () => {
   assert.equal(getState().subjectUi.spelling.prefs.yearFilter, 'extra');
 
   assert.equal(handler.handle('spelling-start'), true);
+  await flushPromises();
+  await flushPromises();
+  await flushPromises();
+  await flushPromises();
   assert.equal(sent[0].command, 'save-prefs');
   assert.deepEqual(sent[0].payload, { prefs: { yearFilter: 'extra' } });
   assert.equal(sent[1].command, 'start-session');
@@ -1205,6 +1209,7 @@ test('remote spelling save failures stay scoped to the original learner', async 
         return pending.promise;
       },
     },
+    preferenceSaveDebounceMs: 0,
   });
 
   assert.equal(handler.handle('spelling-set-pref', { pref: 'yearFilter', value: 'extra' }), true);
@@ -1225,7 +1230,9 @@ test('remote spelling save failures stay scoped to the original learner', async 
 
   try {
     if (globalThis.console) globalThis.console.warn = () => {};
+    await flushTimers();
     pending.reject(new Error('Save failed'));
+    await flushPromises();
     await flushPromises();
   } finally {
     if (globalThis.console) globalThis.console.warn = originalWarn;
@@ -1251,4 +1258,83 @@ test('remote spelling save failures stay scoped to the original learner', async 
 
   assert.equal(getState().subjectUi.spelling.prefs.yearFilter, 'core');
   assert.equal(getState().subjectUi.spelling.error, 'Save failed');
+});
+
+test('remote spelling successful commands clear scoped save errors', async () => {
+  const persistedPrefs = { mode: 'smart', yearFilter: 'core', roundLength: '10', extraWordFamilies: false };
+  const { getState, store } = createStoreHarness({
+    learners: { selectedId: 'learner-a' },
+    subjectUi: {
+      spelling: {
+        phase: 'dashboard',
+        prefs: { ...persistedPrefs },
+        error: '',
+      },
+    },
+  });
+  const pendingSave = deferred();
+  const sent = [];
+  const originalWarn = globalThis.console?.warn;
+  const originalReload = store.reloadFromRepositories;
+  store.reloadFromRepositories = (options) => {
+    originalReload(options);
+    store.patch((current) => ({
+      subjectUi: {
+        ...current.subjectUi,
+        spelling: {
+          ...current.subjectUi.spelling,
+          phase: 'session',
+          prefs: { ...persistedPrefs },
+          error: '',
+        },
+      },
+    }));
+  };
+  const handler = createRemoteSpellingActionHandler({
+    store,
+    services: {
+      spelling: {
+        getPrefs() {
+          return persistedPrefs;
+        },
+      },
+    },
+    tts: createTtsHarness(),
+    readModels: { readJson: async () => ({}) },
+    subjectCommands: {
+      send(request) {
+        sent.push(request);
+        if (request.command === 'save-prefs') return pendingSave.promise;
+        return Promise.resolve({ subjectReadModel: { phase: 'session' } });
+      },
+    },
+    preferenceSaveDebounceMs: 0,
+  });
+
+  assert.equal(handler.handle('spelling-set-pref', { pref: 'yearFilter', value: 'extra' }), true);
+
+  try {
+    if (globalThis.console) globalThis.console.warn = () => {};
+    await flushTimers();
+    pendingSave.reject(new Error('Save failed'));
+    await flushPromises();
+    await flushPromises();
+  } finally {
+    if (globalThis.console) globalThis.console.warn = originalWarn;
+  }
+
+  assert.equal(getState().subjectUi.spelling.error, 'Save failed');
+
+  assert.equal(handler.handle('spelling-start'), true);
+  await flushPromises();
+  await flushPromises();
+  await flushPromises();
+  await flushPromises();
+
+  assert.deepEqual(sent.map((request) => request.command), ['save-prefs', 'start-session']);
+  assert.equal(getState().subjectUi.spelling.phase, 'session');
+  assert.equal(getState().subjectUi.spelling.error, '');
+
+  handler.reapplyPendingOptimisticPrefs();
+  assert.equal(getState().subjectUi.spelling.error, '');
 });

--- a/tests/spelling-remote-actions.test.js
+++ b/tests/spelling-remote-actions.test.js
@@ -1082,3 +1082,173 @@ test('remote spelling word-bank drill submit is blocked while read-only', () => 
   assert.equal(sent.length, 0);
   assert.match(errors[0], /read-only/i);
 });
+
+test('remote spelling optimistic prefs reapply after learner switches', () => {
+  const prefsByLearner = {
+    'learner-a': { mode: 'smart', yearFilter: 'core', roundLength: '10', extraWordFamilies: false },
+    'learner-b': { mode: 'smart', yearFilter: 'core', roundLength: '20', extraWordFamilies: false },
+  };
+  const { getState, store } = createStoreHarness({
+    learners: { selectedId: 'learner-a' },
+    subjectUi: {
+      spelling: {
+        phase: 'dashboard',
+        prefs: { ...prefsByLearner['learner-a'] },
+        error: '',
+      },
+    },
+  });
+  const pending = deferred();
+  const sent = [];
+  const handler = createRemoteSpellingActionHandler({
+    store,
+    services: {
+      spelling: {
+        getPrefs(learnerId) {
+          return prefsByLearner[learnerId] || {};
+        },
+      },
+    },
+    tts: createTtsHarness(),
+    readModels: { readJson: async () => ({}) },
+    subjectCommands: {
+      send(request) {
+        sent.push(request);
+        return pending.promise;
+      },
+    },
+  });
+
+  assert.equal(handler.handle('spelling-set-pref', { pref: 'yearFilter', value: 'extra' }), true);
+  assert.equal(getState().subjectUi.spelling.prefs.yearFilter, 'extra');
+
+  store.patch((current) => ({
+    ...current,
+    learners: { selectedId: 'learner-b' },
+    subjectUi: {
+      ...current.subjectUi,
+      spelling: {
+        phase: 'dashboard',
+        prefs: { ...prefsByLearner['learner-b'] },
+        error: '',
+      },
+    },
+  }));
+  handler.reapplyPendingOptimisticPrefs();
+  assert.equal(getState().subjectUi.spelling.prefs.yearFilter, 'core');
+
+  store.patch((current) => ({
+    ...current,
+    learners: { selectedId: 'learner-a' },
+    subjectUi: {
+      ...current.subjectUi,
+      spelling: {
+        phase: 'dashboard',
+        prefs: { ...prefsByLearner['learner-a'] },
+        error: '',
+      },
+    },
+  }));
+  handler.reapplyPendingOptimisticPrefs();
+  assert.equal(getState().subjectUi.spelling.prefs.yearFilter, 'extra');
+
+  assert.equal(handler.handle('spelling-start'), true);
+  assert.equal(sent[0].command, 'save-prefs');
+  assert.deepEqual(sent[0].payload, { prefs: { yearFilter: 'extra' } });
+  assert.equal(sent[1].command, 'start-session');
+  assert.equal(sent[1].payload.yearFilter, 'extra');
+});
+
+test('remote spelling save failures stay scoped to the original learner', async () => {
+  const prefsByLearner = {
+    'learner-a': { mode: 'smart', yearFilter: 'core', roundLength: '10', extraWordFamilies: false },
+    'learner-b': { mode: 'smart', yearFilter: 'core', roundLength: '20', extraWordFamilies: false },
+  };
+  const { getState, store } = createStoreHarness({
+    learners: { selectedId: 'learner-a' },
+    subjectUi: {
+      spelling: {
+        phase: 'dashboard',
+        prefs: { ...prefsByLearner['learner-a'] },
+        error: '',
+      },
+    },
+  });
+  const pending = deferred();
+  const errors = [];
+  const originalWarn = globalThis.console?.warn;
+  const handler = createRemoteSpellingActionHandler({
+    store,
+    services: {
+      spelling: {
+        getPrefs(learnerId) {
+          return prefsByLearner[learnerId] || {};
+        },
+      },
+    },
+    tts: createTtsHarness(),
+    readModels: { readJson: async () => ({}) },
+    setRuntimeError(message) {
+      errors.push({ learnerId: getState().learners.selectedId, message });
+      store.patch((current) => ({
+        subjectUi: {
+          ...current.subjectUi,
+          spelling: {
+            ...current.subjectUi.spelling,
+            error: message,
+          },
+        },
+      }));
+    },
+    subjectCommands: {
+      send() {
+        return pending.promise;
+      },
+    },
+  });
+
+  assert.equal(handler.handle('spelling-set-pref', { pref: 'yearFilter', value: 'extra' }), true);
+  assert.equal(getState().subjectUi.spelling.prefs.yearFilter, 'extra');
+
+  store.patch((current) => ({
+    ...current,
+    learners: { selectedId: 'learner-b' },
+    subjectUi: {
+      ...current.subjectUi,
+      spelling: {
+        phase: 'dashboard',
+        prefs: { ...prefsByLearner['learner-b'] },
+        error: '',
+      },
+    },
+  }));
+
+  try {
+    if (globalThis.console) globalThis.console.warn = () => {};
+    pending.reject(new Error('Save failed'));
+    await flushPromises();
+  } finally {
+    if (globalThis.console) globalThis.console.warn = originalWarn;
+  }
+
+  assert.deepEqual(errors, []);
+  assert.equal(getState().learners.selectedId, 'learner-b');
+  assert.equal(getState().subjectUi.spelling.error, '');
+
+  store.patch((current) => ({
+    ...current,
+    learners: { selectedId: 'learner-a' },
+    subjectUi: {
+      ...current.subjectUi,
+      spelling: {
+        phase: 'dashboard',
+        prefs: { ...prefsByLearner['learner-a'] },
+        error: '',
+      },
+    },
+  }));
+  handler.reapplyPendingOptimisticPrefs();
+
+  assert.equal(getState().subjectUi.spelling.prefs.yearFilter, 'core');
+  assert.equal(getState().subjectUi.spelling.error, 'Save failed');
+});


### PR DESCRIPTION
## Summary

Spelling setup preferences now update immediately in the remote/full-lockdown runtime instead of waiting for the `save-prefs` round trip. The UI applies local optimistic patches for mode, pool, round length, and option toggles, while the current remote action queue coalesces rapid option saves before sending them to the Worker.

## Details

- Rebased onto current `origin/main` at `b9b1197` and integrated the optimistic spelling preference flow with PR #92's rapid option-save coalescing queue in `src/subjects/spelling/remote-actions.js`.
- Added a focused optimistic preference helper that shares spelling mode, year-filter, round-length, and boolean normalisation rules.
- Keep preference toggles and start payloads sourced from the currently visible prefs plus pending preference intents, so fast repeated toggles and immediate starts use the learner's latest UI intent.
- Reapply the selected learner's pending optimistic spelling prefs after learner-switch reloads, so setup rendering and `spelling-start` use the same visible state.
- Scope save-failure runtime errors to the learner that started the save, avoid caching rejected optimistic prefs, and clear learner-scoped save errors after later successful spelling command responses.
- Preserve PR #92's debounced/coalesced preference-save behaviour while ensuring save failures are handled by the preference chain without leaving unhandled rejections.
- Covered the summary-to-setup reset path, active-session preservation, learner-scoped pending patches, fast double-toggle reversal, pending-pref cache rollback, learner-switch reapply, scoped save-failure errors, stale-error recovery, and PR #92 coalescing/flush semantics with targeted tests.

## Verification

- `node --test tests/spelling-remote-actions.test.js tests/spelling-optimistic-prefs.test.js tests/subject-command-actions.test.js` (23 pass)
- `git merge-tree --write-tree HEAD origin/main` (no content conflicts)
- `git diff --check origin/main...HEAD`
- `npm test -- --test-concurrency=1` (499 pass / 1 skip)
- `npm run check`