### PR TITLE
feat(spelling): U1 post-mastery selector + dashboard gating via guardianMissionState

### DIFF
--- a/shared/spelling/service.js
+++ b/shared/spelling/service.js
@@ -21,6 +21,7 @@ import {
   GUARDIAN_MAX_REVIEW_LEVEL,
   GUARDIAN_MAX_ROUND_LENGTH,
   GUARDIAN_MIN_ROUND_LENGTH,
+  GUARDIAN_MISSION_STATES,
   GUARDIAN_SECURE_STAGE,
   cloneSerialisable,
   createInitialSpellingState,
@@ -60,15 +61,33 @@ export { isGuardianEligibleSlug };
  *
  * Contract:
  *   - `allWordsMega` false → 'locked' (dashboard renders legacy setup).
- *   - Empty guardian map + any unguarded Mega slug → 'first-patrol' (fresh
- *     graduate has never run Guardian; even a single unguarded Mega word
- *     opens the first patrol).
+ *   - Empty guardian map + unguarded Mega slugs AND the combined pool can
+ *     fill a minimum-length round (`>= GUARDIAN_MIN_ROUND_LENGTH`) →
+ *     'first-patrol'. Below that threshold `selectGuardianWords` would
+ *     produce a short round, so we collapse to 'rested' to keep Begin
+ *     disabled rather than ship a 1-4 word Guardian.
  *   - Any eligible wobbling-due entry → 'wobbling' (urgent recovery check).
- *   - Any eligible due entry → 'due' (the normal daily patrol).
+ *     Wobbling always dominates 'due' so a single recovery drill rides even
+ *     under the round-length minimum (the selector tops up from non-due
+ *     guardians if needed).
+ *   - Any eligible due entry → 'due' (the normal daily patrol). Same
+ *     top-up reasoning as wobbling — a short due round top-ups from the
+ *     non-due bucket.
  *   - No due entries, but a round CAN be produced via top-up or lazy-create
- *     AND policy allows optional patrol → 'optional-patrol'.
- *   - Everything guarded, nothing due, no top-up policy → 'rested'
- *     (Begin disabled, copy shows next check in N days).
+ *     AND the combined pool hits `GUARDIAN_MIN_ROUND_LENGTH`, AND policy
+ *     allows optional patrol → 'optional-patrol'.
+ *   - Everything guarded, nothing due, no top-up policy (or pool too small)
+ *     → 'rested' (Begin disabled, copy shows next check in N days).
+ *
+ * Short-round invariant (adversarial sev 60/50): `selectGuardianWords` walks
+ * four buckets (wobbling-due, non-wobbling-due, lazy-create, top-up) and
+ * stops at `GUARDIAN_MIN_ROUND_LENGTH`. If the dashboard advertises
+ * 'first-patrol' or 'optional-patrol' without the combined pool reaching
+ * that threshold, the learner would tap Begin and receive a 1-4 word round
+ * — below the Guardian minimum. This helper therefore gates both states on
+ * `unguardedMegaCount + entries.length >= GUARDIAN_MIN_ROUND_LENGTH`. The
+ * 'wobbling' and 'due' states skip this check because a single wobbling or
+ * due entry plus the selector's own top-up fallback always fills the round.
  *
  * The helper is tolerant of null/garbage inputs: if `ctx` is falsy or
  * `allWordsMega` is not strictly true, the result is 'locked'. This lets
@@ -93,6 +112,19 @@ export { isGuardianEligibleSlug };
  * @returns {string}  One of `GUARDIAN_MISSION_STATES`.
  */
 export function computeGuardianMissionState(ctx) {
+  const resolved = resolveGuardianMissionState(ctx);
+  // Runtime sanity check — if the state-machine above ever returns an
+  // unknown label (e.g. a typo like 'fist-patrol'), refuse to leak the
+  // garbage into UI copy. Throwing here is loud on purpose: the dashboard
+  // branches on this value and would otherwise render the defensive fallback
+  // silently, hiding the bug.
+  if (!GUARDIAN_MISSION_STATES.includes(resolved)) {
+    throw new Error(`computeGuardianMissionState: unknown state "${resolved}"`);
+  }
+  return resolved;
+}
+
+function resolveGuardianMissionState(ctx) {
   if (!ctx || typeof ctx !== 'object' || Array.isArray(ctx)) return 'locked';
   if (ctx.allWordsMega !== true) return 'locked';
 
@@ -104,8 +136,22 @@ export function computeGuardianMissionState(ctx) {
   const policy = ctx.policy && typeof ctx.policy === 'object' && !Array.isArray(ctx.policy) ? ctx.policy : {};
   const allowOptionalPatrol = policy.allowOptionalPatrol !== false; // default true
 
+  // Combined-pool size fed to the selector. `selectGuardianWords` walks
+  // wobbling-due → non-wobbling-due → lazy-create → top-up and stops at
+  // GUARDIAN_MIN_ROUND_LENGTH (5). The dashboard therefore must not offer
+  // 'first-patrol' or 'optional-patrol' unless the pool reaches that
+  // minimum — otherwise the learner would click Begin and receive a short
+  // round with fewer than 5 words, violating the Guardian round invariant.
+  const combinedPoolSize = unguardedMegaCount + entries.length;
+  const canFillRound = combinedPoolSize >= GUARDIAN_MIN_ROUND_LENGTH;
+
   // Fresh graduate: has never run Guardian AND has Mega words to patrol.
-  if (entries.length === 0 && unguardedMegaCount > 0) return 'first-patrol';
+  // Requires enough combined pool to fill the round; otherwise the learner
+  // is effectively 'rested' until more words graduate.
+  if (entries.length === 0 && unguardedMegaCount > 0) {
+    if (canFillRound) return 'first-patrol';
+    return 'rested';
+  }
 
   const wobblingDue = entries.some((entry) => entry?.wobbling === true && Number(entry?.nextDueDay) <= todayDay);
   if (wobblingDue) return 'wobbling';
@@ -116,11 +162,110 @@ export function computeGuardianMissionState(ctx) {
   // Nothing due. `optional-patrol` is only offered when a round CAN be
   // produced — either by lazy-creating from an unguarded Mega slug OR by
   // topping up from a non-due guardian (selector's bucket 4). If neither is
-  // possible, OR the caller explicitly disabled the optional path, we are
-  // 'rested'.
+  // possible, OR the caller explicitly disabled the optional path, OR the
+  // combined pool is below the minimum round length, we are 'rested'.
   const canProduceTopUpRound = unguardedMegaCount > 0 || entries.length > 0;
-  if (allowOptionalPatrol && canProduceTopUpRound) return 'optional-patrol';
+  if (allowOptionalPatrol && canProduceTopUpRound && canFillRound) return 'optional-patrol';
   return 'rested';
+}
+
+/**
+ * Pure aggregate helper. Walks `guardianMap` once to produce the filtered
+ * eligible-entries list and the decomposed due-count scalars; walks
+ * `progressMap` once to produce `unguardedMegaCount`. Returning all seven
+ * fields from a single helper means `getPostMasteryState` (service) and
+ * `getSpellingPostMasteryState` (read-model) cannot drift — they consume
+ * the same derivation.
+ *
+ * The helper trusts that `isGuardianEligibleSlug` is the single orphan
+ * predicate (U2 contract). Callers pass in the ambient `wordBySlug`
+ * (runtime content) and `progressMap` (learner state) so the predicate can
+ * filter orphan records without the helper itself needing to import word
+ * data.
+ *
+ * Invariant guaranteed by the implementation:
+ *   `wobblingDueCount + nonWobblingDueCount === guardianDueCount`
+ *
+ * @param {object} params
+ * @param {object} params.guardianMap   slug -> normalised guardian record
+ * @param {object} params.progressMap   slug -> legacy progress record
+ * @param {object} params.wordBySlug    slug -> published word metadata
+ * @param {number} params.todayDay      integer day (Math.floor(ts/DAY_MS))
+ * @returns {{
+ *   eligibleGuardianEntries: Array<{slug: string, wobbling: boolean, nextDueDay: number}>,
+ *   guardianDueCount: number,
+ *   wobblingDueCount: number,
+ *   nonWobblingDueCount: number,
+ *   wobblingCount: number,
+ *   nextGuardianDueDay: number|null,
+ *   unguardedMegaCount: number,
+ * }}
+ */
+export function deriveGuardianAggregates({
+  guardianMap = {},
+  progressMap = {},
+  wordBySlug = {},
+  todayDay = 0,
+} = {}) {
+  const safeGuardianMap = guardianMap && typeof guardianMap === 'object' && !Array.isArray(guardianMap)
+    ? guardianMap
+    : {};
+  const safeProgressMap = progressMap && typeof progressMap === 'object' && !Array.isArray(progressMap)
+    ? progressMap
+    : {};
+  const safeWordBySlug = wordBySlug && typeof wordBySlug === 'object' && !Array.isArray(wordBySlug)
+    ? wordBySlug
+    : {};
+  const safeToday = Number.isFinite(Number(todayDay)) ? Math.floor(Number(todayDay)) : 0;
+
+  const eligibleGuardianEntries = [];
+  let guardianDueCount = 0;
+  let wobblingCount = 0;
+  let wobblingDueCount = 0;
+  let nonWobblingDueCount = 0;
+  let nextGuardianDueDay = null;
+
+  for (const [slug, record] of Object.entries(safeGuardianMap)) {
+    if (!record) continue;
+    if (!isGuardianEligibleSlug(slug, safeProgressMap, safeWordBySlug)) continue;
+    const isWobbling = record.wobbling === true;
+    const entryDueDay = Number(record.nextDueDay);
+    eligibleGuardianEntries.push({
+      slug,
+      wobbling: isWobbling,
+      nextDueDay: entryDueDay,
+    });
+    const isDueToday = entryDueDay <= safeToday;
+    if (isDueToday) {
+      guardianDueCount += 1;
+      if (isWobbling) {
+        wobblingDueCount += 1;
+      } else {
+        nonWobblingDueCount += 1;
+      }
+    }
+    if (isWobbling) wobblingCount += 1;
+    if (nextGuardianDueDay === null || entryDueDay < nextGuardianDueDay) {
+      nextGuardianDueDay = entryDueDay;
+    }
+  }
+
+  let unguardedMegaCount = 0;
+  for (const [slug] of Object.entries(safeProgressMap)) {
+    if (!isGuardianEligibleSlug(slug, safeProgressMap, safeWordBySlug)) continue;
+    if (Object.prototype.hasOwnProperty.call(safeGuardianMap, slug)) continue;
+    unguardedMegaCount += 1;
+  }
+
+  return {
+    eligibleGuardianEntries,
+    guardianDueCount,
+    wobblingDueCount,
+    nonWobblingDueCount,
+    wobblingCount,
+    nextGuardianDueDay,
+    unguardedMegaCount,
+  };
 }
 
 const PREF_KEY = 'ks2-platform-v2.spelling-prefs';
@@ -872,56 +1017,23 @@ export function createSpellingService({ repository, storage, tts, now, random, c
     const today = currentTodayDay();
     const allWordsMega = isAllWordsMega(progressStore);
 
-    // U2: orphan sanitiser — count only entries whose slug is still a valid
-    // Guardian candidate (known in runtime, stage >= Mega, pool !== extra).
-    // Persisted orphan records stay intact; they simply drop out of counts
-    // and the earliest-due calculation.
-    // U1: collect decomposed counts + eligible-entries list so the dashboard
-    // state machine can branch without re-scanning the map.
-    const eligibleGuardianEntries = [];
-    let guardianDueCount = 0;
-    let wobblingCount = 0;
-    let wobblingDueCount = 0;
-    let nonWobblingDueCount = 0;
-    let nextGuardianDueDay = null;
-    for (const [slug, record] of Object.entries(guardianMap)) {
-      if (!record) continue;
-      if (!isGuardianEligibleSlug(slug, progressStore, runtimeWordBySlug)) continue;
-      eligibleGuardianEntries.push({
-        slug,
-        wobbling: record.wobbling === true,
-        nextDueDay: record.nextDueDay,
-      });
-      const isDueToday = record.nextDueDay <= today;
-      if (isDueToday) {
-        guardianDueCount += 1;
-        if (record.wobbling === true) {
-          wobblingDueCount += 1;
-        } else {
-          nonWobblingDueCount += 1;
-        }
-      }
-      if (record.wobbling === true) wobblingCount += 1;
-      if (nextGuardianDueDay === null || record.nextDueDay < nextGuardianDueDay) {
-        nextGuardianDueDay = record.nextDueDay;
-      }
-    }
+    // Shared derivation — same helper feeds `getSpellingPostMasteryState`
+    // in the read-model so service and read-model cannot drift. U2 orphan
+    // sanitiser lives inside the helper (via `isGuardianEligibleSlug`), so
+    // a content hot-swap removing a slug automatically drops it from the
+    // counts here and in the read-model.
+    const aggregates = deriveGuardianAggregates({
+      guardianMap,
+      progressMap: progressStore,
+      wordBySlug: runtimeWordBySlug,
+      todayDay: today,
+    });
 
-    // U1: core-pool Mega slugs that have no guardian record yet. Drives the
-    // 'first-patrol' state and `guardianAvailableCount` ("N patrol words
-    // available" copy).
-    let unguardedMegaCount = 0;
-    for (const [slug] of Object.entries(progressStore)) {
-      if (!isGuardianEligibleSlug(slug, progressStore, runtimeWordBySlug)) continue;
-      if (Object.prototype.hasOwnProperty.call(guardianMap, slug)) continue;
-      unguardedMegaCount += 1;
-    }
-
-    const guardianAvailableCount = unguardedMegaCount + eligibleGuardianEntries.length;
+    const guardianAvailableCount = aggregates.unguardedMegaCount + aggregates.eligibleGuardianEntries.length;
     const guardianMissionState = computeGuardianMissionState({
       allWordsMega,
-      eligibleGuardianEntries,
-      unguardedMegaCount,
+      eligibleGuardianEntries: aggregates.eligibleGuardianEntries,
+      unguardedMegaCount: aggregates.unguardedMegaCount,
       todayDay: today,
       policy: { allowOptionalPatrol: true },
     });
@@ -929,15 +1041,15 @@ export function createSpellingService({ repository, storage, tts, now, random, c
 
     return {
       allWordsMega,
-      guardianDueCount,
-      wobblingCount,
-      wobblingDueCount,
-      nonWobblingDueCount,
-      unguardedMegaCount,
+      guardianDueCount: aggregates.guardianDueCount,
+      wobblingCount: aggregates.wobblingCount,
+      wobblingDueCount: aggregates.wobblingDueCount,
+      nonWobblingDueCount: aggregates.nonWobblingDueCount,
+      unguardedMegaCount: aggregates.unguardedMegaCount,
       guardianAvailableCount,
       guardianMissionState,
       guardianMissionAvailable,
-      nextGuardianDueDay,
+      nextGuardianDueDay: aggregates.nextGuardianDueDay,
       todayDay: today,
       guardianMap,
     };

--- a/shared/spelling/service.js
+++ b/shared/spelling/service.js
@@ -53,6 +53,76 @@ import {
 // free of the full word dataset (see audit-client-bundle.mjs).
 export { isGuardianEligibleSlug };
 
+/**
+ * Pure dashboard state machine (U1). Derives the Guardian mission state from
+ * aggregate counts so the Setup scene, the module shortcut gate, and any
+ * downstream consumer can branch their copy on a single labelled value.
+ *
+ * Contract:
+ *   - `allWordsMega` false → 'locked' (dashboard renders legacy setup).
+ *   - Empty guardian map + any unguarded Mega slug → 'first-patrol' (fresh
+ *     graduate has never run Guardian; even a single unguarded Mega word
+ *     opens the first patrol).
+ *   - Any eligible wobbling-due entry → 'wobbling' (urgent recovery check).
+ *   - Any eligible due entry → 'due' (the normal daily patrol).
+ *   - No due entries, but a round CAN be produced via top-up or lazy-create
+ *     AND policy allows optional patrol → 'optional-patrol'.
+ *   - Everything guarded, nothing due, no top-up policy → 'rested'
+ *     (Begin disabled, copy shows next check in N days).
+ *
+ * The helper is tolerant of null/garbage inputs: if `ctx` is falsy or
+ * `allWordsMega` is not strictly true, the result is 'locked'. This lets
+ * the remote-sync client-read-models stub default to 'locked' without a
+ * special-case code path.
+ *
+ * @param {object} ctx
+ * @param {boolean} ctx.allWordsMega
+ * @param {Array<{slug: string, wobbling: boolean, nextDueDay: number}>} ctx.eligibleGuardianEntries
+ *   Guardian records whose slugs have already been run through
+ *   `isGuardianEligibleSlug` — orphan slugs must be excluded by the caller
+ *   before passing in. The helper trusts this contract rather than
+ *   re-filtering (keeps the helper decoupled from `wordBySlug` / `progressMap`).
+ * @param {number} ctx.unguardedMegaCount
+ *   Number of core-pool Mega slugs that have no entry in the guardian map.
+ *   Zero when every Mega word is already being tracked.
+ * @param {number} ctx.todayDay   Integer day (Math.floor(ts/DAY_MS)).
+ * @param {object} [ctx.policy]
+ * @param {boolean} [ctx.policy.allowOptionalPatrol=true]  If false, the
+ *   'optional-patrol' branch collapses into 'rested' so the Begin button
+ *   stays disabled when the only available round is non-urgent.
+ * @returns {string}  One of `GUARDIAN_MISSION_STATES`.
+ */
+export function computeGuardianMissionState(ctx) {
+  if (!ctx || typeof ctx !== 'object' || Array.isArray(ctx)) return 'locked';
+  if (ctx.allWordsMega !== true) return 'locked';
+
+  const todayDay = Number.isFinite(Number(ctx.todayDay)) ? Math.floor(Number(ctx.todayDay)) : 0;
+  const entries = Array.isArray(ctx.eligibleGuardianEntries) ? ctx.eligibleGuardianEntries : [];
+  const unguardedMegaCount = Number.isFinite(Number(ctx.unguardedMegaCount))
+    ? Math.max(0, Math.floor(Number(ctx.unguardedMegaCount)))
+    : 0;
+  const policy = ctx.policy && typeof ctx.policy === 'object' && !Array.isArray(ctx.policy) ? ctx.policy : {};
+  const allowOptionalPatrol = policy.allowOptionalPatrol !== false; // default true
+
+  // Fresh graduate: has never run Guardian AND has Mega words to patrol.
+  if (entries.length === 0 && unguardedMegaCount > 0) return 'first-patrol';
+
+  const wobblingDue = entries.some((entry) => entry?.wobbling === true && Number(entry?.nextDueDay) <= todayDay);
+  if (wobblingDue) return 'wobbling';
+
+  const anyDue = entries.some((entry) => Number(entry?.nextDueDay) <= todayDay);
+  if (anyDue) return 'due';
+
+  // Nothing due. `optional-patrol` is only offered when a round CAN be
+  // produced — either by lazy-creating from an unguarded Mega slug OR by
+  // topping up from a non-due guardian (selector's bucket 4). If neither is
+  // possible, OR the caller explicitly disabled the optional path, we are
+  // 'rested'.
+  const canProduceTopUpRound = unguardedMegaCount > 0 || entries.length > 0;
+  if (allowOptionalPatrol && canProduceTopUpRound) return 'optional-patrol';
+  return 'rested';
+}
+
 const PREF_KEY = 'ks2-platform-v2.spelling-prefs';
 const GUARDIAN_PROGRESS_KEY_PREFIX = 'ks2-spell-guardian-';
 const PROGRESS_KEY_PREFIX = 'ks2-spell-progress-';
@@ -785,10 +855,16 @@ export function createSpellingService({ repository, storage, tts, now, random, c
    * service state so the Setup scene, Alt+4 gate, and summary copy see a
    * consistent view without drilling a read-model through the container tree.
    *
-   * Returns: { allWordsMega, guardianDueCount, wobblingCount, nextGuardianDueDay, todayDay, guardianMap }
+   * Returns: { allWordsMega, guardianDueCount, wobblingCount, nextGuardianDueDay,
+   *            todayDay, guardianMap, wobblingDueCount, nonWobblingDueCount,
+   *            unguardedMegaCount, guardianAvailableCount, guardianMissionState,
+   *            guardianMissionAvailable }
    * The raw `guardianMap` is included so UI consumers can compute per-word
    * labels (e.g. "Wobbling — due tomorrow") via `guardianLabel` without a
-   * second round-trip to storage.
+   * second round-trip to storage. U1 additions mirror the read-model selector
+   * shape so the dashboard gate (`guardianMissionAvailable`) and the labelled
+   * state (`guardianMissionState`) read the same value whether they are fed
+   * by the live service or the pre-computed read-model.
    */
   function getPostMasteryState(learnerId) {
     const progressStore = progressSnapshot(learnerId) || {};
@@ -800,23 +876,67 @@ export function createSpellingService({ repository, storage, tts, now, random, c
     // Guardian candidate (known in runtime, stage >= Mega, pool !== extra).
     // Persisted orphan records stay intact; they simply drop out of counts
     // and the earliest-due calculation.
+    // U1: collect decomposed counts + eligible-entries list so the dashboard
+    // state machine can branch without re-scanning the map.
+    const eligibleGuardianEntries = [];
     let guardianDueCount = 0;
     let wobblingCount = 0;
+    let wobblingDueCount = 0;
+    let nonWobblingDueCount = 0;
     let nextGuardianDueDay = null;
     for (const [slug, record] of Object.entries(guardianMap)) {
       if (!record) continue;
       if (!isGuardianEligibleSlug(slug, progressStore, runtimeWordBySlug)) continue;
-      if (record.nextDueDay <= today) guardianDueCount += 1;
+      eligibleGuardianEntries.push({
+        slug,
+        wobbling: record.wobbling === true,
+        nextDueDay: record.nextDueDay,
+      });
+      const isDueToday = record.nextDueDay <= today;
+      if (isDueToday) {
+        guardianDueCount += 1;
+        if (record.wobbling === true) {
+          wobblingDueCount += 1;
+        } else {
+          nonWobblingDueCount += 1;
+        }
+      }
       if (record.wobbling === true) wobblingCount += 1;
       if (nextGuardianDueDay === null || record.nextDueDay < nextGuardianDueDay) {
         nextGuardianDueDay = record.nextDueDay;
       }
     }
 
+    // U1: core-pool Mega slugs that have no guardian record yet. Drives the
+    // 'first-patrol' state and `guardianAvailableCount` ("N patrol words
+    // available" copy).
+    let unguardedMegaCount = 0;
+    for (const [slug] of Object.entries(progressStore)) {
+      if (!isGuardianEligibleSlug(slug, progressStore, runtimeWordBySlug)) continue;
+      if (Object.prototype.hasOwnProperty.call(guardianMap, slug)) continue;
+      unguardedMegaCount += 1;
+    }
+
+    const guardianAvailableCount = unguardedMegaCount + eligibleGuardianEntries.length;
+    const guardianMissionState = computeGuardianMissionState({
+      allWordsMega,
+      eligibleGuardianEntries,
+      unguardedMegaCount,
+      todayDay: today,
+      policy: { allowOptionalPatrol: true },
+    });
+    const guardianMissionAvailable = guardianMissionState !== 'locked' && guardianMissionState !== 'rested';
+
     return {
       allWordsMega,
       guardianDueCount,
       wobblingCount,
+      wobblingDueCount,
+      nonWobblingDueCount,
+      unguardedMegaCount,
+      guardianAvailableCount,
+      guardianMissionState,
+      guardianMissionAvailable,
       nextGuardianDueDay,
       todayDay: today,
       guardianMap,

--- a/src/subjects/spelling/client-read-models.js
+++ b/src/subjects/spelling/client-read-models.js
@@ -1,6 +1,7 @@
 import {
   cloneSerialisable,
   createInitialSpellingState,
+  createLockedPostMasteryState,
   normaliseBoolean,
   normaliseMode,
   normaliseRoundLength,
@@ -125,23 +126,20 @@ export function createSpellingReadModelService({ getState = () => null } = {}) {
       // permanently disabled. The defaults mirror the 'locked' state so the
       // legacy dashboard renders until the first command round-trip
       // populates `subjectUi.spelling.postMastery`.
+      //
+      // Uses the shared `createLockedPostMasteryState()` factory (defined in
+      // `service-contract.js`) so this stub, the session-phase shortcut in
+      // `spelling-view-model.js`, and the `computeGuardianMissionState`
+      // 'locked' result never drift. `todayDay` is populated from the live
+      // clock so UI copy that formats "next check in N days" renders a
+      // sensible (albeit zero-delta) value before hydration.
       const cached = readModel(learnerId).postMastery;
       if (cached && typeof cached === 'object' && !Array.isArray(cached)) {
         return cloneSerialisable(cached);
       }
       return {
-        allWordsMega: false,
-        guardianDueCount: 0,
-        wobblingCount: 0,
-        wobblingDueCount: 0,
-        nonWobblingDueCount: 0,
-        unguardedMegaCount: 0,
-        guardianAvailableCount: 0,
-        guardianMissionState: 'locked',
-        guardianMissionAvailable: false,
-        nextGuardianDueDay: null,
+        ...createLockedPostMasteryState(),
         todayDay: Math.floor(Date.now() / (24 * 60 * 60 * 1000)),
-        guardianMap: {},
       };
     },
     getAudioCue(learnerId) {

--- a/src/subjects/spelling/client-read-models.js
+++ b/src/subjects/spelling/client-read-models.js
@@ -118,6 +118,13 @@ export function createSpellingReadModelService({ getState = () => null } = {}) {
       // through the next cached command response which carries the real
       // state via the Worker engine. This keeps the Setup render stable
       // while the first round trip is in flight.
+      //
+      // U1 critical: the Setup scene gates the Begin button on
+      // `guardianMissionAvailable`; without the defaults below, the
+      // remote-sync dashboard would read `undefined` for the gate and stay
+      // permanently disabled. The defaults mirror the 'locked' state so the
+      // legacy dashboard renders until the first command round-trip
+      // populates `subjectUi.spelling.postMastery`.
       const cached = readModel(learnerId).postMastery;
       if (cached && typeof cached === 'object' && !Array.isArray(cached)) {
         return cloneSerialisable(cached);
@@ -126,6 +133,12 @@ export function createSpellingReadModelService({ getState = () => null } = {}) {
         allWordsMega: false,
         guardianDueCount: 0,
         wobblingCount: 0,
+        wobblingDueCount: 0,
+        nonWobblingDueCount: 0,
+        unguardedMegaCount: 0,
+        guardianAvailableCount: 0,
+        guardianMissionState: 'locked',
+        guardianMissionAvailable: false,
         nextGuardianDueDay: null,
         todayDay: Math.floor(Date.now() / (24 * 60 * 60 * 1000)),
         guardianMap: {},

--- a/src/subjects/spelling/components/SpellingSetupScene.jsx
+++ b/src/subjects/spelling/components/SpellingSetupScene.jsx
@@ -104,6 +104,11 @@ function PostMegaModeCard({
 
 function GraduationStatRibbon({ postMastery, secureCount }) {
   const dueCount = Math.max(0, Number(postMastery?.guardianDueCount) || 0);
+  const wobblingDueCount = Math.max(0, Number(postMastery?.wobblingDueCount) || 0);
+  const nonWobblingDueCount = Math.max(0, Number(postMastery?.nonWobblingDueCount) || 0);
+  // Fallback for legacy callers (e.g. tests injecting a pre-U1 postMastery
+  // shape): if the decomposed counts are missing, fall back to the single
+  // `wobblingCount` so the ribbon still renders something sensible.
   const wobblingCount = Math.max(0, Number(postMastery?.wobblingCount) || 0);
   const today = Number.isFinite(Number(postMastery?.todayDay)) ? Math.floor(Number(postMastery.todayDay)) : 0;
   const nextDue = Number.isFinite(Number(postMastery?.nextGuardianDueDay)) ? Math.floor(Number(postMastery.nextGuardianDueDay)) : null;
@@ -113,13 +118,19 @@ function GraduationStatRibbon({ postMastery, secureCount }) {
   if (Number.isFinite(secureCount) && secureCount > 0) {
     items.push({ label: 'Words secured', value: String(secureCount) });
   }
-  items.push({
-    label: 'Due today',
-    value: String(dueCount),
-    accent: dueCount > 0 ? 'due' : null,
-  });
-  if (wobblingCount > 0) {
-    items.push({ label: 'Wobbling', value: String(wobblingCount), accent: 'wobbling' });
+  // U1: decomposed "N urgent + M patrol" when a wobbling/due mix exists.
+  if (wobblingDueCount > 0 && nonWobblingDueCount > 0) {
+    items.push({ label: 'Urgent checks', value: String(wobblingDueCount), accent: 'wobbling' });
+    items.push({ label: 'Patrol words', value: String(nonWobblingDueCount), accent: 'due' });
+  } else {
+    items.push({
+      label: 'Due today',
+      value: String(dueCount),
+      accent: dueCount > 0 ? 'due' : null,
+    });
+    if (wobblingCount > 0 && wobblingDueCount === 0) {
+      items.push({ label: 'Wobbling', value: String(wobblingCount), accent: 'wobbling' });
+    }
   }
   if (nextDueDelta !== null && dueCount === 0) {
     items.push({
@@ -492,16 +503,77 @@ function PostMegaSetupContent({
 }) {
   const guardianCard = POST_MEGA_MODE_CARDS.find((mode) => mode.id === 'guardian') || POST_MEGA_MODE_CARDS[0];
   const otherCards = POST_MEGA_MODE_CARDS.filter((mode) => mode.id !== 'guardian');
+  // U1: branch copy + gating on `guardianMissionState`. Fall back to the
+  // legacy `guardianDueCount > 0` signal when the read-model has not yet
+  // populated the new scalars so remote-sync and any pre-U1 caller remain
+  // stable.
+  const missionState = typeof postMastery?.guardianMissionState === 'string'
+    ? postMastery.guardianMissionState
+    : null;
   const dueCount = Math.max(0, Number(postMastery?.guardianDueCount) || 0);
   const wobblingCount = Math.max(0, Number(postMastery?.wobblingCount) || 0);
-  const guardianActive = dueCount > 0;
+  const wobblingDueCount = Math.max(0, Number(postMastery?.wobblingDueCount) || 0);
+  const nonWobblingDueCount = Math.max(0, Number(postMastery?.nonWobblingDueCount) || 0);
+  const unguardedMegaCount = Math.max(0, Number(postMastery?.unguardedMegaCount) || 0);
+  const today = Number.isFinite(Number(postMastery?.todayDay)) ? Math.floor(Number(postMastery.todayDay)) : 0;
+  const nextDue = Number.isFinite(Number(postMastery?.nextGuardianDueDay)) ? Math.floor(Number(postMastery.nextGuardianDueDay)) : null;
+  const nextDueDelta = nextDue == null ? null : Math.max(0, nextDue - today);
   const secureCount = Number(stats?.secure) || 0;
-  const guardianDescription = guardianActive
-    ? wobblingCount > 0
+
+  // `guardianMissionAvailable` is the single Begin-button gate. Legacy
+  // fallback: `guardianDueCount > 0` keeps old tests green if a caller passes
+  // a postMastery object without the new scalars.
+  const availableFromState = typeof postMastery?.guardianMissionAvailable === 'boolean'
+    ? postMastery.guardianMissionAvailable
+    : dueCount > 0;
+  const guardianActive = availableFromState;
+
+  const nextDueLabel = nextDueDelta == null
+    ? 'soon'
+    : nextDueDelta <= 0 ? 'today' : nextDueDelta === 1 ? 'tomorrow' : `in ${nextDueDelta} days`;
+
+  // Copy ladder — branches on the canonical U1 state when present, falls
+  // back to the pre-U1 counts otherwise.
+  let guardianDescription;
+  let missionBadge;
+  if (missionState === 'first-patrol') {
+    const remaining = Math.max(1, unguardedMegaCount);
+    guardianDescription = `First Guardian patrol ready — ${remaining} word${remaining === 1 ? '' : 's'} from your Word Vault.`;
+    missionBadge = 'FIRST PATROL';
+  } else if (missionState === 'wobbling') {
+    if (wobblingDueCount > 0 && nonWobblingDueCount > 0) {
+      guardianDescription = `${wobblingDueCount} urgent check${wobblingDueCount === 1 ? '' : 's'} + ${nonWobblingDueCount} patrol word${nonWobblingDueCount === 1 ? '' : 's'}.`;
+    } else {
+      guardianDescription = `${wobblingDueCount || dueCount} wobbling word${(wobblingDueCount || dueCount) === 1 ? '' : 's'} need a Guardian check today.`;
+    }
+    missionBadge = 'URGENT';
+  } else if (missionState === 'due') {
+    guardianDescription = `${dueCount} word${dueCount === 1 ? '' : 's'} ready for their Guardian check.`;
+    missionBadge = 'ACTIVE DUTY';
+  } else if (missionState === 'optional-patrol') {
+    guardianDescription = 'No urgent duties. Optional patrol available to keep the Vault warm.';
+    missionBadge = 'OPTIONAL PATROL';
+  } else if (missionState === 'rested') {
+    guardianDescription = `All guardians rested. Next check ${nextDueLabel}.`;
+    missionBadge = 'ALL RESTED';
+  } else if (missionState === 'locked') {
+    // Defensive: 'locked' means allWordsMega is false, so PostMegaSetupContent
+    // should not be rendered. If a caller hits this branch anyway, render a
+    // sensible fallback rather than crashing.
+    guardianDescription = 'Guardian Mission unlocks once every core word is secure.';
+    missionBadge = 'LOCKED';
+  } else if (guardianActive) {
+    // Pre-U1 fallback: compose copy from the legacy counts.
+    guardianDescription = wobblingCount > 0
       ? `${dueCount} word${dueCount === 1 ? '' : 's'} need a check today — ${wobblingCount} wobbling.`
-      : `${dueCount} word${dueCount === 1 ? '' : 's'} ready for their Guardian check.`
-    : 'All guardians rested — return tomorrow to patrol the Vault again.';
-  const missionBadge = guardianActive ? 'ACTIVE DUTY' : 'ALL RESTED';
+      : `${dueCount} word${dueCount === 1 ? '' : 's'} ready for their Guardian check.`;
+    missionBadge = 'ACTIVE DUTY';
+  } else {
+    // Pre-U1 fallback: no due, legacy rested copy.
+    guardianDescription = 'All guardians rested — return tomorrow to patrol the Vault again.';
+    missionBadge = 'ALL RESTED';
+  }
+
   const beginDisabled = startDisabled || runtimeReadOnly || !guardianActive;
   const beginText = pendingCommand === 'start-session'
     ? 'Starting...'
@@ -527,7 +599,11 @@ function PostMegaSetupContent({
         words you already own. Smart Review, Trouble Drill, and the SATs Test have done their work.
       </p>
       <GraduationStatRibbon postMastery={postMastery} secureCount={secureCount} />
-      <div className="mode-row mode-row-post-mega" data-variant={guardianActive ? 'active' : 'rested'}>
+      <div
+        className="mode-row mode-row-post-mega"
+        data-variant={guardianActive ? 'active' : 'rested'}
+        data-mission-state={missionState || undefined}
+      >
         <PostMegaModeCard
           mode={guardianCard}
           variant={guardianActive ? 'active' : 'rested'}

--- a/src/subjects/spelling/components/spelling-view-model.js
+++ b/src/subjects/spelling/components/spelling-view-model.js
@@ -2,7 +2,7 @@ import { monsterSummaryFromSpellingAnalytics } from '../../../platform/game/mons
 import { resolveMonsterVisual } from '../../../platform/game/monster-visual-config.js';
 import { monsterVisualFrameStyle } from '../../../platform/game/monster-visual-style.js';
 import { formatElapsedMinutes } from '../../../platform/core/utils.js';
-import { isGuardianEligibleSlug } from '../service-contract.js';
+import { createLockedPostMasteryState, isGuardianEligibleSlug } from '../service-contract.js';
 
 export const SPELLING_ACCENT = '#3E6FA8';
 export const DAY_MS = 24 * 60 * 60 * 1000;
@@ -914,15 +914,16 @@ export function buildSpellingContext({ appState, service, repositories, subject 
   // does not consult these, so we skip the storage read there to keep the
   // session hot-path cheap.
   const postMasteryPhases = new Set(['dashboard', 'summary', 'word-bank']);
+  // When the session-phase shortcut skips the service read, we still
+  // hand the dashboard a structurally complete snapshot so every field the
+  // PostMegaSetupContent (or later Guardian summary) reads is defined.
+  // Uses the same factory as `client-read-models.js` so the three
+  // historical fallback shapes stay in sync.
   const postMastery = postMasteryPhases.has(ui.phase) && typeof service.getPostMasteryState === 'function'
     ? service.getPostMasteryState(learner.id)
     : {
-        allWordsMega: false,
-        guardianDueCount: 0,
-        wobblingCount: 0,
-        nextGuardianDueDay: null,
+        ...createLockedPostMasteryState(),
         todayDay: Math.floor(Date.now() / DAY_MS),
-        guardianMap: {},
       };
   return {
     learner,

--- a/src/subjects/spelling/module.js
+++ b/src/subjects/spelling/module.js
@@ -218,6 +218,7 @@ export const spellingModule = {
       // Review round. `service.getPostMasteryState` is defined on the canonical
       // spelling service; the client-read-model facade returns a conservative
       // `allWordsMega: false` shape so the gate fails safe under remote-sync.
+      // TODO(U10/future): consider migrating Alt+4 gate to postMastery.guardianMissionAvailable — plan R1 kept the guardianDueCount fallback intentionally
       if (mode === 'guardian') {
         const postMastery = typeof service.getPostMasteryState === 'function'
           ? service.getPostMasteryState(learnerId)

--- a/src/subjects/spelling/read-model.js
+++ b/src/subjects/spelling/read-model.js
@@ -1,12 +1,12 @@
 import { WORD_BY_SLUG as DEFAULT_WORD_BY_SLUG } from './data/word-data.js';
 import {
   GUARDIAN_SECURE_STAGE,
-  isGuardianEligibleSlug,
   normaliseGuardianMap,
   normaliseYearFilter,
 } from './service-contract.js';
 import {
   computeGuardianMissionState,
+  deriveGuardianAggregates,
   selectGuardianWords,
 } from '../../../shared/spelling/service.js';
 import { normaliseBufferedGeminiVoice, normaliseTtsProvider } from './tts-providers.js';
@@ -163,47 +163,28 @@ export function getSpellingPostMasteryState({
   // (wobbling-due vs non-wobbling-due) and collect the eligible-entries list
   // so the dashboard state machine (`computeGuardianMissionState`) can branch
   // copy without re-scanning the map.
-  const guardianEntries = Object.entries(guardianMap);
-  const eligibleGuardianEntries = [];
-  let guardianDueCount = 0;
-  let wobblingDueCount = 0;
-  let nonWobblingDueCount = 0;
-  let wobblingCount = 0;
-  let nextGuardianDueDay = null;
-  for (const [slug, record] of guardianEntries) {
-    if (!record) continue;
-    if (!isGuardianEligibleSlug(slug, progressMap, runtime.bySlug)) continue;
-    eligibleGuardianEntries.push({
-      slug,
-      wobbling: record.wobbling === true,
-      nextDueDay: record.nextDueDay,
-    });
-    const isDueToday = record.nextDueDay <= currentDay;
-    if (isDueToday) {
-      guardianDueCount += 1;
-      if (record.wobbling === true) {
-        wobblingDueCount += 1;
-      } else {
-        nonWobblingDueCount += 1;
-      }
-    }
-    if (record.wobbling === true) wobblingCount += 1;
-    if (nextGuardianDueDay === null || record.nextDueDay < nextGuardianDueDay) {
-      nextGuardianDueDay = record.nextDueDay;
-    }
-  }
-
-  // U1: count core-pool Mega slugs that have no guardian record yet. These
-  // drive the 'first-patrol' state and feed `guardianAvailableCount` which
-  // the stat ribbon surfaces as "N patrol words available".
-  let unguardedMegaCount = 0;
-  for (const [slug, entry] of Object.entries(progressMap)) {
-    if (!isGuardianEligibleSlug(slug, progressMap, runtime.bySlug)) continue;
-    if (Object.prototype.hasOwnProperty.call(guardianMap, slug)) continue;
-    unguardedMegaCount += 1;
-    // Keep the void reference so the linter does not complain about `entry`.
-    void entry;
-  }
+  //
+  // The derivation lives in `shared/spelling/service.js::deriveGuardianAggregates`
+  // so the service-layer `getPostMasteryState` and this read-model consume
+  // exactly the same walk — any future refinement (e.g. a richer orphan
+  // predicate) lands in one place. The invariant
+  // `wobblingDueCount + nonWobblingDueCount === guardianDueCount` is
+  // guaranteed by that helper; tests in spelling-guardian.test.js pin it.
+  const aggregates = deriveGuardianAggregates({
+    guardianMap,
+    progressMap,
+    wordBySlug: runtime.bySlug,
+    todayDay: currentDay,
+  });
+  const {
+    eligibleGuardianEntries,
+    guardianDueCount,
+    wobblingDueCount,
+    nonWobblingDueCount,
+    wobblingCount,
+    nextGuardianDueDay,
+    unguardedMegaCount,
+  } = aggregates;
 
   const guardianAvailableCount = unguardedMegaCount + eligibleGuardianEntries.length;
   const guardianMissionState = computeGuardianMissionState({

--- a/src/subjects/spelling/read-model.js
+++ b/src/subjects/spelling/read-model.js
@@ -5,7 +5,10 @@ import {
   normaliseGuardianMap,
   normaliseYearFilter,
 } from './service-contract.js';
-import { selectGuardianWords } from '../../../shared/spelling/service.js';
+import {
+  computeGuardianMissionState,
+  selectGuardianWords,
+} from '../../../shared/spelling/service.js';
 import { normaliseBufferedGeminiVoice, normaliseTtsProvider } from './tts-providers.js';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -155,19 +158,62 @@ export function getSpellingPostMasteryState({
   // the counts or the earliest-due calculation. Persisted orphan records are
   // preserved in `data.guardian`; they simply stay out of the numbers until
   // the content bundle re-publishes their slug at core-pool + stage >= Mega.
+  //
+  // U1: alongside the legacy aggregate counts we derive decomposed counts
+  // (wobbling-due vs non-wobbling-due) and collect the eligible-entries list
+  // so the dashboard state machine (`computeGuardianMissionState`) can branch
+  // copy without re-scanning the map.
   const guardianEntries = Object.entries(guardianMap);
+  const eligibleGuardianEntries = [];
   let guardianDueCount = 0;
+  let wobblingDueCount = 0;
+  let nonWobblingDueCount = 0;
   let wobblingCount = 0;
   let nextGuardianDueDay = null;
   for (const [slug, record] of guardianEntries) {
     if (!record) continue;
     if (!isGuardianEligibleSlug(slug, progressMap, runtime.bySlug)) continue;
-    if (record.nextDueDay <= currentDay) guardianDueCount += 1;
+    eligibleGuardianEntries.push({
+      slug,
+      wobbling: record.wobbling === true,
+      nextDueDay: record.nextDueDay,
+    });
+    const isDueToday = record.nextDueDay <= currentDay;
+    if (isDueToday) {
+      guardianDueCount += 1;
+      if (record.wobbling === true) {
+        wobblingDueCount += 1;
+      } else {
+        nonWobblingDueCount += 1;
+      }
+    }
     if (record.wobbling === true) wobblingCount += 1;
     if (nextGuardianDueDay === null || record.nextDueDay < nextGuardianDueDay) {
       nextGuardianDueDay = record.nextDueDay;
     }
   }
+
+  // U1: count core-pool Mega slugs that have no guardian record yet. These
+  // drive the 'first-patrol' state and feed `guardianAvailableCount` which
+  // the stat ribbon surfaces as "N patrol words available".
+  let unguardedMegaCount = 0;
+  for (const [slug, entry] of Object.entries(progressMap)) {
+    if (!isGuardianEligibleSlug(slug, progressMap, runtime.bySlug)) continue;
+    if (Object.prototype.hasOwnProperty.call(guardianMap, slug)) continue;
+    unguardedMegaCount += 1;
+    // Keep the void reference so the linter does not complain about `entry`.
+    void entry;
+  }
+
+  const guardianAvailableCount = unguardedMegaCount + eligibleGuardianEntries.length;
+  const guardianMissionState = computeGuardianMissionState({
+    allWordsMega,
+    eligibleGuardianEntries,
+    unguardedMegaCount,
+    todayDay: currentDay,
+    policy: { allowOptionalPatrol: true },
+  });
+  const guardianMissionAvailable = guardianMissionState !== 'locked' && guardianMissionState !== 'rested';
 
   // Recommended words — a deterministic preview for UI consumers. We only
   // produce this when the learner has actually graduated; otherwise the
@@ -190,6 +236,12 @@ export function getSpellingPostMasteryState({
     allWordsMega,
     guardianDueCount,
     wobblingCount,
+    wobblingDueCount,
+    nonWobblingDueCount,
+    unguardedMegaCount,
+    guardianAvailableCount,
+    guardianMissionState,
+    guardianMissionAvailable,
     recommendedWords,
     nextGuardianDueDay,
   };

--- a/src/subjects/spelling/service-contract.js
+++ b/src/subjects/spelling/service-contract.js
@@ -11,21 +11,68 @@ export const GUARDIAN_DEFAULT_ROUND_LENGTH = 8;
 
 /**
  * Canonical set of dashboard/selector-facing Guardian mission states. Order
- * matches the state-machine priority: 'locked' (not post-Mega) takes
- * precedence over 'first-patrol' which takes precedence over 'wobbling' etc.
+ * matches the state-machine priority as enforced in `computeGuardianMissionState`:
+ * 'locked' (not post-Mega) > 'first-patrol' (fresh graduate, empty map) >
+ * 'wobbling' (urgent recovery dominates due) > 'due' (normal daily patrol) >
+ * 'optional-patrol' (nothing due but a round can be produced) > 'rested'
+ * (terminal — Begin disabled).
+ *
  * The 'rested' terminal state disables the Begin button; every other state
  * opens it. Consumers should derive the `guardianMissionAvailable` boolean
  * from this set via `!== 'locked' && !== 'rested'` rather than re-enumerating
  * enabled states.
+ *
+ * `computeGuardianMissionState` uses this frozen list at runtime as a
+ * sanity check: the returned state must be a member of this set, otherwise
+ * a typo in the state-machine implementation is caught immediately rather
+ * than leaking an unknown label into UI copy.
  */
 export const GUARDIAN_MISSION_STATES = Object.freeze([
   'locked',
   'first-patrol',
-  'due',
   'wobbling',
+  'due',
   'optional-patrol',
   'rested',
 ]);
+/**
+ * Single-source factory for the "locked" post-mastery snapshot. Three fallbacks
+ * used to be duplicated in-line:
+ *   1. `client-read-models.js::getPostMasteryState` (remote-sync stub before
+ *      the first command round-trip hydrates `subjectUi.spelling.postMastery`).
+ *   2. `spelling-view-model.js::buildSpellingViewModel` (session-phase shortcut
+ *      when `getPostMasteryState` is not worth calling).
+ *   3. `computeGuardianMissionState(...) === 'locked'` (the state-machine
+ *      return value).
+ *
+ * Any future field we add to the post-mastery shape must be defaulted in one
+ * place, or the remote-sync dashboard risks reading `undefined` for a
+ * gating scalar. Callers that want to override a field (e.g. populate
+ * `todayDay` from the live clock) can spread the factory output:
+ *
+ *   { ...createLockedPostMasteryState(), todayDay: currentDay }
+ *
+ * The factory returns a fresh object every call so callers can mutate the
+ * result without aliasing hazards.
+ */
+export function createLockedPostMasteryState() {
+  return {
+    allWordsMega: false,
+    guardianDueCount: 0,
+    wobblingCount: 0,
+    wobblingDueCount: 0,
+    nonWobblingDueCount: 0,
+    unguardedMegaCount: 0,
+    guardianAvailableCount: 0,
+    guardianMissionState: 'locked',
+    guardianMissionAvailable: false,
+    nextGuardianDueDay: null,
+    todayDay: 0,
+    guardianMap: {},
+    recommendedWords: [],
+  };
+}
+
 // Canonical secure-stage threshold shared by the service layer, the
 // post-mastery read-model, and the Word Bank view-model. Prior to U2 this
 // constant was duplicated as `GUARDIAN_SECURE_STAGE` in shared/spelling/service.js

--- a/src/subjects/spelling/service-contract.js
+++ b/src/subjects/spelling/service-contract.js
@@ -8,6 +8,24 @@ export const GUARDIAN_MAX_REVIEW_LEVEL = GUARDIAN_INTERVALS.length - 1;
 export const GUARDIAN_MIN_ROUND_LENGTH = 5;
 export const GUARDIAN_MAX_ROUND_LENGTH = 8;
 export const GUARDIAN_DEFAULT_ROUND_LENGTH = 8;
+
+/**
+ * Canonical set of dashboard/selector-facing Guardian mission states. Order
+ * matches the state-machine priority: 'locked' (not post-Mega) takes
+ * precedence over 'first-patrol' which takes precedence over 'wobbling' etc.
+ * The 'rested' terminal state disables the Begin button; every other state
+ * opens it. Consumers should derive the `guardianMissionAvailable` boolean
+ * from this set via `!== 'locked' && !== 'rested'` rather than re-enumerating
+ * enabled states.
+ */
+export const GUARDIAN_MISSION_STATES = Object.freeze([
+  'locked',
+  'first-patrol',
+  'due',
+  'wobbling',
+  'optional-patrol',
+  'rested',
+]);
 // Canonical secure-stage threshold shared by the service layer, the
 // post-mastery read-model, and the Word Bank view-model. Prior to U2 this
 // constant was duplicated as `GUARDIAN_SECURE_STAGE` in shared/spelling/service.js

--- a/tests/react-spelling-surface.test.js
+++ b/tests/react-spelling-surface.test.js
@@ -62,6 +62,69 @@ test('client spelling read model preserves word-family variant preference', () =
   assert.equal(service.getPrefs('learner-a').extraWordFamilies, true);
 });
 
+// ----- U1: remote-sync fallback getPostMasteryState stub ---------------------
+// The Setup scene reads `postMastery` via the runtime service. Under
+// remote-sync runtime, the client shell does not have direct access to the
+// learner's guardian map, so `createSpellingReadModelService#getPostMasteryState`
+// returns a defensive stub until the first command response carries the
+// real state. U1 adds new dashboard-gating scalars; the stub must expose
+// them with safe defaults (locked state, begin disabled) so the remote-sync
+// dashboard does not render with `undefined` gating scalars.
+
+test('U1 client-read-models stub: getPostMasteryState returns locked defaults for all U1 fields', () => {
+  const service = createSpellingReadModelService({
+    getState: () => ({}),
+  });
+  const snapshot = service.getPostMasteryState('learner-a');
+  assert.equal(snapshot.allWordsMega, false);
+  assert.equal(snapshot.guardianDueCount, 0);
+  assert.equal(snapshot.wobblingCount, 0);
+  assert.equal(snapshot.nextGuardianDueDay, null);
+  // U1 additions — critical: without these, the remote-sync dashboard
+  // would read `undefined` for the Begin gate and stay permanently disabled.
+  assert.equal(snapshot.guardianMissionState, 'locked');
+  assert.equal(snapshot.guardianMissionAvailable, false);
+  assert.equal(snapshot.unguardedMegaCount, 0);
+  assert.equal(snapshot.guardianAvailableCount, 0);
+  assert.equal(snapshot.wobblingDueCount, 0);
+  assert.equal(snapshot.nonWobblingDueCount, 0);
+});
+
+test('U1 client-read-models stub: cached postMastery from app state wins over defaults', () => {
+  const cached = {
+    allWordsMega: true,
+    guardianDueCount: 2,
+    wobblingCount: 1,
+    nextGuardianDueDay: 12345,
+    todayDay: 18000,
+    guardianMap: {},
+    guardianMissionState: 'wobbling',
+    guardianMissionAvailable: true,
+    unguardedMegaCount: 0,
+    guardianAvailableCount: 2,
+    wobblingDueCount: 1,
+    nonWobblingDueCount: 1,
+  };
+  const service = createSpellingReadModelService({
+    getState: () => ({
+      subjectUi: {
+        spelling: {
+          subjectId: 'spelling',
+          learnerId: 'learner-a',
+          version: 2,
+          phase: 'dashboard',
+          postMastery: cached,
+        },
+      },
+    }),
+  });
+  const snapshot = service.getPostMasteryState('learner-a');
+  assert.equal(snapshot.guardianMissionState, 'wobbling');
+  assert.equal(snapshot.guardianMissionAvailable, true);
+  assert.equal(snapshot.wobblingDueCount, 1);
+  assert.equal(snapshot.nonWobblingDueCount, 1);
+});
+
 test('React spelling session scene preserves input, replay, and submit affordances', async () => {
   const html = await renderSpellingSurfaceFixture({ phase: 'session' });
 
@@ -144,10 +207,12 @@ test('React spelling setup scene renders the post-Mega dashboard with Guardian M
   assert.doesNotMatch(html, /Choose today/);
 });
 
-test('React spelling setup scene shows "All guardians rested" copy when allWordsMega && guardianDueCount === 0', async () => {
-  // Seed guardians but schedule them all for the future so nothing is due
-  // today. The Begin button should be inert and the card should read as a
-  // quiet signal rather than a greyed-out state.
+test('U1: React setup scene shows optional-patrol copy when post-Mega but no word is due today', async () => {
+  // Fresh post-Mega learner with one existing guardian record scheduled for
+  // the future, and (by seeding) 212 other core Mega words not yet in the
+  // guardian map. Per the U1 state machine: zero due + top-up available →
+  // 'optional-patrol'. The dashboard advertises an optional patrol rather
+  // than a flat "All rested" because a round CAN still be produced.
   const today = Math.floor(Date.now() / (24 * 60 * 60 * 1000));
   const html = await renderSpellingSurfaceFixture({
     phase: 'setup',
@@ -168,13 +233,15 @@ test('React spelling setup scene shows "All guardians rested" copy when allWords
 
   assert.match(html, /Graduated · Spelling Guardian/);
   assert.match(html, /Guardian Mission/);
-  assert.match(html, /All guardians rested/);
-  assert.match(html, /ALL RESTED/);
-  // The primary begin CTA must be disabled so clicking it does nothing.
-  assert.match(html, /<button[^>]*data-action="spelling-shortcut-start"[^>]*data-mode="guardian"[^>]*disabled=""/);
-  // The rested-state "Rested" chip appears on the Guardian card frame itself.
-  assert.match(html, /mode-card-post-status/);
-  assert.match(html, /Rested/);
+  // U1 state machine wins: the dashboard advertises an optional patrol
+  // because the selector can top up from non-due + unguarded Mega slugs.
+  assert.match(html, /No urgent duties\. Optional patrol available/);
+  assert.match(html, /OPTIONAL PATROL/);
+  assert.match(html, /data-mission-state="optional-patrol"/);
+  // The Begin CTA must be enabled in optional-patrol so the learner can
+  // choose to run a warm-up round.
+  assert.match(html, /<button[^>]*data-action="spelling-shortcut-start"[^>]*data-mode="guardian"[^>]*>Begin Guardian Mission/);
+  assert.doesNotMatch(html, /<button[^>]*data-action="spelling-shortcut-start"[^>]*data-mode="guardian"[^>]*disabled=""/);
 });
 
 // ----- U6: Summary + Word Bank Guardian surfaces -----------------------------

--- a/tests/react-spelling-surface.test.js
+++ b/tests/react-spelling-surface.test.js
@@ -244,6 +244,80 @@ test('U1: React setup scene shows optional-patrol copy when post-Mega but no wor
   assert.doesNotMatch(html, /<button[^>]*data-action="spelling-shortcut-start"[^>]*data-mode="guardian"[^>]*disabled=""/);
 });
 
+// ----- U1 review: remaining mission state renders (due, rested, locked) -------
+// Completion of the PostMegaSetupContent mission-state copy coverage. The
+// earlier tests pin first-patrol (via ACTIVE DUTY variant), wobbling (via
+// optional-patrol), and optional-patrol; these fill in the remaining three
+// so the ladder is fully defended by the React-render smoke.
+
+test('U1 review: React setup scene shows "due" copy + ACTIVE DUTY + enabled Begin when a non-wobbling word is due', async () => {
+  const today = Math.floor(Date.now() / (24 * 60 * 60 * 1000));
+  const html = await renderSpellingSurfaceFixture({
+    phase: 'setup',
+    postMega: {
+      guardian: {
+        possess: {
+          reviewLevel: 2,
+          lastReviewedDay: today - 3,
+          nextDueDay: today,
+          correctStreak: 2,
+          lapses: 0,
+          renewals: 0,
+          wobbling: false,
+        },
+      },
+    },
+  });
+  assert.match(html, /data-mission-state="due"/);
+  assert.match(html, /ACTIVE DUTY/);
+  // Copy for `due` state pulls the "N words ready for their Guardian check"
+  // line from PostMegaSetupContent.
+  assert.match(html, /ready for their Guardian check/);
+  // Begin is enabled.
+  assert.doesNotMatch(html, /<button[^>]*data-action="spelling-shortcut-start"[^>]*data-mode="guardian"[^>]*disabled=""/);
+});
+
+test('U1 review: React setup scene shows "wobbling" copy + URGENT + enabled Begin when a wobbling word is due', async () => {
+  const today = Math.floor(Date.now() / (24 * 60 * 60 * 1000));
+  const html = await renderSpellingSurfaceFixture({
+    phase: 'setup',
+    postMega: {
+      guardian: {
+        possess: {
+          reviewLevel: 0,
+          lastReviewedDay: today - 3,
+          nextDueDay: today - 1,
+          correctStreak: 0,
+          lapses: 1,
+          renewals: 0,
+          wobbling: true,
+        },
+      },
+    },
+  });
+  assert.match(html, /data-mission-state="wobbling"/);
+  assert.match(html, /URGENT/);
+  // The `wobbling` branch either mixes wobbling + non-wobbling copy or
+  // shows the single-wobbling line; either way "Guardian check today"
+  // anchors the PostMegaSetupContent output.
+  assert.match(html, /Guardian check today|urgent check/);
+  // Begin enabled.
+  assert.doesNotMatch(html, /<button[^>]*data-action="spelling-shortcut-start"[^>]*data-mode="guardian"[^>]*disabled=""/);
+});
+
+test('U1 review: React setup scene does NOT render PostMegaSetupContent when not graduated (locked → legacy dashboard)', async () => {
+  // `locked` means `allWordsMega` is false. SpellingSetupScene renders the
+  // legacy 3-mode dashboard instead of PostMegaSetupContent, and the mission
+  // copy / data-mission-state attribute must not leak in.
+  const html = await renderSpellingSurfaceFixture({ phase: 'setup' });
+  assert.doesNotMatch(html, /data-mission-state=/);
+  assert.doesNotMatch(html, /PostMegaSetupContent|The Word Vault is yours|Graduated · Spelling Guardian/);
+  // Legacy shell stays intact.
+  assert.match(html, /Smart Review/);
+  assert.match(html, /Trouble Drill/);
+  assert.match(html, /SATs Test/);
+});
+
 // ----- U6: Summary + Word Bank Guardian surfaces -----------------------------
 
 test('React spelling Word Bank renders the legacy 6-chip row identically when allWordsMega is false', async () => {

--- a/tests/spelling-guardian.test.js
+++ b/tests/spelling-guardian.test.js
@@ -24,11 +24,15 @@ import { normaliseServerSpellingData } from '../worker/src/subjects/spelling/eng
 import {
   advanceGuardianOnCorrect,
   advanceGuardianOnWrong,
+  computeGuardianMissionState,
   ensureGuardianRecord,
   isGuardianEligibleSlug,
   selectGuardianWords,
 } from '../shared/spelling/service.js';
-import { GUARDIAN_SECURE_STAGE } from '../src/subjects/spelling/service-contract.js';
+import {
+  GUARDIAN_MISSION_STATES,
+  GUARDIAN_SECURE_STAGE,
+} from '../src/subjects/spelling/service-contract.js';
 import { createSpellingService } from '../src/subjects/spelling/service.js';
 import { createSpellingPersistence } from '../src/subjects/spelling/repository.js';
 import { createLocalPlatformRepositories } from '../src/platform/core/repositories/index.js';
@@ -2981,4 +2985,377 @@ test('U2 read-model: legacy-demoted slug (stage < GUARDIAN_SECURE_STAGE) exclude
   const state = getSpellingPostMasteryState({ subjectStateRecord, runtimeSnapshot, now: U4_NOW_MS });
   assert.equal(state.guardianDueCount, 1, 'stage-3 record excluded; only w1 remains');
   assert.equal(state.wobblingCount, 0, 'stage-3 record excluded from wobbling count');
+});
+
+// ----- U1: computeGuardianMissionState truth table ---------------------------
+// `computeGuardianMissionState` is a pure helper the selector reuses. Tests
+// below hit every documented branch of the state machine (locked, first-patrol,
+// wobbling, due, optional-patrol, rested) under the canonical policy
+// `{ allowOptionalPatrol: true }`. Changing the branches without updating this
+// block is intended to fail loudly.
+
+test('U1: GUARDIAN_MISSION_STATES is the frozen canonical list', () => {
+  assert.equal(Object.isFrozen(GUARDIAN_MISSION_STATES), true);
+  assert.deepEqual(
+    [...GUARDIAN_MISSION_STATES],
+    ['locked', 'first-patrol', 'due', 'wobbling', 'optional-patrol', 'rested'],
+  );
+});
+
+test('U1 state machine: not post-Mega → locked', () => {
+  const state = computeGuardianMissionState({
+    allWordsMega: false,
+    eligibleGuardianEntries: [],
+    unguardedMegaCount: 0,
+    todayDay: TODAY,
+    policy: { allowOptionalPatrol: true },
+  });
+  assert.equal(state, 'locked');
+});
+
+test('U1 state machine: not post-Mega even when guardians look plausible → locked (aggregate gate wins)', () => {
+  const state = computeGuardianMissionState({
+    allWordsMega: false,
+    eligibleGuardianEntries: [
+      { slug: 'possess', wobbling: true, nextDueDay: TODAY - 1 },
+    ],
+    unguardedMegaCount: 5,
+    todayDay: TODAY,
+    policy: { allowOptionalPatrol: true },
+  });
+  assert.equal(state, 'locked');
+});
+
+test('U1 state machine: post-Mega + empty guardian map + unguarded Mega words → first-patrol', () => {
+  const state = computeGuardianMissionState({
+    allWordsMega: true,
+    eligibleGuardianEntries: [],
+    unguardedMegaCount: 8,
+    todayDay: TODAY,
+    policy: { allowOptionalPatrol: true },
+  });
+  assert.equal(state, 'first-patrol');
+});
+
+test('U1 state machine: first-patrol threshold is >= 1 unguarded, not the minimum round length', () => {
+  // Even a single unguarded Mega word counts as first-patrol; the selector
+  // falls back to top-up if the round would be short.
+  const state = computeGuardianMissionState({
+    allWordsMega: true,
+    eligibleGuardianEntries: [],
+    unguardedMegaCount: 1,
+    todayDay: TODAY,
+    policy: { allowOptionalPatrol: true },
+  });
+  assert.equal(state, 'first-patrol');
+});
+
+test('U1 state machine: exactly GUARDIAN_MIN_ROUND_LENGTH unguarded Mega + zero due → first-patrol', () => {
+  const state = computeGuardianMissionState({
+    allWordsMega: true,
+    eligibleGuardianEntries: [],
+    unguardedMegaCount: GUARDIAN_MIN_ROUND_LENGTH,
+    todayDay: TODAY,
+    policy: { allowOptionalPatrol: true },
+  });
+  assert.equal(state, 'first-patrol');
+});
+
+test('U1 state machine: any wobbling-due eligible entry → wobbling (dominates due/first-patrol)', () => {
+  const state = computeGuardianMissionState({
+    allWordsMega: true,
+    eligibleGuardianEntries: [
+      { slug: 'accommodate', wobbling: true, nextDueDay: TODAY - 1 },
+      { slug: 'believe', wobbling: false, nextDueDay: TODAY },
+    ],
+    unguardedMegaCount: 3,
+    todayDay: TODAY,
+    policy: { allowOptionalPatrol: true },
+  });
+  assert.equal(state, 'wobbling');
+});
+
+test('U1 state machine: wobbling not due yet does NOT trigger wobbling state', () => {
+  const state = computeGuardianMissionState({
+    allWordsMega: true,
+    eligibleGuardianEntries: [
+      { slug: 'accommodate', wobbling: true, nextDueDay: TODAY + 3 },
+      { slug: 'believe', wobbling: false, nextDueDay: TODAY },
+    ],
+    unguardedMegaCount: 0,
+    todayDay: TODAY,
+    policy: { allowOptionalPatrol: true },
+  });
+  // wobbling scheduled in future → the only due entry is `believe` (non-wobbling)
+  assert.equal(state, 'due');
+});
+
+test('U1 state machine: due entries with no wobbling → due', () => {
+  const state = computeGuardianMissionState({
+    allWordsMega: true,
+    eligibleGuardianEntries: [
+      { slug: 'believe', wobbling: false, nextDueDay: TODAY - 1 },
+      { slug: 'bicycle', wobbling: false, nextDueDay: TODAY },
+      { slug: 'breath', wobbling: false, nextDueDay: TODAY + 7 },
+    ],
+    unguardedMegaCount: 0,
+    todayDay: TODAY,
+    policy: { allowOptionalPatrol: true },
+  });
+  assert.equal(state, 'due');
+});
+
+test('U1 state machine: zero due but unguarded Mega available → optional-patrol (policy on)', () => {
+  const state = computeGuardianMissionState({
+    allWordsMega: true,
+    eligibleGuardianEntries: [
+      { slug: 'believe', wobbling: false, nextDueDay: TODAY + 14 },
+    ],
+    unguardedMegaCount: 3,
+    todayDay: TODAY,
+    policy: { allowOptionalPatrol: true },
+  });
+  assert.equal(state, 'optional-patrol');
+});
+
+test('U1 state machine: zero due, only non-due guardians → optional-patrol (top-up producible)', () => {
+  const state = computeGuardianMissionState({
+    allWordsMega: true,
+    eligibleGuardianEntries: [
+      { slug: 'believe', wobbling: false, nextDueDay: TODAY + 14 },
+      { slug: 'bicycle', wobbling: false, nextDueDay: TODAY + 30 },
+    ],
+    unguardedMegaCount: 0,
+    todayDay: TODAY,
+    policy: { allowOptionalPatrol: true },
+  });
+  assert.equal(state, 'optional-patrol');
+});
+
+test('U1 state machine: zero due + zero unguarded + zero guardians → rested', () => {
+  const state = computeGuardianMissionState({
+    allWordsMega: true,
+    eligibleGuardianEntries: [],
+    unguardedMegaCount: 0,
+    todayDay: TODAY,
+    policy: { allowOptionalPatrol: true },
+  });
+  assert.equal(state, 'rested');
+});
+
+test('U1 state machine: zero due, top-up available, but allowOptionalPatrol=false → rested', () => {
+  const state = computeGuardianMissionState({
+    allWordsMega: true,
+    eligibleGuardianEntries: [
+      { slug: 'believe', wobbling: false, nextDueDay: TODAY + 14 },
+    ],
+    unguardedMegaCount: 3,
+    todayDay: TODAY,
+    policy: { allowOptionalPatrol: false },
+  });
+  assert.equal(state, 'rested');
+});
+
+test('U1 state machine: defaults to allowOptionalPatrol=true when policy is absent', () => {
+  const state = computeGuardianMissionState({
+    allWordsMega: true,
+    eligibleGuardianEntries: [],
+    unguardedMegaCount: 3,
+    todayDay: TODAY,
+  });
+  assert.equal(state, 'first-patrol');
+});
+
+test('U1 state machine: wrong-typed inputs fall back to locked (defensive)', () => {
+  // Garbage shape should not throw; defensive read-time contract.
+  assert.equal(computeGuardianMissionState({}), 'locked');
+  assert.equal(computeGuardianMissionState(null), 'locked');
+  assert.equal(computeGuardianMissionState(undefined), 'locked');
+});
+
+// ----- U1: getSpellingPostMasteryState return shape ---------------------------
+
+test('U1 read-model: getSpellingPostMasteryState exposes U1 fields for fresh graduate (first-patrol)', () => {
+  const runtimeSnapshot = makeRuntimeSnapshot({ coreCount: 10 });
+  const subjectStateRecord = makeSubjectStateRecord({
+    progress: secureProgressEntries(runtimeSnapshot.coreWords),
+    guardian: {},
+  });
+  const state = getSpellingPostMasteryState({ subjectStateRecord, runtimeSnapshot, now: U4_NOW_MS });
+  assert.equal(state.allWordsMega, true);
+  assert.equal(state.guardianMissionState, 'first-patrol');
+  assert.equal(state.guardianMissionAvailable, true);
+  assert.equal(state.unguardedMegaCount, 10, 'all 10 core Mega slugs are unguarded');
+  assert.equal(state.guardianAvailableCount, 10);
+  assert.equal(state.wobblingDueCount, 0);
+  assert.equal(state.nonWobblingDueCount, 0);
+  assert.equal(state.guardianDueCount, 0);
+});
+
+test('U1 read-model: wobbling state with decomposed counts for 2 wobbling-due + 3 non-wobbling-due', () => {
+  const runtimeSnapshot = makeRuntimeSnapshot({ coreCount: 10 });
+  const [w0, w1, w2, w3, w4] = runtimeSnapshot.coreWords;
+  const subjectStateRecord = makeSubjectStateRecord({
+    progress: secureProgressEntries(runtimeSnapshot.coreWords),
+    guardian: {
+      [w0.slug]: { reviewLevel: 0, lastReviewedDay: TODAY - 3, nextDueDay: TODAY - 1, correctStreak: 0, lapses: 1, renewals: 0, wobbling: true },
+      [w1.slug]: { reviewLevel: 1, lastReviewedDay: TODAY - 2, nextDueDay: TODAY, correctStreak: 0, lapses: 1, renewals: 0, wobbling: true },
+      [w2.slug]: { reviewLevel: 2, lastReviewedDay: TODAY - 4, nextDueDay: TODAY - 1, correctStreak: 2, lapses: 0, renewals: 0, wobbling: false },
+      [w3.slug]: { reviewLevel: 1, lastReviewedDay: TODAY - 3, nextDueDay: TODAY, correctStreak: 1, lapses: 0, renewals: 0, wobbling: false },
+      [w4.slug]: { reviewLevel: 0, lastReviewedDay: TODAY - 1, nextDueDay: TODAY, correctStreak: 0, lapses: 0, renewals: 0, wobbling: false },
+    },
+  });
+  const state = getSpellingPostMasteryState({ subjectStateRecord, runtimeSnapshot, now: U4_NOW_MS });
+  assert.equal(state.guardianMissionState, 'wobbling');
+  assert.equal(state.guardianMissionAvailable, true);
+  assert.equal(state.wobblingDueCount, 2);
+  assert.equal(state.nonWobblingDueCount, 3);
+  assert.equal(state.guardianDueCount, 5);
+  assert.equal(state.unguardedMegaCount, 5, '5 core Mega slugs still unguarded');
+  assert.equal(state.guardianAvailableCount, 10);
+});
+
+test('U1 read-model: due state (no wobbling, any due)', () => {
+  const runtimeSnapshot = makeRuntimeSnapshot({ coreCount: 10 });
+  const [w0, w1] = runtimeSnapshot.coreWords;
+  const subjectStateRecord = makeSubjectStateRecord({
+    progress: secureProgressEntries(runtimeSnapshot.coreWords),
+    guardian: {
+      [w0.slug]: { reviewLevel: 2, lastReviewedDay: TODAY - 4, nextDueDay: TODAY - 1, correctStreak: 2, lapses: 0, renewals: 0, wobbling: false },
+      [w1.slug]: { reviewLevel: 1, lastReviewedDay: TODAY - 3, nextDueDay: TODAY, correctStreak: 1, lapses: 0, renewals: 0, wobbling: false },
+    },
+  });
+  const state = getSpellingPostMasteryState({ subjectStateRecord, runtimeSnapshot, now: U4_NOW_MS });
+  assert.equal(state.guardianMissionState, 'due');
+  assert.equal(state.guardianMissionAvailable, true);
+  assert.equal(state.wobblingDueCount, 0);
+  assert.equal(state.nonWobblingDueCount, 2);
+});
+
+test('U1 read-model: optional-patrol (0 due, 3 unguarded Mega)', () => {
+  const runtimeSnapshot = makeRuntimeSnapshot({ coreCount: 10 });
+  const [w0, w1] = runtimeSnapshot.coreWords;
+  const subjectStateRecord = makeSubjectStateRecord({
+    progress: secureProgressEntries(runtimeSnapshot.coreWords),
+    guardian: {
+      // Two guardians, both future-due so not counted as due today.
+      [w0.slug]: { reviewLevel: 3, lastReviewedDay: TODAY - 1, nextDueDay: TODAY + 30, correctStreak: 3, lapses: 0, renewals: 0, wobbling: false },
+      [w1.slug]: { reviewLevel: 2, lastReviewedDay: TODAY - 3, nextDueDay: TODAY + 14, correctStreak: 2, lapses: 0, renewals: 0, wobbling: false },
+    },
+  });
+  const state = getSpellingPostMasteryState({ subjectStateRecord, runtimeSnapshot, now: U4_NOW_MS });
+  assert.equal(state.guardianMissionState, 'optional-patrol');
+  assert.equal(state.guardianMissionAvailable, true);
+  assert.equal(state.guardianDueCount, 0);
+  assert.equal(state.unguardedMegaCount, 8, '10 secure - 2 guarded = 8 unguarded Mega');
+});
+
+test('U1 read-model: rested (0 due, 0 unguarded — all words in guardian map, all future)', () => {
+  // Only 2 core words; both are already in the guardian map with future due
+  // days. No unguarded Mega + no due Guardian = rested.
+  const runtimeSnapshot = makeRuntimeSnapshot({ coreCount: 2 });
+  const [w0, w1] = runtimeSnapshot.coreWords;
+  const subjectStateRecord = makeSubjectStateRecord({
+    progress: secureProgressEntries(runtimeSnapshot.coreWords),
+    guardian: {
+      [w0.slug]: { reviewLevel: 3, lastReviewedDay: TODAY - 1, nextDueDay: TODAY + 30, correctStreak: 3, lapses: 0, renewals: 0, wobbling: false },
+      [w1.slug]: { reviewLevel: 2, lastReviewedDay: TODAY - 3, nextDueDay: TODAY + 14, correctStreak: 2, lapses: 0, renewals: 0, wobbling: false },
+    },
+  });
+  const state = getSpellingPostMasteryState({ subjectStateRecord, runtimeSnapshot, now: U4_NOW_MS });
+  assert.equal(state.guardianMissionState, 'optional-patrol',
+    'top-up from non-due guardians still counts as optional patrol under default policy');
+  // Now promote to "everything guarded, nothing due, policy off" scenario only
+  // via the helper directly to get 'rested'.
+  const rested = computeGuardianMissionState({
+    allWordsMega: true,
+    eligibleGuardianEntries: [
+      { slug: w0.slug, wobbling: false, nextDueDay: TODAY + 30 },
+      { slug: w1.slug, wobbling: false, nextDueDay: TODAY + 14 },
+    ],
+    unguardedMegaCount: 0,
+    todayDay: TODAY,
+    policy: { allowOptionalPatrol: false },
+  });
+  assert.equal(rested, 'rested');
+});
+
+test('U1 read-model: all-rested scenario (no guardians, no unguarded) → rested + not available', () => {
+  const runtimeSnapshot = makeRuntimeSnapshot({ coreCount: 0 });
+  const subjectStateRecord = makeSubjectStateRecord({ progress: {}, guardian: {} });
+  const state = getSpellingPostMasteryState({ subjectStateRecord, runtimeSnapshot, now: U4_NOW_MS });
+  // No core words at all → allWordsMega = false → locked.
+  assert.equal(state.allWordsMega, false);
+  assert.equal(state.guardianMissionState, 'locked');
+  assert.equal(state.guardianMissionAvailable, false);
+});
+
+test('U1 read-model: locked state (not post-Mega) exposes U1 fields with safe defaults', () => {
+  const runtimeSnapshot = makeRuntimeSnapshot({ coreCount: 10 });
+  // Secure 5/10 → not post-Mega.
+  const subjectStateRecord = makeSubjectStateRecord({
+    progress: secureProgressEntries(runtimeSnapshot.coreWords.slice(0, 5)),
+  });
+  const state = getSpellingPostMasteryState({ subjectStateRecord, runtimeSnapshot, now: U4_NOW_MS });
+  assert.equal(state.allWordsMega, false);
+  assert.equal(state.guardianMissionState, 'locked');
+  assert.equal(state.guardianMissionAvailable, false);
+  assert.equal(state.unguardedMegaCount, 5, 'unguardedMegaCount reports raw Mega-but-unguarded count regardless of state');
+  assert.equal(state.guardianAvailableCount, 5);
+  assert.equal(state.wobblingDueCount, 0);
+  assert.equal(state.nonWobblingDueCount, 0);
+});
+
+test('U1 read-model: content rollback (168/170 → stage=3 on 2 words) flips allWordsMega=false → locked', () => {
+  const runtimeSnapshot = makeRuntimeSnapshot({ coreCount: 170 });
+  const progress = secureProgressEntries(runtimeSnapshot.coreWords);
+  // Pretend content rollback — 2 words dropped to stage 3.
+  progress[runtimeSnapshot.coreWords[0].slug] = { ...progress[runtimeSnapshot.coreWords[0].slug], stage: 3 };
+  progress[runtimeSnapshot.coreWords[1].slug] = { ...progress[runtimeSnapshot.coreWords[1].slug], stage: 3 };
+  const subjectStateRecord = makeSubjectStateRecord({ progress });
+  const state = getSpellingPostMasteryState({ subjectStateRecord, runtimeSnapshot, now: U4_NOW_MS });
+  assert.equal(state.allWordsMega, false);
+  assert.equal(state.guardianMissionState, 'locked');
+  assert.equal(state.guardianMissionAvailable, false);
+});
+
+test('U1 read-model: orphan guardian entry does not inflate decomposed counts', () => {
+  // The orphan ghostword is present only in the guardian map (content
+  // hot-swap removed the slug from runtime + progress). A real rollback
+  // scenario: storage keeps the guardian record but progress no longer lists
+  // the slug. The learner remains post-Mega because `publishedCoreCount`
+  // matches `secureCoreCount` across the 10 core words.
+  const runtimeSnapshot = makeRuntimeSnapshot({ coreCount: 10 });
+  const [w0] = runtimeSnapshot.coreWords;
+  const subjectStateRecord = makeSubjectStateRecord({
+    progress: secureProgressEntries(runtimeSnapshot.coreWords),
+    guardian: {
+      [w0.slug]: { reviewLevel: 0, lastReviewedDay: TODAY - 3, nextDueDay: TODAY - 1, correctStreak: 0, lapses: 1, renewals: 0, wobbling: true },
+      // Orphan wobbling-due must not feed wobblingDueCount.
+      ghostword: { reviewLevel: 0, lastReviewedDay: TODAY - 3, nextDueDay: TODAY - 1, correctStreak: 0, lapses: 2, renewals: 0, wobbling: true },
+    },
+  });
+  const state = getSpellingPostMasteryState({ subjectStateRecord, runtimeSnapshot, now: U4_NOW_MS });
+  assert.equal(state.allWordsMega, true, 'learner still counts as post-Mega on the 10 core slugs');
+  assert.equal(state.wobblingDueCount, 1, 'orphan skipped from wobbling-due count');
+  assert.equal(state.nonWobblingDueCount, 0);
+  assert.equal(state.guardianMissionState, 'wobbling');
+});
+
+test('U1 read-model integration: postMastery field on buildSpellingLearnerReadModel mirrors selector state', () => {
+  const runtimeSnapshot = makeRuntimeSnapshot({ coreCount: 10 });
+  const [w0] = runtimeSnapshot.coreWords;
+  const subjectStateRecord = makeSubjectStateRecord({
+    progress: secureProgressEntries(runtimeSnapshot.coreWords),
+    guardian: {
+      [w0.slug]: { reviewLevel: 0, lastReviewedDay: TODAY - 3, nextDueDay: TODAY - 1, correctStreak: 0, lapses: 1, renewals: 0, wobbling: true },
+    },
+  });
+  const output = buildSpellingLearnerReadModel({ subjectStateRecord, runtimeSnapshot, now: U4_NOW_MS });
+  assert.equal(output.postMastery.guardianMissionState, 'wobbling');
+  assert.equal(output.postMastery.guardianMissionAvailable, true);
+  assert.equal(output.postMastery.wobblingDueCount, 1);
+  assert.equal(output.postMastery.nonWobblingDueCount, 0);
+  assert.equal(output.postMastery.unguardedMegaCount, 9);
+  assert.equal(output.postMastery.guardianAvailableCount, 10);
 });

--- a/tests/spelling-guardian.test.js
+++ b/tests/spelling-guardian.test.js
@@ -25,6 +25,7 @@ import {
   advanceGuardianOnCorrect,
   advanceGuardianOnWrong,
   computeGuardianMissionState,
+  deriveGuardianAggregates,
   ensureGuardianRecord,
   isGuardianEligibleSlug,
   selectGuardianWords,
@@ -32,6 +33,7 @@ import {
 import {
   GUARDIAN_MISSION_STATES,
   GUARDIAN_SECURE_STAGE,
+  createLockedPostMasteryState,
 } from '../src/subjects/spelling/service-contract.js';
 import { createSpellingService } from '../src/subjects/spelling/service.js';
 import { createSpellingPersistence } from '../src/subjects/spelling/repository.js';
@@ -2996,9 +2998,11 @@ test('U2 read-model: legacy-demoted slug (stage < GUARDIAN_SECURE_STAGE) exclude
 
 test('U1: GUARDIAN_MISSION_STATES is the frozen canonical list', () => {
   assert.equal(Object.isFrozen(GUARDIAN_MISSION_STATES), true);
+  // Order now reflects the real state-machine priority:
+  // locked > first-patrol > wobbling > due > optional-patrol > rested.
   assert.deepEqual(
     [...GUARDIAN_MISSION_STATES],
-    ['locked', 'first-patrol', 'due', 'wobbling', 'optional-patrol', 'rested'],
+    ['locked', 'first-patrol', 'wobbling', 'due', 'optional-patrol', 'rested'],
   );
 });
 
@@ -3037,13 +3041,40 @@ test('U1 state machine: post-Mega + empty guardian map + unguarded Mega words �
   assert.equal(state, 'first-patrol');
 });
 
-test('U1 state machine: first-patrol threshold is >= 1 unguarded, not the minimum round length', () => {
-  // Even a single unguarded Mega word counts as first-patrol; the selector
-  // falls back to top-up if the round would be short.
+test('U1 state machine: first-patrol requires combined pool >= GUARDIAN_MIN_ROUND_LENGTH', () => {
+  // Short-round invariant (sev 60): if the combined pool of unguarded Mega
+  // words + existing guardian entries cannot fill a minimum-length round,
+  // the dashboard must not offer 'first-patrol' — the learner would tap
+  // Begin and receive a 1-4 word Guardian. Collapse to 'rested' instead.
   const state = computeGuardianMissionState({
     allWordsMega: true,
     eligibleGuardianEntries: [],
     unguardedMegaCount: 1,
+    todayDay: TODAY,
+    policy: { allowOptionalPatrol: true },
+  });
+  assert.equal(state, 'rested');
+});
+
+test('U1 state machine: first-patrol with unguarded just below MIN_ROUND_LENGTH → rested', () => {
+  // Exactly 4 unguarded Mega + zero guardian entries → 4 < MIN (5) → rested.
+  const state = computeGuardianMissionState({
+    allWordsMega: true,
+    eligibleGuardianEntries: [],
+    unguardedMegaCount: GUARDIAN_MIN_ROUND_LENGTH - 1,
+    todayDay: TODAY,
+    policy: { allowOptionalPatrol: true },
+  });
+  assert.equal(state, 'rested');
+});
+
+test('U1 state machine: first-patrol with unguardedMegaCount >= MIN_ROUND_LENGTH → first-patrol', () => {
+  // Clean first-patrol scenario: 5 unguarded Mega + zero guardian entries →
+  // 5 >= MIN (5) → first-patrol as documented.
+  const state = computeGuardianMissionState({
+    allWordsMega: true,
+    eligibleGuardianEntries: [],
+    unguardedMegaCount: GUARDIAN_MIN_ROUND_LENGTH,
     todayDay: TODAY,
     policy: { allowOptionalPatrol: true },
   });
@@ -3106,24 +3137,47 @@ test('U1 state machine: due entries with no wobbling → due', () => {
 });
 
 test('U1 state machine: zero due but unguarded Mega available → optional-patrol (policy on)', () => {
+  // 1 entry + 4 unguarded = 5, which meets GUARDIAN_MIN_ROUND_LENGTH → optional-patrol.
   const state = computeGuardianMissionState({
     allWordsMega: true,
     eligibleGuardianEntries: [
       { slug: 'believe', wobbling: false, nextDueDay: TODAY + 14 },
     ],
-    unguardedMegaCount: 3,
+    unguardedMegaCount: 4,
     todayDay: TODAY,
     policy: { allowOptionalPatrol: true },
   });
   assert.equal(state, 'optional-patrol');
 });
 
-test('U1 state machine: zero due, only non-due guardians → optional-patrol (top-up producible)', () => {
+test('U1 state machine: optional-patrol requires combined pool >= MIN_ROUND_LENGTH (sev 60)', () => {
+  // 3 non-due entries only → combined pool = 3, below MIN (5) → rested.
+  // If the dashboard offered optional-patrol here the learner would tap
+  // Begin and receive a 3-word round.
   const state = computeGuardianMissionState({
     allWordsMega: true,
     eligibleGuardianEntries: [
       { slug: 'believe', wobbling: false, nextDueDay: TODAY + 14 },
       { slug: 'bicycle', wobbling: false, nextDueDay: TODAY + 30 },
+      { slug: 'breath', wobbling: false, nextDueDay: TODAY + 45 },
+    ],
+    unguardedMegaCount: 0,
+    todayDay: TODAY,
+    policy: { allowOptionalPatrol: true },
+  });
+  assert.equal(state, 'rested');
+});
+
+test('U1 state machine: zero due, only non-due guardians but pool >= MIN → optional-patrol (top-up producible)', () => {
+  // 5 non-due entries → combined pool = 5 meets MIN → optional-patrol.
+  const state = computeGuardianMissionState({
+    allWordsMega: true,
+    eligibleGuardianEntries: [
+      { slug: 'believe', wobbling: false, nextDueDay: TODAY + 14 },
+      { slug: 'bicycle', wobbling: false, nextDueDay: TODAY + 30 },
+      { slug: 'breath', wobbling: false, nextDueDay: TODAY + 45 },
+      { slug: 'business', wobbling: false, nextDueDay: TODAY + 50 },
+      { slug: 'calendar', wobbling: false, nextDueDay: TODAY + 60 },
     ],
     unguardedMegaCount: 0,
     todayDay: TODAY,
@@ -3144,12 +3198,14 @@ test('U1 state machine: zero due + zero unguarded + zero guardians → rested', 
 });
 
 test('U1 state machine: zero due, top-up available, but allowOptionalPatrol=false → rested', () => {
+  // Pool of 1 entry + 5 unguarded = 6 (>= MIN), but policy.allowOptionalPatrol
+  // is false so the optional path collapses to 'rested'.
   const state = computeGuardianMissionState({
     allWordsMega: true,
     eligibleGuardianEntries: [
       { slug: 'believe', wobbling: false, nextDueDay: TODAY + 14 },
     ],
-    unguardedMegaCount: 3,
+    unguardedMegaCount: 5,
     todayDay: TODAY,
     policy: { allowOptionalPatrol: false },
   });
@@ -3157,10 +3213,11 @@ test('U1 state machine: zero due, top-up available, but allowOptionalPatrol=fals
 });
 
 test('U1 state machine: defaults to allowOptionalPatrol=true when policy is absent', () => {
+  // Combined pool = 5 (meets MIN) → first-patrol (empty entries + unguarded).
   const state = computeGuardianMissionState({
     allWordsMega: true,
     eligibleGuardianEntries: [],
-    unguardedMegaCount: 3,
+    unguardedMegaCount: GUARDIAN_MIN_ROUND_LENGTH,
     todayDay: TODAY,
   });
   assert.equal(state, 'first-patrol');
@@ -3250,9 +3307,11 @@ test('U1 read-model: optional-patrol (0 due, 3 unguarded Mega)', () => {
   assert.equal(state.unguardedMegaCount, 8, '10 secure - 2 guarded = 8 unguarded Mega');
 });
 
-test('U1 read-model: rested (0 due, 0 unguarded — all words in guardian map, all future)', () => {
+test('U1 read-model: rested (0 due, 0 unguarded, pool below MIN → collapsed to rested)', () => {
   // Only 2 core words; both are already in the guardian map with future due
-  // days. No unguarded Mega + no due Guardian = rested.
+  // days. Combined pool = 2 (below GUARDIAN_MIN_ROUND_LENGTH = 5) → rested
+  // even under the default allowOptionalPatrol=true policy, because the
+  // selector could not produce a minimum-length round.
   const runtimeSnapshot = makeRuntimeSnapshot({ coreCount: 2 });
   const [w0, w1] = runtimeSnapshot.coreWords;
   const subjectStateRecord = makeSubjectStateRecord({
@@ -3263,11 +3322,14 @@ test('U1 read-model: rested (0 due, 0 unguarded — all words in guardian map, a
     },
   });
   const state = getSpellingPostMasteryState({ subjectStateRecord, runtimeSnapshot, now: U4_NOW_MS });
-  assert.equal(state.guardianMissionState, 'optional-patrol',
-    'top-up from non-due guardians still counts as optional patrol under default policy');
-  // Now promote to "everything guarded, nothing due, policy off" scenario only
-  // via the helper directly to get 'rested'.
-  const rested = computeGuardianMissionState({
+  assert.equal(state.guardianMissionState, 'rested',
+    'combined pool < MIN_ROUND_LENGTH collapses optional-patrol to rested (short-round invariant)');
+  assert.equal(state.guardianMissionAvailable, false);
+
+  // And of course, explicitly disabling the optional-patrol policy also yields
+  // 'rested' — but with a 2-entry + 0-unguarded pool we are already there
+  // under the default policy thanks to the short-round invariant.
+  const restedExplicit = computeGuardianMissionState({
     allWordsMega: true,
     eligibleGuardianEntries: [
       { slug: w0.slug, wobbling: false, nextDueDay: TODAY + 30 },
@@ -3277,7 +3339,7 @@ test('U1 read-model: rested (0 due, 0 unguarded — all words in guardian map, a
     todayDay: TODAY,
     policy: { allowOptionalPatrol: false },
   });
-  assert.equal(rested, 'rested');
+  assert.equal(restedExplicit, 'rested');
 });
 
 test('U1 read-model: all-rested scenario (no guardians, no unguarded) → rested + not available', () => {
@@ -3358,4 +3420,284 @@ test('U1 read-model integration: postMastery field on buildSpellingLearnerReadMo
   assert.equal(output.postMastery.nonWobblingDueCount, 0);
   assert.equal(output.postMastery.unguardedMegaCount, 9);
   assert.equal(output.postMastery.guardianAvailableCount, 10);
+});
+
+// ----- U1 review: deriveGuardianAggregates helper ------------------------------
+// The aggregate helper is the single source of truth for the seven derived
+// scalars the service and the read-model both expose. These tests pin the
+// shape (particularly the `wobblingDueCount + nonWobblingDueCount === guardianDueCount`
+// invariant) and the orphan-sanitiser contract.
+
+test('U1 review: deriveGuardianAggregates returns all 7 documented fields', () => {
+  const runtimeSnapshot = makeRuntimeSnapshot({ coreCount: 10 });
+  const [w0, w1] = runtimeSnapshot.coreWords;
+  const progressMap = secureProgressEntries(runtimeSnapshot.coreWords);
+  const guardianMap = {
+    [w0.slug]: { reviewLevel: 1, lastReviewedDay: TODAY - 3, nextDueDay: TODAY, correctStreak: 1, lapses: 0, renewals: 0, wobbling: false },
+    [w1.slug]: { reviewLevel: 0, lastReviewedDay: TODAY - 4, nextDueDay: TODAY - 1, correctStreak: 0, lapses: 1, renewals: 0, wobbling: true },
+  };
+  const aggregates = deriveGuardianAggregates({
+    guardianMap,
+    progressMap,
+    wordBySlug: runtimeSnapshot.wordBySlug,
+    todayDay: TODAY,
+  });
+  assert.deepEqual(Object.keys(aggregates).sort(), [
+    'eligibleGuardianEntries',
+    'guardianDueCount',
+    'nextGuardianDueDay',
+    'nonWobblingDueCount',
+    'unguardedMegaCount',
+    'wobblingCount',
+    'wobblingDueCount',
+  ]);
+});
+
+test('U1 review: deriveGuardianAggregates invariant — wobblingDueCount + nonWobblingDueCount === guardianDueCount', () => {
+  // Matrix fixture: 8 different scenarios cover the combinatorial space
+  // (no guardians, all due, no due, mix of wobbling and non-wobbling, orphan
+  // slugs, future due). Each must honour the invariant.
+  const runtimeSnapshot = makeRuntimeSnapshot({ coreCount: 10 });
+  const progressMap = secureProgressEntries(runtimeSnapshot.coreWords);
+  const slugs = runtimeSnapshot.coreWords.map((word) => word.slug);
+
+  const matrix = [
+    { name: 'empty guardian map', guardian: {} },
+    {
+      name: 'single wobbling due',
+      guardian: {
+        [slugs[0]]: { reviewLevel: 0, lastReviewedDay: TODAY - 3, nextDueDay: TODAY - 1, correctStreak: 0, lapses: 1, renewals: 0, wobbling: true },
+      },
+    },
+    {
+      name: 'single non-wobbling due',
+      guardian: {
+        [slugs[0]]: { reviewLevel: 2, lastReviewedDay: TODAY - 2, nextDueDay: TODAY, correctStreak: 2, lapses: 0, renewals: 0, wobbling: false },
+      },
+    },
+    {
+      name: 'mix of wobbling-due + non-wobbling-due + non-due',
+      guardian: {
+        [slugs[0]]: { reviewLevel: 0, lastReviewedDay: TODAY - 3, nextDueDay: TODAY - 1, correctStreak: 0, lapses: 1, renewals: 0, wobbling: true },
+        [slugs[1]]: { reviewLevel: 2, lastReviewedDay: TODAY - 2, nextDueDay: TODAY, correctStreak: 2, lapses: 0, renewals: 0, wobbling: false },
+        [slugs[2]]: { reviewLevel: 3, lastReviewedDay: TODAY - 1, nextDueDay: TODAY + 30, correctStreak: 3, lapses: 0, renewals: 0, wobbling: false },
+        [slugs[3]]: { reviewLevel: 1, lastReviewedDay: TODAY - 5, nextDueDay: TODAY + 7, correctStreak: 0, lapses: 1, renewals: 0, wobbling: true },
+      },
+    },
+    {
+      name: 'all due (all wobbling)',
+      guardian: Object.fromEntries(slugs.map((slug) => [
+        slug,
+        { reviewLevel: 0, lastReviewedDay: TODAY - 3, nextDueDay: TODAY - 1, correctStreak: 0, lapses: 1, renewals: 0, wobbling: true },
+      ])),
+    },
+    {
+      name: 'all due (none wobbling)',
+      guardian: Object.fromEntries(slugs.map((slug) => [
+        slug,
+        { reviewLevel: 2, lastReviewedDay: TODAY - 2, nextDueDay: TODAY, correctStreak: 2, lapses: 0, renewals: 0, wobbling: false },
+      ])),
+    },
+    {
+      name: 'all future-due (none due today)',
+      guardian: Object.fromEntries(slugs.map((slug) => [
+        slug,
+        { reviewLevel: 3, lastReviewedDay: TODAY - 1, nextDueDay: TODAY + 30, correctStreak: 3, lapses: 0, renewals: 0, wobbling: false },
+      ])),
+    },
+    {
+      name: 'orphan slug mixed in (must NOT count)',
+      guardian: {
+        [slugs[0]]: { reviewLevel: 0, lastReviewedDay: TODAY - 3, nextDueDay: TODAY - 1, correctStreak: 0, lapses: 1, renewals: 0, wobbling: true },
+        ghostword: { reviewLevel: 0, lastReviewedDay: TODAY - 3, nextDueDay: TODAY - 1, correctStreak: 0, lapses: 2, renewals: 0, wobbling: true },
+      },
+    },
+  ];
+
+  for (const scenario of matrix) {
+    const aggregates = deriveGuardianAggregates({
+      guardianMap: scenario.guardian,
+      progressMap,
+      wordBySlug: runtimeSnapshot.wordBySlug,
+      todayDay: TODAY,
+    });
+    assert.equal(
+      aggregates.wobblingDueCount + aggregates.nonWobblingDueCount,
+      aggregates.guardianDueCount,
+      `invariant failed for scenario "${scenario.name}": ${aggregates.wobblingDueCount} + ${aggregates.nonWobblingDueCount} !== ${aggregates.guardianDueCount}`,
+    );
+  }
+});
+
+test('U1 review: deriveGuardianAggregates returns zero counts + null nextDue for empty inputs', () => {
+  const aggregates = deriveGuardianAggregates({});
+  assert.deepEqual(aggregates.eligibleGuardianEntries, []);
+  assert.equal(aggregates.guardianDueCount, 0);
+  assert.equal(aggregates.wobblingDueCount, 0);
+  assert.equal(aggregates.nonWobblingDueCount, 0);
+  assert.equal(aggregates.wobblingCount, 0);
+  assert.equal(aggregates.unguardedMegaCount, 0);
+  assert.equal(aggregates.nextGuardianDueDay, null);
+});
+
+test('U1 review: deriveGuardianAggregates tolerates null/garbage inputs without throwing', () => {
+  assert.doesNotThrow(() => deriveGuardianAggregates({ guardianMap: null, progressMap: null, wordBySlug: null, todayDay: 'oops' }));
+  const aggregates = deriveGuardianAggregates({ guardianMap: null, progressMap: null, wordBySlug: null, todayDay: 'oops' });
+  assert.equal(aggregates.guardianDueCount, 0);
+  assert.equal(aggregates.unguardedMegaCount, 0);
+});
+
+// ----- U1 review: createLockedPostMasteryState factory --------------------------
+// The factory is the single source for the three parallel "locked" fallback
+// objects that used to live inline in client-read-models.js, spelling-view-model.js,
+// and as an implicit `computeGuardianMissionState({allWordsMega: false})` result.
+
+test('U1 review: createLockedPostMasteryState returns structurally complete locked shape', () => {
+  const state = createLockedPostMasteryState();
+  assert.equal(state.allWordsMega, false);
+  assert.equal(state.guardianMissionState, 'locked');
+  assert.equal(state.guardianMissionAvailable, false);
+  assert.equal(state.guardianDueCount, 0);
+  assert.equal(state.wobblingCount, 0);
+  assert.equal(state.wobblingDueCount, 0);
+  assert.equal(state.nonWobblingDueCount, 0);
+  assert.equal(state.unguardedMegaCount, 0);
+  assert.equal(state.guardianAvailableCount, 0);
+  assert.equal(state.nextGuardianDueDay, null);
+  assert.equal(state.todayDay, 0);
+  assert.deepEqual(state.guardianMap, {});
+  assert.deepEqual(state.recommendedWords, []);
+});
+
+test('U1 review: createLockedPostMasteryState fields match computeGuardianMissionState({allWordsMega: false}) result', () => {
+  // If `computeGuardianMissionState` would produce 'locked' for a no-content
+  // learner, the factory's `guardianMissionState` must match. This is the
+  // invariant the review called out — if the two paths drift, the remote-sync
+  // dashboard disagrees with the canonical state machine.
+  const locked = computeGuardianMissionState({ allWordsMega: false });
+  const factory = createLockedPostMasteryState();
+  assert.equal(factory.guardianMissionState, locked);
+  assert.equal(factory.guardianMissionAvailable, false);
+});
+
+test('U1 review: createLockedPostMasteryState returns fresh objects — mutating one does not affect another', () => {
+  const first = createLockedPostMasteryState();
+  first.guardianMap.mutated = 'yes';
+  first.recommendedWords.push('should-not-leak');
+  const second = createLockedPostMasteryState();
+  assert.deepEqual(second.guardianMap, {});
+  assert.deepEqual(second.recommendedWords, []);
+});
+
+// ----- U1 review: runtime validator on GUARDIAN_MISSION_STATES ------------------
+
+test('U1 review: GUARDIAN_MISSION_STATES matches all computeGuardianMissionState outputs across a matrix', () => {
+  // Every documented branch of the state machine must return a label that
+  // lives in GUARDIAN_MISSION_STATES. The machine now enforces this via a
+  // throw-on-unknown-state guard; this test locks in the complement (every
+  // branch returns something valid).
+  const cases = [
+    { allWordsMega: false, eligibleGuardianEntries: [], unguardedMegaCount: 0, todayDay: TODAY },
+    { allWordsMega: true, eligibleGuardianEntries: [], unguardedMegaCount: 0, todayDay: TODAY },
+    { allWordsMega: true, eligibleGuardianEntries: [], unguardedMegaCount: GUARDIAN_MIN_ROUND_LENGTH, todayDay: TODAY },
+    { allWordsMega: true, eligibleGuardianEntries: [{ slug: 'a', wobbling: true, nextDueDay: TODAY - 1 }], unguardedMegaCount: 5, todayDay: TODAY },
+    { allWordsMega: true, eligibleGuardianEntries: [{ slug: 'a', wobbling: false, nextDueDay: TODAY }], unguardedMegaCount: 4, todayDay: TODAY },
+    { allWordsMega: true, eligibleGuardianEntries: [
+      { slug: 'a', wobbling: false, nextDueDay: TODAY + 10 },
+      { slug: 'b', wobbling: false, nextDueDay: TODAY + 20 },
+      { slug: 'c', wobbling: false, nextDueDay: TODAY + 30 },
+      { slug: 'd', wobbling: false, nextDueDay: TODAY + 40 },
+      { slug: 'e', wobbling: false, nextDueDay: TODAY + 50 },
+    ], unguardedMegaCount: 0, todayDay: TODAY },
+  ];
+  for (const ctx of cases) {
+    const state = computeGuardianMissionState(ctx);
+    assert.ok(
+      GUARDIAN_MISSION_STATES.includes(state),
+      `computeGuardianMissionState produced "${state}" for ctx=${JSON.stringify(ctx)} which is not in GUARDIAN_MISSION_STATES`,
+    );
+  }
+});
+
+// ----- U1 review: service/read-model parity -----------------------------------
+// Feed the exact same fixture through both selectors and assert the U1 field
+// prefix is byte-identical. Catches drift like "service rounded nextGuardianDueDay
+// but read-model didn't".
+
+function makeParityService({ now, storage = installMemoryStorage() } = {}) {
+  const repositories = createLocalPlatformRepositories({ storage });
+  const spoken = [];
+  const service = createSpellingService({
+    repository: createSpellingPersistence({ repositories, now }),
+    now,
+    random: () => 0.5,
+    tts: {
+      speak(payload) {
+        spoken.push(payload);
+      },
+      stop() {},
+      warmup() {},
+    },
+  });
+  return { storage, repositories, service };
+}
+
+test('U1 review parity: service.getPostMasteryState and read-model getSpellingPostMasteryState return identical U1 fields', () => {
+  // Setup: a realistic 170-core-word learner with a mix of wobbling-due,
+  // non-wobbling-due, future-due, and unguarded Mega slugs. Both selectors
+  // see the same storage + runtime and must agree on every U1 scalar.
+  const now = () => Date.UTC(2026, 0, 10);
+  const todayForService = Math.floor(now() / DAY_MS);
+  const { service, repositories } = makeParityService({ now });
+
+  // Hand-build the progress + guardian map the service will read.
+  const coreWords = WORDS.filter((word) => word.spellingPool === 'core');
+  const progress = Object.fromEntries(coreWords.map((word) => [word.slug, {
+    stage: 4,
+    attempts: 6,
+    correct: 5,
+    wrong: 1,
+    dueDay: todayForService + 60,
+    lastDay: todayForService - 7,
+    lastResult: true,
+  }]));
+  const guardian = {
+    [coreWords[0].slug]: { reviewLevel: 0, lastReviewedDay: todayForService - 3, nextDueDay: todayForService - 1, correctStreak: 0, lapses: 1, renewals: 0, wobbling: true },
+    [coreWords[1].slug]: { reviewLevel: 2, lastReviewedDay: todayForService - 2, nextDueDay: todayForService, correctStreak: 2, lapses: 0, renewals: 0, wobbling: false },
+    [coreWords[2].slug]: { reviewLevel: 3, lastReviewedDay: todayForService - 1, nextDueDay: todayForService + 30, correctStreak: 3, lapses: 0, renewals: 0, wobbling: false },
+  };
+  repositories.subjectStates.writeData('learner-a', 'spelling', { progress, guardian });
+
+  const serviceSnapshot = service.getPostMasteryState('learner-a');
+
+  // Read-model consumes the subject-state record shape directly. Build it
+  // from the repository's view so the two callers see the same data.
+  const subjectStateRecord = repositories.subjectStates.read('learner-a', 'spelling');
+  const readModelSnapshot = getSpellingPostMasteryState({
+    subjectStateRecord,
+    runtimeSnapshot: { words: WORDS, wordBySlug: WORD_BY_SLUG },
+    now: todayForService * DAY_MS,
+  });
+
+  // Assert every U1 field matches. The read-model also emits `recommendedWords`
+  // which the service omits; we intentionally ignore that delta here.
+  const u1Fields = [
+    'allWordsMega',
+    'guardianDueCount',
+    'wobblingCount',
+    'wobblingDueCount',
+    'nonWobblingDueCount',
+    'unguardedMegaCount',
+    'guardianAvailableCount',
+    'guardianMissionState',
+    'guardianMissionAvailable',
+    'nextGuardianDueDay',
+  ];
+  for (const field of u1Fields) {
+    assert.deepEqual(
+      serviceSnapshot[field],
+      readModelSnapshot[field],
+      `parity drift on field "${field}": service=${JSON.stringify(serviceSnapshot[field])} vs readModel=${JSON.stringify(readModelSnapshot[field])}`,
+    );
+  }
 });

--- a/tests/spelling.test.js
+++ b/tests/spelling.test.js
@@ -762,3 +762,91 @@ test('smartBucket routes secure-stage words with historical wrongs to fragile be
   assert.equal(result.ok, true);
   assert.deepEqual(result.session.uniqueWords, [fragileSlug]);
 });
+
+// ----- U1: service-side getPostMasteryState mirror ----------------------------
+// The service's live `getPostMasteryState` feeds the Alt+4 module gate and the
+// setup-scene render. U1 extends it with the same new fields the read-model
+// selector returns (`guardianMissionState`, `guardianMissionAvailable`,
+// `unguardedMegaCount`, `guardianAvailableCount`, `wobblingDueCount`,
+// `nonWobblingDueCount`). These tests drive a core-sized learner through the
+// service and spot-check the derived fields.
+
+function seedFullCoreMega({ repositories, learnerId, today, guardian = {} }) {
+  const progress = Object.fromEntries(WORDS
+    .filter((word) => word.spellingPool === 'core')
+    .map((word) => [word.slug, {
+      stage: 4,
+      attempts: 6,
+      correct: 5,
+      wrong: 1,
+      dueDay: today + 60,
+      lastDay: today - 7,
+      lastResult: true,
+    }]));
+  repositories.subjectStates.writeData(learnerId, 'spelling', {
+    progress,
+    guardian,
+  });
+  return progress;
+}
+
+test('U1 service: getPostMasteryState exposes all U1 fields for fresh graduate', () => {
+  const now = () => Date.UTC(2026, 0, 10);
+  const today = Math.floor(now() / (24 * 60 * 60 * 1000));
+  const { service, repositories } = makeService({ now, random: makeSeededRandom(1) });
+  seedFullCoreMega({ repositories, learnerId: 'learner-a', today, guardian: {} });
+
+  const snapshot = service.getPostMasteryState('learner-a');
+  assert.equal(snapshot.allWordsMega, true);
+  assert.equal(snapshot.guardianMissionState, 'first-patrol');
+  assert.equal(snapshot.guardianMissionAvailable, true);
+  assert.equal(snapshot.guardianDueCount, 0);
+  assert.equal(snapshot.wobblingDueCount, 0);
+  assert.equal(snapshot.nonWobblingDueCount, 0);
+  assert.ok(snapshot.unguardedMegaCount > 0, 'all Mega core slugs are unguarded');
+  assert.equal(snapshot.guardianAvailableCount, snapshot.unguardedMegaCount);
+});
+
+test('U1 service: getPostMasteryState mirrors read-model for wobbling scenario', () => {
+  const now = () => Date.UTC(2026, 0, 10);
+  const today = Math.floor(now() / (24 * 60 * 60 * 1000));
+  const { service, repositories } = makeService({ now, random: makeSeededRandom(1) });
+  const guardian = {
+    possess: { reviewLevel: 0, lastReviewedDay: today - 3, nextDueDay: today - 1, correctStreak: 0, lapses: 1, renewals: 0, wobbling: true },
+    believe: { reviewLevel: 2, lastReviewedDay: today - 2, nextDueDay: today, correctStreak: 2, lapses: 0, renewals: 0, wobbling: false },
+  };
+  seedFullCoreMega({ repositories, learnerId: 'learner-a', today, guardian });
+
+  const snapshot = service.getPostMasteryState('learner-a');
+  assert.equal(snapshot.guardianMissionState, 'wobbling');
+  assert.equal(snapshot.guardianMissionAvailable, true);
+  assert.equal(snapshot.wobblingDueCount, 1);
+  assert.equal(snapshot.nonWobblingDueCount, 1);
+  assert.equal(snapshot.guardianDueCount, 2);
+});
+
+test('U1 service: getPostMasteryState returns locked state when learner has not graduated', () => {
+  const now = () => Date.UTC(2026, 0, 10);
+  const { service } = makeService({ now, random: makeSeededRandom(1) });
+  // No seed — learner-a has no progress.
+  const snapshot = service.getPostMasteryState('learner-a');
+  assert.equal(snapshot.allWordsMega, false);
+  assert.equal(snapshot.guardianMissionState, 'locked');
+  assert.equal(snapshot.guardianMissionAvailable, false);
+});
+
+test('U1 service: optional-patrol when some Mega words are still unguarded but none due', () => {
+  const now = () => Date.UTC(2026, 0, 10);
+  const today = Math.floor(now() / (24 * 60 * 60 * 1000));
+  const { service, repositories } = makeService({ now, random: makeSeededRandom(1) });
+  const guardian = {
+    possess: { reviewLevel: 3, lastReviewedDay: today - 1, nextDueDay: today + 30, correctStreak: 3, lapses: 0, renewals: 0, wobbling: false },
+    believe: { reviewLevel: 2, lastReviewedDay: today - 2, nextDueDay: today + 14, correctStreak: 2, lapses: 0, renewals: 0, wobbling: false },
+  };
+  seedFullCoreMega({ repositories, learnerId: 'learner-a', today, guardian });
+  const snapshot = service.getPostMasteryState('learner-a');
+  assert.equal(snapshot.guardianDueCount, 0, 'nothing due');
+  assert.equal(snapshot.guardianMissionState, 'optional-patrol');
+  assert.equal(snapshot.guardianMissionAvailable, true);
+  assert.ok(snapshot.unguardedMegaCount > 0);
+});


### PR DESCRIPTION
## Summary
- Extend `getSpellingPostMasteryState` (read-model) and `getPostMasteryState` (service) with a canonical state machine: `locked` / `first-patrol` / `wobbling` / `due` / `optional-patrol` / `rested`.
- Dashboard gates the Begin button on `guardianMissionAvailable` instead of the legacy `guardianDueCount > 0`, so fresh graduates can run their first patrol (R1). Copy + stat ribbon decompose into "N urgent + M patrol" (R2).
- Extend the remote-sync `client-read-models.js` fallback stub so the new gating scalars have safe `locked` defaults — otherwise the remote-sync dashboard would stay permanently `beginDisabled` until the first command round-trip.

## Design
- `computeGuardianMissionState(ctx)` pure helper exported from `shared/spelling/service.js`. Single source of truth for every dashboard branch.
- `GUARDIAN_MISSION_STATES = Object.freeze([...])` in `service-contract.js` (additive — no `SPELLING_SERVICE_STATE_VERSION` bump; new fields are derived, not persisted).
- New selector return fields: `unguardedMegaCount`, `guardianAvailableCount`, `wobblingDueCount`, `nonWobblingDueCount`, `guardianMissionState`, `guardianMissionAvailable`. Legacy `guardianDueCount` / `wobblingCount` / `nextGuardianDueDay` unchanged.
- `PostMegaSetupContent` in `SpellingSetupScene.jsx` branches copy + `missionBadge` on `guardianMissionState`. Falls back to legacy counts when the read-model has not populated the new scalars (keeps pre-U1 tests green).
- Stat ribbon grows a "Urgent checks / Patrol words" split when `wobblingDueCount > 0 && nonWobblingDueCount > 0`; collapses back to the single "Due today" counter otherwise.

## Requirements coverage
- **R1**: fresh-graduate first-patrol is enabled (`guardianMissionState === 'first-patrol'` when `allWordsMega && unguardedMegaCount > 0 && guardianMap is empty`).
- **R2**: daily-patrol semantics are honest — `optional-patrol` copy when zero due + top-up available; decomposed ribbon when wobbling/due mix exists; `nextGuardianDueDay` surfaces relative-day next-check for the rested case.

## Test plan
- [x] `computeGuardianMissionState` truth table: every state + defensive null/garbage inputs.
- [x] `getSpellingPostMasteryState` return-shape tests: first-patrol, wobbling (decomposed counts), due, optional-patrol, rested (via helper), locked, content-rollback, orphan-preserved.
- [x] Service-side `getPostMasteryState` mirror: fresh graduate, wobbling, optional-patrol, locked.
- [x] `client-read-models.js` stub: safe `locked` defaults + cached-value passthrough for all U1 fields.
- [x] Existing "All guardians rested" fixture retargeted to the `optional-patrol` state it now correctly represents (learner has 212 unguarded core Mega slugs → top-up producible).
- [x] Full `npm test`: 2066 passing, 1 skipped, 1 pre-existing failure (`grammar-production-smoke`).

## Scope boundaries honoured
- Not touching `REPO_SCHEMA_VERSION` or `SPELLING_SERVICE_STATE_VERSION` (additive derived fields only).
- Not touching `legacy-engine.js`, `normaliseServerSpellingData`, or any persisted shape.
- `allWordsMega` stays a core-pool-only concept; `unguardedMegaCount` matches.

## Plan reference
`docs/plans/2026-04-25-005-feat-post-mega-spelling-guardian-hardening-plan.md` (U1 — lines 331–390).