### PR TITLE
feat(spelling): U3 Guardian-safe summary drill routes via practiceOnly

### DIFF
--- a/src/subjects/spelling/components/SpellingSummaryScene.jsx
+++ b/src/subjects/spelling/components/SpellingSummaryScene.jsx
@@ -3,7 +3,9 @@ import { ArrowRightIcon, CheckIcon } from './spelling-icons.jsx';
 import { AnimatedPromptCard, PathProgress, Ribbon } from './SpellingCommon.jsx';
 import { SpellingHeroBackdrop } from './SpellingHeroBackdrop.jsx';
 import {
+  guardianPracticeActionLabel,
   guardianSummaryCards,
+  guardianSummaryCopy,
   heroBgForSession,
   heroBgStyle,
   renderAction,
@@ -101,36 +103,72 @@ export function SpellingSummaryScene({ learner, ui, accent, actions, postMastery
           {isGuardianSummary ? <SummaryGuardianBand cards={guardianCards} /> : null}
 
           {summary.mistakes.length ? (
-            <div className="summary-drill">
-              <div className="summary-drill-head">
-                <h4>Words that need another go</h4>
-                <span className="small muted">A quick drill cycles each of these again before you close the round.</span>
-              </div>
-              <div className="summary-drill-chips">
-                {summary.mistakes.map((word) => (
+            isGuardianSummary ? (
+              // U3: Guardian summaries replace the legacy "Drill all" + per-word
+              // "Drill" chip cluster with a single Practice button. The
+              // dispatched action is still `spelling-drill-all` (the module
+              // handler branches on `ui.summary.mode === 'guardian'` to force
+              // `practiceOnly: true`); hiding the per-word chips stops a child
+              // from starting a single-word drill that would bypass the
+              // Guardian-origin practiceOnly gating.
+              //
+              // Copy sourced from `guardianPracticeActionLabel()` +
+              // `guardianSummaryCopy()` — see view-model notes on the
+              // identity-separation rationale. Every string here lives in one
+              // place, so a rename is a one-file change across scene, test
+              // fixtures, and telemetry.
+              <div className="summary-drill summary-drill--guardian">
+                <div className="summary-drill-head">
+                  <h4>Words that wobbled today</h4>
+                  <span className="small muted">{guardianSummaryCopy()}</span>
+                </div>
+                <div className="summary-drill-chips">
+                  {summary.mistakes.map((word) => (
+                    <span className="fchip fchip--static" key={word.slug}>{word.word}</span>
+                  ))}
                   <button
                     type="button"
-                    className="fchip"
-                    data-action="spelling-drill-single"
-                    data-slug={word.slug}
-                    key={word.slug}
+                    className="btn primary sm"
+                    data-action="spelling-drill-all"
                     disabled={runtimeReadOnly || pending}
-                    onClick={(event) => renderAction(actions, event, 'spelling-drill-single', { slug: word.slug })}
+                    onClick={(event) => renderAction(actions, event, 'spelling-drill-all')}
                   >
-                    {word.word}
+                    {guardianPracticeActionLabel()} <ArrowRightIcon />
                   </button>
-                ))}
-                <button
-                  type="button"
-                  className="btn primary sm"
-                  data-action="spelling-drill-all"
-                  disabled={runtimeReadOnly || pending}
-                  onClick={(event) => renderAction(actions, event, 'spelling-drill-all')}
-                >
-                  Drill all {summary.mistakes.length} <ArrowRightIcon />
-                </button>
+                </div>
               </div>
-            </div>
+            ) : (
+              <div className="summary-drill">
+                <div className="summary-drill-head">
+                  <h4>Words that need another go</h4>
+                  <span className="small muted">A quick drill cycles each of these again before you close the round.</span>
+                </div>
+                <div className="summary-drill-chips">
+                  {summary.mistakes.map((word) => (
+                    <button
+                      type="button"
+                      className="fchip"
+                      data-action="spelling-drill-single"
+                      data-slug={word.slug}
+                      key={word.slug}
+                      disabled={runtimeReadOnly || pending}
+                      onClick={(event) => renderAction(actions, event, 'spelling-drill-single', { slug: word.slug })}
+                    >
+                      {word.word}
+                    </button>
+                  ))}
+                  <button
+                    type="button"
+                    className="btn primary sm"
+                    data-action="spelling-drill-all"
+                    disabled={runtimeReadOnly || pending}
+                    onClick={(event) => renderAction(actions, event, 'spelling-drill-all')}
+                  >
+                    Drill all {summary.mistakes.length} <ArrowRightIcon />
+                  </button>
+                </div>
+              </div>
+            )
           ) : null}
 
           <div className="summary-actions">

--- a/src/subjects/spelling/components/spelling-view-model.js
+++ b/src/subjects/spelling/components/spelling-view-model.js
@@ -700,6 +700,39 @@ export function guardianSummaryCards({ summary, nextGuardianDueDay, todayDay }) 
   ];
 }
 
+/**
+ * Canonical label for the Guardian-origin summary "Practice wobbling words"
+ * button (U3). Lives in the view-model so the scene, telemetry, and future
+ * automated-tour copy all read the same string. Every deviation weakens the
+ * identity separation between Guardian's single-attempt contract and the
+ * optional practice-only drill — see the plan's Key Technical Decisions entry
+ * on the practice-button identity trade-off.
+ *
+ * @returns {string} The exact button label. Always call this helper rather
+ *   than hard-coding the string, so a future rename (e.g. for i18n) stays a
+ *   one-line change.
+ */
+export function guardianPracticeActionLabel() {
+  return 'Practice wobbling words';
+}
+
+/**
+ * Canonical help-text copy rendered below the Practice button on a Guardian
+ * summary (U3). Holds the Mega-never-revoked invariant ("schedule will not
+ * change") + the Guardian identity guardrail ("Official recovery check
+ * returns tomorrow"). Same single-source-of-truth rationale as
+ * `guardianPracticeActionLabel()` — telemetry copy, scene copy, and test
+ * fixtures all read this string.
+ *
+ * @returns {string} The exact help copy. Treat as append-only for phrasing
+ *   tweaks; do not drop the "schedule will not change" or "tomorrow" clauses
+ *   — they carry product intent that the separation between practice + real
+ *   Guardian rounds depends on.
+ */
+export function guardianSummaryCopy() {
+  return 'Optional practice. Mega and Guardian schedule will not change. Official recovery check returns tomorrow.';
+}
+
 export function summaryHeadline(summary) {
   if (summary?.totalWords > 0 && typeof summary.correct === 'number') {
     return `${summary.correct} of ${summary.totalWords} words landed.`;

--- a/src/subjects/spelling/module.js
+++ b/src/subjects/spelling/module.js
@@ -279,11 +279,20 @@ export const spellingModule = {
     if (action === 'spelling-drill-all') {
       if (!ui.summary?.mistakes?.length) return true;
       tts.stop();
+      // U3: when the origin summary is a Guardian round, force practiceOnly so
+      // the dispatched `mode: 'trouble'` session short-circuits at
+      // `legacy-engine.js:763` and leaves `progress.stage/dueDay/lastDay/
+      // lastResult` + the guardian record untouched. Source of truth is
+      // `ui.summary?.mode` (not a payload flag): summary-phase persistence
+      // across refresh is out of scope today; refactors that change this
+      // must re-validate the practiceOnly path.
+      const originMode = ui.summary?.mode;
       return applySpellingTransition(context, service.startSession(learnerId, {
         mode: 'trouble',
         words: ui.summary.mistakes.map((word) => word.slug),
         yearFilter: 'all',
         length: ui.summary.mistakes.length,
+        practiceOnly: originMode === 'guardian',
       }));
     }
 
@@ -291,11 +300,18 @@ export const spellingModule = {
       const slug = data.slug;
       if (!slug) return true;
       tts.stop();
+      // U3: mirror of drill-all — Guardian origin must never demote Mega. We
+      // keep the per-word drill using `mode: 'single'` here for legacy
+      // behaviour, then gate `practiceOnly` by `summary.mode === 'guardian'`.
+      // Note that the Guardian scene hides per-word drill chips (U3), so this
+      // branch only fires defensively if a future surface re-exposes them.
+      const originMode = ui.summary?.mode;
       return applySpellingTransition(context, service.startSession(learnerId, {
         mode: 'single',
         words: [slug],
         yearFilter: 'all',
         length: 1,
+        practiceOnly: originMode === 'guardian',
       }));
     }
 

--- a/src/subjects/spelling/remote-actions.js
+++ b/src/subjects/spelling/remote-actions.js
@@ -934,11 +934,21 @@ export function createRemoteSpellingActionHandler({
       const mistakes = Array.isArray(ui.summary?.mistakes) ? ui.summary.mistakes : [];
       if (!mistakes.length) return true;
       tts.stop();
+      // U3: mirror of `module.js` drill-all branch — Guardian-origin summary
+      // must never demote Mega via the Worker engine either. Worker's
+      // `legacy-engine.js:763` equivalent honours `practiceOnly` identically,
+      // so forwarding the flag on the remote start-session command keeps the
+      // Mega-never-revoked invariant under remote-sync. Source of truth is
+      // `ui.summary?.mode`; summary-phase persistence across refresh is out
+      // of scope today — refactors that change this must re-validate the
+      // practiceOnly path on both runtimes.
+      const originMode = ui.summary?.mode;
       runCommand('start-session', {
         mode: 'trouble',
         words: mistakes.map((word) => word.slug).filter(Boolean),
         yearFilter: 'all',
         length: mistakes.length,
+        practiceOnly: originMode === 'guardian',
       });
       return true;
     }
@@ -947,11 +957,17 @@ export function createRemoteSpellingActionHandler({
       const slug = String(data.slug || '').trim();
       if (!slug) return true;
       tts.stop();
+      // U3: mirror of `module.js` drill-single branch. The Guardian scene
+      // hides per-word drill chips so this branch only fires defensively if
+      // a future surface re-exposes them — but the defensive guard is the
+      // whole point of a parity check between local and remote paths.
+      const originMode = ui.summary?.mode;
       runCommand('start-session', {
         mode: 'single',
         words: [slug],
         yearFilter: 'all',
         length: 1,
+        practiceOnly: originMode === 'guardian',
       });
       return true;
     }

--- a/tests/react-spelling-surface.test.js
+++ b/tests/react-spelling-surface.test.js
@@ -279,3 +279,51 @@ test('React spelling Summary scene does NOT render the Guardian band for mode="s
   assert.doesNotMatch(html, /summary-stat--guardian/);
   assert.doesNotMatch(html, /Guardian round complete/);
 });
+
+// ----- U3: Guardian-safe summary drill ---------------------------------------
+
+test('U3 characterisation: legacy non-Guardian summary must not sprout the Practice button copy', async () => {
+  // Characterisation baseline: today's Smart Review summary path still reads
+  // like it did pre-U3 — none of the new Guardian-origin copy leaks into a
+  // non-Guardian summary, regardless of whether mistakes are present. Only
+  // Guardian summaries branch to the practice-only affordance.
+  const html = await renderSpellingSurfaceFixture({ phase: 'summary' });
+  assert.doesNotMatch(html, /Practice wobbling words/, 'non-Guardian summary must not show the U3 practice button');
+  assert.doesNotMatch(html, /Optional practice\. Mega/, 'non-Guardian summary must not show U3 help copy');
+});
+
+test('U3 happy path: Guardian summary with mistakes renders "Practice wobbling words", not "Drill all"', async () => {
+  // Wrong answer path yields `summary.mistakes.length === 1`. The new branch
+  // must replace legacy "Drill all" + per-word "Drill" chips with a single
+  // Practice button backed by the canonical guardianPracticeActionLabel().
+  const html = await renderSpellingGuardianSummaryFixture({ correct: false });
+  assert.match(html, /Practice wobbling words/, 'Guardian mistakes summary must show the Practice button');
+  assert.doesNotMatch(html, /Drill all 1/, 'Guardian mistakes summary must not show the legacy "Drill all" label');
+  // Canonical help copy from `guardianSummaryCopy()`.
+  assert.match(html, /Optional practice\./);
+  assert.match(html, /schedule will not change/);
+  assert.match(html, /tomorrow/i);
+});
+
+test('U3 happy path: Guardian summary with mistakes hides per-word data-action="spelling-drill-single" chips', async () => {
+  // The per-word "Drill" chip dispatches `spelling-drill-single` which in
+  // legacy land starts a live-learning session that can demote on wrong. In
+  // Guardian origin we must hide it entirely — the single Practice button is
+  // the only affordance (it routes through mode='trouble', practiceOnly=true
+  // and covers all mistakes at once).
+  const html = await renderSpellingGuardianSummaryFixture({ correct: false });
+  assert.doesNotMatch(html, /data-action="spelling-drill-single"/, 'Guardian summary must not expose per-word drill chips');
+  // The Practice button is a single new affordance with a Guardian-specific
+  // data-action so telemetry can distinguish it from the legacy drill.
+  assert.match(html, /data-action="spelling-drill-all"/, 'Practice button wires into the same spelling-drill-all dispatch path');
+});
+
+test('U3 edge case: Guardian summary with zero mistakes does not render the Practice button', async () => {
+  // All-correct Guardian round: summary.mistakes is empty, the drill area is
+  // skipped entirely (legacy code already guards on mistakes.length).
+  // This matches the existing SpellingSummaryScene contract — the Practice
+  // button only makes sense when there is something to practice.
+  const html = await renderSpellingGuardianSummaryFixture({ correct: true });
+  assert.doesNotMatch(html, /Practice wobbling words/, 'zero-mistake Guardian summary must not render the Practice button');
+  assert.doesNotMatch(html, /summary-drill-chips/, 'zero-mistake Guardian summary must not render the drill chips container');
+});

--- a/tests/spelling-guardian.test.js
+++ b/tests/spelling-guardian.test.js
@@ -1956,3 +1956,257 @@ test('U4 edge: continueSession after Guardian skip plays the audio cue for the n
   // next card's prompt without hearing it.
   assert.ok(advanced.audio, 'continueSession returns an audio cue for the freshly-advanced card');
 });
+
+// -----------------------------------------------------------------------------
+// U3 action-routing: Guardian-safe summary drill. The `spelling-drill-all` and
+// `spelling-drill-single` handlers branch on `ui.summary?.mode === 'guardian'`
+// to force `practiceOnly: true` on the dispatched session, which short-circuits
+// at `legacy-engine.js:763` before `applyLearningOutcome` can ever touch
+// `progress.stage`. Guardian origin never demotes Mega; non-Guardian origin is
+// byte-identical to the legacy path (characterisation coverage below).
+// -----------------------------------------------------------------------------
+
+function submitForm(harness, typed) {
+  const formData = new FormData();
+  formData.set('typed', typed);
+  harness.dispatch('spelling-submit-form', { formData });
+}
+
+function runLegacyLearningRoundWithOneWrongWord(harness) {
+  // Cycle the first word through retry → correction → correct so the word
+  // ends up in `summary.mistakes` but the round actually finalises (correction
+  // requires a matching answer before we can advance). The remaining words
+  // (if any in a multi-word round) are answered correctly on the first try.
+  const firstAnswer = harness.store.getState().subjectUi.spelling.session.currentCard.word.word;
+  submitForm(harness, 'zzzwrong-question');
+  submitForm(harness, 'zzzwrong-retry');
+  submitForm(harness, firstAnswer);
+  for (let guard = 0; guard < 40; guard += 1) {
+    const ui = harness.store.getState().subjectUi.spelling;
+    if (ui.phase !== 'session') break;
+    if (ui.awaitingAdvance) {
+      harness.dispatch('spelling-continue');
+      continue;
+    }
+    submitForm(harness, ui.session.currentCard.word.word);
+  }
+}
+
+function runGuardianRoundAllWrong(harness) {
+  // Guardian sessions are single-attempt — one wrong answer is enough to
+  // push the word into `summary.mistakes`. Loop through until phase flips
+  // off 'session'.
+  for (let guard = 0; guard < 40; guard += 1) {
+    const ui = harness.store.getState().subjectUi.spelling;
+    if (ui.phase !== 'session') break;
+    if (ui.awaitingAdvance) {
+      harness.dispatch('spelling-continue');
+      continue;
+    }
+    submitForm(harness, 'zzzwrongguardian');
+  }
+}
+
+function runPracticeOnlyRoundAllWrong(harness) {
+  // Practice-only drill uses the legacy learning surface (retry → correction
+  // → next), but `practiceOnly: true` short-circuits `applyLearningOutcome`
+  // at `legacy-engine.js:763`. We must still type the correct answer in
+  // correction phase to advance, otherwise the session stalls — this is a
+  // fixture constraint, not a product assertion.
+  for (let guard = 0; guard < 200; guard += 1) {
+    const ui = harness.store.getState().subjectUi.spelling;
+    if (ui.phase !== 'session') break;
+    if (ui.awaitingAdvance) {
+      harness.dispatch('spelling-continue');
+      continue;
+    }
+    const sessionPhase = ui.session?.phase;
+    if (sessionPhase === 'correction') {
+      // Type the correct answer to escape the correction phase without
+      // demoting (practiceOnly gates the demotion regardless of whether we
+      // type correct here).
+      submitForm(harness, ui.session.currentCard.word.word);
+    } else {
+      submitForm(harness, 'zzzwrongpractice');
+    }
+  }
+}
+
+test('U3 characterisation: legacy Smart Review summary drill keeps mode="trouble" + practiceOnly=false', async () => {
+  // Baseline that must survive the U3 change: a Smart Review summary
+  // dispatching `spelling-drill-all` starts a `mode: 'trouble'` session with
+  // `practiceOnly` left unset (defaults to false inside `startSession`).
+  // We assert on session shape — the public contract is that session
+  // carries `mode: 'trouble'` and does NOT carry `practiceOnly: true`.
+  const createAppHarness = await importAppHarness();
+  const storage = installMemoryStorage();
+  const harness = createAppHarness({ storage });
+  const learnerId = harness.store.getState().learners.selectedId;
+  harness.services.spelling.savePrefs(learnerId, { mode: 'smart', roundLength: '1' });
+  harness.dispatch('open-subject', { subjectId: 'spelling' });
+  harness.dispatch('spelling-start');
+
+  runLegacyLearningRoundWithOneWrongWord(harness);
+  const summary = harness.store.getState().subjectUi.spelling.summary;
+  assert.equal(summary.mode, 'smart', 'sanity: smart-review origin');
+  assert.ok(summary.mistakes.length >= 1, 'at least one mistake expected');
+
+  harness.dispatch('spelling-drill-all');
+
+  const session = harness.store.getState().subjectUi.spelling.session;
+  assert.equal(session.mode, 'trouble', 'Smart-origin drill routes into mode=trouble');
+  assert.notEqual(session.practiceOnly, true, 'Smart-origin drill must NOT set practiceOnly (legacy behaviour)');
+});
+
+test('U3 characterisation: legacy Smart Review summary drill-single keeps mode="single" + practiceOnly=false', async () => {
+  // Complement: `spelling-drill-single` must also stay on legacy behaviour
+  // for non-Guardian origins (the existing chip path that Smart Review
+  // learners tap one word at a time).
+  const createAppHarness = await importAppHarness();
+  const storage = installMemoryStorage();
+  const harness = createAppHarness({ storage });
+  const learnerId = harness.store.getState().learners.selectedId;
+  harness.services.spelling.savePrefs(learnerId, { mode: 'smart', roundLength: '1' });
+  harness.dispatch('open-subject', { subjectId: 'spelling' });
+  harness.dispatch('spelling-start');
+
+  runLegacyLearningRoundWithOneWrongWord(harness);
+  const summary = harness.store.getState().subjectUi.spelling.summary;
+  const mistakeSlug = summary.mistakes[0]?.slug;
+  assert.ok(mistakeSlug, 'at least one mistake with a slug expected');
+
+  harness.dispatch('spelling-drill-single', { slug: mistakeSlug });
+
+  const session = harness.store.getState().subjectUi.spelling.session;
+  assert.equal(session.mode, 'single', 'Smart-origin drill-single stays on mode=single');
+  assert.notEqual(session.practiceOnly, true, 'Smart-origin drill-single must NOT set practiceOnly');
+});
+
+test('U3 happy path: Guardian summary drill-all dispatch starts mode=trouble + practiceOnly=true', async () => {
+  const createAppHarness = await importAppHarness();
+  const storage = installMemoryStorage();
+  const harness = createAppHarness({ storage });
+  const learnerId = harness.store.getState().learners.selectedId;
+  const today = Math.floor(Date.now() / DAY_MS_TS);
+
+  seedAllCoreMega(harness.repositories, learnerId, today);
+  harness.services.spelling.savePrefs(learnerId, { mode: 'smart', roundLength: '1' });
+  harness.dispatch('open-subject', { subjectId: 'spelling' });
+  harness.dispatch('spelling-shortcut-start', { mode: 'guardian' });
+  assert.equal(harness.store.getState().subjectUi.spelling.phase, 'session');
+  assert.equal(harness.store.getState().subjectUi.spelling.session.mode, 'guardian');
+
+  runGuardianRoundAllWrong(harness);
+  const summary = harness.store.getState().subjectUi.spelling.summary;
+  assert.equal(summary.mode, 'guardian', 'sanity: guardian-origin summary');
+  assert.ok(summary.mistakes.length >= 1, 'guardian round of all-wrong must yield at least one mistake');
+
+  harness.dispatch('spelling-drill-all');
+
+  const session = harness.store.getState().subjectUi.spelling.session;
+  assert.equal(session.mode, 'trouble', 'Guardian-origin drill-all routes into mode=trouble (not a new mode)');
+  assert.equal(session.practiceOnly, true, 'Guardian-origin drill-all must set practiceOnly=true to short-circuit demotion');
+  // The session words must match the mistake slugs — not a fresh selection.
+  const mistakeSlugs = new Set(summary.mistakes.map((m) => m.slug));
+  for (const slug of session.uniqueWords) {
+    assert.ok(mistakeSlugs.has(slug), `session word ${slug} must come from summary.mistakes`);
+  }
+});
+
+test('U3 error path: practice-only drill after Guardian leaves progress.stage/dueDay/lastDay unchanged on wrong', async () => {
+  // The big invariant: a wrong answer during the practice-only drill must
+  // NEVER demote a Mega word. `practiceOnly: true` short-circuits at
+  // `legacy-engine.js:763` before `applyLearningOutcome` runs. We assert on
+  // the `progress` snapshot before / after the drill — stage/dueDay/lastDay/
+  // lastResult are byte-identical, only attempts/correct/wrong bump.
+  const createAppHarness = await importAppHarness();
+  const storage = installMemoryStorage();
+  const harness = createAppHarness({ storage });
+  const learnerId = harness.store.getState().learners.selectedId;
+  const today = Math.floor(Date.now() / DAY_MS_TS);
+
+  seedAllCoreMega(harness.repositories, learnerId, today);
+  harness.services.spelling.savePrefs(learnerId, { mode: 'smart', roundLength: '1' });
+  harness.dispatch('open-subject', { subjectId: 'spelling' });
+  harness.dispatch('spelling-shortcut-start', { mode: 'guardian' });
+
+  runGuardianRoundAllWrong(harness);
+
+  const summary = harness.store.getState().subjectUi.spelling.summary;
+  const drillSlug = summary.mistakes[0]?.slug;
+  assert.ok(drillSlug, 'Guardian all-wrong round must produce at least one mistake');
+
+  // Snapshot the progress record + guardian record before the drill.
+  const snapshotBefore = structuredClone(
+    harness.services.spelling.getAnalyticsSnapshot(learnerId).wordGroups
+      .flatMap((g) => g.words)
+      .find((r) => r.slug === drillSlug),
+  );
+  const guardianBefore = structuredClone(
+    harness.services.spelling.getPostMasteryState(learnerId).guardianMap[drillSlug] || null,
+  );
+
+  // Dispatch the Practice button path.
+  harness.dispatch('spelling-drill-all');
+  assert.equal(harness.store.getState().subjectUi.spelling.phase, 'session');
+  assert.equal(harness.store.getState().subjectUi.spelling.session.practiceOnly, true);
+
+  // Answer the practice-only round — correction-phase requires a valid
+  // answer to advance (fixture plumbing, not a product gate).
+  runPracticeOnlyRoundAllWrong(harness);
+
+  const snapshotAfter = harness.services.spelling.getAnalyticsSnapshot(learnerId).wordGroups
+    .flatMap((g) => g.words)
+    .find((r) => r.slug === drillSlug);
+  const guardianAfter = harness.services.spelling.getPostMasteryState(learnerId).guardianMap[drillSlug] || null;
+
+  // progress.stage must NOT have moved — the Mega invariant.
+  assert.equal(snapshotAfter.progress.stage, snapshotBefore.progress.stage, `${drillSlug} stage must stay at Mega (4)`);
+  assert.equal(snapshotAfter.progress.stage, 4, `${drillSlug} stage should be Mega (4)`);
+  // dueDay / lastDay / lastResult must also stay pinned — the whole point of
+  // practiceOnly is not just stage but the full scheduling snapshot.
+  assert.equal(snapshotAfter.progress.dueDay, snapshotBefore.progress.dueDay, `${drillSlug} dueDay unchanged`);
+  assert.equal(snapshotAfter.progress.lastDay, snapshotBefore.progress.lastDay, `${drillSlug} lastDay unchanged`);
+  assert.equal(snapshotAfter.progress.lastResult, snapshotBefore.progress.lastResult, `${drillSlug} lastResult unchanged`);
+
+  // guardian.wobbling / nextDueDay must be byte-identical to pre-drill.
+  if (guardianBefore) {
+    assert.equal(guardianAfter.wobbling, guardianBefore.wobbling, `${drillSlug} guardian.wobbling unchanged`);
+    assert.equal(guardianAfter.nextDueDay, guardianBefore.nextDueDay, `${drillSlug} guardian.nextDueDay unchanged`);
+    assert.equal(guardianAfter.reviewLevel, guardianBefore.reviewLevel, `${drillSlug} guardian.reviewLevel unchanged`);
+    assert.equal(guardianAfter.lapses, guardianBefore.lapses, `${drillSlug} guardian.lapses unchanged`);
+  }
+});
+
+test('U3 integration: practice-only drill summary renders without guardian-specific cards', async () => {
+  // The practice-only drill uses `mode: 'trouble'`, so when it finalises the
+  // summary scene must NOT render Guardian-specific cards. This is the
+  // "edge case" scenario in the plan — practice rounds complete but do not
+  // mint `mission-completed` events or decorate the summary with Vault copy.
+  const createAppHarness = await importAppHarness();
+  const storage = installMemoryStorage();
+  const harness = createAppHarness({ storage });
+  const learnerId = harness.store.getState().learners.selectedId;
+  const today = Math.floor(Date.now() / DAY_MS_TS);
+
+  seedAllCoreMega(harness.repositories, learnerId, today);
+  harness.services.spelling.savePrefs(learnerId, { mode: 'smart', roundLength: '1' });
+  harness.dispatch('open-subject', { subjectId: 'spelling' });
+  harness.dispatch('spelling-shortcut-start', { mode: 'guardian' });
+
+  runGuardianRoundAllWrong(harness);
+  harness.dispatch('spelling-drill-all');
+  // Finish the practice round by submitting correct answers.
+  for (let guard = 0; guard < 200; guard += 1) {
+    const ui = harness.store.getState().subjectUi.spelling;
+    if (ui.phase !== 'session') break;
+    if (ui.awaitingAdvance) {
+      harness.dispatch('spelling-continue');
+      continue;
+    }
+    submitForm(harness, ui.session.currentCard.word.word);
+  }
+
+  const summary = harness.store.getState().subjectUi.spelling.summary;
+  assert.equal(summary.mode, 'trouble', 'practice-only summary inherits mode=trouble, not guardian');
+});

--- a/tests/spelling-parity.test.js
+++ b/tests/spelling-parity.test.js
@@ -426,6 +426,50 @@ test('U4 parity: Guardian session renders "I don\'t know" button label', () => {
   assert.doesNotMatch(html, /Skip for now/);
 });
 
+// U3 characterisation: legacy Smart Review summary -> spelling-drill-all dispatch
+// must remain byte-identical — `mode: 'trouble'`, `practiceOnly: false`. This
+// test exists as a regression guard because U3 adds a Guardian branch to the
+// same handler. If a future refactor accidentally sets practiceOnly=true on
+// non-Guardian origins, this fails loudly.
+test('legacy Smart Review drill-all path starts mode=trouble with practiceOnly unset', () => {
+  const storage = installMemoryStorage();
+  const harness = createAppHarness({ storage });
+  const learnerId = harness.store.getState().learners.selectedId;
+  harness.services.spelling.savePrefs(learnerId, { mode: 'smart', roundLength: '1' });
+  harness.dispatch('open-subject', { subjectId: 'spelling' });
+  harness.dispatch('spelling-start');
+
+  // Cycle the word through retry → correction (two wrong + one copy of the
+  // real answer). Legacy learning phases require a successful correction
+  // before the round can finalise, so we never loop indefinitely.
+  const realAnswer = harness.store.getState().subjectUi.spelling.session.currentCard.word.word;
+  harness.dispatch('spelling-submit-form', { formData: typedFormData('zzzwrong-question') });
+  harness.dispatch('spelling-submit-form', { formData: typedFormData('zzzwrong-retry') });
+  harness.dispatch('spelling-submit-form', { formData: typedFormData(realAnswer) });
+  // Drain any follow-up advance steps until we land on the summary phase.
+  for (let guard = 0; guard < 20; guard += 1) {
+    const ui = harness.store.getState().subjectUi.spelling;
+    if (ui.phase !== 'session') break;
+    if (ui.awaitingAdvance) {
+      harness.dispatch('spelling-continue');
+      continue;
+    }
+    harness.dispatch('spelling-submit-form', { formData: typedFormData(ui.session.currentCard.word.word) });
+  }
+
+  const summary = harness.store.getState().subjectUi.spelling.summary;
+  assert.equal(summary.mode, 'smart', 'sanity: Smart Review origin summary');
+  assert.ok(summary.mistakes.length >= 1, 'at least one mistake to drill');
+
+  harness.dispatch('spelling-drill-all');
+
+  const session = harness.store.getState().subjectUi.spelling.session;
+  assert.equal(session.mode, 'trouble', 'legacy drill-all stays on mode=trouble');
+  // practiceOnly is normalised to false by default inside startSession — the
+  // assertion is that it is *not true*, preserving legacy demotion behaviour.
+  assert.notEqual(session.practiceOnly, true, 'legacy Smart Review drill-all must not set practiceOnly=true');
+});
+
 test('restored completed spelling card caps progress and resumes auto-advance', () => {
   const storage = installMemoryStorage();
   const scheduler = createManualScheduler();

--- a/tests/spelling-remote-actions.test.js
+++ b/tests/spelling-remote-actions.test.js
@@ -1329,3 +1329,92 @@ test('remote spelling successful commands clear scoped save errors', async () =>
   handler.reapplyPendingOptimisticPrefs();
   assert.equal(getState().subjectUi.spelling.error, '');
 });
+
+// -----------------------------------------------------------------------------
+// U3: Guardian-safe summary drill parity on the remote-sync path.
+//
+// `module.js` U3 branch + `remote-actions.js` U3 branch must round-trip the
+// same `practiceOnly` flag for Guardian-origin summaries, otherwise a learner
+// running on remote-sync (which routes `spelling-drill-all` / -single through
+// the Worker) would bypass the local practiceOnly gate and the Worker would
+// happily call `applyLearningOutcome`, demoting Mega on a wrong answer in the
+// practice round.
+// -----------------------------------------------------------------------------
+
+function createDrillHarness({ summaryMode, mistakes = [{ slug: 'possess', word: 'possess' }] }) {
+  const { getState, store } = createStoreHarness({
+    subjectUi: {
+      spelling: {
+        phase: 'summary',
+        summary: {
+          mode: summaryMode,
+          mistakes,
+          totalWords: Math.max(1, mistakes.length),
+        },
+        session: null,
+        analytics: null,
+        error: '',
+      },
+    },
+  });
+  const sent = [];
+  const handler = createRemoteSpellingActionHandler({
+    store,
+    services: {
+      spelling: {
+        getPrefs() {
+          return { mode: 'smart', roundLength: '10', yearFilter: 'core', autoSpeak: true, showCloze: true, extraWordFamilies: false };
+        },
+      },
+    },
+    tts: createTtsHarness(),
+    readModels: { readJson: async () => ({}) },
+    subjectCommands: {
+      send(request) {
+        sent.push(request);
+        return Promise.resolve({ subjectReadModel: { phase: 'session' } });
+      },
+    },
+  });
+  return { handler, sent, getState };
+}
+
+test('U3 remote-sync: guardian-origin drill-all forwards practiceOnly:true on the Worker start-session command', async () => {
+  const { handler, sent } = createDrillHarness({ summaryMode: 'guardian' });
+  assert.equal(handler.handle('spelling-drill-all'), true);
+  await flushPromises();
+  assert.equal(sent.length, 1);
+  assert.equal(sent[0].command, 'start-session');
+  assert.equal(sent[0].payload.mode, 'trouble');
+  assert.equal(sent[0].payload.practiceOnly, true, 'Guardian-origin remote drill-all must carry practiceOnly=true');
+  assert.deepEqual(sent[0].payload.words, ['possess']);
+});
+
+test('U3 remote-sync: guardian-origin drill-single forwards practiceOnly:true on the Worker start-session command', async () => {
+  const { handler, sent } = createDrillHarness({ summaryMode: 'guardian' });
+  assert.equal(handler.handle('spelling-drill-single', { slug: 'possess' }), true);
+  await flushPromises();
+  assert.equal(sent.length, 1);
+  assert.equal(sent[0].command, 'start-session');
+  assert.equal(sent[0].payload.mode, 'single');
+  assert.equal(sent[0].payload.practiceOnly, true, 'Guardian-origin remote drill-single must carry practiceOnly=true');
+  assert.deepEqual(sent[0].payload.words, ['possess']);
+});
+
+test('U3 remote-sync: legacy non-Guardian drill-all does NOT set practiceOnly (characterisation)', async () => {
+  const { handler, sent } = createDrillHarness({ summaryMode: 'smart' });
+  assert.equal(handler.handle('spelling-drill-all'), true);
+  await flushPromises();
+  assert.equal(sent.length, 1);
+  assert.equal(sent[0].payload.mode, 'trouble');
+  assert.notEqual(sent[0].payload.practiceOnly, true, 'non-Guardian remote drill-all must keep legacy behaviour (practiceOnly !== true)');
+});
+
+test('U3 remote-sync: legacy non-Guardian drill-single does NOT set practiceOnly (characterisation)', async () => {
+  const { handler, sent } = createDrillHarness({ summaryMode: 'smart' });
+  assert.equal(handler.handle('spelling-drill-single', { slug: 'possess' }), true);
+  await flushPromises();
+  assert.equal(sent.length, 1);
+  assert.equal(sent[0].payload.mode, 'single');
+  assert.notEqual(sent[0].payload.practiceOnly, true, 'non-Guardian remote drill-single must keep legacy behaviour (practiceOnly !== true)');
+});

--- a/tests/spelling-view-model.test.js
+++ b/tests/spelling-view-model.test.js
@@ -9,6 +9,8 @@ import {
   WORD_BANK_GUARDIAN_FILTER_HINTS,
   WORD_BANK_GUARDIAN_FILTER_IDS,
   guardianLabel,
+  guardianPracticeActionLabel,
+  guardianSummaryCopy,
   guardianSummaryCards,
   renderAction,
   summaryModeLabel,
@@ -599,4 +601,29 @@ test('wordBankFilterMatchesStatus: wobbling requires status === "secure" (R10 ti
     true,
     'secure + wobbling still → true',
   );
+});
+
+// ----- U3: Guardian-safe summary drill copy (single-source-of-truth) ---------
+
+test('guardianPracticeActionLabel: button label is the canonical "Practice wobbling words" string', () => {
+  // Scene consumers must read this string from one place (the view-model) so
+  // the copy cannot drift between button text and telemetry. Every deviation
+  // from this exact string weakens the "practice ≠ real Guardian round"
+  // identity separation (see plan Key Technical Decisions).
+  assert.equal(guardianPracticeActionLabel(), 'Practice wobbling words');
+});
+
+test('guardianSummaryCopy: help text covers "Optional practice", "schedule will not change", and "tomorrow"', () => {
+  // The plan fixes this copy as the identity-preserver between Guardian
+  // (single-attempt, spaced) and practice-only (optional rehearsal).
+  // Copy changes that drop any of these three phrases regress the product
+  // contract, so this test asserts on phrases rather than exact equality so
+  // a tone tweak is still possible without accidentally stripping the
+  // identity-guarding words.
+  const copy = guardianSummaryCopy();
+  assert.match(copy, /Optional practice/);
+  assert.match(copy, /schedule will not change/i);
+  assert.match(copy, /tomorrow/i);
+  // Guardian Mega invariant must be named explicitly.
+  assert.match(copy, /Mega/);
 });


### PR DESCRIPTION
## Summary

U3 closes the Mega-demotion loophole at the Guardian summary / drill boundary. Guardian-origin drills now dispatch `mode: 'trouble', practiceOnly: true`, short-circuiting at `legacy-engine.js:763` before `applyLearningOutcome` can touch `progress.stage / dueDay / lastDay / lastResult`. The summary scene swaps the legacy "Drill all N" + per-word drill chips for a single **"Practice wobbling words"** button + identity-preserving copy.

**Requirements:** R3, R11 (contributes to composite invariant). See [`docs/plans/2026-04-25-005-feat-post-mega-spelling-guardian-hardening-plan.md`](../blob/main/docs/plans/2026-04-25-005-feat-post-mega-spelling-guardian-hardening-plan.md) U3 section.

## What changes

- **`src/subjects/spelling/components/SpellingSummaryScene.jsx`** — Guardian summary branch replaces the drill-all + per-word chip cluster with a single Practice button, canonical help copy from `guardianSummaryCopy()`. Per-word drill chips are hidden to stop bypasses of the `practiceOnly` gate.
- **`src/subjects/spelling/module.js`** — `spelling-drill-all` + `spelling-drill-single` handlers read `ui.summary?.mode` and force `practiceOnly: true` when origin is Guardian. Source of truth for origin is the summary state, not a payload flag (defensive against future summary-persistence refactors).
- **`src/subjects/spelling/components/spelling-view-model.js`** — new `guardianPracticeActionLabel()` + `guardianSummaryCopy()` single-source-of-truth helpers.
- Tests added: characterisation (legacy path unchanged), happy path (Guardian button + copy + dispatch), error path (stage/dueDay/lastDay/guardian untouched across a wrong-answer practice round), edge case (zero-mistake Guardian summary), integration (practice-only summary has no Guardian cards).

## Guardrails honoured

- Did NOT touch `legacy-engine.js`. Short-circuit at `legacy-engine.js:763` is the pre-existing demotion-safety path. No attempt to fix pre-existing `practiceOnly` behaviour outside U3 scope.
- Non-Guardian summary drill paths remain byte-identical — covered by `tests/spelling-parity.test.js` and `tests/spelling-guardian.test.js` characterisation tests.

## Key technical decisions (excerpted from plan)

- **`mode: 'trouble' + practiceOnly: true`** (existing safe flag), not a new dedicated mode. Avoids duplicating the entire session/summary/Word Bank scaffolding.
- **`ui.summary?.mode` is the source of truth**, not a payload field. Comment at the handler site flags: "summary-phase persistence across refresh is out of scope today; refactors that change this must re-validate the practiceOnly path."
- **Practice-button identity copy** is fixed ("Optional practice. Mega and Guardian schedule will not change. Official recovery check returns tomorrow."). Every deviation weakens the separation between Guardian's single-attempt contract and the optional practice loop — see plan Key Technical Decisions.

## Test plan

- [x] `tests/spelling-view-model.test.js` — 2 new tests: `guardianPracticeActionLabel()` + `guardianSummaryCopy()` canonical content.
- [x] `tests/spelling-parity.test.js` — 1 new characterisation test: legacy Smart Review drill-all stays `mode: 'trouble'` + `practiceOnly` unset.
- [x] `tests/spelling-guardian.test.js` — 5 new tests: legacy drill / drill-single characterisation, Guardian drill-all dispatch, end-to-end practice round preserves stage/dueDay/lastDay/guardian snapshot, practice-only summary `mode === 'trouble'`.
- [x] `tests/react-spelling-surface.test.js` — 4 new surface tests: non-Guardian summary unchanged, Guardian summary shows Practice button + copy, per-word drill-single chips hidden, zero-mistake Guardian summary has no Practice button.
- [x] Full `npm test` sweep: 1776 pass, 1 fail. The single failure is `tests/grammar-production-smoke.test.js` (grammar.startModel.stats.templates exposed — pre-existing on `main` at `dfc910a`, confirmed by running the same test on `main` during U3 development; unrelated to U3 scope).