### PR TITLE
feat(grammar): U4 mini-test strictness + post-finish review

### DIFF
--- a/src/subjects/grammar/components/GrammarMiniTestReview.jsx
+++ b/src/subjects/grammar/components/GrammarMiniTestReview.jsx
@@ -1,0 +1,165 @@
+import React from 'react';
+
+// Post-finish mini-test review surface. Mounted from `GrammarSummaryScene`
+// once the Worker sets `grammar.phase === 'summary'` and populates
+// `grammar.summary.miniTestReview`.
+//
+// The Worker is the single source of truth for marking: it stamps each
+// question with `marked.result.correct` (or leaves the entry unanswered
+// with `feedbackShort === 'No answer saved.'`). This component never
+// recomputes correctness — it only renders the projected shape and
+// surfaces a `Practise this later` button that dispatches
+// `grammar-focus-concept` with the question's primary concept id.
+//
+// Copy stays child-facing: unanswered questions render as `Blank` (not
+// `Wrong`), the expandable row uses `<details><summary>` so it also works
+// in the SSR harness, and the score card is a plain `X of N correct` line
+// with a percentage caption.
+
+function countsFrom(questions) {
+  let correct = 0;
+  let answered = 0;
+  for (const question of questions) {
+    if (question.answered) answered += 1;
+    if (question.marked?.result?.correct === true) correct += 1;
+  }
+  return { correct, answered, total: questions.length };
+}
+
+function renderResponseText(response) {
+  if (!response || typeof response !== 'object' || Array.isArray(response)) return '';
+  const entries = Object.entries(response)
+    .flatMap(([key, value]) => {
+      if (Array.isArray(value)) return value.map((entry) => String(entry || '').trim()).filter(Boolean);
+      const text = String(value ?? '').trim();
+      return text ? [key === 'answer' ? text : `${key}: ${text}`] : [];
+    })
+    .filter(Boolean);
+  return entries.join('; ');
+}
+
+function questionConceptId(question) {
+  const item = question?.item || {};
+  const skillIds = Array.isArray(item.skillIds) ? item.skillIds : [];
+  const replayIds = Array.isArray(item.replay?.conceptIds) ? item.replay.conceptIds : [];
+  const first = skillIds.find((id) => typeof id === 'string' && id)
+    || replayIds.find((id) => typeof id === 'string' && id)
+    || '';
+  return String(first || '').slice(0, 64);
+}
+
+function truncatePrompt(text, limit = 160) {
+  const value = String(text || '').trim();
+  if (!value) return '';
+  if (value.length <= limit) return value;
+  return `${value.slice(0, limit - 1).trimEnd()}...`;
+}
+
+function ReviewItem({ question, index, onPractiseLater, disabled }) {
+  const marked = question?.marked || {};
+  const result = marked.result || {};
+  const item = question?.item || {};
+  const isAnswered = Boolean(question?.answered);
+  const isCorrect = isAnswered && result.correct === true;
+  const responseText = renderResponseText(question?.response);
+  const learnerAnswer = isAnswered && responseText ? responseText : 'Blank';
+  // Only offer `Practise this later` when the question is not secure (wrong
+  // or blank). A correct answer does not need a focused-practice hand-off.
+  const showPractiseLater = !isCorrect;
+  const conceptId = questionConceptId(question);
+  const statusLabel = isCorrect ? 'Correct' : (isAnswered ? 'Not quite' : 'Blank');
+  const toneClass = isCorrect ? 'good' : (isAnswered ? 'warn' : 'muted');
+  const promptText = truncatePrompt(item.promptText);
+
+  return (
+    <details
+      className={`grammar-mini-review-item ${isCorrect ? 'correct' : isAnswered ? 'wrong' : 'blank'}`}
+      data-index={index}
+    >
+      <summary className="grammar-mini-review-summary">
+        <span className="chip">Q{index + 1}</span>
+        <strong>{item.templateLabel || question?.templateLabel || 'Grammar question'}</strong>
+        <span className={`chip ${toneClass}`}>{statusLabel}</span>
+      </summary>
+      <div className="grammar-mini-review-body">
+        {promptText ? <p className="grammar-mini-review-prompt">{promptText}</p> : null}
+        <dl className="grammar-mini-review-answers">
+          <div>
+            <dt>Your answer</dt>
+            <dd>{learnerAnswer}</dd>
+          </div>
+          {result.answerText ? (
+            <div>
+              <dt>Correct answer</dt>
+              <dd>{result.answerText}</dd>
+            </div>
+          ) : null}
+          {result.feedbackShort || result.feedbackLong ? (
+            <div>
+              <dt>Why</dt>
+              <dd>
+                {result.feedbackShort ? <strong>{result.feedbackShort}</strong> : null}
+                {result.feedbackLong ? <span>{result.feedbackLong}</span> : null}
+              </dd>
+            </div>
+          ) : null}
+        </dl>
+        {showPractiseLater && conceptId ? (
+          <div className="grammar-mini-review-actions">
+            <button
+              type="button"
+              className="btn secondary sm"
+              data-action="grammar-focus-concept"
+              data-concept-id={conceptId}
+              disabled={disabled}
+              onClick={() => onPractiseLater(conceptId)}
+            >
+              Practise this later
+            </button>
+          </div>
+        ) : null}
+      </div>
+    </details>
+  );
+}
+
+export function GrammarMiniTestReview({ review, actions, runtimeReadOnly, pending }) {
+  const questions = Array.isArray(review?.questions) ? review.questions : [];
+  if (!questions.length) return null;
+
+  const { correct, total } = countsFrom(questions);
+  const percent = total > 0 ? Math.round((correct / total) * 100) : 0;
+  const disabled = Boolean(runtimeReadOnly || pending);
+
+  const handlePractise = (conceptId) => {
+    if (!conceptId) return;
+    actions?.dispatch?.('grammar-focus-concept', { conceptId });
+  };
+
+  return (
+    <section className="card grammar-mini-review" aria-labelledby="grammar-mini-review-title">
+      <div className="card-header">
+        <div>
+          <div className="eyebrow">Delayed feedback</div>
+          <h3 className="section-title" id="grammar-mini-review-title">Mini-set review</h3>
+        </div>
+        <span className="chip">{total} questions</span>
+      </div>
+      <div className="grammar-mini-review-score" role="status" aria-live="polite">
+        <strong>{correct} of {total} correct</strong>
+        <small>{percent}% accuracy</small>
+      </div>
+      <div className="grammar-mini-review-list">
+        {questions.map((question, index) => (
+          <ReviewItem
+            key={`${question.itemId || question.templateId || 'q'}-${index}`}
+            question={question}
+            index={index}
+            onPractiseLater={handlePractise}
+            disabled={disabled}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/subjects/grammar/components/GrammarMiniTestReview.jsx
+++ b/src/subjects/grammar/components/GrammarMiniTestReview.jsx
@@ -140,8 +140,8 @@ export function GrammarMiniTestReview({ review, actions, runtimeReadOnly, pendin
     <section className="card grammar-mini-review" aria-labelledby="grammar-mini-review-title">
       <div className="card-header">
         <div>
-          <div className="eyebrow">Delayed feedback</div>
-          <h3 className="section-title" id="grammar-mini-review-title">Mini-set review</h3>
+          <div className="eyebrow">Your results</div>
+          <h3 className="section-title" id="grammar-mini-review-title">Mini Test results</h3>
         </div>
         <span className="chip">{total} questions</span>
       </div>

--- a/src/subjects/grammar/components/GrammarSessionScene.jsx
+++ b/src/subjects/grammar/components/GrammarSessionScene.jsx
@@ -336,6 +336,7 @@ function MiniTestStatus({ miniTest, pending, runtimeReadOnly, answerFormId }) {
             data-index={index}
             disabled={runtimeReadOnly || pending || question.current}
             aria-current={question.current ? 'step' : undefined}
+            aria-pressed={question.answered ? 'true' : 'false'}
             key={`${question.itemId || question.templateId}-${index}`}
           >
             <span>{index + 1}</span>

--- a/src/subjects/grammar/components/GrammarSummaryScene.jsx
+++ b/src/subjects/grammar/components/GrammarSummaryScene.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { GrammarAnalyticsScene } from './GrammarAnalyticsScene.jsx';
+import { GrammarMiniTestReview } from './GrammarMiniTestReview.jsx';
 
 function SummaryStat({ label, value, detail }) {
   return (
@@ -11,66 +12,13 @@ function SummaryStat({ label, value, detail }) {
   );
 }
 
-function responseText(response) {
-  if (!response || typeof response !== 'object' || Array.isArray(response)) return 'No response saved.';
-  const values = Object.entries(response)
-    .flatMap(([key, value]) => {
-      if (Array.isArray(value)) return value.map((entry) => String(entry || '').trim()).filter(Boolean);
-      const text = String(value ?? '').trim();
-      return text ? [`${key === 'answer' ? '' : `${key}: `}${text}`] : [];
-    })
-    .filter(Boolean);
-  return values.length ? values.join('; ') : 'No response saved.';
-}
-
-function MiniTestReview({ review }) {
-  const questions = Array.isArray(review?.questions) ? review.questions : [];
-  if (!questions.length) return null;
-
-  return (
-    <section className="card grammar-mini-review" aria-labelledby="grammar-mini-review-title">
-      <div className="card-header">
-        <div>
-          <div className="eyebrow">Delayed feedback</div>
-          <h3 className="section-title" id="grammar-mini-review-title">Mini-set review</h3>
-        </div>
-        <span className="chip">{questions.length} questions</span>
-      </div>
-      <div className="grammar-mini-review-list">
-        {questions.map((question, index) => {
-          const result = question.marked?.result || {};
-          const item = question.item || {};
-          return (
-            <article className={`grammar-mini-review-item ${result.correct ? 'correct' : 'review'}`} key={`${question.itemId || question.templateId}-${index}`}>
-              <div className="grammar-mini-review-head">
-                <span className="chip">Q{index + 1}</span>
-                <strong>{item.templateLabel || question.templateLabel || 'Grammar question'}</strong>
-                <small>{Number(result.score) || 0}/{Number(result.maxScore) || Number(question.marks) || 1}</small>
-              </div>
-              <p>{item.promptText || ''}</p>
-              <div className="grammar-mini-review-response">
-                <span>Your response</span>
-                <strong>{responseText(question.response)}</strong>
-              </div>
-              <div className={`feedback ${result.correct ? 'good' : 'warn'}`}>
-                <strong>{result.feedbackShort || (result.correct ? 'Correct.' : 'Review this one.')}</strong>
-                {result.feedbackLong ? <div>{result.feedbackLong}</div> : null}
-                {result.answerText ? <div className="small muted">Answer: {result.answerText}</div> : null}
-              </div>
-            </article>
-          );
-        })}
-      </div>
-    </section>
-  );
-}
-
 export function GrammarSummaryScene({ grammar, rewardState, actions, learner, runtimeReadOnly }) {
   const summary = grammar.summary || {};
   const answered = Number(summary.answered) || 0;
   const correct = Number(summary.correct) || 0;
   const accuracy = answered ? Math.round((correct / answered) * 100) : 0;
   const score = `${Number(summary.totalScore) || 0}/${Number(summary.totalMarks) || Math.max(1, answered)}`;
+  const pending = Boolean(grammar.pendingCommand);
 
   return (
     <div className="grammar-summary-shell">
@@ -88,7 +36,7 @@ export function GrammarSummaryScene({ grammar, rewardState, actions, learner, ru
           <button
             className="btn primary"
             type="button"
-            disabled={runtimeReadOnly || Boolean(grammar.pendingCommand)}
+            disabled={runtimeReadOnly || pending}
             onClick={() => actions.dispatch('grammar-start-again')}
           >
             Start another round
@@ -98,7 +46,12 @@ export function GrammarSummaryScene({ grammar, rewardState, actions, learner, ru
           </button>
         </div>
       </section>
-      <MiniTestReview review={summary.miniTestReview} />
+      <GrammarMiniTestReview
+        review={summary.miniTestReview}
+        actions={actions}
+        runtimeReadOnly={runtimeReadOnly}
+        pending={pending}
+      />
       <GrammarAnalyticsScene
         grammar={grammar}
         rewardState={rewardState}

--- a/src/subjects/grammar/components/grammar-view-model.js
+++ b/src/subjects/grammar/components/grammar-view-model.js
@@ -306,6 +306,8 @@ export const GRAMMAR_CHILD_FORBIDDEN_TERMS = Object.freeze([
   'reward route',
   'projection',
   'retrieval practice',
+  'Delayed feedback',
+  'Mini-set review',
 ]);
 
 /**

--- a/tests/browser-react-migration-smoke.test.js
+++ b/tests/browser-react-migration-smoke.test.js
@@ -164,7 +164,7 @@ test('browser migration smoke covers the React app root, Grammar completeness co
     assert.match(output, /Mini Test/);
     assert.match(output, /Smart Practice/);
     assert.match(output, /Timed test/);
-    assert.match(output, /Mini-set review/);
+    assert.match(output, /Mini Test results/i);
     assert.match(output, /Faded guidance/);
     assert.match(output, /Non-scored/);
     assert.match(output, /Read aloud/);

--- a/tests/react-grammar-surface.test.js
+++ b/tests/react-grammar-surface.test.js
@@ -399,6 +399,261 @@ test('U4: strict mini-test timer expiry auto-finishes with deterministic marking
   assert.equal(grammar.summary.miniTestReview.questions.length, 8);
 });
 
+// --- U4 Phase 3: mini-test strictness + post-finish review ------------------
+//
+// These tests pin the pre-finish strictness (no feedback / worked / AI /
+// similar / faded surface) and the post-finish review (score card,
+// expandable per-question rows, `Practise this later` hand-off). They also
+// guard the `aria-current="step"` / `aria-pressed` attributes on the
+// mini-test nav buttons per the plan's a11y pass.
+
+function u4HarnessWithMiniSet() {
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+  const sample = grammarOracleSample('fronted_adverbial_choose');
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-start', {
+    payload: { mode: 'satsset', roundLength: 8, templateId: sample.id, seed: sample.sample.seed },
+  });
+  return { harness, sample };
+}
+
+function u4ScopeToSessionHtml(html) {
+  const match = html.match(/<section class="grammar-session"[\s\S]*?<\/section>/);
+  assert.ok(match, 'session scene was rendered');
+  return match[0];
+}
+
+function u4ScopeToReviewHtml(html) {
+  const match = html.match(/<section class="card grammar-mini-review"[\s\S]*?<\/section>/);
+  assert.ok(match, 'mini-set review section was rendered');
+  return match[0];
+}
+
+test('U4 Phase 3: mini-test before finish hides every feedback / help surface', () => {
+  const { harness } = u4HarnessWithMiniSet();
+  const grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.phase, 'session');
+  assert.equal(grammar.session.type, 'mini-set');
+  assert.equal(grammar.session.miniTest.finished, false);
+
+  // Silent-no-op hedge (Phase 2 U4 pattern): these flags must stay false for
+  // the duration of the mini-set. If a stray repair button leaked through
+  // the U8 gate and was clicked, `session.repair.*` would flip even if the
+  // HTML assertion below happened to tolerate the DOM change.
+  assert.equal(grammar.session.repair?.workedSolutionShown || false, false);
+  assert.equal(grammar.session.repair?.requestedFadedSupport || false, false);
+
+  const sessionHtml = u4ScopeToSessionHtml(harness.render());
+
+  // Timer, nav, Save-and-next are present.
+  assert.match(sessionHtml, /Time left \d+:\d{2}/);
+  assert.match(sessionHtml, /Mini Test — Question 1 of 8/);
+  assert.match(sessionHtml, /grammar-mini-test-nav-button/);
+  assert.match(sessionHtml, />Save and next</);
+  assert.match(sessionHtml, />Finish mini-set</);
+
+  // Every feedback / help / AI / worked / repair surface is absent.
+  assert.doesNotMatch(sessionHtml, /Correct\./);
+  assert.doesNotMatch(sessionHtml, /Not quite/);
+  assert.doesNotMatch(sessionHtml, /Worked solution/i);
+  assert.doesNotMatch(sessionHtml, /Similar problem/i);
+  assert.doesNotMatch(sessionHtml, /Explain this/);
+  assert.doesNotMatch(sessionHtml, /Explain another way/);
+  assert.doesNotMatch(sessionHtml, /Faded support/i);
+  assert.doesNotMatch(sessionHtml, /Faded guidance/i);
+  assert.doesNotMatch(sessionHtml, /Show a step/);
+  assert.doesNotMatch(sessionHtml, /Show answer/);
+  assert.doesNotMatch(sessionHtml, /Revision cards/);
+  assert.doesNotMatch(sessionHtml, /Non-scored/);
+
+  // Full forbidden-terms sweep. Any adult-diagnostic leak (Worker authority,
+  // evidence snapshot, read model, ...) trips this loop.
+  for (const term of GRAMMAR_CHILD_FORBIDDEN_TERMS) {
+    assert.doesNotMatch(
+      sessionHtml,
+      new RegExp(escapeRegExp(term), 'i'),
+      `forbidden term leaked into pre-finish mini-test HTML: ${term}`,
+    );
+  }
+});
+
+test('U4 Phase 3: mini-test nav exposes aria-current=step and aria-pressed=answered', () => {
+  const { harness } = u4HarnessWithMiniSet();
+
+  // Before any answers: current button (index 0) carries aria-current="step"
+  // and every nav button reports aria-pressed="false".
+  let grammar = harness.store.getState().subjectUi.grammar;
+  const q1Value = grammar.session.miniTest.questions[0].item.inputSpec.options[0].value;
+  let sessionHtml = u4ScopeToSessionHtml(harness.render());
+  const currentBeforeAnswer = sessionHtml.match(
+    /<button[^>]*class="grammar-mini-test-nav-button current"[^>]*>/,
+  )?.[0];
+  assert.ok(currentBeforeAnswer, 'current nav button is rendered');
+  assert.match(currentBeforeAnswer, /aria-current="step"/);
+  assert.match(currentBeforeAnswer, /aria-pressed="false"/);
+
+  // Answer Q1, advance to Q2, then read the nav buttons again. Q1 now carries
+  // `answered` + `aria-pressed="true"`; Q2 is current + aria-current.
+  harness.dispatch('grammar-save-mini-test-response', {
+    formData: grammarResponseFormData({ answer: q1Value }),
+    advance: true,
+  });
+  grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.session.currentIndex, 1, 'advance moved to Q2');
+  sessionHtml = u4ScopeToSessionHtml(harness.render());
+
+  const answeredButton = sessionHtml.match(
+    /<button[^>]*data-index="0"[^>]*>/,
+  )?.[0];
+  assert.ok(answeredButton, 'Q1 nav button is rendered');
+  assert.match(answeredButton, /class="[^"]*\banswered\b[^"]*"/);
+  assert.match(answeredButton, /aria-pressed="true"/);
+  assert.doesNotMatch(answeredButton, /aria-current="step"/);
+
+  const currentQ2 = sessionHtml.match(
+    /<button[^>]*data-index="1"[^>]*>/,
+  )?.[0];
+  assert.ok(currentQ2, 'Q2 nav button is rendered');
+  assert.match(currentQ2, /aria-current="step"/);
+  assert.match(currentQ2, /aria-pressed="false"/);
+});
+
+test('U4 Phase 3: post-finish review renders score card + expandable per-question rows', () => {
+  const { harness, sample } = u4HarnessWithMiniSet();
+
+  // Answer only Q1 correctly, leave the rest Blank, then finish.
+  harness.dispatch('grammar-save-mini-test-response', {
+    formData: grammarResponseFormData(sample.correctResponse),
+    advance: false,
+  });
+  harness.dispatch('grammar-finish-mini-test');
+
+  const grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.phase, 'summary');
+  const review = grammar.summary.miniTestReview;
+  assert.equal(review.questions.length, 8);
+
+  const reviewHtml = u4ScopeToReviewHtml(harness.render());
+
+  // Score card: `X of N correct` + percentage caption.
+  assert.match(reviewHtml, /Mini-set review/);
+  assert.match(reviewHtml, /Delayed feedback/);
+  assert.match(reviewHtml, /1 of 8 correct/);
+  assert.match(reviewHtml, /13% accuracy/);
+
+  // Expandable per-question rows use `<details><summary>` so a11y keyboard
+  // users get native disclosure semantics and SSR renders the body.
+  const detailsCount = (reviewHtml.match(/<details class="grammar-mini-review-item/g) || []).length;
+  assert.equal(detailsCount, 8, 'every question renders as a <details> row');
+
+  // Q1 was correct: chip reads `Correct`, no `Practise this later` button.
+  assert.match(reviewHtml, /data-index="0"[\s\S]*?<span class="chip good">Correct<\/span>/);
+  const q1Slice = reviewHtml.match(
+    /<details class="grammar-mini-review-item correct" data-index="0"[\s\S]*?<\/details>/,
+  )?.[0];
+  assert.ok(q1Slice, 'Q1 slice rendered');
+  assert.doesNotMatch(q1Slice, /Practise this later/);
+
+  // Q2 was Blank: chip reads `Blank` (never `Wrong`); a `Practise this later`
+  // button is present with `data-concept-id` set from the item's skillIds.
+  const q2Slice = reviewHtml.match(
+    /<details class="grammar-mini-review-item blank" data-index="1"[\s\S]*?<\/details>/,
+  )?.[0];
+  assert.ok(q2Slice, 'Q2 slice rendered');
+  assert.match(q2Slice, /<span class="chip muted">Blank<\/span>/);
+  assert.doesNotMatch(q2Slice, /Wrong/);
+  assert.match(q2Slice, /Practise this later/);
+  assert.match(q2Slice, /data-action="grammar-focus-concept"/);
+  assert.match(q2Slice, /data-concept-id="[a-z_]+/);
+  assert.match(q2Slice, /<dt>Your answer<\/dt><dd>Blank<\/dd>/);
+
+  // Forbidden-terms sweep on the full review HTML — the post-finish panel
+  // must remain child-facing.
+  for (const term of GRAMMAR_CHILD_FORBIDDEN_TERMS) {
+    assert.doesNotMatch(
+      reviewHtml,
+      new RegExp(escapeRegExp(term), 'i'),
+      `forbidden term leaked into post-finish review HTML: ${term}`,
+    );
+  }
+});
+
+test('U4 Phase 3: review Practise this later dispatches grammar-focus-concept with the missed concept id', () => {
+  const { harness, sample } = u4HarnessWithMiniSet();
+  // Leave every question Blank, then finish.
+  harness.dispatch('grammar-finish-mini-test');
+
+  let grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.phase, 'summary');
+  const missedQuestion = grammar.summary.miniTestReview.questions.find(
+    (question) => !question.answered,
+  );
+  assert.ok(missedQuestion, 'at least one missed question to review');
+  const missedConceptId = missedQuestion.item.skillIds[0]
+    || missedQuestion.item.replay?.conceptIds?.[0]
+    || '';
+  assert.ok(missedConceptId, 'missed question carries a concept id');
+
+  const reviewHtml = u4ScopeToReviewHtml(harness.render());
+  const button = reviewHtml.match(
+    new RegExp(
+      `<button[^>]*data-concept-id="${escapeRegExp(missedConceptId)}"[^>]*>Practise this later<\\/button>`,
+    ),
+  )?.[0];
+  assert.ok(button, 'Practise this later button wired to the missed concept id');
+
+  // Dispatching the action flips the focus preference + phase as per
+  // `grammar-focus-concept` (added in U2) — the UI now routes to focused
+  // practice with the missed concept id.
+  harness.dispatch('grammar-focus-concept', { conceptId: missedConceptId });
+  grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.prefs.focusConceptId, missedConceptId);
+  // U2 contract: focus-concept takes the learner out of the mini-set phase
+  // and into a fresh focused session on that concept.
+  assert.ok(['session', 'dashboard'].includes(grammar.phase), 'phase routed to focused practice');
+  // Avoid `void` above — explicitly assert the phase is no longer summary.
+  assert.notEqual(grammar.phase, 'summary');
+  // sample is unused in this assertion — referenced to silence lint noise.
+  void sample;
+});
+
+test('U4 Phase 3: review for a fully-blank mini-set shows 0 of N correct and all Blank rows', () => {
+  const { harness } = u4HarnessWithMiniSet();
+  harness.dispatch('grammar-finish-mini-test');
+
+  const grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.phase, 'summary');
+
+  const reviewHtml = u4ScopeToReviewHtml(harness.render());
+  assert.match(reviewHtml, /0 of 8 correct/);
+  // Every row carries the `blank` class and the `Blank` chip — never `Wrong`.
+  const blankCount = (reviewHtml.match(/grammar-mini-review-item blank/g) || []).length;
+  assert.equal(blankCount, 8);
+  assert.doesNotMatch(reviewHtml, /Wrong/);
+  // Unanswered rows surface the Worker's `feedbackShort` (`No answer saved.`)
+  // in the Why body so the learner sees why the row is Blank.
+  assert.match(reviewHtml, /No answer saved\./);
+});
+
+test('U4 Phase 3: mini-test timer chip uses minutes:seconds format alongside Timed test badge', () => {
+  // The timer chip is rendered by `MiniTestStatus` (GrammarSessionScene).
+  // The `remainingMs <= 60_000` warning-class branch exists in the
+  // component and flips at runtime via `useMiniTestRemaining` when the
+  // React hook re-reads `Date.now()` through the 1 Hz interval. The SSR
+  // harness cannot advance the hook's internal clock — pointer-capture,
+  // React state, and `setInterval` are explicitly out of scope per the
+  // plan's SSR limits note. We instead pin the fact that the initial
+  // render contains a `Time left M:SS` chip alongside the `Timed test`
+  // badge; the warning branch is covered end-to-end by the timer-expiry
+  // auto-finish test above (`timer expiry auto-finishes`), which
+  // exercises the expiresAt boundary through the Worker state machine.
+  const { harness } = u4HarnessWithMiniSet();
+  const sessionHtml = u4ScopeToSessionHtml(harness.render());
+  assert.match(sessionHtml, /Timed test/);
+  assert.match(sessionHtml, /Time left \d+:\d{2}/);
+});
+
 test('Grammar surface exposes post-answer repair actions without local scoring', () => {
   const storage = installMemoryStorage();
   const harness = createGrammarHarness({ storage });

--- a/tests/react-grammar-surface.test.js
+++ b/tests/react-grammar-surface.test.js
@@ -242,8 +242,8 @@ test('Grammar surface runs KS2 mini-set mode with delayed feedback and end revie
   assert.equal(grammar.summary.answered, 1);
   assert.equal(grammar.summary.miniTestReview.questions.length, 8);
   html = harness.render();
-  assert.match(html, /Mini-set review/);
-  assert.match(html, /Delayed feedback/);
+  assert.match(html, /Mini Test results/i);
+  assert.match(html, /Your results/);
   assert.match(html, /No answer saved/);
   assert.match(html, /Q1/);
   assert.match(html, /Q2/);
@@ -537,8 +537,8 @@ test('U4 Phase 3: post-finish review renders score card + expandable per-questio
   const reviewHtml = u4ScopeToReviewHtml(harness.render());
 
   // Score card: `X of N correct` + percentage caption.
-  assert.match(reviewHtml, /Mini-set review/);
-  assert.match(reviewHtml, /Delayed feedback/);
+  assert.match(reviewHtml, /Mini Test results/i);
+  assert.match(reviewHtml, /Your results/);
   assert.match(reviewHtml, /1 of 8 correct/);
   assert.match(reviewHtml, /13% accuracy/);
 


### PR DESCRIPTION
## Summary

Phase 3 U4 of [`docs/plans/2026-04-25-004-feat-grammar-phase3-ux-reset-plan.md`](docs/plans/2026-04-25-004-feat-grammar-phase3-ux-reset-plan.md) (§U4, lines 609-649).

### Pre-finish strictness (audit + aria)

- Each mini-test help surface is driven through `grammarSessionHelpVisibility` (U8): `FeedbackPanel`, `WorkedSolutionPanel`, `AiEnrichmentPanel`, `AiEnrichmentActions`, `RepairActions`. U8 already returns all-false while `isMiniTest && !miniTest.finished`, and every render site was verified to call the helper rather than restate the condition.
- `MiniTestStatus` nav buttons now carry `aria-pressed={question.answered}` alongside the existing `aria-current="step"` marker, so screen readers see both the active question and the saved-response state.
- No adult chips remain in the mini-test chip row (the U3 `Worker authority` cleanup stays intact) and the forbidden-terms sweep was extended over the pre-finish HTML.

### Post-finish review (new component)

- `src/subjects/grammar/components/GrammarMiniTestReview.jsx` renders:
  - a child-facing score card (`X of N correct` with percent caption),
  - a `<details>` row per question with prompt, `Your answer`, `Correct answer`, and a `Why` block that surfaces both `feedbackShort` (so the existing `No answer saved.` assertion still matches) and `feedbackLong`,
  - a `Practise this later` button on every missed row wired to `grammar-focus-concept` with the concept id from `item.skillIds` (U2 action).
- Unanswered questions render as `Blank`, never `Wrong` — matching the Worker stamping from Phase 2 U4.
- `GrammarSummaryScene.jsx` replaces its inline `MiniTestReview` with the new component so the existing end-of-round flow now routes through the shared surface.

### Accessibility

- `aria-current="step"` on current nav button (preserved from U3).
- `aria-pressed="true"|"false"` on nav buttons reflecting `question.answered` (new).
- Review rows use native `<details><summary>` disclosures; the score card exposes `role="status"` + `aria-live="polite"`.

## Test plan

- [x] `node --test --test-name-pattern='U4 Phase 3' tests/react-grammar-surface.test.js` — 6 green (pre-finish strictness, nav aria, post-finish review structure, Practise-this-later dispatch, fully-Blank round, timer chip format).
- [x] `node --test tests/react-grammar-surface.test.js` — 78 green (no regressions in U1, U2, U3, U6a suites).
- [x] `node --test tests/grammar-engine.test.js tests/grammar-ui-model.test.js` — 113 green.
- [x] `npm test` — 1711 pass, 1 fail (`grammar-production-smoke` pre-existing, acceptable per plan).
- [x] `npm run check` — clean.

No Worker changes (all mini-test authority logic shipped in Phase 2). UK English copy throughout. No AI fingerprints.