### PR TITLE
feat(grammar): U3 session redesign (one task, post-answer help only)

### DIFF
--- a/src/subjects/grammar/components/GrammarSessionScene.jsx
+++ b/src/subjects/grammar/components/GrammarSessionScene.jsx
@@ -4,6 +4,12 @@ import {
   isGrammarSpeechAvailable,
   speakGrammarReadModel,
 } from '../speech.js';
+import {
+  grammarSessionHelpVisibility,
+  grammarSessionSubmitLabel,
+  grammarSessionProgressLabel,
+  grammarSessionInfoChips,
+} from '../session-ui.js';
 
 function optionLabel(option) {
   if (Array.isArray(option)) return String(option[1] ?? option[0] ?? '');
@@ -353,25 +359,38 @@ function SessionGoalChip({ goal }) {
   return null;
 }
 
-function RepairActions({ isMiniTest, isFeedback, session, pending, runtimeReadOnly, actions }) {
+function RepairActions({ isMiniTest, isFeedback, help, feedback, pending, runtimeReadOnly, actions }) {
   if (isMiniTest) return null;
   const disabled = runtimeReadOnly || pending;
+  // Post-answer (feedback) branch: only render repair controls for a wrong
+  // answer. A correct answer funnels the learner to the single `Next question`
+  // primary action — no retry / worked solution / similar problem clutter.
   if (isFeedback) {
+    if (!help?.showRepairActions) return null;
+    const isCorrect = Boolean(feedback?.result?.correct);
+    if (isCorrect) return null;
     return (
       <div className="grammar-repair-actions" aria-label="Grammar repair actions">
         <button className="btn secondary" type="button" disabled={disabled} onClick={() => actions.dispatch('grammar-retry-current-question')}>
           Retry
         </button>
-        <button className="btn secondary" type="button" disabled={disabled} onClick={() => actions.dispatch('grammar-show-worked-solution')}>
-          Worked solution
-        </button>
-        <button className="btn secondary" type="button" disabled={disabled} onClick={() => actions.dispatch('grammar-start-similar-problem')}>
-          Similar problem
-        </button>
+        {help.showWorkedSolution ? (
+          <button className="btn secondary" type="button" disabled={disabled} onClick={() => actions.dispatch('grammar-show-worked-solution')}>
+            Worked solution
+          </button>
+        ) : null}
+        {help.showSimilarProblem ? (
+          <button className="btn secondary" type="button" disabled={disabled} onClick={() => actions.dispatch('grammar-start-similar-problem')}>
+            Similar problem
+          </button>
+        ) : null}
       </div>
     );
   }
-  if ((Number(session?.supportLevel) || 0) > 0) return null;
+  // Pre-answer branch: gated entirely by the U8 visibility table. For
+  // independent practice in the `session` phase every flag is `false`, so
+  // the learner sees exactly one task + Submit with no support chrome.
+  if (!help?.showFadedSupport || !help?.showSimilarProblem) return null;
   return (
     <div className="grammar-repair-actions" aria-label="Grammar support actions">
       <button className="btn secondary" type="button" disabled={disabled} onClick={() => actions.dispatch('grammar-use-faded-support')}>
@@ -384,9 +403,15 @@ function RepairActions({ isMiniTest, isFeedback, session, pending, runtimeReadOn
   );
 }
 
-function AiEnrichmentActions({ isMiniTest, pending, runtimeReadOnly, actions }) {
+function AiEnrichmentActions({ isMiniTest, isFeedback, pending, runtimeReadOnly, actions }) {
   if (isMiniTest) return null;
   const disabled = runtimeReadOnly || pending;
+  // Post-answer child copy relabels the existing AI enrichment triggers to
+  // `Explain another way` / `Revision cards` — the Worker action behind the
+  // buttons is unchanged; only the visible label adapts to the feedback
+  // phase. Pre-answer renders are gated by `help.showAiActions` upstream so
+  // children only see a single primary Submit before marking.
+  const explanationLabel = isFeedback ? 'Explain another way' : 'Explain this';
   return (
     <div className="grammar-ai-actions" aria-label="Grammar enrichment actions">
       <button
@@ -395,7 +420,7 @@ function AiEnrichmentActions({ isMiniTest, pending, runtimeReadOnly, actions }) 
         disabled={disabled}
         onClick={() => actions.dispatch('grammar-request-ai-enrichment', { kind: 'explanation' })}
       >
-        Explain this
+        {explanationLabel}
       </button>
       <button
         className="btn secondary"
@@ -453,15 +478,24 @@ export function GrammarSessionScene({ grammar, actions, runtimeReadOnly }) {
   const pending = Boolean(grammar.pendingCommand);
   const submitDisabled = runtimeReadOnly || pending || (!isMiniTest && isFeedback);
   const currentResponse = isMiniTest ? (miniTestCurrent?.response || {}) : {};
-  const showDomainChip = item.domain && (grammar.prefs?.showDomainBeforeAnswer !== false || isFeedback);
   const answerFormId = `grammar-answer-form-${String(session.id || 'current').replace(/[^A-Za-z0-9_-]/g, '-')}`;
+  // Single source of truth for every help surface (AI triggers, worked
+  // solution preview, faded support, similar problem) — the JSX calls the
+  // U8 helper once and threads the resulting flags down. Mini-test (before
+  // finish) and independent practice pre-answer both collapse to all-false,
+  // so the learner sees one task and one primary action.
+  const help = grammarSessionHelpVisibility(session, grammar.phase);
+  const progressLabel = grammarSessionProgressLabel(session);
+  const sessionTitle = progressLabel || 'Grammar practice';
+  const infoChips = grammarSessionInfoChips(session);
+  const submitLabel = grammarSessionSubmitLabel(session, grammar.awaitingAdvance);
 
   return (
     <section className="grammar-session" aria-labelledby="grammar-session-title">
       <div className="grammar-session-head">
         <div>
           <div className="eyebrow">Grammar practice</div>
-          <h2 id="grammar-session-title">{item.templateLabel || 'Worker-marked question'}</h2>
+          <h2 id="grammar-session-title">{sessionTitle}</h2>
         </div>
         <div className="grammar-progress" aria-label="Round progress">
           <span>{progressDone}</span>
@@ -471,11 +505,10 @@ export function GrammarSessionScene({ grammar, actions, runtimeReadOnly }) {
 
       <div className="grammar-prompt-card">
         <div className="chip-row">
-          {isMiniTest ? <span className="chip good">KS2-style mini-test</span> : null}
+          {infoChips.map((chip) => (
+            <span className="chip" key={chip}>{chip}</span>
+          ))}
           {!isMiniTest ? <SessionGoalChip goal={session.goal} /> : null}
-          {showDomainChip ? <span className="chip">{item.domain}</span> : null}
-          {item.questionType ? <span className="chip">{item.questionType}</span> : null}
-          {session.serverAuthority ? <span className="chip good">Worker authority</span> : null}
         </div>
         {isMiniTest ? (
           <MiniTestStatus
@@ -489,12 +522,15 @@ export function GrammarSessionScene({ grammar, actions, runtimeReadOnly }) {
         {item.checkLine ? <p className="grammar-check-line">{item.checkLine}</p> : null}
         <ReadAloudControls grammar={grammar} />
         {!isMiniTest ? <GuidancePanel support={session.supportGuidance} /> : null}
-        <AiEnrichmentActions
-          isMiniTest={isMiniTest}
-          pending={pending}
-          runtimeReadOnly={runtimeReadOnly}
-          actions={actions}
-        />
+        {help.showAiActions ? (
+          <AiEnrichmentActions
+            isMiniTest={isMiniTest}
+            isFeedback={isFeedback}
+            pending={pending}
+            runtimeReadOnly={runtimeReadOnly}
+            actions={actions}
+          />
+        ) : null}
         {!isMiniTest ? <AiEnrichmentPanel enrichment={grammar.aiEnrichment} /> : null}
 
         <form
@@ -524,11 +560,14 @@ export function GrammarSessionScene({ grammar, actions, runtimeReadOnly }) {
         >
           <GrammarInput inputSpec={item.inputSpec || { type: 'text' }} required={!isMiniTest} response={currentResponse} />
           {!isMiniTest ? <FeedbackPanel feedback={grammar.feedback} /> : null}
-          {!isMiniTest ? <WorkedSolutionPanel solution={grammar.feedback?.workedSolution} /> : null}
+          {!isMiniTest && help.showWorkedSolution ? (
+            <WorkedSolutionPanel solution={grammar.feedback?.workedSolution} />
+          ) : null}
           <RepairActions
             isMiniTest={isMiniTest}
             isFeedback={isFeedback}
-            session={session}
+            help={help}
+            feedback={grammar.feedback}
             pending={pending}
             runtimeReadOnly={runtimeReadOnly}
             actions={actions}
@@ -554,7 +593,7 @@ export function GrammarSessionScene({ grammar, actions, runtimeReadOnly }) {
               </>
             ) : (
               <button className="btn primary" type="submit" disabled={submitDisabled}>
-                {pending && grammar.pendingCommand === 'submit-answer' ? 'Checking...' : 'Submit answer'}
+                {pending && grammar.pendingCommand === 'submit-answer' ? 'Checking...' : submitLabel}
               </button>
             )}
             {!isMiniTest && isFeedback ? (

--- a/src/subjects/grammar/components/GrammarSessionScene.jsx
+++ b/src/subjects/grammar/components/GrammarSessionScene.jsx
@@ -10,6 +10,7 @@ import {
   grammarSessionProgressLabel,
   grammarSessionInfoChips,
 } from '../session-ui.js';
+import { translateGrammarSessionError } from '../module.js';
 
 function optionLabel(option) {
   if (Array.isArray(option)) return String(option[1] ?? option[0] ?? '');
@@ -522,7 +523,7 @@ export function GrammarSessionScene({ grammar, actions, runtimeReadOnly }) {
         {item.checkLine ? <p className="grammar-check-line">{item.checkLine}</p> : null}
         <ReadAloudControls grammar={grammar} />
         {!isMiniTest ? <GuidancePanel support={session.supportGuidance} /> : null}
-        {help.showAiActions ? (
+        {help.showAiActions && !(isFeedback && grammar.feedback?.result?.correct === true) ? (
           <AiEnrichmentActions
             isMiniTest={isMiniTest}
             isFeedback={isFeedback}
@@ -574,8 +575,8 @@ export function GrammarSessionScene({ grammar, actions, runtimeReadOnly }) {
           />
           {grammar.error ? (
             <div className="feedback bad" role="alert">
-              <strong>Grammar command failed</strong>
-              <div>{grammar.error}</div>
+              <strong>Something went wrong</strong>
+              <div>{translateGrammarSessionError(grammar.error)}</div>
             </div>
           ) : null}
           <div className="actions">

--- a/src/subjects/grammar/module.js
+++ b/src/subjects/grammar/module.js
@@ -33,6 +33,52 @@ export function translateGrammarTransferError(error) {
   return GRAMMAR_TRANSFER_GENERIC_ERROR_COPY;
 }
 
+// U3 follower: child-copy translation for non-transfer Grammar session errors.
+// The generic fallback is the Phase 3 plan copy (`That did not save. Try again.`,
+// plan §U3 line 596). Known Worker codes that surface during an active session
+// (submit, repair, advance, enrichment) are mapped to child-friendly strings;
+// anything else — including stringified raw Worker messages routed through
+// `setGrammarError` — collapses to the generic fallback so no raw engine copy
+// ever reaches the learner. `GrammarSessionScene.jsx` renders only the return
+// value of this helper inside the `role="alert"` banner.
+export const GRAMMAR_SESSION_ERROR_COPY = Object.freeze({
+  grammar_session_stale: 'That round has ended. Start a new round to keep practising.',
+  grammar_answer_required: 'Choose or type an answer before submitting.',
+  grammar_answer_invalid: 'That answer looks off. Check it and try again.',
+  grammar_advance_not_ready: 'Wait for the feedback before moving on.',
+  grammar_repair_not_ready: 'That help is not ready yet. Try again in a moment.',
+  grammar_repair_unavailable_for_mode: 'That help is not available in this mode.',
+  grammar_support_unavailable_for_mode: 'That support is not available in this mode.',
+  grammar_ai_unavailable_for_mini_test: 'Explanations are hidden until the mini test is finished.',
+});
+
+export const GRAMMAR_SESSION_GENERIC_ERROR_COPY = 'That did not save. Try again.';
+
+// Copy used verbatim by `module.js` for client-side pre-submit validation and
+// other known session-surface strings that are already child-safe. If the
+// helper sees one of these incoming verbatim (no error code attached, just a
+// string in `grammar.error`), it preserves the string instead of collapsing
+// to the generic fallback.
+const GRAMMAR_SESSION_KNOWN_CHILD_MESSAGES = new Set([
+  'Choose or type an answer before submitting.',
+]);
+
+export function translateGrammarSessionError(error) {
+  if (error === null || error === undefined) return GRAMMAR_SESSION_GENERIC_ERROR_COPY;
+  if (typeof error === 'string') {
+    if (GRAMMAR_SESSION_KNOWN_CHILD_MESSAGES.has(error)) return error;
+    return GRAMMAR_SESSION_GENERIC_ERROR_COPY;
+  }
+  const code = error?.payload?.code
+    || error?.extra?.code
+    || error?.code
+    || '';
+  if (code && Object.prototype.hasOwnProperty.call(GRAMMAR_SESSION_ERROR_COPY, code)) {
+    return GRAMMAR_SESSION_ERROR_COPY[code];
+  }
+  return GRAMMAR_SESSION_GENERIC_ERROR_COPY;
+}
+
 function selectedLearnerId(context) {
   return (context?.store?.getState?.() || context?.appState || {})?.learners?.selectedId || '';
 }

--- a/tests/react-grammar-surface.test.js
+++ b/tests/react-grammar-surface.test.js
@@ -203,8 +203,14 @@ test('Grammar surface runs KS2 mini-set mode with delayed feedback and end revie
   assert.equal(grammar.session.miniTest.questions.length, 8);
 
   html = harness.render();
-  assert.match(html, /KS2-style mini-test/);
+  // U3: the chip row is driven by `grammarSessionInfoChips` — mini-set
+  // surfaces the child-friendly `Mini Test` chip instead of the legacy
+  // `KS2-style mini-test` adult copy.
+  assert.match(html, /Mini Test/);
   assert.match(html, /Timed test/);
+  // U3: h2 title is now `grammarSessionProgressLabel` — mini-test uses the
+  // `Mini Test — Question X of N` pattern from U8.
+  assert.match(html, /Mini Test — Question 1 of 8/);
   assert.match(html, /Question 1 of 8/);
   assert.match(html, /Save response/);
   assert.match(html, /Finish mini-set/);
@@ -393,7 +399,7 @@ test('U4: strict mini-test timer expiry auto-finishes with deterministic marking
   assert.equal(grammar.summary.miniTestReview.questions.length, 8);
 });
 
-test('Grammar surface exposes in-session repair actions without local scoring', () => {
+test('Grammar surface exposes post-answer repair actions without local scoring', () => {
   const storage = installMemoryStorage();
   const harness = createGrammarHarness({ storage });
   const sample = grammarOracleSample('fronted_adverbial_choose');
@@ -408,9 +414,14 @@ test('Grammar surface exposes in-session repair actions without local scoring', 
     },
   });
 
+  // U3: pre-answer path surfaces one task + one primary action — no
+  // faded/similar buttons visible before marking. The actions themselves
+  // remain wired and dispatchable (Worker owns authority), but the UI
+  // only reveals them after submission so children see a single primary
+  // action at a time.
   let html = harness.render();
-  assert.match(html, /Faded support/);
-  assert.match(html, /Similar problem/);
+  assert.doesNotMatch(html, /Faded support/);
+  assert.doesNotMatch(html, /Similar problem/);
 
   harness.dispatch('grammar-use-faded-support');
   html = harness.render();
@@ -446,7 +457,7 @@ test('Grammar surface exposes in-session repair actions without local scoring', 
   assert.equal(grammar.session.repair.similarProblems, 1);
 });
 
-test('Grammar session exposes non-scored AI enrichment triggers', () => {
+test('Grammar session exposes non-scored AI enrichment triggers after marking', () => {
   const storage = installMemoryStorage();
   const harness = createGrammarHarness({ storage });
   const sample = grammarOracleSample('fronted_adverbial_choose');
@@ -460,8 +471,23 @@ test('Grammar session exposes non-scored AI enrichment triggers', () => {
     },
   });
 
+  // U3: pre-answer session hides every help surface — no AI trigger
+  // buttons visible until the learner has submitted an answer.
   let html = harness.render();
-  assert.match(html, /Explain this/);
+  assert.doesNotMatch(html, /Explain this/);
+  assert.doesNotMatch(html, /Explain another way/);
+  assert.doesNotMatch(html, /Revision cards/);
+
+  // Submit the correct response so the session enters feedback phase.
+  harness.dispatch('grammar-submit-form', {
+    formData: grammarResponseFormData(sample.correctResponse),
+  });
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'feedback');
+
+  // U3: feedback phase relabels the existing AI enrichment trigger to
+  // `Explain another way`; the revision-card trigger keeps its label.
+  html = harness.render();
+  assert.match(html, /Explain another way/);
   assert.match(html, /Revision cards/);
 
   harness.dispatch('grammar-request-ai-enrichment', { kind: 'explanation' });
@@ -586,7 +612,14 @@ test('Grammar dashboard hides adult-diagnostic goal/teaching toggles but preserv
   assert.equal(grammar.session.supportLevel, 0);
 });
 
-test('Grammar show-domain setting affects display only before answer feedback', () => {
+test('Grammar show-domain preference persists and analytics still register attempts', () => {
+  // U3: the adult `domain` chip has been removed from the session surface.
+  // Setting `showDomainBeforeAnswer` no longer drives visible chip copy —
+  // `grammarSessionInfoChips` surfaces only child-friendly labels. The
+  // preference still lives on `grammar.prefs` for future reuse, but it
+  // must not gate scoring or analytics attempts. This test keeps the
+  // preference-plumbing guarantee and the analytics increment invariant
+  // that the original `show-domain` test protected.
   const storage = installMemoryStorage();
   const harness = createGrammarHarness({ storage });
   const sample = grammarOracleSample('fronted_adverbial_choose');
@@ -601,15 +634,20 @@ test('Grammar show-domain setting affects display only before answer feedback', 
     },
   });
 
-  let html = harness.render();
+  const html = harness.render();
+  // Neither phase surfaces the adult `domain` chip any more.
   assert.doesNotMatch(html, />Adverbials<\/span>/);
 
   harness.dispatch('grammar-submit-form', {
     formData: grammarResponseFormData(sample.correctResponse),
   });
-  html = harness.render();
-  assert.match(html, />Adverbials<\/span>/);
-  assert.equal(harness.store.getState().subjectUi.grammar.analytics.concepts.find((concept) => concept.id === 'adverbials').attempts, 1);
+  // The preference still round-trips into the normalised read model.
+  assert.equal(harness.store.getState().subjectUi.grammar.prefs.showDomainBeforeAnswer, false);
+  // Analytics still records the attempt — U3 only touches surface chrome.
+  assert.equal(
+    harness.store.getState().subjectUi.grammar.analytics.concepts.find((concept) => concept.id === 'adverbials').attempts,
+    1,
+  );
 });
 
 test('Grammar monster progress rehydrates from persisted Codex state after reload normalisation', () => {
@@ -1943,4 +1981,161 @@ test('U2 follower: grammar-focus-concept remote path chains start-session after 
     }, 'learner-a'),
   });
   await Promise.resolve();
+});
+
+// --- U3 session redesign (one task, post-answer help only) -----------------
+//
+// These tests pin the visibility contract that `grammarSessionHelpVisibility`
+// (U8) ships to the JSX. They cover the three canonical states: pre-answer
+// session, post-answer correct, post-answer wrong. Every adult-facing string
+// removed by U3 (`Worker authority`, `Worker-marked question`) is asserted
+// absent, and the full `GRAMMAR_CHILD_FORBIDDEN_TERMS` fixture is iterated on
+// the session HTML so a future leak is caught automatically.
+
+function u3HarnessWithSample() {
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+  const sample = grammarOracleSample('fronted_adverbial_choose');
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-start', {
+    payload: {
+      roundLength: 2,
+      templateId: sample.id,
+      seed: sample.sample.seed,
+    },
+  });
+  return { harness, sample };
+}
+
+function u3ScopeToSessionHtml(html) {
+  // `harness.render()` returns the whole app surface. The session scene is
+  // emitted as `<section class="grammar-session"...>` — we narrow the HTML
+  // so dashboard/analytics panels (which may legitimately hold adult
+  // strings behind a `Grown-up view` disclosure) are not swept by the
+  // forbidden-terms loop.
+  const match = html.match(/<section class="grammar-session"[\s\S]*?<\/section>/);
+  assert.ok(match, 'session scene was rendered');
+  return match[0];
+}
+
+test('U3: pre-answer session hides every help surface', () => {
+  const { harness } = u3HarnessWithSample();
+
+  const grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.phase, 'session');
+  // Silent-no-op hedge (Phase 2 U4): the worked-solution flag stays false
+  // pre-answer, so if a stray button ever slipped through the gate the
+  // state would betray the leak. Mirrors the faded-support assertion.
+  assert.equal(grammar.session.repair.workedSolutionShown, false);
+
+  const sessionHtml = u3ScopeToSessionHtml(harness.render());
+
+  // Help surfaces gated entirely pre-answer.
+  assert.doesNotMatch(sessionHtml, /Explain this/);
+  assert.doesNotMatch(sessionHtml, /Explain another way/);
+  assert.doesNotMatch(sessionHtml, /Revision cards/);
+  assert.doesNotMatch(sessionHtml, /Worked solution/);
+  assert.doesNotMatch(sessionHtml, /Similar problem/);
+  assert.doesNotMatch(sessionHtml, /Faded support/);
+
+  // Adult-facing copy removed by U3.
+  assert.doesNotMatch(sessionHtml, /Worker authority/i);
+  assert.doesNotMatch(sessionHtml, /Worker-marked question/i);
+
+  // Full forbidden-terms sweep on the session HTML. Any new forbidden
+  // term added to the fixture automatically gates this test.
+  for (const term of GRAMMAR_CHILD_FORBIDDEN_TERMS) {
+    assert.doesNotMatch(
+      sessionHtml,
+      new RegExp(escapeRegExp(term), 'i'),
+      `forbidden term leaked into session HTML: ${term}`,
+    );
+  }
+
+  // Single primary action remains: the answer input + Submit button.
+  // U3: the submit label is driven by `grammarSessionSubmitLabel(session,
+  // awaitingAdvance)` — practice/pre-answer resolves to `Submit` (no
+  // `answer` tail), matching the Spelling one-task layout.
+  assert.match(sessionHtml, /name="answer"/);
+  assert.match(sessionHtml, />Submit<\/button>/);
+});
+
+test('U3: post-answer correct shows Next question and hides repair', () => {
+  const { harness, sample } = u3HarnessWithSample();
+
+  harness.dispatch('grammar-submit-form', {
+    formData: grammarResponseFormData(sample.correctResponse),
+  });
+  const grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.phase, 'feedback');
+  assert.equal(grammar.feedback.result.correct, true);
+
+  const sessionHtml = u3ScopeToSessionHtml(harness.render());
+
+  // Primary continuation is the single `Next question` button.
+  assert.match(sessionHtml, /Next question/);
+  // Correct answers do not surface retry / show-a-step / show-answer.
+  assert.doesNotMatch(sessionHtml, /Retry/);
+  assert.doesNotMatch(sessionHtml, /Show a step/);
+  assert.doesNotMatch(sessionHtml, /Show answer/);
+  assert.doesNotMatch(sessionHtml, /Worker authority/i);
+  assert.doesNotMatch(sessionHtml, /Worker-marked question/i);
+});
+
+test('U3: post-answer wrong shows repair + relabelled AI explanation', () => {
+  const { harness, sample } = u3HarnessWithSample();
+  const wrongAnswer = sample.sample.inputSpec.options.find(
+    (option) => option.value !== sample.correctResponse.answer,
+  ).value;
+
+  harness.dispatch('grammar-submit-form', {
+    formData: grammarResponseFormData({ answer: wrongAnswer }),
+  });
+  const grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.phase, 'feedback');
+  assert.equal(grammar.feedback.result.correct, false);
+
+  const sessionHtml = u3ScopeToSessionHtml(harness.render());
+
+  // Post-answer wrong renders every repair / help surface.
+  assert.match(sessionHtml, /Retry/);
+  assert.match(sessionHtml, /Worked solution/);
+  assert.match(sessionHtml, /Similar problem/);
+  // AI enrichment trigger relabelled to child copy in the feedback phase.
+  assert.match(sessionHtml, /Explain another way/);
+  assert.doesNotMatch(sessionHtml, /Explain this/);
+  assert.match(sessionHtml, /Revision cards/);
+  // Adult-facing copy still absent.
+  assert.doesNotMatch(sessionHtml, /Worker authority/i);
+  assert.doesNotMatch(sessionHtml, /Worker-marked question/i);
+});
+
+test('U3: forbidden-terms sweep runs across the full session HTML in every phase', () => {
+  const { harness, sample } = u3HarnessWithSample();
+  const wrongAnswer = sample.sample.inputSpec.options.find(
+    (option) => option.value !== sample.correctResponse.answer,
+  ).value;
+
+  // Pre-answer
+  let sessionHtml = u3ScopeToSessionHtml(harness.render());
+  for (const term of GRAMMAR_CHILD_FORBIDDEN_TERMS) {
+    assert.doesNotMatch(
+      sessionHtml,
+      new RegExp(escapeRegExp(term), 'i'),
+      `pre-answer session leaked forbidden term: ${term}`,
+    );
+  }
+
+  // Post-answer wrong — the densest surface (repair + AI + worked solution).
+  harness.dispatch('grammar-submit-form', {
+    formData: grammarResponseFormData({ answer: wrongAnswer }),
+  });
+  sessionHtml = u3ScopeToSessionHtml(harness.render());
+  for (const term of GRAMMAR_CHILD_FORBIDDEN_TERMS) {
+    assert.doesNotMatch(
+      sessionHtml,
+      new RegExp(escapeRegExp(term), 'i'),
+      `post-answer session leaked forbidden term: ${term}`,
+    );
+  }
 });

--- a/tests/react-grammar-surface.test.js
+++ b/tests/react-grammar-surface.test.js
@@ -478,9 +478,14 @@ test('Grammar session exposes non-scored AI enrichment triggers after marking', 
   assert.doesNotMatch(html, /Explain another way/);
   assert.doesNotMatch(html, /Revision cards/);
 
-  // Submit the correct response so the session enters feedback phase.
+  // U3 follower: the AI enrichment triggers surface in the wrong-answer
+  // branch of feedback (correct answers resolve with a single-line
+  // explanation + Next question only, per plan §U3 lines 592-593).
+  const wrongAnswer = sample.sample.inputSpec.options.find(
+    (option) => option.value !== sample.correctResponse.answer,
+  ).value;
   harness.dispatch('grammar-submit-form', {
-    formData: grammarResponseFormData(sample.correctResponse),
+    formData: grammarResponseFormData({ answer: wrongAnswer }),
   });
   assert.equal(harness.store.getState().subjectUi.grammar.phase, 'feedback');
 
@@ -2078,6 +2083,14 @@ test('U3: post-answer correct shows Next question and hides repair', () => {
   assert.doesNotMatch(sessionHtml, /Retry/);
   assert.doesNotMatch(sessionHtml, /Show a step/);
   assert.doesNotMatch(sessionHtml, /Show answer/);
+  // U3 follower: correct answers also suppress every remediation surface.
+  // `Worked solution`, `Similar problem`, `Faded support`, and the AI
+  // enrichment relabel (`Explain another way`) are post-answer-wrong
+  // affordances only — never surfaced when the learner is correct.
+  assert.doesNotMatch(sessionHtml, /Worked solution/i);
+  assert.doesNotMatch(sessionHtml, /Similar problem/i);
+  assert.doesNotMatch(sessionHtml, /Faded support/i);
+  assert.doesNotMatch(sessionHtml, /Explain another way/i);
   assert.doesNotMatch(sessionHtml, /Worker authority/i);
   assert.doesNotMatch(sessionHtml, /Worker-marked question/i);
 });
@@ -2138,4 +2151,59 @@ test('U3: forbidden-terms sweep runs across the full session HTML in every phase
       `post-answer session leaked forbidden term: ${term}`,
     );
   }
+
+  // U3 follower: post-answer correct — sparser surface but still needs the
+  // forbidden-terms sweep so a future regression (e.g., a progress summary
+  // leaking `Worker authority` into the correct-answer feedback) is caught.
+  const { harness: harness2, sample: sample2 } = u3HarnessWithSample();
+  harness2.dispatch('grammar-submit-form', {
+    formData: grammarResponseFormData(sample2.correctResponse),
+  });
+  sessionHtml = u3ScopeToSessionHtml(harness2.render());
+  for (const term of GRAMMAR_CHILD_FORBIDDEN_TERMS) {
+    assert.doesNotMatch(
+      sessionHtml,
+      new RegExp(escapeRegExp(term), 'i'),
+      `post-answer-correct session leaked forbidden term: ${term}`,
+    );
+  }
+});
+
+// U3 follower: the error banner is rendered via `translateGrammarSessionError`
+// so raw Worker strings never leak to children. The pre-submit validation
+// path (dispatching `grammar-submit-form` with no response) writes a
+// known child-copy string to `grammar.error`; the banner must render that
+// copy and carry `role="alert"` for assistive tech. This test pins both.
+test('U3 follower: error banner renders child copy with role="alert"', () => {
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+  const sample = grammarOracleSample('fronted_adverbial_choose');
+
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-start', {
+    payload: {
+      roundLength: 2,
+      templateId: sample.id,
+      seed: sample.sample.seed,
+    },
+  });
+  // Invalid submit: FormData carries no `answer`, triggering the client-side
+  // `setGrammarError(context, 'Choose or type an answer before submitting.')`
+  // branch in `module.js`.
+  harness.dispatch('grammar-submit-form', { formData: new FormData() });
+
+  const grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.phase, 'session');
+  assert.match(grammar.error, /Choose or type an answer/);
+
+  const sessionHtml = u3ScopeToSessionHtml(harness.render());
+  // Banner preserves `role="alert"` (assistive tech contract).
+  assert.match(sessionHtml, /<div class="feedback bad" role="alert">/);
+  // Banner renders the child-copy translation, NOT the adult-diagnostic
+  // `Grammar command failed` title the pre-follower JSX used.
+  assert.doesNotMatch(sessionHtml, /Grammar command failed/);
+  assert.match(sessionHtml, /Something went wrong/);
+  // In this validation path, the translator preserves the already-child
+  // copy string verbatim — so the banner body shows it.
+  assert.match(sessionHtml, /Choose or type an answer before submitting\./);
 });


### PR DESCRIPTION
## Summary

Ship Unit **U3** of the Grammar Phase 3 UX reset. The independent-practice `GrammarSessionScene.jsx` is rewritten so the learner always sees exactly **one task and one primary action**. Every help surface (AI triggers, worked solution, faded support, similar problem) is gated behind the single U8 truth table `grammarSessionHelpVisibility(session, grammar.phase)` — there is now one place that decides visibility, not five.

Plan reference: [`docs/plans/2026-04-25-004-feat-grammar-phase3-ux-reset-plan.md`](docs/plans/2026-04-25-004-feat-grammar-phase3-ux-reset-plan.md) — Unit U3, lines 565–606.

## Gating rules (via `grammarSessionHelpVisibility`)

- **Pre-answer session** (`grammar.phase === 'session'`): every help flag is `false`. HTML contains only the prompt, input, Read aloud, and `Submit` — no `Explain this`, `Revision cards`, `Worked solution`, `Similar problem`, `Faded support`.
- **Post-answer correct** (`phase === 'feedback'`, `feedback.result.correct === true`): single `Next question` button; no retry / show-a-step / show-answer clutter.
- **Post-answer wrong** (`feedback.result.correct === false`): `Retry` + `Worked solution` + `Similar problem` render, and the existing AI enrichment trigger is relabelled to `Explain another way` (no new Worker action added; only the visible label changes in feedback phase).
- **Mini-test pre-finish**: visibility table returns all-false — U4 handles strictness; this unit only confirms the gate is correctly read.

## Removed adult strings

- `Worker authority` chip (line 478 in the previous version): removed entirely.
- `Worker-marked question` h2 fallback (line 464): replaced with `grammarSessionProgressLabel(session)` (child copy, `Question X of N` / `Mini Test — Question X of N`).
- Adult `domain` chip (`Adverbials`, etc.) and internal `questionType` chip: dropped; chip row is now driven by `grammarSessionInfoChips(session)`.
- Legacy `KS2-style mini-test` chip wording: replaced by the child-friendly `Mini Test` chip from the U8 helper.
- Submit label comes from `grammarSessionSubmitLabel(session, awaitingAdvance)` — practice pre-answer is `Submit`, not `Submit answer`.

## Tests

- `tests/react-grammar-surface.test.js` extended with four U3-dedicated tests:
  - `U3: pre-answer session hides every help surface` — asserts absence of every help button + `name="answer"` and single-action Submit present + silent-no-op hedge `session.repair.workedSolutionShown === false`.
  - `U3: post-answer correct shows Next question and hides repair` — asserts `Next question` present, retry/show-a-step/show-answer absent.
  - `U3: post-answer wrong shows repair + relabelled AI explanation` — asserts Retry / Worked solution / Similar problem + `Explain another way` (not `Explain this`) + `Revision cards`.
  - `U3: forbidden-terms sweep runs across the full session HTML in every phase` — iterates the full `GRAMMAR_CHILD_FORBIDDEN_TERMS` fixture on both pre-answer and post-answer-wrong session HTML.
- Existing tests updated for the new chip row, the new submit label, and the relabelled feedback-phase AI trigger (no coverage loss — each mutation is equivalent to the original assertion after accounting for U3's gating).

## Test plan

- [x] `node --test tests/react-grammar-surface.test.js` (71 / 71 pass).
- [x] `node --test tests/grammar-ui-model.test.js` (81 / 81 pass — U8 helpers unchanged).
- [x] `npm test` — `1610 pass / 1 fail`. The single failure is the pre-existing `grammar-production-smoke` smoke test (`grammar.startModel.stats.templates` leak, unrelated to U3; present on `main`).
- [x] `npm run check` — passes clean; audit and dry-run deploy succeed.
- [ ] Manual SSR inspection of pre-answer render confirms single primary action. _(SSR test HTML snapshots exercised in the new U3 tests.)_