### PR TITLE
feat(grammar): add evidence analytics read models

### DIFF
--- a/src/platform/hubs/parent-read-model.js
+++ b/src/platform/hubs/parent-read-model.js
@@ -8,6 +8,7 @@ import {
   platformRoleLabel,
 } from '../access/roles.js';
 import { buildSpellingLearnerReadModel } from '../../subjects/spelling/read-model.js';
+import { buildGrammarLearnerReadModel } from '../../subjects/grammar/read-model.js';
 
 function asTs(value, fallback = 0) {
   const numeric = Number(value);
@@ -16,6 +17,19 @@ function asTs(value, fallback = 0) {
 
 function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isActionableFocus(entry) {
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return false;
+  return Boolean(entry.activeSessionId)
+    || (Number(entry.dueCount) || 0) > 0
+    || (Number(entry.troubleCount) || 0) > 0;
+}
+
+function orderDueWork(entries = []) {
+  return entries
+    .filter(Boolean)
+    .sort((a, b) => Number(isActionableFocus(b)) - Number(isActionableFocus(a)));
 }
 
 function normaliseAccessibleLearnerEntry(rawValue) {
@@ -58,10 +72,21 @@ export function buildParentHubReadModel({
     runtimeSnapshot: runtimeSnapshots.spelling || null,
     now,
   });
+  const grammar = buildGrammarLearnerReadModel({
+    subjectStateRecord: isPlainObject(subjectStates.grammar) ? subjectStates.grammar : null,
+    practiceSessions,
+    eventLog,
+    now,
+  });
+  const activeSubjectCount = [
+    spelling.progressSnapshot.trackedWords > 0,
+    grammar.hasEvidence,
+  ].filter(Boolean).length;
 
   const lastActivityAt = Math.max(
     asTs(learner?.createdAt, 0),
     asTs(spelling?.overview?.lastActivityAt, 0),
+    asTs(grammar?.overview?.lastActivityAt, 0),
     ...Object.values(isPlainObject(gameState) ? gameState : {}).map((entry) => asTs(entry?.updatedAt, 0)),
     0,
   );
@@ -98,23 +123,37 @@ export function buildParentHubReadModel({
       goal: learner?.goal || 'sats',
       dailyMinutes: Number(learner?.dailyMinutes) || 15,
       lastActivityAt,
-      activeSubjectCount: spelling.progressSnapshot.trackedWords > 0 ? 1 : 0,
+      activeSubjectCount,
     },
     learnerOverview: {
       secureWords: spelling.progressSnapshot.secureWords,
       dueWords: spelling.progressSnapshot.dueWords,
       troubleWords: spelling.progressSnapshot.troubleWords,
       accuracyPercent: spelling.progressSnapshot.accuracyPercent,
+      secureGrammarConcepts: grammar.progressSnapshot.securedConcepts,
+      dueGrammarConcepts: grammar.progressSnapshot.dueConcepts,
+      weakGrammarConcepts: grammar.progressSnapshot.weakConcepts,
+      grammarAccuracyPercent: grammar.progressSnapshot.accuracyPercent,
       recentSessions: spelling.recentSessions.length,
     },
     selectedLearnerId: resolvedLearnerId,
     accessibleLearners: learnerOptions,
-    dueWork: [spelling.currentFocus],
-    recentSessions: spelling.recentSessions,
-    strengths: spelling.strengths,
-    weaknesses: spelling.weaknesses,
-    misconceptionPatterns: spelling.misconceptionPatterns,
-    progressSnapshots: [spelling.progressSnapshot],
+    dueWork: orderDueWork([
+      spelling.currentFocus,
+      ...(grammar.hasEvidence ? [grammar.currentFocus] : []),
+    ]),
+    recentSessions: [...spelling.recentSessions, ...grammar.recentSessions]
+      .sort((a, b) => asTs(b.updatedAt, 0) - asTs(a.updatedAt, 0))
+      .slice(0, 6),
+    strengths: [...spelling.strengths, ...grammar.strengths].slice(0, 6),
+    weaknesses: [...spelling.weaknesses, ...grammar.weaknesses].slice(0, 6),
+    misconceptionPatterns: [...spelling.misconceptionPatterns, ...grammar.misconceptionPatterns]
+      .sort((a, b) => (Number(b.count) || 0) - (Number(a.count) || 0) || asTs(b.lastSeenAt, 0) - asTs(a.lastSeenAt, 0))
+      .slice(0, 8),
+    progressSnapshots: [
+      spelling.progressSnapshot,
+      ...(grammar.hasEvidence ? [grammar.progressSnapshot] : []),
+    ],
     exportEntryPoints: [
       {
         kind: 'learner',

--- a/src/subjects/grammar/components/GrammarAnalyticsScene.jsx
+++ b/src/subjects/grammar/components/GrammarAnalyticsScene.jsx
@@ -21,15 +21,53 @@ function securedCountForRoute(route, conceptsById) {
   ), 0);
 }
 
+function EmptyEvidence({ children }) {
+  return <p className="small muted">{children}</p>;
+}
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function numericScore(value, fallback) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+}
+
+function normaliseRecentActivityEntry(entry = {}) {
+  const result = isPlainObject(entry.result) ? entry.result : {};
+  const correct = entry.correct ?? result.correct;
+  return {
+    itemId: entry.itemId || '',
+    templateId: entry.templateId || '',
+    label: entry.questionTypeLabel || entry.templateLabel || entry.label || entry.templateId || 'Grammar item',
+    correct: Boolean(correct),
+    score: numericScore(entry.score ?? result.score, 0),
+    maxScore: numericScore(entry.maxScore ?? result.maxScore, 1),
+  };
+}
+
+function recentActivityForAnalytics(analytics = {}) {
+  if (Array.isArray(analytics.recentActivity) && analytics.recentActivity.length) {
+    return analytics.recentActivity.slice(0, 5).map(normaliseRecentActivityEntry);
+  }
+  if (Array.isArray(analytics.recentAttempts)) {
+    return analytics.recentAttempts.slice(-5).reverse().map(normaliseRecentActivityEntry);
+  }
+  return [];
+}
+
 export function GrammarAnalyticsScene({ grammar, rewardState: providedRewardState = null }) {
   const concepts = grammar.analytics?.concepts || [];
   const counts = grammar.stats?.concepts || {};
+  const progressSnapshot = grammar.analytics?.progressSnapshot || {};
+  const evidenceSummary = Array.isArray(grammar.analytics?.evidenceSummary) ? grammar.analytics.evidenceSummary : [];
+  const misconceptionPatterns = Array.isArray(grammar.analytics?.misconceptionPatterns) ? grammar.analytics.misconceptionPatterns : [];
+  const questionTypeSummary = Array.isArray(grammar.analytics?.questionTypeSummary) ? grammar.analytics.questionTypeSummary : [];
   const conceptsById = new Map(concepts.map((concept) => [concept.id, concept]));
   const grouped = groupedGrammarConcepts(concepts);
   const rewardState = providedRewardState || grammar.projections?.rewards?.state || {};
-  const recentAttempts = Array.isArray(grammar.analytics?.recentAttempts)
-    ? grammar.analytics.recentAttempts.slice(-5).reverse()
-    : [];
+  const recentActivity = recentActivityForAnalytics(grammar.analytics || {});
 
   return (
     <section className="card grammar-analytics" aria-labelledby="grammar-analytics-title">
@@ -51,6 +89,28 @@ export function GrammarAnalyticsScene({ grammar, rewardState: providedRewardStat
 
       <div className="grammar-analytics-grid">
         <div className="grammar-evidence-list">
+          <div className="grammar-evidence-summary" aria-label="Grammar evidence summary">
+            <div className="grammar-stat">
+              <span>tracked</span>
+              <strong>{progressSnapshot.trackedConcepts ?? 0}/{progressSnapshot.totalConcepts ?? concepts.length}</strong>
+              <small>concepts</small>
+            </div>
+            <div className="grammar-stat">
+              <span>accuracy</span>
+              <strong>{progressSnapshot.accuracyPercent == null ? '-' : `${progressSnapshot.accuracyPercent}%`}</strong>
+              <small>answered evidence</small>
+            </div>
+          </div>
+          {evidenceSummary.length ? (
+            <div className="grammar-method-list">
+              {evidenceSummary.map((entry) => (
+                <div key={entry.id || entry.label}>
+                  <strong>{entry.label}</strong>
+                  <span>{entry.detail}</span>
+                </div>
+              ))}
+            </div>
+          ) : null}
           {grouped.map((group) => (
             <div className="grammar-evidence-domain" key={group.domain}>
               <strong>{group.domain}</strong>
@@ -94,13 +154,42 @@ export function GrammarAnalyticsScene({ grammar, rewardState: providedRewardStat
         </div>
       </div>
 
+      <div className="grammar-evidence-panels">
+        <div>
+          <div className="eyebrow">Misconception repair</div>
+          {misconceptionPatterns.length ? (
+            <ol>
+              {misconceptionPatterns.map((entry) => (
+                <li key={entry.id}>
+                  <strong>{entry.label}</strong>
+                  <span>{entry.count || 0} signal{Number(entry.count) === 1 ? '' : 's'}</span>
+                </li>
+              ))}
+            </ol>
+          ) : <EmptyEvidence>No recurring misconception pattern recorded yet.</EmptyEvidence>}
+        </div>
+        <div>
+          <div className="eyebrow">Question-type evidence</div>
+          {questionTypeSummary.length ? (
+            <ol>
+              {questionTypeSummary.map((entry) => (
+                <li key={entry.id}>
+                  <strong>{entry.label}</strong>
+                  <span>{entry.correct || 0}/{entry.attempts || 0} correct · {entry.status || 'learning'}</span>
+                </li>
+              ))}
+            </ol>
+          ) : <EmptyEvidence>No question-type evidence recorded yet.</EmptyEvidence>}
+        </div>
+      </div>
+
       <div className="grammar-recent">
         <div className="eyebrow">Recent attempts</div>
-        {recentAttempts.length ? (
+        {recentActivity.length ? (
           <ol>
-            {recentAttempts.map((attempt, index) => (
+            {recentActivity.map((attempt, index) => (
               <li key={`${attempt.itemId || attempt.templateId || 'attempt'}-${index}`}>
-                <strong>{attempt.templateLabel || attempt.templateId || 'Grammar item'}</strong>
+                <strong>{attempt.label}</strong>
                 <span>{attempt.correct ? 'correct' : 'review'} · score {attempt.score ?? 0}/{attempt.maxScore ?? 1}</span>
               </li>
             ))}

--- a/src/subjects/grammar/metadata.js
+++ b/src/subjects/grammar/metadata.js
@@ -253,6 +253,61 @@ function statsFromConcepts(concepts) {
   };
 }
 
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function humanLabel(id) {
+  return String(id || '')
+    .replace(/_confusion$/, '')
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function asTimestamp(value, fallback = 0) {
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+  }
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric >= 0 ? numeric : fallback;
+}
+
+function fallbackMisconceptionPatterns(counts = {}) {
+  if (!isPlainObject(counts)) return [];
+  return Object.entries(counts)
+    .map(([id, rawEntry]) => {
+      const entry = isPlainObject(rawEntry) ? rawEntry : {};
+      return {
+        subjectId: 'grammar',
+        id,
+        label: `${humanLabel(id)} pattern`,
+        count: Math.max(0, Math.floor(Number(entry.count) || 0)),
+        lastSeenAt: asTimestamp(entry.lastSeenAt, 0),
+        source: 'grammar-state',
+      };
+    })
+    .filter((entry) => entry.count > 0)
+    .sort((a, b) => (b.count - a.count) || (b.lastSeenAt - a.lastSeenAt))
+    .slice(0, 5);
+}
+
+function progressSnapshotFromConcepts(concepts) {
+  const correct = concepts.reduce((sum, concept) => sum + (Number(concept.correct) || 0), 0);
+  const wrong = concepts.reduce((sum, concept) => sum + (Number(concept.wrong) || 0), 0);
+  const attempts = correct + wrong;
+  return {
+    subjectId: 'grammar',
+    totalConcepts: concepts.length,
+    trackedConcepts: concepts.filter((concept) => (Number(concept.attempts) || 0) > 0).length,
+    securedConcepts: concepts.filter((concept) => concept.status === 'secured').length,
+    dueConcepts: concepts.filter((concept) => concept.status === 'due').length,
+    weakConcepts: concepts.filter((concept) => concept.status === 'weak').length,
+    untouchedConcepts: concepts.filter((concept) => concept.status === 'new').length,
+    accuracyPercent: attempts ? Math.round((correct / attempts) * 100) : null,
+  };
+}
+
 export function normaliseGrammarReadModel(rawValue = {}, learnerId = '') {
   const raw = rawValue && typeof rawValue === 'object' && !Array.isArray(rawValue) ? rawValue : {};
   const concepts = mergeConcepts(raw.analytics?.concepts);
@@ -267,6 +322,11 @@ export function normaliseGrammarReadModel(rawValue = {}, learnerId = '') {
   const phase = ['dashboard', 'session', 'feedback', 'summary'].includes(raw.phase)
     ? raw.phase
     : 'dashboard';
+  const rawAnalytics = isPlainObject(raw.analytics) ? raw.analytics : {};
+  const misconceptionCounts = isPlainObject(rawAnalytics.misconceptionCounts) ? rawAnalytics.misconceptionCounts : {};
+  const progressSnapshot = isPlainObject(rawAnalytics.progressSnapshot)
+    ? { ...progressSnapshotFromConcepts(concepts), ...rawAnalytics.progressSnapshot }
+    : progressSnapshotFromConcepts(concepts);
 
   return {
     subjectId: GRAMMAR_SUBJECT_ID,
@@ -291,8 +351,15 @@ export function normaliseGrammarReadModel(rawValue = {}, learnerId = '') {
     stats,
     analytics: {
       concepts,
-      misconceptionCounts: raw.analytics?.misconceptionCounts || {},
-      recentAttempts: Array.isArray(raw.analytics?.recentAttempts) ? raw.analytics.recentAttempts.slice(-12) : [],
+      misconceptionCounts,
+      misconceptionPatterns: Array.isArray(rawAnalytics.misconceptionPatterns)
+        ? rawAnalytics.misconceptionPatterns.slice(0, 5)
+        : fallbackMisconceptionPatterns(misconceptionCounts),
+      questionTypeSummary: Array.isArray(rawAnalytics.questionTypeSummary) ? rawAnalytics.questionTypeSummary.slice(0, 6) : [],
+      progressSnapshot,
+      evidenceSummary: Array.isArray(rawAnalytics.evidenceSummary) ? rawAnalytics.evidenceSummary.slice(0, 4) : [],
+      recentAttempts: Array.isArray(rawAnalytics.recentAttempts) ? rawAnalytics.recentAttempts.slice(-12) : [],
+      recentActivity: Array.isArray(rawAnalytics.recentActivity) ? rawAnalytics.recentActivity.slice(0, 8) : [],
     },
     capabilities: {
       enabledModes: Array.isArray(raw.capabilities?.enabledModes) && raw.capabilities.enabledModes.length

--- a/src/subjects/grammar/read-model.js
+++ b/src/subjects/grammar/read-model.js
@@ -1,0 +1,345 @@
+import { GRAMMAR_CLIENT_CONCEPTS } from './metadata.js';
+
+const QUESTION_TYPE_LABELS = Object.freeze({
+  identify: 'Identify the feature',
+  choose: 'Choose the correct sentence',
+  fix: 'Fix the sentence',
+  rewrite: 'Rewrite the sentence',
+  build: 'Build or transform',
+  explain: 'Explain why',
+  classify: 'Classify',
+  fill: 'Complete the sentence',
+});
+
+function asTs(value, fallback = 0) {
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+  }
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric >= 0 ? numeric : fallback;
+}
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normaliseMasteryNode(rawValue) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  return {
+    attempts: Math.max(0, Math.floor(Number(raw.attempts) || 0)),
+    correct: Math.max(0, Math.floor(Number(raw.correct) || 0)),
+    wrong: Math.max(0, Math.floor(Number(raw.wrong) || 0)),
+    strength: Number.isFinite(Number(raw.strength)) ? Math.max(0.02, Math.min(0.99, Number(raw.strength))) : 0.25,
+    intervalDays: Math.max(0, Number(raw.intervalDays) || 0),
+    dueAt: asTs(raw.dueAt, 0),
+    lastSeenAt: typeof raw.lastSeenAt === 'string' ? raw.lastSeenAt : null,
+    lastWrongAt: typeof raw.lastWrongAt === 'string' ? raw.lastWrongAt : null,
+    correctStreak: Math.max(0, Math.floor(Number(raw.correctStreak) || 0)),
+  };
+}
+
+function grammarConceptStatus(node, nowTs) {
+  const value = normaliseMasteryNode(node);
+  if (!value.attempts) return 'new';
+  if (value.strength < 0.42 || value.wrong > value.correct + 1) return 'weak';
+  if ((value.dueAt || 0) <= nowTs) return 'due';
+  if (value.strength >= 0.82 && value.intervalDays >= 7 && value.correctStreak >= 3) return 'secured';
+  return 'learning';
+}
+
+function accuracyPercent(correct, wrong) {
+  const total = Math.max(0, Number(correct) || 0) + Math.max(0, Number(wrong) || 0);
+  if (!total) return null;
+  return Math.round((Math.max(0, Number(correct) || 0) / total) * 100);
+}
+
+function humanLabel(id) {
+  return String(id || '')
+    .replace(/_confusion$/, '')
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function questionTypeLabel(id) {
+  return QUESTION_TYPE_LABELS[id] || humanLabel(id);
+}
+
+function sortTop(entries, scoreFn, limit = 3) {
+  return [...entries]
+    .sort((a, b) => {
+      const scoreDelta = scoreFn(b) - scoreFn(a);
+      if (scoreDelta) return scoreDelta;
+      return String(a.label || a.id || '').localeCompare(String(b.label || b.id || ''));
+    })
+    .slice(0, limit);
+}
+
+function conceptRowsFromState(state, nowTs) {
+  const mastery = isPlainObject(state?.mastery?.concepts) ? state.mastery.concepts : {};
+  return GRAMMAR_CLIENT_CONCEPTS.map((concept) => {
+    const node = normaliseMasteryNode(mastery[concept.id]);
+    const status = grammarConceptStatus(node, nowTs);
+    return {
+      ...concept,
+      status,
+      attempts: node.attempts,
+      correct: node.correct,
+      wrong: node.wrong,
+      strength: node.strength,
+      dueAt: node.dueAt,
+      lastSeenAt: node.lastSeenAt,
+      lastWrongAt: node.lastWrongAt,
+      correctStreak: node.correctStreak,
+    };
+  });
+}
+
+function progressSnapshotFromConcepts(concepts) {
+  const attempted = concepts.filter((concept) => concept.attempts > 0);
+  const correct = concepts.reduce((sum, concept) => sum + concept.correct, 0);
+  const wrong = concepts.reduce((sum, concept) => sum + concept.wrong, 0);
+  return {
+    subjectId: 'grammar',
+    totalConcepts: concepts.length,
+    trackedConcepts: attempted.length,
+    securedConcepts: concepts.filter((concept) => concept.status === 'secured').length,
+    dueConcepts: concepts.filter((concept) => concept.status === 'due').length,
+    weakConcepts: concepts.filter((concept) => concept.status === 'weak').length,
+    untouchedConcepts: concepts.filter((concept) => concept.status === 'new').length,
+    accuracyPercent: accuracyPercent(correct, wrong),
+  };
+}
+
+function domainSummaries(concepts) {
+  const groups = new Map();
+  for (const concept of concepts) {
+    const id = concept.domain || 'Grammar';
+    const current = groups.get(id) || {
+      id,
+      label: id,
+      secureCount: 0,
+      dueCount: 0,
+      weakCount: 0,
+      attemptCount: 0,
+      correct: 0,
+      wrong: 0,
+      rows: [],
+    };
+    current.rows.push(concept);
+    current.secureCount += concept.status === 'secured' ? 1 : 0;
+    current.dueCount += concept.status === 'due' ? 1 : 0;
+    current.weakCount += concept.status === 'weak' ? 1 : 0;
+    current.attemptCount += concept.attempts;
+    current.correct += concept.correct;
+    current.wrong += concept.wrong;
+    groups.set(id, current);
+  }
+  return [...groups.values()].map((entry) => ({
+    ...entry,
+    accuracyPercent: accuracyPercent(entry.correct, entry.wrong),
+  }));
+}
+
+function misconceptionPatternsFromState(state, eventLog = []) {
+  const patterns = new Map();
+  const misconceptions = isPlainObject(state?.misconceptions) ? state.misconceptions : {};
+  for (const [id, rawEntry] of Object.entries(misconceptions)) {
+    const entry = isPlainObject(rawEntry) ? rawEntry : {};
+    patterns.set(id, {
+      subjectId: 'grammar',
+      id,
+      label: `${humanLabel(id)} pattern`,
+      count: Math.max(0, Math.floor(Number(entry.count) || 0)),
+      lastSeenAt: asTs(entry.lastSeenAt, 0),
+      source: 'grammar-state',
+    });
+  }
+
+  for (const event of Array.isArray(eventLog) ? eventLog : []) {
+    if (event?.subjectId !== 'grammar' || event?.type !== 'grammar.misconception-seen' || !event.misconception) continue;
+    const id = String(event.misconception);
+    const current = patterns.get(id) || {
+      subjectId: 'grammar',
+      id,
+      label: `${humanLabel(id)} pattern`,
+      count: 0,
+      lastSeenAt: 0,
+      source: 'grammar-event',
+    };
+    if (current.source === 'grammar-event') current.count += 1;
+    current.lastSeenAt = Math.max(current.lastSeenAt, asTs(event.createdAt, 0));
+    patterns.set(id, current);
+  }
+
+  return [...patterns.values()]
+    .filter((entry) => entry.count > 0)
+    .sort((a, b) => (b.count - a.count) || (b.lastSeenAt - a.lastSeenAt))
+    .slice(0, 5);
+}
+
+function questionTypeSummaryFromState(state, nowTs) {
+  const mastery = isPlainObject(state?.mastery?.questionTypes) ? state.mastery.questionTypes : {};
+  return Object.entries(mastery)
+    .map(([id, rawNode]) => {
+      const node = normaliseMasteryNode(rawNode);
+      return {
+        subjectId: 'grammar',
+        id,
+        label: questionTypeLabel(id),
+        status: grammarConceptStatus(node, nowTs),
+        attempts: node.attempts,
+        correct: node.correct,
+        wrong: node.wrong,
+        accuracyPercent: accuracyPercent(node.correct, node.wrong),
+        strength: node.strength,
+        dueAt: node.dueAt,
+      };
+    })
+    .filter((entry) => entry.attempts > 0)
+    .sort((a, b) => {
+      const troubleDelta = (Number(b.wrong) - Number(a.wrong)) || (Number(a.accuracyPercent ?? 101) - Number(b.accuracyPercent ?? 101));
+      if (troubleDelta) return troubleDelta;
+      return String(a.label).localeCompare(String(b.label));
+    })
+    .slice(0, 6);
+}
+
+function recentGrammarSessions(practiceSessions = []) {
+  return (Array.isArray(practiceSessions) ? practiceSessions : [])
+    .filter((record) => record?.subjectId === 'grammar')
+    .sort((a, b) => asTs(b.updatedAt, 0) - asTs(a.updatedAt, 0))
+    .slice(0, 6)
+    .map((record) => {
+      const answered = Number(record?.summary?.answered) || 0;
+      const correct = Number(record?.summary?.correct) || 0;
+      return {
+        id: record.id,
+        subjectId: 'grammar',
+        status: record.status,
+        sessionKind: record.sessionKind || record.summary?.mode || 'practice',
+        label: record?.summary?.mode ? `Grammar ${record.summary.mode}` : 'Grammar practice',
+        updatedAt: asTs(record.updatedAt, asTs(record.createdAt, 0)),
+        mistakeCount: Math.max(0, answered - correct),
+        headline: answered ? `${correct}/${answered}` : '',
+      };
+    });
+}
+
+function currentGrammarFocus({ concepts, sessions, snapshot }) {
+  const activeSession = sessions.find((record) => record.status === 'active') || null;
+  const weakConcepts = concepts.filter((concept) => concept.status === 'weak');
+  const dueConcepts = concepts.filter((concept) => concept.status === 'due');
+  if (activeSession) {
+    return {
+      subjectId: 'grammar',
+      recommendedMode: 'smart',
+      label: 'Continue Grammar practice',
+      detail: 'A live Grammar round is saved for this learner.',
+      dueCount: dueConcepts.length,
+      troubleCount: weakConcepts.length,
+      activeSessionId: activeSession.id,
+    };
+  }
+  if (weakConcepts.length) {
+    return {
+      subjectId: 'grammar',
+      recommendedMode: 'smart',
+      label: 'Repair Grammar misconceptions',
+      detail: `${weakConcepts[0].name} is the highest current Grammar load.`,
+      dueCount: dueConcepts.length,
+      troubleCount: weakConcepts.length,
+      activeSessionId: null,
+    };
+  }
+  if (dueConcepts.length) {
+    return {
+      subjectId: 'grammar',
+      recommendedMode: 'smart',
+      label: 'Clear due Grammar concepts',
+      detail: `${dueConcepts.length} concept${dueConcepts.length === 1 ? '' : 's'} need spaced review.`,
+      dueCount: dueConcepts.length,
+      troubleCount: weakConcepts.length,
+      activeSessionId: null,
+    };
+  }
+  return {
+    subjectId: 'grammar',
+    recommendedMode: 'smart',
+    label: snapshot.trackedConcepts ? 'Keep Grammar evidence fresh' : 'Start Grammar evidence',
+    detail: snapshot.trackedConcepts
+      ? `${snapshot.trackedConcepts} concept${snapshot.trackedConcepts === 1 ? '' : 's'} have answer evidence.`
+      : 'No Grammar answer evidence is stored yet.',
+    dueCount: dueConcepts.length,
+    troubleCount: weakConcepts.length,
+    activeSessionId: null,
+  };
+}
+
+export function buildGrammarLearnerReadModel({
+  subjectStateRecord = null,
+  practiceSessions = [],
+  eventLog = [],
+  now = Date.now,
+} = {}) {
+  const nowTs = typeof now === 'function' ? asTs(now(), Date.now()) : asTs(now, Date.now());
+  const record = isPlainObject(subjectStateRecord) ? subjectStateRecord : {};
+  const state = isPlainObject(record.data) && isPlainObject(record.data.mastery)
+    ? record.data
+    : (isPlainObject(record.ui) ? record.ui : {});
+  const concepts = conceptRowsFromState(state, nowTs);
+  const snapshot = progressSnapshotFromConcepts(concepts);
+  const domains = domainSummaries(concepts);
+  const sessions = recentGrammarSessions(practiceSessions);
+  const strengths = sortTop(
+    domains.filter((entry) => entry.secureCount > 0),
+    (entry) => entry.secureCount * 10 + (entry.accuracyPercent || 0),
+    3,
+  ).map((entry) => ({
+    subjectId: 'grammar',
+    id: entry.id,
+    label: entry.label,
+    detail: `${entry.secureCount} secure concept${entry.secureCount === 1 ? '' : 's'}`,
+    secureCount: entry.secureCount,
+    dueCount: entry.dueCount,
+    troubleCount: entry.weakCount,
+  }));
+  const weaknesses = sortTop(
+    domains.filter((entry) => entry.dueCount > 0 || entry.weakCount > 0),
+    (entry) => entry.weakCount * 12 + entry.dueCount * 7 - (entry.accuracyPercent || 0) / 10,
+    3,
+  ).map((entry) => ({
+    subjectId: 'grammar',
+    id: entry.id,
+    label: entry.label,
+    detail: `${entry.dueCount} due · ${entry.weakCount} weak`,
+    secureCount: entry.secureCount,
+    dueCount: entry.dueCount,
+    troubleCount: entry.weakCount,
+  }));
+  const misconceptionPatterns = misconceptionPatternsFromState(state, eventLog);
+  const questionTypeSummary = questionTypeSummaryFromState(state, nowTs);
+  const lastActivityAt = Math.max(
+    asTs(record.updatedAt, 0),
+    ...concepts.map((concept) => asTs(concept.lastSeenAt, 0)),
+    ...sessions.map((session) => asTs(session.updatedAt, 0)),
+    ...((Array.isArray(eventLog) ? eventLog : []).filter((event) => event?.subjectId === 'grammar').map((event) => asTs(event.createdAt, 0))),
+    0,
+  );
+
+  return {
+    subjectId: 'grammar',
+    currentFocus: currentGrammarFocus({ concepts, sessions, snapshot }),
+    progressSnapshot: snapshot,
+    overview: {
+      ...snapshot,
+      lastActivityAt,
+    },
+    strengths,
+    weaknesses,
+    misconceptionPatterns,
+    questionTypeSummary,
+    recentSessions: sessions,
+    hasEvidence: snapshot.trackedConcepts > 0 || sessions.length > 0 || misconceptionPatterns.length > 0,
+  };
+}

--- a/src/surfaces/hubs/ParentHubSurface.jsx
+++ b/src/surfaces/hubs/ParentHubSurface.jsx
@@ -19,6 +19,19 @@ function HubStrengthList({ title, items = [], emptyText = 'No signal yet.' }) {
   );
 }
 
+function snapshotSubjectId(snapshot = {}) {
+  if (snapshot.subjectId) return snapshot.subjectId;
+  return snapshot.totalConcepts != null || snapshot.trackedConcepts != null ? 'grammar' : 'spelling';
+}
+
+function snapshotChipLabel(snapshot = {}) {
+  const subjectId = snapshotSubjectId(snapshot);
+  if (subjectId === 'grammar') {
+    return `Grammar: ${snapshot.trackedConcepts ?? 0}/${snapshot.totalConcepts ?? 0} concepts`;
+  }
+  return `Spelling: ${snapshot.trackedWords ?? 0}/${snapshot.totalPublishedWords ?? 0} words`;
+}
+
 export function ParentHubSurface({ appState, model, hubState = {}, accessContext = {}, actions }) {
   const loadingRemote = accessContext?.shellAccess?.source === 'worker-session' && hubState.status === 'loading' && !model;
   if (loadingRemote) {
@@ -58,7 +71,10 @@ export function ParentHubSurface({ appState, model, hubState = {}, accessContext
   const strengths = Array.isArray(model.strengths) ? model.strengths : [];
   const weaknesses = Array.isArray(model.weaknesses) ? model.weaknesses : [];
   const patterns = Array.isArray(model.misconceptionPatterns) ? model.misconceptionPatterns : [];
-  const snapshot = Array.isArray(model.progressSnapshots) ? model.progressSnapshots[0] : null;
+  const progressSnapshots = Array.isArray(model.progressSnapshots) ? model.progressSnapshots : [];
+  const grammarDueConcepts = Number(overview.dueGrammarConcepts) || 0;
+  const grammarWeakConcepts = Number(overview.weakGrammarConcepts) || 0;
+  const grammarReviewConcepts = grammarDueConcepts + grammarWeakConcepts;
   const accessibleLearners = Array.isArray(model.accessibleLearners) ? model.accessibleLearners : [];
   const selectedLearnerId = model.selectedLearnerId || model.learner?.id || '';
   const notice = hubState.notice || accessContext.adultSurfaceNotice || '';
@@ -99,9 +115,12 @@ export function ParentHubSurface({ appState, model, hubState = {}, accessContext
           <h3 className="section-title" style={{ fontSize: '1.2rem' }}>Current picture</h3>
           <div className="stat-grid" style={{ marginTop: 16 }}>
             <div className="stat"><div className="stat-label">Secure words</div><div className="stat-value">{overview.secureWords ?? 0}</div><div className="stat-sub">Spelling snapshot</div></div>
-            <div className="stat"><div className="stat-label">Due now</div><div className="stat-value">{overview.dueWords ?? 0}</div><div className="stat-sub">Needs spaced return</div></div>
-            <div className="stat"><div className="stat-label">Trouble load</div><div className="stat-value">{overview.troubleWords ?? 0}</div><div className="stat-sub">Recent difficulty</div></div>
-            <div className="stat"><div className="stat-label">Accuracy</div><div className="stat-value">{overview.accuracyPercent == null ? '—' : `${overview.accuracyPercent}%`}</div><div className="stat-sub">Across durable progress</div></div>
+            <div className="stat"><div className="stat-label">Due words</div><div className="stat-value">{overview.dueWords ?? 0}</div><div className="stat-sub">Spelling return</div></div>
+            <div className="stat"><div className="stat-label">Trouble words</div><div className="stat-value">{overview.troubleWords ?? 0}</div><div className="stat-sub">Recent spelling mistakes</div></div>
+            <div className="stat"><div className="stat-label">Spelling accuracy</div><div className="stat-value">{overview.accuracyPercent == null ? '—' : `${overview.accuracyPercent}%`}</div><div className="stat-sub">Durable word progress</div></div>
+            <div className="stat"><div className="stat-label">Grammar secured</div><div className="stat-value">{overview.secureGrammarConcepts ?? 0}</div><div className="stat-sub">Concepts secure</div></div>
+            <div className="stat"><div className="stat-label">Grammar review</div><div className="stat-value">{grammarReviewConcepts}</div><div className="stat-sub">{grammarDueConcepts} due · {grammarWeakConcepts} weak</div></div>
+            <div className="stat"><div className="stat-label">Grammar accuracy</div><div className="stat-value">{overview.grammarAccuracyPercent == null ? '—' : `${overview.grammarAccuracyPercent}%`}</div><div className="stat-sub">Concept evidence</div></div>
           </div>
           <div className="callout" style={{ marginTop: 16 }}>
             <strong>Current focus</strong>
@@ -118,9 +137,9 @@ export function ParentHubSurface({ appState, model, hubState = {}, accessContext
           <h3 className="section-title" style={{ fontSize: '1.2rem' }}>Portable recovery points</h3>
           <p className="subtitle">Parent Hub only surfaces export entry points. It does not invent a separate reporting store.</p>
           <div className="chip-row" style={{ marginTop: 14 }}>
-            <span className="chip">Tracked: {snapshot?.trackedWords ?? 0}</span>
-            <span className="chip">Published pool: {snapshot?.totalPublishedWords ?? 0}</span>
-            <span className="chip">Subject: spelling</span>
+            {progressSnapshots.length ? progressSnapshots.map((snapshot, index) => (
+              <span className="chip" key={`${snapshotSubjectId(snapshot)}-${index}`}>{snapshotChipLabel(snapshot)}</span>
+            )) : <span className="chip">No subject snapshot</span>}
           </div>
           <div className="actions" style={{ marginTop: 16 }}>
             {(model.exportEntryPoints || []).map((entry) => (

--- a/styles/app.css
+++ b/styles/app.css
@@ -6635,6 +6635,55 @@ textarea:focus-visible {
   align-items: start;
 }
 
+.grammar-evidence-summary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.grammar-method-list,
+.grammar-evidence-panels {
+  display: grid;
+  gap: 10px;
+}
+
+.grammar-method-list > div,
+.grammar-evidence-panels > div {
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel-soft);
+}
+
+.grammar-method-list strong,
+.grammar-method-list span,
+.grammar-evidence-panels strong,
+.grammar-evidence-panels span {
+  display: block;
+  overflow-wrap: anywhere;
+}
+
+.grammar-method-list span,
+.grammar-evidence-panels span {
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 0.88rem;
+  line-height: 1.4;
+}
+
+.grammar-evidence-panels {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-top: 18px;
+}
+
+.grammar-evidence-panels ol {
+  display: grid;
+  gap: 8px;
+  margin: 10px 0 0;
+  padding-left: 20px;
+}
+
 .grammar-route-panel {
   display: grid;
   gap: 10px;
@@ -6703,7 +6752,8 @@ textarea:focus-visible {
 
 @media (max-width: 980px) {
   .grammar-setup-grid,
-  .grammar-analytics-grid {
+  .grammar-analytics-grid,
+  .grammar-evidence-panels {
     grid-template-columns: 1fr;
   }
 }

--- a/tests/helpers/react-render.js
+++ b/tests/helpers/react-render.js
@@ -209,13 +209,16 @@ export function renderHubSurfaceFixture({ surface = 'parent' } = {}) {
     };
     const parentModel = {
       learner: { id: 'learner-a', name: 'Ava', lastActivityAt: Date.UTC(2026, 3, 22, 12, 0) },
-      learnerOverview: { secureWords: 8, dueWords: 2, troubleWords: 1, accuracyPercent: 82 },
-      dueWork: [{ label: 'Review due spellings', detail: 'Two words are ready.' }],
+      learnerOverview: { secureWords: 8, dueWords: 2, troubleWords: 1, accuracyPercent: 82, secureGrammarConcepts: 2, dueGrammarConcepts: 1, weakGrammarConcepts: 1, grammarAccuracyPercent: 67 },
+      dueWork: [{ label: 'Review due spellings', detail: 'Two words are ready.' }, { subjectId: 'grammar', label: 'Repair Grammar misconceptions', detail: 'Adverbials need another pass.' }],
       recentSessions: [{ id: 'session-1', label: 'Smart Review', status: 'completed', sessionKind: 'spelling', mistakeCount: 1, updatedAt: Date.UTC(2026, 3, 22, 12, 0), headline: 'Good recall' }],
       strengths: [{ label: 'Suffixes', detail: 'Secure recall', secureCount: 4, troubleCount: 0 }],
       weaknesses: [{ label: 'Possession', detail: 'Needs another pass', secureCount: 1, troubleCount: 1 }],
       misconceptionPatterns: [{ label: 'Double consonant', source: 'event log', count: 2, lastSeenAt: Date.UTC(2026, 3, 22, 12, 0) }],
-      progressSnapshots: [{ trackedWords: 213, totalPublishedWords: 235 }],
+      progressSnapshots: [
+        { subjectId: 'spelling', trackedWords: 213, totalPublishedWords: 235 },
+        { subjectId: 'grammar', trackedConcepts: 3, totalConcepts: 18, securedConcepts: 2, dueConcepts: 1, weakConcepts: 1 },
+      ],
       exportEntryPoints: [{ action: 'platform-export-learner', label: 'Export current learner' }],
       accessibleLearners: [{ learnerId: 'learner-a', learnerName: 'Ava', yearGroup: 'Y5', membershipRoleLabel: 'Viewer', writable: false }],
       selectedLearnerId: 'learner-a',

--- a/tests/hub-read-models.test.js
+++ b/tests/hub-read-models.test.js
@@ -122,6 +122,132 @@ test('parent hub read model keeps recently missed secure words in the trouble co
   assert.equal(model.dueWork[0].recommendedMode, 'trouble');
 });
 
+test('parent hub read model includes Grammar evidence without replacing Spelling', () => {
+  const learner = makeLearner();
+  const model = buildParentHubReadModel({
+    learner,
+    platformRole: 'parent',
+    membershipRole: 'owner',
+    subjectStates: {
+      spelling: {
+        data: {
+          progress: {
+            possess: { stage: 4, attempts: 4, correct: 4, wrong: 0, dueDay: 999999 },
+          },
+        },
+      },
+      grammar: {
+        data: {
+          mastery: {
+            concepts: {
+              adverbials: {
+                attempts: 1,
+                correct: 0,
+                wrong: 1,
+                strength: 0.1,
+                dueAt: 1,
+                lastSeenAt: '2026-04-24T10:00:00.000Z',
+                lastWrongAt: '2026-04-24T10:00:00.000Z',
+                correctStreak: 0,
+              },
+            },
+            questionTypes: {
+              choose: {
+                attempts: 1,
+                correct: 0,
+                wrong: 1,
+                strength: 0.1,
+                dueAt: 1,
+              },
+            },
+          },
+          misconceptions: {
+            fronted_adverbial_confusion: {
+              count: 1,
+              lastSeenAt: '2026-04-24T10:00:00.000Z',
+            },
+          },
+        },
+        updatedAt: 5000,
+      },
+    },
+    practiceSessions: [
+      {
+        id: 'grammar-complete',
+        learnerId: learner.id,
+        subjectId: 'grammar',
+        sessionKind: 'practice',
+        status: 'completed',
+        summary: { mode: 'smart', answered: 1, correct: 0 },
+        createdAt: 6000,
+        updatedAt: 7000,
+      },
+    ],
+    eventLog: [],
+    now: () => 1_777_000_000_000,
+  });
+
+  assert.equal(model.progressSnapshots[0].subjectId, 'spelling');
+  assert.equal(model.progressSnapshots.some((snapshot) => snapshot.subjectId === 'grammar'), true);
+  assert.equal(model.learnerOverview.weakGrammarConcepts, 1);
+  assert.equal(model.dueWork[0].subjectId, 'grammar');
+  const grammarDueWork = model.dueWork.find((entry) => entry.subjectId === 'grammar');
+  assert.ok(grammarDueWork);
+  assert.match(grammarDueWork.label, /Grammar/);
+  assert.equal(grammarDueWork.recommendedMode, 'smart');
+  assert.ok(model.misconceptionPatterns.some((entry) => entry.subjectId === 'grammar' && /Fronted Adverbial/.test(entry.label)));
+  assert.ok(model.recentSessions.some((entry) => entry.subjectId === 'grammar' && entry.headline === '0/1'));
+});
+
+test('admin hub diagnostics use actionable Grammar focus before empty Spelling fallback', () => {
+  const learner = makeLearner();
+  const model = buildAdminHubReadModel({
+    account: {
+      id: 'adult-admin',
+      selectedLearnerId: learner.id,
+      platformRole: 'admin',
+    },
+    platformRole: 'admin',
+    spellingContentBundle: SEEDED_SPELLING_CONTENT_BUNDLE,
+    memberships: [
+      {
+        learnerId: learner.id,
+        learner,
+        role: 'owner',
+      },
+    ],
+    learnerBundles: {
+      [learner.id]: {
+        subjectStates: {
+          grammar: {
+            data: {
+              mastery: {
+                concepts: {
+                  adverbials: {
+                    attempts: 1,
+                    correct: 0,
+                    wrong: 1,
+                    strength: 0.1,
+                    dueAt: 1,
+                    lastSeenAt: '2026-04-24T10:00:00.000Z',
+                    lastWrongAt: '2026-04-24T10:00:00.000Z',
+                    correctStreak: 0,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    selectedLearnerId: learner.id,
+    now: () => 1_777_000_000_000,
+  });
+
+  assert.equal(model.learnerSupport.selectedDiagnostics.currentFocus.subjectId, 'grammar');
+  assert.match(model.learnerSupport.selectedDiagnostics.currentFocus.label, /Grammar/);
+});
+
 test('admin hub read model reports published release status, validation state, audit stream, and learner diagnostics', () => {
   const learner = makeLearner();
   const model = buildAdminHubReadModel({

--- a/tests/react-grammar-surface.test.js
+++ b/tests/react-grammar-surface.test.js
@@ -143,6 +143,86 @@ test('Grammar monster progress rehydrates from persisted Codex state after reloa
   assert.match(html, /1\/18 Codex/);
 });
 
+test('Grammar analytics renders evidence before reward progress', () => {
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+  const sample = grammarOracleSample('fronted_adverbial_choose');
+
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-start', {
+    payload: {
+      roundLength: 1,
+      templateId: sample.id,
+      seed: sample.sample.seed,
+    },
+  });
+  harness.dispatch('grammar-submit-form', {
+    formData: grammarResponseFormData({ answer: sample.sample.inputSpec.options[0].value }),
+  });
+  harness.dispatch('grammar-continue');
+
+  const html = harness.render();
+
+  assert.match(html, /Misconception repair/);
+  assert.match(html, /Fronted Adverbial pattern/);
+  assert.match(html, /Question-type evidence/);
+  assert.match(html, /Choose the correct sentence/);
+});
+
+test('Grammar analytics renders normalised recent activity before raw attempts', () => {
+  const storage = installMemoryStorage();
+  const harness = createAppHarness({ storage });
+  const learnerId = harness.store.getState().learners.selectedId;
+
+  harness.store.updateSubjectUi('grammar', normaliseGrammarReadModel({
+    phase: 'dashboard',
+    analytics: {
+      recentActivity: [{
+        templateId: 'question_mark_select',
+        questionTypeLabel: 'Choose punctuation',
+        correct: true,
+        score: 1,
+        maxScore: 1,
+      }],
+      recentAttempts: [{
+        templateId: 'legacy_wrong_attempt',
+        result: { correct: false, score: 0, maxScore: 1 },
+      }],
+    },
+  }, learnerId));
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+
+  const html = harness.render();
+
+  assert.match(html, /Choose punctuation/);
+  assert.match(html, /correct · score 1\/1/);
+  assert.doesNotMatch(html, /legacy_wrong_attempt/);
+  assert.doesNotMatch(html, /review · score 0\/1/);
+});
+
+test('Grammar analytics falls back to legacy recent attempt result payloads', () => {
+  const storage = installMemoryStorage();
+  const harness = createAppHarness({ storage });
+  const learnerId = harness.store.getState().learners.selectedId;
+
+  harness.store.updateSubjectUi('grammar', normaliseGrammarReadModel({
+    phase: 'dashboard',
+    analytics: {
+      recentAttempts: [{
+        templateId: 'legacy_correct_attempt',
+        result: { correct: true, score: 1, maxScore: 1 },
+      }],
+    },
+  }, learnerId));
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+
+  const html = harness.render();
+
+  assert.match(html, /legacy_correct_attempt/);
+  assert.match(html, /correct · score 1\/1/);
+  assert.doesNotMatch(html, /review · score 0\/1/);
+});
+
 test('Grammar command responses are pinned to the learner that sent them', async () => {
   let resolveCommand;
   const toasts = [];
@@ -238,6 +318,22 @@ test('Grammar normaliser preserves Worker concept copy over client placeholders'
   assert.equal(clauses.summary, 'Worker-authored concept summary.');
   assert.equal(clauses.punctuationForGrammar, false);
   assert.equal(clauses.attempts, 3);
+});
+
+test('Grammar normaliser parses ISO misconception timestamps in fallback patterns', () => {
+  const isoTimestamp = '2026-04-24T10:00:00.000Z';
+  const grammar = normaliseGrammarReadModel({
+    analytics: {
+      misconceptionCounts: {
+        fronted_adverbial_confusion: {
+          count: 2,
+          lastSeenAt: isoTimestamp,
+        },
+      },
+    },
+  });
+
+  assert.equal(grammar.analytics.misconceptionPatterns[0].lastSeenAt, Date.parse(isoTimestamp));
 });
 
 test('Grammar locked future modes render unavailable without dispatching commands', () => {

--- a/tests/react-hub-surfaces.test.js
+++ b/tests/react-hub-surfaces.test.js
@@ -10,6 +10,10 @@ test('React Parent Hub surface renders readable learner payload and read-only no
   assert.match(html, /Ava/);
   assert.match(html, /Read-only learner/);
   assert.match(html, /viewer memberships/);
+  assert.match(html, /Trouble words/);
+  assert.match(html, /Grammar secured/);
+  assert.match(html, /Grammar: 3\/18 concepts/);
+  assert.doesNotMatch(html, /Subject: spelling/);
   assert.match(html, /Export current learner/);
   assert.match(html, /disabled=""/);
 });

--- a/tests/worker-grammar-subject-runtime.test.js
+++ b/tests/worker-grammar-subject-runtime.test.js
@@ -136,6 +136,44 @@ test('Grammar command route persists subject state, practice session, and events
   DB.close();
 });
 
+test('Grammar read model exposes evidence analytics for misconceptions and question types', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const app = createWorkerApp({ now: () => 1_777_000_000_000 });
+  const sample = readGrammarLegacyOracle().templates.find((template) => template.id === 'fronted_adverbial_choose');
+  seedAccountLearner(DB);
+
+  const start = await postCommand(app, DB, {
+    command: 'start-session',
+    learnerId: 'learner-a',
+    requestId: 'grammar-evidence-start',
+    expectedLearnerRevision: 0,
+    payload: {
+      mode: 'smart',
+      roundLength: 1,
+      templateId: sample.id,
+      seed: sample.sample.seed,
+    },
+  });
+  assert.equal(start.response.status, 200, JSON.stringify(start.body));
+
+  const submit = await postCommand(app, DB, {
+    command: 'submit-answer',
+    learnerId: 'learner-a',
+    requestId: 'grammar-evidence-submit',
+    expectedLearnerRevision: 1,
+    payload: { response: { answer: sample.sample.inputSpec.options[0].value } },
+  });
+
+  assert.equal(submit.response.status, 200, JSON.stringify(submit.body));
+  assert.equal(submit.body.subjectReadModel.analytics.progressSnapshot.trackedConcepts, 1);
+  assert.equal(submit.body.subjectReadModel.analytics.misconceptionPatterns[0].id, 'fronted_adverbial_confusion');
+  assert.equal(submit.body.subjectReadModel.analytics.questionTypeSummary[0].id, 'choose');
+  assert.equal(submit.body.subjectReadModel.analytics.questionTypeSummary[0].wrong, 1);
+  assert.equal(submit.body.subjectReadModel.analytics.recentActivity[0].misconception, 'fronted_adverbial_confusion');
+
+  DB.close();
+});
+
 test('Grammar concept-secured events project monster rewards atomically', async () => {
   const DB = createMigratedSqliteD1Database();
   const now = 1_777_000_000_000;

--- a/worker/src/subjects/grammar/read-models.js
+++ b/worker/src/subjects/grammar/read-models.js
@@ -118,6 +118,135 @@ function statsFromConcepts(concepts) {
   };
 }
 
+function asTs(value, fallback = 0) {
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+  }
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric >= 0 ? numeric : fallback;
+}
+
+function accuracyPercent(correct, wrong) {
+  const total = Math.max(0, Number(correct) || 0) + Math.max(0, Number(wrong) || 0);
+  if (!total) return null;
+  return Math.round((Math.max(0, Number(correct) || 0) / total) * 100);
+}
+
+function humanLabel(id) {
+  return String(id || '')
+    .replace(/_confusion$/, '')
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function progressSnapshotFromConcepts(concepts) {
+  const correct = concepts.reduce((sum, concept) => sum + (Number(concept.correct) || 0), 0);
+  const wrong = concepts.reduce((sum, concept) => sum + (Number(concept.wrong) || 0), 0);
+  return {
+    subjectId: 'grammar',
+    totalConcepts: concepts.length,
+    trackedConcepts: concepts.filter((concept) => (Number(concept.attempts) || 0) > 0).length,
+    securedConcepts: concepts.filter((concept) => concept.status === 'secured').length,
+    dueConcepts: concepts.filter((concept) => concept.status === 'due').length,
+    weakConcepts: concepts.filter((concept) => concept.status === 'weak').length,
+    untouchedConcepts: concepts.filter((concept) => concept.status === 'new').length,
+    accuracyPercent: accuracyPercent(correct, wrong),
+  };
+}
+
+function misconceptionPatternsFromState(state) {
+  const misconceptions = isPlainObject(state?.misconceptions) ? state.misconceptions : {};
+  return Object.entries(misconceptions)
+    .map(([id, rawEntry]) => {
+      const entry = isPlainObject(rawEntry) ? rawEntry : {};
+      return {
+        subjectId: 'grammar',
+        id,
+        label: `${humanLabel(id)} pattern`,
+        count: Math.max(0, Math.floor(Number(entry.count) || 0)),
+        lastSeenAt: asTs(entry.lastSeenAt, 0),
+        source: 'grammar-state',
+      };
+    })
+    .filter((entry) => entry.count > 0)
+    .sort((a, b) => (b.count - a.count) || (b.lastSeenAt - a.lastSeenAt))
+    .slice(0, 5);
+}
+
+function questionTypeSummaryFromState(state, now) {
+  const questionTypes = isPlainObject(state?.mastery?.questionTypes) ? state.mastery.questionTypes : {};
+  return Object.entries(questionTypes)
+    .map(([id, rawNode]) => {
+      const node = rawNode || {};
+      const correct = Number(node.correct) || 0;
+      const wrong = Number(node.wrong) || 0;
+      const attempts = Number(node.attempts) || 0;
+      return {
+        subjectId: 'grammar',
+        id,
+        label: GRAMMAR_QUESTION_TYPES[id] || humanLabel(id),
+        status: grammarConceptStatus(node, now),
+        attempts,
+        correct,
+        wrong,
+        accuracyPercent: accuracyPercent(correct, wrong),
+        strength: Number.isFinite(Number(node.strength)) ? Number(node.strength) : 0.25,
+        dueAt: asTs(node.dueAt, 0),
+      };
+    })
+    .filter((entry) => entry.attempts > 0)
+    .sort((a, b) => {
+      const troubleDelta = (b.wrong - a.wrong) || (Number(a.accuracyPercent ?? 101) - Number(b.accuracyPercent ?? 101));
+      if (troubleDelta) return troubleDelta;
+      return String(a.label).localeCompare(String(b.label));
+    })
+    .slice(0, 6);
+}
+
+function recentActivityFromAttempts(attempts = []) {
+  return (Array.isArray(attempts) ? attempts : [])
+    .slice(-8)
+    .reverse()
+    .map((attempt) => {
+      const result = isPlainObject(attempt?.result) ? attempt.result : {};
+      return {
+        subjectId: 'grammar',
+        templateId: typeof attempt?.templateId === 'string' ? attempt.templateId : '',
+        itemId: typeof attempt?.itemId === 'string' ? attempt.itemId : '',
+        questionType: typeof attempt?.questionType === 'string' ? attempt.questionType : '',
+        questionTypeLabel: GRAMMAR_QUESTION_TYPES[attempt?.questionType] || humanLabel(attempt?.questionType),
+        conceptIds: Array.isArray(attempt?.conceptIds) ? attempt.conceptIds.filter(Boolean).map(String) : [],
+        correct: Boolean(result.correct),
+        score: Number(result.score) || 0,
+        maxScore: Number(result.maxScore) || 1,
+        misconception: typeof result.misconception === 'string' ? result.misconception : '',
+        createdAt: asTs(attempt?.createdAt, 0),
+      };
+    });
+}
+
+function evidenceSummary({ concepts, patterns }) {
+  const snapshot = progressSnapshotFromConcepts(concepts);
+  return [
+    {
+      id: 'retrieval',
+      label: 'Retrieval evidence',
+      detail: `${snapshot.trackedConcepts}/${snapshot.totalConcepts} concepts have answer evidence.`,
+    },
+    {
+      id: 'spacing',
+      label: 'Spaced review',
+      detail: `${snapshot.dueConcepts} due · ${snapshot.weakConcepts} weak · ${snapshot.untouchedConcepts} untouched.`,
+    },
+    {
+      id: 'misconceptions',
+      label: 'Misconception repair',
+      detail: patterns.length ? `${patterns[0].label} is the strongest current signal.` : 'No recurring misconception pattern recorded yet.',
+    },
+  ];
+}
+
 function capabilityMetadata() {
   const labels = {
     learn: 'Learn a concept',
@@ -143,6 +272,8 @@ export function buildGrammarReadModel({
 } = {}) {
   const safeState = cloneSerialisable(state) || {};
   const concepts = conceptMap(safeState, now);
+  const misconceptionPatterns = misconceptionPatternsFromState(safeState);
+  const recentAttempts = Array.isArray(safeState.recentAttempts) ? safeState.recentAttempts.slice(-12).map(cloneSerialisable) : [];
   return {
     subjectId: 'grammar',
     learnerId,
@@ -166,7 +297,12 @@ export function buildGrammarReadModel({
     analytics: {
       concepts,
       misconceptionCounts: isPlainObject(safeState.misconceptions) ? cloneSerialisable(safeState.misconceptions) : {},
-      recentAttempts: Array.isArray(safeState.recentAttempts) ? safeState.recentAttempts.slice(-12).map(cloneSerialisable) : [],
+      misconceptionPatterns,
+      questionTypeSummary: questionTypeSummaryFromState(safeState, now),
+      progressSnapshot: progressSnapshotFromConcepts(concepts),
+      evidenceSummary: evidenceSummary({ concepts, patterns: misconceptionPatterns }),
+      recentAttempts,
+      recentActivity: recentActivityFromAttempts(recentAttempts),
     },
     capabilities: capabilityMetadata(),
     projections: projections ? cloneSerialisable(projections) : null,


### PR DESCRIPTION
## Summary
- add Grammar evidence analytics to Worker read models: progress snapshots, misconception patterns, question-type summaries, and recent activity
- surface the evidence-first Grammar analytics panel while keeping monster progress secondary
- include durable Grammar evidence in Parent Hub read models without replacing existing Spelling summaries

## Verification
- node --test tests/worker-grammar-subject-runtime.test.js tests/react-grammar-surface.test.js tests/hub-read-models.test.js tests/grammar-engine.test.js tests/grammar-rewards.test.js tests/monster-system.test.js tests/worker-spelling-runtime.test.js tests/worker-tts-route.test.js
- npm test
- npm run check
- git diff --check origin/main...HEAD