### PR TITLE
fix(spelling): show overall dashboard progress

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -37,6 +37,7 @@ import {
   normaliseTtsProvider,
 } from './subjects/spelling/tts-providers.js';
 import { createSpellingReadModelService } from './subjects/spelling/client-read-models.js';
+import { getOverallSpellingStats } from './subjects/spelling/module.js';
 import { resolveSpellingShortcut } from './subjects/spelling/shortcuts.js';
 import {
   monsterSummary,
@@ -1218,10 +1219,9 @@ function buildHomeMonsterSummary(learnerId, context) {
 
 function buildHomeDueTotal(learnerId, context) {
   const spelling = context.services?.spelling;
-  if (!learnerId || !spelling?.getStats || !spelling?.getPrefs) return 0;
+  if (!learnerId || !spelling?.getStats) return 0;
   try {
-    const prefs = spelling.getPrefs(learnerId);
-    const stats = spelling.getStats(learnerId, prefs?.yearFilter || 'all');
+    const stats = getOverallSpellingStats(spelling, learnerId);
     return Number(stats?.due) || 0;
   } catch {
     return 0;

--- a/src/subjects/spelling/module.js
+++ b/src/subjects/spelling/module.js
@@ -55,6 +55,39 @@ function wordBankEntryFor(service, learnerId, slug) {
   return findWordBankEntry(service.getAnalyticsSnapshot(learnerId), slug);
 }
 
+function combineStats(...entries) {
+  const totals = entries.reduce((next, raw) => {
+    const stats = raw && typeof raw === 'object' && !Array.isArray(raw) ? raw : {};
+    next.total += Number(stats.total) || 0;
+    next.secure += Number(stats.secure) || 0;
+    next.due += Number(stats.due) || 0;
+    next.fresh += Number(stats.fresh) || 0;
+    next.trouble += Number(stats.trouble) || 0;
+    next.attempts += Number(stats.attempts) || 0;
+    next.correct += Number(stats.correct) || 0;
+    return next;
+  }, {
+    total: 0,
+    secure: 0,
+    due: 0,
+    fresh: 0,
+    trouble: 0,
+    attempts: 0,
+    correct: 0,
+  });
+  return {
+    ...totals,
+    accuracy: totals.attempts ? Math.round((totals.correct / totals.attempts) * 100) : null,
+  };
+}
+
+export function getOverallSpellingStats(service, learnerId) {
+  return combineStats(
+    service?.getStats?.(learnerId, 'core'),
+    service?.getStats?.(learnerId, 'extra'),
+  );
+}
+
 export const spellingModule = {
   id: 'spelling',
   name: 'Spelling',
@@ -70,8 +103,7 @@ export const spellingModule = {
   },
   getDashboardStats(appState, { service }) {
     const learner = appState.learners.byId[appState.learners.selectedId];
-    const prefs = service.getPrefs(learner.id);
-    const stats = service.getStats(learner.id, prefs.yearFilter);
+    const stats = getOverallSpellingStats(service, learner.id);
     const codex = monsterSummaryFromSpellingAnalytics(service.getAnalyticsSnapshot(learner.id));
     return {
       pct: stats.total ? Math.round((stats.secure / stats.total) * 100) : 0,

--- a/tests/spelling.test.js
+++ b/tests/spelling.test.js
@@ -9,6 +9,7 @@ import { SPELLING_EVENT_TYPES } from '../src/subjects/spelling/events.js';
 import { WORD_BY_SLUG } from '../src/subjects/spelling/data/word-data.js';
 import { rewardEventsFromSpellingEvents } from '../src/subjects/spelling/event-hooks.js';
 import { monsterSummaryFromSpellingAnalytics } from '../src/platform/game/monster-system.js';
+import { getOverallSpellingStats, spellingModule } from '../src/subjects/spelling/module.js';
 
 function makeSeededRandom(seed = 1) {
   let value = seed >>> 0;
@@ -260,6 +261,40 @@ test('legacy all filter normalises to core stats and excludes Extra progress', (
   assert.deepEqual(service.getStats('learner-a', 'all'), service.getStats('learner-a', 'core'));
   assert.equal(service.getStats('learner-a', 'all').attempts, 0);
   assert.equal(service.getStats('learner-a', 'extra').attempts, 1);
+});
+
+test('spelling dashboard card reports overall progress instead of the selected pool', () => {
+  const { service, repositories } = makeService();
+  const learnerId = 'learner-a';
+  service.savePrefs(learnerId, { yearFilter: 'extra' });
+  repositories.subjectStates.writeData(learnerId, 'spelling', {
+    progress: {
+      mollusc: {
+        stage: 4,
+        attempts: 4,
+        correct: 4,
+        wrong: 0,
+        dueDay: Number.MAX_SAFE_INTEGER,
+        lastDay: 10,
+        lastResult: true,
+      },
+    },
+  });
+
+  const appState = {
+    learners: {
+      selectedId: learnerId,
+      byId: { [learnerId]: { id: learnerId, name: 'Ava' } },
+    },
+  };
+  const dashboard = spellingModule.getDashboardStats(appState, { service });
+  const extraStats = service.getStats(learnerId, 'extra');
+  const overallStats = getOverallSpellingStats(service, learnerId);
+
+  assert.equal(extraStats.secure, 1);
+  assert.equal(dashboard.pct, Math.round((overallStats.secure / overallStats.total) * 100));
+  assert.notEqual(dashboard.pct, Math.round((extraStats.secure / extraStats.total) * 100));
+  assert.equal(dashboard.due, overallStats.due);
 });
 
 test('resetting spelling progress preserves the profile TTS provider', () => {


### PR DESCRIPTION
## Summary
- show the Spelling home-card progress from overall Core + Extra word progress instead of the selected spelling pool
- use the same overall spelling stats for the home due total
- add a regression test covering Extra selection versus overall dashboard progress

## Tests
- node --test tests/spelling.test.js
- npm test
- npm run check