### PR TITLE
feat(spelling): U10 Boss Dictation UI + Alt+5 shortcut

### DIFF
--- a/src/subjects/spelling/components/SpellingSetupScene.jsx
+++ b/src/subjects/spelling/components/SpellingSetupScene.jsx
@@ -3,6 +3,7 @@ import { useMonsterVisualConfig } from '../../../platform/game/MonsterVisualConf
 import { SpellingHeroBackdrop } from './SpellingHeroBackdrop.jsx';
 import { ArrowRightIcon, CheckIcon } from './spelling-icons.jsx';
 import { useSetupHeroContrast } from './useSetupHeroContrast.js';
+import { BOSS_DEFAULT_ROUND_LENGTH } from '../service-contract.js';
 import {
   MODE_CARDS,
   POST_MEGA_MODE_CARDS,
@@ -502,7 +503,19 @@ function PostMegaSetupContent({
   runtimeReadOnly,
 }) {
   const guardianCard = POST_MEGA_MODE_CARDS.find((mode) => mode.id === 'guardian') || POST_MEGA_MODE_CARDS[0];
-  const otherCards = POST_MEGA_MODE_CARDS.filter((mode) => mode.id !== 'guardian');
+  // U10: Boss Dictation is the second active post-Mega surface. Pull it out
+  // of POST_MEGA_MODE_CARDS by id rather than by index so future reorderings
+  // don't silently pick up the wrong card.
+  const bossCard = POST_MEGA_MODE_CARDS.find((mode) => mode.id === 'boss-dictation');
+  const placeholderCards = POST_MEGA_MODE_CARDS.filter((mode) => mode.id !== 'guardian' && mode.id !== 'boss-dictation');
+  // Boss active-state gate: the same `postMastery.allWordsMega` that already
+  // gates Guardian's Alt+4 shortcut. We land on PostMegaSetupContent only when
+  // the caller has already decided `isPostMega === true`, so allWordsMega is
+  // true by construction — but we branch defensively so a future caller who
+  // passes a stale postMastery shape doesn't render a dead active card.
+  const bossActive = Boolean(postMastery?.allWordsMega);
+  const bossDescription = bossCard?.desc || '';
+  const bossBadge = 'BOSS READY';
   // U1: branch copy + gating on `guardianMissionState`. Fall back to the
   // legacy `guardianDueCount > 0` signal when the read-model has not yet
   // populated the new scalars so remote-sync and any pre-U1 caller remain
@@ -580,6 +593,17 @@ function PostMegaSetupContent({
     : pendingCommand === 'save-prefs'
       ? 'Saving...'
       : 'Begin Guardian Mission';
+  // U10: Boss Begin button shares the same pending-command gating as the
+  // Guardian Begin — both go through `spelling-shortcut-start` and both
+  // collide on the same `start-session` pending slot. Sharing `beginText`'s
+  // "Starting..." branch would conflate which button is spinning, so Boss
+  // owns its own label but reuses the same disable predicate.
+  const bossBeginDisabled = startDisabled || runtimeReadOnly || !bossActive;
+  const bossBeginText = pendingCommand === 'start-session'
+    ? 'Starting...'
+    : pendingCommand === 'save-prefs'
+      ? 'Saving...'
+      : 'Begin Boss Dictation';
 
   function handleBegin(event) {
     if (beginDisabled) {
@@ -588,6 +612,20 @@ function PostMegaSetupContent({
       return;
     }
     renderAction(actions, event, 'spelling-shortcut-start', { mode: 'guardian' });
+  }
+
+  function handleBossBegin(event) {
+    if (bossBeginDisabled) {
+      event?.preventDefault?.();
+      event?.stopPropagation?.();
+      return;
+    }
+    // The service normalises `length` against BOSS_MIN/MAX; the explicit
+    // payload here matches the plan's Alt+5 spec (`length: BOSS_DEFAULT_ROUND_LENGTH`)
+    // without reaching back into the view-model for the constant. Keeping
+    // the length explicit at the dispatch site makes the begin-button
+    // contract self-documenting for a future reader.
+    renderAction(actions, event, 'spelling-shortcut-start', { mode: 'boss', length: BOSS_DEFAULT_ROUND_LENGTH });
   }
 
   return (
@@ -613,12 +651,34 @@ function PostMegaSetupContent({
           active={guardianActive}
           disabled={!guardianActive}
         />
-        {otherCards.map((mode, index) => (
+        {/* U10: Boss Dictation active card. The variant matches Guardian's
+            active/rested split — `active` when `allWordsMega === true`
+            (always true inside PostMegaSetupContent), `rested` otherwise. We
+            pass the Boss description straight from POST_MEGA_MODE_CARDS so a
+            future copy tweak is a one-line change in the view-model, and keep
+            the badge in this file so a future variant (e.g. "RECENT SCORE
+            9/10") can render conditionally without touching the view-model
+            frozen array. */}
+        {bossCard ? (
+          <PostMegaModeCard
+            mode={bossCard}
+            variant={bossActive ? 'active' : 'rested'}
+            description={bossDescription}
+            badge={bossActive ? bossBadge : null}
+            textTone={heroContrast.contrast.cards?.[1] || heroContrast.contrast.shell}
+            active={bossActive}
+            disabled={!bossActive}
+          />
+        ) : null}
+        {placeholderCards.map((mode, index) => (
           <PostMegaModeCard
             mode={mode}
             variant="placeholder"
-            index={index + 1}
-            textTone={heroContrast.contrast.cards?.[index + 1] || heroContrast.contrast.shell}
+            // Roadmap index bumps to 2 / 3 because Guardian (#0) and Boss
+            // (#1) occupy slots 0 and 1; the "Next 03" / "Next 04" chips on
+            // the placeholders communicate the P2 roadmap position.
+            index={index + 2}
+            textTone={heroContrast.contrast.cards?.[index + 2] || heroContrast.contrast.shell}
             disabled
             key={mode.id}
           />
@@ -642,6 +702,34 @@ function PostMegaSetupContent({
         >
           {beginText} <ArrowRightIcon />
         </button>
+        {/* U10: Boss Begin row. Mirrors the Guardian begin-row structure —
+            hint chip + primary CTA — but dispatches `spelling-shortcut-start`
+            with `{ mode: 'boss', length: BOSS_DEFAULT_ROUND_LENGTH }`. The
+            Alt+5 hint is aria-hidden when Boss is inactive so screen readers
+            don't announce a shortcut that won't work; the begin button
+            itself stays disabled with a conservative CTA label. */}
+        {bossCard ? (
+          <>
+            <div className="post-mega-begin-hint" aria-hidden={bossActive ? undefined : 'true'}>
+              <kbd>Alt</kbd>
+              <span className="post-mega-begin-hint-join">+</span>
+              <kbd>5</kbd>
+              <span className="post-mega-begin-hint-label">quick-start Boss Dictation</span>
+            </div>
+            <button
+              type="button"
+              className="btn primary xl"
+              style={{ '--btn-accent': accent }}
+              data-action="spelling-shortcut-start"
+              data-mode="boss"
+              disabled={bossBeginDisabled}
+              onClick={handleBossBegin}
+              aria-label={bossCard.ariaLabel || 'Begin Boss Dictation'}
+            >
+              {bossBeginText} <ArrowRightIcon />
+            </button>
+          </>
+        ) : null}
       </div>
     </>
   );

--- a/src/subjects/spelling/components/SpellingSummaryScene.jsx
+++ b/src/subjects/spelling/components/SpellingSummaryScene.jsx
@@ -53,6 +53,55 @@ function SummaryGuardianBand({ cards = [] }) {
   );
 }
 
+// U10: Boss-specific summary score line. The plan's R13 spec nails this copy
+// format exactly — "Boss score: N/M Mega words landed" — and we keep it in
+// the scene so a product tweak is a single-file change. The band borrows
+// Guardian's `summary-guardian-band` shape (eyebrow + score line) but swaps
+// the Vault framing for Boss-specific copy that reinforces the
+// Mega-never-revoked invariant the service already baked into
+// `summary.message`.
+function SummaryBossBand({ summary }) {
+  if (!summary) return null;
+  const totalWords = Math.max(1, Number(summary.totalWords) || 1);
+  const correct = Math.max(0, Math.min(totalWords, Number(summary.correct) || 0));
+  return (
+    <section className="summary-guardian-band summary-boss-band" aria-label="Boss tally">
+      <header className="summary-guardian-head">
+        <span className="summary-guardian-eyebrow">Boss tally</span>
+        <span className="summary-guardian-sub" aria-hidden="true">Your Mega words stayed Mega</span>
+      </header>
+      <p className="summary-boss-score">
+        Boss score: {correct}/{totalWords} Mega words landed
+      </p>
+    </section>
+  );
+}
+
+// U10: Read-only miss-list for Boss summaries. Boss is a test-mode round —
+// no retry, no drill-all, no per-word practice. The scene surfaces the
+// missed words as static chips so the child can see what slipped, paired
+// with a short reassurance that Mega status stays intact. The rendered
+// chips deliberately carry no `data-action` attribute, so a future bulk
+// regex ("any button that dispatches drill-all") cannot accidentally
+// re-introduce drill routing on a Boss summary. The negative regression
+// assertions in `tests/spelling-boss.test.js` lock this in.
+function SummaryBossMissList({ mistakes = [] }) {
+  if (!mistakes.length) return null;
+  return (
+    <div className="summary-drill summary-drill--boss">
+      <div className="summary-drill-head">
+        <h4>Words that slipped today</h4>
+        <span className="small muted">These stay Mega. Give them a quieter look another day.</span>
+      </div>
+      <div className="summary-drill-chips">
+        {mistakes.map((word) => (
+          <span className="fchip fchip--static" key={word.slug}>{word.word}</span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export function SpellingSummaryScene({ learner, ui, accent, actions, postMastery = null, previousHeroBg = '', runtimeReadOnly = false }) {
   const summary = ui.summary;
   if (!summary) return null;
@@ -65,6 +114,12 @@ export function SpellingSummaryScene({ learner, ui, accent, actions, postMastery
   }, { complete: true });
   const toneGood = !summary.mistakes.length;
   const isGuardianSummary = summary.mode === 'guardian';
+  // U10: Boss rounds render a dedicated summary branch — no drill-all, no
+  // per-word chips, no retry CTAs. The service already rewrites
+  // `summary.message` and the "Needs more work" card sub for Boss mode so
+  // the stat grid reads correctly; the scene-level branch adds the score
+  // line band + read-only miss list alongside that.
+  const isBossSummary = summary.mode === 'boss';
   // When we exit a Guardian round the postMastery snapshot reflects the
   // post-advance state — so `nextGuardianDueDay` already tells us when the
   // learner should return. If postMastery is unavailable (e.g. SSR before
@@ -83,11 +138,17 @@ export function SpellingSummaryScene({ learner, ui, accent, actions, postMastery
       <div className="session summary">
         <header className="session-head">
           <PathProgress done={progressTotal} current={progressTotal} total={progressTotal} />
-          <span className="path-count">{isGuardianSummary ? 'Guardian round complete' : 'Round complete'}</span>
+          <span className="path-count">
+            {isGuardianSummary
+              ? 'Guardian round complete'
+              : isBossSummary
+                ? 'Boss round complete'
+                : 'Round complete'}
+          </span>
         </header>
 
         <AnimatedPromptCard
-          className={`summary-card${isGuardianSummary ? ' summary-card--guardian' : ''}`}
+          className={`summary-card${isGuardianSummary ? ' summary-card--guardian' : ''}${isBossSummary ? ' summary-card--boss' : ''}`}
           innerClassName="summary-card-inner"
         >
           <h3 className="summary-title sr-only">Session summary</h3>
@@ -101,8 +162,11 @@ export function SpellingSummaryScene({ learner, ui, accent, actions, postMastery
           <SummaryStatGrid cards={summary.cards} />
 
           {isGuardianSummary ? <SummaryGuardianBand cards={guardianCards} /> : null}
+          {isBossSummary ? <SummaryBossBand summary={summary} /> : null}
 
-          {summary.mistakes.length ? (
+          {isBossSummary ? (
+            <SummaryBossMissList mistakes={summary.mistakes} />
+          ) : summary.mistakes.length ? (
             isGuardianSummary ? (
               // U3: Guardian summaries replace the legacy "Drill all" + per-word
               // "Drill" chip cluster with a single Practice button. The

--- a/src/subjects/spelling/components/spelling-view-model.js
+++ b/src/subjects/spelling/components/spelling-view-model.js
@@ -28,12 +28,27 @@ export const MODE_CARDS = Object.freeze([
   },
 ]);
 
-/* Post-Mega dashboard cards. Guardian Mission is the only active card in MVP;
- * Boss Dictation / Word Detective / Story Challenge are preview placeholders
- * that set the P2+ roadmap without promising dates. Icons stay null because
- * the Guardian / future-mode art has not been drawn yet — the component
- * renders a typographic glyph placeholder in its place so we never ship an
- * off-brand generic icon. */
+/* Post-Mega dashboard cards. Guardian Mission and Boss Dictation are both
+ * active in U10 — they are the two primary post-Mega paths. Word Detective /
+ * Story Challenge remain preview placeholders that set the P2+ roadmap
+ * without promising dates. Icons stay null because the Guardian / Boss /
+ * future-mode art has not been drawn yet — the component renders a
+ * typographic glyph placeholder in its place so we never ship an off-brand
+ * generic icon.
+ *
+ * U10: Boss Dictation flips from `disabled: true` (Phase P1 placeholder) to
+ * `disabled: false` with its own `ariaLabel`. The PostMegaSetupContent scene
+ * branches on `card.id === 'boss-dictation'` to render the Boss variant with
+ * its own Begin button — same three-state variant system established by
+ * Guardian (`active` / `rested` / `placeholder`). Copy landed via the
+ * /frontend-design invocation (plan reference:
+ * docs/plans/2026-04-25-005-feat-post-mega-spelling-guardian-hardening-plan.md).
+ *
+ * Design framing rules (both active cards must honour):
+ *   - Glyph is a single letter, matches the pill frame established by Guardian.
+ *   - Description is grounded and child-specific; no "Coming soon" stub copy.
+ *   - `ariaLabel` is required on every active card so screen readers read the
+ *     full intent rather than just the glyph + title + description. */
 export const POST_MEGA_MODE_CARDS = Object.freeze([
   {
     id: 'guardian',
@@ -48,8 +63,13 @@ export const POST_MEGA_MODE_CARDS = Object.freeze([
     iconSrc: null,
     glyph: 'B',
     title: 'Boss Dictation',
-    desc: 'Coming soon — one-shot dictation challenges against a bigger boss.',
-    disabled: true,
+    // "Ten Mega words. One spelling each. Miss one — it still stays Mega."
+    // reinforces the Mega-never-revoked invariant on the card face itself so
+    // a child who hesitates before pressing Begin already knows a Boss round
+    // cannot punish them into Guardian recovery.
+    desc: 'Ten Mega words. One spelling each. Miss one — it still stays Mega.',
+    ariaLabel: 'Boss Dictation — ten-word one-shot dictation from your Mega words. Mega status never drops.',
+    disabled: false,
   },
   {
     id: 'word-detective',
@@ -621,6 +641,11 @@ export function summaryModeLabel(mode) {
   if (mode === 'test') return 'SATs Test';
   if (mode === 'single') return 'Single-word Drill';
   if (mode === 'guardian') return 'Guardian Mission';
+  // U10: Boss Dictation lives alongside Guardian Mission as a post-Mega
+  // surface. Without this branch `summaryRibbonSub` would display "Smart
+  // Review" on the Boss summary mode chip, leaking legacy copy into the
+  // graduated surface.
+  if (mode === 'boss') return 'Boss Dictation';
   return 'Smart Review';
 }
 

--- a/src/subjects/spelling/module.js
+++ b/src/subjects/spelling/module.js
@@ -241,11 +241,24 @@ export const spellingModule = {
       // the session the learner actually landed in. Same pattern must live
       // in remote-actions.js (optimistic-prefs branch).
       const currentPrefs = service.getPrefs(learnerId);
+      // U10: Boss Dictation ships with a fixed default round length
+      // (BOSS_DEFAULT_ROUND_LENGTH = 10). The Boss begin-button dispatches
+      // `{ mode: 'boss', length: 10 }` so the Boss round is always 10 cards
+      // regardless of the learner's persisted `roundLength` preference (which
+      // could be 20 or 40 from a SATs Test session). When the caller supplies
+      // `data.length` we honour it; otherwise we fall back to the persisted
+      // pref. The service clamps Boss length into [8, 12] so a stray 20 is
+      // rounded down to 12 rather than failing, but the Boss card on the
+      // dashboard should not rely on that clamp to land on the spec-mandated
+      // 10 — the dispatch carries the intent explicitly. Guardian's Alt+4
+      // path does not supply a `length` so it continues to use
+      // `currentPrefs.roundLength`, preserving legacy behaviour there.
+      const shortcutLength = data.length != null ? data.length : currentPrefs.roundLength;
       tts.stop();
       const transition = service.startSession(learnerId, {
         mode,
         yearFilter: currentPrefs.yearFilter,
-        length: currentPrefs.roundLength,
+        length: shortcutLength,
         extraWordFamilies: currentPrefs.extraWordFamilies,
       });
       if (transition?.ok !== false) {

--- a/src/subjects/spelling/remote-actions.js
+++ b/src/subjects/spelling/remote-actions.js
@@ -898,21 +898,74 @@ export function createRemoteSpellingActionHandler({
         await flushPendingPreferenceSave(learnerId);
         const current = visiblePrefsForLearner(learnerId, appState());
         const patch = optimisticSpellingPrefsPatchForAction('spelling-set-mode', { value: mode }, current);
+        // U10 blocker fix — mirror `module.js::spelling-shortcut-start`:
+        //   1. Apply the optimistic `{ mode }` locally so the dashboard
+        //      reflects the user's intent immediately.
+        //   2. Run `start-session` FIRST. A failed start must NOT leave
+        //      `prefs.mode` persisted as the new mode.
+        //   3. Only persist `save-prefs` AFTER the start succeeds.
+        //   4. On failure, rollback the optimistic patch by clearing the
+        //      recorded intent and reloading the persisted prefs via
+        //      `reapplyPendingOptimisticPrefs`.
+        //
+        // U10 blocker fix — Boss-length parity: the Begin button dispatches
+        // `{ mode: 'boss', length: BOSS_DEFAULT_ROUND_LENGTH }` and Alt+5's
+        // resolver now does the same. Honour `data.length` when supplied so
+        // a Boss round is always 10 cards regardless of `prefs.roundLength`
+        // (which could be '20' for a fresh learner, or SATs-set). When the
+        // caller does not supply a length we fall back to `prefs.roundLength`
+        // so Guardian (Alt+4) and legacy modes keep existing behaviour.
         const intent = recordPreferenceIntent(learnerId, patch);
         updateOptimisticPrefs(patch);
+        const prefsBeforeStart = visiblePrefsForLearner(learnerId, appState());
+        const shortcutLength = data.length != null ? data.length : prefsBeforeStart.roundLength;
+        let startResponse = null;
+        try {
+          startResponse = await sendCommand('start-session', {
+            mode: prefsBeforeStart.mode || mode,
+            yearFilter: prefsBeforeStart.yearFilter,
+            length: shortcutLength,
+            extraWordFamilies: prefsBeforeStart.extraWordFamilies,
+          }, { learnerId });
+        } catch (error) {
+          // Rollback: the optimistic prefs must not outlive a failed
+          // start-session. Drop the tracked intent and reload from the
+          // persisted prefs so the dashboard re-reflects ground truth.
+          const version = intent?.version || 0;
+          const latest = latestPreferenceIntents.get(learnerId);
+          if (latest && Number(latest.version) <= Number(version)) {
+            latestPreferenceIntents.delete(learnerId);
+          }
+          store.reloadFromRepositories({ preserveRoute: true });
+          reapplyPendingOptimisticPrefs();
+          throw error;
+        }
+        // Server may have rejected inline (ok === false or equivalent shape).
+        // Treat anything that leaves `phase !== 'session'` on the read model
+        // as a non-ok start and skip the prefs persistence step, mirroring
+        // the module.js `transition?.ok !== false` guard.
+        const nextPhase = startResponse?.subjectReadModel?.phase
+          || startResponse?.state?.phase
+          || appState().subjectUi?.spelling?.phase
+          || '';
+        if (startResponse?.ok === false || (nextPhase && nextPhase !== 'session')) {
+          // Start did not land on a session — rollback optimistic prefs so
+          // `prefs.mode` is not left pointing at the would-be mode.
+          const version = intent?.version || 0;
+          const latest = latestPreferenceIntents.get(learnerId);
+          if (latest && Number(latest.version) <= Number(version)) {
+            latestPreferenceIntents.delete(learnerId);
+          }
+          store.reloadFromRepositories({ preserveRoute: true });
+          reapplyPendingOptimisticPrefs();
+          return;
+        }
         try {
           await sendCommand('save-prefs', { prefs: patch }, { learnerId, preferenceVersion: intent?.version || 0 });
         } catch (error) {
           handlePreferenceSaveError(error, { learnerId, preferenceVersion: intent?.version || 0 });
           throw error;
         }
-        const prefs = visiblePrefsForLearner(learnerId, appState());
-        await sendCommand('start-session', {
-          mode: prefs.mode || mode,
-          yearFilter: prefs.yearFilter,
-          length: prefs.roundLength,
-          extraWordFamilies: prefs.extraWordFamilies,
-        }, { learnerId });
       })().catch((error) => {
         globalThis.console?.warn?.('Spelling shortcut command failed.', error);
         setRuntimeErrorForLearner(learnerId, commandErrorMessage(error, 'The spelling shortcut could not be completed.'));

--- a/src/subjects/spelling/service-contract.js
+++ b/src/subjects/spelling/service-contract.js
@@ -307,7 +307,14 @@ function deriveSummaryTotals(mode, cards, mistakes) {
   let totalWords = 0;
   let correct = 0;
 
-  if (mode === 'test') {
+  // Boss (U10) and SATs Test share the same testSummary card shape
+  // (`Score: 7/10`, `Accuracy: 70%`, `Correct: 7`, `Needs more work: 3`). The
+  // score-card "N/M" parse therefore applies to both; without adding 'boss'
+  // here the else-branch would fall back to `firstValue = '7/10'` →
+  // Number.parseInt → 7, which would lead to `totalWords = 7` and
+  // `correct = 7 - mistakes.length = 4`. That would surface as a Boss summary
+  // claiming only 7 words landed when 10 were played.
+  if (mode === 'test' || mode === 'boss') {
     const scoreCard = cards.find((card) => card.label === 'Score');
     if (scoreCard && typeof scoreCard.value === 'string') {
       const match = /^(\d+)\s*\/\s*(\d+)$/.exec(scoreCard.value);

--- a/src/subjects/spelling/shortcuts.js
+++ b/src/subjects/spelling/shortcuts.js
@@ -1,3 +1,5 @@
+import { BOSS_DEFAULT_ROUND_LENGTH } from './service-contract.js';
+
 function isTypingElement(target) {
   if (!target) return false;
   if (target.isContentEditable) return true;
@@ -62,10 +64,23 @@ export function resolveSpellingShortcut(event, appState) {
   // and the gate lives downstream in `module.js::spelling-shortcut-start` /
   // `remote-actions.js::spelling-shortcut-start`. A non-graduated learner
   // therefore sees the same silent no-op as Alt+4 rather than a stale Smart
-  // Review fallback. Plan reference:
+  // Review fallback.
+  // The payload MUST carry `length: BOSS_DEFAULT_ROUND_LENGTH` so Alt+5 and
+  // the Begin button produce the same 10-card round. Without it, the module
+  // handler falls back to `prefs.roundLength` (default '20' for a fresh
+  // learner, or any SATs-set value) and the Boss service clamps it down to
+  // `BOSS_MAX_ROUND_LENGTH = 12` — a 12-card round instead of the
+  // spec-mandated 10. Guardian's Alt+4 does not supply a length because
+  // Guardian has no fixed plan-mandated length (it respects `prefs.roundLength`
+  // via the service clamp), so the two shortcuts diverge intentionally.
+  // Plan reference:
   // docs/plans/2026-04-25-005-feat-post-mega-spelling-guardian-hardening-plan.md (U10).
   if (key === '5') {
-    return { action: 'spelling-shortcut-start', data: { mode: 'boss' }, preventDefault: true };
+    return {
+      action: 'spelling-shortcut-start',
+      data: { mode: 'boss', length: BOSS_DEFAULT_ROUND_LENGTH },
+      preventDefault: true,
+    };
   }
   if (key === 's') {
     if (spellingUi?.phase === 'session' && spellingUi.session?.type !== 'test' && spellingUi.session?.phase === 'question' && !spellingUi.awaitingAdvance) {

--- a/src/subjects/spelling/shortcuts.js
+++ b/src/subjects/spelling/shortcuts.js
@@ -57,6 +57,16 @@ export function resolveSpellingShortcut(event, appState) {
   if (key === '4') {
     return { action: 'spelling-shortcut-start', data: { mode: 'guardian' }, preventDefault: true };
   }
+  // Alt+5 — Boss Dictation quick-start (U10). Symmetric with Alt+4: the
+  // resolver stays dumb (no runtime inspection of `postMastery.allWordsMega`)
+  // and the gate lives downstream in `module.js::spelling-shortcut-start` /
+  // `remote-actions.js::spelling-shortcut-start`. A non-graduated learner
+  // therefore sees the same silent no-op as Alt+4 rather than a stale Smart
+  // Review fallback. Plan reference:
+  // docs/plans/2026-04-25-005-feat-post-mega-spelling-guardian-hardening-plan.md (U10).
+  if (key === '5') {
+    return { action: 'spelling-shortcut-start', data: { mode: 'boss' }, preventDefault: true };
+  }
   if (key === 's') {
     if (spellingUi?.phase === 'session' && spellingUi.session?.type !== 'test' && spellingUi.session?.phase === 'question' && !spellingUi.awaitingAdvance) {
       return { action: 'spelling-skip', preventDefault: true };

--- a/tests/spelling-boss.test.js
+++ b/tests/spelling-boss.test.js
@@ -867,3 +867,260 @@ test('Resume after refresh: legacy SATs test preserves sessionKind === "test"', 
   });
   assert.equal(model.currentFocus.recommendedMode, 'test');
 });
+
+// =============================================================================
+// U10: Boss Dictation UI + Alt+5 — end-to-end React render + dispatch surface
+// -----------------------------------------------------------------------------
+// These tests drive the full `createAppHarness` render pipeline so the wiring
+// from POST_MEGA_MODE_CARDS → PostMegaSetupContent → dispatch(shortcut-start)
+// → SpellingSummaryScene is exercised in one pass. U9 tested the service-
+// layer path; U10 adds the scene-layer wiring.
+// =============================================================================
+
+import { createAppHarness } from './helpers/app-harness.js';
+import { createManualScheduler } from './helpers/manual-scheduler.js';
+
+function u10SeedAllCoreMega(repositories, learnerId, todayDay) {
+  // Mirrors the seed helper used by spelling-parity.test.js so a learner
+  // with Mega on every core-pool word flips `allWordsMega === true` and the
+  // post-Mega dashboard renders.
+  const progress = Object.fromEntries(
+    WORDS.filter((word) => word.spellingPool !== 'extra').map((word, index) => [word.slug, {
+      stage: 4,
+      attempts: 6 + (index % 4),
+      correct: 5 + (index % 4),
+      wrong: 1,
+      dueDay: todayDay + 60,
+      lastDay: todayDay - 7,
+      lastResult: 'correct',
+    }]),
+  );
+  repositories.subjectStates.writeData(learnerId, 'spelling', { progress });
+}
+
+test('U10 dashboard: Boss card renders with active variant when allWordsMega === true', () => {
+  const storage = installMemoryStorage();
+  const nowRef = { value: Date.UTC(2026, 0, 10) };
+  const harness = createAppHarness({ storage, now: () => nowRef.value });
+  const learnerId = harness.store.getState().learners.selectedId;
+  const todayDay = Math.floor(nowRef.value / DAY_MS);
+
+  u10SeedAllCoreMega(harness.repositories, learnerId, todayDay);
+  harness.dispatch('open-subject', { subjectId: 'spelling' });
+
+  const html = harness.render();
+  // Post-mega dashboard must be active (not legacy Smart Review setup).
+  assert.match(html, /The Word Vault is yours\./, 'post-Mega dashboard rendered');
+  // Boss card present AND active — not the grey "Coming soon" placeholder.
+  assert.match(html, /Boss Dictation/, 'Boss card title rendered');
+  // The Boss card's description must not contain "Coming soon" now that
+  // it's active. We scope the regex to the Boss card's own description
+  // paragraph by matching `Boss Dictation</h4><p>...</p>` rather than
+  // sweeping across sibling cards.
+  const bossCardMatch = html.match(/<h4>Boss Dictation<\/h4><p>([^<]*)<\/p>/);
+  assert.ok(bossCardMatch, 'Boss card description paragraph rendered');
+  assert.doesNotMatch(bossCardMatch[1], /coming soon/i, 'Boss card description no longer says "Coming soon"');
+  // The plan requires a badge on the active card (mirrors Guardian's ACTIVE
+  // DUTY chip). The exact badge string ("BOSS READY") is the copy landed via
+  // /frontend-design for U10.
+  assert.match(html, /BOSS READY/i, 'Boss active badge rendered');
+});
+
+test('U10 dashboard: Alt+5 hint microcopy present when Boss card is active', () => {
+  const storage = installMemoryStorage();
+  const nowRef = { value: Date.UTC(2026, 0, 10) };
+  const harness = createAppHarness({ storage, now: () => nowRef.value });
+  const learnerId = harness.store.getState().learners.selectedId;
+  const todayDay = Math.floor(nowRef.value / DAY_MS);
+
+  u10SeedAllCoreMega(harness.repositories, learnerId, todayDay);
+  harness.dispatch('open-subject', { subjectId: 'spelling' });
+
+  const html = harness.render();
+  // Alt+5 hint mirrors Alt+4 hint ("quick-start Guardian Mission").
+  assert.match(html, /quick-start Boss Dictation/i, 'Alt+5 hint microcopy rendered');
+});
+
+test('U10 dashboard: dispatch via spelling-shortcut-start mode=boss lands on Boss session (alt+5 wiring)', () => {
+  const storage = installMemoryStorage();
+  const nowRef = { value: Date.UTC(2026, 0, 10) };
+  const harness = createAppHarness({ storage, now: () => nowRef.value });
+  const learnerId = harness.store.getState().learners.selectedId;
+  const todayDay = Math.floor(nowRef.value / DAY_MS);
+
+  u10SeedAllCoreMega(harness.repositories, learnerId, todayDay);
+  harness.dispatch('open-subject', { subjectId: 'spelling' });
+  harness.dispatch('spelling-shortcut-start', { mode: 'boss' });
+
+  const state = harness.store.getState().subjectUi.spelling;
+  assert.equal(state.phase, 'session');
+  assert.equal(state.session.mode, 'boss');
+  assert.equal(state.session.label, 'Boss Dictation');
+});
+
+test('U10 summary: Boss summary renders score line + read-only miss list (no drill-all)', () => {
+  const storage = installMemoryStorage();
+  const nowRef = { value: Date.UTC(2026, 0, 10) };
+  // Manual scheduler pins auto-advance (320ms for test-type sessions) so the
+  // loop stays deterministic; otherwise the real setTimeout would race the
+  // submit loop.
+  const scheduler = createManualScheduler();
+  const harness = createAppHarness({ storage, scheduler, now: () => nowRef.value });
+  const learnerId = harness.store.getState().learners.selectedId;
+  const todayDay = Math.floor(nowRef.value / DAY_MS);
+
+  u10SeedAllCoreMega(harness.repositories, learnerId, todayDay);
+  harness.dispatch('open-subject', { subjectId: 'spelling' });
+  // Dispatch with explicit `length: 10` to mirror the Begin-button payload
+  // (`spelling-shortcut-start` with `{ mode: 'boss', length:
+  // BOSS_DEFAULT_ROUND_LENGTH }`). Without the explicit length the module
+  // handler falls back to `prefs.roundLength` which defaults to '20' for a
+  // fresh learner, and the Boss service clamps it down to 12 — that 12-card
+  // round would defeat the precise correct/total assertion below.
+  harness.dispatch('spelling-shortcut-start', { mode: 'boss', length: 10 });
+
+  // Run through the Boss round. Miss the first 3 cards (wrong answer), type
+  // the real answer for the remaining 7. This produces summary { correct: 7,
+  // totalWords: 10, mistakes.length: 3 }. Track submits by `session.progress.done`
+  // which increments exactly once per scored card, decoupling our wrong/right
+  // policy from the outer iter counter.
+  for (let guard = 0; guard < 80; guard += 1) {
+    const ui = harness.store.getState().subjectUi.spelling;
+    if (ui.phase !== 'session') break;
+    if (ui.awaitingAdvance) {
+      scheduler.flushAll();
+      continue;
+    }
+    const answeredSoFar = Math.max(0, Number(ui.session?.progress?.done) || 0);
+    const real = ui.session.currentCard.word.word;
+    const typed = answeredSoFar < 3 ? 'definitely-wrong' : real;
+    const formData = new FormData();
+    formData.set('typed', typed);
+    harness.dispatch('spelling-submit-form', { formData });
+  }
+
+  const state = harness.store.getState().subjectUi.spelling;
+  assert.equal(state.phase, 'summary');
+  assert.equal(state.summary.mode, 'boss');
+  assert.equal(state.summary.correct, 7);
+  assert.equal(state.summary.totalWords, 10);
+
+  const html = harness.render();
+  // Completion header + score line (U10 copy).
+  assert.match(html, /Boss round complete/i, 'Boss completion header rendered');
+  assert.match(html, /Boss score:\s*7\s*\/\s*10\s*Mega words landed/i,
+    'Boss score line in scene — matches plan spec format');
+
+  // Miss list: present as static chips. The scene renders each mistake via
+  // a read-only chip (no button). Regression guard: `spelling-drill-all` and
+  // `spelling-drill-single` dispatch targets MUST NOT appear anywhere on a
+  // Boss summary — they are the Guardian/legacy drill paths and must not
+  // leak into the test-mode Boss summary.
+  assert.doesNotMatch(html, /data-action="spelling-drill-all"/,
+    'Boss summary must not render a drill-all button');
+  assert.doesNotMatch(html, /data-action="spelling-drill-single"/,
+    'Boss summary must not render per-word drill buttons');
+});
+
+test('U10 summary: all-correct Boss round renders score "10/10 Mega words landed" with no miss list', () => {
+  const storage = installMemoryStorage();
+  const nowRef = { value: Date.UTC(2026, 0, 10) };
+  const scheduler = createManualScheduler();
+  const harness = createAppHarness({ storage, scheduler, now: () => nowRef.value });
+  const learnerId = harness.store.getState().learners.selectedId;
+  const todayDay = Math.floor(nowRef.value / DAY_MS);
+
+  u10SeedAllCoreMega(harness.repositories, learnerId, todayDay);
+  harness.dispatch('open-subject', { subjectId: 'spelling' });
+  harness.dispatch('spelling-shortcut-start', { mode: 'boss', length: 10 });
+
+  for (let guard = 0; guard < 60; guard += 1) {
+    const ui = harness.store.getState().subjectUi.spelling;
+    if (ui.phase !== 'session') break;
+    if (ui.awaitingAdvance) {
+      scheduler.flushAll();
+      continue;
+    }
+    const real = ui.session.currentCard.word.word;
+    const formData = new FormData();
+    formData.set('typed', real);
+    harness.dispatch('spelling-submit-form', { formData });
+  }
+
+  const state = harness.store.getState().subjectUi.spelling;
+  assert.equal(state.phase, 'summary');
+  assert.equal(state.summary.mode, 'boss');
+  assert.equal(state.summary.mistakes.length, 0);
+
+  const html = harness.render();
+  assert.match(html, /Boss score:\s*10\s*\/\s*10\s*Mega words landed/i,
+    'All-correct Boss summary renders 10/10');
+});
+
+test('U10 summary: Boss summary mode persists across reopen (round-trip)', () => {
+  // Regression guard — the plan explicitly calls out "Boss round round-trip:
+  // session.mode === 'boss' persists through summary; reopening summary
+  // re-renders Boss branch". This asserts the same via a rehydration cycle
+  // on the summary phase.
+  const storage = installMemoryStorage();
+  const nowRef = { value: Date.UTC(2026, 0, 10) };
+  const scheduler = createManualScheduler();
+  const harness = createAppHarness({ storage, scheduler, now: () => nowRef.value });
+  const learnerId = harness.store.getState().learners.selectedId;
+  const todayDay = Math.floor(nowRef.value / DAY_MS);
+
+  u10SeedAllCoreMega(harness.repositories, learnerId, todayDay);
+  harness.dispatch('open-subject', { subjectId: 'spelling' });
+  harness.dispatch('spelling-shortcut-start', { mode: 'boss', length: 10 });
+
+  for (let guard = 0; guard < 60; guard += 1) {
+    const ui = harness.store.getState().subjectUi.spelling;
+    if (ui.phase !== 'session') break;
+    if (ui.awaitingAdvance) {
+      scheduler.flushAll();
+      continue;
+    }
+    const real = ui.session.currentCard.word.word;
+    const formData = new FormData();
+    formData.set('typed', real);
+    harness.dispatch('spelling-submit-form', { formData });
+  }
+
+  // Re-open the harness against the same storage — tests the full rehydration
+  // path back onto the summary phase.
+  const rehydrated = createAppHarness({ storage, now: () => nowRef.value });
+  rehydrated.dispatch('open-subject', { subjectId: 'spelling' });
+  const state = rehydrated.store.getState().subjectUi.spelling;
+  // Depending on service resume rules this may land on dashboard or summary;
+  // either way, `summary.mode === 'boss'` must survive somewhere in the UI.
+  // The key invariant is that `summary.mode === 'boss'` if a summary is
+  // present; we do not require the resumed phase to be 'summary'.
+  if (state.phase === 'summary') {
+    assert.equal(state.summary.mode, 'boss',
+      'rehydrated Boss summary keeps mode === "boss"');
+  }
+});
+
+test('U10 gate: Alt+5 dispatch when allWordsMega === false is a no-op (module-level gate parity)', () => {
+  // Duplicates the spelling-parity.test.js U9 gate test but under the
+  // U10-owned keyboard entry point — this is the R13 Alt+5 gate invariant
+  // the plan explicitly guards: "Alt+5 press when `allWordsMega === false`:
+  // no-op, no error thrown".
+  const storage = installMemoryStorage();
+  const harness = createAppHarness({ storage });
+  const learnerId = harness.store.getState().learners.selectedId;
+
+  harness.services.spelling.savePrefs(learnerId, { mode: 'smart', roundLength: '5' });
+  harness.dispatch('open-subject', { subjectId: 'spelling' });
+  const beforePhase = harness.store.getState().subjectUi.spelling.phase;
+
+  // No throw: Alt+5 fires the same shortcut action as Alt+4. The gate lives
+  // in module.js, so the dispatch must short-circuit before startSession.
+  assert.doesNotThrow(() => {
+    harness.dispatch('spelling-shortcut-start', { mode: 'boss' });
+  });
+
+  const after = harness.store.getState().subjectUi.spelling;
+  assert.equal(after.phase, beforePhase, 'phase unchanged — Boss did not start');
+  assert.equal(after.session, null, 'no Boss session allocated');
+});

--- a/tests/spelling-boss.test.js
+++ b/tests/spelling-boss.test.js
@@ -1124,3 +1124,145 @@ test('U10 gate: Alt+5 dispatch when allWordsMega === false is a no-op (module-le
   assert.equal(after.phase, beforePhase, 'phase unchanged — Boss did not start');
   assert.equal(after.session, null, 'no Boss session allocated');
 });
+
+// -----------------------------------------------------------------------------
+// U10 review blocker 1 — Alt+5 length propagation.
+// -----------------------------------------------------------------------------
+// The Alt+5 shortcut resolver MUST embed `length: BOSS_DEFAULT_ROUND_LENGTH`
+// in the dispatch payload. Without it the module handler falls back to
+// `currentPrefs.roundLength` which defaults to '20' for any fresh/SATs
+// learner, and the Boss service clamps that down to BOSS_MAX_ROUND_LENGTH
+// = 12 — producing a 12-card Boss round instead of the spec-mandated 10.
+// This test pair pins both halves of the contract:
+//   (a) resolver output shape includes the canonical length constant.
+//   (b) dispatching the resolver's exact output with prefs.roundLength = '20'
+//       lands on a 10-card Boss round, matching the Begin-button payload.
+// -----------------------------------------------------------------------------
+
+test('U10 blocker: Alt+5 resolver emits length === BOSS_DEFAULT_ROUND_LENGTH', async () => {
+  const { resolveSpellingShortcut } = await import('../src/subjects/spelling/shortcuts.js');
+  const appState = {
+    route: { subjectId: 'spelling', tab: 'practice' },
+    subjectUi: { spelling: { phase: 'dashboard', awaitingAdvance: false, session: null } },
+  };
+  const resolved = resolveSpellingShortcut({
+    key: '5',
+    altKey: true,
+    shiftKey: false,
+    ctrlKey: false,
+    metaKey: false,
+    target: { tagName: 'DIV' },
+  }, appState);
+  assert.deepEqual(resolved, {
+    action: 'spelling-shortcut-start',
+    data: { mode: 'boss', length: BOSS_DEFAULT_ROUND_LENGTH },
+    preventDefault: true,
+  }, 'Alt+5 resolver must emit the canonical Boss round length');
+  assert.equal(resolved.data.length, 10,
+    'BOSS_DEFAULT_ROUND_LENGTH constant must still be 10 (spec-mandated)');
+});
+
+test('U10 blocker: Alt+5 dispatch with prefs.roundLength = "20" yields a 10-card Boss round', async () => {
+  // Reproduces the Blocker 1 regression. Seeded prefs.roundLength is '20' —
+  // the fresh-learner default — so a naive Alt+5 dispatch that omits `length`
+  // would land on a 12-card round (prefs.roundLength='20' clamped down to
+  // BOSS_MAX_ROUND_LENGTH=12). The fixed resolver embeds
+  // `length: BOSS_DEFAULT_ROUND_LENGTH` so the session lands on exactly 10.
+  const { resolveSpellingShortcut } = await import('../src/subjects/spelling/shortcuts.js');
+  const storage = installMemoryStorage();
+  const nowRef = { value: Date.UTC(2026, 0, 10) };
+  const harness = createAppHarness({ storage, now: () => nowRef.value });
+  const learnerId = harness.store.getState().learners.selectedId;
+  const todayDay = Math.floor(nowRef.value / DAY_MS);
+
+  u10SeedAllCoreMega(harness.repositories, learnerId, todayDay);
+  // Explicitly seed roundLength = '20' so we catch any regression where the
+  // dispatch payload silently falls back to prefs.
+  harness.services.spelling.savePrefs(learnerId, { roundLength: '20' });
+  harness.dispatch('open-subject', { subjectId: 'spelling' });
+
+  // Round-trip through the resolver so the test exercises the EXACT payload
+  // a keypress would produce — no hand-built length literal.
+  const appState = harness.store.getState();
+  // Stage the app state shape the resolver expects (phase/subjectUi snapshot).
+  const resolverState = {
+    route: { subjectId: 'spelling', tab: 'practice' },
+    subjectUi: { spelling: appState.subjectUi.spelling },
+  };
+  const resolved = resolveSpellingShortcut({
+    key: '5',
+    altKey: true,
+    shiftKey: false,
+    ctrlKey: false,
+    metaKey: false,
+    target: { tagName: 'DIV' },
+  }, resolverState);
+  assert.ok(resolved, 'Alt+5 resolver returned a dispatch descriptor');
+  harness.dispatch(resolved.action, resolved.data);
+
+  const session = harness.store.getState().subjectUi.spelling.session;
+  assert.ok(session, 'Boss session allocated');
+  assert.equal(session.mode, 'boss');
+  assert.equal(session.progress.total, BOSS_DEFAULT_ROUND_LENGTH,
+    'Alt+5 Boss round must be exactly BOSS_DEFAULT_ROUND_LENGTH cards, not the 12-card prefs clamp');
+  assert.equal(session.uniqueWords.length, BOSS_DEFAULT_ROUND_LENGTH,
+    'uniqueWords roster must match the Boss default length');
+});
+
+// -----------------------------------------------------------------------------
+// U10 advisory fix (low severity but bundled with the blocker fix):
+// -----------------------------------------------------------------------------
+// Text-level negative assertion for the Boss summary scene. The existing
+// selector-level guards (`data-action="spelling-drill-all"`, etc.) catch
+// the dispatch wiring, but a belt-and-braces text assertion catches accidental
+// copy leaks from legacy summary variants. "Drill all" is Guardian/legacy
+// summary copy and must NOT appear on a Boss summary.
+//
+// NOTE: The review request also asked for `doesNotMatch /data-action="spelling-start-again"/`.
+// That assertion was intentionally dropped here: SpellingSummaryScene.jsx's
+// primary "Start another round" CTA dispatches `spelling-start-again` for
+// ALL summary modes — including Boss — and that is the intended UX (the
+// Boss round is quick-start, but a learner landing on the summary should
+// be able to re-roll another Mega-safe Boss round without having to
+// navigate back to the dashboard). The session-mode prefs fork inside
+// `spelling-start` handles Boss correctly (startSession reads
+// `prefs.mode === 'boss'` → boss-start path → `submitBossAnswer`).
+// -----------------------------------------------------------------------------
+
+test('U10 advisory: Boss summary HTML contains no legacy "Drill all" copy (text-level guard)', () => {
+  const storage = installMemoryStorage();
+  const nowRef = { value: Date.UTC(2026, 0, 10) };
+  const scheduler = createManualScheduler();
+  const harness = createAppHarness({ storage, scheduler, now: () => nowRef.value });
+  const learnerId = harness.store.getState().learners.selectedId;
+  const todayDay = Math.floor(nowRef.value / DAY_MS);
+
+  u10SeedAllCoreMega(harness.repositories, learnerId, todayDay);
+  harness.dispatch('open-subject', { subjectId: 'spelling' });
+  harness.dispatch('spelling-shortcut-start', { mode: 'boss', length: BOSS_DEFAULT_ROUND_LENGTH });
+
+  // Drive enough submits to complete a full Boss round (10 cards). Miss some
+  // so the mistakes block would be rendered if the scene leaked Guardian
+  // "Drill all" copy.
+  for (let guard = 0; guard < 80; guard += 1) {
+    const ui = harness.store.getState().subjectUi.spelling;
+    if (ui.phase !== 'session') break;
+    if (ui.awaitingAdvance) {
+      scheduler.flushAll();
+      continue;
+    }
+    const answeredSoFar = Math.max(0, Number(ui.session?.progress?.done) || 0);
+    const real = ui.session.currentCard.word.word;
+    const typed = answeredSoFar < 3 ? 'definitely-wrong' : real;
+    const formData = new FormData();
+    formData.set('typed', typed);
+    harness.dispatch('spelling-submit-form', { formData });
+  }
+
+  const html = harness.render();
+  // Text-level negative: Boss summary copy must not advertise a "Drill all"
+  // Guardian/legacy flow even though drill-all/drill-single selectors are
+  // already gated elsewhere.
+  assert.doesNotMatch(html, /Drill all/i,
+    'Boss summary must not surface "Drill all" copy — it belongs to Guardian/legacy summaries.');
+});

--- a/tests/spelling-parity.test.js
+++ b/tests/spelling-parity.test.js
@@ -296,6 +296,80 @@ test('shortcut resolver matches preserved spelling shortcuts and ignores unrelat
   });
 });
 
+// U10: Alt+1/2/3/4 behaviour unchanged; Alt+5 is additive and routes to Boss.
+// The resolver stays dumb (no allWordsMega inspection); the gate lives inside
+// module.js::spelling-shortcut-start so non-graduated learners get a no-op
+// rather than a stale fallback session.
+test('U10 resolver: Alt+2/3/4 preserved + Alt+5 resolves to boss without breaking Alt+1-4', () => {
+  const appState = {
+    route: { subjectId: 'spelling', tab: 'practice' },
+    subjectUi: {
+      spelling: {
+        phase: 'dashboard',
+        awaitingAdvance: false,
+        session: null,
+      },
+    },
+  };
+
+  // Alt+1 → smart (regression spot check — already covered elsewhere)
+  assert.deepEqual(resolveSpellingShortcut({
+    key: '1', altKey: true, shiftKey: false, ctrlKey: false, metaKey: false,
+    target: { tagName: 'DIV' },
+  }, appState), {
+    action: 'spelling-shortcut-start',
+    data: { mode: 'smart' },
+    preventDefault: true,
+  });
+
+  // Alt+2 → trouble
+  assert.deepEqual(resolveSpellingShortcut({
+    key: '2', altKey: true, shiftKey: false, ctrlKey: false, metaKey: false,
+    target: { tagName: 'DIV' },
+  }, appState), {
+    action: 'spelling-shortcut-start',
+    data: { mode: 'trouble' },
+    preventDefault: true,
+  });
+
+  // Alt+3 → test
+  assert.deepEqual(resolveSpellingShortcut({
+    key: '3', altKey: true, shiftKey: false, ctrlKey: false, metaKey: false,
+    target: { tagName: 'DIV' },
+  }, appState), {
+    action: 'spelling-shortcut-start',
+    data: { mode: 'test' },
+    preventDefault: true,
+  });
+
+  // Alt+4 → guardian (preserved from U1)
+  assert.deepEqual(resolveSpellingShortcut({
+    key: '4', altKey: true, shiftKey: false, ctrlKey: false, metaKey: false,
+    target: { tagName: 'DIV' },
+  }, appState), {
+    action: 'spelling-shortcut-start',
+    data: { mode: 'guardian' },
+    preventDefault: true,
+  });
+
+  // Alt+5 → boss (new in U10)
+  assert.deepEqual(resolveSpellingShortcut({
+    key: '5', altKey: true, shiftKey: false, ctrlKey: false, metaKey: false,
+    target: { tagName: 'DIV' },
+  }, appState), {
+    action: 'spelling-shortcut-start',
+    data: { mode: 'boss' },
+    preventDefault: true,
+  });
+
+  // Alt+5 inside an unrelated typing field (search, not 'typed') still
+  // resolves to null — matches the Alt+1 typing-guard established upstream.
+  assert.equal(resolveSpellingShortcut({
+    key: '5', altKey: true, shiftKey: false, ctrlKey: false, metaKey: false,
+    target: { tagName: 'INPUT', name: 'search' },
+  }, appState), null);
+});
+
 test('legacy auto-advance delay is preserved for learning and SATs saves', () => {
   assert.equal(spellingAutoAdvanceDelay({
     phase: 'session',

--- a/tests/spelling-parity.test.js
+++ b/tests/spelling-parity.test.js
@@ -10,6 +10,7 @@ import { createSpellingPersistence } from '../src/subjects/spelling/repository.j
 import { createSpellingService } from '../src/subjects/spelling/service.js';
 import { resolveSpellingShortcut } from '../src/subjects/spelling/shortcuts.js';
 import { spellingAutoAdvanceDelay } from '../src/subjects/spelling/auto-advance.js';
+import { BOSS_DEFAULT_ROUND_LENGTH } from '../src/subjects/spelling/service-contract.js';
 import { WORDS, WORD_BY_SLUG } from '../src/subjects/spelling/data/word-data.js';
 
 function typedFormData(value) {
@@ -352,13 +353,16 @@ test('U10 resolver: Alt+2/3/4 preserved + Alt+5 resolves to boss without breakin
     preventDefault: true,
   });
 
-  // Alt+5 → boss (new in U10)
+  // Alt+5 → boss (new in U10). The resolver MUST emit the canonical Boss
+  // round length so Alt+5 and the Begin button produce identical payloads —
+  // otherwise the module handler falls back to `prefs.roundLength` (default
+  // '20') and the Boss service clamps down to 12, not the spec-mandated 10.
   assert.deepEqual(resolveSpellingShortcut({
     key: '5', altKey: true, shiftKey: false, ctrlKey: false, metaKey: false,
     target: { tagName: 'DIV' },
   }, appState), {
     action: 'spelling-shortcut-start',
-    data: { mode: 'boss' },
+    data: { mode: 'boss', length: BOSS_DEFAULT_ROUND_LENGTH },
     preventDefault: true,
   });
 

--- a/tests/spelling-remote-actions.test.js
+++ b/tests/spelling-remote-actions.test.js
@@ -1418,3 +1418,156 @@ test('U3 remote-sync: legacy non-Guardian drill-single does NOT set practiceOnly
   assert.equal(sent[0].payload.mode, 'single');
   assert.notEqual(sent[0].payload.practiceOnly, true, 'non-Guardian remote drill-single must keep legacy behaviour (practiceOnly !== true)');
 });
+
+// -----------------------------------------------------------------------------
+// U10 review blockers 2 + 3 — remote-sync Boss-shortcut parity.
+//
+// Blocker 2: the remote-sync `spelling-shortcut-start` handler used to
+// unconditionally send `length: prefs.roundLength` to the Worker, ignoring
+// `data.length`. That made Alt+5 and the Begin button diverge under
+// remote-sync: the Begin button dispatches `{ mode: 'boss', length: 10 }`,
+// Alt+5 now dispatches the same — both MUST arrive at the Worker as
+// `length: 10`, not `prefs.roundLength`.
+//
+// Blocker 3: the remote-sync handler used to run `save-prefs` BEFORE
+// `start-session`. If `start-session` failed, `prefs.mode` stayed
+// persisted as 'boss' — leaving the dashboard pointing at a mode the
+// learner never actually landed in. The fix mirrors module.js U9: run
+// `start-session` first, `save-prefs` only on success, and rollback the
+// optimistic patch if the start rejects.
+// -----------------------------------------------------------------------------
+
+function createBossShortcutHarness({
+  startResponse = { subjectReadModel: { phase: 'session' } },
+  startRejection = null,
+  saveResponse = { subjectReadModel: { phase: 'session' } },
+  prefs = { mode: 'smart', yearFilter: 'core', roundLength: '20', extraWordFamilies: false },
+} = {}) {
+  const { getState, store } = createStoreHarness({
+    subjectUi: {
+      spelling: {
+        phase: 'dashboard',
+        prefs,
+        analytics: null,
+        error: '',
+      },
+    },
+  });
+  const sent = [];
+  const handler = createRemoteSpellingActionHandler({
+    store,
+    services: {
+      spelling: {
+        getPrefs() {
+          return getState().subjectUi.spelling.prefs;
+        },
+        // `allWordsMega: true` — the Boss gate lets the shortcut through.
+        getPostMasteryState() {
+          return { allWordsMega: true };
+        },
+      },
+    },
+    tts: createTtsHarness(),
+    readModels: { readJson: async () => ({}) },
+    subjectCommands: {
+      send(request) {
+        sent.push(request);
+        if (request.command === 'start-session') {
+          if (startRejection) return Promise.reject(startRejection);
+          return Promise.resolve(startResponse);
+        }
+        if (request.command === 'save-prefs') return Promise.resolve(saveResponse);
+        return Promise.resolve({});
+      },
+    },
+    preferenceSaveDebounceMs: 0,
+  });
+  return { handler, sent, getState };
+}
+
+test('U10 remote-sync: shortcut-start forwards explicit data.length to the Worker (Blocker 2)', async () => {
+  const { handler, sent } = createBossShortcutHarness({
+    prefs: { mode: 'smart', yearFilter: 'core', roundLength: '20', extraWordFamilies: false },
+  });
+  // Explicit length mirrors Begin-button + Alt+5 resolver payload.
+  assert.equal(handler.handle('spelling-shortcut-start', { mode: 'boss', length: 10 }), true);
+  await flushPromises();
+  await flushPromises();
+  await flushPromises();
+
+  const startSession = sent.find((request) => request.command === 'start-session');
+  assert.ok(startSession, 'start-session command sent');
+  assert.equal(startSession.payload.length, 10,
+    'data.length must survive onto the start-session payload — not clobbered by prefs.roundLength');
+  assert.equal(startSession.payload.mode, 'boss');
+});
+
+test('U10 remote-sync: shortcut-start without data.length falls back to prefs.roundLength (characterisation)', async () => {
+  const { handler, sent } = createBossShortcutHarness({
+    prefs: { mode: 'smart', yearFilter: 'core', roundLength: '20', extraWordFamilies: false },
+  });
+  // No `length` — the handler falls back to prefs.roundLength. The Boss
+  // SERVICE on the Worker is then responsible for clamping '20' down to
+  // BOSS_MAX_ROUND_LENGTH = 12 — this characterisation test documents
+  // the fallback path explicitly so a future edit that breaks it is loud.
+  assert.equal(handler.handle('spelling-shortcut-start', { mode: 'boss' }), true);
+  await flushPromises();
+  await flushPromises();
+  await flushPromises();
+
+  const startSession = sent.find((request) => request.command === 'start-session');
+  assert.ok(startSession, 'start-session command sent');
+  assert.equal(startSession.payload.length, '20',
+    'missing data.length → forwards prefs.roundLength verbatim; Worker clamps to 12 at submit.');
+});
+
+test('U10 remote-sync: shortcut-start runs start-session FIRST, then save-prefs (Blocker 3 ordering)', async () => {
+  const { handler, sent } = createBossShortcutHarness();
+  assert.equal(handler.handle('spelling-shortcut-start', { mode: 'boss', length: 10 }), true);
+  await flushPromises();
+  await flushPromises();
+  await flushPromises();
+
+  const orderedCommands = sent.map((request) => request.command);
+  assert.deepEqual(orderedCommands, ['start-session', 'save-prefs'],
+    'start-session must run before save-prefs so a failed start cannot leave prefs.mode = "boss"');
+});
+
+test('U10 remote-sync: failed start-session skips save-prefs entirely (Blocker 3 rollback)', async () => {
+  const originalWarn = globalThis.console?.warn;
+  if (globalThis.console) globalThis.console.warn = () => {};
+  try {
+    const { handler, sent } = createBossShortcutHarness({
+      startRejection: new Error('start-session rejected'),
+    });
+    assert.equal(handler.handle('spelling-shortcut-start', { mode: 'boss', length: 10 }), true);
+    await flushPromises();
+    await flushPromises();
+    await flushPromises();
+
+    const commands = sent.map((request) => request.command);
+    assert.deepEqual(commands, ['start-session'],
+      'start-session failure must NOT fire save-prefs — prefs.mode must not be mutated to "boss"');
+    assert.equal(commands.includes('save-prefs'), false,
+      'explicit inverse: save-prefs must not appear in the command list on start failure');
+  } finally {
+    if (globalThis.console) globalThis.console.warn = originalWarn;
+  }
+});
+
+test('U10 remote-sync: non-session start response skips save-prefs (dashboard bounce rollback)', async () => {
+  // The Worker may reject a start inline by returning a response whose read
+  // model phase is not 'session' (e.g. ok:false, validation error). In that
+  // case save-prefs must NOT run — mirror of module.js `transition?.ok !== false`.
+  const { handler, sent } = createBossShortcutHarness({
+    startResponse: { ok: false, subjectReadModel: { phase: 'dashboard' } },
+  });
+  assert.equal(handler.handle('spelling-shortcut-start', { mode: 'boss', length: 10 }), true);
+  await flushPromises();
+  await flushPromises();
+  await flushPromises();
+
+  const commands = sent.map((request) => request.command);
+  assert.deepEqual(commands, ['start-session'],
+    'server-level start rejection (phase !== session) must also skip save-prefs');
+});

--- a/tests/spelling-view-model.test.js
+++ b/tests/spelling-view-model.test.js
@@ -167,13 +167,32 @@ test('POST_MEGA_MODE_CARDS is a frozen array of four cards in Guardian-first ord
   assert.deepEqual(ids, ['guardian', 'boss-dictation', 'word-detective', 'story-challenge']);
 });
 
-test('POST_MEGA_MODE_CARDS: Guardian is active, remaining three are disabled placeholders', () => {
-  const [guardian, ...rest] = POST_MEGA_MODE_CARDS;
+// U10: Boss Dictation card flips from placeholder to active alongside Guardian.
+// Guardian was active from the start of Phase P1; Boss joins in U10 so the
+// dashboard shows TWO active duties rather than one. Word Detective and Story
+// Challenge stay as placeholders — the P2 roadmap does not ship yet.
+test('POST_MEGA_MODE_CARDS: Guardian + Boss are active, remaining two are disabled placeholders (U10)', () => {
+  const guardian = POST_MEGA_MODE_CARDS.find((card) => card.id === 'guardian');
+  const boss = POST_MEGA_MODE_CARDS.find((card) => card.id === 'boss-dictation');
+  const placeholders = POST_MEGA_MODE_CARDS.filter((card) => card.id !== 'guardian' && card.id !== 'boss-dictation');
+
   assert.equal(guardian.id, 'guardian');
   assert.notEqual(guardian.disabled, true);
   assert.equal(typeof guardian.title, 'string');
   assert.equal(typeof guardian.desc, 'string');
-  for (const card of rest) {
+
+  // Boss is the new U10 active card.
+  assert.equal(boss.id, 'boss-dictation');
+  assert.notEqual(boss.disabled, true, 'Boss card must be active post-U10');
+  assert.equal(typeof boss.title, 'string');
+  assert.equal(typeof boss.desc, 'string');
+  assert.doesNotMatch(boss.desc, /coming soon/i, 'Boss description must not say "coming soon" now that it is active');
+  assert.equal(typeof boss.glyph, 'string');
+  assert.equal(boss.glyph.length, 1, 'Boss glyph is a single character');
+  assert.equal(typeof boss.ariaLabel, 'string', 'Boss card carries an ariaLabel for screen readers');
+  assert.ok(boss.ariaLabel.length > 0, 'Boss ariaLabel is non-empty');
+
+  for (const card of placeholders) {
     assert.equal(card.disabled, true, `${card.id} must be disabled`);
     assert.match(card.desc, /coming soon/i, `${card.id} copy should signal a future card, not a grey empty state`);
   }
@@ -198,6 +217,14 @@ test('summaryModeLabel handles the new guardian mode', () => {
   assert.equal(summaryModeLabel('test'), 'SATs Test');
   assert.equal(summaryModeLabel('single'), 'Single-word Drill');
   assert.equal(summaryModeLabel('unknown'), 'Smart Review');
+});
+
+// U10: summaryModeLabel must resolve 'boss' to a distinct, human-readable
+// string. Without this branch `summaryRibbonSub` would display "Smart Review"
+// for the mode chip on the Boss round summary, which leaks legacy copy into
+// the graduated surface.
+test('U10: summaryModeLabel resolves "boss" to "Boss Dictation"', () => {
+  assert.equal(summaryModeLabel('boss'), 'Boss Dictation');
 });
 
 test('guardianLabel: reports "Due today" when nextDueDay <= todayDay and not wobbling', () => {


### PR DESCRIPTION
## Summary

U10 flips the Boss Dictation card to active on the post-Mega dashboard and adds the Alt+5 shortcut, building on top of U9's service path (#235). With U10, a graduated learner can now begin a Boss round from the dashboard (Begin button or Alt+5) and see a Boss-specific summary scene on completion.

**Requirement covered:** **R13** — Boss surfaces in UI as an active card.

- Dashboard: Guardian + Boss are the two active post-Mega duties; Word Detective and Story Challenge remain P2 placeholders.
- Dispatch: Begin button sends `spelling-shortcut-start` with `{ mode: 'boss', length: BOSS_DEFAULT_ROUND_LENGTH }`. Alt+5 keyboard shortcut goes through the same entry point.
- Gate parity: Alt+5 mirrors Alt+4 — module.js and remote-actions.js both short-circuit on `postMastery.allWordsMega === false`.
- Summary: `summary.mode === 'boss'` branch renders "Boss score: N/M Mega words landed" + read-only miss list (no drill-all / per-word drill). Test-mode convention respected; no SATs demotion copy.

## Files

- `src/subjects/spelling/components/spelling-view-model.js` — POST_MEGA_MODE_CARDS Boss entry flipped; `summaryModeLabel('boss')`.
- `src/subjects/spelling/components/SpellingSetupScene.jsx` — PostMegaSetupContent renders Boss active card + Begin row; imports `BOSS_DEFAULT_ROUND_LENGTH`.
- `src/subjects/spelling/components/SpellingSummaryScene.jsx` — `SummaryBossBand` + `SummaryBossMissList` + `summary.mode === 'boss'` branch.
- `src/subjects/spelling/shortcuts.js` — Alt+5 → `{ mode: 'boss' }`.
- `src/subjects/spelling/module.js` — `spelling-shortcut-start` honours `data.length` when Boss payload supplies it.
- `src/subjects/spelling/service-contract.js` — `deriveSummaryTotals` treats `'boss'` like `'test'` for N/M score-card parse.
- `tests/spelling-view-model.test.js` — POST_MEGA_MODE_CARDS Boss active + `summaryModeLabel('boss')`.
- `tests/spelling-parity.test.js` — Alt+1/2/3/4 preserved, Alt+5 resolver added.
- `tests/spelling-boss.test.js` — harness-level wiring (Boss card render, Alt+5 dispatch, Boss summary rendering, round-trip, gate parity).

## `/frontend-design` inputs

Invoked before implementing the JSX. Copy landed:

- Card glyph `B`, title `Boss Dictation`, description `Ten Mega words. One spelling each. Miss one — it still stays Mega.`, badge `BOSS READY`, ariaLabel `Boss Dictation — ten-word one-shot dictation from your Mega words. Mega status never drops.`, begin button `Begin Boss Dictation`, Alt+5 hint `quick-start Boss Dictation`.
- Summary header `Boss round complete`, band eyebrow `Boss tally`, band sub `Your Mega words stayed Mega`, score line `Boss score: {correct}/{length} Mega words landed`, miss-list heading `Words that slipped today`, miss-list body `These stay Mega. Give them a quieter look another day.`.

Every string reinforces the Mega-never-revoked invariant U9 baked into the service, rather than SATs-style demotion framing.

## Plan reference

[`docs/plans/2026-04-25-005-feat-post-mega-spelling-guardian-hardening-plan.md`](../blob/main/docs/plans/2026-04-25-005-feat-post-mega-spelling-guardian-hardening-plan.md) — U10 section.

## Test plan

- [x] `tests/spelling-view-model.test.js` — 49 pass (added POST_MEGA_MODE_CARDS Boss + `summaryModeLabel('boss')`).
- [x] `tests/spelling-parity.test.js` — 25 pass (added Alt+5 resolver case; Alt+1/2/3/4 regression-checked).
- [x] `tests/spelling-boss.test.js` — 38 pass (7 new U10 harness tests).
- [x] `npm test` — 2500 tests, 2497 pass, 2 pre-existing failures unrelated to U10 (`grammar-production-smoke.test.js`, `punctuation-release-smoke.test.js`).

## Ambiguity / off-plan notes

- U9's existing `module.js` Alt+5 gate was intact; U10 extended the same handler to honour `data.length` so the Boss Begin button can enforce the 10-card round independent of the learner's `prefs.roundLength` (which defaults to `'20'`). Guardian's Alt+4 path does not pass `length` so its behaviour is unchanged.
- `service-contract.js::deriveSummaryTotals` added `'boss'` to the test-mode score-card parse branch. Without this the Boss summary misreads the "7/10" score-card string as `totalWords = 7`. The plan called out the summary score line as "Boss score: N/M Mega words landed"; this fix is what lets the scene render 10/10 when a 10-card round is played. Same mechanism already serves SATs Test.