### PR TITLE
Bound bootstrap history for CPU capacity

### DIFF
--- a/docs/plans/2026-04-25-001-fix-bootstrap-cpu-capacity-plan.md
+++ b/docs/plans/2026-04-25-001-fix-bootstrap-cpu-capacity-plan.md
@@ -1,0 +1,610 @@
+---
+title: "fix: Bound Bootstrap CPU and Capacity Surfaces"
+type: fix
+status: active
+date: 2026-04-25
+origin: docs/plans/james/cpuload/cpuload.md
+deepened: 2026-04-25
+---
+
+# fix: Bound Bootstrap CPU and Capacity Surfaces
+
+## Overview
+
+Turn the Cloudflare Worker / D1 capacity analysis in the origin document into a production hardening plan for KS2 Mastery. The immediate goal is to make `/api/bootstrap` and subject command responses bounded, measurable, and safe on the Workers Free CPU target. The longer-term goal is to support classroom-style concurrent learners through constant-size bootstrap payloads, lazy history reads, precomputed read models, and measured load certification.
+
+This plan treats the Free tier estimates as planning targets, not guarantees. The implementation must prove them with high-history fixtures, production bootstrap smoke checks, and classroom-shaped load tests before James uses them as capacity claims.
+
+---
+
+## Problem Frame
+
+The origin document identifies the real bottleneck as Worker CPU and D1 query work on high-history accounts, especially `/api/bootstrap` and command projection paths that read, parse, redact, normalise, and serialise historical `practice_sessions` and `event_log` data. The current repository confirms that `bootstrapBundle()` reads all practice sessions and all events for every writable learner in the bootstrap bundle, and `readLearnerProjectionBundle()` reads all learner events for command projection.
+
+The product need is simple: learners should be able to continue practising without losing progress or seeing 503s, even when a whole class opens or reloads the app. The engineering response is to make the hot paths small and predictable, not to rely on a paid plan to mask an unbounded architecture.
+
+---
+
+## Requirements Trace
+
+- R1. Reproduce and guard the high-history bootstrap failure mode with deterministic local fixtures and production-safe smoke checks.
+- R2. Make production `/api/bootstrap` constant-size with explicit caps for historical sessions, events, and response bytes.
+- R3. Preserve the existing authenticated Worker ownership, demo-expiry, mutation, idempotency, and public redaction boundaries.
+- R4. Move historical learner sessions and activity away from bootstrap into authorised, paginated, lazy-loaded routes.
+- R5. Introduce persistent learner read models and a public activity feed so normal reads do not rebuild UI state from full event history.
+- R6. Harden subject command projection so common commands do not scan full `event_log`, especially no-op, replay, preference, and answer-transition paths.
+- R7. Keep Spelling, Grammar, and Punctuation on the existing Worker subject command/read-model spine; do not reintroduce browser-owned production engines.
+- R8. Add request-level capacity telemetry for endpoint, wall time, response bytes, D1 rows read/written when available, bounded counts, and failure mode.
+- R9. Reduce client retry amplification: stale revision recovery, bootstrap fallback, and multi-tab behaviour must not turn one CPU failure into repeated full bootstraps.
+- R10. Certify classroom readiness with synthetic history, cold-bootstrap burst, and human-paced learner load tests before making capacity claims.
+- R11. Keep Cloudflare operations on the existing package-script deployment path and production audit posture.
+
+---
+
+## Scope Boundaries
+
+- Do not solve capacity by requiring Workers Paid as the only fix. Paid can be a rollout safety margin, but hot paths still need bounded work.
+- Do not add school/class D1 sharding in the first pass; measure single-database behaviour before splitting tenants.
+- Do not build a full analytics warehouse, reporting redesign, or teacher dashboard in this plan.
+- Do not move production subject scoring, queue selection, or reward mutation back into the browser.
+- Do not expose raw private spelling state, answer-bearing runtime fields, or full historical event payloads through public read models.
+- Do not replace the existing mutation receipt and `state_revision` compare-and-swap model.
+
+### Deferred to Follow-Up Work
+
+- Per-school, per-class, or per-account D1 sharding: decide only after single-database load testing shows D1 queue pressure.
+- Heavy analytics/offline reporting: add later through async read models or exports once hot-path read models are stable.
+- Formal SLO dashboards in an external observability tool: this plan should emit structured data and document thresholds; external dashboard build-out can follow.
+- Workers Paid migration: decide after bounded hot paths and measured Free-tier behaviour are known.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `AGENTS.md` requires Hong Kong Cantonese chat, UK English writing/code, package scripts for Cloudflare operations, and extra care around remote sync, learner state, D1, R2, and deployment paths.
+- `package.json` routes deploy/check/migration through OAuth-safe package scripts and contains `audit:production`, `smoke:production:punctuation`, and `verify` patterns.
+- `wrangler.jsonc` uses Worker assets, D1 `DB`, R2 `SPELLING_AUDIO_BUCKET`, `LEARNER_LOCK`, production vars, and enabled observability.
+- `worker/README.md` defines the production Worker as the authority for sessions, learner access, subject commands, read models, protected audio, Parent Hub, Admin / Operations, and mutation safety.
+- `worker/src/app.js` routes `GET /api/bootstrap`, subject commands, demo reset, hub reads, and production public read-model behaviour.
+- `worker/src/repository.js` currently builds bootstrap from all writable learner rows, all matching `practice_sessions`, all matching `event_log`, subject state, game state, and published monster visual config.
+- `worker/src/repository.js` also exposes `readLearnerProjectionBundle()`, which reads all learner game rows and all learner event rows before command projection.
+- `worker/src/subjects/spelling/commands.js` shows the current command pattern: read runtime, run engine, read projection state, project rewards, build read model, and persist runtime writes.
+- `worker/src/projections/events.js` dedupes against existing events, which is why replacing full-history scans needs an explicit recent-window or token strategy.
+- `worker/migrations/0002_saas_foundation.sql` and `worker/migrations/0006_operating_surfaces.sql` already define the generic tables and basic indexes for `practice_sessions` and `event_log`.
+- `tests/worker-backend.test.js`, `tests/worker-hubs.test.js`, `tests/worker-projections.test.js`, `tests/persistence.test.js`, and `tests/helpers/worker-server.js` are the right test surfaces for bootstrap, hub, command projection, client sync, and D1-backed Worker behaviour.
+- `scripts/production-bundle-audit.mjs` is the existing production-audit style to mirror for a high-history bootstrap probe.
+
+### Institutional Learnings
+
+- Prior ks2-mastery release-gate work used deterministic Node/HTTP checks when browser tooling was flaky; this plan should keep that posture for capacity validation.
+- Production bundle audit is already a strong repo-specific release gate, but it does not prove high-history bootstrap behaviour.
+- No `docs/solutions/` directory exists in this checkout, so institutional learnings come from current repo docs, tests, and recent ks2-mastery release-gate work.
+
+### External References
+
+- Cloudflare Workers limits currently document 100,000 requests/day on Free, 10 ms CPU per HTTP request on Free, no general requests-per-second limit, and Error 1102 for exceeded CPU.
+- Cloudflare D1 limits currently document that each D1 database is single-threaded and processes one query at a time; throughput depends on query duration.
+- Cloudflare D1 pricing currently documents 5 million rows read/day, 100,000 rows written/day, 5 GB storage on Free, and `meta.rows_read` / `meta.rows_written` as the usage tracking path.
+
+---
+
+## Key Technical Decisions
+
+- Bound production bootstrap first, then deepen read models: `/api/bootstrap` is the confirmed hot path and must stop growing with historical rows before the broader read-model migration lands.
+- Keep a compatibility envelope for the API repository bundle: production bootstrap can return bounded `practiceSessions` and `eventLog`, but it should still normalise through the existing repository bundle shape so the React shell does not require a simultaneous rewrite.
+- Move history behind explicit read routes: Parent Hub, activity history, and recent sessions should request their own paginated data instead of receiving it as an incidental bootstrap side effect.
+- Persist read models during existing learner-scoped mutations: updating `learner_read_models` and `learner_activity_feed` inside the same CAS-protected mutation batch keeps reads deterministic without adding a background worker dependency.
+- Replace full-event dedupe with bounded tokens: command projection should dedupe against current command output, request receipts, stored game state, or a small recent event window, not the learner's whole event history.
+- Treat capacity numbers as release evidence: Free-tier classroom estimates stay provisional until high-history fixtures, burst tests, and human-paced simulations prove the actual Worker/D1 profile.
+- Keep telemetry low-risk: log counts, timings, row metrics, caps, and route names; do not log answer-bearing payloads, full event JSON, private spelling prompts, or PII.
+
+---
+
+## Success Metrics
+
+- `/api/bootstrap` has no `outcome: exceededCpu`, Worker Error 1102, or bootstrap-specific 503 in high-history smoke checks.
+- Public production bootstrap returns a bounded payload: first target below 150 KB, later target 75-100 KB once history has moved to lazy routes.
+- Free-tier target: bootstrap P95 Worker CPU remains below 10 ms and subject-command P95 Worker CPU remains below 5 ms in measured high-history and classroom-shaped runs.
+- Learner-facing submit-to-feedback remains reliable under human-paced load: P95 wall time target below 250-400 ms, depending on subject and remote conditions.
+- D1 rows read/write, query duration, and response bytes are visible per capacity run so bottlenecks can be attributed to bootstrap, commands, hubs, TTS, or admin surfaces.
+- Reliability target for capacity certification: 5xx below 0.1%, zero lost progress, stale revision recovery bounded, and no retry storm against `/api/bootstrap`.
+- Product capacity claims stay tied to measured tiers: small pilot, 30-learner classroom beta, 60-learner stretch, and 100+ active learner school-ready target only after corresponding load evidence exists.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Is this a planning task or a debug task? The origin has a known architectural failure mode and concrete desired direction, so this can be planned without further root-cause investigation.
+- Should external docs be refreshed? Yes. Cloudflare limits/pricing are operationally unstable enough to verify against official docs during planning.
+- Should this be a lightweight hotfix only? No. The immediate fix is bounded bootstrap, but command projection, read models, client retry pressure, and load certification are linked production surfaces.
+
+### Deferred to Implementation
+
+- Exact bootstrap caps: choose final per-learner `practiceSessions`, `eventLog`, and response-byte thresholds after the first high-history fixture shows current payload shape.
+- Exact read-model keys: finalise names while implementing the migration, but keep the categories aligned to dashboard summary, parent summary, subject summary, and activity feed.
+- D1 meta availability in local tests: production D1 exposes row metrics, while the local SQLite D1 helper currently returns limited meta; implementers may need a test-only instrumentation layer.
+- Production high-history account identifier: the probe script should support a configured account/learner selector without hard-coding private identifiers.
+- Backfill batch sizing: choose chunk size after checking real D1 SQL duration and write counts on a backup or preview copy.
+- Load-test driver choice: a Node script is likely enough for repo-local repeatability; k6 or autocannon can be adopted if they add clear value.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+  Browser[React shell]
+  Bootstrap[/GET /api/bootstrap/]
+  History[/Lazy history APIs/]
+  Command[/POST /api/subjects/:subjectId/command/]
+  Repo[Worker repository]
+  D1[(D1 generic stores)]
+  ReadModels[(learner_read_models)]
+  Activity[(learner_activity_feed)]
+  Metrics[capacity telemetry]
+
+  Browser --> Bootstrap
+  Browser --> History
+  Browser --> Command
+  Bootstrap --> Repo
+  History --> Repo
+  Command --> Repo
+  Repo --> D1
+  Repo --> ReadModels
+  Repo --> Activity
+  Repo --> Metrics
+```
+
+Bootstrap should read only account/session metadata, writable learner identities, selected/current subject state, active or recent bounded sessions, bounded public event/activity rows, published monster config, and revision metadata. Historical timelines move to lazy routes. Commands continue to persist through generic D1 tables but update read models and activity-feed rows as part of the same mutation result.
+
+---
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+  U1[U1 capacity harness]
+  U2[U2 bounded bootstrap]
+  U3[U3 lazy history APIs]
+  U4[U4 read-model schema]
+  U5[U5 command projection hardening]
+  U6[U6 client recovery pressure]
+  U7[U7 load certification]
+
+  U1 --> U2
+  U2 --> U3
+  U2 --> U4
+  U4 --> U5
+  U3 --> U6
+  U5 --> U6
+  U6 --> U7
+```
+
+- U1. **Capacity Harness and High-History Gate**
+
+**Goal:** Add deterministic fixtures and smoke tooling that prove whether high-history bootstrap and command projection are bounded.
+
+**Requirements:** R1, R8, R10, R11
+
+**Dependencies:** None
+
+**Files:**
+- Create: `tests/worker-bootstrap-capacity.test.js`
+- Create: `scripts/probe-production-bootstrap.mjs`
+- Modify: `tests/helpers/worker-server.js`
+- Modify: `tests/helpers/sqlite-d1.js`
+- Modify: `package.json`
+
+**Approach:**
+- Build a reusable high-history fixture with multiple learners, hundreds of practice sessions, and hundreds to thousands of events.
+- Assert public production bootstrap returns bounded counts, preserves selected learner/revision metadata, and keeps private spelling runtime fields redacted.
+- Extend the local D1 helper only as far as needed to expose test-visible row/query counts or query observations; do not pretend local SQLite meta is identical to production D1.
+- Add a production bootstrap probe that can authenticate with an existing session/cookie or configured request headers and report status, response bytes, bounded counts, and redaction checks.
+
+**Execution note:** Start characterization-first. Let the high-history fixture describe the current failure shape before changing repository behaviour.
+
+**Patterns to follow:**
+- `tests/worker-backend.test.js`
+- `tests/helpers/worker-server.js`
+- `scripts/production-bundle-audit.mjs`
+- `scripts/punctuation-production-smoke.mjs`
+
+**Test scenarios:**
+- Happy path: production-mode public bootstrap for a high-history account returns `200`, selected learner metadata, sync revisions, and a bounded payload.
+- Edge case: an account with multiple writable learners keeps learner selection stable while applying the same history caps per learner or per account.
+- Error path: unauthenticated production bootstrap still fails through the existing auth/session boundary, not through the new probe or capacity code.
+- Integration: the production probe rejects a payload that includes unredacted spelling prompt text, full session state, or uncapped historical event arrays.
+- Integration: local high-history fixture reports the same bounded-count fields that the production probe expects.
+
+**Verification:**
+- High-history bootstrap capacity tests fail on an uncapped implementation and pass once bootstrap is bounded.
+- The production probe produces a clear pass/fail summary without exposing private learner data.
+
+---
+
+- U2. **Bound Production Bootstrap**
+
+**Goal:** Make `/api/bootstrap` safe and constant-size for production public read-model mode.
+
+**Requirements:** R2, R3, R7, R8
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `worker/src/app.js`
+- Modify: `worker/src/repository.js`
+- Modify: `worker/src/http.js`
+- Modify: `worker/src/d1.js`
+- Test: `tests/worker-bootstrap-capacity.test.js`
+- Test: `tests/worker-backend.test.js`
+- Test: `tests/worker-access.test.js`
+- Test: `tests/worker-monster-visual-config.test.js`
+
+**Approach:**
+- Keep `shouldUsePublicReadModels()` as the production switch, but route public bootstrap through bounded query logic.
+- Limit `practice_sessions` to the active session plus a small recent window needed by the first usable screen.
+- Limit `event_log` to a small public recent window or remove it from bootstrap once lazy history routes exist, while preserving enough command/reward state for the shell to render.
+- Preserve `subjectStates`, `gameState`, `syncState`, `monsterVisualConfig`, account/session metadata, subject exposure gates, and public spelling redaction.
+- Return explicit bounded-count metadata for tests and probes, such as sessions returned, events returned, and whether caps were applied.
+- Keep non-production development/test full bundle behaviour only where it is still needed for compatibility, and make sure production never depends on it.
+
+**Patterns to follow:**
+- `bootstrapBundle()` in `worker/src/repository.js`
+- `publicSubjectStateRowToRecord()` and public spelling redaction helpers in `worker/src/repository.js`
+- `tests/worker-backend.test.js` redaction coverage
+- `tests/worker-access.test.js` account-scoping coverage
+
+**Test scenarios:**
+- Happy path: production-mode public bootstrap returns selected learner, current subject UI, revision metadata, and published monster visual config.
+- Happy path: an active practice session is still available after caps are applied.
+- Edge case: high-history accounts with 20 sessions and with 300 sessions produce payloads within the same bounded count envelope.
+- Edge case: learners with no sessions/events still receive an empty but valid bundle.
+- Error path: stale or missing monster visual config still falls back through the existing bootstrap fallback path.
+- Integration: public bootstrap redacts spelling progress/private prompt fields and nulls answer-bearing `sessionState` exactly as existing redaction tests require.
+- Integration: account A cannot see account B learner rows after bounded `IN (...)` query refactoring.
+
+**Verification:**
+- `/api/bootstrap` no longer reads or serialises all historical `practice_sessions` or `event_log` rows in production public read-model mode.
+- Existing bootstrap, access, and monster visual config behaviours remain compatible.
+
+---
+
+- U3. **Lazy Learner History APIs**
+
+**Goal:** Provide authorised, paginated routes for recent sessions and learner activity so history can leave bootstrap without removing user-visible history.
+
+**Requirements:** R3, R4, R7, R9
+
+**Dependencies:** U2
+
+**Files:**
+- Modify: `worker/src/app.js`
+- Modify: `worker/src/repository.js`
+- Modify: `src/platform/core/repositories/api.js`
+- Modify: `src/platform/hubs/api.js`
+- Modify: `src/surfaces/hubs/ParentHubSurface.jsx`
+- Test: `tests/worker-history-api.test.js`
+- Test: `tests/hub-api.test.js`
+- Test: `tests/worker-hubs.test.js`
+
+**Approach:**
+- Add learner-scoped read routes for recent sessions and public activity with `limit` and cursor semantics.
+- Reuse existing membership checks so `owner`, `member`, `viewer`, demo, parent, admin, and ops access stays consistent with current hub rules.
+- Return public/redacted records only; answer-bearing session state and private event JSON must not become visible through the new routes.
+- Update Parent Hub and any shell surfaces that need history to call lazy APIs instead of expecting bootstrap to carry the full timeline.
+- Keep the first learner practice screen independent from these routes so a lazy history failure does not block practice.
+
+**Patterns to follow:**
+- `readParentHub()` / `readAdminHub()` in `worker/src/repository.js`
+- `src/platform/hubs/api.js`
+- `tests/worker-hubs.test.js`
+- `tests/hub-api.test.js`
+
+**Test scenarios:**
+- Happy path: a parent with readable membership receives the first page of recent completed sessions ordered newest first.
+- Happy path: the second page uses the cursor and does not duplicate records from the first page.
+- Edge case: a learner with no historical rows returns an empty page and no error.
+- Error path: a parent without readable membership receives the existing access-denied shape.
+- Error path: expired demo access fails closed before returning learner history.
+- Integration: Parent Hub renders from lazy recent sessions while bootstrap remains bounded.
+- Integration: public activity records do not include private spelling prompt text or answer-bearing engine fields.
+
+**Verification:**
+- Historical UI surfaces can still show recent activity without `/api/bootstrap` returning full history.
+
+---
+
+- U4. **Persistent Read-Model and Activity Feed Stores**
+
+**Goal:** Add the storage foundation for small, fixed-row read models and public activity feed rows.
+
+**Requirements:** R4, R5, R8, R11
+
+**Dependencies:** U2
+
+**Files:**
+- Create: `worker/migrations/0009_capacity_read_models.sql`
+- Create: `worker/src/read-models/learner-read-models.js`
+- Create: `scripts/backfill-learner-read-models.mjs`
+- Modify: `worker/src/repository.js`
+- Modify: `package.json`
+- Test: `tests/worker-read-model-capacity.test.js`
+- Test: `tests/read-model-backfill.test.js`
+- Test: `tests/helpers/sqlite-d1.js`
+
+**Approach:**
+- Add `learner_read_models` keyed by learner and model key for small JSON summaries.
+- Add `learner_activity_feed` keyed by event/activity id, learner, subject, public event type, created time, and redacted public JSON.
+- Index the read paths used by bootstrap, Parent Hub, activity pages, and subject summaries.
+- Keep schema generic and subject-neutral; Spelling, Grammar, and Punctuation should share the store rather than creating subject-specific side tables.
+- Store only public or summary-safe JSON in activity feed rows.
+- Add a resumable backfill script that reads existing generic rows in small learner-scoped batches, writes read-model/activity rows idempotently, and reports rows read/written plus remaining learners.
+- Keep schema migration and data backfill separate: the migration creates empty tables safely; backfill is an explicit operational step after backup/preview verification.
+
+**Patterns to follow:**
+- Generic platform tables in `worker/migrations/0002_saas_foundation.sql`
+- Operating-surface indexes in `worker/migrations/0006_operating_surfaces.sql`
+- Repository normalisation helpers in `worker/src/repository.js`
+
+**Test scenarios:**
+- Happy path: migrations create read-model and activity-feed tables with the expected unique constraints and indexes.
+- Happy path: repository helpers can upsert and read a learner summary by model key.
+- Edge case: missing read-model rows return safe empty summaries, not bootstrap failures.
+- Error path: malformed stored JSON is ignored or normalised without leaking raw storage errors to users.
+- Error path: an interrupted backfill can be rerun without duplicating activity rows or corrupting existing summaries.
+- Integration: activity-feed rows are queryable by learner and cursor order without scanning full `event_log`.
+- Integration: high-history fixture backfill produces summary/read rows that bounded bootstrap and lazy history APIs can consume without full event replay.
+
+**Verification:**
+- The schema and backfill path support bounded reads for existing and future learners before command writers start depending on the new tables.
+
+---
+
+- U5. **Incremental Read Models and Command Projection Hardening**
+
+**Goal:** Update read models during writes and remove full-event scans from common subject command projection.
+
+**Requirements:** R5, R6, R7, R8
+
+**Dependencies:** U4
+
+**Files:**
+- Modify: `worker/src/repository.js`
+- Modify: `worker/src/subjects/spelling/commands.js`
+- Modify: `worker/src/subjects/grammar/commands.js`
+- Modify: `worker/src/subjects/punctuation/commands.js`
+- Modify: `worker/src/projections/events.js`
+- Modify: `worker/src/projections/read-models.js`
+- Modify: `worker/src/projections/rewards.js`
+- Test: `tests/worker-projections.test.js`
+- Test: `tests/server-spelling-engine-parity.test.js`
+- Test: `tests/worker-grammar-subject-runtime.test.js`
+- Test: `tests/worker-punctuation-runtime.test.js`
+- Test: `tests/worker-read-model-capacity.test.js`
+
+**Approach:**
+- Extend the existing runtime persistence plan so command writes can also upsert read-model summaries and append public activity-feed rows in the same guarded mutation batch.
+- Replace `readLearnerProjectionBundle()` full event history reads with a smaller projection input: current game state, relevant read-model summary, and a bounded recent event/token window when dedupe needs historical context.
+- Treat no-op or observational commands, such as word-bank drill checks or commands with `changed: false`, as non-mutating responses that do not load or write historical projection state.
+- Keep reward projection semantics unchanged for Spelling, Grammar, and Punctuation; the change is where historical context comes from, not what rewards mean.
+- Preserve request-receipt replay semantics so duplicate retries do not append duplicate events or rewards.
+
+**Patterns to follow:**
+- `runSubjectCommandMutation()` and `buildSubjectRuntimePersistencePlan()` in `worker/src/repository.js`
+- `worker/src/projections/events.js`
+- `tests/worker-projections.test.js`
+- Subject runtime tests for Spelling, Grammar, and Punctuation
+
+**Test scenarios:**
+- Happy path: securing a spelling word still writes subject state, practice session, event rows, game state, projection read model, and activity feed atomically.
+- Happy path: Grammar and Punctuation command responses preserve their current read-model/reward behaviour.
+- Edge case: a no-op command returns a valid read model without loading full learner event history or incrementing learner revision.
+- Edge case: replaying the same request id returns the stored response and does not create duplicate activity or reward rows.
+- Error path: stale learner revision still returns `409 stale_write` and does not partially update read models.
+- Integration: command projection passes with a high-history learner whose `event_log` contains many unrelated rows.
+- Integration: D1 guarded mutation failure leaves subject state, read models, activity feed, and revision unchanged.
+
+**Verification:**
+- Common commands no longer require full `event_log` reads for projection or dedupe.
+- Existing subject parity and reward tests remain green with incremental read-model writes enabled.
+
+---
+
+- U6. **Client Sync and Retry Pressure Reduction**
+
+**Goal:** Ensure browser recovery behaviour does not amplify CPU pressure through repeated full bootstraps.
+
+**Requirements:** R3, R7, R9
+
+**Dependencies:** U3, U5
+
+**Files:**
+- Modify: `src/platform/core/repositories/api.js`
+- Modify: `src/platform/runtime/subject-command-client.js`
+- Modify: `src/platform/app/bootstrap.js`
+- Test: `tests/persistence.test.js`
+- Test: `tests/spelling-remote-actions.test.js`
+- Test: `tests/hub-api.test.js`
+
+**Approach:**
+- Keep cached bootstrap fallback for unavailable bootstrap responses, but distinguish CPU/503 failure from ordinary offline recovery so the client backs off instead of hammering full bootstrap.
+- Route stale command recovery to the smallest available refresh path once lazy history/read-model endpoints exist; full bootstrap remains the last resort.
+- Add jittered retry/backoff around retryable bootstrap and command failures.
+- Coordinate tabs through a small browser-local mechanism such as `BroadcastChannel` where supported, with a safe fallback when unavailable.
+- Preserve optimistic UI and pending-operation visibility; the user should not lose answers or see false success.
+
+**Patterns to follow:**
+- `hydrateRemoteState()` and `rebasePendingFromRemote()` in `src/platform/core/repositories/api.js`
+- Existing degraded persistence tests in `tests/persistence.test.js`
+- Subject command client tests in `tests/spelling-remote-actions.test.js`
+
+**Test scenarios:**
+- Happy path: one successful bootstrap hydrates cache and subsequent subject commands apply command read models without full rehydrate.
+- Edge case: two tabs hydrating at the same time coordinate or back off so they do not both repeatedly call `/api/bootstrap`.
+- Error path: bootstrap `503` with a usable cache surfaces degraded state and schedules bounded retry/backoff.
+- Error path: stale command recovery tries a minimal state refresh before falling back to full bootstrap.
+- Integration: pending writes remain visible and are not dropped during backoff or tab coordination.
+- Integration: lazy Parent Hub/history failures do not block learner practice.
+
+**Verification:**
+- The client cannot create a retry storm against `/api/bootstrap` under deterministic 503 or stale-revision scenarios.
+
+---
+
+- U7. **Classroom Load Certification and Operational Runbook**
+
+**Goal:** Produce measured capacity evidence and operational guidance for Free-tier pilot, classroom beta, and later school-ready targets.
+
+**Requirements:** R8, R10, R11
+
+**Dependencies:** U1, U2, U5, U6
+
+**Files:**
+- Create: `scripts/classroom-load-test.mjs`
+- Create: `docs/operations/capacity.md`
+- Modify: `package.json`
+- Test: `tests/capacity-scripts.test.js`
+
+**Approach:**
+- Add a repeatable load driver that can run synthetic history setup, cold-bootstrap burst tests, and human-paced learner simulations with distinct learners, request ids, sessions, and revisions.
+- Report endpoint wall time, status distribution, response bytes, bounded counts, D1 row metrics where available, retries, stale conflicts, and 5xx outcomes.
+- Document launch caps as measured results, not theory: family demo, small pilot, classroom beta, and school-ready criteria.
+- Include rollback/degrade guidance for `exceededCpu`, bootstrap 503, D1 overloaded, and D1 Free daily limit errors.
+- Keep production verification aligned with package scripts and the logged-in browser-session rule when user-facing flows change.
+
+**Patterns to follow:**
+- `scripts/production-bundle-audit.mjs`
+- `scripts/punctuation-production-smoke.mjs`
+- `docs/mutation-policy.md`
+- `worker/README.md`
+
+**Test scenarios:**
+- Happy path: script dry-run validates configuration and reports planned scenarios without touching production.
+- Happy path: local fixture mode creates distinct learners and request ids so conflict/idempotency paths are exercised.
+- Edge case: script refuses to run production load without explicit origin and authentication configuration.
+- Error path: failed requests are grouped by endpoint/status and do not hide `exceededCpu`, D1 overloaded, or auth failures.
+- Integration: capacity report includes enough evidence to decide whether 30, 60, or 100 active learner targets are supportable.
+
+**Verification:**
+- James can point to a measured capacity table and operational runbook rather than an estimate-only answer.
+
+---
+
+## System-Wide Impact
+
+```mermaid
+flowchart TB
+  Auth[Auth/session]
+  Bootstrap[Bootstrap]
+  Commands[Subject commands]
+  D1[D1 tables]
+  Hubs[Parent/Admin hubs]
+  Client[Client sync cache]
+  Ops[Smoke/load tools]
+
+  Auth --> Bootstrap
+  Auth --> Commands
+  Auth --> Hubs
+  Bootstrap --> D1
+  Commands --> D1
+  Commands --> Bootstrap
+  Hubs --> D1
+  Client --> Bootstrap
+  Client --> Commands
+  Ops --> Bootstrap
+  Ops --> Commands
+```
+
+- **Interaction graph:** Auth/session, bootstrap, subject commands, D1 persistence, read models, hub routes, client cache, and production probes all interact.
+- **Error propagation:** Bootstrap 503 and D1 overload must become explicit probe/load-test failures and bounded client degraded states, not invisible retries.
+- **State lifecycle risks:** Read-model updates must share the existing CAS/idempotency boundary so subject state, activity, rewards, and revision cannot diverge.
+- **API surface parity:** Spelling, Grammar, and Punctuation should keep the same subject command/read-model contract; only projection internals and read inputs should change.
+- **Integration coverage:** Unit tests alone will not prove classroom readiness; high-history fixtures, production smoke, and load tests are required.
+- **Unchanged invariants:** Production scoring stays Worker-owned, public bootstrap stays redacted, demo sessions fail closed when expired, and Cloudflare operations use package scripts.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Bootstrap caps remove data the React shell still assumes is present | Medium | High | Add high-history bootstrap tests plus UI/hub tests before removing historical rows; move consumers to lazy APIs first when needed. |
+| Read-model writes create partial-state bugs | Medium | High | Write read models inside existing guarded mutation batches and test stale-write rollback. |
+| Projection dedupe changes reward semantics | Medium | High | Keep reward projection parity tests and replay/idempotency tests around secured-word and reward rows. |
+| Local SQLite helper cannot model production D1 row metrics exactly | High | Medium | Treat local meta as instrumentation for shape, not truth; production probe and load scripts collect real D1/Worker evidence. |
+| New indexes reduce reads but increase Free-tier writes | Medium | Medium | Measure rows written and document the trade-off; add only indexes that serve hot-path queries. |
+| Client backoff hides real sync failures | Low | High | Preserve degraded persistence UI and pending-operation state; never mark failed writes as synced. |
+| Capacity claims overrun evidence | Medium | High | Keep launch caps in `docs/operations/capacity.md` tied to measured runs and dates. |
+
+---
+
+## Alternative Approaches Considered
+
+- Upgrade Workers Paid first: useful as a safety margin, but rejected as the primary fix because unbounded bootstrap/history work would still hurt latency, D1 queueing, and product trust.
+- Shard D1 by class immediately: deferred because current evidence points first to unbounded reads/serialisation; sharding should follow measured D1 queue pressure.
+- Build async analytics first: deferred because learner practice and bootstrap reliability are the urgent production surfaces.
+- Remove all history from the product temporarily: rejected because Parent Hub and recovery workflows still need history; paginated/lazy reads preserve UX without loading everything at startup.
+
+---
+
+## Phased Delivery
+
+### Phase 1: Stop the Known Hot Path
+
+- U1 Capacity Harness and High-History Gate
+- U2 Bound Production Bootstrap
+
+Exit criterion: high-history production bootstrap is bounded, redacted, and has no known `exceededCpu` path from full historical payload reconstruction.
+
+### Phase 2: Remove History From Startup
+
+- U3 Lazy Learner History APIs
+- U4 Persistent Read-Model and Activity Feed Stores
+
+Exit criterion: bootstrap no longer grows with `event_log` or completed-session history, and history views have explicit authorised routes.
+
+### Phase 3: Harden Writes and Recovery
+
+- U5 Incremental Read Models and Command Projection Hardening
+- U6 Client Sync and Retry Pressure Reduction
+
+Exit criterion: common commands do not scan full learner history, stale/retry paths do not full-bootstrap unless unavoidable, and no-progress-loss behaviours remain intact.
+
+### Phase 4: Certify Capacity
+
+- U7 Classroom Load Certification and Operational Runbook
+
+Exit criterion: capacity guidance is backed by measured synthetic history, cold-bootstrap burst, and human-paced learner runs.
+
+---
+
+## Documentation / Operational Notes
+
+- Update `docs/operations/capacity.md` with measured capacity tiers, thresholds, run dates, and what plan/version was tested.
+- Keep deployment and migration instructions aligned with package scripts: `npm run check`, `npm run db:migrate:remote`, and `npm run deploy` are the normal Cloudflare path.
+- Production UI verification is required after deployment because this changes user-facing bootstrap, history, and recovery flows.
+- Alert thresholds should include any `exceededCpu`, `/api/bootstrap` 503, D1 overloaded errors, high bootstrap response bytes, and D1 Free daily-limit approach.
+- Rollout should prefer bounded bootstrap first, then lazy endpoints/read models, then projection hardening, then capacity claims.
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/plans/james/cpuload/cpuload.md](docs/plans/james/cpuload/cpuload.md)
+- Related code: [worker/src/app.js](worker/src/app.js)
+- Related code: [worker/src/repository.js](worker/src/repository.js)
+- Related code: [worker/src/subjects/spelling/commands.js](worker/src/subjects/spelling/commands.js)
+- Related code: [src/platform/core/repositories/api.js](src/platform/core/repositories/api.js)
+- Related tests: [tests/worker-backend.test.js](tests/worker-backend.test.js)
+- Related tests: [tests/worker-projections.test.js](tests/worker-projections.test.js)
+- Related tests: [tests/persistence.test.js](tests/persistence.test.js)
+- Cloudflare Workers limits: [https://developers.cloudflare.com/workers/platform/limits/](https://developers.cloudflare.com/workers/platform/limits/)
+- Cloudflare Workers pricing: [https://developers.cloudflare.com/workers/platform/pricing/](https://developers.cloudflare.com/workers/platform/pricing/)
+- Cloudflare D1 limits: [https://developers.cloudflare.com/d1/platform/limits/](https://developers.cloudflare.com/d1/platform/limits/)
+- Cloudflare D1 pricing: [https://developers.cloudflare.com/d1/platform/pricing/](https://developers.cloudflare.com/d1/platform/pricing/)

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "deploy:oauth": "npm run deploy",
     "deploy:ci": "npm run deploy",
     "ops:tail": "node ./scripts/wrangler-oauth.mjs tail ks2-mastery --format pretty",
+    "smoke:production:bootstrap": "node ./scripts/probe-production-bootstrap.mjs",
     "smoke:production:grammar": "node ./scripts/grammar-production-smoke.mjs",
     "smoke:production:punctuation": "node ./scripts/punctuation-production-smoke.mjs",
     "test": "node --test",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "deploy:oauth": "npm run deploy",
     "deploy:ci": "npm run deploy",
     "ops:tail": "node ./scripts/wrangler-oauth.mjs tail ks2-mastery --format pretty",
+    "read-models:backfill": "node ./scripts/backfill-learner-read-models.mjs",
     "smoke:production:bootstrap": "node ./scripts/probe-production-bootstrap.mjs",
     "smoke:production:grammar": "node ./scripts/grammar-production-smoke.mjs",
     "smoke:production:punctuation": "node ./scripts/punctuation-production-smoke.mjs",

--- a/scripts/backfill-learner-read-models.mjs
+++ b/scripts/backfill-learner-read-models.mjs
@@ -1,0 +1,261 @@
+import { existsSync } from 'node:fs';
+import { DatabaseSync } from 'node:sqlite';
+import { pathToFileURL } from 'node:url';
+
+import { all, first, run } from '../worker/src/d1.js';
+import {
+  LEARNER_SUMMARY_MODEL_KEY,
+  activityFeedRowFromEventRow,
+} from '../worker/src/read-models/learner-read-models.js';
+
+const DEFAULT_BATCH_SIZE = 25;
+
+class SqliteStatement {
+  constructor(statement) {
+    this.statement = statement;
+    this.params = [];
+  }
+
+  bind(...params) {
+    this.params = params;
+    return this;
+  }
+
+  async first() {
+    const row = this.statement.get(...this.params);
+    return row ? { ...row } : null;
+  }
+
+  async all() {
+    return {
+      results: this.statement.all(...this.params).map((row) => ({ ...row })),
+    };
+  }
+
+  async run() {
+    const meta = this.statement.run(...this.params);
+    return {
+      success: true,
+      meta: {
+        changes: meta.changes,
+        rows_read: 0,
+        rows_written: Math.max(0, Number(meta.changes) || 0),
+      },
+    };
+  }
+}
+
+class SqliteD1 {
+  constructor(filename) {
+    this.db = new DatabaseSync(filename);
+    this.db.exec('PRAGMA foreign_keys = ON;');
+  }
+
+  prepare(sql) {
+    return new SqliteStatement(this.db.prepare(sql));
+  }
+
+  close() {
+    this.db.close();
+  }
+}
+
+function argValue(argv, name, fallback = '') {
+  const index = argv.indexOf(name);
+  if (index === -1 || index + 1 >= argv.length) return fallback;
+  return argv[index + 1];
+}
+
+function positiveInteger(value, fallback) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+async function upsertReadModel(db, learnerId, model, nowTs) {
+  await run(db, `
+    INSERT INTO learner_read_models (learner_id, model_key, model_json, source_revision, generated_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?)
+    ON CONFLICT(learner_id, model_key) DO UPDATE SET
+      model_json = excluded.model_json,
+      source_revision = excluded.source_revision,
+      generated_at = excluded.generated_at,
+      updated_at = excluded.updated_at
+  `, [
+    learnerId,
+    LEARNER_SUMMARY_MODEL_KEY,
+    JSON.stringify(model),
+    Math.max(0, Number(model.sourceRevision) || 0),
+    nowTs,
+    nowTs,
+  ]);
+}
+
+async function upsertActivityRows(db, activityRows) {
+  let written = 0;
+  for (const row of activityRows) {
+    const result = await run(db, `
+      INSERT INTO learner_activity_feed (
+        id, learner_id, subject_id, activity_type, activity_json,
+        source_event_id, created_at, updated_at
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(id) DO UPDATE SET
+        learner_id = excluded.learner_id,
+        subject_id = excluded.subject_id,
+        activity_type = excluded.activity_type,
+        activity_json = excluded.activity_json,
+        source_event_id = excluded.source_event_id,
+        created_at = excluded.created_at,
+        updated_at = excluded.updated_at
+    `, [
+      row.id,
+      row.learnerId,
+      row.subjectId || null,
+      row.activityType,
+      JSON.stringify(row.activity),
+      row.sourceEventId || null,
+      Math.max(0, Number(row.createdAt) || 0),
+      Math.max(0, Number(row.updatedAt) || 0),
+    ]);
+    written += Math.max(0, Number(result?.meta?.rows_written ?? result?.meta?.changes) || 0);
+  }
+  return written;
+}
+
+async function learnerRows(db, { learnerId = null, afterLearnerId = '', batchSize = DEFAULT_BATCH_SIZE } = {}) {
+  if (learnerId) {
+    return all(db, `
+      SELECT id, state_revision
+      FROM learner_profiles
+      WHERE id = ?
+      ORDER BY id ASC
+    `, [learnerId]);
+  }
+  return all(db, `
+    SELECT id, state_revision
+    FROM learner_profiles
+    WHERE id > ?
+    ORDER BY id ASC
+    LIMIT ?
+  `, [afterLearnerId, batchSize]);
+}
+
+async function countRows(db, sql, params = []) {
+  const row = await first(db, sql, params);
+  return Math.max(0, Number(row?.count) || 0);
+}
+
+async function buildLearnerSummary(db, learner, nowTs) {
+  const learnerId = learner.id;
+  const [subjectStateCount, practiceSessionCount, eventCount, activityCount] = await Promise.all([
+    countRows(db, 'SELECT COUNT(*) AS count FROM child_subject_state WHERE learner_id = ?', [learnerId]),
+    countRows(db, 'SELECT COUNT(*) AS count FROM practice_sessions WHERE learner_id = ?', [learnerId]),
+    countRows(db, 'SELECT COUNT(*) AS count FROM event_log WHERE learner_id = ?', [learnerId]),
+    countRows(db, 'SELECT COUNT(*) AS count FROM learner_activity_feed WHERE learner_id = ?', [learnerId]),
+  ]);
+  return {
+    version: 1,
+    learnerId,
+    generatedAt: nowTs,
+    sourceRevision: Math.max(0, Number(learner.state_revision) || 0),
+    counts: {
+      subjectStates: subjectStateCount,
+      practiceSessions: practiceSessionCount,
+      events: eventCount,
+      publicActivity: activityCount,
+    },
+  };
+}
+
+export async function backfillLearnerReadModels(db, {
+  batchSize = DEFAULT_BATCH_SIZE,
+  learnerId = null,
+  afterLearnerId = '',
+  now = Date.now,
+} = {}) {
+  const resolvedBatchSize = positiveInteger(batchSize, DEFAULT_BATCH_SIZE);
+  const nowTs = Number(typeof now === 'function' ? now() : now) || Date.now();
+  const learners = await learnerRows(db, { learnerId, afterLearnerId, batchSize: resolvedBatchSize });
+  const summary = {
+    processedLearners: 0,
+    readModelsWritten: 0,
+    activityRowsConsidered: 0,
+    activityRowsWritten: 0,
+    lastLearnerId: afterLearnerId || '',
+    remainingLearners: 0,
+  };
+
+  for (const learner of learners) {
+    const events = await all(db, `
+      SELECT id, learner_id, subject_id, system_id, event_type, event_json, created_at
+      FROM event_log
+      WHERE learner_id = ?
+      ORDER BY created_at ASC, id ASC
+    `, [learner.id]);
+    const activityRows = events
+      .map((row) => activityFeedRowFromEventRow(row, { now: nowTs }))
+      .filter(Boolean);
+    summary.activityRowsConsidered += events.length;
+    summary.activityRowsWritten += await upsertActivityRows(db, activityRows);
+
+    const model = await buildLearnerSummary(db, learner, nowTs);
+    await upsertReadModel(db, learner.id, model, nowTs);
+    summary.readModelsWritten += 1;
+    summary.processedLearners += 1;
+    summary.lastLearnerId = learner.id;
+  }
+
+  if (!learnerId) {
+    summary.remainingLearners = await countRows(db, `
+      SELECT COUNT(*) AS count
+      FROM learner_profiles
+      WHERE id > ?
+    `, [summary.lastLearnerId]);
+  }
+
+  return summary;
+}
+
+export function usage() {
+  return [
+    'Usage: node ./scripts/backfill-learner-read-models.mjs --sqlite <path> [options]',
+    '',
+    'Options:',
+    '  --sqlite <path>       SQLite database file to backfill, usually a verified local/preview copy',
+    '  --learner-id <id>     Backfill one learner',
+    '  --after-learner-id <id> Resume after a learner id',
+    '  --batch-size <n>      Learners per run, default 25',
+  ].join('\n');
+}
+
+async function runCli(argv = process.argv.slice(2)) {
+  if (argv.includes('--help') || argv.includes('-h') || !argv.includes('--sqlite')) {
+    console.log(usage());
+    return 0;
+  }
+  const sqlitePath = argValue(argv, '--sqlite');
+  if (!sqlitePath || !existsSync(sqlitePath)) {
+    throw new Error(`SQLite database file was not found: ${sqlitePath}`);
+  }
+  const db = new SqliteD1(sqlitePath);
+  try {
+    const result = await backfillLearnerReadModels(db, {
+      batchSize: positiveInteger(argValue(argv, '--batch-size'), DEFAULT_BATCH_SIZE),
+      learnerId: argValue(argv, '--learner-id', null),
+      afterLearnerId: argValue(argv, '--after-learner-id', ''),
+    });
+    console.log(JSON.stringify({ ok: true, ...result }, null, 2));
+    return 0;
+  } finally {
+    db.close();
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runCli().then((code) => {
+    process.exitCode = code;
+  }).catch((error) => {
+    console.error(JSON.stringify({ ok: false, error: error.message }, null, 2));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/probe-production-bootstrap.mjs
+++ b/scripts/probe-production-bootstrap.mjs
@@ -1,0 +1,302 @@
+import { Buffer } from 'node:buffer';
+import { pathToFileURL } from 'node:url';
+
+const DEFAULT_URL = 'https://ks2.eugnel.uk';
+const DEFAULT_MAX_BYTES = 600_000;
+
+function readOptionValue(argv, index, optionName) {
+  const value = argv[index + 1];
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${optionName} requires a value.`);
+  }
+  return value;
+}
+
+function toPositiveInteger(value, optionName) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${optionName} must be a non-negative integer.`);
+  }
+  return parsed;
+}
+
+function normaliseBaseUrl(value) {
+  const url = new URL(value || DEFAULT_URL);
+  url.pathname = url.pathname.replace(/\/+$/, '');
+  url.search = '';
+  url.hash = '';
+  return url.toString().replace(/\/$/, '');
+}
+
+export function parseProbeArgs(argv = process.argv.slice(2)) {
+  const options = {
+    url: DEFAULT_URL,
+    cookie: '',
+    bearer: '',
+    headers: [],
+    maxBytes: DEFAULT_MAX_BYTES,
+    maxSessions: null,
+    maxEvents: null,
+    forbiddenTokens: [],
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+    } else if (arg === '--url') {
+      options.url = readOptionValue(argv, index, arg);
+      index += 1;
+    } else if (arg === '--cookie') {
+      options.cookie = readOptionValue(argv, index, arg);
+      index += 1;
+    } else if (arg === '--bearer') {
+      options.bearer = readOptionValue(argv, index, arg);
+      index += 1;
+    } else if (arg === '--header') {
+      options.headers.push(readOptionValue(argv, index, arg));
+      index += 1;
+    } else if (arg === '--max-bytes') {
+      options.maxBytes = toPositiveInteger(readOptionValue(argv, index, arg), arg);
+      index += 1;
+    } else if (arg === '--max-sessions') {
+      options.maxSessions = toPositiveInteger(readOptionValue(argv, index, arg), arg);
+      index += 1;
+    } else if (arg === '--max-events') {
+      options.maxEvents = toPositiveInteger(readOptionValue(argv, index, arg), arg);
+      index += 1;
+    } else if (arg === '--forbidden-token') {
+      options.forbiddenTokens.push(readOptionValue(argv, index, arg));
+      index += 1;
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  options.url = normaliseBaseUrl(options.url);
+  return options;
+}
+
+export function buildProbeHeaders(options = {}) {
+  const headers = {
+    accept: 'application/json',
+  };
+
+  if (options.cookie) headers.cookie = options.cookie;
+  if (options.bearer) headers.authorization = `Bearer ${options.bearer}`;
+
+  for (const header of options.headers || []) {
+    const separator = header.indexOf(':');
+    if (separator <= 0) throw new Error(`Invalid header "${header}". Use "name: value".`);
+    const name = header.slice(0, separator).trim();
+    const value = header.slice(separator + 1).trim();
+    if (!name) throw new Error(`Invalid header "${header}". Header name is required.`);
+    headers[name] = value;
+  }
+
+  return headers;
+}
+
+function arrayCount(payload, key) {
+  return Array.isArray(payload?.[key]) ? payload[key].length : 0;
+}
+
+function spellingSubjectEntries(payload) {
+  const subjectStates = payload?.subjectStates;
+  if (!subjectStates || typeof subjectStates !== 'object' || Array.isArray(subjectStates)) {
+    return [];
+  }
+  return Object.entries(subjectStates)
+    .filter(([key]) => key.endsWith('::spelling'))
+    .map(([key, record]) => ({ key, record }));
+}
+
+function appendSpellingRedactionFailures(failures, payload) {
+  const sessions = Array.isArray(payload.practiceSessions) ? payload.practiceSessions : [];
+  for (const session of sessions) {
+    if (session?.subjectId === 'spelling' && session.sessionState !== null) {
+      failures.push(`Spelling practice session ${session.id || '(unknown)'} exposes sessionState.`);
+    }
+  }
+
+  for (const { key, record } of spellingSubjectEntries(payload)) {
+    if (record?.data?.progress !== undefined) {
+      failures.push(`Spelling subject state ${key} exposes progress data.`);
+    }
+    const currentCard = record?.ui?.session?.currentCard;
+    if (currentCard?.word !== undefined) {
+      failures.push(`Spelling subject state ${key} exposes currentCard.word.`);
+    }
+    if (currentCard?.prompt?.sentence !== undefined) {
+      failures.push(`Spelling subject state ${key} exposes prompt.sentence.`);
+    }
+  }
+}
+
+export function analyseBootstrapPayload(payload, {
+  responseBytes = 0,
+  maxBytes = DEFAULT_MAX_BYTES,
+  maxSessions = null,
+  maxEvents = null,
+  forbiddenTokens = [],
+} = {}) {
+  const failures = [];
+  const warnings = [];
+  const practiceSessionCount = arrayCount(payload, 'practiceSessions');
+  const eventCount = arrayCount(payload, 'eventLog');
+  const responseSize = Number(responseBytes) || 0;
+
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return {
+      ok: false,
+      failures: ['Response body is not a JSON object.'],
+      warnings,
+      responseBytes: responseSize,
+      counts: {
+        practiceSessions: 0,
+        eventLog: 0,
+      },
+      capacity: null,
+    };
+  }
+
+  if (payload.ok !== true) {
+    failures.push('Bootstrap payload does not report ok=true.');
+  }
+  if (responseSize > maxBytes) {
+    failures.push(`Bootstrap response is ${responseSize} bytes, above ${maxBytes}.`);
+  }
+  if (maxSessions != null && practiceSessionCount > maxSessions) {
+    failures.push(`Bootstrap returned ${practiceSessionCount} practice sessions, above ${maxSessions}.`);
+  }
+  if (maxEvents != null && eventCount > maxEvents) {
+    failures.push(`Bootstrap returned ${eventCount} events, above ${maxEvents}.`);
+  }
+
+  const capacity = payload.bootstrapCapacity || null;
+  if (!capacity || typeof capacity !== 'object' || Array.isArray(capacity)) {
+    failures.push('Bootstrap payload is missing bootstrapCapacity metadata.');
+  } else {
+    if (capacity.mode !== 'public-bounded') {
+      failures.push(`bootstrapCapacity.mode is ${JSON.stringify(capacity.mode)}, expected "public-bounded".`);
+    }
+    if (Number(capacity.practiceSessions?.returned) !== practiceSessionCount) {
+      failures.push('bootstrapCapacity.practiceSessions.returned does not match practiceSessions length.');
+    }
+    if (Number(capacity.eventLog?.returned) !== eventCount) {
+      failures.push('bootstrapCapacity.eventLog.returned does not match eventLog length.');
+    }
+    if (capacity.practiceSessions?.bounded !== true || capacity.eventLog?.bounded !== true) {
+      failures.push('bootstrapCapacity does not mark practiceSessions and eventLog as bounded.');
+    }
+  }
+
+  appendSpellingRedactionFailures(failures, payload);
+
+  const bodyText = JSON.stringify(payload);
+  for (const token of forbiddenTokens || []) {
+    if (token && bodyText.includes(token)) {
+      failures.push(`Bootstrap payload contains forbidden token: ${token}`);
+    }
+  }
+
+  if (!Array.isArray(payload.practiceSessions)) {
+    warnings.push('practiceSessions is not an array.');
+  }
+  if (!Array.isArray(payload.eventLog)) {
+    warnings.push('eventLog is not an array.');
+  }
+
+  return {
+    ok: failures.length === 0,
+    failures,
+    warnings,
+    responseBytes: responseSize,
+    counts: {
+      practiceSessions: practiceSessionCount,
+      eventLog: eventCount,
+    },
+    capacity,
+  };
+}
+
+export async function probeProductionBootstrap(options = {}) {
+  const url = new URL('/api/bootstrap', options.url || DEFAULT_URL);
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: buildProbeHeaders(options),
+  });
+  const text = await response.text();
+  const responseBytes = Buffer.byteLength(text, 'utf8');
+  let payload = null;
+  let parseError = null;
+
+  try {
+    payload = text ? JSON.parse(text) : null;
+  } catch (error) {
+    parseError = error;
+  }
+
+  const analysis = analyseBootstrapPayload(payload, {
+    responseBytes,
+    maxBytes: options.maxBytes,
+    maxSessions: options.maxSessions,
+    maxEvents: options.maxEvents,
+    forbiddenTokens: options.forbiddenTokens,
+  });
+
+  if (!response.ok) {
+    analysis.failures.unshift(`Bootstrap returned HTTP ${response.status}.`);
+  }
+  if (parseError) {
+    analysis.failures.unshift(`Bootstrap response is not valid JSON: ${parseError.message}`);
+  }
+
+  return {
+    ok: analysis.failures.length === 0,
+    url: url.toString(),
+    status: response.status,
+    ...analysis,
+  };
+}
+
+export function usage() {
+  return [
+    'Usage: node ./scripts/probe-production-bootstrap.mjs [options]',
+    '',
+    'Options:',
+    '  --url <url>                Site origin, default https://ks2.eugnel.uk',
+    '  --cookie <cookie>          Cookie header value from a logged-in browser session',
+    '  --bearer <token>           Bearer token for Authorization',
+    '  --header "name: value"     Extra request header, repeatable',
+    '  --max-bytes <number>       Maximum allowed response bytes',
+    '  --max-sessions <number>    Maximum allowed practiceSessions length',
+    '  --max-events <number>      Maximum allowed eventLog length',
+    '  --forbidden-token <text>   Token that must not appear in the JSON payload, repeatable',
+  ].join('\n');
+}
+
+export async function runProbe(argv = process.argv.slice(2)) {
+  const options = parseProbeArgs(argv);
+  if (options.help) {
+    console.log(usage());
+    return 0;
+  }
+
+  const summary = await probeProductionBootstrap(options);
+  console.log(JSON.stringify(summary, null, 2));
+  return summary.ok ? 0 : 1;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runProbe().then((code) => {
+    process.exitCode = code;
+  }).catch((error) => {
+    console.error(JSON.stringify({
+      ok: false,
+      error: error.message,
+    }, null, 2));
+    process.exitCode = 2;
+  });
+}

--- a/src/main.js
+++ b/src/main.js
@@ -701,6 +701,8 @@ function buildSignedInHubModels(appState) {
     learnerId: adultSurfaceState.parentHub.learnerId || '',
     error: adultSurfaceState.parentHub.error || '',
     notice: adultSurfaceState.notice || '',
+    recentSessionsStatus: adultSurfaceState.parentHub.payload?.parentHistory?.recentSessions?.status || '',
+    recentSessionsError: adultSurfaceState.parentHub.payload?.parentHistory?.recentSessions?.error || '',
   };
   const adminHubState = {
     status: adultSurfaceState.adminHub.status,

--- a/src/platform/hubs/api.js
+++ b/src/platform/hubs/api.js
@@ -62,11 +62,64 @@ export function createHubApi({
     throw new TypeError('Hub API requires a fetch implementation.');
   }
 
+  async function readParentRecentSessions({ learnerId = null, limit = 6, cursor = null } = {}) {
+    const url = buildRequestUrl(baseUrl, '/api/hubs/parent/recent-sessions', {
+      learnerId,
+      limit,
+      cursor,
+    });
+    return fetchHubJson(fetch, url, { method: 'GET' }, authSession);
+  }
+
+  async function readParentActivity({ learnerId = null, limit = 20, cursor = null } = {}) {
+    const url = buildRequestUrl(baseUrl, '/api/hubs/parent/activity', {
+      learnerId,
+      limit,
+      cursor,
+    });
+    return fetchHubJson(fetch, url, { method: 'GET' }, authSession);
+  }
+
   return {
     async readParentHub(learnerId = null) {
       const url = buildRequestUrl(baseUrl, '/api/hubs/parent', { learnerId });
-      return fetchHubJson(fetch, url, { method: 'GET' }, authSession);
+      const payload = await fetchHubJson(fetch, url, { method: 'GET' }, authSession);
+      const resolvedLearnerId = payload?.learnerId || learnerId || payload?.parentHub?.selectedLearnerId || '';
+      try {
+        const history = await readParentRecentSessions({
+          learnerId: resolvedLearnerId,
+          limit: 6,
+        });
+        if (Array.isArray(history?.recentSessions) && payload?.parentHub) {
+          return {
+            ...payload,
+            parentHub: {
+              ...payload.parentHub,
+              recentSessions: history.recentSessions,
+            },
+            parentHistory: {
+              recentSessions: {
+                status: 'loaded',
+                page: history.page || null,
+              },
+            },
+          };
+        }
+      } catch (error) {
+        return {
+          ...payload,
+          parentHistory: {
+            recentSessions: {
+              status: 'error',
+              error: error?.message || 'Recent sessions could not be loaded.',
+            },
+          },
+        };
+      }
+      return payload;
     },
+    readParentRecentSessions,
+    readParentActivity,
     async readAdminHub({ learnerId = null, requestId = null, auditLimit = 20 } = {}) {
       const url = buildRequestUrl(baseUrl, '/api/hubs/admin', {
         learnerId,

--- a/src/surfaces/hubs/ParentHubSurface.jsx
+++ b/src/surfaces/hubs/ParentHubSurface.jsx
@@ -194,6 +194,9 @@ export function ParentHubSurface({ appState, model, hubState = {}, accessContext
   const overview = model.learnerOverview || {};
   const dueWork = Array.isArray(model.dueWork) ? model.dueWork : [];
   const recentSessions = Array.isArray(model.recentSessions) ? model.recentSessions : [];
+  const recentSessionsError = hubState.recentSessionsStatus === 'error'
+    ? (hubState.recentSessionsError || 'Recent sessions could not be loaded.')
+    : '';
   const strengths = Array.isArray(model.strengths) ? model.strengths : [];
   const weaknesses = Array.isArray(model.weaknesses) ? model.weaknesses : [];
   const patterns = Array.isArray(model.misconceptionPatterns) ? model.misconceptionPatterns : [];
@@ -311,6 +314,7 @@ export function ParentHubSurface({ appState, model, hubState = {}, accessContext
             <p className="eyebrow">Recent sessions</p>
             <h3 className="parent-hub-card-title">Latest durable session records</h3>
           </div>
+          {recentSessionsError ? <div className="feedback warn">{recentSessionsError}</div> : null}
           <RecentSessionList sessions={recentSessions} />
         </article>
         <article className="card parent-hub-card">

--- a/tests/helpers/sqlite-d1.js
+++ b/tests/helpers/sqlite-d1.js
@@ -8,8 +8,10 @@ function rootDir() {
 }
 
 class SqliteD1Statement {
-  constructor(statement) {
+  constructor(statement, { sql = '', recordQuery = null } = {}) {
     this.statement = statement;
+    this.sql = sql;
+    this.recordQuery = recordQuery;
     this.params = [];
   }
 
@@ -20,6 +22,12 @@ class SqliteD1Statement {
 
   async first(columnName = undefined) {
     const row = this.statement.get(...this.params);
+    this.recordQuery?.({
+      operation: 'first',
+      sql: this.sql,
+      params: this.params,
+      rowCount: row ? 1 : 0,
+    });
     if (!row) return null;
     if (typeof columnName === 'string' && columnName) return row[columnName] ?? null;
     return { ...row };
@@ -27,30 +35,60 @@ class SqliteD1Statement {
 
   async run() {
     const meta = this.statement.run(...this.params);
+    this.recordQuery?.({
+      operation: 'run',
+      sql: this.sql,
+      params: this.params,
+      changes: meta.changes,
+      rowCount: meta.changes,
+    });
     return {
       success: true,
       meta: {
         changes: meta.changes,
         last_row_id: Number(meta.lastInsertRowid || 0),
+        rows_read: 0,
+        rows_written: Math.max(0, Number(meta.changes) || 0),
       },
     };
   }
 
   async all() {
     const rows = this.statement.all(...this.params).map((row) => ({ ...row }));
-    return { results: rows };
+    this.recordQuery?.({
+      operation: 'all',
+      sql: this.sql,
+      params: this.params,
+      rowCount: rows.length,
+    });
+    return {
+      results: rows,
+      meta: {
+        rows_read: rows.length,
+        rows_written: 0,
+      },
+    };
   }
 }
 
 export class SqliteD1Database {
   constructor(filename = ':memory:') {
     this.db = new DatabaseSync(filename);
+    this.queryLog = [];
     this.supportsSqlTransactions = true;
     this.db.exec('PRAGMA foreign_keys = ON;');
   }
 
   prepare(sql) {
-    return new SqliteD1Statement(this.db.prepare(sql));
+    return new SqliteD1Statement(this.db.prepare(sql), {
+      sql,
+      recordQuery: (entry) => {
+        this.queryLog.push({
+          ...entry,
+          params: Array.isArray(entry.params) ? [...entry.params] : [],
+        });
+      },
+    });
   }
 
   async exec(sql) {
@@ -77,6 +115,16 @@ export class SqliteD1Database {
 
   close() {
     this.db.close();
+  }
+
+  clearQueryLog() {
+    this.queryLog = [];
+  }
+
+  takeQueryLog() {
+    const output = this.queryLog;
+    this.clearQueryLog();
+    return output;
   }
 }
 

--- a/tests/hub-api.test.js
+++ b/tests/hub-api.test.js
@@ -17,6 +17,14 @@ test('hub api client calls parent hub with learner query and auth headers', asyn
     baseUrl: 'https://repo.test',
     fetch: async (url, init = {}) => {
       calls.push({ url: String(url), init });
+      if (String(url).includes('/api/hubs/parent/recent-sessions')) {
+        return jsonResponse({
+          ok: true,
+          learnerId: 'learner-a',
+          recentSessions: [{ id: 'lazy-session', label: 'Lazy session' }],
+          page: { hasMore: false, nextCursor: null },
+        });
+      }
       return jsonResponse({ ok: true, learnerId: 'learner-a', parentHub: { permissions: {} } });
     },
     authSession: createStaticHeaderRepositoryAuthSession({
@@ -28,12 +36,19 @@ test('hub api client calls parent hub with learner query and auth headers', asyn
   const payload = await api.readParentHub('learner-a');
 
   assert.equal(payload.learnerId, 'learner-a');
-  assert.equal(calls.length, 1);
+  assert.deepEqual(payload.parentHub.recentSessions, [{ id: 'lazy-session', label: 'Lazy session' }]);
+  assert.equal(payload.parentHistory.recentSessions.status, 'loaded');
+  assert.equal(calls.length, 2);
   const requestUrl = new URL(calls[0].url);
   assert.equal(requestUrl.pathname, '/api/hubs/parent');
   assert.equal(requestUrl.searchParams.get('learnerId'), 'learner-a');
   assert.equal(calls[0].init.method, 'GET');
   assert.equal(calls[0].init.headers['x-test-auth'], 'adult-parent');
+  const historyUrl = new URL(calls[1].url);
+  assert.equal(historyUrl.pathname, '/api/hubs/parent/recent-sessions');
+  assert.equal(historyUrl.searchParams.get('learnerId'), 'learner-a');
+  assert.equal(historyUrl.searchParams.get('limit'), '6');
+  assert.equal(calls[1].init.headers['x-test-auth'], 'adult-parent');
 });
 
 test('hub api client calls admin hub with learner, request id, audit limit, and auth headers', async () => {
@@ -72,6 +87,9 @@ test('hub api client supports same-origin relative URLs when no base URL is conf
     baseUrl: '',
     fetch: async (url, init = {}) => {
       calls.push({ url: String(url), init });
+      if (String(url).startsWith('/api/hubs/parent/recent-sessions')) {
+        return jsonResponse({ ok: true, learnerId: 'learner-a', recentSessions: [], page: {} });
+      }
       return jsonResponse({ ok: true, learnerId: 'learner-a', parentHub: { permissions: {} } });
     },
   });
@@ -79,11 +97,36 @@ test('hub api client supports same-origin relative URLs when no base URL is conf
   await api.readParentHub('learner-a');
   await api.readAdminHub({ learnerId: 'learner-a', requestId: 'audit-1', auditLimit: 7 });
 
-  assert.equal(calls.length, 2);
+  assert.equal(calls.length, 3);
   assert.equal(calls[0].url, '/api/hubs/parent?learnerId=learner-a');
   assert.equal(calls[0].init.method, 'GET');
-  assert.equal(calls[1].url, '/api/hubs/admin?learnerId=learner-a&requestId=audit-1&auditLimit=7');
+  assert.equal(calls[1].url, '/api/hubs/parent/recent-sessions?learnerId=learner-a&limit=6');
   assert.equal(calls[1].init.method, 'GET');
+  assert.equal(calls[2].url, '/api/hubs/admin?learnerId=learner-a&requestId=audit-1&auditLimit=7');
+  assert.equal(calls[2].init.method, 'GET');
+});
+
+test('hub api client reads paginated parent history routes', async () => {
+  const calls = [];
+  const api = createHubApi({
+    baseUrl: '',
+    fetch: async (url, init = {}) => {
+      calls.push({ url: String(url), init });
+      return jsonResponse({ ok: true, learnerId: 'learner-a', page: { hasMore: false } });
+    },
+    authSession: createStaticHeaderRepositoryAuthSession({
+      cacheScopeKey: 'account:adult-parent',
+      headers: { 'x-test-auth': 'adult-parent' },
+    }),
+  });
+
+  await api.readParentRecentSessions({ learnerId: 'learner-a', limit: 12, cursor: '100:session-1' });
+  await api.readParentActivity({ learnerId: 'learner-a', limit: 9, cursor: '200:event-1' });
+
+  assert.equal(calls[0].url, '/api/hubs/parent/recent-sessions?learnerId=learner-a&limit=12&cursor=100%3Asession-1');
+  assert.equal(calls[0].init.headers['x-test-auth'], 'adult-parent');
+  assert.equal(calls[1].url, '/api/hubs/parent/activity?learnerId=learner-a&limit=9&cursor=200%3Aevent-1');
+  assert.equal(calls[1].init.headers['x-test-auth'], 'adult-parent');
 });
 
 test('hub api client writes monster visual draft, publish, and restore routes', async () => {

--- a/tests/read-model-backfill.test.js
+++ b/tests/read-model-backfill.test.js
@@ -1,0 +1,110 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { backfillLearnerReadModels } from '../scripts/backfill-learner-read-models.mjs';
+import { createMigratedSqliteD1Database } from './helpers/sqlite-d1.js';
+
+const NOW = Date.UTC(2026, 0, 1);
+
+function runSql(db, sql, params = []) {
+  db.db.prepare(sql).run(...params);
+}
+
+function scalar(db, sql, params = []) {
+  const row = db.db.prepare(sql).get(...params);
+  return row ? Object.values(row)[0] : null;
+}
+
+function seedLearner(db, learnerId) {
+  runSql(db, `
+    INSERT INTO learner_profiles (id, name, year_group, avatar_color, goal, daily_minutes, created_at, updated_at, state_revision)
+    VALUES (?, ?, 'Y5', '#3E6FA8', 'sats', 15, ?, ?, 8)
+  `, [learnerId, learnerId, NOW, NOW]);
+}
+
+function insertEvent(db, {
+  id,
+  learnerId,
+  type = 'spelling.word-secured',
+  createdAt,
+}) {
+  runSql(db, `
+    INSERT INTO event_log (id, learner_id, subject_id, system_id, event_type, event_json, created_at)
+    VALUES (?, ?, 'spelling', 'spelling', ?, ?, ?)
+  `, [
+    id,
+    learnerId,
+    type,
+    JSON.stringify({
+      id,
+      type,
+      learnerId,
+      subjectId: 'spelling',
+      mode: 'smart',
+      sessionType: 'learning',
+      yearBand: '5-6',
+      secureCount: 1,
+      privatePrompt: 'secret-prompt-sentence',
+      createdAt,
+    }),
+    createdAt,
+  ]);
+}
+
+test('learner read-model backfill is idempotent and stores public activity only', async () => {
+  const db = createMigratedSqliteD1Database();
+  seedLearner(db, 'learner-a');
+  seedLearner(db, 'learner-b');
+  insertEvent(db, { id: 'event-a-1', learnerId: 'learner-a', createdAt: NOW + 1 });
+  insertEvent(db, { id: 'event-a-private', learnerId: 'learner-a', type: 'spelling.private-debug', createdAt: NOW + 2 });
+  insertEvent(db, { id: 'event-b-1', learnerId: 'learner-b', createdAt: NOW + 3 });
+
+  const first = await backfillLearnerReadModels(db, {
+    batchSize: 1,
+    now: () => NOW + 10,
+  });
+  assert.equal(first.processedLearners, 1);
+  assert.equal(first.remainingLearners, 1);
+  assert.equal(first.lastLearnerId, 'learner-a');
+
+  const second = await backfillLearnerReadModels(db, {
+    afterLearnerId: first.lastLearnerId,
+    batchSize: 5,
+    now: () => NOW + 20,
+  });
+  assert.equal(second.processedLearners, 1);
+  assert.equal(second.remainingLearners, 0);
+
+  const activityCount = scalar(db, 'SELECT COUNT(*) AS count FROM learner_activity_feed');
+  const readModelCount = scalar(db, 'SELECT COUNT(*) AS count FROM learner_read_models');
+  assert.equal(activityCount, 2);
+  assert.equal(readModelCount, 2);
+
+  const beforeRerunActivityCount = activityCount;
+  await backfillLearnerReadModels(db, {
+    batchSize: 5,
+    now: () => NOW + 30,
+  });
+  assert.equal(scalar(db, 'SELECT COUNT(*) AS count FROM learner_activity_feed'), beforeRerunActivityCount);
+  assert.equal(scalar(db, 'SELECT COUNT(*) AS count FROM learner_read_models'), 2);
+
+  const storedActivity = db.db.prepare(`
+    SELECT activity_json
+    FROM learner_activity_feed
+    WHERE source_event_id = 'event-a-1'
+  `).get();
+  assert.equal(JSON.stringify(storedActivity).includes('secret-prompt-sentence'), false);
+  assert.equal(JSON.parse(storedActivity.activity_json).type, 'spelling.word-secured');
+
+  const storedModel = db.db.prepare(`
+    SELECT model_json, source_revision
+    FROM learner_read_models
+    WHERE learner_id = 'learner-a' AND model_key = 'learner.summary.v1'
+  `).get();
+  const model = JSON.parse(storedModel.model_json);
+  assert.equal(storedModel.source_revision, 8);
+  assert.equal(model.counts.events, 2);
+  assert.equal(model.counts.publicActivity, 1);
+
+  db.close();
+});

--- a/tests/worker-bootstrap-capacity.test.js
+++ b/tests/worker-bootstrap-capacity.test.js
@@ -7,6 +7,7 @@ import { createWorkerRepositoryServer } from './helpers/worker-server.js';
 const BASE_URL = 'https://repo.test';
 const NOW = Date.UTC(2026, 0, 1);
 const RECENT_SESSION_LIMIT_PER_LEARNER = 5;
+const ACTIVE_SESSION_LIMIT_PER_LEARNER = 1;
 const RECENT_EVENT_LIMIT_PER_LEARNER = 50;
 
 function cookieFrom(response) {
@@ -154,6 +155,16 @@ function seedHighHistoryLearner(server, accountId, learnerId) {
     updatedAt: NOW + 10_000,
   });
 
+  for (let index = 0; index < 30; index += 1) {
+    insertPracticeSession(server, accountId, {
+      id: `${learnerId}-stale-active-${String(index).padStart(3, '0')}`,
+      learnerId,
+      status: 'active',
+      createdAt: NOW + 20_000 + index,
+      updatedAt: NOW + 20_000 + index,
+    });
+  }
+
   for (let index = 0; index < 40; index += 1) {
     insertPracticeSession(server, accountId, {
       id: `${learnerId}-completed-${String(index).padStart(3, '0')}`,
@@ -236,9 +247,10 @@ test('production bootstrap keeps high-history public payloads bounded and redact
   const learnerCount = payload.learners.allIds.length;
   assert.ok(payload.bootstrapCapacity);
   assert.equal(payload.bootstrapCapacity.mode, 'public-bounded');
+  assert.equal(payload.bootstrapCapacity.limits.activeSessionsPerLearner, ACTIVE_SESSION_LIMIT_PER_LEARNER);
   assert.equal(payload.bootstrapCapacity.practiceSessions.returned, payload.practiceSessions.length);
   assert.equal(payload.bootstrapCapacity.eventLog.returned, payload.eventLog.length);
-  assert.ok(payload.practiceSessions.length <= learnerCount * (RECENT_SESSION_LIMIT_PER_LEARNER + 1));
+  assert.ok(payload.practiceSessions.length <= learnerCount * (RECENT_SESSION_LIMIT_PER_LEARNER + ACTIVE_SESSION_LIMIT_PER_LEARNER));
   assert.ok(payload.eventLog.length <= learnerCount * RECENT_EVENT_LIMIT_PER_LEARNER);
   assert.equal(payload.practiceSessions.every((session) => session.subjectId !== 'spelling' || session.sessionState === null), true);
 
@@ -249,7 +261,7 @@ test('production bootstrap keeps high-history public payloads bounded and redact
   const analysis = analyseBootstrapPayload(payload, {
     responseBytes,
     maxBytes: 600_000,
-    maxSessions: learnerCount * (RECENT_SESSION_LIMIT_PER_LEARNER + 1),
+    maxSessions: learnerCount * (RECENT_SESSION_LIMIT_PER_LEARNER + ACTIVE_SESSION_LIMIT_PER_LEARNER),
     maxEvents: learnerCount * RECENT_EVENT_LIMIT_PER_LEARNER,
     forbiddenTokens: ['private-active-word', 'top-secret-prompt-sentence'],
   });

--- a/tests/worker-bootstrap-capacity.test.js
+++ b/tests/worker-bootstrap-capacity.test.js
@@ -1,0 +1,275 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { analyseBootstrapPayload } from '../scripts/probe-production-bootstrap.mjs';
+import { createWorkerRepositoryServer } from './helpers/worker-server.js';
+
+const BASE_URL = 'https://repo.test';
+const NOW = Date.UTC(2026, 0, 1);
+const RECENT_SESSION_LIMIT_PER_LEARNER = 5;
+const RECENT_EVENT_LIMIT_PER_LEARNER = 50;
+
+function cookieFrom(response) {
+  const setCookie = response.headers.get('set-cookie') || '';
+  const match = /ks2_session=([^;]+)/.exec(setCookie);
+  return match ? `ks2_session=${match[1]}` : '';
+}
+
+async function postJson(server, path, body = {}, headers = {}) {
+  return server.fetchRaw(`${BASE_URL}${path}`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      origin: BASE_URL,
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function runSql(server, sql, params = []) {
+  server.DB.db.prepare(sql).run(...params);
+}
+
+function insertLearner(server, accountId, {
+  id,
+  name,
+  sortIndex,
+  selected = false,
+  stateRevision,
+}) {
+  runSql(server, `
+    INSERT INTO learner_profiles (id, name, year_group, avatar_color, goal, daily_minutes, created_at, updated_at, state_revision)
+    VALUES (?, ?, 'Y5', '#3E6FA8', 'sats', 15, ?, ?, ?)
+  `, [id, name, NOW, NOW, stateRevision]);
+  runSql(server, `
+    INSERT INTO account_learner_memberships (account_id, learner_id, role, sort_index, created_at, updated_at)
+    VALUES (?, ?, 'owner', ?, ?, ?)
+  `, [accountId, id, sortIndex, NOW, NOW]);
+  if (selected) {
+    runSql(server, 'UPDATE adult_accounts SET selected_learner_id = ?, updated_at = ? WHERE id = ?', [id, NOW, accountId]);
+  }
+}
+
+function insertSubjectState(server, accountId, learnerId) {
+  runSql(server, `
+    INSERT INTO child_subject_state (learner_id, subject_id, ui_json, data_json, updated_at, updated_by_account_id)
+    VALUES (?, 'spelling', ?, ?, ?, ?)
+  `, [
+    learnerId,
+    JSON.stringify({
+      phase: 'session',
+      session: {
+        id: `${learnerId}-active`,
+        type: 'learning',
+        mode: 'smart',
+        phase: 'question',
+        progress: { done: 0, total: 1 },
+        currentCard: {
+          word: { word: 'private-active-word', slug: 'private-active-word' },
+          prompt: {
+            sentence: `top-secret-prompt-sentence-${learnerId}`,
+            cloze: 'Spell the missing word.',
+          },
+        },
+      },
+    }),
+    JSON.stringify({
+      prefs: { mode: 'smart' },
+      progress: {
+        possess: { stage: 4 },
+      },
+    }),
+    NOW,
+    accountId,
+  ]);
+}
+
+function insertPracticeSession(server, accountId, {
+  id,
+  learnerId,
+  status,
+  createdAt,
+  updatedAt,
+}) {
+  runSql(server, `
+    INSERT INTO practice_sessions (id, learner_id, subject_id, session_kind, status, session_state_json, summary_json, created_at, updated_at, updated_by_account_id)
+    VALUES (?, ?, 'spelling', 'learning', ?, ?, ?, ?, ?, ?)
+  `, [
+    id,
+    learnerId,
+    status,
+    JSON.stringify({
+      currentCard: {
+        word: { word: 'private-active-word' },
+        prompt: { sentence: `top-secret-prompt-sentence-${learnerId}` },
+      },
+    }),
+    JSON.stringify({
+      cards: [{ label: 'accuracy', value: '100%' }],
+      mistakes: [{ word: 'private-active-word', year: '5-6' }],
+    }),
+    createdAt,
+    updatedAt,
+    accountId,
+  ]);
+}
+
+function insertEvent(server, accountId, {
+  id,
+  learnerId,
+  createdAt,
+}) {
+  runSql(server, `
+    INSERT INTO event_log (id, learner_id, subject_id, system_id, event_type, event_json, created_at, actor_account_id)
+    VALUES (?, ?, 'spelling', 'spelling', 'spelling.word-secured', ?, ?, ?)
+  `, [
+    id,
+    learnerId,
+    JSON.stringify({
+      id,
+      type: 'spelling.word-secured',
+      learnerId,
+      subjectId: 'spelling',
+      mode: 'smart',
+      sessionType: 'learning',
+      spellingPool: 'core',
+      yearBand: '5-6',
+      secureCount: 1,
+      createdAt,
+      privatePrompt: `top-secret-prompt-sentence-${learnerId}`,
+    }),
+    createdAt,
+    accountId,
+  ]);
+}
+
+function seedHighHistoryLearner(server, accountId, learnerId) {
+  insertSubjectState(server, accountId, learnerId);
+  insertPracticeSession(server, accountId, {
+    id: `${learnerId}-active`,
+    learnerId,
+    status: 'active',
+    createdAt: NOW + 10_000,
+    updatedAt: NOW + 10_000,
+  });
+
+  for (let index = 0; index < 40; index += 1) {
+    insertPracticeSession(server, accountId, {
+      id: `${learnerId}-completed-${String(index).padStart(3, '0')}`,
+      learnerId,
+      status: 'completed',
+      createdAt: NOW - index - 1,
+      updatedAt: NOW - index - 1,
+    });
+  }
+
+  for (let index = 0; index < 160; index += 1) {
+    insertEvent(server, accountId, {
+      id: `${learnerId}-event-${String(index).padStart(3, '0')}`,
+      learnerId,
+      createdAt: NOW + index,
+    });
+  }
+}
+
+async function registerProductionAccount(server) {
+  const response = await postJson(server, '/api/auth/register', {
+    email: 'bootstrap-capacity@example.test',
+    password: 'password-1234',
+  });
+  const payload = await response.json();
+  assert.equal(response.status, 201);
+  return {
+    accountId: payload.session.accountId,
+    cookie: cookieFrom(response),
+  };
+}
+
+function createProductionServer() {
+  return createWorkerRepositoryServer({
+    env: {
+      AUTH_MODE: 'production',
+      ENVIRONMENT: 'production',
+      APP_HOSTNAME: 'repo.test',
+    },
+  });
+}
+
+test('production bootstrap keeps high-history public payloads bounded and redacted', async () => {
+  const server = createProductionServer();
+  const { accountId, cookie } = await registerProductionAccount(server);
+
+  insertLearner(server, accountId, {
+    id: 'learner-high-a',
+    name: 'Ava',
+    sortIndex: 0,
+    selected: true,
+    stateRevision: 7,
+  });
+  insertLearner(server, accountId, {
+    id: 'learner-high-b',
+    name: 'Ben',
+    sortIndex: 1,
+    stateRevision: 11,
+  });
+  seedHighHistoryLearner(server, accountId, 'learner-high-a');
+  seedHighHistoryLearner(server, accountId, 'learner-high-b');
+
+  server.DB.clearQueryLog();
+  const response = await server.fetchRaw(`${BASE_URL}/api/bootstrap`, {
+    headers: { cookie },
+  });
+  const text = await response.text();
+  const payload = JSON.parse(text);
+  const responseBytes = Buffer.byteLength(text, 'utf8');
+
+  assert.equal(response.status, 200);
+  assert.equal(payload.ok, true);
+  assert.equal(payload.learners.selectedId, 'learner-high-a');
+  assert.deepEqual(payload.learners.allIds, ['learner-high-a', 'learner-high-b']);
+  assert.equal(payload.syncState.learnerRevisions['learner-high-a'], 7);
+  assert.equal(payload.syncState.learnerRevisions['learner-high-b'], 11);
+  assert.equal(payload.practiceSessions.some((session) => session.id === 'learner-high-a-active'), true);
+  assert.equal(payload.practiceSessions.some((session) => session.id === 'learner-high-b-active'), true);
+
+  const learnerCount = payload.learners.allIds.length;
+  assert.ok(payload.bootstrapCapacity);
+  assert.equal(payload.bootstrapCapacity.mode, 'public-bounded');
+  assert.equal(payload.bootstrapCapacity.practiceSessions.returned, payload.practiceSessions.length);
+  assert.equal(payload.bootstrapCapacity.eventLog.returned, payload.eventLog.length);
+  assert.ok(payload.practiceSessions.length <= learnerCount * (RECENT_SESSION_LIMIT_PER_LEARNER + 1));
+  assert.ok(payload.eventLog.length <= learnerCount * RECENT_EVENT_LIMIT_PER_LEARNER);
+  assert.equal(payload.practiceSessions.every((session) => session.subjectId !== 'spelling' || session.sessionState === null), true);
+
+  const bodyText = JSON.stringify(payload);
+  assert.equal(bodyText.includes('private-active-word'), false);
+  assert.equal(bodyText.includes('top-secret-prompt-sentence'), false);
+
+  const analysis = analyseBootstrapPayload(payload, {
+    responseBytes,
+    maxBytes: 600_000,
+    maxSessions: learnerCount * (RECENT_SESSION_LIMIT_PER_LEARNER + 1),
+    maxEvents: learnerCount * RECENT_EVENT_LIMIT_PER_LEARNER,
+    forbiddenTokens: ['private-active-word', 'top-secret-prompt-sentence'],
+  });
+  assert.deepEqual(analysis.failures, []);
+
+  const eventReads = server.DB.takeQueryLog()
+    .filter((entry) => entry.operation === 'all' && /\bFROM event_log\b/i.test(entry.sql));
+  assert.ok(eventReads.length >= learnerCount);
+  assert.equal(eventReads.every((entry) => entry.rowCount <= RECENT_EVENT_LIMIT_PER_LEARNER), true);
+
+  server.close();
+});
+
+test('production bootstrap still requires an authenticated session before capacity checks', async () => {
+  const server = createProductionServer();
+  const response = await server.fetchRaw(`${BASE_URL}/api/bootstrap`);
+  const payload = await response.json();
+
+  assert.equal(response.status, 401);
+  assert.equal(payload.code, 'unauthenticated');
+
+  server.close();
+});

--- a/tests/worker-history-api.test.js
+++ b/tests/worker-history-api.test.js
@@ -142,15 +142,26 @@ test('parent activity route returns public event rows only', async () => {
 
   const response = await server.fetchAs(
     'adult-parent',
-    `${BASE_URL}/api/hubs/parent/activity?learnerId=learner-history&limit=5`,
+    `${BASE_URL}/api/hubs/parent/activity?learnerId=learner-history&limit=1`,
   );
   const payload = await response.json();
 
   assert.equal(response.status, 200);
-  assert.deepEqual(payload.activity.map((event) => event.type), ['spelling.word-secured', 'spelling.word-secured']);
+  assert.equal(payload.source, 'event_log');
+  assert.deepEqual(payload.activity.map((event) => event.createdAt), [NOW + 3]);
   assert.equal(payload.activity.some((event) => event.id === 'event-private'), false);
   assert.equal(JSON.stringify(payload).includes('secret-prompt-sentence'), false);
-  assert.equal(payload.page.hasMore, false);
+  assert.equal(payload.page.hasMore, true);
+
+  const secondResponse = await server.fetchAs(
+    'adult-parent',
+    `${BASE_URL}/api/hubs/parent/activity?learnerId=learner-history&limit=1&cursor=${encodeURIComponent(payload.page.nextCursor)}`,
+  );
+  const secondPayload = await secondResponse.json();
+
+  assert.equal(secondResponse.status, 200);
+  assert.equal(secondPayload.source, 'event_log');
+  assert.deepEqual(secondPayload.activity.map((event) => event.createdAt), [NOW + 1]);
 
   server.close();
 });

--- a/tests/worker-history-api.test.js
+++ b/tests/worker-history-api.test.js
@@ -1,0 +1,173 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createWorkerRepositoryServer } from './helpers/worker-server.js';
+
+const BASE_URL = 'https://repo.test';
+const NOW = Date.UTC(2026, 0, 1);
+
+function runSql(server, sql, params = []) {
+  server.DB.db.prepare(sql).run(...params);
+}
+
+function seedAccount(server, {
+  accountId,
+  learnerId = 'learner-history',
+  role = 'owner',
+  platformRole = 'parent',
+} = {}) {
+  runSql(server, `
+    INSERT INTO adult_accounts (id, email, display_name, platform_role, selected_learner_id, created_at, updated_at, repo_revision)
+    VALUES (?, ?, 'Parent', ?, NULL, ?, ?, 0)
+  `, [accountId, `${accountId}@example.test`, platformRole, NOW, NOW]);
+  runSql(server, `
+    INSERT INTO learner_profiles (id, name, year_group, avatar_color, goal, daily_minutes, created_at, updated_at, state_revision)
+    VALUES (?, 'Ava', 'Y5', '#3E6FA8', 'sats', 15, ?, ?, 0)
+  `, [learnerId, NOW, NOW]);
+  runSql(server, `
+    INSERT INTO account_learner_memberships (account_id, learner_id, role, sort_index, created_at, updated_at)
+    VALUES (?, ?, ?, 0, ?, ?)
+  `, [accountId, learnerId, role, NOW, NOW]);
+  runSql(server, 'UPDATE adult_accounts SET selected_learner_id = ? WHERE id = ?', [learnerId, accountId]);
+}
+
+function insertSession(server, {
+  id,
+  learnerId = 'learner-history',
+  updatedAt,
+}) {
+  runSql(server, `
+    INSERT INTO practice_sessions (id, learner_id, subject_id, session_kind, status, session_state_json, summary_json, created_at, updated_at, updated_by_account_id)
+    VALUES (?, ?, 'spelling', 'learning', 'completed', ?, ?, ?, ?, 'adult-parent')
+  `, [
+    id,
+    learnerId,
+    JSON.stringify({
+      currentCard: {
+        word: { word: 'secret-word' },
+        prompt: { sentence: 'secret-prompt-sentence' },
+      },
+    }),
+    JSON.stringify({
+      label: 'Smart review',
+      cards: [{ label: 'Correct', value: '6/8' }],
+      mistakes: [{ word: 'secret-word', year: '5-6' }],
+    }),
+    updatedAt - 1,
+    updatedAt,
+  ]);
+}
+
+function insertEvent(server, {
+  id,
+  learnerId = 'learner-history',
+  type = 'spelling.word-secured',
+  createdAt,
+}) {
+  runSql(server, `
+    INSERT INTO event_log (id, learner_id, subject_id, system_id, event_type, event_json, created_at, actor_account_id)
+    VALUES (?, ?, 'spelling', 'spelling', ?, ?, ?, 'adult-parent')
+  `, [
+    id,
+    learnerId,
+    type,
+    JSON.stringify({
+      id,
+      type,
+      learnerId,
+      subjectId: 'spelling',
+      mode: 'smart',
+      sessionType: 'learning',
+      yearBand: '5-6',
+      secureCount: 1,
+      privatePrompt: 'secret-prompt-sentence',
+      createdAt,
+    }),
+    createdAt,
+  ]);
+}
+
+test('parent recent sessions route is paginated, scoped, and redacted', async () => {
+  const server = createWorkerRepositoryServer();
+  seedAccount(server, { accountId: 'adult-parent' });
+  seedAccount(server, { accountId: 'adult-other', learnerId: 'learner-other' });
+
+  for (let index = 0; index < 8; index += 1) {
+    insertSession(server, {
+      id: `session-${index}`,
+      updatedAt: NOW + index,
+    });
+  }
+  insertSession(server, {
+    id: 'other-session',
+    learnerId: 'learner-other',
+    updatedAt: NOW + 100,
+  });
+
+  const firstResponse = await server.fetchAs(
+    'adult-parent',
+    `${BASE_URL}/api/hubs/parent/recent-sessions?learnerId=learner-history&limit=3`,
+  );
+  const firstPayload = await firstResponse.json();
+
+  assert.equal(firstResponse.status, 200);
+  assert.deepEqual(firstPayload.sessions.map((session) => session.id), ['session-7', 'session-6', 'session-5']);
+  assert.deepEqual(firstPayload.recentSessions.map((session) => session.id), ['session-7', 'session-6', 'session-5']);
+  assert.equal(firstPayload.sessions.every((session) => session.sessionState === null), true);
+  assert.equal(JSON.stringify(firstPayload).includes('secret-word'), false);
+  assert.equal(JSON.stringify(firstPayload).includes('secret-prompt-sentence'), false);
+  assert.equal(firstPayload.page.hasMore, true);
+  assert.ok(firstPayload.page.nextCursor);
+
+  const secondResponse = await server.fetchAs(
+    'adult-parent',
+    `${BASE_URL}/api/hubs/parent/recent-sessions?learnerId=learner-history&limit=3&cursor=${encodeURIComponent(firstPayload.page.nextCursor)}`,
+  );
+  const secondPayload = await secondResponse.json();
+
+  assert.equal(secondResponse.status, 200);
+  assert.deepEqual(secondPayload.sessions.map((session) => session.id), ['session-4', 'session-3', 'session-2']);
+  assert.equal(secondPayload.sessions.some((session) => firstPayload.sessions.some((first) => first.id === session.id)), false);
+
+  server.close();
+});
+
+test('parent activity route returns public event rows only', async () => {
+  const server = createWorkerRepositoryServer();
+  seedAccount(server, { accountId: 'adult-parent' });
+
+  insertEvent(server, { id: 'event-public-1', createdAt: NOW + 1 });
+  insertEvent(server, { id: 'event-private', type: 'spelling.private-debug', createdAt: NOW + 2 });
+  insertEvent(server, { id: 'event-public-2', createdAt: NOW + 3 });
+
+  const response = await server.fetchAs(
+    'adult-parent',
+    `${BASE_URL}/api/hubs/parent/activity?learnerId=learner-history&limit=5`,
+  );
+  const payload = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(payload.activity.map((event) => event.type), ['spelling.word-secured', 'spelling.word-secured']);
+  assert.equal(payload.activity.some((event) => event.id === 'event-private'), false);
+  assert.equal(JSON.stringify(payload).includes('secret-prompt-sentence'), false);
+  assert.equal(payload.page.hasMore, false);
+
+  server.close();
+});
+
+test('parent history routes reuse learner read-access boundaries', async () => {
+  const server = createWorkerRepositoryServer();
+  seedAccount(server, { accountId: 'adult-parent' });
+  seedAccount(server, { accountId: 'adult-outsider', learnerId: 'learner-outsider' });
+
+  const response = await server.fetchAs(
+    'adult-outsider',
+    `${BASE_URL}/api/hubs/parent/recent-sessions?learnerId=learner-history`,
+  );
+  const payload = await response.json();
+
+  assert.equal(response.status, 403);
+  assert.equal(payload.code, 'forbidden');
+
+  server.close();
+});

--- a/tests/worker-read-model-capacity.test.js
+++ b/tests/worker-read-model-capacity.test.js
@@ -1,0 +1,158 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createWorkerRepository } from '../worker/src/repository.js';
+import { createWorkerRepositoryServer } from './helpers/worker-server.js';
+
+const NOW = Date.UTC(2026, 0, 1);
+
+function runSql(server, sql, params = []) {
+  server.DB.db.prepare(sql).run(...params);
+}
+
+function seedLearner(server, learnerId = 'learner-read-model') {
+  runSql(server, `
+    INSERT INTO learner_profiles (id, name, year_group, avatar_color, goal, daily_minutes, created_at, updated_at, state_revision)
+    VALUES (?, 'Ava', 'Y5', '#3E6FA8', 'sats', 15, ?, ?, 4)
+  `, [learnerId, NOW, NOW]);
+}
+
+function seedParentAccess(server, {
+  accountId = 'adult-parent',
+  learnerId = 'learner-read-model',
+} = {}) {
+  runSql(server, `
+    INSERT INTO adult_accounts (id, email, display_name, platform_role, selected_learner_id, created_at, updated_at, repo_revision)
+    VALUES (?, ?, 'Parent', 'parent', NULL, ?, ?, 0)
+  `, [accountId, `${accountId}@example.test`, NOW, NOW]);
+  seedLearner(server, learnerId);
+  runSql(server, `
+    INSERT INTO account_learner_memberships (account_id, learner_id, role, sort_index, created_at, updated_at)
+    VALUES (?, ?, 'owner', 0, ?, ?)
+  `, [accountId, learnerId, NOW, NOW]);
+  runSql(server, 'UPDATE adult_accounts SET selected_learner_id = ? WHERE id = ?', [learnerId, accountId]);
+}
+
+test('capacity read-model migration creates indexed summary and activity stores', () => {
+  const server = createWorkerRepositoryServer();
+  const tableRows = server.DB.db.prepare(`
+    SELECT name
+    FROM sqlite_master
+    WHERE type = 'table'
+      AND name IN ('learner_read_models', 'learner_activity_feed')
+    ORDER BY name
+  `).all();
+  const indexRows = server.DB.db.prepare(`
+    SELECT name
+    FROM sqlite_master
+    WHERE type = 'index'
+      AND name IN (
+        'idx_learner_read_models_key_updated',
+        'idx_learner_activity_feed_source_event',
+        'idx_learner_activity_feed_learner_created',
+        'idx_learner_activity_feed_subject_created'
+      )
+    ORDER BY name
+  `).all();
+
+  assert.deepEqual(tableRows.map((row) => row.name), ['learner_activity_feed', 'learner_read_models']);
+  assert.deepEqual(indexRows.map((row) => row.name), [
+    'idx_learner_activity_feed_learner_created',
+    'idx_learner_activity_feed_source_event',
+    'idx_learner_activity_feed_subject_created',
+    'idx_learner_read_models_key_updated',
+  ]);
+
+  server.close();
+});
+
+test('repository read-model helpers upsert, read, and tolerate malformed JSON', async () => {
+  const server = createWorkerRepositoryServer();
+  seedLearner(server);
+  const repository = createWorkerRepository({ env: server.env, now: () => NOW });
+
+  const written = await repository.upsertLearnerReadModel(
+    'learner-read-model',
+    'parent.summary.v1',
+    { overview: { secureWords: 12 } },
+    { sourceRevision: 4, generatedAt: NOW },
+  );
+  assert.equal(written.model.overview.secureWords, 12);
+  assert.equal(written.sourceRevision, 4);
+
+  const read = await repository.readLearnerReadModel('learner-read-model', 'parent.summary.v1');
+  assert.equal(read.model.overview.secureWords, 12);
+  assert.equal(read.missing, false);
+
+  runSql(server, `
+    UPDATE learner_read_models
+    SET model_json = '{broken'
+    WHERE learner_id = 'learner-read-model' AND model_key = 'parent.summary.v1'
+  `);
+  const malformed = await repository.readLearnerReadModel('learner-read-model', 'parent.summary.v1');
+  assert.deepEqual(malformed.model, {});
+  assert.equal(malformed.missing, false);
+
+  const missing = await repository.readLearnerReadModel('learner-read-model', 'missing.summary.v1');
+  assert.equal(missing.missing, true);
+  assert.deepEqual(missing.model, {});
+
+  server.close();
+});
+
+test('parent activity route reads backfilled activity feed before event_log fallback', async () => {
+  const server = createWorkerRepositoryServer();
+  seedParentAccess(server);
+  const repository = createWorkerRepository({ env: server.env, now: () => NOW });
+
+  await repository.upsertLearnerActivityFeedRows([
+    {
+      id: 'activity-2',
+      learnerId: 'learner-read-model',
+      subjectId: 'spelling',
+      activityType: 'spelling.word-secured',
+      activity: {
+        type: 'spelling.word-secured',
+        learnerId: 'learner-read-model',
+        subjectId: 'spelling',
+        createdAt: NOW + 2,
+        secureCount: 2,
+      },
+      sourceEventId: 'event-2',
+      createdAt: NOW + 2,
+      updatedAt: NOW + 2,
+    },
+    {
+      id: 'activity-1',
+      learnerId: 'learner-read-model',
+      subjectId: 'spelling',
+      activityType: 'spelling.word-secured',
+      activity: {
+        type: 'spelling.word-secured',
+        learnerId: 'learner-read-model',
+        subjectId: 'spelling',
+        createdAt: NOW + 1,
+        secureCount: 1,
+      },
+      sourceEventId: 'event-1',
+      createdAt: NOW + 1,
+      updatedAt: NOW + 1,
+    },
+  ]);
+
+  server.DB.clearQueryLog();
+  const response = await server.fetchAs(
+    'adult-parent',
+    'https://repo.test/api/hubs/parent/activity?learnerId=learner-read-model&limit=1',
+  );
+  const payload = await response.json();
+  const queryLog = server.DB.takeQueryLog();
+
+  assert.equal(response.status, 200);
+  assert.equal(payload.source, 'learner_activity_feed');
+  assert.deepEqual(payload.activity.map((event) => event.secureCount), [2]);
+  assert.equal(payload.page.hasMore, true);
+  assert.equal(queryLog.some((entry) => /\bFROM event_log\b/i.test(entry.sql)), false);
+
+  server.close();
+});

--- a/tests/worker-read-model-capacity.test.js
+++ b/tests/worker-read-model-capacity.test.js
@@ -10,6 +10,10 @@ function runSql(server, sql, params = []) {
   server.DB.db.prepare(sql).run(...params);
 }
 
+function countRows(server, tableName, learnerId = 'learner-read-model') {
+  return server.DB.db.prepare(`SELECT COUNT(*) AS count FROM ${tableName} WHERE learner_id = ?`).get(learnerId).count;
+}
+
 function seedLearner(server, learnerId = 'learner-read-model') {
   runSql(server, `
     INSERT INTO learner_profiles (id, name, year_group, avatar_color, goal, daily_minutes, created_at, updated_at, state_revision)
@@ -62,6 +66,168 @@ test('capacity read-model migration creates indexed summary and activity stores'
     'idx_learner_activity_feed_subject_created',
     'idx_learner_read_models_key_updated',
   ]);
+
+  server.close();
+});
+
+test('event appends update learner activity feed after backfill rows exist', async () => {
+  const server = createWorkerRepositoryServer();
+  seedParentAccess(server);
+  const repository = createWorkerRepository({ env: server.env, now: () => NOW + 10 });
+
+  await repository.upsertLearnerActivityFeedRows([
+    {
+      id: 'activity-existing',
+      learnerId: 'learner-read-model',
+      subjectId: 'spelling',
+      activityType: 'spelling.word-secured',
+      activity: {
+        type: 'spelling.word-secured',
+        learnerId: 'learner-read-model',
+        subjectId: 'spelling',
+        createdAt: NOW + 1,
+        secureCount: 1,
+      },
+      sourceEventId: 'event-existing',
+      createdAt: NOW + 1,
+      updatedAt: NOW + 1,
+    },
+  ]);
+
+  await repository.appendEvent('adult-parent', {
+    id: 'event-after-backfill',
+    learnerId: 'learner-read-model',
+    subjectId: 'spelling',
+    type: 'spelling.word-secured',
+    mode: 'smart',
+    sessionType: 'learning',
+    secureCount: 9,
+    privatePrompt: 'secret-prompt-sentence',
+    createdAt: NOW + 10,
+  }, {
+    requestId: 'append-after-backfill',
+    expectedLearnerRevision: 4,
+  });
+
+  server.DB.clearQueryLog();
+  const response = await server.fetchAs(
+    'adult-parent',
+    'https://repo.test/api/hubs/parent/activity?learnerId=learner-read-model&limit=2',
+  );
+  const payload = await response.json();
+  const queryLog = server.DB.takeQueryLog();
+
+  assert.equal(response.status, 200);
+  assert.equal(payload.source, 'learner_activity_feed');
+  assert.deepEqual(payload.activity.map((event) => event.secureCount), [9, 1]);
+  assert.equal(JSON.stringify(payload).includes('secret-prompt-sentence'), false);
+  assert.equal(queryLog.some((entry) => /\bFROM event_log\b/i.test(entry.sql)), false);
+
+  server.close();
+});
+
+test('subject runtime persistence writes public activity feed rows', async () => {
+  const server = createWorkerRepositoryServer();
+  seedParentAccess(server);
+  const repository = createWorkerRepository({ env: server.env, now: () => NOW + 20 });
+
+  await repository.persistSubjectRuntime('adult-parent', 'learner-read-model', 'spelling', {
+    events: [
+      {
+        id: 'runtime-public-event',
+        type: 'spelling.word-secured',
+        learnerId: 'learner-read-model',
+        subjectId: 'spelling',
+        mode: 'smart',
+        sessionType: 'learning',
+        secureCount: 4,
+        privatePrompt: 'secret-prompt-sentence',
+        createdAt: NOW + 20,
+      },
+    ],
+  });
+
+  const response = await server.fetchAs(
+    'adult-parent',
+    'https://repo.test/api/hubs/parent/activity?learnerId=learner-read-model&limit=1',
+  );
+  const payload = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(payload.source, 'learner_activity_feed');
+  assert.deepEqual(payload.activity.map((event) => event.secureCount), [4]);
+  assert.equal(JSON.stringify(payload).includes('secret-prompt-sentence'), false);
+
+  server.close();
+});
+
+test('event clear and runtime reset clear learner activity projections', async () => {
+  const server = createWorkerRepositoryServer();
+  seedParentAccess(server);
+  const repository = createWorkerRepository({ env: server.env, now: () => NOW });
+
+  await repository.upsertLearnerReadModel('learner-read-model', 'parent.summary.v1', {
+    overview: { secureWords: 1 },
+  }, { sourceRevision: 4, generatedAt: NOW });
+  await repository.upsertLearnerActivityFeedRows([
+    {
+      id: 'activity-clearable',
+      learnerId: 'learner-read-model',
+      subjectId: 'spelling',
+      activityType: 'spelling.word-secured',
+      activity: {
+        type: 'spelling.word-secured',
+        learnerId: 'learner-read-model',
+        subjectId: 'spelling',
+        createdAt: NOW,
+        secureCount: 1,
+      },
+      sourceEventId: 'event-clearable',
+      createdAt: NOW,
+      updatedAt: NOW,
+    },
+  ]);
+
+  assert.equal(countRows(server, 'learner_activity_feed'), 1);
+  assert.equal(countRows(server, 'learner_read_models'), 1);
+
+  await repository.clearEventLog('adult-parent', 'learner-read-model', {
+    requestId: 'clear-event-projections',
+    expectedLearnerRevision: 4,
+  });
+
+  assert.equal(countRows(server, 'learner_activity_feed'), 0);
+  assert.equal(countRows(server, 'learner_read_models'), 0);
+
+  await repository.upsertLearnerReadModel('learner-read-model', 'parent.summary.v1', {
+    overview: { secureWords: 2 },
+  }, { sourceRevision: 5, generatedAt: NOW });
+  await repository.upsertLearnerActivityFeedRows([
+    {
+      id: 'activity-resettable',
+      learnerId: 'learner-read-model',
+      subjectId: 'spelling',
+      activityType: 'spelling.word-secured',
+      activity: {
+        type: 'spelling.word-secured',
+        learnerId: 'learner-read-model',
+        subjectId: 'spelling',
+        createdAt: NOW + 1,
+        secureCount: 2,
+      },
+      sourceEventId: 'event-resettable',
+      createdAt: NOW + 1,
+      updatedAt: NOW + 1,
+    },
+  ]);
+
+  await repository.resetLearnerRuntime('adult-parent', 'learner-read-model', {
+    requestId: 'reset-runtime-projections',
+    expectedLearnerRevision: 5,
+  });
+
+  assert.equal(countRows(server, 'learner_activity_feed'), 0);
+  assert.equal(countRows(server, 'learner_read_models'), 0);
 
   server.close();
 });

--- a/worker/migrations/0009_capacity_read_models.sql
+++ b/worker/migrations/0009_capacity_read_models.sql
@@ -1,0 +1,37 @@
+CREATE TABLE IF NOT EXISTS learner_read_models (
+  learner_id TEXT NOT NULL,
+  model_key TEXT NOT NULL,
+  model_json TEXT NOT NULL DEFAULT '{}',
+  source_revision INTEGER NOT NULL DEFAULT 0,
+  generated_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY (learner_id, model_key),
+  FOREIGN KEY (learner_id) REFERENCES learner_profiles(id) ON DELETE CASCADE,
+  CHECK (model_key <> '')
+);
+
+CREATE INDEX IF NOT EXISTS idx_learner_read_models_key_updated
+  ON learner_read_models(model_key, updated_at DESC, learner_id);
+
+CREATE TABLE IF NOT EXISTS learner_activity_feed (
+  id TEXT PRIMARY KEY,
+  learner_id TEXT NOT NULL,
+  subject_id TEXT,
+  activity_type TEXT NOT NULL,
+  activity_json TEXT NOT NULL DEFAULT '{}',
+  source_event_id TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (learner_id) REFERENCES learner_profiles(id) ON DELETE CASCADE,
+  CHECK (activity_type <> '')
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_learner_activity_feed_source_event
+  ON learner_activity_feed(source_event_id)
+  WHERE source_event_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_learner_activity_feed_learner_created
+  ON learner_activity_feed(learner_id, created_at DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_learner_activity_feed_subject_created
+  ON learner_activity_feed(learner_id, subject_id, created_at DESC, id DESC);

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -481,6 +481,36 @@ export function createWorkerApp({
           return json({ ok: true, wordBank: result });
         }
 
+        if (url.pathname === '/api/hubs/parent/recent-sessions' && request.method === 'GET') {
+          await protectDemoParentHubRead({
+            env,
+            request,
+            session,
+            now: now(),
+          });
+          const result = await repository.readParentRecentSessions(session.accountId, {
+            learnerId: url.searchParams.get('learnerId') || null,
+            limit: url.searchParams.get('limit') || null,
+            cursor: url.searchParams.get('cursor') || null,
+          });
+          return json({ ok: true, ...result });
+        }
+
+        if (url.pathname === '/api/hubs/parent/activity' && request.method === 'GET') {
+          await protectDemoParentHubRead({
+            env,
+            request,
+            session,
+            now: now(),
+          });
+          const result = await repository.readParentActivity(session.accountId, {
+            learnerId: url.searchParams.get('learnerId') || null,
+            limit: url.searchParams.get('limit') || null,
+            cursor: url.searchParams.get('cursor') || null,
+          });
+          return json({ ok: true, ...result });
+        }
+
         if (url.pathname === '/api/hubs/parent' && request.method === 'GET') {
           await protectDemoParentHubRead({
             env,

--- a/worker/src/http.js
+++ b/worker/src/http.js
@@ -1,5 +1,5 @@
 export function json(body, status = 200, headers = {}) {
-  return new Response(JSON.stringify(body, null, 2), {
+  return new Response(JSON.stringify(body), {
     status,
     headers: {
       'content-type': 'application/json; charset=utf-8',

--- a/worker/src/read-models/learner-read-models.js
+++ b/worker/src/read-models/learner-read-models.js
@@ -1,0 +1,155 @@
+import { cloneSerialisable } from '../../../src/platform/core/repositories/helpers.js';
+
+export const LEARNER_SUMMARY_MODEL_KEY = 'learner.summary.v1';
+export const PARENT_SUMMARY_MODEL_KEY = 'parent.summary.v1';
+export const PUBLIC_ACTIVITY_TYPES = new Set([
+  'spelling.retry-cleared',
+  'spelling.word-secured',
+  'spelling.mastery-milestone',
+  'spelling.session-completed',
+  'reward.monster',
+  'platform.practice-streak-hit',
+]);
+
+const PUBLIC_ACTIVITY_TEXT_ENUMS = {
+  mode: new Set(['smart', 'trouble', 'single', 'test']),
+  sessionType: new Set(['learning', 'test']),
+  kind: new Set(['caught', 'evolve', 'mega', 'levelup']),
+  monsterId: new Set(['inklet', 'glimmerbug', 'phaeton', 'vellhorn']),
+  spellingPool: new Set(['core', 'extra']),
+  yearBand: new Set(['3-4', '5-6', 'extra']),
+  fromPhase: new Set(['retry', 'correction']),
+};
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function safeJsonParse(text, fallback) {
+  if (text == null || text === '') return cloneSerialisable(fallback);
+  try {
+    return JSON.parse(text);
+  } catch {
+    return cloneSerialisable(fallback);
+  }
+}
+
+function safeText(value) {
+  return typeof value === 'string' && value ? value : null;
+}
+
+function safeNumber(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function safeEnum(key, value) {
+  const text = safeText(value);
+  const allowed = PUBLIC_ACTIVITY_TEXT_ENUMS[key];
+  return text && allowed?.has(text) ? text : null;
+}
+
+export function normaliseReadModelKey(value, fallback = LEARNER_SUMMARY_MODEL_KEY) {
+  const text = String(value || '').trim();
+  return text || fallback;
+}
+
+export function emptyLearnerReadModel(modelKey = LEARNER_SUMMARY_MODEL_KEY) {
+  return {
+    modelKey: normaliseReadModelKey(modelKey),
+    model: {},
+    sourceRevision: 0,
+    generatedAt: 0,
+    updatedAt: 0,
+    missing: true,
+  };
+}
+
+export function normaliseLearnerReadModelRow(row, modelKey = LEARNER_SUMMARY_MODEL_KEY) {
+  if (!row) return emptyLearnerReadModel(modelKey);
+  const parsed = safeJsonParse(row.model_json, {});
+  return {
+    learnerId: row.learner_id || '',
+    modelKey: normaliseReadModelKey(row.model_key, modelKey),
+    model: isPlainObject(parsed) ? parsed : {},
+    sourceRevision: Math.max(0, Number(row.source_revision) || 0),
+    generatedAt: Math.max(0, Number(row.generated_at) || 0),
+    updatedAt: Math.max(0, Number(row.updated_at) || 0),
+    missing: false,
+  };
+}
+
+export function publicActivityFromEventRow(row) {
+  const parsed = safeJsonParse(row?.event_json, {});
+  if (!isPlainObject(parsed)) return null;
+  const type = safeText(parsed.type) || safeText(row?.event_type);
+  if (!PUBLIC_ACTIVITY_TYPES.has(type)) return null;
+
+  const output = {
+    type,
+    learnerId: safeText(parsed.learnerId) || safeText(row?.learner_id),
+    subjectId: parsed.subjectId === 'spelling' || row?.subject_id === 'spelling' ? 'spelling' : null,
+    createdAt: safeNumber(parsed.createdAt) ?? safeNumber(row?.created_at) ?? 0,
+  };
+
+  [
+    'mode',
+    'sessionType',
+    'kind',
+    'monsterId',
+    'spellingPool',
+    'yearBand',
+    'fromPhase',
+  ].forEach((key) => {
+    const value = safeEnum(key, parsed[key]);
+    if (value) output[key] = value;
+  });
+
+  [
+    'totalWords',
+    'mistakeCount',
+    'milestone',
+    'secureCount',
+    'stage',
+    'attemptCount',
+    'streakDays',
+  ].forEach((key) => {
+    const value = safeNumber(parsed[key]);
+    if (value != null) output[key] = value;
+  });
+
+  return output;
+}
+
+export function activityFeedRowFromEventRow(row, { now = Date.now() } = {}) {
+  const activity = publicActivityFromEventRow(row);
+  if (!activity) return null;
+  const sourceEventId = safeText(row?.id);
+  const createdAt = safeNumber(row?.created_at) ?? safeNumber(activity.createdAt) ?? now;
+  return {
+    id: sourceEventId ? `event:${sourceEventId}` : `activity:${activity.type}:${activity.learnerId}:${createdAt}`,
+    learnerId: activity.learnerId || safeText(row?.learner_id) || '',
+    subjectId: activity.subjectId || safeText(row?.subject_id) || null,
+    activityType: activity.type,
+    activity,
+    sourceEventId,
+    createdAt,
+    updatedAt: now,
+  };
+}
+
+export function normaliseActivityFeedRow(row) {
+  if (!row) return null;
+  const activity = safeJsonParse(row.activity_json, {});
+  if (!isPlainObject(activity)) return null;
+  return {
+    id: row.id || '',
+    learnerId: row.learner_id || activity.learnerId || null,
+    subjectId: row.subject_id || activity.subjectId || null,
+    activityType: row.activity_type || activity.type || 'activity',
+    activity: cloneSerialisable(activity),
+    sourceEventId: row.source_event_id || null,
+    createdAt: Math.max(0, Number(row.created_at) || Number(activity.createdAt) || 0),
+    updatedAt: Math.max(0, Number(row.updated_at) || 0),
+  };
+}

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -1137,6 +1137,187 @@ async function loadLearnerReadBundle(db, learnerId) {
   };
 }
 
+function normaliseHistoryLimit(value, { fallback = 10, max = 50 } = {}) {
+  if (value == null || value === '') return fallback;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new BadRequestError('History limit must be a positive integer.', {
+      code: 'history_limit_invalid',
+      limit: value,
+    });
+  }
+  return Math.min(parsed, max);
+}
+
+function encodeHistoryCursor(row, timestampField) {
+  const timestamp = Number(row?.[timestampField]) || 0;
+  const id = encodeURIComponent(String(row?.id || ''));
+  return `${timestamp}:${id}`;
+}
+
+function decodeHistoryCursor(rawCursor) {
+  if (!rawCursor) return null;
+  const separator = String(rawCursor).indexOf(':');
+  if (separator <= 0) {
+    throw new BadRequestError('History cursor is invalid.', {
+      code: 'history_cursor_invalid',
+    });
+  }
+  const timestamp = Number(String(rawCursor).slice(0, separator));
+  const id = decodeURIComponent(String(rawCursor).slice(separator + 1));
+  if (!Number.isFinite(timestamp) || timestamp < 0 || !id) {
+    throw new BadRequestError('History cursor is invalid.', {
+      code: 'history_cursor_invalid',
+    });
+  }
+  return { timestamp, id };
+}
+
+function pageFromRows(rows, limit, timestampField) {
+  const pageRows = rows.slice(0, limit);
+  const hasMore = rows.length > limit;
+  return {
+    rows: pageRows,
+    page: {
+      limit,
+      nextCursor: hasMore && pageRows.length
+        ? encodeHistoryCursor(pageRows[pageRows.length - 1], timestampField)
+        : null,
+      hasMore,
+    },
+  };
+}
+
+function publicHistoryPracticeSessionRowToRecord(row) {
+  return normalisePracticeSessionRecord({
+    ...publicPracticeSessionRowToRecord(row),
+    sessionState: null,
+  });
+}
+
+function recentSessionLabel(record) {
+  if (record?.summary?.label) return record.summary.label;
+  if (record?.subjectId === 'grammar') return `Grammar ${record.sessionKind || 'practice'}`;
+  if (record?.subjectId === 'punctuation') return `Punctuation ${record.sessionKind || 'practice'}`;
+  if (record?.sessionKind === 'test') return 'SATs 20 test';
+  return 'Smart Review';
+}
+
+function recentSessionHeadline(record) {
+  const summary = record?.summary || {};
+  const cards = Array.isArray(summary.cards) ? summary.cards : [];
+  const correctCard = cards.find((card) => String(card?.label || '').toLowerCase().includes('correct'));
+  if (correctCard?.value != null) return String(correctCard.value);
+  const answered = Number(summary.answered);
+  const correct = Number(summary.correct);
+  if (Number.isFinite(answered) && answered > 0 && Number.isFinite(correct)) {
+    return `${correct}/${answered}`;
+  }
+  return '';
+}
+
+function parentRecentSessionFromRecord(record) {
+  return {
+    id: record.id,
+    subjectId: record.subjectId,
+    status: record.status,
+    sessionKind: record.sessionKind,
+    label: recentSessionLabel(record),
+    updatedAt: Number(record.updatedAt) || Number(record.createdAt) || 0,
+    mistakeCount: Array.isArray(record?.summary?.mistakes)
+      ? record.summary.mistakes.length
+      : Math.max(0, (Number(record?.summary?.answered) || 0) - (Number(record?.summary?.correct) || 0)),
+    headline: recentSessionHeadline(record),
+  };
+}
+
+async function resolveParentHistoryAccess(db, accountId, requestedLearnerId = null) {
+  const account = await first(db, 'SELECT id, selected_learner_id, repo_revision, platform_role, account_type FROM adult_accounts WHERE id = ?', [accountId]);
+  const readableMemberships = await listMembershipRows(db, accountId, { writableOnly: false });
+  const defaultLearnerId = account?.selected_learner_id && readableMemberships.some((membership) => membership.id === account.selected_learner_id)
+    ? account.selected_learner_id
+    : (readableMemberships[0]?.id || null);
+  const learnerId = requestedLearnerId || defaultLearnerId;
+  if (!learnerId) {
+    throw new NotFoundError('No learner is selected for this parent view.', {
+      code: 'parent_hub_missing_learner',
+    });
+  }
+  const membership = await requireLearnerReadAccess(db, accountId, learnerId);
+  requireParentHubAccess(account, membership);
+  return {
+    account,
+    readableMemberships,
+    learnerId,
+    membership,
+  };
+}
+
+async function readParentRecentSessions(db, accountId, {
+  learnerId = null,
+  limit = null,
+  cursor = null,
+} = {}) {
+  const access = await resolveParentHistoryAccess(db, accountId, learnerId);
+  const resolvedLimit = normaliseHistoryLimit(limit);
+  const decodedCursor = decodeHistoryCursor(cursor);
+  const cursorClause = decodedCursor
+    ? 'AND (updated_at < ? OR (updated_at = ? AND id < ?))'
+    : '';
+  const cursorParams = decodedCursor
+    ? [decodedCursor.timestamp, decodedCursor.timestamp, decodedCursor.id]
+    : [];
+  const rows = await all(db, `
+    SELECT id, learner_id, subject_id, session_kind, status, session_state_json, summary_json, created_at, updated_at
+    FROM practice_sessions
+    WHERE learner_id = ?
+      ${cursorClause}
+    ORDER BY updated_at DESC, id DESC
+    LIMIT ?
+  `, [access.learnerId, ...cursorParams, resolvedLimit + 1]);
+  const page = pageFromRows(rows, resolvedLimit, 'updated_at');
+  const sessions = page.rows.map(publicHistoryPracticeSessionRowToRecord);
+  return {
+    learnerId: access.learnerId,
+    sessions,
+    recentSessions: sessions.map(parentRecentSessionFromRecord),
+    page: page.page,
+  };
+}
+
+async function readParentActivity(db, accountId, {
+  learnerId = null,
+  limit = null,
+  cursor = null,
+} = {}) {
+  const access = await resolveParentHistoryAccess(db, accountId, learnerId);
+  const resolvedLimit = normaliseHistoryLimit(limit);
+  const decodedCursor = decodeHistoryCursor(cursor);
+  const eventTypes = [...PUBLIC_EVENT_TYPES];
+  const eventTypePlaceholders = sqlPlaceholders(eventTypes.length);
+  const cursorClause = decodedCursor
+    ? 'AND (created_at < ? OR (created_at = ? AND id < ?))'
+    : '';
+  const cursorParams = decodedCursor
+    ? [decodedCursor.timestamp, decodedCursor.timestamp, decodedCursor.id]
+    : [];
+  const rows = await all(db, `
+    SELECT id, learner_id, subject_id, system_id, event_type, event_json, created_at
+    FROM event_log
+    WHERE learner_id = ?
+      AND event_type IN (${eventTypePlaceholders})
+      ${cursorClause}
+    ORDER BY created_at DESC, id DESC
+    LIMIT ?
+  `, [access.learnerId, ...eventTypes, ...cursorParams, resolvedLimit + 1]);
+  const page = pageFromRows(rows, resolvedLimit, 'created_at');
+  return {
+    learnerId: access.learnerId,
+    activity: page.rows.map(publicEventRowToRecord).filter(Boolean),
+    page: page.page,
+  };
+}
+
 async function listMutationReceiptRows(db, accountId, { requestId = null, scopeId = null, limit = 20 } = {}) {
   const clauses = ['account_id = ?'];
   const params = [accountId];
@@ -3392,6 +3573,12 @@ export function createWorkerRepository({ env = {}, now = Date.now } = {}) {
     async readSpellingWordBank(accountId, learnerId, filters = {}) {
       return readSpellingWordBankBundle(db, accountId, learnerId, filters, nowFactory());
     },
+    async readParentRecentSessions(accountId, options = {}) {
+      return readParentRecentSessions(db, accountId, options);
+    },
+    async readParentActivity(accountId, options = {}) {
+      return readParentActivity(db, accountId, options);
+    },
     async writeSubjectContent(accountId, subjectId = 'spelling', rawContent, mutation = {}) {
       const nowTs = nowFactory();
       const account = await first(db, 'SELECT id, platform_role FROM adult_accounts WHERE id = ?', [accountId]);
@@ -3450,19 +3637,12 @@ export function createWorkerRepository({ env = {}, now = Date.now } = {}) {
       });
     },
     async readParentHub(accountId, learnerId = null) {
-      const account = await first(db, 'SELECT id, selected_learner_id, repo_revision, platform_role, account_type FROM adult_accounts WHERE id = ?', [accountId]);
-      const readableMemberships = await listMembershipRows(db, accountId, { writableOnly: false });
-      const defaultLearnerId = account?.selected_learner_id && readableMemberships.some((membership) => membership.id === account.selected_learner_id)
-        ? account.selected_learner_id
-        : (readableMemberships[0]?.id || null);
-      const resolvedLearnerId = learnerId || defaultLearnerId;
-      if (!resolvedLearnerId) {
-        throw new NotFoundError('No learner is selected for this parent view.', {
-          code: 'parent_hub_missing_learner',
-        });
-      }
-      const membership = await requireLearnerReadAccess(db, accountId, resolvedLearnerId);
-      requireParentHubAccess(account, membership);
+      const {
+        account,
+        readableMemberships,
+        learnerId: resolvedLearnerId,
+        membership,
+      } = await resolveParentHistoryAccess(db, accountId, learnerId);
       const learnerRow = await first(db, `
         SELECT l.id, l.name, l.year_group, l.avatar_color, l.goal, l.daily_minutes, l.created_at, l.updated_at
         FROM learner_profiles l

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -83,6 +83,9 @@ const PUBLIC_EVENT_TYPES = new Set([
   'reward.monster',
   'platform.practice-streak-hit',
 ]);
+const PUBLIC_BOOTSTRAP_RECENT_SESSION_LIMIT_PER_LEARNER = 5;
+const PUBLIC_BOOTSTRAP_RECENT_EVENT_LIMIT_PER_LEARNER = 50;
+const PUBLIC_BOOTSTRAP_CAPACITY_VERSION = 1;
 const PUBLIC_MONSTER_CODEX_SYSTEM_ID = 'monster-codex';
 const PUBLIC_MONSTER_IDS = new Set(['inklet', 'glimmerbug', 'phaeton', 'vellhorn']);
 const PUBLIC_DIRECT_SPELLING_MONSTER_IDS = ['inklet', 'glimmerbug', 'vellhorn'];
@@ -2050,6 +2053,111 @@ async function releaseMembershipOrDeleteLearner(db, accountId, learnerId, role, 
   return 'membership_removed';
 }
 
+function rowKey(row, fields = ['id']) {
+  return fields.map((field) => String(row?.[field] ?? '')).join('::');
+}
+
+function sortSessionRows(rows) {
+  return [...rows].sort((a, b) => {
+    const updatedDiff = (Number(b.updated_at) || 0) - (Number(a.updated_at) || 0);
+    if (updatedDiff !== 0) return updatedDiff;
+    return String(b.id || '').localeCompare(String(a.id || ''));
+  });
+}
+
+function sortEventRowsAscending(rows) {
+  return [...rows].sort((a, b) => {
+    const createdDiff = (Number(a.created_at) || 0) - (Number(b.created_at) || 0);
+    if (createdDiff !== 0) return createdDiff;
+    return String(a.id || '').localeCompare(String(b.id || ''));
+  });
+}
+
+async function listPublicBootstrapSessionRows(db, learnerIds) {
+  if (!learnerIds.length) return [];
+  const rowsById = new Map();
+  const placeholders = sqlPlaceholders(learnerIds.length);
+  const activeRows = await all(db, `
+    SELECT id, learner_id, subject_id, session_kind, status, session_state_json, summary_json, created_at, updated_at
+    FROM practice_sessions
+    WHERE learner_id IN (${placeholders})
+      AND status = 'active'
+    ORDER BY updated_at DESC, id DESC
+  `, learnerIds);
+
+  for (const row of activeRows) {
+    rowsById.set(rowKey(row), row);
+  }
+
+  for (const learnerId of learnerIds) {
+    const recentRows = await all(db, `
+      SELECT id, learner_id, subject_id, session_kind, status, session_state_json, summary_json, created_at, updated_at
+      FROM practice_sessions
+      WHERE learner_id = ?
+      ORDER BY updated_at DESC, id DESC
+      LIMIT ?
+    `, [learnerId, PUBLIC_BOOTSTRAP_RECENT_SESSION_LIMIT_PER_LEARNER]);
+    for (const row of recentRows) {
+      rowsById.set(rowKey(row), row);
+    }
+  }
+
+  return sortSessionRows([...rowsById.values()]);
+}
+
+async function listPublicBootstrapEventRows(db, learnerIds) {
+  if (!learnerIds.length) return [];
+  const eventTypes = [...PUBLIC_EVENT_TYPES];
+  if (!eventTypes.length) return [];
+  const eventTypePlaceholders = sqlPlaceholders(eventTypes.length);
+  const rows = [];
+
+  for (const learnerId of learnerIds) {
+    rows.push(...await all(db, `
+      SELECT id, learner_id, subject_id, system_id, event_type, event_json, created_at
+      FROM event_log
+      WHERE learner_id = ?
+        AND event_type IN (${eventTypePlaceholders})
+      ORDER BY created_at DESC, id DESC
+      LIMIT ?
+    `, [learnerId, ...eventTypes, PUBLIC_BOOTSTRAP_RECENT_EVENT_LIMIT_PER_LEARNER]));
+  }
+
+  return sortEventRowsAscending(rows);
+}
+
+function bootstrapCapacityMeta({
+  publicReadModels,
+  learnerCount,
+  sessionRows,
+  eventRows,
+}) {
+  if (!publicReadModels) return null;
+  const sessionRecentLimit = learnerCount * PUBLIC_BOOTSTRAP_RECENT_SESSION_LIMIT_PER_LEARNER;
+  const eventRecentLimit = learnerCount * PUBLIC_BOOTSTRAP_RECENT_EVENT_LIMIT_PER_LEARNER;
+  return {
+    version: PUBLIC_BOOTSTRAP_CAPACITY_VERSION,
+    mode: 'public-bounded',
+    limits: {
+      recentSessionsPerLearner: PUBLIC_BOOTSTRAP_RECENT_SESSION_LIMIT_PER_LEARNER,
+      recentEventsPerLearner: PUBLIC_BOOTSTRAP_RECENT_EVENT_LIMIT_PER_LEARNER,
+    },
+    learners: {
+      returned: learnerCount,
+    },
+    practiceSessions: {
+      returned: sessionRows.length,
+      bounded: true,
+      atOrAboveRecentLimit: learnerCount > 0 && sessionRows.length >= sessionRecentLimit,
+    },
+    eventLog: {
+      returned: eventRows.length,
+      bounded: true,
+      atOrAboveRecentLimit: learnerCount > 0 && eventRows.length >= eventRecentLimit,
+    },
+  };
+}
+
 async function bootstrapBundle(db, accountId, { publicReadModels = false } = {}) {
   const account = await first(db, 'SELECT * FROM adult_accounts WHERE id = ?', [accountId]);
   const monsterVisualConfig = await readBootstrapMonsterVisualRuntimeConfig(db, Date.now());
@@ -2090,6 +2198,14 @@ async function bootstrapBundle(db, accountId, { publicReadModels = false } = {})
         learnerRevisions: {},
       },
       monsterVisualConfig,
+      ...(publicReadModels ? {
+        bootstrapCapacity: bootstrapCapacityMeta({
+          publicReadModels,
+          learnerCount: 0,
+          sessionRows: [],
+          eventRows: [],
+        }),
+      } : {}),
     };
   }
 
@@ -2099,23 +2215,27 @@ async function bootstrapBundle(db, accountId, { publicReadModels = false } = {})
     FROM child_subject_state
     WHERE learner_id IN (${placeholders})
   `, learnerIds);
-  const sessionRows = await all(db, `
-    SELECT id, learner_id, subject_id, session_kind, status, session_state_json, summary_json, created_at, updated_at
-    FROM practice_sessions
-    WHERE learner_id IN (${placeholders})
-    ORDER BY updated_at DESC, id DESC
-  `, learnerIds);
+  const sessionRows = publicReadModels
+    ? await listPublicBootstrapSessionRows(db, learnerIds)
+    : await all(db, `
+      SELECT id, learner_id, subject_id, session_kind, status, session_state_json, summary_json, created_at, updated_at
+      FROM practice_sessions
+      WHERE learner_id IN (${placeholders})
+      ORDER BY updated_at DESC, id DESC
+    `, learnerIds);
   const gameRows = await all(db, `
     SELECT learner_id, system_id, state_json, updated_at
     FROM child_game_state
     WHERE learner_id IN (${placeholders})
   `, learnerIds);
-  const eventRows = await all(db, `
-    SELECT id, learner_id, subject_id, system_id, event_type, event_json, created_at
-    FROM event_log
-    WHERE learner_id IN (${placeholders})
-    ORDER BY created_at ASC, id ASC
-  `, learnerIds);
+  const eventRows = publicReadModels
+    ? await listPublicBootstrapEventRows(db, learnerIds)
+    : await all(db, `
+      SELECT id, learner_id, subject_id, system_id, event_type, event_json, created_at
+      FROM event_log
+      WHERE learner_id IN (${placeholders})
+      ORDER BY created_at ASC, id ASC
+    `, learnerIds);
   const publicSpellingContent = publicReadModels && subjectRows.some((row) => row.subject_id === 'spelling')
     ? await readSpellingRuntimeContentBundle(db, accountId, 'spelling')
     : null;
@@ -2166,6 +2286,14 @@ async function bootstrapBundle(db, accountId, { publicReadModels = false } = {})
       learnerRevisions,
     },
     monsterVisualConfig,
+    ...(publicReadModels ? {
+      bootstrapCapacity: bootstrapCapacityMeta({
+        publicReadModels,
+        learnerCount: learnerIds.length,
+        sessionRows,
+        eventRows,
+      }),
+    } : {}),
   };
 }
 

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -32,6 +32,12 @@ import { buildAdminHubReadModel } from '../../src/platform/hubs/admin-read-model
 import { buildParentHubReadModel } from '../../src/platform/hubs/parent-read-model.js';
 import { monsterIdForSpellingWord } from '../../src/platform/game/monster-system.js';
 import { buildSpellingProgressPools, buildSpellingWordBankReadModel } from './content/spelling-read-models.js';
+import {
+  emptyLearnerReadModel,
+  normaliseActivityFeedRow,
+  normaliseLearnerReadModelRow,
+  normaliseReadModelKey,
+} from './read-models/learner-read-models.js';
 import { buildSpellingAudioCue } from './subjects/spelling/audio.js';
 import { buildPunctuationReadModel } from './subjects/punctuation/read-models.js';
 import { createPunctuationService } from '../../shared/punctuation/service.js';
@@ -1285,6 +1291,106 @@ async function readParentRecentSessions(db, accountId, {
   };
 }
 
+async function upsertLearnerReadModel(db, learnerId, modelKey, model, {
+  sourceRevision = 0,
+  generatedAt = Date.now(),
+} = {}) {
+  const key = normaliseReadModelKey(modelKey);
+  const timestamp = Math.max(0, Number(generatedAt) || Date.now());
+  await run(db, `
+    INSERT INTO learner_read_models (learner_id, model_key, model_json, source_revision, generated_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?)
+    ON CONFLICT(learner_id, model_key) DO UPDATE SET
+      model_json = excluded.model_json,
+      source_revision = excluded.source_revision,
+      generated_at = excluded.generated_at,
+      updated_at = excluded.updated_at
+  `, [
+    learnerId,
+    key,
+    JSON.stringify(cloneSerialisable(model) || {}),
+    Math.max(0, Number(sourceRevision) || 0),
+    timestamp,
+    timestamp,
+  ]);
+  return readLearnerReadModel(db, learnerId, key);
+}
+
+async function readLearnerReadModel(db, learnerId, modelKey) {
+  const key = normaliseReadModelKey(modelKey);
+  const row = await first(db, `
+    SELECT learner_id, model_key, model_json, source_revision, generated_at, updated_at
+    FROM learner_read_models
+    WHERE learner_id = ? AND model_key = ?
+  `, [learnerId, key]);
+  return row ? normaliseLearnerReadModelRow(row, key) : emptyLearnerReadModel(key);
+}
+
+async function upsertLearnerActivityFeedRows(db, activityRows = []) {
+  let written = 0;
+  for (const row of activityRows) {
+    if (!row?.id || !row?.learnerId || !row?.activityType || !row?.activity) continue;
+    const result = await run(db, `
+      INSERT INTO learner_activity_feed (
+        id, learner_id, subject_id, activity_type, activity_json,
+        source_event_id, created_at, updated_at
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(id) DO UPDATE SET
+        learner_id = excluded.learner_id,
+        subject_id = excluded.subject_id,
+        activity_type = excluded.activity_type,
+        activity_json = excluded.activity_json,
+        source_event_id = excluded.source_event_id,
+        created_at = excluded.created_at,
+        updated_at = excluded.updated_at
+    `, [
+      row.id,
+      row.learnerId,
+      row.subjectId || null,
+      row.activityType,
+      JSON.stringify(cloneSerialisable(row.activity) || {}),
+      row.sourceEventId || null,
+      Math.max(0, Number(row.createdAt) || 0),
+      Math.max(0, Number(row.updatedAt) || Date.now()),
+    ]);
+    written += Math.max(0, Number(result?.meta?.rows_written ?? result?.meta?.changes) || 0);
+  }
+  return { count: written };
+}
+
+async function readLearnerActivityFeed(db, learnerId, {
+  limit = null,
+  cursor = null,
+} = {}) {
+  const resolvedLimit = normaliseHistoryLimit(limit);
+  const decodedCursor = decodeHistoryCursor(cursor);
+  const cursorClause = decodedCursor
+    ? 'AND (created_at < ? OR (created_at = ? AND id < ?))'
+    : '';
+  const cursorParams = decodedCursor
+    ? [decodedCursor.timestamp, decodedCursor.timestamp, decodedCursor.id]
+    : [];
+  const rows = await all(db, `
+    SELECT id, learner_id, subject_id, activity_type, activity_json, source_event_id, created_at, updated_at
+    FROM learner_activity_feed
+    WHERE learner_id = ?
+      ${cursorClause}
+    ORDER BY created_at DESC, id DESC
+    LIMIT ?
+  `, [learnerId, ...cursorParams, resolvedLimit + 1]);
+  const page = pageFromRows(rows, resolvedLimit, 'created_at');
+  const feedRowCount = rows.length
+    ? rows.length
+    : Number(await scalar(db, 'SELECT COUNT(*) AS count FROM learner_activity_feed WHERE learner_id = ?', [learnerId], 'count') || 0);
+  return {
+    learnerId,
+    activities: page.rows.map(normaliseActivityFeedRow).filter(Boolean),
+    page: page.page,
+    hasFeedRows: feedRowCount > 0,
+  };
+}
+
 async function readParentActivity(db, accountId, {
   learnerId = null,
   limit = null,
@@ -1292,6 +1398,19 @@ async function readParentActivity(db, accountId, {
 } = {}) {
   const access = await resolveParentHistoryAccess(db, accountId, learnerId);
   const resolvedLimit = normaliseHistoryLimit(limit);
+  const feed = await readLearnerActivityFeed(db, access.learnerId, {
+    limit: resolvedLimit,
+    cursor,
+  });
+  if (feed.hasFeedRows) {
+    return {
+      learnerId: access.learnerId,
+      activity: feed.activities.map((entry) => entry.activity),
+      page: feed.page,
+      source: 'learner_activity_feed',
+    };
+  }
+
   const decodedCursor = decodeHistoryCursor(cursor);
   const eventTypes = [...PUBLIC_EVENT_TYPES];
   const eventTypePlaceholders = sqlPlaceholders(eventTypes.length);
@@ -1315,6 +1434,7 @@ async function readParentActivity(db, accountId, {
     learnerId: access.learnerId,
     activity: page.rows.map(publicEventRowToRecord).filter(Boolean),
     page: page.page,
+    source: 'event_log',
   };
 }
 
@@ -3578,6 +3698,18 @@ export function createWorkerRepository({ env = {}, now = Date.now } = {}) {
     },
     async readParentActivity(accountId, options = {}) {
       return readParentActivity(db, accountId, options);
+    },
+    async upsertLearnerReadModel(learnerId, modelKey, model, options = {}) {
+      return upsertLearnerReadModel(db, learnerId, modelKey, model, options);
+    },
+    async readLearnerReadModel(learnerId, modelKey) {
+      return readLearnerReadModel(db, learnerId, modelKey);
+    },
+    async upsertLearnerActivityFeedRows(rows = []) {
+      return upsertLearnerActivityFeedRows(db, rows);
+    },
+    async readLearnerActivityFeed(learnerId, options = {}) {
+      return readLearnerActivityFeed(db, learnerId, options);
     },
     async writeSubjectContent(accountId, subjectId = 'spelling', rawContent, mutation = {}) {
       const nowTs = nowFactory();

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -33,6 +33,7 @@ import { buildParentHubReadModel } from '../../src/platform/hubs/parent-read-mod
 import { monsterIdForSpellingWord } from '../../src/platform/game/monster-system.js';
 import { buildSpellingProgressPools, buildSpellingWordBankReadModel } from './content/spelling-read-models.js';
 import {
+  activityFeedRowFromEventRow,
   emptyLearnerReadModel,
   normaliseActivityFeedRow,
   normaliseLearnerReadModelRow,
@@ -90,6 +91,8 @@ const PUBLIC_EVENT_TYPES = new Set([
   'platform.practice-streak-hit',
 ]);
 const PUBLIC_BOOTSTRAP_RECENT_SESSION_LIMIT_PER_LEARNER = 5;
+const PUBLIC_BOOTSTRAP_ACTIVE_SESSION_LIMIT_PER_LEARNER = 1;
+const PUBLIC_BOOTSTRAP_ACTIVE_SESSION_LOOKUP_LIMIT_PER_LEARNER = 5;
 const PUBLIC_BOOTSTRAP_RECENT_EVENT_LIMIT_PER_LEARNER = 50;
 const PUBLIC_BOOTSTRAP_CAPACITY_VERSION = 1;
 const PUBLIC_MONSTER_CODEX_SYSTEM_ID = 'monster-codex';
@@ -1359,6 +1362,56 @@ async function upsertLearnerActivityFeedRows(db, activityRows = []) {
   return { count: written };
 }
 
+function activityFeedRowFromEventRecord(event, {
+  id,
+  learnerId,
+  subjectId = null,
+  systemId = null,
+  eventType,
+  createdAt,
+  now = Date.now(),
+} = {}) {
+  if (!event || typeof event !== 'object' || Array.isArray(event)) return null;
+  return activityFeedRowFromEventRow({
+    id,
+    learner_id: learnerId,
+    subject_id: subjectId,
+    system_id: systemId,
+    event_type: eventType,
+    event_json: JSON.stringify(event),
+    created_at: createdAt,
+  }, { now });
+}
+
+function bindLearnerActivityFeedUpsertStatement(db, row, { guard = null } = {}) {
+  if (!row?.id || !row?.learnerId || !row?.activityType || !row?.activity) return null;
+  const params = [
+    row.id,
+    row.learnerId,
+    row.subjectId || null,
+    row.activityType,
+    JSON.stringify(cloneSerialisable(row.activity) || {}),
+    row.sourceEventId || null,
+    Math.max(0, Number(row.createdAt) || 0),
+    Math.max(0, Number(row.updatedAt) || Date.now()),
+  ];
+  return bindStatement(db, `
+    INSERT INTO learner_activity_feed (
+      id, learner_id, subject_id, activity_type, activity_json,
+      source_event_id, created_at, updated_at
+    )
+    ${guardedValueSource(params.length, guard)}
+    ON CONFLICT(id) DO UPDATE SET
+      learner_id = excluded.learner_id,
+      subject_id = excluded.subject_id,
+      activity_type = excluded.activity_type,
+      activity_json = excluded.activity_json,
+      source_event_id = excluded.source_event_id,
+      created_at = excluded.created_at,
+      updated_at = excluded.updated_at
+  `, guardedParams(params, guard));
+}
+
 async function readLearnerActivityFeed(db, learnerId, {
   limit = null,
   cursor = null,
@@ -2374,20 +2427,57 @@ function sortEventRowsAscending(rows) {
   });
 }
 
+function subjectStateActiveSessionId(row) {
+  const ui = safeJsonParse(row?.ui_json, {});
+  const sessionId = ui?.session?.id;
+  return typeof sessionId === 'string' && sessionId ? sessionId : null;
+}
+
+async function listPublicBootstrapActiveSessionIds(db, learnerIds) {
+  const ids = [];
+  for (const learnerId of learnerIds) {
+    const rows = await all(db, `
+      SELECT ui_json
+      FROM child_subject_state
+      WHERE learner_id = ?
+      ORDER BY updated_at DESC, subject_id ASC
+      LIMIT ?
+    `, [learnerId, PUBLIC_BOOTSTRAP_ACTIVE_SESSION_LOOKUP_LIMIT_PER_LEARNER]);
+    const sessionIdsForLearner = new Set();
+    for (const row of rows) {
+      const sessionId = subjectStateActiveSessionId(row);
+      if (!sessionId || sessionIdsForLearner.has(sessionId)) continue;
+      sessionIdsForLearner.add(sessionId);
+      ids.push(sessionId);
+      if (sessionIdsForLearner.size >= PUBLIC_BOOTSTRAP_ACTIVE_SESSION_LIMIT_PER_LEARNER) break;
+    }
+  }
+  return ids;
+}
+
 async function listPublicBootstrapSessionRows(db, learnerIds) {
   if (!learnerIds.length) return [];
   const rowsById = new Map();
   const placeholders = sqlPlaceholders(learnerIds.length);
-  const activeRows = await all(db, `
-    SELECT id, learner_id, subject_id, session_kind, status, session_state_json, summary_json, created_at, updated_at
-    FROM practice_sessions
-    WHERE learner_id IN (${placeholders})
-      AND status = 'active'
-    ORDER BY updated_at DESC, id DESC
-  `, learnerIds);
+  const activeSessionIds = await listPublicBootstrapActiveSessionIds(db, learnerIds);
+  if (activeSessionIds.length) {
+    const activeRows = await all(db, `
+      SELECT id, learner_id, subject_id, session_kind, status, session_state_json, summary_json, created_at, updated_at
+      FROM practice_sessions
+      WHERE learner_id IN (${placeholders})
+        AND id IN (${sqlPlaceholders(activeSessionIds.length)})
+        AND status = 'active'
+      ORDER BY updated_at DESC, id DESC
+      LIMIT ?
+    `, [
+      ...learnerIds,
+      ...activeSessionIds,
+      learnerIds.length * PUBLIC_BOOTSTRAP_ACTIVE_SESSION_LIMIT_PER_LEARNER,
+    ]);
 
-  for (const row of activeRows) {
-    rowsById.set(rowKey(row), row);
+    for (const row of activeRows) {
+      rowsById.set(rowKey(row), row);
+    }
   }
 
   for (const learnerId of learnerIds) {
@@ -2434,12 +2524,15 @@ function bootstrapCapacityMeta({
   eventRows,
 }) {
   if (!publicReadModels) return null;
+  const sessionActiveLimit = learnerCount * PUBLIC_BOOTSTRAP_ACTIVE_SESSION_LIMIT_PER_LEARNER;
   const sessionRecentLimit = learnerCount * PUBLIC_BOOTSTRAP_RECENT_SESSION_LIMIT_PER_LEARNER;
+  const sessionLimit = sessionActiveLimit + sessionRecentLimit;
   const eventRecentLimit = learnerCount * PUBLIC_BOOTSTRAP_RECENT_EVENT_LIMIT_PER_LEARNER;
   return {
     version: PUBLIC_BOOTSTRAP_CAPACITY_VERSION,
     mode: 'public-bounded',
     limits: {
+      activeSessionsPerLearner: PUBLIC_BOOTSTRAP_ACTIVE_SESSION_LIMIT_PER_LEARNER,
       recentSessionsPerLearner: PUBLIC_BOOTSTRAP_RECENT_SESSION_LIMIT_PER_LEARNER,
       recentEventsPerLearner: PUBLIC_BOOTSTRAP_RECENT_EVENT_LIMIT_PER_LEARNER,
     },
@@ -2450,6 +2543,7 @@ function bootstrapCapacityMeta({
       returned: sessionRows.length,
       bounded: true,
       atOrAboveRecentLimit: learnerCount > 0 && sessionRows.length >= sessionRecentLimit,
+      atOrAboveMaximumLimit: learnerCount > 0 && sessionRows.length >= sessionLimit,
     },
     eventLog: {
       returned: eventRows.length,
@@ -2864,6 +2958,17 @@ function buildSubjectRuntimePersistencePlan(db, accountId, learnerId, subjectId,
         created_at = excluded.created_at,
         actor_account_id = excluded.actor_account_id
     `, guardedParams(eventParams, guard)));
+    const activityRow = activityFeedRowFromEventRecord(event, {
+      id,
+      learnerId: event.learnerId,
+      subjectId: event.subjectId || null,
+      systemId: event.systemId || null,
+      eventType,
+      createdAt,
+      now: nowTs,
+    });
+    const activityStatement = bindLearnerActivityFeedUpsertStatement(db, activityRow, { guard });
+    if (activityStatement) statements.push(activityStatement);
   }
 
   const summary = {
@@ -3614,6 +3719,16 @@ export function createWorkerRepository({ env = {}, now = Date.now } = {}) {
             createdAt,
             accountId,
           ]);
+          const activityRow = activityFeedRowFromEventRecord(next, {
+            id,
+            learnerId: next.learnerId,
+            subjectId: next.subjectId || null,
+            systemId: next.systemId || null,
+            eventType,
+            createdAt,
+            now: nowTs,
+          });
+          if (activityRow) await upsertLearnerActivityFeedRows(db, [activityRow]);
           return { count: next ? 1 : 0, event: next };
         },
       });
@@ -3628,7 +3743,11 @@ export function createWorkerRepository({ env = {}, now = Date.now } = {}) {
         mutation,
         nowTs,
         apply: async () => {
-          await run(db, 'DELETE FROM event_log WHERE learner_id = ?', [learnerId]);
+          await batch(db, [
+            bindStatement(db, 'DELETE FROM event_log WHERE learner_id = ?', [learnerId]),
+            bindStatement(db, 'DELETE FROM learner_activity_feed WHERE learner_id = ?', [learnerId]),
+            bindStatement(db, 'DELETE FROM learner_read_models WHERE learner_id = ?', [learnerId]),
+          ]);
           return { learnerId, cleared: true };
         },
       });
@@ -3648,6 +3767,8 @@ export function createWorkerRepository({ env = {}, now = Date.now } = {}) {
             bindStatement(db, 'DELETE FROM practice_sessions WHERE learner_id = ?', [learnerId]),
             bindStatement(db, 'DELETE FROM child_game_state WHERE learner_id = ?', [learnerId]),
             bindStatement(db, 'DELETE FROM event_log WHERE learner_id = ?', [learnerId]),
+            bindStatement(db, 'DELETE FROM learner_activity_feed WHERE learner_id = ?', [learnerId]),
+            bindStatement(db, 'DELETE FROM learner_read_models WHERE learner_id = ?', [learnerId]),
           ]);
           return {
             learnerId,


### PR DESCRIPTION
## Summary
- Bound production public bootstrap history payloads and add a production bootstrap probe.
- Add lazy parent history APIs for recent sessions and activity feeds.
- Add learner read-model/activity-feed schema, repository helpers, and an idempotent local backfill script.
- Fix review blockers by projecting public activity during normal event/runtime writes, clearing projections on reset/clear, and capping active bootstrap sessions from bounded subject-state session ids.

## Verification
- node --test tests/worker-bootstrap-capacity.test.js tests/worker-backend.test.js tests/worker-access.test.js tests/worker-monster-visual-config.test.js
- node --test tests/worker-history-api.test.js tests/hub-api.test.js tests/worker-hubs.test.js
- node --test tests/worker-read-model-capacity.test.js tests/read-model-backfill.test.js tests/worker-history-api.test.js
- node --test tests/worker-read-model-capacity.test.js tests/worker-bootstrap-capacity.test.js tests/worker-history-api.test.js
- npm test
- npm run check

## Review
- Independent reviewer pass 1 found two blockers: projection sync/clear lifecycle and unbounded active bootstrap sessions.
- Fixed in 6ebe494.
- Independent reviewer pass 2 found no blocker, critical, or major issues.

## Residual Risk
- No live production smoke or remote D1 migration apply has been run yet; local SQLite migrations and Wrangler dry-run passed.
