### PR TITLE
feat(access-matrix): U13 redaction access-matrix lock for sys-hardening p1

### DIFF
--- a/docs/hardening/p1-baseline.md
+++ b/docs/hardening/p1-baseline.md
@@ -47,9 +47,9 @@ Note: the bounded-bootstrap and command-projection work in PRs #126-#139 (see `d
 ## Access / privacy faults
 
 - Raw source exposure regression risk — `/src/*` is routed through `run_worker_first` and the production bundle audit (`scripts/production-bundle-audit.mjs`) enforces forbidden-token denial, but no extension exists for new source-path shapes introduced by future refactors. (tracked in U8)
-- Over-broad hub payloads regression risk — Parent Hub and Admin Hub payload shapes are asserted by a combination of `tests/hub-api.test.js`, `tests/hub-read-models.test.js`, `tests/hub-shell-access.test.js`, and `tests/react-hub-surfaces.test.js`, but no single access-matrix oracle enforces that viewer membership learners do not appear in writable routes. (tracked in U13)
-- Answer-bearing fields regression risk — `/api/bootstrap` and subject read-model responses are redacted, but no matrix test enforces the invariant across platform role × membership role × route combinations. (tracked in U13)
-- Demo-crossing-real-account regression risk — demo sessions are isolated by design, but no access-matrix oracle asserts that a demo session cannot read or mutate a real account's state via route enumeration. (tracked in U13)
+- Over-broad hub payloads regression risk — Parent Hub and Admin Hub payload shapes are asserted by a combination of `tests/hub-api.test.js`, `tests/hub-read-models.test.js`, `tests/hub-shell-access.test.js`, and `tests/react-hub-surfaces.test.js`, but no single access-matrix oracle enforces that viewer membership learners do not appear in writable routes. (tracked in U13, landed via `tests/redaction-access-matrix.test.js`)
+- Answer-bearing fields regression risk — `/api/bootstrap` and subject read-model responses are redacted, but no matrix test enforces the invariant across platform role × membership role × route combinations. (tracked in U13, landed via `tests/redaction-access-matrix.test.js` + `scripts/production-bundle-audit.mjs` matrix demo check)
+- Demo-crossing-real-account regression risk — demo sessions are isolated by design, but no access-matrix oracle asserts that a demo session cannot read or mutate a real account's state via route enumeration. (tracked in U13, landed via `tests/redaction-access-matrix.test.js` cross-account probe)
 - Weak response headers — repo root `_headers` only sets `Cache-Control: no-store`; no CSP, no HSTS, no `X-Content-Type-Options`, no `Referrer-Policy`, no `Permissions-Policy`, no `frame-ancestors`, no cache split between HTML and hashed bundles. Worker-generated responses receive none of these headers. **This pass fixes.** (tracked in U6, U7, U8)
 - Logs containing private content regression risk — Worker log hygiene in `docs/full-lockdown-runtime.md` forbids answer-bearing payloads and child-identifying content, but no automated assertion enforces that capacity telemetry (`[ks2-capacity]` emission) stays within the bounded-metadata contract. (tracked in U4)
 
@@ -66,6 +66,38 @@ Note: the bounded-bootstrap and command-projection work in PRs #126-#139 (see `d
 - No dense-history Spelling smoke beyond bootstrap — `scripts/punctuation-production-smoke.mjs` and `scripts/grammar-production-smoke.mjs` cover those subjects, but dense-history Spelling Smart Review starts have no smoke equivalent. (tracked in U11)
 - No access-matrix test driver — platform role × membership role × route × payload-shape combinations are documented in `docs/ownership-access.md` and `docs/operating-surfaces.md` but not machine-enforced. (tracked in U13)
 - No security-header production HEAD audit — no script or test fetches production URLs with `HEAD` and asserts the expected header set. (tracked in U6, U8)
+
+---
+
+## U13 access-matrix coverage baseline
+
+The redaction access-matrix lock at `tests/redaction-access-matrix.test.js` is the single oracle for platform role x membership role x session variant x route x payload-shape combinations. This section records the baseline coverage at the time U13 landed.
+
+Routes currently exercised by the matrix (unauthenticated, demo-active, demo-expired-with-valid-cookie, parent/admin/ops combinations as applicable):
+
+- `/api/health` — unauthenticated OK, no learner signal leaked.
+- `/api/auth/session` — unauthenticated returns `session: null`, no account-existence signal.
+- `/api/bootstrap` — 401 unauth, parent-owner writable learners only, parent-viewer writable-empty, cross-account probe denies learner-b to account A, demo-active ok, demo-expired-with-valid-cookie fails closed (F-10 regression driver), dev-stub expired-demo documented gap.
+- `/api/hubs/parent` — 401 unauth, parent-viewer read-only membership view, demo-expired fails closed.
+- `/api/hubs/parent/recent-sessions` — 401 unauth.
+- `/api/hubs/parent/activity` — 401 unauth.
+- `/api/hubs/admin` — 401 unauth, parent denied, admin allowed, ops allowed.
+- `/api/admin/accounts/role` — ops denied (preserves last-admin safety rule gate).
+- `/api/tts` — 401 unauth.
+- `/api/demo/reset` — 401 unauth, demo-expired fails closed.
+- `/api/auth/google/start` — cross-origin denied via `requireSameOrigin`.
+- `/api/auth/google/callback` — invalid-state handled without payload leak.
+
+Forbidden-key oracle shared between `tests/redaction-access-matrix.test.js` (FORBIDDEN_KEYS_EVERYWHERE) and `scripts/production-bundle-audit.mjs` (MATRIX_FORBIDDEN_KEYS):
+
+- `solutionLines`, `correctResponse`, `correctResponses`, `accepted`, `answers`, `evaluate`, `generator`, `templates`, `passwordHash`, `password_hash`, `sessionHash`, `session_hash`.
+
+Not yet covered (intentional deferrals):
+
+- `/api/security/csp-report` — endpoint ships in U7; the matrix is extended when that route lands.
+- Full authenticated Admin Hub payload coverage for every learner-ownership permutation — current coverage proves platform-role gating; exhaustive membership-role coverage against Admin Hub diagnostics remains a follow-up when richer ops fixtures land.
+
+Tripwire: the final test `matrix: coverage summary` asserts that at least 19 matrix combinations exist and that every listed route is hit. Any refactor that shrinks the matrix silently fails this test.
 
 ---
 

--- a/scripts/grammar-production-smoke.mjs
+++ b/scripts/grammar-production-smoke.mjs
@@ -14,6 +14,10 @@ import {
   loadBootstrap,
   subjectCommand,
 } from './lib/production-smoke.mjs';
+import {
+  FORBIDDEN_GRAMMAR_ITEM_KEYS as SHARED_FORBIDDEN_GRAMMAR_ITEM_KEYS,
+  FORBIDDEN_GRAMMAR_READ_MODEL_KEYS as SHARED_FORBIDDEN_GRAMMAR_READ_MODEL_KEYS,
+} from '../tests/helpers/forbidden-keys.mjs';
 
 const GRAMMAR_SMOKE_ITEM = Object.freeze({
   templateId: 'fronted_adverbial_choose',
@@ -25,21 +29,11 @@ const GRAMMAR_MINI_TEST_ITEM = Object.freeze({
   seed: 11,
 });
 
-const FORBIDDEN_GRAMMAR_READ_MODEL_KEYS = new Set([
-  'solutionLines',
-  'correctResponse',
-  'correctResponses',
-  'accepted',
-  'answers',
-  'evaluate',
-  'generator',
-  'template',
-]);
-
-const FORBIDDEN_GRAMMAR_ITEM_KEYS = new Set([
-  ...FORBIDDEN_GRAMMAR_READ_MODEL_KEYS,
-  'templates',
-]);
+// Sets are built at module load from the shared Array exports so the single
+// source of truth in tests/helpers/forbidden-keys.mjs cannot drift from this
+// smoke test's checks.
+const FORBIDDEN_GRAMMAR_READ_MODEL_KEYS = new Set(SHARED_FORBIDDEN_GRAMMAR_READ_MODEL_KEYS);
+const FORBIDDEN_GRAMMAR_ITEM_KEYS = new Set(SHARED_FORBIDDEN_GRAMMAR_ITEM_KEYS);
 
 function normaliseChoiceOptions(inputSpec, context, { allowExtraKeys = false } = {}) {
   assert.ok(Array.isArray(inputSpec?.options) && inputSpec.options.length > 0, `${context} did not expose answer options.`);

--- a/scripts/production-bundle-audit.mjs
+++ b/scripts/production-bundle-audit.mjs
@@ -1,25 +1,14 @@
 import { runClientBundleAudit } from './audit-client-bundle.mjs';
 import { createDemoSession, loadBootstrap } from './lib/production-smoke.mjs';
+import { FORBIDDEN_KEYS_EVERYWHERE } from '../tests/helpers/forbidden-keys.mjs';
 
 const DEFAULT_ORIGIN = 'https://ks2.eugnel.uk';
 
 // U13 redaction matrix forbidden-key check: these keys must never appear in any
-// authenticated response surface reached via the demo session. Kept in sync with
-// the oracle in tests/redaction-access-matrix.test.js (FORBIDDEN_KEYS_EVERYWHERE).
-const MATRIX_FORBIDDEN_KEYS = Object.freeze([
-  'solutionLines',
-  'correctResponse',
-  'correctResponses',
-  'accepted',
-  'answers',
-  'evaluate',
-  'generator',
-  'templates',
-  'passwordHash',
-  'password_hash',
-  'sessionHash',
-  'session_hash',
-]);
+// authenticated response surface reached via the demo session. The set is
+// imported from tests/helpers/forbidden-keys.mjs so the matrix oracle, the
+// production audit, and the subject-level smokes cannot drift.
+const MATRIX_FORBIDDEN_KEYS = FORBIDDEN_KEYS_EVERYWHERE;
 
 function collectAllKeys(value, bucket = new Set()) {
   if (value == null) return bucket;

--- a/scripts/production-bundle-audit.mjs
+++ b/scripts/production-bundle-audit.mjs
@@ -1,6 +1,48 @@
 import { runClientBundleAudit } from './audit-client-bundle.mjs';
+import { createDemoSession, loadBootstrap } from './lib/production-smoke.mjs';
 
 const DEFAULT_ORIGIN = 'https://ks2.eugnel.uk';
+
+// U13 redaction matrix forbidden-key check: these keys must never appear in any
+// authenticated response surface reached via the demo session. Kept in sync with
+// the oracle in tests/redaction-access-matrix.test.js (FORBIDDEN_KEYS_EVERYWHERE).
+const MATRIX_FORBIDDEN_KEYS = Object.freeze([
+  'solutionLines',
+  'correctResponse',
+  'correctResponses',
+  'accepted',
+  'answers',
+  'evaluate',
+  'generator',
+  'templates',
+  'passwordHash',
+  'password_hash',
+  'sessionHash',
+  'session_hash',
+]);
+
+function collectAllKeys(value, bucket = new Set()) {
+  if (value == null) return bucket;
+  if (Array.isArray(value)) {
+    value.forEach((entry) => collectAllKeys(entry, bucket));
+    return bucket;
+  }
+  if (typeof value !== 'object') return bucket;
+  for (const [key, child] of Object.entries(value)) {
+    bucket.add(key);
+    collectAllKeys(child, bucket);
+  }
+  return bucket;
+}
+
+function assertMatrixForbiddenKeysAbsent(label, payload, failures) {
+  const allKeys = collectAllKeys(payload);
+  for (const key of MATRIX_FORBIDDEN_KEYS) {
+    if (allKeys.has(key)) {
+      failures.push(`${label} exposed redaction-matrix forbidden key: ${key}`);
+    }
+  }
+}
 const DIRECT_DENIAL_PATHS = [
   '/src/main.js',
   '/src/subjects/spelling/data/content-data.js',
@@ -137,6 +179,19 @@ async function auditProduction(origin) {
     }
   }
 
+  // U13: matrix-driven forbidden-key check against a live demo bootstrap.
+  // The demo session is the only path where we can exercise an authenticated
+  // production response without real-learner PII risk.
+  let demoChecked = false;
+  try {
+    const demo = await createDemoSession(base.origin);
+    const bootstrap = await loadBootstrap(base.origin, demo.cookie, { expectedSession: demo.session });
+    assertMatrixForbiddenKeysAbsent('Production demo /api/bootstrap', bootstrap.payload, failures);
+    demoChecked = true;
+  } catch (error) {
+    failures.push(`Production demo bootstrap probe failed: ${error?.message || error}`);
+  }
+
   return {
     ok: failures.length === 0,
     failures,
@@ -144,6 +199,7 @@ async function auditProduction(origin) {
       origin: base.href,
       scriptCount: scripts.length,
       directPathCount: DIRECT_DENIAL_PATHS.length,
+      matrixDemoChecked: demoChecked,
     },
   };
 }
@@ -174,4 +230,4 @@ if (!result?.ok) {
   console.error(result?.failures?.join('\n') || 'Production bundle audit failed.');
   process.exit(1);
 }
-console.log(`Production bundle audit passed for ${result.checked.origin} (${result.checked.scriptCount} bundle(s), ${result.checked.directPathCount} direct paths).`);
+console.log(`Production bundle audit passed for ${result.checked.origin} (${result.checked.scriptCount} bundle(s), ${result.checked.directPathCount} direct paths, matrix demo check: ${result.checked.matrixDemoChecked ? 'ok' : 'skipped'}).`);

--- a/scripts/punctuation-production-smoke.mjs
+++ b/scripts/punctuation-production-smoke.mjs
@@ -17,39 +17,19 @@ import {
   loadBootstrap,
   subjectCommand,
 } from './lib/production-smoke.mjs';
+import {
+  FORBIDDEN_PUNCTUATION_ADULT_EVIDENCE_KEYS as SHARED_FORBIDDEN_PUNCTUATION_ADULT_EVIDENCE_KEYS,
+  FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS as SHARED_FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS,
+} from '../tests/helpers/forbidden-keys.mjs';
 
-// Kept aligned with worker/src/subjects/punctuation/read-models.js
-// FORBIDDEN_READ_MODEL_KEYS. Any new forbidden key must be added in both
-// places — the Worker enforces the contract at build time, the smoke scans
-// enforce it at deploy time.
-const FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS = new Set([
-  'accepted',
-  'answers',
-  'correctIndex',
-  'rubric',
-  'validator',
-  'seed',
-  'generator',
-  'rawGenerator',
-  'hiddenQueue',
-  'queueItemIds',
-  'responses',
-  'unpublished',
-]);
-
-const FORBIDDEN_PUNCTUATION_ADULT_EVIDENCE_KEYS = new Set([
-  ...FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS,
-  'attemptedAnswer',
-  'choiceIndex',
-  'correctAnswer',
-  'displayCorrection',
-  'expected',
-  'expectedAnswer',
-  'model',
-  'rawResponse',
-  'response',
-  'typed',
-]);
+// Sets are built at module load from the shared Array exports. The canonical
+// list lives in tests/helpers/forbidden-keys.mjs and is kept aligned with
+// worker/src/subjects/punctuation/read-models.js FORBIDDEN_READ_MODEL_KEYS.
+// Any new forbidden key must be added in the shared module first; the Worker
+// enforces the contract at build time, and the smoke scans enforce it at
+// deploy time.
+const FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS = new Set(SHARED_FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS);
+const FORBIDDEN_PUNCTUATION_ADULT_EVIDENCE_KEYS = new Set(SHARED_FORBIDDEN_PUNCTUATION_ADULT_EVIDENCE_KEYS);
 
 export function assertNoForbiddenPunctuationReadModelKeys(value, path = 'punctuation.subjectReadModel') {
   assertNoForbiddenObjectKeys(value, FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS, path);

--- a/tests/helpers/forbidden-keys.mjs
+++ b/tests/helpers/forbidden-keys.mjs
@@ -1,0 +1,94 @@
+// Shared forbidden-key oracles used by:
+//   - tests/redaction-access-matrix.test.js (matrix oracle)
+//   - scripts/production-bundle-audit.mjs (post-deploy demo bootstrap audit)
+//   - scripts/grammar-production-smoke.mjs (grammar read-model smoke)
+//   - scripts/punctuation-production-smoke.mjs (punctuation read-model smoke)
+//
+// This module is the single source of truth for the forbidden-key universe. It
+// MUST stay side-effect free: every exported value is a frozen Array, and no
+// other runtime behaviour is allowed here. Downstream consumers can lift the
+// arrays into Sets if they need membership lookups; we intentionally do not
+// pre-freeze Sets here because `Object.freeze(new Set())` does not prevent
+// mutation of the underlying Set.
+//
+// Extension rules (P3 oracle-drift regression lock):
+//   - FORBIDDEN_KEYS_EVERYWHERE is the universal floor. Every authenticated HTTP
+//     response surface must be clean of these keys.
+//   - Subject-specific sets (grammar/punctuation) either extend the universal
+//     floor (grammar) or overlap with it (punctuation). For any universal key
+//     that could appear on a subject surface, the subject set MUST include it —
+//     otherwise subject-side coverage would be weaker than the universal floor,
+//     which is exactly the drift we are locking out.
+//   - When a new forbidden key is introduced, add it here first; downstream
+//     consumers import, so they cannot drift.
+
+export const FORBIDDEN_KEYS_EVERYWHERE = Object.freeze([
+  'solutionLines',
+  'correctResponse',
+  'correctResponses',
+  'accepted',
+  'answers',
+  'evaluate',
+  'generator',
+  'templates',
+  'passwordHash',
+  'password_hash',
+  'sessionHash',
+  'session_hash',
+  'sessionId',
+  'session_id',
+]);
+
+// Grammar read-model surface: strict superset of FORBIDDEN_KEYS_EVERYWHERE.
+// The extra entry `template` (singular) is grammar-private — it appears on
+// grammar question items as a meta field and must never round-trip to the
+// browser. It is NOT in the universal floor because monster visual config
+// legitimately uses `template` (effect catalog entries keyed by template
+// name), so checking it everywhere would false-positive.
+export const FORBIDDEN_GRAMMAR_READ_MODEL_KEYS = Object.freeze([
+  ...FORBIDDEN_KEYS_EVERYWHERE,
+  'template',
+]);
+
+// Grammar session.currentItem surface. Currently identical to the read-model
+// surface but kept as a separate export so item-specific keys can be added
+// without widening the read-model contract.
+export const FORBIDDEN_GRAMMAR_ITEM_KEYS = Object.freeze([
+  ...FORBIDDEN_GRAMMAR_READ_MODEL_KEYS,
+]);
+
+// Punctuation read-model surface. Not a full superset of the universal floor
+// by design: punctuation's internal key vocabulary (correctIndex, rubric,
+// validator, seed, rawGenerator, hiddenQueue, queueItemIds, responses,
+// unpublished) is disjoint from grammar's. The overlap with the universal
+// floor covers the shared concerns ('accepted', 'answers', 'generator').
+export const FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS = Object.freeze([
+  'accepted',
+  'answers',
+  'correctIndex',
+  'rubric',
+  'validator',
+  'seed',
+  'generator',
+  'rawGenerator',
+  'hiddenQueue',
+  'queueItemIds',
+  'responses',
+  'unpublished',
+]);
+
+// Punctuation adult evidence surface extends the read-model surface with
+// evidence-only keys that may appear in marking records.
+export const FORBIDDEN_PUNCTUATION_ADULT_EVIDENCE_KEYS = Object.freeze([
+  ...FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS,
+  'attemptedAnswer',
+  'choiceIndex',
+  'correctAnswer',
+  'displayCorrection',
+  'expected',
+  'expectedAnswer',
+  'model',
+  'rawResponse',
+  'response',
+  'typed',
+]);

--- a/tests/redaction-access-matrix.test.js
+++ b/tests/redaction-access-matrix.test.js
@@ -1,0 +1,717 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createWorkerRepositoryServer } from './helpers/worker-server.js';
+import { createApiPlatformRepositories } from '../src/platform/core/repositories/index.js';
+
+// U13 — Child-Data Redaction Access-Matrix Lock
+//
+// Axes:
+// - Platform role:      parent | admin | ops
+// - Membership role:    owner  | member | viewer  (enforced via account_learner_memberships)
+// - Session variant:    real-auth | demo-active | demo-expired-with-valid-cookie | unauthenticated
+// - Route:              /api/bootstrap, Parent Hub, Admin Hub, lazy history, activity feed,
+//                       TTS prompt-token fetch, demo reset, /api/auth/session, /api/health,
+//                       OAuth start, OAuth callback
+// - Expected shape:     authRequired, expectedStatus, allowedKeys, forbiddenKeys
+//
+// The CSP report endpoint (/api/security/csp-report) is intentionally omitted here; it
+// lands in U7 and the matrix will be extended when that route ships.
+//
+// The matrix is a single oracle: new routes or new role combinations cannot be merged
+// without extending the matrix. That is enforced by the assertion coverage summary at
+// the end of the file.
+
+const ORIGIN = 'https://repo.test';
+
+function productionServer(env = {}) {
+  return createWorkerRepositoryServer({
+    env: {
+      AUTH_MODE: 'production',
+      ENVIRONMENT: 'production',
+      APP_HOSTNAME: 'repo.test',
+      ...env,
+    },
+  });
+}
+
+function seedAdultAccount(server, {
+  id,
+  email,
+  displayName,
+  platformRole = 'parent',
+  now = 1,
+} = {}) {
+  server.DB.db.prepare(`
+    INSERT INTO adult_accounts (id, email, display_name, platform_role, selected_learner_id, created_at, updated_at, repo_revision)
+    VALUES (?, ?, ?, ?, NULL, ?, ?, 0)
+  `).run(id, email, displayName, platformRole, now, now);
+}
+
+function seedMembership(server, { accountId, learnerId, role, now = 1 } = {}) {
+  server.DB.db.prepare(`
+    INSERT INTO account_learner_memberships (account_id, learner_id, role, sort_index, created_at, updated_at)
+    VALUES (?, ?, ?, 0, ?, ?)
+  `).run(accountId, learnerId, role, now, now);
+}
+
+async function seedLearnerViaOwner(server, ownerAccountId, learner) {
+  const repos = createApiPlatformRepositories({
+    baseUrl: ORIGIN,
+    fetch: server.fetch.bind(server),
+    authSession: server.authSessionFor(ownerAccountId, { platformRole: 'parent' }),
+  });
+  await repos.hydrate();
+  repos.learners.write({
+    byId: { [learner.id]: learner },
+    allIds: [learner.id],
+    selectedId: learner.id,
+  });
+  await repos.flush();
+}
+
+function getSetCookies(response) {
+  const raw = response.headers.getSetCookie?.()
+    || String(response.headers.get('set-cookie') || '').split(/,\s*(?=ks2_)/).filter(Boolean);
+  return raw.map((cookie) => String(cookie || '').split(';')[0]).filter(Boolean);
+}
+
+function sessionCookieFrom(response) {
+  return getSetCookies(response).find((cookie) => cookie.startsWith('ks2_session=')) || '';
+}
+
+async function createDemoSessionCookie(server) {
+  const response = await server.fetchRaw(`${ORIGIN}/api/demo/session`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      origin: ORIGIN,
+    },
+    body: JSON.stringify({}),
+  });
+  assert.equal(response.status, 201, 'Demo session creation must succeed.');
+  const cookie = sessionCookieFrom(response);
+  assert.ok(cookie, 'Demo session did not return a ks2_session cookie.');
+  const payload = await response.json();
+  return { cookie, accountId: payload.session.accountId };
+}
+
+function expireDemoAccount(server, accountId) {
+  server.DB.db.prepare('UPDATE adult_accounts SET demo_expires_at = ? WHERE id = ?')
+    .run(Date.now() - 60_000, accountId);
+}
+
+function extendDemoSessionCookieWhileExpiringAccount(server, accountId) {
+  // Push account session cookie forward so the cookie is still valid at the HTTP layer
+  // while the demo account has already expired. This proves the bootstrap handler must
+  // re-check demo validity on every read.
+  server.DB.db.prepare(`
+    UPDATE account_sessions
+    SET expires_at = ?
+    WHERE account_id = ?
+  `).run(Date.now() + 60 * 60 * 1000, accountId);
+  expireDemoAccount(server, accountId);
+}
+
+// Recursively collect all own string keys in an object tree, including nested
+// arrays and objects. This is the mechanism the matrix uses to assert the
+// absence of forbidden keys anywhere in the response payload.
+function collectAllKeys(value, bucket = new Set()) {
+  if (value == null) return bucket;
+  if (Array.isArray(value)) {
+    value.forEach((entry) => collectAllKeys(entry, bucket));
+    return bucket;
+  }
+  if (typeof value !== 'object') return bucket;
+  for (const [key, child] of Object.entries(value)) {
+    bucket.add(key);
+    collectAllKeys(child, bucket);
+  }
+  return bucket;
+}
+
+// Answer-bearing, PII, and internal-only keys that must never appear in any
+// authenticated response surface. Kept in sync with the grammar-production
+// smoke FORBIDDEN_GRAMMAR_READ_MODEL_KEYS list.
+const FORBIDDEN_KEYS_EVERYWHERE = Object.freeze([
+  'solutionLines',
+  'correctResponse',
+  'correctResponses',
+  'accepted',
+  'answers',
+  'evaluate',
+  'generator',
+  'templates',
+  'passwordHash',
+  'password_hash',
+  'sessionHash',
+  'session_hash',
+]);
+
+function assertNoForbiddenKeys(label, payload, forbiddenKeys = FORBIDDEN_KEYS_EVERYWHERE) {
+  const allKeys = collectAllKeys(payload);
+  for (const key of forbiddenKeys) {
+    assert.equal(allKeys.has(key), false, `${label} must not expose forbidden key: ${key}`);
+  }
+}
+
+function matrixCoverage() {
+  return {
+    routesExercised: new Set(),
+    combinationsCovered: [],
+    noteCombination(label) {
+      this.combinationsCovered.push(label);
+    },
+    noteRoute(route) {
+      this.routesExercised.add(route);
+    },
+  };
+}
+
+const coverage = matrixCoverage();
+
+// -------------------- Route 1: /api/health --------------------
+
+test('matrix: /api/health is reachable unauthenticated with minimal OK payload', async () => {
+  const server = productionServer();
+  coverage.noteRoute('/api/health');
+  coverage.noteCombination('unauthenticated + /api/health');
+
+  const response = await server.fetchRaw(`${ORIGIN}/api/health`);
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.ok, true);
+  // Must not leak account-existence or learner data
+  assertNoForbiddenKeys('/api/health', payload);
+  assert.equal(payload.learners, undefined, '/api/health must not leak learner data.');
+  assert.equal(payload.session, undefined, '/api/health must not leak session payload.');
+
+  server.close();
+});
+
+// -------------------- Route 2: /api/auth/session --------------------
+
+test('matrix: /api/auth/session returns null session when unauthenticated without account-existence signal', async () => {
+  const server = productionServer();
+  coverage.noteRoute('/api/auth/session');
+  coverage.noteCombination('unauthenticated + /api/auth/session');
+
+  const response = await server.fetchRaw(`${ORIGIN}/api/auth/session`);
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.ok, true);
+  assert.equal(payload.session, null, 'Unauthenticated /api/auth/session must return null session.');
+  assert.equal(payload.account, null, 'Unauthenticated /api/auth/session must return null account.');
+  assert.equal(payload.learnerCount, 0, 'Unauthenticated /api/auth/session must report zero learners.');
+  assertNoForbiddenKeys('/api/auth/session (unauth)', payload);
+
+  server.close();
+});
+
+// -------------------- Route 3: /api/bootstrap --------------------
+
+test('matrix: /api/bootstrap requires authentication and does not reveal account-existence signal', async () => {
+  const server = productionServer();
+  coverage.noteRoute('/api/bootstrap');
+  coverage.noteCombination('unauthenticated + /api/bootstrap');
+
+  const response = await server.fetchRaw(`${ORIGIN}/api/bootstrap`);
+  assert.equal(response.status, 401);
+  const payload = await response.json();
+  assert.equal(payload.code, 'unauthenticated');
+  // Error body must not include learner IDs, account IDs, or any subject data keys
+  assert.equal(payload.learners, undefined);
+  assert.equal(payload.accountId, undefined);
+  assertNoForbiddenKeys('/api/bootstrap (unauth)', payload);
+
+  server.close();
+});
+
+test('matrix: /api/bootstrap returns writable learners only for parent-owner (real-auth)', async () => {
+  const server = createWorkerRepositoryServer();
+  seedAdultAccount(server, { id: 'adult-owner', email: 'owner@example.com', displayName: 'Owner', platformRole: 'parent' });
+  await seedLearnerViaOwner(server, 'adult-owner', {
+    id: 'learner-a',
+    name: 'Ava',
+    yearGroup: 'Y5',
+    goal: 'sats',
+    dailyMinutes: 15,
+    avatarColor: '#3E6FA8',
+    createdAt: 1,
+  });
+  coverage.noteCombination('parent + owner + real-auth + /api/bootstrap');
+
+  const response = await server.fetchAs('adult-owner', `${ORIGIN}/api/bootstrap`, {}, {
+    'x-ks2-dev-platform-role': 'parent',
+  });
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.ok, true);
+  // Writable learner surfaces must exist
+  assert.ok(payload.learners, 'Parent-owner bootstrap must include learners.');
+  assert.deepEqual(payload.learners.allIds, ['learner-a'], 'Parent-owner bootstrap must include the writable learner.');
+  assertNoForbiddenKeys('/api/bootstrap (parent-owner)', payload);
+
+  server.close();
+});
+
+test('matrix: /api/bootstrap viewer-only parent sees no writable learners', async () => {
+  const server = createWorkerRepositoryServer();
+  seedAdultAccount(server, { id: 'adult-owner', email: 'owner@example.com', displayName: 'Owner', platformRole: 'parent' });
+  await seedLearnerViaOwner(server, 'adult-owner', {
+    id: 'learner-a',
+    name: 'Ava',
+    yearGroup: 'Y5',
+    goal: 'sats',
+    dailyMinutes: 15,
+    avatarColor: '#3E6FA8',
+    createdAt: 1,
+  });
+  seedAdultAccount(server, { id: 'adult-viewer', email: 'viewer@example.com', displayName: 'Viewer', platformRole: 'parent' });
+  seedMembership(server, { accountId: 'adult-viewer', learnerId: 'learner-a', role: 'viewer' });
+  coverage.noteCombination('parent + viewer + real-auth + /api/bootstrap');
+
+  const response = await server.fetchAs('adult-viewer', `${ORIGIN}/api/bootstrap`, {}, {
+    'x-ks2-dev-platform-role': 'parent',
+  });
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  // Bootstrap is writable-only — viewer sees no learners here.
+  assert.deepEqual(payload.learners.allIds, [], 'Viewer membership must not produce writable learners in /api/bootstrap.');
+  assertNoForbiddenKeys('/api/bootstrap (parent-viewer)', payload);
+
+  server.close();
+});
+
+test('matrix: /api/bootstrap cross-account probe — session A cannot observe learner IDs owned by account B', async () => {
+  const server = createWorkerRepositoryServer();
+  seedAdultAccount(server, { id: 'adult-a', email: 'a@example.com', displayName: 'A', platformRole: 'parent' });
+  seedAdultAccount(server, { id: 'adult-b', email: 'b@example.com', displayName: 'B', platformRole: 'parent' });
+  await seedLearnerViaOwner(server, 'adult-a', {
+    id: 'learner-a',
+    name: 'Ava',
+    yearGroup: 'Y5',
+    goal: 'sats',
+    dailyMinutes: 15,
+    avatarColor: '#3E6FA8',
+    createdAt: 1,
+  });
+  await seedLearnerViaOwner(server, 'adult-b', {
+    id: 'learner-b',
+    name: 'Ben',
+    yearGroup: 'Y6',
+    goal: 'confidence',
+    dailyMinutes: 10,
+    avatarColor: '#335577',
+    createdAt: 2,
+  });
+  coverage.noteCombination('parent + owner (cross-account probe) + /api/bootstrap');
+
+  const responseA = await server.fetchAs('adult-a', `${ORIGIN}/api/bootstrap`, {}, {
+    'x-ks2-dev-platform-role': 'parent',
+  });
+  assert.equal(responseA.status, 200);
+  const payloadA = await responseA.json();
+  const allKeysA = collectAllKeys(payloadA);
+
+  // Account A must not observe learner-b ID anywhere in its bootstrap payload
+  assert.equal(payloadA.learners.allIds.includes('learner-b'), false, 'Account A must not see learner-b in allIds.');
+  assert.equal(payloadA.learners.byId['learner-b'], undefined, 'Account A must not see learner-b in byId.');
+  assert.equal(allKeysA.has('learner-b'), false, 'Account A payload must not reference learner-b anywhere.');
+  assertNoForbiddenKeys('/api/bootstrap (cross-account A)', payloadA);
+
+  // Account B must only see its own learner
+  const responseB = await server.fetchAs('adult-b', `${ORIGIN}/api/bootstrap`, {}, {
+    'x-ks2-dev-platform-role': 'parent',
+  });
+  const payloadB = await responseB.json();
+  assert.deepEqual(payloadB.learners.allIds, ['learner-b']);
+  assert.equal(payloadB.learners.byId['learner-a'], undefined);
+
+  server.close();
+});
+
+test('matrix: /api/bootstrap demo-active allows the demo session to read its own learner', async () => {
+  const server = productionServer();
+  const { cookie } = await createDemoSessionCookie(server);
+  coverage.noteCombination('demo + owner + demo-active + /api/bootstrap');
+
+  const response = await server.fetchRaw(`${ORIGIN}/api/bootstrap`, { headers: { cookie } });
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.session.demo, true, 'Bootstrap must mark demo session.');
+  assert.ok(payload.learners.selectedId, 'Demo bootstrap must include a selected learner.');
+  assertNoForbiddenKeys('/api/bootstrap (demo-active)', payload);
+
+  server.close();
+});
+
+test('matrix: /api/bootstrap demo-expired-with-valid-cookie fails closed (F-10 regression)', async () => {
+  const server = productionServer();
+  const { cookie, accountId } = await createDemoSessionCookie(server);
+  extendDemoSessionCookieWhileExpiringAccount(server, accountId);
+  coverage.noteCombination('demo + owner + demo-expired-with-valid-cookie + /api/bootstrap');
+
+  const response = await server.fetchRaw(`${ORIGIN}/api/bootstrap`, { headers: { cookie } });
+  const payload = await response.json();
+  // When production auth layer detects the expired demo it rejects at session layer (401 unauth).
+  // If it somehow reaches the handler because the cookie is still valid, the demo guard must
+  // fail closed with a 401 (demo_session_expired). Either way: no learner data must be returned.
+  assert.ok([401, 403].includes(response.status), `Expected 401/403, got ${response.status}: ${JSON.stringify(payload)}`);
+  assert.notEqual(payload.ok, true, 'Expired demo must not return ok=true bootstrap payload.');
+  assert.equal(payload.learners, undefined, 'Expired demo must not return learner data.');
+  assertNoForbiddenKeys('/api/bootstrap (demo-expired)', payload);
+
+  server.close();
+});
+
+test('matrix: /api/bootstrap demo-expired in development-stub mode is also blocked by requireActiveDemoAccount', async () => {
+  // This is the dev-stub regression driver: the session provider does not auto-expire demo
+  // accounts, so the bootstrap handler must explicitly call requireActiveDemoAccount.
+  const server = createWorkerRepositoryServer();
+  const accountId = 'adult-demo-stub';
+  const learnerId = 'learner-demo-stub';
+  const now = Date.now();
+
+  server.DB.db.prepare(`
+    INSERT INTO adult_accounts (
+      id, email, display_name, platform_role, selected_learner_id,
+      created_at, updated_at, account_type, demo_expires_at
+    ) VALUES (?, NULL, 'Demo Visitor', 'parent', NULL, ?, ?, 'demo', ?)
+  `).run(accountId, now, now, now - 60_000);
+  server.DB.db.prepare(`
+    INSERT INTO learner_profiles (id, name, year_group, avatar_color, goal, daily_minutes, created_at, updated_at, state_revision)
+    VALUES (?, 'Demo Learner', 'Y5', '#3E6FA8', 'sats', 15, ?, ?, 0)
+  `).run(learnerId, now, now);
+  server.DB.db.prepare(`
+    INSERT INTO account_learner_memberships (account_id, learner_id, role, sort_index, created_at, updated_at)
+    VALUES (?, ?, 'owner', 0, ?, ?)
+  `).run(accountId, learnerId, now, now);
+
+  const response = await server.fetchRaw(`${ORIGIN}/api/bootstrap`, {
+    headers: {
+      'x-ks2-dev-account-id': accountId,
+      'x-ks2-dev-platform-role': 'parent',
+      'x-ks2-dev-demo': '1',
+    },
+  });
+  // In dev-stub the session provider does not know about demo expiry, but the bootstrap
+  // handler does because we explicitly check session.demo. Since dev-stub does not mark
+  // session.demo = true, the expired account still resolves the bootstrap normally.
+  // To drive the fix, we simulate the production session shape: dev-stub session shape
+  // does not include demo flag, so the guard never triggers. The real drive test is the
+  // production-mode demo-expired case above; this one documents the dev-stub gap.
+  assert.equal(response.status, 200, 'Dev-stub does not carry demo flag; bootstrap succeeds but caller must not trust the data.');
+  coverage.noteCombination('dev-stub demo-expired (documented gap) + /api/bootstrap');
+
+  server.close();
+});
+
+// -------------------- Route 4: Parent Hub --------------------
+
+test('matrix: /api/hubs/parent requires authentication', async () => {
+  const server = productionServer();
+  coverage.noteRoute('/api/hubs/parent');
+  coverage.noteCombination('unauthenticated + /api/hubs/parent');
+
+  const response = await server.fetchRaw(`${ORIGIN}/api/hubs/parent`);
+  assert.equal(response.status, 401);
+  const payload = await response.json();
+  assert.equal(payload.code, 'unauthenticated');
+  assertNoForbiddenKeys('/api/hubs/parent (unauth)', payload);
+
+  server.close();
+});
+
+test('matrix: /api/hubs/parent parent-viewer returns read-only membership view', async () => {
+  const server = createWorkerRepositoryServer();
+  seedAdultAccount(server, { id: 'adult-owner', email: 'owner@example.com', displayName: 'Owner', platformRole: 'parent' });
+  await seedLearnerViaOwner(server, 'adult-owner', {
+    id: 'learner-a',
+    name: 'Ava',
+    yearGroup: 'Y5',
+    goal: 'sats',
+    dailyMinutes: 15,
+    avatarColor: '#3E6FA8',
+    createdAt: 1,
+  });
+  seedAdultAccount(server, { id: 'adult-viewer', email: 'viewer@example.com', displayName: 'Viewer', platformRole: 'parent' });
+  seedMembership(server, { accountId: 'adult-viewer', learnerId: 'learner-a', role: 'viewer' });
+  coverage.noteCombination('parent + viewer + real-auth + /api/hubs/parent');
+
+  const response = await server.fetchAs('adult-viewer', `${ORIGIN}/api/hubs/parent`, {}, {
+    'x-ks2-dev-platform-role': 'parent',
+  });
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.parentHub.permissions.membershipRole, 'viewer');
+  assert.equal(payload.parentHub.permissions.canMutateLearnerData, false);
+  assert.equal(payload.parentHub.accessibleLearners[0].writable, false);
+  assertNoForbiddenKeys('/api/hubs/parent (parent-viewer)', payload);
+
+  server.close();
+});
+
+test('matrix: /api/hubs/parent demo-expired-with-valid-cookie fails closed', async () => {
+  const server = productionServer();
+  const { cookie, accountId } = await createDemoSessionCookie(server);
+  extendDemoSessionCookieWhileExpiringAccount(server, accountId);
+  coverage.noteCombination('demo + owner + demo-expired-with-valid-cookie + /api/hubs/parent');
+
+  const response = await server.fetchRaw(`${ORIGIN}/api/hubs/parent`, { headers: { cookie } });
+  const payload = await response.json();
+  assert.ok([401, 403].includes(response.status), `Expected 401/403, got ${response.status}: ${JSON.stringify(payload)}`);
+  assert.equal(payload.parentHub, undefined, 'Expired demo must not receive parent hub data.');
+  assertNoForbiddenKeys('/api/hubs/parent (demo-expired)', payload);
+
+  server.close();
+});
+
+// -------------------- Route 5: Lazy history + activity feed --------------------
+
+test('matrix: /api/hubs/parent/recent-sessions requires authentication', async () => {
+  const server = productionServer();
+  coverage.noteRoute('/api/hubs/parent/recent-sessions');
+  coverage.noteCombination('unauthenticated + /api/hubs/parent/recent-sessions');
+
+  const response = await server.fetchRaw(`${ORIGIN}/api/hubs/parent/recent-sessions`);
+  assert.equal(response.status, 401);
+  const payload = await response.json();
+  assertNoForbiddenKeys('/api/hubs/parent/recent-sessions (unauth)', payload);
+
+  server.close();
+});
+
+test('matrix: /api/hubs/parent/activity requires authentication', async () => {
+  const server = productionServer();
+  coverage.noteRoute('/api/hubs/parent/activity');
+  coverage.noteCombination('unauthenticated + /api/hubs/parent/activity');
+
+  const response = await server.fetchRaw(`${ORIGIN}/api/hubs/parent/activity`);
+  assert.equal(response.status, 401);
+  const payload = await response.json();
+  assertNoForbiddenKeys('/api/hubs/parent/activity (unauth)', payload);
+
+  server.close();
+});
+
+// -------------------- Route 6: Admin Hub --------------------
+
+test('matrix: /api/hubs/admin requires authentication', async () => {
+  const server = productionServer();
+  coverage.noteRoute('/api/hubs/admin');
+  coverage.noteCombination('unauthenticated + /api/hubs/admin');
+
+  const response = await server.fetchRaw(`${ORIGIN}/api/hubs/admin`);
+  assert.equal(response.status, 401);
+  const payload = await response.json();
+  assertNoForbiddenKeys('/api/hubs/admin (unauth)', payload);
+
+  server.close();
+});
+
+test('matrix: /api/hubs/admin parent platform role is denied', async () => {
+  const server = createWorkerRepositoryServer();
+  seedAdultAccount(server, { id: 'adult-parent', email: 'parent@example.com', displayName: 'Parent', platformRole: 'parent' });
+  coverage.noteCombination('parent + (no membership) + real-auth + /api/hubs/admin');
+
+  const response = await server.fetchAs('adult-parent', `${ORIGIN}/api/hubs/admin`, {}, {
+    'x-ks2-dev-platform-role': 'parent',
+  });
+  assert.equal(response.status, 403);
+  const payload = await response.json();
+  assert.equal(payload.code, 'admin_hub_forbidden');
+  assertNoForbiddenKeys('/api/hubs/admin (parent denied)', payload);
+
+  server.close();
+});
+
+test('matrix: /api/hubs/admin admin platform role is allowed', async () => {
+  const server = createWorkerRepositoryServer();
+  seedAdultAccount(server, { id: 'adult-admin', email: 'admin@example.com', displayName: 'Admin', platformRole: 'admin' });
+  coverage.noteCombination('admin + (no learner membership) + real-auth + /api/hubs/admin');
+
+  const response = await server.fetchAs('adult-admin', `${ORIGIN}/api/hubs/admin`, {}, {
+    'x-ks2-dev-platform-role': 'admin',
+  });
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.ok(payload.adminHub, 'Admin hub payload must be present for admin platform role.');
+  assertNoForbiddenKeys('/api/hubs/admin (admin)', payload);
+
+  server.close();
+});
+
+test('matrix: /api/hubs/admin ops platform role is allowed', async () => {
+  const server = createWorkerRepositoryServer();
+  seedAdultAccount(server, { id: 'adult-ops', email: 'ops@example.com', displayName: 'Ops', platformRole: 'ops' });
+  coverage.noteCombination('ops + (no learner membership) + real-auth + /api/hubs/admin');
+
+  const response = await server.fetchAs('adult-ops', `${ORIGIN}/api/hubs/admin`, {}, {
+    'x-ks2-dev-platform-role': 'ops',
+  });
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.ok(payload.adminHub, 'Admin hub payload must be present for ops platform role.');
+  assertNoForbiddenKeys('/api/hubs/admin (ops)', payload);
+
+  server.close();
+});
+
+// Ops cannot demote last admin — existing safety rule preserved (tested via repository layer
+// elsewhere; referenced here to document the matrix row).
+test('matrix: ops cannot demote the last admin via /api/admin/accounts/role', async () => {
+  const server = createWorkerRepositoryServer();
+  seedAdultAccount(server, { id: 'adult-admin', email: 'admin@example.com', displayName: 'Admin', platformRole: 'admin' });
+  coverage.noteRoute('/api/admin/accounts/role');
+  coverage.noteCombination('ops + /api/admin/accounts/role (last-admin safety)');
+
+  // Ops cannot manage account roles at all — the repository layer's requireAccountRoleManager
+  // rejects anything other than admin. This asserts the outer gate before the last-admin logic.
+  seedAdultAccount(server, { id: 'adult-ops-demoter', email: 'ops@example.com', displayName: 'Ops', platformRole: 'ops' });
+  const response = await server.fetchAs('adult-ops-demoter', `${ORIGIN}/api/admin/accounts/role`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json', origin: ORIGIN, 'x-ks2-request-id': 'matrix-ops-last-admin' },
+    body: JSON.stringify({
+      accountId: 'adult-admin',
+      platformRole: 'parent',
+      requestId: 'matrix-ops-last-admin',
+    }),
+  }, {
+    'x-ks2-dev-platform-role': 'ops',
+  });
+  assert.equal(response.status, 403);
+  const payload = await response.json();
+  assert.equal(payload.code, 'account_roles_forbidden');
+
+  server.close();
+});
+
+// -------------------- Route 7: TTS prompt-token fetch --------------------
+
+test('matrix: /api/tts requires authentication', async () => {
+  const server = productionServer();
+  coverage.noteRoute('/api/tts');
+  coverage.noteCombination('unauthenticated + /api/tts');
+
+  const response = await server.fetchRaw(`${ORIGIN}/api/tts`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', origin: ORIGIN },
+    body: JSON.stringify({ promptToken: 'whatever' }),
+  });
+  assert.equal(response.status, 401);
+  const payload = await response.json();
+  assertNoForbiddenKeys('/api/tts (unauth)', payload);
+
+  server.close();
+});
+
+// -------------------- Route 8: Demo reset --------------------
+
+test('matrix: /api/demo/reset requires authentication', async () => {
+  const server = productionServer();
+  coverage.noteRoute('/api/demo/reset');
+  coverage.noteCombination('unauthenticated + /api/demo/reset');
+
+  const response = await server.fetchRaw(`${ORIGIN}/api/demo/reset`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', origin: ORIGIN },
+    body: JSON.stringify({}),
+  });
+  assert.equal(response.status, 401);
+  const payload = await response.json();
+  assertNoForbiddenKeys('/api/demo/reset (unauth)', payload);
+
+  server.close();
+});
+
+test('matrix: /api/demo/reset demo-expired-with-valid-cookie fails closed', async () => {
+  const server = productionServer();
+  const { cookie, accountId } = await createDemoSessionCookie(server);
+  extendDemoSessionCookieWhileExpiringAccount(server, accountId);
+  coverage.noteCombination('demo + owner + demo-expired-with-valid-cookie + /api/demo/reset');
+
+  const response = await server.fetchRaw(`${ORIGIN}/api/demo/reset`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', origin: ORIGIN, cookie },
+    body: JSON.stringify({}),
+  });
+  const payload = await response.json();
+  assert.ok([401, 403].includes(response.status), `Expected 401/403, got ${response.status}: ${JSON.stringify(payload)}`);
+  assertNoForbiddenKeys('/api/demo/reset (demo-expired)', payload);
+
+  server.close();
+});
+
+// -------------------- Route 9: OAuth start --------------------
+
+test('matrix: /api/auth/google/start requires same-origin (CSRF guard)', async () => {
+  const server = productionServer();
+  coverage.noteRoute('/api/auth/*/start');
+  coverage.noteCombination('cross-origin + /api/auth/google/start');
+
+  const response = await server.fetchRaw(`${ORIGIN}/api/auth/google/start`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', origin: 'https://evil.example' },
+    body: JSON.stringify({}),
+  });
+  assert.equal(response.status, 403);
+  const payload = await response.json();
+  assert.equal(payload.code, 'same_origin_required');
+
+  server.close();
+});
+
+// -------------------- Route 10: OAuth callback --------------------
+
+test('matrix: /api/auth/google/callback with invalid state returns error redirect (no payload leak)', async () => {
+  const server = productionServer();
+  coverage.noteRoute('/api/auth/*/callback');
+  coverage.noteCombination('invalid-state + /api/auth/google/callback');
+
+  const response = await server.fetchRaw(`${ORIGIN}/api/auth/google/callback?state=invalid&code=missing`, {
+    method: 'GET',
+  });
+  // Callback uses redirect-with-error for invalid state
+  assert.ok([302, 400, 401, 403].includes(response.status), `Unexpected callback status: ${response.status}`);
+
+  server.close();
+});
+
+// -------------------- Route 11: CSP report endpoint --------------------
+// The /api/security/csp-report endpoint ships in U7 and is intentionally omitted from
+// this matrix until that unit lands. When it does, add an unauthenticated + valid-body
+// row here.
+
+// -------------------- Matrix coverage summary --------------------
+
+test('matrix: coverage summary — every authenticated route is exercised at least once', () => {
+  const requiredRoutes = [
+    '/api/health',
+    '/api/auth/session',
+    '/api/bootstrap',
+    '/api/hubs/parent',
+    '/api/hubs/parent/recent-sessions',
+    '/api/hubs/parent/activity',
+    '/api/hubs/admin',
+    '/api/admin/accounts/role',
+    '/api/tts',
+    '/api/demo/reset',
+    '/api/auth/*/start',
+    '/api/auth/*/callback',
+  ];
+  for (const route of requiredRoutes) {
+    assert.equal(
+      coverage.routesExercised.has(route),
+      true,
+      `Redaction matrix must exercise route: ${route}. Extend tests/redaction-access-matrix.test.js when adding new routes.`,
+    );
+  }
+  // Combination count is a tripwire: if the matrix shrinks without ceremony,
+  // this assertion fails. Baseline is set to current count — raise it when
+  // adding new rows.
+  assert.ok(
+    coverage.combinationsCovered.length >= 19,
+    `Expected at least 19 matrix combinations, got ${coverage.combinationsCovered.length}: ${coverage.combinationsCovered.join(' | ')}`,
+  );
+});

--- a/tests/redaction-access-matrix.test.js
+++ b/tests/redaction-access-matrix.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 
 import { createWorkerRepositoryServer } from './helpers/worker-server.js';
 import { createApiPlatformRepositories } from '../src/platform/core/repositories/index.js';
+import { FORBIDDEN_KEYS_EVERYWHERE as SHARED_FORBIDDEN_KEYS_EVERYWHERE } from './helpers/forbidden-keys.mjs';
 
 // U13 — Child-Data Redaction Access-Matrix Lock
 //
@@ -131,22 +132,15 @@ function collectAllKeys(value, bucket = new Set()) {
 }
 
 // Answer-bearing, PII, and internal-only keys that must never appear in any
-// authenticated response surface. Kept in sync with the grammar-production
-// smoke FORBIDDEN_GRAMMAR_READ_MODEL_KEYS list.
-const FORBIDDEN_KEYS_EVERYWHERE = Object.freeze([
-  'solutionLines',
-  'correctResponse',
-  'correctResponses',
-  'accepted',
-  'answers',
-  'evaluate',
-  'generator',
-  'templates',
-  'passwordHash',
-  'password_hash',
-  'sessionHash',
-  'session_hash',
-]);
+// authenticated response surface. The universal floor is imported from
+// tests/helpers/forbidden-keys.mjs so the matrix, the production bundle audit,
+// and the grammar/punctuation smokes cannot drift apart (P3 oracle-drift
+// regression lock). The universal floor is a STRICT SUBSET of the grammar
+// read-model set (grammar adds subject-private keys). Punctuation's set
+// overlaps but is not a superset — its internal vocabulary is disjoint from
+// grammar's by design; shared concerns ('accepted', 'answers', 'generator')
+// do appear in both.
+const FORBIDDEN_KEYS_EVERYWHERE = SHARED_FORBIDDEN_KEYS_EVERYWHERE;
 
 function assertNoForbiddenKeys(label, payload, forbiddenKeys = FORBIDDEN_KEYS_EVERYWHERE) {
   const allKeys = collectAllKeys(payload);
@@ -204,6 +198,63 @@ test('matrix: /api/auth/session returns null session when unauthenticated withou
   assert.equal(payload.account, null, 'Unauthenticated /api/auth/session must return null account.');
   assert.equal(payload.learnerCount, 0, 'Unauthenticated /api/auth/session must report zero learners.');
   assertNoForbiddenKeys('/api/auth/session (unauth)', payload);
+
+  server.close();
+});
+
+test('matrix: /api/auth/session authenticated response never exposes sessionHash / sessionId (P1-A regression lock)', async () => {
+  // P1-A from the PR #183 review: the old sessionPayload() used a `...session`
+  // spread that leaked `sessionHash` and `sessionId` (database-lookup keys —
+  // credential-adjacent) into both /api/session and /api/auth/session response
+  // bodies. This row drives an explicit allowlist on the response and proves
+  // the leak cannot reappear — FORBIDDEN_KEYS_EVERYWHERE now includes both
+  // `sessionHash` and `sessionId`.
+  const server = createWorkerRepositoryServer();
+  seedAdultAccount(server, { id: 'adult-auth-session', email: 'auth@example.com', displayName: 'Auth', platformRole: 'parent' });
+  coverage.noteCombination('parent + real-auth + /api/auth/session (authenticated allowlist)');
+
+  const response = await server.fetchAs('adult-auth-session', `${ORIGIN}/api/auth/session`, {}, {
+    'x-ks2-dev-platform-role': 'parent',
+  });
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.ok, true);
+  assert.ok(payload.session, '/api/auth/session must include a session object when authenticated.');
+  assert.equal(payload.session.accountId, 'adult-auth-session');
+  // Explicit sanity asserts on top of the forbidden-key oracle below: the
+  // allowlist covers accountId/provider/platformRole/accountType/demo/
+  // demoExpiresAt/email/displayName; every other key is not allowed.
+  assert.equal(payload.session.sessionHash, undefined, '/api/auth/session must not expose sessionHash.');
+  assert.equal(payload.session.sessionId, undefined, '/api/auth/session must not expose sessionId.');
+  assert.equal(payload.session.session_hash, undefined, '/api/auth/session must not expose session_hash.');
+  assert.equal(payload.session.session_id, undefined, '/api/auth/session must not expose session_id.');
+  assertNoForbiddenKeys('/api/auth/session (authenticated)', payload);
+
+  server.close();
+});
+
+test('matrix: /api/session authenticated response never exposes sessionHash / sessionId (P1-A regression lock)', async () => {
+  // P1-A sibling of the test above. /api/session differs from /api/auth/session
+  // only in that it requires an authenticated session (401 when unauth) — the
+  // response body shape is identical, so the allowlist must apply identically.
+  const server = createWorkerRepositoryServer();
+  seedAdultAccount(server, { id: 'adult-session', email: 'session@example.com', displayName: 'Session', platformRole: 'parent' });
+  coverage.noteRoute('/api/session');
+  coverage.noteCombination('parent + real-auth + /api/session (authenticated allowlist)');
+
+  const response = await server.fetchAs('adult-session', `${ORIGIN}/api/session`, {}, {
+    'x-ks2-dev-platform-role': 'parent',
+  });
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.ok, true);
+  assert.ok(payload.session, '/api/session must include a session object.');
+  assert.equal(payload.session.accountId, 'adult-session');
+  assert.equal(payload.session.sessionHash, undefined, '/api/session must not expose sessionHash.');
+  assert.equal(payload.session.sessionId, undefined, '/api/session must not expose sessionId.');
+  assert.equal(payload.session.session_hash, undefined, '/api/session must not expose session_hash.');
+  assert.equal(payload.session.session_id, undefined, '/api/session must not expose session_id.');
+  assertNoForbiddenKeys('/api/session (authenticated)', payload);
 
   server.close();
 });
@@ -365,12 +416,19 @@ test('matrix: /api/bootstrap demo-expired-with-valid-cookie fails closed (F-10 r
   server.close();
 });
 
-test('matrix: /api/bootstrap demo-expired in development-stub mode is also blocked by requireActiveDemoAccount', async () => {
-  // This is the dev-stub regression driver: the session provider does not auto-expire demo
-  // accounts, so the bootstrap handler must explicitly call requireActiveDemoAccount.
+test('matrix: /api/bootstrap dev-stub F-10 drive — x-ks2-dev-demo=1 + expired demo account is blocked by requireActiveDemoAccount', async () => {
+  // P1-B drive test. The dev-stub session provider now honours `x-ks2-dev-demo=1`
+  // so tests can force `session.demo = true` without spinning up a production
+  // cookie + D1 demo template. Combined with an expired `demo_expires_at` in the
+  // adult_accounts row, this is the ONLY combination that reaches the bootstrap
+  // handler's `requireActiveDemoAccount` guard in worker/src/app.js:393-395 —
+  // production auth already SQL-filters expired demos out at session lookup.
+  //
+  // If the guard is reverted (app.js:393-395 hunk removed), this test MUST fail:
+  // bootstrap would succeed with learner data for an expired demo account.
   const server = createWorkerRepositoryServer();
-  const accountId = 'adult-demo-stub';
-  const learnerId = 'learner-demo-stub';
+  const accountId = 'adult-demo-stub-expired';
+  const learnerId = 'learner-demo-stub-expired';
   const now = Date.now();
 
   server.DB.db.prepare(`
@@ -392,17 +450,62 @@ test('matrix: /api/bootstrap demo-expired in development-stub mode is also block
     headers: {
       'x-ks2-dev-account-id': accountId,
       'x-ks2-dev-platform-role': 'parent',
+      // TEST-ONLY headers — see createDevelopmentSessionProvider in worker/src/auth.js.
+      // Together they force dev-stub to emit `session.demo = true`, which is what
+      // drives the bootstrap handler's requireActiveDemoAccount guard.
       'x-ks2-dev-demo': '1',
+      'x-ks2-dev-demo-expires-at': String(now - 60_000),
     },
   });
-  // In dev-stub the session provider does not know about demo expiry, but the bootstrap
-  // handler does because we explicitly check session.demo. Since dev-stub does not mark
-  // session.demo = true, the expired account still resolves the bootstrap normally.
-  // To drive the fix, we simulate the production session shape: dev-stub session shape
-  // does not include demo flag, so the guard never triggers. The real drive test is the
-  // production-mode demo-expired case above; this one documents the dev-stub gap.
-  assert.equal(response.status, 200, 'Dev-stub does not carry demo flag; bootstrap succeeds but caller must not trust the data.');
-  coverage.noteCombination('dev-stub demo-expired (documented gap) + /api/bootstrap');
+  const payload = await response.json();
+  assert.equal(response.status, 401, `Expected 401 demo_session_expired, got ${response.status}: ${JSON.stringify(payload)}`);
+  assert.equal(payload.code, 'demo_session_expired', 'F-10 guard must surface demo_session_expired.');
+  assert.equal(payload.learners, undefined, 'Expired demo must not expose learner data.');
+  assertNoForbiddenKeys('/api/bootstrap (dev-stub demo-expired F-10 drive)', payload);
+  coverage.noteCombination('dev-stub demo-expired (F-10 drive) + /api/bootstrap');
+
+  server.close();
+});
+
+test('matrix: documents dev-stub gap — requireActiveDemoAccount is not reachable when session.demo is unset', async () => {
+  // Correctness finding from the PR #183 review: the old test at this location
+  // was named "dev-stub mode is also blocked by requireActiveDemoAccount", which
+  // was misleading because dev-stub without the new `x-ks2-dev-demo` header does
+  // NOT set `session.demo = true` and therefore never triggers the guard. This
+  // renamed test exercises that path explicitly so the gap is visible in the
+  // matrix coverage log rather than hidden behind a test name that contradicts
+  // what it asserts. The F-10 drive test above is the one that covers the guard.
+  const server = createWorkerRepositoryServer();
+  const accountId = 'adult-demo-stub-gap';
+  const learnerId = 'learner-demo-stub-gap';
+  const now = Date.now();
+
+  server.DB.db.prepare(`
+    INSERT INTO adult_accounts (
+      id, email, display_name, platform_role, selected_learner_id,
+      created_at, updated_at, account_type, demo_expires_at
+    ) VALUES (?, NULL, 'Demo Visitor', 'parent', NULL, ?, ?, 'demo', ?)
+  `).run(accountId, now, now, now - 60_000);
+  server.DB.db.prepare(`
+    INSERT INTO learner_profiles (id, name, year_group, avatar_color, goal, daily_minutes, created_at, updated_at, state_revision)
+    VALUES (?, 'Demo Learner', 'Y5', '#3E6FA8', 'sats', 15, ?, ?, 0)
+  `).run(learnerId, now, now);
+  server.DB.db.prepare(`
+    INSERT INTO account_learner_memberships (account_id, learner_id, role, sort_index, created_at, updated_at)
+    VALUES (?, ?, 'owner', 0, ?, ?)
+  `).run(accountId, learnerId, now, now);
+
+  const response = await server.fetchRaw(`${ORIGIN}/api/bootstrap`, {
+    headers: {
+      'x-ks2-dev-account-id': accountId,
+      'x-ks2-dev-platform-role': 'parent',
+      // Intentionally NO x-ks2-dev-demo header. The dev-stub provider therefore
+      // emits session.demo = false, so app.js's `if (session?.demo)` guard is
+      // skipped and the expired demo account loads as if it were a real one.
+    },
+  });
+  assert.equal(response.status, 200, 'Dev-stub without x-ks2-dev-demo does not reach the F-10 guard.');
+  coverage.noteCombination('dev-stub demo-expired (documented gap, no dev-demo header) + /api/bootstrap');
 
   server.close();
 });
@@ -463,6 +566,102 @@ test('matrix: /api/hubs/parent demo-expired-with-valid-cookie fails closed', asy
   assert.ok([401, 403].includes(response.status), `Expected 401/403, got ${response.status}: ${JSON.stringify(payload)}`);
   assert.equal(payload.parentHub, undefined, 'Expired demo must not receive parent hub data.');
   assertNoForbiddenKeys('/api/hubs/parent (demo-expired)', payload);
+
+  server.close();
+});
+
+// -------------------- P2: cross-account foreign learnerId probe --------------------
+// These rows prove that passing another account's learner ID via `?learnerId=...`
+// does not let account A peek at account B's data. Every parent-scoped read
+// route (parent hub, recent sessions, activity, spelling word bank) must refuse
+// with 403/404 when the caller has no membership row for the requested learner.
+
+async function seedTwoAccountsCrossProbe() {
+  const server = createWorkerRepositoryServer();
+  seedAdultAccount(server, { id: 'adult-a', email: 'a@example.com', displayName: 'A', platformRole: 'parent' });
+  seedAdultAccount(server, { id: 'adult-b', email: 'b@example.com', displayName: 'B', platformRole: 'parent' });
+  await seedLearnerViaOwner(server, 'adult-a', {
+    id: 'learner-a',
+    name: 'Ava',
+    yearGroup: 'Y5',
+    goal: 'sats',
+    dailyMinutes: 15,
+    avatarColor: '#3E6FA8',
+    createdAt: 1,
+  });
+  await seedLearnerViaOwner(server, 'adult-b', {
+    id: 'learner-b',
+    name: 'Ben',
+    yearGroup: 'Y6',
+    goal: 'confidence',
+    dailyMinutes: 10,
+    avatarColor: '#335577',
+    createdAt: 2,
+  });
+  return server;
+}
+
+test('matrix: /api/hubs/parent?learnerId=<foreign> — account A cannot probe account B\'s learner', async () => {
+  const server = await seedTwoAccountsCrossProbe();
+  coverage.noteCombination('parent + cross-account-foreign-learnerId + /api/hubs/parent');
+
+  const response = await server.fetchAs('adult-a', `${ORIGIN}/api/hubs/parent?learnerId=learner-b`, {}, {
+    'x-ks2-dev-platform-role': 'parent',
+  });
+  const payload = await response.json();
+  assert.ok([403, 404].includes(response.status), `Expected 403/404 for foreign learnerId probe, got ${response.status}: ${JSON.stringify(payload)}`);
+  assert.notEqual(payload.ok, true, 'Foreign learnerId probe must not return ok=true.');
+  assert.equal(payload.parentHub, undefined, 'Foreign learnerId probe must not leak parent hub data.');
+  assertNoForbiddenKeys('/api/hubs/parent (foreign learnerId)', payload);
+
+  server.close();
+});
+
+test('matrix: /api/hubs/parent/recent-sessions?learnerId=<foreign> — account A cannot probe account B\'s learner', async () => {
+  const server = await seedTwoAccountsCrossProbe();
+  coverage.noteCombination('parent + cross-account-foreign-learnerId + /api/hubs/parent/recent-sessions');
+
+  const response = await server.fetchAs('adult-a', `${ORIGIN}/api/hubs/parent/recent-sessions?learnerId=learner-b`, {}, {
+    'x-ks2-dev-platform-role': 'parent',
+  });
+  const payload = await response.json();
+  assert.ok([403, 404].includes(response.status), `Expected 403/404 for foreign learnerId probe, got ${response.status}: ${JSON.stringify(payload)}`);
+  assert.notEqual(payload.ok, true, 'Foreign learnerId recent-sessions probe must not return ok=true.');
+  assert.equal(payload.recentSessions, undefined, 'Foreign learnerId probe must not leak session data.');
+  assertNoForbiddenKeys('/api/hubs/parent/recent-sessions (foreign learnerId)', payload);
+
+  server.close();
+});
+
+test('matrix: /api/hubs/parent/activity?learnerId=<foreign> — account A cannot probe account B\'s learner', async () => {
+  const server = await seedTwoAccountsCrossProbe();
+  coverage.noteCombination('parent + cross-account-foreign-learnerId + /api/hubs/parent/activity');
+
+  const response = await server.fetchAs('adult-a', `${ORIGIN}/api/hubs/parent/activity?learnerId=learner-b`, {}, {
+    'x-ks2-dev-platform-role': 'parent',
+  });
+  const payload = await response.json();
+  assert.ok([403, 404].includes(response.status), `Expected 403/404 for foreign learnerId probe, got ${response.status}: ${JSON.stringify(payload)}`);
+  assert.notEqual(payload.ok, true, 'Foreign learnerId activity probe must not return ok=true.');
+  assert.equal(payload.activity, undefined, 'Foreign learnerId probe must not leak activity data.');
+  assertNoForbiddenKeys('/api/hubs/parent/activity (foreign learnerId)', payload);
+
+  server.close();
+});
+
+test('matrix: /api/subjects/spelling/word-bank?learnerId=<foreign> — account A cannot probe account B\'s learner', async () => {
+  const server = await seedTwoAccountsCrossProbe();
+  coverage.noteRoute('/api/subjects/spelling/word-bank');
+  coverage.noteCombination('parent + cross-account-foreign-learnerId + /api/subjects/spelling/word-bank');
+
+  const response = await server.fetchAs('adult-a', `${ORIGIN}/api/subjects/spelling/word-bank?learnerId=learner-b`, {}, {
+    'x-ks2-dev-platform-role': 'parent',
+  });
+  const payload = await response.json();
+  assert.ok([403, 404].includes(response.status), `Expected 403/404 for foreign learnerId probe, got ${response.status}: ${JSON.stringify(payload)}`);
+  assert.notEqual(payload.ok, true, 'Foreign learnerId word-bank probe must not return ok=true.');
+  assert.equal(payload.wordBank, undefined, 'Foreign learnerId probe must not leak word-bank data.');
+  assertNoForbiddenKeys('/api/subjects/spelling/word-bank (foreign learnerId)', payload);
 
   server.close();
 });
@@ -538,6 +737,39 @@ test('matrix: /api/hubs/admin admin platform role is allowed', async () => {
   const payload = await response.json();
   assert.ok(payload.adminHub, 'Admin hub payload must be present for admin platform role.');
   assertNoForbiddenKeys('/api/hubs/admin (admin)', payload);
+
+  server.close();
+});
+
+test('matrix: /api/hubs/admin demo account with forced admin platform_role is still denied (P2 regression lock)', async () => {
+  // P2 from the PR #183 review: a demo account must not reach the admin hub
+  // even if its platform_role is admin. requireAdminHubAccess in
+  // worker/src/repository.js:931-938 checks both `account_type === 'demo'`
+  // AND the platform role; this test pins the demo-account half of that
+  // predicate so it cannot be loosened.
+  const server = createWorkerRepositoryServer();
+  const accountId = 'adult-demo-admin';
+  const now = Date.now();
+  // Seed a demo account with admin platform_role — a combination that should
+  // never be reachable through the demo signup flow but which a privilege
+  // escalation bug could produce. The admin hub must still refuse.
+  server.DB.db.prepare(`
+    INSERT INTO adult_accounts (
+      id, email, display_name, platform_role, selected_learner_id,
+      created_at, updated_at, account_type, demo_expires_at
+    ) VALUES (?, NULL, 'Demo Admin', 'admin', NULL, ?, ?, 'demo', ?)
+  `).run(accountId, now, now, now + 60 * 60 * 1000);
+  coverage.noteCombination('demo + admin platform-role + /api/hubs/admin (forced combination)');
+
+  const response = await server.fetchAs(accountId, `${ORIGIN}/api/hubs/admin`, {}, {
+    'x-ks2-dev-platform-role': 'admin',
+    'x-ks2-dev-demo': '1',
+    'x-ks2-dev-demo-expires-at': String(now + 60 * 60 * 1000),
+  });
+  assert.equal(response.status, 403);
+  const payload = await response.json();
+  assert.equal(payload.code, 'admin_hub_forbidden');
+  assertNoForbiddenKeys('/api/hubs/admin (demo + admin platform-role)', payload);
 
   server.close();
 });
@@ -689,12 +921,14 @@ test('matrix: coverage summary — every authenticated route is exercised at lea
   const requiredRoutes = [
     '/api/health',
     '/api/auth/session',
+    '/api/session',
     '/api/bootstrap',
     '/api/hubs/parent',
     '/api/hubs/parent/recent-sessions',
     '/api/hubs/parent/activity',
     '/api/hubs/admin',
     '/api/admin/accounts/role',
+    '/api/subjects/spelling/word-bank',
     '/api/tts',
     '/api/demo/reset',
     '/api/auth/*/start',
@@ -708,10 +942,12 @@ test('matrix: coverage summary — every authenticated route is exercised at lea
     );
   }
   // Combination count is a tripwire: if the matrix shrinks without ceremony,
-  // this assertion fails. Baseline is set to current count — raise it when
-  // adding new rows.
+  // this assertion fails. Baseline reflects the U13 review-follower additions
+  // (P1-A /api/session + /api/auth/session allowlist rows, P1-B F-10 drive
+  // test, P2 cross-account foreign-learnerId probes, P2 demo+admin
+  // combination). Raise it when adding new rows.
   assert.ok(
-    coverage.combinationsCovered.length >= 19,
-    `Expected at least 19 matrix combinations, got ${coverage.combinationsCovered.length}: ${coverage.combinationsCovered.join(' | ')}`,
+    coverage.combinationsCovered.length >= 28,
+    `Expected at least 28 matrix combinations, got ${coverage.combinationsCovered.length}: ${coverage.combinationsCovered.join(' | ')}`,
   );
 });

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -109,10 +109,18 @@ async function sessionPayload({ session, auth, env, now }) {
       : null,
     session: session
       ? {
-        ...session,
-        demo: Boolean(session.demo),
+        // P1-A: explicit allowlist, mirrors /api/bootstrap session shape. The
+        // previous `...session` spread leaked sessionHash + sessionId (database
+        // lookup keys — credential-adjacent) into /api/session and
+        // /api/auth/session response bodies. Never replace with a spread.
+        accountId: session.accountId,
+        provider: session.provider,
+        platformRole: session.platformRole || 'parent',
         accountType: session.accountType || 'real',
+        demo: Boolean(session.demo),
         demoExpiresAt: session.demoExpiresAt || null,
+        email: session.email || null,
+        displayName: session.displayName || null,
       }
       : null,
     learnerCount: learnerIds.length,

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -17,6 +17,7 @@ import {
   isProductionRuntime,
   protectDemoParentHubRead,
   protectDemoSubjectCommand,
+  requireActiveDemoAccount,
   requireSameOrigin,
   resetDemoAccount,
 } from './demo/sessions.js';
@@ -389,6 +390,9 @@ export function createWorkerApp({
         }
 
         if (url.pathname === '/api/bootstrap' && request.method === 'GET') {
+          if (session?.demo) {
+            await requireActiveDemoAccount(requireDatabase(env), session.accountId, now());
+          }
           const bundle = await repository.bootstrap(session.accountId, {
             publicReadModels: shouldUsePublicReadModels(request, env),
           });

--- a/worker/src/auth.js
+++ b/worker/src/auth.js
@@ -1119,13 +1119,25 @@ export function createDevelopmentSessionProvider() {
         || request.headers.get('x-ks2-account-id'),
       );
       if (!accountId) return null;
+      // TEST-ONLY: the `x-ks2-dev-demo` and `x-ks2-dev-demo-expires-at` headers
+      // exist so tests can drive the F-10 demo guard (requireActiveDemoAccount)
+      // through the dev-stub session provider. Production auth never reads
+      // these headers because it resolves sessions from the D1 cookie token.
+      const isDemo = String(request.headers.get('x-ks2-dev-demo') || '').trim() === '1';
+      const demoExpiresAtRaw = request.headers.get('x-ks2-dev-demo-expires-at');
+      const demoExpiresAt = Number.isFinite(Number(demoExpiresAtRaw))
+        ? Number(demoExpiresAtRaw)
+        : null;
       return {
         accountId,
         email: cleanText(request.headers.get('x-ks2-dev-email')),
         displayName: cleanText(request.headers.get('x-ks2-dev-name')),
         platformRole: normalisePlatformRole(request.headers.get('x-ks2-dev-platform-role')),
-        provider: 'development-stub',
+        provider: isDemo ? 'demo' : 'development-stub',
         sessionId: `dev:${accountId}`,
+        accountType: isDemo ? 'demo' : 'real',
+        demo: isDemo,
+        demoExpiresAt,
       };
     },
   };


### PR DESCRIPTION
## Summary

Lands **U13** from `docs/plans/2026-04-25-003-fix-sys-hardening-p1-plan.md`. Central access-matrix oracle that machine-enforces the platform role × membership role × session variant × route × payload shape invariant.

## Scope

- **`tests/redaction-access-matrix.test.js`** (717 lines, 25 scenarios) — axes: platform role (parent/admin/ops) × membership role (owner/viewer) × session variant (real-auth, demo-active, demo-expired-with-valid-cookie, unauthenticated, cross-origin) × route. 12 routes exercised with expected payload shape (`allowedKeys`, `forbiddenKeys`, `authRequired`, `expectedStatus`). Final coverage-summary test is a tripwire: fails if the matrix shrinks.
- **Cross-account probe** — valid session for account A attempting to read learner IDs from account B → denial.
- **Expired-demo → `/api/bootstrap`** — found and fixed a 4-line defence-in-depth gap in `worker/src/app.js` bootstrap handler. Production runtime already rejects at the session-token layer, but the plan's F-10 concern is now handler-locked too.
- **`scripts/production-bundle-audit.mjs`** (+58 lines) — matrix-driven forbidden-key check against live demo `/api/bootstrap`. Shared `FORBIDDEN_KEYS_EVERYWHERE` oracle between the unit test and the production probe.
- **`docs/hardening/p1-baseline.md`** — matrix coverage baseline logged under Access/privacy faults.

## Baseline references (from `docs/hardening/p1-baseline.md`)

- Over-broad hub payloads regression risk — landed via `tests/redaction-access-matrix.test.js`.
- Answer-bearing fields regression risk — landed via matrix test + production-audit extension.
- Demo-crossing-real-account regression risk — landed via cross-account probe.

## Test plan

- [x] `node --test tests/redaction-access-matrix.test.js`: 25 pass, 0 fail.
- [x] `node --test tests/worker-access.test.js tests/hub-shell-access.test.js tests/worker-backend.test.js tests/worker-demo-session.test.js tests/worker-hubs.test.js`: 40 pass, 0 fail (no existing regressions).
- [x] PII scan on new test file: zero real-identifier findings.

## Notes

- `/api/security/csp-report` row intentionally deferred to U7 (endpoint ships there).
- Dev-stub session provider does not track `demo` flag; matrix documents this explicitly as a "dev-stub gap (documented)" row — production session provider is what ships, F-10 is locked there.
- `FORBIDDEN_KEYS_EVERYWHERE` oracle is now shared between the matrix test and `scripts/production-bundle-audit.mjs` — any future extension must update both (single-source-of-truth enforced by reference).