### PR TITLE
feat(punctuation): U8 strip contextPack from child learner read-model

### DIFF
--- a/src/subjects/punctuation/client-read-models.js
+++ b/src/subjects/punctuation/client-read-models.js
@@ -15,12 +15,25 @@ function currentUi(getState, learnerId = null) {
   };
 }
 
+// Phase 3 U8 (origin R34): child learner read-model never carries `contextPack`.
+// The Worker `buildPunctuationReadModel` already drops it at assembly time; this
+// belt-and-braces strip catches any future regression (e.g. a synthetic payload
+// loaded from a stale cache or a scope-parameter change) before it reaches the
+// React surface. See docs/plans/2026-04-25-005-*.md U8.
+function stripForbiddenChildScopeFields(state) {
+  if (!state || typeof state !== 'object' || Array.isArray(state)) return state;
+  if (!('contextPack' in state)) return state;
+  const { contextPack: _ignored, ...rest } = state;
+  return rest;
+}
+
 export function createPunctuationReadModelService({ getState } = {}) {
   return {
     initState(rawState) {
-      return rawState && typeof rawState === 'object' && !Array.isArray(rawState)
+      const base = rawState && typeof rawState === 'object' && !Array.isArray(rawState)
         ? { ...createInitialPunctuationState(), ...clone(rawState) }
         : createInitialPunctuationState();
+      return stripForbiddenChildScopeFields(base);
     },
     getPrefs(learnerId) {
       return normalisePunctuationPrefs(currentUi(getState, learnerId).ui.prefs);

--- a/src/subjects/punctuation/command-actions.js
+++ b/src/subjects/punctuation/command-actions.js
@@ -74,6 +74,13 @@ export const punctuationSubjectCommandActions = Object.freeze({
       return withCommandExpectation({}, state);
     },
   },
+  // Retained for a future Parent/Admin surface (origin R34) — NOT dispatched
+  // by any child scene post-Phase-3. The Worker command still exists at
+  // `worker/src/subjects/punctuation/commands.js` (`request-context-pack`) and
+  // the AI enrichment pipeline in `worker/src/subjects/punctuation/ai-enrichment.js`
+  // continues to work. Child-scope read-models intentionally omit the resulting
+  // `contextPack` summary — see `worker/src/subjects/punctuation/read-models.js`
+  // and the belt-and-braces strip in `client-read-models.js`.
   'punctuation-context-pack': {
     mutates: false,
     command: 'request-context-pack',

--- a/tests/punctuation-read-models.test.js
+++ b/tests/punctuation-read-models.test.js
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { buildPunctuationReadModel } from '../worker/src/subjects/punctuation/read-models.js';
+import { createPunctuationReadModelService } from '../src/subjects/punctuation/client-read-models.js';
 
 const BASE_STATE = {
   phase: 'summary',
@@ -140,10 +141,11 @@ test('analytics payload fails closed on forbidden fields', () => {
   }), /server-only .*field: rubric/);
 });
 
-test('contextPack allowlist strips forbidden fields before the recursive scan', () => {
-  // contextPack goes through safeContextPackSummary's allowlist, so a
-  // forbidden field never reaches the payload. Defence-in-depth happens
-  // earlier; the scan covers clone-passthrough paths instead.
+test('default child-scope payload does not carry contextPack (U8)', () => {
+  // Phase 3 U8: even when the Worker composes a read-model with a fully
+  // populated context-pack summary, the child-scope payload must not
+  // expose the `contextPack` key. Parent/Admin surfaces will opt back in
+  // via a future scope parameter; today child is the only caller.
   const result = buildPunctuationReadModel({
     learnerId: 'learner-a',
     state: BASE_STATE,
@@ -157,8 +159,17 @@ test('contextPack allowlist strips forbidden fields before the recursive scan', 
       generator: { seed: 'leak' },
     },
   });
-  assert.equal(result.contextPack.acceptedCount, 3);
-  assert.equal('generator' in result.contextPack, false);
+  assert.equal('contextPack' in result, false);
+});
+
+test('child-scope payload has no contextPack key when contextPack arg is omitted (U8)', () => {
+  const result = buildPunctuationReadModel({
+    learnerId: 'learner-a',
+    state: BASE_STATE,
+    prefs: {},
+    stats: {},
+  });
+  assert.equal('contextPack' in result, false);
 });
 
 test('stats payload fails closed on forbidden fields', () => {
@@ -219,6 +230,36 @@ test('scan catches rawGenerator, queueItemIds, and responses at any depth', () =
   }
 });
 
+test('client normaliser drops contextPack if the worker ever re-adds it (U8 belt-and-braces)', () => {
+  // Guards against a future Worker regression that sneaks `contextPack` back
+  // into the default child-scope payload. The cache-hydration path must strip
+  // the field before the React surface ever sees it.
+  const service = createPunctuationReadModelService({ getState: () => null });
+  const rawFromWorker = {
+    subjectId: 'punctuation',
+    phase: 'summary',
+    contextPack: {
+      status: 'ready',
+      acceptedCount: 3,
+      rejectedCount: 0,
+      atomKinds: ['noun'],
+    },
+  };
+  const normalised = service.initState(rawFromWorker);
+  assert.equal('contextPack' in normalised, false);
+});
+
+test('client normaliser passes through an ordinary payload unchanged (U8)', () => {
+  const service = createPunctuationReadModelService({ getState: () => null });
+  const normalised = service.initState({
+    subjectId: 'punctuation',
+    phase: 'setup',
+    error: '',
+  });
+  assert.equal(normalised.phase, 'setup');
+  assert.equal('contextPack' in normalised, false);
+});
+
 test('clean payloads with all allowed fields pass redaction', () => {
   const result = buildPunctuationReadModel({
     learnerId: 'learner-a',
@@ -230,6 +271,7 @@ test('clean payloads with all allowed fields pass redaction', () => {
       releaseId: 'punctuation-r4-full-14-skill-structure',
       skills: [{ id: 'speech', name: 'Speech', clusterId: 'speech' }],
     },
+    // contextPack is intentionally passed but not exposed on the child payload (U8).
     contextPack: {
       status: 'ready',
       acceptedCount: 3,
@@ -241,6 +283,6 @@ test('clean payloads with all allowed fields pass redaction', () => {
   });
   assert.equal(result.phase, 'summary');
   assert.equal(result.summary.correctCount, 2);
-  assert.equal(result.contextPack.acceptedCount, 3);
+  assert.equal('contextPack' in result, false);
   assert.equal(result.content.skills[0].id, 'speech');
 });

--- a/tests/punctuation-read-models.test.js
+++ b/tests/punctuation-read-models.test.js
@@ -250,14 +250,34 @@ test('client normaliser drops contextPack if the worker ever re-adds it (U8 belt
 });
 
 test('client normaliser passes through an ordinary payload unchanged (U8)', () => {
+  // Proves the normaliser ran (phase + error survive) without relying on
+  // `'contextPack' in normalised === false` — that would pass vacuously
+  // because `createInitialPunctuationState()` already omits contextPack,
+  // so the assertion held even if stripForbiddenChildScopeFields were a no-op.
   const service = createPunctuationReadModelService({ getState: () => null });
   const normalised = service.initState({
     subjectId: 'punctuation',
     phase: 'setup',
     error: '',
   });
-  assert.equal(normalised.phase, 'setup');
-  assert.equal('contextPack' in normalised, false);
+  assert.strictEqual(normalised.phase, 'setup');
+  assert.strictEqual(normalised.error, '');
+});
+
+test('client-normaliser strip is shallow: nested contextPack is preserved (documented contract)', () => {
+  // Strip only removes top-level `contextPack`, not nested occurrences. The Worker's
+  // assertNoForbiddenReadModelKeys + safeSummary allowlist handle deep-nested forbidden
+  // keys; this client strip is an intentionally cheap top-level last-line-of-defence.
+  const service = createPunctuationReadModelService({ getState: () => null });
+  const normalised = service.initState({
+    subjectId: 'punctuation',
+    phase: 'setup',
+    summary: { contextPack: { status: 'ready' }, total: 3 },
+  });
+  assert.ok(normalised.summary, 'summary should still normalise');
+  assert.strictEqual(normalised.summary.total, 3);
+  assert.ok('contextPack' in normalised.summary, 'nested contextPack is intentionally preserved by shallow strip');
+  assert.strictEqual('contextPack' in normalised, false, 'top-level contextPack is still stripped');
 });
 
 test('clean payloads with all allowed fields pass redaction', () => {

--- a/tests/worker-punctuation-runtime.test.js
+++ b/tests/worker-punctuation-runtime.test.js
@@ -559,7 +559,10 @@ test('punctuation context-pack command returns a named configuration error witho
     assert.equal(result.body.mutation.appliedRevision, 0);
     assert.equal(result.body.contextPack.status, 'unavailable');
     assert.equal(result.body.contextPack.code, 'punctuation_context_provider_missing');
-    assert.equal(result.body.subjectReadModel.contextPack.code, 'punctuation_context_provider_missing');
+    // Phase 3 U8: context-pack summary stays on the top-level response body
+    // (useful for a future Parent/Admin surface) but must not be attached to
+    // the child-scope `subjectReadModel` payload.
+    assert.equal('contextPack' in result.body.subjectReadModel, false);
     assert.equal(harness.DB.db.prepare('SELECT COUNT(*) AS count FROM child_subject_state').get().count, 0);
   } finally {
     harness.close();
@@ -589,7 +592,8 @@ test('punctuation context-pack command rejects malformed configured JSON without
     assert.equal(result.body.contextPack.code, 'punctuation_context_pack_invalid');
     assert.equal(result.body.contextPack.acceptedCount, 0);
     assert.equal(result.body.contextPack.rejectedCount, 1);
-    assert.equal(result.body.subjectReadModel.contextPack.code, 'punctuation_context_pack_invalid');
+    // Phase 3 U8: child-scope `subjectReadModel` no longer carries contextPack.
+    assert.equal('contextPack' in result.body.subjectReadModel, false);
     assert.doesNotMatch(payloadText(result.body), /\{bad json|provider|key/i);
     assert.equal(harness.DB.db.prepare('SELECT COUNT(*) AS count FROM child_subject_state').get().count, 0);
   } finally {
@@ -625,8 +629,11 @@ test('punctuation context-pack command returns only a safe compiler summary when
     assert.equal(result.body.contextPack.acceptedCount, 6);
     assert.equal(result.body.contextPack.affectedGeneratorFamilies.includes('gen_speech_insert'), true);
     assert.equal(result.body.contextPack.generatedItemCount > 0, true);
-    assert.doesNotMatch(payloadText(result.body.subjectReadModel.contextPack), /Maya|ropes|can we start now|well-known|raw|prompt|provider|key/i);
+    // Phase 3 U8: child-scope `subjectReadModel` no longer carries contextPack;
+    // the top-level response body still does for a future Parent/Admin caller.
+    assert.equal('contextPack' in result.body.subjectReadModel, false);
     assert.doesNotMatch(payloadText(result.body.subjectReadModel), /"accepted"|correctIndex|rubric|validator|hiddenQueue|generatorFamilyId/);
+    assert.doesNotMatch(payloadText(result.body.subjectReadModel), /Maya|ropes|can we start now|well-known|raw|prompt|provider|key/i);
   } finally {
     harness.close();
   }

--- a/worker/src/subjects/punctuation/read-models.js
+++ b/worker/src/subjects/punctuation/read-models.js
@@ -180,7 +180,10 @@ function safeSummary(summary) {
   return cloneSerialisable(summary);
 }
 
-function safeContextPackSummary(summary) {
+// Retained for a future Parent/Admin scope wiring (origin R34). Not dispatched
+// by the child read-model since Phase 3 U8; exported so the future caller can
+// reuse the same allowlist rather than reinventing it.
+export function safeContextPackSummary(summary) {
   if (!isPlainObject(summary)) return null;
   return {
     status: summary.status === 'ready' ? 'ready' : (summary.status === 'unavailable' ? 'unavailable' : 'not_requested'),
@@ -228,6 +231,12 @@ export function buildPunctuationReadModel({
   stats,
   analytics = null,
   content = null,
+  // contextPack is accepted for forward compatibility with a future Parent/Admin
+  // scope, but Phase 3 U8 (origin R34) never attaches it to the default child
+  // payload — the child surface never renders it. `safeContextPackSummary` and
+  // `worker/src/subjects/punctuation/ai-enrichment.js` stay in place for that
+  // future caller; today the argument is silently ignored by the read-model.
+  // eslint-disable-next-line no-unused-vars
   contextPack = null,
 } = {}) {
   const safeState = cloneSerialisable(state) || {};
@@ -247,7 +256,6 @@ export function buildPunctuationReadModel({
     prefs: cloneSerialisable(prefs) || {},
     stats: cloneSerialisable(stats) || {},
     analytics: analytics ? cloneSerialisable(analytics) : null,
-    contextPack: safeContextPackSummary(contextPack),
     content: content ? cloneSerialisable(content) : {
       releaseId: PUNCTUATION_RELEASE_ID,
       releaseName: PUNCTUATION_CONTENT_MANIFEST.releaseName,


### PR DESCRIPTION
## Summary
- Worker `buildPunctuationReadModel` no longer attaches `contextPack` to the default child-scope payload (`worker/src/subjects/punctuation/read-models.js`).
- Client normaliser drops `contextPack` defensively if the worker ever re-adds it (belt-and-braces).
- `punctuation-context-pack` client action + `worker/src/subjects/punctuation/ai-enrichment.js` retained for a future Parent/Admin surface with a comment block noting the retention rationale.
- Tests: child-scope payload has no `contextPack` key; client normaliser strips synthetic payloads; context-pack compiler (adult-scope) still works.

## Plan reference
`docs/plans/2026-04-25-005-feat-punctuation-phase3-ux-rebuild-plan.md` — U8. Closes Phase 2 R34 / origin R34.

## Release-id impact
`release-id impact: none` — no engine / content / Oracle-fixture change.

## Test plan
- [x] Default child-scope payload has no `contextPack` key
- [x] Client normaliser defensively strips synthetic contextPack
- [x] `request-context-pack` Worker command still executes (AI enrichment unchanged)
- [x] Phase 2 redaction matrix unchanged
- [x] `npm test` full suite green (two pre-existing unrelated failures observed on main: grammar-production-smoke templates-field flag and one Windows EPERM temp-file flake on verify-capacity-evidence that passes on rerun)