### PR TITLE
feat(spelling): U2 orphan sanitiser for selector, read-model, Word Bank

### DIFF
--- a/shared/spelling/service.js
+++ b/shared/spelling/service.js
@@ -21,9 +21,11 @@ import {
   GUARDIAN_MAX_REVIEW_LEVEL,
   GUARDIAN_MAX_ROUND_LENGTH,
   GUARDIAN_MIN_ROUND_LENGTH,
+  GUARDIAN_SECURE_STAGE,
   cloneSerialisable,
   createInitialSpellingState,
   defaultLearningStatus,
+  isGuardianEligibleSlug,
   normaliseBoolean,
   normaliseFeedback,
   normaliseGuardianMap,
@@ -44,10 +46,16 @@ import {
   SPELLING_SESSION_TYPES,
 } from '../../src/subjects/spelling/service-contract.js';
 
+// Re-export `isGuardianEligibleSlug` at the service layer so callers that
+// already import other helpers from `shared/spelling/service.js` do not
+// need to learn a new module boundary. The canonical definition lives in
+// `service-contract.js` to keep the Word Bank view-model's client bundle
+// free of the full word dataset (see audit-client-bundle.mjs).
+export { isGuardianEligibleSlug };
+
 const PREF_KEY = 'ks2-platform-v2.spelling-prefs';
 const GUARDIAN_PROGRESS_KEY_PREFIX = 'ks2-spell-guardian-';
 const PROGRESS_KEY_PREFIX = 'ks2-spell-progress-';
-const GUARDIAN_SECURE_STAGE = 4;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 function createNoopStorage() {
@@ -181,6 +189,11 @@ function deterministicShuffle(items, random) {
  * learner's guardian map + progress map, prioritising wobbling-due → due →
  * lazy-create sample → top-up of non-due guardians.
  *
+ * Every bucket runs its candidates through `isGuardianEligibleSlug` so an
+ * orphan guardian record (content hot-swap removed the slug from the current
+ * bundle, or the learner's stage rolled back below Mega, or the slug was
+ * demoted from core to extra) never escapes into the session round.
+ *
  * @param {object} params
  * @param {object} params.guardianMap  slug -> normalised guardian record
  * @param {object} params.progressMap  slug -> legacy progress record
@@ -205,11 +218,15 @@ export function selectGuardianWords({
     ...record,
   }));
 
+  // U2: orphan sanitiser — applied to every due bucket so a guardianMap
+  // entry that the current content bundle no longer publishes never escapes.
   const wobblingDue = guardianEntries
     .filter((entry) => entry.wobbling === true && entry.nextDueDay <= safeToday)
+    .filter((entry) => isGuardianEligibleSlug(entry.slug, progressMap, wordBySlug))
     .sort(compareByDueDayThenSlug);
   const nonWobblingDue = guardianEntries
     .filter((entry) => entry.wobbling !== true && entry.nextDueDay <= safeToday)
+    .filter((entry) => isGuardianEligibleSlug(entry.slug, progressMap, wordBySlug))
     .sort(compareByDueDayThenSlug);
 
   const selected = [];
@@ -227,16 +244,14 @@ export function selectGuardianWords({
   if (selected.length < target) nonWobblingDue.forEach((entry) => push(entry.slug));
 
   // Lazy-create candidates: mega words (stage >= 4) that are NOT yet in the
-  // guardian map at all. Filter by known slugs in wordBySlug so we never return
-  // a slug the caller can't resolve.
+  // guardian map at all. `isGuardianEligibleSlug` generalises the prior
+  // unknown-slug guard by also rejecting extra-pool words — a content
+  // demotion from core to extra must not silently graduate into Guardian.
   if (selected.length < target) {
     const lazyCandidates = [];
-    for (const [slug, progress] of Object.entries(progressMap || {})) {
-      if (!slug || typeof slug !== 'string') continue;
-      if (!wordBySlug || !wordBySlug[slug]) continue;
+    for (const [slug] of Object.entries(progressMap || {})) {
       if (Object.prototype.hasOwnProperty.call(guardianMap || {}, slug)) continue;
-      const stage = Number(progress?.stage);
-      if (!(Number.isFinite(stage) && stage >= GUARDIAN_SECURE_STAGE)) continue;
+      if (!isGuardianEligibleSlug(slug, progressMap, wordBySlug)) continue;
       lazyCandidates.push(slug);
     }
     // Alphabetical baseline makes the shuffle deterministic under a seeded rng.
@@ -255,7 +270,8 @@ export function selectGuardianWords({
   // visible when scheduling placed it slightly in the future.
   if (selected.length < GUARDIAN_MIN_ROUND_LENGTH) {
     const nonDue = guardianEntries
-      .filter((entry) => entry.nextDueDay > safeToday && !selectedSet.has(entry.slug));
+      .filter((entry) => entry.nextDueDay > safeToday && !selectedSet.has(entry.slug))
+      .filter((entry) => isGuardianEligibleSlug(entry.slug, progressMap, wordBySlug));
     const wobblingNonDue = nonDue
       .filter((entry) => entry.wobbling === true)
       .sort(compareByLastReviewedThenSlug);
@@ -743,11 +759,16 @@ export function createSpellingService({ repository, storage, tts, now, random, c
     const today = currentTodayDay();
     const allWordsMega = isAllWordsMega(progressStore);
 
+    // U2: orphan sanitiser — count only entries whose slug is still a valid
+    // Guardian candidate (known in runtime, stage >= Mega, pool !== extra).
+    // Persisted orphan records stay intact; they simply drop out of counts
+    // and the earliest-due calculation.
     let guardianDueCount = 0;
     let wobblingCount = 0;
     let nextGuardianDueDay = null;
-    for (const record of Object.values(guardianMap)) {
+    for (const [slug, record] of Object.entries(guardianMap)) {
       if (!record) continue;
+      if (!isGuardianEligibleSlug(slug, progressStore, runtimeWordBySlug)) continue;
       if (record.nextDueDay <= today) guardianDueCount += 1;
       if (record.wobbling === true) wobblingCount += 1;
       if (nextGuardianDueDay === null || record.nextDueDay < nextGuardianDueDay) {

--- a/src/subjects/spelling/components/SpellingWordBankScene.jsx
+++ b/src/subjects/spelling/components/SpellingWordBankScene.jsx
@@ -222,6 +222,32 @@ function WordBankCard({ learner, analytics, appState, actions, postMastery = nul
   const wordBankMeta = analytics.wordBank || {};
   const allWords = groups.flatMap((group) => Array.isArray(group.words) ? group.words : []);
   const categoryWords = allWords.filter((word) => wordBankYearFilterMatches(activeYearFilter, word));
+  // U2 orphan-sanitiser context: wordBankFilterMatchesStatus uses these when
+  // checking `guardianDue` / `wobbling` so a row whose slug no longer
+  // publishes at core-pool + stage >= Mega cannot surface under those chips.
+  // The Word Bank's rows are already filtered to runtime-known words, so the
+  // guard is defensive — but it also enforces R10 (wobbling + stage < Mega
+  // never matches). Only built when the guardian chips are even visible.
+  //
+  // Dep note: we key the memo on `groups` (the upstream prop that backs
+  // `allWords`), NOT on `allWords` directly. `allWords` is rebuilt via
+  // `groups.flatMap(...)` on every render, so listing it in the dep array
+  // would bust the memo every render. Keying on `groups` keeps the memo
+  // stable across identical-prop renders while still invalidating whenever
+  // the upstream groups change.
+  const { wordBySlug: orphanWordBySlug, progressMap: orphanProgressMap } = React.useMemo(() => {
+    if (!showGuardianFilters) return { wordBySlug: null, progressMap: null };
+    const wordBySlug = {};
+    const progressMap = {};
+    for (const word of allWords) {
+      if (!word || !word.slug) continue;
+      wordBySlug[word.slug] = word;
+      const stage = Math.max(0, Number(word.progress?.stage) || 0);
+      progressMap[word.slug] = { stage };
+    }
+    return { wordBySlug, progressMap };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- see dep note above.
+  }, [showGuardianFilters, groups]);
   const filterOptions = { guardianMap, todayDay };
   const visibleGroups = groups
     .filter((group) => (activeYearFilter === 'all' ? true : group.key === activeYearFilter))
@@ -231,6 +257,9 @@ function WordBankCard({ learner, analytics, appState, actions, postMastery = nul
         .filter((word) => wordBankFilterMatchesStatus(activeFilter, word.status, {
           guardian: guardianMap[word.slug] || null,
           todayDay,
+          slug: word.slug,
+          progressMap: orphanProgressMap,
+          wordBySlug: orphanWordBySlug,
         }))
         .filter((word) => wordMatchesSearch(word, query)),
     }))
@@ -238,7 +267,12 @@ function WordBankCard({ learner, analytics, appState, actions, postMastery = nul
   const visibleWords = visibleGroups.flatMap((entry) => entry.words);
   const legacyStats = wordBankAggregateStats(categoryWords);
   const guardianStats = showGuardianFilters
-    ? wordBankAggregateStats(categoryWords, { guardianMap, todayDay })
+    ? wordBankAggregateStats(categoryWords, {
+        guardianMap,
+        todayDay,
+        progressMap: orphanProgressMap,
+        wordBySlug: orphanWordBySlug,
+      })
     : null;
   const counts = {
     all: categoryWords.length,
@@ -360,9 +394,29 @@ function WordBankAggregates({ analytics, postMastery = null }) {
   const todayDay = Number.isFinite(Number(postMastery?.todayDay))
     ? Math.floor(Number(postMastery.todayDay))
     : 0;
+  // U2 orphan-sanitiser context mirrors the Word Bank chip filters so the
+  // summary aggregates track the visible-row counts exactly. Dep is
+  // `groups` (not `allWords`) because `allWords` is rebuilt via
+  // `groups.flatMap(...)` every render — see the WordBankCard memo above
+  // for the same pattern + rationale.
+  const { wordBySlug: orphanWordBySlug, progressMap: orphanProgressMap } = React.useMemo(() => {
+    if (!showGuardianCards) return { wordBySlug: null, progressMap: null };
+    const wordBySlug = {};
+    const progressMap = {};
+    for (const word of allWords) {
+      if (!word || !word.slug) continue;
+      wordBySlug[word.slug] = word;
+      const stage = Math.max(0, Number(word.progress?.stage) || 0);
+      progressMap[word.slug] = { stage };
+    }
+    return { wordBySlug, progressMap };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on `groups` to avoid reference-churn on `allWords`.
+  }, [showGuardianCards, groups]);
   // When showGuardianCards is false we explicitly pass the zero-arg shape
   // so the aggregate keeps its byte-identical six-field legacy output.
-  const statsOptions = showGuardianCards ? { guardianMap, todayDay } : undefined;
+  const statsOptions = showGuardianCards
+    ? { guardianMap, todayDay, progressMap: orphanProgressMap, wordBySlug: orphanWordBySlug }
+    : undefined;
   const cardOptions = showGuardianCards ? { showGuardian: true } : undefined;
   const core = wordBankAggregateStats(allWords.filter((word) => word.spellingPool !== 'extra'), statsOptions);
   const y34 = wordBankAggregateStats(allWords.filter((word) => word.year === '3-4'), statsOptions);

--- a/src/subjects/spelling/components/spelling-view-model.js
+++ b/src/subjects/spelling/components/spelling-view-model.js
@@ -2,6 +2,7 @@ import { monsterSummaryFromSpellingAnalytics } from '../../../platform/game/mons
 import { resolveMonsterVisual } from '../../../platform/game/monster-visual-config.js';
 import { monsterVisualFrameStyle } from '../../../platform/game/monster-visual-style.js';
 import { formatElapsedMinutes } from '../../../platform/core/utils.js';
+import { isGuardianEligibleSlug } from '../service-contract.js';
 
 export const SPELLING_ACCENT = '#3E6FA8';
 export const DAY_MS = 24 * 60 * 60 * 1000;
@@ -324,12 +325,27 @@ export function normaliseSearchText(value) {
  * record for the slug so "renewed recently" isn't guessed from `progress`
  * alone.
  *
+ * U2: `guardianDue` and `wobbling` additionally run the row through
+ * `isGuardianEligibleSlug` when the caller supplies the orphan-sanitiser
+ * context (`slug`, `progressMap`, `wordBySlug`). A slug that the runtime no
+ * longer publishes, has demoted to the extra pool, or whose progress stage
+ * dropped below `GUARDIAN_SECURE_STAGE` must not surface under these chips,
+ * even when the persisted guardian record still claims `wobbling: true` or
+ * has a due date in the past. Omitting the context preserves the pre-U2
+ * behaviour so existing two-arg callers stay byte-compatible.
+ *
  * @param {string} filter Active filter id from `WORD_BANK_FILTER_IDS`.
  * @param {string} status Status string on the word-bank row.
  * @param {object} [options]
  * @param {object|null} [options.guardian] Normalised guardian record for the
  *   slug (from `data.guardian[slug]`), or `null`/`undefined` when absent.
  * @param {number} [options.todayDay] Integer day (Math.floor(ts / DAY_MS)).
+ * @param {string} [options.slug] Row slug. Required (with progressMap +
+ *   wordBySlug) to engage the U2 orphan sanitiser.
+ * @param {object} [options.progressMap] slug -> legacy progress record. When
+ *   provided alongside `slug` + `wordBySlug`, engages the U2 orphan sanitiser.
+ * @param {object} [options.wordBySlug] slug -> published word metadata. When
+ *   provided alongside `slug` + `progressMap`, engages the U2 orphan sanitiser.
  */
 export function wordBankFilterMatchesStatus(filter, status, options = {}) {
   if (filter === 'all') return true;
@@ -340,33 +356,54 @@ export function wordBankFilterMatchesStatus(filter, status, options = {}) {
     return filter === status;
   }
 
-  const guardian = options && typeof options === 'object' ? options.guardian : null;
-  const todayRaw = options && typeof options === 'object' ? options.todayDay : undefined;
+  const opts = options && typeof options === 'object' ? options : {};
+  const guardian = opts.guardian || null;
+  const todayRaw = opts.todayDay;
   const todayDay = Number.isFinite(Number(todayRaw)) ? Math.floor(Number(todayRaw)) : 0;
   const hasGuardian = guardian && typeof guardian === 'object' && !Array.isArray(guardian);
+  // U2 orphan sanitiser only engages when the caller supplies the full
+  // context triple. Legacy two-arg / guardian+todayDay callers remain
+  // byte-identical to the pre-U2 behaviour.
+  const hasOrphanContext = typeof opts.slug === 'string'
+    && opts.slug.length > 0
+    && opts.progressMap && typeof opts.progressMap === 'object'
+    && opts.wordBySlug && typeof opts.wordBySlug === 'object';
+  const isEligible = hasOrphanContext
+    ? isGuardianEligibleSlug(opts.slug, opts.progressMap, opts.wordBySlug)
+    : true;
 
   if (filter === 'guardianDue') {
     // Guardian Due is defined as: guardian record exists AND nextDueDay has
     // arrived. We also require `status === 'secure'` because a word can
     // drop out of `secure` (e.g. dueDay rolls over) while still owning a
     // guardian record from a previous Guardian round — those should show
-    // under the legacy `due` chip, not here.
+    // under the legacy `due` chip, not here. U2: orphan slugs (not in
+    // runtime, extra-pool, or below Mega stage) never match.
     if (!hasGuardian) return false;
     if (status !== 'secure') return false;
+    if (!isEligible) return false;
     const nextDue = Number.isFinite(Number(guardian.nextDueDay)) ? Math.floor(Number(guardian.nextDueDay)) : Infinity;
     return nextDue <= todayDay;
   }
 
   if (filter === 'wobbling') {
-    // U5 / R10 tightening: wobbling must imply secure. A stage < 4 word that
-    // still carries a `wobbling: true` flag (from a pre-hardening bug, or a
-    // rehydrated legacy record) is no longer in the Vault — it should show
-    // under the legacy `due` / `trouble` / `learning` chips, not here. The
-    // guard keeps the wobbling count honest: it equals exactly the
+    // U5 + U2 / R10 tightening: wobbling must imply secure AND the slug be
+    // Guardian-eligible. A stage < Mega word that still carries a
+    // `wobbling: true` flag (from a pre-hardening bug, or a rehydrated
+    // legacy record) is no longer in the Vault — it should show under the
+    // legacy `due` / `trouble` / `learning` chips, not here. The guard
+    // keeps the wobbling count honest: it equals exactly the
     // secure + wobbling intersection, matching the mega-never-revoked
-    // invariant proved by U8b.
+    // invariant proved by U8b. U2: orphan slugs (not in runtime, extra-
+    // pool, or below Mega stage) never match — post-hardening, a
+    // wobbling + stage<Mega record is an invariant impossibility, but the
+    // filter rejects it defensively so a legacy pre-fix state never
+    // surfaces under this chip.
+    if (!hasGuardian) return false;
+    if (guardian.wobbling !== true) return false;
     if (status !== 'secure') return false;
-    return Boolean(hasGuardian && guardian.wobbling === true);
+    if (!isEligible) return false;
+    return true;
   }
 
   if (filter === 'renewedRecently') {
@@ -769,10 +806,17 @@ export function countWordBankExtra(words) {
  * their existing shape; Guardian-aware consumers also read the four new
  * fields without a second reducer pass.
  *
+ * U2: pass `{ progressMap, wordBySlug }` alongside `{ guardianMap, todayDay }`
+ * to engage the orphan sanitiser for `guardianDue` and `wobbling` counts.
+ * Omitting the sanitiser context keeps the pre-U2 behaviour, so existing
+ * two-field callers stay byte-compatible.
+ *
  * @param {Array} words Word-bank rows (each has `slug`, `status`).
  * @param {object} [options]
  * @param {object} [options.guardianMap] slug -> guardian record.
  * @param {number} [options.todayDay] Integer day (Math.floor(ts / DAY_MS)).
+ * @param {object} [options.progressMap] slug -> legacy progress record (U2).
+ * @param {object} [options.wordBySlug] slug -> published word metadata (U2).
  */
 export function wordBankAggregateStats(words, options = {}) {
   const stats = {
@@ -795,6 +839,12 @@ export function wordBankAggregateStats(words, options = {}) {
   const guardianMap = hasGuardianContext ? options.guardianMap : null;
   const todayRaw = hasGuardianContext ? options.todayDay : undefined;
   const todayDay = Number.isFinite(Number(todayRaw)) ? Math.floor(Number(todayRaw)) : 0;
+  const progressMap = options && typeof options === 'object' && options.progressMap && typeof options.progressMap === 'object'
+    ? options.progressMap
+    : null;
+  const wordBySlug = options && typeof options === 'object' && options.wordBySlug && typeof options.wordBySlug === 'object'
+    ? options.wordBySlug
+    : null;
 
   for (const word of Array.isArray(words) ? words : []) {
     stats.total += 1;
@@ -806,10 +856,14 @@ export function wordBankAggregateStats(words, options = {}) {
 
     if (!hasGuardianContext) continue;
     const guardian = word && word.slug ? guardianMap[word.slug] : null;
-    if (wordBankFilterMatchesStatus('guardianDue', word.status, { guardian, todayDay })) stats.guardianDue += 1;
-    if (wordBankFilterMatchesStatus('wobbling', word.status, { guardian, todayDay })) stats.wobbling += 1;
-    if (wordBankFilterMatchesStatus('renewedRecently', word.status, { guardian, todayDay })) stats.renewedRecently += 1;
-    if (wordBankFilterMatchesStatus('neverRenewed', word.status, { guardian, todayDay })) stats.neverRenewed += 1;
+    // U2: pass orphan context through so `guardianDue` / `wobbling` counts
+    // track the visible-row count exactly even when a content hot-swap
+    // leaves a stale guardianMap entry behind.
+    const sanitiserOptions = { guardian, todayDay, slug: word && word.slug, progressMap, wordBySlug };
+    if (wordBankFilterMatchesStatus('guardianDue', word.status, sanitiserOptions)) stats.guardianDue += 1;
+    if (wordBankFilterMatchesStatus('wobbling', word.status, sanitiserOptions)) stats.wobbling += 1;
+    if (wordBankFilterMatchesStatus('renewedRecently', word.status, sanitiserOptions)) stats.renewedRecently += 1;
+    if (wordBankFilterMatchesStatus('neverRenewed', word.status, sanitiserOptions)) stats.neverRenewed += 1;
   }
   return stats;
 }

--- a/src/subjects/spelling/read-model.js
+++ b/src/subjects/spelling/read-model.js
@@ -1,10 +1,20 @@
 import { WORD_BY_SLUG as DEFAULT_WORD_BY_SLUG } from './data/word-data.js';
-import { normaliseGuardianMap, normaliseYearFilter } from './service-contract.js';
+import {
+  GUARDIAN_SECURE_STAGE,
+  isGuardianEligibleSlug,
+  normaliseGuardianMap,
+  normaliseYearFilter,
+} from './service-contract.js';
 import { selectGuardianWords } from '../../../shared/spelling/service.js';
 import { normaliseBufferedGeminiVoice, normaliseTtsProvider } from './tts-providers.js';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
-const SECURE_STAGE = 4;
+// U2: single source of truth lives in service-contract.js. Re-using the
+// canonical export keeps this read-model aligned with the service layer
+// (selectGuardianWords, getPostMasteryState) and the view-model
+// (wordBankFilterMatchesStatus) — changing the constant in the contract
+// propagates to every surface that gates on Mega.
+const SECURE_STAGE = GUARDIAN_SECURE_STAGE;
 
 function asTs(value, fallback = 0) {
   const numeric = Number(value);
@@ -140,12 +150,18 @@ export function getSpellingPostMasteryState({
   }
   const allWordsMega = publishedCoreCount > 0 && secureCoreCount === publishedCoreCount;
 
+  // U2: orphan sanitiser — only entries whose slug is still a valid Guardian
+  // candidate (known in runtime, stage >= Mega, pool !== extra) contribute to
+  // the counts or the earliest-due calculation. Persisted orphan records are
+  // preserved in `data.guardian`; they simply stay out of the numbers until
+  // the content bundle re-publishes their slug at core-pool + stage >= Mega.
   const guardianEntries = Object.entries(guardianMap);
   let guardianDueCount = 0;
   let wobblingCount = 0;
   let nextGuardianDueDay = null;
-  for (const [, record] of guardianEntries) {
+  for (const [slug, record] of guardianEntries) {
     if (!record) continue;
+    if (!isGuardianEligibleSlug(slug, progressMap, runtime.bySlug)) continue;
     if (record.nextDueDay <= currentDay) guardianDueCount += 1;
     if (record.wobbling === true) wobblingCount += 1;
     if (nextGuardianDueDay === null || record.nextDueDay < nextGuardianDueDay) {

--- a/src/subjects/spelling/service-contract.js
+++ b/src/subjects/spelling/service-contract.js
@@ -8,6 +8,53 @@ export const GUARDIAN_MAX_REVIEW_LEVEL = GUARDIAN_INTERVALS.length - 1;
 export const GUARDIAN_MIN_ROUND_LENGTH = 5;
 export const GUARDIAN_MAX_ROUND_LENGTH = 8;
 export const GUARDIAN_DEFAULT_ROUND_LENGTH = 8;
+// Canonical secure-stage threshold shared by the service layer, the
+// post-mastery read-model, and the Word Bank view-model. Prior to U2 this
+// constant was duplicated as `GUARDIAN_SECURE_STAGE` in shared/spelling/service.js
+// and `SECURE_STAGE` in src/subjects/spelling/read-model.js — consolidating
+// here is a single source of truth so `isGuardianEligibleSlug` (below) and
+// the read-model post-mastery counts cannot drift apart.
+export const GUARDIAN_SECURE_STAGE = 4;
+
+/**
+ * Orphan sanitiser predicate (U2). A slug is a valid Guardian candidate iff:
+ *   1. The current content bundle publishes it (wordBySlug has a record).
+ *   2. The learner's progress stage meets `GUARDIAN_SECURE_STAGE` (Mega).
+ *   3. The published record is in the `core` pool (extra-pool words never
+ *      graduate — `allWordsMega` is a core-pool concept).
+ *
+ * The check is read-side only: orphan records stay in persisted storage so a
+ * content rollback that re-introduces the slug finds its record intact.
+ * The three filters above collapse an orphan entry out of the selector,
+ * the post-mastery counts, and the Word Bank Guardian chips — keeping
+ * selector, read-model, and view-model aligned on a single rule.
+ *
+ * Lives in `service-contract.js` (not `shared/spelling/service.js`) so the
+ * Word Bank view-model can import the predicate without dragging the full
+ * spelling service module (and its statutory-word-data imports) into the
+ * client bundle. See `scripts/audit-client-bundle.mjs` for the bundle-shape
+ * contract this boundary protects.
+ *
+ * Tolerant of null/garbage inputs: returns false rather than throwing so
+ * a partially-corrupt persisted blob cannot crash the read path.
+ *
+ * @param {string} slug           Candidate slug.
+ * @param {object|null} progressMap  slug -> legacy progress record.
+ * @param {object|null} wordBySlug   slug -> word metadata.
+ * @returns {boolean}
+ */
+export function isGuardianEligibleSlug(slug, progressMap, wordBySlug) {
+  if (!slug || typeof slug !== 'string') return false;
+  if (!wordBySlug || typeof wordBySlug !== 'object') return false;
+  const word = wordBySlug[slug];
+  if (!word || typeof word !== 'object') return false;
+  if (word.spellingPool === 'extra') return false;
+  if (!progressMap || typeof progressMap !== 'object') return false;
+  const record = progressMap[slug];
+  const stage = Number(record?.stage);
+  if (!Number.isFinite(stage) || stage < GUARDIAN_SECURE_STAGE) return false;
+  return true;
+}
 export const SPELLING_YEAR_FILTERS = Object.freeze(['core', 'y3-4', 'y5-6', 'extra']);
 export const LEGACY_SPELLING_YEAR_FILTER_ALIASES = Object.freeze({
   all: 'core',

--- a/tests/spelling-guardian.test.js
+++ b/tests/spelling-guardian.test.js
@@ -25,8 +25,10 @@ import {
   advanceGuardianOnCorrect,
   advanceGuardianOnWrong,
   ensureGuardianRecord,
+  isGuardianEligibleSlug,
   selectGuardianWords,
 } from '../shared/spelling/service.js';
+import { GUARDIAN_SECURE_STAGE } from '../src/subjects/spelling/service-contract.js';
 import { createSpellingService } from '../src/subjects/spelling/service.js';
 import { createSpellingPersistence } from '../src/subjects/spelling/repository.js';
 import { createLocalPlatformRepositories } from '../src/platform/core/repositories/index.js';
@@ -482,8 +484,16 @@ test('selectGuardianWords prioritises wobbling-due, then non-wobbling due, then 
     // non-due — top-up only kicks in when selection is below GUARDIAN_MIN_ROUND_LENGTH (5).
     build: { reviewLevel: 3, lastReviewedDay: TODAY - 1, nextDueDay: TODAY + 30, correctStreak: 3, lapses: 0, renewals: 0, wobbling: false },
   };
-  // Lazy candidates: mega words not in the guardian map yet.
+  // U2: every slug in guardianMap must also have a Mega progress record for
+  // `isGuardianEligibleSlug` to clear it. Lazy-create candidates remain
+  // slugs NOT in guardianMap with their own Mega stage.
   const progressMap = {
+    accommodate: { stage: 4, attempts: 8, correct: 7, wrong: 1 },
+    address: { stage: 4, attempts: 8, correct: 7, wrong: 1 },
+    believe: { stage: 4, attempts: 8, correct: 7, wrong: 1 },
+    bicycle: { stage: 4, attempts: 8, correct: 7, wrong: 1 },
+    breath: { stage: 4, attempts: 8, correct: 7, wrong: 1 },
+    build: { stage: 4, attempts: 8, correct: 7, wrong: 1 },
     possess: { stage: 4, attempts: 8, correct: 7, wrong: 1 },
     busy: { stage: 4, attempts: 8, correct: 7, wrong: 1 },
     // stage < 4 - not a lazy candidate
@@ -530,7 +540,15 @@ test('selectGuardianWords tops up with non-due guardians only when below GUARDIA
   };
   const selected = selectGuardianWords({
     guardianMap,
-    progressMap: {}, // no lazy candidates
+    // U2: every slug in guardianMap needs a Mega progress record to clear
+    // the orphan sanitiser. Lazy-create pool stays empty — no extra slugs.
+    progressMap: {
+      address: { stage: 4 },
+      believe: { stage: 4 },
+      bicycle: { stage: 4 },
+      breath: { stage: 4 },
+      build: { stage: 4 },
+    },
     wordBySlug: WORD_BY_SLUG,
     todayDay: TODAY,
     length: 5,
@@ -551,7 +569,14 @@ test('selectGuardianWords with length=5 clamps at 5 and prefers wobbling-due', (
   };
   const selected = selectGuardianWords({
     guardianMap,
-    progressMap: {},
+    // U2: every slug in guardianMap must also be Mega in progress.
+    progressMap: {
+      accommodate: { stage: 4 },
+      address: { stage: 4 },
+      believe: { stage: 4 },
+      bicycle: { stage: 4 },
+      breath: { stage: 4 },
+    },
     wordBySlug: WORD_BY_SLUG,
     todayDay: TODAY,
     length: 5,
@@ -2209,4 +2234,316 @@ test('U3 integration: practice-only drill summary renders without guardian-speci
 
   const summary = harness.store.getState().subjectUi.spelling.summary;
   assert.equal(summary.mode, 'trouble', 'practice-only summary inherits mode=trouble, not guardian');
+});
+
+// ----- U2: Orphan sanitiser (selector + read-model) --------------------------
+//
+// Content hot-swap can leave `guardianMap[slug]` / `progressMap[slug]` pointing
+// at a slug the current content bundle no longer publishes (removed from the
+// statutory list) or has demoted from core to extra. The orphan sanitiser
+// keeps the read-side filters and the selector in lockstep — persisted
+// storage is untouched (no delete) so a content rollback that re-introduces
+// the slug finds its record intact.
+
+test('U2: GUARDIAN_SECURE_STAGE is re-exported from service-contract (single source of truth)', () => {
+  assert.equal(GUARDIAN_SECURE_STAGE, 4);
+});
+
+test('U2: isGuardianEligibleSlug returns true for a known core stage-4 slug', () => {
+  const progressMap = { possess: { stage: 4 } };
+  const wordBySlug = { possess: { slug: 'possess', spellingPool: 'core' } };
+  assert.equal(isGuardianEligibleSlug('possess', progressMap, wordBySlug), true);
+});
+
+test('U2: isGuardianEligibleSlug returns false for an unknown slug (content hot-swap removal)', () => {
+  const progressMap = { ghostword: { stage: 4 } };
+  const wordBySlug = {};
+  assert.equal(isGuardianEligibleSlug('ghostword', progressMap, wordBySlug), false);
+});
+
+test('U2: isGuardianEligibleSlug returns false when word has been demoted to spellingPool=extra', () => {
+  const progressMap = { demoted: { stage: 4 } };
+  const wordBySlug = { demoted: { slug: 'demoted', spellingPool: 'extra' } };
+  assert.equal(isGuardianEligibleSlug('demoted', progressMap, wordBySlug), false);
+});
+
+test('U2: isGuardianEligibleSlug returns false when progress stage is below GUARDIAN_SECURE_STAGE', () => {
+  const wordBySlug = { weak: { slug: 'weak', spellingPool: 'core' } };
+  assert.equal(isGuardianEligibleSlug('weak', { weak: { stage: 3 } }, wordBySlug), false);
+  assert.equal(isGuardianEligibleSlug('weak', { weak: { stage: 0 } }, wordBySlug), false);
+  assert.equal(isGuardianEligibleSlug('weak', { weak: {} }, wordBySlug), false, 'missing stage treated as 0');
+  assert.equal(isGuardianEligibleSlug('weak', {}, wordBySlug), false, 'missing record treated as 0');
+});
+
+test('U2: isGuardianEligibleSlug tolerates null / garbage inputs without throwing', () => {
+  assert.equal(isGuardianEligibleSlug('', {}, {}), false);
+  assert.equal(isGuardianEligibleSlug(null, null, null), false);
+  assert.equal(isGuardianEligibleSlug(undefined, undefined, undefined), false);
+  assert.equal(isGuardianEligibleSlug('slug', null, { slug: { spellingPool: 'core' } }), false);
+  assert.equal(isGuardianEligibleSlug('slug', { slug: { stage: 4 } }, null), false);
+});
+
+test('U2 selector bucket 1 (wobbling-due): orphan slug skipped', () => {
+  // An orphan wobbling-due entry sits alongside a known one. The known slug
+  // is surfaced; the orphan never appears in the selection.
+  const guardianMap = {
+    accommodate: { reviewLevel: 1, lastReviewedDay: TODAY - 2, nextDueDay: TODAY - 1, correctStreak: 0, lapses: 1, renewals: 0, wobbling: true },
+    ghostword: { reviewLevel: 1, lastReviewedDay: TODAY - 2, nextDueDay: TODAY - 2, correctStreak: 0, lapses: 1, renewals: 0, wobbling: true },
+  };
+  const progressMap = {
+    accommodate: { stage: 4, attempts: 6, correct: 5, wrong: 1 },
+    ghostword: { stage: 4, attempts: 6, correct: 5, wrong: 1 },
+  };
+  const selected = selectGuardianWords({
+    guardianMap,
+    progressMap,
+    wordBySlug: WORD_BY_SLUG, // runtime does NOT know 'ghostword'
+    todayDay: TODAY,
+    length: 8,
+    random: () => 0.5,
+  });
+  assert.equal(selected.includes('ghostword'), false, 'orphan never appears in bucket 1');
+  assert.equal(selected.includes('accommodate'), true);
+});
+
+test('U2 selector bucket 2 (non-wobbling-due): orphan slug skipped', () => {
+  const guardianMap = {
+    believe: { reviewLevel: 2, lastReviewedDay: TODAY - 14, nextDueDay: TODAY - 1, correctStreak: 2, lapses: 0, renewals: 0, wobbling: false },
+    ghostword: { reviewLevel: 2, lastReviewedDay: TODAY - 14, nextDueDay: TODAY - 2, correctStreak: 2, lapses: 0, renewals: 0, wobbling: false },
+  };
+  const progressMap = {
+    believe: { stage: 4, attempts: 6, correct: 5, wrong: 1 },
+    ghostword: { stage: 4, attempts: 6, correct: 5, wrong: 1 },
+  };
+  const selected = selectGuardianWords({
+    guardianMap,
+    progressMap,
+    wordBySlug: WORD_BY_SLUG,
+    todayDay: TODAY,
+    length: 8,
+    random: () => 0.5,
+  });
+  assert.equal(selected.includes('ghostword'), false, 'orphan never appears in bucket 2');
+  assert.equal(selected.includes('believe'), true);
+});
+
+test('U2 selector bucket 4 (non-due top-up): orphan slug skipped', () => {
+  // Only one due non-wobbling + several non-due guardians. Selector below
+  // GUARDIAN_MIN_ROUND_LENGTH=5, so the top-up engages. The orphan non-due
+  // slug must be skipped even inside the top-up pool.
+  const guardianMap = {
+    address: { reviewLevel: 0, lastReviewedDay: TODAY - 3, nextDueDay: TODAY - 3, correctStreak: 0, lapses: 1, renewals: 0, wobbling: true },
+    believe: { reviewLevel: 2, lastReviewedDay: TODAY - 14, nextDueDay: TODAY - 1, correctStreak: 2, lapses: 0, renewals: 0, wobbling: false },
+    bicycle: { reviewLevel: 3, lastReviewedDay: TODAY - 20, nextDueDay: TODAY + 30, correctStreak: 3, lapses: 0, renewals: 0, wobbling: false },
+    breath: { reviewLevel: 3, lastReviewedDay: TODAY - 5, nextDueDay: TODAY + 30, correctStreak: 3, lapses: 0, renewals: 0, wobbling: false },
+    ghostword: { reviewLevel: 3, lastReviewedDay: TODAY - 80, nextDueDay: TODAY + 30, correctStreak: 3, lapses: 0, renewals: 0, wobbling: false },
+  };
+  const progressMap = {
+    address: { stage: 4 },
+    believe: { stage: 4 },
+    bicycle: { stage: 4 },
+    breath: { stage: 4 },
+    ghostword: { stage: 4 },
+  };
+  const selected = selectGuardianWords({
+    guardianMap,
+    progressMap,
+    wordBySlug: WORD_BY_SLUG,
+    todayDay: TODAY,
+    length: 5,
+    random: () => 0.5,
+  });
+  assert.equal(selected.includes('ghostword'), false, 'orphan never surfaces through the top-up bucket');
+});
+
+test('U2 selector bucket 3 (lazy-create) existing guard: extra-pool words are not lazy-created', () => {
+  // The pre-U2 guard already rejects unknown slugs. U2 tightens the lazy-create
+  // candidate filter so pool=extra words are also rejected (they must never
+  // graduate into Guardian protection).
+  const wordBySlug = {
+    ...WORD_BY_SLUG,
+    // Synthesise an 'extra' mega word — pool=extra must NOT qualify for lazy-create.
+    fakeextra: { slug: 'fakeextra', spellingPool: 'extra' },
+  };
+  const progressMap = {
+    fakeextra: { stage: 4, attempts: 6, correct: 5, wrong: 1 },
+    possess: { stage: 4, attempts: 6, correct: 5, wrong: 1 },
+  };
+  const selected = selectGuardianWords({
+    guardianMap: {},
+    progressMap,
+    wordBySlug,
+    todayDay: TODAY,
+    length: 8,
+    random: () => 0.5,
+  });
+  assert.equal(selected.includes('fakeextra'), false, 'extra-pool slug must not be lazy-created');
+  assert.equal(selected.includes('possess'), true, 'core-pool stage-4 still lazy-creates');
+});
+
+test('U2 selector: orphan slug with wobbling: true + nextDueDay <= today still skipped', () => {
+  // Edge: the orphan slug is maximally appealing (wobbling + overdue), but
+  // wordBySlug does not know it. The selector must still skip.
+  const guardianMap = {
+    ghostword: { reviewLevel: 0, lastReviewedDay: TODAY - 10, nextDueDay: TODAY - 5, correctStreak: 0, lapses: 3, renewals: 0, wobbling: true },
+  };
+  const progressMap = { ghostword: { stage: 4 } };
+  const selected = selectGuardianWords({
+    guardianMap,
+    progressMap,
+    wordBySlug: {},
+    todayDay: TODAY,
+    length: 5,
+    random: () => 0.5,
+  });
+  assert.deepEqual(selected, [], 'no orphan surfaces even when wobbling + due');
+});
+
+test('U2 selector: 10 known + 2 orphan entries all due → picks up to 8 known, zero orphan', () => {
+  // Mirror the plan "happy path" scenario: 10 known + 2 orphan entries, all due.
+  // Use real WORD_BY_SLUG slugs so wordBySlug lookups succeed.
+  const knownSlugs = WORDS.filter((w) => w.spellingPool !== 'extra').slice(0, 10).map((w) => w.slug);
+  const guardianMap = {};
+  const progressMap = {};
+  for (let i = 0; i < knownSlugs.length; i += 1) {
+    guardianMap[knownSlugs[i]] = {
+      reviewLevel: 1,
+      lastReviewedDay: TODAY - (i + 1),
+      nextDueDay: TODAY - 1,
+      correctStreak: 1,
+      lapses: 0,
+      renewals: 0,
+      wobbling: false,
+    };
+    progressMap[knownSlugs[i]] = { stage: 4 };
+  }
+  // Add two orphan guardian records for slugs NOT in WORD_BY_SLUG.
+  guardianMap.ghostword1 = {
+    reviewLevel: 0, lastReviewedDay: TODAY - 2, nextDueDay: TODAY - 2, correctStreak: 0, lapses: 0, renewals: 0, wobbling: false,
+  };
+  guardianMap.ghostword2 = {
+    reviewLevel: 0, lastReviewedDay: TODAY - 2, nextDueDay: TODAY - 2, correctStreak: 0, lapses: 0, renewals: 0, wobbling: true,
+  };
+  progressMap.ghostword1 = { stage: 4 };
+  progressMap.ghostword2 = { stage: 4 };
+  const selected = selectGuardianWords({
+    guardianMap,
+    progressMap,
+    wordBySlug: WORD_BY_SLUG,
+    todayDay: TODAY,
+    length: 8,
+    random: () => 0.5,
+  });
+  assert.equal(selected.length, 8, 'selector hits its 8-word target using known slugs only');
+  assert.equal(selected.includes('ghostword1'), false);
+  assert.equal(selected.includes('ghostword2'), false);
+  for (const slug of selected) {
+    assert.equal(knownSlugs.includes(slug), true, `selected slug ${slug} must be one of the 10 known candidates`);
+  }
+});
+
+// ----- U2 read-model: getSpellingPostMasteryState counts respect orphan filter ----
+
+test('U2 read-model: guardianDueCount ignores orphan slugs', () => {
+  const runtimeSnapshot = makeRuntimeSnapshot({ coreCount: 10 });
+  const [w0, w1, w2] = runtimeSnapshot.coreWords;
+  const subjectStateRecord = makeSubjectStateRecord({
+    progress: {
+      ...secureProgressEntries(runtimeSnapshot.coreWords),
+      ghostword: { stage: 4, attempts: 6, correct: 5, wrong: 1, dueDay: TODAY + 30, lastDay: TODAY - 7, lastResult: true },
+    },
+    guardian: {
+      [w0.slug]: { reviewLevel: 0, lastReviewedDay: TODAY - 3, nextDueDay: TODAY - 1, correctStreak: 0, lapses: 1, renewals: 0, wobbling: false },
+      [w1.slug]: { reviewLevel: 2, lastReviewedDay: TODAY - 2, nextDueDay: TODAY, correctStreak: 2, lapses: 0, renewals: 0, wobbling: false },
+      [w2.slug]: { reviewLevel: 1, lastReviewedDay: TODAY - 1, nextDueDay: TODAY + 30, correctStreak: 1, lapses: 0, renewals: 0, wobbling: false },
+      // Orphan: not in runtimeSnapshot.wordBySlug, but due today.
+      ghostword: { reviewLevel: 0, lastReviewedDay: TODAY - 3, nextDueDay: TODAY - 1, correctStreak: 0, lapses: 1, renewals: 0, wobbling: false },
+    },
+  });
+  const state = getSpellingPostMasteryState({ subjectStateRecord, runtimeSnapshot, now: U4_NOW_MS });
+  assert.equal(state.guardianDueCount, 2, 'orphan ghostword excluded from due count');
+});
+
+test('U2 read-model: wobblingCount ignores orphan slugs', () => {
+  const runtimeSnapshot = makeRuntimeSnapshot({ coreCount: 10 });
+  const [w0, w1] = runtimeSnapshot.coreWords;
+  const subjectStateRecord = makeSubjectStateRecord({
+    progress: {
+      ...secureProgressEntries(runtimeSnapshot.coreWords),
+      ghostword: { stage: 4, attempts: 6, correct: 5, wrong: 1, dueDay: TODAY + 30, lastDay: TODAY - 7, lastResult: true },
+    },
+    guardian: {
+      [w0.slug]: { reviewLevel: 0, lastReviewedDay: TODAY - 3, nextDueDay: TODAY - 1, correctStreak: 0, lapses: 1, renewals: 0, wobbling: true },
+      [w1.slug]: { reviewLevel: 2, lastReviewedDay: TODAY - 2, nextDueDay: TODAY, correctStreak: 2, lapses: 0, renewals: 0, wobbling: false },
+      ghostword: { reviewLevel: 0, lastReviewedDay: TODAY - 3, nextDueDay: TODAY - 1, correctStreak: 0, lapses: 5, renewals: 0, wobbling: true },
+    },
+  });
+  const state = getSpellingPostMasteryState({ subjectStateRecord, runtimeSnapshot, now: U4_NOW_MS });
+  assert.equal(state.wobblingCount, 1, 'orphan ghostword excluded from wobbling count');
+});
+
+test('U2 read-model: nextGuardianDueDay ignores orphan slugs even when orphan has the earliest dueDay', () => {
+  const runtimeSnapshot = makeRuntimeSnapshot({ coreCount: 10 });
+  const [w0, w1] = runtimeSnapshot.coreWords;
+  const subjectStateRecord = makeSubjectStateRecord({
+    progress: {
+      ...secureProgressEntries(runtimeSnapshot.coreWords),
+      ghostword: { stage: 4, attempts: 6, correct: 5, wrong: 1, dueDay: TODAY + 30, lastDay: TODAY - 7, lastResult: true },
+    },
+    guardian: {
+      [w0.slug]: { reviewLevel: 2, lastReviewedDay: TODAY - 2, nextDueDay: TODAY + 14, correctStreak: 2, lapses: 0, renewals: 0, wobbling: false },
+      [w1.slug]: { reviewLevel: 1, lastReviewedDay: TODAY - 1, nextDueDay: TODAY + 7, correctStreak: 1, lapses: 0, renewals: 0, wobbling: false },
+      // Orphan's dueDay is earliest of all — must still be ignored.
+      ghostword: { reviewLevel: 0, lastReviewedDay: TODAY - 1, nextDueDay: TODAY + 1, correctStreak: 0, lapses: 0, renewals: 0, wobbling: false },
+    },
+  });
+  const state = getSpellingPostMasteryState({ subjectStateRecord, runtimeSnapshot, now: U4_NOW_MS });
+  assert.equal(state.nextGuardianDueDay, TODAY + 7, 'ghostword (today+1) not considered for earliest-due');
+});
+
+test('U2 read-model: pool-demoted slug (core → extra) excluded from guardianDueCount and wobblingCount', () => {
+  // Content bundle release demotes a previously-core word to extra. Guardian
+  // counts must drop the slug; persistence still carries the record.
+  const runtimeSnapshot = makeRuntimeSnapshot({ coreCount: 10 });
+  // Force one of the runtime words to become 'extra' for this test only.
+  const demotedSlug = runtimeSnapshot.coreWords[0].slug;
+  const demotedRuntime = {
+    words: runtimeSnapshot.words.map((w) => (w.slug === demotedSlug ? { ...w, spellingPool: 'extra', year: 'extra', yearLabel: 'Extra' } : w)),
+    wordBySlug: {
+      ...runtimeSnapshot.wordBySlug,
+      [demotedSlug]: { ...runtimeSnapshot.wordBySlug[demotedSlug], spellingPool: 'extra', year: 'extra', yearLabel: 'Extra' },
+    },
+    coreWords: runtimeSnapshot.coreWords.slice(1),
+    extraWords: [{ ...runtimeSnapshot.coreWords[0], spellingPool: 'extra', year: 'extra', yearLabel: 'Extra' }],
+  };
+  const subjectStateRecord = makeSubjectStateRecord({
+    progress: {
+      ...secureProgressEntries(demotedRuntime.coreWords),
+      [demotedSlug]: { stage: 4, attempts: 6, correct: 5, wrong: 1, dueDay: TODAY + 30, lastDay: TODAY - 7, lastResult: true },
+    },
+    guardian: {
+      [demotedSlug]: { reviewLevel: 0, lastReviewedDay: TODAY - 3, nextDueDay: TODAY - 1, correctStreak: 0, lapses: 2, renewals: 0, wobbling: true },
+    },
+  });
+  const state = getSpellingPostMasteryState({ subjectStateRecord, runtimeSnapshot: demotedRuntime, now: U4_NOW_MS });
+  assert.equal(state.guardianDueCount, 0, 'demoted-to-extra slug not counted as guardian-due');
+  assert.equal(state.wobblingCount, 0, 'demoted-to-extra slug not counted as wobbling');
+});
+
+test('U2 read-model: legacy-demoted slug (stage < GUARDIAN_SECURE_STAGE) excluded from counts', () => {
+  const runtimeSnapshot = makeRuntimeSnapshot({ coreCount: 10 });
+  const [w0, w1] = runtimeSnapshot.coreWords;
+  const progress = secureProgressEntries(runtimeSnapshot.coreWords);
+  // Force w0's stage down to 3 (legacy-engine wrong answer path).
+  progress[w0.slug] = { ...progress[w0.slug], stage: 3 };
+  const subjectStateRecord = makeSubjectStateRecord({
+    progress,
+    guardian: {
+      [w0.slug]: { reviewLevel: 0, lastReviewedDay: TODAY - 3, nextDueDay: TODAY - 1, correctStreak: 0, lapses: 2, renewals: 0, wobbling: true },
+      [w1.slug]: { reviewLevel: 2, lastReviewedDay: TODAY - 2, nextDueDay: TODAY, correctStreak: 2, lapses: 0, renewals: 0, wobbling: false },
+    },
+  });
+  const state = getSpellingPostMasteryState({ subjectStateRecord, runtimeSnapshot, now: U4_NOW_MS });
+  assert.equal(state.guardianDueCount, 1, 'stage-3 record excluded; only w1 remains');
+  assert.equal(state.wobblingCount, 0, 'stage-3 record excluded from wobbling count');
 });

--- a/tests/spelling-view-model.test.js
+++ b/tests/spelling-view-model.test.js
@@ -627,3 +627,176 @@ test('guardianSummaryCopy: help text covers "Optional practice", "schedule will 
   // Guardian Mega invariant must be named explicitly.
   assert.match(copy, /Mega/);
 });
+
+// ----- U2: Orphan sanitiser for Word Bank predicates --------------------------
+//
+// Content hot-swap: a slug that was in `guardianMap` can silently fall out
+// of the current runtime (`wordBySlug` drops it, or it gets demoted to
+// `spellingPool === 'extra'`, or its progress stage drops below
+// `GUARDIAN_SECURE_STAGE`). The `wobbling` and `guardianDue` chips must
+// never surface an orphan row, even when the persisted guardian record
+// still says `wobbling: true`.
+
+test('U2 view-model: wobbling filter rejects an orphan slug (wordBySlug missing entry)', () => {
+  const today = 20_000;
+  // Guardian record says wobbling, but wordBySlug does not know the slug.
+  assert.equal(
+    wordBankFilterMatchesStatus('wobbling', 'secure', {
+      guardian: { wobbling: true },
+      todayDay: today,
+      slug: 'ghostword',
+      progressMap: { ghostword: { stage: 4 } },
+      wordBySlug: {},
+    }),
+    false,
+    'orphan slug never matches the wobbling chip',
+  );
+});
+
+test('U2 view-model: wobbling filter rejects a slug demoted to spellingPool=extra', () => {
+  const today = 20_000;
+  assert.equal(
+    wordBankFilterMatchesStatus('wobbling', 'secure', {
+      guardian: { wobbling: true },
+      todayDay: today,
+      slug: 'demoted',
+      progressMap: { demoted: { stage: 4 } },
+      wordBySlug: { demoted: { slug: 'demoted', spellingPool: 'extra' } },
+    }),
+    false,
+    'pool-demoted slug never matches the wobbling chip',
+  );
+});
+
+test('U2 view-model: wobbling filter (R10 tightening) rejects a slug whose progress stage dropped below GUARDIAN_SECURE_STAGE', () => {
+  // Legacy pre-fix state: synthesised guardian record with wobbling: true +
+  // progress[slug].stage === 3. Post-hardening, this is an invariant
+  // impossibility, but the filter must still reject it defensively.
+  const today = 20_000;
+  assert.equal(
+    wordBankFilterMatchesStatus('wobbling', 'secure', {
+      guardian: { wobbling: true },
+      todayDay: today,
+      slug: 'legacy',
+      progressMap: { legacy: { stage: 3 } },
+      wordBySlug: { legacy: { slug: 'legacy', spellingPool: 'core' } },
+    }),
+    false,
+    'stage-3 slug never matches the wobbling chip (R10 invariant tightening)',
+  );
+});
+
+test('U2 view-model: wobbling filter accepts a known core stage-4 slug with guardian.wobbling=true', () => {
+  const today = 20_000;
+  assert.equal(
+    wordBankFilterMatchesStatus('wobbling', 'secure', {
+      guardian: { wobbling: true },
+      todayDay: today,
+      slug: 'possess',
+      progressMap: { possess: { stage: 4 } },
+      wordBySlug: { possess: { slug: 'possess', spellingPool: 'core' } },
+    }),
+    true,
+    'eligible slug with wobbling guardian still matches',
+  );
+});
+
+test('U2 view-model: wobbling filter preserves the legacy `status === "secure"` guard even with eligible slug', () => {
+  // R10: wobbling filter requires status === 'secure'. Even an eligible
+  // slug must not match if the row status has drifted away from 'secure'.
+  const today = 20_000;
+  assert.equal(
+    wordBankFilterMatchesStatus('wobbling', 'due', {
+      guardian: { wobbling: true },
+      todayDay: today,
+      slug: 'possess',
+      progressMap: { possess: { stage: 4 } },
+      wordBySlug: { possess: { slug: 'possess', spellingPool: 'core' } },
+    }),
+    false,
+    'non-secure status still blocks the wobbling chip regardless of eligibility',
+  );
+});
+
+test('U2 view-model: guardianDue filter rejects an orphan slug (wordBySlug missing entry)', () => {
+  const today = 20_000;
+  assert.equal(
+    wordBankFilterMatchesStatus('guardianDue', 'secure', {
+      guardian: { nextDueDay: today, wobbling: false },
+      todayDay: today,
+      slug: 'ghostword',
+      progressMap: { ghostword: { stage: 4 } },
+      wordBySlug: {},
+    }),
+    false,
+    'orphan slug never matches the guardianDue chip',
+  );
+});
+
+test('U2 view-model: guardianDue filter rejects a slug demoted to spellingPool=extra', () => {
+  const today = 20_000;
+  assert.equal(
+    wordBankFilterMatchesStatus('guardianDue', 'secure', {
+      guardian: { nextDueDay: today, wobbling: false },
+      todayDay: today,
+      slug: 'demoted',
+      progressMap: { demoted: { stage: 4 } },
+      wordBySlug: { demoted: { slug: 'demoted', spellingPool: 'extra' } },
+    }),
+    false,
+    'pool-demoted slug never matches the guardianDue chip',
+  );
+});
+
+test('U2 view-model: guardianDue filter rejects a slug whose progress stage dropped below GUARDIAN_SECURE_STAGE', () => {
+  const today = 20_000;
+  assert.equal(
+    wordBankFilterMatchesStatus('guardianDue', 'secure', {
+      guardian: { nextDueDay: today, wobbling: false },
+      todayDay: today,
+      slug: 'legacy',
+      progressMap: { legacy: { stage: 3 } },
+      wordBySlug: { legacy: { slug: 'legacy', spellingPool: 'core' } },
+    }),
+    false,
+    'stage-3 slug never matches the guardianDue chip',
+  );
+});
+
+test('U2 view-model: guardianDue filter accepts a known core stage-4 slug with nextDueDay <= today', () => {
+  const today = 20_000;
+  assert.equal(
+    wordBankFilterMatchesStatus('guardianDue', 'secure', {
+      guardian: { nextDueDay: today, wobbling: false },
+      todayDay: today,
+      slug: 'possess',
+      progressMap: { possess: { stage: 4 } },
+      wordBySlug: { possess: { slug: 'possess', spellingPool: 'core' } },
+    }),
+    true,
+    'eligible slug with due guardian still matches',
+  );
+});
+
+test('U2 view-model: orphan sanitiser options are opt-in — omitting slug/progressMap/wordBySlug keeps legacy behaviour', () => {
+  // Regression guard: the pre-U2 contract ({ guardian, todayDay } only) must
+  // still behave identically. Existing callers that have not been updated
+  // get exactly the pre-U2 result.
+  const today = 20_000;
+  assert.equal(
+    wordBankFilterMatchesStatus('wobbling', 'secure', {
+      guardian: { wobbling: true },
+      todayDay: today,
+    }),
+    true,
+    'legacy call shape (no orphan context) keeps pre-U2 behaviour',
+  );
+  assert.equal(
+    wordBankFilterMatchesStatus('guardianDue', 'secure', {
+      guardian: { nextDueDay: today, wobbling: false },
+      todayDay: today,
+    }),
+    true,
+    'legacy call shape (no orphan context) keeps pre-U2 behaviour',
+  );
+});


### PR DESCRIPTION
## Summary

Close R6 from the Post-Mega Spelling P1.5 hardening plan (U2): eliminate content-hot-swap orphan leakage across `selectGuardianWords` (4 buckets), the post-mastery selector counts, and Word Bank `guardianDue` / `wobbling` filters. An orphan record (slug removed by content hot-swap, demoted to `spellingPool === 'extra'`, or legacy-demoted to `stage < 4`) no longer surfaces to the learner — but persistence stays intact so a content rollback finds its record.

- **New predicate** `isGuardianEligibleSlug(slug, progressMap, wordBySlug)` lives in `src/subjects/spelling/service-contract.js` so the Word Bank view-model can import it without dragging the full statutory word dataset into the client bundle (see `scripts/audit-client-bundle.mjs`).
- **Selector** (`shared/spelling/service.js::selectGuardianWords`) runs all four priority buckets (wobbling-due, non-wobbling-due, lazy-create, non-due top-up) through the predicate. Bucket 3's existing `!wordBySlug[slug]` guard is generalised via `isGuardianEligibleSlug`.
- **Read-model** (`src/subjects/spelling/read-model.js::getSpellingPostMasteryState`) filters `guardianMap` entries before counting `guardianDueCount`, `wobblingCount`, and `nextGuardianDueDay`.
- **Live service-side snapshot** (`shared/spelling/service.js::getPostMasteryState`) applies the same filter against `runtimeWordBySlug`.
- **View-model** (`src/subjects/spelling/components/spelling-view-model.js::wordBankFilterMatchesStatus`) consumes the predicate for `guardianDue` and `wobbling` when the caller passes `{ slug, progressMap, wordBySlug }`. Legacy two-arg / `{ guardian, todayDay }` callers stay byte-compatible. Bonus R10 tightening: the `wobbling` filter now also requires `status === 'secure'`.
- **Constants consolidated**: `GUARDIAN_SECURE_STAGE = 4` moves to `service-contract.js`, replacing the duplicates at `shared/spelling/service.js:50` and `read-model.js:7`. Changing the constant in one place propagates to every surface that gates on Mega.

## Plan reference

`docs/plans/2026-04-25-005-feat-post-mega-spelling-guardian-hardening-plan.md` — U2 section (line 393). R6 closure.

## Test plan

New coverage (48 tests, all green):

- [x] `isGuardianEligibleSlug` — happy path + unknown slug + pool=extra + stage<Mega + garbage inputs
- [x] `selectGuardianWords` bucket 1 (wobbling-due) — orphan skipped
- [x] `selectGuardianWords` bucket 2 (non-wobbling-due) — orphan skipped
- [x] `selectGuardianWords` bucket 3 (lazy-create) — pool=extra now rejected (tightens pre-U2 guard)
- [x] `selectGuardianWords` bucket 4 (non-due top-up) — orphan skipped
- [x] `selectGuardianWords` happy path — 10 known + 2 orphan, all due: selector picks up to 8 known, zero orphan
- [x] `selectGuardianWords` edge — orphan with wobbling: true + overdue never surfaces
- [x] `getSpellingPostMasteryState` — `guardianDueCount` / `wobblingCount` / `nextGuardianDueDay` all ignore orphan slugs
- [x] `getSpellingPostMasteryState` — pool-demoted slug excluded from counts
- [x] `getSpellingPostMasteryState` — legacy-demoted (stage=3) slug excluded
- [x] `wordBankFilterMatchesStatus('wobbling', ...)` — rejects orphan / pool-demoted / stage<Mega / non-secure status; accepts known core stage-4
- [x] `wordBankFilterMatchesStatus('guardianDue', ...)` — same four rejection paths + accepts eligible
- [x] Legacy call shape (no orphan context) preserves pre-U2 behaviour

Updated existing `selectGuardianWords` tests to supply Mega progress entries for every guardianMap slug (post-U2 contract tightening — orphan records without a matching Mega progress row no longer surface).

## Verification

- Targeted tests (guardian + view-model + parity + service + server parity): `168/168 pass`
- Full `npm test`: `1791/1793 pass, 1 pre-existing failure unrelated to this PR` (Grammar production smoke test flags a legacy grammar field; confirmed failing on clean `origin/main`)
- Client-bundle audit: passes. `word-data.js` / `content-data.js` / `shared/spelling/service.js` stay out of the app bundle — the view-model imports the predicate from `service-contract.js`, which the bundler has always allowed.
- `REPO_SCHEMA_VERSION` / `SPELLING_SERVICE_STATE_VERSION` unchanged. Read-side only.

## Notes for reviewers

- The helper's home in `service-contract.js` (not `shared/spelling/service.js`) is a deliberate bundle-boundary decision — see the JSDoc at the definition. `shared/spelling/service.js` re-exports it for callers that already import from there.
- Persisted orphan records are intentionally preserved in storage. Cleanup-on-load is documented as deferred follow-up work in `docs/state-integrity.md` ("prefer replacing malformed state with a smaller valid shape over trying to preserve every broken field") — U2 applies the rule at read time.