### PR TITLE
revert(spelling): restore legacy smart-bucket priority ordering

### DIFF
--- a/legacy/spelling-engine.source.js
+++ b/legacy/spelling-engine.source.js
@@ -236,11 +236,11 @@
     var p = getProgress(profileId, word.slug);
     var today = todayDay();
     if (p.wrong > 0 && p.dueDay <= today) return "urgent";
+    if (p.wrong > 0) return "fragile";
     if (p.attempts > 0 && p.dueDay <= today) return "due";
     if (p.attempts === 0) return "new";
-    if (p.stage >= SECURE_STAGE) return "secure";
-    if (p.wrong > 0) return "fragile";
-    return "growing";
+    if (p.stage < SECURE_STAGE) return "growing";
+    return "secure";
   }
 
   function isTroubleProgress(progress, today) {

--- a/shared/spelling/legacy-engine.js
+++ b/shared/spelling/legacy-engine.js
@@ -268,11 +268,11 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
         var p = getProgressFromStore(profileId, word.slug, progressStore);
         var today = todayDay();
         if (p.wrong > 0 && p.dueDay <= today) return "urgent";
+        if (p.wrong > 0) return "fragile";
         if (p.attempts > 0 && p.dueDay <= today) return "due";
         if (p.attempts === 0) return "new";
-        if (p.stage >= SECURE_STAGE) return "secure";
-        if (p.wrong > 0) return "fragile";
-        return "growing";
+        if (p.stage < SECURE_STAGE) return "growing";
+        return "secure";
       }
 
       function isTroubleProgress(progress, today) {

--- a/shared/spelling/legacy-engine.js
+++ b/shared/spelling/legacy-engine.js
@@ -265,6 +265,7 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
       }
 
       function smartBucket(profileId, word, progressStore) {
+        // Any historical `wrong > 0` routes to fragile before due/new/secure — legacy priority restored by PR #145 (reverts #87).
         var p = getProgressFromStore(profileId, word.slug, progressStore);
         var today = todayDay();
         if (p.wrong > 0 && p.dueDay <= today) return "urgent";

--- a/tests/spelling.test.js
+++ b/tests/spelling.test.js
@@ -192,57 +192,6 @@ test('Smart Review reuses one progress snapshot when starting from dense learner
   assert.equal(reads.get('ks2-spell-progress-learner-a'), 1);
 });
 
-test('Smart Review keeps secured Extra words with old mistakes behind active learning', () => {
-  const now = () => Date.UTC(2026, 0, 10);
-  const today = Math.floor(now() / (24 * 60 * 60 * 1000));
-  const { service, repositories } = makeService({
-    now,
-    random: makeSequenceRandom([0.1, 0.5, 0.5], 0.5),
-  });
-  const extraSlugs = WORDS
-    .filter((word) => word.spellingPool === 'extra')
-    .map((word) => word.slug);
-  const progress = Object.fromEntries(extraSlugs.map((slug) => [slug, {
-    stage: 6,
-    attempts: 6,
-    correct: 6,
-    wrong: 0,
-    dueDay: today + 60,
-    lastDay: today - 1,
-    lastResult: 'correct',
-  }]));
-  progress.botanist = {
-    ...progress.botanist,
-    attempts: 10,
-    correct: 9,
-    wrong: 1,
-  };
-  progress.corrode = {
-    stage: 3,
-    attempts: 3,
-    correct: 3,
-    wrong: 0,
-    dueDay: today + 7,
-    lastDay: today - 1,
-    lastResult: 'correct',
-  };
-  repositories.subjectStates.writeData('learner-a', 'spelling', { progress });
-
-  const extraRows = service.getAnalyticsSnapshot('learner-a').wordGroups
-    .find((group) => group.key === 'extra')
-    .words;
-  assert.equal(extraRows.find((word) => word.slug === 'botanist')?.status, 'secure');
-  assert.equal(extraRows.find((word) => word.slug === 'corrode')?.status, 'learning');
-
-  const transition = service.startSession('learner-a', {
-    mode: 'smart',
-    yearFilter: 'extra',
-    length: 1,
-  });
-
-  assert.deepEqual(transition.state.session.uniqueWords, ['corrode']);
-});
-
 test('Trouble Drill stays inside Extra and falls back to Extra Smart Review when no Extra trouble exists', () => {
   const { service } = makeService({ random: makeSeededRandom(9) });
 

--- a/tests/spelling.test.js
+++ b/tests/spelling.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { installMemoryStorage } from './helpers/memory-storage.js';
+import { installMemoryStorage, MemoryStorage } from './helpers/memory-storage.js';
 import { createLocalPlatformRepositories } from '../src/platform/core/repositories/index.js';
 import { createSpellingService } from '../src/subjects/spelling/service.js';
 import { createSpellingPersistence } from '../src/subjects/spelling/repository.js';
@@ -10,6 +10,7 @@ import { WORDS, WORD_BY_SLUG } from '../src/subjects/spelling/data/word-data.js'
 import { rewardEventsFromSpellingEvents } from '../src/subjects/spelling/event-hooks.js';
 import { monsterSummaryFromSpellingAnalytics } from '../src/platform/game/monster-system.js';
 import { getOverallSpellingStats, spellingModule } from '../src/subjects/spelling/module.js';
+import { createLegacySpellingEngine } from '../shared/spelling/legacy-engine.js';
 
 function makeSeededRandom(seed = 1) {
   let value = seed >>> 0;
@@ -727,4 +728,36 @@ test('malformed persisted session state falls back safely instead of crashing', 
 
   assert.equal(restored.phase, 'dashboard');
   assert.match(restored.error, /could not|missing|valid words/i);
+});
+
+// Pins the legacy smartBucket priority restored by PR #145 (reverts #87). A word
+// with stage >= SECURE_STAGE AND wrong > 0 MUST bucket as `fragile`, not
+// `secure`. Exercised through chooseSmartWords because smartBucket is internal.
+test('smartBucket routes secure-stage words with historical wrongs to fragile before secure', () => {
+  const now = () => Date.UTC(2026, 0, 10);
+  const today = Math.floor(now() / (24 * 60 * 60 * 1000));
+  const storage = new MemoryStorage();
+  const profileId = 'learner-guard';
+  const fragileSlug = 'fragile-secure';
+  const freshSlug = 'fresh-new';
+  const minimalWords = [
+    { slug: fragileSlug, word: fragileSlug, year: '3-4', family: 'f1', spellingPool: 'core', accepted: [fragileSlug], sentence: '', sentences: [] },
+    { slug: freshSlug, word: freshSlug, year: '3-4', family: 'f2', spellingPool: 'core', accepted: [freshSlug], sentence: '', sentences: [] },
+  ];
+  // Secure stage + historical wrong + not due today → pre-revert this was `secure`,
+  // post-revert this is `fragile`.
+  storage.setItem(`ks2-spell-progress-${profileId}`, JSON.stringify({
+    [fragileSlug]: { stage: 5, attempts: 6, correct: 4, wrong: 2, dueDay: today + 30, lastDay: today - 1, lastResult: 'correct' },
+  }));
+  // Sequence: bucket-pick roll * total(fragile=5 + new=3 = 8) = 0.8 → picks fragile;
+  // scoreForSmart random; word-pick roll. Fallback 0.5 covers any trailing draws.
+  const randomValues = [0.1, 0.5, 0.5];
+  let index = 0;
+  const random = () => (index < randomValues.length ? randomValues[index++] : 0.5);
+
+  const engine = createLegacySpellingEngine({ words: minimalWords, storage, now, random });
+  const result = engine.createSession({ profileId, mode: 'smart', yearFilter: 'core', length: 1 });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.session.uniqueWords, [fragileSlug]);
 });


### PR DESCRIPTION
## Summary
- Reverts the `smartBucket()` priority sequence introduced by **6371ac2** (`fix(spelling): prioritise active extra learning words`, merged via #87).
- Applied as a surgical 3-file edit because a clean `git revert` no longer works: `f92f22b` deleted `src/subjects/spelling/engine/legacy-engine.js` (dead-code cleanup) and `1a256a7` added a `progressStore` parameter to `smartBucket()` in `shared/spelling/legacy-engine.js`.

## What the sequence was, and what it becomes again

**After 6371ac2 (being reverted):**
```
urgent → due → new → secure (stage ≥ SECURE) → fragile → growing
```

**After this PR (restored legacy order):**
```
urgent → fragile → due → new → growing → secure
```

The behavioural difference: words with any historical `wrong > 0` go back to `fragile` even after reaching `SECURE_STAGE`, matching the pre-6371ac2 engine.

## Files changed (+6 / −57)
- `shared/spelling/legacy-engine.js` — swap `if` order inside `smartBucket()` (signature preserved).
- `legacy/spelling-engine.source.js` — same swap to keep the runtime mirror in parity.
- `tests/spelling.test.js` — remove the test added by 6371ac2 (`Smart Review keeps secured Extra words with old mistakes behind active learning`) that asserts the new ordering and would fail post-revert.

## Verification
- `node --test tests/spelling.test.js` → **25/25 pass** (24 pre-existing + 1 new guard test pinning the restored ordering).
- Pre-existing `tests/spelling-parity.test.js` module-resolution failure was reproduced on unchanged `main` (missing `react` in this worktree's `node_modules`); not caused by this PR.

## Test plan
- [x] CI runs `npm test` and all spelling suites stay green.
- [ ] Smoke: a learner with a long-since-secured Extra word that has `wrong > 0` in history gets `fragile` status again (not `secure`).
- [ ] Parity holds between `shared/spelling/legacy-engine.js` and `legacy/spelling-engine.source.js` (same `smartBucket()` order).

## Notes for reviewer
- No data migration, no schema change — pure classification reordering.
- Only the production `shared/` runtime and the `legacy/` source-of-truth are touched; `src/subjects/spelling/engine/legacy-engine.js` no longer exists (deleted in `f92f22b`) so the revert is naturally 2-file-wide on the engine side.
- Behavioural impact: Extra pool words with any historical `wrong > 0` will re-enter the `fragile` bucket even after reaching `SECURE_STAGE`, mirroring the pre-6371ac2 engine. This is the explicit intent of the revert.