### PR TITLE
fix(runtime): retry transient subject command failures

### DIFF
--- a/src/platform/runtime/subject-command-client.js
+++ b/src/platform/runtime/subject-command-client.js
@@ -16,6 +16,18 @@ function isStaleWriteConflict(error) {
     && error.code === 'stale_write';
 }
 
+function isRetryableTransportFailure(error) {
+  return error instanceof SubjectCommandClientError
+    && error.retryable
+    && !isStaleWriteConflict(error);
+}
+
+function sleep(ms) {
+  const delay = Math.max(0, Number(ms) || 0);
+  if (!delay) return Promise.resolve();
+  return new Promise((resolve) => setTimeout(resolve, delay));
+}
+
 export class SubjectCommandClientError extends Error {
   constructor({ status = 0, payload = null, message = '' } = {}) {
     super(message || payload?.message || `Subject command failed (${status}).`);
@@ -33,6 +45,8 @@ export function createSubjectCommandClient({
   getLearnerRevision = () => 0,
   onCommandApplied = () => {},
   onStaleWrite = null,
+  retryAttempts = 2,
+  retryDelayMs = 250,
 } = {}) {
   if (typeof fetchFn !== 'function') {
     throw new TypeError('Subject command client requires a fetch implementation.');
@@ -95,35 +109,44 @@ export function createSubjectCommandClient({
   }
 
   async function sendWithRetry({ cleanSubjectId, cleanLearnerId, cleanCommand, payload, requestId }) {
+    const maxRetryAttempts = Math.max(0, Number(retryAttempts) || 0);
+    const baseRetryDelayMs = Math.max(0, Number(retryDelayMs) || 0);
+    let transportAttempts = 0;
+    let staleWriteRetried = false;
     let responsePayload;
-    try {
-      responsePayload = await sendOnce({
-        cleanSubjectId,
-        cleanLearnerId,
-        cleanCommand,
-        payload,
-        requestId,
-      });
-    } catch (error) {
-      if (!isStaleWriteConflict(error) || typeof onStaleWrite !== 'function') {
+
+    while (!responsePayload) {
+      try {
+        responsePayload = await sendOnce({
+          cleanSubjectId,
+          cleanLearnerId,
+          cleanCommand,
+          payload,
+          requestId,
+        });
+      } catch (error) {
+        if (isStaleWriteConflict(error) && !staleWriteRetried && typeof onStaleWrite === 'function') {
+          staleWriteRetried = true;
+          await onStaleWrite({
+            error,
+            learnerId: cleanLearnerId,
+            subjectId: cleanSubjectId,
+            command: cleanCommand,
+            payload,
+            requestId,
+          });
+          continue;
+        }
+
+        if (isRetryableTransportFailure(error) && transportAttempts < maxRetryAttempts) {
+          const delayMs = baseRetryDelayMs * (2 ** transportAttempts);
+          transportAttempts += 1;
+          await sleep(delayMs);
+          continue;
+        }
+
         throw error;
       }
-
-      await onStaleWrite({
-        error,
-        learnerId: cleanLearnerId,
-        subjectId: cleanSubjectId,
-        command: cleanCommand,
-        payload,
-        requestId,
-      });
-      responsePayload = await sendOnce({
-        cleanSubjectId,
-        cleanLearnerId,
-        cleanCommand,
-        payload,
-        requestId,
-      });
     }
 
     onCommandApplied({

--- a/tests/subject-command-client.test.js
+++ b/tests/subject-command-client.test.js
@@ -64,3 +64,46 @@ test('subject command client serialises learner commands before reading revision
   assert.deepEqual(commandBodies.map((body) => body.expectedLearnerRevision), [0, 1]);
   assert.equal(revision, 2);
 });
+
+test('subject command client retries transient server failures with the same request id', async () => {
+  let revision = 7;
+  const commandBodies = [];
+  const fetch = async (input, init = {}) => {
+    const body = JSON.parse(init.body);
+    commandBodies.push(body);
+    if (commandBodies.length === 1) {
+      return new Response(JSON.stringify({
+        ok: false,
+        code: 'backend_unavailable',
+        message: 'D1 was temporarily unavailable.',
+      }), { status: 503, headers: { 'content-type': 'application/json' } });
+    }
+    return new Response(JSON.stringify({
+      ok: true,
+      mutation: {
+        appliedRevision: body.expectedLearnerRevision + 1,
+      },
+    }), { status: 200, headers: { 'content-type': 'application/json' } });
+  };
+  const commands = createSubjectCommandClient({
+    fetch,
+    getLearnerRevision: () => revision,
+    retryDelayMs: 0,
+    onCommandApplied({ response }) {
+      revision = Number(response.mutation?.appliedRevision) || revision;
+    },
+  });
+
+  await commands.send({
+    subjectId: 'spelling',
+    learnerId: 'learner-a',
+    command: 'start-session',
+    payload: { mode: 'smart', length: 20 },
+    requestId: 'cmd-transient-503',
+  });
+
+  assert.equal(commandBodies.length, 2);
+  assert.deepEqual(commandBodies.map((body) => body.requestId), ['cmd-transient-503', 'cmd-transient-503']);
+  assert.deepEqual(commandBodies.map((body) => body.expectedLearnerRevision), [7, 7]);
+  assert.equal(revision, 8);
+});


### PR DESCRIPTION
## Summary
- retry retryable subject command transport failures with short backoff
- keep the same request id across retries so server mutation receipts can replay safely
- cover transient 503 retry behaviour in subject command client tests

## Verification
- npm test
- npm run check