### PR TITLE
style(profile): align settings page with home/codex journal aesthetic

### DIFF
--- a/src/surfaces/profile/ProfileSettingsSurface.jsx
+++ b/src/surfaces/profile/ProfileSettingsSurface.jsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { TopNav } from '../shell/TopNav.jsx';
 import { PersistenceBanner } from '../shell/PersistenceBanner.jsx';
+import { randomHeroBackground } from '../home/data.js';
 import {
   BUFFERED_GEMINI_VOICE_OPTIONS,
   normaliseBufferedGeminiVoice,
@@ -15,17 +16,21 @@ const TTS_PROVIDER_OPTIONS = [
 
 const SOCIAL_PROVIDERS = ['google', 'facebook', 'x', 'apple'];
 
+const GOAL_LABELS = {
+  confidence: 'Confidence and habit',
+  sats: 'KS2 SATs prep',
+  'catch-up': 'Catch-up and recovery',
+};
+
+const YEAR_GROUPS = ['Y3', 'Y4', 'Y5', 'Y6'];
+
 function safeColour(value, fallback = '#3E6FA8') {
   const colour = String(value || '').trim();
   return /^#[0-9a-fA-F]{6}$/.test(colour) ? colour : fallback;
 }
 
 function goalLabel(value) {
-  return {
-    confidence: 'Confidence and habit',
-    sats: 'KS2 SATs prep',
-    'catch-up': 'Catch-up and recovery',
-  }[value] || 'KS2 SATs prep';
+  return GOAL_LABELS[value] || GOAL_LABELS.sats;
 }
 
 function initials(name) {
@@ -82,20 +87,47 @@ function PersistenceInline({ snapshot }) {
         ? 'Memory only'
         : 'This browser trusted';
   return (
-    <div className="chip-row" style={{ marginTop: 14 }}>
-      <span className={`chip ${mode === 'degraded' ? 'warn' : mode === 'remote-sync' ? 'good' : ''}`}>{mode === 'remote-sync' ? 'Remote sync' : mode === 'degraded' ? 'Sync degraded' : 'Local-only'}</span>
+    <div className="chip-row profile-persistence-chips" role="status" aria-label="Persistence snapshot">
+      <span className={`chip ${mode === 'degraded' ? 'warn' : mode === 'remote-sync' ? 'good' : ''}`}>
+        {mode === 'remote-sync' ? 'Remote sync' : mode === 'degraded' ? 'Sync degraded' : 'Local-only'}
+      </span>
       <span className="chip">{trust}</span>
       <span className="chip">Pending: {Number(snapshot?.pendingWriteCount) || 0}</span>
     </div>
   );
 }
 
+function ProfileShell({ chrome, actions, children, appState }) {
+  return (
+    <div className="app-shell profile-settings-shell">
+      <TopNav
+        theme={chrome.theme}
+        onToggleTheme={actions.toggleTheme}
+        onNavigateHome={actions.navigateHome}
+        learners={chrome.learnerOptions || []}
+        selectedLearnerId={chrome.learner?.id || ''}
+        learnerLabel={chrome.learnerLabel || ''}
+        signedInAs={chrome.signedInAs}
+        onSelectLearner={actions.selectLearner}
+        onOpenProfileSettings={actions.openProfileSettings}
+        onLogout={actions.logout}
+        persistenceMode={chrome.persistence?.mode || 'local-only'}
+        persistenceLabel={chrome.persistence?.label || ''}
+      />
+      <PersistenceBanner snapshot={appState.persistence} onRetry={actions.retryPersistence} />
+      {children}
+    </div>
+  );
+}
+
 function EmptyProfile({ actions, writeLocked = false }) {
+  const heroBg = useMemo(() => randomHeroBackground(), []);
   return (
     <main className="profile-page">
-      <section className="profile-empty-state hero-paper">
-        <div>
-          <div className="eyebrow">Profile settings</div>
+      <section className="profile-hero profile-hero-empty hero-paper" style={{ '--hero-bg': `url('${heroBg}')` }}>
+        <div className="hero-art profile-hero-art" aria-hidden="true" />
+        <div className="profile-hero-copy">
+          <p className="eyebrow">Profile settings</p>
           <h1 className="profile-title">No writable learner is available</h1>
           <p className="profile-lede">Create or select a learner before changing study rhythm, profile colour, or portable data.</p>
           <div className="profile-hero-actions">
@@ -116,15 +148,15 @@ function DemoConversionPanel({ actions }) {
 
   return (
     <section className="profile-panel profile-demo-conversion-panel">
-      <div className="profile-panel-head">
+      <header className="profile-panel-head">
         <div>
-          <div className="eyebrow">Demo progress</div>
+          <p className="eyebrow">Demo progress</p>
           <h2 className="section-title">Create an account</h2>
         </div>
         <span className="chip good">Progress kept</span>
-      </div>
+      </header>
       <p className="subtitle">Keep this demo learner, spelling progress and Codex rewards by creating a parent account.</p>
-      <form className="auth-form" onSubmit={submit}>
+      <form className="auth-form profile-demo-form" onSubmit={submit}>
         <label className="field">
           <span>Email</span>
           <input className="input" type="email" name="email" autoComplete="email" required />
@@ -136,7 +168,7 @@ function DemoConversionPanel({ actions }) {
         <button className="btn primary lg" type="submit">Create account from demo</button>
       </form>
       <div className="auth-divider"><span>Social sign-in</span></div>
-      <div className="auth-social">
+      <div className="auth-social profile-demo-social">
         {SOCIAL_PROVIDERS.map((provider) => (
           <button
             key={provider}
@@ -152,6 +184,212 @@ function DemoConversionPanel({ actions }) {
   );
 }
 
+function IdentityCard({ learner, accent, liveSubjectCount, subjectCount, ordinal, learnerCount }) {
+  return (
+    <aside className="profile-identity" aria-label="Current learner summary">
+      <div className="profile-avatar" aria-hidden="true">{initials(learner.name)}</div>
+      <div className="profile-identity-copy">
+        <strong>{learner.name}</strong>
+        <span>{learner.yearGroup} · {goalLabel(learner.goal)}</span>
+      </div>
+      <div className="profile-mini-stats" role="list" aria-label="Learner profile summary">
+        <span role="listitem">
+          <strong>{learner.dailyMinutes || 15}</strong>
+          <small>daily minutes</small>
+        </span>
+        <span role="listitem">
+          <strong>{ordinal}/{learnerCount}</strong>
+          <small>learner</small>
+        </span>
+        <span role="listitem">
+          <strong>{liveSubjectCount}/{subjectCount}</strong>
+          <small>subjects live</small>
+        </span>
+      </div>
+    </aside>
+  );
+}
+
+function StudyRhythmPanel({ learner, learners, appState, accent, writeLocked, writeLockReason, actions }) {
+  return (
+    <section className="profile-panel profile-rhythm-panel">
+      <header className="profile-panel-head">
+        <div>
+          <p className="eyebrow">Learner details</p>
+          <h2 className="section-title">Study rhythm</h2>
+        </div>
+        <span className="chip profile-shared-chip" style={{ borderColor: accent, color: accent }}>Shared profile</span>
+      </header>
+      {writeLockReason && <div className="feedback warn" role="status">{writeLockReason}</div>}
+      {learners.length > 1 && (
+        <label className="profile-form-field profile-form-field-wide profile-learner-switcher">
+          <span>Current learner</span>
+          <select
+            className="select"
+            name="learnerId"
+            value={appState.learners.selectedId}
+            onChange={(event) => actions.selectLearner(event.target.value)}
+          >
+            {learners.map((entry) => (
+              <option value={entry.id} key={entry.id}>{entry.name} · {entry.yearGroup}</option>
+            ))}
+          </select>
+        </label>
+      )}
+      <div className="profile-form-grid">
+        <label className="profile-form-field profile-form-field-wide">
+          <span>Name</span>
+          <input className="input" name="name" autoComplete="off" defaultValue={learner.name} disabled={writeLocked} />
+        </label>
+        <label className="profile-form-field">
+          <span>Year group</span>
+          <select className="select" name="yearGroup" defaultValue={learner.yearGroup} disabled={writeLocked}>
+            {YEAR_GROUPS.map((value) => <option value={value} key={value}>{value}</option>)}
+          </select>
+        </label>
+        <label className="profile-form-field">
+          <span>Primary goal</span>
+          <select className="select" name="goal" defaultValue={learner.goal || 'sats'} disabled={writeLocked}>
+            <option value="confidence">Confidence and habit</option>
+            <option value="sats">KS2 SATs prep</option>
+            <option value="catch-up">Catch-up and recovery</option>
+          </select>
+        </label>
+        <label className="profile-form-field">
+          <span>Daily minutes</span>
+          <input
+            className="input"
+            type="number"
+            min="5"
+            max="60"
+            name="dailyMinutes"
+            autoComplete="off"
+            defaultValue={learner.dailyMinutes || 15}
+            disabled={writeLocked}
+          />
+        </label>
+        <label className="profile-form-field profile-colour-field">
+          <span>Accent colour</span>
+          <input
+            className="input"
+            type="color"
+            name="avatarColor"
+            autoComplete="off"
+            defaultValue={accent}
+            disabled={writeLocked}
+          />
+        </label>
+      </div>
+    </section>
+  );
+}
+
+function DictationVoicePanel({ ttsProvider, bufferedGeminiVoice, writeLocked, testVoice }) {
+  return (
+    <section className="profile-panel profile-dictation-panel">
+      <header className="profile-panel-head">
+        <div>
+          <p className="eyebrow">Sound</p>
+          <h2 className="section-title">Dictation voice</h2>
+        </div>
+        <span className="chip">Per browser</span>
+      </header>
+      <p className="subtitle">Pick the voice that reads each word aloud. Test before you save — preferences stick to this browser.</p>
+      <div className="profile-tts-control">
+        <div className="profile-tts-options" role="radiogroup" aria-label="Dictation voice">
+          {TTS_PROVIDER_OPTIONS.map((option) => (
+            <label className="profile-tts-option" key={option.value} title={option.title || option.label}>
+              <input
+                type="radio"
+                name="ttsProvider"
+                value={option.value}
+                defaultChecked={ttsProvider === option.value}
+              />
+              <span>{option.label}</span>
+            </label>
+          ))}
+        </div>
+        <button
+          className="btn secondary profile-tts-test-btn"
+          type="button"
+          data-action="tts-test"
+          onClick={testVoice}
+        >
+          <span className="profile-tts-test-label">Test</span>
+        </button>
+      </div>
+      <label className="profile-form-field profile-form-field-wide">
+        <span>Pre-cached Gemini voice</span>
+        <select className="select" name="bufferedGeminiVoice" defaultValue={bufferedGeminiVoice} disabled={writeLocked}>
+          {BUFFERED_GEMINI_VOICE_OPTIONS.map((option) => (
+            <option value={option.id} key={option.id}>{option.label}</option>
+          ))}
+        </select>
+      </label>
+    </section>
+  );
+}
+
+function DangerZonePanel({ writeLocked, actions }) {
+  return (
+    <section className="profile-panel profile-danger-panel" aria-labelledby="profile-danger-title">
+      <header className="profile-panel-head">
+        <div>
+          <p className="eyebrow">Permanent actions</p>
+          <h2 id="profile-danger-title" className="section-title">Danger zone</h2>
+        </div>
+      </header>
+      <p className="subtitle">A reset clears learner progress without removing the learner. Deletion is permanent and removes every subject history for this learner.</p>
+      <div className="profile-form-danger-actions">
+        <button
+          className="btn warn lg"
+          type="button"
+          disabled={writeLocked}
+          onClick={() => actions.dispatch('learner-reset-progress')}
+        >
+          Reset learner progress
+        </button>
+        <button
+          className="btn bad lg"
+          type="button"
+          disabled={writeLocked}
+          onClick={() => actions.dispatch('learner-delete')}
+        >
+          Delete learner
+        </button>
+      </div>
+    </section>
+  );
+}
+
+function PortableSnapshotsPanel({ appState, importLocked, importLockReason, actions }) {
+  return (
+    <section className="profile-panel profile-data-panel">
+      <header className="profile-panel-head">
+        <div>
+          <p className="eyebrow">Data safety</p>
+          <h2 className="section-title">Portable snapshots</h2>
+        </div>
+      </header>
+      <p className="subtitle">Exports use JSON recovery points. Imports keep existing learners unless a full-app snapshot replaces this browser dataset.</p>
+      <PersistenceInline snapshot={appState.persistence} />
+      {importLocked && <div className="feedback warn" role="status">{importLockReason}</div>}
+      <div className="actions profile-data-actions">
+        <button className="btn secondary" type="button" onClick={() => actions.dispatch('platform-export-learner')}>Export current learner</button>
+        <button className="btn secondary" type="button" onClick={() => actions.dispatch('platform-export-app')}>Export full app</button>
+        <button className="btn ghost" type="button" disabled={importLocked} onClick={() => actions.dispatch('platform-import')}>Import JSON</button>
+      </div>
+      <input
+        id="platform-import-file"
+        style={{ display: 'none' }}
+        type="file"
+        accept=".json,application/json"
+        onChange={(event) => actions.dispatch('platform-import-file-selected', { input: event.currentTarget })}
+      />
+    </section>
+  );
+}
+
 export function ProfileSettingsSurface({ appState, chrome, actions, subjectCount = 0, liveSubjectCount = 0 }) {
   const learner = selectedLearner(appState);
   const learners = learnerList(appState);
@@ -159,36 +397,25 @@ export function ProfileSettingsSurface({ appState, chrome, actions, subjectCount
   const writeLocked = Boolean(writeLockReason);
   const importLockReason = dataImportLockReason(appState, chrome, writeLockReason);
   const importLocked = Boolean(importLockReason);
+  const heroBg = useMemo(() => randomHeroBackground(), [learner?.id]);
+
   if (!learner) {
     return (
-      <div className="app-shell profile-settings-shell">
-        <TopNav
-          theme={chrome.theme}
-          onToggleTheme={actions.toggleTheme}
-          onNavigateHome={actions.navigateHome}
-          learners={chrome.learnerOptions || []}
-          selectedLearnerId={chrome.learner?.id || ''}
-          learnerLabel={chrome.learnerLabel || ''}
-          signedInAs={chrome.signedInAs}
-          onSelectLearner={actions.selectLearner}
-          onOpenProfileSettings={actions.openProfileSettings}
-          onLogout={actions.logout}
-          persistenceMode={chrome.persistence?.mode || 'local-only'}
-          persistenceLabel={chrome.persistence?.label || ''}
-        />
-        <PersistenceBanner snapshot={appState.persistence} onRetry={actions.retryPersistence} />
+      <ProfileShell chrome={chrome} actions={actions} appState={appState}>
         <EmptyProfile actions={actions} writeLocked={writeLocked} />
-      </div>
+      </ProfileShell>
     );
   }
 
   const accent = safeColour(learner.avatarColor);
   const ttsProvider = normaliseTtsProvider(chrome.ttsProvider);
   const bufferedGeminiVoice = normaliseBufferedGeminiVoice(chrome.bufferedGeminiVoice);
+
   const submit = (event) => {
     event.preventDefault();
     actions.dispatch('learner-save-form', { formData: new FormData(event.currentTarget) });
   };
+
   const testVoice = (event) => {
     const form = event.currentTarget.form;
     const formData = form ? new FormData(form) : null;
@@ -198,167 +425,89 @@ export function ProfileSettingsSurface({ appState, chrome, actions, subjectCount
     });
   };
 
+  const heroStyle = {
+    '--profile-accent': accent,
+    '--hero-bg': `url('${heroBg}')`,
+  };
+
   return (
-    <div className="app-shell profile-settings-shell">
-      <TopNav
-        theme={chrome.theme}
-        onToggleTheme={actions.toggleTheme}
-        onNavigateHome={actions.navigateHome}
-        learners={chrome.learnerOptions || []}
-        selectedLearnerId={chrome.learner?.id || ''}
-        learnerLabel={chrome.learnerLabel || ''}
-        signedInAs={chrome.signedInAs}
-        onSelectLearner={actions.selectLearner}
-        onOpenProfileSettings={actions.openProfileSettings}
-        onLogout={actions.logout}
-        persistenceMode={chrome.persistence?.mode || 'local-only'}
-        persistenceLabel={chrome.persistence?.label || ''}
-      />
-      <PersistenceBanner snapshot={appState.persistence} onRetry={actions.retryPersistence} />
+    <ProfileShell chrome={chrome} actions={actions} appState={appState}>
       <main className="profile-page">
-        <section className="profile-hero hero-paper" style={{ '--profile-accent': accent }}>
+        <section className="profile-hero hero-paper" style={heroStyle}>
+          <div className="hero-art profile-hero-art" aria-hidden="true" />
           <div className="profile-hero-copy">
-            <div className="profile-kicker">Profile settings</div>
-            <h1 className="profile-title">Learning profile for {learner.name}</h1>
+            <p className="eyebrow">Profile settings</p>
+            <h1 className="profile-title">
+              Learning profile for <em>{learner.name}</em>
+            </h1>
             <p className="profile-lede">Year group, goal and daily rhythm stay shared across every subject in the dashboard.</p>
             <div className="profile-hero-actions">
-              <button className="btn primary xl" type="button" disabled={writeLocked} onClick={() => actions.dispatch('learner-create')} style={{ background: accent }}>Add learner</button>
+              <button
+                className="btn primary xl"
+                type="button"
+                disabled={writeLocked}
+                onClick={() => actions.dispatch('learner-create')}
+                style={{ background: accent }}
+              >
+                Add learner
+              </button>
               <button className="btn ghost xl" type="button" onClick={actions.navigateHome}>Back to dashboard</button>
             </div>
           </div>
-          <div className="profile-identity">
-            <div className="profile-avatar" aria-hidden="true">{initials(learner.name)}</div>
-            <div className="profile-identity-copy">
-              <strong>{learner.name}</strong>
-              <span>{learner.yearGroup} / {goalLabel(learner.goal)}</span>
-            </div>
-            <div className="profile-mini-stats" aria-label="Learner profile summary">
-              <span><strong>{learner.dailyMinutes || 15}</strong><small>daily minutes</small></span>
-              <span><strong>{learnerOrdinal(appState)}/{learners.length}</strong><small>learner</small></span>
-              <span><strong>{liveSubjectCount}/{subjectCount}</strong><small>subjects live</small></span>
-            </div>
-          </div>
+          <IdentityCard
+            learner={learner}
+            accent={accent}
+            liveSubjectCount={liveSubjectCount}
+            subjectCount={subjectCount}
+            ordinal={learnerOrdinal(appState)}
+            learnerCount={learners.length}
+          />
         </section>
 
-        <section className="profile-layout">
-          <form id="learner-profile-form" className="profile-panel profile-editor-panel" onSubmit={submit}>
-            <div className="profile-panel-head">
-              <div>
-                <div className="eyebrow">Learner details</div>
-                <h2 className="section-title">Study rhythm</h2>
-              </div>
-              <span className="chip" style={{ borderColor: accent, color: accent }}>Shared profile</span>
-            </div>
-            {writeLockReason && <div className="feedback warn" role="status">{writeLockReason}</div>}
-            {learners.length > 1 && (
-              <label className="profile-form-field profile-form-field-wide">
-                <span>Current learner</span>
-                <select className="select" name="learnerId" value={appState.learners.selectedId} onChange={(event) => actions.selectLearner(event.target.value)}>
-                  {learners.map((entry) => (
-                    <option value={entry.id} key={entry.id}>{entry.name} · {entry.yearGroup}</option>
-                  ))}
-                </select>
-              </label>
-            )}
-            <div className="profile-form-grid">
-              <label className="profile-form-field profile-form-field-wide">
-                <span>Name</span>
-                <input className="input" name="name" autoComplete="off" defaultValue={learner.name} disabled={writeLocked} />
-              </label>
-              <label className="profile-form-field">
-                <span>Year group</span>
-                <select className="select" name="yearGroup" defaultValue={learner.yearGroup} disabled={writeLocked}>
-                  {['Y3', 'Y4', 'Y5', 'Y6'].map((value) => <option value={value} key={value}>{value}</option>)}
-                </select>
-              </label>
-              <label className="profile-form-field">
-                <span>Primary goal</span>
-                <select className="select" name="goal" defaultValue={learner.goal || 'sats'} disabled={writeLocked}>
-                  <option value="confidence">Confidence and habit</option>
-                  <option value="sats">KS2 SATs prep</option>
-                  <option value="catch-up">Catch-up and recovery</option>
-                </select>
-              </label>
-              <label className="profile-form-field">
-                <span>Daily minutes</span>
-                <input className="input" type="number" min="5" max="60" name="dailyMinutes" autoComplete="off" defaultValue={learner.dailyMinutes || 15} disabled={writeLocked} />
-              </label>
-              <label className="profile-form-field profile-colour-field">
-                <span>Accent colour</span>
-                <input className="input" type="color" name="avatarColor" autoComplete="off" defaultValue={accent} disabled={writeLocked} />
-              </label>
-              <div className="profile-form-field profile-form-field-wide">
-                <span>Dictation voice</span>
-                <div className="profile-tts-control">
-                  <div className="profile-tts-options" role="radiogroup" aria-label="Dictation voice">
-                    {TTS_PROVIDER_OPTIONS.map((option) => (
-                      <label className="profile-tts-option" key={option.value} title={option.title || option.label}>
-                        <input
-                          type="radio"
-                          name="ttsProvider"
-                          value={option.value}
-                          defaultChecked={ttsProvider === option.value}
-                        />
-                        <span>{option.label}</span>
-                      </label>
-                    ))}
-                  </div>
-                  <button
-                    className="btn secondary profile-tts-test-btn"
-                    type="button"
-                    data-action="tts-test"
-                    onClick={testVoice}
-                  >
-                    <span className="profile-tts-test-label">Test</span>
-                  </button>
-                </div>
-              </div>
-              <label className="profile-form-field profile-form-field-wide">
-                <span>Pre-cached Gemini voice</span>
-                <select className="select" name="bufferedGeminiVoice" defaultValue={bufferedGeminiVoice} disabled={writeLocked}>
-                  {BUFFERED_GEMINI_VOICE_OPTIONS.map((option) => (
-                    <option value={option.id} key={option.id}>{option.label}</option>
-                  ))}
-                </select>
-              </label>
-            </div>
-            <div className="profile-form-footer">
-              <div className="profile-form-danger-actions">
-                <button className="btn warn lg" type="button" disabled={writeLocked} onClick={() => actions.dispatch('learner-reset-progress')}>Reset learner progress</button>
-                <button className="btn bad lg" type="button" disabled={writeLocked} onClick={() => actions.dispatch('learner-delete')}>Delete learner</button>
-              </div>
-              <button className="btn primary lg" style={{ background: accent }} type="submit" disabled={writeLocked}>Save learner profile</button>
-            </div>
+        <div className="profile-layout">
+          <form id="learner-profile-form" className="profile-form-column" onSubmit={submit}>
+            <StudyRhythmPanel
+              learner={learner}
+              learners={learners}
+              appState={appState}
+              accent={accent}
+              writeLocked={writeLocked}
+              writeLockReason={writeLockReason}
+              actions={actions}
+            />
+            <DictationVoicePanel
+              ttsProvider={ttsProvider}
+              bufferedGeminiVoice={bufferedGeminiVoice}
+              writeLocked={writeLocked}
+              testVoice={testVoice}
+            />
+            <DangerZonePanel writeLocked={writeLocked} actions={actions} />
+            <footer className="profile-form-footer">
+              <p className="profile-form-footer-note" aria-hidden={writeLocked ? 'false' : 'true'}>
+                {writeLocked ? 'Writes are paused — unlock persistence to save.' : 'Changes apply across every subject once saved.'}
+              </p>
+              <button
+                className="btn primary lg"
+                style={{ background: accent }}
+                type="submit"
+                disabled={writeLocked}
+              >
+                Save learner profile
+              </button>
+            </footer>
           </form>
 
           <aside className="profile-side-panels">
             {chrome.session?.demo && <DemoConversionPanel actions={actions} />}
-            <section className="profile-panel profile-data-panel">
-              <div className="profile-panel-head">
-                <div>
-                  <div className="eyebrow">Data safety</div>
-                  <h2 className="section-title">Portable snapshots</h2>
-                </div>
-              </div>
-              <p className="subtitle">Exports use JSON recovery points. Imports keep existing learners unless a full-app snapshot replaces this browser dataset.</p>
-              <PersistenceInline snapshot={appState.persistence} />
-              {importLocked && <div className="feedback warn" role="status">{importLockReason}</div>}
-              <div className="actions profile-data-actions">
-                <button className="btn secondary" type="button" onClick={() => actions.dispatch('platform-export-learner')}>Export current learner</button>
-                <button className="btn secondary" type="button" onClick={() => actions.dispatch('platform-export-app')}>Export full app</button>
-                <button className="btn ghost" type="button" disabled={importLocked} onClick={() => actions.dispatch('platform-import')}>Import JSON</button>
-              </div>
-              <input
-                id="platform-import-file"
-                style={{ display: 'none' }}
-                type="file"
-                accept=".json,application/json"
-                onChange={(event) => actions.dispatch('platform-import-file-selected', { input: event.currentTarget })}
-              />
-            </section>
+            <PortableSnapshotsPanel
+              appState={appState}
+              importLocked={importLocked}
+              importLockReason={importLockReason}
+              actions={actions}
+            />
           </aside>
-        </section>
+        </div>
       </main>
-    </div>
+    </ProfileShell>
   );
 }

--- a/styles/app.css
+++ b/styles/app.css
@@ -2218,14 +2218,6 @@ textarea:focus-visible {
   z-index: 2;
 }
 
-.profile-kicker {
-  color: var(--muted);
-  font-size: 0.78rem;
-  font-weight: 900;
-  letter-spacing: 0;
-  text-transform: uppercase;
-}
-
 .profile-title {
   max-width: 13ch;
   margin: 6px 0 0;
@@ -6857,5 +6849,403 @@ textarea:focus-visible {
       padding-left: max(16px, env(safe-area-inset-left));
       padding-right: max(16px, env(safe-area-inset-right));
     }
+  }
+}
+
+/* ==========================================================
+   Profile settings — alignment with the home / codex
+   journal aesthetic. Overrides earlier .profile-hero and
+   .hero-paper rules so the profile page reads as another
+   paper in the same codex. Keep this block last so source
+   order wins without needing compound selector specificity.
+   ========================================================== */
+
+.profile-hero {
+  grid-template-columns: minmax(0, 1.24fr) minmax(280px, 0.76fr);
+  gap: clamp(20px, 3.2vw, 36px);
+  align-items: center;
+  min-height: 360px;
+  padding: clamp(34px, 5vw, 48px) clamp(28px, 4vw, 44px) clamp(30px, 4vw, 40px);
+  background:
+    radial-gradient(120% 95% at 100% 0%,
+      color-mix(in oklab, var(--profile-accent, var(--brand)) 22%, transparent),
+      transparent 58%),
+    radial-gradient(130% 95% at 0% 100%,
+      color-mix(in oklab, var(--phaeton) 15%, transparent),
+      transparent 62%),
+    var(--panel);
+}
+
+.profile-hero-art.hero-art {
+  opacity: 0.48;
+}
+
+.profile-hero-art.hero-art::after {
+  background:
+    linear-gradient(100deg,
+      color-mix(in oklab, var(--panel) 94%, transparent) 0%,
+      color-mix(in oklab, var(--panel) 72%, transparent) 38%,
+      color-mix(in oklab, var(--panel) 36%, transparent) 72%,
+      color-mix(in oklab, var(--panel) 14%, transparent) 100%),
+    linear-gradient(180deg,
+      color-mix(in oklab, var(--panel) 20%, transparent) 0%,
+      transparent 42%,
+      transparent 70%,
+      color-mix(in oklab, var(--panel) 24%, transparent) 100%);
+}
+
+.profile-hero-copy {
+  max-width: 640px;
+  padding-top: clamp(0px, 1.4vw, 12px);
+}
+
+.profile-hero-copy .eyebrow {
+  color: color-mix(in oklab, var(--profile-accent, var(--brand)) 68%, var(--muted));
+  font-weight: 800;
+  letter-spacing: 0.12em;
+}
+
+.profile-title {
+  max-width: 18ch;
+  margin: 10px 0 0;
+  font-family: var(--font-serif);
+  font-size: clamp(2.1rem, 4.2vw, 3.1rem);
+  line-height: 1.02;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+}
+
+.profile-title em {
+  font-style: italic;
+  color: color-mix(in oklab, var(--profile-accent, var(--brand)) 80%, var(--ink));
+  font-weight: 500;
+}
+
+.profile-lede {
+  max-width: 54ch;
+  margin: 16px 0 0;
+  color: var(--ink-2);
+  font-size: 1.02rem;
+  line-height: 1.5;
+}
+
+.profile-hero-actions {
+  margin-top: clamp(20px, 2.8vw, 28px);
+}
+
+/* Identity card — glass disc with accent halo */
+.profile-identity {
+  justify-self: end;
+  align-self: center;
+  display: grid;
+  grid-template-columns: 1fr;
+  justify-items: center;
+  gap: 14px;
+  width: min(100%, 320px);
+  padding: 22px 20px 18px;
+  text-align: center;
+  border: 1px solid color-mix(in oklab, var(--line) 66%, transparent);
+  border-radius: var(--radius);
+  background:
+    linear-gradient(180deg,
+      color-mix(in oklab, var(--panel) 72%, transparent) 0%,
+      color-mix(in oklab, var(--panel) 42%, transparent) 100%);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow:
+    0 24px 44px -28px color-mix(in oklab, var(--profile-accent, var(--brand)) 45%, transparent),
+    inset 0 0 0 1px color-mix(in oklab, white 12%, transparent);
+}
+
+.profile-avatar {
+  width: clamp(96px, 14vw, 132px);
+  font-size: clamp(2rem, 4.4vw, 2.9rem);
+  box-shadow:
+    0 22px 38px -22px color-mix(in oklab, var(--profile-accent, var(--brand)) 55%, transparent),
+    inset 0 0 0 6px color-mix(in oklab, white 22%, transparent);
+}
+
+.profile-identity-copy strong {
+  font-size: 1.3rem;
+}
+
+.profile-mini-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  width: 100%;
+  margin: 4px 0 0;
+}
+
+.profile-mini-stats > span {
+  display: grid;
+  gap: 4px;
+  padding: 10px 6px;
+  border: 1px solid color-mix(in oklab, var(--line-strong) 45%, transparent);
+  border-radius: var(--radius-sm);
+  background: color-mix(in oklab, var(--panel) 60%, transparent);
+}
+
+.profile-mini-stats strong {
+  font-family: var(--font-serif);
+  font-size: 1.2rem;
+  line-height: 1;
+  font-weight: 500;
+}
+
+.profile-mini-stats small {
+  color: var(--muted);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+/* Main layout — form column and side rail */
+.profile-layout {
+  grid-template-columns: minmax(0, 1.2fr) minmax(300px, 0.8fr);
+  gap: 20px;
+  align-items: start;
+}
+
+.profile-form-column {
+  display: grid;
+  gap: 18px;
+  min-width: 0;
+}
+
+.profile-side-panels {
+  display: grid;
+  gap: 18px;
+  min-width: 0;
+}
+
+/* Panel base — soft codex-warm paper */
+.profile-panel {
+  position: relative;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background:
+    linear-gradient(180deg,
+      var(--panel) 0%,
+      color-mix(in oklab, var(--panel-soft) 55%, var(--panel)) 100%);
+  box-shadow: var(--shadow-xs);
+  padding: 22px 24px;
+}
+
+.profile-panel-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  margin: 0 0 14px;
+}
+
+.profile-panel-head .eyebrow {
+  margin-bottom: 4px;
+}
+
+.profile-panel-head .section-title {
+  font-size: 1.4rem;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+}
+
+.profile-panel .subtitle {
+  margin: -4px 0 14px;
+  color: var(--ink-2);
+  font-size: 0.96rem;
+  line-height: 1.5;
+}
+
+/* Study rhythm: accent top stripe hints the learner's colour */
+.profile-rhythm-panel {
+  overflow: hidden;
+  padding-top: 20px;
+}
+
+.profile-rhythm-panel::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 3px;
+  background: linear-gradient(90deg,
+    color-mix(in oklab, var(--profile-accent, var(--brand)) 85%, transparent) 0%,
+    color-mix(in oklab, var(--profile-accent, var(--brand)) 45%, transparent) 55%,
+    transparent 100%);
+}
+
+.profile-shared-chip {
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+}
+
+.profile-learner-switcher {
+  margin-bottom: 14px;
+}
+
+.profile-form-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+/* Dictation panel — leans on the glimmer accent so it sits between
+   the warm rhythm panel and the bad-tone danger zone. */
+.profile-dictation-panel {
+  background:
+    linear-gradient(180deg,
+      var(--panel) 0%,
+      color-mix(in oklab, var(--glimmer-soft) 42%, var(--panel)) 100%);
+}
+
+.profile-dictation-panel .profile-panel-head .chip {
+  background: color-mix(in oklab, var(--glimmer) 12%, var(--panel));
+  border-color: color-mix(in oklab, var(--glimmer) 38%, var(--line));
+  color: color-mix(in oklab, var(--glimmer) 72%, var(--ink));
+}
+
+.profile-dictation-panel .profile-tts-control {
+  margin-bottom: 14px;
+}
+
+/* Danger zone — soft red so destructive actions feel deliberate */
+.profile-danger-panel {
+  background:
+    linear-gradient(180deg,
+      var(--panel) 0%,
+      color-mix(in oklab, var(--bad-soft) 48%, var(--panel)) 100%);
+  border-color: color-mix(in oklab, var(--bad) 22%, var(--line));
+}
+
+.profile-danger-panel .section-title {
+  color: var(--bad-strong);
+}
+
+.profile-danger-panel .profile-form-danger-actions {
+  margin: 12px 0 0;
+}
+
+/* Sticky-feeling footer with an accent glow that mirrors the hero */
+.profile-form-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 0;
+  padding: 16px 22px;
+  border: 1px solid color-mix(in oklab, var(--profile-accent, var(--brand)) 28%, var(--line));
+  border-radius: var(--radius-lg);
+  background:
+    linear-gradient(180deg,
+      color-mix(in oklab, var(--panel) 92%, transparent) 0%,
+      color-mix(in oklab, var(--profile-accent, var(--brand)) 10%, var(--panel)) 100%);
+  box-shadow:
+    0 18px 32px -26px color-mix(in oklab, var(--profile-accent, var(--brand)) 60%, transparent);
+}
+
+.profile-form-footer-note {
+  margin: 0;
+  color: var(--ink-2);
+  font-size: 0.92rem;
+  line-height: 1.4;
+}
+
+.profile-form-footer .btn.primary.lg {
+  flex: 0 0 auto;
+  min-height: 46px;
+  padding: 12px 20px;
+  box-shadow: 0 12px 22px -14px color-mix(in oklab, var(--profile-accent, var(--brand)) 70%, transparent);
+}
+
+/* Data panel chrome */
+.profile-data-panel .profile-persistence-chips {
+  margin: 0 0 12px;
+}
+
+.profile-data-panel .feedback {
+  margin: 10px 0;
+}
+
+.profile-data-actions {
+  margin-top: 14px;
+}
+
+/* Demo conversion */
+.profile-demo-conversion-panel {
+  background:
+    linear-gradient(180deg,
+      var(--panel) 0%,
+      color-mix(in oklab, var(--good-soft) 40%, var(--panel)) 100%);
+  border-color: color-mix(in oklab, var(--good) 28%, var(--line));
+}
+
+.profile-demo-conversion-panel .section-title {
+  color: var(--good-strong);
+}
+
+.profile-demo-form {
+  margin-top: 8px;
+}
+
+.profile-demo-social {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-top: 12px;
+}
+
+/* Empty state — reuses hero-paper, adds the same hero-art wash */
+.profile-hero-empty {
+  grid-template-columns: 1fr;
+  min-height: 320px;
+}
+
+.profile-hero-empty .profile-hero-copy {
+  max-width: 58ch;
+}
+
+/* Responsive tuning */
+@media (max-width: 980px) {
+  .profile-hero {
+    grid-template-columns: 1fr;
+    min-height: auto;
+  }
+  .profile-identity {
+    justify-self: start;
+    width: 100%;
+    max-width: 420px;
+  }
+  .profile-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .profile-hero {
+    padding: 28px 22px 26px;
+  }
+  .profile-panel {
+    padding: 20px 18px;
+  }
+  .profile-form-grid {
+    grid-template-columns: 1fr;
+  }
+  .profile-form-footer {
+    flex-direction: column;
+    align-items: stretch;
+    padding: 16px 18px;
+  }
+  .profile-form-footer .btn.primary.lg {
+    width: 100%;
+  }
+  .profile-form-danger-actions {
+    flex-direction: column;
+  }
+  .profile-form-danger-actions .btn {
+    width: 100%;
+  }
+  .profile-mini-stats {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+  .profile-demo-social {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }


### PR DESCRIPTION
## Summary
- Re-skin `ProfileSettingsSurface.jsx` to share the home/codex paper-and-Fraunces aesthetic: hero now uses the shared `hero-paper` treatment with region background, hairlines, accent halo and italic-serif learner name; form splits into three codex-style cards (Study rhythm w/ accent top stripe, Dictation voice on glimmer tint, Danger zone on soft bad tint) plus an accent-glow Save footer.
- Identity card becomes a glass disc with hairline mini-stats matching the codex-stat language.
- All handlers, form field names, and the exact-match HTML asserted by `tests/react-shared-surfaces.test.js` (Save / Add learner / Import JSON disabled markup) are preserved.
- Append a single Profile-alignment CSS block at the end of `styles/app.css` so source-order wins without needing compound selectors; drop the now-orphan `.profile-kicker` rule.

## Test plan
- [x] `npm test` — 533 tests pass (1 skipped, 0 fail)
- [x] `npm run check` — wrangler dry-run deploy succeeds, client bundle audit passes
- [x] `npm run build:bundles` — 497.3 KB
- [ ] Eyeball the live `ks2.eugnel.uk` profile page after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)