### PR TITLE
fix(client): avoid bootstrap on stale command revision

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -424,12 +424,47 @@ tts.subscribe((event) => {
 
 const readModels = createReadModelClient({ baseUrl: '', fetch: credentialFetch });
 const spellingContent = createSpellingContentApi({ fetch: credentialFetch });
+
+function staleWriteCurrentRevision(error) {
+  const payload = error?.payload;
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null;
+
+  const expectedCandidates = [
+    payload.expectedRevision,
+    payload.mutation?.expectedRevision,
+  ];
+  let expectedRevision = null;
+  for (const candidate of expectedCandidates) {
+    const revision = Number(candidate);
+    if (Number.isFinite(revision) && revision >= 0) {
+      expectedRevision = revision;
+      break;
+    }
+  }
+
+  const currentCandidates = [
+    payload.currentRevision,
+    payload.mutation?.currentRevision,
+  ];
+  for (const candidate of currentCandidates) {
+    const revision = Number(candidate);
+    if (!Number.isFinite(revision) || revision < 0) continue;
+    if (expectedRevision !== null && revision <= expectedRevision) continue;
+    return revision;
+  }
+  return null;
+}
+
 const subjectCommands = createSubjectCommandClient({
   baseUrl: '',
   fetch: credentialFetch,
   getLearnerRevision: (learnerId) => repositories.runtime?.readLearnerRevision?.(learnerId) || 0,
-  onStaleWrite: async () => {
-    await repositories.hydrate({ cacheScope: 'subject-command-stale-write' });
+  onStaleWrite: async ({ error, learnerId }) => {
+    const refreshed = repositories.runtime?.applyLearnerRevisionHint?.(
+      learnerId,
+      staleWriteCurrentRevision(error),
+    ) === true;
+    if (!refreshed) await repositories.hydrate({ cacheScope: 'subject-command-stale-write' });
   },
   onCommandApplied: ({ learnerId, subjectId, response }) => {
     repositories.runtime?.applySubjectCommandResult?.({ learnerId, subjectId, response });

--- a/src/platform/core/repositories/api.js
+++ b/src/platform/core/repositories/api.js
@@ -1239,6 +1239,21 @@ export function createApiPlatformRepositories({
     }
   }
 
+  function applyLearnerRevisionHint(learnerId, revision) {
+    const cleanLearnerId = String(learnerId || '').trim();
+    if (revision == null || (typeof revision === 'string' && !revision.trim())) return false;
+    const hintedRevision = Number(revision);
+    if (!cleanLearnerId || !Number.isFinite(hintedRevision) || hintedRevision < 0) return false;
+
+    const current = normaliseSyncState(syncState);
+    const currentRevision = Math.max(0, Number(current.learnerRevisions?.[cleanLearnerId]) || 0);
+    if (hintedRevision < currentRevision) return false;
+
+    syncState = setScopeRevision(syncState, 'learner', cleanLearnerId, hintedRevision);
+    persistLocalCache('subject-command:stale-revision-hint');
+    return true;
+  }
+
   function applyCommandResultToCache({ learnerId, subjectId, response } = {}) {
     if (!response || typeof response !== 'object' || Array.isArray(response)) return null;
     const readModel = response.subjectReadModel || null;
@@ -1792,6 +1807,9 @@ export function createApiPlatformRepositories({
       readLearnerRevision(learnerId) {
         const current = normaliseSyncState(syncState);
         return Math.max(0, Number(current.learnerRevisions?.[learnerId]) || 0);
+      },
+      applyLearnerRevisionHint(learnerId, revision) {
+        return applyLearnerRevisionHint(learnerId, revision);
       },
       applySubjectCommandResult({ learnerId, subjectId, response } = {}) {
         return applyCommandResultToCache({ learnerId, subjectId, response });

--- a/tests/persistence.test.js
+++ b/tests/persistence.test.js
@@ -17,6 +17,18 @@ import { createMockRepositoryServer } from './helpers/mock-api-server.js';
 
 const DEFAULT_API_CACHE_STORAGE_KEY = 'ks2-platform-v2.api-cache-state:default';
 
+function staleWriteCurrentRevision(payload) {
+  const candidates = [
+    payload?.currentRevision,
+    payload?.mutation?.currentRevision,
+  ];
+  for (const candidate of candidates) {
+    const revision = Number(candidate);
+    if (Number.isFinite(revision) && revision >= 0) return revision;
+  }
+  return null;
+}
+
 async function waitForPersistenceIdle(repositories, attempts = 25) {
   await Promise.resolve();
   for (let index = 0; index < attempts; index += 1) {
@@ -695,7 +707,7 @@ test('subject command responses update the api cache without queuing broad runti
   assert.equal(server.requests.some((request) => request.path === '/api/child-subject-state'), false);
 });
 
-test('subject commands rehydrate and retry once after a stale learner revision', async () => {
+test('subject commands refresh stale learner revision without a second bootstrap', async () => {
   const storage = installMemoryStorage();
   const server = createMockRepositoryServer({
     learners: learnerSnapshot(),
@@ -722,7 +734,7 @@ test('subject commands rehydrate and retry once after a stale learner revision',
           policyVersion: 1,
           accountRevision: 0,
           learnerRevisions: {
-            'learner-a': bootstrapCount === 1 ? 0 : 1,
+            'learner-a': 0,
           },
         },
       }), { status: 200, headers: { 'content-type': 'application/json' } });
@@ -735,10 +747,8 @@ test('subject commands rehydrate and retry once after a stale learner revision',
           ok: false,
           code: 'stale_write',
           message: 'Mutation rejected because this state changed in another tab or device.',
-          mutation: {
-            expectedRevision: body.expectedLearnerRevision,
-            currentRevision: 1,
-          },
+          expectedRevision: body.expectedLearnerRevision,
+          currentRevision: 1,
         }), { status: 409, headers: { 'content-type': 'application/json' } });
       }
       return new Response(JSON.stringify({
@@ -787,8 +797,12 @@ test('subject commands rehydrate and retry once after a stale learner revision',
     baseUrl: 'https://repo.test',
     fetch,
     getLearnerRevision: (learnerId) => repositories.runtime.readLearnerRevision(learnerId),
-    onStaleWrite: async () => {
-      await repositories.hydrate({ cacheScope: 'subject-command-stale-write' });
+    onStaleWrite: async ({ error, learnerId }) => {
+      const refreshed = repositories.runtime.applyLearnerRevisionHint(
+        learnerId,
+        staleWriteCurrentRevision(error?.payload),
+      );
+      if (!refreshed) await repositories.hydrate({ cacheScope: 'subject-command-stale-write' });
     },
     onCommandApplied: ({ learnerId, subjectId, response }) => {
       repositories.runtime.applySubjectCommandResult({ learnerId, subjectId, response });
@@ -803,9 +817,96 @@ test('subject commands rehydrate and retry once after a stale learner revision',
     requestId: 'cmd-client-stale',
   });
 
-  assert.equal(bootstrapCount, 2);
+  assert.equal(bootstrapCount, 1);
   assert.deepEqual(commandBodies.map((body) => body.expectedLearnerRevision), [0, 1]);
   assert.equal(commandBodies[0].requestId, commandBodies[1].requestId);
   assert.equal(repositories.runtime.readLearnerRevision('learner-a'), 2);
   assert.equal(repositories.subjectStates.read('learner-a', 'spelling').ui.phase, 'session');
+});
+
+test('subject commands fall back to bootstrap when stale revision hints are missing', async () => {
+  const storage = installMemoryStorage();
+  const server = createMockRepositoryServer({
+    learners: learnerSnapshot(),
+    subjectStates: {
+      'learner-a::spelling': {
+        ui: { phase: 'dashboard' },
+        data: {},
+        updatedAt: 1,
+      },
+    },
+  });
+  const commandBodies = [];
+  let bootstrapCount = 0;
+  const fetch = async (input, init = {}) => {
+    const url = new URL(typeof input === 'string' ? input : input.url, 'https://repo.test');
+    const method = String(init.method || 'GET').toUpperCase();
+    if (url.pathname === '/api/bootstrap' && method === 'GET') {
+      bootstrapCount += 1;
+      const remote = await server.fetch(input, init);
+      const payload = await remote.json();
+      return new Response(JSON.stringify({
+        ...payload,
+        syncState: {
+          policyVersion: 1,
+          accountRevision: 0,
+          learnerRevisions: {
+            'learner-a': bootstrapCount === 1 ? 0 : 1,
+          },
+        },
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    }
+    if (url.pathname === '/api/subjects/spelling/command' && method === 'POST') {
+      const body = JSON.parse(init.body);
+      commandBodies.push(body);
+      if (commandBodies.length === 1) {
+        return new Response(JSON.stringify({
+          ok: false,
+          code: 'stale_write',
+          message: 'Mutation rejected because this state changed in another tab or device.',
+        }), { status: 409, headers: { 'content-type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({
+        ok: true,
+        mutation: {
+          appliedRevision: 2,
+        },
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    }
+    return server.fetch(input, init);
+  };
+  const repositories = createApiPlatformRepositories({
+    baseUrl: 'https://repo.test',
+    fetch,
+    storage,
+  });
+  await repositories.hydrate();
+
+  const commands = createSubjectCommandClient({
+    baseUrl: 'https://repo.test',
+    fetch,
+    getLearnerRevision: (learnerId) => repositories.runtime.readLearnerRevision(learnerId),
+    onStaleWrite: async ({ error, learnerId }) => {
+      const refreshed = repositories.runtime.applyLearnerRevisionHint(
+        learnerId,
+        staleWriteCurrentRevision(error?.payload),
+      );
+      if (!refreshed) await repositories.hydrate({ cacheScope: 'subject-command-stale-write' });
+    },
+    onCommandApplied: ({ learnerId, subjectId, response }) => {
+      repositories.runtime.applySubjectCommandResult({ learnerId, subjectId, response });
+    },
+  });
+
+  await commands.send({
+    subjectId: 'spelling',
+    learnerId: 'learner-a',
+    command: 'start-session',
+    payload: { mode: 'smart', length: 1 },
+    requestId: 'cmd-client-stale-fallback',
+  });
+
+  assert.equal(bootstrapCount, 2);
+  assert.deepEqual(commandBodies.map((body) => body.expectedLearnerRevision), [0, 1]);
+  assert.equal(repositories.runtime.readLearnerRevision('learner-a'), 2);
 });


### PR DESCRIPTION
## Summary\n- refresh stale subject-command learner revisions from server conflict hints before retrying\n- fall back to full bootstrap when stale-write payloads do not include a usable revision\n- cover both no-bootstrap retry and missing-hint fallback in persistence tests\n\n## Verification\n- npm test -- --test-name-pattern="subject commands refresh stale learner revision|subject commands fall back to bootstrap" tests/persistence.test.js\n- npm test\n- npm run check\n- git diff --check