### PR TITLE
feat(capacity): U2 threshold gates + evidence hooks for sys-hardening p1

### DIFF
--- a/docs/operations/capacity.md
+++ b/docs/operations/capacity.md
@@ -48,6 +48,46 @@ npm run check
 npm run deploy
 ```
 
+## Threshold-Run Procedure
+
+The classroom load driver and production bootstrap probe both support hard threshold gates so a CI step can fail purely on threshold violation. No threshold flag is set by default — absent flags preserve the existing reporting behaviour exactly.
+
+### Classroom load driver flags
+
+Add any combination of the following to `npm run capacity:classroom`. Each flag is an optional hard gate; if absent the gate is not enforced. When any gate is violated the script exits non-zero and prints a `thresholds.violations` block in the JSON report.
+
+- `--max-5xx <count>` — fail if total HTTP 5xx responses exceed `<count>`.
+- `--max-network-failures <count>` — fail if network-level failures exceed `<count>`.
+- `--max-bootstrap-p95-ms <ms>` — fail if `/api/bootstrap` P95 wall time exceeds `<ms>`.
+- `--max-command-p95-ms <ms>` — fail if subject-command P95 wall time exceeds `<ms>`.
+- `--max-response-bytes <bytes>` — fail if any endpoint's maximum response bytes exceed `<bytes>`.
+- `--require-zero-signals` — fail if any `exceededCpu`, `d1Overloaded`, `d1DailyLimit`, `rateLimited`, `networkFailure`, or `server5xx` signal is observed.
+- `--confirm-high-production-load` — additional acknowledgement for larger production load shapes; required by operators before running at classroom or stretch scale.
+
+The `capacity:classroom:release-gate` package script bakes the recommended defaults:
+
+```sh
+npm run capacity:classroom:release-gate -- --production --origin https://ks2.eugnel.uk --confirm-production-load --confirm-high-production-load --demo-sessions --learners 30 --bootstrap-burst 20 --rounds 1
+```
+
+The release-gate script is equivalent to `capacity:classroom` with `--max-5xx 0 --max-network-failures 0 --max-bootstrap-p95-ms 1000 --max-command-p95-ms 750 --max-response-bytes 600000 --require-zero-signals` prepended. Any additional arguments you supply on the command line layer on top.
+
+### Probe bootstrap flags
+
+`npm run smoke:production:bootstrap` supports three hard gates:
+
+- `--max-bytes <bytes>` — fail when the response body exceeds `<bytes>` (default 600 000).
+- `--max-sessions <count>` — fail when `practiceSessions` length exceeds `<count>`.
+- `--max-events <count>` — fail when `eventLog` length exceeds `<count>`.
+
+A threshold violation emits a `thresholdViolations` entry in the JSON report alongside the legacy `failures` list, and exits non-zero. Raw response bodies are never surfaced in the output even when a threshold trips — only the measured size, count, and the configured limit.
+
+### Recommended CI wiring
+
+1. Run `npm run capacity:classroom:release-gate -- --dry-run` as a deterministic smoke on every pull request. The dry-run still reports the `thresholds` block so the JSON shape is stable.
+2. For production release gates, invoke the same script with `--production --origin <origin> --confirm-production-load --confirm-high-production-load --demo-sessions` so isolated demo sessions carry the load.
+3. Record the resulting `thresholds.violations` array, plan summary, and commit SHA alongside the run, per the `Evidence To Record` checklist.
+
 ## Evidence To Record
 
 For each capacity run, record:

--- a/docs/operations/capacity.md
+++ b/docs/operations/capacity.md
@@ -62,7 +62,13 @@ Add any combination of the following to `npm run capacity:classroom`. Each flag 
 - `--max-command-p95-ms <ms>` — fail if subject-command P95 wall time exceeds `<ms>`.
 - `--max-response-bytes <bytes>` — fail if any endpoint's maximum response bytes exceed `<bytes>`.
 - `--require-zero-signals` — fail if any `exceededCpu`, `d1Overloaded`, `d1DailyLimit`, `rateLimited`, `networkFailure`, or `server5xx` signal is observed.
-- `--confirm-high-production-load` — additional acknowledgement for larger production load shapes; required by operators before running at classroom or stretch scale.
+- `--confirm-high-production-load` — required by operators before running `--production` at classroom or stretch scale (learners ≥ 20 or bootstrap-burst ≥ 20). Enforced by `validateClassroomLoadOptions`: a production run that exceeds the high-load threshold and omits this flag is rejected with a clear error.
+
+**Important safety interactions**
+
+- **Threshold flags are incompatible with `--dry-run`.** Dry-run has no measurements, so every threshold would always pass silently. The script rejects the combination with a clear error; CI gates must choose `--local-fixture` or `--production`.
+- **Mode flags are mutually exclusive.** Specifying more than one of `--dry-run`, `--local-fixture`, `--production` is rejected. The prior last-wins behaviour silently downgraded a `--production` run to `--dry-run` when both appeared.
+- **Duplicate threshold flags are rejected.** Specifying `--max-5xx` twice (or any other threshold) is rejected. This prevents a release-gate wrapper from being silently weakened by a later argument repeating the flag with a looser value.
 
 The `capacity:classroom:release-gate` package script bakes the recommended defaults:
 
@@ -70,7 +76,7 @@ The `capacity:classroom:release-gate` package script bakes the recommended defau
 npm run capacity:classroom:release-gate -- --production --origin https://ks2.eugnel.uk --confirm-production-load --confirm-high-production-load --demo-sessions --learners 30 --bootstrap-burst 20 --rounds 1
 ```
 
-The release-gate script is equivalent to `capacity:classroom` with `--max-5xx 0 --max-network-failures 0 --max-bootstrap-p95-ms 1000 --max-command-p95-ms 750 --max-response-bytes 600000 --require-zero-signals` prepended. Any additional arguments you supply on the command line layer on top.
+The release-gate script is equivalent to `capacity:classroom` with `--max-5xx 0 --max-network-failures 0 --max-bootstrap-p95-ms 1000 --max-command-p95-ms 750 --max-response-bytes 600000 --require-zero-signals` prepended. Any additional arguments you supply on the command line layer on top — but they cannot repeat a threshold already baked in (duplicate-flag rejection), and they cannot choose `--dry-run` (threshold-vs-dry-run rejection).
 
 ### Probe bootstrap flags
 
@@ -84,8 +90,8 @@ A threshold violation emits a `thresholdViolations` entry in the JSON report alo
 
 ### Recommended CI wiring
 
-1. Run `npm run capacity:classroom:release-gate -- --dry-run` as a deterministic smoke on every pull request. The dry-run still reports the `thresholds` block so the JSON shape is stable.
-2. For production release gates, invoke the same script with `--production --origin <origin> --confirm-production-load --confirm-high-production-load --demo-sessions` so isolated demo sessions carry the load.
+1. On every pull request, run `npm run capacity:classroom -- --dry-run --learners 30 --bootstrap-burst 20 --rounds 1` (no threshold flags — dry-run cannot meaningfully evaluate thresholds). This validates the plan shape and argument parsing without network traffic.
+2. For the production release gate, invoke `npm run capacity:classroom:release-gate -- --production --origin <origin> --confirm-production-load --confirm-high-production-load --demo-sessions --learners 30 --bootstrap-burst 20 --rounds 1` so isolated demo sessions carry the load and thresholds fire against real measurements.
 3. Record the resulting `thresholds.violations` array, plan summary, and commit SHA alongside the run, per the `Evidence To Record` checklist.
 
 ## Evidence To Record

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "check": "node ./scripts/wrangler-oauth.mjs deploy --dry-run",
     "check:oauth": "npm run check",
     "capacity:classroom": "node ./scripts/classroom-load-test.mjs",
+    "capacity:classroom:release-gate": "node ./scripts/classroom-load-test.mjs --max-5xx 0 --max-network-failures 0 --max-bootstrap-p95-ms 1000 --max-command-p95-ms 750 --max-response-bytes 600000 --require-zero-signals",
     "content:seed": "node scripts/seed-spelling-content-from-legacy.mjs",
     "content:enrich": "node scripts/enrich-spelling-vocabulary.mjs",
     "content:validate": "node scripts/validate-spelling-content.mjs",

--- a/scripts/classroom-load-test.mjs
+++ b/scripts/classroom-load-test.mjs
@@ -246,41 +246,66 @@ export function parseClassroomLoadArgs(argv = process.argv.slice(2)) {
     help: false,
   };
 
+  let modeFlag = null;
+  const assignedFlags = new Set();
+  const assignOnce = (flag) => {
+    if (assignedFlags.has(flag)) {
+      throw new Error(`${flag} specified more than once; refusing to let later value silently override the earlier one.`);
+    }
+    assignedFlags.add(flag);
+  };
+  const setMode = (flag, nextMode) => {
+    if (modeFlag && modeFlag !== flag) {
+      throw new Error(`Conflicting mode flags: ${modeFlag} and ${flag}. Specify exactly one of --dry-run, --local-fixture, --production.`);
+    }
+    modeFlag = flag;
+    options.mode = nextMode;
+  };
+
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === '--help' || arg === '-h') {
       options.help = true;
     } else if (arg === '--dry-run') {
-      options.mode = 'dry-run';
+      setMode(arg, 'dry-run');
     } else if (arg === '--local-fixture') {
-      options.mode = 'local-fixture';
+      setMode(arg, 'local-fixture');
     } else if (arg === '--production') {
-      options.mode = 'production';
+      setMode(arg, 'production');
     } else if (arg === '--origin' || arg === '--url') {
+      assignOnce('--origin/--url');
       options.origin = normaliseOrigin(readOptionValue(argv, index, arg));
       index += 1;
     } else if (arg === '--learners') {
+      assignOnce(arg);
       options.learners = positiveInteger(readOptionValue(argv, index, arg), arg);
       index += 1;
     } else if (arg === '--bootstrap-burst') {
+      assignOnce(arg);
       options.bootstrapBurst = positiveInteger(readOptionValue(argv, index, arg), arg);
       index += 1;
     } else if (arg === '--rounds') {
+      assignOnce(arg);
       options.rounds = positiveInteger(readOptionValue(argv, index, arg), arg);
       index += 1;
     } else if (arg === '--pacing-ms') {
+      assignOnce(arg);
       options.pacingMs = nonNegativeInteger(readOptionValue(argv, index, arg), arg);
       index += 1;
     } else if (arg === '--timeout-ms') {
+      assignOnce(arg);
       options.timeoutMs = positiveInteger(readOptionValue(argv, index, arg), arg);
       index += 1;
     } else if (arg === '--cookie') {
+      assignOnce(arg);
       options.cookie = readOptionValue(argv, index, arg);
       index += 1;
     } else if (arg === '--bearer') {
+      assignOnce(arg);
       options.bearer = readOptionValue(argv, index, arg);
       index += 1;
     } else if (arg === '--header') {
+      // Headers are cumulative by design (repeatable per docs); no assignOnce.
       options.headers.push(readOptionValue(argv, index, arg));
       index += 1;
     } else if (arg === '--demo-sessions') {
@@ -292,18 +317,23 @@ export function parseClassroomLoadArgs(argv = process.argv.slice(2)) {
     } else if (arg === '--summary-only') {
       options.includeMeasurements = false;
     } else if (arg === '--max-5xx') {
+      assignOnce(arg);
       options.max5xx = nonNegativeInteger(readOptionValue(argv, index, arg), arg);
       index += 1;
     } else if (arg === '--max-network-failures') {
+      assignOnce(arg);
       options.maxNetworkFailures = nonNegativeInteger(readOptionValue(argv, index, arg), arg);
       index += 1;
     } else if (arg === '--max-bootstrap-p95-ms') {
+      assignOnce(arg);
       options.maxBootstrapP95Ms = nonNegativeInteger(readOptionValue(argv, index, arg), arg);
       index += 1;
     } else if (arg === '--max-command-p95-ms') {
+      assignOnce(arg);
       options.maxCommandP95Ms = nonNegativeInteger(readOptionValue(argv, index, arg), arg);
       index += 1;
     } else if (arg === '--max-response-bytes') {
+      assignOnce(arg);
       options.maxResponseBytes = nonNegativeInteger(readOptionValue(argv, index, arg), arg);
       index += 1;
     } else if (arg === '--require-zero-signals') {
@@ -315,6 +345,8 @@ export function parseClassroomLoadArgs(argv = process.argv.slice(2)) {
 
   return options;
 }
+
+const HIGH_PRODUCTION_LOAD_THRESHOLD = 20;
 
 export function buildClassroomLoadPlan(options = {}) {
   const mode = options.mode || 'dry-run';
@@ -358,7 +390,16 @@ export function buildClassroomLoadPlan(options = {}) {
 }
 
 export function validateClassroomLoadOptions(options = {}) {
-  if (options.help || options.mode === 'dry-run') return;
+  if (options.help) return;
+  if (options.mode === 'dry-run') {
+    // Dry-run has no measurements, so threshold gates cannot meaningfully evaluate.
+    // If thresholds are set, fail closed so CI cannot accidentally ship a permanent
+    // silent-green gate via --dry-run + --max-* flags. Adversarial review finding adv-001.
+    if (hasThresholdFlags(options)) {
+      throw new Error('Threshold flags (--max-*, --require-zero-signals) cannot be combined with --dry-run; dry-run has no measurements and would always pass. Use --local-fixture or --production.');
+    }
+    return;
+  }
   if (!options.origin) {
     throw new Error(`${options.mode} load requires --origin.`);
   }
@@ -375,6 +416,17 @@ export function validateClassroomLoadOptions(options = {}) {
     const hasAuth = hasExplicitAuthConfig(options);
     if (!options.confirmProductionLoad || !hasAuth) {
       throw new Error('production load requires --confirm-production-load and explicit auth configuration (--cookie, --bearer, --header, or --demo-sessions).');
+    }
+    // H4 enforcement per docs/hardening/p1-baseline.md and docs/operations/capacity.md.
+    // Classroom-scale production loads (>=20 learners or >=20 bootstrap burst) must carry
+    // the second confirmation, otherwise the documented safety rail is a no-op.
+    // Adversarial review finding adv-003.
+    const highLoad = Number(options.learners) >= HIGH_PRODUCTION_LOAD_THRESHOLD
+      || Number(options.bootstrapBurst) >= HIGH_PRODUCTION_LOAD_THRESHOLD;
+    if (highLoad && !options.confirmHighProductionLoad) {
+      throw new Error(
+        `production load at classroom scale (learners >= ${HIGH_PRODUCTION_LOAD_THRESHOLD} or bootstrap-burst >= ${HIGH_PRODUCTION_LOAD_THRESHOLD}) requires --confirm-high-production-load in addition to --confirm-production-load.`,
+      );
     }
   }
 }
@@ -437,6 +489,14 @@ function highestP95(summary, endpointList) {
   return peak;
 }
 
+function gatedEndpointsHaveMeasurements(summary, endpointList) {
+  for (const key of endpointList) {
+    const metrics = summary.endpoints?.[key];
+    if (metrics && Number(metrics.count) > 0) return true;
+  }
+  return false;
+}
+
 function maxResponseBytesAcross(summary) {
   let peak = 0;
   for (const metrics of Object.values(summary.endpoints || {})) {
@@ -473,26 +533,49 @@ export function evaluateCapacityThresholds(summary = {}, options = {}) {
   }
 
   if (options.maxBootstrapP95Ms != null) {
-    const observed = highestP95(summary, BOOTSTRAP_P95_ENDPOINTS);
-    if (observed > options.maxBootstrapP95Ms) {
+    if (!gatedEndpointsHaveMeasurements(summary, BOOTSTRAP_P95_ENDPOINTS)) {
+      // Adversarial review adv-006: fail closed when the gated endpoint set
+      // produced no measurements. Otherwise an unrelated bug (missed scenario,
+      // endpoint path drift) silently deactivates the gate.
       violations.push({
         threshold: 'max-bootstrap-p95-ms',
         limit: options.maxBootstrapP95Ms,
-        observed,
-        message: `Bootstrap P95 wall time ${observed} ms exceeds ${options.maxBootstrapP95Ms} ms.`,
+        observed: null,
+        gatedEndpoints: [...BOOTSTRAP_P95_ENDPOINTS],
+        message: `No measurements captured for bootstrap gated endpoints (${BOOTSTRAP_P95_ENDPOINTS.join(', ')}); threshold cannot be evaluated safely.`,
       });
+    } else {
+      const observed = highestP95(summary, BOOTSTRAP_P95_ENDPOINTS);
+      if (observed > options.maxBootstrapP95Ms) {
+        violations.push({
+          threshold: 'max-bootstrap-p95-ms',
+          limit: options.maxBootstrapP95Ms,
+          observed,
+          message: `Bootstrap P95 wall time ${observed} ms exceeds ${options.maxBootstrapP95Ms} ms.`,
+        });
+      }
     }
   }
 
   if (options.maxCommandP95Ms != null) {
-    const observed = highestP95(summary, COMMAND_P95_ENDPOINTS);
-    if (observed > options.maxCommandP95Ms) {
+    if (!gatedEndpointsHaveMeasurements(summary, COMMAND_P95_ENDPOINTS)) {
       violations.push({
         threshold: 'max-command-p95-ms',
         limit: options.maxCommandP95Ms,
-        observed,
-        message: `Subject-command P95 wall time ${observed} ms exceeds ${options.maxCommandP95Ms} ms.`,
+        observed: null,
+        gatedEndpoints: [...COMMAND_P95_ENDPOINTS],
+        message: `No measurements captured for command gated endpoints (${COMMAND_P95_ENDPOINTS.join(', ')}); threshold cannot be evaluated safely.`,
       });
+    } else {
+      const observed = highestP95(summary, COMMAND_P95_ENDPOINTS);
+      if (observed > options.maxCommandP95Ms) {
+        violations.push({
+          threshold: 'max-command-p95-ms',
+          limit: options.maxCommandP95Ms,
+          observed,
+          message: `Subject-command P95 wall time ${observed} ms exceeds ${options.maxCommandP95Ms} ms.`,
+        });
+      }
     }
   }
 

--- a/scripts/classroom-load-test.mjs
+++ b/scripts/classroom-load-test.mjs
@@ -235,7 +235,14 @@ export function parseClassroomLoadArgs(argv = process.argv.slice(2)) {
     headers: [],
     demoSessions: false,
     confirmProductionLoad: false,
+    confirmHighProductionLoad: false,
     includeMeasurements: true,
+    max5xx: null,
+    maxNetworkFailures: null,
+    maxBootstrapP95Ms: null,
+    maxCommandP95Ms: null,
+    maxResponseBytes: null,
+    requireZeroSignals: false,
     help: false,
   };
 
@@ -280,8 +287,27 @@ export function parseClassroomLoadArgs(argv = process.argv.slice(2)) {
       options.demoSessions = true;
     } else if (arg === '--confirm-production-load') {
       options.confirmProductionLoad = true;
+    } else if (arg === '--confirm-high-production-load') {
+      options.confirmHighProductionLoad = true;
     } else if (arg === '--summary-only') {
       options.includeMeasurements = false;
+    } else if (arg === '--max-5xx') {
+      options.max5xx = nonNegativeInteger(readOptionValue(argv, index, arg), arg);
+      index += 1;
+    } else if (arg === '--max-network-failures') {
+      options.maxNetworkFailures = nonNegativeInteger(readOptionValue(argv, index, arg), arg);
+      index += 1;
+    } else if (arg === '--max-bootstrap-p95-ms') {
+      options.maxBootstrapP95Ms = nonNegativeInteger(readOptionValue(argv, index, arg), arg);
+      index += 1;
+    } else if (arg === '--max-command-p95-ms') {
+      options.maxCommandP95Ms = nonNegativeInteger(readOptionValue(argv, index, arg), arg);
+      index += 1;
+    } else if (arg === '--max-response-bytes') {
+      options.maxResponseBytes = nonNegativeInteger(readOptionValue(argv, index, arg), arg);
+      index += 1;
+    } else if (arg === '--require-zero-signals') {
+      options.requireZeroSignals = true;
     } else {
       throw new Error(`Unknown option: ${arg}`);
     }
@@ -375,6 +401,138 @@ function signalFor(entry) {
   if (entry.status === 429) return 'rateLimited';
   if (!entry.status) return 'networkFailure';
   return null;
+}
+
+const OPERATIONAL_SIGNAL_KEYS = Object.freeze([
+  'exceededCpu',
+  'd1Overloaded',
+  'd1DailyLimit',
+  'rateLimited',
+  'networkFailure',
+  'server5xx',
+]);
+
+const BOOTSTRAP_P95_ENDPOINTS = Object.freeze([
+  'GET /api/bootstrap',
+]);
+
+const COMMAND_P95_ENDPOINTS = Object.freeze([
+  'POST /api/subjects/grammar/command',
+]);
+
+function collectObservedSignals(signals = {}) {
+  const observed = [];
+  for (const key of OPERATIONAL_SIGNAL_KEYS) {
+    if (Number(signals[key]) > 0) observed.push(key);
+  }
+  return observed;
+}
+
+function highestP95(summary, endpointList) {
+  let peak = 0;
+  for (const key of endpointList) {
+    const metrics = summary.endpoints?.[key];
+    if (metrics && Number(metrics.p95WallMs) > peak) peak = Number(metrics.p95WallMs);
+  }
+  return peak;
+}
+
+function maxResponseBytesAcross(summary) {
+  let peak = 0;
+  for (const metrics of Object.values(summary.endpoints || {})) {
+    if (metrics && Number(metrics.maxResponseBytes) > peak) peak = Number(metrics.maxResponseBytes);
+  }
+  return peak;
+}
+
+export function evaluateCapacityThresholds(summary = {}, options = {}) {
+  const violations = [];
+
+  if (options.max5xx != null) {
+    const observed = Number(summary.signals?.server5xx || 0);
+    if (observed > options.max5xx) {
+      violations.push({
+        threshold: 'max-5xx',
+        limit: options.max5xx,
+        observed,
+        message: `Observed ${observed} 5xx response(s); limit is ${options.max5xx}.`,
+      });
+    }
+  }
+
+  if (options.maxNetworkFailures != null) {
+    const observed = Number(summary.signals?.networkFailure || 0);
+    if (observed > options.maxNetworkFailures) {
+      violations.push({
+        threshold: 'max-network-failures',
+        limit: options.maxNetworkFailures,
+        observed,
+        message: `Observed ${observed} network failure(s); limit is ${options.maxNetworkFailures}.`,
+      });
+    }
+  }
+
+  if (options.maxBootstrapP95Ms != null) {
+    const observed = highestP95(summary, BOOTSTRAP_P95_ENDPOINTS);
+    if (observed > options.maxBootstrapP95Ms) {
+      violations.push({
+        threshold: 'max-bootstrap-p95-ms',
+        limit: options.maxBootstrapP95Ms,
+        observed,
+        message: `Bootstrap P95 wall time ${observed} ms exceeds ${options.maxBootstrapP95Ms} ms.`,
+      });
+    }
+  }
+
+  if (options.maxCommandP95Ms != null) {
+    const observed = highestP95(summary, COMMAND_P95_ENDPOINTS);
+    if (observed > options.maxCommandP95Ms) {
+      violations.push({
+        threshold: 'max-command-p95-ms',
+        limit: options.maxCommandP95Ms,
+        observed,
+        message: `Subject-command P95 wall time ${observed} ms exceeds ${options.maxCommandP95Ms} ms.`,
+      });
+    }
+  }
+
+  if (options.maxResponseBytes != null) {
+    const observed = maxResponseBytesAcross(summary);
+    if (observed > options.maxResponseBytes) {
+      violations.push({
+        threshold: 'max-response-bytes',
+        limit: options.maxResponseBytes,
+        observed,
+        message: `Response bytes ${observed} exceeded cap ${options.maxResponseBytes}.`,
+      });
+    }
+  }
+
+  if (options.requireZeroSignals) {
+    const signals = collectObservedSignals(summary.signals || {});
+    if (signals.length) {
+      violations.push({
+        threshold: 'require-zero-signals',
+        limit: 0,
+        observed: signals.length,
+        signals,
+        message: `Observed operational signal(s): ${signals.join(', ')}.`,
+      });
+    }
+  }
+
+  return violations;
+}
+
+export function hasThresholdFlags(options = {}) {
+  return (
+    options.max5xx != null
+    || options.maxNetworkFailures != null
+    || options.maxBootstrapP95Ms != null
+    || options.maxCommandP95Ms != null
+    || options.maxResponseBytes != null
+    || options.requireZeroSignals === true
+  );
 }
 
 export function summariseCapacityResults(measurements = [], plan = {}) {
@@ -603,6 +761,23 @@ async function runHumanPacedRounds(origin, options, contexts, plan) {
   return measurements;
 }
 
+function buildThresholdsBlock(options, summary) {
+  const configured = hasThresholdFlags(options);
+  const violations = configured ? evaluateCapacityThresholds(summary, options) : [];
+  return {
+    configured,
+    limits: {
+      max5xx: options.max5xx,
+      maxNetworkFailures: options.maxNetworkFailures,
+      maxBootstrapP95Ms: options.maxBootstrapP95Ms,
+      maxCommandP95Ms: options.maxCommandP95Ms,
+      maxResponseBytes: options.maxResponseBytes,
+      requireZeroSignals: options.requireZeroSignals,
+    },
+    violations,
+  };
+}
+
 export async function runClassroomLoadTest(argv = process.argv.slice(2)) {
   const options = parseClassroomLoadArgs(argv);
   if (options.help) {
@@ -611,11 +786,14 @@ export async function runClassroomLoadTest(argv = process.argv.slice(2)) {
   validateClassroomLoadOptions(options);
   const plan = buildClassroomLoadPlan(options);
   if (options.mode === 'dry-run') {
+    const summary = summariseCapacityResults([], plan);
+    const thresholds = buildThresholdsBlock(options, summary);
     return {
-      ok: true,
+      ok: thresholds.violations.length === 0,
       dryRun: true,
       plan,
-      summary: summariseCapacityResults([], plan),
+      summary,
+      thresholds,
     };
   }
 
@@ -629,14 +807,16 @@ export async function runClassroomLoadTest(argv = process.argv.slice(2)) {
   const summary = summariseCapacityResults(measurements, {
     ...plan,
   });
+  const thresholds = buildThresholdsBlock(options, summary);
 
   return {
-    ok: summary.ok,
+    ok: summary.ok && thresholds.violations.length === 0,
     dryRun: false,
     startedAt,
     finishedAt: new Date().toISOString(),
     plan,
     summary,
+    thresholds,
     ...(options.includeMeasurements ? { measurements } : {}),
   };
 }
@@ -646,23 +826,33 @@ export function usage() {
     'Usage: node ./scripts/classroom-load-test.mjs [options]',
     '',
     'Modes:',
-    '  --dry-run                  Print the planned capacity run without network requests (default)',
-    '  --local-fixture            Run against a local/loopback origin using demo sessions',
-    '  --production               Run against a production or preview origin; requires explicit confirmation and auth',
+    '  --dry-run                         Print the planned capacity run without network requests (default)',
+    '  --local-fixture                   Run against a local/loopback origin using demo sessions',
+    '  --production                      Run against a production or preview origin; requires explicit confirmation and auth',
     '',
     'Options:',
-    '  --origin <url>             Target origin for local-fixture or production runs',
-    '  --learners <number>        Virtual learner count, default 3',
-    '  --bootstrap-burst <number> Concurrent cold bootstrap requests, default 6',
-    '  --rounds <number>          Human-paced Grammar rounds per learner, default 1',
-    '  --pacing-ms <number>       Delay between learner command groups, default 0',
-    '  --timeout-ms <number>      Per-request timeout, default 15000',
-    '  --cookie <cookie>          Cookie header for an existing authenticated run',
-    '  --bearer <token>           Authorization bearer token',
-    '  --header "name: value"     Extra request header, repeatable',
-    '  --demo-sessions            Create one isolated demo session per virtual learner',
-    '  --confirm-production-load  Required before --production sends requests',
-    '  --summary-only             Omit per-request measurements from JSON output',
+    '  --origin <url>                    Target origin for local-fixture or production runs',
+    '  --learners <number>               Virtual learner count, default 3',
+    '  --bootstrap-burst <number>        Concurrent cold bootstrap requests, default 6',
+    '  --rounds <number>                 Human-paced Grammar rounds per learner, default 1',
+    '  --pacing-ms <number>              Delay between learner command groups, default 0',
+    '  --timeout-ms <number>             Per-request timeout, default 15000',
+    '  --cookie <cookie>                 Cookie header for an existing authenticated run',
+    '  --bearer <token>                  Authorization bearer token',
+    '  --header "name: value"            Extra request header, repeatable',
+    '  --demo-sessions                   Create one isolated demo session per virtual learner',
+    '  --confirm-production-load         Required before --production sends requests',
+    '  --confirm-high-production-load    Additional acknowledgement for larger production load shapes',
+    '  --summary-only                    Omit per-request measurements from JSON output',
+    '',
+    'Threshold gates (release-gate mode; non-zero exit on any violation):',
+    '  --max-5xx <count>                 Maximum tolerated HTTP 5xx responses',
+    '  --max-network-failures <count>    Maximum tolerated network failures',
+    '  --max-bootstrap-p95-ms <ms>       Maximum tolerated /api/bootstrap P95 wall time',
+    '  --max-command-p95-ms <ms>         Maximum tolerated subject-command P95 wall time',
+    '  --max-response-bytes <bytes>      Maximum tolerated response bytes across endpoints',
+    '  --require-zero-signals            Fail on any exceededCpu / d1Overloaded / d1DailyLimit /',
+    '                                    rateLimited / networkFailure / server5xx signal',
   ].join('\n');
 }
 

--- a/scripts/probe-production-bootstrap.mjs
+++ b/scripts/probe-production-bootstrap.mjs
@@ -142,6 +142,7 @@ export function analyseBootstrapPayload(payload, {
   forbiddenTokens = [],
 } = {}) {
   const failures = [];
+  const thresholdViolations = [];
   const warnings = [];
   const practiceSessionCount = arrayCount(payload, 'practiceSessions');
   const eventCount = arrayCount(payload, 'eventLog');
@@ -151,6 +152,7 @@ export function analyseBootstrapPayload(payload, {
     return {
       ok: false,
       failures: ['Response body is not a JSON object.'],
+      thresholdViolations: [],
       warnings,
       responseBytes: responseSize,
       counts: {
@@ -165,13 +167,34 @@ export function analyseBootstrapPayload(payload, {
     failures.push('Bootstrap payload does not report ok=true.');
   }
   if (responseSize > maxBytes) {
-    failures.push(`Bootstrap response is ${responseSize} bytes, above ${maxBytes}.`);
+    const message = `Bootstrap response is ${responseSize} bytes, above ${maxBytes}.`;
+    failures.push(message);
+    thresholdViolations.push({
+      threshold: 'max-bytes',
+      limit: maxBytes,
+      observed: responseSize,
+      message,
+    });
   }
   if (maxSessions != null && practiceSessionCount > maxSessions) {
-    failures.push(`Bootstrap returned ${practiceSessionCount} practice sessions, above ${maxSessions}.`);
+    const message = `Bootstrap returned ${practiceSessionCount} practice sessions, above ${maxSessions}.`;
+    failures.push(message);
+    thresholdViolations.push({
+      threshold: 'max-sessions',
+      limit: maxSessions,
+      observed: practiceSessionCount,
+      message,
+    });
   }
   if (maxEvents != null && eventCount > maxEvents) {
-    failures.push(`Bootstrap returned ${eventCount} events, above ${maxEvents}.`);
+    const message = `Bootstrap returned ${eventCount} events, above ${maxEvents}.`;
+    failures.push(message);
+    thresholdViolations.push({
+      threshold: 'max-events',
+      limit: maxEvents,
+      observed: eventCount,
+      message,
+    });
   }
 
   const capacity = payload.bootstrapCapacity || null;
@@ -211,6 +234,7 @@ export function analyseBootstrapPayload(payload, {
   return {
     ok: failures.length === 0,
     failures,
+    thresholdViolations,
     warnings,
     responseBytes: responseSize,
     counts: {
@@ -270,10 +294,12 @@ export function usage() {
     '  --cookie <cookie>          Cookie header value from a logged-in browser session',
     '  --bearer <token>           Bearer token for Authorization',
     '  --header "name: value"     Extra request header, repeatable',
-    '  --max-bytes <number>       Maximum allowed response bytes',
+    '  --forbidden-token <text>   Token that must not appear in the JSON payload, repeatable',
+    '',
+    'Hard threshold gates (non-zero exit on violation):',
+    '  --max-bytes <number>       Maximum allowed response bytes (default 600000)',
     '  --max-sessions <number>    Maximum allowed practiceSessions length',
     '  --max-events <number>      Maximum allowed eventLog length',
-    '  --forbidden-token <text>   Token that must not appear in the JSON payload, repeatable',
   ].join('\n');
 }
 

--- a/scripts/probe-production-bootstrap.mjs
+++ b/scripts/probe-production-bootstrap.mjs
@@ -41,32 +41,52 @@ export function parseProbeArgs(argv = process.argv.slice(2)) {
     help: false,
   };
 
+  // Adversarial residual adv-residual-1: reject duplicate non-cumulative
+  // flags so a release-gate wrapper cannot be silently weakened by a
+  // later user-supplied threshold. Mirrors the classroom parser's
+  // assignOnce hardening.
+  const assignedFlags = new Set();
+  const assignOnce = (flag) => {
+    if (assignedFlags.has(flag)) {
+      throw new Error(`${flag} specified more than once; refusing to let later value silently override the earlier one.`);
+    }
+    assignedFlags.add(flag);
+  };
+
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === '--help' || arg === '-h') {
       options.help = true;
     } else if (arg === '--url') {
+      assignOnce(arg);
       options.url = readOptionValue(argv, index, arg);
       index += 1;
     } else if (arg === '--cookie') {
+      assignOnce(arg);
       options.cookie = readOptionValue(argv, index, arg);
       index += 1;
     } else if (arg === '--bearer') {
+      assignOnce(arg);
       options.bearer = readOptionValue(argv, index, arg);
       index += 1;
     } else if (arg === '--header') {
+      // Cumulative by design (repeatable per docs).
       options.headers.push(readOptionValue(argv, index, arg));
       index += 1;
     } else if (arg === '--max-bytes') {
+      assignOnce(arg);
       options.maxBytes = toPositiveInteger(readOptionValue(argv, index, arg), arg);
       index += 1;
     } else if (arg === '--max-sessions') {
+      assignOnce(arg);
       options.maxSessions = toPositiveInteger(readOptionValue(argv, index, arg), arg);
       index += 1;
     } else if (arg === '--max-events') {
+      assignOnce(arg);
       options.maxEvents = toPositiveInteger(readOptionValue(argv, index, arg), arg);
       index += 1;
     } else if (arg === '--forbidden-token') {
+      // Cumulative by design (repeatable per docs).
       options.forbiddenTokens.push(readOptionValue(argv, index, arg));
       index += 1;
     } else {

--- a/scripts/probe-production-bootstrap.mjs
+++ b/scripts/probe-production-bootstrap.mjs
@@ -148,11 +148,30 @@ export function analyseBootstrapPayload(payload, {
   const eventCount = arrayCount(payload, 'eventLog');
   const responseSize = Number(responseBytes) || 0;
 
+  // Adversarial review adv-004: evaluate the responseBytes gate before the
+  // early-return. A non-JSON body can still carry oversize bytes, and CI
+  // that filters on thresholdViolations needs the gate to fire regardless
+  // of parse success.
+  const evaluateByteGate = () => {
+    if (responseSize > maxBytes) {
+      const message = `Bootstrap response is ${responseSize} bytes, above ${maxBytes}.`;
+      failures.push(message);
+      thresholdViolations.push({
+        threshold: 'max-bytes',
+        limit: maxBytes,
+        observed: responseSize,
+        message,
+      });
+    }
+  };
+
   if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    evaluateByteGate();
+    failures.unshift('Response body is not a JSON object.');
     return {
       ok: false,
-      failures: ['Response body is not a JSON object.'],
-      thresholdViolations: [],
+      failures,
+      thresholdViolations,
       warnings,
       responseBytes: responseSize,
       counts: {
@@ -166,16 +185,7 @@ export function analyseBootstrapPayload(payload, {
   if (payload.ok !== true) {
     failures.push('Bootstrap payload does not report ok=true.');
   }
-  if (responseSize > maxBytes) {
-    const message = `Bootstrap response is ${responseSize} bytes, above ${maxBytes}.`;
-    failures.push(message);
-    thresholdViolations.push({
-      threshold: 'max-bytes',
-      limit: maxBytes,
-      observed: responseSize,
-      message,
-    });
-  }
+  evaluateByteGate();
   if (maxSessions != null && practiceSessionCount > maxSessions) {
     const message = `Bootstrap returned ${practiceSessionCount} practice sessions, above ${maxSessions}.`;
     failures.push(message);
@@ -277,11 +287,15 @@ export async function probeProductionBootstrap(options = {}) {
     analysis.failures.unshift(`Bootstrap response is not valid JSON: ${parseError.message}`);
   }
 
+  // Correctness residual C-R1: put the spread before the explicit `ok`
+  // so that a valid-looking JSON body with HTTP 5xx (which unshifts a
+  // failure above) cannot leak `analysis.ok === true` into the outer
+  // return value.
   return {
+    ...analysis,
     ok: analysis.failures.length === 0,
     url: url.toString(),
     status: response.status,
-    ...analysis,
   };
 }
 

--- a/tests/capacity-scripts.test.js
+++ b/tests/capacity-scripts.test.js
@@ -57,6 +57,11 @@ test('classroom load script dry-run reports the planned scenarios without networ
     assert.equal(report.plan.scenarios[1].rounds, 2);
     assert.equal(report.plan.expectedRequests, 36);
     assert.equal(report.summary.totalRequests, 0);
+    // Back-compat: absent threshold flags do not change the exit contract;
+    // the block is reported but has zero configured limits and zero
+    // violations so a script running with the old invocation keeps exiting 0.
+    assert.equal(report.thresholds.configured, false);
+    assert.deepEqual(report.thresholds.violations, []);
   } finally {
     globalThis.fetch = previousFetch;
   }

--- a/tests/capacity-thresholds.test.js
+++ b/tests/capacity-thresholds.test.js
@@ -6,6 +6,7 @@ import {
   evaluateCapacityThresholds,
   runClassroomLoadTest,
   summariseCapacityResults,
+  validateClassroomLoadOptions,
 } from '../scripts/classroom-load-test.mjs';
 import {
   analyseBootstrapPayload,
@@ -541,8 +542,34 @@ test('classroom allows <20 learner production runs without --confirm-high-produc
     '--rounds', '1',
   ]);
   assert.equal(options.confirmHighProductionLoad, false);
-  // Importing validate directly to avoid actually firing network requests.
-  // Should not throw for a 10-learner production run.
+  // Validate must pass for a 10-learner production run without the flag.
+  // C-T1 testing-gap: previously only parsed without asserting validation outcome.
+  assert.doesNotThrow(() => validateClassroomLoadOptions(options));
+});
+
+test('classroom production validation fires at exactly 20 learners (adv-003 boundary)', () => {
+  // Boundary pinned: >= 20 enforces the flag, < 20 does not.
+  const options20 = parseClassroomLoadArgs([
+    '--production',
+    '--origin', 'https://ks2.eugnel.uk',
+    '--confirm-production-load',
+    '--cookie', 'ks2_session=real',
+    '--learners', '20',
+    '--bootstrap-burst', '1',
+    '--rounds', '1',
+  ]);
+  assert.throws(() => validateClassroomLoadOptions(options20), /--confirm-high-production-load/);
+
+  const options19 = parseClassroomLoadArgs([
+    '--production',
+    '--origin', 'https://ks2.eugnel.uk',
+    '--confirm-production-load',
+    '--cookie', 'ks2_session=real',
+    '--learners', '19',
+    '--bootstrap-burst', '19',
+    '--rounds', '1',
+  ]);
+  assert.doesNotThrow(() => validateClassroomLoadOptions(options19));
 });
 
 test('P95 bootstrap gate fails closed when no measurements captured (adv-006)', () => {
@@ -609,4 +636,29 @@ test('integer parser rejects missing value for threshold flag (C-04)', () => {
     () => parseClassroomLoadArgs(['--dry-run', '--max-5xx']),
     /--max-5xx requires a value/,
   );
+});
+
+test('probe parser rejects duplicate --max-bytes (adv-residual-1)', () => {
+  assert.throws(
+    () => parseProbeArgs(['--max-bytes', '500000', '--max-bytes', '1000000']),
+    /--max-bytes specified more than once/,
+  );
+});
+
+test('probe parser rejects duplicate --max-sessions', () => {
+  assert.throws(
+    () => parseProbeArgs(['--max-sessions', '10', '--max-sessions', '1000']),
+    /--max-sessions specified more than once/,
+  );
+});
+
+test('probe parser allows --header and --forbidden-token repeated (cumulative)', () => {
+  const options = parseProbeArgs([
+    '--header', 'x-a: 1',
+    '--header', 'x-b: 2',
+    '--forbidden-token', 'alpha',
+    '--forbidden-token', 'beta',
+  ]);
+  assert.deepEqual(options.headers, ['x-a: 1', 'x-b: 2']);
+  assert.deepEqual(options.forbiddenTokens, ['alpha', 'beta']);
 });

--- a/tests/capacity-thresholds.test.js
+++ b/tests/capacity-thresholds.test.js
@@ -403,4 +403,210 @@ test('probe bootstrap parses --max-sessions and --max-events as hard gates', () 
   assert.equal(analysis.ok, false);
   assert.ok(analysis.failures.some((entry) => entry.includes('practice sessions')));
   assert.ok(analysis.failures.some((entry) => entry.includes('events')));
+  // Adversarial review C-02 / testing-gap: pin the structured thresholdViolations contents.
+  const triggered = analysis.thresholdViolations.map((entry) => entry.threshold).sort();
+  assert.deepEqual(triggered, ['max-events', 'max-sessions']);
+  const byThreshold = Object.fromEntries(analysis.thresholdViolations.map((entry) => [entry.threshold, entry]));
+  assert.equal(byThreshold['max-sessions'].limit, 12);
+  assert.equal(byThreshold['max-sessions'].observed, 20);
+  assert.equal(byThreshold['max-events'].limit, 100);
+  assert.equal(byThreshold['max-events'].observed, 150);
+});
+
+test('probe bootstrap max-bytes violation emits structured thresholdViolations entry', () => {
+  const payload = {
+    ok: true,
+    bootstrapCapacity: {
+      mode: 'public-bounded',
+      practiceSessions: { returned: 0, bounded: true },
+      eventLog: { returned: 0, bounded: true },
+    },
+    practiceSessions: [],
+    eventLog: [],
+  };
+  const analysis = analyseBootstrapPayload(payload, {
+    responseBytes: 5_000,
+    maxBytes: 1,
+  });
+  assert.equal(analysis.thresholdViolations.length, 1);
+  assert.equal(analysis.thresholdViolations[0].threshold, 'max-bytes');
+  assert.equal(analysis.thresholdViolations[0].limit, 1);
+  assert.equal(analysis.thresholdViolations[0].observed, 5_000);
+});
+
+test('probe bootstrap populates thresholdViolations even when body fails to parse (adv-004)', () => {
+  // Early-return path for non-JSON-object body must still fire the byte gate.
+  const analysis = analyseBootstrapPayload(null, {
+    responseBytes: 2_000_000,
+    maxBytes: 600_000,
+  });
+  assert.equal(analysis.ok, false);
+  assert.ok(analysis.failures.some((entry) => entry.includes('Response body is not a JSON object')));
+  assert.equal(analysis.thresholdViolations.length, 1);
+  assert.equal(analysis.thresholdViolations[0].threshold, 'max-bytes');
+  assert.equal(analysis.thresholdViolations[0].limit, 600_000);
+  assert.equal(analysis.thresholdViolations[0].observed, 2_000_000);
+});
+
+test('classroom dry-run with threshold flags is rejected (adv-001)', async () => {
+  await assert.rejects(
+    runClassroomLoadTest(['--dry-run', '--max-5xx', '0']),
+    /Threshold flags .* cannot be combined with --dry-run/,
+  );
+});
+
+test('classroom dry-run with --require-zero-signals is rejected (adv-001)', async () => {
+  await assert.rejects(
+    runClassroomLoadTest(['--dry-run', '--require-zero-signals']),
+    /Threshold flags .* cannot be combined with --dry-run/,
+  );
+});
+
+test('classroom rejects duplicate --max-5xx flag (adv-002)', () => {
+  assert.throws(
+    () => parseClassroomLoadArgs(['--dry-run', '--max-5xx', '0', '--max-5xx', '500']),
+    /--max-5xx specified more than once/,
+  );
+});
+
+test('classroom rejects duplicate --learners flag', () => {
+  assert.throws(
+    () => parseClassroomLoadArgs(['--dry-run', '--learners', '3', '--learners', '30']),
+    /--learners specified more than once/,
+  );
+});
+
+test('classroom rejects conflicting --production --dry-run (adv-005)', () => {
+  assert.throws(
+    () => parseClassroomLoadArgs(['--production', '--dry-run']),
+    /Conflicting mode flags: --production and --dry-run/,
+  );
+});
+
+test('classroom rejects conflicting --dry-run --local-fixture (adv-005)', () => {
+  assert.throws(
+    () => parseClassroomLoadArgs(['--dry-run', '--local-fixture']),
+    /Conflicting mode flags: --dry-run and --local-fixture/,
+  );
+});
+
+test('classroom allows --header repeated (cumulative by design)', () => {
+  const options = parseClassroomLoadArgs([
+    '--dry-run',
+    '--header', 'x-custom: a',
+    '--header', 'x-custom2: b',
+  ]);
+  assert.deepEqual(options.headers, ['x-custom: a', 'x-custom2: b']);
+});
+
+test('classroom validates confirm-high-production-load for 30 learners (adv-003)', async () => {
+  await assert.rejects(
+    runClassroomLoadTest([
+      '--production',
+      '--origin', 'https://ks2.eugnel.uk',
+      '--confirm-production-load',
+      '--cookie', 'ks2_session=real',
+      '--learners', '30',
+      '--bootstrap-burst', '1',
+      '--rounds', '1',
+    ]),
+    /--confirm-high-production-load/,
+  );
+});
+
+test('classroom validates confirm-high-production-load for 30 bootstrap burst (adv-003)', async () => {
+  await assert.rejects(
+    runClassroomLoadTest([
+      '--production',
+      '--origin', 'https://ks2.eugnel.uk',
+      '--confirm-production-load',
+      '--cookie', 'ks2_session=real',
+      '--learners', '1',
+      '--bootstrap-burst', '30',
+      '--rounds', '1',
+    ]),
+    /--confirm-high-production-load/,
+  );
+});
+
+test('classroom allows <20 learner production runs without --confirm-high-production-load (adv-003 lower bound)', () => {
+  // Must parse + validate cleanly; actual run is not invoked here.
+  const options = parseClassroomLoadArgs([
+    '--production',
+    '--origin', 'https://ks2.eugnel.uk',
+    '--confirm-production-load',
+    '--cookie', 'ks2_session=real',
+    '--learners', '10',
+    '--bootstrap-burst', '10',
+    '--rounds', '1',
+  ]);
+  assert.equal(options.confirmHighProductionLoad, false);
+  // Importing validate directly to avoid actually firing network requests.
+  // Should not throw for a 10-learner production run.
+});
+
+test('P95 bootstrap gate fails closed when no measurements captured (adv-006)', () => {
+  const summary = summariseCapacityResults([
+    // Only command measurements; no bootstrap endpoint key.
+    {
+      scenario: 'human-paced-grammar-round',
+      method: 'POST',
+      endpoint: '/api/subjects/grammar/command',
+      status: 200,
+      ok: true,
+      wallMs: 100,
+      responseBytes: 500,
+    },
+  ], { expectedRequests: 1 });
+  const violations = evaluateCapacityThresholds(summary, { maxBootstrapP95Ms: 1000 });
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].threshold, 'max-bootstrap-p95-ms');
+  assert.equal(violations[0].observed, null);
+  assert.ok(violations[0].message.includes('No measurements'));
+});
+
+test('P95 command gate fails closed when no measurements captured (adv-006)', () => {
+  const summary = summariseCapacityResults([
+    // Only bootstrap measurements; no command endpoint key.
+    {
+      scenario: 'cold-bootstrap-burst',
+      method: 'GET',
+      endpoint: '/api/bootstrap',
+      status: 200,
+      ok: true,
+      wallMs: 100,
+      responseBytes: 500,
+    },
+  ], { expectedRequests: 1 });
+  const violations = evaluateCapacityThresholds(summary, { maxCommandP95Ms: 750 });
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].threshold, 'max-command-p95-ms');
+  assert.equal(violations[0].observed, null);
+});
+
+test('integer parser rejects non-integer values for threshold flags (C-04)', () => {
+  for (const flag of ['--max-5xx', '--max-network-failures', '--max-bootstrap-p95-ms', '--max-command-p95-ms', '--max-response-bytes']) {
+    assert.throws(
+      () => parseClassroomLoadArgs(['--dry-run', flag, '1.5']),
+      /must be a non-negative integer/,
+      `${flag} should reject 1.5`,
+    );
+    assert.throws(
+      () => parseClassroomLoadArgs(['--dry-run', flag, '-1']),
+      /must be a non-negative integer/,
+      `${flag} should reject -1`,
+    );
+    assert.throws(
+      () => parseClassroomLoadArgs(['--dry-run', flag, 'abc']),
+      /must be a non-negative integer/,
+      `${flag} should reject abc`,
+    );
+  }
+});
+
+test('integer parser rejects missing value for threshold flag (C-04)', () => {
+  assert.throws(
+    () => parseClassroomLoadArgs(['--dry-run', '--max-5xx']),
+    /--max-5xx requires a value/,
+  );
 });

--- a/tests/capacity-thresholds.test.js
+++ b/tests/capacity-thresholds.test.js
@@ -1,0 +1,406 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  parseClassroomLoadArgs,
+  evaluateCapacityThresholds,
+  runClassroomLoadTest,
+  summariseCapacityResults,
+} from '../scripts/classroom-load-test.mjs';
+import {
+  analyseBootstrapPayload,
+  parseProbeArgs,
+} from '../scripts/probe-production-bootstrap.mjs';
+import { createGrammarQuestion } from '../worker/src/subjects/grammar/content.js';
+
+function jsonResponse(payload, init = {}) {
+  const status = Number(init.status) || 200;
+  const headers = Object.fromEntries(
+    Object.entries({
+      'content-type': 'application/json',
+      ...(init.headers || {}),
+    }).map(([key, value]) => [key.toLowerCase(), value]),
+  );
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get(name) {
+        return headers[String(name).toLowerCase()] || null;
+      },
+      getSetCookie() {
+        const value = headers['set-cookie'];
+        if (Array.isArray(value)) return value;
+        return value ? [value] : [];
+      },
+    },
+    async text() {
+      return JSON.stringify(payload);
+    },
+  };
+}
+
+test('classroom threshold flags parse with defaults disabled (back-compat)', () => {
+  const options = parseClassroomLoadArgs(['--dry-run']);
+  assert.equal(options.max5xx, null);
+  assert.equal(options.maxNetworkFailures, null);
+  assert.equal(options.maxBootstrapP95Ms, null);
+  assert.equal(options.maxCommandP95Ms, null);
+  assert.equal(options.maxResponseBytes, null);
+  assert.equal(options.requireZeroSignals, false);
+  assert.equal(options.confirmHighProductionLoad, false);
+});
+
+test('classroom threshold flags parse numeric and boolean flag values', () => {
+  const options = parseClassroomLoadArgs([
+    '--dry-run',
+    '--max-5xx', '0',
+    '--max-network-failures', '0',
+    '--max-bootstrap-p95-ms', '1000',
+    '--max-command-p95-ms', '750',
+    '--max-response-bytes', '600000',
+    '--require-zero-signals',
+    '--confirm-high-production-load',
+  ]);
+  assert.equal(options.max5xx, 0);
+  assert.equal(options.maxNetworkFailures, 0);
+  assert.equal(options.maxBootstrapP95Ms, 1000);
+  assert.equal(options.maxCommandP95Ms, 750);
+  assert.equal(options.maxResponseBytes, 600_000);
+  assert.equal(options.requireZeroSignals, true);
+  assert.equal(options.confirmHighProductionLoad, true);
+});
+
+test('evaluateCapacityThresholds returns empty violations when no flags set', () => {
+  const summary = summariseCapacityResults([
+    {
+      scenario: 'cold-bootstrap-burst',
+      method: 'GET',
+      endpoint: '/api/bootstrap',
+      status: 500,
+      ok: false,
+      wallMs: 9_000,
+      responseBytes: 900_000,
+      code: 'exceeded_cpu',
+      message: 'CPU limit',
+    },
+  ], { expectedRequests: 1 });
+  const violations = evaluateCapacityThresholds(summary, {});
+  assert.deepEqual(violations, []);
+});
+
+test('evaluateCapacityThresholds flags --max-5xx violations', () => {
+  const summary = summariseCapacityResults([
+    {
+      scenario: 'cold-bootstrap-burst',
+      method: 'GET',
+      endpoint: '/api/bootstrap',
+      status: 500,
+      ok: false,
+      wallMs: 20,
+      responseBytes: 100,
+    },
+    {
+      scenario: 'cold-bootstrap-burst',
+      method: 'GET',
+      endpoint: '/api/bootstrap',
+      status: 503,
+      ok: false,
+      wallMs: 20,
+      responseBytes: 100,
+    },
+  ], { expectedRequests: 2 });
+  const violations = evaluateCapacityThresholds(summary, { max5xx: 0 });
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].threshold, 'max-5xx');
+  assert.equal(violations[0].limit, 0);
+  assert.equal(violations[0].observed, 2);
+});
+
+test('evaluateCapacityThresholds flags --max-network-failures violations', () => {
+  const summary = summariseCapacityResults([
+    {
+      scenario: 'cold-bootstrap-burst',
+      method: 'GET',
+      endpoint: '/api/bootstrap',
+      status: 0,
+      ok: false,
+      wallMs: 20,
+      responseBytes: 0,
+    },
+  ], { expectedRequests: 1 });
+  const violations = evaluateCapacityThresholds(summary, { maxNetworkFailures: 0 });
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].threshold, 'max-network-failures');
+});
+
+test('evaluateCapacityThresholds flags bootstrap P95 above limit', () => {
+  const summary = summariseCapacityResults([
+    {
+      scenario: 'cold-bootstrap-burst',
+      method: 'GET',
+      endpoint: '/api/bootstrap',
+      status: 200,
+      ok: true,
+      wallMs: 2000,
+      responseBytes: 100,
+    },
+    {
+      scenario: 'cold-bootstrap-burst',
+      method: 'GET',
+      endpoint: '/api/bootstrap',
+      status: 200,
+      ok: true,
+      wallMs: 2500,
+      responseBytes: 100,
+    },
+  ], { expectedRequests: 2 });
+  const violations = evaluateCapacityThresholds(summary, { maxBootstrapP95Ms: 1000 });
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].threshold, 'max-bootstrap-p95-ms');
+  assert.ok(violations[0].observed >= 2000);
+});
+
+test('evaluateCapacityThresholds flags command P95 above limit', () => {
+  const summary = summariseCapacityResults([
+    {
+      scenario: 'human-paced-grammar-round',
+      method: 'POST',
+      endpoint: '/api/subjects/grammar/command',
+      status: 200,
+      ok: true,
+      wallMs: 1500,
+      responseBytes: 100,
+    },
+  ], { expectedRequests: 1 });
+  const violations = evaluateCapacityThresholds(summary, { maxCommandP95Ms: 750 });
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].threshold, 'max-command-p95-ms');
+});
+
+test('evaluateCapacityThresholds flags max-response-bytes violations', () => {
+  const summary = summariseCapacityResults([
+    {
+      scenario: 'cold-bootstrap-burst',
+      method: 'GET',
+      endpoint: '/api/bootstrap',
+      status: 200,
+      ok: true,
+      wallMs: 40,
+      responseBytes: 900_000,
+    },
+  ], { expectedRequests: 1 });
+  const violations = evaluateCapacityThresholds(summary, { maxResponseBytes: 600_000 });
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].threshold, 'max-response-bytes');
+  assert.equal(violations[0].observed, 900_000);
+});
+
+test('evaluateCapacityThresholds flags --require-zero-signals with any operational signal', () => {
+  const summary = summariseCapacityResults([
+    {
+      scenario: 'cold-bootstrap-burst',
+      method: 'GET',
+      endpoint: '/api/bootstrap',
+      status: 503,
+      ok: false,
+      wallMs: 40,
+      responseBytes: 200,
+      code: 'exceeded_cpu',
+      message: 'Worker CPU limit',
+    },
+  ], { expectedRequests: 1 });
+  const violations = evaluateCapacityThresholds(summary, { requireZeroSignals: true });
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].threshold, 'require-zero-signals');
+  assert.ok(Array.isArray(violations[0].signals));
+  assert.ok(violations[0].signals.includes('exceededCpu'));
+});
+
+test('classroom load dry-run with thresholds absent exits ok (back-compat)', async () => {
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    throw new Error('dry-run should not fetch');
+  };
+  try {
+    const report = await runClassroomLoadTest([
+      '--dry-run',
+      '--learners', '3',
+      '--bootstrap-burst', '3',
+      '--rounds', '1',
+    ]);
+    assert.equal(report.ok, true);
+    assert.equal(report.dryRun, true);
+    assert.equal(report.thresholds?.configured || false, false);
+    assert.equal(report.thresholds?.violations?.length || 0, 0);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('classroom load fails when --max-5xx is violated by a 500 response', async () => {
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = async () => jsonResponse({ ok: false, code: 'server_error' }, { status: 500 });
+  try {
+    const report = await runClassroomLoadTest([
+      '--production',
+      '--origin', 'https://ks2.eugnel.uk',
+      '--confirm-production-load',
+      '--cookie', 'ks2_session=real',
+      '--learners', '1',
+      '--bootstrap-burst', '1',
+      '--rounds', '1',
+      '--max-5xx', '0',
+    ]);
+    assert.equal(report.ok, false);
+    assert.equal(report.thresholds.configured, true);
+    const triggered = report.thresholds.violations.map((entry) => entry.threshold);
+    assert.ok(triggered.includes('max-5xx'));
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('classroom load fails when --require-zero-signals observes an operational signal', async () => {
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = async () => jsonResponse({
+    ok: false,
+    code: 'exceeded_cpu',
+    message: 'Worker CPU limit exceeded.',
+  }, { status: 503 });
+  try {
+    const report = await runClassroomLoadTest([
+      '--production',
+      '--origin', 'https://ks2.eugnel.uk',
+      '--confirm-production-load',
+      '--cookie', 'ks2_session=real',
+      '--learners', '1',
+      '--bootstrap-burst', '1',
+      '--rounds', '1',
+      '--require-zero-signals',
+    ]);
+    assert.equal(report.ok, false);
+    const triggered = report.thresholds.violations.map((entry) => entry.threshold);
+    assert.ok(triggered.includes('require-zero-signals'));
+    // The triggered block names the signals but does not expose the raw
+    // failure body; the summary JSON stays bounded.
+    assert.equal(JSON.stringify(report).includes('<html'), false);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('classroom load with all thresholds satisfied exits ok and reports a clean threshold block', async () => {
+  const previousFetch = globalThis.fetch;
+  const grammarQuestion = createGrammarQuestion({
+    templateId: 'fronted_adverbial_choose',
+    seed: 1,
+  });
+  globalThis.fetch = async (url, init = {}) => {
+    const parsed = new URL(String(url));
+    if (parsed.pathname === '/api/bootstrap') {
+      return jsonResponse({
+        ok: true,
+        learners: {
+          selectedId: 'learner-real',
+          byId: { 'learner-real': { stateRevision: 0 } },
+          allIds: ['learner-real'],
+        },
+      });
+    }
+    if (parsed.pathname === '/api/subjects/grammar/command') {
+      const body = JSON.parse(init.body);
+      const subjectReadModel = body.command === 'start-session'
+        ? {
+            phase: 'session',
+            session: {
+              currentItem: {
+                templateId: 'fronted_adverbial_choose',
+                seed: 1,
+                inputSpec: grammarQuestion.inputSpec,
+              },
+            },
+          }
+        : { phase: body.command === 'submit-answer' ? 'feedback' : 'summary' };
+      return jsonResponse({
+        ok: true,
+        mutation: { appliedRevision: Number(body.expectedLearnerRevision || 0) + 1 },
+        subjectReadModel,
+      });
+    }
+    return jsonResponse({ ok: false }, { status: 404 });
+  };
+  try {
+    const report = await runClassroomLoadTest([
+      '--production',
+      '--origin', 'https://ks2.eugnel.uk',
+      '--confirm-production-load',
+      '--cookie', 'ks2_session=real',
+      '--learners', '1',
+      '--bootstrap-burst', '1',
+      '--rounds', '1',
+      '--max-5xx', '0',
+      '--max-network-failures', '0',
+      '--max-bootstrap-p95-ms', '60000',
+      '--max-command-p95-ms', '60000',
+      '--max-response-bytes', '600000',
+    ]);
+    assert.equal(report.ok, true);
+    assert.equal(report.thresholds.configured, true);
+    assert.deepEqual(report.thresholds.violations, []);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('probe bootstrap with --max-bytes 1 hard-fails and does not expose raw body', () => {
+  const payload = {
+    ok: true,
+    bootstrapCapacity: {
+      mode: 'public-bounded',
+      practiceSessions: { returned: 0, bounded: true },
+      eventLog: { returned: 0, bounded: true },
+    },
+    practiceSessions: [],
+    eventLog: [],
+  };
+  const analysis = analyseBootstrapPayload(payload, {
+    responseBytes: 5_000,
+    maxBytes: 1,
+  });
+  assert.equal(analysis.ok, false);
+  const failuresJoined = analysis.failures.join('\n');
+  assert.ok(failuresJoined.includes('5000'));
+  assert.ok(failuresJoined.includes('above 1'));
+});
+
+test('probe bootstrap parses --max-sessions and --max-events as hard gates', () => {
+  const options = parseProbeArgs([
+    '--max-bytes', '500000',
+    '--max-sessions', '12',
+    '--max-events', '100',
+  ]);
+  assert.equal(options.maxBytes, 500_000);
+  assert.equal(options.maxSessions, 12);
+  assert.equal(options.maxEvents, 100);
+
+  const payload = {
+    ok: true,
+    bootstrapCapacity: {
+      mode: 'public-bounded',
+      practiceSessions: { returned: 20, bounded: true },
+      eventLog: { returned: 150, bounded: true },
+    },
+    practiceSessions: new Array(20).fill({ id: 'session', subjectId: 'grammar', sessionState: null }),
+    eventLog: new Array(150).fill({ type: 'example' }),
+  };
+  const analysis = analyseBootstrapPayload(payload, {
+    responseBytes: 400,
+    maxBytes: 500_000,
+    maxSessions: 12,
+    maxEvents: 100,
+  });
+  assert.equal(analysis.ok, false);
+  assert.ok(analysis.failures.some((entry) => entry.includes('practice sessions')));
+  assert.ok(analysis.failures.some((entry) => entry.includes('events')));
+});


### PR DESCRIPTION
## Summary

Lands **U2** from `docs/plans/2026-04-25-003-fix-sys-hardening-p1-plan.md`. Converts `scripts/classroom-load-test.mjs` into a release gate and adds hard-fail thresholds to `scripts/probe-production-bootstrap.mjs`.

## Scope

- **`scripts/classroom-load-test.mjs`** — new flags: `--max-5xx`, `--max-network-failures`, `--max-bootstrap-p95-ms`, `--max-command-p95-ms`, `--max-response-bytes`, `--require-zero-signals`, `--confirm-high-production-load`. Non-zero exit on any violation. Every report now carries a `thresholds: { configured, limits, violations }` block.
- **`scripts/probe-production-bootstrap.mjs`** — `--max-bytes`, `--max-sessions`, `--max-events` now emit structured `thresholdViolations` alongside the legacy `failures` output so CI can key deterministically on violation category.
- **`package.json`** — new `capacity:classroom:release-gate` script with canonical thresholds baked in for CI.
- **`tests/capacity-thresholds.test.js`** — 15 new scenarios covering each flag's violation path, back-compat (no flags = no change), combined flags, and probe-bootstrap structured-violation shape.
- **`tests/capacity-scripts.test.js`** — back-compat assertion that `thresholds.configured=false` when no flags supplied.
- **`docs/operations/capacity.md`** — new "Threshold-Run Procedure" section.

## Baseline references

Addresses entries from `docs/hardening/p1-baseline.md` Server faults:
- **H1** — Post-merge production validation. Threshold-gated run shape is now available; dated production evidence lands in a follow-up capacity-evidence PR (U3).
- **H3** — Threshold-based load failure.
- **H4** — `--confirm-high-production-load` flag parsed and carried.

## Test plan

- [x] `node --test tests/capacity-thresholds.test.js tests/capacity-scripts.test.js tests/production-smoke-helpers.test.js` — 28 pass, 0 fail.
- [x] Back-compat dry-run: `npm run capacity:classroom -- --dry-run --learners 3 --bootstrap-burst 3 --rounds 1 --summary-only` exits 0 with `thresholds.configured=false`, `violations=[]`.
- [x] Threshold violation reported: probe-bootstrap `--max-bytes 1` against a large fixture yields `thresholdViolations=[{threshold:"max-bytes",limit:1,observed:…}]` and exits 1.
- [x] No pre-existing tests regressed.

## Plan-note

Probe-bootstrap gates were already hard-failing in the prior implementation (soft-warning phrasing in plan no longer matched tree reality). Kept existing hard-fail semantics; added structured `thresholdViolations` for deterministic CI consumption.

## Known unrelated failure on Windows

`tests/effect-config-defaults.test.js` fails with LF vs CRLF line-ending mismatch. Reproducible on clean `main` pre-U2; not introduced by this PR.