### PR TITLE
feat(scripts): add fresh-worktree preflight before npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "smoke:production:bootstrap": "node ./scripts/probe-production-bootstrap.mjs",
     "smoke:production:grammar": "node ./scripts/grammar-production-smoke.mjs",
     "smoke:production:punctuation": "node ./scripts/punctuation-production-smoke.mjs",
+    "pretest": "node ./scripts/preflight-test.mjs",
     "test": "node --test",
     "test:migration:browser": "KS2_BROWSER_SMOKE=1 node --test tests/browser-react-migration-smoke.test.js",
     "verify": "npm test && npm run check"

--- a/scripts/preflight-test.mjs
+++ b/scripts/preflight-test.mjs
@@ -1,0 +1,35 @@
+// Fresh-worktree preflight: fails fast with an actionable message when
+// node_modules is missing. Git worktrees do not share node_modules with
+// the primary checkout, so the first `npm test` in a new worktree would
+// otherwise produce a cryptic ERR_MODULE_NOT_FOUND stack from deep inside
+// a test file. Catching it here keeps the signal clear for anyone
+// starting work in a fresh worktree.
+import { access } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import path from 'node:path';
+
+const REQUIRED_PACKAGES = ['react', 'esbuild'];
+
+async function isInstalled(packageName) {
+  const pkgJson = path.join('node_modules', packageName, 'package.json');
+  try {
+    await access(pkgJson, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const missing = [];
+for (const pkg of REQUIRED_PACKAGES) {
+  if (!await isInstalled(pkg)) {
+    missing.push(pkg);
+  }
+}
+
+if (missing.length > 0) {
+  console.error(
+    `Missing node_modules (${missing.join(', ')}) — run "npm install" from this worktree root before "npm test". Git worktrees do not share node_modules with the primary checkout.`,
+  );
+  process.exit(1);
+}

--- a/scripts/preflight-test.mjs
+++ b/scripts/preflight-test.mjs
@@ -8,6 +8,15 @@ import { access } from 'node:fs/promises';
 import { constants } from 'node:fs';
 import path from 'node:path';
 
+// Sentinel set, not exhaustive. Pick devDependencies that (a) are imported
+// during `npm test` (directly or transitively via a bundler step) and (b)
+// have zero same-repo fallbacks -- so a missing install produces an
+// actionable, non-cryptic failure instead of a deep stacktrace. Adding more
+// packages here is cheap (one `access` call each); keep the list small
+// enough that a contributor can eyeball it against package.json. Iterating
+// devDependencies dynamically was considered and rejected: it couples this
+// script to package.json parsing and would flag pure build-only deps that
+// `npm test` does not need.
 const REQUIRED_PACKAGES = ['react', 'esbuild'];
 
 async function isInstalled(packageName) {

--- a/tests/preflight-test.test.js
+++ b/tests/preflight-test.test.js
@@ -1,0 +1,60 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+// Regression guard for scripts/preflight-test.mjs. The preflight only buys
+// anything if a future cleanup pass cannot silently swap `console.error` +
+// `process.exit(1)` for `throw` (which would re-bury the message inside a
+// stacktrace) or drop the exit-1 (which would let `npm test` continue into
+// the cryptic ERR_MODULE_NOT_FOUND the preflight was meant to replace).
+// These tests lock in the observable contract: exit code 1, expected
+// stderr line, and a sane no-op when node_modules *is* present.
+//
+// We spawn the preflight in a temp cwd so the test does not depend on the
+// ambient worktree state (node_modules here is always installed when the
+// suite runs, so an in-place invocation would never exercise the missing
+// branch).
+
+const SCRIPT = path.resolve('scripts/preflight-test.mjs');
+
+function spawnInCwd(cwd) {
+  return spawnSync(process.execPath, [SCRIPT], { cwd, stdio: 'pipe' });
+}
+
+function makeTempDir(prefix) {
+  return mkdtempSync(path.join(tmpdir(), prefix));
+}
+
+test('preflight exits 1 with actionable stderr when node_modules is absent', () => {
+  const cwd = makeTempDir('preflight-missing-');
+  try {
+    const result = spawnInCwd(cwd);
+    assert.equal(result.status, 1, 'preflight must exit 1 when a required package is missing');
+    const stderr = result.stderr.toString();
+    assert.match(stderr, /Missing node_modules/, 'stderr should name the failure mode');
+    assert.match(stderr, /npm install/, 'stderr should tell the reader how to fix it');
+    assert.match(stderr, /worktree/, 'stderr should explain why (git worktrees)');
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('preflight exits 0 when all required packages are present', () => {
+  const cwd = makeTempDir('preflight-present-');
+  try {
+    // Mirror the shape the preflight probes: node_modules/<pkg>/package.json.
+    for (const pkg of ['react', 'esbuild']) {
+      const pkgDir = path.join(cwd, 'node_modules', pkg);
+      mkdirSync(pkgDir, { recursive: true });
+      writeFileSync(path.join(pkgDir, 'package.json'), '{"name":"' + pkg + '"}');
+    }
+    const result = spawnInCwd(cwd);
+    assert.equal(result.status, 0, 'preflight must exit 0 when every required package resolves');
+    assert.equal(result.stderr.toString(), '', 'preflight must stay silent on the happy path');
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- Adds `scripts/preflight-test.mjs` — a ~30-line preflight that checks for `react` and `esbuild` in `node_modules/` and exits 1 with an actionable message if either is missing.
- Wires it via `"pretest"` in `package.json` so it runs automatically before `npm test`. Happy-path overhead is ~10ms filesystem stat; lost in Node startup noise.

## Why this matters

Git worktrees do not share `node_modules` with the primary checkout. The first `npm test` in a new worktree (before `npm install`) produces a deep `ERR_MODULE_NOT_FOUND: Cannot find package 'react'` stacktrace from inside whichever test file happens to import it first — an hour-long diagnosis for a one-command fix. This PR front-loads the signal: the first thing you see is the fix.

The message:

```
Missing node_modules (...) — run "npm install" from this worktree root before "npm test". Git worktrees do not share node_modules with the primary checkout.
```

## Test plan

- [x] Happy path: `node ./scripts/preflight-test.mjs` → silent, exits 0, <50ms (measured 671ms total incl. Node startup).
- [x] Only `react` missing: exits 1 with `Missing node_modules (react) — ...`.
- [x] Only `esbuild` missing: exits 1 with `Missing node_modules (esbuild) — ...`.
- [x] Both missing (`mv node_modules /tmp/nm-bak`): exits 1 with `Missing node_modules (react, esbuild) — ...`.
- [x] Partial install simulation covered by "only esbuild missing" above.
- [x] `npm test` auto-invokes `pretest` → 1148 pass, 1 fail, 1 skipped (the 1 fail is a pre-existing CRLF/LF fixture bug in `tests/fixtures/effect-config-bundled.snapshot.json`, tracked as a follow-up; unrelated to this PR).

## Design notes

- UK English per `AGENTS.md` (`worktree`, `node_modules`).
- Checks `react` + `esbuild` specifically — these were the two packages that dominated the `ERR_MODULE_NOT_FOUND` failure surface observed during worktree setup. A full dep audit would be over-engineering for this use case.
- Uses only `node:fs` / `node:path` — no third-party imports (which would be self-defeating).
- The preflight is advisory; it does not auto-install. `npm install` is cheap but not universally safe to auto-run without consent.

Part of plan: `docs/plans/2026-04-25-004-fix-test-failures-env-and-windows-cli-plan.md` (U4).