### PR TITLE
feat(spelling): U2 guardian domain event types and factories

### DIFF
--- a/src/subjects/spelling/events.js
+++ b/src/subjects/spelling/events.js
@@ -5,6 +5,10 @@ export const SPELLING_EVENT_TYPES = Object.freeze({
   WORD_SECURED: 'spelling.word-secured',
   MASTERY_MILESTONE: 'spelling.mastery-milestone',
   SESSION_COMPLETED: 'spelling.session-completed',
+  GUARDIAN_RENEWED: 'spelling.guardian.renewed',
+  GUARDIAN_WOBBLED: 'spelling.guardian.wobbled',
+  GUARDIAN_RECOVERED: 'spelling.guardian.recovered',
+  GUARDIAN_MISSION_COMPLETED: 'spelling.guardian.mission-completed',
 });
 
 export const SPELLING_MASTERY_MILESTONES = Object.freeze([1, 5, 10, 25, 50, 100, 150, 200]);
@@ -101,5 +105,118 @@ export function createSpellingSessionCompletedEvent({ learnerId, session, summar
     sessionType: session.type,
     totalWords: Array.isArray(session.uniqueWords) ? session.uniqueWords.length : 0,
     mistakeCount: Array.isArray(summary?.mistakes) ? summary.mistakes.length : 0,
+  };
+}
+
+/**
+ * Emitted when a word in a Guardian Mission is answered correctly and its
+ * review interval advances to the next schedule step. Carries the resulting
+ * reviewLevel and nextDueDay so reward subscribers (landing later) can show
+ * "next check in N days" toasts without re-computing the schedule.
+ */
+export function createSpellingGuardianRenewedEvent({
+  learnerId,
+  session,
+  slug,
+  reviewLevel = 0,
+  nextDueDay = null,
+  createdAt,
+  wordMeta,
+} = {}) {
+  const word = wordFields(slug, wordMeta);
+  if (!word) return null;
+  return {
+    ...baseSpellingEvent(
+      SPELLING_EVENT_TYPES.GUARDIAN_RENEWED,
+      { learnerId, session, createdAt },
+      [learnerId || 'default', session?.id || 'session', slug, Number.isInteger(reviewLevel) ? reviewLevel : 'na'],
+    ),
+    ...word,
+    reviewLevel: Number.isInteger(reviewLevel) && reviewLevel >= 0 ? reviewLevel : 0,
+    nextDueDay: Number.isFinite(Number(nextDueDay)) && Number(nextDueDay) >= 0 ? Math.floor(Number(nextDueDay)) : null,
+  };
+}
+
+/**
+ * Emitted when a Guardian Mission word is answered wrongly and enters the
+ * "wobbling" maintenance state. Mega stays intact; wobbling is a flag on the
+ * guardian sibling record, not a demotion of progress.stage. Carries the
+ * lapses count so reward subscribers can react to repeated wobbles.
+ */
+export function createSpellingGuardianWobbledEvent({
+  learnerId,
+  session,
+  slug,
+  lapses = 0,
+  createdAt,
+  wordMeta,
+} = {}) {
+  const word = wordFields(slug, wordMeta);
+  if (!word) return null;
+  return {
+    ...baseSpellingEvent(
+      SPELLING_EVENT_TYPES.GUARDIAN_WOBBLED,
+      { learnerId, session, createdAt },
+      [learnerId || 'default', session?.id || 'session', slug, Number.isInteger(lapses) ? lapses : 'na'],
+    ),
+    ...word,
+    lapses: Number.isInteger(lapses) && lapses >= 0 ? lapses : 0,
+  };
+}
+
+/**
+ * Emitted when a previously-wobbling word is answered correctly and clears
+ * its wobbling flag. Renewal count is the lifetime total of wobbling->clear
+ * transitions for this word. reviewLevel is unchanged on recovery (preserves
+ * the spaced schedule rather than restarting from 0).
+ */
+export function createSpellingGuardianRecoveredEvent({
+  learnerId,
+  session,
+  slug,
+  renewals = 0,
+  reviewLevel = 0,
+  createdAt,
+  wordMeta,
+} = {}) {
+  const word = wordFields(slug, wordMeta);
+  if (!word) return null;
+  return {
+    ...baseSpellingEvent(
+      SPELLING_EVENT_TYPES.GUARDIAN_RECOVERED,
+      { learnerId, session, createdAt },
+      [learnerId || 'default', session?.id || 'session', slug, Number.isInteger(renewals) ? renewals : 'na'],
+    ),
+    ...word,
+    renewals: Number.isInteger(renewals) && renewals >= 0 ? renewals : 0,
+    reviewLevel: Number.isInteger(reviewLevel) && reviewLevel >= 0 ? reviewLevel : 0,
+  };
+}
+
+/**
+ * Emitted when a Guardian Mission round finalises to summary. Mirrors
+ * createSpellingSessionCompletedEvent's shape but carries guardian-specific
+ * counts so reward subscribers (and later dashboards) don't have to walk the
+ * per-word event stream.
+ */
+export function createSpellingGuardianMissionCompletedEvent({
+  learnerId,
+  session,
+  renewalCount = 0,
+  wobbledCount = 0,
+  recoveredCount = 0,
+  createdAt,
+} = {}) {
+  if (!session?.id) return null;
+  return {
+    ...baseSpellingEvent(
+      SPELLING_EVENT_TYPES.GUARDIAN_MISSION_COMPLETED,
+      { learnerId, session, createdAt },
+      [learnerId || 'default', session.id],
+    ),
+    totalWords: Array.isArray(session.uniqueWords) ? session.uniqueWords.length : 0,
+    renewalCount: Number.isInteger(renewalCount) && renewalCount >= 0 ? renewalCount : 0,
+    wobbledCount: Number.isInteger(wobbledCount) && wobbledCount >= 0 ? wobbledCount : 0,
+    recoveredCount: Number.isInteger(recoveredCount) && recoveredCount >= 0 ? recoveredCount : 0,
   };
 }

--- a/src/subjects/spelling/events.js
+++ b/src/subjects/spelling/events.js
@@ -133,7 +133,7 @@ export function createSpellingGuardianRenewedEvent({
     ),
     ...word,
     reviewLevel: Number.isInteger(reviewLevel) && reviewLevel >= 0 ? reviewLevel : 0,
-    nextDueDay: Number.isFinite(Number(nextDueDay)) && Number(nextDueDay) >= 0 ? Math.floor(Number(nextDueDay)) : null,
+    nextDueDay: Number.isInteger(nextDueDay) && nextDueDay >= 0 ? nextDueDay : null,
   };
 }
 

--- a/tests/spelling-guardian.test.js
+++ b/tests/spelling-guardian.test.js
@@ -13,6 +13,13 @@ import {
   normaliseGuardianRecord,
   normaliseMode,
 } from '../src/subjects/spelling/service-contract.js';
+import {
+  SPELLING_EVENT_TYPES,
+  createSpellingGuardianMissionCompletedEvent,
+  createSpellingGuardianRecoveredEvent,
+  createSpellingGuardianRenewedEvent,
+  createSpellingGuardianWobbledEvent,
+} from '../src/subjects/spelling/events.js';
 import { normaliseServerSpellingData } from '../worker/src/subjects/spelling/engine.js';
 
 const TODAY = 18_000;
@@ -188,4 +195,173 @@ test('Worker normaliseServerSpellingData defaults nowTs to Date.now() when not s
   // (guardian is {} so there are no records to check). Just confirm it returns the expected keys.
   assert.deepEqual(Object.keys(result).sort(), ['guardian', 'prefs', 'progress']);
   assert.deepEqual(result.guardian, {});
+});
+
+// ----- U2: guardian domain event factories ------------------------------------
+
+const GUARDIAN_SESSION = Object.freeze({
+  id: 'session-guardian-1',
+  mode: 'guardian',
+  type: 'learning',
+  uniqueWords: ['possess', 'accommodate', 'believe'],
+});
+
+test('SPELLING_EVENT_TYPES gains exactly four guardian event types with kebab-case values', () => {
+  assert.equal(SPELLING_EVENT_TYPES.GUARDIAN_RENEWED, 'spelling.guardian.renewed');
+  assert.equal(SPELLING_EVENT_TYPES.GUARDIAN_WOBBLED, 'spelling.guardian.wobbled');
+  assert.equal(SPELLING_EVENT_TYPES.GUARDIAN_RECOVERED, 'spelling.guardian.recovered');
+  assert.equal(SPELLING_EVENT_TYPES.GUARDIAN_MISSION_COMPLETED, 'spelling.guardian.mission-completed');
+  const values = Object.values(SPELLING_EVENT_TYPES);
+  assert.equal(values.length, 8, 'exactly 8 event types after U2');
+  assert.equal(new Set(values).size, values.length, 'all event types unique');
+});
+
+test('createSpellingGuardianRenewedEvent returns a well-formed event', () => {
+  const event = createSpellingGuardianRenewedEvent({
+    learnerId: 'learner-a',
+    session: GUARDIAN_SESSION,
+    slug: 'possess',
+    reviewLevel: 2,
+    nextDueDay: 18_014,
+    createdAt: 1_780_000_000_000,
+  });
+  assert.equal(event.type, SPELLING_EVENT_TYPES.GUARDIAN_RENEWED);
+  assert.equal(event.subjectId, 'spelling');
+  assert.equal(event.learnerId, 'learner-a');
+  assert.equal(event.sessionId, 'session-guardian-1');
+  assert.equal(event.mode, 'guardian');
+  assert.equal(event.createdAt, 1_780_000_000_000);
+  assert.equal(event.wordSlug, 'possess');
+  assert.equal(event.word, 'possess');
+  assert.equal(event.spellingPool, 'core');
+  assert.equal(event.reviewLevel, 2);
+  assert.equal(event.nextDueDay, 18_014);
+});
+
+test('createSpellingGuardianRenewedEvent returns null on missing/unknown slug', () => {
+  assert.equal(createSpellingGuardianRenewedEvent({ learnerId: 'a', session: GUARDIAN_SESSION }), null);
+  assert.equal(createSpellingGuardianRenewedEvent({ learnerId: 'a', session: GUARDIAN_SESSION, slug: '__unknown__' }), null);
+});
+
+test('createSpellingGuardianRenewedEvent falls back to Date.now() when createdAt is invalid', () => {
+  const before = Date.now();
+  const event = createSpellingGuardianRenewedEvent({
+    learnerId: 'a',
+    session: GUARDIAN_SESSION,
+    slug: 'possess',
+    reviewLevel: 0,
+    createdAt: -1,
+  });
+  const after = Date.now();
+  assert.ok(event.createdAt >= before && event.createdAt <= after);
+});
+
+test('createSpellingGuardianRenewedEvent clamps invalid reviewLevel / nextDueDay to safe defaults', () => {
+  const event = createSpellingGuardianRenewedEvent({
+    learnerId: 'a',
+    session: GUARDIAN_SESSION,
+    slug: 'possess',
+    reviewLevel: 'garbage',
+    nextDueDay: 'also-garbage',
+    createdAt: 1,
+  });
+  assert.equal(event.reviewLevel, 0);
+  assert.equal(event.nextDueDay, null);
+});
+
+test('createSpellingGuardianRenewedEvent produces a stable dedupe id for identical inputs', () => {
+  const input = {
+    learnerId: 'learner-a',
+    session: GUARDIAN_SESSION,
+    slug: 'possess',
+    reviewLevel: 1,
+    nextDueDay: 18_003,
+    createdAt: 1_780_000_000_000,
+  };
+  assert.equal(createSpellingGuardianRenewedEvent(input).id, createSpellingGuardianRenewedEvent(input).id);
+});
+
+test('createSpellingGuardianWobbledEvent carries lapse count and word metadata', () => {
+  const event = createSpellingGuardianWobbledEvent({
+    learnerId: 'learner-a',
+    session: GUARDIAN_SESSION,
+    slug: 'accommodate',
+    lapses: 2,
+    createdAt: 1_780_000_001_000,
+  });
+  assert.equal(event.type, SPELLING_EVENT_TYPES.GUARDIAN_WOBBLED);
+  assert.equal(event.wordSlug, 'accommodate');
+  assert.equal(event.lapses, 2);
+});
+
+test('createSpellingGuardianWobbledEvent returns null on missing slug', () => {
+  assert.equal(createSpellingGuardianWobbledEvent({ learnerId: 'a', session: GUARDIAN_SESSION }), null);
+  assert.equal(createSpellingGuardianWobbledEvent({ learnerId: 'a', session: GUARDIAN_SESSION, slug: 'not-a-word' }), null);
+});
+
+test('createSpellingGuardianRecoveredEvent carries renewals + unchanged reviewLevel', () => {
+  const event = createSpellingGuardianRecoveredEvent({
+    learnerId: 'learner-a',
+    session: GUARDIAN_SESSION,
+    slug: 'believe',
+    renewals: 1,
+    reviewLevel: 3,
+    createdAt: 1_780_000_002_000,
+  });
+  assert.equal(event.type, SPELLING_EVENT_TYPES.GUARDIAN_RECOVERED);
+  assert.equal(event.wordSlug, 'believe');
+  assert.equal(event.renewals, 1);
+  assert.equal(event.reviewLevel, 3);
+});
+
+test('createSpellingGuardianRecoveredEvent returns null on missing slug', () => {
+  assert.equal(createSpellingGuardianRecoveredEvent({ learnerId: 'a', session: GUARDIAN_SESSION }), null);
+  assert.equal(createSpellingGuardianRecoveredEvent({ learnerId: 'a', session: GUARDIAN_SESSION, slug: 'unknown' }), null);
+});
+
+test('createSpellingGuardianMissionCompletedEvent carries session and mission counts', () => {
+  const event = createSpellingGuardianMissionCompletedEvent({
+    learnerId: 'learner-a',
+    session: GUARDIAN_SESSION,
+    renewalCount: 4,
+    wobbledCount: 1,
+    recoveredCount: 1,
+    createdAt: 1_780_000_003_000,
+  });
+  assert.equal(event.type, SPELLING_EVENT_TYPES.GUARDIAN_MISSION_COMPLETED);
+  assert.equal(event.sessionId, 'session-guardian-1');
+  assert.equal(event.totalWords, 3);
+  assert.equal(event.renewalCount, 4);
+  assert.equal(event.wobbledCount, 1);
+  assert.equal(event.recoveredCount, 1);
+});
+
+test('createSpellingGuardianMissionCompletedEvent returns null when session.id is missing', () => {
+  assert.equal(createSpellingGuardianMissionCompletedEvent({ learnerId: 'a' }), null);
+  assert.equal(createSpellingGuardianMissionCompletedEvent({ learnerId: 'a', session: { id: '' } }), null);
+});
+
+test('createSpellingGuardianMissionCompletedEvent clamps negative counts to 0', () => {
+  const event = createSpellingGuardianMissionCompletedEvent({
+    learnerId: 'a',
+    session: GUARDIAN_SESSION,
+    renewalCount: -1,
+    wobbledCount: 'nope',
+    recoveredCount: 1.5,
+  });
+  assert.equal(event.renewalCount, 0);
+  assert.equal(event.wobbledCount, 0);
+  assert.equal(event.recoveredCount, 0);
+});
+
+test('all guardian event factories produce deterministic id collisions when inputs match', () => {
+  const learnerId = 'learner-a';
+  const createdAt = 1_780_000_000_000;
+  const renewed1 = createSpellingGuardianRenewedEvent({ learnerId, session: GUARDIAN_SESSION, slug: 'possess', reviewLevel: 1, createdAt });
+  const renewed2 = createSpellingGuardianRenewedEvent({ learnerId, session: GUARDIAN_SESSION, slug: 'possess', reviewLevel: 1, createdAt });
+  const wobbled1 = createSpellingGuardianWobbledEvent({ learnerId, session: GUARDIAN_SESSION, slug: 'possess', lapses: 0, createdAt });
+  const wobbled2 = createSpellingGuardianWobbledEvent({ learnerId, session: GUARDIAN_SESSION, slug: 'possess', lapses: 0, createdAt });
+  assert.equal(renewed1.id, renewed2.id);
+  assert.equal(wobbled1.id, wobbled2.id);
+  assert.notEqual(renewed1.id, wobbled1.id, 'different event types produce different ids even for same slug');
 });

--- a/tests/spelling-guardian.test.js
+++ b/tests/spelling-guardian.test.js
@@ -341,7 +341,7 @@ test('createSpellingGuardianMissionCompletedEvent returns null when session.id i
   assert.equal(createSpellingGuardianMissionCompletedEvent({ learnerId: 'a', session: { id: '' } }), null);
 });
 
-test('createSpellingGuardianMissionCompletedEvent clamps negative counts to 0', () => {
+test('createSpellingGuardianMissionCompletedEvent rejects non-integer and negative counts to 0', () => {
   const event = createSpellingGuardianMissionCompletedEvent({
     learnerId: 'a',
     session: GUARDIAN_SESSION,


### PR DESCRIPTION
## Summary

Plan U2 — adds the four `spelling.guardian.*` event types and their factories.

- `SPELLING_EVENT_TYPES` gains `GUARDIAN_RENEWED`, `GUARDIAN_WOBBLED`, `GUARDIAN_RECOVERED`, `GUARDIAN_MISSION_COMPLETED` (8 total after this PR). All values kebab-case per repo convention.
- 4 factory functions follow the existing per-word + session-level shapes (`createSpellingWordSecuredEvent` / `createSpellingSessionCompletedEvent`):
  - `renewed` carries `reviewLevel` + `nextDueDay`
  - `wobbled` carries lifetime `lapses` count
  - `recovered` carries lifetime `renewals` count + unchanged `reviewLevel` (emphasises schedule resumption, not restart)
  - `mission-completed` carries `renewalCount` / `wobbledCount` / `recoveredCount` + session `totalWords`
- All factories return `null` on missing/unknown slug (parity with existing factories), clamp bad counts to 0, and produce deterministic dedupe ids.

**No runtime behaviour change.** No emission path exists yet — events remain dormant until U3 wires guardian grading into `startSession`. No reward subscriber consumes them in MVP (per plan Scope Boundaries).

## Plan reference

Ships U2 from [`docs/plans/james/post-mega-spelling/2026-04-25-003-feat-post-mega-spelling-mvp-plan.md`](docs/plans/james/post-mega-spelling/2026-04-25-003-feat-post-mega-spelling-mvp-plan.md).

## Test plan

- [ ] `node --test tests/spelling-guardian.test.js tests/spelling.test.js` — 56/56 pass locally.
- [ ] 15 new assertions covering: type registry, factory shape, null-on-missing-slug, `safeTimestamp` fallback for invalid `createdAt`, clamping of bad `reviewLevel` / `nextDueDay` / count fields, deterministic dedupe ids, event-type uniqueness.
- [ ] No existing test touched; no existing factory modified.