### PR TITLE
Bound command projection reads

### DIFF
--- a/tests/worker-projections.test.js
+++ b/tests/worker-projections.test.js
@@ -6,6 +6,7 @@ import { MONSTER_CELEBRATION_REPLAY_REQUEST_TYPE } from '../worker/src/projectio
 import { createMigratedSqliteD1Database } from './helpers/sqlite-d1.js';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+const PROJECTION_RECENT_EVENT_LIMIT = 200;
 
 function seedAccountLearner(DB, { accountId = 'adult-a', learnerId = 'learner-a' } = {}) {
   const now = Date.UTC(2026, 0, 1);
@@ -107,6 +108,11 @@ function insertProjectionWindowFillerEvents(DB, { learnerId = 'learner-a', count
   }
 }
 
+function eventLogReads(DB) {
+  return DB.takeQueryLog()
+    .filter((entry) => entry.operation === 'all' && /\bFROM event_log\b/i.test(entry.sql));
+}
+
 async function completePossessRound(harness) {
   let latest = await harness.command('start-session', {
     mode: 'single',
@@ -164,6 +170,17 @@ test('spelling command projection applies monster rewards and returns celebratio
       WHERE learner_id = 'learner-a' AND event_type = 'reward.monster'
     `).get().count;
     assert.equal(rewardCount, 1);
+    const readModelRow = harness.DB.db.prepare(`
+      SELECT model_json, source_revision
+      FROM learner_read_models
+      WHERE learner_id = 'learner-a'
+        AND model_key = 'command.projection.v1'
+    `).get();
+    assert.ok(readModelRow);
+    const readModel = JSON.parse(readModelRow.model_json);
+    assert.equal(readModel.rewards.systemId, 'monster-codex');
+    assert.ok(readModel.rewards.state.inklet.mastered.includes('possess'));
+    assert.ok(readModelRow.source_revision >= secureSubmit.body.mutation.appliedRevision);
 
     const replay = await harness.postRaw(secureSubmit.requestBody);
     assert.equal(replay.response.status, 200);
@@ -226,7 +243,10 @@ test('spelling command projection emits requested monster celebration replays on
       createdAt: Date.UTC(2026, 3, 24, 18, 0, 0),
     });
 
+    harness.DB.clearQueryLog();
     const firstCompletion = await completePossessRound(harness);
+    const firstEventReads = eventLogReads(harness.DB);
+    assert.equal(firstEventReads.every((entry) => entry.rowCount <= PROJECTION_RECENT_EVENT_LIMIT), true);
     const firstReplayEvents = firstCompletion.latest.body.projections.rewards.events
       .filter((event) => event.replayRequestId === replayRequestId);
 
@@ -250,6 +270,36 @@ test('spelling command projection emits requested monster celebration replays on
         .some((event) => event.replayRequestId === replayRequestId),
       false,
     );
+  } finally {
+    harness.close();
+  }
+});
+
+test('no-op spelling command avoids historical projection reads and learner writes', async () => {
+  const harness = createCommandHarness();
+
+  try {
+    insertProjectionWindowFillerEvents(harness.DB, {
+      count: 1005,
+      startAt: Date.UTC(2026, 3, 24, 17, 30, 0),
+    });
+
+    harness.DB.clearQueryLog();
+    const result = await harness.command('check-word-bank-drill', {
+      slug: 'possess',
+      typed: 'possess',
+    });
+    const reads = eventLogReads(harness.DB);
+
+    assert.equal(result.body.changed, false);
+    assert.equal(result.body.mutation.appliedRevision, 0);
+    assert.equal(reads.length, 0);
+    const readModelCount = harness.DB.db.prepare(`
+      SELECT COUNT(*) AS count
+      FROM learner_read_models
+      WHERE learner_id = 'learner-a'
+    `).get().count;
+    assert.equal(readModelCount, 0);
   } finally {
     harness.close();
   }

--- a/worker/src/read-models/learner-read-models.js
+++ b/worker/src/read-models/learner-read-models.js
@@ -2,6 +2,7 @@ import { cloneSerialisable } from '../../../src/platform/core/repositories/helpe
 
 export const LEARNER_SUMMARY_MODEL_KEY = 'learner.summary.v1';
 export const PARENT_SUMMARY_MODEL_KEY = 'parent.summary.v1';
+export const COMMAND_PROJECTION_MODEL_KEY = 'command.projection.v1';
 export const PUBLIC_ACTIVITY_TYPES = new Set([
   'spelling.retry-cleared',
   'spelling.word-secured',

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -34,6 +34,7 @@ import { monsterIdForSpellingWord } from '../../src/platform/game/monster-system
 import { buildSpellingProgressPools, buildSpellingWordBankReadModel } from './content/spelling-read-models.js';
 import {
   activityFeedRowFromEventRow,
+  COMMAND_PROJECTION_MODEL_KEY,
   emptyLearnerReadModel,
   normaliseActivityFeedRow,
   normaliseLearnerReadModelRow,
@@ -96,6 +97,8 @@ const PUBLIC_BOOTSTRAP_ACTIVE_SESSION_LOOKUP_LIMIT_PER_LEARNER = 5;
 const PUBLIC_BOOTSTRAP_RECENT_EVENT_LIMIT_PER_LEARNER = 50;
 const PUBLIC_BOOTSTRAP_CAPACITY_VERSION = 1;
 const PUBLIC_MONSTER_CODEX_SYSTEM_ID = 'monster-codex';
+const PROJECTION_RECENT_EVENT_LIMIT = 200;
+const COMMAND_PROJECTION_READ_MODEL_VERSION = 1;
 const PUBLIC_MONSTER_IDS = new Set(['inklet', 'glimmerbug', 'phaeton', 'vellhorn']);
 const PUBLIC_DIRECT_SPELLING_MONSTER_IDS = ['inklet', 'glimmerbug', 'vellhorn'];
 const PUBLIC_MONSTER_BRANCHES = new Set(['b1', 'b2']);
@@ -1319,6 +1322,33 @@ async function upsertLearnerReadModel(db, learnerId, modelKey, model, {
   return readLearnerReadModel(db, learnerId, key);
 }
 
+function bindLearnerReadModelUpsertStatement(db, learnerId, modelKey, model, {
+  sourceRevision = 0,
+  generatedAt = Date.now(),
+  updatedAt = generatedAt,
+  guard = null,
+} = {}) {
+  const key = normaliseReadModelKey(modelKey);
+  const timestamp = Math.max(0, Number(updatedAt) || Date.now());
+  const params = [
+    learnerId,
+    key,
+    JSON.stringify(cloneSerialisable(model) || {}),
+    Math.max(0, Number(sourceRevision) || 0),
+    Math.max(0, Number(generatedAt) || timestamp),
+    timestamp,
+  ];
+  return bindStatement(db, `
+    INSERT INTO learner_read_models (learner_id, model_key, model_json, source_revision, generated_at, updated_at)
+    ${guardedValueSource(params.length, guard)}
+    ON CONFLICT(learner_id, model_key) DO UPDATE SET
+      model_json = excluded.model_json,
+      source_revision = excluded.source_revision,
+      generated_at = excluded.generated_at,
+      updated_at = excluded.updated_at
+  `, guardedParams(params, guard));
+}
+
 async function readLearnerReadModel(db, learnerId, modelKey) {
   const key = normaliseReadModelKey(modelKey);
   const row = await first(db, `
@@ -1410,6 +1440,27 @@ function bindLearnerActivityFeedUpsertStatement(db, row, { guard = null } = {}) 
       created_at = excluded.created_at,
       updated_at = excluded.updated_at
   `, guardedParams(params, guard));
+}
+
+function commandProjectionReadModelFromRuntime(runtime, events, nowTs) {
+  const gameState = runtime?.gameState && typeof runtime.gameState === 'object' && !Array.isArray(runtime.gameState)
+    ? runtime.gameState
+    : {};
+  const rewardState = cloneSerialisable(gameState[PUBLIC_MONSTER_CODEX_SYSTEM_ID]) || {};
+  const eventList = Array.isArray(events) ? events : [];
+  return {
+    version: COMMAND_PROJECTION_READ_MODEL_VERSION,
+    generatedAt: Math.max(0, Number(nowTs) || Date.now()),
+    rewards: {
+      systemId: PUBLIC_MONSTER_CODEX_SYSTEM_ID,
+      state: rewardState,
+    },
+    eventCounts: {
+      written: eventList.length,
+      domain: eventList.filter((event) => typeof event?.type === 'string' && !event.type.startsWith('reward.')).length,
+      reactions: eventList.filter((event) => typeof event?.type === 'string' && event.type.startsWith('reward.')).length,
+    },
+  };
 }
 
 async function readLearnerActivityFeed(db, learnerId, {
@@ -2740,12 +2791,17 @@ async function readLearnerProjectionBundle(db, accountId, learnerId) {
     SELECT id, learner_id, subject_id, system_id, event_type, event_json, created_at
     FROM event_log
     WHERE learner_id = ?
-    ORDER BY created_at ASC, id ASC
-  `, [learnerId]);
+    ORDER BY created_at DESC, id DESC
+    LIMIT ?
+  `, [learnerId, PROJECTION_RECENT_EVENT_LIMIT]);
+  const commandProjectionReadModel = await readLearnerReadModel(db, learnerId, COMMAND_PROJECTION_MODEL_KEY);
 
   return {
     gameState: Object.fromEntries(gameRows.map((row) => [row.system_id, gameStateRowToRecord(row)])),
-    events: normaliseEventLog(eventRows.map(eventRowToRecord).filter(Boolean)),
+    events: normaliseEventLog(sortEventRowsAscending(eventRows).map(eventRowToRecord).filter(Boolean)),
+    readModels: {
+      commandProjection: commandProjectionReadModel,
+    },
   };
 }
 
@@ -2969,6 +3025,21 @@ function buildSubjectRuntimePersistencePlan(db, accountId, learnerId, subjectId,
     });
     const activityStatement = bindLearnerActivityFeedUpsertStatement(db, activityRow, { guard });
     if (activityStatement) statements.push(activityStatement);
+  }
+  if (Object.prototype.hasOwnProperty.call(gameState, PUBLIC_MONSTER_CODEX_SYSTEM_ID)) {
+    const commandProjectionReadModel = commandProjectionReadModelFromRuntime(runtime, persistedEvents, nowTs);
+    statements.push(bindLearnerReadModelUpsertStatement(
+      db,
+      learnerId,
+      COMMAND_PROJECTION_MODEL_KEY,
+      commandProjectionReadModel,
+      {
+        sourceRevision: guard ? guard.expectedRevision + 1 : 0,
+        generatedAt: nowTs,
+        updatedAt: nowTs,
+        guard,
+      },
+    ));
   }
 
   const summary = {


### PR DESCRIPTION
## Summary
- Bound command projection event reads to a recent event-token window instead of scanning full learner event history.
- Persist a small command projection read model when reward game state changes.
- Add high-history and no-op command tests covering bounded event reads and non-mutating projection paths.

## Verification
- node --test tests/worker-projections.test.js tests/server-spelling-engine-parity.test.js tests/worker-read-model-capacity.test.js tests/worker-grammar-subject-runtime.test.js tests/worker-punctuation-runtime.test.js
- npm test
- npm run check

## Review
- Independent reviewer found no blocker findings against origin/main...HEAD.
- PR has no review threads or actionable comments, so gh-address-comments was a no-op.

## Notes
- This U5 slice removes the full event scan from common command projection input while preserving explicit replay-context lookups by event type/id.
- Residual: command.projection.v1 is persisted and readable but not yet consumed by handlers; that can be the next U5 follow-up if we want to use the read model directly.
