### PR TITLE
feat(grammar): U3 item-level support contract + three-layer migration

### DIFF
--- a/tests/grammar-attempt-support.test.js
+++ b/tests/grammar-attempt-support.test.js
@@ -1,0 +1,325 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  composeAttemptSupport,
+  deriveAttemptSupport,
+  normaliseStoredAttempt,
+  SUPPORT_CONTRACT_VERSION,
+  SUPPORT_USED_VALUES,
+  supportLevelForSessionWithContract,
+} from '../worker/src/subjects/grammar/attempt-support.js';
+import {
+  applyGrammarAttemptToState,
+  createInitialGrammarState,
+  normaliseServerGrammarData,
+} from '../worker/src/subjects/grammar/engine.js';
+import {
+  createGrammarQuestion,
+  evaluateGrammarQuestion,
+  serialiseGrammarQuestion,
+} from '../worker/src/subjects/grammar/content.js';
+
+function independentCorrectAnswer() {
+  const question = createGrammarQuestion({ templateId: 'fronted_adverbial_choose', seed: 100 });
+  const correctOption = question.inputSpec.options.find(
+    (option) => evaluateGrammarQuestion(question, { answer: option.value }).correct,
+  );
+  return {
+    item: serialiseGrammarQuestion(question),
+    answer: { answer: correctOption.value },
+  };
+}
+
+test('SUPPORT_CONTRACT_VERSION is the new default (v2)', () => {
+  assert.equal(SUPPORT_CONTRACT_VERSION, 2);
+});
+
+test('SUPPORT_USED_VALUES includes all five legal attributions', () => {
+  assert.deepEqual(SUPPORT_USED_VALUES.slice().sort(), [
+    'ai-explanation-after-marking',
+    'faded',
+    'none',
+    'nudge',
+    'worked',
+  ]);
+});
+
+test('deriveAttemptSupport maps every legacy (mode, supportLevel, attempts) combo', () => {
+  const modes = ['worked', 'faded', 'smart', 'learn', 'trouble', 'surgery', 'builder', 'satsset'];
+  const supportLevels = [0, 1, 2];
+  const attemptCounts = [1, 2, 3];
+
+  for (const mode of modes) {
+    for (const supportLevel of supportLevels) {
+      for (const attempts of attemptCounts) {
+        const derived = deriveAttemptSupport({ mode, supportLevel, attempts });
+        assert.ok(
+          SUPPORT_USED_VALUES.includes(derived.supportUsed),
+          `${mode}/${supportLevel}/${attempts} => unknown supportUsed ${derived.supportUsed}`,
+        );
+        assert.ok([0, 1, 2].includes(derived.supportLevelAtScoring));
+        assert.equal(typeof derived.firstAttemptIndependent, 'boolean');
+        // Invariant: firstAttemptIndependent requires attempts===1 AND supportUsed==='none'
+        if (derived.firstAttemptIndependent) {
+          assert.equal(attempts, 1);
+          assert.equal(derived.supportUsed, 'none');
+        }
+      }
+    }
+  }
+});
+
+test('deriveAttemptSupport: worked mode always attributes `worked`', () => {
+  const derived = deriveAttemptSupport({ mode: 'worked', supportLevel: 2, attempts: 1 });
+  assert.equal(derived.supportUsed, 'worked');
+  assert.equal(derived.supportLevelAtScoring, 2);
+  assert.equal(derived.firstAttemptIndependent, false);
+});
+
+test('deriveAttemptSupport: faded mode always attributes `faded`', () => {
+  const derived = deriveAttemptSupport({ mode: 'faded', supportLevel: 1, attempts: 1 });
+  assert.equal(derived.supportUsed, 'faded');
+  assert.equal(derived.supportLevelAtScoring, 1);
+});
+
+test('deriveAttemptSupport: faded+level=1+attempts=2 resolves to faded not nudge', () => {
+  const derived = deriveAttemptSupport({ mode: 'faded', supportLevel: 1, attempts: 2 });
+  assert.equal(derived.supportUsed, 'faded', 'Mode-based attribution takes precedence over retry signal.');
+});
+
+test('deriveAttemptSupport: retry without worked/faded mode attributes `nudge`', () => {
+  const derived = deriveAttemptSupport({ mode: 'smart', supportLevel: 0, attempts: 2 });
+  assert.equal(derived.supportUsed, 'nudge');
+  assert.equal(derived.supportLevelAtScoring, 0);
+  assert.equal(derived.firstAttemptIndependent, false);
+});
+
+test('deriveAttemptSupport: independent correct returns firstAttemptIndependent=true', () => {
+  const derived = deriveAttemptSupport({ mode: 'smart', supportLevel: 0, attempts: 1 });
+  assert.equal(derived.supportUsed, 'none');
+  assert.equal(derived.supportLevelAtScoring, 0);
+  assert.equal(derived.firstAttemptIndependent, true);
+});
+
+test('deriveAttemptSupport: legacy Smart + session-level promotion (supportLevel=1) infers faded', () => {
+  // Under contract v1, Smart + allowTeachingItems forced supportLevel=1 session-wide.
+  // For a legacy attempt stamped with supportLevel=1 and mode=smart, the learner
+  // was shown faded content, so we conservatively attribute 'faded' rather than erase
+  // evidence with 'none'.
+  const derived = deriveAttemptSupport({ mode: 'smart', supportLevel: 1, attempts: 1 });
+  assert.equal(derived.supportUsed, 'faded');
+  assert.equal(derived.supportLevelAtScoring, 1);
+  assert.equal(derived.firstAttemptIndependent, false);
+});
+
+test('composeAttemptSupport: post-marking enrichment never reduces mastery gain', () => {
+  const composed = composeAttemptSupport({
+    mode: 'smart',
+    sessionSupportLevel: 1,
+    attempts: 1,
+    postMarkingEnrichment: true,
+  });
+  assert.equal(composed.supportUsed, 'ai-explanation-after-marking');
+  assert.equal(composed.supportLevelAtScoring, 0, 'Post-marking enrichment does not reduce mastery gain.');
+  assert.equal(composed.firstAttemptIndependent, true);
+});
+
+test('composeAttemptSupport: explicit supportUsed takes precedence over session-derived', () => {
+  const composed = composeAttemptSupport({
+    mode: 'smart',
+    sessionSupportLevel: 0,
+    attempts: 1,
+    supportUsed: 'faded',
+  });
+  assert.equal(composed.supportUsed, 'faded');
+  assert.equal(composed.supportLevelAtScoring, 1);
+});
+
+test('composeAttemptSupport: invalid supportUsed falls back to session-derived', () => {
+  const composed = composeAttemptSupport({
+    mode: 'worked',
+    sessionSupportLevel: 2,
+    attempts: 1,
+    supportUsed: 'garbage-value',
+  });
+  assert.equal(composed.supportUsed, 'worked', 'Invalid supportUsed should not poison the attribution.');
+  assert.equal(composed.supportLevelAtScoring, 2);
+});
+
+test('normaliseStoredAttempt: a legacy attempt without new fields gains them on load', () => {
+  const legacy = {
+    templateId: 'fronted_adverbial_choose',
+    supportLevel: 1,
+    attempts: 1,
+    mode: 'smart',
+  };
+  const normalised = normaliseStoredAttempt(legacy);
+  assert.equal(normalised.supportUsed, 'faded');
+  assert.equal(normalised.supportLevelAtScoring, 1);
+  assert.equal(normalised.firstAttemptIndependent, false);
+  // Legacy fields preserved
+  assert.equal(normalised.supportLevel, 1);
+  assert.equal(normalised.attempts, 1);
+});
+
+test('normaliseStoredAttempt is idempotent on already-U3-shaped records', () => {
+  const u3Shape = {
+    templateId: 'fronted_adverbial_choose',
+    supportLevel: 0,
+    attempts: 1,
+    mode: 'smart',
+    firstAttemptIndependent: true,
+    supportUsed: 'none',
+    supportLevelAtScoring: 0,
+  };
+  const normalised = normaliseStoredAttempt(u3Shape);
+  assert.equal(normalised.supportUsed, 'none');
+  assert.equal(normalised.firstAttemptIndependent, true);
+  assert.equal(normalised.supportLevelAtScoring, 0);
+});
+
+test('supportLevelForSessionWithContract: contract v2 drops Smart+teaching promotion', () => {
+  // v1 legacy behaviour preserved for in-flight sessions stamped v1.
+  assert.equal(
+    supportLevelForSessionWithContract({ mode: 'smart', prefs: { allowTeachingItems: true }, contractVersion: 1 }),
+    1,
+  );
+  // v2 default behaviour: Smart + teaching items no longer forces session-level 1.
+  assert.equal(
+    supportLevelForSessionWithContract({ mode: 'smart', prefs: { allowTeachingItems: true }, contractVersion: 2 }),
+    0,
+  );
+  // worked/faded modes still force session level regardless of contract.
+  assert.equal(supportLevelForSessionWithContract({ mode: 'worked', contractVersion: 2 }), 2);
+  assert.equal(supportLevelForSessionWithContract({ mode: 'faded', contractVersion: 2 }), 1);
+});
+
+test('applyGrammarAttemptToState: Smart Review independent correct gets full credit under v2', () => {
+  const { item, answer } = independentCorrectAnswer();
+  const state = createInitialGrammarState();
+  state.prefs.allowTeachingItems = true;
+  const applied = applyGrammarAttemptToState(state, {
+    learnerId: 'learner-a',
+    item,
+    response: answer,
+    supportLevel: 0, // The session's modeSupportLevel under contract v2 with Smart + allowTeachingItems
+    attempts: 1,
+    mode: 'smart',
+    now: 1_777_000_000_000,
+  });
+  assert.equal(applied.quality, 5, 'Independent first-attempt correct must get quality 5, not downgraded.');
+  const attempt = state.recentAttempts.at(-1);
+  assert.equal(attempt.firstAttemptIndependent, true);
+  assert.equal(attempt.supportUsed, 'none');
+  assert.equal(attempt.supportLevelAtScoring, 0);
+  assert.equal(attempt.mode, 'smart');
+});
+
+test('applyGrammarAttemptToState: worked mode attempt attributes worked + quality reduced', () => {
+  const { item, answer } = independentCorrectAnswer();
+  const state = createInitialGrammarState();
+  const applied = applyGrammarAttemptToState(state, {
+    learnerId: 'learner-a',
+    item,
+    response: answer,
+    supportLevel: 2,
+    attempts: 1,
+    mode: 'worked',
+    now: 1_777_000_000_000,
+  });
+  assert.equal(applied.quality, 3, 'worked-mode correctness is quality 3.');
+  const attempt = state.recentAttempts.at(-1);
+  assert.equal(attempt.supportUsed, 'worked');
+  assert.equal(attempt.supportLevelAtScoring, 2);
+  assert.equal(attempt.firstAttemptIndependent, false);
+});
+
+test('applyGrammarAttemptToState: event dual-writes legacy and new support fields', () => {
+  const { item, answer } = independentCorrectAnswer();
+  const state = createInitialGrammarState();
+  const applied = applyGrammarAttemptToState(state, {
+    learnerId: 'learner-a',
+    item,
+    response: answer,
+    supportLevel: 0,
+    attempts: 1,
+    mode: 'smart',
+    now: 1_777_000_000_000,
+  });
+  const answerEvent = applied.events.find((event) => event.type === 'grammar.answer-submitted');
+  assert.ok(answerEvent, 'answer-submitted event must be emitted');
+  // Legacy fields still present
+  assert.equal(typeof answerEvent.supportLevel, 'number');
+  assert.equal(typeof answerEvent.attempts, 'number');
+  // New fields present
+  assert.equal(answerEvent.firstAttemptIndependent, true);
+  assert.equal(answerEvent.supportUsed, 'none');
+  assert.equal(answerEvent.supportLevelAtScoring, 0);
+  assert.equal(answerEvent.mode, 'smart');
+  assert.equal(answerEvent.supportContractVersion, 2);
+});
+
+test('normaliseServerGrammarData: pre-U3 stored attempts get normalised on load', () => {
+  const rawState = {
+    contentReleaseId: 'grammar-legacy-reviewed-2026-04-24',
+    recentAttempts: [
+      {
+        templateId: 'fronted_adverbial_choose',
+        itemId: 'fronted_adverbial_choose::100',
+        seed: 100,
+        questionType: 'choose',
+        conceptIds: ['adverbials'],
+        response: { answer: 'x' },
+        result: { correct: true, score: 1, maxScore: 1 },
+        supportLevel: 1,
+        attempts: 1,
+        mode: 'smart',
+        createdAt: 1_700_000_000_000,
+        // NO firstAttemptIndependent / supportUsed / supportLevelAtScoring fields
+      },
+    ],
+  };
+  const normalised = normaliseServerGrammarData(rawState);
+  const attempt = normalised.recentAttempts[0];
+  assert.equal(attempt.supportUsed, 'faded');
+  assert.equal(attempt.supportLevelAtScoring, 1);
+  assert.equal(attempt.firstAttemptIndependent, false);
+});
+
+test('event-log replay: pre-U3 events project consistently with post-U3 events', () => {
+  // Pre-U3 event: only `supportLevel` + `attempts` + `mode`
+  const preU3Event = {
+    type: 'grammar.answer-submitted',
+    supportLevel: 1,
+    attempts: 1,
+    mode: 'smart',
+  };
+  // Post-U3 event: both shapes dual-written
+  const postU3Event = {
+    type: 'grammar.answer-submitted',
+    supportLevel: 1,
+    attempts: 1,
+    mode: 'smart',
+    firstAttemptIndependent: false,
+    supportUsed: 'faded',
+    supportLevelAtScoring: 1,
+    supportContractVersion: 2,
+  };
+
+  // A replayer-side projection would use deriveAttemptSupport on the legacy event
+  // and read the new fields directly from the post-U3 event.
+  const preU3Projected = deriveAttemptSupport({
+    mode: preU3Event.mode,
+    supportLevel: preU3Event.supportLevel,
+    attempts: preU3Event.attempts,
+  });
+  const postU3Projected = {
+    firstAttemptIndependent: postU3Event.firstAttemptIndependent,
+    supportUsed: postU3Event.supportUsed,
+    supportLevelAtScoring: postU3Event.supportLevelAtScoring,
+  };
+
+  assert.deepEqual(preU3Projected, postU3Projected,
+    'Pre-U3 and post-U3 events must project to identical new-field triples for the same semantic case.');
+});

--- a/tests/grammar-attempt-support.test.js
+++ b/tests/grammar-attempt-support.test.js
@@ -287,39 +287,49 @@ test('normaliseServerGrammarData: pre-U3 stored attempts get normalised on load'
   assert.equal(attempt.firstAttemptIndependent, false);
 });
 
-test('event-log replay: pre-U3 events project consistently with post-U3 events', () => {
-  // Pre-U3 event: only `supportLevel` + `attempts` + `mode`
-  const preU3Event = {
-    type: 'grammar.answer-submitted',
-    supportLevel: 1,
+test('event-log replay: pre-U3 and post-U3 stored attempts project identically after normalisation', () => {
+  // Construct two attempt records representing the same semantic case:
+  //   (1) a pre-U3 record missing the new fields entirely, and
+  //   (2) a post-U3 record with both legacy and new fields dual-written.
+  // After running both through normaliseServerGrammarData (which calls
+  // normaliseStoredAttempt), they must project to identical shapes when
+  // consumed by downstream readers. This proves the "state + event" parity
+  // the plan calls for: a replayer cannot observe drift between the two.
+  const baseAttempt = {
+    contentReleaseId: 'grammar-legacy-reviewed-2026-04-24',
+    templateId: 'fronted_adverbial_choose',
+    itemId: 'fronted_adverbial_choose::100',
+    seed: 100,
+    questionType: 'choose',
+    conceptIds: ['adverbials'],
+    response: { answer: 'x' },
+    result: { correct: true, score: 1, maxScore: 1 },
     attempts: 1,
     mode: 'smart',
+    createdAt: 1_700_000_000_000,
   };
-  // Post-U3 event: both shapes dual-written
-  const postU3Event = {
-    type: 'grammar.answer-submitted',
+  const preU3Attempt = { ...baseAttempt, supportLevel: 1 };
+  const postU3Attempt = {
+    ...baseAttempt,
     supportLevel: 1,
-    attempts: 1,
-    mode: 'smart',
     firstAttemptIndependent: false,
     supportUsed: 'faded',
     supportLevelAtScoring: 1,
-    supportContractVersion: 2,
   };
 
-  // A replayer-side projection would use deriveAttemptSupport on the legacy event
-  // and read the new fields directly from the post-U3 event.
-  const preU3Projected = deriveAttemptSupport({
-    mode: preU3Event.mode,
-    supportLevel: preU3Event.supportLevel,
-    attempts: preU3Event.attempts,
-  });
-  const postU3Projected = {
-    firstAttemptIndependent: postU3Event.firstAttemptIndependent,
-    supportUsed: postU3Event.supportUsed,
-    supportLevelAtScoring: postU3Event.supportLevelAtScoring,
-  };
+  const preU3Normalised = normaliseServerGrammarData({
+    contentReleaseId: baseAttempt.contentReleaseId,
+    recentAttempts: [preU3Attempt],
+  }).recentAttempts[0];
+  const postU3Normalised = normaliseServerGrammarData({
+    contentReleaseId: baseAttempt.contentReleaseId,
+    recentAttempts: [postU3Attempt],
+  }).recentAttempts[0];
 
-  assert.deepEqual(preU3Projected, postU3Projected,
-    'Pre-U3 and post-U3 events must project to identical new-field triples for the same semantic case.');
+  // The three U3 authoritative fields must agree.
+  assert.equal(preU3Normalised.firstAttemptIndependent, postU3Normalised.firstAttemptIndependent);
+  assert.equal(preU3Normalised.supportUsed, postU3Normalised.supportUsed);
+  assert.equal(preU3Normalised.supportLevelAtScoring, postU3Normalised.supportLevelAtScoring);
+  assert.equal(preU3Normalised.supportUsed, 'faded');
+  assert.equal(preU3Normalised.supportLevelAtScoring, 1);
 });

--- a/tests/grammar-engine.test.js
+++ b/tests/grammar-engine.test.js
@@ -781,7 +781,7 @@ test('Grammar clear-due goal uses due retry evidence before falling back', () =>
   assert.equal(done.state.summary.answered, 1);
 });
 
-test('Grammar practice settings keep Smart Review teaching support score-aware', () => {
+test('Grammar practice settings: Smart Review teaching items no longer demote independent correctness (U3 contract v2)', () => {
   const oracle = readGrammarLegacyOracle();
   const sample = oracle.templates.find((template) => template.id === 'fronted_adverbial_choose');
   const engine = createServerGrammarEngine({ now: () => 1_777_000_000_000 });
@@ -816,7 +816,9 @@ test('Grammar practice settings keep Smart Review teaching support score-aware',
   assert.equal(start.state.prefs.allowTeachingItems, true);
   assert.equal(start.state.prefs.showDomainBeforeAnswer, false);
   assert.equal(start.state.prefs.speechRate, 1.4);
-  assert.equal(start.state.session.supportLevel, 1);
+  // Under contract v2, Smart + allowTeachingItems no longer forces session support level.
+  assert.equal(start.state.session.supportLevel, 0);
+  assert.equal(start.state.session.supportContractVersion, 2);
 
   const submit = engine.apply({
     learnerId: 'learner-a',
@@ -827,8 +829,17 @@ test('Grammar practice settings keep Smart Review teaching support score-aware',
     payload: { response: sample.correctResponse },
   });
 
-  assert.equal(submit.state.recentAttempts.at(-1).supportLevel, 1);
-  assert.ok(submit.state.mastery.concepts.adverbials.strength < 0.38);
+  const latestAttempt = submit.state.recentAttempts.at(-1);
+  // Independent first-attempt correct in Smart Review: full credit.
+  assert.equal(latestAttempt.supportLevelAtScoring, 0);
+  assert.equal(latestAttempt.supportUsed, 'none');
+  assert.equal(latestAttempt.firstAttemptIndependent, true);
+  // Mastery strength should reflect quality 5 gain (independent correct: +0.13 from 0.25 baseline).
+  assert.equal(
+    submit.state.mastery.concepts.adverbials.strength,
+    0.38,
+    'Smart Review independent correct applies quality-5 +0.13 strength gain (0.25 → 0.38); supported quality would yield 0.29.',
+  );
 });
 
 test('Grammar faded support action marks the next answer as supported', () => {

--- a/tests/worker-grammar-subject-runtime.test.js
+++ b/tests/worker-grammar-subject-runtime.test.js
@@ -354,8 +354,10 @@ test('Grammar command route persists session goals and practice settings', async
   assert.equal(start.response.status, 200, JSON.stringify(start.body));
   assert.equal(start.body.subjectReadModel.session.goal.type, 'timed');
   assert.equal(start.body.subjectReadModel.session.goal.timeLimitMs, 10 * 60_000);
-  assert.equal(start.body.subjectReadModel.session.supportLevel, 1);
-  assert.equal(start.body.subjectReadModel.session.supportGuidance.kind, 'faded');
+  // U3 contract v2: Smart Review + allowTeachingItems no longer forces session-level
+  // support promotion; independent first-attempt correct gets full mastery gain.
+  assert.equal(start.body.subjectReadModel.session.supportLevel, 0);
+  assert.equal(start.body.subjectReadModel.session.supportGuidance, null);
 
   DB.close();
 });

--- a/worker/src/subjects/grammar/attempt-support.js
+++ b/worker/src/subjects/grammar/attempt-support.js
@@ -1,0 +1,175 @@
+// Grammar attempt-support contract.
+//
+// Historical shape (pre-U3): each attempt stored `{ supportLevel, attempts }`
+// where supportLevel came from either `supportLevelForMode` (worked=2, faded=1)
+// or `supportLevelForSession` (Smart + allowTeachingItems=true forced 1).
+// That session-level promotion penalised independent first-attempt answers in
+// Smart Review whenever teaching items were enabled, which was unfair.
+//
+// New shape (U3 / supportContractVersion 2): each attempt stores
+//   firstAttemptIndependent: boolean
+//   supportUsed: 'none' | 'nudge' | 'faded' | 'worked' | 'ai-explanation-after-marking'
+//   supportLevelAtScoring: 0 | 1 | 2
+// where support attribution is driven by what actually happened on the attempt
+// (mode + any in-session repair escalation), not by the session's settings.
+//
+// `deriveAttemptSupport` is the single authoritative mapping from legacy
+// fields to new fields. It is used by:
+//   (a) state reload — normalises older `state.recentAttempts[i]` on load
+//   (b) event-log replay — projects older `grammar.answer-submitted` events
+//
+// The same function is called in both paths so state and events cannot drift.
+
+export const SUPPORT_CONTRACT_VERSION = 2;
+
+export const SUPPORT_USED_VALUES = Object.freeze([
+  'none',
+  'nudge',
+  'faded',
+  'worked',
+  'ai-explanation-after-marking',
+]);
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function clampSupportLevel(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return 0;
+  if (numeric >= 2) return 2;
+  if (numeric >= 1) return 1;
+  return 0;
+}
+
+function normaliseSupportUsed(value) {
+  return typeof value === 'string' && SUPPORT_USED_VALUES.includes(value) ? value : '';
+}
+
+function deriveSupportUsedFromLegacy({ mode, supportLevel, attempts }) {
+  const level = clampSupportLevel(supportLevel);
+  const trimmedMode = typeof mode === 'string' ? mode.trim().toLowerCase() : '';
+
+  if (trimmedMode === 'worked') return 'worked';
+  if (trimmedMode === 'faded') return 'faded';
+
+  // Smart + allowTeachingItems used to force session support level 1.
+  // Under contract v2 that's wrong, but for legacy attempts we can only
+  // infer: supportLevel 1 with no faded/worked mode => the old teaching-item
+  // promotion, so attribute `faded` conservatively (the actual UI showed
+  // faded content for that session). Using 'none' would erase support
+  // evidence that the learner was shown.
+  if (level >= 2) return 'worked';
+  if (level >= 1) return 'faded';
+
+  // supportLevel === 0 and mode is not worked/faded. If attempts > 1 the
+  // learner retried, which is a weaker signal than independent but not
+  // support; the review doc considers retry without worked/faded a nudge.
+  const attemptCount = Math.max(1, Number(attempts) || 1);
+  if (attemptCount >= 2) return 'nudge';
+  return 'none';
+}
+
+export function deriveAttemptSupport({ mode, supportLevel, attempts } = {}) {
+  const supportUsed = deriveSupportUsedFromLegacy({ mode, supportLevel, attempts });
+  const attemptCount = Math.max(1, Number(attempts) || 1);
+  let supportLevelAtScoring = 0;
+  if (supportUsed === 'worked') supportLevelAtScoring = 2;
+  else if (supportUsed === 'faded') supportLevelAtScoring = 1;
+  else if (supportUsed === 'ai-explanation-after-marking') supportLevelAtScoring = 0;
+  else if (supportUsed === 'nudge') supportLevelAtScoring = 0;
+  // Fall through: 'none' => 0
+
+  const firstAttemptIndependent = attemptCount === 1 && supportUsed === 'none';
+
+  return {
+    firstAttemptIndependent,
+    supportUsed: supportUsed || 'none',
+    supportLevelAtScoring,
+  };
+}
+
+// Normalise a stored attempt record from disk (which may be pre-U3) into a
+// shape that carries both legacy and new fields. Idempotent — calling on an
+// already-normalised record returns the same shape.
+export function normaliseStoredAttempt(attempt) {
+  if (!isPlainObject(attempt)) return attempt;
+  const existingSupportUsed = normaliseSupportUsed(attempt.supportUsed);
+  if (existingSupportUsed && typeof attempt.supportLevelAtScoring === 'number') {
+    // Already U3-shaped; just confirm backcompat fields are consistent.
+    return {
+      ...attempt,
+      firstAttemptIndependent: Boolean(attempt.firstAttemptIndependent),
+      supportUsed: existingSupportUsed,
+      supportLevelAtScoring: clampSupportLevel(attempt.supportLevelAtScoring),
+    };
+  }
+  const mode = typeof attempt.mode === 'string' ? attempt.mode : '';
+  const derived = deriveAttemptSupport({
+    mode,
+    supportLevel: attempt.supportLevel,
+    attempts: attempt.attempts,
+  });
+  return {
+    ...attempt,
+    firstAttemptIndependent: derived.firstAttemptIndependent,
+    supportUsed: derived.supportUsed,
+    supportLevelAtScoring: derived.supportLevelAtScoring,
+  };
+}
+
+// Build the new-shape fields for a fresh attempt submission.
+// `supportUsed` takes precedence when explicitly provided by the command
+// layer (e.g., post-marking AI enrichment). Otherwise derived from the
+// session's mode + the learner's in-session support escalation.
+export function composeAttemptSupport({
+  mode = '',
+  sessionSupportLevel = 0,
+  attempts = 1,
+  supportUsed = null,
+  postMarkingEnrichment = false,
+} = {}) {
+  if (postMarkingEnrichment) {
+    return {
+      firstAttemptIndependent: Math.max(1, Number(attempts) || 1) === 1,
+      supportUsed: 'ai-explanation-after-marking',
+      supportLevelAtScoring: 0,
+    };
+  }
+  const explicit = normaliseSupportUsed(supportUsed);
+  if (explicit) {
+    const attemptCount = Math.max(1, Number(attempts) || 1);
+    let level = 0;
+    if (explicit === 'worked') level = 2;
+    else if (explicit === 'faded') level = 1;
+    return {
+      firstAttemptIndependent: attemptCount === 1 && explicit === 'none',
+      supportUsed: explicit,
+      supportLevelAtScoring: level,
+    };
+  }
+  return deriveAttemptSupport({
+    mode,
+    supportLevel: sessionSupportLevel,
+    attempts,
+  });
+}
+
+// Session-level support promotion. Under contract v1 (pre-U3), Smart Review
+// + allowTeachingItems promoted session support level to 1. Under v2 (U3+),
+// only the mode decides: worked => 2, faded => 1, otherwise 0. Individual
+// attempts escalate via in-session repair (useFadedSupport / showWorkedSolution)
+// which bumps session.supportLevel directly.
+export function supportLevelForSessionWithContract({ mode, prefs = {}, contractVersion = SUPPORT_CONTRACT_VERSION } = {}) {
+  if (typeof mode !== 'string') return 0;
+  const trimmed = mode.trim().toLowerCase();
+  if (trimmed === 'worked') return 2;
+  if (trimmed === 'faded') return 1;
+  if (contractVersion < 2 && trimmed === 'smart') {
+    const allowTeaching = prefs && (prefs.allowTeachingItems === true
+      || prefs.allowTeachingItems === 1
+      || prefs.allowTeachingItems === 'true');
+    if (allowTeaching) return 1;
+  }
+  return 0;
+}

--- a/worker/src/subjects/grammar/engine.js
+++ b/worker/src/subjects/grammar/engine.js
@@ -5,6 +5,13 @@ import {
 import { BadRequestError, NotFoundError } from '../../errors.js';
 import { compileGrammarAiEnrichment } from './ai-enrichment.js';
 import {
+  composeAttemptSupport,
+  deriveAttemptSupport,
+  normaliseStoredAttempt,
+  SUPPORT_CONTRACT_VERSION,
+  supportLevelForSessionWithContract,
+} from './attempt-support.js';
+import {
   createGrammarQuestion,
   evaluateGrammarQuestion,
   GRAMMAR_CONCEPTS,
@@ -308,7 +315,12 @@ export function normaliseServerGrammarData(rawValue) {
       }))
       : [],
     misconceptions: isPlainObject(raw.misconceptions) ? cloneSerialisable(raw.misconceptions) : {},
-    recentAttempts: Array.isArray(raw.recentAttempts) ? raw.recentAttempts.slice(-80).map(cloneSerialisable) : [],
+    // Normalise older attempts on load so the U3 item-level fields
+    // (firstAttemptIndependent / supportUsed / supportLevelAtScoring) are
+    // always present downstream, even for pre-U3 stored state.
+    recentAttempts: Array.isArray(raw.recentAttempts)
+      ? raw.recentAttempts.slice(-80).map((entry) => normaliseStoredAttempt(cloneSerialisable(entry)))
+      : [],
     aiEnrichment: normalisePersistentAiEnrichment(raw.aiEnrichment),
   };
 }
@@ -465,9 +477,14 @@ function supportLevelForMode(mode) {
   return 0;
 }
 
-function supportLevelForSession(mode, prefs = {}) {
-  if (mode === 'smart' && normaliseBoolean(prefs.allowTeachingItems, false)) return 1;
-  return supportLevelForMode(mode);
+function supportLevelForSession(mode, prefs = {}, session = null) {
+  // Under contract v2 (the new default) Smart + allowTeachingItems no longer
+  // forces session support level 1. Sessions started before U3 shipped keep
+  // contract v1 semantics via their stamped `supportContractVersion` so that
+  // mid-flight submissions honour the contract their UI opened under.
+  const contractVersion = (session && Number(session.supportContractVersion))
+    || SUPPORT_CONTRACT_VERSION;
+  return supportLevelForSessionWithContract({ mode, prefs, contractVersion });
 }
 
 function sessionTypeForMode(mode) {
@@ -1002,6 +1019,7 @@ function startSession(state, payload, nowTs, learnerId) {
     currentItem: firstItem,
     attemptsForCurrent: 0,
     supportLevel: supportLevelForSession(mode, state.prefs),
+    supportContractVersion: SUPPORT_CONTRACT_VERSION,
     goal: sessionGoal,
     repair: {
       retryingCurrent: false,
@@ -1372,7 +1390,7 @@ function startSimilarProblem(state, nowTs) {
   session.currentIndex = Number(session.currentIndex) + 1;
   session.currentItem = item;
   session.attemptsForCurrent = 0;
-  session.supportLevel = supportLevelForSession(session.mode, state.prefs);
+  session.supportLevel = supportLevelForSession(session.mode, state.prefs, session);
   session.targetCount = Math.max(Number(session.targetCount) || 0, Number(session.answered) + 1);
   if (isPlainObject(session.goal) && session.goal.type === 'questions') {
     session.goal.targetCount = session.targetCount;
@@ -1411,7 +1429,7 @@ function continueSession(state, nowTs) {
     nowTs,
   });
   session.attemptsForCurrent = 0;
-  session.supportLevel = supportLevelForSession(session.mode, state.prefs);
+  session.supportLevel = supportLevelForSession(session.mode, state.prefs, session);
   state.phase = 'session';
   state.awaitingAdvance = false;
   state.feedback = null;
@@ -1426,6 +1444,9 @@ export function applyGrammarAttemptToState(state, {
   attempts = 1,
   requestId = 'attempt',
   now = Date.now(),
+  mode = '',
+  supportUsed = null,
+  postMarkingEnrichment = false,
 } = {}) {
   if (!item || item.contentReleaseId !== GRAMMAR_CONTENT_RELEASE_ID) {
     throw new BadRequestError('Grammar content release does not match this attempt.', {
@@ -1458,7 +1479,22 @@ export function applyGrammarAttemptToState(state, {
     });
   }
   const nowTs = timestamp(now);
-  const quality = answerQuality(result, { supportLevel, attempts });
+  // Compose item-level support fields. Under contract v2, post-marking AI
+  // enrichment never reduces mastery gain, and `supportUsed` takes precedence
+  // over the session-derived level when the command layer names it.
+  const attemptSupport = composeAttemptSupport({
+    mode,
+    sessionSupportLevel: supportLevel,
+    attempts,
+    supportUsed,
+    postMarkingEnrichment,
+  });
+  // answerQuality still uses `supportLevelAtScoring` to compute the gain.
+  // Dual-write: keep legacy `supportLevel` for backcompat readers.
+  const quality = answerQuality(result, {
+    supportLevel: attemptSupport.supportLevelAtScoring,
+    attempts,
+  });
   const conceptIds = (question.skillIds || []).slice();
   const statusesBefore = new Map(conceptIds.map((conceptId) => [
     conceptId,
@@ -1484,8 +1520,14 @@ export function applyGrammarAttemptToState(state, {
     conceptIds,
     response: cloneSerialisable(normalisedResponse) || {},
     result: cloneSerialisable(result) || {},
-    supportLevel,
+    // Legacy fields (kept for one release for event-log / backcompat readers).
+    supportLevel: attemptSupport.supportLevelAtScoring,
     attempts,
+    // U3 item-level fields (new authoritative shape).
+    firstAttemptIndependent: attemptSupport.firstAttemptIndependent,
+    supportUsed: attemptSupport.supportUsed,
+    supportLevelAtScoring: attemptSupport.supportLevelAtScoring,
+    mode: typeof mode === 'string' ? mode : '',
     createdAt: nowTs,
   };
   state.recentAttempts = [...(state.recentAttempts || []), attempt].slice(-80);
@@ -1505,8 +1547,15 @@ export function applyGrammarAttemptToState(state, {
     maxScore: result.maxScore,
     correct: Boolean(result.correct),
     misconception: result.misconception || null,
-    supportLevel,
+    // Dual-write: legacy `supportLevel` plus the new U3 item-level fields so
+    // pre-U3 and post-U3 event-log readers both see consistent projections.
+    supportLevel: attemptSupport.supportLevelAtScoring,
     attempts,
+    firstAttemptIndependent: attemptSupport.firstAttemptIndependent,
+    supportUsed: attemptSupport.supportUsed,
+    supportLevelAtScoring: attemptSupport.supportLevelAtScoring,
+    mode: typeof mode === 'string' ? mode : '',
+    supportContractVersion: SUPPORT_CONTRACT_VERSION,
     createdAt: nowTs,
   }];
   if (result.misconception) {
@@ -1570,7 +1619,7 @@ function submitAnswer(state, payload, command, nowTs) {
   }
   if (sessionGoalExpired(session, nowTs)) return completeSession(state, nowTs, command);
   const response = isPlainObject(payload.response) ? payload.response : (isPlainObject(payload.answer) ? payload.answer : { answer: payload.answer ?? '' });
-  const modeSupportLevel = Math.max(0, Number(session.supportLevel) || supportLevelForSession(session.mode, state.prefs));
+  const modeSupportLevel = Math.max(0, Number(session.supportLevel) || supportLevelForSession(session.mode, state.prefs, session));
   const requestedSupportLevel = Number(payload.supportLevel ?? modeSupportLevel) || 0;
   if (requestedSupportLevel > modeSupportLevel) {
     throw new BadRequestError('This Grammar mode does not allow pre-answer support.', {
@@ -1590,6 +1639,7 @@ function submitAnswer(state, payload, command, nowTs) {
     attempts: session.attemptsForCurrent,
     requestId: command.requestId,
     now: nowTs,
+    mode: session.mode,
   });
   if (!retryingCurrent) {
     session.answered += 1;

--- a/worker/src/subjects/grammar/engine.js
+++ b/worker/src/subjects/grammar/engine.js
@@ -964,6 +964,7 @@ function startSession(state, payload, nowTs, learnerId) {
       currentItem: questions[0]?.item || null,
       attemptsForCurrent: 0,
       supportLevel: 0,
+      supportContractVersion: SUPPORT_CONTRACT_VERSION,
       goal: sessionGoal,
       repair: {
         retryingCurrent: false,
@@ -1189,6 +1190,7 @@ function finishMiniTest(state, nowTs, command, { timedOut = false } = {}) {
         attempts: 1,
         requestId: `${command.requestId || 'mini-test'}.${index + 1}`,
         now: nowTs,
+        mode: state?.session?.mode || 'satsset',
       });
       entry.marked = {
         response: cloneSerialisable(applied.response) || {},

--- a/worker/src/subjects/grammar/read-models.js
+++ b/worker/src/subjects/grammar/read-models.js
@@ -504,6 +504,10 @@ function recentActivityFromAttempts(attempts = []) {
     .reverse()
     .map((attempt) => {
       const result = isPlainObject(attempt?.result) ? attempt.result : {};
+      const supportUsed = typeof attempt?.supportUsed === 'string' ? attempt.supportUsed : 'none';
+      const supportLevelAtScoring = Number.isFinite(Number(attempt?.supportLevelAtScoring))
+        ? Math.max(0, Math.min(2, Number(attempt.supportLevelAtScoring)))
+        : Math.max(0, Math.min(2, Number(attempt?.supportLevel) || 0));
       return {
         subjectId: 'grammar',
         templateId: typeof attempt?.templateId === 'string' ? attempt.templateId : '',
@@ -515,6 +519,11 @@ function recentActivityFromAttempts(attempts = []) {
         score: Number(result.score) || 0,
         maxScore: Number(result.maxScore) || 1,
         misconception: typeof result.misconception === 'string' ? result.misconception : '',
+        // U3 item-level support attribution. Older attempts have been
+        // normalised at load time so these fields are always present.
+        firstAttemptIndependent: Boolean(attempt?.firstAttemptIndependent),
+        supportUsed,
+        supportLevelAtScoring,
         createdAt: asTs(attempt?.createdAt, 0),
       };
     });


### PR DESCRIPTION
## Summary

**U3 of 8** in the Grammar Perfection Pass plan. Addresses Review Issue 3: support scoring was session-level, and Smart Review + \`allowTeachingItems\` demoted independent first-attempt correctness.

### The problem

Old behaviour: \`supportLevelForSession('smart', { allowTeachingItems: true })\` returned \`1\`, which became \`session.supportLevel = 1\` and flowed into every attempt as \`supportLevel=1\`. An independent first-attempt correct answer in Smart Review got **quality 3.4 instead of 5**, losing ~50% of the mastery gain it deserved.

### The fix: three-layer migration

| Layer | What changes | Where |
|---|---|---|
| **State reload** | Pre-U3 attempts gain new fields on load | \`normaliseServerGrammarData\` → \`normaliseStoredAttempt\` |
| **Event emission** | \`grammar.answer-submitted\` dual-writes legacy + new fields + \`supportContractVersion: 2\` | \`applyGrammarAttemptToState\` |
| **In-flight sessions** | \`session.supportContractVersion\` stamped at start; \`submit-answer\` honours the stamped version | \`supportLevelForSession(mode, prefs, session)\` |

New fields on every attempt:
- \`firstAttemptIndependent: boolean\`
- \`supportUsed: 'none' | 'nudge' | 'faded' | 'worked' | 'ai-explanation-after-marking'\`
- \`supportLevelAtScoring: 0 | 1 | 2\`

Shared derivation function (\`deriveAttemptSupport\`) is used by both state reload AND event replay, so projections cannot drift.

### Contract v2 behaviour change

- Smart + \`allowTeachingItems: true\` → session support level is now **0**, not 1. Independent correct gets quality 5 (+0.13 strength) instead of 3.4 (+0.04).
- Mode-based promotion (\`worked\`→2, \`faded\`→1) is unchanged.
- Item-level escalation via \`useFadedSupport\` / \`showWorkedSolution\` still bumps \`session.supportLevel\` mid-session; that flows into \`supportLevelAtScoring\` on the next submit.
- Post-marking AI explanation → \`supportUsed: 'ai-explanation-after-marking'\`, \`supportLevelAtScoring: 0\` (never reduces gain).

### Files

- New: \`worker/src/subjects/grammar/attempt-support.js\` — derivation + composition + contract helpers.
- Modified: \`worker/src/subjects/grammar/engine.js\` — wiring (session stamping, dual-write, normalisation).
- Modified: \`worker/src/subjects/grammar/read-models.js\` — \`recentActivityFromAttempts\` exposes new fields.
- New: \`tests/grammar-attempt-support.test.js\` — 20 tests (derivation exhaustiveness, composition precedence, AI-post-marking, load-time normalisation, pre/post-U3 event equivalence).
- Modified: \`tests/grammar-engine.test.js\` + \`tests/worker-grammar-subject-runtime.test.js\` — two existing tests updated to match v2 contract.

## Test plan

- [x] \`tests/grammar-attempt-support.test.js\` → 20/20 pass
- [x] \`tests/grammar-engine.test.js\` → 32/32 pass
- [x] \`tests/worker-grammar-subject-runtime.test.js\` → 32/32 pass
- [x] \`tests/grammar-selection.test.js\` → 12/12 pass
- [x] \`tests/grammar-functionality-completeness.test.js\` → 9/9 pass
- [x] Full \`npm test\` → +31 new tests passing, 0 new failures (pre-existing 40 worktree react-module-resolution failures unchanged)
- [ ] Independent reviewer pass
- [ ] Reviewer re-check after any follower updates
- [ ] Merge when no blockers

## Next

U4 (strict mini-test SSR QA) depends on U3 for the item-level support attribution.