### PR TITLE
fix(punctuation): recursive fail-closed scan across Worker read-model (Phase 2 U2)

### DIFF
--- a/scripts/punctuation-production-smoke.mjs
+++ b/scripts/punctuation-production-smoke.mjs
@@ -18,6 +18,10 @@ import {
   subjectCommand,
 } from './lib/production-smoke.mjs';
 
+// Kept aligned with worker/src/subjects/punctuation/read-models.js
+// FORBIDDEN_READ_MODEL_KEYS. Any new forbidden key must be added in both
+// places — the Worker enforces the contract at build time, the smoke scans
+// enforce it at deploy time.
 const FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS = new Set([
   'accepted',
   'answers',

--- a/tests/punctuation-read-models.test.js
+++ b/tests/punctuation-read-models.test.js
@@ -1,0 +1,224 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildPunctuationReadModel } from '../worker/src/subjects/punctuation/read-models.js';
+
+const BASE_STATE = {
+  phase: 'summary',
+  session: null,
+  feedback: null,
+  summary: {
+    completedAt: 1_777_000_000_000,
+    correctCount: 2,
+    total: 4,
+    mode: 'smart',
+    releaseId: 'punctuation-r4-full-14-skill-structure',
+    sessionId: 'session-abc',
+    reviewRows: [
+      {
+        itemId: 'sp_choose_reporting_comma',
+        mode: 'choose',
+        correct: true,
+        skillIds: ['speech'],
+        misconceptionTags: [],
+        displayCorrection: '"We made it!" shouted Noah.',
+      },
+    ],
+    misconceptionTags: ['speech.quote_missing'],
+  },
+  availability: { status: 'ready', code: null, message: '' },
+};
+
+test('safeSummary passes a clean payload through redaction without throwing', () => {
+  const result = buildPunctuationReadModel({
+    learnerId: 'learner-a',
+    state: BASE_STATE,
+    prefs: {},
+    stats: { publishedRewardUnits: 14, securedRewardUnits: 0 },
+  });
+  assert.equal(result.phase, 'summary');
+  assert.equal(result.summary.correctCount, 2);
+  assert.equal(result.summary.mode, 'smart');
+});
+
+test('safeSummary fails closed when a forbidden key is present anywhere in the summary', () => {
+  const leaky = {
+    ...BASE_STATE,
+    summary: {
+      ...BASE_STATE.summary,
+      accepted: ['"We made it!" shouted Noah.'],
+    },
+  };
+  assert.throws(() => buildPunctuationReadModel({
+    learnerId: 'learner-a',
+    state: leaky,
+    prefs: {},
+    stats: {},
+  }), /server-only .*field: accepted/);
+});
+
+test('safeSummary fails closed on a nested forbidden key inside a review row', () => {
+  const leaky = {
+    ...BASE_STATE,
+    summary: {
+      ...BASE_STATE.summary,
+      reviewRows: [
+        {
+          ...BASE_STATE.summary.reviewRows[0],
+          validator: { facets: ['speech::insert'] },
+        },
+      ],
+    },
+  };
+  assert.throws(() => buildPunctuationReadModel({
+    learnerId: 'learner-a',
+    state: leaky,
+    prefs: {},
+    stats: {},
+  }), /server-only .*field: validator/);
+});
+
+test('safeSummary fails closed on nested seed and hiddenQueue fields', () => {
+  const leaky = {
+    ...BASE_STATE,
+    summary: {
+      ...BASE_STATE.summary,
+      nextQueue: { hiddenQueue: ['sp_item_1'] },
+    },
+  };
+  assert.throws(() => buildPunctuationReadModel({
+    learnerId: 'learner-a',
+    state: leaky,
+    prefs: {},
+    stats: {},
+  }), /server-only .*field: hiddenQueue/);
+});
+
+test('feedback allowlist already strips forbidden fields before the recursive scan', () => {
+  // Feedback goes through safeFeedback's allowlist, so a forbidden field
+  // on the raw feedback never reaches the payload. The scan is belt-and-
+  // braces for paths that are cloneSerialisable'd (prefs, stats, analytics,
+  // summary) — feedback is defended earlier.
+  const feedbackState = {
+    phase: 'feedback',
+    session: {
+      id: 'session-abc',
+      mode: 'smart',
+      length: 4,
+      answeredCount: 1,
+      correctCount: 1,
+      currentItem: { id: 'ok', mode: 'choose', prompt: '', stem: '' },
+    },
+    feedback: {
+      kind: 'error',
+      headline: 'Missing quote',
+      body: 'Speech punctuation must go inside the closing quote.',
+      correctIndex: 2,
+    },
+    availability: { status: 'ready', code: null, message: '' },
+  };
+  const result = buildPunctuationReadModel({
+    learnerId: 'learner-a',
+    state: feedbackState,
+    prefs: {},
+    stats: {},
+  });
+  assert.equal(result.feedback.kind, 'error');
+  assert.equal('correctIndex' in result.feedback, false);
+});
+
+test('analytics payload fails closed on forbidden fields', () => {
+  const analyticsLeak = {
+    byItemMode: [{ id: 'insert', attempts: 2, correct: 1, rubric: { facets: [] } }],
+  };
+  assert.throws(() => buildPunctuationReadModel({
+    learnerId: 'learner-a',
+    state: BASE_STATE,
+    prefs: {},
+    stats: {},
+    analytics: analyticsLeak,
+  }), /server-only .*field: rubric/);
+});
+
+test('contextPack allowlist strips forbidden fields before the recursive scan', () => {
+  // contextPack goes through safeContextPackSummary's allowlist, so a
+  // forbidden field never reaches the payload. Defence-in-depth happens
+  // earlier; the scan covers clone-passthrough paths instead.
+  const result = buildPunctuationReadModel({
+    learnerId: 'learner-a',
+    state: BASE_STATE,
+    prefs: {},
+    stats: {},
+    contextPack: {
+      status: 'ready',
+      acceptedCount: 3,
+      rejectedCount: 0,
+      atomKinds: ['noun'],
+      generator: { seed: 'leak' },
+    },
+  });
+  assert.equal(result.contextPack.acceptedCount, 3);
+  assert.equal('generator' in result.contextPack, false);
+});
+
+test('stats payload fails closed on forbidden fields', () => {
+  assert.throws(() => buildPunctuationReadModel({
+    learnerId: 'learner-a',
+    state: BASE_STATE,
+    prefs: {},
+    stats: { publishedRewardUnits: 14, securedRewardUnits: 0, hiddenQueue: ['x'] },
+  }), /server-only .*field: hiddenQueue/);
+});
+
+test('content payload fails closed on forbidden fields', () => {
+  assert.throws(() => buildPunctuationReadModel({
+    learnerId: 'learner-a',
+    state: BASE_STATE,
+    prefs: {},
+    stats: {},
+    content: {
+      releaseId: 'r4',
+      skills: [],
+      unpublished: { peek: 'leak' },
+    },
+  }), /server-only .*field: unpublished/);
+});
+
+test('availability payload fails closed on forbidden fields', () => {
+  const leakyState = {
+    ...BASE_STATE,
+    availability: { status: 'ready', code: null, message: '', seed: 'x' },
+  };
+  assert.throws(() => buildPunctuationReadModel({
+    learnerId: 'learner-a',
+    state: leakyState,
+    prefs: {},
+    stats: {},
+  }), /server-only .*field: seed/);
+});
+
+test('clean payloads with all allowed fields pass redaction', () => {
+  const result = buildPunctuationReadModel({
+    learnerId: 'learner-a',
+    state: BASE_STATE,
+    prefs: { mode: 'smart', roundLength: '4' },
+    stats: { total: 14, secure: 0, publishedRewardUnits: 14, securedRewardUnits: 0 },
+    analytics: { bySessionMode: [], byItemMode: [], weakestFacets: [] },
+    content: {
+      releaseId: 'punctuation-r4-full-14-skill-structure',
+      skills: [{ id: 'speech', name: 'Speech', clusterId: 'speech' }],
+    },
+    contextPack: {
+      status: 'ready',
+      acceptedCount: 3,
+      rejectedCount: 0,
+      atomKinds: ['noun'],
+      affectedGeneratorFamilies: ['speech.basic'],
+      generatedItemCount: 3,
+    },
+  });
+  assert.equal(result.phase, 'summary');
+  assert.equal(result.summary.correctCount, 2);
+  assert.equal(result.contextPack.acceptedCount, 3);
+  assert.equal(result.content.skills[0].id, 'speech');
+});

--- a/tests/punctuation-read-models.test.js
+++ b/tests/punctuation-read-models.test.js
@@ -197,6 +197,28 @@ test('availability payload fails closed on forbidden fields', () => {
   }), /server-only .*field: seed/);
 });
 
+test('scan catches rawGenerator, queueItemIds, and responses at any depth', () => {
+  for (const key of ['rawGenerator', 'queueItemIds', 'responses']) {
+    const leaky = {
+      ...BASE_STATE,
+      summary: {
+        ...BASE_STATE.summary,
+        metadata: { [key]: { payload: 'leak' } },
+      },
+    };
+    assert.throws(
+      () => buildPunctuationReadModel({
+        learnerId: 'learner-a',
+        state: leaky,
+        prefs: {},
+        stats: {},
+      }),
+      new RegExp(`server-only .*field: ${key}`),
+      `forbidden key ${key} must trip the recursive scan`,
+    );
+  }
+});
+
 test('clean payloads with all allowed fields pass redaction', () => {
   const result = buildPunctuationReadModel({
     learnerId: 'learner-a',

--- a/worker/src/subjects/punctuation/read-models.js
+++ b/worker/src/subjects/punctuation/read-models.js
@@ -16,6 +16,17 @@ const FORBIDDEN_ITEM_FIELDS = new Set([
   'unpublished',
 ]);
 
+// Extends FORBIDDEN_ITEM_FIELDS with keys that could leak through summary,
+// feedback, analytics, context-pack, or availability payloads. Kept aligned
+// with scripts/punctuation-production-smoke.mjs:FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS
+// so smoke-side and Worker-side guards share one contract.
+const FORBIDDEN_READ_MODEL_KEYS = new Set([
+  ...FORBIDDEN_ITEM_FIELDS,
+  'rawGenerator',
+  'queueItemIds',
+  'responses',
+]);
+
 function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
@@ -162,6 +173,10 @@ function safeFeedback(feedback) {
 
 function safeSummary(summary) {
   if (!isPlainObject(summary)) return null;
+  // cloneSerialisable strips non-JSON values; the subsequent recursive scan
+  // at payload assembly time enforces the forbidden-field contract. Summary
+  // shape is intentionally permissive so new harmless fields can be added
+  // without a code change — only forbidden keys trip the guard.
   return cloneSerialisable(summary);
 }
 
@@ -190,6 +205,22 @@ function assertNoForbiddenItemFields(item) {
   }
 }
 
+function assertNoForbiddenReadModelKeys(value, path = 'punctuation') {
+  if (value == null || typeof value !== 'object') return;
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index += 1) {
+      assertNoForbiddenReadModelKeys(value[index], `${path}[${index}]`);
+    }
+    return;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    if (FORBIDDEN_READ_MODEL_KEYS.has(key)) {
+      throw new Error(`Punctuation read model attempted to expose server-only ${path}.${key} field: ${key}`);
+    }
+    assertNoForbiddenReadModelKeys(child, `${path}.${key}`);
+  }
+}
+
 export function buildPunctuationReadModel({
   learnerId,
   state,
@@ -203,7 +234,7 @@ export function buildPunctuationReadModel({
   const phase = typeof safeState.phase === 'string' ? safeState.phase : 'setup';
   const hideGpsInterimFeedback = safeState.session?.mode === 'gps' && phase !== 'summary';
   if (phase === 'active-item') assertNoForbiddenItemFields(safeState.session?.currentItem);
-  return {
+  const payload = {
     subjectId: 'punctuation',
     learnerId,
     version: 1,
@@ -225,4 +256,13 @@ export function buildPunctuationReadModel({
       skills: safeContentSkills(),
     },
   };
+  // Recursive fail-closed scan across every branch of the payload. Catches
+  // leaked keys introduced by upstream service-state changes that bypass the
+  // per-phase allowlists (e.g. new validator field added inside a review row,
+  // hiddenQueue carried on a nested summary branch, rubric nested inside
+  // analytics). Throws rather than silently stripping so tests and dev runs
+  // surface the leak; production operators monitor via the command route's
+  // error telemetry.
+  assertNoForbiddenReadModelKeys(payload);
+  return payload;
 }


### PR DESCRIPTION
## Summary

- Adds `assertNoForbiddenReadModelKeys` — a recursive scan over the assembled Worker read-model payload — so forbidden server-only fields cannot slip through clone-passthrough branches (summary, analytics, stats, prefs, content, availability).
- Existing per-phase allowlists (`safeCurrentItem`, `safeFeedback`, `safeContextPackSummary`, `safeSession`) remain the primary defence; the recursive scan is belt-and-braces for paths that rely on `cloneSerialisable` without per-field allowlisting.
- Extends the forbidden-key set with `rawGenerator`, `queueItemIds`, `responses` to match `scripts/punctuation-production-smoke.mjs` so Worker and smoke enforce one contract. Documented the alignment rule in a comment on the smoke script.

Part of Punctuation Phase 2 hardening ([U2 in plan](../blob/feat/punctuation-p2-u2-redaction/docs/plans/2026-04-25-002-feat-punctuation-phase2-hardening-plan.md)).

## Test plan

- [x] New `tests/punctuation-read-models.test.js` — 11 tests cover clean payloads and forbidden-key injection at root, nested review rows, analytics, stats, content, availability, and documented allowlist-strip behaviour for feedback/contextPack
- [x] `npx node --test tests/punctuation-read-models.test.js tests/worker-punctuation-runtime.test.js` — 32 tests green
- [x] Full suite: 893 tests / 884 pass / 8 pre-existing failures (bundle-audit expects built bundle; unrelated Grammar surface test pre-existing)
- [ ] CI: full suite green