### PR TITLE
feat(punctuation): add guided learning mode

### DIFF
--- a/docs/plans/2026-04-24-002-feat-punctuation-legacy-parity-plan.md
+++ b/docs/plans/2026-04-24-002-feat-punctuation-legacy-parity-plan.md
@@ -152,7 +152,7 @@ tests/
 
 ## Implementation Units
 
-- [ ] U1. **Create a Legacy Parity Baseline**
+- [x] U1. **Create a Legacy Parity Baseline**
 
 **Goal:** Convert the donor HTML expectations into a durable repo-local parity matrix before changing production behaviour.
 
@@ -174,13 +174,13 @@ tests/
 
 - `tests/punctuation-legacy-parity.test.js` confirms all 14 legacy skill ids remain present in `shared/punctuation/content.js`.
 - It confirms current production has the shipped `choose`, `insert`, `fix`, and `transfer` item modes.
-- It confirms `guided`, `weak`, `combine`, `paragraph`, and `gps` are tracked as open parity rows before their units land.
+- It confirms `weak`, `combine`, `paragraph`, and `gps` are tracked as open parity rows, while `guided` is marked ported after U2.
 - It confirms browser API-key AI and localStorage authority are marked `rejected`, not accidentally planned.
 - It fails if a parity row has no owner unit.
 
 ---
 
-- [ ] U2. **Add Guided Learn Mode**
+- [x] U2. **Add Guided Learn Mode**
 
 **Goal:** Port legacy guided learning as a first-class production session mode with teach material, focused skill selection, worked examples, faded help, and support-aware evidence.
 

--- a/docs/punctuation-production.md
+++ b/docs/punctuation-production.md
@@ -221,8 +221,8 @@ shared/punctuation/legacy-parity.js
 
 The baseline currently classifies legacy behaviour as:
 
-- Ported: the 14-skill map, Worker command runtime, Smart review, `choose`, `insert`, `fix`, `transfer`, reward-unit analytics, skill rows, and recent mistakes.
-- Planned: guided learning, dedicated weak spots, sentence combining, paragraph repair, GPS test mode, richer transfer validators, safe context-pack compilation, and deeper Parent/Admin evidence.
+- Ported: the 14-skill map, Worker command runtime, Smart review, guided learning, `choose`, `insert`, `fix`, `transfer`, reward-unit analytics, skill rows, and recent mistakes.
+- Planned: dedicated weak spots, sentence combining, paragraph repair, GPS test mode, richer transfer validators, safe context-pack compilation, and deeper Parent/Admin evidence.
 - Replaced: legacy standalone `choose`, `insert`, `fix`, and `transfer` session buttons are represented by production item modes inside Smart review and focused cluster sessions.
 - Rejected: the legacy single-file production route, localStorage source of truth, browser-owned marking, and browser-stored AI provider keys.
 

--- a/shared/punctuation/scheduler.js
+++ b/shared/punctuation/scheduler.js
@@ -4,6 +4,7 @@ export const DAY_MS = 24 * 60 * 60 * 1000;
 export const MIN_MS = 60 * 1000;
 
 const SMART_MODE_CYCLE = Object.freeze(['choose', 'insert', 'fix', 'transfer']);
+const GUIDED_MODE_CYCLE = Object.freeze(['choose', 'insert', 'fix']);
 const CLUSTER_MODE = Object.freeze({
   endmarks: 'endmarks',
   apostrophe: 'apostrophe',
@@ -98,9 +99,10 @@ export function memorySnapshot(value, now = Date.now) {
   };
 }
 
-export function updateMemoryState(rawState, wasCorrect, now = Date.now) {
+export function updateMemoryState(rawState, wasCorrect, now = Date.now, options = {}) {
   const state = normaliseMemoryState(rawState);
   const nowValue = timestamp(now);
+  const supported = Boolean(options?.supported);
   state.attempts += 1;
   state.lastSeen = nowValue;
   state.lastCorrect = Boolean(wasCorrect);
@@ -109,14 +111,20 @@ export function updateMemoryState(rawState, wasCorrect, now = Date.now) {
 
   if (wasCorrect) {
     state.correct += 1;
-    state.streak += 1;
-    if (state.firstCorrectAt == null) state.firstCorrectAt = nowValue;
-    state.lastCorrectAt = nowValue;
-    if (state.attempts === 1) state.intervalDays = 1;
-    else if (state.streak === 2) state.intervalDays = Math.max(2, state.intervalDays + 2);
-    else state.intervalDays = Math.max(1, Math.round((state.intervalDays || 1) * state.ease));
-    state.ease = Math.max(1.25, Math.min(3.2, state.ease + 0.06));
-    state.dueAt = nowValue + state.intervalDays * DAY_MS;
+    if (supported) {
+      state.ease = Math.max(1.25, Math.min(3.2, state.ease + 0.02));
+      state.intervalDays = Math.max(1, state.intervalDays || 1);
+      state.dueAt = nowValue + DAY_MS;
+    } else {
+      state.streak += 1;
+      if (state.firstCorrectAt == null) state.firstCorrectAt = nowValue;
+      state.lastCorrectAt = nowValue;
+      if (state.attempts === 1) state.intervalDays = 1;
+      else if (state.streak === 2) state.intervalDays = Math.max(2, state.intervalDays + 2);
+      else state.intervalDays = Math.max(1, Math.round((state.intervalDays || 1) * state.ease));
+      state.ease = Math.max(1.25, Math.min(3.2, state.ease + 0.06));
+      state.dueAt = nowValue + state.intervalDays * DAY_MS;
+    }
   } else {
     state.incorrect += 1;
     state.lapses += 1;
@@ -134,29 +142,34 @@ function progressForItem(progress, itemId) {
 }
 
 function targetMode(session, prefs = {}) {
-  const mode = prefs.mode || 'smart';
+  const mode = session?.mode || prefs.mode || 'smart';
+  if (mode === 'guided') {
+    return GUIDED_MODE_CYCLE[(Number(session?.answeredCount) || 0) % GUIDED_MODE_CYCLE.length];
+  }
   if (mode === 'endmarks' || mode === 'apostrophe' || mode === 'speech' || mode === 'comma_flow' || mode === 'boundary' || mode === 'structure') {
     return SMART_MODE_CYCLE[(Number(session?.answeredCount) || 0) % SMART_MODE_CYCLE.length];
   }
   return SMART_MODE_CYCLE[(Number(session?.answeredCount) || 0) % SMART_MODE_CYCLE.length];
 }
 
-function targetCluster(prefs = {}) {
-  if (prefs.mode === 'endmarks') return 'endmarks';
-  if (prefs.mode === 'apostrophe') return 'apostrophe';
-  if (prefs.mode === 'speech') return 'speech';
-  if (prefs.mode === 'comma_flow') return 'comma_flow';
-  if (prefs.mode === 'boundary') return 'boundary';
-  if (prefs.mode === 'structure') return 'structure';
+function targetCluster(prefs = {}, session = {}) {
+  const mode = session?.mode || prefs.mode;
+  if (mode === 'endmarks') return 'endmarks';
+  if (mode === 'apostrophe') return 'apostrophe';
+  if (mode === 'speech') return 'speech';
+  if (mode === 'comma_flow') return 'comma_flow';
+  if (mode === 'boundary') return 'boundary';
+  if (mode === 'structure') return 'structure';
   return null;
 }
 
-function candidateItems(indexes, { mode, clusterId }) {
+function candidateItems(indexes, { mode, clusterId, skillId }) {
   const source = indexes.itemsByMode.get(mode) || [];
   return source.filter((item) => {
     const skill = indexes.skillById.get(item.skillIds?.[0]);
     if (!skill?.published) return false;
     if (clusterId && item.clusterId !== clusterId) return false;
+    if (skillId && !item.skillIds?.includes(skillId)) return false;
     return true;
   });
 }
@@ -188,9 +201,12 @@ export function selectPunctuationItem({
   candidateWindow = 32,
 } = {}) {
   const mode = targetMode(session, prefs);
-  const clusterId = targetCluster(prefs);
+  const clusterId = targetCluster(prefs, session);
+  const guidedSkillId = (session?.mode || prefs.mode) === 'guided'
+    ? (session?.guidedSkillId || prefs.guidedSkillId || null)
+    : null;
   const recent = new Set(Array.isArray(session?.recentItemIds) ? session.recentItemIds.slice(-6) : []);
-  const candidates = candidateItems(indexes, { mode, clusterId });
+  const candidates = candidateItems(indexes, { mode, clusterId, skillId: guidedSkillId });
   const windowed = candidates.slice(0, Math.max(1, candidateWindow));
   const rows = windowed.map((item) => {
     const snap = memorySnapshot(progressForItem(progress, item.id), now);

--- a/shared/punctuation/service.js
+++ b/shared/punctuation/service.js
@@ -152,6 +152,8 @@ export function normalisePunctuationData(value) {
               mode: typeof attempt.mode === 'string' ? attempt.mode : '',
               skillIds: normaliseStringArray(attempt.skillIds),
               rewardUnitId: typeof attempt.rewardUnitId === 'string' ? attempt.rewardUnitId : '',
+              sessionMode: typeof attempt.sessionMode === 'string' ? attempt.sessionMode : '',
+              supportLevel: normaliseNonNegativeInteger(attempt.supportLevel, 0),
               correct: attempt.correct === true,
               misconceptionTags: normaliseStringArray(attempt.misconceptionTags),
             }))
@@ -194,8 +196,43 @@ function normaliseItemForState(item) {
   return safe;
 }
 
+function guidedTeachBoxForSkill(skillId, supportLevel = 0) {
+  const skill = PUNCTUATION_CONTENT_MANIFEST.skills.find((entry) => entry.id === skillId && entry.published);
+  if (!skill) return null;
+  const level = normaliseNonNegativeInteger(supportLevel, 0);
+  if (level <= 0) return null;
+  const box = {
+    skillId: skill.id,
+    name: skill.name,
+    rule: skill.rule || '',
+    selfCheckPrompt: 'Check the rule, compare the examples, then try the item without looking for the answer pattern.',
+  };
+  if (level >= 2) {
+    box.workedExample = {
+      before: skill.workedBad || '',
+      after: skill.workedGood || '',
+    };
+    box.contrastExample = {
+      before: skill.contrastBad || '',
+      after: skill.contrastGood || '',
+    };
+  }
+  return box;
+}
+
+function guidedSessionReadModel(skillId, supportLevel) {
+  if (!skillId) return null;
+  return {
+    skillId,
+    supportLevel: normaliseNonNegativeInteger(supportLevel, 0),
+    teachBox: guidedTeachBoxForSkill(skillId, supportLevel),
+  };
+}
+
 function normaliseSession(value) {
   if (!isPlainObject(value)) return null;
+  const guidedSkillId = typeof value.guidedSkillId === 'string' ? value.guidedSkillId : null;
+  const guidedSupportLevel = normaliseNonNegativeInteger(value.guidedSupportLevel, 0);
   return {
     id: typeof value.id === 'string' && value.id ? value.id : '',
     releaseId: typeof value.releaseId === 'string' ? value.releaseId : PUNCTUATION_RELEASE_ID,
@@ -211,6 +248,11 @@ function normaliseSession(value) {
     recentItemIds: normaliseStringArray(value.recentItemIds).slice(-10),
     securedUnits: normaliseStringArray(value.securedUnits),
     misconceptionTags: normaliseStringArray(value.misconceptionTags),
+    guidedSkillId,
+    guidedSupportLevel,
+    guided: value.mode === 'guided'
+      ? (isPlainObject(value.guided) ? cloneSerialisable(value.guided) : guidedSessionReadModel(guidedSkillId, guidedSupportLevel))
+      : null,
     serverAuthority: value.serverAuthority === SERVER_AUTHORITY ? SERVER_AUTHORITY : null,
   };
 }
@@ -264,6 +306,27 @@ function rewardUnitForItem(indexes, item) {
 
 function facetKey(skillId, mode) {
   return `${skillId}::${mode}`;
+}
+
+function publishedSkill(indexes, skillId) {
+  const skill = indexes.skillById.get(skillId);
+  return skill?.published ? skill : null;
+}
+
+function chooseGuidedSkill(data, indexes, requestedSkillId, now = Date.now) {
+  if (publishedSkill(indexes, requestedSkillId)) return requestedSkillId;
+  const rows = indexes.publishedSkillIds.map((skillId, order) => {
+    const items = indexes.itemsBySkill.get(skillId) || [];
+    const snaps = items.map((item) => memorySnapshot(data.progress.items[item.id], now));
+    const hasWeak = snaps.some((snap) => snap.bucket === 'weak');
+    const hasDue = snaps.some((snap) => snap.bucket === 'due');
+    const mastery = snaps.length ? snaps.reduce((sum, snap) => sum + snap.mastery, 0) / snaps.length : 0;
+    const attempts = snaps.reduce((sum, snap) => sum + snap.attempts, 0);
+    const rank = hasWeak ? 0 : hasDue ? 1 : attempts ? 2 : 3;
+    return { skillId, rank, mastery, order };
+  });
+  rows.sort((a, b) => a.rank - b.rank || a.mastery - b.mastery || a.order - b.order);
+  return rows[0]?.skillId || indexes.publishedSkillIds[0] || null;
 }
 
 function sessionFocus(session = {}, indexes = PUNCTUATION_CONTENT_INDEXES) {
@@ -533,6 +596,12 @@ export function createPunctuationService({
     startSession(learnerId, options = {}) {
       const current = readData(repository, learnerId);
       const prefs = normalisePunctuationPrefs({ ...current.prefs, ...options });
+      const requestedGuidedSkillId = typeof options?.skillId === 'string'
+        ? options.skillId
+        : (typeof options?.guidedSkillId === 'string' ? options.guidedSkillId : null);
+      const guidedSkillId = prefs.mode === 'guided'
+        ? chooseGuidedSkill(current, indexes, requestedGuidedSkillId, clock)
+        : null;
       const session = {
         id: uid('punctuation-session', clock, random),
         releaseId: manifest.releaseId || PUNCTUATION_RELEASE_ID,
@@ -548,6 +617,9 @@ export function createPunctuationService({
         recentItemIds: [],
         securedUnits: [],
         misconceptionTags: [],
+        guidedSkillId,
+        guidedSupportLevel: guidedSkillId ? 2 : 0,
+        guided: guidedSkillId ? guidedSessionReadModel(guidedSkillId, 2) : null,
       };
       const state = nextActiveState({ learnerId, session, data: current, indexes, prefs, now: clock, random });
       syncPracticeSession(repository, learnerId, state, clock);
@@ -567,17 +639,24 @@ export function createPunctuationService({
         : { typed: normaliseAnswerText(rawAnswer) };
       const result = markPunctuationAnswer({ item, answer });
       const nowValue = clock();
+      const supportLevel = state.session.mode === 'guided'
+        ? normaliseNonNegativeInteger(state.session.guidedSupportLevel, 0)
+        : 0;
+      const guidedSupport = supportLevel > 0;
       const rewardUnit = rewardUnitForItem(indexes, item);
       const previousUnitSnap = rewardUnit
         ? memorySnapshot(data.progress.rewardUnits[rewardUnit.masteryKey] ? { attempts: 3, correct: 3, streak: 3, firstCorrectAt: 0, lastCorrectAt: 8 * 24 * 60 * 60 * 1000 } : data.progress.items[item.id], nowValue)
         : null;
 
-      data.progress.items[item.id] = updateMemoryState(data.progress.items[item.id], result.correct, nowValue);
+      data.progress.items[item.id] = updateMemoryState(data.progress.items[item.id], result.correct, nowValue, {
+        supported: guidedSupport,
+      });
       for (const skillId of item.skillIds || []) {
         data.progress.facets[facetKey(skillId, item.mode)] = updateMemoryState(
           data.progress.facets[facetKey(skillId, item.mode)],
           result.correct,
           nowValue,
+          { supported: guidedSupport },
         );
       }
       const nextItemSnap = memorySnapshot(data.progress.items[item.id], nowValue);
@@ -600,6 +679,8 @@ export function createPunctuationService({
         mode: item.mode,
         skillIds: item.skillIds || [],
         rewardUnitId: item.rewardUnitId || '',
+        sessionMode: state.session.mode || '',
+        supportLevel,
         correct: result.correct,
         misconceptionTags: result.misconceptionTags || [],
       });
@@ -614,7 +695,13 @@ export function createPunctuationService({
         updatedAt: nowValue,
         securedUnits: [...new Set([...(state.session.securedUnits || []), ...securedUnits])],
         misconceptionTags: [...new Set([...(state.session.misconceptionTags || []), ...(result.misconceptionTags || [])])],
+        guidedSupportLevel: state.session.mode === 'guided'
+          ? (result.correct ? Math.max(0, supportLevel - 1) : 2)
+          : 0,
       };
+      nextSession.guided = state.session.mode === 'guided'
+        ? guidedSessionReadModel(nextSession.guidedSkillId, nextSession.guidedSupportLevel)
+        : null;
       const feedback = {
         kind: result.correct ? 'success' : 'error',
         headline: result.correct ? 'Correct.' : 'Not quite.',

--- a/src/subjects/punctuation/command-actions.js
+++ b/src/subjects/punctuation/command-actions.js
@@ -12,10 +12,13 @@ export const punctuationSubjectCommandActions = Object.freeze({
     command: 'start-session',
     payload({ data, state }) {
       const prefs = state.subjectUi?.punctuation?.prefs || {};
-      return {
+      const payload = {
         mode: data?.mode || prefs.mode || 'smart',
         roundLength: data?.roundLength || prefs.roundLength || '4',
       };
+      const skillId = data?.skillId || data?.guidedSkillId;
+      if (skillId) payload.skillId = skillId;
+      return payload;
     },
   },
   'punctuation-start-again': {

--- a/src/subjects/punctuation/components/PunctuationPracticeSurface.jsx
+++ b/src/subjects/punctuation/components/PunctuationPracticeSurface.jsx
@@ -16,6 +16,9 @@ function newlineTextStyle(value) {
 function SetupView({ learner, stats, ui, actions }) {
   const scene = bellstormSceneForPhase('setup');
   const content = ui.content || {};
+  const guidedSkills = Array.isArray(content.skills) ? content.skills : [];
+  const [guidedSkillId, setGuidedSkillId] = useState(guidedSkills[0]?.id || '');
+  const selectedGuidedSkillId = guidedSkillId || guidedSkills[0]?.id || '';
   return (
     <section className="card border-top punctuation-surface" style={{ borderTopColor: '#B8873F' }}>
       <div className="punctuation-hero">
@@ -33,12 +36,60 @@ function SetupView({ learner, stats, ui, actions }) {
       </div>
       <div className="actions" style={{ marginTop: 16 }}>
         <button className="btn primary" type="button" data-punctuation-start onClick={() => actions.dispatch('punctuation-start')}>Start practice</button>
+        {guidedSkills.length ? (
+          <label className="field" style={{ minWidth: 220 }}>
+            <span>Guided skill</span>
+            <select
+              className="input"
+              value={selectedGuidedSkillId}
+              onChange={(event) => setGuidedSkillId(event.target.value)}
+            >
+              {guidedSkills.map((skill) => (
+                <option key={skill.id} value={skill.id}>{skill.name}</option>
+              ))}
+            </select>
+          </label>
+        ) : null}
+        <button
+          className="btn secondary"
+          type="button"
+          data-punctuation-guided-start
+          onClick={() => actions.dispatch('punctuation-start', { mode: 'guided', skillId: selectedGuidedSkillId || undefined })}
+        >
+          Guided learn
+        </button>
         <button className="btn secondary" type="button" onClick={() => actions.dispatch('punctuation-start', { mode: 'speech' })}>Speech focus</button>
         <button className="btn secondary" type="button" onClick={() => actions.dispatch('punctuation-start', { mode: 'comma_flow' })}>Comma focus</button>
         <button className="btn secondary" type="button" onClick={() => actions.dispatch('punctuation-start', { mode: 'boundary' })}>Boundary focus</button>
         <button className="btn secondary" type="button" onClick={() => actions.dispatch('punctuation-start', { mode: 'structure' })}>Structure focus</button>
       </div>
     </section>
+  );
+}
+
+function GuidedTeachBox({ guided }) {
+  const box = guided?.teachBox;
+  if (!box) return null;
+  return (
+    <div className="callout punctuation-guided-teach" style={{ marginTop: 14 }}>
+      <strong>{box.name}</strong>
+      {box.rule ? <p style={{ marginTop: 8 }}>{box.rule}</p> : null}
+      {box.workedExample?.before || box.workedExample?.after ? (
+        <div className="small" style={{ marginTop: 8 }}>
+          <strong>Worked example</strong>
+          <div style={newlineTextStyle(box.workedExample.before)}>{box.workedExample.before}</div>
+          <div style={newlineTextStyle(box.workedExample.after)}>{box.workedExample.after}</div>
+        </div>
+      ) : null}
+      {box.contrastExample?.before || box.contrastExample?.after ? (
+        <div className="small" style={{ marginTop: 8 }}>
+          <strong>Common mistake</strong>
+          <div style={newlineTextStyle(box.contrastExample.before)}>{box.contrastExample.before}</div>
+          <div style={newlineTextStyle(box.contrastExample.after)}>{box.contrastExample.after}</div>
+        </div>
+      ) : null}
+      {box.selfCheckPrompt ? <div className="small muted" style={{ marginTop: 8 }}>{box.selfCheckPrompt}</div> : null}
+    </div>
   );
 }
 
@@ -118,6 +169,7 @@ function ActiveItemView({ ui, actions }) {
           <p className="subtitle">{currentItemInstruction(item)}</p>
         </div>
       </div>
+      <GuidedTeachBox guided={ui.session?.guided} />
       {item.stem ? <div className="callout" style={{ marginTop: 14, ...newlineTextStyle(item.stem) }}>{item.stem}</div> : null}
       <div className="progress" style={{ marginTop: 14 }}><span style={{ width: `${progress}%` }} /></div>
       <div style={{ marginTop: 16 }}>

--- a/src/subjects/punctuation/service-contract.js
+++ b/src/subjects/punctuation/service-contract.js
@@ -12,6 +12,7 @@ export const PUNCTUATION_PHASES = Object.freeze([
 
 export const PUNCTUATION_MODES = Object.freeze([
   'smart',
+  'guided',
   'endmarks',
   'apostrophe',
   'speech',

--- a/tests/fixtures/punctuation-legacy-parity/legacy-baseline.json
+++ b/tests/fixtures/punctuation-legacy-parity/legacy-baseline.json
@@ -29,9 +29,10 @@
     {
       "id": "guided",
       "legacyLabel": "Guided learn",
-      "status": "planned",
+      "status": "ported",
       "ownerUnit": "U2",
-      "notes": "Needs teach boxes, worked examples, self-check prompts, and support-aware evidence."
+      "assertPresent": true,
+      "notes": "Worker-owned guided mode exposes safe teach boxes, worked examples, self-check prompts, and support-aware evidence."
     },
     {
       "id": "insert",
@@ -144,9 +145,9 @@
     {
       "id": "self_check_prompt",
       "legacyKey": "showSelfCheck",
-      "status": "planned",
+      "status": "ported",
       "ownerUnit": "U2",
-      "notes": "Guided mode may expose safe self-check prompts; GPS must suppress them."
+      "notes": "Guided mode exposes safe self-check prompts through the read model; GPS must suppress them."
     },
     {
       "id": "auto_generate_items",

--- a/tests/punctuation-guided.test.js
+++ b/tests/punctuation-guided.test.js
@@ -1,0 +1,108 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  createPunctuationContentIndexes,
+} from '../shared/punctuation/content.js';
+import {
+  createMemoryState,
+  memorySnapshot,
+  updateMemoryState,
+} from '../shared/punctuation/scheduler.js';
+import { createPunctuationService } from '../shared/punctuation/service.js';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function makeRepository() {
+  let data = null;
+  return {
+    readData() {
+      return data;
+    },
+    writeData(_learnerId, nextData) {
+      data = JSON.parse(JSON.stringify(nextData));
+      return data;
+    },
+    syncPracticeSession() {},
+    snapshot() {
+      return data;
+    },
+  };
+}
+
+function correctAnswerFor(readItem) {
+  const source = createPunctuationContentIndexes().itemById.get(readItem.id);
+  assert.ok(source, `Expected source item for ${readItem.id}`);
+  if (readItem.inputKind === 'choice') return { choiceIndex: source.correctIndex };
+  return { typed: source.model };
+}
+
+test('guided mode starts against the requested published skill', () => {
+  const repository = makeRepository();
+  const service = createPunctuationService({ repository, now: () => 1_800_000_000_000, random: () => 0 });
+
+  const start = service.startSession('learner-a', {
+    mode: 'guided',
+    skillId: 'speech',
+    roundLength: '2',
+  }).state;
+
+  assert.equal(start.session.mode, 'guided');
+  assert.equal(start.session.guidedSkillId, 'speech');
+  assert.equal(start.session.guidedSupportLevel, 2);
+  assert.equal(typeof start.session.guided.teachBox.workedExample.before, 'string');
+  assert.equal(typeof start.session.guided.teachBox.contrastExample.before, 'string');
+  assert.equal(start.session.currentItem.skillIds.includes('speech'), true);
+  assert.equal(start.session.currentItem.mode, 'choose');
+});
+
+test('guided mode falls back to a valid skill when the requested skill is unavailable', () => {
+  const repository = makeRepository();
+  const service = createPunctuationService({ repository, now: () => 1_800_000_000_000, random: () => 0 });
+
+  const start = service.startSession('learner-a', {
+    mode: 'guided',
+    skillId: 'not-a-skill',
+    roundLength: '1',
+  }).state;
+
+  assert.equal(start.session.mode, 'guided');
+  assert.equal(typeof start.session.guidedSkillId, 'string');
+  assert.equal(start.session.currentItem.skillIds.includes(start.session.guidedSkillId), true);
+});
+
+test('guided support decreases after clean answers and is recorded on attempts', () => {
+  const repository = makeRepository();
+  const service = createPunctuationService({ repository, now: () => 1_800_000_000_000, random: () => 0 });
+
+  const start = service.startSession('learner-a', {
+    mode: 'guided',
+    skillId: 'sentence_endings',
+    roundLength: '2',
+  }).state;
+  const first = service.submitAnswer('learner-a', start, correctAnswerFor(start.session.currentItem)).state;
+
+  assert.equal(first.session.guidedSupportLevel, 1);
+  assert.equal(first.session.guided.teachBox.workedExample, undefined);
+  assert.equal(typeof first.session.guided.teachBox.rule, 'string');
+  assert.equal(repository.snapshot().progress.attempts.at(-1).sessionMode, 'guided');
+  assert.equal(repository.snapshot().progress.attempts.at(-1).supportLevel, 2);
+
+  const next = service.continueSession('learner-a', first).state;
+  const second = service.submitAnswer('learner-a', next, correctAnswerFor(next.session.currentItem)).state;
+  assert.equal(second.session.guidedSupportLevel, 0);
+  assert.equal(second.session.guided.teachBox, null);
+  assert.equal(repository.snapshot().progress.attempts.at(-1).supportLevel, 1);
+});
+
+test('supported correct answers do not create a clean secure streak', () => {
+  let state = createMemoryState();
+  state = updateMemoryState(state, true, 0, { supported: true });
+  state = updateMemoryState(state, true, 8 * DAY_MS, { supported: true });
+  state = updateMemoryState(state, true, 16 * DAY_MS, { supported: true });
+
+  const snap = memorySnapshot(state, 16 * DAY_MS);
+  assert.equal(snap.state.correct, 3);
+  assert.equal(snap.state.streak, 0);
+  assert.equal(snap.secure, false);
+});

--- a/tests/punctuation-legacy-parity.test.js
+++ b/tests/punctuation-legacy-parity.test.js
@@ -46,8 +46,12 @@ test('punctuation legacy parity records shipped item modes and open mode gaps', 
     assert.equal(row?.present, true, `${mode} should exist in production item modes`);
   }
 
+  const guided = report.rows.find((entry) => entry.section === 'sessionModes' && entry.id === 'guided');
+  assert.equal(guided?.status, 'ported');
+  assert.equal(guided?.ownerUnit, 'U2');
+  assert.equal(guided?.present, true);
+
   for (const [id, ownerUnit] of [
-    ['guided', 'U2'],
     ['weak', 'U3'],
     ['combine', 'U4'],
     ['paragraph', 'U5'],

--- a/tests/react-punctuation-scene.test.js
+++ b/tests/react-punctuation-scene.test.js
@@ -74,6 +74,66 @@ test('punctuation React surface keeps server-only fields out of active HTML', ()
   assert.equal(html.includes(PUNCTUATION_RELEASE_ID), false);
 });
 
+test('punctuation React surface renders guided setup controls and teach boxes', () => {
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.store.updateSubjectUi('punctuation', {
+    phase: 'setup',
+    content: {
+      publishedScopeCopy: 'This Punctuation release covers all 14 KS2 punctuation skills.',
+      skills: [
+        { id: 'sentence_endings', name: 'Capital letters and sentence endings', clusterId: 'endmarks' },
+        { id: 'speech', name: 'Inverted commas and speech punctuation', clusterId: 'speech' },
+      ],
+    },
+  });
+
+  const setupHtml = harness.render();
+  assert.match(setupHtml, /Guided skill/);
+  assert.match(setupHtml, /Guided learn/);
+  assert.match(setupHtml, /data-punctuation-guided-start/);
+
+  harness.store.updateSubjectUi('punctuation', {
+    phase: 'active-item',
+    session: {
+      id: 'guided-ui',
+      mode: 'guided',
+      length: 1,
+      answeredCount: 0,
+      guided: {
+        skillId: 'speech',
+        supportLevel: 2,
+        teachBox: {
+          name: 'Inverted commas and speech punctuation',
+          rule: 'Put spoken words inside inverted commas.',
+          workedExample: {
+            before: 'Mia said come here.',
+            after: 'Mia said, "Come here."',
+          },
+          contrastExample: {
+            before: 'Mia said "come here".',
+            after: 'Mia said, "Come here."',
+          },
+          selfCheckPrompt: 'Check the rule, compare the examples, then try the item without looking for the answer pattern.',
+        },
+      },
+      currentItem: {
+        id: 'sp_insert_question',
+        mode: 'insert',
+        inputKind: 'text',
+        prompt: 'Add the direct-speech punctuation.',
+        stem: 'Ella asked, can we start now?',
+      },
+    },
+  });
+  const activeHtml = harness.render();
+  assert.match(activeHtml, /Inverted commas and speech punctuation/);
+  assert.match(activeHtml, /Put spoken words inside inverted commas/);
+  assert.match(activeHtml, /Worked example/);
+  assert.match(activeHtml, /Common mistake/);
+  assert.doesNotMatch(activeHtml, /accepted|correctIndex|rubric|validator|generator|hiddenQueue/);
+});
+
 test('punctuation text input remounts when the current text item changes', async () => {
   const source = await readFile(
     new URL('../src/subjects/punctuation/components/PunctuationPracticeSurface.jsx', import.meta.url),

--- a/tests/subject-command-actions.test.js
+++ b/tests/subject-command-actions.test.js
@@ -190,3 +190,12 @@ test('punctuation start command action preserves explicit focus mode and round l
 
   assert.deepEqual(payload, { mode: 'structure', roundLength: '1' });
 });
+
+test('punctuation start command action passes guided skill only when present', () => {
+  const payload = punctuationSubjectCommandActions['punctuation-start'].payload({
+    data: { mode: 'guided', roundLength: '2', skillId: 'speech' },
+    state: baseState(),
+  });
+
+  assert.deepEqual(payload, { mode: 'guided', roundLength: '2', skillId: 'speech' });
+});

--- a/tests/worker-punctuation-runtime.test.js
+++ b/tests/worker-punctuation-runtime.test.js
@@ -4,7 +4,10 @@ import assert from 'node:assert/strict';
 import { createWorkerApp } from '../worker/src/app.js';
 import { createWorkerSubjectRuntime } from '../worker/src/subjects/runtime.js';
 import { buildPunctuationReadModel } from '../worker/src/subjects/punctuation/read-models.js';
-import { createPunctuationMasteryKey } from '../shared/punctuation/content.js';
+import {
+  createPunctuationContentIndexes,
+  createPunctuationMasteryKey,
+} from '../shared/punctuation/content.js';
 import { createMigratedSqliteD1Database } from './helpers/sqlite-d1.js';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -90,6 +93,13 @@ function payloadText(value) {
   return JSON.stringify(value);
 }
 
+function correctAnswerFor(readItem) {
+  const source = createPunctuationContentIndexes().itemById.get(readItem.id);
+  assert.ok(source, `Expected source item for ${readItem.id}`);
+  if (readItem.inputKind === 'choice') return { choiceIndex: source.correctIndex };
+  return { typed: source.model };
+}
+
 test('Worker runtime registers punctuation command handlers', async () => {
   const runtime = createWorkerSubjectRuntime({ punctuation: { random: () => 0 } });
   let runtimeReads = 0;
@@ -141,6 +151,56 @@ test('punctuation command route starts a session and persists through generic ru
     `).get();
     assert.equal(subjectRows.count, 1);
     assert.equal(sessionRows.count, 1);
+  } finally {
+    harness.close();
+  }
+});
+
+test('punctuation command route starts guided mode with a redacted teach box', async () => {
+  const harness = createHarness();
+  try {
+    const start = await harness.command('start-session', {
+      mode: 'guided',
+      skillId: 'speech',
+      roundLength: '1',
+    });
+
+    assert.equal(start.body.subjectReadModel.phase, 'active-item');
+    assert.equal(start.body.subjectReadModel.session.mode, 'guided');
+    assert.equal(start.body.subjectReadModel.session.guided.skillId, 'speech');
+    assert.equal(start.body.subjectReadModel.session.guided.supportLevel, 2);
+    assert.match(start.body.subjectReadModel.session.guided.teachBox.rule, /spoken words/i);
+    assert.ok(start.body.subjectReadModel.session.guided.teachBox.workedExample);
+    assert.ok(start.body.subjectReadModel.session.guided.teachBox.contrastExample);
+    assert.equal(start.body.subjectReadModel.session.currentItem.skillIds.includes('speech'), true);
+    assert.doesNotMatch(payloadText(start.body.subjectReadModel), /accepted|correctIndex|rubric|validator|hiddenQueue|generator/);
+  } finally {
+    harness.close();
+  }
+});
+
+test('punctuation guided mode fades visible support with the recorded support level', async () => {
+  const harness = createHarness();
+  try {
+    const start = await harness.command('start-session', {
+      mode: 'guided',
+      skillId: 'sentence_endings',
+      roundLength: '2',
+    });
+    const firstAnswer = correctAnswerFor(start.body.subjectReadModel.session.currentItem);
+    const first = await harness.command('submit-answer', firstAnswer);
+
+    assert.equal(first.body.subjectReadModel.session.guided.supportLevel, 1);
+    assert.match(first.body.subjectReadModel.session.guided.teachBox.rule, /sentence/i);
+    assert.equal(first.body.subjectReadModel.session.guided.teachBox.workedExample, undefined);
+    assert.equal(first.body.subjectReadModel.session.guided.teachBox.contrastExample, undefined);
+
+    const next = await harness.command('continue-session');
+    const secondAnswer = correctAnswerFor(next.body.subjectReadModel.session.currentItem);
+    const second = await harness.command('submit-answer', secondAnswer);
+
+    assert.equal(second.body.subjectReadModel.session.guided.supportLevel, 0);
+    assert.equal(second.body.subjectReadModel.session.guided.teachBox, null);
   } finally {
     harness.close();
   }

--- a/worker/src/subjects/punctuation/commands.js
+++ b/worker/src/subjects/punctuation/commands.js
@@ -27,6 +27,13 @@ function contentMeta() {
     publishedSkillCount: PUNCTUATION_CONTENT_MANIFEST.skills.filter((skill) => skill.published).length,
     publishedRewardUnitCount: PUNCTUATION_CONTENT_MANIFEST.rewardUnits.filter((unit) => unit.published).length,
     publishedScopeCopy: PUNCTUATION_CONTENT_MANIFEST.publishedScopeCopy,
+    skills: PUNCTUATION_CONTENT_MANIFEST.skills
+      .filter((skill) => skill.published)
+      .map((skill) => ({
+        id: skill.id,
+        name: skill.name,
+        clusterId: skill.clusterId,
+      })),
   };
 }
 

--- a/worker/src/subjects/punctuation/read-models.js
+++ b/worker/src/subjects/punctuation/read-models.js
@@ -43,6 +43,45 @@ function safeCurrentItem(item) {
   return safe;
 }
 
+function safeContentSkills() {
+  return PUNCTUATION_CONTENT_MANIFEST.skills
+    .filter((skill) => skill.published)
+    .map((skill) => ({
+      id: skill.id,
+      name: skill.name,
+      clusterId: skill.clusterId,
+    }));
+}
+
+function normaliseSupportLevel(value) {
+  const level = Number(value);
+  return Number.isInteger(level) && level > 0 ? level : 0;
+}
+
+function guidedTeachBox(skillId, supportLevel = 0) {
+  const skill = PUNCTUATION_CONTENT_MANIFEST.skills.find((entry) => entry.id === skillId && entry.published);
+  if (!skill) return null;
+  const level = normaliseSupportLevel(supportLevel);
+  if (level <= 0) return null;
+  const box = {
+    skillId: skill.id,
+    name: skill.name,
+    rule: skill.rule || '',
+    selfCheckPrompt: 'Check the rule, compare the examples, then try the item without looking for the answer pattern.',
+  };
+  if (level >= 2) {
+    box.workedExample = {
+      before: skill.workedBad || '',
+      after: skill.workedGood || '',
+    };
+    box.contrastExample = {
+      before: skill.contrastBad || '',
+      after: skill.contrastGood || '',
+    };
+  }
+  return box;
+}
+
 function safeSession(session, phase) {
   if (!isPlainObject(session)) return null;
   const safe = {
@@ -57,6 +96,11 @@ function safeSession(session, phase) {
     currentItem: phase === 'active-item' || phase === 'feedback' ? safeCurrentItem(session.currentItem) : null,
     securedUnits: Array.isArray(session.securedUnits) ? session.securedUnits.filter((entry) => typeof entry === 'string') : [],
     misconceptionTags: Array.isArray(session.misconceptionTags) ? session.misconceptionTags.filter((entry) => typeof entry === 'string') : [],
+    guided: session.mode === 'guided' ? {
+      skillId: typeof session.guidedSkillId === 'string' ? session.guidedSkillId : null,
+      supportLevel: normaliseSupportLevel(session.guidedSupportLevel),
+      teachBox: guidedTeachBox(session.guidedSkillId, session.guidedSupportLevel),
+    } : null,
     serverAuthority: session.serverAuthority === 'worker' ? 'worker' : null,
   };
   return safe;
@@ -128,6 +172,7 @@ export function buildPunctuationReadModel({
       releaseName: PUNCTUATION_CONTENT_MANIFEST.releaseName,
       fullSkillCount: PUNCTUATION_CONTENT_MANIFEST.fullSkillCount,
       publishedScopeCopy: PUNCTUATION_CONTENT_MANIFEST.publishedScopeCopy,
+      skills: safeContentSkills(),
     },
   };
 }


### PR DESCRIPTION
## Summary
- add Worker-owned punctuation guided mode with requested-skill fallback and safe teach-box read models
- surface guided skill selection and teach boxes in the React punctuation practice UI
- update legacy parity tracking so U2 guided learning/self-check prompts are marked ported

## Tests
- npm test
- npm run check
- git diff --check