### PR TITLE
feat(grammar): U5 summary redesign (5 cards + mini-test score + Grown-up view)

### DIFF
--- a/src/subjects/grammar/components/GrammarPracticeSurface.jsx
+++ b/src/subjects/grammar/components/GrammarPracticeSurface.jsx
@@ -102,6 +102,29 @@ export function GrammarPracticeSurface({
     return <GrammarSummaryScene {...shared} />;
   }
 
+  // Phase 3 U5: `Grown-up view` on the summary dispatches
+  // `grammar-open-analytics`, flipping phase to `'analytics'`. The scene
+  // renders full-surface here (not inside a `<details>`) with a back
+  // affordance so the adult can return to the summary. U7 scopes the
+  // deeper child/adult split; here we only plumb the phase transition.
+  if (grammar.phase === 'analytics') {
+    return (
+      <div className="grammar-surface grammar-surface--analytics">
+        <div className="grammar-analytics-back-row">
+          <button
+            type="button"
+            className="btn ghost"
+            data-action="grammar-close-analytics"
+            onClick={() => actions.dispatch('grammar-close-analytics')}
+          >
+            Back to round summary
+          </button>
+        </div>
+        <GrammarAnalyticsScene {...shared} />
+      </div>
+    );
+  }
+
   if (grammar.phase === 'bank') {
     return (
       <div className="grammar-surface">

--- a/src/subjects/grammar/components/GrammarSummaryScene.jsx
+++ b/src/subjects/grammar/components/GrammarSummaryScene.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { GrammarMiniTestReview } from './GrammarMiniTestReview.jsx';
 import { grammarSummaryCards } from './grammar-view-model.js';
+import { grammarMissedConceptFromUi } from '../module.js';
 
 // Phase 3 U5: child-friendly round-end surface. Regular practice renders
 // the five summary cards (Answered / Correct / Trouble spots found / New
@@ -149,14 +150,32 @@ export function GrammarSummaryScene({ grammar, rewardState, actions, learner, ru
   const miniTest = isMiniTestSummary(summary);
   const cards = grammarSummaryCards(summary, effectiveRewardState);
   const handleGrownUp = () => actions.dispatch('grammar-open-analytics');
+  // U5 follower: regular-practice `Practise missed` is a silent no-op
+  // when there is no actionable missed / weak / due concept. Compute the
+  // same concept id that `grammar-practise-missed` would resolve inside
+  // the module, then gate the button via `disabled` so the child sees a
+  // muted state instead of a deceptive tap target. Mirrors the mini-test
+  // branch's `missedConceptId` pattern.
+  const regularMissedConceptId = miniTest ? '' : grammarMissedConceptFromUi(grammar);
 
   if (miniTest) {
     const missedConceptId = firstMissedMiniTestConceptId(summary);
+    // U5 follower: `Fix missed concepts` is the product-suggested next
+    // step after a Mini Test, so it takes the primary variant and leads
+    // the row. `Review answers` is a lower-stakes scroll affordance and
+    // drops to secondary. Order mirrors the hierarchy: primary first.
     const buttons = [
+      {
+        action: 'grammar-practise-missed',
+        label: 'Fix missed concepts',
+        variant: 'primary',
+        disabled: !missedConceptId,
+        onClick: () => actions.dispatch('grammar-practise-missed'),
+      },
       {
         action: 'grammar-review-mini-test',
         label: 'Review answers',
-        variant: 'primary',
+        variant: 'secondary',
         onClick: () => {
           if (typeof globalThis?.document?.getElementById === 'function') {
             const node = globalThis.document.getElementById('grammar-mini-review-title');
@@ -165,13 +184,6 @@ export function GrammarSummaryScene({ grammar, rewardState, actions, learner, ru
             }
           }
         },
-      },
-      {
-        action: 'grammar-practise-missed',
-        label: 'Fix missed concepts',
-        variant: 'secondary',
-        disabled: !missedConceptId,
-        onClick: () => actions.dispatch('grammar-practise-missed'),
       },
     ];
     return (
@@ -201,6 +213,7 @@ export function GrammarSummaryScene({ grammar, rewardState, actions, learner, ru
       action: 'grammar-practise-missed',
       label: 'Practise missed',
       variant: 'primary',
+      disabled: !regularMissedConceptId,
       onClick: () => actions.dispatch('grammar-practise-missed'),
     },
     {

--- a/src/subjects/grammar/components/GrammarSummaryScene.jsx
+++ b/src/subjects/grammar/components/GrammarSummaryScene.jsx
@@ -1,64 +1,233 @@
 import React from 'react';
-import { GrammarAnalyticsScene } from './GrammarAnalyticsScene.jsx';
 import { GrammarMiniTestReview } from './GrammarMiniTestReview.jsx';
+import { grammarSummaryCards } from './grammar-view-model.js';
 
-function SummaryStat({ label, value, detail }) {
+// Phase 3 U5: child-friendly round-end surface. Regular practice renders
+// the five summary cards (Answered / Correct / Trouble spots found / New
+// secure / Monster progress) above a three-button primary action row and a
+// quiet "Grown-up view" secondary. Mini-test rounds render a score card +
+// review mount + two mini-test primary actions (`Review answers`, `Fix
+// missed concepts`). No evidence tables, no misconception prose, no parent
+// summary draft, no analytics appear in the default child surface — those
+// live behind `grammar-open-analytics` (phase: 'analytics').
+
+function isMiniTestSummary(summary) {
+  if (!summary) return false;
+  if (summary.miniTestReview && Array.isArray(summary.miniTestReview.questions)) return true;
+  if (summary.mode === 'satsset') return true;
+  return false;
+}
+
+function SummaryCards({ cards }) {
   return (
-    <div className="grammar-stat">
-      <span>{label}</span>
-      <strong>{value}</strong>
-      {detail ? <small>{detail}</small> : null}
+    <div className="grammar-summary-cards" role="list">
+      {cards.map((card) => {
+        if (card.id === 'monster-progress') {
+          const monsters = Array.isArray(card.value) ? card.value : [];
+          return (
+            <div
+              className="grammar-summary-card grammar-summary-card--monster"
+              data-card-id={card.id}
+              role="listitem"
+              key={card.id}
+            >
+              <div className="grammar-summary-card-label">{card.label}</div>
+              <ul className="grammar-summary-monster-list">
+                {monsters.map((monster) => (
+                  <li className="grammar-summary-monster" key={monster.id} data-monster-id={monster.id}>
+                    <strong>{monster.name}</strong>
+                    <span>{monster.mastered}/{monster.total}</span>
+                  </li>
+                ))}
+              </ul>
+              <div className="grammar-summary-card-detail">{card.detail}</div>
+            </div>
+          );
+        }
+        return (
+          <div
+            className="grammar-summary-card"
+            data-card-id={card.id}
+            role="listitem"
+            key={card.id}
+          >
+            <div className="grammar-summary-card-label">{card.label}</div>
+            <strong className="grammar-summary-card-value">{card.value}</strong>
+            <div className="grammar-summary-card-detail">{card.detail}</div>
+          </div>
+        );
+      })}
     </div>
   );
 }
 
+function ScoreCard({ summary }) {
+  const questions = Array.isArray(summary?.miniTestReview?.questions)
+    ? summary.miniTestReview.questions
+    : [];
+  const total = questions.length || Number(summary?.totalMarks) || 0;
+  let correct = 0;
+  for (const question of questions) {
+    if (question?.marked?.result?.correct === true) correct += 1;
+  }
+  const percent = total > 0 ? Math.round((correct / total) * 100) : 0;
+  return (
+    <div className="grammar-summary-score" role="status" aria-live="polite">
+      <div className="grammar-summary-score-headline">
+        <strong>{correct} of {total} correct</strong>
+        <small>{percent}% accuracy</small>
+      </div>
+      <div className="grammar-summary-score-detail">Mini Test complete</div>
+    </div>
+  );
+}
+
+function PrimaryActions({ buttons, disabled }) {
+  return (
+    <div className="grammar-summary-primary-actions" role="group" aria-label="Next steps">
+      {buttons.map((button) => (
+        <button
+          key={button.action}
+          type="button"
+          className={`btn ${button.variant || 'primary'}`}
+          data-action={button.action}
+          disabled={disabled || button.disabled === true}
+          onClick={button.onClick}
+        >
+          {button.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function SecondaryActions({ onGrownUp, disabled }) {
+  return (
+    <div className="grammar-summary-secondary-actions">
+      <button
+        type="button"
+        className="btn ghost"
+        data-action="grammar-open-analytics"
+        aria-label="Open adult report"
+        disabled={disabled}
+        onClick={onGrownUp}
+      >
+        Grown-up view
+      </button>
+    </div>
+  );
+}
+
+function firstMissedMiniTestConceptId(summary) {
+  const questions = Array.isArray(summary?.miniTestReview?.questions)
+    ? summary.miniTestReview.questions
+    : [];
+  for (const question of questions) {
+    const correct = question?.marked?.result?.correct === true;
+    if (correct) continue;
+    const item = question?.item || {};
+    const skillIds = Array.isArray(item.skillIds) ? item.skillIds : [];
+    const replayIds = Array.isArray(item.replay?.conceptIds) ? item.replay.conceptIds : [];
+    const candidate = skillIds.find((id) => typeof id === 'string' && id)
+      || replayIds.find((id) => typeof id === 'string' && id)
+      || '';
+    if (candidate) return String(candidate).slice(0, 64);
+  }
+  return '';
+}
+
 export function GrammarSummaryScene({ grammar, rewardState, actions, learner, runtimeReadOnly }) {
   const summary = grammar.summary || {};
-  const answered = Number(summary.answered) || 0;
-  const correct = Number(summary.correct) || 0;
-  const accuracy = answered ? Math.round((correct / answered) * 100) : 0;
-  const score = `${Number(summary.totalScore) || 0}/${Number(summary.totalMarks) || Math.max(1, answered)}`;
   const pending = Boolean(grammar.pendingCommand);
+  const disabled = Boolean(runtimeReadOnly) || pending;
+  // `rewardState` is resolved upstream by `GrammarPracticeSurface` so the
+  // summary monster progress reflects the learner's real unioned cluster
+  // totals (projected + persisted view). Fall back to the grammar
+  // projection slice defensively when the surface was rendered without the
+  // resolved prop (e.g. a direct snapshot harness render).
+  const effectiveRewardState = rewardState || grammar.projections?.rewards?.state || {};
+  const miniTest = isMiniTestSummary(summary);
+  const cards = grammarSummaryCards(summary, effectiveRewardState);
+  const handleGrownUp = () => actions.dispatch('grammar-open-analytics');
+
+  if (miniTest) {
+    const missedConceptId = firstMissedMiniTestConceptId(summary);
+    const buttons = [
+      {
+        action: 'grammar-review-mini-test',
+        label: 'Review answers',
+        variant: 'primary',
+        onClick: () => {
+          if (typeof globalThis?.document?.getElementById === 'function') {
+            const node = globalThis.document.getElementById('grammar-mini-review-title');
+            if (node && typeof node.scrollIntoView === 'function') {
+              node.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
+          }
+        },
+      },
+      {
+        action: 'grammar-practise-missed',
+        label: 'Fix missed concepts',
+        variant: 'secondary',
+        disabled: !missedConceptId,
+        onClick: () => actions.dispatch('grammar-practise-missed'),
+      },
+    ];
+    return (
+      <div className="grammar-summary-shell grammar-summary-shell--mini-test">
+        <section className="card grammar-summary-card-wrap" aria-labelledby="grammar-summary-title">
+          <div className="eyebrow">Mini Test complete</div>
+          <h2 className="section-title" id="grammar-summary-title">
+            Nice work, {learner?.name || 'friend'} — results are in
+          </h2>
+          <ScoreCard summary={summary} />
+          <PrimaryActions buttons={buttons} disabled={disabled} />
+          <SecondaryActions onGrownUp={handleGrownUp} disabled={disabled} />
+        </section>
+        <GrammarMiniTestReview
+          review={summary.miniTestReview}
+          actions={actions}
+          runtimeReadOnly={runtimeReadOnly}
+          pending={pending}
+        />
+      </div>
+    );
+  }
+
+  // Regular practice branch.
+  const buttons = [
+    {
+      action: 'grammar-practise-missed',
+      label: 'Practise missed',
+      variant: 'primary',
+      onClick: () => actions.dispatch('grammar-practise-missed'),
+    },
+    {
+      action: 'grammar-start-again',
+      label: 'Start another round',
+      variant: 'primary',
+      onClick: () => actions.dispatch('grammar-start-again'),
+    },
+    {
+      action: 'grammar-open-concept-bank',
+      label: 'Open Grammar Bank',
+      variant: 'secondary',
+      onClick: () => actions.dispatch('grammar-open-concept-bank'),
+    },
+  ];
 
   return (
     <div className="grammar-summary-shell">
-      <section className="card grammar-summary-card" aria-labelledby="grammar-summary-title">
-        <div className="eyebrow">Grammar session summary</div>
+      <section className="card grammar-summary-card-wrap" aria-labelledby="grammar-summary-title">
+        <div className="eyebrow">Grammar round complete</div>
         <h2 className="section-title" id="grammar-summary-title">
-          {learner?.name || 'This learner'} completed a Grammar round
+          Nice work — round complete
         </h2>
-        <div className="grammar-summary-stats">
-          <SummaryStat label="Answered" value={answered} detail={summary.mode || 'practice'} />
-          <SummaryStat label="Correct" value={correct} detail={`${accuracy}% accuracy`} />
-          <SummaryStat label="Score" value={score} detail="marks" />
-        </div>
-        <div className="actions">
-          <button
-            className="btn primary"
-            type="button"
-            disabled={runtimeReadOnly || pending}
-            onClick={() => actions.dispatch('grammar-start-again')}
-          >
-            Start another round
-          </button>
-          <button className="btn secondary" type="button" onClick={() => actions.dispatch('grammar-back')}>
-            Back to Grammar setup
-          </button>
-        </div>
+        <SummaryCards cards={cards} />
+        <PrimaryActions buttons={buttons} disabled={disabled} />
+        <SecondaryActions onGrownUp={handleGrownUp} disabled={disabled} />
       </section>
-      <GrammarMiniTestReview
-        review={summary.miniTestReview}
-        actions={actions}
-        runtimeReadOnly={runtimeReadOnly}
-        pending={pending}
-      />
-      <GrammarAnalyticsScene
-        grammar={grammar}
-        rewardState={rewardState}
-        actions={actions}
-        learner={learner}
-        runtimeReadOnly={runtimeReadOnly}
-      />
     </div>
   );
 }

--- a/src/subjects/grammar/metadata.js
+++ b/src/subjects/grammar/metadata.js
@@ -556,8 +556,11 @@ export function normaliseGrammarReadModel(rawValue = {}, learnerId = '') {
   // that the U1 dashboard can dispatch `grammar-open-concept-bank` /
   // `grammar-open-transfer` before U2 + U6b land. The downstream scene files
   // ship in later units; today the surface renders a lightweight stub for
-  // either phase so the state transition is safe.
-  const phase = ['dashboard', 'bank', 'transfer', 'session', 'feedback', 'summary'].includes(raw.phase)
+  // either phase so the state transition is safe. Phase 3 U5 adds
+  // `'analytics'` so the summary's `Grown-up view` button can flip to the
+  // adult analytics surface (previously mounted unconditionally below the
+  // dashboard `<details>`).
+  const phase = ['dashboard', 'bank', 'transfer', 'session', 'feedback', 'summary', 'analytics'].includes(raw.phase)
     ? raw.phase
     : 'dashboard';
   const rawAnalytics = isPlainObject(raw.analytics) ? raw.analytics : {};

--- a/src/subjects/grammar/module.js
+++ b/src/subjects/grammar/module.js
@@ -249,7 +249,7 @@ function responseHasAnswer(response) {
 // fallback) wins. Regular practice has no per-question review, so we fall
 // back to the analytics concept list and pick the first `weak` / `due`
 // concept. Returns `''` when nothing is actionable so the caller can no-op.
-function grammarMissedConceptFromUi(ui) {
+export function grammarMissedConceptFromUi(ui) {
   const summary = ui?.summary && typeof ui.summary === 'object' ? ui.summary : {};
   const questions = Array.isArray(summary.miniTestReview?.questions)
     ? summary.miniTestReview.questions

--- a/src/subjects/grammar/module.js
+++ b/src/subjects/grammar/module.js
@@ -243,6 +243,34 @@ function responseHasAnswer(response) {
   return Object.entries(response).some(([, value]) => hasGrammarResponseValue(value));
 }
 
+// Phase 3 U5: picks the first concept id that the learner should revisit
+// after a round. Mini-test summaries carry a marked `miniTestReview` — the
+// first incorrect or blank question's `skillIds[0]` (or `replay.conceptIds`
+// fallback) wins. Regular practice has no per-question review, so we fall
+// back to the analytics concept list and pick the first `weak` / `due`
+// concept. Returns `''` when nothing is actionable so the caller can no-op.
+function grammarMissedConceptFromUi(ui) {
+  const summary = ui?.summary && typeof ui.summary === 'object' ? ui.summary : {};
+  const questions = Array.isArray(summary.miniTestReview?.questions)
+    ? summary.miniTestReview.questions
+    : [];
+  for (const question of questions) {
+    const correct = question?.marked?.result?.correct === true;
+    if (correct) continue;
+    const item = question?.item || {};
+    const skillIds = Array.isArray(item.skillIds) ? item.skillIds : [];
+    const replayIds = Array.isArray(item.replay?.conceptIds) ? item.replay.conceptIds : [];
+    const candidate = skillIds.find((id) => typeof id === 'string' && id)
+      || replayIds.find((id) => typeof id === 'string' && id)
+      || '';
+    if (candidate) return String(candidate).slice(0, 64);
+  }
+  const concepts = Array.isArray(ui?.analytics?.concepts) ? ui.analytics.concepts : [];
+  const weakFirst = concepts.find((concept) => concept?.status === 'weak')
+    || concepts.find((concept) => concept?.status === 'due');
+  return weakFirst?.id ? String(weakFirst.id).slice(0, 64) : '';
+}
+
 function resetToDashboard(context) {
   const learnerId = selectedLearnerId(context);
   context.store.updateSubjectUi(GRAMMAR_SUBJECT_ID, (current) => ({
@@ -483,6 +511,59 @@ export const grammarModule = {
           }
           sendGrammarCommand(context, 'start-session', payload);
         },
+      });
+    }
+
+    // Phase 3 U5: `grammar-open-analytics` flips the phase to `'analytics'`
+    // so the adult Analytics Scene renders in place of the summary. U7
+    // scopes the adult/child content split more thoroughly; here we just
+    // gate the surface behind the new phase. `grammar-close-analytics`
+    // returns to the summary without clearing it so the five summary cards
+    // are still visible when the adult closes the adult view.
+    if (action === 'grammar-open-analytics') {
+      if (ui.pendingCommand) return true;
+      if (ui.phase === 'session' || ui.phase === 'feedback') return true;
+      context.store.updateSubjectUi(GRAMMAR_SUBJECT_ID, (current) => ({
+        ...normaliseGrammarReadModel(current, learnerId),
+        phase: 'analytics',
+        error: '',
+      }));
+      return true;
+    }
+
+    if (action === 'grammar-close-analytics') {
+      if (ui.pendingCommand) return true;
+      context.store.updateSubjectUi(GRAMMAR_SUBJECT_ID, (current) => {
+        const normalised = normaliseGrammarReadModel(current, learnerId);
+        const targetPhase = normalised.summary ? 'summary' : 'dashboard';
+        return {
+          ...normalised,
+          phase: targetPhase,
+          error: '',
+        };
+      });
+      return true;
+    }
+
+    // Phase 3 U5: `grammar-practise-missed` is the "Practise missed" /
+    // "Fix missed concepts" primary action on the summary. It iterates the
+    // mini-test review (if present) to find the first incorrect question,
+    // falls back to the analytics snapshot for `weak` / `due` concepts in
+    // regular practice, then chains `grammar-focus-concept` so the learner
+    // drops into a focused round on that concept id. No-op when no missed
+    // concept can be found (e.g. perfect round — the button was disabled
+    // in the mini-test branch, and still no-op for regular practice).
+    if (action === 'grammar-practise-missed') {
+      if (ui.pendingCommand) return true;
+      const conceptId = grammarMissedConceptFromUi(ui);
+      if (!conceptId) return true;
+      // Reuse the existing `grammar-focus-concept` code path so the prefs +
+      // phase transitions stay in one place. We pass the conceptId as
+      // `context.data.conceptId` which is exactly what the focus branch
+      // expects. The return value bubbles up untouched.
+      return grammarModule.handleAction('grammar-focus-concept', {
+        ...context,
+        data: { conceptId },
       });
     }
 

--- a/tests/react-grammar-surface.test.js
+++ b/tests/react-grammar-surface.test.js
@@ -123,12 +123,24 @@ test('Grammar surface runs from setup to Worker-style feedback and summary', () 
   harness.dispatch('grammar-continue');
   assert.equal(harness.store.getState().subjectUi.grammar.phase, 'summary');
   html = harness.render();
-  assert.match(html, /Grammar session summary/);
-  assert.match(html, /1\/1/);
+  // Phase 3 U5: child-facing summary headline replaces the adult "Grammar
+  // session summary" eyebrow. The round stats are surfaced via the five
+  // summary cards (Answered/Correct/Trouble spots/New secure/Monster
+  // progress) rather than a "1/1" score string.
+  assert.match(html, /Nice work — round complete/);
+  assert.match(html, /data-card-id="answered"/);
+  assert.match(html, /data-card-id="monster-progress"/);
 
-  harness.dispatch('grammar-back');
-  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'dashboard');
-  assert.match(harness.render(), /Grammar Garden/);
+  // Phase 3 U5: retired buttons replaced with three primary actions
+  // (Practise missed / Start another round / Open Grammar Bank) plus the
+  // secondary `Grown-up view` (dispatches `grammar-open-analytics`). The
+  // old `grammar-back` button is no longer on the summary, so return to
+  // the dashboard via `Open Grammar Bank` → dashboard routing is covered
+  // elsewhere; here we assert `Start another round` remains wired.
+  assert.match(html, /data-action="grammar-start-again"/);
+  assert.match(html, /data-action="grammar-practise-missed"/);
+  assert.match(html, /data-action="grammar-open-concept-bank"/);
+  assert.match(html, /data-action="grammar-open-analytics"/);
 });
 
 test('Grammar Enter key advances from feedback to the next question', () => {
@@ -958,6 +970,14 @@ test('Grammar analytics renders evidence before reward progress', () => {
     formData: grammarResponseFormData({ answer: sample.sample.inputSpec.options[0].value }),
   });
   harness.dispatch('grammar-continue');
+
+  // Phase 3 U5: analytics is no longer auto-rendered beneath the summary.
+  // The summary carries a `Grown-up view` button dispatching
+  // `grammar-open-analytics`, which flips phase to `'analytics'` and
+  // renders `GrammarAnalyticsScene`. We dispatch here to surface the
+  // analytics HTML this test is asserting on.
+  harness.dispatch('grammar-open-analytics');
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'analytics');
 
   const html = harness.render();
 
@@ -2461,4 +2481,263 @@ test('U3 follower: error banner renders child copy with role="alert"', () => {
   // In this validation path, the translator preserves the already-child
   // copy string verbatim — so the banner body shows it.
   assert.match(sessionHtml, /Choose or type an answer before submitting\./);
+});
+
+// ---------------------------------------------------------------------------
+// U5: Summary redesign (child-friendly round end + Grown-up view gate)
+// ---------------------------------------------------------------------------
+// The regular-practice summary is the five-card grid produced by
+// `grammarSummaryCards(summary, rewardState)` plus the three primary actions
+// (Practise missed / Start another round / Open Grammar Bank) and the quiet
+// `Grown-up view` secondary. The mini-test summary renders a score card,
+// the existing `GrammarMiniTestReview`, and two primary actions (Review
+// answers / Fix missed concepts) plus the same `Grown-up view`. The adult
+// analytics surface is gated behind `grammar-open-analytics` — it never
+// auto-renders in the summary HTML.
+
+function u5RunRegularToSummary() {
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+  const sample = grammarOracleSample();
+
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-start', {
+    payload: {
+      roundLength: 1,
+      templateId: sample.id,
+      seed: sample.sample.seed,
+    },
+  });
+  harness.dispatch('grammar-submit-form', {
+    formData: grammarResponseFormData(sample.correctResponse),
+  });
+  harness.dispatch('grammar-continue');
+  return { harness, sample };
+}
+
+function u5ScopeToSummaryHtml(html) {
+  const match = html.match(/<div class="grammar-summary-shell[^"]*">[\s\S]*?<\/div><\/main>/);
+  assert.ok(match, 'summary shell was rendered');
+  // Trim trailing `</main>` so the returned HTML is the summary subtree.
+  return match[0].replace(/<\/main>$/, '');
+}
+
+test('U5: regular summary renders exactly five summary cards', () => {
+  const { harness } = u5RunRegularToSummary();
+  const html = u5ScopeToSummaryHtml(harness.render());
+
+  const cardIds = ['answered', 'correct', 'trouble', 'new-secure', 'monster-progress'];
+  for (const id of cardIds) {
+    assert.match(html, new RegExp(`data-card-id="${id}"`), `summary card missing: ${id}`);
+  }
+  // Exactly five cards — no drift.
+  const cardMatches = html.match(/data-card-id="/g) || [];
+  assert.equal(cardMatches.length, 5, 'summary must render exactly five cards');
+
+  // Labels match the plan spec.
+  assert.match(html, /Answered/);
+  assert.match(html, /Correct/);
+  assert.match(html, /Trouble spots found/);
+  assert.match(html, /New secure/);
+  assert.match(html, /Monster progress/);
+});
+
+test('U5: regular summary primary action row has three buttons (Practise missed, Start another round, Open Grammar Bank)', () => {
+  const { harness } = u5RunRegularToSummary();
+  const html = u5ScopeToSummaryHtml(harness.render());
+
+  const primaryRow = html.match(
+    /<div class="grammar-summary-primary-actions"[^>]*>[\s\S]*?<\/div>/,
+  )?.[0];
+  assert.ok(primaryRow, 'primary action row rendered');
+
+  assert.match(primaryRow, /data-action="grammar-practise-missed"[^>]*>Practise missed</);
+  assert.match(primaryRow, /data-action="grammar-start-again"[^>]*>Start another round</);
+  assert.match(primaryRow, /data-action="grammar-open-concept-bank"[^>]*>Open Grammar Bank</);
+
+  // Exactly three buttons in the primary row — no drift.
+  const buttonCount = (primaryRow.match(/<button /g) || []).length;
+  assert.equal(buttonCount, 3, 'primary row must hold exactly three buttons');
+});
+
+test('U5: regular summary secondary row holds the Grown-up view button with aria-label="Open adult report"', () => {
+  const { harness } = u5RunRegularToSummary();
+  const html = u5ScopeToSummaryHtml(harness.render());
+
+  const secondaryRow = html.match(
+    /<div class="grammar-summary-secondary-actions"[^>]*>[\s\S]*?<\/div>/,
+  )?.[0];
+  assert.ok(secondaryRow, 'secondary action row rendered');
+  assert.match(secondaryRow, /data-action="grammar-open-analytics"/);
+  assert.match(secondaryRow, /aria-label="Open adult report"/);
+  assert.match(secondaryRow, />Grown-up view</);
+});
+
+test('U5: Grown-up view dispatches grammar-open-analytics and flips phase to analytics', () => {
+  const { harness } = u5RunRegularToSummary();
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'summary');
+
+  harness.dispatch('grammar-open-analytics');
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'analytics');
+
+  const html = harness.render();
+  // Analytics scene is rendered directly by the phase router. The adult
+  // surface carries Misconception repair / Question-type evidence / etc.
+  assert.match(html, /class="grammar-analytics-back-row"/);
+  assert.match(html, /data-action="grammar-close-analytics"/);
+  assert.match(html, /Grammar analytics/);
+
+  // `grammar-close-analytics` returns to summary (because `grammar.summary`
+  // is still populated).
+  harness.dispatch('grammar-close-analytics');
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'summary');
+});
+
+test('U5: regular summary Monster progress card iterates the four active monsters only', () => {
+  const { harness } = u5RunRegularToSummary();
+  const html = u5ScopeToSummaryHtml(harness.render());
+
+  const monsterBlock = html.match(
+    /<div class="grammar-summary-card grammar-summary-card--monster"[\s\S]*?<\/ul>/,
+  )?.[0];
+  assert.ok(monsterBlock, 'monster progress card rendered');
+
+  const activeIds = ['bracehart', 'chronalyx', 'couronnail', 'concordium'];
+  for (const id of activeIds) {
+    assert.match(monsterBlock, new RegExp(`data-monster-id="${id}"`));
+  }
+  // Exactly four active monsters — reserved ids absent per R15.
+  const monsterRows = (monsterBlock.match(/data-monster-id="/g) || []).length;
+  assert.equal(monsterRows, 4, 'monster progress card must iterate exactly four active monsters');
+
+  assert.doesNotMatch(monsterBlock, /Glossbloom/i);
+  assert.doesNotMatch(monsterBlock, /Loomrill/i);
+  assert.doesNotMatch(monsterBlock, /Mirrane/i);
+});
+
+test('U5: regular summary HTML does not leak adult-diagnostic analytics copy or reserved monsters', () => {
+  const { harness } = u5RunRegularToSummary();
+  const html = u5ScopeToSummaryHtml(harness.render());
+
+  // The densest adult-only strings from `GrammarAnalyticsScene` — evidence
+  // summary header, parent summary draft aside, misconception pattern
+  // block, Bellstorm bridge copy — must not appear in the default summary.
+  assert.doesNotMatch(html, /Evidence summary|parent summary|misconception pattern|Bellstorm bridge/i);
+
+  // Reserved monsters absent from every corner of the summary.
+  assert.doesNotMatch(html, /Glossbloom|Loomrill|Mirrane/i);
+
+  // Forbidden-terms sweep across the full summary subtree.
+  for (const term of GRAMMAR_CHILD_FORBIDDEN_TERMS) {
+    assert.doesNotMatch(
+      html,
+      new RegExp(escapeRegExp(term), 'i'),
+      `forbidden term leaked into default summary HTML: ${term}`,
+    );
+  }
+});
+
+test('U5: mini-test summary renders score card plus Review answers + Fix missed concepts primary actions', () => {
+  const { harness, sample } = u4HarnessWithMiniSet();
+  harness.dispatch('grammar-save-mini-test-response', {
+    formData: grammarResponseFormData(sample.correctResponse),
+    advance: false,
+  });
+  harness.dispatch('grammar-finish-mini-test');
+
+  const grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.phase, 'summary');
+  assert.ok(grammar.summary?.miniTestReview?.questions?.length);
+
+  const html = u5ScopeToSummaryHtml(harness.render());
+
+  // Score card headline (correct of total + percent accuracy).
+  const scoreBlock = html.match(/<div class="grammar-summary-score"[\s\S]*?<\/div>/)?.[0];
+  assert.ok(scoreBlock, 'mini-test score card rendered');
+  assert.match(scoreBlock, /1 of 8 correct/);
+  assert.match(scoreBlock, /13% accuracy/);
+
+  // Primary actions row: `Review answers` + `Fix missed concepts`. Exactly two.
+  const primaryRow = html.match(
+    /<div class="grammar-summary-primary-actions"[^>]*>[\s\S]*?<\/div>/,
+  )?.[0];
+  assert.ok(primaryRow, 'mini-test primary actions row rendered');
+  assert.match(primaryRow, />Review answers</);
+  assert.match(primaryRow, />Fix missed concepts</);
+  assert.match(primaryRow, /data-action="grammar-practise-missed"/);
+
+  const buttonCount = (primaryRow.match(/<button /g) || []).length;
+  assert.equal(buttonCount, 2, 'mini-test primary row holds exactly two buttons');
+
+  // The old generic buttons `Start another round` + `Back to Grammar setup`
+  // must NOT appear on the mini-test summary variant.
+  assert.doesNotMatch(primaryRow, /Start another round/);
+  assert.doesNotMatch(primaryRow, /Back to Grammar setup/);
+
+  // `GrammarMiniTestReview` is still mounted below the summary card, so the
+  // adjacent review section is present (contains its own `Mini Test results`
+  // score card + per-question rows).
+  assert.match(html, /class="card grammar-mini-review"/);
+  assert.match(html, /Mini Test results/);
+
+  // Grown-up view still surfaces the adult analytics for this variant.
+  assert.match(html, /data-action="grammar-open-analytics"/);
+  assert.match(html, /aria-label="Open adult report"/);
+});
+
+test('U5: grammar-practise-missed routes the learner out of summary with the first missed concept id as focus', () => {
+  const { harness } = u4HarnessWithMiniSet();
+  // Leave every question Blank — every review entry is missed.
+  harness.dispatch('grammar-finish-mini-test');
+
+  let grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.phase, 'summary');
+  const firstQuestion = grammar.summary.miniTestReview.questions[0];
+  const expectedConceptId = firstQuestion.item.skillIds[0]
+    || firstQuestion.item.replay?.conceptIds?.[0]
+    || '';
+  assert.ok(expectedConceptId, 'first review question carries a concept id');
+
+  harness.dispatch('grammar-practise-missed');
+  grammar = harness.store.getState().subjectUi.grammar;
+
+  // `grammar-practise-missed` delegates to `grammar-focus-concept`, which
+  // saves the focus preference and starts a fresh focused round. The
+  // learner is no longer on the summary phase.
+  assert.notEqual(grammar.phase, 'summary');
+  assert.equal(grammar.prefs.focusConceptId, expectedConceptId);
+  assert.ok(['session', 'dashboard'].includes(grammar.phase), 'phase routed to focused practice');
+});
+
+test('U5: grammar-open-analytics renders GrammarAnalyticsScene via the phase router', () => {
+  const { harness } = u5RunRegularToSummary();
+  harness.dispatch('grammar-open-analytics');
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'analytics');
+
+  const html = harness.render();
+  // The analytics surface lives inside `.grammar-surface--analytics` now
+  // (phase: 'analytics') — not behind `<details class="grammar-grown-up-view">`.
+  assert.match(html, /class="grammar-surface grammar-surface--analytics"/);
+  // Back affordance routes `grammar-close-analytics`.
+  assert.match(html, /data-action="grammar-close-analytics"/);
+  // Canonical analytics content is present.
+  assert.match(html, /Grammar analytics/);
+  assert.match(html, /Evidence snapshot/);
+});
+
+test('U5: grammar-open-analytics is a no-op mid-session so the active round is not wiped', () => {
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+  const sample = grammarOracleSample();
+
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-start', {
+    payload: { roundLength: 1, templateId: sample.id, seed: sample.sample.seed },
+  });
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'session');
+
+  harness.dispatch('grammar-open-analytics');
+  // Phase stays on session — `grammar-open-analytics` refuses to fire
+  // mid-session or mid-feedback.
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'session');
 });

--- a/tests/react-grammar-surface.test.js
+++ b/tests/react-grammar-surface.test.js
@@ -2741,3 +2741,167 @@ test('U5: grammar-open-analytics is a no-op mid-session so the active round is n
   // mid-session or mid-feedback.
   assert.equal(harness.store.getState().subjectUi.grammar.phase, 'session');
 });
+
+// ---------------------------------------------------------------------------
+// U5 follower coverage: mini-test `Fix missed concepts` variant flip, regular-
+// practice `Practise missed` disabled state, analytics close-fallback, and
+// weak-vs-due precedence when resolving the missed concept id.
+// ---------------------------------------------------------------------------
+
+test('U5 follower T1: regular-practice grammar-practise-missed prefers a weak analytics concept over a due one', () => {
+  const { harness } = u5RunRegularToSummary();
+  const learnerId = harness.store.getState().learners.selectedId;
+
+  // Seed analytics.concepts so the missed-concept helper has something to
+  // act on (regular-practice summaries have no `miniTestReview`, so the
+  // helper falls straight through to analytics). `word_classes` is weak,
+  // `clauses` is due -- weak must win.
+  harness.store.updateSubjectUi('grammar', (current) => {
+    const normalised = normaliseGrammarReadModel(current, learnerId);
+    return {
+      ...normalised,
+      analytics: {
+        ...normalised.analytics,
+        concepts: [
+          { id: 'clauses', status: 'due' },
+          { id: 'word_classes', status: 'weak' },
+        ],
+      },
+    };
+  });
+
+  let grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.phase, 'summary', 'setup left learner on summary');
+  assert.equal(grammar.prefs.focusConceptId, '', 'focus preference clean before dispatch');
+
+  harness.dispatch('grammar-practise-missed');
+  grammar = harness.store.getState().subjectUi.grammar;
+
+  // weak beats due -- `word_classes` wins and routes into a focused round.
+  assert.equal(grammar.prefs.focusConceptId, 'word_classes');
+  assert.notEqual(grammar.phase, 'summary');
+});
+
+test('U5 follower T2: grammar-practise-missed is a silent no-op when the round has no missed or weak / due concept', () => {
+  const { harness } = u5RunRegularToSummary();
+  const learnerId = harness.store.getState().learners.selectedId;
+
+  // Wipe analytics.concepts so no weak / due concept is present. Regular
+  // practice summaries carry no miniTestReview, so the helper has nothing
+  // to act on -- the handler must return early without mutating phase or
+  // prefs.
+  harness.store.updateSubjectUi('grammar', (current) => {
+    const normalised = normaliseGrammarReadModel(current, learnerId);
+    return {
+      ...normalised,
+      analytics: { ...normalised.analytics, concepts: [] },
+    };
+  });
+
+  const before = harness.store.getState().subjectUi.grammar;
+  assert.equal(before.phase, 'summary');
+  const focusBefore = before.prefs.focusConceptId;
+
+  harness.dispatch('grammar-practise-missed');
+  const after = harness.store.getState().subjectUi.grammar;
+
+  assert.equal(after.phase, 'summary', 'phase unchanged when nothing to practise');
+  assert.equal(after.prefs.focusConceptId, focusBefore, 'focus preference unchanged');
+});
+
+test('U5 follower T3: grammar-close-analytics falls back to dashboard when summary has been cleared', () => {
+  const { harness } = u5RunRegularToSummary();
+  const learnerId = harness.store.getState().learners.selectedId;
+
+  harness.dispatch('grammar-open-analytics');
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'analytics');
+
+  // Simulate the summary being cleared (e.g. server eviction or a follow-up
+  // dispatch that reset the round). The close-analytics fallback must route
+  // to dashboard, never leave the learner stranded on a phase with nothing
+  // to render.
+  harness.store.updateSubjectUi('grammar', (current) => {
+    const normalised = normaliseGrammarReadModel(current, learnerId);
+    return { ...normalised, summary: null, phase: 'analytics' };
+  });
+
+  harness.dispatch('grammar-close-analytics');
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'dashboard');
+});
+
+test('U5 follower T4: mini-test Fix missed concepts button renders disabled when every question is correct', () => {
+  const { harness } = u4HarnessWithMiniSet();
+  harness.dispatch('grammar-finish-mini-test');
+
+  const learnerId = harness.store.getState().learners.selectedId;
+  const beforeGrammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(beforeGrammar.phase, 'summary');
+  assert.ok(Array.isArray(beforeGrammar.summary?.miniTestReview?.questions));
+
+  // Force every review question to be marked correct so the first-missed
+  // resolver returns ''. analytics.concepts also wiped so the module-side
+  // fallback does not resurrect a concept id from weak / due analytics.
+  harness.store.updateSubjectUi('grammar', (current) => {
+    const normalised = normaliseGrammarReadModel(current, learnerId);
+    const questions = normalised.summary.miniTestReview.questions.map((question) => ({
+      ...question,
+      answered: true,
+      marked: {
+        ...(question.marked || {}),
+        result: { ...(question.marked?.result || {}), correct: true },
+      },
+    }));
+    return {
+      ...normalised,
+      summary: {
+        ...normalised.summary,
+        miniTestReview: { ...normalised.summary.miniTestReview, questions },
+      },
+      analytics: { ...normalised.analytics, concepts: [] },
+    };
+  });
+
+  const html = harness.render();
+  const primaryRow = html.match(
+    /<div class="grammar-summary-primary-actions"[^>]*>[\s\S]*?<\/div>/,
+  )?.[0];
+  assert.ok(primaryRow, 'mini-test primary actions row rendered');
+
+  const fixButton = primaryRow.match(
+    /<button[^>]*data-action="grammar-practise-missed"[^>]*>[^<]*<\/button>/,
+  )?.[0];
+  assert.ok(fixButton, 'Fix missed concepts button rendered');
+  assert.match(fixButton, /disabled/, 'Fix missed concepts button carries the disabled attribute when no misses');
+});
+
+test('U5 follower T5: mini-test primary row puts Fix missed concepts first with the primary variant and Review answers second as secondary', () => {
+  const { harness } = u4HarnessWithMiniSet();
+  // Leave every question Blank so the resolver finds a missed concept id
+  // and the primary button is enabled.
+  harness.dispatch('grammar-finish-mini-test');
+
+  const html = harness.render();
+  const primaryRow = html.match(
+    /<div class="grammar-summary-primary-actions"[^>]*>[\s\S]*?<\/div>/,
+  )?.[0];
+  assert.ok(primaryRow, 'mini-test primary actions row rendered');
+
+  // Button order -- Fix missed concepts must appear before Review answers.
+  const fixIndex = primaryRow.indexOf('>Fix missed concepts<');
+  const reviewIndex = primaryRow.indexOf('>Review answers<');
+  assert.ok(fixIndex >= 0 && reviewIndex >= 0, 'both mini-test primary buttons rendered');
+  assert.ok(fixIndex < reviewIndex, 'Fix missed concepts renders before Review answers');
+
+  // Variants -- Fix missed concepts carries `btn primary`, Review answers
+  // carries `btn secondary`.
+  assert.match(
+    primaryRow,
+    /<button[^>]*class="btn primary"[^>]*data-action="grammar-practise-missed"[^>]*>Fix missed concepts</,
+    'Fix missed concepts is the primary variant',
+  );
+  assert.match(
+    primaryRow,
+    /<button[^>]*class="btn secondary"[^>]*data-action="grammar-review-mini-test"[^>]*>Review answers</,
+    'Review answers is the secondary variant',
+  );
+});

--- a/tests/subject-expansion.test.js
+++ b/tests/subject-expansion.test.js
@@ -190,7 +190,10 @@ const grammarSpec = {
   // to the child-facing `GRAMMAR_DASHBOARD_HERO.title` ("Grammar Garden").
   practiceMatcher: /Grammar Garden/,
   sessionMatcher: /Grammar practice|question marks/i,
-  summaryMatcher: /Grammar session summary/,
+  // Phase 3 U5 replaces the adult `Grammar session summary` eyebrow with the
+  // child-facing `Nice work — round complete` headline on the redesigned
+  // summary scene.
+  summaryMatcher: /Nice work — round complete/,
   getUiState(harness) {
     return harness.store.getState().subjectUi.grammar;
   },


### PR DESCRIPTION
## Summary

Phase 3 U5 of [2026-04-25-004-feat-grammar-phase3-ux-reset-plan.md](docs/plans/2026-04-25-004-feat-grammar-phase3-ux-reset-plan.md) — replaces the adult-flavoured Grammar round-end surface with a child-friendly variant and gates the adult analytics behind a single `Grown-up view` action.

**Regular-practice summary** renders the five child-friendly cards from `grammarSummaryCards(summary, rewardState)`:
- Answered
- Correct
- Trouble spots found
- New secure
- Monster progress (four active monsters only: Bracehart / Chronalyx / Couronnail / Concordium, per R15)

Three primary actions: `Practise missed` · `Start another round` · `Open Grammar Bank`. Secondary row holds `Grown-up view` dispatching the new `grammar-open-analytics` action.

**Mini-test summary** (detected via `summary.miniTestReview` presence or `summary.mode === 'satsset'`) renders a score card (`X of N correct` + percent), mounts the existing `GrammarMiniTestReview` below it, and surfaces two primary actions: `Review answers` (focuses the review headline) and `Fix missed concepts` (dispatches `grammar-practise-missed`). Closes BLK-2 — the two generic buttons (`Start another round` / `Back to Grammar setup`) plus N review-level `Practise this later` no longer compete; the primary path is now explicit for both variants.

**New actions** in `src/subjects/grammar/module.js`:
- `grammar-open-analytics` — flips phase to new `'analytics'` (added to `normaliseGrammarReadModel` allowlist) so `GrammarPracticeSurface` renders `GrammarAnalyticsScene` directly with a back affordance. No-op mid-session.
- `grammar-close-analytics` — returns to summary (or dashboard when summary is cleared).
- `grammar-practise-missed` — picks the first incorrect / blank mini-test question's concept id (falls back to the first `weak` / `due` analytics concept for regular practice), then delegates to the existing `grammar-focus-concept` code path so the prefs + start-session chain stays in one place.

## Test Plan

- [x] `node --test tests/react-grammar-surface.test.js` — 88 tests pass (78 existing + 10 new U5)
- [x] `node --test tests/react-grammar-surface.test.js tests/subject-expansion.test.js` — 113 tests pass
- [x] `npm test` — 1768 pass, 1 skipped, 1 pre-existing failure (`grammar.startModel.stats.templates` in production smoke, unrelated)
- [x] `npm run check` — passes cleanly
- [x] Regular summary renders exactly five cards with the plan's labels
- [x] Regular primary action row has three buttons; secondary row has `Grown-up view` with `aria-label="Open adult report"`
- [x] Mini-test summary renders score card plus `Review answers` + `Fix missed concepts`
- [x] Monster progress iterates four active monsters only — reserved Glossbloom / Loomrill / Mirrane absent
- [x] Forbidden-terms sweep on default summary HTML passes every term in `GRAMMAR_CHILD_FORBIDDEN_TERMS`
- [x] `Evidence summary|parent summary|misconception pattern|Bellstorm bridge` absent from the default summary
- [x] `grammar-open-analytics` renders `GrammarAnalyticsScene` via the phase router (not the old `<details>` in the setup surface)
- [x] `grammar-practise-missed` transitions the learner out of `summary` with the correct concept id as focus
- [x] `grammar-open-analytics` is a no-op mid-session so active rounds are not wiped