### PR TITLE
docs(spelling): Phase 4 — document guardian events + close post-Mega plan

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -19,6 +19,13 @@ subject service -> domain events -> platform event runtime -> subscribers -> rew
 - `spelling.word-secured`
 - `spelling.mastery-milestone`
 - `spelling.session-completed`
+- `spelling.guardian.renewed`
+- `spelling.guardian.wobbled`
+- `spelling.guardian.recovered`
+- `spelling.guardian.mission-completed`
+
+The `spelling.guardian.*` family is emitted from the post-Mega "Spelling Guardian" maintenance layer (see `docs/spelling-service.md` for the schedule contract).
+No reward subscriber consumes these events yet; the MVP treats Guardian as a pedagogy-only surface. A future reward subscriber may react to `renewed`/`recovered` toasts without touching the spelling service, consistent with the "subject decides, reward reacts" rule.
 
 ### Derived by the platform runtime
 

--- a/docs/plans/james/post-mega-spelling/2026-04-25-003-feat-post-mega-spelling-mvp-plan.md
+++ b/docs/plans/james/post-mega-spelling/2026-04-25-003-feat-post-mega-spelling-mvp-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Post-Mega Spelling Guardian MVP"
 type: feat
-status: active
+status: completed
 date: 2026-04-25
 origin: docs/plans/james/post-mega-spelling/post-mega-spelling-p1.md
 ---

--- a/docs/spelling-service.md
+++ b/docs/spelling-service.md
@@ -143,6 +143,14 @@ The service now emits:
   - Fired when total secure-word count hits a milestone such as 1, 5, 10 or 25
 - `spelling.session-completed`
   - Fired when a round finalises to a summary
+- `spelling.guardian.renewed`
+  - Fired in a Guardian Mission when a non-wobbling word is answered correctly, advancing its `reviewLevel` along the `[3, 7, 14, 30, 60, 90]` day ladder
+- `spelling.guardian.wobbled`
+  - Fired when a Guardian Mission word is answered wrongly; marks `wobbling: true` on the per-word guardian record but never mutates `progress.stage` (Mega is preserved)
+- `spelling.guardian.recovered`
+  - Fired when a previously-wobbling word is answered correctly; clears wobbling, bumps `renewals`, preserves the existing `reviewLevel`
+- `spelling.guardian.mission-completed`
+  - Fired when a Guardian Mission round finalises to summary; carries `renewalCount`, `wobbledCount`, `recoveredCount`, `totalWords`
 
 The platform runtime may then derive additional platform-wide events such as `platform.practice-streak-hit` from those subject events.
 The spelling reward subscriber translates `spelling.word-secured` into monster/codex reaction events and persisted reward history.


### PR DESCRIPTION
## Summary

Final Phase 4 of the post-Mega Spelling Guardian MVP. Updates `docs/events.md` + `docs/spelling-service.md` to reflect the four new `spelling.guardian.*` event types and flips the plan frontmatter to `status: completed`. 

## All 6 implementation units shipped

| Unit | PR | Commit |
|------|-----|--------|
| U0 (plan doc) | #162 | `976b016` |
| U1 (service contract + state v2) | #167 | `653629e` |
| U2 (domain events + factories) | #170 | `34d89c5` |
| U3 (scheduler + session wiring) | #178 | `f45c6d8` |
| U4 (post-mastery read-model) | #181 | `4087313` |
| U5 (setup dashboard + Alt+4) | #185 | `bcda926` |
| U6 (summary + Word Bank surfaces) | #187 | `e7eef43` |

## Changed in this PR

- **`docs/events.md`**: adds 4 `spelling.guardian.*` events to the "Emitted by the Spelling service" list with a short note that MVP has no reward subscriber reacting to them (per plan Scope Boundaries).
- **`docs/spelling-service.md`**: Domain events section lists all 8 event types with accurate one-line descriptions, including the guardian schedule ladder `[3, 7, 14, 30, 60, 90]`.
- **Plan frontmatter**: `status: active → completed`. All 9 Requirements Trace items (R1-R9) landed across U1-U6 as planned.

## Final verify

- `node --test tests/spelling-guardian.test.js tests/spelling.test.js tests/spelling-parity.test.js tests/server-spelling-engine-parity.test.js tests/spelling-view-model.test.js tests/spelling-optimistic-prefs.test.js tests/react-spelling-surface.test.js tests/persistence.test.js tests/mutation-policy.test.js` — **195/195 pass** on fresh `origin/main`.
- `npm test` full suite — 1405 pass / 1 pre-existing grammar production-smoke failure unrelated to this work / 1 skipped.

## Test plan

- [x] Plan document renders cleanly on GitHub with final status
- [x] `docs/events.md` list exactly matches `SPELLING_EVENT_TYPES` object in `src/subjects/spelling/events.js`
- [x] No behavioural change — docs-only PR