### PR TITLE
style(app): polish detail and texture layer

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -8103,3 +8103,204 @@ textarea:focus-visible {
     background var(--dur) var(--ease-out),
     color var(--dur) var(--ease-out);
 }
+
+/* ==========================================================
+   Polish layer 3 + 4 — detail and texture refinements that
+   continue the paper aesthetic. Editorial focus halo, generic
+   <details> chevron, refined ink/caret/selection, smooth scroll,
+   custom paper scrollbars, italic-em editorial pop, dormant
+   button loading state. All additive, no token changes.
+   ========================================================== */
+
+/* ---------- Layer 3 · Editorial focus halo ----------
+   Soft brand-tinted halo around a slightly transparent ink rule.
+   Specificity = (0,1,1) so bespoke focus styles like
+   `.codex-creature-button:focus-visible`, `.subject-breadcrumb-link
+   :focus-visible`, `.wb-drill-audio-btn:focus-visible` (all (0,2,0))
+   continue to win where they own the paper-native focus styling. */
+button:focus-visible,
+.btn:focus-visible,
+.home-section-link:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--ink) 78%, transparent);
+  outline-offset: 3px;
+  box-shadow: 0 0 0 5px color-mix(in oklab, var(--brand) 14%, transparent);
+}
+.btn.primary:focus-visible {
+  box-shadow:
+    0 0 0 5px color-mix(in oklab, var(--brand) 22%, transparent),
+    inset 0 1px 0 rgba(255,255,255,0.28);
+}
+
+/* ---------- Layer 3 · Generic <details> chevron ----------
+   Applies to plain <details> blocks (PersistenceBanner,
+   AdminHubSurface). Lower specificity than the existing
+   `.parent-hub-session-item summary` rules, so parent-hub keeps
+   its bespoke chevron and layout. */
+details > summary {
+  list-style: none;
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--ink-2);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  transition: color var(--dur) var(--ease-out);
+}
+details > summary::-webkit-details-marker { display: none; }
+details > summary::before {
+  content: "›";
+  font-family: var(--font-serif);
+  font-size: 1.1rem;
+  line-height: 1;
+  color: var(--muted);
+  display: inline-block;
+  transform-origin: center;
+  transition: transform var(--dur) var(--ease-out), color var(--dur) var(--ease-out);
+}
+details[open] > summary::before {
+  transform: rotate(90deg);
+  color: var(--brand);
+}
+details > summary:hover {
+  color: var(--brand-ink);
+}
+@media (prefers-reduced-motion: reduce) {
+  details > summary::before {
+    transition: none !important;
+  }
+}
+
+/* ---------- Layer 3 · Caret + selection refinement ---------- */
+input, textarea {
+  caret-color: var(--brand);
+}
+::selection {
+  background: color-mix(in oklab, var(--brand) 24%, transparent);
+  color: var(--ink);
+}
+
+/* ---------- Layer 3 · Placeholder ink ---------- */
+input::placeholder,
+textarea::placeholder {
+  color: var(--subtle);
+  opacity: 1;
+  font-style: italic;
+}
+
+/* ---------- Layer 3 · Smooth scroll ----------
+   Existing `@media (prefers-reduced-motion: reduce)` already
+   sets `scroll-behavior: auto !important;` so this is safe. */
+html { scroll-behavior: smooth; }
+
+/* ---------- Layer 3 · Dormant button loading state ----------
+   Activates only when JSX adds `.is-loading`. Inline spinner
+   replaces label without changing button geometry. */
+.btn.is-loading {
+  pointer-events: none;
+  position: relative;
+  color: transparent !important;
+  text-shadow: none !important;
+}
+.btn.is-loading::after {
+  content: "";
+  position: absolute;
+  top: 50%; left: 50%;
+  width: 1em; height: 1em;
+  margin: -0.5em 0 0 -0.5em;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  color: var(--ink-2);
+  animation: polish-spin 720ms linear infinite;
+}
+.btn.primary.is-loading::after { color: rgba(255,255,255,0.9); }
+@keyframes polish-spin {
+  to { transform: rotate(360deg); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .btn.is-loading::after {
+    animation-duration: 1.6s !important;
+  }
+}
+
+/* ---------- Layer 4 · Italic-em editorial pop ----------
+   The hero mission italic word ("waiting." in the home hero)
+   gets a soft brand bloom — barely perceptible but lifts the
+   word off the paper. */
+.hero-mission .mission em {
+  text-shadow: 0 1px 0 color-mix(in oklab, var(--brand-soft) 70%, transparent);
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .hero-mission .mission em {
+    text-shadow: 0 0 18px color-mix(in oklab, var(--brand) 28%, transparent);
+  }
+}
+:root[data-theme="dark"] .hero-mission .mission em {
+  text-shadow: 0 0 18px color-mix(in oklab, var(--brand) 28%, transparent);
+}
+
+/* ---------- Layer 4 · Paper-aesthetic scrollbars ----------
+   Thin warm scrollbars instead of generic OS-native chrome.
+   Falls back gracefully on browsers that ignore the standards. */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--line-strong) transparent;
+}
+*::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+*::-webkit-scrollbar-thumb {
+  background: var(--line-strong);
+  border-radius: 999px;
+  transition: background var(--dur) var(--ease-out);
+}
+*::-webkit-scrollbar-thumb:hover {
+  background: var(--muted);
+}
+*::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+/* ---------- Layer 4 · Section-divider hairline above section heads ----------
+   Gives the journal-feel separator between the hero and the
+   first section, and between subsequent sections. The eyebrow
+   above each parent-hub section already provides a soft tag —
+   this hairline reinforces the page rhythm. */
+.home-section-head {
+  position: relative;
+  padding-top: 28px;
+}
+.home-section-head::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(
+    to right,
+    transparent,
+    color-mix(in oklab, var(--line-strong) 70%, transparent) 14%,
+    color-mix(in oklab, var(--line-strong) 70%, transparent) 86%,
+    transparent
+  );
+  pointer-events: none;
+}
+
+/* ---------- Layer 4 · Print refinement ---------- */
+@media print {
+  .hero-paper,
+  .codex-card,
+  .subject-card,
+  .parent-hub-card {
+    box-shadow: none !important;
+    animation: none !important;
+  }
+  .codex-stage-dot.is-current {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Summary

Second pass of additive CSS polish on `styles/app.css` (+201 lines). Continues the paper aesthetic / Fraunces editorial design language. No token changes, no JSX changes. Builds on the motion + hover layer landed in #113.

## What changed

**Layer 3 · Detail polish**

- **Editorial focus halo** — warm brand-tinted `box-shadow` ring around a slightly transparent ink outline; applied to `button`, `.btn`, `.home-section-link`. Bespoke focus rules (`.codex-creature-button`, `.subject-breadcrumb-link`, `.wb-drill-audio-btn`, etc.) continue to win on specificity (0,2,0 vs 0,1,1).
- **Generic `<details>` chevron** — rotate-on-open animation for plain `<details>` blocks (`PersistenceBanner`, `AdminHubSurface`). Lower specificity than the existing `.parent-hub-session-item summary` rules so parent-hub keeps its bespoke flex layout (`display: flex; justify-content: space-between`).
- **Caret + selection refinement** — `caret-color: var(--brand)` on inputs / textareas; refined `::selection` background mix.
- **Italic placeholder ink** — `var(--subtle)` colour, italic, full opacity (overrides browser default fade).
- **Smooth scroll** — `html { scroll-behavior: smooth }`. Already covered by the existing `@media (prefers-reduced-motion: reduce) { scroll-behavior: auto !important }` block.
- **Dormant `.btn.is-loading` state** — hides label, shows a centred CSS spinner, deactivates pointer events. Activates only when JSX adds the class — no behavioural change today, ready for use when needed.

**Layer 4 · Texture & finish**

- **Italic-em editorial pop** — `.hero-mission .mission em` (the "waiting." italic in the home hero) gains a soft brand bloom: warm-soft `text-shadow` in light mode, cool brand glow in dark mode.
- **Paper-aesthetic thin scrollbars** — warm `--line-strong` thumb on transparent track via `scrollbar-width` / `scrollbar-color` standards properties plus WebKit `::-webkit-scrollbar` rules. Falls back gracefully.
- **Section divider hairline** — gradient `transparent → line-strong → transparent` rule above `.home-section-head`. Adds journal rhythm between hero and grid sections without competing with the existing eyebrow markers.
- **Print refinement** — `@media print` resets shadows and animations on `hero-paper`, `subject-card`, `codex-card`, `parent-hub-card` so PDFs read as flat ink.

## Reduced motion + dark mode + a11y

- Every animation block has a corresponding `@media (prefers-reduced-motion: reduce)` override.
- Dark-mode variants of the italic-em bloom use the brand-strong glow rather than the soft fill, so contrast holds against `--panel`.
- Generic details chevron transitions are killed under reduced motion.
- All bespoke focus rings remain — only buttons that previously fell through to the global `button:focus-visible` ink-outline rule gain the new halo.

## Test plan

- [x] `npm run build` succeeds; CSS braces balanced (8307 lines, +201 from main).
- [x] `npm test` passes (567 tests).
- [x] Browser mock (Chrome DevTools), light mode: focus halo verified at `outline: 2px solid oklab(...)` with brand-tinted box-shadow; details chevron rotates from `matrix(1,0,0,1,...)` to `matrix(0,1,-1,0,...)` (= rotate(90deg)) on open; italic placeholder shows italicised; loading button hides label + shows spinner.
- [x] Browser mock, dark mode: italic-em brand glow visible against `--panel`; section divider hairline reads correctly; cancel button focus halo legible.
- [x] Cascade check: `.parent-hub-session-item summary` keeps `display: flex; justify-content: space-between; gap: 12px`; generic `details > summary` gets `display: inline-flex; gap: 8px`; both render expected chevron.
- [ ] Production smoke (`smoke:production:*`) after merge + deploy.
- [ ] Live verification on `ks2.eugnel.uk` post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)