### PR TITLE
docs(grammar): decide paragraph transfer lane

### DIFF
--- a/docs/grammar-transfer-decision.md
+++ b/docs/grammar-transfer-decision.md
@@ -1,0 +1,27 @@
+# Grammar Paragraph Transfer Decision
+
+This decision closes the open Grammar follow-up about paragraph-level transfer.
+
+## Decision
+
+Grammar paragraph transfer will ship, when implemented, as a non-scored transfer lane first.
+
+It will ask learners to apply secured Grammar choices in short writing, but it must not mark paragraph writing, mutate mastery, schedule retries, unlock monsters, or count towards Concordium. The existing Worker-marked Grammar engine remains the only score-bearing authority for Grammar mastery.
+
+## Rejected For Now
+
+- Teacher-reviewed paragraph marking is not promised. It needs a separate workflow, reviewer role model, moderation rules, and adult-facing evidence design before product copy can mention it.
+- Deterministic paragraph scoring is not the first transfer lane. Paragraph writing creates too many valid answers for the current template/accepted-answer model, and false precision would weaken the secured-evidence contract.
+- AI-marked paragraph scoring is rejected. AI may support non-scored explanation or drafting only after server-side validation; it must not author or mark score-bearing Grammar evidence.
+
+## Implementation Contract
+
+- Transfer prompts may use concepts, recent weak areas, and visible analytics to choose a writing target.
+- Transfer output is practice artefact only until a later reviewed scoring plan exists.
+- Transfer may be stored as non-scored activity or adult-readable evidence, but it must be clearly separated from mastery events, retry queues, reward projection, and question-type strength.
+- Any future score-bearing transfer path requires a new content-release decision, deterministic marking tests, production smoke coverage, and explicit no-regression checks for Spelling, Punctuation, D1, R2, and rewards.
+- Bellstorm Coast remains the separate Punctuation subject. Punctuation-for-grammar concepts still count inside the 18-concept Grammar denominator for GPS mastery.
+
+## Next Slice
+
+The next implementation slice should add a non-scored paragraph transfer activity behind the existing locked placeholder, with no mastery mutation and with adult evidence copy that clearly labels it as writing application rather than scored Grammar progress.

--- a/docs/plans/2026-04-24-001-feat-grammar-mastery-region-plan.md
+++ b/docs/plans/2026-04-24-001-feat-grammar-mastery-region-plan.md
@@ -40,7 +40,7 @@ Open Grammar follow-up scope:
 
 - [x] Track remaining legacy functionality completeness in `docs/plans/2026-04-25-001-feat-grammar-functionality-completeness-plan.md`: strict mini-test, session goals/settings, in-session repair, visible AI triggers, read aloud, adult/data replacement parity, and release gates are complete.
 - [x] Add transfer and Bellstorm bridge placeholders without collapsing Grammar and Punctuation product identities.
-- [ ] Decide later whether paragraph-level transfer becomes non-scored, teacher-reviewed, or a separate deterministic workflow.
+- [x] Decide paragraph-level transfer direction: `docs/grammar-transfer-decision.md` sets the first transfer lane as non-scored writing application, with teacher-reviewed or deterministic paragraph scoring deferred to separate reviewed plans.
 - [ ] Decide whether to connect a live AI provider to the safe lane; provider keys must stay server-side and output must pass the existing validator.
 - [ ] Continue to run `npm test`, `npm run check`, and Grammar production/UI smoke for each shipped Grammar slice.
 

--- a/src/subjects/grammar/components/GrammarPracticeSurface.jsx
+++ b/src/subjects/grammar/components/GrammarPracticeSurface.jsx
@@ -12,20 +12,20 @@ const GRAMMAR_TRANSFER_PLACEHOLDERS = Object.freeze([
     id: 'paragraph-transfer',
     eyebrow: 'Non-scored transfer',
     title: 'Paragraph transfer',
-    copy: 'Coming next: short paragraph application that asks the learner to use Grammar choices in a wider piece of writing.',
+    copy: 'Decision: this will be non-scored paragraph application first, so learners can use Grammar choices in a wider piece of writing without changing mastery evidence.',
     bullets: [
-      'No score is recorded from this placeholder.',
-      'Teacher review and paragraph marking are not promised in this release.',
+      'No score, retry, reward, or Concordium progress is recorded from this transfer lane.',
+      'Teacher review and deterministic paragraph scoring are separate future decisions, not hidden promises.',
     ],
   },
   {
     id: 'writing-application',
     eyebrow: 'Future writing application',
     title: 'Richer writing tasks',
-    copy: 'Reserved for sentence-to-writing practice once the deterministic Grammar evidence and reporting path are stable.',
+    copy: 'Reserved for sentence-to-writing practice after the non-scored transfer lane proves the right evidence shape.',
     bullets: [
       'Worker-marked Grammar remains the only score-bearing authority.',
-      'Any future writing workflow will ship as its own reviewed capability.',
+      'Any future score-bearing writing workflow will ship as its own reviewed capability.',
     ],
   },
 ]);

--- a/tests/grammar-functionality-completeness.test.js
+++ b/tests/grammar-functionality-completeness.test.js
@@ -21,6 +21,7 @@ const baselinePath = path.join(rootDir, 'tests/fixtures/grammar-functionality-co
 const livePlanPath = path.join(rootDir, 'docs/plans/2026-04-24-001-feat-grammar-mastery-region-plan.md');
 const completenessPlanPath = path.join(rootDir, 'docs/plans/2026-04-25-001-feat-grammar-functionality-completeness-plan.md');
 const completenessDocPath = path.join(rootDir, 'docs/grammar-functionality-completeness.md');
+const transferDecisionPath = path.join(rootDir, 'docs/grammar-transfer-decision.md');
 
 function readBaseline() {
   return JSON.parse(fs.readFileSync(baselinePath, 'utf8'));
@@ -125,9 +126,15 @@ test('Grammar completeness documentation and live checklist point at the active 
   const livePlan = fs.readFileSync(livePlanPath, 'utf8');
   const completenessPlan = fs.readFileSync(completenessPlanPath, 'utf8');
   const completenessDoc = fs.readFileSync(completenessDocPath, 'utf8');
+  const transferDecision = fs.readFileSync(transferDecisionPath, 'utf8');
 
   assert.match(livePlan, /2026-04-25-001-feat-grammar-functionality-completeness-plan\.md/);
+  assert.match(livePlan, /docs\/grammar-transfer-decision\.md/);
+  assert.doesNotMatch(livePlan, /Decide later whether paragraph-level transfer becomes/);
   assert.match(completenessPlan, /## Implementation Units/);
   assert.match(completenessDoc, /strict mini-test/i);
   assert.match(completenessDoc, /browser-held AI keys/i);
+  assert.match(transferDecision, /non-scored transfer lane first/);
+  assert.match(transferDecision, /must not mark paragraph writing, mutate mastery, schedule retries, unlock monsters, or count towards Concordium/);
+  assert.match(transferDecision, /AI-marked paragraph scoring is rejected/);
 });

--- a/tests/react-grammar-surface.test.js
+++ b/tests/react-grammar-surface.test.js
@@ -424,7 +424,9 @@ test('Grammar renders transfer and Bellstorm bridge placeholders as locked futur
   assert.match(html, /Writing application roadmap/);
   assert.match(html, /Paragraph transfer/);
   assert.match(html, /Richer writing tasks/);
-  assert.match(html, /Teacher review and paragraph marking are not promised/);
+  assert.match(html, /Decision: this will be non-scored paragraph application first/);
+  assert.match(html, /No score, retry, reward, or Concordium progress/);
+  assert.match(html, /Teacher review and deterministic paragraph scoring are separate future decisions/);
   assert.match(html, /Worker-marked Grammar remains the only score-bearing authority/);
   assert.match(html, /Bellstorm bridge/);
   assert.match(html, /Punctuation-for-grammar stays in Grammar/);


### PR DESCRIPTION
## Summary

- Decide the Grammar paragraph-transfer direction as a non-scored writing application lane first.
- Update the live Grammar checklist and transfer placeholder copy so teacher-reviewed or deterministic paragraph scoring are clearly deferred.
- Add regression coverage that pins the decision doc and UI copy.

## Verification

- `NODE_PATH=/Users/jamesto/Coding/ks2-mastery/node_modules npm test -- tests/grammar-functionality-completeness.test.js tests/react-grammar-surface.test.js`
- `npm run check`
- `git diff --check`

## External CI

- Cloudflare Workers Builds remains part of the PR gate. Local Wrangler dry-run, public output assertion, and client bundle audit pass via `npm run check`.
### Reviewer evidence

- Independent reviewer: no blockers on paragraph-transfer decision, UI copy, Worker-owned scoring boundary, or live checklist.
- External CI: GitGuardian and GitHub Actions checks are green. Cloudflare Workers Builds suite is queued with no check run; local `npm run check` passed and covers build, public output assertion, client bundle audit, and Wrangler dry-run.
