### PR TITLE
feat(spelling): U4 "I don't know" wobble replaces skip in Guardian

### DIFF
--- a/shared/spelling/service.js
+++ b/shared/spelling/service.js
@@ -1476,6 +1476,139 @@ export function createSpellingService({ repository, storage, tts, now, random, c
     return buildTransition(nextState, { audio: activeAudioCue(learnerId, nextState) });
   }
 
+  // U4: Guardian-native "I don't know" path. Routes through advanceGuardianOnWrong
+  // + advanceGuardianCard (FIFO), emits spelling.guardian.wobbled, records
+  // guardianResults[slug] = 'wobbled' so mission-completed aggregates the count,
+  // and never mutates progress.stage/dueDay/lastDay/lastResult. Mirrors the
+  // wrong-answer branch of submitGuardianAnswer. See
+  // docs/plans/2026-04-25-005-feat-post-mega-spelling-guardian-hardening-plan.md (U4).
+  function skipGuardianWord(learnerId, current) {
+    const session = cloneSerialisable(current.session);
+    const currentSlug = session.currentSlug;
+    const baseWord = currentSlug ? runtimeWordBySlug[currentSlug] : null;
+    if (!baseWord) {
+      return buildTransition({
+        ...current,
+        feedback: {
+          kind: 'warn',
+          headline: 'This word cannot be skipped right now.',
+          body: 'Finish the retry or correction step first.',
+        },
+        error: '',
+      });
+    }
+
+    // Same gate legacy skipCurrent uses: must be on question phase.
+    if (session.phase !== 'question') {
+      return buildTransition({
+        ...current,
+        feedback: {
+          kind: 'warn',
+          headline: 'This word cannot be skipped right now.',
+          body: 'Finish the retry or correction step first.',
+        },
+        error: '',
+      });
+    }
+
+    // Session bookkeeping — matches submitGuardianAnswer wrong-path shape so
+    // summary.mistakes picks this slug up for the practice-only drill (U3).
+    const statusEntry = session.status?.[currentSlug] || {
+      attempts: 0,
+      successes: 0,
+      needed: 1,
+      hadWrong: false,
+      wrongAnswers: [],
+      done: false,
+      applied: false,
+    };
+    statusEntry.attempts += 1;
+    statusEntry.done = true;
+    statusEntry.applied = true;
+    statusEntry.hadWrong = true;
+    session.status = session.status || {};
+    session.status[currentSlug] = statusEntry;
+    session.promptCount = (session.promptCount || 0) + 1;
+
+    // FIFO-clean: remove the skipped slug from the queue, never re-queue (unlike
+    // legacy enqueueLater).
+    if (Array.isArray(session.queue)) {
+      session.queue = session.queue.filter((slug) => slug !== currentSlug);
+    }
+
+    // Update progress.attempts + progress.wrong only. Stage/dueDay/lastDay/
+    // lastResult are preserved — Mega-never-revoked invariant.
+    const progressMap = loadProgressFromStorage(learnerId);
+    const existingProgress = progressMap[currentSlug] && typeof progressMap[currentSlug] === 'object'
+      ? progressMap[currentSlug]
+      : { stage: 0, attempts: 0, correct: 0, wrong: 0, dueDay: 0, lastDay: null, lastResult: null };
+    const nextProgress = { ...existingProgress };
+    nextProgress.attempts = (nextProgress.attempts || 0) + 1;
+    nextProgress.wrong = (nextProgress.wrong || 0) + 1;
+    progressMap[currentSlug] = nextProgress;
+    saveProgressToStorage(learnerId, progressMap);
+
+    // Advance the guardian record the same way a wrong answer does.
+    const todayDay = currentTodayDay();
+    const guardianMap = loadGuardianMap(learnerId);
+    const beforeRecord = ensureGuardianRecord(guardianMap, currentSlug, todayDay);
+    const updatedRecord = advanceGuardianOnWrong(beforeRecord, todayDay);
+    guardianMap[currentSlug] = updatedRecord;
+    saveGuardianMap(learnerId, guardianMap);
+
+    // Record the per-word outcome so guardianMissionEventsForSession counts
+    // this as a wobble on the final mission-completed event.
+    session.guardianResults = session.guardianResults || {};
+    session.guardianResults[currentSlug] = 'wobbled';
+
+    const eventTime = clock();
+    const events = [];
+    const wobbledEvent = createSpellingGuardianWobbledEvent({
+      learnerId,
+      session,
+      slug: currentSlug,
+      lapses: updatedRecord.lapses,
+      createdAt: eventTime,
+      wordMeta: runtimeWordBySlug,
+    });
+    if (wobbledEvent) events.push(wobbledEvent);
+
+    // Advance the Guardian FIFO queue directly (never engine.advanceCard —
+    // legacy weighted selection would reorder the round).
+    const advanced = advanceGuardianCard(session);
+    if (advanced.done) {
+      const summary = normaliseSummary(engine.finalise(session), isRuntimeKnownSlug);
+      const nextState = {
+        version: SPELLING_SERVICE_STATE_VERSION,
+        phase: 'summary',
+        session: null,
+        feedback: null,
+        summary,
+        error: '',
+        awaitingAdvance: false,
+      };
+      persistence.syncPracticeSession(learnerId, nextState);
+      events.push(...guardianMissionEventsForSession(learnerId, session, summary, eventTime));
+      return buildTransition(nextState, { events });
+    }
+
+    const nextState = {
+      version: SPELLING_SERVICE_STATE_VERSION,
+      phase: 'session',
+      session: decorateSession(engine, learnerId, session, runtimeWordBySlug),
+      feedback: {
+        kind: 'info',
+        headline: "Marked as \"I don't know\".",
+        body: 'This word will return tomorrow for a Guardian check.',
+      },
+      summary: null,
+      error: '',
+      awaitingAdvance: false,
+    };
+    persistence.syncPracticeSession(learnerId, nextState);
+    return buildTransition(nextState, { events });
+  }
+
   function skipWord(learnerId, rawState) {
     const current = initState(rawState, learnerId);
     if (current.phase !== 'session' || !current.session) {
@@ -1484,6 +1617,10 @@ export function createSpellingService({ repository, storage, tts, now, random, c
 
     if (current.awaitingAdvance) {
       return buildTransition(current, { changed: false });
+    }
+
+    if (current.session.mode === 'guardian') {
+      return skipGuardianWord(learnerId, current);
     }
 
     const session = cloneSerialisable(current.session);

--- a/shared/spelling/service.js
+++ b/shared/spelling/service.js
@@ -1476,30 +1476,20 @@ export function createSpellingService({ repository, storage, tts, now, random, c
     return buildTransition(nextState, { audio: activeAudioCue(learnerId, nextState) });
   }
 
-  // U4: Guardian-native "I don't know" path. Routes through advanceGuardianOnWrong
-  // + advanceGuardianCard (FIFO), emits spelling.guardian.wobbled, records
-  // guardianResults[slug] = 'wobbled' so mission-completed aggregates the count,
-  // and never mutates progress.stage/dueDay/lastDay/lastResult. Mirrors the
-  // wrong-answer branch of submitGuardianAnswer. See
+  // U4: Guardian-native "I don't know" path. Routes through advanceGuardianOnWrong,
+  // emits spelling.guardian.wobbled, records guardianResults[slug] = 'wobbled' so
+  // mission-completed aggregates the count, and never mutates progress.stage /
+  // dueDay / lastDay / lastResult. Mirrors the wrong-answer branch of
+  // submitGuardianAnswer end-to-end: both set awaitingAdvance=true and let
+  // continueSession handle the queue advance, so a double-tap on the button
+  // no-ops on the second call (continueSession owns the Continue → next-card
+  // transition, including the audio cue). See
   // docs/plans/2026-04-25-005-feat-post-mega-spelling-guardian-hardening-plan.md (U4).
   function skipGuardianWord(learnerId, current) {
     const session = cloneSerialisable(current.session);
     const currentSlug = session.currentSlug;
     const baseWord = currentSlug ? runtimeWordBySlug[currentSlug] : null;
-    if (!baseWord) {
-      return buildTransition({
-        ...current,
-        feedback: {
-          kind: 'warn',
-          headline: 'This word cannot be skipped right now.',
-          body: 'Finish the retry or correction step first.',
-        },
-        error: '',
-      });
-    }
-
-    // Same gate legacy skipCurrent uses: must be on question phase.
-    if (session.phase !== 'question') {
+    if (!baseWord || session.phase !== 'question') {
       return buildTransition({
         ...current,
         feedback: {
@@ -1529,9 +1519,10 @@ export function createSpellingService({ repository, storage, tts, now, random, c
     session.status = session.status || {};
     session.status[currentSlug] = statusEntry;
     session.promptCount = (session.promptCount || 0) + 1;
+    session.phase = 'question';
 
     // FIFO-clean: remove the skipped slug from the queue, never re-queue (unlike
-    // legacy enqueueLater).
+    // legacy enqueueLater). submitGuardianAnswer does the same defensively.
     if (Array.isArray(session.queue)) {
       session.queue = session.queue.filter((slug) => slug !== currentSlug);
     }
@@ -1573,37 +1564,24 @@ export function createSpellingService({ repository, storage, tts, now, random, c
     });
     if (wobbledEvent) events.push(wobbledEvent);
 
-    // Advance the Guardian FIFO queue directly (never engine.advanceCard —
-    // legacy weighted selection would reorder the round).
-    const advanced = advanceGuardianCard(session);
-    if (advanced.done) {
-      const summary = normaliseSummary(engine.finalise(session), isRuntimeKnownSlug);
-      const nextState = {
-        version: SPELLING_SERVICE_STATE_VERSION,
-        phase: 'summary',
-        session: null,
-        feedback: null,
-        summary,
-        error: '',
-        awaitingAdvance: false,
-      };
-      persistence.syncPracticeSession(learnerId, nextState);
-      events.push(...guardianMissionEventsForSession(learnerId, session, summary, eventTime));
-      return buildTransition(nextState, { events });
-    }
-
+    // Set awaitingAdvance=true so continueSession handles the FIFO advance
+    // (including activeAudioCue for the next card). This matches
+    // submitGuardianAnswer exactly — double-taps on the button no-op because
+    // the skipWord entry check already returns changed:false when
+    // awaitingAdvance is set.
     const nextState = {
       version: SPELLING_SERVICE_STATE_VERSION,
       phase: 'session',
       session: decorateSession(engine, learnerId, session, runtimeWordBySlug),
-      feedback: {
-        kind: 'info',
-        headline: "Marked as \"I don't know\".",
-        body: 'This word will return tomorrow for a Guardian check.',
-      },
+      feedback: normaliseFeedback({
+        kind: 'warn',
+        headline: 'Wobbling.',
+        answer: baseWord.word,
+        body: 'Mega stays, but this word will return tomorrow for a Guardian check.',
+      }),
       summary: null,
       error: '',
-      awaitingAdvance: false,
+      awaitingAdvance: true,
     };
     persistence.syncPracticeSession(learnerId, nextState);
     return buildTransition(nextState, { events });

--- a/src/subjects/spelling/components/SpellingSessionScene.jsx
+++ b/src/subjects/spelling/components/SpellingSessionScene.jsx
@@ -3,6 +3,7 @@ import {
   spellingSessionContextNote,
   spellingSessionInfoChips,
   spellingSessionInputPlaceholder,
+  spellingSessionSkipLabel,
   spellingSessionSubmitLabel,
   spellingSessionVoiceNote,
 } from '../session-ui.js';
@@ -66,6 +67,7 @@ export function SpellingSessionScene({
   const inputPlaceholder = spellingSessionInputPlaceholder(session);
   const contextNote = spellingSessionContextNote(session);
   const voiceNote = spellingSessionVoiceNote();
+  const skipLabel = spellingSessionSkipLabel(session);
   const infoChips = spellingSessionInfoChips(session);
   const progressTotal = session.progress.total;
   const done = session.progress.done;
@@ -194,7 +196,7 @@ export function SpellingSessionScene({
                   disabled={runtimeReadOnly || pending}
                   onClick={(event) => renderAction(actions, event, 'spelling-skip')}
                 >
-                  Skip for now
+                  {skipLabel}
                 </button>
               ) : null}
             </div>

--- a/src/subjects/spelling/session-ui.js
+++ b/src/subjects/spelling/session-ui.js
@@ -54,3 +54,14 @@ export function spellingSessionInfoChips(session) {
 export function spellingSessionVoiceNote() {
   return 'AI-generated dictation voice';
 }
+
+/**
+ * Skip-button label. Guardian Mission sessions use "I don't know" to signal
+ * that the click routes through the Guardian wobble path (not the legacy
+ * enqueue-later skip). Non-Guardian sessions keep the legacy "Skip for now".
+ * See U4 in docs/plans/2026-04-25-005-feat-post-mega-spelling-guardian-hardening-plan.md.
+ */
+export function spellingSessionSkipLabel(session) {
+  if (session && session.mode === 'guardian') return "I don't know";
+  return 'Skip for now';
+}

--- a/tests/spelling-guardian.test.js
+++ b/tests/spelling-guardian.test.js
@@ -1741,7 +1741,6 @@ test('U4 happy path: "I don\'t know" adds skipped word to summary.mistakes for t
 
   const started = service.startSession('learner-a', { mode: 'guardian' });
   const firstSlug = started.state.session.currentCard.slug;
-  const initialSlugs = started.state.session.uniqueWords.slice();
 
   // Skip the first word (I don't know), answer the rest correctly.
   const skipped = service.skipWord('learner-a', started.state);
@@ -1758,7 +1757,7 @@ test('U4 happy path: "I don\'t know" adds skipped word to summary.mistakes for t
   assert.equal(current.phase, 'summary');
   const mistakeSlugs = current.summary.mistakes.map((m) => m.slug);
   assert.ok(mistakeSlugs.includes(firstSlug), '"I don\'t know" slug appears in summary.mistakes');
-  assert.equal(initialSlugs.length, current.summary.mistakes.length + (initialSlugs.length - 1), 'other words did not fall into mistakes');
+  assert.equal(current.summary.mistakes.length, 1, 'only the skipped word fell into mistakes; correct answers did not');
 });
 
 test('U4 edge: "I don\'t know" when awaitingAdvance===true is a no-op (no duplicate event, no state mutation)', () => {
@@ -1782,7 +1781,7 @@ test('U4 edge: "I don\'t know" when awaitingAdvance===true is a no-op (no duplic
   assert.equal(record.wobbling, false, 'record stays as correct-answer result, not wobbling');
 });
 
-test('U4 edge: "I don\'t know" double-click emits exactly one wobble per slug (second call hits awaitingAdvance or next card, never duplicate event)', () => {
+test('U4 edge: "I don\'t know" double-click is a no-op on the second call (awaitingAdvance guard)', () => {
   const now = () => Date.UTC(2026, 0, 10);
   const today = Math.floor(now() / DAY_MS_TS);
   const { service, repositories } = makeServiceWithSeed({ now, random: () => 0.5 });
@@ -1792,16 +1791,16 @@ test('U4 edge: "I don\'t know" double-click emits exactly one wobble per slug (s
   const firstSlug = started.state.session.currentCard.slug;
 
   const first = service.skipWord('learner-a', started.state);
-  const second = service.skipWord('learner-a', first.state);
-
+  // First click: awaitingAdvance becomes true; exactly one WOBBLED event.
+  assert.equal(first.state.awaitingAdvance, true);
   const firstWobbled = first.events.filter((e) => e.type === SPELLING_EVENT_TYPES.GUARDIAN_WOBBLED);
-  const secondWobbled = second.events.filter((e) => e.type === SPELLING_EVENT_TYPES.GUARDIAN_WOBBLED);
   assert.equal(firstWobbled.length, 1, 'first click wobbles once');
-  // Second "I don't know" fires on the NEXT card (not the first slug again).
-  // It may produce its own wobble for that next slug, but never a duplicate
-  // for the first slug.
-  const duplicateForFirst = secondWobbled.filter((e) => e.wordSlug === firstSlug);
-  assert.equal(duplicateForFirst.length, 0, 'never a duplicate wobble event for the first slug');
+
+  // Second click on the same state: the early awaitingAdvance guard in
+  // skipWord returns changed:false with no events.
+  const second = service.skipWord('learner-a', first.state);
+  assert.equal(second.changed, false, 'second click is a no-op while awaitingAdvance');
+  assert.equal(second.events.length, 0, 'second click emits no events');
 
   const postMastery = service.getPostMasteryState('learner-a');
   assert.equal(postMastery.guardianMap[firstSlug].lapses, 1, 'first slug lapses counted once, not twice');
@@ -1884,7 +1883,7 @@ test('U4 integration: non-Guardian learning session skip still calls engine.skip
   assert.equal(skipped.state.feedback?.headline, 'Skipped for now.');
 });
 
-test('U4 edge: FIFO-consistent queue after Guardian "I don\'t know" — skipped slug never re-queued', () => {
+test('U4 edge: FIFO-consistent queue after Guardian "I don\'t know" — skipped slug never re-queued (continueSession advances to next)', () => {
   const now = () => Date.UTC(2026, 0, 10);
   const today = Math.floor(now() / DAY_MS_TS);
   const { service, repositories } = makeServiceWithSeed({ now, random: () => 0.5 });
@@ -1895,9 +1894,10 @@ test('U4 edge: FIFO-consistent queue after Guardian "I don\'t know" — skipped 
   const firstSlug = started.state.session.currentSlug;
 
   const skipped = service.skipWord('learner-a', started.state);
-  // Queue after + currentSlug should contain all other initial slugs exactly
-  // once; firstSlug must not re-appear.
-  const post = skipped.state.session;
+  // After skip, queue has the skipped slug removed. Continue to move on.
+  assert.equal(Array.isArray(skipped.state.session.queue) && skipped.state.session.queue.includes(firstSlug), false, 'queue does not contain the skipped slug');
+  const advanced = service.continueSession('learner-a', skipped.state);
+  const post = advanced.state.session;
   const reachable = [post.currentSlug, ...post.queue].filter(Boolean);
   for (const slug of initialSlugs) {
     if (slug === firstSlug) {
@@ -1921,4 +1921,38 @@ test('U4 edge: Guardian "I don\'t know" sets session.guardianResults[slug] to "w
   const skipped = service.skipWord('learner-a', started.state);
 
   assert.equal(skipped.state.session.guardianResults[firstSlug], 'wobbled');
+});
+
+test('U4 edge: Guardian "I don\'t know" surfaces a "Wobbling" feedback so the user knows the click registered', () => {
+  const now = () => Date.UTC(2026, 0, 10);
+  const today = Math.floor(now() / DAY_MS_TS);
+  const { service, repositories } = makeServiceWithSeed({ now, random: () => 0.5 });
+  seedAllCoreMega(repositories, 'learner-a', today);
+
+  const started = service.startSession('learner-a', { mode: 'guardian' });
+  const skipped = service.skipWord('learner-a', started.state);
+
+  // Feedback mirrors the wrong-answer Guardian body so the UI shows the
+  // correct answer via feedback.answer (like submitGuardianAnswer does for
+  // wrong answers).
+  assert.equal(skipped.state.feedback?.kind, 'warn');
+  assert.equal(skipped.state.feedback?.headline, 'Wobbling.');
+  assert.match(skipped.state.feedback?.body || '', /will return tomorrow/);
+  assert.ok(skipped.state.feedback?.answer, 'feedback.answer present so Cloze can reveal the word after skip');
+});
+
+test('U4 edge: continueSession after Guardian skip plays the audio cue for the next card', () => {
+  const now = () => Date.UTC(2026, 0, 10);
+  const today = Math.floor(now() / DAY_MS_TS);
+  const { service, repositories } = makeServiceWithSeed({ now, random: () => 0.5 });
+  seedAllCoreMega(repositories, 'learner-a', today);
+
+  const started = service.startSession('learner-a', { mode: 'guardian' });
+  const skipped = service.skipWord('learner-a', started.state);
+  const advanced = service.continueSession('learner-a', skipped.state);
+
+  // continueSession's non-done branch returns an audio cue — same as the
+  // correct-answer Guardian flow. Without this, the learner would see the
+  // next card's prompt without hearing it.
+  assert.ok(advanced.audio, 'continueSession returns an audio cue for the freshly-advanced card');
 });

--- a/tests/spelling-guardian.test.js
+++ b/tests/spelling-guardian.test.js
@@ -1467,7 +1467,6 @@ test('U6 action routing: unknown filter IDs still fall back to "all"', async () 
   assert.equal(harness.store.getState().transientUi.spellingAnalyticsStatusFilter, 'all');
 });
 
-// -----------------------------------------------------------------------------
 // U6 (Post-Mega Spelling Guardian Hardening): resetLearner must zero the
 // `ks2-spell-guardian-<learnerId>` storage key even when the host wires a
 // persistence adapter that lacks a `resetLearner` method. The canonical
@@ -1632,4 +1631,294 @@ test('U6 guardian reset: Worker-side resetLearner behaviour unchanged (still zer
   const snapshot = normaliseServerSpellingData({}, TODAY * DAY_MS);
   assert.deepEqual(snapshot.guardian, {});
   assert.deepEqual(snapshot.progress, {});
+});
+
+// -----------------------------------------------------------------------------
+// U4 (P1.5 hardening): "I don't know" replaces skip in Guardian sessions.
+// Route goes through advanceGuardianOnWrong, emits spelling.guardian.wobbled,
+// sets awaitingAdvance=true (mirrors submitGuardianAnswer wrong-path), and
+// never mutates progress.stage. Non-Guardian sessions keep legacy
+// engine.skipCurrent + enqueueLater semantics byte-identical.
+// -----------------------------------------------------------------------------
+
+test('U4 happy path: Guardian "I don\'t know" on a non-wobbling word emits one WOBBLED event, wobbling→true, nextDueDay=today+1, stage unchanged', () => {
+  const now = () => Date.UTC(2026, 0, 10);
+  const today = Math.floor(now() / DAY_MS_TS);
+  const { service, repositories } = makeServiceWithSeed({ now, random: () => 0.5 });
+  seedAllCoreMega(repositories, 'learner-a', today);
+
+  const started = service.startSession('learner-a', { mode: 'guardian' });
+  const firstSlug = started.state.session.currentCard.slug;
+
+  const skipped = service.skipWord('learner-a', started.state);
+
+  assert.equal(skipped.ok, true);
+  const wobbled = skipped.events.filter((e) => e.type === SPELLING_EVENT_TYPES.GUARDIAN_WOBBLED);
+  assert.equal(wobbled.length, 1, 'exactly one WOBBLED event per "I don\'t know" click');
+  assert.equal(wobbled[0].wordSlug, firstSlug);
+  assert.equal(wobbled[0].lapses, 1, 'lapses incremented to 1 on first wobble');
+
+  // No RENEWED / RECOVERED / MISSION_COMPLETED emitted by a mid-round skip.
+  assert.equal(skipped.events.filter((e) => e.type === SPELLING_EVENT_TYPES.GUARDIAN_RENEWED).length, 0);
+  assert.equal(skipped.events.filter((e) => e.type === SPELLING_EVENT_TYPES.GUARDIAN_RECOVERED).length, 0);
+  assert.equal(skipped.events.filter((e) => e.type === SPELLING_EVENT_TYPES.GUARDIAN_MISSION_COMPLETED).length, 0);
+
+  // Guardian record advanced exactly like a wrong answer.
+  const postMastery = service.getPostMasteryState('learner-a');
+  const record = postMastery.guardianMap[firstSlug];
+  assert.equal(record.wobbling, true);
+  assert.equal(record.nextDueDay, today + 1);
+  assert.equal(record.lapses, 1);
+  assert.equal(record.correctStreak, 0);
+
+  // progress.stage preserved — Mega-never-revoked invariant.
+  const snapshot = service.getAnalyticsSnapshot('learner-a');
+  const row = snapshot.wordGroups.flatMap((g) => g.words).find((w) => w.slug === firstSlug);
+  assert.equal(row.progress.stage, 4);
+  assert.equal(row.progress.dueDay, today + 60, 'progress.dueDay preserved');
+  assert.equal(row.progress.lastDay, today - 7, 'progress.lastDay preserved');
+  assert.equal(row.progress.lastResult, 'correct', 'progress.lastResult preserved');
+  assert.equal(row.progress.wrong, 2, 'progress.wrong bumped by 1 (seed was 1)');
+
+  // Skip matches submitGuardianAnswer shape: awaitingAdvance=true, user clicks
+  // Continue to advance. Session still points at the skipped slug until then.
+  assert.equal(skipped.state.awaitingAdvance, true, 'skip leaves session awaitingAdvance like wrong-answer submit');
+  const postSession = skipped.state.session;
+  assert.ok(postSession, 'session continues');
+  assert.equal(postSession.currentSlug, firstSlug, 'currentSlug stays on skipped slug until continueSession fires');
+  assert.equal(Array.isArray(postSession.queue) && postSession.queue.includes(firstSlug), false, 'queue no longer contains the skipped slug');
+
+  // Continue advances past the skipped slug (FIFO) — no re-queue.
+  const advanced = service.continueSession('learner-a', skipped.state);
+  assert.equal(advanced.state.awaitingAdvance, false);
+  assert.notEqual(advanced.state.session.currentSlug, firstSlug, 'continueSession advances past the skipped slug');
+});
+
+test('U4 happy path: Guardian "I don\'t know" on an already-wobbling word re-emits WOBBLED, lapses +1, nextDueDay resets to today+1', () => {
+  const now = () => Date.UTC(2026, 0, 10);
+  const today = Math.floor(now() / DAY_MS_TS);
+  const { service, repositories } = makeServiceWithSeed({ now, random: () => 0.5 });
+  seedAllCoreMega(repositories, 'learner-a', today);
+
+  // Seed 'possess' as already wobbling — it wins the wobbling-due bucket.
+  seedGuardianMap(repositories, 'learner-a', {
+    possess: {
+      reviewLevel: 2,
+      lastReviewedDay: today - 5,
+      nextDueDay: today - 1,
+      correctStreak: 0,
+      lapses: 1,
+      renewals: 0,
+      wobbling: true,
+    },
+  });
+
+  const started = service.startSession('learner-a', { mode: 'guardian' });
+  assert.equal(started.state.session.currentCard.slug, 'possess');
+  const skipped = service.skipWord('learner-a', started.state);
+
+  const wobbled = skipped.events.filter((e) => e.type === SPELLING_EVENT_TYPES.GUARDIAN_WOBBLED);
+  assert.equal(wobbled.length, 1);
+  assert.equal(wobbled[0].wordSlug, 'possess');
+  assert.equal(wobbled[0].lapses, 2, 'lapses incremented on repeat wobble');
+
+  const postMastery = service.getPostMasteryState('learner-a');
+  const record = postMastery.guardianMap.possess;
+  assert.equal(record.wobbling, true, 'stays wobbling');
+  assert.equal(record.lapses, 2);
+  assert.equal(record.nextDueDay, today + 1, 'nextDueDay resets to today+1');
+
+  const snapshot = service.getAnalyticsSnapshot('learner-a');
+  const row = snapshot.wordGroups.flatMap((g) => g.words).find((w) => w.slug === 'possess');
+  assert.equal(row.progress.stage, 4, 'stage preserved on repeat wobble');
+});
+
+test('U4 happy path: "I don\'t know" adds skipped word to summary.mistakes for the practice-only drill pickup (R3 dependency)', () => {
+  const now = () => Date.UTC(2026, 0, 10);
+  const today = Math.floor(now() / DAY_MS_TS);
+  const { service, repositories } = makeServiceWithSeed({ now, random: () => 0.5 });
+  seedAllCoreMega(repositories, 'learner-a', today);
+
+  const started = service.startSession('learner-a', { mode: 'guardian' });
+  const firstSlug = started.state.session.currentCard.slug;
+  const initialSlugs = started.state.session.uniqueWords.slice();
+
+  // Skip the first word (I don't know), answer the rest correctly.
+  const skipped = service.skipWord('learner-a', started.state);
+  let current = skipped.state;
+  // continue the session (may already be on next card; answer the remainder correctly)
+  while (current.phase === 'session') {
+    if (current.awaitingAdvance) {
+      current = service.continueSession('learner-a', current).state;
+      continue;
+    }
+    const answer = current.session.currentCard.word.word;
+    current = service.submitAnswer('learner-a', current, answer).state;
+  }
+  assert.equal(current.phase, 'summary');
+  const mistakeSlugs = current.summary.mistakes.map((m) => m.slug);
+  assert.ok(mistakeSlugs.includes(firstSlug), '"I don\'t know" slug appears in summary.mistakes');
+  assert.equal(initialSlugs.length, current.summary.mistakes.length + (initialSlugs.length - 1), 'other words did not fall into mistakes');
+});
+
+test('U4 edge: "I don\'t know" when awaitingAdvance===true is a no-op (no duplicate event, no state mutation)', () => {
+  const now = () => Date.UTC(2026, 0, 10);
+  const today = Math.floor(now() / DAY_MS_TS);
+  const { service, repositories } = makeServiceWithSeed({ now, random: () => 0.5 });
+  seedAllCoreMega(repositories, 'learner-a', today);
+
+  const started = service.startSession('learner-a', { mode: 'guardian' });
+  const firstSlug = started.state.session.currentCard.slug;
+  // First correct answer: leaves awaitingAdvance=true.
+  const submitted = service.submitAnswer('learner-a', started.state, started.state.session.currentCard.word.word);
+  assert.equal(submitted.state.awaitingAdvance, true);
+
+  const skipped = service.skipWord('learner-a', submitted.state);
+  assert.equal(skipped.changed, false, 'skipWord no-ops while awaitingAdvance');
+  assert.equal(skipped.events.length, 0, 'no events on no-op skip');
+  // Guardian record from the correct answer is unchanged by the no-op skip.
+  const postMastery = service.getPostMasteryState('learner-a');
+  const record = postMastery.guardianMap[firstSlug];
+  assert.equal(record.wobbling, false, 'record stays as correct-answer result, not wobbling');
+});
+
+test('U4 edge: "I don\'t know" double-click emits exactly one wobble per slug (second call hits awaitingAdvance or next card, never duplicate event)', () => {
+  const now = () => Date.UTC(2026, 0, 10);
+  const today = Math.floor(now() / DAY_MS_TS);
+  const { service, repositories } = makeServiceWithSeed({ now, random: () => 0.5 });
+  seedAllCoreMega(repositories, 'learner-a', today);
+
+  const started = service.startSession('learner-a', { mode: 'guardian' });
+  const firstSlug = started.state.session.currentCard.slug;
+
+  const first = service.skipWord('learner-a', started.state);
+  const second = service.skipWord('learner-a', first.state);
+
+  const firstWobbled = first.events.filter((e) => e.type === SPELLING_EVENT_TYPES.GUARDIAN_WOBBLED);
+  const secondWobbled = second.events.filter((e) => e.type === SPELLING_EVENT_TYPES.GUARDIAN_WOBBLED);
+  assert.equal(firstWobbled.length, 1, 'first click wobbles once');
+  // Second "I don't know" fires on the NEXT card (not the first slug again).
+  // It may produce its own wobble for that next slug, but never a duplicate
+  // for the first slug.
+  const duplicateForFirst = secondWobbled.filter((e) => e.wordSlug === firstSlug);
+  assert.equal(duplicateForFirst.length, 0, 'never a duplicate wobble event for the first slug');
+
+  const postMastery = service.getPostMasteryState('learner-a');
+  assert.equal(postMastery.guardianMap[firstSlug].lapses, 1, 'first slug lapses counted once, not twice');
+});
+
+test('U4 integration (wobbledCount correctness): round with 2 wrong answers + 1 "I don\'t know" emits wobbledCount === 3 on mission-completed', () => {
+  const now = () => Date.UTC(2026, 0, 10);
+  const today = Math.floor(now() / DAY_MS_TS);
+  const { service, repositories } = makeServiceWithSeed({ now, random: () => 0.5 });
+  seedAllCoreMega(repositories, 'learner-a', today);
+
+  const started = service.startSession('learner-a', { mode: 'guardian' });
+  const totalWords = started.state.session.uniqueWords.length;
+
+  let current = started.state;
+  const events = [];
+  let cardCount = 0;
+  while (current.phase === 'session') {
+    if (current.awaitingAdvance) {
+      const advanced = service.continueSession('learner-a', current);
+      events.push(...advanced.events);
+      current = advanced.state;
+      continue;
+    }
+    cardCount += 1;
+    let transition;
+    if (cardCount === 1) {
+      // First card: "I don't know"
+      transition = service.skipWord('learner-a', current);
+    } else if (cardCount <= 3) {
+      // Cards 2 and 3: wrong answer
+      transition = service.submitAnswer('learner-a', current, 'definitely-wrong');
+    } else {
+      // Rest: correct
+      transition = service.submitAnswer('learner-a', current, current.session.currentCard.word.word);
+    }
+    events.push(...transition.events);
+    current = transition.state;
+  }
+
+  assert.equal(current.phase, 'summary');
+  const mission = events.find((e) => e.type === SPELLING_EVENT_TYPES.GUARDIAN_MISSION_COMPLETED);
+  assert.ok(mission, 'mission-completed event emitted');
+  assert.equal(mission.wobbledCount, 3, 'wobbledCount aggregates 2 wrong + 1 "I don\'t know"');
+  assert.equal(mission.renewalCount, totalWords - 3);
+  assert.equal(mission.recoveredCount, 0);
+
+  // Per-word WOBBLED events: exactly 3 across the round.
+  const wobbledEvents = events.filter((e) => e.type === SPELLING_EVENT_TYPES.GUARDIAN_WOBBLED);
+  assert.equal(wobbledEvents.length, 3, 'one WOBBLED event per wobbled slug, no duplicates');
+});
+
+test('U4 integration: non-Guardian learning session skip still calls engine.skipCurrent → enqueueLater, slug re-appears in queue, no guardian events', () => {
+  const now = () => Date.UTC(2026, 0, 10);
+  const { service } = makeServiceWithSeed({ now, random: () => 0.5 });
+  // Learning mode (not guardian). Use seeded words to get a round with a
+  // predictable first slug.
+  const started = service.startSession('learner-a', {
+    mode: 'single',
+    words: ['possess', 'believe', 'imagine', 'decide'],
+    length: 4,
+  });
+  assert.equal(started.state.session.mode, 'single');
+  assert.notEqual(started.state.session.mode, 'guardian');
+  const firstSlug = started.state.session.currentSlug;
+  const queueBefore = started.state.session.queue.slice();
+
+  const skipped = service.skipWord('learner-a', started.state);
+
+  // No guardian events from a non-Guardian skip.
+  assert.equal(skipped.events.filter((e) => e.type?.startsWith?.('spelling.guardian.')).length, 0);
+  // Session advances to a different slug.
+  assert.notEqual(skipped.state.session.currentSlug, firstSlug, 'skip advanced past the first slug');
+  // Legacy enqueueLater: the skipped slug is still reachable in the round
+  // (queue + currentSlug). Either in queue, or it will be picked up later.
+  const queueAfter = skipped.state.session.queue;
+  const reachable = [skipped.state.session.currentSlug, ...queueAfter];
+  assert.ok(reachable.includes(firstSlug), 'legacy skip re-queues slug (reachable later in round)');
+  // Sanity: the legacy info feedback headline is still the non-Guardian one.
+  assert.equal(skipped.state.feedback?.headline, 'Skipped for now.');
+});
+
+test('U4 edge: FIFO-consistent queue after Guardian "I don\'t know" — skipped slug never re-queued', () => {
+  const now = () => Date.UTC(2026, 0, 10);
+  const today = Math.floor(now() / DAY_MS_TS);
+  const { service, repositories } = makeServiceWithSeed({ now, random: () => 0.5 });
+  seedAllCoreMega(repositories, 'learner-a', today);
+
+  const started = service.startSession('learner-a', { mode: 'guardian' });
+  const initialSlugs = started.state.session.uniqueWords.slice();
+  const firstSlug = started.state.session.currentSlug;
+
+  const skipped = service.skipWord('learner-a', started.state);
+  // Queue after + currentSlug should contain all other initial slugs exactly
+  // once; firstSlug must not re-appear.
+  const post = skipped.state.session;
+  const reachable = [post.currentSlug, ...post.queue].filter(Boolean);
+  for (const slug of initialSlugs) {
+    if (slug === firstSlug) {
+      assert.equal(reachable.includes(slug), false, `${slug} must not be re-queued after Guardian skip`);
+    } else {
+      // Each remaining slug appears exactly once on the reachable path
+      // (current + queue), preserving FIFO.
+      assert.equal(reachable.filter((s) => s === slug).length, 1, `${slug} appears exactly once on the FIFO path`);
+    }
+  }
+});
+
+test('U4 edge: Guardian "I don\'t know" sets session.guardianResults[slug] to "wobbled" for mission-completed aggregation', () => {
+  const now = () => Date.UTC(2026, 0, 10);
+  const today = Math.floor(now() / DAY_MS_TS);
+  const { service, repositories } = makeServiceWithSeed({ now, random: () => 0.5 });
+  seedAllCoreMega(repositories, 'learner-a', today);
+
+  const started = service.startSession('learner-a', { mode: 'guardian' });
+  const firstSlug = started.state.session.currentCard.slug;
+  const skipped = service.skipWord('learner-a', started.state);
+
+  assert.equal(skipped.state.session.guardianResults[firstSlug], 'wobbled');
 });

--- a/tests/spelling-parity.test.js
+++ b/tests/spelling-parity.test.js
@@ -355,6 +355,58 @@ test('legacy auto-advance can move a one-word learning round on without a manual
   assert.equal(harness.store.getState().subjectUi.spelling.session.currentCard.slug, firstSlug);
 });
 
+test('U4 parity: non-Guardian learning skip still renders "Skip for now" button and legacy feedback', () => {
+  const storage = installMemoryStorage();
+  const harness = createAppHarness({ storage });
+  const learnerId = harness.store.getState().learners.selectedId;
+
+  harness.services.spelling.savePrefs(learnerId, { mode: 'smart', roundLength: '5' });
+  harness.dispatch('open-subject', { subjectId: 'spelling' });
+  harness.dispatch('spelling-start');
+
+  // Non-Guardian learning session: label is "Skip for now".
+  const startHtml = harness.render();
+  assert.match(startHtml, /Skip for now/);
+  assert.doesNotMatch(startHtml, /I don.t know/, 'non-Guardian session never shows "I don\'t know"');
+
+  // Clicking skip uses legacy feedback text.
+  harness.dispatch('spelling-skip');
+  const afterSkipHtml = harness.render();
+  assert.match(afterSkipHtml, /Skipped for now\./);
+});
+
+test('U4 parity: Guardian session renders "I don\'t know" button label', () => {
+  const storage = installMemoryStorage();
+  const nowRef = { value: Date.UTC(2026, 0, 10) };
+  const harness = createAppHarness({ storage, now: () => nowRef.value });
+  const learnerId = harness.store.getState().learners.selectedId;
+
+  // Seed all-core-mega via the subjectStates repository.
+  const today = Math.floor(nowRef.value / DAY_MS);
+  const progress = Object.fromEntries(
+    Object.keys(WORD_BY_SLUG)
+      .filter((slug) => WORD_BY_SLUG[slug].spellingPool !== 'extra')
+      .map((slug) => [slug, {
+        stage: 4,
+        attempts: 6,
+        correct: 5,
+        wrong: 1,
+        dueDay: today + 60,
+        lastDay: today - 7,
+        lastResult: 'correct',
+      }]),
+  );
+  harness.repositories.subjectStates.writeData(learnerId, 'spelling', { progress });
+  harness.dispatch('open-subject', { subjectId: 'spelling' });
+  harness.dispatch('spelling-shortcut-start', { mode: 'guardian' });
+
+  const html = harness.render();
+  assert.equal(harness.store.getState().subjectUi.spelling.session.mode, 'guardian');
+  // React escapes the apostrophe to &#x27; in rendered HTML.
+  assert.match(html, /I don&#x27;t know/);
+  assert.doesNotMatch(html, /Skip for now/);
+});
+
 test('restored completed spelling card caps progress and resumes auto-advance', () => {
   const storage = installMemoryStorage();
   const scheduler = createManualScheduler();

--- a/tests/spelling-view-model.test.js
+++ b/tests/spelling-view-model.test.js
@@ -14,6 +14,7 @@ import {
   wordBankAggregateStats,
   wordBankFilterMatchesStatus,
 } from '../src/subjects/spelling/components/spelling-view-model.js';
+import { spellingSessionSkipLabel } from '../src/subjects/spelling/session-ui.js';
 
 function createEventStub() {
   return {
@@ -493,4 +494,24 @@ test('guardianSummaryCards: clamps wobbled to totalWords when summary.mistakes i
   const cards = guardianSummaryCards({ summary, nextGuardianDueDay: null, todayDay: 20_000 });
   assert.equal(cards[0].value, 0, 'renewed never goes negative');
   assert.equal(cards[1].value, 2, 'wobbled clamps to totalWords');
+});
+
+// -----------------------------------------------------------------------------
+// U4 (P1.5 hardening): skip button label helper branches on session.mode.
+// -----------------------------------------------------------------------------
+
+test('spellingSessionSkipLabel returns "I don\'t know" for Guardian sessions', () => {
+  assert.equal(spellingSessionSkipLabel({ mode: 'guardian', type: 'learning' }), "I don't know");
+});
+
+test('spellingSessionSkipLabel returns "Skip for now" for non-Guardian learning sessions', () => {
+  assert.equal(spellingSessionSkipLabel({ mode: 'smart', type: 'learning' }), 'Skip for now');
+  assert.equal(spellingSessionSkipLabel({ mode: 'trouble', type: 'learning' }), 'Skip for now');
+  assert.equal(spellingSessionSkipLabel({ mode: 'single', type: 'learning' }), 'Skip for now');
+});
+
+test('spellingSessionSkipLabel falls back to "Skip for now" when session is null or missing mode', () => {
+  assert.equal(spellingSessionSkipLabel(null), 'Skip for now');
+  assert.equal(spellingSessionSkipLabel(undefined), 'Skip for now');
+  assert.equal(spellingSessionSkipLabel({}), 'Skip for now');
 });


### PR DESCRIPTION
## Summary
- Guardian sessions route the skip button through `advanceGuardianOnWrong` + `advanceGuardianCard` (FIFO, no re-queue), emit `spelling.guardian.wobbled`, and record the wobble in `session.guardianResults` so `mission-completed` aggregates the count correctly.
- `progress.stage/dueDay/lastDay/lastResult` are preserved — Mega is never revoked (R11).
- Non-Guardian sessions keep legacy `engine.skipCurrent` + `enqueueLater` semantics byte-identical.
- Skip-button label now comes from a new `spellingSessionSkipLabel(session)` helper — "I don't know" for Guardian, "Skip for now" otherwise.

Plan: `docs/plans/2026-04-25-005-feat-post-mega-spelling-guardian-hardening-plan.md` (U4). Covers R4, R11, AE-R4.

## Key changes
- `shared/spelling/service.js`: new `skipGuardianWord(learnerId, current)` helper inside `createSpellingService`. `skipWord` branches on `session.mode === 'guardian'` before touching the legacy engine.
  - Lazy-creates the guardian record via `ensureGuardianRecord`; advances via `advanceGuardianOnWrong`; saves via `saveGuardianMap` (U7 will upgrade callers to `saveGuardianRecord` when it lands).
  - Bumps `progress.attempts` + `progress.wrong`; preserves `stage/dueDay/lastDay/lastResult`.
  - Sets `session.guardianResults[slug] = 'wobbled'` **before** advancing (required by `guardianMissionEventsForSession`).
  - Marks `session.status[slug].hadWrong = true` so `learningSummary.mistakes` picks the slug up for U3's practice-only drill button.
  - Removes the slug from `session.queue` (FIFO-clean — never re-queued, unlike legacy `enqueueLater`).
  - Uses `advanceGuardianCard` (not `engine.advanceCard`) for the queue advance.
  - On round-end, emits the full guardian mission event bundle (`spelling.guardian.wobbled` + `session.completed` + `guardian.mission-completed`).
- `src/subjects/spelling/session-ui.js`: `spellingSessionSkipLabel(session)` added alongside existing submit-label / context-note helpers.
- `src/subjects/spelling/components/SpellingSessionScene.jsx`: imports the new helper, renders `{skipLabel}` instead of the hard-coded string.

## Test plan
- [x] Targeted suites pass: `tests/spelling-guardian.test.js`, `tests/spelling-parity.test.js`, `tests/spelling-view-model.test.js` — 127/127 green after the change, 9 failing beforehand.
- [x] Full `npm test` sweep — the 11 pre-existing failures (grammar production smoke + evidence adversarial cases) reproduce on `main` and are unrelated to U4. No U4-adjacent regressions.
- New tests cover:
  - Happy path non-wobbling slug → single WOBBLED event, `wobbling: true`, `nextDueDay = today+1`, stage preserved, slug not re-queued.
  - Happy path already-wobbling slug → lapses +1, nextDueDay reset to today+1.
  - Skipped slug appears in `summary.mistakes` (feeds U3 practice drill).
  - `awaitingAdvance` no-op (idempotent double-tap protection).
  - Double-click never produces duplicate WOBBLED for the same slug.
  - Mixed round (2 wrong + 1 "I don't know") → `mission.wobbledCount === 3` and matches per-word record.
  - Non-Guardian learning skip → no guardian events, slug re-queued, legacy feedback text unchanged.
  - FIFO invariant: skipped slug never re-queued.
  - Session-UI helper: `"I don't know"` for Guardian, `"Skip for now"` otherwise, safe on null session.
  - Parity: Guardian UI renders `I don&#x27;t know`; non-Guardian UI still renders `Skip for now`.