### PR TITLE
fix(spelling): keep synced actions on command boundary

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -737,6 +737,10 @@ const controller = createAppController({
   subjectExposureGates,
   runtimeBoundary,
   autoAdvanceDispatchContinue: () => handleRemoteSpellingAction('spelling-continue'),
+  extraContext: () => ({
+    session: boot.session,
+    handleRemoteSpellingAction,
+  }),
   tts,
   services,
   cacheSubjectUiWrites: true,
@@ -1178,6 +1182,8 @@ function contextFor(subjectId = null) {
     runtimeBoundary,
     subjects: exposedSubjects(SUBJECTS, subjectExposureGates),
     subjectExposureGates,
+    session: boot.session,
+    handleRemoteSpellingAction,
     runtimeReadOnly: appState.persistence?.mode === 'degraded',
     ...buildHubModels(appState),
   };

--- a/src/subjects/spelling/module.js
+++ b/src/subjects/spelling/module.js
@@ -5,6 +5,29 @@ import {
   WORD_BANK_YEAR_FILTER_IDS,
   findWordBankEntry,
 } from './components/spelling-view-model.js';
+import { shouldHandleRemoteSpellingAction } from './remote-actions.js';
+
+function usesServerSyncedSpellingRuntime(context) {
+  const sessionMode = context?.session?.mode || context?.snapshot?.session?.mode || '';
+  if (sessionMode === 'remote-sync' || sessionMode === 'demo-sync') return true;
+
+  const persistence = context?.appState?.persistence || context?.snapshot?.appState?.persistence || null;
+  if (persistence?.mode === 'remote-sync') return true;
+  return persistence?.mode === 'degraded' && persistence?.remoteAvailable === true;
+}
+
+function delegateServerSyncedSpellingAction(action, context) {
+  if (!shouldHandleRemoteSpellingAction(action) || !usesServerSyncedSpellingRuntime(context)) return null;
+
+  if (typeof context?.handleRemoteSpellingAction === 'function') {
+    return Boolean(context.handleRemoteSpellingAction(action, context.data || {}));
+  }
+
+  context?.store?.updateSubjectUi?.('spelling', {
+    error: 'Spelling practice needs the Worker command boundary.',
+  });
+  return true;
+}
 
 function applySpellingTransition(context, transition) {
   if (!transition) return true;
@@ -113,6 +136,9 @@ export const spellingModule = {
     };
   },
   handleAction(action, context) {
+    const delegated = delegateServerSyncedSpellingAction(action, context);
+    if (delegated !== null) return delegated;
+
     const { appState, data, store, service, tts } = context;
     const learnerId = appState.learners.selectedId;
     const ui = service.initState(appState.subjectUi.spelling, learnerId);

--- a/tests/app-controller.test.js
+++ b/tests/app-controller.test.js
@@ -224,6 +224,33 @@ test('controller dispatches spelling transitions through store, repositories, ev
   assert.ok(controller.repositories.practiceSessions.list(learnerId).length >= 1);
 });
 
+test('controller delegates server-synced spelling actions to the remote command boundary', () => {
+  const storage = installMemoryStorage();
+  const repositories = createLocalPlatformRepositories({ storage });
+  const remoteCalls = [];
+  const session = { signedIn: true, mode: 'remote-sync', platformRole: 'parent' };
+  const controller = createAppController({
+    repositories,
+    session,
+    extraContext: {
+      session,
+      handleRemoteSpellingAction(action, data) {
+        remoteCalls.push({ action, data });
+        return true;
+      },
+    },
+  });
+  const learnerId = controller.store.getState().learners.selectedId;
+
+  controller.dispatch('open-subject', { subjectId: 'spelling' });
+  controller.dispatch('spelling-start', { source: 'test' });
+
+  assert.deepEqual(remoteCalls, [{ action: 'spelling-start', data: { source: 'test' } }]);
+  assert.equal(controller.store.getState().subjectUi.spelling.phase, 'dashboard');
+  assert.equal(controller.repositories.practiceSessions.list(learnerId).length, 0);
+  assert.equal(controller.runtimeBoundary.list().length, 0);
+});
+
 test('controller keeps late Grammar command responses scoped to their original learner', async () => {
   const storage = installMemoryStorage();
   const repositories = createLocalPlatformRepositories({ storage });


### PR DESCRIPTION
## Summary

Server-synced spelling could still fall through to the legacy local spelling module when an action path reached `controller.dispatch` instead of the remote action handler first. That path attempted retired generic runtime writes such as `PUT /api/practice-sessions`, which production correctly rejects because spelling progress must go through the Worker subject command boundary.

This change makes the spelling module detect remote/demo sync runtimes and delegate every remote-owned spelling action back to `handleRemoteSpellingAction` before any local service transition can run. The main app now passes the boot session and remote spelling handler into both controller and surface contexts, so fallback action paths preserve the same command-boundary behaviour as the primary React runtime.

## Verification

- `npm test -- tests/app-controller.test.js`
- `npm test`
- `npm run check`
- `npm run deploy`
- Production bundle audit passed for `https://ks2.eugnel.uk/`
- Post-deploy demo subject command `start-session` returned `200` with phase `session`
- Production browser cache recovered to `pendingCount: 0`, with no `Sync degraded` banner and no console errors

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)