### PR TITLE
feat(punctuation): U2 setup scene (child dashboard) + stale-prefs migration

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2004,6 +2004,18 @@ function buildSurfaceActions() {
     openAdminHub: () => dispatchAction('open-admin-hub'),
     logout: () => dispatchAction('platform-logout'),
     retryPersistence: () => dispatchAction('persistence-retry'),
+    // adv-234 (HIGH 1): expose a direct store-merge handle so client-only
+    // UI latches (e.g. Punctuation Setup's `prefsMigrated` store-level gate)
+    // can land BEFORE a dispatch that routes through `handleRemotePunctuationAction`
+    // into `punctuationCommandActions.handle` — which returns true on every
+    // punctuation-set-mode call and short-circuits the module's fall-through
+    // to `handleSubjectAction`. Without this handle, the module handler that
+    // sets `prefsMigrated: true` is only exercised by the test harness, so
+    // the stale-prefs migration re-fires on every Setup SSR in production.
+    // Component-level callers should only use this for tightly scoped UI
+    // latches that the plan explicitly calls out — mutation-of-record still
+    // flows through `dispatch`.
+    updateSubjectUi: (subjectId, updater) => store.updateSubjectUi(subjectId, updater),
     // P1.5 Phase A (U2): expose dirty-row registration to the admin surface
     // so the AccountOpsMetadataRow can flip its dirtyRef through a stable
     // actions handle. The registry is module-scope (see

--- a/src/main.js
+++ b/src/main.js
@@ -38,7 +38,10 @@ import { createSubjectCommandActionHandler } from './platform/runtime/subject-co
 import { createSubjectCommandClient } from './platform/runtime/subject-command-client.js';
 import { createReadModelClient } from './platform/runtime/read-model-client.js';
 import { createPunctuationReadModelService } from './subjects/punctuation/client-read-models.js';
-import { punctuationSubjectCommandActions } from './subjects/punctuation/command-actions.js';
+import {
+  createPunctuationOnCommandError,
+  punctuationSubjectCommandActions,
+} from './subjects/punctuation/command-actions.js';
 import { createRemoteSpellingActionHandler } from './subjects/spelling/remote-actions.js';
 import { createPlatformTts } from './subjects/spelling/tts.js';
 import {
@@ -2694,10 +2697,13 @@ const punctuationCommandActions = createSubjectCommandActionHandler({
   setSubjectError: setPunctuationRuntimeError,
   pendingKeys: pendingPunctuationCommandKeys,
   onCommandResult: applyPunctuationCommandResponse,
-  onCommandError(error) {
-    globalThis.console?.warn?.('Punctuation command failed.', error);
-    setPunctuationRuntimeError(error?.payload?.message || error?.message || 'The punctuation command could not be completed.');
-  },
+  // adv-234-006 MEDIUM: on `save-prefs` failure, clear the `prefsMigrated`
+  // latch so the Setup scene's one-shot stale-prefs migration can retry
+  // on the next render. See `createPunctuationOnCommandError`.
+  onCommandError: createPunctuationOnCommandError({
+    store,
+    setSubjectError: setPunctuationRuntimeError,
+  }),
   actions: punctuationSubjectCommandActions,
 });
 

--- a/src/subjects/punctuation/command-actions.js
+++ b/src/subjects/punctuation/command-actions.js
@@ -31,6 +31,42 @@ function withCommandExpectation(payload = {}, state = {}) {
   };
 }
 
+// adv-234-006 MEDIUM: the Setup scene latches `ui.prefsMigrated: true`
+// CLIENT-SIDE (via the adv-234 HIGH 1 fix) BEFORE the `punctuation-set-mode`
+// dispatch fires. If the subsequent Worker `save-prefs` command rejects
+// (network, 5xx, offline), stored prefs on the repo stay on the legacy
+// cluster mode but the client latch has already been persisted as `true`.
+// Every subsequent render then sees `legacyCluster=true` AND
+// `prefsMigrated=true`, so the migration never re-fires — the learner is
+// stuck with Smart Review aria-pressed while every session runs the
+// stored cluster mode.
+//
+// This factory builds the `onCommandError` handler used by
+// `createSubjectCommandActionHandler` in `src/main.js`. On a `save-prefs`
+// failure it clears `prefsMigrated`, rearming the one-shot migration so the
+// next Setup render can retry it. Non-`save-prefs` failures surface the
+// subject error message unchanged.
+export function createPunctuationOnCommandError({
+  store,
+  setSubjectError,
+  warn = (message, error) => globalThis.console?.warn?.(message, error),
+  fallbackMessage = 'The punctuation command could not be completed.',
+} = {}) {
+  if (!store || typeof store.updateSubjectUi !== 'function') {
+    throw new TypeError('createPunctuationOnCommandError requires a store with updateSubjectUi.');
+  }
+  if (typeof setSubjectError !== 'function') {
+    throw new TypeError('createPunctuationOnCommandError requires a setSubjectError callback.');
+  }
+  return function onPunctuationCommandError(error, context = {}) {
+    warn('Punctuation command failed.', error);
+    if (context?.command === 'save-prefs') {
+      store.updateSubjectUi('punctuation', { prefsMigrated: false });
+    }
+    setSubjectError(error?.payload?.message || error?.message || fallbackMessage);
+  };
+}
+
 export const punctuationSubjectCommandActions = Object.freeze({
   'punctuation-start': {
     command: 'start-session',

--- a/src/subjects/punctuation/components/PunctuationPracticeSurface.jsx
+++ b/src/subjects/punctuation/components/PunctuationPracticeSurface.jsx
@@ -5,91 +5,23 @@ import {
 } from './punctuation-view-model.js';
 import { PunctuationMapScene } from './PunctuationMapScene.jsx';
 import { PunctuationSessionScene } from './PunctuationSessionScene.jsx';
+import { PunctuationSetupScene } from './PunctuationSetupScene.jsx';
 
-function learnerName(appState, learnerId) {
-  return appState?.learners?.byId?.[learnerId]?.name || 'Learner';
+function learnerRecord(appState, learnerId) {
+  const record = appState?.learners?.byId?.[learnerId];
+  return record && typeof record === 'object' && !Array.isArray(record) ? record : null;
 }
 
 function newlineTextStyle(value) {
   return String(value || '').includes('\n') ? { whiteSpace: 'pre-wrap' } : undefined;
 }
 
-function SetupView({ learner, stats, ui, actions }) {
-  const scene = bellstormSceneForPhase('setup');
-  const content = ui.content || {};
-  const guidedSkills = Array.isArray(content.skills) ? content.skills : [];
-  const [guidedSkillId, setGuidedSkillId] = useState(guidedSkills[0]?.id || '');
-  const selectedGuidedSkillId = guidedSkillId || guidedSkills[0]?.id || '';
-  const isDisabled = composeIsDisabled(ui);
-  return (
-    <section className="card border-top punctuation-surface" style={{ borderTopColor: '#B8873F' }}>
-      <div className="punctuation-hero">
-        <img src={scene.src} srcSet={scene.srcSet} sizes="(max-width: 980px) 100vw, 960px" alt="" aria-hidden="true" />
-        <div>
-          <div className="eyebrow">Bellstorm Coast</div>
-          <h2 className="section-title">Punctuation practice</h2>
-          <p className="subtitle">{content.publishedScopeCopy || 'Punctuation covers the 14-skill KS2 progression with Smart Review, Guided focus, Weak Spots, GPS tests, sentence combining, paragraph repair, and transfer practice.'}</p>
-        </div>
-      </div>
-      <div className="stat-grid" style={{ marginTop: 16 }}>
-        <div className="stat"><div className="stat-label">Accuracy</div><div className="stat-value">{stats.accuracy || 0}%</div><div className="stat-sub">{learner}</div></div>
-        <div className="stat"><div className="stat-label">Secure units</div><div className="stat-value">{stats.securedRewardUnits || 0}</div><div className="stat-sub">{stats.publishedRewardUnits || 14} published</div></div>
-        <div className="stat"><div className="stat-label">Due</div><div className="stat-value">{stats.due || 0}</div><div className="stat-sub">Review items</div></div>
-      </div>
-      <div className="actions" style={{ marginTop: 16 }}>
-        <button className="btn primary" type="button" disabled={isDisabled} data-punctuation-start onClick={() => actions.dispatch('punctuation-start')}>Start practice</button>
-        {guidedSkills.length ? (
-          <label className="field" style={{ minWidth: 220 }}>
-            <span>Guided skill</span>
-            <select
-              className="input"
-              value={selectedGuidedSkillId}
-              disabled={isDisabled}
-              onChange={(event) => setGuidedSkillId(event.target.value)}
-            >
-              {guidedSkills.map((skill) => (
-                <option key={skill.id} value={skill.id}>{skill.name}</option>
-              ))}
-            </select>
-          </label>
-        ) : null}
-        <button
-          className="btn secondary"
-          type="button"
-          disabled={isDisabled}
-          data-punctuation-guided-start
-          onClick={() => actions.dispatch('punctuation-start', { mode: 'guided', skillId: selectedGuidedSkillId || undefined })}
-        >
-          Guided learn
-        </button>
-        <button
-          className="btn secondary"
-          type="button"
-          disabled={isDisabled}
-          data-punctuation-weak-start
-          onClick={() => actions.dispatch('punctuation-start', { mode: 'weak' })}
-        >
-          Weak spots
-        </button>
-        <button
-          className="btn secondary"
-          type="button"
-          disabled={isDisabled}
-          data-punctuation-gps-start
-          onClick={() => actions.dispatch('punctuation-start', { mode: 'gps', roundLength: '8' })}
-        >
-          GPS test
-        </button>
-        <button className="btn secondary" type="button" disabled={isDisabled} data-punctuation-endmarks-start onClick={() => actions.dispatch('punctuation-start', { mode: 'endmarks' })}>Endmarks focus</button>
-        <button className="btn secondary" type="button" disabled={isDisabled} data-punctuation-apostrophe-start onClick={() => actions.dispatch('punctuation-start', { mode: 'apostrophe' })}>Apostrophe focus</button>
-        <button className="btn secondary" type="button" disabled={isDisabled} onClick={() => actions.dispatch('punctuation-start', { mode: 'speech' })}>Speech focus</button>
-        <button className="btn secondary" type="button" disabled={isDisabled} onClick={() => actions.dispatch('punctuation-start', { mode: 'comma_flow' })}>Comma focus</button>
-        <button className="btn secondary" type="button" disabled={isDisabled} onClick={() => actions.dispatch('punctuation-start', { mode: 'boundary' })}>Boundary focus</button>
-        <button className="btn secondary" type="button" disabled={isDisabled} onClick={() => actions.dispatch('punctuation-start', { mode: 'structure' })}>Structure focus</button>
-      </div>
-    </section>
-  );
-}
+// Phase 3 U2 removed the legacy `SetupView` from this module. The
+// Setup phase now delegates to `PunctuationSetupScene.jsx`, which
+// renders the dashboard hero + today cards + three primary mode
+// cards + Open Map secondary card + round-length toggle + active
+// monster strip. See `./PunctuationSetupScene.jsx` for the current
+// implementation and the one-shot stale-prefs migration.
 
 function SummaryView({ ui, actions }) {
   const summary = ui.summary || {};
@@ -149,7 +81,25 @@ export function PunctuationPracticeSurface({ appState, service, actions }) {
   const learnerId = appState.learners.selectedId;
   const ui = service?.initState?.(appState.subjectUi?.punctuation, learnerId) || appState.subjectUi?.punctuation || {};
   const stats = useMemo(() => service?.getStats?.(learnerId) || ui.stats || {}, [learnerId, service, ui.stats]);
-  const learner = learnerName(appState, learnerId);
+  const learner = learnerRecord(appState, learnerId);
+  // U2: prefer `ui.prefs` so the display collapse stays coherent across
+  // re-renders; fall back to the service read (which hits the data
+  // repository) when `ui.prefs` has not yet been mirrored (e.g. first
+  // Setup visit on a pre-U2 subject state). Service read is side-effect
+  // free.
+  const prefs = (ui && typeof ui === 'object' && !Array.isArray(ui) && ui.prefs)
+    ? ui.prefs
+    : (service?.getPrefs?.(learnerId) || {});
+  // U2: the active monster strip reads monster reward state from
+  // `ui.rewardState` (mirrors the Map scene's source). When not
+  // present, default to empty so the strip renders fresh-learner
+  // zeros rather than throwing.
+  const rewardState = (ui && typeof ui === 'object' && !Array.isArray(ui)
+    && ui.rewardState
+    && typeof ui.rewardState === 'object'
+    && !Array.isArray(ui.rewardState))
+    ? ui.rewardState
+    : {};
 
   // Phase 3 U3: `active-item` + `feedback` route through the consolidated
   // `PunctuationSessionScene`. Summary stays inline until U4; Map routes
@@ -160,5 +110,20 @@ export function PunctuationPracticeSurface({ appState, service, actions }) {
   if (ui.phase === 'summary') return <SummaryView ui={ui} actions={actions} />;
   if (ui.phase === 'map') return <PunctuationMapScene ui={ui} actions={actions} />;
 
-  return <SetupView learner={learner} stats={stats} ui={ui} actions={actions} />;
+  // U2: every non-session / non-map / non-unavailable / non-error phase
+  // falls through to the Setup scene. The Phase 2 enum still includes
+  // `'setup'`, `'unavailable'`, and `'error'`; the latter two keep
+  // their Phase 2 behaviour (the parent shell handles unavailable /
+  // error banners). Unknown phase strings default to Setup so a rogue
+  // payload doesn't land the learner on a broken blank scene.
+  return (
+    <PunctuationSetupScene
+      ui={ui}
+      actions={actions}
+      prefs={prefs}
+      stats={stats}
+      learner={learner}
+      rewardState={rewardState}
+    />
+  );
 }

--- a/src/subjects/punctuation/components/PunctuationSetupScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationSetupScene.jsx
@@ -44,6 +44,7 @@ import {
   ACTIVE_PUNCTUATION_MONSTER_IDS,
   PUNCTUATION_DASHBOARD_HERO,
   PUNCTUATION_PRIMARY_MODE_CARDS,
+  PUNCTUATION_SETUP_ROUND_LENGTH_OPTIONS,
   bellstormSceneForPhase,
   buildPunctuationDashboardModel,
   composeIsDisabled,
@@ -69,7 +70,9 @@ const LEGACY_PUNCTUATION_MODE_IDS = Object.freeze(new Set([
 // Compact three-option toggle for the Setup scene. Default 4 (per plan);
 // 8 and 12 are the other two stops. Mirrors the Spelling LengthPicker's
 // radiogroup shape so screen readers land on the same familiar control.
-const PUNCTUATION_ROUND_LENGTH_OPTIONS = Object.freeze(['4', '8', '12']);
+// Shared as `PUNCTUATION_SETUP_ROUND_LENGTH_OPTIONS` from the view-model so
+// the module's `punctuation-set-round-length` handler can validate against
+// the same narrow enum (adv-234-001).
 
 function TodayCard({ card }) {
   return (
@@ -138,7 +141,7 @@ function RoundLengthToggle({ selectedValue, disabled, actions }) {
       role="radiogroup"
       aria-label="Round length"
     >
-      {PUNCTUATION_ROUND_LENGTH_OPTIONS.map((value) => {
+      {PUNCTUATION_SETUP_ROUND_LENGTH_OPTIONS.map((value) => {
         const selected = selectedValue === value;
         return (
           <button
@@ -195,7 +198,7 @@ function selectedRoundLength(prefs) {
     ? prefs.roundLength
     : null;
   const candidate = typeof raw === 'string' && raw ? raw : '4';
-  return PUNCTUATION_ROUND_LENGTH_OPTIONS.includes(candidate) ? candidate : '4';
+  return PUNCTUATION_SETUP_ROUND_LENGTH_OPTIONS.includes(candidate) ? candidate : '4';
 }
 
 export function PunctuationSetupScene({ ui, actions, prefs, stats, learner, rewardState }) {
@@ -211,7 +214,7 @@ export function PunctuationSetupScene({ ui, actions, prefs, stats, learner, rewa
     [stats, prefs, rewardState],
   );
 
-  // One-shot stale-prefs migration. Two gates combine to guarantee
+  // One-shot stale-prefs migration. Three gates combine to guarantee
   // exactly one dispatch per session:
   //
   //   1. `migratedRef` — React-level gate. Persists across every
@@ -221,8 +224,19 @@ export function PunctuationSetupScene({ ui, actions, prefs, stats, learner, rewa
   //   2. `ui.prefsMigrated` — store-level gate. Survives component
   //      tear-down and rebuild (SSR renders produce fresh trees each
   //      time; `migratedRef` alone would re-fire on every SSR call).
-  //      Set by the module's `punctuation-migrate-prefs` handler as
-  //      part of the same store update that saves the new mode.
+  //      Latched CLIENT-SIDE below via `actions.updateSubjectUi` BEFORE
+  //      the dispatch fires — see adv-234 HIGH 1 for the detail. The
+  //      module's `punctuation-set-mode` handler also sets this latch
+  //      as part of its store update, but in production the dispatch
+  //      routes through `handleRemotePunctuationAction` → the Worker
+  //      `save-prefs` command, which returns true and short-circuits
+  //      the fall-through to `handleSubjectAction` → module handler.
+  //      Landing the latch here keeps both the harness (module-handler
+  //      path) and production (Worker-command path) in lock-step.
+  //   3. Reload-from-repositories after the Worker response rehydrates
+  //      `prefs.mode` to 'smart' — so even if the client-side latch is
+  //      somehow lost, the next render's `legacyCluster` check is
+  //      false.
   //
   // The check runs synchronously in the component body rather than
   // an effect — `renderToStaticMarkup` does not execute effects, so a
@@ -242,6 +256,16 @@ export function PunctuationSetupScene({ ui, actions, prefs, stats, learner, rewa
   const legacyCluster = typeof storedMode === 'string' && LEGACY_PUNCTUATION_MODE_IDS.has(storedMode);
   if (legacyCluster && !migratedRef.current && !prefsMigrated) {
     migratedRef.current = true;
+    // adv-234 HIGH 1: latch the store-level gate BEFORE dispatching so the
+    // production Worker-command path (which never falls through to the
+    // module handler) still gets the `prefsMigrated: true` store update.
+    // `updateSubjectUi` is exposed on `actions` by both the production
+    // `buildSurfaceActions` in main.js and the tests/helpers/react-app-ssr
+    // renderer. Safe to call during render — it is a plain store merge,
+    // not a dispatch through `handleSubjectAction`, so no re-entrant loop.
+    if (typeof actions.updateSubjectUi === 'function') {
+      actions.updateSubjectUi('punctuation', { prefsMigrated: true });
+    }
     actions.dispatch('punctuation-set-mode', { value: 'smart' });
   }
 

--- a/src/subjects/punctuation/components/PunctuationSetupScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationSetupScene.jsx
@@ -1,0 +1,327 @@
+// Phase 3 U2 — Punctuation Setup scene (child dashboard).
+//
+// Replaces the Phase 2 `SetupView`'s 10-button mode grid with a Hero +
+// Today cards + three primary journey cards (Smart Review / Wobbly Spots
+// / GPS Check) + one "Open Punctuation Map" secondary card + compact
+// round-length toggle (4 / 8 / 12) + active-monster strip. Reserved
+// monsters (Colisk / Hyphang / Carillon) are NEVER rendered — the
+// iterator is `ACTIVE_PUNCTUATION_MONSTER_IDS` full stop (plan R10 /
+// learning #5).
+//
+// Mode display: `aria-pressed` on the primary cards is driven by
+// `punctuationPrimaryModeFromPrefs(prefs)`, which collapses the 6
+// Phase 2 cluster modes (endmarks / apostrophe / speech / comma_flow /
+// boundary / structure) AND `guided` to `'smart'` for display. That
+// normaliser is display-only — stored prefs still carry the stale
+// value until the one-shot migration below persists the collapse.
+//
+// Stale-prefs migration (R1, plan line 408): on first render, if the
+// stored `prefs.mode` is one of the 6 cluster values or `'guided'`, the
+// scene dispatches `punctuation-set-mode` with `{ value: 'smart' }` to
+// migrate the stored value once. Two gates combine to guarantee exactly
+// one dispatch per session:
+//   - A `useRef` gate protects the same component instance from
+//     re-dispatching across React-level re-renders (including React 18
+//     strict-mode's double-invoke).
+//   - A store-level `ui.prefsMigrated` latch (set by the module's
+//     `punctuation-set-mode` handler) protects against component
+//     tear-down + rebuild — SSR renders produce fresh trees each time,
+//     so the useRef gate alone would re-fire on every server-side
+//     render.
+// Without this migration, `punctuation-start-again` (dispatched from
+// Summary) would silently start a cluster-focus session the learner
+// can no longer configure.
+//
+// Every mutation control threads `composeIsDisabled(ui)` so the
+// dashboard pauses visually whenever a command is in flight, the
+// runtime is degraded/unavailable, or the platform has flipped the
+// subject read-only (plan R11 — the same signal wired through Map,
+// Session, Feedback, and Summary scenes).
+
+import React, { useMemo, useRef } from 'react';
+
+import {
+  ACTIVE_PUNCTUATION_MONSTER_IDS,
+  PUNCTUATION_DASHBOARD_HERO,
+  PUNCTUATION_PRIMARY_MODE_CARDS,
+  bellstormSceneForPhase,
+  buildPunctuationDashboardModel,
+  composeIsDisabled,
+  punctuationMonsterDisplayName,
+  punctuationPrimaryModeFromPrefs,
+} from './punctuation-view-model.js';
+import { progressForPunctuationMonster } from '../../../platform/game/mastery/punctuation.js';
+
+// The 6 Phase 2 cluster mode ids + `guided` — the set that triggers the
+// one-shot stored-prefs migration. Local to this scene because the
+// migration is a Setup-specific concern; the view-model exposes the
+// display collapse (`punctuationPrimaryModeFromPrefs`) separately.
+const LEGACY_PUNCTUATION_MODE_IDS = Object.freeze(new Set([
+  'endmarks',
+  'apostrophe',
+  'speech',
+  'comma_flow',
+  'boundary',
+  'structure',
+  'guided',
+]));
+
+// Compact three-option toggle for the Setup scene. Default 4 (per plan);
+// 8 and 12 are the other two stops. Mirrors the Spelling LengthPicker's
+// radiogroup shape so screen readers land on the same familiar control.
+const PUNCTUATION_ROUND_LENGTH_OPTIONS = Object.freeze(['4', '8', '12']);
+
+function TodayCard({ card }) {
+  return (
+    <div className="punctuation-today-card" data-today-id={card.id}>
+      <div className="punctuation-today-label">{card.label}</div>
+      <div className="punctuation-today-value">{card.value}</div>
+      <div className="punctuation-today-detail">{card.detail}</div>
+    </div>
+  );
+}
+
+function PrimaryModeCard({ card, selected, disabled, actions }) {
+  const classes = ['punctuation-primary-mode'];
+  if (selected) classes.push('selected');
+  if (disabled) classes.push('is-disabled');
+  if (card.badge) classes.push('is-recommended');
+  return (
+    <button
+      type="button"
+      className={classes.join(' ')}
+      data-mode-id={card.id}
+      data-action="punctuation-set-mode"
+      data-value={card.id}
+      aria-pressed={selected ? 'true' : 'false'}
+      disabled={disabled}
+      aria-disabled={disabled ? 'true' : undefined}
+      onClick={() => {
+        if (disabled) return;
+        actions.dispatch('punctuation-set-mode', { value: card.id });
+      }}
+    >
+      {card.badge ? <span className="punctuation-primary-mode-eyebrow">{card.badge}</span> : null}
+      <h4 className="punctuation-primary-mode-title">{card.label}</h4>
+      <p className="punctuation-primary-mode-desc">{card.description}</p>
+    </button>
+  );
+}
+
+function OpenMapCard({ disabled, actions }) {
+  const classes = ['punctuation-secondary-mode'];
+  if (disabled) classes.push('is-disabled');
+  return (
+    <button
+      type="button"
+      className={classes.join(' ')}
+      data-action="punctuation-open-map"
+      disabled={disabled}
+      aria-disabled={disabled ? 'true' : undefined}
+      onClick={() => {
+        if (disabled) return;
+        actions.dispatch('punctuation-open-map');
+      }}
+    >
+      <h4 className="punctuation-secondary-mode-title">Open Punctuation Map</h4>
+      <p className="punctuation-secondary-mode-desc">
+        Browse the 14 skills by monster and status.
+      </p>
+    </button>
+  );
+}
+
+function RoundLengthToggle({ selectedValue, disabled, actions }) {
+  return (
+    <div
+      className="punctuation-length-toggle"
+      role="radiogroup"
+      aria-label="Round length"
+    >
+      {PUNCTUATION_ROUND_LENGTH_OPTIONS.map((value) => {
+        const selected = selectedValue === value;
+        return (
+          <button
+            type="button"
+            role="radio"
+            aria-checked={selected ? 'true' : 'false'}
+            className={`punctuation-length-option${selected ? ' selected' : ''}`}
+            data-action="punctuation-set-round-length"
+            data-value={value}
+            disabled={disabled}
+            key={value}
+            onClick={() => {
+              if (disabled) return;
+              actions.dispatch('punctuation-set-round-length', { value });
+            }}
+          >
+            <span>{value}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function ActiveMonsterStrip({ rewardState }) {
+  // Iterate `ACTIVE_PUNCTUATION_MONSTER_IDS` only — reserved monsters
+  // (colisk / hyphang / carillon) never surface even if the reward
+  // state carries entries for them (plan R10).
+  return (
+    <div className="punctuation-active-monsters" aria-label="Active monsters">
+      {ACTIVE_PUNCTUATION_MONSTER_IDS.map((monsterId) => {
+        const progress = progressForPunctuationMonster(rewardState, monsterId);
+        return (
+          <div
+            className="punctuation-active-monster"
+            data-monster-id={monsterId}
+            key={monsterId}
+          >
+            <div className="punctuation-active-monster-name">
+              {punctuationMonsterDisplayName(monsterId)}
+            </div>
+            <div className="punctuation-active-monster-progress muted">
+              {`${progress.mastered}/${progress.publishedTotal} secure`}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function selectedRoundLength(prefs) {
+  const raw = prefs && typeof prefs === 'object' && !Array.isArray(prefs)
+    ? prefs.roundLength
+    : null;
+  const candidate = typeof raw === 'string' && raw ? raw : '4';
+  return PUNCTUATION_ROUND_LENGTH_OPTIONS.includes(candidate) ? candidate : '4';
+}
+
+export function PunctuationSetupScene({ ui, actions, prefs, stats, learner, rewardState }) {
+  const scene = bellstormSceneForPhase('setup');
+  const disabled = composeIsDisabled(ui);
+
+  // Display-only collapse of legacy cluster / `guided` prefs to `'smart'`.
+  // Stored value stays untouched until the migration effect below
+  // persists the collapse via dispatch.
+  const primaryMode = useMemo(() => punctuationPrimaryModeFromPrefs(prefs), [prefs]);
+  const dashboard = useMemo(
+    () => buildPunctuationDashboardModel(stats, { prefs }, rewardState),
+    [stats, prefs, rewardState],
+  );
+
+  // One-shot stale-prefs migration. Two gates combine to guarantee
+  // exactly one dispatch per session:
+  //
+  //   1. `migratedRef` — React-level gate. Persists across every
+  //      re-render of the same component instance (including React
+  //      18's strict-mode double-invoke) so a client-side re-render
+  //      never fires the dispatch twice.
+  //   2. `ui.prefsMigrated` — store-level gate. Survives component
+  //      tear-down and rebuild (SSR renders produce fresh trees each
+  //      time; `migratedRef` alone would re-fire on every SSR call).
+  //      Set by the module's `punctuation-migrate-prefs` handler as
+  //      part of the same store update that saves the new mode.
+  //
+  // The check runs synchronously in the component body rather than
+  // an effect — `renderToStaticMarkup` does not execute effects, so a
+  // useEffect-based migration would never fire server-side. Dispatch
+  // to the store is safe during render because it goes to the app
+  // store (not component state) and the guards above prevent a
+  // re-entrant loop.
+  //
+  // `legacyCluster` is computed from the raw stored mode, not the
+  // display collapse, so a reverted state is detected only the first
+  // time before `prefsMigrated` latches.
+  const migratedRef = useRef(false);
+  const prefsMigrated = Boolean(ui && typeof ui === 'object' && !Array.isArray(ui) && ui.prefsMigrated);
+  const storedMode = prefs && typeof prefs === 'object' && !Array.isArray(prefs)
+    ? prefs.mode
+    : null;
+  const legacyCluster = typeof storedMode === 'string' && LEGACY_PUNCTUATION_MODE_IDS.has(storedMode);
+  if (legacyCluster && !migratedRef.current && !prefsMigrated) {
+    migratedRef.current = true;
+    actions.dispatch('punctuation-set-mode', { value: 'smart' });
+  }
+
+  const selectedLengthValue = selectedRoundLength(prefs);
+  const learnerName = learner && typeof learner === 'object' && !Array.isArray(learner)
+    && typeof learner.name === 'string' && learner.name.trim()
+    ? learner.name.trim()
+    : '';
+
+  return (
+    <section
+      className="card border-top punctuation-surface punctuation-setup-scene"
+      data-punctuation-phase="setup"
+      style={{ borderTopColor: '#B8873F' }}
+    >
+      <div className="punctuation-hero">
+        <img
+          src={scene.src}
+          srcSet={scene.srcSet}
+          sizes="(max-width: 980px) 100vw, 960px"
+          alt=""
+          aria-hidden="true"
+        />
+        <div>
+          <div className="eyebrow">{PUNCTUATION_DASHBOARD_HERO.eyebrow}</div>
+          <h2 className="section-title">{PUNCTUATION_DASHBOARD_HERO.headline}</h2>
+          <p className="subtitle">{PUNCTUATION_DASHBOARD_HERO.subtitle}</p>
+          {learnerName ? (
+            <p className="punctuation-hero-welcome">
+              {`Hi ${learnerName} — ready for a short round?`}
+            </p>
+          ) : null}
+        </div>
+      </div>
+
+      <section className="punctuation-today" aria-label="Today at a glance">
+        {dashboard.isEmpty ? (
+          <div className="punctuation-today-empty" data-testid="punctuation-today-empty">
+            Start your first round to see your scores here.
+          </div>
+        ) : (
+          <div className="punctuation-today-grid">
+            {dashboard.todayCards.map((card) => (
+              <TodayCard card={card} key={card.id} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="punctuation-primary-modes" aria-label="Choose a round">
+        <div className="punctuation-primary-grid">
+          {PUNCTUATION_PRIMARY_MODE_CARDS.map((card) => (
+            <PrimaryModeCard
+              card={card}
+              selected={card.id === primaryMode}
+              disabled={disabled}
+              actions={actions}
+              key={card.id}
+            />
+          ))}
+        </div>
+
+        <div className="punctuation-secondary-grid">
+          <OpenMapCard disabled={disabled} actions={actions} />
+        </div>
+
+        <div className="punctuation-round-controls">
+          <span className="punctuation-round-label">Round length</span>
+          <RoundLengthToggle
+            selectedValue={selectedLengthValue}
+            disabled={disabled}
+            actions={actions}
+          />
+        </div>
+      </section>
+
+      <section className="punctuation-monsters-section" aria-label="Your monsters">
+        <h3 className="punctuation-monsters-heading">Your monsters</h3>
+        <ActiveMonsterStrip rewardState={rewardState} />
+      </section>
+    </section>
+  );
+}

--- a/src/subjects/punctuation/components/punctuation-view-model.js
+++ b/src/subjects/punctuation/components/punctuation-view-model.js
@@ -255,6 +255,18 @@ export const PUNCTUATION_DASHBOARD_HERO = Object.freeze({
   subtitle: "Pick a short round — we'll queue what matters next.",
 });
 
+// --- Setup round-length toggle options -------------------------------------
+
+// The three stops the child Setup toggle exposes. Tighter subset of the
+// service-contract `PUNCTUATION_ROUND_LENGTHS` superset (which accepts
+// 1 / 2 / 3 / 4 / 6 / 8 / 12 / 'all' so the /start Worker command can still
+// honour legacy per-skill drills). The Setup dispatch handler validates
+// against THIS narrower enum so a rogue payload cannot smuggle an off-menu
+// length (e.g. 'all' or '1') in via the primary dashboard control
+// (adv-234-001). Shared so the Scene and the module handler agree byte-
+// for-byte on what a legitimate Setup round-length dispatch looks like.
+export const PUNCTUATION_SETUP_ROUND_LENGTH_OPTIONS = Object.freeze(['4', '8', '12']);
+
 // --- Forbidden-terms fixture -----------------------------------------------
 
 // Every adult / internal term that must not appear in child-facing
@@ -719,11 +731,16 @@ export function buildPunctuationDashboardModel(stats, learner, rewardState) {
   const secureCount = safeNumber(safeStats.securedRewardUnits ?? safeStats.secure, 0);
   const accuracyValue = safeNumber(safeStats.accuracy, 0);
 
+  // HIGH 3 (adv-234 follow-up): child-register `detail` strings. The
+  // previous "Reward units you own" / "This release" wording was adult-
+  // register (the former leaks the internal "reward unit" token, the
+  // latter the release-id token). Child copy stays in the same 3-5 word
+  // slot so the card grid layout is unchanged.
   const todayCards = Object.freeze([
-    Object.freeze({ id: 'secure', label: 'Secure', value: secureCount, detail: 'Reward units you own' }),
+    Object.freeze({ id: 'secure', label: 'Secure', value: secureCount, detail: 'Skills you know well' }),
     Object.freeze({ id: 'due', label: 'Due', value: dueCount, detail: 'Come back to these today' }),
     Object.freeze({ id: 'weak', label: 'Wobbly', value: weakCount, detail: 'Needs another go' }),
-    Object.freeze({ id: 'accuracy', label: 'Accuracy', value: accuracyValue, detail: 'This release' }),
+    Object.freeze({ id: 'accuracy', label: 'Accuracy', value: accuracyValue, detail: 'Your best so far' }),
   ]);
 
   const prefs = learner && typeof learner === 'object' && !Array.isArray(learner)

--- a/src/subjects/punctuation/module.js
+++ b/src/subjects/punctuation/module.js
@@ -2,9 +2,12 @@ import {
   createInitialPunctuationState,
   isPublishedPunctuationSkillId,
   normalisePunctuationMapUi,
+  normalisePunctuationPrefs,
+  normalisePunctuationRoundLength,
   sanitisePunctuationUiOnRehydrate,
   PUNCTUATION_MAP_MONSTER_FILTER_IDS,
   PUNCTUATION_MAP_STATUS_FILTER_IDS,
+  PUNCTUATION_MODES,
   PUNCTUATION_OPEN_MAP_ALLOWED_PHASES,
 } from './service-contract.js';
 import { SUBJECT_EXPOSURE_GATES } from '../../platform/core/subject-availability.js';
@@ -94,8 +97,47 @@ export const punctuationModule = {
     const ui = currentUi(context, learnerId);
 
     if (action === 'punctuation-set-mode') {
-      service.savePrefs(learnerId, { mode: data.value });
-      store.updateSubjectUi('punctuation', { phase: 'setup', error: '' });
+      // U2: reject invalid mode values so a rogue payload cannot smuggle a
+      // non-enum mode into stored prefs. `PUNCTUATION_MODES` stays at 10
+      // entries (R17); Phase 3's stale-prefs migration explicitly dispatches
+      // `'smart'` / `'weak'` / `'gps'` from the Setup scene and relies on
+      // this guard to refuse garbage.
+      if (!PUNCTUATION_MODES.includes(data?.value)) return false;
+      const nextPrefs = service.savePrefs(learnerId, { mode: data.value });
+      // U2: mirror the saved prefs into `ui.prefs` so downstream scenes and
+      // tests can read the canonical value from `state.subjectUi.punctuation.prefs`.
+      // The service writes to the data repository; without this update the
+      // next render (and the Phase 3 test that asserts
+      // `state.subjectUi.punctuation.prefs.mode === 'smart'`) would see stale
+      // ui state. Mirrors Grammar's `resetToDashboardWithPrefs`.
+      //
+      // Stale-prefs migration latch: ANY successful `punctuation-set-mode`
+      // dispatch flips `prefsMigrated` to `true`. This latch prevents the
+      // Setup scene's one-shot stale-prefs migration from re-firing on
+      // subsequent renders, even if stored prefs somehow revert. A fresh
+      // page load or learner switch clears it (session-memory only; not
+      // persisted to the subject data repository).
+      store.updateSubjectUi('punctuation', {
+        phase: 'setup',
+        error: '',
+        prefs: normalisePunctuationPrefs(nextPrefs || {}),
+        prefsMigrated: true,
+      });
+      return true;
+    }
+
+    if (action === 'punctuation-set-round-length') {
+      // U2: round-length toggle on the Setup scene's primary mode section.
+      // Validates the value against the shared enum so a rogue payload
+      // cannot smuggle an unsupported length into stored prefs. Returns
+      // `false` on invalid input so the caller treats the dispatch as a
+      // miss rather than a silent success (pairs with learning #7).
+      const normalised = normalisePunctuationRoundLength(data?.value, null);
+      if (!normalised) return false;
+      const nextPrefs = service.savePrefs(learnerId, { roundLength: normalised });
+      store.updateSubjectUi('punctuation', {
+        prefs: normalisePunctuationPrefs(nextPrefs || {}),
+      });
       return true;
     }
 

--- a/src/subjects/punctuation/module.js
+++ b/src/subjects/punctuation/module.js
@@ -3,13 +3,13 @@ import {
   isPublishedPunctuationSkillId,
   normalisePunctuationMapUi,
   normalisePunctuationPrefs,
-  normalisePunctuationRoundLength,
   sanitisePunctuationUiOnRehydrate,
   PUNCTUATION_MAP_MONSTER_FILTER_IDS,
   PUNCTUATION_MAP_STATUS_FILTER_IDS,
   PUNCTUATION_MODES,
   PUNCTUATION_OPEN_MAP_ALLOWED_PHASES,
 } from './service-contract.js';
+import { PUNCTUATION_SETUP_ROUND_LENGTH_OPTIONS } from './components/punctuation-view-model.js';
 import { SUBJECT_EXPOSURE_GATES } from '../../platform/core/subject-availability.js';
 
 function applyTransition(context, transition) {
@@ -97,6 +97,17 @@ export const punctuationModule = {
     const ui = currentUi(context, learnerId);
 
     if (action === 'punctuation-set-mode') {
+      // adv-234-004 (MEDIUM): phase guard. `punctuation-set-mode` is a Setup-
+      // scoped affordance (the three primary mode cards + the one-shot
+      // stale-prefs migration dispatch that fires from the Setup-phase render).
+      // Admin / Parent-Hub surfaces that want to write prefs on a learner's
+      // behalf should go through the Worker `save-prefs` command directly, not
+      // through this module action — respecting the same Map-phase discipline
+      // (adv-219-007). Refuse from non-Setup phases so a stray dispatch treats
+      // as a miss rather than a silent success (learning #7). Safe for the
+      // Setup render-time migration dispatch: the scene itself renders under
+      // `ui.phase === 'setup'`.
+      if (ui.phase !== 'setup') return false;
       // U2: reject invalid mode values so a rogue payload cannot smuggle a
       // non-enum mode into stored prefs. `PUNCTUATION_MODES` stays at 10
       // entries (R17); Phase 3's stale-prefs migration explicitly dispatches
@@ -114,9 +125,21 @@ export const punctuationModule = {
       // Stale-prefs migration latch: ANY successful `punctuation-set-mode`
       // dispatch flips `prefsMigrated` to `true`. This latch prevents the
       // Setup scene's one-shot stale-prefs migration from re-firing on
-      // subsequent renders, even if stored prefs somehow revert. A fresh
-      // page load or learner switch clears it (session-memory only; not
-      // persisted to the subject data repository).
+      // subsequent renders, even if stored prefs somehow revert.
+      //
+      // `prefsMigrated` persists across reloads via `subjectStates.writeUi`
+      // — once a learner has migrated from a legacy cluster mode to `'smart'`,
+      // we never re-migrate them, even if a data-restore path later writes
+      // a cluster value back into their prefs. This matches the plan's
+      // intent that migration is a one-shot, per-learner event (plan R1,
+      // line 408). A fresh learner (different selectedId) starts without
+      // the latch; switching back to a migrated learner re-hydrates it.
+      //
+      // Parent-Hub backup restore that rolls stored prefs back to a legacy
+      // cluster mode while leaving `prefsMigrated: true` in place is an
+      // accepted edge case — see the PR body's "Accepted risk" section
+      // (adv-234-003). A manual dispatch of `punctuation-set-mode`
+      // `{ value: 'smart' }` re-runs the save cleanly.
       store.updateSubjectUi('punctuation', {
         phase: 'setup',
         error: '',
@@ -127,14 +150,23 @@ export const punctuationModule = {
     }
 
     if (action === 'punctuation-set-round-length') {
-      // U2: round-length toggle on the Setup scene's primary mode section.
-      // Validates the value against the shared enum so a rogue payload
-      // cannot smuggle an unsupported length into stored prefs. Returns
-      // `false` on invalid input so the caller treats the dispatch as a
-      // miss rather than a silent success (pairs with learning #7).
-      const normalised = normalisePunctuationRoundLength(data?.value, null);
-      if (!normalised) return false;
-      const nextPrefs = service.savePrefs(learnerId, { roundLength: normalised });
+      // adv-234-001 (MEDIUM): phase guard. Round-length is a Setup-scoped
+      // affordance (the compact 4 / 8 / 12 toggle on the Setup scene). A
+      // dispatch from session / feedback / summary / map would otherwise save
+      // prefs mid-session without any reflection in the active session's
+      // `length`. Refuse so the caller treats the dispatch as a miss rather
+      // than a silent success (learning #7).
+      if (ui.phase !== 'setup') return false;
+      // adv-234-001 (MEDIUM): validate against the narrow UI enum
+      // `PUNCTUATION_SETUP_ROUND_LENGTH_OPTIONS = ['4', '8', '12']` rather
+      // than the storage-level `normalisePunctuationRoundLength` which also
+      // accepts 1 / 2 / 3 / 6 / 'all' (the superset kept for `/start-session`
+      // payloads that still honour legacy per-skill drills). The Setup toggle
+      // exposes exactly three stops; a rogue payload carrying 'all' or '1'
+      // bypasses the primary-dashboard contract and must be rejected here.
+      const value = typeof data?.value === 'string' ? data.value : '';
+      if (!PUNCTUATION_SETUP_ROUND_LENGTH_OPTIONS.includes(value)) return false;
+      const nextPrefs = service.savePrefs(learnerId, { roundLength: value });
       store.updateSubjectUi('punctuation', {
         prefs: normalisePunctuationPrefs(nextPrefs || {}),
       });

--- a/tests/helpers/punctuation-scene-render.js
+++ b/tests/helpers/punctuation-scene-render.js
@@ -1,0 +1,73 @@
+// Standalone SSR renderer for the PunctuationSetupScene. Used by tests that
+// need to inject a production-shaped `actions` object (e.g. `dispatch` wired
+// through `createSubjectCommandActionHandler` + mock subject commands + the
+// real `handleRemotePunctuationAction` routing) rather than the
+// app-harness's single-path dispatch.
+//
+// Mirrors the approach in `react-app-ssr.js` — compiles the Scene module via
+// esbuild on first call and reuses the bundle for subsequent renders. No
+// controller / store / subject-command-client plumbing; the caller owns all
+// that.
+
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildSync } from 'esbuild';
+
+const moduleUrl = typeof import.meta.url === 'string' ? import.meta.url : null;
+const rootDir = moduleUrl ? path.resolve(path.dirname(fileURLToPath(moduleUrl)), '../..') : process.cwd();
+const require = createRequire(moduleUrl || path.join(rootDir, 'tests/helpers/punctuation-scene-render.js'));
+
+let renderer = null;
+let rendererDir = null;
+
+function nodePaths() {
+  return [
+    path.join(rootDir, 'node_modules'),
+    ...String(process.env.NODE_PATH || '').split(path.delimiter),
+  ].filter((entry) => entry && existsSync(entry));
+}
+
+function loadRenderer() {
+  if (renderer) return renderer;
+  rendererDir = mkdtempSync(path.join(tmpdir(), 'ks2-punctuation-scene-render-'));
+  const entryPath = path.join(rendererDir, 'entry.jsx');
+  const bundlePath = path.join(rendererDir, 'entry.cjs');
+  writeFileSync(entryPath, `
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { PunctuationSetupScene } from ${JSON.stringify(path.join(rootDir, 'src/subjects/punctuation/components/PunctuationSetupScene.jsx'))};
+
+    export function renderPunctuationSetupSceneStandalone(props) {
+      return renderToStaticMarkup(React.createElement(PunctuationSetupScene, props));
+    }
+  `);
+  buildSync({
+    absWorkingDir: rootDir,
+    entryPoints: [entryPath],
+    outfile: bundlePath,
+    bundle: true,
+    platform: 'node',
+    format: 'cjs',
+    target: ['node24'],
+    jsx: 'automatic',
+    jsxImportSource: 'react',
+    loader: { '.js': 'jsx' },
+    nodePaths: nodePaths(),
+    logLevel: 'silent',
+  });
+  renderer = require(bundlePath);
+  return renderer;
+}
+
+export function renderPunctuationSetupSceneStandalone(props) {
+  return loadRenderer().renderPunctuationSetupSceneStandalone(props);
+}
+
+export function cleanupPunctuationSceneRenderer() {
+  renderer = null;
+  if (rendererDir) rmSync(rendererDir, { recursive: true, force: true });
+  rendererDir = null;
+}

--- a/tests/helpers/react-app-ssr.js
+++ b/tests/helpers/react-app-ssr.js
@@ -65,6 +65,12 @@ function loadRenderer() {
         openAdminHub() { controller.store.openAdminHub(); },
         logout() {},
         retryPersistence() { controller.dispatch('persistence-retry'); },
+        // adv-234 (HIGH 1): mirror the production buildSurfaceActions shape so
+        // components that need a store-merge latch (Punctuation Setup's
+        // prefsMigrated guard) behave the same way under SSR as in the browser.
+        updateSubjectUi(subjectId, updater) {
+          controller.store.updateSubjectUi(subjectId, updater);
+        },
       };
     }
 

--- a/tests/punctuation-view-model.test.js
+++ b/tests/punctuation-view-model.test.js
@@ -520,6 +520,32 @@ test('U1 view-model: buildPunctuationDashboardModel surfaces non-zero stats', ()
   assert.equal(model.primaryMode, 'smart');
 });
 
+test('U2 view-model (adv-234 HIGH 3): Today-card detail strings are child-register', () => {
+  // Original Phase 3 U2 copy leaked "Reward units you own" / "This release"
+  // — the former exposes the internal "reward unit" token, the latter the
+  // release-id bookkeeping term. Both are adult-register and must not
+  // render to a child learner. This test locks the replacements so a
+  // future copy drift that reinstates either string fails loudly.
+  const model = buildPunctuationDashboardModel(
+    { due: 1, weak: 1, securedRewardUnits: 1, accuracy: 50 },
+    { prefs: { mode: 'smart' } },
+    {},
+  );
+  const byId = Object.fromEntries(model.todayCards.map((card) => [card.id, card]));
+  // Forbidden adult strings must not reappear.
+  assert.notEqual(byId.secure.detail, 'Reward units you own');
+  assert.notEqual(byId.accuracy.detail, 'This release');
+  // Every detail string is non-empty and short (the 3-5 word slot the
+  // dashboard grid was designed around).
+  for (const card of model.todayCards) {
+    assert.equal(typeof card.detail, 'string');
+    assert.ok(card.detail.length > 0, `card ${card.id} detail is empty`);
+    // Child-register sanity: no raw "release" / "reward unit" tokens.
+    assert.ok(!/reward units?/i.test(card.detail), `card ${card.id} detail references "reward unit"`);
+    assert.ok(!/\brelease\b/i.test(card.detail), `card ${card.id} detail references "release"`);
+  }
+});
+
 test('U1 view-model: buildPunctuationDashboardModel activeMonsters iterate only the 4 active ids', () => {
   const rewardState = {
     pealark: { mastered: ['m1', 'm2'] },

--- a/tests/react-punctuation-scene.test.js
+++ b/tests/react-punctuation-scene.test.js
@@ -2484,3 +2484,123 @@ test('punctuation remote dispatch (adv-234 HIGH 1): production-shape routing lat
   const savePrefsCallsAfterSecondMount = sent.filter((request) => request.command === 'save-prefs');
   assert.equal(savePrefsCallsAfterSecondMount.length, 0, 'second mount must not re-fire the save-prefs Worker call');
 });
+
+test('punctuation remote dispatch (adv-234-006 MEDIUM): Worker save-prefs failure rearms prefsMigrated latch', async () => {
+  // adv-234-006: if the Worker `save-prefs` command rejects (network /
+  // 5xx / offline) after the Setup scene has latched
+  // `ui.prefsMigrated: true` CLIENT-SIDE (the adv-234 HIGH 1 fix), the
+  // stored prefs on the repo remain on the legacy cluster mode but the
+  // client latch persists as true. Without reversing the latch on
+  // failure, every subsequent Setup render sees `legacyCluster=true`
+  // AND `prefsMigrated=true` — the migration never re-fires and the
+  // learner is stuck with the Smart Review aria-pressed state while
+  // each session runs the stored cluster mode.
+  //
+  // The fix wires `createSubjectCommandActionHandler`'s onCommandError
+  // through `createPunctuationOnCommandError`, which clears
+  // `prefsMigrated` back to false when the failing command is
+  // `save-prefs`. A subsequent Setup render can then retry migration.
+  //
+  // This test mirrors the adv-234 HIGH 1 production-dispatch pattern
+  // above but swaps the mock subjectCommands for a rejecting one and
+  // wires the real factory so we exercise the production contract.
+
+  const { createSubjectCommandActionHandler } = await import(
+    '../src/platform/runtime/subject-command-actions.js'
+  );
+  const {
+    createPunctuationOnCommandError,
+    punctuationSubjectCommandActions,
+  } = await import('../src/subjects/punctuation/command-actions.js');
+
+  const harness = createPunctuationHarness();
+  const learnerId = harness.store.getState().learners.selectedId;
+  harness.services.punctuation.savePrefs(learnerId, { mode: 'endmarks', roundLength: '4' });
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+
+  // Rejecting subjectCommands — every `send` fails with a network error.
+  const sent = [];
+  const subjectCommands = {
+    send(request) {
+      sent.push(request);
+      return Promise.reject(new Error('network failure'));
+    },
+  };
+
+  // Capture subject-error strings the factory forwards to set-error.
+  const subjectErrors = [];
+
+  // Wire the PRODUCTION onCommandError factory so the test exercises the
+  // same code path as main.js — not a test-only inline copy.
+  const punctuationCommandHandler = createSubjectCommandActionHandler({
+    subjectId: 'punctuation',
+    subjectCommands,
+    getState: () => harness.store.getState(),
+    actions: punctuationSubjectCommandActions,
+    onCommandError: createPunctuationOnCommandError({
+      store: harness.store,
+      setSubjectError: (message) => {
+        subjectErrors.push(message);
+      },
+      warn: () => {},
+    }),
+  });
+
+  function prodDispatch(action, data = {}) {
+    const handled = punctuationCommandHandler.handle(action, data);
+    if (!handled) {
+      harness.handleSubjectAction(action, data);
+    }
+  }
+
+  const { renderPunctuationSetupSceneStandalone } = await import(
+    './helpers/punctuation-scene-render.js'
+  );
+  renderPunctuationSetupSceneStandalone({
+    ui: harness.store.getState().subjectUi.punctuation,
+    actions: {
+      dispatch: prodDispatch,
+      updateSubjectUi: (subjectId, updater) => harness.store.updateSubjectUi(subjectId, updater),
+    },
+    prefs: { mode: 'endmarks', roundLength: '4' },
+    stats: {},
+    learner: null,
+    rewardState: {},
+  });
+
+  // The migration dispatch latches `prefsMigrated: true` BEFORE the
+  // Worker send fires — mirror of the adv-234 HIGH 1 invariant.
+  assert.equal(
+    harness.store.getState().subjectUi.punctuation.prefsMigrated,
+    true,
+    'migration must latch `prefsMigrated: true` before dispatch',
+  );
+
+  // Exactly one save-prefs request reaches the (rejecting) mock.
+  const savePrefsCalls = sent.filter((request) => request.command === 'save-prefs');
+  assert.equal(savePrefsCalls.length, 1, `expected exactly one save-prefs Worker call, got ${savePrefsCalls.length}`);
+
+  // Flush queued microtasks so the reject + onCommandError settle.
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+
+  // Core adv-234-006 assertion: the latch is CLEARED so the next render
+  // can retry the migration. Without the fix, the latch stays true and
+  // the learner is stranded with a stored cluster mode.
+  assert.equal(
+    harness.store.getState().subjectUi.punctuation.prefsMigrated,
+    false,
+    'save-prefs failure must clear `prefsMigrated` so the migration can retry',
+  );
+
+  // Stored prefs on the repo are unchanged — the Worker rejection means
+  // no persistence happened — so the next render's legacyCluster check
+  // still matches and a retry is warranted.
+  const repoPrefs = harness.services.punctuation.getPrefs(learnerId);
+  assert.equal(repoPrefs.mode, 'endmarks', 'stored prefs.mode must remain on the legacy cluster after the Worker rejection');
+
+  // A subject-error message is surfaced so the learner/UX knows the
+  // command failed — factory keeps parity with the previous behaviour.
+  assert.ok(subjectErrors.length >= 1, 'save-prefs failure must surface a subject error');
+});

--- a/tests/react-punctuation-scene.test.js
+++ b/tests/react-punctuation-scene.test.js
@@ -2225,3 +2225,262 @@ test('punctuation Setup scene stale-prefs migration: re-render does not re-dispa
   // The migration did NOT fire again — the revert stands.
   assert.equal(harness.store.getState().subjectUi.punctuation.prefs.mode, 'speech');
 });
+
+test('punctuation Setup scene stale-prefs migration (adv-234 HIGH 1): store-level prefsMigrated latch is set by the render', () => {
+  // adv-234 HIGH 1: the Scene latches `ui.prefsMigrated: true` VIA
+  // `actions.updateSubjectUi` BEFORE the `punctuation-set-mode` dispatch
+  // fires, so the latch lands regardless of whether the dispatch routes
+  // through the module handler (test harness) or the remote command
+  // boundary (production `handleRemotePunctuationAction` path — where the
+  // Worker `save-prefs` command short-circuits the fall-through to
+  // `handleSubjectAction`). We assert the store state directly after the
+  // first render — `ui.prefsMigrated === true` proves the client-side
+  // latch fired.
+  const harness = createPunctuationHarness();
+  const learnerId = harness.store.getState().learners.selectedId;
+  harness.services.punctuation.savePrefs(learnerId, { mode: 'endmarks', roundLength: '4' });
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+
+  const beforeLatch = harness.store.getState().subjectUi.punctuation.prefsMigrated;
+  // Fresh Setup state — latch starts unset.
+  assert.ok(!beforeLatch, 'prefsMigrated must start unset on a fresh open-subject');
+
+  harness.render();
+
+  const afterLatch = harness.store.getState().subjectUi.punctuation.prefsMigrated;
+  assert.equal(afterLatch, true, 'prefsMigrated must latch true after the first Setup render migrates');
+});
+
+test('punctuation Setup scene stale-prefs migration (adv-234 HIGH 1): second mount with prefsMigrated set does NOT re-dispatch', () => {
+  // Second Setup mount (fresh component instance — `migratedRef` reset)
+  // where the store already carries `prefsMigrated: true` must NOT run
+  // the migration. This is the production regression the HIGH 1 fix
+  // closes: a subsequent SSR render of the Setup scene no longer re-
+  // fires the Worker `save-prefs` command.
+  //
+  // Stored mode is set to a legacy cluster value AND the latch is
+  // pre-set to simulate the "learner previously migrated this
+  // session" state. If the Scene ignores the store-level latch it
+  // will migrate `prefs.mode` back to 'smart' (mutation) and the
+  // test fails.
+  const harness = createPunctuationHarness();
+  const learnerId = harness.store.getState().learners.selectedId;
+  harness.services.punctuation.savePrefs(learnerId, { mode: 'speech', roundLength: '4' });
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.store.updateSubjectUi('punctuation', {
+    prefs: { mode: 'speech', roundLength: '4' },
+    prefsMigrated: true,
+  });
+
+  harness.render();
+
+  // The migration MUST NOT have run — stored mode stays at 'speech'.
+  assert.equal(harness.store.getState().subjectUi.punctuation.prefs.mode, 'speech');
+  // The latch stayed true.
+  assert.equal(harness.store.getState().subjectUi.punctuation.prefsMigrated, true);
+});
+
+test('punctuation module handler (adv-234-004 MEDIUM): punctuation-set-mode rejected from non-setup phases', () => {
+  // adv-234-004: set-mode is a Setup-scoped mutation. A dispatch from
+  // active-item / feedback / summary / map must not mutate prefs. This
+  // locks the phase guard at the module handler level — the Scene-side
+  // migration dispatch still works because Setup-phase render is the
+  // only trigger.
+  const harness = createPunctuationHarness();
+  const learnerId = harness.store.getState().learners.selectedId;
+  harness.services.punctuation.savePrefs(learnerId, { mode: 'smart', roundLength: '4' });
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+
+  // Force the Setup → active-item transition via a direct store merge so
+  // we don't rely on `punctuation-start` spinning a real session.
+  harness.store.updateSubjectUi('punctuation', {
+    phase: 'active-item',
+    session: { id: 'mid-session', currentItem: { id: 'it-1' }, answeredCount: 0 },
+    prefs: { mode: 'smart', roundLength: '4' },
+    prefsMigrated: true,
+  });
+
+  // Returns false from non-setup phase; controller.dispatch's
+  // `handled` boolean surfaces via handleSubjectAction.
+  const handled = harness.handleSubjectAction('punctuation-set-mode', { value: 'weak' });
+  assert.equal(handled, false, 'set-mode must be rejected from active-item phase');
+  // Stored mode is untouched.
+  assert.equal(harness.store.getState().subjectUi.punctuation.prefs.mode, 'smart');
+});
+
+test('punctuation module handler (adv-234-001 MEDIUM): punctuation-set-round-length rejected from non-setup phases', () => {
+  const harness = createPunctuationHarness();
+  const learnerId = harness.store.getState().learners.selectedId;
+  harness.services.punctuation.savePrefs(learnerId, { mode: 'smart', roundLength: '4' });
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+
+  harness.store.updateSubjectUi('punctuation', {
+    phase: 'active-item',
+    session: { id: 's-1', currentItem: { id: 'it' }, answeredCount: 0 },
+    prefs: { mode: 'smart', roundLength: '4' },
+    prefsMigrated: true,
+  });
+
+  const handled = harness.handleSubjectAction('punctuation-set-round-length', { value: '8' });
+  assert.equal(handled, false, 'set-round-length must be rejected from active-item phase');
+  // roundLength stays at 4.
+  assert.equal(harness.store.getState().subjectUi.punctuation.prefs.roundLength, '4');
+});
+
+test('punctuation module handler (adv-234-001 MEDIUM): punctuation-set-round-length rejects off-enum values (all / 1)', () => {
+  // The narrower UI-level enum is ['4', '8', '12']. The storage-level
+  // `normalisePunctuationRoundLength` accepts 1 / 2 / 3 / 6 / 'all' too —
+  // those are kept valid for the /start-session Worker command so legacy
+  // per-skill drills still work, but the Setup dashboard toggle must never
+  // accept them. Rogue 'all' / '1' payloads are rejected here.
+  const harness = createPunctuationHarness();
+  const learnerId = harness.store.getState().learners.selectedId;
+  harness.services.punctuation.savePrefs(learnerId, { mode: 'smart', roundLength: '4' });
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+
+  // Setup phase, but value is out of the narrow enum.
+  for (const badValue of ['all', '1', '2', '3', '6', 'seven', '', null, undefined, 4]) {
+    const handled = harness.handleSubjectAction('punctuation-set-round-length', { value: badValue });
+    assert.equal(handled, false, `set-round-length should reject value ${JSON.stringify(badValue)}`);
+    // Stored prefs (via the service) must still read roundLength '4'.
+    // `ui.prefs` is only populated once a successful handler mirrors — a
+    // rejected dispatch leaves `ui.prefs` undefined on a freshly-opened
+    // Setup, so we read from the repository via the service as the
+    // canonical source.
+    assert.equal(
+      harness.services.punctuation.getPrefs(learnerId).roundLength,
+      '4',
+      `stored prefs.roundLength must stay at 4 after rejected ${JSON.stringify(badValue)}`,
+    );
+  }
+});
+
+test('punctuation module handler (adv-234-001 MEDIUM): punctuation-set-round-length accepts each narrow-enum stop', () => {
+  // Positive-case pair for the rejection test above: the three narrow-enum
+  // stops DO save through to stored prefs when dispatched from Setup.
+  for (const value of ['4', '8', '12']) {
+    const harness = createPunctuationHarness();
+    const learnerId = harness.store.getState().learners.selectedId;
+    harness.services.punctuation.savePrefs(learnerId, { mode: 'smart', roundLength: '4' });
+    harness.dispatch('open-subject', { subjectId: 'punctuation' });
+
+    const handled = harness.handleSubjectAction('punctuation-set-round-length', { value });
+    assert.equal(handled, true, `set-round-length should accept ${value}`);
+    assert.equal(harness.store.getState().subjectUi.punctuation.prefs.roundLength, value);
+  }
+});
+
+test('punctuation remote dispatch (adv-234 HIGH 1): production-shape routing latches prefsMigrated and sends exactly one save-prefs', async () => {
+  // Simulates the production dispatch chain (main.js):
+  //   dispatchAction → handleRemotePunctuationAction → punctuationCommandActions.handle
+  // The subject-command-actions handler routes `punctuation-set-mode` through
+  // the Worker save-prefs command and RETURNS TRUE — the fall-through to
+  // `handleSubjectAction` (which would run the module handler that sets
+  // `prefsMigrated: true`) never happens in production. Before the HIGH 1
+  // fix, a subsequent SSR render would re-run the migration dispatch and
+  // send ANOTHER save-prefs command to the Worker.
+  //
+  // The fix latches `ui.prefsMigrated: true` CLIENT-SIDE via
+  // `actions.updateSubjectUi` BEFORE the dispatch fires, so regardless of
+  // downstream routing the store's `prefsMigrated` gate is set and the
+  // next render skips the migration.
+  //
+  // This test verifies that contract end-to-end without spinning the full
+  // main.js stack: we render the Setup scene with `actions.dispatch` wired
+  // to a production-shaped routing that calls the real
+  // `punctuationCommandActions.handle` against a mock subjectCommands.
+
+  // Deferred imports so other test files don't pay the cost.
+  const { createSubjectCommandActionHandler } = await import(
+    '../src/platform/runtime/subject-command-actions.js'
+  );
+  const { punctuationSubjectCommandActions } = await import(
+    '../src/subjects/punctuation/command-actions.js'
+  );
+
+  const harness = createPunctuationHarness();
+  const learnerId = harness.store.getState().learners.selectedId;
+  harness.services.punctuation.savePrefs(learnerId, { mode: 'endmarks', roundLength: '4' });
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+
+  // Mock subject-command client — captures every outgoing request and
+  // resolves each `send` with a benign response.
+  const sent = [];
+  const subjectCommands = {
+    send(request) {
+      sent.push(request);
+      return Promise.resolve({ ok: true, learnerId: request.learnerId });
+    },
+  };
+  const punctuationCommandHandler = createSubjectCommandActionHandler({
+    subjectId: 'punctuation',
+    subjectCommands,
+    getState: () => harness.store.getState(),
+    actions: punctuationSubjectCommandActions,
+  });
+
+  // Production-shape dispatch: handleRemotePunctuationAction → handler.handle
+  // short-circuits for set-mode (and the other mapped actions). If the
+  // handler does NOT claim the action it falls through to the module
+  // handleAction so setup-only UI mutations (updateSubjectUi) still land.
+  function prodDispatch(action, data = {}) {
+    const handled = punctuationCommandHandler.handle(action, data);
+    if (!handled) {
+      harness.handleSubjectAction(action, data);
+    }
+  }
+
+  // Render the Setup scene directly with a production-shaped actions
+  // object. The Scene's migration dispatch must both latch
+  // `prefsMigrated: true` AND emit exactly one save-prefs Worker call.
+  const { renderPunctuationSetupSceneStandalone } = await import(
+    './helpers/punctuation-scene-render.js'
+  );
+  renderPunctuationSetupSceneStandalone({
+    ui: harness.store.getState().subjectUi.punctuation,
+    actions: {
+      dispatch: prodDispatch,
+      updateSubjectUi: (subjectId, updater) => harness.store.updateSubjectUi(subjectId, updater),
+    },
+    prefs: { mode: 'endmarks', roundLength: '4' },
+    stats: {},
+    learner: null,
+    rewardState: {},
+  });
+
+  // Flush the queued promise microtasks so the send() resolutions settle.
+  await Promise.resolve();
+  await Promise.resolve();
+
+  // Exactly one save-prefs command should have been sent to the Worker.
+  const savePrefsCalls = sent.filter((request) => request.command === 'save-prefs');
+  assert.equal(savePrefsCalls.length, 1, `expected exactly one save-prefs Worker call, got ${savePrefsCalls.length}`);
+  assert.deepEqual(savePrefsCalls[0].payload, { prefs: { mode: 'smart' } });
+
+  // The store-level latch was set BY THE SCENE BEFORE the dispatch — not
+  // by the (never-invoked-in-prod) module handler. This is the key
+  // HIGH 1 assertion.
+  assert.equal(harness.store.getState().subjectUi.punctuation.prefsMigrated, true);
+
+  // A second render MUST NOT re-fire the migration. Because we use the
+  // same Scene helper but a fresh component tree, the only remaining
+  // gate is the store-level `prefsMigrated` latch.
+  sent.length = 0;
+  renderPunctuationSetupSceneStandalone({
+    ui: harness.store.getState().subjectUi.punctuation,
+    actions: {
+      dispatch: prodDispatch,
+      updateSubjectUi: (subjectId, updater) => harness.store.updateSubjectUi(subjectId, updater),
+    },
+    // Deliberately simulate a data-restore that rolled prefs back to a
+    // legacy cluster mode — the latch must STILL block re-migration.
+    prefs: { mode: 'boundary', roundLength: '4' },
+    stats: {},
+    learner: null,
+    rewardState: {},
+  });
+  await Promise.resolve();
+
+  const savePrefsCallsAfterSecondMount = sent.filter((request) => request.command === 'save-prefs');
+  assert.equal(savePrefsCallsAfterSecondMount.length, 0, 'second mount must not re-fire the save-prefs Worker call');
+});

--- a/tests/react-punctuation-scene.test.js
+++ b/tests/react-punctuation-scene.test.js
@@ -45,22 +45,24 @@ function answerCurrentItemCorrectly(harness) {
 }
 
 test('punctuation React surface renders setup, active item, feedback and summary states', () => {
+  // Phase 3 U2 replaces the Phase 2 ten-button mode grid with a
+  // dashboard hero + three primary mode cards (Smart Review / Wobbly
+  // Spots / GPS Check) + one Open Map secondary card + round-length
+  // toggle. The old `data-punctuation-*-start` data attributes and
+  // `Endmarks focus` / `Apostrophe focus` / etc. labels are gone —
+  // the U2 describe block below tests the new dashboard shape
+  // explicitly, so this smoke test only asserts the hero + the
+  // three primary card labels land on Setup.
   const harness = createPunctuationHarness();
   harness.dispatch('open-subject', { subjectId: 'punctuation' });
 
   const setupHtml = harness.render();
   assert.match(setupHtml, /Bellstorm Coast/);
   assert.match(setupHtml, /Punctuation practice/);
-  assert.match(setupHtml, /data-punctuation-start/);
-  // Phase 2 U8: all six cluster focus buttons must reach the setup surface.
-  assert.match(setupHtml, /data-punctuation-endmarks-start/);
-  assert.match(setupHtml, /data-punctuation-apostrophe-start/);
-  assert.match(setupHtml, />Endmarks focus</);
-  assert.match(setupHtml, />Apostrophe focus</);
-  assert.match(setupHtml, />Speech focus</);
-  assert.match(setupHtml, />Comma focus</);
-  assert.match(setupHtml, />Boundary focus</);
-  assert.match(setupHtml, />Structure focus</);
+  assert.match(setupHtml, />Smart Review</);
+  assert.match(setupHtml, />Wobbly Spots</);
+  assert.match(setupHtml, />GPS Check</);
+  assert.match(setupHtml, /data-action="punctuation-set-mode"/);
 
   startOneItemPunctuationSession(harness);
   const activeHtml = harness.render();
@@ -92,28 +94,14 @@ test('punctuation React surface keeps server-only fields out of active HTML', ()
   assert.equal(html.includes(PUNCTUATION_RELEASE_ID), false);
 });
 
-test('punctuation React surface renders guided setup controls and teach boxes', () => {
+test('punctuation React surface renders Guided teach box during an active session', () => {
+  // Phase 3 U2: the setup-surface Guided dropdown + Weak / GPS buttons
+  // are removed (the new dashboard uses three primary mode cards +
+  // Open Map). This test keeps the active-item Guided teach-box
+  // regression coverage — the current session's guided teach-box
+  // payload still renders rule + worked example + common mistake.
   const harness = createPunctuationHarness();
   harness.dispatch('open-subject', { subjectId: 'punctuation' });
-  harness.store.updateSubjectUi('punctuation', {
-    phase: 'setup',
-    content: {
-      publishedScopeCopy: 'This Punctuation release covers all 14 KS2 punctuation skills.',
-      skills: [
-        { id: 'sentence_endings', name: 'Capital letters and sentence endings', clusterId: 'endmarks' },
-        { id: 'speech', name: 'Inverted commas and speech punctuation', clusterId: 'speech' },
-      ],
-    },
-  });
-
-  const setupHtml = harness.render();
-  assert.match(setupHtml, /Guided skill/);
-  assert.match(setupHtml, /Guided learn/);
-  assert.match(setupHtml, /data-punctuation-guided-start/);
-  assert.match(setupHtml, /Weak spots/);
-  assert.match(setupHtml, /data-punctuation-weak-start/);
-  assert.match(setupHtml, /GPS test/);
-  assert.match(setupHtml, /data-punctuation-gps-start/);
 
   harness.store.updateSubjectUi('punctuation', {
     phase: 'active-item',
@@ -434,7 +422,12 @@ test('punctuation text-item controls disable when runtime is degraded', () => {
   assert.match(html, /<button[^>]*disabled[^>]*data-punctuation-submit/);
 });
 
-test('punctuation setup view disables Start practice when availability is degraded', () => {
+test('punctuation setup view disables primary mode cards when availability is degraded', () => {
+  // Phase 3 U2: the old `data-punctuation-start` Start practice button
+  // is replaced with three primary mode cards + an Open Map secondary
+  // card. Every mutation control threads `composeIsDisabled(ui)`, so
+  // degraded availability disables the Smart Review card (and every
+  // other card beside it).
   const harness = createPunctuationHarness();
   harness.dispatch('open-subject', { subjectId: 'punctuation' });
   harness.store.updateSubjectUi('punctuation', {
@@ -442,7 +435,11 @@ test('punctuation setup view disables Start practice when availability is degrad
     availability: { status: 'degraded', code: 'runtime_degraded', message: 'paused' },
   });
   const html = harness.render();
-  assert.match(html, /<button[^>]*disabled[^>]*data-punctuation-start/);
+  assert.match(
+    html,
+    /<button[^>]*disabled[^>]*data-action="punctuation-set-mode"[^>]*data-value="smart"|<button[^>]*data-action="punctuation-set-mode"[^>]*data-value="smart"[^>]*disabled/,
+    'Smart Review card must be disabled under degraded availability',
+  );
 });
 
 test('punctuation feedback view disables Continue while a command is pending', () => {
@@ -1901,4 +1898,330 @@ test('design-lens HIGH: every item mode passes the PUNCTUATION_CHILD_FORBIDDEN_T
       `forbidden term leak in session scene (${extra.mode}): ${leaks.join(', ')}`,
     );
   }
+});
+
+// ---------------------------------------------------------------------------
+// Phase 3 U2 — Punctuation setup scene (child dashboard).
+//
+// Replaces the Phase 2 ten-button mode grid with Hero + Today cards +
+// three primary journey cards (Smart Review / Wobbly Spots / GPS Check) +
+// one "Open Punctuation Map" secondary card + compact round-length
+// toggle + active-monster strip. Reserved monsters (Colisk / Hyphang /
+// Carillon) NEVER surface regardless of state shape.
+//
+// SSR blind spots (learning #6): focus, pointer-capture, and scroll are
+// not observable here — assertions pair HTML-match with state-level
+// checks (learning #7) where a silent no-op would otherwise pass.
+// ---------------------------------------------------------------------------
+
+function forbiddenTermsInSetupHtml(html) {
+  const leaks = [];
+  for (const term of PUNCTUATION_CHILD_FORBIDDEN_TERMS) {
+    if (term instanceof RegExp) {
+      if (term.test(html)) leaks.push(String(term));
+      continue;
+    }
+    if (typeof term !== 'string' || !term) continue;
+    if (html.toLowerCase().includes(term.toLowerCase())) leaks.push(term);
+  }
+  return leaks;
+}
+
+test('punctuation Setup scene renders 3 primary mode cards + Open Map secondary card', () => {
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  const html = harness.render();
+
+  // Three primary journey cards, each tagged by mode id.
+  for (const modeId of ['smart', 'weak', 'gps']) {
+    assert.match(
+      html,
+      new RegExp(`data-action="punctuation-set-mode"[^>]*data-value="${modeId}"`),
+      `missing primary mode card for ${modeId}`,
+    );
+  }
+  // Child-facing labels land too.
+  assert.match(html, />Smart Review</);
+  assert.match(html, />Wobbly Spots</);
+  assert.match(html, />GPS Check</);
+  // Exactly one Open Map secondary card.
+  const openMapMatches = html.match(/data-action="punctuation-open-map"/g) || [];
+  assert.equal(openMapMatches.length, 1, 'expected exactly one Open Map affordance');
+  assert.match(html, />Open Punctuation Map</);
+});
+
+test('punctuation Setup scene does not render the 6 cluster focus buttons (plan R1)', () => {
+  // Phase 3 U2 demotes the 6 cluster focus modes from primary-setup
+  // affordances. They stay dispatchable via direct mode dispatch
+  // (Phase 2 U9 parity matrix) but should never appear as Setup
+  // buttons again. Regression guard against a future revert.
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  const html = harness.render();
+
+  for (const label of ['Endmarks focus', 'Apostrophe focus', 'Speech focus', 'Comma focus', 'Boundary focus', 'Structure focus']) {
+    assert.doesNotMatch(html, new RegExp(`>${label}<`), `${label} should no longer render on Setup`);
+  }
+  // Also check the old data attributes are gone.
+  assert.doesNotMatch(html, /data-punctuation-endmarks-start/);
+  assert.doesNotMatch(html, /data-punctuation-apostrophe-start/);
+  assert.doesNotMatch(html, /data-punctuation-guided-start/);
+  assert.doesNotMatch(html, /data-punctuation-weak-start/);
+  assert.doesNotMatch(html, /data-punctuation-gps-start/);
+});
+
+test('punctuation Setup scene Smart Review card has aria-pressed="true" when prefs.mode is smart', () => {
+  const harness = createPunctuationHarness();
+  const learnerId = harness.store.getState().learners.selectedId;
+  harness.services.punctuation.savePrefs(learnerId, { mode: 'smart', roundLength: '4' });
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  // Force a fresh dispatch so ui.prefs mirrors the stored mode.
+  harness.dispatch('punctuation-set-mode', { value: 'smart' });
+  const html = harness.render();
+
+  assert.match(
+    html,
+    /data-value="smart"[^>]*aria-pressed="true"|aria-pressed="true"[^>]*data-value="smart"/,
+    'Smart Review card should be aria-pressed="true" when prefs.mode === "smart"',
+  );
+});
+
+test('punctuation Setup scene Wobbly card has aria-pressed="true" when prefs.mode is weak', () => {
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.dispatch('punctuation-set-mode', { value: 'weak' });
+  const html = harness.render();
+  assert.match(
+    html,
+    /data-value="weak"[^>]*aria-pressed="true"|aria-pressed="true"[^>]*data-value="weak"/,
+    'Wobbly Spots card should be aria-pressed="true" when prefs.mode === "weak"',
+  );
+});
+
+test('punctuation Setup scene GPS card has aria-pressed="true" when prefs.mode is gps', () => {
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.dispatch('punctuation-set-mode', { value: 'gps' });
+  const html = harness.render();
+  assert.match(
+    html,
+    /data-value="gps"[^>]*aria-pressed="true"|aria-pressed="true"[^>]*data-value="gps"/,
+    'GPS Check card should be aria-pressed="true" when prefs.mode === "gps"',
+  );
+});
+
+test('punctuation Setup scene: clicking Smart Review sets state.subjectUi.punctuation.prefs.mode to smart', () => {
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.dispatch('punctuation-set-mode', { value: 'smart' });
+  const state = harness.store.getState().subjectUi.punctuation;
+  assert.equal(state.prefs.mode, 'smart');
+});
+
+test('punctuation Setup scene: clicking Wobbly sets state.subjectUi.punctuation.prefs.mode to weak', () => {
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.dispatch('punctuation-set-mode', { value: 'weak' });
+  const state = harness.store.getState().subjectUi.punctuation;
+  assert.equal(state.prefs.mode, 'weak');
+});
+
+test('punctuation Setup scene: clicking GPS sets state.subjectUi.punctuation.prefs.mode to gps', () => {
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.dispatch('punctuation-set-mode', { value: 'gps' });
+  const state = harness.store.getState().subjectUi.punctuation;
+  assert.equal(state.prefs.mode, 'gps');
+});
+
+test('punctuation Setup scene: Open Map dispatch transitions phase setup → map (paired state assertion)', () => {
+  // Paired state-level assertion per learning #7 — catches the
+  // U2-before-U5 ordering gap where the dispatch silently no-ops.
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  assert.equal(harness.store.getState().subjectUi.punctuation.phase, 'setup');
+
+  harness.dispatch('punctuation-open-map');
+  assert.equal(harness.store.getState().subjectUi.punctuation.phase, 'map');
+});
+
+test('punctuation Setup scene: degraded availability disables every primary and secondary card', () => {
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.store.updateSubjectUi('punctuation', {
+    availability: { status: 'degraded', code: 'runtime_degraded', message: 'paused' },
+  });
+  const html = harness.render();
+
+  // Each primary mode card is disabled.
+  for (const modeId of ['smart', 'weak', 'gps']) {
+    assert.match(
+      html,
+      new RegExp(`<button[^>]*disabled[^>]*data-action="punctuation-set-mode"[^>]*data-value="${modeId}"|<button[^>]*data-action="punctuation-set-mode"[^>]*data-value="${modeId}"[^>]*disabled`),
+      `primary mode card ${modeId} should be disabled under degraded availability`,
+    );
+  }
+  // Open Map secondary card is disabled.
+  assert.match(
+    html,
+    /<button[^>]*disabled[^>]*data-action="punctuation-open-map"|<button[^>]*data-action="punctuation-open-map"[^>]*disabled/,
+    'Open Map card should be disabled under degraded availability',
+  );
+});
+
+test('punctuation Setup scene: pendingCommand disables every primary and secondary card', () => {
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.store.updateSubjectUi('punctuation', {
+    pendingCommand: 'save-prefs',
+  });
+  const html = harness.render();
+
+  for (const modeId of ['smart', 'weak', 'gps']) {
+    assert.match(
+      html,
+      new RegExp(`<button[^>]*disabled[^>]*data-action="punctuation-set-mode"[^>]*data-value="${modeId}"|<button[^>]*data-action="punctuation-set-mode"[^>]*data-value="${modeId}"[^>]*disabled`),
+      `primary mode card ${modeId} should be disabled while pendingCommand is set`,
+    );
+  }
+  assert.match(
+    html,
+    /<button[^>]*disabled[^>]*data-action="punctuation-open-map"|<button[^>]*data-action="punctuation-open-map"[^>]*disabled/,
+    'Open Map card should be disabled while pendingCommand is set',
+  );
+});
+
+test('punctuation Setup scene: fresh learner renders zero-state copy (guards Phase 2 hasEvidence fix)', () => {
+  // A fresh learner with no stats should NOT see "1 skill due" or any
+  // inflated Today counter. The empty-state copy lives in a dedicated
+  // data-testid hook so this test stays resilient to copy tweaks.
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  const html = harness.render();
+
+  // Zero-state copy lands — every count is zero, so the dashboard
+  // shows the empty-state prompt instead of the grid.
+  assert.match(html, /data-testid="punctuation-today-empty"/);
+});
+
+test('punctuation Setup scene: reserved monster ids NEVER appear in the active monster strip', () => {
+  // Smuggle reserved monster entries into the reward state. The
+  // iterator is `ACTIVE_PUNCTUATION_MONSTER_IDS` only (plan R10), so
+  // even a poisoned rewardState must not surface the reserved trio.
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.store.updateSubjectUi('punctuation', {
+    rewardState: {
+      pealark: { mastered: ['r1'] },
+      colisk: { mastered: ['c1', 'c2'] },
+      hyphang: { mastered: ['h1'] },
+      carillon: { mastered: ['ca1'] },
+    },
+  });
+  const html = harness.render();
+
+  for (const reserved of ['colisk', 'hyphang', 'carillon']) {
+    assert.doesNotMatch(
+      html,
+      new RegExp(`data-monster-id="${reserved}"`),
+      `reserved monster ${reserved} leaked into the active monster strip`,
+    );
+  }
+  // The four active monsters all render.
+  for (const active of ['pealark', 'claspin', 'curlune', 'quoral']) {
+    assert.match(
+      html,
+      new RegExp(`data-monster-id="${active}"`),
+      `active monster ${active} should render in the strip`,
+    );
+  }
+});
+
+test('punctuation Setup scene SSR HTML contains no forbidden child terms', () => {
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  const html = harness.render();
+  const leaks = forbiddenTermsInSetupHtml(html);
+  assert.deepEqual(leaks, [], `forbidden term leak in Setup scene HTML: ${leaks.join(', ')}`);
+});
+
+test('punctuation Setup scene stale-prefs migration: endmarks prefs collapse to smart on first render', () => {
+  // Pre-Phase-3 stored `prefs.mode === 'endmarks'` → Setup renders with
+  // Smart Review aria-pressed="true" (display normaliser) AND first
+  // render dispatches `punctuation-set-mode` with `{ value: 'smart' }`
+  // to migrate stored state once.
+  const harness = createPunctuationHarness();
+  const learnerId = harness.store.getState().learners.selectedId;
+  harness.services.punctuation.savePrefs(learnerId, { mode: 'endmarks', roundLength: '4' });
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+
+  // First render — the effect dispatches the migration.
+  const html = harness.render();
+  // Display collapse: Smart Review reads as aria-pressed="true".
+  assert.match(
+    html,
+    /data-value="smart"[^>]*aria-pressed="true"|aria-pressed="true"[^>]*data-value="smart"/,
+    'Smart Review must render as aria-pressed="true" when prefs.mode is a legacy cluster value',
+  );
+  // Migration persisted — stored prefs.mode is now 'smart'.
+  assert.equal(harness.store.getState().subjectUi.punctuation.prefs.mode, 'smart');
+});
+
+test('punctuation Setup scene stale-prefs migration: apostrophe prefs also collapse to smart', () => {
+  const harness = createPunctuationHarness();
+  const learnerId = harness.store.getState().learners.selectedId;
+  harness.services.punctuation.savePrefs(learnerId, { mode: 'apostrophe', roundLength: '4' });
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.render();
+  assert.equal(harness.store.getState().subjectUi.punctuation.prefs.mode, 'smart');
+});
+
+test('punctuation Setup scene stale-prefs migration: guided prefs also collapse to smart', () => {
+  // `'guided'` is the seventh value that should migrate — Guided is no
+  // longer a primary affordance (the Modal's Practise-this path is
+  // Guided under the hood, but the learner-facing mode is collapsed).
+  const harness = createPunctuationHarness();
+  const learnerId = harness.store.getState().learners.selectedId;
+  harness.services.punctuation.savePrefs(learnerId, { mode: 'guided', roundLength: '4' });
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.render();
+  assert.equal(harness.store.getState().subjectUi.punctuation.prefs.mode, 'smart');
+});
+
+test('punctuation Setup scene stale-prefs migration: smart prefs do NOT trigger a migration dispatch', () => {
+  // Starting with `prefs.mode === 'smart'` should not touch the store's
+  // prefs at all (no re-dispatch, no updateSubjectUi with a prefs
+  // delta). We snapshot the store version before and after the render.
+  const harness = createPunctuationHarness();
+  const learnerId = harness.store.getState().learners.selectedId;
+  harness.services.punctuation.savePrefs(learnerId, { mode: 'smart', roundLength: '4' });
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.render();
+  // The store should still have the fresh-open state — stored mode
+  // never flipped to anything else.
+  const state = harness.store.getState().subjectUi.punctuation;
+  // `state.prefs` is undefined until a dispatch mirrors it into ui
+  // state; the absence itself proves no migration dispatch fired.
+  assert.ok(!state.prefs || state.prefs.mode === 'smart');
+});
+
+test('punctuation Setup scene stale-prefs migration: re-render does not re-dispatch', () => {
+  // After the first render migrates, a subsequent render with the same
+  // component instance must not re-dispatch — the `useRef` gate in
+  // `PunctuationSetupScene.jsx` closes the loop.
+  const harness = createPunctuationHarness();
+  const learnerId = harness.store.getState().learners.selectedId;
+  harness.services.punctuation.savePrefs(learnerId, { mode: 'boundary', roundLength: '4' });
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+
+  harness.render();
+  assert.equal(harness.store.getState().subjectUi.punctuation.prefs.mode, 'smart');
+
+  // Force prefs.mode to revert via direct store mutation — the next
+  // render must not re-run the migration because `migratedRef` stays
+  // true within the same component instance.
+  harness.store.updateSubjectUi('punctuation', { prefs: { mode: 'speech', roundLength: '4' } });
+  harness.render();
+  // The migration did NOT fire again — the revert stands.
+  assert.equal(harness.store.getState().subjectUi.punctuation.prefs.mode, 'speech');
 });


### PR DESCRIPTION
## Summary
- New `PunctuationSetupScene.jsx` with hero + today cards + 3 primary mode cards (Smart / Wobbly / GPS) + 1 Open Map secondary card + round-length toggle + active monster strip.
- Removes the 10-button mode grid from the setup surface.
- One-shot stale-prefs migration: on first render, if `prefs.mode` is one of the 6 cluster values or `'guided'`, dispatch `punctuation-set-mode` `{ value: 'smart' }`. Client-side `prefsMigrated` latch (set BEFORE the dispatch via `actions.updateSubjectUi`) prevents re-dispatch across SSR mounts even when the dispatch routes through the remote Worker command layer.
- Router delegates `setup` phase to new scene.
- `punctuationPrimaryModeFromPrefs` determines `aria-pressed` on primary cards (display-only collapse).

## adv-234 follower pass (2026-04-25)
- **HIGH 1 fixed** — prod dispatch bypass. `handleRemotePunctuationAction` routes `punctuation-set-mode` through `punctuationCommandActions.handle` (Worker `save-prefs`) and returns `true`, never falling through to `handleSubjectAction` → module handler. The module handler's `prefsMigrated: true` store update therefore only lands in the test harness. Fix: added `actions.updateSubjectUi(subjectId, updater)` to `buildSurfaceActions` (main.js) and the SSR harness (`react-app-ssr.js`); Scene latches `prefsMigrated: true` client-side BEFORE the dispatch so production and harness agree.
- **HIGH 2 over-flagged** — `publishedTotal` is a JS identifier in the view-model, not text that ever reaches rendered HTML (`${progress.mastered}/${progress.publishedTotal} secure` renders as `"3/14 secure"`). Setup scene SSR forbidden-terms sweep (`tests/react-punctuation-scene.test.js:974`) confirms no literal leak; no refactor shipped.
- **HIGH 3 fixed** — `'Reward units you own'` → `'Skills you know well'`; `'This release'` → `'Your best so far'`. Locked by a new view-model test asserting neither adult-register string re-appears in `todayCards[].detail`.
- **MEDIUM adv-234-001 fixed** — `punctuation-set-round-length` now guards on `ui.phase === 'setup'` and validates against the narrower UI enum `PUNCTUATION_SETUP_ROUND_LENGTH_OPTIONS = ['4', '8', '12']`, not the storage-sanitiser superset that also accepts `1 / 2 / 3 / 6 / 'all'`. Shared frozen const in `punctuation-view-model.js` so the Scene and module handler cannot drift.
- **MEDIUM adv-234-004 fixed** — `punctuation-set-mode` gains a `ui.phase === 'setup'` guard. The migration dispatch still fires because the Setup scene is itself rendered under that phase.
- **MEDIUM adv-234-002 fixed** — corrected the misleading "session-memory only; not persisted" comment. `prefsMigrated` DOES persist via `subjectStates.writeUi` by design, matching the plan's one-shot-per-learner intent.
- **MEDIUM adv-234-003 accepted risk** — Parent-Hub backup restore that rolls stored prefs back to a legacy cluster mode while leaving `prefsMigrated: true` in place leaves the learner stuck on display-collapsed `'smart'` until a manual `punctuation-set-mode` `{ value: 'smart' }` re-saves. Parent-Hub restore is a rare operator path; the workaround is a one-tap Setup action. Deferred to a future guardian-layer pass rather than fixed here (would require `sanitisePunctuationUiOnRehydrate` to read `prefs` and re-arm `prefsMigrated`, widening the sanitiser's responsibility).

## Plan reference
U2.

## Release-id impact
`release-id impact: none`.

## Test plan
- [x] 3 primary cards + Open Map secondary; no 10-button mode grid
- [x] Stale-prefs migration (6 clusters + guided → smart, one-shot)
- [x] Reserved monsters absent from active-monster strip
- [x] composeIsDisabled threads through every control
- [x] No PUNCTUATION_CHILD_FORBIDDEN_TERMS
- [x] Open Map dispatch transitions phase setup → map (paired state assertion)
- [x] HIGH 1: store-level `prefsMigrated` latch set on first render
- [x] HIGH 1: second SSR mount with latch set does NOT re-fire Worker `save-prefs`
- [x] HIGH 1 integration: production-shape routing through real `punctuationSubjectCommandActions` + mock subject-command-client sends exactly one `save-prefs` call with payload `{ prefs: { mode: 'smart' } }` and second mount sends zero
- [x] HIGH 3: Today-card detail strings are child-register (no "reward unit" / "release" tokens)
- [x] MEDIUM 1: `punctuation-set-round-length` rejected from non-setup phases
- [x] MEDIUM 1: `punctuation-set-round-length` rejects off-enum values (`all`, `1`, `2`, `3`, `6`, non-string, numbers)
- [x] MEDIUM 1: `punctuation-set-round-length` accepts each narrow-enum stop (`'4'`, `'8'`, `'12'`)
- [x] MEDIUM 2: `punctuation-set-mode` rejected from non-setup phases