### PR TITLE
feat(grammar): enable sentence builder mode

### DIFF
--- a/src/subjects/grammar/components/GrammarSetupScene.jsx
+++ b/src/subjects/grammar/components/GrammarSetupScene.jsx
@@ -38,9 +38,10 @@ export function GrammarSetupScene({ learner, grammar, actions, runtimeReadOnly }
   const selectedMode = grammar.prefs?.mode || 'smart';
   const troubleMode = selectedMode === 'trouble';
   const surgeryMode = selectedMode === 'surgery';
-  const focusDisabled = troubleMode || surgeryMode;
+  const builderMode = selectedMode === 'builder';
+  const focusDisabled = troubleMode || surgeryMode || builderMode;
   const selectedFocus = focusDisabled ? '' : (grammar.prefs?.focusConceptId || '');
-  const focusPlaceholder = troubleMode ? 'Weakest concept' : (surgeryMode ? 'Surgery mix' : 'Smart mix');
+  const focusPlaceholder = troubleMode ? 'Weakest concept' : (surgeryMode ? 'Surgery mix' : (builderMode ? 'Builder mix' : 'Smart mix'));
   const groupedConcepts = groupedGrammarConcepts(grammar.analytics?.concepts || []);
   const setupDisabled = runtimeReadOnly || Boolean(grammar.pendingCommand);
 

--- a/src/subjects/grammar/metadata.js
+++ b/src/subjects/grammar/metadata.js
@@ -137,10 +137,10 @@ export const GRAMMAR_ENABLED_MODES = Object.freeze([
   { id: 'satsset', label: 'KS2-style mini-set', detail: 'A short mixed set with SATs-friendly question shapes.' },
   { id: 'trouble', label: 'Weak concepts drill', detail: 'Targets the weakest Grammar concepts with retry pressure.' },
   { id: 'surgery', label: 'Sentence surgery', detail: 'Fix and rewrite sentence-level Grammar errors.' },
+  { id: 'builder', label: 'Sentence builder', detail: 'Build and rewrite sentences from structured prompts.' },
 ]);
 
 export const GRAMMAR_LOCKED_MODES = Object.freeze([
-  { id: 'builder', label: 'Sentence builder', reason: 'coming-next' },
   { id: 'worked', label: 'Worked examples', reason: 'coming-next' },
   { id: 'faded', label: 'Faded guidance', reason: 'coming-next' },
 ]);

--- a/src/subjects/grammar/module.js
+++ b/src/subjects/grammar/module.js
@@ -16,12 +16,13 @@ function selectedGrammarUi(context) {
 
 function grammarModeKey(value) {
   const mode = String(value || '').trim().toLowerCase().replace(/[\s_]+/g, '-');
+  if (mode === 'sentence-builder') return 'builder';
   return mode === 'sentence-surgery' ? 'surgery' : mode;
 }
 
 function grammarModeUsesFocus(value) {
   const mode = grammarModeKey(value);
-  return mode !== 'trouble' && mode !== 'surgery';
+  return mode !== 'trouble' && mode !== 'surgery' && mode !== 'builder';
 }
 
 function updateGrammarUiForLearner(context, learnerId, updater) {

--- a/tests/grammar-engine.test.js
+++ b/tests/grammar-engine.test.js
@@ -457,6 +457,54 @@ test('Grammar sentence surgery clears stored focus and stays inside the surgery 
   assert.equal(template.tags.includes('surgery'), true);
 });
 
+test('Grammar sentence builder mode only picks builder templates and clears stored focus', () => {
+  const engine = createServerGrammarEngine({ now: () => 1_777_000_000_000 });
+  const start = engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: {
+      data: {
+        prefs: {
+          focusConceptId: 'word_classes',
+        },
+      },
+    },
+    command: 'start-session',
+    requestId: 'start-builder',
+    payload: {
+      mode: 'builder',
+      roundLength: 3,
+      seed: 42,
+    },
+  });
+  const template = GRAMMAR_TEMPLATE_METADATA.find((entry) => entry.id === start.state.session.currentItem.templateId);
+
+  assert.equal(start.state.phase, 'session');
+  assert.equal(start.state.session.mode, 'builder');
+  assert.equal(start.state.session.type, 'sentence-builder');
+  assert.equal(start.state.session.focusConceptId, '');
+  assert.equal(start.state.prefs.focusConceptId, '');
+  assert.equal(start.practiceSession.sessionKind, 'builder');
+  assert.equal(template.tags.includes('builder'), true);
+  assert.match(start.state.session.currentItem.questionType, /^(build|rewrite)$/);
+});
+
+test('Grammar sentence builder rejects explicit non-builder templates', () => {
+  const engine = createServerGrammarEngine({ now: () => 1_777_000_000_000 });
+
+  assert.throws(() => engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: {},
+    command: 'start-session',
+    requestId: 'start-builder-bypass',
+    payload: {
+      mode: 'builder',
+      roundLength: 3,
+      seed: 42,
+      templateId: 'sentence_type_table',
+    },
+  }), (error) => error?.extra?.code === 'grammar_template_unavailable_for_mode');
+});
+
 test('Grammar save-prefs clears completed summary state', () => {
   const oracle = readGrammarLegacyOracle();
   const sample = oracle.templates.find((template) => template.id === 'question_mark_select');

--- a/tests/react-grammar-surface.test.js
+++ b/tests/react-grammar-surface.test.js
@@ -347,6 +347,7 @@ test('Grammar normaliser upgrades stale persisted mode capabilities', () => {
       lockedModes: [
         { id: 'trouble', label: 'Weak concepts drill', reason: 'coming-next' },
         { id: 'surgery', label: 'Sentence surgery', reason: 'coming-next' },
+        { id: 'builder', label: 'Sentence builder', reason: 'coming-next' },
       ],
     },
   });
@@ -355,6 +356,8 @@ test('Grammar normaliser upgrades stale persisted mode capabilities', () => {
   assert.equal(grammar.capabilities.lockedModes.some((mode) => mode.id === 'trouble'), false);
   assert.equal(grammar.capabilities.enabledModes.some((mode) => mode.id === 'surgery'), true);
   assert.equal(grammar.capabilities.lockedModes.some((mode) => mode.id === 'surgery'), false);
+  assert.equal(grammar.capabilities.enabledModes.some((mode) => mode.id === 'builder'), true);
+  assert.equal(grammar.capabilities.lockedModes.some((mode) => mode.id === 'builder'), false);
 });
 
 test('Grammar locked future modes render unavailable without dispatching commands', () => {
@@ -368,7 +371,9 @@ test('Grammar locked future modes render unavailable without dispatching command
   assert.doesNotMatch(html, /<button class="grammar-mode locked" type="button" disabled="">[\s\S]*Weak concepts drill/);
   assert.match(html, /<button class="grammar-mode" type="button">[\s\S]*Sentence surgery/);
   assert.doesNotMatch(html, /<button class="grammar-mode locked" type="button" disabled="">[\s\S]*Sentence surgery/);
-  assert.match(html, /Sentence builder[\s\S]*Coming next/);
+  assert.match(html, /<button class="grammar-mode" type="button">[\s\S]*Sentence builder/);
+  assert.doesNotMatch(html, /<button class="grammar-mode locked" type="button" disabled="">[\s\S]*Sentence builder/);
+  assert.match(html, /Worked examples[\s\S]*Coming next/);
   assert.match(html, /button class="grammar-mode locked" type="button" disabled=""/);
 });
 
@@ -454,4 +459,35 @@ test('Grammar explicit template starts ignore stored focus through the client wr
   assert.equal(grammar.session.currentItem.templateId, sample.id);
   assert.equal(grammar.session.focusConceptId, '');
   assert.equal(grammar.prefs.focusConceptId, 'word_classes');
+});
+
+test('Grammar setup can start sentence builder mode', () => {
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-set-focus', { value: 'word_classes' });
+  assert.equal(harness.store.getState().subjectUi.grammar.prefs.focusConceptId, 'word_classes');
+
+  harness.dispatch('grammar-set-mode', { value: 'builder' });
+  assert.equal(harness.store.getState().subjectUi.grammar.prefs.mode, 'builder');
+  assert.equal(harness.store.getState().subjectUi.grammar.prefs.focusConceptId, '');
+  assert.match(harness.render(), /<select class="input" disabled=""><option value="" selected="">Builder mix<\/option>/);
+
+  harness.dispatch('grammar-set-focus', { value: 'word_classes' });
+  assert.equal(harness.store.getState().subjectUi.grammar.prefs.focusConceptId, '');
+
+  harness.dispatch('grammar-start', {
+    payload: {
+      roundLength: 1,
+      seed: 123,
+    },
+  });
+
+  const grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.phase, 'session');
+  assert.equal(grammar.session.mode, 'builder');
+  assert.equal(grammar.session.type, 'sentence-builder');
+  assert.equal(grammar.session.focusConceptId, '');
+  assert.match(grammar.session.currentItem.questionType, /^(build|rewrite)$/);
 });

--- a/tests/worker-grammar-subject-runtime.test.js
+++ b/tests/worker-grammar-subject-runtime.test.js
@@ -84,9 +84,11 @@ test('worker subject runtime registers Grammar command handlers', async () => {
     'satsset',
     'trouble',
     'surgery',
+    'builder',
   ]);
   assert.equal(result.subjectReadModel.capabilities.lockedModes.some((mode) => mode.id === 'trouble'), false);
   assert.equal(result.subjectReadModel.capabilities.lockedModes.some((mode) => mode.id === 'surgery'), false);
+  assert.equal(result.subjectReadModel.capabilities.lockedModes.some((mode) => mode.id === 'builder'), false);
 });
 
 test('worker subject runtime starts Grammar trouble drills against weak concepts', async () => {
@@ -312,6 +314,58 @@ test('Grammar command route starts explicit templates without inheriting stored 
   assert.equal(start.body.subjectReadModel.session.currentItem.templateId, sample.id);
   assert.equal(start.body.subjectReadModel.session.focusConceptId, '');
   assert.equal(start.body.subjectReadModel.prefs.focusConceptId, 'word_classes');
+
+  DB.close();
+});
+
+test('Grammar command route accepts sentence builder mode', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const app = createWorkerApp({ now: () => 1_777_000_000_000 });
+  seedAccountLearner(DB);
+
+  const start = await postCommand(app, DB, {
+    command: 'start-session',
+    learnerId: 'learner-a',
+    requestId: 'grammar-builder-route-start',
+    expectedLearnerRevision: 0,
+    payload: {
+      mode: 'builder',
+      roundLength: 2,
+      seed: 120,
+    },
+  });
+
+  assert.equal(start.response.status, 200, JSON.stringify(start.body));
+  assert.equal(start.body.subjectReadModel.phase, 'session');
+  assert.equal(start.body.subjectReadModel.session.mode, 'builder');
+  assert.equal(start.body.subjectReadModel.session.type, 'sentence-builder');
+  assert.equal(start.body.subjectReadModel.session.focusConceptId, '');
+  assert.match(start.body.subjectReadModel.session.currentItem.questionType, /^(build|rewrite)$/);
+  assert.equal(start.body.subjectReadModel.capabilities.lockedModes.some((mode) => mode.id === 'builder'), false);
+
+  DB.close();
+});
+
+test('Grammar command route rejects non-builder template overrides in builder mode', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const app = createWorkerApp({ now: () => 1_777_000_000_000 });
+  seedAccountLearner(DB);
+
+  const start = await postCommand(app, DB, {
+    command: 'start-session',
+    learnerId: 'learner-a',
+    requestId: 'grammar-builder-route-template-bypass',
+    expectedLearnerRevision: 0,
+    payload: {
+      mode: 'builder',
+      roundLength: 2,
+      seed: 120,
+      templateId: 'sentence_type_table',
+    },
+  });
+
+  assert.equal(start.response.status, 400, JSON.stringify(start.body));
+  assert.equal(start.body.code, 'grammar_template_unavailable_for_mode');
 
   DB.close();
 });

--- a/worker/src/subjects/grammar/engine.js
+++ b/worker/src/subjects/grammar/engine.js
@@ -20,8 +20,10 @@ const DEFAULT_MINI_SET_LENGTH = 8;
 const SHORT_RESPONSE_TEXT_LIMIT = 512;
 const LONG_RESPONSE_TEXT_LIMIT = 2000;
 const LIST_RESPONSE_LIMIT = 40;
-const ENABLED_MODES = new Set(['learn', 'smart', 'satsset', 'trouble', 'surgery']);
-const LOCKED_MODES = Object.freeze(['builder', 'worked', 'faded']);
+const ENABLED_MODES = new Set(['learn', 'smart', 'satsset', 'trouble', 'surgery', 'builder']);
+const LOCKED_MODES = Object.freeze(['worked', 'faded']);
+const NO_STORED_FOCUS_MODES = new Set(['trouble', 'surgery', 'builder']);
+const NO_SESSION_FOCUS_MODES = new Set(['surgery', 'builder']);
 const GRAMMAR_CONCEPT_IDS = new Set(GRAMMAR_CONCEPTS.map((concept) => concept.id));
 
 function isPlainObject(value) {
@@ -400,6 +402,7 @@ function templateFitsMode(template, mode) {
   if (!template) return false;
   if (mode === 'satsset' && !template.satsFriendly) return false;
   if (mode === 'surgery' && !(template.tags || []).includes('surgery')) return false;
+  if (mode === 'builder' && !(template.tags || []).includes('builder')) return false;
   return true;
 }
 
@@ -506,6 +509,7 @@ function normaliseMode(value) {
   const mode = String(value || 'smart').trim().toLowerCase().replace(/[\s_]+/g, '-');
   if (mode === 'mini-set' || mode === 'mini' || mode === 'test') return 'satsset';
   if (mode === 'sentence-surgery') return 'surgery';
+  if (mode === 'sentence-builder') return 'builder';
   return mode || 'smart';
 }
 
@@ -588,11 +592,11 @@ function startSession(state, payload, nowTs, learnerId) {
     ? payload.focusConceptId
     : (typeof payload.skillId === 'string' ? payload.skillId : '');
   const storedFocusConceptId = normaliseStoredFocusConceptId(state.prefs.focusConceptId);
-  const prefsFocusConceptId = mode === 'surgery'
+  const prefsFocusConceptId = NO_SESSION_FOCUS_MODES.has(mode)
     ? ''
     : (hasPayloadFocusConcept
       ? requestedFocusConceptId
-      : (mode === 'trouble' ? '' : storedFocusConceptId));
+      : (NO_STORED_FOCUS_MODES.has(mode) ? '' : storedFocusConceptId));
   const sessionRequestedFocusConceptId = templateId && !hasPayloadFocusConcept
     ? ''
     : prefsFocusConceptId;
@@ -639,7 +643,9 @@ function startSession(state, payload, nowTs, learnerId) {
     id: sessionId,
     type: mode === 'satsset'
       ? 'mini-set'
-      : (mode === 'trouble' ? 'trouble-drill' : (mode === 'surgery' ? 'sentence-surgery' : 'practice')),
+      : (mode === 'trouble'
+        ? 'trouble-drill'
+        : (mode === 'surgery' ? 'sentence-surgery' : (mode === 'builder' ? 'sentence-builder' : 'practice'))),
     mode,
     focusConceptId: sessionFocusConceptId,
     startedAt: nowTs,
@@ -901,7 +907,7 @@ function savePrefs(state, payload) {
   const prefs = isPlainObject(payload.prefs) ? payload.prefs : payload;
   const nextMode = prefs.mode ? normaliseMode(prefs.mode) : state.prefs.mode;
   const hasFocusConcept = Object.prototype.hasOwnProperty.call(prefs, 'focusConceptId');
-  const nextFocusConceptId = nextMode === 'trouble' || nextMode === 'surgery'
+  const nextFocusConceptId = NO_STORED_FOCUS_MODES.has(nextMode)
     ? ''
     : (hasFocusConcept
       ? normaliseStoredFocusConceptId(prefs.focusConceptId)

--- a/worker/src/subjects/grammar/read-models.js
+++ b/worker/src/subjects/grammar/read-models.js
@@ -254,7 +254,7 @@ function capabilityMetadata() {
     satsset: { label: 'KS2-style mini-set', detail: 'A short mixed set with SATs-friendly question shapes.' },
     trouble: { label: 'Weak concepts drill', detail: 'Targets the weakest Grammar concepts with retry pressure.' },
     surgery: { label: 'Sentence surgery', detail: 'Fix and rewrite sentence-level Grammar errors.' },
-    builder: { label: 'Sentence builder' },
+    builder: { label: 'Sentence builder', detail: 'Build and rewrite sentences from structured prompts.' },
     worked: { label: 'Worked examples' },
     faded: { label: 'Faded guidance' },
   };


### PR DESCRIPTION
## Summary
- Enable Grammar Sentence builder as a Worker-command-backed mode while keeping worked examples and faded guidance locked.
- Filter builder sessions to templates tagged for sentence building and clear stored focus so mixed builder rounds do not inherit unsupported concept state.
- Update client and Worker capability metadata with engine, route, and React regression coverage.

## Review update
- Engineering review completed against `origin/main` on 2026-04-24.
- No code fixes were required after review.
- Greptile had no active comments on the PR.
- Copilot review reported a reviewer error only, with no actionable code finding.

## Verification
- `node --test tests/grammar-engine.test.js tests/worker-grammar-subject-runtime.test.js tests/react-grammar-surface.test.js tests/hub-read-models.test.js tests/subject-expansion.test.js`
- `npm test`
- `npm run check`

## Latest local evidence
- Targeted Grammar/Worker/React suite: 91 passing tests.
- Full suite: 537 passing tests, 1 browser-smoke skip gated by `KS2_BROWSER_SMOKE`.
- Worker dry-run: build, public assertion, client bundle audit, and binding inspection passed.
- GitHub checks: GitGuardian Security Checks and Workers Builds both succeeded for `2fc1f4bb`.
