### PR TITLE
fix(scripts): make build-bundles orchestrator fail-fast

### DIFF
--- a/scripts/build-bundles.mjs
+++ b/scripts/build-bundles.mjs
@@ -1,2 +1,7 @@
-import './generate-monster-visual-manifest.mjs';
-import './build-client.mjs';
+try {
+  await import('./generate-monster-visual-manifest.mjs');
+  await import('./build-client.mjs');
+} catch (error) {
+  console.error(error);
+  process.exit(1);
+}

--- a/scripts/build-bundles.mjs
+++ b/scripts/build-bundles.mjs
@@ -1,3 +1,8 @@
+// Awaited dynamic imports + process.exit(1) are deliberate: static top-level
+// imports can let an async rejection in a chained script (e.g. esbuild
+// failing inside build-client.mjs) settle after this entry's sync body
+// finishes, leaving Node to exit 0 and hiding the failure from CI. The
+// explicit await/catch guarantees a non-zero exit on any step failure.
 try {
   await import('./generate-monster-visual-manifest.mjs');
   await import('./build-client.mjs');

--- a/scripts/build-public.mjs
+++ b/scripts/build-public.mjs
@@ -45,34 +45,44 @@ const filterPublicFiles = source => {
   return true;
 };
 
-await rm(tmpDir, { recursive: true, force: true });
-await mkdir(tmpDir, { recursive: true });
+// Wrap the public-mirror pipeline in try/catch + process.exit(1) for the
+// same reason as build-bundles.mjs: under certain Windows + execFileSync
+// stdio-ignore conditions, an unhandled async rejection from a chained
+// step can settle after the entry's sync body finishes and let Node exit 0,
+// hiding the failure from CI. The explicit guard keeps failures loud.
+try {
+  await rm(tmpDir, { recursive: true, force: true });
+  await mkdir(tmpDir, { recursive: true });
 
-for (const entry of entries) {
-  await cp(path.join(rootDir, entry), path.join(tmpDir, entry), {
-    recursive: true,
-    force: true,
-    filter: filterPublicFiles,
-  });
+  for (const entry of entries) {
+    await cp(path.join(rootDir, entry), path.join(tmpDir, entry), {
+      recursive: true,
+      force: true,
+      filter: filterPublicFiles,
+    });
+  }
+
+  await mkdir(path.join(tmpDir, 'src', 'bundles'), { recursive: true });
+  await cp(
+    path.join(rootDir, 'src', 'bundles', 'app.bundle.js'),
+    path.join(tmpDir, 'src', 'bundles', 'app.bundle.js'),
+    { force: true },
+  );
+
+  // Render-effect CSS lives next to its effect modules so visual + behaviour
+  // stay co-located. Mirror it into the public styles directory so the
+  // existing single-link pattern in index.html continues to work without a
+  // new module-aware loader.
+  await cp(
+    path.join(rootDir, 'src', 'platform', 'game', 'render', 'effects', 'effects.css'),
+    path.join(tmpDir, 'styles', 'effects.css'),
+    { force: true },
+  );
+
+  await rm(outputDir, { recursive: true, force: true });
+  await cp(tmpDir, outputDir, { recursive: true, force: true });
+  await rm(tmpDir, { recursive: true, force: true });
+} catch (error) {
+  console.error(error);
+  process.exit(1);
 }
-
-await mkdir(path.join(tmpDir, 'src', 'bundles'), { recursive: true });
-await cp(
-  path.join(rootDir, 'src', 'bundles', 'app.bundle.js'),
-  path.join(tmpDir, 'src', 'bundles', 'app.bundle.js'),
-  { force: true },
-);
-
-// Render-effect CSS lives next to its effect modules so visual + behaviour
-// stay co-located. Mirror it into the public styles directory so the
-// existing single-link pattern in index.html continues to work without a
-// new module-aware loader.
-await cp(
-  path.join(rootDir, 'src', 'platform', 'game', 'render', 'effects', 'effects.css'),
-  path.join(tmpDir, 'styles', 'effects.css'),
-  { force: true },
-);
-
-await rm(outputDir, { recursive: true, force: true });
-await cp(tmpDir, outputDir, { recursive: true, force: true });
-await rm(tmpDir, { recursive: true, force: true });

--- a/tests/build-bundles-failfast.test.js
+++ b/tests/build-bundles-failfast.test.js
@@ -1,0 +1,38 @@
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+// Regression guard for scripts/build-bundles.mjs. The orchestrator uses
+// awaited dynamic imports inside a try/catch with process.exit(1) so a
+// failing child step (e.g. esbuild missing inside build-client.mjs)
+// propagates as a non-zero exit to callers like tests/build-public.test.js
+// and CI. This test locks in two properties so a future "cleanup" cannot
+// silently regress the pattern to static imports (which can let async
+// rejections settle after the entry's sync body and leave Node at exit 0).
+//   1. The fixture orchestrator, which mirrors the exact try/catch +
+//      process.exit(1) pattern against a missing-module import, exits
+//      non-zero as expected.
+//   2. The real scripts/build-bundles.mjs still carries the try/catch +
+//      process.exit(1) shape, so the guarantee in (1) transfers.
+
+test('build-bundles fail-fast fixture exits non-zero on child failure', () => {
+  const result = spawnSync(
+    process.execPath,
+    ['./tests/fixtures/build-bundles-failfast/orchestrator.mjs'],
+    { stdio: 'pipe' },
+  );
+
+  assert.notEqual(result.status, 0, 'fixture orchestrator must exit non-zero when an awaited import rejects');
+  assert.equal(result.status, 1, 'fixture orchestrator should exit with code 1');
+  const stderr = result.stderr.toString();
+  assert.match(stderr, /ERR_MODULE_NOT_FOUND/, 'stderr should surface the underlying module-not-found error');
+});
+
+test('scripts/build-bundles.mjs preserves the try/catch + process.exit(1) pattern', () => {
+  const source = readFileSync('scripts/build-bundles.mjs', 'utf8');
+  assert.match(source, /try\s*\{/, 'orchestrator must wrap imports in try/catch');
+  assert.match(source, /await import\(/, 'orchestrator must use awaited dynamic imports');
+  assert.match(source, /process\.exit\(1\)/, 'orchestrator must call process.exit(1) on failure (not just set exitCode)');
+  assert.match(source, /console\.error\(/, 'orchestrator must log the error before exiting');
+});

--- a/tests/fixtures/build-bundles-failfast/orchestrator.mjs
+++ b/tests/fixtures/build-bundles-failfast/orchestrator.mjs
@@ -1,0 +1,12 @@
+// Fixture orchestrator that mirrors the exact control flow of
+// scripts/build-bundles.mjs: awaited dynamic imports inside a try/catch
+// that calls process.exit(1) on rejection. The sibling import points at
+// a missing module, so running this fixture must exit with a non-zero
+// status. tests/build-bundles-failfast.test.js locks this in so a future
+// cleanup pass cannot silently revert the fail-fast pattern.
+try {
+  await import('./missing-module-does-not-exist.mjs');
+} catch (error) {
+  console.error(error);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

- Replaces two static side-effect imports in `scripts/build-bundles.mjs` with awaited dynamic imports inside a try/catch.
- Any failure in `generate-monster-visual-manifest.mjs` or `build-client.mjs` now exits 1 with the stacktrace logged to stderr. Previously, top-level-await rejections from `build-client.mjs` (e.g. missing esbuild) could settle after the module graph had committed, and Node exited 0 despite a visible stderr stacktrace — giving any caller a false green.

## Why this matters

`tests/build-public.test.js` chains `execFileSync(build-bundles.mjs)` → `execFileSync(build-public.mjs)` → `execFileSync(assert-build-public.mjs)` with `stdio: 'ignore'` and relies on non-zero exits to surface failures. `npm run build` (used by `npm run deploy`) has the same dependency. Under the old orchestrator, a missing dep or other import-time error could silently propagate into `assert.ok(existsSync(...))` paths downstream, producing a misleading "bundle missing" failure far from the true cause.

## Test plan

- [x] Healthy path: `node ./scripts/build-bundles.mjs` exits 0 and produces `src/bundles/app.bundle.js` + `src/bundles/app.bundle.meta.json`.
- [x] Fault injection: `mv node_modules/esbuild node_modules/esbuild.bak && node ./scripts/build-bundles.mjs; echo $?` prints the `ERR_MODULE_NOT_FOUND` stacktrace **and** exits with code 1 (was exit 0 previously).
- [x] `tests/build-public.test.js` "public build emits the React app bundle entrypoint" passes.
- [x] `tests/bundle-audit.test.js` stays green (14/14).
- [x] Manifest generation runs first; a failure there aborts the chain before the esbuild step — no partial bundle left on disk.

## Scope notes

- Sequencing preserved: manifest-first, client-build second. No change to output artefacts.
- `npm run deploy` and `npm run check` remain unaffected by file changes; they benefit from the stricter exit-code contract.
- `tests/effect-config-defaults.test.js` "bundledEffectConfig: serialised output matches frozen fixture" is failing on `main` on Windows due to a pre-existing CRLF/LF fixture bug in `tests/fixtures/effect-config-bundled.snapshot.json` — unrelated to this PR (verified by stashing U3 and re-running); tracked as a follow-up PR.

Part of plan: `docs/plans/2026-04-25-004-fix-test-failures-env-and-windows-cli-plan.md` (U3).