### PR TITLE
fix(tests): normalise CRLF in effect-config frozen-fixture comparison

### DIFF
--- a/tests/effect-config-defaults.test.js
+++ b/tests/effect-config-defaults.test.js
@@ -162,6 +162,10 @@ test('bundledEffectConfig: serialised output matches frozen fixture', () => {
     existsSync(FIXTURE_PATH),
     `Fixture missing at ${FIXTURE_PATH}. Run with UPDATE_EFFECT_CONFIG_FIXTURE=1 to create it.`,
   );
-  const expected = readFileSync(FIXTURE_PATH, 'utf8').replace(/\n$/, '');
+  // Normalise CRLF -> LF before comparing: on Windows with
+  // `core.autocrlf=true`, the LF-committed fixture is CRLF in the working
+  // copy, while stableStringify produces LF in memory. The golden's
+  // semantic content is LF; CRLF is a checkout-time artefact.
+  const expected = readFileSync(FIXTURE_PATH, 'utf8').replace(/\r\n/g, '\n').replace(/\n$/, '');
   assert.equal(serialised, expected);
 });


### PR DESCRIPTION
## Summary

- Fixes `tests/effect-config-defaults.test.js` "bundledEffectConfig: serialised output matches frozen fixture" — was failing on Windows on every line of an 1800+ line JSON snapshot because of CRLF vs LF mismatch.
- One-line change: `.replace(/\r\n/g, '\n')` ahead of the existing trailing-newline strip, with a why-comment.

## Root cause

Git's `core.autocrlf=true` (the default on Windows) converts the LF-committed fixture `tests/fixtures/effect-config-bundled.snapshot.json` to CRLF in the working copy on checkout. `stableStringify(bundledEffectConfig())` produces pure LF in memory. The comparison mismatches on every line.

The fixture's semantic content is LF — CRLF is a checkout-time artefact, not a property of the data. Normalising at read-time is the right layer to fix it: it treats the fixture as a logical LF-terminated string regardless of how the OS presented it to `readFileSync`.

## Test plan

- [x] `node --test tests/effect-config-defaults.test.js` → 14/14 pass (was 13/14).
- [x] `npm test` → 1151 pass, 0 fail, 1 skipped (was 1150/1/1). The 1 skip is `KS2_BROWSER_SMOKE`-gated.
- [x] No behavioural change on Unix: the regex is a no-op when the working copy is already LF, so Linux/macOS CI output is unchanged.
- [x] The fixture itself stays LF in git — no `.gitattributes` or fixture re-encoding needed.

## Alternatives considered

- **`.gitattributes` with `tests/fixtures/*.snapshot.json text eol=lf`** — would prevent autocrlf conversion on checkout. More "correct" at the git layer but affects how all fixtures land across every contributor's working copy; wider blast radius. Deferred in favour of the surgical test-level fix.
- **Update fixture with UPDATE_EFFECT_CONFIG_FIXTURE=1** — would trade one platform's line endings for the other's, not resolve the root cause.

Surfaced as a follow-up during verification of the plan at `docs/plans/2026-04-25-004-fix-test-failures-env-and-windows-cli-plan.md`.