### PR TITLE
feat(punctuation): add gps test mode

### DIFF
--- a/docs/plans/2026-04-24-002-feat-punctuation-legacy-parity-plan.md
+++ b/docs/plans/2026-04-24-002-feat-punctuation-legacy-parity-plan.md
@@ -328,7 +328,7 @@ tests/
 
 ---
 
-- [ ] U6. **Add True GPS Test Mode**
+- [x] U6. **Add True GPS Test Mode**
 
 **Goal:** Port legacy GPS-style test behaviour with delayed feedback and end-of-test review.
 

--- a/docs/punctuation-production.md
+++ b/docs/punctuation-production.md
@@ -244,8 +244,8 @@ shared/punctuation/legacy-parity.js
 
 The baseline currently classifies legacy behaviour as:
 
-- Ported: the 14-skill map, Worker command runtime, Smart review, guided learning, dedicated weak spots, `choose`, `insert`, `fix`, `transfer`, `combine`, `paragraph`, reward-unit analytics, skill rows, and recent mistakes.
-- Planned: GPS test mode, richer transfer validators, safe context-pack compilation, and deeper Parent/Admin evidence.
+- Ported: the 14-skill map, Worker command runtime, Smart review, guided learning, dedicated weak spots, GPS test mode, `choose`, `insert`, `fix`, `transfer`, `combine`, `paragraph`, reward-unit analytics, skill rows, and recent mistakes.
+- Planned: richer transfer validators, safe context-pack compilation, and deeper Parent/Admin evidence.
 - Replaced: legacy standalone `choose`, `insert`, `fix`, `transfer`, sentence-combining, and paragraph-repair session buttons are represented by production item modes inside Smart review, weak spots, and focused cluster sessions.
 - Rejected: the legacy single-file production route, localStorage source of truth, browser-owned marking, and browser-stored AI provider keys.
 

--- a/shared/punctuation/service.js
+++ b/shared/punctuation/service.js
@@ -10,6 +10,7 @@ import {
   createPunctuationUnitSecuredEvent,
 } from './events.js';
 import { createPunctuationRuntimeManifest } from './generators.js';
+import { parseChoiceIndex } from './choice-index.js';
 import { markPunctuationAnswer, normaliseAnswerText } from './marking.js';
 import {
   memorySnapshot,
@@ -35,6 +36,7 @@ import {
 const SUBJECT_ID = 'punctuation';
 const SERVER_AUTHORITY = 'worker';
 const GENERATED_ITEMS_PER_FAMILY = 1;
+const MAX_GPS_QUEUE_LENGTH = 12;
 
 function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -153,6 +155,7 @@ export function normalisePunctuationData(value) {
               skillIds: normaliseStringArray(attempt.skillIds),
               rewardUnitId: typeof attempt.rewardUnitId === 'string' ? attempt.rewardUnitId : '',
               sessionMode: typeof attempt.sessionMode === 'string' ? attempt.sessionMode : '',
+              testMode: attempt.testMode === 'gps' ? 'gps' : null,
               supportLevel: normaliseNonNegativeInteger(attempt.supportLevel, 0),
               correct: attempt.correct === true,
               misconceptionTags: normaliseStringArray(attempt.misconceptionTags),
@@ -194,6 +197,54 @@ function normaliseItemForState(item) {
       : [];
   }
   return safe;
+}
+
+function normaliseFacetForReview(value) {
+  if (!isPlainObject(value)) return null;
+  const id = typeof value.id === 'string' ? value.id : '';
+  if (!id) return null;
+  return {
+    id,
+    ok: value.ok === true,
+    label: typeof value.label === 'string' ? value.label : '',
+  };
+}
+
+function normaliseGpsResponse(value) {
+  if (!isPlainObject(value)) return null;
+  const itemId = typeof value.itemId === 'string' ? value.itemId : '';
+  if (!itemId) return null;
+  return {
+    itemId,
+    mode: typeof value.mode === 'string' ? value.mode : '',
+    skillIds: normaliseStringArray(value.skillIds),
+    rewardUnitId: typeof value.rewardUnitId === 'string' ? value.rewardUnitId : '',
+    prompt: typeof value.prompt === 'string' ? value.prompt : '',
+    stem: typeof value.stem === 'string' ? value.stem : '',
+    attemptedAnswer: typeof value.attemptedAnswer === 'string' ? value.attemptedAnswer.slice(0, 500) : '',
+    displayCorrection: typeof value.displayCorrection === 'string' ? value.displayCorrection : '',
+    explanation: typeof value.explanation === 'string' ? value.explanation : '',
+    correct: value.correct === true,
+    misconceptionTags: normaliseStringArray(value.misconceptionTags),
+    facets: Array.isArray(value.facets) ? value.facets.map(normaliseFacetForReview).filter(Boolean) : [],
+  };
+}
+
+function normaliseGpsSession(value) {
+  if (!isPlainObject(value)) {
+    return {
+      queueItemIds: [],
+      responses: [],
+      delayedFeedback: true,
+    };
+  }
+  return {
+    queueItemIds: normaliseStringArray(value.queueItemIds).slice(0, MAX_GPS_QUEUE_LENGTH),
+    responses: Array.isArray(value.responses)
+      ? value.responses.map(normaliseGpsResponse).filter(Boolean).slice(0, MAX_GPS_QUEUE_LENGTH)
+      : [],
+    delayedFeedback: true,
+  };
 }
 
 function guidedTeachBoxForSkill(skillId, supportLevel = 0) {
@@ -245,10 +296,11 @@ function normaliseSession(value) {
   if (!isPlainObject(value)) return null;
   const guidedSkillId = typeof value.guidedSkillId === 'string' ? value.guidedSkillId : null;
   const guidedSupportLevel = normaliseNonNegativeInteger(value.guidedSupportLevel, 0);
+  const mode = normalisePunctuationMode(value.mode);
   return {
     id: typeof value.id === 'string' && value.id ? value.id : '',
     releaseId: typeof value.releaseId === 'string' ? value.releaseId : PUNCTUATION_RELEASE_ID,
-    mode: normalisePunctuationMode(value.mode),
+    mode,
     length: Math.max(1, normaliseNonNegativeInteger(value.length, 4)),
     phase: value.phase === 'feedback' ? 'feedback' : 'active-item',
     startedAt: normaliseTimestamp(value.startedAt, 0),
@@ -262,10 +314,11 @@ function normaliseSession(value) {
     misconceptionTags: normaliseStringArray(value.misconceptionTags),
     guidedSkillId,
     guidedSupportLevel,
-    guided: value.mode === 'guided'
+    guided: mode === 'guided'
       ? (isPlainObject(value.guided) ? cloneSerialisable(value.guided) : guidedSessionReadModel(guidedSkillId, guidedSupportLevel))
       : null,
-    weakFocus: value.mode === 'weak' ? normaliseWeakFocus(value.weakFocus) : null,
+    weakFocus: mode === 'weak' ? normaliseWeakFocus(value.weakFocus) : null,
+    gps: mode === 'gps' ? normaliseGpsSession(value.gps) : null,
     serverAuthority: value.serverAuthority === SERVER_AUTHORITY ? SERVER_AUTHORITY : null,
   };
 }
@@ -464,6 +517,13 @@ function roundLengthFromPrefs(prefs = {}) {
   return Math.max(1, Number.parseInt(value, 10) || 4);
 }
 
+function roundLengthForSession(prefs = {}, options = {}) {
+  if (prefs.mode !== 'gps') return roundLengthFromPrefs(prefs);
+  const value = normalisePunctuationRoundLength(options.testLength ?? options.roundLength ?? options.length ?? prefs.roundLength);
+  if (value === 'all') return 8;
+  return Math.min(MAX_GPS_QUEUE_LENGTH, Math.max(1, Number.parseInt(value, 10) || 4));
+}
+
 function prefsForSession(session = {}, fallback = {}) {
   return normalisePunctuationPrefs({
     ...fallback,
@@ -472,12 +532,164 @@ function prefsForSession(session = {}, fallback = {}) {
   });
 }
 
+function answerDisplayText(item, answer = {}) {
+  if (item?.mode === 'choose') {
+    const index = parseChoiceIndex(answer.choiceIndex ?? answer.value ?? answer.typed);
+    const option = index != null && Array.isArray(item.options)
+      ? item.options.find((entry, fallbackIndex) => {
+          if (isPlainObject(entry)) return Number(entry.index) === index;
+          return fallbackIndex === index;
+        })
+      : null;
+    if (isPlainObject(option)) return normaliseAnswerText(option.text);
+    if (typeof option === 'string') return normaliseAnswerText(option);
+    return index != null ? `Choice ${index + 1}` : '';
+  }
+  return normaliseAnswerText(answer.typed ?? answer.answer ?? '');
+}
+
+function reviewItemFromResult({ item, answer, result }) {
+  return {
+    itemId: item.id,
+    mode: item.mode,
+    skillIds: Array.isArray(item.skillIds) ? [...item.skillIds] : [],
+    rewardUnitId: item.rewardUnitId || '',
+    prompt: item.prompt || '',
+    stem: item.stem || '',
+    attemptedAnswer: answerDisplayText(item, answer),
+    displayCorrection: result.expected || item.model || '',
+    explanation: item.explanation || result.note || '',
+    correct: result.correct === true,
+    misconceptionTags: Array.isArray(result.misconceptionTags) ? [...result.misconceptionTags] : [],
+    facets: Array.isArray(result.facets) ? result.facets.map(normaliseFacetForReview).filter(Boolean) : [],
+  };
+}
+
+function resultFromReviewResponse(response = {}) {
+  return {
+    correct: response.correct === true,
+    expected: response.displayCorrection || '',
+    note: response.explanation || '',
+    misconceptionTags: normaliseStringArray(response.misconceptionTags),
+    facets: Array.isArray(response.facets) ? response.facets.map(normaliseFacetForReview).filter(Boolean) : [],
+  };
+}
+
+function applyMarkedAttemptToProgress({
+  data,
+  indexes,
+  session,
+  item,
+  result,
+  nowValue,
+  supportLevel = 0,
+} = {}) {
+  const guidedSupport = supportLevel > 0;
+  const rewardUnit = rewardUnitForItem(indexes, item);
+
+  data.progress.items[item.id] = updateMemoryState(data.progress.items[item.id], result.correct, nowValue, {
+    supported: guidedSupport,
+  });
+  for (const skillId of item.skillIds || []) {
+    data.progress.facets[facetKey(skillId, item.mode)] = updateMemoryState(
+      data.progress.facets[facetKey(skillId, item.mode)],
+      result.correct,
+      nowValue,
+      { supported: guidedSupport },
+    );
+  }
+
+  const nextItemSnap = memorySnapshot(data.progress.items[item.id], nowValue);
+  const securedRows = [];
+  if (rewardUnit && nextItemSnap.secure && !data.progress.rewardUnits[rewardUnit.masteryKey]) {
+    data.progress.rewardUnits[rewardUnit.masteryKey] = {
+      masteryKey: rewardUnit.masteryKey,
+      releaseId: rewardUnit.releaseId,
+      clusterId: rewardUnit.clusterId,
+      rewardUnitId: rewardUnit.rewardUnitId,
+      securedAt: nowValue,
+    };
+    securedRows.push({ masteryKey: rewardUnit.masteryKey, item, rewardUnit });
+  }
+
+  data.progress.attempts.push({
+    ts: nowValue,
+    sessionId: session.id,
+    itemId: item.id,
+    mode: item.mode,
+    skillIds: item.skillIds || [],
+    rewardUnitId: item.rewardUnitId || '',
+    sessionMode: session.mode || '',
+    testMode: session.mode === 'gps' ? 'gps' : null,
+    supportLevel,
+    correct: result.correct,
+    misconceptionTags: result.misconceptionTags || [],
+  });
+  data.progress.attempts = data.progress.attempts.slice(-1000);
+
+  return { securedRows };
+}
+
+function attemptEventsForReviewResponses({ learnerId, session, responses, indexes, createdAt }) {
+  const events = [];
+  for (const [index, response] of responses.entries()) {
+    const item = itemForId(indexes, response.itemId);
+    if (!item) continue;
+    const eventSession = {
+      ...session,
+      answeredCount: index,
+    };
+    const result = resultFromReviewResponse(response);
+    events.push(createPunctuationItemAttemptedEvent({
+      learnerId,
+      session: eventSession,
+      item,
+      result,
+      answer: response.attemptedAnswer || '',
+      createdAt,
+    }));
+    events.push(...createPunctuationMisconceptionObservedEvents({
+      learnerId,
+      session: eventSession,
+      item,
+      result,
+      createdAt,
+    }));
+  }
+  return events;
+}
+
+function unitEventsForSecuredRows({ learnerId, session, securedRows, createdAt }) {
+  return securedRows.map(({ masteryKey, item, rewardUnit }) => createPunctuationUnitSecuredEvent({
+    learnerId,
+    session,
+    item,
+    rewardUnit,
+    masteryKey,
+    createdAt,
+  }));
+}
+
+function gpsRecommendedMode(responses = []) {
+  const missed = responses.filter((entry) => entry && entry.correct !== true);
+  if (missed.length) {
+    return {
+      recommendedMode: 'weak',
+      recommendedLabel: 'Weak spots',
+    };
+  }
+  return {
+    recommendedMode: 'smart',
+    recommendedLabel: 'Smart review',
+  };
+}
+
 function sessionSummary(session, data, indexes, now = Date.now) {
   const total = Number(session?.answeredCount) || 0;
   const correct = Number(session?.correctCount) || 0;
-  return {
+  const summary = {
     label: 'Punctuation session summary',
-    message: total ? 'Session complete.' : 'Session ended.',
+    message: session?.mode === 'gps' && total ? 'GPS test complete.' : (total ? 'Session complete.' : 'Session ended.'),
     total,
     correct,
     accuracy: total ? Math.round((correct / total) * 100) : 0,
@@ -492,10 +704,74 @@ function sessionSummary(session, data, indexes, now = Date.now) {
       published: indexes.publishedRewardUnits.length,
     },
   };
+  if (session?.mode === 'gps') {
+    const reviewItems = Array.isArray(session.gps?.responses)
+      ? session.gps.responses.map((entry, index) => ({
+          index: index + 1,
+          ...normaliseGpsResponse(entry),
+        })).filter((entry) => entry.itemId)
+      : [];
+    summary.label = 'Punctuation GPS test summary';
+    summary.gps = {
+      delayedFeedback: true,
+      ...gpsRecommendedMode(reviewItems),
+      reviewItems,
+    };
+  }
+  return summary;
 }
 
-function nextActiveState({ learnerId, session, data, indexes, prefs, now, random }) {
-  const selection = selectPunctuationItem({
+function buildGpsQueue({ session, data, indexes, prefs, now, random }) {
+  const length = Math.min(MAX_GPS_QUEUE_LENGTH, Math.max(1, Number(session.length) || 4));
+  const queue = [];
+  let draftSession = {
+    ...session,
+    recentItemIds: [],
+    currentItemId: '',
+    answeredCount: 0,
+  };
+  for (let index = 0; index < length; index += 1) {
+    const selection = selectPunctuationItem({
+      indexes,
+      progress: data.progress,
+      session: { ...draftSession, answeredCount: index },
+      prefs,
+      now,
+      random,
+    });
+    if (!selection.item) break;
+    queue.push(selection.item.id);
+    draftSession = {
+      ...draftSession,
+      currentItemId: selection.item.id,
+      recentItemIds: [...draftSession.recentItemIds, selection.item.id].slice(-10),
+    };
+  }
+  return queue;
+}
+
+function selectionForSession({ session, data, indexes, prefs, now, random }) {
+  if (session.mode === 'gps') {
+    const queueItemIds = Array.isArray(session.gps?.queueItemIds) ? session.gps.queueItemIds : [];
+    const nextItemId = queueItemIds[session.answeredCount] || '';
+    const item = itemForId(indexes, nextItemId);
+    if (item) {
+      return {
+        item,
+        weakFocus: null,
+      };
+    }
+    throw serviceError(
+      'punctuation_gps_queue_stale',
+      'The fixed Punctuation GPS queue no longer matches the active content release.',
+      {
+        itemId: nextItemId,
+        answeredCount: session.answeredCount,
+        queueLength: queueItemIds.length,
+      },
+    );
+  }
+  return selectPunctuationItem({
     indexes,
     progress: data.progress,
     session,
@@ -503,6 +779,10 @@ function nextActiveState({ learnerId, session, data, indexes, prefs, now, random
     now,
     random,
   });
+}
+
+function nextActiveState({ learnerId, session, data, indexes, prefs, now, random }) {
+  const selection = selectionForSession({ session, data, indexes, prefs, now, random });
   if (!selection.item) {
     throw serviceError('punctuation_content_unavailable', 'No published Punctuation content is available.');
   }
@@ -560,6 +840,78 @@ export function createPunctuationService({
   indexes = createPunctuationContentIndexes(manifest),
 } = {}) {
   const clock = () => timestamp(now);
+  const activeReleaseId = manifest.releaseId || PUNCTUATION_RELEASE_ID;
+
+  function assertGpsReleaseCurrent(session, command) {
+    if (session?.mode !== 'gps') return;
+    const sessionReleaseId = typeof session.releaseId === 'string' && session.releaseId
+      ? session.releaseId
+      : PUNCTUATION_RELEASE_ID;
+    if (sessionReleaseId === activeReleaseId) return;
+    throw serviceError(
+      'punctuation_gps_release_stale',
+      'The active Punctuation GPS test was started against an older content release.',
+      {
+        command,
+        sessionId: typeof session.id === 'string' ? session.id : '',
+        sessionReleaseId,
+        releaseId: activeReleaseId,
+      },
+    );
+  }
+
+  function assertExpectedSessionContext(session, expectedContext, command) {
+    if (!session) return;
+    const context = isPlainObject(expectedContext) ? expectedContext : {};
+    const expectedSessionId = typeof context.expectedSessionId === 'string' && context.expectedSessionId
+      ? context.expectedSessionId
+      : null;
+    const expectedItemId = typeof context.expectedItemId === 'string' && context.expectedItemId
+      ? context.expectedItemId
+      : null;
+    const expectedReleaseId = typeof context.expectedReleaseId === 'string' && context.expectedReleaseId
+      ? context.expectedReleaseId
+      : null;
+    const rawExpectedAnsweredCount = context.expectedAnsweredCount;
+    const hasExpectedAnsweredCount = (
+      (typeof rawExpectedAnsweredCount === 'number' || typeof rawExpectedAnsweredCount === 'string')
+      && rawExpectedAnsweredCount !== ''
+      && Number.isFinite(Number(rawExpectedAnsweredCount))
+    );
+    const expectedAnsweredCount = hasExpectedAnsweredCount ? Number(rawExpectedAnsweredCount) : null;
+    const requiresExpectedContext = session.mode === 'gps';
+    const missingRequiredContext = requiresExpectedContext && (
+      !expectedSessionId
+      || !expectedItemId
+      || !expectedReleaseId
+      || !hasExpectedAnsweredCount
+    );
+
+    if (
+      missingRequiredContext
+      || (expectedSessionId && expectedSessionId !== session.id)
+      || (expectedItemId && expectedItemId !== session.currentItemId)
+      || (expectedReleaseId && expectedReleaseId !== session.releaseId)
+      || (hasExpectedAnsweredCount && expectedAnsweredCount !== session.answeredCount)
+    ) {
+      throw serviceError(
+        'punctuation_command_stale',
+        'The Punctuation command no longer matches the active session item.',
+        {
+          command,
+          expectedSessionId,
+          sessionId: session.id || '',
+          expectedItemId,
+          itemId: session.currentItemId || '',
+          expectedAnsweredCount,
+          answeredCount: session.answeredCount,
+          expectedReleaseId,
+          releaseId: session.releaseId || '',
+          missingExpectedContext: missingRequiredContext,
+        },
+      );
+    }
+  }
 
   function requireActiveItem(ui, command = 'submit-answer') {
     const state = normaliseState(ui);
@@ -569,6 +921,7 @@ export function createPunctuationService({
         phase: state.phase,
       });
     }
+    assertGpsReleaseCurrent(state.session, command);
     return state;
   }
 
@@ -581,6 +934,76 @@ export function createPunctuationService({
       });
     }
     return state;
+  }
+
+  function finaliseGpsSession({ learnerId, state, data, session, responses, nowValue }) {
+    assertGpsReleaseCurrent(session, 'finalise-gps');
+    const securedRows = [];
+    const resolvedResponses = responses.map((response, index) => {
+      const responseItem = itemForId(indexes, response.itemId);
+      if (!responseItem) {
+        throw serviceError(
+          'punctuation_gps_response_stale',
+          'A completed Punctuation GPS response no longer matches the active content release.',
+          {
+            itemId: response.itemId,
+            responseIndex: index,
+            sessionId: session.id,
+          },
+        );
+      }
+      return { index, response, responseItem };
+    });
+    for (const { index, response, responseItem } of resolvedResponses) {
+      const applied = applyMarkedAttemptToProgress({
+        data,
+        indexes,
+        session: { ...session, answeredCount: index },
+        item: responseItem,
+        result: resultFromReviewResponse(response),
+        nowValue,
+        supportLevel: 0,
+      });
+      securedRows.push(...applied.securedRows);
+    }
+    const nextSession = {
+      ...session,
+      securedUnits: [...new Set([
+        ...(session.securedUnits || []),
+        ...securedRows.map((entry) => entry.masteryKey),
+      ])],
+    };
+    data.progress.sessionsCompleted += responses.length > 0 ? 1 : 0;
+    writeData(repository, learnerId, data);
+    const summary = sessionSummary(nextSession, data, indexes, clock);
+    const nextState = {
+      ...state,
+      phase: 'summary',
+      session: nextSession,
+      feedback: null,
+      summary,
+      error: '',
+    };
+    syncPracticeSession(repository, learnerId, nextState, clock);
+    const events = responses.length > 0
+      ? [
+          ...attemptEventsForReviewResponses({
+            learnerId,
+            session: nextSession,
+            responses,
+            indexes,
+            createdAt: nowValue,
+          }),
+          ...unitEventsForSecuredRows({
+            learnerId,
+            session: nextSession,
+            securedRows,
+            createdAt: nowValue,
+          }),
+          createPunctuationSessionCompletedEvent({ learnerId, session: nextSession, summary, createdAt: nowValue }),
+        ]
+      : [];
+    return stateTransition(nextState, { events });
   }
 
   const service = {
@@ -618,9 +1041,9 @@ export function createPunctuationService({
         : null;
       const session = {
         id: uid('punctuation-session', clock, random),
-        releaseId: manifest.releaseId || PUNCTUATION_RELEASE_ID,
+        releaseId: activeReleaseId,
         mode: prefs.mode,
-        length: roundLengthFromPrefs(prefs),
+        length: roundLengthForSession(prefs, options),
         phase: 'active-item',
         startedAt: clock(),
         updatedAt: clock(),
@@ -635,13 +1058,26 @@ export function createPunctuationService({
         guidedSupportLevel: guidedSkillId ? 2 : 0,
         guided: guidedSkillId ? guidedSessionReadModel(guidedSkillId, 2) : null,
         weakFocus: null,
+        gps: prefs.mode === 'gps' ? { queueItemIds: [], responses: [], delayedFeedback: true } : null,
       };
+      if (session.mode === 'gps') {
+        session.gps.queueItemIds = buildGpsQueue({
+          session,
+          data: current,
+          indexes,
+          prefs,
+          now: clock,
+          random,
+        });
+        session.length = session.gps.queueItemIds.length || session.length;
+      }
       const state = nextActiveState({ learnerId, session, data: current, indexes, prefs, now: clock, random });
       syncPracticeSession(repository, learnerId, state, clock);
       return stateTransition(state);
     },
-    submitAnswer(learnerId, uiState, rawAnswer = '') {
+    submitAnswer(learnerId, uiState, rawAnswer = '', expectedContext = {}) {
       const state = requireActiveItem(uiState, 'submit-answer');
+      assertExpectedSessionContext(state.session, expectedContext, 'submit-answer');
       const data = readData(repository, learnerId);
       const item = itemForId(indexes, state.session.currentItemId);
       if (!item) {
@@ -657,49 +1093,61 @@ export function createPunctuationService({
       const supportLevel = state.session.mode === 'guided'
         ? normaliseNonNegativeInteger(state.session.guidedSupportLevel, 0)
         : 0;
-      const guidedSupport = supportLevel > 0;
-      const rewardUnit = rewardUnitForItem(indexes, item);
-      const previousUnitSnap = rewardUnit
-        ? memorySnapshot(data.progress.rewardUnits[rewardUnit.masteryKey] ? { attempts: 3, correct: 3, streak: 3, firstCorrectAt: 0, lastCorrectAt: 8 * 24 * 60 * 60 * 1000 } : data.progress.items[item.id], nowValue)
-        : null;
-
-      data.progress.items[item.id] = updateMemoryState(data.progress.items[item.id], result.correct, nowValue, {
-        supported: guidedSupport,
-      });
-      for (const skillId of item.skillIds || []) {
-        data.progress.facets[facetKey(skillId, item.mode)] = updateMemoryState(
-          data.progress.facets[facetKey(skillId, item.mode)],
-          result.correct,
-          nowValue,
-          { supported: guidedSupport },
-        );
-      }
-      const nextItemSnap = memorySnapshot(data.progress.items[item.id], nowValue);
-      const securedUnits = [];
-      if (rewardUnit && nextItemSnap.secure && !data.progress.rewardUnits[rewardUnit.masteryKey]) {
-        data.progress.rewardUnits[rewardUnit.masteryKey] = {
-          masteryKey: rewardUnit.masteryKey,
-          releaseId: rewardUnit.releaseId,
-          clusterId: rewardUnit.clusterId,
-          rewardUnitId: rewardUnit.rewardUnitId,
-          securedAt: nowValue,
+      const reviewResponse = reviewItemFromResult({ item, answer, result });
+      if (state.session.mode === 'gps') {
+        const gps = normaliseGpsSession(state.session.gps);
+        const nextResponses = [...gps.responses, reviewResponse].slice(0, MAX_GPS_QUEUE_LENGTH);
+        const nextSession = {
+          ...state.session,
+          phase: 'active-item',
+          answeredCount: state.session.answeredCount + 1,
+          correctCount: state.session.correctCount + (result.correct ? 1 : 0),
+          updatedAt: nowValue,
+          securedUnits: normaliseStringArray(state.session.securedUnits),
+          misconceptionTags: [...new Set([...(state.session.misconceptionTags || []), ...(result.misconceptionTags || [])])],
+          guided: null,
+          guidedSupportLevel: 0,
+          gps: {
+            ...gps,
+            responses: nextResponses,
+            delayedFeedback: true,
+          },
         };
-        securedUnits.push(rewardUnit.masteryKey);
+
+        if (nextSession.answeredCount >= nextSession.length) {
+          return finaliseGpsSession({
+            learnerId,
+            state,
+            data,
+            session: nextSession,
+            responses: nextResponses,
+            nowValue,
+          });
+        }
+
+        const nextState = nextActiveState({
+          learnerId,
+          session: nextSession,
+          data,
+          indexes,
+          prefs: prefsForSession(nextSession, data.prefs),
+          now: clock,
+          random,
+        });
+        syncPracticeSession(repository, learnerId, nextState, clock);
+        return stateTransition(nextState, { events: [] });
       }
 
-      data.progress.attempts.push({
-        ts: nowValue,
-        sessionId: state.session.id,
-        itemId: item.id,
-        mode: item.mode,
-        skillIds: item.skillIds || [],
-        rewardUnitId: item.rewardUnitId || '',
-        sessionMode: state.session.mode || '',
+      const { securedRows } = applyMarkedAttemptToProgress({
+        data,
+        indexes,
+        session: state.session,
+        item,
+        result,
+        nowValue,
         supportLevel,
-        correct: result.correct,
-        misconceptionTags: result.misconceptionTags || [],
       });
-      data.progress.attempts = data.progress.attempts.slice(-1000);
+      const securedUnits = securedRows.map((entry) => entry.masteryKey);
       writeData(repository, learnerId, data);
 
       const nextSession = {
@@ -721,7 +1169,7 @@ export function createPunctuationService({
         kind: result.correct ? 'success' : 'error',
         headline: result.correct ? 'Correct.' : 'Not quite.',
         body: result.note || item.explanation || '',
-        attemptedAnswer: normaliseAnswerText(answer.typed ?? answer.answer ?? answer.choiceIndex ?? ''),
+        attemptedAnswer: answerDisplayText(item, answer),
         displayCorrection: result.expected || item.model || '',
         explanation: item.explanation || '',
         misconceptionTags: result.misconceptionTags || [],
@@ -752,18 +1200,15 @@ export function createPunctuationService({
         result,
         createdAt: nowValue,
       });
-      const unitEvents = securedUnits.map((masteryKey) => createPunctuationUnitSecuredEvent({
+      const unitEvents = unitEventsForSecuredRows({
         learnerId,
         session: state.session,
-        item,
-        rewardUnit,
-        masteryKey,
+        securedRows,
         createdAt: nowValue,
-      }));
+      });
 
       return stateTransition(nextState, {
         events: [attemptEvent, ...misconceptionEvents, ...unitEvents],
-        changed: !previousUnitSnap || true,
       });
     },
     continueSession(learnerId, uiState) {
@@ -797,8 +1242,14 @@ export function createPunctuationService({
       syncPracticeSession(repository, learnerId, nextState, clock);
       return stateTransition(nextState);
     },
-    skipItem(learnerId, uiState) {
+    skipItem(learnerId, uiState, expectedContext = {}) {
       const state = requireActiveItem(uiState, 'skip-item');
+      assertExpectedSessionContext(state.session, expectedContext, 'skip-item');
+      if (state.session.mode === 'gps') {
+        return service.submitAnswer(learnerId, state, state.session.currentItem?.inputKind === 'choice'
+          ? { choiceIndex: null }
+          : { typed: '' }, expectedContext);
+      }
       const data = readData(repository, learnerId);
       const nextSession = {
         ...state.session,
@@ -833,10 +1284,37 @@ export function createPunctuationService({
       syncPracticeSession(repository, learnerId, nextState, clock);
       return stateTransition(nextState);
     },
-    endSession(learnerId, uiState) {
+    endSession(learnerId, uiState, expectedContext = {}) {
       const state = normaliseState(uiState);
       if (!state.session) return stateTransition(createInitialPunctuationState());
+      if (state.phase === 'summary') return stateTransition(state, { changed: false });
+      assertGpsReleaseCurrent(state.session, state.session.mode === 'gps' ? 'finalise-gps' : 'end-session');
+      assertExpectedSessionContext(state.session, expectedContext, 'end-session');
       const data = readData(repository, learnerId);
+      if (state.session.mode === 'gps') {
+        const nowValue = clock();
+        const gps = normaliseGpsSession(state.session.gps);
+        const responses = gps.responses;
+        const nextSession = {
+          ...state.session,
+          answeredCount: responses.length,
+          correctCount: responses.filter((response) => response.correct).length,
+          gps: {
+            ...gps,
+            responses,
+            delayedFeedback: true,
+          },
+          misconceptionTags: [...new Set(responses.flatMap((response) => response.misconceptionTags || []))],
+        };
+        return finaliseGpsSession({
+          learnerId,
+          state,
+          data,
+          session: nextSession,
+          responses,
+          nowValue,
+        });
+      }
       data.progress.sessionsCompleted += state.session.answeredCount > 0 ? 1 : 0;
       writeData(repository, learnerId, data);
       const summary = sessionSummary(state.session, data, indexes, clock);

--- a/src/subjects/punctuation/command-actions.js
+++ b/src/subjects/punctuation/command-actions.js
@@ -7,6 +7,30 @@ export function punctuationSubmitAnswerPayload(data = {}) {
   return { typed: data?.typed || data?.answer || '' };
 }
 
+function commandExpectationForState(state = {}) {
+  const session = state.subjectUi?.punctuation?.session;
+  if (!session || typeof session !== 'object') return {};
+  const expectation = {};
+  if (typeof session.id === 'string' && session.id) expectation.expectedSessionId = session.id;
+  if (typeof session.currentItem?.id === 'string' && session.currentItem.id) {
+    expectation.expectedItemId = session.currentItem.id;
+  }
+  if (Number.isFinite(Number(session.answeredCount))) {
+    expectation.expectedAnsweredCount = Number(session.answeredCount);
+  }
+  if (typeof session.releaseId === 'string' && session.releaseId) {
+    expectation.expectedReleaseId = session.releaseId;
+  }
+  return expectation;
+}
+
+function withCommandExpectation(payload = {}, state = {}) {
+  return {
+    ...payload,
+    ...commandExpectationForState(state),
+  };
+}
+
 export const punctuationSubjectCommandActions = Object.freeze({
   'punctuation-start': {
     command: 'start-session',
@@ -33,13 +57,23 @@ export const punctuationSubjectCommandActions = Object.freeze({
   },
   'punctuation-submit-form': {
     command: 'submit-answer',
-    payload({ data }) {
-      return punctuationSubmitAnswerPayload(data);
+    payload({ data, state }) {
+      return withCommandExpectation(punctuationSubmitAnswerPayload(data), state);
     },
   },
   'punctuation-continue': { command: 'continue-session' },
-  'punctuation-skip': { command: 'skip-item' },
-  'punctuation-end-early': { command: 'end-session' },
+  'punctuation-skip': {
+    command: 'skip-item',
+    payload({ state }) {
+      return withCommandExpectation({}, state);
+    },
+  },
+  'punctuation-end-early': {
+    command: 'end-session',
+    payload({ state }) {
+      return withCommandExpectation({}, state);
+    },
+  },
   'punctuation-set-mode': {
     command: 'save-prefs',
     payload({ data }) {

--- a/src/subjects/punctuation/components/PunctuationPracticeSurface.jsx
+++ b/src/subjects/punctuation/components/PunctuationPracticeSurface.jsx
@@ -66,6 +66,14 @@ function SetupView({ learner, stats, ui, actions }) {
         >
           Weak spots
         </button>
+        <button
+          className="btn secondary"
+          type="button"
+          data-punctuation-gps-start
+          onClick={() => actions.dispatch('punctuation-start', { mode: 'gps', roundLength: '8' })}
+        >
+          GPS test
+        </button>
         <button className="btn secondary" type="button" onClick={() => actions.dispatch('punctuation-start', { mode: 'speech' })}>Speech focus</button>
         <button className="btn secondary" type="button" onClick={() => actions.dispatch('punctuation-start', { mode: 'comma_flow' })}>Comma focus</button>
         <button className="btn secondary" type="button" onClick={() => actions.dispatch('punctuation-start', { mode: 'boundary' })}>Boundary focus</button>
@@ -180,6 +188,7 @@ function ActiveItemView({ ui, actions }) {
   const scene = bellstormSceneForPhase('active-item');
   const progress = ui.session?.length ? Math.round(((ui.session.answeredCount || 0) / ui.session.length) * 100) : 0;
   const submit = (payload) => actions.dispatch('punctuation-submit-form', payload);
+  const isGps = ui.session?.mode === 'gps';
 
   return (
     <section className="card border-top punctuation-surface" style={{ borderTopColor: '#B8873F' }}>
@@ -192,6 +201,13 @@ function ActiveItemView({ ui, actions }) {
         </div>
       </div>
       <WeakFocusChips focus={ui.session?.weakFocus} />
+      {isGps ? (
+        <div className="chip-row" style={{ marginTop: 14 }}>
+          <span className="chip">GPS test</span>
+          <span className="chip">Delayed feedback</span>
+          <span className="chip">{(ui.session?.answeredCount || 0) + 1} of {ui.session?.length || 0}</span>
+        </div>
+      ) : null}
       <GuidedTeachBox guided={ui.session?.guided} />
       {item.stem ? <div className="callout" style={{ marginTop: 14, ...newlineTextStyle(item.stem) }}>{item.stem}</div> : null}
       <div className="progress" style={{ marginTop: 14 }}><span style={{ width: `${progress}%` }} /></div>
@@ -243,6 +259,7 @@ function FeedbackView({ ui, actions }) {
 function SummaryView({ ui, actions }) {
   const summary = ui.summary || {};
   const scene = bellstormSceneForPhase('summary');
+  const gpsReview = Array.isArray(summary.gps?.reviewItems) ? summary.gps.reviewItems : [];
   return (
     <section className="card border-top punctuation-surface" style={{ borderTopColor: '#2E8479' }}>
       <div className="punctuation-strip">
@@ -258,6 +275,33 @@ function SummaryView({ ui, actions }) {
         <div className="stat"><div className="stat-label">Correct</div><div className="stat-value">{summary.correct || 0}</div><div className="stat-sub">Clean attempts</div></div>
         <div className="stat"><div className="stat-label">Accuracy</div><div className="stat-value">{summary.accuracy || 0}%</div><div className="stat-sub">Session score</div></div>
       </div>
+      {gpsReview.length ? (
+        <div className="callout punctuation-gps-review" style={{ marginTop: 16 }}>
+          <strong>GPS review</strong>
+          <div className="small muted" style={{ marginTop: 6 }}>
+            Next: {summary.gps?.recommendedLabel || 'Smart review'}
+          </div>
+          <div style={{ display: 'grid', gap: 10, marginTop: 12 }}>
+            {gpsReview.map((entry) => (
+              <div key={`${entry.index}-${entry.itemId}`} className={`feedback ${entry.correct ? 'good' : 'warn'}`}>
+                <strong>{entry.index}. {entry.correct ? 'Correct' : 'Review'}</strong>
+                <div style={{ marginTop: 6 }}>{entry.prompt}</div>
+                {entry.attemptedAnswer ? <div className="small" style={{ marginTop: 6 }}>Answer: {entry.attemptedAnswer}</div> : null}
+                {entry.displayCorrection ? (
+                  <div className="small" style={{ marginTop: 6, ...newlineTextStyle(entry.displayCorrection) }}>
+                    Model: {entry.displayCorrection}
+                  </div>
+                ) : null}
+                {entry.misconceptionTags?.length ? (
+                  <div className="chip-row" style={{ marginTop: 8 }}>
+                    {entry.misconceptionTags.map((tag) => <span className="chip warn" key={`${entry.itemId}-${tag}`}>{tag}</span>)}
+                  </div>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
       <div className="actions" style={{ marginTop: 16 }}>
         <button className="btn primary" type="button" onClick={() => actions.dispatch('punctuation-start-again')}>Start again</button>
         <button className="btn secondary" type="button" onClick={() => actions.dispatch('punctuation-back')}>Back to dashboard</button>

--- a/src/subjects/punctuation/service-contract.js
+++ b/src/subjects/punctuation/service-contract.js
@@ -14,6 +14,7 @@ export const PUNCTUATION_MODES = Object.freeze([
   'smart',
   'guided',
   'weak',
+  'gps',
   'endmarks',
   'apostrophe',
   'speech',
@@ -128,6 +129,49 @@ export function normalisePunctuationFeedback(value) {
   };
 }
 
+function normalisePunctuationFacet(value) {
+  if (!isPlainObject(value)) return null;
+  const id = normaliseString(value.id);
+  if (!id) return null;
+  return {
+    id,
+    ok: normaliseBoolean(value.ok),
+    label: normaliseString(value.label),
+  };
+}
+
+function normaliseGpsReviewItem(value, index) {
+  if (!isPlainObject(value)) return null;
+  return {
+    index: normaliseNonNegativeInteger(value.index, index + 1),
+    itemId: normaliseString(value.itemId),
+    mode: normaliseString(value.mode),
+    skillIds: normaliseStringArray(value.skillIds),
+    prompt: normaliseString(value.prompt),
+    stem: normaliseString(value.stem),
+    attemptedAnswer: normaliseString(value.attemptedAnswer).trim().slice(0, 500),
+    displayCorrection: normaliseString(value.displayCorrection),
+    explanation: normaliseString(value.explanation),
+    correct: normaliseBoolean(value.correct),
+    misconceptionTags: normaliseStringArray(value.misconceptionTags),
+    facets: Array.isArray(value.facets)
+      ? value.facets.map(normalisePunctuationFacet).filter(Boolean)
+      : [],
+  };
+}
+
+function normaliseGpsSummary(value) {
+  if (!isPlainObject(value)) return null;
+  return {
+    delayedFeedback: normaliseBoolean(value.delayedFeedback, true),
+    recommendedMode: normalisePunctuationMode(value.recommendedMode, 'smart'),
+    recommendedLabel: normaliseString(value.recommendedLabel, 'Smart review'),
+    reviewItems: Array.isArray(value.reviewItems)
+      ? value.reviewItems.map(normaliseGpsReviewItem).filter(Boolean)
+      : [],
+  };
+}
+
 export function normalisePunctuationSummary(value) {
   if (!isPlainObject(value)) return null;
   const total = normaliseNonNegativeInteger(value.total, 0);
@@ -144,5 +188,6 @@ export function normalisePunctuationSummary(value) {
     focus: normaliseStringArray(value.focus),
     securedUnits: normaliseStringArray(value.securedUnits),
     misconceptionTags: normaliseStringArray(value.misconceptionTags),
+    gps: normaliseGpsSummary(value.gps),
   };
 }

--- a/tests/fixtures/punctuation-legacy-parity/legacy-baseline.json
+++ b/tests/fixtures/punctuation-legacy-parity/legacy-baseline.json
@@ -87,9 +87,10 @@
     {
       "id": "gps",
       "legacyLabel": "True GPS test mode",
-      "status": "planned",
+      "status": "ported",
       "ownerUnit": "U6",
-      "notes": "Needs fixed test length, delayed feedback, score summary, and review model."
+      "assertPresent": true,
+      "notes": "Production GPS mode locks a server-owned queue, suppresses item feedback during the test, and releases a safe score/review model at completion."
     }
   ],
   "itemModes": [

--- a/tests/punctuation-gps.test.js
+++ b/tests/punctuation-gps.test.js
@@ -1,0 +1,259 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { PUNCTUATION_EVENT_TYPES } from '../shared/punctuation/events.js';
+import { createPunctuationService } from '../shared/punctuation/service.js';
+
+function makeRepository(initialData = null) {
+  let data = initialData;
+  let practiceSession = null;
+  return {
+    readData() {
+      return data;
+    },
+    writeData(_learnerId, nextData) {
+      data = JSON.parse(JSON.stringify(nextData));
+      return data;
+    },
+    syncPracticeSession(_learnerId, _state, record) {
+      practiceSession = JSON.parse(JSON.stringify(record));
+      return practiceSession;
+    },
+    snapshot() {
+      return { data, practiceSession };
+    },
+  };
+}
+
+function correctAnswerFor(item) {
+  if (item.inputKind === 'choice') {
+    return { choiceIndex: item.options.find((option) => option.text === item.model)?.index ?? 0 };
+  }
+  return { typed: item.model };
+}
+
+function wrongAnswerFor(item) {
+  return item.inputKind === 'choice' ? { choiceIndex: 99 } : { typed: 'not sure' };
+}
+
+function expectedContextForState(state) {
+  return {
+    expectedSessionId: state.session.id,
+    expectedItemId: state.session.currentItem?.id || state.session.currentItemId,
+    expectedAnsweredCount: state.session.answeredCount,
+    expectedReleaseId: state.session.releaseId,
+  };
+}
+
+function submitGpsAnswer(service, learnerId, state, answer) {
+  return service.submitAnswer(learnerId, state, answer, expectedContextForState(state));
+}
+
+function skipGpsItem(service, learnerId, state) {
+  return service.skipItem(learnerId, state, expectedContextForState(state));
+}
+
+function endGpsSession(service, learnerId, state) {
+  return service.endSession(learnerId, state, expectedContextForState(state));
+}
+
+test('gps mode starts with a locked bounded queue and no guided support', () => {
+  const repository = makeRepository();
+  const service = createPunctuationService({ repository, now: () => 1_800_000_000_000, random: () => 0 });
+
+  const start = service.startSession('learner-a', { mode: 'gps', testLength: '3' }).state;
+
+  assert.equal(start.phase, 'active-item');
+  assert.equal(start.session.mode, 'gps');
+  assert.equal(start.session.length, 3);
+  assert.equal(start.session.gps.queueItemIds.length, 3);
+  assert.equal(start.session.currentItemId, start.session.gps.queueItemIds[0]);
+  assert.equal(start.session.guided, null);
+  assert.equal(start.session.gps.delayedFeedback, true);
+  assert.equal(repository.snapshot().practiceSession.status, 'active');
+});
+
+test('gps submit advances through the fixed queue without feedback or progress leakage', () => {
+  const repository = makeRepository();
+  const service = createPunctuationService({ repository, now: () => 1_800_000_000_000, random: () => 0 });
+  const start = service.startSession('learner-a', { mode: 'gps', roundLength: '3' }).state;
+  const queue = [...start.session.gps.queueItemIds];
+
+  const first = submitGpsAnswer(service, 'learner-a', start, correctAnswerFor(start.session.currentItem));
+
+  assert.equal(first.state.phase, 'active-item');
+  assert.equal(first.state.feedback, null);
+  assert.deepEqual(first.events, []);
+  assert.deepEqual(first.state.session.gps.queueItemIds, queue);
+  assert.equal(first.state.session.answeredCount, 1);
+  assert.equal(first.state.session.currentItemId, queue[1]);
+  assert.equal(first.state.session.gps.responses.length, 1);
+  assert.equal(repository.snapshot().data, null);
+  assert.equal(service.getStats('learner-a').attempts, 0);
+});
+
+test('gps mutating commands require visible session context', () => {
+  const repository = makeRepository();
+  const service = createPunctuationService({ repository, now: () => 1_800_000_000_000, random: () => 0 });
+  const start = service.startSession('learner-a', { mode: 'gps', roundLength: '2' }).state;
+
+  for (const runCommand of [
+    () => service.submitAnswer('learner-a', start, correctAnswerFor(start.session.currentItem)),
+    () => service.skipItem('learner-a', start),
+    () => service.endSession('learner-a', start),
+  ]) {
+    assert.throws(
+      runCommand,
+      (error) => {
+        assert.equal(error.code, 'punctuation_command_stale');
+        assert.equal(error.details.missingExpectedContext, true);
+        assert.equal(error.details.sessionId, start.session.id);
+        assert.equal(error.details.itemId, start.session.currentItemId);
+        return true;
+      },
+    );
+  }
+  assert.equal(repository.snapshot().data, null);
+});
+
+test('gps submit fails closed when the locked queue no longer resolves', () => {
+  const repository = makeRepository();
+  const service = createPunctuationService({ repository, now: () => 1_800_000_000_000, random: () => 0 });
+  const start = service.startSession('learner-a', { mode: 'gps', roundLength: '3' }).state;
+  const stale = JSON.parse(JSON.stringify(start));
+  stale.session.gps.queueItemIds[1] = 'missing-content-item';
+
+  assert.throws(
+    () => submitGpsAnswer(service, 'learner-a', stale, correctAnswerFor(stale.session.currentItem)),
+    (error) => {
+      assert.equal(error.code, 'punctuation_gps_queue_stale');
+      assert.equal(error.details.itemId, 'missing-content-item');
+      assert.equal(error.details.answeredCount, 1);
+      return true;
+    },
+  );
+  assert.equal(repository.snapshot().data, null);
+});
+
+test('gps completion fails closed when a stored response no longer resolves', () => {
+  const repository = makeRepository();
+  const service = createPunctuationService({ repository, now: () => 1_800_000_000_000, random: () => 0 });
+  const start = service.startSession('learner-a', { mode: 'gps', roundLength: '2' }).state;
+  const active = submitGpsAnswer(service, 'learner-a', start, correctAnswerFor(start.session.currentItem)).state;
+  const stale = JSON.parse(JSON.stringify(active));
+  stale.session.gps.responses[0].itemId = 'missing-completed-item';
+
+  assert.throws(
+    () => submitGpsAnswer(service, 'learner-a', stale, correctAnswerFor(stale.session.currentItem)),
+    (error) => {
+      assert.equal(error.code, 'punctuation_gps_response_stale');
+      assert.equal(error.details.itemId, 'missing-completed-item');
+      assert.equal(error.details.responseIndex, 0);
+      return true;
+    },
+  );
+  assert.equal(repository.snapshot().data, null);
+  assert.equal(repository.snapshot().practiceSession.status, 'active');
+});
+
+test('gps commands fail closed when the content release drifts even if item ids resolve', () => {
+  const repository = makeRepository();
+  const service = createPunctuationService({ repository, now: () => 1_800_000_000_000, random: () => 0 });
+  const start = service.startSession('learner-a', { mode: 'gps', roundLength: '2' }).state;
+  const staleStart = JSON.parse(JSON.stringify(start));
+  staleStart.session.releaseId = 'stale-release-id';
+
+  assert.throws(
+    () => submitGpsAnswer(service, 'learner-a', staleStart, correctAnswerFor(staleStart.session.currentItem)),
+    (error) => {
+      assert.equal(error.code, 'punctuation_gps_release_stale');
+      assert.equal(error.details.command, 'submit-answer');
+      assert.equal(error.details.sessionReleaseId, 'stale-release-id');
+      return true;
+    },
+  );
+  assert.throws(
+    () => skipGpsItem(service, 'learner-a', staleStart),
+    (error) => {
+      assert.equal(error.code, 'punctuation_gps_release_stale');
+      assert.equal(error.details.command, 'skip-item');
+      return true;
+    },
+  );
+
+  const active = submitGpsAnswer(service, 'learner-a', start, correctAnswerFor(start.session.currentItem)).state;
+  const staleActive = JSON.parse(JSON.stringify(active));
+  staleActive.session.releaseId = 'stale-release-id';
+
+  assert.throws(
+    () => submitGpsAnswer(service, 'learner-a', staleActive, correctAnswerFor(staleActive.session.currentItem)),
+    (error) => {
+      assert.equal(error.code, 'punctuation_gps_release_stale');
+      assert.equal(error.details.command, 'submit-answer');
+      return true;
+    },
+  );
+  assert.throws(
+    () => endGpsSession(service, 'learner-a', staleActive),
+    (error) => {
+      assert.equal(error.code, 'punctuation_gps_release_stale');
+      assert.equal(error.details.command, 'finalise-gps');
+      return true;
+    },
+  );
+  assert.equal(repository.snapshot().data, null);
+  assert.equal(repository.snapshot().practiceSession.status, 'active');
+});
+
+test('gps completion releases review rows and then writes learning evidence', () => {
+  const repository = makeRepository();
+  const service = createPunctuationService({ repository, now: () => 1_800_000_000_000, random: () => 0 });
+  let state = service.startSession('learner-a', { mode: 'gps', roundLength: '3' }).state;
+
+  state = submitGpsAnswer(service, 'learner-a', state, correctAnswerFor(state.session.currentItem)).state;
+  state = submitGpsAnswer(service, 'learner-a', state, wrongAnswerFor(state.session.currentItem)).state;
+  const finished = submitGpsAnswer(service, 'learner-a', state, correctAnswerFor(state.session.currentItem));
+
+  assert.equal(finished.state.phase, 'summary');
+  assert.equal(finished.state.feedback, null);
+  assert.equal(finished.state.summary.label, 'Punctuation GPS test summary');
+  assert.equal(finished.state.summary.total, 3);
+  assert.equal(finished.state.summary.correct, 2);
+  assert.equal(finished.state.summary.gps.reviewItems.length, 3);
+  assert.equal(finished.state.summary.gps.reviewItems[1].correct, false);
+  assert.equal(finished.state.summary.gps.reviewItems[1].displayCorrection.length > 0, true);
+  assert.equal(finished.state.summary.gps.recommendedMode, 'weak');
+  assert.equal(finished.events.filter((event) => event.type === PUNCTUATION_EVENT_TYPES.ITEM_ATTEMPTED).length, 3);
+  assert.equal(finished.events.some((event) => event.type === PUNCTUATION_EVENT_TYPES.SESSION_COMPLETED), true);
+
+  const data = repository.snapshot().data;
+  assert.equal(data.progress.attempts.length, 3);
+  assert.equal(data.progress.attempts.every((attempt) => attempt.sessionMode === 'gps'), true);
+  assert.equal(data.progress.attempts.every((attempt) => attempt.testMode === 'gps'), true);
+  assert.equal(data.progress.sessionsCompleted, 1);
+});
+
+test('gps end early releases accumulated delayed review and evidence once', () => {
+  const repository = makeRepository();
+  const service = createPunctuationService({ repository, now: () => 1_800_000_000_000, random: () => 0 });
+  const start = service.startSession('learner-a', { mode: 'gps', roundLength: '3' }).state;
+  const active = submitGpsAnswer(service, 'learner-a', start, wrongAnswerFor(start.session.currentItem)).state;
+
+  const ended = endGpsSession(service, 'learner-a', active);
+
+  assert.equal(ended.state.phase, 'summary');
+  assert.equal(ended.state.summary.total, 1);
+  assert.equal(ended.state.summary.correct, 0);
+  assert.equal(ended.state.summary.gps.reviewItems.length, 1);
+  assert.equal(ended.events.filter((event) => event.type === PUNCTUATION_EVENT_TYPES.ITEM_ATTEMPTED).length, 1);
+  assert.equal(ended.events.some((event) => event.type === PUNCTUATION_EVENT_TYPES.SESSION_COMPLETED), true);
+  assert.equal(repository.snapshot().data.progress.attempts.length, 1);
+  assert.equal(repository.snapshot().data.progress.sessionsCompleted, 1);
+
+  const repeated = service.endSession('learner-a', ended.state);
+
+  assert.equal(repeated.changed, false);
+  assert.deepEqual(repeated.events, []);
+  assert.equal(repository.snapshot().data.progress.attempts.length, 1);
+  assert.equal(repository.snapshot().data.progress.sessionsCompleted, 1);
+});

--- a/tests/punctuation-legacy-parity.test.js
+++ b/tests/punctuation-legacy-parity.test.js
@@ -61,18 +61,15 @@ test('punctuation legacy parity records shipped item modes and open mode gaps', 
   assert.equal(weak?.ownerUnit, 'U3');
   assert.equal(weak?.present, true);
 
+  const gps = report.rows.find((entry) => entry.section === 'sessionModes' && entry.id === 'gps');
+  assert.equal(gps?.status, 'ported');
+  assert.equal(gps?.ownerUnit, 'U6');
+  assert.equal(gps?.present, true);
+
   const paragraphSession = report.rows.find((entry) => entry.section === 'sessionModes' && entry.id === 'paragraph');
   assert.equal(paragraphSession?.status, 'replaced');
   assert.equal(paragraphSession?.ownerUnit, 'U5');
   assert.equal(paragraphSession?.present, false);
-
-  for (const [id, ownerUnit] of [
-    ['gps', 'U6'],
-  ]) {
-    const row = report.rows.find((entry) => entry.id === id);
-    assert.equal(row?.status, 'planned', `${id} should remain planned`);
-    assert.equal(row?.ownerUnit, ownerUnit, `${id} should be owned by ${ownerUnit}`);
-  }
 });
 
 test('punctuation legacy parity rejects unsafe legacy authority instead of planning it', () => {

--- a/tests/react-punctuation-scene.test.js
+++ b/tests/react-punctuation-scene.test.js
@@ -94,6 +94,8 @@ test('punctuation React surface renders guided setup controls and teach boxes', 
   assert.match(setupHtml, /data-punctuation-guided-start/);
   assert.match(setupHtml, /Weak spots/);
   assert.match(setupHtml, /data-punctuation-weak-start/);
+  assert.match(setupHtml, /GPS test/);
+  assert.match(setupHtml, /data-punctuation-gps-start/);
 
   harness.store.updateSubjectUi('punctuation', {
     phase: 'active-item',
@@ -169,6 +171,85 @@ test('punctuation React surface renders weak focus chips safely', () => {
   assert.match(html, /Inverted commas and speech punctuation/);
   assert.match(html, /insert/);
   assert.doesNotMatch(html, /accepted|correctIndex|rubric|validator|generator|hiddenQueue/);
+});
+
+test('punctuation React surface renders GPS active progress and final review', () => {
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.store.updateSubjectUi('punctuation', {
+    phase: 'active-item',
+    session: {
+      id: 'gps-ui',
+      mode: 'gps',
+      length: 3,
+      answeredCount: 1,
+      gps: {
+        testLength: 3,
+        answeredCount: 1,
+        remainingCount: 2,
+        delayedFeedback: true,
+      },
+      guided: null,
+      currentItem: {
+        id: 'se_insert_capital',
+        mode: 'insert',
+        inputKind: 'text',
+        prompt: 'Add the missing capital letter and full stop.',
+        stem: 'the boat reached the harbour',
+      },
+    },
+  });
+
+  const activeHtml = harness.render();
+  assert.match(activeHtml, /GPS test/);
+  assert.match(activeHtml, /Delayed feedback/);
+  assert.match(activeHtml, /2 of 3/);
+  assert.doesNotMatch(activeHtml, /Worked example|Common mistake|displayCorrection|accepted|correctIndex|rubric|validator|generator|hiddenQueue|queueItemIds|responses/);
+
+  harness.store.updateSubjectUi('punctuation', {
+    phase: 'summary',
+    summary: {
+      label: 'Punctuation GPS test summary',
+      message: 'GPS test complete.',
+      total: 2,
+      correct: 1,
+      accuracy: 50,
+      gps: {
+        delayedFeedback: true,
+        recommendedMode: 'weak',
+        recommendedLabel: 'Weak spots',
+        reviewItems: [
+          {
+            index: 1,
+            itemId: 'se_insert_capital',
+            mode: 'insert',
+            prompt: 'Add the missing capital letter and full stop.',
+            attemptedAnswer: 'The boat reached the harbour.',
+            displayCorrection: 'The boat reached the harbour.',
+            correct: true,
+            misconceptionTags: [],
+          },
+          {
+            index: 2,
+            itemId: 'sp_insert_question',
+            mode: 'insert',
+            prompt: 'Add the direct-speech punctuation.',
+            attemptedAnswer: 'Ella asked can we start now',
+            displayCorrection: 'Ella asked, "Can we start now?"',
+            correct: false,
+            misconceptionTags: ['speech.quote_missing'],
+          },
+        ],
+      },
+    },
+  });
+
+  const summaryHtml = harness.render();
+  assert.match(summaryHtml, /GPS review/);
+  assert.match(summaryHtml, /Next: Weak spots/);
+  assert.match(summaryHtml, /1\. Correct/);
+  assert.match(summaryHtml, /2\. Review/);
+  assert.match(summaryHtml, /speech\.quote_missing/);
 });
 
 test('punctuation text input remounts when the current text item changes', async () => {

--- a/tests/subject-command-actions.test.js
+++ b/tests/subject-command-actions.test.js
@@ -174,12 +174,60 @@ async function sendPunctuationActionPayload(data) {
 }
 
 test('punctuation browser command action keeps choiceIndex parsing strict', async () => {
-  assert.deepEqual(await sendPunctuationActionPayload({ choiceIndex: 0 }), { choiceIndex: 0 });
-  assert.deepEqual(await sendPunctuationActionPayload({ choiceIndex: '0' }), { choiceIndex: 0 });
+  assert.deepEqual(await sendPunctuationActionPayload({ choiceIndex: 0 }), {
+    choiceIndex: 0,
+    expectedSessionId: 'session-a',
+  });
+  assert.deepEqual(await sendPunctuationActionPayload({ choiceIndex: '0' }), {
+    choiceIndex: 0,
+    expectedSessionId: 'session-a',
+  });
 
   for (const choiceIndex of [null, '', [0]]) {
-    assert.deepEqual(await sendPunctuationActionPayload({ choiceIndex }), { typed: '' });
+    assert.deepEqual(await sendPunctuationActionPayload({ choiceIndex }), {
+      typed: '',
+      expectedSessionId: 'session-a',
+    });
   }
+});
+
+test('punctuation browser command action binds submits to the visible item context', async () => {
+  const sent = [];
+  const handler = createSubjectCommandActionHandler({
+    subjectId: 'punctuation',
+    getState() {
+      return {
+        learners: { selectedId: 'learner-a' },
+        subjectUi: {
+          punctuation: {
+            session: {
+              id: 'session-gps',
+              releaseId: 'punctuation-release-1',
+              answeredCount: 1,
+              currentItem: { id: 'item-visible' },
+            },
+          },
+        },
+      };
+    },
+    subjectCommands: {
+      send(request) {
+        sent.push(request);
+        return Promise.resolve({ ok: true });
+      },
+    },
+    actions: punctuationSubjectCommandActions,
+  });
+
+  assert.equal(handler.handle('punctuation-submit-form', { typed: 'Answer.' }), true);
+  await flushPromises();
+  assert.deepEqual(sent[0].payload, {
+    typed: 'Answer.',
+    expectedSessionId: 'session-gps',
+    expectedItemId: 'item-visible',
+    expectedAnsweredCount: 1,
+    expectedReleaseId: 'punctuation-release-1',
+  });
 });
 
 test('punctuation start command action preserves explicit focus mode and round length', () => {

--- a/tests/worker-punctuation-runtime.test.js
+++ b/tests/worker-punctuation-runtime.test.js
@@ -59,6 +59,18 @@ function createHarness({ punctuationEnabled = true, random = () => 0 } = {}) {
     return { response, body: await response.json(), requestBody: body };
   }
 
+  async function bootstrap(headers = {}) {
+    const response = await app.fetch(new Request('https://repo.test/api/bootstrap', {
+      method: 'GET',
+      headers: {
+        origin: 'https://repo.test',
+        'x-ks2-dev-account-id': 'adult-a',
+        ...headers,
+      },
+    }), env, {});
+    return { response, body: await response.json() };
+  }
+
   async function command(commandName, payload = {}) {
     sequence += 1;
     const result = await postRaw({
@@ -79,6 +91,7 @@ function createHarness({ punctuationEnabled = true, random = () => 0 } = {}) {
     env,
     nowRef,
     postRaw,
+    bootstrap,
     command,
     close() {
       DB.close();
@@ -98,6 +111,26 @@ function correctAnswerFor(readItem) {
   assert.ok(source, `Expected source item for ${readItem.id}`);
   if (readItem.inputKind === 'choice') return { choiceIndex: source.correctIndex };
   return { typed: source.model };
+}
+
+function wrongAnswerFor(readItem) {
+  return readItem.inputKind === 'choice' ? { choiceIndex: 99 } : { typed: 'not sure' };
+}
+
+function expectedContextForSession(session) {
+  return {
+    expectedSessionId: session.id,
+    expectedItemId: session.currentItem?.id || '',
+    expectedAnsweredCount: session.answeredCount,
+    expectedReleaseId: session.releaseId,
+  };
+}
+
+function answerPayloadForSession(session, answer) {
+  return {
+    ...answer,
+    ...expectedContextForSession(session),
+  };
 }
 
 test('Worker runtime registers punctuation command handlers', async () => {
@@ -285,6 +318,204 @@ test('punctuation command route serves paragraph items through redacted multilin
     });
     assert.equal(submit.body.subjectReadModel.feedback.kind, 'success');
     assert.equal(submit.body.domainEvents.some((event) => event.type === 'punctuation.item-attempted'), true);
+  } finally {
+    harness.close();
+  }
+});
+
+test('punctuation command route runs GPS mode with delayed feedback and final review', async () => {
+  const harness = createHarness();
+  try {
+    let step = await harness.command('start-session', { mode: 'gps', roundLength: '3' });
+
+    assert.equal(step.body.subjectReadModel.phase, 'active-item');
+    assert.equal(step.body.subjectReadModel.session.mode, 'gps');
+    assert.equal(step.body.subjectReadModel.session.length, 3);
+    assert.deepEqual(step.body.subjectReadModel.session.gps, {
+      testLength: 3,
+      answeredCount: 0,
+      remainingCount: 3,
+      delayedFeedback: true,
+    });
+    assert.equal(step.body.subjectReadModel.session.guided, null);
+    assert.doesNotMatch(payloadText(step.body.subjectReadModel), /accepted|correctIndex|rubric|validator|hiddenQueue|queueItemIds|responses|generator|model|displayCorrection/);
+
+    step = await harness.command(
+      'submit-answer',
+      answerPayloadForSession(step.body.subjectReadModel.session, wrongAnswerFor(step.body.subjectReadModel.session.currentItem)),
+    );
+    assert.equal(step.body.subjectReadModel.phase, 'active-item');
+    assert.equal(step.body.subjectReadModel.feedback, null);
+    assert.equal(step.body.subjectReadModel.session.correctCount, 0);
+    assert.deepEqual(step.body.subjectReadModel.session.misconceptionTags, []);
+    assert.equal(step.body.subjectReadModel.session.gps.answeredCount, 1);
+    assert.equal(step.body.subjectReadModel.stats.attempts, 0);
+    assert.equal(step.body.subjectReadModel.stats.correct, 0);
+    assert.deepEqual(step.body.domainEvents, []);
+    assert.deepEqual(step.body.reactionEvents, []);
+    assert.doesNotMatch(payloadText(step.body.subjectReadModel), /accepted|correctIndex|rubric|validator|hiddenQueue|queueItemIds|responses|generator|model|displayCorrection/);
+
+    step = await harness.command(
+      'submit-answer',
+      answerPayloadForSession(step.body.subjectReadModel.session, correctAnswerFor(step.body.subjectReadModel.session.currentItem)),
+    );
+    const final = await harness.command(
+      'submit-answer',
+      answerPayloadForSession(step.body.subjectReadModel.session, correctAnswerFor(step.body.subjectReadModel.session.currentItem)),
+    );
+
+    assert.equal(final.body.subjectReadModel.phase, 'summary');
+    assert.equal(final.body.subjectReadModel.summary.label, 'Punctuation GPS test summary');
+    assert.equal(final.body.subjectReadModel.summary.total, 3);
+    assert.equal(final.body.subjectReadModel.summary.correct, 2);
+    assert.equal(final.body.subjectReadModel.summary.gps.reviewItems.length, 3);
+    assert.equal(final.body.subjectReadModel.summary.gps.recommendedMode, 'weak');
+    assert.equal(final.body.domainEvents.filter((event) => event.type === 'punctuation.item-attempted').length, 3);
+    assert.equal(final.body.domainEvents.some((event) => event.type === 'punctuation.session-completed'), true);
+
+    const publicBootstrap = await harness.bootstrap({ 'x-ks2-public-read-models': '1' });
+    assert.equal(publicBootstrap.response.status, 200, JSON.stringify(publicBootstrap.body));
+    const publicState = publicBootstrap.body.subjectStates['learner-a::punctuation'];
+    const publicSession = publicBootstrap.body.practiceSessions.find((session) => session.subjectId === 'punctuation');
+    assert.deepEqual(publicState.ui.summary.gps.reviewItems, []);
+    assert.deepEqual(publicSession.summary.gps.reviewItems, []);
+    assert.doesNotMatch(payloadText({ publicState, publicSession }), /attemptedAnswer|displayCorrection|explanation|prompt|stem/);
+
+    const itemAttemptRows = harness.DB.db.prepare(`
+      SELECT COUNT(*) AS count
+      FROM event_log
+      WHERE learner_id = 'learner-a' AND event_type = 'punctuation.item-attempted'
+    `).get().count;
+    const replay = await harness.postRaw(final.requestBody);
+    assert.equal(replay.response.status, 200);
+    assert.equal(replay.body.mutation.replayed, true);
+    assert.equal(harness.DB.db.prepare(`
+      SELECT COUNT(*) AS count
+      FROM event_log
+      WHERE learner_id = 'learner-a' AND event_type = 'punctuation.item-attempted'
+    `).get().count, itemAttemptRows);
+  } finally {
+    harness.close();
+  }
+});
+
+test('punctuation GPS submit rejects stale retries bound to the previous item', async () => {
+  const harness = createHarness();
+  try {
+    const start = await harness.command('start-session', { mode: 'gps', roundLength: '2' });
+    const firstSession = start.body.subjectReadModel.session;
+    const firstItem = firstSession.currentItem;
+    const staleContext = expectedContextForSession(firstSession);
+    const stalePayload = {
+      ...wrongAnswerFor(firstItem),
+      ...staleContext,
+    };
+
+    await harness.command('submit-answer', answerPayloadForSession(firstSession, correctAnswerFor(firstItem)));
+    const currentRevision = harness.revision;
+    const staleRetry = await harness.postRaw({
+      command: 'submit-answer',
+      learnerId: 'learner-a',
+      requestId: 'punctuation-gps-stale-retry',
+      expectedLearnerRevision: currentRevision,
+      payload: stalePayload,
+    });
+
+    assert.equal(staleRetry.response.status, 400, JSON.stringify(staleRetry.body));
+    assert.equal(staleRetry.body.code, 'punctuation_command_stale');
+    assert.equal(staleRetry.body.expectedItemId, firstItem.id);
+    assert.notEqual(staleRetry.body.itemId, firstItem.id);
+
+    for (const command of ['skip-item', 'end-session']) {
+      const staleCommand = await harness.postRaw({
+        command,
+        learnerId: 'learner-a',
+        requestId: `punctuation-gps-stale-${command}`,
+        expectedLearnerRevision: currentRevision,
+        payload: staleContext,
+      });
+      assert.equal(staleCommand.response.status, 400, JSON.stringify(staleCommand.body));
+      assert.equal(staleCommand.body.code, 'punctuation_command_stale');
+      assert.equal(staleCommand.body.expectedItemId, firstItem.id);
+      assert.notEqual(staleCommand.body.itemId, firstItem.id);
+    }
+    assert.equal(harness.DB.db.prepare(`
+      SELECT COUNT(*) AS count
+      FROM event_log
+      WHERE learner_id = 'learner-a' AND event_type = 'punctuation.item-attempted'
+    `).get().count, 0);
+  } finally {
+    harness.close();
+  }
+});
+
+test('punctuation GPS commands reject missing visible item context', async () => {
+  const harness = createHarness();
+  try {
+    const start = await harness.command('start-session', { mode: 'gps', roundLength: '2' });
+    const firstSession = start.body.subjectReadModel.session;
+
+    for (const [command, payload] of [
+      ['submit-answer', correctAnswerFor(firstSession.currentItem)],
+      ['skip-item', {}],
+      ['end-session', {}],
+    ]) {
+      const result = await harness.postRaw({
+        command,
+        learnerId: 'learner-a',
+        requestId: `punctuation-gps-missing-context-${command}`,
+        expectedLearnerRevision: harness.revision,
+        payload,
+      });
+      assert.equal(result.response.status, 400, JSON.stringify(result.body));
+      assert.equal(result.body.code, 'punctuation_command_stale');
+      assert.equal(result.body.missingExpectedContext, true);
+      assert.equal(result.body.sessionId, firstSession.id);
+      assert.equal(result.body.itemId, firstSession.currentItem.id);
+    }
+    assert.equal(harness.DB.db.prepare(`
+      SELECT COUNT(*) AS count
+      FROM event_log
+      WHERE learner_id = 'learner-a' AND event_type = 'punctuation.item-attempted'
+    `).get().count, 0);
+  } finally {
+    harness.close();
+  }
+});
+
+test('public bootstrap redacts active Punctuation GPS queue and delayed answers', async () => {
+  const harness = createHarness();
+  try {
+    let step = await harness.command('start-session', { mode: 'gps', roundLength: '3' });
+    step = await harness.command(
+      'submit-answer',
+      answerPayloadForSession(step.body.subjectReadModel.session, wrongAnswerFor(step.body.subjectReadModel.session.currentItem)),
+    );
+
+    const publicBootstrap = await harness.bootstrap({ 'x-ks2-public-read-models': '1' });
+    assert.equal(publicBootstrap.response.status, 200, JSON.stringify(publicBootstrap.body));
+
+    const publicState = publicBootstrap.body.subjectStates['learner-a::punctuation'];
+    const publicReadModel = publicState.ui;
+    const publicSession = publicBootstrap.body.practiceSessions.find((session) => session.subjectId === 'punctuation');
+    const publicRuntimeText = payloadText({ publicState, publicSession });
+
+    assert.deepEqual(publicState.data, {});
+    assert.equal(publicReadModel.subjectId, 'punctuation');
+    assert.equal(publicReadModel.phase, 'active-item');
+    assert.equal(publicReadModel.session.mode, 'gps');
+    assert.equal(publicReadModel.session.correctCount, 0);
+    assert.deepEqual(publicReadModel.session.misconceptionTags, []);
+    assert.deepEqual(publicReadModel.session.gps, {
+      testLength: 3,
+      answeredCount: 1,
+      remainingCount: 2,
+      delayedFeedback: true,
+    });
+    assert.equal(publicReadModel.feedback, null);
+    assert.equal(publicSession.sessionState, null);
+    assert.equal(publicSession.summary, null);
+    assert.doesNotMatch(publicRuntimeText, /accepted|correctIndex|rubric|validator|hiddenQueue|queueItemIds|responses|generator|model|displayCorrection/);
   } finally {
     harness.close();
   }

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -33,6 +33,12 @@ import { buildParentHubReadModel } from '../../src/platform/hubs/parent-read-mod
 import { monsterIdForSpellingWord } from '../../src/platform/game/monster-system.js';
 import { buildSpellingProgressPools, buildSpellingWordBankReadModel } from './content/spelling-read-models.js';
 import { buildSpellingAudioCue } from './subjects/spelling/audio.js';
+import { buildPunctuationReadModel } from './subjects/punctuation/read-models.js';
+import { createPunctuationService } from '../../shared/punctuation/service.js';
+import {
+  createInitialPunctuationState,
+  normalisePunctuationSummary,
+} from '../../src/subjects/punctuation/service-contract.js';
 import {
   BUNDLED_MONSTER_VISUAL_CONFIG,
   MONSTER_VISUAL_SCHEMA_VERSION,
@@ -239,8 +245,43 @@ function redactSpellingUiForClient(ui, data = {}, learnerId = '', {
   };
 }
 
+function createPunctuationReadModelService(data, now) {
+  return createPunctuationService({
+    repository: {
+      readData() {
+        return cloneSerialisable(data) || {};
+      },
+    },
+    now: () => now,
+    random: () => 0,
+  });
+}
+
+function redactPunctuationUiForClient(ui, data = {}, learnerId = '', { now = Date.now() } = {}) {
+  const service = createPunctuationReadModelService(data, now);
+  const state = service.initState(ui || createInitialPunctuationState());
+  const readModel = buildPunctuationReadModel({
+    learnerId,
+    state,
+    prefs: service.getPrefs(learnerId),
+    stats: service.getStats(learnerId),
+    analytics: service.getAnalyticsSnapshot(learnerId),
+  });
+  if (readModel.summary?.gps) {
+    readModel.summary = publicPunctuationPracticeSessionSummary(readModel.summary);
+  }
+  return readModel;
+}
+
 async function publicSubjectStateRowToRecord(row, { spellingContentSnapshot = null, now = Date.now() } = {}) {
   const record = subjectStateRowToRecord(row);
+  if (row.subject_id === 'punctuation') {
+    return normaliseSubjectStateRecord({
+      ui: redactPunctuationUiForClient(record.ui, record.data, row.learner_id, { now }),
+      data: {},
+      updatedAt: record.updatedAt,
+    });
+  }
   if (row.subject_id !== 'spelling') return record;
   const audio = await buildSpellingAudioCue({
     learnerId: row.learner_id,
@@ -394,12 +435,21 @@ function practiceSessionRowToRecord(row) {
 
 function publicPracticeSessionRowToRecord(row) {
   const record = practiceSessionRowToRecord(row);
-  if (record.subjectId !== 'spelling') return record;
-  return normalisePracticeSessionRecord({
-    ...record,
-    sessionState: null,
-    summary: publicPracticeSessionSummary(record.summary, record.sessionKind),
-  });
+  if (record.subjectId === 'spelling') {
+    return normalisePracticeSessionRecord({
+      ...record,
+      sessionState: null,
+      summary: publicPracticeSessionSummary(record.summary, record.sessionKind),
+    });
+  }
+  if (record.subjectId === 'punctuation') {
+    return normalisePracticeSessionRecord({
+      ...record,
+      sessionState: null,
+      summary: publicPunctuationPracticeSessionSummary(record.summary),
+    });
+  }
+  return record;
 }
 
 function eventRowToRecord(row) {
@@ -453,6 +503,22 @@ function publicPracticeSessionSummary(summary, sessionKind) {
     mistakes: Array.isArray(raw.mistakes)
       ? raw.mistakes.map(publicMistakeSummary)
       : [],
+  };
+}
+
+function publicPunctuationPracticeSessionSummary(summary) {
+  const safe = normalisePunctuationSummary(summary);
+  if (!safe) return null;
+  return {
+    ...safe,
+    gps: safe.gps
+      ? {
+        delayedFeedback: safe.gps.delayedFeedback,
+        recommendedMode: safe.gps.recommendedMode,
+        recommendedLabel: safe.gps.recommendedLabel,
+        reviewItems: [],
+      }
+      : null,
   };
 }
 

--- a/worker/src/subjects/punctuation/engine.js
+++ b/worker/src/subjects/punctuation/engine.js
@@ -77,6 +77,29 @@ function typedAnswerFromPayload(payload = {}) {
   return '';
 }
 
+function expectedSessionContextFromPayload(payload = {}) {
+  if (!isPlainObject(payload)) return {};
+  const expected = {};
+  if (typeof payload.expectedSessionId === 'string' && payload.expectedSessionId) {
+    expected.expectedSessionId = payload.expectedSessionId;
+  }
+  if (typeof payload.expectedItemId === 'string' && payload.expectedItemId) {
+    expected.expectedItemId = payload.expectedItemId;
+  }
+  const rawExpectedAnsweredCount = payload.expectedAnsweredCount;
+  if (
+    (typeof rawExpectedAnsweredCount === 'number' || typeof rawExpectedAnsweredCount === 'string')
+    && rawExpectedAnsweredCount !== ''
+    && Number.isFinite(Number(rawExpectedAnsweredCount))
+  ) {
+    expected.expectedAnsweredCount = Number(rawExpectedAnsweredCount);
+  }
+  if (typeof payload.expectedReleaseId === 'string' && payload.expectedReleaseId) {
+    expected.expectedReleaseId = payload.expectedReleaseId;
+  }
+  return expected;
+}
+
 function translatePunctuationError(error) {
   if (!(error instanceof PunctuationServiceError)) throw error;
   if (error.code === 'punctuation_content_unavailable') {
@@ -126,13 +149,18 @@ export function createServerPunctuationEngine({ now = Date.now, random = Math.ra
         if (command === 'start-session') {
           transition = service.startSession(learnerId, payload);
         } else if (command === 'submit-answer') {
-          transition = service.submitAnswer(learnerId, currentState, typedAnswerFromPayload(payload));
+          transition = service.submitAnswer(
+            learnerId,
+            currentState,
+            typedAnswerFromPayload(payload),
+            expectedSessionContextFromPayload(payload),
+          );
         } else if (command === 'continue-session') {
           transition = service.continueSession(learnerId, currentState);
         } else if (command === 'skip-item') {
-          transition = service.skipItem(learnerId, currentState);
+          transition = service.skipItem(learnerId, currentState, expectedSessionContextFromPayload(payload));
         } else if (command === 'end-session') {
-          transition = service.endSession(learnerId, currentState);
+          transition = service.endSession(learnerId, currentState, expectedSessionContextFromPayload(payload));
         } else if (command === 'save-prefs') {
           const prefs = service.savePrefs(learnerId, payload.prefs || payload);
           transition = {

--- a/worker/src/subjects/punctuation/read-models.js
+++ b/worker/src/subjects/punctuation/read-models.js
@@ -94,8 +94,21 @@ function safeWeakFocus(value) {
   };
 }
 
+function safeGpsSession(session) {
+  if (session?.mode !== 'gps') return null;
+  const length = Number.isFinite(Number(session.length)) ? Number(session.length) : 0;
+  const answeredCount = Number.isFinite(Number(session.answeredCount)) ? Number(session.answeredCount) : 0;
+  return {
+    testLength: length,
+    answeredCount,
+    remainingCount: Math.max(0, length - answeredCount),
+    delayedFeedback: true,
+  };
+}
+
 function safeSession(session, phase) {
   if (!isPlainObject(session)) return null;
+  const hideGpsInterimResults = session.mode === 'gps';
   const safe = {
     id: typeof session.id === 'string' ? session.id : '',
     releaseId: typeof session.releaseId === 'string' ? session.releaseId : PUNCTUATION_RELEASE_ID,
@@ -104,16 +117,21 @@ function safeSession(session, phase) {
     phase: phase === 'feedback' ? 'feedback' : 'active-item',
     startedAt: Number.isFinite(Number(session.startedAt)) ? Number(session.startedAt) : 0,
     answeredCount: Number.isFinite(Number(session.answeredCount)) ? Number(session.answeredCount) : 0,
-    correctCount: Number.isFinite(Number(session.correctCount)) ? Number(session.correctCount) : 0,
+    correctCount: hideGpsInterimResults
+      ? 0
+      : (Number.isFinite(Number(session.correctCount)) ? Number(session.correctCount) : 0),
     currentItem: phase === 'active-item' || phase === 'feedback' ? safeCurrentItem(session.currentItem) : null,
     securedUnits: Array.isArray(session.securedUnits) ? session.securedUnits.filter((entry) => typeof entry === 'string') : [],
-    misconceptionTags: Array.isArray(session.misconceptionTags) ? session.misconceptionTags.filter((entry) => typeof entry === 'string') : [],
+    misconceptionTags: hideGpsInterimResults
+      ? []
+      : (Array.isArray(session.misconceptionTags) ? session.misconceptionTags.filter((entry) => typeof entry === 'string') : []),
     guided: session.mode === 'guided' ? {
       skillId: typeof session.guidedSkillId === 'string' ? session.guidedSkillId : null,
       supportLevel: normaliseSupportLevel(session.guidedSupportLevel),
       teachBox: guidedTeachBox(session.guidedSkillId, session.guidedSupportLevel),
     } : null,
     weakFocus: session.mode === 'weak' ? safeWeakFocus(session.weakFocus) : null,
+    gps: session.mode === 'gps' ? safeGpsSession(session) : null,
     serverAuthority: session.serverAuthority === 'worker' ? 'worker' : null,
   };
   return safe;
@@ -166,6 +184,7 @@ export function buildPunctuationReadModel({
 } = {}) {
   const safeState = cloneSerialisable(state) || {};
   const phase = typeof safeState.phase === 'string' ? safeState.phase : 'setup';
+  const hideGpsInterimFeedback = safeState.session?.mode === 'gps' && phase !== 'summary';
   if (phase === 'active-item') assertNoForbiddenItemFields(safeState.session?.currentItem);
   return {
     subjectId: 'punctuation',
@@ -173,7 +192,7 @@ export function buildPunctuationReadModel({
     version: 1,
     phase,
     session: ['active-item', 'feedback'].includes(phase) ? safeSession(safeState.session, phase) : null,
-    feedback: phase === 'feedback' || phase === 'summary' ? safeFeedback(safeState.feedback) : null,
+    feedback: hideGpsInterimFeedback ? null : (phase === 'feedback' || phase === 'summary' ? safeFeedback(safeState.feedback) : null),
     summary: phase === 'summary' ? safeSummary(safeState.summary) : null,
     error: typeof safeState.error === 'string' ? safeState.error : '',
     availability: cloneSerialisable(safeState.availability) || { status: 'ready', code: null, message: '' },


### PR DESCRIPTION
## Summary
- add `gps` as a first-class Punctuation session mode with a server-owned fixed test queue
- suppress item-by-item correctness, feedback, model answers, stats updates, reward events, and guided support until the GPS test is completed
- redact active GPS queue/response internals from public bootstrap subject states and practice sessions
- strip long-lived GPS review rows from public practice-session history and public bootstrap summary state while keeping the immediate command response summary usable
- fail closed when a persisted fixed GPS queue, stored GPS response, GPS session release id, or stale browser retry no longer matches the active session/content context
- require submit/skip/end commands for GPS to carry the visible session, item, answered count, and release so no-context API retries cannot apply an old answer to the next queued item
- make completed GPS end-session calls idempotent so repeated finish requests do not double-apply delayed evidence
- release a final GPS review with score, per-item safe corrections, misconception tags, and weak/smart follow-up guidance
- update the React surface, Worker read-model redaction, legacy parity fixture, and production docs for U6

## Verification
- node --test tests/punctuation-gps.test.js tests/worker-punctuation-runtime.test.js tests/subject-command-actions.test.js
- node --test tests/punctuation-*.test.js tests/react-punctuation-*.test.js tests/subject-command-actions.test.js tests/bundle-audit.test.js tests/worker-backend.test.js tests/worker-auth.test.js
- npm test (645 pass, 1 skipped)
- npm run check
- git diff --check