### PR TITLE
fix(codex): use high-res feature images

### DIFF
--- a/src/surfaces/home/CodexCreature.jsx
+++ b/src/surfaces/home/CodexCreature.jsx
@@ -36,7 +36,7 @@ export function CodexCreatureVisual({ entry, sizes, context = 'card' }) {
     stage: entry.stage,
     context: codexVisualContext(context),
     config: monsterVisualConfig?.config,
-    preferredSize: context === 'preview' ? 1280 : 640,
+    preferredSize: preferredMonsterImageSize(context),
   });
 
   return (
@@ -60,6 +60,11 @@ function codexVisualContext(context) {
   if (context === 'feature') return 'codexFeature';
   if (context === 'preview') return 'lightbox';
   return 'codexCard';
+}
+
+function preferredMonsterImageSize(context) {
+  if (context === 'feature' || context === 'preview') return 1280;
+  return 640;
 }
 
 function creatureMotionStyle(entry, context) {

--- a/src/surfaces/home/CodexHero.jsx
+++ b/src/surfaces/home/CodexHero.jsx
@@ -62,7 +62,7 @@ function CodexFeature({ entry, onPreviewCreature }) {
       <CodexCreatureTrigger
         entry={entry}
         context="feature"
-        sizes="(max-width: 820px) 52vw, 260px"
+        sizes="(max-width: 820px) 76vw, 700px"
         onPreview={onPreviewCreature}
       />
       <div className="codex-feature-meta">

--- a/tests/helpers/react-render.js
+++ b/tests/helpers/react-render.js
@@ -157,6 +157,19 @@ export function renderMonsterVisualRendererFixture() {
             }}
             sizes="160px"
           />
+          <CodexCreatureVisual
+            entry={{
+              id: 'phaeton',
+              branch: 'b1',
+              stage: 4,
+              displayState: 'monster',
+              imageAlt: 'Phaeton',
+              img: '',
+              srcSet: '',
+            }}
+            context="feature"
+            sizes="(max-width: 820px) 76vw, 700px"
+          />
           <MonsterMeadow
             monsters={[{
               id: 'vellhorn-caught',

--- a/tests/monster-visual-renderers.test.js
+++ b/tests/monster-visual-renderers.test.js
@@ -19,6 +19,8 @@ test('monster visual renderers use published config for meadow and reward toast'
   assert.match(html, /clip-path:inset\(10\.0% 15\.0% 5\.0% 5\.0%\)/);
   assert.match(html, /class="ss-meadow-visual" style="--visual-offset-x:12\.00px/);
   assert.match(html, /class="monster-celebration-visual after" data-stage="3" style="--visual-offset-x:18\.00px/);
+  assert.match(html, /src="\.\/assets\/monsters\/phaeton\/b1\/phaeton-b1-4\.1280\.webp\?v=20260421-branches"/);
+  assert.match(html, /sizes="\(max-width: 820px\) 76vw, 700px"/);
   assert.match(html, /--visual-shadow-x:7\.00px/);
   assert.match(html, /--visual-shadow-scale:1\.350/);
   assert.match(html, /--visual-shadow-opacity:0\.340/);


### PR DESCRIPTION
## Summary
- Use the 1280px monster asset as the Codex feature-image fallback, matching the lightbox path.
- Update the Codex feature image sizes hint so the browser can select the higher-resolution source for the large feature art.
- Add renderer coverage that checks the feature context emits the 1280px source.

## Verification
- npm test
- npm run check