### PR TITLE
test(capacity): add classroom load certification driver

### DIFF
--- a/docs/operations/capacity.md
+++ b/docs/operations/capacity.md
@@ -1,0 +1,96 @@
+# KS2 Mastery Capacity Operations
+
+This runbook records how capacity is certified for `/api/bootstrap`, subject commands, D1-backed read models, and client recovery paths. Capacity claims must be based on dated measurements from this repository, not planning estimates.
+
+## Current Certification Status
+
+| Target | Status | Evidence Required Before Claiming Support |
+| --- | --- | --- |
+| Family demo | Ready for bounded-bootstrap smoke checks | `npm run smoke:production:bootstrap` passes with a logged-in or demo session and no redaction failures. |
+| Small pilot | Provisional | High-history bootstrap fixture passes, production bootstrap probe stays below the configured byte/count caps, and no `exceededCpu` or D1 overload appears during a small load run. |
+| 30-learner classroom beta | Not certified | `npm run capacity:classroom -- --production --confirm-production-load ...` passes for 30 active learners, including cold-bootstrap burst and human-paced Grammar command rounds. |
+| 60-learner stretch | Not certified | Same evidence as classroom beta, with acceptable P95 wall time and zero 5xx across repeated runs. |
+| 100+ school-ready target | Not certified | Requires repeated 100+ learner runs, D1 row metrics, operational tail evidence, and a rollback/degrade drill. |
+
+## Standard Commands
+
+Local dry-run, no network:
+
+```sh
+npm run capacity:classroom -- --dry-run --learners 30 --bootstrap-burst 20 --rounds 1
+```
+
+Local fixture against a dev Worker using isolated demo sessions:
+
+```sh
+npm run capacity:classroom -- --local-fixture --origin http://localhost:8787 --demo-sessions --learners 10 --bootstrap-burst 10 --rounds 1
+```
+
+Production or preview run, fail-closed unless confirmation and auth are explicit:
+
+```sh
+npm run capacity:classroom -- --production --origin https://ks2.eugnel.uk --confirm-production-load --demo-sessions --learners 10 --bootstrap-burst 10 --rounds 1
+```
+
+Production bootstrap probe for a logged-in session:
+
+```sh
+npm run smoke:production:bootstrap -- --url https://ks2.eugnel.uk --cookie "ks2_session=..." --max-bytes 600000 --max-sessions 12 --max-events 100
+```
+
+Use package scripts for Cloudflare operations. Normal deploy verification remains:
+
+```sh
+npm test
+npm run check
+npm run deploy
+```
+
+## Evidence To Record
+
+For each capacity run, record:
+
+- Date, commit SHA, environment, and whether the run used demo or real authenticated sessions.
+- Virtual learners, bootstrap burst size, command rounds, and pacing.
+- Status distribution, endpoint/status grouping, P50/P95 wall time, max response bytes, and total requests.
+- Any `exceededCpu`, `/api/bootstrap` 503, D1 overloaded, D1 daily-limit, auth failure, stale conflict, or retry amplification signal.
+- Whether learner progress was preserved and whether the run left pending or blocked writes.
+
+## Operational Thresholds
+
+Treat any of these as release blockers until investigated:
+
+- Any Worker Error 1102 or `exceededCpu` signal.
+- Any `/api/bootstrap` 503 during the high-history probe or classroom load run.
+- Any D1 overloaded or D1 daily-limit response.
+- P95 bootstrap wall time above 1,000 ms in a synthetic run.
+- P95 subject-command wall time above 750 ms in a human-paced synthetic run.
+- Bootstrap payload above the configured byte cap or missing `bootstrapCapacity` metadata.
+- Any redaction failure exposing private spelling prompts, raw answers, or server-only runtime fields.
+
+## Degrade And Rollback Guidance
+
+If `/api/bootstrap` starts returning CPU or 503 failures:
+
+1. Confirm whether the failure is deterministic by running `npm run smoke:production:bootstrap` against the affected account/session.
+2. Check Worker tail output with `npm run ops:tail` and group failures by endpoint and status.
+3. If bounded bootstrap metadata is absent, stop deployment and roll back to the last commit with passing high-history bootstrap evidence.
+4. If bounded metadata is present but D1 is overloaded, reduce load, avoid classroom launch claims, and investigate query duration/row counts before retrying.
+5. Keep learner-facing writes on the subject command boundary; do not re-enable broad browser-owned runtime writes as a workaround.
+
+If subject commands show high latency or 5xx:
+
+1. Separate stale revision conflicts from server failures.
+2. Check whether retries are preserving request ids and expected revisions.
+3. Verify command projection is using read models or bounded recent windows rather than full `event_log` scans.
+4. Roll back the command-path change if progress preservation or idempotency is at risk.
+
+## Launch Language
+
+Use evidence-tied language:
+
+- "Measured on commit `<sha>` with `<n>` virtual learners and `<m>` cold bootstraps."
+- "No 5xx, no `exceededCpu`, no D1 overload, P95 bootstrap `<x>` ms, P95 command `<y>` ms."
+- "Not certified for a full-class simultaneous reload" when those measurements are missing.
+
+Do not claim classroom or school readiness from Free-tier limits alone.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "assets:monster-visual-manifest": "node ./scripts/generate-monster-visual-manifest.mjs",
     "check": "node ./scripts/wrangler-oauth.mjs deploy --dry-run",
     "check:oauth": "npm run check",
+    "capacity:classroom": "node ./scripts/classroom-load-test.mjs",
     "content:seed": "node scripts/seed-spelling-content-from-legacy.mjs",
     "content:enrich": "node scripts/enrich-spelling-vocabulary.mjs",
     "content:validate": "node scripts/validate-spelling-content.mjs",

--- a/scripts/classroom-load-test.mjs
+++ b/scripts/classroom-load-test.mjs
@@ -1,0 +1,684 @@
+#!/usr/bin/env node
+
+import { Buffer } from 'node:buffer';
+import { performance } from 'node:perf_hooks';
+import { pathToFileURL } from 'node:url';
+
+import { correctResponseFor } from './grammar-production-smoke.mjs';
+
+const DEFAULT_PRODUCTION_ORIGIN = 'https://ks2.eugnel.uk';
+const DEFAULT_TIMEOUT_MS = 15_000;
+const GRAMMAR_LOAD_ITEM = Object.freeze({
+  templateId: 'fronted_adverbial_choose',
+  seed: 1,
+});
+let requestSequence = 0;
+
+function readOptionValue(argv, index, optionName) {
+  const value = argv[index + 1];
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${optionName} requires a value.`);
+  }
+  return value;
+}
+
+function nonNegativeInteger(value, optionName) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${optionName} must be a non-negative integer.`);
+  }
+  return parsed;
+}
+
+function positiveInteger(value, optionName) {
+  const parsed = nonNegativeInteger(value, optionName);
+  if (parsed <= 0) throw new Error(`${optionName} must be greater than zero.`);
+  return parsed;
+}
+
+function normaliseOrigin(value) {
+  const url = new URL(/^https?:\/\//i.test(value) ? value : `https://${value}`);
+  return url.origin;
+}
+
+function isLocalOrigin(origin) {
+  const host = new URL(origin).hostname;
+  return host === 'localhost' || host === '127.0.0.1' || host === '::1' || host.endsWith('.test');
+}
+
+function optionHeaders(headers = []) {
+  const output = {};
+  for (const header of headers) {
+    const separator = header.indexOf(':');
+    if (separator <= 0) throw new Error(`Invalid header "${header}". Use "name: value".`);
+    const name = header.slice(0, separator).trim();
+    const value = header.slice(separator + 1).trim();
+    if (!name) throw new Error(`Invalid header "${header}". Header name is required.`);
+    output[name] = value;
+  }
+  return output;
+}
+
+function hasAuthHeader(headers = []) {
+  for (const header of headers) {
+    const separator = header.indexOf(':');
+    const name = separator > 0 ? header.slice(0, separator).trim().toLowerCase() : '';
+    const value = separator > 0 ? header.slice(separator + 1).trim() : '';
+    if ((name === 'authorization' || name === 'cookie') && value) return true;
+  }
+  return false;
+}
+
+function hasExplicitAuthConfig(options = {}) {
+  return Boolean(
+    String(options.cookie || '').trim()
+    || String(options.bearer || '').trim()
+    || options.demoSessions
+    || hasAuthHeader(options.headers),
+  );
+}
+
+function nonAuthOptionHeaders(headers = []) {
+  const output = optionHeaders(headers);
+  for (const key of Object.keys(output)) {
+    if (['authorization', 'cookie'].includes(key.toLowerCase())) {
+      delete output[key];
+    }
+  }
+  return output;
+}
+
+function authHeaders(options, cookie = '') {
+  return {
+    accept: 'application/json',
+    ...optionHeaders(options.headers),
+    ...(options.bearer ? { authorization: `Bearer ${options.bearer}` } : {}),
+    ...(cookie || options.cookie ? { cookie: cookie || options.cookie } : {}),
+  };
+}
+
+function contextAuthHeaders(options, context) {
+  const cookie = context.cookie || '';
+  if (options.demoSessions) {
+    return {
+      accept: 'application/json',
+      ...nonAuthOptionHeaders(options.headers),
+      ...(cookie ? { cookie } : {}),
+    };
+  }
+  return authHeaders(options, cookie);
+}
+
+function safeFailureMessage({ payload, networkError, parseError }) {
+  if (payload?.message) return payload.message;
+  if (networkError) return networkError.message || 'Network request failed.';
+  if (parseError) return 'Response body was not valid JSON.';
+  return '';
+}
+
+function getSetCookies(response) {
+  const values = response.headers.getSetCookie?.();
+  if (Array.isArray(values) && values.length) return values;
+  return String(response.headers.get('set-cookie') || '')
+    .split(/,\s*(?=ks2_)/)
+    .filter(Boolean);
+}
+
+function sessionCookieFrom(response) {
+  return getSetCookies(response)
+    .map((cookie) => String(cookie || '').split(';')[0])
+    .find((cookie) => cookie.startsWith('ks2_session=')) || '';
+}
+
+function timeoutSignal(timeoutMs) {
+  if (typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function') {
+    return AbortSignal.timeout(timeoutMs);
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  timer.unref?.();
+  return controller.signal;
+}
+
+async function wait(ms) {
+  if (!ms) return;
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function timedJsonRequest({
+  origin,
+  path,
+  method = 'GET',
+  headers = {},
+  body = null,
+  scenario,
+  virtualLearner = null,
+  timeoutMs,
+}) {
+  const url = new URL(path, origin);
+  const started = performance.now();
+  let response;
+  let text = '';
+  let payload = null;
+  let parseError = null;
+  let networkError = null;
+
+  try {
+    response = await fetch(url, {
+      method,
+      headers,
+      ...(body == null ? {} : { body: JSON.stringify(body) }),
+      signal: timeoutSignal(timeoutMs),
+    });
+    text = await response.text();
+    try {
+      payload = text ? JSON.parse(text) : {};
+    } catch (error) {
+      parseError = error;
+    }
+  } catch (error) {
+    networkError = error;
+  }
+
+  const wallMs = Math.round((performance.now() - started) * 10) / 10;
+  const status = response?.status || 0;
+  const bytes = Buffer.byteLength(text || '', 'utf8');
+  const failureText = !response?.ok || parseError || networkError
+    ? String(text || payload?.message || networkError?.message || parseError?.message || '').slice(0, 2_000)
+    : '';
+  const ok = Boolean(response?.ok) && payload?.ok !== false && !parseError && !networkError;
+
+  const measurement = {
+    scenario,
+    virtualLearner,
+    method,
+    endpoint: url.pathname,
+    status,
+    ok,
+    wallMs,
+    responseBytes: bytes,
+    code: payload?.code || payload?.error || null,
+    message: safeFailureMessage({ payload, networkError, parseError }),
+    requestId: body?.requestId || null,
+  };
+  Object.defineProperty(measurement, 'payload', {
+    value: payload,
+    enumerable: false,
+  });
+  const cookie = response ? sessionCookieFrom(response) : '';
+  if (cookie) {
+    Object.defineProperty(measurement, 'cookie', {
+      value: cookie,
+      enumerable: false,
+    });
+  }
+  if (failureText) {
+    Object.defineProperty(measurement, 'failureText', {
+      value: failureText,
+      enumerable: false,
+    });
+  }
+  return measurement;
+}
+
+export function parseClassroomLoadArgs(argv = process.argv.slice(2)) {
+  const options = {
+    mode: 'dry-run',
+    origin: '',
+    learners: 3,
+    bootstrapBurst: 6,
+    rounds: 1,
+    pacingMs: 0,
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+    cookie: '',
+    bearer: '',
+    headers: [],
+    demoSessions: false,
+    confirmProductionLoad: false,
+    includeMeasurements: true,
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+    } else if (arg === '--dry-run') {
+      options.mode = 'dry-run';
+    } else if (arg === '--local-fixture') {
+      options.mode = 'local-fixture';
+    } else if (arg === '--production') {
+      options.mode = 'production';
+    } else if (arg === '--origin' || arg === '--url') {
+      options.origin = normaliseOrigin(readOptionValue(argv, index, arg));
+      index += 1;
+    } else if (arg === '--learners') {
+      options.learners = positiveInteger(readOptionValue(argv, index, arg), arg);
+      index += 1;
+    } else if (arg === '--bootstrap-burst') {
+      options.bootstrapBurst = positiveInteger(readOptionValue(argv, index, arg), arg);
+      index += 1;
+    } else if (arg === '--rounds') {
+      options.rounds = positiveInteger(readOptionValue(argv, index, arg), arg);
+      index += 1;
+    } else if (arg === '--pacing-ms') {
+      options.pacingMs = nonNegativeInteger(readOptionValue(argv, index, arg), arg);
+      index += 1;
+    } else if (arg === '--timeout-ms') {
+      options.timeoutMs = positiveInteger(readOptionValue(argv, index, arg), arg);
+      index += 1;
+    } else if (arg === '--cookie') {
+      options.cookie = readOptionValue(argv, index, arg);
+      index += 1;
+    } else if (arg === '--bearer') {
+      options.bearer = readOptionValue(argv, index, arg);
+      index += 1;
+    } else if (arg === '--header') {
+      options.headers.push(readOptionValue(argv, index, arg));
+      index += 1;
+    } else if (arg === '--demo-sessions') {
+      options.demoSessions = true;
+    } else if (arg === '--confirm-production-load') {
+      options.confirmProductionLoad = true;
+    } else if (arg === '--summary-only') {
+      options.includeMeasurements = false;
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+export function buildClassroomLoadPlan(options = {}) {
+  const mode = options.mode || 'dry-run';
+  const origin = options.origin || (mode === 'production' ? DEFAULT_PRODUCTION_ORIGIN : '');
+  const learners = positiveInteger(options.learners ?? 3, '--learners');
+  const bootstrapBurst = positiveInteger(options.bootstrapBurst ?? Math.max(learners, 1), '--bootstrap-burst');
+  const rounds = positiveInteger(options.rounds ?? 1, '--rounds');
+  const pacingMs = nonNegativeInteger(options.pacingMs ?? 0, '--pacing-ms');
+  const virtualLearners = Array.from({ length: learners }, (_, index) => ({
+    index,
+    label: `learner-${String(index + 1).padStart(2, '0')}`,
+  }));
+
+  return {
+    mode,
+    origin: origin || null,
+    virtualLearners,
+    scenarios: [
+      {
+        name: 'cold-bootstrap-burst',
+        requests: bootstrapBurst,
+        concurrency: Math.min(bootstrapBurst, learners),
+        endpoint: 'GET /api/bootstrap',
+      },
+      {
+        name: 'human-paced-grammar-round',
+        learners,
+        rounds,
+        pacingMs,
+        commandsPerRound: 3,
+        endpoint: 'POST /api/subjects/grammar/command',
+      },
+    ],
+    expectedRequests: learners + bootstrapBurst + (learners * rounds * 3) + (options.demoSessions ? learners : 0),
+    safety: {
+      productionRequiresConfirmation: true,
+      productionRequiresAuth: true,
+      localFixtureRequiresDemoSessions: true,
+    },
+  };
+}
+
+export function validateClassroomLoadOptions(options = {}) {
+  if (options.help || options.mode === 'dry-run') return;
+  if (!options.origin) {
+    throw new Error(`${options.mode} load requires --origin.`);
+  }
+  if (options.mode === 'local-fixture') {
+    if (!isLocalOrigin(options.origin)) {
+      throw new Error('local fixture load must use a localhost, loopback, or .test origin.');
+    }
+    if (!options.demoSessions) {
+      throw new Error('local fixture load requires --demo-sessions so each virtual learner gets an isolated session.');
+    }
+    return;
+  }
+  if (options.mode === 'production') {
+    const hasAuth = hasExplicitAuthConfig(options);
+    if (!options.confirmProductionLoad || !hasAuth) {
+      throw new Error('production load requires --confirm-production-load and explicit auth configuration (--cookie, --bearer, --header, or --demo-sessions).');
+    }
+  }
+}
+
+function groupKey(entry) {
+  return `${entry.method} ${entry.endpoint} ${entry.status || 'network'}`;
+}
+
+function percentile(values, percentileValue) {
+  if (!values.length) return 0;
+  const sorted = [...values].sort((left, right) => left - right);
+  const index = Math.min(sorted.length - 1, Math.ceil((percentileValue / 100) * sorted.length) - 1);
+  return sorted[index];
+}
+
+function signalFor(entry) {
+  const text = `${entry.code || ''} ${entry.message || ''} ${entry.failureText || ''}`.toLowerCase();
+  if (entry.status === 1102 || /exceeded[_\s-]?cpu|cpu limit|worker cpu/.test(text)) return 'exceededCpu';
+  if (/\berror\s*1102\b|\b1102\b.*worker/.test(text)) return 'exceededCpu';
+  if (/d1.*overloaded|overloaded/.test(text)) return 'd1Overloaded';
+  if (/daily.*limit|rows.*limit|quota/.test(text)) return 'd1DailyLimit';
+  if (entry.status === 401 || entry.status === 403 || /unauth|forbidden/.test(text)) return 'authFailure';
+  if (entry.status >= 500) return 'server5xx';
+  if (entry.status === 429) return 'rateLimited';
+  if (!entry.status) return 'networkFailure';
+  return null;
+}
+
+export function summariseCapacityResults(measurements = [], plan = {}) {
+  const statusCounts = {};
+  const endpointStatus = {};
+  const signals = {};
+  const endpointMetrics = {};
+  const failures = [];
+
+  for (const entry of measurements) {
+    const status = String(entry.status || 'network');
+    statusCounts[status] = (statusCounts[status] || 0) + 1;
+    const key = groupKey(entry);
+    endpointStatus[key] = (endpointStatus[key] || 0) + 1;
+
+    const endpointKey = `${entry.method} ${entry.endpoint}`;
+    const metrics = endpointMetrics[endpointKey] || {
+      count: 0,
+      wallMs: [],
+      responseBytes: [],
+      maxResponseBytes: 0,
+    };
+    metrics.count += 1;
+    metrics.wallMs.push(Number(entry.wallMs) || 0);
+    metrics.responseBytes.push(Number(entry.responseBytes) || 0);
+    metrics.maxResponseBytes = Math.max(metrics.maxResponseBytes, Number(entry.responseBytes) || 0);
+    endpointMetrics[endpointKey] = metrics;
+
+    const signal = signalFor(entry);
+    if (signal) signals[signal] = (signals[signal] || 0) + 1;
+    if (!entry.ok || signal) {
+      failures.push({
+        scenario: entry.scenario,
+        endpoint: endpointKey,
+        status: entry.status,
+        code: entry.code,
+        message: entry.message,
+        signal,
+      });
+    }
+  }
+
+  const endpoints = Object.fromEntries(Object.entries(endpointMetrics).map(([key, metrics]) => [key, {
+    count: metrics.count,
+    p50WallMs: percentile(metrics.wallMs, 50),
+    p95WallMs: percentile(metrics.wallMs, 95),
+    maxResponseBytes: metrics.maxResponseBytes,
+  }]));
+
+  return {
+    ok: failures.length === 0,
+    totalRequests: measurements.length,
+    expectedRequests: plan.expectedRequests || 0,
+    statusCounts,
+    endpointStatus,
+    endpoints,
+    signals,
+    failures,
+  };
+}
+
+async function createDemoContextWithResponse(origin, options, virtualLearner) {
+  const measurement = await timedJsonRequest({
+    origin,
+    path: '/api/demo/session',
+    method: 'POST',
+    headers: {
+      accept: 'application/json',
+      ...nonAuthOptionHeaders(options.headers),
+      'content-type': 'application/json',
+      origin,
+    },
+    scenario: 'demo-session-setup',
+    virtualLearner: virtualLearner.label,
+    timeoutMs: options.timeoutMs,
+  });
+  if (!measurement.ok || !measurement.cookie || !measurement.payload?.session?.learnerId) {
+    throw new Error(`Demo session setup failed for ${virtualLearner.label}; refusing to reuse global auth for an isolated load context.`);
+  }
+  return {
+    ...virtualLearner,
+    cookie: measurement.cookie,
+    accountId: measurement.payload?.session?.accountId || null,
+    learnerId: measurement.payload?.session?.learnerId || null,
+    revision: 0,
+    setupMeasurement: measurement,
+  };
+}
+
+async function loadBootstrapForContext(origin, options, context, scenario) {
+  const measurement = await timedJsonRequest({
+    origin,
+    path: '/api/bootstrap',
+    method: 'GET',
+    headers: contextAuthHeaders(options, context),
+    scenario,
+    virtualLearner: context.label,
+    timeoutMs: options.timeoutMs,
+  });
+  const learnerId = measurement.payload?.learners?.selectedId || context.learnerId;
+  const revision = Number(measurement.payload?.learners?.byId?.[learnerId]?.stateRevision);
+  return {
+    measurement,
+    context: {
+      ...context,
+      learnerId,
+      revision: Number.isFinite(revision) ? revision : context.revision,
+    },
+  };
+}
+
+function commandRequestId(context, round, command) {
+  requestSequence += 1;
+  const learner = String(context.learnerId || context.label).replace(/[^a-zA-Z0-9_-]/g, '-');
+  return `load-${learner}-r${round}-${command}-${Date.now()}-${requestSequence}`;
+}
+
+async function sendGrammarCommand(origin, options, context, round, command, payload = {}) {
+  const requestId = commandRequestId(context, round, command);
+  const measurement = await timedJsonRequest({
+    origin,
+    path: '/api/subjects/grammar/command',
+    method: 'POST',
+    headers: {
+      ...contextAuthHeaders(options, context),
+      'content-type': 'application/json',
+      origin,
+    },
+    body: {
+      subjectId: 'grammar',
+      learnerId: context.learnerId,
+      command,
+      requestId,
+      correlationId: requestId,
+      expectedLearnerRevision: context.revision,
+      payload,
+    },
+    scenario: 'human-paced-grammar-round',
+    virtualLearner: context.label,
+    timeoutMs: options.timeoutMs,
+  });
+  const nextRevision = Number(measurement.payload?.mutation?.appliedRevision);
+  return {
+    measurement,
+    context: {
+      ...context,
+      revision: Number.isFinite(nextRevision) ? nextRevision : context.revision,
+    },
+  };
+}
+
+async function runGrammarRound(origin, options, context, round) {
+  const measurements = [];
+  let current = context;
+
+  let step = await sendGrammarCommand(origin, options, current, round, 'start-session', {
+    mode: 'smart',
+    roundLength: 1,
+    templateId: GRAMMAR_LOAD_ITEM.templateId,
+    seed: GRAMMAR_LOAD_ITEM.seed,
+  });
+  measurements.push(step.measurement);
+  current = step.context;
+
+  const currentItem = step.measurement.payload?.subjectReadModel?.session?.currentItem;
+  const response = currentItem ? correctResponseFor(currentItem) : { answer: '' };
+  step = await sendGrammarCommand(origin, options, current, round, 'submit-answer', { response });
+  measurements.push(step.measurement);
+  current = step.context;
+
+  step = await sendGrammarCommand(origin, options, current, round, 'continue-session');
+  measurements.push(step.measurement);
+  current = step.context;
+
+  return { context: current, measurements };
+}
+
+async function prepareContexts(origin, options, plan) {
+  const setupMeasurements = [];
+  let contexts = plan.virtualLearners.map((entry) => ({
+    ...entry,
+    cookie: options.cookie,
+    accountId: null,
+    learnerId: null,
+    revision: 0,
+  }));
+
+  if (options.demoSessions) {
+    contexts = [];
+    for (const virtualLearner of plan.virtualLearners) {
+      const context = await createDemoContextWithResponse(origin, options, virtualLearner);
+      setupMeasurements.push(context.setupMeasurement);
+      contexts.push(context);
+    }
+  }
+
+  const bootstrapped = [];
+  for (const context of contexts) {
+    const { measurement, context: nextContext } = await loadBootstrapForContext(origin, options, context, 'initial-bootstrap');
+    setupMeasurements.push(measurement);
+    bootstrapped.push(nextContext);
+  }
+
+  return { contexts: bootstrapped, measurements: setupMeasurements };
+}
+
+async function runColdBootstrapBurst(origin, options, contexts, plan) {
+  const scenario = plan.scenarios.find((entry) => entry.name === 'cold-bootstrap-burst');
+  const requests = Array.from({ length: scenario.requests }, (_, index) => {
+    const context = contexts[index % contexts.length];
+    return loadBootstrapForContext(origin, options, context, scenario.name).then((result) => result.measurement);
+  });
+  return Promise.all(requests);
+}
+
+async function runHumanPacedRounds(origin, options, contexts, plan) {
+  const measurements = [];
+  for (let round = 1; round <= options.rounds; round += 1) {
+    for (let index = 0; index < contexts.length; index += 1) {
+      const result = await runGrammarRound(origin, options, contexts[index], round);
+      contexts[index] = result.context;
+      measurements.push(...result.measurements);
+      await wait(options.pacingMs);
+    }
+  }
+  return measurements;
+}
+
+export async function runClassroomLoadTest(argv = process.argv.slice(2)) {
+  const options = parseClassroomLoadArgs(argv);
+  if (options.help) {
+    return { ok: true, help: true, usage: usage() };
+  }
+  validateClassroomLoadOptions(options);
+  const plan = buildClassroomLoadPlan(options);
+  if (options.mode === 'dry-run') {
+    return {
+      ok: true,
+      dryRun: true,
+      plan,
+      summary: summariseCapacityResults([], plan),
+    };
+  }
+
+  const origin = options.origin;
+  const startedAt = new Date().toISOString();
+  const measurements = [];
+  const prepared = await prepareContexts(origin, options, plan);
+  measurements.push(...prepared.measurements);
+  measurements.push(...await runColdBootstrapBurst(origin, options, prepared.contexts, plan));
+  measurements.push(...await runHumanPacedRounds(origin, options, prepared.contexts, plan));
+  const summary = summariseCapacityResults(measurements, {
+    ...plan,
+  });
+
+  return {
+    ok: summary.ok,
+    dryRun: false,
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    plan,
+    summary,
+    ...(options.includeMeasurements ? { measurements } : {}),
+  };
+}
+
+export function usage() {
+  return [
+    'Usage: node ./scripts/classroom-load-test.mjs [options]',
+    '',
+    'Modes:',
+    '  --dry-run                  Print the planned capacity run without network requests (default)',
+    '  --local-fixture            Run against a local/loopback origin using demo sessions',
+    '  --production               Run against a production or preview origin; requires explicit confirmation and auth',
+    '',
+    'Options:',
+    '  --origin <url>             Target origin for local-fixture or production runs',
+    '  --learners <number>        Virtual learner count, default 3',
+    '  --bootstrap-burst <number> Concurrent cold bootstrap requests, default 6',
+    '  --rounds <number>          Human-paced Grammar rounds per learner, default 1',
+    '  --pacing-ms <number>       Delay between learner command groups, default 0',
+    '  --timeout-ms <number>      Per-request timeout, default 15000',
+    '  --cookie <cookie>          Cookie header for an existing authenticated run',
+    '  --bearer <token>           Authorization bearer token',
+    '  --header "name: value"     Extra request header, repeatable',
+    '  --demo-sessions            Create one isolated demo session per virtual learner',
+    '  --confirm-production-load  Required before --production sends requests',
+    '  --summary-only             Omit per-request measurements from JSON output',
+  ].join('\n');
+}
+
+if (process.argv[1] && !process.env.NODE_TEST_CONTEXT && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runClassroomLoadTest().then((report) => {
+    if (report.help) {
+      console.log(report.usage);
+    } else {
+      console.log(JSON.stringify(report, null, 2));
+    }
+    process.exitCode = report.ok ? 0 : 1;
+  }).catch((error) => {
+    console.error(JSON.stringify({
+      ok: false,
+      error: error.message,
+    }, null, 2));
+    process.exitCode = 2;
+  });
+}

--- a/tests/capacity-scripts.test.js
+++ b/tests/capacity-scripts.test.js
@@ -1,0 +1,420 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  runClassroomLoadTest,
+  summariseCapacityResults,
+} from '../scripts/classroom-load-test.mjs';
+import { createGrammarQuestion } from '../worker/src/subjects/grammar/content.js';
+
+function jsonResponse(payload, init = {}) {
+  const status = Number(init.status) || 200;
+  const headers = Object.fromEntries(
+    Object.entries({
+      'content-type': 'application/json',
+      ...(init.headers || {}),
+    }).map(([key, value]) => [key.toLowerCase(), value]),
+  );
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get(name) {
+        return headers[String(name).toLowerCase()] || null;
+      },
+      getSetCookie() {
+        const value = headers['set-cookie'];
+        if (Array.isArray(value)) return value;
+        return value ? [value] : [];
+      },
+    },
+    async text() {
+      return JSON.stringify(payload);
+    },
+  };
+}
+
+test('classroom load script dry-run reports the planned scenarios without network', async () => {
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    throw new Error('dry-run should not fetch');
+  };
+
+  try {
+    const report = await runClassroomLoadTest([
+      '--dry-run',
+      '--learners', '4',
+      '--bootstrap-burst', '8',
+      '--rounds', '2',
+    ]);
+
+    assert.equal(report.ok, true);
+    assert.equal(report.dryRun, true);
+    assert.equal(report.plan.virtualLearners.length, 4);
+    assert.equal(report.plan.scenarios[0].name, 'cold-bootstrap-burst');
+    assert.equal(report.plan.scenarios[0].requests, 8);
+    assert.equal(report.plan.scenarios[1].name, 'human-paced-grammar-round');
+    assert.equal(report.plan.scenarios[1].rounds, 2);
+    assert.equal(report.plan.expectedRequests, 36);
+    assert.equal(report.summary.totalRequests, 0);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('classroom load local fixture creates isolated learners and request ids', async () => {
+  const previousFetch = globalThis.fetch;
+  const calls = [];
+  const commandBodies = [];
+  const grammarQuestion = createGrammarQuestion({
+    templateId: 'fronted_adverbial_choose',
+    seed: 1,
+  });
+
+  globalThis.fetch = async (url, init = {}) => {
+    const parsed = new URL(String(url));
+    calls.push({ url: String(url), init });
+
+    if (parsed.pathname === '/api/demo/session') {
+      const index = calls.filter((call) => new URL(call.url).pathname === '/api/demo/session').length;
+      return jsonResponse({
+        ok: true,
+        session: {
+          demo: true,
+          accountId: `account-${index}`,
+          learnerId: `learner-${index}`,
+        },
+      }, {
+        status: 201,
+        headers: {
+          'set-cookie': `ks2_session=demo-${index}; Path=/; HttpOnly`,
+        },
+      });
+    }
+
+    const cookie = String(init.headers?.cookie || '');
+    const learnerIndex = /demo-(\d+)/.exec(cookie)?.[1] || '1';
+    const learnerId = `learner-${learnerIndex}`;
+
+    if (parsed.pathname === '/api/bootstrap') {
+      return jsonResponse({
+        ok: true,
+        learners: {
+          selectedId: learnerId,
+          byId: {
+            [learnerId]: {
+              id: learnerId,
+              name: `Learner ${learnerIndex}`,
+              stateRevision: 0,
+            },
+          },
+          allIds: [learnerId],
+        },
+      });
+    }
+
+    if (parsed.pathname === '/api/subjects/grammar/command') {
+      const body = JSON.parse(init.body);
+      commandBodies.push(body);
+      const appliedRevision = Number(body.expectedLearnerRevision || 0) + 1;
+      const subjectReadModel = body.command === 'start-session'
+        ? {
+            phase: 'session',
+            session: {
+              currentItem: {
+                templateId: 'fronted_adverbial_choose',
+                seed: 1,
+                inputSpec: grammarQuestion.inputSpec,
+              },
+            },
+          }
+        : { phase: body.command === 'submit-answer' ? 'feedback' : 'summary' };
+      return jsonResponse({
+        ok: true,
+        mutation: { appliedRevision },
+        subjectReadModel,
+      });
+    }
+
+    return jsonResponse({ ok: false, code: 'not_found' }, { status: 404 });
+  };
+
+  try {
+    const report = await runClassroomLoadTest([
+      '--local-fixture',
+      '--origin', 'http://localhost:8787',
+      '--demo-sessions',
+      '--bearer', 'real-token',
+      '--header', 'cookie: ks2_session=header-real',
+      '--header', 'x-trace-id: capacity-test',
+      '--learners', '2',
+      '--bootstrap-burst', '2',
+      '--rounds', '1',
+    ]);
+
+    assert.equal(report.ok, true);
+    assert.equal(report.summary.totalRequests, 12);
+    assert.deepEqual(report.summary.statusCounts, { 200: 10, 201: 2 });
+    assert.equal(commandBodies.length, 6);
+    assert.deepEqual(new Set(commandBodies.map((body) => body.learnerId)), new Set(['learner-1', 'learner-2']));
+    assert.equal(new Set(commandBodies.map((body) => body.requestId)).size, commandBodies.length);
+    assert.equal(commandBodies.every((body) => body.requestId.startsWith(`load-${body.learnerId}-`)), true);
+    const demoSessionCalls = calls.filter((call) => new URL(call.url).pathname === '/api/demo/session');
+    const learnerCalls = calls.filter((call) => new URL(call.url).pathname !== '/api/demo/session');
+    assert.equal(demoSessionCalls.length, 2);
+    assert.equal(demoSessionCalls.every((call) => !call.init.headers.authorization), true);
+    assert.equal(demoSessionCalls.every((call) => !call.init.headers.cookie), true);
+    assert.equal(demoSessionCalls.every((call) => call.init.headers['x-trace-id'] === 'capacity-test'), true);
+    assert.equal(learnerCalls.every((call) => !call.init.headers.authorization), true);
+    assert.equal(learnerCalls.every((call) => String(call.init.headers.cookie || '').startsWith('ks2_session=demo-')), true);
+    assert.equal(learnerCalls.every((call) => call.init.headers['x-trace-id'] === 'capacity-test'), true);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('classroom load production mode refuses to run without explicit confirmation and auth', async () => {
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    throw new Error('production guard should run before fetch');
+  };
+
+  try {
+    await assert.rejects(
+      () => runClassroomLoadTest([
+        '--production',
+        '--origin', 'https://ks2.eugnel.uk',
+        '--learners', '1',
+      ]),
+      /production load requires --confirm-production-load and explicit auth configuration/,
+    );
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('classroom load production auth guard does not treat arbitrary headers as auth', async () => {
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    throw new Error('production guard should run before fetch');
+  };
+
+  try {
+    await assert.rejects(
+      () => runClassroomLoadTest([
+        '--production',
+        '--origin', 'https://ks2.eugnel.uk',
+        '--confirm-production-load',
+        '--header', 'x-trace-id: only-trace',
+        '--learners', '1',
+      ]),
+      /production load requires --confirm-production-load and explicit auth configuration/,
+    );
+    await assert.rejects(
+      () => runClassroomLoadTest([
+        '--production',
+        '--origin', 'https://ks2.eugnel.uk',
+        '--confirm-production-load',
+        '--header', 'authorization:',
+        '--learners', '1',
+      ]),
+      /production load requires --confirm-production-load and explicit auth configuration/,
+    );
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('classroom load production auth guard accepts explicit authorization headers', async () => {
+  const previousFetch = globalThis.fetch;
+  const calls = [];
+  const grammarQuestion = createGrammarQuestion({
+    templateId: 'fronted_adverbial_choose',
+    seed: 1,
+  });
+
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url: String(url), init });
+    const parsed = new URL(String(url));
+    if (parsed.pathname === '/api/bootstrap') {
+      return jsonResponse({
+        ok: true,
+        learners: {
+          selectedId: 'learner-real',
+          byId: { 'learner-real': { stateRevision: 0 } },
+          allIds: ['learner-real'],
+        },
+      });
+    }
+    if (parsed.pathname === '/api/subjects/grammar/command') {
+      const body = JSON.parse(init.body);
+      const subjectReadModel = body.command === 'start-session'
+        ? {
+            phase: 'session',
+            session: {
+              currentItem: {
+                templateId: 'fronted_adverbial_choose',
+                seed: 1,
+                inputSpec: grammarQuestion.inputSpec,
+              },
+            },
+          }
+        : { phase: body.command === 'submit-answer' ? 'feedback' : 'summary' };
+      return jsonResponse({
+        ok: true,
+        mutation: { appliedRevision: Number(body.expectedLearnerRevision || 0) + 1 },
+        subjectReadModel,
+      });
+    }
+    return jsonResponse({ ok: false, code: 'not_found' }, { status: 404 });
+  };
+
+  try {
+    const report = await runClassroomLoadTest([
+      '--production',
+      '--origin', 'https://ks2.eugnel.uk',
+      '--confirm-production-load',
+      '--header', 'authorization: Bearer explicit',
+      '--learners', '1',
+      '--bootstrap-burst', '1',
+      '--rounds', '1',
+    ]);
+
+    assert.equal(report.ok, true);
+    assert.equal(report.summary.expectedRequests, 5);
+    assert.equal(report.summary.totalRequests, 5);
+    assert.equal(calls.every((call) => call.init.headers.authorization === 'Bearer explicit'), true);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('classroom load demo sessions fail closed instead of falling back to operator cookies', async () => {
+  const previousFetch = globalThis.fetch;
+  const calls = [];
+
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url: String(url), init });
+    if (new URL(String(url)).pathname === '/api/demo/session') {
+      return jsonResponse({
+        ok: false,
+        code: 'demo_unavailable',
+        message: 'Demo session unavailable.',
+      }, { status: 503 });
+    }
+    return jsonResponse({
+      ok: true,
+      learners: {
+        selectedId: 'real-learner',
+        byId: { 'real-learner': { stateRevision: 0 } },
+        allIds: ['real-learner'],
+      },
+    });
+  };
+
+  try {
+    await assert.rejects(
+      () => runClassroomLoadTest([
+        '--local-fixture',
+        '--origin', 'http://localhost:8787',
+        '--demo-sessions',
+        '--cookie', 'ks2_session=real',
+        '--learners', '1',
+        '--bootstrap-burst', '1',
+        '--rounds', '1',
+      ]),
+      /Demo session setup failed for learner-01; refusing to reuse global auth/,
+    );
+    assert.equal(calls.length, 1);
+    assert.equal(new URL(calls[0].url).pathname, '/api/demo/session');
+    assert.equal(calls[0].init.headers.cookie, undefined);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('classroom load summary groups operational failure signals', () => {
+  const summary = summariseCapacityResults([
+    {
+      scenario: 'cold-bootstrap-burst',
+      method: 'GET',
+      endpoint: '/api/bootstrap',
+      status: 503,
+      ok: false,
+      wallMs: 40,
+      responseBytes: 120,
+      code: 'exceeded_cpu',
+      message: 'Worker CPU limit exceeded during bootstrap.',
+    },
+    {
+      scenario: 'human-paced-grammar-round',
+      method: 'POST',
+      endpoint: '/api/subjects/grammar/command',
+      status: 503,
+      ok: false,
+      wallMs: 55,
+      responseBytes: 80,
+      code: 'd1_overloaded',
+      message: 'D1 overloaded.',
+    },
+    {
+      scenario: 'initial-bootstrap',
+      method: 'GET',
+      endpoint: '/api/bootstrap',
+      status: 401,
+      ok: false,
+      wallMs: 10,
+      responseBytes: 40,
+      code: 'unauthenticated',
+      message: 'Authentication required.',
+    },
+  ], { expectedRequests: 3 });
+
+  assert.equal(summary.ok, false);
+  assert.deepEqual(summary.statusCounts, { 503: 2, 401: 1 });
+  assert.equal(summary.endpointStatus['GET /api/bootstrap 503'], 1);
+  assert.equal(summary.endpointStatus['POST /api/subjects/grammar/command 503'], 1);
+  assert.equal(summary.endpointStatus['GET /api/bootstrap 401'], 1);
+  assert.deepEqual(summary.signals, {
+    exceededCpu: 1,
+    d1Overloaded: 1,
+    authFailure: 1,
+  });
+});
+
+test('classroom load summary detects Worker 1102 from non-json failure text without exposing the body', async () => {
+  const previousFetch = globalThis.fetch;
+
+  globalThis.fetch = async () => ({
+    ok: false,
+    status: 500,
+    headers: {
+      get() { return 'text/html'; },
+      getSetCookie() { return []; },
+    },
+    async text() {
+      return '<html><title>Error 1102</title><body>Worker exceeded CPU time limit.</body></html>';
+    },
+  });
+
+  try {
+    const report = await runClassroomLoadTest([
+      '--production',
+      '--origin', 'https://ks2.eugnel.uk',
+      '--confirm-production-load',
+      '--cookie', 'ks2_session=real',
+      '--learners', '1',
+      '--bootstrap-burst', '1',
+      '--rounds', '1',
+    ]);
+
+    assert.equal(report.ok, false);
+    assert.equal(report.summary.signals.exceededCpu, report.summary.totalRequests);
+    assert.equal(JSON.stringify(report).includes('Worker exceeded CPU time limit'), false);
+    assert.equal(JSON.stringify(report).includes('Error 1102'), false);
+    assert.equal(JSON.stringify(report).includes('Unexpected token'), false);
+    assert.equal(JSON.stringify(report).includes('<html'), false);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});


### PR DESCRIPTION
Summary:
- add a fail-closed classroom load certification CLI for dry-run, local fixture, and explicit production runs
- add capacity script tests covering dry-run planning, isolated demo learners/request ids, production safety guards, and failure grouping
- add capacity operations runbook with evidence requirements, thresholds, and rollback guidance

Verification:
- npm test -- tests/capacity-scripts.test.js tests/worker-bootstrap-capacity.test.js tests/production-smoke-helpers.test.js
- npm run capacity:classroom -- --dry-run --learners 3 --bootstrap-burst 6 --rounds 1 --summary-only
- npm test -- --test-concurrency=1
- npm run check
- git diff --check