### PR TITLE
fix(spelling): count up word bank stats

### DIFF
--- a/src/subjects/spelling/components/SpellingCommon.jsx
+++ b/src/subjects/spelling/components/SpellingCommon.jsx
@@ -7,6 +7,9 @@ import {
 
 const useMeasuredLayoutEffect = typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect;
 const CLOZE_BLANK_PATTERN = /_{5,}/;
+const COUNT_UP_MIN_MS = 360;
+const COUNT_UP_MAX_MS = 920;
+const COUNT_UP_MS_PER_STEP = 9;
 
 export const spellingAnswerInputProps = {
   autoComplete: 'off',
@@ -14,6 +17,98 @@ export const spellingAnswerInputProps = {
   autoCorrect: 'off',
   spellCheck: false,
 };
+
+function numericCountTarget(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) return Math.max(0, Math.round(value));
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) return null;
+  return Math.max(0, Number.parseInt(trimmed, 10));
+}
+
+function countDuration(from, to) {
+  const distance = Math.abs(to - from);
+  return Math.min(COUNT_UP_MAX_MS, Math.max(COUNT_UP_MIN_MS, distance * COUNT_UP_MS_PER_STEP));
+}
+
+function prefersReducedMotion() {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+export function CountUpValue({
+  as: Element = 'span',
+  value,
+  className = '',
+}) {
+  const target = numericCountTarget(value);
+  const initialValue = target == null ? value : target;
+  const [displayValue, setDisplayValue] = React.useState(initialValue);
+  const [isCounting, setIsCounting] = React.useState(false);
+  const displayRef = React.useRef(initialValue);
+
+  React.useEffect(() => {
+    if (target == null) {
+      displayRef.current = value;
+      setDisplayValue(value);
+      setIsCounting(false);
+      return undefined;
+    }
+
+    if (prefersReducedMotion() || typeof window === 'undefined' || typeof window.requestAnimationFrame !== 'function') {
+      displayRef.current = target;
+      setDisplayValue(target);
+      setIsCounting(false);
+      return undefined;
+    }
+
+    const startValue = Number(displayRef.current);
+    if (!Number.isFinite(startValue) || startValue === target) {
+      displayRef.current = target;
+      setDisplayValue(target);
+      setIsCounting(false);
+      return undefined;
+    }
+
+    let frameId = 0;
+    const startTime = window.performance?.now?.() ?? Date.now();
+    const duration = countDuration(startValue, target);
+    const distance = target - startValue;
+    setIsCounting(true);
+
+    const tick = (now) => {
+      const elapsed = Math.max(0, now - startTime);
+      const progress = Math.min(1, elapsed / duration);
+      const eased = 1 - ((1 - progress) ** 3);
+      const nextValue = Math.round(startValue + (distance * eased));
+      displayRef.current = nextValue;
+      setDisplayValue(nextValue);
+      if (progress < 1) {
+        frameId = window.requestAnimationFrame(tick);
+        return;
+      }
+      displayRef.current = target;
+      setDisplayValue(target);
+      setIsCounting(false);
+    };
+
+    frameId = window.requestAnimationFrame(tick);
+    return () => {
+      if (frameId) window.cancelAnimationFrame(frameId);
+      setIsCounting(false);
+    };
+  }, [target, value]);
+
+  const classes = [className, isCounting ? 'is-counting' : ''].filter(Boolean).join(' ');
+  const props = {
+    className: classes || undefined,
+  };
+  if (target != null) {
+    props['data-count-target'] = String(target);
+  }
+
+  return <Element {...props}>{target == null ? String(displayValue || '') : displayValue}</Element>;
+}
 
 function measurePromptCardHeight(cardNode, contentNode) {
   if (!cardNode || !contentNode || typeof window === 'undefined') return null;
@@ -183,9 +278,9 @@ export function SummaryCards({ cards = [] }) {
   return (
     <div className="stat-grid">
       {cards.map((card) => (
-        <div className="stat" key={`${card.label}-${card.value}`}>
+        <div className="stat" key={card.label}>
           <div className="stat-label">{card.label}</div>
-          <div className="stat-value">{card.value}</div>
+          <CountUpValue as="div" className="stat-value" value={card.value} />
           <div className="stat-sub">{card.sub || ''}</div>
         </div>
       ))}

--- a/src/subjects/spelling/components/SpellingWordBankScene.jsx
+++ b/src/subjects/spelling/components/SpellingWordBankScene.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { SearchIcon } from './spelling-icons.jsx';
-import { SummaryCards } from './SpellingCommon.jsx';
+import { CountUpValue, SummaryCards } from './SpellingCommon.jsx';
 import { SpellingHeroBackdrop } from './SpellingHeroBackdrop.jsx';
 import { SpellingWordDetailModal } from './SpellingWordDetailModal.jsx';
 import {
@@ -55,7 +55,7 @@ function FilterChips({ counts, activeFilter, actions }) {
           >
             <span className={`wb-status-swatch ${chip.swatch}`} aria-hidden="true" />
             <span className="wb-chip-label">{chip.label}</span>
-            <span className="wb-chip-count">{counts[chip.id] ?? 0}</span>
+            <CountUpValue className="wb-chip-count" value={counts[chip.id] ?? 0} />
           </button>
         );
       })}
@@ -85,7 +85,7 @@ function YearChips({ counts, activeYearFilter, actions }) {
             onClick={(event) => renderAction(actions, event, 'spelling-analytics-year-filter', { value: chip.id })}
           >
             <span className="wb-chip-label">{chip.label}</span>
-            <span className="wb-chip-count">{counts[chip.id] ?? 0}</span>
+            <CountUpValue className="wb-chip-count" value={counts[chip.id] ?? 0} />
           </button>
         );
       })}

--- a/styles/app.css
+++ b/styles/app.css
@@ -371,8 +371,22 @@ textarea:focus-visible {
   padding: 14px;
 }
 .stat-label { color: var(--muted); font-size: 0.85rem; margin-bottom: 6px; }
-.stat-value { font-size: 1.5rem; font-weight: 900; line-height: 1; }
+.stat-value {
+  font-size: 1.5rem;
+  font-weight: 900;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+.stat-value.is-counting {
+  color: var(--brand-ink);
+  animation: stat-count-settle 360ms var(--ease-out) both;
+}
 .stat-sub { color: var(--muted); font-size: 0.82rem; margin-top: 6px; }
+
+@keyframes stat-count-settle {
+  from { opacity: 0.74; transform: translateY(3px); }
+  to { opacity: 1; transform: translateY(0); }
+}
 
 .subject-card {
   padding: 0;
@@ -5392,6 +5406,10 @@ textarea:focus-visible {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .stat-value.is-counting,
+  .wb-chip-count.is-counting {
+    animation: none;
+  }
   .wb-search, .wb-word-pill { transition: none; }
   .wb-word-pill:hover,
   .wb-word-pill:active { transform: none; }
@@ -5450,7 +5468,11 @@ textarea:focus-visible {
   border-radius: 999px;
   font-size: 0.7rem;
   font-weight: 700;
+  font-variant-numeric: tabular-nums;
   color: var(--muted);
+}
+.wb-chip-count.is-counting {
+  animation: stat-count-settle 320ms var(--ease-out) both;
 }
 .wb-chip.on .wb-chip-count {
   background: color-mix(in oklab, var(--brand) 18%, var(--panel));


### PR DESCRIPTION
## Summary
First Word Bank visits now treat the empty stat frame as an intentional count-up rather than a server delay. Numeric stat cards and filter chips keep stable React keys, animate between loaded values, and respect reduced-motion preferences by jumping straight to the final counts.

## Testing
- npm test -- tests/react-spelling-surface.test.js tests/smoke.test.js
- npm test
- npm run check

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)