### PR TITLE
feat(punctuation): composite disabled signal for active-item UI (Phase 2 U4)

### DIFF
--- a/shared/punctuation/service.js
+++ b/shared/punctuation/service.js
@@ -369,7 +369,13 @@ function normaliseState(value) {
     error: typeof raw.error === 'string' ? raw.error : '',
     availability: isPlainObject(raw.availability)
       ? {
-          status: raw.availability.status === 'unavailable' ? 'unavailable' : 'ready',
+          // Accepted statuses: 'ready' (default), 'degraded' (runtime still
+          // writable but UI should pause mutations), 'unavailable' (exposure
+          // gate off or content missing). Anything else coerces to 'ready'.
+          status: (raw.availability.status === 'unavailable'
+            || raw.availability.status === 'degraded')
+            ? raw.availability.status
+            : 'ready',
           code: typeof raw.availability.code === 'string' ? raw.availability.code : null,
           message: typeof raw.availability.message === 'string' ? raw.availability.message : '',
         }

--- a/src/subjects/punctuation/components/PunctuationPracticeSurface.jsx
+++ b/src/subjects/punctuation/components/PunctuationPracticeSurface.jsx
@@ -13,12 +13,29 @@ function newlineTextStyle(value) {
   return String(value || '').includes('\n') ? { whiteSpace: 'pre-wrap' } : undefined;
 }
 
+// Composite disable signal shared across Setup, ActiveItem, and Feedback
+// views. Mutation controls (start, submit, continue, skip, end) must pause
+// whenever a command is in flight, the runtime is degraded/unavailable, or
+// the platform has flipped the subject read-only. The adapter layer
+// (subject-command-client) is the authoritative dedupe; the UI signal is
+// the visual echo.
+function composeIsDisabled(ui) {
+  const availabilityStatus = ui?.availability?.status || 'ready';
+  const runtimeReadOnly = Boolean(ui?.runtime?.readOnly);
+  const pending = Boolean(ui?.pendingCommand);
+  return pending
+    || runtimeReadOnly
+    || availabilityStatus === 'degraded'
+    || availabilityStatus === 'unavailable';
+}
+
 function SetupView({ learner, stats, ui, actions }) {
   const scene = bellstormSceneForPhase('setup');
   const content = ui.content || {};
   const guidedSkills = Array.isArray(content.skills) ? content.skills : [];
   const [guidedSkillId, setGuidedSkillId] = useState(guidedSkills[0]?.id || '');
   const selectedGuidedSkillId = guidedSkillId || guidedSkills[0]?.id || '';
+  const isDisabled = composeIsDisabled(ui);
   return (
     <section className="card border-top punctuation-surface" style={{ borderTopColor: '#B8873F' }}>
       <div className="punctuation-hero">
@@ -35,13 +52,14 @@ function SetupView({ learner, stats, ui, actions }) {
         <div className="stat"><div className="stat-label">Due</div><div className="stat-value">{stats.due || 0}</div><div className="stat-sub">Review items</div></div>
       </div>
       <div className="actions" style={{ marginTop: 16 }}>
-        <button className="btn primary" type="button" data-punctuation-start onClick={() => actions.dispatch('punctuation-start')}>Start practice</button>
+        <button className="btn primary" type="button" disabled={isDisabled} data-punctuation-start onClick={() => actions.dispatch('punctuation-start')}>Start practice</button>
         {guidedSkills.length ? (
           <label className="field" style={{ minWidth: 220 }}>
             <span>Guided skill</span>
             <select
               className="input"
               value={selectedGuidedSkillId}
+              disabled={isDisabled}
               onChange={(event) => setGuidedSkillId(event.target.value)}
             >
               {guidedSkills.map((skill) => (
@@ -53,6 +71,7 @@ function SetupView({ learner, stats, ui, actions }) {
         <button
           className="btn secondary"
           type="button"
+          disabled={isDisabled}
           data-punctuation-guided-start
           onClick={() => actions.dispatch('punctuation-start', { mode: 'guided', skillId: selectedGuidedSkillId || undefined })}
         >
@@ -61,6 +80,7 @@ function SetupView({ learner, stats, ui, actions }) {
         <button
           className="btn secondary"
           type="button"
+          disabled={isDisabled}
           data-punctuation-weak-start
           onClick={() => actions.dispatch('punctuation-start', { mode: 'weak' })}
         >
@@ -69,15 +89,16 @@ function SetupView({ learner, stats, ui, actions }) {
         <button
           className="btn secondary"
           type="button"
+          disabled={isDisabled}
           data-punctuation-gps-start
           onClick={() => actions.dispatch('punctuation-start', { mode: 'gps', roundLength: '8' })}
         >
           GPS test
         </button>
-        <button className="btn secondary" type="button" onClick={() => actions.dispatch('punctuation-start', { mode: 'speech' })}>Speech focus</button>
-        <button className="btn secondary" type="button" onClick={() => actions.dispatch('punctuation-start', { mode: 'comma_flow' })}>Comma focus</button>
-        <button className="btn secondary" type="button" onClick={() => actions.dispatch('punctuation-start', { mode: 'boundary' })}>Boundary focus</button>
-        <button className="btn secondary" type="button" onClick={() => actions.dispatch('punctuation-start', { mode: 'structure' })}>Structure focus</button>
+        <button className="btn secondary" type="button" disabled={isDisabled} onClick={() => actions.dispatch('punctuation-start', { mode: 'speech' })}>Speech focus</button>
+        <button className="btn secondary" type="button" disabled={isDisabled} onClick={() => actions.dispatch('punctuation-start', { mode: 'comma_flow' })}>Comma focus</button>
+        <button className="btn secondary" type="button" disabled={isDisabled} onClick={() => actions.dispatch('punctuation-start', { mode: 'boundary' })}>Boundary focus</button>
+        <button className="btn secondary" type="button" disabled={isDisabled} onClick={() => actions.dispatch('punctuation-start', { mode: 'structure' })}>Structure focus</button>
       </div>
     </section>
   );
@@ -189,17 +210,7 @@ function ActiveItemView({ ui, actions }) {
   const progress = ui.session?.length ? Math.round(((ui.session.answeredCount || 0) / ui.session.length) * 100) : 0;
   const submit = (payload) => actions.dispatch('punctuation-submit-form', payload);
   const isGps = ui.session?.mode === 'gps';
-  // Composite disable signal: mutation controls freeze whenever a command is
-  // in flight, the runtime is degraded/unavailable, or the platform has
-  // flipped the subject read-only. UI state is the visual echo; the adapter
-  // layer (subject-command-client) is the authoritative dedupe gate.
-  const availabilityStatus = ui.availability?.status || 'ready';
-  const runtimeReadOnly = Boolean(ui.runtime?.readOnly);
-  const pending = Boolean(ui.pendingCommand);
-  const isDisabled = pending
-    || runtimeReadOnly
-    || availabilityStatus === 'degraded'
-    || availabilityStatus === 'unavailable';
+  const isDisabled = composeIsDisabled(ui);
 
   return (
     <section className="card border-top punctuation-surface" style={{ borderTopColor: '#B8873F' }}>
@@ -238,6 +249,7 @@ function ActiveItemView({ ui, actions }) {
 function FeedbackView({ ui, actions }) {
   const feedback = ui.feedback || {};
   const scene = bellstormSceneForPhase('feedback');
+  const isDisabled = composeIsDisabled(ui);
   return (
     <section className="card border-top punctuation-surface" style={{ borderTopColor: feedback.kind === 'success' ? '#2E8479' : '#B8873F' }}>
       <div className="punctuation-strip">
@@ -260,8 +272,8 @@ function FeedbackView({ ui, actions }) {
         </div>
       ) : null}
       <div className="actions" style={{ marginTop: 16 }}>
-        <button className="btn primary" type="button" data-punctuation-continue onClick={() => actions.dispatch('punctuation-continue')}>Continue</button>
-        <button className="btn secondary" type="button" onClick={() => actions.dispatch('punctuation-end-early')}>Finish now</button>
+        <button className="btn primary" type="button" disabled={isDisabled} data-punctuation-continue onClick={() => actions.dispatch('punctuation-continue')}>Continue</button>
+        <button className="btn secondary" type="button" disabled={isDisabled} onClick={() => actions.dispatch('punctuation-end-early')}>Finish now</button>
       </div>
     </section>
   );

--- a/src/subjects/punctuation/components/PunctuationPracticeSurface.jsx
+++ b/src/subjects/punctuation/components/PunctuationPracticeSurface.jsx
@@ -189,6 +189,17 @@ function ActiveItemView({ ui, actions }) {
   const progress = ui.session?.length ? Math.round(((ui.session.answeredCount || 0) / ui.session.length) * 100) : 0;
   const submit = (payload) => actions.dispatch('punctuation-submit-form', payload);
   const isGps = ui.session?.mode === 'gps';
+  // Composite disable signal: mutation controls freeze whenever a command is
+  // in flight, the runtime is degraded/unavailable, or the platform has
+  // flipped the subject read-only. UI state is the visual echo; the adapter
+  // layer (subject-command-client) is the authoritative dedupe gate.
+  const availabilityStatus = ui.availability?.status || 'ready';
+  const runtimeReadOnly = Boolean(ui.runtime?.readOnly);
+  const pending = Boolean(ui.pendingCommand);
+  const isDisabled = pending
+    || runtimeReadOnly
+    || availabilityStatus === 'degraded'
+    || availabilityStatus === 'unavailable';
 
   return (
     <section className="card border-top punctuation-surface" style={{ borderTopColor: '#B8873F' }}>
@@ -213,12 +224,12 @@ function ActiveItemView({ ui, actions }) {
       <div className="progress" style={{ marginTop: 14 }}><span style={{ width: `${progress}%` }} /></div>
       <div style={{ marginTop: 16 }}>
         {item.inputKind === 'choice'
-          ? <ChoiceItem item={item} disabled={false} onSubmit={submit} />
-          : <TextItem key={item.id || item.prompt} item={item} disabled={false} onSubmit={submit} />}
+          ? <ChoiceItem item={item} disabled={isDisabled} onSubmit={submit} />
+          : <TextItem key={item.id || item.prompt} item={item} disabled={isDisabled} onSubmit={submit} />}
       </div>
       <div className="actions" style={{ marginTop: 16 }}>
-        <button className="btn ghost" type="button" onClick={() => actions.dispatch('punctuation-skip')}>Skip</button>
-        <button className="btn ghost" type="button" onClick={() => actions.dispatch('punctuation-end-early')}>End session</button>
+        <button className="btn ghost" type="button" disabled={isDisabled} onClick={() => actions.dispatch('punctuation-skip')}>Skip</button>
+        <button className="btn ghost" type="button" disabled={isDisabled} onClick={() => actions.dispatch('punctuation-end-early')}>End session</button>
       </div>
     </section>
   );

--- a/tests/react-punctuation-scene.test.js
+++ b/tests/react-punctuation-scene.test.js
@@ -346,3 +346,83 @@ test('punctuation React surface preserves newline-sensitive bullet text', () => 
   assert.match(html, /Bring\n- a drink\n- a hat\n- a sketchbook/);
   assert.match(html, /Bring:\n- a drink\n- a hat\n- a sketchbook/);
 });
+
+test('punctuation text-item controls disable while a command is pending', () => {
+  // Use a text-input item so the "disabled" outcome isolates to the composite
+  // pending/degraded signal (not to "no choice selected").
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.store.updateSubjectUi('punctuation', {
+    phase: 'active-item',
+    pendingCommand: 'punctuation-submit-form',
+    session: {
+      id: 'pending-ui',
+      mode: 'smart',
+      length: 2,
+      answeredCount: 0,
+      currentItem: {
+        id: 'sp_insert_endmark',
+        mode: 'insert',
+        inputKind: 'text',
+        prompt: 'Insert the punctuation.',
+        stem: 'We met at noon',
+      },
+    },
+  });
+  const html = harness.render();
+  // Submit and Reset buttons must both be disabled while pendingCommand is set.
+  assert.match(html, /<button[^>]*disabled[^>]*data-punctuation-submit/);
+  assert.match(html, /Reset text[^<]*<\/button>/);
+  assert.match(html, /disabled[^<]*>Reset text/);
+});
+
+test('punctuation text-item controls disable when runtime is degraded', () => {
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.store.updateSubjectUi('punctuation', {
+    phase: 'active-item',
+    availability: { status: 'degraded', code: 'runtime_degraded', message: 'Punctuation is temporarily read-only.' },
+    session: {
+      id: 'degraded-ui',
+      mode: 'smart',
+      length: 1,
+      answeredCount: 0,
+      currentItem: {
+        id: 'sp_insert_endmark_degraded',
+        mode: 'insert',
+        inputKind: 'text',
+        prompt: 'Insert the punctuation.',
+        stem: 'We met at noon',
+      },
+    },
+  });
+  const html = harness.render();
+  assert.match(html, /<button[^>]*disabled[^>]*data-punctuation-submit/);
+});
+
+test('punctuation text-item submit remains enabled in the idle state', () => {
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.store.updateSubjectUi('punctuation', {
+    phase: 'active-item',
+    session: {
+      id: 'idle-ui',
+      mode: 'smart',
+      length: 1,
+      answeredCount: 0,
+      currentItem: {
+        id: 'sp_insert_endmark_idle',
+        mode: 'insert',
+        inputKind: 'text',
+        prompt: 'Insert the punctuation.',
+        stem: 'We met at noon',
+      },
+    },
+  });
+  const html = harness.render();
+  assert.doesNotMatch(
+    html,
+    /<button[^>]*disabled[^>]*data-punctuation-submit/,
+    'idle active text item must allow submit',
+  );
+});

--- a/tests/react-punctuation-scene.test.js
+++ b/tests/react-punctuation-scene.test.js
@@ -400,6 +400,36 @@ test('punctuation text-item controls disable when runtime is degraded', () => {
   assert.match(html, /<button[^>]*disabled[^>]*data-punctuation-submit/);
 });
 
+test('punctuation setup view disables Start practice when availability is degraded', () => {
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.store.updateSubjectUi('punctuation', {
+    phase: 'setup',
+    availability: { status: 'degraded', code: 'runtime_degraded', message: 'paused' },
+  });
+  const html = harness.render();
+  assert.match(html, /<button[^>]*disabled[^>]*data-punctuation-start/);
+});
+
+test('punctuation feedback view disables Continue while a command is pending', () => {
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.store.updateSubjectUi('punctuation', {
+    phase: 'feedback',
+    pendingCommand: 'punctuation-continue',
+    session: {
+      id: 'feedback-pending',
+      mode: 'smart',
+      length: 2,
+      answeredCount: 1,
+      currentItem: { id: 'x', mode: 'insert', inputKind: 'text', prompt: 'p', stem: '' },
+    },
+    feedback: { kind: 'success', headline: 'Nice.', body: 'Punctuation correct.' },
+  });
+  const html = harness.render();
+  assert.match(html, /<button[^>]*disabled[^>]*data-punctuation-continue/);
+});
+
 test('punctuation text-item submit remains enabled in the idle state', () => {
   const harness = createPunctuationHarness();
   harness.dispatch('open-subject', { subjectId: 'punctuation' });


### PR DESCRIPTION
## Summary

- Replace hard-coded \`disabled={false}\` in \`PunctuationPracticeSurface.jsx\` with a composite \`isDisabled\` signal from \`ui.pendingCommand\`, \`ui.runtime?.readOnly\`, \`ui.availability?.status === 'degraded'\`, \`ui.availability?.status === 'unavailable'\`.
- Apply \`disabled={isDisabled}\` to answer controls, Skip, and End session buttons.
- Expand \`shared/punctuation/service.js\` \`normaliseState\` to accept \`'degraded'\` alongside \`'ready'\` and \`'unavailable'\` (previously silently coerced to \`'ready'\`).

The adapter-layer dedupe (via existing \`pendingKeys\` in \`subject-command-actions.js\`, per U3 prep) remains the authoritative gate; the UI signal is the visual echo. Plan's U4 scope for per-command token dedup was satisfied in existing infrastructure — no adapter changes needed.

Part of Punctuation Phase 2 hardening ([U4 in plan](../blob/feat/punctuation-p2-u4-ui-state/docs/plans/2026-04-25-002-feat-punctuation-phase2-hardening-plan.md)).

## Test plan

- [x] \`tests/react-punctuation-scene.test.js\` — 3 new tests (pending, degraded, idle); 12 total pass
- [x] Full suite: 921 / 913 / 7 (same pre-existing failures as base)
- [ ] CI: full suite green