### PR TITLE
fix(scripts): make audit-client-bundle CLI guard cross-platform

### DIFF
--- a/scripts/audit-client-bundle.mjs
+++ b/scripts/audit-client-bundle.mjs
@@ -1,5 +1,6 @@
 import { access, readFile, readdir } from 'node:fs/promises';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 const rootDir = process.cwd();
 
@@ -205,7 +206,7 @@ export async function runClientBundleAudit({
   };
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const result = await runClientBundleAudit({
     bundlePath: argValue('--bundle', DEFAULT_BUNDLE),
     metafilePath: argValue('--metafile', DEFAULT_METAFILE),


### PR DESCRIPTION
## Summary

- Fixes 7 failing tests in `tests/bundle-audit.test.js` that used `assert.throws(() => execFileSync(audit-client-bundle.mjs, ...))` to verify the audit script rejects forbidden inputs. The script was silently exiting 0 on Windows.
- Replaces `` if (import.meta.url === `file://${process.argv[1]}`) `` with `if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href)` — matches the existing pattern in 5 sibling scripts.

## Root cause

`import.meta.url` on Windows is `file:///C:/James/.../scripts/audit-client-bundle.mjs` (three slashes, drive letter). `process.argv[1]` is a relative path like `./scripts/audit-client-bundle.mjs`. The interpolation `file://./scripts/...` never matches, so the CLI guard fails silently — the script exports its function, the entry block never runs, process exits 0 without auditing anything.

This is a real production-safety bug: `execFileSync` callers were getting a false pass on every forbidden-input scenario the test suite covers (legacy spelling content seed, Grammar server runtime, browser AI provider keys, Punctuation AI context-pack, legacy broad write routes, etc.).

## Pattern followed

Already-correct siblings:
- `scripts/punctuation-production-smoke.mjs:357`
- `scripts/probe-production-bootstrap.mjs:292`
- `scripts/grammar-production-smoke.mjs:417`
- `scripts/backfill-learner-read-models.mjs:254`
- `scripts/classroom-load-test.mjs:669`

All use `if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href)`. This PR conforms `audit-client-bundle.mjs` to the same idiom.

## Test plan

- [x] `node --test tests/bundle-audit.test.js` → 14/14 pass (was 7/14)
- [x] `npm test` → 968 pass, 0 fail, 1 skipped (was 961 pass, 7 fail, 1 skipped)
- [x] Manual edge case: `node ./scripts/audit-client-bundle.mjs --bundle <bad> --metafile <meta> --public-dir <pub>` now exits 1 with `Forbidden production-client token ...` on stderr (was exit 0 silently)
- [x] `runClientBundleAudit` export signature unchanged — no API surface change for callers

Part of plan: `docs/plans/2026-04-25-004-fix-test-failures-env-and-windows-cli-plan.md` (U2).