### PR TITLE
fix(scripts): enable shell mode for cross-platform wrangler-oauth spawn

### DIFF
--- a/scripts/wrangler-oauth.mjs
+++ b/scripts/wrangler-oauth.mjs
@@ -14,10 +14,17 @@ if (!isWorkersBuild) {
   delete env.CLOUDFLARE_API_TOKEN;
 }
 
+// `shell: true` is required on Windows for Node >= 20 to spawn `.cmd`
+// files: without it, spawnSync rejects with EINVAL (a security hardening
+// introduced in the Node 20.x line against CVE-2024-27980). Shell-quoting
+// wranglerArgs is safe here because they come from package.json scripts,
+// not user input. On POSIX, `shell: true` keeps behaviour unchanged for
+// our arg shape.
 const npxBin = process.platform === 'win32' ? 'npx.cmd' : 'npx';
 const result = spawnSync(npxBin, ['wrangler', ...wranglerArgs], {
   stdio: 'inherit',
   env,
+  shell: true,
 });
 
 if (result.error) {


### PR DESCRIPTION
## Summary

- Fixes `npm run check` on Windows, which was failing with `spawnSync npx.cmd EINVAL`.
- One-line change: `shell: true` added to the `spawnSync` options in `scripts/wrangler-oauth.mjs`, with a why-comment citing the Node CVE that drove the hardening.
- Affects every npm script routed through wrangler-oauth on Windows: `check`, `db:migrate:local`, `db:migrate:remote`, `db:backup:remote`, `db:reset:remote`, `ops:tail`, `deploy` — all previously broken on Windows, all now work.

## Root cause

Node 20.x hardened `spawnSync` against CVE-2024-27980 (batch file argument injection). One side effect: spawning `.cmd` / `.bat` files without `shell: true` now rejects with `EINVAL`. Our wrapper spawns `npx.cmd` on Windows and was hitting the hardened path.

`shell: true` routes the spawn through the Windows shell (`cmd.exe`), which can resolve `.cmd` extensions. Shell-quoting `wranglerArgs` is safe here because they come from `package.json` script definitions, not user input. On POSIX the option is effectively a no-op for our argument shape.

## Test plan

- [x] `npm run check` exits 0 on Windows — OAuth dry-run deploy completes, wrangler prints the binding list and `--dry-run: exiting now.`
- [x] `npm test` → 1206 pass, 0 fail, 1 skipped. No regression. (The 1 skip is the `KS2_BROWSER_SMOKE`-gated browser migration smoke.)
- [x] `spawnSync`'s arg array is unchanged — just the options bag grows by one field.
- [x] Error path preserved: when wrangler exits non-zero, `result.status` still propagates; when spawn itself fails, `result.error.message` is still surfaced.

## Security consideration

The comment documents why `shell: true` is safe in this specific wrapper: `wranglerArgs` come from the project's own `package.json` script definitions, never from untrusted input. Future contributors extending this wrapper should preserve that invariant or switch to passing an explicit full path + skipping shell.

Surfaced as a follow-up during verification of the plan at `docs/plans/2026-04-25-004-fix-test-failures-env-and-windows-cli-plan.md`.