### PR TITLE
feat(grammar): U6a transferLane client plumbing + save-transfer-evidence dispatcher

### DIFF
--- a/src/subjects/grammar/metadata.js
+++ b/src/subjects/grammar/metadata.js
@@ -266,6 +266,111 @@ function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
 
+// U6a: Defensive mirror of Worker's transferLane read-model (source of truth:
+// worker/src/subjects/grammar/read-models.js:840-874 and
+// worker/src/subjects/grammar/transfer-prompts.js:95-104). The client never
+// trusts Worker-side keys to be present, but also does not silently discard
+// them: unknown top-level keys round-trip, malformed arrays coerce to [], and
+// a missing transferLane returns a shape-stable zero-value object.
+//
+// The Worker deliberately asymmetrically omits `selfAssessment` from archived
+// `history[*]` snapshots while including it on `latest`. Do NOT "repair" this
+// asymmetry on the client — historical ticks are intentionally not surfaced.
+//
+// The Worker already redacts `reviewCopy` (adult-only) from each prompt
+// summary and `requestId` from evidence snapshots. Client normaliser must NOT
+// re-introduce either field. Tests assert both absent anywhere under
+// `rm.transferLane` via a recursive scan.
+//
+// Evidence is server-sorted by `updatedAt` descending
+// (worker/src/subjects/grammar/read-models.js:872). Client preserves insertion
+// order from the Worker payload and never re-sorts.
+const EMPTY_TRANSFER_LANE = Object.freeze({
+  mode: '',
+  prompts: Object.freeze([]),
+  limits: Object.freeze({ maxPrompts: 0, historyPerPrompt: 0, writingCapChars: 0 }),
+  evidence: Object.freeze([]),
+});
+
+function normaliseGrammarTransferPrompt(raw) {
+  const prompt = isPlainObject(raw) ? raw : {};
+  return {
+    id: typeof prompt.id === 'string' ? prompt.id : '',
+    title: typeof prompt.title === 'string' ? prompt.title : '',
+    brief: typeof prompt.brief === 'string' ? prompt.brief : '',
+    grammarTargets: Array.isArray(prompt.grammarTargets)
+      ? prompt.grammarTargets.filter((entry) => typeof entry === 'string')
+      : [],
+    checklist: Array.isArray(prompt.checklist)
+      ? prompt.checklist.filter((entry) => typeof entry === 'string')
+      : [],
+  };
+}
+
+function normaliseGrammarTransferSelfAssessment(raw) {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter(isPlainObject)
+    .map((entry) => ({
+      key: typeof entry.key === 'string' ? entry.key : '',
+      checked: Boolean(entry.checked),
+    }))
+    .filter((entry) => entry.key);
+}
+
+function normaliseGrammarTransferLatest(raw) {
+  if (!isPlainObject(raw)) return null;
+  return {
+    writing: typeof raw.writing === 'string' ? raw.writing : '',
+    selfAssessment: normaliseGrammarTransferSelfAssessment(raw.selfAssessment),
+    savedAt: asTimestamp(raw.savedAt, 0),
+    source: typeof raw.source === 'string' ? raw.source : '',
+  };
+}
+
+function normaliseGrammarTransferHistoryEntry(raw) {
+  const entry = isPlainObject(raw) ? raw : {};
+  return {
+    writing: typeof entry.writing === 'string' ? entry.writing : '',
+    savedAt: asTimestamp(entry.savedAt, 0),
+    source: typeof entry.source === 'string' ? entry.source : '',
+  };
+}
+
+function normaliseGrammarTransferEvidenceEntry(raw) {
+  const entry = isPlainObject(raw) ? raw : {};
+  return {
+    promptId: typeof entry.promptId === 'string' ? entry.promptId : '',
+    latest: normaliseGrammarTransferLatest(entry.latest),
+    history: Array.isArray(entry.history)
+      ? entry.history.map(normaliseGrammarTransferHistoryEntry)
+      : [],
+    updatedAt: asTimestamp(entry.updatedAt, 0),
+  };
+}
+
+function normaliseGrammarTransferLane(raw) {
+  if (!isPlainObject(raw)) {
+    return {
+      mode: '',
+      prompts: [],
+      limits: { maxPrompts: 0, historyPerPrompt: 0, writingCapChars: 0 },
+      evidence: [],
+    };
+  }
+  const limits = isPlainObject(raw.limits) ? raw.limits : {};
+  return {
+    mode: typeof raw.mode === 'string' ? raw.mode : '',
+    prompts: Array.isArray(raw.prompts) ? raw.prompts.map(normaliseGrammarTransferPrompt) : [],
+    limits: {
+      maxPrompts: Number(limits.maxPrompts) || 0,
+      historyPerPrompt: Number(limits.historyPerPrompt) || 0,
+      writingCapChars: Number(limits.writingCapChars) || 0,
+    },
+    evidence: Array.isArray(raw.evidence) ? raw.evidence.map(normaliseGrammarTransferEvidenceEntry) : [],
+  };
+}
+
 function humanLabel(id) {
   return String(id || '')
     .replace(/_confusion$/, '')
@@ -472,11 +577,14 @@ export function normaliseGrammarReadModel(rawValue = {}, learnerId = '') {
       },
     },
     aiEnrichment: normaliseAiEnrichment(raw.aiEnrichment),
+    transferLane: normaliseGrammarTransferLane(raw.transferLane),
     projections: raw.projections || null,
     pendingCommand: raw.pendingCommand || '',
     error: typeof raw.error === 'string' ? raw.error : '',
   };
 }
+
+export { EMPTY_TRANSFER_LANE, normaliseGrammarTransferLane };
 
 export function groupedGrammarConcepts(concepts = []) {
   const groups = new Map();

--- a/src/subjects/grammar/module.js
+++ b/src/subjects/grammar/module.js
@@ -5,6 +5,31 @@ import {
 } from './metadata.js';
 import { normaliseGrammarSpeechRate } from './speech.js';
 
+// U6a: Child-facing copy for the four known `save-transfer-evidence` error
+// codes emitted by the Worker (worker/src/subjects/grammar/engine.js:1723-1803,
+// all surface through `err.extra.code`). Unknown codes fall back to a generic
+// message; the UI must render `rm.error` with role="alert" whenever it is
+// non-empty. UK English copy throughout.
+export const GRAMMAR_TRANSFER_ERROR_COPY = Object.freeze({
+  grammar_transfer_unavailable_during_mini_test: 'You cannot save writing during a mini test.',
+  grammar_transfer_prompt_not_found: 'That writing prompt is not available.',
+  grammar_transfer_writing_required: 'Write at least a few words before saving.',
+  grammar_transfer_quota_exceeded: 'You have too many saved writings. Delete one to save more.',
+});
+
+export const GRAMMAR_TRANSFER_GENERIC_ERROR_COPY = 'That did not save. Try again.';
+
+export function translateGrammarTransferError(error) {
+  const code = error?.payload?.code
+    || error?.extra?.code
+    || error?.code
+    || '';
+  if (code && Object.prototype.hasOwnProperty.call(GRAMMAR_TRANSFER_ERROR_COPY, code)) {
+    return GRAMMAR_TRANSFER_ERROR_COPY[code];
+  }
+  return GRAMMAR_TRANSFER_GENERIC_ERROR_COPY;
+}
+
 function selectedLearnerId(context) {
   return (context?.store?.getState?.() || context?.appState || {})?.learners?.selectedId || '';
 }
@@ -70,7 +95,7 @@ function applyRemoteReadModel(context, response, { learnerId } = {}) {
   context.store.reloadFromRepositories?.({ preserveRoute: true });
 }
 
-function sendGrammarCommand(context, command, payload = {}) {
+function sendGrammarCommand(context, command, payload = {}, { translateError } = {}) {
   const learnerId = selectedLearnerId(context);
   if (!learnerId) return true;
   const ui = selectedGrammarUi(context);
@@ -100,7 +125,9 @@ function sendGrammarCommand(context, command, payload = {}) {
     applyRemoteReadModel(context, response, { learnerId });
   }).catch((error) => {
     globalThis.console?.warn?.('Grammar command failed.', error);
-    setGrammarError(context, error?.payload?.message || error?.message || 'The Grammar command could not be completed.', { learnerId });
+    const fallback = error?.payload?.message || error?.message || 'The Grammar command could not be completed.';
+    const message = typeof translateError === 'function' ? translateError(error) || fallback : fallback;
+    setGrammarError(context, message, { learnerId });
   });
 
   return true;
@@ -385,6 +412,35 @@ export const grammarModule = {
         : { kind: context.data?.kind || 'explanation' };
       if (service?.requestAiEnrichment) return applyLocalTransition(context, service.requestAiEnrichment(learnerId, payload));
       return sendGrammarCommand(context, 'request-ai-enrichment', payload);
+    }
+
+    if (action === 'grammar-save-transfer-evidence') {
+      // U6a: dispatch the Worker's `save-transfer-evidence` command with the
+      // exact contract: { promptId, writing, selfAssessment: [{key, checked}] }.
+      // The Worker's payload key is `selfAssessment`; sending `checklist`
+      // silently drops the learner's ticks. See
+      // worker/src/subjects/grammar/engine.js:1754-1760. The existing
+      // `pendingCommand` short-circuit in `sendGrammarCommand` prevents
+      // double-dispatch on rapid taps.
+      const source = context.data?.payload && typeof context.data.payload === 'object' && !Array.isArray(context.data.payload)
+        ? context.data.payload
+        : (context.data && typeof context.data === 'object' ? context.data : {});
+      const payload = {
+        promptId: typeof source.promptId === 'string' ? source.promptId : '',
+        writing: typeof source.writing === 'string' ? source.writing : '',
+        selfAssessment: Array.isArray(source.selfAssessment)
+          ? source.selfAssessment
+            .filter((entry) => entry && typeof entry === 'object' && !Array.isArray(entry))
+            .map((entry) => ({
+              key: typeof entry.key === 'string' ? entry.key : '',
+              checked: Boolean(entry.checked),
+            }))
+            .filter((entry) => entry.key)
+          : [],
+      };
+      return sendGrammarCommand(context, 'save-transfer-evidence', payload, {
+        translateError: translateGrammarTransferError,
+      });
     }
 
     if (action === 'grammar-end-early') {

--- a/tests/grammar-transfer-lane.test.js
+++ b/tests/grammar-transfer-lane.test.js
@@ -15,6 +15,7 @@ import {
   createServerGrammarEngine,
 } from '../worker/src/subjects/grammar/engine.js';
 import { buildGrammarReadModel } from '../worker/src/subjects/grammar/read-models.js';
+import { normaliseGrammarReadModel } from '../src/subjects/grammar/metadata.js';
 
 test('U7: transfer-prompts catalogue contains at least 4 seed prompts with grammar targets', () => {
   assert.ok(GRAMMAR_TRANSFER_PROMPTS.length >= 4);
@@ -297,4 +298,209 @@ test('U7: save for an existing prompt at the cap succeeds (quota only trips on N
   assert.equal(result.state.transferEvidence[realPromptId].latest.writing, 'updated draft');
   // Quota unchanged
   assert.equal(Object.keys(result.state.transferEvidence).length, GRAMMAR_TRANSFER_MAX_PROMPTS);
+});
+
+// ----------------------------------------------------------------------------
+// U6a: client-side transferLane plumbing drift-detection tests.
+// ----------------------------------------------------------------------------
+function collectKeyPaths(value, pathPrefix = '', acc = new Set()) {
+  if (value === null || typeof value !== 'object') return acc;
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => collectKeyPaths(entry, `${pathPrefix}[${index}]`, acc));
+    return acc;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    const nextPath = pathPrefix ? `${pathPrefix}.${key}` : key;
+    acc.add(nextPath);
+    collectKeyPaths(child, nextPath, acc);
+  }
+  return acc;
+}
+
+function assertNoForbiddenReadModelKeys(value, forbidden) {
+  const forbiddenSet = new Set(forbidden);
+  const visit = (node, pathPrefix) => {
+    if (node === null || typeof node !== 'object') return;
+    if (Array.isArray(node)) {
+      node.forEach((entry, index) => visit(entry, `${pathPrefix}[${index}]`));
+      return;
+    }
+    for (const [key, child] of Object.entries(node)) {
+      const nextPath = pathPrefix ? `${pathPrefix}.${key}` : key;
+      if (forbiddenSet.has(key)) {
+        assert.fail(`Forbidden key "${key}" found at ${nextPath}`);
+      }
+      visit(child, nextPath);
+    }
+  };
+  visit(value, '');
+}
+
+test('U6a: client normaliseGrammarReadModel exposes transferLane with full Worker shape', () => {
+  const engine = createServerGrammarEngine({ now: () => 1_777_000_000_000 });
+  const promptId = GRAMMAR_TRANSFER_PROMPT_IDS[0];
+
+  const saved = engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: {},
+    command: 'save-transfer-evidence',
+    requestId: 'tx-u6a-drift',
+    payload: {
+      promptId,
+      writing: 'Suddenly, lightning split the sky. The storm, which roared overhead, pressed on.',
+      selfAssessment: [
+        { key: 'fronted-adverbial', checked: true },
+        { key: 'parenthesis-commas', checked: true },
+      ],
+    },
+  });
+
+  const workerRm = buildGrammarReadModel({ learnerId: 'learner-a', state: saved.state, now: 1_777_000_000_000 });
+  assert.ok(workerRm.transferLane, 'Worker read model must include transferLane');
+
+  const clientRm = normaliseGrammarReadModel(workerRm, 'learner-a');
+  assert.ok(clientRm.transferLane, 'client normaliser must expose transferLane');
+
+  // Every key path the Worker emits under transferLane must be reachable after
+  // normalisation. Missing keys indicate silent drift.
+  const workerPaths = collectKeyPaths(workerRm.transferLane);
+  const clientPaths = collectKeyPaths(clientRm.transferLane);
+  const missing = [...workerPaths].filter((path) => !clientPaths.has(path));
+  assert.deepEqual(missing, [], `client dropped transferLane keys: ${missing.join(', ')}`);
+
+  // Spot-check the nested Worker contract explicitly.
+  assert.equal(clientRm.transferLane.mode, 'non-scored');
+  assert.ok(clientRm.transferLane.prompts.length >= 4);
+  const firstPrompt = clientRm.transferLane.prompts[0];
+  assert.equal(typeof firstPrompt.id, 'string');
+  assert.equal(typeof firstPrompt.title, 'string');
+  assert.equal(typeof firstPrompt.brief, 'string');
+  assert.ok(Array.isArray(firstPrompt.grammarTargets));
+  assert.ok(Array.isArray(firstPrompt.checklist));
+
+  assert.equal(typeof clientRm.transferLane.limits.maxPrompts, 'number');
+  assert.equal(typeof clientRm.transferLane.limits.historyPerPrompt, 'number');
+  assert.equal(typeof clientRm.transferLane.limits.writingCapChars, 'number');
+
+  const evidence = clientRm.transferLane.evidence.find((entry) => entry.promptId === promptId);
+  assert.ok(evidence, 'evidence entry for saved promptId must round-trip');
+  assert.equal(evidence.latest.source, 'transfer-lane');
+  assert.ok(evidence.latest.writing.startsWith('Suddenly'));
+  assert.equal(evidence.latest.selfAssessment.length, 2);
+  assert.equal(evidence.latest.selfAssessment[0].key, 'fronted-adverbial');
+  assert.equal(evidence.latest.selfAssessment[0].checked, true);
+});
+
+test('U6a: normaliseGrammarReadModel omits reviewCopy and requestId anywhere under transferLane', () => {
+  const engine = createServerGrammarEngine({ now: () => 1_777_000_000_000 });
+  const promptId = GRAMMAR_TRANSFER_PROMPT_IDS[0];
+
+  const saved = engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: {},
+    command: 'save-transfer-evidence',
+    requestId: 'tx-redaction',
+    payload: { promptId, writing: 'Short evidence sample.' },
+  });
+  const workerRm = buildGrammarReadModel({ learnerId: 'learner-a', state: saved.state, now: 1_777_000_000_000 });
+  const clientRm = normaliseGrammarReadModel(workerRm, 'learner-a');
+
+  assertNoForbiddenReadModelKeys(clientRm.transferLane, ['reviewCopy', 'requestId']);
+});
+
+test('U6a: evidence preserves Worker-side updatedAt descending sort (no client re-sort)', () => {
+  const workerRm = {
+    transferLane: {
+      mode: 'non-scored',
+      prompts: [
+        { id: 'a', title: 'A', brief: 'b', grammarTargets: [], checklist: [] },
+      ],
+      limits: { maxPrompts: 20, historyPerPrompt: 5, writingCapChars: 2000 },
+      evidence: [
+        { promptId: 'p3', latest: { writing: 'x', selfAssessment: [], savedAt: 300, source: 'transfer-lane' }, history: [], updatedAt: 300 },
+        { promptId: 'p2', latest: { writing: 'x', selfAssessment: [], savedAt: 200, source: 'transfer-lane' }, history: [], updatedAt: 200 },
+        { promptId: 'p1', latest: { writing: 'x', selfAssessment: [], savedAt: 100, source: 'transfer-lane' }, history: [], updatedAt: 100 },
+      ],
+    },
+  };
+  const clientRm = normaliseGrammarReadModel(workerRm, 'learner-a');
+  assert.deepEqual(
+    clientRm.transferLane.evidence.map((entry) => entry.promptId),
+    ['p3', 'p2', 'p1'],
+    'client must preserve Worker-side updatedAt descending order',
+  );
+});
+
+test('U6a: missing transferLane returns shape-stable zero values', () => {
+  const clientRm = normaliseGrammarReadModel({}, 'learner-a');
+  assert.deepEqual(clientRm.transferLane, {
+    mode: '',
+    prompts: [],
+    limits: { maxPrompts: 0, historyPerPrompt: 0, writingCapChars: 0 },
+    evidence: [],
+  });
+});
+
+test('U6a: malformed transferLane.prompts coerces to []', () => {
+  const clientRm = normaliseGrammarReadModel({
+    transferLane: {
+      mode: 'non-scored',
+      prompts: 'not-an-array',
+      limits: { maxPrompts: 20, historyPerPrompt: 5, writingCapChars: 2000 },
+      evidence: [],
+    },
+  }, 'learner-a');
+  assert.deepEqual(clientRm.transferLane.prompts, []);
+  assert.equal(clientRm.transferLane.mode, 'non-scored');
+});
+
+test('U6a: malformed evidence[0].latest.selfAssessment coerces to []', () => {
+  const clientRm = normaliseGrammarReadModel({
+    transferLane: {
+      mode: 'non-scored',
+      prompts: [],
+      limits: { maxPrompts: 20, historyPerPrompt: 5, writingCapChars: 2000 },
+      evidence: [{
+        promptId: 'p1',
+        latest: { writing: 'hi', selfAssessment: undefined, savedAt: 0, source: 'transfer-lane' },
+        history: [],
+        updatedAt: 0,
+      }],
+    },
+  }, 'learner-a');
+  assert.deepEqual(clientRm.transferLane.evidence[0].latest.selfAssessment, []);
+});
+
+test('U6a: orphaned evidence (promptId not in prompts catalogue) passes through untouched', () => {
+  const workerRm = {
+    transferLane: {
+      mode: 'non-scored',
+      prompts: [
+        { id: 'real-prompt', title: 'Real', brief: 'b', grammarTargets: [], checklist: [] },
+      ],
+      limits: { maxPrompts: 20, historyPerPrompt: 5, writingCapChars: 2000 },
+      evidence: [{
+        promptId: 'retired-prompt',
+        latest: { writing: 'orphaned draft', selfAssessment: [], savedAt: 123, source: 'transfer-lane' },
+        history: [],
+        updatedAt: 123,
+      }],
+    },
+  };
+  const clientRm = normaliseGrammarReadModel(workerRm, 'learner-a');
+  const orphan = clientRm.transferLane.evidence.find((entry) => entry.promptId === 'retired-prompt');
+  assert.ok(orphan, 'orphaned evidence must pass through the normaliser untouched');
+  assert.equal(orphan.latest.writing, 'orphaned draft');
+  assert.equal(orphan.latest.source, 'transfer-lane');
+  // Catalogue still reachable
+  assert.equal(clientRm.transferLane.prompts.length, 1);
+  assert.equal(clientRm.transferLane.prompts[0].id, 'real-prompt');
+});
+
+test('U6a: U6a does NOT add "transfer" to the phase allowlist — that is U6b scope', () => {
+  // U6a is plumbing only; the `'transfer'` phase string belongs to U6b when
+  // the scene ships. Assert that passing `phase: 'transfer'` still falls back
+  // to the default `'dashboard'` phase on the client.
+  const clientRm = normaliseGrammarReadModel({ phase: 'transfer' }, 'learner-a');
+  assert.equal(clientRm.phase, 'dashboard');
 });

--- a/tests/react-grammar-surface.test.js
+++ b/tests/react-grammar-surface.test.js
@@ -8,7 +8,12 @@ import {
 } from './helpers/grammar-subject-harness.js';
 import { readGrammarLegacyOracle } from './helpers/grammar-legacy-oracle.js';
 import { installMemoryStorage } from './helpers/memory-storage.js';
-import { grammarModule } from '../src/subjects/grammar/module.js';
+import {
+  grammarModule,
+  GRAMMAR_TRANSFER_ERROR_COPY,
+  GRAMMAR_TRANSFER_GENERIC_ERROR_COPY,
+  translateGrammarTransferError,
+} from '../src/subjects/grammar/module.js';
 import { normaliseGrammarReadModel } from '../src/subjects/grammar/metadata.js';
 import { grammarMasteryKey } from '../src/platform/game/monster-system.js';
 import { getSubject, SUBJECTS } from '../src/platform/core/subject-registry.js';
@@ -1144,4 +1149,246 @@ test('Grammar surface routes persisted retired-id state through the normaliser b
   // Concordium surfaces the unioned retired-id progress.
   assert.match(html, /Concordium/);
   assert.match(html, /1\/18 Codex/);
+});
+
+// ----------------------------------------------------------------------------
+// U6a: module-level `grammar-save-transfer-evidence` dispatcher + error map.
+// ----------------------------------------------------------------------------
+function buildGrammarTransferDispatchContext({
+  pendingCommand = '',
+  sendImpl,
+  initialTransferLane,
+} = {}) {
+  const toasts = [];
+  const celebrations = [];
+  const initialUi = normaliseGrammarReadModel({
+    transferLane: initialTransferLane,
+    pendingCommand,
+  }, 'learner-a');
+  const context = {
+    appState: {
+      learners: { selectedId: 'learner-a' },
+      subjectUi: { grammar: initialUi },
+    },
+    runtimeReadOnly: false,
+    subjectCommands: {
+      send: sendImpl,
+    },
+    store: {
+      getState() {
+        return context.appState;
+      },
+      updateSubjectUi(subjectId, updater) {
+        const previous = context.appState.subjectUi[subjectId] || {};
+        const next = typeof updater === 'function' ? updater(previous) : { ...previous, ...updater };
+        context.appState = {
+          ...context.appState,
+          subjectUi: { ...context.appState.subjectUi, [subjectId]: next },
+        };
+      },
+      updateSubjectUiForLearner(learnerId, subjectId, updater) {
+        if (learnerId !== 'learner-a') return false;
+        context.store.updateSubjectUi(subjectId, updater);
+        return true;
+      },
+      pushToasts(events) { toasts.push(...events); },
+      pushMonsterCelebrations(events) { celebrations.push(...events); },
+      reloadFromRepositories() {},
+    },
+    toasts,
+    celebrations,
+  };
+  return context;
+}
+
+test('U6a: grammar-save-transfer-evidence dispatches Worker save-transfer-evidence with exact payload (no checklist alias)', async () => {
+  const observed = { request: null };
+  let resolveCommand;
+  const context = buildGrammarTransferDispatchContext({
+    sendImpl(request) {
+      observed.request = request;
+      return new Promise((resolve) => { resolveCommand = resolve; });
+    },
+  });
+
+  const handled = grammarModule.handleAction('grammar-save-transfer-evidence', {
+    ...context,
+    data: {
+      payload: {
+        promptId: 'storm-scene',
+        writing: 'Suddenly, the storm broke. Lightning, which split the sky, lit the fields.',
+        selfAssessment: [{ key: 'fronted-adverbial', checked: true }, { key: 'parenthesis-commas', checked: false }],
+      },
+    },
+  });
+  assert.equal(handled, true);
+
+  // Worker command boundary receives exact shape; no `checklist` alias.
+  assert.ok(observed.request, 'subjectCommands.send must be called');
+  assert.equal(observed.request.subjectId, 'grammar');
+  assert.equal(observed.request.learnerId, 'learner-a');
+  assert.equal(observed.request.command, 'save-transfer-evidence');
+  assert.deepEqual(Object.keys(observed.request.payload).sort(), ['promptId', 'selfAssessment', 'writing']);
+  assert.equal(observed.request.payload.promptId, 'storm-scene');
+  assert.equal(observed.request.payload.writing.startsWith('Suddenly'), true);
+  assert.deepEqual(observed.request.payload.selfAssessment, [
+    { key: 'fronted-adverbial', checked: true },
+    { key: 'parenthesis-commas', checked: false },
+  ]);
+  // No checklist alias sneaking into the payload
+  assert.equal(Object.prototype.hasOwnProperty.call(observed.request.payload, 'checklist'), false);
+
+  // Worker returns a read model with the new evidence; mastery stays untouched.
+  const masteryBefore = context.appState.subjectUi.grammar.analytics;
+  resolveCommand({
+    subjectReadModel: normaliseGrammarReadModel({
+      learnerId: 'learner-a',
+      phase: 'dashboard',
+      transferLane: {
+        mode: 'non-scored',
+        prompts: [{ id: 'storm-scene', title: 'Storm scene', brief: 'Describe a storm.', grammarTargets: ['adverbials'], checklist: ['fronted-adverbial'] }],
+        limits: { maxPrompts: 20, historyPerPrompt: 5, writingCapChars: 2000 },
+        evidence: [{
+          promptId: 'storm-scene',
+          latest: {
+            writing: 'Suddenly, the storm broke. Lightning, which split the sky, lit the fields.',
+            selfAssessment: [{ key: 'fronted-adverbial', checked: true }, { key: 'parenthesis-commas', checked: false }],
+            savedAt: 1_777_000_000_000,
+            source: 'transfer-lane',
+          },
+          history: [],
+          updatedAt: 1_777_000_000_000,
+        }],
+      },
+    }, 'learner-a'),
+    projections: { rewards: { toastEvents: [], events: [] } },
+  });
+  await Promise.resolve();
+  await Promise.resolve();
+
+  const grammar = context.appState.subjectUi.grammar;
+  const evidence = grammar.transferLane.evidence.find((entry) => entry.promptId === 'storm-scene');
+  assert.ok(evidence, 'transferLane.evidence must update after save');
+  assert.equal(evidence.latest.writing.startsWith('Suddenly'), true);
+  // Mastery node unchanged (object-identity-ish — same keys/values)
+  assert.equal(JSON.stringify(grammar.analytics), JSON.stringify(masteryBefore));
+  // No reward events fired
+  assert.equal(context.toasts.length, 0);
+  assert.equal(context.celebrations.length, 0);
+});
+
+test('U6a: grammar-save-transfer-evidence short-circuits when pendingCommand is in flight', () => {
+  let sendCalled = false;
+  const context = buildGrammarTransferDispatchContext({
+    pendingCommand: 'save-transfer-evidence',
+    sendImpl() {
+      sendCalled = true;
+      return Promise.resolve({});
+    },
+  });
+
+  grammarModule.handleAction('grammar-save-transfer-evidence', {
+    ...context,
+    data: { payload: { promptId: 'p1', writing: 'draft', selfAssessment: [] } },
+  });
+
+  assert.equal(sendCalled, false, 'pendingCommand short-circuit must prevent double-dispatch');
+});
+
+test('U6a: GRAMMAR_TRANSFER_ERROR_COPY maps every known Worker error code to UK-English child copy', () => {
+  const codes = [
+    'grammar_transfer_unavailable_during_mini_test',
+    'grammar_transfer_prompt_not_found',
+    'grammar_transfer_writing_required',
+    'grammar_transfer_quota_exceeded',
+  ];
+  for (const code of codes) {
+    assert.ok(GRAMMAR_TRANSFER_ERROR_COPY[code], `copy for ${code} must be defined`);
+    assert.equal(typeof GRAMMAR_TRANSFER_ERROR_COPY[code], 'string');
+    assert.ok(GRAMMAR_TRANSFER_ERROR_COPY[code].length > 0);
+  }
+  assert.equal(GRAMMAR_TRANSFER_ERROR_COPY.grammar_transfer_unavailable_during_mini_test, 'You cannot save writing during a mini test.');
+  assert.equal(GRAMMAR_TRANSFER_ERROR_COPY.grammar_transfer_prompt_not_found, 'That writing prompt is not available.');
+  assert.equal(GRAMMAR_TRANSFER_ERROR_COPY.grammar_transfer_writing_required, 'Write at least a few words before saving.');
+  assert.equal(GRAMMAR_TRANSFER_ERROR_COPY.grammar_transfer_quota_exceeded, 'You have too many saved writings. Delete one to save more.');
+});
+
+test('U6a: translateGrammarTransferError routes the four Worker error codes through child copy', async () => {
+  const cases = [
+    { code: 'grammar_transfer_unavailable_during_mini_test' },
+    { code: 'grammar_transfer_prompt_not_found' },
+    { code: 'grammar_transfer_writing_required' },
+    { code: 'grammar_transfer_quota_exceeded' },
+  ];
+  for (const { code } of cases) {
+    // err.extra.code is the canonical location (see engine.js:1740)
+    const withExtra = { message: 'raw', extra: { code } };
+    // err.payload.code is the transport shape seen by the client command helper
+    const withPayload = { message: 'raw', payload: { code } };
+    assert.equal(translateGrammarTransferError(withExtra), GRAMMAR_TRANSFER_ERROR_COPY[code]);
+    assert.equal(translateGrammarTransferError(withPayload), GRAMMAR_TRANSFER_ERROR_COPY[code]);
+  }
+  assert.equal(translateGrammarTransferError({ message: 'something' }), GRAMMAR_TRANSFER_GENERIC_ERROR_COPY);
+  assert.equal(translateGrammarTransferError(null), GRAMMAR_TRANSFER_GENERIC_ERROR_COPY);
+});
+
+test('U6a: grammar-save-transfer-evidence routes Worker errors through child copy into rm.error', async () => {
+  const errorCodes = [
+    'grammar_transfer_unavailable_during_mini_test',
+    'grammar_transfer_prompt_not_found',
+    'grammar_transfer_writing_required',
+    'grammar_transfer_quota_exceeded',
+  ];
+  for (const code of errorCodes) {
+    const error = Object.assign(new Error('raw worker message'), { payload: { code } });
+    const context = buildGrammarTransferDispatchContext({
+      sendImpl() { return Promise.reject(error); },
+    });
+
+    grammarModule.handleAction('grammar-save-transfer-evidence', {
+      ...context,
+      data: { payload: { promptId: 'p1', writing: 'draft', selfAssessment: [] } },
+    });
+    // Let the rejected promise resolve through the micro-task queue.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const grammar = context.appState.subjectUi.grammar;
+    assert.equal(grammar.error, GRAMMAR_TRANSFER_ERROR_COPY[code], `error copy for ${code}`);
+    assert.equal(grammar.pendingCommand, '', 'pendingCommand clears after error');
+  }
+});
+
+test('U6a: grammar-save-transfer-evidence dispatch drops non-object selfAssessment entries silently', () => {
+  const observed = { request: null };
+  const context = buildGrammarTransferDispatchContext({
+    sendImpl(request) {
+      observed.request = request;
+      return new Promise(() => {}); // never resolve
+    },
+  });
+
+  grammarModule.handleAction('grammar-save-transfer-evidence', {
+    ...context,
+    data: {
+      payload: {
+        promptId: 'p1',
+        writing: 'draft',
+        selfAssessment: [
+          { key: 'ok', checked: true },
+          null,
+          'string-entry',
+          { key: '', checked: true }, // empty key dropped
+          { key: 'ok2', checked: false },
+        ],
+      },
+    },
+  });
+
+  assert.ok(observed.request);
+  assert.deepEqual(observed.request.payload.selfAssessment, [
+    { key: 'ok', checked: true },
+    { key: 'ok2', checked: false },
+  ]);
 });


### PR DESCRIPTION
## Summary

U6a closes the Worker to client drift for the non-scored Writing Try lane. Plumbing only; the `GrammarTransferScene` lands in U6b.

- **`normaliseGrammarReadModel` in `src/subjects/grammar/metadata.js`** now exposes `transferLane` with a defensive shape that mirrors `worker/src/subjects/grammar/read-models.js:840-874` exactly: `{ mode, prompts, limits, evidence }` where `prompts = [{ id, title, brief, grammarTargets, checklist }]` (note: `brief`, NOT `theme`) and `evidence = [{ promptId, latest: { writing, selfAssessment, savedAt, source }, history: [{ writing, savedAt, source }], updatedAt }]`. Missing `transferLane` yields a shape-stable zero-valued object. Malformed arrays coerce to `[]`. Worker-side `updatedAt` descending order is preserved without client re-sort, and the Worker redaction of `reviewCopy`/`requestId` is preserved (asserted via recursive scan).
- **`'transfer'` is intentionally NOT added to the phase allowlist in this unit.** That belongs in U6b when the scene ships. Guarded by a test.
- **`grammar-save-transfer-evidence` action in `src/subjects/grammar/module.js`** dispatches the Worker `save-transfer-evidence` command with exact payload `{ promptId: string, writing: string, selfAssessment: Array<{ key, checked }> }`. The payload key is `selfAssessment` (NOT `checklist` — sending `checklist` would silently drop ticks). Honours the existing `sendGrammarCommand` pendingCommand short-circuit.
- **`GRAMMAR_TRANSFER_ERROR_COPY` translation map** in `src/subjects/grammar/module.js`, routed via `translateGrammarTransferError` into `rm.error`:
  - `grammar_transfer_unavailable_during_mini_test` -> "You cannot save writing during a mini test."
  - `grammar_transfer_prompt_not_found` -> "That writing prompt is not available."
  - `grammar_transfer_writing_required` -> "Write at least a few words before saving."
  - `grammar_transfer_quota_exceeded` -> "You have too many saved writings. Delete one to save more."
  - Unknown codes fall back to "That did not save. Try again."

## Test Plan

- [x] `node --test tests/grammar-transfer-lane.test.js` runs green (20/20 tests, 8 new U6a cases added).
- [x] `node --test tests/react-grammar-surface.test.js` runs green (42/42 tests, 6 new U6a cases added).
- [x] `npm run check` passes (lint, type-check, bundle audit, assertions).
- [x] `npm test` runs green except for one **pre-existing unrelated failure** in `tests/grammar-production-smoke.test.js` (`grammar.startModel.stats.templates exposed a server-only field`). Reproduced on clean `origin/main` before this PR was authored — see plan U8 context. Not introduced by U6a; recommend routing fix through a separate smoke-guard PR.

## Test Scenarios Covered

### `tests/grammar-transfer-lane.test.js` (U6a additions)
- Drift detection: every Worker `transferLane` key at every nesting level is reachable after `normaliseGrammarReadModel`.
- Recursive absence: `reviewCopy` and `requestId` are not reintroduced anywhere under `rm.transferLane`.
- Server-sort preservation: evidence stays in `updatedAt` descending order (no client re-sort).
- Zero-shape guard: missing `transferLane` returns a stable `{ mode: '', prompts: [], limits: {...}, evidence: [] }`.
- Malformed coercion: `prompts = 'not-an-array'` and `latest.selfAssessment = undefined` coerce to `[]`.
- Orphaned evidence: evidence for a `promptId` absent from the catalogue passes through untouched (UI handles rendering in U6b).
- Phase allowlist guard: passing `phase: 'transfer'` still falls back to `'dashboard'` — U6a scope does not add `'transfer'`.

### `tests/react-grammar-surface.test.js` (U6a additions)
- Dispatcher boundary: `grammar-save-transfer-evidence` dispatches Worker `save-transfer-evidence` with exactly `{ promptId, writing, selfAssessment }` — no `checklist` alias. `rm.transferLane.evidence` updates, `rm.analytics` (mastery) unchanged, no reward events fire.
- `pendingCommand` short-circuit: second dispatch while a command is in flight is silently dropped.
- Error-code mapping: full table-driven test for all four Worker error codes routing into `rm.error` via child copy.
- Generic fallback: unknown error codes and null errors both yield the generic fallback copy.
- Input hygiene: non-object, empty-key, and string `selfAssessment` entries are dropped silently before dispatch.

## Plan Reference

`docs/plans/2026-04-25-004-feat-grammar-phase3-ux-reset-plan.md` — U6a unit (line 418) and the Authoritative `transferLane` contract block (line 140).

## Rules Observed

- Worker code untouched (contract is authoritative, verified not modified).
- UK English throughout copy strings.
- Payload key is `selfAssessment`, field name is `brief`.
- `'transfer'` phase allowlist NOT modified (belongs to U6b).