### PR TITLE
feat(grammar): U6b Writing Try scene (non-scored writing with saved history)

### DIFF
--- a/src/subjects/grammar/components/GrammarPracticeSurface.jsx
+++ b/src/subjects/grammar/components/GrammarPracticeSurface.jsx
@@ -4,15 +4,16 @@ import { GrammarConceptBankScene } from './GrammarConceptBankScene.jsx';
 import { GrammarSessionScene } from './GrammarSessionScene.jsx';
 import { GrammarSetupScene } from './GrammarSetupScene.jsx';
 import { GrammarSummaryScene } from './GrammarSummaryScene.jsx';
+import { GrammarTransferScene } from './GrammarTransferScene.jsx';
 import { GRAMMAR_MONSTER_ROUTES, GRAMMAR_SUBJECT_ID, normaliseGrammarReadModel } from '../metadata.js';
 import { normaliseGrammarRewardState } from '../../../platform/game/monster-system.js';
 
 const MONSTER_CODEX_SYSTEM_ID = 'monster-codex';
 
 // Phase 3 U2 replaces the Grammar Bank placeholder stub with the real
-// `GrammarConceptBankScene`. The Writing Try scene (`GrammarTransferScene`)
-// still ships as a placeholder until U6b lands; until then, U1's stub
-// holds the phase transition safe with a way back to the dashboard.
+// `GrammarConceptBankScene`. Phase 3 U6b replaces the Writing Try
+// placeholder with `GrammarTransferScene` — the non-scored writing
+// surface consuming the Worker `transferLane` read model.
 
 function selectedLearner(appState) {
   const learnerId = appState?.learners?.selectedId || '';
@@ -55,24 +56,6 @@ function resolveGrammarRewardState({ grammar, learner, repositories }) {
   const normalisedPersisted = normaliseGrammarRewardState(persistedState);
   if (hasGrammarRewardProgress(normalisedPersisted)) return normalisedPersisted;
   return Object.keys(normalisedProjected).length ? normalisedProjected : normalisedPersisted;
-}
-
-function GrammarTransferPlaceholderScene({ actions }) {
-  // U1 wires the "Writing Try" secondary button; U6b ships the real scene.
-  return (
-    <section className="grammar-transfer-placeholder" aria-labelledby="grammar-transfer-placeholder-title">
-      <h2 id="grammar-transfer-placeholder-title">Writing Try</h2>
-      <p>Non-scored writing practice is opening up soon. Nothing you write here will change your Grammar scores.</p>
-      <button
-        type="button"
-        className="btn primary"
-        data-action="grammar-back"
-        onClick={() => actions.dispatch('grammar-back')}
-      >
-        Back to Grammar Garden
-      </button>
-    </section>
-  );
 }
 
 export function GrammarPracticeSurface({
@@ -136,7 +119,7 @@ export function GrammarPracticeSurface({
   if (grammar.phase === 'transfer') {
     return (
       <div className="grammar-surface">
-        <GrammarTransferPlaceholderScene {...shared} />
+        <GrammarTransferScene {...shared} />
       </div>
     );
   }

--- a/src/subjects/grammar/components/GrammarTransferScene.jsx
+++ b/src/subjects/grammar/components/GrammarTransferScene.jsx
@@ -156,6 +156,9 @@ function ChecklistField({ items, ticks, disabled, onToggle }) {
   return (
     <fieldset className="grammar-transfer-checklist" disabled={disabled}>
       <legend className="grammar-transfer-checklist-legend">Self-check</legend>
+      <p className="grammar-transfer-checklist-hint">
+        Tick what you tried — it is just a reminder for you. Nothing is marked.
+      </p>
       <ul className="grammar-transfer-checklist-list">
         {items.map((item, index) => {
           const key = `check-${index}`;
@@ -229,6 +232,7 @@ function WriteMode({
           aria-describedby="grammar-transfer-counter"
           placeholder="Write 3-5 sentences here. Nothing you write is scored."
           value={draft}
+          disabled={pending}
           onChange={(event) => onDraftChange(event.currentTarget.value)}
         />
       </label>
@@ -267,6 +271,7 @@ function WriteMode({
           className="btn ghost"
           data-action="grammar-select-transfer-prompt"
           data-prompt-id=""
+          disabled={pending}
           onClick={onChangePrompt}
         >
           Change prompt
@@ -276,7 +281,19 @@ function WriteMode({
   );
 }
 
-function SavedHistory({ evidence }) {
+function labelForTick(tick, checklist) {
+  const key = typeof tick?.key === 'string' ? tick.key : '';
+  const match = /^check-(\d+)$/.exec(key);
+  if (!match) return key;
+  const index = Number(match[1]);
+  const items = Array.isArray(checklist) ? checklist : [];
+  if (Number.isInteger(index) && index >= 0 && typeof items[index] === 'string' && items[index]) {
+    return items[index];
+  }
+  return Number.isInteger(index) && index >= 0 ? `Check ${index + 1}` : key;
+}
+
+function SavedHistory({ evidence, checklist }) {
   if (!evidence) return null;
   const latest = evidence.latest;
   const history = Array.isArray(evidence.history)
@@ -303,7 +320,7 @@ function SavedHistory({ evidence }) {
                   key={tick.key || `tick-${index}`}
                 >
                   <span className="grammar-transfer-saved-tick-icon" aria-hidden="true">{tick.checked ? '[x]' : '[ ]'}</span>
-                  <span className="grammar-transfer-saved-tick-key">{tick.key}</span>
+                  <span className="grammar-transfer-saved-tick-label">{labelForTick(tick, checklist)}</span>
                 </li>
               ))}
             </ul>
@@ -466,7 +483,7 @@ export function GrammarTransferScene({ grammar, actions }) {
             onSave={handleSave}
             onChangePrompt={handleChangePrompt}
           />
-          <SavedHistory evidence={selectedEvidence} />
+          <SavedHistory evidence={selectedEvidence} checklist={activePrompt?.checklist} />
         </>
       ) : (
         <PickPromptMode

--- a/src/subjects/grammar/components/GrammarTransferScene.jsx
+++ b/src/subjects/grammar/components/GrammarTransferScene.jsx
@@ -1,0 +1,482 @@
+import React from 'react';
+import { GRAMMAR_CLIENT_CONCEPTS } from '../metadata.js';
+import {
+  GRAMMAR_CLUSTER_DISPLAY_NAMES,
+  grammarMonsterClusterForConcept,
+} from './grammar-view-model.js';
+
+// Phase 3 U6b: Writing Try scene. Non-scored writing surface reachable via
+// the dashboard's "Writing Try" secondary button (U1). Consumes the Worker
+// `transferLane` read model plumbed through by U6a and mirrors the Grammar
+// Bank scene's layout conventions (hero + back row + body card + secondary
+// sections).
+//
+// Three modes, chosen by the `ui.transfer.selectedPromptId` slot:
+//   1. pick-prompt   — no prompt selected; renders the prompt catalogue.
+//   2. write         — a prompt is selected; renders prompt details + a
+//                      textarea + self-check checklist + Save button.
+//   3. saved-history — rendered below the write surface when the selected
+//                      prompt already has `latest` evidence. Shows latest
+//                      (with self-assessment ticks) plus up to four
+//                      `history` snapshots (history omits self-assessment
+//                      by Worker contract asymmetry).
+//
+// Orphaned evidence (a promptId in `transferLane.evidence` that is absent
+// from `transferLane.prompts`) renders in a separate "Retired prompts"
+// section as read-only cards — matching the U6a Key Technical Decisions.
+//
+// Non-scored invariants held at the UI layer: no score card, no retry
+// button, no reward toast, no Concordium progress surface, no mastery
+// number. The scene only routes `grammar-save-transfer-evidence` plus the
+// four transient UI dispatchers registered in `module.js` for U6b.
+
+const WRITING_CAP = 2000;
+const HISTORY_LIMIT = 4;
+
+const CONCEPT_NAMES_BY_ID = Object.freeze(Object.fromEntries(
+  GRAMMAR_CLIENT_CONCEPTS.map((concept) => [concept.id, concept.name]),
+));
+
+function conceptLabel(conceptId) {
+  if (typeof conceptId !== 'string' || !conceptId) return '';
+  const name = CONCEPT_NAMES_BY_ID[conceptId];
+  if (name) return name;
+  // Fall back to a humanised id so an unexpected Worker target does not
+  // leak a raw snake_case id into child copy.
+  return conceptId
+    .replace(/[_-]+/g, ' ')
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function clusterLabelFor(conceptId) {
+  const clusterId = grammarMonsterClusterForConcept(conceptId);
+  return GRAMMAR_CLUSTER_DISPLAY_NAMES[clusterId] || '';
+}
+
+function relativeSavedAt(savedAt, nowMs = Date.now()) {
+  const timestamp = Number(savedAt);
+  if (!Number.isFinite(timestamp) || timestamp <= 0) return 'Just now';
+  const now = Number.isFinite(nowMs) ? nowMs : Date.now();
+  const deltaSeconds = Math.max(0, Math.floor((now - timestamp) / 1000));
+  if (deltaSeconds < 60) return 'Just now';
+  if (deltaSeconds < 60 * 60) {
+    const mins = Math.floor(deltaSeconds / 60);
+    return `${mins} minute${mins === 1 ? '' : 's'} ago`;
+  }
+  if (deltaSeconds < 60 * 60 * 24) {
+    const hours = Math.floor(deltaSeconds / (60 * 60));
+    return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+  }
+  const days = Math.floor(deltaSeconds / (60 * 60 * 24));
+  if (days < 30) return `${days} day${days === 1 ? '' : 's'} ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months} month${months === 1 ? '' : 's'} ago`;
+  const years = Math.floor(days / 365);
+  return `${years} year${years === 1 ? '' : 's'} ago`;
+}
+
+function truncate(value, limit = 240) {
+  const text = String(value || '');
+  if (text.length <= limit) return text;
+  return `${text.slice(0, limit).trimEnd()}...`;
+}
+
+function evidenceCountForPrompt(evidence, promptId) {
+  if (!promptId) return 0;
+  const entry = evidence.find((candidate) => candidate.promptId === promptId);
+  if (!entry) return 0;
+  const latestCount = entry.latest ? 1 : 0;
+  const historyCount = Array.isArray(entry.history) ? entry.history.length : 0;
+  return latestCount + historyCount;
+}
+
+function PromptCard({ prompt, savedCount, onStart }) {
+  return (
+    <article
+      className="grammar-transfer-prompt-card"
+      data-prompt-id={prompt.id}
+    >
+      <header className="grammar-transfer-prompt-head">
+        <h3 className="grammar-transfer-prompt-title">{prompt.title}</h3>
+        {savedCount > 0 ? (
+          <span className="grammar-transfer-prompt-saved-chip" aria-label={`${savedCount} saved writing${savedCount === 1 ? '' : 's'}`}>
+            {savedCount} saved
+          </span>
+        ) : null}
+      </header>
+      <p className="grammar-transfer-prompt-brief">{prompt.brief}</p>
+      {prompt.grammarTargets.length ? (
+        <ul className="grammar-transfer-prompt-targets" aria-label="Grammar focus">
+          {prompt.grammarTargets.map((target) => (
+            <li className="grammar-transfer-prompt-target" key={target} data-concept-id={target}>
+              {conceptLabel(target)}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      <div className="grammar-transfer-prompt-actions">
+        <button
+          type="button"
+          className="btn primary sm"
+          data-action="grammar-select-transfer-prompt"
+          data-prompt-id={prompt.id}
+          onClick={() => onStart(prompt.id)}
+        >
+          Start writing
+        </button>
+      </div>
+    </article>
+  );
+}
+
+function PickPromptMode({ prompts, evidence, onStart }) {
+  if (!prompts.length) {
+    return (
+      <div className="grammar-transfer-empty" role="status">
+        No writing prompts available right now. Check back after you finish a round.
+      </div>
+    );
+  }
+  return (
+    <div className="grammar-transfer-prompt-grid">
+      {prompts.map((prompt) => (
+        <PromptCard
+          prompt={prompt}
+          savedCount={evidenceCountForPrompt(evidence, prompt.id)}
+          onStart={onStart}
+          key={prompt.id}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ChecklistField({ items, ticks, disabled, onToggle }) {
+  if (!items.length) return null;
+  return (
+    <fieldset className="grammar-transfer-checklist" disabled={disabled}>
+      <legend className="grammar-transfer-checklist-legend">Self-check</legend>
+      <ul className="grammar-transfer-checklist-list">
+        {items.map((item, index) => {
+          const key = `check-${index}`;
+          const checked = Boolean(ticks[key]);
+          return (
+            <li className="grammar-transfer-checklist-item" key={key}>
+              <label className="grammar-transfer-checklist-label">
+                <input
+                  type="checkbox"
+                  className="grammar-transfer-checklist-input"
+                  data-action="grammar-toggle-transfer-check"
+                  data-check-key={key}
+                  checked={checked}
+                  disabled={disabled}
+                  onChange={(event) => onToggle(key, event.currentTarget.checked)}
+                />
+                <span className="grammar-transfer-checklist-copy">{item}</span>
+              </label>
+            </li>
+          );
+        })}
+      </ul>
+    </fieldset>
+  );
+}
+
+function WriteMode({
+  prompt,
+  draft,
+  ticks,
+  writingCap,
+  saveDisabled,
+  saveLabel,
+  overCap,
+  pending,
+  onDraftChange,
+  onToggle,
+  onSave,
+  onChangePrompt,
+}) {
+  const remaining = Math.max(0, writingCap - draft.length);
+  const counterClass = overCap
+    ? 'grammar-transfer-counter grammar-transfer-counter--warn'
+    : 'grammar-transfer-counter';
+  const counterLabel = overCap
+    ? `${draft.length} of ${writingCap} — too long`
+    : `${draft.length} / ${writingCap}`;
+  return (
+    <section className="grammar-transfer-write" aria-labelledby="grammar-transfer-write-title">
+      <header className="grammar-transfer-write-head">
+        <h3 id="grammar-transfer-write-title" className="grammar-transfer-write-title">{prompt.title}</h3>
+        <p className="grammar-transfer-write-brief">{prompt.brief}</p>
+        {prompt.grammarTargets.length ? (
+          <ul className="grammar-transfer-write-targets" aria-label="Grammar focus">
+            {prompt.grammarTargets.map((target) => (
+              <li className="grammar-transfer-write-target" key={target} data-concept-id={target}>
+                <span className="grammar-transfer-write-target-name">{conceptLabel(target)}</span>
+                <span className="grammar-transfer-write-target-cluster">{clusterLabelFor(target)}</span>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </header>
+
+      <label className="grammar-transfer-textarea-field">
+        <span className="grammar-transfer-textarea-label">Your writing</span>
+        <textarea
+          className="grammar-transfer-textarea"
+          name="grammarTransferDraft"
+          data-action="grammar-update-transfer-draft"
+          aria-describedby="grammar-transfer-counter"
+          placeholder="Write 3-5 sentences here. Nothing you write is scored."
+          value={draft}
+          onChange={(event) => onDraftChange(event.currentTarget.value)}
+        />
+      </label>
+      <div
+        id="grammar-transfer-counter"
+        className={counterClass}
+        role={overCap ? 'alert' : 'status'}
+        aria-live={overCap ? 'assertive' : 'polite'}
+      >
+        {counterLabel}
+      </div>
+      {overCap ? (
+        <p className="grammar-transfer-counter-warn-copy">That is longer than we can save. Please shorten it.</p>
+      ) : null}
+
+      <ChecklistField
+        items={prompt.checklist}
+        ticks={ticks}
+        disabled={pending}
+        onToggle={onToggle}
+      />
+
+      <div className="grammar-transfer-write-actions">
+        <button
+          type="button"
+          className="btn primary"
+          data-action="grammar-save-transfer-evidence"
+          data-prompt-id={prompt.id}
+          disabled={saveDisabled}
+          onClick={onSave}
+        >
+          {saveLabel}
+        </button>
+        <button
+          type="button"
+          className="btn ghost"
+          data-action="grammar-select-transfer-prompt"
+          data-prompt-id=""
+          onClick={onChangePrompt}
+        >
+          Change prompt
+        </button>
+      </div>
+    </section>
+  );
+}
+
+function SavedHistory({ evidence }) {
+  if (!evidence) return null;
+  const latest = evidence.latest;
+  const history = Array.isArray(evidence.history)
+    ? evidence.history.slice(0, HISTORY_LIMIT)
+    : [];
+  if (!latest && !history.length) return null;
+  return (
+    <section className="grammar-transfer-saved" aria-labelledby="grammar-transfer-saved-title">
+      <h3 id="grammar-transfer-saved-title" className="grammar-transfer-saved-title">My saved writing</h3>
+      {latest ? (
+        <article className="grammar-transfer-saved-entry grammar-transfer-saved-entry--latest" data-saved-kind="latest">
+          <header className="grammar-transfer-saved-entry-head">
+            <strong className="grammar-transfer-saved-entry-label">Latest</strong>
+            <span className="grammar-transfer-saved-entry-time">{relativeSavedAt(latest.savedAt)}</span>
+          </header>
+          <p className="grammar-transfer-saved-entry-writing">{truncate(latest.writing)}</p>
+          {Array.isArray(latest.selfAssessment) && latest.selfAssessment.length ? (
+            <ul className="grammar-transfer-saved-ticks" aria-label="Self-check ticks">
+              {latest.selfAssessment.map((tick, index) => (
+                <li
+                  className={`grammar-transfer-saved-tick${tick.checked ? ' is-checked' : ''}`}
+                  data-check-key={tick.key}
+                  data-checked={tick.checked ? 'true' : 'false'}
+                  key={tick.key || `tick-${index}`}
+                >
+                  <span className="grammar-transfer-saved-tick-icon" aria-hidden="true">{tick.checked ? '[x]' : '[ ]'}</span>
+                  <span className="grammar-transfer-saved-tick-key">{tick.key}</span>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </article>
+      ) : null}
+      {history.length ? (
+        <ol className="grammar-transfer-saved-history">
+          {history.map((entry, index) => (
+            <li className="grammar-transfer-saved-entry grammar-transfer-saved-entry--history" data-saved-kind="history" key={`history-${index}`}>
+              <header className="grammar-transfer-saved-entry-head">
+                <strong className="grammar-transfer-saved-entry-label">Earlier</strong>
+                <span className="grammar-transfer-saved-entry-time">{relativeSavedAt(entry.savedAt)}</span>
+              </header>
+              <p className="grammar-transfer-saved-entry-writing">{truncate(entry.writing)}</p>
+            </li>
+          ))}
+        </ol>
+      ) : null}
+    </section>
+  );
+}
+
+function OrphanedEvidence({ entries }) {
+  if (!entries.length) return null;
+  return (
+    <section
+      className="grammar-transfer-orphaned"
+      aria-labelledby="grammar-transfer-orphaned-title"
+      data-section-id="retired-prompts"
+    >
+      <h3 id="grammar-transfer-orphaned-title" className="grammar-transfer-orphaned-title">Retired prompts</h3>
+      <p className="grammar-transfer-orphaned-hint">
+        These writings were saved for writing prompts that are no longer on the list. They are kept so a grown-up can still read them.
+      </p>
+      <ul className="grammar-transfer-orphaned-list">
+        {entries.map((entry) => (
+          <li
+            className="grammar-transfer-orphaned-entry"
+            data-prompt-id={entry.promptId}
+            key={entry.promptId}
+          >
+            <header className="grammar-transfer-orphaned-head">
+              <strong className="grammar-transfer-orphaned-label">Saved for a retired writing prompt</strong>
+              <span className="grammar-transfer-orphaned-time">{relativeSavedAt(entry.latest?.savedAt || entry.updatedAt)}</span>
+            </header>
+            <p className="grammar-transfer-orphaned-writing">{truncate(entry.latest?.writing || '')}</p>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export function GrammarTransferScene({ grammar, actions }) {
+  const transferLane = grammar?.transferLane || { prompts: [], evidence: [], limits: { writingCapChars: WRITING_CAP } };
+  const prompts = Array.isArray(transferLane.prompts) ? transferLane.prompts : [];
+  const evidence = Array.isArray(transferLane.evidence) ? transferLane.evidence : [];
+  const writingCap = Number(transferLane.limits?.writingCapChars) > 0
+    ? Number(transferLane.limits.writingCapChars)
+    : WRITING_CAP;
+
+  const transferUi = grammar?.ui?.transfer || { selectedPromptId: '', draft: '', ticks: {} };
+  const selectedPromptId = transferUi.selectedPromptId || '';
+  const draft = typeof transferUi.draft === 'string' ? transferUi.draft : '';
+  const ticks = transferUi.ticks && typeof transferUi.ticks === 'object' && !Array.isArray(transferUi.ticks)
+    ? transferUi.ticks
+    : {};
+
+  const activePrompt = selectedPromptId
+    ? prompts.find((prompt) => prompt.id === selectedPromptId) || null
+    : null;
+
+  const selectedEvidence = activePrompt
+    ? evidence.find((entry) => entry.promptId === activePrompt.id) || null
+    : null;
+
+  const promptIdSet = new Set(prompts.map((prompt) => prompt.id));
+  const orphanedEvidence = evidence.filter((entry) => entry.promptId && !promptIdSet.has(entry.promptId));
+
+  const pendingSave = grammar?.pendingCommand === 'save-transfer-evidence';
+  const overCap = draft.length > writingCap;
+  const emptyDraft = draft.trim().length === 0;
+  const saveDisabled = pendingSave || overCap || emptyDraft;
+  const saveLabel = pendingSave ? 'Saving...' : 'Save writing';
+
+  const handleBack = () => {
+    actions?.dispatch?.('grammar-close-transfer');
+  };
+  const handleStart = (promptId) => {
+    actions?.dispatch?.('grammar-select-transfer-prompt', { promptId });
+  };
+  const handleChangePrompt = () => {
+    actions?.dispatch?.('grammar-select-transfer-prompt', { promptId: '' });
+  };
+  const handleDraftChange = (value) => {
+    actions?.dispatch?.('grammar-update-transfer-draft', { writing: value });
+  };
+  const handleToggle = (key, checked) => {
+    actions?.dispatch?.('grammar-toggle-transfer-check', { key, checked });
+  };
+  const handleSave = () => {
+    if (!activePrompt) return;
+    if (saveDisabled) return;
+    const checklist = Array.isArray(activePrompt.checklist) ? activePrompt.checklist : [];
+    const selfAssessment = checklist.map((_item, index) => {
+      const key = `check-${index}`;
+      return { key, checked: Boolean(ticks[key]) };
+    });
+    actions?.dispatch?.('grammar-save-transfer-evidence', {
+      payload: {
+        promptId: activePrompt.id,
+        writing: draft,
+        selfAssessment,
+      },
+    });
+  };
+
+  const errorMessage = typeof grammar?.error === 'string' ? grammar.error : '';
+
+  return (
+    <section className="grammar-transfer-scene" aria-labelledby="grammar-transfer-title">
+      <header className="grammar-transfer-topbar">
+        <button
+          type="button"
+          className="btn ghost sm"
+          data-action="grammar-close-transfer"
+          onClick={handleBack}
+        >
+          &larr; Back to Grammar Garden
+        </button>
+        <div className="grammar-transfer-topbar-copy">
+          <h2 id="grammar-transfer-title" className="grammar-transfer-title">Writing Try</h2>
+          <p className="grammar-transfer-subtitle">
+            Pick a prompt and write a short paragraph. Nothing you write here is scored.
+          </p>
+        </div>
+      </header>
+
+      {errorMessage ? (
+        <div className="grammar-transfer-error feedback bad" role="alert">
+          <strong>Something went wrong</strong>
+          <div>{errorMessage}</div>
+        </div>
+      ) : null}
+
+      {activePrompt ? (
+        <>
+          <WriteMode
+            prompt={activePrompt}
+            draft={draft}
+            ticks={ticks}
+            writingCap={writingCap}
+            saveDisabled={saveDisabled}
+            saveLabel={saveLabel}
+            overCap={overCap}
+            pending={pendingSave}
+            onDraftChange={handleDraftChange}
+            onToggle={handleToggle}
+            onSave={handleSave}
+            onChangePrompt={handleChangePrompt}
+          />
+          <SavedHistory evidence={selectedEvidence} />
+        </>
+      ) : (
+        <PickPromptMode
+          prompts={prompts}
+          evidence={evidence}
+          onStart={handleStart}
+        />
+      )}
+
+      <OrphanedEvidence entries={orphanedEvidence} />
+    </section>
+  );
+}

--- a/src/subjects/grammar/metadata.js
+++ b/src/subjects/grammar/metadata.js
@@ -379,6 +379,54 @@ function normaliseGrammarBankUi(raw) {
   };
 }
 
+// Phase 3 U6b: Writing Try scene carries transient UI state — the selected
+// prompt id (null until the learner picks one), the in-progress writing
+// draft, and the self-check ticks keyed by the checklist item's stable
+// `check-<index>` key. We keep the state inside the Grammar read model for
+// the same reason `bank` lives here: every Grammar UI slice routes through
+// `normaliseGrammarReadModel`, so a mixed home would make the dispatcher
+// asymmetric. The writing draft is capped server-side at 2000 chars but we
+// slice again defensively so a malformed upstream value cannot push the
+// textarea over the cap during SSR.
+const EMPTY_GRAMMAR_TRANSFER_UI = Object.freeze({
+  selectedPromptId: '',
+  draft: '',
+  ticks: Object.freeze({}),
+});
+
+function normaliseGrammarTransferTicks(raw) {
+  if (!isPlainObject(raw)) return {};
+  const out = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (typeof key !== 'string' || !key) continue;
+    // Cap keys defensively so a malformed upstream tick map cannot grow
+    // without bound through round-trips.
+    out[key.slice(0, 64)] = Boolean(value);
+  }
+  return out;
+}
+
+// Defensive upper bound for `ui.transfer.draft`. The Worker's writing cap is
+// 2000 chars (GRAMMAR_TRANSFER_WRITING_CAP), but the UI must be able to
+// *detect* an over-cap draft so the Writing Try scene can render the
+// "That is longer than we can save" warning + disable Save. Truncating
+// here would hide the over-cap path from the scene. 5000 is chosen as a
+// generous sanity limit so a runaway upstream value cannot grow without
+// bound — it is more than double the Worker cap and well below any
+// reasonable practical input.
+const GRAMMAR_TRANSFER_DRAFT_HARD_MAX = 5000;
+
+function normaliseGrammarTransferUi(raw) {
+  if (!isPlainObject(raw)) return { selectedPromptId: '', draft: '', ticks: {} };
+  const selectedPromptId = typeof raw.selectedPromptId === 'string' ? raw.selectedPromptId.slice(0, 64) : '';
+  const draft = typeof raw.draft === 'string' ? raw.draft.slice(0, GRAMMAR_TRANSFER_DRAFT_HARD_MAX) : '';
+  return {
+    selectedPromptId,
+    draft,
+    ticks: normaliseGrammarTransferTicks(raw.ticks),
+  };
+}
+
 function normaliseGrammarTransferLane(raw) {
   if (!isPlainObject(raw)) {
     return {
@@ -620,6 +668,14 @@ export function normaliseGrammarReadModel(rawValue = {}, learnerId = '') {
     // read model so filter selections survive StrictMode double-renders and
     // round-trip through the normaliser without stomping unrelated fields.
     bank: normaliseGrammarBankUi(raw.bank),
+    // Phase 3 U6b: persist the Writing Try scene's transient UI state
+    // (selected prompt, draft writing, self-check ticks) in the same slot
+    // for the same reason as `bank` above. The draft is cleared on save
+    // success (the dispatcher handles that) so the textarea returns to an
+    // empty state after the evidence lands.
+    ui: {
+      transfer: normaliseGrammarTransferUi(raw.ui?.transfer),
+    },
     projections: raw.projections || null,
     pendingCommand: raw.pendingCommand || '',
     error: typeof raw.error === 'string' ? raw.error : '',
@@ -633,6 +689,7 @@ export {
   VALID_GRAMMAR_BANK_CLUSTER_FILTERS,
   normaliseGrammarBankUi,
 };
+export { EMPTY_GRAMMAR_TRANSFER_UI, normaliseGrammarTransferUi };
 
 export function groupedGrammarConcepts(concepts = []) {
   const groups = new Map();

--- a/src/subjects/grammar/module.js
+++ b/src/subjects/grammar/module.js
@@ -570,11 +570,84 @@ export const grammarModule = {
     if (action === 'grammar-open-transfer') {
       if (ui.pendingCommand) return true;
       if (ui.phase === 'session' || ui.phase === 'feedback') return true;
-      context.store.updateSubjectUi(GRAMMAR_SUBJECT_ID, (current) => ({
-        ...normaliseGrammarReadModel(current, learnerId),
-        phase: 'transfer',
-        error: '',
-      }));
+      context.store.updateSubjectUi(GRAMMAR_SUBJECT_ID, (current) => {
+        const normalised = normaliseGrammarReadModel(current, learnerId);
+        // Clear any stale Writing Try transient state so reopening the
+        // scene never auto-picks the last prompt or restores a half-typed
+        // draft from a previous visit (matches the Grammar Bank detail
+        // modal reset in `grammar-open-concept-bank`).
+        return {
+          ...normalised,
+          phase: 'transfer',
+          ui: { ...normalised.ui, transfer: { selectedPromptId: '', draft: '', ticks: {} } },
+          error: '',
+        };
+      });
+      return true;
+    }
+
+    // Phase 3 U6b: Writing Try transient-state dispatchers. All four mutate
+    // only the `ui.transfer` slice — no session, feedback, summary, or
+    // mastery side-effects — so they are safe to fire without a
+    // pendingCommand guard. The normaliser re-validates every value on
+    // round-trip, so a malformed client-side patch cannot persist.
+
+    if (action === 'grammar-close-transfer') {
+      return resetToDashboard(context);
+    }
+
+    if (action === 'grammar-select-transfer-prompt') {
+      const raw = String(context.data?.promptId || context.data?.value || '').slice(0, 64);
+      context.store.updateSubjectUi(GRAMMAR_SUBJECT_ID, (current) => {
+        const normalised = normaliseGrammarReadModel(current, learnerId);
+        // Switching prompts clears the draft + ticks so a learner never
+        // submits a previous prompt's writing under the wrong promptId.
+        return {
+          ...normalised,
+          ui: { ...normalised.ui, transfer: { selectedPromptId: raw, draft: '', ticks: {} } },
+          error: '',
+        };
+      });
+      return true;
+    }
+
+    if (action === 'grammar-update-transfer-draft') {
+      // U6b: do NOT truncate at the Worker writing cap (2000) here — the
+      // UI needs to detect over-cap drafts to render the child-copy
+      // warning and disable Save. The normaliser applies a much larger
+      // hard cap to prevent unbounded growth while still preserving the
+      // over-cap signal for the scene.
+      const raw = String(context.data?.writing ?? context.data?.value ?? '');
+      context.store.updateSubjectUi(GRAMMAR_SUBJECT_ID, (current) => {
+        const normalised = normaliseGrammarReadModel(current, learnerId);
+        return {
+          ...normalised,
+          ui: {
+            ...normalised.ui,
+            transfer: { ...normalised.ui.transfer, draft: raw },
+          },
+        };
+      });
+      return true;
+    }
+
+    if (action === 'grammar-toggle-transfer-check') {
+      const key = String(context.data?.key || '').slice(0, 64);
+      if (!key) return true;
+      const checked = Boolean(context.data?.checked);
+      context.store.updateSubjectUi(GRAMMAR_SUBJECT_ID, (current) => {
+        const normalised = normaliseGrammarReadModel(current, learnerId);
+        return {
+          ...normalised,
+          ui: {
+            ...normalised.ui,
+            transfer: {
+              ...normalised.ui.transfer,
+              ticks: { ...normalised.ui.transfer.ticks, [key]: checked },
+            },
+          },
+        };
+      });
       return true;
     }
 
@@ -745,8 +818,35 @@ export const grammarModule = {
             .filter((entry) => entry.key)
           : [],
       };
+      // U6b: capture the selectedPromptId before dispatch so the resolve
+      // callback can restore it AFTER `applyRemoteReadModel` clobbers the
+      // client `ui.transfer` slot with the Worker's response (the Worker
+      // response never carries the client-side UI slot, so the default
+      // empty shape overwrites selectedPromptId otherwise).
+      const selectedPromptIdBefore = payload.promptId;
       return sendGrammarCommand(context, 'save-transfer-evidence', payload, {
         translateError: translateGrammarTransferError,
+        // U6b: after a successful save, clear the draft + ticks so the
+        // textarea returns to an empty state while leaving
+        // `selectedPromptId` so the learner still sees the saved-history
+        // for the same prompt. The Worker response has already merged the
+        // fresh `transferLane.evidence` through `applyRemoteReadModel`.
+        onResolved: () => {
+          updateGrammarUiForLearner(context, learnerId, (current) => {
+            const normalised = normaliseGrammarReadModel(current, learnerId);
+            return {
+              ...normalised,
+              ui: {
+                ...normalised.ui,
+                transfer: {
+                  selectedPromptId: selectedPromptIdBefore || normalised.ui.transfer.selectedPromptId,
+                  draft: '',
+                  ticks: {},
+                },
+              },
+            };
+          });
+        },
       });
     }
 

--- a/tests/grammar-transfer-scene.test.js
+++ b/tests/grammar-transfer-scene.test.js
@@ -18,6 +18,7 @@ import { installMemoryStorage } from './helpers/memory-storage.js';
 import {
   grammarModule,
   GRAMMAR_TRANSFER_ERROR_COPY,
+  translateGrammarTransferError,
 } from '../src/subjects/grammar/module.js';
 import { normaliseGrammarReadModel } from '../src/subjects/grammar/metadata.js';
 import { GRAMMAR_CHILD_FORBIDDEN_TERMS } from '../src/subjects/grammar/components/grammar-view-model.js';
@@ -238,6 +239,21 @@ test('U6b: pending save disables the Save button and the label flips to "Saving.
   assert.match(html, /data-action="grammar-save-transfer-evidence"[^>]*disabled[^>]*>Saving\.\.\./);
 });
 
+test('U6b: pending save disables textarea, Change prompt button, and checklist fieldset (prevents mid-save races)', () => {
+  const harness = openTransferHarness({
+    transferLane: defaultTransferLane(),
+    transferUi: { selectedPromptId: 'storm-scene', draft: 'Draft in flight.' },
+    pendingCommand: 'save-transfer-evidence',
+  });
+  const html = harness.render();
+  // Textarea is disabled so the learner cannot mutate the draft mid-save.
+  assert.match(html, /<textarea[^>]*name="grammarTransferDraft"[^>]*disabled/);
+  // Change prompt is disabled so a mid-save prompt-switch race cannot occur.
+  assert.match(html, /data-action="grammar-select-transfer-prompt"[^>]*data-prompt-id=""[^>]*disabled[^>]*>Change prompt</);
+  // Checklist fieldset is disabled (existing behaviour, re-asserted for completeness).
+  assert.match(html, /<fieldset[^>]*class="grammar-transfer-checklist"[^>]*disabled/);
+});
+
 // ----------------------------------------------------------------------------
 // Save dispatch contract
 // ----------------------------------------------------------------------------
@@ -366,6 +382,12 @@ test('U6b: saved-history shows latest (with selfAssessment ticks) plus up to 4 h
   // selfAssessment ticks render on the latest card only.
   assert.match(html, /data-check-key="check-0"[^>]*data-checked="true"/);
   assert.match(html, /data-check-key="check-2"[^>]*data-checked="true"/);
+  // Tick labels render the original checklist prompt text, not the raw key
+  // (child-facing copy; `check-0` would read as marking to a KS2 learner).
+  assert.match(html, /Use at least one fronted adverbial\./);
+  assert.match(html, /Use a pair of commas for parenthesis\./);
+  assert.match(html, /Use one relative clause\./);
+  assert.doesNotMatch(html, /grammar-transfer-saved-tick-label[^>]*>check-0</);
   // Only 4 of the 6 history entries render.
   const historyMatches = html.match(/data-saved-kind="history"/g) || [];
   assert.equal(historyMatches.length, 4, 'history is limited to 4 entries');
@@ -373,6 +395,50 @@ test('U6b: saved-history shows latest (with selfAssessment ticks) plus up to 4 h
   assert.doesNotMatch(html, /Earlier draft 1\./);
   assert.doesNotMatch(html, /Earlier draft 2\./);
   assert.match(html, /Earlier draft 6\./);
+});
+
+test('U6b: saved tick label falls back to "Check N" when checklist item is missing (orphan safety)', () => {
+  // Simulate an orphaned evidence shape where the Worker emits ticks whose
+  // index exceeds the current prompt's checklist (e.g., the prompt was
+  // shortened after the evidence was saved). The UI must not regress to the
+  // raw `check-N` key; it should humanise to `Check N+1` instead.
+  const harness = openTransferHarness({
+    transferLane: defaultTransferLane({
+      evidence: [{
+        promptId: 'storm-scene',
+        latest: {
+          writing: 'Draft with stale ticks.',
+          selfAssessment: [
+            { key: 'check-0', checked: true },
+            { key: 'check-9', checked: true },
+          ],
+          savedAt: 1_777_000_000_000,
+          source: 'transfer-lane',
+        },
+        history: [],
+        updatedAt: 1_777_000_000_000,
+      }],
+    }),
+    transferUi: { selectedPromptId: 'storm-scene' },
+  });
+  const html = harness.render();
+  // check-0 resolves to the real checklist item text.
+  assert.match(html, /Use at least one fronted adverbial\./);
+  // check-9 overflows the 3-item checklist and falls back to human-readable.
+  assert.match(html, /grammar-transfer-saved-tick-label[^>]*>Check 10</);
+  // No raw check-N keys leak into the label span.
+  assert.doesNotMatch(html, /grammar-transfer-saved-tick-label[^>]*>check-9</);
+});
+
+test('U6b: Self-check fieldset renders the child-friendly explanation hint', () => {
+  const harness = openTransferHarness({
+    transferLane: defaultTransferLane(),
+    transferUi: { selectedPromptId: 'storm-scene' },
+  });
+  const html = harness.render();
+  // Legend must be followed by the "it is just a reminder" explanation so a
+  // KS2 child does not read Self-check as marking.
+  assert.match(html, /<legend[^>]*>Self-check<\/legend>[\s\S]*?Tick what you tried[\s\S]*?Nothing is marked\./);
 });
 
 test('U6b: orphaned evidence renders as a "Retired prompts" card (no Start writing button)', () => {
@@ -419,14 +485,20 @@ test('U6b: each of the four Worker error codes surfaces its child copy in role="
       transferLane: defaultTransferLane(),
       transferUi: { selectedPromptId: 'storm-scene', draft: 'A draft', ticks: {} },
     });
-    // Set rm.error directly to the translated child copy (module.js path
-    // is already covered in the U6a tests).
+    // Route the raw Worker error-code shape through the real translator so
+    // this test proves the code -> child-copy mapping, not just the render
+    // of a pre-translated string. Shape mirrors `sendGrammarCommand`'s
+    // `err.extra.code` path (see src/subjects/grammar/module.js:25-34).
+    const rawWorkerError = { extra: { code } };
+    const translated = translateGrammarTransferError(rawWorkerError);
+    assert.equal(translated, GRAMMAR_TRANSFER_ERROR_COPY[code],
+      `translator maps ${code} to the expected child copy`);
     harness.store.updateSubjectUi('grammar', (current) => ({
       ...normaliseGrammarReadModel(current, learnerId),
-      error: GRAMMAR_TRANSFER_ERROR_COPY[code],
+      error: translated,
     }));
     const html = harness.render();
-    const expected = GRAMMAR_TRANSFER_ERROR_COPY[code].replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const expected = translated.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     assert.match(html, new RegExp(`role="alert"[\\s\\S]*?${expected}`),
       `expected child copy for ${code} to render in role=alert`);
   }
@@ -506,11 +578,36 @@ function assertNoForbiddenReadModelKeys(value, forbidden) {
   visit(value, '');
 }
 
+// Strip known-changing fields (transferEvidence + timestamp-like keys) from a
+// grammar-state snapshot so the save-transfer-evidence round-trip can be deep
+// -equalled for a true non-scored invariant. Timestamp keys listed explicitly
+// rather than heuristic to avoid false negatives on future shape changes.
+const GRAMMAR_STATE_CHANGING_TOP_LEVEL_KEYS = new Set([
+  'transferEvidence',
+  'updatedAt',
+  'lastWriteAt',
+  'lastUpdatedAt',
+  'lastSavedAt',
+  'savedAt',
+]);
+function snapshotNonScoredGrammarState(state) {
+  const stripped = {};
+  for (const [key, value] of Object.entries(state)) {
+    if (GRAMMAR_STATE_CHANGING_TOP_LEVEL_KEYS.has(key)) continue;
+    stripped[key] = value;
+  }
+  return JSON.parse(JSON.stringify(stripped));
+}
+
 test('U6b: full Worker round-trip — save-transfer-evidence leaves mastery unchanged, positive evidence delta, no reward toast', () => {
   const engine = createServerGrammarEngine({ now: () => 1_777_000_000_000 });
   const initial = createInitialGrammarState();
   const beforeMastery = JSON.stringify(initial.mastery);
   const beforeRetry = JSON.stringify(initial.retryQueue);
+  // Full-state snapshot (excluding transferEvidence + timestamps) so we can
+  // assert that nothing beyond the intended evidence delta mutates across the
+  // save. Broader than the mastery/retry-only JSON.stringify checks below.
+  const beforeFullState = snapshotNonScoredGrammarState(initial);
 
   const result = engine.apply({
     learnerId: 'learner-a',
@@ -531,6 +628,13 @@ test('U6b: full Worker round-trip — save-transfer-evidence leaves mastery unch
   // Mastery / retry unchanged across the save.
   assert.equal(JSON.stringify(result.state.mastery), beforeMastery);
   assert.equal(JSON.stringify(result.state.retryQueue), beforeRetry);
+
+  // Full-state invariant: every other top-level slot is identical before and
+  // after the save. Prevents silent regressions that sneak scoring fields in
+  // through new keys (e.g., `streaks`, `summary`, `aiEnrichment` deltas).
+  const afterFullState = snapshotNonScoredGrammarState(result.state);
+  assert.deepEqual(afterFullState, beforeFullState,
+    'non-scored save must leave every slot except transferEvidence and timestamps untouched');
 
   // Positive evidence delta.
   const entry = result.state.transferEvidence[GRAMMAR_TRANSFER_PROMPT_IDS[0]];

--- a/tests/grammar-transfer-scene.test.js
+++ b/tests/grammar-transfer-scene.test.js
@@ -1,0 +1,695 @@
+// Phase 3 U6b: Writing Try scene (`GrammarTransferScene.jsx`) coverage.
+//
+// SSR blind-spots documented for readers:
+//   * True DOM focus / autoFocus cannot be asserted here — the SSR harness
+//     only emits static markup. Focus return from the "Change prompt"
+//     back-affordance is a browser side-effect and is covered by manual QA.
+//   * `requestIdleCallback`, `MutationObserver`, pointer-capture and IME
+//     composition are not simulated. We assert structural markers
+//     (data-action attributes, role / aria roles, rendered copy) instead.
+//   * React onChange events do not fire in SSR; we dispatch the store
+//     actions directly to model the runtime transitions.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createAppHarness } from './helpers/app-harness.js';
+import { installMemoryStorage } from './helpers/memory-storage.js';
+import {
+  grammarModule,
+  GRAMMAR_TRANSFER_ERROR_COPY,
+} from '../src/subjects/grammar/module.js';
+import { normaliseGrammarReadModel } from '../src/subjects/grammar/metadata.js';
+import { GRAMMAR_CHILD_FORBIDDEN_TERMS } from '../src/subjects/grammar/components/grammar-view-model.js';
+import {
+  GRAMMAR_TRANSFER_PROMPT_IDS,
+} from '../worker/src/subjects/grammar/transfer-prompts.js';
+import {
+  createInitialGrammarState,
+  createServerGrammarEngine,
+} from '../worker/src/subjects/grammar/engine.js';
+import { buildGrammarReadModel } from '../worker/src/subjects/grammar/read-models.js';
+
+const SAMPLE_PROMPTS = [
+  {
+    id: 'storm-scene',
+    title: 'Describe a storm',
+    brief: 'Write a short paragraph describing a storm rolling in.',
+    grammarTargets: ['adverbials', 'parenthesis_commas', 'relative_clauses'],
+    checklist: [
+      'Use at least one fronted adverbial.',
+      'Use a pair of commas for parenthesis.',
+      'Use one relative clause.',
+    ],
+  },
+  {
+    id: 'market-stall',
+    title: 'At the market stall',
+    brief: 'Write 3-5 sentences about a busy market.',
+    grammarTargets: ['noun_phrases'],
+    checklist: [
+      'Use one expanded noun phrase.',
+    ],
+  },
+];
+
+const SAMPLE_LIMITS = { maxPrompts: 20, historyPerPrompt: 5, writingCapChars: 2000 };
+
+function seedTransferLane(harness, { transferLane, transferUi = {}, pendingCommand = '' } = {}) {
+  const learnerId = harness.store.getState().learners.selectedId;
+  harness.store.updateSubjectUi('grammar', (current) => normaliseGrammarReadModel({
+    ...current,
+    phase: 'transfer',
+    transferLane,
+    pendingCommand,
+    ui: { transfer: transferUi },
+  }, learnerId));
+}
+
+function openTransferHarness({ transferLane, transferUi = {}, pendingCommand = '' } = {}) {
+  const storage = installMemoryStorage();
+  const harness = createAppHarness({ storage });
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  seedTransferLane(harness, { transferLane, transferUi, pendingCommand });
+  return harness;
+}
+
+function defaultTransferLane(overrides = {}) {
+  return {
+    mode: 'non-scored',
+    prompts: SAMPLE_PROMPTS,
+    limits: SAMPLE_LIMITS,
+    evidence: [],
+    ...overrides,
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Pick-prompt mode
+// ----------------------------------------------------------------------------
+
+test('U6b: pick-prompt mode lists every prompt card with title, brief, and grammar target badges', () => {
+  const harness = openTransferHarness({ transferLane: defaultTransferLane() });
+  const html = harness.render();
+  assert.match(html, /class="grammar-transfer-scene"/);
+  assert.match(html, /Writing Try/);
+  // Both prompts render as cards with titles + briefs.
+  assert.match(html, /Describe a storm/);
+  assert.match(html, /Write a short paragraph describing a storm rolling in\./);
+  assert.match(html, /At the market stall/);
+  // Grammar target badges map concept ids to child-friendly names via
+  // GRAMMAR_CLIENT_CONCEPTS (e.g., `adverbials` -> `Adverbials and fronted adverbials`).
+  assert.match(html, /Adverbials and fronted adverbials/);
+  assert.match(html, /Expanded noun phrases/);
+  // Each card has a Start writing primary button wired to the selector.
+  const startMatches = html.match(/data-action="grammar-select-transfer-prompt"[^>]*data-prompt-id="storm-scene"[^>]*>Start writing</g) || [];
+  assert.equal(startMatches.length, 1, 'exactly one Start writing button per prompt card');
+});
+
+test('U6b: pick-prompt mode shows a saved-count chip for prompts that already have evidence', () => {
+  const harness = openTransferHarness({
+    transferLane: defaultTransferLane({
+      evidence: [{
+        promptId: 'storm-scene',
+        latest: { writing: 'Prior draft.', selfAssessment: [], savedAt: 1_777_000_000_000, source: 'transfer-lane' },
+        history: [
+          { writing: 'Older draft.', savedAt: 1_776_000_000_000, source: 'transfer-lane' },
+        ],
+        updatedAt: 1_777_000_000_000,
+      }],
+    }),
+  });
+  const html = harness.render();
+  // 1 latest + 1 history = 2 saved items
+  assert.match(html, /data-prompt-id="storm-scene"[\s\S]*?2 saved/);
+});
+
+test('U6b: empty prompts catalogue renders a friendly empty state (not a blank page)', () => {
+  const harness = openTransferHarness({
+    transferLane: defaultTransferLane({ prompts: [] }),
+  });
+  const html = harness.render();
+  assert.match(html, /class="grammar-transfer-empty"/);
+  assert.match(html, /No writing prompts available right now/);
+});
+
+// ----------------------------------------------------------------------------
+// Write mode
+// ----------------------------------------------------------------------------
+
+test('U6b: selecting a prompt transitions to write mode with textarea + checklist + counter', () => {
+  const harness = openTransferHarness({
+    transferLane: defaultTransferLane(),
+    transferUi: { selectedPromptId: 'storm-scene' },
+  });
+  const html = harness.render();
+  // Hero swaps to prompt title; textarea appears.
+  assert.match(html, /id="grammar-transfer-write-title"[^>]*>Describe a storm/);
+  assert.match(html, /<textarea[^>]*name="grammarTransferDraft"/);
+  // Counter reads 0 / 2000 with no typed characters.
+  assert.match(html, /id="grammar-transfer-counter"[^>]*>0 \/ 2000/);
+  // Checklist renders one <li> per item with stable `check-N` keys.
+  assert.match(html, /data-check-key="check-0"/);
+  assert.match(html, /data-check-key="check-1"/);
+  assert.match(html, /data-check-key="check-2"/);
+  // Save button is disabled while the draft is empty.
+  assert.match(html, /data-action="grammar-save-transfer-evidence"[^>]*disabled/);
+  // "Change prompt" secondary routes back to pick-prompt mode.
+  assert.match(html, /data-action="grammar-select-transfer-prompt"[^>]*data-prompt-id=""[^>]*>Change prompt</);
+});
+
+test('U6b: dispatching grammar-select-transfer-prompt moves the UI into write mode and grammar-select-transfer-prompt with empty id returns to pick-prompt mode', () => {
+  const harness = openTransferHarness({ transferLane: defaultTransferLane() });
+
+  harness.dispatch('grammar-select-transfer-prompt', { promptId: 'storm-scene' });
+  let ui = harness.store.getState().subjectUi.grammar;
+  assert.equal(ui.ui.transfer.selectedPromptId, 'storm-scene');
+  assert.equal(ui.ui.transfer.draft, '', 'draft clears on prompt selection');
+  assert.deepEqual(ui.ui.transfer.ticks, {}, 'ticks clear on prompt selection');
+
+  // Change prompt back to empty
+  harness.dispatch('grammar-select-transfer-prompt', { promptId: '' });
+  ui = harness.store.getState().subjectUi.grammar;
+  assert.equal(ui.ui.transfer.selectedPromptId, '');
+});
+
+test('U6b: grammar-update-transfer-draft persists the draft verbatim so the scene can warn on over-cap input', () => {
+  const harness = openTransferHarness({
+    transferLane: defaultTransferLane(),
+    transferUi: { selectedPromptId: 'storm-scene' },
+  });
+  harness.dispatch('grammar-update-transfer-draft', { writing: 'Suddenly, the storm broke.' });
+  assert.equal(harness.store.getState().subjectUi.grammar.ui.transfer.draft, 'Suddenly, the storm broke.');
+
+  // Over-cap input is preserved (not silently truncated) so the scene can
+  // detect > 2000 chars and disable Save. The normaliser still applies a
+  // larger hard sanity ceiling to prevent unbounded growth.
+  harness.dispatch('grammar-update-transfer-draft', { writing: 'x'.repeat(2500) });
+  assert.equal(harness.store.getState().subjectUi.grammar.ui.transfer.draft.length, 2500);
+});
+
+test('U6b: grammar-toggle-transfer-check stores a stable check-N key as Boolean', () => {
+  const harness = openTransferHarness({
+    transferLane: defaultTransferLane(),
+    transferUi: { selectedPromptId: 'storm-scene' },
+  });
+  harness.dispatch('grammar-toggle-transfer-check', { key: 'check-0', checked: true });
+  harness.dispatch('grammar-toggle-transfer-check', { key: 'check-2', checked: true });
+  const ticks = harness.store.getState().subjectUi.grammar.ui.transfer.ticks;
+  assert.equal(ticks['check-0'], true);
+  assert.equal(ticks['check-2'], true);
+  // Untoggling updates the stored Boolean without dropping the key.
+  harness.dispatch('grammar-toggle-transfer-check', { key: 'check-0', checked: false });
+  assert.equal(harness.store.getState().subjectUi.grammar.ui.transfer.ticks['check-0'], false);
+});
+
+test('U6b: over-cap draft disables Save and renders the child-friendly warning copy', () => {
+  const oversized = 'x'.repeat(2100);
+  // Build a harness and then seed a transfer UI with an over-cap draft
+  // directly so we bypass the normaliser cap on ui.transfer.draft (which
+  // itself slices to writingCapChars). We write the field onto the
+  // subjectUi slot post-normalisation to simulate an upstream Worker
+  // projection emitting over-cap evidence (defensive render path).
+  const harness = openTransferHarness({ transferLane: defaultTransferLane() });
+  const learnerId = harness.store.getState().learners.selectedId;
+  harness.store.updateSubjectUi('grammar', (current) => {
+    const normalised = normaliseGrammarReadModel(current, learnerId);
+    return {
+      ...normalised,
+      ui: {
+        ...normalised.ui,
+        transfer: { selectedPromptId: 'storm-scene', draft: oversized, ticks: {} },
+      },
+    };
+  });
+  const html = harness.render();
+  assert.match(html, /class="grammar-transfer-counter grammar-transfer-counter--warn"/);
+  assert.match(html, /That is longer than we can save\. Please shorten it\./);
+  assert.match(html, /data-action="grammar-save-transfer-evidence"[^>]*disabled/);
+});
+
+test('U6b: pending save disables the Save button and the label flips to "Saving..."', () => {
+  const harness = openTransferHarness({
+    transferLane: defaultTransferLane(),
+    transferUi: { selectedPromptId: 'storm-scene', draft: 'Draft in flight.' },
+    pendingCommand: 'save-transfer-evidence',
+  });
+  const html = harness.render();
+  assert.match(html, /data-action="grammar-save-transfer-evidence"[^>]*disabled[^>]*>Saving\.\.\./);
+});
+
+// ----------------------------------------------------------------------------
+// Save dispatch contract
+// ----------------------------------------------------------------------------
+
+test('U6b: Save dispatches grammar-save-transfer-evidence with exact {promptId, writing, selfAssessment} payload (no "checklist" key)', () => {
+  const observed = { request: null };
+  const context = {
+    appState: {
+      learners: { selectedId: 'learner-a' },
+      subjectUi: {
+        grammar: normaliseGrammarReadModel({
+          phase: 'transfer',
+          ui: { transfer: {
+            selectedPromptId: 'storm-scene',
+            draft: 'Suddenly, the storm broke. Lightning, which split the sky, lit the fields.',
+            ticks: { 'check-0': true, 'check-2': true },
+          } },
+          transferLane: {
+            mode: 'non-scored',
+            prompts: SAMPLE_PROMPTS,
+            limits: SAMPLE_LIMITS,
+            evidence: [],
+          },
+        }, 'learner-a'),
+      },
+    },
+    runtimeReadOnly: false,
+    subjectCommands: {
+      send(request) {
+        observed.request = request;
+        return new Promise(() => {});
+      },
+    },
+    store: {
+      getState() { return context.appState; },
+      updateSubjectUi(subjectId, updater) {
+        const previous = context.appState.subjectUi[subjectId] || {};
+        const next = typeof updater === 'function' ? updater(previous) : { ...previous, ...updater };
+        context.appState = {
+          ...context.appState,
+          subjectUi: { ...context.appState.subjectUi, [subjectId]: next },
+        };
+      },
+      updateSubjectUiForLearner(learnerId, subjectId, updater) {
+        if (learnerId !== 'learner-a') return false;
+        context.store.updateSubjectUi(subjectId, updater);
+        return true;
+      },
+      pushToasts() {},
+      pushMonsterCelebrations() {},
+      reloadFromRepositories() {},
+    },
+  };
+  // Replicate what GrammarTransferScene would do: build selfAssessment
+  // from the prompt's checklist length so every checklist index becomes a
+  // stable `check-N` entry.
+  const prompt = SAMPLE_PROMPTS[0];
+  const ticks = context.appState.subjectUi.grammar.ui.transfer.ticks;
+  const selfAssessment = prompt.checklist.map((_item, index) => ({
+    key: `check-${index}`,
+    checked: Boolean(ticks[`check-${index}`]),
+  }));
+
+  const handled = grammarModule.handleAction('grammar-save-transfer-evidence', {
+    ...context,
+    data: {
+      payload: {
+        promptId: prompt.id,
+        writing: context.appState.subjectUi.grammar.ui.transfer.draft,
+        selfAssessment,
+      },
+    },
+  });
+  assert.equal(handled, true);
+
+  assert.ok(observed.request, 'subjectCommands.send must be called');
+  assert.equal(observed.request.command, 'save-transfer-evidence');
+  assert.deepEqual(Object.keys(observed.request.payload).sort(), ['promptId', 'selfAssessment', 'writing']);
+  assert.equal(observed.request.payload.promptId, 'storm-scene');
+  assert.equal(observed.request.payload.writing.startsWith('Suddenly'), true);
+  assert.deepEqual(observed.request.payload.selfAssessment, [
+    { key: 'check-0', checked: true },
+    { key: 'check-1', checked: false },
+    { key: 'check-2', checked: true },
+  ]);
+  assert.equal(Object.prototype.hasOwnProperty.call(observed.request.payload, 'checklist'), false,
+    'payload must carry selfAssessment, not checklist');
+});
+
+// ----------------------------------------------------------------------------
+// Saved-history rendering
+// ----------------------------------------------------------------------------
+
+test('U6b: saved-history shows latest (with selfAssessment ticks) plus up to 4 history entries', () => {
+  // Worker emits history most-recent-first (see
+  // worker/src/subjects/grammar/engine.js — saveTransferEvidence shifts
+  // prior drafts to the front of `history`). We mirror that order here so
+  // the UI cap at 4 discards the *oldest*, not the most-recent, entries.
+  const history = [];
+  for (let i = 6; i >= 1; i -= 1) {
+    history.push({ writing: `Earlier draft ${i}.`, savedAt: 1_770_000_000_000 + i * 1000, source: 'transfer-lane' });
+  }
+  const harness = openTransferHarness({
+    transferLane: defaultTransferLane({
+      evidence: [{
+        promptId: 'storm-scene',
+        latest: {
+          writing: 'Final draft - the storm rolled in.',
+          selfAssessment: [
+            { key: 'check-0', checked: true },
+            { key: 'check-1', checked: false },
+            { key: 'check-2', checked: true },
+          ],
+          savedAt: 1_777_000_000_000,
+          source: 'transfer-lane',
+        },
+        history,
+        updatedAt: 1_777_000_000_000,
+      }],
+    }),
+    transferUi: { selectedPromptId: 'storm-scene' },
+  });
+  const html = harness.render();
+  assert.match(html, /id="grammar-transfer-saved-title"[^>]*>My saved writing/);
+  assert.match(html, /Final draft - the storm rolled in\./);
+  // selfAssessment ticks render on the latest card only.
+  assert.match(html, /data-check-key="check-0"[^>]*data-checked="true"/);
+  assert.match(html, /data-check-key="check-2"[^>]*data-checked="true"/);
+  // Only 4 of the 6 history entries render.
+  const historyMatches = html.match(/data-saved-kind="history"/g) || [];
+  assert.equal(historyMatches.length, 4, 'history is limited to 4 entries');
+  // The oldest two (Earlier draft 1/2) must not appear.
+  assert.doesNotMatch(html, /Earlier draft 1\./);
+  assert.doesNotMatch(html, /Earlier draft 2\./);
+  assert.match(html, /Earlier draft 6\./);
+});
+
+test('U6b: orphaned evidence renders as a "Retired prompts" card (no Start writing button)', () => {
+  const harness = openTransferHarness({
+    transferLane: defaultTransferLane({
+      evidence: [{
+        promptId: 'retired-prompt-id',
+        latest: {
+          writing: 'A saved draft for a retired prompt.',
+          selfAssessment: [],
+          savedAt: 1_777_000_000_000,
+          source: 'transfer-lane',
+        },
+        history: [],
+        updatedAt: 1_777_000_000_000,
+      }],
+    }),
+  });
+  const html = harness.render();
+  assert.match(html, /data-section-id="retired-prompts"/);
+  assert.match(html, /Saved for a retired writing prompt/);
+  assert.match(html, /A saved draft for a retired prompt\./);
+  // The orphan section must not render a Start writing button for the retired prompt.
+  assert.doesNotMatch(html, /data-action="grammar-select-transfer-prompt"[^>]*data-prompt-id="retired-prompt-id"/);
+});
+
+// ----------------------------------------------------------------------------
+// Error handling
+// ----------------------------------------------------------------------------
+
+test('U6b: each of the four Worker error codes surfaces its child copy in role="alert"', async () => {
+  const codes = [
+    'grammar_transfer_unavailable_during_mini_test',
+    'grammar_transfer_prompt_not_found',
+    'grammar_transfer_writing_required',
+    'grammar_transfer_quota_exceeded',
+  ];
+  for (const code of codes) {
+    const storage = installMemoryStorage();
+    const harness = createAppHarness({ storage });
+    const learnerId = harness.store.getState().learners.selectedId;
+    harness.dispatch('open-subject', { subjectId: 'grammar' });
+    seedTransferLane(harness, {
+      transferLane: defaultTransferLane(),
+      transferUi: { selectedPromptId: 'storm-scene', draft: 'A draft', ticks: {} },
+    });
+    // Set rm.error directly to the translated child copy (module.js path
+    // is already covered in the U6a tests).
+    harness.store.updateSubjectUi('grammar', (current) => ({
+      ...normaliseGrammarReadModel(current, learnerId),
+      error: GRAMMAR_TRANSFER_ERROR_COPY[code],
+    }));
+    const html = harness.render();
+    const expected = GRAMMAR_TRANSFER_ERROR_COPY[code].replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    assert.match(html, new RegExp(`role="alert"[\\s\\S]*?${expected}`),
+      `expected child copy for ${code} to render in role=alert`);
+  }
+});
+
+// ----------------------------------------------------------------------------
+// Absence: no scoring / adult-diagnostic terms leak into the rendered HTML
+// ----------------------------------------------------------------------------
+
+test('U6b: scene HTML never leaks scoring language (score, mastery, points earned, level up)', () => {
+  const harness = openTransferHarness({
+    transferLane: defaultTransferLane({
+      evidence: [{
+        promptId: 'storm-scene',
+        latest: {
+          writing: 'Filled draft.',
+          selfAssessment: [{ key: 'check-0', checked: true }],
+          savedAt: 1_777_000_000_000,
+          source: 'transfer-lane',
+        },
+        history: [],
+        updatedAt: 1_777_000_000_000,
+      }],
+    }),
+    transferUi: { selectedPromptId: 'storm-scene', draft: 'Draft text.' },
+  });
+  const html = harness.render();
+  // Narrow to the scene section only so the rest of the app (e.g., the
+  // dashboard adult disclosure) does not pollute the absence sweep.
+  const sceneMatch = html.match(/<section class="grammar-transfer-scene"[\s\S]*?<\/section>/);
+  assert.ok(sceneMatch, 'transfer scene renders');
+  const sceneHtml = sceneMatch[0];
+  assert.doesNotMatch(sceneHtml, /\bscore\b/i);
+  assert.doesNotMatch(sceneHtml, /\bmastery\b/i);
+  assert.doesNotMatch(sceneHtml, /points earned/i);
+  assert.doesNotMatch(sceneHtml, /level up/i);
+  assert.doesNotMatch(sceneHtml, /reviewCopy/i);
+  assert.doesNotMatch(sceneHtml, /requestId/i);
+});
+
+test('U6b: scene HTML contains none of GRAMMAR_CHILD_FORBIDDEN_TERMS', () => {
+  const harness = openTransferHarness({
+    transferLane: defaultTransferLane(),
+    transferUi: { selectedPromptId: 'storm-scene', draft: 'Draft.' },
+  });
+  const html = harness.render();
+  const sceneMatch = html.match(/<section class="grammar-transfer-scene"[\s\S]*?<\/section>/);
+  assert.ok(sceneMatch);
+  const sceneHtml = sceneMatch[0];
+  for (const term of GRAMMAR_CHILD_FORBIDDEN_TERMS) {
+    const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    assert.doesNotMatch(sceneHtml, new RegExp(escaped, 'i'), `forbidden term leaked: ${term}`);
+  }
+  assert.doesNotMatch(sceneHtml, /\bWorker\b/i);
+});
+
+// ----------------------------------------------------------------------------
+// Non-scored invariants + recursive redaction scan
+// ----------------------------------------------------------------------------
+
+function assertNoForbiddenReadModelKeys(value, forbidden) {
+  const forbiddenSet = new Set(forbidden);
+  const visit = (node, pathPrefix) => {
+    if (node === null || typeof node !== 'object') return;
+    if (Array.isArray(node)) {
+      node.forEach((entry, index) => visit(entry, `${pathPrefix}[${index}]`));
+      return;
+    }
+    for (const [key, child] of Object.entries(node)) {
+      const nextPath = pathPrefix ? `${pathPrefix}.${key}` : key;
+      if (forbiddenSet.has(key)) {
+        assert.fail(`Forbidden key "${key}" found at ${nextPath}`);
+      }
+      visit(child, nextPath);
+    }
+  };
+  visit(value, '');
+}
+
+test('U6b: full Worker round-trip — save-transfer-evidence leaves mastery unchanged, positive evidence delta, no reward toast', () => {
+  const engine = createServerGrammarEngine({ now: () => 1_777_000_000_000 });
+  const initial = createInitialGrammarState();
+  const beforeMastery = JSON.stringify(initial.mastery);
+  const beforeRetry = JSON.stringify(initial.retryQueue);
+
+  const result = engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: { ui: initial, data: { ...initial } },
+    command: 'save-transfer-evidence',
+    requestId: 'tx-u6b-full',
+    payload: {
+      promptId: GRAMMAR_TRANSFER_PROMPT_IDS[0],
+      writing: 'Suddenly, thunder cracked. The clouds, which blocked the sun, loomed overhead.',
+      selfAssessment: [
+        { key: 'check-0', checked: true },
+        { key: 'check-1', checked: false },
+        { key: 'check-2', checked: true },
+      ],
+    },
+  });
+
+  // Mastery / retry unchanged across the save.
+  assert.equal(JSON.stringify(result.state.mastery), beforeMastery);
+  assert.equal(JSON.stringify(result.state.retryQueue), beforeRetry);
+
+  // Positive evidence delta.
+  const entry = result.state.transferEvidence[GRAMMAR_TRANSFER_PROMPT_IDS[0]];
+  assert.ok(entry, 'evidence entry lands after save');
+  assert.equal(entry.latest.writing.startsWith('Suddenly'), true);
+  assert.deepEqual(entry.latest.selfAssessment, [
+    { key: 'check-0', checked: true },
+    { key: 'check-1', checked: false },
+    { key: 'check-2', checked: true },
+  ]);
+
+  // No reward.monster event fires.
+  for (const event of result.events) {
+    assert.notEqual(event.type, 'reward.monster');
+    assert.notEqual(event.type, 'grammar.answer-submitted');
+    assert.notEqual(event.type, 'grammar.concept-secured');
+    assert.notEqual(event.type, 'grammar.misconception-seen');
+  }
+
+  // Client normaliser passes redaction scan.
+  const rm = buildGrammarReadModel({ learnerId: 'learner-a', state: result.state, now: 1_777_000_000_000 });
+  const clientRm = normaliseGrammarReadModel(rm, 'learner-a');
+  assertNoForbiddenReadModelKeys(clientRm.transferLane, ['reviewCopy', 'requestId']);
+});
+
+test('U6b: save-success onResolved callback clears draft + ticks but preserves selectedPromptId', async () => {
+  let resolveCommand;
+  const context = {
+    appState: {
+      learners: { selectedId: 'learner-a' },
+      subjectUi: {
+        grammar: normaliseGrammarReadModel({
+          phase: 'transfer',
+          ui: {
+            transfer: {
+              selectedPromptId: 'storm-scene',
+              draft: 'Pre-save draft text.',
+              ticks: { 'check-0': true },
+            },
+          },
+          transferLane: defaultTransferLane(),
+        }, 'learner-a'),
+      },
+    },
+    runtimeReadOnly: false,
+    subjectCommands: {
+      send() {
+        return new Promise((resolve) => { resolveCommand = resolve; });
+      },
+    },
+    store: {
+      getState() { return context.appState; },
+      updateSubjectUi(subjectId, updater) {
+        const previous = context.appState.subjectUi[subjectId] || {};
+        const next = typeof updater === 'function' ? updater(previous) : { ...previous, ...updater };
+        context.appState = {
+          ...context.appState,
+          subjectUi: { ...context.appState.subjectUi, [subjectId]: next },
+        };
+      },
+      updateSubjectUiForLearner(learnerId, subjectId, updater) {
+        if (learnerId !== 'learner-a') return false;
+        context.store.updateSubjectUi(subjectId, updater);
+        return true;
+      },
+      pushToasts() {},
+      pushMonsterCelebrations() {},
+      reloadFromRepositories() {},
+    },
+  };
+
+  grammarModule.handleAction('grammar-save-transfer-evidence', {
+    ...context,
+    data: {
+      payload: {
+        promptId: 'storm-scene',
+        writing: 'Pre-save draft text.',
+        selfAssessment: [{ key: 'check-0', checked: true }],
+      },
+    },
+  });
+  // Confirm pendingCommand registered before the resolve.
+  assert.equal(context.appState.subjectUi.grammar.pendingCommand, 'save-transfer-evidence');
+
+  resolveCommand({
+    subjectReadModel: normaliseGrammarReadModel({
+      learnerId: 'learner-a',
+      phase: 'transfer',
+      transferLane: {
+        mode: 'non-scored',
+        prompts: SAMPLE_PROMPTS,
+        limits: SAMPLE_LIMITS,
+        evidence: [{
+          promptId: 'storm-scene',
+          latest: {
+            writing: 'Pre-save draft text.',
+            selfAssessment: [{ key: 'check-0', checked: true }],
+            savedAt: 1_777_000_000_000,
+            source: 'transfer-lane',
+          },
+          history: [],
+          updatedAt: 1_777_000_000_000,
+        }],
+      },
+    }, 'learner-a'),
+    projections: { rewards: { toastEvents: [], events: [] } },
+  });
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+
+  const ui = context.appState.subjectUi.grammar;
+  assert.equal(ui.ui.transfer.selectedPromptId, 'storm-scene', 'selectedPromptId preserved so learner sees saved-history');
+  assert.equal(ui.ui.transfer.draft, '', 'draft clears after save success');
+  assert.deepEqual(ui.ui.transfer.ticks, {}, 'ticks clear after save success');
+  // Evidence updated
+  const evidence = ui.transferLane.evidence.find((entry) => entry.promptId === 'storm-scene');
+  assert.ok(evidence);
+  assert.equal(evidence.latest.writing, 'Pre-save draft text.');
+});
+
+// ----------------------------------------------------------------------------
+// Phase allowlist + router
+// ----------------------------------------------------------------------------
+
+test('U6b: normaliseGrammarReadModel accepts "transfer" as a valid phase', () => {
+  const rm = normaliseGrammarReadModel({ phase: 'transfer' }, 'learner-a');
+  assert.equal(rm.phase, 'transfer');
+});
+
+test('U6b: ui.transfer slot defaults to empty shape when missing from upstream state', () => {
+  const rm = normaliseGrammarReadModel({}, 'learner-a');
+  assert.deepEqual(rm.ui.transfer, { selectedPromptId: '', draft: '', ticks: {} });
+});
+
+test('U6b: grammar-close-transfer returns the learner to the dashboard and resets transient state', () => {
+  const harness = openTransferHarness({
+    transferLane: defaultTransferLane(),
+    transferUi: { selectedPromptId: 'storm-scene', draft: 'Unsaved draft.', ticks: { 'check-0': true } },
+  });
+  harness.dispatch('grammar-close-transfer');
+  const ui = harness.store.getState().subjectUi.grammar;
+  assert.equal(ui.phase, 'dashboard');
+});
+
+test('U6b: grammar-open-transfer clears stale Writing Try transient state (draft, ticks, selectedPromptId)', () => {
+  const storage = installMemoryStorage();
+  const harness = createAppHarness({ storage });
+  const learnerId = harness.store.getState().learners.selectedId;
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  // Seed stale transient state from a prior visit.
+  harness.store.updateSubjectUi('grammar', (current) => normaliseGrammarReadModel({
+    ...current,
+    ui: { transfer: { selectedPromptId: 'storm-scene', draft: 'stale', ticks: { 'check-0': true } } },
+  }, learnerId));
+  harness.dispatch('grammar-open-transfer');
+  const ui = harness.store.getState().subjectUi.grammar;
+  assert.equal(ui.phase, 'transfer');
+  assert.equal(ui.ui.transfer.selectedPromptId, '');
+  assert.equal(ui.ui.transfer.draft, '');
+  assert.deepEqual(ui.ui.transfer.ticks, {});
+});

--- a/tests/react-grammar-surface.test.js
+++ b/tests/react-grammar-surface.test.js
@@ -987,7 +987,7 @@ test('Grammar analytics renders evidence before reward progress', () => {
   assert.match(html, /Choose the correct sentence/);
 });
 
-test('Grammar dashboard Writing Try dispatches grammar-open-transfer to the Writing Try placeholder scene', () => {
+test('Grammar dashboard Writing Try dispatches grammar-open-transfer to the Writing Try scene', () => {
   const storage = installMemoryStorage();
   const harness = createAppHarness({ storage });
 
@@ -999,8 +999,12 @@ test('Grammar dashboard Writing Try dispatches grammar-open-transfer to the Writ
   harness.dispatch('grammar-open-transfer');
   assert.equal(harness.store.getState().subjectUi.grammar.phase, 'transfer');
   const transferHtml = harness.render();
+  // Phase 3 U6b replaces the placeholder stub with the real scene. The
+  // hero copy reinforces that the surface is non-scored without leaking
+  // adult-diagnostic terms.
   assert.match(transferHtml, /Writing Try/);
-  assert.match(transferHtml, /Non-scored writing/);
+  assert.match(transferHtml, /Nothing you write here is scored/);
+  assert.match(transferHtml, /class="grammar-transfer-scene"/);
   // Back action returns the learner safely to the dashboard.
   harness.dispatch('grammar-back');
   assert.equal(harness.store.getState().subjectUi.grammar.phase, 'dashboard');


### PR DESCRIPTION
## Summary

Ships the non-scored Writing Try surface for Phase 3, replacing the U1 placeholder stub with `GrammarTransferScene.jsx`. The scene consumes the Worker `transferLane` read model plumbed through by U6a and renders three modes (pick-prompt, write, saved-history) plus a retired-prompts section for orphaned evidence.

Links: [Phase 3 plan §U6b](../blob/feat/grammar-p3-u6b-writing-try/docs/plans/2026-04-25-004-feat-grammar-phase3-ux-reset-plan.md#L694-L747).

### Three modes

- **Pick-prompt** (no `selectedPromptId`): renders the prompt catalogue as cards, each with `title`, `brief`, child-friendly `grammarTargets` badges via `GRAMMAR_CLIENT_CONCEPTS`, a saved-count chip, and a `Start writing` primary button.
- **Write** (`selectedPromptId` set): renders prompt details, a 2000-char writing textarea with a live `X / 2000` counter (warn style + child copy when over), a self-check `<fieldset>` using stable `check-<index>` keys, primary `Save writing` + ghost `Change prompt` buttons.
- **Saved-history**: renders below the write surface when the selected prompt has evidence. Shows `latest` (with `selfAssessment` ticks) plus up to 4 `history` entries (history omits `selfAssessment` per Worker asymmetry; the UI respects the Worker's most-recent-first sort).

Orphaned evidence (promptId not in the current catalogue) renders in a separate `Retired prompts` section with no Start writing button.

### New UI actions (in `module.js`)

- `grammar-close-transfer` — back to dashboard.
- `grammar-select-transfer-prompt` — sets `selectedPromptId` and clears draft + ticks so learners never submit a prior prompt's writing under the wrong id.
- `grammar-update-transfer-draft` — preserves the draft verbatim so the scene can detect over-cap input and disable Save (normaliser applies a larger sanity hard cap, not the Worker 2000-char cap).
- `grammar-toggle-transfer-check` — flips a `check-N` key in `ticks`.
- `grammar-save-transfer-evidence` — already shipped in U6a; now gains an `onResolved` callback that clears draft + ticks but preserves `selectedPromptId` so learners see the fresh saved-history for the same prompt.

### Non-scored invariants (asserted at the UI and Worker boundaries)

- No `score`, `mastery`, `points earned`, `level up`, `reviewCopy`, or `requestId` ever renders in the scene HTML.
- Full-cycle Worker round-trip test: save-transfer-evidence leaves `state.mastery` and `state.retryQueue` byte-identical, shows positive delta on `state.transferEvidence[promptId]`, emits no `reward.monster` / `grammar.answer-submitted` / `grammar.concept-secured` / `grammar.misconception-seen` event.
- Recursive redaction scan `assertNoForbiddenReadModelKeys(rm.transferLane, ['reviewCopy', 'requestId'])` passes.
- `GRAMMAR_CHILD_FORBIDDEN_TERMS` iterated against the rendered scene HTML — no leak.

## Test plan

- [x] `node --test tests/grammar-transfer-scene.test.js tests/grammar-transfer-lane.test.js tests/react-grammar-surface.test.js` — 255 tests green.
- [x] `npm test` — 1911 tests, 1909 pass, 1 pre-existing failure on `grammar-production-smoke` (not related to U6b; confirmed reproduces on main without this branch).
- [x] `npm run check` — green.
- [x] New test file `tests/grammar-transfer-scene.test.js` covers:
  - Pick-prompt mode (prompt cards, saved chip, empty state).
  - Write mode (textarea, counter, checklist, Save disabled rules).
  - Over-cap draft (>2000 chars) disables Save + renders child-copy warning.
  - Pending `save-transfer-evidence` disables Save + flips label to `Saving...`.
  - Exact Save payload shape `{promptId, writing, selfAssessment: Array<{key, checked}>}` — no `checklist` alias.
  - Saved-history latest + up to 4 history entries, self-assessment ticks on latest only.
  - Orphaned evidence renders as `Retired prompts` card without Start writing.
  - Four Worker error codes route through child copy in `role="alert"`.
  - Absence sweeps (scoring language, `GRAMMAR_CHILD_FORBIDDEN_TERMS`).
  - Full Worker round-trip proving non-scored invariants.
  - `save-success` onResolved clears draft + ticks, preserves selectedPromptId.
  - `normaliseGrammarReadModel` phase allowlist accepts `'transfer'` and `ui.transfer` defaults to safe empty shape.
  - `grammar-open-transfer` clears stale transient state on reopen.

## Notes

- Payload key is `selfAssessment`, not `checklist`. Sending `checklist` silently drops ticks per Worker contract.
- Field is `brief`, not `theme`. Cross-checked against `worker/src/subjects/grammar/transfer-prompts.js`.
- Phase allowlist extension for `'transfer'` already landed in U1; no change needed here.
- UK English throughout. No AI fingerprints.