### PR TITLE
feat(grammar): enable worked and faded support

### DIFF
--- a/docs/plans/2026-04-24-001-feat-grammar-mastery-region-plan.md
+++ b/docs/plans/2026-04-24-001-feat-grammar-mastery-region-plan.md
@@ -1,8 +1,9 @@
 ---
 title: "feat: Full Grammar Mastery Region"
 type: feat
-status: active
+status: live-checklist
 date: 2026-04-24
+last_checked: 2026-04-24
 origin: docs/brainstorms/2026-04-24-grammar-mastery-region-requirements.md
 deepened: 2026-04-24
 ---
@@ -16,6 +17,29 @@ Build The Clause Conservatory as the full Grammar region, delivered in stages. S
 The full target is the legacy Grammar mastery model: 18 KS2 Grammar / GPS concepts, 51 deterministic templates, misconception-aware feedback, spaced review, KS2-style mini-tests, and seven Grammar monsters. The game layer derives from secured learning evidence only. It must never influence marking, scheduling, retry queues, or mastery status.
 
 This plan assumes the full-lockdown runtime direction continues: React renders UI and submitted form state, while production scored session creation, marking, scheduling, persistence, domain events, reward projection, and read models are Worker-owned.
+
+## Live Checklist Snapshot
+
+This plan is now a live checklist for the Grammar line. The original plan text below preserves the implementation rationale and staged sequencing, while this snapshot reflects the current branch target after the Grammar production-smoke and sentence-builder work has landed.
+
+Current Grammar state:
+
+- [x] Grammar is a Worker-owned production subject behind `POST /api/subjects/grammar/command`.
+- [x] The Clause Conservatory surface is live as the real Grammar subject route, not the placeholder.
+- [x] Current content release id is `grammar-legacy-reviewed-2026-04-24`.
+- [x] The full denominator is represented: 18 KS2 Grammar / GPS concepts and 51 deterministic templates.
+- [x] Analytics read models expose concept status, misconception patterns, question-type weakness, recent activity, and evidence summaries.
+- [x] All seven Grammar monsters are wired as derived reward progress from secured Grammar evidence.
+- [x] Enabled Grammar modes cover learn, smart mixed review, KS2-style mini-set, weak concepts drill, sentence surgery, sentence builder, worked examples, and faded guidance.
+- [x] Strict KS2-style mini-set mode remains unsupported by pre-answer worked/faded guidance.
+- [x] Production smoke exists as `npm run smoke:production:grammar`.
+
+Open Grammar follow-up scope:
+
+- [ ] Add the optional AI enrichment safe lane for explanations, revision cards, and parent-summary drafts; AI must remain non-scored and server-side.
+- [ ] Add transfer and Bellstorm bridge placeholders without collapsing Grammar and Punctuation product identities.
+- [ ] Decide later whether paragraph-level transfer becomes non-scored, teacher-reviewed, or a separate deterministic workflow.
+- [ ] Continue to run `npm test`, `npm run check`, and Grammar production/UI smoke for each shipped Grammar slice.
 
 ---
 
@@ -587,7 +611,7 @@ sequenceDiagram
 **Verification:**
 - Grammar rewards are derived, subject-aware, asset-backed, and non-regressive for existing spelling rewards.
 
-- [ ] U6. **Add Stage 1 Analytics And Parent Evidence Read Models**
+- [x] U6. **Add Stage 1 Analytics And Parent Evidence Read Models**
 
 **Goal:** Provide educational evidence first and reward progress second for learner and adult-facing Grammar surfaces.
 
@@ -624,7 +648,7 @@ sequenceDiagram
 **Verification:**
 - Grammar progress can be explained without the game layer, and the game layer remains visibly secondary.
 
-- [ ] U7. **Add Full Legacy Practice Modes**
+- [x] U7. **Add Full Legacy Practice Modes**
 
 **Goal:** Complete the legacy practice experience beyond Stage 1 core modes.
 
@@ -732,7 +756,7 @@ sequenceDiagram
 **Verification:**
 - Full roadmap is visible in product UI without creating fake functionality or collapsing subject identities.
 
-- [ ] U10. **Release Gate And Production Verification**
+- [x] U10. **Release Gate And Production Verification**
 
 **Goal:** Treat Grammar as production-sensitive and verify it without weakening Spelling, bundle lockdown, or deployment safety.
 

--- a/src/subjects/grammar/components/GrammarSessionScene.jsx
+++ b/src/subjects/grammar/components/GrammarSessionScene.jsx
@@ -132,6 +132,48 @@ function FeedbackPanel({ feedback }) {
   );
 }
 
+function GuidancePanel({ support }) {
+  if (!support) return null;
+  const worked = support.kind === 'worked';
+  const concepts = Array.isArray(support.concepts) ? support.concepts : [];
+  const notices = Array.isArray(support.notices) ? support.notices.filter(Boolean) : [];
+  const example = support.workedExample || {};
+  const contrast = support.contrast || {};
+
+  return (
+    <aside className={`grammar-guidance ${worked ? 'worked' : 'faded'}`} aria-label={support.title || 'Grammar guidance'}>
+      <div className="grammar-guidance-head">
+        <span className="chip good">{support.title || (worked ? 'Worked example' : 'Faded guidance')}</span>
+        {concepts[0]?.name ? <strong>{concepts[0].name}</strong> : null}
+      </div>
+
+      {worked && (example.prompt || example.exampleResponse || example.why) ? (
+        <div className="grammar-guidance-example">
+          {example.prompt ? <p><span>Prompt</span>{example.prompt}</p> : null}
+          {example.exampleResponse ? <p><span>Model</span>{example.exampleResponse}</p> : null}
+          {example.why ? <p><span>Why</span>{example.why}</p> : null}
+        </div>
+      ) : null}
+
+      {!worked && support.summary ? <p className="grammar-guidance-summary">{support.summary}</p> : null}
+
+      {!worked && (contrast.secureExample || contrast.nearMiss || contrast.why) ? (
+        <div className="grammar-guidance-contrast">
+          {contrast.secureExample ? <p><span>Secure</span>{contrast.secureExample}</p> : null}
+          {contrast.nearMiss ? <p><span>Near miss</span>{contrast.nearMiss}</p> : null}
+          {contrast.why ? <p><span>Check</span>{contrast.why}</p> : null}
+        </div>
+      ) : null}
+
+      {notices.length ? (
+        <ul className="grammar-guidance-notices">
+          {notices.map((notice) => <li key={notice}>{notice}</li>)}
+        </ul>
+      ) : null}
+    </aside>
+  );
+}
+
 export function GrammarSessionScene({ grammar, actions, runtimeReadOnly }) {
   const session = grammar.session || {};
   const item = session.currentItem || {};
@@ -162,6 +204,7 @@ export function GrammarSessionScene({ grammar, actions, runtimeReadOnly }) {
         </div>
         <p className="grammar-prompt">{item.promptText || 'Loading the next Grammar item...'}</p>
         {item.checkLine ? <p className="grammar-check-line">{item.checkLine}</p> : null}
+        <GuidancePanel support={session.supportGuidance} />
 
         <form
           className="grammar-answer-form"

--- a/src/subjects/grammar/components/GrammarSetupScene.jsx
+++ b/src/subjects/grammar/components/GrammarSetupScene.jsx
@@ -59,8 +59,8 @@ export function GrammarSetupScene({ learner, grammar, actions, runtimeReadOnly }
           <div className="eyebrow">Clause Conservatory</div>
           <h2 id="grammar-setup-title">Grammar retrieval practice</h2>
           <p>
-            {learner?.name || 'This learner'} can start with the Stage 1 Worker-marked grammar engine,
-            while the full concept map stays visible for the larger product build.
+            {learner?.name || 'This learner'} can practise with Worker-marked grammar modes while the
+            full concept map stays visible for the larger product build.
           </p>
           <div className="grammar-hero-stats" aria-label="Grammar coverage">
             <Stat label="Concepts" value={counts.total || 18} detail="full map" />
@@ -74,7 +74,7 @@ export function GrammarSetupScene({ learner, grammar, actions, runtimeReadOnly }
         <section className="card grammar-start-card" aria-labelledby="grammar-start-title">
           <div className="card-header">
             <div>
-              <div className="eyebrow">Stage 1 practice</div>
+              <div className="eyebrow">Worker-marked modes</div>
               <h3 className="section-title" id="grammar-start-title">Start a Grammar round</h3>
             </div>
             <span className="chip good">Worker marked</span>

--- a/src/subjects/grammar/metadata.js
+++ b/src/subjects/grammar/metadata.js
@@ -138,12 +138,11 @@ export const GRAMMAR_ENABLED_MODES = Object.freeze([
   { id: 'trouble', label: 'Weak concepts drill', detail: 'Targets the weakest Grammar concepts with retry pressure.' },
   { id: 'surgery', label: 'Sentence surgery', detail: 'Fix and rewrite sentence-level Grammar errors.' },
   { id: 'builder', label: 'Sentence builder', detail: 'Build and rewrite sentences from structured prompts.' },
+  { id: 'worked', label: 'Worked examples', detail: 'Practise with a model example before answering.' },
+  { id: 'faded', label: 'Faded guidance', detail: 'Practise with prompts and contrasts, but no answer to the current item.' },
 ]);
 
-export const GRAMMAR_LOCKED_MODES = Object.freeze([
-  { id: 'worked', label: 'Worked examples', reason: 'coming-next' },
-  { id: 'faded', label: 'Faded guidance', reason: 'coming-next' },
-]);
+export const GRAMMAR_LOCKED_MODES = Object.freeze([]);
 
 export const GRAMMAR_MONSTER_ROUTES = Object.freeze([
   {

--- a/src/subjects/grammar/module.js
+++ b/src/subjects/grammar/module.js
@@ -17,7 +17,10 @@ function selectedGrammarUi(context) {
 function grammarModeKey(value) {
   const mode = String(value || '').trim().toLowerCase().replace(/[\s_]+/g, '-');
   if (mode === 'sentence-builder') return 'builder';
-  return mode === 'sentence-surgery' ? 'surgery' : mode;
+  if (mode === 'sentence-surgery') return 'surgery';
+  if (mode === 'worked-example' || mode === 'worked-examples') return 'worked';
+  if (mode === 'faded-support' || mode === 'faded-guidance') return 'faded';
+  return mode;
 }
 
 function grammarModeUsesFocus(value) {

--- a/styles/app.css
+++ b/styles/app.css
@@ -6475,6 +6475,65 @@ textarea:focus-visible {
   line-height: 1.5;
 }
 
+.grammar-guidance {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+  border: 1px solid #c5d9cf;
+  border-radius: 8px;
+  background: #f4faf6;
+  color: var(--ink);
+}
+
+.grammar-guidance.faded {
+  border-color: #d9caa7;
+  background: #fff8eb;
+}
+
+.grammar-guidance-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+}
+
+.grammar-guidance-head strong {
+  font-size: 0.96rem;
+}
+
+.grammar-guidance-example,
+.grammar-guidance-contrast {
+  display: grid;
+  gap: 8px;
+}
+
+.grammar-guidance-example p,
+.grammar-guidance-contrast p,
+.grammar-guidance-summary {
+  margin: 0;
+  line-height: 1.48;
+}
+
+.grammar-guidance-example span,
+.grammar-guidance-contrast span {
+  display: inline-block;
+  min-width: 74px;
+  margin-right: 8px;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.grammar-guidance-notices {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding-left: 18px;
+  color: var(--ink-2);
+  line-height: 1.45;
+}
+
 .grammar-answer-form {
   display: grid;
   gap: 16px;

--- a/tests/grammar-engine.test.js
+++ b/tests/grammar-engine.test.js
@@ -505,6 +505,85 @@ test('Grammar sentence builder rejects explicit non-builder templates', () => {
   }), (error) => error?.extra?.code === 'grammar_template_unavailable_for_mode');
 });
 
+test('Grammar worked and faded modes apply supported scoring levels', () => {
+  const oracle = readGrammarLegacyOracle();
+  const sample = oracle.templates.find((template) => template.id === 'fronted_adverbial_choose');
+  const engine = createServerGrammarEngine({ now: () => 1_777_000_000_000 });
+
+  const worked = engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: {},
+    command: 'start-session',
+    requestId: 'start-worked',
+    payload: {
+      mode: 'worked',
+      roundLength: 1,
+      templateId: sample.id,
+      seed: sample.sample.seed,
+    },
+  });
+  assert.equal(worked.state.session.mode, 'worked');
+  assert.equal(worked.state.session.type, 'worked-example');
+  assert.equal(worked.state.session.supportLevel, 2);
+
+  const workedSubmit = engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: { ui: worked.state, data: worked.data },
+    latestSession: worked.practiceSession,
+    command: 'submit-answer',
+    requestId: 'submit-worked',
+    payload: { response: sample.correctResponse },
+  });
+  assert.equal(workedSubmit.state.recentAttempts.at(-1).supportLevel, 2);
+
+  const faded = engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: {},
+    command: 'start-session',
+    requestId: 'start-faded',
+    payload: {
+      mode: 'faded',
+      roundLength: 1,
+      templateId: sample.id,
+      seed: sample.sample.seed,
+    },
+  });
+  assert.equal(faded.state.session.mode, 'faded');
+  assert.equal(faded.state.session.type, 'faded-guidance');
+  assert.equal(faded.state.session.supportLevel, 1);
+});
+
+test('Grammar strict mini-set rejects pre-answer support payloads', () => {
+  const oracle = readGrammarLegacyOracle();
+  const sample = oracle.templates.find((template) => template.id === 'fronted_adverbial_choose');
+  const engine = createServerGrammarEngine({ now: () => 1_777_000_000_000 });
+
+  const start = engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: {},
+    command: 'start-session',
+    requestId: 'start-strict-support',
+    payload: {
+      mode: 'satsset',
+      roundLength: 1,
+      templateId: sample.id,
+      seed: sample.sample.seed,
+    },
+  });
+
+  assert.throws(() => engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: { ui: start.state, data: start.data },
+    latestSession: start.practiceSession,
+    command: 'submit-answer',
+    requestId: 'submit-strict-support',
+    payload: {
+      response: sample.correctResponse,
+      supportLevel: 1,
+    },
+  }), (error) => error?.extra?.code === 'grammar_support_unavailable_for_mode');
+});
+
 test('Grammar save-prefs clears completed summary state', () => {
   const oracle = readGrammarLegacyOracle();
   const sample = oracle.templates.find((template) => template.id === 'question_mark_select');

--- a/tests/react-grammar-surface.test.js
+++ b/tests/react-grammar-surface.test.js
@@ -348,19 +348,19 @@ test('Grammar normaliser upgrades stale persisted mode capabilities', () => {
         { id: 'trouble', label: 'Weak concepts drill', reason: 'coming-next' },
         { id: 'surgery', label: 'Sentence surgery', reason: 'coming-next' },
         { id: 'builder', label: 'Sentence builder', reason: 'coming-next' },
+        { id: 'worked', label: 'Worked examples', reason: 'coming-next' },
+        { id: 'faded', label: 'Faded guidance', reason: 'coming-next' },
       ],
     },
   });
 
-  assert.equal(grammar.capabilities.enabledModes.some((mode) => mode.id === 'trouble'), true);
-  assert.equal(grammar.capabilities.lockedModes.some((mode) => mode.id === 'trouble'), false);
-  assert.equal(grammar.capabilities.enabledModes.some((mode) => mode.id === 'surgery'), true);
-  assert.equal(grammar.capabilities.lockedModes.some((mode) => mode.id === 'surgery'), false);
-  assert.equal(grammar.capabilities.enabledModes.some((mode) => mode.id === 'builder'), true);
-  assert.equal(grammar.capabilities.lockedModes.some((mode) => mode.id === 'builder'), false);
+  for (const modeId of ['trouble', 'surgery', 'builder', 'worked', 'faded']) {
+    assert.equal(grammar.capabilities.enabledModes.some((mode) => mode.id === modeId), true, modeId);
+    assert.equal(grammar.capabilities.lockedModes.some((mode) => mode.id === modeId), false, modeId);
+  }
 });
 
-test('Grammar locked future modes render unavailable without dispatching commands', () => {
+test('Grammar legacy modes render available without locked placeholders', () => {
   const storage = installMemoryStorage();
   const harness = createAppHarness({ storage });
 
@@ -373,8 +373,11 @@ test('Grammar locked future modes render unavailable without dispatching command
   assert.doesNotMatch(html, /<button class="grammar-mode locked" type="button" disabled="">[\s\S]*Sentence surgery/);
   assert.match(html, /<button class="grammar-mode" type="button">[\s\S]*Sentence builder/);
   assert.doesNotMatch(html, /<button class="grammar-mode locked" type="button" disabled="">[\s\S]*Sentence builder/);
-  assert.match(html, /Worked examples[\s\S]*Coming next/);
-  assert.match(html, /button class="grammar-mode locked" type="button" disabled=""/);
+  assert.match(html, /<button class="grammar-mode" type="button">[\s\S]*Worked examples/);
+  assert.doesNotMatch(html, /<button class="grammar-mode locked" type="button" disabled="">[\s\S]*Worked examples/);
+  assert.match(html, /<button class="grammar-mode" type="button">[\s\S]*Faded guidance/);
+  assert.doesNotMatch(html, /<button class="grammar-mode locked" type="button" disabled="">[\s\S]*Faded guidance/);
+  assert.doesNotMatch(html, /Coming next/);
 });
 
 test('Grammar setup can start trouble drill mode', () => {
@@ -490,4 +493,56 @@ test('Grammar setup can start sentence builder mode', () => {
   assert.equal(grammar.session.type, 'sentence-builder');
   assert.equal(grammar.session.focusConceptId, '');
   assert.match(grammar.session.currentItem.questionType, /^(build|rewrite)$/);
+});
+
+test('Grammar setup can start worked example mode with guidance', () => {
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-set-focus', { value: 'word_classes' });
+  harness.dispatch('grammar-set-mode', { value: 'worked' });
+  assert.equal(harness.store.getState().subjectUi.grammar.prefs.mode, 'worked');
+  assert.equal(harness.store.getState().subjectUi.grammar.prefs.focusConceptId, 'word_classes');
+
+  harness.dispatch('grammar-start', {
+    payload: {
+      roundLength: 1,
+      seed: 123,
+    },
+  });
+
+  const grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.phase, 'session');
+  assert.equal(grammar.session.mode, 'worked');
+  assert.equal(grammar.session.type, 'worked-example');
+  assert.equal(grammar.session.supportLevel, 2);
+  assert.equal(grammar.session.supportGuidance.kind, 'worked');
+  assert.match(harness.render(), /Worked example/);
+  assert.match(harness.render(), /Model/);
+});
+
+test('Grammar setup can start faded guidance mode with lower support', () => {
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-set-mode', { value: 'faded' });
+  assert.equal(harness.store.getState().subjectUi.grammar.prefs.mode, 'faded');
+
+  harness.dispatch('grammar-start', {
+    payload: {
+      roundLength: 1,
+      seed: 123,
+    },
+  });
+
+  const grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.phase, 'session');
+  assert.equal(grammar.session.mode, 'faded');
+  assert.equal(grammar.session.type, 'faded-guidance');
+  assert.equal(grammar.session.supportLevel, 1);
+  assert.equal(grammar.session.supportGuidance.kind, 'faded');
+  assert.match(harness.render(), /Faded guidance/);
+  assert.match(harness.render(), /Near miss/);
 });

--- a/tests/worker-grammar-subject-runtime.test.js
+++ b/tests/worker-grammar-subject-runtime.test.js
@@ -85,10 +85,14 @@ test('worker subject runtime registers Grammar command handlers', async () => {
     'trouble',
     'surgery',
     'builder',
+    'worked',
+    'faded',
   ]);
   assert.equal(result.subjectReadModel.capabilities.lockedModes.some((mode) => mode.id === 'trouble'), false);
   assert.equal(result.subjectReadModel.capabilities.lockedModes.some((mode) => mode.id === 'surgery'), false);
   assert.equal(result.subjectReadModel.capabilities.lockedModes.some((mode) => mode.id === 'builder'), false);
+  assert.equal(result.subjectReadModel.capabilities.lockedModes.some((mode) => mode.id === 'worked'), false);
+  assert.equal(result.subjectReadModel.capabilities.lockedModes.some((mode) => mode.id === 'faded'), false);
 });
 
 test('worker subject runtime starts Grammar trouble drills against weak concepts', async () => {
@@ -342,6 +346,63 @@ test('Grammar command route accepts sentence builder mode', async () => {
   assert.equal(start.body.subjectReadModel.session.focusConceptId, '');
   assert.match(start.body.subjectReadModel.session.currentItem.questionType, /^(build|rewrite)$/);
   assert.equal(start.body.subjectReadModel.capabilities.lockedModes.some((mode) => mode.id === 'builder'), false);
+
+  DB.close();
+});
+
+test('Grammar command route accepts worked example mode with concept guidance', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const app = createWorkerApp({ now: () => 1_777_000_000_000 });
+  seedAccountLearner(DB);
+
+  const start = await postCommand(app, DB, {
+    command: 'start-session',
+    learnerId: 'learner-a',
+    requestId: 'grammar-worked-route-start',
+    expectedLearnerRevision: 0,
+    payload: {
+      mode: 'worked',
+      roundLength: 1,
+      seed: 120,
+    },
+  });
+
+  assert.equal(start.response.status, 200, JSON.stringify(start.body));
+  assert.equal(start.body.subjectReadModel.session.mode, 'worked');
+  assert.equal(start.body.subjectReadModel.session.type, 'worked-example');
+  assert.equal(start.body.subjectReadModel.session.supportLevel, 2);
+  assert.equal(start.body.subjectReadModel.session.supportGuidance.kind, 'worked');
+  assert.ok(start.body.subjectReadModel.session.supportGuidance.workedExample.exampleResponse);
+  assert.equal(start.body.subjectReadModel.capabilities.lockedModes.some((mode) => mode.id === 'worked'), false);
+
+  DB.close();
+});
+
+test('Grammar command route accepts faded guidance mode without current-answer leakage', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const app = createWorkerApp({ now: () => 1_777_000_000_000 });
+  seedAccountLearner(DB);
+
+  const start = await postCommand(app, DB, {
+    command: 'start-session',
+    learnerId: 'learner-a',
+    requestId: 'grammar-faded-route-start',
+    expectedLearnerRevision: 0,
+    payload: {
+      mode: 'faded',
+      roundLength: 1,
+      seed: 120,
+    },
+  });
+
+  assert.equal(start.response.status, 200, JSON.stringify(start.body));
+  assert.equal(start.body.subjectReadModel.session.mode, 'faded');
+  assert.equal(start.body.subjectReadModel.session.type, 'faded-guidance');
+  assert.equal(start.body.subjectReadModel.session.supportLevel, 1);
+  assert.equal(start.body.subjectReadModel.session.supportGuidance.kind, 'faded');
+  assert.equal(start.body.subjectReadModel.session.currentItem.solutionLines, undefined);
+  assert.equal(start.body.subjectReadModel.session.supportGuidance.workedExample, undefined);
+  assert.equal(start.body.subjectReadModel.capabilities.lockedModes.some((mode) => mode.id === 'faded'), false);
 
   DB.close();
 });

--- a/tests/worker-grammar-subject-runtime.test.js
+++ b/tests/worker-grammar-subject-runtime.test.js
@@ -407,6 +407,70 @@ test('Grammar command route accepts faded guidance mode without current-answer l
   DB.close();
 });
 
+test('Grammar faded guidance omits contrast examples that match current options', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const app = createWorkerApp({ now: () => 1_777_000_000_000 });
+  seedAccountLearner(DB);
+
+  const start = await postCommand(app, DB, {
+    command: 'start-session',
+    learnerId: 'learner-a',
+    requestId: 'grammar-faded-formality-leakage',
+    expectedLearnerRevision: 0,
+    payload: {
+      mode: 'faded',
+      roundLength: 1,
+      templateId: 'proc2_formality_choice',
+      seed: 1,
+    },
+  });
+
+  assert.equal(start.response.status, 200, JSON.stringify(start.body));
+  const session = start.body.subjectReadModel.session;
+  const optionLabels = session.currentItem.inputSpec.options.map((option) => option.label);
+  assert.ok(optionLabels.includes('The club was established last year.'));
+  assert.ok(optionLabels.includes('The club got set up last year.'));
+  assert.equal(session.supportGuidance.kind, 'faded');
+  assert.equal(session.supportGuidance.contrast.secureExample, undefined);
+  assert.equal(session.supportGuidance.contrast.nearMiss, undefined);
+  assert.equal(session.supportGuidance.contrast.why, 'The first is more formal.');
+  assert.equal(JSON.stringify(session.supportGuidance).includes('The club was established last year.'), false);
+  assert.equal(JSON.stringify(session.supportGuidance).includes('The club got set up last year.'), false);
+
+  DB.close();
+});
+
+test('Grammar worked guidance omits model answers that match current table rows', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const app = createWorkerApp({ now: () => 1_777_000_000_000 });
+  seedAccountLearner(DB);
+
+  const start = await postCommand(app, DB, {
+    command: 'start-session',
+    learnerId: 'learner-a',
+    requestId: 'grammar-worked-row-leakage',
+    expectedLearnerRevision: 0,
+    payload: {
+      mode: 'worked',
+      roundLength: 1,
+      templateId: 'sentence_type_table',
+      seed: 4,
+    },
+  });
+
+  assert.equal(start.response.status, 200, JSON.stringify(start.body));
+  const session = start.body.subjectReadModel.session;
+  const rowLabels = session.currentItem.inputSpec.rows.map((row) => row.label);
+  assert.ok(rowLabels.includes('Close the gate before the dog escapes.'));
+  assert.equal(session.supportGuidance.kind, 'worked');
+  assert.equal(session.supportGuidance.workedExample.prompt, 'Which sentence is a command?');
+  assert.equal(session.supportGuidance.workedExample.exampleResponse, undefined);
+  assert.equal(session.supportGuidance.workedExample.why, 'It tells someone to do something.');
+  assert.equal(JSON.stringify(session.supportGuidance).includes('Close the gate before the dog escapes.'), false);
+
+  DB.close();
+});
+
 test('Grammar command route rejects non-builder template overrides in builder mode', async () => {
   const DB = createMigratedSqliteD1Database();
   const app = createWorkerApp({ now: () => 1_777_000_000_000 });

--- a/worker/src/subjects/grammar/engine.js
+++ b/worker/src/subjects/grammar/engine.js
@@ -20,8 +20,8 @@ const DEFAULT_MINI_SET_LENGTH = 8;
 const SHORT_RESPONSE_TEXT_LIMIT = 512;
 const LONG_RESPONSE_TEXT_LIMIT = 2000;
 const LIST_RESPONSE_LIMIT = 40;
-const ENABLED_MODES = new Set(['learn', 'smart', 'satsset', 'trouble', 'surgery', 'builder']);
-const LOCKED_MODES = Object.freeze(['worked', 'faded']);
+const ENABLED_MODES = new Set(['learn', 'smart', 'satsset', 'trouble', 'surgery', 'builder', 'worked', 'faded']);
+const LOCKED_MODES = Object.freeze([]);
 const NO_STORED_FOCUS_MODES = new Set(['trouble', 'surgery', 'builder']);
 const NO_SESSION_FOCUS_MODES = new Set(['surgery', 'builder']);
 const GRAMMAR_CONCEPT_IDS = new Set(GRAMMAR_CONCEPTS.map((concept) => concept.id));
@@ -366,6 +366,22 @@ function answerQuality(result, attempt = {}) {
   return 0;
 }
 
+function supportLevelForMode(mode) {
+  if (mode === 'worked') return 2;
+  if (mode === 'faded') return 1;
+  return 0;
+}
+
+function sessionTypeForMode(mode) {
+  if (mode === 'satsset') return 'mini-set';
+  if (mode === 'trouble') return 'trouble-drill';
+  if (mode === 'surgery') return 'sentence-surgery';
+  if (mode === 'builder') return 'sentence-builder';
+  if (mode === 'worked') return 'worked-example';
+  if (mode === 'faded') return 'faded-guidance';
+  return 'practice';
+}
+
 function bumpMisconception(state, tag, nowTs) {
   if (!tag) return;
   const current = isPlainObject(state.misconceptions[tag]) ? state.misconceptions[tag] : { count: 0, lastSeenAt: null };
@@ -510,6 +526,8 @@ function normaliseMode(value) {
   if (mode === 'mini-set' || mode === 'mini' || mode === 'test') return 'satsset';
   if (mode === 'sentence-surgery') return 'surgery';
   if (mode === 'sentence-builder') return 'builder';
+  if (mode === 'worked-example' || mode === 'worked-examples') return 'worked';
+  if (mode === 'faded-support' || mode === 'faded-guidance') return 'faded';
   return mode || 'smart';
 }
 
@@ -641,11 +659,7 @@ function startSession(state, payload, nowTs, learnerId) {
   };
   state.session = {
     id: sessionId,
-    type: mode === 'satsset'
-      ? 'mini-set'
-      : (mode === 'trouble'
-        ? 'trouble-drill'
-        : (mode === 'surgery' ? 'sentence-surgery' : (mode === 'builder' ? 'sentence-builder' : 'practice'))),
+    type: sessionTypeForMode(mode),
     mode,
     focusConceptId: sessionFocusConceptId,
     startedAt: nowTs,
@@ -658,7 +672,7 @@ function startSession(state, payload, nowTs, learnerId) {
     currentIndex: 0,
     currentItem: firstItem,
     attemptsForCurrent: 0,
-    supportLevel: 0,
+    supportLevel: supportLevelForMode(mode),
     serverAuthority: SERVER_AUTHORITY,
   };
   return [];
@@ -733,7 +747,7 @@ function continueSession(state, nowTs) {
     nowTs,
   });
   session.attemptsForCurrent = 0;
-  session.supportLevel = 0;
+  session.supportLevel = supportLevelForMode(session.mode);
   state.phase = 'session';
   state.awaitingAdvance = false;
   state.feedback = null;
@@ -877,12 +891,21 @@ function submitAnswer(state, payload, command, nowTs) {
     });
   }
   const response = isPlainObject(payload.response) ? payload.response : (isPlainObject(payload.answer) ? payload.answer : { answer: payload.answer ?? '' });
+  const modeSupportLevel = supportLevelForMode(session.mode);
+  const requestedSupportLevel = Number(payload.supportLevel ?? modeSupportLevel) || 0;
+  if (requestedSupportLevel > modeSupportLevel) {
+    throw new BadRequestError('This Grammar mode does not allow pre-answer support.', {
+      code: 'grammar_support_unavailable_for_mode',
+      subjectId: SUBJECT_ID,
+      mode: session.mode,
+    });
+  }
   session.attemptsForCurrent = Number(session.attemptsForCurrent || 0) + 1;
   const applied = applyGrammarAttemptToState(state, {
     learnerId: command.learnerId,
     item: session.currentItem,
     response,
-    supportLevel: Number(payload.supportLevel ?? session.supportLevel) || 0,
+    supportLevel: modeSupportLevel,
     attempts: session.attemptsForCurrent,
     requestId: command.requestId,
     now: nowTs,

--- a/worker/src/subjects/grammar/read-models.js
+++ b/worker/src/subjects/grammar/read-models.js
@@ -63,6 +63,76 @@ function safeCurrentItem(item) {
   };
 }
 
+function conceptById(conceptId) {
+  return GRAMMAR_CONCEPTS.find((concept) => concept.id === conceptId) || null;
+}
+
+function conceptSupportSummary(concept) {
+  if (!concept) return null;
+  return {
+    id: concept.id,
+    name: concept.name,
+    domain: concept.domain,
+    summary: concept.summary,
+  };
+}
+
+function safeWorkedExample(concept) {
+  const worked = isPlainObject(concept?.worked) ? concept.worked : {};
+  if (!worked.prompt && !worked.answer && !worked.why) return null;
+  return {
+    prompt: typeof worked.prompt === 'string' ? worked.prompt : '',
+    exampleResponse: typeof worked.answer === 'string' ? worked.answer : '',
+    why: typeof worked.why === 'string' ? worked.why : '',
+  };
+}
+
+function safeContrast(concept) {
+  const contrast = isPlainObject(concept?.contrast) ? concept.contrast : {};
+  if (!contrast.good && !contrast.nearMiss && !contrast.why) return null;
+  return {
+    secureExample: typeof contrast.good === 'string' ? contrast.good : '',
+    nearMiss: typeof contrast.nearMiss === 'string' ? contrast.nearMiss : '',
+    why: typeof contrast.why === 'string' ? contrast.why : '',
+  };
+}
+
+function supportGuidanceForSession(session) {
+  const level = Math.max(0, Number(session?.supportLevel) || 0);
+  if (!level) return null;
+  const conceptIds = Array.isArray(session?.currentItem?.skillIds)
+    ? session.currentItem.skillIds.filter(Boolean).map(String)
+    : [];
+  const concepts = conceptIds
+    .map(conceptById)
+    .filter(Boolean);
+  const primary = concepts[0] || null;
+  const summaries = concepts
+    .map(conceptSupportSummary)
+    .filter(Boolean);
+
+  if (level >= 2) {
+    return {
+      kind: 'worked',
+      level,
+      title: 'Worked example',
+      concepts: summaries,
+      workedExample: safeWorkedExample(primary),
+      notices: Array.isArray(primary?.notices) ? primary.notices.slice(0, 2) : [],
+    };
+  }
+
+  return {
+    kind: 'faded',
+    level,
+    title: 'Faded guidance',
+    concepts: summaries,
+    summary: typeof primary?.summary === 'string' ? primary.summary : '',
+    notices: Array.isArray(primary?.notices) ? primary.notices.slice(0, 3) : [],
+    contrast: safeContrast(primary),
+  };
+}
+
 function safeSession(session) {
   if (!isPlainObject(session)) return null;
   return {
@@ -78,6 +148,8 @@ function safeSession(session) {
     totalMarks: Number.isFinite(Number(session.totalMarks)) ? Number(session.totalMarks) : 0,
     currentIndex: Number.isFinite(Number(session.currentIndex)) ? Number(session.currentIndex) : 0,
     currentItem: safeCurrentItem(session.currentItem),
+    supportLevel: Number.isFinite(Number(session.supportLevel)) ? Math.max(0, Number(session.supportLevel)) : 0,
+    supportGuidance: supportGuidanceForSession(session),
     serverAuthority: session.serverAuthority === GRAMMAR_SERVER_AUTHORITY ? GRAMMAR_SERVER_AUTHORITY : null,
   };
 }
@@ -255,8 +327,8 @@ function capabilityMetadata() {
     trouble: { label: 'Weak concepts drill', detail: 'Targets the weakest Grammar concepts with retry pressure.' },
     surgery: { label: 'Sentence surgery', detail: 'Fix and rewrite sentence-level Grammar errors.' },
     builder: { label: 'Sentence builder', detail: 'Build and rewrite sentences from structured prompts.' },
-    worked: { label: 'Worked examples' },
-    faded: { label: 'Faded guidance' },
+    worked: { label: 'Worked examples', detail: 'Practise with a model example before answering.' },
+    faded: { label: 'Faded guidance', detail: 'Practise with prompts and contrasts, but no answer to the current item.' },
   };
   return {
     enabledModes: Array.from(GRAMMAR_ENABLED_MODES).map((id) => ({ id, ...(modes[id] || { label: id }) })),

--- a/worker/src/subjects/grammar/read-models.js
+++ b/worker/src/subjects/grammar/read-models.js
@@ -77,29 +77,125 @@ function conceptSupportSummary(concept) {
   };
 }
 
-function safeWorkedExample(concept) {
-  const worked = isPlainObject(concept?.worked) ? concept.worked : {};
-  if (!worked.prompt && !worked.answer && !worked.why) return null;
-  return {
-    prompt: typeof worked.prompt === 'string' ? worked.prompt : '',
-    exampleResponse: typeof worked.answer === 'string' ? worked.answer : '',
-    why: typeof worked.why === 'string' ? worked.why : '',
-  };
+function normaliseComparableText(value) {
+  if (typeof value !== 'string') return '';
+  return value
+    .normalize('NFKC')
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
 }
 
-function safeContrast(concept) {
+function addCurrentSurfaceText(texts, value) {
+  const normalised = normaliseComparableText(value);
+  if (normalised.length >= 4) texts.add(normalised);
+}
+
+function addChoiceSurfaceTexts(texts, options) {
+  if (!Array.isArray(options)) return;
+  for (const option of options) {
+    if (Array.isArray(option)) {
+      addCurrentSurfaceText(texts, option[0]);
+      addCurrentSurfaceText(texts, option[1]);
+    } else if (isPlainObject(option)) {
+      addCurrentSurfaceText(texts, option.value);
+      addCurrentSurfaceText(texts, option.label);
+    } else {
+      addCurrentSurfaceText(texts, option);
+    }
+  }
+}
+
+function addInputSurfaceTexts(texts, inputSpec) {
+  if (!isPlainObject(inputSpec)) return;
+  addCurrentSurfaceText(texts, inputSpec.label);
+  addChoiceSurfaceTexts(texts, inputSpec.options);
+
+  if (Array.isArray(inputSpec.rows)) {
+    for (const row of inputSpec.rows) {
+      if (!isPlainObject(row)) continue;
+      addCurrentSurfaceText(texts, row.label);
+      addChoiceSurfaceTexts(texts, row.options);
+    }
+  }
+
+  if (Array.isArray(inputSpec.fields)) {
+    for (const field of inputSpec.fields) {
+      if (!isPlainObject(field)) continue;
+      addCurrentSurfaceText(texts, field.label);
+      addChoiceSurfaceTexts(texts, field.options);
+    }
+  }
+}
+
+function currentItemSurfaceTexts(item) {
+  const texts = new Set();
+  if (!isPlainObject(item)) return texts;
+  addCurrentSurfaceText(texts, item.promptText);
+  addCurrentSurfaceText(texts, item.reflectionPrompt);
+  addCurrentSurfaceText(texts, item.checkLine);
+  if (Array.isArray(item.solutionLines)) {
+    for (const line of item.solutionLines) addCurrentSurfaceText(texts, line);
+  }
+  addInputSurfaceTexts(texts, item.inputSpec);
+  return texts;
+}
+
+function overlapsCurrentItemSurface(value, currentTexts) {
+  const candidate = normaliseComparableText(value);
+  if (candidate.length < 4) return false;
+  for (const current of currentTexts) {
+    if (candidate === current) return true;
+    if (current.length >= 12 && candidate.includes(current)) return true;
+    if (current.includes(candidate)) return true;
+  }
+  return false;
+}
+
+function safeGuidanceText(value, currentTexts) {
+  if (typeof value !== 'string') return '';
+  return overlapsCurrentItemSurface(value, currentTexts) ? '' : value;
+}
+
+function safeWorkedExample(concept, currentTexts = new Set()) {
+  const worked = isPlainObject(concept?.worked) ? concept.worked : {};
+  if (!worked.prompt && !worked.answer && !worked.why) return null;
+  const prompt = safeGuidanceText(worked.prompt, currentTexts);
+  const exampleResponse = safeGuidanceText(worked.answer, currentTexts);
+  const why = safeGuidanceText(worked.why, currentTexts);
+  if (!prompt && !exampleResponse && !why) return null;
+  const model = {};
+  if (prompt) model.prompt = prompt;
+  if (exampleResponse) model.exampleResponse = exampleResponse;
+  if (why) model.why = why;
+  return model;
+}
+
+function safeContrast(concept, currentTexts = new Set()) {
   const contrast = isPlainObject(concept?.contrast) ? concept.contrast : {};
   if (!contrast.good && !contrast.nearMiss && !contrast.why) return null;
-  return {
-    secureExample: typeof contrast.good === 'string' ? contrast.good : '',
-    nearMiss: typeof contrast.nearMiss === 'string' ? contrast.nearMiss : '',
-    why: typeof contrast.why === 'string' ? contrast.why : '',
-  };
+  const secureExample = safeGuidanceText(contrast.good, currentTexts);
+  const nearMiss = safeGuidanceText(contrast.nearMiss, currentTexts);
+  const why = safeGuidanceText(contrast.why, currentTexts);
+  if (!secureExample && !nearMiss && !why) return null;
+  const model = {};
+  if (secureExample) model.secureExample = secureExample;
+  if (nearMiss) model.nearMiss = nearMiss;
+  if (why) model.why = why;
+  return model;
 }
 
 function supportGuidanceForSession(session) {
   const level = Math.max(0, Number(session?.supportLevel) || 0);
   if (!level) return null;
+  const currentTexts = currentItemSurfaceTexts(session?.currentItem);
   const conceptIds = Array.isArray(session?.currentItem?.skillIds)
     ? session.currentItem.skillIds.filter(Boolean).map(String)
     : [];
@@ -117,7 +213,7 @@ function supportGuidanceForSession(session) {
       level,
       title: 'Worked example',
       concepts: summaries,
-      workedExample: safeWorkedExample(primary),
+      workedExample: safeWorkedExample(primary, currentTexts),
       notices: Array.isArray(primary?.notices) ? primary.notices.slice(0, 2) : [],
     };
   }
@@ -129,7 +225,7 @@ function supportGuidanceForSession(session) {
     concepts: summaries,
     summary: typeof primary?.summary === 'string' ? primary.summary : '',
     notices: Array.isArray(primary?.notices) ? primary.notices.slice(0, 3) : [],
-    contrast: safeContrast(primary),
+    contrast: safeContrast(primary, currentTexts),
   };
 }
 


### PR DESCRIPTION
## Summary
- Enable Grammar worked examples and faded guidance as Worker-command-backed modes.
- Apply supported-scoring penalties from the server session so worked mode uses support level 2 and faded mode uses support level 1.
- Return concept-level guidance in the Grammar read model without exposing current-item solution lines or answer authority.
- Update the Grammar plan to a live checklist reflecting the shipped Grammar line and remaining follow-up scope.

## Verification
- `node --test tests/grammar-engine.test.js tests/worker-grammar-subject-runtime.test.js tests/react-grammar-surface.test.js tests/grammar-production-smoke.test.js`
- `npm test`
- `npm run check`

## Notes
- KS2-style mini-set mode rejects pre-answer support payloads.
- AI enrichment and transfer/Bellstorm bridge placeholders remain follow-up work.
