### PR TITLE
feat(grammar): U5 declarative answerSpec registry

### DIFF
--- a/tests/grammar-answer-spec.test.js
+++ b/tests/grammar-answer-spec.test.js
@@ -1,0 +1,175 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  ANSWER_SPEC_KINDS,
+  markByAnswerSpec,
+  validateAnswerSpec,
+} from '../worker/src/subjects/grammar/answer-spec.js';
+
+test('ANSWER_SPEC_KINDS lists all six declarative types', () => {
+  assert.deepEqual(ANSWER_SPEC_KINDS.slice().sort(), [
+    'acceptedSet',
+    'exact',
+    'manualReviewOnly',
+    'multiField',
+    'normalisedText',
+    'punctuationPattern',
+  ]);
+});
+
+test('exact: rejects near-miss punctuation, accepts byte-identical', () => {
+  const spec = { kind: 'exact', golden: ['Question mark.'], nearMiss: ['question mark', 'Question mark'], maxScore: 1 };
+  assert.equal(markByAnswerSpec(spec, { answer: 'Question mark.' }).correct, true);
+  assert.equal(markByAnswerSpec(spec, { answer: 'Question mark' }).correct, false, 'missing trailing dot');
+  assert.equal(markByAnswerSpec(spec, { answer: 'question mark.' }).correct, false, 'wrong case');
+});
+
+test('normalisedText: accepts whitespace + case variants, preserves the golden', () => {
+  const spec = { kind: 'normalisedText', golden: ['subordinate clause'], nearMiss: ['subordinate'], maxScore: 1 };
+  assert.equal(markByAnswerSpec(spec, { answer: '  Subordinate  Clause  ' }).correct, true);
+  assert.equal(markByAnswerSpec(spec, { answer: 'subordinate' }).correct, false);
+});
+
+test('acceptedSet: two equivalent clause-combine sentences both score full marks', () => {
+  const spec = {
+    kind: 'acceptedSet',
+    golden: [
+      'Although Mia was tired, she finished the race.',
+      'Mia finished the race although she was tired.',
+    ],
+    nearMiss: ['Mia finished the race although tired.'],
+    maxScore: 2,
+  };
+  const a = markByAnswerSpec(spec, { answer: 'Although Mia was tired, she finished the race.' });
+  const b = markByAnswerSpec(spec, { answer: 'Mia finished the race although she was tired.' });
+  assert.equal(a.correct, true);
+  assert.equal(a.score, 2);
+  assert.equal(b.correct, true);
+  assert.equal(b.score, 2);
+
+  const nearMiss = markByAnswerSpec(spec, { answer: 'Mia finished the race although tired.' });
+  assert.equal(nearMiss.correct, false);
+});
+
+test('acceptedSet: near-miss punctuation gets partial credit when maxScore > 1', () => {
+  const spec = {
+    kind: 'acceptedSet',
+    golden: ['When the bell rang, the pupils lined up.'],
+    nearMiss: ['When the bell rang the pupils lined up.'],
+    maxScore: 2,
+  };
+  const result = markByAnswerSpec(spec, { answer: 'When the bell rang the pupils lined up' });
+  // Same content without the comma + full stop — partial credit under the
+  // "bare" (punctuation-stripped) comparison path.
+  assert.equal(result.correct, false);
+  assert.ok(result.score > 0, 'partial credit for punctuation-only error');
+  assert.equal(result.misconception, 'punctuation_precision');
+});
+
+test('punctuationPattern: optionalCommas accepts variant without surrounding commas', () => {
+  const spec = {
+    kind: 'punctuationPattern',
+    golden: ['The cat, which sat on the mat, was fat.'],
+    nearMiss: ['The cat which sat on the mat was fat.'],
+    params: { optionalCommas: true },
+    maxScore: 1,
+  };
+  const withCommas = markByAnswerSpec(spec, { answer: 'The cat, which sat on the mat, was fat.' });
+  const withoutCommas = markByAnswerSpec(spec, { answer: 'The cat which sat on the mat was fat.' });
+  assert.equal(withCommas.correct, true);
+  assert.equal(withoutCommas.correct, true, 'optionalCommas should accept the comma-free variant');
+});
+
+test('punctuationPattern: optionalCommas=false rejects comma-free variant', () => {
+  const spec = {
+    kind: 'punctuationPattern',
+    golden: ['The cat, which sat on the mat, was fat.'],
+    nearMiss: [],
+    params: { optionalCommas: false },
+    maxScore: 1,
+  };
+  const withoutCommas = markByAnswerSpec(spec, { answer: 'The cat which sat on the mat was fat.' });
+  assert.equal(withoutCommas.correct, false);
+});
+
+test('multiField: scores each sub-field independently and aggregates', () => {
+  const spec = {
+    kind: 'multiField',
+    params: {
+      fields: {
+        rewrite: { kind: 'normalisedText', golden: ['the dog ran'], nearMiss: [], maxScore: 2 },
+        justify: { kind: 'acceptedSet', golden: ['past tense', 'it happened before'], nearMiss: [], maxScore: 1 },
+      },
+    },
+    maxScore: 3,
+  };
+  const bothCorrect = markByAnswerSpec(spec, { rewrite: { answer: 'The Dog Ran' }, justify: { answer: 'past tense' } });
+  assert.equal(bothCorrect.correct, true);
+  assert.equal(bothCorrect.score, 3);
+  assert.equal(bothCorrect.maxScore, 3);
+
+  const onlyRewrite = markByAnswerSpec(spec, { rewrite: { answer: 'the dog ran' }, justify: { answer: 'because' } });
+  assert.equal(onlyRewrite.correct, false);
+  assert.equal(onlyRewrite.score, 2);
+  assert.equal(onlyRewrite.maxScore, 3);
+});
+
+test('manualReviewOnly: never auto-scores correct', () => {
+  const spec = {
+    kind: 'manualReviewOnly',
+    golden: [],
+    nearMiss: [],
+    maxScore: 0,
+    feedbackLong: 'A teacher will review this response.',
+  };
+  const result = markByAnswerSpec(spec, { answer: 'My storm paragraph with a relative clause...' });
+  assert.equal(result.correct, false, 'manualReviewOnly must never auto-correct');
+  assert.equal(result.score, 0);
+});
+
+test('markByAnswerSpec tolerates missing/malformed input gracefully', () => {
+  assert.equal(markByAnswerSpec(null, { answer: 'x' }).correct, false);
+  assert.equal(markByAnswerSpec({}, { answer: 'x' }).correct, false);
+  assert.equal(markByAnswerSpec({ kind: 'garbage-kind', golden: ['y'], nearMiss: [] }, { answer: 'x' }).correct, false);
+  assert.equal(markByAnswerSpec({ kind: 'acceptedSet', golden: [], nearMiss: [] }, { answer: 'x' }).misconception, 'marking_unavailable');
+  assert.equal(markByAnswerSpec({ kind: 'acceptedSet', golden: ['ok'], nearMiss: [] }, null).correct, false);
+});
+
+test('validateAnswerSpec: all kinds with golden + nearMiss pass', () => {
+  for (const kind of ['exact', 'normalisedText', 'acceptedSet', 'punctuationPattern']) {
+    assert.ok(validateAnswerSpec({ kind, golden: ['x'], nearMiss: [] }), kind);
+  }
+  assert.ok(validateAnswerSpec({ kind: 'manualReviewOnly' }));
+  assert.ok(validateAnswerSpec({
+    kind: 'multiField',
+    params: { fields: { a: { kind: 'exact', golden: ['x'], nearMiss: [] } } },
+  }));
+});
+
+test('validateAnswerSpec: rejects missing golden (except manualReviewOnly)', () => {
+  assert.throws(() => validateAnswerSpec({ kind: 'exact', golden: [], nearMiss: [] }), /golden/);
+  assert.throws(() => validateAnswerSpec({ kind: 'acceptedSet', nearMiss: [] }), /golden/);
+  assert.throws(() => validateAnswerSpec({ kind: 'exact', golden: ['x'] }), /nearMiss/);
+  assert.throws(() => validateAnswerSpec({ kind: 'garbage' }), /kind must be one of/);
+});
+
+test('validateAnswerSpec: multiField recursively validates subfields', () => {
+  assert.throws(() => validateAnswerSpec({
+    kind: 'multiField',
+    params: { fields: { broken: { kind: 'exact', golden: [], nearMiss: [] } } },
+  }), /multiField\.broken/);
+});
+
+test('Backcompat: content.js inline accepted-array marking still works through the new marker', async () => {
+  // content.js markStringAnswer is now a thin adapter — it constructs a
+  // transient acceptedSet spec and delegates to markByAnswerSpec. Every
+  // existing inline `accepted: [...]` call in content.js continues to work
+  // because the shape is backwards compatible with the existing opts.
+  const { createGrammarQuestion, evaluateGrammarQuestion } = await import('../worker/src/subjects/grammar/content.js');
+  const question = createGrammarQuestion({ templateId: 'combine_clauses_rewrite', seed: 1 });
+  assert.ok(question, 'question should build');
+  const evaluation = evaluateGrammarQuestion(question, { answer: 'Although Mia was tired, she finished the race.' });
+  assert.equal(typeof evaluation.correct, 'boolean');
+  assert.ok(evaluation.maxScore >= 1);
+});

--- a/worker/src/subjects/grammar/answer-spec.js
+++ b/worker/src/subjects/grammar/answer-spec.js
@@ -1,0 +1,306 @@
+// Grammar accepted-answer registry (U5).
+//
+// Every constructed-response template should eventually declare an `answerSpec`
+// of the shape:
+//   { kind, params, golden: string[], nearMiss?: string[] }
+// where kind ∈ 'exact' | 'normalisedText' | 'acceptedSet' | 'punctuationPattern'
+//            | 'multiField' | 'manualReviewOnly'
+//
+// The existing inline `accepted: [...]` arrays remain valid during the migration
+// window: `markStringAnswer(respText, accepted, opts)` (content.js) constructs a
+// transient `acceptedSet` spec and delegates to `markByAnswerSpec` here. That
+// keeps the marking contract single-sourced without requiring an immediate
+// migration of all ~20 constructed-response templates.
+//
+// `validateAnswerSpec` is exported for content-release tests that want to opt
+// into strict per-template validation. It is not called automatically at module
+// load — making it automatic would break the migration-window shape where
+// `markStringAnswer` carries its own accepted array.
+
+const ANSWER_SPEC_KINDS = Object.freeze([
+  'exact',
+  'normalisedText',
+  'acceptedSet',
+  'punctuationPattern',
+  'multiField',
+  'manualReviewOnly',
+]);
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function safeString(value) {
+  return value == null ? '' : String(value);
+}
+
+function normaliseWhitespace(text) {
+  return safeString(text).replace(/\s+/g, ' ').trim();
+}
+
+function caseFold(text) {
+  return safeString(text).toLowerCase();
+}
+
+function stripPunctuationForSet(text) {
+  return normaliseWhitespace(safeString(text).replace(/[.,;:!?"'`]/g, ''));
+}
+
+function collapsePunctuationPattern(text) {
+  // For punctuation-sensitive marking we normalise surrounding whitespace but
+  // keep the punctuation characters themselves. Optional commas around
+  // parentheticals are matched separately via `optionalCommas`.
+  return normaliseWhitespace(safeString(text));
+}
+
+function compareExact(response, accepted) {
+  return safeString(response) === safeString(accepted);
+}
+
+function compareNormalisedText(response, accepted) {
+  return caseFold(normaliseWhitespace(response)) === caseFold(normaliseWhitespace(accepted));
+}
+
+function compareAcceptedSet(response, acceptedList) {
+  const candidate = caseFold(normaliseWhitespace(response));
+  return acceptedList.some((accepted) => caseFold(normaliseWhitespace(accepted)) === candidate);
+}
+
+function comparePunctuationPattern(response, accepted, { optionalCommas = false } = {}) {
+  const candidate = collapsePunctuationPattern(response);
+  const target = collapsePunctuationPattern(accepted);
+  if (candidate === target) return true;
+  if (optionalCommas) {
+    // Accept the same sentence with surrounding commas stripped.
+    const stripCommas = (text) => text.replace(/\s*,\s*/g, ' ').replace(/\s+/g, ' ').trim();
+    if (stripCommas(candidate) === stripCommas(target)) return true;
+  }
+  return false;
+}
+
+function mkMarkResult({ correct, score, maxScore, misconception, feedbackShort, feedbackLong, answerText, minimalHint }) {
+  const result = {
+    correct: Boolean(correct),
+    score: Number.isFinite(Number(score)) ? Number(score) : 0,
+    maxScore: Number.isFinite(Number(maxScore)) ? Number(maxScore) : 1,
+    misconception: misconception || null,
+    feedbackShort: feedbackShort || (correct ? 'Correct.' : 'Not quite.'),
+    feedbackLong: feedbackLong || '',
+    answerText: safeString(answerText),
+  };
+  if (minimalHint !== undefined) result.minimalHint = minimalHint;
+  return result;
+}
+
+function markExact(spec, response) {
+  const accepted = Array.isArray(spec.golden) && spec.golden.length ? spec.golden[0] : '';
+  const correct = compareExact(response, accepted);
+  return mkMarkResult({
+    correct,
+    score: correct ? (spec.maxScore || 1) : 0,
+    maxScore: spec.maxScore || 1,
+    misconception: correct ? null : (spec.misconception || 'misread_question'),
+    feedbackLong: spec.feedbackLong || (correct ? '' : `Correct answer: ${accepted}`),
+    answerText: accepted,
+  });
+}
+
+function markNormalisedText(spec, response) {
+  const accepted = Array.isArray(spec.golden) && spec.golden.length ? spec.golden[0] : '';
+  const correct = compareNormalisedText(response, accepted);
+  return mkMarkResult({
+    correct,
+    score: correct ? (spec.maxScore || 1) : 0,
+    maxScore: spec.maxScore || 1,
+    misconception: correct ? null : (spec.misconception || 'misread_question'),
+    feedbackLong: spec.feedbackLong || (correct ? '' : `Correct answer: ${accepted}`),
+    answerText: accepted,
+  });
+}
+
+function markAcceptedSet(spec, response) {
+  const accepted = Array.isArray(spec.golden) && spec.golden.length ? spec.golden : [];
+  if (accepted.length === 0) {
+    return mkMarkResult({
+      correct: false,
+      score: 0,
+      maxScore: spec.maxScore || 1,
+      misconception: 'marking_unavailable',
+      feedbackLong: 'Accepted-answer list is empty.',
+      answerText: '',
+    });
+  }
+  const fullMarks = spec.maxScore || 2;
+  // Exact match (case + punctuation + whitespace sensitive) for full marks
+  const candidate = safeString(response).trim();
+  const exactMatch = accepted.find((entry) => safeString(entry).trim() === candidate);
+  if (exactMatch) {
+    return mkMarkResult({
+      correct: true,
+      score: fullMarks,
+      maxScore: fullMarks,
+      feedbackLong: spec.feedbackLong || `Correct answer: ${accepted[0]}`,
+      answerText: exactMatch,
+    });
+  }
+  // Partial credit path (fullMarks > 1): normalised + punctuation-stripped match.
+  // A learner who produced the same words but missed a comma/full-stop earns
+  // (fullMarks - 1) with a punctuation-precision misconception tag.
+  if (fullMarks > 1) {
+    const responseStripped = stripPunctuationForSet(response);
+    const bareMatch = accepted.find((entry) => stripPunctuationForSet(entry) === responseStripped);
+    if (bareMatch) {
+      return mkMarkResult({
+        correct: false,
+        score: fullMarks - 1,
+        maxScore: fullMarks,
+        misconception: spec.punctuationMisconception || 'punctuation_precision',
+        feedbackShort: 'The grammar idea is close, but the exact punctuation or wording is not fully correct.',
+        feedbackLong: spec.feedbackLong || `Correct answer: ${accepted[0]}`,
+        answerText: bareMatch,
+      });
+    }
+  }
+  return mkMarkResult({
+    correct: false,
+    score: 0,
+    maxScore: fullMarks,
+    misconception: spec.misconception || 'misread_question',
+    feedbackLong: spec.feedbackLong || `Correct answer: ${accepted[0]}`,
+    answerText: accepted[0],
+  });
+}
+
+function markPunctuationPattern(spec, response) {
+  const accepted = Array.isArray(spec.golden) && spec.golden.length ? spec.golden[0] : '';
+  const correct = comparePunctuationPattern(response, accepted, {
+    optionalCommas: Boolean(spec.params?.optionalCommas),
+  });
+  return mkMarkResult({
+    correct,
+    score: correct ? (spec.maxScore || 1) : 0,
+    maxScore: spec.maxScore || 1,
+    misconception: correct ? null : (spec.misconception || 'punctuation_precision'),
+    feedbackLong: spec.feedbackLong || (correct ? '' : `Correct answer: ${accepted}`),
+    answerText: accepted,
+  });
+}
+
+function markMultiField(spec, response) {
+  const fields = isPlainObject(spec.params?.fields) ? spec.params.fields : {};
+  const responses = isPlainObject(response) ? response : {};
+  let subtotal = 0;
+  let max = 0;
+  const misconceptions = [];
+  for (const [key, subSpec] of Object.entries(fields)) {
+    const subResult = markByAnswerSpec(subSpec, responses[key]);
+    subtotal += Number(subResult.score) || 0;
+    max += Number(subResult.maxScore) || 0;
+    if (!subResult.correct && subResult.misconception) misconceptions.push(subResult.misconception);
+  }
+  const correct = max > 0 && subtotal >= max;
+  return mkMarkResult({
+    correct,
+    score: subtotal,
+    maxScore: max || (spec.maxScore || 1),
+    misconception: correct ? null : (misconceptions[0] || spec.misconception || 'misread_question'),
+    feedbackLong: spec.feedbackLong || '',
+    answerText: '',
+  });
+}
+
+function markManualReviewOnly(spec) {
+  return mkMarkResult({
+    correct: false,
+    score: 0,
+    maxScore: spec.maxScore || 0,
+    misconception: null,
+    feedbackShort: 'Saved for review.',
+    feedbackLong: spec.feedbackLong || 'This response is saved for teacher or parent review and is not auto-marked.',
+    answerText: '',
+  });
+}
+
+export function markByAnswerSpec(spec, response) {
+  if (!isPlainObject(spec)) {
+    return mkMarkResult({
+      correct: false,
+      score: 0,
+      maxScore: 1,
+      misconception: 'marking_unavailable',
+      feedbackLong: 'No answer specification provided.',
+      answerText: '',
+    });
+  }
+  const kind = spec.kind;
+  if (!ANSWER_SPEC_KINDS.includes(kind)) {
+    return mkMarkResult({
+      correct: false,
+      score: 0,
+      maxScore: spec.maxScore || 1,
+      misconception: 'marking_unavailable',
+      feedbackLong: `Unsupported answer spec kind: ${kind}`,
+      answerText: '',
+    });
+  }
+  const responseText = isPlainObject(response)
+    ? (typeof response.answer === 'string' ? response.answer : safeString(response.answer ?? ''))
+    : safeString(response);
+  switch (kind) {
+    case 'exact': return markExact(spec, responseText);
+    case 'normalisedText': return markNormalisedText(spec, responseText);
+    case 'acceptedSet': return markAcceptedSet(spec, responseText);
+    case 'punctuationPattern': return markPunctuationPattern(spec, responseText);
+    case 'multiField': return markMultiField(spec, response);
+    case 'manualReviewOnly': return markManualReviewOnly(spec);
+    default: return mkMarkResult({
+      correct: false,
+      score: 0,
+      maxScore: spec.maxScore || 1,
+      misconception: 'marking_unavailable',
+      feedbackLong: 'Unsupported answer spec kind.',
+      answerText: '',
+    });
+  }
+}
+
+// Strict validator — intentionally NOT called at module import so the
+// migration-window inline-`accepted` shape keeps working. Content-release tests
+// can opt into this to enforce declarative shapes per template.
+export function validateAnswerSpec(spec, { requireGolden = true, requireNearMiss = true } = {}) {
+  if (!isPlainObject(spec)) {
+    throw new Error('answerSpec must be a plain object');
+  }
+  if (!ANSWER_SPEC_KINDS.includes(spec.kind)) {
+    throw new Error(`answerSpec.kind must be one of ${ANSWER_SPEC_KINDS.join(', ')}`);
+  }
+  if (spec.kind === 'manualReviewOnly') {
+    return true; // manualReviewOnly has no golden/nearMiss requirement
+  }
+  if (spec.kind === 'multiField') {
+    if (!isPlainObject(spec.params?.fields)) {
+      throw new Error('multiField answerSpec requires params.fields object');
+    }
+    for (const [key, sub] of Object.entries(spec.params.fields)) {
+      try {
+        validateAnswerSpec(sub, { requireGolden, requireNearMiss });
+      } catch (err) {
+        throw new Error(`multiField.${key}: ${err.message}`);
+      }
+    }
+    return true;
+  }
+  if (requireGolden) {
+    if (!Array.isArray(spec.golden) || spec.golden.length === 0) {
+      throw new Error(`${spec.kind} answerSpec requires non-empty golden[] array`);
+    }
+  }
+  if (requireNearMiss) {
+    if (!Array.isArray(spec.nearMiss)) {
+      throw new Error(`${spec.kind} answerSpec requires nearMiss[] array (empty is fine)`);
+    }
+  }
+  return true;
+}
+
+export { ANSWER_SPEC_KINDS };

--- a/worker/src/subjects/grammar/answer-spec.js
+++ b/worker/src/subjects/grammar/answer-spec.js
@@ -17,7 +17,7 @@
 // load — making it automatic would break the migration-window shape where
 // `markStringAnswer` carries its own accepted array.
 
-const ANSWER_SPEC_KINDS = Object.freeze([
+export const ANSWER_SPEC_KINDS = Object.freeze([
   'exact',
   'normalisedText',
   'acceptedSet',
@@ -25,6 +25,8 @@ const ANSWER_SPEC_KINDS = Object.freeze([
   'multiField',
   'manualReviewOnly',
 ]);
+
+export const DEFAULT_MINIMAL_HINT = 'Check the sentence structure and the instruction again.';
 
 function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -79,7 +81,7 @@ function comparePunctuationPattern(response, accepted, { optionalCommas = false 
 }
 
 function mkMarkResult({ correct, score, maxScore, misconception, feedbackShort, feedbackLong, answerText, minimalHint }) {
-  const result = {
+  return {
     correct: Boolean(correct),
     score: Number.isFinite(Number(score)) ? Number(score) : 0,
     maxScore: Number.isFinite(Number(maxScore)) ? Number(maxScore) : 1,
@@ -87,9 +89,12 @@ function mkMarkResult({ correct, score, maxScore, misconception, feedbackShort, 
     feedbackShort: feedbackShort || (correct ? 'Correct.' : 'Not quite.'),
     feedbackLong: feedbackLong || '',
     answerText: safeString(answerText),
+    // Default hint so direct callers (U7 transfer lane, future content-release
+    // templates with declarative answerSpec) inherit the same shape the
+    // legacy content.js mkResult guarantees. Adapter paths can still inject
+    // a concept-specific hint via content.js markStringAnswer.
+    minimalHint: minimalHint ?? DEFAULT_MINIMAL_HINT,
   };
-  if (minimalHint !== undefined) result.minimalHint = minimalHint;
-  return result;
 }
 
 function markExact(spec, response) {
@@ -187,7 +192,17 @@ function markPunctuationPattern(spec, response) {
 }
 
 function markMultiField(spec, response) {
-  const fields = isPlainObject(spec.params?.fields) ? spec.params.fields : {};
+  const fields = isPlainObject(spec.params?.fields) ? spec.params.fields : null;
+  if (!fields || Object.keys(fields).length === 0) {
+    return mkMarkResult({
+      correct: false,
+      score: 0,
+      maxScore: spec.maxScore || 1,
+      misconception: 'marking_unavailable',
+      feedbackLong: 'multiField answer spec requires params.fields with at least one entry.',
+      answerText: '',
+    });
+  }
   const responses = isPlainObject(response) ? response : {};
   let subtotal = 0;
   let max = 0;
@@ -303,4 +318,3 @@ export function validateAnswerSpec(spec, { requireGolden = true, requireNearMiss
   return true;
 }
 
-export { ANSWER_SPEC_KINDS };

--- a/worker/src/subjects/grammar/content.js
+++ b/worker/src/subjects/grammar/content.js
@@ -1,5 +1,6 @@
 // Generated from the reviewed KS2 Grammar legacy engine.
 // Regenerate with: node scripts/extract-grammar-legacy-oracle.mjs --source <legacy-html>
+import { markByAnswerSpec } from './answer-spec.js';
 
 const MISCONCEPTIONS = {
   sentence_function_confusion: "Mixed up sentence functions or punctuation cues",
@@ -3877,40 +3878,28 @@ function mkResult({correct, score, maxScore, misconception, feedbackShort, feedb
   };
 }
 
+// Thin adapter — U5 migration window. Inline `accepted: [...]` arrays on
+// template items continue to flow through this helper, which constructs a
+// transient `acceptedSet` answerSpec and delegates to the shared
+// markByAnswerSpec marker in ./answer-spec.js. Every marking call in this
+// module therefore routes through the same declarative code path, even before
+// per-template answerSpec declarations land in a content-release PR.
+//
+// We keep the legacy `minimalHint` lookup injection here so the result shape
+// matches `mkResult` exactly (oracle fixtures depend on it).
 function markStringAnswer(respText, acceptedList, opts = {}) {
-  const cmp = compareAnswerString(respText, acceptedList);
-  const fullMarks = opts.maxScore || 2;
-  const exactText = acceptedList[0];
-  if (cmp.exact) {
-    return mkResult({
-      correct:true,
-      score:fullMarks,
-      maxScore:fullMarks,
-      feedbackShort:"Correct.",
-      feedbackLong: opts.feedbackLong || `Correct answer: ${exactText}`,
-      answerText: exactText
-    });
-  }
-  if (cmp.bare && fullMarks > 1) {
-    return mkResult({
-      correct:false,
-      score:fullMarks - 1,
-      maxScore:fullMarks,
-      misconception: opts.punctuationMisconception || "punctuation_precision",
-      feedbackShort:"The grammar idea is close, but the exact punctuation or wording is not fully correct.",
-      feedbackLong: opts.feedbackLong || `Correct answer: ${exactText}`,
-      answerText: exactText
-    });
-  }
-  return mkResult({
-    correct:false,
-    score:0,
-    maxScore:fullMarks,
-    misconception: opts.misconception || "misread_question",
-    feedbackShort:"Not quite.",
-    feedbackLong: opts.feedbackLong || `Correct answer: ${exactText}`,
-    answerText: exactText
-  });
+  const spec = {
+    kind: 'acceptedSet',
+    golden: Array.isArray(acceptedList) ? acceptedList.slice() : [],
+    nearMiss: [],
+    maxScore: opts.maxScore || 2,
+    misconception: opts.misconception,
+    punctuationMisconception: opts.punctuationMisconception,
+    feedbackLong: opts.feedbackLong,
+  };
+  const result = markByAnswerSpec(spec, { answer: respText });
+  result.minimalHint = MINIMAL_HINTS[result.misconception] || "Check the sentence structure and the instruction again.";
+  return result;
 }
 
 function makeBaseQuestion(template, seed, data) {


### PR DESCRIPTION
## Summary

**U5 of 8** in the Grammar Perfection Pass plan. Addresses Review Issue 9: accepted-answer handling relies on inline arrays, not a declarative registry.

### What lands

- **New module:** \`worker/src/subjects/grammar/answer-spec.js\`
  - \`markByAnswerSpec(spec, response)\` — single marking entry point
  - Six declarative kinds: \`exact\` / \`normalisedText\` / \`acceptedSet\` / \`punctuationPattern\` / \`multiField\` / \`manualReviewOnly\`
  - \`validateAnswerSpec(spec, opts)\` — opt-in strict validator for content-release tests
- **Migration adapter:** \`content.js\` \`markStringAnswer\` now constructs a transient \`acceptedSet\` spec from the existing \`accepted: [...]\` arrays and delegates to \`markByAnswerSpec\`. Every marking call in Grammar flows through the new path, even before per-template \`answerSpec\` declarations land in a content-release PR.
- **\`minimalHint\` preserved:** adapter injects the legacy \`MINIMAL_HINTS\` lookup so oracle fixtures match byte-for-byte. No \`contentReleaseId\` bump.

### Scope decision (per plan)

Per-template \`answerSpec\` declarations for all 20 constructed-response templates are **deferred to a content-release PR** — that's content work, not engine work, and changing \`contentReleaseId\` invalidates stored attempt evidence. The declarative machinery is now in production so the content PR can land those shapes one concept at a time.

### Six kinds with golden + nearMiss

| Kind | Example |
|---|---|
| \`exact\` | \`"Question mark."\` byte-identical only |
| \`normalisedText\` | \`"subordinate clause"\` trim/case/whitespace tolerant |
| \`acceptedSet\` | Multiple equivalent sentences (clause-combine, cause-effect) |
| \`punctuationPattern\` | \`optionalCommas\` option for parenthesis tasks |
| \`multiField\` | Rewrite + justify scored independently |
| \`manualReviewOnly\` | Transfer writing (U7) — never auto-scores correct |

## Test plan
- [x] \`tests/grammar-answer-spec.test.js\` → 14 new tests
- [x] \`tests/grammar-engine.test.js\` → 32/32 (oracle replay preserved)
- [x] Full grammar target suite (167 tests): all green
- [ ] Independent reviewer pass
- [ ] Reviewer re-check
- [ ] Merge when no blockers

## Next
U6 (analytics confidence taxonomy) depends on U5. U7 will use \`manualReviewOnly\` for the transfer lane. U8 wraps up.