### PR TITLE
feat(punctuation): expand transfer validators

### DIFF
--- a/docs/plans/2026-04-24-002-feat-punctuation-legacy-parity-plan.md
+++ b/docs/plans/2026-04-24-002-feat-punctuation-legacy-parity-plan.md
@@ -364,7 +364,7 @@ tests/
 
 ---
 
-- [ ] U7. **Expand Transfer Validators And Evidence**
+- [x] U7. **Expand Transfer Validators And Evidence**
 
 **Goal:** Bring the current constrained transfer work closer to the legacy breadth without pretending to judge unconstrained writing.
 

--- a/shared/punctuation/content.js
+++ b/shared/punctuation/content.js
@@ -403,6 +403,26 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     source: 'fixed',
   },
   {
+    id: 'lc_transfer_bake_sale',
+    mode: 'transfer',
+    skillIds: ['list_commas'],
+    clusterId: 'comma_flow',
+    rewardUnitId: 'list-commas-core',
+    prompt: 'Write one sentence using this exact stem and list: For the bake sale we needed eggs, flour, butter and sugar.',
+    stem: '',
+    accepted: ['For the bake sale we needed eggs, flour, butter and sugar.'],
+    explanation: 'The sentence keeps the stem and separates the list items with commas.',
+    model: 'For the bake sale we needed eggs, flour, butter and sugar.',
+    validator: {
+      type: 'requiresListCommas',
+      opening: 'For the bake sale we needed',
+      items: ['eggs', 'flour', 'butter', 'sugar'],
+    },
+    misconceptionTags: ['comma.list_separator_missing', 'comma.list_words_changed', 'comma.unnecessary_final_comma'],
+    readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    source: 'fixed',
+  },
+  {
     id: 'lc_combine_trip_list',
     mode: 'combine',
     skillIds: ['list_commas'],
@@ -624,7 +644,7 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     skillIds: ['speech'],
     clusterId: 'speech',
     rewardUnitId: 'speech-core',
-    prompt: 'Write one sentence of direct speech using these exact spoken words: can we start now',
+    prompt: 'Write one sentence of direct speech using these exact spoken words: Can we start now?',
     stem: '',
     accepted: ['Mia asked, "Can we start now?"'],
     explanation: 'Direct speech needs inverted commas, a capital letter, and a question mark inside the closing inverted comma.',
@@ -637,6 +657,28 @@ export const PUNCTUATION_ITEMS = Object.freeze([
       requiredTerminal: '?',
     },
     misconceptionTags: ['speech.quote_missing', 'speech.punctuation_outside_quote', 'speech.reporting_comma_missing', 'speech.capitalisation_missing', 'speech.words_changed'],
+    readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    source: 'fixed',
+  },
+  {
+    id: 'sp_fa_transfer_at_last_speech',
+    mode: 'transfer',
+    skillIds: ['speech', 'fronted_adverbial'],
+    clusterId: 'speech',
+    rewardUnitId: 'speech-core',
+    prompt: 'Write one sentence using this exact opening, reporting clause and spoken words: At last / Noah shouted / we made it!',
+    stem: '',
+    accepted: ['At last, Noah shouted, "We made it!"'],
+    explanation: 'The fronted adverbial needs a comma, and the spoken words need inverted commas and correct end punctuation.',
+    model: 'At last, Noah shouted, "We made it!"',
+    validator: {
+      type: 'frontedAdverbialWithSpeech',
+      phrase: 'At last',
+      reportingClause: 'Noah shouted',
+      words: 'we made it',
+      requiredTerminal: '!',
+    },
+    misconceptionTags: ['comma.fronted_adverbial_missing', 'speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing', 'speech.words_changed'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
     source: 'fixed',
   },
@@ -1043,6 +1085,22 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     source: 'fixed',
   },
   {
+    id: 'hy_transfer_man_eating_shark',
+    mode: 'transfer',
+    skillIds: ['hyphen'],
+    clusterId: 'boundary',
+    rewardUnitId: 'hyphens-core',
+    prompt: "Write one sentence that includes this exact phrase: man-eating shark.",
+    stem: '',
+    accepted: ['The divers spotted a man-eating shark near the reef.'],
+    explanation: 'The hyphen avoids ambiguity in the noun phrase.',
+    model: 'The divers spotted a man-eating shark near the reef.',
+    validator: { type: 'requiresHyphenatedPhrase', phrase: 'man-eating shark' },
+    misconceptionTags: ['boundary.hyphen_missing', 'boundary.words_changed'],
+    readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    source: 'fixed',
+  },
+  {
     id: 'pa_choose_coach',
     mode: 'choose',
     skillIds: ['parenthesis'],
@@ -1118,7 +1176,7 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     skillIds: ['parenthesis'],
     clusterId: 'structure',
     rewardUnitId: 'parenthesis-core',
-    prompt: 'Write one sentence that adds this parenthesis: which opened last year.',
+    prompt: 'Write one sentence using this exact frame and parenthesis: The library / which opened last year / is busy.',
     stem: '',
     accepted: ['The library, which opened last year, is busy.'],
     explanation: 'The parenthesis is marked before and after the extra information.',
@@ -1214,7 +1272,7 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     skillIds: ['colon_list'],
     clusterId: 'structure',
     rewardUnitId: 'colons-core',
-    prompt: 'Write one sentence that uses a colon to introduce this exact list: a torch, a map and a whistle.',
+    prompt: 'Write one sentence using this exact opening and list: We needed three things / a torch, a map and a whistle.',
     stem: '',
     accepted: ['We needed three things: a torch, a map and a whistle.'],
     explanation: 'The colon introduces the list after a complete opening clause.',
@@ -1223,6 +1281,26 @@ export const PUNCTUATION_ITEMS = Object.freeze([
       type: 'requiresColonBeforeList',
       opening: 'We needed three things',
       items: ['a torch', 'a map', 'a whistle'],
+    },
+    misconceptionTags: ['structure.colon_missing', 'structure.list_words_changed', 'structure.list_separator_missing'],
+    readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    source: 'fixed',
+  },
+  {
+    id: 'cl_lc_transfer_toolkit',
+    mode: 'transfer',
+    skillIds: ['colon_list', 'list_commas'],
+    clusterId: 'structure',
+    rewardUnitId: 'colons-core',
+    prompt: 'Write one sentence using this exact stem and list after a colon: Our toolkit contained three items / glue, card and scissors.',
+    stem: '',
+    accepted: ['Our toolkit contained three items: glue, card and scissors.'],
+    explanation: 'A complete opening clause can be followed by a colon and a list.',
+    model: 'Our toolkit contained three items: glue, card and scissors.',
+    validator: {
+      type: 'requiresColonBeforeList',
+      opening: 'Our toolkit contained three items',
+      items: ['glue', 'card', 'scissors'],
     },
     misconceptionTags: ['structure.colon_missing', 'structure.list_words_changed', 'structure.list_separator_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
@@ -1575,13 +1653,13 @@ export const PUNCTUATION_REWARD_UNITS = Object.freeze([
     id: 'speech-core',
     clusterId: 'speech',
     skillIds: ['speech'],
-    evidenceItemIds: ['sp_choose_reporting_comma', 'sp_insert_question', 'sp_fix_question', 'sp_transfer_question', 'pg_fronted_speech'],
+    evidenceItemIds: ['sp_choose_reporting_comma', 'sp_insert_question', 'sp_fix_question', 'sp_transfer_question', 'sp_fa_transfer_at_last_speech', 'pg_fronted_speech'],
   }),
   rewardUnit({
     id: 'list-commas-core',
     clusterId: 'comma_flow',
     skillIds: ['list_commas'],
-    evidenceItemIds: ['lc_choose_picnic', 'lc_insert_supplies', 'lc_fix_display', 'lc_transfer_trip', 'lc_combine_trip_list'],
+    evidenceItemIds: ['lc_choose_picnic', 'lc_insert_supplies', 'lc_fix_display', 'lc_transfer_trip', 'lc_transfer_bake_sale', 'lc_combine_trip_list'],
   }),
   rewardUnit({
     id: 'fronted-adverbials-core',
@@ -1611,7 +1689,7 @@ export const PUNCTUATION_REWARD_UNITS = Object.freeze([
     id: 'hyphens-core',
     clusterId: 'boundary',
     skillIds: ['hyphen'],
-    evidenceItemIds: ['hy_choose_shark', 'hy_insert_little_used', 'hy_fix_fast_moving', 'hy_transfer_well_known'],
+    evidenceItemIds: ['hy_choose_shark', 'hy_insert_little_used', 'hy_fix_fast_moving', 'hy_transfer_well_known', 'hy_transfer_man_eating_shark'],
   }),
   rewardUnit({
     id: 'parenthesis-core',
@@ -1623,7 +1701,7 @@ export const PUNCTUATION_REWARD_UNITS = Object.freeze([
     id: 'colons-core',
     clusterId: 'structure',
     skillIds: ['colon_list'],
-    evidenceItemIds: ['cl_choose_supplies', 'cl_insert_awards', 'cl_fix_camp', 'cl_transfer_trip', 'cl_combine_awards'],
+    evidenceItemIds: ['cl_choose_supplies', 'cl_insert_awards', 'cl_fix_camp', 'cl_transfer_trip', 'cl_lc_transfer_toolkit', 'cl_combine_awards'],
   }),
   rewardUnit({
     id: 'semicolon-lists-core',
@@ -1879,6 +1957,75 @@ function assertNoDuplicates(values, label, errors) {
   }
 }
 
+function normaliseVisibleContractText(value) {
+  return String(value ?? '')
+    .toLowerCase()
+    .replace(/[‘’]/g, "'")
+    .replace(/[“”]/g, '"')
+    .replace(/[–—]/g, '-')
+    .replace(/\s+([,.;:?!])/g, '$1')
+    .replace(/\s*-\s*/g, '-')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function visibleContractIncludes(visibleText, requirement) {
+  const required = normaliseVisibleContractText(requirement);
+  return !required || visibleText.includes(required);
+}
+
+function transferValidatorRequirements(item) {
+  if (item?.mode !== 'transfer') return [];
+  const validator = item.validator || {};
+  switch (validator.type) {
+    case 'startsWithWordQuestion':
+      return [validator.word];
+    case 'requiresTokens':
+      return asArray(validator.tokens);
+    case 'requiresListCommas':
+      return [
+        validator.opening || validator.stem,
+        ...asArray(validator.items),
+      ];
+    case 'startsWithPhraseComma':
+      return [validator.phrase];
+    case 'speechWithWords':
+      return [
+        validator.requiredTerminal
+          ? `${validator.words || validator.spokenWords}${validator.requiredTerminal}`
+          : (validator.words || validator.spokenWords),
+      ];
+    case 'frontedAdverbialWithSpeech':
+      return [
+        validator.phrase,
+        validator.reportingClause,
+        validator.requiredTerminal
+          ? `${validator.words || validator.spokenWords}${validator.requiredTerminal}`
+          : (validator.words || validator.spokenWords),
+      ];
+    case 'requiresBoundaryBetweenClauses':
+      return [validator.left, validator.right];
+    case 'requiresHyphenatedPhrase':
+      return [validator.phrase];
+    case 'requiresParentheticalPhrase':
+      return [validator.before, validator.phrase, validator.after];
+    case 'requiresColonBeforeList':
+      return [
+        validator.opening,
+        ...asArray(validator.items),
+      ];
+    case 'requiresSemicolonList':
+      return asArray(validator.items);
+    case 'requiresBulletStemAndItems':
+      return [
+        validator.stem,
+        ...asArray(validator.items),
+      ];
+    default:
+      return [];
+  }
+}
+
 function pushIndexed(map, key, value) {
   if (!map.has(key)) map.set(key, []);
   map.get(key).push(value);
@@ -2010,6 +2157,12 @@ export function validatePunctuationManifest(manifest = PUNCTUATION_CONTENT_MANIF
     for (const skillId of asArray(item.skillIds)) {
       if (!indexes.skillById.has(skillId)) errors.push(`Item ${item.id} references missing skill ${skillId}.`);
     }
+    const visibleContract = normaliseVisibleContractText(`${item.prompt || ''} ${item.stem || ''}`);
+    for (const requirement of transferValidatorRequirements(item)) {
+      if (!visibleContractIncludes(visibleContract, requirement)) {
+        errors.push(`Transfer item ${item.id} hides validator requirement ${requirement}.`);
+      }
+    }
   }
 
   for (const unit of indexes.rewardUnits) {
@@ -2020,6 +2173,16 @@ export function validatePunctuationManifest(manifest = PUNCTUATION_CONTENT_MANIF
     const hasGenerator = asArray(unit.generatorFamilyIds).some((familyId) => indexes.generatorFamilyById.has(familyId));
     if (unit.published && !hasEvidenceItem && !hasGenerator) {
       errors.push(`Published reward unit ${unit.rewardUnitId} has no deterministic evidence.`);
+    }
+    for (const itemId of asArray(unit.evidenceItemIds)) {
+      const item = indexes.itemById.get(itemId);
+      if (!item) {
+        errors.push(`Reward unit ${unit.rewardUnitId} lists missing evidence item ${itemId}.`);
+        continue;
+      }
+      if (item.rewardUnitId !== unit.rewardUnitId) {
+        errors.push(`Reward unit ${unit.rewardUnitId} lists evidence item ${itemId} from ${item.rewardUnitId}.`);
+      }
     }
     const expectedKey = createPunctuationMasteryKey({
       releaseId: unit.releaseId,

--- a/shared/punctuation/marking.js
+++ b/shared/punctuation/marking.js
@@ -201,11 +201,32 @@ function wordSequencePreserved(text, words = []) {
   for (const word of words) {
     const target = stripPunctuation(word);
     if (!target) continue;
-    const index = clean.indexOf(target, cursor);
-    if (index < 0) return false;
-    cursor = index + target.length;
+    const slice = clean.slice(cursor);
+    const match = new RegExp(`(?:^|\\s)${escapeRegExp(target)}(?=\\s|$)`).exec(slice);
+    if (!match) return false;
+    cursor += match.index + match[0].length;
   }
   return true;
+}
+
+function wordCount(value) {
+  const clean = stripPunctuation(value);
+  return clean ? clean.split(' ').filter(Boolean).length : 0;
+}
+
+function requiredTokenCoverage(text, tokens = []) {
+  const clean = canonicalPunctuationText(text).toLowerCase();
+  const required = (Array.isArray(tokens) ? tokens : [])
+    .map((token) => canonicalPunctuationText(token))
+    .filter(Boolean);
+  const missing = required.filter((token) => {
+    const exactTokenPattern = new RegExp(`(?:^|[^a-z0-9])${escapeRegExp(token.toLowerCase())}(?=$|[^a-z0-9])`);
+    return !exactTokenPattern.test(clean);
+  });
+  return {
+    missing,
+    ok: required.length > 0 && missing.length === 0,
+  };
 }
 
 function terminalMarkFromModel(item, fallback = '.') {
@@ -223,6 +244,10 @@ function singleSentenceOk(text, requiredTerminal = null) {
   if (!sentenceEnds(clean, requiredTerminal)) return false;
   const body = clean.replace(/[.?!]["']?$/, '').trim();
   return !/[.?!]/.test(body);
+}
+
+function transferSentenceOk(item, text, requiredTerminal = null) {
+  return item?.mode === 'paragraph' ? true : singleSentenceOk(text, requiredTerminal);
 }
 
 function listCommaPattern(words = [], { finalComma = false } = {}) {
@@ -245,6 +270,23 @@ function listCommaOk(text, words = []) {
   return {
     commaPlacement,
     hasFinalComma: !commaPlacement && withFinalComma ? withFinalComma.test(clean) : false,
+  };
+}
+
+function openingPhraseMainClause(text, phrase) {
+  const clean = canonicalPunctuationText(text);
+  const canonicalPhrase = canonicalPunctuationText(phrase || '');
+  const lower = clean.toLowerCase();
+  const phraseOk = Boolean(canonicalPhrase) && lower.startsWith(canonicalPhrase.toLowerCase());
+  const afterPhrase = phraseOk ? clean.slice(canonicalPhrase.length) : '';
+  const commaOk = phraseOk && /^\s*,/.test(afterPhrase);
+  const mainClause = commaOk
+    ? afterPhrase.replace(/^\s*,\s*/, '').replace(/[.?!]["']?$/, '').trim()
+    : '';
+  return {
+    phraseOk,
+    commaOk,
+    mainClauseOk: commaOk && wordCount(mainClause) >= 2,
   };
 }
 
@@ -296,7 +338,10 @@ function hyphenatedPhrase(text, phrase) {
   const phraseText = canonicalPunctuationText(phrase || '').toLowerCase();
   const phraseWords = phraseText.replace(/-/g, ' ').split(/\s+/).filter(Boolean);
   const wordsOk = phraseWords.length > 0 && wordSequencePreserved(clean, phraseWords);
-  const hyphenOk = Boolean(phraseText) && clean.toLowerCase().includes(phraseText);
+  const hyphenOk = Boolean(phraseText) && new RegExp(
+    `(?:^|[^a-z0-9])${escapeRegExp(phraseText)}(?=$|[^a-z0-9])`,
+    'i',
+  ).test(clean);
   return { wordsOk, hyphenOk };
 }
 
@@ -402,6 +447,58 @@ function bulletStemAndItems(text, validator = {}) {
   const allowedEndings = new Set(['', '.']);
   const punctuationOk = bulletMarkersOk && endings.every((ending) => allowedEndings.has(ending)) && new Set(endings).size <= 1;
   return { stemOk, colonOk, itemsOk, bulletMarkersOk, punctuationOk };
+}
+
+function frontedAdverbialWithSpeech(text, validator = {}, requiredTerminal = null) {
+  const clean = canonicalPunctuationText(text);
+  const phrase = canonicalPunctuationText(validator.phrase || '');
+  const expectedReportingClause = canonicalPunctuationText(validator.reportingClause || '');
+  const phraseParts = openingPhraseMainClause(clean, phrase);
+  const quote = findQuotePair(text);
+  const beforeQuoteText = quote.ok ? beforeOpeningQuote(text, quote.pair) : '';
+  const afterPhraseBeforeQuote = phraseParts.phraseOk
+    ? canonicalPunctuationText(beforeQuoteText).slice(phrase.length).trim()
+    : '';
+  const reportingWords = afterPhraseBeforeQuote
+    .replace(/^,\s*/, '')
+    .replace(/,\s*$/, '')
+    .trim();
+  const reportingWordsOk = expectedReportingClause
+    ? stripPunctuation(reportingWords) === stripPunctuation(expectedReportingClause)
+    : wordCount(reportingWords) >= 2;
+  const reportingClauseOk = quote.ok
+    && /,\s*$/.test(beforeQuoteText)
+    && reportingWordsOk;
+  const speech = evaluateSpeechRubric(text, {
+    type: 'speech',
+    reportingPosition: 'before',
+    spokenWords: validator.words || validator.spokenWords,
+    requiredTerminal,
+  });
+  const speechFacetOk = (id) => speech.facets.find((entry) => entry.id === id)?.ok === true;
+  const quoteOk = speechFacetOk('quote_variant');
+  const speechPunctuationOkValue = speechFacetOk('speech_punctuation');
+  const capitalOk = speechFacetOk('capitalisation');
+  const speechWordsOk = speechFacetOk('preservation');
+  const unwantedOk = quote.ok ? speechFacetOk('unwanted_punctuation') : true;
+  const sentenceOk = singleSentenceOk(text, requiredTerminal);
+  return {
+    correct: phraseParts.phraseOk
+      && phraseParts.commaOk
+      && reportingClauseOk
+      && speech.correct
+      && sentenceOk,
+    phraseOk: phraseParts.phraseOk,
+    commaOk: phraseParts.commaOk,
+    reportingClauseOk,
+    quoteOk,
+    speechPunctuationOk: speechPunctuationOkValue,
+    capitalOk,
+    preservationOk: phraseParts.phraseOk && reportingWordsOk && speechWordsOk,
+    unwantedOk,
+    sentenceOk,
+    speech,
+  };
 }
 
 function anchoredListSentence(text, validator = {}, requiredTerminal = null) {
@@ -526,48 +623,72 @@ function markTransfer(item, answer) {
   if (validator.type === 'startsWithWordQuestion') {
     const firstWord = String(validator.word || '').toLowerCase();
     const lower = text.toLowerCase();
-    const correct = lower.startsWith(`${firstWord} `) && sentenceStartsWithCapital(text) && sentenceEnds(text, '?');
+    const wordOk = lower.startsWith(`${firstWord} `);
+    const capitalOk = sentenceStartsWithCapital(text);
+    const terminalOk = sentenceEnds(text, '?');
+    const sentenceOk = transferSentenceOk(item, text, '?');
+    const correct = wordOk && capitalOk && terminalOk && sentenceOk;
     return {
       correct,
       expected: item.model || '',
       note: correct ? 'That begins like a question and ends with a question mark.' : `Start with ${validator.word}, use a capital letter, and end with a question mark.`,
-      misconceptionTags: correct ? [] : ['endmarks.question_mark_missing', 'endmarks.capitalisation_missing'],
+      misconceptionTags: correct ? [] : [...new Set([
+        ...(wordOk ? [] : ['endmarks.question_starter_changed']),
+        ...(terminalOk ? [] : ['endmarks.question_mark_missing']),
+        ...(capitalOk ? [] : ['endmarks.capitalisation_missing']),
+        ...(sentenceOk ? [] : ['transfer.extra_sentence']),
+      ])],
       facets: [
-        facet('capitalisation', sentenceStartsWithCapital(text)),
-        facet('speech_punctuation', sentenceEnds(text, '?')),
+        facet('preservation', wordOk),
+        facet('capitalisation', capitalOk),
+        facet('terminal_punctuation', terminalOk),
+        ...(item.mode === 'paragraph' ? [] : [facet('single_sentence', sentenceOk)]),
       ],
     };
   }
 
   if (validator.type === 'requiresTokens') {
-    const lower = text.toLowerCase();
-    const missing = (Array.isArray(validator.tokens) ? validator.tokens : [])
-      .filter((token) => !lower.includes(String(token).toLowerCase()));
-    const correct = missing.length === 0 && sentenceStartsWithCapital(text) && sentenceEnds(text);
+    const { missing, ok: tokensOk } = requiredTokenCoverage(text, validator.tokens);
+    const capitalOk = sentenceStartsWithCapital(text);
+    const terminalOk = sentenceEnds(text);
+    const sentenceOk = transferSentenceOk(item, text);
+    const correct = tokensOk && capitalOk && terminalOk && sentenceOk;
     return {
       correct,
       expected: item.model || '',
       note: missing.length ? `Include these exact forms: ${missing.join(', ')}.` : 'Good. The required punctuated forms are present.',
-      misconceptionTags: correct ? [] : (Array.isArray(item.misconceptionTags) ? [...item.misconceptionTags] : []),
+      misconceptionTags: correct ? [] : [...new Set([
+        ...(tokensOk ? [] : itemTags(item)),
+        ...(capitalOk ? [] : ['apostrophe.capitalisation_missing']),
+        ...(terminalOk ? [] : ['apostrophe.terminal_missing']),
+        ...(sentenceOk ? [] : ['transfer.extra_sentence']),
+      ])],
       facets: [
-        facet('capitalisation', sentenceStartsWithCapital(text)),
-        facet('speech_punctuation', sentenceEnds(text)),
+        facet('preservation', tokensOk),
+        facet('capitalisation', capitalOk),
+        facet('terminal_punctuation', terminalOk),
+        ...(item.mode === 'paragraph' ? [] : [facet('single_sentence', sentenceOk)]),
       ],
     };
   }
 
   if (validator.type === 'requiresListCommas') {
     const words = Array.isArray(validator.items) ? validator.items : [];
-    const wordsOk = words.length >= 2 && wordSequencePreserved(text, words);
+    const opening = canonicalPunctuationText(validator.opening || validator.stem || '');
+    const clean = canonicalPunctuationText(text);
+    const openingOk = !opening || clean.toLowerCase().startsWith(opening.toLowerCase());
+    const wordsOk = words.length >= 2 && openingOk && wordSequencePreserved(text, opening ? [opening, ...words] : words);
     const { commaPlacement, hasFinalComma } = listCommaOk(text, words);
     const capitalOk = sentenceStartsWithCapital(text);
     const terminalOk = sentenceEnds(text);
-    const correct = wordsOk && commaPlacement && capitalOk && terminalOk;
+    const sentenceOk = transferSentenceOk(item, text);
+    const correct = wordsOk && commaPlacement && capitalOk && terminalOk && sentenceOk;
     const tags = [];
     if (!wordsOk) tags.push('comma.list_words_changed');
     if (!commaPlacement) tags.push(hasFinalComma ? 'comma.unnecessary_final_comma' : 'comma.list_separator_missing');
     if (!capitalOk) tags.push('comma.capitalisation_missing');
     if (!terminalOk) tags.push('comma.terminal_missing');
+    if (terminalOk && !sentenceOk) tags.push('transfer.extra_sentence');
     return {
       correct,
       expected: item.model || '',
@@ -578,49 +699,87 @@ function markTransfer(item, answer) {
         facet('comma_placement', commaPlacement),
         facet('capitalisation', capitalOk),
         facet('terminal_punctuation', terminalOk),
+        ...(item.mode === 'paragraph' ? [] : [facet('single_sentence', sentenceOk)]),
       ],
     };
   }
 
   if (validator.type === 'startsWithPhraseComma') {
-    const phrase = canonicalPunctuationText(validator.phrase || '');
-    const clean = canonicalPunctuationText(text);
-    const phraseOk = Boolean(phrase) && clean.toLowerCase().startsWith(phrase.toLowerCase());
-    const commaOk = Boolean(phrase) && clean.toLowerCase().startsWith(`${phrase.toLowerCase()},`);
+    const { phraseOk, commaOk, mainClauseOk } = openingPhraseMainClause(text, validator.phrase);
     const capitalOk = sentenceStartsWithCapital(text);
     const terminalOk = sentenceEnds(text);
-    const correct = phraseOk && commaOk && capitalOk && terminalOk;
+    const sentenceOk = transferSentenceOk(item, text);
+    const correct = phraseOk && commaOk && mainClauseOk && capitalOk && terminalOk && sentenceOk;
     const tags = [];
     if (!phraseOk) tags.push('comma.opening_phrase_changed');
     if (phraseOk && !commaOk) tags.push(primaryCommaTag(item, 'comma.fronted_adverbial_missing'));
+    if (commaOk && !mainClauseOk) tags.push('comma.main_clause_missing');
     if (!capitalOk) tags.push('comma.capitalisation_missing');
     if (!terminalOk) tags.push('comma.terminal_missing');
+    if (terminalOk && !sentenceOk) tags.push('transfer.extra_sentence');
     return {
       correct,
       expected: item.model || '',
       note: correct ? 'The opening phrase is followed by a comma.' : `Begin with ${validator.phrase}, add the comma, and finish the sentence.`,
       misconceptionTags: correct ? [] : [...new Set(tags.length ? tags : itemTags(item))],
       facets: [
-        facet('preservation', phraseOk),
+        facet('preservation', phraseOk && mainClauseOk),
         facet('comma_placement', commaOk),
         facet('capitalisation', capitalOk),
         facet('terminal_punctuation', terminalOk),
+        ...(item.mode === 'paragraph' ? [] : [facet('single_sentence', sentenceOk)]),
       ],
     };
   }
 
   if (validator.type === 'speechWithWords') {
+    const requiredTerminal = validator.requiredTerminal || '?';
     const rubric = evaluateSpeechRubric(text, {
       type: 'speech',
       spokenWords: validator.words,
-      requiredTerminal: validator.requiredTerminal || '?',
+      requiredTerminal,
     });
+    const sentenceOk = transferSentenceOk(item, text, requiredTerminal);
+    const correct = rubric.correct && sentenceOk;
     return {
-      correct: rubric.correct,
+      correct,
       expected: item.model || '',
       note: rubric.correct ? 'The spoken words are punctuated as a question.' : 'Include inverted commas around the spoken words and keep the question mark with the speech.',
-      misconceptionTags: rubric.misconceptionTags,
-      facets: rubric.facets,
+      misconceptionTags: correct ? [] : [...new Set([
+        ...(rubric.correct ? [] : rubric.misconceptionTags),
+        ...(sentenceOk ? [] : ['transfer.extra_sentence']),
+      ])],
+      facets: [
+        ...rubric.facets,
+        ...(item.mode === 'paragraph' ? [] : [facet('single_sentence', sentenceOk)]),
+      ],
+    };
+  }
+
+  if (validator.type === 'frontedAdverbialWithSpeech') {
+    const requiredTerminal = validator.requiredTerminal || terminalMarkFromModel(item, '!');
+    const result = frontedAdverbialWithSpeech(text, validator, requiredTerminal);
+    const tags = [];
+    if (!result.phraseOk) tags.push('comma.opening_phrase_changed');
+    if (result.phraseOk && !result.commaOk) tags.push(primaryCommaTag(item, 'comma.fronted_adverbial_missing'));
+    if (result.quoteOk && !result.reportingClauseOk) tags.push('speech.reporting_comma_missing');
+    if (!result.sentenceOk) tags.push('transfer.extra_sentence');
+    tags.push(...result.speech.misconceptionTags);
+    return {
+      correct: result.correct,
+      expected: item.model || '',
+      note: result.correct ? 'That combines a fronted adverbial with direct speech.' : `Begin with "${validator.phrase}," and include correctly punctuated direct speech.`,
+      misconceptionTags: result.correct ? [] : [...new Set(tags.length ? tags : itemTags(item))],
+      facets: [
+        facet('preservation', result.preservationOk),
+        facet('comma_placement', result.commaOk),
+        facet('quote_variant', result.quoteOk),
+        facet('speech_punctuation', result.speechPunctuationOk),
+        facet('reporting_clause', result.reportingClauseOk),
+        facet('capitalisation', result.capitalOk),
+        facet('unwanted_punctuation', result.unwantedOk),
+        facet('single_sentence', result.sentenceOk),
+      ],
     };
   }
 
@@ -628,7 +787,8 @@ function markTransfer(item, answer) {
     const { wordsOk, markOk, between, mark } = boundaryBetweenClauses(text, validator);
     const capitalOk = sentenceStartsWithCapital(text);
     const terminalOk = sentenceEnds(text);
-    const correct = wordsOk && markOk && capitalOk && terminalOk;
+    const sentenceOk = transferSentenceOk(item, text);
+    const correct = wordsOk && markOk && capitalOk && terminalOk && sentenceOk;
     const tags = [];
     const isSemicolon = String(mark).trim() === ';';
     if (!wordsOk) tags.push('boundary.words_changed');
@@ -638,6 +798,7 @@ function markTransfer(item, answer) {
     }
     if (!capitalOk) tags.push('boundary.capitalisation_missing');
     if (!terminalOk) tags.push('boundary.terminal_missing');
+    if (terminalOk && !sentenceOk) tags.push('transfer.extra_sentence');
     return {
       correct,
       expected: item.model || '',
@@ -648,6 +809,7 @@ function markTransfer(item, answer) {
         facet('boundary_mark', markOk),
         facet('capitalisation', capitalOk),
         facet('terminal_punctuation', terminalOk),
+        ...(item.mode === 'paragraph' ? [] : [facet('single_sentence', sentenceOk)]),
       ],
     };
   }
@@ -656,12 +818,14 @@ function markTransfer(item, answer) {
     const { wordsOk, hyphenOk } = hyphenatedPhrase(text, validator.phrase);
     const capitalOk = sentenceStartsWithCapital(text);
     const terminalOk = sentenceEnds(text);
-    const correct = wordsOk && hyphenOk && capitalOk && terminalOk;
+    const sentenceOk = transferSentenceOk(item, text);
+    const correct = wordsOk && hyphenOk && capitalOk && terminalOk && sentenceOk;
     const tags = [];
     if (!wordsOk) tags.push('boundary.words_changed');
     if (wordsOk && !hyphenOk) tags.push('boundary.hyphen_missing');
     if (!capitalOk) tags.push('boundary.capitalisation_missing');
     if (!terminalOk) tags.push('boundary.terminal_missing');
+    if (terminalOk && !sentenceOk) tags.push('transfer.extra_sentence');
     return {
       correct,
       expected: item.model || '',
@@ -672,6 +836,7 @@ function markTransfer(item, answer) {
         facet('hyphenated_phrase', hyphenOk),
         facet('capitalisation', capitalOk),
         facet('terminal_punctuation', terminalOk),
+        ...(item.mode === 'paragraph' ? [] : [facet('single_sentence', sentenceOk)]),
       ],
     };
   }
@@ -680,12 +845,14 @@ function markTransfer(item, answer) {
     const { wordsOk, openOk, closeOk, punctuationOk } = parentheticalPhrase(text, validator);
     const capitalOk = sentenceStartsWithCapital(text);
     const terminalOk = sentenceEnds(text);
-    const correct = wordsOk && punctuationOk && capitalOk && terminalOk;
+    const sentenceOk = transferSentenceOk(item, text);
+    const correct = wordsOk && punctuationOk && capitalOk && terminalOk && sentenceOk;
     const tags = [];
     if (!wordsOk) tags.push('structure.words_changed');
     if (wordsOk && !punctuationOk) tags.push(openOk || closeOk ? 'structure.parenthesis_unbalanced' : 'structure.parenthesis_missing');
     if (!capitalOk) tags.push('structure.capitalisation_missing');
     if (!terminalOk) tags.push('structure.terminal_missing');
+    if (terminalOk && !sentenceOk) tags.push('transfer.extra_sentence');
     return {
       correct,
       expected: item.model || '',
@@ -696,6 +863,7 @@ function markTransfer(item, answer) {
         facet('parenthetical_phrase', punctuationOk),
         facet('capitalisation', capitalOk),
         facet('terminal_punctuation', terminalOk),
+        ...(item.mode === 'paragraph' ? [] : [facet('single_sentence', sentenceOk)]),
       ],
     };
   }
@@ -704,13 +872,15 @@ function markTransfer(item, answer) {
     const { wordsOk, colonOk, listOk, hasFinalComma } = colonBeforeList(text, validator);
     const capitalOk = sentenceStartsWithCapital(text);
     const terminalOk = sentenceEnds(text);
-    const correct = wordsOk && colonOk && listOk && capitalOk && terminalOk;
+    const sentenceOk = transferSentenceOk(item, text);
+    const correct = wordsOk && colonOk && listOk && capitalOk && terminalOk && sentenceOk;
     const tags = [];
     if (!wordsOk) tags.push('structure.list_words_changed');
     if (wordsOk && !colonOk) tags.push('structure.colon_missing');
     if (wordsOk && !listOk) tags.push(hasFinalComma ? 'comma.unnecessary_final_comma' : 'structure.list_separator_missing');
     if (!capitalOk) tags.push('structure.capitalisation_missing');
     if (!terminalOk) tags.push('structure.terminal_missing');
+    if (terminalOk && !sentenceOk) tags.push('transfer.extra_sentence');
     return {
       correct,
       expected: item.model || '',
@@ -722,6 +892,7 @@ function markTransfer(item, answer) {
         facet('list_separators', listOk),
         facet('capitalisation', capitalOk),
         facet('terminal_punctuation', terminalOk),
+        ...(item.mode === 'paragraph' ? [] : [facet('single_sentence', sentenceOk)]),
       ],
     };
   }
@@ -730,12 +901,14 @@ function markTransfer(item, answer) {
     const { wordsOk, separatorsOk } = semicolonList(text, validator);
     const capitalOk = sentenceStartsWithCapital(text);
     const terminalOk = sentenceEnds(text);
-    const correct = wordsOk && separatorsOk && capitalOk && terminalOk;
+    const sentenceOk = transferSentenceOk(item, text);
+    const correct = wordsOk && separatorsOk && capitalOk && terminalOk && sentenceOk;
     const tags = [];
     if (!wordsOk) tags.push('structure.list_words_changed');
     if (wordsOk && !separatorsOk) tags.push('structure.semicolon_list_missing');
     if (!capitalOk) tags.push('structure.capitalisation_missing');
     if (!terminalOk) tags.push('structure.terminal_missing');
+    if (terminalOk && !sentenceOk) tags.push('transfer.extra_sentence');
     return {
       correct,
       expected: item.model || '',
@@ -746,6 +919,7 @@ function markTransfer(item, answer) {
         facet('list_separators', separatorsOk),
         facet('capitalisation', capitalOk),
         facet('terminal_punctuation', terminalOk),
+        ...(item.mode === 'paragraph' ? [] : [facet('single_sentence', sentenceOk)]),
       ],
     };
   }

--- a/tests/punctuation-content.test.js
+++ b/tests/punctuation-content.test.js
@@ -102,12 +102,62 @@ test('manifest validation rejects duplicate reward mastery keys and missing read
     ...PUNCTUATION_CONTENT_MANIFEST,
     items: PUNCTUATION_CONTENT_MANIFEST.items.filter((item) => ![
       'sp_transfer_question',
+      'sp_fa_transfer_at_last_speech',
       'pg_fronted_speech',
       'pg_parenthesis_speech',
     ].includes(item.id)),
   };
   assert.equal(validatePunctuationManifest(missingTransfer).ok, false);
   assert.match(validatePunctuationManifest(missingTransfer).errors.join('\n'), /Published skill speech is missing readiness row constrained_transfer/);
+
+  const missingEvidence = {
+    ...PUNCTUATION_CONTENT_MANIFEST,
+    rewardUnits: PUNCTUATION_CONTENT_MANIFEST.rewardUnits.map((unit) => (
+      unit.rewardUnitId === 'speech-core'
+        ? { ...unit, evidenceItemIds: [...unit.evidenceItemIds, 'sp_missing_transfer_evidence'] }
+        : unit
+    )),
+  };
+  assert.equal(validatePunctuationManifest(missingEvidence).ok, false);
+  assert.match(validatePunctuationManifest(missingEvidence).errors.join('\n'), /Reward unit speech-core lists missing evidence item sp_missing_transfer_evidence/);
+
+  const hiddenTransferRequirement = {
+    ...PUNCTUATION_CONTENT_MANIFEST,
+    items: PUNCTUATION_CONTENT_MANIFEST.items.map((item) => (
+      item.id === 'sp_fa_transfer_at_last_speech'
+        ? { ...item, prompt: "Write one sentence that begins with 'At last' and includes direct speech." }
+        : item
+    )),
+  };
+  assert.equal(validatePunctuationManifest(hiddenTransferRequirement).ok, false);
+  assert.match(validatePunctuationManifest(hiddenTransferRequirement).errors.join('\n'), /Transfer item sp_fa_transfer_at_last_speech hides validator requirement Noah shouted/);
+
+  const hiddenSpeechTerminal = {
+    ...PUNCTUATION_CONTENT_MANIFEST,
+    items: PUNCTUATION_CONTENT_MANIFEST.items.map((item) => (
+      item.id === 'sp_fa_transfer_at_last_speech'
+        ? { ...item, prompt: 'Write one sentence using this exact opening, reporting clause and spoken words: At last / Noah shouted / we made it.' }
+        : item
+    )),
+  };
+  assert.equal(validatePunctuationManifest(hiddenSpeechTerminal).ok, false);
+  assert.match(validatePunctuationManifest(hiddenSpeechTerminal).errors.join('\n'), /Transfer item sp_fa_transfer_at_last_speech hides validator requirement we made it!/);
+
+  const hiddenPunctuationRequirement = {
+    ...PUNCTUATION_CONTENT_MANIFEST,
+    items: PUNCTUATION_CONTENT_MANIFEST.items.map((item) => {
+      if (item.id === 'hy_transfer_man_eating_shark') {
+        return { ...item, prompt: "Write one sentence that includes this exact phrase: man eating shark." };
+      }
+      if (item.id === 'ac_transfer_contractions') {
+        return { ...item, prompt: 'Write one sentence that includes both cant and were.' };
+      }
+      return item;
+    }),
+  };
+  assert.equal(validatePunctuationManifest(hiddenPunctuationRequirement).ok, false);
+  assert.match(validatePunctuationManifest(hiddenPunctuationRequirement).errors.join('\n'), /Transfer item hy_transfer_man_eating_shark hides validator requirement man-eating shark/);
+  assert.match(validatePunctuationManifest(hiddenPunctuationRequirement).errors.join('\n'), /Transfer item ac_transfer_contractions hides validator requirement can't/);
 });
 
 test('published skills meet the content-readiness matrix', () => {

--- a/tests/punctuation-marking.test.js
+++ b/tests/punctuation-marking.test.js
@@ -8,6 +8,10 @@ function item(id) {
   return PUNCTUATION_CONTENT_INDEXES.itemById.get(id);
 }
 
+function facet(result, id) {
+  return result.facets.find((entry) => entry.id === id);
+}
+
 test('speech rubric accepts straight, curly, single, and double inverted commas', () => {
   const rubric = {
     type: 'speech',
@@ -79,12 +83,22 @@ test('endmarks and apostrophe marking handles exact answers and constrained tran
     answer: { typed: "We can't leave yet because we're still tidying up." },
   }).correct, true);
 
+  const embeddedContractions = markPunctuationAnswer({
+    item: item('ac_transfer_contractions'),
+    answer: { typed: "We can'tankerous because we'rewolf." },
+  });
+  assert.equal(embeddedContractions.correct, false);
+  assert.equal(embeddedContractions.misconceptionTags.includes('apostrophe.contraction_missing'), true);
+  assert.equal(facet(embeddedContractions, 'preservation')?.ok, false);
+
   const missingToken = markPunctuationAnswer({
     item: item('ap_transfer_possession'),
     answer: { typed: "The children's paintings were near the teachers notices." },
   });
   assert.equal(missingToken.correct, false);
   assert.equal(missingToken.misconceptionTags.includes('apostrophe.possession_missing'), true);
+  assert.equal(facet(missingToken, 'preservation')?.ok, false);
+  assert.equal(facet(missingToken, 'terminal_punctuation')?.ok, true);
 });
 
 test('comma list transfer requires preserved items and KS2 list comma placement', () => {
@@ -108,6 +122,19 @@ test('comma list transfer requires preserved items and KS2 list comma placement'
   });
   assert.equal(finalComma.correct, false);
   assert.equal(finalComma.misconceptionTags.includes('comma.unnecessary_final_comma'), true);
+
+  const anchored = markPunctuationAnswer({
+    item: item('lc_transfer_bake_sale'),
+    answer: { typed: 'For the bake sale we needed eggs, flour, butter and sugar.' },
+  });
+  assert.equal(anchored.correct, true);
+
+  const changedStem = markPunctuationAnswer({
+    item: item('lc_transfer_bake_sale'),
+    answer: { typed: 'For the party we needed eggs, flour, butter and sugar.' },
+  });
+  assert.equal(changedStem.correct, false);
+  assert.equal(changedStem.misconceptionTags.includes('comma.list_words_changed'), true);
 });
 
 test('fronted adverbial and clarity transfers require the opening phrase comma', () => {
@@ -136,6 +163,14 @@ test('fronted adverbial and clarity transfers require the opening phrase comma',
   });
   assert.equal(missingClarityComma.correct, false);
   assert.equal(missingClarityComma.misconceptionTags.includes('comma.clarity_missing'), true);
+
+  const noMainClause = markPunctuationAnswer({
+    item: item('fa_transfer_after_lunch'),
+    answer: { typed: 'After lunch,.' },
+  });
+  assert.equal(noMainClause.correct, false);
+  assert.equal(noMainClause.misconceptionTags.includes('comma.main_clause_missing'), true);
+  assert.equal(facet(noMainClause, 'preservation')?.ok, false);
 });
 
 test('boundary transfer validators require target marks between preserved clauses', () => {
@@ -187,6 +222,97 @@ test('hyphen transfer validator requires the exact hyphenated phrase', () => {
   });
   assert.equal(changedPhrase.correct, false);
   assert.equal(changedPhrase.misconceptionTags.includes('boundary.words_changed'), true);
+
+  const legacyPhrase = markPunctuationAnswer({
+    item: item('hy_transfer_man_eating_shark'),
+    answer: { typed: 'The divers spotted a man-eating shark near the reef.' },
+  });
+  assert.equal(legacyPhrase.correct, true);
+
+  const missingLegacyHyphen = markPunctuationAnswer({
+    item: item('hy_transfer_man_eating_shark'),
+    answer: { typed: 'The divers spotted a man eating shark near the reef.' },
+  });
+  assert.equal(missingLegacyHyphen.correct, false);
+  assert.equal(missingLegacyHyphen.misconceptionTags.includes('boundary.hyphen_missing'), true);
+
+  const embeddedLegacyPhrase = markPunctuationAnswer({
+    item: item('hy_transfer_man_eating_shark'),
+    answer: { typed: 'The divers spotted a human-eating shark near the reef.' },
+  });
+  assert.equal(embeddedLegacyPhrase.correct, false);
+  assert.equal(embeddedLegacyPhrase.misconceptionTags.includes('boundary.words_changed'), true);
+
+  const embeddedWellKnownPhrase = markPunctuationAnswer({
+    item: item('hy_transfer_well_known'),
+    answer: { typed: 'The swell-known author visited our class.' },
+  });
+  assert.equal(embeddedWellKnownPhrase.correct, false);
+  assert.equal(embeddedWellKnownPhrase.misconceptionTags.includes('boundary.words_changed'), true);
+});
+
+test('mixed transfer validators constrain fronted speech and colon-list stems', () => {
+  const frontedSpeech = markPunctuationAnswer({
+    item: item('sp_fa_transfer_at_last_speech'),
+    answer: { typed: 'At last, Noah shouted, "We made it!"' },
+  });
+  assert.equal(frontedSpeech.correct, true);
+  assert.equal(facet(frontedSpeech, 'comma_placement')?.ok, true);
+  assert.equal(facet(frontedSpeech, 'speech_punctuation')?.ok, true);
+  assert.equal(facet(frontedSpeech, 'single_sentence')?.ok, true);
+
+  const missingFrontedComma = markPunctuationAnswer({
+    item: item('sp_fa_transfer_at_last_speech'),
+    answer: { typed: 'At last Noah shouted, "We made it!"' },
+  });
+  assert.equal(missingFrontedComma.correct, false);
+  assert.equal(missingFrontedComma.misconceptionTags.includes('comma.fronted_adverbial_missing'), true);
+  assert.equal(missingFrontedComma.misconceptionTags.includes('speech.reporting_comma_missing'), false);
+  assert.equal(facet(missingFrontedComma, 'reporting_clause')?.ok, true);
+
+  const invalidReportingClause = markPunctuationAnswer({
+    item: item('sp_fa_transfer_at_last_speech'),
+    answer: { typed: 'At last, blue green, "We made it!"' },
+  });
+  assert.equal(invalidReportingClause.correct, false);
+  assert.equal(facet(invalidReportingClause, 'preservation')?.ok, false);
+  assert.equal(facet(invalidReportingClause, 'reporting_clause')?.ok, false);
+
+  const changedSpeechWords = markPunctuationAnswer({
+    item: item('sp_fa_transfer_at_last_speech'),
+    answer: { typed: 'At last, Noah shouted, "We missed it!"' },
+  });
+  assert.equal(changedSpeechWords.correct, false);
+  assert.equal(changedSpeechWords.misconceptionTags.includes('speech.words_changed'), true);
+
+  const missingReportingClause = markPunctuationAnswer({
+    item: item('sp_fa_transfer_at_last_speech'),
+    answer: { typed: 'At last, "We made it!"' },
+  });
+  assert.equal(missingReportingClause.correct, false);
+  assert.equal(missingReportingClause.misconceptionTags.includes('speech.reporting_comma_missing'), true);
+
+  const mixedColonList = markPunctuationAnswer({
+    item: item('cl_lc_transfer_toolkit'),
+    answer: { typed: 'Our toolkit contained three items: glue, card and scissors.' },
+  });
+  assert.equal(mixedColonList.correct, true);
+  assert.equal(facet(mixedColonList, 'colon_boundary')?.ok, true);
+  assert.equal(facet(mixedColonList, 'list_separators')?.ok, true);
+
+  const changedStem = markPunctuationAnswer({
+    item: item('cl_lc_transfer_toolkit'),
+    answer: { typed: 'Our toolkit contained useful items: glue, card and scissors.' },
+  });
+  assert.equal(changedStem.correct, false);
+  assert.equal(changedStem.misconceptionTags.includes('structure.list_words_changed'), true);
+
+  const finalComma = markPunctuationAnswer({
+    item: item('cl_lc_transfer_toolkit'),
+    answer: { typed: 'Our toolkit contained three items: glue, card, and scissors.' },
+  });
+  assert.equal(finalComma.correct, false);
+  assert.equal(finalComma.misconceptionTags.includes('comma.unnecessary_final_comma'), true);
 });
 
 test('structure transfer validators require explicit punctuation roles', () => {

--- a/tests/punctuation-service.test.js
+++ b/tests/punctuation-service.test.js
@@ -2,7 +2,9 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  createPunctuationContentIndexes,
   createPunctuationMasteryKey,
+  PUNCTUATION_CONTENT_MANIFEST,
   PUNCTUATION_RELEASE_ID,
 } from '../shared/punctuation/content.js';
 import { PUNCTUATION_EVENT_TYPES } from '../shared/punctuation/events.js';
@@ -149,6 +151,32 @@ test('weak spots sessions target weak facets and record weak attempt metadata', 
   const attempt = repository.snapshot().data.progress.attempts.at(-1);
   assert.equal(attempt.sessionMode, 'weak');
   assert.equal(attempt.supportLevel, 0);
+});
+
+test('mixed transfer attempts update every included skill-by-mode facet', () => {
+  const mixedTransfer = PUNCTUATION_CONTENT_MANIFEST.items.find((entry) => entry.id === 'sp_fa_transfer_at_last_speech');
+  const manifest = {
+    ...PUNCTUATION_CONTENT_MANIFEST,
+    items: [mixedTransfer],
+    generatorFamilies: [],
+  };
+  const repository = makeRepository();
+  const service = createPunctuationService({
+    repository,
+    now: () => 0,
+    random: () => 0,
+    manifest,
+    indexes: createPunctuationContentIndexes(manifest),
+  });
+
+  const start = service.startSession('learner-a', { mode: 'smart', roundLength: '1' }).state;
+  assert.equal(start.session.currentItem.id, 'sp_fa_transfer_at_last_speech');
+  service.submitAnswer('learner-a', start, { typed: 'At last, Noah shouted, "We made it!"' });
+
+  const data = repository.snapshot().data;
+  assert.equal(data.progress.attempts.at(-1).mode, 'transfer');
+  assert.equal(data.progress.facets['speech::transfer'].correct, 1);
+  assert.equal(data.progress.facets['fronted_adverbial::transfer'].correct, 1);
 });
 
 test('one correct answer does not unlock secure-unit progress', () => {


### PR DESCRIPTION
## Summary
- add legacy-shaped constrained transfer evidence for stemmed list commas, fronted speech, man-eating shark hyphenation, and mixed colon/list commas
- tighten transfer validators around preserved target wording, anchored stems, terminal punctuation, one-sentence answers, and mixed direct-speech facets
- mark U7 complete in the punctuation legacy parity plan

## Verification
- node --test tests/punctuation-marking.test.js tests/punctuation-service.test.js
- node --test tests/punctuation-content.test.js tests/punctuation-combine.test.js tests/punctuation-paragraph.test.js
- node --test tests/punctuation-*.test.js tests/react-punctuation-*.test.js tests/subject-command-actions.test.js
- npm test
- npm run check
- git diff --check