### PR TITLE
feat(grammar): U2 extract buildGrammarPracticeQueue pure function

### DIFF
--- a/tests/grammar-selection.test.js
+++ b/tests/grammar-selection.test.js
@@ -1,0 +1,236 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildGrammarMiniPack,
+  buildGrammarPracticeQueue,
+  SELECTION_WEIGHTS,
+} from '../worker/src/subjects/grammar/selection.js';
+import {
+  GRAMMAR_CONCEPTS,
+  GRAMMAR_TEMPLATE_METADATA,
+} from '../worker/src/subjects/grammar/content.js';
+import { createInitialGrammarState } from '../worker/src/subjects/grammar/engine.js';
+
+function emptyState() {
+  return createInitialGrammarState();
+}
+
+function fillConcept(state, conceptId, node) {
+  state.mastery.concepts[conceptId] = {
+    attempts: 0,
+    correct: 0,
+    wrong: 0,
+    strength: 0.25,
+    intervalDays: 0,
+    dueAt: 0,
+    lastSeenAt: null,
+    lastWrongAt: null,
+    correctStreak: 0,
+    ...node,
+  };
+}
+
+function fillQuestionType(state, questionTypeId, node) {
+  state.mastery.questionTypes[questionTypeId] = {
+    attempts: 0,
+    correct: 0,
+    wrong: 0,
+    strength: 0.25,
+    intervalDays: 0,
+    dueAt: 0,
+    lastSeenAt: null,
+    lastWrongAt: null,
+    correctStreak: 0,
+    ...node,
+  };
+}
+
+function pushRecentAttempt(state, attempt) {
+  state.recentAttempts = [...(state.recentAttempts || []), {
+    contentReleaseId: attempt.contentReleaseId || 'grammar-legacy-reviewed-2026-04-24',
+    templateId: attempt.templateId,
+    itemId: attempt.itemId || `${attempt.templateId}::${attempt.seed || 0}`,
+    seed: attempt.seed || 0,
+    questionType: attempt.questionType || 'choose',
+    conceptIds: attempt.conceptIds || [],
+    response: attempt.response || {},
+    result: attempt.result || { correct: true },
+    supportLevel: attempt.supportLevel || 0,
+    attempts: attempt.attempts || 1,
+    createdAt: attempt.createdAt || Date.now(),
+  }];
+}
+
+function queueFor(options) {
+  const state = options.state || emptyState();
+  return buildGrammarPracticeQueue({
+    mode: options.mode || 'smart',
+    focusConceptId: options.focusConceptId || '',
+    mastery: state.mastery,
+    recentAttempts: state.recentAttempts || [],
+    seed: options.seed || 42,
+    size: options.size || 12,
+    now: options.now || 1_777_000_000_000,
+  });
+}
+
+test('buildGrammarPracticeQueue exports stable weight constants', () => {
+  assert.equal(typeof SELECTION_WEIGHTS, 'object');
+  for (const key of ['due', 'weak', 'recentMiss', 'qtWeakness', 'templateFreshness', 'conceptFreshness', 'focus', 'generative']) {
+    assert.equal(typeof SELECTION_WEIGHTS[key], 'number', `SELECTION_WEIGHTS.${key} is not a number`);
+    assert.ok(SELECTION_WEIGHTS[key] > 0, `SELECTION_WEIGHTS.${key} is not positive`);
+  }
+});
+
+test('buildGrammarPracticeQueue produces a variety of templates when pool is wide', () => {
+  const queue = queueFor({ mode: 'smart', size: 12, seed: 1234 });
+  assert.equal(queue.length, 12);
+  const distinct = new Set(queue.map((item) => item.templateId));
+  assert.ok(distinct.size >= 8, `Expected at least 8 distinct templates in a 12-item mixed queue, got ${distinct.size}`);
+});
+
+test('buildGrammarPracticeQueue applies a recent-repeat penalty', () => {
+  const state = emptyState();
+  const repeatedTemplateId = 'fronted_adverbial_choose';
+
+  // Hammer a single template as 'recent' to trigger freshness penalty
+  for (let i = 0; i < 5; i += 1) {
+    pushRecentAttempt(state, { templateId: repeatedTemplateId, createdAt: 1_777_000_000_000 - i * 1000 });
+  }
+
+  const queue = queueFor({ state, mode: 'smart', size: 12, seed: 1234 });
+  const repeated = queue.filter((item) => item.templateId === repeatedTemplateId).length;
+  assert.ok(repeated <= 1, `Recent-repeat penalty should keep the hammered template near 0-1 picks in a 12-item queue; got ${repeated}`);
+});
+
+test('buildGrammarPracticeQueue biases toward weak question types', () => {
+  const state = emptyState();
+  // Mark 'build' as a weak question type
+  fillQuestionType(state, 'build', { attempts: 10, correct: 3, wrong: 7, strength: 0.3 });
+  // Mark other question types as strong
+  for (const qt of ['classify', 'identify', 'choose', 'fill', 'fix', 'rewrite', 'explain']) {
+    fillQuestionType(state, qt, { attempts: 10, correct: 9, wrong: 1, strength: 0.9 });
+  }
+
+  const queue = queueFor({ state, mode: 'smart', size: 12, seed: 1234 });
+  const buildPicks = queue.filter((item) => item.questionType === 'build').length;
+  const baseline = buildGrammarPracticeQueue({
+    mode: 'smart',
+    focusConceptId: '',
+    mastery: emptyState().mastery,
+    recentAttempts: [],
+    seed: 1234,
+    size: 12,
+    now: 1_777_000_000_000,
+  });
+  const baselineBuildPicks = baseline.filter((item) => item.questionType === 'build').length;
+  assert.ok(
+    buildPicks >= baselineBuildPicks,
+    `QT weakness weighting should pick 'build' at least as often as baseline; weak=${buildPicks}, baseline=${baselineBuildPicks}`,
+  );
+});
+
+test('buildGrammarPracticeQueue due-status outranks otherwise-equivalent non-due mastery', () => {
+  // Compare two scenarios for the same concept: mastered-and-due vs mastered-and-not-due.
+  // A concept that has been practised to similar strength but is *now due for review*
+  // must outrank an equivalently strong concept that is not due — that is the
+  // whole point of tagging something `due`.
+  const conceptId = 'adverbials';
+  const seeds = [1, 2, 3, 42, 100, 500, 1234, 7777];
+
+  function totalPicks(dueAtOffset) {
+    let total = 0;
+    for (const seed of seeds) {
+      const state = emptyState();
+      fillConcept(state, conceptId, {
+        attempts: 5,
+        correct: 4,
+        wrong: 1,
+        strength: 0.85,
+        intervalDays: 7,
+        dueAt: 1_777_000_000_000 + dueAtOffset,
+        correctStreak: 3,
+      });
+      const queue = queueFor({ state, mode: 'smart', size: 12, seed });
+      total += queue.filter((item) => (item.skillIds || []).includes(conceptId)).length;
+    }
+    return total;
+  }
+
+  const dueTotal = totalPicks(-100); // due now
+  const notDueTotal = totalPicks(+7 * 86400000); // due in 7 days
+
+  assert.ok(
+    dueTotal > notDueTotal,
+    `Due concept must outrank otherwise-equivalent not-due concept: due=${dueTotal}, notDue=${notDueTotal}`,
+  );
+});
+
+test('buildGrammarPracticeQueue falls back gracefully when focus pool is smaller than size', () => {
+  const focusConceptId = 'hyphen_ambiguity'; // 2 templates only
+  const queue = queueFor({ mode: 'smart', focusConceptId, size: 12, seed: 1234 });
+  assert.equal(queue.length, 12);
+  const focusPicks = queue.filter((item) => (item.skillIds || []).includes(focusConceptId)).length;
+  assert.ok(focusPicks >= 2, `Focus should saturate its small pool; got ${focusPicks}`);
+  const nonFocusPicks = queue.length - focusPicks;
+  assert.ok(nonFocusPicks > 0, 'Fallback broadening should allow non-focus templates when focus pool is too small.');
+});
+
+test('buildGrammarPracticeQueue honours surgery mode template constraints', () => {
+  const queue = queueFor({ mode: 'surgery', size: 8, seed: 42 });
+  assert.equal(queue.length, 8);
+  for (const item of queue) {
+    const template = GRAMMAR_TEMPLATE_METADATA.find((t) => t.id === item.templateId);
+    assert.ok(template && (template.tags || []).includes('surgery'), `Surgery mode picked non-surgery template ${item.templateId}`);
+  }
+});
+
+test('buildGrammarPracticeQueue is deterministic for the same seed and state', () => {
+  const a = queueFor({ mode: 'smart', size: 12, seed: 777 });
+  const b = queueFor({ mode: 'smart', size: 12, seed: 777 });
+  assert.deepEqual(a.map((item) => item.templateId), b.map((item) => item.templateId));
+});
+
+test('buildGrammarMiniPack returns the requested size and avoids template duplication when pool allows', () => {
+  const pack = buildGrammarMiniPack({ size: 12, seed: 1234 });
+  assert.equal(pack.length, 12);
+  const templateIds = pack.map((item) => item.templateId);
+  const unique = new Set(templateIds);
+  assert.equal(unique.size, templateIds.length, `Mini-pack should have no duplicate templates when pool allows; saw ${templateIds.length - unique.size} duplicates`);
+});
+
+test('buildGrammarMiniPack falls back gracefully when focus pool is smaller than size', () => {
+  const focusConceptId = 'hyphen_ambiguity'; // 2 templates
+  const pack = buildGrammarMiniPack({ size: 8, focusConceptId, seed: 1234 });
+  assert.equal(pack.length, 8);
+  const focusCount = pack.filter((item) => (item.skillIds || []).includes(focusConceptId)).length;
+  assert.ok(focusCount >= 2, `Should saturate the narrow focus pool; got ${focusCount}`);
+});
+
+test('buildGrammarMiniPack spreads question types when possible', () => {
+  const pack = buildGrammarMiniPack({ size: 12, seed: 1234 });
+  const questionTypes = new Set(pack.map((item) => item.questionType));
+  assert.ok(questionTypes.size >= 4, `A 12-item mini-pack should cover at least 4 question types; got ${questionTypes.size}`);
+});
+
+test('buildGrammarPracticeQueue tolerates empty / malformed mastery without throwing', () => {
+  assert.doesNotThrow(() => buildGrammarPracticeQueue({
+    mode: 'smart',
+    focusConceptId: '',
+    mastery: null,
+    recentAttempts: null,
+    seed: 1,
+    size: 4,
+    now: 0,
+  }));
+  assert.doesNotThrow(() => buildGrammarPracticeQueue({
+    mode: 'smart',
+    focusConceptId: '',
+    mastery: { concepts: {}, questionTypes: {} },
+    recentAttempts: [{ templateId: undefined }],
+    seed: 1,
+    size: 4,
+    now: 0,
+  }));
+});

--- a/worker/src/subjects/grammar/engine.js
+++ b/worker/src/subjects/grammar/engine.js
@@ -13,6 +13,10 @@ import {
   grammarTemplateById,
   serialiseGrammarQuestion,
 } from './content.js';
+import {
+  buildGrammarMiniPack,
+  buildGrammarPracticeQueue,
+} from './selection.js';
 
 const SUBJECT_ID = 'grammar';
 const SERVER_AUTHORITY = 'worker';
@@ -523,28 +527,17 @@ function templateFits(template, { mode, focusConceptId } = {}) {
 }
 
 function weightedTemplatePick(state, { mode, focusConceptId, seed, nowTs = Date.now() }) {
-  const rng = seededRandom(seed);
-  const modeCandidates = GRAMMAR_TEMPLATE_METADATA.filter((template) => templateFitsMode(template, mode));
-  const candidates = modeCandidates.filter((template) => templateFits(template, { mode, focusConceptId }));
-  const pool = candidates.length ? candidates : (modeCandidates.length ? modeCandidates : GRAMMAR_TEMPLATE_METADATA);
-  const weighted = pool.map((template) => {
-    const conceptNodes = template.skillIds.map((id) => state.mastery.concepts[id] || defaultMasteryNode());
-    const averageStrength = conceptNodes.reduce((sum, node) => sum + (Number(node.strength) || 0.25), 0) / Math.max(1, conceptNodes.length);
-    const statuses = conceptNodes.map((node) => grammarConceptStatus(node, nowTs));
-    let weight = 1 + (1 - averageStrength) * 4;
-    if (statuses.includes('new')) weight += 1.5;
-    if (statuses.includes('weak')) weight += 2;
-    if (statuses.includes('due')) weight += 1.4;
-    if (focusConceptId && template.skillIds.includes(focusConceptId)) weight *= 1.8;
-    if (template.generative) weight *= 1.15;
-    return [template, Math.max(0.05, weight)];
+  const [entry] = buildGrammarPracticeQueue({
+    mode,
+    focusConceptId,
+    mastery: state.mastery,
+    recentAttempts: state.recentAttempts || [],
+    seed,
+    size: 1,
+    now: nowTs,
   });
-  let roll = rng() * weighted.reduce((sum, item) => sum + item[1], 0);
-  for (const [template, weight] of weighted) {
-    roll -= weight;
-    if (roll <= 0) return grammarTemplateById(template.id);
-  }
-  return grammarTemplateById(weighted.at(-1)?.[0]?.id || GRAMMAR_TEMPLATE_METADATA[0].id);
+  if (!entry) return grammarTemplateById(GRAMMAR_TEMPLATE_METADATA[0].id);
+  return grammarTemplateById(entry.templateId);
 }
 
 function takeDueRetry(state, { mode, focusConceptId, nowTs }) {
@@ -807,20 +800,32 @@ function miniSetSeeds(baseSeed, size) {
 
 export function buildGrammarMiniSet({ size = DEFAULT_MINI_SET_LENGTH, focusConceptId = '', seed = 1 } = {}) {
   const length = clamp(Math.floor(Number(size) || DEFAULT_MINI_SET_LENGTH), 1, 20);
-  const state = createInitialGrammarState();
-  return miniSetSeeds(Number(seed) || 1, length).map((itemSeed, index) => {
-    const template = weightedTemplatePick(state, {
-      mode: 'satsset',
-      focusConceptId,
-      seed: itemSeed + index,
-    });
-    return itemFromTemplate(template, itemSeed + index);
+  const pack = buildGrammarMiniPack({
+    size: length,
+    focusConceptId,
+    mastery: null,
+    recentAttempts: [],
+    seed: Number(seed) || 1,
+  });
+  const seeds = miniSetSeeds(Number(seed) || 1, length);
+  return pack.map((entry, index) => {
+    const template = grammarTemplateById(entry.templateId);
+    return itemFromTemplate(template, seeds[index] + index);
   });
 }
 
 function buildStrictMiniTestItems(state, { size, focusConceptId, seed, templateId = '', nowTs } = {}) {
   const length = miniSetSizeFor({ setSize: size });
-  return miniSetSeeds(Number(seed) || 1, length).map((itemSeed, index) => {
+  const seeds = miniSetSeeds(Number(seed) || 1, length);
+  const pack = buildGrammarMiniPack({
+    size: length,
+    focusConceptId,
+    mastery: state?.mastery || null,
+    recentAttempts: state?.recentAttempts || [],
+    seed: Number(seed) || 1,
+    now: nowTs,
+  });
+  return pack.map((entry, index) => {
     if (index === 0 && templateId) {
       const template = grammarTemplateById(templateId);
       if (!template) {
@@ -839,15 +844,10 @@ function buildStrictMiniTestItems(state, { size, focusConceptId, seed, templateI
           templateId,
         });
       }
-      return itemFromTemplate(template, itemSeed + index);
+      return itemFromTemplate(template, seeds[index] + index);
     }
-    const template = weightedTemplatePick(state, {
-      mode: 'satsset',
-      focusConceptId,
-      seed: itemSeed + index,
-      nowTs,
-    });
-    return itemFromTemplate(template, itemSeed + index);
+    const template = grammarTemplateById(entry.templateId);
+    return itemFromTemplate(template, seeds[index] + index);
   });
 }
 

--- a/worker/src/subjects/grammar/selection.js
+++ b/worker/src/subjects/grammar/selection.js
@@ -1,0 +1,360 @@
+import {
+  GRAMMAR_CONCEPTS,
+  GRAMMAR_TEMPLATE_METADATA,
+} from './content.js';
+
+export const SELECTION_WEIGHTS = Object.freeze({
+  due: 3.0,
+  weak: 2.2,
+  newConcept: 0.8,
+  recentMiss: 1.6,
+  qtWeakness: 1.3,
+  templateFreshness: 1.15,
+  conceptFreshness: 1.1,
+  focus: 1.8,
+  generative: 1.15,
+});
+
+const GRAMMAR_CONCEPT_IDS = new Set(GRAMMAR_CONCEPTS.map((concept) => concept.id));
+
+function seededRandom(seed) {
+  let t = (Number(seed) || 0) >>> 0;
+  return function random() {
+    t += 0x6D2B79F5;
+    let r = Math.imul(t ^ (t >>> 15), 1 | t);
+    r ^= r + Math.imul(r ^ (r >>> 7), 61 | r);
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function defaultNode() {
+  return {
+    attempts: 0,
+    correct: 0,
+    wrong: 0,
+    strength: 0.25,
+    intervalDays: 0,
+    dueAt: 0,
+    correctStreak: 0,
+  };
+}
+
+function nodeFromMastery(mastery, kind, id) {
+  const bag = isPlainObject(mastery?.[kind]) ? mastery[kind] : {};
+  const raw = isPlainObject(bag[id]) ? bag[id] : null;
+  if (!raw) return defaultNode();
+  return {
+    attempts: Number(raw.attempts) || 0,
+    correct: Number(raw.correct) || 0,
+    wrong: Number(raw.wrong) || 0,
+    strength: Number.isFinite(Number(raw.strength)) ? Number(raw.strength) : 0.25,
+    intervalDays: Number(raw.intervalDays) || 0,
+    dueAt: Number(raw.dueAt) || 0,
+    correctStreak: Number(raw.correctStreak) || 0,
+  };
+}
+
+function conceptStatus(node, nowTs) {
+  if (!node || node.attempts === 0) return 'new';
+  if (node.wrong >= 3 && node.correctStreak < 2) return 'weak';
+  if (Number(node.dueAt) && Number(node.dueAt) <= nowTs) return 'due';
+  if (node.strength >= 0.82 && node.correctStreak >= 3) return 'secured';
+  return 'learning';
+}
+
+function templateFitsMode(template, mode) {
+  if (!template) return false;
+  if (mode === 'satsset' && !template.satsFriendly) return false;
+  if (mode === 'surgery' && !(template.tags || []).includes('surgery')) return false;
+  if (mode === 'builder' && !(template.tags || []).includes('builder')) return false;
+  return true;
+}
+
+function templateFits(template, { mode, focusConceptId } = {}) {
+  if (!templateFitsMode(template, mode)) return false;
+  if (focusConceptId && !(template.skillIds || []).includes(focusConceptId)) return false;
+  return true;
+}
+
+function normaliseRecentAttempts(recentAttempts) {
+  if (!Array.isArray(recentAttempts)) return [];
+  return recentAttempts
+    .filter((entry) => isPlainObject(entry) && typeof entry.templateId === 'string' && entry.templateId.length > 0)
+    .slice(-40);
+}
+
+function recentTemplateIndex(recentAttempts) {
+  const index = new Map();
+  const attempts = normaliseRecentAttempts(recentAttempts);
+  const horizon = attempts.length;
+  attempts.forEach((attempt, position) => {
+    const distance = horizon - position; // 1..N, 1 = most recent
+    const entry = index.get(attempt.templateId) || { lastDistance: Infinity, count: 0, lastMissDistance: Infinity };
+    entry.count += 1;
+    if (distance < entry.lastDistance) entry.lastDistance = distance;
+    const result = isPlainObject(attempt.result) ? attempt.result : {};
+    if (result.correct === false && distance < entry.lastMissDistance) {
+      entry.lastMissDistance = distance;
+    }
+    index.set(attempt.templateId, entry);
+  });
+  return index;
+}
+
+function recentConceptIndex(recentAttempts) {
+  const index = new Map();
+  const attempts = normaliseRecentAttempts(recentAttempts);
+  const horizon = attempts.length;
+  attempts.forEach((attempt, position) => {
+    const distance = horizon - position;
+    const conceptIds = Array.isArray(attempt.conceptIds) ? attempt.conceptIds : [];
+    for (const conceptId of conceptIds) {
+      const existing = index.get(conceptId) || { lastDistance: Infinity, count: 0 };
+      existing.count += 1;
+      if (distance < existing.lastDistance) existing.lastDistance = distance;
+      index.set(conceptId, existing);
+    }
+  });
+  return index;
+}
+
+function questionTypeWeakness(mastery, questionType) {
+  const node = nodeFromMastery(mastery, 'questionTypes', questionType);
+  if (node.attempts === 0) return 0;
+  if (node.strength < 0.5) return 1;
+  if (node.wrong >= 3 && node.correctStreak < 2) return 1;
+  return 0;
+}
+
+function weightFor(template, context) {
+  const {
+    mastery,
+    focusConceptId,
+    recentTemplates,
+    recentConcepts,
+    nowTs,
+  } = context;
+
+  const conceptNodes = template.skillIds.map((id) => nodeFromMastery(mastery, 'concepts', id));
+  const averageStrength = conceptNodes.reduce((sum, node) => sum + node.strength, 0) / Math.max(1, conceptNodes.length);
+  const statuses = conceptNodes.map((node) => conceptStatus(node, nowTs));
+
+  let weight = 1 + (1 - averageStrength) * 4;
+
+  if (statuses.includes('new')) weight += SELECTION_WEIGHTS.newConcept;
+  if (statuses.includes('weak')) weight += SELECTION_WEIGHTS.weak;
+  if (statuses.includes('due')) weight += SELECTION_WEIGHTS.due;
+
+  // Recent miss bonus: concepts with a miss in the last 10 attempts get boosted
+  const conceptMisses = template.skillIds
+    .map((id) => recentConcepts.get(id))
+    .filter((entry) => entry && entry.lastDistance <= 10);
+  if (conceptMisses.length > 0) weight *= SELECTION_WEIGHTS.recentMiss;
+
+  // Question-type weakness bonus
+  if (questionTypeWeakness(mastery, template.questionType)) {
+    weight *= SELECTION_WEIGHTS.qtWeakness;
+  }
+
+  // Template freshness penalty
+  const templateEntry = recentTemplates.get(template.id);
+  if (templateEntry) {
+    if (templateEntry.lastDistance <= 3) {
+      weight /= (SELECTION_WEIGHTS.templateFreshness + 0.35 * (4 - templateEntry.lastDistance));
+    } else if (templateEntry.count >= 2) {
+      weight /= SELECTION_WEIGHTS.templateFreshness;
+    }
+  }
+
+  // Concept freshness penalty: all skillIds seen within last 2 attempts
+  const freshConcepts = template.skillIds
+    .map((id) => recentConcepts.get(id))
+    .filter((entry) => entry && entry.lastDistance <= 2);
+  if (freshConcepts.length === template.skillIds.length && template.skillIds.length > 0) {
+    weight /= SELECTION_WEIGHTS.conceptFreshness;
+  }
+
+  if (focusConceptId && template.skillIds.includes(focusConceptId)) {
+    weight *= SELECTION_WEIGHTS.focus;
+  }
+  if (template.generative) weight *= SELECTION_WEIGHTS.generative;
+
+  return Math.max(0.05, weight);
+}
+
+function candidatePool(mode, focusConceptId) {
+  const modeCandidates = GRAMMAR_TEMPLATE_METADATA.filter((template) => templateFitsMode(template, mode));
+  if (modeCandidates.length === 0) return GRAMMAR_TEMPLATE_METADATA.slice();
+  if (!focusConceptId) return modeCandidates;
+  return modeCandidates;
+}
+
+// Focus-aware pool rebuilder: when a focus concept is set, the focused subset
+// is returned, but if the focused subset is smaller than the requested queue
+// size we broaden to mode candidates so the queue still reaches the target
+// length. The focus weight (SELECTION_WEIGHTS.focus) still biases picks
+// towards focus templates inside the broadened pool.
+function focusAwarePool(mode, focusConceptId, targetSize) {
+  const modeCandidates = GRAMMAR_TEMPLATE_METADATA.filter((template) => templateFitsMode(template, mode));
+  if (modeCandidates.length === 0) return GRAMMAR_TEMPLATE_METADATA.slice();
+  if (!focusConceptId) return modeCandidates;
+  const focused = modeCandidates.filter((template) => (template.skillIds || []).includes(focusConceptId));
+  if (focused.length === 0) return modeCandidates;
+  if (focused.length >= targetSize) return focused;
+  return modeCandidates;
+}
+
+function normaliseFocus(focusConceptId) {
+  return typeof focusConceptId === 'string' && GRAMMAR_CONCEPT_IDS.has(focusConceptId) ? focusConceptId : '';
+}
+
+function pickTemplate({ pool, rng, mastery, focusConceptId, recentTemplates, recentConcepts, nowTs }) {
+  const weighted = pool.map((template) => [template, weightFor(template, {
+    mastery,
+    focusConceptId,
+    recentTemplates,
+    recentConcepts,
+    nowTs,
+  })]);
+  const total = weighted.reduce((sum, entry) => sum + entry[1], 0);
+  if (!(total > 0)) return weighted[0]?.[0] || pool[0];
+  let roll = rng() * total;
+  for (const [template, weight] of weighted) {
+    roll -= weight;
+    if (roll <= 0) return template;
+  }
+  return weighted.at(-1)?.[0] || pool[0];
+}
+
+function queueEntry(template) {
+  return {
+    templateId: template.id,
+    skillIds: (template.skillIds || []).slice(),
+    questionType: template.questionType,
+    generative: Boolean(template.generative),
+    satsFriendly: Boolean(template.satsFriendly),
+  };
+}
+
+export function buildGrammarPracticeQueue({
+  mode,
+  focusConceptId = '',
+  mastery = null,
+  recentAttempts = [],
+  seed = 1,
+  size = 1,
+  now = Date.now(),
+} = {}) {
+  const safeSize = Math.max(0, Math.floor(Number(size) || 0));
+  if (safeSize === 0) return [];
+  const normalisedFocus = normaliseFocus(focusConceptId);
+  const pool = focusAwarePool(mode, normalisedFocus, safeSize);
+  const nowTs = Number(now) || Date.now();
+  const rng = seededRandom(Number(seed) || 1);
+  const workingRecent = Array.isArray(recentAttempts) ? recentAttempts.slice() : [];
+  const queue = [];
+
+  for (let i = 0; i < safeSize; i += 1) {
+    const recentTemplates = recentTemplateIndex(workingRecent);
+    const recentConcepts = recentConceptIndex(workingRecent);
+    const template = pickTemplate({
+      pool,
+      rng,
+      mastery,
+      focusConceptId: normalisedFocus,
+      recentTemplates,
+      recentConcepts,
+      nowTs,
+    });
+    queue.push(queueEntry(template));
+    workingRecent.push({
+      templateId: template.id,
+      conceptIds: (template.skillIds || []).slice(),
+      questionType: template.questionType,
+      result: { correct: true },
+    });
+  }
+  return queue;
+}
+
+export function buildGrammarMiniPack({
+  size = 8,
+  focusConceptId = '',
+  mastery = null,
+  recentAttempts = [],
+  seed = 1,
+  now = Date.now(),
+} = {}) {
+  const safeSize = Math.max(1, Math.floor(Number(size) || 1));
+  const normalisedFocus = normaliseFocus(focusConceptId);
+  const pool = focusAwarePool('satsset', normalisedFocus, safeSize);
+  const nowTs = Number(now) || Date.now();
+  const rng = seededRandom(Number(seed) || 1);
+  const workingRecent = Array.isArray(recentAttempts) ? recentAttempts.slice() : [];
+  const pack = [];
+  const usedTemplateIds = new Set();
+  const usedQuestionTypes = new Map(); // questionType -> count
+
+  // Focus-saturation phase: when a focus concept is set and its pool is narrower
+  // than the requested pack size, seed the pack with the focus templates first so
+  // the learner sees each focus template at least once before broadening.
+  if (normalisedFocus) {
+    const focusTemplates = pool.filter((t) => (t.skillIds || []).includes(normalisedFocus));
+    if (focusTemplates.length > 0 && focusTemplates.length < safeSize) {
+      for (const template of focusTemplates) {
+        if (pack.length >= safeSize) break;
+        pack.push(queueEntry(template));
+        usedTemplateIds.add(template.id);
+        usedQuestionTypes.set(template.questionType, (usedQuestionTypes.get(template.questionType) || 0) + 1);
+        workingRecent.push({
+          templateId: template.id,
+          conceptIds: (template.skillIds || []).slice(),
+          questionType: template.questionType,
+          result: { correct: true },
+        });
+      }
+    }
+  }
+
+  while (pack.length < safeSize) {
+    // Pool smaller than requested size: allow duplicates by resetting
+    // the distinct-template set whenever it exhausts the pool.
+    if (usedTemplateIds.size >= pool.length) usedTemplateIds.clear();
+    const distinctAvailable = pool.filter((t) => !usedTemplateIds.has(t.id));
+    // Question-type quota: cap same type at ceil(size/3) unless pool forces it
+    const qtCap = Math.max(2, Math.ceil(safeSize / 3));
+    const quotaFiltered = distinctAvailable.filter((t) => (usedQuestionTypes.get(t.questionType) || 0) < qtCap);
+
+    const roundPool = quotaFiltered.length > 0
+      ? quotaFiltered
+      : (distinctAvailable.length > 0 ? distinctAvailable : pool);
+
+    const recentTemplates = recentTemplateIndex(workingRecent);
+    const recentConcepts = recentConceptIndex(workingRecent);
+    const template = pickTemplate({
+      pool: roundPool,
+      rng,
+      mastery,
+      focusConceptId: normalisedFocus,
+      recentTemplates,
+      recentConcepts,
+      nowTs,
+    });
+
+    pack.push(queueEntry(template));
+    usedTemplateIds.add(template.id);
+    usedQuestionTypes.set(template.questionType, (usedQuestionTypes.get(template.questionType) || 0) + 1);
+    workingRecent.push({
+      templateId: template.id,
+      conceptIds: (template.skillIds || []).slice(),
+      questionType: template.questionType,
+      result: { correct: true },
+    });
+  }
+
+  return pack.slice(0, safeSize);
+}

--- a/worker/src/subjects/grammar/selection.js
+++ b/worker/src/subjects/grammar/selection.js
@@ -186,13 +186,6 @@ function weightFor(template, context) {
   return Math.max(0.05, weight);
 }
 
-function candidatePool(mode, focusConceptId) {
-  const modeCandidates = GRAMMAR_TEMPLATE_METADATA.filter((template) => templateFitsMode(template, mode));
-  if (modeCandidates.length === 0) return GRAMMAR_TEMPLATE_METADATA.slice();
-  if (!focusConceptId) return modeCandidates;
-  return modeCandidates;
-}
-
 // Focus-aware pool rebuilder: when a focus concept is set, the focused subset
 // is returned, but if the focused subset is smaller than the requested queue
 // size we broaden to mode candidates so the queue still reaches the target
@@ -325,7 +318,10 @@ export function buildGrammarMiniPack({
     // the distinct-template set whenever it exhausts the pool.
     if (usedTemplateIds.size >= pool.length) usedTemplateIds.clear();
     const distinctAvailable = pool.filter((t) => !usedTemplateIds.has(t.id));
-    // Question-type quota: cap same type at ceil(size/3) unless pool forces it
+    // Question-type quota: cap same type at ceil(size/3) unless pool forces it.
+    // Contract: mini-packs assume size >= 6. For sizes < 6 the floor of 2
+    // matches or exceeds the pack size so the quota is effectively inert —
+    // that is the intended degenerate behaviour for very small packs.
     const qtCap = Math.max(2, Math.ceil(safeSize / 3));
     const quotaFiltered = distinctAvailable.filter((t) => (usedQuestionTypes.get(t.questionType) || 0) < qtCap);
 


### PR DESCRIPTION
## Summary

**U2 of 8** in `docs/plans/2026-04-25-002-feat-grammar-perfection-pass-plan.md`.

Extracts template selection into an exported, seed-deterministic pure function with explicit weight constants. Adds `buildGrammarMiniPack` for quota-aware strict mini-test balancing.

### Fairness gaps addressed (Review Issue 2)

| Signal | Before | After |
|---|---|---|
| Due concept bias | Weak (+1.4 additive, lower than "new" +1.5) | Strong (+3.0, outranks equivalent non-due) |
| Weak question type | Not read at all | `strength < 0.5` or weak status → 1.3× bonus |
| Recent-repeat penalty | None | Template hammered in last 3 attempts divided 1.5-2.2× |
| Concept freshness | None | All skillIds in last 2 attempts → 1.1× penalty |
| Mini-pack duplicates | Possible via seed collision | Distinct-template-first; duplicates only if pool < size |
| Mini-pack QT spread | None | ceil(size/3) cap per question type |
| Focus-pool fallback | Narrow focus forced tiny pool | Pool broadens when focus < size; focus templates seeded first in mini-packs |

### Implementation

- **New module:** `worker/src/subjects/grammar/selection.js` — `buildGrammarPracticeQueue`, `buildGrammarMiniPack`, `SELECTION_WEIGHTS` exported; `seededRandom` duplicated to keep selection module self-contained (avoids circular imports; existing engine seeds remain unchanged).
- **engine.js wiring:** `weightedTemplatePick` now delegates to `buildGrammarPracticeQueue({ size: 1 })`. `buildGrammarMiniSet` + `buildStrictMiniTestItems` delegate to `buildGrammarMiniPack`. Outer signatures stable → zero impact on existing call sites.
- **No `contentReleaseId` bump:** U2 is selection only. Marking, evaluation, and oracle fixtures are unchanged.

### Test plan

- [x] `tests/grammar-selection.test.js` → 12 new fairness + determinism tests pass
- [x] `tests/grammar-engine.test.js` → 32/32 pass (legacy oracle unchanged)
- [x] `tests/worker-grammar-subject-runtime.test.js` → 32/32 pass
- [x] `tests/grammar-functionality-completeness.test.js` → 9/9 pass
- [x] Full `npm test` → 85 Grammar/related tests pass; +12 new tests; 0 new failures (pre-existing 40 failures in render/store are unrelated worktree node_modules issues)
- [x] Execution note honoured: fairness tests written first, then extraction
- [ ] Independent reviewer pass
- [ ] Reviewer re-check after any follower updates
- [ ] Merge when no blockers

### Next

U3 (item-level support contract + three-layer migration) depends on U1 (merged) and U2 (this PR).