### PR TITLE
fix(grammar): Enter-key continue + selection recent-template dedup

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -40,6 +40,7 @@ import {
 import { createSpellingReadModelService } from './subjects/spelling/client-read-models.js';
 import { getOverallSpellingStats } from './subjects/spelling/module.js';
 import { resolveSpellingShortcut } from './subjects/spelling/shortcuts.js';
+import { resolveGrammarShortcut } from './subjects/grammar/shortcuts.js';
 import {
   monsterSummary,
   monsterSummaryFromSpellingAnalytics,
@@ -2223,7 +2224,9 @@ document.addEventListener('keydown', (event) => {
 }, true);
 
 globalThis.addEventListener?.('keydown', (event) => {
-  const shortcut = resolveSpellingShortcut(event, store.getState());
+  const appState = store.getState();
+  const shortcut = resolveSpellingShortcut(event, appState)
+    || resolveGrammarShortcut(event, appState);
   if (!shortcut) return;
   if (shortcut.preventDefault) event.preventDefault();
   if (shortcut.focusSelector) {

--- a/src/platform/app/create-app-controller.js
+++ b/src/platform/app/create-app-controller.js
@@ -3,6 +3,7 @@ import { createSubjectRuntimeBoundary } from '../core/subject-runtime.js';
 import { createEventRuntime, createPracticeStreakSubscriber } from '../events/index.js';
 import { createSpellingAutoAdvanceController } from '../../subjects/spelling/auto-advance.js';
 import { resolveSpellingShortcut } from '../../subjects/spelling/shortcuts.js';
+import { resolveGrammarShortcut } from '../../subjects/grammar/shortcuts.js';
 import {
   normaliseBufferedGeminiVoice,
   normaliseTtsProvider,
@@ -457,7 +458,9 @@ export function createAppController({
   }
 
   function keydown(eventLike = {}) {
-    const shortcut = resolveSpellingShortcut(eventLike, store.getState());
+    const appState = store.getState();
+    const shortcut = resolveSpellingShortcut(eventLike, appState)
+      || resolveGrammarShortcut(eventLike, appState);
     if (!shortcut) return false;
     if (shortcut.action) {
       dispatch(shortcut.action, shortcut.data || {});

--- a/src/subjects/grammar/shortcuts.js
+++ b/src/subjects/grammar/shortcuts.js
@@ -1,0 +1,35 @@
+import { GRAMMAR_SUBJECT_ID, normaliseGrammarReadModel } from './metadata.js';
+
+function isTypingElement(target) {
+  if (!target) return false;
+  if (target.isContentEditable) return true;
+  const tagName = String(target.tagName || '').toUpperCase();
+  return tagName === 'INPUT' || tagName === 'TEXTAREA' || tagName === 'SELECT';
+}
+
+function isMiniTestSession(session) {
+  return session && typeof session === 'object' && session.type === 'mini-set';
+}
+
+export function resolveGrammarShortcut(event, appState) {
+  const subjectId = appState?.route?.subjectId || null;
+  const tab = appState?.route?.tab || 'practice';
+  if (subjectId !== GRAMMAR_SUBJECT_ID || tab !== 'practice') return null;
+
+  if (event?.key !== 'Enter') return null;
+  if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return null;
+  if (event.repeat) return null;
+
+  if (isTypingElement(event?.target)) return null;
+
+  const grammar = normaliseGrammarReadModel(
+    appState?.subjectUi?.[GRAMMAR_SUBJECT_ID],
+    appState?.learners?.selectedId || '',
+  );
+
+  if (grammar.phase !== 'feedback' && !grammar.awaitingAdvance) return null;
+  if (isMiniTestSession(grammar.session)) return null;
+  if (grammar.pendingCommand) return null;
+
+  return { action: 'grammar-continue', preventDefault: true };
+}

--- a/tests/grammar-shortcuts.test.js
+++ b/tests/grammar-shortcuts.test.js
@@ -1,0 +1,106 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { resolveGrammarShortcut } from '../src/subjects/grammar/shortcuts.js';
+
+function buildAppState({
+  subjectId = 'grammar',
+  tab = 'practice',
+  phase = 'feedback',
+  awaitingAdvance = true,
+  sessionType = 'practice',
+  pendingCommand = '',
+} = {}) {
+  return {
+    route: { subjectId, tab },
+    learners: { selectedId: 'learner-1' },
+    subjectUi: {
+      grammar: {
+        phase,
+        awaitingAdvance,
+        pendingCommand,
+        session: { id: 's-1', type: sessionType },
+      },
+    },
+  };
+}
+
+test('resolveGrammarShortcut dispatches grammar-continue when Enter hits a feedback phase', () => {
+  const result = resolveGrammarShortcut(
+    { key: 'Enter', target: { tagName: 'BODY' } },
+    buildAppState(),
+  );
+  assert.deepEqual(result, { action: 'grammar-continue', preventDefault: true });
+});
+
+test('resolveGrammarShortcut ignores Enter while the user is typing in a textarea', () => {
+  const result = resolveGrammarShortcut(
+    { key: 'Enter', target: { tagName: 'TEXTAREA' } },
+    buildAppState(),
+  );
+  assert.equal(result, null);
+});
+
+test('resolveGrammarShortcut ignores Enter while the user is typing in an input', () => {
+  const result = resolveGrammarShortcut(
+    { key: 'Enter', target: { tagName: 'INPUT', name: 'answer' } },
+    buildAppState(),
+  );
+  assert.equal(result, null);
+});
+
+test('resolveGrammarShortcut ignores Enter outside the Grammar practice tab', () => {
+  const result = resolveGrammarShortcut(
+    { key: 'Enter', target: { tagName: 'BODY' } },
+    buildAppState({ subjectId: 'spelling' }),
+  );
+  assert.equal(result, null);
+});
+
+test('resolveGrammarShortcut ignores Enter when Grammar is not in feedback / awaiting advance', () => {
+  const result = resolveGrammarShortcut(
+    { key: 'Enter', target: { tagName: 'BODY' } },
+    buildAppState({ phase: 'session', awaitingAdvance: false }),
+  );
+  assert.equal(result, null);
+});
+
+test('resolveGrammarShortcut ignores Enter during a strict mini-test', () => {
+  const result = resolveGrammarShortcut(
+    { key: 'Enter', target: { tagName: 'BODY' } },
+    buildAppState({ sessionType: 'mini-set' }),
+  );
+  assert.equal(result, null);
+});
+
+test('resolveGrammarShortcut ignores Enter while a Grammar command is in flight', () => {
+  const result = resolveGrammarShortcut(
+    { key: 'Enter', target: { tagName: 'BODY' } },
+    buildAppState({ pendingCommand: 'continue-session' }),
+  );
+  assert.equal(result, null);
+});
+
+test('resolveGrammarShortcut ignores modifier keys combined with Enter', () => {
+  const result = resolveGrammarShortcut(
+    { key: 'Enter', shiftKey: true, target: { tagName: 'BODY' } },
+    buildAppState(),
+  );
+  assert.equal(result, null);
+});
+
+test('resolveGrammarShortcut ignores key-repeat Enter events so holding does not chain continues', () => {
+  const result = resolveGrammarShortcut(
+    { key: 'Enter', repeat: true, target: { tagName: 'BODY' } },
+    buildAppState(),
+  );
+  assert.equal(result, null);
+});
+
+test('resolveGrammarShortcut ignores non-Enter keys', () => {
+  const result = resolveGrammarShortcut(
+    { key: 'Escape', target: { tagName: 'BODY' } },
+    buildAppState(),
+  );
+  assert.equal(result, null);
+});

--- a/tests/react-grammar-surface.test.js
+++ b/tests/react-grammar-surface.test.js
@@ -78,6 +78,52 @@ test('Grammar surface runs from setup to Worker-style feedback and summary', () 
   assert.match(harness.render(), /Grammar retrieval practice/);
 });
 
+test('Grammar Enter key advances from feedback to the next question', () => {
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+  const sample = grammarOracleSample();
+
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-start', {
+    payload: {
+      roundLength: 2,
+      templateId: sample.id,
+      seed: sample.sample.seed,
+    },
+  });
+
+  harness.dispatch('grammar-submit-form', {
+    formData: grammarResponseFormData(sample.correctResponse),
+  });
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'feedback');
+
+  assert.equal(harness.keydown({ key: 'Enter', target: { tagName: 'BODY' } }), true);
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'session');
+});
+
+test('Grammar Enter key is ignored while focus is inside a typing element', () => {
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+  const sample = grammarOracleSample();
+
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-start', {
+    payload: {
+      roundLength: 2,
+      templateId: sample.id,
+      seed: sample.sample.seed,
+    },
+  });
+
+  harness.dispatch('grammar-submit-form', {
+    formData: grammarResponseFormData(sample.correctResponse),
+  });
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'feedback');
+
+  harness.keydown({ key: 'Enter', target: { tagName: 'TEXTAREA' } });
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'feedback');
+});
+
 test('Grammar surface runs KS2 mini-set mode with delayed feedback and end review', () => {
   const storage = installMemoryStorage();
   const harness = createGrammarHarness({ storage });


### PR DESCRIPTION
## Summary

- **Bug 1 (Enter key):** Pressing Enter during Grammar feedback now advances to the next question through a new `resolveGrammarShortcut` module, mirroring `resolveSpellingShortcut`. The primary submit button legitimately disables in feedback phase to stop double-submits, but that also suppressed the browser's default Enter-to-submit. Grammar had no equivalent shortcut layer; now it does.
- **Bug 2 (duplicate templates):** Perfection-pass Unit U2 extracted — `buildGrammarPracticeQueue` + `buildGrammarMiniPack` are now a pure, seed-deterministic module under `worker/src/subjects/grammar/selection.js`. Weights penalise templates served in the last 3 picks, boost candidates whose concepts appear in recent misses, and boost weak question-type candidates. Mini-sets enforce a per-template repeat cap unless the focused pool is smaller than the set.

## Why both in one PR

James specified SDLC cycle: PR → independent reviewer → review-follower → independent reviewer → merge. Both fixes touch the Grammar module, share review context, and the Bug 2 root cause is named in the perfection-pass plan as Issue 2 / Unit U2. Splitting would double the review overhead without separating risk.

## Scope boundaries

- Perfection-pass Units U3-U8 remain ``planned`` — this PR lands U2 only.
- No `contentReleaseId` bump (empty-state weighting is identical to the pre-U2 baseline; legacy oracle still pins marking fidelity).
- No UI-level Enter-to-submit changes for radio / choice inputs — James chose the narrowest scope (feedback-only Enter handling).

## Test plan

- [x] `npm test tests/grammar-shortcuts.test.js` — 10 pass
- [x] `npm test tests/grammar-selection.test.js` — 9 pass
- [x] `npm test tests/grammar-engine.test.js` — 33 pass (32 existing + 1 new no-dupe)
- [x] `npm test tests/react-grammar-surface.test.js` — 31 pass (29 existing + 2 new Enter-key)
- [x] `npm test tests/worker-grammar-subject-runtime.test.js` — 26 pass (existing, unchanged)
- [x] `npm test tests/grammar-rewards.test.js` + `grammar-functionality-completeness` + `grammar-production-smoke` + `grammar-speech` — all 139 Grammar tests pass
- [x] `npm test` overall — 858/866 pass; the 7 failing `client bundle audit` tests are **pre-existing on main** (verified by `git stash`-ing changes and re-running — same 7 fail). Not regressed by this PR.
- [ ] Manual production UI check (post-deploy): sign in at `ks2.eugnel.uk`, answer a Grammar question, verify Enter advances past feedback; run a 12-question focus round and verify no back-to-back duplicates.

## Files changed

**Created:**
- `src/subjects/grammar/shortcuts.js` — `resolveGrammarShortcut`
- `worker/src/subjects/grammar/selection.js` — `buildGrammarPracticeQueue` + `buildGrammarMiniPack` + `GRAMMAR_SELECTION_WEIGHTS`
- `tests/grammar-shortcuts.test.js` — 10 shortcut scenarios
- `tests/grammar-selection.test.js` — 9 selection scenarios

**Modified:**
- `src/main.js` — wire Grammar shortcut after Spelling in global keydown listener
- `src/platform/app/create-app-controller.js` — wire Grammar shortcut into `controller.keydown` for SSR tests
- `worker/src/subjects/grammar/engine.js` — `weightedTemplatePick`, `buildGrammarMiniSet`, `buildStrictMiniTestItems` now thin wrappers over `selection.js`
- `tests/grammar-engine.test.js` — new no-duplicate mini-set assertion
- `tests/react-grammar-surface.test.js` — new Enter-key behaviour assertions
- `docs/plans/2026-04-25-002-feat-grammar-perfection-pass-plan.md` — U2 status annotation

## Plan reference

`C:\Users\B52620\.claude\plans\floofy-stirring-marshmallow.md`