### PR TITLE
feat(grammar): U8 view-model layer (session-ui + grammar-view-model)

### DIFF
--- a/src/subjects/grammar/components/grammar-view-model.js
+++ b/src/subjects/grammar/components/grammar-view-model.js
@@ -1,0 +1,503 @@
+// Pure view-model helpers for the Grammar surface. Frozen option lists,
+// child-facing label/tone mappings, filter + search helpers, dashboard and
+// Grammar Bank model builders, forbidden-term fixture. No React imports.
+// No SSR. Every helper is a pure function over plain data so tests can
+// assert behaviour without rendering JSX.
+//
+// The pattern mirrors `src/subjects/spelling/components/spelling-view-model.js`
+// — subject-scoped lists + filter helpers + aggregate card builders. The
+// intent is that every JSX unit in Phase 3 imports from this single file
+// plus `../session-ui.js` rather than restating copy or filter predicates
+// inline. When new forbidden terms appear we add them here once and every
+// child surface inherits the guard through U10's fixture-driven test.
+
+import { GRAMMAR_CLIENT_CONCEPTS } from '../metadata.js';
+import {
+  GRAMMAR_AGGREGATE_CONCEPTS,
+  GRAMMAR_CONCEPT_TO_MONSTER,
+  GRAMMAR_REWARD_RELEASE_ID,
+  grammarConceptIdFromMasteryKey,
+} from '../../../platform/game/mastery/grammar.js';
+import { GRAMMAR_GRAND_MONSTER_ID } from '../../../platform/game/mastery/shared.js';
+
+// --- Frozen option lists ----------------------------------------------------
+
+// The dashboard's four primary mode cards. `Smart Practice` sits first so it
+// is the obvious default action (R2). `Grammar Bank` is the fourth card and
+// routes into U2's new bank scene. `satsset` maps to the existing mode id so
+// the module dispatcher does not need renaming.
+export const GRAMMAR_PRIMARY_MODE_CARDS = Object.freeze([
+  Object.freeze({
+    id: 'smart',
+    title: 'Smart Practice',
+    desc: 'Due · weak · one fresh concept.',
+  }),
+  Object.freeze({
+    id: 'trouble',
+    title: 'Fix Trouble Spots',
+    desc: 'Only the concepts you usually miss.',
+  }),
+  Object.freeze({
+    id: 'satsset',
+    title: 'Mini Test',
+    desc: 'Short timed set. Marks at the end.',
+  }),
+  Object.freeze({
+    id: 'bank',
+    title: 'Grammar Bank',
+    desc: 'Browse every concept with child-friendly statuses.',
+  }),
+]);
+
+// Secondary modes disclosed under the dashboard's "More practice" details
+// block. Order follows the plan: Learn → Sentence Surgery → Sentence Builder
+// → Worked Examples → Faded Guidance.
+export const GRAMMAR_MORE_PRACTICE_MODES = Object.freeze([
+  Object.freeze({ id: 'learn', title: 'Learn a concept', desc: 'Focused retrieval on one concept at a time.' }),
+  Object.freeze({ id: 'surgery', title: 'Sentence Surgery', desc: 'Fix and rewrite sentence-level errors.' }),
+  Object.freeze({ id: 'builder', title: 'Sentence Builder', desc: 'Build sentences from structured prompts.' }),
+  Object.freeze({ id: 'worked', title: 'Worked Examples', desc: 'See a modelled answer before your turn.' }),
+  Object.freeze({ id: 'faded', title: 'Faded Guidance', desc: 'Less help each round. You do the reasoning.' }),
+]);
+
+// Grammar Bank status filter ids. `all` is the default; `due` surfaces
+// concepts the spaced-practice schedule will route next; `trouble` surfaces
+// `needs-repair` concepts; `learning` maps to `building`; `nearly-secure`
+// maps to `consolidating`; `new` maps to `emerging`. The frozen Set lets
+// module actions validate ids in O(1).
+export const GRAMMAR_BANK_STATUS_FILTER_IDS = Object.freeze(new Set([
+  'all',
+  'due',
+  'trouble',
+  'learning',
+  'nearly-secure',
+  'secure',
+  'new',
+]));
+
+// Grammar Bank cluster filter ids. Post-U0 the active roster is 3 direct
+// cluster monsters plus Concordium's whole-Grammar aggregate, so `concordium`
+// shows every concept including the five punctuation-for-grammar ones. The
+// three retired ids (Glossbloom, Loomrill, Mirrane) are intentionally absent.
+export const GRAMMAR_BANK_CLUSTER_FILTER_IDS = Object.freeze(new Set([
+  'all',
+  'bracehart',
+  'chronalyx',
+  'couronnail',
+  'concordium',
+]));
+
+// Hero headline + subheadline for the dashboard. Frozen so U1 can swap it in
+// one place after James reviews the final copy. Subhead MUST be child-facing
+// and must not mention any forbidden term.
+export const GRAMMAR_DASHBOARD_HERO = Object.freeze({
+  title: 'Grammar Garden',
+  subtitle: "One short round. Fix tricky sentences. Grow your Grammar creatures.",
+});
+
+// Frozen order of child-facing Grammar monsters. Post-U0 the active roster
+// is Bracehart, Chronalyx, Couronnail (3 direct clusters) plus Concordium
+// (whole-Grammar aggregate). Retired ids Glossbloom / Loomrill / Mirrane
+// never appear here — summary and dashboard consume this list directly.
+const ACTIVE_GRAMMAR_MONSTER_IDS = Object.freeze([
+  'bracehart',
+  'chronalyx',
+  'couronnail',
+  GRAMMAR_GRAND_MONSTER_ID, // 'concordium'
+]);
+
+const ACTIVE_GRAMMAR_MONSTER_DISPLAY_NAMES = Object.freeze({
+  bracehart: 'Bracehart',
+  chronalyx: 'Chronalyx',
+  couronnail: 'Couronnail',
+  concordium: 'Concordium',
+});
+
+const ACTIVE_GRAMMAR_MONSTER_CONCEPT_COUNTS = Object.freeze({
+  bracehart: 6,
+  chronalyx: 4,
+  couronnail: 3,
+  concordium: GRAMMAR_AGGREGATE_CONCEPTS.length,
+});
+
+// --- Forbidden-terms fixture ------------------------------------------------
+
+// Every adult/developer term that must not appear in child surfaces. U10
+// iterates this list against every child phase. The list is frozen so a
+// rogue mutation would throw rather than silently weakening the guard.
+//
+// Additions here propagate automatically — we do not maintain per-phase
+// override lists. `isGrammarChildCopy` uses a case-insensitive match, so
+// there is no need to duplicate capitalised variants; the wrapper check
+// handles those.
+export const GRAMMAR_CHILD_FORBIDDEN_TERMS = Object.freeze([
+  'Worker',
+  'Worker-marked',
+  'Worker authority',
+  'Worker marked',
+  'Worker-held',
+  'Stage 1',
+  'Full placeholder map',
+  'Full map',
+  'Evidence snapshot',
+  'Reserved reward routes',
+  'Reserved reward',
+  'Bellstorm bridge',
+  '18-concept denominator',
+  'read model',
+  'denominator',
+  'reward route',
+  'projection',
+  'retrieval practice',
+]);
+
+/**
+ * Returns `true` iff `text` contains none of `GRAMMAR_CHILD_FORBIDDEN_TERMS`.
+ * Match is case-insensitive. Empty / non-string input returns `true` so the
+ * helper is safe to call against e.g. `undefined` chip labels.
+ */
+export function isGrammarChildCopy(text) {
+  if (typeof text !== 'string' || !text) return true;
+  const haystack = text.toLowerCase();
+  for (const term of GRAMMAR_CHILD_FORBIDDEN_TERMS) {
+    if (typeof term !== 'string' || !term) continue;
+    if (haystack.includes(term.toLowerCase())) return false;
+  }
+  return true;
+}
+
+// --- Child confidence label mapping -----------------------------------------
+
+const CHILD_CONFIDENCE_LABELS = Object.freeze({
+  emerging: 'New',
+  building: 'Learning',
+  'needs-repair': 'Trouble spot',
+  consolidating: 'Nearly secure',
+  secure: 'Secure',
+});
+
+const CHILD_CONFIDENCE_TONES = Object.freeze({
+  emerging: 'new',
+  building: 'learning',
+  'needs-repair': 'trouble',
+  consolidating: 'nearly-secure',
+  secure: 'secure',
+});
+
+/**
+ * Translates the internal five-label taxonomy (`emerging | building |
+ * consolidating | secure | needs-repair`) into child-friendly copy. Input
+ * shape accepts `{ label }` so callers can pass the entire confidence
+ * projection. Unknown labels fall back to `Learning`, matching the Spelling
+ * wording default.
+ */
+export function grammarChildConfidenceLabel({ label } = {}) {
+  if (typeof label !== 'string') return 'Learning';
+  return CHILD_CONFIDENCE_LABELS[label] || 'Learning';
+}
+
+/**
+ * CSS-class-appropriate tone for each child confidence label. Matches the
+ * status-chip tone family used by Spelling's Word Bank so the visual hierarchy
+ * is consistent across subjects.
+ */
+export function grammarChildConfidenceTone(label) {
+  if (typeof label !== 'string') return 'learning';
+  return CHILD_CONFIDENCE_TONES[label] || 'learning';
+}
+
+// --- Concept → cluster resolver ---------------------------------------------
+
+/**
+ * Resolves a Grammar concept id to its active cluster monster. Returns one
+ * of `'bracehart' | 'chronalyx' | 'couronnail' | 'concordium'`. Concepts
+ * that are punctuation-for-grammar only (e.g. `parenthesis_commas`) live in
+ * Concordium's aggregate cluster — they are not mapped to a direct cluster
+ * in `GRAMMAR_CONCEPT_TO_MONSTER`, so this helper falls back to Concordium.
+ * Unknown concept ids also return `'concordium'` to keep the dashboard safe.
+ */
+export function grammarMonsterClusterForConcept(conceptId) {
+  if (typeof conceptId !== 'string' || !conceptId) return GRAMMAR_GRAND_MONSTER_ID;
+  const directCluster = GRAMMAR_CONCEPT_TO_MONSTER[conceptId];
+  if (directCluster) return directCluster;
+  return GRAMMAR_GRAND_MONSTER_ID;
+}
+
+// --- Grammar Bank filter helpers --------------------------------------------
+
+/**
+ * Maps a child-facing status filter id to the internal confidence label.
+ * `all` matches every label. Otherwise the mapping is the inverse of
+ * `grammarChildConfidenceLabel`. Input `label` is the internal five-label
+ * string (e.g., `'needs-repair'`); input `filter` is the child id (e.g.,
+ * `'trouble'`).
+ */
+export function grammarBankFilterMatchesStatus(filter, label) {
+  if (filter === 'all') return true;
+  if (typeof label !== 'string') return false;
+  if (filter === 'trouble') return label === 'needs-repair';
+  if (filter === 'learning') return label === 'building';
+  if (filter === 'nearly-secure') return label === 'consolidating';
+  if (filter === 'new') return label === 'emerging';
+  if (filter === 'secure') return label === 'secure';
+  if (filter === 'due') return label === 'needs-repair' || label === 'building';
+  return false;
+}
+
+// --- Search helper ----------------------------------------------------------
+
+function normaliseSearchText(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function conceptMatchesQuery(concept, query) {
+  if (!query) return true;
+  const fields = [
+    concept?.name,
+    concept?.summary,
+    concept?.domain,
+    concept?.example,
+    ...(Array.isArray(concept?.examples) ? concept.examples : []),
+  ].map(normaliseSearchText);
+  return fields.some((field) => field.includes(query));
+}
+
+// --- Dashboard model builder ------------------------------------------------
+
+function safeNumber(value, fallback = 0) {
+  const num = Number(value);
+  return Number.isFinite(num) && num >= 0 ? Math.floor(num) : fallback;
+}
+
+function masteredCountForRewardEntry(entry, releaseId = GRAMMAR_REWARD_RELEASE_ID) {
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return 0;
+  const masteredList = Array.isArray(entry.mastered) ? entry.mastered : [];
+  if (masteredList.length === 0) return safeNumber(entry.masteredCount, 0);
+  const conceptIds = new Set();
+  for (const key of masteredList) {
+    const scopedReleaseId = typeof entry.releaseId === 'string' && entry.releaseId
+      ? entry.releaseId
+      : releaseId;
+    const conceptId = grammarConceptIdFromMasteryKey(key, scopedReleaseId);
+    if (conceptId) conceptIds.add(conceptId);
+  }
+  return conceptIds.size || masteredList.length;
+}
+
+function concordiumProgressFromReward(rewardState) {
+  if (!rewardState || typeof rewardState !== 'object' || Array.isArray(rewardState)) {
+    return { mastered: 0, total: GRAMMAR_AGGREGATE_CONCEPTS.length };
+  }
+  const entry = rewardState[GRAMMAR_GRAND_MONSTER_ID];
+  return {
+    mastered: masteredCountForRewardEntry(entry),
+    total: GRAMMAR_AGGREGATE_CONCEPTS.length,
+  };
+}
+
+/**
+ * Builds the dashboard view-model. Pure reducer over the read-model +
+ * learner + reward-state shapes. Returns a safe empty shape when any input
+ * is missing, so the dashboard never throws on a fresh learner.
+ *
+ * Shape:
+ *   {
+ *     modeCards:     Frozen copy of GRAMMAR_PRIMARY_MODE_CARDS,
+ *     todayCards:    Array<{ id, label, value, detail }>,
+ *     concordiumProgress: { mastered: number, total: number },
+ *     primaryMode:   string,  // grammar.prefs.mode
+ *     moreModes:     Frozen copy of GRAMMAR_MORE_PRACTICE_MODES,
+ *     writingTryAvailable: boolean,
+ *   }
+ */
+export function buildGrammarDashboardModel(grammar, _learner, rewardState) {
+  const safeGrammar = grammar && typeof grammar === 'object' && !Array.isArray(grammar) ? grammar : {};
+  const progressSnapshot = safeGrammar.analytics?.progressSnapshot && typeof safeGrammar.analytics.progressSnapshot === 'object'
+    ? safeGrammar.analytics.progressSnapshot
+    : {};
+  const counts = safeGrammar.stats?.concepts || {};
+
+  const dueCount = safeNumber(progressSnapshot.dueConcepts ?? counts.due, 0);
+  const troubleCount = safeNumber(progressSnapshot.weakConcepts ?? counts.weak, 0);
+  const secureCount = safeNumber(progressSnapshot.securedConcepts ?? counts.secured, 0);
+  // Streak is surfaced when the progress snapshot carries it (forward-compat
+  // for U5 / U1 once a real streak field lands). Falls back to 0 today.
+  const streakCount = safeNumber(progressSnapshot.streak ?? progressSnapshot.streakCount, 0);
+
+  const todayCards = [
+    Object.freeze({ id: 'due', label: 'Due', value: dueCount, detail: 'Come back to these today' }),
+    Object.freeze({ id: 'trouble', label: 'Trouble spots', value: troubleCount, detail: 'Fix what wobbles' }),
+    Object.freeze({ id: 'secure', label: 'Secure', value: secureCount, detail: 'You own these' }),
+    Object.freeze({ id: 'streak', label: 'Streak', value: streakCount, detail: 'Rounds in a row' }),
+  ];
+
+  const aiEnabled = safeGrammar.capabilities?.aiEnrichment?.enabled !== false;
+  const primaryMode = typeof safeGrammar.prefs?.mode === 'string' && safeGrammar.prefs.mode
+    ? safeGrammar.prefs.mode
+    : 'smart';
+
+  return {
+    modeCards: GRAMMAR_PRIMARY_MODE_CARDS,
+    todayCards: Object.freeze(todayCards),
+    concordiumProgress: concordiumProgressFromReward(rewardState),
+    primaryMode,
+    moreModes: GRAMMAR_MORE_PRACTICE_MODES,
+    writingTryAvailable: aiEnabled,
+  };
+}
+
+// --- Grammar Bank model builder ---------------------------------------------
+
+function childLabelForConcept(concept) {
+  // Analytics concept shape carries an internal `confidenceLabel` after the
+  // Worker projects it. Older fixtures may only carry a coarse `status` —
+  // `'new' | 'learning' | 'weak' | 'due' | 'secured'`. We map status → label
+  // so the bank renders a child label even on first boot.
+  if (typeof concept?.confidenceLabel === 'string') return concept.confidenceLabel;
+  switch (concept?.status) {
+    case 'secured': return 'secure';
+    case 'due': return 'needs-repair';
+    case 'weak': return 'needs-repair';
+    case 'learning': return 'building';
+    case 'new':
+    default: return 'emerging';
+  }
+}
+
+function defaultConceptMetadata(conceptId) {
+  const entry = GRAMMAR_CLIENT_CONCEPTS.find((concept) => concept.id === conceptId);
+  return entry || { id: conceptId, name: conceptId, summary: '', domain: '' };
+}
+
+function buildBankCard(concept) {
+  const metadata = defaultConceptMetadata(concept?.id || '');
+  const label = childLabelForConcept(concept);
+  return {
+    id: metadata.id,
+    name: concept?.name || metadata.name,
+    domain: concept?.domain || metadata.domain,
+    summary: concept?.summary || metadata.summary,
+    label,
+    childLabel: grammarChildConfidenceLabel({ label }),
+    tone: grammarChildConfidenceTone(label),
+    cluster: grammarMonsterClusterForConcept(metadata.id),
+    attempts: safeNumber(concept?.attempts, 0),
+    correct: safeNumber(concept?.correct, 0),
+    wrong: safeNumber(concept?.wrong, 0),
+  };
+}
+
+function bankCardMatchesFilter(card, { statusFilter, clusterFilter, query }) {
+  if (!grammarBankFilterMatchesStatus(statusFilter || 'all', card.label)) return false;
+  if (clusterFilter && clusterFilter !== 'all') {
+    if (clusterFilter === 'concordium') {
+      // The Concordium filter shows every concept (aggregate view).
+    } else if (card.cluster !== clusterFilter) {
+      return false;
+    }
+  }
+  if (query && !conceptMatchesQuery(card, query)) return false;
+  return true;
+}
+
+function bankCountsFromCards(cards) {
+  const counts = {
+    all: cards.length,
+    due: 0,
+    trouble: 0,
+    learning: 0,
+    'nearly-secure': 0,
+    secure: 0,
+    new: 0,
+  };
+  for (const card of cards) {
+    if (card.label === 'needs-repair') counts.trouble += 1;
+    if (card.label === 'needs-repair' || card.label === 'building') counts.due += 1;
+    if (card.label === 'building') counts.learning += 1;
+    if (card.label === 'consolidating') counts['nearly-secure'] += 1;
+    if (card.label === 'secure') counts.secure += 1;
+    if (card.label === 'emerging') counts.new += 1;
+  }
+  return counts;
+}
+
+/**
+ * Builds the Grammar Bank view-model. Filters by `statusFilter` and
+ * `clusterFilter`, narrows by `query` (searches concept name, summary,
+ * domain, example). Always returns the full 18 concepts when
+ * `{ statusFilter: 'all', clusterFilter: 'all', query: '' }`.
+ */
+export function buildGrammarBankModel(grammar, { statusFilter = 'all', clusterFilter = 'all', query = '' } = {}) {
+  const safeGrammar = grammar && typeof grammar === 'object' && !Array.isArray(grammar) ? grammar : {};
+  const concepts = Array.isArray(safeGrammar.analytics?.concepts)
+    ? safeGrammar.analytics.concepts
+    : [];
+
+  // Ensure every known concept is represented. If the read-model is missing
+  // a concept (e.g., freshly-boot learner), we fall back to the static
+  // metadata so the bank always shows 18 cards when no filter is active.
+  const byId = new Map(concepts.map((entry) => [entry?.id, entry]));
+  const allCards = GRAMMAR_CLIENT_CONCEPTS.map((metadata) => {
+    const analytics = byId.get(metadata.id) || { id: metadata.id, status: 'new' };
+    return buildBankCard(analytics);
+  });
+
+  const normalisedQuery = normaliseSearchText(query);
+  const filteredCards = allCards.filter((card) => bankCardMatchesFilter(card, {
+    statusFilter,
+    clusterFilter,
+    query: normalisedQuery,
+  }));
+
+  return {
+    cards: filteredCards,
+    counts: bankCountsFromCards(allCards),
+    total: allCards.length,
+  };
+}
+
+// --- Summary cards builder --------------------------------------------------
+
+function masteredSummaryFromReward(rewardState) {
+  if (!rewardState || typeof rewardState !== 'object' || Array.isArray(rewardState)) {
+    return ACTIVE_GRAMMAR_MONSTER_IDS.map((monsterId) => Object.freeze({
+      id: monsterId,
+      name: ACTIVE_GRAMMAR_MONSTER_DISPLAY_NAMES[monsterId] || monsterId,
+      mastered: 0,
+      total: ACTIVE_GRAMMAR_MONSTER_CONCEPT_COUNTS[monsterId] || 1,
+    }));
+  }
+  return ACTIVE_GRAMMAR_MONSTER_IDS.map((monsterId) => Object.freeze({
+    id: monsterId,
+    name: ACTIVE_GRAMMAR_MONSTER_DISPLAY_NAMES[monsterId] || monsterId,
+    mastered: masteredCountForRewardEntry(rewardState[monsterId]),
+    total: ACTIVE_GRAMMAR_MONSTER_CONCEPT_COUNTS[monsterId] || 1,
+  }));
+}
+
+/**
+ * Builds the five summary cards for the child-facing round-end screen:
+ * Answered / Correct / Trouble spots found / New secure / Monster progress
+ * (4 active only). Reserved monsters never appear in the monster progress
+ * entry, matching R15. Safe on empty summary and empty reward state.
+ */
+export function grammarSummaryCards(summary, rewardState) {
+  const safeSummary = summary && typeof summary === 'object' && !Array.isArray(summary) ? summary : {};
+  const answered = safeNumber(safeSummary.answered, 0);
+  const correct = safeNumber(safeSummary.correct, 0);
+  const troubleSpotsFound = safeNumber(safeSummary.troubleSpotsFound ?? safeSummary.weakConceptsSurfaced, 0);
+  const newSecure = safeNumber(safeSummary.conceptsNewlySecured ?? safeSummary.newSecure, 0);
+
+  return Object.freeze([
+    Object.freeze({ id: 'answered', label: 'Answered', value: answered, detail: 'Questions this round' }),
+    Object.freeze({ id: 'correct', label: 'Correct', value: correct, detail: answered ? `${Math.round((correct / answered) * 100)}% accuracy` : 'No answers yet' }),
+    Object.freeze({ id: 'trouble', label: 'Trouble spots found', value: troubleSpotsFound, detail: 'We will come back to these' }),
+    Object.freeze({ id: 'new-secure', label: 'New secure', value: newSecure, detail: 'Concepts you just locked in' }),
+    Object.freeze({
+      id: 'monster-progress',
+      label: 'Monster progress',
+      value: masteredSummaryFromReward(rewardState),
+      detail: 'Your four Grammar creatures',
+    }),
+  ]);
+}

--- a/src/subjects/grammar/session-ui.js
+++ b/src/subjects/grammar/session-ui.js
@@ -1,0 +1,152 @@
+// Pure session label/visibility selectors for the Grammar surface. Mirrors
+// the shape of `src/subjects/spelling/session-ui.js` so every JSX unit
+// imports from one source of truth rather than restating branches inline.
+//
+// No React. No SSR. No import from `./components/*`. These helpers are
+// pure functions on the Worker-projected `session` shape plus the
+// `grammar.phase` string. They are safe to call in any test.
+
+function isMiniTestSession(session) {
+  return Boolean(session) && session.type === 'mini-set';
+}
+
+function miniTestQuestions(session) {
+  return Array.isArray(session?.miniTest?.questions) ? session.miniTest.questions : [];
+}
+
+function miniTestIsFinished(session) {
+  return Boolean(session?.miniTest?.finished);
+}
+
+/**
+ * Label for the primary session submit button. The branches mirror the
+ * Spelling helper: mini-test uses `Save and next`, retry uses `Try again`,
+ * feedback locks in a saved answer, otherwise we default to `Submit`.
+ *
+ * Returns one of: `Submit | Saved | Try again | Save and next | Finish mini-set`.
+ */
+export function grammarSessionSubmitLabel(session, awaitingAdvance = false) {
+  if (!session) return 'Submit';
+  if (awaitingAdvance) return 'Saved';
+  if (isMiniTestSession(session)) {
+    if (miniTestIsFinished(session)) return 'Finish mini-set';
+    return 'Save and next';
+  }
+  if (session.phase === 'retry') return 'Try again';
+  return 'Submit';
+}
+
+/**
+ * Single truth table for help/support visibility during the session and
+ * feedback phases. Every JSX unit that decides whether to render an AI
+ * action, worked solution, faded-support button, or similar-problem
+ * button must call this helper once and thread the returned flags down.
+ *
+ * Rules:
+ * - Mini-test (before finish): every flag is `false`. No feedback, no AI,
+ *   no support, no worked solution, no similar problem.
+ * - Independent practice, pre-answer (`grammarPhase === 'session'`):
+ *   every help flag is `false`. The learner sees one prompt + one input +
+ *   Submit. AI, worked, similar-problem are gated behind marking.
+ * - Independent practice, feedback (`grammarPhase === 'feedback'`):
+ *   AI actions, repair actions (retry / worked / similar), worked solution
+ *   preview and similar-problem button are all visible. Faded support is
+ *   visible only when `session.supportLevel === 0` (the learner has not
+ *   already opted into a support mode).
+ */
+export function grammarSessionHelpVisibility(session, grammarPhase) {
+  const noHelp = {
+    showAiActions: false,
+    showRepairActions: false,
+    showWorkedSolution: false,
+    showSimilarProblem: false,
+    showFadedSupport: false,
+  };
+  if (!session) return noHelp;
+  if (isMiniTestSession(session) && !miniTestIsFinished(session)) return noHelp;
+  if (grammarPhase !== 'feedback') return noHelp;
+
+  const supportLevel = Number.isFinite(Number(session.supportLevel))
+    ? Math.max(0, Number(session.supportLevel))
+    : 0;
+
+  return {
+    showAiActions: true,
+    showRepairActions: true,
+    showWorkedSolution: true,
+    showSimilarProblem: true,
+    showFadedSupport: supportLevel === 0,
+  };
+}
+
+/**
+ * Child-facing progress label. Mini-test uses `Mini Test — Question X of N`
+ * to match the test copy in plan §U8 `grammarSessionProgressLabel` scenario.
+ * Independent practice uses `Question X of N` based on `currentIndex` and
+ * `targetCount`. The label is never `Phase: retry` — child copy stays
+ * mastery-friendly and does not expose engine phase names.
+ */
+export function grammarSessionProgressLabel(session) {
+  if (!session) return '';
+  if (isMiniTestSession(session)) {
+    const questions = miniTestQuestions(session);
+    const total = Math.max(1, Number(session.miniTest?.setSize) || questions.length || 1);
+    const index = Math.max(0, Number(session.miniTest?.currentIndex) || 0);
+    const questionNumber = Math.min(total, index + 1);
+    return `Mini Test — Question ${questionNumber} of ${total}`;
+  }
+  const rawTotal = Number(session.targetCount);
+  const total = Number.isFinite(rawTotal) && rawTotal > 0 ? Math.floor(rawTotal) : 1;
+  const rawIndex = Number(session.currentIndex);
+  const safeIndex = Number.isFinite(rawIndex) && rawIndex >= 0 ? Math.floor(rawIndex) : 0;
+  const questionNumber = Math.min(total, safeIndex + 1);
+  return `Question ${questionNumber} of ${total}`;
+}
+
+/**
+ * Small set of chips for the session-prompt header. Child mode removes
+ * `Worker authority`, adult `domain`, and internal `questionType` labels.
+ * Only two child-friendly chips are surfaced today:
+ *   - `Mini Test` when the session is a mini-set.
+ *   - The concept display name, if the current item carries one.
+ * Returns an array of strings so JSX consumers just `.map()`.
+ */
+export function grammarSessionInfoChips(session) {
+  if (!session) return [];
+  const chips = [];
+  if (isMiniTestSession(session)) chips.push('Mini Test');
+  const conceptName = session.currentItem?.conceptName
+    || (Array.isArray(session.currentItem?.concepts) ? session.currentItem.concepts[0]?.name : '')
+    || '';
+  if (typeof conceptName === 'string' && conceptName.trim()) {
+    chips.push(conceptName.trim());
+  }
+  return chips;
+}
+
+/**
+ * Child-friendly footer note for the session surface. Never mentions
+ * `Worker`, `evidence`, `projection`, or reward routes. Mini-test and
+ * practice get different reminders. This is the full visible note; U3
+ * drops it in place of the previous adult-diagnostic copy.
+ */
+export function grammarSessionFooterNote(session) {
+  if (!session) return '';
+  if (isMiniTestSession(session)) {
+    return 'Mini Test keeps marks hidden until the end. Save your answer and move on.';
+  }
+  return 'Answer the question. You will see feedback after you submit.';
+}
+
+/**
+ * Tone mapping for the feedback panel. Correct answers read as `good`;
+ * incorrect answers read as `bad`; anything else (e.g., pending, cancelled)
+ * reads as `neutral`. Consumers render this through an existing CSS chip
+ * class.
+ */
+export function grammarFeedbackTone(result) {
+  if (!result || typeof result !== 'object') return 'neutral';
+  if (result.correct === true) return 'good';
+  if (result.correct === false) return 'bad';
+  return 'neutral';
+}

--- a/tests/grammar-ui-model.test.js
+++ b/tests/grammar-ui-model.test.js
@@ -1,0 +1,676 @@
+// Phase 3 U8 — Grammar view-model + session-ui pure helpers.
+//
+// These tests are the load-bearing assertion surface for U8. Every helper
+// exported by `src/subjects/grammar/session-ui.js` and
+// `src/subjects/grammar/components/grammar-view-model.js` is exercised here
+// with a happy path, an edge case, and (where relevant) an error-path
+// assertion. No SSR render. No React. Every fixture is a plain object so
+// the test file runs fast on `node --test` alone.
+//
+// Integration: subsequent Phase 3 JSX units (U1, U2, U3, U4, U5, U6b, U7)
+// inherit the visibility + labelling truth tables from this file rather
+// than restating the rules inline.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  grammarSessionSubmitLabel,
+  grammarSessionHelpVisibility,
+  grammarSessionProgressLabel,
+  grammarSessionInfoChips,
+  grammarSessionFooterNote,
+  grammarFeedbackTone,
+} from '../src/subjects/grammar/session-ui.js';
+import {
+  GRAMMAR_PRIMARY_MODE_CARDS,
+  GRAMMAR_MORE_PRACTICE_MODES,
+  GRAMMAR_BANK_STATUS_FILTER_IDS,
+  GRAMMAR_BANK_CLUSTER_FILTER_IDS,
+  GRAMMAR_DASHBOARD_HERO,
+  GRAMMAR_CHILD_FORBIDDEN_TERMS,
+  grammarChildConfidenceLabel,
+  grammarChildConfidenceTone,
+  grammarMonsterClusterForConcept,
+  grammarBankFilterMatchesStatus,
+  buildGrammarDashboardModel,
+  buildGrammarBankModel,
+  grammarSummaryCards,
+  isGrammarChildCopy,
+} from '../src/subjects/grammar/components/grammar-view-model.js';
+
+// -----------------------------------------------------------------------------
+// grammarSessionSubmitLabel
+// -----------------------------------------------------------------------------
+
+test('U8 session-ui: grammarSessionSubmitLabel null session returns Submit', () => {
+  assert.equal(grammarSessionSubmitLabel(null), 'Submit');
+  assert.equal(grammarSessionSubmitLabel(undefined), 'Submit');
+});
+
+test('U8 session-ui: grammarSessionSubmitLabel awaitingAdvance returns Saved', () => {
+  assert.equal(grammarSessionSubmitLabel({ type: 'smart' }, true), 'Saved');
+});
+
+test('U8 session-ui: grammarSessionSubmitLabel mini-test returns Save and next', () => {
+  assert.equal(
+    grammarSessionSubmitLabel({ type: 'mini-set', miniTest: { finished: false } }, false),
+    'Save and next',
+  );
+});
+
+test('U8 session-ui: grammarSessionSubmitLabel finished mini-test returns Finish mini-set', () => {
+  assert.equal(
+    grammarSessionSubmitLabel({ type: 'mini-set', miniTest: { finished: true } }, false),
+    'Finish mini-set',
+  );
+});
+
+test('U8 session-ui: grammarSessionSubmitLabel retry returns Try again', () => {
+  assert.equal(grammarSessionSubmitLabel({ type: 'smart', phase: 'retry' }), 'Try again');
+});
+
+test('U8 session-ui: grammarSessionSubmitLabel default returns Submit', () => {
+  assert.equal(grammarSessionSubmitLabel({ type: 'smart' }), 'Submit');
+});
+
+// -----------------------------------------------------------------------------
+// grammarSessionHelpVisibility — the single truth table for U1/U3/U4/U6b
+// -----------------------------------------------------------------------------
+
+test('U8 session-ui: grammarSessionHelpVisibility mini-test before finish is all false (AE1, AE2)', () => {
+  const flags = grammarSessionHelpVisibility(
+    { type: 'mini-set', miniTest: { finished: false } },
+    'session',
+  );
+  assert.deepEqual(flags, {
+    showAiActions: false,
+    showRepairActions: false,
+    showWorkedSolution: false,
+    showSimilarProblem: false,
+    showFadedSupport: false,
+  });
+});
+
+test('U8 session-ui: grammarSessionHelpVisibility mini-test in feedback still hides help when miniTest.finished is false', () => {
+  const flags = grammarSessionHelpVisibility(
+    { type: 'mini-set', miniTest: { finished: false } },
+    'feedback',
+  );
+  assert.equal(flags.showAiActions, false);
+  assert.equal(flags.showRepairActions, false);
+  assert.equal(flags.showWorkedSolution, false);
+  assert.equal(flags.showSimilarProblem, false);
+  assert.equal(flags.showFadedSupport, false);
+});
+
+test('U8 session-ui: grammarSessionHelpVisibility smart-feedback-supportLevel-0 shows full help (AE3)', () => {
+  const flags = grammarSessionHelpVisibility(
+    { type: 'smart', supportLevel: 0 },
+    'feedback',
+  );
+  assert.equal(flags.showAiActions, true);
+  assert.equal(flags.showRepairActions, true);
+  assert.equal(flags.showWorkedSolution, true);
+  assert.equal(flags.showSimilarProblem, true);
+  assert.equal(flags.showFadedSupport, true);
+});
+
+test('U8 session-ui: grammarSessionHelpVisibility smart-feedback-supportLevel-2 hides faded support', () => {
+  const flags = grammarSessionHelpVisibility(
+    { type: 'smart', supportLevel: 2 },
+    'feedback',
+  );
+  assert.equal(flags.showFadedSupport, false);
+  assert.equal(flags.showAiActions, true);
+  assert.equal(flags.showRepairActions, true);
+});
+
+test('U8 session-ui: grammarSessionHelpVisibility smart-session pre-answer hides everything', () => {
+  const flags = grammarSessionHelpVisibility(
+    { type: 'smart', supportLevel: 0 },
+    'session',
+  );
+  assert.deepEqual(flags, {
+    showAiActions: false,
+    showRepairActions: false,
+    showWorkedSolution: false,
+    showSimilarProblem: false,
+    showFadedSupport: false,
+  });
+});
+
+test('U8 session-ui: grammarSessionHelpVisibility null session returns all false', () => {
+  assert.deepEqual(grammarSessionHelpVisibility(null, 'feedback'), {
+    showAiActions: false,
+    showRepairActions: false,
+    showWorkedSolution: false,
+    showSimilarProblem: false,
+    showFadedSupport: false,
+  });
+});
+
+// -----------------------------------------------------------------------------
+// grammarSessionProgressLabel
+// -----------------------------------------------------------------------------
+
+test('U8 session-ui: grammarSessionProgressLabel null returns empty string', () => {
+  assert.equal(grammarSessionProgressLabel(null), '');
+});
+
+test('U8 session-ui: grammarSessionProgressLabel independent practice renders Question X of N', () => {
+  assert.equal(
+    grammarSessionProgressLabel({ type: 'smart', currentIndex: 2, targetCount: 5 }),
+    'Question 3 of 5',
+  );
+});
+
+test('U8 session-ui: grammarSessionProgressLabel mini-test renders Mini Test — Question X of N', () => {
+  assert.equal(
+    grammarSessionProgressLabel({
+      type: 'mini-set',
+      miniTest: { questions: [{}, {}, {}], currentIndex: 1 },
+    }),
+    'Mini Test — Question 2 of 3',
+  );
+});
+
+test('U8 session-ui: grammarSessionProgressLabel clamps current index to total', () => {
+  assert.equal(
+    grammarSessionProgressLabel({ type: 'smart', currentIndex: 99, targetCount: 5 }),
+    'Question 5 of 5',
+  );
+});
+
+// -----------------------------------------------------------------------------
+// grammarSessionInfoChips
+// -----------------------------------------------------------------------------
+
+test('U8 session-ui: grammarSessionInfoChips null returns empty array', () => {
+  assert.deepEqual(grammarSessionInfoChips(null), []);
+});
+
+test('U8 session-ui: grammarSessionInfoChips mini-test adds Mini Test chip', () => {
+  assert.deepEqual(grammarSessionInfoChips({ type: 'mini-set', miniTest: {} }), ['Mini Test']);
+});
+
+test('U8 session-ui: grammarSessionInfoChips surfaces concept name when present', () => {
+  assert.deepEqual(
+    grammarSessionInfoChips({ type: 'smart', currentItem: { conceptName: 'Relative clauses' } }),
+    ['Relative clauses'],
+  );
+});
+
+test('U8 session-ui: grammarSessionInfoChips drops adult domain / questionType chips', () => {
+  // Even if the read-model carries adult-only fields, the child info chips
+  // never surface them. This is an explicit guard against accidentally
+  // re-adding "Worker authority" / domain / questionType as a chip.
+  const chips = grammarSessionInfoChips({
+    type: 'smart',
+    currentItem: { domain: 'Sentence structure', questionType: 'selected_response' },
+  });
+  assert.equal(chips.length, 0);
+});
+
+// -----------------------------------------------------------------------------
+// grammarSessionFooterNote
+// -----------------------------------------------------------------------------
+
+test('U8 session-ui: grammarSessionFooterNote empty when no session', () => {
+  assert.equal(grammarSessionFooterNote(null), '');
+});
+
+test('U8 session-ui: grammarSessionFooterNote mini-test child copy only', () => {
+  const note = grammarSessionFooterNote({ type: 'mini-set', miniTest: {} });
+  assert.equal(typeof note, 'string');
+  assert.ok(note.length > 0);
+  assert.equal(isGrammarChildCopy(note), true);
+});
+
+test('U8 session-ui: grammarSessionFooterNote practice child copy only', () => {
+  const note = grammarSessionFooterNote({ type: 'smart' });
+  assert.equal(typeof note, 'string');
+  assert.ok(note.length > 0);
+  assert.equal(isGrammarChildCopy(note), true);
+});
+
+// -----------------------------------------------------------------------------
+// grammarFeedbackTone
+// -----------------------------------------------------------------------------
+
+test('U8 session-ui: grammarFeedbackTone correct returns good', () => {
+  assert.equal(grammarFeedbackTone({ correct: true }), 'good');
+});
+
+test('U8 session-ui: grammarFeedbackTone wrong returns bad', () => {
+  assert.equal(grammarFeedbackTone({ correct: false }), 'bad');
+});
+
+test('U8 session-ui: grammarFeedbackTone neutral returns neutral', () => {
+  assert.equal(grammarFeedbackTone(null), 'neutral');
+  assert.equal(grammarFeedbackTone({}), 'neutral');
+});
+
+// -----------------------------------------------------------------------------
+// GRAMMAR_PRIMARY_MODE_CARDS — roster + shape contract
+// -----------------------------------------------------------------------------
+
+test('U8 view-model: GRAMMAR_PRIMARY_MODE_CARDS has exactly four cards (plan requirement)', () => {
+  assert.equal(GRAMMAR_PRIMARY_MODE_CARDS.length, 4);
+});
+
+test('U8 view-model: GRAMMAR_PRIMARY_MODE_CARDS ids match active-mode set', () => {
+  const ids = GRAMMAR_PRIMARY_MODE_CARDS.map((card) => card.id);
+  assert.deepEqual(ids, ['smart', 'trouble', 'satsset', 'bank']);
+});
+
+test('U8 view-model: GRAMMAR_PRIMARY_MODE_CARDS titles match child copy', () => {
+  const titles = Object.fromEntries(GRAMMAR_PRIMARY_MODE_CARDS.map((card) => [card.id, card.title]));
+  assert.equal(titles.smart, 'Smart Practice');
+  assert.equal(titles.trouble, 'Fix Trouble Spots');
+  assert.equal(titles.satsset, 'Mini Test');
+  assert.equal(titles.bank, 'Grammar Bank');
+});
+
+test('U8 view-model: GRAMMAR_PRIMARY_MODE_CARDS is frozen and deeply frozen', () => {
+  assert.equal(Object.isFrozen(GRAMMAR_PRIMARY_MODE_CARDS), true);
+  for (const card of GRAMMAR_PRIMARY_MODE_CARDS) {
+    assert.equal(Object.isFrozen(card), true);
+  }
+});
+
+test('U8 view-model: GRAMMAR_PRIMARY_MODE_CARDS titles use only child copy', () => {
+  for (const card of GRAMMAR_PRIMARY_MODE_CARDS) {
+    assert.equal(isGrammarChildCopy(card.title), true, `title "${card.title}" contains forbidden term`);
+    assert.equal(isGrammarChildCopy(card.desc), true, `desc "${card.desc}" contains forbidden term`);
+  }
+});
+
+// -----------------------------------------------------------------------------
+// GRAMMAR_MORE_PRACTICE_MODES
+// -----------------------------------------------------------------------------
+
+test('U8 view-model: GRAMMAR_MORE_PRACTICE_MODES has exactly five secondary modes', () => {
+  assert.equal(GRAMMAR_MORE_PRACTICE_MODES.length, 5);
+  assert.deepEqual(
+    GRAMMAR_MORE_PRACTICE_MODES.map((mode) => mode.id),
+    ['learn', 'surgery', 'builder', 'worked', 'faded'],
+  );
+});
+
+test('U8 view-model: GRAMMAR_MORE_PRACTICE_MODES are frozen', () => {
+  assert.equal(Object.isFrozen(GRAMMAR_MORE_PRACTICE_MODES), true);
+  for (const mode of GRAMMAR_MORE_PRACTICE_MODES) {
+    assert.equal(Object.isFrozen(mode), true);
+  }
+});
+
+// -----------------------------------------------------------------------------
+// Frozen filter-id sets
+// -----------------------------------------------------------------------------
+
+test('U8 view-model: GRAMMAR_BANK_STATUS_FILTER_IDS contains the seven child filter ids', () => {
+  assert.equal(GRAMMAR_BANK_STATUS_FILTER_IDS.size, 7);
+  for (const id of ['all', 'due', 'trouble', 'learning', 'nearly-secure', 'secure', 'new']) {
+    assert.equal(GRAMMAR_BANK_STATUS_FILTER_IDS.has(id), true, `missing ${id}`);
+  }
+});
+
+test('U8 view-model: GRAMMAR_BANK_CLUSTER_FILTER_IDS matches the four active roster ids plus all', () => {
+  assert.equal(GRAMMAR_BANK_CLUSTER_FILTER_IDS.size, 5);
+  for (const id of ['all', 'bracehart', 'chronalyx', 'couronnail', 'concordium']) {
+    assert.equal(GRAMMAR_BANK_CLUSTER_FILTER_IDS.has(id), true, `missing ${id}`);
+  }
+});
+
+test('U8 view-model: GRAMMAR_BANK_CLUSTER_FILTER_IDS never lists retired ids (R15)', () => {
+  for (const retiredId of ['glossbloom', 'loomrill', 'mirrane']) {
+    assert.equal(GRAMMAR_BANK_CLUSTER_FILTER_IDS.has(retiredId), false, `${retiredId} leaked into filter`);
+  }
+});
+
+// -----------------------------------------------------------------------------
+// GRAMMAR_DASHBOARD_HERO
+// -----------------------------------------------------------------------------
+
+test('U8 view-model: GRAMMAR_DASHBOARD_HERO has child-friendly copy', () => {
+  assert.equal(GRAMMAR_DASHBOARD_HERO.title, 'Grammar Garden');
+  assert.equal(typeof GRAMMAR_DASHBOARD_HERO.subtitle, 'string');
+  assert.ok(GRAMMAR_DASHBOARD_HERO.subtitle.length > 0);
+  assert.equal(isGrammarChildCopy(GRAMMAR_DASHBOARD_HERO.title), true);
+  assert.equal(isGrammarChildCopy(GRAMMAR_DASHBOARD_HERO.subtitle), true);
+});
+
+// -----------------------------------------------------------------------------
+// grammarChildConfidenceLabel + grammarChildConfidenceTone
+// -----------------------------------------------------------------------------
+
+test('U8 view-model: grammarChildConfidenceLabel maps the five internal labels (R12)', () => {
+  assert.equal(grammarChildConfidenceLabel({ label: 'emerging' }), 'New');
+  assert.equal(grammarChildConfidenceLabel({ label: 'building' }), 'Learning');
+  assert.equal(grammarChildConfidenceLabel({ label: 'needs-repair' }), 'Trouble spot');
+  assert.equal(grammarChildConfidenceLabel({ label: 'consolidating' }), 'Nearly secure');
+  assert.equal(grammarChildConfidenceLabel({ label: 'secure' }), 'Secure');
+});
+
+test('U8 view-model: grammarChildConfidenceLabel unknown label falls back to Learning', () => {
+  assert.equal(grammarChildConfidenceLabel({ label: 'not-a-label' }), 'Learning');
+  assert.equal(grammarChildConfidenceLabel({}), 'Learning');
+  assert.equal(grammarChildConfidenceLabel({ label: null }), 'Learning');
+});
+
+test('U8 view-model: grammarChildConfidenceTone maps tones for CSS classes', () => {
+  assert.equal(grammarChildConfidenceTone('emerging'), 'new');
+  assert.equal(grammarChildConfidenceTone('building'), 'learning');
+  assert.equal(grammarChildConfidenceTone('needs-repair'), 'trouble');
+  assert.equal(grammarChildConfidenceTone('consolidating'), 'nearly-secure');
+  assert.equal(grammarChildConfidenceTone('secure'), 'secure');
+  assert.equal(grammarChildConfidenceTone('unknown'), 'learning');
+});
+
+// -----------------------------------------------------------------------------
+// grammarMonsterClusterForConcept
+// -----------------------------------------------------------------------------
+
+test('U8 view-model: grammarMonsterClusterForConcept maps direct clusters (word_classes → couronnail)', () => {
+  assert.equal(grammarMonsterClusterForConcept('word_classes'), 'couronnail');
+  assert.equal(grammarMonsterClusterForConcept('noun_phrases'), 'bracehart');
+  assert.equal(grammarMonsterClusterForConcept('clauses'), 'bracehart');
+  assert.equal(grammarMonsterClusterForConcept('relative_clauses'), 'bracehart');
+  assert.equal(grammarMonsterClusterForConcept('sentence_functions'), 'bracehart');
+  assert.equal(grammarMonsterClusterForConcept('active_passive'), 'bracehart');
+  assert.equal(grammarMonsterClusterForConcept('subject_object'), 'bracehart');
+  assert.equal(grammarMonsterClusterForConcept('tense_aspect'), 'chronalyx');
+  assert.equal(grammarMonsterClusterForConcept('modal_verbs'), 'chronalyx');
+  assert.equal(grammarMonsterClusterForConcept('adverbials'), 'chronalyx');
+  assert.equal(grammarMonsterClusterForConcept('pronouns_cohesion'), 'chronalyx');
+  assert.equal(grammarMonsterClusterForConcept('standard_english'), 'couronnail');
+  assert.equal(grammarMonsterClusterForConcept('formality'), 'couronnail');
+});
+
+test('U8 view-model: grammarMonsterClusterForConcept punctuation-for-grammar concepts fall back to concordium', () => {
+  assert.equal(grammarMonsterClusterForConcept('parenthesis_commas'), 'concordium');
+  assert.equal(grammarMonsterClusterForConcept('speech_punctuation'), 'concordium');
+  assert.equal(grammarMonsterClusterForConcept('apostrophes_possession'), 'concordium');
+  assert.equal(grammarMonsterClusterForConcept('boundary_punctuation'), 'concordium');
+  assert.equal(grammarMonsterClusterForConcept('hyphen_ambiguity'), 'concordium');
+});
+
+test('U8 view-model: grammarMonsterClusterForConcept unknown/empty concept ids default to concordium', () => {
+  assert.equal(grammarMonsterClusterForConcept(''), 'concordium');
+  assert.equal(grammarMonsterClusterForConcept(null), 'concordium');
+  assert.equal(grammarMonsterClusterForConcept('not_a_concept'), 'concordium');
+});
+
+// -----------------------------------------------------------------------------
+// grammarBankFilterMatchesStatus
+// -----------------------------------------------------------------------------
+
+test('U8 view-model: grammarBankFilterMatchesStatus all matches everything', () => {
+  assert.equal(grammarBankFilterMatchesStatus('all', 'emerging'), true);
+  assert.equal(grammarBankFilterMatchesStatus('all', 'secure'), true);
+  assert.equal(grammarBankFilterMatchesStatus('all', 'needs-repair'), true);
+});
+
+test('U8 view-model: grammarBankFilterMatchesStatus trouble maps to needs-repair only', () => {
+  assert.equal(grammarBankFilterMatchesStatus('trouble', 'needs-repair'), true);
+  assert.equal(grammarBankFilterMatchesStatus('trouble', 'emerging'), false);
+});
+
+test('U8 view-model: grammarBankFilterMatchesStatus secure does not match consolidating', () => {
+  assert.equal(grammarBankFilterMatchesStatus('secure', 'consolidating'), false);
+  assert.equal(grammarBankFilterMatchesStatus('secure', 'secure'), true);
+});
+
+test('U8 view-model: grammarBankFilterMatchesStatus learning maps to building', () => {
+  assert.equal(grammarBankFilterMatchesStatus('learning', 'building'), true);
+  assert.equal(grammarBankFilterMatchesStatus('learning', 'consolidating'), false);
+});
+
+test('U8 view-model: grammarBankFilterMatchesStatus nearly-secure maps to consolidating', () => {
+  assert.equal(grammarBankFilterMatchesStatus('nearly-secure', 'consolidating'), true);
+  assert.equal(grammarBankFilterMatchesStatus('nearly-secure', 'secure'), false);
+});
+
+test('U8 view-model: grammarBankFilterMatchesStatus new maps to emerging', () => {
+  assert.equal(grammarBankFilterMatchesStatus('new', 'emerging'), true);
+  assert.equal(grammarBankFilterMatchesStatus('new', 'building'), false);
+});
+
+// -----------------------------------------------------------------------------
+// GRAMMAR_CHILD_FORBIDDEN_TERMS + isGrammarChildCopy
+// -----------------------------------------------------------------------------
+
+test('U8 view-model: GRAMMAR_CHILD_FORBIDDEN_TERMS contains the critical adult terms', () => {
+  for (const term of [
+    'Worker',
+    'Worker-marked',
+    'Worker-held',
+    'Stage 1',
+    'Evidence snapshot',
+    'Reserved reward routes',
+    'Bellstorm bridge',
+    'denominator',
+    'reward route',
+    'projection',
+    'retrieval practice',
+  ]) {
+    assert.ok(
+      GRAMMAR_CHILD_FORBIDDEN_TERMS.includes(term),
+      `expected GRAMMAR_CHILD_FORBIDDEN_TERMS to include "${term}"`,
+    );
+  }
+});
+
+test('U8 view-model: GRAMMAR_CHILD_FORBIDDEN_TERMS is frozen', () => {
+  assert.equal(Object.isFrozen(GRAMMAR_CHILD_FORBIDDEN_TERMS), true);
+});
+
+test('U8 view-model: isGrammarChildCopy rejects Worker-marked modes (case-insensitive)', () => {
+  assert.equal(isGrammarChildCopy('Worker-marked modes'), false);
+  assert.equal(isGrammarChildCopy('worker-marked modes'), false);
+  assert.equal(isGrammarChildCopy('WORKER-MARKED MODES'), false);
+});
+
+test('U8 view-model: isGrammarChildCopy accepts child-friendly prompt copy', () => {
+  assert.equal(
+    isGrammarChildCopy('Choose the sentence that uses a relative clause'),
+    true,
+  );
+  assert.equal(isGrammarChildCopy('Fix trouble spots. Grow your creatures.'), true);
+});
+
+test('U8 view-model: isGrammarChildCopy safe on empty / non-string', () => {
+  assert.equal(isGrammarChildCopy(''), true);
+  assert.equal(isGrammarChildCopy(null), true);
+  assert.equal(isGrammarChildCopy(undefined), true);
+});
+
+// -----------------------------------------------------------------------------
+// buildGrammarDashboardModel
+// -----------------------------------------------------------------------------
+
+test('U8 view-model: buildGrammarDashboardModel returns safe empty shape on null inputs', () => {
+  const model = buildGrammarDashboardModel(null, null, null);
+  assert.equal(Array.isArray(model.modeCards), true);
+  assert.equal(model.modeCards.length, 4);
+  assert.equal(model.todayCards.length, 4);
+  assert.equal(model.concordiumProgress.mastered, 0);
+  assert.equal(model.concordiumProgress.total, 18);
+  assert.equal(model.primaryMode, 'smart');
+  assert.equal(Array.isArray(model.moreModes), true);
+  assert.equal(model.moreModes.length, 5);
+  assert.equal(typeof model.writingTryAvailable, 'boolean');
+});
+
+test('U8 view-model: buildGrammarDashboardModel surfaces concept counts', () => {
+  const grammar = {
+    analytics: {
+      progressSnapshot: {
+        dueConcepts: 3,
+        weakConcepts: 2,
+        securedConcepts: 4,
+      },
+    },
+    prefs: { mode: 'trouble' },
+  };
+  const model = buildGrammarDashboardModel(grammar, null, null);
+  const byId = Object.fromEntries(model.todayCards.map((card) => [card.id, card]));
+  assert.equal(byId.due.value, 3);
+  assert.equal(byId.trouble.value, 2);
+  assert.equal(byId.secure.value, 4);
+  assert.equal(model.primaryMode, 'trouble');
+});
+
+test('U8 view-model: buildGrammarDashboardModel concordium progress reads reward state', () => {
+  const rewardState = {
+    concordium: {
+      mastered: [
+        'grammar:grammar-legacy-reviewed-2026-04-24:word_classes',
+        'grammar:grammar-legacy-reviewed-2026-04-24:noun_phrases',
+      ],
+    },
+  };
+  const model = buildGrammarDashboardModel({}, null, rewardState);
+  assert.equal(model.concordiumProgress.mastered, 2);
+  assert.equal(model.concordiumProgress.total, 18);
+});
+
+// -----------------------------------------------------------------------------
+// buildGrammarBankModel
+// -----------------------------------------------------------------------------
+
+test('U8 view-model: buildGrammarBankModel default returns 18 concept cards', () => {
+  const model = buildGrammarBankModel({}, {});
+  assert.equal(model.total, 18);
+  assert.equal(model.cards.length, 18);
+});
+
+test('U8 view-model: buildGrammarBankModel filter=trouble narrows to needs-repair', () => {
+  const grammar = {
+    analytics: {
+      concepts: [
+        { id: 'clauses', confidenceLabel: 'needs-repair', status: 'weak', name: 'Subordinate clauses and conjunctions' },
+        { id: 'word_classes', confidenceLabel: 'secure', status: 'secured', name: 'Word classes' },
+        { id: 'noun_phrases', confidenceLabel: 'building', status: 'learning', name: 'Expanded noun phrases' },
+      ],
+    },
+  };
+  const model = buildGrammarBankModel(grammar, { statusFilter: 'trouble' });
+  assert.ok(model.cards.length >= 1);
+  for (const card of model.cards) {
+    assert.equal(card.label, 'needs-repair');
+  }
+});
+
+test('U8 view-model: buildGrammarBankModel search clause narrows to matching concepts', () => {
+  const model = buildGrammarBankModel({}, { query: 'clause' });
+  assert.ok(model.cards.length >= 2);
+  for (const card of model.cards) {
+    const haystack = `${card.name} ${card.summary} ${card.domain}`.toLowerCase();
+    assert.ok(haystack.includes('clause'), `card ${card.id} should match clause`);
+  }
+});
+
+test('U8 view-model: buildGrammarBankModel cluster filter concordium shows all 18', () => {
+  const model = buildGrammarBankModel({}, { clusterFilter: 'concordium' });
+  assert.equal(model.cards.length, 18);
+});
+
+test('U8 view-model: buildGrammarBankModel cluster filter bracehart narrows to 6', () => {
+  const model = buildGrammarBankModel({}, { clusterFilter: 'bracehart' });
+  assert.equal(model.cards.length, 6);
+  for (const card of model.cards) {
+    assert.equal(card.cluster, 'bracehart');
+  }
+});
+
+test('U8 view-model: buildGrammarBankModel counts total 18 across all statuses', () => {
+  const model = buildGrammarBankModel({}, {});
+  const sumOfBuckets = model.counts.secure
+    + model.counts.trouble
+    + model.counts.learning
+    + model.counts['nearly-secure']
+    + model.counts.new;
+  assert.equal(sumOfBuckets, 18);
+  assert.equal(model.counts.all, 18);
+});
+
+test('U8 view-model: buildGrammarBankModel empty filter + empty grammar returns cards using child labels', () => {
+  const model = buildGrammarBankModel({}, {});
+  for (const card of model.cards) {
+    assert.equal(typeof card.childLabel, 'string');
+    assert.ok(card.childLabel.length > 0);
+    assert.ok(['new', 'learning', 'trouble', 'nearly-secure', 'secure'].includes(card.tone));
+  }
+});
+
+// -----------------------------------------------------------------------------
+// grammarSummaryCards
+// -----------------------------------------------------------------------------
+
+test('U8 view-model: grammarSummaryCards returns five cards with correct order', () => {
+  const cards = grammarSummaryCards({ answered: 6, correct: 4 }, null);
+  assert.equal(cards.length, 5);
+  assert.deepEqual(
+    cards.map((card) => card.id),
+    ['answered', 'correct', 'trouble', 'new-secure', 'monster-progress'],
+  );
+});
+
+test('U8 view-model: grammarSummaryCards monster-progress surfaces 4 active monsters only (R15)', () => {
+  const cards = grammarSummaryCards({}, {
+    bracehart: { mastered: ['grammar:grammar-legacy-reviewed-2026-04-24:clauses'] },
+    concordium: { mastered: ['grammar:grammar-legacy-reviewed-2026-04-24:clauses'] },
+    glossbloom: { mastered: ['grammar:grammar-legacy-reviewed-2026-04-24:noun_phrases'] }, // retired
+  });
+  const monsterCard = cards.find((card) => card.id === 'monster-progress');
+  assert.ok(Array.isArray(monsterCard.value));
+  assert.equal(monsterCard.value.length, 4);
+  const ids = monsterCard.value.map((entry) => entry.id);
+  assert.deepEqual(ids, ['bracehart', 'chronalyx', 'couronnail', 'concordium']);
+  for (const id of ['glossbloom', 'loomrill', 'mirrane']) {
+    assert.equal(ids.includes(id), false, `retired ${id} leaked into monster progress`);
+  }
+});
+
+test('U8 view-model: grammarSummaryCards safe on empty inputs', () => {
+  const cards = grammarSummaryCards(null, null);
+  assert.equal(cards.length, 5);
+  const byId = Object.fromEntries(cards.map((card) => [card.id, card]));
+  assert.equal(byId.answered.value, 0);
+  assert.equal(byId.correct.value, 0);
+  assert.equal(byId.trouble.value, 0);
+  assert.equal(byId['new-secure'].value, 0);
+});
+
+test('U8 view-model: grammarSummaryCards accuracy detail is computed from answered/correct', () => {
+  const cards = grammarSummaryCards({ answered: 4, correct: 3 }, null);
+  const correctCard = cards.find((card) => card.id === 'correct');
+  assert.equal(correctCard.value, 3);
+  assert.ok(correctCard.detail.includes('75%'));
+});
+
+// -----------------------------------------------------------------------------
+// Pure-module safety: no React imports in the view-model files
+// -----------------------------------------------------------------------------
+
+test('U8 safety: session-ui.js does not import react', async () => {
+  const fs = await import('node:fs');
+  const url = await import('node:url');
+  const path = url.fileURLToPath(new URL('../src/subjects/grammar/session-ui.js', import.meta.url));
+  const source = fs.readFileSync(path, 'utf8');
+  assert.equal(/from ['"]react['"]/i.test(source), false);
+  assert.equal(/require\(['"]react['"]\)/i.test(source), false);
+});
+
+test('U8 safety: grammar-view-model.js does not import react', async () => {
+  const fs = await import('node:fs');
+  const url = await import('node:url');
+  const path = url.fileURLToPath(
+    new URL('../src/subjects/grammar/components/grammar-view-model.js', import.meta.url),
+  );
+  const source = fs.readFileSync(path, 'utf8');
+  assert.equal(/from ['"]react['"]/i.test(source), false);
+  assert.equal(/require\(['"]react['"]\)/i.test(source), false);
+});


### PR DESCRIPTION
## Summary

Front-loads the Phase 3 Grammar pure-function view-model layer so every
subsequent JSX unit (U1/U2/U3/U4/U5/U6b/U7) imports labels, visibility
flags, filter predicates, and forbidden-term copy from a single source
of truth rather than restating branches inline.

Plan: [`docs/plans/2026-04-25-004-feat-grammar-phase3-ux-reset-plan.md`](docs/plans/2026-04-25-004-feat-grammar-phase3-ux-reset-plan.md) — U8 unit.

Depends on: U0 (cluster remap, merged in `4216c11`).

## What ships

**`src/subjects/grammar/session-ui.js`** (6 exports, mirrors Spelling's shape):
- `grammarSessionSubmitLabel(session, awaitingAdvance)` — `Submit | Saved | Try again | Save and next | Finish mini-set`.
- `grammarSessionHelpVisibility(session, grammarPhase)` — **single truth table** returning `{ showAiActions, showRepairActions, showWorkedSolution, showSimilarProblem, showFadedSupport }`. Rules: mini-test before finish = all false; pre-answer = all false; feedback = all true except faded support which needs `supportLevel === 0`.
- `grammarSessionProgressLabel(session)` — `Question X of N` or `Mini Test — Question X of N`.
- `grammarSessionInfoChips(session)` — child chips only; drops `Worker authority`, domain, questionType.
- `grammarSessionFooterNote(session)` — child copy, never mentions Worker/evidence/projection.
- `grammarFeedbackTone(result)` — `good | bad | neutral`.

**`src/subjects/grammar/components/grammar-view-model.js`** (13 exports + fixture):
- `GRAMMAR_PRIMARY_MODE_CARDS` — 4 frozen cards (`smart`/`trouble`/`satsset`/`bank` → Smart Practice / Fix Trouble Spots / Mini Test / Grammar Bank).
- `GRAMMAR_MORE_PRACTICE_MODES` — 5 frozen secondary modes (`learn`, `surgery`, `builder`, `worked`, `faded`).
- `GRAMMAR_BANK_STATUS_FILTER_IDS` — frozen Set of 7 ids.
- `GRAMMAR_BANK_CLUSTER_FILTER_IDS` — frozen Set of 5 ids (active roster + `all`; retired ids never appear).
- `GRAMMAR_DASHBOARD_HERO` — `{ title: 'Grammar Garden', subtitle: ... }` (U1 will review with James).
- `GRAMMAR_CHILD_FORBIDDEN_TERMS` — frozen list including `Worker-held` and `retrieval practice` (sourced from Key Technical Decisions).
- `isGrammarChildCopy(text)` — boolean helper for U10 absence fixture.
- `grammarChildConfidenceLabel({ label })` — 5-label → child copy (R12).
- `grammarChildConfidenceTone(label)` — CSS-class tone.
- `grammarMonsterClusterForConcept(conceptId)` — returns active cluster or `concordium` for pun-for-grammar concepts.
- `grammarBankFilterMatchesStatus(filter, label)` — status filter predicate.
- `buildGrammarDashboardModel(grammar, learner, rewardState)` — dashboard model (safe empty shape on null inputs).
- `buildGrammarBankModel(grammar, { statusFilter, clusterFilter, query })` — bank model with search.
- `grammarSummaryCards(summary, rewardState)` — 5 cards with 4 active monsters only (R15).

**`tests/grammar-ui-model.test.js`** — 70 pure-function assertions:
- Every session-ui helper + its edge cases.
- AE1/AE2 covered by mini-test before-finish returning all-false visibility.
- AE3 covered by feedback-with-supportLevel-0 returning all-true visibility.
- R12 5-label → child copy mapping.
- R15 retired monsters never appear in cluster filter, monster progress, or summary.
- Safety: neither view-model file imports React (scanned via `fs.readFileSync`).

## Non-goals

- No JSX change (reviewers block if we touch scenes).
- No Worker change.
- No `contentReleaseId` bump.
- No Spelling file edits.

## Test plan

- [x] `node --test tests/grammar-ui-model.test.js` — 70 pass, 0 fail.
- [x] `npm test` — full suite green except one pre-existing `grammar-production-smoke` failure on `origin/main` (unrelated to U8; confirmed by re-running with U8 files stashed).
- [x] `npm run check` — green (build, assert-build-public, audit-client, wrangler dry-run).
- [x] grep confirms neither new file imports React.
- [ ] Reviewers: gate this PR; do not merge. Later units will import from these modules.