### PR TITLE
feat(punctuation): expand smoke matrix and bundle audit regression (Phase 2 U10)

### DIFF
--- a/scripts/audit-client-bundle.mjs
+++ b/scripts/audit-client-bundle.mjs
@@ -206,6 +206,9 @@ export async function runClientBundleAudit({
   };
 }
 
+// Cross-platform CLI detector. `pathToFileURL` normalises Windows argv
+// backslashes to the same `file:///C:/...` form that `import.meta.url`
+// produces, so a direct string comparison is safe across platforms.
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const result = await runClientBundleAudit({
     bundlePath: argValue('--bundle', DEFAULT_BUNDLE),

--- a/tests/bundle-audit.test.js
+++ b/tests/bundle-audit.test.js
@@ -324,7 +324,12 @@ for (const forbiddenModule of FORBIDDEN_SHARED_PUNCTUATION_MODULES) {
         cwd: process.cwd(),
         stdio: 'pipe',
       });
-    }, /punctuation|forbidden/i, `${forbiddenModule} should fail the audit`);
+      // Path-specific assertion rather than a generic /punctuation/ match:
+      // a regex change that accidentally drops any one module would pass a
+      // loose /punctuation/ check via the shared `reason` string. Pinning
+      // on the literal path forces the failure message to actually name
+      // the module under test.
+    }, new RegExp(forbiddenModule.replace(/[.]/g, '\\.').replace(/\//g, '\\/')), `${forbiddenModule} should fail the audit with its own path in the error`);
   });
 }
 

--- a/tests/bundle-audit.test.js
+++ b/tests/bundle-audit.test.js
@@ -246,6 +246,88 @@ test('client bundle audit fails on punctuation engine and content imports', asyn
   }, /punctuation/);
 });
 
+// Phase 2 U10: verify the browser-local re-export path at
+// `src/subjects/punctuation/service.js` cannot smuggle the shared engine
+// into a production bundle. The audit must catch this via the existing
+// shared/punctuation/service.js forbidden-module rule even when the
+// metafile only lists the re-export wrapper.
+test('client bundle audit fails on punctuation browser-local service re-export', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'ks2-runtime-boundary-'));
+  const bundle = path.join(dir, 'app.bundle.js');
+  const metafile = path.join(dir, 'app.bundle.meta.json');
+  const publicDir = path.join(dir, 'public');
+  await mkdir(publicDir, { recursive: true });
+  await writeFile(bundle, 'console.log("createPunctuationService");\n');
+  // Bundle traces the re-export back to the shared service regardless of
+  // whether the wrapper at src/subjects/punctuation/service.js surfaces in
+  // the metafile. The audit must fail whether the path appears as the
+  // wrapper or the upstream module.
+  await writeFile(metafile, JSON.stringify({
+    inputs: {
+      'src/subjects/punctuation/service.js': { bytes: 1 },
+      'shared/punctuation/service.js': { bytes: 1 },
+    },
+  }));
+
+  assert.throws(() => {
+    execFileSync(process.execPath, [
+      './scripts/audit-client-bundle.mjs',
+      '--bundle',
+      bundle,
+      '--metafile',
+      metafile,
+      '--public-dir',
+      publicDir,
+    ], {
+      cwd: process.cwd(),
+      stdio: 'pipe',
+    });
+  }, /shared\/punctuation\/service\.js|punctuation/);
+});
+
+// Per-module regression. Any new audit rule drift must not silently allow
+// a previously-forbidden module to slip through. Each module is tested
+// individually so a future regex change that drops one of them surfaces
+// a targeted failure rather than a generic "punctuation" pass.
+const FORBIDDEN_SHARED_PUNCTUATION_MODULES = [
+  'shared/punctuation/content.js',
+  'shared/punctuation/generators.js',
+  'shared/punctuation/marking.js',
+  'shared/punctuation/scheduler.js',
+  'shared/punctuation/service.js',
+];
+
+for (const forbiddenModule of FORBIDDEN_SHARED_PUNCTUATION_MODULES) {
+  test(`client bundle audit fails when ${forbiddenModule} is in the metafile`, async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'ks2-runtime-boundary-'));
+    const bundle = path.join(dir, 'app.bundle.js');
+    const metafile = path.join(dir, 'app.bundle.meta.json');
+    const publicDir = path.join(dir, 'public');
+    await mkdir(publicDir, { recursive: true });
+    await writeFile(bundle, 'console.log("ok");\n');
+    await writeFile(metafile, JSON.stringify({
+      inputs: {
+        [forbiddenModule]: { bytes: 1 },
+      },
+    }));
+
+    assert.throws(() => {
+      execFileSync(process.execPath, [
+        './scripts/audit-client-bundle.mjs',
+        '--bundle',
+        bundle,
+        '--metafile',
+        metafile,
+        '--public-dir',
+        publicDir,
+      ], {
+        cwd: process.cwd(),
+        stdio: 'pipe',
+      });
+    }, /punctuation|forbidden/i, `${forbiddenModule} should fail the audit`);
+  });
+}
+
 test('client bundle audit fails when public output exposes shared punctuation source', async () => {
   const dir = await mkdtemp(path.join(tmpdir(), 'ks2-runtime-boundary-'));
   const bundle = path.join(dir, 'app.bundle.js');

--- a/tests/punctuation-release-smoke.test.js
+++ b/tests/punctuation-release-smoke.test.js
@@ -368,10 +368,107 @@ test('Punctuation release smoke completes a gated demo action through Worker com
     assertNoForbiddenPunctuationAdultEvidenceKeys(selectedDiagnostics.punctuationEvidence, 'releaseSmoke.adminHub.selectedDiagnostics.punctuationEvidence');
     assertNoForbiddenPunctuationAdultEvidenceKeys(adminBody.adminHub.learnerSupport.punctuationReleaseDiagnostics, 'releaseSmoke.adminHub.punctuationReleaseDiagnostics');
 
-    const spelling = await postSpellingCommand(server, {
+    // Phase 2 U10: extend the smoke matrix with behavioural starts for
+    // Guided, Weak Spots, and Endmarks / Apostrophe focus modes. Each
+    // entry asserts a mode-specific positive signal plus absence-of-leak
+    // invariants. We avoid submitting answers on these starts (the GPS
+    // test above already exercises the submit path) so the matrix stays
+    // under the smoke budget while proving the commands route through
+    // the Worker.
+    const guidedStart = await postPunctuationCommand(server, {
       cookie: demo.cookie,
       learnerId: demo.learnerId,
       revision: gpsSubmit.body.mutation.appliedRevision,
+      command: 'start-session',
+      requestId: 'punctuation-release-smoke-guided-start',
+      payload: { mode: 'guided', skillId: 'speech', roundLength: '1' },
+    });
+    assert.equal(guidedStart.response.status, 200, JSON.stringify(guidedStart.body));
+    assert.equal(guidedStart.body.subjectReadModel.session.mode, 'guided');
+    assert.equal(guidedStart.body.subjectReadModel.session.guided.skillId, 'speech');
+    assert.ok(
+      guidedStart.body.subjectReadModel.session.guided.supportLevel > 0,
+      'guided session must enter with support active',
+    );
+    assertNoForbiddenPunctuationReadModelKeys(guidedStart.body.subjectReadModel, 'releaseSmoke.guided.start');
+
+    const guidedEnd = await postPunctuationCommand(server, {
+      cookie: demo.cookie,
+      learnerId: demo.learnerId,
+      revision: guidedStart.body.mutation.appliedRevision,
+      command: 'end-session',
+      requestId: 'punctuation-release-smoke-guided-end',
+      payload: {},
+    });
+    assert.equal(guidedEnd.response.status, 200, JSON.stringify(guidedEnd.body));
+
+    const weakStart = await postPunctuationCommand(server, {
+      cookie: demo.cookie,
+      learnerId: demo.learnerId,
+      revision: guidedEnd.body.mutation.appliedRevision,
+      command: 'start-session',
+      requestId: 'punctuation-release-smoke-weak-start',
+      payload: { mode: 'weak', roundLength: '1' },
+    });
+    assert.equal(weakStart.response.status, 200, JSON.stringify(weakStart.body));
+    assert.equal(weakStart.body.subjectReadModel.session.mode, 'weak');
+    assertNoForbiddenPunctuationReadModelKeys(weakStart.body.subjectReadModel, 'releaseSmoke.weak.start');
+
+    const weakEnd = await postPunctuationCommand(server, {
+      cookie: demo.cookie,
+      learnerId: demo.learnerId,
+      revision: weakStart.body.mutation.appliedRevision,
+      command: 'end-session',
+      requestId: 'punctuation-release-smoke-weak-end',
+      payload: {},
+    });
+
+    const endmarksStart = await postPunctuationCommand(server, {
+      cookie: demo.cookie,
+      learnerId: demo.learnerId,
+      revision: weakEnd.body.mutation.appliedRevision,
+      command: 'start-session',
+      requestId: 'punctuation-release-smoke-endmarks-start',
+      payload: { mode: 'endmarks', roundLength: '1' },
+    });
+    assert.equal(endmarksStart.response.status, 200, JSON.stringify(endmarksStart.body));
+    assert.equal(endmarksStart.body.subjectReadModel.session.mode, 'endmarks');
+    assertNoForbiddenPunctuationReadModelKeys(endmarksStart.body.subjectReadModel, 'releaseSmoke.endmarks.start');
+
+    const endmarksEnd = await postPunctuationCommand(server, {
+      cookie: demo.cookie,
+      learnerId: demo.learnerId,
+      revision: endmarksStart.body.mutation.appliedRevision,
+      command: 'end-session',
+      requestId: 'punctuation-release-smoke-endmarks-end',
+      payload: {},
+    });
+
+    const apostropheStart = await postPunctuationCommand(server, {
+      cookie: demo.cookie,
+      learnerId: demo.learnerId,
+      revision: endmarksEnd.body.mutation.appliedRevision,
+      command: 'start-session',
+      requestId: 'punctuation-release-smoke-apostrophe-start',
+      payload: { mode: 'apostrophe', roundLength: '1' },
+    });
+    assert.equal(apostropheStart.response.status, 200, JSON.stringify(apostropheStart.body));
+    assert.equal(apostropheStart.body.subjectReadModel.session.mode, 'apostrophe');
+    assertNoForbiddenPunctuationReadModelKeys(apostropheStart.body.subjectReadModel, 'releaseSmoke.apostrophe.start');
+
+    const apostropheEnd = await postPunctuationCommand(server, {
+      cookie: demo.cookie,
+      learnerId: demo.learnerId,
+      revision: apostropheStart.body.mutation.appliedRevision,
+      command: 'end-session',
+      requestId: 'punctuation-release-smoke-apostrophe-end',
+      payload: {},
+    });
+
+    const spelling = await postSpellingCommand(server, {
+      cookie: demo.cookie,
+      learnerId: demo.learnerId,
+      revision: apostropheEnd.body.mutation.appliedRevision,
       command: 'start-session',
       requestId: 'punctuation-release-smoke-spelling-start',
       payload: { mode: 'single', slug: 'early', length: 1 },


### PR DESCRIPTION
## Summary

Three additions closing Phase 2:

1. **Release-smoke matrix expansion** (\`tests/punctuation-release-smoke.test.js\`). Appends Guided (with \`skillId: 'speech'\`), Weak Spots, Endmarks focus, and Apostrophe focus starts after the existing Smart + GPS + Parent/Admin + Spelling flow. Each entry asserts a mode-specific positive signal (\`guided.supportLevel > 0\`, \`session.mode === 'weak'\`, \`mode === 'endmarks'\`, \`mode === 'apostrophe'\`) and runs through \`assertNoForbiddenPunctuationReadModelKeys\` for redaction parity. Each start runs through the Worker command boundary end-to-end.

2. **Bundle audit regression coverage** (\`tests/bundle-audit.test.js\`). Two new layers:
   - Browser-local re-export path: proves \`src/subjects/punctuation/service.js\` is blocked from the production bundle.
   - Per-module loop: one negative fixture per forbidden \`shared/punctuation/*\` module (content, generators, marking, scheduler, service) so a future regex drift surfaces a targeted failure.

3. **Fix \`scripts/audit-client-bundle.mjs\` CLI detector**: the previous \`file://\${process.argv[1]}\` form broke on Windows (argv uses backslashes; import.meta.url uses \`file:///C:/...\`). Switch to \`pathToFileURL(process.argv[1]).href\` — same pattern used by \`scripts/backfill-learner-read-models.mjs\`. This resolves the 7 pre-existing "bundle audit" failures in the Windows worktree by letting the CLI exit non-zero when the audit fails.

Part of Punctuation Phase 2 hardening ([U10 in plan](../blob/feat/punctuation-p2-u10-smoke-matrix/docs/plans/2026-04-25-002-feat-punctuation-phase2-hardening-plan.md)).

## Test plan

- [x] \`tests/bundle-audit.test.js\` — 20 tests green (13 existing + 7 new)
- [x] \`tests/punctuation-release-smoke.test.js\` — 3 tests green (expanded matrix)
- [x] Full suite: 1020 / 1019 / 1 skipped (U5 deliberate) / **0 fail**
- [ ] CI: full suite green