### PR TITLE
feat(grammar): U9 visual + accessibility pass across Phase 3 scenes

### DIFF
--- a/src/subjects/grammar/components/GrammarConceptBankScene.jsx
+++ b/src/subjects/grammar/components/GrammarConceptBankScene.jsx
@@ -192,6 +192,7 @@ export function GrammarConceptBankScene({ grammar, actions }) {
           type="button"
           className="btn ghost sm"
           data-action="grammar-close-concept-bank"
+          aria-label="Back to Grammar Garden dashboard"
           onClick={() => actions?.dispatch?.('grammar-close-concept-bank')}
         >
           &larr; Back to Grammar Garden

--- a/src/subjects/grammar/components/GrammarPracticeSurface.jsx
+++ b/src/subjects/grammar/components/GrammarPracticeSurface.jsx
@@ -98,6 +98,7 @@ export function GrammarPracticeSurface({
             type="button"
             className="btn ghost"
             data-action="grammar-close-analytics"
+            aria-label="Back to round summary"
             onClick={() => actions.dispatch('grammar-close-analytics')}
           >
             Back to round summary

--- a/src/subjects/grammar/components/GrammarTransferScene.jsx
+++ b/src/subjects/grammar/components/GrammarTransferScene.jsx
@@ -229,6 +229,7 @@ function WriteMode({
           className="grammar-transfer-textarea"
           name="grammarTransferDraft"
           data-action="grammar-update-transfer-draft"
+          data-autofocus="true"
           aria-describedby="grammar-transfer-counter"
           placeholder="Write 3-5 sentences here. Nothing you write is scored."
           value={draft}
@@ -448,6 +449,7 @@ export function GrammarTransferScene({ grammar, actions }) {
           type="button"
           className="btn ghost sm"
           data-action="grammar-close-transfer"
+          aria-label="Back to Grammar Garden dashboard"
           onClick={handleBack}
         >
           &larr; Back to Grammar Garden

--- a/tests/react-accessibility-contract.test.js
+++ b/tests/react-accessibility-contract.test.js
@@ -1,9 +1,37 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 
 import { renderAuthSurfaceFixture, renderAppFixture } from './helpers/react-render.js';
 import { installMemoryStorage } from './helpers/memory-storage.js';
 import { createAppHarness } from './helpers/app-harness.js';
+import {
+  createGrammarHarness,
+  grammarResponseFormData,
+} from './helpers/grammar-subject-harness.js';
+import { readGrammarLegacyOracle } from './helpers/grammar-legacy-oracle.js';
+import { normaliseGrammarReadModel } from '../src/subjects/grammar/metadata.js';
+
+// ----------------------------------------------------------------------------
+// Phase 3 U9 — Grammar accessibility contract.
+//
+// SSR blind spots intentionally left to manual QA (Windows + macOS browsers):
+//   - Real DOM focus motion (data-autofocus is a marker only; the runtime
+//     hook lives in the post-render app shell and cannot be asserted from
+//     renderToStaticMarkup).
+//   - Pointer capture, touch targets under 44px on small phones (CSS
+//     assertion only — we rely on `.btn` / `.btn.xl` min-height rules in
+//     `styles/app.css` which SSR cannot measure in pixels).
+//   - Browser IME candidate windows while typing in the Grammar answer
+//     input / Writing Try textarea.
+//   - Scroll-into-view motion (summary `Review answers` uses
+//     `scrollIntoView`, only callable at runtime).
+//   - Animation frames / `requestIdleCallback` / `MutationObserver`-driven
+//     side effects (none read-critical for a11y here).
+//   - Keyboard focus *return* after the concept detail modal closes; the
+//     `data-focus-return-id` attribute is the SSR-visible shim and the
+//     actual `element.focus()` motion is a runtime concern.
+// ----------------------------------------------------------------------------
 
 test('auth and app error surfaces expose live failure feedback', async () => {
   const authHtml = await renderAuthSurfaceFixture();
@@ -49,3 +77,214 @@ test('word-bank modal declares dialog semantics, tabs, replay, and drill control
   assert.match(html, /spellcheck="false"/);
   assert.doesNotMatch(html, />possess<\/h2>/);
 });
+
+// ----------------------------------------------------------------------------
+// Phase 3 U9 — Grammar scene a11y contract entries
+// ----------------------------------------------------------------------------
+
+function grammarOracleSample(templateId = 'question_mark_select') {
+  return readGrammarLegacyOracle().templates.find((template) => template.id === templateId);
+}
+
+function openGrammarDashboard() {
+  const harness = createGrammarHarness({ storage: installMemoryStorage() });
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  return harness;
+}
+
+test('Grammar dashboard exposes labelled form controls and a single primary action', () => {
+  const harness = openGrammarDashboard();
+  const html = harness.render();
+
+  // Round length and speech rate selects live inside wrapping `<label>`
+  // elements (implicit labelling).
+  assert.match(html, /<label class="field"><span>Round length<\/span>/);
+  assert.match(html, /<label class="field"><span>Speech rate<\/span>/);
+  // Exactly one primary CTA in the default dashboard state (`Begin round`).
+  const primaryMatches = html.match(/class="btn primary[^"]*"/g) || [];
+  assert.equal(primaryMatches.length, 1, 'dashboard must render a single .btn.primary');
+});
+
+test('Grammar Bank chips, search, and modal meet the Phase 3 a11y contract', () => {
+  const harness = openGrammarDashboard();
+  harness.dispatch('grammar-open-concept-bank');
+  const bankHtml = harness.render();
+
+  // Search input carries an explicit aria-label (there is no visible label
+  // text adjacent to the input — the wrapping <span> is visually hidden).
+  assert.match(bankHtml, /aria-label="Search Grammar concepts"/);
+  // Filter chips expose aria-pressed toggling.
+  assert.match(bankHtml, /aria-pressed="(?:true|false)"[^>]*data-action="grammar-concept-bank-filter"/);
+  assert.match(bankHtml, /aria-pressed="(?:true|false)"[^>]*data-action="grammar-concept-bank-cluster-filter"/);
+  // Back to dashboard button is explicitly labelled (text + aria-label).
+  assert.match(bankHtml, /aria-label="Back to Grammar Garden dashboard"/);
+
+  // Open the concept detail modal — dialog semantics + labelledby required.
+  const anyCard = harness.store.getState().subjectUi.grammar.analytics?.concepts?.[0];
+  const seededConceptId = anyCard?.id || 'relative_clauses';
+  harness.dispatch('grammar-concept-detail-open', { conceptId: seededConceptId });
+  const modalHtml = harness.render();
+  assert.match(modalHtml, /role="dialog"/);
+  assert.match(modalHtml, /aria-modal="true"/);
+  assert.match(modalHtml, /aria-labelledby="grammar-concept-detail-title-/);
+  // Focus-return shim for modal close.
+  assert.match(modalHtml, /data-focus-trigger-id="grammar-bank-concept-card-/);
+  // Close button has an explicit aria-label.
+  assert.match(modalHtml, /aria-label="Close concept details"/);
+});
+
+test('Grammar session answer input carries the autofocus shim and feedback live regions', () => {
+  const harness = createGrammarHarness({ storage: installMemoryStorage() });
+  // Use a textarea template so the autofocus shim marker is exercised on
+  // the text-entry branch of GrammarInput (choice templates render radio
+  // inputs that intentionally do not carry data-autofocus).
+  const sample = grammarOracleSample('fix_fronted_adverbial');
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-start', {
+    payload: {
+      roundLength: 1,
+      templateId: sample.id,
+      seed: sample.sample.seed,
+    },
+  });
+
+  let html = harness.render();
+  // Session answer input is auto-focus-marked so the runtime shell can
+  // restore focus on session entry. The textarea branch carries the shim.
+  assert.match(html, /class="input grammar-textarea"[^>]*data-autofocus="true"/);
+  // Single .btn.primary per session state (Submit in pre-answer phase).
+  const preAnswerPrimary = (html.match(/class="btn primary[^"]*"/g) || []).length;
+  assert.equal(preAnswerPrimary, 1, 'session pre-answer must render a single .btn.primary');
+
+  harness.dispatch('grammar-submit-form', {
+    formData: grammarResponseFormData(sample.correctResponse),
+  });
+  html = harness.render();
+  // Feedback panel carries role=status + aria-live=polite (good or warn).
+  assert.match(html, /class="feedback (?:good|warn)" role="status" aria-live="polite"/);
+});
+
+test('Grammar session error banner carries role="alert" so assistive tech announces failures', () => {
+  const harness = createGrammarHarness({ storage: installMemoryStorage() });
+  const learnerId = harness.store.getState().learners.selectedId;
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.store.updateSubjectUiForLearner(learnerId, 'grammar', (previous) => ({
+    ...normaliseGrammarReadModel(previous, learnerId),
+    phase: 'session',
+    error: 'Grammar is unavailable right now.',
+    session: {
+      id: 'sess-a11y',
+      currentIndex: 0,
+      targetCount: 1,
+      answered: 0,
+      currentItem: {
+        promptText: 'Type your answer.',
+        inputSpec: { type: 'text' },
+      },
+    },
+  }));
+  const html = harness.render();
+  assert.match(html, /role="alert"/);
+});
+
+test('Grammar mini-test nav exposes aria-current=step + aria-pressed for assistive tech', () => {
+  const harness = createGrammarHarness({ storage: installMemoryStorage() });
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-set-mode', { value: 'satsset' });
+  harness.dispatch('grammar-start', { payload: { roundLength: 2 } });
+  const html = harness.render();
+  // aria-current on the current question; aria-pressed="false" everywhere
+  // (no questions saved yet).
+  assert.match(html, /aria-current="step"/);
+  assert.match(html, /aria-pressed="false"/);
+});
+
+test('Grammar Writing Try scene labels the textarea, carries autofocus marker, and uses fieldset/legend self-check', () => {
+  const harness = openGrammarDashboard();
+  const learnerId = harness.store.getState().learners.selectedId;
+  harness.store.updateSubjectUiForLearner(learnerId, 'grammar', (previous) => ({
+    ...normaliseGrammarReadModel(previous, learnerId),
+    phase: 'transfer',
+    transferLane: {
+      mode: 'non-scored',
+      prompts: [{
+        id: 'storm-scene',
+        title: 'Storm scene',
+        brief: 'Describe a storm for a reader.',
+        grammarTargets: ['adverbials'],
+        checklist: ['I used a fronted adverbial.', 'I used commas for parenthesis.'],
+      }],
+      limits: { writingCapChars: 2000 },
+      evidence: [],
+    },
+    ui: {
+      ...(previous?.ui || {}),
+      transfer: { selectedPromptId: 'storm-scene', draft: '', ticks: {} },
+    },
+  }));
+
+  const html = harness.render();
+  // Back button aria-label.
+  assert.match(html, /aria-label="Back to Grammar Garden dashboard"/);
+  // Textarea wrapped in a `<label>` with visible text and marked for
+  // runtime autofocus on mode entry.
+  assert.match(html, /<span class="grammar-transfer-textarea-label">Your writing<\/span>/);
+  assert.match(html, /class="grammar-transfer-textarea"[^>]*data-autofocus="true"/);
+  // Counter uses role=status + aria-live=polite under cap.
+  assert.match(html, /id="grammar-transfer-counter"[^>]*role="status"[^>]*aria-live="polite"/);
+  // Checklist uses native fieldset + legend (read as a group by assistive
+  // tech) and every checkbox sits inside a <label>.
+  assert.match(html, /<fieldset class="grammar-transfer-checklist"[^>]*><legend[^>]*>Self-check<\/legend>/);
+  assert.match(html, /<label class="grammar-transfer-checklist-label">/);
+});
+
+test('Grammar summary Grown-up view button advertises adult report semantics', () => {
+  const harness = createGrammarHarness({ storage: installMemoryStorage() });
+  const sample = grammarOracleSample();
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-start', {
+    payload: { roundLength: 1, templateId: sample.id, seed: sample.sample.seed },
+  });
+  harness.dispatch('grammar-submit-form', {
+    formData: grammarResponseFormData(sample.correctResponse),
+  });
+  harness.dispatch('grammar-continue');
+  const html = harness.render();
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'summary');
+  // Summary carries the adult-report escape hatch on a quiet ghost button.
+  assert.match(html, /aria-label="Open adult report"/);
+  assert.match(html, /class="btn ghost"[^>]*aria-label="Open adult report"/);
+});
+
+test('Grammar analytics back button is labelled for assistive tech', () => {
+  const harness = createGrammarHarness({ storage: installMemoryStorage() });
+  const sample = grammarOracleSample();
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-start', {
+    payload: { roundLength: 1, templateId: sample.id, seed: sample.sample.seed },
+  });
+  harness.dispatch('grammar-submit-form', {
+    formData: grammarResponseFormData(sample.correctResponse),
+  });
+  harness.dispatch('grammar-continue');
+  harness.dispatch('grammar-open-analytics');
+  const html = harness.render();
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'analytics');
+  assert.match(html, /aria-label="Back to round summary"/);
+  // Analytics heading labels the scene section.
+  assert.match(html, /aria-labelledby="grammar-analytics-title"/);
+});
+
+test('Grammar button CSS contract — .btn.xl primary keeps a 44px-friendly tap target', () => {
+  // The Grammar dashboard `Begin round` button applies `.btn.primary.xl`
+  // from `styles/app.css`. We guard the 48px min-height rule against
+  // accidental regression. SSR cannot measure pixels, so we read the CSS
+  // source instead (per Phase 3 U9 test plan — CSS rule assertion is the
+  // agreed proxy for touch-target width on mobile).
+  const cssPath = new URL('../styles/app.css', import.meta.url);
+  const css = readFileSync(cssPath, 'utf8');
+  const xlRule = css.match(/\.btn\.xl\s*\{[\s\S]*?min-height:\s*(\d+)px/);
+  assert.ok(xlRule, '.btn.xl rule must declare min-height');
+  assert.ok(Number(xlRule[1]) >= 44, `.btn.xl min-height must be >= 44px (got ${xlRule[1]}px)`);
+});
+


### PR DESCRIPTION
## Summary

Phase 3 U9 hygiene pass across shipped Grammar scenes (U1 dashboard, U2 bank + detail modal, U3 session, U4 mini-test review, U5 summary, U6b Writing Try, U7 analytics). No redesign, no CSS mutation, no Worker / Spelling touches.

Plan: [`docs/plans/2026-04-25-004-feat-grammar-phase3-ux-reset-plan.md` § U9](../blob/main/docs/plans/2026-04-25-004-feat-grammar-phase3-ux-reset-plan.md).

## Scenes touched

| Scene | Change |
| --- | --- |
| `GrammarTransferScene.jsx` | `data-autofocus="true"` on write-mode textarea; `aria-label` on back button |
| `GrammarConceptBankScene.jsx` | `aria-label` on back button |
| `GrammarPracticeSurface.jsx` | `aria-label` on analytics back button |

No other scene needed edits — the existing JSX already met the a11y contract (U1 `aria-pressed` on mode cards, U2 `role="dialog"` + `aria-modal` + `aria-labelledby`, U3 `role="status"` + `aria-live` on feedback + `role="alert"` on error, U4 `aria-current="step"` + `aria-pressed` on mini-test nav, U5 `aria-label="Open adult report"` on Grown-up view, U6b `<fieldset>` + `<legend>` on self-check).

## aria-* additions

- `aria-label="Back to Grammar Garden dashboard"` on bank + transfer back buttons.
- `aria-label="Back to round summary"` on analytics back button.
- `data-autofocus="true"` on Writing Try textarea (parity with session answer textarea).

## Tests added

Extended `tests/react-accessibility-contract.test.js` with 9 Grammar scene entries:

- Dashboard labelled selects + single `.btn.primary` per state.
- Bank: aria-pressed chips, labelled search, labelled back, dialog modal semantics with focus-return shim.
- Session: textarea autofocus marker, feedback live regions, single primary.
- Session error banner: `role="alert"`.
- Mini-test nav: `aria-current="step"` + `aria-pressed`.
- Writing Try: textarea label + autofocus, live counter, fieldset/legend self-check with `<label>`-wrapped checkboxes.
- Summary Grown-up view: `aria-label="Open adult report"` on ghost button.
- Analytics: labelled back button + `aria-labelledby` heading.
- CSS contract: `.btn.xl` min-height ≥ 44px (tap-target guard, SSR-safe proxy).

## SSR blind spots (manual-QA gates)

Documented at the top of the test file:

- Real DOM focus motion (only markers are SSR-asserted).
- Pointer capture + touch-target pixel width.
- Browser IME candidate windows.
- Scroll-into-view motion.
- Animation frames / `requestIdleCallback` / `MutationObserver`.
- Focus return after modal close (shim attribute asserted; runtime focus call is a browser concern).

## Test plan

- [x] `node --test tests/react-grammar-surface.test.js tests/react-accessibility-contract.test.js` — 116 tests pass
- [x] `npm test` — 2130 pass, 1 pre-existing failure (`grammar-production-smoke.test.js` — `stats.templates` server-field leak, unrelated to U9)
- [x] `npm run check` — passes (build + audit green)
- [ ] Manual: keyboard-only traversal on Windows + macOS browsers
- [ ] Manual: screen-reader pass with VoiceOver/NVDA on the six Grammar scenes

## Rules respected

- Do not touch Spelling CSS (AGENTS.md line 14).
- Do not touch Worker.
- No redesign — hygiene pass only.
- UK English throughout, no AI fingerprints.