### PR TITLE
feat(punctuation): U5 Map phase + PunctuationMapScene

### DIFF
--- a/src/platform/app/create-app-controller.js
+++ b/src/platform/app/create-app-controller.js
@@ -483,6 +483,13 @@ export function createAppController({
     getSnapshot,
     subscribe,
     dispatch,
+    // Exposed for tests that need the subject-handler's truthy/falsy return
+    // value. Production callers should always use `dispatch` (which wraps
+    // `handleSubjectAction` in the autoAdvance / audio lifecycle and
+    // swallows the boolean); adv-219-007's refuse-to-dispatch assertion
+    // pairs the raw handler return with a state-level check to close
+    // learning #7's silent-no-op gap.
+    handleSubjectAction,
     keydown,
     autoAdvance,
     scheduler,

--- a/src/platform/core/store.js
+++ b/src/platform/core/store.js
@@ -42,7 +42,7 @@ function makeLearner(name = 'Learner 1') {
   };
 }
 
-function buildSubjectUiState(subject, persistedEntry = null) {
+function buildSubjectUiState(subject, persistedEntry = null, { rehydrate = false } = {}) {
   const initialState = subject.initState();
   if (!initialState || typeof initialState !== 'object' || Array.isArray(initialState)) {
     throw new TypeError(`Subject "${subject.id}" initState() must return an object.`);
@@ -52,17 +52,28 @@ function buildSubjectUiState(subject, persistedEntry = null) {
     ? persistedEntry
     : null;
 
+  // On rehydrate (boot over a persisted `subjectStates` snapshot), subjects
+  // may opt-in to sanitise the persisted entry before it merges over
+  // defaults — typically to strip session-ephemeral fields (e.g. Punctuation
+  // U5's `phase: 'map'` + `mapUi`) that must never echo back across a
+  // reload. Live `updateSubjectUi` dispatches (which rebuild entries from
+  // the current in-memory snapshot) pass `rehydrate: false`, so the Map
+  // phase remains legitimate while the session is active.
+  const sanitisedPersisted = (rehydrate && persisted && typeof subject.sanitiseUiOnRehydrate === 'function')
+    ? subject.sanitiseUiOnRehydrate(persisted)
+    : persisted;
+
   return {
     ...DEFAULT_SUBJECT_UI,
     ...initialState,
-    ...(persisted || {}),
+    ...(sanitisedPersisted || {}),
   };
 }
 
-function buildSubjectUiTree(subjects, persistedUi = {}) {
+function buildSubjectUiTree(subjects, persistedUi = {}, { rehydrate = false } = {}) {
   return Object.fromEntries(subjects.map((subject) => [
     subject.id,
-    buildSubjectUiState(subject, persistedUi[subject.id] || null),
+    buildSubjectUiState(subject, persistedUi[subject.id] || null, { rehydrate }),
   ]));
 }
 
@@ -269,12 +280,12 @@ function stateFromRepositories(subjects, repositories) {
   };
 }
 
-function sanitiseState(rawState, subjects) {
+function sanitiseState(rawState, subjects, { rehydrate = false } = {}) {
   const learners = normaliseLearnersSnapshot(rawState?.learners);
   return {
     route: normaliseRoute(rawState?.route, subjects),
     learners,
-    subjectUi: buildSubjectUiTree(subjects, rawState?.subjectUi || {}),
+    subjectUi: buildSubjectUiTree(subjects, rawState?.subjectUi || {}, { rehydrate }),
     persistence: normalisePersistenceSnapshot(rawState?.persistence),
     transientUi: normaliseTransientUi(rawState?.transientUi),
     toasts: normaliseToasts(rawState?.toasts),
@@ -285,13 +296,24 @@ function sanitiseState(rawState, subjects) {
 function subjectUiForLearner(registry, repositories, learnerId) {
   const records = learnerId ? repositories.subjectStates.readForLearner(learnerId) : {};
   const persistedUi = Object.fromEntries(Object.entries(records).map(([subjectId, record]) => [subjectId, record.ui]));
-  return buildSubjectUiTree(registry, persistedUi);
+  // Switching between learners re-reads each subject's UI from the persisted
+  // snapshot, so this is a rehydrate path too — ephemeral fields (e.g.
+  // Punctuation's `phase: 'map'`) must be sanitised on entry.
+  return buildSubjectUiTree(registry, persistedUi, { rehydrate: true });
 }
 
 export function createStore(subjects, { repositories, cacheSubjectUiWrites = false } = {}) {
   const registry = buildSubjectRegistry(subjects);
   const resolvedRepositories = validatePlatformRepositories(repositories);
-  let state = sanitiseState(stateFromRepositories(registry, resolvedRepositories), registry);
+  // Initial bootstrap reads every subject UI from the persisted snapshot —
+  // this is the canonical rehydrate path, so ephemeral fields (e.g.
+  // Punctuation U5's `phase: 'map'` + `mapUi`) get sanitised before the
+  // store serves its first `getState()`.
+  let state = sanitiseState(
+    stateFromRepositories(registry, resolvedRepositories),
+    registry,
+    { rehydrate: true },
+  );
   const listeners = new Set();
 
   function notify() {
@@ -304,6 +326,9 @@ export function createStore(subjects, { repositories, cacheSubjectUiWrites = fal
 
   function setState(updater) {
     const nextState = typeof updater === 'function' ? updater(state) : updater;
+    // Live updates: rehydrate flag stays false, so session-ephemeral
+    // sanitisers fire only on bootstrap / learner switch, never on each
+    // dispatch.
     state = sanitiseState(nextState, registry);
     notify();
   }

--- a/src/platform/core/store.js
+++ b/src/platform/core/store.js
@@ -346,13 +346,22 @@ export function createStore(subjects, { repositories, cacheSubjectUiWrites = fal
     const previousRoute = state.route;
     const previousMonsterCelebrations = state.monsterCelebrations;
     const nextState = stateFromRepositories(registry, resolvedRepositories);
+    // adv-219-006: `reloadFromRepositories` re-reads every subject UI entry
+    // from the persisted `subjectStates` snapshot, which makes this a
+    // rehydrate path just like bootstrap (createStore) and learner-switch
+    // (subjectUiForLearner). Without `rehydrate: true` the persisted entry
+    // would shallow-merge straight over defaults, echoing
+    // `phase: 'map'` + `mapUi` back into in-memory state — defeating the
+    // bootstrap sanitiser on persistence-retry, learner-deletion,
+    // server-synced settings, clear-all-progress, import-snapshot, and the
+    // Punctuation command response adapter. Thread the flag through.
     state = sanitiseState({
       ...nextState,
       route: preserveRoute ? previousRoute : nextState.route,
       monsterCelebrations: preserveMonsterCelebrations
         ? previousMonsterCelebrations
         : nextState.monsterCelebrations,
-    }, registry);
+    }, registry, { rehydrate: true });
     notify();
     return state;
   }

--- a/src/subjects/punctuation/components/PunctuationMapScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationMapScene.jsx
@@ -1,0 +1,354 @@
+// Phase 3 U5 — Punctuation Map scene.
+//
+// Browsing surface over the 14 published Punctuation skills, grouped under
+// the 4 active monsters (Pealark / Claspin / Curlune / Quoral). Learners
+// filter by status chip (All / New / Learning / Due / Wobbly / Secure) and
+// monster chip, then tap a skill card to open the Skill Detail modal (U6)
+// or jump straight into Guided focus via "Practise this".
+//
+// Data flow:
+//   - 14 skills: imported from `PUNCTUATION_CLIENT_SKILLS` in the subject's
+//     client-safe read-model module (name + clusterId per skill).
+//   - Cluster → monster mapping: `PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER` in
+//     the view-model — a client mirror of the Worker's canonical
+//     `PUNCTUATION_CLUSTERS.monsterId`. The shared content module is
+//     forbidden from the browser bundle (bundle-audit rule), so the
+//     mapping is copied here and tested against the plan's fixture.
+//   - Per-skill status: derived client-side from the analytics snapshot's
+//     `skillRows` when available (ui.analytics.skillRows), falling back
+//     to every skill reading as `'new'` for fresh learners.
+//   - Active monster state: `buildPunctuationMapModel` iterates only
+//     `ACTIVE_PUNCTUATION_MONSTER_IDS`, full stop — reserved monsters
+//     (Colisk / Hyphang / Carillon) never surface even if the reward
+//     state contains them (plan R10 / learning #5).
+//
+// Every mutation control threads `composeIsDisabled(ui)` — the filter chips,
+// the "Practise this" button, and the "Open details" button all disable as a
+// single bundle whenever availability flips to degraded / unavailable, a
+// command is in flight, or the runtime is read-only (plan R11).
+//
+// U5 deviation note: the "Practise this" / "Open details" buttons dispatch
+// `punctuation-skill-detail-open` with `{ skillId }`. The module handler for
+// that action lands in U5 alongside this scene so the dispatch is a real
+// state delta; U6 follows up with the modal component that consumes
+// `mapUi.detailOpenSkillId` + `mapUi.detailTab`. Documented in the PR body.
+
+import React from 'react';
+
+import {
+  ACTIVE_PUNCTUATION_MONSTER_IDS,
+  PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER,
+  PUNCTUATION_DASHBOARD_HERO,
+  PUNCTUATION_MAP_MONSTER_FILTER_IDS,
+  PUNCTUATION_MAP_STATUS_FILTER_IDS,
+  bellstormSceneForPhase,
+  buildPunctuationMapModel,
+  composeIsDisabled,
+  punctuationChildStatusLabel,
+  punctuationMonsterDisplayName,
+  punctuationSkillRuleOneLiner,
+} from './punctuation-view-model.js';
+import { PUNCTUATION_CLIENT_SKILLS } from '../read-model.js';
+
+// Child-facing labels for the status filter chips. `'all'` is a literal
+// "All"; the other five ids reach for the shared child-copy mapping in
+// `punctuationChildStatusLabel` so any future rename lands in one place.
+function statusFilterLabel(id) {
+  if (id === 'all') return 'All';
+  return punctuationChildStatusLabel(id);
+}
+
+// Child-facing labels for the monster filter chips. `'all'` is a literal
+// "All"; every other id reaches for `punctuationMonsterDisplayName` so the
+// roster display-name table stays the single source of truth.
+function monsterFilterLabel(id) {
+  if (id === 'all') return 'All';
+  return punctuationMonsterDisplayName(id);
+}
+
+// Normalise `mapUi` for render — accepts undefined (default shape) or a
+// partial object. Mirrors `normalisePunctuationMapUi` in service-contract
+// but operates on the shape actually threaded into the scene (the caller
+// has already run the normaliser when the Map phase opened; this is a
+// defence against a hand-rolled fixture that omits the field).
+function mapUiFromState(ui) {
+  const raw = ui && typeof ui === 'object' && !Array.isArray(ui) ? ui.mapUi : null;
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { statusFilter: 'all', monsterFilter: 'all', detailOpenSkillId: null, detailTab: 'learn' };
+  }
+  const statusFilter = typeof raw.statusFilter === 'string'
+    && PUNCTUATION_MAP_STATUS_FILTER_IDS.includes(raw.statusFilter)
+    ? raw.statusFilter
+    : 'all';
+  const monsterFilter = typeof raw.monsterFilter === 'string'
+    && PUNCTUATION_MAP_MONSTER_FILTER_IDS.includes(raw.monsterFilter)
+    ? raw.monsterFilter
+    : 'all';
+  return {
+    statusFilter,
+    monsterFilter,
+    detailOpenSkillId: typeof raw.detailOpenSkillId === 'string' && raw.detailOpenSkillId
+      ? raw.detailOpenSkillId
+      : null,
+    detailTab: raw.detailTab === 'practise' ? 'practise' : 'learn',
+  };
+}
+
+// Build the 14 skill-row inputs for `buildPunctuationMapModel`. When the
+// Worker-projected analytics snapshot carries `skillRows`, we enrich each
+// row with the client-held name / clusterId (so a rogue payload can't
+// substitute adult copy). Fresh learners or degraded runtimes fall back to
+// "status: 'new'" across every skill, which keeps the Map populated and
+// browsable while the analytics snapshot is empty.
+function assembleSkillRows(ui) {
+  const analytics = ui && typeof ui === 'object' && !Array.isArray(ui) ? ui.analytics : null;
+  const snapshotRows = analytics && Array.isArray(analytics.skillRows) ? analytics.skillRows : [];
+  const snapshotById = new Map();
+  for (const row of snapshotRows) {
+    if (row && typeof row === 'object' && !Array.isArray(row) && typeof row.skillId === 'string') {
+      snapshotById.set(row.skillId, row);
+    }
+  }
+  return PUNCTUATION_CLIENT_SKILLS.map((skill) => {
+    const snap = snapshotById.get(skill.id) || null;
+    const rawStatus = snap && typeof snap.status === 'string' ? snap.status : 'new';
+    return {
+      skillId: skill.id,
+      name: skill.name,
+      clusterId: skill.clusterId,
+      status: rawStatus,
+      attempts: Number(snap?.attempts) || 0,
+      accuracy: Number.isFinite(Number(snap?.accuracy)) ? Number(snap.accuracy) : null,
+      mastery: Number(snap?.mastery) || 0,
+      dueAt: Number(snap?.dueAt) || 0,
+    };
+  });
+}
+
+function StatusFilterChips({ activeFilter, disabled, actions }) {
+  return (
+    <div
+      className="punctuation-map-chips punctuation-map-chips--status"
+      role="group"
+      aria-label="Filter skills by status"
+    >
+      {PUNCTUATION_MAP_STATUS_FILTER_IDS.map((id) => {
+        const active = id === activeFilter;
+        return (
+          <button
+            key={id}
+            type="button"
+            className={`chip${active ? ' on' : ''}`}
+            aria-pressed={active ? 'true' : 'false'}
+            disabled={disabled}
+            data-action="punctuation-map-status-filter"
+            data-value={id}
+            onClick={() => actions.dispatch('punctuation-map-status-filter', { value: id })}
+          >
+            {statusFilterLabel(id)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function MonsterFilterChips({ activeFilter, disabled, actions }) {
+  return (
+    <div
+      className="punctuation-map-chips punctuation-map-chips--monster"
+      role="group"
+      aria-label="Filter skills by monster"
+    >
+      {PUNCTUATION_MAP_MONSTER_FILTER_IDS.map((id) => {
+        const active = id === activeFilter;
+        return (
+          <button
+            key={id}
+            type="button"
+            className={`chip${active ? ' on' : ''}`}
+            aria-pressed={active ? 'true' : 'false'}
+            disabled={disabled}
+            data-action="punctuation-map-monster-filter"
+            data-value={id}
+            onClick={() => actions.dispatch('punctuation-map-monster-filter', { value: id })}
+          >
+            {monsterFilterLabel(id)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function SkillCard({ skill, disabled, actions }) {
+  return (
+    <article className="punctuation-map-skill-card" data-skill-id={skill.skillId}>
+      <header className="punctuation-map-skill-card-head">
+        <h4>{skill.name}</h4>
+        <span className={`chip punctuation-map-skill-status punctuation-map-skill-status--${skill.status}`}>
+          {skill.statusLabel}
+        </span>
+      </header>
+      <p className="punctuation-map-skill-rule">{punctuationSkillRuleOneLiner(skill.skillId)}</p>
+      <div className="punctuation-map-skill-actions actions">
+        <button
+          type="button"
+          className="btn primary"
+          disabled={disabled}
+          data-action="punctuation-skill-detail-open"
+          data-skill-id={skill.skillId}
+          data-value="practise"
+          onClick={() => actions.dispatch('punctuation-skill-detail-open', {
+            skillId: skill.skillId,
+            tab: 'practise',
+          })}
+        >
+          Practise this
+        </button>
+        <button
+          type="button"
+          className="btn secondary"
+          disabled={disabled}
+          data-action="punctuation-skill-detail-open"
+          data-skill-id={skill.skillId}
+          data-value="learn"
+          onClick={() => actions.dispatch('punctuation-skill-detail-open', {
+            skillId: skill.skillId,
+            tab: 'learn',
+          })}
+        >
+          Open details
+        </button>
+      </div>
+    </article>
+  );
+}
+
+function MonsterGroup({ monster, statusFilter, disabled, actions }) {
+  const filteredSkills = statusFilter === 'all'
+    ? monster.skills
+    : monster.skills.filter((skill) => skill.status === statusFilter);
+  return (
+    <section
+      className="punctuation-map-monster-group"
+      aria-label={`${monster.name} skills`}
+      data-monster-id={monster.monsterId}
+    >
+      <header className="punctuation-map-monster-group-head">
+        <h3>{monster.name}</h3>
+        <p className="muted">
+          {monster.skills.length} skill{monster.skills.length === 1 ? '' : 's'} · {monster.mastered} mastered
+        </p>
+      </header>
+      <div className="punctuation-map-skill-grid">
+        {filteredSkills.length
+          ? filteredSkills.map((skill) => (
+            <SkillCard
+              key={skill.skillId}
+              skill={skill}
+              disabled={disabled}
+              actions={actions}
+            />
+          ))
+          : <div className="punctuation-map-empty muted">Nothing to show with this status yet.</div>}
+      </div>
+    </section>
+  );
+}
+
+export function PunctuationMapScene({ ui, actions }) {
+  const scene = bellstormSceneForPhase('map');
+  const disabled = composeIsDisabled(ui);
+  const mapUi = mapUiFromState(ui);
+  const rewardState = ui && typeof ui === 'object' && !Array.isArray(ui) && ui.rewardState
+    && typeof ui.rewardState === 'object' && !Array.isArray(ui.rewardState)
+    ? ui.rewardState
+    : {};
+  const skillRows = assembleSkillRows(ui);
+  const model = buildPunctuationMapModel(
+    skillRows,
+    rewardState,
+    PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER,
+  );
+  // Apply the monster filter at the group level so the four sections remain
+  // in the DOM but only the selected monster's card list renders. This keeps
+  // the "reserved monsters never render" guarantee intact regardless of the
+  // filter value (the iterator is still `ACTIVE_PUNCTUATION_MONSTER_IDS`).
+  const visibleMonsters = mapUi.monsterFilter === 'all'
+    ? model.monsters
+    : model.monsters.filter((monster) => monster.monsterId === mapUi.monsterFilter);
+
+  return (
+    <section
+      className="card border-top punctuation-surface punctuation-map-scene"
+      data-punctuation-map
+      data-punctuation-phase="map"
+      style={{ borderTopColor: '#B8873F' }}
+    >
+      <div className="punctuation-hero">
+        <img
+          src={scene.src}
+          srcSet={scene.srcSet}
+          sizes="(max-width: 980px) 100vw, 960px"
+          alt=""
+          aria-hidden="true"
+        />
+        <div>
+          <div className="eyebrow">{PUNCTUATION_DASHBOARD_HERO.eyebrow}</div>
+          <h2 className="section-title">Punctuation Map</h2>
+          <p className="subtitle">
+            The 14 Punctuation skills, grouped by monster. Tap a skill to see the rule or start a short round.
+          </p>
+        </div>
+      </div>
+
+      <div className="punctuation-map-filters">
+        <StatusFilterChips
+          activeFilter={mapUi.statusFilter}
+          disabled={disabled}
+          actions={actions}
+        />
+        <MonsterFilterChips
+          activeFilter={mapUi.monsterFilter}
+          disabled={disabled}
+          actions={actions}
+        />
+      </div>
+
+      <div className="punctuation-map-body" data-punctuation-map-body>
+        {visibleMonsters.length
+          ? visibleMonsters.map((monster) => (
+            <MonsterGroup
+              key={monster.monsterId}
+              monster={monster}
+              statusFilter={mapUi.statusFilter}
+              disabled={disabled}
+              actions={actions}
+            />
+          ))
+          : <div className="punctuation-map-empty muted">No matching skills yet.</div>}
+      </div>
+
+      <div className="actions" style={{ marginTop: 16 }}>
+        <button
+          type="button"
+          className="btn secondary"
+          disabled={disabled}
+          data-action="punctuation-close-map"
+          onClick={() => actions.dispatch('punctuation-close-map')}
+        >
+          Back to dashboard
+        </button>
+      </div>
+
+      {ACTIVE_PUNCTUATION_MONSTER_IDS.length !== 4 ? (
+        // Defensive assertion — if the active roster ever changes shape the
+        // Map's four-section layout breaks. Rendered as hidden metadata so a
+        // regression shows up in the DOM tree tests without blowing up the
+        // learner experience.
+        <div hidden data-punctuation-map-roster-drift="true" />
+      ) : null}
+    </section>
+  );
+}

--- a/src/subjects/punctuation/components/PunctuationMapScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationMapScene.jsx
@@ -39,8 +39,6 @@ import {
   ACTIVE_PUNCTUATION_MONSTER_IDS,
   PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER,
   PUNCTUATION_DASHBOARD_HERO,
-  PUNCTUATION_MAP_MONSTER_FILTER_IDS,
-  PUNCTUATION_MAP_STATUS_FILTER_IDS,
   bellstormSceneForPhase,
   buildPunctuationMapModel,
   composeIsDisabled,
@@ -48,6 +46,11 @@ import {
   punctuationMonsterDisplayName,
   punctuationSkillRuleOneLiner,
 } from './punctuation-view-model.js';
+import {
+  PUNCTUATION_MAP_MONSTER_FILTER_IDS,
+  PUNCTUATION_MAP_STATUS_FILTER_IDS,
+  normalisePunctuationMapUi,
+} from '../service-contract.js';
 import { PUNCTUATION_CLIENT_SKILLS } from '../read-model.js';
 
 // Child-facing labels for the status filter chips. `'all'` is a literal
@@ -66,33 +69,12 @@ function monsterFilterLabel(id) {
   return punctuationMonsterDisplayName(id);
 }
 
-// Normalise `mapUi` for render — accepts undefined (default shape) or a
-// partial object. Mirrors `normalisePunctuationMapUi` in service-contract
-// but operates on the shape actually threaded into the scene (the caller
-// has already run the normaliser when the Map phase opened; this is a
-// defence against a hand-rolled fixture that omits the field).
-function mapUiFromState(ui) {
-  const raw = ui && typeof ui === 'object' && !Array.isArray(ui) ? ui.mapUi : null;
-  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
-    return { statusFilter: 'all', monsterFilter: 'all', detailOpenSkillId: null, detailTab: 'learn' };
-  }
-  const statusFilter = typeof raw.statusFilter === 'string'
-    && PUNCTUATION_MAP_STATUS_FILTER_IDS.includes(raw.statusFilter)
-    ? raw.statusFilter
-    : 'all';
-  const monsterFilter = typeof raw.monsterFilter === 'string'
-    && PUNCTUATION_MAP_MONSTER_FILTER_IDS.includes(raw.monsterFilter)
-    ? raw.monsterFilter
-    : 'all';
-  return {
-    statusFilter,
-    monsterFilter,
-    detailOpenSkillId: typeof raw.detailOpenSkillId === 'string' && raw.detailOpenSkillId
-      ? raw.detailOpenSkillId
-      : null,
-    detailTab: raw.detailTab === 'practise' ? 'practise' : 'learn',
-  };
-}
+// `mapUi` normalisation delegates to the service-contract's
+// `normalisePunctuationMapUi` (see `../service-contract.js`). The maint-lens
+// reviewer flagged the previous `mapUiFromState` helper as duplication of
+// that function; importing the contract version keeps the scene rendering
+// against the single source of truth and lets future changes to the shape
+// (e.g. new filter ids) land once.
 
 // Build the 14 skill-row inputs for `buildPunctuationMapModel`. When the
 // Worker-projected analytics snapshot carries `skillRows`, we enrich each
@@ -260,7 +242,7 @@ function MonsterGroup({ monster, statusFilter, disabled, actions }) {
 export function PunctuationMapScene({ ui, actions }) {
   const scene = bellstormSceneForPhase('map');
   const disabled = composeIsDisabled(ui);
-  const mapUi = mapUiFromState(ui);
+  const mapUi = normalisePunctuationMapUi(ui?.mapUi);
   const rewardState = ui && typeof ui === 'object' && !Array.isArray(ui) && ui.rewardState
     && typeof ui.rewardState === 'object' && !Array.isArray(ui.rewardState)
     ? ui.rewardState
@@ -279,6 +261,21 @@ export function PunctuationMapScene({ ui, actions }) {
     ? model.monsters
     : model.monsters.filter((monster) => monster.monsterId === mapUi.monsterFilter);
 
+  // Live-region total across every visible monster group, post-status-filter.
+  // Pairs with the `role="status"` <p> below so a screen reader announces how
+  // many skills a filter combination yields. Mirrors the Grammar Concept Bank
+  // "Showing N of M concepts" pattern (design-lens MEDIUM).
+  const visibleSkillCount = mapUi.statusFilter === 'all'
+    ? visibleMonsters.reduce((sum, monster) => sum + monster.skills.length, 0)
+    : visibleMonsters.reduce(
+      (sum, monster) => sum + monster.skills.filter((skill) => skill.status === mapUi.statusFilter).length,
+      0,
+    );
+  const totalSkillCount = model.monsters.reduce((sum, monster) => sum + monster.skills.length, 0);
+  const summaryText = visibleSkillCount === totalSkillCount
+    ? `Showing all ${totalSkillCount} skills.`
+    : `Showing ${visibleSkillCount} of ${totalSkillCount} skills.`;
+
   return (
     <section
       className="card border-top punctuation-surface punctuation-map-scene"
@@ -286,6 +283,22 @@ export function PunctuationMapScene({ ui, actions }) {
       data-punctuation-phase="map"
       style={{ borderTopColor: '#B8873F' }}
     >
+      {/* Back button at the top, mirroring Spelling word-bank-topbar and
+          Grammar grammar-bank-topbar (design-lens MEDIUM). A top-of-scene
+          affordance matches the pattern learners already know from the
+          sibling banks and keeps the scroll-up return path cheap. */}
+      <header className="punctuation-map-topbar">
+        <button
+          type="button"
+          className="btn ghost sm"
+          disabled={disabled}
+          data-action="punctuation-close-map"
+          onClick={() => actions.dispatch('punctuation-close-map')}
+        >
+          &larr; Back to dashboard
+        </button>
+      </header>
+
       <div className="punctuation-hero">
         <img
           src={scene.src}
@@ -316,6 +329,11 @@ export function PunctuationMapScene({ ui, actions }) {
         />
       </div>
 
+      {/* Live-region count of visible skills after filters apply. A screen
+          reader announces the new total whenever a chip flips the filter
+          state (design-lens MEDIUM). */}
+      <p className="punctuation-map-summary muted" role="status">{summaryText}</p>
+
       <div className="punctuation-map-body" data-punctuation-map-body>
         {visibleMonsters.length
           ? visibleMonsters.map((monster) => (
@@ -328,18 +346,6 @@ export function PunctuationMapScene({ ui, actions }) {
             />
           ))
           : <div className="punctuation-map-empty muted">No matching skills yet.</div>}
-      </div>
-
-      <div className="actions" style={{ marginTop: 16 }}>
-        <button
-          type="button"
-          className="btn secondary"
-          disabled={disabled}
-          data-action="punctuation-close-map"
-          onClick={() => actions.dispatch('punctuation-close-map')}
-        >
-          Back to dashboard
-        </button>
       </div>
 
       {ACTIVE_PUNCTUATION_MONSTER_IDS.length !== 4 ? (

--- a/src/subjects/punctuation/components/PunctuationPracticeSurface.jsx
+++ b/src/subjects/punctuation/components/PunctuationPracticeSurface.jsx
@@ -5,6 +5,7 @@ import {
   currentItemInstruction,
   punctuationPhaseLabel,
 } from './punctuation-view-model.js';
+import { PunctuationMapScene } from './PunctuationMapScene.jsx';
 
 function learnerName(appState, learnerId) {
   return appState?.learners?.byId?.[learnerId]?.name || 'Learner';
@@ -329,6 +330,7 @@ export function PunctuationPracticeSurface({ appState, service, actions }) {
   if (ui.phase === 'active-item') return <ActiveItemView ui={ui} actions={actions} />;
   if (ui.phase === 'feedback') return <FeedbackView ui={ui} actions={actions} />;
   if (ui.phase === 'summary') return <SummaryView ui={ui} actions={actions} />;
+  if (ui.phase === 'map') return <PunctuationMapScene ui={ui} actions={actions} />;
 
   return <SetupView learner={learner} stats={stats} ui={ui} actions={actions} />;
 }

--- a/src/subjects/punctuation/components/punctuation-view-model.js
+++ b/src/subjects/punctuation/components/punctuation-view-model.js
@@ -19,6 +19,21 @@
 
 import { resolveMonsterVisual } from '../../../platform/game/monster-visual-config.js';
 import { MONSTERS_BY_SUBJECT } from '../../../platform/game/monsters.js';
+import {
+  PUNCTUATION_MAP_DETAIL_TAB_IDS,
+  PUNCTUATION_MAP_MONSTER_FILTER_IDS,
+  PUNCTUATION_MAP_STATUS_FILTER_IDS,
+} from '../service-contract.js';
+
+// U5 layer fix (adv-219-005): the Map filter + detail-tab id lists are the
+// service-contract's single source of truth. The view-model re-exports them
+// under their existing names so renderers / tests keep their current import
+// paths while the one-way `contract → view-model` dependency is restored.
+export {
+  PUNCTUATION_MAP_DETAIL_TAB_IDS,
+  PUNCTUATION_MAP_MONSTER_FILTER_IDS,
+  PUNCTUATION_MAP_STATUS_FILTER_IDS,
+};
 
 const BELLSTORM_BASE = '/assets/regions/bellstorm-coast';
 
@@ -135,19 +150,10 @@ export const PUNCTUATION_PRIMARY_MODE_CARDS = Object.freeze([
 ]);
 
 // --- Punctuation Map filter lists ------------------------------------------
-
-// Map status chips. Order matches the plan: All / New / Learning / Due /
-// Wobbly / Secure. Child copy — the `weak` id reads as "Wobbly" in the UI.
-export const PUNCTUATION_MAP_STATUS_FILTER_IDS = Object.freeze([
-  'all', 'new', 'learning', 'due', 'weak', 'secure',
-]);
-
-// Map monster chips. Order matches the plan / codebase active roster. Reserved
-// monsters (Colisk / Hyphang / Carillon) are intentionally absent so a rogue
-// payload cannot surface a retired name as a filter option.
-export const PUNCTUATION_MAP_MONSTER_FILTER_IDS = Object.freeze([
-  'all', 'pealark', 'claspin', 'curlune', 'quoral',
-]);
+//
+// Status, monster, and detail-tab id lists moved to service-contract.js in U5
+// (adv-219-005 layer fix). The view-model re-exports them via the top-of-file
+// `export { ... }` block so downstream imports keep working.
 
 // Short, child-facing rule one-liners for the Punctuation Map scene's skill
 // cards. Each line is a single sentence in KS2-friendly copy — no dotted

--- a/src/subjects/punctuation/components/punctuation-view-model.js
+++ b/src/subjects/punctuation/components/punctuation-view-model.js
@@ -149,6 +149,59 @@ export const PUNCTUATION_MAP_MONSTER_FILTER_IDS = Object.freeze([
   'all', 'pealark', 'claspin', 'curlune', 'quoral',
 ]);
 
+// Short, child-facing rule one-liners for the Punctuation Map scene's skill
+// cards. Each line is a single sentence in KS2-friendly copy — no dotted
+// misconception tags, no adult jargon. Map scene renders one per card; U6's
+// Skill Detail modal reaches for richer content (rule + worked example +
+// contrast) rather than these one-liners. A missing skill falls back to
+// `'Practise this punctuation skill.'` so the card never renders empty.
+const PUNCTUATION_SKILL_RULE_ONE_LINERS = Object.freeze({
+  sentence_endings: 'Start with a capital; end with . ! or ? — no gaps.',
+  list_commas: 'Put a comma between each item in a list.',
+  apostrophe_contractions: "Slot the mark in where the missing letters belong.",
+  apostrophe_possession: "Add 's to show belonging; a plural ending in s takes one mark.",
+  speech: 'Speech marks wrap the spoken words; the end mark sits inside.',
+  fronted_adverbial: 'Put a comma after the opener when it comes before the main clause.',
+  parenthesis: 'Mark an extra idea with two commas, two brackets, or two dashes — one pair only.',
+  comma_clarity: 'Add a comma when it stops the sentence from being misread.',
+  colon_list: 'Use a colon to introduce a list after a complete clause.',
+  semicolon: 'Use a semi-colon to link two closely-related complete clauses.',
+  dash_clause: 'Use a pair of dashes to break off a side thought.',
+  semicolon_list: 'Use semi-colons between long list items that already contain commas.',
+  bullet_points: 'Keep bullet punctuation consistent across every item in the list.',
+  hyphen: 'Hyphenate word pairs before a noun when they act as one idea.',
+});
+
+/**
+ * Returns the child-facing rule one-liner for a skill id, used by U5's Map
+ * scene skill cards. Unknown ids fall back to a generic "Practise this" line
+ * rather than surfacing the raw id. Output is always a single sentence
+ * suitable for a KS2 reader.
+ */
+export function punctuationSkillRuleOneLiner(skillId) {
+  if (typeof skillId !== 'string' || !skillId) return 'Practise this punctuation skill.';
+  const line = PUNCTUATION_SKILL_RULE_ONE_LINERS[skillId];
+  return typeof line === 'string' && line ? line : 'Practise this punctuation skill.';
+}
+
+// Client-safe cluster → monster mapping. The Worker canonical source of truth
+// is `shared/punctuation/content.js`'s `PUNCTUATION_CLUSTERS`, which the
+// bundle-audit rules forbid from the browser bundle. This constant is the
+// client mirror of that mapping for U5's Map scene — it must stay in lock-step
+// with the shared content's `monsterId` field on every cluster. Skills whose
+// cluster maps to `structure` land on Curlune (List / Structure cluster); the
+// grand monster (Quoral) is reserved for the "published release" aggregate
+// and is the fallback target for any skill whose cluster is unknown (see
+// `buildPunctuationMapModel`).
+export const PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER = Object.freeze({
+  endmarks: 'pealark',
+  speech: 'pealark',
+  boundary: 'pealark',
+  apostrophe: 'claspin',
+  comma_flow: 'curlune',
+  structure: 'curlune',
+});
+
 // --- Active monster roster -------------------------------------------------
 
 // The four learner-facing Punctuation monsters. Read from

--- a/src/subjects/punctuation/module.js
+++ b/src/subjects/punctuation/module.js
@@ -149,6 +149,18 @@ export const punctuationModule = {
       // Parallel to `punctuation-back` when already in the Map phase. Split
       // as its own action so the Map scene's close-button dispatch is
       // semantically distinct from the generic back-to-dashboard path.
+      //
+      // adv-219-008 guard: round-2's adv-219-007 pass tightened the five
+      // Map-scoped filter / detail handlers but missed this sixth. Without
+      // the guard, a stray dispatch from `active-item` / `feedback` /
+      // `summary` / `setup` / `error` unconditionally writes
+      // `{ phase: 'setup', error: '', mapUi: <default> }` which destroys a
+      // live session AND seeds a default mapUi payload into state +
+      // localStorage (tempting the rehydrate path into restoring filter
+      // state across reloads that sanitisePunctuationUiOnRehydrate would
+      // otherwise clear). Refuse from non-map phases so the caller treats
+      // the dispatch as a miss rather than a silent success (learning #7).
+      if (ui.phase !== 'map') return false;
       const nextMapUi = {
         ...normalisePunctuationMapUi(ui.mapUi),
         detailOpenSkillId: null,

--- a/src/subjects/punctuation/module.js
+++ b/src/subjects/punctuation/module.js
@@ -1,4 +1,11 @@
-import { createInitialPunctuationState } from './service-contract.js';
+import {
+  createInitialPunctuationState,
+  normalisePunctuationMapUi,
+} from './service-contract.js';
+import {
+  PUNCTUATION_MAP_MONSTER_FILTER_IDS,
+  PUNCTUATION_MAP_STATUS_FILTER_IDS,
+} from './components/punctuation-view-model.js';
 import { SUBJECT_EXPOSURE_GATES } from '../../platform/core/subject-availability.js';
 
 function applyTransition(context, transition) {
@@ -80,7 +87,119 @@ export const punctuationModule = {
     }
 
     if (action === 'punctuation-back') {
-      store.updateSubjectUi('punctuation', { phase: 'setup', error: '' });
+      // Returning from the Map phase should clear the ephemeral detail modal
+      // state; other phases do not carry a mapUi field so the reset is a
+      // no-op for them. Subsequent Map re-opens start from defaults anyway,
+      // but explicitly clearing detailOpenSkillId keeps the state clean in
+      // tests that interleave phases.
+      const nextMapUi = ui.phase === 'map' && ui.mapUi
+        ? { ...normalisePunctuationMapUi(ui.mapUi), detailOpenSkillId: null }
+        : undefined;
+      store.updateSubjectUi('punctuation', {
+        phase: 'setup',
+        error: '',
+        ...(nextMapUi ? { mapUi: nextMapUi } : {}),
+      });
+      return true;
+    }
+
+    // --- U5: Punctuation Map phase handlers ---------------------------------
+    //
+    // All four handlers below are pure UI-state mutations — no Worker
+    // command is issued. They toggle the local `phase` / `mapUi` carried on
+    // `subjectUi.punctuation`. Invalid payloads return `false` so the
+    // caller (adapter layer) treats the dispatch as a miss rather than a
+    // silent success (pairs with learning #7 — "HTML absence tests pass
+    // whether a command genuinely fails closed or silently does nothing").
+
+    if (action === 'punctuation-open-map') {
+      store.updateSubjectUi('punctuation', {
+        phase: 'map',
+        error: '',
+        mapUi: normalisePunctuationMapUi(),
+      });
+      return true;
+    }
+
+    if (action === 'punctuation-close-map') {
+      // Parallel to `punctuation-back` when already in the Map phase. Split
+      // as its own action so the Map scene's close-button dispatch is
+      // semantically distinct from the generic back-to-dashboard path.
+      const nextMapUi = {
+        ...normalisePunctuationMapUi(ui.mapUi),
+        detailOpenSkillId: null,
+      };
+      store.updateSubjectUi('punctuation', {
+        phase: 'setup',
+        error: '',
+        mapUi: nextMapUi,
+      });
+      return true;
+    }
+
+    if (action === 'punctuation-map-status-filter') {
+      const value = typeof data?.value === 'string' ? data.value : '';
+      if (!PUNCTUATION_MAP_STATUS_FILTER_IDS.includes(value)) return false;
+      const nextMapUi = {
+        ...normalisePunctuationMapUi(ui.mapUi),
+        statusFilter: value,
+      };
+      store.updateSubjectUi('punctuation', { mapUi: nextMapUi });
+      return true;
+    }
+
+    if (action === 'punctuation-map-monster-filter') {
+      const value = typeof data?.value === 'string' ? data.value : '';
+      if (!PUNCTUATION_MAP_MONSTER_FILTER_IDS.includes(value)) return false;
+      const nextMapUi = {
+        ...normalisePunctuationMapUi(ui.mapUi),
+        monsterFilter: value,
+      };
+      store.updateSubjectUi('punctuation', { mapUi: nextMapUi });
+      return true;
+    }
+
+    // --- U5 deviation: Skill Detail modal state handlers -------------------
+    //
+    // U6 will create the PunctuationSkillDetailModal component that consumes
+    // `mapUi.detailOpenSkillId` + `mapUi.detailTab`. The three handlers
+    // below land in U5 so the Map scene's "Open details" / "Practise this"
+    // buttons dispatch a real state delta today rather than dead-ending
+    // until U6 arrives. Pure UI-state mutations, no Worker side-effect.
+    // Recorded in the PR body as an intentional deviation from the plan's
+    // strict unit boundary.
+
+    if (action === 'punctuation-skill-detail-open') {
+      const skillId = typeof data?.skillId === 'string' && data.skillId ? data.skillId : '';
+      if (!skillId) return false;
+      const rawTab = typeof data?.tab === 'string' ? data.tab : 'learn';
+      const detailTab = rawTab === 'practise' ? 'practise' : 'learn';
+      const nextMapUi = {
+        ...normalisePunctuationMapUi(ui.mapUi),
+        detailOpenSkillId: skillId,
+        detailTab,
+      };
+      store.updateSubjectUi('punctuation', { mapUi: nextMapUi });
+      return true;
+    }
+
+    if (action === 'punctuation-skill-detail-close') {
+      const nextMapUi = {
+        ...normalisePunctuationMapUi(ui.mapUi),
+        detailOpenSkillId: null,
+      };
+      store.updateSubjectUi('punctuation', { mapUi: nextMapUi });
+      return true;
+    }
+
+    if (action === 'punctuation-skill-detail-tab') {
+      const rawTab = typeof data?.value === 'string' ? data.value : '';
+      if (rawTab !== 'learn' && rawTab !== 'practise') return false;
+      const nextMapUi = {
+        ...normalisePunctuationMapUi(ui.mapUi),
+        detailTab: rawTab,
+      };
+      store.updateSubjectUi('punctuation', { mapUi: nextMapUi });
       return true;
     }
 

--- a/src/subjects/punctuation/module.js
+++ b/src/subjects/punctuation/module.js
@@ -1,11 +1,12 @@
 import {
   createInitialPunctuationState,
+  isPublishedPunctuationSkillId,
   normalisePunctuationMapUi,
-} from './service-contract.js';
-import {
+  sanitisePunctuationUiOnRehydrate,
   PUNCTUATION_MAP_MONSTER_FILTER_IDS,
   PUNCTUATION_MAP_STATUS_FILTER_IDS,
-} from './components/punctuation-view-model.js';
+  PUNCTUATION_OPEN_MAP_ALLOWED_PHASES,
+} from './service-contract.js';
 import { SUBJECT_EXPOSURE_GATES } from '../../platform/core/subject-availability.js';
 
 function applyTransition(context, transition) {
@@ -36,6 +37,13 @@ export const punctuationModule = {
   reactPractice: true,
   initState() {
     return createInitialPunctuationState();
+  },
+  // U5 (adv-219-001): Map phase + mapUi are session-ephemeral. The store's
+  // rehydrate path invokes this hook once per boot on the persisted entry;
+  // `phase === 'map'` is coerced back to `'setup'` and `mapUi` is stripped
+  // so a reload never lands on the Map phase with stale filter state.
+  sanitiseUiOnRehydrate(entry) {
+    return sanitisePunctuationUiOnRehydrate(entry);
   },
   getDashboardStats(appState, { service }) {
     const learnerId = appState.learners.selectedId;
@@ -113,9 +121,25 @@ export const punctuationModule = {
     // whether a command genuinely fails closed or silently does nothing").
 
     if (action === 'punctuation-open-map') {
+      // adv-219-002 guard: `punctuation-open-map` is only a legitimate
+      // affordance from Setup (the dashboard Map link) and Summary (the
+      // next-action button on the Summary scene per plan line 519). A
+      // dispatch from `active-item` / `feedback` / `unavailable` / `error`
+      // / `map` itself would otherwise leave a zombie `session` +
+      // `feedback` under `phase: 'map'` thanks to the shallow-merge store
+      // path. Refuse the transition so the caller treats the dispatch as a
+      // miss rather than a silent success.
+      if (!PUNCTUATION_OPEN_MAP_ALLOWED_PHASES.includes(ui.phase)) {
+        return false;
+      }
       store.updateSubjectUi('punctuation', {
         phase: 'map',
         error: '',
+        // Clear feedback defensively — summary-phase transitions in
+        // `active-item → feedback → summary` already null it, but a
+        // belt-and-braces reset here means no open-map path ever lands on
+        // a feedback payload from an earlier session.
+        feedback: null,
         mapUi: normalisePunctuationMapUi(),
       });
       return true;
@@ -170,8 +194,14 @@ export const punctuationModule = {
     // strict unit boundary.
 
     if (action === 'punctuation-skill-detail-open') {
-      const skillId = typeof data?.skillId === 'string' && data.skillId ? data.skillId : '';
-      if (!skillId) return false;
+      // adv-219-004: skillId must be a published Punctuation skill id so the
+      // U6 Skill Detail modal never opens against a rogue payload.
+      // `isPublishedPunctuationSkillId` gates both the string shape and the
+      // membership check against the frozen `PUNCTUATION_CLIENT_SKILL_IDS`
+      // list in service-contract. Unknown ids return `false` — the store is
+      // not touched and the caller treats the dispatch as a miss.
+      if (!isPublishedPunctuationSkillId(data?.skillId)) return false;
+      const skillId = data.skillId;
       const rawTab = typeof data?.tab === 'string' ? data.tab : 'learn';
       const detailTab = rawTab === 'practise' ? 'practise' : 'learn';
       const nextMapUi = {

--- a/src/subjects/punctuation/module.js
+++ b/src/subjects/punctuation/module.js
@@ -162,6 +162,14 @@ export const punctuationModule = {
     }
 
     if (action === 'punctuation-map-status-filter') {
+      // adv-219-007: all five Map-scoped handlers below must gate on
+      // `ui.phase === 'map'`. A dispatch from Setup / active-item / feedback
+      // / summary / unavailable / error would otherwise seed `mapUi` into
+      // state + localStorage, which then tempts the rehydrate path into
+      // restoring filter state across reloads that the adv-219-001 /
+      // adv-219-006 sanitiser would otherwise clear. Return false so the
+      // caller treats the dispatch as a miss rather than a silent success.
+      if (ui.phase !== 'map') return false;
       const value = typeof data?.value === 'string' ? data.value : '';
       if (!PUNCTUATION_MAP_STATUS_FILTER_IDS.includes(value)) return false;
       const nextMapUi = {
@@ -173,6 +181,8 @@ export const punctuationModule = {
     }
 
     if (action === 'punctuation-map-monster-filter') {
+      // adv-219-007: phase guard — see punctuation-map-status-filter above.
+      if (ui.phase !== 'map') return false;
       const value = typeof data?.value === 'string' ? data.value : '';
       if (!PUNCTUATION_MAP_MONSTER_FILTER_IDS.includes(value)) return false;
       const nextMapUi = {
@@ -194,6 +204,8 @@ export const punctuationModule = {
     // strict unit boundary.
 
     if (action === 'punctuation-skill-detail-open') {
+      // adv-219-007: phase guard — detail state is Map-scoped.
+      if (ui.phase !== 'map') return false;
       // adv-219-004: skillId must be a published Punctuation skill id so the
       // U6 Skill Detail modal never opens against a rogue payload.
       // `isPublishedPunctuationSkillId` gates both the string shape and the
@@ -214,6 +226,8 @@ export const punctuationModule = {
     }
 
     if (action === 'punctuation-skill-detail-close') {
+      // adv-219-007: phase guard — detail state is Map-scoped.
+      if (ui.phase !== 'map') return false;
       const nextMapUi = {
         ...normalisePunctuationMapUi(ui.mapUi),
         detailOpenSkillId: null,
@@ -223,6 +237,8 @@ export const punctuationModule = {
     }
 
     if (action === 'punctuation-skill-detail-tab') {
+      // adv-219-007: phase guard — detail state is Map-scoped.
+      if (ui.phase !== 'map') return false;
       const rawTab = typeof data?.value === 'string' ? data.value : '';
       if (rawTab !== 'learn' && rawTab !== 'practise') return false;
       const nextMapUi = {

--- a/src/subjects/punctuation/read-model.js
+++ b/src/subjects/punctuation/read-model.js
@@ -3,7 +3,7 @@ const CURRENT_RELEASE_ID = 'punctuation-r4-full-14-skill-structure';
 const TOTAL_REWARD_UNITS = 14;
 const DAILY_TARGET_ATTEMPTS = 4;
 
-const PUNCTUATION_CLIENT_SKILLS = Object.freeze([
+export const PUNCTUATION_CLIENT_SKILLS = Object.freeze([
   { id: 'sentence_endings', name: 'Capital letters and sentence endings', clusterId: 'endmarks' },
   { id: 'list_commas', name: 'Commas in lists', clusterId: 'comma_flow' },
   { id: 'apostrophe_contractions', name: 'Apostrophes for contraction', clusterId: 'apostrophe' },

--- a/src/subjects/punctuation/service-contract.js
+++ b/src/subjects/punctuation/service-contract.js
@@ -1,3 +1,8 @@
+import {
+  PUNCTUATION_MAP_MONSTER_FILTER_IDS,
+  PUNCTUATION_MAP_STATUS_FILTER_IDS,
+} from './components/punctuation-view-model.js';
+
 export const PUNCTUATION_SERVICE_STATE_VERSION = 1;
 export const PUNCTUATION_CURRENT_RELEASE_ID = 'punctuation-r4-full-14-skill-structure';
 
@@ -8,6 +13,12 @@ export const PUNCTUATION_PHASES = Object.freeze([
   'summary',
   'unavailable',
   'error',
+  // U5: Punctuation Map is a browsing phase — a learner taps the Map link from
+  // Setup, filters the 14 skills by status / monster, and (in U6) opens a
+  // skill detail modal. The phase carries ephemeral UI state via `mapUi`
+  // (see `normalisePunctuationMapUi`) — no Worker command is issued when
+  // entering or leaving the phase.
+  'map',
 ]);
 
 export const PUNCTUATION_MODES = Object.freeze([
@@ -88,6 +99,39 @@ export function normalisePunctuationPrefs(value = {}) {
     mode,
     roundLength: normalisePunctuationRoundLength(raw.roundLength ?? raw.length),
   };
+}
+
+// U5: Punctuation Map UI-state shape. Ephemeral; lives on the in-memory store
+// only, never persisted. Validated against the view-model's frozen filter
+// lists so a rogue payload cannot smuggle a reserved monster id into the
+// Map's monster filter. Invalid inputs fall back to the defaults listed
+// below — never throws.
+//
+// Defaults when the Map phase first opens:
+//   { statusFilter: 'all', monsterFilter: 'all', detailOpenSkillId: null,
+//     detailTab: 'learn' }
+//
+// `detailOpenSkillId` is either a non-empty string (the currently-open skill
+// detail in U6's modal) or `null`. `detailTab` is either `'learn'` or
+// `'practise'`; invalid input falls back to `'learn'`.
+const PUNCTUATION_MAP_DETAIL_TABS = Object.freeze(new Set(['learn', 'practise']));
+
+export function normalisePunctuationMapUi(value = {}) {
+  const raw = isPlainObject(value) ? value : {};
+  const rawStatusFilter = typeof raw.statusFilter === 'string' ? raw.statusFilter : 'all';
+  const statusFilter = PUNCTUATION_MAP_STATUS_FILTER_IDS.includes(rawStatusFilter)
+    ? rawStatusFilter
+    : 'all';
+  const rawMonsterFilter = typeof raw.monsterFilter === 'string' ? raw.monsterFilter : 'all';
+  const monsterFilter = PUNCTUATION_MAP_MONSTER_FILTER_IDS.includes(rawMonsterFilter)
+    ? rawMonsterFilter
+    : 'all';
+  const detailOpenSkillId = typeof raw.detailOpenSkillId === 'string' && raw.detailOpenSkillId
+    ? raw.detailOpenSkillId
+    : null;
+  const rawDetailTab = typeof raw.detailTab === 'string' ? raw.detailTab : 'learn';
+  const detailTab = PUNCTUATION_MAP_DETAIL_TABS.has(rawDetailTab) ? rawDetailTab : 'learn';
+  return { statusFilter, monsterFilter, detailOpenSkillId, detailTab };
 }
 
 export function createInitialPunctuationState() {

--- a/src/subjects/punctuation/service-contract.js
+++ b/src/subjects/punctuation/service-contract.js
@@ -1,8 +1,3 @@
-import {
-  PUNCTUATION_MAP_MONSTER_FILTER_IDS,
-  PUNCTUATION_MAP_STATUS_FILTER_IDS,
-} from './components/punctuation-view-model.js';
-
 export const PUNCTUATION_SERVICE_STATE_VERSION = 1;
 export const PUNCTUATION_CURRENT_RELEASE_ID = 'punctuation-r4-full-14-skill-structure';
 
@@ -20,6 +15,60 @@ export const PUNCTUATION_PHASES = Object.freeze([
   // entering or leaving the phase.
   'map',
 ]);
+
+// U5: Phases from which `punctuation-open-map` is a legitimate affordance.
+// Setup is the primary entry point (Map link on the dashboard); Summary offers
+// "Open Punctuation Map" as a next-action (plan line 519). Any other phase —
+// `active-item`, `feedback`, `unavailable`, `error`, or `map` itself — refuses
+// the transition to prevent an orphan session / stale feedback from leaking
+// into phase=map (adversarial reviewer adv-219-002).
+export const PUNCTUATION_OPEN_MAP_ALLOWED_PHASES = Object.freeze(['setup', 'summary']);
+
+// U5: Map filter chip rows and detail-tab ids. These frozen lists are the
+// single source of truth — `normalisePunctuationMapUi` validates inputs
+// against them, module handlers guard dispatched values against them, and
+// the view-model / scene re-exports them for render-time chip iteration.
+// Reserved Punctuation monsters (Colisk / Hyphang / Carillon) are absent
+// from the monster filter list so a rogue payload cannot surface a retired
+// name as a filter option.
+export const PUNCTUATION_MAP_STATUS_FILTER_IDS = Object.freeze([
+  'all', 'new', 'learning', 'due', 'weak', 'secure',
+]);
+
+export const PUNCTUATION_MAP_MONSTER_FILTER_IDS = Object.freeze([
+  'all', 'pealark', 'claspin', 'curlune', 'quoral',
+]);
+
+export const PUNCTUATION_MAP_DETAIL_TAB_IDS = Object.freeze(['learn', 'practise']);
+
+// U5: Published skill ids. Client-safe mirror of the 14 skills that ship in
+// the current Punctuation release. Defined here (rather than read-model.js)
+// so the normaliser + module handler can validate a dispatched `skillId`
+// without reaching into a client-only module. The full skill metadata (name +
+// clusterId) lives on `PUNCTUATION_CLIENT_SKILLS` in read-model.js; this set
+// must stay in lock-step with that list (drift-tested).
+export const PUNCTUATION_CLIENT_SKILL_IDS = Object.freeze([
+  'sentence_endings',
+  'list_commas',
+  'apostrophe_contractions',
+  'apostrophe_possession',
+  'speech',
+  'fronted_adverbial',
+  'parenthesis',
+  'comma_clarity',
+  'colon_list',
+  'semicolon',
+  'dash_clause',
+  'semicolon_list',
+  'bullet_points',
+  'hyphen',
+]);
+
+const PUNCTUATION_CLIENT_SKILL_ID_SET = new Set(PUNCTUATION_CLIENT_SKILL_IDS);
+
+export function isPublishedPunctuationSkillId(value) {
+  return typeof value === 'string' && PUNCTUATION_CLIENT_SKILL_ID_SET.has(value);
+}
 
 export const PUNCTUATION_MODES = Object.freeze([
   'smart',
@@ -102,19 +151,19 @@ export function normalisePunctuationPrefs(value = {}) {
 }
 
 // U5: Punctuation Map UI-state shape. Ephemeral; lives on the in-memory store
-// only, never persisted. Validated against the view-model's frozen filter
-// lists so a rogue payload cannot smuggle a reserved monster id into the
-// Map's monster filter. Invalid inputs fall back to the defaults listed
-// below — never throws.
+// only, never persisted. Validated against the frozen filter / skill-id lists
+// above so a rogue payload cannot smuggle a reserved monster id or an
+// unpublished skill id into the Map's chip row or detail modal. Invalid
+// inputs fall back to the defaults listed below — never throws.
 //
 // Defaults when the Map phase first opens:
 //   { statusFilter: 'all', monsterFilter: 'all', detailOpenSkillId: null,
 //     detailTab: 'learn' }
 //
-// `detailOpenSkillId` is either a non-empty string (the currently-open skill
-// detail in U6's modal) or `null`. `detailTab` is either `'learn'` or
-// `'practise'`; invalid input falls back to `'learn'`.
-const PUNCTUATION_MAP_DETAIL_TABS = Object.freeze(new Set(['learn', 'practise']));
+// `detailOpenSkillId` is either a published skill id (currently one of 14)
+// or `null`. `detailTab` is either `'learn'` or `'practise'`; invalid input
+// falls back to `'learn'`.
+const PUNCTUATION_MAP_DETAIL_TABS = new Set(PUNCTUATION_MAP_DETAIL_TAB_IDS);
 
 export function normalisePunctuationMapUi(value = {}) {
   const raw = isPlainObject(value) ? value : {};
@@ -126,12 +175,34 @@ export function normalisePunctuationMapUi(value = {}) {
   const monsterFilter = PUNCTUATION_MAP_MONSTER_FILTER_IDS.includes(rawMonsterFilter)
     ? rawMonsterFilter
     : 'all';
-  const detailOpenSkillId = typeof raw.detailOpenSkillId === 'string' && raw.detailOpenSkillId
+  // detailOpenSkillId must be a published skill id — unknown ids reset to
+  // null so a U6 modal consumer never renders against a rogue payload.
+  const detailOpenSkillId = isPublishedPunctuationSkillId(raw.detailOpenSkillId)
     ? raw.detailOpenSkillId
     : null;
   const rawDetailTab = typeof raw.detailTab === 'string' ? raw.detailTab : 'learn';
   const detailTab = PUNCTUATION_MAP_DETAIL_TABS.has(rawDetailTab) ? rawDetailTab : 'learn';
   return { statusFilter, monsterFilter, detailOpenSkillId, detailTab };
+}
+
+// U5: Rehydrate-time sanitiser for `subjectUi.punctuation`. Called exactly
+// once when the store boots over a persisted `subjectStates` snapshot — the
+// Map phase and its `mapUi` filter state are session-ephemeral by plan
+// (R5 line 565 / line 583), so they must NOT survive a page reload. A live
+// snapshot that carries `phase === 'map'` is coerced back to `'setup'`; the
+// `mapUi` field is stripped entirely so the Map reopens from defaults.
+//
+// This sanitiser runs only on rehydrate — live `updateSubjectUi` dispatches
+// (which build state from the current in-memory entry) bypass it, so the
+// Map phase remains legitimate while the session is active.
+export function sanitisePunctuationUiOnRehydrate(entry) {
+  if (!isPlainObject(entry)) return entry;
+  const needsCoerce = entry.phase === 'map' || 'mapUi' in entry;
+  if (!needsCoerce) return entry;
+  const next = { ...entry };
+  if (next.phase === 'map') next.phase = 'setup';
+  if ('mapUi' in next) delete next.mapUi;
+  return next;
 }
 
 export function createInitialPunctuationState() {

--- a/tests/punctuation-map-phase.test.js
+++ b/tests/punctuation-map-phase.test.js
@@ -1,0 +1,373 @@
+// Phase 3 U5 — Punctuation Map phase + module action handlers.
+//
+// Service-contract + module-layer assertions for U5. The scene-render side
+// lives in `tests/react-punctuation-scene.test.js`; this file is pure-
+// function / pure-reducer territory:
+//   - `PUNCTUATION_PHASES` extension lock
+//   - `normalisePunctuationMapUi` default / fallback behaviour
+//   - Module handlers for open / close / filters + skill-detail state
+//     (U5 deviation: modal state handlers land here so U6 is JSX-only)
+//
+// No SSR. No React. Tests use the app harness so state mutations thread
+// through the real dispatch pipeline, matching production behaviour.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  PUNCTUATION_PHASES,
+  normalisePunctuationMapUi,
+} from '../src/subjects/punctuation/service-contract.js';
+import {
+  PUNCTUATION_MAP_MONSTER_FILTER_IDS,
+  PUNCTUATION_MAP_STATUS_FILTER_IDS,
+} from '../src/subjects/punctuation/components/punctuation-view-model.js';
+import { createAppHarness } from './helpers/app-harness.js';
+import { installMemoryStorage } from './helpers/memory-storage.js';
+import { SUBJECT_EXPOSURE_GATES } from '../src/platform/core/subject-availability.js';
+
+function createHarness() {
+  return createAppHarness({
+    storage: installMemoryStorage(),
+    subjectExposureGates: { [SUBJECT_EXPOSURE_GATES.punctuation]: true },
+  });
+}
+
+function punctuationState(harness) {
+  return harness.store.getState().subjectUi.punctuation || {};
+}
+
+// ---------------------------------------------------------------------------
+// PUNCTUATION_PHASES — `'map'` added, frozen at 7 entries (R17).
+// ---------------------------------------------------------------------------
+
+test('U5: PUNCTUATION_PHASES includes `map`', () => {
+  assert.equal(PUNCTUATION_PHASES.includes('map'), true);
+});
+
+test('U5: PUNCTUATION_PHASES frozen list is exactly the 7 expected phases', () => {
+  // Order-insensitive check: the phase strings themselves are the contract,
+  // not their position. Length check pins the list so a future unit cannot
+  // silently stretch the enum.
+  const expected = new Set([
+    'setup',
+    'active-item',
+    'feedback',
+    'summary',
+    'unavailable',
+    'error',
+    'map',
+  ]);
+  assert.equal(PUNCTUATION_PHASES.length, 7);
+  for (const phase of PUNCTUATION_PHASES) {
+    assert.equal(expected.has(phase), true, `unexpected phase ${phase}`);
+  }
+  assert.equal(Object.isFrozen(PUNCTUATION_PHASES), true);
+});
+
+// ---------------------------------------------------------------------------
+// normalisePunctuationMapUi — defaults + fallback behaviour.
+// ---------------------------------------------------------------------------
+
+test('U5 normalisePunctuationMapUi: undefined returns full default shape', () => {
+  const ui = normalisePunctuationMapUi(undefined);
+  assert.deepEqual(ui, {
+    statusFilter: 'all',
+    monsterFilter: 'all',
+    detailOpenSkillId: null,
+    detailTab: 'learn',
+  });
+});
+
+test('U5 normalisePunctuationMapUi: null returns full default shape', () => {
+  assert.deepEqual(
+    normalisePunctuationMapUi(null),
+    { statusFilter: 'all', monsterFilter: 'all', detailOpenSkillId: null, detailTab: 'learn' },
+  );
+});
+
+test('U5 normalisePunctuationMapUi: valid values pass through unchanged', () => {
+  const ui = normalisePunctuationMapUi({
+    statusFilter: 'weak',
+    monsterFilter: 'pealark',
+    detailOpenSkillId: 'speech',
+    detailTab: 'practise',
+  });
+  assert.deepEqual(ui, {
+    statusFilter: 'weak',
+    monsterFilter: 'pealark',
+    detailOpenSkillId: 'speech',
+    detailTab: 'practise',
+  });
+});
+
+test('U5 normalisePunctuationMapUi: invalid statusFilter falls back to `all`', () => {
+  const ui = normalisePunctuationMapUi({ statusFilter: 'garbage' });
+  assert.equal(ui.statusFilter, 'all');
+});
+
+test('U5 normalisePunctuationMapUi: reserved monster id rejects back to `all`', () => {
+  // A rogue payload trying to surface a retired monster id via the Map
+  // filter must fall back to `all` rather than pressing the reserved chip.
+  for (const reserved of ['colisk', 'hyphang', 'carillon']) {
+    const ui = normalisePunctuationMapUi({ monsterFilter: reserved });
+    assert.equal(ui.monsterFilter, 'all', `${reserved} leaked into monsterFilter`);
+  }
+});
+
+test('U5 normalisePunctuationMapUi: invalid detailTab falls back to `learn`', () => {
+  const ui = normalisePunctuationMapUi({ detailTab: 'garbage' });
+  assert.equal(ui.detailTab, 'learn');
+});
+
+test('U5 normalisePunctuationMapUi: empty-string detailOpenSkillId falls back to null', () => {
+  const ui = normalisePunctuationMapUi({ detailOpenSkillId: '' });
+  assert.equal(ui.detailOpenSkillId, null);
+});
+
+test('U5 normalisePunctuationMapUi: non-string detailOpenSkillId falls back to null', () => {
+  assert.equal(normalisePunctuationMapUi({ detailOpenSkillId: 123 }).detailOpenSkillId, null);
+  assert.equal(normalisePunctuationMapUi({ detailOpenSkillId: {} }).detailOpenSkillId, null);
+  assert.equal(normalisePunctuationMapUi({ detailOpenSkillId: [] }).detailOpenSkillId, null);
+});
+
+test('U5 normalisePunctuationMapUi: array input coerces to defaults', () => {
+  // Arrays are typeof object in JS; the normaliser must guard against them
+  // so a [key, value] pair can't accidentally set any field.
+  assert.deepEqual(
+    normalisePunctuationMapUi(['foo', 'bar']),
+    { statusFilter: 'all', monsterFilter: 'all', detailOpenSkillId: null, detailTab: 'learn' },
+  );
+});
+
+test('U5 normalisePunctuationMapUi: accepts every valid status filter id', () => {
+  for (const id of PUNCTUATION_MAP_STATUS_FILTER_IDS) {
+    assert.equal(normalisePunctuationMapUi({ statusFilter: id }).statusFilter, id);
+  }
+});
+
+test('U5 normalisePunctuationMapUi: accepts every valid monster filter id', () => {
+  for (const id of PUNCTUATION_MAP_MONSTER_FILTER_IDS) {
+    assert.equal(normalisePunctuationMapUi({ monsterFilter: id }).monsterFilter, id);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Module: `punctuation-open-map` / `punctuation-close-map`
+// ---------------------------------------------------------------------------
+
+test('U5 module: punctuation-open-map transitions setup → map with default mapUi', () => {
+  const harness = createHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  // Pre-condition: Setup phase.
+  assert.equal(punctuationState(harness).phase, 'setup');
+
+  harness.dispatch('punctuation-open-map');
+
+  const next = punctuationState(harness);
+  assert.equal(next.phase, 'map');
+  assert.deepEqual(next.mapUi, {
+    statusFilter: 'all',
+    monsterFilter: 'all',
+    detailOpenSkillId: null,
+    detailTab: 'learn',
+  });
+});
+
+test('U5 module: punctuation-close-map transitions map → setup and clears detailOpenSkillId', () => {
+  const harness = createHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.dispatch('punctuation-open-map');
+  harness.dispatch('punctuation-skill-detail-open', { skillId: 'speech' });
+  assert.equal(punctuationState(harness).mapUi.detailOpenSkillId, 'speech');
+
+  harness.dispatch('punctuation-close-map');
+
+  const next = punctuationState(harness);
+  assert.equal(next.phase, 'setup');
+  assert.equal(next.mapUi.detailOpenSkillId, null);
+});
+
+test('U5 module: punctuation-back from map phase resets phase to setup and clears detailOpenSkillId', () => {
+  const harness = createHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.dispatch('punctuation-open-map');
+  harness.dispatch('punctuation-skill-detail-open', { skillId: 'list_commas' });
+
+  harness.dispatch('punctuation-back');
+
+  const next = punctuationState(harness);
+  assert.equal(next.phase, 'setup');
+  assert.equal(next.mapUi.detailOpenSkillId, null);
+});
+
+// ---------------------------------------------------------------------------
+// Module: filter handlers — paired state-level assertions (learning #7).
+// ---------------------------------------------------------------------------
+
+test('U5 module: punctuation-map-status-filter accepts each valid value', () => {
+  const harness = createHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.dispatch('punctuation-open-map');
+
+  for (const id of PUNCTUATION_MAP_STATUS_FILTER_IDS) {
+    harness.dispatch('punctuation-map-status-filter', { value: id });
+    assert.equal(
+      punctuationState(harness).mapUi.statusFilter,
+      id,
+      `statusFilter did not update to ${id}`,
+    );
+  }
+});
+
+test('U5 module: punctuation-map-status-filter rejects an invalid value (no state mutation)', () => {
+  const harness = createHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.dispatch('punctuation-open-map');
+  // Set a known value first so we can prove the invalid dispatch is a no-op.
+  harness.dispatch('punctuation-map-status-filter', { value: 'weak' });
+  assert.equal(punctuationState(harness).mapUi.statusFilter, 'weak');
+
+  harness.dispatch('punctuation-map-status-filter', { value: 'garbage' });
+
+  // Invalid value: state is unchanged — the handler returned `false` and no
+  // `updateSubjectUi` mutation fired. The paired state-level assertion closes
+  // the silent-no-op gap (learning #7): an HTML-absence check alone would
+  // pass whether the handler genuinely refused the value or just happened
+  // not to render the change.
+  assert.equal(punctuationState(harness).mapUi.statusFilter, 'weak');
+});
+
+test('U5 module: punctuation-map-status-filter rejects missing value', () => {
+  const harness = createHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.dispatch('punctuation-open-map');
+  harness.dispatch('punctuation-map-status-filter', { value: 'weak' });
+
+  harness.dispatch('punctuation-map-status-filter', {});
+
+  assert.equal(punctuationState(harness).mapUi.statusFilter, 'weak');
+});
+
+test('U5 module: punctuation-map-monster-filter accepts each valid active monster id', () => {
+  const harness = createHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.dispatch('punctuation-open-map');
+
+  for (const id of PUNCTUATION_MAP_MONSTER_FILTER_IDS) {
+    harness.dispatch('punctuation-map-monster-filter', { value: id });
+    assert.equal(
+      punctuationState(harness).mapUi.monsterFilter,
+      id,
+      `monsterFilter did not update to ${id}`,
+    );
+  }
+});
+
+test('U5 module: punctuation-map-monster-filter rejects reserved monster ids (no state mutation)', () => {
+  const harness = createHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.dispatch('punctuation-open-map');
+  harness.dispatch('punctuation-map-monster-filter', { value: 'pealark' });
+  assert.equal(punctuationState(harness).mapUi.monsterFilter, 'pealark');
+
+  for (const reserved of ['colisk', 'hyphang', 'carillon']) {
+    harness.dispatch('punctuation-map-monster-filter', { value: reserved });
+    // Reserved ids never reach the filter list; state must retain the
+    // previously-set `pealark` value.
+    assert.equal(
+      punctuationState(harness).mapUi.monsterFilter,
+      'pealark',
+      `reserved ${reserved} leaked past the validator`,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Module: skill-detail state handlers (U5 deviation for U6 readiness).
+// ---------------------------------------------------------------------------
+
+test('U5 module: punctuation-skill-detail-open sets detailOpenSkillId and defaults detailTab to `learn`', () => {
+  const harness = createHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.dispatch('punctuation-open-map');
+
+  harness.dispatch('punctuation-skill-detail-open', { skillId: 'speech' });
+
+  const state = punctuationState(harness);
+  assert.equal(state.mapUi.detailOpenSkillId, 'speech');
+  assert.equal(state.mapUi.detailTab, 'learn');
+});
+
+test('U5 module: punctuation-skill-detail-open honours explicit `practise` tab', () => {
+  const harness = createHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.dispatch('punctuation-open-map');
+
+  harness.dispatch('punctuation-skill-detail-open', { skillId: 'comma_clarity', tab: 'practise' });
+
+  const state = punctuationState(harness);
+  assert.equal(state.mapUi.detailOpenSkillId, 'comma_clarity');
+  assert.equal(state.mapUi.detailTab, 'practise');
+});
+
+test('U5 module: punctuation-skill-detail-open falls back to `learn` on invalid tab', () => {
+  const harness = createHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.dispatch('punctuation-open-map');
+
+  harness.dispatch('punctuation-skill-detail-open', { skillId: 'speech', tab: 'garbage' });
+
+  assert.equal(punctuationState(harness).mapUi.detailTab, 'learn');
+});
+
+test('U5 module: punctuation-skill-detail-open rejects empty / non-string skillId', () => {
+  const harness = createHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.dispatch('punctuation-open-map');
+  harness.dispatch('punctuation-skill-detail-open', { skillId: 'speech' });
+  assert.equal(punctuationState(harness).mapUi.detailOpenSkillId, 'speech');
+
+  harness.dispatch('punctuation-skill-detail-open', { skillId: '' });
+  harness.dispatch('punctuation-skill-detail-open', { skillId: 123 });
+  harness.dispatch('punctuation-skill-detail-open', {});
+
+  // Invalid payloads return `false` — state retains the previous skillId.
+  assert.equal(punctuationState(harness).mapUi.detailOpenSkillId, 'speech');
+});
+
+test('U5 module: punctuation-skill-detail-close resets detailOpenSkillId to null', () => {
+  const harness = createHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.dispatch('punctuation-open-map');
+  harness.dispatch('punctuation-skill-detail-open', { skillId: 'speech' });
+
+  harness.dispatch('punctuation-skill-detail-close');
+
+  assert.equal(punctuationState(harness).mapUi.detailOpenSkillId, null);
+});
+
+test('U5 module: punctuation-skill-detail-tab switches tabs within an open detail', () => {
+  const harness = createHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.dispatch('punctuation-open-map');
+  harness.dispatch('punctuation-skill-detail-open', { skillId: 'speech' });
+  assert.equal(punctuationState(harness).mapUi.detailTab, 'learn');
+
+  harness.dispatch('punctuation-skill-detail-tab', { value: 'practise' });
+
+  assert.equal(punctuationState(harness).mapUi.detailTab, 'practise');
+});
+
+test('U5 module: punctuation-skill-detail-tab rejects invalid tab values', () => {
+  const harness = createHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.dispatch('punctuation-open-map');
+  harness.dispatch('punctuation-skill-detail-open', { skillId: 'speech', tab: 'practise' });
+  assert.equal(punctuationState(harness).mapUi.detailTab, 'practise');
+
+  harness.dispatch('punctuation-skill-detail-tab', { value: 'garbage' });
+
+  // Invalid value: handler returns false, state is unchanged.
+  assert.equal(punctuationState(harness).mapUi.detailTab, 'practise');
+});

--- a/tests/punctuation-map-phase.test.js
+++ b/tests/punctuation-map-phase.test.js
@@ -754,3 +754,118 @@ test('U5 filter handlers ALLOW dispatch when phase is map (adv-219-007 positive)
   );
   assert.equal(punctuationState(harness).mapUi.detailOpenSkillId, 'speech');
 });
+
+// ---------------------------------------------------------------------------
+// Adversarial reviewer HIGH adv-219-008 — `punctuation-close-map` is the sixth
+// Map-scoped handler and was missed by the adv-219-007 round-2 pass. Without a
+// phase guard, a stray dispatch from `active-item` / `feedback` / `summary` /
+// `setup` / `error` unconditionally sets `{ phase: 'setup', error: '', mapUi }`
+// which destroys a live session AND seeds a default mapUi payload into state
+// + localStorage. Handler must refuse (return `false`) so the caller treats
+// the dispatch as a miss and production state is preserved.
+// ---------------------------------------------------------------------------
+
+test('U5 module: punctuation-close-map refuses to dispatch from active-item phase (adv-219-008)', () => {
+  const harness = createHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  // Seed an active-item phase with a live session payload.
+  harness.store.updateSubjectUi('punctuation', {
+    phase: 'active-item',
+    session: { id: 'session-1', currentItem: { id: 'item-1' } },
+  });
+  assert.equal(punctuationState(harness).phase, 'active-item');
+
+  const result = harness.handleSubjectAction('punctuation-close-map');
+  assert.equal(result, false, 'close-map must return false outside map phase');
+
+  const state = punctuationState(harness);
+  assert.equal(state.phase, 'active-item', 'phase must remain active-item');
+  assert.ok(state.session, 'live session must be preserved on refused dispatch');
+  assert.equal(state.mapUi, undefined, 'mapUi must NOT be seeded by a refused dispatch');
+});
+
+test('U5 module: punctuation-close-map refuses to dispatch from setup phase (adv-219-008)', () => {
+  const harness = createHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  assert.equal(punctuationState(harness).phase, 'setup');
+  assert.equal(punctuationState(harness).mapUi, undefined);
+
+  const result = harness.handleSubjectAction('punctuation-close-map');
+  assert.equal(result, false, 'close-map must return false from setup phase');
+
+  const state = punctuationState(harness);
+  assert.equal(state.phase, 'setup');
+  assert.equal(state.mapUi, undefined, 'mapUi must NOT be seeded from setup dispatch');
+});
+
+test('U5 module: punctuation-close-map refuses to dispatch from feedback phase (adv-219-008)', () => {
+  const harness = createHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.store.updateSubjectUi('punctuation', {
+    phase: 'feedback',
+    feedback: { kind: 'success', headline: 'Great!', body: '' },
+  });
+  assert.equal(punctuationState(harness).phase, 'feedback');
+
+  const result = harness.handleSubjectAction('punctuation-close-map');
+  assert.equal(result, false);
+
+  const state = punctuationState(harness);
+  assert.equal(state.phase, 'feedback', 'phase must remain feedback');
+  assert.ok(state.feedback, 'feedback payload must be preserved on refused dispatch');
+  assert.equal(state.mapUi, undefined);
+});
+
+test('U5 module: punctuation-close-map refuses to dispatch from summary phase (adv-219-008)', () => {
+  const harness = createHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.store.updateSubjectUi('punctuation', {
+    phase: 'summary',
+    summary: { label: 'Session', total: 0, correct: 0 },
+  });
+  assert.equal(punctuationState(harness).phase, 'summary');
+
+  const result = harness.handleSubjectAction('punctuation-close-map');
+  assert.equal(result, false);
+
+  const state = punctuationState(harness);
+  assert.equal(state.phase, 'summary', 'phase must remain summary');
+  assert.ok(state.summary, 'summary payload must be preserved');
+  assert.equal(state.mapUi, undefined);
+});
+
+test('U5 module: punctuation-close-map refuses to dispatch from error phase (adv-219-008)', () => {
+  const harness = createHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.store.updateSubjectUi('punctuation', {
+    phase: 'error',
+    error: 'Something went wrong',
+  });
+  assert.equal(punctuationState(harness).phase, 'error');
+
+  const result = harness.handleSubjectAction('punctuation-close-map');
+  assert.equal(result, false);
+
+  const state = punctuationState(harness);
+  assert.equal(state.phase, 'error', 'phase must remain error');
+  assert.equal(state.mapUi, undefined);
+});
+
+test('U5 module: punctuation-close-map ALLOWS dispatch when phase is map (adv-219-008 positive)', () => {
+  // Control: the guard must only refuse non-map phases. Inside map the
+  // close-map handler continues to transition map → setup + reset detail state.
+  const harness = createHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.dispatch('punctuation-open-map');
+  harness.dispatch('punctuation-skill-detail-open', { skillId: 'speech' });
+  assert.equal(punctuationState(harness).phase, 'map');
+  assert.equal(punctuationState(harness).mapUi.detailOpenSkillId, 'speech');
+
+  const result = harness.handleSubjectAction('punctuation-close-map');
+  assert.equal(result, true, 'close-map must succeed from map phase');
+
+  const state = punctuationState(harness);
+  assert.equal(state.phase, 'setup', 'phase must transition to setup');
+  assert.equal(state.error, '');
+  assert.equal(state.mapUi.detailOpenSkillId, null, 'detailOpenSkillId must be cleared');
+});

--- a/tests/punctuation-map-phase.test.js
+++ b/tests/punctuation-map-phase.test.js
@@ -577,3 +577,180 @@ test('U5 normalisePunctuationMapUi: rejects detailOpenSkillId not in PUNCTUATION
   const ui = normalisePunctuationMapUi({ detailOpenSkillId: 'nonexistent_xyz' });
   assert.equal(ui.detailOpenSkillId, null);
 });
+
+// ---------------------------------------------------------------------------
+// Adversarial reviewer HIGH adv-219-006 — `reloadFromRepositories` must
+// rehydrate through the sanitiser. Bootstrap already strips `phase: 'map'` +
+// `mapUi`, but the production hot paths (persistence retry, learner deletion,
+// settings sync, clear-all-progress, import-snapshot, Punctuation command
+// response) all call `reloadFromRepositories` which re-reads persisted UI and
+// MUST apply the same rehydrate sanitiser. Without this, the Map phase and
+// its filter state survive across reload paths mid-session.
+// ---------------------------------------------------------------------------
+
+test('U5 reloadFromRepositories strips persisted phase=map + mapUi (adv-219-006)', () => {
+  const storage = installMemoryStorage();
+  const harness = createAppHarness({
+    storage,
+    subjectExposureGates: { [SUBJECT_EXPOSURE_GATES.punctuation]: true },
+  });
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.dispatch('punctuation-open-map');
+  harness.dispatch('punctuation-map-status-filter', { value: 'weak' });
+  harness.dispatch('punctuation-map-monster-filter', { value: 'pealark' });
+  harness.dispatch('punctuation-skill-detail-open', { skillId: 'speech' });
+
+  // Pre-condition: Map phase + filters are live in memory AND persisted.
+  const pre = harness.store.getState().subjectUi.punctuation;
+  assert.equal(pre.phase, 'map');
+  assert.equal(pre.mapUi.statusFilter, 'weak');
+  assert.equal(pre.mapUi.monsterFilter, 'pealark');
+  assert.equal(pre.mapUi.detailOpenSkillId, 'speech');
+
+  // Hot path: reloadFromRepositories is called by persistence-retry,
+  // learner-deletion, settings-switch, clear-all-progress, import-snapshot
+  // and the Punctuation command response adapter. It re-reads persisted UI
+  // and must sanitise the rehydrate exactly like bootstrap does.
+  harness.store.reloadFromRepositories({ preserveRoute: true });
+
+  const post = harness.store.getState().subjectUi.punctuation;
+  assert.notEqual(
+    post.phase,
+    'map',
+    'phase "map" must NOT survive reloadFromRepositories',
+  );
+  assert.equal(
+    post.phase,
+    'setup',
+    'phase must coerce to "setup" on reload rehydrate',
+  );
+  // mapUi either stripped entirely or defaulted — either is acceptable per
+  // the rehydrate sanitiser contract.
+  const mapUi = post.mapUi;
+  const isStrippedOrDefault = mapUi === undefined
+    || (
+      mapUi.statusFilter === 'all'
+      && mapUi.monsterFilter === 'all'
+      && mapUi.detailOpenSkillId === null
+    );
+  assert.ok(
+    isStrippedOrDefault,
+    `mapUi must NOT carry persisted state after reload, got ${JSON.stringify(mapUi)}`,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Adversarial reviewer HIGH adv-219-007 — the five Map-scoped handlers must
+// gate on `ui.phase === 'map'`. Without the guard, a dispatch from Setup /
+// active-item / feedback / summary / unavailable / error lands `mapUi` in
+// state + localStorage, which then tempts the rehydrate path into restoring
+// filter state even when the reload sanitiser would otherwise clear it.
+// Handlers return `false` so the caller treats the dispatch as a miss.
+// ---------------------------------------------------------------------------
+
+test('U5 filter handlers refuse to dispatch from setup phase (adv-219-007)', () => {
+  const harness = createHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  // Pre-condition: phase is setup — NOT map.
+  assert.equal(punctuationState(harness).phase, 'setup');
+  assert.equal(punctuationState(harness).mapUi, undefined);
+
+  const statusResult = harness.handleSubjectAction('punctuation-map-status-filter', { value: 'weak' });
+  assert.equal(statusResult, false, 'status-filter must return false outside map phase');
+  assert.equal(punctuationState(harness).mapUi, undefined);
+
+  const monsterResult = harness.handleSubjectAction('punctuation-map-monster-filter', { value: 'pealark' });
+  assert.equal(monsterResult, false, 'monster-filter must return false outside map phase');
+  assert.equal(punctuationState(harness).mapUi, undefined);
+
+  const detailOpenResult = harness.handleSubjectAction('punctuation-skill-detail-open', { skillId: 'speech' });
+  assert.equal(detailOpenResult, false, 'skill-detail-open must return false outside map phase');
+  assert.equal(punctuationState(harness).mapUi, undefined);
+
+  const detailCloseResult = harness.handleSubjectAction('punctuation-skill-detail-close');
+  assert.equal(detailCloseResult, false, 'skill-detail-close must return false outside map phase');
+  assert.equal(punctuationState(harness).mapUi, undefined);
+
+  const detailTabResult = harness.handleSubjectAction('punctuation-skill-detail-tab', { value: 'practise' });
+  assert.equal(detailTabResult, false, 'skill-detail-tab must return false outside map phase');
+  assert.equal(punctuationState(harness).mapUi, undefined);
+});
+
+test('U5 filter handlers refuse to dispatch from active-item phase (adv-219-007)', () => {
+  const harness = createHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  // Seed an active-item phase directly — the guard is phase-level and does
+  // not require a real session, only that phase !== 'map'.
+  harness.store.updateSubjectUi('punctuation', {
+    phase: 'active-item',
+    session: { id: 'session-1', currentItem: { id: 'item-1' } },
+  });
+  assert.equal(punctuationState(harness).phase, 'active-item');
+
+  const statusResult = harness.handleSubjectAction('punctuation-map-status-filter', { value: 'weak' });
+  assert.equal(statusResult, false);
+  assert.equal(
+    punctuationState(harness).mapUi,
+    undefined,
+    'active-item dispatch must NOT seed mapUi',
+  );
+  // Session must remain intact — the refused dispatch is a true no-op.
+  assert.ok(punctuationState(harness).session);
+
+  const detailOpenResult = harness.handleSubjectAction('punctuation-skill-detail-open', { skillId: 'speech' });
+  assert.equal(detailOpenResult, false);
+  assert.equal(punctuationState(harness).mapUi, undefined);
+});
+
+test('U5 filter handlers refuse to dispatch from feedback phase (adv-219-007)', () => {
+  const harness = createHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.store.updateSubjectUi('punctuation', {
+    phase: 'feedback',
+    feedback: { kind: 'success', headline: 'Great!', body: '' },
+  });
+  assert.equal(punctuationState(harness).phase, 'feedback');
+
+  const monsterResult = harness.handleSubjectAction('punctuation-map-monster-filter', { value: 'pealark' });
+  assert.equal(monsterResult, false);
+  assert.equal(punctuationState(harness).mapUi, undefined);
+  assert.ok(
+    punctuationState(harness).feedback,
+    'feedback payload must remain intact on refused dispatch',
+  );
+});
+
+test('U5 filter handlers refuse to dispatch from summary phase (adv-219-007)', () => {
+  const harness = createHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.store.updateSubjectUi('punctuation', {
+    phase: 'summary',
+    summary: { label: 'Session', total: 0, correct: 0 },
+  });
+  assert.equal(punctuationState(harness).phase, 'summary');
+
+  const tabResult = harness.handleSubjectAction('punctuation-skill-detail-tab', { value: 'practise' });
+  assert.equal(tabResult, false);
+  assert.equal(punctuationState(harness).mapUi, undefined);
+});
+
+test('U5 filter handlers ALLOW dispatch when phase is map (adv-219-007 positive)', () => {
+  // Control: the guard must only refuse non-map phases. Inside map the five
+  // handlers continue to mutate state exactly as before.
+  const harness = createHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.dispatch('punctuation-open-map');
+  assert.equal(punctuationState(harness).phase, 'map');
+
+  assert.equal(
+    harness.handleSubjectAction('punctuation-map-status-filter', { value: 'weak' }),
+    true,
+  );
+  assert.equal(punctuationState(harness).mapUi.statusFilter, 'weak');
+
+  assert.equal(
+    harness.handleSubjectAction('punctuation-skill-detail-open', { skillId: 'speech' }),
+    true,
+  );
+  assert.equal(punctuationState(harness).mapUi.detailOpenSkillId, 'speech');
+});

--- a/tests/punctuation-map-phase.test.js
+++ b/tests/punctuation-map-phase.test.js
@@ -371,3 +371,209 @@ test('U5 module: punctuation-skill-detail-tab rejects invalid tab values', () =>
   // Invalid value: handler returns false, state is unchanged.
   assert.equal(punctuationState(harness).mapUi.detailTab, 'practise');
 });
+
+// ---------------------------------------------------------------------------
+// Adversarial reviewer HIGH adv-219-001 — `mapUi` + `phase: 'map'` must NOT
+// survive a page reload. The plan (line 565, 583) pins the Map phase and its
+// filter state as session-ephemeral: there is no D1 persistence path and a
+// fresh harness over the same localStorage must land on `phase: 'setup'` with
+// mapUi defaulted (or absent). This test reproduces the reload by
+// instantiating a second `createAppHarness` over the same `MemoryStorage`.
+// ---------------------------------------------------------------------------
+
+test('U5 persistence: phase=map and mapUi filter/detail state do not survive reload', () => {
+  const storage = installMemoryStorage();
+
+  const h1 = createAppHarness({
+    storage,
+    subjectExposureGates: { [SUBJECT_EXPOSURE_GATES.punctuation]: true },
+  });
+  h1.dispatch('open-subject', { subjectId: 'punctuation' });
+  h1.dispatch('punctuation-open-map');
+  h1.dispatch('punctuation-map-status-filter', { value: 'weak' });
+  h1.dispatch('punctuation-map-monster-filter', { value: 'pealark' });
+  h1.dispatch('punctuation-skill-detail-open', { skillId: 'speech' });
+
+  // Pre-condition: live state reflects the Map-phase interactions.
+  const pre = h1.store.getState().subjectUi.punctuation;
+  assert.equal(pre.phase, 'map');
+  assert.equal(pre.mapUi.statusFilter, 'weak');
+  assert.equal(pre.mapUi.monsterFilter, 'pealark');
+  assert.equal(pre.mapUi.detailOpenSkillId, 'speech');
+
+  // Simulate reload by constructing a second harness over the same storage.
+  // `createAppHarness` re-hydrates from the repositories, which in turn read
+  // from `localStorage` (the MemoryStorage we installed above).
+  const h2 = createAppHarness({
+    storage,
+    subjectExposureGates: { [SUBJECT_EXPOSURE_GATES.punctuation]: true },
+  });
+  const post = h2.store.getState().subjectUi.punctuation;
+
+  // Phase must NOT survive: learner returns to Setup after a reload. This
+  // guards the plan's "mapUi is session-ephemeral" invariant (line 565, 583)
+  // against the current shallow-merge `buildSubjectUiState` path which would
+  // otherwise echo `phase: 'map'` straight back from `localStorage`.
+  assert.notEqual(post.phase, 'map', 'phase "map" must NOT survive a reload');
+  assert.equal(post.phase, 'setup', 'phase must coerce to "setup" on rehydrate');
+
+  // mapUi must NOT carry persisted filter / detail state. Either the field is
+  // stripped entirely or it matches the default shape.
+  const mapUi = post.mapUi;
+  const isStrippedOrDefault = mapUi === undefined
+    || (
+      mapUi.statusFilter === 'all'
+      && mapUi.monsterFilter === 'all'
+      && mapUi.detailOpenSkillId === null
+    );
+  assert.ok(
+    isStrippedOrDefault,
+    `mapUi must NOT carry persisted filter / detail state, got ${JSON.stringify(mapUi)}`,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Adversarial reviewer HIGH adv-219-002 — `punctuation-open-map` must guard
+// against orphan-session creation. The shallow-merge path preserves `session`
+// / `feedback` / `summary` when called mid-session, which leaves a zombie
+// session pinned under `phase: 'map'`. The guard restricts open-map to the
+// phases where Map is a legitimate affordance: `'setup'` and `'summary'`.
+// ---------------------------------------------------------------------------
+
+test('U5 open-map guard: refuses to dispatch from active-item phase', () => {
+  // State-level assertion only: `harness.dispatch` always returns `true` at
+  // the app-controller layer (it wraps handle-subject-action inside a
+  // try/finally and returns `true` unconditionally). The guard's failure
+  // mode surfaces as a no-op on `state.phase` / `state.session` — paired
+  // state-level checks close the silent-no-op gap (learning #7).
+  const harness = createHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  // Put the subject into `active-item` with a live session. A plain
+  // updateSubjectUi write is enough — the guard is phase-level and does not
+  // care how the session was seeded.
+  harness.store.updateSubjectUi('punctuation', {
+    phase: 'active-item',
+    session: { id: 'zombie-session', currentItem: { id: 'item-1' } },
+  });
+  assert.equal(punctuationState(harness).phase, 'active-item');
+
+  harness.dispatch('punctuation-open-map');
+
+  assert.equal(
+    punctuationState(harness).phase,
+    'active-item',
+    'phase must remain active-item (guard refused the transition)',
+  );
+  assert.ok(
+    punctuationState(harness).session,
+    'session must NOT be orphaned into phase=map',
+  );
+  assert.equal(
+    punctuationState(harness).mapUi,
+    undefined,
+    'mapUi must NOT be seeded from a refused open-map dispatch',
+  );
+});
+
+test('U5 open-map guard: refuses to dispatch from feedback phase', () => {
+  const harness = createHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.store.updateSubjectUi('punctuation', {
+    phase: 'feedback',
+    feedback: { kind: 'success', headline: 'Great!', body: '' },
+  });
+
+  harness.dispatch('punctuation-open-map');
+
+  assert.equal(
+    punctuationState(harness).phase,
+    'feedback',
+    'phase must remain feedback (guard refused the transition)',
+  );
+  assert.ok(
+    punctuationState(harness).feedback,
+    'feedback payload must NOT be wiped by a refused open-map dispatch',
+  );
+});
+
+test('U5 open-map guard: allowed from setup phase', () => {
+  const harness = createHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  assert.equal(punctuationState(harness).phase, 'setup');
+
+  harness.dispatch('punctuation-open-map');
+
+  assert.equal(punctuationState(harness).phase, 'map');
+  assert.ok(punctuationState(harness).mapUi, 'mapUi must seed on successful open-map');
+});
+
+test('U5 open-map guard: allowed from summary phase', () => {
+  // Per plan line 519 — the Summary scene offers an "Open Punctuation Map"
+  // next-action button. Guard must permit the transition out of summary.
+  const harness = createHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.store.updateSubjectUi('punctuation', {
+    phase: 'summary',
+    summary: { label: 'Punctuation session summary', total: 0, correct: 0 },
+    session: null,
+    feedback: null,
+  });
+
+  harness.dispatch('punctuation-open-map');
+
+  assert.equal(punctuationState(harness).phase, 'map');
+});
+
+// ---------------------------------------------------------------------------
+// Adversarial reviewer MEDIUM adv-219-004 — `punctuation-skill-detail-open`
+// must validate skillId against the published PUNCTUATION_CLIENT_SKILLS list.
+// An arbitrary string lands a rogue detailOpenSkillId in state and, in U6,
+// would render an empty / malformed modal.
+// ---------------------------------------------------------------------------
+
+test('U5 skill-detail-open: rejects skillId not in PUNCTUATION_CLIENT_SKILLS', () => {
+  // State-level assertion only — see comment on the open-map guard tests
+  // above (harness.dispatch returns true unconditionally at the controller
+  // layer). The handler's refusal surfaces as state retaining the prior
+  // value; learning #7's silent-no-op gap is closed by the paired check.
+  const harness = createHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.dispatch('punctuation-open-map');
+  // Seed a known-good value so we can prove the invalid dispatch is a no-op.
+  harness.dispatch('punctuation-skill-detail-open', { skillId: 'speech' });
+  assert.equal(punctuationState(harness).mapUi.detailOpenSkillId, 'speech');
+
+  harness.dispatch('punctuation-skill-detail-open', {
+    skillId: 'nonexistent_xyz',
+  });
+
+  assert.equal(
+    punctuationState(harness).mapUi.detailOpenSkillId,
+    'speech',
+    'state must retain prior skillId when an unknown id is dispatched',
+  );
+});
+
+test('U5 skill-detail-open: accepts every published PUNCTUATION_CLIENT_SKILLS id', async () => {
+  const { PUNCTUATION_CLIENT_SKILLS } = await import('../src/subjects/punctuation/read-model.js');
+  const harness = createHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.dispatch('punctuation-open-map');
+
+  for (const skill of PUNCTUATION_CLIENT_SKILLS) {
+    harness.dispatch('punctuation-skill-detail-open', { skillId: skill.id });
+    assert.equal(
+      punctuationState(harness).mapUi.detailOpenSkillId,
+      skill.id,
+      `published id ${skill.id} must be accepted`,
+    );
+  }
+});
+
+test('U5 normalisePunctuationMapUi: rejects detailOpenSkillId not in PUNCTUATION_CLIENT_SKILLS', async () => {
+  // Second-line defence: even if a rogue payload reaches the normaliser
+  // directly (e.g. via a raw service-contract call), detailOpenSkillId must
+  // reset to null for unknown ids.
+  const ui = normalisePunctuationMapUi({ detailOpenSkillId: 'nonexistent_xyz' });
+  assert.equal(ui.detailOpenSkillId, null);
+});

--- a/tests/punctuation-view-model.test.js
+++ b/tests/punctuation-view-model.test.js
@@ -687,3 +687,43 @@ test('U1 safety: punctuation-view-model.js does not import react', async () => {
   assert.equal(/from ['"]react['"]/i.test(source), false);
   assert.equal(/require\(['"]react['"]\)/i.test(source), false);
 });
+
+// ---------------------------------------------------------------------------
+// Round-2 maintainability LOW — drift guard between the skill-id list in
+// `service-contract.js` (used by the normaliser + module handler) and the
+// full skill metadata in `read-model.js` (used by the Map scene + selectors).
+// A silent divergence would mean a Map entry exists without a validation
+// counterpart, or vice versa — a class of bug the frozen lists were meant
+// to prevent. One symmetric assertion keeps both files in lock-step.
+// ---------------------------------------------------------------------------
+
+test('U5 drift: PUNCTUATION_CLIENT_SKILL_IDS stays in lock-step with PUNCTUATION_CLIENT_SKILLS', async () => {
+  const { PUNCTUATION_CLIENT_SKILL_IDS } = await import(
+    '../src/subjects/punctuation/service-contract.js'
+  );
+  const { PUNCTUATION_CLIENT_SKILLS } = await import(
+    '../src/subjects/punctuation/read-model.js'
+  );
+  assert.equal(
+    PUNCTUATION_CLIENT_SKILL_IDS.length,
+    PUNCTUATION_CLIENT_SKILLS.length,
+    'skill-id list length diverged from skill metadata list',
+  );
+  const clientIds = new Set(PUNCTUATION_CLIENT_SKILLS.map((skill) => skill.id));
+  for (const id of PUNCTUATION_CLIENT_SKILL_IDS) {
+    assert.ok(
+      clientIds.has(id),
+      `${id} is in PUNCTUATION_CLIENT_SKILL_IDS but not in PUNCTUATION_CLIENT_SKILLS`,
+    );
+  }
+  // Symmetric direction: every skill id in the read-model must also appear
+  // in the validation list — otherwise a Map entry would render with no way
+  // to ever be dispatched by a guarded handler.
+  const contractIds = new Set(PUNCTUATION_CLIENT_SKILL_IDS);
+  for (const skill of PUNCTUATION_CLIENT_SKILLS) {
+    assert.ok(
+      contractIds.has(skill.id),
+      `${skill.id} is in PUNCTUATION_CLIENT_SKILLS but not in PUNCTUATION_CLIENT_SKILL_IDS`,
+    );
+  }
+});

--- a/tests/punctuation-view-model.test.js
+++ b/tests/punctuation-view-model.test.js
@@ -18,6 +18,7 @@ import {
   ACTIVE_PUNCTUATION_MONSTER_DISPLAY_NAMES,
   ACTIVE_PUNCTUATION_MONSTER_IDS,
   PUNCTUATION_CHILD_FORBIDDEN_TERMS,
+  PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER,
   PUNCTUATION_DASHBOARD_HERO,
   PUNCTUATION_MAP_MONSTER_FILTER_IDS,
   PUNCTUATION_MAP_STATUS_FILTER_IDS,
@@ -40,6 +41,7 @@ import {
   punctuationSkillModalPreferredExample,
 } from '../src/subjects/punctuation/components/punctuation-view-model.js';
 import { MONSTERS_BY_SUBJECT } from '../src/platform/game/monsters.js';
+import { PUNCTUATION_CLUSTERS } from '../shared/punctuation/content.js';
 
 // ---------------------------------------------------------------------------
 // composeIsDisabled (R11) — moved from PunctuationPracticeSurface.jsx in U1.
@@ -640,6 +642,34 @@ test('U1 view-model: buildPunctuationMapModel output shape is frozen end-to-end'
     for (const skill of monster.skills) {
       assert.equal(Object.isFrozen(skill), true);
     }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER — drift guard against the Worker's
+// canonical `PUNCTUATION_CLUSTERS.monsterId` table in
+// `shared/punctuation/content.js`. The client mirror is forbidden from
+// importing the shared content in the browser bundle (bundle-audit rule);
+// tests allow the import so the mapping stays locked in step.
+// ---------------------------------------------------------------------------
+
+test('U5 drift: PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER matches shared PUNCTUATION_CLUSTERS', () => {
+  for (const cluster of PUNCTUATION_CLUSTERS) {
+    const clientMapped = PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER[cluster.id];
+    assert.equal(
+      clientMapped,
+      cluster.monsterId,
+      `client mirror drifted for cluster "${cluster.id}": expected "${cluster.monsterId}", got "${clientMapped}"`,
+    );
+  }
+  // Also guard against the client mirror carrying any cluster id not present
+  // in the shared canonical list.
+  const canonicalIds = new Set(PUNCTUATION_CLUSTERS.map((cluster) => cluster.id));
+  for (const clientId of Object.keys(PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER)) {
+    assert.ok(
+      canonicalIds.has(clientId),
+      `client mirror carries unknown cluster id "${clientId}"`,
+    );
   }
 });
 

--- a/tests/react-punctuation-scene.test.js
+++ b/tests/react-punctuation-scene.test.js
@@ -682,3 +682,57 @@ test('punctuation Map phase: skill-detail open / close transitions mapUi correct
   harness.dispatch('punctuation-skill-detail-close');
   assert.equal(harness.store.getState().subjectUi.punctuation.mapUi.detailOpenSkillId, null);
 });
+
+// ---------------------------------------------------------------------------
+// Design-lens follow-ups from U5 review: top-bar Back button + live-region
+// filtered-count summary. Mirrors Spelling `word-bank-topbar` and Grammar
+// `grammar-bank-topbar` patterns.
+// ---------------------------------------------------------------------------
+
+test('punctuation Map scene renders a top-bar Back to dashboard button (design-lens)', () => {
+  const harness = createPunctuationHarness();
+  openMapScene(harness);
+  const html = harness.render();
+
+  // `punctuation-map-topbar` parallels Spelling's `word-bank-topbar` and
+  // Grammar's `grammar-bank-topbar` so a screen reader lands on the exit
+  // affordance before the hero / filter rows.
+  assert.match(html, /class="punctuation-map-topbar"/);
+  // The top-bar back button dispatches `punctuation-close-map`.
+  assert.match(
+    html,
+    /<header class="punctuation-map-topbar">[\s\S]*?data-action="punctuation-close-map"[\s\S]*?<\/header>/,
+    'top-bar must contain a punctuation-close-map button',
+  );
+});
+
+test('punctuation Map scene renders a role="status" live-region count of visible skills', () => {
+  const harness = createPunctuationHarness();
+  openMapScene(harness);
+  const html = harness.render();
+
+  // Default filters render all 14 skills — the summary text reads "Showing
+  // all 14 skills." and lives inside a role="status" <p> so a screen reader
+  // announces filter changes.
+  assert.match(
+    html,
+    /role="status"[^>]*>Showing all 14 skills\.<|>Showing all 14 skills\.<[^>]*role="status"/,
+    'live-region summary must read "Showing all 14 skills." by default',
+  );
+});
+
+test('punctuation Map scene live-region count reflects a monster filter flip', () => {
+  const harness = createPunctuationHarness();
+  openMapScene(harness);
+  // Apply the Pealark monster filter — Pealark owns endmarks + speech +
+  // boundary clusters, which carry 5 skills total (sentence_endings, speech,
+  // semicolon, dash_clause, hyphen). The summary must re-count.
+  harness.dispatch('punctuation-map-monster-filter', { value: 'pealark' });
+
+  const html = harness.render();
+  assert.match(
+    html,
+    /role="status"[^>]*>Showing 5 of 14 skills\.<|>Showing 5 of 14 skills\.<[^>]*role="status"/,
+    'live-region summary must reflect the narrowed monster filter',
+  );
+});

--- a/tests/react-punctuation-scene.test.js
+++ b/tests/react-punctuation-scene.test.js
@@ -6,6 +6,12 @@ import { createAppHarness } from './helpers/app-harness.js';
 import { installMemoryStorage } from './helpers/memory-storage.js';
 import { PUNCTUATION_RELEASE_ID } from '../shared/punctuation/content.js';
 import { SUBJECT_EXPOSURE_GATES } from '../src/platform/core/subject-availability.js';
+import {
+  PUNCTUATION_CHILD_FORBIDDEN_TERMS,
+  PUNCTUATION_MAP_MONSTER_FILTER_IDS,
+  PUNCTUATION_MAP_STATUS_FILTER_IDS,
+} from '../src/subjects/punctuation/components/punctuation-view-model.js';
+import { PUNCTUATION_MODES } from '../src/subjects/punctuation/service-contract.js';
 
 function createPunctuationHarness() {
   return createAppHarness({
@@ -464,4 +470,215 @@ test('punctuation text-item submit remains enabled in the idle state', () => {
     /<button[^>]*disabled[^>]*data-punctuation-submit/,
     'idle active text item must allow submit',
   );
+});
+
+// ---------------------------------------------------------------------------
+// Phase 3 U5 — Punctuation Map scene.
+//
+// `phase === 'map'` renders 14 skill cards across the 4 active monsters with
+// filter chips and skill-detail open/close state handling. Reserved monsters
+// (Colisk / Hyphang / Carillon) never surface regardless of state shape.
+//
+// SSR blind spots (learning #6): pointer-capture, focus, and scroll are not
+// observable here — every assertion below is a paired HTML-match +
+// state-level check (learning #7) to close the silent-no-op gap.
+// ---------------------------------------------------------------------------
+
+function openMapScene(harness) {
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.dispatch('punctuation-open-map');
+}
+
+function forbiddenTermsInHtml(html) {
+  const leaks = [];
+  for (const term of PUNCTUATION_CHILD_FORBIDDEN_TERMS) {
+    if (term instanceof RegExp) {
+      if (term.test(html)) leaks.push(String(term));
+      continue;
+    }
+    if (typeof term !== 'string' || !term) continue;
+    if (html.toLowerCase().includes(term.toLowerCase())) leaks.push(term);
+  }
+  return leaks;
+}
+
+test('punctuation Map scene renders 14 skill cards across 4 monster groups', () => {
+  const harness = createPunctuationHarness();
+  openMapScene(harness);
+  const html = harness.render();
+
+  // Each active monster renders as a section with the aria-label "<Name> skills".
+  for (const name of ['Pealark', 'Claspin', 'Curlune', 'Quoral']) {
+    assert.match(html, new RegExp(`aria-label="${name} skills"`), `missing monster group for ${name}`);
+  }
+  // 14 skill cards — count the per-card wrapper.
+  const cardMatches = html.match(/class="punctuation-map-skill-card"/g) || [];
+  assert.equal(cardMatches.length, 14, `expected 14 skill cards, got ${cardMatches.length}`);
+});
+
+test('punctuation Map scene never renders reserved monster groups', () => {
+  const harness = createPunctuationHarness();
+  openMapScene(harness);
+  // Smuggle reserved monster entries into the reward state via updateSubjectUi.
+  // The Map scene iterator is ACTIVE_PUNCTUATION_MONSTER_IDS only, so even a
+  // poisoned rewardState must not surface the reserved trio as groups.
+  harness.store.updateSubjectUi('punctuation', {
+    rewardState: {
+      pealark: { mastered: ['r1'] },
+      colisk: { mastered: ['c1', 'c2'] },
+      hyphang: { mastered: ['h1'] },
+      carillon: { mastered: ['ca1'] },
+    },
+  });
+  const html = harness.render();
+
+  for (const reserved of ['Colisk', 'Hyphang', 'Carillon']) {
+    assert.doesNotMatch(html, new RegExp(`aria-label="${reserved} skills"`), `reserved ${reserved} leaked as a group`);
+    assert.doesNotMatch(html, new RegExp(`data-monster-id="${reserved.toLowerCase()}"`));
+  }
+});
+
+test('punctuation Map scene renders the status filter chip row with child copy', () => {
+  const harness = createPunctuationHarness();
+  openMapScene(harness);
+  const html = harness.render();
+
+  // Plan: ['All','New','Learning','Due','Wobbly','Secure'].
+  for (const label of ['All', 'New', 'Learning', 'Due today', 'Wobbly', 'Secure']) {
+    assert.match(html, new RegExp(`>${label}<`), `missing status chip label ${label}`);
+  }
+  assert.match(html, /data-action="punctuation-map-status-filter"/);
+  // Every chip carries aria-pressed — the group is the canonical accessible
+  // "toggle row" shape.
+  for (const id of PUNCTUATION_MAP_STATUS_FILTER_IDS) {
+    assert.match(html, new RegExp(`data-value="${id}"`));
+  }
+});
+
+test('punctuation Map scene renders the monster filter chip row with active roster only', () => {
+  const harness = createPunctuationHarness();
+  openMapScene(harness);
+  const html = harness.render();
+
+  for (const id of PUNCTUATION_MAP_MONSTER_FILTER_IDS) {
+    assert.match(html, new RegExp(`data-action="punctuation-map-monster-filter"[^>]*data-value="${id}"`));
+  }
+  // Reserved monster chips never appear — the frozen filter list excludes
+  // them at the source.
+  for (const reserved of ['colisk', 'hyphang', 'carillon']) {
+    assert.doesNotMatch(
+      html,
+      new RegExp(`data-action="punctuation-map-monster-filter"[^>]*data-value="${reserved}"`),
+      `reserved ${reserved} chip leaked`,
+    );
+  }
+});
+
+test('punctuation Map scene: clicking Wobbly sets state.mapUi.statusFilter to `weak`', () => {
+  const harness = createPunctuationHarness();
+  openMapScene(harness);
+  // Simulate the click by dispatching through the real pipeline.
+  harness.dispatch('punctuation-map-status-filter', { value: 'weak' });
+
+  const state = harness.store.getState().subjectUi.punctuation;
+  assert.equal(state.mapUi.statusFilter, 'weak');
+
+  // Paired HTML assertion: aria-pressed flips to "true" on the Wobbly chip.
+  const html = harness.render();
+  assert.match(
+    html,
+    /data-value="weak"[^>]*aria-pressed="true"|aria-pressed="true"[^>]*data-value="weak"/,
+    'Wobbly chip should render with aria-pressed="true"',
+  );
+});
+
+test('punctuation Map scene: clicking Pealark sets state.mapUi.monsterFilter to `pealark`', () => {
+  const harness = createPunctuationHarness();
+  openMapScene(harness);
+  harness.dispatch('punctuation-map-monster-filter', { value: 'pealark' });
+
+  const state = harness.store.getState().subjectUi.punctuation;
+  assert.equal(state.mapUi.monsterFilter, 'pealark');
+});
+
+test('punctuation Map scene: invalid status-filter value returns false and leaves state unchanged', () => {
+  const harness = createPunctuationHarness();
+  openMapScene(harness);
+  harness.dispatch('punctuation-map-status-filter', { value: 'weak' });
+  assert.equal(harness.store.getState().subjectUi.punctuation.mapUi.statusFilter, 'weak');
+
+  harness.dispatch('punctuation-map-status-filter', { value: 'garbage' });
+
+  // Invalid payload: the handler returns false, the store is not touched,
+  // and the paired state assertion catches the silent-no-op (learning #7).
+  assert.equal(harness.store.getState().subjectUi.punctuation.mapUi.statusFilter, 'weak');
+});
+
+test('punctuation Map scene: PUNCTUATION_MODES enum unchanged at 10 entries (R17)', () => {
+  // The Map is a phase, not a mode. No amount of Phase 3 scene work should
+  // extend the mode enum past the Phase 2 shape.
+  assert.equal(PUNCTUATION_MODES.length, 10);
+});
+
+test('punctuation Map scene: degraded availability disables Practise this and filter chips', () => {
+  const harness = createPunctuationHarness();
+  openMapScene(harness);
+  harness.store.updateSubjectUi('punctuation', {
+    availability: { status: 'degraded', code: 'runtime_degraded', message: 'paused' },
+  });
+  const html = harness.render();
+
+  // Every filter chip in the group row renders with `disabled`.
+  for (const id of PUNCTUATION_MAP_STATUS_FILTER_IDS) {
+    assert.match(
+      html,
+      new RegExp(`<button[^>]*disabled[^>]*data-value="${id}"[^>]*data-action="punctuation-map-status-filter"|<button[^>]*disabled[^>]*data-action="punctuation-map-status-filter"[^>]*data-value="${id}"`),
+      `status chip ${id} should be disabled under degraded availability`,
+    );
+  }
+  // At least one "Practise this" button is disabled.
+  assert.match(
+    html,
+    /<button[^>]*disabled[^>]*>Practise this<\/button>/,
+    'Practise this must be disabled under degraded availability',
+  );
+});
+
+test('punctuation Map scene SSR HTML contains no forbidden child terms', () => {
+  const harness = createPunctuationHarness();
+  openMapScene(harness);
+  const html = harness.render();
+  const leaks = forbiddenTermsInHtml(html);
+  assert.deepEqual(leaks, [], `forbidden term leak in Map scene HTML: ${leaks.join(', ')}`);
+});
+
+test('punctuation Map phase transition: setup → map → setup via dispatch chain', () => {
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  assert.equal(harness.store.getState().subjectUi.punctuation.phase, 'setup');
+
+  harness.dispatch('punctuation-open-map');
+  assert.equal(harness.store.getState().subjectUi.punctuation.phase, 'map');
+  // mapUi lands at defaults when the phase first opens.
+  assert.deepEqual(harness.store.getState().subjectUi.punctuation.mapUi, {
+    statusFilter: 'all',
+    monsterFilter: 'all',
+    detailOpenSkillId: null,
+    detailTab: 'learn',
+  });
+
+  harness.dispatch('punctuation-back');
+  assert.equal(harness.store.getState().subjectUi.punctuation.phase, 'setup');
+  assert.equal(harness.store.getState().subjectUi.punctuation.mapUi.detailOpenSkillId, null);
+});
+
+test('punctuation Map phase: skill-detail open / close transitions mapUi correctly', () => {
+  const harness = createPunctuationHarness();
+  openMapScene(harness);
+
+  harness.dispatch('punctuation-skill-detail-open', { skillId: 'speech' });
+  assert.equal(harness.store.getState().subjectUi.punctuation.mapUi.detailOpenSkillId, 'speech');
+
+  harness.dispatch('punctuation-skill-detail-close');
+  assert.equal(harness.store.getState().subjectUi.punctuation.mapUi.detailOpenSkillId, null);
 });


### PR DESCRIPTION
## Summary
- Extend `PUNCTUATION_PHASES` with `'map'` (frozen list now 7 entries).
- New `normalisePunctuationMapUi` + `mapUi` state shape (statusFilter, monsterFilter, detailOpenSkillId, detailTab).
- Module handlers: `punctuation-open-map`, `punctuation-close-map`, `punctuation-map-status-filter`, `punctuation-map-monster-filter`. Plus `punctuation-skill-detail-open/close/tab` (state-only; U6 wires the modal component).
- New `PunctuationMapScene.jsx` renders 14 skills grouped under 4 active monsters (Pealark/Claspin/Curlune/Quoral) with status + monster filter chips.
- `PunctuationPracticeSurface.jsx` routes `phase === 'map'` to the new scene.

## Plan reference
`docs/plans/2026-04-25-005-feat-punctuation-phase3-ux-rebuild-plan.md` U5.

Minor deviation: `punctuation-skill-detail-{open,close,tab}` state handlers land here instead of U6 to keep U6 a pure JSX-composition unit. U6 still owns the `PunctuationSkillDetailModal` component that consumes `mapUi.detailOpenSkillId` / `mapUi.detailTab`. Buttons in the Map scene already dispatch a real state delta rather than dead-ending until U6 (learning #7 — silent-no-op hazard).

Secondary deviations (documented in code comments):
- `PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER` added to `punctuation-view-model.js` so the Map scene can group skills by monster without importing `shared/punctuation/content.js` (which the bundle-audit rule forbids from the browser bundle). The mapping is the client mirror of the Worker's `PUNCTUATION_CLUSTERS.monsterId` and stays in lock-step with the U1 test fixture.
- `PUNCTUATION_CLIENT_SKILLS` promoted to a named export in `src/subjects/punctuation/read-model.js` so the scene can render the full 14-skill roster without duplicating it.
- `PUNCTUATION_SKILL_RULE_ONE_LINERS` + `punctuationSkillRuleOneLiner(skillId)` helper added to the view-model for the Map card's rule line. Copy lands initial versions; U6 / U10 will refine.

## Release-id impact
`release-id impact: none` — pure client UI, no engine/content changes.

## Test plan
- [x] `tests/punctuation-map-phase.test.js` — 28 new assertions (phase extension, `normalisePunctuationMapUi` defaults/fallbacks, every module handler's happy path + rejection path, paired state-level assertions throughout).
- [x] `tests/react-punctuation-scene.test.js` — 12 new assertions in a "Punctuation Map scene" describe block: 14 skill cards across 4 monster groups, reserved monsters never rendered even with poisoned reward state, filter chips with full child-copy labels, paired HTML + state-level assertions for Wobbly/Pealark filter clicks, invalid-value rejection, `PUNCTUATION_MODES` unchanged at 10 entries (R17), degraded-availability disables every chip + "Practise this", forbidden-term sweep across Map-phase SSR HTML.
- [x] `tests/punctuation-view-model.test.js` — all 54 U1 tests still green.
- [x] `tests/punctuation-session-ui.test.js` — U1 session-ui tests still green.
- [x] `tests/bundle-audit.test.js` — 26/26 green; `shared/punctuation/*` does not leak into the client bundle.
- [x] Full `npm test` — 1913 pass / 1 fail. The single failure (`Grammar production smoke scans feedback and summary models for forbidden keys` — `grammar.startModel.stats.templates`) is pre-existing on `origin/main`, confirmed by stashing U5 changes and re-running the suite. Unrelated to U5.

## R trace
- R2 (Map scene, 14 skills, filters): covered by `PunctuationMapScene.jsx` + map-phase tests.
- R10 (reserved monsters never rendered): `buildPunctuationMapModel` iterates `ACTIVE_PUNCTUATION_MONSTER_IDS` only; `PunctuationMapScene` tested against poisoned reward state.
- R11 (`composeIsDisabled` threads every mutation control): filter chips, "Practise this", "Open details", "Back to dashboard" — all thread the helper.
- R15 (no forbidden child terms): Map-phase SSR HTML asserts against `PUNCTUATION_CHILD_FORBIDDEN_TERMS`.
- R17 (Map is a phase, not a mode): `PUNCTUATION_MODES.length === 10` test locks the enum.

## Follow-ups for U6
- Create `PunctuationSkillDetailModal.jsx` consuming `mapUi.detailOpenSkillId` / `mapUi.detailTab`.
- Modal's "Practise this" dispatches `punctuation-start` with `{ mode: 'guided', guidedSkillId: <id>, roundLength: '4' }`.
- Refine `PUNCTUATION_SKILL_RULE_ONE_LINERS` copy during U6 / U10 sweep (initial lines are placeholders).