### PR TITLE
feat(punctuation): U6 Skill Detail Modal + guided-focus dispatch

### DIFF
--- a/src/subjects/punctuation/components/PunctuationMapScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationMapScene.jsx
@@ -52,6 +52,7 @@ import {
   normalisePunctuationMapUi,
 } from '../service-contract.js';
 import { PUNCTUATION_CLIENT_SKILLS } from '../read-model.js';
+import { PunctuationSkillDetailModal } from './PunctuationSkillDetailModal.jsx';
 
 // Child-facing labels for the status filter chips. `'all'` is a literal
 // "All"; the other five ids reach for the shared child-copy mapping in
@@ -354,6 +355,20 @@ export function PunctuationMapScene({ ui, actions }) {
         // regression shows up in the DOM tree tests without blowing up the
         // learner experience.
         <div hidden data-punctuation-map-roster-drift="true" />
+      ) : null}
+
+      {/* U6 Skill Detail modal: rendered when `mapUi.detailOpenSkillId` points
+          at a published Punctuation skill id. The modal consumes
+          `mapUi.detailTab` for the Learn/Practise tab state and dispatches
+          `punctuation-start` `{ mode: 'guided', guidedSkillId, roundLength:
+          '4' }` from its "Practise this" button (plan R3). */}
+      {mapUi.detailOpenSkillId ? (
+        <PunctuationSkillDetailModal
+          skillId={mapUi.detailOpenSkillId}
+          detailTab={mapUi.detailTab}
+          ui={ui}
+          actions={actions}
+        />
       ) : null}
     </section>
   );

--- a/src/subjects/punctuation/components/PunctuationSkillDetailModal.jsx
+++ b/src/subjects/punctuation/components/PunctuationSkillDetailModal.jsx
@@ -1,0 +1,235 @@
+// Phase 3 U6 — Punctuation Skill Detail modal.
+//
+// Opens on top of the Punctuation Map scene whenever `mapUi.detailOpenSkillId`
+// is a published skill id. Two tabs — Learn and Practise — consume the
+// U5-landed `mapUi.detailTab` state. The modal renders EXACTLY 3 pedagogy
+// fields per skill:
+//
+//   1. `rule`          (always — the child-facing rule statement)
+//   2. `contrastBad`   (always — the common mix-up)
+//   3. `workedGood` OR `contrastGood` (chosen via
+//      `PUNCTUATION_SKILL_MODAL_PREFERRED_EXAMPLE`, default `workedGood`;
+//      `comma_clarity` overrides to `workedGood` — plan Key Technical
+//      Decisions, adv-219-005 deepening)
+//
+// Other fields from `PUNCTUATION_SKILLS` (workedBad, phase, prereq, published)
+// never ship — the component imports only the 3-field `PUNCTUATION_SKILL_MODAL_CONTENT`
+// client mirror from `punctuation-view-model.js`, so the modal payload is
+// structurally incapable of leaking an accepted answer, validator, generator,
+// rubric, or any other forbidden read-model key (plan R13).
+//
+// "Practise this" dispatch contract (plan R3, verified against
+// `shared/punctuation/service.js:1281-1283`): the button closes the modal
+// FIRST, then dispatches `punctuation-start` with
+// `{ mode: 'guided', guidedSkillId: <skillId>, roundLength: '4' }`. Cluster
+// mode (e.g. `mode: 'speech', skillId: 'speech'`) would silently drop the
+// skill-pin because `guidedSkillId` is only honoured when `prefs.mode ===
+// 'guided'`.
+//
+// Multi-skill paragraph caveat (plan R2): some skills participate in
+// `PUNCTUATION_ITEMS` entries whose `skillIds.length > 1`. For those, the
+// Practise tab renders a footnote — "Some practice questions may also
+// include other punctuation skills." — so a Guided-focus learner isn't
+// surprised by a multi-skill paragraph repair. `punctuationSkillHasMultiSkillItems`
+// returns the set membership from the client-safe mirror.
+//
+// Accessibility: `role="dialog"`, `aria-modal="true"`, `aria-labelledby`
+// pointing at the skill-name <h2>. Close button + scrim click + Esc all
+// dispatch `punctuation-skill-detail-close`. A focus trap is NOT needed in
+// SSR (the harness renders once and doesn't mount an event bridge) — the
+// browser-side focus trap lives on the modal root via the standard Esc /
+// tab keydown handlers wired through `actions.dispatch`.
+
+import React from 'react';
+
+import {
+  PUNCTUATION_MAP_DETAIL_TAB_IDS,
+  PUNCTUATION_SKILL_MODAL_PREFERRED_EXAMPLE,
+  composeIsDisabled,
+  punctuationSkillHasMultiSkillItems,
+  punctuationSkillModalContent,
+  punctuationSkillModalPreferredExample,
+} from './punctuation-view-model.js';
+import { PUNCTUATION_CLIENT_SKILLS } from '../read-model.js';
+
+// Keep the exported tab ids alias available for downstream consumers without
+// forcing them through the service-contract re-export chain.
+export { PUNCTUATION_MAP_DETAIL_TAB_IDS };
+export { PUNCTUATION_SKILL_MODAL_PREFERRED_EXAMPLE };
+
+function skillNameFor(skillId) {
+  const entry = PUNCTUATION_CLIENT_SKILLS.find((skill) => skill.id === skillId);
+  return entry?.name || skillId;
+}
+
+function LearnBody({ skillId, content, preferredExample }) {
+  const exampleText = preferredExample === 'contrastGood'
+    ? content.contrastGood
+    : content.workedGood;
+  const exampleLabel = preferredExample === 'contrastGood'
+    ? 'Strong example'
+    : 'Worked example';
+  return (
+    <div className="punctuation-skill-modal-body" data-punctuation-skill-modal-body="learn">
+      <section className="punctuation-skill-modal-section">
+        <h3 className="punctuation-skill-modal-section-label">The rule</h3>
+        <p className="punctuation-skill-modal-rule">{content.rule}</p>
+      </section>
+      <section className="punctuation-skill-modal-section">
+        <h3 className="punctuation-skill-modal-section-label">{exampleLabel}</h3>
+        <blockquote
+          className="punctuation-skill-modal-example"
+          data-punctuation-skill-modal-example-kind={preferredExample}
+        >
+          {exampleText}
+        </blockquote>
+      </section>
+      <section className="punctuation-skill-modal-section">
+        <h3 className="punctuation-skill-modal-section-label">Common mix-up</h3>
+        <blockquote className="punctuation-skill-modal-contrast-bad">
+          {content.contrastBad}
+        </blockquote>
+      </section>
+    </div>
+  );
+}
+
+function PractiseBody({ skillId, skillName, disabled, actions }) {
+  const multiSkill = punctuationSkillHasMultiSkillItems(skillId);
+  return (
+    <div className="punctuation-skill-modal-body" data-punctuation-skill-modal-body="practise">
+      <p className="punctuation-skill-modal-practise-copy">
+        A short focused round on <strong>{skillName}</strong>. We pick four questions for you — answer at your own pace.
+      </p>
+      {multiSkill ? (
+        <p
+          className="punctuation-skill-modal-multi-skill-note muted"
+          data-punctuation-skill-modal-multi-skill-note="true"
+        >
+          Some practice questions may also include other punctuation skills.
+        </p>
+      ) : null}
+      <div className="punctuation-skill-modal-actions actions">
+        <button
+          type="button"
+          className="btn primary"
+          disabled={disabled}
+          data-action="punctuation-start"
+          data-punctuation-start-skill
+          data-skill-id={skillId}
+          onClick={() => {
+            // Close modal before dispatching start so the Map→Session
+            // transition lands on a clean mapUi state (plan U6 approach).
+            actions.dispatch('punctuation-skill-detail-close');
+            actions.dispatch('punctuation-start', {
+              mode: 'guided',
+              guidedSkillId: skillId,
+              roundLength: '4',
+            });
+          }}
+        >
+          Practise this
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function PunctuationSkillDetailModal({ skillId, detailTab = 'learn', ui, actions }) {
+  if (typeof skillId !== 'string' || !skillId) return null;
+  const content = punctuationSkillModalContent(skillId);
+  if (!content) return null;
+  const disabled = composeIsDisabled(ui);
+  const preferredExample = punctuationSkillModalPreferredExample(skillId);
+  const safeTab = detailTab === 'practise' ? 'practise' : 'learn';
+  const skillName = skillNameFor(skillId);
+  const titleId = 'punctuation-skill-detail-title';
+
+  const closeFromScrim = (event) => {
+    // Only dismiss when the click landed on the scrim itself, not a child
+    // modal element — guards against accidental close when a learner taps
+    // a button or tab inside the modal.
+    if (event.target?.closest?.('.punctuation-skill-modal')) return;
+    actions.dispatch('punctuation-skill-detail-close');
+  };
+
+  const handleKeyDown = (event) => {
+    if (event.key === 'Escape') {
+      event.stopPropagation();
+      actions.dispatch('punctuation-skill-detail-close');
+    }
+  };
+
+  return (
+    <div
+      className="punctuation-skill-modal-scrim"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      data-punctuation-skill-modal
+      data-skill-id={skillId}
+      data-detail-tab={safeTab}
+      onClick={closeFromScrim}
+      onKeyDown={handleKeyDown}
+    >
+      <div className="punctuation-skill-modal-backdrop" aria-hidden="true" />
+      <div className="punctuation-skill-modal" data-skill-id={skillId}>
+        <header className="punctuation-skill-modal-head">
+          <div>
+            <p className="punctuation-skill-modal-eyebrow">Punctuation skill</p>
+            <h2 id={titleId} className="punctuation-skill-modal-title">{skillName}</h2>
+          </div>
+          <button
+            type="button"
+            className="punctuation-skill-modal-close"
+            data-action="punctuation-skill-detail-close"
+            aria-label="Close skill detail"
+            onClick={() => actions.dispatch('punctuation-skill-detail-close')}
+          >
+            ×
+          </button>
+        </header>
+        <div className="punctuation-skill-modal-tabs" role="tablist" aria-label="Skill detail tabs">
+          <button
+            type="button"
+            role="tab"
+            className={`punctuation-skill-modal-tab${safeTab === 'learn' ? ' on' : ''}`}
+            aria-selected={safeTab === 'learn' ? 'true' : 'false'}
+            data-action="punctuation-skill-detail-tab"
+            data-value="learn"
+            onClick={() => actions.dispatch('punctuation-skill-detail-tab', { value: 'learn' })}
+          >
+            Learn
+          </button>
+          <button
+            type="button"
+            role="tab"
+            className={`punctuation-skill-modal-tab${safeTab === 'practise' ? ' on' : ''}`}
+            aria-selected={safeTab === 'practise' ? 'true' : 'false'}
+            data-action="punctuation-skill-detail-tab"
+            data-value="practise"
+            onClick={() => actions.dispatch('punctuation-skill-detail-tab', { value: 'practise' })}
+          >
+            Practise
+          </button>
+        </div>
+        {safeTab === 'practise'
+          ? (
+            <PractiseBody
+              skillId={skillId}
+              skillName={skillName}
+              disabled={disabled}
+              actions={actions}
+            />
+          )
+          : (
+            <LearnBody
+              skillId={skillId}
+              content={content}
+              preferredExample={preferredExample}
+            />
+          )}
+      </div>
+    </div>
+  );
+}

--- a/src/subjects/punctuation/components/PunctuationSkillDetailModal.jsx
+++ b/src/subjects/punctuation/components/PunctuationSkillDetailModal.jsx
@@ -18,29 +18,40 @@
 // structurally incapable of leaking an accepted answer, validator, generator,
 // rubric, or any other forbidden read-model key (plan R13).
 //
-// "Practise this" dispatch contract (plan R3, verified against
-// `shared/punctuation/service.js:1281-1283`): the button closes the modal
-// FIRST, then dispatches `punctuation-start` with
-// `{ mode: 'guided', guidedSkillId: <skillId>, roundLength: '4' }`. Cluster
-// mode (e.g. `mode: 'speech', skillId: 'speech'`) would silently drop the
-// skill-pin because `guidedSkillId` is only honoured when `prefs.mode ===
-// 'guided'`.
+// "Practise this" dispatch contract (plan R3 + review-follower adv-231-003):
+// the button dispatches `punctuation-start` FIRST with
+// `{ mode: 'guided', guidedSkillId: <skillId>, roundLength: '4' }` and then
+// `punctuation-skill-detail-close`. If `punctuation-start` throws
+// `punctuation_content_unavailable` the runtime fallback replaces the scene;
+// inverting the order ensures that, on success, the Modal unmounts naturally
+// alongside the Map scene, and on failure the Modal stays mounted so the
+// learner keeps their context instead of being stranded on a runtime
+// fallback view. Cluster mode (e.g. `mode: 'speech', skillId: 'speech'`)
+// would silently drop the skill-pin because `guidedSkillId` is only honoured
+// when `prefs.mode === 'guided'`.
 //
 // Multi-skill paragraph caveat (plan R2): some skills participate in
 // `PUNCTUATION_ITEMS` entries whose `skillIds.length > 1`. For those, the
-// Practise tab renders a footnote — "Some practice questions may also
-// include other punctuation skills." — so a Guided-focus learner isn't
-// surprised by a multi-skill paragraph repair. `punctuationSkillHasMultiSkillItems`
-// returns the set membership from the client-safe mirror.
+// Practise tab renders a softened footnote — "You might see one or two
+// other punctuation skills too — that's normal!" — so a Guided-focus learner
+// isn't surprised by a multi-skill paragraph repair.
+// `punctuationSkillHasMultiSkillItems` returns the set membership from the
+// client-safe mirror.
 //
-// Accessibility: `role="dialog"`, `aria-modal="true"`, `aria-labelledby`
-// pointing at the skill-name <h2>. Close button + scrim click + Esc all
-// dispatch `punctuation-skill-detail-close`. A focus trap is NOT needed in
-// SSR (the harness renders once and doesn't mount an event bridge) — the
-// browser-side focus trap lives on the modal root via the standard Esc /
-// tab keydown handlers wired through `actions.dispatch`.
+// Accessibility (review-follower HIGH 2 + HIGH 3):
+// - The inner `.punctuation-skill-modal` card carries `role="dialog"`,
+//   `aria-modal="true"`, and `aria-labelledby` pointing at the scoped
+//   (per-skill) title id. The scrim remains a click-absorber with
+//   `aria-hidden="true"` — screen-reader users land on the dialog itself.
+// - The Close button carries `data-autofocus="true"` for the platform's
+//   autofocus wiring (`src/main.js` scopes the selector to
+//   `.wb-modal-scrim` only, so a `useEffect` + ref fallback focuses the
+//   Close button in every other mount path — dialog semantics land on
+//   open without the learner having to click first).
+// - Esc + Close button + scrim click all dispatch
+//   `punctuation-skill-detail-close`.
 
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 
 import {
   PUNCTUATION_MAP_DETAIL_TAB_IDS,
@@ -106,7 +117,7 @@ function PractiseBody({ skillId, skillName, disabled, actions }) {
           className="punctuation-skill-modal-multi-skill-note muted"
           data-punctuation-skill-modal-multi-skill-note="true"
         >
-          Some practice questions may also include other punctuation skills.
+          You might see one or two other punctuation skills too — that's normal!
         </p>
       ) : null}
       <div className="punctuation-skill-modal-actions actions">
@@ -118,14 +129,19 @@ function PractiseBody({ skillId, skillName, disabled, actions }) {
           data-punctuation-start-skill
           data-skill-id={skillId}
           onClick={() => {
-            // Close modal before dispatching start so the Map→Session
-            // transition lands on a clean mapUi state (plan U6 approach).
-            actions.dispatch('punctuation-skill-detail-close');
+            // Review-follower adv-231-003: dispatch start FIRST, then close.
+            // If `punctuation-start` throws (e.g. `punctuation_content_unavailable`)
+            // the runtime fallback replaces the scene and the Modal would be
+            // gone before the learner could retry. Dispatching start first
+            // means: on success, the Modal unmounts naturally when the phase
+            // transitions to `active-item` (Map scene also unmounts); on
+            // failure, the Modal stays open so the learner keeps context.
             actions.dispatch('punctuation-start', {
               mode: 'guided',
               guidedSkillId: skillId,
               roundLength: '4',
             });
+            actions.dispatch('punctuation-skill-detail-close');
           }}
         >
           Practise this
@@ -136,6 +152,29 @@ function PractiseBody({ skillId, skillName, disabled, actions }) {
 }
 
 export function PunctuationSkillDetailModal({ skillId, detailTab = 'learn', ui, actions }) {
+  // Hooks must run before any early return so React sees the same order on
+  // every render — useRef is safe to call even when we ultimately return
+  // null below.
+  const closeButtonRef = useRef(null);
+  // Runtime autofocus fallback. The platform's `[data-autofocus="true"]`
+  // handler in `src/main.js` is scoped to `.wb-modal-scrim` (Spelling) so
+  // it does not reach this Punctuation modal. Focusing the Close button on
+  // mount hands screen-reader users the dialog announcement + a keyboard-
+  // actionable control on open. SSR tests assert on the `data-autofocus`
+  // attribute; this effect is the browser-only companion.
+  useEffect(() => {
+    if (!skillId) return undefined;
+    const button = closeButtonRef.current;
+    if (button && typeof button.focus === 'function') {
+      try {
+        button.focus();
+      } catch {
+        /* non-focusable platforms fall through */
+      }
+    }
+    return undefined;
+  }, [skillId]);
+
   if (typeof skillId !== 'string' || !skillId) return null;
   const content = punctuationSkillModalContent(skillId);
   if (!content) return null;
@@ -143,7 +182,10 @@ export function PunctuationSkillDetailModal({ skillId, detailTab = 'learn', ui, 
   const preferredExample = punctuationSkillModalPreferredExample(skillId);
   const safeTab = detailTab === 'practise' ? 'practise' : 'learn';
   const skillName = skillNameFor(skillId);
-  const titleId = 'punctuation-skill-detail-title';
+  // Review-follower LOW: scope the title id per-skill so the DOM cannot
+  // ever contain two elements with id `punctuation-skill-detail-title` —
+  // e.g. when tests render back-to-back with different skills.
+  const titleId = `punctuation-skill-detail-title-${skillId}`;
 
   const closeFromScrim = (event) => {
     // Only dismiss when the click landed on the scrim itself, not a child
@@ -163,17 +205,25 @@ export function PunctuationSkillDetailModal({ skillId, detailTab = 'learn', ui, 
   return (
     <div
       className="punctuation-skill-modal-scrim"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby={titleId}
       data-punctuation-skill-modal
       data-skill-id={skillId}
       data-detail-tab={safeTab}
       onClick={closeFromScrim}
       onKeyDown={handleKeyDown}
     >
+      {/* Scrim has no ARIA role — it is a click-absorber + visual overlay
+          only. Dialog semantics live on the inner card below so screen-
+          reader users land on the dialog landmark itself. `aria-hidden`
+          is intentionally NOT set on the scrim: React would propagate it
+          to the inner dialog subtree and hide the whole modal from AT. */}
       <div className="punctuation-skill-modal-backdrop" aria-hidden="true" />
-      <div className="punctuation-skill-modal" data-skill-id={skillId}>
+      <div
+        className="punctuation-skill-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        data-skill-id={skillId}
+      >
         <header className="punctuation-skill-modal-head">
           <div>
             <p className="punctuation-skill-modal-eyebrow">Punctuation skill</p>
@@ -181,8 +231,10 @@ export function PunctuationSkillDetailModal({ skillId, detailTab = 'learn', ui, 
           </div>
           <button
             type="button"
+            ref={closeButtonRef}
             className="punctuation-skill-modal-close"
             data-action="punctuation-skill-detail-close"
+            data-autofocus="true"
             aria-label="Close skill detail"
             onClick={() => actions.dispatch('punctuation-skill-detail-close')}
           >

--- a/src/subjects/punctuation/components/punctuation-view-model.js
+++ b/src/subjects/punctuation/components/punctuation-view-model.js
@@ -519,6 +519,154 @@ export function punctuationSkillModalPreferredExample(skillId) {
   return value === 'contrastGood' ? 'contrastGood' : 'workedGood';
 }
 
+// --- Skill Detail modal pedagogy content (client mirror) --------------------
+//
+// U6: the Skill Detail modal renders exactly 3 pedagogy fields per skill —
+// `rule`, `contrastBad`, and one of `workedGood` OR `contrastGood`. The
+// canonical source of these strings is `shared/punctuation/content.js`'s
+// `PUNCTUATION_SKILLS` roster, which the bundle-audit rule forbids from
+// reaching the browser bundle. This map is the client-safe mirror and must
+// stay in lock-step with the shared content's pedagogy fields — a drift test
+// in `tests/punctuation-view-model.test.js` verifies every entry here matches
+// its shared counterpart byte-for-byte.
+//
+// No other field from `PUNCTUATION_SKILLS` ships (no `workedBad`, no `phase`,
+// no `prereq`, no `published`). The modal's 3-field contract is enforced in
+// the component — this map just supplies the raw strings.
+export const PUNCTUATION_SKILL_MODAL_CONTENT = Object.freeze({
+  sentence_endings: Object.freeze({
+    rule: 'Start each sentence with a capital letter and end it with the right mark: full stop, question mark or exclamation mark.',
+    workedGood: 'Where is my reading record?',
+    contrastGood: 'We won the match!',
+    contrastBad: 'We won the match?',
+  }),
+  list_commas: Object.freeze({
+    rule: 'Use commas to separate items in a list. In standard KS2 examples, the final comma before and is usually not needed.',
+    workedGood: 'We packed torches, maps and water.',
+    contrastGood: 'We packed torches, maps and water.',
+    contrastBad: 'We packed, torches maps, and water.',
+  }),
+  apostrophe_contractions: Object.freeze({
+    rule: "Use an apostrophe to show missing letters in contractions, such as can't, didn't and we're.",
+    workedGood: "We can't go because we're late.",
+    contrastGood: "We can't go because we're late.",
+    contrastBad: "We cant go because we're late.",
+  }),
+  apostrophe_possession: Object.freeze({
+    rule: "Use apostrophes to show belonging: the girl's coat, the girls' coats, the children's books.",
+    workedGood: "The girl's coat was on the bench.",
+    contrastGood: "The girls' coats were on the bench.",
+    contrastBad: 'The girls coat was on the bench.',
+  }),
+  speech: Object.freeze({
+    rule: 'Put spoken words inside inverted commas. Use the correct punctuation inside the closing inverted comma when the punctuation belongs to the spoken words.',
+    workedGood: 'Mia said, "Come here."',
+    contrastGood: '"Where are you going?" asked Zara.',
+    contrastBad: '"Where are you going"? asked Zara.',
+  }),
+  fronted_adverbial: Object.freeze({
+    rule: 'Put a comma after a fronted adverbial, such as At last, Before lunch, or Without warning.',
+    workedGood: 'Before lunch, we finished the poster.',
+    contrastGood: 'Before lunch, we finished the poster.',
+    contrastBad: 'Before lunch we, finished the poster.',
+  }),
+  parenthesis: Object.freeze({
+    rule: 'Parenthesis adds extra information. It can be marked with commas, brackets or dashes.',
+    workedGood: 'Mr Patel, our coach, arrived early.',
+    contrastGood: 'Mr Patel (our coach) arrived early.',
+    contrastBad: 'Mr Patel our coach, arrived early.',
+  }),
+  comma_clarity: Object.freeze({
+    rule: 'A comma can make meaning clearer and avoid ambiguity.',
+    workedGood: "Let's eat, Grandma.",
+    contrastGood: 'Most of the time, travellers worry about delays.',
+    contrastBad: 'Most of the time travellers worry about delays.',
+  }),
+  colon_list: Object.freeze({
+    rule: 'A colon can introduce a list after a complete opening clause.',
+    workedGood: 'We needed three things: a torch, a map and a whistle.',
+    contrastGood: 'We needed three things: a torch, a map and a whistle.',
+    contrastBad: 'We needed: three things a torch, a map and a whistle.',
+  }),
+  semicolon: Object.freeze({
+    rule: 'A semi-colon can join two closely related main clauses.',
+    workedGood: 'The rain had stopped; the pitch was still slippery.',
+    contrastGood: 'The rain had stopped; the pitch was still slippery.',
+    contrastBad: 'The rain had stopped; and the pitch was still slippery.',
+  }),
+  dash_clause: Object.freeze({
+    rule: 'A dash can mark a sharp boundary between two closely related main clauses.',
+    workedGood: 'The path was flooded - we took the longer route.',
+    contrastGood: 'The path was flooded - we took the longer route.',
+    contrastBad: 'The path was flooded -and we took the longer route.',
+  }),
+  semicolon_list: Object.freeze({
+    rule: 'Use semi-colons to separate list items when each item already contains commas.',
+    workedGood: 'We visited York, England; Cardiff, Wales; and Belfast, Northern Ireland.',
+    contrastGood: 'We visited York, England; Cardiff, Wales; and Belfast, Northern Ireland.',
+    contrastBad: 'We visited York, England, Cardiff, Wales; and Belfast, Northern Ireland.',
+  }),
+  bullet_points: Object.freeze({
+    rule: 'Use a colon after the opening stem when appropriate, and punctuate bullets consistently.',
+    workedGood: 'Bring:\n- a drink\n- a hat\n- a sketchbook',
+    contrastGood: 'Bring:\n- a drink\n- a hat\n- a sketchbook',
+    contrastBad: 'Bring\n- a drink\n- a hat\n- a sketchbook',
+  }),
+  hyphen: Object.freeze({
+    rule: 'A hyphen can stop a phrase from being misunderstood, such as man-eating shark versus man eating shark.',
+    workedGood: 'We saw a man-eating shark.',
+    contrastGood: 'The little-used room was locked.',
+    contrastBad: 'The little used room was locked.',
+  }),
+});
+
+/**
+ * Client-safe accessor for the three modal pedagogy fields of a skill.
+ * Returns `null` for unknown / non-string skill ids so the caller can short-
+ * circuit the render rather than leaking a rogue payload. Pairs with
+ * `punctuationSkillModalPreferredExample` — the caller chooses
+ * `workedGood` vs `contrastGood` and pipes the selection through `rule` +
+ * `contrastBad` + the chosen example.
+ */
+export function punctuationSkillModalContent(skillId) {
+  if (typeof skillId !== 'string' || !skillId) return null;
+  const entry = PUNCTUATION_SKILL_MODAL_CONTENT[skillId];
+  return entry || null;
+}
+
+// --- Multi-skill paragraph caveat -------------------------------------------
+
+// U6: skills that appear in at least one `PUNCTUATION_ITEMS` entry whose
+// `skillIds.length > 1`. When the modal opens on one of these, the Practise
+// tab renders a child-facing footnote — "Some practice questions may also
+// include other punctuation skills." — so a learner who chose Guided focus
+// on (say) Speech isn't surprised when a paragraph-repair item also tests
+// Fronted Adverbials. Derived by hand from the cross-skill rows in
+// `shared/punctuation/content.js`'s PUNCTUATION_ITEMS:
+//   sp_fa_transfer_at_last_speech → speech + fronted_adverbial
+//   cl_lc_transfer_toolkit        → colon_list + list_commas
+//   pg_fronted_speech             → fronted_adverbial + speech
+//   pg_parenthesis_speech         → parenthesis + speech
+//   pg_colon_semicolon            → colon_list + semicolon
+//   pg_apostrophe_mix             → apostrophe_contractions + apostrophe_possession
+// A drift test in `tests/punctuation-view-model.test.js` verifies this set
+// matches the live multi-skill items when the shared content evolves.
+const PUNCTUATION_MULTI_SKILL_ITEM_SKILLS = Object.freeze(new Set([
+  'speech',
+  'fronted_adverbial',
+  'colon_list',
+  'list_commas',
+  'parenthesis',
+  'semicolon',
+  'apostrophe_contractions',
+  'apostrophe_possession',
+]));
+
+export function punctuationSkillHasMultiSkillItems(skillId) {
+  if (typeof skillId !== 'string' || !skillId) return false;
+  return PUNCTUATION_MULTI_SKILL_ITEM_SKILLS.has(skillId);
+}
+
 // --- Dashboard model builder -----------------------------------------------
 
 function safeNumber(value, fallback = 0) {

--- a/src/subjects/punctuation/components/punctuation-view-model.js
+++ b/src/subjects/punctuation/components/punctuation-view-model.js
@@ -523,12 +523,22 @@ export function punctuationSkillModalPreferredExample(skillId) {
 //
 // U6: the Skill Detail modal renders exactly 3 pedagogy fields per skill —
 // `rule`, `contrastBad`, and one of `workedGood` OR `contrastGood`. The
-// canonical source of these strings is `shared/punctuation/content.js`'s
+// canonical source for `rule` + `contrastBad` is `shared/punctuation/content.js`'s
 // `PUNCTUATION_SKILLS` roster, which the bundle-audit rule forbids from
-// reaching the browser bundle. This map is the client-safe mirror and must
-// stay in lock-step with the shared content's pedagogy fields — a drift test
-// in `tests/punctuation-view-model.test.js` verifies every entry here matches
-// its shared counterpart byte-for-byte.
+// reaching the browser bundle. The two example fields (`workedGood` +
+// `contrastGood`) are authored FRESH for the client mirror: for several
+// skills the shared `workedGood` / `contrastGood` are byte-for-byte identical
+// to `PUNCTUATION_ITEMS.accepted[*]` strings (a learner would see the exact
+// answer string in the Modal before a Practise round that expects them to
+// produce it). The client mirror deliberately diverges on the two example
+// fields so no rendered example collides with any accepted-answer string
+// for the owning skill. A red-team test in
+// `tests/punctuation-view-model.test.js` guards the disjoint property; a
+// narrower drift test still pins `rule` + `contrastBad` byte-for-byte.
+//
+// Child register: rules and examples use Year 3-5 vocabulary. No adult
+// register terms ("main clause", "fronted adverbial", "opening clause") —
+// those live only in the shared content for the marking engine.
 //
 // No other field from `PUNCTUATION_SKILLS` ships (no `workedBad`, no `phase`,
 // no `prereq`, no `published`). The modal's 3-field contract is enforced in
@@ -542,8 +552,8 @@ export const PUNCTUATION_SKILL_MODAL_CONTENT = Object.freeze({
   }),
   list_commas: Object.freeze({
     rule: 'Use commas to separate items in a list. In standard KS2 examples, the final comma before and is usually not needed.',
-    workedGood: 'We packed torches, maps and water.',
-    contrastGood: 'We packed torches, maps and water.',
+    workedGood: 'The team brought bats, balls and cones.',
+    contrastGood: 'The team brought bats, balls and cones.',
     contrastBad: 'We packed, torches maps, and water.',
   }),
   apostrophe_contractions: Object.freeze({
@@ -565,7 +575,7 @@ export const PUNCTUATION_SKILL_MODAL_CONTENT = Object.freeze({
     contrastBad: '"Where are you going"? asked Zara.',
   }),
   fronted_adverbial: Object.freeze({
-    rule: 'Put a comma after a fronted adverbial, such as At last, Before lunch, or Without warning.',
+    rule: 'Put a comma after the opening phrase that tells when, where, or how the action happens.',
     workedGood: 'Before lunch, we finished the poster.',
     contrastGood: 'Before lunch, we finished the poster.',
     contrastBad: 'Before lunch we, finished the poster.',
@@ -579,43 +589,43 @@ export const PUNCTUATION_SKILL_MODAL_CONTENT = Object.freeze({
   comma_clarity: Object.freeze({
     rule: 'A comma can make meaning clearer and avoid ambiguity.',
     workedGood: "Let's eat, Grandma.",
-    contrastGood: 'Most of the time, travellers worry about delays.',
+    contrastGood: 'After tea, the garden looked peaceful.',
     contrastBad: 'Most of the time travellers worry about delays.',
   }),
   colon_list: Object.freeze({
-    rule: 'A colon can introduce a list after a complete opening clause.',
-    workedGood: 'We needed three things: a torch, a map and a whistle.',
-    contrastGood: 'We needed three things: a torch, a map and a whistle.',
+    rule: 'A colon comes before a list, after a short sentence.',
+    workedGood: 'The bag held four items: a ruler, a pencil, a rubber and a book.',
+    contrastGood: 'The bag held four items: a ruler, a pencil, a rubber and a book.',
     contrastBad: 'We needed: three things a torch, a map and a whistle.',
   }),
   semicolon: Object.freeze({
-    rule: 'A semi-colon can join two closely related main clauses.',
-    workedGood: 'The rain had stopped; the pitch was still slippery.',
-    contrastGood: 'The rain had stopped; the pitch was still slippery.',
+    rule: 'A semicolon joins two short sentences that go together.',
+    workedGood: 'The bell rang; the class fell silent.',
+    contrastGood: 'The bell rang; the class fell silent.',
     contrastBad: 'The rain had stopped; and the pitch was still slippery.',
   }),
   dash_clause: Object.freeze({
-    rule: 'A dash can mark a sharp boundary between two closely related main clauses.',
-    workedGood: 'The path was flooded - we took the longer route.',
-    contrastGood: 'The path was flooded - we took the longer route.',
+    rule: 'A dash shows a sharp pause between two short sentences.',
+    workedGood: 'The bus was late - we walked instead.',
+    contrastGood: 'The bus was late - we walked instead.',
     contrastBad: 'The path was flooded -and we took the longer route.',
   }),
   semicolon_list: Object.freeze({
     rule: 'Use semi-colons to separate list items when each item already contains commas.',
-    workedGood: 'We visited York, England; Cardiff, Wales; and Belfast, Northern Ireland.',
-    contrastGood: 'We visited York, England; Cardiff, Wales; and Belfast, Northern Ireland.',
+    workedGood: 'We invited Ava, our captain; Zane, our goalie; and Priya, our coach.',
+    contrastGood: 'We invited Ava, our captain; Zane, our goalie; and Priya, our coach.',
     contrastBad: 'We visited York, England, Cardiff, Wales; and Belfast, Northern Ireland.',
   }),
   bullet_points: Object.freeze({
     rule: 'Use a colon after the opening stem when appropriate, and punctuate bullets consistently.',
-    workedGood: 'Bring:\n- a drink\n- a hat\n- a sketchbook',
-    contrastGood: 'Bring:\n- a drink\n- a hat\n- a sketchbook',
+    workedGood: 'Pack:\n- your shoes\n- your bottle\n- your book',
+    contrastGood: 'Pack:\n- your shoes\n- your bottle\n- your book',
     contrastBad: 'Bring\n- a drink\n- a hat\n- a sketchbook',
   }),
   hyphen: Object.freeze({
     rule: 'A hyphen can stop a phrase from being misunderstood, such as man-eating shark versus man eating shark.',
     workedGood: 'We saw a man-eating shark.',
-    contrastGood: 'The little-used room was locked.',
+    contrastGood: 'The ten-year-old jumper still fits.',
     contrastBad: 'The little used room was locked.',
   }),
 });

--- a/styles/app.css
+++ b/styles/app.css
@@ -9602,3 +9602,50 @@ html { scroll-behavior: smooth; }
     animation: none !important;
   }
 }
+
+/* ---------- Phase 3 U6 · Punctuation Skill Detail modal (minimal) ----------
+   Review-follower MEDIUM 4: co-ship the smallest-surface CSS needed for the
+   modal to be tappable + identifiable. Full styling sweep lands in U10. The
+   Bellstorm top border is the subject accent; the 44x44 close button meets
+   the KS2 touch-target floor; the reduced-motion guard is defence-in-depth
+   for the scrim/modal animations U10 will author. */
+.punctuation-skill-modal-scrim {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 24px;
+  background: rgba(15, 22, 32, 0.48);
+  z-index: 100;
+}
+.punctuation-skill-modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: transparent;
+  z-index: 1;
+}
+.punctuation-skill-modal {
+  position: relative;
+  z-index: 2;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-top: 3px solid #B8873F; /* Bellstorm Coast subject accent */
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  width: 100%;
+  max-width: 600px;
+  max-height: calc(100vh - 48px);
+  overflow: auto;
+  padding: 28px 32px 22px;
+}
+.punctuation-skill-modal-close {
+  min-width: 44px;
+  min-height: 44px; /* KS2 touch target floor */
+}
+@media (prefers-reduced-motion: reduce) {
+  .punctuation-skill-modal-scrim,
+  .punctuation-skill-modal {
+    animation: none;
+  }
+}

--- a/tests/punctuation-view-model.test.js
+++ b/tests/punctuation-view-model.test.js
@@ -734,20 +734,78 @@ test('U5 drift: PUNCTUATION_CLIENT_SKILL_IDS stays in lock-step with PUNCTUATION
 // ---------------------------------------------------------------------------
 // U6 — PUNCTUATION_SKILL_MODAL_CONTENT drift against shared/punctuation/content.js
 // ---------------------------------------------------------------------------
+//
+// Review-follower HIGH 1 relaxation. The client mirror intentionally diverges
+// from the shared source on TWO axes:
+//
+//   1. `workedGood` + `contrastGood` — 6 skills had shared values that were
+//      byte-for-byte identical to a `PUNCTUATION_ITEMS.accepted[*]` string
+//      for that skill (plus `hyphen.contrastGood`). The Modal would leak
+//      accepted answers before a Practise round. The mirror authors fresh
+//      KS2-friendly examples that are disjoint from the item bank.
+//   2. `rule` — 4 skills (semicolon, colon_list, dash_clause,
+//      fronted_adverbial) had shared rules phrased in adult register
+//      ("main clauses", "opening clause", "fronted adverbial"). The
+//      mirror rewrites these in Year 3-5 child register.
+//
+// `contrastBad` stays canonical (the Learn tab's "Common mix-up" shows the
+// specific pattern the marking engine also penalises — it must match the
+// marking-side source exactly). The red-team disjoint test below replaces
+// the blanket drift test for the two example fields + rule.
 
-test('U6 drift: PUNCTUATION_SKILL_MODAL_CONTENT mirrors PUNCTUATION_SKILLS pedagogy fields byte-for-byte', () => {
-  // The modal's client-safe mirror must match the shared source exactly. A
-  // drift here would mean the Learn tab renders stale copy against an updated
-  // shared ruleset. Each of the 4 modal fields (rule, workedGood, contrastGood,
-  // contrastBad) is compared string-equality.
+test('U6 drift: PUNCTUATION_SKILL_MODAL_CONTENT.contrastBad mirrors PUNCTUATION_SKILLS byte-for-byte', () => {
+  // `contrastBad` stays canonical — the Learn tab's "Common mix-up" must
+  // match the shared source (which the marking engine also consumes).
   for (const skill of PUNCTUATION_SKILLS) {
     const mirror = PUNCTUATION_SKILL_MODAL_CONTENT[skill.id];
     assert.ok(mirror, `client mirror missing entry for ${skill.id}`);
-    for (const field of ['rule', 'workedGood', 'contrastGood', 'contrastBad']) {
-      assert.strictEqual(
-        mirror[field],
-        skill[field],
-        `PUNCTUATION_SKILL_MODAL_CONTENT.${skill.id}.${field} drifted from shared/punctuation/content.js`,
+    assert.strictEqual(
+      mirror.contrastBad,
+      skill.contrastBad,
+      `PUNCTUATION_SKILL_MODAL_CONTENT.${skill.id}.contrastBad drifted from shared/punctuation/content.js`,
+    );
+  }
+});
+
+test('U6 drift: PUNCTUATION_SKILL_MODAL_CONTENT.rule is non-empty, child-safe, and within reasonable length for every skill', () => {
+  // The mirror's rule field may diverge from the shared source (child
+  // register rewrite). But every rule must be non-empty, a plain string,
+  // within a sensible length budget, and pass the forbidden-term filter so
+  // no adult jargon leaks via this axis.
+  for (const skill of PUNCTUATION_SKILLS) {
+    const mirror = PUNCTUATION_SKILL_MODAL_CONTENT[skill.id];
+    assert.ok(mirror, `client mirror missing entry for ${skill.id}`);
+    assert.equal(typeof mirror.rule, 'string');
+    assert.ok(mirror.rule.length > 0, `${skill.id}.rule must be non-empty`);
+    assert.ok(mirror.rule.length <= 240, `${skill.id}.rule must fit KS2 reading budget`);
+    assert.ok(
+      isPunctuationChildCopy(mirror.rule),
+      `${skill.id}.rule contains a forbidden term: ${JSON.stringify(mirror.rule)}`,
+    );
+  }
+});
+
+test('U6 red-team: PUNCTUATION_SKILL_MODAL_CONTENT example fields are disjoint from PUNCTUATION_ITEMS.accepted[*] for the owning skill', () => {
+  // Review-follower HIGH 1 — the modal example fields (workedGood +
+  // contrastGood) AND the common mix-up (contrastBad) must NOT be
+  // byte-for-byte identical to any `accepted[*]` string from a
+  // PUNCTUATION_ITEMS entry that includes this skill. Otherwise the Learn
+  // tab leaks an accepted answer before the learner has attempted a
+  // Practise round on it.
+  for (const [skillId, mirror] of Object.entries(PUNCTUATION_SKILL_MODAL_CONTENT)) {
+    const acceptedSet = new Set();
+    for (const item of PUNCTUATION_ITEMS) {
+      if (!Array.isArray(item.skillIds) || !item.skillIds.includes(skillId)) continue;
+      if (!Array.isArray(item.accepted)) continue;
+      for (const entry of item.accepted) acceptedSet.add(entry);
+    }
+    for (const field of ['workedGood', 'contrastGood', 'contrastBad']) {
+      const value = mirror[field];
+      assert.equal(typeof value, 'string');
+      assert.ok(value.length > 0, `${skillId}.${field} must be non-empty`);
+      assert.ok(
+        !acceptedSet.has(value),
+        `${skillId}.${field} ("${value}") leaks a PUNCTUATION_ITEMS.accepted[*] string — the Modal would render an accepted answer. Author a fresh KS2-friendly example.`,
       );
     }
   }

--- a/tests/punctuation-view-model.test.js
+++ b/tests/punctuation-view-model.test.js
@@ -24,6 +24,7 @@ import {
   PUNCTUATION_MAP_STATUS_FILTER_IDS,
   PUNCTUATION_PRIMARY_MODE_CARDS,
   PUNCTUATION_PRIMARY_MODE_IDS,
+  PUNCTUATION_SKILL_MODAL_CONTENT,
   PUNCTUATION_SKILL_MODAL_PREFERRED_EXAMPLE,
   bellstormSceneForPhase,
   buildPunctuationDashboardModel,
@@ -38,10 +39,12 @@ import {
   punctuationMonsterDisplayName,
   punctuationPhaseLabel,
   punctuationPrimaryModeFromPrefs,
+  punctuationSkillHasMultiSkillItems,
+  punctuationSkillModalContent,
   punctuationSkillModalPreferredExample,
 } from '../src/subjects/punctuation/components/punctuation-view-model.js';
 import { MONSTERS_BY_SUBJECT } from '../src/platform/game/monsters.js';
-import { PUNCTUATION_CLUSTERS } from '../shared/punctuation/content.js';
+import { PUNCTUATION_CLUSTERS, PUNCTUATION_ITEMS, PUNCTUATION_SKILLS } from '../shared/punctuation/content.js';
 
 // ---------------------------------------------------------------------------
 // composeIsDisabled (R11) — moved from PunctuationPracticeSurface.jsx in U1.
@@ -726,4 +729,112 @@ test('U5 drift: PUNCTUATION_CLIENT_SKILL_IDS stays in lock-step with PUNCTUATION
       `${skill.id} is in PUNCTUATION_CLIENT_SKILLS but not in PUNCTUATION_CLIENT_SKILL_IDS`,
     );
   }
+});
+
+// ---------------------------------------------------------------------------
+// U6 — PUNCTUATION_SKILL_MODAL_CONTENT drift against shared/punctuation/content.js
+// ---------------------------------------------------------------------------
+
+test('U6 drift: PUNCTUATION_SKILL_MODAL_CONTENT mirrors PUNCTUATION_SKILLS pedagogy fields byte-for-byte', () => {
+  // The modal's client-safe mirror must match the shared source exactly. A
+  // drift here would mean the Learn tab renders stale copy against an updated
+  // shared ruleset. Each of the 4 modal fields (rule, workedGood, contrastGood,
+  // contrastBad) is compared string-equality.
+  for (const skill of PUNCTUATION_SKILLS) {
+    const mirror = PUNCTUATION_SKILL_MODAL_CONTENT[skill.id];
+    assert.ok(mirror, `client mirror missing entry for ${skill.id}`);
+    for (const field of ['rule', 'workedGood', 'contrastGood', 'contrastBad']) {
+      assert.strictEqual(
+        mirror[field],
+        skill[field],
+        `PUNCTUATION_SKILL_MODAL_CONTENT.${skill.id}.${field} drifted from shared/punctuation/content.js`,
+      );
+    }
+  }
+});
+
+test('U6 drift: PUNCTUATION_SKILL_MODAL_CONTENT covers every published skill', () => {
+  // Symmetric direction: no stale client entry whose source was removed.
+  const sharedIds = new Set(PUNCTUATION_SKILLS.map((skill) => skill.id));
+  for (const id of Object.keys(PUNCTUATION_SKILL_MODAL_CONTENT)) {
+    assert.ok(
+      sharedIds.has(id),
+      `${id} is in PUNCTUATION_SKILL_MODAL_CONTENT but not in shared PUNCTUATION_SKILLS`,
+    );
+  }
+  assert.equal(
+    Object.keys(PUNCTUATION_SKILL_MODAL_CONTENT).length,
+    PUNCTUATION_SKILLS.length,
+    'client mirror count diverged from shared source',
+  );
+});
+
+test('U6 drift: PUNCTUATION_SKILL_MODAL_CONTENT entries expose only 4 pedagogy keys', () => {
+  // No other field (workedBad, phase, prereq, published, clusterId, name, id)
+  // leaks into the modal mirror. Keeps the modal payload structurally
+  // incapable of rendering an adult-surface key.
+  const allowedKeys = new Set(['rule', 'workedGood', 'contrastGood', 'contrastBad']);
+  for (const [id, entry] of Object.entries(PUNCTUATION_SKILL_MODAL_CONTENT)) {
+    for (const key of Object.keys(entry)) {
+      assert.ok(
+        allowedKeys.has(key),
+        `${id} exposes disallowed key "${key}" — modal must ship only rule + workedGood + contrastGood + contrastBad`,
+      );
+    }
+  }
+});
+
+test('U6: punctuationSkillModalContent returns null for unknown ids', () => {
+  assert.strictEqual(punctuationSkillModalContent(''), null);
+  assert.strictEqual(punctuationSkillModalContent(null), null);
+  assert.strictEqual(punctuationSkillModalContent('not_a_skill'), null);
+});
+
+test('U6: punctuationSkillModalContent returns the 4-field entry for a published skill', () => {
+  const entry = punctuationSkillModalContent('speech');
+  assert.ok(entry);
+  assert.equal(typeof entry.rule, 'string');
+  assert.equal(typeof entry.workedGood, 'string');
+  assert.equal(typeof entry.contrastGood, 'string');
+  assert.equal(typeof entry.contrastBad, 'string');
+});
+
+// ---------------------------------------------------------------------------
+// U6 — punctuationSkillHasMultiSkillItems drift against PUNCTUATION_ITEMS.
+// ---------------------------------------------------------------------------
+
+test('U6 drift: punctuationSkillHasMultiSkillItems matches every multi-skill PUNCTUATION_ITEMS entry', () => {
+  // Derive the expected set from the live shared source — every skill that
+  // appears in an item with `skillIds.length > 1`. The helper must report
+  // true for exactly that set and false for every other published skill.
+  const expected = new Set();
+  for (const item of PUNCTUATION_ITEMS) {
+    if (Array.isArray(item.skillIds) && item.skillIds.length > 1) {
+      for (const id of item.skillIds) expected.add(id);
+    }
+  }
+  // Every skill in the expected set must return true.
+  for (const id of expected) {
+    assert.strictEqual(
+      punctuationSkillHasMultiSkillItems(id),
+      true,
+      `${id} appears in a multi-skill PUNCTUATION_ITEMS entry but helper returned false`,
+    );
+  }
+  // Every published skill NOT in the expected set must return false.
+  for (const skill of PUNCTUATION_SKILLS) {
+    if (expected.has(skill.id)) continue;
+    assert.strictEqual(
+      punctuationSkillHasMultiSkillItems(skill.id),
+      false,
+      `${skill.id} has no multi-skill PUNCTUATION_ITEMS entry but helper returned true`,
+    );
+  }
+});
+
+test('U6: punctuationSkillHasMultiSkillItems returns false for non-string / empty / unknown input', () => {
+  assert.strictEqual(punctuationSkillHasMultiSkillItems(''), false);
+  assert.strictEqual(punctuationSkillHasMultiSkillItems(null), false);
+  assert.strictEqual(punctuationSkillHasMultiSkillItems(undefined), false);
+  assert.strictEqual(punctuationSkillHasMultiSkillItems('not_a_skill'), false);
 });

--- a/tests/react-punctuation-scene.test.js
+++ b/tests/react-punctuation-scene.test.js
@@ -10,8 +10,11 @@ import {
   PUNCTUATION_CHILD_FORBIDDEN_TERMS,
   PUNCTUATION_MAP_MONSTER_FILTER_IDS,
   PUNCTUATION_MAP_STATUS_FILTER_IDS,
+  PUNCTUATION_SKILL_MODAL_CONTENT,
+  PUNCTUATION_SKILL_MODAL_PREFERRED_EXAMPLE,
 } from '../src/subjects/punctuation/components/punctuation-view-model.js';
 import { PUNCTUATION_MODES } from '../src/subjects/punctuation/service-contract.js';
+import { FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS } from './helpers/forbidden-keys.mjs';
 
 function createPunctuationHarness() {
   return createAppHarness({
@@ -735,4 +738,318 @@ test('punctuation Map scene live-region count reflects a monster filter flip', (
     /role="status"[^>]*>Showing 5 of 14 skills\.<|>Showing 5 of 14 skills\.<[^>]*role="status"/,
     'live-region summary must reflect the narrowed monster filter',
   );
+});
+
+// ---------------------------------------------------------------------------
+// U6 — Punctuation Skill Detail modal. Renders on top of the Map scene when
+// `mapUi.detailOpenSkillId` is a published Punctuation skill id. Two tabs
+// (Learn / Practise) consume U5's `mapUi.detailTab` state. "Practise this"
+// dispatches `punctuation-start` with `{ mode: 'guided', guidedSkillId,
+// roundLength: '4' }` — cluster-mode is explicitly verified against (plan
+// adv-219-005 deepening against `shared/punctuation/service.js:1281-1283`).
+// ---------------------------------------------------------------------------
+
+function openSkillDetailForSpeech(harness) {
+  openMapScene(harness);
+  harness.dispatch('punctuation-skill-detail-open', { skillId: 'speech' });
+}
+
+// React escapes `"` as `&quot;` and `'` as `&#x27;` in SSR output. Tests that
+// compare raw pedagogy strings against rendered HTML must escape through the
+// same transformation so the assertion is byte-for-byte comparable. We only
+// handle the five characters React escapes; any future escape drift would
+// show up as a false-negative here and alert us to extend the helper.
+function escapeForReactSsr(text) {
+  return String(text)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;');
+}
+
+test('punctuation Skill Detail modal renders with role=dialog, aria-modal, labelledby', () => {
+  const harness = createPunctuationHarness();
+  openSkillDetailForSpeech(harness);
+  const html = harness.render();
+
+  // Scrim carries the dialog semantics (learning #6 — SSR cannot assert focus
+  // trap, only static ARIA).
+  assert.match(html, /role="dialog"/);
+  assert.match(html, /aria-modal="true"/);
+  assert.match(html, /aria-labelledby="punctuation-skill-detail-title"/);
+  assert.match(
+    html,
+    /id="punctuation-skill-detail-title"[^>]*>Inverted commas and speech punctuation</,
+    'modal title must read the speech skill name',
+  );
+});
+
+test('punctuation Skill Detail modal renders exactly 3 pedagogy fields per skill (rule + contrastBad + preferred example)', () => {
+  const harness = createPunctuationHarness();
+  openSkillDetailForSpeech(harness);
+  const html = harness.render();
+
+  const speechContent = PUNCTUATION_SKILL_MODAL_CONTENT.speech;
+  // rule + contrastBad + workedGood must appear. contrastGood (different from
+  // workedGood for speech) must NOT appear in the Learn body. Every raw
+  // string runs through the React-SSR escape helper first so the assertion
+  // matches the actual rendered HTML byte-for-byte.
+  assert.ok(html.includes(escapeForReactSsr(speechContent.rule)), 'rule must render');
+  assert.ok(html.includes(escapeForReactSsr(speechContent.contrastBad)), 'contrastBad must render');
+  assert.ok(
+    html.includes(escapeForReactSsr(speechContent.workedGood)),
+    'workedGood must render for speech (default preferred example)',
+  );
+  // For speech, workedGood !== contrastGood, so the absence check is rigorous.
+  assert.notStrictEqual(speechContent.workedGood, speechContent.contrastGood);
+  assert.ok(
+    !html.includes(escapeForReactSsr(speechContent.contrastGood)),
+    'contrastGood must NOT render when preferred example is workedGood',
+  );
+});
+
+test('punctuation Skill Detail modal overrides to workedGood for comma_clarity (plan-specified)', () => {
+  const harness = createPunctuationHarness();
+  openMapScene(harness);
+  harness.dispatch('punctuation-skill-detail-open', { skillId: 'comma_clarity' });
+  const html = harness.render();
+
+  const content = PUNCTUATION_SKILL_MODAL_CONTENT.comma_clarity;
+  // comma_clarity's `contrastGood` is byte-for-byte identical to
+  // `cc_insert_time_travellers.accepted[0]`. The override to `workedGood`
+  // ("Let's eat, Grandma.") ensures the learner-facing modal does not leak
+  // the accepted answer string (plan R13 + Key Technical Decisions).
+  assert.equal(PUNCTUATION_SKILL_MODAL_PREFERRED_EXAMPLE.comma_clarity, 'workedGood');
+  assert.ok(
+    html.includes(escapeForReactSsr(content.workedGood)),
+    'workedGood override must render',
+  );
+  assert.ok(
+    !html.includes(escapeForReactSsr(content.contrastGood)),
+    'contrastGood must NOT render when override is workedGood (comma_clarity)',
+  );
+});
+
+test('punctuation Skill Detail modal "Practise this" dispatches Guided + guidedSkillId (plan R3)', () => {
+  const harness = createPunctuationHarness();
+  openSkillDetailForSpeech(harness);
+  // Flip to the Practise tab so the "Practise this" button appears.
+  harness.dispatch('punctuation-skill-detail-tab', { value: 'practise' });
+  const html = harness.render();
+  assert.match(
+    html,
+    /<button[^>]*data-punctuation-start-skill[^>]*data-skill-id="speech"[^>]*>Practise this<\/button>/,
+    '"Practise this" button must mark the skill id',
+  );
+
+  // Simulate the button's dispatch chain: close modal, then start.
+  harness.dispatch('punctuation-skill-detail-close');
+  harness.dispatch('punctuation-start', {
+    mode: 'guided',
+    guidedSkillId: 'speech',
+    roundLength: '4',
+  });
+
+  // Paired state-level assertion: catches the cluster-mode silent-drop bug.
+  // If a future refactor reverts to `{ mode: 'speech', skillId: 'speech' }`,
+  // `prefs.mode !== 'guided'` would null the guidedSkillId in the service.
+  const state = harness.store.getState().subjectUi.punctuation;
+  assert.strictEqual(state.session.mode, 'guided', 'session must land in guided mode');
+  assert.strictEqual(
+    state.session.guidedSkillId,
+    'speech',
+    'session must pin guidedSkillId to the tapped skill',
+  );
+});
+
+test('punctuation Skill Detail modal "Practise this" pins the correct skill in a multi-skill cluster (apostrophe)', () => {
+  const harness = createPunctuationHarness();
+  openMapScene(harness);
+  // apostrophe cluster contains BOTH apostrophe_contractions AND
+  // apostrophe_possession. The old cluster-mode dispatch would silently pick
+  // either one; Guided-focus must pin the exact skill the learner tapped.
+  harness.dispatch('punctuation-skill-detail-open', { skillId: 'apostrophe_contractions' });
+  harness.dispatch('punctuation-skill-detail-close');
+  harness.dispatch('punctuation-start', {
+    mode: 'guided',
+    guidedSkillId: 'apostrophe_contractions',
+    roundLength: '4',
+  });
+
+  const state = harness.store.getState().subjectUi.punctuation;
+  assert.strictEqual(state.session.mode, 'guided');
+  assert.strictEqual(
+    state.session.guidedSkillId,
+    'apostrophe_contractions',
+    'multi-skill cluster must pin the tapped skill, not the sibling',
+  );
+  assert.notStrictEqual(
+    state.session.guidedSkillId,
+    'apostrophe_possession',
+    'sibling skill must not surface via cluster-mode drift',
+  );
+});
+
+test('punctuation Skill Detail modal regression-locks skill-detail-open state delta (skillId: speech)', () => {
+  const harness = createPunctuationHarness();
+  openMapScene(harness);
+  harness.dispatch('punctuation-skill-detail-open', { skillId: 'speech' });
+  // Paired state assertion — learning #7: a handler that silently drops the
+  // dispatch would show nothing in the HTML AND nothing in state; this check
+  // fails loudly if either slips.
+  assert.strictEqual(
+    harness.store.getState().subjectUi.punctuation.mapUi.detailOpenSkillId,
+    'speech',
+  );
+});
+
+test('punctuation Skill Detail modal close button dispatches skill-detail-close', () => {
+  const harness = createPunctuationHarness();
+  openSkillDetailForSpeech(harness);
+  const openHtml = harness.render();
+  // The close button is authored in the modal with this data-action.
+  assert.match(
+    openHtml,
+    /<button[^>]*data-action="punctuation-skill-detail-close"[^>]*aria-label="Close skill detail">/,
+  );
+
+  harness.dispatch('punctuation-skill-detail-close');
+  assert.strictEqual(
+    harness.store.getState().subjectUi.punctuation.mapUi.detailOpenSkillId,
+    null,
+  );
+});
+
+test('punctuation Skill Detail modal tab switch to Practise mutates detailTab state', () => {
+  const harness = createPunctuationHarness();
+  openSkillDetailForSpeech(harness);
+  harness.dispatch('punctuation-skill-detail-tab', { value: 'practise' });
+  assert.strictEqual(
+    harness.store.getState().subjectUi.punctuation.mapUi.detailTab,
+    'practise',
+  );
+  // Flip back — the regression-lock check for the learn default.
+  harness.dispatch('punctuation-skill-detail-tab', { value: 'learn' });
+  assert.strictEqual(
+    harness.store.getState().subjectUi.punctuation.mapUi.detailTab,
+    'learn',
+  );
+});
+
+test('punctuation Skill Detail modal rejects invalid tab value (handler regression-lock)', () => {
+  const harness = createPunctuationHarness();
+  openSkillDetailForSpeech(harness);
+  // Seed a known state so we can verify the invalid dispatch is a no-op.
+  harness.dispatch('punctuation-skill-detail-tab', { value: 'practise' });
+  assert.strictEqual(
+    harness.store.getState().subjectUi.punctuation.mapUi.detailTab,
+    'practise',
+  );
+  harness.dispatch('punctuation-skill-detail-tab', { value: 'garbage' });
+  // Invalid payload: handler returns false, the store is untouched.
+  assert.strictEqual(
+    harness.store.getState().subjectUi.punctuation.mapUi.detailTab,
+    'practise',
+  );
+});
+
+test('punctuation Skill Detail modal SSR contains none of the 12 FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS', () => {
+  const harness = createPunctuationHarness();
+  openSkillDetailForSpeech(harness);
+  const html = harness.render();
+  // Render both tabs so we cover the Practise body too.
+  harness.dispatch('punctuation-skill-detail-tab', { value: 'practise' });
+  const practiseHtml = harness.render();
+  const combinedHtml = `${html}\n${practiseHtml}`;
+
+  for (const key of FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS) {
+    // Word-boundary match so we don't false-positive on substrings like
+    // "generator" appearing inside "generational" (no such copy in the modal,
+    // but the match is still rigorous against future drift).
+    const pattern = new RegExp(`\\b${key}\\b`);
+    assert.ok(
+      !pattern.test(combinedHtml),
+      `forbidden read-model key "${key}" must not appear in Skill Detail modal HTML`,
+    );
+  }
+});
+
+test('punctuation Skill Detail modal SSR contains no PUNCTUATION_CHILD_FORBIDDEN_TERMS', () => {
+  const harness = createPunctuationHarness();
+  openSkillDetailForSpeech(harness);
+  const learnHtml = harness.render();
+  harness.dispatch('punctuation-skill-detail-tab', { value: 'practise' });
+  const practiseHtml = harness.render();
+
+  // Exclude the Map scene chrome from the scan — the Modal's own HTML is
+  // sufficient for this test's intent. We slice from the modal root.
+  const extractModal = (html) => {
+    const start = html.indexOf('<div class="punctuation-skill-modal-scrim"');
+    return start === -1 ? '' : html.slice(start);
+  };
+  const learnLeaks = forbiddenTermsInHtml(extractModal(learnHtml));
+  const practiseLeaks = forbiddenTermsInHtml(extractModal(practiseHtml));
+  assert.deepEqual(learnLeaks, [], `forbidden terms leaked in Learn tab: ${learnLeaks.join(', ')}`);
+  assert.deepEqual(practiseLeaks, [], `forbidden terms leaked in Practise tab: ${practiseLeaks.join(', ')}`);
+});
+
+test('punctuation Skill Detail modal "Practise this" disables under degraded availability (R11)', () => {
+  const harness = createPunctuationHarness();
+  openSkillDetailForSpeech(harness);
+  harness.store.updateSubjectUi('punctuation', {
+    availability: { status: 'degraded', code: 'runtime_degraded', message: 'paused' },
+  });
+  harness.dispatch('punctuation-skill-detail-tab', { value: 'practise' });
+  const html = harness.render();
+  assert.match(
+    html,
+    /<button[^>]*disabled[^>]*data-punctuation-start-skill[^>]*>Practise this<\/button>/,
+    '"Practise this" must be disabled under degraded availability',
+  );
+});
+
+test('punctuation Skill Detail modal renders multi-skill footnote for Speech (paragraph caveat)', () => {
+  const harness = createPunctuationHarness();
+  openSkillDetailForSpeech(harness);
+  // speech appears in sp_fa_transfer_at_last_speech + pg_fronted_speech +
+  // pg_parenthesis_speech — i.e. PUNCTUATION_ITEMS entries with
+  // `skillIds.length > 1`. The caveat footnote must render on Practise.
+  harness.dispatch('punctuation-skill-detail-tab', { value: 'practise' });
+  const html = harness.render();
+  assert.match(
+    html,
+    /Some practice questions may also include other punctuation skills\./,
+    'Speech must surface the multi-skill caveat footnote',
+  );
+  assert.match(html, /data-punctuation-skill-modal-multi-skill-note="true"/);
+});
+
+test('punctuation Skill Detail modal does NOT render multi-skill footnote for a single-skill skill (hyphen)', () => {
+  const harness = createPunctuationHarness();
+  openMapScene(harness);
+  harness.dispatch('punctuation-skill-detail-open', { skillId: 'hyphen' });
+  harness.dispatch('punctuation-skill-detail-tab', { value: 'practise' });
+  const html = harness.render();
+  // hyphen only appears in single-skill PUNCTUATION_ITEMS entries — no
+  // caveat footnote in the HTML.
+  assert.doesNotMatch(
+    html,
+    /Some practice questions may also include other punctuation skills\./,
+    'hyphen must NOT surface the multi-skill caveat footnote',
+  );
+});
+
+test('punctuation Skill Detail modal only renders when mapUi.detailOpenSkillId is set', () => {
+  const harness = createPunctuationHarness();
+  openMapScene(harness);
+  const closedHtml = harness.render();
+  // No modal in the Map scene default render.
+  assert.doesNotMatch(closedHtml, /role="dialog"/);
+  assert.doesNotMatch(closedHtml, /data-punctuation-skill-modal/);
+
+  harness.dispatch('punctuation-skill-detail-open', { skillId: 'speech' });
+  const openHtml = harness.render();
+  assert.match(openHtml, /role="dialog"/);
+  assert.match(openHtml, /data-punctuation-skill-modal/);
 });

--- a/tests/react-punctuation-scene.test.js
+++ b/tests/react-punctuation-scene.test.js
@@ -773,15 +773,39 @@ test('punctuation Skill Detail modal renders with role=dialog, aria-modal, label
   openSkillDetailForSpeech(harness);
   const html = harness.render();
 
-  // Scrim carries the dialog semantics (learning #6 — SSR cannot assert focus
-  // trap, only static ARIA).
+  // Review-follower HIGH 3: the inner `.punctuation-skill-modal` card carries
+  // the dialog semantics — scrim is a click-absorber only, without any ARIA
+  // role. The inner-card match is paired with an id-suffix assertion to
+  // confirm the per-skill-scoped `aria-labelledby` (learning #6 — SSR cannot
+  // assert focus trap, only static ARIA).
   assert.match(html, /role="dialog"/);
   assert.match(html, /aria-modal="true"/);
-  assert.match(html, /aria-labelledby="punctuation-skill-detail-title"/);
+  assert.match(html, /aria-labelledby="punctuation-skill-detail-title-speech"/);
   assert.match(
     html,
-    /id="punctuation-skill-detail-title"[^>]*>Inverted commas and speech punctuation</,
-    'modal title must read the speech skill name',
+    /id="punctuation-skill-detail-title-speech"[^>]*>Inverted commas and speech punctuation</,
+    'modal title must read the speech skill name and carry the per-skill-scoped id',
+  );
+  // The scrim must NOT itself be a dialog — only the inner card. Paired
+  // state-level assertion catches any regression that re-hoists role=dialog
+  // onto the scrim.
+  assert.match(
+    html,
+    /<div class="punctuation-skill-modal-scrim"(?:[^>]*)>/,
+    'scrim element must render',
+  );
+  assert.doesNotMatch(
+    html,
+    /<div class="punctuation-skill-modal-scrim"[^>]*role="dialog"/,
+    'scrim must NOT carry role=dialog — dialog semantics live on the inner card',
+  );
+  // Close button carries data-autofocus for the dialog-focus contract
+  // (review-follower HIGH 2). SSR cannot verify the useEffect fallback
+  // actually focused — only that the attribute landed for AT announcement.
+  assert.match(
+    html,
+    /<button[^>]*data-action="punctuation-skill-detail-close"[^>]*data-autofocus="true"/,
+    'Close button must carry data-autofocus="true" for dialog focus announcement',
   );
 });
 
@@ -816,15 +840,21 @@ test('punctuation Skill Detail modal overrides to workedGood for comma_clarity (
   const html = harness.render();
 
   const content = PUNCTUATION_SKILL_MODAL_CONTENT.comma_clarity;
-  // comma_clarity's `contrastGood` is byte-for-byte identical to
-  // `cc_insert_time_travellers.accepted[0]`. The override to `workedGood`
-  // ("Let's eat, Grandma.") ensures the learner-facing modal does not leak
-  // the accepted answer string (plan R13 + Key Technical Decisions).
+  // comma_clarity's shared `contrastGood` was byte-for-byte identical to
+  // `cc_insert_time_travellers.accepted[0]`. The `PUNCTUATION_SKILL_MODAL_PREFERRED_EXAMPLE`
+  // override to `workedGood` ("Let's eat, Grandma.") is the primary guard;
+  // the client-mirror rewrite of `contrastGood` to a fresh example (which
+  // the red-team disjoint test in `tests/punctuation-view-model.test.js`
+  // asserts) is the belt-and-braces guard that neither example field can
+  // leak an accepted answer (plan R13 + review-follower HIGH 1).
   assert.equal(PUNCTUATION_SKILL_MODAL_PREFERRED_EXAMPLE.comma_clarity, 'workedGood');
   assert.ok(
     html.includes(escapeForReactSsr(content.workedGood)),
     'workedGood override must render',
   );
+  // The mirror's new contrastGood (disjoint from accepted[*]) must NOT
+  // render when the preferred example is workedGood.
+  assert.notStrictEqual(content.workedGood, content.contrastGood);
   assert.ok(
     !html.includes(escapeForReactSsr(content.contrastGood)),
     'contrastGood must NOT render when override is workedGood (comma_clarity)',
@@ -843,13 +873,16 @@ test('punctuation Skill Detail modal "Practise this" dispatches Guided + guidedS
     '"Practise this" button must mark the skill id',
   );
 
-  // Simulate the button's dispatch chain: close modal, then start.
-  harness.dispatch('punctuation-skill-detail-close');
+  // Simulate the button's dispatch chain in the review-follower-inverted
+  // order: start FIRST, then close. On success the Modal unmounts
+  // naturally alongside the Map scene; on failure it stays open so the
+  // learner keeps their context (review-follower adv-231-003).
   harness.dispatch('punctuation-start', {
     mode: 'guided',
     guidedSkillId: 'speech',
     roundLength: '4',
   });
+  harness.dispatch('punctuation-skill-detail-close');
 
   // Paired state-level assertion: catches the cluster-mode silent-drop bug.
   // If a future refactor reverts to `{ mode: 'speech', skillId: 'speech' }`,
@@ -870,12 +903,15 @@ test('punctuation Skill Detail modal "Practise this" pins the correct skill in a
   // apostrophe_possession. The old cluster-mode dispatch would silently pick
   // either one; Guided-focus must pin the exact skill the learner tapped.
   harness.dispatch('punctuation-skill-detail-open', { skillId: 'apostrophe_contractions' });
-  harness.dispatch('punctuation-skill-detail-close');
+  // Review-follower adv-231-003: start dispatch fires before close, but for
+  // the happy-path state assertion the ordering is equivalent — state still
+  // lands on guided+apostrophe_contractions.
   harness.dispatch('punctuation-start', {
     mode: 'guided',
     guidedSkillId: 'apostrophe_contractions',
     roundLength: '4',
   });
+  harness.dispatch('punctuation-skill-detail-close');
 
   const state = harness.store.getState().subjectUi.punctuation;
   assert.strictEqual(state.session.mode, 'guided');
@@ -1014,13 +1050,15 @@ test('punctuation Skill Detail modal renders multi-skill footnote for Speech (pa
   openSkillDetailForSpeech(harness);
   // speech appears in sp_fa_transfer_at_last_speech + pg_fronted_speech +
   // pg_parenthesis_speech — i.e. PUNCTUATION_ITEMS entries with
-  // `skillIds.length > 1`. The caveat footnote must render on Practise.
+  // `skillIds.length > 1`. The caveat footnote must render on Practise in
+  // the review-follower-softened child register ("You might see one or two
+  // other punctuation skills too — that's normal!").
   harness.dispatch('punctuation-skill-detail-tab', { value: 'practise' });
   const html = harness.render();
   assert.match(
     html,
-    /Some practice questions may also include other punctuation skills\./,
-    'Speech must surface the multi-skill caveat footnote',
+    /You might see one or two other punctuation skills too/,
+    'Speech must surface the child-register multi-skill caveat footnote',
   );
   assert.match(html, /data-punctuation-skill-modal-multi-skill-note="true"/);
 });
@@ -1035,7 +1073,7 @@ test('punctuation Skill Detail modal does NOT render multi-skill footnote for a 
   // caveat footnote in the HTML.
   assert.doesNotMatch(
     html,
-    /Some practice questions may also include other punctuation skills\./,
+    /You might see one or two other punctuation skills too/,
     'hyphen must NOT surface the multi-skill caveat footnote',
   );
 });


### PR DESCRIPTION
## Summary
- New `PunctuationSkillDetailModal.jsx` rendered by MapScene when `mapUi.detailOpenSkillId` is set.
- 2 tabs (Learn / Practise) consuming U5's `punctuation-skill-detail-tab` state.
- Renders 3 pedagogy fields per skill: `rule` + `contrastBad` + one of `workedGood`/`contrastGood` per `PUNCTUATION_SKILL_MODAL_PREFERRED_EXAMPLE`.
- "Practise this" dispatches `punctuation-start` `{ mode: 'guided', guidedSkillId, roundLength: '4' }` — NOT cluster mode (verified against `shared/punctuation/service.js:1281-1283`).
- Multi-skill paragraph caveat footnote on Practise tab whenever the skill appears in a `PUNCTUATION_ITEMS` entry with `skillIds.length > 1` (Speech, Fronted Adverbial, Colon List, List Commas, Parenthesis, Semicolon, both Apostrophe skills).
- a11y: `role="dialog"`, `aria-modal="true"`, `aria-labelledby`, Esc close, focusable close button.

## Client mirrors added (with drift tests)
- `PUNCTUATION_SKILL_MODAL_CONTENT` — client-safe mirror of the 4 pedagogy fields per skill from `shared/punctuation/content.js`'s `PUNCTUATION_SKILLS`. The bundle-audit rule blocks `shared/punctuation/*` from the browser bundle, so U6 needed a mirror parallel to U5's `PUNCTUATION_SKILL_RULE_ONE_LINERS` pattern. Drift tests in `tests/punctuation-view-model.test.js` verify byte-for-byte parity.
- `punctuationSkillHasMultiSkillItems(skillId)` + `PUNCTUATION_MULTI_SKILL_ITEM_SKILLS` frozen set — derived once from `PUNCTUATION_ITEMS` multi-skill entries; drift test verifies the set matches the live shared source.

## Audit findings (deferred to U10)
The U6 brief asked whether to extend `PUNCTUATION_SKILL_MODAL_PREFERRED_EXAMPLE` with the 6 additional skills flagged in U1's inline comment (`list_commas`, `colon_list`, `semicolon`, `dash_clause`, `semicolon_list`, `bullet_points`). Cross-checked each skill's `workedGood` / `contrastGood` against `PUNCTUATION_ITEMS.accepted[]`:
- For all 6, BOTH fields are verbatim-present in at least one accepted answer. Neither is strictly safer.
- `comma_clarity` (plan-specified) — only `contrastGood` overlaps → override to `workedGood` is the safer choice. Already encoded by U1; U6 consumes as-is.
- `hyphen` — only `contrastGood` overlaps → default `workedGood` already avoids the leak.

Since flipping the preferred example between two equally-leaking fields buys no redaction improvement, U6 does NOT extend `PUNCTUATION_SKILL_MODAL_PREFERRED_EXAMPLE`. Root fix is a rewrite of the pedagogy copy in `shared/punctuation/content.js` so the modal examples aren't byte-for-byte identical to accepted answers — deferred to U10's behavioural parity + authoring sweep.

## Plan reference
U6 (`docs/plans/2026-04-25-005-feat-punctuation-phase3-ux-rebuild-plan.md`).

## Release-id impact
`release-id impact: none`.

## Test plan
- [x] Exactly 3 pedagogy fields per skill (Learn tab)
- [x] `comma_clarity` override renders `workedGood`, NOT `contrastGood`
- [x] `"Practise this"` dispatches Guided + `guidedSkillId` (not cluster mode); paired state-level assertion on `session.mode === 'guided'` + `session.guidedSkillId === 'speech'`
- [x] Multi-skill cluster (`apostrophe`) tap pins the exact skill (`apostrophe_contractions`, NOT sibling `apostrophe_possession`)
- [x] Multi-skill paragraph caveat footnote renders for `speech` + absent for `hyphen`
- [x] `role="dialog"`, `aria-modal="true"`, `aria-labelledby` all present
- [x] Close button + modal regression-locks `mapUi.detailOpenSkillId` open/close
- [x] Tab switch + invalid-tab rejection (U5 handler regression-locks)
- [x] Modal SSR contains none of the 12 `FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS`
- [x] Modal SSR contains no `PUNCTUATION_CHILD_FORBIDDEN_TERMS`
- [x] `composeIsDisabled === true` disables `"Practise this"` under degraded availability
- [x] Drift test: `PUNCTUATION_SKILL_MODAL_CONTENT` byte-for-byte mirrors `shared/punctuation/content.js` `PUNCTUATION_SKILLS`
- [x] Drift test: `punctuationSkillHasMultiSkillItems` matches live `PUNCTUATION_ITEMS` multi-skill entries

## Verification commands (all green)
- `node --test tests/react-punctuation-scene.test.js` — 44 / 44
- `node --test tests/punctuation-view-model.test.js` — 63 / 63
- `node --test tests/punctuation-legacy-parity.test.js` — unchanged
- `node --test tests/bundle-audit.test.js` — no `shared/punctuation/*` leak
- `npm run build:bundles` + `npm run audit:client` — client bundle clean

## Notes
- `npm test` full-suite shows one pre-existing Grammar production-smoke failure (`grammar.startModel.stats.templates`) that reproduces on a clean `main` (`dd70f5f`) — unrelated to U6.