### PR TITLE
feat(grammar): U6 analytics confidence taxonomy + sample-size

### DIFF
--- a/tests/grammar-confidence.test.js
+++ b/tests/grammar-confidence.test.js
@@ -1,0 +1,94 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  deriveGrammarConfidence,
+  GRAMMAR_CONFIDENCE_LABELS,
+} from '../worker/src/subjects/grammar/read-models.js';
+
+test('U6: GRAMMAR_CONFIDENCE_LABELS lists all five labels', () => {
+  assert.deepEqual(GRAMMAR_CONFIDENCE_LABELS.slice().sort(), [
+    'building',
+    'consolidating',
+    'emerging',
+    'needs-repair',
+    'secure',
+  ]);
+});
+
+test('U6: emerging — new concept with thin evidence (<=2 attempts)', () => {
+  assert.equal(deriveGrammarConfidence({
+    status: 'new', attempts: 0, strength: 0.25, correctStreak: 0, intervalDays: 0, recentMisses: 0,
+  }), 'emerging');
+  assert.equal(deriveGrammarConfidence({
+    status: 'learning', attempts: 1, strength: 0.35, correctStreak: 1, intervalDays: 0, recentMisses: 0,
+  }), 'emerging');
+  assert.equal(deriveGrammarConfidence({
+    status: 'learning', attempts: 2, strength: 0.4, correctStreak: 1, intervalDays: 0, recentMisses: 0,
+  }), 'emerging');
+});
+
+test('U6: needs-repair — weak status OR 2+ recent misses', () => {
+  assert.equal(deriveGrammarConfidence({
+    status: 'weak', attempts: 8, strength: 0.3, correctStreak: 0, intervalDays: 0, recentMisses: 0,
+  }), 'needs-repair');
+  // Even with high strength, 2+ recent misses triggers needs-repair
+  assert.equal(deriveGrammarConfidence({
+    status: 'learning', attempts: 10, strength: 0.7, correctStreak: 0, intervalDays: 0, recentMisses: 2,
+  }), 'needs-repair');
+});
+
+test('U6: secure — strength >= 0.82, streak >= 3, intervalDays >= 7', () => {
+  assert.equal(deriveGrammarConfidence({
+    status: 'secured', attempts: 10, strength: 0.95, correctStreak: 5, intervalDays: 10, recentMisses: 0,
+  }), 'secure');
+  assert.equal(deriveGrammarConfidence({
+    status: 'secured', attempts: 9, strength: 0.82, correctStreak: 3, intervalDays: 7, recentMisses: 0,
+  }), 'secure', 'boundary conditions met');
+});
+
+test('U6: consolidating — strength + streak secured but intervalDays < 7 (heavy same-week practice)', () => {
+  // The canonical case from the plan: attempts=100, correctStreak=10, strength=0.95, intervalDays=3
+  assert.equal(deriveGrammarConfidence({
+    status: 'learning', attempts: 100, strength: 0.95, correctStreak: 10, intervalDays: 3, recentMisses: 0,
+  }), 'consolidating');
+  // Also triggers just below the 7-day gate
+  assert.equal(deriveGrammarConfidence({
+    status: 'learning', attempts: 20, strength: 0.9, correctStreak: 4, intervalDays: 6.9, recentMisses: 0,
+  }), 'consolidating');
+});
+
+test('U6: building — everything else (moderate strength, evidence building up)', () => {
+  assert.equal(deriveGrammarConfidence({
+    status: 'learning', attempts: 4, strength: 0.55, correctStreak: 1, intervalDays: 1, recentMisses: 0,
+  }), 'building');
+  assert.equal(deriveGrammarConfidence({
+    status: 'learning', attempts: 6, strength: 0.7, correctStreak: 2, intervalDays: 3, recentMisses: 0,
+  }), 'building');
+});
+
+test('U6: precedence — emerging beats needs-repair when attempts <= 2', () => {
+  // If a concept has only 2 attempts both wrong, attempts<=2 rule runs first
+  // so the label is 'emerging' not 'needs-repair' — thin evidence is the
+  // more informative signal for a learner with so few attempts.
+  assert.equal(deriveGrammarConfidence({
+    status: 'weak', attempts: 2, strength: 0.15, correctStreak: 0, intervalDays: 0, recentMisses: 2,
+  }), 'emerging');
+});
+
+test('U6: precedence — needs-repair beats secure when 2+ recent misses present', () => {
+  // A concept that once met secure thresholds but has recent-miss signal
+  // should surface as needs-repair so the learner is nudged back to it.
+  assert.equal(deriveGrammarConfidence({
+    status: 'secured', attempts: 20, strength: 0.9, correctStreak: 4, intervalDays: 10, recentMisses: 2,
+  }), 'needs-repair');
+});
+
+test('U6: malformed inputs fall back to emerging without throwing', () => {
+  assert.doesNotThrow(() => deriveGrammarConfidence(null));
+  assert.doesNotThrow(() => deriveGrammarConfidence({}));
+  assert.doesNotThrow(() => deriveGrammarConfidence(undefined));
+  assert.equal(deriveGrammarConfidence(null), 'emerging');
+  assert.equal(deriveGrammarConfidence({}), 'emerging');
+  assert.equal(deriveGrammarConfidence({ attempts: 'garbage', strength: NaN }), 'emerging');
+});

--- a/worker/src/subjects/grammar/read-models.js
+++ b/worker/src/subjects/grammar/read-models.js
@@ -376,23 +376,115 @@ function safeSession(session, now = Date.now()) {
   };
 }
 
+// U6 confidence taxonomy — five labels driven by strength, streak, recent
+// misses, and spacing. Derived read-model projection; never mutates state.
+//
+//   emerging     <= 2 attempts (thin evidence, show as "Emerging")
+//   needs-repair weak status OR >= 2 recent misses
+//   secure       strength >= 0.82 AND correctStreak >= 3 AND intervalDays >= 7
+//   consolidating strength >= 0.82 AND correctStreak >= 3 AND intervalDays < 7
+//                (heavy same-week practice, not yet spaced)
+//   building     everything else
+export const GRAMMAR_CONFIDENCE_LABELS = Object.freeze([
+  'emerging',
+  'building',
+  'consolidating',
+  'secure',
+  'needs-repair',
+]);
+
+function intervalDaysFromNode(node) {
+  if (!node) return 0;
+  if (Number.isFinite(Number(node.intervalDays))) return Number(node.intervalDays);
+  return 0;
+}
+
+function recentMissCountForConcept(recentAttempts, conceptId) {
+  if (!Array.isArray(recentAttempts) || !conceptId) return 0;
+  let count = 0;
+  for (const attempt of recentAttempts.slice(-12)) {
+    const conceptIds = Array.isArray(attempt?.conceptIds) ? attempt.conceptIds : [];
+    const result = isPlainObject(attempt?.result) ? attempt.result : {};
+    if (conceptIds.includes(conceptId) && result.correct === false) count += 1;
+  }
+  return count;
+}
+
+function recentMissCountForQuestionType(recentAttempts, questionType) {
+  if (!Array.isArray(recentAttempts) || !questionType) return 0;
+  let count = 0;
+  for (const attempt of recentAttempts.slice(-12)) {
+    const result = isPlainObject(attempt?.result) ? attempt.result : {};
+    if (attempt?.questionType === questionType && result.correct === false) count += 1;
+  }
+  return count;
+}
+
+function distinctTemplatesFor(recentAttempts, matcher) {
+  if (!Array.isArray(recentAttempts)) return 0;
+  const seen = new Set();
+  for (const attempt of recentAttempts) {
+    if (matcher(attempt) && typeof attempt?.templateId === 'string' && attempt.templateId) {
+      seen.add(attempt.templateId);
+    }
+  }
+  return seen.size;
+}
+
+export function deriveGrammarConfidence(raw) {
+  const input = isPlainObject(raw) ? raw : {};
+  const { status, attempts, strength, correctStreak, intervalDays, recentMisses } = input;
+  const attemptCount = Math.max(0, Number(attempts) || 0);
+  const strengthValue = Number.isFinite(Number(strength)) ? Number(strength) : 0.25;
+  const streak = Math.max(0, Number(correctStreak) || 0);
+  const spacingDays = Math.max(0, Number(intervalDays) || 0);
+  const misses = Math.max(0, Number(recentMisses) || 0);
+
+  if (attemptCount <= 2) return 'emerging';
+  if (status === 'weak' || misses >= 2) return 'needs-repair';
+  if (strengthValue >= 0.82 && streak >= 3 && spacingDays >= 7) return 'secure';
+  if (strengthValue >= 0.82 && streak >= 3 && spacingDays < 7) return 'consolidating';
+  return 'building';
+}
+
 function conceptMap(state, now) {
   const mastery = isPlainObject(state?.mastery?.concepts) ? state.mastery.concepts : {};
+  const recentAttempts = Array.isArray(state?.recentAttempts) ? state.recentAttempts : [];
   return GRAMMAR_CONCEPTS.map((concept) => {
     const node = mastery[concept.id] || null;
+    const status = grammarConceptStatus(node, now);
+    const attempts = Number(node?.attempts) || 0;
+    const strength = Number.isFinite(Number(node?.strength)) ? Number(node.strength) : 0.25;
+    const correctStreak = Number(node?.correctStreak) || 0;
+    const intervalDays = intervalDaysFromNode(node);
+    const recentMisses = recentMissCountForConcept(recentAttempts, concept.id);
+    const distinctTemplates = distinctTemplatesFor(recentAttempts, (attempt) =>
+      Array.isArray(attempt?.conceptIds) && attempt.conceptIds.includes(concept.id));
+    const confidenceLabel = deriveGrammarConfidence({
+      status, attempts, strength, correctStreak, intervalDays, recentMisses,
+    });
     return {
       id: concept.id,
       name: concept.name,
       domain: concept.domain,
       summary: concept.summary,
       punctuationForGrammar: Boolean(concept.punctuationForGrammar),
-      status: grammarConceptStatus(node, now),
-      attempts: Number(node?.attempts) || 0,
+      status,
+      attempts,
       correct: Number(node?.correct) || 0,
       wrong: Number(node?.wrong) || 0,
-      strength: Number.isFinite(Number(node?.strength)) ? Number(node.strength) : 0.25,
+      strength,
       dueAt: Number(node?.dueAt) || 0,
-      correctStreak: Number(node?.correctStreak) || 0,
+      correctStreak,
+      intervalDays,
+      // U6 confidence projection — never mutated into state; derived per read.
+      confidence: {
+        label: confidenceLabel,
+        sampleSize: attempts,
+        intervalDays,
+        distinctTemplates,
+        recentMisses,
+      },
     };
   });
 }
@@ -470,23 +562,41 @@ function misconceptionPatternsFromState(state) {
 
 function questionTypeSummaryFromState(state, now) {
   const questionTypes = isPlainObject(state?.mastery?.questionTypes) ? state.mastery.questionTypes : {};
+  const recentAttempts = Array.isArray(state?.recentAttempts) ? state.recentAttempts : [];
   return Object.entries(questionTypes)
     .map(([id, rawNode]) => {
       const node = rawNode || {};
       const correct = Number(node.correct) || 0;
       const wrong = Number(node.wrong) || 0;
       const attempts = Number(node.attempts) || 0;
+      const status = grammarConceptStatus(node, now);
+      const strength = Number.isFinite(Number(node.strength)) ? Number(node.strength) : 0.25;
+      const correctStreak = Number(node.correctStreak) || 0;
+      const intervalDays = intervalDaysFromNode(node);
+      const recentMisses = recentMissCountForQuestionType(recentAttempts, id);
+      const distinctTemplates = distinctTemplatesFor(recentAttempts, (attempt) => attempt?.questionType === id);
+      const confidenceLabel = deriveGrammarConfidence({
+        status, attempts, strength, correctStreak, intervalDays, recentMisses,
+      });
       return {
         subjectId: 'grammar',
         id,
         label: GRAMMAR_QUESTION_TYPES[id] || humanLabel(id),
-        status: grammarConceptStatus(node, now),
+        status,
         attempts,
         correct,
         wrong,
         accuracyPercent: accuracyPercent(correct, wrong),
-        strength: Number.isFinite(Number(node.strength)) ? Number(node.strength) : 0.25,
+        strength,
         dueAt: asTs(node.dueAt, 0),
+        intervalDays,
+        confidence: {
+          label: confidenceLabel,
+          sampleSize: attempts,
+          intervalDays,
+          distinctTemplates,
+          recentMisses,
+        },
       };
     })
     .filter((entry) => entry.attempts > 0)

--- a/worker/src/subjects/grammar/read-models.js
+++ b/worker/src/subjects/grammar/read-models.js
@@ -385,6 +385,16 @@ function safeSession(session, now = Date.now()) {
 //   consolidating strength >= 0.82 AND correctStreak >= 3 AND intervalDays < 7
 //                (heavy same-week practice, not yet spaced)
 //   building     everything else
+//
+// Notes:
+// - Low-strength detection is delegated to `status === 'weak'`, not to a raw
+//   strength threshold. The grammarConceptStatus machine is the authoritative
+//   source for "weak"; if it declares a node weak, needs-repair follows.
+//   Raw strength alone does not trigger needs-repair because strength can
+//   drift below a threshold momentarily after a single wrong answer without
+//   the status machine escalating it.
+// - The label order is "weakest-to-strongest then needs-repair" by semantic
+//   intent. Consumers iterating the frozen array get that semantic order.
 export const GRAMMAR_CONFIDENCE_LABELS = Object.freeze([
   'emerging',
   'building',
@@ -393,16 +403,26 @@ export const GRAMMAR_CONFIDENCE_LABELS = Object.freeze([
   'needs-repair',
 ]);
 
+// Shared horizon for "recent" windows in the confidence projection.
+// Exposed so parent hubs and other consumers can describe the signal
+// consistently ("missed 2 of the last N attempts"). The engine caps
+// state.recentAttempts at 80 at write time; this is the read-side slice.
+export const GRAMMAR_RECENT_ATTEMPT_HORIZON = 12;
+
 function intervalDaysFromNode(node) {
   if (!node) return 0;
   if (Number.isFinite(Number(node.intervalDays))) return Number(node.intervalDays);
   return 0;
 }
 
+function recentWindow(recentAttempts) {
+  return Array.isArray(recentAttempts) ? recentAttempts.slice(-GRAMMAR_RECENT_ATTEMPT_HORIZON) : [];
+}
+
 function recentMissCountForConcept(recentAttempts, conceptId) {
-  if (!Array.isArray(recentAttempts) || !conceptId) return 0;
+  if (!conceptId) return 0;
   let count = 0;
-  for (const attempt of recentAttempts.slice(-12)) {
+  for (const attempt of recentWindow(recentAttempts)) {
     const conceptIds = Array.isArray(attempt?.conceptIds) ? attempt.conceptIds : [];
     const result = isPlainObject(attempt?.result) ? attempt.result : {};
     if (conceptIds.includes(conceptId) && result.correct === false) count += 1;
@@ -411,19 +431,20 @@ function recentMissCountForConcept(recentAttempts, conceptId) {
 }
 
 function recentMissCountForQuestionType(recentAttempts, questionType) {
-  if (!Array.isArray(recentAttempts) || !questionType) return 0;
+  if (!questionType) return 0;
   let count = 0;
-  for (const attempt of recentAttempts.slice(-12)) {
+  for (const attempt of recentWindow(recentAttempts)) {
     const result = isPlainObject(attempt?.result) ? attempt.result : {};
     if (attempt?.questionType === questionType && result.correct === false) count += 1;
   }
   return count;
 }
 
+// Aligned to GRAMMAR_RECENT_ATTEMPT_HORIZON so distinctTemplates and
+// recentMisses are directly comparable "recent" signals.
 function distinctTemplatesFor(recentAttempts, matcher) {
-  if (!Array.isArray(recentAttempts)) return 0;
   const seen = new Set();
-  for (const attempt of recentAttempts) {
+  for (const attempt of recentWindow(recentAttempts)) {
     if (matcher(attempt) && typeof attempt?.templateId === 'string' && attempt.templateId) {
       seen.add(attempt.templateId);
     }


### PR DESCRIPTION
## Summary

**U6 of 8** in the Grammar Perfection Pass plan. Addresses Review Issue 8: analytics show strength without confidence or sample-size context.

### Five-label taxonomy

| Label | Condition |
|---|---|
| \`emerging\` | \`<= 2 attempts\` (thin evidence) |
| \`needs-repair\` | weak status OR \`>= 2 recent misses\` |
| \`secure\` | \`strength >= 0.82 AND streak >= 3 AND intervalDays >= 7\` |
| \`consolidating\` | \`strength >= 0.82 AND streak >= 3 AND intervalDays < 7\` — heavy same-week practice not yet spaced |
| \`building\` | everything else |

The \`consolidating\` label closes the plan's canonical edge case: a concept with \`attempts: 100, streak: 10, strength: 0.95, intervalDays: 3\` would previously fall to \`building\` and mislead a reader; now it reads as "you've drilled this a lot this week, spaced review pending".

### Implementation

- **New export:** \`deriveGrammarConfidence(input)\` — pure, malformed-input-tolerant, never mutates state.
- **Read-model injection:** \`conceptMap\` and \`questionTypeSummaryFromState\` now emit a \`confidence: { label, sampleSize, intervalDays, distinctTemplates, recentMisses }\` object per entry. Derived from \`state.mastery\` + \`state.recentAttempts\` on each read.
- **Precedence rules** tested explicitly: \`emerging\` beats \`needs-repair\` when \`attempts <= 2\`; \`needs-repair\` beats \`secure\` when \`recentMisses >= 2\`.

## Test plan
- [x] \`tests/grammar-confidence.test.js\` → 9 new tests
- [x] Full grammar suite → 176/176 pass
- [ ] Independent reviewer pass
- [ ] Reviewer re-check
- [ ] Merge

## Next
U7 (non-scored transfer lane) → U8 (release gate).