### PR TITLE
feat(grammar): enable trouble drill mode

### DIFF
--- a/src/subjects/grammar/components/GrammarSetupScene.jsx
+++ b/src/subjects/grammar/components/GrammarSetupScene.jsx
@@ -36,7 +36,8 @@ export function GrammarSetupScene({ learner, grammar, actions, runtimeReadOnly }
   const counts = grammar.stats?.concepts || {};
   const templates = grammar.stats?.templates || {};
   const selectedMode = grammar.prefs?.mode || 'smart';
-  const selectedFocus = grammar.prefs?.focusConceptId || '';
+  const troubleMode = selectedMode === 'trouble';
+  const selectedFocus = troubleMode ? '' : (grammar.prefs?.focusConceptId || '');
   const groupedConcepts = groupedGrammarConcepts(grammar.analytics?.concepts || []);
   const setupDisabled = runtimeReadOnly || Boolean(grammar.pendingCommand);
 
@@ -103,10 +104,10 @@ export function GrammarSetupScene({ learner, grammar, actions, runtimeReadOnly }
               <select
                 className="input"
                 value={selectedFocus}
-                disabled={setupDisabled}
+                disabled={setupDisabled || troubleMode}
                 onChange={(event) => actions.dispatch('grammar-set-focus', { value: event.currentTarget.value })}
               >
-                <option value="">Smart mix</option>
+                <option value="">{troubleMode ? 'Weakest concept' : 'Smart mix'}</option>
                 {(grammar.analytics?.concepts || []).map((concept) => (
                   <option value={concept.id} key={concept.id}>{concept.name}</option>
                 ))}

--- a/src/subjects/grammar/metadata.js
+++ b/src/subjects/grammar/metadata.js
@@ -135,10 +135,10 @@ export const GRAMMAR_ENABLED_MODES = Object.freeze([
   { id: 'learn', label: 'Learn a concept', detail: 'Focused retrieval on one concept at a time.' },
   { id: 'smart', label: 'Smart mixed review', detail: 'Worker-selected review across Grammar concepts.' },
   { id: 'satsset', label: 'KS2-style mini-set', detail: 'A short mixed set with SATs-friendly question shapes.' },
+  { id: 'trouble', label: 'Weak concepts drill', detail: 'Targets the weakest Grammar concepts with retry pressure.' },
 ]);
 
 export const GRAMMAR_LOCKED_MODES = Object.freeze([
-  { id: 'trouble', label: 'Weak concepts drill', reason: 'coming-next' },
   { id: 'surgery', label: 'Sentence surgery', reason: 'coming-next' },
   { id: 'builder', label: 'Sentence builder', reason: 'coming-next' },
   { id: 'worked', label: 'Worked examples', reason: 'coming-next' },
@@ -308,6 +308,27 @@ function progressSnapshotFromConcepts(concepts) {
   };
 }
 
+function modeById(modes = []) {
+  return new Map((Array.isArray(modes) ? modes : [])
+    .filter((mode) => mode && typeof mode === 'object' && !Array.isArray(mode) && typeof mode.id === 'string')
+    .map((mode) => [mode.id, mode]));
+}
+
+function mergeModeList(currentModes, rawModes = []) {
+  const rawById = modeById(rawModes);
+  return currentModes.map((mode) => {
+    const rawMode = rawById.get(mode.id) || {};
+    return {
+      ...mode,
+      ...rawMode,
+      id: mode.id,
+      label: typeof rawMode.label === 'string' && rawMode.label ? rawMode.label : mode.label,
+      detail: typeof rawMode.detail === 'string' && rawMode.detail ? rawMode.detail : mode.detail,
+      reason: typeof rawMode.reason === 'string' && rawMode.reason ? rawMode.reason : mode.reason,
+    };
+  });
+}
+
 export function normaliseGrammarReadModel(rawValue = {}, learnerId = '') {
   const raw = rawValue && typeof rawValue === 'object' && !Array.isArray(rawValue) ? rawValue : {};
   const concepts = mergeConcepts(raw.analytics?.concepts);
@@ -362,12 +383,8 @@ export function normaliseGrammarReadModel(rawValue = {}, learnerId = '') {
       recentActivity: Array.isArray(rawAnalytics.recentActivity) ? rawAnalytics.recentActivity.slice(0, 8) : [],
     },
     capabilities: {
-      enabledModes: Array.isArray(raw.capabilities?.enabledModes) && raw.capabilities.enabledModes.length
-        ? raw.capabilities.enabledModes
-        : GRAMMAR_ENABLED_MODES,
-      lockedModes: Array.isArray(raw.capabilities?.lockedModes) && raw.capabilities.lockedModes.length
-        ? raw.capabilities.lockedModes
-        : GRAMMAR_LOCKED_MODES,
+      enabledModes: mergeModeList(GRAMMAR_ENABLED_MODES, raw.capabilities?.enabledModes),
+      lockedModes: mergeModeList(GRAMMAR_LOCKED_MODES, raw.capabilities?.lockedModes),
     },
     projections: raw.projections || null,
     pendingCommand: raw.pendingCommand || '',

--- a/src/subjects/grammar/module.js
+++ b/src/subjects/grammar/module.js
@@ -98,13 +98,24 @@ function applyLocalTransition(context, transition) {
 
 function grammarStartPayload(ui, data = {}) {
   const prefs = ui.prefs || DEFAULT_GRAMMAR_PREFS;
-  return {
-    mode: data.mode || prefs.mode || DEFAULT_GRAMMAR_PREFS.mode,
+  const payload = data.payload && typeof data.payload === 'object' && !Array.isArray(data.payload) ? data.payload : {};
+  const mode = payload.mode || data.mode || prefs.mode || DEFAULT_GRAMMAR_PREFS.mode;
+  const request = {
+    mode,
     roundLength: data.roundLength || prefs.roundLength || DEFAULT_GRAMMAR_PREFS.roundLength,
-    focusConceptId: Object.prototype.hasOwnProperty.call(data, 'focusConceptId')
-      ? data.focusConceptId
-      : prefs.focusConceptId || '',
-    ...(data.payload && typeof data.payload === 'object' && !Array.isArray(data.payload) ? data.payload : {}),
+  };
+  if (Object.prototype.hasOwnProperty.call(data, 'focusConceptId')) {
+    request.focusConceptId = data.focusConceptId;
+  } else if (
+    String(mode).trim().toLowerCase() !== 'trouble'
+    && !Object.prototype.hasOwnProperty.call(payload, 'focusConceptId')
+    && !Object.prototype.hasOwnProperty.call(payload, 'skillId')
+  ) {
+    request.focusConceptId = prefs.focusConceptId || '';
+  }
+  return {
+    ...request,
+    ...payload,
   };
 }
 
@@ -216,11 +227,12 @@ export const grammarModule = {
 
     if (action === 'grammar-set-mode') {
       const mode = context.data?.value || DEFAULT_GRAMMAR_PREFS.mode;
+      const patch = mode === 'trouble' ? { mode, focusConceptId: '' } : { mode };
       if (service?.savePrefs) {
-        const prefs = service.savePrefs(learnerId, { mode });
+        const prefs = service.savePrefs(learnerId, patch);
         return resetToDashboardWithPrefs(context, prefs);
       }
-      return sendGrammarCommand(context, 'save-prefs', { prefs: { mode } });
+      return sendGrammarCommand(context, 'save-prefs', { prefs: patch });
     }
 
     if (action === 'grammar-set-round-length') {

--- a/src/subjects/grammar/module.js
+++ b/src/subjects/grammar/module.js
@@ -246,6 +246,13 @@ export const grammarModule = {
 
     if (action === 'grammar-set-focus') {
       const focusConceptId = context.data?.value || '';
+      if (ui.prefs?.mode === 'trouble') {
+        if (service?.savePrefs) {
+          const prefs = service.savePrefs(learnerId, { focusConceptId: '' });
+          return resetToDashboardWithPrefs(context, prefs);
+        }
+        return sendGrammarCommand(context, 'save-prefs', { prefs: { focusConceptId: '' } });
+      }
       if (service?.savePrefs) {
         const prefs = service.savePrefs(learnerId, { focusConceptId });
         return resetToDashboardWithPrefs(context, prefs);

--- a/src/subjects/grammar/read-model.js
+++ b/src/subjects/grammar/read-model.js
@@ -244,7 +244,7 @@ function currentGrammarFocus({ concepts, sessions, snapshot }) {
   if (weakConcepts.length) {
     return {
       subjectId: 'grammar',
-      recommendedMode: 'smart',
+      recommendedMode: 'trouble',
       label: 'Repair Grammar misconceptions',
       detail: `${weakConcepts[0].name} is the highest current Grammar load.`,
       dueCount: dueConcepts.length,

--- a/tests/grammar-engine.test.js
+++ b/tests/grammar-engine.test.js
@@ -338,6 +338,31 @@ test('Grammar trouble mode honours explicit focus payloads separately from store
   assert.ok(start.state.session.currentItem.skillIds.includes('word_classes'));
 });
 
+test('Grammar save-prefs keeps trouble focus on automatic weakest selection', () => {
+  const engine = createServerGrammarEngine({ now: () => 1_777_000_000_000 });
+  const saved = engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: {
+      data: {
+        prefs: {
+          mode: 'trouble',
+          focusConceptId: '',
+        },
+      },
+    },
+    command: 'save-prefs',
+    requestId: 'prefs-trouble-focus',
+    payload: {
+      prefs: {
+        focusConceptId: 'word_classes',
+      },
+    },
+  });
+
+  assert.equal(saved.state.prefs.mode, 'trouble');
+  assert.equal(saved.state.prefs.focusConceptId, '');
+});
+
 test('Grammar save-prefs clears completed summary state', () => {
   const oracle = readGrammarLegacyOracle();
   const sample = oracle.templates.find((template) => template.id === 'question_mark_select');

--- a/tests/grammar-engine.test.js
+++ b/tests/grammar-engine.test.js
@@ -254,6 +254,50 @@ test('Grammar server engine creates a session, marks an answer, and records summ
   assert.ok(done.events.some((event) => event.type === 'grammar.session-completed'));
 });
 
+test('Grammar trouble mode targets the weakest concept without pinning focus prefs', () => {
+  const engine = createServerGrammarEngine({ now: () => 1_777_000_000_000 });
+  const start = engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: {
+      data: {
+        mastery: {
+          concepts: {
+            adverbials: {
+              attempts: 4,
+              correct: 0,
+              wrong: 4,
+              strength: 0.12,
+              dueAt: 1,
+            },
+            word_classes: {
+              attempts: 2,
+              correct: 0,
+              wrong: 2,
+              strength: 0.08,
+              dueAt: 1,
+            },
+          },
+        },
+      },
+    },
+    command: 'start-session',
+    requestId: 'start-trouble',
+    payload: {
+      mode: 'trouble',
+      roundLength: 3,
+      seed: 42,
+    },
+  });
+
+  assert.equal(start.state.phase, 'session');
+  assert.equal(start.state.session.mode, 'trouble');
+  assert.equal(start.state.session.type, 'trouble-drill');
+  assert.equal(start.state.session.focusConceptId, 'adverbials');
+  assert.equal(start.state.prefs.focusConceptId, '');
+  assert.equal(start.practiceSession.sessionKind, 'trouble');
+  assert.ok(start.state.session.currentItem.skillIds.includes('adverbials'));
+});
+
 test('Grammar save-prefs clears completed summary state', () => {
   const oracle = readGrammarLegacyOracle();
   const sample = oracle.templates.find((template) => template.id === 'question_mark_select');

--- a/tests/grammar-engine.test.js
+++ b/tests/grammar-engine.test.js
@@ -260,6 +260,9 @@ test('Grammar trouble mode targets the weakest concept without pinning focus pre
     learnerId: 'learner-a',
     subjectRecord: {
       data: {
+        prefs: {
+          focusConceptId: 'word_classes',
+        },
         mastery: {
           concepts: {
             adverbials: {
@@ -270,11 +273,13 @@ test('Grammar trouble mode targets the weakest concept without pinning focus pre
               dueAt: 1,
             },
             word_classes: {
-              attempts: 2,
-              correct: 0,
-              wrong: 2,
-              strength: 0.08,
-              dueAt: 1,
+              attempts: 8,
+              correct: 8,
+              wrong: 0,
+              strength: 0.9,
+              intervalDays: 10,
+              dueAt: 1_777_000_000_000 + 10 * 86400000,
+              correctStreak: 5,
             },
           },
         },
@@ -296,6 +301,41 @@ test('Grammar trouble mode targets the weakest concept without pinning focus pre
   assert.equal(start.state.prefs.focusConceptId, '');
   assert.equal(start.practiceSession.sessionKind, 'trouble');
   assert.ok(start.state.session.currentItem.skillIds.includes('adverbials'));
+});
+
+test('Grammar trouble mode honours explicit focus payloads separately from stored prefs', () => {
+  const engine = createServerGrammarEngine({ now: () => 1_777_000_000_000 });
+  const start = engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: {
+      data: {
+        mastery: {
+          concepts: {
+            adverbials: {
+              attempts: 4,
+              correct: 0,
+              wrong: 4,
+              strength: 0.12,
+              dueAt: 1,
+            },
+          },
+        },
+      },
+    },
+    command: 'start-session',
+    requestId: 'start-trouble-focused',
+    payload: {
+      mode: 'trouble',
+      focusConceptId: 'word_classes',
+      roundLength: 3,
+      seed: 42,
+    },
+  });
+
+  assert.equal(start.state.session.mode, 'trouble');
+  assert.equal(start.state.session.focusConceptId, 'word_classes');
+  assert.equal(start.state.prefs.focusConceptId, 'word_classes');
+  assert.ok(start.state.session.currentItem.skillIds.includes('word_classes'));
 });
 
 test('Grammar save-prefs clears completed summary state', () => {

--- a/tests/hub-read-models.test.js
+++ b/tests/hub-read-models.test.js
@@ -194,7 +194,7 @@ test('parent hub read model includes Grammar evidence without replacing Spelling
   const grammarDueWork = model.dueWork.find((entry) => entry.subjectId === 'grammar');
   assert.ok(grammarDueWork);
   assert.match(grammarDueWork.label, /Grammar/);
-  assert.equal(grammarDueWork.recommendedMode, 'smart');
+  assert.equal(grammarDueWork.recommendedMode, 'trouble');
   assert.ok(model.misconceptionPatterns.some((entry) => entry.subjectId === 'grammar' && /Fronted Adverbial/.test(entry.label)));
   assert.ok(model.recentSessions.some((entry) => entry.subjectId === 'grammar' && entry.headline === '0/1'));
 });

--- a/tests/react-grammar-surface.test.js
+++ b/tests/react-grammar-surface.test.js
@@ -336,6 +336,25 @@ test('Grammar normaliser parses ISO misconception timestamps in fallback pattern
   assert.equal(grammar.analytics.misconceptionPatterns[0].lastSeenAt, Date.parse(isoTimestamp));
 });
 
+test('Grammar normaliser upgrades stale persisted mode capabilities', () => {
+  const grammar = normaliseGrammarReadModel({
+    capabilities: {
+      enabledModes: [
+        { id: 'learn', label: 'Learn a concept' },
+        { id: 'smart', label: 'Smart mixed review' },
+        { id: 'satsset', label: 'KS2-style mini-set' },
+      ],
+      lockedModes: [
+        { id: 'trouble', label: 'Weak concepts drill', reason: 'coming-next' },
+        { id: 'surgery', label: 'Sentence surgery', reason: 'coming-next' },
+      ],
+    },
+  });
+
+  assert.equal(grammar.capabilities.enabledModes.some((mode) => mode.id === 'trouble'), true);
+  assert.equal(grammar.capabilities.lockedModes.some((mode) => mode.id === 'trouble'), false);
+});
+
 test('Grammar locked future modes render unavailable without dispatching commands', () => {
   const storage = installMemoryStorage();
   const harness = createAppHarness({ storage });
@@ -343,7 +362,29 @@ test('Grammar locked future modes render unavailable without dispatching command
   harness.dispatch('open-subject', { subjectId: 'grammar' });
   const html = harness.render();
 
-  assert.match(html, /Weak concepts drill[\s\S]*Coming next/);
+  assert.match(html, /<button class="grammar-mode" type="button">[\s\S]*Weak concepts drill/);
+  assert.doesNotMatch(html, /<button class="grammar-mode locked" type="button" disabled="">[\s\S]*Weak concepts drill/);
   assert.match(html, /Sentence surgery[\s\S]*Coming next/);
   assert.match(html, /button class="grammar-mode locked" type="button" disabled=""/);
+});
+
+test('Grammar setup can start trouble drill mode', () => {
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-set-mode', { value: 'trouble' });
+  assert.equal(harness.store.getState().subjectUi.grammar.prefs.mode, 'trouble');
+
+  harness.dispatch('grammar-start', {
+    payload: {
+      roundLength: 1,
+      seed: 123,
+    },
+  });
+
+  const grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.phase, 'session');
+  assert.equal(grammar.session.mode, 'trouble');
+  assert.equal(grammar.session.type, 'trouble-drill');
 });

--- a/tests/react-grammar-surface.test.js
+++ b/tests/react-grammar-surface.test.js
@@ -379,6 +379,10 @@ test('Grammar setup can start trouble drill mode', () => {
   harness.dispatch('grammar-set-mode', { value: 'trouble' });
   assert.equal(harness.store.getState().subjectUi.grammar.prefs.mode, 'trouble');
   assert.equal(harness.store.getState().subjectUi.grammar.prefs.focusConceptId, '');
+  assert.match(harness.render(), /<select class="input" disabled=""><option value="" selected="">Weakest concept<\/option>/);
+
+  harness.dispatch('grammar-set-focus', { value: 'word_classes' });
+  assert.equal(harness.store.getState().subjectUi.grammar.prefs.focusConceptId, '');
 
   harness.dispatch('grammar-start', {
     payload: {

--- a/tests/react-grammar-surface.test.js
+++ b/tests/react-grammar-surface.test.js
@@ -373,8 +373,12 @@ test('Grammar setup can start trouble drill mode', () => {
   const harness = createGrammarHarness({ storage });
 
   harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-set-focus', { value: 'word_classes' });
+  assert.equal(harness.store.getState().subjectUi.grammar.prefs.focusConceptId, 'word_classes');
+
   harness.dispatch('grammar-set-mode', { value: 'trouble' });
   assert.equal(harness.store.getState().subjectUi.grammar.prefs.mode, 'trouble');
+  assert.equal(harness.store.getState().subjectUi.grammar.prefs.focusConceptId, '');
 
   harness.dispatch('grammar-start', {
     payload: {

--- a/tests/worker-grammar-subject-runtime.test.js
+++ b/tests/worker-grammar-subject-runtime.test.js
@@ -78,6 +78,66 @@ test('worker subject runtime registers Grammar command handlers', async () => {
   assert.equal(result.subjectReadModel.session.currentItem.templateId, 'fronted_adverbial_choose');
   assert.equal(result.subjectReadModel.session.currentItem.evaluate, undefined);
   assert.equal(result.subjectReadModel.session.currentItem.promptText.includes('<'), false);
+  assert.deepEqual(result.subjectReadModel.capabilities.enabledModes.map((mode) => mode.id), [
+    'learn',
+    'smart',
+    'satsset',
+    'trouble',
+  ]);
+  assert.equal(result.subjectReadModel.capabilities.lockedModes.some((mode) => mode.id === 'trouble'), false);
+});
+
+test('worker subject runtime starts Grammar trouble drills against weak concepts', async () => {
+  const runtime = createWorkerSubjectRuntime({
+    grammar: { now: () => 1_777_000_000_000 },
+  });
+  const result = await runtime.dispatch({
+    subjectId: 'grammar',
+    command: 'start-session',
+    learnerId: 'learner-a',
+    requestId: 'grammar-trouble-start',
+    correlationId: 'grammar-trouble-start',
+    expectedLearnerRevision: 0,
+    payload: { mode: 'trouble', roundLength: 2, seed: 77 },
+  }, {
+    session: { accountId: 'adult-a' },
+    now: 1_777_000_000_000,
+    repository: {
+      async readSubjectRuntime(accountId, learnerId, subjectId) {
+        assert.equal(accountId, 'adult-a');
+        assert.equal(learnerId, 'learner-a');
+        assert.equal(subjectId, 'grammar');
+        return {
+          subjectRecord: {
+            ui: null,
+            data: {
+              mastery: {
+                concepts: {
+                  adverbials: {
+                    attempts: 3,
+                    correct: 0,
+                    wrong: 3,
+                    strength: 0.1,
+                    dueAt: 1,
+                  },
+                },
+              },
+            },
+          },
+          latestSession: null,
+        };
+      },
+      async readLearnerProjectionState() {
+        return { gameState: {}, events: [] };
+      },
+    },
+  });
+
+  assert.equal(result.subjectReadModel.phase, 'session');
+  assert.equal(result.subjectReadModel.session.mode, 'trouble');
+  assert.equal(result.subjectReadModel.session.type, 'trouble-drill');
+  assert.equal(result.subjectReadModel.session.focusConceptId, 'adverbials');
+  assert.ok(result.subjectReadModel.session.currentItem.skillIds.includes('adverbials'));
 });
 
 test('Grammar command route persists subject state, practice session, and events', async () => {
@@ -132,6 +192,32 @@ test('Grammar command route persists subject state, practice session, and events
   assert.equal(data.mastery.concepts.speech_punctuation.attempts, 1);
   assert.equal(DB.db.prepare("SELECT COUNT(*) AS count FROM practice_sessions WHERE subject_id = 'grammar'").get().count, 1);
   assert.equal(DB.db.prepare("SELECT COUNT(*) AS count FROM event_log WHERE subject_id = 'grammar' AND event_type = 'grammar.answer-submitted'").get().count, 1);
+
+  DB.close();
+});
+
+test('Grammar command route accepts trouble drill mode', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const app = createWorkerApp({ now: () => 1_777_000_000_000 });
+  seedAccountLearner(DB);
+
+  const start = await postCommand(app, DB, {
+    command: 'start-session',
+    learnerId: 'learner-a',
+    requestId: 'grammar-trouble-route-start',
+    expectedLearnerRevision: 0,
+    payload: {
+      mode: 'trouble',
+      roundLength: 2,
+      seed: 120,
+    },
+  });
+
+  assert.equal(start.response.status, 200, JSON.stringify(start.body));
+  assert.equal(start.body.subjectReadModel.phase, 'session');
+  assert.equal(start.body.subjectReadModel.session.mode, 'trouble');
+  assert.equal(start.body.subjectReadModel.session.type, 'trouble-drill');
+  assert.equal(start.body.subjectReadModel.capabilities.lockedModes.some((mode) => mode.id === 'trouble'), false);
 
   DB.close();
 });

--- a/worker/src/subjects/grammar/engine.js
+++ b/worker/src/subjects/grammar/engine.js
@@ -875,9 +875,11 @@ function savePrefs(state, payload) {
   const prefs = isPlainObject(payload.prefs) ? payload.prefs : payload;
   const nextMode = prefs.mode ? normaliseMode(prefs.mode) : state.prefs.mode;
   const hasFocusConcept = Object.prototype.hasOwnProperty.call(prefs, 'focusConceptId');
-  const nextFocusConceptId = hasFocusConcept
-    ? normaliseStoredFocusConceptId(prefs.focusConceptId)
-    : (nextMode === 'trouble' ? '' : normaliseStoredFocusConceptId(state.prefs.focusConceptId));
+  const nextFocusConceptId = nextMode === 'trouble'
+    ? ''
+    : (hasFocusConcept
+      ? normaliseStoredFocusConceptId(prefs.focusConceptId)
+      : normaliseStoredFocusConceptId(state.prefs.focusConceptId));
   state.prefs = {
     ...state.prefs,
     mode: ENABLED_MODES.has(nextMode) ? nextMode : state.prefs.mode,

--- a/worker/src/subjects/grammar/engine.js
+++ b/worker/src/subjects/grammar/engine.js
@@ -20,8 +20,8 @@ const DEFAULT_MINI_SET_LENGTH = 8;
 const SHORT_RESPONSE_TEXT_LIMIT = 512;
 const LONG_RESPONSE_TEXT_LIMIT = 2000;
 const LIST_RESPONSE_LIMIT = 40;
-const ENABLED_MODES = new Set(['learn', 'smart', 'satsset']);
-const LOCKED_MODES = Object.freeze(['trouble', 'surgery', 'builder', 'worked', 'faded']);
+const ENABLED_MODES = new Set(['learn', 'smart', 'satsset', 'trouble']);
+const LOCKED_MODES = Object.freeze(['surgery', 'builder', 'worked', 'faded']);
 const GRAMMAR_CONCEPT_IDS = new Set(GRAMMAR_CONCEPTS.map((concept) => concept.id));
 
 function isPlainObject(value) {
@@ -466,6 +466,26 @@ function nextItem(state, { mode, focusConceptId, seed, templateId = '', nowTs = 
   return itemFromTemplate(weightedTemplatePick(state, { mode, focusConceptId, seed, nowTs }), seed);
 }
 
+function weakestConceptIdForTrouble(state, nowTs) {
+  return GRAMMAR_CONCEPTS
+    .map((concept) => {
+      const node = state.mastery.concepts[concept.id] || defaultMasteryNode();
+      return {
+        id: concept.id,
+        node,
+        status: grammarConceptStatus(node, nowTs),
+      };
+    })
+    .filter((entry) => entry.status === 'weak')
+    .sort((a, b) => {
+      const wrongDelta = (Number(b.node.wrong) || 0) - (Number(a.node.wrong) || 0);
+      if (wrongDelta) return wrongDelta;
+      const strengthDelta = (Number(a.node.strength) || 0.25) - (Number(b.node.strength) || 0.25);
+      if (strengthDelta) return strengthDelta;
+      return String(a.id).localeCompare(String(b.id));
+    })[0]?.id || '';
+}
+
 function normaliseMode(value) {
   const mode = String(value || 'smart').trim().toLowerCase().replace(/[\s_]+/g, '-');
   if (mode === 'mini-set' || mode === 'mini' || mode === 'test') return 'satsset';
@@ -559,20 +579,23 @@ function startSession(state, payload, nowTs, learnerId) {
       conceptId: focusConceptId,
     });
   }
+  const sessionFocusConceptId = mode === 'trouble' && !focusConceptId
+    ? weakestConceptIdForTrouble(state, nowTs)
+    : focusConceptId;
   const roundLength = roundLengthFor(mode, payload, state.prefs);
   const baseSeed = Number.isFinite(Number(payload.seed))
     ? Number(payload.seed)
-    : stableHash(`${payload.requestId || ''}:${nowTs}:${focusConceptId}:${mode}`);
+    : stableHash(`${payload.requestId || ''}:${nowTs}:${sessionFocusConceptId}:${mode}`);
   const sessionId = serverSessionId(learnerId, {
     requestId: payload.requestId,
     nowTs,
     baseSeed,
     mode,
-    focusConceptId,
+    focusConceptId: sessionFocusConceptId,
   });
   const firstItem = nextItem(state, {
     mode,
-    focusConceptId,
+    focusConceptId: sessionFocusConceptId,
     seed: baseSeed,
     nowTs,
     templateId: typeof payload.templateId === 'string' ? payload.templateId : '',
@@ -590,9 +613,9 @@ function startSession(state, payload, nowTs, learnerId) {
   };
   state.session = {
     id: sessionId,
-    type: mode === 'satsset' ? 'mini-set' : 'practice',
+    type: mode === 'satsset' ? 'mini-set' : (mode === 'trouble' ? 'trouble-drill' : 'practice'),
     mode,
-    focusConceptId,
+    focusConceptId: sessionFocusConceptId,
     startedAt: nowTs,
     targetCount: roundLength,
     answered: 0,

--- a/worker/src/subjects/grammar/engine.js
+++ b/worker/src/subjects/grammar/engine.js
@@ -571,7 +571,7 @@ function startSession(state, payload, nowTs, learnerId) {
     : (typeof payload.skillId === 'string' ? payload.skillId : '');
   const focusConceptId = hasPayloadFocusConcept
     ? requestedFocusConceptId
-    : normaliseStoredFocusConceptId(state.prefs.focusConceptId);
+    : (mode === 'trouble' ? '' : normaliseStoredFocusConceptId(state.prefs.focusConceptId));
   if (focusConceptId && !isGrammarConceptId(focusConceptId)) {
     throw new BadRequestError('Grammar concept is not available.', {
       code: 'grammar_concept_not_found',
@@ -877,7 +877,7 @@ function savePrefs(state, payload) {
   const hasFocusConcept = Object.prototype.hasOwnProperty.call(prefs, 'focusConceptId');
   const nextFocusConceptId = hasFocusConcept
     ? normaliseStoredFocusConceptId(prefs.focusConceptId)
-    : normaliseStoredFocusConceptId(state.prefs.focusConceptId);
+    : (nextMode === 'trouble' ? '' : normaliseStoredFocusConceptId(state.prefs.focusConceptId));
   state.prefs = {
     ...state.prefs,
     mode: ENABLED_MODES.has(nextMode) ? nextMode : state.prefs.mode,

--- a/worker/src/subjects/grammar/read-models.js
+++ b/worker/src/subjects/grammar/read-models.js
@@ -248,19 +248,19 @@ function evidenceSummary({ concepts, patterns }) {
 }
 
 function capabilityMetadata() {
-  const labels = {
-    learn: 'Learn a concept',
-    smart: 'Smart mixed review',
-    satsset: 'KS2-style mini-set',
-    trouble: 'Weak concepts drill',
-    surgery: 'Sentence surgery',
-    builder: 'Sentence builder',
-    worked: 'Worked examples',
-    faded: 'Faded guidance',
+  const modes = {
+    learn: { label: 'Learn a concept', detail: 'Focused retrieval on one concept at a time.' },
+    smart: { label: 'Smart mixed review', detail: 'Worker-selected review across Grammar concepts.' },
+    satsset: { label: 'KS2-style mini-set', detail: 'A short mixed set with SATs-friendly question shapes.' },
+    trouble: { label: 'Weak concepts drill', detail: 'Targets the weakest Grammar concepts with retry pressure.' },
+    surgery: { label: 'Sentence surgery' },
+    builder: { label: 'Sentence builder' },
+    worked: { label: 'Worked examples' },
+    faded: { label: 'Faded guidance' },
   };
   return {
-    enabledModes: Array.from(GRAMMAR_ENABLED_MODES).map((id) => ({ id, label: labels[id] || id })),
-    lockedModes: Array.from(GRAMMAR_LOCKED_MODES).map((id) => ({ id, label: labels[id] || id, reason: 'coming-next' })),
+    enabledModes: Array.from(GRAMMAR_ENABLED_MODES).map((id) => ({ id, ...(modes[id] || { label: id }) })),
+    lockedModes: Array.from(GRAMMAR_LOCKED_MODES).map((id) => ({ id, label: modes[id]?.label || id, reason: 'coming-next' })),
   };
 }
 


### PR DESCRIPTION
## Summary
- Enable Grammar Weak concepts drill as a supported Worker-command-backed mode while keeping the remaining future modes locked.
- Start trouble drills against the weakest current Grammar concept when no explicit focus is selected, without silently pinning that focus into saved preferences.
- Update Grammar hub recommendations and stale capability normalisation so persisted read models do not keep the newly enabled mode hidden.

## Verification
- `node --test tests/grammar-engine.test.js tests/worker-grammar-subject-runtime.test.js tests/react-grammar-surface.test.js tests/hub-read-models.test.js tests/subject-expansion.test.js`
- `npm test`
- `npm run check`