### PR TITLE
fix(spelling): add server replay for missed celebrations

### DIFF
--- a/tests/worker-projections.test.js
+++ b/tests/worker-projections.test.js
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { createWorkerApp } from '../worker/src/app.js';
+import { MONSTER_CELEBRATION_REPLAY_REQUEST_TYPE } from '../worker/src/projections/monster-replays.js';
 import { createMigratedSqliteD1Database } from './helpers/sqlite-d1.js';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -79,6 +80,33 @@ function createCommandHarness() {
   };
 }
 
+function insertEvent(DB, event) {
+  DB.db.prepare(`
+    INSERT INTO event_log (id, learner_id, subject_id, system_id, event_type, event_json, created_at, actor_account_id)
+    VALUES (?, ?, ?, ?, ?, ?, ?, 'adult-a')
+  `).run(
+    event.id,
+    event.learnerId,
+    event.subjectId || null,
+    event.systemId || null,
+    event.type,
+    JSON.stringify(event),
+    event.createdAt,
+  );
+}
+
+function insertProjectionWindowFillerEvents(DB, { learnerId = 'learner-a', count = 1005, startAt }) {
+  for (let index = 0; index < count; index += 1) {
+    insertEvent(DB, {
+      id: `spelling.projection-window-filler:${index}`,
+      type: 'spelling.session-completed',
+      learnerId,
+      subjectId: 'spelling',
+      createdAt: startAt + index,
+    });
+  }
+}
+
 async function completePossessRound(harness) {
   let latest = await harness.command('start-session', {
     mode: 'single',
@@ -146,6 +174,82 @@ test('spelling command projection applies monster rewards and returns celebratio
       WHERE learner_id = 'learner-a' AND event_type = 'reward.monster'
     `).get().count;
     assert.equal(rewardCountAfterReplay, rewardCount);
+  } finally {
+    harness.close();
+  }
+});
+
+test('spelling command projection emits requested monster celebration replays on session completion once', async () => {
+  const harness = createCommandHarness();
+  const replayRequestId = 'ops.monster-celebration-replay-request:learner-a:test';
+  const replaySourceEvents = [
+    {
+      id: 'reward.monster:learner-a:inklet:evolve:3:6',
+      type: 'reward.monster',
+      kind: 'evolve',
+      learnerId: 'learner-a',
+      subjectId: 'spelling',
+      systemId: 'monster-codex',
+      monsterId: 'inklet',
+      monster: { id: 'inklet', name: 'Inklet', accent: '#3E6FA8' },
+      previous: { mastered: 59, stage: 2, level: 5, caught: true, branch: 'b1' },
+      next: { mastered: 60, stage: 3, level: 6, caught: true, branch: 'b1' },
+      createdAt: Date.UTC(2026, 3, 24, 16, 35, 9),
+    },
+    {
+      id: 'reward.monster:learner-a:glimmerbug:evolve:1:1',
+      type: 'reward.monster',
+      kind: 'evolve',
+      learnerId: 'learner-a',
+      subjectId: 'spelling',
+      systemId: 'monster-codex',
+      monsterId: 'glimmerbug',
+      monster: { id: 'glimmerbug', name: 'Glimmerbug', accent: '#B43CD9' },
+      previous: { mastered: 9, stage: 0, level: 0, caught: true, branch: 'b1' },
+      next: { mastered: 10, stage: 1, level: 1, caught: true, branch: 'b1' },
+      createdAt: Date.UTC(2026, 3, 24, 17, 8, 9),
+    },
+  ];
+
+  try {
+    replaySourceEvents.forEach((event) => insertEvent(harness.DB, event));
+    insertProjectionWindowFillerEvents(harness.DB, {
+      startAt: Date.UTC(2026, 3, 24, 17, 30, 0),
+    });
+    insertEvent(harness.DB, {
+      id: replayRequestId,
+      type: MONSTER_CELEBRATION_REPLAY_REQUEST_TYPE,
+      learnerId: 'learner-a',
+      subjectId: 'spelling',
+      eventIds: replaySourceEvents.map((event) => event.id),
+      reason: 'manual-production-replay-test',
+      createdAt: Date.UTC(2026, 3, 24, 18, 0, 0),
+    });
+
+    const firstCompletion = await completePossessRound(harness);
+    const firstReplayEvents = firstCompletion.latest.body.projections.rewards.events
+      .filter((event) => event.replayRequestId === replayRequestId);
+
+    assert.deepEqual(firstReplayEvents.map((event) => event.replayOf), replaySourceEvents.map((event) => event.id));
+    assert.deepEqual(firstReplayEvents.map((event) => event.monsterId), ['inklet', 'glimmerbug']);
+    assert.ok(firstReplayEvents.every((event) => event.type === 'reward.monster' && event.kind === 'evolve'));
+
+    const replayRows = harness.DB.db.prepare(`
+      SELECT id
+      FROM event_log
+      WHERE learner_id = 'learner-a'
+        AND event_type = 'reward.monster'
+        AND id LIKE 'reward.monster.replay:%'
+      ORDER BY created_at ASC, id ASC
+    `).all();
+    assert.deepEqual(replayRows.map((row) => row.id), firstReplayEvents.map((event) => event.id));
+
+    const secondCompletion = await completePossessRound(harness);
+    assert.equal(
+      secondCompletion.latest.body.projections.rewards.events
+        .some((event) => event.replayRequestId === replayRequestId),
+      false,
+    );
   } finally {
     harness.close();
   }

--- a/worker/src/projections/monster-replays.js
+++ b/worker/src/projections/monster-replays.js
@@ -1,0 +1,87 @@
+import { normaliseMonsterCelebrationEvents } from '../../../src/platform/game/monster-celebrations.js';
+
+export const MONSTER_CELEBRATION_REPLAY_REQUEST_TYPE = 'ops.monster-celebration-replay-request';
+
+function eventId(event) {
+  return typeof event?.id === 'string' && event.id ? event.id : '';
+}
+
+function eventCreatedAt(event) {
+  return Number.isFinite(Number(event?.createdAt)) ? Number(event.createdAt) : 0;
+}
+
+function replayId(requestId, sourceId) {
+  return `reward.monster.replay:${requestId}:${sourceId}`;
+}
+
+function replayRequestEventIds(request) {
+  if (Array.isArray(request?.eventIds)) {
+    return request.eventIds.filter((id) => typeof id === 'string' && id);
+  }
+  return typeof request?.eventId === 'string' && request.eventId ? [request.eventId] : [];
+}
+
+function replayRequests(events, { learnerId = '', subjectId = 'spelling' } = {}) {
+  return (Array.isArray(events) ? events : [])
+    .filter((event) => event?.type === MONSTER_CELEBRATION_REPLAY_REQUEST_TYPE)
+    .filter((event) => !learnerId || event.learnerId === learnerId)
+    .filter((event) => !event.subjectId || event.subjectId === subjectId)
+    .sort((a, b) => eventCreatedAt(a) - eventCreatedAt(b));
+}
+
+export function monsterCelebrationReplayReferenceIds(events, options = {}) {
+  const sourceIds = new Set();
+  const replayIds = new Set();
+  for (const request of replayRequests(events, options)) {
+    const requestId = eventId(request);
+    if (!requestId) continue;
+    for (const sourceId of replayRequestEventIds(request)) {
+      sourceIds.add(sourceId);
+      replayIds.add(replayId(requestId, sourceId));
+    }
+  }
+  return {
+    sourceIds: [...sourceIds],
+    replayIds: [...replayIds],
+  };
+}
+
+export function monsterCelebrationReplayEvents(events, {
+  learnerId = '',
+  subjectId = 'spelling',
+  now = Date.now(),
+} = {}) {
+  const list = Array.isArray(events) ? events : [];
+  const sourceById = new Map();
+  const seenIds = new Set();
+  for (const event of list) {
+    const id = eventId(event);
+    if (!id) continue;
+    sourceById.set(id, event);
+    seenIds.add(id);
+  }
+
+  const output = [];
+  for (const request of replayRequests(list, { learnerId, subjectId })) {
+    const requestId = eventId(request);
+    if (!requestId) continue;
+    for (const sourceId of replayRequestEventIds(request)) {
+      const source = sourceById.get(sourceId);
+      const replayEventId = replayId(requestId, sourceId);
+      if (!source || seenIds.has(replayEventId)) continue;
+      const [event] = normaliseMonsterCelebrationEvents(source);
+      if (!event) continue;
+      output.push({
+        ...event,
+        id: replayEventId,
+        learnerId: learnerId || event.learnerId,
+        subjectId,
+        replayOf: sourceId,
+        replayRequestId: requestId,
+        createdAt: Math.max(0, Number(now) || Date.now()) + output.length,
+      });
+      seenIds.add(replayEventId);
+    }
+  }
+  return output;
+}

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -1459,6 +1459,37 @@ async function readLearnerProjectionBundle(db, accountId, learnerId) {
   };
 }
 
+function uniqueStringList(value) {
+  return [...new Set((Array.isArray(value) ? value : [])
+    .filter((entry) => typeof entry === 'string' && entry))];
+}
+
+async function readLearnerEventLogEvents(db, accountId, learnerId, { ids = [], eventTypes = [] } = {}) {
+  await requireLearnerWriteAccess(db, accountId, learnerId);
+  const safeIds = uniqueStringList(ids);
+  const safeEventTypes = uniqueStringList(eventTypes);
+  if (!safeIds.length && !safeEventTypes.length) return [];
+
+  const clauses = ['learner_id = ?'];
+  const params = [learnerId];
+  if (safeIds.length) {
+    clauses.push(`id IN (${sqlPlaceholders(safeIds.length)})`);
+    params.push(...safeIds);
+  }
+  if (safeEventTypes.length) {
+    clauses.push(`event_type IN (${sqlPlaceholders(safeEventTypes.length)})`);
+    params.push(...safeEventTypes);
+  }
+
+  const rows = await all(db, `
+    SELECT id, learner_id, subject_id, system_id, event_type, event_json, created_at
+    FROM event_log
+    WHERE ${clauses.join(' AND ')}
+    ORDER BY created_at ASC, id ASC
+  `, params);
+  return rows.map(eventRowToRecord).filter(Boolean);
+}
+
 function guardedValueSource(valueCount, guard) {
   const placeholders = sqlPlaceholders(valueCount);
   if (!guard) return `VALUES (${placeholders})`;
@@ -2109,6 +2140,9 @@ export function createWorkerRepository({ env = {}, now = Date.now } = {}) {
     },
     async readLearnerProjectionState(accountId, learnerId) {
       return readLearnerProjectionBundle(db, accountId, learnerId);
+    },
+    async readLearnerEventLogEvents(accountId, learnerId, filters = {}) {
+      return readLearnerEventLogEvents(db, accountId, learnerId, filters);
     },
     async persistSubjectRuntime(accountId, learnerId, subjectId = 'spelling', runtime = {}) {
       return persistSubjectRuntimeBundle(db, accountId, learnerId, subjectId, runtime, nowFactory());

--- a/worker/src/subjects/spelling/commands.js
+++ b/worker/src/subjects/spelling/commands.js
@@ -2,6 +2,11 @@ import { SEEDED_SPELLING_CONTENT_BUNDLE } from '../../../../src/subjects/spellin
 import { resolveRuntimeSnapshot } from '../../../../src/subjects/spelling/content/model.js';
 import { NotFoundError } from '../../errors.js';
 import { combineCommandEvents } from '../../projections/events.js';
+import {
+  MONSTER_CELEBRATION_REPLAY_REQUEST_TYPE,
+  monsterCelebrationReplayEvents,
+  monsterCelebrationReplayReferenceIds,
+} from '../../projections/monster-replays.js';
 import { buildCommandProjectionReadModel } from '../../projections/read-models.js';
 import { projectSpellingRewards } from '../../projections/rewards.js';
 import { buildSpellingAudioCue } from './audio.js';
@@ -42,6 +47,26 @@ function clientAnalytics(analytics) {
       source: 'server-read-model-api',
     },
   };
+}
+
+async function replayContextEvents(context, learnerId) {
+  const replayRequests = await context.repository.readLearnerEventLogEvents(
+    context.session.accountId,
+    learnerId,
+    { eventTypes: [MONSTER_CELEBRATION_REPLAY_REQUEST_TYPE] },
+  );
+  const { sourceIds, replayIds } = monsterCelebrationReplayReferenceIds(replayRequests, {
+    learnerId,
+    subjectId: 'spelling',
+  });
+  const referenceIds = [...new Set([...sourceIds, ...replayIds])];
+  if (!referenceIds.length) return replayRequests;
+  const referenceEvents = await context.repository.readLearnerEventLogEvents(
+    context.session.accountId,
+    learnerId,
+    { ids: referenceIds },
+  );
+  return [...replayRequests, ...referenceEvents];
 }
 
 async function readRuntimeContent(context) {
@@ -125,9 +150,21 @@ export function createSpellingCommandHandlers({ now, random } = {}) {
       domainEvents: result.events,
       gameState: projectionState.gameState,
     });
+    let replayEvents = [];
+    if (result.state?.phase === 'summary') {
+      const replayContext = await replayContextEvents(context, command.learnerId);
+      replayEvents = monsterCelebrationReplayEvents([
+        ...projectionState.events,
+        ...replayContext,
+      ], {
+        learnerId: command.learnerId,
+        subjectId: 'spelling',
+        now: nowValue,
+      });
+    }
     const projectedEvents = combineCommandEvents({
       domainEvents: result.events,
-      reactionEvents: projectedRewards.rewardEvents,
+      reactionEvents: [...projectedRewards.rewardEvents, ...replayEvents],
       existingEvents: projectionState.events,
     });
     const replayAudioCue = await buildSpellingAudioCue({


### PR DESCRIPTION
## Summary
- Add a Worker-side manual monster celebration replay request that emits copied reward overlays only when a spelling session reaches summary.
- Persist replay-specific reward event ids so a manual request is consumed once and does not replay on later sessions.
- Cover the Nelson-shaped case with a regression test for two requested evolve overlays emitted together and skipped on the next completion.

## Verification
- `npm test -- tests/worker-projections.test.js`
- `npm test -- tests/worker-projections.test.js tests/spelling-remote-actions.test.js tests/store.test.js`
- `npm test`
- `npm run check`
