### PR TITLE
fix(spelling): guard repeated session starts

### DIFF
--- a/src/platform/core/store.js
+++ b/src/platform/core/store.js
@@ -165,6 +165,9 @@ function normaliseTransientUi(rawValue) {
     ? cloneSerialisable(raw.spellingWordDetail)
     : null;
   return {
+    spellingPendingCommand: typeof raw.spellingPendingCommand === 'string'
+      ? raw.spellingPendingCommand.slice(0, 80)
+      : '',
     spellingAnalyticsWordSearch: typeof raw.spellingAnalyticsWordSearch === 'string'
       ? raw.spellingAnalyticsWordSearch.slice(0, 80)
       : '',
@@ -200,6 +203,7 @@ function isCleanSpellingSetupEntry(spellingUi, transientUi) {
     && !spellingUi.summary
     && !spellingUi.error
     && !spellingUi.awaitingAdvance
+    && !transientUi?.spellingPendingCommand
     && !transientUi?.spellingWordDetailSlug
     && !transientUi?.spellingWordDetail
     && !transientUi?.spellingWordBankDrillTyped

--- a/src/subjects/spelling/components/SpellingSessionScene.jsx
+++ b/src/subjects/spelling/components/SpellingSessionScene.jsx
@@ -59,7 +59,10 @@ export function SpellingSessionScene({
 
   const showCloze = prefs.showCloze && session.type !== 'test';
   const awaitingAdvance = Boolean(ui.awaitingAdvance);
+  const pendingCommand = ui.pendingCommand || '';
+  const pending = Boolean(pendingCommand);
   const submitLabel = spellingSessionSubmitLabel(session, awaitingAdvance);
+  const effectiveSubmitLabel = pendingCommand === 'submit-answer' ? 'Checking...' : submitLabel;
   const inputPlaceholder = spellingSessionInputPlaceholder(session);
   const contextNote = spellingSessionContextNote(session);
   const voiceNote = spellingSessionVoiceNote();
@@ -141,7 +144,7 @@ export function SpellingSessionScene({
                 {...spellingAnswerInputProps}
                 placeholder={inputPlaceholder}
                 aria-label="Type the spelling"
-                disabled={awaitingAdvance || runtimeReadOnly}
+                disabled={awaitingAdvance || runtimeReadOnly || pending}
               />
             </div>
             <div className="audio-row">
@@ -167,15 +170,15 @@ export function SpellingSessionScene({
               </button>
             </div>
             <div className="action-row">
-              <button className="btn primary lg" style={{ '--btn-accent': accent }} type="submit" disabled={awaitingAdvance || runtimeReadOnly}>
-                {submitLabel}{awaitingAdvance ? null : <> <ArrowRightIcon /></>}
+              <button className="btn primary lg" style={{ '--btn-accent': accent }} type="submit" disabled={awaitingAdvance || runtimeReadOnly || pending}>
+                {effectiveSubmitLabel}{awaitingAdvance || pending ? null : <> <ArrowRightIcon /></>}
               </button>
               {awaitingAdvance ? (
                 <button
                   className="btn good lg"
                   type="button"
                   data-action="spelling-continue"
-                  disabled={runtimeReadOnly}
+                  disabled={runtimeReadOnly || pending}
                   onClick={(event) => renderAction(actions, event, 'spelling-continue', {
                     flowTransition: isCompletingRound,
                   })}
@@ -188,7 +191,7 @@ export function SpellingSessionScene({
                   className="btn ghost lg"
                   type="button"
                   data-action="spelling-skip"
-                  disabled={runtimeReadOnly}
+                  disabled={runtimeReadOnly || pending}
                   onClick={(event) => renderAction(actions, event, 'spelling-skip')}
                 >
                   Skip for now
@@ -212,7 +215,7 @@ export function SpellingSessionScene({
               className="btn sm bad"
               type="button"
               data-action="spelling-end-early"
-              disabled={runtimeReadOnly}
+              disabled={runtimeReadOnly || pending}
               onClick={(event) => renderAction(actions, event, 'spelling-end-early')}
             >
               End round early

--- a/src/subjects/spelling/components/SpellingSetupScene.jsx
+++ b/src/subjects/spelling/components/SpellingSetupScene.jsx
@@ -112,7 +112,7 @@ function YearPicker({ prefs, actions, disabled = false }) {
   );
 }
 
-function ToggleChip({ pref, checked, label, actions, runtimeReadOnly = false }) {
+function ToggleChip({ pref, checked, label, actions, disabled = false }) {
   return (
     <button
       type="button"
@@ -120,7 +120,7 @@ function ToggleChip({ pref, checked, label, actions, runtimeReadOnly = false }) 
       aria-pressed={checked ? 'true' : 'false'}
       data-action="spelling-toggle-pref"
       data-pref={pref}
-      disabled={runtimeReadOnly}
+      disabled={disabled}
       onClick={(event) => renderAction(actions, event, 'spelling-toggle-pref', { pref })}
     >
       <span className="box" aria-hidden="true">{checked ? <CheckIcon /> : null}</span>
@@ -173,6 +173,7 @@ export function SpellingSetupScene({
   repositories,
   subject,
   prefs,
+  ui,
   codex,
   accent,
   actions,
@@ -192,6 +193,14 @@ export function SpellingSetupScene({
   const heroContrast = useSetupHeroContrast(heroBg, prefs.mode);
   const heroTone = heroContrast.contrast.tone || heroToneForBg(heroBg);
   const setupClasses = ['setup-main'];
+  const pendingCommand = ui?.pendingCommand || '';
+  const preferenceControlsDisabled = runtimeReadOnly || Boolean(pendingCommand && pendingCommand !== 'save-prefs');
+  const startDisabled = runtimeReadOnly || Boolean(pendingCommand);
+  const beginText = pendingCommand === 'start-session'
+    ? 'Starting...'
+    : pendingCommand === 'save-prefs'
+      ? 'Saving...'
+      : begin;
   if (heroContrast.contrast.shell === 'light') setupClasses.push('hero-dark');
 
   return (
@@ -228,7 +237,7 @@ export function SpellingSetupScene({
                   <ModeCard
                     mode={mode}
                     selected={prefs.mode === mode.id}
-                    disabled={runtimeReadOnly}
+                    disabled={preferenceControlsDisabled}
                     actions={actions}
                     textTone={heroContrast.contrast.cards[index] || heroContrast.contrast.shell}
                     key={mode.id}
@@ -239,18 +248,18 @@ export function SpellingSetupScene({
           <div className="setup-control-stack">
             <div className={tweakClass} {...tweakAria}>
               <span className="tool-label">Round length</span>
-              <LengthPicker prefs={prefs} actions={actions} disabled={hideTweaks || runtimeReadOnly} />
+              <LengthPicker prefs={prefs} actions={actions} disabled={hideTweaks || preferenceControlsDisabled} />
             </div>
             <div className={tweakClass} {...tweakAria}>
               <span className="tool-label">Pool</span>
-              <YearPicker prefs={prefs} actions={actions} disabled={hideTweaks || runtimeReadOnly} />
+              <YearPicker prefs={prefs} actions={actions} disabled={hideTweaks || preferenceControlsDisabled} />
             </div>
             <div className="tweak-row">
               <span className="tool-label">Options</span>
-              <ToggleChip pref="showCloze" checked={Boolean(prefs.showCloze)} label="Show sentence" actions={actions} runtimeReadOnly={runtimeReadOnly} />
-              <ToggleChip pref="autoSpeak" checked={Boolean(prefs.autoSpeak)} label="Auto-play audio" actions={actions} runtimeReadOnly={runtimeReadOnly} />
+              <ToggleChip pref="showCloze" checked={Boolean(prefs.showCloze)} label="Show sentence" actions={actions} disabled={preferenceControlsDisabled} />
+              <ToggleChip pref="autoSpeak" checked={Boolean(prefs.autoSpeak)} label="Auto-play audio" actions={actions} disabled={preferenceControlsDisabled} />
               {showExtraFamilyOption ? (
-                <ToggleChip pref="extraWordFamilies" checked={Boolean(prefs.extraWordFamilies)} label="Word-family variants" actions={actions} runtimeReadOnly={runtimeReadOnly} />
+                <ToggleChip pref="extraWordFamilies" checked={Boolean(prefs.extraWordFamilies)} label="Word-family variants" actions={actions} disabled={preferenceControlsDisabled} />
               ) : <span className="toggle-chip option-placeholder" aria-hidden="true" />}
             </div>
           </div>
@@ -260,10 +269,10 @@ export function SpellingSetupScene({
               className="btn primary xl"
               style={{ '--btn-accent': accent }}
               data-action="spelling-start"
-              disabled={runtimeReadOnly}
+              disabled={startDisabled}
               onClick={(event) => renderAction(actions, event, 'spelling-start')}
             >
-              {begin} <ArrowRightIcon />
+              {beginText} <ArrowRightIcon />
             </button>
           </div>
         </div>

--- a/src/subjects/spelling/components/SpellingSummaryScene.jsx
+++ b/src/subjects/spelling/components/SpellingSummaryScene.jsx
@@ -26,6 +26,8 @@ function SummaryStatGrid({ cards = [] }) {
 export function SpellingSummaryScene({ learner, ui, accent, actions, previousHeroBg = '', runtimeReadOnly = false }) {
   const summary = ui.summary;
   if (!summary) return null;
+  const pendingCommand = ui.pendingCommand || '';
+  const pending = Boolean(pendingCommand);
   const progressTotal = Math.max(1, summary.totalWords || 1);
   const heroBg = heroBgForSession(learner.id, {
     mode: summary.mode,
@@ -67,7 +69,7 @@ export function SpellingSummaryScene({ learner, ui, accent, actions, previousHer
                     data-action="spelling-drill-single"
                     data-slug={word.slug}
                     key={word.slug}
-                    disabled={runtimeReadOnly}
+                    disabled={runtimeReadOnly || pending}
                     onClick={(event) => renderAction(actions, event, 'spelling-drill-single', { slug: word.slug })}
                   >
                     {word.word}
@@ -77,7 +79,7 @@ export function SpellingSummaryScene({ learner, ui, accent, actions, previousHer
                   type="button"
                   className="btn primary sm"
                   data-action="spelling-drill-all"
-                  disabled={runtimeReadOnly}
+                  disabled={runtimeReadOnly || pending}
                   onClick={(event) => renderAction(actions, event, 'spelling-drill-all')}
                 >
                   Drill all {summary.mistakes.length} <ArrowRightIcon />
@@ -100,10 +102,10 @@ export function SpellingSummaryScene({ learner, ui, accent, actions, previousHer
               className="btn primary lg"
               style={{ '--btn-accent': accent }}
               data-action="spelling-start-again"
-              disabled={runtimeReadOnly}
+              disabled={runtimeReadOnly || pending}
               onClick={(event) => renderAction(actions, event, 'spelling-start-again')}
             >
-              Start another round <ArrowRightIcon />
+              {pendingCommand === 'start-session' ? 'Starting...' : 'Start another round'} <ArrowRightIcon />
             </button>
             <button
               type="button"

--- a/src/subjects/spelling/components/spelling-view-model.js
+++ b/src/subjects/spelling/components/spelling-view-model.js
@@ -481,7 +481,10 @@ export function findWordBankEntry(analytics, slug) {
 
 export function buildSpellingContext({ appState, service, repositories, subject }) {
   const learner = appState.learners.byId[appState.learners.selectedId];
-  const ui = service.initState(appState.subjectUi.spelling, learner.id);
+  const ui = {
+    ...service.initState(appState.subjectUi.spelling, learner.id),
+    pendingCommand: appState.transientUi?.spellingPendingCommand || '',
+  };
   const needsAnalytics = ui.phase === 'dashboard' || ui.phase === 'word-bank';
   const analytics = needsAnalytics ? service.getAnalyticsSnapshot(learner.id) : null;
   return {

--- a/src/subjects/spelling/remote-actions.js
+++ b/src/subjects/spelling/remote-actions.js
@@ -21,7 +21,14 @@ const SPELLING_COMMAND_ACTIONS = new Set([
   'spelling-drill-single',
 ]);
 
+const SPELLING_SETUP_PREF_ACTIONS = new Set([
+  'spelling-set-mode',
+  'spelling-set-pref',
+  'spelling-toggle-pref',
+]);
+
 const SPELLING_IN_FLIGHT_DEDUPE_COMMANDS = new Set([
+  'save-prefs',
   'start-session',
   'submit-answer',
   'continue-session',
@@ -57,6 +64,17 @@ function commandErrorMessage(error, fallback) {
   return error?.payload?.message || error?.message || fallback;
 }
 
+function spellingPendingCommand(appState = {}) {
+  return appState.transientUi?.spellingPendingCommand || '';
+}
+
+function pendingCommandBlocksAction(action, appState = {}) {
+  const pendingCommand = spellingPendingCommand(appState);
+  if (!pendingCommand || !SPELLING_COMMAND_ACTIONS.has(action)) return false;
+  if (pendingCommand === 'save-prefs' && SPELLING_SETUP_PREF_ACTIONS.has(action)) return false;
+  return true;
+}
+
 export function shouldHandleRemoteSpellingAction(action) {
   return SPELLING_COMMAND_ACTIONS.has(action)
     || SPELLING_UI_LOCAL_ACTIONS.has(action)
@@ -74,6 +92,7 @@ export function spellingCommandDedupeKey(command, appState = {}) {
   const learnerId = appState.learners?.selectedId || '';
   if (!learnerId) return '';
   if (command === 'start-session') return `${command}:${learnerId}:setup`;
+  if (command === 'save-prefs') return `${command}:${learnerId}:prefs`;
   const session = appState.subjectUi?.spelling?.session || {};
   const sessionId = session.id || '';
   if (!sessionId) return '';
@@ -210,6 +229,48 @@ export function createRemoteSpellingActionHandler({
     }
   }
 
+  function setPendingCommand(command, { preserveExisting = false } = {}) {
+    if (!SPELLING_IN_FLIGHT_DEDUPE_COMMANDS.has(command)) return false;
+    if (preserveExisting && spellingPendingCommand(appState())) return false;
+    store.patch((current) => ({
+      transientUi: {
+        ...current.transientUi,
+        spellingPendingCommand: command,
+      },
+    }));
+    return true;
+  }
+
+  function clearPendingCommand(command) {
+    if (!SPELLING_IN_FLIGHT_DEDUPE_COMMANDS.has(command)) return;
+    store.patch((current) => {
+      if (current.transientUi?.spellingPendingCommand !== command) return {};
+      return {
+        transientUi: {
+          ...current.transientUi,
+          spellingPendingCommand: '',
+        },
+      };
+    });
+  }
+
+  function beginPendingCommand(command) {
+    const state = appState();
+    const dedupeKey = spellingCommandDedupeKey(command, state);
+    if (dedupeKey && pendingCommandKeys.has(dedupeKey)) return { ok: false, dedupeKey: '' };
+    if (SPELLING_IN_FLIGHT_DEDUPE_COMMANDS.has(command) && spellingPendingCommand(state)) {
+      return { ok: false, dedupeKey: '' };
+    }
+    if (dedupeKey) pendingCommandKeys.add(dedupeKey);
+    setPendingCommand(command);
+    return { ok: true, dedupeKey };
+  }
+
+  function releasePendingCommand(command, dedupeKey) {
+    if (dedupeKey) pendingCommandKeys.delete(dedupeKey);
+    clearPendingCommand(command);
+  }
+
   async function sendCommand(command, payload = {}, { learnerId: requestedLearnerId = '', preferenceVersion = 0 } = {}) {
     const state = appState();
     const learnerId = requestedLearnerId || state.learners?.selectedId;
@@ -284,10 +345,16 @@ export function createRemoteSpellingActionHandler({
     let tracked;
     const next = previous
       .catch(() => {})
-      .then(() => sendCommand('save-prefs', { prefs }, { learnerId, preferenceVersion }));
+      .then(() => {
+        setPendingCommand('save-prefs', { preserveExisting: true });
+        return sendCommand('save-prefs', { prefs }, { learnerId, preferenceVersion });
+      });
     tracked = next.finally(() => {
       if (preferenceSaveChains.get(learnerId) === tracked) {
         preferenceSaveChains.delete(learnerId);
+        if (spellingPendingCommand(appState()) === 'save-prefs') {
+          clearPendingCommand('save-prefs');
+        }
       }
     });
     preferenceSaveChains.set(learnerId, tracked);
@@ -323,9 +390,8 @@ export function createRemoteSpellingActionHandler({
   }
 
   function runCommand(command, payload = {}, { learnerId: requestedLearnerId = '', beforeSend = null } = {}) {
-    const dedupeKey = spellingCommandDedupeKey(command, appState());
-    if (dedupeKey && pendingCommandKeys.has(dedupeKey)) return false;
-    if (dedupeKey) pendingCommandKeys.add(dedupeKey);
+    const pending = beginPendingCommand(command);
+    if (!pending.ok) return false;
     const commandPromise = typeof beforeSend === 'function'
       ? Promise.resolve()
         .then(beforeSend)
@@ -335,7 +401,7 @@ export function createRemoteSpellingActionHandler({
       globalThis.console?.warn?.('Spelling command failed.', error);
       setRuntimeError(commandErrorMessage(error, 'The spelling command could not be completed.'));
     }).finally(() => {
-      if (dedupeKey) pendingCommandKeys.delete(dedupeKey);
+      releasePendingCommand(command, pending.dedupeKey);
     });
     return true;
   }
@@ -586,6 +652,10 @@ export function createRemoteSpellingActionHandler({
       return true;
     }
 
+    if (pendingCommandBlocksAction(action, state)) {
+      return true;
+    }
+
     if (action === 'spelling-set-pref') {
       const patch = { [data.pref]: data.value };
       updateOptimisticPrefs(patch);
@@ -633,6 +703,8 @@ export function createRemoteSpellingActionHandler({
         const confirmed = globalThis.confirm?.('End the current spelling session and switch?');
         if (confirmed === false) return true;
       }
+      const pending = beginPendingCommand('start-session');
+      if (!pending.ok) return true;
       tts.stop();
       (async () => {
         await flushPendingPreferenceSave(learnerId);
@@ -649,6 +721,8 @@ export function createRemoteSpellingActionHandler({
       })().catch((error) => {
         globalThis.console?.warn?.('Spelling shortcut command failed.', error);
         setRuntimeError(commandErrorMessage(error, 'The spelling shortcut could not be completed.'));
+      }).finally(() => {
+        releasePendingCommand('start-session', pending.dedupeKey);
       });
       return true;
     }

--- a/tests/helpers/react-render.js
+++ b/tests/helpers/react-render.js
@@ -296,7 +296,7 @@ export function renderSubjectRouteFixture({ subject = 'placeholder' } = {}) {
   `);
 }
 
-export function renderSpellingSurfaceFixture({ phase = 'setup' } = {}) {
+export function renderSpellingSurfaceFixture({ phase = 'setup', pendingCommand = '' } = {}) {
   return renderFixture(`
     import React from 'react';
     import { renderToStaticMarkup } from 'react-dom/server';
@@ -332,6 +332,15 @@ export function renderSpellingSurfaceFixture({ phase = 'setup' } = {}) {
     }
     if (selectedPhase === 'modal') {
       controller.dispatch('spelling-word-detail-open', { slug: 'possess', value: 'drill' });
+    }
+    const pendingCommand = ${JSON.stringify(pendingCommand)};
+    if (pendingCommand) {
+      controller.store.patch((current) => ({
+        transientUi: {
+          ...current.transientUi,
+          spellingPendingCommand: pendingCommand,
+        },
+      }));
     }
     const appState = controller.store.getState();
     const context = controller.contextFor('spelling');

--- a/tests/react-spelling-surface.test.js
+++ b/tests/react-spelling-surface.test.js
@@ -15,6 +15,26 @@ test('React spelling setup scene renders primary practice controls', async () =>
   assert.match(html, /data-action="spelling-start"/);
 });
 
+test('React spelling setup scene disables start while a remote start is pending', async () => {
+  const html = await renderSpellingSurfaceFixture({
+    phase: 'setup',
+    pendingCommand: 'start-session',
+  });
+
+  assert.match(html, /Starting\.\.\./);
+  assert.match(html, /<button[^>]*data-action="spelling-start"[^>]*disabled=""/);
+});
+
+test('React spelling setup scene disables start while options are saving', async () => {
+  const html = await renderSpellingSurfaceFixture({
+    phase: 'setup',
+    pendingCommand: 'save-prefs',
+  });
+
+  assert.match(html, /Saving\.\.\./);
+  assert.match(html, /<button[^>]*data-action="spelling-start"[^>]*disabled=""/);
+});
+
 test('client spelling read model preserves word-family variant preference', () => {
   const service = createSpellingReadModelService({
     getState: () => ({

--- a/tests/spelling-remote-actions.test.js
+++ b/tests/spelling-remote-actions.test.js
@@ -100,6 +100,9 @@ function createTtsHarness() {
 
 test('spelling command dedupe key includes learner and prompt context', () => {
   assert.equal(spellingCommandDedupeKey('save-prefs', {}), '');
+  assert.equal(spellingCommandDedupeKey('save-prefs', {
+    learners: { selectedId: 'learner-a' },
+  }), 'save-prefs:learner-a:prefs');
   assert.equal(spellingCommandDedupeKey('start-session', {
     learners: { selectedId: 'learner-a' },
   }), 'start-session:learner-a:setup');
@@ -258,6 +261,121 @@ test('remote spelling start flushes pending setup preferences first', async () =
   assert.deepEqual(sent[0].payload, { prefs: { roundLength: '5' } });
   assert.equal(sent[1].payload.length, '5');
   assert.equal(sent[1].payload.mode, 'smart');
+});
+
+test('remote spelling start marks pending and ignores duplicate clicks before settlement', async () => {
+  const { getState, store } = createStoreHarness({
+    subjectUi: {
+      spelling: {
+        phase: 'dashboard',
+        prefs: {
+          mode: 'smart',
+          roundLength: '20',
+          yearFilter: 'core',
+          extraWordFamilies: false,
+        },
+        analytics: null,
+        audio: null,
+        error: '',
+      },
+    },
+  });
+  const tts = createTtsHarness();
+  const pending = deferred();
+  const sent = [];
+  const handler = createRemoteSpellingActionHandler({
+    store,
+    services: {
+      spelling: {
+        getPrefs() {
+          return getState().subjectUi.spelling.prefs;
+        },
+      },
+    },
+    tts,
+    readModels: { readJson: async () => ({}) },
+    subjectCommands: {
+      send(request) {
+        sent.push(request);
+        return pending.promise;
+      },
+    },
+  });
+
+  assert.equal(handler.handle('spelling-start'), true);
+  assert.equal(getState().transientUi.spellingPendingCommand, 'start-session');
+  assert.equal(handler.handle('spelling-start'), true);
+  await flushPromises();
+  assert.equal(sent.length, 1);
+  assert.equal(tts.stopCalls, 1);
+
+  pending.resolve({ subjectReadModel: { phase: 'session' } });
+  await flushPromises();
+  await flushPromises();
+  assert.equal(getState().transientUi.spellingPendingCommand, '');
+});
+
+test('remote spelling start waits while an option save is in flight', async () => {
+  const { getState, store } = createStoreHarness({
+    subjectUi: {
+      spelling: {
+        phase: 'dashboard',
+        prefs: {
+          mode: 'smart',
+          roundLength: '10',
+          yearFilter: 'core',
+          autoSpeak: true,
+          showCloze: true,
+          extraWordFamilies: false,
+        },
+        analytics: null,
+        error: '',
+      },
+    },
+  });
+  const firstSave = deferred();
+  const tts = createTtsHarness();
+  const sent = [];
+  const handler = createRemoteSpellingActionHandler({
+    store,
+    services: {
+      spelling: {
+        getPrefs() {
+          return getState().subjectUi.spelling.prefs;
+        },
+      },
+    },
+    tts,
+    readModels: { readJson: async () => ({}) },
+    subjectCommands: {
+      send(request) {
+        sent.push(request);
+        if (request.command === 'save-prefs') return firstSave.promise;
+        return Promise.resolve({ subjectReadModel: { phase: 'session' } });
+      },
+    },
+    preferenceSaveDebounceMs: 0,
+  });
+
+  assert.equal(handler.handle('spelling-set-pref', { pref: 'roundLength', value: '5' }), true);
+  await flushTimers();
+  await flushPromises();
+  assert.deepEqual(sent.map((request) => request.command), ['save-prefs']);
+  assert.equal(getState().transientUi.spellingPendingCommand, 'save-prefs');
+
+  assert.equal(handler.handle('spelling-start'), true);
+  await flushPromises();
+  assert.deepEqual(sent.map((request) => request.command), ['save-prefs']);
+  assert.equal(tts.stopCalls, 0);
+
+  firstSave.resolve({ subjectReadModel: { phase: 'dashboard' } });
+  await flushPromises();
+  await flushPromises();
+  assert.equal(getState().transientUi.spellingPendingCommand, '');
+
+  assert.equal(handler.handle('spelling-start'), true);
+  await flushPromises();
+  assert.deepEqual(sent.map((request) => request.command), ['save-prefs', 'start-session']);
 });
 
 test('remote spelling keeps newer pending preferences when an older save response reloads', async () => {


### PR DESCRIPTION
## Summary
- Add a transient pending-command guard for remote Spelling commands so repeated Start Session clicks are ignored while the first command is in flight.
- Include `save-prefs` in the pending guard: Start is blocked while option saves are in flight, but setup option edits remain usable so the latest preference intent is preserved.
- Disable Spelling setup, session, and summary command controls while relevant remote commands are pending, with Saving... / Starting... feedback on setup actions.
- Rebase the branch onto current `origin/main` and reconcile the stale PR conflicts in the Spelling remote actions and tests.

## Verification
- `node --test --test-name-pattern='remote spelling|React spelling setup' tests/spelling-remote-actions.test.js tests/react-spelling-surface.test.js`
- `npm test` (494 pass / 1 skipped)
- `npm run check`
- `git diff --check`