### PR TITLE
Add reusable Grammar production smoke

### DIFF
--- a/docs/full-lockdown-runtime.md
+++ b/docs/full-lockdown-runtime.md
@@ -112,6 +112,14 @@ npm run smoke:production:punctuation
 
 It verifies a production demo session, the Punctuation exposure gate, a Worker-owned Punctuation start-submit-summary path, and a Worker-owned English Spelling start path with redacted prompt-token audio.
 
+When Grammar is the deployed change, run:
+
+```bash
+npm run smoke:production:grammar
+```
+
+It verifies a production demo session, a fixed Worker-owned Grammar start-submit-summary path, and the same English Spelling prompt-token start path so Grammar changes do not regress the reference subject.
+
 ## Operations
 
 Wrangler observability is enabled, but production should still alert on the signals that would indicate the lockdown boundary is under stress:

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "deploy:oauth": "npm run deploy",
     "deploy:ci": "npm run deploy",
     "ops:tail": "node ./scripts/wrangler-oauth.mjs tail ks2-mastery --format pretty",
+    "smoke:production:grammar": "node ./scripts/grammar-production-smoke.mjs",
     "smoke:production:punctuation": "node ./scripts/punctuation-production-smoke.mjs",
     "test": "node --test",
     "test:migration:browser": "KS2_BROWSER_SMOKE=1 node --test tests/browser-react-migration-smoke.test.js",

--- a/scripts/grammar-production-smoke.mjs
+++ b/scripts/grammar-production-smoke.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import assert from 'node:assert/strict';
+import { pathToFileURL } from 'node:url';
 
 import {
   createGrammarQuestion,
@@ -19,7 +20,7 @@ const GRAMMAR_SMOKE_ITEM = Object.freeze({
   seed: 1,
 });
 
-const FORBIDDEN_GRAMMAR_KEYS = new Set([
+const FORBIDDEN_GRAMMAR_READ_MODEL_KEYS = new Set([
   'solutionLines',
   'correctResponse',
   'correctResponses',
@@ -28,16 +29,33 @@ const FORBIDDEN_GRAMMAR_KEYS = new Set([
   'evaluate',
   'generator',
   'template',
+]);
+
+const FORBIDDEN_GRAMMAR_ITEM_KEYS = new Set([
+  ...FORBIDDEN_GRAMMAR_READ_MODEL_KEYS,
   'templates',
 ]);
 
-function correctResponseFor(readItem) {
+function normaliseChoiceOptions(inputSpec, context) {
+  assert.ok(Array.isArray(inputSpec?.options) && inputSpec.options.length > 0, `${context} did not expose answer options.`);
+  return inputSpec.options.map((option, index) => {
+    assert.equal(typeof option?.value, 'string', `${context} exposed option ${index + 1} without a string value.`);
+    assert.equal(typeof option?.label, 'string', `${context} exposed option ${index + 1} without a string label.`);
+    return {
+      value: option.value,
+      label: option.label,
+    };
+  });
+}
+
+export function assertNoForbiddenGrammarReadModelKeys(value, path = 'grammar.subjectReadModel') {
+  assertNoForbiddenObjectKeys(value, FORBIDDEN_GRAMMAR_READ_MODEL_KEYS, path);
+  assertNoForbiddenObjectKeys(value?.session?.currentItem, FORBIDDEN_GRAMMAR_ITEM_KEYS, `${path}.session.currentItem`);
+}
+
+export function correctResponseFor(readItem) {
   assert.equal(readItem?.inputSpec?.type, 'single_choice', 'Grammar production read model did not expose a single-choice input.');
-  assert.ok(Array.isArray(readItem?.inputSpec?.options) && readItem.inputSpec.options.length > 0, 'Grammar production read model did not expose answer options.');
-  for (const option of readItem.inputSpec.options) {
-    assert.equal(typeof option?.value, 'string', 'Grammar production read model exposed an option without a string value.');
-    assert.equal(typeof option?.label, 'string', 'Grammar production read model exposed an option without a string label.');
-  }
+  const readOptions = normaliseChoiceOptions(readItem.inputSpec, 'Grammar production read model');
 
   const question = createGrammarQuestion({
     templateId: readItem?.templateId,
@@ -45,15 +63,16 @@ function correctResponseFor(readItem) {
   });
   assert.ok(question, `Could not rebuild Grammar smoke question for ${readItem?.templateId || 'unknown template'}.`);
   assert.equal(question.inputSpec?.type, 'single_choice', 'Grammar production smoke expects a single-choice template.');
+  const expectedOptions = normaliseChoiceOptions(question.inputSpec, 'Regenerated Grammar smoke question');
+  assert.deepEqual(readOptions, expectedOptions, 'Grammar production option set did not match the regenerated question.');
 
-  for (const option of question.inputSpec.options || []) {
-    const value = String(option?.value ?? option ?? '');
-    if (evaluateGrammarQuestion(question, { answer: value })?.correct) {
-      return { answer: value };
+  for (const option of readOptions) {
+    if (evaluateGrammarQuestion(question, { answer: option.value })?.correct) {
+      return { answer: option.value };
     }
   }
 
-  throw new Error(`Could not derive a correct Grammar smoke response for ${readItem?.templateId}.`);
+  throw new Error(`Grammar production options did not contain a correct answer for ${readItem?.templateId}.`);
 }
 
 async function smokeGrammar({ origin, cookie, learnerId, revision }) {
@@ -78,7 +97,7 @@ async function smokeGrammar({ origin, cookie, learnerId, revision }) {
   assert.equal(startModel?.session?.serverAuthority, 'worker', 'Grammar session was not Worker-owned.');
   assert.equal(startModel?.session?.targetCount, 1, 'Grammar smoke round did not use one target item.');
   assert.equal(startModel?.session?.currentItem?.templateId, GRAMMAR_SMOKE_ITEM.templateId);
-  assertNoForbiddenObjectKeys(startModel.session?.currentItem, FORBIDDEN_GRAMMAR_KEYS, 'grammar.currentItem');
+  assertNoForbiddenGrammarReadModelKeys(startModel, 'grammar.startModel');
 
   const response = correctResponseFor(startModel.session.currentItem);
   step = await subjectCommand({
@@ -94,6 +113,7 @@ async function smokeGrammar({ origin, cookie, learnerId, revision }) {
   const feedbackModel = step.payload.subjectReadModel;
   assert.equal(feedbackModel?.phase, 'feedback', 'Grammar submit did not return feedback phase.');
   assert.equal(feedbackModel?.feedback?.result?.correct, true, 'Grammar smoke answer was not accepted.');
+  assertNoForbiddenGrammarReadModelKeys(feedbackModel, 'grammar.feedbackModel');
 
   step = await subjectCommand({
     origin,
@@ -108,6 +128,7 @@ async function smokeGrammar({ origin, cookie, learnerId, revision }) {
   assert.equal(summaryModel?.phase, 'summary', 'Grammar continue did not reach summary.');
   assert.equal(summaryModel?.summary?.answered, 1, 'Grammar summary did not record one answered item.');
   assert.equal(summaryModel?.summary?.targetCount, 1, 'Grammar summary did not preserve the one-item target.');
+  assertNoForbiddenGrammarReadModelKeys(summaryModel, 'grammar.summaryModel');
 
   return {
     revision,
@@ -177,7 +198,9 @@ async function main() {
   }, null, 2));
 }
 
-main().catch((error) => {
-  console.error(`[grammar-production-smoke] ${error?.stack || error?.message || error}`);
-  process.exit(1);
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(`[grammar-production-smoke] ${error?.stack || error?.message || error}`);
+    process.exit(1);
+  });
+}

--- a/scripts/grammar-production-smoke.mjs
+++ b/scripts/grammar-production-smoke.mjs
@@ -32,6 +32,13 @@ const FORBIDDEN_GRAMMAR_KEYS = new Set([
 ]);
 
 function correctResponseFor(readItem) {
+  assert.equal(readItem?.inputSpec?.type, 'single_choice', 'Grammar production read model did not expose a single-choice input.');
+  assert.ok(Array.isArray(readItem?.inputSpec?.options) && readItem.inputSpec.options.length > 0, 'Grammar production read model did not expose answer options.');
+  for (const option of readItem.inputSpec.options) {
+    assert.equal(typeof option?.value, 'string', 'Grammar production read model exposed an option without a string value.');
+    assert.equal(typeof option?.label, 'string', 'Grammar production read model exposed an option without a string label.');
+  }
+
   const question = createGrammarQuestion({
     templateId: readItem?.templateId,
     seed: readItem?.seed,
@@ -124,8 +131,10 @@ async function smokeSpelling({ origin, cookie, learnerId, revision }) {
   assert.equal(model?.session?.serverAuthority, 'worker', 'Spelling session was not Worker-owned.');
   assert.equal(model?.session?.progress?.total, 1, 'Spelling smoke round did not use one target word.');
   assert.equal(model?.session?.currentCard?.word, undefined, 'Spelling read model exposed the raw word.');
+  assert.equal(model?.session?.currentCard?.prompt?.sentence, undefined, 'Spelling read model exposed the raw sentence.');
   assert.ok(model?.session?.currentCard?.prompt?.cloze, 'Spelling read model did not include the redacted cloze prompt.');
   assert.ok(step.payload?.audio?.promptToken, 'Spelling command did not return a prompt token.');
+  assert.ok(model?.audio?.promptToken, 'Spelling read model did not include a prompt token.');
 
   return {
     revision: step.revision,

--- a/scripts/grammar-production-smoke.mjs
+++ b/scripts/grammar-production-smoke.mjs
@@ -36,11 +36,15 @@ const FORBIDDEN_GRAMMAR_ITEM_KEYS = new Set([
   'templates',
 ]);
 
-function normaliseChoiceOptions(inputSpec, context) {
+function normaliseChoiceOptions(inputSpec, context, { allowExtraKeys = false } = {}) {
   assert.ok(Array.isArray(inputSpec?.options) && inputSpec.options.length > 0, `${context} did not expose answer options.`);
   return inputSpec.options.map((option, index) => {
     assert.equal(typeof option?.value, 'string', `${context} exposed option ${index + 1} without a string value.`);
     assert.equal(typeof option?.label, 'string', `${context} exposed option ${index + 1} without a string label.`);
+    if (!allowExtraKeys) {
+      const keys = Object.keys(option).sort();
+      assert.deepEqual(keys, ['label', 'value'], `${context} exposed option ${index + 1} with unexpected fields: ${keys.join(', ')}`);
+    }
     return {
       value: option.value,
       label: option.label,
@@ -63,7 +67,7 @@ export function correctResponseFor(readItem) {
   });
   assert.ok(question, `Could not rebuild Grammar smoke question for ${readItem?.templateId || 'unknown template'}.`);
   assert.equal(question.inputSpec?.type, 'single_choice', 'Grammar production smoke expects a single-choice template.');
-  const expectedOptions = normaliseChoiceOptions(question.inputSpec, 'Regenerated Grammar smoke question');
+  const expectedOptions = normaliseChoiceOptions(question.inputSpec, 'Regenerated Grammar smoke question', { allowExtraKeys: true });
   assert.deepEqual(readOptions, expectedOptions, 'Grammar production option set did not match the regenerated question.');
 
   for (const option of readOptions) {
@@ -167,7 +171,7 @@ async function smokeSpelling({ origin, cookie, learnerId, revision }) {
 async function main() {
   const origin = configuredOrigin();
   const demo = await createDemoSession(origin);
-  const bootstrap = await loadBootstrap(origin, demo.cookie);
+  const bootstrap = await loadBootstrap(origin, demo.cookie, { expectedSession: demo.session });
 
   const grammar = await smokeGrammar({
     origin,

--- a/scripts/grammar-production-smoke.mjs
+++ b/scripts/grammar-production-smoke.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+
+import {
+  createGrammarQuestion,
+  evaluateGrammarQuestion,
+} from '../worker/src/subjects/grammar/content.js';
+import {
+  assertNoForbiddenObjectKeys,
+  configuredOrigin,
+  createDemoSession,
+  loadBootstrap,
+  subjectCommand,
+} from './lib/production-smoke.mjs';
+
+const GRAMMAR_SMOKE_ITEM = Object.freeze({
+  templateId: 'fronted_adverbial_choose',
+  seed: 1,
+});
+
+const FORBIDDEN_GRAMMAR_KEYS = new Set([
+  'solutionLines',
+  'correctResponse',
+  'correctResponses',
+  'accepted',
+  'answers',
+  'evaluate',
+  'generator',
+  'template',
+  'templates',
+]);
+
+function correctResponseFor(readItem) {
+  const question = createGrammarQuestion({
+    templateId: readItem?.templateId,
+    seed: readItem?.seed,
+  });
+  assert.ok(question, `Could not rebuild Grammar smoke question for ${readItem?.templateId || 'unknown template'}.`);
+  assert.equal(question.inputSpec?.type, 'single_choice', 'Grammar production smoke expects a single-choice template.');
+
+  for (const option of question.inputSpec.options || []) {
+    const value = String(option?.value ?? option ?? '');
+    if (evaluateGrammarQuestion(question, { answer: value })?.correct) {
+      return { answer: value };
+    }
+  }
+
+  throw new Error(`Could not derive a correct Grammar smoke response for ${readItem?.templateId}.`);
+}
+
+async function smokeGrammar({ origin, cookie, learnerId, revision }) {
+  let step = await subjectCommand({
+    origin,
+    cookie,
+    subjectId: 'grammar',
+    learnerId,
+    revision,
+    command: 'start-session',
+    payload: {
+      mode: 'smart',
+      roundLength: 1,
+      templateId: GRAMMAR_SMOKE_ITEM.templateId,
+      seed: GRAMMAR_SMOKE_ITEM.seed,
+    },
+  });
+  revision = step.revision;
+  const startModel = step.payload.subjectReadModel;
+  assert.equal(startModel?.phase, 'session', 'Grammar did not start in session phase.');
+  assert.equal(startModel?.authority, 'worker', 'Grammar read model was not Worker-authoritative.');
+  assert.equal(startModel?.session?.serverAuthority, 'worker', 'Grammar session was not Worker-owned.');
+  assert.equal(startModel?.session?.targetCount, 1, 'Grammar smoke round did not use one target item.');
+  assert.equal(startModel?.session?.currentItem?.templateId, GRAMMAR_SMOKE_ITEM.templateId);
+  assertNoForbiddenObjectKeys(startModel.session?.currentItem, FORBIDDEN_GRAMMAR_KEYS, 'grammar.currentItem');
+
+  const response = correctResponseFor(startModel.session.currentItem);
+  step = await subjectCommand({
+    origin,
+    cookie,
+    subjectId: 'grammar',
+    learnerId,
+    revision,
+    command: 'submit-answer',
+    payload: { response },
+  });
+  revision = step.revision;
+  const feedbackModel = step.payload.subjectReadModel;
+  assert.equal(feedbackModel?.phase, 'feedback', 'Grammar submit did not return feedback phase.');
+  assert.equal(feedbackModel?.feedback?.result?.correct, true, 'Grammar smoke answer was not accepted.');
+
+  step = await subjectCommand({
+    origin,
+    cookie,
+    subjectId: 'grammar',
+    learnerId,
+    revision,
+    command: 'continue-session',
+  });
+  revision = step.revision;
+  const summaryModel = step.payload.subjectReadModel;
+  assert.equal(summaryModel?.phase, 'summary', 'Grammar continue did not reach summary.');
+  assert.equal(summaryModel?.summary?.answered, 1, 'Grammar summary did not record one answered item.');
+  assert.equal(summaryModel?.summary?.targetCount, 1, 'Grammar summary did not preserve the one-item target.');
+
+  return {
+    revision,
+    templateId: startModel.session.currentItem.templateId,
+    summaryAnswered: summaryModel.summary.answered,
+  };
+}
+
+async function smokeSpelling({ origin, cookie, learnerId, revision }) {
+  const step = await subjectCommand({
+    origin,
+    cookie,
+    subjectId: 'spelling',
+    learnerId,
+    revision,
+    command: 'start-session',
+    payload: { mode: 'single', slug: 'early', length: 1 },
+  });
+  const model = step.payload.subjectReadModel;
+  assert.equal(model?.phase, 'session', 'Spelling did not start in session phase.');
+  assert.equal(model?.session?.serverAuthority, 'worker', 'Spelling session was not Worker-owned.');
+  assert.equal(model?.session?.progress?.total, 1, 'Spelling smoke round did not use one target word.');
+  assert.equal(model?.session?.currentCard?.word, undefined, 'Spelling read model exposed the raw word.');
+  assert.ok(model?.session?.currentCard?.prompt?.cloze, 'Spelling read model did not include the redacted cloze prompt.');
+  assert.ok(step.payload?.audio?.promptToken, 'Spelling command did not return a prompt token.');
+
+  return {
+    revision: step.revision,
+    progressTotal: model.session.progress.total,
+    hasPromptToken: true,
+  };
+}
+
+async function main() {
+  const origin = configuredOrigin();
+  const demo = await createDemoSession(origin);
+  const bootstrap = await loadBootstrap(origin, demo.cookie);
+
+  const grammar = await smokeGrammar({
+    origin,
+    cookie: demo.cookie,
+    learnerId: bootstrap.learnerId,
+    revision: bootstrap.revision,
+  });
+  const spelling = await smokeSpelling({
+    origin,
+    cookie: demo.cookie,
+    learnerId: bootstrap.learnerId,
+    revision: grammar.revision,
+  });
+
+  console.log(JSON.stringify({
+    ok: true,
+    origin,
+    accountId: demo.session.accountId,
+    learnerId: bootstrap.learnerId,
+    grammar: {
+      templateId: grammar.templateId,
+      summaryAnswered: grammar.summaryAnswered,
+    },
+    spelling: {
+      progressTotal: spelling.progressTotal,
+      hasPromptToken: spelling.hasPromptToken,
+    },
+  }, null, 2));
+}
+
+main().catch((error) => {
+  console.error(`[grammar-production-smoke] ${error?.stack || error?.message || error}`);
+  process.exit(1);
+});

--- a/scripts/lib/production-smoke.mjs
+++ b/scripts/lib/production-smoke.mjs
@@ -136,11 +136,26 @@ export async function createDemoSession(origin) {
   return { cookie, session: result.payload.session };
 }
 
-export async function loadBootstrap(origin, cookie) {
+export async function loadBootstrap(origin, cookie, { expectedSession = null } = {}) {
   const result = await getJson(origin, '/api/bootstrap', { cookie });
   assertOkResponse('Bootstrap', result);
+  if (expectedSession) {
+    assert.equal(result.payload?.session?.demo, true, 'Bootstrap session was not marked as demo.');
+    assert.equal(
+      result.payload?.session?.accountId,
+      expectedSession.accountId,
+      'Bootstrap account did not match the demo session account.',
+    );
+  }
   const learnerId = result.payload?.learners?.selectedId;
   assert.ok(learnerId, 'Bootstrap did not include a selected learner.');
+  if (expectedSession?.learnerId) {
+    assert.equal(
+      learnerId,
+      expectedSession.learnerId,
+      'Bootstrap selected learner did not match the demo session learner.',
+    );
+  }
   return {
     payload: result.payload,
     learnerId,

--- a/scripts/lib/production-smoke.mjs
+++ b/scripts/lib/production-smoke.mjs
@@ -1,0 +1,150 @@
+import assert from 'node:assert/strict';
+
+export const DEFAULT_PRODUCTION_ORIGIN = 'https://ks2.eugnel.uk';
+
+export function argValue(...names) {
+  for (const name of names) {
+    const index = process.argv.indexOf(name);
+    if (index !== -1 && index + 1 < process.argv.length) return process.argv[index + 1];
+  }
+  return '';
+}
+
+export function configuredOrigin({
+  envName = 'KS2_SMOKE_ORIGIN',
+  defaultOrigin = DEFAULT_PRODUCTION_ORIGIN,
+} = {}) {
+  const raw = argValue('--origin', '--url') || process.env[envName] || defaultOrigin;
+  const value = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+  return new URL(value).origin;
+}
+
+function getSetCookies(response) {
+  const values = response.headers.getSetCookie?.();
+  if (Array.isArray(values) && values.length) return values;
+  return String(response.headers.get('set-cookie') || '')
+    .split(/,\s*(?=ks2_)/)
+    .filter(Boolean);
+}
+
+function sessionCookieFrom(response) {
+  return getSetCookies(response)
+    .map((cookie) => String(cookie || '').split(';')[0])
+    .find((cookie) => cookie.startsWith('ks2_session=')) || '';
+}
+
+async function readJsonResponse(response) {
+  const text = await response.text().catch(() => '');
+  try {
+    return text ? JSON.parse(text) : {};
+  } catch {
+    return { rawBody: text };
+  }
+}
+
+async function fetchJson(url, init = {}) {
+  const response = await fetch(url, init);
+  const payload = await readJsonResponse(response);
+  return { response, payload };
+}
+
+function sameOriginHeaders(origin, cookie = '') {
+  return {
+    accept: 'application/json',
+    'content-type': 'application/json',
+    origin,
+    ...(cookie ? { cookie } : {}),
+  };
+}
+
+export async function postJson(origin, path, body = {}, { cookie = '' } = {}) {
+  return fetchJson(new URL(path, origin), {
+    method: 'POST',
+    headers: sameOriginHeaders(origin, cookie),
+    body: JSON.stringify(body),
+  });
+}
+
+export async function getJson(origin, path, { cookie = '' } = {}) {
+  return fetchJson(new URL(path, origin), {
+    method: 'GET',
+    headers: {
+      accept: 'application/json',
+      ...(cookie ? { cookie } : {}),
+    },
+  });
+}
+
+export function assertOkResponse(label, result) {
+  assert.ok(result.response.ok, `${label} failed with ${result.response.status}: ${JSON.stringify(result.payload)}`);
+  assert.notEqual(result.payload?.ok, false, `${label} returned ok=false: ${JSON.stringify(result.payload)}`);
+}
+
+export function assertNoForbiddenObjectKeys(value, forbiddenKeys, path = 'readModel') {
+  if (value == null || typeof value !== 'object') return;
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => assertNoForbiddenObjectKeys(entry, forbiddenKeys, `${path}[${index}]`));
+    return;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    assert.equal(forbiddenKeys.has(key), false, `${path}.${key} exposed a server-only field.`);
+    assertNoForbiddenObjectKeys(child, forbiddenKeys, `${path}.${key}`);
+  }
+}
+
+function nextRevisionFrom(commandPayload, previousRevision) {
+  const applied = Number(commandPayload?.mutation?.appliedRevision);
+  return Number.isFinite(applied) ? applied : previousRevision;
+}
+
+export function createRequestId(prefix) {
+  createRequestId.sequence = (createRequestId.sequence || 0) + 1;
+  return `${prefix}-${Date.now()}-${createRequestId.sequence}`;
+}
+
+export async function createDemoSession(origin) {
+  const result = await postJson(origin, '/api/demo/session');
+  assertOkResponse('Demo session creation', result);
+  const cookie = sessionCookieFrom(result.response);
+  assert.ok(cookie, 'Demo session did not return a ks2_session cookie.');
+  assert.equal(result.payload?.session?.demo, true, 'Demo session payload was not marked as demo.');
+  return { cookie, session: result.payload.session };
+}
+
+export async function loadBootstrap(origin, cookie) {
+  const result = await getJson(origin, '/api/bootstrap', { cookie });
+  assertOkResponse('Bootstrap', result);
+  const learnerId = result.payload?.learners?.selectedId;
+  assert.ok(learnerId, 'Bootstrap did not include a selected learner.');
+  return {
+    payload: result.payload,
+    learnerId,
+    revision: Number(result.payload?.learners?.byId?.[learnerId]?.stateRevision) || 0,
+  };
+}
+
+export async function subjectCommand({
+  origin,
+  cookie,
+  subjectId,
+  learnerId,
+  revision,
+  command,
+  payload = {},
+}) {
+  const requestId = createRequestId(`${subjectId}-${command}`);
+  const result = await postJson(origin, `/api/subjects/${encodeURIComponent(subjectId)}/command`, {
+    subjectId,
+    learnerId,
+    command,
+    requestId,
+    correlationId: requestId,
+    expectedLearnerRevision: revision,
+    payload,
+  }, { cookie });
+  assertOkResponse(`${subjectId} ${command}`, result);
+  return {
+    payload: result.payload,
+    revision: nextRevisionFrom(result.payload, revision),
+  };
+}

--- a/scripts/lib/production-smoke.mjs
+++ b/scripts/lib/production-smoke.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 
 export const DEFAULT_PRODUCTION_ORIGIN = 'https://ks2.eugnel.uk';
+export const DEFAULT_SMOKE_TIMEOUT_MS = 15_000;
 
 export function argValue(...names) {
   for (const name of names) {
@@ -42,8 +43,32 @@ async function readJsonResponse(response) {
   }
 }
 
+function configuredTimeoutMs() {
+  const value = Number(argValue('--timeout-ms') || process.env.KS2_SMOKE_TIMEOUT_MS || DEFAULT_SMOKE_TIMEOUT_MS);
+  return Number.isFinite(value) && value > 0 ? value : DEFAULT_SMOKE_TIMEOUT_MS;
+}
+
+function timeoutSignal(timeoutMs) {
+  if (typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function') {
+    return AbortSignal.timeout(timeoutMs);
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  timer.unref?.();
+  return controller.signal;
+}
+
 async function fetchJson(url, init = {}) {
-  const response = await fetch(url, init);
+  const timeoutMs = configuredTimeoutMs();
+  let response;
+  try {
+    response = await fetch(url, {
+      ...init,
+      signal: init.signal || timeoutSignal(timeoutMs),
+    });
+  } catch (error) {
+    throw new Error(`Request to ${url} failed or timed out after ${timeoutMs}ms: ${error?.message || error}`);
+  }
   const payload = await readJsonResponse(response);
   return { response, payload };
 }

--- a/scripts/punctuation-production-smoke.mjs
+++ b/scripts/punctuation-production-smoke.mjs
@@ -131,7 +131,7 @@ async function smokeSpelling({ origin, cookie, learnerId, revision }) {
 async function main() {
   const origin = configuredOrigin();
   const demo = await createDemoSession(origin);
-  const bootstrap = await loadBootstrap(origin, demo.cookie);
+  const bootstrap = await loadBootstrap(origin, demo.cookie, { expectedSession: demo.session });
   assert.equal(
     bootstrap.payload?.subjectExposureGates?.punctuationProduction,
     true,

--- a/scripts/punctuation-production-smoke.mjs
+++ b/scripts/punctuation-production-smoke.mjs
@@ -4,8 +4,14 @@ import assert from 'node:assert/strict';
 
 import { createPunctuationContentIndexes } from '../shared/punctuation/content.js';
 import { createPunctuationRuntimeManifest } from '../shared/punctuation/generators.js';
+import {
+  assertNoForbiddenObjectKeys,
+  configuredOrigin,
+  createDemoSession,
+  loadBootstrap,
+  subjectCommand,
+} from './lib/production-smoke.mjs';
 
-const DEFAULT_ORIGIN = 'https://ks2.eugnel.uk';
 const FORBIDDEN_READ_MODEL_KEYS = new Set([
   'accepted',
   'answers',
@@ -18,148 +24,8 @@ const FORBIDDEN_READ_MODEL_KEYS = new Set([
   'unpublished',
 ]);
 
-function argValue(...names) {
-  for (const name of names) {
-    const index = process.argv.indexOf(name);
-    if (index !== -1 && index + 1 < process.argv.length) return process.argv[index + 1];
-  }
-  return '';
-}
-
-function configuredOrigin() {
-  const raw = argValue('--origin', '--url') || process.env.KS2_SMOKE_ORIGIN || DEFAULT_ORIGIN;
-  const value = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
-  return new URL(value).origin;
-}
-
-function getSetCookies(response) {
-  const values = response.headers.getSetCookie?.();
-  if (Array.isArray(values) && values.length) return values;
-  return String(response.headers.get('set-cookie') || '')
-    .split(/,\s*(?=ks2_)/)
-    .filter(Boolean);
-}
-
-function sessionCookieFrom(response) {
-  return getSetCookies(response)
-    .map((cookie) => String(cookie || '').split(';')[0])
-    .find((cookie) => cookie.startsWith('ks2_session=')) || '';
-}
-
-async function readJsonResponse(response) {
-  const text = await response.text().catch(() => '');
-  try {
-    return text ? JSON.parse(text) : {};
-  } catch {
-    return { rawBody: text };
-  }
-}
-
-async function fetchJson(url, init = {}) {
-  const response = await fetch(url, init);
-  const payload = await readJsonResponse(response);
-  return { response, payload };
-}
-
-function sameOriginHeaders(origin, cookie = '') {
-  return {
-    accept: 'application/json',
-    'content-type': 'application/json',
-    origin,
-    ...(cookie ? { cookie } : {}),
-  };
-}
-
-async function postJson(origin, path, body = {}, { cookie = '' } = {}) {
-  return fetchJson(new URL(path, origin), {
-    method: 'POST',
-    headers: sameOriginHeaders(origin, cookie),
-    body: JSON.stringify(body),
-  });
-}
-
-async function getJson(origin, path, { cookie = '' } = {}) {
-  return fetchJson(new URL(path, origin), {
-    method: 'GET',
-    headers: {
-      accept: 'application/json',
-      ...(cookie ? { cookie } : {}),
-    },
-  });
-}
-
-function assertOkResponse(label, result) {
-  assert.ok(result.response.ok, `${label} failed with ${result.response.status}: ${JSON.stringify(result.payload)}`);
-  assert.notEqual(result.payload?.ok, false, `${label} returned ok=false: ${JSON.stringify(result.payload)}`);
-}
-
 function assertNoForbiddenReadModelKeys(value, path = 'subjectReadModel') {
-  if (value == null || typeof value !== 'object') return;
-  if (Array.isArray(value)) {
-    value.forEach((entry, index) => assertNoForbiddenReadModelKeys(entry, `${path}[${index}]`));
-    return;
-  }
-  for (const [key, child] of Object.entries(value)) {
-    assert.equal(FORBIDDEN_READ_MODEL_KEYS.has(key), false, `${path}.${key} exposed a server-only read-model field.`);
-    assertNoForbiddenReadModelKeys(child, `${path}.${key}`);
-  }
-}
-
-function nextRevisionFrom(commandPayload, previousRevision) {
-  const applied = Number(commandPayload?.mutation?.appliedRevision);
-  return Number.isFinite(applied) ? applied : previousRevision;
-}
-
-function createRequestId(prefix) {
-  createRequestId.sequence = (createRequestId.sequence || 0) + 1;
-  return `${prefix}-${Date.now()}-${createRequestId.sequence}`;
-}
-
-async function createDemoSession(origin) {
-  const result = await postJson(origin, '/api/demo/session');
-  assertOkResponse('Demo session creation', result);
-  const cookie = sessionCookieFrom(result.response);
-  assert.ok(cookie, 'Demo session did not return a ks2_session cookie.');
-  assert.equal(result.payload?.session?.demo, true, 'Demo session payload was not marked as demo.');
-  return { cookie, session: result.payload.session };
-}
-
-async function loadBootstrap(origin, cookie) {
-  const result = await getJson(origin, '/api/bootstrap', { cookie });
-  assertOkResponse('Bootstrap', result);
-  const learnerId = result.payload?.learners?.selectedId;
-  assert.ok(learnerId, 'Bootstrap did not include a selected learner.');
-  return {
-    payload: result.payload,
-    learnerId,
-    revision: Number(result.payload?.learners?.byId?.[learnerId]?.stateRevision) || 0,
-  };
-}
-
-async function subjectCommand({
-  origin,
-  cookie,
-  subjectId,
-  learnerId,
-  revision,
-  command,
-  payload = {},
-}) {
-  const requestId = createRequestId(`${subjectId}-${command}`);
-  const result = await postJson(origin, `/api/subjects/${encodeURIComponent(subjectId)}/command`, {
-    subjectId,
-    learnerId,
-    command,
-    requestId,
-    correlationId: requestId,
-    expectedLearnerRevision: revision,
-    payload,
-  }, { cookie });
-  assertOkResponse(`${subjectId} ${command}`, result);
-  return {
-    payload: result.payload,
-    revision: nextRevisionFrom(result.payload, revision),
-  };
+  assertNoForbiddenObjectKeys(value, FORBIDDEN_READ_MODEL_KEYS, path);
 }
 
 function punctuationAnswerFor(readItem) {

--- a/tests/grammar-production-smoke.test.js
+++ b/tests/grammar-production-smoke.test.js
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  createGrammarQuestion,
+  evaluateGrammarQuestion,
+} from '../worker/src/subjects/grammar/content.js';
+import {
+  assertNoForbiddenGrammarReadModelKeys,
+  correctResponseFor,
+} from '../scripts/grammar-production-smoke.mjs';
+
+function smokeQuestion() {
+  const question = createGrammarQuestion({
+    templateId: 'fronted_adverbial_choose',
+    seed: 1,
+  });
+  assert.ok(question, 'Fixture question should exist.');
+  return question;
+}
+
+function readItemFromQuestion(question) {
+  return {
+    templateId: question.templateId,
+    seed: question.seed,
+    inputSpec: question.inputSpec,
+  };
+}
+
+test('Grammar production smoke answers from the production-visible option set', () => {
+  const question = smokeQuestion();
+  const readItem = readItemFromQuestion(question);
+  const response = correctResponseFor(readItem);
+
+  assert.ok(
+    readItem.inputSpec.options.some((option) => option.value === response.answer),
+    'Smoke response should use a value present in the read-model options.',
+  );
+  assert.equal(evaluateGrammarQuestion(question, response)?.correct, true);
+});
+
+test('Grammar production smoke rejects option sets that do not match the regenerated item', () => {
+  const question = smokeQuestion();
+  const correctOption = question.inputSpec.options.find((option) => (
+    evaluateGrammarQuestion(question, { answer: option.value })?.correct
+  ));
+  assert.ok(correctOption, 'Fixture question should have a correct option.');
+
+  const readItem = readItemFromQuestion(question);
+  readItem.inputSpec = {
+    ...readItem.inputSpec,
+    options: readItem.inputSpec.options.map((option) => (
+      option.value === correctOption.value
+        ? { value: 'hidden-local-answer', label: 'Hidden local answer' }
+        : option
+    )),
+  };
+
+  assert.throws(
+    () => correctResponseFor(readItem),
+    /Grammar production option set did not match the regenerated question/,
+  );
+});
+
+test('Grammar production smoke scans feedback and summary models for forbidden keys', () => {
+  assert.doesNotThrow(() => assertNoForbiddenGrammarReadModelKeys({
+    stats: { templates: { total: 44, selectedResponse: 20 } },
+    session: {
+      currentItem: {
+        templateId: 'fronted_adverbial_choose',
+        inputSpec: { type: 'single_choice', options: [{ value: 'A', label: 'A' }] },
+      },
+    },
+  }, 'grammar.startModel'));
+
+  assert.throws(
+    () => assertNoForbiddenGrammarReadModelKeys({
+      feedback: { result: { correctResponses: ['A'] } },
+    }, 'grammar.feedbackModel'),
+    /grammar\.feedbackModel\.feedback\.result\.correctResponses exposed a server-only field/,
+  );
+
+  assert.throws(
+    () => assertNoForbiddenGrammarReadModelKeys({
+      session: { currentItem: { templates: [{ id: 'fronted_adverbial_choose' }] } },
+    }, 'grammar.summaryModel'),
+    /grammar\.summaryModel\.session\.currentItem\.templates exposed a server-only field/,
+  );
+});

--- a/tests/grammar-production-smoke.test.js
+++ b/tests/grammar-production-smoke.test.js
@@ -62,6 +62,22 @@ test('Grammar production smoke rejects option sets that do not match the regener
   );
 });
 
+test('Grammar production smoke rejects extra production option fields', () => {
+  const question = smokeQuestion();
+  const readItem = readItemFromQuestion(question);
+  readItem.inputSpec = {
+    ...readItem.inputSpec,
+    options: readItem.inputSpec.options.map((option, index) => (
+      index === 0 ? { ...option, correct: true } : option
+    )),
+  };
+
+  assert.throws(
+    () => correctResponseFor(readItem),
+    /Grammar production read model exposed option 1 with unexpected fields: correct, label, value/,
+  );
+});
+
 test('Grammar production smoke scans feedback and summary models for forbidden keys', () => {
   assert.doesNotThrow(() => assertNoForbiddenGrammarReadModelKeys({
     stats: { templates: { total: 44, selectedResponse: 20 } },

--- a/tests/production-smoke-helpers.test.js
+++ b/tests/production-smoke-helpers.test.js
@@ -1,0 +1,201 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  assertNoForbiddenObjectKeys,
+  configuredOrigin,
+  createDemoSession,
+  loadBootstrap,
+  subjectCommand,
+} from '../scripts/lib/production-smoke.mjs';
+
+function jsonResponse(payload, init = {}) {
+  const status = Number(init.status) || 200;
+  const headers = Object.fromEntries(
+    Object.entries({
+      'content-type': 'application/json',
+      ...(init.headers || {}),
+    }).map(([key, value]) => [key.toLowerCase(), value]),
+  );
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get(name) {
+        return headers[String(name).toLowerCase()] || null;
+      },
+      ...(init.withoutGetSetCookie ? {} : {
+        getSetCookie() {
+          const value = headers['set-cookie'];
+          if (Array.isArray(value)) return value;
+          return value ? [value] : [];
+        },
+      }),
+    },
+    async text() {
+      return JSON.stringify(payload);
+    },
+  };
+}
+
+test('production smoke origin config accepts env and CLI overrides', () => {
+  const previousArgv = process.argv;
+  const previousOrigin = process.env.KS2_SMOKE_ORIGIN;
+
+  try {
+    process.argv = ['node', 'smoke'];
+    process.env.KS2_SMOKE_ORIGIN = 'preview.example.test/path';
+    assert.equal(configuredOrigin(), 'https://preview.example.test');
+
+    process.argv = ['node', 'smoke', '--origin', 'http://localhost:8787/demo'];
+    assert.equal(configuredOrigin(), 'http://localhost:8787');
+  } finally {
+    process.argv = previousArgv;
+    if (previousOrigin === undefined) {
+      delete process.env.KS2_SMOKE_ORIGIN;
+    } else {
+      process.env.KS2_SMOKE_ORIGIN = previousOrigin;
+    }
+  }
+});
+
+test('production smoke helpers create demo, bootstrap, and send subject command envelope', async () => {
+  const previousFetch = globalThis.fetch;
+  const calls = [];
+
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url: String(url), init });
+    if (calls.length === 1) {
+      return jsonResponse({
+        ok: true,
+        session: { demo: true, accountId: 'account-a' },
+      }, {
+        status: 201,
+        headers: {
+          'set-cookie': [
+            'theme=dark; Path=/',
+            'ks2_session=demo123; Path=/; HttpOnly',
+          ],
+        },
+      });
+    }
+    if (calls.length === 2) {
+      return jsonResponse({
+        ok: true,
+        learners: {
+          selectedId: 'learner-a',
+          byId: {
+            'learner-a': { stateRevision: 7 },
+          },
+        },
+      });
+    }
+    return jsonResponse({
+      ok: true,
+      mutation: { appliedRevision: 8 },
+      subjectReadModel: { phase: 'session' },
+    });
+  };
+
+  try {
+    const origin = 'https://preview.example.test';
+    const demo = await createDemoSession(origin);
+    assert.equal(demo.cookie, 'ks2_session=demo123');
+    assert.deepEqual(demo.session, { demo: true, accountId: 'account-a' });
+
+    const bootstrap = await loadBootstrap(origin, demo.cookie);
+    assert.equal(bootstrap.learnerId, 'learner-a');
+    assert.equal(bootstrap.revision, 7);
+
+    const step = await subjectCommand({
+      origin,
+      cookie: demo.cookie,
+      subjectId: 'grammar',
+      learnerId: bootstrap.learnerId,
+      revision: bootstrap.revision,
+      command: 'start-session',
+      payload: { mode: 'smart' },
+    });
+
+    assert.equal(step.revision, 8);
+    assert.equal(step.payload.subjectReadModel.phase, 'session');
+    assert.equal(calls[0].url, 'https://preview.example.test/api/demo/session');
+    assert.equal(calls[0].init.method, 'POST');
+    assert.equal(calls[0].init.headers.origin, origin);
+    assert.equal(calls[0].init.signal instanceof AbortSignal, true);
+    assert.equal(calls[1].url, 'https://preview.example.test/api/bootstrap');
+    assert.equal(calls[1].init.headers.cookie, demo.cookie);
+
+    const commandBody = JSON.parse(calls[2].init.body);
+    assert.equal(calls[2].url, 'https://preview.example.test/api/subjects/grammar/command');
+    assert.equal(calls[2].init.headers.cookie, demo.cookie);
+    assert.equal(commandBody.subjectId, 'grammar');
+    assert.equal(commandBody.learnerId, 'learner-a');
+    assert.equal(commandBody.command, 'start-session');
+    assert.equal(commandBody.expectedLearnerRevision, 7);
+    assert.deepEqual(commandBody.payload, { mode: 'smart' });
+    assert.match(commandBody.requestId, /^grammar-start-session-\d+-\d+$/);
+    assert.equal(commandBody.correlationId, commandBody.requestId);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('production smoke demo session parses combined set-cookie fallback', async () => {
+  const previousFetch = globalThis.fetch;
+
+  globalThis.fetch = async () => jsonResponse({
+    ok: true,
+    session: { demo: true, accountId: 'account-a' },
+  }, {
+    status: 201,
+    withoutGetSetCookie: true,
+    headers: {
+      'set-cookie': 'theme=dark; Path=/, ks2_session=demo123; Path=/; HttpOnly',
+    },
+  });
+
+  try {
+    const demo = await createDemoSession('https://preview.example.test');
+    assert.equal(demo.cookie, 'ks2_session=demo123');
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('production smoke helper reports fetch failures with timeout context', async () => {
+  const previousArgv = process.argv;
+  const previousFetch = globalThis.fetch;
+  const previousTimeout = process.env.KS2_SMOKE_TIMEOUT_MS;
+
+  process.argv = ['node', 'smoke'];
+  process.env.KS2_SMOKE_TIMEOUT_MS = '25';
+  globalThis.fetch = async () => {
+    throw new Error('network stuck');
+  };
+
+  try {
+    await assert.rejects(
+      () => createDemoSession('https://preview.example.test'),
+      /Request to https:\/\/preview\.example\.test\/api\/demo\/session failed or timed out after 25ms: network stuck/,
+    );
+  } finally {
+    process.argv = previousArgv;
+    globalThis.fetch = previousFetch;
+    if (previousTimeout === undefined) {
+      delete process.env.KS2_SMOKE_TIMEOUT_MS;
+    } else {
+      process.env.KS2_SMOKE_TIMEOUT_MS = previousTimeout;
+    }
+  }
+});
+
+test('production smoke forbidden-key assertion scans nested arrays and objects', () => {
+  assert.doesNotThrow(() => {
+    assertNoForbiddenObjectKeys({ item: [{ prompt: { text: 'Safe' } }] }, new Set(['answer']));
+  });
+
+  assert.throws(() => {
+    assertNoForbiddenObjectKeys({ item: [{ prompt: { answer: 'leaked' } }] }, new Set(['answer']));
+  }, /readModel\.item\[0\]\.prompt\.answer exposed a server-only field/);
+});

--- a/tests/production-smoke-helpers.test.js
+++ b/tests/production-smoke-helpers.test.js
@@ -68,7 +68,7 @@ test('production smoke helpers create demo, bootstrap, and send subject command 
     if (calls.length === 1) {
       return jsonResponse({
         ok: true,
-        session: { demo: true, accountId: 'account-a' },
+        session: { demo: true, accountId: 'account-a', learnerId: 'learner-a' },
       }, {
         status: 201,
         headers: {
@@ -82,6 +82,7 @@ test('production smoke helpers create demo, bootstrap, and send subject command 
     if (calls.length === 2) {
       return jsonResponse({
         ok: true,
+        session: { demo: true, accountId: 'account-a' },
         learners: {
           selectedId: 'learner-a',
           byId: {
@@ -101,9 +102,9 @@ test('production smoke helpers create demo, bootstrap, and send subject command 
     const origin = 'https://preview.example.test';
     const demo = await createDemoSession(origin);
     assert.equal(demo.cookie, 'ks2_session=demo123');
-    assert.deepEqual(demo.session, { demo: true, accountId: 'account-a' });
+    assert.deepEqual(demo.session, { demo: true, accountId: 'account-a', learnerId: 'learner-a' });
 
-    const bootstrap = await loadBootstrap(origin, demo.cookie);
+    const bootstrap = await loadBootstrap(origin, demo.cookie, { expectedSession: demo.session });
     assert.equal(bootstrap.learnerId, 'learner-a');
     assert.equal(bootstrap.revision, 7);
 


### PR DESCRIPTION
## Summary
- add a reusable Grammar production smoke script for the Worker command path
- extract shared production-smoke helpers and refactor the Punctuation smoke to use them
- harden Grammar smoke answer derivation so it only submits production-visible options and asserts the option set matches the regenerated template
- fail the smoke when demo bootstrap resolves to a different account or learner than the created demo session
- fail the Grammar smoke when production-visible options expose unexpected answer-bearing fields
- scan Grammar start, feedback, and summary read models for server-only fields
- document the Grammar post-deploy smoke in the full-lockdown runbook

## Verification
- `node --test tests/grammar-production-smoke.test.js tests/production-smoke-helpers.test.js` (9 pass)
- `npm run smoke:production:grammar` on `https://ks2.eugnel.uk`
- `npm run smoke:production:punctuation` on `https://ks2.eugnel.uk`
- `npm test` (541 pass / 1 skipped)
- `npm run check`
- `git diff --check`
- GitHub checks: GitGuardian Security Checks pass; Workers Builds: ks2-mastery pass