### PR TITLE
feat(punctuation): add weak spots drill

### DIFF
--- a/docs/plans/2026-04-24-002-feat-punctuation-legacy-parity-plan.md
+++ b/docs/plans/2026-04-24-002-feat-punctuation-legacy-parity-plan.md
@@ -174,7 +174,7 @@ tests/
 
 - `tests/punctuation-legacy-parity.test.js` confirms all 14 legacy skill ids remain present in `shared/punctuation/content.js`.
 - It confirms current production has the shipped `choose`, `insert`, `fix`, and `transfer` item modes.
-- It confirms `weak`, `combine`, `paragraph`, and `gps` are tracked as open parity rows, while `guided` is marked ported after U2.
+- It confirms `combine`, `paragraph`, and `gps` are tracked as open parity rows, while `guided` and `weak` are marked ported after U2/U3.
 - It confirms browser API-key AI and localStorage authority are marked `rejected`, not accidentally planned.
 - It fails if a parity row has no owner unit.
 
@@ -218,7 +218,7 @@ tests/
 
 ---
 
-- [ ] U3. **Add Dedicated Weak Spots Drill**
+- [x] U3. **Add Dedicated Weak Spots Drill**
 
 **Goal:** Port the legacy `weak` mode as an explicit drill that targets fragile skill-by-mode facets and due items.
 

--- a/docs/punctuation-production.md
+++ b/docs/punctuation-production.md
@@ -221,8 +221,8 @@ shared/punctuation/legacy-parity.js
 
 The baseline currently classifies legacy behaviour as:
 
-- Ported: the 14-skill map, Worker command runtime, Smart review, guided learning, `choose`, `insert`, `fix`, `transfer`, reward-unit analytics, skill rows, and recent mistakes.
-- Planned: dedicated weak spots, sentence combining, paragraph repair, GPS test mode, richer transfer validators, safe context-pack compilation, and deeper Parent/Admin evidence.
+- Ported: the 14-skill map, Worker command runtime, Smart review, guided learning, dedicated weak spots, `choose`, `insert`, `fix`, `transfer`, reward-unit analytics, skill rows, and recent mistakes.
+- Planned: sentence combining, paragraph repair, GPS test mode, richer transfer validators, safe context-pack compilation, and deeper Parent/Admin evidence.
 - Replaced: legacy standalone `choose`, `insert`, `fix`, and `transfer` session buttons are represented by production item modes inside Smart review and focused cluster sessions.
 - Rejected: the legacy single-file production route, localStorage source of truth, browser-owned marking, and browser-stored AI provider keys.
 

--- a/shared/punctuation/scheduler.js
+++ b/shared/punctuation/scheduler.js
@@ -141,6 +141,14 @@ function progressForItem(progress, itemId) {
   return normaliseMemoryState(progress?.items?.[itemId]);
 }
 
+function progressForFacet(progress, skillId, mode) {
+  return normaliseMemoryState(progress?.facets?.[`${skillId}::${mode}`]);
+}
+
+function skillName(indexes, skillId) {
+  return indexes.skillById.get(skillId)?.name || skillId;
+}
+
 function targetMode(session, prefs = {}) {
   const mode = session?.mode || prefs.mode || 'smart';
   if (mode === 'guided') {
@@ -191,6 +199,150 @@ function weightedPick(rows, random = Math.random) {
   return rows[rows.length - 1].item;
 }
 
+function recentMissForItem(progress, item) {
+  const attempts = Array.isArray(progress?.attempts) ? progress.attempts : [];
+  return attempts.slice(-12).reverse().find((attempt) => {
+    if (!attempt || attempt.correct === true) return false;
+    if (attempt.itemId === item.id) return true;
+    if (attempt.mode !== item.mode) return false;
+    const attemptSkills = Array.isArray(attempt.skillIds) ? attempt.skillIds : [];
+    return item.skillIds?.some((skillId) => attemptSkills.includes(skillId));
+  }) || null;
+}
+
+function strongestFacet(indexes, progress, item, now) {
+  return (item.skillIds || [])
+    .map((skillId) => {
+      const snap = memorySnapshot(progressForFacet(progress, skillId, item.mode), now);
+      const bucketRank = snap.bucket === 'weak' ? 4 : snap.bucket === 'due' ? 3 : snap.bucket === 'learning' ? 2 : snap.bucket === 'new' ? 1 : 0;
+      return {
+        skillId,
+        skillName: skillName(indexes, skillId),
+        mode: item.mode,
+        clusterId: item.clusterId || null,
+        bucket: snap.bucket,
+        mastery: snap.mastery,
+        rank: bucketRank,
+      };
+    })
+    .sort((a, b) => b.rank - a.rank || a.mastery - b.mastery || a.skillId.localeCompare(b.skillId))[0] || null;
+}
+
+function weakCandidateRow(indexes, progress, item, now, order, recent) {
+  const itemSnap = memorySnapshot(progressForItem(progress, item.id), now);
+  const facet = strongestFacet(indexes, progress, item, now);
+  const recentMiss = recentMissForItem(progress, item);
+  let priority = 10;
+  let source = 'fallback';
+  let bucket = itemSnap.bucket;
+
+  if (facet?.bucket === 'weak') {
+    priority = 90;
+    source = 'weak_facet';
+    bucket = 'weak';
+  } else if (itemSnap.bucket === 'weak') {
+    priority = 82;
+    source = 'weak_item';
+    bucket = 'weak';
+  } else if (recentMiss) {
+    priority = 74;
+    source = 'recent_miss';
+    bucket = 'weak';
+  } else if (facet?.bucket === 'due') {
+    priority = 62;
+    source = 'due_facet';
+    bucket = 'due';
+  } else if (itemSnap.bucket === 'due') {
+    priority = 54;
+    source = 'due_item';
+    bucket = 'due';
+  } else if (itemSnap.bucket === 'new' || facet?.bucket === 'new') {
+    priority = 24;
+    source = 'fallback';
+    bucket = 'new';
+  } else if (itemSnap.bucket === 'secure') {
+    priority = 4;
+    source = 'fallback';
+    bucket = 'secure';
+  }
+
+  if (recent.has(item.id)) priority *= 0.08;
+
+  const focusSkillId = facet?.skillId || item.skillIds?.[0] || '';
+  return {
+    item,
+    order,
+    priority,
+    weight: Math.max(0.1, priority),
+    weakFocus: {
+      skillId: focusSkillId,
+      skillName: skillName(indexes, focusSkillId),
+      mode: item.mode,
+      clusterId: item.clusterId || null,
+      bucket,
+      source,
+    },
+  };
+}
+
+function publishedItem(indexes, item) {
+  if (!item) return false;
+  const skill = indexes.skillById.get(item.skillIds?.[0]);
+  return Boolean(skill?.published);
+}
+
+function facetEvidenceRows(progress, now, bucket) {
+  const facets = isPlainObject(progress?.facets) ? progress.facets : {};
+  return Object.entries(facets)
+    .map(([key, value]) => {
+      const [skillId, mode] = key.split('::');
+      const snap = memorySnapshot(value, now);
+      return { skillId, mode, snap };
+    })
+    .filter((entry) => entry.skillId && entry.mode && entry.snap.bucket === bucket)
+    .sort((a, b) => a.snap.mastery - b.snap.mastery || a.skillId.localeCompare(b.skillId) || a.mode.localeCompare(b.mode));
+}
+
+function itemEvidenceRows(progress, now, bucket) {
+  const items = isPlainObject(progress?.items) ? progress.items : {};
+  return Object.entries(items)
+    .map(([itemId, value]) => ({ itemId, snap: memorySnapshot(value, now) }))
+    .filter((entry) => entry.itemId && entry.snap.bucket === bucket)
+    .sort((a, b) => a.snap.mastery - b.snap.mastery || a.itemId.localeCompare(b.itemId));
+}
+
+function weakRows(indexes, progress, session, now, maxWindow) {
+  const recent = new Set(Array.isArray(session?.recentItemIds) ? session.recentItemIds.slice(-6) : []);
+  const rows = [];
+  const seen = new Set();
+  const limit = Math.max(1, maxWindow);
+  const addItem = (item) => {
+    if (rows.length >= limit || !publishedItem(indexes, item) || seen.has(item.id)) return;
+    seen.add(item.id);
+    rows.push(weakCandidateRow(indexes, progress, item, now, rows.length, recent));
+  };
+  const addFacet = ({ skillId, mode }) => {
+    for (const item of indexes.itemsByMode.get(mode) || []) {
+      if (item.skillIds?.includes(skillId)) addItem(item);
+      if (rows.length >= limit) return;
+    }
+  };
+
+  for (const entry of facetEvidenceRows(progress, now, 'weak')) addFacet(entry);
+  for (const entry of itemEvidenceRows(progress, now, 'weak')) addItem(indexes.itemById.get(entry.itemId));
+  for (const attempt of (Array.isArray(progress?.attempts) ? progress.attempts.slice(-12).reverse() : [])) {
+    if (attempt?.correct === false) addItem(indexes.itemById.get(attempt.itemId));
+  }
+  for (const entry of facetEvidenceRows(progress, now, 'due')) addFacet(entry);
+  for (const entry of itemEvidenceRows(progress, now, 'due')) addItem(indexes.itemById.get(entry.itemId));
+  for (const item of indexes.items) {
+    addItem(item);
+    if (rows.length >= limit) break;
+  }
+
+  return rows.sort((a, b) => b.priority - a.priority || a.order - b.order);
+}
+
 export function selectPunctuationItem({
   indexes = PUNCTUATION_CONTENT_INDEXES,
   progress = {},
@@ -200,14 +352,30 @@ export function selectPunctuationItem({
   random = Math.random,
   candidateWindow = 32,
 } = {}) {
-  const mode = targetMode(session, prefs);
+  const sessionMode = session?.mode || prefs.mode || 'smart';
+  const mode = sessionMode === 'weak' ? null : targetMode(session, prefs);
   const clusterId = targetCluster(prefs, session);
   const guidedSkillId = (session?.mode || prefs.mode) === 'guided'
     ? (session?.guidedSkillId || prefs.guidedSkillId || null)
     : null;
+  const maxWindow = Math.max(1, candidateWindow);
+  if (sessionMode === 'weak') {
+    const rows = weakRows(indexes, progress, session, now, maxWindow);
+    const picked = weightedPick(rows, random) || rows[0]?.item || null;
+    const pickedRow = rows.find((row) => row.item.id === picked?.id) || null;
+    return {
+      item: picked ? clone(picked) : null,
+      targetMode: picked?.mode || null,
+      targetClusterId: picked?.clusterId || null,
+      weakFocus: pickedRow ? clone(pickedRow.weakFocus) : null,
+      inspectedCount: rows.length,
+      candidateCount: indexes.items.length,
+    };
+  }
+
   const recent = new Set(Array.isArray(session?.recentItemIds) ? session.recentItemIds.slice(-6) : []);
   const candidates = candidateItems(indexes, { mode, clusterId, skillId: guidedSkillId });
-  const windowed = candidates.slice(0, Math.max(1, candidateWindow));
+  const windowed = candidates.slice(0, maxWindow);
   const rows = windowed.map((item) => {
     const snap = memorySnapshot(progressForItem(progress, item.id), now);
     let weight = 1;
@@ -224,6 +392,7 @@ export function selectPunctuationItem({
     item: item ? clone(item) : null,
     targetMode: mode,
     targetClusterId: clusterId,
+    weakFocus: null,
     inspectedCount: windowed.length,
     candidateCount: candidates.length,
   };

--- a/shared/punctuation/service.js
+++ b/shared/punctuation/service.js
@@ -229,6 +229,18 @@ function guidedSessionReadModel(skillId, supportLevel) {
   };
 }
 
+function normaliseWeakFocus(value) {
+  if (!isPlainObject(value)) return null;
+  return {
+    skillId: typeof value.skillId === 'string' ? value.skillId : '',
+    skillName: typeof value.skillName === 'string' ? value.skillName : '',
+    mode: typeof value.mode === 'string' ? value.mode : '',
+    clusterId: typeof value.clusterId === 'string' ? value.clusterId : null,
+    bucket: typeof value.bucket === 'string' ? value.bucket : '',
+    source: typeof value.source === 'string' ? value.source : '',
+  };
+}
+
 function normaliseSession(value) {
   if (!isPlainObject(value)) return null;
   const guidedSkillId = typeof value.guidedSkillId === 'string' ? value.guidedSkillId : null;
@@ -253,6 +265,7 @@ function normaliseSession(value) {
     guided: value.mode === 'guided'
       ? (isPlainObject(value.guided) ? cloneSerialisable(value.guided) : guidedSessionReadModel(guidedSkillId, guidedSupportLevel))
       : null,
+    weakFocus: value.mode === 'weak' ? normaliseWeakFocus(value.weakFocus) : null,
     serverAuthority: value.serverAuthority === SERVER_AUTHORITY ? SERVER_AUTHORITY : null,
   };
 }
@@ -500,6 +513,7 @@ function nextActiveState({ learnerId, session, data, indexes, prefs, now, random
     currentItemId: selection.item.id,
     currentItem: normaliseItemForState(selection.item),
     recentItemIds: [...(session.recentItemIds || []), selection.item.id].slice(-10),
+    weakFocus: session.mode === 'weak' ? normaliseWeakFocus(selection.weakFocus) : null,
   };
   return {
     version: PUNCTUATION_SERVICE_STATE_VERSION,
@@ -620,6 +634,7 @@ export function createPunctuationService({
         guidedSkillId,
         guidedSupportLevel: guidedSkillId ? 2 : 0,
         guided: guidedSkillId ? guidedSessionReadModel(guidedSkillId, 2) : null,
+        weakFocus: null,
       };
       const state = nextActiveState({ learnerId, session, data: current, indexes, prefs, now: clock, random });
       syncPracticeSession(repository, learnerId, state, clock);

--- a/src/subjects/punctuation/components/PunctuationPracticeSurface.jsx
+++ b/src/subjects/punctuation/components/PunctuationPracticeSurface.jsx
@@ -58,12 +58,34 @@ function SetupView({ learner, stats, ui, actions }) {
         >
           Guided learn
         </button>
+        <button
+          className="btn secondary"
+          type="button"
+          data-punctuation-weak-start
+          onClick={() => actions.dispatch('punctuation-start', { mode: 'weak' })}
+        >
+          Weak spots
+        </button>
         <button className="btn secondary" type="button" onClick={() => actions.dispatch('punctuation-start', { mode: 'speech' })}>Speech focus</button>
         <button className="btn secondary" type="button" onClick={() => actions.dispatch('punctuation-start', { mode: 'comma_flow' })}>Comma focus</button>
         <button className="btn secondary" type="button" onClick={() => actions.dispatch('punctuation-start', { mode: 'boundary' })}>Boundary focus</button>
         <button className="btn secondary" type="button" onClick={() => actions.dispatch('punctuation-start', { mode: 'structure' })}>Structure focus</button>
       </div>
     </section>
+  );
+}
+
+function WeakFocusChips({ focus }) {
+  if (!focus) return null;
+  const label = focus.bucket === 'weak'
+    ? 'Weak focus'
+    : (focus.bucket === 'due' ? 'Due review' : 'Mixed review');
+  return (
+    <div className="chip-row" style={{ marginTop: 14 }}>
+      <span className={`chip ${focus.bucket === 'weak' ? 'warn' : ''}`}>{label}</span>
+      {focus.skillName ? <span className="chip">{focus.skillName}</span> : null}
+      {focus.mode ? <span className="chip">{focus.mode}</span> : null}
+    </div>
   );
 }
 
@@ -169,6 +191,7 @@ function ActiveItemView({ ui, actions }) {
           <p className="subtitle">{currentItemInstruction(item)}</p>
         </div>
       </div>
+      <WeakFocusChips focus={ui.session?.weakFocus} />
       <GuidedTeachBox guided={ui.session?.guided} />
       {item.stem ? <div className="callout" style={{ marginTop: 14, ...newlineTextStyle(item.stem) }}>{item.stem}</div> : null}
       <div className="progress" style={{ marginTop: 14 }}><span style={{ width: `${progress}%` }} /></div>

--- a/src/subjects/punctuation/service-contract.js
+++ b/src/subjects/punctuation/service-contract.js
@@ -13,6 +13,7 @@ export const PUNCTUATION_PHASES = Object.freeze([
 export const PUNCTUATION_MODES = Object.freeze([
   'smart',
   'guided',
+  'weak',
   'endmarks',
   'apostrophe',
   'speech',

--- a/tests/fixtures/punctuation-legacy-parity/legacy-baseline.json
+++ b/tests/fixtures/punctuation-legacy-parity/legacy-baseline.json
@@ -72,9 +72,10 @@
     {
       "id": "weak",
       "legacyLabel": "Weak spots drill",
-      "status": "planned",
+      "status": "ported",
       "ownerUnit": "U3",
-      "notes": "Needs an explicit drill targeting weak skill-by-mode facets."
+      "assertPresent": true,
+      "notes": "Explicit weak drill targets weak and due item memory plus weak skill-by-mode facets with safe focus metadata."
     },
     {
       "id": "transfer",

--- a/tests/punctuation-legacy-parity.test.js
+++ b/tests/punctuation-legacy-parity.test.js
@@ -51,8 +51,12 @@ test('punctuation legacy parity records shipped item modes and open mode gaps', 
   assert.equal(guided?.ownerUnit, 'U2');
   assert.equal(guided?.present, true);
 
+  const weak = report.rows.find((entry) => entry.section === 'sessionModes' && entry.id === 'weak');
+  assert.equal(weak?.status, 'ported');
+  assert.equal(weak?.ownerUnit, 'U3');
+  assert.equal(weak?.present, true);
+
   for (const [id, ownerUnit] of [
-    ['weak', 'U3'],
     ['combine', 'U4'],
     ['paragraph', 'U5'],
     ['gps', 'U6'],

--- a/tests/punctuation-scheduler.test.js
+++ b/tests/punctuation-scheduler.test.js
@@ -39,6 +39,124 @@ test('scheduler is deterministic under fixed state and random input', () => {
   assert.equal(first.item.mode, 'choose');
 });
 
+test('weak mode prioritises weak skill-by-mode facets', () => {
+  const weakFacet = updateMemoryState(createMemoryState(), false, 0);
+  const result = selectPunctuationItem({
+    progress: {
+      items: {},
+      facets: { 'speech::insert': weakFacet },
+      rewardUnits: {},
+      attempts: [],
+      sessionsCompleted: 0,
+    },
+    session: { mode: 'weak', answeredCount: 0, recentItemIds: [] },
+    prefs: { mode: 'weak' },
+    now: 0,
+    random: () => 0,
+  });
+
+  assert.equal(result.item.id, 'sp_insert_question');
+  assert.equal(result.item.mode, 'insert');
+  assert.equal(result.weakFocus.skillId, 'speech');
+  assert.equal(result.weakFocus.bucket, 'weak');
+  assert.equal(result.weakFocus.source, 'weak_facet');
+});
+
+test('weak mode avoids repeating a recent item when another weak alternative exists', () => {
+  const weakFacet = updateMemoryState(createMemoryState(), false, 0);
+  const result = selectPunctuationItem({
+    progress: {
+      items: {},
+      facets: {
+        'speech::insert': weakFacet,
+        'speech::fix': weakFacet,
+      },
+      rewardUnits: {},
+      attempts: [],
+      sessionsCompleted: 0,
+    },
+    session: { mode: 'weak', answeredCount: 0, recentItemIds: ['sp_insert_question'] },
+    prefs: { mode: 'weak' },
+    now: 0,
+    random: () => 0,
+  });
+
+  assert.equal(result.item.id, 'sp_fix_question');
+  assert.equal(result.item.mode, 'fix');
+  assert.equal(result.weakFocus.source, 'weak_facet');
+});
+
+test('weak mode falls back to mixed review when no weak evidence exists', () => {
+  const result = selectPunctuationItem({
+    progress: { items: {}, facets: {}, rewardUnits: {}, attempts: [], sessionsCompleted: 0 },
+    session: { mode: 'weak', answeredCount: 0, recentItemIds: [] },
+    prefs: { mode: 'weak' },
+    now: 0,
+    random: () => 0,
+  });
+
+  assert.ok(result.item);
+  assert.equal(result.weakFocus.source, 'fallback');
+  assert.equal(result.weakFocus.bucket, 'new');
+});
+
+test('weak mode selects due skill-by-mode facets before fallback review', () => {
+  let dueFacet = createMemoryState();
+  dueFacet = updateMemoryState(dueFacet, true, 0);
+  const result = selectPunctuationItem({
+    progress: {
+      items: {},
+      facets: { 'speech::fix': dueFacet },
+      rewardUnits: {},
+      attempts: [],
+      sessionsCompleted: 0,
+    },
+    session: { mode: 'weak', answeredCount: 0, recentItemIds: [] },
+    prefs: { mode: 'weak' },
+    now: 2 * DAY_MS,
+    random: () => 0,
+  });
+
+  assert.equal(result.item.id, 'sp_fix_question');
+  assert.equal(result.weakFocus.bucket, 'due');
+  assert.equal(result.weakFocus.source, 'due_facet');
+});
+
+test('weak mode keeps expanded-manifest candidate scoring bounded', async () => {
+  const { PUNCTUATION_CONTENT_MANIFEST, createPunctuationContentIndexes } = await import('../shared/punctuation/content.js');
+  const extraItems = Array.from({ length: 500 }, (_, index) => ({
+    id: `weak_extra_speech_${index}`,
+    mode: 'choose',
+    skillIds: ['speech'],
+    clusterId: 'speech',
+    rewardUnitId: 'speech-core',
+    prompt: 'Choose the best punctuated sentence.',
+    options: ['A.', 'B.'],
+    correctIndex: 0,
+    explanation: 'Bounded fixture.',
+    model: 'A.',
+    misconceptionTags: ['speech.fixture'],
+    readiness: ['retrieve_discriminate'],
+    source: 'generated',
+  }));
+  const indexes = createPunctuationContentIndexes({
+    ...PUNCTUATION_CONTENT_MANIFEST,
+    items: [...PUNCTUATION_CONTENT_MANIFEST.items, ...extraItems],
+  });
+  const result = selectPunctuationItem({
+    indexes,
+    progress: { items: {}, facets: {}, rewardUnits: {}, attempts: [], sessionsCompleted: 0 },
+    session: { mode: 'weak', answeredCount: 0, recentItemIds: [] },
+    prefs: { mode: 'weak' },
+    now: 0,
+    random: () => 0,
+    candidateWindow: 24,
+  });
+
+  assert.equal(result.inspectedCount, 24);
+  assert.ok(result.candidateCount > result.inspectedCount);
+});
+
 test('comma flow focus mode selects published comma cluster items only', () => {
   const result = selectPunctuationItem({
     progress: { items: {} },

--- a/tests/punctuation-service.test.js
+++ b/tests/punctuation-service.test.js
@@ -6,6 +6,7 @@ import {
   PUNCTUATION_RELEASE_ID,
 } from '../shared/punctuation/content.js';
 import { PUNCTUATION_EVENT_TYPES } from '../shared/punctuation/events.js';
+import { createMemoryState, updateMemoryState } from '../shared/punctuation/scheduler.js';
 import { createPunctuationService, PunctuationServiceError } from '../shared/punctuation/service.js';
 
 function makeRepository() {
@@ -31,6 +32,13 @@ function makeRepository() {
       return { data, practiceSession };
     },
   };
+}
+
+function correctAnswerFor(item) {
+  if (item.inputKind === 'choice') {
+    return { choiceIndex: item.options.find((option) => option.text === item.model)?.index ?? 0 };
+  }
+  return { typed: item.model };
 }
 
 test('punctuation service follows setup -> active-item -> feedback -> active-item -> summary', () => {
@@ -115,6 +123,32 @@ test('focus sessions keep their selected cluster after continue and skip', () =>
 
   const skipped = service.skipItem('learner-a', continued).state;
   assert.equal(skipped.session.currentItem.clusterId, 'structure');
+});
+
+test('weak spots sessions target weak facets and record weak attempt metadata', () => {
+  const repository = makeRepository();
+  repository.writeData('learner-a', {
+    prefs: { mode: 'smart', roundLength: '1' },
+    progress: {
+      items: {},
+      facets: { 'speech::insert': updateMemoryState(createMemoryState(), false, 0) },
+      rewardUnits: {},
+      attempts: [],
+      sessionsCompleted: 0,
+    },
+  });
+  const service = createPunctuationService({ repository, now: () => 0, random: () => 0 });
+
+  const start = service.startSession('learner-a', { mode: 'weak', roundLength: '1' }).state;
+  assert.equal(start.session.mode, 'weak');
+  assert.equal(start.session.currentItem.id, 'sp_insert_question');
+  assert.equal(start.session.weakFocus.skillId, 'speech');
+  assert.equal(start.session.weakFocus.source, 'weak_facet');
+
+  service.submitAnswer('learner-a', start, correctAnswerFor(start.session.currentItem));
+  const attempt = repository.snapshot().data.progress.attempts.at(-1);
+  assert.equal(attempt.sessionMode, 'weak');
+  assert.equal(attempt.supportLevel, 0);
 });
 
 test('one correct answer does not unlock secure-unit progress', () => {

--- a/tests/react-punctuation-scene.test.js
+++ b/tests/react-punctuation-scene.test.js
@@ -92,6 +92,8 @@ test('punctuation React surface renders guided setup controls and teach boxes', 
   assert.match(setupHtml, /Guided skill/);
   assert.match(setupHtml, /Guided learn/);
   assert.match(setupHtml, /data-punctuation-guided-start/);
+  assert.match(setupHtml, /Weak spots/);
+  assert.match(setupHtml, /data-punctuation-weak-start/);
 
   harness.store.updateSubjectUi('punctuation', {
     phase: 'active-item',
@@ -132,6 +134,41 @@ test('punctuation React surface renders guided setup controls and teach boxes', 
   assert.match(activeHtml, /Worked example/);
   assert.match(activeHtml, /Common mistake/);
   assert.doesNotMatch(activeHtml, /accepted|correctIndex|rubric|validator|generator|hiddenQueue/);
+});
+
+test('punctuation React surface renders weak focus chips safely', () => {
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.store.updateSubjectUi('punctuation', {
+    phase: 'active-item',
+    session: {
+      id: 'weak-ui',
+      mode: 'weak',
+      length: 1,
+      answeredCount: 0,
+      weakFocus: {
+        skillId: 'speech',
+        skillName: 'Inverted commas and speech punctuation',
+        mode: 'insert',
+        clusterId: 'speech',
+        bucket: 'weak',
+        source: 'weak_facet',
+      },
+      currentItem: {
+        id: 'sp_insert_question',
+        mode: 'insert',
+        inputKind: 'text',
+        prompt: 'Add the direct-speech punctuation.',
+        stem: 'Ella asked, can we start now?',
+      },
+    },
+  });
+
+  const html = harness.render();
+  assert.match(html, /Weak focus/);
+  assert.match(html, /Inverted commas and speech punctuation/);
+  assert.match(html, /insert/);
+  assert.doesNotMatch(html, /accepted|correctIndex|rubric|validator|generator|hiddenQueue/);
 });
 
 test('punctuation text input remounts when the current text item changes', async () => {

--- a/tests/worker-punctuation-runtime.test.js
+++ b/tests/worker-punctuation-runtime.test.js
@@ -206,6 +206,35 @@ test('punctuation guided mode fades visible support with the recorded support le
   }
 });
 
+test('punctuation command route starts weak spots with safe focus metadata', async () => {
+  const harness = createHarness();
+  try {
+    await harness.command('start-session', { mode: 'speech', roundLength: '4' });
+    const insert = await harness.command('skip-item');
+    assert.equal(insert.body.subjectReadModel.session.currentItem.id, 'sp_insert_question');
+    await harness.command('submit-answer', { typed: 'Ella asked can we start now' });
+
+    const weak = await harness.command('start-session', { mode: 'weak', roundLength: '1' });
+
+    assert.equal(weak.body.subjectReadModel.phase, 'active-item');
+    assert.equal(weak.body.subjectReadModel.session.mode, 'weak');
+    assert.equal(weak.body.subjectReadModel.session.currentItem.id, 'sp_insert_question');
+    assert.equal(weak.body.subjectReadModel.session.weakFocus.skillId, 'speech');
+    assert.equal(weak.body.subjectReadModel.session.weakFocus.source, 'weak_facet');
+    assert.deepEqual(Object.keys(weak.body.subjectReadModel.session.weakFocus).sort(), [
+      'bucket',
+      'clusterId',
+      'mode',
+      'skillId',
+      'skillName',
+      'source',
+    ]);
+    assert.doesNotMatch(payloadText(weak.body.subjectReadModel), /accepted|correctIndex|rubric|validator|hiddenQueue|generator/);
+  } finally {
+    harness.close();
+  }
+});
+
 test('punctuation command route stays unavailable until the rollout gate is enabled', async () => {
   const harness = createHarness({ punctuationEnabled: false });
   try {

--- a/worker/src/subjects/punctuation/read-models.js
+++ b/worker/src/subjects/punctuation/read-models.js
@@ -82,6 +82,18 @@ function guidedTeachBox(skillId, supportLevel = 0) {
   return box;
 }
 
+function safeWeakFocus(value) {
+  if (!isPlainObject(value)) return null;
+  return {
+    skillId: typeof value.skillId === 'string' ? value.skillId : '',
+    skillName: typeof value.skillName === 'string' ? value.skillName : '',
+    mode: typeof value.mode === 'string' ? value.mode : '',
+    clusterId: typeof value.clusterId === 'string' ? value.clusterId : null,
+    bucket: typeof value.bucket === 'string' ? value.bucket : '',
+    source: typeof value.source === 'string' ? value.source : '',
+  };
+}
+
 function safeSession(session, phase) {
   if (!isPlainObject(session)) return null;
   const safe = {
@@ -101,6 +113,7 @@ function safeSession(session, phase) {
       supportLevel: normaliseSupportLevel(session.guidedSupportLevel),
       teachBox: guidedTeachBox(session.guidedSkillId, session.guidedSupportLevel),
     } : null,
+    weakFocus: session.mode === 'weak' ? safeWeakFocus(session.weakFocus) : null,
     serverAuthority: session.serverAuthority === 'worker' ? 'worker' : null,
   };
   return safe;


### PR DESCRIPTION
## Summary
- add explicit Punctuation weak spots session mode targeting weak/due item memory and weak skill-by-mode facets
- expose safe weak-focus metadata through Worker read models and React focus chips
- update legacy parity tracking and live checklist so U3 weak spots is marked ported

## Tests
- node --test tests/punctuation-scheduler.test.js tests/punctuation-service.test.js tests/worker-punctuation-runtime.test.js tests/react-punctuation-scene.test.js tests/punctuation-legacy-parity.test.js tests/subject-command-actions.test.js
- node --test tests/punctuation-*.test.js tests/react-punctuation-*.test.js tests/subject-command-actions.test.js tests/bundle-audit.test.js
- npm test
- npm run check
- git diff --check HEAD~1..HEAD