### PR TITLE
fix(client): jitter subject command retries

### DIFF
--- a/src/platform/runtime/subject-command-client.js
+++ b/src/platform/runtime/subject-command-client.js
@@ -1,5 +1,8 @@
 import { uid } from '../core/utils.js';
 
+const DEFAULT_RETRY_JITTER_MAX_MS = 125;
+const DEFAULT_RETRY_MAX_DELAY_MS = 2_000;
+
 function joinUrl(baseUrl, path) {
   const base = String(baseUrl || '').replace(/\/$/, '');
   const suffix = String(path || '').startsWith('/') ? path : `/${path}`;
@@ -28,6 +31,51 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, delay));
 }
 
+function boundedRandom(random) {
+  try {
+    const raw = typeof random === 'function' ? Number(random()) : 0;
+    if (!Number.isFinite(raw)) return 0;
+    return Math.min(1, Math.max(0, raw));
+  } catch {
+    return 0;
+  }
+}
+
+function retryDelayForAttempt(attempt, { baseDelayMs, jitterMaxMs, maxDelayMs, random }) {
+  const exponent = Math.max(0, Number(attempt) || 0);
+  const baseDelay = Math.max(0, Number(baseDelayMs) || 0) * (2 ** exponent);
+  if (!baseDelay) return 0;
+  const jitter = Math.floor(Math.max(0, Number(jitterMaxMs) || 0) * boundedRandom(random));
+  const uncapped = baseDelay + jitter;
+  const maxDelay = Math.max(0, Number(maxDelayMs) || 0);
+  return maxDelay ? Math.min(maxDelay, uncapped) : uncapped;
+}
+
+function snapshotCommandPayload(payload) {
+  if (payload === undefined) return {};
+  const serialised = JSON.stringify(payload);
+  return serialised === undefined ? undefined : JSON.parse(serialised);
+}
+
+function createCommandBody({
+  cleanSubjectId,
+  cleanLearnerId,
+  cleanCommand,
+  payloadSnapshot,
+  requestId,
+  expectedLearnerRevision,
+}) {
+  return JSON.stringify({
+    subjectId: cleanSubjectId,
+    learnerId: cleanLearnerId,
+    command: cleanCommand,
+    requestId,
+    correlationId: requestId,
+    expectedLearnerRevision,
+    payload: payloadSnapshot,
+  });
+}
+
 export class SubjectCommandClientError extends Error {
   constructor({ status = 0, payload = null, message = '' } = {}) {
     super(message || payload?.message || `Subject command failed (${status}).`);
@@ -47,6 +95,10 @@ export function createSubjectCommandClient({
   onStaleWrite = null,
   retryAttempts = 2,
   retryDelayMs = 250,
+  retryJitterMs = null,
+  retryMaxDelayMs = DEFAULT_RETRY_MAX_DELAY_MS,
+  random = Math.random,
+  sleep: sleepFn = sleep,
 } = {}) {
   if (typeof fetchFn !== 'function') {
     throw new TypeError('Subject command client requires a fetch implementation.');
@@ -67,8 +119,7 @@ export function createSubjectCommandClient({
     return queued;
   }
 
-  async function sendOnce({ cleanSubjectId, cleanLearnerId, cleanCommand, payload, requestId }) {
-    const expectedLearnerRevision = Number(getLearnerRevision(cleanLearnerId)) || 0;
+  async function sendOnce({ cleanSubjectId, requestId, body }) {
     let response;
     try {
       response = await fetchFn(joinUrl(baseUrl, `/api/subjects/${encodeURIComponent(cleanSubjectId)}/command`), {
@@ -79,15 +130,7 @@ export function createSubjectCommandClient({
           'x-ks2-request-id': requestId,
           'x-ks2-correlation-id': requestId,
         },
-        body: JSON.stringify({
-          subjectId: cleanSubjectId,
-          learnerId: cleanLearnerId,
-          command: cleanCommand,
-          requestId,
-          correlationId: requestId,
-          expectedLearnerRevision,
-          payload,
-        }),
+        body,
       });
     } catch (error) {
       throw new SubjectCommandClientError({
@@ -111,18 +154,39 @@ export function createSubjectCommandClient({
   async function sendWithRetry({ cleanSubjectId, cleanLearnerId, cleanCommand, payload, requestId }) {
     const maxRetryAttempts = Math.max(0, Number(retryAttempts) || 0);
     const baseRetryDelayMs = Math.max(0, Number(retryDelayMs) || 0);
+    const retryJitterMaxMs = retryJitterMs == null
+      ? Math.min(DEFAULT_RETRY_JITTER_MAX_MS, Math.floor(baseRetryDelayMs / 2))
+      : Math.max(0, Number(retryJitterMs) || 0);
+    const commandSleep = typeof sleepFn === 'function' ? sleepFn : sleep;
     let transportAttempts = 0;
     let staleWriteRetried = false;
+    let expectedLearnerRevision = Number(getLearnerRevision(cleanLearnerId)) || 0;
+    let payloadSnapshot;
+    try {
+      payloadSnapshot = snapshotCommandPayload(payload);
+    } catch (error) {
+      throw new SubjectCommandClientError({
+        status: 400,
+        payload: { code: 'subject_command_client_invalid_payload' },
+        message: error?.message || 'Subject command payload must be JSON serialisable.',
+      });
+    }
+    let body = createCommandBody({
+      cleanSubjectId,
+      cleanLearnerId,
+      cleanCommand,
+      payloadSnapshot,
+      requestId,
+      expectedLearnerRevision,
+    });
     let responsePayload;
 
     while (!responsePayload) {
       try {
         responsePayload = await sendOnce({
           cleanSubjectId,
-          cleanLearnerId,
-          cleanCommand,
-          payload,
           requestId,
+          body,
         });
       } catch (error) {
         if (isStaleWriteConflict(error) && !staleWriteRetried && typeof onStaleWrite === 'function') {
@@ -132,16 +196,31 @@ export function createSubjectCommandClient({
             learnerId: cleanLearnerId,
             subjectId: cleanSubjectId,
             command: cleanCommand,
-            payload,
+            payload: snapshotCommandPayload(payloadSnapshot),
             requestId,
+          });
+          expectedLearnerRevision = Number(getLearnerRevision(cleanLearnerId)) || 0;
+          transportAttempts = 0;
+          body = createCommandBody({
+            cleanSubjectId,
+            cleanLearnerId,
+            cleanCommand,
+            payloadSnapshot,
+            requestId,
+            expectedLearnerRevision,
           });
           continue;
         }
 
         if (isRetryableTransportFailure(error) && transportAttempts < maxRetryAttempts) {
-          const delayMs = baseRetryDelayMs * (2 ** transportAttempts);
+          const delayMs = retryDelayForAttempt(transportAttempts, {
+            baseDelayMs: baseRetryDelayMs,
+            jitterMaxMs: retryJitterMaxMs,
+            maxDelayMs: retryMaxDelayMs,
+            random,
+          });
           transportAttempts += 1;
-          await sleep(delayMs);
+          await commandSleep(delayMs);
           continue;
         }
 

--- a/tests/bundle-audit.test.js
+++ b/tests/bundle-audit.test.js
@@ -65,7 +65,7 @@ test('client bundle audit fails when Grammar server engine or content enters the
       cwd: process.cwd(),
       stdio: 'pipe',
     });
-  }, /server-authoritative Grammar engine\/content/);
+  }, /server-authoritative Grammar runtime, engine, content, and enrichment code/);
 });
 
 test('client bundle audit fails on browser-side AI provider key tokens', async () => {

--- a/tests/subject-command-client.test.js
+++ b/tests/subject-command-client.test.js
@@ -107,3 +107,187 @@ test('subject command client retries transient server failures with the same req
   assert.deepEqual(commandBodies.map((body) => body.expectedLearnerRevision), [7, 7]);
   assert.equal(revision, 8);
 });
+
+test('subject command client freezes expected revision across transport retries', async () => {
+  let revision = 12;
+  const commandBodies = [];
+  const retryDelays = [];
+  const fetch = async (input, init = {}) => {
+    const body = JSON.parse(init.body);
+    commandBodies.push(body);
+    if (commandBodies.length === 1) {
+      return new Response(JSON.stringify({
+        ok: false,
+        code: 'backend_unavailable',
+        message: 'D1 was temporarily unavailable.',
+      }), { status: 503, headers: { 'content-type': 'application/json' } });
+    }
+    return new Response(JSON.stringify({
+      ok: true,
+      mutation: {
+        appliedRevision: body.expectedLearnerRevision + 1,
+      },
+    }), { status: 200, headers: { 'content-type': 'application/json' } });
+  };
+  const commands = createSubjectCommandClient({
+    fetch,
+    getLearnerRevision: () => revision,
+    retryDelayMs: 50,
+    retryJitterMs: 0,
+    sleep: async (delayMs) => {
+      retryDelays.push(delayMs);
+      revision = 13;
+    },
+  });
+
+  await commands.send({
+    subjectId: 'spelling',
+    learnerId: 'learner-a',
+    command: 'submit-answer',
+    payload: { typed: 'answer' },
+    requestId: 'cmd-frozen-503',
+  });
+
+  assert.deepEqual(retryDelays, [50]);
+  assert.deepEqual(commandBodies.map((body) => body.requestId), ['cmd-frozen-503', 'cmd-frozen-503']);
+  assert.deepEqual(commandBodies.map((body) => body.expectedLearnerRevision), [12, 12]);
+});
+
+test('subject command client freezes payload across transport retries', async () => {
+  const payload = { typed: 'first', context: { promptId: 'prompt-a' } };
+  const commandBodies = [];
+  const fetch = async (input, init = {}) => {
+    const body = JSON.parse(init.body);
+    commandBodies.push(body);
+    if (commandBodies.length === 1) {
+      return new Response(JSON.stringify({
+        ok: false,
+        code: 'backend_unavailable',
+        message: 'D1 was temporarily unavailable.',
+      }), { status: 503, headers: { 'content-type': 'application/json' } });
+    }
+    return new Response(JSON.stringify({
+      ok: true,
+      mutation: {
+        appliedRevision: body.expectedLearnerRevision + 1,
+      },
+    }), { status: 200, headers: { 'content-type': 'application/json' } });
+  };
+  const commands = createSubjectCommandClient({
+    fetch,
+    getLearnerRevision: () => 4,
+    retryDelayMs: 50,
+    retryJitterMs: 0,
+    sleep: async () => {
+      payload.typed = 'second';
+      payload.context.promptId = 'prompt-b';
+    },
+  });
+
+  await commands.send({
+    subjectId: 'spelling',
+    learnerId: 'learner-a',
+    command: 'submit-answer',
+    payload,
+    requestId: 'cmd-frozen-payload-503',
+  });
+
+  assert.deepEqual(commandBodies.map((body) => body.requestId), ['cmd-frozen-payload-503', 'cmd-frozen-payload-503']);
+  assert.deepEqual(commandBodies.map((body) => body.payload), [
+    { typed: 'first', context: { promptId: 'prompt-a' } },
+    { typed: 'first', context: { promptId: 'prompt-a' } },
+  ]);
+});
+
+test('subject command client refreshes expected revision only after stale-write recovery', async () => {
+  let revision = 12;
+  const payload = { typed: 'first' };
+  const commandBodies = [];
+  const fetch = async (input, init = {}) => {
+    const body = JSON.parse(init.body);
+    commandBodies.push(body);
+    if (commandBodies.length === 1) {
+      return new Response(JSON.stringify({
+        ok: false,
+        code: 'stale_write',
+        message: 'Mutation rejected because this state changed in another tab or device.',
+      }), { status: 409, headers: { 'content-type': 'application/json' } });
+    }
+    return new Response(JSON.stringify({
+      ok: true,
+      mutation: {
+        appliedRevision: body.expectedLearnerRevision + 1,
+      },
+    }), { status: 200, headers: { 'content-type': 'application/json' } });
+  };
+  const commands = createSubjectCommandClient({
+    fetch,
+    getLearnerRevision: () => revision,
+    retryDelayMs: 0,
+    onStaleWrite: async ({ payload: stalePayload }) => {
+      revision = 13;
+      stalePayload.typed = 'handler-mutated-copy';
+      payload.typed = 'second';
+    },
+  });
+
+  await commands.send({
+    subjectId: 'spelling',
+    learnerId: 'learner-a',
+    command: 'submit-answer',
+    payload,
+    requestId: 'cmd-stale-revision-refresh',
+  });
+
+  assert.deepEqual(commandBodies.map((body) => body.requestId), ['cmd-stale-revision-refresh', 'cmd-stale-revision-refresh']);
+  assert.deepEqual(commandBodies.map((body) => body.expectedLearnerRevision), [12, 13]);
+  assert.deepEqual(commandBodies.map((body) => body.payload), [{ typed: 'first' }, { typed: 'first' }]);
+});
+
+test('subject command client jitters bounded retry delays for transient command failures', async () => {
+  const commandBodies = [];
+  const retryDelays = [];
+  const randomValues = [0.5, 1];
+  const fetch = async (input, init = {}) => {
+    const body = JSON.parse(init.body);
+    commandBodies.push(body);
+    if (commandBodies.length <= 2) {
+      return new Response(JSON.stringify({
+        ok: false,
+        code: 'backend_unavailable',
+        message: 'D1 was temporarily unavailable.',
+      }), { status: 503, headers: { 'content-type': 'application/json' } });
+    }
+    return new Response(JSON.stringify({
+      ok: true,
+      mutation: {
+        appliedRevision: body.expectedLearnerRevision + 1,
+      },
+    }), { status: 200, headers: { 'content-type': 'application/json' } });
+  };
+  const commands = createSubjectCommandClient({
+    fetch,
+    getLearnerRevision: () => 12,
+    retryAttempts: 2,
+    retryDelayMs: 100,
+    retryJitterMs: 40,
+    retryMaxDelayMs: 220,
+    random: () => randomValues.shift() ?? 0,
+    sleep: async (delayMs) => {
+      retryDelays.push(delayMs);
+    },
+  });
+
+  await commands.send({
+    subjectId: 'spelling',
+    learnerId: 'learner-a',
+    command: 'submit-answer',
+    payload: { typed: 'answer' },
+    requestId: 'cmd-jitter-503',
+  });
+
+  assert.equal(commandBodies.length, 3);
+  assert.deepEqual(commandBodies.map((body) => body.requestId), ['cmd-jitter-503', 'cmd-jitter-503', 'cmd-jitter-503']);
+  assert.deepEqual(commandBodies.map((body) => body.expectedLearnerRevision), [12, 12, 12]);
+  assert.deepEqual(retryDelays, [120, 220]);
+});


### PR DESCRIPTION
## Summary
- add bounded jitter to subject command retry delays so transient 5xx/network failures do not synchronise retries across clients
- keep retry semantics unchanged for request id and expected learner revision
- update the bundle-audit test expectation to match the current Grammar runtime/content audit wording on main

## Verification
- node --test tests/subject-command-client.test.js tests/spelling-remote-actions.test.js tests/subject-command-actions.test.js
- node --test tests/bundle-audit.test.js tests/subject-command-client.test.js tests/spelling-remote-actions.test.js tests/subject-command-actions.test.js
- npm test
- npm run check
- git diff --check

## Plan
- U6 follow-up from docs/plans/2026-04-25-001-fix-bootstrap-cpu-capacity-plan.md: command retries now use bounded jitter/backoff after the bootstrap backoff slice landed.