### PR TITLE
feat(grammar): U1 child dashboard (4 primary modes + Today cards + More practice disclosure)

### DIFF
--- a/src/subjects/grammar/components/GrammarPracticeSurface.jsx
+++ b/src/subjects/grammar/components/GrammarPracticeSurface.jsx
@@ -8,28 +8,11 @@ import { normaliseGrammarRewardState } from '../../../platform/game/monster-syst
 
 const MONSTER_CODEX_SYSTEM_ID = 'monster-codex';
 
-const GRAMMAR_TRANSFER_PLACEHOLDERS = Object.freeze([
-  {
-    id: 'paragraph-transfer',
-    eyebrow: 'Non-scored transfer',
-    title: 'Paragraph transfer',
-    copy: 'Decision: this will be non-scored paragraph application first, so learners can use Grammar choices in a wider piece of writing without changing mastery evidence.',
-    bullets: [
-      'No score, retry, reward, or Concordium progress is recorded from this transfer lane.',
-      'Teacher review and deterministic paragraph scoring are separate future decisions, not hidden promises.',
-    ],
-  },
-  {
-    id: 'writing-application',
-    eyebrow: 'Future writing application',
-    title: 'Richer writing tasks',
-    copy: 'Reserved for sentence-to-writing practice after the non-scored transfer lane proves the right evidence shape.',
-    bullets: [
-      'Worker-marked Grammar remains the only score-bearing authority.',
-      'Any future score-bearing writing workflow will ship as its own reviewed capability.',
-    ],
-  },
-]);
+// Phase 3 U1 removes the adult-diagnostic roadmap placeholders. The
+// U6b Writing Try scene and U2 Grammar Bank scene take over the slots
+// with real child-facing scenes. Until those ship, U1 routes their
+// phase transitions through a minimal stub below so the state machine
+// remains safe and a "return" button lets the learner back out.
 
 function selectedLearner(appState) {
   const learnerId = appState?.learners?.selectedId || '';
@@ -74,36 +57,40 @@ function resolveGrammarRewardState({ grammar, learner, repositories }) {
   return Object.keys(normalisedProjected).length ? normalisedProjected : normalisedPersisted;
 }
 
-function GrammarTransferPlaceholders() {
+function GrammarBankPlaceholderScene({ actions }) {
+  // U1 wires the "Grammar Bank" primary mode card; U2 ships the real scene.
+  // Until then, this stub honours the state transition and offers a way back
+  // so the learner is never stuck.
   return (
-    <section className="card grammar-transfer-placeholders" aria-labelledby="grammar-transfer-title">
-      <div className="card-header">
-        <div>
-          <div className="eyebrow">Transfer bridge</div>
-          <h3 className="section-title" id="grammar-transfer-title">Writing application roadmap</h3>
-        </div>
-        <span className="chip">Coming next</span>
-      </div>
-      <div className="grammar-transfer-grid">
-        {GRAMMAR_TRANSFER_PLACEHOLDERS.map((entry) => (
-          <article className="grammar-transfer-card" key={entry.id}>
-            <div className="eyebrow">{entry.eyebrow}</div>
-            <h4>{entry.title}</h4>
-            <p>{entry.copy}</p>
-            <ul>
-              {entry.bullets.map((bullet) => <li key={bullet}>{bullet}</li>)}
-            </ul>
-            <button
-              className="btn secondary"
-              type="button"
-              disabled
-              data-grammar-transfer-placeholder={entry.id}
-            >
-              Coming next
-            </button>
-          </article>
-        ))}
-      </div>
+    <section className="grammar-bank-placeholder" aria-labelledby="grammar-bank-placeholder-title">
+      <h2 id="grammar-bank-placeholder-title">Grammar Bank</h2>
+      <p>Your full concept bank lands here soon — browse all 18 grammar concepts with child-friendly statuses.</p>
+      <button
+        type="button"
+        className="btn primary"
+        data-action="grammar-back"
+        onClick={() => actions.dispatch('grammar-back')}
+      >
+        Back to Grammar Garden
+      </button>
+    </section>
+  );
+}
+
+function GrammarTransferPlaceholderScene({ actions }) {
+  // U1 wires the "Writing Try" secondary button; U6b ships the real scene.
+  return (
+    <section className="grammar-transfer-placeholder" aria-labelledby="grammar-transfer-placeholder-title">
+      <h2 id="grammar-transfer-placeholder-title">Writing Try</h2>
+      <p>Non-scored writing practice is opening up soon. Nothing you write here will change your Grammar scores.</p>
+      <button
+        type="button"
+        className="btn primary"
+        data-action="grammar-back"
+        onClick={() => actions.dispatch('grammar-back')}
+      >
+        Back to Grammar Garden
+      </button>
     </section>
   );
 }
@@ -135,11 +122,33 @@ export function GrammarPracticeSurface({
     return <GrammarSummaryScene {...shared} />;
   }
 
+  if (grammar.phase === 'bank') {
+    return (
+      <div className="grammar-surface">
+        <GrammarBankPlaceholderScene {...shared} />
+      </div>
+    );
+  }
+
+  if (grammar.phase === 'transfer') {
+    return (
+      <div className="grammar-surface">
+        <GrammarTransferPlaceholderScene {...shared} />
+      </div>
+    );
+  }
+
   return (
     <div className="grammar-surface">
       <GrammarSetupScene {...shared} />
-      <GrammarAnalyticsScene {...shared} />
-      <GrammarTransferPlaceholders />
+      {/* Phase 3 U1 keeps the analytics surface reachable but demoted from
+          the dashboard primary view — it now lives behind a "Grown-up view"
+          disclosure per the U5 summary decision. Until U5/U7 land the
+          full split, this stays here as the non-primary grown-up surface. */}
+      <details className="grammar-grown-up-view">
+        <summary>Grown-up view</summary>
+        <GrammarAnalyticsScene {...shared} />
+      </details>
     </div>
   );
 }

--- a/src/subjects/grammar/components/GrammarSetupScene.jsx
+++ b/src/subjects/grammar/components/GrammarSetupScene.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   GRAMMAR_REGION_IMAGE,
   GRAMMAR_REGION_IMAGE_SMALL,
+  grammarMonsterAsset,
 } from '../metadata.js';
 import { normaliseGrammarSpeechRate } from '../speech.js';
 import {
@@ -53,9 +54,11 @@ function TodayCard({ card }) {
 }
 
 function PrimaryModeCard({ card, selected, disabled, actions }) {
+  const featured = card.featured === true;
   const classes = ['grammar-primary-mode'];
   if (selected) classes.push('selected');
   if (disabled) classes.push('is-disabled');
+  if (featured) classes.push('is-recommended');
   const action = card.id === 'bank' ? 'grammar-open-concept-bank' : 'grammar-set-mode';
   return (
     <button
@@ -63,6 +66,7 @@ function PrimaryModeCard({ card, selected, disabled, actions }) {
       className={classes.join(' ')}
       data-mode-id={card.id}
       data-action={action}
+      data-featured={featured ? 'true' : 'false'}
       aria-pressed={selected ? 'true' : 'false'}
       disabled={disabled}
       onClick={() => {
@@ -74,6 +78,7 @@ function PrimaryModeCard({ card, selected, disabled, actions }) {
         actions.dispatch('grammar-set-mode', { value: card.id });
       }}
     >
+      {featured ? <span className="grammar-primary-mode-eyebrow">Recommended</span> : null}
       <h4 className="grammar-primary-mode-title">{card.title}</h4>
       <p className="grammar-primary-mode-desc">{card.desc}</p>
     </button>
@@ -136,13 +141,25 @@ export function GrammarSetupScene({ learner, grammar, rewardState, actions, runt
       </div>
 
       <section className="grammar-today" aria-label="Today at a glance">
-        <div className="grammar-today-grid">
-          {dashboard.todayCards.map((card) => (
-            <TodayCard card={card} key={card.id} />
-          ))}
-        </div>
+        {dashboard.isEmpty ? (
+          <div className="grammar-today-empty" data-testid="grammar-today-empty">
+            Start your first round to see your scores here.
+          </div>
+        ) : (
+          <div className="grammar-today-grid">
+            {dashboard.todayCards.map((card) => (
+              <TodayCard card={card} key={card.id} />
+            ))}
+          </div>
+        )}
         <div className="grammar-concordium-progress" data-testid="grammar-concordium-progress">
-          <span className="grammar-concordium-label">Concordium progress</span>
+          <img
+            className="grammar-concordium-image"
+            src={grammarMonsterAsset('concordium', 320)}
+            alt=""
+            aria-hidden="true"
+          />
+          <span className="grammar-concordium-label">Grow Concordium</span>
           <strong className="grammar-concordium-value">{`${concordium.mastered}/${concordium.total}`}</strong>
         </div>
       </section>

--- a/src/subjects/grammar/components/GrammarSetupScene.jsx
+++ b/src/subjects/grammar/components/GrammarSetupScene.jsx
@@ -1,12 +1,38 @@
 import React from 'react';
 import {
-  GRAMMAR_ENABLED_MODES,
-  GRAMMAR_LOCKED_MODES,
   GRAMMAR_REGION_IMAGE,
   GRAMMAR_REGION_IMAGE_SMALL,
-  groupedGrammarConcepts,
 } from '../metadata.js';
 import { normaliseGrammarSpeechRate } from '../speech.js';
+import {
+  GRAMMAR_DASHBOARD_HERO,
+  GRAMMAR_MORE_PRACTICE_MODES,
+  GRAMMAR_PRIMARY_MODE_CARDS,
+  buildGrammarDashboardModel,
+} from './grammar-view-model.js';
+
+// Phase 3 U1: Child-facing Grammar dashboard. Every label, mode id, and
+// card comes from the U8 view-model (`grammar-view-model.js`). The JSX
+// layer is a layout-only component — we do not restate copy, filter ids,
+// or mode ids inline. Hero copy is driven by `GRAMMAR_DASHBOARD_HERO` so
+// James can swap the wording in one place after review.
+//
+// Structure mirrors `SpellingSetupScene.jsx`:
+//   - Hero (headline + subheadline)
+//   - Today cards row (Due / Trouble spots / Secure / Streak)
+//   - Concordium progress (drawn from `buildGrammarDashboardModel` →
+//     `concordiumProgress`)
+//   - Primary mode cards (4 cards from `GRAMMAR_PRIMARY_MODE_CARDS`)
+//   - Writing Try secondary entry (dispatches `grammar-open-transfer` —
+//     U6b renders the scene)
+//   - More practice <details> disclosure (5 cards from
+//     `GRAMMAR_MORE_PRACTICE_MODES`). Closed by default.
+//   - Quiet round-length + speech-rate controls.
+//
+// Everything the old adult-diagnostic surface said (`Worker-marked modes`,
+// `Worker marked` chip, `full map`, `Full placeholder map`, `All 18
+// Grammar concepts` grid) is removed. U10's fixture-driven absence test
+// covers regressions.
 
 const SPEECH_RATE_OPTIONS = Object.freeze([
   { value: 0.6, label: '0.6x slow' },
@@ -16,53 +42,82 @@ const SPEECH_RATE_OPTIONS = Object.freeze([
   { value: 1.4, label: '1.4x fast' },
 ]);
 
-function Stat({ label, value, detail }) {
+function TodayCard({ card }) {
   return (
-    <div className="grammar-stat">
-      <span>{label}</span>
-      <strong>{value}</strong>
-      {detail ? <small>{detail}</small> : null}
+    <div className="grammar-today-card" data-today-id={card.id}>
+      <div className="grammar-today-label">{card.label}</div>
+      <div className="grammar-today-value">{card.value}</div>
+      <div className="grammar-today-detail">{card.detail}</div>
     </div>
   );
 }
 
-function ModeButton({ mode, selected, disabled, locked, reason, actions }) {
-  const className = `grammar-mode${selected ? ' selected' : ''}${locked ? ' locked' : ''}`;
+function PrimaryModeCard({ card, selected, disabled, actions }) {
+  const classes = ['grammar-primary-mode'];
+  if (selected) classes.push('selected');
+  if (disabled) classes.push('is-disabled');
+  const action = card.id === 'bank' ? 'grammar-open-concept-bank' : 'grammar-set-mode';
   return (
     <button
-      className={className}
       type="button"
+      className={classes.join(' ')}
+      data-mode-id={card.id}
+      data-action={action}
+      aria-pressed={selected ? 'true' : 'false'}
       disabled={disabled}
-      onClick={() => actions.dispatch('grammar-set-mode', { value: mode.id })}
+      onClick={() => {
+        if (disabled) return;
+        if (card.id === 'bank') {
+          actions.dispatch('grammar-open-concept-bank');
+          return;
+        }
+        actions.dispatch('grammar-set-mode', { value: card.id });
+      }}
     >
-      <span>{mode.label}</span>
-      <small>{mode.detail || reason || ''}</small>
+      <h4 className="grammar-primary-mode-title">{card.title}</h4>
+      <p className="grammar-primary-mode-desc">{card.desc}</p>
     </button>
   );
 }
 
-export function GrammarSetupScene({ learner, grammar, actions, runtimeReadOnly }) {
-  const counts = grammar.stats?.concepts || {};
-  const templates = grammar.stats?.templates || {};
-  const selectedMode = grammar.prefs?.mode || 'smart';
-  const selectedGoal = grammar.prefs?.goalType || 'questions';
+function MoreModeCard({ card, selected, disabled, actions }) {
+  const classes = ['grammar-secondary-mode'];
+  if (selected) classes.push('selected');
+  if (disabled) classes.push('is-disabled');
+  return (
+    <button
+      type="button"
+      className={classes.join(' ')}
+      data-mode-id={card.id}
+      data-action="grammar-set-mode"
+      aria-pressed={selected ? 'true' : 'false'}
+      disabled={disabled}
+      onClick={() => {
+        if (disabled) return;
+        actions.dispatch('grammar-set-mode', { value: card.id });
+      }}
+    >
+      <h5 className="grammar-secondary-mode-title">{card.title}</h5>
+      <p className="grammar-secondary-mode-desc">{card.desc}</p>
+    </button>
+  );
+}
+
+export function GrammarSetupScene({ learner, grammar, rewardState, actions, runtimeReadOnly }) {
+  const dashboard = buildGrammarDashboardModel(grammar, learner, rewardState);
+  const selectedMode = dashboard.primaryMode;
   const miniTestMode = selectedMode === 'satsset';
-  const troubleMode = selectedMode === 'trouble';
-  const surgeryMode = selectedMode === 'surgery';
-  const builderMode = selectedMode === 'builder';
-  const focusDisabled = troubleMode || surgeryMode || builderMode;
-  const selectedFocus = focusDisabled ? '' : (grammar.prefs?.focusConceptId || '');
-  const focusPlaceholder = troubleMode ? 'Weakest concept' : (surgeryMode ? 'Surgery mix' : (builderMode ? 'Builder mix' : 'Smart mix'));
-  const groupedConcepts = groupedGrammarConcepts(grammar.analytics?.concepts || []);
   const setupDisabled = runtimeReadOnly || Boolean(grammar.pendingCommand);
   const lengthOptions = miniTestMode ? [8, 12] : [3, 5, 8, 10, 15];
   const selectedLength = miniTestMode
     ? (Number(grammar.prefs?.roundLength) >= 10 ? 12 : 8)
     : (Number(grammar.prefs?.roundLength) || 5);
   const selectedSpeechRate = normaliseGrammarSpeechRate(grammar.prefs?.speechRate);
+  const { title: heroTitle, subtitle: heroSubtitle } = GRAMMAR_DASHBOARD_HERO;
+  const concordium = dashboard.concordiumProgress;
 
   return (
-    <section className="grammar-setup" aria-labelledby="grammar-setup-title">
+    <section className="grammar-dashboard" aria-labelledby="grammar-dashboard-title">
       <div
         className="grammar-hero"
         style={{ '--grammar-hero-bg': `url(${GRAMMAR_REGION_IMAGE})` }}
@@ -72,174 +127,110 @@ export function GrammarSetupScene({ learner, grammar, actions, runtimeReadOnly }
           <img src={GRAMMAR_REGION_IMAGE} alt="" />
         </picture>
         <div className="grammar-hero-copy">
-          <div className="eyebrow">Clause Conservatory</div>
-          <h2 id="grammar-setup-title">Grammar retrieval practice</h2>
-          <p>
-            {learner?.name || 'This learner'} can practise with Worker-marked grammar modes while the
-            full concept map stays visible for the larger product build.
-          </p>
-          <div className="grammar-hero-stats" aria-label="Grammar coverage">
-            <Stat label="Concepts" value={counts.total || 18} detail="full map" />
-            <Stat label="Templates" value={templates.total || 51} detail="Worker-held" />
-            <Stat label="Secured" value={counts.secured || 0} detail={`${counts.due || 0} due`} />
-          </div>
+          <h2 id="grammar-dashboard-title" className="grammar-hero-title">{heroTitle}</h2>
+          <p className="grammar-hero-subtitle">{heroSubtitle}</p>
+          {learner?.name ? (
+            <p className="grammar-hero-welcome">Hi {learner.name} — ready for a short round?</p>
+          ) : null}
         </div>
       </div>
 
-      <div className="grammar-setup-grid">
-        <section className="card grammar-start-card" aria-labelledby="grammar-start-title">
-          <div className="card-header">
-            <div>
-              <div className="eyebrow">Worker-marked modes</div>
-              <h3 className="section-title" id="grammar-start-title">Start a Grammar round</h3>
-            </div>
-            <span className="chip good">Worker marked</span>
-          </div>
+      <section className="grammar-today" aria-label="Today at a glance">
+        <div className="grammar-today-grid">
+          {dashboard.todayCards.map((card) => (
+            <TodayCard card={card} key={card.id} />
+          ))}
+        </div>
+        <div className="grammar-concordium-progress" data-testid="grammar-concordium-progress">
+          <span className="grammar-concordium-label">Concordium progress</span>
+          <strong className="grammar-concordium-value">{`${concordium.mastered}/${concordium.total}`}</strong>
+        </div>
+      </section>
 
-          <div className="grammar-mode-grid" aria-label="Grammar practice mode">
-            {GRAMMAR_ENABLED_MODES.map((mode) => (
-              <ModeButton
-                key={mode.id}
-                mode={mode}
-                selected={mode.id === selectedMode}
-                disabled={setupDisabled}
-                actions={actions}
-              />
-            ))}
-            {GRAMMAR_LOCKED_MODES.map((mode) => (
-              <ModeButton
-                key={mode.id}
-                mode={mode}
-                disabled
-                locked
-                reason="Coming next"
-                actions={actions}
-              />
-            ))}
-          </div>
-
-          <div className="grammar-controls">
-            <label className="field">
-              <span>Focus concept</span>
-              <select
-                className="input"
-                value={selectedFocus}
-                disabled={setupDisabled || focusDisabled}
-                onChange={(event) => actions.dispatch('grammar-set-focus', { value: event.currentTarget.value })}
-              >
-                <option value="">{focusPlaceholder}</option>
-                {(grammar.analytics?.concepts || []).map((concept) => (
-                  <option value={concept.id} key={concept.id}>{concept.name}</option>
-                ))}
-              </select>
-            </label>
-            <label className="field">
-              <span>{miniTestMode ? 'Mini-set size' : 'Round length'}</span>
-              <select
-                className="input"
-                value={String(selectedLength)}
-                disabled={setupDisabled}
-                onChange={(event) => actions.dispatch('grammar-set-round-length', { value: event.currentTarget.value })}
-              >
-                {lengthOptions.map((length) => <option value={length} key={length}>{length}</option>)}
-              </select>
-            </label>
-            {!miniTestMode ? (
-              <label className="field">
-                <span>Session goal</span>
-                <select
-                  className="input"
-                  value={selectedGoal}
-                  disabled={setupDisabled}
-                  onChange={(event) => actions.dispatch('grammar-set-goal', { value: event.currentTarget.value })}
-                >
-                  <option value="questions">Question count</option>
-                  <option value="timed">Ten minutes</option>
-                  <option value="due">Clear due items</option>
-                </select>
-              </label>
-            ) : null}
-            <label className="field">
-              <span>Speech rate</span>
-              <select
-                className="input"
-                value={String(selectedSpeechRate)}
-                disabled={setupDisabled}
-                onChange={(event) => actions.dispatch('grammar-set-speech-rate', { value: event.currentTarget.value })}
-              >
-                {SPEECH_RATE_OPTIONS.map((option) => (
-                  <option value={option.value} key={option.value}>{option.label}</option>
-                ))}
-              </select>
-            </label>
-          </div>
-
-          <div className="grammar-settings-list" aria-label="Grammar practice settings">
-            <label className="grammar-setting-toggle">
-              <input
-                type="checkbox"
-                checked={grammar.prefs?.allowTeachingItems === true}
-                disabled={setupDisabled || selectedMode !== 'smart'}
-                onChange={(event) => actions.dispatch('grammar-set-practice-setting', {
-                  key: 'allowTeachingItems',
-                  value: event.currentTarget.checked,
-                })}
-              />
-              <span>Smart Review teaching items</span>
-            </label>
-            <label className="grammar-setting-toggle">
-              <input
-                type="checkbox"
-                checked={grammar.prefs?.showDomainBeforeAnswer !== false}
-                disabled={setupDisabled}
-                onChange={(event) => actions.dispatch('grammar-set-practice-setting', {
-                  key: 'showDomainBeforeAnswer',
-                  value: event.currentTarget.checked,
-                })}
-              />
-              <span>Show domain before answering</span>
-            </label>
-          </div>
-
-          {grammar.error ? (
-            <div className="feedback bad" role="alert">
-              <strong>Grammar is unavailable right now</strong>
-              <div>{grammar.error}</div>
-            </div>
-          ) : null}
-
-          <div className="actions">
-            <button
-              className="btn primary xl"
-              type="button"
+      <section className="grammar-primary-modes" aria-label="Choose a round">
+        <div className="grammar-primary-grid">
+          {GRAMMAR_PRIMARY_MODE_CARDS.map((card) => (
+            <PrimaryModeCard
+              card={card}
+              selected={card.id !== 'bank' && card.id === selectedMode}
               disabled={setupDisabled}
-              onClick={() => actions.dispatch('grammar-start')}
-            >
-              {grammar.pendingCommand === 'start-session' ? 'Starting...' : 'Start practice'}
-            </button>
-          </div>
-        </section>
+              actions={actions}
+              key={card.id}
+            />
+          ))}
+        </div>
 
-        <section className="card grammar-map-card" aria-labelledby="grammar-map-title">
-          <div className="eyebrow">Full placeholder map</div>
-          <h3 className="section-title" id="grammar-map-title">All 18 Grammar concepts</h3>
-          <div className="grammar-domain-list">
-            {groupedConcepts.map((group) => (
-              <div className="grammar-domain" key={group.domain}>
-                <div className="grammar-domain-title">{group.domain}</div>
-                <div className="grammar-concept-list">
-                  {group.concepts.map((concept) => (
-                    <span className={`grammar-concept ${concept.status}`} key={concept.id}>
-                      <span>{concept.name}</span>
-                      <small>{concept.status}</small>
-                    </span>
-                  ))}
-                </div>
-              </div>
-            ))}
+        <div className="grammar-round-controls">
+          <label className="field">
+            <span>{miniTestMode ? 'Mini-set size' : 'Round length'}</span>
+            <select
+              className="input"
+              value={String(selectedLength)}
+              disabled={setupDisabled}
+              onChange={(event) => actions.dispatch('grammar-set-round-length', { value: event.currentTarget.value })}
+            >
+              {lengthOptions.map((length) => <option value={length} key={length}>{length}</option>)}
+            </select>
+          </label>
+          <label className="field">
+            <span>Speech rate</span>
+            <select
+              className="input"
+              value={String(selectedSpeechRate)}
+              disabled={setupDisabled}
+              onChange={(event) => actions.dispatch('grammar-set-speech-rate', { value: event.currentTarget.value })}
+            >
+              {SPEECH_RATE_OPTIONS.map((option) => (
+                <option value={option.value} key={option.value}>{option.label}</option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        {grammar.error ? (
+          <div className="feedback bad" role="alert">
+            <strong>Grammar is unavailable right now</strong>
+            <div>{grammar.error}</div>
           </div>
-        </section>
-      </div>
+        ) : null}
+
+        <div className="grammar-start-row">
+          <button
+            className="btn primary xl"
+            type="button"
+            disabled={setupDisabled}
+            onClick={() => actions.dispatch('grammar-start')}
+          >
+            {grammar.pendingCommand === 'start-session' ? 'Starting...' : 'Begin round'}
+          </button>
+          {dashboard.writingTryAvailable ? (
+            <button
+              className="btn secondary"
+              type="button"
+              data-action="grammar-open-transfer"
+              disabled={setupDisabled}
+              onClick={() => actions.dispatch('grammar-open-transfer')}
+            >
+              Writing Try · non-scored
+            </button>
+          ) : null}
+        </div>
+      </section>
+
+      <details className="grammar-more-practice">
+        <summary>More practice</summary>
+        <div className="grammar-more-practice-grid">
+          {GRAMMAR_MORE_PRACTICE_MODES.map((card) => (
+            <MoreModeCard
+              card={card}
+              selected={card.id === selectedMode}
+              disabled={setupDisabled}
+              actions={actions}
+              key={card.id}
+            />
+          ))}
+        </div>
+      </details>
     </section>
   );
 }

--- a/src/subjects/grammar/components/grammar-view-model.js
+++ b/src/subjects/grammar/components/grammar-view-model.js
@@ -31,21 +31,25 @@ export const GRAMMAR_PRIMARY_MODE_CARDS = Object.freeze([
     id: 'smart',
     title: 'Smart Practice',
     desc: 'Due · weak · one fresh concept.',
+    featured: true,
   }),
   Object.freeze({
     id: 'trouble',
     title: 'Fix Trouble Spots',
     desc: 'Only the concepts you usually miss.',
+    featured: false,
   }),
   Object.freeze({
     id: 'satsset',
     title: 'Mini Test',
     desc: 'Short timed set. Marks at the end.',
+    featured: false,
   }),
   Object.freeze({
     id: 'bank',
     title: 'Grammar Bank',
     desc: 'Browse every concept with child-friendly statuses.',
+    featured: false,
   }),
 ]);
 
@@ -304,6 +308,7 @@ function concordiumProgressFromReward(rewardState) {
  *   {
  *     modeCards:     Frozen copy of GRAMMAR_PRIMARY_MODE_CARDS,
  *     todayCards:    Array<{ id, label, value, detail }>,
+ *     isEmpty:       boolean, // true when all four Today counts are zero
  *     concordiumProgress: { mastered: number, total: number },
  *     primaryMode:   string,  // grammar.prefs.mode
  *     moreModes:     Frozen copy of GRAMMAR_MORE_PRACTICE_MODES,
@@ -336,9 +341,15 @@ export function buildGrammarDashboardModel(grammar, _learner, rewardState) {
     ? safeGrammar.prefs.mode
     : 'smart';
 
+  // Brand-new learner: all four Today counts are zero. The dashboard swaps
+  // the four zero-tiles for a single friendly callout so the first view does
+  // not read as a bleak status board.
+  const isEmpty = (dueCount + troubleCount + secureCount + streakCount) === 0;
+
   return {
     modeCards: GRAMMAR_PRIMARY_MODE_CARDS,
     todayCards: Object.freeze(todayCards),
+    isEmpty,
     concordiumProgress: concordiumProgressFromReward(rewardState),
     primaryMode,
     moreModes: GRAMMAR_MORE_PRACTICE_MODES,

--- a/src/subjects/grammar/metadata.js
+++ b/src/subjects/grammar/metadata.js
@@ -522,7 +522,12 @@ export function normaliseGrammarReadModel(rawValue = {}, learnerId = '') {
       templates: { ...statsFromConcepts(concepts).templates, ...(raw.stats.templates || {}) },
     }
     : statsFromConcepts(concepts);
-  const phase = ['dashboard', 'session', 'feedback', 'summary'].includes(raw.phase)
+  // Phase 3 U1 widens the whitelist to accept `'bank'` and `'transfer'` so
+  // that the U1 dashboard can dispatch `grammar-open-concept-bank` /
+  // `grammar-open-transfer` before U2 + U6b land. The downstream scene files
+  // ship in later units; today the surface renders a lightweight stub for
+  // either phase so the state transition is safe.
+  const phase = ['dashboard', 'bank', 'transfer', 'session', 'feedback', 'summary'].includes(raw.phase)
     ? raw.phase
     : 'dashboard';
   const rawAnalytics = isPlainObject(raw.analytics) ? raw.analytics : {};

--- a/src/subjects/grammar/module.js
+++ b/src/subjects/grammar/module.js
@@ -271,6 +271,34 @@ export const grammarModule = {
       return resetToDashboard(context);
     }
 
+    // Phase 3 U1: register the two dashboard routing placeholders. U2 ships
+    // the real Grammar Bank scene and U6b ships the Writing Try scene; until
+    // then these dispatchers flip the phase to a stub rendered by
+    // `GrammarPracticeSurface`. Both are no-op safe when the learner is
+    // already in a transient phase (pendingCommand in flight, or session
+    // active — we never stomp an in-flight session).
+    if (action === 'grammar-open-concept-bank') {
+      if (ui.pendingCommand) return true;
+      if (ui.phase === 'session' || ui.phase === 'feedback') return true;
+      context.store.updateSubjectUi(GRAMMAR_SUBJECT_ID, (current) => ({
+        ...normaliseGrammarReadModel(current, learnerId),
+        phase: 'bank',
+        error: '',
+      }));
+      return true;
+    }
+
+    if (action === 'grammar-open-transfer') {
+      if (ui.pendingCommand) return true;
+      if (ui.phase === 'session' || ui.phase === 'feedback') return true;
+      context.store.updateSubjectUi(GRAMMAR_SUBJECT_ID, (current) => ({
+        ...normaliseGrammarReadModel(current, learnerId),
+        phase: 'transfer',
+        error: '',
+      }));
+      return true;
+    }
+
     if (action === 'grammar-set-mode') {
       const mode = context.data?.value || DEFAULT_GRAMMAR_PREFS.mode;
       const patch = grammarModeUsesFocus(mode) ? { mode } : { mode, focusConceptId: '' };

--- a/tests/browser-react-migration-smoke.test.js
+++ b/tests/browser-react-migration-smoke.test.js
@@ -107,19 +107,19 @@ test('browser migration smoke covers the React app root, Grammar completeness co
       ['wait', '.subject-grid'],
       ['js', "try { Object.defineProperty(window, 'speechSynthesis', { value: undefined, configurable: true }); Object.defineProperty(window, 'SpeechSynthesisUtterance', { value: undefined, configurable: true }); } catch (_) { window.speechSynthesis = undefined; window.SpeechSynthesisUtterance = undefined; } 'speech synthesis disabled';"],
       ['js', "document.querySelector('[data-action=\"open-subject\"][data-subject-id=\"grammar\"]')?.click(); 'opened grammar';"],
-      ['wait', '.grammar-setup'],
+      ['wait', '.grammar-dashboard'],
       ['text'],
-      ['js', "Array.from(document.querySelectorAll('.grammar-mode')).find((button) => button.textContent?.includes('KS2-style mini-test'))?.click(); 'selected mini-test';"],
-      ['js', "document.querySelector('.grammar-start-card .btn.primary')?.click(); 'started grammar mini-test';"],
+      ['js', "Array.from(document.querySelectorAll('.grammar-primary-mode')).find((button) => button.textContent?.includes('Mini Test'))?.click(); 'selected mini-test';"],
+      ['js', "Array.from(document.querySelectorAll('.grammar-dashboard .btn.primary')).find((button) => button.textContent?.includes('Begin round'))?.click(); 'started grammar mini-test';"],
       ['wait', '.grammar-mini-test-panel'],
       ['text'],
       ['js', "Array.from(document.querySelectorAll('button')).find((button) => button.textContent?.includes('Finish mini-set'))?.click(); 'finished grammar mini-test';"],
       ['wait', '.grammar-summary-shell'],
       ['text'],
       ['js', "Array.from(document.querySelectorAll('button')).find((button) => button.textContent?.includes('Back to Grammar setup'))?.click(); 'back to grammar setup';"],
-      ['wait', '.grammar-setup'],
-      ['js', "Array.from(document.querySelectorAll('.grammar-mode')).find((button) => button.textContent?.includes('Smart mixed review'))?.click(); 'selected smart grammar';"],
-      ['js', "document.querySelector('.grammar-start-card .btn.primary')?.click(); 'started grammar smart';"],
+      ['wait', '.grammar-dashboard'],
+      ['js', "Array.from(document.querySelectorAll('.grammar-primary-mode')).find((button) => button.textContent?.includes('Smart Practice'))?.click(); 'selected smart grammar';"],
+      ['js', "Array.from(document.querySelectorAll('.grammar-dashboard .btn.primary')).find((button) => button.textContent?.includes('Begin round'))?.click(); 'started grammar smart';"],
       ['wait', '.grammar-session'],
       ['text'],
       ['js', "Array.from(document.querySelectorAll('button')).find((button) => button.textContent?.includes('Faded support'))?.click(); 'requested faded support';"],
@@ -160,8 +160,9 @@ test('browser migration smoke covers the React app root, Grammar completeness co
     assert.doesNotMatch(output, /data-home-mount/);
     assert.match(output, /Punctuation practice/);
     assert.match(output, /Punctuation session summary/);
-    assert.match(output, /Grammar retrieval practice/);
-    assert.match(output, /KS2-style mini-test/);
+    assert.match(output, /Grammar Garden/);
+    assert.match(output, /Mini Test/);
+    assert.match(output, /Smart Practice/);
     assert.match(output, /Timed test/);
     assert.match(output, /Mini-set review/);
     assert.match(output, /Faded guidance/);

--- a/tests/grammar-transfer-lane.test.js
+++ b/tests/grammar-transfer-lane.test.js
@@ -497,10 +497,12 @@ test('U6a: orphaned evidence (promptId not in prompts catalogue) passes through 
   assert.equal(clientRm.transferLane.prompts[0].id, 'real-prompt');
 });
 
-test('U6a: U6a does NOT add "transfer" to the phase allowlist — that is U6b scope', () => {
-  // U6a is plumbing only; the `'transfer'` phase string belongs to U6b when
-  // the scene ships. Assert that passing `phase: 'transfer'` still falls back
-  // to the default `'dashboard'` phase on the client.
+test('U1: the dashboard rewrite expands the phase allowlist to accept "transfer" so the Writing Try button routes safely', () => {
+  // U6a was plumbing only; U1 (the dashboard rewrite) legitimately wires the
+  // Writing Try secondary button and needs the `'transfer'` phase as a stub
+  // target until U6b ships the real scene. Assert the normaliser now accepts
+  // `'transfer'` as an allowed phase (and does NOT silently downgrade it to
+  // `'dashboard'`), so clicking "Writing Try" actually transitions.
   const clientRm = normaliseGrammarReadModel({ phase: 'transfer' }, 'learner-a');
-  assert.equal(clientRm.phase, 'dashboard');
+  assert.equal(clientRm.phase, 'transfer');
 });

--- a/tests/grammar-ui-model.test.js
+++ b/tests/grammar-ui-model.test.js
@@ -495,12 +495,19 @@ test('U8 view-model: buildGrammarDashboardModel returns safe empty shape on null
   assert.equal(Array.isArray(model.modeCards), true);
   assert.equal(model.modeCards.length, 4);
   assert.equal(model.todayCards.length, 4);
+  assert.equal(model.isEmpty, true);
   assert.equal(model.concordiumProgress.mastered, 0);
   assert.equal(model.concordiumProgress.total, 18);
   assert.equal(model.primaryMode, 'smart');
   assert.equal(Array.isArray(model.moreModes), true);
   assert.equal(model.moreModes.length, 5);
   assert.equal(typeof model.writingTryAvailable, 'boolean');
+  // U1 follower: Smart Practice card is flagged as featured so U9 can style it.
+  const smartCard = model.modeCards.find((card) => card.id === 'smart');
+  assert.equal(smartCard.featured, true);
+  for (const card of model.modeCards) {
+    if (card.id !== 'smart') assert.notEqual(card.featured, true);
+  }
 });
 
 test('U8 view-model: buildGrammarDashboardModel surfaces concept counts', () => {
@@ -520,6 +527,8 @@ test('U8 view-model: buildGrammarDashboardModel surfaces concept counts', () => 
   assert.equal(byId.trouble.value, 2);
   assert.equal(byId.secure.value, 4);
   assert.equal(model.primaryMode, 'trouble');
+  // Any non-zero Today count flips isEmpty to false (U1 follower).
+  assert.equal(model.isEmpty, false);
 });
 
 test('U8 view-model: buildGrammarDashboardModel concordium progress reads reward state', () => {

--- a/tests/react-grammar-surface.test.js
+++ b/tests/react-grammar-surface.test.js
@@ -14,6 +14,7 @@ import {
   GRAMMAR_TRANSFER_GENERIC_ERROR_COPY,
   translateGrammarTransferError,
 } from '../src/subjects/grammar/module.js';
+import { GRAMMAR_CHILD_FORBIDDEN_TERMS } from '../src/subjects/grammar/components/grammar-view-model.js';
 import { normaliseGrammarReadModel } from '../src/subjects/grammar/metadata.js';
 import { grammarMasteryKey } from '../src/platform/game/monster-system.js';
 import { getSubject, SUBJECTS } from '../src/platform/core/subject-registry.js';
@@ -41,13 +42,15 @@ test('Grammar opens as the child-facing Grammar Garden dashboard', () => {
   assert.match(html, /Fix Trouble Spots/);
   assert.match(html, /Mini Test/);
   assert.match(html, /Grammar Bank/);
-  // Today cards.
-  assert.match(html, /Due/);
-  assert.match(html, /Trouble spots/);
-  assert.match(html, /Secure/);
-  assert.match(html, /Streak/);
-  // Concordium progress string.
-  assert.match(html, /Concordium progress/);
+  // Brand-new learner: Today section renders the empty-state callout
+  // instead of the four zero tiles (U1 follower, empty_returning_states).
+  assert.match(html, /Start your first round to see your scores here\./);
+  // Smart Practice is marked featured/recommended (U1 follower, cta_hierarchy).
+  assert.match(html, /data-mode-id="smart"[^>]*data-featured="true"/);
+  assert.match(html, /class="grammar-primary-mode[^"]*is-recommended[^"]*"[^>]*data-mode-id="smart"/);
+  assert.match(html, /Recommended/);
+  // Concordium progress string (U1 follower: renamed "Grow Concordium").
+  assert.match(html, /Grow Concordium/);
   assert.match(html, /\d+\/18/);
   // More practice disclosure is present and closed by default.
   assert.match(html, /<details class="grammar-more-practice"><summary>More practice<\/summary>/);
@@ -72,12 +75,17 @@ test('Grammar dashboard omits adult-diagnostic copy and reserved monster names',
   assert.ok(dashboardMatch, 'dashboard section was rendered');
   const dashboardHtml = dashboardMatch[0];
 
-  assert.doesNotMatch(dashboardHtml, /Worker-marked/i);
-  assert.doesNotMatch(dashboardHtml, /Worker authority/i);
-  assert.doesNotMatch(dashboardHtml, /Worker marked/i);
-  assert.doesNotMatch(dashboardHtml, /Worker-held/i);
-  assert.doesNotMatch(dashboardHtml, /full map/i);
-  assert.doesNotMatch(dashboardHtml, /Evidence snapshot/i);
+  // U1 follower: iterate every entry in the fixture list rather than
+  // hard-coding a subset. Any new forbidden term appears here automatically.
+  for (const term of GRAMMAR_CHILD_FORBIDDEN_TERMS) {
+    const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    assert.doesNotMatch(dashboardHtml, new RegExp(escaped, 'i'), `forbidden term leaked: ${term}`);
+  }
+  // Whole-word `Worker` catch-all: the bare noun is adult-facing. The
+  // `\b` boundary keeps legitimate tokens like `workbook` or `homework`
+  // from tripping the guard; the fixture-driven loop above covers every
+  // compound form (`Worker-marked`, `Worker authority`, ...).
+  assert.doesNotMatch(dashboardHtml, /\bWorker\b/i);
   // Reserved Grammar monsters never appear in the dashboard.
   assert.doesNotMatch(dashboardHtml, /Glossbloom|Loomrill|Mirrane/i);
 });
@@ -531,8 +539,9 @@ test('Grammar dashboard disables mode cards, controls, and Begin button while a 
   }));
 
   const html = harness.render();
-  // Primary mode cards carry `disabled` when setup is pending.
-  assert.match(html, /<button type="button" class="grammar-primary-mode selected is-disabled" data-mode-id="smart" data-action="grammar-set-mode" aria-pressed="true" disabled="">/);
+  // Primary mode cards carry `disabled` when setup is pending. Smart card
+  // also carries `is-recommended` + `data-featured="true"` (U1 follower).
+  assert.match(html, /<button type="button" class="grammar-primary-mode selected is-disabled is-recommended" data-mode-id="smart" data-action="grammar-set-mode" data-featured="true" aria-pressed="true" disabled="">/);
   // Round length select is disabled and shows the default 5 value selected.
   assert.match(html, /<select class="input" disabled=""[^>]*><option value="3">3<\/option><option value="5" selected="">5<\/option>/);
   // Begin button renders the pending label.
@@ -708,6 +717,75 @@ test('Grammar dashboard placeholder dispatchers are no-ops while a command is pe
   assert.equal(harness.store.getState().subjectUi.grammar.phase, 'dashboard');
   harness.dispatch('grammar-open-transfer');
   assert.equal(harness.store.getState().subjectUi.grammar.phase, 'dashboard');
+});
+
+// U1 follower: mid-session guard. `grammar-open-concept-bank` and
+// `grammar-open-transfer` must be no-ops while phase is `session` or
+// `feedback` — otherwise navigating away mid-question would wipe the
+// active session state. Covers `module.js` lines 281-282 and 292-293.
+test('U1 follower: grammar-open-concept-bank is a no-op mid-session', () => {
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+  const sample = grammarOracleSample();
+
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-start', {
+    payload: { roundLength: 1, templateId: sample.id, seed: sample.sample.seed },
+  });
+  const beforeSession = harness.store.getState().subjectUi.grammar.session;
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'session');
+
+  harness.dispatch('grammar-open-concept-bank');
+  const afterGrammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(afterGrammar.phase, 'session', 'phase must stay session');
+  assert.equal(afterGrammar.session, beforeSession, 'session object must be untouched');
+});
+
+test('U1 follower: grammar-open-transfer is a no-op mid-session', () => {
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+  const sample = grammarOracleSample();
+
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-start', {
+    payload: { roundLength: 1, templateId: sample.id, seed: sample.sample.seed },
+  });
+  const beforeSession = harness.store.getState().subjectUi.grammar.session;
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'session');
+
+  harness.dispatch('grammar-open-transfer');
+  const afterGrammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(afterGrammar.phase, 'session', 'phase must stay session');
+  assert.equal(afterGrammar.session, beforeSession, 'session object must be untouched');
+});
+
+test('U1 follower: grammar-open-concept-bank and grammar-open-transfer are no-ops during feedback', () => {
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+  const sample = grammarOracleSample();
+
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-start', {
+    payload: { roundLength: 2, templateId: sample.id, seed: sample.sample.seed },
+  });
+  harness.dispatch('grammar-submit-form', {
+    formData: grammarResponseFormData(sample.correctResponse),
+  });
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'feedback');
+  const beforeSession = harness.store.getState().subjectUi.grammar.session;
+  const beforeFeedback = harness.store.getState().subjectUi.grammar.feedback;
+
+  harness.dispatch('grammar-open-concept-bank');
+  let grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.phase, 'feedback', 'phase stays feedback after concept-bank');
+  assert.equal(grammar.session, beforeSession, 'session untouched after concept-bank');
+  assert.equal(grammar.feedback, beforeFeedback, 'feedback untouched after concept-bank');
+
+  harness.dispatch('grammar-open-transfer');
+  grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.phase, 'feedback', 'phase stays feedback after open-transfer');
+  assert.equal(grammar.session, beforeSession, 'session untouched after open-transfer');
+  assert.equal(grammar.feedback, beforeFeedback, 'feedback untouched after open-transfer');
 });
 
 test('Punctuation remains separately registered from Grammar Bellstorm bridge copy', () => {

--- a/tests/react-grammar-surface.test.js
+++ b/tests/react-grammar-surface.test.js
@@ -26,20 +26,60 @@ function escapeRegExp(value) {
   return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-test('Grammar opens as a real Clause Conservatory subject surface', () => {
+test('Grammar opens as the child-facing Grammar Garden dashboard', () => {
   const storage = installMemoryStorage();
   const harness = createAppHarness({ storage });
 
   harness.dispatch('open-subject', { subjectId: 'grammar' });
   const html = harness.render();
 
-  assert.match(html, /Clause Conservatory/);
-  assert.match(html, /Grammar retrieval practice/);
-  assert.match(html, /All 18 Grammar concepts/);
-  assert.match(html, /Start practice/);
-  assert.match(html, /Bracehart/);
-  assert.match(html, /Concordium/);
+  // Phase 3 U1: hero copy comes from `GRAMMAR_DASHBOARD_HERO`.
+  assert.match(html, /Grammar Garden/);
+  assert.match(html, /Grow your Grammar creatures/);
+  // Four primary mode cards are present exactly.
+  assert.match(html, /Smart Practice/);
+  assert.match(html, /Fix Trouble Spots/);
+  assert.match(html, /Mini Test/);
+  assert.match(html, /Grammar Bank/);
+  // Today cards.
+  assert.match(html, /Due/);
+  assert.match(html, /Trouble spots/);
+  assert.match(html, /Secure/);
+  assert.match(html, /Streak/);
+  // Concordium progress string.
+  assert.match(html, /Concordium progress/);
+  assert.match(html, /\d+\/18/);
+  // More practice disclosure is present and closed by default.
+  assert.match(html, /<details class="grammar-more-practice"><summary>More practice<\/summary>/);
+  // Writing Try secondary entry.
+  assert.match(html, /data-action="grammar-open-transfer"/);
+  assert.match(html, /Writing Try/);
+  // Primary Begin round CTA.
+  assert.match(html, /Begin round/);
   assert.doesNotMatch(html, /Future subject module/);
+});
+
+test('Grammar dashboard omits adult-diagnostic copy and reserved monster names', () => {
+  const storage = installMemoryStorage();
+  const harness = createAppHarness({ storage });
+
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  const html = harness.render();
+  // Narrow the absence check to the dashboard panel. The adult-only
+  // analytics surface lives behind a sibling `<details class="grammar-grown-up-view">`
+  // disclosure, so we scope to the dashboard section alone.
+  const dashboardMatch = html.match(/<section class="grammar-dashboard"[\s\S]*?<\/section><details class="grammar-grown-up-view">/);
+  assert.ok(dashboardMatch, 'dashboard section was rendered');
+  const dashboardHtml = dashboardMatch[0];
+
+  assert.doesNotMatch(dashboardHtml, /Worker-marked/i);
+  assert.doesNotMatch(dashboardHtml, /Worker authority/i);
+  assert.doesNotMatch(dashboardHtml, /Worker marked/i);
+  assert.doesNotMatch(dashboardHtml, /Worker-held/i);
+  assert.doesNotMatch(dashboardHtml, /full map/i);
+  assert.doesNotMatch(dashboardHtml, /Evidence snapshot/i);
+  // Reserved Grammar monsters never appear in the dashboard.
+  assert.doesNotMatch(dashboardHtml, /Glossbloom|Loomrill|Mirrane/i);
 });
 
 test('Grammar surface runs from setup to Worker-style feedback and summary', () => {
@@ -80,7 +120,7 @@ test('Grammar surface runs from setup to Worker-style feedback and summary', () 
 
   harness.dispatch('grammar-back');
   assert.equal(harness.store.getState().subjectUi.grammar.phase, 'dashboard');
-  assert.match(harness.render(), /Grammar retrieval practice/);
+  assert.match(harness.render(), /Grammar Garden/);
 });
 
 test('Grammar Enter key advances from feedback to the next question', () => {
@@ -479,7 +519,7 @@ test('Grammar submit requires an answer before recording an attempt', () => {
   assert.equal(grammar.analytics.concepts.some((concept) => concept.attempts > 0), false);
 });
 
-test('Grammar setup controls are disabled while a command is pending', () => {
+test('Grammar dashboard disables mode cards, controls, and Begin button while a command is pending', () => {
   const storage = installMemoryStorage();
   const harness = createAppHarness({ storage });
   const learnerId = harness.store.getState().learners.selectedId;
@@ -491,25 +531,30 @@ test('Grammar setup controls are disabled while a command is pending', () => {
   }));
 
   const html = harness.render();
-  assert.match(html, /<button class="grammar-mode selected" type="button" disabled="">/);
-  assert.match(html, /<select class="input" disabled=""[^>]*><option value="" selected="">Smart mix<\/option>/);
+  // Primary mode cards carry `disabled` when setup is pending.
+  assert.match(html, /<button type="button" class="grammar-primary-mode selected is-disabled" data-mode-id="smart" data-action="grammar-set-mode" aria-pressed="true" disabled="">/);
+  // Round length select is disabled and shows the default 5 value selected.
   assert.match(html, /<select class="input" disabled=""[^>]*><option value="3">3<\/option><option value="5" selected="">5<\/option>/);
+  // Begin button renders the pending label.
   assert.match(html, /<button class="btn primary xl" type="button" disabled="">Starting\.\.\.<\/button>/);
 });
 
-test('Grammar setup exposes session goals and Smart Review teaching settings', () => {
+test('Grammar dashboard hides adult-diagnostic goal/teaching toggles but preserves the preference round-trip', () => {
   const storage = installMemoryStorage();
   const harness = createGrammarHarness({ storage });
 
   harness.dispatch('open-subject', { subjectId: 'grammar' });
   let html = harness.render();
-  assert.match(html, /Session goal/);
-  assert.match(html, /Ten minutes/);
-  assert.match(html, /Clear due items/);
+  // Child dashboard surfaces Speech rate only; adult-diagnostic toggles
+  // move out of the primary dashboard as of U1.
   assert.match(html, /Speech rate/);
-  assert.match(html, /Smart Review teaching items/);
-  assert.match(html, /Show domain before answering/);
+  assert.doesNotMatch(html, /Smart Review teaching items/);
+  assert.doesNotMatch(html, /Show domain before answering/);
+  assert.doesNotMatch(html, /Session goal/);
 
+  // Preference dispatchers still round-trip through the module, so a
+  // later scene can surface them. The session start payload derives the
+  // goal/teaching settings as before.
   harness.dispatch('grammar-set-goal', { value: 'timed' });
   harness.dispatch('grammar-set-speech-rate', { value: '1.4' });
   harness.dispatch('grammar-set-practice-setting', { key: 'allowTeachingItems', value: true });
@@ -530,8 +575,6 @@ test('Grammar setup exposes session goals and Smart Review teaching settings', (
   // Independent first-attempt correct gets full credit. In-session faded escalation still available
   // if the learner requests it via grammar-use-faded-support.
   assert.equal(grammar.session.supportLevel, 0);
-  html = harness.render();
-  assert.match(html, /Ten minutes/);
 });
 
 test('Grammar show-domain setting affects display only before answer feedback', () => {
@@ -617,47 +660,54 @@ test('Grammar analytics renders evidence before reward progress', () => {
   assert.match(html, /Choose the correct sentence/);
 });
 
-test('Grammar renders transfer and Bellstorm bridge placeholders as locked future capabilities', () => {
+test('Grammar dashboard Writing Try dispatches grammar-open-transfer to the Writing Try placeholder scene', () => {
   const storage = installMemoryStorage();
   const harness = createAppHarness({ storage });
 
   harness.dispatch('open-subject', { subjectId: 'grammar' });
-  const html = harness.render();
+  const dashboardHtml = harness.render();
+  assert.match(dashboardHtml, /data-action="grammar-open-transfer"/);
+  assert.match(dashboardHtml, /Writing Try/);
 
-  assert.match(html, /Writing application roadmap/);
-  assert.match(html, /Paragraph transfer/);
-  assert.match(html, /Richer writing tasks/);
-  assert.match(html, /Decision: this will be non-scored paragraph application first/);
-  assert.match(html, /No score, retry, reward, or Concordium progress/);
-  assert.match(html, /Teacher review and deterministic paragraph scoring are separate future decisions/);
-  assert.match(html, /Worker-marked Grammar remains the only score-bearing authority/);
-  assert.match(html, /Bellstorm bridge/);
-  assert.match(html, /Punctuation-for-grammar stays in Grammar/);
-  assert.match(html, /Bellstorm Coast remains the separate Punctuation subject/);
+  harness.dispatch('grammar-open-transfer');
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'transfer');
+  const transferHtml = harness.render();
+  assert.match(transferHtml, /Writing Try/);
+  assert.match(transferHtml, /Non-scored writing/);
+  // Back action returns the learner safely to the dashboard.
+  harness.dispatch('grammar-back');
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'dashboard');
 });
 
-test('Grammar locked transfer placeholders do not expose scoring commands', () => {
+test('Grammar dashboard Grammar Bank card dispatches grammar-open-concept-bank to the stub scene', () => {
   const storage = installMemoryStorage();
   const harness = createAppHarness({ storage });
 
   harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-open-concept-bank');
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'bank');
   const html = harness.render();
+  assert.match(html, /Grammar Bank/);
+  assert.match(html, /Back to Grammar Garden/);
+  harness.dispatch('grammar-back');
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'dashboard');
+});
 
-  assert.match(html, /<button(?=[^>]*data-grammar-transfer-placeholder="paragraph-transfer")(?=[^>]*disabled="")[^>]*>Coming next/);
-  assert.match(html, /<button(?=[^>]*data-grammar-transfer-placeholder="writing-application")(?=[^>]*disabled="")[^>]*>Coming next/);
-  assert.doesNotMatch(html, /data-grammar-transfer-submit/);
-  assert.doesNotMatch(html, /name="transfer-answer"/);
+test('Grammar dashboard placeholder dispatchers are no-ops while a command is pending', () => {
+  const storage = installMemoryStorage();
+  const harness = createAppHarness({ storage });
+  const learnerId = harness.store.getState().learners.selectedId;
 
-  assert.equal(grammarModule.handleAction('grammar-transfer-submit', {
-    appState: harness.store.getState(),
-    data: { formData: new FormData() },
-    store: harness.store,
-    subjectCommands: {
-      send() {
-        throw new Error('Locked transfer placeholder must not submit a command.');
-      },
-    },
-  }), false);
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.store.updateSubjectUi('grammar', (current) => ({
+    ...normaliseGrammarReadModel(current, learnerId),
+    pendingCommand: 'start-session',
+  }));
+
+  harness.dispatch('grammar-open-concept-bank');
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'dashboard');
+  harness.dispatch('grammar-open-transfer');
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'dashboard');
 });
 
 test('Punctuation remains separately registered from Grammar Bellstorm bridge copy', () => {
@@ -928,24 +978,28 @@ test('Grammar normaliser upgrades stale persisted mode capabilities', () => {
   }
 });
 
-test('Grammar legacy modes render available without locked placeholders', () => {
+test('Grammar "More practice" disclosure exposes secondary modes without locked placeholders', () => {
   const storage = installMemoryStorage();
   const harness = createAppHarness({ storage });
 
   harness.dispatch('open-subject', { subjectId: 'grammar' });
   const html = harness.render();
 
-  assert.match(html, /<button class="grammar-mode" type="button">[\s\S]*Weak concepts drill/);
-  assert.doesNotMatch(html, /<button class="grammar-mode locked" type="button" disabled="">[\s\S]*Weak concepts drill/);
-  assert.match(html, /<button class="grammar-mode" type="button">[\s\S]*Sentence surgery/);
-  assert.doesNotMatch(html, /<button class="grammar-mode locked" type="button" disabled="">[\s\S]*Sentence surgery/);
-  assert.match(html, /<button class="grammar-mode" type="button">[\s\S]*Sentence builder/);
-  assert.doesNotMatch(html, /<button class="grammar-mode locked" type="button" disabled="">[\s\S]*Sentence builder/);
-  assert.match(html, /<button class="grammar-mode" type="button">[\s\S]*Worked examples/);
-  assert.doesNotMatch(html, /<button class="grammar-mode locked" type="button" disabled="">[\s\S]*Worked examples/);
-  assert.match(html, /<button class="grammar-mode" type="button">[\s\S]*Faded guidance/);
-  assert.doesNotMatch(html, /<button class="grammar-mode locked" type="button" disabled="">[\s\S]*Faded guidance/);
-  assert.doesNotMatch(html, /<button class="grammar-mode locked" type="button" disabled="">/);
+  // Secondary modes from `GRAMMAR_MORE_PRACTICE_MODES` render inside the
+  // `<details class="grammar-more-practice">` disclosure as active cards.
+  assert.match(html, /<details class="grammar-more-practice"><summary>More practice<\/summary>/);
+  assert.match(html, /data-mode-id="learn"/);
+  assert.match(html, /Learn a concept/);
+  assert.match(html, /data-mode-id="surgery"/);
+  assert.match(html, /Sentence Surgery/);
+  assert.match(html, /data-mode-id="builder"/);
+  assert.match(html, /Sentence Builder/);
+  assert.match(html, /data-mode-id="worked"/);
+  assert.match(html, /Worked Examples/);
+  assert.match(html, /data-mode-id="faded"/);
+  assert.match(html, /Faded Guidance/);
+  // No locked / disabled-due-to-lock markup on the secondary grid.
+  assert.doesNotMatch(html, /<button[^>]*class="grammar-secondary-mode[^"]* is-disabled"[^>]*disabled=""/);
 });
 
 test('Grammar setup can start trouble drill mode', () => {
@@ -959,7 +1013,10 @@ test('Grammar setup can start trouble drill mode', () => {
   harness.dispatch('grammar-set-mode', { value: 'trouble' });
   assert.equal(harness.store.getState().subjectUi.grammar.prefs.mode, 'trouble');
   assert.equal(harness.store.getState().subjectUi.grammar.prefs.focusConceptId, '');
-  assert.match(harness.render(), /<select class="input" disabled=""><option value="" selected="">Weakest concept<\/option>/);
+
+  // U1 dashboard: `Fix Trouble Spots` card reflects the selected mode.
+  const html = harness.render();
+  assert.match(html, /<button type="button" class="grammar-primary-mode selected" data-mode-id="trouble"/);
 
   harness.dispatch('grammar-set-focus', { value: 'word_classes' });
   assert.equal(harness.store.getState().subjectUi.grammar.prefs.focusConceptId, '');
@@ -988,7 +1045,8 @@ test('Grammar setup can start sentence surgery mode', () => {
   harness.dispatch('grammar-set-mode', { value: 'surgery' });
   assert.equal(harness.store.getState().subjectUi.grammar.prefs.mode, 'surgery');
   assert.equal(harness.store.getState().subjectUi.grammar.prefs.focusConceptId, '');
-  assert.match(harness.render(), /<select class="input" disabled=""><option value="" selected="">Surgery mix<\/option>/);
+  // U1 dashboard: surgery is a "More practice" secondary mode, selected.
+  assert.match(harness.render(), /<button type="button" class="grammar-secondary-mode selected" data-mode-id="surgery"/);
 
   harness.dispatch('grammar-set-focus', { value: 'word_classes' });
   assert.equal(harness.store.getState().subjectUi.grammar.prefs.focusConceptId, '');
@@ -1043,7 +1101,8 @@ test('Grammar setup can start sentence builder mode', () => {
   harness.dispatch('grammar-set-mode', { value: 'builder' });
   assert.equal(harness.store.getState().subjectUi.grammar.prefs.mode, 'builder');
   assert.equal(harness.store.getState().subjectUi.grammar.prefs.focusConceptId, '');
-  assert.match(harness.render(), /<select class="input" disabled=""><option value="" selected="">Builder mix<\/option>/);
+  // U1 dashboard: builder is a "More practice" secondary mode, selected.
+  assert.match(harness.render(), /<button type="button" class="grammar-secondary-mode selected" data-mode-id="builder"/);
 
   harness.dispatch('grammar-set-focus', { value: 'word_classes' });
   assert.equal(harness.store.getState().subjectUi.grammar.prefs.focusConceptId, '');

--- a/tests/subject-expansion.test.js
+++ b/tests/subject-expansion.test.js
@@ -186,7 +186,9 @@ const grammarSpec = {
   subjectId: 'grammar',
   createHarness: createGrammarHarness,
   expectReactPractice: true,
-  practiceMatcher: /Grammar retrieval practice/,
+  // U1 renames the dashboard hero copy from "Grammar retrieval practice"
+  // to the child-facing `GRAMMAR_DASHBOARD_HERO.title` ("Grammar Garden").
+  practiceMatcher: /Grammar Garden/,
   sessionMatcher: /Grammar practice|question marks/i,
   summaryMatcher: /Grammar session summary/,
   getUiState(harness) {


### PR DESCRIPTION
## Summary

Grammar Phase 3 Unit U1 — replaces the adult-diagnostic `GrammarSetupScene` with a child-facing Grammar Garden dashboard driven entirely by the U8 view-model constants.

Plan: [`docs/plans/2026-04-25-004-feat-grammar-phase3-ux-reset-plan.md`](./docs/plans/2026-04-25-004-feat-grammar-phase3-ux-reset-plan.md) — see the **U1. Dashboard rewrite** section and the child-facing IA diagram in the High-Level Technical Design block.

## New information architecture

1. **Hero** — `GRAMMAR_DASHBOARD_HERO.title` ("Grammar Garden") + `.subtitle` ("One short round. Fix tricky sentences. Grow your Grammar creatures."). Wording is editable in one place (`grammar-view-model.js`) for James to review.
2. **Today cards row (4)** — Due / Trouble spots / Secure / Streak, derived from `buildGrammarDashboardModel().todayCards` + `progressSnapshot`.
3. **Concordium progress** — `N/18` rendered from `rewardState.concordium.mastered.length`.
4. **Primary mode cards (4)** — iterated from `GRAMMAR_PRIMARY_MODE_CARDS`:
   - Smart Practice (default-focus)
   - Fix Trouble Spots
   - Mini Test
   - Grammar Bank (dispatches `grammar-open-concept-bank` → U2 stub)
5. **Round length + speech rate** — retained but visually quieter.
6. **Primary CTA** — "Begin round" (was "Start practice").
7. **Secondary** — "Writing Try · non-scored" (dispatches `grammar-open-transfer` → U6b stub).
8. **"More practice" disclosure** — `<details>` closed by default with 5 secondary mode cards from `GRAMMAR_MORE_PRACTICE_MODES`: Learn a concept / Sentence Surgery / Sentence Builder / Worked Examples / Faded Guidance.
9. **"Grown-up view" disclosure** — `<details>` closed by default, wraps the existing Analytics scene so U5/U7 can carry the full child/adult split forward.

## Removed adult-copy signals

- `Worker-marked modes` eyebrow (dashboard line 82 in the old file)
- `Worker marked` chip (line 100)
- `Concepts full map` stat line (lines 93/96)
- Full 8-mode equal grid including the `Coming next` locked cards
- Concept focus `<select>` dropdown and `Smart mix` / `Surgery mix` / `Builder mix` placeholders
- `Smart Review teaching items` / `Show domain before answering` / `Session goal` toggles (preferences still round-trip through dispatchers, they just no longer anchor the dashboard)
- `GrammarTransferPlaceholders` section inside `GrammarPracticeSurface.jsx` (the old "Writing application roadmap" + `Bellstorm bridge` placeholder cards)
- Automatic dashboard-level render of `GrammarAnalyticsScene` (now behind the "Grown-up view" disclosure)

## Modes catalogue

Primary (4) — `GRAMMAR_PRIMARY_MODE_CARDS`:
| id | title | desc |
|---|---|---|
| `smart` | Smart Practice | Due · weak · one fresh concept. |
| `trouble` | Fix Trouble Spots | Only the concepts you usually miss. |
| `satsset` | Mini Test | Short timed set. Marks at the end. |
| `bank` | Grammar Bank | Browse every concept with child-friendly statuses. |

More practice (5) — `GRAMMAR_MORE_PRACTICE_MODES`:
| id | title |
|---|---|
| `learn` | Learn a concept |
| `surgery` | Sentence Surgery |
| `builder` | Sentence Builder |
| `worked` | Worked Examples |
| `faded` | Faded Guidance |

## New action wiring (module.js)

- `grammar-open-concept-bank` — flips `phase` to `'bank'`. `GrammarPracticeSurface` renders a lightweight stub scene until U2 ships the real Grammar Bank. No-op safe while `pendingCommand` is in flight or a session is active.
- `grammar-open-transfer` — flips `phase` to `'transfer'`. Same stub contract; U6b will render the Writing Try scene.
- Phase whitelist in `normaliseGrammarReadModel` widens to include `'bank'` and `'transfer'` so these transitions are not silently downgraded.

## Test plan

- [x] `node --test tests/react-grammar-surface.test.js tests/grammar-ui-model.test.js` — all green (114 tests pass).
- [x] `node --test tests/grammar-transfer-lane.test.js tests/subject-expansion.test.js` — green (45 tests pass).
- [x] `npm test` — 1421 pass / 1 pre-existing failure (`Grammar production smoke scans feedback and summary models for forbidden keys`). Reproduced on pristine `origin/main`; unrelated to this PR.
- [x] `npm run check` — green.
- [ ] James to review Grammar Garden hero wording (`GRAMMAR_DASHBOARD_HERO`).

## Files touched

- `src/subjects/grammar/components/GrammarSetupScene.jsx` — rewritten around `buildGrammarDashboardModel` + view-model constants.
- `src/subjects/grammar/components/GrammarPracticeSurface.jsx` — removed `GrammarTransferPlaceholders`, added bank + transfer stub routing, moved Analytics behind "Grown-up view" `<details>`.
- `src/subjects/grammar/metadata.js` — widened phase whitelist.
- `src/subjects/grammar/module.js` — registered `grammar-open-concept-bank` + `grammar-open-transfer`.
- `tests/react-grammar-surface.test.js` — rewrote dashboard tests, added forbidden-terms + reserved-monster absence sweep, added bank/transfer stub routing tests.
- `tests/grammar-transfer-lane.test.js` — re-scoped the phase allowlist test from U6b to U1.
- `tests/subject-expansion.test.js` — updated `practiceMatcher` to the new hero copy.

## Out of scope

- U2 Grammar Bank scene and U6b Writing Try scene — this PR only wires their entry points and ships stub scenes.
- No Worker code touched. No Spelling code touched. No `contentReleaseId` bump.