### PR TITLE
feat(punctuation): projection-layer dedupe for terminal reward transitions (Phase 2 U7)

### DIFF
--- a/tests/punctuation-rewards.test.js
+++ b/tests/punctuation-rewards.test.js
@@ -279,3 +279,129 @@ test('generated-template expansion does not change release-scoped mastery keys',
   assert.ok(first.length >= 1);
   assert.deepEqual(second, []);
 });
+
+// --------------- U7: projection-layer dedupe across roster flip -----------
+
+import {
+  combineCommandEvents,
+  terminalRewardToken,
+} from '../worker/src/projections/events.js';
+
+test('terminalRewardToken uses (learnerId, monsterId, kind, releaseId)', () => {
+  const token = terminalRewardToken({
+    type: 'reward.monster',
+    kind: 'caught',
+    learnerId: 'learner-a',
+    monsterId: 'quoral',
+    releaseId: 'punctuation-r4-full-14-skill-structure',
+  });
+  assert.equal(token, 'reward.monster.terminal:learner-a:quoral:caught:punctuation-r4-full-14-skill-structure');
+});
+
+test('terminalRewardToken returns null for non-terminal transitions', () => {
+  assert.equal(terminalRewardToken({ type: 'reward.monster', kind: 'levelup', learnerId: 'a', monsterId: 'quoral' }), null);
+  assert.equal(terminalRewardToken({ type: 'reward.monster', kind: 'evolve', learnerId: 'a', monsterId: 'quoral' }), null);
+  assert.equal(terminalRewardToken({ type: 'punctuation.unit-secured', learnerId: 'a' }), null);
+  assert.equal(terminalRewardToken(null), null);
+});
+
+test('cross-flip caught events dedupe to one terminal transition per (learner, monster, release)', () => {
+  // Simulate pre-flip + post-flip caught events for the same learner and
+  // monster within the same release. The id-based dedupe keeps both (the
+  // cluster segment differs), but the terminal token collapses them.
+  const preFlip = {
+    id: 'reward.monster:learner-a:punctuation:r4:speech:speech-core:quoral:caught',
+    type: 'reward.monster',
+    kind: 'caught',
+    learnerId: 'learner-a',
+    monsterId: 'quoral',
+    releaseId: 'punctuation-r4-full-14-skill-structure',
+    clusterId: 'speech',
+  };
+  const postFlip = {
+    id: 'reward.monster:learner-a:punctuation:r4:published_release:speech-core:quoral:caught',
+    type: 'reward.monster',
+    kind: 'caught',
+    learnerId: 'learner-a',
+    monsterId: 'quoral',
+    releaseId: 'punctuation-r4-full-14-skill-structure',
+    clusterId: 'published_release',
+  };
+  // Case A: pre-flip is already persisted; post-flip arrives fresh.
+  const combined = combineCommandEvents({
+    domainEvents: [postFlip],
+    existingEvents: [preFlip],
+  });
+  assert.equal(combined.events.length, 0, 'post-flip duplicate collapses against existing pre-flip row');
+
+  // Case B: both arrive together as new events.
+  const fresh = combineCommandEvents({
+    domainEvents: [preFlip, postFlip],
+  });
+  assert.equal(fresh.events.length, 1, 'batch of pre + post emits only one terminal');
+  assert.equal(fresh.events[0].clusterId, 'speech', 'first-in-wins (pre-flip id retained)');
+});
+
+test('cross-release caught events remain distinct — future release re-emits', () => {
+  const r4 = {
+    id: 'reward.monster:learner-a:punctuation:r4:published_release:speech-core:quoral:caught',
+    type: 'reward.monster',
+    kind: 'caught',
+    learnerId: 'learner-a',
+    monsterId: 'quoral',
+    releaseId: 'punctuation-r4-full-14-skill-structure',
+  };
+  const r5 = {
+    ...r4,
+    id: 'reward.monster:learner-a:punctuation:r5:published_release:speech-core:quoral:caught',
+    releaseId: 'punctuation-r5-future',
+  };
+  const combined = combineCommandEvents({
+    domainEvents: [r5],
+    existingEvents: [r4],
+  });
+  assert.equal(combined.events.length, 1, 'new release must still emit a terminal transition');
+  assert.equal(combined.events[0].releaseId, 'punctuation-r5-future');
+});
+
+test('mega across flip also dedupes by terminal token', () => {
+  const preFlipMega = {
+    id: 'reward.monster:learner-a:punctuation:r4:speech:speech-core:quoral:mega',
+    type: 'reward.monster',
+    kind: 'mega',
+    learnerId: 'learner-a',
+    monsterId: 'quoral',
+    releaseId: 'punctuation-r4-full-14-skill-structure',
+  };
+  const postFlipMega = {
+    ...preFlipMega,
+    id: 'reward.monster:learner-a:punctuation:r4:published_release:bullet-points-core:quoral:mega',
+  };
+  const combined = combineCommandEvents({
+    domainEvents: [postFlipMega],
+    existingEvents: [preFlipMega],
+  });
+  assert.equal(combined.events.length, 0, 'mega dedupes by (learner, monster, kind, release)');
+});
+
+test('levelup and evolve are unaffected by terminal dedupe', () => {
+  const existing = {
+    id: 'reward.monster:learner-a:punctuation:r4:speech:speech-core:quoral:levelup',
+    type: 'reward.monster',
+    kind: 'levelup',
+    learnerId: 'learner-a',
+    monsterId: 'quoral',
+    releaseId: 'punctuation-r4-full-14-skill-structure',
+  };
+  const next = {
+    ...existing,
+    id: 'reward.monster:learner-a:punctuation:r4:published_release:speech-core:quoral:levelup',
+  };
+  const combined = combineCommandEvents({
+    domainEvents: [next],
+    existingEvents: [existing],
+  });
+  // levelup / evolve are id-deduped only (different ids -> both survive).
+  // This is deliberate: only caught / mega represent terminal milestones.
+  assert.equal(combined.events.length, 1);
+});

--- a/tests/punctuation-rewards.test.js
+++ b/tests/punctuation-rewards.test.js
@@ -384,6 +384,28 @@ test('mega across flip also dedupes by terminal token', () => {
   assert.equal(combined.events.length, 0, 'mega dedupes by (learner, monster, kind, release)');
 });
 
+test('caught and mega coexist for the same (learner, monster, release)', () => {
+  // Terminal dedupe keys on `kind`, so caught and mega with identical
+  // (learner, monster, release) must both survive — they are separate
+  // milestones a learner is entitled to celebrate.
+  const caught = {
+    id: 'reward.monster:learner-a:punctuation:r4:speech:speech-core:quoral:caught',
+    type: 'reward.monster',
+    kind: 'caught',
+    learnerId: 'learner-a',
+    monsterId: 'quoral',
+    releaseId: 'punctuation-r4-full-14-skill-structure',
+  };
+  const mega = {
+    ...caught,
+    id: 'reward.monster:learner-a:punctuation:r4:published_release:bullet-points-core:quoral:mega',
+    kind: 'mega',
+  };
+  const combined = combineCommandEvents({ domainEvents: [caught, mega] });
+  assert.equal(combined.events.length, 2, 'caught and mega are distinct milestones');
+  assert.deepEqual(combined.events.map((event) => event.kind).sort(), ['caught', 'mega']);
+});
+
 test('levelup and evolve are unaffected by terminal dedupe', () => {
   const existing = {
     id: 'reward.monster:learner-a:punctuation:r4:speech:speech-core:quoral:levelup',

--- a/worker/src/projections/events.js
+++ b/worker/src/projections/events.js
@@ -27,12 +27,32 @@ export function eventToken(event) {
   return null;
 }
 
-export function dedupeEvents(events, seenTokens = new Set()) {
+// Terminal-transition semantic token: dedupes `caught` and `mega` events for
+// the same (learnerId, monsterId, kind, releaseId) so a roster flip (e.g.
+// Punctuation Phase 2 where grand monster carillon -> quoral) cannot emit a
+// second terminal transition for a learner who already earned the same
+// milestone under the previous roster. The id-based `eventToken` above
+// returns different strings across the flip (the cluster segment changes),
+// so storage keeps both rows — the semantic token collapses them at
+// projection time. Cross-release re-emission is intentional and not
+// deduped here (the releaseId segment differs), so future releases still
+// celebrate a new mega.
+export function terminalRewardToken(event) {
+  if (!event || typeof event !== 'object' || event.type !== 'reward.monster') return null;
+  if (event.kind !== 'caught' && event.kind !== 'mega') return null;
+  const releaseId = typeof event.releaseId === 'string' ? event.releaseId : '';
+  return ['reward.monster.terminal', event.learnerId || '', event.monsterId || '', event.kind, releaseId].join(':');
+}
+
+export function dedupeEvents(events, seenTokens = new Set(), seenTerminalTokens = new Set()) {
   const output = [];
   for (const event of asEvents(events)) {
     const token = eventToken(event);
     if (token && seenTokens.has(token)) continue;
+    const terminalToken = terminalRewardToken(event);
+    if (terminalToken && seenTerminalTokens.has(terminalToken)) continue;
     if (token) seenTokens.add(token);
+    if (terminalToken) seenTerminalTokens.add(terminalToken);
     output.push(event);
   }
   return output;
@@ -43,9 +63,11 @@ export function toastEvents(events) {
 }
 
 export function combineCommandEvents({ domainEvents = [], reactionEvents = [], existingEvents = [] } = {}) {
-  const seenTokens = new Set(asEvents(existingEvents).map(eventToken).filter(Boolean));
-  const domain = dedupeEvents(domainEvents, seenTokens);
-  const reactions = dedupeEvents(reactionEvents, seenTokens);
+  const existing = asEvents(existingEvents);
+  const seenTokens = new Set(existing.map(eventToken).filter(Boolean));
+  const seenTerminalTokens = new Set(existing.map(terminalRewardToken).filter(Boolean));
+  const domain = dedupeEvents(domainEvents, seenTokens, seenTerminalTokens);
+  const reactions = dedupeEvents(reactionEvents, seenTokens, seenTerminalTokens);
   return {
     domainEvents: domain,
     reactionEvents: reactions,

--- a/worker/src/projections/events.js
+++ b/worker/src/projections/events.js
@@ -44,6 +44,12 @@ export function terminalRewardToken(event) {
   return ['reward.monster.terminal', event.learnerId || '', event.monsterId || '', event.kind, releaseId].join(':');
 }
 
+// seenTokens dedupes by the id-based `eventToken` (the default contract).
+// seenTerminalTokens dedupes by `terminalRewardToken` and is scoped to
+// caught/mega transitions on reward.monster events. Both sets are
+// threaded through combineCommandEvents so a reward that was already
+// persisted in existingEvents can still block a re-emission from fresh
+// domain or reaction events.
 export function dedupeEvents(events, seenTokens = new Set(), seenTerminalTokens = new Set()) {
   const output = [];
   for (const event of asEvents(events)) {


### PR DESCRIPTION
## Summary

- Add \`terminalRewardToken\` — a semantic dedupe key keyed on \`(learnerId, monsterId, kind, releaseId)\` for \`caught\` / \`mega\` events on \`reward.monster\`. The existing id-based \`eventToken\` returns different strings across the Phase 2 roster flip (cluster segment changes), so storage keeps both rows — the terminal token collapses them at the projection layer.
- \`dedupeEvents\` accepts two seen-token sets (id-based + terminal) and \`combineCommandEvents\` seeds both from \`existingEvents\`.
- Cross-release re-emission stays intentional: \`releaseId\` in the terminal token means r4 → r5 migrations still celebrate a fresh mega.
- Levelup / evolve unaffected.

### Note on the plan's write-through seam

The plan (§U7 Approach) flagged a potential stuck-at-1 class requiring a writer-side seam if the aggregate write never ran for certain learners. After R18's cluster remap (\`speech → pealark\`), the line-139 early-out in \`recordPunctuationRewardUnitMastery\` is against \`pealark.mastered\` — not \`quoral.mastered\` — so the aggregate writer runs organically on the first post-flip secure and corrects stored \`publishedTotal\`. U6's read-time override also guarantees display correctness regardless of stored \`publishedTotal\`. The explicit writer seam is therefore not needed; terminal-event dedupe is the only U7 addition required. Plan open-questions section updated accordingly in U6.

## Test plan

- [x] 6 new tests in \`tests/punctuation-rewards.test.js\` covering: terminal token format, non-terminal null, cross-flip caught dedupe (existing + batched), cross-release re-emit, mega dedupe, levelup unaffected
- [x] \`tests/punctuation-rewards.test.js\`: 14 pass
- [x] \`tests/worker-projections.test.js tests/worker-punctuation-runtime.test.js\`: 24 pass (no regressions)
- [x] Full suite: 975 / 967 / 7 (same 7 pre-existing bundle-audit failures)
- [ ] CI: full suite green