### PR TITLE
chore(punctuation): enable production exposure

### DIFF
--- a/docs/punctuation-production.md
+++ b/docs/punctuation-production.md
@@ -178,7 +178,7 @@ The Punctuation release gate includes:
 - asset tests for Bellstorm Coast scenes and Punctuation monster artwork
 - bundle/public-output audits proving engine/content source is not shipped to the browser
 
-Production exposure is controlled by the `PUNCTUATION_SUBJECT_ENABLED` Worker env var, which feeds the browser `punctuationProduction` subject exposure gate. The default production value is `false`: the Worker command route, dashboard card, and direct subject route stay unavailable until the full gate has passed and the env var is intentionally flipped.
+Production exposure is controlled by the `PUNCTUATION_SUBJECT_ENABLED` Worker env var, which feeds the browser `punctuationProduction` subject exposure gate. The release-smoke gate now covers both sides of the rollout: `false` keeps the Worker command route, dashboard card, and direct subject route unavailable; `true` exposes the subject only after the Worker-backed demo path has been verified.
 
 Before deployment, run:
 
@@ -191,6 +191,6 @@ After deployment, verify the production UI on `https://ks2.eugnel.uk` with a log
 
 ## Expansion Path
 
-The next Punctuation release should deepen one learning cluster or validator family at a time. Each expansion needs enough fixed items, generated templates, negative tests, misconception tags, transfer facets, and reward-unit denominators before the public exposure flag is changed.
+The next Punctuation release should deepen one learning cluster or validator family at a time. Each expansion needs enough fixed items, generated templates, negative tests, misconception tags, transfer facets, and reward-unit denominators before learner-facing mastery claims are widened.
 
 Do not expose planned clusters just because monster assets exist. Bellstorm Coast rewards should continue to follow secure learning evidence.

--- a/docs/subject-expansion.md
+++ b/docs/subject-expansion.md
@@ -195,6 +195,7 @@ The Punctuation slice adds a concrete precedent for future real subjects:
 - reward projection follows domain events, not UI clicks or game-layer state
 - monster progress uses subject-specific units while the Codex remains shared
 - public exposure needs deterministic demo evidence: the default gate hides the subject, and the enabled gate completes a Worker-backed learner action before rollout
+- flipping a subject exposure env var is a reviewable release step, not an incidental code cleanup
 
 ### 8. Scope discipline
 

--- a/tests/punctuation-release-smoke.test.js
+++ b/tests/punctuation-release-smoke.test.js
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 
 import { SUBJECT_EXPOSURE_GATES } from '../src/platform/core/subject-availability.js';
 import { createPunctuationContentIndexes } from '../shared/punctuation/content.js';
@@ -8,6 +9,11 @@ import { createWorkerRepositoryServer } from './helpers/worker-server.js';
 
 const RUNTIME_PUNCTUATION_ITEMS = createPunctuationContentIndexes(createPunctuationRuntimeManifest()).itemById;
 const SERVER_ONLY_READ_MODEL_FIELDS = /accepted|correctIndex|rubric|validator|hiddenQueue|generator/;
+
+async function readWranglerVars() {
+  const source = await readFile(new URL('../wrangler.jsonc', import.meta.url), 'utf8');
+  return JSON.parse(source).vars || {};
+}
 
 function productionServer({ punctuationEnabled = false } = {}) {
   return createWorkerRepositoryServer({
@@ -178,6 +184,11 @@ test('Punctuation release smoke keeps demo exposure blocked by default', async (
   } finally {
     server.close();
   }
+});
+
+test('Punctuation production rollout config intentionally enables the exposure gate', async () => {
+  const vars = await readWranglerVars();
+  assert.equal(vars.PUNCTUATION_SUBJECT_ENABLED, 'true');
 });
 
 test('Punctuation release smoke completes a gated demo action through Worker commands', async () => {

--- a/worker/README.md
+++ b/worker/README.md
@@ -134,7 +134,7 @@ For Grammar, the Worker owns session creation, deterministic question generation
 
 For Punctuation, the Worker owns session creation, item selection, deterministic marking, spaced scheduling, misconception events, release-scoped secure-unit progress, completed session writes, Bellstorm Coast reward projection, and the returned read model.
 
-Punctuation remains behind the `PUNCTUATION_SUBJECT_ENABLED` rollout env var. The production default is `false`, so the command route and browser exposure stay unavailable until release verification is accepted and the flag is intentionally changed.
+Punctuation remains behind the `PUNCTUATION_SUBJECT_ENABLED` rollout env var. The production deployment now sets it to `true` after the release-smoke gate passed, so the command route and browser exposure are intentionally available after deployment. Set it back to `false` for an immediate rollout rollback.
 
 The React client sends user intent and renders the response. It does not use browser-local Spelling, Grammar, or Punctuation engines as a production fallback.
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -32,7 +32,7 @@
     "APP_HOSTNAME": "ks2.eugnel.uk",
     "AUTH_MODE": "production",
     "ENVIRONMENT": "production",
-    "PUNCTUATION_SUBJECT_ENABLED": "false",
+    "PUNCTUATION_SUBJECT_ENABLED": "true",
     "SOCIAL_LOGIN_WIRE_ENABLED": "true"
   },
   "d1_databases": [


### PR DESCRIPTION
## Summary
- flip the production Punctuation rollout flag to expose the subject after the release-smoke gate
- add a rollout-config assertion so the exposure change is explicit and reviewable
- update Punctuation rollout docs with the enabled state and rollback path

## Verification
- node --test tests/punctuation-release-smoke.test.js tests/worker-punctuation-runtime.test.js tests/subject-expansion.test.js tests/spelling.test.js tests/spelling-parity.test.js tests/server-spelling-engine-parity.test.js tests/spelling-remote-actions.test.js tests/subject-command-actions.test.js
- npm test
- npm run check

## Notes
- Wrangler dry-run now shows PUNCTUATION_SUBJECT_ENABLED ("true").
- This PR does not deploy by itself; production exposure happens after merge plus deploy.
