### PR TITLE
feat(grammar): U2 Grammar Bank scene + concept detail modal

### DIFF
--- a/src/subjects/grammar/components/GrammarConceptBankScene.jsx
+++ b/src/subjects/grammar/components/GrammarConceptBankScene.jsx
@@ -1,0 +1,264 @@
+import React from 'react';
+import { GrammarConceptDetailModal } from './GrammarConceptDetailModal.jsx';
+import {
+  GRAMMAR_BANK_CLUSTER_CHIPS,
+  GRAMMAR_BANK_HERO,
+  GRAMMAR_BANK_STATUS_CHIPS,
+  buildGrammarBankModel,
+  grammarBankAggregateCards,
+} from './grammar-view-model.js';
+
+// Phase 3 U2: Grammar Bank scene. Mirrors the Spelling Word Bank scene
+// shape — hero, aggregate card row, search + filter chips, concept grid,
+// detail modal. Every label, chip id, and count comes from the U8
+// view-model. The JSX layer is layout-only.
+//
+// Focus-return contract: concept cards carry `data-focus-return-id` so
+// the detail modal can restore focus on close (SSR-visible marker; the
+// actual focus motion is a browser runtime side-effect and asserted via
+// manual QA — see `GrammarConceptDetailModal.jsx` for the hook).
+//
+// Search: the search input is controlled locally (draft) and commits its
+// value on blur / Enter via `grammar-concept-bank-search`. This mirrors
+// the Spelling Word Bank pattern so typing does not force every
+// keystroke through the store.
+
+function AggregateCards({ counts }) {
+  const cards = grammarBankAggregateCards(counts);
+  return (
+    <div className="grammar-bank-aggregates" role="list">
+      {cards.map((card) => (
+        <div className="grammar-bank-aggregate-card" role="listitem" data-aggregate-id={card.id} key={card.id}>
+          <div className="grammar-bank-aggregate-label">{card.label}</div>
+          <div className="grammar-bank-aggregate-value">{card.value}</div>
+          <div className="grammar-bank-aggregate-sub">{card.sub}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function StatusFilterChips({ counts, activeFilter, onChange }) {
+  return (
+    <div className="grammar-bank-chips grammar-bank-status-chips" role="group" aria-label="Filter concepts by status">
+      {GRAMMAR_BANK_STATUS_CHIPS.map((chip) => {
+        const active = chip.id === activeFilter;
+        const chipCount = counts[chip.id] ?? 0;
+        return (
+          <button
+            type="button"
+            aria-pressed={active ? 'true' : 'false'}
+            className={`grammar-bank-chip grammar-bank-chip-status${active ? ' on' : ''}`}
+            data-action="grammar-concept-bank-filter"
+            data-value={chip.id}
+            key={chip.id}
+            onClick={() => onChange(chip.id)}
+          >
+            <span className={`grammar-bank-chip-swatch tone-${chip.tone}`} aria-hidden="true" />
+            <span className="grammar-bank-chip-label">{chip.label}</span>
+            <span className="grammar-bank-chip-count">{chipCount}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function ClusterFilterChips({ counts, activeFilter, onChange }) {
+  return (
+    <div className="grammar-bank-chips grammar-bank-cluster-chips" role="group" aria-label="Filter concepts by cluster">
+      {GRAMMAR_BANK_CLUSTER_CHIPS.map((chip) => {
+        const active = chip.id === activeFilter;
+        const chipCount = counts[chip.id] ?? 0;
+        return (
+          <button
+            type="button"
+            aria-pressed={active ? 'true' : 'false'}
+            className={`grammar-bank-chip grammar-bank-chip-cluster${active ? ' on' : ''}`}
+            data-action="grammar-concept-bank-cluster-filter"
+            data-value={chip.id}
+            key={chip.id}
+            onClick={() => onChange(chip.id)}
+          >
+            <span className="grammar-bank-chip-label">{chip.label}</span>
+            <span className="grammar-bank-chip-count">{chipCount}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function ConceptCard({ card, onPractise, onOpenDetail }) {
+  const returnId = `grammar-bank-concept-card-${card.id}`;
+  return (
+    <article
+      className={`grammar-bank-card tone-${card.tone}`}
+      data-concept-id={card.id}
+      data-cluster-id={card.cluster}
+      data-status-label={card.label}
+    >
+      <header className="grammar-bank-card-head">
+        <div className="grammar-bank-card-head-copy">
+          <h3 className="grammar-bank-card-title">{card.name}</h3>
+          <p className="grammar-bank-card-domain">{card.domain}</p>
+        </div>
+        <span className={`grammar-bank-card-status-chip tone-${card.tone}`}>{card.childLabel}</span>
+      </header>
+      <p className="grammar-bank-card-summary">{card.summary}</p>
+      {card.example ? (
+        <blockquote className="grammar-bank-card-example">{card.example}</blockquote>
+      ) : null}
+      <div className="grammar-bank-card-foot">
+        <span className="grammar-bank-card-cluster-badge" data-cluster-id={card.cluster}>{card.clusterName}</span>
+        <div className="grammar-bank-card-actions">
+          <button
+            type="button"
+            className="btn primary sm"
+            data-action="grammar-focus-concept"
+            data-concept-id={card.id}
+            onClick={() => onPractise(card.id)}
+          >
+            Practise 5
+          </button>
+          <button
+            type="button"
+            className="btn ghost sm"
+            data-action="grammar-concept-detail-open"
+            data-concept-id={card.id}
+            data-focus-return-id={returnId}
+            onClick={() => onOpenDetail(card.id)}
+          >
+            See example
+          </button>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export function GrammarConceptBankScene({ grammar, actions }) {
+  const bankUi = grammar?.bank || {};
+  const activeStatus = bankUi.statusFilter || 'all';
+  const activeCluster = bankUi.clusterFilter || 'all';
+  const persistedQuery = bankUi.query || '';
+  const detailConceptId = bankUi.detailConceptId || '';
+
+  const [draftQuery, setDraftQuery] = React.useState(persistedQuery);
+  React.useEffect(() => {
+    setDraftQuery(persistedQuery);
+  }, [persistedQuery]);
+
+  const commitSearch = React.useCallback((value) => {
+    const next = String(value || '').slice(0, 80);
+    if (next === persistedQuery) return;
+    actions?.dispatch?.('grammar-concept-bank-search', { value: next });
+  }, [actions, persistedQuery]);
+
+  const bankModel = buildGrammarBankModel(grammar, {
+    statusFilter: activeStatus,
+    clusterFilter: activeCluster,
+    query: draftQuery,
+  });
+
+  const handleStatusChange = (id) => {
+    actions?.dispatch?.('grammar-concept-bank-filter', { value: id });
+  };
+  const handleClusterChange = (id) => {
+    actions?.dispatch?.('grammar-concept-bank-cluster-filter', { value: id });
+  };
+  const handlePractise = (conceptId) => {
+    actions?.dispatch?.('grammar-focus-concept', { conceptId });
+  };
+  const handleOpenDetail = (conceptId) => {
+    actions?.dispatch?.('grammar-concept-detail-open', { conceptId });
+  };
+
+  const detailCard = detailConceptId
+    ? bankModel.cards.find((card) => card.id === detailConceptId)
+      || buildGrammarBankModel(grammar, { statusFilter: 'all', clusterFilter: 'all', query: '' })
+        .cards.find((card) => card.id === detailConceptId)
+    : null;
+
+  const totalMatches = bankModel.cards.length;
+  const summaryText = totalMatches === bankModel.total
+    ? `Showing all ${bankModel.total} concepts.`
+    : `Showing ${totalMatches} of ${bankModel.total} concepts.`;
+
+  return (
+    <section className="grammar-bank-scene" aria-labelledby="grammar-bank-title">
+      <header className="grammar-bank-topbar">
+        <button
+          type="button"
+          className="btn ghost sm"
+          data-action="grammar-close-concept-bank"
+          onClick={() => actions?.dispatch?.('grammar-close-concept-bank')}
+        >
+          &larr; Back to Grammar Garden
+        </button>
+        <div className="grammar-bank-topbar-copy">
+          <h2 id="grammar-bank-title" className="grammar-bank-title">{GRAMMAR_BANK_HERO.title}</h2>
+          <p className="grammar-bank-subtitle">{GRAMMAR_BANK_HERO.subtitle}</p>
+        </div>
+      </header>
+
+      <AggregateCards counts={bankModel.counts} />
+
+      <div className="grammar-bank-toolbar">
+        <label className="grammar-bank-search">
+          <span className="grammar-bank-search-label">Search concepts</span>
+          <input
+            type="search"
+            name="grammarConceptBankSearch"
+            autoComplete="off"
+            placeholder="Search concepts"
+            value={draftQuery}
+            data-action="grammar-concept-bank-search"
+            aria-label="Search Grammar concepts"
+            onChange={(event) => setDraftQuery(event.currentTarget.value.slice(0, 80))}
+            onBlur={(event) => commitSearch(event.currentTarget.value)}
+            onKeyDown={(event) => {
+              if (event.key !== 'Enter') return;
+              event.preventDefault();
+              commitSearch(event.currentTarget.value);
+            }}
+          />
+        </label>
+        <div className="grammar-bank-filter-stack">
+          <StatusFilterChips
+            counts={bankModel.counts}
+            activeFilter={activeStatus}
+            onChange={handleStatusChange}
+          />
+          <ClusterFilterChips
+            counts={bankModel.clusterCounts}
+            activeFilter={activeCluster}
+            onChange={handleClusterChange}
+          />
+        </div>
+      </div>
+
+      <p className="grammar-bank-summary" role="status">{summaryText}</p>
+
+      <div className="grammar-bank-grid">
+        {bankModel.cards.length
+          ? bankModel.cards.map((card) => (
+            <ConceptCard
+              card={card}
+              onPractise={handlePractise}
+              onOpenDetail={handleOpenDetail}
+              key={card.id}
+            />
+          ))
+          : (
+            <div className="grammar-bank-empty" role="status">{GRAMMAR_BANK_HERO.empty}</div>
+          )
+        }
+      </div>
+
+      {detailCard ? (
+        <GrammarConceptDetailModal card={detailCard} actions={actions} />
+      ) : null}
+    </section>
+  );
+}

--- a/src/subjects/grammar/components/GrammarConceptBankScene.jsx
+++ b/src/subjects/grammar/components/GrammarConceptBankScene.jsx
@@ -23,8 +23,8 @@ import {
 // the Spelling Word Bank pattern so typing does not force every
 // keystroke through the store.
 
-function AggregateCards({ counts }) {
-  const cards = grammarBankAggregateCards(counts);
+function AggregateCards({ counts, total }) {
+  const cards = grammarBankAggregateCards(counts, { total });
   return (
     <div className="grammar-bank-aggregates" role="list">
       {cards.map((card) => (
@@ -202,7 +202,7 @@ export function GrammarConceptBankScene({ grammar, actions }) {
         </div>
       </header>
 
-      <AggregateCards counts={bankModel.counts} />
+      <AggregateCards counts={bankModel.counts} total={bankModel.total} />
 
       <div className="grammar-bank-toolbar">
         <label className="grammar-bank-search">
@@ -251,7 +251,9 @@ export function GrammarConceptBankScene({ grammar, actions }) {
             />
           ))
           : (
-            <div className="grammar-bank-empty" role="status">{GRAMMAR_BANK_HERO.empty}</div>
+            <div className="grammar-bank-empty" role="status">
+              {draftQuery ? GRAMMAR_BANK_HERO.emptyWithSearch : GRAMMAR_BANK_HERO.empty}
+            </div>
           )
         }
       </div>

--- a/src/subjects/grammar/components/GrammarConceptDetailModal.jsx
+++ b/src/subjects/grammar/components/GrammarConceptDetailModal.jsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { createPortal } from 'react-dom';
+import {
+  GRAMMAR_CLUSTER_DISPLAY_NAMES,
+  grammarConceptEvidenceLine,
+  grammarConceptExamples,
+} from './grammar-view-model.js';
+
+// Phase 3 U2: per-concept detail modal. Opens when the learner taps
+// `See example` on a concept card. Focus management:
+//   - `aria-modal="true"` + `role="dialog"` so assistive tech scopes focus.
+//   - Escape key closes the modal.
+//   - On close, focus returns to the triggering card via the
+//     `data-focus-return-id` attribute on the modal wrapper; the JSX scene
+//     reads it after close and restores focus. SSR cannot assert the runtime
+//     focus motion, so this contract is a manual QA gate — the attribute is
+//     the SSR-asserted shim.
+//   - `createPortal` mounts the modal at `document.body` when a DOM is
+//     present so it escapes the surface's layout stacking; during SSR we
+//     return the JSX tree directly so `renderToString` finds it.
+//
+// All copy is child-facing. `Practise this` dispatches `grammar-focus-concept`
+// which module.js routes into a focused practice round. `Close` dispatches
+// `grammar-concept-detail-close`.
+
+export function GrammarConceptDetailModal({ card, actions }) {
+  const triggerReturnId = card?.id ? `grammar-bank-concept-card-${card.id}` : '';
+  const titleId = card?.id ? `grammar-concept-detail-title-${card.id}` : 'grammar-concept-detail-title';
+
+  React.useEffect(() => {
+    if (typeof document === 'undefined' || !card?.id) return undefined;
+    const onKey = (event) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        actions?.dispatch?.('grammar-concept-detail-close');
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [actions, card?.id]);
+
+  React.useEffect(() => {
+    // On unmount (close), return focus to the triggering bank card.
+    return () => {
+      if (typeof document === 'undefined' || !triggerReturnId) return;
+      const el = document.querySelector(`[data-focus-return-id="${triggerReturnId}"]`);
+      if (el && typeof el.focus === 'function') el.focus();
+    };
+  }, [triggerReturnId]);
+
+  if (!card) return null;
+  const examples = grammarConceptExamples(card.id);
+  const evidence = grammarConceptEvidenceLine({ attempts: card.attempts, correct: card.correct });
+  const clusterName = card.clusterName
+    || GRAMMAR_CLUSTER_DISPLAY_NAMES[card.cluster]
+    || '';
+
+  const onScrimClick = (event) => {
+    if (event.target?.closest?.('.grammar-bank-modal')) return;
+    actions?.dispatch?.('grammar-concept-detail-close');
+  };
+
+  const onCloseClick = () => actions?.dispatch?.('grammar-concept-detail-close');
+  const onPractiseClick = () => actions?.dispatch?.('grammar-focus-concept', { conceptId: card.id });
+
+  const modal = (
+    <div
+      className="grammar-bank-modal-scrim"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      data-focus-trigger-id={triggerReturnId}
+      onClick={onScrimClick}
+    >
+      <div className="grammar-bank-modal-backdrop" aria-hidden="true" />
+      <div className="grammar-bank-modal" data-concept-id={card.id}>
+        <header className="grammar-bank-modal-head">
+          <div className="grammar-bank-modal-head-main">
+            <p className="grammar-bank-modal-eyebrow">{clusterName ? `${clusterName} cluster` : 'Grammar concept'}</p>
+            <h2 id={titleId} className="grammar-bank-modal-title">{card.name}</h2>
+            <p className={`grammar-bank-modal-status tone-${card.tone}`}>{card.childLabel}</p>
+          </div>
+          <button
+            type="button"
+            className="grammar-bank-modal-close"
+            data-action="grammar-concept-detail-close"
+            aria-label="Close concept details"
+            onClick={onCloseClick}
+          >
+            &times;
+          </button>
+        </header>
+        <div className="grammar-bank-modal-body">
+          <section className="grammar-bank-modal-section">
+            <p className="grammar-bank-modal-section-label">What it is</p>
+            <p className="grammar-bank-modal-summary">{card.summary || 'No summary available yet.'}</p>
+          </section>
+          <section className="grammar-bank-modal-section">
+            <p className="grammar-bank-modal-section-label">Example sentences</p>
+            {examples.length ? (
+              <ul className="grammar-bank-modal-examples">
+                {examples.map((sentence, index) => (
+                  <li className="grammar-bank-modal-example" key={`${card.id}-ex-${index}`}>{sentence}</li>
+                ))}
+              </ul>
+            ) : (
+              <p className="grammar-bank-modal-empty">No examples on file for this concept yet.</p>
+            )}
+          </section>
+          <section className="grammar-bank-modal-section">
+            <p className="grammar-bank-modal-section-label">How you are doing</p>
+            <p className="grammar-bank-modal-evidence">{evidence}</p>
+          </section>
+        </div>
+        <footer className="grammar-bank-modal-actions">
+          <button
+            type="button"
+            className="btn primary"
+            data-action="grammar-focus-concept"
+            data-concept-id={card.id}
+            onClick={onPractiseClick}
+          >
+            Practise this
+          </button>
+          <button
+            type="button"
+            className="btn ghost"
+            data-action="grammar-concept-detail-close"
+            onClick={onCloseClick}
+          >
+            Close
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+
+  if (typeof document === 'undefined' || !document.body) return modal;
+  return createPortal(modal, document.body);
+}

--- a/src/subjects/grammar/components/GrammarPracticeSurface.jsx
+++ b/src/subjects/grammar/components/GrammarPracticeSurface.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { GrammarAnalyticsScene } from './GrammarAnalyticsScene.jsx';
+import { GrammarConceptBankScene } from './GrammarConceptBankScene.jsx';
 import { GrammarSessionScene } from './GrammarSessionScene.jsx';
 import { GrammarSetupScene } from './GrammarSetupScene.jsx';
 import { GrammarSummaryScene } from './GrammarSummaryScene.jsx';
@@ -8,11 +9,10 @@ import { normaliseGrammarRewardState } from '../../../platform/game/monster-syst
 
 const MONSTER_CODEX_SYSTEM_ID = 'monster-codex';
 
-// Phase 3 U1 removes the adult-diagnostic roadmap placeholders. The
-// U6b Writing Try scene and U2 Grammar Bank scene take over the slots
-// with real child-facing scenes. Until those ship, U1 routes their
-// phase transitions through a minimal stub below so the state machine
-// remains safe and a "return" button lets the learner back out.
+// Phase 3 U2 replaces the Grammar Bank placeholder stub with the real
+// `GrammarConceptBankScene`. The Writing Try scene (`GrammarTransferScene`)
+// still ships as a placeholder until U6b lands; until then, U1's stub
+// holds the phase transition safe with a way back to the dashboard.
 
 function selectedLearner(appState) {
   const learnerId = appState?.learners?.selectedId || '';
@@ -55,26 +55,6 @@ function resolveGrammarRewardState({ grammar, learner, repositories }) {
   const normalisedPersisted = normaliseGrammarRewardState(persistedState);
   if (hasGrammarRewardProgress(normalisedPersisted)) return normalisedPersisted;
   return Object.keys(normalisedProjected).length ? normalisedProjected : normalisedPersisted;
-}
-
-function GrammarBankPlaceholderScene({ actions }) {
-  // U1 wires the "Grammar Bank" primary mode card; U2 ships the real scene.
-  // Until then, this stub honours the state transition and offers a way back
-  // so the learner is never stuck.
-  return (
-    <section className="grammar-bank-placeholder" aria-labelledby="grammar-bank-placeholder-title">
-      <h2 id="grammar-bank-placeholder-title">Grammar Bank</h2>
-      <p>Your full concept bank lands here soon — browse all 18 grammar concepts with child-friendly statuses.</p>
-      <button
-        type="button"
-        className="btn primary"
-        data-action="grammar-back"
-        onClick={() => actions.dispatch('grammar-back')}
-      >
-        Back to Grammar Garden
-      </button>
-    </section>
-  );
 }
 
 function GrammarTransferPlaceholderScene({ actions }) {
@@ -125,7 +105,7 @@ export function GrammarPracticeSurface({
   if (grammar.phase === 'bank') {
     return (
       <div className="grammar-surface">
-        <GrammarBankPlaceholderScene {...shared} />
+        <GrammarConceptBankScene {...shared} />
       </div>
     );
   }

--- a/src/subjects/grammar/components/grammar-view-model.js
+++ b/src/subjects/grammar/components/grammar-view-model.js
@@ -99,6 +99,158 @@ export const GRAMMAR_DASHBOARD_HERO = Object.freeze({
   subtitle: "One short round. Fix tricky sentences. Grow your Grammar creatures.",
 });
 
+// Hero copy for the Grammar Bank scene. Child-facing only — kept frozen so
+// U10's absence sweep iterates a single source of truth. Every concept card
+// that renders here carries one short example sentence drawn from
+// `GRAMMAR_CONCEPT_EXAMPLES` below.
+export const GRAMMAR_BANK_HERO = Object.freeze({
+  title: 'Grammar Bank',
+  subtitle: 'Browse every concept. Tap a card to see examples or practise five questions.',
+  empty: 'No concepts match your filters. Try another status or cluster.',
+});
+
+// Frozen map of child-facing labels for each Grammar Bank status filter. The
+// scene iterates `GRAMMAR_BANK_STATUS_CHIPS` so the order stays stable across
+// renders and matches the plan ordering: All · Due · Trouble · Learning ·
+// Nearly secure · Secure · New.
+export const GRAMMAR_BANK_STATUS_CHIPS = Object.freeze([
+  Object.freeze({ id: 'all', label: 'All', tone: 'all' }),
+  Object.freeze({ id: 'due', label: 'Due', tone: 'due' }),
+  Object.freeze({ id: 'trouble', label: 'Trouble', tone: 'trouble' }),
+  Object.freeze({ id: 'learning', label: 'Learning', tone: 'learning' }),
+  Object.freeze({ id: 'nearly-secure', label: 'Nearly secure', tone: 'nearly-secure' }),
+  Object.freeze({ id: 'secure', label: 'Secure', tone: 'secure' }),
+  Object.freeze({ id: 'new', label: 'New', tone: 'new' }),
+]);
+
+// Frozen map of cluster filter chips. Order matches the plan: All ·
+// Bracehart · Chronalyx · Couronnail · Concordium. Child-facing copy only —
+// reserved monster ids (Glossbloom / Loomrill / Mirrane) never appear here.
+export const GRAMMAR_BANK_CLUSTER_CHIPS = Object.freeze([
+  Object.freeze({ id: 'all', label: 'All clusters' }),
+  Object.freeze({ id: 'bracehart', label: 'Bracehart' }),
+  Object.freeze({ id: 'chronalyx', label: 'Chronalyx' }),
+  Object.freeze({ id: 'couronnail', label: 'Couronnail' }),
+  Object.freeze({ id: 'concordium', label: 'Concordium' }),
+]);
+
+// Child-facing display names for the active Grammar clusters. Used by the
+// concept card badge. Reserved monsters are intentionally absent so a rogue
+// concept→cluster mapping cannot surface a retired name as a badge.
+export const GRAMMAR_CLUSTER_DISPLAY_NAMES = Object.freeze({
+  bracehart: 'Bracehart',
+  chronalyx: 'Chronalyx',
+  couronnail: 'Couronnail',
+  concordium: 'Concordium',
+});
+
+// One short KS2-appropriate example sentence per Grammar concept. The bank
+// card surfaces the first example; the detail modal surfaces up to two.
+// Examples are written as full sentences so a learner can read them aloud.
+// Keep sentences short, concrete, and free of adult-diagnostic language.
+export const GRAMMAR_CONCEPT_EXAMPLES = Object.freeze({
+  sentence_functions: Object.freeze([
+    'Have you finished your homework?',
+    'Shut the gate before the dog escapes!',
+  ]),
+  word_classes: Object.freeze([
+    'The small fox ran quickly across the field.',
+    'She quietly opened the ancient wooden box.',
+  ]),
+  noun_phrases: Object.freeze([
+    'A tall tree with silver bark stood by the lake.',
+    'The excited children on the beach built a sandcastle.',
+  ]),
+  adverbials: Object.freeze([
+    'After lunch, we walked to the park.',
+    'Suddenly, the lights went out.',
+  ]),
+  clauses: Object.freeze([
+    'We stayed inside because the rain was heavy.',
+    'Although it was late, Ben kept reading.',
+  ]),
+  relative_clauses: Object.freeze([
+    'The dog, which was muddy, ran inside.',
+    'My friend who plays the piano lives next door.',
+  ]),
+  tense_aspect: Object.freeze([
+    'I have finished my book.',
+    'They were playing football when the bell rang.',
+  ]),
+  standard_english: Object.freeze([
+    'We were late for the bus.',
+    'She did her homework before tea.',
+  ]),
+  pronouns_cohesion: Object.freeze([
+    'Maya picked up the kitten and stroked it gently.',
+    'The children waved at the bus driver, who waved back.',
+  ]),
+  formality: Object.freeze([
+    'May I leave the room, please?',
+    'I would be grateful if you could reply soon.',
+  ]),
+  active_passive: Object.freeze([
+    'The chef baked the cake. (active)',
+    'The cake was baked by the chef. (passive)',
+  ]),
+  subject_object: Object.freeze([
+    'The cat chased the mouse.',
+    'Jamal kicked the ball into the net.',
+  ]),
+  modal_verbs: Object.freeze([
+    'You should wear a coat.',
+    'We might visit Gran on Saturday.',
+  ]),
+  parenthesis_commas: Object.freeze([
+    'The garden, full of roses, smelled sweet.',
+    'Our teacher (who is very kind) helped us tidy up.',
+  ]),
+  speech_punctuation: Object.freeze([
+    '"Where are my shoes?" asked Leo.',
+    'Sara said, "I will meet you at the gate."',
+  ]),
+  apostrophes_possession: Object.freeze([
+    "The girls' coats were on the hooks.",
+    "Tom's bag fell off the chair.",
+  ]),
+  boundary_punctuation: Object.freeze([
+    'Bring these items: a pen, a ruler and a book.',
+    'The sky turned dark; the storm was close.',
+  ]),
+  hyphen_ambiguity: Object.freeze([
+    'Please resign the letter and send it back.',
+    'The man-eating shark circled the boat.',
+  ]),
+});
+
+// Returns the first example sentence for a concept, or an empty string if no
+// example exists. Safe on unknown ids.
+export function grammarConceptPrimaryExample(conceptId) {
+  if (typeof conceptId !== 'string' || !conceptId) return '';
+  const entries = GRAMMAR_CONCEPT_EXAMPLES[conceptId];
+  return Array.isArray(entries) && entries.length ? entries[0] : '';
+}
+
+// Returns the full example list for a concept (up to two sentences) or an
+// empty array. Used by the detail modal.
+export function grammarConceptExamples(conceptId) {
+  if (typeof conceptId !== 'string' || !conceptId) return [];
+  const entries = GRAMMAR_CONCEPT_EXAMPLES[conceptId];
+  return Array.isArray(entries) ? entries.slice(0, 2) : [];
+}
+
+// Child-facing copy for concept attempt evidence. Returns a single short
+// sentence like "You've answered 3 of these. 2 were correct." Hides raw
+// percentages — learners see whole-number tallies only.
+export function grammarConceptEvidenceLine({ attempts = 0, correct = 0 } = {}) {
+  const safeAttempts = Number.isFinite(Number(attempts)) && Number(attempts) > 0 ? Math.floor(Number(attempts)) : 0;
+  const safeCorrect = Number.isFinite(Number(correct)) && Number(correct) > 0 ? Math.floor(Number(correct)) : 0;
+  if (safeAttempts === 0) return 'You have not answered any of these yet.';
+  const noun = safeAttempts === 1 ? 'answer' : 'answers';
+  const correctWord = safeCorrect === 1 ? 'was correct' : 'were correct';
+  return `You have ${safeAttempts} ${noun} on this concept. ${safeCorrect} ${correctWord}.`;
+}
+
 // Frozen order of child-facing Grammar monsters. Post-U0 the active roster
 // is Bracehart, Chronalyx, Couronnail (3 direct clusters) plus Concordium
 // (whole-Grammar aggregate). Retired ids Glossbloom / Loomrill / Mirrane
@@ -383,6 +535,8 @@ function defaultConceptMetadata(conceptId) {
 function buildBankCard(concept) {
   const metadata = defaultConceptMetadata(concept?.id || '');
   const label = childLabelForConcept(concept);
+  const cluster = grammarMonsterClusterForConcept(metadata.id);
+  const examples = grammarConceptExamples(metadata.id);
   return {
     id: metadata.id,
     name: concept?.name || metadata.name,
@@ -391,7 +545,10 @@ function buildBankCard(concept) {
     label,
     childLabel: grammarChildConfidenceLabel({ label }),
     tone: grammarChildConfidenceTone(label),
-    cluster: grammarMonsterClusterForConcept(metadata.id),
+    cluster,
+    clusterName: GRAMMAR_CLUSTER_DISPLAY_NAMES[cluster] || '',
+    example: examples[0] || '',
+    examples,
     attempts: safeNumber(concept?.attempts, 0),
     correct: safeNumber(concept?.correct, 0),
     wrong: safeNumber(concept?.wrong, 0),
@@ -433,6 +590,23 @@ function bankCountsFromCards(cards) {
 }
 
 /**
+ * Builds the Grammar Bank aggregate summary cards (Answered totals across
+ * every concept, broken out by status). Counts are whole integers — no
+ * percentages — so a learner sees plain tallies.
+ */
+export function grammarBankAggregateCards(counts = {}) {
+  const safe = counts && typeof counts === 'object' && !Array.isArray(counts) ? counts : {};
+  return Object.freeze([
+    Object.freeze({ id: 'total', label: 'Total', value: safeNumber(safe.all, 0), sub: 'Grammar concepts tracked' }),
+    Object.freeze({ id: 'secure', label: 'Secure', value: safeNumber(safe.secure, 0), sub: 'You own these' }),
+    Object.freeze({ id: 'nearly-secure', label: 'Nearly secure', value: safeNumber(safe['nearly-secure'], 0), sub: 'Almost there' }),
+    Object.freeze({ id: 'trouble', label: 'Trouble', value: safeNumber(safe.trouble, 0), sub: 'Fix these next' }),
+    Object.freeze({ id: 'learning', label: 'Learning', value: safeNumber(safe.learning, 0), sub: 'Building up' }),
+    Object.freeze({ id: 'new', label: 'New', value: safeNumber(safe.new, 0), sub: 'Not yet introduced' }),
+  ]);
+}
+
+/**
  * Builds the Grammar Bank view-model. Filters by `statusFilter` and
  * `clusterFilter`, narrows by `query` (searches concept name, summary,
  * domain, example). Always returns the full 18 concepts when
@@ -454,15 +628,33 @@ export function buildGrammarBankModel(grammar, { statusFilter = 'all', clusterFi
   });
 
   const normalisedQuery = normaliseSearchText(query);
+  const clusterScopedCards = allCards.filter((card) => {
+    if (!clusterFilter || clusterFilter === 'all') return true;
+    if (clusterFilter === 'concordium') return true;
+    return card.cluster === clusterFilter;
+  });
   const filteredCards = allCards.filter((card) => bankCardMatchesFilter(card, {
     statusFilter,
     clusterFilter,
     query: normalisedQuery,
   }));
 
+  // Status-chip counts reflect the currently selected cluster scope so the
+  // numbers next to each chip match what clicking the chip would reveal.
+  // Cluster-chip counts reflect the full concept list so switching clusters
+  // always shows the total for that cluster.
+  const clusterCounts = {
+    all: allCards.length,
+    bracehart: allCards.filter((card) => card.cluster === 'bracehart').length,
+    chronalyx: allCards.filter((card) => card.cluster === 'chronalyx').length,
+    couronnail: allCards.filter((card) => card.cluster === 'couronnail').length,
+    concordium: allCards.length, // aggregate view shows every concept
+  };
+
   return {
     cards: filteredCards,
-    counts: bankCountsFromCards(allCards),
+    counts: bankCountsFromCards(clusterScopedCards),
+    clusterCounts,
     total: allCards.length,
   };
 }

--- a/src/subjects/grammar/components/grammar-view-model.js
+++ b/src/subjects/grammar/components/grammar-view-model.js
@@ -107,6 +107,7 @@ export const GRAMMAR_BANK_HERO = Object.freeze({
   title: 'Grammar Bank',
   subtitle: 'Browse every concept. Tap a card to see examples or practise five questions.',
   empty: 'No concepts match your filters. Try another status or cluster.',
+  emptyWithSearch: 'No concepts match. Try clearing your search or changing the filters.',
 });
 
 // Frozen map of child-facing labels for each Grammar Bank status filter. The
@@ -218,8 +219,8 @@ export const GRAMMAR_CONCEPT_EXAMPLES = Object.freeze({
     'The sky turned dark; the storm was close.',
   ]),
   hyphen_ambiguity: Object.freeze([
-    'Please resign the letter and send it back.',
     'The man-eating shark circled the boat.',
+    'Please re-sign the letter and send it back.',
   ]),
 });
 
@@ -592,12 +593,18 @@ function bankCountsFromCards(cards) {
 /**
  * Builds the Grammar Bank aggregate summary cards (Answered totals across
  * every concept, broken out by status). Counts are whole integers — no
- * percentages — so a learner sees plain tallies.
+ * percentages — so a learner sees plain tallies. `total` is the globally
+ * stable concept count (always 18 for the KS2 roster); the scene passes the
+ * `total` from `buildGrammarBankModel` so the Total card stays stable even
+ * when a cluster filter narrows the other tallies.
  */
-export function grammarBankAggregateCards(counts = {}) {
+export function grammarBankAggregateCards(counts = {}, { total } = {}) {
   const safe = counts && typeof counts === 'object' && !Array.isArray(counts) ? counts : {};
+  const totalValue = Number.isFinite(Number(total)) && Number(total) >= 0
+    ? Math.floor(Number(total))
+    : safeNumber(safe.all, 0);
   return Object.freeze([
-    Object.freeze({ id: 'total', label: 'Total', value: safeNumber(safe.all, 0), sub: 'Grammar concepts tracked' }),
+    Object.freeze({ id: 'total', label: 'Total', value: totalValue, sub: 'Grammar concepts tracked' }),
     Object.freeze({ id: 'secure', label: 'Secure', value: safeNumber(safe.secure, 0), sub: 'You own these' }),
     Object.freeze({ id: 'nearly-secure', label: 'Nearly secure', value: safeNumber(safe['nearly-secure'], 0), sub: 'Almost there' }),
     Object.freeze({ id: 'trouble', label: 'Trouble', value: safeNumber(safe.trouble, 0), sub: 'Fix these next' }),

--- a/src/subjects/grammar/metadata.js
+++ b/src/subjects/grammar/metadata.js
@@ -349,6 +349,36 @@ function normaliseGrammarTransferEvidenceEntry(raw) {
   };
 }
 
+// Phase 3 U2: the Grammar Bank scene carries transient UI state — active
+// status filter, active cluster filter, search query, currently open concept
+// detail modal id. We keep it inside the Grammar read model (rather than the
+// platform-level `transientUi`) because every other Grammar UI slice already
+// lives here; mixing locations would make the dispatcher asymmetric. Valid
+// filter ids are enforced by the U8 frozen sets; unknown ids collapse to
+// `all`. The search query is capped at 80 characters to mirror Spelling.
+const VALID_GRAMMAR_BANK_STATUS_FILTERS = new Set(['all', 'due', 'trouble', 'learning', 'nearly-secure', 'secure', 'new']);
+const VALID_GRAMMAR_BANK_CLUSTER_FILTERS = new Set(['all', 'bracehart', 'chronalyx', 'couronnail', 'concordium']);
+const EMPTY_GRAMMAR_BANK_UI = Object.freeze({
+  statusFilter: 'all',
+  clusterFilter: 'all',
+  query: '',
+  detailConceptId: '',
+});
+
+function normaliseGrammarBankUi(raw) {
+  if (!isPlainObject(raw)) return { ...EMPTY_GRAMMAR_BANK_UI };
+  const rawStatus = typeof raw.statusFilter === 'string' ? raw.statusFilter : 'all';
+  const rawCluster = typeof raw.clusterFilter === 'string' ? raw.clusterFilter : 'all';
+  const rawQuery = typeof raw.query === 'string' ? raw.query : '';
+  const rawDetail = typeof raw.detailConceptId === 'string' ? raw.detailConceptId : '';
+  return {
+    statusFilter: VALID_GRAMMAR_BANK_STATUS_FILTERS.has(rawStatus) ? rawStatus : 'all',
+    clusterFilter: VALID_GRAMMAR_BANK_CLUSTER_FILTERS.has(rawCluster) ? rawCluster : 'all',
+    query: rawQuery.slice(0, 80),
+    detailConceptId: rawDetail.slice(0, 64),
+  };
+}
+
 function normaliseGrammarTransferLane(raw) {
   if (!isPlainObject(raw)) {
     return {
@@ -583,6 +613,10 @@ export function normaliseGrammarReadModel(rawValue = {}, learnerId = '') {
     },
     aiEnrichment: normaliseAiEnrichment(raw.aiEnrichment),
     transferLane: normaliseGrammarTransferLane(raw.transferLane),
+    // Phase 3 U2: persist the Grammar Bank filter + search state inside the
+    // read model so filter selections survive StrictMode double-renders and
+    // round-trip through the normaliser without stomping unrelated fields.
+    bank: normaliseGrammarBankUi(raw.bank),
     projections: raw.projections || null,
     pendingCommand: raw.pendingCommand || '',
     error: typeof raw.error === 'string' ? raw.error : '',
@@ -590,6 +624,12 @@ export function normaliseGrammarReadModel(rawValue = {}, learnerId = '') {
 }
 
 export { EMPTY_TRANSFER_LANE, normaliseGrammarTransferLane };
+export {
+  EMPTY_GRAMMAR_BANK_UI,
+  VALID_GRAMMAR_BANK_STATUS_FILTERS,
+  VALID_GRAMMAR_BANK_CLUSTER_FILTERS,
+  normaliseGrammarBankUi,
+};
 
 export function groupedGrammarConcepts(concepts = []) {
   const groups = new Map();

--- a/src/subjects/grammar/module.js
+++ b/src/subjects/grammar/module.js
@@ -1,6 +1,9 @@
 import {
   DEFAULT_GRAMMAR_PREFS,
+  EMPTY_GRAMMAR_BANK_UI,
   GRAMMAR_SUBJECT_ID,
+  VALID_GRAMMAR_BANK_CLUSTER_FILTERS,
+  VALID_GRAMMAR_BANK_STATUS_FILTERS,
   normaliseGrammarReadModel,
 } from './metadata.js';
 import { normaliseGrammarSpeechRate } from './speech.js';
@@ -286,6 +289,135 @@ export const grammarModule = {
         error: '',
       }));
       return true;
+    }
+
+    // Phase 3 U2: Grammar Bank dispatchers. All four mutate the `bank` UI
+    // slice only — never the session, feedback, summary, or mastery state —
+    // so they are safe to fire without a pendingCommand guard. The
+    // normaliser re-validates the filter / cluster ids on every round-trip.
+
+    if (action === 'grammar-close-concept-bank') {
+      return resetToDashboard(context);
+    }
+
+    if (action === 'grammar-concept-bank-filter') {
+      const raw = String(context.data?.value || 'all');
+      const next = VALID_GRAMMAR_BANK_STATUS_FILTERS.has(raw) ? raw : 'all';
+      context.store.updateSubjectUi(GRAMMAR_SUBJECT_ID, (current) => {
+        const normalised = normaliseGrammarReadModel(current, learnerId);
+        return {
+          ...normalised,
+          bank: { ...normalised.bank, statusFilter: next },
+        };
+      });
+      return true;
+    }
+
+    if (action === 'grammar-concept-bank-cluster-filter') {
+      const raw = String(context.data?.value || 'all');
+      const next = VALID_GRAMMAR_BANK_CLUSTER_FILTERS.has(raw) ? raw : 'all';
+      context.store.updateSubjectUi(GRAMMAR_SUBJECT_ID, (current) => {
+        const normalised = normaliseGrammarReadModel(current, learnerId);
+        return {
+          ...normalised,
+          bank: { ...normalised.bank, clusterFilter: next },
+        };
+      });
+      return true;
+    }
+
+    if (action === 'grammar-concept-bank-search') {
+      const raw = String(context.data?.value ?? '').slice(0, 80);
+      context.store.updateSubjectUi(GRAMMAR_SUBJECT_ID, (current) => {
+        const normalised = normaliseGrammarReadModel(current, learnerId);
+        return {
+          ...normalised,
+          bank: { ...normalised.bank, query: raw },
+        };
+      });
+      return true;
+    }
+
+    if (action === 'grammar-concept-detail-open') {
+      const raw = String(context.data?.conceptId || context.data?.value || '').slice(0, 64);
+      if (!raw) return true;
+      context.store.updateSubjectUi(GRAMMAR_SUBJECT_ID, (current) => {
+        const normalised = normaliseGrammarReadModel(current, learnerId);
+        return {
+          ...normalised,
+          bank: { ...normalised.bank, detailConceptId: raw },
+        };
+      });
+      return true;
+    }
+
+    if (action === 'grammar-concept-detail-close') {
+      context.store.updateSubjectUi(GRAMMAR_SUBJECT_ID, (current) => {
+        const normalised = normaliseGrammarReadModel(current, learnerId);
+        return {
+          ...normalised,
+          bank: { ...normalised.bank, detailConceptId: '' },
+        };
+      });
+      return true;
+    }
+
+    if (action === 'grammar-focus-concept') {
+      // Dispatched from bank concept cards + detail modal. Routes into a
+      // focused practice round by mirroring the existing `grammar-set-focus`
+      // + `grammar-start` combination (with a `learn` mode fallback so
+      // `grammarModeUsesFocus` picks up the focusConceptId on start). The
+      // `pendingCommand` guard prevents double-tap races.
+      if (ui.pendingCommand) return true;
+      const conceptId = String(context.data?.conceptId || context.data?.value || '').slice(0, 64);
+      if (!conceptId) return true;
+
+      // Persist the focus preference; fall back to `learn` mode so the start
+      // payload carries the focusConceptId (smart / mini-set modes drop
+      // focus via `grammarModeUsesFocus`). The bank UI slice is cleared so
+      // reopening the bank does not re-apply stale filter state from the
+      // previous visit.
+      const existingMode = ui.prefs?.mode || DEFAULT_GRAMMAR_PREFS.mode;
+      const targetMode = grammarModeUsesFocus(existingMode) ? existingMode : 'learn';
+      const prefsPatch = { mode: targetMode, focusConceptId: conceptId };
+      if (service?.savePrefs) {
+        const nextPrefs = service.savePrefs(learnerId, prefsPatch);
+        context.store.updateSubjectUi(GRAMMAR_SUBJECT_ID, (current) => {
+          const normalised = normaliseGrammarReadModel(current, learnerId);
+          return {
+            ...normalised,
+            prefs: { ...normalised.prefs, ...(nextPrefs || prefsPatch) },
+            bank: { ...EMPTY_GRAMMAR_BANK_UI },
+            phase: 'dashboard',
+            pendingCommand: '',
+            error: '',
+          };
+        });
+      } else {
+        // Remote-save path: close the bank first, then fire save-prefs. The
+        // follow-up start-session fires after the prefs round-trip lands.
+        context.store.updateSubjectUi(GRAMMAR_SUBJECT_ID, (current) => {
+          const normalised = normaliseGrammarReadModel(current, learnerId);
+          return {
+            ...normalised,
+            bank: { ...EMPTY_GRAMMAR_BANK_UI },
+            phase: 'dashboard',
+            error: '',
+          };
+        });
+        sendGrammarCommand(context, 'save-prefs', { prefs: prefsPatch });
+      }
+
+      const payload = {
+        mode: targetMode,
+        focusConceptId: conceptId,
+        roundLength: ui.prefs?.roundLength || DEFAULT_GRAMMAR_PREFS.roundLength,
+        goalType: ui.prefs?.goalType || DEFAULT_GRAMMAR_PREFS.goalType,
+        allowTeachingItems: ui.prefs?.allowTeachingItems === true,
+        showDomainBeforeAnswer: ui.prefs?.showDomainBeforeAnswer !== false,
+      };
+      if (service?.startSession) return applyLocalTransition(context, service.startSession(learnerId, payload));
+      return sendGrammarCommand(context, 'start-session', payload);
     }
 
     if (action === 'grammar-open-transfer') {

--- a/src/subjects/grammar/module.js
+++ b/src/subjects/grammar/module.js
@@ -98,7 +98,7 @@ function applyRemoteReadModel(context, response, { learnerId } = {}) {
   context.store.reloadFromRepositories?.({ preserveRoute: true });
 }
 
-function sendGrammarCommand(context, command, payload = {}, { translateError } = {}) {
+function sendGrammarCommand(context, command, payload = {}, { translateError, onResolved } = {}) {
   const learnerId = selectedLearnerId(context);
   if (!learnerId) return true;
   const ui = selectedGrammarUi(context);
@@ -126,6 +126,11 @@ function sendGrammarCommand(context, command, payload = {}, { translateError } =
     payload,
   }).then((response) => {
     applyRemoteReadModel(context, response, { learnerId });
+    if (typeof onResolved === 'function') {
+      try { onResolved(response); } catch (callbackError) {
+        globalThis.console?.warn?.('Grammar command onResolved failed.', callbackError);
+      }
+    }
   }).catch((error) => {
     globalThis.console?.warn?.('Grammar command failed.', error);
     const fallback = error?.payload?.message || error?.message || 'The Grammar command could not be completed.';
@@ -283,11 +288,17 @@ export const grammarModule = {
     if (action === 'grammar-open-concept-bank') {
       if (ui.pendingCommand) return true;
       if (ui.phase === 'session' || ui.phase === 'feedback') return true;
-      context.store.updateSubjectUi(GRAMMAR_SUBJECT_ID, (current) => ({
-        ...normaliseGrammarReadModel(current, learnerId),
-        phase: 'bank',
-        error: '',
-      }));
+      context.store.updateSubjectUi(GRAMMAR_SUBJECT_ID, (current) => {
+        const normalised = normaliseGrammarReadModel(current, learnerId);
+        return {
+          ...normalised,
+          phase: 'bank',
+          // Clear any stale detail modal id from the previous bank visit so
+          // reopening never auto-pops the modal.
+          bank: { ...normalised.bank, detailConceptId: '' },
+          error: '',
+        };
+      });
       return true;
     }
 
@@ -380,6 +391,14 @@ export const grammarModule = {
       const existingMode = ui.prefs?.mode || DEFAULT_GRAMMAR_PREFS.mode;
       const targetMode = grammarModeUsesFocus(existingMode) ? existingMode : 'learn';
       const prefsPatch = { mode: targetMode, focusConceptId: conceptId };
+      const payload = {
+        mode: targetMode,
+        focusConceptId: conceptId,
+        roundLength: ui.prefs?.roundLength || DEFAULT_GRAMMAR_PREFS.roundLength,
+        goalType: ui.prefs?.goalType || DEFAULT_GRAMMAR_PREFS.goalType,
+        allowTeachingItems: ui.prefs?.allowTeachingItems === true,
+        showDomainBeforeAnswer: ui.prefs?.showDomainBeforeAnswer !== false,
+      };
       if (service?.savePrefs) {
         const nextPrefs = service.savePrefs(learnerId, prefsPatch);
         context.store.updateSubjectUi(GRAMMAR_SUBJECT_ID, (current) => {
@@ -393,31 +412,32 @@ export const grammarModule = {
             error: '',
           };
         });
-      } else {
-        // Remote-save path: close the bank first, then fire save-prefs. The
-        // follow-up start-session fires after the prefs round-trip lands.
-        context.store.updateSubjectUi(GRAMMAR_SUBJECT_ID, (current) => {
-          const normalised = normaliseGrammarReadModel(current, learnerId);
-          return {
-            ...normalised,
-            bank: { ...EMPTY_GRAMMAR_BANK_UI },
-            phase: 'dashboard',
-            error: '',
-          };
-        });
-        sendGrammarCommand(context, 'save-prefs', { prefs: prefsPatch });
+        if (service?.startSession) return applyLocalTransition(context, service.startSession(learnerId, payload));
+        return sendGrammarCommand(context, 'start-session', payload);
       }
 
-      const payload = {
-        mode: targetMode,
-        focusConceptId: conceptId,
-        roundLength: ui.prefs?.roundLength || DEFAULT_GRAMMAR_PREFS.roundLength,
-        goalType: ui.prefs?.goalType || DEFAULT_GRAMMAR_PREFS.goalType,
-        allowTeachingItems: ui.prefs?.allowTeachingItems === true,
-        showDomainBeforeAnswer: ui.prefs?.showDomainBeforeAnswer !== false,
-      };
-      if (service?.startSession) return applyLocalTransition(context, service.startSession(learnerId, payload));
-      return sendGrammarCommand(context, 'start-session', payload);
+      // Remote-save path: close the bank first, then fire save-prefs and chain
+      // start-session inside its resolve callback. The earlier version fell
+      // through to a second sendGrammarCommand call that was silently no-op'd
+      // by the `pendingCommand` guard at the top of `sendGrammarCommand`.
+      context.store.updateSubjectUi(GRAMMAR_SUBJECT_ID, (current) => {
+        const normalised = normaliseGrammarReadModel(current, learnerId);
+        return {
+          ...normalised,
+          bank: { ...EMPTY_GRAMMAR_BANK_UI },
+          phase: 'dashboard',
+          error: '',
+        };
+      });
+      return sendGrammarCommand(context, 'save-prefs', { prefs: prefsPatch }, {
+        onResolved: () => {
+          if (service?.startSession) {
+            applyLocalTransition(context, service.startSession(learnerId, payload));
+            return;
+          }
+          sendGrammarCommand(context, 'start-session', payload);
+        },
+      });
     }
 
     if (action === 'grammar-open-transfer') {

--- a/tests/grammar-ui-model.test.js
+++ b/tests/grammar-ui-model.test.js
@@ -764,6 +764,33 @@ test('U2 view-model: grammarBankAggregateCards returns frozen cards in the expec
   assert.equal(cards[2].value, 3);
 });
 
+test('U2 follower: grammarBankAggregateCards Total card uses override total when counts narrow to a cluster', async () => {
+  const { grammarBankAggregateCards } = await import('../src/subjects/grammar/components/grammar-view-model.js');
+  // Cluster-scoped counts: only 6 concepts in view, but the global total is 18.
+  const counts = { all: 6, secure: 1, 'nearly-secure': 1, trouble: 1, learning: 1, new: 2, due: 2 };
+  const cards = grammarBankAggregateCards(counts, { total: 18 });
+  // Total stays globally stable; the other tallies still reflect the scope.
+  assert.equal(cards[0].value, 18);
+  assert.equal(cards[0].sub, 'Grammar concepts tracked');
+  assert.equal(cards[1].value, 1);
+});
+
+test('U2 follower: GRAMMAR_CONCEPT_EXAMPLES.hyphen_ambiguity primary example is the clear positive case', async () => {
+  const { GRAMMAR_CONCEPT_EXAMPLES, grammarConceptPrimaryExample } = await import('../src/subjects/grammar/components/grammar-view-model.js');
+  // [0] must be the clear positive "man-eating shark" example, [1] the re-sign one.
+  assert.equal(GRAMMAR_CONCEPT_EXAMPLES.hyphen_ambiguity[0], 'The man-eating shark circled the boat.');
+  assert.equal(GRAMMAR_CONCEPT_EXAMPLES.hyphen_ambiguity[1], 'Please re-sign the letter and send it back.');
+  assert.equal(grammarConceptPrimaryExample('hyphen_ambiguity'), 'The man-eating shark circled the boat.');
+});
+
+test('U2 follower: GRAMMAR_BANK_HERO exposes a search-aware emptyWithSearch copy', async () => {
+  const { GRAMMAR_BANK_HERO } = await import('../src/subjects/grammar/components/grammar-view-model.js');
+  assert.equal(typeof GRAMMAR_BANK_HERO.emptyWithSearch, 'string');
+  assert.ok(GRAMMAR_BANK_HERO.emptyWithSearch.length > 0);
+  assert.match(GRAMMAR_BANK_HERO.emptyWithSearch, /search/i);
+  assert.notEqual(GRAMMAR_BANK_HERO.emptyWithSearch, GRAMMAR_BANK_HERO.empty);
+});
+
 test('U2 view-model: buildGrammarBankModel exposes clusterCounts for chip badges', async () => {
   const { buildGrammarBankModel } = await import('../src/subjects/grammar/components/grammar-view-model.js');
   const model = buildGrammarBankModel({}, { statusFilter: 'all', clusterFilter: 'all', query: '' });

--- a/tests/grammar-ui-model.test.js
+++ b/tests/grammar-ui-model.test.js
@@ -683,3 +683,93 @@ test('U8 safety: grammar-view-model.js does not import react', async () => {
   assert.equal(/from ['"]react['"]/i.test(source), false);
   assert.equal(/require\(['"]react['"]\)/i.test(source), false);
 });
+
+// -----------------------------------------------------------------------------
+// U2: GRAMMAR_CONCEPT_EXAMPLES + helpers — one example per concept, short
+// sentences, no forbidden terms. Tests for the Grammar Bank scene's view-model
+// surface: chip orderings, aggregate cards, cluster counts, evidence copy.
+// -----------------------------------------------------------------------------
+
+test('U2 view-model: GRAMMAR_CONCEPT_EXAMPLES covers all 18 concepts', async () => {
+  const {
+    GRAMMAR_CONCEPT_EXAMPLES,
+    grammarConceptPrimaryExample,
+    grammarConceptExamples,
+  } = await import('../src/subjects/grammar/components/grammar-view-model.js');
+  const { GRAMMAR_CLIENT_CONCEPTS } = await import('../src/subjects/grammar/metadata.js');
+  assert.equal(Object.keys(GRAMMAR_CONCEPT_EXAMPLES).length, 18);
+  for (const concept of GRAMMAR_CLIENT_CONCEPTS) {
+    const examples = GRAMMAR_CONCEPT_EXAMPLES[concept.id];
+    assert.ok(Array.isArray(examples), `${concept.id} has examples`);
+    assert.ok(examples.length >= 1, `${concept.id} has at least one example`);
+    assert.equal(typeof grammarConceptPrimaryExample(concept.id), 'string');
+    assert.ok(grammarConceptPrimaryExample(concept.id).length > 0);
+    assert.equal(grammarConceptExamples(concept.id).length, examples.length);
+  }
+});
+
+test('U2 view-model: GRAMMAR_CONCEPT_EXAMPLES are KS2-appropriate short sentences', async () => {
+  const { GRAMMAR_CONCEPT_EXAMPLES } = await import('../src/subjects/grammar/components/grammar-view-model.js');
+  for (const [conceptId, entries] of Object.entries(GRAMMAR_CONCEPT_EXAMPLES)) {
+    for (const sentence of entries) {
+      assert.ok(sentence.length <= 100, `${conceptId} example too long: ${sentence}`);
+      assert.ok(sentence.length >= 3, `${conceptId} example too short`);
+    }
+  }
+});
+
+test('U2 view-model: grammarConceptPrimaryExample safe on unknown ids', async () => {
+  const { grammarConceptPrimaryExample, grammarConceptExamples } = await import('../src/subjects/grammar/components/grammar-view-model.js');
+  assert.equal(grammarConceptPrimaryExample(''), '');
+  assert.equal(grammarConceptPrimaryExample(null), '');
+  assert.equal(grammarConceptPrimaryExample('bogus-id'), '');
+  assert.deepEqual(grammarConceptExamples(null), []);
+  assert.deepEqual(grammarConceptExamples('bogus-id'), []);
+});
+
+test('U2 view-model: grammarConceptEvidenceLine produces child copy tallies (no percentages)', async () => {
+  const { grammarConceptEvidenceLine } = await import('../src/subjects/grammar/components/grammar-view-model.js');
+  assert.equal(grammarConceptEvidenceLine({ attempts: 0, correct: 0 }), 'You have not answered any of these yet.');
+  assert.equal(grammarConceptEvidenceLine({ attempts: 3, correct: 2 }), 'You have 3 answers on this concept. 2 were correct.');
+  assert.equal(grammarConceptEvidenceLine({ attempts: 1, correct: 1 }), 'You have 1 answer on this concept. 1 was correct.');
+  assert.equal(grammarConceptEvidenceLine({ attempts: 5, correct: 0 }), 'You have 5 answers on this concept. 0 were correct.');
+  // No raw percentage in the output
+  assert.doesNotMatch(grammarConceptEvidenceLine({ attempts: 10, correct: 7 }), /\d+%/);
+});
+
+test('U2 view-model: GRAMMAR_BANK_STATUS_CHIPS ordering matches filter ids', async () => {
+  const { GRAMMAR_BANK_STATUS_CHIPS, GRAMMAR_BANK_STATUS_FILTER_IDS: filterIds } = await import('../src/subjects/grammar/components/grammar-view-model.js');
+  assert.equal(GRAMMAR_BANK_STATUS_CHIPS.length, filterIds.size);
+  for (const chip of GRAMMAR_BANK_STATUS_CHIPS) {
+    assert.ok(filterIds.has(chip.id), `chip ${chip.id} must be a valid filter id`);
+    assert.ok(typeof chip.label === 'string');
+    assert.ok(chip.label.length > 0);
+  }
+});
+
+test('U2 view-model: GRAMMAR_BANK_CLUSTER_CHIPS never includes reserved monster ids', async () => {
+  const { GRAMMAR_BANK_CLUSTER_CHIPS } = await import('../src/subjects/grammar/components/grammar-view-model.js');
+  for (const chip of GRAMMAR_BANK_CLUSTER_CHIPS) {
+    assert.ok(!['glossbloom', 'loomrill', 'mirrane'].includes(chip.id), `reserved id leaked: ${chip.id}`);
+  }
+});
+
+test('U2 view-model: grammarBankAggregateCards returns frozen cards in the expected order', async () => {
+  const { grammarBankAggregateCards } = await import('../src/subjects/grammar/components/grammar-view-model.js');
+  const counts = { all: 18, secure: 2, 'nearly-secure': 3, trouble: 5, learning: 4, new: 4, due: 10 };
+  const cards = grammarBankAggregateCards(counts);
+  assert.equal(cards.length, 6);
+  assert.deepEqual(cards.map((c) => c.id), ['total', 'secure', 'nearly-secure', 'trouble', 'learning', 'new']);
+  assert.equal(cards[0].value, 18);
+  assert.equal(cards[2].value, 3);
+});
+
+test('U2 view-model: buildGrammarBankModel exposes clusterCounts for chip badges', async () => {
+  const { buildGrammarBankModel } = await import('../src/subjects/grammar/components/grammar-view-model.js');
+  const model = buildGrammarBankModel({}, { statusFilter: 'all', clusterFilter: 'all', query: '' });
+  assert.equal(model.clusterCounts.all, 18);
+  assert.equal(model.clusterCounts.bracehart, 6);
+  assert.equal(model.clusterCounts.chronalyx, 4);
+  assert.equal(model.clusterCounts.couronnail, 3);
+  assert.equal(model.clusterCounts.concordium, 18);
+});

--- a/tests/react-grammar-surface.test.js
+++ b/tests/react-grammar-surface.test.js
@@ -1529,3 +1529,250 @@ test('U6a: grammar-save-transfer-evidence dispatch drops non-object selfAssessme
     { key: 'ok2', checked: false },
   ]);
 });
+
+// ----------------------------------------------------------------------------
+// U2: Grammar Bank scene + concept detail modal.
+//
+// SSR limits — documented here so readers know what is (and is not) asserted:
+//   * Focus management beyond the SSR-visible `data-focus-return-id`
+//     attribute cannot be asserted here. The attribute sits on the
+//     triggering card; the modal restores focus to it on close via a
+//     runtime effect. That effect is a browser side-effect and is
+//     covered by manual QA, not the SSR harness.
+//   * Escape-key closes the modal via a document-level keydown listener.
+//     The SSR harness does not simulate document-level events, so we
+//     assert the dispatcher exists via the data-action attribute + a
+//     direct dispatch of `grammar-concept-detail-close` through the
+//     action bus.
+//   * `createPortal` targets `document.body` at runtime, but the SSR
+//     renderer returns the JSX tree inline when no document is present
+//     (see `GrammarConceptDetailModal.jsx`) so the rendered HTML still
+//     contains the modal markup for assertions.
+// ----------------------------------------------------------------------------
+
+function openGrammarBankHarness() {
+  const storage = installMemoryStorage();
+  const harness = createAppHarness({ storage });
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-open-concept-bank');
+  return harness;
+}
+
+test('U2: Grammar Bank renders 18 concept cards when filters are all/all', () => {
+  const harness = openGrammarBankHarness();
+  const html = harness.render();
+  assert.match(html, /class="grammar-bank-scene"/);
+  assert.match(html, /Grammar Bank/);
+  assert.match(html, /Back to Grammar Garden/);
+  // Exactly 18 concept cards render in the default all/all view.
+  const cards = html.match(/<article[^>]*class="grammar-bank-card[^"]*"/g) || [];
+  assert.equal(cards.length, 18, 'bank renders 18 concept cards in default view');
+  // Aggregate summary row exposes a Total card for accessibility.
+  assert.match(html, /data-aggregate-id="total"/);
+});
+
+test('U2: Grammar Bank status filter "trouble" narrows to needs-repair concepts', () => {
+  const harness = openGrammarBankHarness();
+  const learnerId = harness.store.getState().learners.selectedId;
+
+  // Seed one concept with needs-repair confidence so the trouble filter has
+  // at least one match; every other concept should be excluded.
+  harness.store.updateSubjectUi('grammar', (current) => {
+    const normalised = normaliseGrammarReadModel(current, learnerId);
+    const concepts = normalised.analytics.concepts.map((concept) => (
+      concept.id === 'relative_clauses'
+        ? { ...concept, confidenceLabel: 'needs-repair', attempts: 4, correct: 1, wrong: 3 }
+        : concept
+    ));
+    return {
+      ...normalised,
+      analytics: { ...normalised.analytics, concepts },
+    };
+  });
+
+  harness.dispatch('grammar-concept-bank-filter', { value: 'trouble' });
+  const html = harness.render();
+  // The chip toggles aria-pressed; the grid narrows to the seeded concept.
+  // Attribute order in the rendered HTML is aria-pressed first, then
+  // data-value, so we assert both attrs appear on the same <button> element.
+  assert.match(html, /aria-pressed="true"[^>]*data-value="trouble"/);
+  const cards = html.match(/<article[^>]*class="grammar-bank-card[^"]*"[^>]*data-concept-id="([^"]+)"/g) || [];
+  assert.equal(cards.length, 1, 'only the needs-repair concept matches the trouble filter');
+  assert.match(cards[0], /data-concept-id="relative_clauses"/);
+  // Status chip on the card surfaces child copy, not internal labels.
+  assert.match(html, /Trouble spot/);
+});
+
+test('U2: Grammar Bank cluster filter "bracehart" narrows to exactly 6 concepts', () => {
+  const harness = openGrammarBankHarness();
+  harness.dispatch('grammar-concept-bank-cluster-filter', { value: 'bracehart' });
+  const html = harness.render();
+  const cards = html.match(/<article[^>]*class="grammar-bank-card[^"]*"/g) || [];
+  assert.equal(cards.length, 6, 'bracehart cluster contains exactly 6 concepts');
+  // Cluster chip toggles aria-pressed.
+  assert.match(html, /aria-pressed="true"[^>]*data-value="bracehart"/);
+  // Every rendered card carries the bracehart cluster badge.
+  const badges = html.match(/grammar-bank-card-cluster-badge"[^>]*data-cluster-id="bracehart"/g) || [];
+  assert.equal(badges.length, 6);
+});
+
+test('U2: Grammar Bank cluster filter "concordium" shows all 18 concepts', () => {
+  const harness = openGrammarBankHarness();
+  harness.dispatch('grammar-concept-bank-cluster-filter', { value: 'concordium' });
+  const html = harness.render();
+  const cards = html.match(/<article[^>]*class="grammar-bank-card[^"]*"/g) || [];
+  assert.equal(cards.length, 18, 'concordium (aggregate) shows every concept');
+});
+
+test('U2: Grammar Bank search "clause" narrows case-insensitively', () => {
+  const harness = openGrammarBankHarness();
+  // Simulate a committed search (input commit path goes through the action).
+  harness.dispatch('grammar-concept-bank-search', { value: 'Clause' });
+  const html = harness.render();
+  const cards = html.match(/<article[^>]*class="grammar-bank-card[^"]*"[^>]*data-concept-id="([^"]+)"/g) || [];
+  assert.ok(cards.length >= 2, 'search for "clause" matches at least two concepts');
+  assert.ok(cards.some((markup) => /data-concept-id="clauses"/.test(markup)));
+  assert.ok(cards.some((markup) => /data-concept-id="relative_clauses"/.test(markup)));
+  // Non-matching concepts are absent.
+  assert.ok(!cards.some((markup) => /data-concept-id="modal_verbs"/.test(markup)));
+});
+
+test('U2: Grammar Bank "Practise 5" button dispatches grammar-focus-concept with concept id', () => {
+  // Use the full grammar harness so the server engine service is available;
+  // `grammar-focus-concept` routes through `service.savePrefs` +
+  // `service.startSession` so it needs a real engine.
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-open-concept-bank');
+  // Assert the button markup carries the action + concept id so the
+  // keyboard / click handler both route the same id.
+  const html = harness.render();
+  assert.match(html, /data-action="grammar-focus-concept"[^>]*data-concept-id="word_classes"/);
+
+  // Dispatch the action directly and verify the prefs + phase transition.
+  harness.dispatch('grammar-focus-concept', { conceptId: 'word_classes' });
+  const grammar = harness.store.getState().subjectUi.grammar;
+  // focusConceptId persists on the prefs so subsequent rounds keep the focus.
+  assert.equal(grammar.prefs.focusConceptId, 'word_classes');
+  // The focus mode is a focus-using mode (smart/learn/worked/faded — NOT
+  // trouble/surgery/builder which drop focus).
+  assert.ok(['smart', 'learn', 'worked', 'faded'].includes(grammar.prefs.mode));
+  // The start-session transition flips the phase out of `bank`.
+  assert.notEqual(grammar.phase, 'bank');
+  // The session carries the focus concept id so the first question targets it.
+  assert.equal(grammar.session?.focusConceptId, 'word_classes');
+});
+
+test('U2: Grammar Bank detail modal opens with role="dialog" and aria-modal="true"', () => {
+  const harness = openGrammarBankHarness();
+  harness.dispatch('grammar-concept-detail-open', { conceptId: 'relative_clauses' });
+  const html = harness.render();
+  assert.match(html, /role="dialog"/);
+  assert.match(html, /aria-modal="true"/);
+  assert.match(html, /aria-labelledby="grammar-concept-detail-title-relative_clauses"/);
+  // Modal body carries the concept name + example + close button.
+  assert.match(html, /Relative clauses/);
+  assert.match(html, /data-action="grammar-concept-detail-close"/);
+  // At least one example sentence for the concept renders inside the modal.
+  assert.match(html, /The dog, which was muddy, ran inside\./);
+});
+
+test('U2: Grammar Bank detail modal exposes focus-return marker on the triggering card', () => {
+  const harness = openGrammarBankHarness();
+  const html = harness.render();
+  // Every concept card carries a `data-focus-return-id` marker on its
+  // `See example` button so the modal close hook can restore focus.
+  assert.match(html, /data-focus-return-id="grammar-bank-concept-card-relative_clauses"/);
+});
+
+test('U2: Grammar Bank empty state renders "No concepts match" when filters exclude everything', () => {
+  const harness = openGrammarBankHarness();
+  // A search that matches no concept name / summary / example / domain.
+  harness.dispatch('grammar-concept-bank-search', { value: 'zzz-unreachable-token' });
+  const html = harness.render();
+  const cards = html.match(/<article[^>]*class="grammar-bank-card[^"]*"/g) || [];
+  assert.equal(cards.length, 0, 'no concept cards render when the search excludes everything');
+  assert.match(html, /No concepts match your filters\. Try another status or cluster\./);
+});
+
+test('U2: Grammar Bank HTML contains none of GRAMMAR_CHILD_FORBIDDEN_TERMS', () => {
+  const harness = openGrammarBankHarness();
+  harness.dispatch('grammar-concept-detail-open', { conceptId: 'clauses' });
+  const html = harness.render();
+  // Narrow to the bank scene markup to avoid sweeping the adult analytics
+  // disclosure (which lives behind a sibling `<details>`).
+  const sceneMatch = html.match(/<section class="grammar-bank-scene"[\s\S]*?<\/section>/);
+  assert.ok(sceneMatch, 'Grammar Bank scene renders');
+  const sceneHtml = sceneMatch[0];
+  for (const term of GRAMMAR_CHILD_FORBIDDEN_TERMS) {
+    const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    assert.doesNotMatch(sceneHtml, new RegExp(escaped, 'i'), `forbidden term leaked: ${term}`);
+  }
+  // Reserved monsters must never appear as cluster badges in the bank.
+  assert.doesNotMatch(sceneHtml, /Glossbloom|Loomrill|Mirrane/i);
+});
+
+test('U2: Grammar Bank concept cards never render raw percentages', () => {
+  const harness = openGrammarBankHarness();
+  const learnerId = harness.store.getState().learners.selectedId;
+  // Seed a non-trivial attempts count so any accidental percentage render
+  // would surface in the card markup.
+  harness.store.updateSubjectUi('grammar', (current) => {
+    const normalised = normaliseGrammarReadModel(current, learnerId);
+    const concepts = normalised.analytics.concepts.map((concept) => (
+      concept.id === 'noun_phrases'
+        ? { ...concept, attempts: 10, correct: 7, wrong: 3 }
+        : concept
+    ));
+    return {
+      ...normalised,
+      analytics: { ...normalised.analytics, concepts },
+    };
+  });
+  const html = harness.render();
+  const cardsHtml = (html.match(/<article[^>]*class="grammar-bank-card[^"]*"[\s\S]*?<\/article>/g) || []).join('\n');
+  assert.ok(cardsHtml.length > 0, 'bank cards render');
+  assert.doesNotMatch(cardsHtml, /\d+%/, 'percentage characters must not appear in concept cards');
+});
+
+test('U2: Grammar Bank close action returns the learner to the dashboard', () => {
+  const harness = openGrammarBankHarness();
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'bank');
+  harness.dispatch('grammar-close-concept-bank');
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'dashboard');
+  const html = harness.render();
+  assert.match(html, /Grammar Garden/);
+});
+
+test('U2: Grammar Bank detail-close clears the detailConceptId slice', () => {
+  const harness = openGrammarBankHarness();
+  harness.dispatch('grammar-concept-detail-open', { conceptId: 'word_classes' });
+  assert.equal(harness.store.getState().subjectUi.grammar.bank.detailConceptId, 'word_classes');
+  harness.dispatch('grammar-concept-detail-close');
+  assert.equal(harness.store.getState().subjectUi.grammar.bank.detailConceptId, '');
+});
+
+test('U2: Grammar Bank filter + search round-trip through the normaliser without stomping unrelated state', () => {
+  const harness = openGrammarBankHarness();
+  harness.dispatch('grammar-concept-bank-filter', { value: 'learning' });
+  harness.dispatch('grammar-concept-bank-cluster-filter', { value: 'chronalyx' });
+  harness.dispatch('grammar-concept-bank-search', { value: 'verb' });
+  const grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.bank.statusFilter, 'learning');
+  assert.equal(grammar.bank.clusterFilter, 'chronalyx');
+  assert.equal(grammar.bank.query, 'verb');
+  // Session, summary, feedback untouched.
+  assert.equal(grammar.phase, 'bank');
+  assert.equal(grammar.session, null);
+  assert.equal(grammar.summary, null);
+  assert.equal(grammar.feedback, null);
+});
+
+test('U2: Grammar Bank rejects invalid filter ids via the normaliser', () => {
+  const harness = openGrammarBankHarness();
+  harness.dispatch('grammar-concept-bank-filter', { value: 'bogus-status' });
+  assert.equal(harness.store.getState().subjectUi.grammar.bank.statusFilter, 'all');
+  harness.dispatch('grammar-concept-bank-cluster-filter', { value: 'glossbloom' });
+  assert.equal(harness.store.getState().subjectUi.grammar.bank.clusterFilter, 'all');
+});

--- a/tests/react-grammar-surface.test.js
+++ b/tests/react-grammar-surface.test.js
@@ -1689,11 +1689,14 @@ test('U2: Grammar Bank detail modal exposes focus-return marker on the triggerin
 test('U2: Grammar Bank empty state renders "No concepts match" when filters exclude everything', () => {
   const harness = openGrammarBankHarness();
   // A search that matches no concept name / summary / example / domain.
+  // U2 follower: when the search query is non-empty, the empty state swaps
+  // to the search-aware copy. The filter-only empty copy is covered by a
+  // dedicated follower test further down.
   harness.dispatch('grammar-concept-bank-search', { value: 'zzz-unreachable-token' });
   const html = harness.render();
   const cards = html.match(/<article[^>]*class="grammar-bank-card[^"]*"/g) || [];
   assert.equal(cards.length, 0, 'no concept cards render when the search excludes everything');
-  assert.match(html, /No concepts match your filters\. Try another status or cluster\./);
+  assert.match(html, /No concepts match\. Try clearing your search or changing the filters\./);
 });
 
 test('U2: Grammar Bank HTML contains none of GRAMMAR_CHILD_FORBIDDEN_TERMS', () => {
@@ -1775,4 +1778,169 @@ test('U2: Grammar Bank rejects invalid filter ids via the normaliser', () => {
   assert.equal(harness.store.getState().subjectUi.grammar.bank.statusFilter, 'all');
   harness.dispatch('grammar-concept-bank-cluster-filter', { value: 'glossbloom' });
   assert.equal(harness.store.getState().subjectUi.grammar.bank.clusterFilter, 'all');
+});
+
+// ----------------------------------------------------------------------------
+// U2 follower: hyphen example swap, search-aware empty state, remote
+// focus-concept chain, stale modal clear, cluster-total sublabel.
+// ----------------------------------------------------------------------------
+
+test('U2 follower: Grammar Bank empty state swaps copy when search query is non-empty', () => {
+  const harness = openGrammarBankHarness();
+  // Filter-only empty (no search) — existing copy.
+  harness.dispatch('grammar-concept-bank-cluster-filter', { value: 'bracehart' });
+  harness.dispatch('grammar-concept-bank-filter', { value: 'secure' });
+  let html = harness.render();
+  let cards = html.match(/<article[^>]*class="grammar-bank-card[^"]*"/g) || [];
+  assert.equal(cards.length, 0, 'filter-only empty state renders');
+  assert.match(html, /No concepts match your filters\. Try another status or cluster\./);
+  assert.doesNotMatch(html, /Try clearing your search/);
+
+  // Search-present empty — new copy.
+  harness.dispatch('grammar-concept-bank-filter', { value: 'all' });
+  harness.dispatch('grammar-concept-bank-cluster-filter', { value: 'all' });
+  harness.dispatch('grammar-concept-bank-search', { value: 'zzz-unreachable-token' });
+  html = harness.render();
+  cards = html.match(/<article[^>]*class="grammar-bank-card[^"]*"/g) || [];
+  assert.equal(cards.length, 0, 'search-present empty state renders');
+  assert.match(html, /No concepts match\. Try clearing your search or changing the filters\./);
+  assert.doesNotMatch(html, /Try another status or cluster/);
+});
+
+test('U2 follower: Grammar Bank hyphen_ambiguity card primary example is the man-eating shark', () => {
+  const harness = openGrammarBankHarness();
+  const html = harness.render();
+  // The card blockquote surfaces `example` (examples[0]) from the view-model.
+  // After the swap, the clear positive example must be the one on-card.
+  const cardMatch = html.match(/data-concept-id="hyphen_ambiguity"[\s\S]*?<\/article>/);
+  assert.ok(cardMatch, 'hyphen_ambiguity card renders');
+  assert.match(cardMatch[0], /The man-eating shark circled the boat\./);
+  assert.doesNotMatch(cardMatch[0], /Please resign the letter/);
+});
+
+test('U2 follower: reopening Grammar Bank after closing detail modal does not auto-show the modal', () => {
+  const harness = openGrammarBankHarness();
+  // Open the detail modal.
+  harness.dispatch('grammar-concept-detail-open', { conceptId: 'word_classes' });
+  assert.equal(harness.store.getState().subjectUi.grammar.bank.detailConceptId, 'word_classes');
+  let html = harness.render();
+  assert.match(html, /role="dialog"/);
+
+  // Close the bank (returns to dashboard — the legacy resetToDashboard path
+  // does not touch the bank slice, so detailConceptId remained stale).
+  harness.dispatch('grammar-close-concept-bank');
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'dashboard');
+
+  // Reopen the bank. With the follower fix, `grammar-open-concept-bank`
+  // clears `bank.detailConceptId`, so the modal must NOT auto-appear.
+  harness.dispatch('grammar-open-concept-bank');
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'bank');
+  assert.equal(
+    harness.store.getState().subjectUi.grammar.bank.detailConceptId,
+    '',
+    'detailConceptId cleared on reopen',
+  );
+  html = harness.render();
+  assert.doesNotMatch(html, /role="dialog"/, 'detail modal must not auto-pop on bank reopen');
+});
+
+test('U2 follower: Grammar Bank aggregate "Total" card stays at 18 under a cluster filter', () => {
+  const harness = openGrammarBankHarness();
+  harness.dispatch('grammar-concept-bank-cluster-filter', { value: 'bracehart' });
+  const html = harness.render();
+  // Grid narrows to the bracehart cluster's 6 cards.
+  const cards = html.match(/<article[^>]*class="grammar-bank-card[^"]*"/g) || [];
+  assert.equal(cards.length, 6);
+  // Total aggregate card still shows the global 18 so the sub-label
+  // "Grammar concepts tracked" stays truthful under narrower filters.
+  const totalCard = html.match(/data-aggregate-id="total"[\s\S]*?<\/div><\/div>/);
+  assert.ok(totalCard, 'total aggregate card renders');
+  assert.match(totalCard[0], />18<\/div>/);
+  assert.match(totalCard[0], /Grammar concepts tracked/);
+});
+
+test('U2 follower: grammar-focus-concept remote path chains start-session after save-prefs resolves', async () => {
+  // Build a context WITHOUT `service.savePrefs` / `service.startSession` so
+  // the remote path runs. Observe that `save-prefs` goes first and
+  // `start-session` only dispatches after the save-prefs promise resolves.
+  const sent = [];
+  let resolveSavePrefs;
+  let resolveStartSession;
+  const context = {
+    appState: {
+      learners: { selectedId: 'learner-a' },
+      subjectUi: { grammar: normaliseGrammarReadModel({ phase: 'bank' }, 'learner-a') },
+    },
+    runtimeReadOnly: false,
+    subjectCommands: {
+      send(request) {
+        sent.push({ command: request.command, payload: request.payload });
+        if (request.command === 'save-prefs') {
+          return new Promise((resolve) => { resolveSavePrefs = resolve; });
+        }
+        if (request.command === 'start-session') {
+          return new Promise((resolve) => { resolveStartSession = resolve; });
+        }
+        return Promise.resolve({});
+      },
+    },
+    store: {
+      getState() { return context.appState; },
+      updateSubjectUi(subjectId, updater) {
+        const previous = context.appState.subjectUi[subjectId] || {};
+        const next = typeof updater === 'function' ? updater(previous) : { ...previous, ...updater };
+        context.appState = {
+          ...context.appState,
+          subjectUi: { ...context.appState.subjectUi, [subjectId]: next },
+        };
+      },
+      updateSubjectUiForLearner(learnerId, subjectId, updater) {
+        if (learnerId !== 'learner-a') return false;
+        context.store.updateSubjectUi(subjectId, updater);
+        return true;
+      },
+      pushToasts() {},
+      pushMonsterCelebrations() {},
+      reloadFromRepositories() {},
+    },
+    data: { conceptId: 'relative_clauses' },
+  };
+
+  const handled = grammarModule.handleAction('grammar-focus-concept', context);
+  assert.equal(handled, true);
+
+  // Only save-prefs has gone so far; start-session must wait for the resolve.
+  assert.equal(sent.length, 1, 'only save-prefs dispatched before save resolves');
+  assert.equal(sent[0].command, 'save-prefs');
+  assert.equal(sent[0].payload.prefs.focusConceptId, 'relative_clauses');
+
+  // Resolve save-prefs with a valid read model.
+  resolveSavePrefs({
+    subjectReadModel: normaliseGrammarReadModel({
+      learnerId: 'learner-a',
+      phase: 'dashboard',
+      prefs: { mode: 'learn', focusConceptId: 'relative_clauses' },
+    }, 'learner-a'),
+  });
+  // Flush microtasks.
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+
+  // Now start-session must have dispatched via the onResolved callback.
+  assert.equal(sent.length, 2, 'start-session dispatched after save-prefs resolved');
+  assert.equal(sent[1].command, 'start-session');
+  assert.equal(sent[1].payload.focusConceptId, 'relative_clauses');
+  // `smart` is a focus-using mode (only trouble/surgery/builder drop focus),
+  // so the target mode stays `smart` rather than falling back to `learn`.
+  assert.equal(sent[1].payload.mode, 'smart');
+
+  // Resolve start-session so any trailing handlers run cleanly.
+  resolveStartSession({
+    subjectReadModel: normaliseGrammarReadModel({
+      learnerId: 'learner-a',
+      phase: 'session',
+    }, 'learner-a'),
+  });
+  await Promise.resolve();
 });


### PR DESCRIPTION
## Summary
- Ship the real Grammar Bank scene (`GrammarConceptBankScene.jsx`) and per-concept detail modal (`GrammarConceptDetailModal.jsx`); replace the U1 placeholder stub in `GrammarPracticeSurface.jsx`'s phase router.
- Add `GRAMMAR_CONCEPT_EXAMPLES` (one short KS2 example per concept, 18 total; modal shows up to two), plus `grammarBankAggregateCards`, `grammarConceptEvidenceLine`, and chip ordering fixtures to `grammar-view-model.js`.
- Register new actions in `module.js`: `grammar-close-concept-bank`, `grammar-concept-bank-filter`, `grammar-concept-bank-cluster-filter`, `grammar-concept-bank-search`, `grammar-concept-detail-open`, `grammar-concept-detail-close`, `grammar-focus-concept`. Extend `normaliseGrammarReadModel` with a `bank` slice (statusFilter / clusterFilter / query / detailConceptId) guarded by frozen id sets.

Plan reference: `docs/plans/2026-04-25-004-feat-grammar-phase3-ux-reset-plan.md` — U2 section.

### 18 concept examples (one per card)
| Concept | Primary example |
|---|---|
| sentence_functions | Have you finished your homework? |
| word_classes | The small fox ran quickly across the field. |
| noun_phrases | A tall tree with silver bark stood by the lake. |
| adverbials | After lunch, we walked to the park. |
| clauses | We stayed inside because the rain was heavy. |
| relative_clauses | The dog, which was muddy, ran inside. |
| tense_aspect | I have finished my book. |
| standard_english | We were late for the bus. |
| pronouns_cohesion | Maya picked up the kitten and stroked it gently. |
| formality | May I leave the room, please? |
| active_passive | The chef baked the cake. (active) |
| subject_object | The cat chased the mouse. |
| modal_verbs | You should wear a coat. |
| parenthesis_commas | The garden, full of roses, smelled sweet. |
| speech_punctuation | "Where are my shoes?" asked Leo. |
| apostrophes_possession | The girls' coats were on the hooks. |
| boundary_punctuation | Bring these items: a pen, a ruler and a book. |
| hyphen_ambiguity | The man-eating shark circled the boat. |

### New actions in `grammar/module.js`
- `grammar-close-concept-bank` — routes back to the dashboard.
- `grammar-concept-bank-filter` — sets `bank.statusFilter` (validated against `VALID_GRAMMAR_BANK_STATUS_FILTERS`).
- `grammar-concept-bank-cluster-filter` — sets `bank.clusterFilter` (validated against `VALID_GRAMMAR_BANK_CLUSTER_FILTERS`; reserved monster ids rejected).
- `grammar-concept-bank-search` — persists the search query (80-char cap mirroring Spelling).
- `grammar-concept-detail-open` / `grammar-concept-detail-close` — flip the modal open/closed by setting `bank.detailConceptId`.
- `grammar-focus-concept` — clears the bank slice, saves prefs (`mode` falls back to `learn` when the current mode drops focus, else retained), and dispatches `start-session` with the concept id.

### Files
- `src/subjects/grammar/components/GrammarConceptBankScene.jsx` (new)
- `src/subjects/grammar/components/GrammarConceptDetailModal.jsx` (new)
- `src/subjects/grammar/components/GrammarPracticeSurface.jsx` — phase router now renders the real scene on `phase === 'bank'`
- `src/subjects/grammar/components/grammar-view-model.js` — examples + helpers + chip fixtures + `grammarBankAggregateCards`
- `src/subjects/grammar/metadata.js` — `bank` UI slice + filter validators in `normaliseGrammarReadModel`
- `src/subjects/grammar/module.js` — 6 new bank action dispatchers + `grammar-focus-concept`
- `tests/react-grammar-surface.test.js` — 13 U2 cases
- `tests/grammar-ui-model.test.js` — 8 U2 cases

## Test plan
- [x] `node --test tests/react-grammar-surface.test.js tests/grammar-ui-model.test.js` green (62 + 78 cases).
- [x] `npm test` green aside from pre-existing `grammar-production-smoke` failure (stats.templates forbidden key — tracked outside U2).
- [x] `npm run check` green (wrangler dry-run + build + audit).
- [x] Bank SSR renders 18 concept cards when filters are `all`/`all`; `bracehart` filter narrows to exactly 6, `concordium` shows every concept, `chronalyx` shows 4, `couronnail` shows 3.
- [x] Status filter `trouble` narrows to concepts with child label `Trouble spot`.
- [x] Search `clause` narrows case-insensitively to `clauses` + `relative_clauses`.
- [x] `Practise 5` button dispatches `grammar-focus-concept` with the concept id; session starts with `focusConceptId` set.
- [x] Detail modal opens with `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` pointing at the title; close dispatcher clears `bank.detailConceptId`.
- [x] Focus-return marker (`data-focus-return-id="grammar-bank-concept-card-<id>"`) present on triggering cards; SSR blind spots called out in test header (runtime focus motion is a manual QA gate).
- [x] Empty bank renders child-friendly "No concepts match" copy.
- [x] Absence sweep: no `GRAMMAR_CHILD_FORBIDDEN_TERMS` in bank scene HTML; no reserved monster names (`Glossbloom`/`Loomrill`/`Mirrane`); no raw percentages on cards.
- [x] Filter / cluster / search round-trip through `normaliseGrammarReadModel` without stomping `session`, `feedback`, or `summary`.

## SSR limits (documented)
Focus management beyond the SSR-visible `data-focus-return-id` attribute and Escape-key close via document listener are browser-runtime side-effects — the SSR harness does not simulate document-level events. They remain manual QA gates. The tests assert the dispatcher data attributes and direct action dispatches instead.