### PR TITLE
fix(spelling): cache progress during smart session start

### DIFF
--- a/shared/spelling/legacy-engine.js
+++ b/shared/spelling/legacy-engine.js
@@ -212,8 +212,12 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
         return Object.assign({}, defaultProgress(), existing || {});
       }
 
+      function getProgressFromStore(profileId, slug, progressStore) {
+        return progressForSlug(progressStore || loadProgress(profileId), slug);
+      }
+
       function getProgress(profileId, slug) {
-        return progressForSlug(loadProgress(profileId), slug);
+        return getProgressFromStore(profileId, slug);
       }
 
       function setProgress(profileId, slug, record) {
@@ -234,8 +238,8 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
         return POOLS.core.slice();
       }
 
-      function scoreForSmart(profileId, word) {
-        var p = getProgress(profileId, word.slug);
+      function scoreForSmart(profileId, word, progressStore) {
+        var p = getProgressFromStore(profileId, word.slug, progressStore);
         var today = todayDay();
         var total = p.correct + p.wrong;
         var score = 0;
@@ -248,8 +252,8 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
         return score;
       }
 
-      function scoreForTrouble(profileId, word) {
-        var p = getProgress(profileId, word.slug);
+      function scoreForTrouble(profileId, word, progressStore) {
+        var p = getProgressFromStore(profileId, word.slug, progressStore);
         var total = p.correct + p.wrong;
         var score = 10;
         if (p.wrong > 0) score += p.wrong * 24;
@@ -260,8 +264,8 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
         return score;
       }
 
-      function smartBucket(profileId, word) {
-        var p = getProgress(profileId, word.slug);
+      function smartBucket(profileId, word, progressStore) {
+        var p = getProgressFromStore(profileId, word.slug, progressStore);
         var today = todayDay();
         if (p.wrong > 0 && p.dueDay <= today) return "urgent";
         if (p.attempts > 0 && p.dueDay <= today) return "due";
@@ -303,9 +307,10 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
         return weight;
       }
 
-      function chooseSmartWords(profileId, opts) {
+      function chooseSmartWords(profileId, opts, progressStore) {
         opts = opts || {};
         var available = filteredWords(opts.yearFilter).slice();
+        var store = progressStore || loadProgress(profileId);
         var length = typeof opts.length === "number" ? opts.length : Infinity;
         var target = Math.min(length, available.length);
         var bucketWeights = { urgent: 7, fragile: 5, due: 4, new: 3, growing: 2, secure: 0.7 };
@@ -314,16 +319,16 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
         while (selected.length < target && available.length) {
           var bucketChoices = Object.keys(bucketWeights).map(function (name) {
             var baseWeight = bucketWeights[name];
-            var words = available.filter(function (word) { return smartBucket(profileId, word) === name; });
+            var words = available.filter(function (word) { return smartBucket(profileId, word, store) === name; });
             if (!words.length) return null;
-            var recentBuckets = selected.slice(-3).map(function (item) { return smartBucket(profileId, item); });
+            var recentBuckets = selected.slice(-3).map(function (item) { return smartBucket(profileId, item, store); });
             var repeatPenalty = recentBuckets.filter(function (bucket) { return bucket === name; }).length >= 2 ? 0.5 : 1;
             return { name: name, words: words, weight: baseWeight * repeatPenalty };
           }).filter(Boolean);
 
           var chosenBucket = weightedPick(bucketChoices, function (bucket) { return bucket.weight; });
           if (!chosenBucket) break;
-          var chosenWord = weightedPick(chosenBucket.words, function (word) { return selectionWeight(word, selected, scoreForSmart(profileId, word)); });
+          var chosenWord = weightedPick(chosenBucket.words, function (word) { return selectionWeight(word, selected, scoreForSmart(profileId, word, store)); });
           if (!chosenWord) break;
           selected.push(chosenWord);
           var idx = available.findIndex(function (word) { return word.slug === chosenWord.slug; });
@@ -332,16 +337,17 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
         return selected;
       }
 
-      function chooseTroubleWords(profileId, opts) {
+      function chooseTroubleWords(profileId, opts, progressStore) {
         opts = opts || {};
         var today = todayDay();
+        var store = progressStore || loadProgress(profileId);
         var candidates = filteredWords(opts.yearFilter).filter(function (word) {
-          var p = getProgress(profileId, word.slug);
+          var p = getProgressFromStore(profileId, word.slug, store);
           return isTroubleProgress(p, today);
         });
 
         if (!candidates.length) {
-          return { words: chooseSmartWords(profileId, opts), fallback: true };
+          return { words: chooseSmartWords(profileId, opts, store), fallback: true };
         }
 
         var length = typeof opts.length === "number" ? opts.length : Infinity;
@@ -349,7 +355,7 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
         var available = candidates.slice();
         var selected = [];
         while (selected.length < target && available.length) {
-          var chosenWord = weightedPick(available, function (word) { return selectionWeight(word, selected, scoreForTrouble(profileId, word)); });
+          var chosenWord = weightedPick(available, function (word) { return selectionWeight(word, selected, scoreForTrouble(profileId, word, store)); });
           if (!chosenWord) break;
           selected.push(chosenWord);
           var idx = available.findIndex(function (word) { return word.slug === chosenWord.slug; });
@@ -434,6 +440,7 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
         var mode = options.mode || MODES.SMART;
         var yearFilter = mode === MODES.TEST ? "core" : normaliseFilter(options.yearFilter);
         var length = typeof options.length === "number" ? options.length : 20;
+        var progressStore = mode === MODES.TEST ? null : loadProgress(profileId);
 
         var selected = [];
         var actualMode = mode;
@@ -443,14 +450,14 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
           selected = options.words.slice();
           actualMode = options.mode || MODES.SINGLE;
         } else if (mode === MODES.TROUBLE) {
-          var choice = chooseTroubleWords(profileId, { yearFilter: yearFilter, length: length });
+          var choice = chooseTroubleWords(profileId, { yearFilter: yearFilter, length: length }, progressStore);
           selected = choice.words;
           fallback = choice.fallback;
           if (fallback) actualMode = MODES.SMART;
         } else if (mode === MODES.TEST) {
           selected = chooseTestWords(profileId, { yearFilter: yearFilter, length: length });
         } else {
-          selected = chooseSmartWords(profileId, { yearFilter: yearFilter, length: length });
+          selected = chooseSmartWords(profileId, { yearFilter: yearFilter, length: length }, progressStore);
         }
 
         if (!selected.length) {
@@ -461,7 +468,7 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
         if (actualMode !== MODES.TEST) {
           for (var k = 0; k < selected.length; k++) {
             var word = selected[k];
-            var progress = getProgress(profileId, word.slug);
+            var progress = getProgressFromStore(profileId, word.slug, progressStore);
             status[word.slug] = {
               attempts: 0,
               successes: 0,
@@ -504,12 +511,12 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
           startedAt: Date.now(),
         };
 
-        return { ok: true, session: session, fallback: fallback };
+        return { ok: true, session: session, fallback: fallback, progressStore: progressStore };
       }
 
-      function candidateWeightForQueueSlug(session, profileId, slug, index) {
+      function candidateWeightForQueueSlug(session, profileId, slug, index, progressStore) {
         var word = WORD_BY_SLUG[slug];
-        var progress = getProgress(profileId, slug);
+        var progress = getProgressFromStore(profileId, slug, progressStore);
         var info = session.status[slug];
         var weight = Math.max(1, 10 - index);
         if (progress.dueDay <= todayDay()) weight += 14;
@@ -521,11 +528,11 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
         return Math.max(0.2, weight);
       }
 
-      function chooseNextQueueSlug(session, profileId) {
+      function chooseNextQueueSlug(session, profileId, progressStore) {
         if (!session || !session.queue.length) return null;
         var windowSize = Math.min(8, session.queue.length);
         var candidates = session.queue.slice(0, windowSize).map(function (slug, index) {
-          return { slug: slug, index: index, weight: candidateWeightForQueueSlug(session, profileId, slug, index) };
+          return { slug: slug, index: index, weight: candidateWeightForQueueSlug(session, profileId, slug, index, progressStore) };
         });
         var picked = weightedPick(candidates, function (item) { return item.weight; });
         if (!picked) return session.queue.shift();
@@ -573,7 +580,7 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
       // { done: false, word, prompt } if a card is ready; or { done: true } if
       // the queue is exhausted. Only valid while phase === 'question' (the caller
       // should not call this during retry/correction).
-      function advanceCard(session, profileId) {
+      function advanceCard(session, profileId, progressStore) {
         if (!session) return { done: true };
         if (session.type === "test") {
           if (!session.queue.length) return { done: true };
@@ -583,7 +590,7 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
         }
 
         while (session.queue.length) {
-          var nextSlug = chooseNextQueueSlug(session, profileId);
+          var nextSlug = chooseNextQueueSlug(session, profileId, progressStore);
           if (!nextSlug) break;
           if (!session.status[nextSlug].done) {
             setCurrentPrompt(session, nextSlug);

--- a/shared/spelling/service.js
+++ b/shared/spelling/service.js
@@ -262,7 +262,7 @@ function savedPromptForSlug(rawSession, slug, wordBySlug = DEFAULT_WORD_BY_SLUG)
     || normalisePromptForSlug(rawSession?.currentCard?.prompt, slug, wordBySlug);
 }
 
-function decorateSession(engine, learnerId, session, wordBySlug = DEFAULT_WORD_BY_SLUG) {
+function decorateSession(engine, learnerId, session, wordBySlug = DEFAULT_WORD_BY_SLUG, progressStore = null) {
   if (!session) return null;
   const currentPrompt = session.currentSlug ? buildPrompt(engine, session, session.currentSlug, wordBySlug) : null;
   const currentCard = session.currentSlug && currentPrompt
@@ -272,6 +272,11 @@ function decorateSession(engine, learnerId, session, wordBySlug = DEFAULT_WORD_B
         prompt: currentPrompt,
       }
     : null;
+  const currentProgress = currentCard?.slug
+    ? (progressStore && typeof engine.progressForSlug === 'function'
+      ? engine.progressForSlug(progressStore, currentCard.slug)
+      : engine.getProgress(learnerId, currentCard.slug))
+    : null;
 
   return {
     ...session,
@@ -279,7 +284,7 @@ function decorateSession(engine, learnerId, session, wordBySlug = DEFAULT_WORD_B
     currentPrompt,
     currentCard,
     progress: buildProgressMeta(session),
-    currentStage: currentCard?.slug ? engine.getProgress(learnerId, currentCard.slug).stage : 0,
+    currentStage: currentProgress?.stage || 0,
   };
 }
 
@@ -671,8 +676,8 @@ export function createSpellingService({ repository, storage, tts, now, random, c
       }, { ok: false });
     }
 
-    const firstCard = engine.advanceCard(created.session, learnerId);
-    const session = firstCard.done ? null : decorateSession(engine, learnerId, created.session, runtimeWordBySlug);
+    const firstCard = engine.advanceCard(created.session, learnerId, created.progressStore);
+    const session = firstCard.done ? null : decorateSession(engine, learnerId, created.session, runtimeWordBySlug, created.progressStore);
     if (!session) {
       return buildTransition({
         ...createInitialSpellingState(),

--- a/tests/spelling.test.js
+++ b/tests/spelling.test.js
@@ -150,6 +150,48 @@ test('Smart Review can be scoped to the Extra spelling pool', () => {
   assert.ok(words.every((word) => word.year === 'extra'));
 });
 
+test('Smart Review reuses one progress snapshot when starting from dense learner history', () => {
+  const now = () => Date.UTC(2026, 0, 10);
+  const today = Math.floor(now() / (24 * 60 * 60 * 1000));
+  const storage = installMemoryStorage();
+  const repositories = createLocalPlatformRepositories({ storage });
+  const progress = Object.fromEntries(WORDS
+    .filter((word) => word.spellingPool === 'core')
+    .map((word, index) => [word.slug, {
+      stage: index % 6,
+      attempts: 4 + (index % 5),
+      correct: 3 + (index % 5),
+      wrong: index % 3,
+      dueDay: today - (index % 7),
+      lastDay: today - 1,
+      lastResult: index % 3 === 0 ? 'correct' : 'wrong',
+    }]));
+  repositories.subjectStates.writeData('learner-a', 'spelling', { progress });
+  const persistence = createSpellingPersistence({ repositories, now });
+  const reads = countStorageReads(persistence.storage);
+  const service = createSpellingService({
+    repository: persistence,
+    now,
+    random: makeSeededRandom(17),
+    tts: {
+      speak() {},
+      stop() {},
+      warmup() {},
+    },
+  });
+
+  const transition = service.startSession('learner-a', {
+    mode: 'smart',
+    yearFilter: 'core',
+    length: 10,
+  });
+
+  assert.equal(transition.ok, true);
+  assert.equal(transition.state.phase, 'session');
+  assert.equal(transition.state.session.uniqueWords.length, 10);
+  assert.equal(reads.get('ks2-spell-progress-learner-a'), 1);
+});
+
 test('Smart Review keeps secured Extra words with old mistakes behind active learning', () => {
   const now = () => Date.UTC(2026, 0, 10);
   const today = Math.floor(now() / (24 * 60 * 60 * 1000));


### PR DESCRIPTION
## Summary
- Cache the learner progress map once while building Smart Review and Trouble Drill sessions.
- Reuse that snapshot for selection scoring, session status initialisation, first-card queue weighting, and current stage decoration.
- Add a dense-history regression test that asserts Smart Review start reads the learner progress snapshot once.

## Verification
- `node --test tests/spelling.test.js tests/server-spelling-engine-parity.test.js`
- Eugenia production runtime benchmark: start-session dropped from about 1.7s before the fix to 12.5ms with the cached progress snapshot.
- `npm test` (713 pass, 1 skip after `npm ci` in the worktree)
- `npm run check`
- `git diff --check`