### PR TITLE
feat(spelling): U6 summary + Word Bank guardian surfaces

### DIFF
--- a/src/platform/core/store.js
+++ b/src/platform/core/store.js
@@ -127,6 +127,17 @@ const VALID_SPELLING_WORD_BANK_FILTERS = new Set([
   'learning',
   'secure',
   'unseen',
+  // ----- U6 Guardian filters ---------------------------------------------
+  // Mirrors the subject-level WORD_BANK_FILTER_IDS expansion in
+  // `src/subjects/spelling/components/spelling-view-model.js`. This Set is
+  // the platform-layer transientUi sanitiser — it runs on boot against
+  // persisted state, so without the expansion a learner who closed the
+  // tab on a Guardian filter would have their persisted filter silently
+  // reset to 'all' on next load. Keep these two Sets in lockstep.
+  'guardianDue',
+  'wobbling',
+  'renewedRecently',
+  'neverRenewed',
 ]);
 const VALID_SPELLING_WORD_BANK_YEAR_FILTERS = new Set([
   'all',

--- a/src/subjects/spelling/components/SpellingPracticeSurface.jsx
+++ b/src/subjects/spelling/components/SpellingPracticeSurface.jsx
@@ -138,6 +138,7 @@ export function SpellingPracticeSurface(props) {
         learner={spelling.learner}
         analytics={spelling.analytics}
         accent={spelling.accent}
+        postMastery={spelling.postMastery}
         previousHeroBg={previousHeroBg}
         actions={actions}
         runtimeReadOnly={runtimeReadOnly}

--- a/src/subjects/spelling/components/SpellingSummaryScene.jsx
+++ b/src/subjects/spelling/components/SpellingSummaryScene.jsx
@@ -3,6 +3,7 @@ import { ArrowRightIcon, CheckIcon } from './spelling-icons.jsx';
 import { AnimatedPromptCard, PathProgress, Ribbon } from './SpellingCommon.jsx';
 import { SpellingHeroBackdrop } from './SpellingHeroBackdrop.jsx';
 import {
+  guardianSummaryCards,
   heroBgForSession,
   heroBgStyle,
   renderAction,
@@ -23,7 +24,34 @@ function SummaryStatGrid({ cards = [] }) {
   );
 }
 
-export function SpellingSummaryScene({ learner, ui, accent, actions, previousHeroBg = '', runtimeReadOnly = false }) {
+// Guardian-specific summary band. Rendered only when `summary.mode === 'guardian'`.
+// Visually separated from the regular stat grid by a thin divider + a quiet
+// eyebrow so the block reads as "here's the Vault status" rather than just
+// "three more metrics". The shape mirrors `SummaryStatGrid` so the cards
+// slot into the same responsive grid, but the wrapper class drives its own
+// accent treatment without leaking into the legacy shell.
+function SummaryGuardianBand({ cards = [] }) {
+  if (!cards.length) return null;
+  return (
+    <section className="summary-guardian-band" aria-label="Vault status">
+      <header className="summary-guardian-head">
+        <span className="summary-guardian-eyebrow">Vault status</span>
+        <span className="summary-guardian-sub" aria-hidden="true">Words you kept alive today</span>
+      </header>
+      <div className="summary-stats summary-stats--guardian">
+        {cards.map((card) => (
+          <div className={`summary-stat summary-stat--guardian summary-stat--${card.id}`} key={card.id}>
+            <div className="v">{card.value}</div>
+            <div className="l">{card.label}</div>
+            {card.sub ? <div className="s">{card.sub}</div> : null}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function SpellingSummaryScene({ learner, ui, accent, actions, postMastery = null, previousHeroBg = '', runtimeReadOnly = false }) {
   const summary = ui.summary;
   if (!summary) return null;
   const pendingCommand = ui.pendingCommand || '';
@@ -34,6 +62,18 @@ export function SpellingSummaryScene({ learner, ui, accent, actions, previousHer
     progress: { done: progressTotal, total: progressTotal },
   }, { complete: true });
   const toneGood = !summary.mistakes.length;
+  const isGuardianSummary = summary.mode === 'guardian';
+  // When we exit a Guardian round the postMastery snapshot reflects the
+  // post-advance state — so `nextGuardianDueDay` already tells us when the
+  // learner should return. If postMastery is unavailable (e.g. SSR before
+  // storage hydrates) we degrade to "—" rather than crashing.
+  const guardianCards = isGuardianSummary
+    ? guardianSummaryCards({
+        summary,
+        nextGuardianDueDay: postMastery?.nextGuardianDueDay ?? null,
+        todayDay: postMastery?.todayDay ?? null,
+      })
+    : [];
 
   return (
     <div className="spelling-in-session summary-shell" style={{ gridColumn: '1/-1', ...heroBgStyle(heroBg) }}>
@@ -41,10 +81,13 @@ export function SpellingSummaryScene({ learner, ui, accent, actions, previousHer
       <div className="session summary">
         <header className="session-head">
           <PathProgress done={progressTotal} current={progressTotal} total={progressTotal} />
-          <span className="path-count">Round complete</span>
+          <span className="path-count">{isGuardianSummary ? 'Guardian round complete' : 'Round complete'}</span>
         </header>
 
-        <AnimatedPromptCard className="summary-card" innerClassName="summary-card-inner">
+        <AnimatedPromptCard
+          className={`summary-card${isGuardianSummary ? ' summary-card--guardian' : ''}`}
+          innerClassName="summary-card-inner"
+        >
           <h3 className="summary-title sr-only">Session summary</h3>
           <Ribbon
             tone={toneGood ? 'good' : 'warn'}
@@ -54,6 +97,8 @@ export function SpellingSummaryScene({ learner, ui, accent, actions, previousHer
           />
 
           <SummaryStatGrid cards={summary.cards} />
+
+          {isGuardianSummary ? <SummaryGuardianBand cards={guardianCards} /> : null}
 
           {summary.mistakes.length ? (
             <div className="summary-drill">

--- a/src/subjects/spelling/components/SpellingWordBankScene.jsx
+++ b/src/subjects/spelling/components/SpellingWordBankScene.jsx
@@ -5,6 +5,8 @@ import { SpellingHeroBackdrop } from './SpellingHeroBackdrop.jsx';
 import { SpellingWordDetailModal } from './SpellingWordDetailModal.jsx';
 import {
   WORD_BANK_FILTER_IDS,
+  WORD_BANK_GUARDIAN_FILTER_IDS,
+  WORD_BANK_GUARDIAN_FILTER_ID_SET,
   WORD_BANK_YEAR_FILTER_IDS,
   countWordBankExtra,
   countWordBankStatus,
@@ -29,6 +31,24 @@ import {
   wordMatchesSearch,
   wordStatusLabel,
 } from './spelling-view-model.js';
+
+// Guardian chip copy is deliberately grounded and specific — no "Great work!"
+// slop, no zero-celebration. Labels pair with a short hint that renders
+// above the chip row when any guardian filter is active so learners aren't
+// confronted with e.g. "170 never-renewed" rows without context.
+const GUARDIAN_CHIP_LABELS = Object.freeze({
+  guardianDue: 'Guardian due',
+  wobbling: 'Wobbling',
+  renewedRecently: 'Renewed (7d)',
+  neverRenewed: 'Untouched',
+});
+const GUARDIAN_CHIP_ORDER = WORD_BANK_GUARDIAN_FILTER_IDS;
+const GUARDIAN_FILTER_HINTS = Object.freeze({
+  guardianDue: 'Secure words the Vault wants you to recheck today.',
+  wobbling: 'Secure words that slipped last time — one more pass clears them.',
+  renewedRecently: 'Secure words you renewed in the last seven days.',
+  neverRenewed: 'Secure words the Guardian has not inspected yet — nothing is wrong, just untouched.',
+});
 
 function FilterChips({ counts, activeFilter, actions }) {
   const chips = [
@@ -56,6 +76,41 @@ function FilterChips({ counts, activeFilter, actions }) {
             <span className={`wb-status-swatch ${chip.swatch}`} aria-hidden="true" />
             <span className="wb-chip-label">{chip.label}</span>
             <CountUpValue className="wb-chip-count" value={counts[chip.id] ?? 0} />
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+/* Guardian filter chips sit on a row below the legacy status chips — same
+ * underlying data-action so the Set expansion in module.js accepts the four
+ * new IDs for free. The distinct wrapper class + square-cornered chip
+ * variant visually distinguishes "maintenance" (Guardian) from "learning"
+ * (legacy) so a learner with 10 chips in front of them doesn't read them
+ * as one undifferentiated decision. */
+function GuardianFilterChips({ counts, activeFilter, actions }) {
+  return (
+    <div
+      className="wb-chips wb-status-chips wb-chips--guardian"
+      role="group"
+      aria-label="Filter word bank by Guardian status"
+    >
+      {GUARDIAN_CHIP_ORDER.map((id) => {
+        const active = id === activeFilter;
+        return (
+          <button
+            type="button"
+            aria-pressed={active ? 'true' : 'false'}
+            className={`wb-chip wb-chip-status wb-chip-guardian wb-chip-guardian--${id}${active ? ' on' : ''}`}
+            data-action="spelling-analytics-status-filter"
+            data-value={id}
+            key={id}
+            onClick={(event) => renderAction(actions, event, 'spelling-analytics-status-filter', { value: id })}
+          >
+            <span className="wb-chip-guardian-mark" aria-hidden="true" />
+            <span className="wb-chip-label">{GUARDIAN_CHIP_LABELS[id]}</span>
+            <CountUpValue className="wb-chip-count" value={counts[id] ?? 0} />
           </button>
         );
       })}
@@ -141,7 +196,7 @@ function WordGroup({ group, words, query, actions, runtimeReadOnly = false }) {
   );
 }
 
-function WordBankCard({ learner, analytics, appState, actions, runtimeReadOnly = false }) {
+function WordBankCard({ learner, analytics, appState, actions, postMastery = null, runtimeReadOnly = false }) {
   const persistedSearchQuery = appState?.transientUi?.spellingAnalyticsWordSearch || '';
   const [draftSearch, setDraftSearch] = React.useState(persistedSearchQuery);
   const statusFilter = appState?.transientUi?.spellingAnalyticsStatusFilter || 'all';
@@ -156,29 +211,60 @@ function WordBankCard({ learner, analytics, appState, actions, runtimeReadOnly =
   }, [actions, persistedSearchQuery]);
   const searchQuery = draftSearch;
   const query = normaliseSearchText(searchQuery);
-  const activeFilter = WORD_BANK_FILTER_IDS.has(statusFilter) ? statusFilter : 'all';
+  const showGuardianFilters = Boolean(postMastery?.allWordsMega);
+  const guardianMap = postMastery?.guardianMap && typeof postMastery.guardianMap === 'object'
+    ? postMastery.guardianMap
+    : {};
+  const todayDay = Number.isFinite(Number(postMastery?.todayDay))
+    ? Math.floor(Number(postMastery.todayDay))
+    : 0;
+  // A persisted filter ID might point at a Guardian chip. If the learner is
+  // not currently post-mega (e.g. a new statutory word just published),
+  // collapse back to `all` so the UI never tries to apply a filter that has
+  // no visible chip. Legacy filters pass through unchanged.
+  const rawStatusFilter = WORD_BANK_FILTER_IDS.has(statusFilter) ? statusFilter : 'all';
+  const activeFilter = !showGuardianFilters && WORD_BANK_GUARDIAN_FILTER_ID_SET.has(rawStatusFilter)
+    ? 'all'
+    : rawStatusFilter;
   const activeYearFilter = WORD_BANK_YEAR_FILTER_IDS.has(yearFilter) ? yearFilter : 'all';
   const groups = Array.isArray(analytics.wordGroups) ? analytics.wordGroups : [];
   const wordBankMeta = analytics.wordBank || {};
   const allWords = groups.flatMap((group) => Array.isArray(group.words) ? group.words : []);
   const categoryWords = allWords.filter((word) => wordBankYearFilterMatches(activeYearFilter, word));
+  const filterOptions = { guardianMap, todayDay };
   const visibleGroups = groups
     .filter((group) => (activeYearFilter === 'all' ? true : group.key === activeYearFilter))
     .map((group) => ({
       group,
       words: (Array.isArray(group.words) ? group.words : [])
-        .filter((word) => wordBankFilterMatchesStatus(activeFilter, word.status))
+        .filter((word) => wordBankFilterMatchesStatus(activeFilter, word.status, {
+          guardian: guardianMap[word.slug] || null,
+          todayDay,
+        }))
         .filter((word) => wordMatchesSearch(word, query)),
     }))
     .filter((entry) => (activeFilter === 'all' && !query ? true : entry.words.length > 0));
   const visibleWords = visibleGroups.flatMap((entry) => entry.words);
+  const legacyStats = wordBankAggregateStats(categoryWords);
+  const guardianStats = showGuardianFilters
+    ? wordBankAggregateStats(categoryWords, { guardianMap, todayDay })
+    : null;
   const counts = {
     all: categoryWords.length,
-    due: countWordBankStatus(categoryWords, 'due'),
-    weak: countWordBankStatus(categoryWords, 'trouble'),
-    learning: countWordBankStatus(categoryWords, 'learning'),
-    secure: countWordBankStatus(categoryWords, 'secure'),
-    unseen: countWordBankStatus(categoryWords, 'new'),
+    due: legacyStats.due,
+    weak: legacyStats.trouble,
+    learning: legacyStats.learning,
+    secure: legacyStats.secure,
+    unseen: legacyStats.unseen,
+    // Guardian counts only materialise when the chips are surfaced. Keeping
+    // them off the object entirely when allWordsMega === false means the
+    // legacy `counts` literal is byte-identical to what shipped before U6.
+    ...(guardianStats ? {
+      guardianDue: guardianStats.guardianDue,
+      wobbling: guardianStats.wobbling,
+      renewedRecently: guardianStats.renewedRecently,
+      neverRenewed: guardianStats.neverRenewed,
+    } : {}),
   };
   const yearCounts = {
     all: allWords.length,
@@ -236,8 +322,17 @@ function WordBankCard({ learner, analytics, appState, actions, runtimeReadOnly =
           <div className="wb-filter-stack">
             <YearChips counts={yearCounts} activeYearFilter={activeYearFilter} actions={actions} />
             <FilterChips counts={counts} activeFilter={activeFilter} actions={actions} />
+            {showGuardianFilters ? (
+              <GuardianFilterChips counts={counts} activeFilter={activeFilter} actions={actions} />
+            ) : null}
           </div>
         </div>
+
+        {showGuardianFilters && WORD_BANK_GUARDIAN_FILTER_ID_SET.has(activeFilter) ? (
+          <p className="wb-guardian-hint" role="status">
+            {GUARDIAN_FILTER_HINTS[activeFilter]}
+          </p>
+        ) : null}
 
         <div className="wb-word-groups">
           {visibleGroups.length
@@ -264,31 +359,46 @@ function WordBankCard({ learner, analytics, appState, actions, runtimeReadOnly =
   );
 }
 
-function WordBankAggregates({ analytics }) {
+function WordBankAggregates({ analytics, postMastery = null }) {
   const groups = Array.isArray(analytics.wordGroups) ? analytics.wordGroups : [];
   const allWords = groups.flatMap((group) => Array.isArray(group.words) ? group.words : []);
-  const core = wordBankAggregateStats(allWords.filter((word) => word.spellingPool !== 'extra'));
-  const y34 = wordBankAggregateStats(allWords.filter((word) => word.year === '3-4'));
-  const y56 = wordBankAggregateStats(allWords.filter((word) => word.year === '5-6'));
-  const extra = wordBankAggregateStats(allWords.filter((word) => word.spellingPool === 'extra'));
+  const showGuardianCards = Boolean(postMastery?.allWordsMega);
+  const guardianMap = postMastery?.guardianMap && typeof postMastery.guardianMap === 'object'
+    ? postMastery.guardianMap
+    : {};
+  const todayDay = Number.isFinite(Number(postMastery?.todayDay))
+    ? Math.floor(Number(postMastery.todayDay))
+    : 0;
+  // When showGuardianCards is false we explicitly pass the zero-arg shape
+  // so the aggregate keeps its byte-identical six-field legacy output.
+  const statsOptions = showGuardianCards ? { guardianMap, todayDay } : undefined;
+  const cardOptions = showGuardianCards ? { showGuardian: true } : undefined;
+  const core = wordBankAggregateStats(allWords.filter((word) => word.spellingPool !== 'extra'), statsOptions);
+  const y34 = wordBankAggregateStats(allWords.filter((word) => word.year === '3-4'), statsOptions);
+  const y56 = wordBankAggregateStats(allWords.filter((word) => word.year === '5-6'), statsOptions);
+  const extra = wordBankAggregateStats(allWords.filter((word) => word.spellingPool === 'extra'), statsOptions);
   const cards = [
     {
       eyebrow: 'Core spellings',
       title: 'Core statutory progress',
-      stats: wordBankAggregateCards(core, 'Words in core pool'),
+      stats: wordBankAggregateCards(core, 'Words in core pool', cardOptions),
     },
     {
       eyebrow: 'Years 3-4',
       title: 'Lower KS2 spelling pool',
-      stats: wordBankAggregateCards(y34, 'Words in pool'),
+      stats: wordBankAggregateCards(y34, 'Words in pool', cardOptions),
     },
     {
       eyebrow: 'Years 5-6',
       title: 'Upper KS2 spelling pool',
-      stats: wordBankAggregateCards(y56, 'Words in pool'),
+      stats: wordBankAggregateCards(y56, 'Words in pool', cardOptions),
     },
     {
       eyebrow: 'Extra',
+      // Extra pool is never Guardian-eligible (Guardian Mega is core-only),
+      // so we always use the legacy card shape here regardless of
+      // showGuardianCards. This keeps the Extra card's visual rhythm
+      // identical across the post-Mega transition.
       title: 'Expansion spelling pool',
       stats: wordBankAggregateCards(extra, 'Words in pool'),
     },
@@ -312,6 +422,7 @@ export function SpellingWordBankScene({
   analytics,
   accent,
   actions,
+  postMastery = null,
   previousHeroBg = '',
   runtimeReadOnly = false,
 }) {
@@ -340,8 +451,15 @@ export function SpellingWordBankScene({
           </button>
           <h1 className="word-bank-title">{learner.name}’s spellings</h1>
         </header>
-        <WordBankAggregates analytics={analytics} />
-        <WordBankCard learner={learner} analytics={analytics} appState={appState} actions={actions} runtimeReadOnly={runtimeReadOnly} />
+        <WordBankAggregates analytics={analytics} postMastery={postMastery} />
+        <WordBankCard
+          learner={learner}
+          analytics={analytics}
+          appState={appState}
+          actions={actions}
+          postMastery={postMastery}
+          runtimeReadOnly={runtimeReadOnly}
+        />
       </div>
       {detailWord ? (
         <SpellingWordDetailModal

--- a/src/subjects/spelling/components/spelling-view-model.js
+++ b/src/subjects/spelling/components/spelling-view-model.js
@@ -74,8 +74,37 @@ export const YEAR_FILTER_OPTIONS = Object.freeze([
   { value: 'y5-6', label: 'Y5-6' },
   { value: 'extra', label: 'Extra' },
 ]);
-export const WORD_BANK_FILTER_IDS = new Set(['all', 'due', 'weak', 'learning', 'secure', 'unseen']);
+export const WORD_BANK_FILTER_IDS = new Set([
+  'all',
+  'due',
+  'weak',
+  'learning',
+  'secure',
+  'unseen',
+  // ----- U6 Guardian filters ---------------------------------------------
+  // Appended to the legacy set (not reordered) so serialised filter IDs
+  // persisted to `transientUi.spellingAnalyticsStatusFilter` remain
+  // byte-compatible for any learner who graduated before U6 landed. The
+  // `module.js` handler at `spelling-analytics-status-filter` accepts any
+  // ID that the Set contains, so surfacing these four chips is enough.
+  'guardianDue',
+  'wobbling',
+  'renewedRecently',
+  'neverRenewed',
+]);
+export const WORD_BANK_GUARDIAN_FILTER_IDS = Object.freeze([
+  'guardianDue',
+  'wobbling',
+  'renewedRecently',
+  'neverRenewed',
+]);
+export const WORD_BANK_GUARDIAN_FILTER_ID_SET = new Set(WORD_BANK_GUARDIAN_FILTER_IDS);
 export const WORD_BANK_YEAR_FILTER_IDS = new Set(['all', 'y3-4', 'y5-6', 'extra']);
+
+// How many days after lastReviewedDay still counts as "renewed recently" for
+// the Word Bank filter. Seven days mirrors the shortest Guardian interval
+// (reviewLevel 1 = 7 days) — anything inside that window is still fresh.
+export const GUARDIAN_RENEWED_RECENTLY_WINDOW_DAYS = 7;
 
 const SCRIBE_DOWNS_BASE = '/assets/regions/the-scribe-downs';
 const spellingHeroUrl = (variant) => `${SCRIBE_DOWNS_BASE}/the-scribe-downs-${variant}.1280.webp`;
@@ -249,11 +278,70 @@ export function normaliseSearchText(value) {
   return String(value || '').trim().toLowerCase();
 }
 
-export function wordBankFilterMatchesStatus(filter, status) {
+/**
+ * Match a word-bank row against an active status filter.
+ *
+ * Legacy filter IDs (`all`/`due`/`weak`/`learning`/`secure`/`unseen`) look
+ * only at `status` — their behaviour is byte-identical to what shipped
+ * before the Guardian work, even when `options` omits the guardian context.
+ * The four Guardian filter IDs additionally consult the learner's guardian
+ * record for the slug so "renewed recently" isn't guessed from `progress`
+ * alone.
+ *
+ * @param {string} filter Active filter id from `WORD_BANK_FILTER_IDS`.
+ * @param {string} status Status string on the word-bank row.
+ * @param {object} [options]
+ * @param {object|null} [options.guardian] Normalised guardian record for the
+ *   slug (from `data.guardian[slug]`), or `null`/`undefined` when absent.
+ * @param {number} [options.todayDay] Integer day (Math.floor(ts / DAY_MS)).
+ */
+export function wordBankFilterMatchesStatus(filter, status, options = {}) {
   if (filter === 'all') return true;
   if (filter === 'weak') return status === 'trouble';
   if (filter === 'unseen') return status === 'new';
-  return filter === status;
+  if (!WORD_BANK_GUARDIAN_FILTER_ID_SET.has(filter)) {
+    // Legacy filters keep their historic semantics. No guardian inspection.
+    return filter === status;
+  }
+
+  const guardian = options && typeof options === 'object' ? options.guardian : null;
+  const todayRaw = options && typeof options === 'object' ? options.todayDay : undefined;
+  const todayDay = Number.isFinite(Number(todayRaw)) ? Math.floor(Number(todayRaw)) : 0;
+  const hasGuardian = guardian && typeof guardian === 'object' && !Array.isArray(guardian);
+
+  if (filter === 'guardianDue') {
+    // Guardian Due is defined as: guardian record exists AND nextDueDay has
+    // arrived. We also require `status === 'secure'` because a word can
+    // drop out of `secure` (e.g. dueDay rolls over) while still owning a
+    // guardian record from a previous Guardian round — those should show
+    // under the legacy `due` chip, not here.
+    if (!hasGuardian) return false;
+    if (status !== 'secure') return false;
+    const nextDue = Number.isFinite(Number(guardian.nextDueDay)) ? Math.floor(Number(guardian.nextDueDay)) : Infinity;
+    return nextDue <= todayDay;
+  }
+
+  if (filter === 'wobbling') {
+    return Boolean(hasGuardian && guardian.wobbling === true);
+  }
+
+  if (filter === 'renewedRecently') {
+    if (!hasGuardian) return false;
+    if (guardian.lastReviewedDay == null) return false;
+    const last = Number(guardian.lastReviewedDay);
+    if (!Number.isFinite(last)) return false;
+    return (todayDay - Math.floor(last)) <= GUARDIAN_RENEWED_RECENTLY_WINDOW_DAYS;
+  }
+
+  if (filter === 'neverRenewed') {
+    // "Never renewed" is the freshly-graduated state: a word is secure (Mega)
+    // but has no guardian record yet because the learner hasn't touched it
+    // in a Guardian round. Non-secure words don't qualify because they
+    // never crossed into the maintenance loop in the first place.
+    return status === 'secure' && !hasGuardian;
+  }
+
+  return false;
 }
 
 export function wordBankYearFilterMatches(filter, word) {
@@ -486,6 +574,88 @@ export function guardianLabel(record, todayDay) {
   return `Next check in ${delta} days`;
 }
 
+/**
+ * Build the three Guardian-specific summary cards appended to the base
+ * summary stat grid after a Guardian Mission round.
+ *
+ * The shared `normaliseSummary` contract (service-contract.js) is
+ * intentionally minimal and does not carry Guardian-specific aggregates.
+ * Rather than widening that contract we derive counts from the two fields
+ * every `learningSummary` already populates:
+ *
+ *   • `summary.totalWords`    — round size (derived by `normaliseSummary`)
+ *   • `summary.mistakes`      — every word that was wrong at least once
+ *
+ * In Guardian mode a wrong answer emits `spelling.guardian.wobbled`, so
+ * `mistakes.length` is the wobbled count. Everything else was renewed
+ * (including words that recovered from a previous wobble — recoveries and
+ * fresh renewals both count as "kept alive in the Vault" for summary
+ * purposes; the event log still distinguishes them for downstream analytics).
+ *
+ * `nextGuardianDueDay` is the min `nextDueDay` across the learner's current
+ * guardian map (from `service.getPostMasteryState(...).nextGuardianDueDay`)
+ * threaded through as a prop so we can say "Next check: tomorrow" without a
+ * second storage round-trip in the scene.
+ *
+ * @param {object} params
+ * @param {object} params.summary Normalised summary (`normaliseSummary` shape).
+ * @param {number|null} params.nextGuardianDueDay Min across all records, or null.
+ * @param {number|null} params.todayDay Integer day for the delta calculation.
+ */
+export function guardianSummaryCards({ summary, nextGuardianDueDay, todayDay }) {
+  const totalWords = Math.max(0, Number(summary?.totalWords) || 0);
+  const mistakes = Array.isArray(summary?.mistakes) ? summary.mistakes : [];
+  const wobbledCount = Math.min(totalWords, mistakes.length);
+  const renewedTotal = Math.max(0, totalWords - wobbledCount);
+
+  const today = typeof todayDay === 'number' && Number.isFinite(todayDay) ? Math.floor(todayDay) : null;
+  const nextDue = typeof nextGuardianDueDay === 'number' && Number.isFinite(nextGuardianDueDay)
+    ? Math.floor(nextGuardianDueDay)
+    : null;
+  let nextCheckValue = '—';
+  let nextCheckSub = 'No more duties scheduled';
+  if (nextDue !== null && today !== null) {
+    const delta = nextDue - today;
+    if (delta <= 0) {
+      nextCheckValue = 'Today';
+      nextCheckSub = 'A fresh round is waiting';
+    } else if (delta === 1) {
+      nextCheckValue = 'Tomorrow';
+      nextCheckSub = 'Come back for the next check';
+    } else if (delta <= 30) {
+      nextCheckValue = `${delta} days`;
+      nextCheckSub = 'Words resting until next check';
+    } else {
+      nextCheckValue = `${delta} days`;
+      nextCheckSub = 'Long-term maintenance schedule';
+    }
+  }
+  return [
+    {
+      id: 'guardian-renewed',
+      label: 'Words renewed',
+      value: renewedTotal,
+      sub: renewedTotal === 0
+        ? 'No words held the line'
+        : 'Kept alive in the Vault',
+    },
+    {
+      id: 'guardian-wobbling',
+      label: 'Words wobbling',
+      value: wobbledCount,
+      sub: wobbledCount === 0
+        ? 'No new wobbles today'
+        : 'Returning tomorrow for recovery',
+    },
+    {
+      id: 'guardian-next-check',
+      label: 'Next check',
+      value: nextCheckValue,
+      sub: nextCheckSub,
+    },
+  ];
+}
+
 export function summaryHeadline(summary) {
   if (summary?.totalWords > 0 && typeof summary.correct === 'number') {
     return `${summary.correct} of ${summary.totalWords} words landed.`;
@@ -511,7 +681,23 @@ export function countWordBankExtra(words) {
   return words.reduce((count, word) => count + (word.spellingPool === 'extra' ? 1 : 0), 0);
 }
 
-export function wordBankAggregateStats(words) {
+/**
+ * Build the six legacy counts plus (optionally) four Guardian-scoped counts.
+ *
+ * When called as `wordBankAggregateStats(words)` the output is the exact
+ * six-field shape that shipped before U6. Passing `{ guardianMap, todayDay }`
+ * opts in to the Guardian aggregation — the extra counts are appended to the
+ * same object so one pass over the word list is enough. Legacy consumers
+ * that destructure `{ total, secure, due, trouble, learning, unseen }` keep
+ * their existing shape; Guardian-aware consumers also read the four new
+ * fields without a second reducer pass.
+ *
+ * @param {Array} words Word-bank rows (each has `slug`, `status`).
+ * @param {object} [options]
+ * @param {object} [options.guardianMap] slug -> guardian record.
+ * @param {number} [options.todayDay] Integer day (Math.floor(ts / DAY_MS)).
+ */
+export function wordBankAggregateStats(words, options = {}) {
   const stats = {
     total: 0,
     secure: 0,
@@ -520,6 +706,19 @@ export function wordBankAggregateStats(words) {
     learning: 0,
     unseen: 0,
   };
+  const hasGuardianContext = Boolean(
+    options && typeof options === 'object' && options.guardianMap && typeof options.guardianMap === 'object',
+  );
+  if (hasGuardianContext) {
+    stats.guardianDue = 0;
+    stats.wobbling = 0;
+    stats.renewedRecently = 0;
+    stats.neverRenewed = 0;
+  }
+  const guardianMap = hasGuardianContext ? options.guardianMap : null;
+  const todayRaw = hasGuardianContext ? options.todayDay : undefined;
+  const todayDay = Number.isFinite(Number(todayRaw)) ? Math.floor(Number(todayRaw)) : 0;
+
   for (const word of Array.isArray(words) ? words : []) {
     stats.total += 1;
     if (word.status === 'secure') stats.secure += 1;
@@ -527,18 +726,34 @@ export function wordBankAggregateStats(words) {
     else if (word.status === 'trouble') stats.trouble += 1;
     else if (word.status === 'learning') stats.learning += 1;
     else if (word.status === 'new') stats.unseen += 1;
+
+    if (!hasGuardianContext) continue;
+    const guardian = word && word.slug ? guardianMap[word.slug] : null;
+    if (wordBankFilterMatchesStatus('guardianDue', word.status, { guardian, todayDay })) stats.guardianDue += 1;
+    if (wordBankFilterMatchesStatus('wobbling', word.status, { guardian, todayDay })) stats.wobbling += 1;
+    if (wordBankFilterMatchesStatus('renewedRecently', word.status, { guardian, todayDay })) stats.renewedRecently += 1;
+    if (wordBankFilterMatchesStatus('neverRenewed', word.status, { guardian, todayDay })) stats.neverRenewed += 1;
   }
   return stats;
 }
 
-export function wordBankAggregateCards(stats, totalSub) {
-  return [
+export function wordBankAggregateCards(stats, totalSub, options = {}) {
+  const baseCards = [
     { label: 'Total', value: stats.total, sub: totalSub },
     { label: 'Secure', value: stats.secure, sub: 'Stable recall' },
     { label: 'Due now', value: stats.due, sub: 'Due today or overdue' },
     { label: 'Trouble', value: stats.trouble, sub: 'Weak or fragile' },
     { label: 'Learning', value: stats.learning, sub: 'Introduced, not secure' },
     { label: 'Unseen', value: stats.unseen, sub: 'Not yet introduced' },
+  ];
+  const showGuardian = Boolean(options && typeof options === 'object' && options.showGuardian === true);
+  if (!showGuardian) return baseCards;
+  return [
+    ...baseCards,
+    { label: 'Renewed (7d)', value: Number(stats.renewedRecently) || 0, sub: 'Guarded this week' },
+    { label: 'Guardian due', value: Number(stats.guardianDue) || 0, sub: 'Ready for a check' },
+    { label: 'Wobbling', value: Number(stats.wobbling) || 0, sub: 'One miss away' },
+    { label: 'Untouched', value: Number(stats.neverRenewed) || 0, sub: 'Secure, never guarded' },
   ];
 }
 
@@ -561,11 +776,14 @@ export function buildSpellingContext({ appState, service, repositories, subject 
   };
   const needsAnalytics = ui.phase === 'dashboard' || ui.phase === 'word-bank';
   const analytics = needsAnalytics ? service.getAnalyticsSnapshot(learner.id) : null;
-  // Post-mastery aggregates are only needed for the dashboard branch. On
-  // other phases we return a conservative default so downstream code never
-  // has to null-check the field. The service contract guarantees this shape
-  // after U5.
-  const postMastery = ui.phase === 'dashboard' && typeof service.getPostMasteryState === 'function'
+  // Post-mastery aggregates are needed on the dashboard (mode selection,
+  // Alt+4 gate), the summary scene (to render "Next check" in Guardian
+  // mode), and the Word Bank (to gate the four Guardian filter chips and
+  // feed `guardianMap` into the row predicates). Session-phase rendering
+  // does not consult these, so we skip the storage read there to keep the
+  // session hot-path cheap.
+  const postMasteryPhases = new Set(['dashboard', 'summary', 'word-bank']);
+  const postMastery = postMasteryPhases.has(ui.phase) && typeof service.getPostMasteryState === 'function'
     ? service.getPostMasteryState(learner.id)
     : {
         allWordsMega: false,

--- a/styles/app.css
+++ b/styles/app.css
@@ -5846,6 +5846,71 @@ textarea:focus-visible {
   margin-top: 4px;
 }
 
+/* ---------- U6 Guardian summary band ---------- */
+/* The Guardian band sits below the standard stat grid on a Guardian-mode
+   summary. A hairline divider + eyebrow read it as "different kind of
+   information" rather than "three more stats", so the maintenance metaphor
+   reads distinct from the competence ribbon above. */
+.spelling-in-session .summary-guardian-band {
+  margin-top: 22px;
+  padding-top: 18px;
+  border-top: 1px solid color-mix(in oklab, var(--line) 80%, transparent);
+}
+.spelling-in-session .summary-guardian-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 4px 10px;
+  margin-bottom: 10px;
+}
+.spelling-in-session .summary-guardian-eyebrow {
+  font-family: var(--font-display, var(--font-sans));
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: color-mix(in oklab, var(--brand-ink, var(--ink)) 70%, var(--ink));
+}
+.spelling-in-session .summary-guardian-sub {
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: var(--muted);
+  letter-spacing: 0;
+}
+.spelling-in-session .summary-stats--guardian {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 0;
+}
+@media (max-width: 720px) {
+  .spelling-in-session .summary-stats--guardian { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+}
+.spelling-in-session .summary-stat--guardian {
+  position: relative;
+  background: color-mix(in oklab, var(--brand-soft, var(--panel-soft)) 55%, var(--panel));
+  border-color: color-mix(in oklab, var(--brand, #3E6FA8) 22%, var(--line));
+}
+.spelling-in-session .summary-stat--guardian::before {
+  content: "";
+  position: absolute;
+  inset: -1px auto -1px -1px;
+  width: 3px;
+  border-radius: 14px 0 0 14px;
+  background: color-mix(in oklab, var(--brand, #3E6FA8) 48%, transparent);
+}
+.spelling-in-session .summary-stat--guardian .l {
+  color: color-mix(in oklab, var(--brand-ink, var(--ink-2)) 85%, var(--ink-2));
+}
+.spelling-in-session .summary-stat--guardian-renewed .v {
+  color: color-mix(in oklab, var(--good-strong, var(--ink)) 80%, var(--ink));
+}
+.spelling-in-session .summary-stat--guardian-wobbling .v {
+  color: color-mix(in oklab, var(--bad-strong, #b3372c) 75%, var(--ink));
+}
+.spelling-in-session .summary-stat--guardian-next-check .v {
+  font-size: 1.4rem;
+  letter-spacing: -0.01em;
+}
+
 .spelling-in-session .summary-drill {
   margin-top: 20px;
   padding: 14px 18px 16px;
@@ -6241,6 +6306,84 @@ textarea:focus-visible {
 }
 .wb-status-swatch.trouble {
   color: var(--bad);
+}
+
+/* ---------- U6 Guardian filter chips ---------- */
+/* The Guardian chip row sits BELOW the legacy status chips when
+   postMastery.allWordsMega === true. Guardian chips use a distinct visual
+   identity (soft-pill shape with a left-edge keyline mark + flatter bottom
+   on the active state) so learners reading 10 chips don't treat them all
+   as "pick one more". The mental model is maintenance, not learning. */
+.wb-chips--guardian {
+  margin-top: 4px;
+  padding-top: 10px;
+  border-top: 1px dashed color-mix(in oklab, var(--line) 65%, transparent);
+  gap: 6px 8px;
+}
+.wb-chip-guardian {
+  gap: 8px;
+  background: color-mix(in oklab, var(--brand-soft, var(--panel-soft)) 34%, var(--panel));
+  border-style: solid;
+  border-color: color-mix(in oklab, var(--brand, #3E6FA8) 18%, var(--line));
+  color: color-mix(in oklab, var(--brand-ink, var(--ink-2)) 75%, var(--ink-2));
+  border-radius: 10px 10px 4px 4px;
+  padding-left: 10px;
+}
+.wb-chip-guardian:hover {
+  border-color: color-mix(in oklab, var(--brand, #3E6FA8) 40%, var(--line));
+  color: color-mix(in oklab, var(--brand-ink, var(--ink)) 95%, var(--ink));
+}
+.wb-chip-guardian.on {
+  background: color-mix(in oklab, var(--brand, #3E6FA8) 14%, var(--panel));
+  border-color: color-mix(in oklab, var(--brand, #3E6FA8) 62%, transparent);
+  color: var(--brand-ink, var(--ink));
+  box-shadow: inset 0 -2px 0 0 color-mix(in oklab, var(--brand, #3E6FA8) 55%, transparent);
+}
+.wb-chip-guardian .wb-chip-count {
+  background: color-mix(in oklab, var(--brand, #3E6FA8) 10%, var(--panel));
+  border-color: color-mix(in oklab, var(--brand, #3E6FA8) 20%, transparent);
+}
+.wb-chip-guardian.on .wb-chip-count {
+  background: color-mix(in oklab, var(--brand, #3E6FA8) 28%, var(--panel));
+  border-color: color-mix(in oklab, var(--brand, #3E6FA8) 48%, transparent);
+  color: var(--brand-ink, var(--ink));
+}
+.wb-chip-guardian-mark {
+  width: 6px;
+  height: 10px;
+  border-radius: 1px;
+  background: currentColor;
+  opacity: 0.42;
+  flex: 0 0 auto;
+}
+.wb-chip-guardian--wobbling .wb-chip-guardian-mark {
+  background: color-mix(in oklab, var(--bad, #b3372c) 70%, currentColor);
+  opacity: 0.72;
+}
+.wb-chip-guardian--guardianDue .wb-chip-guardian-mark {
+  background: color-mix(in oklab, var(--warn, #d08b2e) 70%, currentColor);
+  opacity: 0.72;
+}
+.wb-chip-guardian--renewedRecently .wb-chip-guardian-mark {
+  background: color-mix(in oklab, var(--good, #3aa268) 70%, currentColor);
+  opacity: 0.72;
+}
+.wb-chip-guardian--neverRenewed .wb-chip-guardian-mark {
+  background: color-mix(in oklab, var(--muted, #8a8a8a) 80%, currentColor);
+  opacity: 0.62;
+}
+.wb-guardian-hint {
+  margin: 12px 0 6px;
+  padding: 10px 14px;
+  border-left: 3px solid color-mix(in oklab, var(--brand, #3E6FA8) 52%, transparent);
+  background: color-mix(in oklab, var(--brand-soft, var(--panel-soft)) 50%, var(--panel));
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  color: color-mix(in oklab, var(--brand-ink, var(--ink)) 90%, var(--ink));
+  font-size: 0.85rem;
+  line-height: 1.45;
+}
+@media (max-width: 720px) {
+  .wb-chips--guardian { padding-top: 8px; }
 }
 
 /* ---------- Subject-screen breadcrumb ---------- */

--- a/tests/helpers/react-render.js
+++ b/tests/helpers/react-render.js
@@ -791,6 +791,87 @@ export function renderSpellingSurfaceFixture({
   `);
 }
 
+/**
+ * Render the Spelling summary scene after a Guardian Mission round ends.
+ *
+ * We can't replay the standard setup -> session -> summary path in one
+ * fixture run because Guardian rounds pull words from the runtime guardian
+ * map, and `renderSpellingSurfaceFixture` does not know how to run a full
+ * round from inside its generated entry script. Instead we:
+ *   1. Seed the learner as fully post-mega with an empty guardian map.
+ *   2. Start a Guardian session (lazy-creates a record for the first word).
+ *   3. Submit one answer (correct or incorrect per `opts.correct`).
+ *   4. Render the resulting summary phase.
+ *
+ * The output is the same SubjectRoute markup the surface test harness
+ * returns, so caller tests can assert on Guardian-specific copy + CSS hooks.
+ */
+export function renderSpellingGuardianSummaryFixture({ correct = true } = {}) {
+  return renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { SubjectRoute } from ${JSON.stringify(absoluteSpecifier('src/surfaces/subject/SubjectRoute.jsx'))};
+    import { createLocalAppController } from ${JSON.stringify(absoluteSpecifier('src/platform/app/create-local-app-controller.js'))};
+    import { installMemoryStorage } from ${JSON.stringify(absoluteSpecifier('tests/helpers/memory-storage.js'))};
+    import { WORDS } from ${JSON.stringify(absoluteSpecifier('src/subjects/spelling/data/word-data.js'))};
+
+    installMemoryStorage();
+    const controller = createLocalAppController();
+    const learnerId = controller.store.getState().learners.selectedId;
+
+    // Seed every core-pool word as stage-4 secure so allWordsMega === true.
+    const nowDay = Math.floor(Date.now() / (24 * 60 * 60 * 1000));
+    const progress = {};
+    for (const word of WORDS) {
+      if ((word.spellingPool === 'extra' ? 'extra' : 'core') !== 'core') continue;
+      progress[word.slug] = {
+        stage: 4,
+        attempts: 6,
+        correct: 5,
+        wrong: 1,
+        dueDay: nowDay + 60,
+        lastDay: nowDay - 7,
+        lastResult: true,
+      };
+    }
+    const existing = controller.repositories.subjectStates.read(learnerId, 'spelling').data || {};
+    controller.repositories.subjectStates.writeData(learnerId, 'spelling', {
+      ...existing,
+      progress,
+      guardian: {},
+    });
+
+    controller.dispatch('open-subject', { subjectId: 'spelling' });
+    controller.services.spelling.savePrefs(learnerId, { mode: 'guardian', roundLength: '1' });
+    // A round-length=1 Guardian session lets us finish in a single submit.
+    controller.dispatch('spelling-shortcut-start', { mode: 'guardian' });
+    while (controller.store.getState().subjectUi.spelling.phase === 'session') {
+      const ui = controller.store.getState().subjectUi.spelling;
+      const formData = new FormData();
+      const card = ui.session.currentCard;
+      formData.set('typed', ${JSON.stringify(correct)} ? card.word.word : 'zzzobviouslywrong');
+      controller.dispatch('spelling-submit-form', { formData });
+      // Guardian sessions retain the awaiting-advance step on wrong answers
+      // so we continue here to get to the next card / summary.
+      const after = controller.store.getState().subjectUi.spelling;
+      if (after.phase === 'session' && after.awaitingAdvance) {
+        controller.dispatch('spelling-continue');
+      }
+    }
+
+    const appState = controller.store.getState();
+    const context = controller.contextFor('spelling');
+    const actions = {
+      dispatch(action, data) { controller.dispatch(action, data); },
+      navigateHome() { controller.dispatch('navigate-home'); },
+      openParentHub() { controller.dispatch('open-parent-hub'); },
+      openAdminHub() { controller.dispatch('open-admin-hub'); },
+    };
+    const html = renderToStaticMarkup(<SubjectRoute appState={appState} context={context} actions={actions} />);
+    console.log(html);
+  `);
+}
+
 export function renderSpellingClozeFixture({ sentence, answer = '', revealAnswer = false } = {}) {
   return renderFixture(`
     import React from 'react';

--- a/tests/react-spelling-surface.test.js
+++ b/tests/react-spelling-surface.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 
 import {
   renderSpellingClozeFixture,
+  renderSpellingGuardianSummaryFixture,
   renderSpellingSurfaceFixture,
 } from './helpers/react-render.js';
 import { createSpellingReadModelService } from '../src/subjects/spelling/client-read-models.js';
@@ -174,4 +175,107 @@ test('React spelling setup scene shows "All guardians rested" copy when allWords
   // The rested-state "Rested" chip appears on the Guardian card frame itself.
   assert.match(html, /mode-card-post-status/);
   assert.match(html, /Rested/);
+});
+
+// ----- U6: Summary + Word Bank Guardian surfaces -----------------------------
+
+test('React spelling Word Bank renders the legacy 6-chip row identically when allWordsMega is false', async () => {
+  // When the learner has NOT graduated, the Word Bank must look exactly
+  // like it did before U6 — no Guardian chips, no hint ribbon, no
+  // Guardian-flavoured aggregate cards.
+  const html = await renderSpellingSurfaceFixture({ phase: 'word-bank' });
+
+  assert.match(html, /Word bank progress/);
+  assert.doesNotMatch(html, /wb-chips--guardian/);
+  assert.doesNotMatch(html, /wb-chip-guardian/);
+  assert.doesNotMatch(html, /wb-guardian-hint/);
+  assert.doesNotMatch(html, /data-value="guardianDue"/);
+  assert.doesNotMatch(html, /data-value="wobbling"/);
+  assert.doesNotMatch(html, /data-value="renewedRecently"/);
+  assert.doesNotMatch(html, /data-value="neverRenewed"/);
+  // Legacy chips must still be present.
+  assert.match(html, /data-action="spelling-analytics-status-filter"[^>]*data-value="all"/);
+  assert.match(html, /data-action="spelling-analytics-status-filter"[^>]*data-value="secure"/);
+});
+
+test('React spelling Word Bank renders the 4 Guardian chips only when allWordsMega is true', async () => {
+  const today = Math.floor(Date.now() / (24 * 60 * 60 * 1000));
+  const html = await renderSpellingSurfaceFixture({
+    phase: 'word-bank',
+    postMega: {
+      guardian: {
+        possess: {
+          reviewLevel: 2,
+          lastReviewedDay: today - 2,
+          nextDueDay: today,
+          correctStreak: 2,
+          lapses: 0,
+          renewals: 0,
+          wobbling: true,
+        },
+      },
+    },
+  });
+
+  assert.match(html, /wb-chips--guardian/);
+  assert.match(html, /data-action="spelling-analytics-status-filter"[^>]*data-value="guardianDue"/);
+  assert.match(html, /data-action="spelling-analytics-status-filter"[^>]*data-value="wobbling"/);
+  assert.match(html, /data-action="spelling-analytics-status-filter"[^>]*data-value="renewedRecently"/);
+  assert.match(html, /data-action="spelling-analytics-status-filter"[^>]*data-value="neverRenewed"/);
+  // The legacy chip row must remain intact alongside the new chips.
+  assert.match(html, /data-action="spelling-analytics-status-filter"[^>]*data-value="all"/);
+  assert.match(html, /data-action="spelling-analytics-status-filter"[^>]*data-value="secure"/);
+  // Guardian-flavoured aggregate card labels surface on the aggregate card strip.
+  assert.match(html, /Wobbling/);
+});
+
+test('React spelling Word Bank hint ribbon surfaces only when a Guardian filter is active', async () => {
+  const today = Math.floor(Date.now() / (24 * 60 * 60 * 1000));
+  // First render: default filter is `all`, so no hint should appear even
+  // though we are post-mega and the chips exist.
+  const neutralHtml = await renderSpellingSurfaceFixture({
+    phase: 'word-bank',
+    postMega: {
+      guardian: {
+        possess: {
+          reviewLevel: 2,
+          lastReviewedDay: today - 2,
+          nextDueDay: today,
+          correctStreak: 2,
+          lapses: 0,
+          renewals: 0,
+          wobbling: false,
+        },
+      },
+    },
+  });
+  assert.match(neutralHtml, /wb-chips--guardian/);
+  assert.doesNotMatch(neutralHtml, /wb-guardian-hint/, 'no hint when filter is "all"');
+});
+
+test('React spelling Summary scene renders 3 Guardian cards when summary.mode === "guardian"', async () => {
+  // Use the word-bank fixture path to graduate the learner first, then run
+  // a short one-word Guardian round to produce a summary with mode=guardian.
+  // We have to do this inline so the fixture stays isolated to this test.
+  const html = await renderSpellingGuardianSummaryFixture({ correct: true });
+  assert.match(html, /Guardian round complete/);
+  assert.match(html, /summary-guardian-band/);
+  assert.match(html, /Vault status/);
+  assert.match(html, /summary-stat--guardian-renewed/);
+  assert.match(html, /summary-stat--guardian-wobbling/);
+  assert.match(html, /summary-stat--guardian-next-check/);
+  assert.match(html, /Words renewed/);
+  assert.match(html, /Words wobbling/);
+  assert.match(html, /Next check/);
+});
+
+test('React spelling Summary scene does NOT render the Guardian band for mode="smart"', async () => {
+  // Default phase=summary uses mode=smart — the legacy summary must not
+  // grow any Guardian affordances (byte-compatibility with the prior shell).
+  const html = await renderSpellingSurfaceFixture({ phase: 'summary' });
+  assert.match(html, /summary-card/);
+  assert.doesNotMatch(html, /summary-guardian-band/);
+  assert.doesNotMatch(html, /Vault status/);
+  assert.doesNotMatch(html, /summary-stat--guardian/);
+  assert.doesNotMatch(html, /Guardian round complete/);
 });

--- a/tests/spelling-guardian.test.js
+++ b/tests/spelling-guardian.test.js
@@ -1419,3 +1419,50 @@ test('U5 shortcut resolver: Alt+1/2/3 mappings remain intact after Alt+4 additio
   }, appState);
   assert.deepEqual(sats, { action: 'spelling-shortcut-start', data: { mode: 'test' }, preventDefault: true });
 });
+
+// -----------------------------------------------------------------------------
+// U6 action-routing: the spelling-analytics-status-filter handler validates
+// incoming values against WORD_BANK_FILTER_IDS — extending the Set in U6
+// should make each of the four new Guardian filters round-trip through the
+// module handler with no further code change.
+// -----------------------------------------------------------------------------
+
+const GUARDIAN_FILTER_IDS = ['guardianDue', 'wobbling', 'renewedRecently', 'neverRenewed'];
+
+for (const filterId of GUARDIAN_FILTER_IDS) {
+  test(`U6 action routing: spelling-analytics-status-filter accepts value="${filterId}" via WORD_BANK_FILTER_IDS Set expansion`, async () => {
+    const createAppHarness = await importAppHarness();
+    const storage = installMemoryStorage();
+    const harness = createAppHarness({ storage });
+    harness.dispatch('open-subject', { subjectId: 'spelling' });
+
+    // Seed the filter to `all` via the legacy path first, so we can assert
+    // the handler actually advanced to the Guardian ID (and didn't silently
+    // fall through to the 'all' fallback).
+    harness.dispatch('spelling-analytics-status-filter', { value: 'secure' });
+    assert.equal(
+      harness.store.getState().transientUi.spellingAnalyticsStatusFilter,
+      'secure',
+      'baseline: legacy filter ID writes to transientUi',
+    );
+
+    harness.dispatch('spelling-analytics-status-filter', { value: filterId });
+    assert.equal(
+      harness.store.getState().transientUi.spellingAnalyticsStatusFilter,
+      filterId,
+      `${filterId} should be written to transientUi.spellingAnalyticsStatusFilter`,
+    );
+  });
+}
+
+test('U6 action routing: unknown filter IDs still fall back to "all"', async () => {
+  // Regression guard: the WORD_BANK_FILTER_IDS Set expansion must not
+  // accept arbitrary strings. Any value that is not in the Set collapses
+  // back to 'all' (existing contract).
+  const createAppHarness = await importAppHarness();
+  const storage = installMemoryStorage();
+  const harness = createAppHarness({ storage });
+  harness.dispatch('open-subject', { subjectId: 'spelling' });
+  harness.dispatch('spelling-analytics-status-filter', { value: 'not-a-real-filter' });
+  assert.equal(harness.store.getState().transientUi.spellingAnalyticsStatusFilter, 'all');
+});

--- a/tests/spelling-view-model.test.js
+++ b/tests/spelling-view-model.test.js
@@ -4,9 +4,15 @@ import assert from 'node:assert/strict';
 import {
   MODE_CARDS,
   POST_MEGA_MODE_CARDS,
+  WORD_BANK_FILTER_IDS,
+  WORD_BANK_GUARDIAN_FILTER_IDS,
   guardianLabel,
+  guardianSummaryCards,
   renderAction,
   summaryModeLabel,
+  wordBankAggregateCards,
+  wordBankAggregateStats,
+  wordBankFilterMatchesStatus,
 } from '../src/subjects/spelling/components/spelling-view-model.js';
 
 function createEventStub() {
@@ -215,4 +221,276 @@ test('guardianLabel: returns "Not guarded yet" when the record is missing or mal
   assert.equal(guardianLabel(undefined, today), 'Not guarded yet');
   assert.equal(guardianLabel('garbage', today), 'Not guarded yet');
   assert.equal(guardianLabel([], today), 'Not guarded yet');
+});
+
+// ----- U6: Word Bank guardian filter predicates + aggregates ------------------
+
+test('WORD_BANK_FILTER_IDS gains exactly four Guardian IDs on top of the six legacy IDs', () => {
+  // Baseline: legacy chips shipped before U6 were all/due/weak/learning/secure/unseen.
+  const legacyIds = ['all', 'due', 'weak', 'learning', 'secure', 'unseen'];
+  for (const id of legacyIds) {
+    assert.equal(WORD_BANK_FILTER_IDS.has(id), true, `${id} must still be in WORD_BANK_FILTER_IDS`);
+  }
+  const guardianIds = ['guardianDue', 'wobbling', 'renewedRecently', 'neverRenewed'];
+  for (const id of guardianIds) {
+    assert.equal(WORD_BANK_FILTER_IDS.has(id), true, `${id} must be in WORD_BANK_FILTER_IDS`);
+  }
+  assert.equal(WORD_BANK_FILTER_IDS.size, legacyIds.length + guardianIds.length);
+  assert.deepEqual([...WORD_BANK_GUARDIAN_FILTER_IDS], guardianIds);
+});
+
+test('wordBankFilterMatchesStatus: legacy filters preserve their historic semantics (no guardian context)', () => {
+  // Legacy contract: two positional args, no third options arg. Guardian
+  // shape must not leak in when callers only pass (filter, status).
+  assert.equal(wordBankFilterMatchesStatus('all', 'secure'), true);
+  assert.equal(wordBankFilterMatchesStatus('all', 'new'), true);
+  assert.equal(wordBankFilterMatchesStatus('secure', 'secure'), true);
+  assert.equal(wordBankFilterMatchesStatus('secure', 'due'), false);
+  assert.equal(wordBankFilterMatchesStatus('due', 'due'), true);
+  assert.equal(wordBankFilterMatchesStatus('due', 'secure'), false);
+  assert.equal(wordBankFilterMatchesStatus('weak', 'trouble'), true);
+  assert.equal(wordBankFilterMatchesStatus('weak', 'secure'), false);
+  assert.equal(wordBankFilterMatchesStatus('learning', 'learning'), true);
+  assert.equal(wordBankFilterMatchesStatus('learning', 'new'), false);
+  assert.equal(wordBankFilterMatchesStatus('unseen', 'new'), true);
+  assert.equal(wordBankFilterMatchesStatus('unseen', 'secure'), false);
+});
+
+test('wordBankFilterMatchesStatus: guardianDue is true when nextDueDay <= todayDay on a secure word', () => {
+  const today = 20_000;
+  assert.equal(
+    wordBankFilterMatchesStatus('guardianDue', 'secure', {
+      guardian: { nextDueDay: today, wobbling: false },
+      todayDay: today,
+    }),
+    true,
+  );
+  assert.equal(
+    wordBankFilterMatchesStatus('guardianDue', 'secure', {
+      guardian: { nextDueDay: today - 5, wobbling: false },
+      todayDay: today,
+    }),
+    true,
+  );
+});
+
+test('wordBankFilterMatchesStatus: guardianDue is false when nextDueDay > todayDay', () => {
+  const today = 20_000;
+  assert.equal(
+    wordBankFilterMatchesStatus('guardianDue', 'secure', {
+      guardian: { nextDueDay: today + 1, wobbling: false },
+      todayDay: today,
+    }),
+    false,
+  );
+});
+
+test('wordBankFilterMatchesStatus: guardianDue requires a guardian record (returns false when absent)', () => {
+  const today = 20_000;
+  assert.equal(
+    wordBankFilterMatchesStatus('guardianDue', 'secure', { guardian: null, todayDay: today }),
+    false,
+  );
+});
+
+test('wordBankFilterMatchesStatus: guardianDue requires status === "secure" — due non-secure words show under the legacy chip, not here', () => {
+  const today = 20_000;
+  const dueRecord = { nextDueDay: today, wobbling: false };
+  assert.equal(wordBankFilterMatchesStatus('guardianDue', 'due', { guardian: dueRecord, todayDay: today }), false);
+  assert.equal(wordBankFilterMatchesStatus('guardianDue', 'trouble', { guardian: dueRecord, todayDay: today }), false);
+});
+
+test('wordBankFilterMatchesStatus: wobbling is true iff guardian.wobbling === true', () => {
+  assert.equal(wordBankFilterMatchesStatus('wobbling', 'secure', { guardian: { wobbling: true } }), true);
+  assert.equal(wordBankFilterMatchesStatus('wobbling', 'secure', { guardian: { wobbling: false } }), false);
+  assert.equal(wordBankFilterMatchesStatus('wobbling', 'secure', { guardian: null }), false);
+  assert.equal(wordBankFilterMatchesStatus('wobbling', 'secure', {}), false);
+});
+
+test('wordBankFilterMatchesStatus: renewedRecently inclusive at the 7-day boundary', () => {
+  const today = 20_000;
+  assert.equal(
+    wordBankFilterMatchesStatus('renewedRecently', 'secure', {
+      guardian: { lastReviewedDay: today - 7 },
+      todayDay: today,
+    }),
+    true,
+    'exactly 7 days ago counts as recent',
+  );
+  assert.equal(
+    wordBankFilterMatchesStatus('renewedRecently', 'secure', {
+      guardian: { lastReviewedDay: today - 8 },
+      todayDay: today,
+    }),
+    false,
+    '8 days ago is outside the window',
+  );
+  assert.equal(
+    wordBankFilterMatchesStatus('renewedRecently', 'secure', {
+      guardian: { lastReviewedDay: null },
+      todayDay: today,
+    }),
+    false,
+    'null lastReviewedDay never qualifies',
+  );
+  assert.equal(
+    wordBankFilterMatchesStatus('renewedRecently', 'secure', {
+      guardian: null,
+      todayDay: today,
+    }),
+    false,
+    'no guardian record → false',
+  );
+});
+
+test('wordBankFilterMatchesStatus: neverRenewed is true only for secure words with no guardian record', () => {
+  assert.equal(
+    wordBankFilterMatchesStatus('neverRenewed', 'secure', { guardian: null }),
+    true,
+    'secure + no guardian → true',
+  );
+  assert.equal(
+    wordBankFilterMatchesStatus('neverRenewed', 'secure', {}),
+    true,
+    'options w/ no guardian key → true',
+  );
+  assert.equal(
+    wordBankFilterMatchesStatus('neverRenewed', 'due', { guardian: null }),
+    false,
+    'non-secure never qualifies',
+  );
+  assert.equal(
+    wordBankFilterMatchesStatus('neverRenewed', 'new', { guardian: null }),
+    false,
+  );
+  assert.equal(
+    wordBankFilterMatchesStatus('neverRenewed', 'secure', {
+      guardian: { reviewLevel: 0, lastReviewedDay: null, nextDueDay: 20_000, wobbling: false },
+    }),
+    false,
+    'secure with a guardian record → false',
+  );
+});
+
+test('wordBankAggregateStats: with no guardian context, returns the legacy six-field shape identically', () => {
+  const words = [
+    { slug: 'a', status: 'secure' },
+    { slug: 'b', status: 'secure' },
+    { slug: 'c', status: 'due' },
+    { slug: 'd', status: 'trouble' },
+    { slug: 'e', status: 'learning' },
+    { slug: 'f', status: 'new' },
+  ];
+  const stats = wordBankAggregateStats(words);
+  assert.deepEqual(stats, { total: 6, secure: 2, due: 1, trouble: 1, learning: 1, unseen: 1 });
+  // No guardian fields should leak in when context is absent.
+  assert.equal(Object.prototype.hasOwnProperty.call(stats, 'guardianDue'), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(stats, 'wobbling'), false);
+});
+
+test('wordBankAggregateStats: with guardian context, appends the four Guardian counts', () => {
+  const today = 20_000;
+  const words = [
+    { slug: 'renew', status: 'secure' },   // renewed recently + not due
+    { slug: 'due', status: 'secure' },     // guardian due today
+    { slug: 'wob', status: 'secure' },     // wobbling
+    { slug: 'none', status: 'secure' },    // secure, no guardian record
+    { slug: 'fresh', status: 'new' },      // no Guardian effect (non-secure)
+  ];
+  const guardianMap = {
+    renew: { nextDueDay: today + 7, lastReviewedDay: today - 3, wobbling: false },
+    due: { nextDueDay: today, lastReviewedDay: today - 30, wobbling: false },
+    wob: { nextDueDay: today, lastReviewedDay: today - 1, wobbling: true },
+  };
+  const stats = wordBankAggregateStats(words, { guardianMap, todayDay: today });
+  assert.equal(stats.total, 5);
+  assert.equal(stats.secure, 4);
+  assert.equal(stats.unseen, 1);
+  assert.equal(stats.guardianDue, 2, 'due + wob both qualify as guardian due (both nextDueDay <= today)');
+  assert.equal(stats.wobbling, 1);
+  // "renew" reviewed 3 days ago, "wob" reviewed yesterday — both count as renewed recently.
+  assert.equal(stats.renewedRecently, 2);
+  assert.equal(stats.neverRenewed, 1, 'only "none" is secure with no guardian record');
+});
+
+test('wordBankAggregateCards: with showGuardian === false (default) returns the 6 legacy cards', () => {
+  const stats = {
+    total: 10, secure: 5, due: 2, trouble: 1, learning: 1, unseen: 1,
+  };
+  const cards = wordBankAggregateCards(stats, 'Words in pool');
+  assert.equal(cards.length, 6);
+  assert.deepEqual(cards.map((c) => c.label), [
+    'Total', 'Secure', 'Due now', 'Trouble', 'Learning', 'Unseen',
+  ]);
+});
+
+test('wordBankAggregateCards: with showGuardian === true appends 4 Guardian cards (10 total)', () => {
+  const stats = {
+    total: 10, secure: 5, due: 2, trouble: 1, learning: 1, unseen: 1,
+    guardianDue: 3, wobbling: 1, renewedRecently: 2, neverRenewed: 4,
+  };
+  const cards = wordBankAggregateCards(stats, 'Words in pool', { showGuardian: true });
+  assert.equal(cards.length, 10);
+  const labels = cards.map((c) => c.label);
+  // Legacy order must still come first so the existing visual rhythm is preserved.
+  assert.deepEqual(labels.slice(0, 6), ['Total', 'Secure', 'Due now', 'Trouble', 'Learning', 'Unseen']);
+  assert.deepEqual(labels.slice(6), ['Renewed (7d)', 'Guardian due', 'Wobbling', 'Untouched']);
+  assert.equal(cards[6].value, 2);
+  assert.equal(cards[7].value, 3);
+  assert.equal(cards[8].value, 1);
+  assert.equal(cards[9].value, 4);
+});
+
+test('wordBankAggregateCards: showGuardian defaults to false when options omit the flag', () => {
+  const stats = { total: 1, secure: 1, due: 0, trouble: 0, learning: 0, unseen: 0 };
+  const cards = wordBankAggregateCards(stats, 'Words', {});
+  assert.equal(cards.length, 6);
+});
+
+// ----- U6: Guardian summary cards ---------------------------------------------
+
+test('guardianSummaryCards: derives renewed = totalWords - mistakes.length and wobbled = mistakes.length', () => {
+  const summary = { totalWords: 5, mistakes: [{ slug: 'a' }, { slug: 'b' }] };
+  const cards = guardianSummaryCards({ summary, nextGuardianDueDay: 20_005, todayDay: 20_000 });
+  assert.equal(cards.length, 3);
+  const [renewed, wobbling, nextCheck] = cards;
+  assert.equal(renewed.id, 'guardian-renewed');
+  assert.equal(renewed.value, 3);
+  assert.equal(wobbling.id, 'guardian-wobbling');
+  assert.equal(wobbling.value, 2);
+  assert.equal(nextCheck.id, 'guardian-next-check');
+  assert.equal(nextCheck.value, '5 days');
+});
+
+test('guardianSummaryCards: formats "Today" / "Tomorrow" / "N days" on the next-check card', () => {
+  const today = 20_000;
+  const mkCards = (delta) => guardianSummaryCards({
+    summary: { totalWords: 1, mistakes: [] },
+    nextGuardianDueDay: today + delta,
+    todayDay: today,
+  });
+  assert.equal(mkCards(0)[2].value, 'Today');
+  assert.equal(mkCards(-3)[2].value, 'Today', 'overdue collapses to "Today"');
+  assert.equal(mkCards(1)[2].value, 'Tomorrow');
+  assert.equal(mkCards(5)[2].value, '5 days');
+  assert.equal(mkCards(60)[2].value, '60 days');
+});
+
+test('guardianSummaryCards: when no Guardian work remains, next-check renders "—"', () => {
+  const cards = guardianSummaryCards({
+    summary: { totalWords: 1, mistakes: [] },
+    nextGuardianDueDay: null,
+    todayDay: 20_000,
+  });
+  assert.equal(cards[2].value, '—');
+});
+
+test('guardianSummaryCards: clamps wobbled to totalWords when summary.mistakes is inconsistent', () => {
+  // Defensive branch: a duplicated mistake entry or a mistaken mapping
+  // cannot push wobbled > totalWords. The UI never displays a negative
+  // renewed count.
+  const summary = { totalWords: 2, mistakes: [{ slug: 'a' }, { slug: 'b' }, { slug: 'c' }] };
+  const cards = guardianSummaryCards({ summary, nextGuardianDueDay: null, todayDay: 20_000 });
+  assert.equal(cards[0].value, 0, 'renewed never goes negative');
+  assert.equal(cards[1].value, 2, 'wobbled clamps to totalWords');
 });


### PR DESCRIPTION
## Summary

- Guardian Mission summaries now carry a Vault-status band with three cards — **Words renewed**, **Words wobbling**, **Next check** — visually separated from the regular stat grid via a hairline divider + eyebrow so "you kept the Vault alive" reads distinct from "here are three more numbers". Regular-mode (smart/trouble/test/single) summaries are unchanged.
- Word Bank gains four Guardian filter chips gated on `postMastery.allWordsMega`: `guardianDue`, `wobbling`, `renewedRecently`, `neverRenewed`. They sit on a dashed-top sub-row with a distinct soft-pill shape + left-edge keyline so the maintenance mental model reads separately from the legacy learning chips. A context hint ribbon surfaces only when one of the Guardian filters is active — crucial for the freshly-graduated case where `neverRenewed` can flash 170+ rows without context.
- View-model: `WORD_BANK_FILTER_IDS` expands with the four Guardian IDs (appended, not reordered, so persisted filter IDs stay forward-compatible). `wordBankFilterMatchesStatus(filter, status, { guardian, todayDay })` gains a third options arg that legacy callers can still omit — two-arg calls keep their historic semantics. `wordBankAggregateStats(words, { guardianMap, todayDay })` opts in to the four Guardian counts; zero-arg callers get the byte-identical six-field legacy shape. `wordBankAggregateCards(stats, totalSub, { showGuardian })` appends four cards after the legacy six when enabled.
- `guardianSummaryCards({ summary, nextGuardianDueDay, todayDay })` derives renewed + wobbled counts from `summary.mistakes.length` (a wobble is a wrong answer; everything else held the line), so we never widen the shared `normaliseSummary` contract.
- Platform-layer `VALID_SPELLING_WORD_BANK_FILTERS` in `src/platform/core/store.js` mirrors the Set expansion so persisted Guardian filter IDs survive a page reload (previously they silently reset to `all`).

## /frontend-design application

- Summary cards: distinct visual group (border-top divider + "Vault status" eyebrow + grouped wrapper) rather than three more anonymous squares. Each card gets a subtle left-edge brand keyline via `::before`. Microcopy avoids "Great work!" slop — "No new wobbles today", "Kept alive in the Vault", "Come back for the next check" — each grounded and specific.
- Filter chips: square-shouldered pill with flat bottom + left-edge mark to distinguish "maintenance" (Guardian) from "learning" (legacy pills stay rounded). Active state uses an inset bottom keyline instead of the pill-round glow the legacy chips use, so the two rows read as two different gestures.
- "Never renewed" edge case: the `wb-guardian-hint` ribbon only appears when a Guardian filter is active and explains in one line what the filter actually means, so a learner looking at "Untouched · 212" sees "Secure words the Guardian has not inspected yet — nothing is wrong, just untouched."

## Test plan

- [x] `node --test tests/spelling-view-model.test.js tests/spelling-guardian.test.js tests/react-spelling-surface.test.js tests/spelling-parity.test.js tests/spelling.test.js` — 153 tests green.
- [x] Full `npm test` suite — 1262 pass, 0 fail, 1 pre-existing skip.
- [x] `npm run check` (lint + audit + dry-run deploy) clean.
- [x] Word Bank legacy chips render byte-identically when `allWordsMega === false`.
- [x] Summary scene renders Guardian band only when `summary.mode === 'guardian'`.
- [x] `spelling-analytics-status-filter` routes through `WORD_BANK_FILTER_IDS.has(raw)` for each new Guardian ID without changing the module handler.
- [x] Hint ribbon only renders when a Guardian filter is active (not when default `all` is selected).