### PR TITLE
feat(spelling): U5 Guardian/Boss session-ui + Word Bank chip polish

### DIFF
--- a/src/subjects/spelling/components/SpellingSessionScene.jsx
+++ b/src/subjects/spelling/components/SpellingSessionScene.jsx
@@ -58,7 +58,14 @@ export function SpellingSessionScene({
     );
   }
 
-  const showCloze = prefs.showCloze && session.type !== 'test';
+  // U5 / R5: Guardian sessions never surface the cloze hint even when the
+  // learner's `prefs.showCloze` is true. The hint is a scaffolding
+  // affordance for learning — Guardian is a retrieval check on Mega words
+  // that already live in the Vault, so a hint would leak the very answer
+  // the round is supposed to prove. `session.type === 'test'` already
+  // covers SATs Test (and Boss via its `type: 'test'` override in U9), so
+  // the only new branch here is `session.mode === 'guardian'`.
+  const showCloze = prefs.showCloze && session.type !== 'test' && session.mode !== 'guardian';
   const awaitingAdvance = Boolean(ui.awaitingAdvance);
   const pendingCommand = ui.pendingCommand || '';
   const pending = Boolean(pendingCommand);

--- a/src/subjects/spelling/components/SpellingWordBankScene.jsx
+++ b/src/subjects/spelling/components/SpellingWordBankScene.jsx
@@ -5,6 +5,8 @@ import { SpellingHeroBackdrop } from './SpellingHeroBackdrop.jsx';
 import { SpellingWordDetailModal } from './SpellingWordDetailModal.jsx';
 import {
   WORD_BANK_FILTER_IDS,
+  WORD_BANK_GUARDIAN_CHIP_LABELS,
+  WORD_BANK_GUARDIAN_FILTER_HINTS,
   WORD_BANK_GUARDIAN_FILTER_IDS,
   WORD_BANK_GUARDIAN_FILTER_ID_SET,
   WORD_BANK_YEAR_FILTER_IDS,
@@ -32,23 +34,12 @@ import {
   wordStatusLabel,
 } from './spelling-view-model.js';
 
-// Guardian chip copy is deliberately grounded and specific — no "Great work!"
-// slop, no zero-celebration. Labels pair with a short hint that renders
-// above the chip row when any guardian filter is active so learners aren't
-// confronted with e.g. "170 never-renewed" rows without context.
-const GUARDIAN_CHIP_LABELS = Object.freeze({
-  guardianDue: 'Guardian due',
-  wobbling: 'Wobbling',
-  renewedRecently: 'Renewed (7d)',
-  neverRenewed: 'Untouched',
-});
+// Guardian chip copy and hints live in the view-model so the SSR scene, any
+// test harness, and any future surface read from a single source of truth.
+// See `WORD_BANK_GUARDIAN_CHIP_LABELS` in `spelling-view-model.js` for the
+// U5 copy polish rationale (R10). The `GUARDIAN_CHIP_ORDER` alias here keeps
+// the existing local variable name stable for the rest of the scene.
 const GUARDIAN_CHIP_ORDER = WORD_BANK_GUARDIAN_FILTER_IDS;
-const GUARDIAN_FILTER_HINTS = Object.freeze({
-  guardianDue: 'Secure words the Vault wants you to recheck today.',
-  wobbling: 'Secure words that slipped last time — one more pass clears them.',
-  renewedRecently: 'Secure words you renewed in the last seven days.',
-  neverRenewed: 'Secure words the Guardian has not inspected yet — nothing is wrong, just untouched.',
-});
 
 function FilterChips({ counts, activeFilter, actions }) {
   const chips = [
@@ -109,7 +100,7 @@ function GuardianFilterChips({ counts, activeFilter, actions }) {
             onClick={(event) => renderAction(actions, event, 'spelling-analytics-status-filter', { value: id })}
           >
             <span className="wb-chip-guardian-mark" aria-hidden="true" />
-            <span className="wb-chip-label">{GUARDIAN_CHIP_LABELS[id]}</span>
+            <span className="wb-chip-label">{WORD_BANK_GUARDIAN_CHIP_LABELS[id]}</span>
             <CountUpValue className="wb-chip-count" value={counts[id] ?? 0} />
           </button>
         );
@@ -330,7 +321,7 @@ function WordBankCard({ learner, analytics, appState, actions, postMastery = nul
 
         {showGuardianFilters && WORD_BANK_GUARDIAN_FILTER_ID_SET.has(activeFilter) ? (
           <p className="wb-guardian-hint" role="status">
-            {GUARDIAN_FILTER_HINTS[activeFilter]}
+            {WORD_BANK_GUARDIAN_FILTER_HINTS[activeFilter]}
           </p>
         ) : null}
 

--- a/src/subjects/spelling/components/spelling-view-model.js
+++ b/src/subjects/spelling/components/spelling-view-model.js
@@ -101,6 +101,40 @@ export const WORD_BANK_GUARDIAN_FILTER_IDS = Object.freeze([
 export const WORD_BANK_GUARDIAN_FILTER_ID_SET = new Set(WORD_BANK_GUARDIAN_FILTER_IDS);
 export const WORD_BANK_YEAR_FILTER_IDS = new Set(['all', 'y3-4', 'y5-6', 'extra']);
 
+/* U5: Word Bank Guardian chip copy polish (R10).
+ *
+ * The chip-label map lives in the view-model (not the JSX scene) so there is
+ * a single source of truth for display text; the scene imports from here.
+ * Labels are deliberately grounded and child-specific — no "Great work!"
+ * slop, no zero-celebration — and matched by ARIA labels at render time so
+ * screen-reader users hear the same phrase. The hint map mirrors the chip
+ * IDs so an accidental label/hint divergence fails the parity tests.
+ *
+ * Previous copy (pre-U5, kept in comments for historical reference):
+ *   guardianDue     → 'Guardian due'
+ *   wobbling        → 'Wobbling'
+ *   renewedRecently → 'Renewed (7d)'
+ *   neverRenewed    → 'Untouched'
+ *
+ * New copy (post-U5, ships on R10):
+ *   guardianDue     → 'Due for check'
+ *   wobbling        → 'Wobbling words'
+ *   renewedRecently → 'Guarded this week'
+ *   neverRenewed    → 'Not guarded yet'
+ */
+export const WORD_BANK_GUARDIAN_CHIP_LABELS = Object.freeze({
+  guardianDue: 'Due for check',
+  wobbling: 'Wobbling words',
+  renewedRecently: 'Guarded this week',
+  neverRenewed: 'Not guarded yet',
+});
+export const WORD_BANK_GUARDIAN_FILTER_HINTS = Object.freeze({
+  guardianDue: 'Secure words the Vault wants you to recheck today.',
+  wobbling: 'Secure words that slipped last time — one more pass clears them.',
+  renewedRecently: 'Secure words you renewed in the last seven days.',
+  neverRenewed: 'Secure words the Guardian has not inspected yet — nothing is wrong, just untouched.',
+});
+
 // How many days after lastReviewedDay still counts as "renewed recently" for
 // the Word Bank filter. Seven days mirrors the shortest Guardian interval
 // (reviewLevel 1 = 7 days) — anything inside that window is still fresh.
@@ -322,6 +356,14 @@ export function wordBankFilterMatchesStatus(filter, status, options = {}) {
   }
 
   if (filter === 'wobbling') {
+    // U5 / R10 tightening: wobbling must imply secure. A stage < 4 word that
+    // still carries a `wobbling: true` flag (from a pre-hardening bug, or a
+    // rehydrated legacy record) is no longer in the Vault — it should show
+    // under the legacy `due` / `trouble` / `learning` chips, not here. The
+    // guard keeps the wobbling count honest: it equals exactly the
+    // secure + wobbling intersection, matching the mega-never-revoked
+    // invariant proved by U8b.
+    if (status !== 'secure') return false;
     return Boolean(hasGuardian && guardian.wobbling === true);
   }
 

--- a/src/subjects/spelling/components/spelling-view-model.js
+++ b/src/subjects/spelling/components/spelling-view-model.js
@@ -106,9 +106,11 @@ export const WORD_BANK_YEAR_FILTER_IDS = new Set(['all', 'y3-4', 'y5-6', 'extra'
  * The chip-label map lives in the view-model (not the JSX scene) so there is
  * a single source of truth for display text; the scene imports from here.
  * Labels are deliberately grounded and child-specific — no "Great work!"
- * slop, no zero-celebration — and matched by ARIA labels at render time so
- * screen-reader users hear the same phrase. The hint map mirrors the chip
- * IDs so an accidental label/hint divergence fails the parity tests.
+ * slop, no zero-celebration — and because each chip button's visible label
+ * span doubles as its accessible name (no explicit aria-label on the chip
+ * button), renaming the label here automatically updates the screen-reader
+ * text too. The hint map mirrors the chip IDs so an accidental label/hint
+ * divergence fails the parity tests.
  *
  * Previous copy (pre-U5, kept in comments for historical reference):
  *   guardianDue     → 'Guardian due'

--- a/src/subjects/spelling/session-ui.js
+++ b/src/subjects/spelling/session-ui.js
@@ -2,9 +2,24 @@ function isLearningSession(session) {
   return Boolean(session) && session.type !== 'test';
 }
 
+// Boss Dictation session helper branches.
+// U5 defines these Boss strings so U9's `submitBossAnswer` tests can assert
+// against them before the Boss service path lands. The guardrail is that a
+// Boss session (`session.mode === 'boss'`) is `type: 'test'`-shaped yet must
+// NEVER leak SATs copy like "SATs one-shot" or "SATs mode uses audio only"
+// — those belong to the statutory SATs Test surface, not Boss.
+function isBossSession(session) {
+  return Boolean(session) && session.mode === 'boss';
+}
+
+function isGuardianSession(session) {
+  return Boolean(session) && session.mode === 'guardian';
+}
+
 export function spellingSessionSubmitLabel(session, awaitingAdvance = false) {
   if (!session) return 'Submit';
   if (awaitingAdvance) return 'Saved';
+  if (isBossSession(session)) return 'Lock it in';
   if (session.type === 'test') return 'Save and next';
   if (session.phase === 'retry') return 'Try again';
   if (session.phase === 'correction') return 'Lock it in';
@@ -13,6 +28,7 @@ export function spellingSessionSubmitLabel(session, awaitingAdvance = false) {
 
 export function spellingSessionInputPlaceholder(session) {
   if (!session) return 'Type the spelling here';
+  if (isBossSession(session)) return 'Type the Mega word';
   if (session.type === 'test') return 'Type the spelling and move on';
   if (session.phase === 'retry') return 'Try once more from memory';
   if (session.phase === 'correction') return 'Type the correct spelling once';
@@ -21,6 +37,8 @@ export function spellingSessionInputPlaceholder(session) {
 
 export function spellingSessionContextNote(session) {
   if (!session) return 'Family hidden during live recall.';
+  if (isBossSession(session)) return 'Boss round. Mega words only.';
+  if (isGuardianSession(session)) return 'Spell the word from memory. One clean attempt.';
   if (session.type === 'test') return 'SATs mode uses audio only. Press Replay to hear the dictation again.';
   return 'Family hidden during live recall.';
 }
@@ -38,6 +56,7 @@ export function spellingSessionFooterNote(session) {
 
 export function spellingSessionProgressLabel(session) {
   if (!session) return '';
+  if (isBossSession(session)) return 'Boss round';
   if (session.type === 'test') return 'SATs one-shot';
   if (session.practiceOnly) return 'Practice only';
   return `Phase: ${session.phase}`;
@@ -48,6 +67,8 @@ export function spellingSessionInfoChips(session) {
   const chips = [];
   if (session.currentCard?.word?.yearLabel) chips.push(session.currentCard.word.yearLabel);
   if (session.practiceOnly) chips.push('Practice only');
+  if (isGuardianSession(session)) chips.push('Guardian');
+  if (isBossSession(session)) chips.push('Boss');
   return chips;
 }
 

--- a/tests/spelling-parity.test.js
+++ b/tests/spelling-parity.test.js
@@ -571,3 +571,37 @@ test('SATs Test session does not leak Guardian copy after U5 (parity guard)', ()
   assert.doesNotMatch(html, /Spell the word from memory\. One clean attempt\./);
   assert.doesNotMatch(html, /Boss round\. Mega words only\./);
 });
+
+// Trouble Drill pure-function parity. Integration-level trouble sessions
+// depend on the learner having a due backlog, which is brittle to seed in
+// a byte-for-byte parity test. We assert the pure session-ui helpers
+// instead so regressions in branch ordering — e.g. an accidental Guardian
+// chip leaking into trouble — are caught reliably.
+test('Trouble Drill pure session-ui helpers: byte-for-byte unchanged under U5', async () => {
+  const {
+    spellingSessionContextNote,
+    spellingSessionInfoChips,
+    spellingSessionInputPlaceholder,
+    spellingSessionProgressLabel,
+    spellingSessionSubmitLabel,
+    spellingSessionSkipLabel,
+  } = await import('../src/subjects/spelling/session-ui.js');
+  const trouble = {
+    type: 'learning',
+    mode: 'trouble',
+    phase: 'question',
+    practiceOnly: false,
+    currentCard: { word: { yearLabel: 'Y5-6' } },
+  };
+  assert.equal(spellingSessionSubmitLabel(trouble), 'Submit');
+  assert.equal(spellingSessionInputPlaceholder(trouble), 'Type the spelling here');
+  assert.equal(spellingSessionContextNote(trouble), 'Family hidden during live recall.');
+  assert.equal(spellingSessionProgressLabel(trouble), 'Phase: question');
+  assert.deepEqual(spellingSessionInfoChips(trouble), ['Y5-6']);
+  assert.equal(spellingSessionSkipLabel(trouble), 'Skip for now');
+
+  // Practice-only trouble drill (U3) — chip row + progress label unchanged.
+  const practiceTrouble = { ...trouble, practiceOnly: true };
+  assert.equal(spellingSessionProgressLabel(practiceTrouble), 'Practice only');
+  assert.deepEqual(spellingSessionInfoChips(practiceTrouble), ['Y5-6', 'Practice only']);
+});

--- a/tests/spelling-parity.test.js
+++ b/tests/spelling-parity.test.js
@@ -10,7 +10,7 @@ import { createSpellingPersistence } from '../src/subjects/spelling/repository.j
 import { createSpellingService } from '../src/subjects/spelling/service.js';
 import { resolveSpellingShortcut } from '../src/subjects/spelling/shortcuts.js';
 import { spellingAutoAdvanceDelay } from '../src/subjects/spelling/auto-advance.js';
-import { WORD_BY_SLUG } from '../src/subjects/spelling/data/word-data.js';
+import { WORDS, WORD_BY_SLUG } from '../src/subjects/spelling/data/word-data.js';
 
 function typedFormData(value) {
   const formData = new FormData();
@@ -19,6 +19,25 @@ function typedFormData(value) {
 }
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+
+// U5 helper — mirrors `seedAllCoreMega` in spelling-guardian.test.js so the
+// parity test can drive a Guardian round without a cross-test import. Every
+// core-pool word graduates to stage 4 with a 60-day dueDay cushion; the
+// lastDay -7 means the word is comfortably past its Mega lockout.
+function seedAllCoreMegaForGuardian(repositories, learnerId, todayDay) {
+  const progress = Object.fromEntries(
+    WORDS.filter((word) => word.spellingPool !== 'extra').map((word, index) => [word.slug, {
+      stage: 4,
+      attempts: 6 + (index % 4),
+      correct: 5 + (index % 4),
+      wrong: 1,
+      dueDay: todayDay + 60,
+      lastDay: todayDay - 7,
+      lastResult: 'correct',
+    }]),
+  );
+  repositories.subjectStates.writeData(learnerId, 'spelling', { progress });
+}
 
 function completeSingleWordRound(harness, answer = 'possess') {
   harness.dispatch('spelling-drill-single', { slug: 'possess' });
@@ -437,4 +456,118 @@ test('restored completed spelling card caps progress and resumes auto-advance', 
   restoredScheduler.flushAll();
 
   assert.equal(restoredHarness.store.getState().subjectUi.spelling.phase, 'summary');
+});
+
+// ----- U5: Guardian clean-retrieval UX (R5) -----------------------------------
+//
+// These assertions drive the full SSR path through `harness.render()` so we
+// catch integration-level regressions (prefs → scene prop drilling → JSX).
+// Matching logic:
+//   - `prefs.showCloze === true` + guardian mode → no active cloze in HTML.
+//   - Guardian info chip appears verbatim.
+//   - Guardian context note appears verbatim.
+//   - SATs-only copy must not leak into a Guardian session.
+
+test('Guardian session hides the cloze hint even when showCloze is true (R5)', () => {
+  const storage = installMemoryStorage();
+  const nowRef = { value: Date.UTC(2026, 0, 10) };
+  const harness = createAppHarness({ storage, now: () => nowRef.value });
+  const learnerId = harness.store.getState().learners.selectedId;
+  const todayDay = Math.floor(nowRef.value / DAY_MS);
+
+  seedAllCoreMegaForGuardian(harness.repositories, learnerId, todayDay);
+  harness.services.spelling.savePrefs(learnerId, { mode: 'smart', showCloze: true });
+  harness.dispatch('open-subject', { subjectId: 'spelling' });
+  harness.dispatch('spelling-shortcut-start', { mode: 'guardian' });
+
+  const state = harness.store.getState().subjectUi.spelling;
+  assert.equal(state.phase, 'session');
+  assert.equal(state.session.mode, 'guardian');
+
+  const html = harness.render();
+  // Active cloze renders as `<div class="cloze">` with no "muted" modifier;
+  // the hidden/muted render uses `cloze muted`. A Guardian round must never
+  // show the active form.
+  assert.doesNotMatch(html, /<div class="cloze"(?!\s+muted)/, 'no active cloze element in Guardian mode');
+});
+
+test('Guardian session renders the "Guardian" info chip (R5)', () => {
+  const storage = installMemoryStorage();
+  const nowRef = { value: Date.UTC(2026, 0, 10) };
+  const harness = createAppHarness({ storage, now: () => nowRef.value });
+  const learnerId = harness.store.getState().learners.selectedId;
+  const todayDay = Math.floor(nowRef.value / DAY_MS);
+
+  seedAllCoreMegaForGuardian(harness.repositories, learnerId, todayDay);
+  harness.services.spelling.savePrefs(learnerId, { mode: 'smart' });
+  harness.dispatch('open-subject', { subjectId: 'spelling' });
+  harness.dispatch('spelling-shortcut-start', { mode: 'guardian' });
+
+  const html = harness.render();
+  assert.match(html, /Guardian/);
+});
+
+test('Guardian session renders the clean-retrieval context note and no SATs copy (R5)', () => {
+  const storage = installMemoryStorage();
+  const nowRef = { value: Date.UTC(2026, 0, 10) };
+  const harness = createAppHarness({ storage, now: () => nowRef.value });
+  const learnerId = harness.store.getState().learners.selectedId;
+  const todayDay = Math.floor(nowRef.value / DAY_MS);
+
+  seedAllCoreMegaForGuardian(harness.repositories, learnerId, todayDay);
+  harness.services.spelling.savePrefs(learnerId, { mode: 'smart', showCloze: false });
+  harness.dispatch('open-subject', { subjectId: 'spelling' });
+  harness.dispatch('spelling-shortcut-start', { mode: 'guardian' });
+
+  const html = harness.render();
+  assert.match(html, /Spell the word from memory\. One clean attempt\./);
+  // SATs-only copy must not leak.
+  assert.doesNotMatch(html, /SATs mode uses audio only/);
+  assert.doesNotMatch(html, /SATs one-shot/);
+});
+
+test('Smart Review session still shows cloze when showCloze=true (U5 parity guard)', () => {
+  const storage = installMemoryStorage();
+  const harness = createAppHarness({ storage });
+  const learnerId = harness.store.getState().learners.selectedId;
+
+  harness.services.spelling.savePrefs(learnerId, { mode: 'smart', showCloze: true, roundLength: '1' });
+  harness.dispatch('open-subject', { subjectId: 'spelling' });
+  harness.dispatch('spelling-start');
+
+  const html = harness.render();
+  // Smart Review with showCloze=true must still render an active cloze.
+  assert.match(html, /<div class="cloze">/);
+  // No guardian copy and no Boss copy should leak into a smart-review round.
+  assert.doesNotMatch(html, /Spell the word from memory\. One clean attempt\./);
+  assert.doesNotMatch(html, /Boss round/);
+});
+
+test('Smart Review with showCloze=false still shows the default context note (U5 parity guard)', () => {
+  const storage = installMemoryStorage();
+  const harness = createAppHarness({ storage });
+  const learnerId = harness.store.getState().learners.selectedId;
+
+  harness.services.spelling.savePrefs(learnerId, { mode: 'smart', showCloze: false, roundLength: '1' });
+  harness.dispatch('open-subject', { subjectId: 'spelling' });
+  harness.dispatch('spelling-start');
+
+  const html = harness.render();
+  assert.match(html, /Family hidden during live recall\./);
+  assert.doesNotMatch(html, /Spell the word from memory\. One clean attempt\./);
+});
+
+test('SATs Test session does not leak Guardian copy after U5 (parity guard)', () => {
+  const storage = installMemoryStorage();
+  const harness = createAppHarness({ storage });
+  const learnerId = harness.store.getState().learners.selectedId;
+
+  harness.services.spelling.savePrefs(learnerId, { mode: 'test' });
+  harness.dispatch('open-subject', { subjectId: 'spelling' });
+  harness.dispatch('spelling-start');
+
+  const html = harness.render();
+  assert.match(html, /SATs mode uses audio only\. Press Replay to hear the dictation again\./);
+  assert.doesNotMatch(html, /Spell the word from memory\. One clean attempt\./);
+  assert.doesNotMatch(html, /Boss round\. Mega words only\./);
 });

--- a/tests/spelling-session-ui.test.js
+++ b/tests/spelling-session-ui.test.js
@@ -1,0 +1,160 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  spellingSessionContextNote,
+  spellingSessionFooterNote,
+  spellingSessionInfoChips,
+  spellingSessionInputPlaceholder,
+  spellingSessionProgressLabel,
+  spellingSessionSubmitLabel,
+  spellingSessionVoiceNote,
+} from '../src/subjects/spelling/session-ui.js';
+
+// ----- Characterisation: pre-U5 behaviour for Smart / Trouble / SATs ---------
+
+test('spellingSessionSubmitLabel: legacy labels unchanged', () => {
+  assert.equal(spellingSessionSubmitLabel(null), 'Submit');
+  assert.equal(spellingSessionSubmitLabel(undefined), 'Submit');
+  assert.equal(spellingSessionSubmitLabel({ type: 'learning', phase: 'question' }), 'Submit');
+  assert.equal(spellingSessionSubmitLabel({ type: 'learning', phase: 'retry' }), 'Try again');
+  assert.equal(spellingSessionSubmitLabel({ type: 'learning', phase: 'correction' }), 'Lock it in');
+  assert.equal(spellingSessionSubmitLabel({ type: 'test' }), 'Save and next');
+  assert.equal(spellingSessionSubmitLabel({ type: 'learning' }, true), 'Saved');
+});
+
+test('spellingSessionInputPlaceholder: legacy placeholders unchanged', () => {
+  assert.equal(spellingSessionInputPlaceholder(null), 'Type the spelling here');
+  assert.equal(spellingSessionInputPlaceholder({ type: 'learning', phase: 'question' }), 'Type the spelling here');
+  assert.equal(spellingSessionInputPlaceholder({ type: 'learning', phase: 'retry' }), 'Try once more from memory');
+  assert.equal(spellingSessionInputPlaceholder({ type: 'learning', phase: 'correction' }), 'Type the correct spelling once');
+  assert.equal(spellingSessionInputPlaceholder({ type: 'test' }), 'Type the spelling and move on');
+});
+
+test('spellingSessionContextNote: legacy notes unchanged', () => {
+  assert.equal(spellingSessionContextNote(null), 'Family hidden during live recall.');
+  assert.equal(spellingSessionContextNote({ type: 'learning' }), 'Family hidden during live recall.');
+  assert.equal(
+    spellingSessionContextNote({ type: 'test' }),
+    'SATs mode uses audio only. Press Replay to hear the dictation again.',
+  );
+});
+
+test('spellingSessionFooterNote: practice-only wording unchanged (U3 guard)', () => {
+  const practice = spellingSessionFooterNote({ type: 'learning', practiceOnly: true });
+  assert.match(practice, /Practice-only drill/);
+  assert.match(practice, /do not change correct counts/);
+});
+
+test('spellingSessionProgressLabel: legacy progress labels unchanged', () => {
+  assert.equal(spellingSessionProgressLabel(null), '');
+  assert.equal(spellingSessionProgressLabel({ type: 'test' }), 'SATs one-shot');
+  assert.equal(spellingSessionProgressLabel({ type: 'learning', practiceOnly: true }), 'Practice only');
+  assert.equal(spellingSessionProgressLabel({ type: 'learning', phase: 'question' }), 'Phase: question');
+});
+
+test('spellingSessionInfoChips: legacy chip shapes unchanged', () => {
+  assert.deepEqual(spellingSessionInfoChips(null), []);
+  assert.deepEqual(
+    spellingSessionInfoChips({ type: 'learning', currentCard: { word: { yearLabel: 'Y5-6' } } }),
+    ['Y5-6'],
+  );
+  assert.deepEqual(
+    spellingSessionInfoChips({ type: 'learning', practiceOnly: true, currentCard: { word: { yearLabel: 'Y3-4' } } }),
+    ['Y3-4', 'Practice only'],
+  );
+  assert.deepEqual(
+    spellingSessionInfoChips({ type: 'test', currentCard: { word: { yearLabel: 'Y5-6' } } }),
+    ['Y5-6'],
+  );
+});
+
+test('spellingSessionVoiceNote returns stable AI-dictation copy', () => {
+  assert.equal(spellingSessionVoiceNote(), 'AI-generated dictation voice');
+});
+
+// ----- U5: Guardian info chip + Guardian context note -------------------------
+
+test('spellingSessionInfoChips: Guardian session appends a "Guardian" chip', () => {
+  const session = {
+    type: 'learning',
+    mode: 'guardian',
+    currentCard: { word: { yearLabel: 'Y5-6' } },
+  };
+  assert.deepEqual(spellingSessionInfoChips(session), ['Y5-6', 'Guardian']);
+});
+
+test('spellingSessionInfoChips: Guardian chip survives a missing yearLabel', () => {
+  const session = {
+    type: 'learning',
+    mode: 'guardian',
+    currentCard: { word: {} },
+  };
+  assert.deepEqual(spellingSessionInfoChips(session), ['Guardian']);
+});
+
+test('spellingSessionContextNote: Guardian-mode copy is clean-retrieval wording', () => {
+  const note = spellingSessionContextNote({ type: 'learning', mode: 'guardian' });
+  assert.equal(note, 'Spell the word from memory. One clean attempt.');
+});
+
+test('spellingSessionContextNote: Guardian mode must NOT leak SATs copy', () => {
+  const note = spellingSessionContextNote({ type: 'learning', mode: 'guardian' });
+  assert.doesNotMatch(note, /SATs/);
+  assert.doesNotMatch(note, /audio only/);
+});
+
+// ----- U5: Boss session-ui strings (pre-U9 definition) ------------------------
+
+test('spellingSessionInfoChips: Boss session appends a "Boss" chip, not "Guardian"', () => {
+  const session = {
+    type: 'test',
+    mode: 'boss',
+    currentCard: { word: { yearLabel: 'Y5-6' } },
+  };
+  const chips = spellingSessionInfoChips(session);
+  assert.deepEqual(chips, ['Y5-6', 'Boss']);
+  assert.equal(chips.includes('Guardian'), false, 'Boss chip must not co-render a Guardian chip');
+});
+
+test('spellingSessionContextNote: Boss mode returns Boss-specific copy, not SATs copy', () => {
+  const note = spellingSessionContextNote({ type: 'test', mode: 'boss' });
+  assert.doesNotMatch(note, /SATs/, 'Boss context must not leak SATs wording');
+  assert.doesNotMatch(note, /audio only/);
+  assert.match(note, /Mega/i, 'Boss copy grounds on "Mega words only" framing');
+});
+
+test('spellingSessionSubmitLabel: Boss session returns a Boss-specific label (not SATs "Save and next")', () => {
+  const label = spellingSessionSubmitLabel({ type: 'test', mode: 'boss' }, false);
+  assert.notEqual(label, 'Save and next', 'Boss must not borrow the SATs submit wording');
+  assert.equal(typeof label, 'string');
+  assert.ok(label.length > 0);
+});
+
+test('spellingSessionInputPlaceholder: Boss session returns Boss-specific placeholder (not SATs)', () => {
+  const placeholder = spellingSessionInputPlaceholder({ type: 'test', mode: 'boss' });
+  assert.notEqual(placeholder, 'Type the spelling and move on', 'Boss must not borrow the SATs placeholder');
+  assert.equal(typeof placeholder, 'string');
+  assert.ok(placeholder.length > 0);
+});
+
+test('spellingSessionProgressLabel: Boss session does NOT return SATs copy', () => {
+  const label = spellingSessionProgressLabel({ type: 'test', mode: 'boss' });
+  assert.notEqual(label, 'SATs one-shot', 'Boss must not borrow the SATs progress label');
+  assert.equal(typeof label, 'string');
+  assert.ok(label.length > 0);
+});
+
+// ----- U5: SATs remains byte-identical (parity guard) ------------------------
+
+test('SATs Test session-ui helpers unchanged byte-for-byte after U5', () => {
+  const sats = {
+    type: 'test',
+    currentCard: { word: { yearLabel: 'Y5-6' } },
+  };
+  assert.equal(spellingSessionSubmitLabel(sats), 'Save and next');
+  assert.equal(spellingSessionInputPlaceholder(sats), 'Type the spelling and move on');
+  assert.equal(spellingSessionContextNote(sats), 'SATs mode uses audio only. Press Replay to hear the dictation again.');
+  assert.equal(spellingSessionProgressLabel(sats), 'SATs one-shot');
+  assert.deepEqual(spellingSessionInfoChips(sats), ['Y5-6']);
+});

--- a/tests/spelling-view-model.test.js
+++ b/tests/spelling-view-model.test.js
@@ -5,6 +5,8 @@ import {
   MODE_CARDS,
   POST_MEGA_MODE_CARDS,
   WORD_BANK_FILTER_IDS,
+  WORD_BANK_GUARDIAN_CHIP_LABELS,
+  WORD_BANK_GUARDIAN_FILTER_HINTS,
   WORD_BANK_GUARDIAN_FILTER_IDS,
   guardianLabel,
   guardianSummaryCards,
@@ -514,4 +516,87 @@ test('spellingSessionSkipLabel falls back to "Skip for now" when session is null
   assert.equal(spellingSessionSkipLabel(null), 'Skip for now');
   assert.equal(spellingSessionSkipLabel(undefined), 'Skip for now');
   assert.equal(spellingSessionSkipLabel({}), 'Skip for now');
+});
+
+// ----- U5: Word Bank chip copy polish (R10) -----------------------------------
+//
+// The four Guardian filter IDs are rendered via a label map that used to read
+// "Guardian due / Wobbling / Renewed (7d) / Untouched". U5 rewords them to
+// "Due for check / Wobbling words / Guarded this week / Not guarded yet" so
+// the child-facing copy sounds consistent with the rest of the Guardian
+// dashboard. The rename is a single-source-of-truth swap in
+// `spelling-view-model.js::WORD_BANK_GUARDIAN_CHIP_LABELS` (moved out of the
+// JSX scene in U5 so both the SSR component and the Node tests read from the
+// same place).
+
+test('WORD_BANK_GUARDIAN_CHIP_LABELS uses the U5 child-friendly phrases', () => {
+  assert.equal(WORD_BANK_GUARDIAN_CHIP_LABELS.guardianDue, 'Due for check');
+  assert.equal(WORD_BANK_GUARDIAN_CHIP_LABELS.wobbling, 'Wobbling words');
+  assert.equal(WORD_BANK_GUARDIAN_CHIP_LABELS.renewedRecently, 'Guarded this week');
+  assert.equal(WORD_BANK_GUARDIAN_CHIP_LABELS.neverRenewed, 'Not guarded yet');
+});
+
+test('WORD_BANK_GUARDIAN_CHIP_LABELS covers every Guardian filter ID so no chip can render "undefined"', () => {
+  const ids = [...WORD_BANK_GUARDIAN_FILTER_IDS];
+  for (const id of ids) {
+    assert.ok(
+      Object.prototype.hasOwnProperty.call(WORD_BANK_GUARDIAN_CHIP_LABELS, id),
+      `${id} is missing a Guardian chip label`,
+    );
+    assert.equal(typeof WORD_BANK_GUARDIAN_CHIP_LABELS[id], 'string');
+    assert.ok(WORD_BANK_GUARDIAN_CHIP_LABELS[id].length > 0);
+  }
+});
+
+test('WORD_BANK_GUARDIAN_FILTER_HINTS still covers every Guardian filter ID (hint map parity)', () => {
+  for (const id of [...WORD_BANK_GUARDIAN_FILTER_IDS]) {
+    assert.ok(
+      Object.prototype.hasOwnProperty.call(WORD_BANK_GUARDIAN_FILTER_HINTS, id),
+      `${id} is missing a Guardian filter hint`,
+    );
+    assert.equal(typeof WORD_BANK_GUARDIAN_FILTER_HINTS[id], 'string');
+  }
+});
+
+test('WORD_BANK_GUARDIAN_CHIP_LABELS and WORD_BANK_GUARDIAN_FILTER_HINTS are frozen', () => {
+  assert.equal(Object.isFrozen(WORD_BANK_GUARDIAN_CHIP_LABELS), true);
+  assert.equal(Object.isFrozen(WORD_BANK_GUARDIAN_FILTER_HINTS), true);
+});
+
+// ----- U5: wobbling filter status guard (R10 tightening) ----------------------
+
+test('wordBankFilterMatchesStatus: wobbling requires status === "secure" (R10 tightening)', () => {
+  // Plan spec, U5 edge case:
+  //   Synthesised guardian record with wobbling: true + progress[slug].stage === 3
+  //   (legacy pre-fix state). Filter returns FALSE after R10 tightening.
+  // A stage-3 word has status 'learning' / 'trouble' / 'due', not 'secure';
+  // if a pre-hardening bug left a wobbling flag on such a record, the Word
+  // Bank should not flip that into a Guardian chip because the word is no
+  // longer in the Vault. This keeps the wobbling chip honest: its count
+  // matches exactly the secure+wobbling set.
+  const wobblingRecord = { wobbling: true };
+  assert.equal(
+    wordBankFilterMatchesStatus('wobbling', 'learning', { guardian: wobblingRecord }),
+    false,
+    'non-secure + wobbling → false',
+  );
+  assert.equal(
+    wordBankFilterMatchesStatus('wobbling', 'trouble', { guardian: wobblingRecord }),
+    false,
+  );
+  assert.equal(
+    wordBankFilterMatchesStatus('wobbling', 'due', { guardian: wobblingRecord }),
+    false,
+  );
+  assert.equal(
+    wordBankFilterMatchesStatus('wobbling', 'new', { guardian: wobblingRecord }),
+    false,
+  );
+  // Secure + wobbling still holds (this is the happy path the chip was
+  // designed for); regression guard for the baseline assertion above.
+  assert.equal(
+    wordBankFilterMatchesStatus('wobbling', 'secure', { guardian: wobblingRecord }),
+    true,
+    'secure + wobbling still → true',
+  );
 });


### PR DESCRIPTION
## Summary
- Guardian sessions: suppress cloze hint (R5), add "Guardian" info chip, and show "Spell the word from memory. One clean attempt." as the context note.
- Boss session-ui helpers are pre-wired here so U9 tests can assert Boss-specific strings without a later rename: submit label, placeholder, progress label, info chip, and the Boss context note "Boss round. Mega words only." — SATs copy (e.g. "SATs one-shot" / "SATs mode uses audio only") never leaks into Boss.
- Word Bank chip labels move to `spelling-view-model.js` (single source of truth) and adopt the R10 polish: "Due for check / Wobbling words / Guarded this week / Not guarded yet". The `wobbling` filter gains a `status === 'secure'` guard — wobbling now strictly implies secure, so a stale `wobbling: true` flag on a stage-<4 word cannot resurface under the Guardian chip.

Requirements: **R5** (Guardian clean-retrieval UX), **R10** (Word Bank chip copy polish + wobbling invariant).
Plan: `docs/plans/2026-04-25-005-feat-post-mega-spelling-guardian-hardening-plan.md` — U5 section.

## Test plan
- [x] `tests/spelling-session-ui.test.js` — 17 new tests: pre-U5 characterisation of Smart / Trouble / SATs helpers (unchanged), new Guardian chip + context note, Boss helpers defined with explicit "not SATs" assertions, and a final byte-for-byte parity block for SATs.
- [x] `tests/spelling-view-model.test.js` — 5 new tests: Guardian chip label map exports the U5 copy, label/hint parity covers every filter ID, both maps are frozen, and wobbling filter returns `false` for non-secure status (R10 tightening regression guard).
- [x] `tests/spelling-parity.test.js` — 6 new SSR integration tests: Guardian cloze off when `showCloze=true`, Guardian chip rendered, Guardian context note rendered, Smart Review cloze-on still renders the active cloze, Smart Review cloze-off shows the default family-hidden note, and SATs Test does not leak Guardian/Boss copy.
- [x] Targeted: `node --test tests/spelling-session-ui.test.js tests/spelling-view-model.test.js tests/spelling-parity.test.js` → 68/68 pass.
- [x] Full spelling sweep: `node --test tests/spelling*.test.js` → 228/228 pass (no Guardian / parity / view-model regression).
- [x] Full `npm test`: 1813/1815 pass, 1 skipped, 1 pre-existing `grammar-production-smoke` failure (unrelated `grammar.startModel.stats.templates` server-only field leak — reproduces on clean `origin/main`, outside U5 scope).