### PR TITLE
feat(grammar): add transfer bridge placeholders

### DIFF
--- a/docs/plans/2026-04-24-001-feat-grammar-mastery-region-plan.md
+++ b/docs/plans/2026-04-24-001-feat-grammar-mastery-region-plan.md
@@ -33,11 +33,12 @@ Current Grammar state:
 - [x] Enabled Grammar modes cover learn, smart mixed review, KS2-style mini-set, weak concepts drill, sentence surgery, sentence builder, worked examples, and faded guidance.
 - [x] Strict KS2-style mini-set mode remains unsupported by pre-answer worked/faded guidance.
 - [x] AI enrichment now has a non-scored Worker safe lane that validates server-side enrichment output and only permits reviewed deterministic drill ids.
+- [x] Transfer and Bellstorm bridge placeholders now show the non-scored writing roadmap while keeping Bellstorm Coast as a separate Punctuation subject.
 - [x] Production smoke exists as `npm run smoke:production:grammar`.
 
 Open Grammar follow-up scope:
 
-- [ ] Add transfer and Bellstorm bridge placeholders without collapsing Grammar and Punctuation product identities.
+- [x] Add transfer and Bellstorm bridge placeholders without collapsing Grammar and Punctuation product identities.
 - [ ] Decide later whether paragraph-level transfer becomes non-scored, teacher-reviewed, or a separate deterministic workflow.
 - [ ] Decide whether to connect a live AI provider to the safe lane; provider keys must stay server-side and output must pass the existing validator.
 - [ ] Continue to run `npm test`, `npm run check`, and Grammar production/UI smoke for each shipped Grammar slice.
@@ -725,7 +726,7 @@ sequenceDiagram
 **Verification:**
 - AI improves explanation and reporting only; deterministic engine remains the sole score-bearing authority.
 
-- [ ] U9. **Add Transfer And Bellstorm Bridge Placeholders**
+- [x] U9. **Add Transfer And Bellstorm Bridge Placeholders**
 
 **Goal:** Make the full product path explicit without overbuilding paragraph writing or the future Punctuation region in the initial stages.
 

--- a/src/subjects/grammar/components/GrammarAnalyticsScene.jsx
+++ b/src/subjects/grammar/components/GrammarAnalyticsScene.jsx
@@ -57,6 +57,10 @@ function recentActivityForAnalytics(analytics = {}) {
   return [];
 }
 
+function punctuationGrammarConcepts(concepts = []) {
+  return concepts.filter((concept) => concept.punctuationForGrammar === true);
+}
+
 export function GrammarAnalyticsScene({ grammar, rewardState: providedRewardState = null }) {
   const concepts = grammar.analytics?.concepts || [];
   const counts = grammar.stats?.concepts || {};
@@ -68,6 +72,8 @@ export function GrammarAnalyticsScene({ grammar, rewardState: providedRewardStat
   const grouped = groupedGrammarConcepts(concepts);
   const rewardState = providedRewardState || grammar.projections?.rewards?.state || {};
   const recentActivity = recentActivityForAnalytics(grammar.analytics || {});
+  const punctuationConcepts = punctuationGrammarConcepts(concepts);
+  const securedPunctuationConcepts = punctuationConcepts.filter((concept) => concept.status === 'secured').length;
 
   return (
     <section className="card grammar-analytics" aria-labelledby="grammar-analytics-title">
@@ -85,6 +91,27 @@ export function GrammarAnalyticsScene({ grammar, rewardState: providedRewardStat
         <StatusCount label="weak" value={counts.weak || 0} className="weak" />
         <StatusCount label="due" value={counts.due || 0} className="due" />
         <StatusCount label="secured" value={counts.secured || 0} className="secured" />
+      </div>
+
+      <div className="grammar-bellstorm-bridge" aria-label="Grammar and Bellstorm Coast bridge">
+        <div>
+          <div className="eyebrow">Bellstorm bridge</div>
+          <h4>Punctuation-for-grammar stays in Grammar</h4>
+          <p>
+            These {punctuationConcepts.length} concepts count inside the 18-concept Grammar denominator for
+            KS2 GPS mastery. Bellstorm Coast remains the separate Punctuation subject for richer punctuation
+            progression.
+          </p>
+        </div>
+        <div className="grammar-bridge-counts" aria-label="Punctuation-for-grammar concept progress">
+          <strong>{securedPunctuationConcepts}/{punctuationConcepts.length || 0}</strong>
+          <span>secured in Grammar</span>
+        </div>
+        <div className="grammar-bridge-concepts" aria-label="Punctuation-for-grammar concepts">
+          {punctuationConcepts.map((concept) => (
+            <span className={`grammar-mini-concept ${concept.status}`} key={concept.id}>{concept.name}</span>
+          ))}
+        </div>
       </div>
 
       <div className="grammar-analytics-grid">

--- a/src/subjects/grammar/components/GrammarPracticeSurface.jsx
+++ b/src/subjects/grammar/components/GrammarPracticeSurface.jsx
@@ -7,6 +7,29 @@ import { GRAMMAR_MONSTER_ROUTES, GRAMMAR_SUBJECT_ID, normaliseGrammarReadModel }
 
 const MONSTER_CODEX_SYSTEM_ID = 'monster-codex';
 
+const GRAMMAR_TRANSFER_PLACEHOLDERS = Object.freeze([
+  {
+    id: 'paragraph-transfer',
+    eyebrow: 'Non-scored transfer',
+    title: 'Paragraph transfer',
+    copy: 'Coming next: short paragraph application that asks the learner to use Grammar choices in a wider piece of writing.',
+    bullets: [
+      'No score is recorded from this placeholder.',
+      'Teacher review and paragraph marking are not promised in this release.',
+    ],
+  },
+  {
+    id: 'writing-application',
+    eyebrow: 'Future writing application',
+    title: 'Richer writing tasks',
+    copy: 'Reserved for sentence-to-writing practice once the deterministic Grammar evidence and reporting path are stable.',
+    bullets: [
+      'Worker-marked Grammar remains the only score-bearing authority.',
+      'Any future writing workflow will ship as its own reviewed capability.',
+    ],
+  },
+]);
+
 function selectedLearner(appState) {
   const learnerId = appState?.learners?.selectedId || '';
   return learnerId ? appState.learners?.byId?.[learnerId] || null : null;
@@ -43,6 +66,40 @@ function resolveGrammarRewardState({ grammar, learner, repositories }) {
   return Object.keys(projectedState).length ? projectedState : persistedState;
 }
 
+function GrammarTransferPlaceholders() {
+  return (
+    <section className="card grammar-transfer-placeholders" aria-labelledby="grammar-transfer-title">
+      <div className="card-header">
+        <div>
+          <div className="eyebrow">Transfer bridge</div>
+          <h3 className="section-title" id="grammar-transfer-title">Writing application roadmap</h3>
+        </div>
+        <span className="chip">Coming next</span>
+      </div>
+      <div className="grammar-transfer-grid">
+        {GRAMMAR_TRANSFER_PLACEHOLDERS.map((entry) => (
+          <article className="grammar-transfer-card" key={entry.id}>
+            <div className="eyebrow">{entry.eyebrow}</div>
+            <h4>{entry.title}</h4>
+            <p>{entry.copy}</p>
+            <ul>
+              {entry.bullets.map((bullet) => <li key={bullet}>{bullet}</li>)}
+            </ul>
+            <button
+              className="btn secondary"
+              type="button"
+              disabled
+              data-grammar-transfer-placeholder={entry.id}
+            >
+              Coming next
+            </button>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
 export function GrammarPracticeSurface({
   appState,
   subject,
@@ -74,6 +131,7 @@ export function GrammarPracticeSurface({
     <div className="grammar-surface">
       <GrammarSetupScene {...shared} />
       <GrammarAnalyticsScene {...shared} />
+      <GrammarTransferPlaceholders />
     </div>
   );
 }

--- a/src/subjects/placeholders/index.js
+++ b/src/subjects/placeholders/index.js
@@ -33,11 +33,13 @@ export const grammarModule = createPlaceholderSubject({
 export const punctuationModule = createPlaceholderSubject({
   id: 'punctuation',
   name: 'Punctuation',
-  blurb: 'Commas, apostrophes, speech marks and more.',
+  blurb: 'Bellstorm Coast remains the separate path for commas, apostrophes, speech marks and punctuation progression.',
   accent: '#B8873F',
   accentSoft: '#F0E1C4',
   accentTint: '#F7EEDC',
   icon: 'quote',
+  region: 'Bellstorm Coast',
+  roadmapStage: 'separate-subject',
 });
 
 export const readingModule = createPlaceholderSubject({

--- a/styles/app.css
+++ b/styles/app.css
@@ -6754,6 +6754,96 @@ textarea:focus-visible {
   border-color: #edd9ae;
 }
 
+.grammar-bellstorm-bridge {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(120px, 0.18fr);
+  gap: 12px;
+  align-items: start;
+  margin-bottom: 18px;
+  padding: 16px;
+  border: 1px solid #e1c995;
+  border-radius: 8px;
+  background: #fff9ec;
+}
+
+.grammar-bellstorm-bridge h4,
+.grammar-transfer-card h4 {
+  margin: 0;
+  color: var(--ink);
+  font-size: 1rem;
+}
+
+.grammar-bellstorm-bridge p,
+.grammar-transfer-card p {
+  margin: 6px 0 0;
+  color: var(--ink-2);
+  line-height: 1.48;
+}
+
+.grammar-bridge-counts {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid #e5d3a8;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.7);
+  text-align: center;
+}
+
+.grammar-bridge-counts strong {
+  color: #8f5f16;
+  font-size: 1.4rem;
+  line-height: 1;
+}
+
+.grammar-bridge-counts span {
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.grammar-bridge-concepts {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.grammar-transfer-placeholders {
+  border-top: 4px solid #b8873f;
+}
+
+.grammar-transfer-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.grammar-transfer-card {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel-soft);
+}
+
+.grammar-transfer-card ul {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding-left: 18px;
+  color: var(--ink-2);
+  line-height: 1.42;
+}
+
+.grammar-transfer-card .btn {
+  justify-self: start;
+}
+
 .grammar-analytics-grid {
   display: grid;
   grid-template-columns: minmax(0, 1.1fr) minmax(280px, 0.9fr);
@@ -6879,6 +6969,8 @@ textarea:focus-visible {
 @media (max-width: 980px) {
   .grammar-setup-grid,
   .grammar-analytics-grid,
+  .grammar-bellstorm-bridge,
+  .grammar-transfer-grid,
   .grammar-evidence-panels {
     grid-template-columns: 1fr;
   }

--- a/tests/react-grammar-surface.test.js
+++ b/tests/react-grammar-surface.test.js
@@ -11,6 +11,7 @@ import { installMemoryStorage } from './helpers/memory-storage.js';
 import { grammarModule } from '../src/subjects/grammar/module.js';
 import { normaliseGrammarReadModel } from '../src/subjects/grammar/metadata.js';
 import { grammarMasteryKey } from '../src/platform/game/monster-system.js';
+import { getSubject, SUBJECTS } from '../src/platform/core/subject-registry.js';
 
 function grammarOracleSample(templateId = 'question_mark_select') {
   return readGrammarLegacyOracle().templates.find((template) => template.id === templateId);
@@ -167,6 +168,60 @@ test('Grammar analytics renders evidence before reward progress', () => {
   assert.match(html, /Fronted Adverbial pattern/);
   assert.match(html, /Question-type evidence/);
   assert.match(html, /Choose the correct sentence/);
+});
+
+test('Grammar renders transfer and Bellstorm bridge placeholders as locked future capabilities', () => {
+  const storage = installMemoryStorage();
+  const harness = createAppHarness({ storage });
+
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  const html = harness.render();
+
+  assert.match(html, /Writing application roadmap/);
+  assert.match(html, /Paragraph transfer/);
+  assert.match(html, /Richer writing tasks/);
+  assert.match(html, /Teacher review and paragraph marking are not promised/);
+  assert.match(html, /Worker-marked Grammar remains the only score-bearing authority/);
+  assert.match(html, /Bellstorm bridge/);
+  assert.match(html, /Punctuation-for-grammar stays in Grammar/);
+  assert.match(html, /Bellstorm Coast remains the separate Punctuation subject/);
+});
+
+test('Grammar locked transfer placeholders do not expose scoring commands', () => {
+  const storage = installMemoryStorage();
+  const harness = createAppHarness({ storage });
+
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  const html = harness.render();
+
+  assert.match(html, /<button(?=[^>]*data-grammar-transfer-placeholder="paragraph-transfer")(?=[^>]*disabled="")[^>]*>Coming next/);
+  assert.match(html, /<button(?=[^>]*data-grammar-transfer-placeholder="writing-application")(?=[^>]*disabled="")[^>]*>Coming next/);
+  assert.doesNotMatch(html, /data-grammar-transfer-submit/);
+  assert.doesNotMatch(html, /name="transfer-answer"/);
+
+  assert.equal(grammarModule.handleAction('grammar-transfer-submit', {
+    appState: harness.store.getState(),
+    data: { formData: new FormData() },
+    store: harness.store,
+    subjectCommands: {
+      send() {
+        throw new Error('Locked transfer placeholder must not submit a command.');
+      },
+    },
+  }), false);
+});
+
+test('Punctuation remains separately registered from Grammar Bellstorm bridge copy', () => {
+  const grammarSubject = getSubject('grammar');
+  const punctuationSubject = getSubject('punctuation');
+
+  assert.equal(grammarSubject.id, 'grammar');
+  assert.equal(punctuationSubject.id, 'punctuation');
+  assert.notEqual(grammarSubject, punctuationSubject);
+  assert.equal(punctuationSubject.name, 'Punctuation');
+  assert.equal(punctuationSubject.available, true);
+  assert.match(punctuationSubject.blurb, /full KS2 punctuation map/);
+  assert.equal(SUBJECTS.filter((subject) => subject.id === 'punctuation').length, 1);
 });
 
 test('Grammar analytics renders normalised recent activity before raw attempts', () => {
@@ -440,7 +495,7 @@ test('Grammar legacy modes render available without locked placeholders', () => 
   assert.doesNotMatch(html, /<button class="grammar-mode locked" type="button" disabled="">[\s\S]*Worked examples/);
   assert.match(html, /<button class="grammar-mode" type="button">[\s\S]*Faded guidance/);
   assert.doesNotMatch(html, /<button class="grammar-mode locked" type="button" disabled="">[\s\S]*Faded guidance/);
-  assert.doesNotMatch(html, /Coming next/);
+  assert.doesNotMatch(html, /<button class="grammar-mode locked" type="button" disabled="">/);
 });
 
 test('Grammar setup can start trouble drill mode', () => {


### PR DESCRIPTION
## Summary
- add locked, non-scored Grammar transfer placeholders for paragraph transfer and richer writing application
- add a Bellstorm bridge panel that counts punctuation-for-grammar inside Grammar while keeping Bellstorm Coast as a separate Punctuation subject
- update the Grammar live checklist for U9 and add regression coverage for locked placeholders plus subject identity separation

## Verification
- env NODE_PATH=/Users/jamesto/Coding/ks2-mastery/node_modules npm test -- tests/react-grammar-surface.test.js tests/react-subject-contract.test.js tests/subject-contract.test.js
- git diff --check
- env NODE_PATH=/Users/jamesto/Coding/ks2-mastery/node_modules npm test (574 pass, 1 skipped browser smoke)
- npm run check