### PR TITLE
fix(spelling): coalesce rapid option saves

### DIFF
--- a/src/subjects/spelling/remote-actions.js
+++ b/src/subjects/spelling/remote-actions.js
@@ -4,6 +4,7 @@ import {
 } from './components/spelling-view-model.js';
 
 const READ_ONLY_MESSAGE = 'Practice is read-only while sync is degraded. Retry sync before continuing.';
+const SETUP_PREF_SAVE_DEBOUNCE_MS = 120;
 
 const SPELLING_COMMAND_ACTIONS = new Set([
   'spelling-set-mode',
@@ -126,11 +127,15 @@ export function createRemoteSpellingActionHandler({
   readModels,
   tts,
   isReadOnly = () => false,
+  preferenceSaveDebounceMs = SETUP_PREF_SAVE_DEBOUNCE_MS,
   setRuntimeError = (message) => {
     store?.updateSubjectUi?.('spelling', { error: message || 'Practice is temporarily unavailable.' });
   },
   pendingCommandKeys = new Set(),
 } = {}) {
+  const pendingPreferenceSaves = new Map();
+  const preferenceSaveChains = new Map();
+
   function appState() {
     return store?.getState?.() || {};
   }
@@ -202,9 +207,9 @@ export function createRemoteSpellingActionHandler({
     }
   }
 
-  async function sendCommand(command, payload = {}) {
+  async function sendCommand(command, payload = {}, { learnerId: requestedLearnerId = '' } = {}) {
     const state = appState();
-    const learnerId = state.learners?.selectedId;
+    const learnerId = requestedLearnerId || state.learners?.selectedId;
     if (!learnerId) return null;
     const response = await subjectCommands.send({
       subjectId: 'spelling',
@@ -216,11 +221,87 @@ export function createRemoteSpellingActionHandler({
     return response;
   }
 
-  function runCommand(command, payload = {}) {
+  function preferenceSaveDelayMs() {
+    return Math.max(0, Number(preferenceSaveDebounceMs) || 0);
+  }
+
+  function updateOptimisticPrefs(prefsPatch = {}) {
+    const patch = prefsPatch && typeof prefsPatch === 'object' && !Array.isArray(prefsPatch) ? prefsPatch : {};
+    if (!Object.keys(patch).length) return;
+    store.updateSubjectUi('spelling', (current = {}) => ({
+      ...current,
+      prefs: {
+        ...(current.prefs || {}),
+        ...patch,
+      },
+      error: '',
+    }));
+  }
+
+  function takePendingPreferenceSave(learnerId) {
+    const entry = pendingPreferenceSaves.get(learnerId);
+    if (!entry) return null;
+    if (entry.timer) clearTimeout(entry.timer);
+    pendingPreferenceSaves.delete(learnerId);
+    return entry.prefs && typeof entry.prefs === 'object' && !Array.isArray(entry.prefs) ? entry.prefs : null;
+  }
+
+  function trackPreferenceSave(learnerId, prefs) {
+    const previous = preferenceSaveChains.get(learnerId) || Promise.resolve();
+    let tracked;
+    const next = previous
+      .catch(() => {})
+      .then(() => sendCommand('save-prefs', { prefs }, { learnerId }));
+    tracked = next.finally(() => {
+      if (preferenceSaveChains.get(learnerId) === tracked) {
+        preferenceSaveChains.delete(learnerId);
+      }
+    });
+    preferenceSaveChains.set(learnerId, tracked);
+    return tracked;
+  }
+
+  function flushPendingPreferenceSave(learnerId) {
+    if (!learnerId) return Promise.resolve(null);
+    const pendingPrefs = takePendingPreferenceSave(learnerId);
+    if (pendingPrefs && Object.keys(pendingPrefs).length) {
+      return trackPreferenceSave(learnerId, pendingPrefs);
+    }
+    return preferenceSaveChains.get(learnerId) || Promise.resolve(null);
+  }
+
+  function handlePreferenceSaveError(error) {
+    globalThis.console?.warn?.('Spelling preference save failed.', error);
+    setRuntimeError(commandErrorMessage(error, 'The spelling options could not be saved.'));
+  }
+
+  function schedulePreferenceSave(learnerId, prefsPatch = {}) {
+    if (!learnerId) return false;
+    const patch = prefsPatch && typeof prefsPatch === 'object' && !Array.isArray(prefsPatch) ? prefsPatch : {};
+    if (!Object.keys(patch).length) return true;
+    const current = pendingPreferenceSaves.get(learnerId);
+    if (current?.timer) clearTimeout(current.timer);
+    const prefs = {
+      ...(current?.prefs || {}),
+      ...patch,
+    };
+    const timer = setTimeout(() => {
+      flushPendingPreferenceSave(learnerId).catch(handlePreferenceSaveError);
+    }, preferenceSaveDelayMs());
+    pendingPreferenceSaves.set(learnerId, { prefs, timer });
+    return true;
+  }
+
+  function runCommand(command, payload = {}, { learnerId: requestedLearnerId = '', beforeSend = null } = {}) {
     const dedupeKey = spellingCommandDedupeKey(command, appState());
     if (dedupeKey && pendingCommandKeys.has(dedupeKey)) return false;
     if (dedupeKey) pendingCommandKeys.add(dedupeKey);
-    sendCommand(command, payload).catch((error) => {
+    const commandPromise = typeof beforeSend === 'function'
+      ? Promise.resolve()
+        .then(beforeSend)
+        .then((nextPayload) => sendCommand(command, nextPayload || payload, { learnerId: requestedLearnerId }))
+      : sendCommand(command, payload, { learnerId: requestedLearnerId });
+    commandPromise.catch((error) => {
       globalThis.console?.warn?.('Spelling command failed.', error);
       setRuntimeError(commandErrorMessage(error, 'The spelling command could not be completed.'));
     }).finally(() => {
@@ -476,29 +557,41 @@ export function createRemoteSpellingActionHandler({
     }
 
     if (action === 'spelling-set-pref') {
-      runCommand('save-prefs', { prefs: { [data.pref]: data.value } });
+      const patch = { [data.pref]: data.value };
+      updateOptimisticPrefs(patch);
+      schedulePreferenceSave(learnerId, patch);
       return true;
     }
 
     if (action === 'spelling-set-mode') {
-      runCommand('save-prefs', { prefs: { mode: data.value } });
+      const patch = { mode: data.value };
+      updateOptimisticPrefs(patch);
+      schedulePreferenceSave(learnerId, patch);
       return true;
     }
 
     if (action === 'spelling-toggle-pref') {
       const current = spelling?.getPrefs?.(learnerId) || {};
-      runCommand('save-prefs', { prefs: { [data.pref]: !current[data.pref] } });
+      const patch = { [data.pref]: !current[data.pref] };
+      updateOptimisticPrefs(patch);
+      schedulePreferenceSave(learnerId, patch);
       return true;
     }
 
     if (action === 'spelling-start' || action === 'spelling-start-again') {
-      const prefs = spelling?.getPrefs?.(learnerId) || {};
       tts.stop();
-      runCommand('start-session', {
-        mode: prefs.mode,
-        yearFilter: prefs.yearFilter,
-        length: prefs.roundLength,
-        extraWordFamilies: prefs.extraWordFamilies,
+      runCommand('start-session', {}, {
+        learnerId,
+        beforeSend: async () => {
+          await flushPendingPreferenceSave(learnerId);
+          const prefs = spelling?.getPrefs?.(learnerId) || {};
+          return {
+            mode: prefs.mode,
+            yearFilter: prefs.yearFilter,
+            length: prefs.roundLength,
+            extraWordFamilies: prefs.extraWordFamilies,
+          };
+        },
       });
       return true;
     }
@@ -512,14 +605,16 @@ export function createRemoteSpellingActionHandler({
       }
       tts.stop();
       (async () => {
-        await sendCommand('save-prefs', { prefs: { mode } });
+        await flushPendingPreferenceSave(learnerId);
+        updateOptimisticPrefs({ mode });
+        await sendCommand('save-prefs', { prefs: { mode } }, { learnerId });
         const prefs = spelling?.getPrefs?.(learnerId) || { mode };
         await sendCommand('start-session', {
           mode: prefs.mode || mode,
           yearFilter: prefs.yearFilter,
           length: prefs.roundLength,
           extraWordFamilies: prefs.extraWordFamilies,
-        });
+        }, { learnerId });
       })().catch((error) => {
         globalThis.console?.warn?.('Spelling shortcut command failed.', error);
         setRuntimeError(commandErrorMessage(error, 'The spelling shortcut could not be completed.'));

--- a/src/subjects/spelling/remote-actions.js
+++ b/src/subjects/spelling/remote-actions.js
@@ -135,6 +135,8 @@ export function createRemoteSpellingActionHandler({
 } = {}) {
   const pendingPreferenceSaves = new Map();
   const preferenceSaveChains = new Map();
+  const preferenceIntentCounters = new Map();
+  const latestPreferenceIntents = new Map();
 
   function appState() {
     return store?.getState?.() || {};
@@ -144,7 +146,7 @@ export function createRemoteSpellingActionHandler({
     return state.subjectUi?.spelling?.analytics || null;
   }
 
-  function applyCommandResponse(response, { command = '' } = {}) {
+  function applyCommandResponse(response, { command = '', learnerId = '', preferenceVersion = 0 } = {}) {
     if (response?.projections?.rewards?.toastEvents?.length) {
       store.pushToasts(response.projections.rewards.toastEvents);
     }
@@ -155,6 +157,7 @@ export function createRemoteSpellingActionHandler({
       tts.stop();
     }
     store.reloadFromRepositories({ preserveRoute: true });
+    reconcilePreferenceSaveResponse({ command, learnerId, preferenceVersion });
     if (response?.audio?.promptToken) {
       tts.speak(response.audio);
     }
@@ -207,7 +210,7 @@ export function createRemoteSpellingActionHandler({
     }
   }
 
-  async function sendCommand(command, payload = {}, { learnerId: requestedLearnerId = '' } = {}) {
+  async function sendCommand(command, payload = {}, { learnerId: requestedLearnerId = '', preferenceVersion = 0 } = {}) {
     const state = appState();
     const learnerId = requestedLearnerId || state.learners?.selectedId;
     if (!learnerId) return null;
@@ -217,7 +220,7 @@ export function createRemoteSpellingActionHandler({
       command,
       payload,
     });
-    applyCommandResponse(response, { command });
+    applyCommandResponse(response, { command, learnerId, preferenceVersion });
     return response;
   }
 
@@ -238,20 +241,50 @@ export function createRemoteSpellingActionHandler({
     }));
   }
 
+  function recordPreferenceIntent(learnerId, prefsPatch = {}) {
+    const patch = prefsPatch && typeof prefsPatch === 'object' && !Array.isArray(prefsPatch) ? prefsPatch : {};
+    if (!learnerId || !Object.keys(patch).length) return null;
+    const version = (preferenceIntentCounters.get(learnerId) || 0) + 1;
+    const previous = latestPreferenceIntents.get(learnerId);
+    const intent = {
+      version,
+      prefs: {
+        ...(previous?.prefs || {}),
+        ...patch,
+      },
+    };
+    preferenceIntentCounters.set(learnerId, version);
+    latestPreferenceIntents.set(learnerId, intent);
+    return intent;
+  }
+
+  function reconcilePreferenceSaveResponse({ command = '', learnerId = '', preferenceVersion = 0 } = {}) {
+    if (command !== 'save-prefs' || !learnerId) return;
+    const latest = latestPreferenceIntents.get(learnerId);
+    if (!latest) return;
+    if (Number(latest.version) <= Number(preferenceVersion)) {
+      latestPreferenceIntents.delete(learnerId);
+      return;
+    }
+    if (appState().learners?.selectedId === learnerId) {
+      updateOptimisticPrefs(latest.prefs);
+    }
+  }
+
   function takePendingPreferenceSave(learnerId) {
     const entry = pendingPreferenceSaves.get(learnerId);
     if (!entry) return null;
     if (entry.timer) clearTimeout(entry.timer);
     pendingPreferenceSaves.delete(learnerId);
-    return entry.prefs && typeof entry.prefs === 'object' && !Array.isArray(entry.prefs) ? entry.prefs : null;
+    return entry.prefs && typeof entry.prefs === 'object' && !Array.isArray(entry.prefs) ? entry : null;
   }
 
-  function trackPreferenceSave(learnerId, prefs) {
+  function trackPreferenceSave(learnerId, prefs, preferenceVersion = 0) {
     const previous = preferenceSaveChains.get(learnerId) || Promise.resolve();
     let tracked;
     const next = previous
       .catch(() => {})
-      .then(() => sendCommand('save-prefs', { prefs }, { learnerId }));
+      .then(() => sendCommand('save-prefs', { prefs }, { learnerId, preferenceVersion }));
     tracked = next.finally(() => {
       if (preferenceSaveChains.get(learnerId) === tracked) {
         preferenceSaveChains.delete(learnerId);
@@ -263,9 +296,9 @@ export function createRemoteSpellingActionHandler({
 
   function flushPendingPreferenceSave(learnerId) {
     if (!learnerId) return Promise.resolve(null);
-    const pendingPrefs = takePendingPreferenceSave(learnerId);
-    if (pendingPrefs && Object.keys(pendingPrefs).length) {
-      return trackPreferenceSave(learnerId, pendingPrefs);
+    const pending = takePendingPreferenceSave(learnerId);
+    if (pending?.prefs && Object.keys(pending.prefs).length) {
+      return trackPreferenceSave(learnerId, pending.prefs, pending.version);
     }
     return preferenceSaveChains.get(learnerId) || Promise.resolve(null);
   }
@@ -279,16 +312,13 @@ export function createRemoteSpellingActionHandler({
     if (!learnerId) return false;
     const patch = prefsPatch && typeof prefsPatch === 'object' && !Array.isArray(prefsPatch) ? prefsPatch : {};
     if (!Object.keys(patch).length) return true;
+    const intent = recordPreferenceIntent(learnerId, patch);
     const current = pendingPreferenceSaves.get(learnerId);
     if (current?.timer) clearTimeout(current.timer);
-    const prefs = {
-      ...(current?.prefs || {}),
-      ...patch,
-    };
     const timer = setTimeout(() => {
       flushPendingPreferenceSave(learnerId).catch(handlePreferenceSaveError);
     }, preferenceSaveDelayMs());
-    pendingPreferenceSaves.set(learnerId, { prefs, timer });
+    pendingPreferenceSaves.set(learnerId, { prefs: intent.prefs, version: intent.version, timer });
     return true;
   }
 
@@ -606,8 +636,9 @@ export function createRemoteSpellingActionHandler({
       tts.stop();
       (async () => {
         await flushPendingPreferenceSave(learnerId);
+        const intent = recordPreferenceIntent(learnerId, { mode });
         updateOptimisticPrefs({ mode });
-        await sendCommand('save-prefs', { prefs: { mode } }, { learnerId });
+        await sendCommand('save-prefs', { prefs: { mode } }, { learnerId, preferenceVersion: intent?.version || 0 });
         const prefs = spelling?.getPrefs?.(learnerId) || { mode };
         await sendCommand('start-session', {
           mode: prefs.mode || mode,

--- a/tests/spelling-remote-actions.test.js
+++ b/tests/spelling-remote-actions.test.js
@@ -10,6 +10,10 @@ function flushPromises() {
   return Promise.resolve().then(() => Promise.resolve());
 }
 
+function flushTimers() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 function deferred() {
   let resolve;
   let reject;
@@ -142,6 +146,118 @@ test('remote spelling actions dedupe in-flight session commands and release afte
   await flushPromises();
   assert.equal(handler.handle('spelling-submit-form', { formData }), true);
   assert.equal(sent.length, 2);
+});
+
+test('remote spelling setup preference changes are coalesced before saving', async () => {
+  const { getState, store } = createStoreHarness({
+    subjectUi: {
+      spelling: {
+        phase: 'dashboard',
+        prefs: {
+          mode: 'smart',
+          roundLength: '10',
+          yearFilter: 'core',
+          autoSpeak: true,
+          showCloze: true,
+        },
+        analytics: null,
+        error: '',
+      },
+    },
+  });
+  const sent = [];
+  const handler = createRemoteSpellingActionHandler({
+    store,
+    services: {
+      spelling: {
+        getPrefs() {
+          return getState().subjectUi.spelling.prefs;
+        },
+      },
+    },
+    tts: createTtsHarness(),
+    readModels: { readJson: async () => ({}) },
+    subjectCommands: {
+      send(request) {
+        sent.push(request);
+        return Promise.resolve({ subjectReadModel: { phase: 'dashboard' } });
+      },
+    },
+    preferenceSaveDebounceMs: 0,
+  });
+
+  assert.equal(handler.handle('spelling-set-pref', { pref: 'roundLength', value: '5' }), true);
+  assert.equal(handler.handle('spelling-set-pref', { pref: 'yearFilter', value: 'extra' }), true);
+  assert.equal(handler.handle('spelling-toggle-pref', { pref: 'autoSpeak' }), true);
+
+  assert.equal(sent.length, 0);
+  assert.equal(getState().subjectUi.spelling.prefs.roundLength, '5');
+  assert.equal(getState().subjectUi.spelling.prefs.yearFilter, 'extra');
+  assert.equal(getState().subjectUi.spelling.prefs.autoSpeak, false);
+
+  await flushTimers();
+  await flushPromises();
+
+  assert.equal(sent.length, 1);
+  assert.equal(sent[0].command, 'save-prefs');
+  assert.deepEqual(sent[0].payload, {
+    prefs: {
+      roundLength: '5',
+      yearFilter: 'extra',
+      autoSpeak: false,
+    },
+  });
+});
+
+test('remote spelling start flushes pending setup preferences first', async () => {
+  const { getState, store } = createStoreHarness({
+    subjectUi: {
+      spelling: {
+        phase: 'dashboard',
+        prefs: {
+          mode: 'smart',
+          roundLength: '10',
+          yearFilter: 'core',
+          autoSpeak: true,
+          showCloze: true,
+          extraWordFamilies: false,
+        },
+        analytics: null,
+        error: '',
+      },
+    },
+  });
+  const sent = [];
+  const handler = createRemoteSpellingActionHandler({
+    store,
+    services: {
+      spelling: {
+        getPrefs() {
+          return getState().subjectUi.spelling.prefs;
+        },
+      },
+    },
+    tts: createTtsHarness(),
+    readModels: { readJson: async () => ({}) },
+    subjectCommands: {
+      send(request) {
+        sent.push(request);
+        return Promise.resolve({ subjectReadModel: { phase: request.command === 'start-session' ? 'session' : 'dashboard' } });
+      },
+    },
+    preferenceSaveDebounceMs: 10_000,
+  });
+
+  assert.equal(handler.handle('spelling-set-pref', { pref: 'roundLength', value: '5' }), true);
+  assert.equal(handler.handle('spelling-start'), true);
+
+  await flushTimers();
+  await flushPromises();
+
+  assert.deepEqual(sent.map((request) => request.command), ['save-prefs', 'start-session']);
+  assert.deepEqual(sent[0].payload, { prefs: { roundLength: '5' } });
+  assert.equal(sent[1].payload.length, '5');
+  assert.equal(sent[1].payload.mode, 'smart');
 });
 
 test('remote spelling command response preserves reward side effects and TTS stop rules', () => {

--- a/tests/spelling-remote-actions.test.js
+++ b/tests/spelling-remote-actions.test.js
@@ -260,6 +260,80 @@ test('remote spelling start flushes pending setup preferences first', async () =
   assert.equal(sent[1].payload.mode, 'smart');
 });
 
+test('remote spelling keeps newer pending preferences when an older save response reloads', async () => {
+  const { getState, store } = createStoreHarness({
+    subjectUi: {
+      spelling: {
+        phase: 'dashboard',
+        prefs: {
+          mode: 'smart',
+          roundLength: '10',
+          yearFilter: 'core',
+          autoSpeak: true,
+          showCloze: true,
+        },
+        analytics: null,
+        error: '',
+      },
+    },
+  });
+  const firstSave = deferred();
+  const sent = [];
+  const handler = createRemoteSpellingActionHandler({
+    store,
+    services: {
+      spelling: {
+        getPrefs() {
+          return getState().subjectUi.spelling.prefs;
+        },
+      },
+    },
+    tts: createTtsHarness(),
+    readModels: { readJson: async () => ({}) },
+    subjectCommands: {
+      send(request) {
+        sent.push(request);
+        if (sent.length === 1) return firstSave.promise;
+        return Promise.resolve({ subjectReadModel: { phase: 'dashboard' } });
+      },
+    },
+    preferenceSaveDebounceMs: 0,
+  });
+
+  assert.equal(handler.handle('spelling-set-pref', { pref: 'roundLength', value: '5' }), true);
+  await flushTimers();
+  await flushPromises();
+  assert.equal(sent.length, 1);
+
+  assert.equal(handler.handle('spelling-set-pref', { pref: 'yearFilter', value: 'extra' }), true);
+  await flushTimers();
+  await flushPromises();
+  assert.equal(sent.length, 1);
+  assert.equal(getState().subjectUi.spelling.prefs.yearFilter, 'extra');
+
+  store.updateSubjectUi('spelling', (current = {}) => ({
+    ...current,
+    prefs: {
+      ...(current.prefs || {}),
+      roundLength: '5',
+      yearFilter: 'core',
+    },
+  }));
+  firstSave.resolve({ subjectReadModel: { phase: 'dashboard' } });
+  await flushPromises();
+  await flushPromises();
+
+  assert.equal(getState().subjectUi.spelling.prefs.roundLength, '5');
+  assert.equal(getState().subjectUi.spelling.prefs.yearFilter, 'extra');
+  assert.equal(sent.length, 2);
+  assert.deepEqual(sent[1].payload, {
+    prefs: {
+      roundLength: '5',
+      yearFilter: 'extra',
+    },
+  });
+});
+
 test('remote spelling command response preserves reward side effects and TTS stop rules', () => {
   const { calls, store } = createStoreHarness();
   const tts = createTtsHarness();


### PR DESCRIPTION
## Summary
- Coalesce rapid spelling setup preference changes into a single debounced `save-prefs` command while keeping the setup UI responsive.
- Flush pending preference saves before starting a spelling session so the latest options are persisted and used for the round.
- Reconcile stale in-flight `save-prefs` responses so older server read models cannot overwrite newer local option intent.
- Add regression coverage for rapid option changes, change-then-start behaviour, and stale save response ordering.

## Verification
- `npm test`
- `npm run check`