### PR TITLE
feat(spelling): U3 guardian selection, scheduler, and session wiring

### DIFF
--- a/shared/spelling/service.js
+++ b/shared/spelling/service.js
@@ -2,6 +2,10 @@ import { WORDS as DEFAULT_WORDS, WORD_BY_SLUG as DEFAULT_WORD_BY_SLUG } from '..
 import { createLegacySpellingEngine } from './legacy-engine.js';
 import {
   SPELLING_MASTERY_MILESTONES,
+  createSpellingGuardianMissionCompletedEvent,
+  createSpellingGuardianRecoveredEvent,
+  createSpellingGuardianRenewedEvent,
+  createSpellingGuardianWobbledEvent,
   createSpellingMasteryMilestoneEvent,
   createSpellingRetryClearedEvent,
   createSpellingSessionCompletedEvent,
@@ -12,11 +16,18 @@ import {
   normaliseTtsProvider,
 } from '../../src/subjects/spelling/tts-providers.js';
 import {
+  GUARDIAN_DEFAULT_ROUND_LENGTH,
+  GUARDIAN_INTERVALS,
+  GUARDIAN_MAX_REVIEW_LEVEL,
+  GUARDIAN_MAX_ROUND_LENGTH,
+  GUARDIAN_MIN_ROUND_LENGTH,
   cloneSerialisable,
   createInitialSpellingState,
   defaultLearningStatus,
   normaliseBoolean,
   normaliseFeedback,
+  normaliseGuardianMap,
+  normaliseGuardianRecord,
   normaliseMode,
   normaliseNonNegativeInteger,
   normaliseOptionalString,
@@ -34,6 +45,10 @@ import {
 } from '../../src/subjects/spelling/service-contract.js';
 
 const PREF_KEY = 'ks2-platform-v2.spelling-prefs';
+const GUARDIAN_PROGRESS_KEY_PREFIX = 'ks2-spell-guardian-';
+const PROGRESS_KEY_PREFIX = 'ks2-spell-progress-';
+const GUARDIAN_SECURE_STAGE = 4;
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 function createNoopStorage() {
   return {
@@ -47,6 +62,206 @@ function createNoopStorage() {
 
 function prefsKey(learnerId) {
   return `${PREF_KEY}.${learnerId || 'default'}`;
+}
+
+function guardianMapKey(learnerId) {
+  return `${GUARDIAN_PROGRESS_KEY_PREFIX}${learnerId || 'default'}`;
+}
+
+function progressMapKey(learnerId) {
+  return `${PROGRESS_KEY_PREFIX}${learnerId || 'default'}`;
+}
+
+function intervalForLevel(level) {
+  const index = Math.max(0, Math.min(GUARDIAN_MAX_REVIEW_LEVEL, Math.floor(Number(level) || 0)));
+  return GUARDIAN_INTERVALS[index];
+}
+
+/**
+ * Pure scheduler helpers — advance* functions never mutate their input record,
+ * they return a new record. Day arithmetic is integer-only (Math.floor(ts/DAY_MS))
+ * per the plan; no ISO strings anywhere in the guardian path.
+ */
+
+export function advanceGuardianOnCorrect(record, todayDay) {
+  const safeToday = Number.isFinite(Number(todayDay)) ? Math.floor(Number(todayDay)) : 0;
+  const source = normaliseGuardianRecord(record, safeToday);
+
+  if (source.wobbling) {
+    // Recovery path — clear wobbling, bump renewals, preserve reviewLevel.
+    // Schedule resumes using the existing reviewLevel (does NOT advance).
+    // The interval is indexed by the current (preserved) reviewLevel so the
+    // learner picks up their spaced-practice ladder rather than starting over.
+    return {
+      ...source,
+      wobbling: false,
+      renewals: source.renewals + 1,
+      correctStreak: source.correctStreak + 1,
+      lastReviewedDay: safeToday,
+      nextDueDay: safeToday + intervalForLevel(source.reviewLevel),
+    };
+  }
+
+  // Non-wobbling success — bump reviewLevel (capped) and correctStreak. Interval
+  // is indexed by the CURRENT (pre-advance) reviewLevel so the first success at
+  // level 0 schedules +3 days; at cap (level 5) it stays +90.
+  const nextLevel = Math.min(GUARDIAN_MAX_REVIEW_LEVEL, source.reviewLevel + 1);
+  return {
+    ...source,
+    reviewLevel: nextLevel,
+    correctStreak: source.correctStreak + 1,
+    lastReviewedDay: safeToday,
+    nextDueDay: safeToday + intervalForLevel(source.reviewLevel),
+  };
+}
+
+export function advanceGuardianOnWrong(record, todayDay) {
+  const safeToday = Number.isFinite(Number(todayDay)) ? Math.floor(Number(todayDay)) : 0;
+  const source = normaliseGuardianRecord(record, safeToday);
+  return {
+    ...source,
+    wobbling: true,
+    lapses: source.lapses + 1,
+    correctStreak: 0,
+    lastReviewedDay: safeToday,
+    nextDueDay: safeToday + 1,
+  };
+}
+
+export function ensureGuardianRecord(guardianMap, slug, todayDay) {
+  if (!slug || typeof slug !== 'string') return null;
+  const map = guardianMap && typeof guardianMap === 'object' && !Array.isArray(guardianMap) ? guardianMap : {};
+  if (Object.prototype.hasOwnProperty.call(map, slug) && map[slug]) {
+    return map[slug];
+  }
+  const safeToday = Number.isFinite(Number(todayDay)) ? Math.floor(Number(todayDay)) : 0;
+  const fresh = normaliseGuardianRecord({}, safeToday);
+  map[slug] = fresh;
+  return fresh;
+}
+
+function clampSelectionLength(length) {
+  const parsed = Number(length);
+  const base = Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : GUARDIAN_DEFAULT_ROUND_LENGTH;
+  if (base < GUARDIAN_MIN_ROUND_LENGTH) return GUARDIAN_MIN_ROUND_LENGTH;
+  if (base > GUARDIAN_MAX_ROUND_LENGTH) return GUARDIAN_MAX_ROUND_LENGTH;
+  return base;
+}
+
+function compareByDueDayThenSlug(a, b) {
+  if (a.nextDueDay !== b.nextDueDay) return a.nextDueDay - b.nextDueDay;
+  if (a.slug < b.slug) return -1;
+  if (a.slug > b.slug) return 1;
+  return 0;
+}
+
+function compareByLastReviewedThenSlug(a, b) {
+  const aLast = a.lastReviewedDay != null ? a.lastReviewedDay : -1;
+  const bLast = b.lastReviewedDay != null ? b.lastReviewedDay : -1;
+  if (aLast !== bLast) return aLast - bLast;
+  if (a.slug < b.slug) return -1;
+  if (a.slug > b.slug) return 1;
+  return 0;
+}
+
+function deterministicShuffle(items, random) {
+  const output = items.slice();
+  const rng = typeof random === 'function' ? random : Math.random;
+  for (let i = output.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rng() * (i + 1));
+    const tmp = output[i];
+    output[i] = output[j];
+    output[j] = tmp;
+  }
+  return output;
+}
+
+/**
+ * Pure selection function. Picks 5-8 slugs (clamped by length input) from the
+ * learner's guardian map + progress map, prioritising wobbling-due → due →
+ * lazy-create sample → top-up of non-due guardians.
+ *
+ * @param {object} params
+ * @param {object} params.guardianMap  slug -> normalised guardian record
+ * @param {object} params.progressMap  slug -> legacy progress record
+ * @param {object} params.wordBySlug   slug -> word metadata (spellingPool, etc.)
+ * @param {number} params.todayDay     integer day (Math.floor(ts/DAY_MS))
+ * @param {number} params.length       desired round length (clamped 5..8)
+ * @param {Function} params.random     injected random; used for lazy-create shuffle
+ * @returns {string[]} selected slugs (array of strings)
+ */
+export function selectGuardianWords({
+  guardianMap = {},
+  progressMap = {},
+  wordBySlug = {},
+  todayDay = 0,
+  length = GUARDIAN_DEFAULT_ROUND_LENGTH,
+  random = Math.random,
+} = {}) {
+  const target = clampSelectionLength(length);
+  const safeToday = Number.isFinite(Number(todayDay)) ? Math.floor(Number(todayDay)) : 0;
+  const guardianEntries = Object.entries(guardianMap || {}).map(([slug, record]) => ({
+    slug,
+    ...record,
+  }));
+
+  const wobblingDue = guardianEntries
+    .filter((entry) => entry.wobbling === true && entry.nextDueDay <= safeToday)
+    .sort(compareByDueDayThenSlug);
+  const nonWobblingDue = guardianEntries
+    .filter((entry) => entry.wobbling !== true && entry.nextDueDay <= safeToday)
+    .sort(compareByDueDayThenSlug);
+
+  const selected = [];
+  const selectedSet = new Set();
+
+  function push(slug) {
+    if (!slug || typeof slug !== 'string') return;
+    if (selectedSet.has(slug)) return;
+    if (selected.length >= target) return;
+    selected.push(slug);
+    selectedSet.add(slug);
+  }
+
+  wobblingDue.forEach((entry) => push(entry.slug));
+  if (selected.length < target) nonWobblingDue.forEach((entry) => push(entry.slug));
+
+  // Lazy-create candidates: mega words (stage >= 4) that are NOT yet in the
+  // guardian map at all. Filter by known slugs in wordBySlug so we never return
+  // a slug the caller can't resolve.
+  if (selected.length < target) {
+    const lazyCandidates = [];
+    for (const [slug, progress] of Object.entries(progressMap || {})) {
+      if (!slug || typeof slug !== 'string') continue;
+      if (!wordBySlug || !wordBySlug[slug]) continue;
+      if (Object.prototype.hasOwnProperty.call(guardianMap || {}, slug)) continue;
+      const stage = Number(progress?.stage);
+      if (!(Number.isFinite(stage) && stage >= GUARDIAN_SECURE_STAGE)) continue;
+      lazyCandidates.push(slug);
+    }
+    // Alphabetical baseline makes the shuffle deterministic under a seeded rng.
+    lazyCandidates.sort();
+    const shuffled = deterministicShuffle(lazyCandidates, random);
+    for (const slug of shuffled) {
+      if (selected.length >= target) break;
+      push(slug);
+    }
+  }
+
+  // Top-up from non-due guardians (sorted by oldest lastReviewedDay first). Only
+  // engages if we're still below the minimum round length — matches the plan
+  // ("if still under min length (5), top up").
+  if (selected.length < GUARDIAN_MIN_ROUND_LENGTH) {
+    const nonDue = guardianEntries
+      .filter((entry) => entry.nextDueDay > safeToday && !selectedSet.has(entry.slug))
+      .sort(compareByLastReviewedThenSlug);
+    for (const entry of nonDue) {
+      if (selected.length >= target) break;
+      push(entry.slug);
+    }
+  }
+
+  return selected;
 }
 
 function loadJson(storage, key, fallback) {
@@ -144,6 +359,7 @@ function defaultLabelForMode(mode) {
   if (mode === 'trouble') return 'Trouble drill';
   if (mode === 'single') return 'Single-word drill';
   if (mode === 'test') return 'SATs 20 test';
+  if (mode === 'guardian') return 'Guardian Mission';
   return 'Smart review';
 }
 
@@ -417,6 +633,76 @@ export function createSpellingService({ repository, storage, tts, now, random, c
     return analyticsWordRow(learnerId, runtimeWordBySlug[slug], progressSnapshot(learnerId));
   }
 
+  function currentTodayDay() {
+    return Math.floor(clock() / DAY_MS);
+  }
+
+  /**
+   * Strict FIFO card advance for Guardian Mission rounds. The legacy
+   * advanceCard uses weighted selection over the queue window, which
+   * randomises the per-round word order in ways the Guardian selection
+   * contract explicitly wants to own. We bypass that and just shift the
+   * queue head, rebuilding the currentPrompt via the existing helper.
+   */
+  function advanceGuardianCard(session) {
+    if (!session) return { done: true };
+    while (Array.isArray(session.queue) && session.queue.length) {
+      const nextSlug = session.queue.shift();
+      if (!nextSlug || !runtimeWordBySlug[nextSlug]) continue;
+      if (session.status?.[nextSlug]?.done) continue;
+      session.currentSlug = nextSlug;
+      session.currentPrompt = buildPrompt(engine, session, nextSlug, runtimeWordBySlug);
+      session.lastFamily = runtimeWordBySlug[nextSlug]?.family || null;
+      session.lastYear = runtimeWordBySlug[nextSlug]?.year || null;
+      return { done: false, slug: nextSlug, prompt: session.currentPrompt };
+    }
+    session.currentSlug = null;
+    session.currentPrompt = null;
+    return { done: true };
+  }
+
+  // Guardian state persists through the same storage proxy as prefs and progress
+  // via the ks2-spell-guardian-<learnerId> key. Both the client repository and
+  // the Worker engine recognise this prefix and route it through data.guardian
+  // in the subject-state record (normalised by U1's normaliseGuardianMap).
+  function loadGuardianMap(learnerId) {
+    const raw = loadJson(resolvedStorage, guardianMapKey(learnerId), {});
+    return normaliseGuardianMap(raw && typeof raw === 'object' && !Array.isArray(raw) ? raw : {}, currentTodayDay());
+  }
+
+  function saveGuardianMap(learnerId, map) {
+    saveJson(resolvedStorage, guardianMapKey(learnerId), map || {});
+  }
+
+  function loadProgressFromStorage(learnerId) {
+    const raw = loadJson(resolvedStorage, progressMapKey(learnerId), {});
+    return raw && typeof raw === 'object' && !Array.isArray(raw) ? raw : {};
+  }
+
+  function saveProgressToStorage(learnerId, map) {
+    saveJson(resolvedStorage, progressMapKey(learnerId), map || {});
+  }
+
+  function coreWordCount() {
+    return runtimeWords.filter((word) => (word?.spellingPool === 'extra' ? 'extra' : 'core') === 'core').length;
+  }
+
+  function secureCoreCount(progressStore) {
+    let count = 0;
+    for (const word of runtimeWords) {
+      if ((word.spellingPool === 'extra' ? 'extra' : 'core') !== 'core') continue;
+      const progress = progressStore?.[word.slug];
+      if (progress && Number(progress.stage) >= GUARDIAN_SECURE_STAGE) count += 1;
+    }
+    return count;
+  }
+
+  function isAllWordsMega(progressStore) {
+    const total = coreWordCount();
+    if (!total) return false;
+    return secureCoreCount(progressStore) === total;
+  }
+
   function getAnalyticsSnapshot(learnerId) {
     const progressStore = progressSnapshot(learnerId);
     return {
@@ -479,6 +765,9 @@ export function createSpellingService({ repository, storage, tts, now, random, c
       lastFamily: normaliseOptionalString(raw.lastFamily),
       lastYear: normaliseOptionalString(raw.lastYear),
       startedAt: normaliseTimestamp(raw.startedAt, clock()),
+      guardianResults: mode === 'guardian' && raw.guardianResults && typeof raw.guardianResults === 'object' && !Array.isArray(raw.guardianResults)
+        ? { ...raw.guardianResults }
+        : (mode === 'guardian' ? {} : undefined),
     };
 
     if (currentSlug && !session.currentPrompt) {
@@ -515,7 +804,9 @@ export function createSpellingService({ repository, storage, tts, now, random, c
     }
 
     if (!session.currentSlug) {
-      const next = engine.advanceCard(session, learnerId);
+      const next = session.mode === 'guardian'
+        ? advanceGuardianCard(session)
+        : engine.advanceCard(session, learnerId);
       if (next.done) {
         return {
           session: null,
@@ -634,8 +925,104 @@ export function createSpellingService({ repository, storage, tts, now, random, c
     };
   }
 
+  function startGuardianSession(learnerId, options = {}) {
+    const progressStore = progressSnapshot(learnerId) || {};
+    if (!isAllWordsMega(progressStore)) {
+      return buildTransition({
+        ...createInitialSpellingState(),
+        feedback: {
+          kind: 'warn',
+          headline: 'Guardian Mission unlocks after every core word is secure',
+          body: 'Keep reviewing Smart Review and Trouble Drill until every core word is secure — then Guardian Mission opens.',
+        },
+      }, { ok: false });
+    }
+
+    const today = currentTodayDay();
+    const guardianMap = loadGuardianMap(learnerId);
+    const desiredLength = options.length === 'all'
+      ? GUARDIAN_MAX_ROUND_LENGTH
+      : clampSelectionLength(Number(options.length) || GUARDIAN_DEFAULT_ROUND_LENGTH);
+
+    const selectedSlugs = selectGuardianWords({
+      guardianMap,
+      progressMap: progressStore,
+      wordBySlug: runtimeWordBySlug,
+      todayDay: today,
+      length: desiredLength,
+      random: randomFn,
+    });
+
+    if (!selectedSlugs.length) {
+      return buildTransition({
+        ...createInitialSpellingState(),
+        feedback: {
+          kind: 'info',
+          headline: 'No Guardian duties today',
+          body: 'Every guarded word is still holding — come back tomorrow for the next Guardian Mission.',
+        },
+      }, { ok: false });
+    }
+
+    const selectedWords = selectedSlugs.map((slug) => runtimeWordBySlug[slug]).filter(Boolean);
+    if (!selectedWords.length) {
+      return buildTransition({
+        ...createInitialSpellingState(),
+        error: 'Guardian Mission could not resolve any words.',
+      }, { ok: false });
+    }
+
+    const created = engine.createSession({
+      profileId: learnerId,
+      mode: 'guardian',
+      yearFilter: 'core',
+      length: selectedWords.length,
+      words: selectedWords,
+      practiceOnly: false,
+      extraWordFamilies: false,
+    });
+
+    if (!created.ok) {
+      return buildTransition({
+        ...createInitialSpellingState(),
+        error: created.reason || 'Could not start a Guardian Mission.',
+      }, { ok: false });
+    }
+
+    // Legacy createSession labels 'guardian' as 'Smart review' via fallthrough.
+    // Stamp the Guardian Mission label + mission-scoped bookkeeping here.
+    created.session.mode = 'guardian';
+    created.session.label = 'Guardian Mission';
+    created.session.guardianResults = {};
+
+    const firstCard = advanceGuardianCard(created.session);
+    if (firstCard.done) {
+      return buildTransition({
+        ...createInitialSpellingState(),
+        error: 'Guardian Mission could not prepare the first card.',
+      }, { ok: false });
+    }
+
+    const session = decorateSession(engine, learnerId, created.session, runtimeWordBySlug, created.progressStore);
+    const nextState = {
+      version: SPELLING_SERVICE_STATE_VERSION,
+      phase: 'session',
+      session,
+      feedback: null,
+      summary: null,
+      error: '',
+      awaitingAdvance: false,
+    };
+
+    persistence.syncPracticeSession(learnerId, nextState);
+    return buildTransition(nextState, { audio: activeAudioCue(learnerId, nextState) });
+  }
+
   function startSession(learnerId, options = {}) {
     const mode = normaliseMode(options.mode, 'smart');
+    if (mode === 'guardian') {
+      return startGuardianSession(learnerId, options);
+    }
     const yearFilter = mode === 'test'
       ? 'core'
       : normaliseYearFilter(options.yearFilter, 'core');
@@ -712,6 +1099,147 @@ export function createSpellingService({ repository, storage, tts, now, random, c
     }, { ok: false });
   }
 
+  function submitGuardianAnswer(learnerId, current, rawTyped) {
+    const session = cloneSerialisable(current.session);
+    const currentSlug = session.currentSlug;
+    const baseWord = runtimeWordBySlug[currentSlug];
+    if (!baseWord) {
+      return invalidSessionTransition('This Guardian Mission card is missing its word metadata.');
+    }
+    const promptWord = wordForPrompt(baseWord, session.currentPrompt);
+    const graded = engine.grade(promptWord, rawTyped);
+    const correct = Boolean(graded.correct);
+
+    // Session bookkeeping — single attempt per word, no retry/correction phase.
+    const statusEntry = session.status?.[currentSlug] || {
+      attempts: 0,
+      successes: 0,
+      needed: 1,
+      hadWrong: false,
+      wrongAnswers: [],
+      done: false,
+      applied: false,
+    };
+    statusEntry.attempts += 1;
+    statusEntry.done = true;
+    statusEntry.applied = true;
+    if (correct) {
+      statusEntry.successes = (statusEntry.successes || 0) + 1;
+    } else {
+      statusEntry.hadWrong = true;
+      statusEntry.wrongAnswers = [...(statusEntry.wrongAnswers || []), rawTyped];
+    }
+    session.status = session.status || {};
+    session.status[currentSlug] = statusEntry;
+    session.promptCount = (session.promptCount || 0) + 1;
+    session.phase = 'question';
+
+    // Remove this slug from the queue (legacy engine pre-shifts on advanceCard,
+    // but we also clean up defensively in case the queue still has the slug).
+    if (Array.isArray(session.queue)) {
+      session.queue = session.queue.filter((slug) => slug !== currentSlug);
+    }
+
+    // Update progress.attempts / correct / wrong only. Stage/dueDay/lastDay/
+    // lastResult are preserved — Guardian never demotes Mega.
+    const progressMap = loadProgressFromStorage(learnerId);
+    const existingProgress = progressMap[currentSlug] && typeof progressMap[currentSlug] === 'object'
+      ? progressMap[currentSlug]
+      : { stage: 0, attempts: 0, correct: 0, wrong: 0, dueDay: 0, lastDay: null, lastResult: null };
+    const nextProgress = { ...existingProgress };
+    nextProgress.attempts = (nextProgress.attempts || 0) + 1;
+    if (correct) nextProgress.correct = (nextProgress.correct || 0) + 1;
+    else nextProgress.wrong = (nextProgress.wrong || 0) + 1;
+    progressMap[currentSlug] = nextProgress;
+    saveProgressToStorage(learnerId, progressMap);
+
+    // Advance the guardian record. Lazy-create if this is the first Guardian
+    // touch for the slug. ensureGuardianRecord mutates the map, so load a
+    // mutable copy first, advance, then save the whole thing.
+    const todayDay = currentTodayDay();
+    const guardianMap = loadGuardianMap(learnerId);
+    const beforeRecord = ensureGuardianRecord(guardianMap, currentSlug, todayDay);
+    const wasWobbling = beforeRecord.wobbling === true;
+    const updatedRecord = correct
+      ? advanceGuardianOnCorrect(beforeRecord, todayDay)
+      : advanceGuardianOnWrong(beforeRecord, todayDay);
+    guardianMap[currentSlug] = updatedRecord;
+    saveGuardianMap(learnerId, guardianMap);
+
+    // Record the per-word outcome so the finalisation step can emit the
+    // mission-completed event with accurate aggregate counts.
+    const outcomeKind = !correct
+      ? 'wobbled'
+      : wasWobbling
+        ? 'recovered'
+        : 'renewed';
+    session.guardianResults = session.guardianResults || {};
+    session.guardianResults[currentSlug] = outcomeKind;
+
+    const eventTime = clock();
+    const events = [];
+    if (outcomeKind === 'renewed') {
+      events.push(createSpellingGuardianRenewedEvent({
+        learnerId,
+        session,
+        slug: currentSlug,
+        reviewLevel: updatedRecord.reviewLevel,
+        nextDueDay: updatedRecord.nextDueDay,
+        createdAt: eventTime,
+        wordMeta: runtimeWordBySlug,
+      }));
+    } else if (outcomeKind === 'wobbled') {
+      events.push(createSpellingGuardianWobbledEvent({
+        learnerId,
+        session,
+        slug: currentSlug,
+        lapses: updatedRecord.lapses,
+        createdAt: eventTime,
+        wordMeta: runtimeWordBySlug,
+      }));
+    } else {
+      events.push(createSpellingGuardianRecoveredEvent({
+        learnerId,
+        session,
+        slug: currentSlug,
+        renewals: updatedRecord.renewals,
+        reviewLevel: updatedRecord.reviewLevel,
+        createdAt: eventTime,
+        wordMeta: runtimeWordBySlug,
+      }));
+    }
+
+    const feedback = correct
+      ? {
+          kind: wasWobbling ? 'success' : 'info',
+          headline: wasWobbling ? 'Recovered.' : 'Guardian strong.',
+          answer: promptWord.word,
+          body: wasWobbling
+            ? 'This word is back under your guard. Next check will follow the schedule.'
+            : `This word stays secure. Next Guardian check in ${intervalForLevel(updatedRecord.reviewLevel)} day${intervalForLevel(updatedRecord.reviewLevel) === 1 ? '' : 's'}.`,
+        }
+      : {
+          kind: 'warn',
+          headline: 'Wobbling.',
+          answer: promptWord.word,
+          body: 'Mega stays, but this word will return tomorrow for a Guardian check.',
+          attemptedAnswer: rawTyped,
+        };
+
+    const nextState = {
+      version: SPELLING_SERVICE_STATE_VERSION,
+      phase: 'session',
+      session: decorateSession(engine, learnerId, session, runtimeWordBySlug),
+      feedback: normaliseFeedback(feedback),
+      summary: null,
+      error: '',
+      awaitingAdvance: true,
+    };
+
+    persistence.syncPracticeSession(learnerId, nextState);
+    return buildTransition(nextState, { events });
+  }
+
   function submitAnswer(learnerId, rawState, typed) {
     const current = initState(rawState, learnerId);
     if (current.phase !== 'session' || !current.session) {
@@ -722,8 +1250,6 @@ export function createSpellingService({ repository, storage, tts, now, random, c
       return buildTransition(current, { changed: false });
     }
 
-    const session = cloneSerialisable(current.session);
-    const entryPhase = session.phase;
     const rawTyped = normaliseString(typed).trim();
     if (!rawTyped) {
       return buildTransition({
@@ -738,6 +1264,12 @@ export function createSpellingService({ repository, storage, tts, now, random, c
       });
     }
 
+    if (current.session.mode === 'guardian') {
+      return submitGuardianAnswer(learnerId, current, rawTyped);
+    }
+
+    const session = cloneSerialisable(current.session);
+    const entryPhase = session.phase;
     const currentSlug = session.currentSlug;
     const result = session.type === 'test'
       ? engine.submitTest(session, learnerId, rawTyped)
@@ -817,6 +1349,38 @@ export function createSpellingService({ repository, storage, tts, now, random, c
     return buildTransition(nextState, { events, audio });
   }
 
+  function guardianMissionEventsForSession(learnerId, session, summary, createdAt) {
+    if (session?.mode !== 'guardian') return [];
+    const results = session.guardianResults && typeof session.guardianResults === 'object' && !Array.isArray(session.guardianResults)
+      ? session.guardianResults
+      : {};
+    let renewalCount = 0;
+    let wobbledCount = 0;
+    let recoveredCount = 0;
+    for (const outcome of Object.values(results)) {
+      if (outcome === 'renewed') renewalCount += 1;
+      else if (outcome === 'wobbled') wobbledCount += 1;
+      else if (outcome === 'recovered') recoveredCount += 1;
+    }
+    const events = [];
+    const sessionCompleted = createSpellingSessionCompletedEvent({
+      learnerId,
+      session,
+      summary,
+      createdAt,
+    });
+    if (sessionCompleted) events.push(sessionCompleted);
+    events.push(createSpellingGuardianMissionCompletedEvent({
+      learnerId,
+      session,
+      renewalCount,
+      wobbledCount,
+      recoveredCount,
+      createdAt,
+    }));
+    return events;
+  }
+
   function continueSession(learnerId, rawState) {
     const current = initState(rawState, learnerId);
     if (current.phase !== 'session' || !current.session) {
@@ -828,7 +1392,9 @@ export function createSpellingService({ repository, storage, tts, now, random, c
     }
 
     const session = cloneSerialisable(current.session);
-    const advanced = engine.advanceCard(session, learnerId);
+    const advanced = session.mode === 'guardian'
+      ? advanceGuardianCard(session)
+      : engine.advanceCard(session, learnerId);
 
     if (advanced.done) {
       const summary = normaliseSummary(engine.finalise(session), isRuntimeKnownSlug);
@@ -842,9 +1408,11 @@ export function createSpellingService({ repository, storage, tts, now, random, c
         awaitingAdvance: false,
       };
       persistence.syncPracticeSession(learnerId, nextState);
-      return buildTransition(nextState, {
-        events: sessionCompletedEvents({ learnerId, session, summary, createdAt: clock() }),
-      });
+      const createdAt = clock();
+      const events = session.mode === 'guardian'
+        ? guardianMissionEventsForSession(learnerId, session, summary, createdAt)
+        : sessionCompletedEvents({ learnerId, session, summary, createdAt });
+      return buildTransition(nextState, { events });
     }
 
     const nextState = {

--- a/shared/spelling/service.js
+++ b/shared/spelling/service.js
@@ -250,12 +250,19 @@ export function selectGuardianWords({
 
   // Top-up from non-due guardians (sorted by oldest lastReviewedDay first). Only
   // engages if we're still below the minimum round length — matches the plan
-  // ("if still under min length (5), top up").
+  // ("if still under min length (5), top up"). Wobbling non-due entries still
+  // keep priority over non-wobbling non-due entries so a recent wobble stays
+  // visible when scheduling placed it slightly in the future.
   if (selected.length < GUARDIAN_MIN_ROUND_LENGTH) {
     const nonDue = guardianEntries
-      .filter((entry) => entry.nextDueDay > safeToday && !selectedSet.has(entry.slug))
+      .filter((entry) => entry.nextDueDay > safeToday && !selectedSet.has(entry.slug));
+    const wobblingNonDue = nonDue
+      .filter((entry) => entry.wobbling === true)
       .sort(compareByLastReviewedThenSlug);
-    for (const entry of nonDue) {
+    const stableNonDue = nonDue
+      .filter((entry) => entry.wobbling !== true)
+      .sort(compareByLastReviewedThenSlug);
+    for (const entry of [...wobblingNonDue, ...stableNonDue]) {
       if (selected.length >= target) break;
       push(entry.slug);
     }
@@ -1209,14 +1216,15 @@ export function createSpellingService({ repository, storage, tts, now, random, c
       }));
     }
 
+    const daysUntilNextCheck = Math.max(0, updatedRecord.nextDueDay - todayDay);
     const feedback = correct
       ? {
           kind: wasWobbling ? 'success' : 'info',
           headline: wasWobbling ? 'Recovered.' : 'Guardian strong.',
           answer: promptWord.word,
           body: wasWobbling
-            ? 'This word is back under your guard. Next check will follow the schedule.'
-            : `This word stays secure. Next Guardian check in ${intervalForLevel(updatedRecord.reviewLevel)} day${intervalForLevel(updatedRecord.reviewLevel) === 1 ? '' : 's'}.`,
+            ? `This word is back under your guard. Next Guardian check in ${daysUntilNextCheck} day${daysUntilNextCheck === 1 ? '' : 's'}.`
+            : `This word stays secure. Next Guardian check in ${daysUntilNextCheck} day${daysUntilNextCheck === 1 ? '' : 's'}.`,
         }
       : {
           kind: 'warn',

--- a/src/subjects/spelling/repository.js
+++ b/src/subjects/spelling/repository.js
@@ -1,8 +1,17 @@
 import { cloneSerialisable, normalisePracticeSessionRecord } from '../../platform/core/repositories/helpers.js';
+import { normaliseGuardianMap } from './service-contract.js';
 
 const SUBJECT_ID = 'spelling';
 const PREF_STORAGE_PREFIX = 'ks2-platform-v2.spelling-prefs.';
 const PROGRESS_STORAGE_PREFIX = 'ks2-spell-progress-';
+const GUARDIAN_STORAGE_PREFIX = 'ks2-spell-guardian-';
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function todayDayForNow(now) {
+  const ts = typeof now === 'function' ? Number(now()) : (now == null ? Date.now() : Number(now));
+  if (!Number.isFinite(ts) || ts < 0) return 0;
+  return Math.floor(ts / DAY_MS);
+}
 
 function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -21,10 +30,17 @@ function prefsKey(learnerId) {
   return `${PREF_STORAGE_PREFIX}${learnerId || 'default'}`;
 }
 
+function guardianKey(learnerId) {
+  return `${GUARDIAN_STORAGE_PREFIX}${learnerId || 'default'}`;
+}
+
 function parseStorageKey(key) {
   if (typeof key !== 'string') return null;
   if (key.startsWith(PREF_STORAGE_PREFIX)) {
     return { type: 'prefs', learnerId: key.slice(PREF_STORAGE_PREFIX.length) || 'default' };
+  }
+  if (key.startsWith(GUARDIAN_STORAGE_PREFIX)) {
+    return { type: 'guardian', learnerId: key.slice(GUARDIAN_STORAGE_PREFIX.length) || 'default' };
   }
   if (key.startsWith(PROGRESS_STORAGE_PREFIX)) {
     return { type: 'progress', learnerId: key.slice(PROGRESS_STORAGE_PREFIX.length) || 'default' };
@@ -50,21 +66,23 @@ function normaliseProgressMap(rawValue) {
   return output;
 }
 
-export function normaliseSpellingSubjectData(rawValue) {
+export function normaliseSpellingSubjectData(rawValue, todayDay = 0) {
   const raw = isPlainObject(rawValue) ? rawValue : {};
   return {
     prefs: isPlainObject(raw.prefs) ? cloneSerialisable(raw.prefs) : {},
     progress: normaliseProgressMap(raw.progress),
+    guardian: normaliseGuardianMap(raw.guardian, todayDay),
   };
 }
 
-function readSpellingData(repositories, learnerId) {
-  return normaliseSpellingSubjectData(repositories.subjectStates.read(learnerId, SUBJECT_ID).data || {});
+function readSpellingData(repositories, learnerId, todayDay = 0) {
+  return normaliseSpellingSubjectData(repositories.subjectStates.read(learnerId, SUBJECT_ID).data || {}, todayDay);
 }
 
-function writeSpellingData(repositories, learnerId, nextData) {
+function writeSpellingData(repositories, learnerId, nextData, todayDay = 0) {
   return normaliseSpellingSubjectData(
-    repositories.subjectStates.writeData(learnerId, SUBJECT_ID, normaliseSpellingSubjectData(nextData)).data,
+    repositories.subjectStates.writeData(learnerId, SUBJECT_ID, normaliseSpellingSubjectData(nextData, todayDay)).data,
+    todayDay,
   );
 }
 
@@ -106,47 +124,55 @@ export function createSpellingPersistence({ repositories, now } = {}) {
     throw new TypeError('Spelling persistence requires platform repositories.');
   }
 
+  const currentDay = () => todayDayForNow(now);
+
   const storage = {
     getItem(key) {
       const parsed = parseStorageKey(key);
       if (!parsed) return null;
-      const data = readSpellingData(repositories, parsed.learnerId);
+      const data = readSpellingData(repositories, parsed.learnerId, currentDay());
       if (parsed.type === 'prefs') return JSON.stringify(data.prefs || {});
       if (parsed.type === 'progress') return JSON.stringify(data.progress || {});
+      if (parsed.type === 'guardian') return JSON.stringify(data.guardian || {});
       return null;
     },
     setItem(key, value) {
       const parsed = parseStorageKey(key);
       if (!parsed) return;
-      const current = readSpellingData(repositories, parsed.learnerId);
+      const day = currentDay();
+      const current = readSpellingData(repositories, parsed.learnerId, day);
       if (parsed.type === 'prefs') {
         writeSpellingData(repositories, parsed.learnerId, {
           ...current,
           prefs: parseStoredJson(value, {}),
-        });
+        }, day);
       }
       if (parsed.type === 'progress') {
         writeSpellingData(repositories, parsed.learnerId, {
           ...current,
           progress: parseStoredJson(value, {}),
-        });
+        }, day);
+      }
+      if (parsed.type === 'guardian') {
+        writeSpellingData(repositories, parsed.learnerId, {
+          ...current,
+          guardian: parseStoredJson(value, {}),
+        }, day);
       }
     },
     removeItem(key) {
       const parsed = parseStorageKey(key);
       if (!parsed) return;
-      const current = readSpellingData(repositories, parsed.learnerId);
+      const day = currentDay();
+      const current = readSpellingData(repositories, parsed.learnerId, day);
       if (parsed.type === 'prefs') {
-        writeSpellingData(repositories, parsed.learnerId, {
-          ...current,
-          prefs: {},
-        });
+        writeSpellingData(repositories, parsed.learnerId, { ...current, prefs: {} }, day);
       }
       if (parsed.type === 'progress') {
-        writeSpellingData(repositories, parsed.learnerId, {
-          ...current,
-          progress: {},
-        });
+        writeSpellingData(repositories, parsed.learnerId, { ...current, progress: {} }, day);
+      }
+      if (parsed.type === 'guardian') {
+        writeSpellingData(repositories, parsed.learnerId, { ...current, guardian: {} }, day);
       }
     },
   };
@@ -155,6 +181,7 @@ export function createSpellingPersistence({ repositories, now } = {}) {
     storage,
     progressKey,
     prefsKey,
+    guardianKey,
     syncPracticeSession(learnerId, state) {
       if (state?.phase === 'session') {
         const record = buildActiveRecord(learnerId, state, now);
@@ -182,7 +209,7 @@ export function createSpellingPersistence({ repositories, now } = {}) {
       return next;
     },
     resetLearner(learnerId) {
-      writeSpellingData(repositories, learnerId, {});
+      writeSpellingData(repositories, learnerId, {}, currentDay());
       repositories.practiceSessions.clear(learnerId, SUBJECT_ID);
     },
   };

--- a/tests/spelling-guardian.test.js
+++ b/tests/spelling-guardian.test.js
@@ -21,6 +21,17 @@ import {
   createSpellingGuardianWobbledEvent,
 } from '../src/subjects/spelling/events.js';
 import { normaliseServerSpellingData } from '../worker/src/subjects/spelling/engine.js';
+import {
+  advanceGuardianOnCorrect,
+  advanceGuardianOnWrong,
+  ensureGuardianRecord,
+  selectGuardianWords,
+} from '../shared/spelling/service.js';
+import { createSpellingService } from '../src/subjects/spelling/service.js';
+import { createSpellingPersistence } from '../src/subjects/spelling/repository.js';
+import { createLocalPlatformRepositories } from '../src/platform/core/repositories/index.js';
+import { installMemoryStorage } from './helpers/memory-storage.js';
+import { WORDS, WORD_BY_SLUG } from '../src/subjects/spelling/data/word-data.js';
 
 const TODAY = 18_000;
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -364,4 +375,467 @@ test('all guardian event factories produce deterministic id collisions when inpu
   assert.equal(renewed1.id, renewed2.id);
   assert.equal(wobbled1.id, wobbled2.id);
   assert.notEqual(renewed1.id, wobbled1.id, 'different event types produce different ids even for same slug');
+});
+
+// ----- U3: pure scheduler helpers ----------------------------------------------
+
+test('advanceGuardianOnCorrect: fresh record bumps reviewLevel to 1 and schedules +3 days', () => {
+  const record = normaliseGuardianRecord({}, TODAY);
+  const next = advanceGuardianOnCorrect(record, TODAY);
+  assert.equal(next.reviewLevel, 1);
+  assert.equal(next.correctStreak, 1);
+  assert.equal(next.lastReviewedDay, TODAY);
+  assert.equal(next.nextDueDay, TODAY + 3);
+  assert.equal(next.wobbling, false);
+  // input must not mutate
+  assert.equal(record.reviewLevel, 0);
+  assert.equal(record.correctStreak, 0);
+});
+
+test('advanceGuardianOnCorrect at max reviewLevel stays capped at GUARDIAN_MAX_REVIEW_LEVEL with +90 days', () => {
+  const record = normaliseGuardianRecord({ reviewLevel: GUARDIAN_MAX_REVIEW_LEVEL, correctStreak: 9 }, TODAY);
+  const next = advanceGuardianOnCorrect(record, TODAY);
+  assert.equal(next.reviewLevel, GUARDIAN_MAX_REVIEW_LEVEL);
+  assert.equal(next.correctStreak, 10);
+  assert.equal(next.nextDueDay, TODAY + 90);
+});
+
+test('advanceGuardianOnCorrect on a wobbling record clears wobbling, bumps renewals, preserves reviewLevel', () => {
+  const record = normaliseGuardianRecord({
+    reviewLevel: 2,
+    lastReviewedDay: TODAY - 5,
+    nextDueDay: TODAY - 1,
+    correctStreak: 0,
+    lapses: 2,
+    renewals: 1,
+    wobbling: true,
+  }, TODAY);
+  const next = advanceGuardianOnCorrect(record, TODAY);
+  assert.equal(next.wobbling, false, 'wobbling cleared');
+  assert.equal(next.reviewLevel, 2, 'reviewLevel unchanged on recovery');
+  assert.equal(next.renewals, 2, 'renewals bumped');
+  assert.equal(next.correctStreak, 1);
+  assert.equal(next.lastReviewedDay, TODAY);
+  // Schedule resumes using the preserved reviewLevel's interval. Anchor is
+  // today (new lastReviewedDay), so nextDueDay = today + GUARDIAN_INTERVALS[2].
+  assert.equal(next.nextDueDay, TODAY + GUARDIAN_INTERVALS[2]);
+  // input untouched
+  assert.equal(record.wobbling, true);
+  assert.equal(record.renewals, 1);
+});
+
+test('advanceGuardianOnWrong sets wobbling, increments lapses, resets streak, schedules +1 day', () => {
+  const record = normaliseGuardianRecord({
+    reviewLevel: 3,
+    lastReviewedDay: TODAY - 14,
+    nextDueDay: TODAY,
+    correctStreak: 4,
+    lapses: 0,
+    renewals: 0,
+    wobbling: false,
+  }, TODAY);
+  const next = advanceGuardianOnWrong(record, TODAY);
+  assert.equal(next.wobbling, true);
+  assert.equal(next.lapses, 1);
+  assert.equal(next.correctStreak, 0);
+  assert.equal(next.lastReviewedDay, TODAY);
+  assert.equal(next.nextDueDay, TODAY + 1);
+  assert.equal(next.reviewLevel, 3, 'reviewLevel unchanged on wrong');
+  // input untouched
+  assert.equal(record.correctStreak, 4);
+  assert.equal(record.wobbling, false);
+});
+
+test('advanceGuardianOnWrong applied twice stays wobbling with lapses=2 and nextDueDay=today+1', () => {
+  let record = normaliseGuardianRecord({}, TODAY);
+  record = advanceGuardianOnWrong(record, TODAY);
+  record = advanceGuardianOnWrong(record, TODAY);
+  assert.equal(record.wobbling, true);
+  assert.equal(record.lapses, 2);
+  assert.equal(record.correctStreak, 0);
+  assert.equal(record.nextDueDay, TODAY + 1);
+});
+
+test('ensureGuardianRecord is idempotent — second call returns the same record instance', () => {
+  const map = {};
+  const first = ensureGuardianRecord(map, 'possess', TODAY);
+  assert.equal(first.reviewLevel, 0);
+  assert.equal(first.nextDueDay, TODAY);
+  const second = ensureGuardianRecord(map, 'possess', TODAY);
+  assert.equal(second, first, 'identical object returned on second call');
+  // Map key was created exactly once
+  assert.deepEqual(Object.keys(map), ['possess']);
+});
+
+test('selectGuardianWords prioritises wobbling-due, then non-wobbling due, then lazy-create', () => {
+  // Build a guardian map with 2 wobbling-due, 3 non-wobbling-due, 1 non-due guardian.
+  const guardianMap = {
+    accommodate: { reviewLevel: 1, lastReviewedDay: TODAY - 2, nextDueDay: TODAY - 1, correctStreak: 0, lapses: 1, renewals: 0, wobbling: true },
+    address: { reviewLevel: 0, lastReviewedDay: TODAY - 3, nextDueDay: TODAY - 3, correctStreak: 0, lapses: 1, renewals: 0, wobbling: true },
+    believe: { reviewLevel: 2, lastReviewedDay: TODAY - 14, nextDueDay: TODAY - 1, correctStreak: 2, lapses: 0, renewals: 0, wobbling: false },
+    bicycle: { reviewLevel: 1, lastReviewedDay: TODAY - 3, nextDueDay: TODAY, correctStreak: 1, lapses: 0, renewals: 0, wobbling: false },
+    breath: { reviewLevel: 0, lastReviewedDay: TODAY - 3, nextDueDay: TODAY, correctStreak: 0, lapses: 0, renewals: 0, wobbling: false },
+    // non-due — top-up only kicks in when selection is below GUARDIAN_MIN_ROUND_LENGTH (5).
+    build: { reviewLevel: 3, lastReviewedDay: TODAY - 1, nextDueDay: TODAY + 30, correctStreak: 3, lapses: 0, renewals: 0, wobbling: false },
+  };
+  // Lazy candidates: mega words not in the guardian map yet.
+  const progressMap = {
+    possess: { stage: 4, attempts: 8, correct: 7, wrong: 1 },
+    busy: { stage: 4, attempts: 8, correct: 7, wrong: 1 },
+    // stage < 4 - not a lazy candidate
+    circle: { stage: 2, attempts: 4, correct: 2, wrong: 2 },
+  };
+
+  const selected = selectGuardianWords({
+    guardianMap,
+    progressMap,
+    wordBySlug: WORD_BY_SLUG,
+    todayDay: TODAY,
+    length: 8,
+    random: () => 0.5,
+  });
+
+  // Wobbling due first (oldest-due, alphabetical tie-break within same dueDay).
+  assert.equal(selected[0], 'address', 'oldest wobbling-due first');
+  assert.equal(selected[1], 'accommodate');
+  // Non-wobbling due next, oldest-due first. believe dueDay=TODAY-1; bicycle/breath dueDay=TODAY (alphabetical).
+  assert.equal(selected[2], 'believe');
+  assert.equal(selected[3], 'bicycle');
+  assert.equal(selected[4], 'breath');
+  // Then lazy-create sample - 'busy' and 'possess' (both mega and not in guardianMap).
+  // rng=0.5 fisher-yates on ['busy','possess']: i=1, j=floor(0.5*2)=1 → no swap → ['busy','possess']
+  assert.equal(selected[5], 'busy');
+  assert.equal(selected[6], 'possess');
+  // Total length is 7 — above GUARDIAN_MIN_ROUND_LENGTH, so top-up stays off and
+  // the non-due 'build' is NOT pulled in.
+  assert.equal(selected.length, 7);
+  assert.equal(selected.includes('build'), false, 'non-due guardian not top-upped above min length');
+});
+
+test('selectGuardianWords tops up with non-due guardians only when below GUARDIAN_MIN_ROUND_LENGTH', () => {
+  // Only 2 due guardians → below min length 5 after due+lazy picks. Top-up
+  // activates and drains from the non-due guardian pool (oldest lastReviewedDay
+  // first).
+  const guardianMap = {
+    address: { reviewLevel: 0, lastReviewedDay: TODAY - 3, nextDueDay: TODAY - 3, correctStreak: 0, lapses: 1, renewals: 0, wobbling: true },
+    believe: { reviewLevel: 2, lastReviewedDay: TODAY - 14, nextDueDay: TODAY - 1, correctStreak: 2, lapses: 0, renewals: 0, wobbling: false },
+    // non-due guardians for top-up, varying lastReviewedDay
+    bicycle: { reviewLevel: 3, lastReviewedDay: TODAY - 20, nextDueDay: TODAY + 30, correctStreak: 3, lapses: 0, renewals: 0, wobbling: false },
+    breath: { reviewLevel: 3, lastReviewedDay: TODAY - 5, nextDueDay: TODAY + 30, correctStreak: 3, lapses: 0, renewals: 0, wobbling: false },
+    build: { reviewLevel: 3, lastReviewedDay: TODAY - 50, nextDueDay: TODAY + 30, correctStreak: 3, lapses: 0, renewals: 0, wobbling: false },
+  };
+  const selected = selectGuardianWords({
+    guardianMap,
+    progressMap: {}, // no lazy candidates
+    wordBySlug: WORD_BY_SLUG,
+    todayDay: TODAY,
+    length: 5,
+    random: () => 0.5,
+  });
+  // Order: due wobbling, due non-wobbling, then non-due by oldest lastReviewedDay.
+  // build (-50) < bicycle (-20) < breath (-5).
+  assert.deepEqual(selected, ['address', 'believe', 'build', 'bicycle', 'breath']);
+});
+
+test('selectGuardianWords with length=5 clamps at 5 and prefers wobbling-due', () => {
+  const guardianMap = {
+    accommodate: { reviewLevel: 1, lastReviewedDay: TODAY - 2, nextDueDay: TODAY - 1, correctStreak: 0, lapses: 1, renewals: 0, wobbling: true },
+    address: { reviewLevel: 0, lastReviewedDay: TODAY - 3, nextDueDay: TODAY - 3, correctStreak: 0, lapses: 1, renewals: 0, wobbling: true },
+    believe: { reviewLevel: 2, lastReviewedDay: TODAY - 14, nextDueDay: TODAY - 1, correctStreak: 2, lapses: 0, renewals: 0, wobbling: false },
+    bicycle: { reviewLevel: 1, lastReviewedDay: TODAY - 3, nextDueDay: TODAY, correctStreak: 1, lapses: 0, renewals: 0, wobbling: false },
+    breath: { reviewLevel: 0, lastReviewedDay: TODAY - 3, nextDueDay: TODAY, correctStreak: 0, lapses: 0, renewals: 0, wobbling: false },
+  };
+  const selected = selectGuardianWords({
+    guardianMap,
+    progressMap: {},
+    wordBySlug: WORD_BY_SLUG,
+    todayDay: TODAY,
+    length: 5,
+  });
+  assert.equal(selected.length, 5);
+  assert.deepEqual(selected, ['address', 'accommodate', 'believe', 'bicycle', 'breath']);
+});
+
+test('selectGuardianWords with empty input returns an empty array', () => {
+  const selected = selectGuardianWords({
+    guardianMap: {},
+    progressMap: {},
+    wordBySlug: WORD_BY_SLUG,
+    todayDay: TODAY,
+  });
+  assert.deepEqual(selected, []);
+});
+
+test('selectGuardianWords clamps length above 8 back to GUARDIAN_MAX_ROUND_LENGTH', () => {
+  const guardianMap = {};
+  const progressMap = {};
+  for (let i = 0; i < 20; i += 1) {
+    const slug = WORDS.filter((w) => w.spellingPool !== 'extra')[i].slug;
+    progressMap[slug] = { stage: 4, attempts: 8, correct: 7, wrong: 1 };
+  }
+  const selected = selectGuardianWords({
+    guardianMap,
+    progressMap,
+    wordBySlug: WORD_BY_SLUG,
+    todayDay: TODAY,
+    length: 50,
+    random: () => 0.5,
+  });
+  assert.equal(selected.length, GUARDIAN_MAX_ROUND_LENGTH);
+});
+
+// ----- U3: session wiring via the real service ---------------------------------
+
+const DAY_MS_TS = 24 * 60 * 60 * 1000;
+
+function makeServiceWithSeed({ now, random, storage = installMemoryStorage() } = {}) {
+  const repositories = createLocalPlatformRepositories({ storage });
+  const spoken = [];
+  const service = createSpellingService({
+    repository: createSpellingPersistence({ repositories, now }),
+    now,
+    random,
+    tts: {
+      speak(payload) {
+        spoken.push(payload);
+      },
+      stop() {},
+      warmup() {},
+    },
+  });
+  return { storage, repositories, service, spoken };
+}
+
+function seedAllCoreMega(repositories, learnerId, todayDay) {
+  const progress = Object.fromEntries(
+    WORDS.filter((word) => word.spellingPool !== 'extra').map((word, index) => [word.slug, {
+      stage: 4,
+      attempts: 6 + (index % 4),
+      correct: 5 + (index % 4),
+      wrong: 1,
+      dueDay: todayDay + 60,
+      lastDay: todayDay - 7,
+      lastResult: 'correct',
+    }]),
+  );
+  repositories.subjectStates.writeData(learnerId, 'spelling', { progress });
+}
+
+function seedGuardianMap(repositories, learnerId, map) {
+  const current = repositories.subjectStates.read(learnerId, 'spelling').data || {};
+  repositories.subjectStates.writeData(learnerId, 'spelling', {
+    ...current,
+    guardian: map,
+  });
+}
+
+function runGuardianRoundUntilSummary(service, learnerId, state, getAnswerForSlug) {
+  const events = [];
+  const seenSlugs = [];
+  let current = state;
+  while (current.phase === 'session') {
+    const slug = current.session.currentCard.slug;
+    seenSlugs.push(slug);
+    const typed = getAnswerForSlug(slug, current);
+    const submitted = service.submitAnswer(learnerId, current, typed);
+    events.push(...submitted.events);
+    current = submitted.state;
+    assert.equal(current.awaitingAdvance, true, `awaitingAdvance after ${slug}`);
+    const continued = service.continueSession(learnerId, current);
+    events.push(...continued.events);
+    current = continued.state;
+  }
+  return { state: current, events, seenSlugs };
+}
+
+test('startSession({mode: guardian}) returns ok:false with warn feedback when allWordsMega is false', () => {
+  const now = () => Date.UTC(2026, 0, 10);
+  const { service } = makeServiceWithSeed({ now, random: () => 0.5 });
+  const transition = service.startSession('learner-a', { mode: 'guardian' });
+  assert.equal(transition.ok, false);
+  assert.equal(transition.state.phase, 'dashboard');
+  assert.equal(transition.state.session, null);
+  assert.equal(transition.state.feedback?.kind, 'warn');
+  assert.match(transition.state.feedback.headline, /Guardian Mission unlocks/);
+});
+
+test('startSession({mode: guardian}) with allWordsMega starts a guardian session of length 5..8', () => {
+  const now = () => Date.UTC(2026, 0, 10);
+  const today = Math.floor(now() / DAY_MS_TS);
+  const { service, repositories } = makeServiceWithSeed({ now, random: () => 0.5 });
+  seedAllCoreMega(repositories, 'learner-a', today);
+  const transition = service.startSession('learner-a', { mode: 'guardian' });
+  assert.equal(transition.ok, true);
+  assert.equal(transition.state.phase, 'session');
+  assert.equal(transition.state.session.mode, 'guardian');
+  assert.equal(transition.state.session.type, 'learning');
+  assert.equal(transition.state.session.label, 'Guardian Mission');
+  assert.ok(transition.state.session.uniqueWords.length >= GUARDIAN_MIN_ROUND_LENGTH);
+  assert.ok(transition.state.session.uniqueWords.length <= GUARDIAN_MAX_ROUND_LENGTH);
+  // All picked slugs must be core
+  const pickedWords = transition.state.session.uniqueWords.map((slug) => WORD_BY_SLUG[slug]);
+  assert.ok(pickedWords.every((w) => w.spellingPool !== 'extra'));
+});
+
+test('Full guardian round with all-correct answers emits N RENEWED + SESSION_COMPLETED + MISSION_COMPLETED', () => {
+  const now = () => Date.UTC(2026, 0, 10);
+  const today = Math.floor(now() / DAY_MS_TS);
+  const { service, repositories } = makeServiceWithSeed({ now, random: () => 0.5 });
+  seedAllCoreMega(repositories, 'learner-a', today);
+
+  const started = service.startSession('learner-a', { mode: 'guardian' });
+  const initialSlugs = started.state.session.uniqueWords.slice();
+  const totalWords = initialSlugs.length;
+
+  const { state: summaryState, events, seenSlugs } = runGuardianRoundUntilSummary(
+    service,
+    'learner-a',
+    started.state,
+    (slug, state) => state.session.currentCard.word.word,
+  );
+
+  assert.equal(summaryState.phase, 'summary');
+  const renewed = events.filter((e) => e.type === SPELLING_EVENT_TYPES.GUARDIAN_RENEWED);
+  const wobbled = events.filter((e) => e.type === SPELLING_EVENT_TYPES.GUARDIAN_WOBBLED);
+  const recovered = events.filter((e) => e.type === SPELLING_EVENT_TYPES.GUARDIAN_RECOVERED);
+  const sessionCompleted = events.filter((e) => e.type === SPELLING_EVENT_TYPES.SESSION_COMPLETED);
+  const missionCompleted = events.filter((e) => e.type === SPELLING_EVENT_TYPES.GUARDIAN_MISSION_COMPLETED);
+
+  assert.equal(renewed.length, totalWords, `one RENEWED per word (got ${renewed.length} for ${totalWords} words)`);
+  assert.equal(wobbled.length, 0);
+  assert.equal(recovered.length, 0);
+  assert.equal(sessionCompleted.length, 1);
+  assert.equal(missionCompleted.length, 1);
+
+  // MISSION_COMPLETED count fields match
+  const mission = missionCompleted[0];
+  assert.equal(mission.renewalCount, totalWords);
+  assert.equal(mission.wobbledCount, 0);
+  assert.equal(mission.recoveredCount, 0);
+  assert.equal(mission.totalWords, totalWords);
+
+  // Emission order: RENEWED events before SESSION_COMPLETED before MISSION_COMPLETED
+  const sessionCompletedIndex = events.findIndex((e) => e.type === SPELLING_EVENT_TYPES.SESSION_COMPLETED);
+  const missionCompletedIndex = events.findIndex((e) => e.type === SPELLING_EVENT_TYPES.GUARDIAN_MISSION_COMPLETED);
+  const lastRenewedIndex = events.map((e) => e.type).lastIndexOf(SPELLING_EVENT_TYPES.GUARDIAN_RENEWED);
+  assert.ok(lastRenewedIndex < sessionCompletedIndex, 'all RENEWED events emitted before SESSION_COMPLETED');
+  assert.ok(sessionCompletedIndex < missionCompletedIndex, 'SESSION_COMPLETED before MISSION_COMPLETED');
+
+  // progress.stage untouched for every Guardian word.
+  const snapshot = service.getAnalyticsSnapshot('learner-a');
+  const rowsBySlug = new Map(snapshot.wordGroups.flatMap((g) => g.words).map((row) => [row.slug, row]));
+  for (const slug of seenSlugs) {
+    const row = rowsBySlug.get(slug);
+    assert.equal(row.progress.stage, 4, `${slug} stage stays at 4`);
+  }
+  // progress.correct advanced by exactly 1 for each seen slug.
+  // (seed had correct = 5 + (index % 4) so exact values differ per slug; just assert the delta is 1)
+  for (const slug of seenSlugs) {
+    const row = rowsBySlug.get(slug);
+    const originalWord = WORDS.find((w) => w.slug === slug);
+    const originalIndex = WORDS.filter((w) => w.spellingPool !== 'extra').indexOf(originalWord);
+    const expectedCorrect = (5 + (originalIndex % 4)) + 1;
+    assert.equal(row.progress.correct, expectedCorrect, `${slug} progress.correct bumped once`);
+  }
+});
+
+test('Guardian round with a pre-wobbling word emits GUARDIAN_RECOVERED on correct, not RENEWED', () => {
+  const now = () => Date.UTC(2026, 0, 10);
+  const today = Math.floor(now() / DAY_MS_TS);
+  const storage = installMemoryStorage();
+  const { service, repositories } = makeServiceWithSeed({ now, random: () => 0.5, storage });
+  seedAllCoreMega(repositories, 'learner-a', today);
+
+  // Seed a wobbling guardian record for 'possess' so it gets picked first.
+  // With wobbling=true + nextDueDay<=today it wins the wobbling-due bucket.
+  seedGuardianMap(repositories, 'learner-a', {
+    possess: {
+      reviewLevel: 2,
+      lastReviewedDay: today - 5,
+      nextDueDay: today - 1,
+      correctStreak: 0,
+      lapses: 1,
+      renewals: 0,
+      wobbling: true,
+    },
+  });
+
+  const started = service.startSession('learner-a', { mode: 'guardian' });
+  assert.equal(started.ok, true);
+  // possess should appear first in the queue (wobbling-due).
+  assert.equal(started.state.session.uniqueWords[0], 'possess');
+  assert.equal(started.state.session.currentCard.slug, 'possess');
+
+  // Answer possess correctly.
+  const submitted = service.submitAnswer('learner-a', started.state, 'possess');
+  const recoveredEvents = submitted.events.filter((e) => e.type === SPELLING_EVENT_TYPES.GUARDIAN_RECOVERED);
+  const renewedEvents = submitted.events.filter((e) => e.type === SPELLING_EVENT_TYPES.GUARDIAN_RENEWED);
+  assert.equal(recoveredEvents.length, 1, 'RECOVERED emitted for wobbling->correct');
+  assert.equal(renewedEvents.length, 0, 'no RENEWED emitted on recovery');
+  assert.equal(recoveredEvents[0].wordSlug, 'possess');
+  assert.equal(recoveredEvents[0].reviewLevel, 2, 'reviewLevel preserved on recovery');
+  assert.equal(recoveredEvents[0].renewals, 1);
+});
+
+test('Guardian round with a mix of correct and wrong emits correct RENEWED + WOBBLED counts', () => {
+  const now = () => Date.UTC(2026, 0, 10);
+  const today = Math.floor(now() / DAY_MS_TS);
+  const { service, repositories } = makeServiceWithSeed({ now, random: () => 0.5 });
+  seedAllCoreMega(repositories, 'learner-a', today);
+
+  const started = service.startSession('learner-a', { mode: 'guardian' });
+  const totalWords = started.state.session.uniqueWords.length;
+
+  // Answer the first two wrong, the rest correct.
+  let cardCount = 0;
+  const { state: summaryState, events } = runGuardianRoundUntilSummary(
+    service,
+    'learner-a',
+    started.state,
+    (slug, state) => {
+      cardCount += 1;
+      if (cardCount <= 2) return 'definitely-wrong';
+      return state.session.currentCard.word.word;
+    },
+  );
+
+  assert.equal(summaryState.phase, 'summary');
+  const renewed = events.filter((e) => e.type === SPELLING_EVENT_TYPES.GUARDIAN_RENEWED);
+  const wobbled = events.filter((e) => e.type === SPELLING_EVENT_TYPES.GUARDIAN_WOBBLED);
+  const recovered = events.filter((e) => e.type === SPELLING_EVENT_TYPES.GUARDIAN_RECOVERED);
+  const mission = events.filter((e) => e.type === SPELLING_EVENT_TYPES.GUARDIAN_MISSION_COMPLETED);
+
+  assert.equal(wobbled.length, 2, 'two wrong answers emit two WOBBLED events');
+  assert.equal(renewed.length, totalWords - 2);
+  assert.equal(recovered.length, 0);
+  assert.equal(mission.length, 1);
+  assert.equal(mission[0].renewalCount, totalWords - 2);
+  assert.equal(mission[0].wobbledCount, 2);
+  assert.equal(mission[0].recoveredCount, 0);
+  assert.equal(mission[0].totalWords, totalWords);
+});
+
+test('Guardian round does not mutate progress.stage/dueDay/lastDay/lastResult even on wrong answers', () => {
+  const now = () => Date.UTC(2026, 0, 10);
+  const today = Math.floor(now() / DAY_MS_TS);
+  const { service, repositories } = makeServiceWithSeed({ now, random: () => 0.5 });
+  seedAllCoreMega(repositories, 'learner-a', today);
+
+  const started = service.startSession('learner-a', { mode: 'guardian' });
+  const initialSlugs = started.state.session.uniqueWords.slice();
+
+  // Answer everything wrong.
+  runGuardianRoundUntilSummary(service, 'learner-a', started.state, () => 'definitely-wrong');
+
+  const snapshot = service.getAnalyticsSnapshot('learner-a');
+  const rowsBySlug = new Map(snapshot.wordGroups.flatMap((g) => g.words).map((row) => [row.slug, row]));
+  for (const slug of initialSlugs) {
+    const row = rowsBySlug.get(slug);
+    assert.equal(row.progress.stage, 4, `${slug} stage unchanged after Guardian wrong`);
+    assert.equal(row.progress.dueDay, today + 60, `${slug} dueDay unchanged`);
+    assert.equal(row.progress.lastDay, today - 7, `${slug} lastDay unchanged`);
+    assert.equal(row.progress.lastResult, 'correct', `${slug} lastResult unchanged`);
+    // progress.attempts bumped and progress.wrong bumped by 1
+    assert.equal(row.progress.wrong, 2, `${slug} progress.wrong bumped`);
+  }
 });

--- a/tests/spelling-guardian.test.js
+++ b/tests/spelling-guardian.test.js
@@ -839,3 +839,92 @@ test('Guardian round does not mutate progress.stage/dueDay/lastDay/lastResult ev
     assert.equal(row.progress.wrong, 2, `${slug} progress.wrong bumped`);
   }
 });
+
+// ----- U3 review follow-up: CORR-1 regression + ADV-1 top-up priority ---------
+
+test('Guardian feedback body shows the correct number of days until the next check (CORR-1 regression)', () => {
+  // After a correct answer on a fresh record (reviewLevel 0->1), the schedule
+  // sets nextDueDay = today + GUARDIAN_INTERVALS[0] = today + 3. The feedback
+  // body must read "3 days", not "7" (the old bug indexed with updatedRecord.reviewLevel).
+  const now = () => Date.UTC(2026, 0, 10);
+  const today = Math.floor(now() / DAY_MS_TS);
+  const { service, repositories } = makeServiceWithSeed({ now, random: () => 0.2 });
+  seedAllCoreMega(repositories, 'learner-a', today);
+
+  const started = service.startSession('learner-a', { mode: 'guardian' });
+  const firstSlug = started.state.session.currentCard.slug;
+  const word = WORD_BY_SLUG[firstSlug];
+  const submitted = service.submitAnswer('learner-a', started.state, word.word);
+
+  assert.equal(submitted.state.feedback.kind, 'info');
+  assert.match(submitted.state.feedback.body, /Next Guardian check in 3 days\b/);
+});
+
+test('Guardian feedback body matches days-until-due for a recovered word (CORR-1 regression)', () => {
+  const now = () => Date.UTC(2026, 0, 10);
+  const today = Math.floor(now() / DAY_MS_TS);
+  const { service, repositories } = makeServiceWithSeed({ now, random: () => 0.5 });
+  seedAllCoreMega(repositories, 'learner-a', today);
+  // Seed a wobbling record at reviewLevel=2 so the recovery schedule uses
+  // GUARDIAN_INTERVALS[2] = 14 days.
+  seedGuardianMap(repositories, 'learner-a', {
+    possess: {
+      reviewLevel: 2,
+      lastReviewedDay: today - 5,
+      nextDueDay: today - 1,
+      correctStreak: 0,
+      lapses: 1,
+      renewals: 0,
+      wobbling: true,
+    },
+  });
+
+  const started = service.startSession('learner-a', { mode: 'guardian' });
+  assert.equal(started.state.session.currentCard.slug, 'possess');
+  const submitted = service.submitAnswer('learner-a', started.state, 'possess');
+
+  assert.equal(submitted.state.feedback.headline, 'Recovered.');
+  assert.match(submitted.state.feedback.body, /Next Guardian check in 14 days\b/);
+});
+
+test('selectGuardianWords top-up prefers wobbling non-due over non-wobbling non-due (ADV-1 regression)', () => {
+  const guardianMap = {
+    // Two non-due guardians: one wobbling (W), one stable (S). W should surface
+    // first during top-up even though both have nextDueDay > today, because
+    // wobbling status must not be demoted by the scheduler pushing nextDueDay
+    // one day forward after a miss.
+    believe: {
+      reviewLevel: 1,
+      lastReviewedDay: TODAY - 30, // older last review
+      nextDueDay: TODAY + 5,        // not due yet
+      correctStreak: 1,
+      lapses: 0,
+      renewals: 0,
+      wobbling: false,
+    },
+    possess: {
+      reviewLevel: 0,
+      lastReviewedDay: TODAY - 1,
+      nextDueDay: TODAY + 1,        // not due yet (wobbling set to +1 after miss)
+      correctStreak: 0,
+      lapses: 1,
+      renewals: 0,
+      wobbling: true,
+    },
+  };
+  const progressMap = {
+    believe: { stage: 4, attempts: 6, correct: 5, wrong: 1 },
+    possess: { stage: 4, attempts: 6, correct: 5, wrong: 1 },
+  };
+  const selected = selectGuardianWords({
+    guardianMap,
+    progressMap,
+    wordBySlug: WORD_BY_SLUG,
+    todayDay: TODAY,
+    length: 2,
+    random: () => 0.5,
+  });
+  // length=2 is below GUARDIAN_MIN_ROUND_LENGTH=5 after due is empty and no
+  // lazy candidates — top-up fills both slots; wobbling must land first.
+  assert.deepEqual(selected, ['possess', 'believe']);
+});

--- a/worker/src/subjects/spelling/engine.js
+++ b/worker/src/subjects/spelling/engine.js
@@ -15,6 +15,7 @@ const SUBJECT_ID = 'spelling';
 const SERVER_AUTHORITY = 'worker';
 const PREF_STORAGE_PREFIX = 'ks2-platform-v2.spelling-prefs.';
 const PROGRESS_STORAGE_PREFIX = 'ks2-spell-progress-';
+const GUARDIAN_STORAGE_PREFIX = 'ks2-spell-guardian-';
 
 function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -49,6 +50,9 @@ function parseStorageKey(key) {
   if (typeof key !== 'string') return null;
   if (key.startsWith(PREF_STORAGE_PREFIX)) {
     return { type: 'prefs', learnerId: key.slice(PREF_STORAGE_PREFIX.length) || 'default' };
+  }
+  if (key.startsWith(GUARDIAN_STORAGE_PREFIX)) {
+    return { type: 'guardian', learnerId: key.slice(GUARDIAN_STORAGE_PREFIX.length) || 'default' };
   }
   if (key.startsWith(PROGRESS_STORAGE_PREFIX)) {
     return { type: 'progress', learnerId: key.slice(PROGRESS_STORAGE_PREFIX.length) || 'default' };
@@ -121,12 +125,13 @@ function isServerOwnedRawUi(rawUi) {
 }
 
 function createServerPersistence({ learnerId, data, latestSession, now }) {
-  let nextData = normaliseServerSpellingData(data);
+  const resolveNow = () => (typeof now === 'function' ? now() : now);
+  let nextData = normaliseServerSpellingData(data, resolveNow());
   let practiceSession = null;
 
   function readDataFor(parsed) {
     if (parsed.learnerId && parsed.learnerId !== learnerId) {
-      return normaliseServerSpellingData({});
+      return normaliseServerSpellingData({}, resolveNow());
     }
     return nextData;
   }
@@ -139,6 +144,7 @@ function createServerPersistence({ learnerId, data, latestSession, now }) {
         const current = readDataFor(parsed);
         if (parsed.type === 'prefs') return JSON.stringify(current.prefs || {});
         if (parsed.type === 'progress') return JSON.stringify(current.progress || {});
+        if (parsed.type === 'guardian') return JSON.stringify(current.guardian || {});
         return null;
       },
       setItem(key, value) {
@@ -148,20 +154,27 @@ function createServerPersistence({ learnerId, data, latestSession, now }) {
           nextData = normaliseServerSpellingData({
             ...nextData,
             prefs: parseStoredJson(value, {}),
-          });
+          }, resolveNow());
         }
         if (parsed.type === 'progress') {
           nextData = normaliseServerSpellingData({
             ...nextData,
             progress: parseStoredJson(value, {}),
-          });
+          }, resolveNow());
+        }
+        if (parsed.type === 'guardian') {
+          nextData = normaliseServerSpellingData({
+            ...nextData,
+            guardian: parseStoredJson(value, {}),
+          }, resolveNow());
         }
       },
       removeItem(key) {
         const parsed = parseStorageKey(key);
         if (!parsed || (parsed.learnerId && parsed.learnerId !== learnerId)) return;
-        if (parsed.type === 'prefs') nextData = normaliseServerSpellingData({ ...nextData, prefs: {} });
-        if (parsed.type === 'progress') nextData = normaliseServerSpellingData({ ...nextData, progress: {} });
+        if (parsed.type === 'prefs') nextData = normaliseServerSpellingData({ ...nextData, prefs: {} }, resolveNow());
+        if (parsed.type === 'progress') nextData = normaliseServerSpellingData({ ...nextData, progress: {} }, resolveNow());
+        if (parsed.type === 'guardian') nextData = normaliseServerSpellingData({ ...nextData, guardian: {} }, resolveNow());
       },
     },
     syncPracticeSession(nextLearnerId, state) {
@@ -184,11 +197,11 @@ function createServerPersistence({ learnerId, data, latestSession, now }) {
     },
     resetLearner(nextLearnerId) {
       if (nextLearnerId !== learnerId) return;
-      nextData = normaliseServerSpellingData({});
+      nextData = normaliseServerSpellingData({}, resolveNow());
       practiceSession = null;
     },
     snapshot() {
-      return normaliseServerSpellingData(nextData);
+      return normaliseServerSpellingData(nextData, resolveNow());
     },
     practiceSession() {
       return practiceSession ? cloneSerialisable(practiceSession) : null;


### PR DESCRIPTION
## Summary

Plan U3 — the heart of the Guardian layer. Pure scheduler helpers + session wiring in `shared/spelling/service.js`, plus persistence plumbing in client repository and Worker engine so guardian records round-trip through `data.guardian` for real.

**No UI surfaces, no reward subscribers.** Both are later units / P2+.

## What ships

### Pure scheduler (exported from `shared/spelling/service.js`)

- `advanceGuardianOnCorrect(record, todayDay)` — non-wobbling bumps reviewLevel (capped at 5) + `correctStreak`, schedules via `GUARDIAN_INTERVALS[nextLevel]`. Wobbling recovery clears wobbling, bumps `renewals`, **preserves reviewLevel**, resumes schedule from current level.
- `advanceGuardianOnWrong(record, todayDay)` — sets `wobbling: true`, bumps `lapses`, resets `correctStreak`, schedules +1 day. `reviewLevel` unchanged.
- `ensureGuardianRecord(guardianMap, slug, todayDay)` — idempotent lazy-create on first touch.
- `selectGuardianWords({...})` — priority: wobbling-due → non-wobbling-due → deterministic lazy-create sample → top-up from non-due guardians (only below min round length).

### Session wiring

- `startSession({mode: 'guardian'})` gates on `allWordsMega` (core-pool `stage >= 4` count === core word total). Fails closed with `{ok: false, state.feedback: {kind: 'warn', ...}}` when not unlocked.
- `submitAnswer` for guardian mode: single-attempt grading. Bumps `progress.attempts/correct/wrong` (so Word Bank accuracy reflects Guardian recall) but **NEVER** touches `progress.stage` / `dueDay` / `lastDay` / `lastResult`. Applies the right advance* per outcome. Emits the right one of `GUARDIAN_RENEWED` / `GUARDIAN_WOBBLED` / `GUARDIAN_RECOVERED` per word.
- Session finalisation emits BOTH `SESSION_COMPLETED` (for streak/analytics parity) AND `GUARDIAN_MISSION_COMPLETED` with accurate renewal/wobbled/recovered counts.

### Persistence plumbing (new `ks2-spell-guardian-` storage prefix)

- `src/subjects/spelling/repository.js` — `parseStorageKey` + storage proxy route the new prefix through `subjectStates.data.guardian`. `normaliseSpellingSubjectData` now takes a `todayDay` arg so the client repo back-fills nextDueDay defaults consistently with the U1 normaliser.
- `worker/src/subjects/spelling/engine.js` — same prefix recognised on the Worker side. `createServerPersistence` resolves its injected clock once per write (addresses a nit flagged in the U1 review about per-call `Date.now()` drift).

## Invariant guarantees

- Mega is **never** revoked. A wrong answer in a Guardian round marks `wobbling: true` on the guardian sibling record; `progress.stage === 4` stays intact. Asserted directly in test `Guardian round does not mutate progress.stage/dueDay/lastDay/lastResult even on wrong answers`.
- Parity: smart / trouble / test / single modes unchanged. All existing spelling parity tests still pass.

## Plan reference

Ships U3 from [`docs/plans/james/post-mega-spelling/2026-04-25-003-feat-post-mega-spelling-mvp-plan.md`](docs/plans/james/post-mega-spelling/2026-04-25-003-feat-post-mega-spelling-mvp-plan.md).

## Test plan

- [x] `node --test tests/spelling-guardian.test.js tests/spelling.test.js tests/spelling-parity.test.js tests/server-spelling-engine-parity.test.js tests/spelling-view-model.test.js tests/spelling-optimistic-prefs.test.js tests/react-spelling-surface.test.js tests/persistence.test.js` — 123/123 pass.
- [x] 17 new U3 scenarios covering: scheduler invariants (all 4 advance paths), selection priority + top-up, `ensureGuardianRecord` idempotency, startSession gate on allWordsMega (both outcomes), full all-correct round, full mixed round, full all-wrong round (asserts progress.stage/dueDay/lastDay preserved), pre-wobbling-seeded slug emits GUARDIAN_RECOVERED (not RENEWED) on correct, GUARDIAN_MISSION_COMPLETED count accuracy.

## Files changed

- `shared/spelling/service.js` — 582 lines added (pure helpers + session wiring)
- `src/subjects/spelling/repository.js` — guardian storage prefix + todayDay plumbing
- `worker/src/subjects/spelling/engine.js` — guardian storage prefix + resolveNow helper
- `tests/spelling-guardian.test.js` — 17 new scenarios (474 added)