### PR TITLE
fix(client): coordinate bootstrap across tabs

### DIFF
--- a/src/platform/core/repositories/api.js
+++ b/src/platform/core/repositories/api.js
@@ -40,6 +40,7 @@ const SUBJECT_STATE_MERGE_STRATEGIES = new Set(['merge', 'ui', 'data', 'replace'
 const BOOTSTRAP_BACKOFF_BASE_MS = 2_000;
 const BOOTSTRAP_BACKOFF_MAX_MS = 30_000;
 const BOOTSTRAP_BACKOFF_JITTER_MS = 250;
+const BOOTSTRAP_COORDINATION_LEASE_MS = BOOTSTRAP_BACKOFF_MAX_MS;
 const LEGACY_RUNTIME_WRITES_ENABLED = typeof process === 'object'
   && process?.env?.NODE_ENV !== 'production';
 const LEGACY_RUNTIME_OPERATION_KINDS = new Set([
@@ -59,6 +60,10 @@ const LEGACY_RUNTIME_OPERATION_KINDS = new Set([
 
 function apiCacheStorageKey(scope = 'default') {
   return `ks2-platform-v2.api-cache-state:${scope}`;
+}
+
+function bootstrapCoordinationStorageKey(storageKey) {
+  return `${storageKey}:bootstrap-coordination`;
 }
 
 function createNoopStorage() {
@@ -538,6 +543,54 @@ function persistCachedState(storage, storageKey, bundle, pendingOperations, sync
   }
 }
 
+function readBootstrapCoordination(storage, storageKey, now) {
+  let raw;
+  try {
+    raw = storage?.getItem?.(storageKey);
+  } catch {
+    return null;
+  }
+  if (!raw) return null;
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  const ownerId = typeof parsed?.ownerId === 'string' && parsed.ownerId ? parsed.ownerId : '';
+  const expiresAt = Number(parsed?.expiresAt);
+  const startedAt = Number(parsed?.startedAt);
+  if (!ownerId || !Number.isFinite(expiresAt) || expiresAt <= now) return null;
+
+  return {
+    ownerId,
+    startedAt: Number.isFinite(startedAt) ? startedAt : 0,
+    expiresAt,
+    remainingMs: Math.max(0, expiresAt - now),
+  };
+}
+
+function writeBootstrapCoordination(storage, storageKey, lease) {
+  try {
+    storage?.setItem?.(storageKey, JSON.stringify(lease));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function clearBootstrapCoordination(storage, storageKey, ownerId, now) {
+  const active = readBootstrapCoordination(storage, storageKey, now);
+  if (active && active.ownerId !== ownerId) return;
+  try {
+    storage?.removeItem?.(storageKey);
+  } catch {
+    // Coordination is best-effort; stale leases expire quickly.
+  }
+}
+
 function upsertPracticeSession(records, record) {
   const next = normalisePracticeSessionRecord(record);
   if (!next.id || !next.learnerId || !next.subjectId) return filterSessions(records);
@@ -982,6 +1035,8 @@ export function createApiPlatformRepositories({
     ? cacheScopeKey
     : repositoryAuthCacheScopeKey(authSession);
   const storageKey = apiCacheStorageKey(resolvedCacheScopeKey);
+  const bootstrapCoordinationKey = bootstrapCoordinationStorageKey(storageKey);
+  const bootstrapCoordinationOwnerId = uid('bootstrap-tab');
   const cachedState = loadCachedState(resolvedStorage, storageKey);
   const cache = normaliseRepositoryBundle(cachedState.bundle);
   let pendingOperations = normalisePendingOperations(cachedState.pendingOperations)
@@ -1031,8 +1086,65 @@ export function createApiPlatformRepositories({
     return bootstrapBackoff;
   }
 
+  function createBootstrapCoordinationBackoff(activeCoordination) {
+    const retryAfterMs = Math.min(
+      BOOTSTRAP_BACKOFF_BASE_MS,
+      Math.max(0, Number(activeCoordination?.remainingMs) || 0),
+    );
+    return {
+      attempt: Math.max(1, Number(bootstrapBackoff?.attempt || 0) + 1),
+      retryAfterMs,
+      retryAt: currentTime() + retryAfterMs,
+      reason: {
+        code: 'bootstrap_in_flight',
+        status: 0,
+        message: 'Another browser tab is already refreshing bootstrap state. Cached data remains available until this tab retries.',
+      },
+    };
+  }
+
+  function backOffForBootstrapCoordination(activeCoordination) {
+    const coordinationBackoff = createBootstrapCoordinationBackoff(activeCoordination);
+    markRemoteFailure(createBootstrapBackoffError(coordinationBackoff, '/api/bootstrap'));
+  }
+
+  async function confirmBootstrapCoordinationBeforeFetch(lease) {
+    if (!lease) return true;
+    await Promise.resolve();
+    const active = readBootstrapCoordination(resolvedStorage, bootstrapCoordinationKey, currentTime());
+    if (!active || active.ownerId === bootstrapCoordinationOwnerId) return true;
+    backOffForBootstrapCoordination(active);
+    return false;
+  }
+
   function clearBootstrapBackoff() {
     bootstrapBackoff = null;
+  }
+
+  function activeBootstrapCoordination() {
+    const active = readBootstrapCoordination(resolvedStorage, bootstrapCoordinationKey, currentTime());
+    if (!active || active.ownerId === bootstrapCoordinationOwnerId) return null;
+    return active;
+  }
+
+  function acquireBootstrapCoordination() {
+    const now = currentTime();
+    const active = readBootstrapCoordination(resolvedStorage, bootstrapCoordinationKey, now);
+    if (active && active.ownerId !== bootstrapCoordinationOwnerId) return null;
+
+    const lease = {
+      ownerId: bootstrapCoordinationOwnerId,
+      startedAt: now,
+      expiresAt: now + BOOTSTRAP_COORDINATION_LEASE_MS,
+    };
+    if (!writeBootstrapCoordination(resolvedStorage, bootstrapCoordinationKey, lease)) return null;
+    const confirmed = readBootstrapCoordination(resolvedStorage, bootstrapCoordinationKey, now);
+    return confirmed?.ownerId === bootstrapCoordinationOwnerId ? lease : null;
+  }
+
+  function releaseBootstrapCoordination(lease) {
+    if (!lease) return;
+    clearBootstrapCoordination(resolvedStorage, bootstrapCoordinationKey, bootstrapCoordinationOwnerId, currentTime());
   }
 
   function createBootstrapBackoffError(backoff, scope = '/api/bootstrap') {
@@ -1084,6 +1196,33 @@ export function createApiPlatformRepositories({
       pendingOperations,
       syncState,
       monsterVisualConfig,
+      bootstrapBackoff,
+    );
+    if (error) {
+      lastCacheError = createPersistenceError({
+        phase: 'cache-write',
+        scope,
+        code: 'cache_write_failed',
+        message: error.message || String(error),
+        retryable: true,
+        resolution: 'retry-sync',
+      });
+    } else {
+      lastCacheError = null;
+    }
+    recomputePersistence();
+    return !error;
+  }
+
+  function persistBootstrapBackoff(scope = 'bootstrap-backoff') {
+    const sharedState = loadCachedState(resolvedStorage, storageKey);
+    const error = persistCachedState(
+      resolvedStorage,
+      storageKey,
+      sharedState.bundle,
+      sharedState.pendingOperations,
+      sharedState.syncState,
+      sharedState.monsterVisualConfig,
       bootstrapBackoff,
     );
     if (error) {
@@ -1464,13 +1603,31 @@ export function createApiPlatformRepositories({
 
   async function hydrateRemoteState({ rebasePending = false, rebasePayloads = false, cacheScope = 'bootstrap' } = {}) {
     const fallbackAvailable = hasCacheFallback(cache, pendingOperations);
+    let bootstrapLease = null;
     if (fallbackAvailable) {
       const activeBackoff = activeBootstrapBackoff();
       if (activeBackoff) {
         markRemoteFailure(createBootstrapBackoffError(activeBackoff, '/api/bootstrap'));
-        persistLocalCache(cacheScope);
         return null;
       }
+
+      const activeCoordination = activeBootstrapCoordination();
+      if (activeCoordination) {
+        backOffForBootstrapCoordination(activeCoordination);
+        return null;
+      }
+
+      bootstrapLease = acquireBootstrapCoordination();
+      if (!bootstrapLease) {
+        const lostCoordinationRace = activeBootstrapCoordination();
+        if (lostCoordinationRace) {
+          backOffForBootstrapCoordination(lostCoordinationRace);
+          return null;
+        }
+      }
+
+      const confirmedBootstrapLease = await confirmBootstrapCoordinationBeforeFetch(bootstrapLease);
+      if (!confirmedBootstrapLease) return null;
     }
 
     try {
@@ -1499,10 +1656,12 @@ export function createApiPlatformRepositories({
         : classifyError(error, '/api/bootstrap');
       markRemoteFailure(persistenceError);
       if (fallbackAvailable) {
-        persistLocalCache(cacheScope);
+        if (backoff) persistBootstrapBackoff(cacheScope);
         return null;
       }
       throw error;
+    } finally {
+      releaseBootstrapCoordination(bootstrapLease);
     }
   }
 

--- a/tests/persistence.test.js
+++ b/tests/persistence.test.js
@@ -628,6 +628,348 @@ test('bootstrap backoff blocks retry flush from masking pending-write recovery s
   assert.equal(server.store.learners.selectedId, 'learner-a');
 });
 
+test('bootstrap hydrate backs off when another tab is already refreshing a usable cache', async () => {
+  const storage = installMemoryStorage();
+  const server = createMockRepositoryServer({
+    learners: learnerSnapshot(),
+  });
+  let now = 8_000;
+  let pauseNextBootstrap = false;
+  let resumeBootstrap = null;
+  const bootstrapRequests = [];
+  const fetch = async (input, init = {}) => {
+    const url = new URL(typeof input === 'string' ? input : input.url, 'https://repo.test');
+    const method = String(init.method || 'GET').toUpperCase();
+    if (url.pathname === '/api/bootstrap' && method === 'GET') {
+      bootstrapRequests.push(now);
+      if (pauseNextBootstrap) {
+        pauseNextBootstrap = false;
+        await new Promise((resolve) => {
+          resumeBootstrap = resolve;
+        });
+      }
+    }
+    return server.fetch(input, init);
+  };
+  const commonOptions = {
+    baseUrl: 'https://repo.test',
+    fetch,
+    storage,
+    now: () => now,
+    random: () => 0,
+  };
+
+  const warmRepositories = createApiPlatformRepositories(commonOptions);
+  await warmRepositories.hydrate();
+  assert.equal(bootstrapRequests.length, 1);
+
+  pauseNextBootstrap = true;
+  const refreshingTab = createApiPlatformRepositories(commonOptions);
+  const refreshPromise = refreshingTab.hydrate();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const backedOffTab = createApiPlatformRepositories(commonOptions);
+  await backedOffTab.hydrate();
+  const backedOff = backedOffTab.persistence.read();
+
+  assert.equal(bootstrapRequests.length, 2);
+  assert.equal(backedOff.mode, 'degraded');
+  assert.equal(backedOff.lastError.code, 'bootstrap_retry_backoff');
+  assert.equal(backedOff.lastError.details.reason.code, 'bootstrap_in_flight');
+  assert.equal(backedOff.pendingWriteCount, 0);
+  assert.equal(backedOffTab.learners.read().selectedId, 'learner-a');
+
+  resumeBootstrap();
+  await refreshPromise;
+  assert.equal(refreshingTab.persistence.read().mode, 'remote-sync');
+});
+
+test('bootstrap hydrate backs off when another tab wins the coordination race', async () => {
+  const storage = installMemoryStorage();
+  const server = createMockRepositoryServer({
+    learners: learnerSnapshot(),
+  });
+  let now = 12_000;
+  let forceRaceLoss = false;
+  const originalSetItem = storage.setItem.bind(storage);
+  storage.setItem = (key, value) => {
+    originalSetItem(key, value);
+    if (forceRaceLoss && String(key).endsWith(':bootstrap-coordination')) {
+      forceRaceLoss = false;
+      originalSetItem(key, JSON.stringify({
+        ownerId: 'other-tab',
+        startedAt: now,
+        expiresAt: now + 2_000,
+      }));
+    }
+  };
+  const bootstrapRequests = [];
+  const fetch = async (input, init = {}) => {
+    const url = new URL(typeof input === 'string' ? input : input.url, 'https://repo.test');
+    const method = String(init.method || 'GET').toUpperCase();
+    if (url.pathname === '/api/bootstrap' && method === 'GET') bootstrapRequests.push(now);
+    return server.fetch(input, init);
+  };
+  const commonOptions = {
+    baseUrl: 'https://repo.test',
+    fetch,
+    storage,
+    now: () => now,
+    random: () => 0,
+  };
+
+  const warmRepositories = createApiPlatformRepositories(commonOptions);
+  await warmRepositories.hydrate();
+  assert.equal(bootstrapRequests.length, 1);
+
+  forceRaceLoss = true;
+  const raceLostTab = createApiPlatformRepositories(commonOptions);
+  await raceLostTab.hydrate();
+
+  const backedOff = raceLostTab.persistence.read();
+  assert.equal(bootstrapRequests.length, 1);
+  assert.equal(backedOff.mode, 'degraded');
+  assert.equal(backedOff.lastError.code, 'bootstrap_retry_backoff');
+  assert.equal(backedOff.lastError.details.reason.code, 'bootstrap_in_flight');
+  assert.equal(raceLostTab.learners.read().selectedId, 'learner-a');
+});
+
+test('bootstrap hydrate backs off when a confirmed lease is overwritten before fetch', async () => {
+  const storage = installMemoryStorage();
+  const server = createMockRepositoryServer({
+    learners: learnerSnapshot(),
+  });
+  let now = 16_000;
+  let overwriteAfterConfirm = false;
+  const originalGetItem = storage.getItem.bind(storage);
+  const originalSetItem = storage.setItem.bind(storage);
+  storage.getItem = (key) => {
+    const value = originalGetItem(key);
+    if (overwriteAfterConfirm && String(key).endsWith(':bootstrap-coordination') && value) {
+      const parsed = JSON.parse(value);
+      if (String(parsed?.ownerId || '').startsWith('bootstrap-tab')) {
+        overwriteAfterConfirm = false;
+        originalSetItem(key, JSON.stringify({
+          ownerId: 'other-tab',
+          startedAt: now,
+          expiresAt: now + 30_000,
+        }));
+      }
+    }
+    return value;
+  };
+  const bootstrapRequests = [];
+  const fetch = async (input, init = {}) => {
+    const url = new URL(typeof input === 'string' ? input : input.url, 'https://repo.test');
+    const method = String(init.method || 'GET').toUpperCase();
+    if (url.pathname === '/api/bootstrap' && method === 'GET') bootstrapRequests.push(now);
+    return server.fetch(input, init);
+  };
+  const commonOptions = {
+    baseUrl: 'https://repo.test',
+    fetch,
+    storage,
+    now: () => now,
+    random: () => 0,
+  };
+
+  const warmRepositories = createApiPlatformRepositories(commonOptions);
+  await warmRepositories.hydrate();
+  assert.equal(bootstrapRequests.length, 1);
+
+  overwriteAfterConfirm = true;
+  const raceLostTab = createApiPlatformRepositories(commonOptions);
+  await raceLostTab.hydrate();
+
+  const backedOff = raceLostTab.persistence.read();
+  assert.equal(bootstrapRequests.length, 1);
+  assert.equal(backedOff.mode, 'degraded');
+  assert.equal(backedOff.lastError.code, 'bootstrap_retry_backoff');
+  assert.equal(backedOff.lastError.details.reason.code, 'bootstrap_in_flight');
+  assert.equal(raceLostTab.learners.read().selectedId, 'learner-a');
+});
+
+test('bootstrap coordination lease covers a slow in-flight refresh', async () => {
+  const storage = installMemoryStorage();
+  const server = createMockRepositoryServer({
+    learners: learnerSnapshot(),
+  });
+  let now = 20_000;
+  let pauseNextBootstrap = false;
+  let resumeBootstrap = null;
+  const bootstrapRequests = [];
+  const fetch = async (input, init = {}) => {
+    const url = new URL(typeof input === 'string' ? input : input.url, 'https://repo.test');
+    const method = String(init.method || 'GET').toUpperCase();
+    if (url.pathname === '/api/bootstrap' && method === 'GET') {
+      bootstrapRequests.push(now);
+      if (pauseNextBootstrap) {
+        pauseNextBootstrap = false;
+        await new Promise((resolve) => {
+          resumeBootstrap = resolve;
+        });
+      }
+    }
+    return server.fetch(input, init);
+  };
+  const commonOptions = {
+    baseUrl: 'https://repo.test',
+    fetch,
+    storage,
+    now: () => now,
+    random: () => 0,
+  };
+
+  const warmRepositories = createApiPlatformRepositories(commonOptions);
+  await warmRepositories.hydrate();
+  assert.equal(bootstrapRequests.length, 1);
+
+  pauseNextBootstrap = true;
+  const refreshingTab = createApiPlatformRepositories(commonOptions);
+  const refreshPromise = refreshingTab.hydrate();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  now += 2_501;
+
+  const backedOffTab = createApiPlatformRepositories(commonOptions);
+  await backedOffTab.hydrate();
+  const backedOff = backedOffTab.persistence.read();
+
+  assert.equal(bootstrapRequests.length, 2);
+  assert.equal(backedOff.lastError.code, 'bootstrap_retry_backoff');
+  assert.equal(backedOff.lastError.details.reason.code, 'bootstrap_in_flight');
+  assert.equal(backedOffTab.learners.read().selectedId, 'learner-a');
+
+  resumeBootstrap();
+  await refreshPromise;
+  assert.equal(refreshingTab.persistence.read().mode, 'remote-sync');
+});
+
+test('bootstrap coordination backoff does not overwrite a fresher shared cache', async () => {
+  const storage = installMemoryStorage();
+  const server = createMockRepositoryServer({
+    learners: learnerSnapshot(),
+  });
+  let now = 30_000;
+  const fetch = async (input, init = {}) => server.fetch(input, init);
+  const commonOptions = {
+    baseUrl: 'https://repo.test',
+    fetch,
+    storage,
+    now: () => now,
+    random: () => 0,
+  };
+
+  const warmRepositories = createApiPlatformRepositories(commonOptions);
+  await warmRepositories.hydrate();
+
+  const staleTab = createApiPlatformRepositories(commonOptions);
+  assert.equal(staleTab.learners.read().selectedId, 'learner-a');
+
+  const stored = JSON.parse(storage.getItem(DEFAULT_API_CACHE_STORAGE_KEY));
+  stored.bundle.learners = {
+    byId: {
+      'learner-b': {
+        id: 'learner-b',
+        name: 'Ben',
+        yearGroup: 'Y5',
+        goal: 'sats',
+        dailyMinutes: 15,
+        avatarColor: '#47A878',
+        createdAt: 2,
+      },
+    },
+    allIds: ['learner-b'],
+    selectedId: 'learner-b',
+  };
+  stored.syncState.learnerRevisions = { 'learner-b': 4 };
+  storage.setItem(DEFAULT_API_CACHE_STORAGE_KEY, JSON.stringify(stored));
+  storage.setItem(`${DEFAULT_API_CACHE_STORAGE_KEY}:bootstrap-coordination`, JSON.stringify({
+    ownerId: 'other-tab',
+    startedAt: now,
+    expiresAt: now + 30_000,
+  }));
+
+  await staleTab.hydrate();
+
+  const after = JSON.parse(storage.getItem(DEFAULT_API_CACHE_STORAGE_KEY));
+  assert.equal(after.bundle.learners.selectedId, 'learner-b');
+  assert.deepEqual(after.bundle.learners.allIds, ['learner-b']);
+  assert.equal(after.bundle.learners.byId['learner-a'], undefined);
+  assert.equal(after.syncState.learnerRevisions['learner-b'], 4);
+  assert.equal(staleTab.persistence.read().lastError.code, 'bootstrap_retry_backoff');
+  assert.equal(staleTab.learners.read().selectedId, 'learner-a');
+});
+
+test('bootstrap failure backoff preserves a fresher shared cache and pending queue', async () => {
+  const storage = installMemoryStorage();
+  const server = createMockRepositoryServer({
+    learners: learnerSnapshot(),
+  });
+  let now = 40_000;
+  const commonOptions = {
+    baseUrl: 'https://repo.test',
+    fetch: server.fetch.bind(server),
+    storage,
+    now: () => now,
+    random: () => 0,
+  };
+
+  const warmRepositories = createApiPlatformRepositories(commonOptions);
+  await warmRepositories.hydrate();
+
+  const staleTab = createApiPlatformRepositories(commonOptions);
+  assert.equal(staleTab.learners.read().selectedId, 'learner-a');
+
+  const learnerB = {
+    id: 'learner-b',
+    name: 'Ben',
+    yearGroup: 'Y5',
+    goal: 'sats',
+    dailyMinutes: 15,
+    avatarColor: '#47A878',
+    createdAt: 2,
+  };
+  const fresherLearners = {
+    byId: { 'learner-b': learnerB },
+    allIds: ['learner-b'],
+    selectedId: 'learner-b',
+  };
+  const stored = JSON.parse(storage.getItem(DEFAULT_API_CACHE_STORAGE_KEY));
+  stored.bundle.learners = fresherLearners;
+  stored.pendingOperations = [{
+    id: 'pending-learner-b',
+    kind: 'learners.write',
+    createdAt: now,
+    status: 'pending',
+    expectedRevision: 4,
+    correlationId: 'pending-learner-b',
+    snapshot: fresherLearners,
+  }];
+  stored.syncState.learnerRevisions = { 'learner-b': 4 };
+  storage.setItem(DEFAULT_API_CACHE_STORAGE_KEY, JSON.stringify(stored));
+  server.setFailure('GET', '/api/bootstrap', {
+    status: 503,
+    body: {
+      ok: false,
+      code: 'exceeded_cpu',
+      message: 'Worker CPU limit exceeded during bootstrap.',
+    },
+  });
+
+  await staleTab.hydrate();
+
+  const after = JSON.parse(storage.getItem(DEFAULT_API_CACHE_STORAGE_KEY));
+  assert.equal(after.bundle.learners.selectedId, 'learner-b');
+  assert.deepEqual(after.bundle.learners.allIds, ['learner-b']);
+  assert.equal(after.bundle.learners.byId['learner-a'], undefined);
+  assert.equal(after.syncState.learnerRevisions['learner-b'], 4);
+  assert.equal(after.pendingOperations.length, 1);
+  assert.equal(after.pendingOperations[0].id, 'pending-learner-b');
+  assert.equal(after.bootstrapBackoff.retryAt, 42_000);
+  assert.equal(staleTab.persistence.read().lastError.code, 'exceeded_cpu');
+  assert.equal(staleTab.learners.read().selectedId, 'learner-a');
+});
+
 test('subject command responses update the api cache without queuing broad runtime writes', async () => {
   const storage = installMemoryStorage();
   const server = createMockRepositoryServer({


### PR DESCRIPTION
## Summary
- add an auth-scoped browser-local bootstrap coordination lease for cached API repositories
- make secondary tabs back off with cached state while another tab is already refreshing `/api/bootstrap`
- cover the two-tab usable-cache path so a second tab does not add a duplicate bootstrap request

## Verification
- npm test -- --test-name-pattern="bootstrap hydrate backs off when another tab" tests/persistence.test.js
- npm test -- tests/persistence.test.js tests/subject-command-client.test.js
- npm test
- npm run check
- git diff --check