### PR TITLE
feat(punctuation): U1 view-model + session-ui + composeIsDisabled extraction

### DIFF
--- a/src/subjects/punctuation/components/PunctuationPracticeSurface.jsx
+++ b/src/subjects/punctuation/components/PunctuationPracticeSurface.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import {
   bellstormSceneForPhase,
+  composeIsDisabled,
   currentItemInstruction,
   punctuationPhaseLabel,
 } from './punctuation-view-model.js';
@@ -11,22 +12,6 @@ function learnerName(appState, learnerId) {
 
 function newlineTextStyle(value) {
   return String(value || '').includes('\n') ? { whiteSpace: 'pre-wrap' } : undefined;
-}
-
-// Composite disable signal shared across Setup, ActiveItem, and Feedback
-// views. Mutation controls (start, submit, continue, skip, end) must pause
-// whenever a command is in flight, the runtime is degraded/unavailable, or
-// the platform has flipped the subject read-only. The adapter layer
-// (subject-command-client) is the authoritative dedupe; the UI signal is
-// the visual echo.
-function composeIsDisabled(ui) {
-  const availabilityStatus = ui?.availability?.status || 'ready';
-  const runtimeReadOnly = Boolean(ui?.runtime?.readOnly);
-  const pending = Boolean(ui?.pendingCommand);
-  return pending
-    || runtimeReadOnly
-    || availabilityStatus === 'degraded'
-    || availabilityStatus === 'unavailable';
 }
 
 function SetupView({ learner, stats, ui, actions }) {

--- a/src/subjects/punctuation/components/punctuation-view-model.js
+++ b/src/subjects/punctuation/components/punctuation-view-model.js
@@ -1,4 +1,24 @@
+// Pure view-model helpers for the Punctuation surface. Frozen option lists,
+// child-facing label/tone mappings, dashboard + Punctuation Map model builders,
+// forbidden-term fixture. No React imports. No SSR. Every helper is a pure
+// function over plain data so tests can assert behaviour without rendering
+// JSX.
+//
+// The pattern mirrors `src/subjects/grammar/components/grammar-view-model.js`
+// and `src/subjects/spelling/components/spelling-view-model.js` — subject-
+// scoped lists + filter helpers + aggregate card builders. The intent is that
+// every JSX unit in Phase 3 imports from this single file plus
+// `../session-ui.js` rather than restating copy, filter predicates, or the
+// composite-disabled helper inline. When new forbidden terms appear we add
+// them here once and every child surface inherits the guard through U10's
+// fixture-driven sweep.
+//
+// Parity guard: `composeIsDisabled` deliberately lives here and nowhere else.
+// Grammar and Spelling each keep their own copy. Any shared extraction must
+// prove Spelling byte-for-byte parity in the PR (AGENTS.md:14).
+
 import { resolveMonsterVisual } from '../../../platform/game/monster-visual-config.js';
+import { MONSTERS_BY_SUBJECT } from '../../../platform/game/monsters.js';
 
 const BELLSTORM_BASE = '/assets/regions/bellstorm-coast';
 
@@ -10,9 +30,20 @@ function sceneUrl(name, size = 1280) {
   return `${BELLSTORM_BASE}/${name}.${size}.webp`;
 }
 
+// --- Bellstorm scene selector ----------------------------------------------
+
+// Setup, Map, and active-item phases use the Bellstorm Coast A–C daily sets.
+// Summary + feedback reach for the D–E boss moments. Map is a browsing scene
+// and therefore reads as a daily view, not a boss view. Unknown phases fall
+// back to the Setup cover so the hero never renders broken assets.
 export function bellstormSceneForPhase(phase = 'setup') {
-  const scenes = phase === 'summary' || phase === 'feedback' ? SUMMARY_SCENES : SETUP_SCENES;
-  const index = phase === 'active-item' ? 2 : phase === 'feedback' ? 1 : phase === 'summary' ? 3 : 0;
+  const useSummarySet = phase === 'summary' || phase === 'feedback';
+  const scenes = useSummarySet ? SUMMARY_SCENES : SETUP_SCENES;
+  let index = 0;
+  if (phase === 'active-item') index = 2;
+  else if (phase === 'feedback') index = 1;
+  else if (phase === 'summary') index = 3;
+  else if (phase === 'map') index = 1; // Map uses Bellstorm Coast A-1 (daily B1 slot)
   const name = scenes[index] || scenes[0];
   return {
     name,
@@ -45,6 +76,7 @@ export function punctuationPhaseLabel(phase = 'setup') {
   if (phase === 'feedback') return 'Feedback';
   if (phase === 'summary') return 'Summary';
   if (phase === 'unavailable') return 'Unavailable';
+  if (phase === 'map') return 'Punctuation Map';
   return 'Setup';
 }
 
@@ -55,4 +87,545 @@ export function currentItemInstruction(item = {}) {
   if (item.mode === 'paragraph') return 'Repair the whole passage.';
   if (item.mode === 'fix') return 'Correct the sentence.';
   return 'Type the sentence with punctuation.';
+}
+
+// --- Composite disable signal ----------------------------------------------
+
+// Mutation controls (start, submit, continue, skip, end, Map filters, Modal
+// Practise) must pause whenever a command is in flight, the runtime is
+// degraded/unavailable, or the platform has flipped the subject read-only.
+// The adapter layer (subject-command-client) is the authoritative dedupe;
+// the UI signal here is the visual echo. Every Phase 3 scene threads this
+// helper — there is no per-scene composite signal.
+export function composeIsDisabled(ui) {
+  const availabilityStatus = ui?.availability?.status || 'ready';
+  const runtimeReadOnly = Boolean(ui?.runtime?.readOnly);
+  const pending = Boolean(ui?.pendingCommand);
+  return pending
+    || runtimeReadOnly
+    || availabilityStatus === 'degraded'
+    || availabilityStatus === 'unavailable';
+}
+
+// --- Primary mode cards (Setup scene) --------------------------------------
+
+// The dashboard's three primary journey cards. `smart` sits first as the
+// obvious default action; `weak` covers "Wobbly Spots"; `gps` is the quick
+// timed check. Order is plan-fixed so every scene renders the same three
+// cards in the same order without restating copy.
+export const PUNCTUATION_PRIMARY_MODE_IDS = Object.freeze(['smart', 'weak', 'gps']);
+
+export const PUNCTUATION_PRIMARY_MODE_CARDS = Object.freeze([
+  Object.freeze({
+    id: 'smart',
+    label: 'Smart Review',
+    description: "A short mix of today's best practice.",
+    badge: 'Recommended',
+  }),
+  Object.freeze({
+    id: 'weak',
+    label: 'Wobbly Spots',
+    description: 'Practise the things that needed another go.',
+  }),
+  Object.freeze({
+    id: 'gps',
+    label: 'GPS Check',
+    description: 'A quick check-up — answers come at the end.',
+  }),
+]);
+
+// --- Punctuation Map filter lists ------------------------------------------
+
+// Map status chips. Order matches the plan: All / New / Learning / Due /
+// Wobbly / Secure. Child copy — the `weak` id reads as "Wobbly" in the UI.
+export const PUNCTUATION_MAP_STATUS_FILTER_IDS = Object.freeze([
+  'all', 'new', 'learning', 'due', 'weak', 'secure',
+]);
+
+// Map monster chips. Order matches the plan / codebase active roster. Reserved
+// monsters (Colisk / Hyphang / Carillon) are intentionally absent so a rogue
+// payload cannot surface a retired name as a filter option.
+export const PUNCTUATION_MAP_MONSTER_FILTER_IDS = Object.freeze([
+  'all', 'pealark', 'claspin', 'curlune', 'quoral',
+]);
+
+// --- Active monster roster -------------------------------------------------
+
+// The four learner-facing Punctuation monsters. Read from
+// `MONSTERS_BY_SUBJECT.punctuation` so the order stays in lock-step with
+// `src/platform/game/monsters.js:186-203`. Reserved monsters are never
+// included. If the code-level roster changes, this list follows automatically.
+const PUNCTUATION_ACTIVE_ROSTER_SOURCE = Object.freeze(
+  Array.isArray(MONSTERS_BY_SUBJECT?.punctuation)
+    ? [...MONSTERS_BY_SUBJECT.punctuation]
+    : ['pealark', 'curlune', 'claspin', 'quoral'],
+);
+
+export const ACTIVE_PUNCTUATION_MONSTER_IDS = Object.freeze(PUNCTUATION_ACTIVE_ROSTER_SOURCE);
+
+// Child-facing display names for the active Punctuation monsters. Reserved
+// monsters are intentionally absent. Falls back to titlecase of the id for
+// any future active addition that lacks an explicit entry.
+export const ACTIVE_PUNCTUATION_MONSTER_DISPLAY_NAMES = Object.freeze({
+  pealark: 'Pealark',
+  claspin: 'Claspin',
+  curlune: 'Curlune',
+  quoral: 'Quoral',
+});
+
+function titlecase(value) {
+  return String(value || '')
+    .replace(/[._-]+/g, ' ')
+    .replace(/\b\w/g, (letter) => letter.toUpperCase())
+    .trim();
+}
+
+export function punctuationMonsterDisplayName(monsterId) {
+  if (typeof monsterId !== 'string' || !monsterId) return '';
+  return ACTIVE_PUNCTUATION_MONSTER_DISPLAY_NAMES[monsterId] || titlecase(monsterId);
+}
+
+// --- Dashboard hero copy ---------------------------------------------------
+
+// Hero headline + subheadline for the Setup / dashboard scene. Frozen so U1
+// can swap it in one place after James reviews the final copy. Child-facing
+// only — U10's sweep validates.
+export const PUNCTUATION_DASHBOARD_HERO = Object.freeze({
+  eyebrow: 'Bellstorm Coast',
+  headline: 'Punctuation practice',
+  subtitle: "Pick a short round — we'll queue what matters next.",
+});
+
+// --- Forbidden-terms fixture -----------------------------------------------
+
+// Every adult / internal term that must not appear in child-facing
+// Punctuation scenes (Setup, Session, Feedback, Summary, Map, Skill Detail).
+// U10 iterates this list against every child phase. Additions land here once
+// and propagate automatically. The list includes:
+//  - Engine / Worker infrastructure terms ('Worker', 'Worker-held', …)
+//  - Redaction forbidden-key names ('accepted', 'correctIndex', 'rubric', …)
+//  - Internal state terms ('subjectUi', 'weakFocus', 'hasEvidence', …)
+//  - Dotted misconception-tag prefixes (`speech.`, `comma.`, …) — catches raw
+//    IDs like `speech.quote_missing` that currently leak via
+//    `PunctuationPracticeSurface.jsx:322` (pre-Phase-3). U4's Summary rewrite
+//    pipes these through `punctuationChildMisconceptionLabel(tag)` and hides
+//    chips with no mapped child label.
+//  - `/\bWorker\b/i` — a whole-word catch-all for any case-variant leakage.
+export const PUNCTUATION_CHILD_FORBIDDEN_TERMS = Object.freeze([
+  'Worker',
+  'Worker-held',
+  'Worker-marked',
+  'accepted',
+  'correctIndex',
+  'rubric',
+  'validator',
+  'generator',
+  'rawGenerator',
+  'mastery key',
+  'mastery-key',
+  'release id',
+  'releaseId',
+  'facet weight',
+  'publishedTotal',
+  'denominator',
+  'projection',
+  'reward route',
+  'read model',
+  'misconception tag',
+  'supportLevel',
+  'contextPack',
+  'Context pack',
+  'skill-bank',
+  'weakFocus',
+  'hasEvidence',
+  'subjectUi',
+  // Dotted misconception-tag prefixes — catches raw IDs like
+  // `speech.quote_missing` that leak via the current monolith's SummaryView.
+  'speech.',
+  'comma.',
+  'boundary.',
+  'apostrophe.',
+  'structure.',
+  'endmarks.',
+  // Whole-word catch-all for any case-variant leakage.
+  /\bWorker\b/i,
+]);
+
+/**
+ * Returns `true` iff `text` contains none of
+ * `PUNCTUATION_CHILD_FORBIDDEN_TERMS`. String terms match
+ * case-insensitively; RegExp terms apply directly. Empty / non-string
+ * input returns `true` so the helper is safe to call against e.g.
+ * `undefined` chip labels.
+ */
+export function isPunctuationChildCopy(text) {
+  if (typeof text !== 'string' || !text) return true;
+  const haystack = text.toLowerCase();
+  for (const term of PUNCTUATION_CHILD_FORBIDDEN_TERMS) {
+    if (term instanceof RegExp) {
+      if (term.test(text)) return false;
+      continue;
+    }
+    if (typeof term !== 'string' || !term) continue;
+    if (haystack.includes(term.toLowerCase())) return false;
+  }
+  return true;
+}
+
+// --- Child status-label map ------------------------------------------------
+
+const PUNCTUATION_CHILD_STATUS_LABELS = Object.freeze({
+  new: 'New',
+  learning: 'Learning',
+  due: 'Due today',
+  weak: 'Wobbly',
+  secure: 'Secure',
+});
+
+/**
+ * Child-facing label for an internal skill status id. Unknown inputs fall
+ * back to `New` so a rogue payload still reads as child copy rather than
+ * leaking an adult id.
+ */
+export function punctuationChildStatusLabel(status) {
+  if (typeof status !== 'string' || !status) return 'New';
+  return PUNCTUATION_CHILD_STATUS_LABELS[status] || 'New';
+}
+
+// --- Misconception-tag → child label ---------------------------------------
+
+// Deterministic map from the dotted misconception-tag IDs emitted by
+// `shared/punctuation/marking.js` to child-friendly short labels. Unknown
+// tags return `null`; the caller hides the chip rather than rendering the
+// raw dotted ID. U4 pipes `feedback.misconceptionTags` through this helper
+// and pairs it with U10's forbidden-term sweep so a missing mapping fails
+// loudly as either an empty chip list (safe) or a forbidden dotted prefix
+// in rendered HTML (caught by U10).
+//
+// Initial translation table — expand in U4 after James reviews. The same
+// table also gets tested in U1 via `tests/punctuation-view-model.test.js`.
+const PUNCTUATION_MISCONCEPTION_CHILD_LABELS = Object.freeze({
+  // speech.*
+  'speech.quote_missing': 'Speech punctuation',
+  'speech.quote_unmatched': 'Speech punctuation',
+  'speech.punctuation_outside_quote': 'Speech punctuation',
+  'speech.punctuation_missing': 'Speech punctuation',
+  'speech.reporting_comma_missing': 'Speech punctuation',
+  'speech.capitalisation_missing': 'Capital letters',
+  'speech.words_changed': 'Spoken words',
+  'speech.unwanted_punctuation': 'Speech punctuation',
+  // comma.*
+  'comma.clarity_missing': 'Comma placement',
+  'comma.list_missing': 'List commas',
+  'comma.list_separator_missing': 'List commas',
+  'comma.list_words_changed': 'List commas',
+  'comma.unnecessary_final_comma': 'List commas',
+  'comma.fronted_adverbial_missing': 'Comma after the opener',
+  'comma.opening_phrase_changed': 'Comma after the opener',
+  'comma.main_clause_missing': 'Comma placement',
+  'comma.capitalisation_missing': 'Capital letters',
+  'comma.terminal_missing': 'End punctuation',
+  // boundary.*
+  'boundary.semicolon_missing': 'Boundary punctuation',
+  'boundary.dash_missing': 'Boundary punctuation',
+  'boundary.hyphen_missing': 'Hyphen',
+  'boundary.comma_splice': 'Boundary punctuation',
+  'boundary.words_changed': 'Boundary punctuation',
+  'boundary.capitalisation_missing': 'Capital letters',
+  'boundary.terminal_missing': 'End punctuation',
+  // apostrophe.*
+  'apostrophe.contraction_missing': 'Apostrophes',
+  'apostrophe.possession_missing': 'Apostrophes',
+  'apostrophe.required_forms_missing': 'Apostrophes',
+  'apostrophe.unrepaired_forms': 'Apostrophes',
+  'apostrophe.capitalisation_missing': 'Capital letters',
+  'apostrophe.terminal_missing': 'End punctuation',
+  // endmarks.*
+  'endmarks.missing': 'End punctuation',
+  'endmarks.question_mark_missing': 'End punctuation',
+  'endmarks.question_starter_changed': 'Sentence wording',
+  'endmarks.capitalisation_missing': 'Capital letters',
+  // structure.*
+  'structure.fronted_missing': 'Sentence structure',
+  'structure.words_changed': 'Sentence structure',
+  'structure.parenthesis_missing': 'Parenthesis',
+  'structure.parenthesis_unbalanced': 'Parenthesis',
+  'structure.colon_missing': 'Colon before a list',
+  'structure.list_words_changed': 'List commas',
+  'structure.list_separator_missing': 'List commas',
+  'structure.semicolon_list_missing': 'Semi-colons in lists',
+  'structure.bullet_colon_missing': 'Bullet points',
+  'structure.bullet_marker_missing': 'Bullet points',
+  'structure.bullet_punctuation_inconsistent': 'Bullet points',
+  'structure.capitalisation_missing': 'Capital letters',
+  'structure.terminal_missing': 'End punctuation',
+});
+
+export function punctuationChildMisconceptionLabel(tag) {
+  if (typeof tag !== 'string' || !tag) return null;
+  const label = PUNCTUATION_MISCONCEPTION_CHILD_LABELS[tag];
+  return typeof label === 'string' && label ? label : null;
+}
+
+// --- Feedback chip builder -------------------------------------------------
+
+/**
+ * Returns up to 2 child-friendly feedback chips derived from the `facet`
+ * list emitted by the marking engine. Uses `facet.label` (the friendly
+ * string from `shared/punctuation/marking.js:FACET_LABELS`) — not the
+ * dotted `misconceptionTags` IDs, which U4 handles separately via
+ * `punctuationChildMisconceptionLabel`. Empty / non-array input returns
+ * `[]`. The cap at 2 keeps the feedback tray short for KS2 learners.
+ */
+export function punctuationFeedbackChips(facets) {
+  if (!Array.isArray(facets) || facets.length === 0) return [];
+  const chips = [];
+  for (const facet of facets) {
+    if (!facet || typeof facet !== 'object' || Array.isArray(facet)) continue;
+    const label = typeof facet.label === 'string' ? facet.label.trim() : '';
+    if (!label) continue;
+    chips.push({
+      id: typeof facet.id === 'string' ? facet.id : label,
+      label,
+      ok: facet.ok === true,
+    });
+    if (chips.length >= 2) break;
+  }
+  return chips;
+}
+
+// --- Prefs mode normaliser -------------------------------------------------
+
+// Returning learners may have `prefs.mode` set to one of the 6 cluster values
+// (`endmarks`, `apostrophe`, `speech`, `comma_flow`, `boundary`, `structure`)
+// or `guided`. Phase 3 removes those as primary-setup affordances; the
+// dashboard renders 3 cards keyed to `smart | weak | gps`. Display-only: we
+// collapse cluster / guided values to `smart` so the aria-pressed state on
+// the primary mode cards stays coherent. Storage migration (a one-shot
+// dispatch of `punctuation-set-mode` with `value: 'smart'`) is U2's job; U1
+// only supplies the display mapping.
+const PUNCTUATION_LEGACY_CLUSTER_MODE_IDS = Object.freeze(new Set([
+  'endmarks',
+  'apostrophe',
+  'speech',
+  'comma_flow',
+  'boundary',
+  'structure',
+  'guided',
+]));
+
+export function punctuationPrimaryModeFromPrefs(prefs) {
+  const mode = prefs && typeof prefs === 'object' && !Array.isArray(prefs)
+    ? prefs.mode
+    : prefs;
+  if (typeof mode !== 'string' || !mode) return 'smart';
+  if (mode === 'smart' || mode === 'weak' || mode === 'gps') return mode;
+  if (PUNCTUATION_LEGACY_CLUSTER_MODE_IDS.has(mode)) return 'smart';
+  return 'smart';
+}
+
+// --- Skill modal preferred example table -----------------------------------
+
+// Per-skill override for the Skill Detail modal pedagogy field (U6). The
+// Modal renders exactly 3 pedagogy fields: `rule`, `contrastBad`, and one of
+// `workedGood` OR `contrastGood`. Default is `workedGood`. We override for
+// skills whose `workedGood` is itself verbatim-identical to a
+// `PUNCTUATION_ITEMS.accepted[0]` string — for those, `contrastGood` is the
+// safer choice. A full per-skill audit runs in U6; U1 seeds only the
+// plan-specified override for `comma_clarity` (whose `contrastGood`
+// `'Most of the time, travellers worry about delays.'` is byte-for-byte
+// identical to `cc_insert_time_travellers.accepted[0]` — see Key Technical
+// Decisions in the Phase 3 plan).
+//
+// Additional per-skill audit findings documented in the PR body:
+// - `list_commas`, `colon_list`, `semicolon`, `dash_clause`,
+//   `semicolon_list`, `bullet_points` — BOTH `workedGood` and `contrastGood`
+//   are verbatim-present in `PUNCTUATION_ITEMS.accepted[]` for at least one
+//   insert/fix item. Neither field is safer than the other; defaulting to
+//   `workedGood` is a seam U6's full audit will re-examine.
+// - `comma_clarity` — only `contrastGood` overlaps → override to
+//   `workedGood` (plan-specified).
+// - `hyphen` — `contrastGood` overlaps but `workedGood` does not → default
+//   `workedGood` already avoids the leak.
+// - `sentence_endings`, `apostrophe_contractions`, `apostrophe_possession`,
+//   `speech`, `fronted_adverbial`, `parenthesis` — neither field overlaps;
+//   default `workedGood` is safe.
+export const PUNCTUATION_SKILL_MODAL_PREFERRED_EXAMPLE = Object.freeze({
+  comma_clarity: 'workedGood',
+});
+
+export function punctuationSkillModalPreferredExample(skillId) {
+  if (typeof skillId !== 'string' || !skillId) return 'workedGood';
+  const value = PUNCTUATION_SKILL_MODAL_PREFERRED_EXAMPLE[skillId];
+  return value === 'contrastGood' ? 'contrastGood' : 'workedGood';
+}
+
+// --- Dashboard model builder -----------------------------------------------
+
+function safeNumber(value, fallback = 0) {
+  const num = Number(value);
+  return Number.isFinite(num) && num >= 0 ? Math.floor(num) : fallback;
+}
+
+function activeMonsterProgressFromReward(rewardState) {
+  const safeReward = rewardState && typeof rewardState === 'object' && !Array.isArray(rewardState)
+    ? rewardState
+    : {};
+  return ACTIVE_PUNCTUATION_MONSTER_IDS.map((monsterId) => {
+    const entry = safeReward[monsterId];
+    const masteredList = Array.isArray(entry?.mastered) ? entry.mastered : [];
+    return Object.freeze({
+      id: monsterId,
+      name: punctuationMonsterDisplayName(monsterId),
+      mastered: masteredList.length || safeNumber(entry?.masteredCount, 0),
+    });
+  });
+}
+
+/**
+ * Builds the Setup-scene dashboard view-model. Pure reducer over the
+ * Punctuation read-model stats shape + reward state. Returns a safe empty
+ * shape when any input is missing, so the dashboard never throws on a fresh
+ * learner. Output:
+ *
+ *   {
+ *     todayCards:      Frozen array of { id, label, value, detail },
+ *     activeMonsters:  Frozen array of { id, name, mastered },
+ *     primaryMode:     string,  // normalised via punctuationPrimaryModeFromPrefs
+ *     isEmpty:         boolean, // true when every Today count is zero
+ *   }
+ */
+export function buildPunctuationDashboardModel(stats, learner, rewardState) {
+  const safeStats = stats && typeof stats === 'object' && !Array.isArray(stats) ? stats : {};
+  const dueCount = safeNumber(safeStats.due, 0);
+  const weakCount = safeNumber(safeStats.weak, 0);
+  const secureCount = safeNumber(safeStats.securedRewardUnits ?? safeStats.secure, 0);
+  const accuracyValue = safeNumber(safeStats.accuracy, 0);
+
+  const todayCards = Object.freeze([
+    Object.freeze({ id: 'secure', label: 'Secure', value: secureCount, detail: 'Reward units you own' }),
+    Object.freeze({ id: 'due', label: 'Due', value: dueCount, detail: 'Come back to these today' }),
+    Object.freeze({ id: 'weak', label: 'Wobbly', value: weakCount, detail: 'Needs another go' }),
+    Object.freeze({ id: 'accuracy', label: 'Accuracy', value: accuracyValue, detail: 'This release' }),
+  ]);
+
+  const prefs = learner && typeof learner === 'object' && !Array.isArray(learner)
+    ? learner.prefs
+    : null;
+  const primaryMode = punctuationPrimaryModeFromPrefs(prefs);
+
+  // Fresh learner: zero attempts, zero secure units, zero wobbly, zero due.
+  const isEmpty = (dueCount + weakCount + secureCount + accuracyValue) === 0;
+
+  return {
+    todayCards,
+    activeMonsters: Object.freeze(activeMonsterProgressFromReward(rewardState)),
+    primaryMode,
+    isEmpty,
+  };
+}
+
+// --- Punctuation Map model builder -----------------------------------------
+
+function normaliseSkillRow(row) {
+  if (!row || typeof row !== 'object' || Array.isArray(row)) return null;
+  const skillId = typeof row.skillId === 'string' ? row.skillId : '';
+  if (!skillId) return null;
+  return {
+    skillId,
+    name: typeof row.name === 'string' ? row.name : skillId,
+    clusterId: typeof row.clusterId === 'string' ? row.clusterId : '',
+    status: typeof row.status === 'string' ? row.status : 'new',
+    attempts: safeNumber(row.attempts, 0),
+    accuracy: Number.isFinite(Number(row.accuracy)) ? Number(row.accuracy) : null,
+    mastery: safeNumber(row.mastery, 0),
+    dueAt: safeNumber(row.dueAt, 0),
+  };
+}
+
+function deriveStatusForSkill(row) {
+  if (!row) return 'new';
+  if (row.attempts === 0) return 'new';
+  return row.status;
+}
+
+function masteredCountForMonster(rewardState, monsterId) {
+  if (!rewardState || typeof rewardState !== 'object' || Array.isArray(rewardState)) return 0;
+  const entry = rewardState[monsterId];
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return 0;
+  const masteredList = Array.isArray(entry.mastered) ? entry.mastered : [];
+  return masteredList.length || safeNumber(entry.masteredCount, 0);
+}
+
+/**
+ * Builds the Punctuation Map view-model. Pure reducer over:
+ *   - `skillRows`        — analytics snapshot (already redacted).
+ *   - `monsterState`     — either a reward-state map keyed by monsterId OR the
+ *                          shape returned by `normalisePunctuationMonsterState`.
+ *                          Both expose `{ mastered: [...] }` per entry.
+ *   - `clusterToMonster` — map cluster id → monsterId. Built from
+ *                          `PUNCTUATION_CLUSTERS` in the caller; U1 tests
+ *                          pass a plain object.
+ *
+ * Output shape (U5's Map scene consumes this directly):
+ *
+ *   {
+ *     monsters: [
+ *       {
+ *         monsterId, name, mastered, skills: [{ skillId, name, clusterId,
+ *           status, statusLabel, attempts, accuracy, mastery, dueAt }]
+ *       }, ...
+ *     ]
+ *   }
+ *
+ * Reserved monsters never appear in the output even if `monsterState`
+ * contains them — the iterator is `ACTIVE_PUNCTUATION_MONSTER_IDS`, full
+ * stop. A skill whose cluster maps to a reserved or unknown monster falls
+ * back to the grand monster (`quoral`) so the 14-skill total stays stable.
+ */
+export function buildPunctuationMapModel(skillRows, monsterState, clusterToMonster) {
+  const rows = (Array.isArray(skillRows) ? skillRows : [])
+    .map(normaliseSkillRow)
+    .filter(Boolean);
+  const clusterMap = clusterToMonster && typeof clusterToMonster === 'object' && !Array.isArray(clusterToMonster)
+    ? clusterToMonster
+    : {};
+  const activeSet = new Set(ACTIVE_PUNCTUATION_MONSTER_IDS);
+  const grandMonsterId = ACTIVE_PUNCTUATION_MONSTER_IDS[ACTIVE_PUNCTUATION_MONSTER_IDS.length - 1] || 'quoral';
+
+  const skillToMonster = new Map();
+  for (const row of rows) {
+    const mappedMonster = clusterMap[row.clusterId];
+    const monsterId = typeof mappedMonster === 'string' && activeSet.has(mappedMonster)
+      ? mappedMonster
+      : grandMonsterId;
+    skillToMonster.set(row.skillId, monsterId);
+  }
+
+  const monsters = ACTIVE_PUNCTUATION_MONSTER_IDS.map((monsterId) => {
+    const skills = rows
+      .filter((row) => skillToMonster.get(row.skillId) === monsterId)
+      .map((row) => {
+        const status = deriveStatusForSkill(row);
+        return Object.freeze({
+          skillId: row.skillId,
+          name: row.name,
+          clusterId: row.clusterId,
+          status,
+          statusLabel: punctuationChildStatusLabel(status),
+          attempts: row.attempts,
+          accuracy: row.accuracy,
+          mastery: row.mastery,
+          dueAt: row.dueAt,
+        });
+      });
+    return Object.freeze({
+      monsterId,
+      name: punctuationMonsterDisplayName(monsterId),
+      mastered: masteredCountForMonster(monsterState, monsterId),
+      skills: Object.freeze(skills),
+    });
+  });
+
+  return Object.freeze({ monsters: Object.freeze(monsters) });
 }

--- a/src/subjects/punctuation/session-ui.js
+++ b/src/subjects/punctuation/session-ui.js
@@ -1,0 +1,121 @@
+// Pure session label/visibility/shape selectors for the Punctuation surface.
+// Mirrors `src/subjects/grammar/session-ui.js` and
+// `src/subjects/spelling/session-ui.js` so every Phase 3 JSX unit imports
+// from one source of truth rather than restating branches inline.
+//
+// No React. No SSR. No import from `./components/*`. These helpers are pure
+// functions on the Worker-projected `session` shape plus the Punctuation
+// `phase` string. They are safe to call in any test.
+
+const TEXT_PREFILL_STEM_MODES = Object.freeze(new Set(['insert', 'fix', 'paragraph']));
+const TEXT_PREFILL_BLANK_MODES = Object.freeze(new Set(['combine', 'transfer']));
+
+/**
+ * Label for the primary session submit button. GPS mode keeps answers
+ * locked in until the end of the round, so its submit reads as "Save
+ * answer" rather than "Check". Every other mode — including the six
+ * cluster-focus modes that stay reachable via direct dispatch — reads as
+ * "Check". Null / unknown session falls back to "Check" so the control
+ * never flashes an empty label during the first render.
+ */
+export function punctuationSessionSubmitLabel(session) {
+  if (session && typeof session === 'object' && !Array.isArray(session) && session.mode === 'gps') {
+    return 'Save answer';
+  }
+  return 'Check';
+}
+
+/**
+ * Describes the text-input shape for a given item mode. Used by U3's Session
+ * scene to decide between "prefill with the stem" (insert / fix / paragraph)
+ * and "blank textarea with source block above" (combine / transfer). Radio-
+ * choice items short-circuit to `{ prefill: 'none' }` — the scene then
+ * renders the existing `ChoiceItem` radio group. Unknown modes fall back to
+ * `{ prefill: 'none' }` so a rogue payload cannot accidentally prefill the
+ * learner's input with the source sentence.
+ *
+ * Returns one of:
+ *   - `{ prefill: 'stem' }`                         — insert / fix / paragraph
+ *   - `{ prefill: 'blank', showSource: true }`      — combine / transfer
+ *   - `{ prefill: 'none' }`                         — choose / unknown
+ */
+export function punctuationSessionInputShape(itemMode) {
+  if (typeof itemMode !== 'string' || !itemMode) return { prefill: 'none' };
+  if (TEXT_PREFILL_STEM_MODES.has(itemMode)) return { prefill: 'stem' };
+  if (TEXT_PREFILL_BLANK_MODES.has(itemMode)) return { prefill: 'blank', showSource: true };
+  return { prefill: 'none' };
+}
+
+/**
+ * Child-facing progress label. Reads as `Question X of N`. Handles the
+ * boundary case where `session.length` is zero (fresh session, no items
+ * queued yet) by falling back to `Question 1` — still child-readable and
+ * stable across first-render. Negative / non-finite values clamp to zero.
+ */
+export function punctuationSessionProgressLabel(session) {
+  if (!session || typeof session !== 'object' || Array.isArray(session)) return 'Question 1';
+  const rawLength = Number(session.length);
+  const total = Number.isFinite(rawLength) && rawLength > 0 ? Math.floor(rawLength) : 0;
+  const rawAnswered = Number(session.answeredCount);
+  const safeAnswered = Number.isFinite(rawAnswered) && rawAnswered >= 0 ? Math.floor(rawAnswered) : 0;
+  const questionNumber = Math.min(Math.max(total, 1), safeAnswered + 1);
+  if (total <= 0) return `Question ${questionNumber}`;
+  return `Question ${questionNumber} of ${total}`;
+}
+
+/**
+ * Single truth table for help / support visibility during the active-item
+ * and feedback phases. Every JSX unit that decides whether to render a
+ * teach box, feedback panel, or GPS delayed-feedback chip row calls this
+ * helper once and threads the flags down.
+ *
+ * Rules:
+ * - GPS mode (any phase): `showFeedback` stays `false` until `phase ===
+ *   'summary'`. GPS keeps its delayed-feedback contract — the learner
+ *   never sees per-item feedback until the round ends. Teach box is
+ *   hidden across every GPS phase.
+ * - Guided mode (active-item or feedback): `showTeachBox` is `true`
+ *   (collapsed to a rule reminder by U3's Session scene) and
+ *   `showFeedback` follows the phase.
+ * - Other modes (Smart / Wobbly / cluster-focus): `showTeachBox` is
+ *   `false`; `showFeedback` follows the phase.
+ *
+ * Returns `{ showTeachBox: boolean, showFeedback: boolean }`.
+ */
+export function punctuationSessionHelpVisibility(session, phase) {
+  const safeSession = session && typeof session === 'object' && !Array.isArray(session) ? session : null;
+  const mode = safeSession && typeof safeSession.mode === 'string' ? safeSession.mode : null;
+  const isGps = mode === 'gps';
+  const isGuided = mode === 'guided';
+
+  if (isGps) {
+    return {
+      showTeachBox: false,
+      showFeedback: phase === 'summary',
+    };
+  }
+
+  return {
+    showTeachBox: isGuided && (phase === 'active-item' || phase === 'feedback'),
+    showFeedback: phase === 'feedback' || phase === 'summary',
+  };
+}
+
+/**
+ * Child-friendly placeholder copy for the text input area. Mode-specific so
+ * combine / transfer prompts the learner to start typing their own answer,
+ * while insert / fix / paragraph modes (where the stem prefills the input)
+ * suggest editing-in-place. Unknown modes fall back to a generic prompt.
+ */
+export function punctuationSessionInputPlaceholder(itemMode) {
+  if (typeof itemMode !== 'string' || !itemMode) return 'Type your answer here';
+  switch (itemMode) {
+    case 'insert': return 'Add the missing punctuation';
+    case 'fix': return 'Fix the punctuation';
+    case 'paragraph': return 'Repair the whole passage';
+    case 'combine': return 'Combine the parts into one sentence';
+    case 'transfer': return 'Write one accurate sentence';
+    case 'choose': return '';
+    default: return 'Type your answer here';
+  }
+}

--- a/tests/punctuation-session-ui.test.js
+++ b/tests/punctuation-session-ui.test.js
@@ -1,0 +1,215 @@
+// Phase 3 U1 — Punctuation session-ui pure-function assertions.
+//
+// These tests are the load-bearing assertion surface for the session-ui half
+// of U1. Every export from `src/subjects/punctuation/session-ui.js` is
+// exercised here with a happy path, an edge case, and (where relevant) an
+// error-path assertion. No SSR render. No React. Every fixture is a plain
+// object so the file runs fast on `node --test` alone.
+//
+// Integration: U3's Session scene calls these helpers once per render and
+// threads the results down; U4's Feedback/Summary scenes consume
+// `punctuationSessionHelpVisibility` for the GPS delayed-feedback contract.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  punctuationSessionHelpVisibility,
+  punctuationSessionInputPlaceholder,
+  punctuationSessionInputShape,
+  punctuationSessionProgressLabel,
+  punctuationSessionSubmitLabel,
+} from '../src/subjects/punctuation/session-ui.js';
+
+// ---------------------------------------------------------------------------
+// punctuationSessionSubmitLabel (R5)
+// ---------------------------------------------------------------------------
+
+test('U1 session-ui: punctuationSessionSubmitLabel returns Save answer in GPS mode', () => {
+  assert.equal(punctuationSessionSubmitLabel({ mode: 'gps' }), 'Save answer');
+});
+
+test('U1 session-ui: punctuationSessionSubmitLabel returns Check in every other mode', () => {
+  assert.equal(punctuationSessionSubmitLabel({ mode: 'smart' }), 'Check');
+  assert.equal(punctuationSessionSubmitLabel({ mode: 'weak' }), 'Check');
+  assert.equal(punctuationSessionSubmitLabel({ mode: 'guided' }), 'Check');
+  // Cluster focus modes still dispatch via the enum — they stay as "Check".
+  assert.equal(punctuationSessionSubmitLabel({ mode: 'speech' }), 'Check');
+  assert.equal(punctuationSessionSubmitLabel({ mode: 'endmarks' }), 'Check');
+});
+
+test('U1 session-ui: punctuationSessionSubmitLabel defaults to Check on null/invalid session', () => {
+  assert.equal(punctuationSessionSubmitLabel(null), 'Check');
+  assert.equal(punctuationSessionSubmitLabel(undefined), 'Check');
+  assert.equal(punctuationSessionSubmitLabel({}), 'Check');
+});
+
+// ---------------------------------------------------------------------------
+// punctuationSessionInputShape (R6) — per-item-type input branch.
+// ---------------------------------------------------------------------------
+
+test('U1 session-ui: punctuationSessionInputShape returns stem-prefill for insert/fix/paragraph', () => {
+  assert.deepEqual(punctuationSessionInputShape('insert'), { prefill: 'stem' });
+  assert.deepEqual(punctuationSessionInputShape('fix'), { prefill: 'stem' });
+  assert.deepEqual(punctuationSessionInputShape('paragraph'), { prefill: 'stem' });
+});
+
+test('U1 session-ui: punctuationSessionInputShape returns blank+source for combine/transfer', () => {
+  assert.deepEqual(
+    punctuationSessionInputShape('combine'),
+    { prefill: 'blank', showSource: true },
+  );
+  assert.deepEqual(
+    punctuationSessionInputShape('transfer'),
+    { prefill: 'blank', showSource: true },
+  );
+});
+
+test('U1 session-ui: punctuationSessionInputShape returns none for choose (radio) mode', () => {
+  assert.deepEqual(punctuationSessionInputShape('choose'), { prefill: 'none' });
+});
+
+test('U1 session-ui: punctuationSessionInputShape returns none on empty/unknown mode (safe default)', () => {
+  // Safe default — a rogue payload must NOT accidentally prefill the input
+  // with source material for a mode the scene does not recognise.
+  assert.deepEqual(punctuationSessionInputShape(''), { prefill: 'none' });
+  assert.deepEqual(punctuationSessionInputShape(null), { prefill: 'none' });
+  assert.deepEqual(punctuationSessionInputShape('mystery-mode'), { prefill: 'none' });
+});
+
+// ---------------------------------------------------------------------------
+// punctuationSessionProgressLabel (R5 header)
+// ---------------------------------------------------------------------------
+
+test('U1 session-ui: punctuationSessionProgressLabel renders Question X of N on a standard round', () => {
+  assert.equal(
+    punctuationSessionProgressLabel({ length: 8, answeredCount: 2 }),
+    'Question 3 of 8',
+  );
+  assert.equal(
+    punctuationSessionProgressLabel({ length: 4, answeredCount: 0 }),
+    'Question 1 of 4',
+  );
+});
+
+test('U1 session-ui: punctuationSessionProgressLabel clamps answered past length to total', () => {
+  // Edge case — if answeredCount equals length (final question answered), the
+  // label still reads within [1, length].
+  assert.equal(
+    punctuationSessionProgressLabel({ length: 4, answeredCount: 4 }),
+    'Question 4 of 4',
+  );
+  assert.equal(
+    punctuationSessionProgressLabel({ length: 4, answeredCount: 99 }),
+    'Question 4 of 4',
+  );
+});
+
+test('U1 session-ui: punctuationSessionProgressLabel handles length=0 fallback', () => {
+  // Fresh session before the queue is populated — renders a stable label.
+  const label = punctuationSessionProgressLabel({ length: 0, answeredCount: 0 });
+  assert.equal(label, 'Question 1');
+  assert.ok(label.length > 0);
+});
+
+test('U1 session-ui: punctuationSessionProgressLabel null/invalid returns Question 1', () => {
+  assert.equal(punctuationSessionProgressLabel(null), 'Question 1');
+  assert.equal(punctuationSessionProgressLabel(undefined), 'Question 1');
+  assert.equal(punctuationSessionProgressLabel([]), 'Question 1');
+});
+
+// ---------------------------------------------------------------------------
+// punctuationSessionHelpVisibility — GPS delayed-feedback + guided teach box.
+// ---------------------------------------------------------------------------
+
+test('U1 session-ui: punctuationSessionHelpVisibility GPS hides feedback until summary', () => {
+  // Active-item — no per-item feedback.
+  assert.deepEqual(
+    punctuationSessionHelpVisibility({ mode: 'gps' }, 'active-item'),
+    { showTeachBox: false, showFeedback: false },
+  );
+  // Feedback phase — still no feedback in GPS (learner never sees per-item).
+  assert.deepEqual(
+    punctuationSessionHelpVisibility({ mode: 'gps' }, 'feedback'),
+    { showTeachBox: false, showFeedback: false },
+  );
+  // Summary — feedback unlocks.
+  assert.deepEqual(
+    punctuationSessionHelpVisibility({ mode: 'gps' }, 'summary'),
+    { showTeachBox: false, showFeedback: true },
+  );
+});
+
+test('U1 session-ui: punctuationSessionHelpVisibility guided shows teach box during active-item', () => {
+  assert.deepEqual(
+    punctuationSessionHelpVisibility({ mode: 'guided' }, 'active-item'),
+    { showTeachBox: true, showFeedback: false },
+  );
+  assert.deepEqual(
+    punctuationSessionHelpVisibility({ mode: 'guided' }, 'feedback'),
+    { showTeachBox: true, showFeedback: true },
+  );
+});
+
+test('U1 session-ui: punctuationSessionHelpVisibility smart/weak hide teach box, feedback follows phase', () => {
+  assert.deepEqual(
+    punctuationSessionHelpVisibility({ mode: 'smart' }, 'active-item'),
+    { showTeachBox: false, showFeedback: false },
+  );
+  assert.deepEqual(
+    punctuationSessionHelpVisibility({ mode: 'smart' }, 'feedback'),
+    { showTeachBox: false, showFeedback: true },
+  );
+  assert.deepEqual(
+    punctuationSessionHelpVisibility({ mode: 'weak' }, 'feedback'),
+    { showTeachBox: false, showFeedback: true },
+  );
+});
+
+test('U1 session-ui: punctuationSessionHelpVisibility null session is fully off', () => {
+  // Defensive: a fresh dashboard render without a session must not bleed
+  // help UI into the visible tree.
+  assert.deepEqual(
+    punctuationSessionHelpVisibility(null, 'active-item'),
+    { showTeachBox: false, showFeedback: false },
+  );
+  assert.deepEqual(
+    punctuationSessionHelpVisibility(undefined, 'feedback'),
+    { showTeachBox: false, showFeedback: true },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// punctuationSessionInputPlaceholder — child-friendly per-mode copy.
+// ---------------------------------------------------------------------------
+
+test('U1 session-ui: punctuationSessionInputPlaceholder maps every known mode to a child string', () => {
+  assert.equal(punctuationSessionInputPlaceholder('insert'), 'Add the missing punctuation');
+  assert.equal(punctuationSessionInputPlaceholder('fix'), 'Fix the punctuation');
+  assert.equal(punctuationSessionInputPlaceholder('paragraph'), 'Repair the whole passage');
+  assert.equal(punctuationSessionInputPlaceholder('combine'), 'Combine the parts into one sentence');
+  assert.equal(punctuationSessionInputPlaceholder('transfer'), 'Write one accurate sentence');
+  // choose — radio group doesn't use a placeholder.
+  assert.equal(punctuationSessionInputPlaceholder('choose'), '');
+});
+
+test('U1 session-ui: punctuationSessionInputPlaceholder falls back to generic prompt on unknown mode', () => {
+  assert.equal(punctuationSessionInputPlaceholder(''), 'Type your answer here');
+  assert.equal(punctuationSessionInputPlaceholder(null), 'Type your answer here');
+  assert.equal(punctuationSessionInputPlaceholder('mystery-mode'), 'Type your answer here');
+});
+
+// ---------------------------------------------------------------------------
+// Pure-module safety: no React imports in the session-ui file.
+// ---------------------------------------------------------------------------
+
+test('U1 safety: session-ui.js does not import react', async () => {
+  const fs = await import('node:fs');
+  const url = await import('node:url');
+  const path = url.fileURLToPath(
+    new URL('../src/subjects/punctuation/session-ui.js', import.meta.url),
+  );
+  const source = fs.readFileSync(path, 'utf8');
+  assert.equal(/from ['"]react['"]/i.test(source), false);
+  assert.equal(/require\(['"]react['"]\)/i.test(source), false);
+});

--- a/tests/punctuation-view-model.test.js
+++ b/tests/punctuation-view-model.test.js
@@ -1,0 +1,659 @@
+// Phase 3 U1 — Punctuation view-model pure-function assertions.
+//
+// These tests are the load-bearing assertion surface for the view-model half
+// of U1. Every export from
+// `src/subjects/punctuation/components/punctuation-view-model.js` is
+// exercised here with a happy path, an edge case, and (where relevant) an
+// error-path assertion. No SSR render. No React. Every fixture is a plain
+// object so the file runs fast on `node --test` alone.
+//
+// Integration: subsequent Phase 3 JSX units (U2–U6) inherit the copy,
+// filter-id, status-label, misconception-mapping, and forbidden-term
+// contracts from this file rather than restating the rules inline.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  ACTIVE_PUNCTUATION_MONSTER_DISPLAY_NAMES,
+  ACTIVE_PUNCTUATION_MONSTER_IDS,
+  PUNCTUATION_CHILD_FORBIDDEN_TERMS,
+  PUNCTUATION_DASHBOARD_HERO,
+  PUNCTUATION_MAP_MONSTER_FILTER_IDS,
+  PUNCTUATION_MAP_STATUS_FILTER_IDS,
+  PUNCTUATION_PRIMARY_MODE_CARDS,
+  PUNCTUATION_PRIMARY_MODE_IDS,
+  PUNCTUATION_SKILL_MODAL_PREFERRED_EXAMPLE,
+  bellstormSceneForPhase,
+  buildPunctuationDashboardModel,
+  buildPunctuationMapModel,
+  composeIsDisabled,
+  currentItemInstruction,
+  isPunctuationChildCopy,
+  punctuationChildMisconceptionLabel,
+  punctuationChildStatusLabel,
+  punctuationFeedbackChips,
+  punctuationMonsterAsset,
+  punctuationMonsterDisplayName,
+  punctuationPhaseLabel,
+  punctuationPrimaryModeFromPrefs,
+  punctuationSkillModalPreferredExample,
+} from '../src/subjects/punctuation/components/punctuation-view-model.js';
+import { MONSTERS_BY_SUBJECT } from '../src/platform/game/monsters.js';
+
+// ---------------------------------------------------------------------------
+// composeIsDisabled (R11) — moved from PunctuationPracticeSurface.jsx in U1.
+// ---------------------------------------------------------------------------
+
+test('U1 view-model: composeIsDisabled returns false when availability ready', () => {
+  assert.equal(composeIsDisabled({ availability: { status: 'ready' } }), false);
+});
+
+test('U1 view-model: composeIsDisabled returns true when availability degraded', () => {
+  assert.equal(composeIsDisabled({ availability: { status: 'degraded' } }), true);
+});
+
+test('U1 view-model: composeIsDisabled returns true when availability unavailable', () => {
+  assert.equal(composeIsDisabled({ availability: { status: 'unavailable' } }), true);
+});
+
+test('U1 view-model: composeIsDisabled returns true when pendingCommand set', () => {
+  assert.equal(composeIsDisabled({ pendingCommand: true }), true);
+});
+
+test('U1 view-model: composeIsDisabled returns true when runtime.readOnly set', () => {
+  assert.equal(composeIsDisabled({ runtime: { readOnly: true } }), true);
+});
+
+test('U1 view-model: composeIsDisabled defaults availability status to ready when missing', () => {
+  // Null / empty UI — no availability key — must read as ready so the Setup
+  // scene renders enabled controls on first boot.
+  assert.equal(composeIsDisabled({}), false);
+  assert.equal(composeIsDisabled(null), false);
+  assert.equal(composeIsDisabled(undefined), false);
+});
+
+// ---------------------------------------------------------------------------
+// PUNCTUATION_PRIMARY_MODE_CARDS + PUNCTUATION_PRIMARY_MODE_IDS
+// ---------------------------------------------------------------------------
+
+test('U1 view-model: PUNCTUATION_PRIMARY_MODE_IDS frozen at [smart, weak, gps]', () => {
+  assert.deepEqual([...PUNCTUATION_PRIMARY_MODE_IDS], ['smart', 'weak', 'gps']);
+  assert.equal(Object.isFrozen(PUNCTUATION_PRIMARY_MODE_IDS), true);
+});
+
+test('U1 view-model: PUNCTUATION_PRIMARY_MODE_CARDS has exactly three cards', () => {
+  assert.equal(PUNCTUATION_PRIMARY_MODE_CARDS.length, 3);
+  assert.deepEqual(
+    PUNCTUATION_PRIMARY_MODE_CARDS.map((card) => card.id),
+    ['smart', 'weak', 'gps'],
+  );
+});
+
+test('U1 view-model: PUNCTUATION_PRIMARY_MODE_CARDS is deeply frozen', () => {
+  assert.equal(Object.isFrozen(PUNCTUATION_PRIMARY_MODE_CARDS), true);
+  for (const card of PUNCTUATION_PRIMARY_MODE_CARDS) {
+    assert.equal(Object.isFrozen(card), true);
+  }
+});
+
+test('U1 view-model: PUNCTUATION_PRIMARY_MODE_CARDS Smart Review carries Recommended badge', () => {
+  const byId = Object.fromEntries(PUNCTUATION_PRIMARY_MODE_CARDS.map((card) => [card.id, card]));
+  assert.equal(byId.smart.label, 'Smart Review');
+  assert.equal(byId.smart.badge, 'Recommended');
+  assert.equal(byId.weak.label, 'Wobbly Spots');
+  assert.equal(byId.gps.label, 'GPS Check');
+});
+
+test('U1 view-model: PUNCTUATION_PRIMARY_MODE_CARDS labels + descriptions use only child copy', () => {
+  for (const card of PUNCTUATION_PRIMARY_MODE_CARDS) {
+    assert.equal(isPunctuationChildCopy(card.label), true, `label "${card.label}" leaks`);
+    assert.equal(isPunctuationChildCopy(card.description), true, `description "${card.description}" leaks`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// PUNCTUATION_MAP_STATUS_FILTER_IDS + PUNCTUATION_MAP_MONSTER_FILTER_IDS
+// ---------------------------------------------------------------------------
+
+test('U1 view-model: PUNCTUATION_MAP_STATUS_FILTER_IDS ordered list matches plan', () => {
+  assert.deepEqual(
+    [...PUNCTUATION_MAP_STATUS_FILTER_IDS],
+    ['all', 'new', 'learning', 'due', 'weak', 'secure'],
+  );
+  assert.equal(Object.isFrozen(PUNCTUATION_MAP_STATUS_FILTER_IDS), true);
+});
+
+test('U1 view-model: PUNCTUATION_MAP_MONSTER_FILTER_IDS contains only active roster', () => {
+  assert.deepEqual(
+    [...PUNCTUATION_MAP_MONSTER_FILTER_IDS],
+    ['all', 'pealark', 'claspin', 'curlune', 'quoral'],
+  );
+  for (const reserved of ['colisk', 'hyphang', 'carillon']) {
+    assert.equal(PUNCTUATION_MAP_MONSTER_FILTER_IDS.includes(reserved), false, `reserved ${reserved} leaked into filter`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// ACTIVE_PUNCTUATION_MONSTER_IDS — must match `MONSTERS_BY_SUBJECT.punctuation`
+// order exactly (R10, learning #5).
+// ---------------------------------------------------------------------------
+
+test('U1 view-model: ACTIVE_PUNCTUATION_MONSTER_IDS matches MONSTERS_BY_SUBJECT.punctuation order', () => {
+  assert.deepEqual(
+    [...ACTIVE_PUNCTUATION_MONSTER_IDS],
+    [...MONSTERS_BY_SUBJECT.punctuation],
+  );
+  assert.equal(ACTIVE_PUNCTUATION_MONSTER_IDS.length, 4);
+});
+
+test('U1 view-model: ACTIVE_PUNCTUATION_MONSTER_IDS never includes reserved trio', () => {
+  for (const reserved of ['colisk', 'hyphang', 'carillon']) {
+    assert.equal(ACTIVE_PUNCTUATION_MONSTER_IDS.includes(reserved), false, `reserved ${reserved} leaked`);
+  }
+});
+
+test('U1 view-model: ACTIVE_PUNCTUATION_MONSTER_DISPLAY_NAMES covers every active id', () => {
+  for (const id of ACTIVE_PUNCTUATION_MONSTER_IDS) {
+    assert.equal(typeof ACTIVE_PUNCTUATION_MONSTER_DISPLAY_NAMES[id], 'string');
+    assert.ok(ACTIVE_PUNCTUATION_MONSTER_DISPLAY_NAMES[id].length > 0, `missing display name for ${id}`);
+  }
+});
+
+test('U1 view-model: punctuationMonsterDisplayName falls back to titlecase for unknown ids', () => {
+  assert.equal(punctuationMonsterDisplayName('pealark'), 'Pealark');
+  // Safe fallback: unknown monster ids still render as child-friendly text
+  // rather than surface the raw kebab-case id.
+  assert.equal(punctuationMonsterDisplayName('new_monster_id'), 'New Monster Id');
+  assert.equal(punctuationMonsterDisplayName(''), '');
+  assert.equal(punctuationMonsterDisplayName(null), '');
+});
+
+// ---------------------------------------------------------------------------
+// PUNCTUATION_DASHBOARD_HERO
+// ---------------------------------------------------------------------------
+
+test('U1 view-model: PUNCTUATION_DASHBOARD_HERO has child-friendly copy', () => {
+  assert.equal(PUNCTUATION_DASHBOARD_HERO.eyebrow, 'Bellstorm Coast');
+  assert.equal(PUNCTUATION_DASHBOARD_HERO.headline, 'Punctuation practice');
+  assert.equal(typeof PUNCTUATION_DASHBOARD_HERO.subtitle, 'string');
+  assert.ok(PUNCTUATION_DASHBOARD_HERO.subtitle.length > 0);
+  assert.equal(isPunctuationChildCopy(PUNCTUATION_DASHBOARD_HERO.eyebrow), true);
+  assert.equal(isPunctuationChildCopy(PUNCTUATION_DASHBOARD_HERO.headline), true);
+  assert.equal(isPunctuationChildCopy(PUNCTUATION_DASHBOARD_HERO.subtitle), true);
+});
+
+// ---------------------------------------------------------------------------
+// PUNCTUATION_CHILD_FORBIDDEN_TERMS + isPunctuationChildCopy (R15)
+// ---------------------------------------------------------------------------
+
+test('U1 view-model: PUNCTUATION_CHILD_FORBIDDEN_TERMS contains the plan-specified adult terms', () => {
+  for (const term of [
+    'Worker',
+    'Worker-held',
+    'Worker-marked',
+    'accepted',
+    'correctIndex',
+    'rubric',
+    'validator',
+    'generator',
+    'rawGenerator',
+    'mastery key',
+    'facet weight',
+    'publishedTotal',
+    'denominator',
+    'projection',
+    'reward route',
+    'read model',
+    'supportLevel',
+    'contextPack',
+    'Context pack',
+    'weakFocus',
+    'hasEvidence',
+    'subjectUi',
+  ]) {
+    assert.ok(
+      PUNCTUATION_CHILD_FORBIDDEN_TERMS.includes(term),
+      `expected PUNCTUATION_CHILD_FORBIDDEN_TERMS to include "${term}"`,
+    );
+  }
+});
+
+test('U1 view-model: PUNCTUATION_CHILD_FORBIDDEN_TERMS includes all 6 dotted-tag prefixes', () => {
+  for (const prefix of ['speech.', 'comma.', 'boundary.', 'apostrophe.', 'structure.', 'endmarks.']) {
+    assert.ok(
+      PUNCTUATION_CHILD_FORBIDDEN_TERMS.includes(prefix),
+      `expected dotted-tag prefix "${prefix}" in forbidden terms`,
+    );
+  }
+});
+
+test('U1 view-model: PUNCTUATION_CHILD_FORBIDDEN_TERMS contains the /\\bWorker\\b/i regex', () => {
+  const hasWorkerRegex = PUNCTUATION_CHILD_FORBIDDEN_TERMS.some((term) => (
+    term instanceof RegExp && /worker/i.test('Worker') && term.test('Worker')
+  ));
+  assert.equal(hasWorkerRegex, true, 'expected a /\\bWorker\\b/i regex entry');
+});
+
+test('U1 view-model: PUNCTUATION_CHILD_FORBIDDEN_TERMS is frozen', () => {
+  assert.equal(Object.isFrozen(PUNCTUATION_CHILD_FORBIDDEN_TERMS), true);
+});
+
+test('U1 view-model: isPunctuationChildCopy rejects forbidden child terms case-insensitively', () => {
+  assert.equal(isPunctuationChildCopy('Worker-held read model'), false);
+  assert.equal(isPunctuationChildCopy('WORKER-HELD READ MODEL'), false);
+  assert.equal(isPunctuationChildCopy('Context pack preview'), false);
+  assert.equal(isPunctuationChildCopy('speech.quote_missing'), false, 'dotted prefix must be caught');
+  assert.equal(isPunctuationChildCopy('comma.clarity_missing'), false);
+});
+
+test('U1 view-model: isPunctuationChildCopy accepts genuine child copy', () => {
+  assert.equal(isPunctuationChildCopy('Keep the comma after the opener.'), true);
+  assert.equal(isPunctuationChildCopy('Practise this skill next.'), true);
+  assert.equal(isPunctuationChildCopy(''), true);
+  assert.equal(isPunctuationChildCopy(null), true);
+  assert.equal(isPunctuationChildCopy(undefined), true);
+});
+
+// ---------------------------------------------------------------------------
+// punctuationChildStatusLabel (R2 copy)
+// ---------------------------------------------------------------------------
+
+test('U1 view-model: punctuationChildStatusLabel maps every known status', () => {
+  assert.equal(punctuationChildStatusLabel('new'), 'New');
+  assert.equal(punctuationChildStatusLabel('learning'), 'Learning');
+  assert.equal(punctuationChildStatusLabel('due'), 'Due today');
+  assert.equal(punctuationChildStatusLabel('weak'), 'Wobbly');
+  assert.equal(punctuationChildStatusLabel('secure'), 'Secure');
+});
+
+test('U1 view-model: punctuationChildStatusLabel unknown status falls back to New', () => {
+  assert.equal(punctuationChildStatusLabel('mystery-bucket'), 'New');
+  assert.equal(punctuationChildStatusLabel(''), 'New');
+  assert.equal(punctuationChildStatusLabel(null), 'New');
+});
+
+// ---------------------------------------------------------------------------
+// punctuationChildMisconceptionLabel (R15) — the dotted-tag translator.
+// ---------------------------------------------------------------------------
+
+test('U1 view-model: punctuationChildMisconceptionLabel maps plan-specified tags', () => {
+  // Happy-path mappings explicitly called out in the plan's Key Technical
+  // Decisions section.
+  assert.equal(punctuationChildMisconceptionLabel('speech.quote_missing'), 'Speech punctuation');
+  assert.equal(punctuationChildMisconceptionLabel('speech.punctuation_outside_quote'), 'Speech punctuation');
+  assert.equal(punctuationChildMisconceptionLabel('comma.clarity_missing'), 'Comma placement');
+  assert.equal(punctuationChildMisconceptionLabel('comma.list_missing'), 'List commas');
+  assert.equal(punctuationChildMisconceptionLabel('boundary.semicolon_missing'), 'Boundary punctuation');
+  assert.equal(punctuationChildMisconceptionLabel('apostrophe.contraction_missing'), 'Apostrophes');
+  assert.equal(punctuationChildMisconceptionLabel('apostrophe.possession_missing'), 'Apostrophes');
+  assert.equal(punctuationChildMisconceptionLabel('endmarks.missing'), 'End punctuation');
+  assert.equal(punctuationChildMisconceptionLabel('structure.fronted_missing'), 'Sentence structure');
+});
+
+test('U1 view-model: punctuationChildMisconceptionLabel returns null for unmapped tags', () => {
+  // Caller hides the chip rather than rendering the raw dotted ID. U10's
+  // forbidden-term sweep backstops any regression where the scene renders
+  // the raw tag instead of the label.
+  assert.equal(punctuationChildMisconceptionLabel('unknown.tag'), null);
+  assert.equal(punctuationChildMisconceptionLabel(''), null);
+  assert.equal(punctuationChildMisconceptionLabel(null), null);
+});
+
+test('U1 view-model: punctuationChildMisconceptionLabel output is child-safe', () => {
+  // Every mapped label must itself pass the forbidden-term sweep, so a
+  // future table edit cannot accidentally smuggle an adult term back in.
+  const mappedTags = [
+    'speech.quote_missing',
+    'speech.punctuation_outside_quote',
+    'speech.reporting_comma_missing',
+    'comma.clarity_missing',
+    'comma.list_missing',
+    'comma.fronted_adverbial_missing',
+    'boundary.semicolon_missing',
+    'boundary.dash_missing',
+    'boundary.hyphen_missing',
+    'apostrophe.contraction_missing',
+    'apostrophe.possession_missing',
+    'apostrophe.required_forms_missing',
+    'endmarks.missing',
+    'endmarks.question_mark_missing',
+    'structure.fronted_missing',
+    'structure.parenthesis_missing',
+    'structure.colon_missing',
+    'structure.semicolon_list_missing',
+    'structure.bullet_colon_missing',
+  ];
+  for (const tag of mappedTags) {
+    const label = punctuationChildMisconceptionLabel(tag);
+    assert.ok(label, `expected label for ${tag}`);
+    assert.equal(isPunctuationChildCopy(label), true, `label "${label}" for tag "${tag}" leaks`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// punctuationFeedbackChips — uses existing friendly facet.label field.
+// ---------------------------------------------------------------------------
+
+test('U1 view-model: punctuationFeedbackChips empty input returns empty array', () => {
+  assert.deepEqual(punctuationFeedbackChips([]), []);
+  assert.deepEqual(punctuationFeedbackChips(null), []);
+  assert.deepEqual(punctuationFeedbackChips(undefined), []);
+  assert.deepEqual(punctuationFeedbackChips('not an array'), []);
+});
+
+test('U1 view-model: punctuationFeedbackChips caps at 2 child-friendly chips', () => {
+  const chips = punctuationFeedbackChips([
+    { id: 'quote_variant', ok: true, label: 'Matched inverted commas' },
+    { id: 'speech_punctuation', ok: false, label: 'Speech punctuation inside the closing inverted comma' },
+    { id: 'capitalisation', ok: true, label: 'Capital letters' },
+  ]);
+  assert.equal(chips.length, 2);
+  assert.equal(chips[0].label, 'Matched inverted commas');
+  assert.equal(chips[1].label, 'Speech punctuation inside the closing inverted comma');
+  assert.equal(chips[0].ok, true);
+  assert.equal(chips[1].ok, false);
+});
+
+test('U1 view-model: punctuationFeedbackChips skips facets missing a label', () => {
+  // Facets with no friendly label are hidden, never rendered as the dotted
+  // id. This pairs with U4's misconception-tag path (handled via
+  // punctuationChildMisconceptionLabel).
+  const chips = punctuationFeedbackChips([
+    { id: 'quote_variant', ok: true, label: '' },
+    { id: 'speech_punctuation', ok: false, label: 'Speech punctuation' },
+  ]);
+  assert.equal(chips.length, 1);
+  assert.equal(chips[0].label, 'Speech punctuation');
+});
+
+// ---------------------------------------------------------------------------
+// punctuationPrimaryModeFromPrefs (stale-prefs display normaliser)
+// ---------------------------------------------------------------------------
+
+test('U1 view-model: punctuationPrimaryModeFromPrefs collapses cluster modes to smart', () => {
+  for (const legacy of ['endmarks', 'apostrophe', 'speech', 'comma_flow', 'boundary', 'structure', 'guided']) {
+    assert.equal(
+      punctuationPrimaryModeFromPrefs({ mode: legacy }),
+      'smart',
+      `legacy ${legacy} should collapse to smart`,
+    );
+  }
+});
+
+test('U1 view-model: punctuationPrimaryModeFromPrefs preserves primary modes', () => {
+  assert.equal(punctuationPrimaryModeFromPrefs({ mode: 'smart' }), 'smart');
+  assert.equal(punctuationPrimaryModeFromPrefs({ mode: 'weak' }), 'weak');
+  assert.equal(punctuationPrimaryModeFromPrefs({ mode: 'gps' }), 'gps');
+});
+
+test('U1 view-model: punctuationPrimaryModeFromPrefs defaults to smart on missing/invalid', () => {
+  assert.equal(punctuationPrimaryModeFromPrefs(null), 'smart');
+  assert.equal(punctuationPrimaryModeFromPrefs(undefined), 'smart');
+  assert.equal(punctuationPrimaryModeFromPrefs({}), 'smart');
+  assert.equal(punctuationPrimaryModeFromPrefs({ mode: '' }), 'smart');
+  assert.equal(punctuationPrimaryModeFromPrefs({ mode: 'not-a-mode' }), 'smart');
+});
+
+// ---------------------------------------------------------------------------
+// PUNCTUATION_SKILL_MODAL_PREFERRED_EXAMPLE + helper
+// ---------------------------------------------------------------------------
+
+test('U1 view-model: PUNCTUATION_SKILL_MODAL_PREFERRED_EXAMPLE is frozen', () => {
+  assert.equal(Object.isFrozen(PUNCTUATION_SKILL_MODAL_PREFERRED_EXAMPLE), true);
+});
+
+test('U1 view-model: punctuationSkillModalPreferredExample defaults to workedGood', () => {
+  assert.equal(punctuationSkillModalPreferredExample('speech'), 'workedGood');
+  assert.equal(punctuationSkillModalPreferredExample('sentence_endings'), 'workedGood');
+  assert.equal(punctuationSkillModalPreferredExample(''), 'workedGood');
+  assert.equal(punctuationSkillModalPreferredExample(null), 'workedGood');
+});
+
+test('U1 view-model: PUNCTUATION_SKILL_MODAL_PREFERRED_EXAMPLE explicitly overrides comma_clarity', () => {
+  // Plan: `comma_clarity.contrastGood` is byte-for-byte identical to
+  // `cc_insert_time_travellers.accepted[0]` — so default `workedGood` is
+  // the safer choice and stays as the explicit override value.
+  assert.equal(PUNCTUATION_SKILL_MODAL_PREFERRED_EXAMPLE.comma_clarity, 'workedGood');
+  assert.equal(punctuationSkillModalPreferredExample('comma_clarity'), 'workedGood');
+});
+
+// ---------------------------------------------------------------------------
+// bellstormSceneForPhase — extended to accept 'map'.
+// ---------------------------------------------------------------------------
+
+test('U1 view-model: bellstormSceneForPhase(map) returns a daily A-C scene', () => {
+  const scene = bellstormSceneForPhase('map');
+  assert.match(scene.name, /^bellstorm-coast-(cover|a1|b1|c1)$/, `map should return a daily scene, got ${scene.name}`);
+  assert.match(scene.src, /\.webp$/);
+  assert.match(scene.srcSet, /640w, .+ 1280w/);
+});
+
+test('U1 view-model: bellstormSceneForPhase preserves existing phase behaviour', () => {
+  // Regression guard — existing react-punctuation-scene.test.js relies on
+  // these names staying stable. Do not change without bumping that test.
+  assert.equal(bellstormSceneForPhase('setup').name, 'bellstorm-coast-cover');
+  assert.equal(bellstormSceneForPhase('active-item').name, 'bellstorm-coast-b1');
+  assert.equal(bellstormSceneForPhase('feedback').name, 'bellstorm-coast-d2');
+  assert.equal(bellstormSceneForPhase('summary').name, 'bellstorm-coast-e2');
+  // Unknown phase falls back to setup cover.
+  assert.equal(bellstormSceneForPhase('unknown').name, 'bellstorm-coast-cover');
+  // Default (no argument) falls back to setup cover.
+  assert.equal(bellstormSceneForPhase().name, 'bellstorm-coast-cover');
+});
+
+// ---------------------------------------------------------------------------
+// punctuationPhaseLabel — extended for 'map'.
+// ---------------------------------------------------------------------------
+
+test('U1 view-model: punctuationPhaseLabel handles every phase including map', () => {
+  assert.equal(punctuationPhaseLabel('active-item'), 'Practice');
+  assert.equal(punctuationPhaseLabel('feedback'), 'Feedback');
+  assert.equal(punctuationPhaseLabel('summary'), 'Summary');
+  assert.equal(punctuationPhaseLabel('unavailable'), 'Unavailable');
+  assert.equal(punctuationPhaseLabel('map'), 'Punctuation Map');
+  assert.equal(punctuationPhaseLabel('setup'), 'Setup');
+  assert.equal(punctuationPhaseLabel(), 'Setup');
+});
+
+// ---------------------------------------------------------------------------
+// currentItemInstruction — regression guard on preserved behaviour.
+// ---------------------------------------------------------------------------
+
+test('U1 view-model: currentItemInstruction branches on inputKind/mode (regression guard)', () => {
+  assert.equal(currentItemInstruction({ inputKind: 'choice' }), 'Choose the best sentence.');
+  assert.equal(currentItemInstruction({ mode: 'transfer' }), 'Write one accurate sentence.');
+  assert.equal(currentItemInstruction({ mode: 'combine' }), 'Combine the parts into one punctuated sentence.');
+  assert.equal(currentItemInstruction({ mode: 'paragraph' }), 'Repair the whole passage.');
+  assert.equal(currentItemInstruction({ mode: 'fix' }), 'Correct the sentence.');
+  assert.equal(currentItemInstruction({}), 'Type the sentence with punctuation.');
+});
+
+// ---------------------------------------------------------------------------
+// punctuationMonsterAsset — sanity on resolver passthrough.
+// ---------------------------------------------------------------------------
+
+test('U1 view-model: punctuationMonsterAsset returns a safe payload shape', () => {
+  const asset = punctuationMonsterAsset('pealark', 0);
+  assert.equal(asset.id, 'pealark');
+  assert.equal(asset.stage, 0);
+  assert.equal(typeof asset.src, 'string');
+});
+
+test('U1 view-model: punctuationMonsterAsset clamps stage to [0, 4]', () => {
+  assert.equal(punctuationMonsterAsset('pealark', -5).stage, 0);
+  assert.equal(punctuationMonsterAsset('pealark', 99).stage, 4);
+  // NaN falls back to stage 0.
+  assert.equal(punctuationMonsterAsset('pealark', 'abc').stage, 0);
+});
+
+// ---------------------------------------------------------------------------
+// buildPunctuationDashboardModel
+// ---------------------------------------------------------------------------
+
+test('U1 view-model: buildPunctuationDashboardModel returns safe empty shape on null inputs', () => {
+  const model = buildPunctuationDashboardModel(null, null, null);
+  assert.equal(Array.isArray(model.todayCards), true);
+  assert.equal(model.todayCards.length, 4);
+  assert.equal(model.isEmpty, true);
+  assert.equal(Array.isArray(model.activeMonsters), true);
+  assert.equal(model.activeMonsters.length, 4);
+  assert.equal(model.primaryMode, 'smart');
+});
+
+test('U1 view-model: buildPunctuationDashboardModel surfaces non-zero stats', () => {
+  const stats = { due: 3, weak: 2, securedRewardUnits: 5, accuracy: 72 };
+  const learner = { prefs: { mode: 'smart' } };
+  const model = buildPunctuationDashboardModel(stats, learner, {});
+  const byId = Object.fromEntries(model.todayCards.map((card) => [card.id, card]));
+  assert.equal(byId.due.value, 3);
+  assert.equal(byId.weak.value, 2);
+  assert.equal(byId.secure.value, 5);
+  assert.equal(byId.accuracy.value, 72);
+  // Any non-zero today count flips isEmpty to false.
+  assert.equal(model.isEmpty, false);
+  assert.equal(model.primaryMode, 'smart');
+});
+
+test('U1 view-model: buildPunctuationDashboardModel activeMonsters iterate only the 4 active ids', () => {
+  const rewardState = {
+    pealark: { mastered: ['m1', 'm2'] },
+    quoral: { mastered: ['m1'] },
+    // Reserved monster smuggled into reward state — must NOT surface.
+    colisk: { mastered: ['x1', 'x2', 'x3'] },
+  };
+  const model = buildPunctuationDashboardModel({}, null, rewardState);
+  const ids = model.activeMonsters.map((entry) => entry.id);
+  assert.deepEqual(ids, [...ACTIVE_PUNCTUATION_MONSTER_IDS]);
+  for (const reserved of ['colisk', 'hyphang', 'carillon']) {
+    assert.equal(ids.includes(reserved), false, `reserved ${reserved} leaked into activeMonsters`);
+  }
+  const byId = Object.fromEntries(model.activeMonsters.map((m) => [m.id, m]));
+  assert.equal(byId.pealark.mastered, 2);
+  assert.equal(byId.quoral.mastered, 1);
+});
+
+test('U1 view-model: buildPunctuationDashboardModel normalises stale cluster-mode prefs', () => {
+  // Returning learners with a legacy cluster mode see the Smart Review card
+  // as the pressed option; U2's scene migrates the stored value.
+  const model = buildPunctuationDashboardModel(
+    {},
+    { prefs: { mode: 'endmarks' } },
+    {},
+  );
+  assert.equal(model.primaryMode, 'smart');
+});
+
+// ---------------------------------------------------------------------------
+// buildPunctuationMapModel (R2, R10)
+// ---------------------------------------------------------------------------
+
+const FOURTEEN_SKILL_ROWS = Object.freeze([
+  { skillId: 'sentence_endings', name: 'Capital letters and sentence endings', clusterId: 'endmarks', status: 'secure', attempts: 12, accuracy: 92, mastery: 88, dueAt: 0 },
+  { skillId: 'list_commas', name: 'Commas in lists', clusterId: 'comma_flow', status: 'learning', attempts: 4, accuracy: 75, mastery: 40, dueAt: 0 },
+  { skillId: 'apostrophe_contractions', name: 'Apostrophes for contraction', clusterId: 'apostrophe', status: 'new', attempts: 0, accuracy: null, mastery: 0, dueAt: 0 },
+  { skillId: 'apostrophe_possession', name: 'Apostrophes for possession', clusterId: 'apostrophe', status: 'weak', attempts: 6, accuracy: 45, mastery: 22, dueAt: 0 },
+  { skillId: 'speech', name: 'Inverted commas and speech punctuation', clusterId: 'speech', status: 'learning', attempts: 3, accuracy: 66, mastery: 30, dueAt: 0 },
+  { skillId: 'fronted_adverbial', name: 'Commas after fronted adverbials', clusterId: 'comma_flow', status: 'secure', attempts: 10, accuracy: 90, mastery: 80, dueAt: 0 },
+  { skillId: 'parenthesis', name: 'Parenthesis with commas, brackets or dashes', clusterId: 'structure', status: 'due', attempts: 5, accuracy: 60, mastery: 35, dueAt: 1 },
+  { skillId: 'comma_clarity', name: 'Commas for clarity', clusterId: 'comma_flow', status: 'new', attempts: 0, accuracy: null, mastery: 0, dueAt: 0 },
+  { skillId: 'colon_list', name: 'Colon before a list', clusterId: 'structure', status: 'new', attempts: 0, accuracy: null, mastery: 0, dueAt: 0 },
+  { skillId: 'semicolon', name: 'Semi-colons between related clauses', clusterId: 'boundary', status: 'new', attempts: 0, accuracy: null, mastery: 0, dueAt: 0 },
+  { skillId: 'dash_clause', name: 'Dashes between related clauses', clusterId: 'boundary', status: 'new', attempts: 0, accuracy: null, mastery: 0, dueAt: 0 },
+  { skillId: 'semicolon_list', name: 'Semi-colons within lists', clusterId: 'structure', status: 'new', attempts: 0, accuracy: null, mastery: 0, dueAt: 0 },
+  { skillId: 'bullet_points', name: 'Punctuation of bullet points', clusterId: 'structure', status: 'new', attempts: 0, accuracy: null, mastery: 0, dueAt: 0 },
+  { skillId: 'hyphen', name: 'Hyphens to avoid ambiguity', clusterId: 'boundary', status: 'new', attempts: 0, accuracy: null, mastery: 0, dueAt: 0 },
+]);
+
+// Plan-level mapping (matches `shared/punctuation/content.js` comment):
+//   Pealark  : endmarks, speech, boundary
+//   Claspin  : apostrophe
+//   Curlune  : comma_flow, structure
+//   Quoral   : grand aggregate
+const CLUSTER_TO_MONSTER = Object.freeze({
+  endmarks: 'pealark',
+  speech: 'pealark',
+  boundary: 'pealark',
+  apostrophe: 'claspin',
+  comma_flow: 'curlune',
+  structure: 'curlune',
+});
+
+test('U1 view-model: buildPunctuationMapModel distributes 14 skills across 4 monsters', () => {
+  const model = buildPunctuationMapModel(FOURTEEN_SKILL_ROWS, {}, CLUSTER_TO_MONSTER);
+  const ids = model.monsters.map((m) => m.monsterId);
+  assert.deepEqual(ids, [...ACTIVE_PUNCTUATION_MONSTER_IDS]);
+  const totalSkills = model.monsters.reduce((sum, monster) => sum + monster.skills.length, 0);
+  assert.equal(totalSkills, 14, `expected 14 skills total, got ${totalSkills}`);
+});
+
+test('U1 view-model: buildPunctuationMapModel filters reserved monsters out of output', () => {
+  // Reserved monster entries smuggled into monsterState must NOT surface as a
+  // group, even if the caller passes them.
+  const poisonedState = {
+    pealark: { mastered: ['a'] },
+    colisk: { mastered: ['x', 'y'] },
+    hyphang: { mastered: ['z'] },
+  };
+  const model = buildPunctuationMapModel(FOURTEEN_SKILL_ROWS, poisonedState, CLUSTER_TO_MONSTER);
+  for (const reserved of ['colisk', 'hyphang', 'carillon']) {
+    assert.equal(
+      model.monsters.some((m) => m.monsterId === reserved),
+      false,
+      `reserved ${reserved} leaked into map model`,
+    );
+  }
+});
+
+test('U1 view-model: buildPunctuationMapModel maps status to child label on each skill', () => {
+  const model = buildPunctuationMapModel(FOURTEEN_SKILL_ROWS, {}, CLUSTER_TO_MONSTER);
+  for (const monster of model.monsters) {
+    for (const skill of monster.skills) {
+      // statusLabel should be the child-copy mapping of status.
+      assert.equal(skill.statusLabel, punctuationChildStatusLabel(skill.status));
+      // And must not expose any forbidden adult terms.
+      assert.equal(isPunctuationChildCopy(skill.statusLabel), true, `skill ${skill.skillId} label "${skill.statusLabel}" leaks`);
+    }
+  }
+});
+
+test('U1 view-model: buildPunctuationMapModel handles skill with unknown cluster by routing to grand monster', () => {
+  // A rogue row whose cluster maps to a reserved or unknown monster must not
+  // disappear — it lands on the grand monster (quoral) so the 14-skill total
+  // stays stable.
+  const rows = [
+    { skillId: 'phantom_skill', name: 'Phantom Skill', clusterId: 'unknown_cluster', status: 'new', attempts: 0 },
+  ];
+  const model = buildPunctuationMapModel(rows, {}, {});
+  const quoralEntry = model.monsters.find((m) => m.monsterId === 'quoral');
+  const placed = quoralEntry?.skills.some((skill) => skill.skillId === 'phantom_skill');
+  assert.equal(placed, true, 'rogue skill must land on quoral (grand monster)');
+});
+
+test('U1 view-model: buildPunctuationMapModel output shape is frozen end-to-end', () => {
+  const model = buildPunctuationMapModel(FOURTEEN_SKILL_ROWS, {}, CLUSTER_TO_MONSTER);
+  assert.equal(Object.isFrozen(model), true);
+  assert.equal(Object.isFrozen(model.monsters), true);
+  for (const monster of model.monsters) {
+    assert.equal(Object.isFrozen(monster), true);
+    assert.equal(Object.isFrozen(monster.skills), true);
+    for (const skill of monster.skills) {
+      assert.equal(Object.isFrozen(skill), true);
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Pure-module safety: no React imports in the view-model file.
+// ---------------------------------------------------------------------------
+
+test('U1 safety: punctuation-view-model.js does not import react', async () => {
+  const fs = await import('node:fs');
+  const url = await import('node:url');
+  const path = url.fileURLToPath(
+    new URL('../src/subjects/punctuation/components/punctuation-view-model.js', import.meta.url),
+  );
+  const source = fs.readFileSync(path, 'utf8');
+  assert.equal(/from ['"]react['"]/i.test(source), false);
+  assert.equal(/require\(['"]react['"]\)/i.test(source), false);
+});


### PR DESCRIPTION
## Summary
- Expand `src/subjects/punctuation/components/punctuation-view-model.js` with frozen option lists (`PUNCTUATION_PRIMARY_MODE_CARDS` / `_IDS`, `PUNCTUATION_MAP_STATUS_FILTER_IDS`, `PUNCTUATION_MAP_MONSTER_FILTER_IDS`, `ACTIVE_PUNCTUATION_MONSTER_IDS` + display names, `PUNCTUATION_DASHBOARD_HERO`, `PUNCTUATION_CHILD_FORBIDDEN_TERMS`, `PUNCTUATION_SKILL_MODAL_PREFERRED_EXAMPLE`) and pure helpers (`composeIsDisabled`, `punctuationChildStatusLabel`, `punctuationChildMisconceptionLabel`, `punctuationFeedbackChips`, `punctuationPrimaryModeFromPrefs`, `buildPunctuationDashboardModel`, `buildPunctuationMapModel`, `isPunctuationChildCopy`, `bellstormSceneForPhase` extended for `'map'`, `punctuationPhaseLabel` extended for `'map'`).
- New `src/subjects/punctuation/session-ui.js` (subject root, not `components/`) with `punctuationSessionSubmitLabel`, `punctuationSessionInputShape`, `punctuationSessionProgressLabel`, `punctuationSessionHelpVisibility`, `punctuationSessionInputPlaceholder`.
- `PunctuationPracticeSurface.jsx` imports `composeIsDisabled` from the view-model instead of holding it inline (no behaviour change).

## Plan reference
`docs/plans/2026-04-25-005-feat-punctuation-phase3-ux-rebuild-plan.md` — U1 (view-model + session-ui + composeIsDisabled extraction). Establishes the single source of truth every subsequent Phase 3 scene imports from.

## Release-id impact
`release-id impact: none` — pure UI refactor, engine + content untouched. No `shared/punctuation/*` change, no Worker command shape change, no `contentReleaseId` bump.

## Parity guard (AGENTS.md:14)
- `composeIsDisabled` stays subject-scoped in `src/subjects/punctuation/components/punctuation-view-model.js`. Grammar and Spelling each keep their own copy. No shared-primitive extraction — cost of duplication is tiny next to the risk of a Spelling parity regression.

## Skill modal preferred-example audit (per Key Technical Decisions)
Run locally against `shared/punctuation/content.js` + `PUNCTUATION_ITEMS.accepted`:
- `comma_clarity` → `contrastGood` = `cc_insert_time_travellers.accepted[0]` exact match → override = `workedGood` (plan-specified).
- `list_commas`, `colon_list`, `semicolon`, `dash_clause`, `semicolon_list`, `bullet_points` → BOTH `workedGood` and `contrastGood` appear verbatim in accepted lists. Default `workedGood` stays for U1; U6 authoring audit will re-examine.
- `hyphen` → `contrastGood` overlaps but `workedGood` does not → default `workedGood` already safe.
- `sentence_endings`, `apostrophe_contractions`, `apostrophe_possession`, `speech`, `fronted_adverbial`, `parenthesis` → neither field overlaps → default `workedGood` safe.
- U1 ships only the `comma_clarity` override explicitly; U6's full authoring audit expands the table as needed.

## Active-roster order pin (learning #5)
`ACTIVE_PUNCTUATION_MONSTER_IDS` is sourced from `MONSTERS_BY_SUBJECT.punctuation` so it stays in lock-step with `src/platform/game/monsters.js:186-203`. Current order: `['pealark', 'curlune', 'claspin', 'quoral']` (matches what's in code, not the plan prose's Pealark/Claspin/Curlune/Quoral narrative order — I followed code per plan directive "match what's in code; don't invent").

## Test plan
- [x] `node --test tests/punctuation-view-model.test.js` — 54 new assertions
- [x] `node --test tests/punctuation-session-ui.test.js` — 18 new assertions
- [x] `node --test tests/react-punctuation-scene.test.js` — existing 14 tests still green (`composeIsDisabled` import-only change on `PunctuationPracticeSurface.jsx`)
- [x] `node --test tests/bundle-audit.test.js` — still green
- [x] `node --test tests/punctuation-legacy-parity.test.js tests/punctuation-read-model.test.js tests/punctuation-read-models.test.js tests/punctuation-ai-context-pack.test.js tests/punctuation-marking.test.js tests/punctuation-gps.test.js tests/punctuation-guided.test.js` — 59 tests green (engine + redaction unchanged)
- [ ] `npm test` — Known Windows pitfall in `tests/verify-capacity-evidence.test.js`: `EPERM` on `rm` in temp directories (pre-existing, unrelated to U1). Every non-verify-capacity test is green.
- [ ] `npm run check` — skipped, pure client-layer refactor; no Worker or infra touched.