### PR TITLE
feat(punctuation): Endmarks/Apostrophe focus + honest scope copy + docs (Phase 2 U8)

### DIFF
--- a/docs/punctuation-production.md
+++ b/docs/punctuation-production.md
@@ -157,17 +157,55 @@ Punctuation emits domain events:
 - `punctuation.unit-secured`
 - `punctuation.session-completed`
 
-Reward projection maps secure units to Bellstorm Coast creatures:
+### Monster Roster (Phase 2)
 
-- Endmarks: Pealark
-- Apostrophe: Claspin
-- Speech: Quoral
-- Comma / Flow: Curlune
-- List / Structure: Colisk
-- Boundary: Hyphang
-- Published release aggregate: Carillon
+The Punctuation roster collapsed in Phase 2 to three active direct creatures plus one grand:
 
-The Punctuation service does not mutate game state directly. It emits domain events; the reward projection records deduplicated mastery keys in the Monster Codex state. Replayed commands or duplicate `unit-secured` events do not double-award the same mastery key.
+- Pealark: Endmarks, Speech, Boundary (5 reward units)
+- Claspin: Apostrophe (2 reward units)
+- Curlune: Comma / Flow, List / Structure (7 reward units)
+- Quoral (grand): full 14 published reward units aggregated across every cluster
+
+Reserved for future Punctuation expansions:
+
+- Colisk
+- Hyphang
+- Carillon
+
+Reserved creatures stay in the `MONSTERS` manifest so the Monster Visual Config tooling, asset manifest, and Admin review pipeline continue to cover them. They are filtered out of active learner Codex / Parent Hub / Admin Hub summaries via the `PUNCTUATION_RESERVED_MONSTER_IDS` constant.
+
+### Migration from the pre-Phase-2 roster
+
+Pre-flip learner progress is preserved without a stored-state rewrite:
+
+- `src/platform/game/mastery/punctuation.js` exports a read-only `normalisePunctuationMonsterState(state)` that unions stored `carillon.mastered` keys into the new `quoral` grand view on every read.
+- `punctuationTotal(entry, fallback, { monsterId })` forces the grand monster to read the release denominator (14) regardless of stored `publishedTotal`. Pre-flip learners with `quoral.publishedTotal: 1` display correctly.
+- Reward writes on the new cluster map organically rewrite stored `publishedTotal` on the next post-flip secure, so stored state self-heals without a migration script.
+- `worker/src/projections/events.js` adds `terminalRewardToken` — a projection-layer dedupe on `(learnerId, monsterId, kind, releaseId)` that collapses pre-flip + post-flip `caught`/`mega` events for the same milestone. Cross-release mega re-emission stays intentional.
+
+### Rollback
+
+Rollback to the pre-Phase-2 bundle is lossless for learners with `publishedTotal: 1` stored on Quoral — `punctuationStageFor(1, 14)` returns stage 1, which matches the pre-flip stage for the same secured set. Learners who earned multiple Speech-era Quoral stages (not possible under the pre-Phase-2 release because Quoral covered only `speech-core`) would see a demotion; confirm the cohort is empty via production D1 before deploying.
+
+### Domain events
+
+The Punctuation service does not mutate game state directly. It emits domain events; the reward projection records deduplicated mastery keys in the Monster Codex state. Replayed commands or duplicate `unit-secured` events do not double-award the same mastery key. Mastery keys use the stable format:
+
+```txt
+punctuation:<releaseId>:<clusterId>:<rewardUnitId>
+```
+
+Migration-read coverage for historical mastery keys lives in `tests/punctuation-monster-migration.test.js`.
+
+## AI Context Pack Decision (Phase 2)
+
+The Worker plumbing for an AI-assisted context-pack compiler stays in place, but the learner React surface deliberately ignores the field in Phase 2. The existing `safeContextPackSummary` allowlist ensures any future upstream field addition trips the fail-closed redaction guard added in Phase 2 U2. Phase 3 will decide whether to productise the context pack as a post-feedback learner surface or keep it teacher/admin-only; until then, the Parent / Admin evidence path is the only surface that consumes it.
+
+## Read-Model Redaction (Phase 2)
+
+Every phase output (active item, feedback, summary, GPS review, analytics, Parent / Admin evidence, context-pack summary) is built from explicit allowlists. A recursive `assertNoForbiddenReadModelKeys` scan runs on the assembled payload before it leaves the Worker so a forbidden field added at any depth of any branch (e.g. `summary.metadata.rawGenerator`, `reviewRow.validator`, `analytics.byItemMode[].rubric`) throws in `NODE_ENV=test` and emits a structured warning + strips the field in production.
+
+The forbidden-key set is kept aligned between `worker/src/subjects/punctuation/read-models.js` (`FORBIDDEN_READ_MODEL_KEYS`) and `scripts/punctuation-production-smoke.mjs` (`FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS`). Adding a new forbidden key means editing both files in the same PR; CI will fail with a clear "server-only field: &lt;key&gt;" message if drift is introduced.
 
 ## Browser Read Model And Lockdown
 

--- a/docs/punctuation-production.md
+++ b/docs/punctuation-production.md
@@ -185,7 +185,7 @@ Pre-flip learner progress is preserved without a stored-state rewrite:
 
 ### Rollback
 
-Rollback to the pre-Phase-2 bundle is lossless for learners with `publishedTotal: 1` stored on Quoral — `punctuationStageFor(1, 14)` returns stage 1, which matches the pre-flip stage for the same secured set. Learners who earned multiple Speech-era Quoral stages (not possible under the pre-Phase-2 release because Quoral covered only `speech-core`) would see a demotion; confirm the cohort is empty via production D1 before deploying.
+Rollback to the pre-Phase-2 bundle is lossless for learners whose stored Quoral entry has `publishedTotal: 1` with one mastered key. The pre-flip bundle reads the stored `publishedTotal: 1` directly (pre-flip Quoral was a direct Speech monster with `masteredMax: 1`), so `punctuationStageFor(1, 1)` returns stage 4 — exactly the stage these learners saw pre-flip. Quoral only carried `speech-core` under the pre-Phase-2 roster, so no learner could have `publishedTotal > 1` from the old code path. Post-Phase-2, if U7's writer path has rewritten a learner's stored `publishedTotal` upward to 14 before rollback, the pre-flip bundle would read `punctuationStageFor(mastered, 14)` and display stage 1 instead of stage 4. That case is avoided in practice because U6's read-time override provides correct display without requiring a stored-value rewrite; confirm the cohort is empty via production D1 before deploying rollback.
 
 ### Domain events
 

--- a/shared/punctuation/content.js
+++ b/shared/punctuation/content.js
@@ -1931,10 +1931,16 @@ export const PUNCTUATION_GENERATOR_FAMILIES = Object.freeze([
 export const PUNCTUATION_CONTENT_MANIFEST = Object.freeze({
   subjectId: PUNCTUATION_SUBJECT_ID,
   releaseId: PUNCTUATION_RELEASE_ID,
-  releaseName: 'Full 14-skill Punctuation learner-engine slice',
+  releaseName: 'Punctuation 14-skill production release',
   partialReleaseLabel: 'Published Punctuation release',
   fullSkillCount: PUNCTUATION_SKILLS.length,
-  publishedScopeCopy: 'This Punctuation release covers all 14 KS2 punctuation skills across Endmarks, Apostrophe, Speech, Comma / Flow, Boundary and Structure.',
+  // Honest scope copy post-Phase-2. The learner engine covers the full
+  // 14-skill progression through Smart Review, Guided focus, Weak Spots,
+  // GPS, sentence combining, paragraph repair, and transfer validators —
+  // which the behavioural smoke matrix (U9 + U10) proves end-to-end. The
+  // phrasing deliberately avoids "complete KS2 Punctuation mastery" so
+  // learners are not misled when content expansion lands in future releases.
+  publishedScopeCopy: 'Punctuation covers the 14-skill KS2 progression with Smart Review, Guided focus, Weak Spots, GPS tests, sentence combining, paragraph repair, and transfer practice.',
   skills: PUNCTUATION_SKILLS,
   clusters: PUNCTUATION_CLUSTERS,
   grandMonster: PUNCTUATION_GRAND_MONSTER,

--- a/src/subjects/punctuation/components/PunctuationPracticeSurface.jsx
+++ b/src/subjects/punctuation/components/PunctuationPracticeSurface.jsx
@@ -43,7 +43,7 @@ function SetupView({ learner, stats, ui, actions }) {
         <div>
           <div className="eyebrow">Bellstorm Coast</div>
           <h2 className="section-title">Punctuation practice</h2>
-          <p className="subtitle">{content.publishedScopeCopy || 'This Punctuation release covers all 14 KS2 punctuation skills.'}</p>
+          <p className="subtitle">{content.publishedScopeCopy || 'Punctuation covers the 14-skill KS2 progression with Smart Review, Guided focus, Weak Spots, GPS tests, sentence combining, paragraph repair, and transfer practice.'}</p>
         </div>
       </div>
       <div className="stat-grid" style={{ marginTop: 16 }}>
@@ -95,6 +95,8 @@ function SetupView({ learner, stats, ui, actions }) {
         >
           GPS test
         </button>
+        <button className="btn secondary" type="button" disabled={isDisabled} data-punctuation-endmarks-start onClick={() => actions.dispatch('punctuation-start', { mode: 'endmarks' })}>Endmarks focus</button>
+        <button className="btn secondary" type="button" disabled={isDisabled} data-punctuation-apostrophe-start onClick={() => actions.dispatch('punctuation-start', { mode: 'apostrophe' })}>Apostrophe focus</button>
         <button className="btn secondary" type="button" disabled={isDisabled} onClick={() => actions.dispatch('punctuation-start', { mode: 'speech' })}>Speech focus</button>
         <button className="btn secondary" type="button" disabled={isDisabled} onClick={() => actions.dispatch('punctuation-start', { mode: 'comma_flow' })}>Comma focus</button>
         <button className="btn secondary" type="button" disabled={isDisabled} onClick={() => actions.dispatch('punctuation-start', { mode: 'boundary' })}>Boundary focus</button>

--- a/src/subjects/punctuation/module.js
+++ b/src/subjects/punctuation/module.js
@@ -19,7 +19,7 @@ function currentUi(context, learnerId) {
 export const punctuationModule = {
   id: 'punctuation',
   name: 'Punctuation',
-  blurb: 'Practise the full KS2 punctuation map across sentence endings, apostrophes, speech, commas, boundaries and structure.',
+  blurb: 'Practise the KS2 punctuation progression: Smart Review, Guided focus, Weak Spots, GPS tests, sentence combining, paragraph repair, and transfer.',
   accent: '#B8873F',
   accentSoft: '#F0E1C4',
   accentTint: '#F7EEDC',
@@ -37,7 +37,7 @@ export const punctuationModule = {
       pct: stats.publishedRewardUnits ? Math.round(((stats.securedRewardUnits || 0) / stats.publishedRewardUnits) * 100) : 0,
       due: stats.due || 0,
       streak: stats.securedRewardUnits || 0,
-      nextUp: stats.weak ? 'Repair weak punctuation' : stats.due ? 'Due review' : 'Full 14-skill punctuation map',
+      nextUp: stats.weak ? 'Repair weak punctuation' : stats.due ? 'Due review' : 'Smart Review',
     };
   },
   handleAction(action, context) {

--- a/tests/punctuation-content.test.js
+++ b/tests/punctuation-content.test.js
@@ -48,7 +48,12 @@ test('published punctuation release includes the hidden full 14-skill Structure 
   ]);
   assert.equal(indexes.publishedRewardUnits.length, 14);
   assert.equal(PUNCTUATION_CONTENT_MANIFEST.fullSkillCount, 14);
-  assert.match(PUNCTUATION_CONTENT_MANIFEST.publishedScopeCopy, /all 14 KS2 punctuation skills/);
+  // Phase 2 scope copy is honest about mode breadth rather than claiming
+  // "all 14 KS2 punctuation skills" as complete mastery. The 14-skill
+  // progression claim survives, but is framed alongside the practice modes
+  // the behavioural smoke matrix proves.
+  assert.match(PUNCTUATION_CONTENT_MANIFEST.publishedScopeCopy, /14-skill KS2 progression/);
+  assert.match(PUNCTUATION_CONTENT_MANIFEST.publishedScopeCopy, /Smart Review/);
 });
 
 test('published reward mastery keys are release-scoped and stable when generator families expand', () => {

--- a/tests/react-grammar-surface.test.js
+++ b/tests/react-grammar-surface.test.js
@@ -664,7 +664,8 @@ test('Punctuation remains separately registered from Grammar Bellstorm bridge co
   assert.notEqual(grammarSubject, punctuationSubject);
   assert.equal(punctuationSubject.name, 'Punctuation');
   assert.equal(punctuationSubject.available, true);
-  assert.match(punctuationSubject.blurb, /full KS2 punctuation map/);
+  // Phase 2 blurb framed by practice modes rather than claiming "full KS2 punctuation map".
+  assert.match(punctuationSubject.blurb, /KS2 punctuation progression/);
   assert.equal(SUBJECTS.filter((subject) => subject.id === 'punctuation').length, 1);
 });
 

--- a/tests/react-punctuation-scene.test.js
+++ b/tests/react-punctuation-scene.test.js
@@ -43,6 +43,15 @@ test('punctuation React surface renders setup, active item, feedback and summary
   assert.match(setupHtml, /Bellstorm Coast/);
   assert.match(setupHtml, /Punctuation practice/);
   assert.match(setupHtml, /data-punctuation-start/);
+  // Phase 2 U8: all six cluster focus buttons must reach the setup surface.
+  assert.match(setupHtml, /data-punctuation-endmarks-start/);
+  assert.match(setupHtml, /data-punctuation-apostrophe-start/);
+  assert.match(setupHtml, />Endmarks focus</);
+  assert.match(setupHtml, />Apostrophe focus</);
+  assert.match(setupHtml, />Speech focus</);
+  assert.match(setupHtml, />Comma focus</);
+  assert.match(setupHtml, />Boundary focus</);
+  assert.match(setupHtml, />Structure focus</);
 
   startOneItemPunctuationSession(harness);
   const activeHtml = harness.render();


### PR DESCRIPTION
## Summary

- Add Endmarks focus + Apostrophe focus buttons to the setup surface (all six cluster modes reachable)
- Downgrade scope copy from "covers all 14 KS2 punctuation skills" to honest wording that reflects what the behavioural smoke matrix proves: the 14-skill progression is present and Smart / Guided / Weak / GPS / combine / paragraph / transfer are the modes that run end-to-end
- Update \`docs/punctuation-production.md\`:
  - Monster Roster subsection (Phase 2 split: 3 active + 1 grand + 3 reserved)
  - Migration-from-pre-Phase-2 subsection (normaliser, publishedTotal override, writer self-heal, terminal-token dedupe)
  - Rollback subsection with publishedTotal: 1 math
  - AI Context Pack Decision (teacher/admin only)
  - Read-Model Redaction (allowlist + recursive fail-closed scan)

Part of Punctuation Phase 2 hardening ([U8 in plan](../blob/feat/punctuation-p2-u8-ux-copy/docs/plans/2026-04-25-002-feat-punctuation-phase2-hardening-plan.md)).

## Test plan

- [x] \`tests/punctuation-content.test.js\` — scope-copy regex updated to match honest wording
- [x] \`tests/react-grammar-surface.test.js\` — blurb regex updated
- [x] Full suite: 976 / 968 / 7 (same pre-existing bundle-audit failures)
- [ ] CI: full suite green