### PR TITLE
fix(spelling): prioritise active extra learning words

### DIFF
--- a/legacy/spelling-engine.source.js
+++ b/legacy/spelling-engine.source.js
@@ -236,11 +236,11 @@
     var p = getProgress(profileId, word.slug);
     var today = todayDay();
     if (p.wrong > 0 && p.dueDay <= today) return "urgent";
-    if (p.wrong > 0) return "fragile";
     if (p.attempts > 0 && p.dueDay <= today) return "due";
     if (p.attempts === 0) return "new";
-    if (p.stage < SECURE_STAGE) return "growing";
-    return "secure";
+    if (p.stage >= SECURE_STAGE) return "secure";
+    if (p.wrong > 0) return "fragile";
+    return "growing";
   }
 
   function isTroubleProgress(progress, today) {

--- a/shared/spelling/legacy-engine.js
+++ b/shared/spelling/legacy-engine.js
@@ -264,11 +264,11 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
         var p = getProgress(profileId, word.slug);
         var today = todayDay();
         if (p.wrong > 0 && p.dueDay <= today) return "urgent";
-        if (p.wrong > 0) return "fragile";
         if (p.attempts > 0 && p.dueDay <= today) return "due";
         if (p.attempts === 0) return "new";
-        if (p.stage < SECURE_STAGE) return "growing";
-        return "secure";
+        if (p.stage >= SECURE_STAGE) return "secure";
+        if (p.wrong > 0) return "fragile";
+        return "growing";
       }
 
       function isTroubleProgress(progress, today) {

--- a/src/subjects/spelling/engine/legacy-engine.js
+++ b/src/subjects/spelling/engine/legacy-engine.js
@@ -264,11 +264,11 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
         var p = getProgress(profileId, word.slug);
         var today = todayDay();
         if (p.wrong > 0 && p.dueDay <= today) return "urgent";
-        if (p.wrong > 0) return "fragile";
         if (p.attempts > 0 && p.dueDay <= today) return "due";
         if (p.attempts === 0) return "new";
-        if (p.stage < SECURE_STAGE) return "growing";
-        return "secure";
+        if (p.stage >= SECURE_STAGE) return "secure";
+        if (p.wrong > 0) return "fragile";
+        return "growing";
       }
 
       function isTroubleProgress(progress, today) {

--- a/tests/spelling.test.js
+++ b/tests/spelling.test.js
@@ -6,7 +6,7 @@ import { createLocalPlatformRepositories } from '../src/platform/core/repositori
 import { createSpellingService } from '../src/subjects/spelling/service.js';
 import { createSpellingPersistence } from '../src/subjects/spelling/repository.js';
 import { SPELLING_EVENT_TYPES } from '../src/subjects/spelling/events.js';
-import { WORD_BY_SLUG } from '../src/subjects/spelling/data/word-data.js';
+import { WORDS, WORD_BY_SLUG } from '../src/subjects/spelling/data/word-data.js';
 import { rewardEventsFromSpellingEvents } from '../src/subjects/spelling/event-hooks.js';
 import { monsterSummaryFromSpellingAnalytics } from '../src/platform/game/monster-system.js';
 import { getOverallSpellingStats, spellingModule } from '../src/subjects/spelling/module.js';
@@ -148,6 +148,57 @@ test('Smart Review can be scoped to the Extra spelling pool', () => {
   assert.equal(words.length, 6);
   assert.ok(words.every((word) => word.spellingPool === 'extra'));
   assert.ok(words.every((word) => word.year === 'extra'));
+});
+
+test('Smart Review keeps secured Extra words with old mistakes behind active learning', () => {
+  const now = () => Date.UTC(2026, 0, 10);
+  const today = Math.floor(now() / (24 * 60 * 60 * 1000));
+  const { service, repositories } = makeService({
+    now,
+    random: makeSequenceRandom([0.1, 0.5, 0.5], 0.5),
+  });
+  const extraSlugs = WORDS
+    .filter((word) => word.spellingPool === 'extra')
+    .map((word) => word.slug);
+  const progress = Object.fromEntries(extraSlugs.map((slug) => [slug, {
+    stage: 6,
+    attempts: 6,
+    correct: 6,
+    wrong: 0,
+    dueDay: today + 60,
+    lastDay: today - 1,
+    lastResult: 'correct',
+  }]));
+  progress.botanist = {
+    ...progress.botanist,
+    attempts: 10,
+    correct: 9,
+    wrong: 1,
+  };
+  progress.corrode = {
+    stage: 3,
+    attempts: 3,
+    correct: 3,
+    wrong: 0,
+    dueDay: today + 7,
+    lastDay: today - 1,
+    lastResult: 'correct',
+  };
+  repositories.subjectStates.writeData('learner-a', 'spelling', { progress });
+
+  const extraRows = service.getAnalyticsSnapshot('learner-a').wordGroups
+    .find((group) => group.key === 'extra')
+    .words;
+  assert.equal(extraRows.find((word) => word.slug === 'botanist')?.status, 'secure');
+  assert.equal(extraRows.find((word) => word.slug === 'corrode')?.status, 'learning');
+
+  const transition = service.startSession('learner-a', {
+    mode: 'smart',
+    yearFilter: 'extra',
+    length: 1,
+  });
+
+  assert.deepEqual(transition.state.session.uniqueWords, ['corrode']);
 });
 
 test('Trouble Drill stays inside Extra and falls back to Extra Smart Review when no Extra trouble exists', () => {


### PR DESCRIPTION
## Summary
- keep secured Extra words with old mistake history in the secure Smart Review bucket while they are not due
- let active learning/growing Extra words take priority over already-secured words
- add a regression case matching the Nelson Extra-pool failure mode

## Verification
- npm test
- npm run check