### PR TITLE
fix(spelling): suppress failed tts warmup 503s

### DIFF
--- a/tests/worker-tts.test.js
+++ b/tests/worker-tts.test.js
@@ -798,6 +798,47 @@ test('TTS cache-only requests warm Gemini audio without returning playback bytes
   }
 });
 
+test('TTS cache-only warmups report provider failures without surfacing service unavailable', async () => {
+  const originalFetch = globalThis.fetch;
+  let providerCalls = 0;
+  globalThis.fetch = async (url) => {
+    providerCalls += 1;
+    assert.match(String(url), /generativelanguage/);
+    return new Response(JSON.stringify({ error: 'temporarily unavailable' }), {
+      status: 503,
+      headers: { 'content-type': 'application/json' },
+    });
+  };
+  const bucket = createMemoryR2Bucket();
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      GEMINI_API_KEY: 'test-gemini-key',
+      SPELLING_AUDIO_BUCKET: bucket,
+    },
+  });
+  try {
+    const prompt = await startSpellingPrompt(server);
+    const response = await server.fetch('https://repo.test/api/tts', ttsRequest({
+      learnerId: prompt.learnerId,
+      promptToken: prompt.promptToken,
+      provider: 'gemini',
+      bufferedGeminiVoice: 'Iapetus',
+      cacheOnly: true,
+    }));
+    const bytes = new Uint8Array(await response.arrayBuffer());
+
+    assert.equal(response.status, 204);
+    assert.equal(response.headers.get('x-ks2-tts-cache'), 'provider_failed');
+    assert.equal(bytes.length, 0);
+    assert.equal(providerCalls, 1);
+    assert.equal(bucket.puts.length, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+    server.close();
+  }
+});
+
 test('TTS cache-only warmups do not spend user playback quota', async () => {
   const originalFetch = globalThis.fetch;
   const calls = [];

--- a/worker/src/tts.js
+++ b/worker/src/tts.js
@@ -287,6 +287,10 @@ function canFallbackProviderError(error) {
   return !Number.isFinite(status) || status >= 500;
 }
 
+function isProviderFailure(error, provider) {
+  return error?.provider === provider;
+}
+
 function spellingAudioBucket(env = {}) {
   const bucket = env.SPELLING_AUDIO_BUCKET;
   return bucket && typeof bucket.get === 'function' && typeof bucket.put === 'function'
@@ -780,6 +784,9 @@ export async function handleTextToSpeechRequest({
     try {
       return await tryGemini();
     } catch (error) {
+      if (cacheOnly && isProviderFailure(error, 'gemini')) {
+        return await finish(cacheOnlyResponse('provider_failed'));
+      }
       if (!canFallbackProviderError(error)) throw error;
       if (cacheOnly || !openAi.apiKey) throw providerUnavailableError(error, [error]);
       try {


### PR DESCRIPTION
## Summary

Cache-only Gemini warmups now fail silently as warmup metadata instead of surfacing `/api/tts` as a 503. This keeps spelling dictation playback on the selected provider while preventing background pre-cache failures from producing per-question Service Unavailable noise.

The Worker still reports real playback, validation, and demo limiter failures normally; only Gemini provider failures from cache-only warmups are converted to `204` with `x-ks2-tts-cache: provider_failed`.

## Validation

- `npm test`
- `npm run check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)