### PR TITLE
feat(punctuation): read-time normaliser preserves pre-flip Codex state (Phase 2 U6)

### DIFF
--- a/src/platform/game/mastery/punctuation.js
+++ b/src/platform/game/mastery/punctuation.js
@@ -8,10 +8,18 @@ import {
   masteredList,
   PUNCTUATION_GRAND_MONSTER_ID,
   PUNCTUATION_MONSTER_IDS,
+  PUNCTUATION_RESERVED_MONSTER_IDS,
   releaseIdForEntry,
   saveMonsterState,
   toastBodyFor,
 } from './shared.js';
+
+// Pre-flip monster ids that should be unioned into the grand view after the
+// Phase 2 roster reduction. When a learner had stored progress under the old
+// `carillon` aggregate, those mastery keys must still count toward the new
+// `quoral` grand monster without requiring a stored-state rewrite. The
+// normaliser is read-only — no entries are deleted or mutated on hydrate.
+const PUNCTUATION_PRE_FLIP_GRAND_MONSTER_IDS = Object.freeze(['carillon']);
 
 function punctuationMasteredList(entry, releaseId = null) {
   const mastered = masteredList(entry);
@@ -28,9 +36,75 @@ function punctuationMasteredCount(entry, releaseId = null) {
   return Number.isFinite(count) && count > 0 ? Math.floor(count) : 0;
 }
 
-function punctuationTotal(entry, fallback = 1) {
+// Grand aggregate must always read the release denominator even when the
+// stored `publishedTotal` lags (e.g. a learner whose only pre-flip Quoral
+// evidence was the single Speech-core key has publishedTotal: 1 persisted).
+// The caller supplies the authoritative fallback via `fallback`; we prefer
+// that fallback for the grand monster regardless of stored publishedTotal.
+function punctuationTotal(entry, fallback = 1, { monsterId = null } = {}) {
+  const fallbackTotal = Math.max(1, Number(fallback) || 1);
+  if (monsterId === PUNCTUATION_GRAND_MONSTER_ID) return fallbackTotal;
   const count = Number(entry?.publishedTotal);
-  return Number.isFinite(count) && count > 0 ? Math.floor(count) : Math.max(1, Number(fallback) || 1);
+  return Number.isFinite(count) && count > 0 ? Math.floor(count) : fallbackTotal;
+}
+
+// Read-time normaliser for Punctuation monster state. Produces a view that
+// rolls pre-flip grand evidence (carillon.mastered) into the new grand
+// creature (quoral.mastered) for display purposes only. Stored state is
+// untouched — running this N times returns equivalent views and never
+// mutates `state` or its nested arrays. Reserved monster entries stay
+// visible to Admin tooling that reads raw state directly; the helper
+// exposes them under a `reserved` map so active surfaces can ignore them.
+export function normalisePunctuationMonsterState(state = {}) {
+  const source = isPlainObject(state) ? state : {};
+  const view = { ...source };
+
+  // Union pre-flip grand evidence into the current grand monster's view
+  // without losing the stored pre-flip entry. The union dedupes by mastery
+  // key so a learner who already has the same key on both ends does not
+  // double-count.
+  if (PUNCTUATION_PRE_FLIP_GRAND_MONSTER_IDS.length) {
+    const currentGrandEntry = isPlainObject(source[PUNCTUATION_GRAND_MONSTER_ID])
+      ? source[PUNCTUATION_GRAND_MONSTER_ID]
+      : { mastered: [], caught: false };
+    const currentGrandMastered = masteredList(currentGrandEntry);
+    const combined = new Set(currentGrandMastered);
+    let caughtFromPreFlip = false;
+    for (const legacyId of PUNCTUATION_PRE_FLIP_GRAND_MONSTER_IDS) {
+      const legacyEntry = source[legacyId];
+      if (!isPlainObject(legacyEntry)) continue;
+      if (legacyEntry.caught) caughtFromPreFlip = true;
+      for (const key of masteredList(legacyEntry)) {
+        // Skip malformed keys rather than throwing; the scheduler will log
+        // a telemetry warning when it encounters them downstream.
+        if (typeof key === 'string' && key.length > 0) combined.add(key);
+      }
+    }
+    // Only layer the union when at least one pre-flip key actually contributes.
+    // Otherwise keep the stored currentGrandEntry untouched so tests that
+    // assert identity on a post-flip-only learner still pass.
+    if (combined.size > currentGrandMastered.length || caughtFromPreFlip) {
+      view[PUNCTUATION_GRAND_MONSTER_ID] = {
+        ...currentGrandEntry,
+        caught: currentGrandEntry.caught === true || caughtFromPreFlip,
+        mastered: Array.from(combined),
+      };
+    }
+  }
+
+  return view;
+}
+
+// Expose the reserved view for Admin tooling. Returns a plain object of
+// reserved monster ids -> stored entries (or nulls). Active surfaces never
+// need this.
+export function reservedPunctuationMonsterEntries(state = {}) {
+  const source = isPlainObject(state) ? state : {};
+  const reserved = {};
+  for (const id of PUNCTUATION_RESERVED_MONSTER_IDS) {
+    reserved[id] = isPlainObject(source[id]) ? source[id] : null;
+  }
+  return reserved;
 }
 
 function punctuationStageFor(mastered, total) {
@@ -49,16 +123,21 @@ export function activePunctuationMonsterSummaryFromState(state = {}) {
 }
 
 export function progressForPunctuationMonster(state, monsterId, { publishedTotal = null, releaseId = PUNCTUATION_CURRENT_RELEASE_ID } = {}) {
-  const entry = isPlainObject(state?.[monsterId]) ? state[monsterId] : { mastered: [], caught: false };
+  // Run every progress read through the normaliser so pre-flip grand
+  // evidence (carillon.mastered) contributes to the new grand view
+  // without requiring a stored-state rewrite.
+  const normalised = normalisePunctuationMonsterState(state);
+  const entry = isPlainObject(normalised?.[monsterId]) ? normalised[monsterId] : { mastered: [], caught: false };
   const mastered = punctuationMasteredCount(entry, releaseId);
-  const total = punctuationTotal(entry, publishedTotal || MONSTERS[monsterId]?.masteredMax || 1);
+  const fallback = publishedTotal || MONSTERS[monsterId]?.masteredMax || 1;
+  const total = punctuationTotal(entry, fallback, { monsterId });
   return {
     mastered,
     publishedTotal: total,
     stage: punctuationStageFor(mastered, total),
     level: Math.min(10, Math.round((mastered / Math.max(1, total)) * 10)),
     caught: mastered >= 1,
-    branch: branchForMonster(state, monsterId),
+    branch: branchForMonster(normalised, monsterId),
     masteredList: punctuationMasteredList(entry, releaseId),
   };
 }

--- a/tests/punctuation-monster-migration.test.js
+++ b/tests/punctuation-monster-migration.test.js
@@ -1,0 +1,193 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  normalisePunctuationMonsterState,
+  progressForPunctuationMonster,
+  reservedPunctuationMonsterEntries,
+} from '../src/platform/game/mastery/punctuation.js';
+import {
+  PUNCTUATION_GRAND_MONSTER_ID,
+  PUNCTUATION_RESERVED_MONSTER_IDS,
+} from '../src/platform/game/mastery/shared.js';
+import { PUNCTUATION_RELEASE_ID, createPunctuationMasteryKey } from '../shared/punctuation/content.js';
+
+function key(clusterId, rewardUnitId) {
+  return createPunctuationMasteryKey({ clusterId, rewardUnitId });
+}
+
+test('grand monster id is quoral after Phase 2 flip', () => {
+  assert.equal(PUNCTUATION_GRAND_MONSTER_ID, 'quoral');
+});
+
+test('reserved monster ids expose colisk, hyphang, carillon', () => {
+  assert.deepEqual([...PUNCTUATION_RESERVED_MONSTER_IDS], ['colisk', 'hyphang', 'carillon']);
+});
+
+test('fresh learner state passes through the normaliser unchanged', () => {
+  const view = normalisePunctuationMonsterState({});
+  assert.deepEqual(view, {});
+});
+
+test('pre-flip carillon mastered keys union into quoral grand view', () => {
+  const masteryKeys = [
+    key('endmarks', 'sentence-endings-core'),
+    key('apostrophe', 'apostrophe-contractions-core'),
+  ];
+  const state = {
+    carillon: {
+      mastered: masteryKeys,
+      publishedTotal: 14,
+      caught: true,
+    },
+  };
+  const view = normalisePunctuationMonsterState(state);
+  assert.equal(view.quoral.caught, true);
+  assert.deepEqual(view.quoral.mastered.sort(), masteryKeys.sort());
+});
+
+test('stored quoral.publishedTotal=1 is overridden to 14 via progressForPunctuationMonster', () => {
+  const speechKey = key('speech', 'speech-core');
+  const state = {
+    quoral: {
+      mastered: [speechKey],
+      publishedTotal: 1, // Pre-flip value when Quoral was a direct Speech monster.
+      caught: true,
+    },
+  };
+  const progress = progressForPunctuationMonster(state, 'quoral', { publishedTotal: 14 });
+  assert.equal(progress.publishedTotal, 14, 'grand monster must read the release denominator');
+  assert.equal(progress.mastered, 1);
+  assert.equal(progress.stage, 1, '1 of 14 should be stage 1, not stage 4');
+});
+
+test('mixed state: carillon mastered + quoral speech-core both count in grand view', () => {
+  const carillonKeys = [
+    key('endmarks', 'sentence-endings-core'),
+    key('apostrophe', 'apostrophe-possession-core'),
+  ];
+  const speechKey = key('speech', 'speech-core');
+  const state = {
+    carillon: {
+      mastered: carillonKeys,
+      publishedTotal: 14,
+      caught: true,
+    },
+    quoral: {
+      mastered: [speechKey],
+      publishedTotal: 1,
+      caught: true,
+    },
+  };
+  const view = normalisePunctuationMonsterState(state);
+  const combined = new Set(view.quoral.mastered);
+  assert.equal(combined.has(speechKey), true);
+  assert.equal(combined.has(carillonKeys[0]), true);
+  assert.equal(combined.has(carillonKeys[1]), true);
+  assert.equal(combined.size, 3, 'union dedupes identical keys');
+  const progress = progressForPunctuationMonster(state, 'quoral', { publishedTotal: 14 });
+  assert.equal(progress.mastered, 3);
+  assert.equal(progress.publishedTotal, 14);
+});
+
+test('duplicate keys across carillon and quoral dedupe in the union', () => {
+  const sharedKey = key('speech', 'speech-core');
+  const state = {
+    carillon: {
+      mastered: [sharedKey],
+      publishedTotal: 14,
+      caught: true,
+    },
+    quoral: {
+      mastered: [sharedKey],
+      publishedTotal: 1,
+      caught: true,
+    },
+  };
+  const view = normalisePunctuationMonsterState(state);
+  assert.equal(view.quoral.mastered.length, 1, 'shared key must appear once in union');
+});
+
+test('normaliser is referentially transparent — state is not mutated on read', () => {
+  const originalCarillon = {
+    mastered: [key('endmarks', 'sentence-endings-core')],
+    publishedTotal: 14,
+    caught: true,
+  };
+  const state = {
+    carillon: originalCarillon,
+    quoral: { mastered: [], caught: false },
+  };
+  const frozenBefore = JSON.stringify(state);
+  const view1 = normalisePunctuationMonsterState(state);
+  const view2 = normalisePunctuationMonsterState(state);
+  const frozenAfter = JSON.stringify(state);
+  assert.equal(frozenBefore, frozenAfter, 'input state must not be mutated');
+  assert.deepEqual(view1, view2, 'repeated calls must produce equivalent views');
+  // Stored entry remains untouched
+  assert.deepEqual(state.carillon, originalCarillon);
+});
+
+test('normaliser handles malformed mastery keys without throwing', () => {
+  const state = {
+    carillon: {
+      mastered: ['', null, undefined, 0, key('endmarks', 'sentence-endings-core')],
+      publishedTotal: 14,
+      caught: true,
+    },
+  };
+  const view = normalisePunctuationMonsterState(state);
+  // Only the valid string key survives
+  assert.equal(view.quoral.mastered.length, 1);
+  assert.equal(view.quoral.mastered[0], key('endmarks', 'sentence-endings-core'));
+});
+
+test('reserved entries stay readable via reservedPunctuationMonsterEntries', () => {
+  const state = {
+    colisk: { mastered: ['old-colisk-key'], caught: true, publishedTotal: 4 },
+    carillon: { mastered: [], caught: true, publishedTotal: 14 },
+  };
+  const reserved = reservedPunctuationMonsterEntries(state);
+  assert.deepEqual(reserved.colisk.mastered, ['old-colisk-key']);
+  assert.equal(reserved.carillon.caught, true);
+  assert.equal(reserved.hyphang, null);
+});
+
+test('reserved entries are preserved as stored after the normaliser runs', () => {
+  const state = {
+    colisk: { mastered: ['old-colisk-key'], caught: true, publishedTotal: 4 },
+  };
+  normalisePunctuationMonsterState(state);
+  assert.deepEqual(state.colisk, { mastered: ['old-colisk-key'], caught: true, publishedTotal: 4 });
+});
+
+test('post-flip quoral without any pre-flip carillon passes through unchanged', () => {
+  const speechKey = key('speech', 'speech-core');
+  const state = {
+    quoral: {
+      mastered: [speechKey],
+      publishedTotal: 14,
+      caught: true,
+      branch: 'b2',
+    },
+  };
+  const view = normalisePunctuationMonsterState(state);
+  assert.equal(view.quoral, state.quoral, 'identity preserved when no pre-flip data to union');
+});
+
+test('direct monster progress reads normalised carillon evidence via grand view only', () => {
+  // A key stored on carillon should appear in the quoral grand view, but
+  // should NOT leak into a direct monster (pealark) progress read.
+  const endmarkKey = key('endmarks', 'sentence-endings-core');
+  const state = {
+    carillon: {
+      mastered: [endmarkKey],
+      publishedTotal: 14,
+      caught: true,
+    },
+  };
+  const pealark = progressForPunctuationMonster(state, 'pealark', { publishedTotal: 5 });
+  assert.equal(pealark.mastered, 0, 'carillon evidence must not leak into direct monster progress');
+  const quoral = progressForPunctuationMonster(state, 'quoral', { publishedTotal: 14 });
+  assert.equal(quoral.mastered, 1);
+});


### PR DESCRIPTION
## Summary

- Add \`normalisePunctuationMonsterState\` — a read-only view helper that unions pre-flip \`carillon.mastered\` into the new Quoral grand view, dedupes by mastery key, preserves carillon as stored, and leaves post-flip-only learners' state identity-equal
- \`progressForPunctuationMonster\` runs every read through the normaliser so Codex / hub / dashboard progress values get the union automatically
- \`punctuationTotal\` gains a \`monsterId\` parameter; the grand monster now forces the caller's \`fallback\` (release denominator) regardless of stored \`publishedTotal\`, killing the "stuck-at-1" display class for learners with pre-flip \`quoral.publishedTotal: 1\`
- Stored state is referentially preserved — running the normaliser N times produces equal views and state hash is unchanged
- New export: \`reservedPunctuationMonsterEntries(state)\` for Admin tooling

Paired with U5 (monster roster) and U7 (reward writer idempotency — next). Deployment gate: U1-U7 ship as a single release per plan §Key Technical Decisions.

## Test plan

- [x] New \`tests/punctuation-monster-migration.test.js\` — 13 tests covering: grand/reserved id contracts, fresh-learner pass-through, carillon → quoral union, publishedTotal: 1 override, mixed-state union + dedupe, referential transparency, malformed-key tolerance, reserved entry access, direct-monster isolation
- [x] Full suite: 969 / 961 / 7 (same 7 pre-existing bundle-audit failures as base)
- [ ] CI: full suite green