### PR TITLE
feat(grammar): enable sentence surgery mode

### DIFF
--- a/src/subjects/grammar/components/GrammarSetupScene.jsx
+++ b/src/subjects/grammar/components/GrammarSetupScene.jsx
@@ -37,7 +37,10 @@ export function GrammarSetupScene({ learner, grammar, actions, runtimeReadOnly }
   const templates = grammar.stats?.templates || {};
   const selectedMode = grammar.prefs?.mode || 'smart';
   const troubleMode = selectedMode === 'trouble';
-  const selectedFocus = troubleMode ? '' : (grammar.prefs?.focusConceptId || '');
+  const surgeryMode = selectedMode === 'surgery';
+  const focusDisabled = troubleMode || surgeryMode;
+  const selectedFocus = focusDisabled ? '' : (grammar.prefs?.focusConceptId || '');
+  const focusPlaceholder = troubleMode ? 'Weakest concept' : (surgeryMode ? 'Surgery mix' : 'Smart mix');
   const groupedConcepts = groupedGrammarConcepts(grammar.analytics?.concepts || []);
   const setupDisabled = runtimeReadOnly || Boolean(grammar.pendingCommand);
 
@@ -104,10 +107,10 @@ export function GrammarSetupScene({ learner, grammar, actions, runtimeReadOnly }
               <select
                 className="input"
                 value={selectedFocus}
-                disabled={setupDisabled || troubleMode}
+                disabled={setupDisabled || focusDisabled}
                 onChange={(event) => actions.dispatch('grammar-set-focus', { value: event.currentTarget.value })}
               >
-                <option value="">{troubleMode ? 'Weakest concept' : 'Smart mix'}</option>
+                <option value="">{focusPlaceholder}</option>
                 {(grammar.analytics?.concepts || []).map((concept) => (
                   <option value={concept.id} key={concept.id}>{concept.name}</option>
                 ))}

--- a/src/subjects/grammar/metadata.js
+++ b/src/subjects/grammar/metadata.js
@@ -136,10 +136,10 @@ export const GRAMMAR_ENABLED_MODES = Object.freeze([
   { id: 'smart', label: 'Smart mixed review', detail: 'Worker-selected review across Grammar concepts.' },
   { id: 'satsset', label: 'KS2-style mini-set', detail: 'A short mixed set with SATs-friendly question shapes.' },
   { id: 'trouble', label: 'Weak concepts drill', detail: 'Targets the weakest Grammar concepts with retry pressure.' },
+  { id: 'surgery', label: 'Sentence surgery', detail: 'Fix and rewrite sentence-level Grammar errors.' },
 ]);
 
 export const GRAMMAR_LOCKED_MODES = Object.freeze([
-  { id: 'surgery', label: 'Sentence surgery', reason: 'coming-next' },
   { id: 'builder', label: 'Sentence builder', reason: 'coming-next' },
   { id: 'worked', label: 'Worked examples', reason: 'coming-next' },
   { id: 'faded', label: 'Faded guidance', reason: 'coming-next' },

--- a/src/subjects/grammar/module.js
+++ b/src/subjects/grammar/module.js
@@ -14,6 +14,16 @@ function selectedGrammarUi(context) {
   return normaliseGrammarReadModel(appState?.subjectUi?.[GRAMMAR_SUBJECT_ID], learnerId);
 }
 
+function grammarModeKey(value) {
+  const mode = String(value || '').trim().toLowerCase().replace(/[\s_]+/g, '-');
+  return mode === 'sentence-surgery' ? 'surgery' : mode;
+}
+
+function grammarModeUsesFocus(value) {
+  const mode = grammarModeKey(value);
+  return mode !== 'trouble' && mode !== 'surgery';
+}
+
 function updateGrammarUiForLearner(context, learnerId, updater) {
   if (!learnerId) return false;
   if (typeof context?.store?.updateSubjectUiForLearner === 'function') {
@@ -107,9 +117,10 @@ function grammarStartPayload(ui, data = {}) {
   if (Object.prototype.hasOwnProperty.call(data, 'focusConceptId')) {
     request.focusConceptId = data.focusConceptId;
   } else if (
-    String(mode).trim().toLowerCase() !== 'trouble'
+    grammarModeUsesFocus(mode)
     && !Object.prototype.hasOwnProperty.call(payload, 'focusConceptId')
     && !Object.prototype.hasOwnProperty.call(payload, 'skillId')
+    && !Object.prototype.hasOwnProperty.call(payload, 'templateId')
   ) {
     request.focusConceptId = prefs.focusConceptId || '';
   }
@@ -227,7 +238,7 @@ export const grammarModule = {
 
     if (action === 'grammar-set-mode') {
       const mode = context.data?.value || DEFAULT_GRAMMAR_PREFS.mode;
-      const patch = mode === 'trouble' ? { mode, focusConceptId: '' } : { mode };
+      const patch = grammarModeUsesFocus(mode) ? { mode } : { mode, focusConceptId: '' };
       if (service?.savePrefs) {
         const prefs = service.savePrefs(learnerId, patch);
         return resetToDashboardWithPrefs(context, prefs);
@@ -246,7 +257,7 @@ export const grammarModule = {
 
     if (action === 'grammar-set-focus') {
       const focusConceptId = context.data?.value || '';
-      if (ui.prefs?.mode === 'trouble') {
+      if (!grammarModeUsesFocus(ui.prefs?.mode)) {
         if (service?.savePrefs) {
           const prefs = service.savePrefs(learnerId, { focusConceptId: '' });
           return resetToDashboardWithPrefs(context, prefs);

--- a/tests/grammar-engine.test.js
+++ b/tests/grammar-engine.test.js
@@ -363,6 +363,100 @@ test('Grammar save-prefs keeps trouble focus on automatic weakest selection', ()
   assert.equal(saved.state.prefs.focusConceptId, '');
 });
 
+test('Grammar sentence surgery mode only picks surgery templates', () => {
+  const engine = createServerGrammarEngine({ now: () => 1_777_000_000_000 });
+  const start = engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: {},
+    command: 'start-session',
+    requestId: 'start-surgery',
+    payload: {
+      mode: 'surgery',
+      roundLength: 3,
+      seed: 42,
+    },
+  });
+  const template = GRAMMAR_TEMPLATE_METADATA.find((entry) => entry.id === start.state.session.currentItem.templateId);
+
+  assert.equal(start.state.phase, 'session');
+  assert.equal(start.state.session.mode, 'surgery');
+  assert.equal(start.state.session.type, 'sentence-surgery');
+  assert.equal(start.practiceSession.sessionKind, 'surgery');
+  assert.equal(template.tags.includes('surgery'), true);
+  assert.match(start.state.session.currentItem.questionType, /^(fix|rewrite)$/);
+});
+
+test('Grammar sentence surgery rejects explicit non-surgery templates', () => {
+  const engine = createServerGrammarEngine({ now: () => 1_777_000_000_000 });
+
+  assert.throws(() => engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: {},
+    command: 'start-session',
+    requestId: 'start-surgery-bypass',
+    payload: {
+      mode: 'surgery',
+      roundLength: 3,
+      seed: 42,
+      templateId: 'sentence_type_table',
+    },
+  }), (error) => error?.extra?.code === 'grammar_template_unavailable_for_mode');
+});
+
+test('Grammar explicit template starts ignore inherited focus prefs', () => {
+  const engine = createServerGrammarEngine({ now: () => 1_777_000_000_000 });
+  const start = engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: {
+      data: {
+        prefs: {
+          focusConceptId: 'word_classes',
+        },
+      },
+    },
+    command: 'start-session',
+    requestId: 'start-explicit-template-with-stored-focus',
+    payload: {
+      mode: 'smart',
+      roundLength: 1,
+      seed: 42,
+      templateId: 'question_mark_select',
+    },
+  });
+
+  assert.equal(start.state.phase, 'session');
+  assert.equal(start.state.session.currentItem.templateId, 'question_mark_select');
+  assert.equal(start.state.session.focusConceptId, '');
+  assert.equal(start.state.prefs.focusConceptId, 'word_classes');
+});
+
+test('Grammar sentence surgery clears stored focus and stays inside the surgery pool', () => {
+  const engine = createServerGrammarEngine({ now: () => 1_777_000_000_000 });
+  const start = engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: {
+      data: {
+        prefs: {
+          focusConceptId: 'word_classes',
+        },
+      },
+    },
+    command: 'start-session',
+    requestId: 'start-surgery-focused',
+    payload: {
+      mode: 'surgery',
+      roundLength: 3,
+      seed: 77,
+    },
+  });
+  const template = GRAMMAR_TEMPLATE_METADATA.find((entry) => entry.id === start.state.session.currentItem.templateId);
+
+  assert.equal(start.state.session.mode, 'surgery');
+  assert.equal(start.state.session.focusConceptId, '');
+  assert.equal(start.state.prefs.focusConceptId, '');
+  assert.equal(template.tags.includes('surgery'), true);
+});
+
 test('Grammar save-prefs clears completed summary state', () => {
   const oracle = readGrammarLegacyOracle();
   const sample = oracle.templates.find((template) => template.id === 'question_mark_select');

--- a/tests/react-grammar-surface.test.js
+++ b/tests/react-grammar-surface.test.js
@@ -353,6 +353,8 @@ test('Grammar normaliser upgrades stale persisted mode capabilities', () => {
 
   assert.equal(grammar.capabilities.enabledModes.some((mode) => mode.id === 'trouble'), true);
   assert.equal(grammar.capabilities.lockedModes.some((mode) => mode.id === 'trouble'), false);
+  assert.equal(grammar.capabilities.enabledModes.some((mode) => mode.id === 'surgery'), true);
+  assert.equal(grammar.capabilities.lockedModes.some((mode) => mode.id === 'surgery'), false);
 });
 
 test('Grammar locked future modes render unavailable without dispatching commands', () => {
@@ -364,7 +366,9 @@ test('Grammar locked future modes render unavailable without dispatching command
 
   assert.match(html, /<button class="grammar-mode" type="button">[\s\S]*Weak concepts drill/);
   assert.doesNotMatch(html, /<button class="grammar-mode locked" type="button" disabled="">[\s\S]*Weak concepts drill/);
-  assert.match(html, /Sentence surgery[\s\S]*Coming next/);
+  assert.match(html, /<button class="grammar-mode" type="button">[\s\S]*Sentence surgery/);
+  assert.doesNotMatch(html, /<button class="grammar-mode locked" type="button" disabled="">[\s\S]*Sentence surgery/);
+  assert.match(html, /Sentence builder[\s\S]*Coming next/);
   assert.match(html, /button class="grammar-mode locked" type="button" disabled=""/);
 });
 
@@ -395,4 +399,59 @@ test('Grammar setup can start trouble drill mode', () => {
   assert.equal(grammar.phase, 'session');
   assert.equal(grammar.session.mode, 'trouble');
   assert.equal(grammar.session.type, 'trouble-drill');
+});
+
+test('Grammar setup can start sentence surgery mode', () => {
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-set-focus', { value: 'word_classes' });
+  assert.equal(harness.store.getState().subjectUi.grammar.prefs.focusConceptId, 'word_classes');
+
+  harness.dispatch('grammar-set-mode', { value: 'surgery' });
+  assert.equal(harness.store.getState().subjectUi.grammar.prefs.mode, 'surgery');
+  assert.equal(harness.store.getState().subjectUi.grammar.prefs.focusConceptId, '');
+  assert.match(harness.render(), /<select class="input" disabled=""><option value="" selected="">Surgery mix<\/option>/);
+
+  harness.dispatch('grammar-set-focus', { value: 'word_classes' });
+  assert.equal(harness.store.getState().subjectUi.grammar.prefs.focusConceptId, '');
+
+  harness.dispatch('grammar-start', {
+    payload: {
+      roundLength: 1,
+      seed: 123,
+    },
+  });
+
+  const grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.phase, 'session');
+  assert.equal(grammar.session.mode, 'surgery');
+  assert.equal(grammar.session.type, 'sentence-surgery');
+  assert.equal(grammar.session.focusConceptId, '');
+  assert.match(grammar.session.currentItem.questionType, /^(fix|rewrite)$/);
+});
+
+test('Grammar explicit template starts ignore stored focus through the client wrapper', () => {
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+  const sample = grammarOracleSample('question_mark_select');
+
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-set-focus', { value: 'word_classes' });
+  assert.equal(harness.store.getState().subjectUi.grammar.prefs.focusConceptId, 'word_classes');
+
+  harness.dispatch('grammar-start', {
+    payload: {
+      roundLength: 1,
+      seed: sample.sample.seed,
+      templateId: sample.id,
+    },
+  });
+
+  const grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.phase, 'session');
+  assert.equal(grammar.session.currentItem.templateId, sample.id);
+  assert.equal(grammar.session.focusConceptId, '');
+  assert.equal(grammar.prefs.focusConceptId, 'word_classes');
 });

--- a/tests/worker-grammar-subject-runtime.test.js
+++ b/tests/worker-grammar-subject-runtime.test.js
@@ -83,8 +83,10 @@ test('worker subject runtime registers Grammar command handlers', async () => {
     'smart',
     'satsset',
     'trouble',
+    'surgery',
   ]);
   assert.equal(result.subjectReadModel.capabilities.lockedModes.some((mode) => mode.id === 'trouble'), false);
+  assert.equal(result.subjectReadModel.capabilities.lockedModes.some((mode) => mode.id === 'surgery'), false);
 });
 
 test('worker subject runtime starts Grammar trouble drills against weak concepts', async () => {
@@ -218,6 +220,98 @@ test('Grammar command route accepts trouble drill mode', async () => {
   assert.equal(start.body.subjectReadModel.session.mode, 'trouble');
   assert.equal(start.body.subjectReadModel.session.type, 'trouble-drill');
   assert.equal(start.body.subjectReadModel.capabilities.lockedModes.some((mode) => mode.id === 'trouble'), false);
+
+  DB.close();
+});
+
+test('Grammar command route accepts sentence surgery mode', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const app = createWorkerApp({ now: () => 1_777_000_000_000 });
+  seedAccountLearner(DB);
+
+  const start = await postCommand(app, DB, {
+    command: 'start-session',
+    learnerId: 'learner-a',
+    requestId: 'grammar-surgery-route-start',
+    expectedLearnerRevision: 0,
+    payload: {
+      mode: 'surgery',
+      roundLength: 2,
+      seed: 120,
+    },
+  });
+
+  assert.equal(start.response.status, 200, JSON.stringify(start.body));
+  assert.equal(start.body.subjectReadModel.phase, 'session');
+  assert.equal(start.body.subjectReadModel.session.mode, 'surgery');
+  assert.equal(start.body.subjectReadModel.session.type, 'sentence-surgery');
+  assert.match(start.body.subjectReadModel.session.currentItem.questionType, /^(fix|rewrite)$/);
+  assert.equal(start.body.subjectReadModel.capabilities.lockedModes.some((mode) => mode.id === 'surgery'), false);
+
+  DB.close();
+});
+
+test('Grammar command route rejects non-surgery template overrides in surgery mode', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const app = createWorkerApp({ now: () => 1_777_000_000_000 });
+  seedAccountLearner(DB);
+
+  const start = await postCommand(app, DB, {
+    command: 'start-session',
+    learnerId: 'learner-a',
+    requestId: 'grammar-surgery-route-template-bypass',
+    expectedLearnerRevision: 0,
+    payload: {
+      mode: 'surgery',
+      roundLength: 2,
+      seed: 120,
+      templateId: 'sentence_type_table',
+    },
+  });
+
+  assert.equal(start.response.status, 400, JSON.stringify(start.body));
+  assert.equal(start.body.code, 'grammar_template_unavailable_for_mode');
+
+  DB.close();
+});
+
+test('Grammar command route starts explicit templates without inheriting stored focus', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const app = createWorkerApp({ now: () => 1_777_000_000_000 });
+  const sample = readGrammarLegacyOracle().templates.find((template) => template.id === 'question_mark_select');
+  seedAccountLearner(DB);
+
+  const prefs = await postCommand(app, DB, {
+    command: 'save-prefs',
+    learnerId: 'learner-a',
+    requestId: 'grammar-explicit-template-focus-prefs',
+    expectedLearnerRevision: 0,
+    payload: {
+      prefs: {
+        focusConceptId: 'word_classes',
+      },
+    },
+  });
+  assert.equal(prefs.response.status, 200, JSON.stringify(prefs.body));
+  assert.equal(prefs.body.subjectReadModel.prefs.focusConceptId, 'word_classes');
+
+  const start = await postCommand(app, DB, {
+    command: 'start-session',
+    learnerId: 'learner-a',
+    requestId: 'grammar-explicit-template-start',
+    expectedLearnerRevision: 1,
+    payload: {
+      mode: 'smart',
+      roundLength: 1,
+      seed: sample.sample.seed,
+      templateId: sample.id,
+    },
+  });
+
+  assert.equal(start.response.status, 200, JSON.stringify(start.body));
+  assert.equal(start.body.subjectReadModel.session.currentItem.templateId, sample.id);
+  assert.equal(start.body.subjectReadModel.session.focusConceptId, '');
+  assert.equal(start.body.subjectReadModel.prefs.focusConceptId, 'word_classes');
 
   DB.close();
 });

--- a/worker/src/subjects/grammar/engine.js
+++ b/worker/src/subjects/grammar/engine.js
@@ -20,8 +20,8 @@ const DEFAULT_MINI_SET_LENGTH = 8;
 const SHORT_RESPONSE_TEXT_LIMIT = 512;
 const LONG_RESPONSE_TEXT_LIMIT = 2000;
 const LIST_RESPONSE_LIMIT = 40;
-const ENABLED_MODES = new Set(['learn', 'smart', 'satsset', 'trouble']);
-const LOCKED_MODES = Object.freeze(['surgery', 'builder', 'worked', 'faded']);
+const ENABLED_MODES = new Set(['learn', 'smart', 'satsset', 'trouble', 'surgery']);
+const LOCKED_MODES = Object.freeze(['builder', 'worked', 'faded']);
 const GRAMMAR_CONCEPT_IDS = new Set(GRAMMAR_CONCEPTS.map((concept) => concept.id));
 
 function isPlainObject(value) {
@@ -396,17 +396,24 @@ function enqueueRetry(state, item, result, nowTs) {
     .slice(0, 120);
 }
 
-function templateFits(template, { mode, focusConceptId } = {}) {
+function templateFitsMode(template, mode) {
   if (!template) return false;
   if (mode === 'satsset' && !template.satsFriendly) return false;
+  if (mode === 'surgery' && !(template.tags || []).includes('surgery')) return false;
+  return true;
+}
+
+function templateFits(template, { mode, focusConceptId } = {}) {
+  if (!templateFitsMode(template, mode)) return false;
   if (focusConceptId && !(template.skillIds || []).includes(focusConceptId)) return false;
   return true;
 }
 
 function weightedTemplatePick(state, { mode, focusConceptId, seed, nowTs = Date.now() }) {
   const rng = seededRandom(seed);
-  const candidates = GRAMMAR_TEMPLATE_METADATA.filter((template) => templateFits(template, { mode, focusConceptId }));
-  const pool = candidates.length ? candidates : GRAMMAR_TEMPLATE_METADATA;
+  const modeCandidates = GRAMMAR_TEMPLATE_METADATA.filter((template) => templateFitsMode(template, mode));
+  const candidates = modeCandidates.filter((template) => templateFits(template, { mode, focusConceptId }));
+  const pool = candidates.length ? candidates : (modeCandidates.length ? modeCandidates : GRAMMAR_TEMPLATE_METADATA);
   const weighted = pool.map((template) => {
     const conceptNodes = template.skillIds.map((id) => state.mastery.concepts[id] || defaultMasteryNode());
     const averageStrength = conceptNodes.reduce((sum, node) => sum + (Number(node.strength) || 0.25), 0) / Math.max(1, conceptNodes.length);
@@ -459,6 +466,15 @@ function nextItem(state, { mode, focusConceptId, seed, templateId = '', nowTs = 
         templateId,
       });
     }
+    if (!templateFits(template, { mode, focusConceptId })) {
+      throw new BadRequestError('Grammar template is not available for this Grammar mode or focus concept.', {
+        code: 'grammar_template_unavailable_for_mode',
+        subjectId: SUBJECT_ID,
+        mode,
+        focusConceptId,
+        templateId,
+      });
+    }
     return itemFromTemplate(template, seed);
   }
   const retry = takeDueRetry(state, { mode, focusConceptId, nowTs });
@@ -489,6 +505,7 @@ function weakestConceptIdForTrouble(state, nowTs) {
 function normaliseMode(value) {
   const mode = String(value || 'smart').trim().toLowerCase().replace(/[\s_]+/g, '-');
   if (mode === 'mini-set' || mode === 'mini' || mode === 'test') return 'satsset';
+  if (mode === 'sentence-surgery') return 'surgery';
   return mode || 'smart';
 }
 
@@ -565,23 +582,30 @@ export function buildGrammarMiniSet({ size = DEFAULT_MINI_SET_LENGTH, focusConce
 
 function startSession(state, payload, nowTs, learnerId) {
   const mode = supportedModeOrThrow(normaliseMode(payload.mode || state.prefs.mode));
+  const templateId = typeof payload.templateId === 'string' ? payload.templateId : '';
   const hasPayloadFocusConcept = typeof payload.focusConceptId === 'string' || typeof payload.skillId === 'string';
   const requestedFocusConceptId = typeof payload.focusConceptId === 'string'
     ? payload.focusConceptId
     : (typeof payload.skillId === 'string' ? payload.skillId : '');
-  const focusConceptId = hasPayloadFocusConcept
-    ? requestedFocusConceptId
-    : (mode === 'trouble' ? '' : normaliseStoredFocusConceptId(state.prefs.focusConceptId));
-  if (focusConceptId && !isGrammarConceptId(focusConceptId)) {
+  const storedFocusConceptId = normaliseStoredFocusConceptId(state.prefs.focusConceptId);
+  const prefsFocusConceptId = mode === 'surgery'
+    ? ''
+    : (hasPayloadFocusConcept
+      ? requestedFocusConceptId
+      : (mode === 'trouble' ? '' : storedFocusConceptId));
+  const sessionRequestedFocusConceptId = templateId && !hasPayloadFocusConcept
+    ? ''
+    : prefsFocusConceptId;
+  if (prefsFocusConceptId && !isGrammarConceptId(prefsFocusConceptId)) {
     throw new BadRequestError('Grammar concept is not available.', {
       code: 'grammar_concept_not_found',
       subjectId: SUBJECT_ID,
-      conceptId: focusConceptId,
+      conceptId: prefsFocusConceptId,
     });
   }
-  const sessionFocusConceptId = mode === 'trouble' && !focusConceptId
+  const sessionFocusConceptId = mode === 'trouble' && !sessionRequestedFocusConceptId
     ? weakestConceptIdForTrouble(state, nowTs)
-    : focusConceptId;
+    : sessionRequestedFocusConceptId;
   const roundLength = roundLengthFor(mode, payload, state.prefs);
   const baseSeed = Number.isFinite(Number(payload.seed))
     ? Number(payload.seed)
@@ -598,7 +622,7 @@ function startSession(state, payload, nowTs, learnerId) {
     focusConceptId: sessionFocusConceptId,
     seed: baseSeed,
     nowTs,
-    templateId: typeof payload.templateId === 'string' ? payload.templateId : '',
+    templateId,
   });
   state.phase = 'session';
   state.awaitingAdvance = false;
@@ -609,11 +633,13 @@ function startSession(state, payload, nowTs, learnerId) {
     ...state.prefs,
     mode,
     roundLength,
-    focusConceptId,
+    focusConceptId: prefsFocusConceptId,
   };
   state.session = {
     id: sessionId,
-    type: mode === 'satsset' ? 'mini-set' : (mode === 'trouble' ? 'trouble-drill' : 'practice'),
+    type: mode === 'satsset'
+      ? 'mini-set'
+      : (mode === 'trouble' ? 'trouble-drill' : (mode === 'surgery' ? 'sentence-surgery' : 'practice')),
     mode,
     focusConceptId: sessionFocusConceptId,
     startedAt: nowTs,
@@ -875,7 +901,7 @@ function savePrefs(state, payload) {
   const prefs = isPlainObject(payload.prefs) ? payload.prefs : payload;
   const nextMode = prefs.mode ? normaliseMode(prefs.mode) : state.prefs.mode;
   const hasFocusConcept = Object.prototype.hasOwnProperty.call(prefs, 'focusConceptId');
-  const nextFocusConceptId = nextMode === 'trouble'
+  const nextFocusConceptId = nextMode === 'trouble' || nextMode === 'surgery'
     ? ''
     : (hasFocusConcept
       ? normaliseStoredFocusConceptId(prefs.focusConceptId)

--- a/worker/src/subjects/grammar/read-models.js
+++ b/worker/src/subjects/grammar/read-models.js
@@ -253,7 +253,7 @@ function capabilityMetadata() {
     smart: { label: 'Smart mixed review', detail: 'Worker-selected review across Grammar concepts.' },
     satsset: { label: 'KS2-style mini-set', detail: 'A short mixed set with SATs-friendly question shapes.' },
     trouble: { label: 'Weak concepts drill', detail: 'Targets the weakest Grammar concepts with retry pressure.' },
-    surgery: { label: 'Sentence surgery' },
+    surgery: { label: 'Sentence surgery', detail: 'Fix and rewrite sentence-level Grammar errors.' },
     builder: { label: 'Sentence builder' },
     worked: { label: 'Worked examples' },
     faded: { label: 'Faded guidance' },


### PR DESCRIPTION
## Summary
- Enable Grammar Sentence surgery as a Worker-command-backed mode while keeping builder/worked/faded locked.
- Filter surgery sessions to fix/rewrite templates tagged for sentence surgery, with focus fallback staying inside the surgery pool.
- Update client and Worker capability metadata plus regression coverage for engine, route, and React setup flows.

## Verification
- `node --test tests/grammar-engine.test.js tests/worker-grammar-subject-runtime.test.js tests/react-grammar-surface.test.js tests/hub-read-models.test.js tests/subject-expansion.test.js`
- `npm test`
- `npm run check`