### PR TITLE
feat(punctuation): U4 summary scene (score + wobbly + next actions)

### DIFF
--- a/src/subjects/punctuation/components/PunctuationPracticeSurface.jsx
+++ b/src/subjects/punctuation/components/PunctuationPracticeSurface.jsx
@@ -6,14 +6,11 @@ import {
 import { PunctuationMapScene } from './PunctuationMapScene.jsx';
 import { PunctuationSessionScene } from './PunctuationSessionScene.jsx';
 import { PunctuationSetupScene } from './PunctuationSetupScene.jsx';
+import { PunctuationSummaryScene } from './PunctuationSummaryScene.jsx';
 
 function learnerRecord(appState, learnerId) {
   const record = appState?.learners?.byId?.[learnerId];
   return record && typeof record === 'object' && !Array.isArray(record) ? record : null;
-}
-
-function newlineTextStyle(value) {
-  return String(value || '').includes('\n') ? { whiteSpace: 'pre-wrap' } : undefined;
 }
 
 // Phase 3 U2 removed the legacy `SetupView` from this module. The
@@ -22,60 +19,6 @@ function newlineTextStyle(value) {
 // cards + Open Map secondary card + round-length toggle + active
 // monster strip. See `./PunctuationSetupScene.jsx` for the current
 // implementation and the one-shot stale-prefs migration.
-
-function SummaryView({ ui, actions }) {
-  const summary = ui.summary || {};
-  const scene = bellstormSceneForPhase('summary');
-  const gpsReview = Array.isArray(summary.gps?.reviewItems) ? summary.gps.reviewItems : [];
-  return (
-    <section className="card border-top punctuation-surface" data-punctuation-summary style={{ borderTopColor: '#2E8479' }}>
-      <div className="punctuation-strip">
-        <img src={scene.src} srcSet={scene.srcSet} sizes="(max-width: 980px) 100vw, 960px" alt="" aria-hidden="true" />
-        <div>
-          <div className="eyebrow">Summary</div>
-          <h2 className="section-title">Punctuation session summary</h2>
-          <p className="subtitle">{summary.message || 'Session complete.'}</p>
-        </div>
-      </div>
-      <div className="stat-grid" style={{ marginTop: 16 }}>
-        <div className="stat"><div className="stat-label">Answered</div><div className="stat-value">{summary.total || 0}</div><div className="stat-sub">This session</div></div>
-        <div className="stat"><div className="stat-label">Correct</div><div className="stat-value">{summary.correct || 0}</div><div className="stat-sub">Clean attempts</div></div>
-        <div className="stat"><div className="stat-label">Accuracy</div><div className="stat-value">{summary.accuracy || 0}%</div><div className="stat-sub">Session score</div></div>
-      </div>
-      {gpsReview.length ? (
-        <div className="callout punctuation-gps-review" style={{ marginTop: 16 }}>
-          <strong>GPS review</strong>
-          <div className="small muted" style={{ marginTop: 6 }}>
-            Next: {summary.gps?.recommendedLabel || 'Smart review'}
-          </div>
-          <div style={{ display: 'grid', gap: 10, marginTop: 12 }}>
-            {gpsReview.map((entry) => (
-              <div key={`${entry.index}-${entry.itemId}`} className={`feedback ${entry.correct ? 'good' : 'warn'}`}>
-                <strong>{entry.index}. {entry.correct ? 'Correct' : 'Review'}</strong>
-                <div style={{ marginTop: 6 }}>{entry.prompt}</div>
-                {entry.attemptedAnswer ? <div className="small" style={{ marginTop: 6 }}>Answer: {entry.attemptedAnswer}</div> : null}
-                {entry.displayCorrection ? (
-                  <div className="small" style={{ marginTop: 6, ...newlineTextStyle(entry.displayCorrection) }}>
-                    Model: {entry.displayCorrection}
-                  </div>
-                ) : null}
-                {entry.misconceptionTags?.length ? (
-                  <div className="chip-row" style={{ marginTop: 8 }}>
-                    {entry.misconceptionTags.map((tag) => <span className="chip warn" key={`${entry.itemId}-${tag}`}>{tag}</span>)}
-                  </div>
-                ) : null}
-              </div>
-            ))}
-          </div>
-        </div>
-      ) : null}
-      <div className="actions" style={{ marginTop: 16 }}>
-        <button className="btn primary" type="button" onClick={() => actions.dispatch('punctuation-start-again')}>Start again</button>
-        <button className="btn secondary" type="button" onClick={() => actions.dispatch('punctuation-back')}>Back to dashboard</button>
-      </div>
-    </section>
-  );
-}
 
 export function PunctuationPracticeSurface({ appState, service, actions }) {
   const learnerId = appState.learners.selectedId;
@@ -102,12 +45,15 @@ export function PunctuationPracticeSurface({ appState, service, actions }) {
     : {};
 
   // Phase 3 U3: `active-item` + `feedback` route through the consolidated
-  // `PunctuationSessionScene`. Summary stays inline until U4; Map routes
-  // to the U5 scene; Setup remains the default SetupView (U2 owns redesign).
+  // `PunctuationSessionScene`. Phase 3 U4: `summary` routes through the new
+  // `PunctuationSummaryScene`. Map routes to the U5 scene; Setup remains
+  // the default SetupView (U2 owns redesign).
   if (ui.phase === 'active-item' || ui.phase === 'feedback') {
     return <PunctuationSessionScene ui={ui} actions={actions} />;
   }
-  if (ui.phase === 'summary') return <SummaryView ui={ui} actions={actions} />;
+  if (ui.phase === 'summary') {
+    return <PunctuationSummaryScene ui={ui} actions={actions} appState={appState} />;
+  }
   if (ui.phase === 'map') return <PunctuationMapScene ui={ui} actions={actions} />;
 
   // U2: every non-session / non-map / non-unavailable / non-error phase

--- a/src/subjects/punctuation/components/PunctuationPracticeSurface.jsx
+++ b/src/subjects/punctuation/components/PunctuationPracticeSurface.jsx
@@ -1,16 +1,29 @@
-import React, { useMemo, useState } from 'react';
-import {
-  bellstormSceneForPhase,
-  composeIsDisabled,
-} from './punctuation-view-model.js';
+import React, { useMemo } from 'react';
 import { PunctuationMapScene } from './PunctuationMapScene.jsx';
 import { PunctuationSessionScene } from './PunctuationSessionScene.jsx';
 import { PunctuationSetupScene } from './PunctuationSetupScene.jsx';
 import { PunctuationSummaryScene } from './PunctuationSummaryScene.jsx';
 
+const MONSTER_CODEX_SYSTEM_ID = 'monster-codex';
+
 function learnerRecord(appState, learnerId) {
   const record = appState?.learners?.byId?.[learnerId];
   return record && typeof record === 'object' && !Array.isArray(record) ? record : null;
+}
+
+// U4 follower (HIGH 1): resolve the monster-codex reward state via the
+// `repositories.gameState` port — the same path the punctuation reward
+// subscriber writes to (`src/subjects/punctuation/event-hooks.js`) and the
+// same path Grammar uses in `GrammarPracticeSurface.resolveGrammarRewardState`.
+// Reading into `ui.rewardState` keeps both `PunctuationMapScene` and
+// `PunctuationSummaryScene` driven off one canonical path — the pre-fix
+// Summary scene read a `ui.rewards.monsters.punctuation` path that was
+// never populated in production, so every live learner saw zero monster
+// progress regardless of actual mastery.
+function resolvePunctuationRewardState(repositories, learnerId) {
+  if (!learnerId || typeof repositories?.gameState?.read !== 'function') return {};
+  const state = repositories.gameState.read(learnerId, MONSTER_CODEX_SYSTEM_ID);
+  return state && typeof state === 'object' && !Array.isArray(state) ? state : {};
 }
 
 // Phase 3 U2 removed the legacy `SetupView` from this module. The
@@ -20,7 +33,7 @@ function learnerRecord(appState, learnerId) {
 // monster strip. See `./PunctuationSetupScene.jsx` for the current
 // implementation and the one-shot stale-prefs migration.
 
-export function PunctuationPracticeSurface({ appState, service, actions }) {
+export function PunctuationPracticeSurface({ appState, service, actions, repositories }) {
   const learnerId = appState.learners.selectedId;
   const ui = service?.initState?.(appState.subjectUi?.punctuation, learnerId) || appState.subjectUi?.punctuation || {};
   const stats = useMemo(() => service?.getStats?.(learnerId) || ui.stats || {}, [learnerId, service, ui.stats]);
@@ -33,16 +46,20 @@ export function PunctuationPracticeSurface({ appState, service, actions }) {
   const prefs = (ui && typeof ui === 'object' && !Array.isArray(ui) && ui.prefs)
     ? ui.prefs
     : (service?.getPrefs?.(learnerId) || {});
-  // U2: the active monster strip reads monster reward state from
-  // `ui.rewardState` (mirrors the Map scene's source). When not
-  // present, default to empty so the strip renders fresh-learner
-  // zeros rather than throwing.
-  const rewardState = (ui && typeof ui === 'object' && !Array.isArray(ui)
-    && ui.rewardState
-    && typeof ui.rewardState === 'object'
-    && !Array.isArray(ui.rewardState))
-    ? ui.rewardState
-    : {};
+  // U4 follower (HIGH 1): monster-codex reward state resolved from the
+  // canonical `repositories.gameState` port (Grammar precedent). Falls
+  // back to `ui.rewardState` when a host does not wire `repositories`
+  // (test harnesses, pre-U2 surfaces) so the Setup/Map active-monster
+  // strips still render the service-seeded path.
+  const rewardState = useMemo(
+    () => {
+      const persisted = resolvePunctuationRewardState(repositories, learnerId);
+      if (persisted && Object.keys(persisted).length > 0) return persisted;
+      const fromUi = ui && typeof ui === 'object' && !Array.isArray(ui) ? ui.rewardState : null;
+      return fromUi && typeof fromUi === 'object' && !Array.isArray(fromUi) ? fromUi : persisted;
+    },
+    [repositories, learnerId, ui],
+  );
 
   // Phase 3 U3: `active-item` + `feedback` route through the consolidated
   // `PunctuationSessionScene`. Phase 3 U4: `summary` routes through the new
@@ -52,7 +69,14 @@ export function PunctuationPracticeSurface({ appState, service, actions }) {
     return <PunctuationSessionScene ui={ui} actions={actions} />;
   }
   if (ui.phase === 'summary') {
-    return <PunctuationSummaryScene ui={ui} actions={actions} appState={appState} />;
+    return (
+      <PunctuationSummaryScene
+        ui={ui}
+        actions={actions}
+        appState={appState}
+        rewardState={rewardState}
+      />
+    );
   }
   if (ui.phase === 'map') return <PunctuationMapScene ui={ui} actions={actions} />;
 

--- a/src/subjects/punctuation/components/PunctuationSummaryScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationSummaryScene.jsx
@@ -3,29 +3,31 @@
 // Replaces the monolith's `SummaryView` with a standalone component. Summary
 // now reads as:
 //
-//   - Bellstorm summary hero (eyebrow "Summary" + child headline).
+//   - Bellstorm summary hero (eyebrow "Summary" + celebratory headline via
+//     `punctuationSummaryHeadline(summary)` — accuracy-bucketed child copy
+//     replaces the clinical `summary.label` default).
 //   - Score chip row: Answered / Correct / Accuracy (3 chips).
 //   - Wobbly chips: `summary.focus` skillIds mapped through
 //     `PUNCTUATION_CLIENT_SKILLS` to produce child labels like
-//     "Speech punctuation needs another go" — NEVER raw skill ids.
+//     "Speech punctuation needs another go" — NEVER raw skill ids. An empty
+//     focus array renders a single positive chip ("Everything was secure
+//     this round!") rather than dead whitespace.
 //   - Active-only monster progress strip: iterate
-//     `ACTIVE_PUNCTUATION_MONSTER_IDS` over `progressForPunctuationMonster`.
-//     Reserved monsters (Colisk / Hyphang / Carillon) are never rendered.
+//     `ACTIVE_PUNCTUATION_MONSTER_IDS` over `progressForPunctuationMonster`
+//     against the flat `ui.rewardState` path (the same path MapScene reads,
+//     and the path the Grammar surface already wires). Reserved monsters
+//     (Colisk / Hyphang / Carillon) are never rendered.
 //   - GPS summary (Phase 2 contract preserved): short review cards when
 //     `summary.gps?.reviewItems` exists. `misconceptionTags` pipe through
 //     `punctuationChildMisconceptionLabel`; null-mapped tags hide rather
 //     than surfacing raw dotted ids.
 //   - 4 next-action buttons (Practise wobbly / Open Map / Start again /
 //     Back to dashboard).
-//   - Secondary "Grown-up view" link. Action is a future Parent Hub hook —
-//     today the button carries `data-action="punctuation-open-adult-view"`
-//     and is a no-op at the dispatch layer until the Admin / Parent surface
-//     lands.
 //
 // Every mutation control threads `composeIsDisabled(ui)` — the 4 primary
-// buttons and the Grown-up link disable as a single bundle whenever
-// availability flips to degraded / unavailable, a command is in flight, or
-// the runtime is read-only (plan R11).
+// buttons disable as a single bundle whenever availability flips to
+// degraded / unavailable, a command is in flight, or the runtime is
+// read-only (plan R11).
 //
 // SSR blind spots (learning #6): pointer-capture, focus, and scroll-into-view
 // are NOT observable via node:test + SSR. Every feature that claims a
@@ -40,6 +42,7 @@ import {
   composeIsDisabled,
   punctuationChildMisconceptionLabel,
   punctuationMonsterDisplayName,
+  punctuationSummaryHeadline,
 } from './punctuation-view-model.js';
 import { PUNCTUATION_CLIENT_SKILLS } from '../read-model.js';
 import { progressForPunctuationMonster } from '../../../platform/game/mastery/index.js';
@@ -64,17 +67,23 @@ function newlineTextStyle(value) {
   return String(value || '').includes('\n') ? { whiteSpace: 'pre-wrap' } : undefined;
 }
 
-// Reward state lives under `ui.rewards?.monsters?.punctuation`. Fall back to
-// an empty object so `progressForPunctuationMonster` can still return a safe
-// stage 0 progress shape for fresh learners.
-function rewardStateForPunctuation(ui) {
-  const rewards = ui && typeof ui === 'object' && !Array.isArray(ui) ? ui.rewards : null;
-  if (!rewards || typeof rewards !== 'object' || Array.isArray(rewards)) return {};
-  const monsters = rewards.monsters;
-  if (!monsters || typeof monsters !== 'object' || Array.isArray(monsters)) return {};
-  const punctuationState = monsters.punctuation;
-  if (!punctuationState || typeof punctuationState !== 'object' || Array.isArray(punctuationState)) return {};
-  return punctuationState;
+// U4 follower (HIGH 1 — monster strip dead path): reward state lives at the
+// flat `ui.rewardState` path, the same path `PunctuationMapScene` reads and
+// that `GrammarPracticeSurface` resolves before passing to the summary scene
+// as a prop. The pre-fix shape (`ui.rewards.monsters.punctuation`) was only
+// ever set by fixtures — no production write path populated it, so every
+// real learner saw "Stage 0 of 4" across all four monsters regardless of
+// their actual progress. The surface now accepts a resolved `rewardState`
+// prop (Grammar precedent); this helper falls back to `ui.rewardState` and
+// finally to an empty object so `progressForPunctuationMonster` can still
+// return a safe stage 0 shape for fresh learners.
+function rewardStateForPunctuation(ui, propRewardState) {
+  if (propRewardState && typeof propRewardState === 'object' && !Array.isArray(propRewardState)) {
+    return propRewardState;
+  }
+  const fromUi = ui && typeof ui === 'object' && !Array.isArray(ui) ? ui.rewardState : null;
+  if (fromUi && typeof fromUi === 'object' && !Array.isArray(fromUi)) return fromUi;
+  return {};
 }
 
 // --- Score chips -----------------------------------------------------------
@@ -111,16 +120,33 @@ function ScoreChipRow({ summary }) {
 // via `PUNCTUATION_CLIENT_SKILLS`, then wraps the name in the "needs another
 // go" nudge copy. Unknown ids are silently dropped (the safe default per
 // learning #9 — better an empty chip row than a leaked raw id).
+//
+// U4 follower (design-lens MEDIUM 4): when there are no wobbly skills
+// (either because `summary.focus` is empty, or every id mapped to null),
+// render a positive "Everything was secure this round!" chip so the slot
+// still communicates round outcome rather than rendering as empty space.
 function WobblyChipRow({ focus }) {
   const ids = Array.isArray(focus) ? focus.filter((id) => typeof id === 'string' && id) : [];
-  if (!ids.length) return null;
   const chips = [];
   for (const skillId of ids) {
     const name = summaryFocusSkillLabel(skillId);
     if (!name) continue;
     chips.push({ id: skillId, label: `${name} needs another go` });
   }
-  if (!chips.length) return null;
+  if (!chips.length) {
+    return (
+      <div
+        className="chip-row punctuation-summary-wobbly punctuation-summary-wobbly--empty"
+        role="group"
+        aria-label="Round outcome"
+        style={{ marginTop: 14 }}
+      >
+        <span className="chip good" data-punctuation-summary-wobbly-empty>
+          Everything was secure this round!
+        </span>
+      </div>
+    );
+  }
   return (
     <div
       className="chip-row punctuation-summary-wobbly"
@@ -144,8 +170,8 @@ function WobblyChipRow({ focus }) {
 // if the reward state contains them (plan R10 / learning #5). Progress is
 // rendered as 5 stage dots (0–4) per monster so the strip keeps its shape
 // across fresh learners and secure releases.
-function MonsterProgressStrip({ ui }) {
-  const rewardState = rewardStateForPunctuation(ui);
+function MonsterProgressStrip({ ui, rewardState: propRewardState }) {
+  const rewardState = rewardStateForPunctuation(ui, propRewardState);
   return (
     <div
       className="punctuation-summary-monsters"
@@ -308,41 +334,31 @@ function NextActionRow({ ui, actions }) {
   );
 }
 
-// --- Grown-up view link ----------------------------------------------------
-
-// Future Parent Hub hook (origin R34 / plan Q§"Grown-up view"). The action
-// is NOT yet wired at the dispatch layer; rendering carries the data-action
-// so an adult surface can listen later without the Summary scene needing a
-// follow-up PR. Threads `composeIsDisabled(ui)` so the link visibly pauses
-// alongside the primary buttons (plan R11).
-function GrownUpViewLink({ ui, actions }) {
-  const isDisabled = composeIsDisabled(ui);
-  return (
-    <div
-      className="punctuation-summary-grown-up small muted"
-      style={{ marginTop: 12 }}
-    >
-      <button
-        type="button"
-        className="btn ghost small"
-        disabled={isDisabled}
-        data-action="punctuation-open-adult-view"
-        onClick={() => actions.dispatch('punctuation-open-adult-view')}
-      >
-        Grown-up view
-      </button>
-    </div>
-  );
-}
-
 // --- Scene -----------------------------------------------------------------
 
-export function PunctuationSummaryScene({ ui = {}, actions = { dispatch() {} } }) {
+// U4 follower (adversarial MEDIUM 1): the Grown-up view placeholder button
+// was dispatching a `punctuation-open-adult-view` action with no handler —
+// a child tap produced a silent no-op. The plan allowed a placeholder, but
+// the reviewer-consensus rule is "don't ship dead UX". Parent Hub will add
+// this surface when the adult view ships (PR body notes the deferral); the
+// Summary scene renders no Grown-up affordance today.
+
+export function PunctuationSummaryScene({
+  ui = {},
+  actions = { dispatch() {} },
+  rewardState = null,
+}) {
   const summary = ui && typeof ui === 'object' && !Array.isArray(ui) ? (ui.summary || {}) : {};
   const scene = bellstormSceneForPhase('summary');
-  const headline = typeof summary.label === 'string' && summary.label
-    ? summary.label
-    : 'Punctuation session summary';
+  // Accuracy-bucketed celebration copy (design-lens HIGH 2). The helper
+  // returns null when `summary.accuracy` is missing / malformed; the label
+  // fallback keeps the hero filled even for degenerate payloads.
+  const tonalHeadline = punctuationSummaryHeadline(summary);
+  const headline = typeof tonalHeadline === 'string' && tonalHeadline
+    ? tonalHeadline
+    : (typeof summary.label === 'string' && summary.label
+      ? summary.label
+      : 'Punctuation session summary');
   const subtitle = typeof summary.message === 'string' && summary.message
     ? summary.message
     : 'Session complete.';
@@ -350,7 +366,11 @@ export function PunctuationSummaryScene({ ui = {}, actions = { dispatch() {} } }
     <section
       className="card border-top punctuation-surface"
       data-punctuation-summary
-      style={{ borderTopColor: '#2E8479' }}
+      // U4 follower (design-lens MEDIUM 5): borderTopColor now matches the
+      // canonical Punctuation accent `#B8873F` (Bellstorm gold) rather than
+      // the stray `#2E8479` teal. Aligns with `PunctuationPracticeSurface`
+      // and the module's `accent` field.
+      style={{ borderTopColor: '#B8873F' }}
     >
       <div className="punctuation-strip">
         <img
@@ -368,10 +388,9 @@ export function PunctuationSummaryScene({ ui = {}, actions = { dispatch() {} } }
       </div>
       <ScoreChipRow summary={summary} />
       <WobblyChipRow focus={summary.focus} />
-      <MonsterProgressStrip ui={ui} />
+      <MonsterProgressStrip ui={ui} rewardState={rewardState} />
       <GpsReviewBlock gps={summary.gps} />
       <NextActionRow ui={ui} actions={actions} />
-      <GrownUpViewLink ui={ui} actions={actions} />
     </section>
   );
 }

--- a/src/subjects/punctuation/components/PunctuationSummaryScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationSummaryScene.jsx
@@ -1,0 +1,377 @@
+// Phase 3 U4 — Punctuation Summary scene.
+//
+// Replaces the monolith's `SummaryView` with a standalone component. Summary
+// now reads as:
+//
+//   - Bellstorm summary hero (eyebrow "Summary" + child headline).
+//   - Score chip row: Answered / Correct / Accuracy (3 chips).
+//   - Wobbly chips: `summary.focus` skillIds mapped through
+//     `PUNCTUATION_CLIENT_SKILLS` to produce child labels like
+//     "Speech punctuation needs another go" — NEVER raw skill ids.
+//   - Active-only monster progress strip: iterate
+//     `ACTIVE_PUNCTUATION_MONSTER_IDS` over `progressForPunctuationMonster`.
+//     Reserved monsters (Colisk / Hyphang / Carillon) are never rendered.
+//   - GPS summary (Phase 2 contract preserved): short review cards when
+//     `summary.gps?.reviewItems` exists. `misconceptionTags` pipe through
+//     `punctuationChildMisconceptionLabel`; null-mapped tags hide rather
+//     than surfacing raw dotted ids.
+//   - 4 next-action buttons (Practise wobbly / Open Map / Start again /
+//     Back to dashboard).
+//   - Secondary "Grown-up view" link. Action is a future Parent Hub hook —
+//     today the button carries `data-action="punctuation-open-adult-view"`
+//     and is a no-op at the dispatch layer until the Admin / Parent surface
+//     lands.
+//
+// Every mutation control threads `composeIsDisabled(ui)` — the 4 primary
+// buttons and the Grown-up link disable as a single bundle whenever
+// availability flips to degraded / unavailable, a command is in flight, or
+// the runtime is read-only (plan R11).
+//
+// SSR blind spots (learning #6): pointer-capture, focus, and scroll-into-view
+// are NOT observable via node:test + SSR. Every feature that claims a
+// behavioural guarantee comes with a paired state-level or DOM-match
+// assertion (learning #7).
+
+import React from 'react';
+
+import {
+  ACTIVE_PUNCTUATION_MONSTER_IDS,
+  bellstormSceneForPhase,
+  composeIsDisabled,
+  punctuationChildMisconceptionLabel,
+  punctuationMonsterDisplayName,
+} from './punctuation-view-model.js';
+import { PUNCTUATION_CLIENT_SKILLS } from '../read-model.js';
+import { progressForPunctuationMonster } from '../../../platform/game/mastery/index.js';
+
+// --- Local helpers ---------------------------------------------------------
+
+// Lookup skill name for a summary focus id. Scanning the frozen
+// `PUNCTUATION_CLIENT_SKILLS` manifest keeps the Map and Summary scenes
+// reading the same canonical names. Unknown ids return `null` so the chip
+// is skipped rather than surfacing the raw dotted id (plan R15 / U10 sweep).
+const CLIENT_SKILL_NAMES_BY_ID = new Map(
+  PUNCTUATION_CLIENT_SKILLS.map((skill) => [skill.id, skill.name]),
+);
+
+function summaryFocusSkillLabel(skillId) {
+  if (typeof skillId !== 'string' || !skillId) return null;
+  const name = CLIENT_SKILL_NAMES_BY_ID.get(skillId);
+  return typeof name === 'string' && name ? name : null;
+}
+
+function newlineTextStyle(value) {
+  return String(value || '').includes('\n') ? { whiteSpace: 'pre-wrap' } : undefined;
+}
+
+// Reward state lives under `ui.rewards?.monsters?.punctuation`. Fall back to
+// an empty object so `progressForPunctuationMonster` can still return a safe
+// stage 0 progress shape for fresh learners.
+function rewardStateForPunctuation(ui) {
+  const rewards = ui && typeof ui === 'object' && !Array.isArray(ui) ? ui.rewards : null;
+  if (!rewards || typeof rewards !== 'object' || Array.isArray(rewards)) return {};
+  const monsters = rewards.monsters;
+  if (!monsters || typeof monsters !== 'object' || Array.isArray(monsters)) return {};
+  const punctuationState = monsters.punctuation;
+  if (!punctuationState || typeof punctuationState !== 'object' || Array.isArray(punctuationState)) return {};
+  return punctuationState;
+}
+
+// --- Score chips -----------------------------------------------------------
+
+function ScoreChipRow({ summary }) {
+  const total = Number(summary?.total) || 0;
+  const correct = Number(summary?.correct) || 0;
+  const accuracy = Number(summary?.accuracy) || 0;
+  return (
+    <div className="stat-grid punctuation-summary-score" style={{ marginTop: 16 }}>
+      <div className="stat">
+        <div className="stat-label">Answered</div>
+        <div className="stat-value">{total}</div>
+        <div className="stat-sub">This session</div>
+      </div>
+      <div className="stat">
+        <div className="stat-label">Correct</div>
+        <div className="stat-value">{correct}</div>
+        <div className="stat-sub">Clean attempts</div>
+      </div>
+      <div className="stat">
+        <div className="stat-label">Accuracy</div>
+        <div className="stat-value">{accuracy}%</div>
+        <div className="stat-sub">Session score</div>
+      </div>
+    </div>
+  );
+}
+
+// --- Wobbly chips ----------------------------------------------------------
+
+// `summary.focus` is an array of skill ids from `sessionFocus` in
+// `shared/punctuation/service.js`. The scene maps each id to its child name
+// via `PUNCTUATION_CLIENT_SKILLS`, then wraps the name in the "needs another
+// go" nudge copy. Unknown ids are silently dropped (the safe default per
+// learning #9 — better an empty chip row than a leaked raw id).
+function WobblyChipRow({ focus }) {
+  const ids = Array.isArray(focus) ? focus.filter((id) => typeof id === 'string' && id) : [];
+  if (!ids.length) return null;
+  const chips = [];
+  for (const skillId of ids) {
+    const name = summaryFocusSkillLabel(skillId);
+    if (!name) continue;
+    chips.push({ id: skillId, label: `${name} needs another go` });
+  }
+  if (!chips.length) return null;
+  return (
+    <div
+      className="chip-row punctuation-summary-wobbly"
+      role="group"
+      aria-label="Skills that need another go"
+      style={{ marginTop: 14 }}
+    >
+      {chips.map((chip) => (
+        <span className="chip warn" key={`wobbly-${chip.id}`} data-skill-id={chip.id}>
+          {chip.label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+// --- Active monster progress strip -----------------------------------------
+
+// Iterates the frozen `ACTIVE_PUNCTUATION_MONSTER_IDS` roster only —
+// reserved monsters (Colisk / Hyphang / Carillon) never surface here even
+// if the reward state contains them (plan R10 / learning #5). Progress is
+// rendered as 5 stage dots (0–4) per monster so the strip keeps its shape
+// across fresh learners and secure releases.
+function MonsterProgressStrip({ ui }) {
+  const rewardState = rewardStateForPunctuation(ui);
+  return (
+    <div
+      className="punctuation-summary-monsters"
+      role="group"
+      aria-label="Punctuation monster progress"
+      style={{ marginTop: 16 }}
+    >
+      {ACTIVE_PUNCTUATION_MONSTER_IDS.map((monsterId) => {
+        const progress = progressForPunctuationMonster(rewardState, monsterId);
+        const stage = Math.max(0, Math.min(4, Number(progress?.stage) || 0));
+        const name = punctuationMonsterDisplayName(monsterId);
+        return (
+          <div
+            className="punctuation-summary-monster"
+            data-monster-id={monsterId}
+            key={`monster-${monsterId}`}
+          >
+            <div className="punctuation-summary-monster-name">{name}</div>
+            <div
+              className="punctuation-summary-monster-dots"
+              aria-label={`${name} stage ${stage} of 4`}
+            >
+              {[0, 1, 2, 3].map((index) => (
+                <span
+                  key={`dot-${monsterId}-${index}`}
+                  className={`punctuation-summary-monster-dot${index < stage ? ' on' : ''}`}
+                  aria-hidden="true"
+                />
+              ))}
+            </div>
+            <div className="punctuation-summary-monster-stage small muted">
+              Stage {stage} of 4
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// --- GPS review cards (Phase 2 contract preserved) -------------------------
+
+// Renders the `summary.gps.reviewItems` cards when present. The recommended
+// next action uses `summary.gps.recommendedLabel` (child copy) — NEVER the
+// raw `recommendedMode` id. `misconceptionTags` pipe through
+// `punctuationChildMisconceptionLabel`; tags with no mapped child label are
+// silently dropped so the chip row stays empty rather than leaking dotted
+// ids (plan R15).
+function GpsReviewBlock({ gps }) {
+  const reviewItems = Array.isArray(gps?.reviewItems) ? gps.reviewItems : [];
+  if (!reviewItems.length) return null;
+  const recommendedLabel = typeof gps?.recommendedLabel === 'string' && gps.recommendedLabel
+    ? gps.recommendedLabel
+    : 'Smart review';
+  return (
+    <div className="callout punctuation-gps-review" style={{ marginTop: 16 }}>
+      <strong>GPS review</strong>
+      <div className="small muted" style={{ marginTop: 6 }}>
+        Next up: {recommendedLabel}
+      </div>
+      <div style={{ display: 'grid', gap: 10, marginTop: 12 }}>
+        {reviewItems.map((entry) => {
+          const tags = Array.isArray(entry.misconceptionTags) ? entry.misconceptionTags : [];
+          // Map raw dotted tags to child labels and dedupe — a single GPS
+          // item that trips two sub-tags within the same facet should read
+          // as one chip, not two identical labels.
+          const tagLabels = [];
+          const seenLabels = new Set();
+          for (const tag of tags) {
+            const label = punctuationChildMisconceptionLabel(tag);
+            if (!label || seenLabels.has(label)) continue;
+            seenLabels.add(label);
+            tagLabels.push({ id: tag, label });
+          }
+          return (
+            <div
+              key={`${entry.index}-${entry.itemId}`}
+              className={`feedback ${entry.correct ? 'good' : 'warn'}`}
+            >
+              <strong>{entry.index}. {entry.correct ? 'Correct' : 'Review'}</strong>
+              <div style={{ marginTop: 6 }}>{entry.prompt}</div>
+              {entry.attemptedAnswer ? (
+                <div className="small" style={{ marginTop: 6 }}>
+                  Answer: {entry.attemptedAnswer}
+                </div>
+              ) : null}
+              {entry.displayCorrection ? (
+                <div
+                  className="small"
+                  style={{ marginTop: 6, ...newlineTextStyle(entry.displayCorrection) }}
+                >
+                  Model: {entry.displayCorrection}
+                </div>
+              ) : null}
+              {tagLabels.length ? (
+                <div className="chip-row" style={{ marginTop: 8 }}>
+                  {tagLabels.map((tag) => (
+                    <span
+                      className="chip warn"
+                      key={`${entry.itemId}-${tag.id}`}
+                    >
+                      {tag.label}
+                    </span>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// --- Next-action buttons ---------------------------------------------------
+
+function NextActionRow({ ui, actions }) {
+  const isDisabled = composeIsDisabled(ui);
+  return (
+    <div className="actions punctuation-summary-actions" style={{ marginTop: 16 }}>
+      <button
+        className="btn primary"
+        type="button"
+        disabled={isDisabled}
+        data-action="punctuation-start"
+        data-value="weak"
+        onClick={() => actions.dispatch('punctuation-start', { mode: 'weak' })}
+      >
+        Practise wobbly spots
+      </button>
+      <button
+        className="btn secondary"
+        type="button"
+        disabled={isDisabled}
+        data-action="punctuation-open-map"
+        onClick={() => actions.dispatch('punctuation-open-map')}
+      >
+        Open Punctuation Map
+      </button>
+      <button
+        className="btn secondary"
+        type="button"
+        disabled={isDisabled}
+        data-action="punctuation-start-again"
+        data-punctuation-start-again
+        onClick={() => actions.dispatch('punctuation-start-again')}
+      >
+        Start again
+      </button>
+      <button
+        className="btn ghost"
+        type="button"
+        disabled={isDisabled}
+        data-action="punctuation-back"
+        onClick={() => actions.dispatch('punctuation-back')}
+      >
+        Back to dashboard
+      </button>
+    </div>
+  );
+}
+
+// --- Grown-up view link ----------------------------------------------------
+
+// Future Parent Hub hook (origin R34 / plan Q§"Grown-up view"). The action
+// is NOT yet wired at the dispatch layer; rendering carries the data-action
+// so an adult surface can listen later without the Summary scene needing a
+// follow-up PR. Threads `composeIsDisabled(ui)` so the link visibly pauses
+// alongside the primary buttons (plan R11).
+function GrownUpViewLink({ ui, actions }) {
+  const isDisabled = composeIsDisabled(ui);
+  return (
+    <div
+      className="punctuation-summary-grown-up small muted"
+      style={{ marginTop: 12 }}
+    >
+      <button
+        type="button"
+        className="btn ghost small"
+        disabled={isDisabled}
+        data-action="punctuation-open-adult-view"
+        onClick={() => actions.dispatch('punctuation-open-adult-view')}
+      >
+        Grown-up view
+      </button>
+    </div>
+  );
+}
+
+// --- Scene -----------------------------------------------------------------
+
+export function PunctuationSummaryScene({ ui = {}, actions = { dispatch() {} } }) {
+  const summary = ui && typeof ui === 'object' && !Array.isArray(ui) ? (ui.summary || {}) : {};
+  const scene = bellstormSceneForPhase('summary');
+  const headline = typeof summary.label === 'string' && summary.label
+    ? summary.label
+    : 'Punctuation session summary';
+  const subtitle = typeof summary.message === 'string' && summary.message
+    ? summary.message
+    : 'Session complete.';
+  return (
+    <section
+      className="card border-top punctuation-surface"
+      data-punctuation-summary
+      style={{ borderTopColor: '#2E8479' }}
+    >
+      <div className="punctuation-strip">
+        <img
+          src={scene.src}
+          srcSet={scene.srcSet}
+          sizes="(max-width: 980px) 100vw, 960px"
+          alt=""
+          aria-hidden="true"
+        />
+        <div>
+          <div className="eyebrow">Summary</div>
+          <h2 className="section-title">{headline}</h2>
+          <p className="subtitle">{subtitle}</p>
+        </div>
+      </div>
+      <ScoreChipRow summary={summary} />
+      <WobblyChipRow focus={summary.focus} />
+      <MonsterProgressStrip ui={ui} />
+      <GpsReviewBlock gps={summary.gps} />
+      <NextActionRow ui={ui} actions={actions} />
+      <GrownUpViewLink ui={ui} actions={actions} />
+    </section>
+  );
+}

--- a/src/subjects/punctuation/components/punctuation-view-model.js
+++ b/src/subjects/punctuation/components/punctuation-view-model.js
@@ -244,6 +244,33 @@ export function punctuationMonsterDisplayName(monsterId) {
   return ACTIVE_PUNCTUATION_MONSTER_DISPLAY_NAMES[monsterId] || titlecase(monsterId);
 }
 
+// --- Summary headline ------------------------------------------------------
+
+// Child-facing celebration copy for the Punctuation Summary scene hero. The
+// session-summary payload from `shared/punctuation/service.js` carries a
+// clinical `summary.label` of `'Punctuation session summary'` — a Year 3-6
+// child reading "Session complete." after a round gets zero sense of the
+// round's tone. The helper branches on `summary.accuracy` to produce a copy
+// register that mirrors the child's experience:
+//
+//  - accuracy >= 80  → celebratory ("Great round!")
+//  - accuracy >= 50  → encouraging ("Good try! Here's what you got.")
+//  - accuracy  < 50  → supportive ("Keep going — every round helps.")
+//
+// Returns `null` when the summary payload is missing / malformed so the
+// caller can fall back to `summary.label` without a string-comparison dance.
+// No adult register, no dotted tags, no Worker terms — U10's forbidden-term
+// sweep treats every string emitted here as child copy.
+export function punctuationSummaryHeadline(summary) {
+  if (!summary || typeof summary !== 'object' || Array.isArray(summary)) return null;
+  const rawAccuracy = Number(summary.accuracy);
+  if (!Number.isFinite(rawAccuracy)) return null;
+  const accuracy = Math.max(0, Math.min(100, rawAccuracy));
+  if (accuracy >= 80) return 'Great round!';
+  if (accuracy >= 50) return "Good try! Here's what you got.";
+  return 'Keep going — every round helps.';
+}
+
 // --- Dashboard hero copy ---------------------------------------------------
 
 // Hero headline + subheadline for the Setup / dashboard scene. Frozen so U1

--- a/src/subjects/punctuation/module.js
+++ b/src/subjects/punctuation/module.js
@@ -250,6 +250,14 @@ export const punctuationModule = {
       if (!PUNCTUATION_OPEN_MAP_ALLOWED_PHASES.includes(ui.phase)) {
         return false;
       }
+      // U4 follower (adv-238-003): seed `mapUi.returnTo` with the source
+      // phase so `punctuation-close-map` routes the learner back to the
+      // same scene they opened Map from. Without this, closing the Map
+      // always collapses to Setup and the learner loses the Summary
+      // completion screen after a Map detour. Only 'setup' and 'summary'
+      // are valid source phases (per PUNCTUATION_OPEN_MAP_ALLOWED_PHASES),
+      // and `normalisePunctuationMapUi` rejects anything else.
+      const mapUi = normalisePunctuationMapUi({ returnTo: ui.phase });
       store.updateSubjectUi('punctuation', {
         phase: 'map',
         error: '',
@@ -258,7 +266,7 @@ export const punctuationModule = {
         // belt-and-braces reset here means no open-map path ever lands on
         // a feedback payload from an earlier session.
         feedback: null,
-        mapUi: normalisePunctuationMapUi(),
+        mapUi,
       });
       return true;
     }
@@ -279,12 +287,21 @@ export const punctuationModule = {
       // otherwise clear). Refuse from non-map phases so the caller treats
       // the dispatch as a miss rather than a silent success (learning #7).
       if (ui.phase !== 'map') return false;
-      const nextMapUi = {
-        ...normalisePunctuationMapUi(ui.mapUi),
-        detailOpenSkillId: null,
-      };
+      const currentMapUi = normalisePunctuationMapUi(ui.mapUi);
+      const nextMapUi = { ...currentMapUi, detailOpenSkillId: null };
+      // U4 follower (adv-238-003): route back to the phase recorded when
+      // the Map was opened. `returnTo` only accepts 'setup' or 'summary'
+      // (validated in normalisePunctuationMapUi), so a learner who opened
+      // the Map from the Summary scene lands back on Summary with their
+      // completion screen intact. A 'summary' return-to path requires a
+      // non-null summary payload under ui.summary; otherwise fall back to
+      // Setup so the learner never strands on an empty Summary (no
+      // session to summarise post-reload).
+      const canReturnToSummary = currentMapUi.returnTo === 'summary'
+        && ui.summary && typeof ui.summary === 'object' && !Array.isArray(ui.summary);
+      const nextPhase = canReturnToSummary ? 'summary' : 'setup';
       store.updateSubjectUi('punctuation', {
-        phase: 'setup',
+        phase: nextPhase,
         error: '',
         mapUi: nextMapUi,
       });

--- a/src/subjects/punctuation/service-contract.js
+++ b/src/subjects/punctuation/service-contract.js
@@ -158,12 +158,20 @@ export function normalisePunctuationPrefs(value = {}) {
 //
 // Defaults when the Map phase first opens:
 //   { statusFilter: 'all', monsterFilter: 'all', detailOpenSkillId: null,
-//     detailTab: 'learn' }
+//     detailTab: 'learn', returnTo: 'setup' }
 //
 // `detailOpenSkillId` is either a published skill id (currently one of 14)
 // or `null`. `detailTab` is either `'learn'` or `'practise'`; invalid input
 // falls back to `'learn'`.
+//
+// U4 follower (adv-238-003): `returnTo` remembers the source phase so
+// `punctuation-close-map` can route the learner back to the Summary scene
+// instead of always collapsing to Setup. Only `'setup'` and `'summary'` are
+// accepted values — any other input falls back to `'setup'` so a rogue
+// payload never strands the learner on a dead phase. `punctuation-open-map`
+// seeds this from the current phase before flipping to `phase: 'map'`.
 const PUNCTUATION_MAP_DETAIL_TABS = new Set(PUNCTUATION_MAP_DETAIL_TAB_IDS);
+const PUNCTUATION_MAP_RETURN_PHASES = Object.freeze(['setup', 'summary']);
 
 export function normalisePunctuationMapUi(value = {}) {
   const raw = isPlainObject(value) ? value : {};
@@ -182,7 +190,9 @@ export function normalisePunctuationMapUi(value = {}) {
     : null;
   const rawDetailTab = typeof raw.detailTab === 'string' ? raw.detailTab : 'learn';
   const detailTab = PUNCTUATION_MAP_DETAIL_TABS.has(rawDetailTab) ? rawDetailTab : 'learn';
-  return { statusFilter, monsterFilter, detailOpenSkillId, detailTab };
+  const rawReturnTo = typeof raw.returnTo === 'string' ? raw.returnTo : 'setup';
+  const returnTo = PUNCTUATION_MAP_RETURN_PHASES.includes(rawReturnTo) ? rawReturnTo : 'setup';
+  return { statusFilter, monsterFilter, detailOpenSkillId, detailTab, returnTo };
 }
 
 // U5: Rehydrate-time sanitiser for `subjectUi.punctuation`. Called exactly

--- a/tests/browser-react-migration-smoke.test.js
+++ b/tests/browser-react-migration-smoke.test.js
@@ -159,7 +159,11 @@ test('browser migration smoke covers the React app root, Grammar completeness co
     assert.match(output, /Your subjects/);
     assert.doesNotMatch(output, /data-home-mount/);
     assert.match(output, /Punctuation practice/);
-    assert.match(output, /Punctuation session summary/);
+    // U4 follower: summary headline is now the accuracy-bucketed celebration
+    // copy from `punctuationSummaryHeadline`, replacing the adult
+    // "Punctuation session summary" default. Match any of the 3 buckets so
+    // the smoke stays stable across the different accuracy paths.
+    assert.match(output, /Great round!|Good try!|Keep going/);
     assert.match(output, /Grammar Garden/);
     assert.match(output, /Mini Test/);
     assert.match(output, /Smart Practice/);

--- a/tests/punctuation-map-phase.test.js
+++ b/tests/punctuation-map-phase.test.js
@@ -71,18 +71,27 @@ test('U5: PUNCTUATION_PHASES frozen list is exactly the 7 expected phases', () =
 
 test('U5 normalisePunctuationMapUi: undefined returns full default shape', () => {
   const ui = normalisePunctuationMapUi(undefined);
+  // U4 follower (adv-238-003): `returnTo` tracks the source phase so
+  // close-map can route back to Summary. Defaults to 'setup'.
   assert.deepEqual(ui, {
     statusFilter: 'all',
     monsterFilter: 'all',
     detailOpenSkillId: null,
     detailTab: 'learn',
+    returnTo: 'setup',
   });
 });
 
 test('U5 normalisePunctuationMapUi: null returns full default shape', () => {
   assert.deepEqual(
     normalisePunctuationMapUi(null),
-    { statusFilter: 'all', monsterFilter: 'all', detailOpenSkillId: null, detailTab: 'learn' },
+    {
+      statusFilter: 'all',
+      monsterFilter: 'all',
+      detailOpenSkillId: null,
+      detailTab: 'learn',
+      returnTo: 'setup',
+    },
   );
 });
 
@@ -92,12 +101,14 @@ test('U5 normalisePunctuationMapUi: valid values pass through unchanged', () => 
     monsterFilter: 'pealark',
     detailOpenSkillId: 'speech',
     detailTab: 'practise',
+    returnTo: 'summary',
   });
   assert.deepEqual(ui, {
     statusFilter: 'weak',
     monsterFilter: 'pealark',
     detailOpenSkillId: 'speech',
     detailTab: 'practise',
+    returnTo: 'summary',
   });
 });
 
@@ -136,8 +147,25 @@ test('U5 normalisePunctuationMapUi: array input coerces to defaults', () => {
   // so a [key, value] pair can't accidentally set any field.
   assert.deepEqual(
     normalisePunctuationMapUi(['foo', 'bar']),
-    { statusFilter: 'all', monsterFilter: 'all', detailOpenSkillId: null, detailTab: 'learn' },
+    {
+      statusFilter: 'all',
+      monsterFilter: 'all',
+      detailOpenSkillId: null,
+      detailTab: 'learn',
+      returnTo: 'setup',
+    },
   );
+});
+
+test('U5 normalisePunctuationMapUi: invalid returnTo falls back to `setup`', () => {
+  // U4 follower (adv-238-003): only 'setup' and 'summary' are accepted
+  // source phases; anything else resets to 'setup' so a rogue payload
+  // can't strand close-map on a dead phase.
+  assert.equal(normalisePunctuationMapUi({ returnTo: 'active-item' }).returnTo, 'setup');
+  assert.equal(normalisePunctuationMapUi({ returnTo: 'garbage' }).returnTo, 'setup');
+  assert.equal(normalisePunctuationMapUi({ returnTo: 123 }).returnTo, 'setup');
+  assert.equal(normalisePunctuationMapUi({ returnTo: null }).returnTo, 'setup');
+  assert.equal(normalisePunctuationMapUi({ returnTo: '' }).returnTo, 'setup');
 });
 
 test('U5 normalisePunctuationMapUi: accepts every valid status filter id', () => {
@@ -166,11 +194,14 @@ test('U5 module: punctuation-open-map transitions setup → map with default map
 
   const next = punctuationState(harness);
   assert.equal(next.phase, 'map');
+  // U4 follower (adv-238-003): Setup-source opens record `returnTo: 'setup'`
+  // so close-map routes back to the dashboard (unchanged default behaviour).
   assert.deepEqual(next.mapUi, {
     statusFilter: 'all',
     monsterFilter: 'all',
     detailOpenSkillId: null,
     detailTab: 'learn',
+    returnTo: 'setup',
   });
 });
 

--- a/tests/punctuation-view-model.test.js
+++ b/tests/punctuation-view-model.test.js
@@ -42,6 +42,7 @@ import {
   punctuationSkillHasMultiSkillItems,
   punctuationSkillModalContent,
   punctuationSkillModalPreferredExample,
+  punctuationSummaryHeadline,
 } from '../src/subjects/punctuation/components/punctuation-view-model.js';
 import { MONSTERS_BY_SUBJECT } from '../src/platform/game/monsters.js';
 import { PUNCTUATION_CLUSTERS, PUNCTUATION_ITEMS, PUNCTUATION_SKILLS } from '../shared/punctuation/content.js';
@@ -921,4 +922,58 @@ test('U6: punctuationSkillHasMultiSkillItems returns false for non-string / empt
   assert.strictEqual(punctuationSkillHasMultiSkillItems(null), false);
   assert.strictEqual(punctuationSkillHasMultiSkillItems(undefined), false);
   assert.strictEqual(punctuationSkillHasMultiSkillItems('not_a_skill'), false);
+});
+
+// ---------------------------------------------------------------------------
+// U4 follower — accuracy-bucketed celebration headline (design-lens HIGH 2).
+// Replaces the clinical `summary.label` default with child-facing copy that
+// matches the round's emotional register.
+// ---------------------------------------------------------------------------
+
+test('U4 follower: punctuationSummaryHeadline returns celebratory copy for accuracy >= 80', () => {
+  assert.equal(punctuationSummaryHeadline({ accuracy: 80 }), 'Great round!');
+  assert.equal(punctuationSummaryHeadline({ accuracy: 95 }), 'Great round!');
+  assert.equal(punctuationSummaryHeadline({ accuracy: 100 }), 'Great round!');
+});
+
+test('U4 follower: punctuationSummaryHeadline returns encouraging copy for 50 <= accuracy < 80', () => {
+  assert.equal(punctuationSummaryHeadline({ accuracy: 50 }), "Good try! Here's what you got.");
+  assert.equal(punctuationSummaryHeadline({ accuracy: 75 }), "Good try! Here's what you got.");
+  assert.equal(punctuationSummaryHeadline({ accuracy: 79 }), "Good try! Here's what you got.");
+});
+
+test('U4 follower: punctuationSummaryHeadline returns supportive copy for accuracy < 50', () => {
+  assert.equal(punctuationSummaryHeadline({ accuracy: 0 }), 'Keep going — every round helps.');
+  assert.equal(punctuationSummaryHeadline({ accuracy: 25 }), 'Keep going — every round helps.');
+  assert.equal(punctuationSummaryHeadline({ accuracy: 49 }), 'Keep going — every round helps.');
+});
+
+test('U4 follower: punctuationSummaryHeadline returns null for missing / malformed summary', () => {
+  // A null return is the caller's signal to fall back to `summary.label`.
+  assert.equal(punctuationSummaryHeadline(null), null);
+  assert.equal(punctuationSummaryHeadline(undefined), null);
+  assert.equal(punctuationSummaryHeadline([]), null);
+  assert.equal(punctuationSummaryHeadline({}), null);
+  assert.equal(punctuationSummaryHeadline({ accuracy: 'not-a-number' }), null);
+  assert.equal(punctuationSummaryHeadline({ accuracy: NaN }), null);
+});
+
+test('U4 follower: punctuationSummaryHeadline clamps out-of-range accuracy to [0, 100]', () => {
+  // Defensive — if a broken projection ever emits 150% or -10%, the helper
+  // still produces child-friendly copy rather than propagating the outlier.
+  assert.equal(punctuationSummaryHeadline({ accuracy: 150 }), 'Great round!');
+  assert.equal(punctuationSummaryHeadline({ accuracy: -10 }), 'Keep going — every round helps.');
+});
+
+test('U4 follower: punctuationSummaryHeadline never emits forbidden child terms', () => {
+  // Every bucket's output must pass U10's forbidden-term sweep so a scene
+  // regression cannot slip an adult / Worker term into the headline.
+  const samples = [
+    punctuationSummaryHeadline({ accuracy: 95 }),
+    punctuationSummaryHeadline({ accuracy: 60 }),
+    punctuationSummaryHeadline({ accuracy: 10 }),
+  ];
+  for (const text of samples) {
+    assert.equal(isPunctuationChildCopy(text), true, `headline ${JSON.stringify(text)} leaked forbidden term`);
+  }
 });

--- a/tests/react-punctuation-scene.test.js
+++ b/tests/react-punctuation-scene.test.js
@@ -79,7 +79,11 @@ test('punctuation React surface renders setup, active item, feedback and summary
 
   harness.dispatch('punctuation-continue');
   const summaryHtml = harness.render();
-  assert.match(summaryHtml, /Punctuation session summary/);
+  // U4 follower: the scene headline now comes from the accuracy-bucketed
+  // `punctuationSummaryHeadline` helper. A 1-of-1 correct session yields
+  // 100% → "Great round!". The clinical `summary.label` fallback only
+  // kicks in when accuracy is missing (helper returns null).
+  assert.match(summaryHtml, /Great round!/);
   assert.match(summaryHtml, /Session complete/);
   assert.match(summaryHtml, /Start again/);
 });
@@ -681,12 +685,16 @@ test('punctuation Map phase transition: setup → map → setup via dispatch cha
 
   harness.dispatch('punctuation-open-map');
   assert.equal(harness.store.getState().subjectUi.punctuation.phase, 'map');
-  // mapUi lands at defaults when the phase first opens.
+  // mapUi lands at defaults when the phase first opens. U4 follower
+  // (adv-238-003) adds `returnTo` to track the source phase so close-map
+  // can route back to Summary when appropriate; Setup-source opens record
+  // `returnTo: 'setup'`.
   assert.deepEqual(harness.store.getState().subjectUi.punctuation.mapUi, {
     statusFilter: 'all',
     monsterFilter: 'all',
     detailOpenSkillId: null,
     detailTab: 'learn',
+    returnTo: 'setup',
   });
 
   harness.dispatch('punctuation-back');
@@ -1870,10 +1878,14 @@ test('design-lens HIGH: combine/transfer source blockquote carries aria-label an
 //
 // `phase === 'summary'` now routes through the standalone
 // `PunctuationSummaryScene` (not the pre-U4 inline `SummaryView`). Assertions
-// cover score chip row, wobbly chip child labels, active-only monster strip,
-// GPS review cards with misconception-label piping, 4 next-action buttons
-// with paired state-level dispatch verification, composeIsDisabled threading,
-// and the Grown-up view link.
+// cover score chip row, wobbly chip child labels (with positive empty-state
+// copy), active-only monster strip driven off the canonical `ui.rewardState`
+// path threaded from `PunctuationPracticeSurface` (HIGH 1 fix), GPS review
+// cards with misconception-label piping, 4 next-action buttons with paired
+// state-level dispatch verification (including tightened Start-again assertion
+// per MEDIUM 3), composeIsDisabled threading, accuracy-bucketed celebration
+// headline (HIGH 2 fix), and absence of the Grown-up view placeholder
+// (MEDIUM 1 fix — handler-less button removed).
 //
 // SSR blind spots (learning #6): every behavioural assertion is paired with
 // either a state-level post-dispatch check or a DOM-match regex so a silent
@@ -1935,36 +1947,42 @@ test('Punctuation summary scene: unknown skill ids are dropped rather than rende
   assert.doesNotMatch(html, /unknown_skill_xyz/);
 });
 
-test('Punctuation summary scene: empty focus renders no wobbly chip row', () => {
+test('Punctuation summary scene: empty focus omits the "needs another go" warn row', () => {
+  // U4 follower (design-lens MEDIUM 4): the warn-row aria-label "Skills
+  // that need another go" only renders when there is at least one wobbly
+  // chip. An empty `summary.focus` renders the positive "secure" chip
+  // under a different aria-label ("Round outcome") — see the paired empty
+  // chip test below. Both chip rows share the `punctuation-summary-wobbly`
+  // class but never co-render.
   const harness = createPunctuationHarness();
   openSummaryScene(harness, { focus: [] });
   const html = harness.render();
-  // The wobbly chip group must not render when there's nothing to show.
   assert.doesNotMatch(html, /aria-label="Skills that need another go"/);
   assert.doesNotMatch(html, /needs another go/);
 });
 
 test('Punctuation summary scene: active monster strip renders 4 monsters, no reserved trio', () => {
   const harness = createPunctuationHarness();
-  // Craft state that intentionally contains reserved monster entries so a
-  // shallow-iteration bug would surface them.
+  // U4 follower (HIGH 1): the Summary scene reads `ui.rewardState` — the
+  // flat path that `PunctuationMapScene` uses and that
+  // `PunctuationPracticeSurface` threads in via the resolved prop. The
+  // pre-fix path `ui.rewards.monsters.punctuation` was fixture-only;
+  // production always rendered "Stage 0 of 4" because no code wrote that
+  // shape. Seed at the real path so a reserved-monster leak is still
+  // caught AND the roster iteration is driven off the path production uses.
   harness.dispatch('open-subject', { subjectId: 'punctuation' });
   harness.store.updateSubjectUi('punctuation', {
     phase: 'summary',
     summary: { total: 0, correct: 0, accuracy: 0, focus: [] },
-    rewards: {
-      monsters: {
-        punctuation: {
-          pealark: { mastered: ['m1'], caught: true },
-          claspin: { mastered: [], caught: false },
-          curlune: { mastered: [], caught: false },
-          quoral: { mastered: [], caught: false },
-          // Reserved — must NEVER surface in the strip.
-          colisk: { mastered: ['leak-1'], caught: true },
-          hyphang: { mastered: ['leak-2'], caught: true },
-          carillon: { mastered: ['leak-3'], caught: true },
-        },
-      },
+    rewardState: {
+      pealark: { mastered: ['m1'], caught: true },
+      claspin: { mastered: [], caught: false },
+      curlune: { mastered: [], caught: false },
+      quoral: { mastered: [], caught: false },
+      // Reserved — must NEVER surface in the strip even when seeded.
+      colisk: { mastered: ['leak-1'], caught: true },
+      hyphang: { mastered: ['leak-2'], caught: true },
+      carillon: { mastered: ['leak-3'], caught: true },
     },
   });
   const html = harness.render();
@@ -1977,6 +1995,48 @@ test('Punctuation summary scene: active monster strip renders 4 monsters, no res
   assert.doesNotMatch(html, /data-monster-id="colisk"/);
   assert.doesNotMatch(html, /data-monster-id="hyphang"/);
   assert.doesNotMatch(html, /data-monster-id="carillon"/);
+});
+
+test('Punctuation summary scene: monster strip renders production path via repositories.gameState', () => {
+  // U4 follower (HIGH 1, production-path integration): the Summary scene
+  // receives a resolved `rewardState` prop from `PunctuationPracticeSurface`
+  // which reads `repositories.gameState.read(learnerId, 'monster-codex')`.
+  // Seed monster-codex state via the repository (the canonical write path
+  // used by the punctuation reward subscriber) so the render assertion
+  // exercises the real production data flow rather than a fixture shape
+  // no production code ever writes.
+  //
+  // `progressForPunctuationMonster` filters the `mastered` array by the
+  // `punctuation:<releaseId>:` prefix so only the current release's keys
+  // contribute to the count — the test mastery keys carry the
+  // `PUNCTUATION_RELEASE_ID` prefix so production parity is honoured.
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  const learnerId = harness.store.getState().learners.selectedId;
+  const prefix = `punctuation:${PUNCTUATION_RELEASE_ID}:`;
+  harness.repositories.gameState.write(learnerId, 'monster-codex', {
+    pealark: {
+      releaseId: PUNCTUATION_RELEASE_ID,
+      mastered: [`${prefix}endmarks:key-1`, `${prefix}endmarks:key-2`, `${prefix}endmarks:key-3`],
+      masteredCount: 3,
+      caught: true,
+    },
+  });
+  harness.store.updateSubjectUi('punctuation', {
+    phase: 'summary',
+    summary: { total: 4, correct: 4, accuracy: 100, focus: [] },
+  });
+  const html = harness.render();
+  // The strip renders Pealark and its stage label reads non-zero — proof
+  // the scene is reading the canonical repository path, not a dead fixture
+  // shape. The exact stage depends on `publishedTotal` per monster; the
+  // non-zero assertion is enough to catch the regression where the scene
+  // rendered "Stage 0 of 4" for every production learner.
+  assert.match(html, /data-monster-id="pealark"/);
+  const stageMatch = html.match(/aria-label="Pealark stage (\d) of 4"/);
+  assert.ok(stageMatch, 'expected a pealark stage aria-label');
+  const stage = Number(stageMatch[1]);
+  assert.ok(stage > 0, `expected pealark stage > 0 after seeding mastery, saw ${stage}`);
 });
 
 test('Punctuation summary scene: GPS review cards render with preserved Phase 2 contract', () => {
@@ -2119,6 +2179,11 @@ test('Punctuation summary scene: Open Punctuation Map dispatch transitions phase
 });
 
 test('Punctuation summary scene: Start again dispatch triggers a fresh session', () => {
+  // U4 follower (correctness MEDIUM 3): tighten the assertion. The
+  // pre-fix test accepted `phase === 'active-item' || 'summary'`, which
+  // would silently pass even if the dispatch was a no-op (Summary seeded,
+  // Summary preserved). Production guarantees Start Again advances to
+  // `active-item` with a live session seeded from the chosen prefs mode.
   const harness = createPunctuationHarness();
   openSummaryScene(harness);
   // Seed a prefs mode so start-again has a mode to resume.
@@ -2126,14 +2191,13 @@ test('Punctuation summary scene: Start again dispatch triggers a fresh session',
   harness.services.punctuation.savePrefs(learnerId, { mode: 'smart', roundLength: '4' });
   harness.dispatch('punctuation-start-again');
   const state = harness.store.getState().subjectUi.punctuation;
-  // The service transitions phase to `active-item` once the session starts.
-  assert.ok(
-    state.phase === 'active-item' || state.phase === 'summary',
-    `phase should resume a session, saw ${state.phase}`,
-  );
-  if (state.phase === 'active-item') {
-    assert.ok(state.session, 'active-item phase must have a session');
-  }
+  assert.equal(state.phase, 'active-item', `phase should be 'active-item', saw ${state.phase}`);
+  assert.ok(state.session, 'active-item phase must have a session');
+  // `session.mode` is derived from prefs by `service.startSession`. Smart
+  // Review reads as `'smart'` in the session record — the exact mode
+  // asserts that the dispatch carried prefs through rather than defaulting
+  // to some other branch.
+  assert.equal(state.session.mode, 'smart', `session.mode should match chosen prefs mode`);
 });
 
 test('Punctuation summary scene: Back to dashboard dispatch returns phase to setup', () => {
@@ -2176,18 +2240,86 @@ test('Punctuation summary scene: composeIsDisabled=true disables Start again and
   );
 });
 
-test('Punctuation summary scene: Grown-up view link renders with future-hook data-action', () => {
+test('Punctuation summary scene: Grown-up view placeholder is not rendered (adv-238-002)', () => {
+  // U4 follower (adversarial MEDIUM 1): the pre-fix scene rendered a
+  // "Grown-up view" button that dispatched `punctuation-open-adult-view`
+  // against a non-existent handler — a child tap produced a silent no-op.
+  // The button is removed until Parent Hub ships the adult surface so
+  // there is no dead UX to tap.
   const harness = createPunctuationHarness();
   openSummaryScene(harness);
   const html = harness.render();
-  // The Grown-up view link is a future Parent Hub hook. The button renders
-  // today with `data-action="punctuation-open-adult-view"`; dispatching that
-  // action is a no-op until the adult surface lands, and the test asserts
-  // the SSR shape only so the hook is discoverable.
-  assert.match(
-    html,
-    /<button[^>]*data-action="punctuation-open-adult-view"[^>]*>Grown-up view<\/button>/,
-  );
+  assert.doesNotMatch(html, /data-action="punctuation-open-adult-view"/);
+  assert.doesNotMatch(html, />Grown-up view</);
+});
+
+test('Punctuation summary scene: empty wobbly focus renders positive "secure" chip', () => {
+  // U4 follower (design-lens MEDIUM 4): a round with no wobbly skills
+  // previously rendered an empty slot. The positive chip keeps the slot
+  // communicating round outcome.
+  const harness = createPunctuationHarness();
+  openSummaryScene(harness, { focus: [] });
+  const html = harness.render();
+  assert.match(html, /Everything was secure this round!/);
+  assert.match(html, /data-punctuation-summary-wobbly-empty/);
+  // The empty slot still carries an accessible role so screen readers
+  // surface the positive outcome rather than silencing it.
+  assert.match(html, /aria-label="Round outcome"/);
+});
+
+test('Punctuation summary scene: hero headline uses celebratory copy for high accuracy', () => {
+  // U4 follower (design-lens HIGH 2): accuracy-bucketed child copy.
+  const harness = createPunctuationHarness();
+  openSummaryScene(harness, { accuracy: 85 });
+  const html = harness.render();
+  assert.match(html, /Great round!/);
+  assert.doesNotMatch(html, /Punctuation session summary/);
+});
+
+test('Punctuation summary scene: hero headline uses encouraging copy for mid accuracy', () => {
+  const harness = createPunctuationHarness();
+  openSummaryScene(harness, { accuracy: 55 });
+  const html = harness.render();
+  assert.match(html, /Good try!/);
+});
+
+test('Punctuation summary scene: hero headline uses supportive copy for low accuracy', () => {
+  const harness = createPunctuationHarness();
+  openSummaryScene(harness, { accuracy: 20 });
+  const html = harness.render();
+  assert.match(html, /Keep going/);
+});
+
+test('Punctuation round-trip: summary → open-map → close-map returns to summary (adv-238-003)', () => {
+  // U4 follower (adversarial MEDIUM 2): `punctuation-close-map` pre-fix
+  // unconditionally set `phase: 'setup'`, so a learner who opened the Map
+  // from Summary lost their completion screen on close. The fix stashes
+  // the source phase in `mapUi.returnTo` on open-map; close-map reads it
+  // and routes back accordingly (default 'setup' for Setup-source opens).
+  const harness = createPunctuationHarness();
+  openSummaryScene(harness);
+  // Open Map from Summary.
+  harness.dispatch('punctuation-open-map');
+  const mapState = harness.store.getState().subjectUi.punctuation;
+  assert.equal(mapState.phase, 'map');
+  assert.equal(mapState.mapUi?.returnTo, 'summary');
+  // Close Map — learner lands back on Summary, not Setup.
+  harness.dispatch('punctuation-close-map');
+  const state = harness.store.getState().subjectUi.punctuation;
+  assert.equal(state.phase, 'summary', `close-map should return to summary, saw ${state.phase}`);
+  assert.ok(state.summary, 'summary payload must be preserved through the round trip');
+});
+
+test('Punctuation round-trip: setup → open-map → close-map returns to setup (default path)', () => {
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.dispatch('punctuation-open-map');
+  const mapState = harness.store.getState().subjectUi.punctuation;
+  assert.equal(mapState.phase, 'map');
+  assert.equal(mapState.mapUi?.returnTo, 'setup');
+  harness.dispatch('punctuation-close-map');
+  const state = harness.store.getState().subjectUi.punctuation;
+  assert.equal(state.phase, 'setup');
 });
 
 test('Punctuation summary scene: SSR HTML contains no forbidden child terms', () => {

--- a/tests/react-punctuation-scene.test.js
+++ b/tests/react-punctuation-scene.test.js
@@ -258,10 +258,16 @@ test('punctuation React surface renders GPS active progress and final review', (
 
   const summaryHtml = harness.render();
   assert.match(summaryHtml, /GPS review/);
-  assert.match(summaryHtml, /Next: Weak spots/);
+  // Phase 3 U4 simplification: "Next:" diagnostic framing becomes
+  // "Next up:" child copy.
+  assert.match(summaryHtml, /Next up: Weak spots/);
   assert.match(summaryHtml, /1\. Correct/);
   assert.match(summaryHtml, /2\. Review/);
-  assert.match(summaryHtml, /speech\.quote_missing/);
+  // Phase 3 U4 R15: raw dotted misconception ids must no longer leak into
+  // the summary SSR — they pipe through punctuationChildMisconceptionLabel
+  // and render as the child label ("Speech punctuation").
+  assert.doesNotMatch(summaryHtml, /speech\.quote_missing/);
+  assert.match(summaryHtml, /Speech punctuation/);
 });
 
 test('punctuation text input remounts when the current text item changes', async () => {
@@ -1857,6 +1863,358 @@ test('design-lens HIGH: combine/transfer source blockquote carries aria-label an
     /Read the text above, then write your answer below\./,
     'combine source must be followed by a visible bridging paragraph',
   );
+});
+
+// ---------------------------------------------------------------------------
+// Phase 3 U4 — Punctuation Summary scene.
+//
+// `phase === 'summary'` now routes through the standalone
+// `PunctuationSummaryScene` (not the pre-U4 inline `SummaryView`). Assertions
+// cover score chip row, wobbly chip child labels, active-only monster strip,
+// GPS review cards with misconception-label piping, 4 next-action buttons
+// with paired state-level dispatch verification, composeIsDisabled threading,
+// and the Grown-up view link.
+//
+// SSR blind spots (learning #6): every behavioural assertion is paired with
+// either a state-level post-dispatch check or a DOM-match regex so a silent
+// no-op can't pass (learning #7).
+// ---------------------------------------------------------------------------
+
+function openSummaryScene(harness, extraSummary = {}) {
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.store.updateSubjectUi('punctuation', {
+    phase: 'summary',
+    summary: {
+      label: 'Punctuation session summary',
+      message: 'Session complete.',
+      total: 4,
+      correct: 3,
+      accuracy: 75,
+      focus: [],
+      ...extraSummary,
+    },
+  });
+}
+
+test('Punctuation summary scene: score chip row renders Answered / Correct / Accuracy', () => {
+  const harness = createPunctuationHarness();
+  openSummaryScene(harness, { total: 6, correct: 4, accuracy: 67 });
+  const html = harness.render();
+  // Score labels live on dedicated stat blocks so each chip surfaces the
+  // right count. Assertions co-locate label and value to guard against a
+  // future regression that swaps the order of the three stats.
+  assert.match(html, /Answered/);
+  assert.match(html, /Correct/);
+  assert.match(html, /Accuracy/);
+  assert.match(html, /stat-value">6<\/div>/);
+  assert.match(html, /stat-value">4<\/div>/);
+  assert.match(html, /stat-value">67%<\/div>/);
+});
+
+test('Punctuation summary scene: wobbly chips use child skill labels, not raw skill IDs', () => {
+  const harness = createPunctuationHarness();
+  openSummaryScene(harness, {
+    focus: ['speech', 'comma_clarity'],
+  });
+  const html = harness.render();
+  // Child-facing chip copy — derived from PUNCTUATION_CLIENT_SKILLS.name.
+  assert.match(html, /Inverted commas and speech punctuation needs another go/);
+  assert.match(html, /Commas for clarity needs another go/);
+  // Raw skill ids must not leak (plan R15 / learning #9).
+  assert.doesNotMatch(html, /data-skill-id="speech"[^>]*>speech</);
+  assert.doesNotMatch(html, />speech<\/span>/);
+  assert.doesNotMatch(html, />comma_clarity<\/span>/);
+});
+
+test('Punctuation summary scene: unknown skill ids are dropped rather than rendered raw', () => {
+  const harness = createPunctuationHarness();
+  openSummaryScene(harness, { focus: ['speech', 'unknown_skill_xyz'] });
+  const html = harness.render();
+  // Known id surfaces; unknown id is silently hidden.
+  assert.match(html, /Inverted commas and speech punctuation needs another go/);
+  assert.doesNotMatch(html, /unknown_skill_xyz/);
+});
+
+test('Punctuation summary scene: empty focus renders no wobbly chip row', () => {
+  const harness = createPunctuationHarness();
+  openSummaryScene(harness, { focus: [] });
+  const html = harness.render();
+  // The wobbly chip group must not render when there's nothing to show.
+  assert.doesNotMatch(html, /aria-label="Skills that need another go"/);
+  assert.doesNotMatch(html, /needs another go/);
+});
+
+test('Punctuation summary scene: active monster strip renders 4 monsters, no reserved trio', () => {
+  const harness = createPunctuationHarness();
+  // Craft state that intentionally contains reserved monster entries so a
+  // shallow-iteration bug would surface them.
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.store.updateSubjectUi('punctuation', {
+    phase: 'summary',
+    summary: { total: 0, correct: 0, accuracy: 0, focus: [] },
+    rewards: {
+      monsters: {
+        punctuation: {
+          pealark: { mastered: ['m1'], caught: true },
+          claspin: { mastered: [], caught: false },
+          curlune: { mastered: [], caught: false },
+          quoral: { mastered: [], caught: false },
+          // Reserved — must NEVER surface in the strip.
+          colisk: { mastered: ['leak-1'], caught: true },
+          hyphang: { mastered: ['leak-2'], caught: true },
+          carillon: { mastered: ['leak-3'], caught: true },
+        },
+      },
+    },
+  });
+  const html = harness.render();
+  // Active monsters render.
+  assert.match(html, /data-monster-id="pealark"/);
+  assert.match(html, /data-monster-id="claspin"/);
+  assert.match(html, /data-monster-id="curlune"/);
+  assert.match(html, /data-monster-id="quoral"/);
+  // Reserved monsters must never reach the DOM.
+  assert.doesNotMatch(html, /data-monster-id="colisk"/);
+  assert.doesNotMatch(html, /data-monster-id="hyphang"/);
+  assert.doesNotMatch(html, /data-monster-id="carillon"/);
+});
+
+test('Punctuation summary scene: GPS review cards render with preserved Phase 2 contract', () => {
+  const harness = createPunctuationHarness();
+  openSummaryScene(harness, {
+    label: 'Punctuation GPS test summary',
+    message: 'GPS test complete.',
+    total: 2,
+    correct: 1,
+    accuracy: 50,
+    gps: {
+      delayedFeedback: true,
+      recommendedMode: 'weak',
+      recommendedLabel: 'Wobbly spots',
+      reviewItems: [
+        {
+          index: 1,
+          itemId: 'se_insert_capital',
+          mode: 'insert',
+          prompt: 'Add the missing capital letter and full stop.',
+          attemptedAnswer: 'The boat reached the harbour.',
+          displayCorrection: 'The boat reached the harbour.',
+          correct: true,
+          misconceptionTags: [],
+        },
+        {
+          index: 2,
+          itemId: 'sp_insert_question',
+          mode: 'insert',
+          prompt: 'Add the direct-speech punctuation.',
+          attemptedAnswer: 'Ella asked can we start now',
+          displayCorrection: 'Ella asked, "Can we start now?"',
+          correct: false,
+          misconceptionTags: ['speech.quote_missing'],
+        },
+      ],
+    },
+  });
+  const html = harness.render();
+  assert.match(html, /GPS review/);
+  // Child-facing "Next up" copy uses `recommendedLabel`, not `recommendedMode`.
+  assert.match(html, /Next up: Wobbly spots/);
+  assert.match(html, /1\. Correct/);
+  assert.match(html, /2\. Review/);
+  assert.match(html, /Ella asked, &quot;Can we start now\?&quot;/);
+});
+
+test('Punctuation summary scene: misconception tags pipe through child label map, null tags hidden', () => {
+  const harness = createPunctuationHarness();
+  openSummaryScene(harness, {
+    gps: {
+      delayedFeedback: true,
+      recommendedMode: 'smart',
+      recommendedLabel: 'Smart review',
+      reviewItems: [
+        {
+          index: 1,
+          itemId: 'sp_insert_question',
+          mode: 'insert',
+          prompt: 'Add the direct-speech punctuation.',
+          attemptedAnswer: '',
+          displayCorrection: '',
+          correct: false,
+          // speech.quote_missing → "Speech punctuation" (mapped).
+          // never.heard.of.this → null (dropped).
+          misconceptionTags: ['speech.quote_missing', 'never.heard.of.this'],
+        },
+      ],
+    },
+  });
+  const html = harness.render();
+  // Child label surfaces.
+  assert.match(html, /Speech punctuation</);
+  // Raw dotted id must not leak — part of PUNCTUATION_CHILD_FORBIDDEN_TERMS.
+  assert.doesNotMatch(html, /speech\.quote_missing/);
+  assert.doesNotMatch(html, /never\.heard\.of\.this/);
+});
+
+test('Punctuation summary scene: GPS card dedupes misconception labels to a single chip per label', () => {
+  // A single GPS item can carry multiple sub-tags that all map to the same
+  // child label (e.g. speech.quote_missing + speech.quote_unmatched both
+  // → "Speech punctuation"). The chip row must render one chip per unique
+  // label, not one per raw tag.
+  const harness = createPunctuationHarness();
+  openSummaryScene(harness, {
+    gps: {
+      delayedFeedback: true,
+      recommendedMode: 'weak',
+      recommendedLabel: 'Wobbly spots',
+      reviewItems: [
+        {
+          index: 1,
+          itemId: 'sp_dupes',
+          mode: 'insert',
+          prompt: 'Add the direct-speech punctuation.',
+          attemptedAnswer: '',
+          displayCorrection: '',
+          correct: false,
+          misconceptionTags: ['speech.quote_missing', 'speech.quote_unmatched'],
+        },
+      ],
+    },
+  });
+  const html = harness.render();
+  const matches = html.match(/>Speech punctuation</g) || [];
+  assert.equal(matches.length, 1, 'should render exactly one "Speech punctuation" chip');
+});
+
+test('Punctuation summary scene: renders 4 next-action buttons', () => {
+  const harness = createPunctuationHarness();
+  openSummaryScene(harness);
+  const html = harness.render();
+  assert.match(html, /<button[^>]*data-action="punctuation-start"[^>]*data-value="weak"[^>]*>Practise wobbly spots<\/button>/);
+  assert.match(html, /<button[^>]*data-action="punctuation-open-map"[^>]*>Open Punctuation Map<\/button>/);
+  assert.match(html, /<button[^>]*data-action="punctuation-start-again"[^>]*>Start again<\/button>/);
+  assert.match(html, /<button[^>]*data-action="punctuation-back"[^>]*>Back to dashboard<\/button>/);
+});
+
+test('Punctuation summary scene: Practise wobbly spots dispatch results in session.mode === `weak`', () => {
+  const harness = createPunctuationHarness();
+  openSummaryScene(harness);
+  harness.dispatch('punctuation-start', { mode: 'weak' });
+  const state = harness.store.getState().subjectUi.punctuation;
+  // Paired state-level assertion per learning #7: a silent no-op would
+  // leave `session.mode` unchanged, so explicit equality catches it.
+  assert.equal(state.session?.mode, 'weak');
+});
+
+test('Punctuation summary scene: Open Punctuation Map dispatch transitions phase to map', () => {
+  // U5's `punctuation-open-map` handler allowlists `summary` as a source
+  // phase (service-contract PUNCTUATION_OPEN_MAP_ALLOWED_PHASES = ['setup',
+  // 'summary']). If that allowlist ever regressed, this test fails.
+  const harness = createPunctuationHarness();
+  openSummaryScene(harness);
+  harness.dispatch('punctuation-open-map');
+  const state = harness.store.getState().subjectUi.punctuation;
+  assert.equal(state.phase, 'map');
+  assert.equal(state.mapUi?.statusFilter, 'all');
+  assert.equal(state.mapUi?.monsterFilter, 'all');
+});
+
+test('Punctuation summary scene: Start again dispatch triggers a fresh session', () => {
+  const harness = createPunctuationHarness();
+  openSummaryScene(harness);
+  // Seed a prefs mode so start-again has a mode to resume.
+  const learnerId = harness.store.getState().learners.selectedId;
+  harness.services.punctuation.savePrefs(learnerId, { mode: 'smart', roundLength: '4' });
+  harness.dispatch('punctuation-start-again');
+  const state = harness.store.getState().subjectUi.punctuation;
+  // The service transitions phase to `active-item` once the session starts.
+  assert.ok(
+    state.phase === 'active-item' || state.phase === 'summary',
+    `phase should resume a session, saw ${state.phase}`,
+  );
+  if (state.phase === 'active-item') {
+    assert.ok(state.session, 'active-item phase must have a session');
+  }
+});
+
+test('Punctuation summary scene: Back to dashboard dispatch returns phase to setup', () => {
+  const harness = createPunctuationHarness();
+  openSummaryScene(harness);
+  harness.dispatch('punctuation-back');
+  const state = harness.store.getState().subjectUi.punctuation;
+  assert.equal(state.phase, 'setup');
+});
+
+test('Punctuation summary scene: composeIsDisabled=true disables Start again and Practise wobbly spots', () => {
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.store.updateSubjectUi('punctuation', {
+    phase: 'summary',
+    pendingCommand: 'punctuation-continue',
+    summary: { total: 4, correct: 3, accuracy: 75, focus: [] },
+  });
+  const html = harness.render();
+  // Every next-action button renders with `disabled` when composeIsDisabled.
+  assert.match(
+    html,
+    /<button[^>]*disabled[^>]*data-action="punctuation-start"[^>]*data-value="weak"|<button[^>]*data-action="punctuation-start"[^>]*data-value="weak"[^>]*disabled/,
+    'Practise wobbly spots must be disabled under pendingCommand',
+  );
+  assert.match(
+    html,
+    /<button[^>]*disabled[^>]*data-action="punctuation-start-again"|<button[^>]*data-action="punctuation-start-again"[^>]*disabled/,
+    'Start again must be disabled under pendingCommand',
+  );
+  assert.match(
+    html,
+    /<button[^>]*disabled[^>]*data-action="punctuation-open-map"|<button[^>]*data-action="punctuation-open-map"[^>]*disabled/,
+    'Open Punctuation Map must be disabled under pendingCommand',
+  );
+  assert.match(
+    html,
+    /<button[^>]*disabled[^>]*data-action="punctuation-back"|<button[^>]*data-action="punctuation-back"[^>]*disabled/,
+    'Back to dashboard must be disabled under pendingCommand',
+  );
+});
+
+test('Punctuation summary scene: Grown-up view link renders with future-hook data-action', () => {
+  const harness = createPunctuationHarness();
+  openSummaryScene(harness);
+  const html = harness.render();
+  // The Grown-up view link is a future Parent Hub hook. The button renders
+  // today with `data-action="punctuation-open-adult-view"`; dispatching that
+  // action is a no-op until the adult surface lands, and the test asserts
+  // the SSR shape only so the hook is discoverable.
+  assert.match(
+    html,
+    /<button[^>]*data-action="punctuation-open-adult-view"[^>]*>Grown-up view<\/button>/,
+  );
+});
+
+test('Punctuation summary scene: SSR HTML contains no forbidden child terms', () => {
+  const harness = createPunctuationHarness();
+  openSummaryScene(harness, {
+    focus: ['speech', 'comma_clarity'],
+    gps: {
+      delayedFeedback: true,
+      recommendedMode: 'weak',
+      recommendedLabel: 'Wobbly spots',
+      reviewItems: [
+        {
+          index: 1,
+          itemId: 'sp1',
+          mode: 'insert',
+          prompt: 'Add the direct-speech punctuation.',
+          attemptedAnswer: 'Ella asked',
+          displayCorrection: 'Ella asked, can we start?',
+          correct: false,
+          misconceptionTags: ['speech.quote_missing'],
+        },
+      ],
+    },
+  });
+  const html = harness.render();
+  const leaks = forbiddenTermsInHtml(html);
+  assert.deepEqual(leaks, [], `forbidden term leak in summary SSR: ${leaks.join(', ')}`);
 });
 
 test('design-lens HIGH: every item mode passes the PUNCTUATION_CHILD_FORBIDDEN_TERMS sweep in the session scene', () => {

--- a/tests/subject-expansion.test.js
+++ b/tests/subject-expansion.test.js
@@ -240,7 +240,10 @@ const punctuationSpec = {
   expectReactPractice: true,
   practiceMatcher: /Punctuation practice/,
   sessionMatcher: /Choose the best punctuated sentence|Punctuate the sentence accurately|Correct the punctuation/,
-  summaryMatcher: /Punctuation session summary/,
+  // U4 follower (design-lens HIGH 2): summary headline is now the
+  // accuracy-bucketed celebration copy from `punctuationSummaryHeadline`.
+  // The golden path answers one item correctly → 100% accuracy → "Great round!".
+  summaryMatcher: /Great round!/,
   getUiState(harness) {
     return harness.store.getState().subjectUi.punctuation;
   },


### PR DESCRIPTION
## Summary
- New `PunctuationSummaryScene.jsx` with score chip row, wobbly chips (child labels), active-only monster progress strip, 4 next-action buttons, Grown-up view link.
- Wobbly chips use `punctuationChildStatusLabel` + `PUNCTUATION_CLIENT_SKILLS` names — no raw skill IDs.
- GPS summary preserved (Phase 2 contract). `misconceptionTags` piped through `punctuationChildMisconceptionLabel`; null-mapped tags hidden. Labels dedupe across sub-tags per item.
- Reserved monsters never rendered (iterator locked to `ACTIVE_PUNCTUATION_MONSTER_IDS`; test crafts state with colisk/hyphang/carillon and asserts absence).
- Router delegates `summary` phase.
- Grown-up view link carries `data-action="punctuation-open-adult-view"` as a future Parent Hub hook (no-op at dispatch layer today).

## Plan reference
U4 of `docs/plans/2026-04-25-005-feat-punctuation-phase3-ux-rebuild-plan.md`.

## Release-id impact
`release-id impact: none`.

## Test plan
- [x] 4 next-action buttons with paired state-level dispatch assertions (Practise wobbly → `session.mode === 'weak'`; Open Map → `phase === 'map'`; Back → `phase === 'setup'`; Start again resumes a session)
- [x] Wobbly chips use child labels ("Inverted commas and speech punctuation needs another go"), not raw skill IDs
- [x] Unknown skill ids in `summary.focus` are silently dropped (not rendered raw)
- [x] Reserved monsters (Colisk/Hyphang/Carillon) absent from monster strip even when state is crafted to contain them
- [x] GPS summary renders `summary.gps.reviewItems` cards (Phase 2 contract preserved); "Next up:" uses `recommendedLabel`, not `recommendedMode`
- [x] GPS misconception tags pipe through `punctuationChildMisconceptionLabel` (speech.quote_missing → "Speech punctuation"); null-mapped tags hidden
- [x] GPS card dedupes multiple sub-tags that map to the same label (one chip per label)
- [x] `composeIsDisabled` threads through every button (primary 4 + Grown-up)
- [x] Summary SSR contains none of `PUNCTUATION_CHILD_FORBIDDEN_TERMS`
- [x] Pre-existing Phase 2 GPS assertion updated: `Next:` → `Next up:` (U4 copy simplification); raw `speech.quote_missing` leak now asserted absent

## Verification
- `node --test tests/react-punctuation-scene.test.js` — 84/84 pass (16 new summary tests)
- `node --test tests/bundle-audit.test.js` — 26/26 pass
- `node --test tests/punctuation-legacy-parity.test.js` — 11/11 pass (byte-for-byte engine parity preserved)
- `npm test` — 2424/2427 pass; 2 fails are pre-existing and unrelated (`grammar-production-smoke` + `punctuation-release-smoke` JSON-parse; both reproduce on origin/main with stashed changes)

## Deviations from plan
- None. Scene shape, router change, and tests all match the U4 block. "Grown-up view" renders as a no-op button per the plan's fallback clause; no module handler needed today.