### PR TITLE
feat(punctuation): reshape monster roster (3 active + 1 grand + 3 reserved) (Phase 2 U5)

### DIFF
--- a/shared/punctuation/content.js
+++ b/shared/punctuation/content.js
@@ -197,6 +197,14 @@ export const PUNCTUATION_SKILLS = Object.freeze([
   },
 ]);
 
+// Active Punctuation cluster -> direct monster mapping for the Phase 2
+// roster reduction. Learning clusters stay the same six groupings; only
+// reward projection collapses to 3 direct creatures + 1 grand.
+//   Pealark  : endmarks, speech, boundary
+//   Claspin  : apostrophe
+//   Curlune  : comma_flow, structure
+//   Quoral   : grand aggregate across all 14 reward units (see
+//              PUNCTUATION_GRAND_MONSTER below)
 export const PUNCTUATION_CLUSTERS = Object.freeze([
   {
     id: 'endmarks',
@@ -215,7 +223,7 @@ export const PUNCTUATION_CLUSTERS = Object.freeze([
   {
     id: 'speech',
     name: 'Speech',
-    monsterId: 'quoral',
+    monsterId: 'pealark',
     published: true,
     skillIds: ['speech'],
   },
@@ -229,14 +237,14 @@ export const PUNCTUATION_CLUSTERS = Object.freeze([
   {
     id: 'structure',
     name: 'List / Structure',
-    monsterId: 'colisk',
+    monsterId: 'curlune',
     published: true,
     skillIds: ['parenthesis', 'colon_list', 'semicolon_list', 'bullet_points'],
   },
   {
     id: 'boundary',
     name: 'Boundary',
-    monsterId: 'hyphang',
+    monsterId: 'pealark',
     published: true,
     skillIds: ['semicolon', 'dash_clause', 'hyphen'],
   },
@@ -245,7 +253,7 @@ export const PUNCTUATION_CLUSTERS = Object.freeze([
 export const PUNCTUATION_GRAND_MONSTER = Object.freeze({
   id: 'published_release',
   name: 'Published Punctuation release',
-  monsterId: 'carillon',
+  monsterId: 'quoral',
 });
 
 export function createPunctuationMasteryKey({

--- a/src/platform/game/mastery/shared.js
+++ b/src/platform/game/mastery/shared.js
@@ -13,13 +13,21 @@ export const SPELLING_MONSTER_IDS = Object.freeze(
 export const PUNCTUATION_MONSTER_IDS = Object.freeze(
   (MONSTERS_BY_SUBJECT.punctuation || []).filter((monsterId) => MONSTERS[monsterId]),
 );
+// Reserved ids stay in the monster manifest for asset tooling and Admin
+// review, but are filtered out of every active learner-facing summary.
+export const PUNCTUATION_RESERVED_MONSTER_IDS = Object.freeze(
+  (MONSTERS_BY_SUBJECT.punctuationReserve || []).filter((monsterId) => MONSTERS[monsterId]),
+);
 export const GRAMMAR_MONSTER_IDS = Object.freeze(
   (MONSTERS_BY_SUBJECT.grammar || []).filter((monsterId) => MONSTERS[monsterId]),
 );
 export const DIRECT_SPELLING_MONSTER_IDS = Object.freeze(
   SPELLING_MONSTER_IDS.filter((monsterId) => monsterId !== 'phaeton'),
 );
-export const PUNCTUATION_GRAND_MONSTER_ID = 'carillon';
+// Quoral becomes the grand aggregate; Carillon moves to reserved. The U6
+// normaliser preserves any pre-flip Carillon evidence by unioning it into
+// the Quoral view at read time.
+export const PUNCTUATION_GRAND_MONSTER_ID = 'quoral';
 export const GRAMMAR_GRAND_MONSTER_ID = 'concordium';
 
 export function readGameState(gameStateRepository, learnerId, systemId = DEFAULT_SYSTEM_ID) {

--- a/src/platform/game/monsters.js
+++ b/src/platform/game/monsters.js
@@ -42,12 +42,13 @@ export const MONSTERS = {
   pealark: {
     id: 'pealark',
     name: 'Pealark',
-    blurb: 'Rises as sentence endings become secure.',
+    blurb: 'Rises with sentence endings, speech and sentence boundaries.',
     accent: '#B8873F',
     secondary: '#E8C66F',
     pale: '#F7EEDC',
     nameByStage: ['Pealark Egg', 'Pealark', 'Chimewing', 'Bellcrest', 'Mega Bellcrest'],
-    masteredMax: 1,
+    // Endmarks (1) + Speech (1) + Boundary (3) = 5 reward units post-remap.
+    masteredMax: 5,
   },
   claspin: {
     id: 'claspin',
@@ -62,27 +63,28 @@ export const MONSTERS = {
   quoral: {
     id: 'quoral',
     name: 'Quoral',
-    blurb: 'Finds its voice through direct speech punctuation.',
+    blurb: 'The grand Bellstorm Coast creature for full Punctuation mastery.',
     accent: '#2E8479',
     secondary: '#8FD6C7',
     pale: '#E5F3EF',
-    nameByStage: ['Quoral Egg', 'Quoral', 'Voiceling', 'Quotecrest', 'Mega Quotecrest'],
-    masteredMax: 1,
+    nameByStage: ['Quoral Egg', 'Quoral', 'Voiceling', 'Choruscrest', 'Grand Quoral'],
+    masteredMax: 14,
   },
   curlune: {
     id: 'curlune',
     name: 'Curlune',
-    blurb: 'Will grow with commas, flow and clarity.',
+    blurb: 'Grows with commas, flow, lists and structural punctuation.',
     accent: '#4B7A4A',
     secondary: '#AACF93',
     pale: '#E8F0E6',
     nameByStage: ['Curlune Egg', 'Curlune', 'Commasprig', 'Flowhorn', 'Mega Flowhorn'],
-    masteredMax: 3,
+    // Comma / Flow (3) + Structure (4) = 7 reward units post-remap.
+    masteredMax: 7,
   },
   colisk: {
     id: 'colisk',
     name: 'Colisk',
-    blurb: 'Will strengthen through lists and sentence structure.',
+    blurb: 'Reserved future Punctuation creature; not active in this release.',
     accent: '#C06B3E',
     secondary: '#EAB08A',
     pale: '#FBEEE4',
@@ -92,7 +94,7 @@ export const MONSTERS = {
   hyphang: {
     id: 'hyphang',
     name: 'Hyphang',
-    blurb: 'Will sharpen with boundaries, dashes and hyphens.',
+    blurb: 'Reserved future Punctuation creature; not active in this release.',
     accent: '#8A5A9D',
     secondary: '#CDAFE1',
     pale: '#F1E9F4',
@@ -102,7 +104,7 @@ export const MONSTERS = {
   carillon: {
     id: 'carillon',
     name: 'Carillon',
-    blurb: 'The aggregate creature for the currently published Punctuation release.',
+    blurb: 'Reserved future Punctuation creature; not active in this release.',
     accent: '#D08A2C',
     secondary: '#E8C45A',
     pale: '#F6EED7',
@@ -183,7 +185,12 @@ export const MONSTERS = {
 
 export const MONSTERS_BY_SUBJECT = {
   spelling: ['inklet', 'glimmerbug', 'phaeton', 'vellhorn'],
-  punctuation: ['pealark', 'claspin', 'quoral', 'curlune', 'colisk', 'hyphang', 'carillon'],
+  // Active Punctuation roster: 3 direct cluster creatures (Pealark, Curlune,
+  // Claspin) + the grand legendary (Quoral) that aggregates all 14 reward
+  // units. Colisk / Hyphang / Carillon remain in MONSTERS for asset tooling
+  // and future activation but are no longer part of the learner-facing set.
+  punctuation: ['pealark', 'curlune', 'claspin', 'quoral'],
+  punctuationReserve: ['colisk', 'hyphang', 'carillon'],
   grammar: ['bracehart', 'glossbloom', 'loomrill', 'chronalyx', 'couronnail', 'mirrane', 'concordium'],
 };
 

--- a/src/surfaces/home/data.js
+++ b/src/surfaces/home/data.js
@@ -632,8 +632,13 @@ function withSynthesisedUncaughtMonsters(summary = []) {
   return [...summary, ...synthesised];
 }
 
+// Subject groups rendered in Codex. Reserved / non-learner-facing groupings
+// inside MONSTERS_BY_SUBJECT (e.g. `punctuationReserve`) are excluded so the
+// Codex keeps the spelling -> punctuation -> grammar ordering learners expect.
+const CODEX_SUBJECT_GROUP_IDS = Object.freeze(['spelling', 'punctuation', 'grammar']);
+
 export function buildCodexSubjectGroups(entries = []) {
-  return Object.keys(MONSTERS_BY_SUBJECT)
+  return CODEX_SUBJECT_GROUP_IDS
     .map((subjectId) => {
       const subjectEntries = entries.filter((entry) => entry.subjectId === subjectId);
       if (!subjectEntries.length) return null;
@@ -749,13 +754,15 @@ function nextCodexMilestone(monsterId, mastered, { subjectId = 'spelling', max =
 
 function codexWordBand(monsterId, subjectId = 'spelling') {
   if (subjectId === 'punctuation') {
-    if (monsterId === 'pealark') return 'Endmarks';
+    if (monsterId === 'pealark') return 'Endmarks, speech and boundary';
     if (monsterId === 'claspin') return 'Apostrophe';
-    if (monsterId === 'quoral') return 'Speech punctuation';
-    if (monsterId === 'curlune') return 'Comma and flow';
-    if (monsterId === 'colisk') return 'List and structure';
-    if (monsterId === 'hyphang') return 'Boundary punctuation';
-    if (monsterId === 'carillon') return 'Published punctuation release';
+    if (monsterId === 'curlune') return 'Comma, flow and structure';
+    if (monsterId === 'quoral') return 'Published punctuation release';
+    // Reserved monsters retain descriptive copy for Admin / asset tooling
+    // even though they are filtered out of active learner summaries.
+    if (monsterId === 'colisk') return 'Reserved: future list and structure';
+    if (monsterId === 'hyphang') return 'Reserved: future boundary expansion';
+    if (monsterId === 'carillon') return 'Reserved: future aggregate legendary';
     return 'Punctuation codex';
   }
   if (subjectId === 'grammar') {

--- a/src/surfaces/home/data.js
+++ b/src/surfaces/home/data.js
@@ -20,6 +20,12 @@ import {
 } from '../../platform/game/monster-visual-config.js';
 
 const MONSTER_VARIANTS = ['b1', 'b2'];
+// Higher number = higher feature weight in pickFeaturedCodexEntry. The grand
+// creatures (Phaeton, Quoral, Concordium) outrank their direct siblings so
+// they win tie-breaks when a learner catches the grand. Reserved Punctuation
+// creatures are pushed to the top numerically only as a tombstone — they are
+// filtered out of active surfaces before ranking applies, so the high rank
+// never reaches the learner-facing sort path.
 const CODEX_POWER_RANK = Object.freeze({
   inklet: 1,
   glimmerbug: 2,
@@ -27,11 +33,11 @@ const CODEX_POWER_RANK = Object.freeze({
   vellhorn: 4,
   pealark: 5,
   claspin: 6,
-  quoral: 7,
-  curlune: 8,
-  colisk: 9,
-  hyphang: 10,
-  carillon: 11,
+  curlune: 7,
+  quoral: 11,
+  colisk: 8,
+  hyphang: 9,
+  carillon: 10,
   bracehart: 12,
   glossbloom: 13,
   loomrill: 14,
@@ -685,7 +691,11 @@ function deriveSubjectStatus(entries) {
 }
 
 export function pickFeaturedCodexEntry(entries = []) {
+  // Reserved creatures (Colisk, Hyphang, Carillon under the Phase 2 roster)
+  // stay in MONSTERS for asset tooling but must never be featured on the
+  // learner Codex hero. Filter them out before ranking.
   return entries
+    .filter((entry) => entry?.subjectId !== 'punctuationReserve')
     .slice()
     .sort((left, right) => {
       if (left.caught !== right.caught) return left.caught ? -1 : 1;
@@ -710,10 +720,13 @@ function codexPowerRank(monsterId) {
   return CODEX_POWER_RANK[monsterId] || 0;
 }
 
-// Lower index = earlier on-ramp; mirrors the curriculum order encoded by
-// MONSTERS_BY_SUBJECT declaration order in src/platform/game/monsters.js.
+// Lower index = earlier on-ramp. Mirrors the curriculum order a learner
+// would progress through, deliberately excluding non-learner-facing groupings
+// (reserved monsters) that otherwise appear as extra entries in
+// Object.keys(MONSTERS_BY_SUBJECT).
+const SUBJECT_PRIORITY_ORDER = Object.freeze(['spelling', 'punctuation', 'grammar']);
 function subjectPriority(subjectId) {
-  const idx = Object.keys(MONSTERS_BY_SUBJECT).indexOf(subjectId);
+  const idx = SUBJECT_PRIORITY_ORDER.indexOf(subjectId);
   return idx === -1 ? 999 : idx;
 }
 

--- a/tests/punctuation-rewards.test.js
+++ b/tests/punctuation-rewards.test.js
@@ -61,10 +61,11 @@ test('first secure Punctuation unit records a cluster monster and the grand aggr
   });
   const state = repository.state();
 
+  // Under the Phase 2 roster: endmarks -> pealark (direct) + quoral (grand).
   assert.equal(events.some((event) => event.monsterId === 'pealark'), true);
-  assert.equal(events.some((event) => event.monsterId === 'carillon'), true);
+  assert.equal(events.some((event) => event.monsterId === 'quoral'), true);
   assert.deepEqual(state.pealark.mastered, [endmarkEvent.masteryKey]);
-  assert.deepEqual(state.carillon.mastered, [endmarkEvent.masteryKey]);
+  assert.deepEqual(state.quoral.mastered, [endmarkEvent.masteryKey]);
 
   const duplicate = rewardEventsFromPunctuationEvents([endmarkEvent], {
     gameStateRepository: repository,
@@ -82,25 +83,27 @@ test('current release monster progress ignores mastery keys from previous releas
     rewardUnitId: 'sentence-endings-core',
   });
   const repository = makeRepository({
-    pealark: { mastered: [oldMasteryKey], caught: true, publishedTotal: 1 },
-    carillon: { mastered: [oldMasteryKey], caught: true, publishedTotal: 14 },
+    // Pealark covers endmarks + speech + boundary under the Phase 2 roster.
+    // Quoral (grand) covers the full 14-unit release.
+    pealark: { mastered: [oldMasteryKey], caught: true, publishedTotal: 5 },
+    quoral: { mastered: [oldMasteryKey], caught: true, publishedTotal: 14 },
   });
 
-  assert.equal(progressForPunctuationMonster(repository.state(), 'pealark', { publishedTotal: 1 }).mastered, 0);
-  assert.equal(progressForPunctuationMonster(repository.state(), 'carillon', { publishedTotal: 14 }).mastered, 0);
+  assert.equal(progressForPunctuationMonster(repository.state(), 'pealark', { publishedTotal: 5 }).mastered, 0);
+  assert.equal(progressForPunctuationMonster(repository.state(), 'quoral', { publishedTotal: 14 }).mastered, 0);
 
   rewardEventsFromPunctuationEvents([endmarkEvent], {
     gameStateRepository: repository,
     random: () => 0,
   });
   const state = repository.state();
-  const pealark = progressForPunctuationMonster(state, 'pealark', { publishedTotal: 1 });
-  const carillon = progressForPunctuationMonster(state, 'carillon', { publishedTotal: 14 });
+  const pealark = progressForPunctuationMonster(state, 'pealark', { publishedTotal: 5 });
+  const quoral = progressForPunctuationMonster(state, 'quoral', { publishedTotal: 14 });
 
   assert.deepEqual(state.pealark.mastered, [oldMasteryKey, endmarkEvent.masteryKey]);
   assert.deepEqual(pealark.masteredList, [endmarkEvent.masteryKey]);
   assert.equal(pealark.mastered, 1);
-  assert.equal(carillon.mastered, 1);
+  assert.equal(quoral.mastered, 1);
 });
 
 test('previous release reward events cannot reserve current release mastery keys', () => {
@@ -162,83 +165,82 @@ test('Apostrophe cluster reaches stage 4 when all published units are secure', (
   assert.equal(progressForPunctuationMonster(repository.state(), 'claspin', { publishedTotal: 2 }).stage, 4);
 });
 
-test('Comma / Flow cluster reaches stage 4 when all published units are secure', () => {
+test('Curlune reaches stage 4 when all published comma_flow + structure units are secure', () => {
+  // Phase 2 roster: Curlune covers comma_flow (3) + structure (4) = 7 units.
   const repository = makeRepository();
-  for (const rewardUnitId of ['list-commas-core', 'fronted-adverbials-core', 'comma-clarity-core']) {
+  const curluneUnits = [
+    ['comma_flow', 'list-commas-core'],
+    ['comma_flow', 'fronted-adverbials-core'],
+    ['comma_flow', 'comma-clarity-core'],
+    ['structure', 'parenthesis-core'],
+    ['structure', 'colons-core'],
+    ['structure', 'semicolon-lists-core'],
+    ['structure', 'bullet-points-core'],
+  ];
+  for (const [clusterId, rewardUnitId] of curluneUnits) {
     recordPunctuationRewardUnitMastery({
       learnerId: 'learner-a',
       releaseId: PUNCTUATION_RELEASE_ID,
-      clusterId: 'comma_flow',
+      clusterId,
       rewardUnitId,
-      masteryKey: masteryKey('comma_flow', rewardUnitId),
+      masteryKey: masteryKey(clusterId, rewardUnitId),
       monsterId: 'curlune',
-      publishedTotal: 3,
+      publishedTotal: 7,
       aggregatePublishedTotal: 14,
       gameStateRepository: repository,
       random: () => 0,
     });
   }
 
-  assert.equal(progressForPunctuationMonster(repository.state(), 'curlune', { publishedTotal: 3 }).stage, 4);
+  assert.equal(progressForPunctuationMonster(repository.state(), 'curlune', { publishedTotal: 7 }).stage, 4);
 });
 
-test('Boundary cluster reaches stage 4 when all published units are secure', () => {
+test('Pealark reaches stage 4 when all published endmarks + speech + boundary units are secure', () => {
+  // Phase 2 roster: Pealark covers endmarks (1) + speech (1) + boundary (3) = 5 units.
   const repository = makeRepository();
-  for (const rewardUnitId of ['semicolons-core', 'dash-clauses-core', 'hyphens-core']) {
+  const pealarkUnits = [
+    ['endmarks', 'sentence-endings-core'],
+    ['speech', 'speech-core'],
+    ['boundary', 'semicolons-core'],
+    ['boundary', 'dash-clauses-core'],
+    ['boundary', 'hyphens-core'],
+  ];
+  for (const [clusterId, rewardUnitId] of pealarkUnits) {
     recordPunctuationRewardUnitMastery({
       learnerId: 'learner-a',
       releaseId: PUNCTUATION_RELEASE_ID,
-      clusterId: 'boundary',
+      clusterId,
       rewardUnitId,
-      masteryKey: masteryKey('boundary', rewardUnitId),
-      monsterId: 'hyphang',
-      publishedTotal: 3,
+      masteryKey: masteryKey(clusterId, rewardUnitId),
+      monsterId: 'pealark',
+      publishedTotal: 5,
       aggregatePublishedTotal: 14,
       gameStateRepository: repository,
       random: () => 0,
     });
   }
 
-  assert.equal(progressForPunctuationMonster(repository.state(), 'hyphang', { publishedTotal: 3 }).stage, 4);
-});
-
-test('List / Structure cluster reaches stage 4 when all published units are secure', () => {
-  const repository = makeRepository();
-  for (const rewardUnitId of ['parenthesis-core', 'colons-core', 'semicolon-lists-core', 'bullet-points-core']) {
-    recordPunctuationRewardUnitMastery({
-      learnerId: 'learner-a',
-      releaseId: PUNCTUATION_RELEASE_ID,
-      clusterId: 'structure',
-      rewardUnitId,
-      masteryKey: masteryKey('structure', rewardUnitId),
-      monsterId: 'colisk',
-      publishedTotal: 4,
-      aggregatePublishedTotal: 14,
-      gameStateRepository: repository,
-      random: () => 0,
-    });
-  }
-
-  assert.equal(progressForPunctuationMonster(repository.state(), 'colisk', { publishedTotal: 4 }).stage, 4);
+  assert.equal(progressForPunctuationMonster(repository.state(), 'pealark', { publishedTotal: 5 }).stage, 4);
 });
 
 test('published-release aggregate reaches stage 4 only for current published denominator', () => {
+  // Phase 2 cluster -> monster remap. Grand aggregate is now Quoral.
   const repository = makeRepository();
   for (const [clusterId, rewardUnitId, monsterId, publishedTotal] of [
-    ['endmarks', 'sentence-endings-core', 'pealark', 1],
+    ['endmarks', 'sentence-endings-core', 'pealark', 5],
     ['apostrophe', 'apostrophe-contractions-core', 'claspin', 2],
     ['apostrophe', 'apostrophe-possession-core', 'claspin', 2],
-    ['speech', 'speech-core', 'quoral', 1],
-    ['comma_flow', 'list-commas-core', 'curlune', 3],
-    ['comma_flow', 'fronted-adverbials-core', 'curlune', 3],
-    ['comma_flow', 'comma-clarity-core', 'curlune', 3],
-    ['structure', 'parenthesis-core', 'colisk', 4],
-    ['structure', 'colons-core', 'colisk', 4],
-    ['structure', 'semicolon-lists-core', 'colisk', 4],
-    ['structure', 'bullet-points-core', 'colisk', 4],
-    ['boundary', 'semicolons-core', 'hyphang', 3],
-    ['boundary', 'dash-clauses-core', 'hyphang', 3],
-    ['boundary', 'hyphens-core', 'hyphang', 3],
+    ['speech', 'speech-core', 'pealark', 5],
+    ['comma_flow', 'list-commas-core', 'curlune', 7],
+    ['comma_flow', 'fronted-adverbials-core', 'curlune', 7],
+    ['comma_flow', 'comma-clarity-core', 'curlune', 7],
+    ['structure', 'parenthesis-core', 'curlune', 7],
+    ['structure', 'colons-core', 'curlune', 7],
+    ['structure', 'semicolon-lists-core', 'curlune', 7],
+    ['structure', 'bullet-points-core', 'curlune', 7],
+    ['boundary', 'semicolons-core', 'pealark', 5],
+    ['boundary', 'dash-clauses-core', 'pealark', 5],
+    ['boundary', 'hyphens-core', 'pealark', 5],
   ]) {
     recordPunctuationRewardUnitMastery({
       learnerId: 'learner-a',
@@ -253,9 +255,9 @@ test('published-release aggregate reaches stage 4 only for current published den
       random: () => 0,
     });
   }
-  const carillon = progressForPunctuationMonster(repository.state(), 'carillon', { publishedTotal: 14 });
-  assert.equal(carillon.mastered, 14);
-  assert.equal(carillon.stage, 4);
+  const quoral = progressForPunctuationMonster(repository.state(), 'quoral', { publishedTotal: 14 });
+  assert.equal(quoral.mastered, 14);
+  assert.equal(quoral.stage, 4);
 });
 
 test('generated-template expansion does not change release-scoped mastery keys', () => {

--- a/tests/react-punctuation-assets.test.js
+++ b/tests/react-punctuation-assets.test.js
@@ -50,14 +50,16 @@ test('Codex entries describe Punctuation as secure units rather than spelling wo
     clusterId: 'endmarks',
     rewardUnitId: 'sentence-endings-core',
   });
+  // Phase 2 roster: Pealark's publishedTotal is 5 (endmarks + speech + boundary).
+  // Quoral is the grand aggregate with 14 units.
   const summary = punctuationMonsterSummaryFromState({
     pealark: {
       mastered: [masteryKey],
-      publishedTotal: 1,
+      publishedTotal: 5,
       caught: true,
       branch: 'b1',
     },
-    carillon: {
+    quoral: {
       mastered: [masteryKey],
       publishedTotal: 14,
       caught: true,
@@ -66,18 +68,18 @@ test('Codex entries describe Punctuation as secure units rather than spelling wo
   }, { aggregateTotal: 14 });
   const entries = buildCodexEntries(summary);
   const pealark = entries.find((entry) => entry.id === 'pealark');
-  const carillon = entries.find((entry) => entry.id === 'carillon');
+  const quoral = entries.find((entry) => entry.id === 'quoral');
 
   assert.equal(pealark.subjectId, 'punctuation');
   assert.equal(pealark.secureLabel, '1 secure unit');
-  assert.equal(pealark.wordBand, 'Endmarks');
-  assert.equal(pealark.nextGoal, 'Fully evolved');
-  assert.match(pealark.img, /assets\/monsters\/pealark\/b1\/pealark-b1-4\.640\.webp/);
+  assert.equal(pealark.wordBand, 'Endmarks, speech and boundary');
+  // 1 of 5 secured = stage 1 (one-fifth of the way).
+  assert.equal(pealark.progressPct, 20);
 
-  assert.equal(carillon.subjectId, 'punctuation');
-  assert.equal(carillon.secureLabel, '1 secure unit');
-  assert.equal(carillon.wordBand, 'Published punctuation release');
-  assert.equal(carillon.progressPct, 7);
+  assert.equal(quoral.subjectId, 'punctuation');
+  assert.equal(quoral.secureLabel, '1 secure unit');
+  assert.equal(quoral.wordBand, 'Published punctuation release');
+  assert.equal(quoral.progressPct, 7);
 });
 
 test('Codex entry defaults remain spelling-compatible', () => {


### PR DESCRIPTION
## Summary

- Collapse Punctuation learner-facing roster: \`pealark / curlune / claspin / quoral\` active, \`colisk / hyphang / carillon\` reserved
- \`PUNCTUATION_GRAND_MONSTER_ID\` flips \`carillon\` → \`quoral\`
- Cluster remap: \`speech\` / \`boundary\` → pealark; \`structure\` → curlune; \`endmarks\` / \`apostrophe\` / \`comma_flow\` unchanged
- Quoral masteredMax 1 → 14 (grand creature); Pealark 1 → 5; Curlune 3 → 7
- Reserved creatures retain definitions but blurbs note reserved status
- New exports: \`MONSTERS_BY_SUBJECT.punctuationReserve\`, \`PUNCTUATION_RESERVED_MONSTER_IDS\`
- \`buildCodexSubjectGroups\` uses a fixed learner-facing subject list so \`punctuationReserve\` doesn't leak into Codex
- Home surface display copy updated for the new creature-to-cluster mapping

U5 leaves reward writes on the new map; pre-flip learner progress preservation comes in U6 normaliser + U7 writer seam.

## Test plan

- [x] \`tests/punctuation-rewards.test.js\` updated (new cluster monsterId expectations, Pealark/Curlune full-coverage tests replacing old Boundary / List-Structure / Comma-Flow)
- [x] \`tests/react-punctuation-assets.test.js\` updated (Codex label copy + grand is now quoral with correct progressPct)
- [x] Full suite: 955 / 947 / 7 (same 7 pre-existing bundle-audit failures as base)
- [ ] CI: full suite green