### PR TITLE
feat(punctuation): expand analytics evidence

### DIFF
--- a/docs/plans/2026-04-24-002-feat-punctuation-legacy-parity-plan.md
+++ b/docs/plans/2026-04-24-002-feat-punctuation-legacy-parity-plan.md
@@ -433,7 +433,7 @@ tests/
 
 ---
 
-- [ ] U9. **Expand Analytics And Parent/Admin Evidence**
+- [x] U9. **Expand Analytics And Parent/Admin Evidence**
 
 **Goal:** Port the legacy analytics depth into production read models and adult reporting surfaces.
 

--- a/shared/punctuation/service.js
+++ b/shared/punctuation/service.js
@@ -37,6 +37,28 @@ const SUBJECT_ID = 'punctuation';
 const SERVER_AUTHORITY = 'worker';
 const GENERATED_ITEMS_PER_FAMILY = 1;
 const MAX_GPS_QUEUE_LENGTH = 12;
+const DAY_MS = 24 * 60 * 60 * 1000;
+const DAILY_TARGET_ATTEMPTS = 4;
+const ITEM_MODE_LABELS = Object.freeze({
+  choose: 'Choice',
+  insert: 'Insert punctuation',
+  fix: 'Proofreading',
+  transfer: 'Transfer writing',
+  combine: 'Sentence combining',
+  paragraph: 'Paragraph repair',
+});
+const SESSION_MODE_LABELS = Object.freeze({
+  smart: 'Smart review',
+  guided: 'Guided learn',
+  weak: 'Weak spots',
+  gps: 'GPS test',
+  endmarks: 'Endmarks focus',
+  apostrophe: 'Apostrophe focus',
+  speech: 'Speech focus',
+  comma_flow: 'Comma / flow focus',
+  boundary: 'Boundary focus',
+  structure: 'Structure focus',
+});
 
 function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -152,13 +174,22 @@ export function normalisePunctuationData(value) {
               sessionId: typeof attempt.sessionId === 'string' ? attempt.sessionId : null,
               itemId: typeof attempt.itemId === 'string' ? attempt.itemId : '',
               mode: typeof attempt.mode === 'string' ? attempt.mode : '',
+              itemMode: typeof attempt.itemMode === 'string'
+                ? attempt.itemMode
+                : (typeof attempt.mode === 'string' ? attempt.mode : ''),
               skillIds: normaliseStringArray(attempt.skillIds),
               rewardUnitId: typeof attempt.rewardUnitId === 'string' ? attempt.rewardUnitId : '',
               sessionMode: typeof attempt.sessionMode === 'string' ? attempt.sessionMode : '',
               testMode: attempt.testMode === 'gps' ? 'gps' : null,
               supportLevel: normaliseNonNegativeInteger(attempt.supportLevel, 0),
+              supportKind: typeof attempt.supportKind === 'string'
+                ? attempt.supportKind
+                : (normaliseNonNegativeInteger(attempt.supportLevel, 0) > 0 ? 'guided' : null),
               correct: attempt.correct === true,
               misconceptionTags: normaliseStringArray(attempt.misconceptionTags),
+              facetOutcomes: Array.isArray(attempt.facetOutcomes)
+                ? attempt.facetOutcomes.map(normaliseFacetForReview).filter(Boolean)
+                : [],
             }))
             .slice(-1000)
         : [],
@@ -432,6 +463,199 @@ function statsFromData(data, indexes = PUNCTUATION_CONTENT_INDEXES, now = Date.n
   };
 }
 
+function percent(correct, attempts) {
+  const total = Math.max(0, Number(attempts) || 0);
+  if (!total) return null;
+  return Math.round((Math.max(0, Number(correct) || 0) / total) * 100);
+}
+
+function humanLabel(value) {
+  return String(value || '')
+    .replace(/[._-]+/g, ' ')
+    .replace(/\b\w/g, (letter) => letter.toUpperCase())
+    .trim();
+}
+
+function itemModeLabel(value) {
+  return ITEM_MODE_LABELS[value] || humanLabel(value) || 'Practice item';
+}
+
+function sessionModeLabel(value) {
+  return SESSION_MODE_LABELS[value] || humanLabel(value) || 'Practice session';
+}
+
+function primarySkill(indexes, skillIds = []) {
+  const firstSkillId = Array.isArray(skillIds) ? skillIds.find((entry) => typeof entry === 'string' && entry) : '';
+  return firstSkillId ? indexes.skillById.get(firstSkillId) : null;
+}
+
+function skillNames(indexes, skillIds = []) {
+  return normaliseStringArray(skillIds)
+    .map((skillId) => indexes.skillById.get(skillId)?.name || humanLabel(skillId))
+    .filter(Boolean);
+}
+
+function groupAttemptAccuracy(attempts, keyFn, labelFn) {
+  const groups = new Map();
+  for (const attempt of attempts) {
+    const id = keyFn(attempt) || 'unknown';
+    const current = groups.get(id) || {
+      subjectId: SUBJECT_ID,
+      id,
+      label: labelFn(id),
+      attempts: 0,
+      correct: 0,
+      wrong: 0,
+      accuracy: null,
+    };
+    current.attempts += 1;
+    if (attempt.correct) current.correct += 1;
+    else current.wrong += 1;
+    current.accuracy = percent(current.correct, current.attempts);
+    groups.set(id, current);
+  }
+  return [...groups.values()]
+    .sort((a, b) => b.attempts - a.attempts || String(a.label).localeCompare(String(b.label)));
+}
+
+function facetRowsFromData(data, indexes, now) {
+  return Object.entries(data.progress.facets || {})
+    .map(([id, rawState]) => {
+      const [skillId, itemMode] = id.split('::');
+      const snap = memorySnapshot(rawState, now);
+      const state = snap.state;
+      const skill = indexes.skillById.get(skillId);
+      const attempts = Number(state.attempts) || 0;
+      return {
+        subjectId: SUBJECT_ID,
+        id,
+        skillId,
+        skillName: skill?.name || humanLabel(skillId),
+        itemMode: itemMode || '',
+        itemModeLabel: itemModeLabel(itemMode),
+        label: `${skill?.name || humanLabel(skillId)} · ${itemModeLabel(itemMode)}`,
+        status: snap.bucket,
+        attempts,
+        correct: Number(state.correct) || 0,
+        wrong: Number(state.incorrect) || 0,
+        accuracy: percent(state.correct, attempts),
+        mastery: snap.mastery,
+        dueAt: Number(state.dueAt) || 0,
+        lastSeenAt: Number(state.lastSeen) || 0,
+      };
+    })
+    .filter((entry) => entry.attempts > 0)
+    .sort((a, b) => {
+      const statusOrder = { weak: 0, due: 1, learning: 2, new: 3, secure: 4 };
+      return (statusOrder[a.status] ?? 99) - (statusOrder[b.status] ?? 99)
+        || a.mastery - b.mastery
+        || b.wrong - a.wrong
+        || b.lastSeenAt - a.lastSeenAt
+        || String(a.label).localeCompare(String(b.label));
+    });
+}
+
+function recentMistakesFromAttempts(attempts, indexes) {
+  return attempts
+    .filter((attempt) => attempt.correct !== true)
+    .slice(-8)
+    .reverse()
+    .map((attempt) => {
+      const itemMode = attempt.itemMode || attempt.mode || '';
+      const names = skillNames(indexes, attempt.skillIds);
+      const primary = primarySkill(indexes, attempt.skillIds);
+      return {
+        subjectId: SUBJECT_ID,
+        itemId: attempt.itemId || '',
+        label: `${primary?.name || names[0] || 'Punctuation'} · ${itemModeLabel(itemMode)}`,
+        itemMode,
+        itemModeLabel: itemModeLabel(itemMode),
+        sessionMode: attempt.sessionMode || 'smart',
+        sessionModeLabel: sessionModeLabel(attempt.sessionMode || 'smart'),
+        skillIds: normaliseStringArray(attempt.skillIds),
+        skillNames: names,
+        rewardUnitId: attempt.rewardUnitId || '',
+        misconceptionTags: normaliseStringArray(attempt.misconceptionTags).slice(0, 6),
+        facetOutcomes: Array.isArray(attempt.facetOutcomes)
+          ? attempt.facetOutcomes
+              .filter((facet) => facet && facet.ok !== true)
+              .map((facet) => ({
+                id: facet.id,
+                label: facet.label || humanLabel(facet.id),
+                ok: false,
+              }))
+              .slice(0, 6)
+          : [],
+        supportLevel: normaliseNonNegativeInteger(attempt.supportLevel, 0),
+        supportKind: attempt.supportKind || null,
+        testMode: attempt.testMode || null,
+        createdAt: normaliseTimestamp(attempt.ts, 0),
+      };
+    });
+}
+
+function misconceptionPatternsFromAttempts(attempts) {
+  const patterns = new Map();
+  for (const attempt of attempts) {
+    for (const tag of normaliseStringArray(attempt.misconceptionTags)) {
+      const current = patterns.get(tag) || {
+        subjectId: SUBJECT_ID,
+        id: tag,
+        label: `${humanLabel(tag)} pattern`,
+        count: 0,
+        lastSeenAt: 0,
+        source: 'punctuation-attempts',
+      };
+      current.count += 1;
+      current.lastSeenAt = Math.max(current.lastSeenAt, normaliseTimestamp(attempt.ts, 0));
+      patterns.set(tag, current);
+    }
+  }
+  return [...patterns.values()]
+    .sort((a, b) => b.count - a.count || b.lastSeenAt - a.lastSeenAt)
+    .slice(0, 8);
+}
+
+function dayIndex(value) {
+  return Math.floor(normaliseTimestamp(value, 0) / DAY_MS);
+}
+
+function streakSummary(attempts, now) {
+  const today = dayIndex(timestamp(now));
+  const activeDays = [...new Set(attempts
+    .map((attempt) => dayIndex(attempt.ts))
+    .filter((day) => Number.isFinite(day) && day >= 0))]
+    .sort((a, b) => a - b);
+  const activeDaySet = new Set(activeDays);
+  let currentDays = 0;
+  for (let day = today; day >= 0 && activeDaySet.has(day); day -= 1) currentDays += 1;
+  let bestDays = 0;
+  let run = 0;
+  let previous = null;
+  for (const day of activeDays) {
+    run = previous != null && day === previous + 1 ? run + 1 : 1;
+    bestDays = Math.max(bestDays, run);
+    previous = day;
+  }
+  return {
+    currentDays,
+    bestDays,
+    activeDays: activeDays.length,
+  };
+}
+
+function dailyGoalSummary(attempts, now) {
+  const today = dayIndex(timestamp(now));
+  const attemptsToday = attempts.filter((attempt) => dayIndex(attempt.ts) === today);
+  return {
+    targetAttempts: DAILY_TARGET_ATTEMPTS,
+    attemptsToday: attemptsToday.length,
+    correctToday: attemptsToday.filter((attempt) => attempt.correct).length,
+    completed: attemptsToday.length >= DAILY_TARGET_ATTEMPTS,
+    progressPercent: Math.min(100, Math.round((attemptsToday.length / DAILY_TARGET_ATTEMPTS) * 100)),
+  };
+}
+
 function analyticsFromData(data, indexes = PUNCTUATION_CONTENT_INDEXES, now = Date.now) {
   const skillRows = indexes.skills.map((skill) => {
     const items = indexes.itemsBySkill.get(skill.id) || [];
@@ -452,17 +676,24 @@ function analyticsFromData(data, indexes = PUNCTUATION_CONTENT_INDEXES, now = Da
       mastery: snaps.length ? Math.round(snaps.reduce((sum, snap) => sum + snap.mastery, 0) / snaps.length) : 0,
     };
   });
+  const attempts = data.progress.attempts;
+  const correct = attempts.filter((attempt) => attempt.correct).length;
+  const weakestFacets = facetRowsFromData(data, indexes, now);
   return {
     releaseId: PUNCTUATION_RELEASE_ID,
-    attempts: data.progress.attempts.length,
-    correct: data.progress.attempts.filter((attempt) => attempt.correct).length,
-    accuracy: data.progress.attempts.length
-      ? Math.round((data.progress.attempts.filter((attempt) => attempt.correct).length / data.progress.attempts.length) * 100)
-      : 0,
+    attempts: attempts.length,
+    correct,
+    accuracy: attempts.length ? Math.round((correct / attempts.length) * 100) : 0,
     sessionsCompleted: data.progress.sessionsCompleted,
     skillRows,
     rewardUnits: currentPublishedRewardUnits(data, indexes),
-    recentMistakes: data.progress.attempts.filter((attempt) => !attempt.correct).slice(-8).reverse(),
+    bySessionMode: groupAttemptAccuracy(attempts, (attempt) => attempt.sessionMode || 'smart', sessionModeLabel),
+    byItemMode: groupAttemptAccuracy(attempts, (attempt) => attempt.itemMode || attempt.mode || 'unknown', itemModeLabel),
+    weakestFacets: weakestFacets.slice(0, 8),
+    recentMistakes: recentMistakesFromAttempts(attempts, indexes),
+    misconceptionPatterns: misconceptionPatternsFromAttempts(attempts),
+    dailyGoal: dailyGoalSummary(attempts, now),
+    streak: streakSummary(attempts, now),
   };
 }
 
@@ -617,13 +848,18 @@ function applyMarkedAttemptToProgress({
     sessionId: session.id,
     itemId: item.id,
     mode: item.mode,
+    itemMode: item.mode,
     skillIds: item.skillIds || [],
     rewardUnitId: item.rewardUnitId || '',
     sessionMode: session.mode || '',
     testMode: session.mode === 'gps' ? 'gps' : null,
     supportLevel,
+    supportKind: supportLevel > 0 ? 'guided' : null,
     correct: result.correct,
     misconceptionTags: result.misconceptionTags || [],
+    facetOutcomes: Array.isArray(result.facets)
+      ? result.facets.map(normaliseFacetForReview).filter(Boolean)
+      : [],
   });
   data.progress.attempts = data.progress.attempts.slice(-1000);
 

--- a/src/platform/hubs/admin-read-model.js
+++ b/src/platform/hubs/admin-read-model.js
@@ -126,6 +126,7 @@ export function buildAdminHubReadModel({
       overview: parentHub.learnerOverview,
       currentFocus: parentHub.dueWork[0] || null,
       grammarEvidence: parentHub.grammarEvidence || null,
+      punctuationEvidence: parentHub.punctuationEvidence || null,
     };
   });
 
@@ -188,6 +189,7 @@ export function buildAdminHubReadModel({
       selectedLearnerId: selectedDiagnostics?.learnerId || '',
       accessibleLearners: diagnosticsEntries,
       selectedDiagnostics,
+      punctuationReleaseDiagnostics: selectedDiagnostics?.punctuationEvidence?.releaseDiagnostics || null,
       entryPoints: [
         ...(canOpenParentHub ? [{
           label: 'Open Parent Hub',
@@ -197,6 +199,12 @@ export function buildAdminHubReadModel({
           label: 'Open Spelling analytics',
           action: 'open-subject',
           subjectId: 'spelling',
+          tab: 'analytics',
+        },
+        {
+          label: 'Open Punctuation analytics',
+          action: 'open-subject',
+          subjectId: 'punctuation',
           tab: 'analytics',
         },
         {

--- a/src/platform/hubs/parent-read-model.js
+++ b/src/platform/hubs/parent-read-model.js
@@ -9,6 +9,7 @@ import {
 } from '../access/roles.js';
 import { buildSpellingLearnerReadModel } from '../../subjects/spelling/read-model.js';
 import { buildGrammarLearnerReadModel } from '../../subjects/grammar/read-model.js';
+import { buildPunctuationLearnerReadModel } from '../../subjects/punctuation/read-model.js';
 
 function asTs(value, fallback = 0) {
   const numeric = Number(value);
@@ -47,6 +48,26 @@ function grammarEvidenceFromReadModel(grammar = {}) {
     recentActivity: Array.isArray(grammar.recentActivity) ? grammar.recentActivity : [],
     recentSessions: Array.isArray(grammar.recentSessions) ? grammar.recentSessions : [],
     parentSummaryDraft: grammar.parentSummaryDraft || null,
+  };
+}
+
+function punctuationEvidenceFromReadModel(punctuation = {}) {
+  return {
+    subjectId: 'punctuation',
+    hasEvidence: Boolean(punctuation.hasEvidence),
+    progressSnapshot: punctuation.progressSnapshot || null,
+    overview: punctuation.overview || null,
+    currentFocus: punctuation.currentFocus || null,
+    skillRows: Array.isArray(punctuation.skillRows) ? punctuation.skillRows : [],
+    bySessionMode: Array.isArray(punctuation.bySessionMode) ? punctuation.bySessionMode : [],
+    byItemMode: Array.isArray(punctuation.byItemMode) ? punctuation.byItemMode : [],
+    weakestFacets: Array.isArray(punctuation.weakestFacets) ? punctuation.weakestFacets : [],
+    recentMistakes: Array.isArray(punctuation.recentMistakes) ? punctuation.recentMistakes : [],
+    misconceptionPatterns: Array.isArray(punctuation.misconceptionPatterns) ? punctuation.misconceptionPatterns : [],
+    recentSessions: Array.isArray(punctuation.recentSessions) ? punctuation.recentSessions : [],
+    dailyGoal: punctuation.dailyGoal || null,
+    streak: punctuation.streak || null,
+    releaseDiagnostics: punctuation.releaseDiagnostics || null,
   };
 }
 
@@ -96,16 +117,24 @@ export function buildParentHubReadModel({
     eventLog,
     now,
   });
+  const punctuation = buildPunctuationLearnerReadModel({
+    subjectStateRecord: isPlainObject(subjectStates.punctuation) ? subjectStates.punctuation : null,
+    practiceSessions,
+    now,
+  });
   const grammarEvidence = grammarEvidenceFromReadModel(grammar);
+  const punctuationEvidence = punctuationEvidenceFromReadModel(punctuation);
   const activeSubjectCount = [
     spelling.progressSnapshot.trackedWords > 0,
     grammar.hasEvidence,
+    punctuation.hasEvidence,
   ].filter(Boolean).length;
 
   const lastActivityAt = Math.max(
     asTs(learner?.createdAt, 0),
     asTs(spelling?.overview?.lastActivityAt, 0),
     asTs(grammar?.overview?.lastActivityAt, 0),
+    asTs(punctuation?.overview?.lastActivityAt, 0),
     ...Object.values(isPlainObject(gameState) ? gameState : {}).map((entry) => asTs(entry?.updatedAt, 0)),
     0,
   );
@@ -153,6 +182,10 @@ export function buildParentHubReadModel({
       dueGrammarConcepts: grammar.progressSnapshot.dueConcepts,
       weakGrammarConcepts: grammar.progressSnapshot.weakConcepts,
       grammarAccuracyPercent: grammar.progressSnapshot.accuracyPercent,
+      securePunctuationUnits: punctuation.progressSnapshot.securedRewardUnits,
+      duePunctuationItems: punctuation.progressSnapshot.dueItems,
+      weakPunctuationItems: punctuation.progressSnapshot.weakItems,
+      punctuationAccuracyPercent: punctuation.progressSnapshot.accuracyPercent,
       recentSessions: spelling.recentSessions.length,
     },
     selectedLearnerId: resolvedLearnerId,
@@ -160,20 +193,23 @@ export function buildParentHubReadModel({
     dueWork: orderDueWork([
       spelling.currentFocus,
       ...(grammar.hasEvidence ? [grammar.currentFocus] : []),
+      ...(punctuation.hasEvidence ? [punctuation.currentFocus] : []),
     ]),
-    recentSessions: [...spelling.recentSessions, ...grammar.recentSessions]
+    recentSessions: [...spelling.recentSessions, ...grammar.recentSessions, ...punctuation.recentSessions]
       .sort((a, b) => asTs(b.updatedAt, 0) - asTs(a.updatedAt, 0))
       .slice(0, 6),
-    strengths: [...spelling.strengths, ...grammar.strengths].slice(0, 6),
-    weaknesses: [...spelling.weaknesses, ...grammar.weaknesses].slice(0, 6),
-    misconceptionPatterns: [...spelling.misconceptionPatterns, ...grammar.misconceptionPatterns]
+    strengths: [...spelling.strengths, ...grammar.strengths, ...punctuation.strengths].slice(0, 6),
+    weaknesses: [...spelling.weaknesses, ...grammar.weaknesses, ...punctuation.weaknesses].slice(0, 6),
+    misconceptionPatterns: [...spelling.misconceptionPatterns, ...grammar.misconceptionPatterns, ...punctuation.misconceptionPatterns]
       .sort((a, b) => (Number(b.count) || 0) - (Number(a.count) || 0) || asTs(b.lastSeenAt, 0) - asTs(a.lastSeenAt, 0))
       .slice(0, 8),
     progressSnapshots: [
       spelling.progressSnapshot,
       ...(grammar.hasEvidence ? [grammar.progressSnapshot] : []),
+      ...(punctuation.hasEvidence ? [punctuation.progressSnapshot] : []),
     ],
     grammarEvidence,
+    punctuationEvidence,
     exportEntryPoints: [
       {
         kind: 'learner',

--- a/src/subjects/punctuation/client-read-models.js
+++ b/src/subjects/punctuation/client-read-models.js
@@ -45,13 +45,30 @@ export function createPunctuationReadModelService({ getState } = {}) {
     },
     getAnalyticsSnapshot(learnerId) {
       return clone(currentUi(getState, learnerId).ui.analytics) || {
+        releaseId: 'punctuation-r4-full-14-skill-structure',
         attempts: 0,
         correct: 0,
         accuracy: 0,
         sessionsCompleted: 0,
         skillRows: [],
         rewardUnits: [],
+        bySessionMode: [],
+        byItemMode: [],
+        weakestFacets: [],
         recentMistakes: [],
+        misconceptionPatterns: [],
+        dailyGoal: {
+          targetAttempts: 4,
+          attemptsToday: 0,
+          correctToday: 0,
+          completed: false,
+          progressPercent: 0,
+        },
+        streak: {
+          currentDays: 0,
+          bestDays: 0,
+          activeDays: 0,
+        },
       };
     },
     startSession() {},

--- a/src/subjects/punctuation/read-model.js
+++ b/src/subjects/punctuation/read-model.js
@@ -1,0 +1,543 @@
+const DAY_MS = 24 * 60 * 60 * 1000;
+const CURRENT_RELEASE_ID = 'punctuation-r4-full-14-skill-structure';
+const TOTAL_REWARD_UNITS = 14;
+const DAILY_TARGET_ATTEMPTS = 4;
+
+const PUNCTUATION_CLIENT_SKILLS = Object.freeze([
+  { id: 'sentence_endings', name: 'Capital letters and sentence endings', clusterId: 'endmarks' },
+  { id: 'list_commas', name: 'Commas in lists', clusterId: 'comma_flow' },
+  { id: 'apostrophe_contractions', name: 'Apostrophes for contraction', clusterId: 'apostrophe' },
+  { id: 'apostrophe_possession', name: 'Apostrophes for possession', clusterId: 'apostrophe' },
+  { id: 'speech', name: 'Inverted commas and speech punctuation', clusterId: 'speech' },
+  { id: 'fronted_adverbial', name: 'Commas after fronted adverbials', clusterId: 'comma_flow' },
+  { id: 'parenthesis', name: 'Parenthesis with commas, brackets or dashes', clusterId: 'structure' },
+  { id: 'comma_clarity', name: 'Commas for clarity', clusterId: 'comma_flow' },
+  { id: 'colon_list', name: 'Colon before a list', clusterId: 'structure' },
+  { id: 'semicolon', name: 'Semi-colons between related clauses', clusterId: 'boundary' },
+  { id: 'dash_clause', name: 'Dashes between related clauses', clusterId: 'boundary' },
+  { id: 'semicolon_list', name: 'Semi-colons within lists', clusterId: 'structure' },
+  { id: 'bullet_points', name: 'Punctuation of bullet points', clusterId: 'structure' },
+  { id: 'hyphen', name: 'Hyphens to avoid ambiguity', clusterId: 'boundary' },
+]);
+
+const PUNCTUATION_CLIENT_REWARD_UNITS = Object.freeze([
+  { clusterId: 'endmarks', rewardUnitId: 'sentence-endings-core' },
+  { clusterId: 'apostrophe', rewardUnitId: 'apostrophe-contractions-core' },
+  { clusterId: 'apostrophe', rewardUnitId: 'apostrophe-possession-core' },
+  { clusterId: 'speech', rewardUnitId: 'speech-core' },
+  { clusterId: 'comma_flow', rewardUnitId: 'list-commas-core' },
+  { clusterId: 'comma_flow', rewardUnitId: 'fronted-adverbials-core' },
+  { clusterId: 'comma_flow', rewardUnitId: 'comma-clarity-core' },
+  { clusterId: 'boundary', rewardUnitId: 'semicolons-core' },
+  { clusterId: 'boundary', rewardUnitId: 'dash-clauses-core' },
+  { clusterId: 'boundary', rewardUnitId: 'hyphens-core' },
+  { clusterId: 'structure', rewardUnitId: 'parenthesis-core' },
+  { clusterId: 'structure', rewardUnitId: 'colons-core' },
+  { clusterId: 'structure', rewardUnitId: 'semicolon-lists-core' },
+  { clusterId: 'structure', rewardUnitId: 'bullet-points-core' },
+]);
+
+function clientMasteryKey({ clusterId, rewardUnitId } = {}) {
+  return `punctuation:${CURRENT_RELEASE_ID}:${clusterId}:${rewardUnitId}`;
+}
+
+const PUNCTUATION_CLIENT_REWARD_UNIT_KEYS = new Set(
+  PUNCTUATION_CLIENT_REWARD_UNITS.map(clientMasteryKey),
+);
+
+const ITEM_MODE_LABELS = Object.freeze({
+  choose: 'Choice',
+  insert: 'Insert punctuation',
+  fix: 'Proofreading',
+  transfer: 'Transfer writing',
+  combine: 'Sentence combining',
+  paragraph: 'Paragraph repair',
+});
+
+const SESSION_MODE_LABELS = Object.freeze({
+  smart: 'Smart review',
+  guided: 'Guided learn',
+  weak: 'Weak spots',
+  gps: 'GPS test',
+  endmarks: 'Endmarks focus',
+  apostrophe: 'Apostrophe focus',
+  speech: 'Speech focus',
+  comma_flow: 'Comma / flow focus',
+  boundary: 'Boundary focus',
+  structure: 'Structure focus',
+});
+
+function asTs(value, fallback = 0) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric >= 0 ? numeric : fallback;
+}
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function humanLabel(value) {
+  return String(value || '')
+    .replace(/[._-]+/g, ' ')
+    .replace(/\b\w/g, (letter) => letter.toUpperCase())
+    .trim();
+}
+
+function itemModeLabel(value) {
+  return ITEM_MODE_LABELS[value] || humanLabel(value) || 'Practice item';
+}
+
+function sessionModeLabel(value) {
+  return SESSION_MODE_LABELS[value] || humanLabel(value) || 'Practice session';
+}
+
+function normaliseStringArray(value) {
+  return (Array.isArray(value) ? value : []).filter((entry) => typeof entry === 'string' && entry);
+}
+
+function normaliseMemoryState(value) {
+  const raw = isPlainObject(value) ? value : {};
+  return {
+    attempts: Math.max(0, Number(raw.attempts) || 0),
+    correct: Math.max(0, Number(raw.correct) || 0),
+    incorrect: Math.max(0, Number(raw.incorrect) || 0),
+    streak: Math.max(0, Number(raw.streak) || 0),
+    lapses: Math.max(0, Number(raw.lapses) || 0),
+    dueAt: Math.max(0, Number(raw.dueAt) || 0),
+    firstCorrectAt: Number.isFinite(Number(raw.firstCorrectAt)) ? Number(raw.firstCorrectAt) : null,
+    lastCorrectAt: Number.isFinite(Number(raw.lastCorrectAt)) ? Number(raw.lastCorrectAt) : null,
+    lastSeen: Math.max(0, Number(raw.lastSeen) || 0),
+  };
+}
+
+function memorySnapshot(value, nowTs) {
+  const state = normaliseMemoryState(value);
+  const attempts = state.attempts;
+  const accuracy = attempts ? state.correct / attempts : 0;
+  const correctSpanDays = state.firstCorrectAt != null && state.lastCorrectAt != null
+    ? Math.floor((state.lastCorrectAt - state.firstCorrectAt) / DAY_MS)
+    : 0;
+  let bucket = 'new';
+  if (!attempts) bucket = 'new';
+  else if (accuracy < 0.65 || (state.lapses >= 2 && state.streak === 0)) bucket = 'weak';
+  else if (state.streak >= 3 && accuracy >= 0.8 && correctSpanDays >= 7) bucket = 'secure';
+  else if (state.dueAt && state.dueAt <= nowTs) bucket = 'due';
+  else bucket = 'learning';
+  const mastery = attempts === 0
+    ? 0
+    : Math.round(100 * (
+        accuracy * 0.55
+        + Math.min(correctSpanDays / 14, 1) * 0.25
+        + Math.min(state.streak / 4, 1) * 0.20
+      ));
+  return { state, attempts, accuracy, bucket, mastery, secure: bucket === 'secure', due: state.dueAt > 0 && state.dueAt <= nowTs };
+}
+
+function percent(correct, attempts) {
+  const total = Math.max(0, Number(attempts) || 0);
+  if (!total) return null;
+  return Math.round((Math.max(0, Number(correct) || 0) / total) * 100);
+}
+
+function skillById() {
+  return new Map(PUNCTUATION_CLIENT_SKILLS.map((skill) => [skill.id, skill]));
+}
+
+function skillNames(skills, skillIds = []) {
+  return normaliseStringArray(skillIds)
+    .map((skillId) => skills.get(skillId)?.name || humanLabel(skillId))
+    .filter(Boolean);
+}
+
+function normaliseAttempt(rawValue) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  const itemMode = typeof raw.itemMode === 'string' ? raw.itemMode : (typeof raw.mode === 'string' ? raw.mode : '');
+  const supportLevel = Math.max(0, Number(raw.supportLevel) || 0);
+  return {
+    ts: asTs(raw.ts, 0),
+    sessionId: typeof raw.sessionId === 'string' ? raw.sessionId : null,
+    itemId: typeof raw.itemId === 'string' ? raw.itemId : '',
+    itemMode,
+    mode: itemMode,
+    skillIds: normaliseStringArray(raw.skillIds),
+    rewardUnitId: typeof raw.rewardUnitId === 'string' ? raw.rewardUnitId : '',
+    sessionMode: typeof raw.sessionMode === 'string' ? raw.sessionMode : 'smart',
+    testMode: raw.testMode === 'gps' ? 'gps' : null,
+    supportLevel,
+    supportKind: typeof raw.supportKind === 'string' ? raw.supportKind : (supportLevel > 0 ? 'guided' : null),
+    correct: raw.correct === true,
+    misconceptionTags: normaliseStringArray(raw.misconceptionTags),
+    facetOutcomes: (Array.isArray(raw.facetOutcomes) ? raw.facetOutcomes : [])
+      .filter(isPlainObject)
+      .map((facet) => ({
+        id: typeof facet.id === 'string' ? facet.id : '',
+        label: typeof facet.label === 'string' ? facet.label : '',
+        ok: facet.ok === true,
+      }))
+      .filter((facet) => facet.id),
+  };
+}
+
+function currentPublishedRewardUnits(rewardUnits) {
+  const rows = new Map();
+  for (const [key, value] of Object.entries(isPlainObject(rewardUnits) ? rewardUnits : {})) {
+    if (!isPlainObject(value)) continue;
+    const masteryKey = typeof value.masteryKey === 'string' && value.masteryKey ? value.masteryKey : key;
+    if (!PUNCTUATION_CLIENT_REWARD_UNIT_KEYS.has(masteryKey)) continue;
+    rows.set(masteryKey, value);
+  }
+  return [...rows.values()];
+}
+
+function groupAttemptAccuracy(attempts, keyFn, labelFn) {
+  const groups = new Map();
+  for (const attempt of attempts) {
+    const id = keyFn(attempt) || 'unknown';
+    const current = groups.get(id) || {
+      subjectId: 'punctuation',
+      id,
+      label: labelFn(id),
+      attempts: 0,
+      correct: 0,
+      wrong: 0,
+      accuracy: null,
+    };
+    current.attempts += 1;
+    if (attempt.correct) current.correct += 1;
+    else current.wrong += 1;
+    current.accuracy = percent(current.correct, current.attempts);
+    groups.set(id, current);
+  }
+  return [...groups.values()]
+    .sort((a, b) => b.attempts - a.attempts || String(a.label).localeCompare(String(b.label)));
+}
+
+function facetRows(progress, skills, nowTs) {
+  const facets = isPlainObject(progress.facets) ? progress.facets : {};
+  return Object.entries(facets)
+    .map(([id, rawState]) => {
+      const [skillId, itemMode] = id.split('::');
+      const snap = memorySnapshot(rawState, nowTs);
+      const state = snap.state;
+      const skill = skills.get(skillId);
+      return {
+        subjectId: 'punctuation',
+        id,
+        skillId,
+        skillName: skill?.name || humanLabel(skillId),
+        itemMode: itemMode || '',
+        itemModeLabel: itemModeLabel(itemMode),
+        label: `${skill?.name || humanLabel(skillId)} · ${itemModeLabel(itemMode)}`,
+        status: snap.bucket,
+        attempts: state.attempts,
+        correct: state.correct,
+        wrong: state.incorrect,
+        accuracy: percent(state.correct, state.attempts),
+        mastery: snap.mastery,
+        dueAt: state.dueAt,
+        lastSeenAt: state.lastSeen,
+      };
+    })
+    .filter((entry) => entry.attempts > 0)
+    .sort((a, b) => {
+      const statusOrder = { weak: 0, due: 1, learning: 2, new: 3, secure: 4 };
+      return (statusOrder[a.status] ?? 99) - (statusOrder[b.status] ?? 99)
+        || a.mastery - b.mastery
+        || b.wrong - a.wrong
+        || b.lastSeenAt - a.lastSeenAt
+        || String(a.label).localeCompare(String(b.label));
+    });
+}
+
+function recentMistakes(attempts, skills) {
+  return attempts
+    .filter((attempt) => !attempt.correct)
+    .slice(-8)
+    .reverse()
+    .map((attempt) => {
+      const names = skillNames(skills, attempt.skillIds);
+      const primarySkill = skills.get(attempt.skillIds[0]);
+      return {
+        subjectId: 'punctuation',
+        itemId: attempt.itemId,
+        label: `${primarySkill?.name || names[0] || 'Punctuation'} · ${itemModeLabel(attempt.itemMode)}`,
+        itemMode: attempt.itemMode,
+        itemModeLabel: itemModeLabel(attempt.itemMode),
+        sessionMode: attempt.sessionMode,
+        sessionModeLabel: sessionModeLabel(attempt.sessionMode),
+        skillIds: attempt.skillIds,
+        skillNames: names,
+        rewardUnitId: attempt.rewardUnitId,
+        misconceptionTags: attempt.misconceptionTags.slice(0, 6),
+        facetOutcomes: attempt.facetOutcomes
+          .filter((facet) => facet.ok !== true)
+          .map((facet) => ({ id: facet.id, label: facet.label || humanLabel(facet.id), ok: false }))
+          .slice(0, 6),
+        supportLevel: attempt.supportLevel,
+        supportKind: attempt.supportKind,
+        testMode: attempt.testMode,
+        createdAt: attempt.ts,
+      };
+    });
+}
+
+function misconceptionPatterns(attempts) {
+  const patterns = new Map();
+  for (const attempt of attempts) {
+    for (const tag of attempt.misconceptionTags) {
+      const current = patterns.get(tag) || {
+        subjectId: 'punctuation',
+        id: tag,
+        label: `${humanLabel(tag)} pattern`,
+        count: 0,
+        lastSeenAt: 0,
+        source: 'punctuation-attempts',
+      };
+      current.count += 1;
+      current.lastSeenAt = Math.max(current.lastSeenAt, attempt.ts);
+      patterns.set(tag, current);
+    }
+  }
+  return [...patterns.values()]
+    .sort((a, b) => b.count - a.count || b.lastSeenAt - a.lastSeenAt)
+    .slice(0, 8);
+}
+
+function dayIndex(value) {
+  return Math.floor(asTs(value, 0) / DAY_MS);
+}
+
+function streakSummary(attempts, nowTs) {
+  const today = dayIndex(nowTs);
+  const activeDays = [...new Set(attempts.map((attempt) => dayIndex(attempt.ts)).filter((day) => day >= 0))]
+    .sort((a, b) => a - b);
+  const activeDaySet = new Set(activeDays);
+  let currentDays = 0;
+  for (let day = today; day >= 0 && activeDaySet.has(day); day -= 1) currentDays += 1;
+  let bestDays = 0;
+  let run = 0;
+  let previous = null;
+  for (const day of activeDays) {
+    run = previous != null && day === previous + 1 ? run + 1 : 1;
+    bestDays = Math.max(bestDays, run);
+    previous = day;
+  }
+  return { currentDays, bestDays, activeDays: activeDays.length };
+}
+
+function dailyGoal(attempts, nowTs) {
+  const today = dayIndex(nowTs);
+  const attemptsToday = attempts.filter((attempt) => dayIndex(attempt.ts) === today);
+  return {
+    targetAttempts: DAILY_TARGET_ATTEMPTS,
+    attemptsToday: attemptsToday.length,
+    correctToday: attemptsToday.filter((attempt) => attempt.correct).length,
+    completed: attemptsToday.length >= DAILY_TARGET_ATTEMPTS,
+    progressPercent: Math.min(100, Math.round((attemptsToday.length / DAILY_TARGET_ATTEMPTS) * 100)),
+  };
+}
+
+function recentSessionRows(practiceSessions) {
+  return (Array.isArray(practiceSessions) ? practiceSessions : [])
+    .filter((record) => record?.subjectId === 'punctuation')
+    .sort((a, b) => asTs(b.updatedAt, 0) - asTs(a.updatedAt, 0))
+    .slice(0, 6)
+    .map((record) => {
+      const total = Math.max(0, Number(record?.summary?.total) || 0);
+      const correct = Math.max(0, Number(record?.summary?.correct) || 0);
+      return {
+        id: record.id,
+        subjectId: 'punctuation',
+        status: record.status,
+        sessionKind: record.sessionKind || record?.summary?.sessionMode || 'smart',
+        label: record?.summary?.label || sessionModeLabel(record.sessionKind || 'smart'),
+        updatedAt: asTs(record.updatedAt, asTs(record.createdAt, 0)),
+        mistakeCount: Math.max(0, total - correct),
+        headline: total ? `${correct}/${total}` : '',
+      };
+    });
+}
+
+function skillRowsFromAttempts(attempts, skills) {
+  return PUNCTUATION_CLIENT_SKILLS.map((skill) => {
+    const rows = attempts.filter((attempt) => attempt.skillIds.includes(skill.id));
+    const correct = rows.filter((attempt) => attempt.correct).length;
+    return {
+      subjectId: 'punctuation',
+      skillId: skill.id,
+      name: skill.name,
+      clusterId: skill.clusterId,
+      attempts: rows.length,
+      correct,
+      wrong: rows.length - correct,
+      accuracy: percent(correct, rows.length),
+    };
+  });
+}
+
+function buildStrengths(skillRows) {
+  return skillRows
+    .filter((row) => row.attempts > 0 && (row.accuracy ?? 0) >= 80)
+    .sort((a, b) => (b.accuracy ?? 0) - (a.accuracy ?? 0) || b.attempts - a.attempts)
+    .slice(0, 3)
+    .map((row) => ({
+      subjectId: 'punctuation',
+      id: row.skillId,
+      label: row.name,
+      detail: `${row.correct}/${row.attempts} accurate attempts`,
+      secureCount: row.correct,
+      dueCount: 0,
+      troubleCount: row.wrong,
+    }));
+}
+
+function buildWeaknesses(weakestFacets) {
+  return weakestFacets
+    .filter((row) => row.status === 'weak' || row.status === 'due')
+    .slice(0, 3)
+    .map((row) => ({
+      subjectId: 'punctuation',
+      id: row.id,
+      label: row.label,
+      detail: `${row.status} · ${row.correct}/${row.attempts} correct`,
+      secureCount: row.status === 'secure' ? 1 : 0,
+      dueCount: row.status === 'due' ? 1 : 0,
+      troubleCount: row.status === 'weak' ? 1 : 0,
+    }));
+}
+
+function activeSessionRecord(practiceSessions) {
+  return (Array.isArray(practiceSessions) ? practiceSessions : [])
+    .filter((record) => record?.subjectId === 'punctuation')
+    .find((record) => record?.status === 'active') || null;
+}
+
+export function buildPunctuationLearnerReadModel({
+  subjectStateRecord = null,
+  practiceSessions = [],
+  now = Date.now,
+} = {}) {
+  const nowTs = typeof now === 'function' ? asTs(now(), Date.now()) : asTs(now, Date.now());
+  const stateRecord = isPlainObject(subjectStateRecord) ? subjectStateRecord : {};
+  const data = isPlainObject(stateRecord.data) ? stateRecord.data : {};
+  const progress = isPlainObject(data.progress) ? data.progress : {};
+  const items = isPlainObject(progress.items) ? progress.items : {};
+  const rewardUnits = isPlainObject(progress.rewardUnits) ? progress.rewardUnits : {};
+  const attempts = (Array.isArray(progress.attempts) ? progress.attempts : []).map(normaliseAttempt);
+  const correct = attempts.filter((attempt) => attempt.correct).length;
+  const skills = skillById();
+  const itemSnapshots = Object.entries(items).map(([itemId, value]) => ({ itemId, ...memorySnapshot(value, nowTs) }));
+  const secureItems = itemSnapshots.filter((entry) => entry.bucket === 'secure').length;
+  const dueItems = itemSnapshots.filter((entry) => entry.bucket === 'due').length;
+  const weakItems = itemSnapshots.filter((entry) => entry.bucket === 'weak').length;
+  const publishedRewardUnits = currentPublishedRewardUnits(rewardUnits);
+  const weakestFacets = facetRows(progress, skills, nowTs);
+  const skillRows = skillRowsFromAttempts(attempts, skills);
+  const strengths = buildStrengths(skillRows);
+  const weaknesses = buildWeaknesses(weakestFacets);
+  const sessions = recentSessionRows(practiceSessions);
+  const activeSession = activeSessionRecord(practiceSessions);
+  const patterns = misconceptionPatterns(attempts);
+  const lastActivityAt = Math.max(
+    ...attempts.map((attempt) => attempt.ts),
+    ...itemSnapshots.map((entry) => entry.state.lastSeen),
+    ...sessions.map((session) => session.updatedAt),
+    asTs(stateRecord.updatedAt, 0),
+    0,
+  );
+
+  let currentFocus = {
+    subjectId: 'punctuation',
+    recommendedMode: 'smart',
+    label: 'Keep Punctuation warm with Smart review',
+    detail: attempts.length
+      ? `${attempts.length} recorded attempt${attempts.length === 1 ? '' : 's'} across the current release.`
+      : 'No Punctuation attempts are stored yet.',
+    dueCount: dueItems,
+    troubleCount: weakItems,
+    activeSessionId: null,
+  };
+  if (activeSession) {
+    currentFocus = {
+      subjectId: 'punctuation',
+      recommendedMode: activeSession.sessionKind || 'smart',
+      label: `Continue ${sessionModeLabel(activeSession.sessionKind || 'smart')}`,
+      detail: 'A live Punctuation round is saved for this learner.',
+      dueCount: dueItems,
+      troubleCount: weakItems,
+      activeSessionId: activeSession.id,
+    };
+  } else if (weaknesses.length) {
+    currentFocus = {
+      subjectId: 'punctuation',
+      recommendedMode: 'weak',
+      label: 'Run a Punctuation weak spots drill next',
+      detail: weaknesses[0].label,
+      dueCount: dueItems,
+      troubleCount: weakItems || weaknesses.length,
+      activeSessionId: null,
+    };
+  } else if (dueItems) {
+    currentFocus = {
+      subjectId: 'punctuation',
+      recommendedMode: 'smart',
+      label: 'Clear due Punctuation practice',
+      detail: `${dueItems} item${dueItems === 1 ? '' : 's'} are due for spaced review.`,
+      dueCount: dueItems,
+      troubleCount: weakItems,
+      activeSessionId: null,
+    };
+  }
+
+  const hasEvidence = attempts.length > 0 || itemSnapshots.length > 0 || publishedRewardUnits.length > 0 || sessions.length > 0;
+  const accuracy = percent(correct, attempts.length);
+  return {
+    subjectId: 'punctuation',
+    hasEvidence,
+    currentFocus,
+    progressSnapshot: {
+      subjectId: 'punctuation',
+      releaseId: CURRENT_RELEASE_ID,
+      totalRewardUnits: TOTAL_REWARD_UNITS,
+      trackedRewardUnits: publishedRewardUnits.length,
+      securedRewardUnits: publishedRewardUnits.length,
+      trackedItems: itemSnapshots.length,
+      secureItems,
+      dueItems,
+      weakItems,
+      attempts: attempts.length,
+      accuracyPercent: accuracy,
+    },
+    overview: {
+      attempts: attempts.length,
+      correct,
+      accuracyPercent: accuracy,
+      sessionsCompleted: Math.max(0, Number(progress.sessionsCompleted) || 0),
+      securedRewardUnits: publishedRewardUnits.length,
+      dueItems,
+      weakItems,
+      lastActivityAt,
+    },
+    skillRows,
+    bySessionMode: groupAttemptAccuracy(attempts, (attempt) => attempt.sessionMode || 'smart', sessionModeLabel),
+    byItemMode: groupAttemptAccuracy(attempts, (attempt) => attempt.itemMode || 'unknown', itemModeLabel),
+    weakestFacets: weakestFacets.slice(0, 8),
+    recentMistakes: recentMistakes(attempts, skills),
+    misconceptionPatterns: patterns,
+    recentSessions: sessions,
+    strengths,
+    weaknesses,
+    dailyGoal: dailyGoal(attempts, nowTs),
+    streak: streakSummary(attempts, nowTs),
+    releaseDiagnostics: {
+      subjectId: 'punctuation',
+      releaseId: CURRENT_RELEASE_ID,
+      publishedSkillCount: PUNCTUATION_CLIENT_SKILLS.length,
+      publishedRewardUnitCount: TOTAL_REWARD_UNITS,
+      trackedRewardUnitCount: publishedRewardUnits.length,
+      sessionCount: sessions.length,
+      weakPatternCount: patterns.length,
+      productionExposureStatus: 'enabled',
+    },
+  };
+}

--- a/src/surfaces/hubs/AdminHubSurface.jsx
+++ b/src/surfaces/hubs/AdminHubSurface.jsx
@@ -134,6 +134,10 @@ export function AdminHubSurface({ appState, model, hubState = {}, accountDirecto
   const auditEntries = Array.isArray(model.auditLogLookup?.entries) ? model.auditLogLookup.entries : [];
   const selectedLearnerId = model.learnerSupport?.selectedLearnerId || selectedDiagnostics?.learnerId || '';
   const selectedGrammarEvidence = selectedDiagnostics?.grammarEvidence || {};
+  const selectedPunctuationEvidence = selectedDiagnostics?.punctuationEvidence || {};
+  const selectedPunctuationRelease = selectedPunctuationEvidence.releaseDiagnostics
+    || model.learnerSupport?.punctuationReleaseDiagnostics
+    || {};
   const notice = hubState.notice || accessContext.adultSurfaceNotice || '';
   const writableLearner = selectedWritableLearner(appState);
 
@@ -237,6 +241,9 @@ export function AdminHubSurface({ appState, model, hubState = {}, accountDirecto
               <div className="small muted">
                 Grammar: {String(entry.grammarEvidence?.progressSnapshot?.dueConcepts ?? entry.overview?.dueGrammarConcepts ?? 0)} due / {String(entry.grammarEvidence?.progressSnapshot?.weakConcepts ?? entry.overview?.weakGrammarConcepts ?? 0)} weak
               </div>
+              <div className="small muted">
+                Punctuation: {String(entry.punctuationEvidence?.progressSnapshot?.dueItems ?? entry.overview?.duePunctuationItems ?? 0)} due / {String(entry.punctuationEvidence?.progressSnapshot?.weakItems ?? entry.overview?.weakPunctuationItems ?? 0)} weak
+              </div>
               <div><button className="btn ghost" type="button" onClick={() => actions.dispatch('adult-surface-learner-select', { value: entry.learnerId })}>Select</button></div>
             </div>
           )) : <p className="small muted">No learner diagnostics are accessible from this account scope yet.</p>}
@@ -249,9 +256,20 @@ export function AdminHubSurface({ appState, model, hubState = {}, accountDirecto
               <div style={{ marginTop: 8 }}>
                 <strong>Grammar diagnostics</strong>: secured {String(selectedGrammarEvidence.progressSnapshot?.securedConcepts ?? selectedDiagnostics.overview?.secureGrammarConcepts ?? 0)} · due {String(selectedGrammarEvidence.progressSnapshot?.dueConcepts ?? selectedDiagnostics.overview?.dueGrammarConcepts ?? 0)} · weak {String(selectedGrammarEvidence.progressSnapshot?.weakConcepts ?? selectedDiagnostics.overview?.weakGrammarConcepts ?? 0)}
               </div>
+              <div style={{ marginTop: 8 }}>
+                <strong>Punctuation diagnostics</strong>: secured {String(selectedPunctuationEvidence.progressSnapshot?.securedRewardUnits ?? selectedDiagnostics.overview?.securePunctuationUnits ?? 0)} · due {String(selectedPunctuationEvidence.progressSnapshot?.dueItems ?? selectedDiagnostics.overview?.duePunctuationItems ?? 0)} · weak {String(selectedPunctuationEvidence.progressSnapshot?.weakItems ?? selectedDiagnostics.overview?.weakPunctuationItems ?? 0)}
+              </div>
+              <div className="small muted" style={{ marginTop: 8 }}>
+                Punctuation release: {selectedPunctuationRelease.releaseId || 'unknown'} · tracked units {String(selectedPunctuationRelease.trackedRewardUnitCount ?? 0)} · sessions {String(selectedPunctuationRelease.sessionCount ?? 0)} · weak patterns {String(selectedPunctuationRelease.weakPatternCount ?? 0)} · exposure {selectedPunctuationRelease.productionExposureStatus || 'unknown'}
+              </div>
               {selectedGrammarEvidence.questionTypeSummary?.[0] ? (
                 <div className="small muted" style={{ marginTop: 8 }}>
                   Question-type focus: {selectedGrammarEvidence.questionTypeSummary[0].label || selectedGrammarEvidence.questionTypeSummary[0].id}
+                </div>
+              ) : null}
+              {selectedPunctuationEvidence.weakestFacets?.[0] ? (
+                <div className="small muted" style={{ marginTop: 8 }}>
+                  Punctuation focus: {selectedPunctuationEvidence.weakestFacets[0].label || selectedPunctuationEvidence.weakestFacets[0].id}
                 </div>
               ) : null}
               <div className="small muted" style={{ marginTop: 8 }}>{selectedDiagnostics.currentFocus?.detail || 'No current focus surfaced.'}</div>

--- a/src/surfaces/hubs/ParentHubSurface.jsx
+++ b/src/surfaces/hubs/ParentHubSurface.jsx
@@ -5,6 +5,7 @@ import { AccessDeniedCard, formatTimestamp, isBlocked, selectedWritableLearner }
 
 function snapshotSubjectId(snapshot = {}) {
   if (snapshot.subjectId) return snapshot.subjectId;
+  if (snapshot.totalRewardUnits != null || snapshot.trackedRewardUnits != null) return 'punctuation';
   return snapshot.totalConcepts != null || snapshot.trackedConcepts != null ? 'grammar' : 'spelling';
 }
 
@@ -12,6 +13,9 @@ function snapshotChipLabel(snapshot = {}) {
   const subjectId = snapshotSubjectId(snapshot);
   if (subjectId === 'grammar') {
     return `Grammar: ${snapshot.trackedConcepts ?? 0}/${snapshot.totalConcepts ?? 0} concepts`;
+  }
+  if (subjectId === 'punctuation') {
+    return `Punctuation: ${snapshot.securedRewardUnits ?? 0}/${snapshot.totalRewardUnits ?? 0} units`;
   }
   return `Spelling: ${snapshot.trackedWords ?? 0}/${snapshot.totalPublishedWords ?? 0} words`;
 }
@@ -25,7 +29,15 @@ function HeadlineFigure({ label, value, tone }) {
   );
 }
 
-function StatGrid({ overview, grammarReviewConcepts, grammarDueConcepts, grammarWeakConcepts }) {
+function StatGrid({
+  overview,
+  grammarReviewConcepts,
+  grammarDueConcepts,
+  grammarWeakConcepts,
+  punctuationReviewItems,
+  punctuationDueItems,
+  punctuationWeakItems,
+}) {
   const cells = [
     { label: 'Secure words', value: overview.secureWords ?? 0, sub: 'Spelling snapshot' },
     { label: 'Due words', value: overview.dueWords ?? 0, sub: 'Spelling return', tone: 'warn' },
@@ -34,6 +46,9 @@ function StatGrid({ overview, grammarReviewConcepts, grammarDueConcepts, grammar
     { label: 'Grammar secured', value: overview.secureGrammarConcepts ?? 0, sub: 'Concepts secure' },
     { label: 'Grammar review', value: grammarReviewConcepts, sub: `${grammarDueConcepts} due · ${grammarWeakConcepts} weak`, tone: 'warn' },
     { label: 'Grammar accuracy', value: overview.grammarAccuracyPercent == null ? '—' : `${overview.grammarAccuracyPercent}%`, sub: 'Concept evidence' },
+    { label: 'Punctuation secured', value: overview.securePunctuationUnits ?? 0, sub: 'Reward units secure' },
+    { label: 'Punctuation review', value: punctuationReviewItems, sub: `${punctuationDueItems} due · ${punctuationWeakItems} weak`, tone: 'warn' },
+    { label: 'Punctuation accuracy', value: overview.punctuationAccuracyPercent == null ? '—' : `${overview.punctuationAccuracyPercent}%`, sub: 'Skill evidence' },
   ];
   return (
     <div className="parent-hub-statgrid">
@@ -276,6 +291,104 @@ function GrammarEvidencePanel({ evidence }) {
   );
 }
 
+function PunctuationFacetEvidence({ evidence }) {
+  const rows = uniqueEvidenceRows(Array.isArray(evidence?.weakestFacets) ? evidence.weakestFacets : []).slice(0, 6);
+  return (
+    <article className="card parent-hub-card">
+      <div className="parent-hub-card-head">
+        <p className="eyebrow">Facet evidence</p>
+        <h3 className="parent-hub-card-title">Punctuation skills needing attention</h3>
+      </div>
+      {rows.length ? (
+        <ul className="parent-hub-ledger-list">
+          {rows.map((entry) => (
+            <li className="parent-hub-ledger-row" key={entry.id || entry.label}>
+              <div className="parent-hub-ledger-main">
+                <strong>{entry.label || entry.skillName || 'Punctuation facet'}</strong>
+                <span className="parent-hub-row-detail">{`${entry.correct ?? 0}/${entry.attempts ?? 0} correct`}</span>
+              </div>
+              <span className="parent-hub-ledger-figure is-warn">{String(entry.wrong ?? 0)}</span>
+              <span className="parent-hub-row-meta">
+                {entry.status || 'learning'}
+                {entry.accuracy == null ? '' : ` · ${entry.accuracy}%`}
+              </span>
+            </li>
+          ))}
+        </ul>
+      ) : <p className="parent-hub-empty small muted">No Punctuation facet weakness has surfaced yet.</p>}
+    </article>
+  );
+}
+
+function PunctuationActivityEvidence({ evidence }) {
+  const sessionModes = Array.isArray(evidence?.bySessionMode) ? evidence.bySessionMode.slice(0, 4) : [];
+  const itemModes = Array.isArray(evidence?.byItemMode) ? evidence.byItemMode.slice(0, 4) : [];
+  const mistakes = Array.isArray(evidence?.recentMistakes) ? evidence.recentMistakes.slice(0, 4) : [];
+  const dailyGoal = evidence?.dailyGoal || null;
+  const streak = evidence?.streak || null;
+  return (
+    <article className="card parent-hub-card">
+      <div className="parent-hub-card-head">
+        <p className="eyebrow">Mode evidence</p>
+        <h3 className="parent-hub-card-title">How recent Punctuation practice breaks down</h3>
+      </div>
+      {sessionModes.length || itemModes.length ? (
+        <ul className="parent-hub-ledger-list">
+          {[...sessionModes, ...itemModes].map((entry) => (
+            <li className="parent-hub-ledger-row" key={`${entry.id || entry.label}-${entry.subjectId || 'punctuation'}`}>
+              <div className="parent-hub-ledger-main">
+                <strong>{entry.label || entry.id}</strong>
+                <span className="parent-hub-row-detail">{`${entry.correct ?? 0}/${entry.attempts ?? 0} correct`}</span>
+              </div>
+              <span className="parent-hub-ledger-figure is-warn">{String(entry.wrong ?? 0)}</span>
+              <span className="parent-hub-row-meta">{entry.accuracy == null ? 'new' : `${entry.accuracy}%`}</span>
+            </li>
+          ))}
+        </ul>
+      ) : <p className="parent-hub-empty small muted">No Punctuation mode evidence has surfaced yet.</p>}
+
+      <div className="parent-hub-focus" style={{ marginTop: 18 }}>
+        <p className="eyebrow">Recent Punctuation mistakes</p>
+        {mistakes.length ? (
+          <ol className="parent-hub-focus-list">
+            {mistakes.map((entry, index) => (
+              <li className="parent-hub-focus-item" key={entry.itemId || `${entry.label}-${index}`}>
+                <span className="parent-hub-focus-marker" aria-hidden="true">{String(index + 1).padStart(2, '0')}</span>
+                <div className="parent-hub-focus-body">
+                  <strong>{entry.label || 'Punctuation attempt'}</strong>
+                  <span className="parent-hub-focus-detail">
+                    {entry.sessionModeLabel || entry.sessionMode || 'Practice'} · {formatTimestamp(entry.createdAt)}
+                  </span>
+                </div>
+              </li>
+            ))}
+          </ol>
+        ) : <p className="parent-hub-empty small muted">No recent Punctuation mistakes are stored yet.</p>}
+      </div>
+
+      <div className="chip-row" style={{ marginTop: 18 }}>
+        {dailyGoal ? <span className="chip">{`Daily goal: ${dailyGoal.attemptsToday ?? 0}/${dailyGoal.targetAttempts ?? 0}`}</span> : null}
+        {streak ? <span className="chip">{`Punctuation streak: ${streak.currentDays ?? 0} day${Number(streak.currentDays) === 1 ? '' : 's'}`}</span> : null}
+      </div>
+    </article>
+  );
+}
+
+function PunctuationEvidencePanel({ evidence }) {
+  return (
+    <>
+      <SectionHead
+        title="Punctuation evidence"
+        note="Skill facets, session modes, item modes, recent mistakes, daily goal, and streak drawn from safe analytics metadata."
+      />
+      <section className="two-col parent-hub-grid parent-hub-punctuation-evidence">
+        <PunctuationFacetEvidence evidence={evidence} />
+        <PunctuationActivityEvidence evidence={evidence} />
+      </section>
+    </>
+  );
+}
+
 function SectionHead({ title, note }) {
   return (
     <div className="home-section-head parent-hub-section-head">
@@ -331,9 +444,13 @@ export function ParentHubSurface({ appState, model, hubState = {}, accessContext
   const patterns = Array.isArray(model.misconceptionPatterns) ? model.misconceptionPatterns : [];
   const progressSnapshots = Array.isArray(model.progressSnapshots) ? model.progressSnapshots : [];
   const grammarEvidence = model.grammarEvidence || {};
+  const punctuationEvidence = model.punctuationEvidence || {};
   const grammarDueConcepts = Number(overview.dueGrammarConcepts) || 0;
   const grammarWeakConcepts = Number(overview.weakGrammarConcepts) || 0;
   const grammarReviewConcepts = grammarDueConcepts + grammarWeakConcepts;
+  const punctuationDueItems = Number(overview.duePunctuationItems) || 0;
+  const punctuationWeakItems = Number(overview.weakPunctuationItems) || 0;
+  const punctuationReviewItems = punctuationDueItems + punctuationWeakItems;
   const accessibleLearners = Array.isArray(model.accessibleLearners) ? model.accessibleLearners : [];
   const selectedLearnerId = model.selectedLearnerId || model.learner?.id || '';
   const notice = hubState.notice || accessContext.adultSurfaceNotice || '';
@@ -387,7 +504,7 @@ export function ParentHubSurface({ appState, model, hubState = {}, accessContext
 
       <SectionHead
         title="Learner overview"
-        note={`Spelling and grammar at a glance for ${firstName}, with the focus parent surfaces are surfacing right now.`}
+        note={`Spelling, grammar, and punctuation at a glance for ${firstName}, with the focus parent surfaces are surfacing right now.`}
       />
       <section className="two-col parent-hub-grid">
         <article className="card parent-hub-card parent-hub-card--overview">
@@ -400,6 +517,9 @@ export function ParentHubSurface({ appState, model, hubState = {}, accessContext
             grammarReviewConcepts={grammarReviewConcepts}
             grammarDueConcepts={grammarDueConcepts}
             grammarWeakConcepts={grammarWeakConcepts}
+            punctuationReviewItems={punctuationReviewItems}
+            punctuationDueItems={punctuationDueItems}
+            punctuationWeakItems={punctuationWeakItems}
           />
           <CurrentFocus items={dueWork} />
         </article>
@@ -435,6 +555,7 @@ export function ParentHubSurface({ appState, model, hubState = {}, accessContext
       </section>
 
       <GrammarEvidencePanel evidence={grammarEvidence} />
+      <PunctuationEvidencePanel evidence={punctuationEvidence} />
 
       <SectionHead
         title="Evidence stream"

--- a/tests/helpers/react-render.js
+++ b/tests/helpers/react-render.js
@@ -358,15 +358,16 @@ export function renderHubSurfaceFixture({ surface = 'parent' } = {}) {
     };
     const parentModel = {
       learner: { id: 'learner-a', name: 'Ava', lastActivityAt: Date.UTC(2026, 3, 22, 12, 0) },
-      learnerOverview: { secureWords: 8, dueWords: 2, troubleWords: 1, accuracyPercent: 82, secureGrammarConcepts: 2, dueGrammarConcepts: 1, weakGrammarConcepts: 1, grammarAccuracyPercent: 67 },
-      dueWork: [{ label: 'Review due spellings', detail: 'Two words are ready.' }, { subjectId: 'grammar', label: 'Repair Grammar misconceptions', detail: 'Adverbials need another pass.' }],
-      recentSessions: [{ id: 'session-1', label: 'Smart Review', status: 'completed', sessionKind: 'spelling', mistakeCount: 1, updatedAt: Date.UTC(2026, 3, 22, 12, 0), headline: 'Good recall' }],
+      learnerOverview: { secureWords: 8, dueWords: 2, troubleWords: 1, accuracyPercent: 82, secureGrammarConcepts: 2, dueGrammarConcepts: 1, weakGrammarConcepts: 1, grammarAccuracyPercent: 67, securePunctuationUnits: 1, duePunctuationItems: 1, weakPunctuationItems: 1, punctuationAccuracyPercent: 50 },
+      dueWork: [{ label: 'Review due spellings', detail: 'Two words are ready.' }, { subjectId: 'grammar', label: 'Repair Grammar misconceptions', detail: 'Adverbials need another pass.' }, { subjectId: 'punctuation', label: 'Run a Punctuation weak spots drill next', detail: 'Speech - Insert punctuation' }],
+      recentSessions: [{ id: 'session-1', label: 'Smart Review', status: 'completed', sessionKind: 'spelling', mistakeCount: 1, updatedAt: Date.UTC(2026, 3, 22, 12, 0), headline: 'Good recall' }, { id: 'punctuation-session-1', subjectId: 'punctuation', label: 'Guided punctuation', status: 'completed', sessionKind: 'guided', mistakeCount: 1, updatedAt: Date.UTC(2026, 3, 22, 13, 0), headline: '1/2' }],
       strengths: [{ label: 'Suffixes', detail: 'Secure recall', secureCount: 4, troubleCount: 0 }],
       weaknesses: [{ label: 'Possession', detail: 'Needs another pass', secureCount: 1, troubleCount: 1 }],
-      misconceptionPatterns: [{ label: 'Double consonant', source: 'event log', count: 2, lastSeenAt: Date.UTC(2026, 3, 22, 12, 0) }],
+      misconceptionPatterns: [{ label: 'Double consonant', source: 'event log', count: 2, lastSeenAt: Date.UTC(2026, 3, 22, 12, 0) }, { subjectId: 'punctuation', label: 'Speech Quote Missing pattern', source: 'punctuation-attempts', count: 1, lastSeenAt: Date.UTC(2026, 3, 22, 13, 0) }],
       progressSnapshots: [
         { subjectId: 'spelling', trackedWords: 213, totalPublishedWords: 235 },
         { subjectId: 'grammar', trackedConcepts: 3, totalConcepts: 18, securedConcepts: 2, dueConcepts: 1, weakConcepts: 1 },
+        { subjectId: 'punctuation', totalRewardUnits: 14, trackedRewardUnits: 1, securedRewardUnits: 1, dueItems: 1, weakItems: 1, attempts: 2, accuracyPercent: 50 },
       ],
       grammarEvidence: {
         subjectId: 'grammar',
@@ -387,6 +388,20 @@ export function renderHubSurfaceFixture({ surface = 'parent' } = {}) {
           nextSteps: ['Practise two fronted adverbial choices'],
           generatedAt: Date.UTC(2026, 3, 22, 12, 0),
         },
+      },
+      punctuationEvidence: {
+        subjectId: 'punctuation',
+        hasEvidence: true,
+        progressSnapshot: { subjectId: 'punctuation', totalRewardUnits: 14, trackedRewardUnits: 1, securedRewardUnits: 1, dueItems: 1, weakItems: 1, attempts: 2, accuracyPercent: 50 },
+        bySessionMode: [{ id: 'guided', label: 'Guided learn', attempts: 1, correct: 0, wrong: 1, accuracy: 0 }],
+        byItemMode: [{ id: 'insert', label: 'Insert punctuation', attempts: 1, correct: 0, wrong: 1, accuracy: 0 }],
+        weakestFacets: [{ id: 'speech::insert', label: 'Speech - Insert punctuation', status: 'weak', attempts: 1, correct: 0, wrong: 1, accuracy: 0 }],
+        recentMistakes: [{ itemId: 'sp_insert_question', label: 'Inverted commas and speech punctuation - Insert punctuation', sessionMode: 'guided', sessionModeLabel: 'Guided learn', createdAt: Date.UTC(2026, 3, 22, 13, 0), supportKind: 'guided' }],
+        misconceptionPatterns: [{ id: 'speech.quote_missing', label: 'Speech Quote Missing pattern', count: 1, lastSeenAt: Date.UTC(2026, 3, 22, 13, 0) }],
+        recentSessions: [],
+        dailyGoal: { targetAttempts: 4, attemptsToday: 1, correctToday: 0, completed: false, progressPercent: 25 },
+        streak: { currentDays: 1, bestDays: 1, activeDays: 1 },
+        releaseDiagnostics: { releaseId: 'punctuation-r4-full-14-skill-structure', trackedRewardUnitCount: 1, sessionCount: 1, weakPatternCount: 1, productionExposureStatus: 'enabled' },
       },
       exportEntryPoints: [{ action: 'platform-export-learner', label: 'Export current learner' }],
       accessibleLearners: [{ learnerId: 'learner-a', learnerName: 'Ava', yearGroup: 'Y5', membershipRoleLabel: 'Viewer', writable: false }],
@@ -419,11 +434,16 @@ export function renderHubSurfaceFixture({ surface = 'parent' } = {}) {
         selectedDiagnostics: {
           learnerId: 'learner-a',
           learnerName: 'Ava',
-          overview: { secureWords: 8, dueWords: 2, troubleWords: 1, secureGrammarConcepts: 2, dueGrammarConcepts: 1, weakGrammarConcepts: 1 },
+          overview: { secureWords: 8, dueWords: 2, troubleWords: 1, secureGrammarConcepts: 2, dueGrammarConcepts: 1, weakGrammarConcepts: 1, securePunctuationUnits: 1, duePunctuationItems: 1, weakPunctuationItems: 1 },
           currentFocus: { detail: 'Review due spellings' },
           grammarEvidence: {
             progressSnapshot: { securedConcepts: 2, dueConcepts: 1, weakConcepts: 1 },
             questionTypeSummary: [{ id: 'choose', label: 'Choose the correct sentence' }],
+          },
+          punctuationEvidence: {
+            progressSnapshot: { securedRewardUnits: 1, dueItems: 1, weakItems: 1 },
+            weakestFacets: [{ id: 'speech::insert', label: 'Speech - Insert punctuation' }],
+            releaseDiagnostics: { releaseId: 'punctuation-r4-full-14-skill-structure', trackedRewardUnitCount: 1, sessionCount: 1, weakPatternCount: 1, productionExposureStatus: 'enabled' },
           },
         },
         accessibleLearners: [{
@@ -433,11 +453,13 @@ export function renderHubSurfaceFixture({ surface = 'parent' } = {}) {
           membershipRoleLabel: 'Viewer',
           accessModeLabel: 'Read-only learner',
           writable: false,
-          overview: { dueWords: 2, dueGrammarConcepts: 1, weakGrammarConcepts: 1 },
+          overview: { dueWords: 2, dueGrammarConcepts: 1, weakGrammarConcepts: 1, duePunctuationItems: 1, weakPunctuationItems: 1 },
           grammarEvidence: { progressSnapshot: { dueConcepts: 1, weakConcepts: 1 } },
+          punctuationEvidence: { progressSnapshot: { dueItems: 1, weakItems: 1 } },
           currentFocus: { label: 'Due spellings' },
         }],
-        entryPoints: [{ action: 'open-subject', label: 'Open Spelling', subjectId: 'spelling' }],
+        punctuationReleaseDiagnostics: { releaseId: 'punctuation-r4-full-14-skill-structure', trackedRewardUnitCount: 1, sessionCount: 1, weakPatternCount: 1, productionExposureStatus: 'enabled' },
+        entryPoints: [{ action: 'open-subject', label: 'Open Spelling', subjectId: 'spelling' }, { action: 'open-subject', label: 'Open Punctuation analytics', subjectId: 'punctuation', tab: 'analytics' }],
       },
     };
     const accountDirectory = {

--- a/tests/hub-read-models.test.js
+++ b/tests/hub-read-models.test.js
@@ -4,6 +4,10 @@ import assert from 'node:assert/strict';
 import { buildParentHubReadModel } from '../src/platform/hubs/parent-read-model.js';
 import { buildAdminHubReadModel } from '../src/platform/hubs/admin-read-model.js';
 import { SEEDED_SPELLING_CONTENT_BUNDLE } from '../src/subjects/spelling/data/content-data.js';
+import { createPunctuationMasteryKey, PUNCTUATION_RELEASE_ID } from '../shared/punctuation/content.js';
+import { createMemoryState, updateMemoryState } from '../shared/punctuation/scheduler.js';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 function makeLearner(id = 'learner-a', name = 'Ava') {
   return {
@@ -15,6 +19,90 @@ function makeLearner(id = 'learner-a', name = 'Ava') {
     avatarColor: '#3E6FA8',
     createdAt: 1000,
   };
+}
+
+function makePunctuationSubjectState(now = 1_777_000_000_000) {
+  const securedMasteryKey = createPunctuationMasteryKey({
+    releaseId: PUNCTUATION_RELEASE_ID,
+    clusterId: 'speech',
+    rewardUnitId: 'speech-core',
+  });
+  return {
+    data: {
+      progress: {
+        items: {
+          sp_insert_question: updateMemoryState(createMemoryState(), false, now),
+          sp_choose_reporting_comma: updateMemoryState(createMemoryState(), true, now - DAY_MS),
+        },
+        facets: {
+          'speech::insert': updateMemoryState(createMemoryState(), false, now),
+          'speech::choose': updateMemoryState(createMemoryState(), true, now - DAY_MS),
+        },
+        rewardUnits: {
+          [securedMasteryKey]: {
+            masteryKey: securedMasteryKey,
+            releaseId: PUNCTUATION_RELEASE_ID,
+            clusterId: 'speech',
+            rewardUnitId: 'speech-core',
+            securedAt: now - 5000,
+          },
+        },
+        attempts: [
+          {
+            ts: now - DAY_MS,
+            sessionId: 'punctuation-gps',
+            itemId: 'sp_choose_reporting_comma',
+            mode: 'choose',
+            skillIds: ['speech'],
+            rewardUnitId: 'speech-core',
+            sessionMode: 'gps',
+            testMode: 'gps',
+            correct: true,
+          },
+          {
+            ts: now,
+            sessionId: 'punctuation-guided',
+            itemId: 'sp_insert_question',
+            mode: 'insert',
+            itemMode: 'insert',
+            skillIds: ['speech'],
+            rewardUnitId: 'speech-core',
+            sessionMode: 'guided',
+            supportLevel: 2,
+            supportKind: 'guided',
+            correct: false,
+            attemptedAnswer: 'Noah shouted we made it.',
+            model: '"We made it!" shouted Noah.',
+            displayCorrection: '"We made it!" shouted Noah.',
+            misconceptionTags: ['speech.quote_missing'],
+            facetOutcomes: [{ id: 'speech::insert', label: 'Speech - Insert punctuation', ok: false }],
+          },
+        ],
+        sessionsCompleted: 2,
+      },
+    },
+    updatedAt: now,
+  };
+}
+
+function addUnknownPunctuationRewardUnits(subjectState, now = 1_777_000_000_000) {
+  const rewardUnits = subjectState.data.progress.rewardUnits;
+  const validUnit = rewardUnits[Object.keys(rewardUnits)[0]];
+  rewardUnits['duplicate-speech-core'] = {
+    ...validUnit,
+    securedAt: now - 4000,
+  };
+  for (let index = 0; index < 15; index += 1) {
+    const masteryKey = `punctuation:${PUNCTUATION_RELEASE_ID}:fake-cluster-${index}:fake-unit-${index}`;
+    rewardUnits[masteryKey] = {
+      masteryKey,
+      releaseId: PUNCTUATION_RELEASE_ID,
+      clusterId: `fake-cluster-${index}`,
+      rewardUnitId: `fake-unit-${index}`,
+      securedAt: now - index,
+    };
+  }
+  return subjectState;
 }
 
 test('parent hub read model summarises due work, recent sessions, strengths, and misconception patterns', () => {
@@ -237,6 +325,49 @@ test('parent hub read model includes Grammar evidence without replacing Spelling
   assert.ok(model.recentSessions.some((entry) => entry.subjectId === 'grammar' && entry.headline === '0/1'));
 });
 
+test('parent hub read model includes Punctuation analytics evidence without raw answers', () => {
+  const learner = makeLearner();
+  const now = 1_777_000_000_000;
+  const punctuationSubjectState = addUnknownPunctuationRewardUnits(makePunctuationSubjectState(now), now);
+  const model = buildParentHubReadModel({
+    learner,
+    platformRole: 'parent',
+    membershipRole: 'owner',
+    subjectStates: {
+      punctuation: punctuationSubjectState,
+    },
+    practiceSessions: [
+      {
+        id: 'punctuation-complete',
+        learnerId: learner.id,
+        subjectId: 'punctuation',
+        sessionKind: 'guided',
+        status: 'completed',
+        summary: { label: 'Guided punctuation', total: 2, correct: 1 },
+        createdAt: now - 1000,
+        updatedAt: now,
+      },
+    ],
+    eventLog: [],
+    now: () => now,
+  });
+
+  assert.equal(model.progressSnapshots.some((snapshot) => snapshot.subjectId === 'punctuation'), true);
+  assert.equal(model.learnerOverview.securePunctuationUnits, 1);
+  assert.equal(model.punctuationEvidence.progressSnapshot.trackedRewardUnits, 1);
+  assert.equal(model.punctuationEvidence.progressSnapshot.totalRewardUnits, 14);
+  assert.equal(model.learnerOverview.weakPunctuationItems, 1);
+  assert.equal(model.dueWork[0].subjectId, 'punctuation');
+  assert.equal(model.punctuationEvidence.bySessionMode.find((entry) => entry.id === 'guided').wrong, 1);
+  assert.equal(model.punctuationEvidence.byItemMode.find((entry) => entry.id === 'insert').attempts, 1);
+  assert.equal(model.punctuationEvidence.weakestFacets[0].id, 'speech::insert');
+  assert.equal(model.punctuationEvidence.recentMistakes[0].supportKind, 'guided');
+  assert.equal(Object.hasOwn(model.punctuationEvidence.recentMistakes[0], 'attemptedAnswer'), false);
+  assert.equal(Object.hasOwn(model.punctuationEvidence.recentMistakes[0], 'model'), false);
+  assert.ok(model.misconceptionPatterns.some((entry) => entry.subjectId === 'punctuation' && /Speech Quote Missing/.test(entry.label)));
+  assert.ok(model.recentSessions.some((entry) => entry.subjectId === 'punctuation' && entry.headline === '1/2'));
+});
+
 test('parent hub read model normalises malformed restored Grammar state safely', () => {
   const learner = makeLearner();
   const model = buildParentHubReadModel({
@@ -314,6 +445,60 @@ test('admin hub diagnostics use actionable Grammar focus before empty Spelling f
   assert.equal(model.learnerSupport.selectedDiagnostics.currentFocus.subjectId, 'grammar');
   assert.match(model.learnerSupport.selectedDiagnostics.currentFocus.label, /Grammar/);
   assert.equal(model.learnerSupport.selectedDiagnostics.grammarEvidence.weakConcepts[0].id, 'adverbials');
+});
+
+test('admin hub diagnostics expose Punctuation release and learner evidence', () => {
+  const learner = makeLearner();
+  const now = 1_777_000_000_000;
+  const model = buildAdminHubReadModel({
+    account: {
+      id: 'adult-admin',
+      selectedLearnerId: learner.id,
+      platformRole: 'admin',
+    },
+    platformRole: 'admin',
+    spellingContentBundle: SEEDED_SPELLING_CONTENT_BUNDLE,
+    memberships: [
+      {
+        learnerId: learner.id,
+        learner,
+        role: 'owner',
+      },
+    ],
+    learnerBundles: {
+      [learner.id]: {
+        subjectStates: {
+          punctuation: addUnknownPunctuationRewardUnits(makePunctuationSubjectState(now), now),
+        },
+        practiceSessions: [
+          {
+            id: 'punctuation-complete',
+            learnerId: learner.id,
+            subjectId: 'punctuation',
+            sessionKind: 'guided',
+            status: 'completed',
+            summary: { label: 'Guided punctuation', total: 2, correct: 1 },
+            createdAt: now - 1000,
+            updatedAt: now,
+          },
+        ],
+        eventLog: [],
+        gameState: {},
+      },
+    },
+    selectedLearnerId: learner.id,
+    now: () => now,
+  });
+
+  const diagnostics = model.learnerSupport.selectedDiagnostics;
+  assert.equal(diagnostics.currentFocus.subjectId, 'punctuation');
+  assert.equal(diagnostics.punctuationEvidence.progressSnapshot.securedRewardUnits, 1);
+  assert.equal(diagnostics.punctuationEvidence.weakestFacets[0].id, 'speech::insert');
+  assert.equal(model.learnerSupport.punctuationReleaseDiagnostics.releaseId, PUNCTUATION_RELEASE_ID);
+  assert.equal(model.learnerSupport.punctuationReleaseDiagnostics.trackedRewardUnitCount, 1);
+  assert.equal(model.learnerSupport.punctuationReleaseDiagnostics.sessionCount, 1);
+  assert.equal(model.learnerSupport.punctuationReleaseDiagnostics.productionExposureStatus, 'enabled');
+  assert.equal(model.learnerSupport.entryPoints.some((entry) => entry.subjectId === 'punctuation' && entry.tab === 'analytics'), true);
 });
 
 test('admin hub read model reports published release status, validation state, audit stream, and learner diagnostics', () => {

--- a/tests/punctuation-analytics.test.js
+++ b/tests/punctuation-analytics.test.js
@@ -1,0 +1,92 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createMemoryState, updateMemoryState } from '../shared/punctuation/scheduler.js';
+import { createPunctuationService } from '../shared/punctuation/service.js';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function makeRepository(initialData = null) {
+  let data = initialData ? JSON.parse(JSON.stringify(initialData)) : null;
+  return {
+    readData() {
+      return data;
+    },
+    writeData(_learnerId, nextData) {
+      data = JSON.parse(JSON.stringify(nextData));
+      return data;
+    },
+  };
+}
+
+test('punctuation analytics exposes safe mode, support, GPS, facet, goal, and streak evidence', () => {
+  const now = Date.UTC(2026, 3, 25, 12, 0, 0);
+  const repository = makeRepository({
+    prefs: { mode: 'smart', roundLength: '4' },
+    progress: {
+      items: {
+        sp_insert_question: updateMemoryState(createMemoryState(), false, now),
+        sp_choose_reporting_comma: updateMemoryState(createMemoryState(), true, now - DAY_MS),
+      },
+      facets: {
+        'speech::insert': updateMemoryState(createMemoryState(), false, now),
+        'speech::choose': updateMemoryState(createMemoryState(), true, now - DAY_MS),
+      },
+      rewardUnits: {},
+      attempts: [
+        {
+          ts: now - DAY_MS,
+          sessionId: 'gps-session',
+          itemId: 'sp_choose_reporting_comma',
+          mode: 'choose',
+          skillIds: ['speech'],
+          rewardUnitId: 'speech-core',
+          sessionMode: 'gps',
+          testMode: 'gps',
+          supportLevel: 0,
+          correct: true,
+          misconceptionTags: [],
+        },
+        {
+          ts: now,
+          sessionId: 'guided-session',
+          itemId: 'sp_insert_question',
+          mode: 'insert',
+          skillIds: ['speech'],
+          rewardUnitId: 'speech-core',
+          sessionMode: 'guided',
+          supportLevel: 2,
+          correct: false,
+          attemptedAnswer: 'Noah shouted we made it.',
+          model: '"We made it!" shouted Noah.',
+          displayCorrection: '"We made it!" shouted Noah.',
+          misconceptionTags: ['speech.quote_missing'],
+          facetOutcomes: [{ id: 'speech::insert', label: 'Speech - Insert punctuation', ok: false }],
+        },
+      ],
+      sessionsCompleted: 2,
+    },
+  });
+  const service = createPunctuationService({ repository, now: () => now, random: () => 0 });
+
+  const analytics = service.getAnalyticsSnapshot('learner-a');
+
+  assert.equal(analytics.bySessionMode.find((entry) => entry.id === 'guided').accuracy, 0);
+  assert.equal(analytics.bySessionMode.find((entry) => entry.id === 'gps').accuracy, 100);
+  assert.equal(analytics.byItemMode.find((entry) => entry.id === 'insert').wrong, 1);
+  assert.equal(analytics.weakestFacets[0].id, 'speech::insert');
+  assert.equal(analytics.dailyGoal.attemptsToday, 1);
+  assert.equal(analytics.streak.currentDays, 2);
+
+  const mistake = analytics.recentMistakes[0];
+  assert.equal(mistake.sessionMode, 'guided');
+  assert.equal(mistake.supportLevel, 2);
+  assert.equal(mistake.supportKind, 'guided');
+  assert.equal(mistake.testMode, null);
+  assert.deepEqual(mistake.facetOutcomes, [{ id: 'speech::insert', label: 'Speech - Insert punctuation', ok: false }]);
+  assert.equal(analytics.misconceptionPatterns[0].id, 'speech.quote_missing');
+
+  assert.equal(Object.hasOwn(mistake, 'attemptedAnswer'), false);
+  assert.equal(Object.hasOwn(mistake, 'model'), false);
+  assert.equal(Object.hasOwn(mistake, 'displayCorrection'), false);
+});

--- a/tests/react-hub-surfaces.test.js
+++ b/tests/react-hub-surfaces.test.js
@@ -18,6 +18,11 @@ test('React Parent Hub surface renders readable learner payload and read-only no
   assert.match(html, /Question-type evidence/);
   assert.match(html, /Recent Grammar activity/);
   assert.match(html, /Parent summary draft/);
+  assert.match(html, /Punctuation secured/);
+  assert.match(html, /Punctuation: 1\/14 units/);
+  assert.match(html, /Punctuation evidence/);
+  assert.match(html, /Speech - Insert punctuation/);
+  assert.match(html, /Recent Punctuation mistakes/);
   assert.doesNotMatch(html, /Subject: spelling/);
   assert.match(html, /Export current learner/);
   assert.match(html, /disabled=""/);
@@ -37,5 +42,8 @@ test('React Admin Operations surface renders content, audit, account roles, and 
   assert.match(html, /admin@example.com/);
   assert.match(html, /Readable learners/);
   assert.match(html, /Grammar diagnostics/);
+  assert.match(html, /Punctuation diagnostics/);
+  assert.match(html, /punctuation-r4-full-14-skill-structure/);
+  assert.match(html, /Open Punctuation analytics/);
   assert.match(html, /Choose the correct sentence/);
 });


### PR DESCRIPTION
## Summary
- extend Punctuation attempt analytics with session mode, item mode, support, GPS/test, facet, daily goal, and streak evidence
- add a safe client-side Punctuation learner read model and surface the evidence in Parent Hub and Admin / Operations diagnostics
- mark U9 complete in the legacy parity plan and cover the new analytics/read-model/UI paths with targeted tests

## Verification
- node --test tests/punctuation-analytics.test.js tests/hub-read-models.test.js tests/react-hub-surfaces.test.js tests/worker-punctuation-runtime.test.js
- npm test
- npm run check