### PR TITLE
fix(spelling): recover multiple missed celebrations

### DIFF
--- a/src/platform/game/monster-celebration-acks.js
+++ b/src/platform/game/monster-celebration-acks.js
@@ -146,6 +146,7 @@ function baselineExistingEvents(events, {
 export function unacknowledgedMonsterCelebrationEvents(events, {
   learnerId = '',
   ignoredIds = new Set(),
+  excludeEventIds = null,
   limit = 1,
   baselineExisting = false,
   baselineEventIds = null,
@@ -165,10 +166,11 @@ export function unacknowledgedMonsterCelebrationEvents(events, {
   }
   const acknowledgedIds = acknowledgedMonsterCelebrationIds(learnerId, { store });
   const ignored = ignoredIds instanceof Set ? ignoredIds : new Set();
+  const excluded = normaliseIdSet(excludeEventIds);
   const candidates = scopedEvents
     .filter((event) => {
       const id = eventId(event);
-      return id && !acknowledgedIds.has(id) && !ignored.has(id);
+      return id && !acknowledgedIds.has(id) && !ignored.has(id) && (!excluded || !excluded.has(id));
     })
     .sort((a, b) => (Number(a.createdAt) || 0) - (Number(b.createdAt) || 0));
 

--- a/src/subjects/spelling/remote-actions.js
+++ b/src/subjects/spelling/remote-actions.js
@@ -17,6 +17,7 @@ import {
 
 const READ_ONLY_MESSAGE = 'Practice is read-only while sync is degraded. Retry sync before continuing.';
 const SETUP_PREF_SAVE_DEBOUNCE_MS = 120;
+const SPELLING_COMPENSATION_EVENT_LIMIT = 25;
 
 const SPELLING_COMMAND_ACTIONS = new Set([
   'spelling-set-mode',
@@ -312,16 +313,18 @@ export function createRemoteSpellingActionHandler({
     const endedSession = spellingSessionEnded(previousSubjectUi, nextSubjectUi);
     let monsterEvents = responseMonsterEvents;
     if (isSelectedLearner && endedSession && !monsterEvents.length) {
+      const loggedRewardEvents = spellingRewardEvents(store.repositories?.eventLog?.list?.(learnerId) || []);
       const ignoredIds = new Set([
         ...eventIds(rewardProjection.events || []),
         ...visibleMonsterCelebrationIds(nextState),
       ]);
       monsterEvents = unacknowledgedMonsterCelebrationEvents(
-        spellingRewardEvents(store.repositories?.eventLog?.list?.(learnerId) || []),
+        loggedRewardEvents,
         {
           learnerId,
           ignoredIds,
-          limit: 1,
+          excludeEventIds: compensationBaselineEventIds,
+          limit: SPELLING_COMPENSATION_EVENT_LIMIT,
           baselineExisting: true,
           baselineEventIds: compensationBaselineEventIds,
         },

--- a/tests/spelling-remote-actions.test.js
+++ b/tests/spelling-remote-actions.test.js
@@ -821,7 +821,23 @@ test('remote spelling command compensates only rewards appended after the comman
     next: { mastered: 10, stage: 1, level: 2, caught: true, branch: 'b1' },
     createdAt: now - 60_000,
   };
-  const commandMissedEvolution = {
+  const commandDirectEvolution = {
+    id: 'reward.monster:learner-a:glimmerbug:evolve:1:2',
+    type: 'reward.monster',
+    kind: 'evolve',
+    learnerId: 'learner-a',
+    subjectId: 'spelling',
+    monsterId: 'glimmerbug',
+    monster: {
+      id: 'glimmerbug',
+      name: 'Glimmerbug',
+      accent: '#F2B84B',
+    },
+    previous: { mastered: 9, stage: 0, level: 1, caught: true, branch: 'b1' },
+    next: { mastered: 10, stage: 1, level: 2, caught: true, branch: 'b1' },
+    createdAt: now,
+  };
+  const commandPhaetonEvolution = {
     id: 'reward.monster:learner-a:phaeton:evolve:1:2',
     type: 'reward.monster',
     kind: 'evolve',
@@ -835,7 +851,7 @@ test('remote spelling command compensates only rewards appended after the comman
     },
     previous: { mastered: 29, stage: 1, level: 2, caught: true, branch: 'b2' },
     next: { mastered: 30, stage: 2, level: 3, caught: true, branch: 'b2' },
-    createdAt: now,
+    createdAt: now + 1,
   };
   const events = [priorEvolution];
   const { getState, store } = createStoreHarness({
@@ -855,7 +871,7 @@ test('remote spelling command compensates only rewards appended after the comman
     readModels: { readJson: async () => ({}) },
     subjectCommands: {
       async send() {
-        events.push(commandMissedEvolution);
+        events.push(commandDirectEvolution, commandPhaetonEvolution);
         return {
           learnerId: 'learner-a',
           subjectReadModel: { phase: 'summary' },
@@ -873,11 +889,13 @@ test('remote spelling command compensates only rewards appended after the comman
   assert.equal(handler.runCommand('end-session'), true);
   await flushPromises();
 
-  assert.equal(getState().monsterCelebrations.queue.length, 1);
-  assert.equal(getState().monsterCelebrations.queue[0].id, commandMissedEvolution.id);
+  assert.deepEqual(getState().monsterCelebrations.queue.map((event) => event.id), [
+    commandDirectEvolution.id,
+    commandPhaetonEvolution.id,
+  ]);
 });
 
-test('remote spelling compensation preserves older recent missed celebrations for later replay', () => {
+test('remote spelling compensation excludes pre-command rewards even with an existing ack baseline', () => {
   installMemoryStorage();
   const now = Date.now();
   const directEvolution = {
@@ -928,6 +946,9 @@ test('remote spelling compensation preserves older recent missed celebrations fo
     readModels: { readJson: async () => ({}) },
     subjectCommands: { send: async () => ({}) },
   });
+  globalThis.localStorage.setItem('ks2-platform-v2.monster-celebration-acks', JSON.stringify({
+    'learner-a': { ids: [], baselineAt: now - 5000 },
+  }));
 
   handler.applyCommandResponse({
     learnerId: 'learner-a',
@@ -940,46 +961,16 @@ test('remote spelling compensation preserves older recent missed celebrations fo
     },
   }, {
     command: 'end-session',
-    compensationBaselineEventIds: new Set(),
+    compensationBaselineEventIds: new Set([directEvolution.id]),
   });
 
   assert.equal(getState().monsterCelebrations.queue.length, 1);
   assert.equal(getState().monsterCelebrations.queue[0].id, phaetonEvolution.id);
-
-  acknowledgeMonsterCelebrationEvents(phaetonEvolution, { learnerId: 'learner-a' });
-  store.dismissMonsterCelebration();
-  store.updateSubjectUi('spelling', {
-    phase: 'session',
-    session: {
-      id: 'session-b',
-      currentSlug: 'necessary',
-      phase: 'answer',
-      promptCount: 1,
-    },
-  });
-  calls.length = 0;
-
-  handler.applyCommandResponse({
-    learnerId: 'learner-a',
-    subjectReadModel: { phase: 'summary' },
-    projections: {
-      rewards: {
-        toastEvents: [],
-        events: [],
-      },
-    },
-  }, {
-    command: 'end-session',
-    compensationBaselineEventIds: new Set([directEvolution.id, phaetonEvolution.id]),
-  });
-
   assert.deepEqual(calls.map(([name]) => name), [
     'reloadFromRepositories',
     'deferMonsterCelebrations',
     'releaseMonsterCelebrations',
   ]);
-  assert.equal(getState().monsterCelebrations.queue.length, 1);
-  assert.equal(getState().monsterCelebrations.queue[0].id, directEvolution.id);
 });
 
 test('remote spelling command response ignores stale learner TTS side effects', () => {


### PR DESCRIPTION
## Summary
- Recover multiple command-time missed spelling monster celebrations in one compensation pass instead of only the newest event.
- Keep compensation scoped to events appended after the command started, so older persisted reward history is not replayed from stale or existing ack baselines.
- Add regression coverage for direct + Phaeton missed celebrations and pre-command exclusion with an existing local ack baseline.

## Verification
- `npm test -- tests/spelling-remote-actions.test.js`
- `npm test`
- `npm run check`
