### PR TITLE
feat(parent-hub): align surface to home/codex paper aesthetic

### DIFF
--- a/src/surfaces/hubs/ParentHubSurface.jsx
+++ b/src/surfaces/hubs/ParentHubSurface.jsx
@@ -3,22 +3,6 @@ import { AdultLearnerSelect } from './AdultLearnerSelect.jsx';
 import { ReadOnlyLearnerNotice } from './ReadOnlyLearnerNotice.jsx';
 import { AccessDeniedCard, formatTimestamp, isBlocked, selectedWritableLearner } from './hub-utils.js';
 
-function HubStrengthList({ title, items = [], emptyText = 'No signal yet.' }) {
-  return (
-    <section className="card">
-      <div className="eyebrow">{title}</div>
-      {items.length ? items.map((item, index) => (
-        <div className="skill-row" key={`${item.label || 'item'}-${index}`}>
-          <div><strong>{item.label || 'Untitled'}</strong></div>
-          <div className="small muted">{item.detail || ''}</div>
-          <div>{String(item.secureCount ?? item.count ?? '—')}</div>
-          <div className="small muted">{item.troubleCount != null ? `${item.troubleCount} trouble` : ''}</div>
-        </div>
-      )) : <p className="small muted">{emptyText}</p>}
-    </section>
-  );
-}
-
 function snapshotSubjectId(snapshot = {}) {
   if (snapshot.subjectId) return snapshot.subjectId;
   return snapshot.totalConcepts != null || snapshot.trackedConcepts != null ? 'grammar' : 'spelling';
@@ -32,11 +16,153 @@ function snapshotChipLabel(snapshot = {}) {
   return `Spelling: ${snapshot.trackedWords ?? 0}/${snapshot.totalPublishedWords ?? 0} words`;
 }
 
+function HeadlineFigure({ label, value, tone }) {
+  return (
+    <div className={`parent-hub-figure${tone ? ` is-${tone}` : ''}`}>
+      <dt className="parent-hub-figure-label">{label}</dt>
+      <dd className="parent-hub-figure-value">{value}</dd>
+    </div>
+  );
+}
+
+function StatGrid({ overview, grammarReviewConcepts, grammarDueConcepts, grammarWeakConcepts }) {
+  const cells = [
+    { label: 'Secure words', value: overview.secureWords ?? 0, sub: 'Spelling snapshot' },
+    { label: 'Due words', value: overview.dueWords ?? 0, sub: 'Spelling return', tone: 'warn' },
+    { label: 'Trouble words', value: overview.troubleWords ?? 0, sub: 'Recent spelling mistakes', tone: 'bad' },
+    { label: 'Spelling accuracy', value: overview.accuracyPercent == null ? '—' : `${overview.accuracyPercent}%`, sub: 'Durable word progress' },
+    { label: 'Grammar secured', value: overview.secureGrammarConcepts ?? 0, sub: 'Concepts secure' },
+    { label: 'Grammar review', value: grammarReviewConcepts, sub: `${grammarDueConcepts} due · ${grammarWeakConcepts} weak`, tone: 'warn' },
+    { label: 'Grammar accuracy', value: overview.grammarAccuracyPercent == null ? '—' : `${overview.grammarAccuracyPercent}%`, sub: 'Concept evidence' },
+  ];
+  return (
+    <div className="parent-hub-statgrid">
+      {cells.map((cell) => (
+        <div className={`parent-hub-stat${cell.tone ? ` is-${cell.tone}` : ''}`} key={cell.label}>
+          <span className="parent-hub-stat-label">{cell.label}</span>
+          <span className="parent-hub-stat-value">{cell.value}</span>
+          {cell.sub ? <span className="parent-hub-stat-sub">{cell.sub}</span> : null}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function CurrentFocus({ items }) {
+  return (
+    <div className={`parent-hub-focus${items.length ? '' : ' is-empty'}`}>
+      <p className="eyebrow">Current focus</p>
+      {items.length ? (
+        <ol className="parent-hub-focus-list">
+          {items.map((entry, index) => (
+            <li className="parent-hub-focus-item" key={`${entry.label || 'item'}-${index}`}>
+              <span className="parent-hub-focus-marker" aria-hidden="true">{String(index + 1).padStart(2, '0')}</span>
+              <div className="parent-hub-focus-body">
+                <strong>{entry.label}</strong>
+                {entry.detail ? <span className="parent-hub-focus-detail">{entry.detail}</span> : null}
+              </div>
+            </li>
+          ))}
+        </ol>
+      ) : <p className="parent-hub-empty small muted">No due work is surfaced yet.</p>}
+    </div>
+  );
+}
+
+function RecentSessionList({ sessions }) {
+  if (!sessions.length) {
+    return <p className="parent-hub-empty small muted">No completed or active sessions are stored yet.</p>;
+  }
+  return (
+    <ol className="parent-hub-session-list">
+      {sessions.map((entry) => {
+        const mistakes = entry.mistakeCount || 0;
+        const tone = mistakes ? 'warn' : 'good';
+        return (
+          <li className="parent-hub-session-item" key={entry.id || entry.updatedAt}>
+            <details>
+              <summary>
+                <span className="parent-hub-session-label">{entry.label}</span>
+                <span className="parent-hub-session-time">{formatTimestamp(entry.updatedAt)}</span>
+              </summary>
+              <div className="parent-hub-session-meta">
+                <span className="chip">{entry.status}</span>
+                <span className="chip">{entry.sessionKind}</span>
+                <span className={`chip ${tone}`}>{`${mistakes} mistake${mistakes === 1 ? '' : 's'}`}</span>
+              </div>
+              {entry.headline ? <p className="parent-hub-session-summary">{entry.headline}</p> : null}
+            </details>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+function MisconceptionList({ patterns }) {
+  if (!patterns.length) {
+    return <p className="parent-hub-empty small muted">No durable mistake patterns have been recorded yet.</p>;
+  }
+  return (
+    <ul className="parent-hub-pattern-list">
+      {patterns.map((entry, index) => (
+        <li className="parent-hub-pattern-item" key={`${entry.label}-${index}`}>
+          <div className="parent-hub-pattern-main">
+            <strong>{entry.label}</strong>
+            <span className="parent-hub-row-detail">{entry.source || 'pattern'}</span>
+          </div>
+          <span className="parent-hub-pattern-count">{entry.count || 0}</span>
+          <span className="parent-hub-row-meta">{formatTimestamp(entry.lastSeenAt)}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function HubLedgerCard({ title, items, emptyText, tone }) {
+  return (
+    <article className="card parent-hub-card parent-hub-card--ledger">
+      <div className="parent-hub-card-head">
+        <p className="eyebrow">{title}</p>
+      </div>
+      {items.length ? (
+        <ul className="parent-hub-ledger-list">
+          {items.map((item, index) => (
+            <li className="parent-hub-ledger-row" key={`${item.label || 'item'}-${index}`}>
+              <div className="parent-hub-ledger-main">
+                <strong>{item.label || 'Untitled'}</strong>
+                {item.detail ? <span className="parent-hub-row-detail">{item.detail}</span> : null}
+              </div>
+              <span className={`parent-hub-ledger-figure${tone ? ` is-${tone}` : ''}`}>
+                {String(item.secureCount ?? item.count ?? '—')}
+              </span>
+              <span className="parent-hub-row-meta">
+                {item.troubleCount != null ? `${item.troubleCount} trouble` : ''}
+              </span>
+            </li>
+          ))}
+        </ul>
+      ) : <p className="parent-hub-empty small muted">{emptyText}</p>}
+    </article>
+  );
+}
+
+function SectionHead({ title, note }) {
+  return (
+    <div className="home-section-head parent-hub-section-head">
+      <div>
+        <h2 className="section-title">{title}</h2>
+        {note ? <p className="codex-section-note">{note}</p> : null}
+      </div>
+    </div>
+  );
+}
+
 export function ParentHubSurface({ appState, model, hubState = {}, accessContext = {}, actions }) {
   const loadingRemote = accessContext?.shellAccess?.source === 'worker-session' && hubState.status === 'loading' && !model;
   if (loadingRemote) {
     return (
-      <section className="card">
+      <section className="card parent-hub-loading">
         <div className="feedback warn">
           <strong>Loading Parent Hub</strong>
           <div style={{ marginTop: 8 }}>Loading live learner access and summary from the Worker hub route.</div>
@@ -80,16 +206,32 @@ export function ParentHubSurface({ appState, model, hubState = {}, accessContext
   const notice = hubState.notice || accessContext.adultSurfaceNotice || '';
   const writableLearner = selectedWritableLearner(appState);
 
+  const learnerName = model.learner?.name || 'Learner';
+  const firstName = (learnerName.split(' ')[0] || learnerName).trim() || learnerName;
+  const accuracyValue = overview.accuracyPercent == null ? '—' : `${overview.accuracyPercent}%`;
+
   return (
     <>
-      <section className="subject-header card border-top" style={{ borderTopColor: '#3E6FA8', marginBottom: 18 }}>
-        <div className="subject-title-row">
-          <div>
-            <div className="eyebrow">Parent Hub thin slice</div>
-            <h2 className="title" style={{ fontSize: 'clamp(1.6rem, 3vw, 2.2rem)' }}>{model.learner.name}</h2>
-            <p className="subtitle">Signed-in parent surfaces now use the live Worker hub payload instead of locally assembled synthetic memberships.</p>
+      <section className="parent-hub-hero">
+        <span className="parent-hub-hero-art" aria-hidden="true" />
+        <div className="parent-hub-hero-copy">
+          <p className="eyebrow">Parent Hub thin slice</p>
+          <h1 className="parent-hub-title">{learnerName}</h1>
+          <p className="parent-hub-lede">
+            Signed-in parent surfaces now use the live Worker hub payload instead of locally assembled synthetic memberships.
+          </p>
+          <div className="chip-row parent-hub-chips">
+            <span className="chip good">{model.permissions.platformRoleLabel}</span>
+            <span className="chip">{model.permissions.membershipRoleLabel}</span>
+            <span className={`chip ${model.permissions.canMutateLearnerData ? 'good' : 'warn'}`}>
+              {model.permissions.accessModeLabel || 'Learner access'}
+            </span>
+            <span className="chip">{`Last activity · ${formatTimestamp(model.learner.lastActivityAt)}`}</span>
           </div>
-          <div className="actions" style={{ alignItems: 'flex-end', justifyContent: 'flex-end' }}>
+        </div>
+
+        <aside className="parent-hub-hero-aside">
+          <div className="parent-hub-learner-select">
             <AdultLearnerSelect
               learners={accessibleLearners}
               selectedLearnerId={selectedLearnerId}
@@ -97,51 +239,52 @@ export function ParentHubSurface({ appState, model, hubState = {}, accessContext
               disabled={hubState.status === 'loading'}
               onSelect={(value) => actions.dispatch('adult-surface-learner-select', { value })}
             />
-            <div className="chip-row">
-              <span className="chip good">{model.permissions.platformRoleLabel}</span>
-              <span className="chip">{model.permissions.membershipRoleLabel}</span>
-              <span className={`chip ${model.permissions.canMutateLearnerData ? 'good' : 'warn'}`}>{model.permissions.accessModeLabel || 'Learner access'}</span>
-              <span className="chip">Last activity: {formatTimestamp(model.learner.lastActivityAt)}</span>
-            </div>
           </div>
-        </div>
-        {notice && <div className="feedback warn" style={{ marginTop: 16 }}>{notice}</div>}
-        <ReadOnlyLearnerNotice access={accessContext.activeAdultLearnerContext} writableLearner={writableLearner} />
+          <dl className="parent-hub-figures">
+            <HeadlineFigure label="Secure words" value={overview.secureWords ?? 0} tone="good" />
+            <HeadlineFigure label="Due" value={overview.dueWords ?? 0} tone="warn" />
+            <HeadlineFigure label="Trouble" value={overview.troubleWords ?? 0} tone="bad" />
+            <HeadlineFigure label="Accuracy" value={accuracyValue} />
+          </dl>
+        </aside>
       </section>
 
-      <section className="two-col" style={{ marginBottom: 20 }}>
-        <article className="card">
-          <div className="eyebrow">Learner overview</div>
-          <h3 className="section-title" style={{ fontSize: '1.2rem' }}>Current picture</h3>
-          <div className="stat-grid" style={{ marginTop: 16 }}>
-            <div className="stat"><div className="stat-label">Secure words</div><div className="stat-value">{overview.secureWords ?? 0}</div><div className="stat-sub">Spelling snapshot</div></div>
-            <div className="stat"><div className="stat-label">Due words</div><div className="stat-value">{overview.dueWords ?? 0}</div><div className="stat-sub">Spelling return</div></div>
-            <div className="stat"><div className="stat-label">Trouble words</div><div className="stat-value">{overview.troubleWords ?? 0}</div><div className="stat-sub">Recent spelling mistakes</div></div>
-            <div className="stat"><div className="stat-label">Spelling accuracy</div><div className="stat-value">{overview.accuracyPercent == null ? '—' : `${overview.accuracyPercent}%`}</div><div className="stat-sub">Durable word progress</div></div>
-            <div className="stat"><div className="stat-label">Grammar secured</div><div className="stat-value">{overview.secureGrammarConcepts ?? 0}</div><div className="stat-sub">Concepts secure</div></div>
-            <div className="stat"><div className="stat-label">Grammar review</div><div className="stat-value">{grammarReviewConcepts}</div><div className="stat-sub">{grammarDueConcepts} due · {grammarWeakConcepts} weak</div></div>
-            <div className="stat"><div className="stat-label">Grammar accuracy</div><div className="stat-value">{overview.grammarAccuracyPercent == null ? '—' : `${overview.grammarAccuracyPercent}%`}</div><div className="stat-sub">Concept evidence</div></div>
+      {notice ? <div className="feedback warn parent-hub-notice">{notice}</div> : null}
+      <ReadOnlyLearnerNotice access={accessContext.activeAdultLearnerContext} writableLearner={writableLearner} />
+
+      <SectionHead
+        title="Learner overview"
+        note={`Spelling and grammar at a glance for ${firstName}, with the focus parent surfaces are surfacing right now.`}
+      />
+      <section className="two-col parent-hub-grid">
+        <article className="card parent-hub-card parent-hub-card--overview">
+          <div className="parent-hub-card-head">
+            <p className="eyebrow">Current picture</p>
+            <h3 className="parent-hub-card-title">{`Where ${firstName} stands`}</h3>
           </div>
-          <div className="callout" style={{ marginTop: 16 }}>
-            <strong>Current focus</strong>
-            {dueWork.length ? dueWork.map((entry) => (
-              <div style={{ marginTop: 8 }} key={entry.label}>
-                <strong>{entry.label}</strong>
-                <div className="small muted">{entry.detail || ''}</div>
-              </div>
-            )) : <div className="small muted" style={{ marginTop: 8 }}>No due work is surfaced yet.</div>}
-          </div>
+          <StatGrid
+            overview={overview}
+            grammarReviewConcepts={grammarReviewConcepts}
+            grammarDueConcepts={grammarDueConcepts}
+            grammarWeakConcepts={grammarWeakConcepts}
+          />
+          <CurrentFocus items={dueWork} />
         </article>
-        <article className="card soft">
-          <div className="eyebrow">Progress snapshot / export</div>
-          <h3 className="section-title" style={{ fontSize: '1.2rem' }}>Portable recovery points</h3>
-          <p className="subtitle">Parent Hub only surfaces export entry points. It does not invent a separate reporting store.</p>
-          <div className="chip-row" style={{ marginTop: 14 }}>
+
+        <article className="card soft parent-hub-card parent-hub-card--snapshot">
+          <div className="parent-hub-card-head">
+            <p className="eyebrow">Progress snapshot / export</p>
+            <h3 className="parent-hub-card-title">Portable recovery points</h3>
+            <p className="parent-hub-card-lede">
+              Parent Hub only surfaces export entry points. It does not invent a separate reporting store.
+            </p>
+          </div>
+          <div className="chip-row parent-hub-snapshot-chips">
             {progressSnapshots.length ? progressSnapshots.map((snapshot, index) => (
               <span className="chip" key={`${snapshotSubjectId(snapshot)}-${index}`}>{snapshotChipLabel(snapshot)}</span>
             )) : <span className="chip">No subject snapshot</span>}
           </div>
-          <div className="actions" style={{ marginTop: 16 }}>
+          <div className="actions parent-hub-snapshot-actions">
             {(model.exportEntryPoints || []).map((entry) => (
               <button
                 className="btn secondary"
@@ -158,35 +301,44 @@ export function ParentHubSurface({ appState, model, hubState = {}, accessContext
         </article>
       </section>
 
-      <section className="two-col" style={{ marginBottom: 20 }}>
-        <article className="card">
-          <div className="eyebrow">Recent sessions</div>
-          <h3 className="section-title" style={{ fontSize: '1.2rem' }}>Latest durable session records</h3>
-          {recentSessions.length ? recentSessions.map((entry) => (
-            <details style={{ marginTop: 12 }} key={entry.id || entry.updatedAt}>
-              <summary>{entry.label} · {formatTimestamp(entry.updatedAt)}</summary>
-              <div className="small muted" style={{ marginTop: 10 }}>{entry.status} · {entry.sessionKind} · mistakes: {entry.mistakeCount || 0}</div>
-              {entry.headline && <div className="small muted" style={{ marginTop: 6 }}>Summary card: {entry.headline}</div>}
-            </details>
-          )) : <p className="small muted">No completed or active sessions are stored yet.</p>}
+      <SectionHead
+        title="Evidence stream"
+        note="Recent sessions and the misconceptions they keep uncovering."
+      />
+      <section className="two-col parent-hub-grid">
+        <article className="card parent-hub-card">
+          <div className="parent-hub-card-head">
+            <p className="eyebrow">Recent sessions</p>
+            <h3 className="parent-hub-card-title">Latest durable session records</h3>
+          </div>
+          <RecentSessionList sessions={recentSessions} />
         </article>
-        <article className="card">
-          <div className="eyebrow">Misconception patterns</div>
-          <h3 className="section-title" style={{ fontSize: '1.2rem' }}>Where correction is clustering</h3>
-          {patterns.length ? patterns.map((entry, index) => (
-            <div className="skill-row" key={`${entry.label}-${index}`}>
-              <div><strong>{entry.label}</strong></div>
-              <div className="small muted">{entry.source || 'pattern'}</div>
-              <div>{entry.count || 0}</div>
-              <div className="small muted">{formatTimestamp(entry.lastSeenAt)}</div>
-            </div>
-          )) : <p className="small muted">No durable mistake patterns have been recorded yet.</p>}
+        <article className="card parent-hub-card">
+          <div className="parent-hub-card-head">
+            <p className="eyebrow">Misconception patterns</p>
+            <h3 className="parent-hub-card-title">Where correction is clustering</h3>
+          </div>
+          <MisconceptionList patterns={patterns} />
         </article>
       </section>
 
-      <section className="two-col">
-        <HubStrengthList title="Broad strengths" items={strengths} emptyText="No broad strengths have emerged yet." />
-        <HubStrengthList title="Broad weaknesses" items={weaknesses} emptyText="No broad weaknesses have surfaced yet." />
+      <SectionHead
+        title="Durable signal"
+        note="Broad strengths and broad weaknesses, drawn from durable learner progress."
+      />
+      <section className="two-col parent-hub-grid">
+        <HubLedgerCard
+          title="Broad strengths"
+          items={strengths}
+          emptyText="No broad strengths have emerged yet."
+          tone="good"
+        />
+        <HubLedgerCard
+          title="Broad weaknesses"
+          items={weaknesses}
+          emptyText="No broad weaknesses have surfaced yet."
+          tone="warn"
+        />
       </section>
     </>
   );

--- a/styles/app.css
+++ b/styles/app.css
@@ -6859,3 +6859,525 @@ textarea:focus-visible {
     }
   }
 }
+
+/* ==========================================================
+   Parent Hub surface — editorial paper layout aligned to
+   home / codex / spelling. Eyebrow rhythm + Fraunces display
+   numerals, warm radial paper, hairline rules, --shadow-warm.
+   ========================================================== */
+
+.parent-hub-hero {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(280px, 0.8fr);
+  gap: 32px;
+  align-items: stretch;
+  padding: clamp(28px, 3.4vw, 40px) clamp(24px, 3.4vw, 38px) clamp(28px, 3.2vw, 36px);
+  border-radius: var(--radius-lg);
+  border: 1px solid color-mix(in oklab, var(--line-strong) 28%, var(--line));
+  background:
+    radial-gradient(140% 100% at 100% 0%, color-mix(in oklab, var(--inklet) 22%, transparent), transparent 58%),
+    radial-gradient(120% 100% at 0% 100%, color-mix(in oklab, var(--phaeton) 14%, transparent), transparent 60%),
+    var(--panel);
+  box-shadow: var(--shadow-warm);
+  overflow: hidden;
+  isolation: isolate;
+  animation: parent-hub-hero-rise 520ms var(--ease-out) both;
+}
+.parent-hub-hero::before,
+.parent-hub-hero::after {
+  content: "";
+  position: absolute;
+  left: clamp(20px, 3vw, 32px);
+  right: clamp(20px, 3vw, 32px);
+  height: 1px;
+  background: color-mix(in oklab, var(--line-strong) 60%, transparent);
+  z-index: 1;
+  pointer-events: none;
+}
+.parent-hub-hero::before { top: 22px; }
+.parent-hub-hero::after { bottom: 22px; }
+
+.parent-hub-hero-art {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(220px 160px at 88% 18%, color-mix(in oklab, var(--inklet) 18%, transparent), transparent 70%),
+    radial-gradient(260px 200px at 6% 88%, color-mix(in oklab, var(--phaeton) 14%, transparent), transparent 72%);
+  opacity: 0.85;
+}
+
+.parent-hub-hero-copy {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding-top: clamp(8px, 1.2vw, 18px);
+  max-width: 60ch;
+}
+.parent-hub-title {
+  margin: 0;
+  font-family: var(--font-serif);
+  font-size: clamp(2.2rem, 4.4vw, 3.2rem);
+  line-height: 1.02;
+  letter-spacing: -0.025em;
+  font-weight: 500;
+  color: var(--ink);
+}
+.parent-hub-lede {
+  margin: 0;
+  max-width: 44ch;
+  color: var(--ink-2);
+  line-height: 1.55;
+  font-size: 1rem;
+}
+.parent-hub-chips {
+  margin-top: 6px;
+}
+
+.parent-hub-hero-aside {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  align-items: stretch;
+  justify-content: flex-start;
+  padding-top: clamp(8px, 1.2vw, 18px);
+}
+.parent-hub-learner-select {
+  display: flex;
+  justify-content: flex-end;
+}
+.parent-hub-learner-select .field {
+  flex: 1 1 100%;
+  min-width: 0;
+}
+.parent-hub-learner-select .field span {
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.parent-hub-learner-select .select {
+  background: color-mix(in oklab, var(--panel) 92%, transparent);
+  border-color: color-mix(in oklab, var(--line-strong) 72%, var(--line));
+  font-weight: 600;
+}
+
+.parent-hub-figures {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0;
+  border-radius: 18px;
+  border: 1px solid color-mix(in oklab, var(--line-strong) 40%, var(--line));
+  background: color-mix(in oklab, var(--panel) 88%, transparent);
+  backdrop-filter: blur(2px);
+  overflow: hidden;
+}
+.parent-hub-figure {
+  position: relative;
+  margin: 0;
+  padding: 16px 18px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  border-right: 1px solid color-mix(in oklab, var(--line-soft) 80%, transparent);
+  border-bottom: 1px solid color-mix(in oklab, var(--line-soft) 80%, transparent);
+}
+.parent-hub-figure:nth-child(2n) { border-right: 0; }
+.parent-hub-figure:nth-last-child(-n+2) { border-bottom: 0; }
+.parent-hub-figure-label {
+  font-family: var(--font-sans);
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.parent-hub-figure-value {
+  margin: 0;
+  font-family: var(--font-serif);
+  font-size: clamp(1.7rem, 2.6vw, 2.15rem);
+  line-height: 1;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+  font-variant-numeric: tabular-nums lining-nums;
+}
+.parent-hub-figure.is-good .parent-hub-figure-value { color: var(--good-strong); }
+.parent-hub-figure.is-warn .parent-hub-figure-value { color: var(--warn-strong); }
+.parent-hub-figure.is-bad  .parent-hub-figure-value { color: var(--bad-strong); }
+
+.parent-hub-notice {
+  margin-top: 16px;
+}
+
+.parent-hub-section-head {
+  margin-top: 36px;
+}
+
+.parent-hub-grid {
+  margin-top: 16px;
+  align-items: stretch;
+}
+.parent-hub-grid .parent-hub-card {
+  height: 100%;
+}
+
+.parent-hub-card {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 24px 24px 22px;
+  border-radius: var(--radius);
+  border-color: color-mix(in oklab, var(--line-strong) 24%, var(--line));
+  box-shadow: var(--shadow-xs);
+  transition: transform var(--dur) var(--ease-out), box-shadow var(--dur) var(--ease-out);
+}
+.parent-hub-card.soft {
+  background: color-mix(in oklab, var(--panel-soft) 96%, var(--panel));
+}
+.parent-hub-card-head {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.parent-hub-card-head .eyebrow { margin-bottom: 0; }
+.parent-hub-card-title {
+  margin: 2px 0 0;
+  font-family: var(--font-serif);
+  font-size: 1.32rem;
+  line-height: 1.2;
+  letter-spacing: -0.015em;
+  font-weight: 500;
+  color: var(--ink);
+}
+.parent-hub-card-lede {
+  margin: 6px 0 0;
+  color: var(--ink-2);
+  font-size: 0.94rem;
+  line-height: 1.55;
+}
+
+.parent-hub-statgrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 10px;
+}
+.parent-hub-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 14px 14px 12px;
+  border-radius: 14px;
+  background: color-mix(in oklab, var(--panel-soft) 88%, var(--panel));
+  border: 1px solid color-mix(in oklab, var(--line-soft) 80%, var(--line));
+  position: relative;
+  overflow: hidden;
+}
+.parent-hub-stat::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: color-mix(in oklab, var(--line-strong) 55%, transparent);
+}
+.parent-hub-stat.is-warn { background: color-mix(in oklab, var(--warn-soft) 60%, var(--panel-soft)); }
+.parent-hub-stat.is-warn::before { background: var(--warn); }
+.parent-hub-stat.is-bad  { background: color-mix(in oklab, var(--bad-soft) 60%, var(--panel-soft)); }
+.parent-hub-stat.is-bad::before  { background: var(--bad); }
+.parent-hub-stat-label {
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.parent-hub-stat-value {
+  font-family: var(--font-serif);
+  font-size: 1.55rem;
+  font-weight: 500;
+  line-height: 1;
+  color: var(--ink);
+  font-variant-numeric: tabular-nums lining-nums;
+  letter-spacing: -0.015em;
+}
+.parent-hub-stat.is-warn .parent-hub-stat-value { color: var(--warn-strong); }
+.parent-hub-stat.is-bad  .parent-hub-stat-value { color: var(--bad-strong); }
+.parent-hub-stat-sub {
+  font-size: 0.78rem;
+  color: var(--muted);
+  line-height: 1.35;
+}
+
+.parent-hub-focus {
+  position: relative;
+  padding: 18px 18px 14px;
+  border-radius: 16px;
+  background: color-mix(in oklab, var(--panel-soft) 80%, var(--panel));
+  border: 1px solid color-mix(in oklab, var(--line-strong) 30%, var(--line-soft));
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.parent-hub-focus.is-empty .parent-hub-empty { margin: 0; }
+.parent-hub-focus .eyebrow { margin: 0; }
+.parent-hub-focus-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.parent-hub-focus-item {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 12px;
+  align-items: baseline;
+}
+.parent-hub-focus-marker {
+  font-family: var(--font-serif);
+  font-size: 1.05rem;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  color: color-mix(in oklab, var(--brand) 70%, var(--muted));
+  letter-spacing: 0.04em;
+  min-width: 2ch;
+}
+.parent-hub-focus-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.parent-hub-focus-body strong {
+  font-weight: 700;
+  color: var(--ink);
+  font-size: 0.98rem;
+}
+.parent-hub-focus-detail {
+  color: var(--ink-2);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.parent-hub-snapshot-chips {
+  margin-top: 4px;
+}
+.parent-hub-snapshot-actions {
+  margin-top: auto;
+  padding-top: 8px;
+}
+
+.parent-hub-session-list,
+.parent-hub-pattern-list,
+.parent-hub-ledger-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+}
+
+.parent-hub-session-list { gap: 4px; }
+.parent-hub-session-item {
+  border-top: 1px solid var(--line-soft);
+}
+.parent-hub-session-item:first-child { border-top: 0; }
+.parent-hub-session-item details {
+  border: 0;
+  padding: 12px 4px 12px;
+}
+.parent-hub-session-item summary {
+  list-style: none;
+  cursor: pointer;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 4px 0;
+  font-weight: 600;
+  color: var(--ink);
+  transition: color var(--dur) var(--ease-out);
+}
+.parent-hub-session-item summary::-webkit-details-marker { display: none; }
+.parent-hub-session-item summary::before {
+  content: "›";
+  font-family: var(--font-serif);
+  font-size: 1.2rem;
+  line-height: 1;
+  color: var(--muted);
+  margin-right: 8px;
+  transform-origin: center;
+  transition: transform var(--dur) var(--ease-out), color var(--dur) var(--ease-out);
+}
+.parent-hub-session-item details[open] summary::before {
+  transform: rotate(90deg);
+  color: var(--brand);
+}
+.parent-hub-session-item summary:hover { color: var(--brand-ink); }
+.parent-hub-session-label {
+  font-family: var(--font-serif);
+  font-size: 1.02rem;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.parent-hub-session-time {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  font-variant-numeric: tabular-nums;
+}
+.parent-hub-session-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 10px 0 0 24px;
+}
+.parent-hub-session-summary {
+  margin: 8px 0 0 24px;
+  color: var(--ink-2);
+  font-size: 0.94rem;
+  line-height: 1.55;
+}
+
+.parent-hub-pattern-list { gap: 0; }
+.parent-hub-pattern-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) auto minmax(0, 0.9fr);
+  align-items: baseline;
+  gap: 14px;
+  padding: 12px 0;
+  border-top: 1px solid var(--line-soft);
+}
+.parent-hub-pattern-item:first-child { border-top: 0; }
+.parent-hub-pattern-main {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.parent-hub-pattern-main strong {
+  font-weight: 700;
+  color: var(--ink);
+  font-size: 0.98rem;
+}
+.parent-hub-pattern-count {
+  font-family: var(--font-serif);
+  font-size: 1.6rem;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums lining-nums;
+  letter-spacing: -0.02em;
+  line-height: 1;
+  color: var(--ink);
+  justify-self: end;
+}
+.parent-hub-row-detail {
+  font-size: 0.86rem;
+  color: var(--muted);
+  line-height: 1.4;
+}
+.parent-hub-row-meta {
+  font-size: 0.82rem;
+  color: var(--muted);
+  letter-spacing: 0.01em;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.parent-hub-ledger-list { gap: 0; }
+.parent-hub-ledger-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1.5fr) auto minmax(0, 0.9fr);
+  align-items: baseline;
+  gap: 14px;
+  padding: 14px 0;
+  border-top: 1px solid var(--line-soft);
+}
+.parent-hub-ledger-row:first-child { border-top: 0; }
+.parent-hub-ledger-main {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.parent-hub-ledger-main strong {
+  font-weight: 700;
+  color: var(--ink);
+  font-size: 1.02rem;
+  letter-spacing: -0.005em;
+}
+.parent-hub-ledger-figure {
+  font-family: var(--font-serif);
+  font-size: 1.7rem;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums lining-nums;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+  justify-self: end;
+}
+.parent-hub-ledger-figure.is-good { color: var(--good-strong); }
+.parent-hub-ledger-figure.is-warn { color: var(--warn-strong); }
+
+.parent-hub-empty {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
+.parent-hub-loading {
+  margin: 0 auto;
+  max-width: 520px;
+}
+
+@keyframes parent-hub-hero-rise {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (max-width: 980px) {
+  .parent-hub-hero {
+    grid-template-columns: 1fr;
+    gap: 22px;
+    padding: 28px 22px 24px;
+  }
+  .parent-hub-hero::before,
+  .parent-hub-hero::after {
+    left: 18px;
+    right: 18px;
+  }
+  .parent-hub-hero-aside { padding-top: 0; }
+  .parent-hub-learner-select { justify-content: flex-start; }
+  .parent-hub-pattern-item,
+  .parent-hub-ledger-row {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+  .parent-hub-row-meta {
+    grid-column: 1 / -1;
+    text-align: left;
+  }
+}
+
+@media (max-width: 640px) {
+  .parent-hub-hero { padding: 22px 18px 20px; }
+  .parent-hub-figures { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .parent-hub-figure { padding: 14px 14px 12px; }
+  .parent-hub-figure-value { font-size: 1.6rem; }
+  .parent-hub-card { padding: 20px 18px 18px; }
+  .parent-hub-section-head { margin-top: 28px; }
+  .parent-hub-pattern-count,
+  .parent-hub-ledger-figure { font-size: 1.4rem; }
+}


### PR DESCRIPTION
## Summary
- Rewrites `ParentHubSurface.jsx` with a Fraunces-led editorial hero (warm radial paper, top/bottom hairline rules, `--shadow-warm`) so Parent Hub finally reads like Home and Codex instead of the legacy subject-header banner.
- Adds a 4-cell headline `dl` of pull figures (Secure / Due / Trouble / Accuracy), tone-coded `parent-hub-stat` cells with 3px accent bars, a numbered current-focus list, and editorial details-driven session / pattern / ledger lists.
- Appends a self-contained `.parent-hub-*` CSS section (~520 lines) using existing tokens (`--inklet`, `--phaeton`, `--font-serif`, `--shadow-warm`, `--radius-lg`) so dark mode and responsive breakpoints (980px / 640px) come for free.

## Behaviour preserved
- Loading / error / permission-denied gates intact (same `AccessDeniedCard` paths).
- `AdultLearnerSelect`, `ReadOnlyLearnerNotice` (with the "viewer memberships" copy), notice banner, and `selectedWritableLearner` wiring kept.
- Full 7-stat overview (`Trouble words`, `Grammar secured`, `Grammar accuracy` etc.), snapshot chips (`Spelling: 213/235 words`, `Grammar: 3/18 concepts`), and `Export current learner` button still render with `disabled=""` / `aria-disabled` for read-only learners.
- Recent sessions, misconception patterns, broad strengths and broad weaknesses all preserved.

## Test plan
- [x] `npm test` (533 tests, 532 pass, 1 KS2_BROWSER_SMOKE skip) — including `tests/react-hub-surfaces.test.js`
- [x] `npm run build` (bundle 497.4kb)
- [x] `npm run check` (wrangler OAuth dry-run deploy)
- [x] Spot-check rendered HTML for all required strings + new design classes (13/13)
- [ ] Manual visual smoke on `/parent-hub` after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)