### PR TITLE
feat(spelling): U1 extend service contract for guardian layer

### DIFF
--- a/src/subjects/spelling/service-contract.js
+++ b/src/subjects/spelling/service-contract.js
@@ -1,7 +1,13 @@
-export const SPELLING_SERVICE_STATE_VERSION = 1;
+export const SPELLING_SERVICE_STATE_VERSION = 2;
 
 export const SPELLING_ROOT_PHASES = Object.freeze(['dashboard', 'session', 'summary', 'word-bank']);
-export const SPELLING_MODES = Object.freeze(['smart', 'trouble', 'test', 'single']);
+export const SPELLING_MODES = Object.freeze(['smart', 'trouble', 'test', 'single', 'guardian']);
+
+export const GUARDIAN_INTERVALS = Object.freeze([3, 7, 14, 30, 60, 90]);
+export const GUARDIAN_MAX_REVIEW_LEVEL = GUARDIAN_INTERVALS.length - 1;
+export const GUARDIAN_MIN_ROUND_LENGTH = 5;
+export const GUARDIAN_MAX_ROUND_LENGTH = 8;
+export const GUARDIAN_DEFAULT_ROUND_LENGTH = 8;
 export const SPELLING_YEAR_FILTERS = Object.freeze(['core', 'y3-4', 'y5-6', 'extra']);
 export const LEGACY_SPELLING_YEAR_FILTER_ALIASES = Object.freeze({
   all: 'core',
@@ -225,4 +231,60 @@ export function normaliseStats(value) {
 export function cloneSerialisable(value) {
   if (value == null) return value;
   return JSON.parse(JSON.stringify(value));
+}
+
+function clampReviewLevel(value) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return 0;
+  if (parsed < 0) return 0;
+  if (parsed > GUARDIAN_MAX_REVIEW_LEVEL) return GUARDIAN_MAX_REVIEW_LEVEL;
+  return Math.floor(parsed);
+}
+
+function normaliseNullableDay(value) {
+  if (value === null) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? Math.floor(parsed) : null;
+}
+
+function normaliseDay(value, fallback) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? Math.floor(parsed) : fallback;
+}
+
+/**
+ * Normalise a per-word guardian record to the canonical shape. Garbage
+ * or missing input yields a safe default record. The default `nextDueDay`
+ * must be supplied by the caller (usually `todayDay()`), because this
+ * module must stay pure — it cannot call `Date.now()` directly without
+ * breaking deterministic tests in shared/spelling/service.js.
+ */
+export function normaliseGuardianRecord(rawValue, todayDay = 0) {
+  const raw = rawValue && typeof rawValue === 'object' && !Array.isArray(rawValue) ? rawValue : {};
+  const safeToday = Number.isFinite(Number(todayDay)) && Number(todayDay) >= 0 ? Math.floor(Number(todayDay)) : 0;
+  return {
+    reviewLevel: clampReviewLevel(raw.reviewLevel),
+    lastReviewedDay: normaliseNullableDay(raw.lastReviewedDay),
+    nextDueDay: normaliseDay(raw.nextDueDay, safeToday),
+    correctStreak: normaliseNonNegativeInteger(raw.correctStreak, 0),
+    lapses: normaliseNonNegativeInteger(raw.lapses, 0),
+    renewals: normaliseNonNegativeInteger(raw.renewals, 0),
+    wobbling: normaliseBoolean(raw.wobbling, false),
+  };
+}
+
+/**
+ * Normalise a slug -> guardian record map. Drops entries with empty/invalid
+ * slugs or with values that cannot be objects. Preserves valid slugs, with
+ * each record individually normalised.
+ */
+export function normaliseGuardianMap(rawValue, todayDay = 0) {
+  const raw = rawValue && typeof rawValue === 'object' && !Array.isArray(rawValue) ? rawValue : {};
+  const output = {};
+  for (const [slug, entry] of Object.entries(raw)) {
+    if (!slug || typeof slug !== 'string') continue;
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
+    output[slug] = normaliseGuardianRecord(entry, todayDay);
+  }
+  return output;
 }

--- a/tests/persistence.test.js
+++ b/tests/persistence.test.js
@@ -986,7 +986,7 @@ test('subject command responses update the api cache without queuing broad runti
         subjectReadModel: {
           subjectId: 'spelling',
           learnerId: body.learnerId,
-          version: 1,
+          version: 2,
           phase: 'session',
           session: {
             id: 'server-session',
@@ -1098,7 +1098,7 @@ test('subject commands refresh stale learner revision without a second bootstrap
         subjectReadModel: {
           subjectId: 'spelling',
           learnerId: body.learnerId,
-          version: 1,
+          version: 2,
           phase: 'session',
           session: {
             id: 'server-session',

--- a/tests/react-spelling-surface.test.js
+++ b/tests/react-spelling-surface.test.js
@@ -43,7 +43,7 @@ test('client spelling read model preserves word-family variant preference', () =
         spelling: {
           subjectId: 'spelling',
           learnerId: 'learner-a',
-          version: 1,
+          version: 2,
           phase: 'dashboard',
           prefs: {
             mode: 'smart',

--- a/tests/spelling-guardian.test.js
+++ b/tests/spelling-guardian.test.js
@@ -1,0 +1,191 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  GUARDIAN_INTERVALS,
+  GUARDIAN_MAX_REVIEW_LEVEL,
+  GUARDIAN_MIN_ROUND_LENGTH,
+  GUARDIAN_MAX_ROUND_LENGTH,
+  GUARDIAN_DEFAULT_ROUND_LENGTH,
+  SPELLING_MODES,
+  SPELLING_SERVICE_STATE_VERSION,
+  normaliseGuardianMap,
+  normaliseGuardianRecord,
+  normaliseMode,
+} from '../src/subjects/spelling/service-contract.js';
+import { normaliseServerSpellingData } from '../worker/src/subjects/spelling/engine.js';
+
+const TODAY = 18_000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+test('SPELLING_MODES includes guardian alongside existing modes', () => {
+  assert.deepEqual(SPELLING_MODES, ['smart', 'trouble', 'test', 'single', 'guardian']);
+  assert.equal(normaliseMode('guardian'), 'guardian');
+  assert.equal(normaliseMode('unknown-mode'), 'smart');
+  assert.equal(normaliseMode('smart'), 'smart');
+});
+
+test('SPELLING_SERVICE_STATE_VERSION is bumped to 2', () => {
+  assert.equal(SPELLING_SERVICE_STATE_VERSION, 2);
+});
+
+test('GUARDIAN_INTERVALS are the planned schedule', () => {
+  assert.deepEqual(GUARDIAN_INTERVALS, [3, 7, 14, 30, 60, 90]);
+  assert.equal(GUARDIAN_MAX_REVIEW_LEVEL, 5);
+  assert.equal(GUARDIAN_MIN_ROUND_LENGTH, 5);
+  assert.equal(GUARDIAN_MAX_ROUND_LENGTH, 8);
+  assert.equal(GUARDIAN_DEFAULT_ROUND_LENGTH, 8);
+});
+
+test('normaliseGuardianRecord returns a complete shape for a well-formed input', () => {
+  const record = normaliseGuardianRecord({
+    reviewLevel: 2,
+    lastReviewedDay: 17_995,
+    nextDueDay: 18_009,
+    correctStreak: 3,
+    lapses: 1,
+    renewals: 0,
+    wobbling: false,
+  }, TODAY);
+  assert.deepEqual(record, {
+    reviewLevel: 2,
+    lastReviewedDay: 17_995,
+    nextDueDay: 18_009,
+    correctStreak: 3,
+    lapses: 1,
+    renewals: 0,
+    wobbling: false,
+  });
+});
+
+test('normaliseGuardianRecord defaults missing fields safely', () => {
+  const record = normaliseGuardianRecord({}, TODAY);
+  assert.deepEqual(record, {
+    reviewLevel: 0,
+    lastReviewedDay: null,
+    nextDueDay: TODAY,
+    correctStreak: 0,
+    lapses: 0,
+    renewals: 0,
+    wobbling: false,
+  });
+});
+
+test('normaliseGuardianRecord clamps reviewLevel to [0, GUARDIAN_MAX_REVIEW_LEVEL]', () => {
+  assert.equal(normaliseGuardianRecord({ reviewLevel: 99 }, TODAY).reviewLevel, GUARDIAN_MAX_REVIEW_LEVEL);
+  assert.equal(normaliseGuardianRecord({ reviewLevel: -3 }, TODAY).reviewLevel, 0);
+  assert.equal(normaliseGuardianRecord({ reviewLevel: 'nope' }, TODAY).reviewLevel, 0);
+  assert.equal(normaliseGuardianRecord({ reviewLevel: 2.7 }, TODAY).reviewLevel, 2);
+});
+
+test('normaliseGuardianRecord coerces wobbling to boolean strictly', () => {
+  assert.equal(normaliseGuardianRecord({ wobbling: true }, TODAY).wobbling, true);
+  assert.equal(normaliseGuardianRecord({ wobbling: false }, TODAY).wobbling, false);
+  assert.equal(normaliseGuardianRecord({ wobbling: 'yes' }, TODAY).wobbling, false);
+  assert.equal(normaliseGuardianRecord({ wobbling: 1 }, TODAY).wobbling, false);
+  assert.equal(normaliseGuardianRecord({}, TODAY).wobbling, false);
+});
+
+test('normaliseGuardianRecord handles null/garbage input by returning a default record', () => {
+  assert.deepEqual(normaliseGuardianRecord(null, TODAY), {
+    reviewLevel: 0,
+    lastReviewedDay: null,
+    nextDueDay: TODAY,
+    correctStreak: 0,
+    lapses: 0,
+    renewals: 0,
+    wobbling: false,
+  });
+  assert.equal(normaliseGuardianRecord('garbage', TODAY).reviewLevel, 0);
+  assert.equal(normaliseGuardianRecord([], TODAY).reviewLevel, 0);
+});
+
+test('normaliseGuardianRecord preserves explicit lastReviewedDay === null', () => {
+  const record = normaliseGuardianRecord({ lastReviewedDay: null }, TODAY);
+  assert.equal(record.lastReviewedDay, null);
+});
+
+test('normaliseGuardianRecord rejects negative nextDueDay, falling back to today', () => {
+  assert.equal(normaliseGuardianRecord({ nextDueDay: -5 }, TODAY).nextDueDay, TODAY);
+  assert.equal(normaliseGuardianRecord({ nextDueDay: 'nope' }, TODAY).nextDueDay, TODAY);
+});
+
+test('normaliseGuardianRecord rejects non-integer streak/lapse/renewal counts', () => {
+  const record = normaliseGuardianRecord({
+    correctStreak: -1,
+    lapses: 'abc',
+    renewals: 1.5,
+  }, TODAY);
+  assert.equal(record.correctStreak, 0);
+  assert.equal(record.lapses, 0);
+  assert.equal(record.renewals, 0);
+});
+
+test('normaliseGuardianMap drops entries with empty slug, non-object value, or array value', () => {
+  const map = normaliseGuardianMap({
+    possess: { reviewLevel: 1, nextDueDay: TODAY },
+    ['']: { reviewLevel: 3 },
+    lose: null,
+    believe: ['not', 'an', 'object'],
+    accommodate: { reviewLevel: 'garbage' }, // valid object; normalises to defaults
+  }, TODAY);
+  assert.deepEqual(Object.keys(map).sort(), ['accommodate', 'possess']);
+  assert.equal(map.accommodate.reviewLevel, 0); // clamped
+  assert.equal(map.possess.reviewLevel, 1);
+});
+
+test('normaliseGuardianMap handles null/undefined input by returning {}', () => {
+  assert.deepEqual(normaliseGuardianMap(null, TODAY), {});
+  assert.deepEqual(normaliseGuardianMap(undefined, TODAY), {});
+  assert.deepEqual(normaliseGuardianMap('garbage', TODAY), {});
+  assert.deepEqual(normaliseGuardianMap([], TODAY), {});
+});
+
+test('Worker normaliseServerSpellingData back-fills guardian:{} for legacy records', () => {
+  const legacy = {
+    prefs: { mode: 'smart', yearFilter: 'core' },
+    progress: { possess: { stage: 4, attempts: 6, correct: 5, wrong: 1, dueDay: 18_050, lastDay: 17_990, lastResult: true } },
+  };
+  const result = normaliseServerSpellingData(legacy, TODAY * DAY_MS);
+  assert.deepEqual(result.guardian, {});
+  assert.equal(result.prefs.mode, 'smart');
+  assert.equal(result.progress.possess.stage, 4);
+});
+
+test('Worker normaliseServerSpellingData round-trips a guardian map', () => {
+  const stored = {
+    prefs: {},
+    progress: {},
+    guardian: {
+      possess: { reviewLevel: 1, lastReviewedDay: 17_995, nextDueDay: 18_002, correctStreak: 1, lapses: 0, renewals: 0, wobbling: false },
+    },
+  };
+  const result = normaliseServerSpellingData(stored, TODAY * DAY_MS);
+  assert.equal(result.guardian.possess.reviewLevel, 1);
+  assert.equal(result.guardian.possess.wobbling, false);
+  assert.equal(result.guardian.possess.nextDueDay, 18_002);
+});
+
+test('Worker normaliseServerSpellingData falls back to today for malformed guardian entries', () => {
+  const stored = {
+    prefs: {},
+    progress: {},
+    guardian: {
+      possess: 'this is not a record',
+      lose: { reviewLevel: 99, wobbling: 'yes' },
+    },
+  };
+  const result = normaliseServerSpellingData(stored, TODAY * DAY_MS);
+  assert.ok(!('possess' in result.guardian), 'garbage value is dropped');
+  assert.equal(result.guardian.lose.reviewLevel, GUARDIAN_MAX_REVIEW_LEVEL);
+  assert.equal(result.guardian.lose.wobbling, false);
+  assert.equal(result.guardian.lose.nextDueDay, TODAY);
+});
+
+test('Worker normaliseServerSpellingData defaults nowTs to Date.now() when not supplied', () => {
+  const result = normaliseServerSpellingData({});
+  // Current day is a stable integer; assert shape plus that nextDueDay was never consulted
+  // (guardian is {} so there are no records to check). Just confirm it returns the expected keys.
+  assert.deepEqual(Object.keys(result).sort(), ['guardian', 'prefs', 'progress']);
+  assert.deepEqual(result.guardian, {});
+});

--- a/tests/spelling-optimistic-prefs.test.js
+++ b/tests/spelling-optimistic-prefs.test.js
@@ -39,7 +39,7 @@ test('optimistic spelling prefs leave completed flows on setup without waiting f
   const next = applyOptimisticSpellingPrefs({
     subjectId: 'spelling',
     learnerId: 'learner-a',
-    version: 1,
+    version: 2,
     phase: 'summary',
     session: null,
     feedback: { kind: 'success', headline: 'Done' },

--- a/tests/spelling.test.js
+++ b/tests/spelling.test.js
@@ -6,6 +6,7 @@ import { createLocalPlatformRepositories } from '../src/platform/core/repositori
 import { createSpellingService } from '../src/subjects/spelling/service.js';
 import { createSpellingPersistence } from '../src/subjects/spelling/repository.js';
 import { SPELLING_EVENT_TYPES } from '../src/subjects/spelling/events.js';
+import { SPELLING_SERVICE_STATE_VERSION } from '../src/subjects/spelling/service-contract.js';
 import { WORDS, WORD_BY_SLUG } from '../src/subjects/spelling/data/word-data.js';
 import { rewardEventsFromSpellingEvents } from '../src/subjects/spelling/event-hooks.js';
 import { monsterSummaryFromSpellingAnalytics } from '../src/platform/game/monster-system.js';
@@ -116,7 +117,7 @@ test('starts a spelling session with an explicit subject-state contract', () => 
   const transition = service.startSession('learner-a', { mode: 'smart', yearFilter: 'all', length: 5 });
 
   assert.equal(transition.ok, true);
-  assert.equal(transition.state.version, 1);
+  assert.equal(transition.state.version, SPELLING_SERVICE_STATE_VERSION);
   assert.equal(transition.state.phase, 'session');
   assert.equal(transition.state.session.progress.total, 5);
   assert.ok(transition.state.session.currentCard.word.word);
@@ -660,7 +661,7 @@ test('analytics snapshot is explicit and normalised', () => {
   const { service } = makeService();
   const snapshot = service.getAnalyticsSnapshot('learner-a');
 
-  assert.equal(snapshot.version, 1);
+  assert.equal(snapshot.version, SPELLING_SERVICE_STATE_VERSION);
   assert.ok(Number.isFinite(snapshot.generatedAt));
   assert.deepEqual(Object.keys(snapshot.pools), ['all', 'core', 'y34', 'y56', 'extra']);
   assert.equal(snapshot.pools.all.total > 0, true);

--- a/worker/src/subjects/spelling/engine.js
+++ b/worker/src/subjects/spelling/engine.js
@@ -2,9 +2,14 @@ import {
   cloneSerialisable,
   normalisePracticeSessionRecord,
 } from '../../../../src/platform/core/repositories/helpers.js';
-import { createInitialSpellingState } from '../../../../src/subjects/spelling/service-contract.js';
+import {
+  createInitialSpellingState,
+  normaliseGuardianMap,
+} from '../../../../src/subjects/spelling/service-contract.js';
 import { createSpellingService } from '../../../../shared/spelling/service.js';
 import { BadRequestError } from '../../errors.js';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 const SUBJECT_ID = 'spelling';
 const SERVER_AUTHORITY = 'worker';
@@ -30,11 +35,13 @@ function normaliseProgressMap(rawValue) {
   return output;
 }
 
-export function normaliseServerSpellingData(rawValue) {
+export function normaliseServerSpellingData(rawValue, nowTs = Date.now()) {
   const raw = isPlainObject(rawValue) ? rawValue : {};
+  const todayDay = Math.floor(Number(nowTs) / DAY_MS);
   return {
     prefs: isPlainObject(raw.prefs) ? cloneSerialisable(raw.prefs) : {},
     progress: normaliseProgressMap(raw.progress),
+    guardian: normaliseGuardianMap(raw.guardian, Number.isFinite(todayDay) && todayDay >= 0 ? todayDay : 0),
   };
 }
 


### PR DESCRIPTION
## Summary

Plan U1 — adds the minimum surface a post-Mega Guardian layer needs, without changing any runtime behaviour.

- `SPELLING_MODES` gains `'guardian'`; `normaliseMode('guardian')` resolves cleanly.
- `SPELLING_SERVICE_STATE_VERSION` bumped `1 → 2` so resumed sessions back-fill the new `data.guardian` sibling map on `initState`.
- `GUARDIAN_INTERVALS = [3, 7, 14, 30, 60, 90]` + companion constants exported for U3 to consume.
- `normaliseGuardianRecord` / `normaliseGuardianMap` — defensive normalisers that fall back to a safe default shape for garbage input (per `docs/state-integrity.md` "prefer a smaller valid shape over broken fields" rule).
- Worker `normaliseServerSpellingData` back-fills `data.guardian = {}` for legacy records and round-trips valid guardian maps; accepts an optional `nowTs` (defaults to `Date.now()`) so all existing callers stay backwards-compatible.

## Test updates

`tests/spelling.test.js` swaps two hard-coded `version: 1` assertions for `SPELLING_SERVICE_STATE_VERSION` references; `tests/persistence.test.js`, `tests/react-spelling-surface.test.js`, `tests/spelling-optimistic-prefs.test.js` update spelling subjectReadModel fixtures from version 1 to version 2.

New `tests/spelling-guardian.test.js` covers: happy path, defaults, clamping, wobbling coercion, null/garbage handling, map-level filtering, Worker back-fill invariants. 16 assertions, all new — 0 changes to existing behavioural tests.

## Plan reference

Ships U1 from [`docs/plans/james/post-mega-spelling/2026-04-25-003-feat-post-mega-spelling-mvp-plan.md`](docs/plans/james/post-mega-spelling/2026-04-25-003-feat-post-mega-spelling-mvp-plan.md).

## Test plan

- [ ] `npm test tests/spelling-guardian.test.js tests/spelling.test.js tests/spelling-parity.test.js tests/spelling-view-model.test.js tests/server-spelling-engine-parity.test.js tests/spelling-optimistic-prefs.test.js tests/react-spelling-surface.test.js tests/persistence.test.js` — 92/92 pass locally.
- [ ] `npm test` — 985/992 pass locally; the 7 failures are pre-existing `tests/bundle-audit.test.js` failures present on clean `origin/main` as well (likely environment-dependent — CI validates).
- [ ] No change to `data.progress` shape, no change to `progress.stage` lifecycle, no change to `SECURE_STAGE`, no change to existing domain event types.