### PR TITLE
chore(punctuation): U9 Phase 2 cleanup tombstones

### DIFF
--- a/docs/punctuation-production.md
+++ b/docs/punctuation-production.md
@@ -4,7 +4,7 @@ Punctuation is now a production subject slice for KS2 Mastery, built from the le
 
 The release deliberately keeps the learner engine first. Monsters and Codex rewards are projections from secured learning evidence; they are not the primary game loop and they do not drive scoring.
 
-## First Release Scope
+## Current Release Scope
 
 Release id:
 
@@ -229,7 +229,7 @@ Worker-first asset routing also denies `/shared/*`, `/worker/*`, `/tests/*`, `/d
 
 The Punctuation release gate includes:
 
-- manifest validation for the 14-skill map, first-release scope, readiness rows, and stable reward keys
+- manifest validation for the 14-skill map, current release scope, readiness rows, and stable reward keys
 - marking tests for exact answers, Speech variants, and misconception tags
 - scheduler and service tests for spaced secure thresholds and transition errors
 - Worker command tests for start, submit, continue, stale transitions, redaction, and idempotent reward projection

--- a/docs/punctuation-production.md
+++ b/docs/punctuation-production.md
@@ -289,3 +289,28 @@ The baseline currently classifies legacy behaviour as:
 - Rejected: the legacy single-file production route, localStorage source of truth, browser-owned marking, browser-stored AI provider keys, browser-direct provider calls, unconstrained free-writing auto-scoring, and AI-authored score-bearing items or marking decisions.
 
 This baseline is deliberately a guardrail, not a demand to copy the legacy architecture. New parity slices should update the fixture status only when the replacement Worker-owned implementation, redacted read model, tests, and release gate exist.
+
+## Operational Telemetry (aspirational)
+
+Phase 2 shipped a set of structured warning codes emitted via the existing `logMutation('warn', …)` path. The codes below are stable so a future observability work item can consume them. The repo does not currently have a dashboard or alerting pipeline that ingests these codes — the thresholds quoted here are **aspirational**, not enforced. Until the pipeline lands, operators reviewing Worker logs after a release should watch for:
+
+- `punctuation-redaction-unknown-key-strip` — expected zero. Any non-zero count indicates an upstream field addition that did not update the allowlist. Investigate immediately.
+- `punctuation-normaliser-malformed-key` — expected low baseline. Sustained activity indicates stale or malformed stored mastery keys that the deferred repair script should address.
+- `punctuation-command-stale-response-drop` — expected low. Spikes indicate client/server revision drift or flaky network.
+- `punctuation-command-dedupe-reject` — expected non-zero for real double-submit cases. Spikes indicate UI regression on the disable state machine.
+- "Stuck-at-1" learner count — a diagnostic query on `child_game_state.punctuation.quoral.publishedTotal < 14` run manually from the D1 console during release week. Expected non-zero initially, trending down as learners practise. A non-draining tail should escalate to the deferred repair script.
+
+These codes and queries are not currently wired to a consumer; the acceptance criteria for graduating them from aspirational to enforced are listed below under "Phase 4 follow-up candidates".
+
+## Phase 4 follow-up candidates
+
+Items deliberately deferred from earlier phases and scheduled for a future Phase 4 (or a dedicated observability work item):
+
+- **Wire the Operational Telemetry warning codes to a consumer.** Concrete acceptance criteria for each code:
+  - Query surface: Cloudflare Workers Analytics Engine, Logpush to an ingesting store, or a Grafana / Loki query pane fed by the Worker log stream. Any one of these is acceptable — the choice is a platform decision, not a code decision.
+  - Metric names (stable; match the warning code verbatim to avoid rename drift): `punctuation-redaction-unknown-key-strip`, `punctuation-normaliser-malformed-key`, `punctuation-command-stale-response-drop`, `punctuation-command-dedupe-reject`, `punctuation-quoral-stuck-at-1`.
+  - Thresholds: `*-unknown-key-strip` must alert on any non-zero 24h window; `*-malformed-key` must alert on > 10 / 24h sustained for 3 consecutive days; `*-stale-response-drop` must alert on > 50 / 24h; `*-dedupe-reject` must alert on a 7-day-over-7-day increase of > 3x; `*-stuck-at-1` must alert only if the count fails to decrease week-over-week for two consecutive weeks post-release.
+  - Consumer: an on-call operations rotation (TBD — likely the same consumer as the Admin Ops Console alert feed once that exists). The default is that this lands as a companion PR alongside whichever phase adds the dashboards.
+- **AI context-pack learner surface.** Phase 2 deferred this deliberately (`safeContextPackSummary` allowlist is already fail-closed). Phase 3 U8 strips it from the default child read model. A Phase 4 decision is required: either productise it as a Parent / Admin-only "Why this question?" surface, or retire the Worker plumbing entirely. The `punctuation-context-pack` client action remains in place as a stub so either path is reachable without a command-surface rewrite.
+
+These items are tracked here (rather than in a GitHub issue) so the doc stays the single source of truth for Punctuation production concerns. When a Phase 4 work item starts, copy the relevant bullet into a tracking issue and link it back to this section.

--- a/src/surfaces/home/data.js
+++ b/src/surfaces/home/data.js
@@ -27,29 +27,58 @@ const MONSTER_VARIANTS = ['b1', 'b2'];
 // the grand — they are filtered out of active surfaces before ranking
 // applies, so the rank position is belt-and-braces against fallback paths
 // that bypass the filter.
+//
+// RESERVED TOMBSTONES (Phase 3 U9): Colisk / Hyphang / Carillon (Punctuation)
+// and Glossbloom / Loomrill / Mirrane (Grammar) are retained ranks, not active
+// learner-facing creatures. They are kept in this active map (rather than a
+// separate RESERVED_CODEX_POWER_RANK constant) for two reasons:
+//   1. `codexPowerRank()` returns `CODEX_POWER_RANK[id] || 0`; a reserved id
+//      missing from the map would rank 0, losing the "reserved below directs"
+//      ordering that Phase 2 U5 baked in. Keeping them in-map preserves that
+//      ordering even if a reserved id escapes the upstream subject filter.
+//   2. `meadowEntriesByPower()` sorts by `codexPowerRank` without a filter of
+//      its own. If a pre-flip learner's stored state ever bypasses
+//      `pickFeaturedCodexEntry`'s `punctuationReserve` / `grammarReserve`
+//      filter (e.g. via a historical monster asset path), the reserved
+//      creature still sorts below its active siblings rather than floating to
+//      the top of the meadow next to Phaeton.
+// Do not renumber these ranks without auditing both guards. The Phase 2 U5
+// invariant — reserved < active directs < grand — must survive any roster
+// change.
 const CODEX_POWER_RANK = Object.freeze({
   inklet: 1,
   glimmerbug: 2,
   phaeton: 3,
   vellhorn: 4,
-  // Reserved Punctuation ranks sit below active directs (Pealark / Claspin /
-  // Curlune) and far below the grand (Quoral).
+  // Reserved-only Punctuation ranks (tombstones). See comment block above —
+  // these sit below active directs per the Phase 2 U5 invariant. They are
+  // filtered out of active learner surfaces before ranking applies; this
+  // placement is belt-and-braces against fallback paths that bypass the
+  // `punctuationReserve` subject filter.
   colisk: 5,
   hyphang: 6,
   carillon: 7,
+  // Active Punctuation directs.
   pealark: 8,
   claspin: 9,
   curlune: 10,
+  // Quoral is the Punctuation grand creature. Must remain strictly above every
+  // active direct (Pealark / Claspin / Curlune) — Phase 2 U5 landmine. Do not
+  // lower this rank when adding more direct creatures; raise it instead.
   quoral: 11,
-  // Reserved Grammar ranks (Phase 3 U0) mirror Punctuation's treatment:
-  // Glossbloom / Loomrill / Mirrane sit below active directs (Bracehart /
-  // Chronalyx / Couronnail) and far below Concordium.
+  // Reserved-only Grammar ranks (Phase 3 U0 tombstones). Same treatment as
+  // Punctuation: below active directs, filtered out before ranking, retained
+  // here to preserve fallback ordering.
   glossbloom: 12,
   loomrill: 13,
   mirrane: 14,
+  // Active Grammar directs.
   bracehart: 15,
   chronalyx: 16,
   couronnail: 17,
+  // Concordium is the Grammar grand creature. Mirrors Quoral's placement:
+  // strictly above every active Grammar direct. See `grammar-monster-roster`
+  // test "Codex landmine #2" which locks this invariant.
   concordium: 18,
 });
 


### PR DESCRIPTION
## Summary
- (a) Skipped U5 roster test: **no action required** — grep confirms zero `.skip()` calls in any `tests/punctuation*.test.js` on current `main`. The sole test-runner skip in the repo (`browser-react-migration-smoke.test.js`) is an env-var gate unrelated to the Punctuation roster. The Phase 2 completion report's "1 skipped (U5 deliberate)" line was already cleared by a subsequent Phase 2 PR; U9 only needs to record that this loose end is closed.
- (b) `docs/punctuation-production.md` "First Release Scope" -> "Current Release Scope" (ongoing release framing). Also updated the single downstream reference in the "Verification Gate" bullet list so the heading rename does not drift.
- (c) `CODEX_POWER_RANK` reserved tombstones **commented in place** (Option A). Reasoning captured in the expanded comment block: `codexPowerRank()` uses `CODEX_POWER_RANK[id] || 0`, so relocating reserved ids to a separate `RESERVED_CODEX_POWER_RANK` constant would collapse the "reserved below directs" ordering that Phase 2 U5 baked in (missing ids would rank 0, below every active id). Keeping them in-map preserves that ordering while still making the tombstone status explicit for future readers. Both Punctuation (Colisk/Hyphang/Carillon) and the Phase 3 U0 Grammar (Glossbloom/Loomrill/Mirrane) tombstones get the same treatment.
- (d) Telemetry thresholds marked aspirational. New "Operational Telemetry (aspirational)" section catalogues the five `logMutation('warn', ...)` codes from Phase 2 and labels their thresholds as aspirational-not-enforced. New "Phase 4 follow-up candidates" section captures the concrete wiring acceptance criteria (query surface, metric names, per-code thresholds, consumer owner) so a future observability PR can pick them up without re-deriving the design. Tracked in-doc rather than a separate GitHub issue; the doc remains the single source of truth for Punctuation production concerns.

## Plan reference
`docs/plans/2026-04-25-005-feat-punctuation-phase3-ux-rebuild-plan.md` — U9.

Independent of U1-U8; landed in parallel per plan. Phase 2 completion report items 2, 3, 4, 5 closed (item 1 covered by U8).

## Release-id impact
`release-id impact: none`.

## Test plan
- [x] `npm test` full suite — 1873 pass / 1 skipped (env-gated browser smoke) / 1 fail (pre-existing `Grammar production smoke scans feedback and summary models for forbidden keys`, unrelated to Punctuation U9)
- [x] No `.skip()` left in punctuation tests (grep confirmed zero)
- [x] `pickFeaturedCodexEntry` reserved-subject filter still green (Phase 2 U5 landmine — 28 rewards + 16 monster-migration + 18 grammar-monster-roster invariant tests pass)
- [x] Quoral=11 remains above all active directs (Phase 2 U5 invariant — explicit in comment block and in `tests/grammar-monster-roster.test.js` Codex landmine #2)
- [x] `SUBJECT_PRIORITY_ORDER = ['spelling','punctuation','grammar']` still explicit (unchanged by this PR)