### PR TITLE
fix(codex): use high-res roster images

### DIFF
--- a/src/surfaces/home/CodexCard.jsx
+++ b/src/surfaces/home/CodexCard.jsx
@@ -18,7 +18,7 @@ export function CodexCard({ entry, onPractice, onPreview }) {
         <div className="codex-portrait">
           <CodexCreatureTrigger
             entry={entry}
-            sizes="(max-width: 820px) 45vw, 180px"
+            sizes="(max-width: 820px) 72vw, 360px"
             onPreview={onPreview}
           />
         </div>

--- a/src/surfaces/home/CodexCreature.jsx
+++ b/src/surfaces/home/CodexCreature.jsx
@@ -63,7 +63,7 @@ function codexVisualContext(context) {
 }
 
 function preferredMonsterImageSize(context) {
-  if (context === 'feature' || context === 'preview') return 1280;
+  if (context === 'card' || context === 'feature' || context === 'preview') return 1280;
   return 640;
 }
 

--- a/tests/helpers/react-render.js
+++ b/tests/helpers/react-render.js
@@ -106,6 +106,7 @@ export function renderMonsterVisualRendererFixture() {
     import { renderToStaticMarkup } from 'react-dom/server';
     import { MonsterVisualConfigProvider } from ${JSON.stringify(absoluteSpecifier('src/platform/game/MonsterVisualConfigContext.jsx'))};
     import { BUNDLED_MONSTER_VISUAL_CONFIG } from ${JSON.stringify(absoluteSpecifier('src/platform/game/monster-visual-config.js'))};
+    import { CodexCard } from ${JSON.stringify(absoluteSpecifier('src/surfaces/home/CodexCard.jsx'))};
     import { CodexCreatureVisual } from ${JSON.stringify(absoluteSpecifier('src/surfaces/home/CodexCreature.jsx'))};
     import { MonsterMeadow } from ${JSON.stringify(absoluteSpecifier('src/surfaces/home/MonsterMeadow.jsx'))};
     import { SetupMeadow } from ${JSON.stringify(absoluteSpecifier('src/subjects/spelling/components/SpellingSetupScene.jsx'))};
@@ -169,6 +170,29 @@ export function renderMonsterVisualRendererFixture() {
             }}
             context="feature"
             sizes="(max-width: 820px) 76vw, 700px"
+          />
+          <CodexCard
+            entry={{
+              id: 'glimmerbug',
+              subjectId: 'spelling',
+              name: 'Mega Lanternwing',
+              speciesName: 'Glimmerbug',
+              blurb: 'Review card fixture.',
+              caught: true,
+              stage: 4,
+              mastered: 100,
+              progressPct: 100,
+              colour: '#B43CD9',
+              soft: '#F8E7F1',
+              branch: 'b1',
+              displayState: 'monster',
+              imageAlt: 'Mega Lanternwing',
+              stageLabel: 'Stage 4',
+              secureLabel: '100 secure words',
+              wordBand: 'Year 5-6 spellings',
+            }}
+            onPractice={() => {}}
+            onPreview={() => {}}
           />
           <MonsterMeadow
             monsters={[{

--- a/tests/monster-visual-renderers.test.js
+++ b/tests/monster-visual-renderers.test.js
@@ -17,10 +17,13 @@ test('monster visual renderers use published config for meadow and reward toast'
   assert.match(html, /opacity:0\.82/);
   assert.match(html, /filter:brightness\(1\.1\)/);
   assert.match(html, /clip-path:inset\(10\.0% 15\.0% 5\.0% 5\.0%\)/);
+  assert.match(html, /src="\.\/assets\/monsters\/vellhorn\/b1\/vellhorn-b1-3\.1280\.webp\?v=20260421-branches"/);
   assert.match(html, /class="ss-meadow-visual" style="--visual-offset-x:12\.00px/);
   assert.match(html, /class="monster-celebration-visual after" data-stage="3" style="--visual-offset-x:18\.00px/);
   assert.match(html, /src="\.\/assets\/monsters\/phaeton\/b1\/phaeton-b1-4\.1280\.webp\?v=20260421-branches"/);
   assert.match(html, /sizes="\(max-width: 820px\) 76vw, 700px"/);
+  assert.match(html, /src="\.\/assets\/monsters\/glimmerbug\/b1\/glimmerbug-b1-4\.1280\.webp\?v=20260421-branches"/);
+  assert.match(html, /sizes="\(max-width: 820px\) 72vw, 360px"/);
   assert.match(html, /--visual-shadow-x:7\.00px/);
   assert.match(html, /--visual-shadow-scale:1\.350/);
   assert.match(html, /--visual-shadow-opacity:0\.340/);


### PR DESCRIPTION
## Summary
- Use the 1280px monster asset fallback for Codex roster card visuals as well as feature/lightbox visuals.
- Increase the roster card image sizes hint so high-density displays can select the higher-resolution source.
- Extend renderer coverage to assert the roster card emits the 1280px image and updated sizes hint.

## Verification
- npm test
- npm run check