### PR TITLE
chore(punctuation): harden legacy parity release gate

### DIFF
--- a/docs/plans/2026-04-24-002-feat-punctuation-legacy-parity-plan.md
+++ b/docs/plans/2026-04-24-002-feat-punctuation-legacy-parity-plan.md
@@ -469,7 +469,7 @@ tests/
 
 ---
 
-- [ ] U10. **Update Production Smoke, Documentation, And Release Gate**
+- [x] U10. **Update Production Smoke, Documentation, And Release Gate**
 
 **Goal:** Make full legacy parity independently verifiable before claiming it is deployed.
 

--- a/docs/punctuation-production.md
+++ b/docs/punctuation-production.md
@@ -197,9 +197,11 @@ The Punctuation release gate includes:
 - Worker command tests for start, submit, continue, stale transitions, redaction, and idempotent reward projection
 - React scene tests for setup, active, feedback, summary, and hidden-field absence
 - subject expansion conformance and golden-path smoke coverage
-- deterministic demo release smoke proving default hidden exposure and gated Worker command execution
+- deterministic demo release smoke proving default hidden exposure, Smart review, GPS delayed review, Parent Hub evidence, gated Worker command execution, and English Spelling startup
 - asset tests for Bellstorm Coast scenes and Punctuation monster artwork
-- bundle/public-output audits proving engine/content source is not shipped to the browser
+- bundle/public-output audits proving engine/content source and raw source paths are not shipped to the browser
+- performance coverage for bounded scheduling across fixed items, generated items, sentence combining, and paragraph repair
+- local release smoke coverage for Admin Hub Punctuation evidence redaction; live production smoke does not require an admin session
 
 Production exposure is controlled by the `PUNCTUATION_SUBJECT_ENABLED` Worker env var, which feeds the browser `punctuationProduction` subject exposure gate. The release-smoke gate now covers both sides of the rollout: `false` keeps the Worker command route, dashboard card, and direct subject route unavailable; `true` exposes the subject only after the Worker-backed demo path has been verified.
 
@@ -218,7 +220,7 @@ For repeatable HTTP evidence after a Punctuation deploy, run:
 npm run smoke:production:punctuation
 ```
 
-The smoke creates an isolated demo session on production, confirms `punctuationProduction` is enabled, completes one Worker-backed Punctuation item through summary, and starts a Worker-backed English Spelling session with a redacted prompt token. This keeps the Punctuation rollout gate tied to the live subject command boundary while also proving the reference Spelling subject still starts correctly.
+The smoke creates an isolated demo session on production, confirms `punctuationProduction` is enabled, completes one Worker-backed Smart review item through summary, completes one GPS test item through delayed review, checks Parent Hub Punctuation evidence for hidden-field redaction, and starts a Worker-backed English Spelling session with a redacted prompt token. This keeps the Punctuation rollout gate tied to the live subject command boundary while also proving the reference Spelling subject still starts correctly.
 
 ## Expansion Path
 
@@ -228,7 +230,7 @@ Do not expose planned clusters just because monster assets exist. Bellstorm Coas
 
 ## Legacy Parity Baseline
 
-Full legacy HTML parity is tracked separately from the current production claim.
+Full legacy HTML learner-facing parity is now claimed against the repo-local baseline. This means the legacy modes and item behaviours are available through the production Worker-owned subject, not that the old single-file architecture has been copied.
 
 The baseline fixture lives at:
 
@@ -244,9 +246,8 @@ shared/punctuation/legacy-parity.js
 
 The baseline currently classifies legacy behaviour as:
 
-- Ported: the 14-skill map, Worker command runtime, Smart review, guided learning, dedicated weak spots, GPS test mode, `choose`, `insert`, `fix`, `transfer`, `combine`, `paragraph`, reward-unit analytics, skill rows, and recent mistakes.
-- Planned: richer transfer validators, safe context-pack compilation, and deeper Parent/Admin evidence.
-- Replaced: legacy standalone `choose`, `insert`, `fix`, `transfer`, sentence-combining, and paragraph-repair session buttons are represented by production item modes inside Smart review, weak spots, and focused cluster sessions.
-- Rejected: the legacy single-file production route, localStorage source of truth, browser-owned marking, and browser-stored AI provider keys.
+- Ported: the 14-skill map, Worker command runtime, Smart review, guided learning, dedicated weak spots, GPS test mode, `choose`, `insert`, `fix`, `transfer`, `combine`, `paragraph`, deterministic transfer validators, safe context-pack compilation, reward-unit analytics, session-mode and item-mode analytics, weakest facets, daily goal, streak, recent mistakes, and Parent/Admin evidence.
+- Replaced: legacy standalone `choose`, `insert`, `fix`, `transfer`, sentence-combining, and paragraph-repair session buttons are represented by production item modes inside Smart review, weak spots, guided practice, GPS, and focused cluster sessions. The legacy browser AI lane is represented by a server-side context-pack compiler that can only contribute sanitised atoms to deterministic generators.
+- Rejected: the legacy single-file production route, localStorage source of truth, browser-owned marking, browser-stored AI provider keys, browser-direct provider calls, unconstrained free-writing auto-scoring, and AI-authored score-bearing items or marking decisions.
 
 This baseline is deliberately a guardrail, not a demand to copy the legacy architecture. New parity slices should update the fixture status only when the replacement Worker-owned implementation, redacted read model, tests, and release gate exist.

--- a/scripts/production-bundle-audit.mjs
+++ b/scripts/production-bundle-audit.mjs
@@ -15,6 +15,7 @@ const DIRECT_DENIAL_PATHS = [
   '/shared/punctuation/service.js',
   '/worker/src/subjects/punctuation/commands.js',
   '/worker/src/subjects/punctuation/read-models.js',
+  '/src/subjects/punctuation/read-model.js',
   '/src/subjects/punctuation/service.js',
   '/src/subjects/punctuation/repository.js',
   '/src/platform/core/local-review-profile.js',

--- a/scripts/punctuation-production-smoke.mjs
+++ b/scripts/punctuation-production-smoke.mjs
@@ -1,18 +1,24 @@
 #!/usr/bin/env node
 
 import assert from 'node:assert/strict';
+import { pathToFileURL } from 'node:url';
 
-import { createPunctuationContentIndexes } from '../shared/punctuation/content.js';
+import {
+  createPunctuationContentIndexes,
+  PUNCTUATION_RELEASE_ID,
+} from '../shared/punctuation/content.js';
 import { createPunctuationRuntimeManifest } from '../shared/punctuation/generators.js';
 import {
   assertNoForbiddenObjectKeys,
+  assertOkResponse,
   configuredOrigin,
   createDemoSession,
+  getJson,
   loadBootstrap,
   subjectCommand,
 } from './lib/production-smoke.mjs';
 
-const FORBIDDEN_READ_MODEL_KEYS = new Set([
+const FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS = new Set([
   'accepted',
   'answers',
   'correctIndex',
@@ -20,19 +26,83 @@ const FORBIDDEN_READ_MODEL_KEYS = new Set([
   'validator',
   'seed',
   'generator',
+  'rawGenerator',
   'hiddenQueue',
+  'queueItemIds',
+  'responses',
   'unpublished',
 ]);
 
-function assertNoForbiddenReadModelKeys(value, path = 'subjectReadModel') {
-  assertNoForbiddenObjectKeys(value, FORBIDDEN_READ_MODEL_KEYS, path);
+const FORBIDDEN_PUNCTUATION_ADULT_EVIDENCE_KEYS = new Set([
+  ...FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS,
+  'attemptedAnswer',
+  'choiceIndex',
+  'correctAnswer',
+  'displayCorrection',
+  'expected',
+  'expectedAnswer',
+  'model',
+  'rawResponse',
+  'response',
+  'typed',
+]);
+
+export function assertNoForbiddenPunctuationReadModelKeys(value, path = 'punctuation.subjectReadModel') {
+  assertNoForbiddenObjectKeys(value, FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS, path);
 }
 
-function punctuationAnswerFor(readItem) {
+export function assertNoForbiddenPunctuationAdultEvidenceKeys(value, path = 'punctuation.adultEvidence') {
+  assertNoForbiddenObjectKeys(value, FORBIDDEN_PUNCTUATION_ADULT_EVIDENCE_KEYS, path);
+}
+
+function normaliseSourceOption(option, index) {
+  if (option && typeof option === 'object' && !Array.isArray(option)) {
+    const optionIndex = Number(option.index);
+    return {
+      index: Number.isInteger(optionIndex) && optionIndex >= 0 ? optionIndex : index,
+      text: typeof option.text === 'string' ? option.text : '',
+    };
+  }
+  return {
+    index,
+    text: typeof option === 'string' ? option : '',
+  };
+}
+
+function visibleOptionSet(readItem) {
+  assert.ok(Array.isArray(readItem?.options), `${readItem?.id || 'unknown item'} did not expose visible choice options.`);
+  return readItem.options.map((option, index) => {
+    assert.equal(typeof option?.text, 'string', `${readItem.id} exposed option ${index + 1} without visible text.`);
+    assert.equal(Number.isInteger(Number(option?.index)), true, `${readItem.id} exposed option ${index + 1} without a numeric index.`);
+    return {
+      index: Number(option.index),
+      text: option.text,
+    };
+  });
+}
+
+function assertVisiblePunctuationItemMatchesSource(readItem, source, path = 'punctuation.currentItem') {
+  assert.equal(readItem?.id, source.id, `${path}.id did not match the source item.`);
+  assert.equal(readItem?.mode, source.mode, `${path}.mode did not match the source item.`);
+  assert.equal(readItem?.inputKind, source.mode === 'choose' ? 'choice' : 'text', `${path}.inputKind did not match the source item.`);
+  assert.equal(readItem?.prompt, source.prompt || '', `${path}.prompt did not match the source item.`);
+  assert.equal(readItem?.stem || '', source.stem || '', `${path}.stem did not match the source item.`);
+  assert.equal(readItem?.clusterId || null, source.clusterId || null, `${path}.clusterId did not match the source item.`);
+  assert.deepEqual(readItem?.skillIds || [], Array.isArray(source.skillIds) ? source.skillIds : [], `${path}.skillIds did not match the source item.`);
+  assert.equal(readItem?.source, source.source === 'generated' ? 'generated' : 'fixed', `${path}.source did not match the source item.`);
+
+  if (readItem.inputKind === 'choice') {
+    const expectedOptions = (Array.isArray(source.options) ? source.options : []).map(normaliseSourceOption);
+    assert.deepEqual(visibleOptionSet(readItem), expectedOptions, `${path}.options did not match the source item visible option set.`);
+  }
+}
+
+export function punctuationAnswerFor(readItem) {
   const manifest = createPunctuationRuntimeManifest();
   const indexes = createPunctuationContentIndexes(manifest);
   const source = indexes.itemById.get(readItem?.id);
   assert.ok(source, `Could not find source punctuation item for ${readItem?.id || 'unknown item'}.`);
+  assertVisiblePunctuationItemMatchesSource(readItem, source);
 
   if (readItem.inputKind === 'choice') {
     assert.ok(Number.isInteger(source.correctIndex), `Punctuation choice item ${source.id} has no correctIndex.`);
@@ -46,7 +116,23 @@ function punctuationAnswerFor(readItem) {
   return { typed };
 }
 
-async function smokePunctuation({ origin, cookie, learnerId, revision }) {
+export function punctuationExpectedContextFor(session = {}) {
+  const context = {};
+  if (typeof session.id === 'string' && session.id) context.expectedSessionId = session.id;
+  if (typeof session.currentItem?.id === 'string' && session.currentItem.id) {
+    context.expectedItemId = session.currentItem.id;
+  }
+  if (Number.isFinite(Number(session.answeredCount))) {
+    context.expectedAnsweredCount = Number(session.answeredCount);
+  }
+  if (typeof session.releaseId === 'string' && session.releaseId) {
+    context.expectedReleaseId = session.releaseId;
+  }
+  assert.equal(session.releaseId, PUNCTUATION_RELEASE_ID, 'Punctuation session release id did not match the current runtime release.');
+  return context;
+}
+
+async function smokePunctuationSmartRound({ origin, cookie, learnerId, revision }) {
   let step = await subjectCommand({
     origin,
     cookie,
@@ -61,10 +147,11 @@ async function smokePunctuation({ origin, cookie, learnerId, revision }) {
   assert.equal(startModel?.phase, 'active-item', 'Punctuation did not start in active-item phase.');
   assert.equal(startModel?.session?.serverAuthority, 'worker', 'Punctuation session was not Worker-owned.');
   assert.equal(startModel?.session?.length, 1, 'Punctuation smoke round did not use length 1.');
-  assertNoForbiddenReadModelKeys(startModel);
+  assertNoForbiddenPunctuationReadModelKeys(startModel, 'punctuation.smart.startModel');
 
   const currentItem = startModel.session?.currentItem;
   const answer = punctuationAnswerFor(currentItem);
+  const expectedContext = punctuationExpectedContextFor(startModel.session);
   step = await subjectCommand({
     origin,
     cookie,
@@ -72,13 +159,13 @@ async function smokePunctuation({ origin, cookie, learnerId, revision }) {
     learnerId,
     revision,
     command: 'submit-answer',
-    payload: answer,
+    payload: { ...answer, ...expectedContext },
   });
   revision = step.revision;
   const feedbackModel = step.payload.subjectReadModel;
   assert.equal(feedbackModel?.phase, 'feedback', 'Punctuation submit did not return feedback phase.');
   assert.equal(feedbackModel?.feedback?.kind, 'success', `Punctuation smoke answer was not accepted for ${currentItem?.id}.`);
-  assertNoForbiddenReadModelKeys(feedbackModel);
+  assertNoForbiddenPunctuationReadModelKeys(feedbackModel, 'punctuation.smart.feedbackModel');
 
   step = await subjectCommand({
     origin,
@@ -92,12 +179,104 @@ async function smokePunctuation({ origin, cookie, learnerId, revision }) {
   const summaryModel = step.payload.subjectReadModel;
   assert.equal(summaryModel?.phase, 'summary', 'Punctuation continue did not reach summary.');
   assert.equal(summaryModel?.summary?.total, 1, 'Punctuation summary did not record one answered item.');
-  assertNoForbiddenReadModelKeys(summaryModel);
+  assertNoForbiddenPunctuationReadModelKeys(summaryModel, 'punctuation.smart.summaryModel');
 
   return {
     revision,
     itemId: currentItem.id,
     summaryTotal: summaryModel.summary.total,
+  };
+}
+
+async function smokePunctuationGpsReview({ origin, cookie, learnerId, revision }) {
+  let step = await subjectCommand({
+    origin,
+    cookie,
+    subjectId: 'punctuation',
+    learnerId,
+    revision,
+    command: 'start-session',
+    payload: { mode: 'gps', roundLength: '1' },
+  });
+  revision = step.revision;
+  const startModel = step.payload.subjectReadModel;
+  assert.equal(startModel?.phase, 'active-item', 'Punctuation GPS did not start in active-item phase.');
+  assert.equal(startModel?.session?.mode, 'gps', 'Punctuation advanced smoke did not start GPS mode.');
+  assert.equal(startModel?.session?.serverAuthority, 'worker', 'Punctuation GPS session was not Worker-owned.');
+  assert.equal(startModel?.session?.gps?.delayedFeedback, true, 'Punctuation GPS did not enable delayed feedback.');
+  assert.equal(startModel?.feedback, null, 'Punctuation GPS exposed feedback before the test ended.');
+  assertNoForbiddenPunctuationReadModelKeys(startModel, 'punctuation.gps.startModel');
+
+  const currentItem = startModel.session?.currentItem;
+  const answer = punctuationAnswerFor(currentItem);
+  const expectedContext = punctuationExpectedContextFor(startModel.session);
+  step = await subjectCommand({
+    origin,
+    cookie,
+    subjectId: 'punctuation',
+    learnerId,
+    revision,
+    command: 'submit-answer',
+    payload: { ...answer, ...expectedContext },
+  });
+  revision = step.revision;
+  const summaryModel = step.payload.subjectReadModel;
+  assert.equal(summaryModel?.phase, 'summary', 'Punctuation GPS submit did not reach the delayed summary.');
+  assert.equal(summaryModel?.summary?.total, 1, 'Punctuation GPS summary did not record one answered item.');
+  assert.equal(summaryModel?.summary?.gps?.delayedFeedback, true, 'Punctuation GPS summary did not preserve delayed-feedback metadata.');
+  assert.equal(summaryModel?.summary?.gps?.reviewItems?.length, 1, 'Punctuation GPS summary did not include one review row.');
+  assert.equal(summaryModel.summary.gps.reviewItems[0]?.itemId, currentItem?.id, 'Punctuation GPS review row did not match the answered item.');
+  assertNoForbiddenPunctuationReadModelKeys(summaryModel, 'punctuation.gps.summaryModel');
+
+  return {
+    revision,
+    itemId: currentItem.id,
+    summaryTotal: summaryModel.summary.total,
+    reviewItems: summaryModel.summary.gps.reviewItems.length,
+  };
+}
+
+async function smokePunctuationParentEvidence({ origin, cookie, learnerId }) {
+  const result = await getJson(origin, `/api/hubs/parent?learnerId=${encodeURIComponent(learnerId)}`, { cookie });
+  assertOkResponse('Parent Hub Punctuation evidence', result);
+  const parentHub = result.payload?.parentHub;
+  assert.ok(parentHub, 'Parent Hub response did not include a parentHub payload.');
+  const evidence = parentHub.punctuationEvidence;
+  assert.equal(evidence?.hasEvidence, true, 'Parent Hub did not expose Punctuation evidence after the smoke attempts.');
+  assert.ok(
+    Number(evidence?.overview?.attempts) >= 2,
+    `Parent Hub Punctuation evidence recorded too few attempts: ${evidence?.overview?.attempts}`,
+  );
+  assert.equal(
+    parentHub.progressSnapshots?.some((snapshot) => snapshot?.subjectId === 'punctuation'),
+    true,
+    'Parent Hub progress snapshots did not include Punctuation.',
+  );
+  assertNoForbiddenPunctuationAdultEvidenceKeys(evidence, 'parentHub.punctuationEvidence');
+  assertNoForbiddenPunctuationAdultEvidenceKeys(parentHub.progressSnapshots, 'parentHub.progressSnapshots');
+  assertNoForbiddenPunctuationAdultEvidenceKeys(parentHub.misconceptionPatterns, 'parentHub.misconceptionPatterns');
+
+  return {
+    attempts: evidence.overview.attempts,
+    accuracyPercent: evidence.overview.accuracyPercent,
+    sessionModes: evidence.bySessionMode.map((entry) => entry.id),
+  };
+}
+
+async function smokePunctuation({ origin, cookie, learnerId, revision }) {
+  const smart = await smokePunctuationSmartRound({ origin, cookie, learnerId, revision });
+  const advanced = await smokePunctuationGpsReview({
+    origin,
+    cookie,
+    learnerId,
+    revision: smart.revision,
+  });
+  const parentHub = await smokePunctuationParentEvidence({ origin, cookie, learnerId });
+  return {
+    revision: advanced.revision,
+    smart,
+    advanced,
+    parentHub,
   };
 }
 
@@ -157,8 +336,12 @@ async function main() {
     accountId: demo.session.accountId,
     learnerId: bootstrap.learnerId,
     punctuation: {
-      itemId: punctuation.itemId,
-      summaryTotal: punctuation.summaryTotal,
+      smartItemId: punctuation.smart.itemId,
+      smartSummaryTotal: punctuation.smart.summaryTotal,
+      advancedMode: 'gps',
+      advancedItemId: punctuation.advanced.itemId,
+      advancedReviewItems: punctuation.advanced.reviewItems,
+      parentHubAttempts: punctuation.parentHub.attempts,
     },
     spelling: {
       progressTotal: spelling.progressTotal,
@@ -167,7 +350,9 @@ async function main() {
   }, null, 2));
 }
 
-main().catch((error) => {
-  console.error(`[punctuation-production-smoke] ${error?.stack || error?.message || error}`);
-  process.exit(1);
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(`[punctuation-production-smoke] ${error?.stack || error?.message || error}`);
+    process.exit(1);
+  });
+}

--- a/src/subjects/punctuation/components/PunctuationPracticeSurface.jsx
+++ b/src/subjects/punctuation/components/PunctuationPracticeSurface.jsx
@@ -261,7 +261,7 @@ function SummaryView({ ui, actions }) {
   const scene = bellstormSceneForPhase('summary');
   const gpsReview = Array.isArray(summary.gps?.reviewItems) ? summary.gps.reviewItems : [];
   return (
-    <section className="card border-top punctuation-surface" style={{ borderTopColor: '#2E8479' }}>
+    <section className="card border-top punctuation-surface" data-punctuation-summary style={{ borderTopColor: '#2E8479' }}>
       <div className="punctuation-strip">
         <img src={scene.src} srcSet={scene.srcSet} sizes="(max-width: 980px) 100vw, 960px" alt="" aria-hidden="true" />
         <div>

--- a/tests/browser-react-migration-smoke.test.js
+++ b/tests/browser-react-migration-smoke.test.js
@@ -81,10 +81,27 @@ test('browser migration smoke covers the React app root, Grammar completeness co
       ['wait', '[data-punctuation-start]'],
       ['text'],
       ['click', '[data-punctuation-start]'],
-      ['wait', '[data-punctuation-submit]'],
-      ['js', "const choice = document.querySelector('input[name=\"choiceIndex\"]'); if (choice) choice.click(); 'picked punctuation option';"],
+      ['wait', 'input[name="choiceIndex"]'],
+      ['click', 'input[name="choiceIndex"]'],
       ['click', '[data-punctuation-submit]'],
       ['wait', '[data-punctuation-continue]'],
+      ['click', '[data-punctuation-continue]'],
+      ['wait', 'textarea[name="typed"]'],
+      ['fill', 'textarea[name="typed"]', 'where is the library'],
+      ['click', '[data-punctuation-submit]'],
+      ['wait', '[data-punctuation-continue]'],
+      ['click', '[data-punctuation-continue]'],
+      ['wait', 'textarea[name="typed"]'],
+      ['fill', 'textarea[name="typed"]', 'the pupils packed pencils rubbers and rulers'],
+      ['click', '[data-punctuation-submit]'],
+      ['wait', '[data-punctuation-continue]'],
+      ['click', '[data-punctuation-continue]'],
+      ['wait', 'textarea[name="typed"]'],
+      ['fill', 'textarea[name="typed"]', 'After lunch, the class checked their work.'],
+      ['click', '[data-punctuation-submit]'],
+      ['wait', '[data-punctuation-continue]'],
+      ['click', '[data-punctuation-continue]'],
+      ['wait', '[data-punctuation-summary]'],
       ['text'],
       ['js', "const punctuationHome = document.querySelector('.profile-brand-button[data-action=\"navigate-home\"]'); if (!punctuationHome) throw new Error('missing punctuation brand home button'); punctuationHome.click(); 'back from punctuation';"],
       ['wait', '.subject-grid'],
@@ -142,7 +159,7 @@ test('browser migration smoke covers the React app root, Grammar completeness co
     assert.match(output, /Your subjects/);
     assert.doesNotMatch(output, /data-home-mount/);
     assert.match(output, /Punctuation practice/);
-    assert.match(output, /Feedback/);
+    assert.match(output, /Punctuation session summary/);
     assert.match(output, /Grammar retrieval practice/);
     assert.match(output, /KS2-style mini-test/);
     assert.match(output, /Timed test/);

--- a/tests/bundle-audit.test.js
+++ b/tests/bundle-audit.test.js
@@ -335,6 +335,51 @@ test('production bundle audit fails source paths served by SPA fallback', async 
   }
 });
 
+test('production bundle audit denies the Punctuation hub read-model source path', async () => {
+  const server = createServer((request, response) => {
+    if (request.url === '/assets/app.js') {
+      response.writeHead(200, { 'content-type': 'application/javascript' });
+      response.end('console.log("ok");');
+      return;
+    }
+    if (request.url === '/src/subjects/punctuation/read-model.js') {
+      response.writeHead(200, { 'content-type': 'application/javascript' });
+      response.end('export function buildPunctuationLearnerReadModel() { return {}; }');
+      return;
+    }
+    if (request.url === '/') {
+      response.writeHead(200, { 'content-type': 'text/html' });
+      response.end('<!doctype html><script src="/assets/app.js"></script>');
+      return;
+    }
+    response.writeHead(404, { 'content-type': 'text/plain' });
+    response.end('not found');
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+  try {
+    const { port } = server.address();
+    await assert.rejects(async () => {
+      await execFileAsync(process.execPath, [
+        './scripts/production-bundle-audit.mjs',
+        '--skip-local',
+        '--url',
+        `http://127.0.0.1:${port}/`,
+      ], {
+        cwd: process.cwd(),
+        timeout: 5000,
+      });
+    }, (error) => {
+      assert.match(error.stderr, /Direct URL should be denied with a 4xx response, got 200: \/src\/subjects\/punctuation\/read-model\.js/);
+      assert.match(error.stderr, /Direct URL unexpectedly served raw source-like JavaScript: \/src\/subjects\/punctuation\/read-model\.js/);
+      return true;
+    });
+  } finally {
+    server.closeAllConnections?.();
+    await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+  }
+});
+
 test('production bundle audit fails on deployed Punctuation context-pack source and provider tokens', async () => {
   const server = createServer((request, response) => {
     if (request.url === '/assets/app.js') {

--- a/tests/punctuation-performance.test.js
+++ b/tests/punctuation-performance.test.js
@@ -38,3 +38,53 @@ test('expanded-manifest start selection stays within the bounded scheduler windo
   assert.equal(result.inspectedCount, 32);
   assert.ok(result.candidateCount > 300);
 });
+
+test('mixed fixed, generated, combine, and paragraph scheduling stays bounded', () => {
+  const modes = ['choose', 'insert', 'fix', 'transfer', 'combine', 'paragraph'];
+  const generated = Array.from({ length: 1800 }, (_, index) => {
+    const mode = modes[index % modes.length];
+    return {
+      id: `generated_mixed_${mode}_${index}`,
+      mode,
+      inputKind: mode === 'choose' ? 'choice' : 'text',
+      skillIds: ['sentence_endings'],
+      clusterId: 'endmarks',
+      rewardUnitId: 'sentence-endings-core',
+      prompt: `Generated ${mode} performance fixture.`,
+      stem: `where is mixed item ${index}`,
+      accepted: [`Where is mixed item ${index}?`],
+      explanation: 'Generated performance fixture.',
+      model: `Where is mixed item ${index}?`,
+      options: mode === 'choose'
+        ? [
+            { text: `where is mixed item ${index}`, correct: false },
+            { text: `Where is mixed item ${index}?`, correct: true },
+          ]
+        : undefined,
+      correctIndex: mode === 'choose' ? 1 : undefined,
+      readiness: [mode],
+      source: 'generated',
+    };
+  });
+  const indexes = createPunctuationContentIndexes({
+    ...PUNCTUATION_CONTENT_MANIFEST,
+    items: [...PUNCTUATION_CONTENT_MANIFEST.items, ...generated],
+  });
+
+  modes.forEach((mode, answeredCount) => {
+    const result = selectPunctuationItem({
+      indexes,
+      progress: { items: {} },
+      session: { mode: 'smart', answeredCount, recentItemIds: [] },
+      prefs: { mode: 'smart' },
+      now: 0,
+      random: () => 0.4,
+      candidateWindow: 40,
+    });
+
+    assert.equal(result.targetMode, mode);
+    assert.equal(result.item.mode, mode);
+    assert.ok(result.inspectedCount <= 40);
+    assert.ok(result.candidateCount >= 300);
+  });
+});

--- a/tests/punctuation-release-smoke.test.js
+++ b/tests/punctuation-release-smoke.test.js
@@ -3,12 +3,14 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 
 import { SUBJECT_EXPOSURE_GATES } from '../src/platform/core/subject-availability.js';
-import { createPunctuationContentIndexes } from '../shared/punctuation/content.js';
-import { createPunctuationRuntimeManifest } from '../shared/punctuation/generators.js';
+import {
+  assertNoForbiddenPunctuationAdultEvidenceKeys,
+  assertNoForbiddenPunctuationReadModelKeys,
+  punctuationAnswerFor,
+  punctuationExpectedContextFor,
+} from '../scripts/punctuation-production-smoke.mjs';
+import { createSession } from '../worker/src/auth.js';
 import { createWorkerRepositoryServer } from './helpers/worker-server.js';
-
-const RUNTIME_PUNCTUATION_ITEMS = createPunctuationContentIndexes(createPunctuationRuntimeManifest()).itemById;
-const SERVER_ONLY_READ_MODEL_FIELDS = /accepted|correctIndex|rubric|validator|hiddenQueue|generator/;
 
 async function readWranglerVars() {
   const source = await readFile(new URL('../wrangler.jsonc', import.meta.url), 'utf8');
@@ -83,10 +85,6 @@ function punctuationMutationCounts(server, { accountId, learnerId, requestId = '
   };
 }
 
-function assertPunctuationReadModelRedacted(readModel) {
-  assert.doesNotMatch(JSON.stringify(readModel), SERVER_ONLY_READ_MODEL_FIELDS);
-}
-
 async function postJson(server, path, body = {}, headers = {}) {
   return server.fetchRaw(`https://repo.test${path}`, {
     method: 'POST',
@@ -120,8 +118,8 @@ async function startDemo(server) {
   };
 }
 
-async function postPunctuationCommand(server, { cookie, learnerId, revision, command, payload = {}, requestId }) {
-  const response = await postJson(server, '/api/subjects/punctuation/command', {
+async function postSubjectCommand(server, subjectId, { cookie, learnerId, revision, command, payload = {}, requestId }) {
+  const response = await postJson(server, `/api/subjects/${subjectId}/command`, {
     command,
     learnerId,
     requestId,
@@ -137,17 +135,30 @@ async function postPunctuationCommand(server, { cookie, learnerId, revision, com
   };
 }
 
-function learnerAnswerFor(item = {}) {
-  const sourceItem = RUNTIME_PUNCTUATION_ITEMS.get(item.id);
-  assert.ok(sourceItem, `Expected a runtime punctuation item for ${item.id || 'unknown item'}`);
-  if (item.inputKind === 'choice') {
-    assert.ok(Number.isInteger(sourceItem.correctIndex), `Expected a correct choice index for ${item.id}`);
-    return { choiceIndex: sourceItem.correctIndex };
-  }
-  const acceptedAnswer = Array.isArray(sourceItem.accepted) ? sourceItem.accepted.find(Boolean) : '';
-  const typed = sourceItem.model || acceptedAnswer;
-  assert.ok(typed, `Expected a model answer for ${item.id}`);
-  return { typed };
+async function postPunctuationCommand(server, args) {
+  return postSubjectCommand(server, 'punctuation', args);
+}
+
+async function postSpellingCommand(server, args) {
+  return postSubjectCommand(server, 'spelling', args);
+}
+
+async function adminCookieForLearner(server, learnerId) {
+  const now = Date.now();
+  const accountId = 'punctuation-release-admin';
+  server.DB.db.prepare(`
+    INSERT INTO adult_accounts (
+      id, email, display_name, platform_role, selected_learner_id,
+      created_at, updated_at, repo_revision, account_type
+    )
+    VALUES (?, ?, ?, 'admin', ?, ?, ?, 0, 'real')
+  `).run(accountId, 'punctuation-release-admin@example.test', 'Punctuation Release Admin', learnerId, now, now);
+  server.DB.db.prepare(`
+    INSERT INTO account_learner_memberships (account_id, learner_id, role, sort_index, created_at, updated_at)
+    VALUES (?, ?, 'owner', 0, ?, ?)
+  `).run(accountId, learnerId, now, now);
+  const session = await createSession(server.env, accountId, 'email', now, { sessionKind: 'real' });
+  return `ks2_session=${session.token}`;
 }
 
 test('Punctuation release smoke keeps demo exposure blocked by default', async () => {
@@ -212,9 +223,12 @@ test('Punctuation release smoke completes a gated demo action through Worker com
     assert.equal(start.response.status, 200, JSON.stringify(start.body));
     assert.equal(start.body.subjectReadModel.phase, 'active-item');
     assert.equal(start.body.subjectReadModel.session.serverAuthority, 'worker');
-    assertPunctuationReadModelRedacted(start.body.subjectReadModel);
+    assertNoForbiddenPunctuationReadModelKeys(start.body.subjectReadModel, 'releaseSmoke.smart.start');
 
-    const submitPayload = learnerAnswerFor(start.body.subjectReadModel.session.currentItem);
+    const submitPayload = {
+      ...punctuationAnswerFor(start.body.subjectReadModel.session.currentItem),
+      ...punctuationExpectedContextFor(start.body.subjectReadModel.session),
+    };
     const submit = await postPunctuationCommand(server, {
       cookie: demo.cookie,
       learnerId: demo.learnerId,
@@ -226,7 +240,7 @@ test('Punctuation release smoke completes a gated demo action through Worker com
     assert.equal(submit.response.status, 200, JSON.stringify(submit.body));
     assert.equal(submit.body.subjectReadModel.phase, 'feedback');
     assert.equal(submit.body.subjectReadModel.feedback.kind, 'success');
-    assertPunctuationReadModelRedacted(submit.body.subjectReadModel);
+    assertNoForbiddenPunctuationReadModelKeys(submit.body.subjectReadModel, 'releaseSmoke.smart.feedback');
     assert.equal(submit.body.domainEvents.some((event) => (
       event.type === 'punctuation.item-attempted' && event.correct === true
     )), true);
@@ -243,7 +257,7 @@ test('Punctuation release smoke completes a gated demo action through Worker com
     assert.equal(done.body.subjectReadModel.summary.total, 1);
     assert.equal(done.body.subjectReadModel.summary.correct, 1);
     assert.equal(done.body.subjectReadModel.summary.accuracy, 100);
-    assertPunctuationReadModelRedacted(done.body.subjectReadModel);
+    assertNoForbiddenPunctuationReadModelKeys(done.body.subjectReadModel, 'releaseSmoke.smart.summary');
 
     assert.equal(server.DB.db.prepare(`
       SELECT COUNT(*) AS count
@@ -294,6 +308,82 @@ test('Punctuation release smoke completes a gated demo action through Worker com
       ...demo,
       requestId: staleRequestId,
     }), beforeStaleCounts);
+
+    const gpsStart = await postPunctuationCommand(server, {
+      cookie: demo.cookie,
+      learnerId: demo.learnerId,
+      revision: done.body.mutation.appliedRevision,
+      command: 'start-session',
+      requestId: 'punctuation-release-smoke-gps-start',
+      payload: { mode: 'gps', roundLength: '1' },
+    });
+    assert.equal(gpsStart.response.status, 200, JSON.stringify(gpsStart.body));
+    assert.equal(gpsStart.body.subjectReadModel.phase, 'active-item');
+    assert.equal(gpsStart.body.subjectReadModel.session.mode, 'gps');
+    assert.equal(gpsStart.body.subjectReadModel.session.gps.delayedFeedback, true);
+    assert.equal(gpsStart.body.subjectReadModel.feedback, null);
+    assertNoForbiddenPunctuationReadModelKeys(gpsStart.body.subjectReadModel, 'releaseSmoke.gps.start');
+
+    const gpsSubmit = await postPunctuationCommand(server, {
+      cookie: demo.cookie,
+      learnerId: demo.learnerId,
+      revision: gpsStart.body.mutation.appliedRevision,
+      command: 'submit-answer',
+      requestId: 'punctuation-release-smoke-gps-submit',
+      payload: {
+        ...punctuationAnswerFor(gpsStart.body.subjectReadModel.session.currentItem),
+        ...punctuationExpectedContextFor(gpsStart.body.subjectReadModel.session),
+      },
+    });
+    assert.equal(gpsSubmit.response.status, 200, JSON.stringify(gpsSubmit.body));
+    assert.equal(gpsSubmit.body.subjectReadModel.phase, 'summary');
+    assert.equal(gpsSubmit.body.subjectReadModel.summary.total, 1);
+    assert.equal(gpsSubmit.body.subjectReadModel.summary.gps.delayedFeedback, true);
+    assert.equal(gpsSubmit.body.subjectReadModel.summary.gps.reviewItems.length, 1);
+    assertNoForbiddenPunctuationReadModelKeys(gpsSubmit.body.subjectReadModel, 'releaseSmoke.gps.summary');
+
+    const parentHub = await server.fetchRaw(`https://repo.test/api/hubs/parent?learnerId=${demo.learnerId}`, {
+      headers: { cookie: demo.cookie },
+    });
+    const parentBody = await parentHub.json();
+    assert.equal(parentHub.status, 200, JSON.stringify(parentBody));
+    assert.equal(parentBody.parentHub.punctuationEvidence.hasEvidence, true);
+    assert.ok(parentBody.parentHub.punctuationEvidence.overview.attempts >= 2);
+    assert.equal(
+      parentBody.parentHub.progressSnapshots.some((snapshot) => snapshot.subjectId === 'punctuation'),
+      true,
+    );
+    assertNoForbiddenPunctuationAdultEvidenceKeys(parentBody.parentHub.punctuationEvidence, 'releaseSmoke.parentHub.punctuationEvidence');
+    assertNoForbiddenPunctuationAdultEvidenceKeys(parentBody.parentHub.progressSnapshots, 'releaseSmoke.parentHub.progressSnapshots');
+
+    const adminCookie = await adminCookieForLearner(server, demo.learnerId);
+    const adminHub = await server.fetchRaw(`https://repo.test/api/hubs/admin?learnerId=${demo.learnerId}&auditLimit=5`, {
+      headers: { cookie: adminCookie },
+    });
+    const adminBody = await adminHub.json();
+    assert.equal(adminHub.status, 200, JSON.stringify(adminBody));
+    const selectedDiagnostics = adminBody.adminHub.learnerSupport.selectedDiagnostics;
+    assert.equal(selectedDiagnostics.learnerId, demo.learnerId);
+    assert.equal(selectedDiagnostics.punctuationEvidence.hasEvidence, true);
+    assertNoForbiddenPunctuationAdultEvidenceKeys(selectedDiagnostics.punctuationEvidence, 'releaseSmoke.adminHub.selectedDiagnostics.punctuationEvidence');
+    assertNoForbiddenPunctuationAdultEvidenceKeys(adminBody.adminHub.learnerSupport.punctuationReleaseDiagnostics, 'releaseSmoke.adminHub.punctuationReleaseDiagnostics');
+
+    const spelling = await postSpellingCommand(server, {
+      cookie: demo.cookie,
+      learnerId: demo.learnerId,
+      revision: gpsSubmit.body.mutation.appliedRevision,
+      command: 'start-session',
+      requestId: 'punctuation-release-smoke-spelling-start',
+      payload: { mode: 'single', slug: 'early', length: 1 },
+    });
+    assert.equal(spelling.response.status, 200, JSON.stringify(spelling.body));
+    assert.equal(spelling.body.subjectReadModel.phase, 'session');
+    assert.equal(spelling.body.subjectReadModel.session.serverAuthority, 'worker');
+    assert.equal(spelling.body.subjectReadModel.session.progress.total, 1);
+    assert.equal(spelling.body.subjectReadModel.session.currentCard.word, undefined);
+    assert.equal(spelling.body.subjectReadModel.session.currentCard.prompt.sentence, undefined);
+    assert.ok(spelling.body.subjectReadModel.session.currentCard.prompt.cloze);
+    assert.ok(spelling.body.subjectReadModel.audio.promptToken);
   } finally {
     server.close();
   }


### PR DESCRIPTION
## Summary
- extend the Punctuation production smoke to verify the production-visible item contract before answering, then cover Smart review, GPS delayed review, Parent Hub evidence redaction, and the reference English Spelling startup path
- reuse the production smoke redaction/answer helpers in local release smoke, add Admin Hub Punctuation evidence redaction, and add bounded mixed-mode scheduler coverage
- update the production bundle audit, browser migration smoke path, docs, and live checklist for the final legacy-parity release gate

## Verification
- node --test tests/punctuation-release-smoke.test.js tests/punctuation-performance.test.js tests/bundle-audit.test.js tests/browser-react-migration-smoke.test.js
- npm test
- npm run check
- git diff --check

## Notes
- KS2_BROWSER_SMOKE=1 node --test tests/browser-react-migration-smoke.test.js was attempted twice, but gstack browse timed out while starting its own server before reaching the app flow.