### PR TITLE
fix(spelling): preserve monster evolution celebrations

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -45,6 +45,9 @@ import {
   monsterSummaryFromSpellingAnalytics,
 } from './platform/game/monster-system.js';
 import {
+  acknowledgeMonsterCelebrationEvents,
+} from './platform/game/monster-celebration-acks.js';
+import {
   exportLearnerSnapshot,
   exportPlatformSnapshot,
   importPlatformSnapshot,
@@ -1817,6 +1820,7 @@ function handleGlobalAction(action, data) {
   }
 
   if (action === 'monster-celebration-dismiss') {
+    acknowledgeMonsterCelebrationEvents(store.getState().monsterCelebrations?.queue?.[0], { learnerId });
     store.dismissMonsterCelebration();
     return true;
   }
@@ -1880,13 +1884,15 @@ function setPunctuationRuntimeError(message) {
 }
 
 function applyPunctuationCommandResponse(response) {
+  const responseLearnerId = String(response?.learnerId || store.getState().learners?.selectedId || '');
+  store.reloadFromRepositories({ preserveRoute: true, preserveMonsterCelebrations: true });
+  if (responseLearnerId && store.getState().learners?.selectedId !== responseLearnerId) return;
   if (response?.projections?.rewards?.toastEvents?.length) {
     store.pushToasts(response.projections.rewards.toastEvents);
   }
   if (response?.projections?.rewards?.events?.length) {
     store.pushMonsterCelebrations(response.projections.rewards.events);
   }
-  store.reloadFromRepositories({ preserveRoute: true });
 }
 
 const pendingPunctuationCommandKeys = new Set();

--- a/src/main.js
+++ b/src/main.js
@@ -46,6 +46,8 @@ import {
 } from './platform/game/monster-system.js';
 import {
   acknowledgeMonsterCelebrationEvents,
+  clearAllMonsterCelebrationAcknowledgements,
+  clearMonsterCelebrationAcknowledgements,
 } from './platform/game/monster-celebration-acks.js';
 import {
   exportLearnerSnapshot,
@@ -828,6 +830,7 @@ function deleteLearnerFromServerSyncedAccount(learnerId) {
   const nextLearners = learnerSnapshotWithout(learnerId);
   if (!nextLearners) return false;
   runtimeBoundary.clearLearner(learnerId);
+  clearMonsterCelebrationAcknowledgements(learnerId);
   repositories.learners.write(nextLearners);
   store.reloadFromRepositories({ preserveRoute: true });
   return true;
@@ -853,6 +856,7 @@ async function resetServerSyncedLearnerProgress(learnerId) {
   await parseApiJson(response);
   await repositories.hydrate({ cacheScope: 'learner-reset-progress' });
   runtimeBoundary.clearLearner(learnerId);
+  clearMonsterCelebrationAcknowledgements(learnerId);
   store.clearMonsterCelebrations();
   store.reloadFromRepositories({ preserveRoute: true });
 }
@@ -1698,6 +1702,7 @@ function handleGlobalAction(action, data) {
       deleteLearnerFromServerSyncedAccount(learnerId);
     } else {
       runtimeBoundary.clearLearner(learnerId);
+      clearMonsterCelebrationAcknowledgements(learnerId);
       resetLearnerData(learnerId);
       store.deleteLearner(learnerId);
     }
@@ -1714,6 +1719,7 @@ function handleGlobalAction(action, data) {
       });
     } else {
       runtimeBoundary.clearLearner(learnerId);
+      clearMonsterCelebrationAcknowledgements(learnerId);
       resetLearnerData(learnerId);
       store.resetSubjectUi();
     }
@@ -1725,6 +1731,7 @@ function handleGlobalAction(action, data) {
     if (!globalThis.confirm('Reset all app data for every learner on this browser?')) return true;
     tts.stop();
     runtimeBoundary.clearAll();
+    clearAllMonsterCelebrationAcknowledgements();
     store.clearAllProgress();
     globalThis.location.reload();
     return true;

--- a/src/platform/app/create-app-controller.js
+++ b/src/platform/app/create-app-controller.js
@@ -14,6 +14,8 @@ import {
 } from '../game/monster-celebrations.js';
 import {
   acknowledgeMonsterCelebrationEvents,
+  clearAllMonsterCelebrationAcknowledgements,
+  clearMonsterCelebrationAcknowledgements,
 } from '../game/monster-celebration-acks.js';
 import { SUBJECTS } from '../core/subject-registry.js';
 import {
@@ -347,6 +349,7 @@ export function createAppController({
     if (action === 'learner-delete') {
       if (!ports.confirm('Warning: delete the current learner and all their subject progress and codex state?')) return true;
       runtimeBoundary.clearLearner(learnerId);
+      clearMonsterCelebrationAcknowledgements(learnerId);
       resetLearnerData(learnerId);
       store.deleteLearner(learnerId);
       return true;
@@ -356,6 +359,7 @@ export function createAppController({
       if (!ports.confirm('Warning: reset subject progress and codex rewards for the current learner?')) return true;
       tts.stop();
       runtimeBoundary.clearLearner(learnerId);
+      clearMonsterCelebrationAcknowledgements(learnerId);
       resetLearnerData(learnerId);
       store.resetSubjectUi();
       return true;
@@ -365,6 +369,7 @@ export function createAppController({
       if (!ports.confirm('Reset all app data for every learner on this browser?')) return true;
       tts.stop();
       runtimeBoundary.clearAll();
+      clearAllMonsterCelebrationAcknowledgements();
       store.clearAllProgress();
       ports.reload();
       return true;

--- a/src/platform/app/create-app-controller.js
+++ b/src/platform/app/create-app-controller.js
@@ -12,6 +12,9 @@ import {
   shouldDelayMonsterCelebrations,
   spellingSessionEnded,
 } from '../game/monster-celebrations.js';
+import {
+  acknowledgeMonsterCelebrationEvents,
+} from '../game/monster-celebration-acks.js';
 import { SUBJECTS } from '../core/subject-registry.js';
 import {
   exposedSubjects,
@@ -392,6 +395,7 @@ export function createAppController({
     }
 
     if (action === 'monster-celebration-dismiss') {
+      acknowledgeMonsterCelebrationEvents(store.getState().monsterCelebrations?.queue?.[0], { learnerId });
       store.dismissMonsterCelebration();
       return true;
     }

--- a/src/platform/core/store.js
+++ b/src/platform/core/store.js
@@ -302,12 +302,16 @@ export function createStore(subjects, { repositories, cacheSubjectUiWrites = fal
     return resolvedRepositories.learners.write(nextLearners);
   }
 
-  function reloadFromRepositories({ preserveRoute = false } = {}) {
+  function reloadFromRepositories({ preserveRoute = false, preserveMonsterCelebrations = false } = {}) {
     const previousRoute = state.route;
+    const previousMonsterCelebrations = state.monsterCelebrations;
     const nextState = stateFromRepositories(registry, resolvedRepositories);
     state = sanitiseState({
       ...nextState,
       route: preserveRoute ? previousRoute : nextState.route,
+      monsterCelebrations: preserveMonsterCelebrations
+        ? previousMonsterCelebrations
+        : nextState.monsterCelebrations,
     }, registry);
     notify();
     return state;

--- a/src/platform/game/monster-celebration-acks.js
+++ b/src/platform/game/monster-celebration-acks.js
@@ -1,0 +1,85 @@
+import {
+  isMonsterCelebrationEvent,
+  normaliseMonsterCelebrationEvents,
+} from './monster-celebrations.js';
+
+const ACK_STORAGE_KEY = 'ks2-platform-v2.monster-celebration-acks';
+const ACK_LIMIT = 500;
+
+function storage() {
+  return globalThis.localStorage || null;
+}
+
+function eventId(event) {
+  return typeof event?.id === 'string' && event.id ? event.id : '';
+}
+
+function readSnapshot(store = storage()) {
+  try {
+    const raw = store?.getItem?.(ACK_STORAGE_KEY);
+    const parsed = raw ? JSON.parse(raw) : {};
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeSnapshot(snapshot, store = storage()) {
+  try {
+    store?.setItem?.(ACK_STORAGE_KEY, JSON.stringify(snapshot || {}));
+  } catch {
+    // Best-effort acknowledgement only; reward state remains authoritative.
+  }
+}
+
+function learnerKey(learnerId) {
+  return typeof learnerId === 'string' && learnerId ? learnerId : 'default';
+}
+
+export function acknowledgedMonsterCelebrationIds(learnerId, { store = storage() } = {}) {
+  const snapshot = readSnapshot(store);
+  const ids = snapshot[learnerKey(learnerId)];
+  return new Set(Array.isArray(ids) ? ids.filter((id) => typeof id === 'string' && id) : []);
+}
+
+export function acknowledgeMonsterCelebrationEvents(events, { learnerId = '', store = storage() } = {}) {
+  const validEvents = normaliseMonsterCelebrationEvents(events);
+  if (!validEvents.length) return false;
+  const key = learnerKey(learnerId || validEvents[0]?.learnerId);
+  const snapshot = readSnapshot(store);
+  const current = Array.isArray(snapshot[key]) ? snapshot[key].filter((id) => typeof id === 'string' && id) : [];
+  const ids = new Set(current);
+  for (const event of validEvents) {
+    const id = eventId(event);
+    if (id) ids.add(id);
+  }
+  snapshot[key] = [...ids].slice(-ACK_LIMIT);
+  writeSnapshot(snapshot, store);
+  return true;
+}
+
+export function unacknowledgedMonsterCelebrationEvents(events, {
+  learnerId = '',
+  ignoredIds = new Set(),
+  limit = 1,
+  acknowledgeSkipped = false,
+  store = storage(),
+} = {}) {
+  const acknowledgedIds = acknowledgedMonsterCelebrationIds(learnerId, { store });
+  const ignored = ignoredIds instanceof Set ? ignoredIds : new Set();
+  const candidates = (Array.isArray(events) ? events : [])
+    .filter(isMonsterCelebrationEvent)
+    .filter((event) => !learnerId || event.learnerId === learnerId)
+    .filter((event) => {
+      const id = eventId(event);
+      return id && !acknowledgedIds.has(id) && !ignored.has(id);
+    })
+    .sort((a, b) => (Number(a.createdAt) || 0) - (Number(b.createdAt) || 0));
+
+  const count = Math.max(1, Number(limit) || 1);
+  const selected = normaliseMonsterCelebrationEvents(candidates.slice(-count));
+  if (acknowledgeSkipped && candidates.length > selected.length) {
+    acknowledgeMonsterCelebrationEvents(candidates.slice(0, -selected.length), { learnerId, store });
+  }
+  return selected;
+}

--- a/src/platform/game/monster-celebration-acks.js
+++ b/src/platform/game/monster-celebration-acks.js
@@ -5,6 +5,7 @@ import {
 
 const ACK_STORAGE_KEY = 'ks2-platform-v2.monster-celebration-acks';
 const ACK_LIMIT = 500;
+const DEFAULT_BASELINE_RECENT_WINDOW_MS = 3 * 24 * 60 * 60 * 1000;
 
 function storage() {
   return globalThis.localStorage || null;
@@ -36,10 +37,36 @@ function learnerKey(learnerId) {
   return typeof learnerId === 'string' && learnerId ? learnerId : 'default';
 }
 
+function normaliseLearnerAckEntry(value) {
+  if (Array.isArray(value)) {
+    return {
+      ids: value.filter((id) => typeof id === 'string' && id).slice(-ACK_LIMIT),
+      baselineAt: 0,
+    };
+  }
+  const raw = value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+  return {
+    ids: Array.isArray(raw.ids)
+      ? raw.ids.filter((id) => typeof id === 'string' && id).slice(-ACK_LIMIT)
+      : [],
+    baselineAt: Math.max(0, Number(raw.baselineAt) || 0),
+  };
+}
+
+function learnerAckEntry(snapshot, learnerId) {
+  return normaliseLearnerAckEntry(snapshot[learnerKey(learnerId)]);
+}
+
+function saveLearnerAckEntry(snapshot, learnerId, entry) {
+  snapshot[learnerKey(learnerId)] = {
+    ids: Array.isArray(entry?.ids) ? entry.ids.filter((id) => typeof id === 'string' && id).slice(-ACK_LIMIT) : [],
+    baselineAt: Math.max(0, Number(entry?.baselineAt) || 0),
+  };
+}
+
 export function acknowledgedMonsterCelebrationIds(learnerId, { store = storage() } = {}) {
   const snapshot = readSnapshot(store);
-  const ids = snapshot[learnerKey(learnerId)];
-  return new Set(Array.isArray(ids) ? ids.filter((id) => typeof id === 'string' && id) : []);
+  return new Set(learnerAckEntry(snapshot, learnerId).ids);
 }
 
 export function acknowledgeMonsterCelebrationEvents(events, { learnerId = '', store = storage() } = {}) {
@@ -47,15 +74,44 @@ export function acknowledgeMonsterCelebrationEvents(events, { learnerId = '', st
   if (!validEvents.length) return false;
   const key = learnerKey(learnerId || validEvents[0]?.learnerId);
   const snapshot = readSnapshot(store);
-  const current = Array.isArray(snapshot[key]) ? snapshot[key].filter((id) => typeof id === 'string' && id) : [];
-  const ids = new Set(current);
+  const current = normaliseLearnerAckEntry(snapshot[key]);
+  const ids = new Set(current.ids);
   for (const event of validEvents) {
     const id = eventId(event);
     if (id) ids.add(id);
   }
-  snapshot[key] = [...ids].slice(-ACK_LIMIT);
+  saveLearnerAckEntry(snapshot, key, {
+    ...current,
+    ids: [...ids],
+  });
   writeSnapshot(snapshot, store);
   return true;
+}
+
+function baselineExistingEvents(events, {
+  learnerId,
+  baselineRecentWindowMs,
+  now,
+  store,
+} = {}) {
+  const snapshot = readSnapshot(store);
+  const entry = learnerAckEntry(snapshot, learnerId);
+  if (entry.baselineAt) return entry;
+
+  const cutoff = Math.max(0, Number(now) || Date.now()) - Math.max(0, Number(baselineRecentWindowMs) || 0);
+  const staleIds = (Array.isArray(events) ? events : [])
+    .filter((event) => {
+      const createdAt = Number(event?.createdAt) || 0;
+      return eventId(event) && (!createdAt || createdAt < cutoff);
+    })
+    .map(eventId);
+
+  saveLearnerAckEntry(snapshot, learnerId, {
+    ids: [...new Set([...entry.ids, ...staleIds])],
+    baselineAt: Math.max(0, Number(now) || Date.now()),
+  });
+  writeSnapshot(snapshot, store);
+  return learnerAckEntry(snapshot, learnerId);
 }
 
 export function unacknowledgedMonsterCelebrationEvents(events, {
@@ -63,13 +119,25 @@ export function unacknowledgedMonsterCelebrationEvents(events, {
   ignoredIds = new Set(),
   limit = 1,
   acknowledgeSkipped = false,
+  baselineExisting = false,
+  baselineRecentWindowMs = DEFAULT_BASELINE_RECENT_WINDOW_MS,
+  now = Date.now(),
   store = storage(),
 } = {}) {
+  const scopedEvents = (Array.isArray(events) ? events : [])
+    .filter(isMonsterCelebrationEvent)
+    .filter((event) => !learnerId || event.learnerId === learnerId);
+  if (baselineExisting) {
+    baselineExistingEvents(scopedEvents, {
+      learnerId,
+      baselineRecentWindowMs,
+      now,
+      store,
+    });
+  }
   const acknowledgedIds = acknowledgedMonsterCelebrationIds(learnerId, { store });
   const ignored = ignoredIds instanceof Set ? ignoredIds : new Set();
-  const candidates = (Array.isArray(events) ? events : [])
-    .filter(isMonsterCelebrationEvent)
-    .filter((event) => !learnerId || event.learnerId === learnerId)
+  const candidates = scopedEvents
     .filter((event) => {
       const id = eventId(event);
       return id && !acknowledgedIds.has(id) && !ignored.has(id);

--- a/src/platform/game/monster-celebration-acks.js
+++ b/src/platform/game/monster-celebration-acks.js
@@ -70,6 +70,29 @@ function normaliseIdSet(value) {
   return new Set(values.filter((id) => typeof id === 'string' && id));
 }
 
+export function clearMonsterCelebrationAcknowledgements(learnerId, { store = storage() } = {}) {
+  if (!learnerId) return false;
+  const snapshot = readSnapshot(store);
+  const key = learnerKey(learnerId);
+  if (!Object.prototype.hasOwnProperty.call(snapshot, key)) return false;
+  delete snapshot[key];
+  writeSnapshot(snapshot, store);
+  return true;
+}
+
+export function clearAllMonsterCelebrationAcknowledgements({ store = storage() } = {}) {
+  try {
+    if (typeof store?.removeItem === 'function') {
+      store.removeItem(ACK_STORAGE_KEY);
+    } else {
+      writeSnapshot({}, store);
+    }
+  } catch {
+    writeSnapshot({}, store);
+  }
+  return true;
+}
+
 export function acknowledgedMonsterCelebrationIds(learnerId, { store = storage() } = {}) {
   const snapshot = readSnapshot(store);
   return new Set(learnerAckEntry(snapshot, learnerId).ids);

--- a/src/platform/game/monster-celebration-acks.js
+++ b/src/platform/game/monster-celebration-acks.js
@@ -118,7 +118,6 @@ export function unacknowledgedMonsterCelebrationEvents(events, {
   learnerId = '',
   ignoredIds = new Set(),
   limit = 1,
-  acknowledgeSkipped = false,
   baselineExisting = false,
   baselineRecentWindowMs = DEFAULT_BASELINE_RECENT_WINDOW_MS,
   now = Date.now(),
@@ -145,9 +144,5 @@ export function unacknowledgedMonsterCelebrationEvents(events, {
     .sort((a, b) => (Number(a.createdAt) || 0) - (Number(b.createdAt) || 0));
 
   const count = Math.max(1, Number(limit) || 1);
-  const selected = normaliseMonsterCelebrationEvents(candidates.slice(-count));
-  if (acknowledgeSkipped && candidates.length > selected.length) {
-    acknowledgeMonsterCelebrationEvents(candidates.slice(0, -selected.length), { learnerId, store });
-  }
-  return selected;
+  return normaliseMonsterCelebrationEvents(candidates.slice(-count));
 }

--- a/src/platform/game/monster-celebration-acks.js
+++ b/src/platform/game/monster-celebration-acks.js
@@ -5,7 +5,6 @@ import {
 
 const ACK_STORAGE_KEY = 'ks2-platform-v2.monster-celebration-acks';
 const ACK_LIMIT = 500;
-const DEFAULT_BASELINE_RECENT_WINDOW_MS = 3 * 24 * 60 * 60 * 1000;
 
 function storage() {
   return globalThis.localStorage || null;
@@ -64,6 +63,13 @@ function saveLearnerAckEntry(snapshot, learnerId, entry) {
   };
 }
 
+function normaliseIdSet(value) {
+  if (value == null) return null;
+  const values = value instanceof Set ? Array.from(value) : value;
+  if (!Array.isArray(values)) return new Set();
+  return new Set(values.filter((id) => typeof id === 'string' && id));
+}
+
 export function acknowledgedMonsterCelebrationIds(learnerId, { store = storage() } = {}) {
   const snapshot = readSnapshot(store);
   return new Set(learnerAckEntry(snapshot, learnerId).ids);
@@ -90,7 +96,7 @@ export function acknowledgeMonsterCelebrationEvents(events, { learnerId = '', st
 
 function baselineExistingEvents(events, {
   learnerId,
-  baselineRecentWindowMs,
+  baselineEventIds = null,
   now,
   store,
 } = {}) {
@@ -98,16 +104,16 @@ function baselineExistingEvents(events, {
   const entry = learnerAckEntry(snapshot, learnerId);
   if (entry.baselineAt) return entry;
 
-  const cutoff = Math.max(0, Number(now) || Date.now()) - Math.max(0, Number(baselineRecentWindowMs) || 0);
-  const staleIds = (Array.isArray(events) ? events : [])
+  const baselineIds = normaliseIdSet(baselineEventIds);
+  const existingIds = (Array.isArray(events) ? events : [])
     .filter((event) => {
-      const createdAt = Number(event?.createdAt) || 0;
-      return eventId(event) && (!createdAt || createdAt < cutoff);
+      const id = eventId(event);
+      return id && (!baselineIds || baselineIds.has(id));
     })
     .map(eventId);
 
   saveLearnerAckEntry(snapshot, learnerId, {
-    ids: [...new Set([...entry.ids, ...staleIds])],
+    ids: [...new Set([...entry.ids, ...existingIds])],
     baselineAt: Math.max(0, Number(now) || Date.now()),
   });
   writeSnapshot(snapshot, store);
@@ -119,7 +125,7 @@ export function unacknowledgedMonsterCelebrationEvents(events, {
   ignoredIds = new Set(),
   limit = 1,
   baselineExisting = false,
-  baselineRecentWindowMs = DEFAULT_BASELINE_RECENT_WINDOW_MS,
+  baselineEventIds = null,
   now = Date.now(),
   store = storage(),
 } = {}) {
@@ -129,7 +135,7 @@ export function unacknowledgedMonsterCelebrationEvents(events, {
   if (baselineExisting) {
     baselineExistingEvents(scopedEvents, {
       learnerId,
-      baselineRecentWindowMs,
+      baselineEventIds,
       now,
       store,
     });

--- a/src/subjects/spelling/remote-actions.js
+++ b/src/subjects/spelling/remote-actions.js
@@ -2,6 +2,14 @@ import {
   WORD_BANK_FILTER_IDS,
   WORD_BANK_YEAR_FILTER_IDS,
 } from './components/spelling-view-model.js';
+import {
+  normaliseMonsterCelebrationEvents,
+  shouldDelayMonsterCelebrations,
+  spellingSessionEnded,
+} from '../../platform/game/monster-celebrations.js';
+import {
+  unacknowledgedMonsterCelebrationEvents,
+} from '../../platform/game/monster-celebration-acks.js';
 
 const READ_ONLY_MESSAGE = 'Practice is read-only while sync is degraded. Retry sync before continuing.';
 const SETUP_PREF_SAVE_DEBOUNCE_MS = 120;
@@ -120,6 +128,24 @@ export function mergeWordBankAnalytics(current, incoming, { append = false } = {
   };
 }
 
+function eventIds(events) {
+  return new Set((Array.isArray(events) ? events : [])
+    .map((event) => (typeof event?.id === 'string' ? event.id : ''))
+    .filter(Boolean));
+}
+
+function visibleMonsterCelebrationIds(state = {}) {
+  return eventIds([
+    ...(state.monsterCelebrations?.pending || []),
+    ...(state.monsterCelebrations?.queue || []),
+  ]);
+}
+
+function spellingRewardEvents(events) {
+  return (Array.isArray(events) ? events : [])
+    .filter((event) => !event?.subjectId || event.subjectId === 'spelling');
+}
+
 export function createRemoteSpellingActionHandler({
   store,
   services,
@@ -146,19 +172,75 @@ export function createRemoteSpellingActionHandler({
     return state.subjectUi?.spelling?.analytics || null;
   }
 
-  function applyCommandResponse(response, { command = '', learnerId = '', preferenceVersion = 0 } = {}) {
-    if (response?.projections?.rewards?.toastEvents?.length) {
-      store.pushToasts(response.projections.rewards.toastEvents);
+  function currentSpellingRewardEventIds(learnerId) {
+    const list = store.repositories?.eventLog?.list;
+    if (typeof list !== 'function') return null;
+    try {
+      return eventIds(spellingRewardEvents(list.call(store.repositories.eventLog, learnerId) || []));
+    } catch {
+      return null;
     }
-    if (response?.projections?.rewards?.events?.length) {
-      store.pushMonsterCelebrations(response.projections.rewards.events);
-    }
-    if (shouldStopSpellingTtsForCommandResponse(command, response)) {
+  }
+
+  function applyCommandResponse(response, {
+    command = '',
+    learnerId: requestedLearnerId = '',
+    preferenceVersion = 0,
+    compensationBaselineEventIds = null,
+  } = {}) {
+    const previousState = appState();
+    const previousSubjectUi = previousState.subjectUi?.spelling || null;
+    const learnerId = String(response?.learnerId || requestedLearnerId || previousState.learners?.selectedId || '');
+    const wasSelectedLearner = !learnerId || previousState.learners?.selectedId === learnerId;
+    const rewardProjection = response?.projections?.rewards || {};
+    const toastEvents = Array.isArray(rewardProjection.toastEvents) ? rewardProjection.toastEvents : [];
+    const responseMonsterEvents = normaliseMonsterCelebrationEvents(rewardProjection.events || []);
+
+    if (wasSelectedLearner && shouldStopSpellingTtsForCommandResponse(command, response)) {
       tts.stop();
     }
-    store.reloadFromRepositories({ preserveRoute: true });
+    store.reloadFromRepositories({ preserveRoute: true, preserveMonsterCelebrations: true });
     reconcilePreferenceSaveResponse({ command, learnerId, preferenceVersion });
-    if (response?.audio?.promptToken) {
+    const nextState = appState();
+    const nextSubjectUi = response?.subjectReadModel || response?.state || nextState.subjectUi?.spelling || null;
+    const isSelectedLearner = !learnerId || nextState.learners?.selectedId === learnerId;
+
+    if (isSelectedLearner && toastEvents.length) {
+      store.pushToasts(toastEvents);
+    }
+
+    const endedSession = spellingSessionEnded(previousSubjectUi, nextSubjectUi);
+    let monsterEvents = responseMonsterEvents;
+    if (isSelectedLearner && endedSession && !monsterEvents.length) {
+      const ignoredIds = new Set([
+        ...eventIds(rewardProjection.events || []),
+        ...visibleMonsterCelebrationIds(nextState),
+      ]);
+      monsterEvents = unacknowledgedMonsterCelebrationEvents(
+        spellingRewardEvents(store.repositories?.eventLog?.list?.(learnerId) || []),
+        {
+          learnerId,
+          ignoredIds,
+          limit: 1,
+          baselineExisting: true,
+          baselineEventIds: compensationBaselineEventIds,
+        },
+      );
+    }
+
+    if (isSelectedLearner && monsterEvents.length) {
+      if (shouldDelayMonsterCelebrations('spelling', previousSubjectUi, nextSubjectUi)) {
+        store.deferMonsterCelebrations(monsterEvents);
+      } else {
+        store.pushMonsterCelebrations(monsterEvents);
+      }
+    }
+
+    if (isSelectedLearner && endedSession) {
+      store.releaseMonsterCelebrations();
+    }
+
+    if (isSelectedLearner && response?.audio?.promptToken) {
       tts.speak(response.audio);
     }
   }
@@ -214,13 +296,19 @@ export function createRemoteSpellingActionHandler({
     const state = appState();
     const learnerId = requestedLearnerId || state.learners?.selectedId;
     if (!learnerId) return null;
+    const compensationBaselineEventIds = currentSpellingRewardEventIds(learnerId);
     const response = await subjectCommands.send({
       subjectId: 'spelling',
       learnerId,
       command,
       payload,
     });
-    applyCommandResponse(response, { command, learnerId, preferenceVersion });
+    applyCommandResponse(response, {
+      command,
+      learnerId,
+      preferenceVersion,
+      compensationBaselineEventIds,
+    });
     return response;
   }
 

--- a/tests/app-controller.test.js
+++ b/tests/app-controller.test.js
@@ -13,6 +13,10 @@ import { createAppController } from '../src/platform/app/create-app-controller.j
 import { createLocalAppController } from '../src/platform/app/create-local-app-controller.js';
 import { createLocalPlatformRepositories } from '../src/platform/core/repositories/index.js';
 import {
+  acknowledgeMonsterCelebrationEvents,
+  acknowledgedMonsterCelebrationIds,
+} from '../src/platform/game/monster-celebration-acks.js';
+import {
   LOCAL_CODEX_REVIEW_LEARNER_ID,
   LOCAL_CODEX_STAGE_REVIEW_LEARNER_IDS,
 } from '../src/platform/core/local-review-profile.js';
@@ -200,6 +204,57 @@ test('controller dispatches profile TTS test through the selected provider', () 
     bufferedGeminiVoice: 'Iapetus',
     kind: 'test',
   });
+});
+
+test('controller clears monster celebration acknowledgements on learner reset, delete, and full reset', () => {
+  installMemoryStorage();
+  const controller = createLocalAppController();
+  const learnerA = controller.store.getState().learners.selectedId;
+  const learnerAReward = {
+    id: 'reward.monster:learner-a:inklet:evolve:1:2',
+    type: 'reward.monster',
+    kind: 'evolve',
+    learnerId: learnerA,
+    monsterId: 'inklet',
+    monster: { id: 'inklet', name: 'Inklet' },
+    previous: { stage: 0, level: 1, caught: true, branch: 'b1' },
+    next: { stage: 1, level: 2, caught: true, branch: 'b1' },
+    createdAt: Date.now(),
+  };
+
+  acknowledgeMonsterCelebrationEvents(learnerAReward, { learnerId: learnerA });
+  assert.equal(acknowledgedMonsterCelebrationIds(learnerA).has(learnerAReward.id), true);
+
+  controller.dispatch('learner-reset-progress');
+
+  assert.equal(acknowledgedMonsterCelebrationIds(learnerA).has(learnerAReward.id), false);
+
+  const learnerB = controller.store.createLearner({ name: 'Bryn', yearGroup: 'Y5' }).id;
+  const learnerBReward = {
+    id: 'reward.monster:learner-b:phaeton:evolve:1:2',
+    type: 'reward.monster',
+    kind: 'evolve',
+    learnerId: learnerB,
+    monsterId: 'phaeton',
+    monster: { id: 'phaeton', name: 'Phaeton' },
+    previous: { stage: 0, level: 1, caught: true, branch: 'b1' },
+    next: { stage: 1, level: 2, caught: true, branch: 'b1' },
+    createdAt: Date.now(),
+  };
+
+  acknowledgeMonsterCelebrationEvents(learnerBReward, { learnerId: learnerB });
+  assert.equal(acknowledgedMonsterCelebrationIds(learnerB).has(learnerBReward.id), true);
+
+  controller.dispatch('learner-delete');
+
+  assert.equal(acknowledgedMonsterCelebrationIds(learnerB).has(learnerBReward.id), false);
+
+  acknowledgeMonsterCelebrationEvents(learnerAReward, { learnerId: learnerA });
+  assert.equal(acknowledgedMonsterCelebrationIds(learnerA).has(learnerAReward.id), true);
+
+  controller.dispatch('platform-reset-all');
+
+  assert.equal(acknowledgedMonsterCelebrationIds(learnerA).has(learnerAReward.id), false);
 });
 
 test('controller dispatches spelling transitions through store, repositories, events, and TTS', () => {

--- a/tests/spelling-remote-actions.test.js
+++ b/tests/spelling-remote-actions.test.js
@@ -611,6 +611,105 @@ test('remote spelling compensation baselines old logged celebrations when ack st
   assert.equal(getState().monsterCelebrations.queue.length, 0);
 });
 
+test('remote spelling compensation preserves older recent missed celebrations for later replay', () => {
+  installMemoryStorage();
+  const now = Date.now();
+  const directEvolution = {
+    id: 'reward.monster:learner-a:inklet:evolve:1:2',
+    type: 'reward.monster',
+    kind: 'evolve',
+    learnerId: 'learner-a',
+    subjectId: 'spelling',
+    monsterId: 'inklet',
+    monster: {
+      id: 'inklet',
+      name: 'Inklet',
+      accent: '#3E6FA8',
+    },
+    previous: { mastered: 9, stage: 0, level: 1, caught: true, branch: 'b1' },
+    next: { mastered: 10, stage: 1, level: 2, caught: true, branch: 'b1' },
+    createdAt: now - 2000,
+  };
+  const phaetonEvolution = {
+    id: 'reward.monster:learner-a:phaeton:evolve:1:2',
+    type: 'reward.monster',
+    kind: 'evolve',
+    learnerId: 'learner-a',
+    subjectId: 'spelling',
+    monsterId: 'phaeton',
+    monster: {
+      id: 'phaeton',
+      name: 'Phaeton',
+      accent: '#7D5CC6',
+    },
+    previous: { mastered: 29, stage: 1, level: 2, caught: true, branch: 'b2' },
+    next: { mastered: 30, stage: 2, level: 3, caught: true, branch: 'b2' },
+    createdAt: now - 1000,
+  };
+  const { calls, getState, store } = createStoreHarness({
+    repositories: {
+      eventLog: {
+        list() {
+          return [directEvolution, phaetonEvolution];
+        },
+      },
+    },
+  });
+  const handler = createRemoteSpellingActionHandler({
+    store,
+    services: { spelling: {} },
+    tts: createTtsHarness(),
+    readModels: { readJson: async () => ({}) },
+    subjectCommands: { send: async () => ({}) },
+  });
+
+  handler.applyCommandResponse({
+    learnerId: 'learner-a',
+    subjectReadModel: { phase: 'summary' },
+    projections: {
+      rewards: {
+        toastEvents: [],
+        events: [],
+      },
+    },
+  }, { command: 'end-session' });
+
+  assert.equal(getState().monsterCelebrations.queue.length, 1);
+  assert.equal(getState().monsterCelebrations.queue[0].id, phaetonEvolution.id);
+
+  acknowledgeMonsterCelebrationEvents(phaetonEvolution, { learnerId: 'learner-a' });
+  store.dismissMonsterCelebration();
+  store.updateSubjectUi('spelling', {
+    phase: 'session',
+    session: {
+      id: 'session-b',
+      currentSlug: 'necessary',
+      phase: 'answer',
+      promptCount: 1,
+    },
+  });
+  calls.length = 0;
+
+  handler.applyCommandResponse({
+    learnerId: 'learner-a',
+    subjectReadModel: { phase: 'summary' },
+    projections: {
+      rewards: {
+        toastEvents: [],
+        events: [],
+      },
+    },
+  }, { command: 'end-session' });
+
+  assert.deepEqual(calls.map(([name]) => name), [
+    'reloadFromRepositories',
+    'deferMonsterCelebrations',
+    'releaseMonsterCelebrations',
+  ]);
+  assert.equal(getState().monsterCelebrations.queue.length, 1);
+  assert.equal(getState().monsterCelebrations.queue[0].id, directEvolution.id);
+});
+
 test('remote spelling command response ignores stale learner TTS side effects', () => {
   const { store } = createStoreHarness({
     learners: { selectedId: 'learner-b' },

--- a/tests/spelling-remote-actions.test.js
+++ b/tests/spelling-remote-actions.test.js
@@ -5,6 +5,8 @@ import {
   createRemoteSpellingActionHandler,
   spellingCommandDedupeKey,
 } from '../src/subjects/spelling/remote-actions.js';
+import { acknowledgeMonsterCelebrationEvents } from '../src/platform/game/monster-celebration-acks.js';
+import { installMemoryStorage } from './helpers/memory-storage.js';
 
 function flushPromises() {
   return Promise.resolve().then(() => Promise.resolve());
@@ -41,6 +43,10 @@ function createStoreHarness(initial = {}) {
         error: '',
       },
     },
+    monsterCelebrations: {
+      pending: [],
+      queue: [],
+    },
     transientUi: {},
     ...(initial || {}),
   };
@@ -72,10 +78,69 @@ function createStoreHarness(initial = {}) {
       calls.push(['pushToasts', toasts]);
     },
     pushMonsterCelebrations(events) {
+      state = {
+        ...state,
+        monsterCelebrations: {
+          ...state.monsterCelebrations,
+          queue: [...(state.monsterCelebrations?.queue || []), ...(Array.isArray(events) ? events : [events])],
+        },
+      };
       calls.push(['pushMonsterCelebrations', events]);
     },
+    deferMonsterCelebrations(events) {
+      state = {
+        ...state,
+        monsterCelebrations: {
+          ...state.monsterCelebrations,
+          pending: [...(state.monsterCelebrations?.pending || []), ...(Array.isArray(events) ? events : [events])],
+        },
+      };
+      calls.push(['deferMonsterCelebrations', events]);
+      return true;
+    },
+    releaseMonsterCelebrations() {
+      state = {
+        ...state,
+        monsterCelebrations: {
+          pending: [],
+          queue: [
+            ...(state.monsterCelebrations?.queue || []),
+            ...(state.monsterCelebrations?.pending || []),
+          ],
+        },
+      };
+      calls.push(['releaseMonsterCelebrations']);
+      return true;
+    },
+    dismissMonsterCelebration() {
+      state = {
+        ...state,
+        monsterCelebrations: {
+          ...state.monsterCelebrations,
+          queue: (state.monsterCelebrations?.queue || []).slice(1),
+        },
+      };
+      calls.push(['dismissMonsterCelebration']);
+      return true;
+    },
     reloadFromRepositories(options) {
+      if (!options?.preserveMonsterCelebrations) {
+        state = {
+          ...state,
+          monsterCelebrations: {
+            pending: [],
+            queue: [],
+          },
+        };
+      }
       calls.push(['reloadFromRepositories', options]);
+    },
+    repositories: initial.repositories || {
+      eventLog: {
+        list() {
+          return [];
+        },
+      },
     },
   };
   return {
@@ -346,29 +411,129 @@ test('remote spelling command response preserves reward side effects and TTS sto
   });
 
   handler.applyCommandResponse({
+    learnerId: 'learner-a',
     subjectReadModel: { phase: 'session' },
     projections: {
       rewards: {
         toastEvents: [{ id: 'toast-a' }],
-        events: [{ id: 'monster-a' }],
+        events: [{
+          id: 'reward.monster:learner-a:inklet:evolve:1:2',
+          type: 'reward.monster',
+          kind: 'evolve',
+          learnerId: 'learner-a',
+          monsterId: 'inklet',
+          monster: { id: 'inklet', name: 'Inklet' },
+          previous: { stage: 0, level: 1, caught: true, branch: 'b1' },
+          next: { stage: 1, level: 2, caught: true, branch: 'b1' },
+          createdAt: 100,
+        }],
       },
     },
   }, { command: 'submit-answer' });
 
   assert.equal(tts.stopCalls, 1);
   assert.deepEqual(calls.map(([name]) => name), [
-    'pushToasts',
-    'pushMonsterCelebrations',
     'reloadFromRepositories',
+    'pushToasts',
+    'deferMonsterCelebrations',
   ]);
 
   handler.applyCommandResponse({
+    learnerId: 'learner-a',
     subjectReadModel: { phase: 'session' },
     audio: { promptToken: 'prompt-a', word: 'early' },
   }, { command: 'submit-answer' });
 
   assert.equal(tts.stopCalls, 1);
   assert.deepEqual(tts.spoken, [{ promptToken: 'prompt-a', word: 'early' }]);
+});
+
+test('remote spelling command compensates a logged monster celebration after the next session finishes', () => {
+  installMemoryStorage();
+  const olderCatch = {
+    id: 'reward.monster:learner-a:inklet:caught:0:0',
+    type: 'reward.monster',
+    kind: 'caught',
+    learnerId: 'learner-a',
+    monsterId: 'inklet',
+    monster: {
+      id: 'inklet',
+      name: 'Inklet',
+      accent: '#3E6FA8',
+    },
+    previous: { mastered: 0, stage: 0, level: 0, caught: false, branch: 'b1' },
+    next: { mastered: 1, stage: 0, level: 0, caught: true, branch: 'b1' },
+    createdAt: 50,
+  };
+  const missedEvolution = {
+    id: 'reward.monster:learner-a:inklet:evolve:1:2',
+    type: 'reward.monster',
+    kind: 'evolve',
+    learnerId: 'learner-a',
+    monsterId: 'inklet',
+    monster: {
+      id: 'inklet',
+      name: 'Inklet',
+      nameByStage: ['Inklet egg', 'Inklet sprout'],
+      accent: '#3E6FA8',
+    },
+    previous: { mastered: 9, stage: 0, level: 1, caught: true, branch: 'b1' },
+    next: { mastered: 10, stage: 1, level: 2, caught: true, branch: 'b1' },
+    createdAt: 100,
+  };
+  const { calls, getState, store } = createStoreHarness({
+    repositories: {
+      eventLog: {
+        list(learnerId) {
+          assert.equal(learnerId, 'learner-a');
+          return [olderCatch, missedEvolution];
+        },
+      },
+    },
+  });
+  const handler = createRemoteSpellingActionHandler({
+    store,
+    services: { spelling: {} },
+    tts: createTtsHarness(),
+    readModels: { readJson: async () => ({}) },
+    subjectCommands: { send: async () => ({}) },
+  });
+
+  handler.applyCommandResponse({
+    learnerId: 'learner-a',
+    subjectReadModel: { phase: 'summary' },
+    projections: {
+      rewards: {
+        toastEvents: [],
+        events: [],
+      },
+    },
+  }, { command: 'end-session' });
+
+  assert.deepEqual(calls.map(([name]) => name), [
+    'reloadFromRepositories',
+    'deferMonsterCelebrations',
+    'releaseMonsterCelebrations',
+  ]);
+  assert.equal(getState().monsterCelebrations.pending.length, 0);
+  assert.equal(getState().monsterCelebrations.queue.length, 1);
+  assert.equal(getState().monsterCelebrations.queue[0].id, missedEvolution.id);
+
+  acknowledgeMonsterCelebrationEvents(missedEvolution, { learnerId: 'learner-a' });
+  store.dismissMonsterCelebration();
+  calls.length = 0;
+  handler.applyCommandResponse({
+    learnerId: 'learner-a',
+    subjectReadModel: { phase: 'summary' },
+    projections: {
+      rewards: {
+        toastEvents: [],
+        events: [],
+      },
+    },
+  }, { command: 'end-session' });
+
+  assert.equal(calls.some(([name]) => name === 'deferMonsterCelebrations'), false);
 });
 
 test('remote spelling word bank open loads analytics and detail into the store', async () => {

--- a/tests/spelling-remote-actions.test.js
+++ b/tests/spelling-remote-actions.test.js
@@ -5,7 +5,10 @@ import {
   createRemoteSpellingActionHandler,
   spellingCommandDedupeKey,
 } from '../src/subjects/spelling/remote-actions.js';
-import { acknowledgeMonsterCelebrationEvents } from '../src/platform/game/monster-celebration-acks.js';
+import {
+  acknowledgeMonsterCelebrationEvents,
+  clearMonsterCelebrationAcknowledgements,
+} from '../src/platform/game/monster-celebration-acks.js';
 import { installMemoryStorage } from './helpers/memory-storage.js';
 
 function flushPromises() {
@@ -618,6 +621,67 @@ test('remote spelling compensation baselines recent logged celebrations that exi
 
   assert.equal(calls.some(([name]) => name === 'deferMonsterCelebrations'), false);
   assert.equal(getState().monsterCelebrations.queue.length, 0);
+});
+
+test('remote spelling compensation can replay a deterministic reward id after reset clears acknowledgements', () => {
+  installMemoryStorage();
+  const reearnedEvolution = {
+    id: 'reward.monster:learner-a:inklet:evolve:1:2',
+    type: 'reward.monster',
+    kind: 'evolve',
+    learnerId: 'learner-a',
+    subjectId: 'spelling',
+    monsterId: 'inklet',
+    monster: {
+      id: 'inklet',
+      name: 'Inklet',
+      accent: '#3E6FA8',
+    },
+    previous: { mastered: 9, stage: 0, level: 1, caught: true, branch: 'b1' },
+    next: { mastered: 10, stage: 1, level: 2, caught: true, branch: 'b1' },
+    createdAt: Date.now(),
+  };
+  acknowledgeMonsterCelebrationEvents(reearnedEvolution, { learnerId: 'learner-a' });
+  clearMonsterCelebrationAcknowledgements('learner-a');
+  const { calls, getState, store } = createStoreHarness({
+    repositories: {
+      eventLog: {
+        list(learnerId) {
+          assert.equal(learnerId, 'learner-a');
+          return [reearnedEvolution];
+        },
+      },
+    },
+  });
+  const handler = createRemoteSpellingActionHandler({
+    store,
+    services: { spelling: {} },
+    tts: createTtsHarness(),
+    readModels: { readJson: async () => ({}) },
+    subjectCommands: { send: async () => ({}) },
+  });
+
+  handler.applyCommandResponse({
+    learnerId: 'learner-a',
+    subjectReadModel: { phase: 'summary' },
+    projections: {
+      rewards: {
+        toastEvents: [],
+        events: [],
+      },
+    },
+  }, {
+    command: 'end-session',
+    compensationBaselineEventIds: new Set(),
+  });
+
+  assert.deepEqual(calls.map(([name]) => name), [
+    'reloadFromRepositories',
+    'deferMonsterCelebrations',
+    'releaseMonsterCelebrations',
+  ]);
+  assert.equal(getState().monsterCelebrations.queue.length, 1);
+  assert.equal(getState().monsterCelebrations.queue[0].id, reearnedEvolution.id);
 });
 
 test('remote spelling command compensates only rewards appended after the command starts', async () => {

--- a/tests/spelling-remote-actions.test.js
+++ b/tests/spelling-remote-actions.test.js
@@ -450,6 +450,7 @@ test('remote spelling command response preserves reward side effects and TTS sto
 
 test('remote spelling command compensates a logged monster celebration after the next session finishes', () => {
   installMemoryStorage();
+  const now = Date.now();
   const olderCatch = {
     id: 'reward.monster:learner-a:inklet:caught:0:0',
     type: 'reward.monster',
@@ -463,7 +464,7 @@ test('remote spelling command compensates a logged monster celebration after the
     },
     previous: { mastered: 0, stage: 0, level: 0, caught: false, branch: 'b1' },
     next: { mastered: 1, stage: 0, level: 0, caught: true, branch: 'b1' },
-    createdAt: 50,
+    createdAt: now - (10 * 24 * 60 * 60 * 1000),
   };
   const missedEvolution = {
     id: 'reward.monster:learner-a:inklet:evolve:1:2',
@@ -479,14 +480,30 @@ test('remote spelling command compensates a logged monster celebration after the
     },
     previous: { mastered: 9, stage: 0, level: 1, caught: true, branch: 'b1' },
     next: { mastered: 10, stage: 1, level: 2, caught: true, branch: 'b1' },
-    createdAt: 100,
+    createdAt: now - 1000,
+  };
+  const nonSpellingReward = {
+    id: 'reward.monster:learner-a:grammar:bracehart:evolve:1:2',
+    type: 'reward.monster',
+    kind: 'evolve',
+    learnerId: 'learner-a',
+    subjectId: 'grammar',
+    monsterId: 'bracehart',
+    monster: {
+      id: 'bracehart',
+      name: 'Bracehart',
+      accent: '#3E6FA8',
+    },
+    previous: { mastered: 1, stage: 1, level: 2, caught: true, branch: 'b1' },
+    next: { mastered: 2, stage: 2, level: 4, caught: true, branch: 'b1' },
+    createdAt: now,
   };
   const { calls, getState, store } = createStoreHarness({
     repositories: {
       eventLog: {
         list(learnerId) {
           assert.equal(learnerId, 'learner-a');
-          return [olderCatch, missedEvolution];
+          return [olderCatch, missedEvolution, nonSpellingReward];
         },
       },
     },
@@ -521,6 +538,15 @@ test('remote spelling command compensates a logged monster celebration after the
 
   acknowledgeMonsterCelebrationEvents(missedEvolution, { learnerId: 'learner-a' });
   store.dismissMonsterCelebration();
+  store.updateSubjectUi('spelling', {
+    phase: 'session',
+    session: {
+      id: 'session-b',
+      currentSlug: 'necessary',
+      phase: 'answer',
+      promptCount: 1,
+    },
+  });
   calls.length = 0;
   handler.applyCommandResponse({
     learnerId: 'learner-a',
@@ -534,6 +560,84 @@ test('remote spelling command compensates a logged monster celebration after the
   }, { command: 'end-session' });
 
   assert.equal(calls.some(([name]) => name === 'deferMonsterCelebrations'), false);
+});
+
+test('remote spelling compensation baselines old logged celebrations when ack state is empty', () => {
+  installMemoryStorage();
+  const oldEvolution = {
+    id: 'reward.monster:learner-a:inklet:evolve:1:2',
+    type: 'reward.monster',
+    kind: 'evolve',
+    learnerId: 'learner-a',
+    monsterId: 'inklet',
+    monster: {
+      id: 'inklet',
+      name: 'Inklet',
+      accent: '#3E6FA8',
+    },
+    previous: { mastered: 9, stage: 0, level: 1, caught: true, branch: 'b1' },
+    next: { mastered: 10, stage: 1, level: 2, caught: true, branch: 'b1' },
+    createdAt: Date.now() - (10 * 24 * 60 * 60 * 1000),
+  };
+  const { calls, getState, store } = createStoreHarness({
+    repositories: {
+      eventLog: {
+        list() {
+          return [oldEvolution];
+        },
+      },
+    },
+  });
+  const handler = createRemoteSpellingActionHandler({
+    store,
+    services: { spelling: {} },
+    tts: createTtsHarness(),
+    readModels: { readJson: async () => ({}) },
+    subjectCommands: { send: async () => ({}) },
+  });
+
+  handler.applyCommandResponse({
+    learnerId: 'learner-a',
+    subjectReadModel: { phase: 'summary' },
+    projections: {
+      rewards: {
+        toastEvents: [],
+        events: [],
+      },
+    },
+  }, { command: 'end-session' });
+
+  assert.equal(calls.some(([name]) => name === 'deferMonsterCelebrations'), false);
+  assert.equal(getState().monsterCelebrations.queue.length, 0);
+});
+
+test('remote spelling command response ignores stale learner TTS side effects', () => {
+  const { store } = createStoreHarness({
+    learners: { selectedId: 'learner-b' },
+  });
+  const tts = createTtsHarness();
+  const handler = createRemoteSpellingActionHandler({
+    store,
+    services: { spelling: {} },
+    tts,
+    readModels: { readJson: async () => ({}) },
+    subjectCommands: { send: async () => ({}) },
+  });
+
+  handler.applyCommandResponse({
+    learnerId: 'learner-a',
+    subjectReadModel: { phase: 'summary' },
+    projections: {
+      rewards: {
+        toastEvents: [{ id: 'toast-a' }],
+        events: [],
+      },
+    },
+    audio: { promptToken: 'prompt-a', word: 'early' },
+  }, { command: 'end-session' });
+
+  assert.equal(tts.stopCalls, 0);
+  assert.deepEqual(tts.spoken, []);
 });
 
 test('remote spelling word bank open loads analytics and detail into the store', async () => {

--- a/tests/spelling-remote-actions.test.js
+++ b/tests/spelling-remote-actions.test.js
@@ -525,7 +525,10 @@ test('remote spelling command compensates a logged monster celebration after the
         events: [],
       },
     },
-  }, { command: 'end-session' });
+  }, {
+    command: 'end-session',
+    compensationBaselineEventIds: new Set([olderCatch.id]),
+  });
 
   assert.deepEqual(calls.map(([name]) => name), [
     'reloadFromRepositories',
@@ -557,14 +560,17 @@ test('remote spelling command compensates a logged monster celebration after the
         events: [],
       },
     },
-  }, { command: 'end-session' });
+  }, {
+    command: 'end-session',
+    compensationBaselineEventIds: new Set([olderCatch.id, missedEvolution.id]),
+  });
 
   assert.equal(calls.some(([name]) => name === 'deferMonsterCelebrations'), false);
 });
 
-test('remote spelling compensation baselines old logged celebrations when ack state is empty', () => {
+test('remote spelling compensation baselines recent logged celebrations that existed before command', () => {
   installMemoryStorage();
-  const oldEvolution = {
+  const recentEvolution = {
     id: 'reward.monster:learner-a:inklet:evolve:1:2',
     type: 'reward.monster',
     kind: 'evolve',
@@ -577,13 +583,13 @@ test('remote spelling compensation baselines old logged celebrations when ack st
     },
     previous: { mastered: 9, stage: 0, level: 1, caught: true, branch: 'b1' },
     next: { mastered: 10, stage: 1, level: 2, caught: true, branch: 'b1' },
-    createdAt: Date.now() - (10 * 24 * 60 * 60 * 1000),
+    createdAt: Date.now() - 60_000,
   };
   const { calls, getState, store } = createStoreHarness({
     repositories: {
       eventLog: {
         list() {
-          return [oldEvolution];
+          return [recentEvolution];
         },
       },
     },
@@ -605,10 +611,88 @@ test('remote spelling compensation baselines old logged celebrations when ack st
         events: [],
       },
     },
-  }, { command: 'end-session' });
+  }, {
+    command: 'end-session',
+    compensationBaselineEventIds: new Set([recentEvolution.id]),
+  });
 
   assert.equal(calls.some(([name]) => name === 'deferMonsterCelebrations'), false);
   assert.equal(getState().monsterCelebrations.queue.length, 0);
+});
+
+test('remote spelling command compensates only rewards appended after the command starts', async () => {
+  installMemoryStorage();
+  const now = Date.now();
+  const priorEvolution = {
+    id: 'reward.monster:learner-a:inklet:evolve:1:2',
+    type: 'reward.monster',
+    kind: 'evolve',
+    learnerId: 'learner-a',
+    subjectId: 'spelling',
+    monsterId: 'inklet',
+    monster: {
+      id: 'inklet',
+      name: 'Inklet',
+      accent: '#3E6FA8',
+    },
+    previous: { mastered: 9, stage: 0, level: 1, caught: true, branch: 'b1' },
+    next: { mastered: 10, stage: 1, level: 2, caught: true, branch: 'b1' },
+    createdAt: now - 60_000,
+  };
+  const commandMissedEvolution = {
+    id: 'reward.monster:learner-a:phaeton:evolve:1:2',
+    type: 'reward.monster',
+    kind: 'evolve',
+    learnerId: 'learner-a',
+    subjectId: 'spelling',
+    monsterId: 'phaeton',
+    monster: {
+      id: 'phaeton',
+      name: 'Phaeton',
+      accent: '#7D5CC6',
+    },
+    previous: { mastered: 29, stage: 1, level: 2, caught: true, branch: 'b2' },
+    next: { mastered: 30, stage: 2, level: 3, caught: true, branch: 'b2' },
+    createdAt: now,
+  };
+  const events = [priorEvolution];
+  const { getState, store } = createStoreHarness({
+    repositories: {
+      eventLog: {
+        list(learnerId) {
+          assert.equal(learnerId, 'learner-a');
+          return events;
+        },
+      },
+    },
+  });
+  const handler = createRemoteSpellingActionHandler({
+    store,
+    services: { spelling: {} },
+    tts: createTtsHarness(),
+    readModels: { readJson: async () => ({}) },
+    subjectCommands: {
+      async send() {
+        events.push(commandMissedEvolution);
+        return {
+          learnerId: 'learner-a',
+          subjectReadModel: { phase: 'summary' },
+          projections: {
+            rewards: {
+              toastEvents: [],
+              events: [],
+            },
+          },
+        };
+      },
+    },
+  });
+
+  assert.equal(handler.runCommand('end-session'), true);
+  await flushPromises();
+
+  assert.equal(getState().monsterCelebrations.queue.length, 1);
+  assert.equal(getState().monsterCelebrations.queue[0].id, commandMissedEvolution.id);
 });
 
 test('remote spelling compensation preserves older recent missed celebrations for later replay', () => {
@@ -672,7 +756,10 @@ test('remote spelling compensation preserves older recent missed celebrations fo
         events: [],
       },
     },
-  }, { command: 'end-session' });
+  }, {
+    command: 'end-session',
+    compensationBaselineEventIds: new Set(),
+  });
 
   assert.equal(getState().monsterCelebrations.queue.length, 1);
   assert.equal(getState().monsterCelebrations.queue[0].id, phaetonEvolution.id);
@@ -699,7 +786,10 @@ test('remote spelling compensation preserves older recent missed celebrations fo
         events: [],
       },
     },
-  }, { command: 'end-session' });
+  }, {
+    command: 'end-session',
+    compensationBaselineEventIds: new Set([directEvolution.id, phaetonEvolution.id]),
+  });
 
   assert.deepEqual(calls.map(([name]) => name), [
     'reloadFromRepositories',

--- a/tests/store.test.js
+++ b/tests/store.test.js
@@ -38,6 +38,32 @@ test('shared store can switch subject tabs without losing route context', () => 
   assert.equal(state.route.tab, 'analytics');
 });
 
+test('shared store can preserve transient monster celebrations across command reloads', () => {
+  const storage = installMemoryStorage();
+  const repositories = createLocalPlatformRepositories({ storage });
+  const store = createStore(SUBJECTS, { repositories });
+  const event = {
+    id: 'reward.monster:learner-a:inklet:evolve:1:2',
+    type: 'reward.monster',
+    kind: 'evolve',
+    learnerId: store.getState().learners.selectedId,
+    monsterId: 'inklet',
+    monster: { id: 'inklet', name: 'Inklet' },
+    previous: { stage: 0, level: 1, caught: true, branch: 'b1' },
+    next: { stage: 1, level: 2, caught: true, branch: 'b1' },
+    createdAt: 100,
+  };
+
+  store.pushMonsterCelebrations(event);
+  store.reloadFromRepositories({ preserveMonsterCelebrations: true });
+
+  assert.equal(store.getState().monsterCelebrations.queue.length, 1);
+  assert.equal(store.getState().monsterCelebrations.queue[0].id, event.id);
+
+  store.reloadFromRepositories();
+  assert.equal(store.getState().monsterCelebrations.queue.length, 0);
+});
+
 test('shared store caches subject setup reset when runtime UI writes are cached', () => {
   const storage = installMemoryStorage();
   const repositories = createLocalPlatformRepositories({ storage });


### PR DESCRIPTION
## Summary
- Preserve pending monster celebration overlays across remote spelling reloads so Nelson-style evolutions are not erased before render.
- Add missed-celebration compensation after the next spelling session finishes, filtered to spelling reward events only.
- Harden replay prevention by baselining reward events that already existed before the current spelling command, so fresh local ack state cannot replay recent historical overlays from another device or cleared storage.
- Clear learner-scoped monster celebration acknowledgements on learner progress reset/delete, and clear all acknowledgement state on browser full reset, so deterministic re-earned rewards can still be compensated after a reset.
- Keep multiple command-time missed spelling celebrations recoverable across later sessions instead of acknowledging skipped overlays unseen.
- Gate stale learner command responses so reward UI and spelling TTS side effects only run for the selected learner.

## Review Fixes
- Filtered compensation candidates to events with no subject id or `subjectId === 'spelling'`.
- Replaced the previous 3-day empty-ack cutoff with an explicit pre-command event-log snapshot; existing rewards are acknowledged into the local baseline, while events appended by the command can still be compensated if the response missed them.
- Gated `tts.stop()` and `tts.speak()` on the selected learner.
- Reset the compensation regression harness back to a live session before the second end-session response and added direct baseline, command-time compensation, stale-TTS, and multiple-missed coverage.
- Removed skipped-candidate acknowledgement so direct plus Phaeton missed celebrations can replay one by one after acknowledgement.
- Invalidated local monster celebration acknowledgement snapshots when learner progress is reset or a learner is deleted, with regression coverage for reset, delete, full reset, and deterministic re-earned reward compensation.
- Rebased the branch onto the latest `origin/main` after resolving the spelling command/preference-save conflict.

## Verification
- `npm test -- tests/spelling-remote-actions.test.js tests/app-controller.test.js`
- `npm test -- tests/spelling-remote-actions.test.js tests/app-controller.test.js tests/store.test.js`
- `npm test`
- `npm run check`