### PR TITLE
feat(spelling): U5 post-Mega dashboard + Alt+4 shortcut

### DIFF
--- a/docs/spelling-service.md
+++ b/docs/spelling-service.md
@@ -170,7 +170,7 @@ These were kept on purpose:
 - SATs test mode stays statutory core-only, even if the learner has selected Extra elsewhere
 - skipping only works in learning question phase and pushes the word later in the round
 - marked cards auto-advance after the preserved short delay instead of needing an extra manual confirmation step
-- the preserved shortcut loop remains available inside active Spelling practice (`Esc`, `Shift+Esc`, `Alt+1/2/3`, `Alt+S`, `Alt+K`) while still avoiding cross-subject collisions in the wider shell
+- the preserved shortcut loop remains available inside active Spelling practice (`Esc`, `Shift+Esc`, `Alt+1/2/3`, `Alt+S`, `Alt+K`) while still avoiding cross-subject collisions in the wider shell; `Alt+4` is an additive Guardian Mission quick-start that is gated at the module layer on `allWordsMega` (silent no-op when the learner has not graduated)
 - dictation audio honours the learner's selected profile provider: OpenAI, Gemini, or local browser speech
 - stage progression and due-day scheduling still come from the preserved legacy engine
 

--- a/shared/spelling/service.js
+++ b/shared/spelling/service.js
@@ -726,6 +726,45 @@ export function createSpellingService({ repository, storage, tts, now, random, c
     };
   }
 
+  /**
+   * Live post-mastery snapshot for UI consumers. Derives the same aggregates
+   * as `getSpellingPostMasteryState` (read-model) but against the in-memory
+   * service state so the Setup scene, Alt+4 gate, and summary copy see a
+   * consistent view without drilling a read-model through the container tree.
+   *
+   * Returns: { allWordsMega, guardianDueCount, wobblingCount, nextGuardianDueDay, todayDay, guardianMap }
+   * The raw `guardianMap` is included so UI consumers can compute per-word
+   * labels (e.g. "Wobbling — due tomorrow") via `guardianLabel` without a
+   * second round-trip to storage.
+   */
+  function getPostMasteryState(learnerId) {
+    const progressStore = progressSnapshot(learnerId) || {};
+    const guardianMap = loadGuardianMap(learnerId);
+    const today = currentTodayDay();
+    const allWordsMega = isAllWordsMega(progressStore);
+
+    let guardianDueCount = 0;
+    let wobblingCount = 0;
+    let nextGuardianDueDay = null;
+    for (const record of Object.values(guardianMap)) {
+      if (!record) continue;
+      if (record.nextDueDay <= today) guardianDueCount += 1;
+      if (record.wobbling === true) wobblingCount += 1;
+      if (nextGuardianDueDay === null || record.nextDueDay < nextGuardianDueDay) {
+        nextGuardianDueDay = record.nextDueDay;
+      }
+    }
+
+    return {
+      allWordsMega,
+      guardianDueCount,
+      wobblingCount,
+      nextGuardianDueDay,
+      todayDay: today,
+      guardianMap,
+    };
+  }
+
   function buildResumeSession(rawSession, learnerId) {
     if (!rawSession || typeof rawSession !== 'object' || Array.isArray(rawSession)) {
       return { session: null, summary: null, error: 'This spelling session is missing its saved state.' };
@@ -1526,6 +1565,7 @@ export function createSpellingService({ repository, storage, tts, now, random, c
     getStats,
     getWordBankEntry,
     getAnalyticsSnapshot,
+    getPostMasteryState,
     startSession,
     submitAnswer,
     continueSession,

--- a/src/subjects/spelling/client-read-models.js
+++ b/src/subjects/spelling/client-read-models.js
@@ -111,6 +111,26 @@ export function createSpellingReadModelService({ getState = () => null } = {}) {
     getAnalyticsSnapshot(learnerId) {
       return cloneSerialisable(readModel(learnerId).analytics || emptyAnalytics());
     },
+    getPostMasteryState(learnerId) {
+      // Remote-sync runtime: the shell does not have direct access to the
+      // learner's guardian map, so the read-model falls back to "not
+      // graduated yet". The server-synced surface re-issues the Setup scene
+      // through the next cached command response which carries the real
+      // state via the Worker engine. This keeps the Setup render stable
+      // while the first round trip is in flight.
+      const cached = readModel(learnerId).postMastery;
+      if (cached && typeof cached === 'object' && !Array.isArray(cached)) {
+        return cloneSerialisable(cached);
+      }
+      return {
+        allWordsMega: false,
+        guardianDueCount: 0,
+        wobblingCount: 0,
+        nextGuardianDueDay: null,
+        todayDay: Math.floor(Date.now() / (24 * 60 * 60 * 1000)),
+        guardianMap: {},
+      };
+    },
     getAudioCue(learnerId) {
       return cloneSerialisable(readModel(learnerId).audio || null);
     },

--- a/src/subjects/spelling/components/SpellingSetupScene.jsx
+++ b/src/subjects/spelling/components/SpellingSetupScene.jsx
@@ -5,6 +5,7 @@ import { ArrowRightIcon, CheckIcon } from './spelling-icons.jsx';
 import { useSetupHeroContrast } from './useSetupHeroContrast.js';
 import {
   MODE_CARDS,
+  POST_MEGA_MODE_CARDS,
   ROUND_LENGTH_OPTIONS,
   YEAR_FILTER_OPTIONS,
   beginLabel,
@@ -39,6 +40,106 @@ function ModeCard({ mode, selected, disabled = false, description, badge, action
       <h4>{mode.title}</h4>
       <p>{desc}</p>
     </button>
+  );
+}
+
+/* Post-Mega cards render a typographic glyph instead of a webp asset — we
+ * have not drawn Guardian / Boss / Detective / Story art yet, and shipping
+ * a generic spotlight icon would cheapen the graduation moment. The glyph
+ * sits inside the same mc-icon frame so the card silhouette stays identical
+ * to the legacy MODE_CARDS rhythm. */
+function ModeCardGlyph({ glyph }) {
+  return (
+    <div className="mc-icon mc-icon-glyph" aria-hidden="true">
+      <span className="mc-glyph">{glyph}</span>
+    </div>
+  );
+}
+
+function PostMegaModeCard({
+  mode,
+  variant,
+  description,
+  badge,
+  index,
+  textTone = 'dark',
+  disabled = false,
+  active = false,
+}) {
+  const classes = ['mode-card', 'mode-card-post'];
+  if (variant) classes.push(`mode-card-post--${variant}`);
+  if (disabled) classes.push('is-disabled');
+  if (active) classes.push('is-active-duty');
+  const roadmapNumber = typeof index === 'number' ? String(index + 1).padStart(2, '0') : null;
+  return (
+    <div
+      className={classes.join(' ')}
+      data-text-tone={textTone}
+      data-mode-id={mode.id}
+      aria-disabled={disabled ? 'true' : undefined}
+    >
+      <div className="mc-top">
+        <ModeCardGlyph glyph={mode.glyph || mode.title?.[0] || '·'} />
+        {badge ? (
+          <span className={`mc-badge mc-badge-post${variant ? ` mc-badge-post--${variant}` : ''}`}>{badge}</span>
+        ) : roadmapNumber ? (
+          <span className="mc-badge mc-badge-post mc-badge-roadmap">
+            <span className="mc-badge-roadmap-label">Next</span>
+            <span className="mc-badge-roadmap-index">{roadmapNumber}</span>
+          </span>
+        ) : null}
+      </div>
+      <h4>{mode.title}</h4>
+      <p>{description != null ? description : mode.desc}</p>
+      {/* The Guardian card intentionally does NOT host an inline Begin button
+       * — a single primary CTA lives in the setup-begin-row below so there
+       * is one clear "start now" affordance per scene. In the rested state
+       * we surface a static "Rested" chip instead. */}
+      {variant === 'rested' ? (
+        <span className="mode-card-post-status" role="status">Rested</span>
+      ) : null}
+    </div>
+  );
+}
+
+function GraduationStatRibbon({ postMastery, secureCount }) {
+  const dueCount = Math.max(0, Number(postMastery?.guardianDueCount) || 0);
+  const wobblingCount = Math.max(0, Number(postMastery?.wobblingCount) || 0);
+  const today = Number.isFinite(Number(postMastery?.todayDay)) ? Math.floor(Number(postMastery.todayDay)) : 0;
+  const nextDue = Number.isFinite(Number(postMastery?.nextGuardianDueDay)) ? Math.floor(Number(postMastery.nextGuardianDueDay)) : null;
+  const nextDueDelta = nextDue == null ? null : nextDue - today;
+
+  const items = [];
+  if (Number.isFinite(secureCount) && secureCount > 0) {
+    items.push({ label: 'Words secured', value: String(secureCount) });
+  }
+  items.push({
+    label: 'Due today',
+    value: String(dueCount),
+    accent: dueCount > 0 ? 'due' : null,
+  });
+  if (wobblingCount > 0) {
+    items.push({ label: 'Wobbling', value: String(wobblingCount), accent: 'wobbling' });
+  }
+  if (nextDueDelta !== null && dueCount === 0) {
+    items.push({
+      label: 'Next check',
+      value: nextDueDelta <= 0 ? 'today' : nextDueDelta === 1 ? 'tomorrow' : `in ${nextDueDelta} days`,
+    });
+  }
+
+  return (
+    <dl className="post-mega-stat-ribbon" aria-label="Guardian duty overview">
+      {items.map((item) => (
+        <div
+          className={`post-mega-stat${item.accent ? ` post-mega-stat--${item.accent}` : ''}`}
+          key={item.label}
+        >
+          <dt>{item.label}</dt>
+          <dd>{item.value}</dd>
+        </div>
+      ))}
+    </dl>
   );
 }
 
@@ -184,18 +285,14 @@ export function SpellingSetupScene({
   codex,
   accent,
   actions,
+  postMastery,
   setupHeroTone = '',
   previousHeroBg = '',
   runtimeReadOnly = false,
 }) {
   const statsFilter = prefs.mode === 'test' ? 'core' : prefs.yearFilter;
   const stats = service.getStats(learner.id, statsFilter);
-  const begin = beginLabel(prefs);
   const heroBg = heroBgForSetup(learner.id, prefs, { tone: setupHeroTone });
-  const hideTweaks = prefs.mode === 'test';
-  const tweakClass = `tweak-row${hideTweaks ? ' is-placeholder' : ''}`;
-  const tweakAria = hideTweaks ? { 'aria-hidden': 'true' } : {};
-  const showExtraFamilyOption = !hideTweaks && prefs.yearFilter === 'extra';
   const mergedHeroStyle = { ...heroBgStyle(heroBg) };
   const heroContrast = useSetupHeroContrast(heroBg, prefs.mode);
   const heroTone = heroContrast.contrast.tone || heroToneForBg(heroBg);
@@ -203,12 +300,10 @@ export function SpellingSetupScene({
   const pendingCommand = ui?.pendingCommand || '';
   const preferenceControlsDisabled = runtimeReadOnly || Boolean(pendingCommand && pendingCommand !== 'save-prefs');
   const startDisabled = runtimeReadOnly || Boolean(pendingCommand);
-  const beginText = pendingCommand === 'start-session'
-    ? 'Starting...'
-    : pendingCommand === 'save-prefs'
-      ? 'Saving...'
-      : begin;
   if (heroContrast.contrast.shell === 'light') setupClasses.push('hero-dark');
+  const isPostMega = Boolean(postMastery?.allWordsMega);
+  const contentClasses = ['setup-content'];
+  if (isPostMega) contentClasses.push('setup-content--post-mega');
 
   return (
     <div className="setup-grid" style={{ gridColumn: '1/-1' }}>
@@ -217,71 +312,36 @@ export function SpellingSetupScene({
         data-react-hero-contrast="true"
         data-hero-tone={heroTone || undefined}
         data-controls-tone={heroContrast.contrast.controls}
+        data-post-mega={isPostMega ? 'true' : undefined}
         ref={heroContrast.ref}
         style={mergedHeroStyle}
       >
         <SpellingHeroBackdrop url={heroBg} previousUrl={previousHeroBg} />
-        <div className="setup-content">
-          <p className="eyebrow">Round setup</p>
-          <h1 className="title">Choose today’s journey.</h1>
-          <p className="lede">Smart Review mixes what’s due, what wobbled last time, and one or two new words. You can go straight to trouble drills or SATs rehearsal if you’d rather.</p>
-          <div className="mode-row">
-            {MODE_CARDS.map((mode, index) => (
-              mode.id === 'trouble' && !stats.trouble
-                ? (
-                  <ModeCard
-                    mode={mode}
-                    selected={prefs.mode === mode.id}
-                    disabled
-                    description="No trouble words yet. Try a round first."
-                    badge="NONE YET"
-                    actions={actions}
-                    textTone={heroContrast.contrast.cards[index] || heroContrast.contrast.shell}
-                    key={mode.id}
-                  />
-                )
-                : (
-                  <ModeCard
-                    mode={mode}
-                    selected={prefs.mode === mode.id}
-                    disabled={preferenceControlsDisabled}
-                    actions={actions}
-                    textTone={heroContrast.contrast.cards[index] || heroContrast.contrast.shell}
-                    key={mode.id}
-                  />
-                )
-            ))}
-          </div>
-          <div className="setup-control-stack">
-            <div className={tweakClass} {...tweakAria}>
-              <span className="tool-label">Round length</span>
-              <LengthPicker prefs={prefs} actions={actions} disabled={hideTweaks || preferenceControlsDisabled} />
-            </div>
-            <div className={tweakClass} {...tweakAria}>
-              <span className="tool-label">Pool</span>
-              <YearPicker prefs={prefs} actions={actions} disabled={hideTweaks || preferenceControlsDisabled} />
-            </div>
-            <div className="tweak-row">
-              <span className="tool-label">Options</span>
-              <ToggleChip pref="showCloze" checked={Boolean(prefs.showCloze)} label="Show sentence" actions={actions} disabled={preferenceControlsDisabled} />
-              <ToggleChip pref="autoSpeak" checked={Boolean(prefs.autoSpeak)} label="Auto-play audio" actions={actions} disabled={preferenceControlsDisabled} />
-              {showExtraFamilyOption ? (
-                <ToggleChip pref="extraWordFamilies" checked={Boolean(prefs.extraWordFamilies)} label="Word-family variants" actions={actions} disabled={preferenceControlsDisabled} />
-              ) : <span className="toggle-chip option-placeholder" aria-hidden="true" />}
-            </div>
-          </div>
-          <div className="setup-begin-row">
-            <button
-              type="button"
-              className="btn primary xl"
-              style={{ '--btn-accent': accent }}
-              data-action="spelling-start"
-              disabled={startDisabled}
-              onClick={(event) => renderAction(actions, event, 'spelling-start')}
-            >
-              {beginText} <ArrowRightIcon />
-            </button>
-          </div>
+        <div className={contentClasses.join(' ')}>
+          {isPostMega ? (
+            <PostMegaSetupContent
+              prefs={prefs}
+              accent={accent}
+              actions={actions}
+              postMastery={postMastery}
+              stats={stats}
+              heroContrast={heroContrast}
+              pendingCommand={pendingCommand}
+              startDisabled={startDisabled}
+              runtimeReadOnly={runtimeReadOnly}
+            />
+          ) : (
+            <LegacySetupContent
+              prefs={prefs}
+              accent={accent}
+              actions={actions}
+              stats={stats}
+              heroContrast={heroContrast}
+              pendingCommand={pendingCommand}
+              preferenceControlsDisabled={preferenceControlsDisabled}
+              startDisabled={startDisabled}
+            />
+          )}
         </div>
       </section>
 
@@ -316,5 +376,197 @@ export function SpellingSetupScene({
         </div>
       </aside>
     </div>
+  );
+}
+
+function LegacySetupContent({
+  prefs,
+  accent,
+  actions,
+  stats,
+  heroContrast,
+  pendingCommand,
+  preferenceControlsDisabled,
+  startDisabled,
+}) {
+  const begin = beginLabel(prefs);
+  const hideTweaks = prefs.mode === 'test';
+  const tweakClass = `tweak-row${hideTweaks ? ' is-placeholder' : ''}`;
+  const tweakAria = hideTweaks ? { 'aria-hidden': 'true' } : {};
+  const showExtraFamilyOption = !hideTweaks && prefs.yearFilter === 'extra';
+  const beginText = pendingCommand === 'start-session'
+    ? 'Starting...'
+    : pendingCommand === 'save-prefs'
+      ? 'Saving...'
+      : begin;
+
+  return (
+    <>
+      <p className="eyebrow">Round setup</p>
+      <h1 className="title">Choose today’s journey.</h1>
+      <p className="lede">Smart Review mixes what’s due, what wobbled last time, and one or two new words. You can go straight to trouble drills or SATs rehearsal if you’d rather.</p>
+      <div className="mode-row">
+        {MODE_CARDS.map((mode, index) => (
+          mode.id === 'trouble' && !stats.trouble
+            ? (
+              <ModeCard
+                mode={mode}
+                selected={prefs.mode === mode.id}
+                disabled
+                description="No trouble words yet. Try a round first."
+                badge="NONE YET"
+                actions={actions}
+                textTone={heroContrast.contrast.cards[index] || heroContrast.contrast.shell}
+                key={mode.id}
+              />
+            )
+            : (
+              <ModeCard
+                mode={mode}
+                selected={prefs.mode === mode.id}
+                disabled={preferenceControlsDisabled}
+                actions={actions}
+                textTone={heroContrast.contrast.cards[index] || heroContrast.contrast.shell}
+                key={mode.id}
+              />
+            )
+        ))}
+      </div>
+      <div className="setup-control-stack">
+        <div className={tweakClass} {...tweakAria}>
+          <span className="tool-label">Round length</span>
+          <LengthPicker prefs={prefs} actions={actions} disabled={hideTweaks || preferenceControlsDisabled} />
+        </div>
+        <div className={tweakClass} {...tweakAria}>
+          <span className="tool-label">Pool</span>
+          <YearPicker prefs={prefs} actions={actions} disabled={hideTweaks || preferenceControlsDisabled} />
+        </div>
+        <div className="tweak-row">
+          <span className="tool-label">Options</span>
+          <ToggleChip pref="showCloze" checked={Boolean(prefs.showCloze)} label="Show sentence" actions={actions} disabled={preferenceControlsDisabled} />
+          <ToggleChip pref="autoSpeak" checked={Boolean(prefs.autoSpeak)} label="Auto-play audio" actions={actions} disabled={preferenceControlsDisabled} />
+          {showExtraFamilyOption ? (
+            <ToggleChip pref="extraWordFamilies" checked={Boolean(prefs.extraWordFamilies)} label="Word-family variants" actions={actions} disabled={preferenceControlsDisabled} />
+          ) : <span className="toggle-chip option-placeholder" aria-hidden="true" />}
+        </div>
+      </div>
+      <div className="setup-begin-row">
+        <button
+          type="button"
+          className="btn primary xl"
+          style={{ '--btn-accent': accent }}
+          data-action="spelling-start"
+          disabled={startDisabled}
+          onClick={(event) => renderAction(actions, event, 'spelling-start')}
+        >
+          {beginText} <ArrowRightIcon />
+        </button>
+      </div>
+    </>
+  );
+}
+
+/* Post-Mega dashboard content. The whole of Setup-main shares the existing
+ * hero backdrop / controls-tone tokens, but the lede, mode row, and begin
+ * button are reshaped around Guardian Mission as the only active path.
+ *
+ * Visual intent (design notes):
+ *  - Lede is declarative ("The Word Vault is yours.") rather than a cheer.
+ *  - Stats ribbon reads as a duty roster, not a victory lap.
+ *  - Guardian card has a distinct "ACTIVE DUTY" badge + CTA baked into the
+ *    card footer — this is the primary path, so its affordance lives where
+ *    the eye goes after the title.
+ *  - Disabled placeholder cards show a subtle roadmap index (Next 02 / 03 /
+ *    04) rather than a greyed-out "Coming soon" shield, so kids read the
+ *    card as "next in the journey" rather than "empty". */
+function PostMegaSetupContent({
+  prefs,
+  accent,
+  actions,
+  postMastery,
+  stats,
+  heroContrast,
+  pendingCommand,
+  startDisabled,
+  runtimeReadOnly,
+}) {
+  const guardianCard = POST_MEGA_MODE_CARDS.find((mode) => mode.id === 'guardian') || POST_MEGA_MODE_CARDS[0];
+  const otherCards = POST_MEGA_MODE_CARDS.filter((mode) => mode.id !== 'guardian');
+  const dueCount = Math.max(0, Number(postMastery?.guardianDueCount) || 0);
+  const wobblingCount = Math.max(0, Number(postMastery?.wobblingCount) || 0);
+  const guardianActive = dueCount > 0;
+  const secureCount = Number(stats?.secure) || 0;
+  const guardianDescription = guardianActive
+    ? wobblingCount > 0
+      ? `${dueCount} word${dueCount === 1 ? '' : 's'} need a check today — ${wobblingCount} wobbling.`
+      : `${dueCount} word${dueCount === 1 ? '' : 's'} ready for their Guardian check.`
+    : 'All guardians rested — return tomorrow to patrol the Vault again.';
+  const missionBadge = guardianActive ? 'ACTIVE DUTY' : 'ALL RESTED';
+  const beginDisabled = startDisabled || runtimeReadOnly || !guardianActive;
+  const beginText = pendingCommand === 'start-session'
+    ? 'Starting...'
+    : pendingCommand === 'save-prefs'
+      ? 'Saving...'
+      : 'Begin Guardian Mission';
+
+  function handleBegin(event) {
+    if (beginDisabled) {
+      event?.preventDefault?.();
+      event?.stopPropagation?.();
+      return;
+    }
+    renderAction(actions, event, 'spelling-shortcut-start', { mode: 'guardian' });
+  }
+
+  return (
+    <>
+      <p className="eyebrow post-mega-eyebrow">Graduated · Spelling Guardian</p>
+      <h1 className="title post-mega-title">The Word Vault is yours.</h1>
+      <p className="lede post-mega-lede">
+        Every core word is secure. Your job now is to keep the Vault strong — short daily checks on
+        words you already own. Smart Review, Trouble Drill, and the SATs Test have done their work.
+      </p>
+      <GraduationStatRibbon postMastery={postMastery} secureCount={secureCount} />
+      <div className="mode-row mode-row-post-mega" data-variant={guardianActive ? 'active' : 'rested'}>
+        <PostMegaModeCard
+          mode={guardianCard}
+          variant={guardianActive ? 'active' : 'rested'}
+          description={guardianDescription}
+          badge={missionBadge}
+          textTone={heroContrast.contrast.cards?.[0] || heroContrast.contrast.shell}
+          active={guardianActive}
+          disabled={!guardianActive}
+        />
+        {otherCards.map((mode, index) => (
+          <PostMegaModeCard
+            mode={mode}
+            variant="placeholder"
+            index={index + 1}
+            textTone={heroContrast.contrast.cards?.[index + 1] || heroContrast.contrast.shell}
+            disabled
+            key={mode.id}
+          />
+        ))}
+      </div>
+      <div className="setup-begin-row post-mega-begin-row">
+        <div className="post-mega-begin-hint" aria-hidden={guardianActive ? undefined : 'true'}>
+          <kbd>Alt</kbd>
+          <span className="post-mega-begin-hint-join">+</span>
+          <kbd>4</kbd>
+          <span className="post-mega-begin-hint-label">quick-start Guardian Mission</span>
+        </div>
+        <button
+          type="button"
+          className="btn primary xl"
+          style={{ '--btn-accent': accent }}
+          data-action="spelling-shortcut-start"
+          data-mode="guardian"
+          disabled={beginDisabled}
+          onClick={handleBegin}
+        >
+          {beginText} <ArrowRightIcon />
+        </button>
+      </div>
+    </>
   );
 }

--- a/src/subjects/spelling/components/spelling-view-model.js
+++ b/src/subjects/spelling/components/spelling-view-model.js
@@ -26,6 +26,47 @@ export const MODE_CARDS = Object.freeze([
     desc: 'One-shot dictation, no retries.',
   },
 ]);
+
+/* Post-Mega dashboard cards. Guardian Mission is the only active card in MVP;
+ * Boss Dictation / Word Detective / Story Challenge are preview placeholders
+ * that set the P2+ roadmap without promising dates. Icons stay null because
+ * the Guardian / future-mode art has not been drawn yet — the component
+ * renders a typographic glyph placeholder in its place so we never ship an
+ * off-brand generic icon. */
+export const POST_MEGA_MODE_CARDS = Object.freeze([
+  {
+    id: 'guardian',
+    iconSrc: null,
+    glyph: 'G',
+    title: 'Guardian Mission',
+    desc: 'Protect the Word Vault. A short check on words you already own.',
+    disabled: false,
+  },
+  {
+    id: 'boss-dictation',
+    iconSrc: null,
+    glyph: 'B',
+    title: 'Boss Dictation',
+    desc: 'Coming soon — one-shot dictation challenges against a bigger boss.',
+    disabled: true,
+  },
+  {
+    id: 'word-detective',
+    iconSrc: null,
+    glyph: 'D',
+    title: 'Word Detective',
+    desc: 'Coming soon — spot what went wrong in tricky misspellings.',
+    disabled: true,
+  },
+  {
+    id: 'story-challenge',
+    iconSrc: null,
+    glyph: 'S',
+    title: 'Story Challenge',
+    desc: 'Coming soon — weave secure words into a story mission.',
+    disabled: true,
+  },
+]);
 export const ROUND_LENGTH_OPTIONS = Object.freeze(['10', '20', '40']);
 export const YEAR_FILTER_OPTIONS = Object.freeze([
   { value: 'core', label: 'Core' },
@@ -410,7 +451,39 @@ export function summaryModeLabel(mode) {
   if (mode === 'trouble') return 'Trouble Drill';
   if (mode === 'test') return 'SATs Test';
   if (mode === 'single') return 'Single-word Drill';
+  if (mode === 'guardian') return 'Guardian Mission';
   return 'Smart Review';
+}
+
+/**
+ * Human-readable microcopy for a single guardian record. Used on the
+ * post-Mega dashboard to explain why a word is in the Vault today.
+ *
+ * Rules:
+ *  - If the record is missing, report "Not guarded yet".
+ *  - If the record is wobbling, lead with "Wobbling" regardless of due day.
+ *  - Otherwise render the next-check delta (today / in 1 day / in N days).
+ *
+ * `todayDay` should be an integer day (Math.floor(ts / DAY_MS)), matching
+ * the convention used by the rest of the spelling read-model.
+ */
+export function guardianLabel(record, todayDay) {
+  if (!record || typeof record !== 'object' || Array.isArray(record)) {
+    return 'Not guarded yet';
+  }
+  const today = Number.isFinite(Number(todayDay)) ? Math.floor(Number(todayDay)) : 0;
+  const nextDue = Number.isFinite(Number(record.nextDueDay)) ? Math.floor(Number(record.nextDueDay)) : today;
+  const delta = nextDue - today;
+
+  if (record.wobbling === true) {
+    if (delta <= 0) return 'Wobbling — due today';
+    if (delta === 1) return 'Wobbling — due in 1 day';
+    return `Wobbling — due in ${delta} days`;
+  }
+
+  if (delta <= 0) return 'Due today';
+  if (delta === 1) return 'Next check in 1 day';
+  return `Next check in ${delta} days`;
 }
 
 export function summaryHeadline(summary) {
@@ -488,12 +561,27 @@ export function buildSpellingContext({ appState, service, repositories, subject 
   };
   const needsAnalytics = ui.phase === 'dashboard' || ui.phase === 'word-bank';
   const analytics = needsAnalytics ? service.getAnalyticsSnapshot(learner.id) : null;
+  // Post-mastery aggregates are only needed for the dashboard branch. On
+  // other phases we return a conservative default so downstream code never
+  // has to null-check the field. The service contract guarantees this shape
+  // after U5.
+  const postMastery = ui.phase === 'dashboard' && typeof service.getPostMasteryState === 'function'
+    ? service.getPostMasteryState(learner.id)
+    : {
+        allWordsMega: false,
+        guardianDueCount: 0,
+        wobblingCount: 0,
+        nextGuardianDueDay: null,
+        todayDay: Math.floor(Date.now() / DAY_MS),
+        guardianMap: {},
+      };
   return {
     learner,
     ui,
     accent: accentFor(subject),
     prefs: service.getPrefs(learner.id),
     analytics,
+    postMastery,
     codex: ui.phase === 'dashboard' && analytics
       ? monsterSummaryFromSpellingAnalytics(analytics, {
           learnerId: learner.id,

--- a/src/subjects/spelling/module.js
+++ b/src/subjects/spelling/module.js
@@ -211,6 +211,19 @@ export const spellingModule = {
     if (action === 'spelling-shortcut-start') {
       const mode = data.mode;
       if (!mode) return true;
+      // Guardian Mission is gated on allWordsMega. The Alt+4 keybinding fires
+      // this action unconditionally (so the shortcut resolver stays dumb and
+      // symmetric with Alt+1/2/3) — the runtime check lives here so the
+      // shortcut is a no-op instead of accidentally starting a stale Smart
+      // Review round. `service.getPostMasteryState` is defined on the canonical
+      // spelling service; the client-read-model facade returns a conservative
+      // `allWordsMega: false` shape so the gate fails safe under remote-sync.
+      if (mode === 'guardian') {
+        const postMastery = typeof service.getPostMasteryState === 'function'
+          ? service.getPostMasteryState(learnerId)
+          : null;
+        if (!postMastery?.allWordsMega) return true;
+      }
       if (ui.phase === 'session') {
         const confirmed = globalThis.confirm?.('End the current spelling session and switch?');
         if (confirmed === false) return true;

--- a/src/subjects/spelling/shortcuts.js
+++ b/src/subjects/spelling/shortcuts.js
@@ -50,6 +50,13 @@ export function resolveSpellingShortcut(event, appState) {
   if (key === '3') {
     return { action: 'spelling-shortcut-start', data: { mode: 'test' }, preventDefault: true };
   }
+  // Alt+4 — Guardian Mission quick-start. The keybinding is additive; the
+  // allWordsMega gate lives in `module.js::spelling-shortcut-start` so a
+  // learner who hasn't graduated yet gets a silent no-op instead of a stale
+  // Smart Review round. Alt+1/2/3 mappings are preserved verbatim.
+  if (key === '4') {
+    return { action: 'spelling-shortcut-start', data: { mode: 'guardian' }, preventDefault: true };
+  }
   if (key === 's') {
     if (spellingUi?.phase === 'session' && spellingUi.session?.type !== 'test' && spellingUi.session?.phase === 'question' && !spellingUi.awaitingAdvance) {
       return { action: 'spelling-skip', preventDefault: true };

--- a/styles/app.css
+++ b/styles/app.css
@@ -4471,6 +4471,283 @@ textarea:focus-visible {
   visibility: hidden;
 }
 
+/* =============================================================
+   Post-Mega dashboard (U5)
+   -------------------------------------------------------------
+   Dense block of Guardian-specific styling. The section reuses
+   the existing hero backdrop, text-tone tokens, and mode-card
+   silhouette so the transition from Smart Review to Guardian
+   feels like the same scene growing a new capability, not a
+   swap to a different page.
+
+   Visual commitments:
+   - Three distinct card identities: active-duty (accent stroke),
+     all-rested (dashed accent, inert), placeholder (parchment
+     fill + roadmap index).
+   - Typographic glyph placeholder for Guardian / Boss / etc.
+     icons we have not drawn yet — shipping a stock icon would
+     read as "we forgot to finish this".
+   - Stat ribbon sits above the mode row: it reframes the learner
+     as a duty-holder rather than a player chasing a target.
+   ============================================================= */
+.setup-content--post-mega .eyebrow.post-mega-eyebrow {
+  letter-spacing: 0.22em;
+  font-weight: 700;
+  color: color-mix(in oklab, var(--brand) 72%, var(--ink));
+}
+.setup-content--post-mega .title.post-mega-title {
+  font-family: var(--font-serif);
+  letter-spacing: -0.018em;
+  line-height: 1.05;
+  max-width: 22ch;
+}
+.setup-content--post-mega .lede.post-mega-lede {
+  max-width: 58ch;
+  color: var(--mode-card-copy, var(--muted));
+}
+.post-mega-stat-ribbon {
+  margin: 18px 0 4px;
+  padding: 14px 16px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
+  gap: 18px 24px;
+  border-radius: calc(var(--radius) - 2px);
+  border: 1px solid color-mix(in oklab, var(--brand) 26%, transparent);
+  background:
+    linear-gradient(180deg,
+      color-mix(in oklab, var(--brand-soft) 32%, transparent) 0%,
+      color-mix(in oklab, var(--panel) 42%, transparent) 100%);
+  backdrop-filter: blur(16px) saturate(1.1);
+  -webkit-backdrop-filter: blur(16px) saturate(1.1);
+}
+.post-mega-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+.post-mega-stat dt {
+  margin: 0;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: color-mix(in oklab, var(--mode-card-title, var(--ink)) 72%, transparent);
+  text-shadow: var(--mode-card-copy-shadow, none);
+}
+.post-mega-stat dd {
+  margin: 0;
+  font-family: var(--font-serif);
+  font-size: 1.5rem;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: var(--mode-card-title, var(--ink));
+  text-shadow: var(--mode-card-heading-shadow, none);
+}
+.post-mega-stat--due dd { color: var(--warn-strong, color-mix(in oklab, var(--brand) 80%, var(--ink))); }
+.post-mega-stat--wobbling dd { color: color-mix(in oklab, var(--bad-strong, #b3372c) 88%, var(--ink)); }
+
+.mode-row.mode-row-post-mega {
+  grid-template-columns: minmax(0, 1.6fr) repeat(3, minmax(0, 1fr));
+  grid-auto-rows: minmax(196px, auto);
+  gap: 14px;
+  margin-top: 22px;
+}
+@media (max-width: 880px) {
+  .mode-row.mode-row-post-mega {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .mode-row.mode-row-post-mega .mode-card-post:first-child {
+    grid-column: span 2;
+  }
+}
+@media (max-width: 540px) {
+  .mode-row.mode-row-post-mega,
+  .mode-row.mode-row-post-mega .mode-card-post:first-child {
+    grid-template-columns: 1fr;
+    grid-column: auto;
+  }
+}
+.mode-card.mode-card-post {
+  cursor: default;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.mode-card.mode-card-post:hover { transform: none; box-shadow: none; }
+.mode-card.mode-card-post--active {
+  cursor: default;
+  border: 1.75px solid color-mix(in oklab, var(--brand) 82%, transparent);
+  background:
+    linear-gradient(165deg,
+      color-mix(in oklab, var(--brand-soft) 54%, transparent) 0%,
+      color-mix(in oklab, var(--panel) 28%, transparent) 82%),
+    color-mix(in oklab, var(--panel) 22%, transparent);
+  box-shadow:
+    0 18px 42px -28px color-mix(in oklab, var(--brand) 45%, transparent),
+    inset 0 1px 0 color-mix(in oklab, white 38%, transparent);
+}
+.mode-card.mode-card-post--active.is-active-duty {
+  /* Earned authority: a single accent line anchors the card without
+     shouting. Kept subtle so the stat ribbon above does the loud work. */
+  position: relative;
+}
+.mode-card.mode-card-post--active.is-active-duty::before {
+  content: '';
+  position: absolute;
+  inset: auto auto 0 16px;
+  width: 38px;
+  height: 3px;
+  border-radius: 3px;
+  background: color-mix(in oklab, var(--brand) 82%, transparent);
+  opacity: 0.92;
+}
+.mode-card.mode-card-post--rested {
+  cursor: default;
+  border: 1.5px dashed color-mix(in oklab, var(--brand) 46%, transparent);
+  background: color-mix(in oklab, var(--panel) 30%, transparent);
+  filter: none;
+  opacity: 1;
+}
+.mode-card.mode-card-post--placeholder {
+  cursor: default;
+  border: 1.25px solid color-mix(in oklab, var(--brand) 16%, var(--line));
+  background:
+    repeating-linear-gradient(135deg,
+      color-mix(in oklab, var(--panel) 34%, transparent) 0,
+      color-mix(in oklab, var(--panel) 34%, transparent) 6px,
+      color-mix(in oklab, var(--panel) 20%, transparent) 6px,
+      color-mix(in oklab, var(--panel) 20%, transparent) 12px);
+  opacity: 0.94;
+  filter: saturate(0.82);
+}
+.mode-card.mode-card-post--placeholder h4,
+.mode-card.mode-card-post--placeholder p {
+  opacity: 0.88;
+}
+.mode-card .mc-icon.mc-icon-glyph {
+  background:
+    radial-gradient(110% 140% at 12% 16%,
+      color-mix(in oklab, var(--brand-soft) 78%, transparent) 0%,
+      color-mix(in oklab, var(--panel) 26%, transparent) 70%);
+  border-color: color-mix(in oklab, white 44%, transparent);
+  color: color-mix(in oklab, var(--brand) 86%, var(--ink));
+}
+.mode-card-post--active .mc-icon.mc-icon-glyph {
+  background:
+    radial-gradient(120% 160% at 18% 12%,
+      color-mix(in oklab, var(--brand) 88%, transparent) 0%,
+      color-mix(in oklab, var(--brand-soft) 65%, transparent) 80%);
+  color: #fff;
+  border-color: color-mix(in oklab, white 60%, transparent);
+}
+.mode-card-post--placeholder .mc-icon.mc-icon-glyph {
+  background: color-mix(in oklab, var(--panel) 34%, transparent);
+  color: color-mix(in oklab, var(--brand) 36%, var(--ink));
+  border-color: color-mix(in oklab, white 24%, transparent);
+}
+.mc-glyph {
+  font-family: var(--font-serif);
+  font-weight: 600;
+  font-size: 1.6rem;
+  line-height: 1;
+  letter-spacing: -0.02em;
+}
+.mc-badge.mc-badge-post {
+  background: color-mix(in oklab, var(--brand-soft) 60%, transparent);
+  color: color-mix(in oklab, var(--brand) 82%, var(--ink));
+  border: 1px solid color-mix(in oklab, var(--brand) 32%, transparent);
+}
+.mc-badge-post--active {
+  background: color-mix(in oklab, var(--brand) 88%, transparent);
+  color: #fff;
+  border-color: color-mix(in oklab, white 50%, transparent);
+  letter-spacing: 0.12em;
+}
+.mc-badge-post--rested {
+  background: color-mix(in oklab, var(--panel) 50%, transparent);
+  color: color-mix(in oklab, var(--brand) 60%, var(--ink));
+  border-style: dashed;
+  letter-spacing: 0.12em;
+}
+.mc-badge-roadmap {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 1px;
+  padding: 4px 8px 3px;
+  line-height: 1;
+  background: transparent;
+  color: color-mix(in oklab, var(--brand) 56%, var(--ink));
+  border: 0;
+}
+.mc-badge-roadmap-label {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  opacity: 0.62;
+}
+.mc-badge-roadmap-index {
+  font-family: var(--font-serif);
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: color-mix(in oklab, var(--brand) 72%, var(--ink));
+}
+.mode-card-post-cta {
+  margin-top: auto;
+  align-self: flex-start;
+  padding: 8px 14px;
+  font-size: 0.92rem;
+  border-radius: calc(var(--radius) - 6px);
+}
+.mode-card-post-status {
+  margin-top: auto;
+  align-self: flex-start;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--panel) 38%, transparent);
+  color: color-mix(in oklab, var(--brand) 60%, var(--ink));
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  border: 1px dashed color-mix(in oklab, var(--brand) 36%, transparent);
+}
+.setup-begin-row.post-mega-begin-row {
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 28px;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+.post-mega-begin-hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.8rem;
+  color: color-mix(in oklab, var(--mode-card-copy, var(--muted)) 88%, transparent);
+  opacity: 0.86;
+}
+.post-mega-begin-hint[aria-hidden="true"] { opacity: 0.3; }
+.post-mega-begin-hint kbd {
+  display: inline-block;
+  padding: 2px 6px;
+  border-radius: 5px;
+  font-family: var(--font-mono, ui-monospace, 'SFMono-Regular', Menlo, monospace);
+  font-size: 0.72rem;
+  font-weight: 600;
+  line-height: 1.1;
+  background: color-mix(in oklab, var(--panel) 45%, transparent);
+  border: 1px solid color-mix(in oklab, var(--brand) 28%, transparent);
+  color: color-mix(in oklab, var(--brand) 80%, var(--ink));
+  box-shadow: inset 0 -1px 0 color-mix(in oklab, black 10%, transparent);
+}
+.post-mega-begin-hint-join { opacity: 0.55; font-weight: 600; }
+.post-mega-begin-hint-label {
+  letter-spacing: 0.02em;
+  margin-left: 4px;
+}
+
 .setup-control-stack {
   min-height: 196px;
   margin-top: 20px;

--- a/tests/helpers/react-render.js
+++ b/tests/helpers/react-render.js
@@ -693,18 +693,57 @@ export function renderSubjectRouteFixture({ subject = 'placeholder' } = {}) {
   `);
 }
 
-export function renderSpellingSurfaceFixture({ phase = 'setup', pendingCommand = '' } = {}) {
+export function renderSpellingSurfaceFixture({
+  phase = 'setup',
+  pendingCommand = '',
+  // postMega: {} → force allWordsMega via seeded progress + optional guardian
+  // records. Omit to render the legacy setup dashboard.
+  postMega = null,
+} = {}) {
   return renderFixture(`
     import React from 'react';
     import { renderToStaticMarkup } from 'react-dom/server';
     import { SubjectRoute } from ${JSON.stringify(absoluteSpecifier('src/surfaces/subject/SubjectRoute.jsx'))};
     import { createLocalAppController } from ${JSON.stringify(absoluteSpecifier('src/platform/app/create-local-app-controller.js'))};
     import { installMemoryStorage } from ${JSON.stringify(absoluteSpecifier('tests/helpers/memory-storage.js'))};
+    import { WORDS } from ${JSON.stringify(absoluteSpecifier('src/subjects/spelling/data/word-data.js'))};
 
     installMemoryStorage();
     const controller = createLocalAppController();
     const selectedPhase = ${JSON.stringify(phase)};
     const learnerId = controller.store.getState().learners.selectedId;
+    const postMega = ${JSON.stringify(postMega)};
+    if (postMega) {
+      // Seed all core words as stage-4 secure, then optionally drop a guardian
+      // record map on top. The spelling persistence layer proxies the
+      // ks2-spell-progress-/ks2-spell-guardian- keys through the subject-state
+      // repository, so we can write via its storage proxy (or the
+      // repositories.subjectStates.writeData helper) and be picked up on the
+      // next getStats / getPostMasteryState call.
+      const nowDay = Math.floor(Date.now() / (24 * 60 * 60 * 1000));
+      const progress = {};
+      for (const word of WORDS) {
+        if ((word.spellingPool === 'extra' ? 'extra' : 'core') !== 'core') continue;
+        progress[word.slug] = {
+          stage: 4,
+          attempts: 6,
+          correct: 5,
+          wrong: 1,
+          dueDay: nowDay + 60,
+          lastDay: nowDay - 7,
+          lastResult: true,
+        };
+      }
+      const guardian = postMega.guardian && typeof postMega.guardian === 'object'
+        ? postMega.guardian
+        : {};
+      const existing = controller.repositories.subjectStates.read(learnerId, 'spelling').data || {};
+      controller.repositories.subjectStates.writeData(learnerId, 'spelling', {
+        ...existing,
+        progress,
+        guardian,
+      });
+    }
     controller.dispatch('open-subject', { subjectId: 'spelling' });
     if (selectedPhase === 'session' || selectedPhase === 'summary') {
       controller.services.spelling.savePrefs(learnerId, { mode: 'smart', roundLength: '1' });

--- a/tests/react-spelling-surface.test.js
+++ b/tests/react-spelling-surface.test.js
@@ -92,3 +92,86 @@ test('React spelling summary and word bank scenes render migration-critical stat
   assert.match(modalHtml, /aria-labelledby="wb-modal-word"/);
   assert.match(modalHtml, /data-action="spelling-word-bank-drill-submit"/);
 });
+
+// ----- U5: post-Mega dashboard + Alt+4 shortcut --------------------------------
+
+test('React spelling setup scene renders the legacy 3-mode row when allWordsMega is false', async () => {
+  const html = await renderSpellingSurfaceFixture({ phase: 'setup' });
+
+  assert.match(html, /Smart Review/);
+  assert.match(html, /Trouble Drill/);
+  assert.match(html, /SATs Test/);
+  assert.doesNotMatch(html, /Guardian Mission/);
+  assert.doesNotMatch(html, /The Word Vault is yours/);
+  assert.doesNotMatch(html, /Graduated · Spelling Guardian/);
+});
+
+test('React spelling setup scene renders the post-Mega dashboard with Guardian Mission + 3 placeholders when allWordsMega is true and words are due', async () => {
+  // Seed a guardian record that is due today so the Guardian card renders
+  // with the "active duty" treatment, not the "all rested" fallback.
+  const today = Math.floor(Date.now() / (24 * 60 * 60 * 1000));
+  const html = await renderSpellingSurfaceFixture({
+    phase: 'setup',
+    postMega: {
+      guardian: {
+        possess: {
+          reviewLevel: 2,
+          lastReviewedDay: today - 7,
+          nextDueDay: today,
+          correctStreak: 2,
+          lapses: 0,
+          renewals: 0,
+          wobbling: false,
+        },
+      },
+    },
+  });
+
+  assert.match(html, /Graduated · Spelling Guardian/);
+  assert.match(html, /The Word Vault is yours/);
+  assert.match(html, /Guardian Mission/);
+  assert.match(html, /Boss Dictation/);
+  assert.match(html, /Word Detective/);
+  assert.match(html, /Story Challenge/);
+  // Placeholder roadmap labels should show "Next 02/03/04" rather than a
+  // single generic "Coming soon" shield, so the codex reads as planned steps.
+  assert.match(html, /mc-badge-roadmap/);
+  // The begin button explicitly routes through spelling-shortcut-start with
+  // mode=guardian so the module-level gate is the one source of truth.
+  assert.match(html, /data-action="spelling-shortcut-start"[^>]*data-mode="guardian"/);
+  assert.match(html, /ACTIVE DUTY/);
+  assert.doesNotMatch(html, /Choose today/);
+});
+
+test('React spelling setup scene shows "All guardians rested" copy when allWordsMega && guardianDueCount === 0', async () => {
+  // Seed guardians but schedule them all for the future so nothing is due
+  // today. The Begin button should be inert and the card should read as a
+  // quiet signal rather than a greyed-out state.
+  const today = Math.floor(Date.now() / (24 * 60 * 60 * 1000));
+  const html = await renderSpellingSurfaceFixture({
+    phase: 'setup',
+    postMega: {
+      guardian: {
+        possess: {
+          reviewLevel: 2,
+          lastReviewedDay: today,
+          nextDueDay: today + 5,
+          correctStreak: 2,
+          lapses: 0,
+          renewals: 0,
+          wobbling: false,
+        },
+      },
+    },
+  });
+
+  assert.match(html, /Graduated · Spelling Guardian/);
+  assert.match(html, /Guardian Mission/);
+  assert.match(html, /All guardians rested/);
+  assert.match(html, /ALL RESTED/);
+  // The primary begin CTA must be disabled so clicking it does nothing.
+  assert.match(html, /<button[^>]*data-action="spelling-shortcut-start"[^>]*data-mode="guardian"[^>]*disabled=""/);
+  // The rested-state "Rested" chip appears on the Guardian card frame itself.
+  assert.match(html, /mode-card-post-status/);
+  assert.match(html, /Rested/);
+});

--- a/tests/spelling-guardian.test.js
+++ b/tests/spelling-guardian.test.js
@@ -1294,3 +1294,128 @@ test('U4 integration: existing legacy fields of buildSpellingLearnerReadModel ou
   assert.equal(typeof output.currentFocus.recommendedMode, 'string');
   assert.equal(typeof output.currentFocus.label, 'string');
 });
+
+// ----- U5: action routing + Alt+4 shortcut gate -------------------------------
+
+/*
+ * U5 tests rely on the full app harness to exercise the module's
+ * `spelling-shortcut-start` handler. Unlike the pure U3 scheduler tests,
+ * these assertions round-trip through the harness dispatcher → subject
+ * module → spelling service, so a regression in the `mode === 'guardian'`
+ * gate will surface as an unwanted state mutation rather than a unit
+ * assertion.
+ */
+async function importAppHarness() {
+  const mod = await import('./helpers/app-harness.js');
+  return mod.createAppHarness;
+}
+
+test('U5 action routing: spelling-shortcut-start with mode=guardian is a no-op when allWordsMega is false', async () => {
+  const createAppHarness = await importAppHarness();
+  const storage = installMemoryStorage();
+  const harness = createAppHarness({ storage });
+  const learnerId = harness.store.getState().learners.selectedId;
+  harness.services.spelling.savePrefs(learnerId, { mode: 'smart', roundLength: '1' });
+  harness.dispatch('open-subject', { subjectId: 'spelling' });
+  const stateBefore = structuredClone(harness.store.getState().subjectUi.spelling);
+  const prefsBefore = structuredClone(harness.services.spelling.getPrefs(learnerId));
+  assert.equal(prefsBefore.mode, 'smart');
+  assert.equal(stateBefore.phase, 'dashboard');
+
+  harness.dispatch('spelling-shortcut-start', { mode: 'guardian' });
+
+  const stateAfter = harness.store.getState().subjectUi.spelling;
+  const prefsAfter = harness.services.spelling.getPrefs(learnerId);
+  // No session started, no mode mutation, no phase transition.
+  assert.equal(stateAfter.phase, 'dashboard', 'phase must stay on dashboard');
+  assert.equal(stateAfter.session, null, 'no session should be created');
+  assert.equal(prefsAfter.mode, 'smart', 'pref mode must stay on smart — guardian gate is inert');
+});
+
+test('U5 action routing: spelling-shortcut-start with mode=guardian starts a session when allWordsMega is true', async () => {
+  const createAppHarness = await importAppHarness();
+  const storage = installMemoryStorage();
+  const harness = createAppHarness({ storage });
+  const learnerId = harness.store.getState().learners.selectedId;
+  harness.services.spelling.savePrefs(learnerId, { mode: 'smart', roundLength: '1' });
+
+  // Seed every core word to stage 4 via the subjectStates repository (same
+  // proxy the service's storage uses), then open the subject.
+  const today = Math.floor(Date.now() / DAY_MS_TS);
+  seedAllCoreMega(harness.repositories, learnerId, today);
+  harness.dispatch('open-subject', { subjectId: 'spelling' });
+
+  // Sanity check: the service reports post-mastery.
+  const postMastery = harness.services.spelling.getPostMasteryState(learnerId);
+  assert.equal(postMastery.allWordsMega, true);
+
+  harness.dispatch('spelling-shortcut-start', { mode: 'guardian' });
+
+  const stateAfter = harness.store.getState().subjectUi.spelling;
+  const prefsAfter = harness.services.spelling.getPrefs(learnerId);
+  assert.equal(prefsAfter.mode, 'guardian', 'pref saved to guardian before startSession');
+  assert.equal(stateAfter.phase, 'session', 'Guardian Mission session is in flight');
+  assert.equal(stateAfter.session.mode, 'guardian');
+  assert.equal(stateAfter.session.label, 'Guardian Mission');
+  assert.ok(stateAfter.session.id, 'session id assigned');
+});
+
+test('U5 shortcut resolver: Alt+4 maps to spelling-shortcut-start with mode=guardian, regardless of allWordsMega', async () => {
+  const { resolveSpellingShortcut } = await import('../src/subjects/spelling/shortcuts.js');
+  const appState = {
+    route: { subjectId: 'spelling', tab: 'practice' },
+    subjectUi: {
+      spelling: { phase: 'dashboard' },
+    },
+  };
+  // The keybinding layer stays simple — it only produces the action. The
+  // module-level gate decides whether to run it, so the resolver test
+  // doesn't care about allWordsMega at all.
+  assert.deepEqual(resolveSpellingShortcut({
+    key: '4',
+    altKey: true,
+    shiftKey: false,
+    ctrlKey: false,
+    metaKey: false,
+    target: { tagName: 'BODY' },
+  }, appState), {
+    action: 'spelling-shortcut-start',
+    data: { mode: 'guardian' },
+    preventDefault: true,
+  });
+});
+
+test('U5 shortcut resolver: Alt+1/2/3 mappings remain intact after Alt+4 addition', async () => {
+  const { resolveSpellingShortcut } = await import('../src/subjects/spelling/shortcuts.js');
+  const appState = {
+    route: { subjectId: 'spelling', tab: 'practice' },
+    subjectUi: { spelling: { phase: 'dashboard' } },
+  };
+  const smart = resolveSpellingShortcut({
+    key: '1',
+    altKey: true,
+    shiftKey: false,
+    ctrlKey: false,
+    metaKey: false,
+    target: { tagName: 'BODY' },
+  }, appState);
+  assert.deepEqual(smart, { action: 'spelling-shortcut-start', data: { mode: 'smart' }, preventDefault: true });
+  const trouble = resolveSpellingShortcut({
+    key: '2',
+    altKey: true,
+    shiftKey: false,
+    ctrlKey: false,
+    metaKey: false,
+    target: { tagName: 'BODY' },
+  }, appState);
+  assert.deepEqual(trouble, { action: 'spelling-shortcut-start', data: { mode: 'trouble' }, preventDefault: true });
+  const sats = resolveSpellingShortcut({
+    key: '3',
+    altKey: true,
+    shiftKey: false,
+    ctrlKey: false,
+    metaKey: false,
+    target: { tagName: 'BODY' },
+  }, appState);
+  assert.deepEqual(sats, { action: 'spelling-shortcut-start', data: { mode: 'test' }, preventDefault: true });
+});

--- a/tests/spelling-view-model.test.js
+++ b/tests/spelling-view-model.test.js
@@ -1,7 +1,13 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { renderAction } from '../src/subjects/spelling/components/spelling-view-model.js';
+import {
+  MODE_CARDS,
+  POST_MEGA_MODE_CARDS,
+  guardianLabel,
+  renderAction,
+  summaryModeLabel,
+} from '../src/subjects/spelling/components/spelling-view-model.js';
 
 function createEventStub() {
   return {
@@ -138,4 +144,75 @@ test('renderAction keeps spelling start audio immediate when view transitions ar
       globalThis.document = originalDocument;
     }
   }
+});
+
+// ----- U5: post-mega dashboard view-model -------------------------------------
+
+test('POST_MEGA_MODE_CARDS is a frozen array of four cards in Guardian-first order', () => {
+  assert.equal(Array.isArray(POST_MEGA_MODE_CARDS), true);
+  assert.equal(Object.isFrozen(POST_MEGA_MODE_CARDS), true);
+  assert.equal(POST_MEGA_MODE_CARDS.length, 4);
+  const ids = POST_MEGA_MODE_CARDS.map((card) => card.id);
+  assert.deepEqual(ids, ['guardian', 'boss-dictation', 'word-detective', 'story-challenge']);
+});
+
+test('POST_MEGA_MODE_CARDS: Guardian is active, remaining three are disabled placeholders', () => {
+  const [guardian, ...rest] = POST_MEGA_MODE_CARDS;
+  assert.equal(guardian.id, 'guardian');
+  assert.notEqual(guardian.disabled, true);
+  assert.equal(typeof guardian.title, 'string');
+  assert.equal(typeof guardian.desc, 'string');
+  for (const card of rest) {
+    assert.equal(card.disabled, true, `${card.id} must be disabled`);
+    assert.match(card.desc, /coming soon/i, `${card.id} copy should signal a future card, not a grey empty state`);
+  }
+});
+
+test('POST_MEGA_MODE_CARDS does not reuse legacy iconSrc paths', () => {
+  // We are deliberately *not* reusing smart-review.webp / trouble-drill.webp /
+  // sats-test.webp to avoid implying those tools are still active. Each card
+  // either renders a fresh asset or leaves iconSrc null so the component can
+  // draw a typographic placeholder.
+  const legacyIcons = new Set(MODE_CARDS.map((card) => card.iconSrc).filter(Boolean));
+  for (const card of POST_MEGA_MODE_CARDS) {
+    if (card.iconSrc) assert.equal(legacyIcons.has(card.iconSrc), false, `${card.id} must not borrow legacy iconSrc`);
+  }
+});
+
+test('summaryModeLabel handles the new guardian mode', () => {
+  assert.equal(summaryModeLabel('guardian'), 'Guardian Mission');
+  // Regression spot-check: the existing labels still resolve.
+  assert.equal(summaryModeLabel('smart'), 'Smart Review');
+  assert.equal(summaryModeLabel('trouble'), 'Trouble Drill');
+  assert.equal(summaryModeLabel('test'), 'SATs Test');
+  assert.equal(summaryModeLabel('single'), 'Single-word Drill');
+  assert.equal(summaryModeLabel('unknown'), 'Smart Review');
+});
+
+test('guardianLabel: reports "Due today" when nextDueDay <= todayDay and not wobbling', () => {
+  const today = 18_000;
+  assert.equal(guardianLabel({ nextDueDay: today, wobbling: false }, today), 'Due today');
+  assert.equal(guardianLabel({ nextDueDay: today - 2, wobbling: false }, today), 'Due today');
+});
+
+test('guardianLabel: reports "Next check in N days" for future due non-wobbling records', () => {
+  const today = 18_000;
+  assert.equal(guardianLabel({ nextDueDay: today + 3, wobbling: false }, today), 'Next check in 3 days');
+  assert.equal(guardianLabel({ nextDueDay: today + 1, wobbling: false }, today), 'Next check in 1 day');
+  assert.equal(guardianLabel({ nextDueDay: today + 30, wobbling: false }, today), 'Next check in 30 days');
+});
+
+test('guardianLabel: leads with "Wobbling" regardless of due-day delta', () => {
+  const today = 18_000;
+  assert.equal(guardianLabel({ nextDueDay: today + 1, wobbling: true }, today), 'Wobbling — due in 1 day');
+  assert.equal(guardianLabel({ nextDueDay: today + 5, wobbling: true }, today), 'Wobbling — due in 5 days');
+  assert.equal(guardianLabel({ nextDueDay: today, wobbling: true }, today), 'Wobbling — due today');
+});
+
+test('guardianLabel: returns "Not guarded yet" when the record is missing or malformed', () => {
+  const today = 18_000;
+  assert.equal(guardianLabel(null, today), 'Not guarded yet');
+  assert.equal(guardianLabel(undefined, today), 'Not guarded yet');
+  assert.equal(guardianLabel('garbage', today), 'Not guarded yet');
+  assert.equal(guardianLabel([], today), 'Not guarded yet');
 });


### PR DESCRIPTION
## Summary

- Render a Guardian-first post-Mega dashboard on `SpellingSetupScene` when every core word is secure: graduation lede, duty-roster stat ribbon, three card states (active-duty, all-rested, roadmap placeholder).
- Bind Alt+4 to `spelling-shortcut-start(mode='guardian')` with the `allWordsMega` gate living in `module.js` (silent no-op when locked) so the shortcut never starts a stale smart round.
- Legacy Smart / Trouble / Test three-card path is untouched; all spelling-parity invariants still hold.

## Visual direction

Design commitments documented on `/frontend-design`:
- Eyebrow plaque "Graduated · Spelling Guardian" replaces "Round setup". No exclamation marks, no trophy imagery.
- Serif display title "The Word Vault is yours." — declarative, not a cheer.
- Stat ribbon renders as a duty roster ("Words secured · Due today · Wobbling · Next check") so the learner reads the scene as a role, not a victory screen.
- Three distinct card identities: accent-stroked active, dashed-border rested, parchment-fill placeholder with a roadmap index (02/03/04). Disabled cards stay inviting — they preview the codex rather than grey out.
- Single primary CTA at the scene foot ("Begin Guardian Mission" + Alt+4 hint). The Guardian card never duplicates the CTA; one affordance per scene.

## Test plan

- [x] `node --test tests/spelling-view-model.test.js tests/spelling-guardian.test.js tests/react-spelling-surface.test.js tests/spelling-parity.test.js tests/spelling.test.js` — 125/125 green
- [x] SSR rendered the post-Mega and all-rested states and reviewed for AI-slop aesthetic (removed duplicate inline card CTA after iteration 1)
- [x] Alt+4 resolver + module gate assertions (no-op when `allWordsMega=false`, starts Guardian Mission when true)
- [x] Legacy Alt+1/2/3 mappings verified unchanged