### PR TITLE
feat(punctuation): U10 child-copy sweep + cluster parity + Phase 3 styles

### DIFF
--- a/src/subjects/punctuation/components/punctuation-view-model.js
+++ b/src/subjects/punctuation/components/punctuation-view-model.js
@@ -13,9 +13,11 @@
 // them here once and every child surface inherits the guard through U10's
 // fixture-driven sweep.
 //
-// Parity guard: `composeIsDisabled` deliberately lives here and nowhere else.
-// Grammar and Spelling each keep their own copy. Any shared extraction must
-// prove Spelling byte-for-byte parity in the PR (AGENTS.md:14).
+// Parity guard: `composeIsDisabled` deliberately lives here and nowhere else
+// in Punctuation's surface. Grammar and Spelling do NOT carry an equivalent
+// export today — their scenes inline the same pending/availability gate. Any
+// future shared extraction must prove Spelling byte-for-byte parity in the PR
+// (AGENTS.md:14).
 
 import { resolveMonsterVisual } from '../../../platform/game/monster-visual-config.js';
 import { MONSTERS_BY_SUBJECT } from '../../../platform/game/monsters.js';

--- a/styles/app.css
+++ b/styles/app.css
@@ -9763,6 +9763,18 @@ html { scroll-behavior: smooth; }
   gap: 6px;
   flex-wrap: wrap;
 }
+/* KS2 touch-target floor for the round-length 4/8/12 toggle. Mirrors
+   the `.punctuation-skill-modal-close` 44×44 target. */
+.punctuation-length-toggle button {
+  min-height: 44px;
+  min-width: 44px;
+  padding: 10px 14px;
+}
+.punctuation-length-toggle button:focus-visible {
+  outline: none;
+  border-color: #B8873F;
+  box-shadow: 0 0 0 3px color-mix(in oklab, #B8873F 18%, transparent);
+}
 
 /* --- Setup — active monster strip -------------------------------------- */
 .punctuation-monsters-section {
@@ -9906,6 +9918,20 @@ html { scroll-behavior: smooth; }
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
+}
+/* KS2 touch-target floor for the Map filter chips (status + monster
+   rows). The `.chip` base sets `padding: 6px 10px` which is below the
+   44×44 target; raise the button-only child selector to the KS2 floor
+   without disturbing other `.chip` consumers. Mirrors
+   `.punctuation-skill-modal-close`. */
+.punctuation-map-chips button {
+  min-height: 44px;
+  padding: 10px 14px;
+}
+.punctuation-map-chips button:focus-visible {
+  outline: none;
+  border-color: #B8873F;
+  box-shadow: 0 0 0 3px color-mix(in oklab, #B8873F 18%, transparent);
 }
 .punctuation-map-summary {
   margin: 0;

--- a/styles/app.css
+++ b/styles/app.css
@@ -9603,12 +9603,388 @@ html { scroll-behavior: smooth; }
   }
 }
 
-/* ---------- Phase 3 U6 · Punctuation Skill Detail modal (minimal) ----------
-   Review-follower MEDIUM 4: co-ship the smallest-surface CSS needed for the
-   modal to be tappable + identifiable. Full styling sweep lands in U10. The
-   Bellstorm top border is the subject accent; the 44x44 close button meets
-   the KS2 touch-target floor; the reduced-motion guard is defence-in-depth
-   for the scrim/modal animations U10 will author. */
+/* ========================================================================
+   Punctuation — Phase 3
+   ------------------------------------------------------------------------
+   Dedicated class-namespaced styling block for the Phase 3 UX rebuild:
+     - Setup dashboard (hero, today cards, primary/secondary mode cards,
+       round-length toggle, active-monster strip).
+     - Session scene (teach-box, prompt, feedback, secondary actions).
+     - Summary scene (wobbly chips, monster progress strip, GPS review,
+       primary/secondary actions).
+     - Map scene (topbar, filter chip rows, monster group headers, skill
+       card grid, empty states).
+     - Skill Detail modal (scrim, dialog, tabs, Learn / Practise bodies).
+   Mobile-first stacking collapses grid layouts to a single column at
+   max-width 760px. `@media (prefers-reduced-motion: reduce)` disables
+   scene transitions across every Phase 3 surface. Bellstorm Coast
+   accent #B8873F is the subject colour for top borders; the rest of
+   the block inherits --panel / --line / --muted so a future theme
+   pass can re-skin without touching this file.
+   ======================================================================== */
+
+/* --- Setup — today cards + primary / secondary mode cards ------------- */
+.punctuation-today-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+  margin-top: 12px;
+}
+.punctuation-today-card {
+  padding: 12px 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--panel-soft);
+  display: grid;
+  gap: 4px;
+}
+.punctuation-today-label {
+  font-size: 0.82rem;
+  color: var(--muted);
+  font-weight: 700;
+}
+.punctuation-today-value {
+  font-size: 1.6rem;
+  line-height: 1;
+  font-weight: 900;
+}
+.punctuation-today-detail {
+  font-size: 0.82rem;
+  color: var(--muted);
+}
+.punctuation-today-empty {
+  padding: 14px 16px;
+  border: 1px dashed var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--panel-soft);
+  color: var(--muted);
+  margin-top: 12px;
+}
+
+.punctuation-primary-modes {
+  display: grid;
+  gap: 14px;
+}
+.punctuation-primary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+.punctuation-primary-mode-card {
+  appearance: none;
+  display: grid;
+  gap: 6px;
+  min-height: 120px;
+  padding: 16px;
+  text-align: left;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--panel-soft);
+  color: var(--ink);
+  cursor: pointer;
+}
+.punctuation-primary-mode-card:hover:not(:disabled),
+.punctuation-primary-mode-card:focus-visible {
+  border-color: #B8873F;
+  box-shadow: 0 0 0 3px color-mix(in oklab, #B8873F 18%, transparent);
+}
+.punctuation-primary-mode-card[aria-pressed="true"] {
+  border-color: #B8873F;
+  background: color-mix(in oklab, #B8873F 8%, var(--panel));
+}
+.punctuation-primary-mode-card:disabled {
+  cursor: not-allowed;
+  opacity: 0.64;
+}
+.punctuation-primary-mode-eyebrow {
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  color: #8a6628;
+  text-transform: uppercase;
+}
+.punctuation-primary-mode-title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 900;
+}
+.punctuation-primary-mode-desc {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.4;
+}
+
+.punctuation-secondary-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 12px;
+}
+.punctuation-secondary-mode-card {
+  appearance: none;
+  display: grid;
+  gap: 4px;
+  padding: 14px 16px;
+  text-align: left;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--panel-soft);
+  color: var(--ink);
+  cursor: pointer;
+}
+.punctuation-secondary-mode-card:hover:not(:disabled),
+.punctuation-secondary-mode-card:focus-visible {
+  border-color: #B8873F;
+  box-shadow: 0 0 0 3px color-mix(in oklab, #B8873F 18%, transparent);
+}
+.punctuation-secondary-mode-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 900;
+}
+.punctuation-secondary-mode-desc {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.4;
+}
+
+.punctuation-round-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 8px;
+}
+.punctuation-round-label {
+  font-weight: 800;
+  color: var(--muted);
+}
+.punctuation-length-toggle {
+  display: inline-flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+/* --- Setup — active monster strip -------------------------------------- */
+.punctuation-monsters-section {
+  display: grid;
+  gap: 10px;
+}
+.punctuation-monsters-heading {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 900;
+}
+.punctuation-active-monsters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 10px;
+}
+.punctuation-active-monster {
+  display: grid;
+  gap: 4px;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--panel-soft);
+}
+.punctuation-active-monster-name {
+  font-weight: 800;
+}
+.punctuation-active-monster-progress {
+  font-size: 0.82rem;
+}
+
+/* --- Session — teach box, source block, feedback reveals --------------- */
+.punctuation-session-scene {
+  display: grid;
+  gap: 16px;
+}
+.punctuation-session-form {
+  display: grid;
+  gap: 10px;
+  margin-top: 12px;
+}
+.punctuation-session-source {
+  margin: 0 0 10px;
+  padding: 12px 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--panel-soft);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+.punctuation-session-teach-rule {
+  margin: 0;
+  font-weight: 800;
+}
+.punctuation-session-teach-details {
+  margin-top: 8px;
+}
+.punctuation-session-body {
+  display: grid;
+  gap: 10px;
+}
+.punctuation-session-secondary-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.punctuation-session-feedback-model,
+.punctuation-session-feedback-more {
+  margin-top: 10px;
+}
+.punctuation-session-progress {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+/* --- Summary — score chips, wobbly chips, monster progress, actions ---- */
+.punctuation-summary-score {
+  margin-top: 16px;
+}
+.punctuation-summary-wobbly {
+  margin-top: 14px;
+}
+.punctuation-summary-wobbly--empty {
+  color: var(--good-ink, #1c5f4a);
+}
+.punctuation-summary-monsters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 10px;
+  margin-top: 16px;
+}
+.punctuation-summary-monster {
+  display: grid;
+  gap: 4px;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--panel-soft);
+}
+.punctuation-summary-monster-name {
+  font-weight: 800;
+}
+.punctuation-summary-monster-dots {
+  display: inline-flex;
+  gap: 4px;
+}
+.punctuation-summary-monster-stage {
+  color: var(--muted);
+}
+.punctuation-summary-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 16px;
+}
+.punctuation-gps-review {
+  display: grid;
+  gap: 10px;
+}
+
+/* --- Map — topbar, filter chip rows, monster groups, skill cards ------- */
+.punctuation-map-scene {
+  display: grid;
+  gap: 16px;
+}
+.punctuation-map-topbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.punctuation-map-filters {
+  display: grid;
+  gap: 10px;
+}
+.punctuation-map-filter-group {
+  display: grid;
+  gap: 6px;
+}
+.punctuation-map-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.punctuation-map-summary {
+  margin: 0;
+}
+.punctuation-map-body {
+  display: grid;
+  gap: 16px;
+}
+.punctuation-map-monster-group {
+  display: grid;
+  gap: 10px;
+}
+.punctuation-map-monster-group-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+}
+.punctuation-map-monster-group-head h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 900;
+}
+.punctuation-map-skill-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 10px;
+}
+.punctuation-map-skill-card {
+  display: grid;
+  gap: 8px;
+  padding: 12px 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--panel-soft);
+}
+.punctuation-map-skill-card-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+}
+.punctuation-map-skill-card-head h4 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 900;
+  line-height: 1.25;
+}
+.punctuation-map-skill-rule {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.4;
+  font-size: 0.9rem;
+}
+.punctuation-map-skill-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.punctuation-map-skill-status--secure {
+  background: var(--good-soft, #e6f3ec);
+  color: #1c5f4a;
+}
+.punctuation-map-skill-status--weak {
+  background: var(--bad-soft, #fbe8e6);
+  color: #7a2e2a;
+}
+.punctuation-map-skill-status--due {
+  background: var(--warn-soft, #fdf1db);
+  color: #805614;
+}
+.punctuation-map-empty {
+  padding: 14px 16px;
+  border: 1px dashed var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--panel-soft);
+}
+
+/* --- Skill Detail modal — scrim, dialog, tabs, bodies ------------------ */
 .punctuation-skill-modal-scrim {
   position: fixed;
   inset: 0;
@@ -9639,13 +10015,112 @@ html { scroll-behavior: smooth; }
   overflow: auto;
   padding: 28px 32px 22px;
 }
+.punctuation-skill-modal-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+.punctuation-skill-modal-eyebrow {
+  margin: 0 0 4px;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #8a6628;
+}
+.punctuation-skill-modal-title {
+  margin: 0;
+  font-size: 1.4rem;
+  line-height: 1.2;
+  font-weight: 900;
+}
 .punctuation-skill-modal-close {
   min-width: 44px;
   min-height: 44px; /* KS2 touch target floor */
 }
+.punctuation-skill-modal-tabs {
+  display: flex;
+  gap: 8px;
+  margin-top: 16px;
+  border-bottom: 1px solid var(--line);
+}
+.punctuation-skill-modal-body {
+  display: grid;
+  gap: 14px;
+  padding-top: 16px;
+}
+.punctuation-skill-modal-section {
+  display: grid;
+  gap: 6px;
+}
+.punctuation-skill-modal-section-label {
+  margin: 0;
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.punctuation-skill-modal-rule {
+  margin: 0;
+  line-height: 1.5;
+}
+.punctuation-skill-modal-example,
+.punctuation-skill-modal-contrast-bad {
+  margin: 0;
+  padding: 10px 14px;
+  border-left: 3px solid #B8873F;
+  background: var(--panel-soft);
+  border-radius: var(--radius-sm);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+.punctuation-skill-modal-contrast-bad {
+  border-left-color: #c84d42;
+  background: var(--bad-soft, #fbe8e6);
+}
+.punctuation-skill-modal-practise-copy {
+  margin: 0;
+  line-height: 1.5;
+}
+.punctuation-skill-modal-multi-skill-note {
+  margin: 0;
+  font-size: 0.9rem;
+}
+.punctuation-skill-modal-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+/* --- Mobile-first stacking for all Phase 3 Punctuation surfaces -------- */
+@media (max-width: 760px) {
+  .punctuation-primary-grid,
+  .punctuation-today-grid,
+  .punctuation-active-monsters,
+  .punctuation-summary-monsters,
+  .punctuation-map-skill-grid {
+    grid-template-columns: 1fr;
+  }
+  .punctuation-skill-modal {
+    padding: 20px 20px 16px;
+    max-height: calc(100vh - 24px);
+  }
+  .punctuation-skill-modal-head {
+    flex-direction: column-reverse;
+    align-items: stretch;
+  }
+}
+
+/* --- Reduced-motion guard across every Phase 3 animation --------------- */
 @media (prefers-reduced-motion: reduce) {
   .punctuation-skill-modal-scrim,
-  .punctuation-skill-modal {
+  .punctuation-skill-modal,
+  .punctuation-map-scene,
+  .punctuation-session-scene,
+  .punctuation-setup-scene {
     animation: none;
+    transition: none;
   }
 }

--- a/tests/react-punctuation-child-copy.test.js
+++ b/tests/react-punctuation-child-copy.test.js
@@ -117,8 +117,34 @@ test('U10: PUNCTUATION_CLIENT_SKILL_IDS has exactly 14 skills (drift guard)', ()
 // -----------------------------------------------------------------------------
 
 function renderSetupPhase() {
+  // Seed populated stats + reward state so the sweep exercises the
+  // populated Setup branches — the empty-state branch renders a single
+  // "Start your first round…" line which does NOT exercise the
+  // `todayCards` map, the active-monster strip, or the stats readout
+  // strings. Populating here keeps the empty-state fallback covered by
+  // the dedicated branch test in `react-punctuation-setup-scene.test.js`
+  // while expanding this copy sweep to every populated surface too.
+  //
+  // `rewardState` keys are monster ids with a `mastered` array — the
+  // same shape `progressForPunctuationMonster` reads. The monster ids
+  // here are the active roster (plan R10 — reserved monsters never
+  // surface even if their reward entries exist).
   const harness = createPunctuationHarness();
   harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.store.updateSubjectUi('punctuation', {
+    stats: {
+      due: 3,
+      weak: 2,
+      securedRewardUnits: 5,
+      accuracy: 82,
+    },
+    rewardState: {
+      pealark: { mastered: ['sentence-endings-core', 'sentence-endings-exclaim'] },
+      curlune: { mastered: ['comma-clarity-core'] },
+      claspin: { mastered: [] },
+      quoral: { mastered: ['speech-core'] },
+    },
+  });
   return harness;
 }
 

--- a/tests/react-punctuation-child-copy.test.js
+++ b/tests/react-punctuation-child-copy.test.js
@@ -1,0 +1,435 @@
+// Phase 3 U10 — fixture-driven forbidden-term sweep across every
+// Punctuation child phase + the Skill Detail modal.
+//
+// This is the Phase 3 completeness gate's copy invariant: every entry in
+// `PUNCTUATION_CHILD_FORBIDDEN_TERMS` must remain absent in every child-
+// facing scene, plus a whole-word `/\bWorker\b/i` catch-all that captures
+// the bare adult noun even when compound forms (`Worker-marked`,
+// `Worker-held`) are already covered by the frozen fixture.
+//
+// The five child phases swept:
+//   setup          — PunctuationSetupScene (dashboard + mode cards + map
+//                    link + monsters strip).
+//   active-item    — PunctuationSessionScene with every item mode
+//                    (insert / fix / paragraph / combine / transfer /
+//                    choose) × both smart and guided contexts.
+//   feedback       — PunctuationSessionScene's FeedbackBranch for
+//                    success + error kinds, with display correction +
+//                    facets + misconception tags populated.
+//   summary        — PunctuationSummaryScene with a mix of focus skills
+//                    and GPS review items carrying dotted tag ids that
+//                    MUST pipe through `punctuationChildMisconceptionLabel`.
+//   map            — PunctuationMapScene with the full 14-skill roster
+//                    across 4 active monsters + filter chips.
+//
+// The Skill Detail modal (U6) sweeps EVERY one of the 14 client-safe
+// skills × 2 tabs (Learn / Practise) = 28 render states so a rogue
+// skill id or a future authoring regression can never leak an adult-
+// register string in a child-facing surface.
+//
+// SSR blind spots (learning #6):
+//   * pointer-capture, true DOM focus, scroll-into-view, IME
+//     composition, animation frames, requestIdleCallback, MutationObserver,
+//     and timer drift are NOT observable via `renderToStaticMarkup`.
+//     They remain manual-QA gates.
+//   * React onChange events do not fire in SSR; every transition is
+//     driven through store dispatches instead.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createAppHarness } from './helpers/app-harness.js';
+import { installMemoryStorage } from './helpers/memory-storage.js';
+import { SUBJECT_EXPOSURE_GATES } from '../src/platform/core/subject-availability.js';
+import { PUNCTUATION_CHILD_FORBIDDEN_TERMS } from '../src/subjects/punctuation/components/punctuation-view-model.js';
+import { PUNCTUATION_CLIENT_SKILL_IDS } from '../src/subjects/punctuation/service-contract.js';
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+function createPunctuationHarness() {
+  return createAppHarness({
+    storage: installMemoryStorage(),
+    subjectExposureGates: { [SUBJECT_EXPOSURE_GATES.punctuation]: true },
+  });
+}
+
+// Collect every forbidden-term leak in `html`. String terms match
+// case-insensitively as substrings (the authored fixture carries both
+// `'Worker-held'` and `'Worker-marked'` as substring entries); RegExp
+// terms (the whole-word `/\bWorker\b/i` catch-all) apply directly.
+function forbiddenTermsInHtml(html) {
+  const leaks = [];
+  for (const term of PUNCTUATION_CHILD_FORBIDDEN_TERMS) {
+    if (term instanceof RegExp) {
+      if (term.test(html)) leaks.push(String(term));
+      continue;
+    }
+    if (typeof term !== 'string' || !term) continue;
+    if (html.toLowerCase().includes(term.toLowerCase())) leaks.push(term);
+  }
+  return leaks;
+}
+
+// -----------------------------------------------------------------------------
+// Fixture integrity — pin the frozen list before iterating
+// -----------------------------------------------------------------------------
+
+test('U10: PUNCTUATION_CHILD_FORBIDDEN_TERMS is non-empty + frozen (fixture integrity)', () => {
+  // A mutated or cleared fixture would silently weaken every downstream
+  // absence assertion. Pin both invariants before iterating — the Grammar
+  // P3 U10 precedent for exactly this guard.
+  assert.ok(Array.isArray(PUNCTUATION_CHILD_FORBIDDEN_TERMS));
+  assert.ok(
+    PUNCTUATION_CHILD_FORBIDDEN_TERMS.length >= 10,
+    `expected at least 10 forbidden terms, saw ${PUNCTUATION_CHILD_FORBIDDEN_TERMS.length}`,
+  );
+  assert.equal(
+    Object.isFrozen(PUNCTUATION_CHILD_FORBIDDEN_TERMS),
+    true,
+    'PUNCTUATION_CHILD_FORBIDDEN_TERMS must stay frozen so mutations throw',
+  );
+  // Regex catch-all is present so a bare `Worker` noun with no surrounding
+  // prefix still fails the sweep (the substring entries only catch
+  // compound forms like `Worker-marked`).
+  assert.ok(
+    PUNCTUATION_CHILD_FORBIDDEN_TERMS.some((term) => term instanceof RegExp),
+    'PUNCTUATION_CHILD_FORBIDDEN_TERMS must include at least one RegExp catch-all',
+  );
+});
+
+test('U10: PUNCTUATION_CLIENT_SKILL_IDS has exactly 14 skills (drift guard)', () => {
+  // The Skill Detail modal sweep below iterates this list × 2 tabs = 28
+  // render states. A drift that removed a skill would silently shrink
+  // the sweep coverage; a drift that added one without updating
+  // PUNCTUATION_SKILL_MODAL_CONTENT would throw in the render. Both
+  // failure modes are caught by pinning the expected length here.
+  assert.equal(PUNCTUATION_CLIENT_SKILL_IDS.length, 14);
+});
+
+// -----------------------------------------------------------------------------
+// Per-phase fixture renderers
+//
+// Each phase's renderer returns a harness with the subject state seeded
+// to the target phase. `renderChildPhaseHtml(phase)` is the single
+// dispatch-driven entry point used by the sweep loop below.
+// -----------------------------------------------------------------------------
+
+function renderSetupPhase() {
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  return harness;
+}
+
+function renderActiveItemPhase() {
+  // Seed a populated session so the teach box, progress header, skill
+  // name, and every surrounding chrome line are exercised by the sweep.
+  // A speech skill with a multi-skill cluster gets the "Speech" mode
+  // header the guided teach-box code path depends on.
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.store.updateSubjectUi('punctuation', {
+    phase: 'active-item',
+    session: {
+      id: 'u10-child-copy-active',
+      mode: 'guided',
+      length: 4,
+      answeredCount: 1,
+      guided: {
+        skillId: 'speech',
+        supportLevel: 2,
+        teachBox: {
+          name: 'Inverted commas and speech punctuation',
+          rule: 'Put spoken words inside inverted commas.',
+          workedExample: {
+            before: 'Mia said come here.',
+            after: 'Mia said, "Come here."',
+          },
+          contrastExample: {
+            before: 'Mia said "come here".',
+            after: 'Mia said, "Come here."',
+          },
+          selfCheckPrompt: 'Check the rule, compare the examples, then try the item without looking for the answer pattern.',
+        },
+      },
+      currentItem: {
+        id: 'sp_insert_question',
+        mode: 'insert',
+        inputKind: 'text',
+        skillIds: ['speech'],
+        prompt: 'Add the direct-speech punctuation.',
+        stem: 'Ella asked, can we start now?',
+      },
+    },
+  });
+  return harness;
+}
+
+function renderFeedbackPhase() {
+  // Feedback carries the fullest shape: kind, headline, body,
+  // displayCorrection behind a <details>, facets (positive + negative),
+  // and misconceptionTags that pipe through
+  // `punctuationChildMisconceptionLabel` (raw dotted ids must NOT leak).
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.store.updateSubjectUi('punctuation', {
+    phase: 'feedback',
+    session: {
+      id: 'u10-child-copy-feedback',
+      mode: 'smart',
+      length: 4,
+      answeredCount: 2,
+      currentItem: {
+        id: 'se_insert_capital',
+        mode: 'insert',
+        inputKind: 'text',
+        skillIds: ['sentence_endings'],
+        prompt: 'Add the missing capital letter and full stop.',
+        stem: 'the boat reached the harbour',
+      },
+    },
+    feedback: {
+      kind: 'error',
+      headline: 'Almost.',
+      body: 'Capital at the start and a full stop at the end.',
+      displayCorrection: 'The boat reached the harbour.',
+      facets: [
+        { id: 'capital', label: 'Capital letter', ok: false },
+        { id: 'ending', label: 'End punctuation', ok: true },
+      ],
+      misconceptionTags: ['speech.quote_missing', 'comma.missing_after_adverbial'],
+    },
+  });
+  return harness;
+}
+
+function renderSummaryPhase() {
+  // Summary carries focus skills (child-labelled wobbly chips), GPS
+  // review items with dotted misconception tags, and the active-only
+  // monster strip. Reserved monsters are NOT seeded — the scene
+  // iterates the active list and reserved trio must stay invisible.
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.store.updateSubjectUi('punctuation', {
+    phase: 'summary',
+    summary: {
+      label: 'Punctuation session summary',
+      message: 'Session complete.',
+      total: 4,
+      correct: 3,
+      accuracy: 75,
+      focus: ['speech', 'comma_clarity'],
+      securedUnits: ['sentence-endings-core'],
+      misconceptionTags: ['speech.quote_missing'],
+      gps: {
+        delayedFeedback: true,
+        recommendedMode: 'weak',
+        recommendedLabel: 'Wobbly Spots',
+        reviewItems: [
+          {
+            index: 1,
+            itemId: 'se_insert_capital',
+            mode: 'insert',
+            skillIds: ['sentence_endings'],
+            prompt: 'Add the missing capital letter and full stop.',
+            stem: 'the boat reached the harbour',
+            attemptedAnswer: 'The boat reached the harbour.',
+            displayCorrection: 'The boat reached the harbour.',
+            correct: true,
+            misconceptionTags: [],
+            facets: [],
+          },
+          {
+            index: 2,
+            itemId: 'sp_insert_question',
+            mode: 'insert',
+            skillIds: ['speech'],
+            prompt: 'Add the direct-speech punctuation.',
+            stem: 'Ella asked, can we start now?',
+            attemptedAnswer: 'Ella asked can we start now',
+            displayCorrection: 'Ella asked, "Can we start now?"',
+            correct: false,
+            misconceptionTags: ['speech.quote_missing'],
+            facets: [],
+          },
+        ],
+      },
+    },
+  });
+  return harness;
+}
+
+function renderMapPhase() {
+  // Open the Map phase via the real dispatch path (plan R5 — Map is
+  // reached from Setup, not by direct state seeding). The filter chip
+  // rows, 14 skill cards, 4 monster sections, and summary counter all
+  // render off the current read-model shape.
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.dispatch('punctuation-open-map');
+  return harness;
+}
+
+// --- Explicit phase allowlist + renderer registry ----------------------------
+//
+// The allowlist is deliberately frozen (Object.freeze) so a typo in a
+// downstream test cannot silently skip coverage. The renderer registry
+// throws on an unknown phase name for the same reason.
+
+export const PUNCTUATION_PHASE3_CHILD_PHASES = Object.freeze([
+  'setup',
+  'active-item',
+  'feedback',
+  'summary',
+  'map',
+]);
+
+const PHASE_RENDERERS = Object.freeze({
+  setup: renderSetupPhase,
+  'active-item': renderActiveItemPhase,
+  feedback: renderFeedbackPhase,
+  summary: renderSummaryPhase,
+  map: renderMapPhase,
+});
+
+function renderChildPhaseHtml(phase) {
+  const renderer = PHASE_RENDERERS[phase];
+  if (typeof renderer !== 'function') {
+    throw new Error(
+      `renderChildPhaseHtml: unknown phase "${phase}". ` +
+      `Expected one of: ${PUNCTUATION_PHASE3_CHILD_PHASES.join(', ')}.`,
+    );
+  }
+  const harness = renderer();
+  return { harness, html: harness.render() };
+}
+
+// -----------------------------------------------------------------------------
+// Forbidden-term sweep — five child phases × every fixture entry
+// -----------------------------------------------------------------------------
+
+test('U10: the five child-phase allowlist is frozen + complete', () => {
+  assert.equal(Object.isFrozen(PUNCTUATION_PHASE3_CHILD_PHASES), true);
+  assert.deepEqual([...PUNCTUATION_PHASE3_CHILD_PHASES], [
+    'setup',
+    'active-item',
+    'feedback',
+    'summary',
+    'map',
+  ]);
+});
+
+test('U10: renderChildPhaseHtml throws on an unknown phase name (silent-skip guard)', () => {
+  // Without this, a typo like `active_item` (underscore) or `feedbacks`
+  // in a downstream test would silently return an empty string and skip
+  // the coverage loop. This is the exact failure mode the U10
+  // completeness gate exists to prevent.
+  assert.throws(() => renderChildPhaseHtml('active_item'), /unknown phase/);
+  assert.throws(() => renderChildPhaseHtml(''), /unknown phase/);
+  assert.throws(() => renderChildPhaseHtml('bogus'), /unknown phase/);
+});
+
+for (const phase of PUNCTUATION_PHASE3_CHILD_PHASES) {
+  test(`U10: ${phase} HTML contains none of PUNCTUATION_CHILD_FORBIDDEN_TERMS`, () => {
+    const { html } = renderChildPhaseHtml(phase);
+    const leaks = forbiddenTermsInHtml(html);
+    assert.deepEqual(
+      leaks,
+      [],
+      `forbidden term leak in ${phase} HTML: ${leaks.join(', ')}`,
+    );
+  });
+
+  test(`U10: ${phase} HTML contains no whole-word /\\bWorker\\b/i catch-all`, () => {
+    const { html } = renderChildPhaseHtml(phase);
+    // `\b` boundary keeps legitimate tokens like `homework` or
+    // `workbook` from tripping the guard. The iterated substring fixture
+    // above covers every compound form; this catch-all protects against
+    // the bare noun.
+    assert.doesNotMatch(
+      html,
+      /\bWorker\b/i,
+      `bare Worker noun leaked into ${phase} HTML`,
+    );
+  });
+}
+
+// -----------------------------------------------------------------------------
+// Skill Detail modal sweep — 14 skills × 2 tabs = 28 render states
+// -----------------------------------------------------------------------------
+//
+// The Modal is a sub-surface of the Map phase. We open it on every
+// published skill and render both tabs so an authoring regression on
+// any single pedagogy string fails loudly here rather than at manual
+// QA. The modal render strictly scopes its output to the scrim subtree
+// so the surrounding Map HTML doesn't double-count toward leaks.
+//
+// Plan R3 reminder: "Practise this" dispatches Guided mode + skill id,
+// not cluster mode. The sweep only asserts copy absence — the
+// behavioural cluster-mode assertions live in `react-punctuation-scene.test.js`.
+
+function extractModalHtml(html) {
+  const start = html.indexOf('<div class="punctuation-skill-modal-scrim"');
+  return start === -1 ? '' : html.slice(start);
+}
+
+for (const skillId of PUNCTUATION_CLIENT_SKILL_IDS) {
+  test(`U10 modal: ${skillId} Learn tab renders with zero forbidden-term leaks`, () => {
+    const harness = createPunctuationHarness();
+    harness.dispatch('open-subject', { subjectId: 'punctuation' });
+    harness.dispatch('punctuation-open-map');
+    harness.dispatch('punctuation-skill-detail-open', { skillId });
+    // Default tab is 'learn' — no explicit dispatch needed. Paired
+    // state-level assertion that the modal actually opened closes the
+    // silent-no-op gap (learning #7).
+    assert.equal(
+      harness.store.getState().subjectUi.punctuation.mapUi.detailOpenSkillId,
+      skillId,
+      `modal must open for ${skillId}`,
+    );
+    assert.equal(
+      harness.store.getState().subjectUi.punctuation.mapUi.detailTab,
+      'learn',
+    );
+    const modalHtml = extractModalHtml(harness.render());
+    assert.ok(modalHtml, `modal HTML must be present for ${skillId}`);
+    const leaks = forbiddenTermsInHtml(modalHtml);
+    assert.deepEqual(
+      leaks,
+      [],
+      `forbidden term leak in Learn tab for ${skillId}: ${leaks.join(', ')}`,
+    );
+    assert.doesNotMatch(
+      modalHtml,
+      /\bWorker\b/i,
+      `bare Worker noun leaked into Learn tab for ${skillId}`,
+    );
+  });
+
+  test(`U10 modal: ${skillId} Practise tab renders with zero forbidden-term leaks`, () => {
+    const harness = createPunctuationHarness();
+    harness.dispatch('open-subject', { subjectId: 'punctuation' });
+    harness.dispatch('punctuation-open-map');
+    harness.dispatch('punctuation-skill-detail-open', { skillId });
+    harness.dispatch('punctuation-skill-detail-tab', { value: 'practise' });
+    assert.equal(
+      harness.store.getState().subjectUi.punctuation.mapUi.detailTab,
+      'practise',
+      `modal must flip to practise tab for ${skillId}`,
+    );
+    const modalHtml = extractModalHtml(harness.render());
+    assert.ok(modalHtml, `modal HTML must be present for ${skillId}`);
+    const leaks = forbiddenTermsInHtml(modalHtml);
+    assert.deepEqual(
+      leaks,
+      [],
+      `forbidden term leak in Practise tab for ${skillId}: ${leaks.join(', ')}`,
+    );
+    assert.doesNotMatch(
+      modalHtml,
+      /\bWorker\b/i,
+      `bare Worker noun leaked into Practise tab for ${skillId}`,
+    );
+  });
+}

--- a/tests/react-punctuation-scene.test.js
+++ b/tests/react-punctuation-scene.test.js
@@ -3094,3 +3094,114 @@ test('punctuation remote dispatch (adv-234-006 MEDIUM): Worker save-prefs failur
   // command failed — factory keeps parity with the previous behaviour.
   assert.ok(subjectErrors.length >= 1, 'save-prefs failure must surface a subject error');
 });
+
+// ---------------------------------------------------------------------------
+// Phase 3 U10 — cluster-mode behavioural goldens (R16).
+//
+// Each of the six cluster focus modes (endmarks / apostrophe / speech /
+// comma_flow / boundary / structure) has a paired state-level assertion
+// that a direct `punctuation-start` dispatch:
+//
+//   1. Transitions phase setup → active-item (paired HTML-agnostic state
+//      assertion that catches the silent-no-op failure mode — learning
+//      #7).
+//   2. Lands session.mode on the requested cluster id (proves the mode
+//      string survived the dispatch unaltered).
+//   3. Lands session.currentItem.skillIds on a skill that belongs to the
+//      cluster's canonical cluster id (proves the scheduler honoured
+//      the cluster constraint — not a generic smart/weak fallback).
+//
+// Plan Key Technical Decision (line 877): The Modal's "Practise this"
+// uses Guided mode + guidedSkillId — NOT cluster mode — because cluster
+// mode would silently drop `skillId` for multi-skill clusters. The
+// cluster modes therefore remain reachable only via direct
+// `punctuation-start` dispatch, which is exactly what the Phase 2 U9
+// matrix preserved. This U10 block locks that behavioural contract
+// against any future refactor that might drop a cluster mode from the
+// scheduler.
+//
+// SSR blind spots (learning #6): focus, pointer-capture, IME, and
+// scroll are not observable here — every assertion is a paired
+// state-level check.
+// ---------------------------------------------------------------------------
+
+const PUNCTUATION_CLUSTER_MODE_MATRIX = Object.freeze([
+  Object.freeze({ mode: 'endmarks', skillIdsSubset: ['sentence_endings'] }),
+  Object.freeze({ mode: 'apostrophe', skillIdsSubset: ['apostrophe_contractions', 'apostrophe_possession'] }),
+  Object.freeze({ mode: 'speech', skillIdsSubset: ['speech'] }),
+  Object.freeze({ mode: 'comma_flow', skillIdsSubset: ['list_commas', 'fronted_adverbial', 'comma_clarity'] }),
+  Object.freeze({ mode: 'boundary', skillIdsSubset: ['semicolon', 'dash_clause', 'hyphen'] }),
+  Object.freeze({ mode: 'structure', skillIdsSubset: ['parenthesis', 'colon_list', 'semicolon_list', 'bullet_points'] }),
+]);
+
+test('U10 cluster matrix: frozen list covers the six cluster focus modes exactly', () => {
+  // A drifted matrix that dropped or added a cluster mode would silently
+  // shrink or inflate the behavioural coverage. Pin the shape before
+  // iterating — the same guard the Grammar P3 U10 precedent uses.
+  assert.equal(Object.isFrozen(PUNCTUATION_CLUSTER_MODE_MATRIX), true);
+  assert.equal(PUNCTUATION_CLUSTER_MODE_MATRIX.length, 6);
+  assert.deepEqual(
+    PUNCTUATION_CLUSTER_MODE_MATRIX.map((entry) => entry.mode),
+    ['endmarks', 'apostrophe', 'speech', 'comma_flow', 'boundary', 'structure'],
+  );
+  // Every cluster mode in the matrix is present in the frozen
+  // PUNCTUATION_MODES enum. A cluster mode that slipped off the enum
+  // but stayed in the matrix would land a session that rounds back to
+  // `'smart'` at the service boundary — which is exactly the silent-
+  // no-op failure mode the paired assertions below catch.
+  for (const entry of PUNCTUATION_CLUSTER_MODE_MATRIX) {
+    assert.ok(
+      PUNCTUATION_MODES.includes(entry.mode),
+      `cluster mode ${entry.mode} must be present in PUNCTUATION_MODES`,
+    );
+  }
+});
+
+for (const entry of PUNCTUATION_CLUSTER_MODE_MATRIX) {
+  test(`U10 cluster ${entry.mode}: punctuation-start lands a session with the matching cluster and a cluster-member skill`, () => {
+    const harness = createPunctuationHarness();
+    harness.dispatch('open-subject', { subjectId: 'punctuation' });
+    // Seed the setup phase explicitly — this is the entry point the
+    // Phase 2 U9 matrix exercises and the most learner-realistic state
+    // for a cluster-start dispatch. Direct dispatch (NOT via the
+    // Skill Detail modal, which uses Guided mode + skill id per plan
+    // Key Technical Decision line 877).
+    harness.dispatch('punctuation-start', {
+      mode: entry.mode,
+      roundLength: '1',
+    });
+
+    const state = harness.store.getState().subjectUi.punctuation;
+
+    // (1) State-level phase transition. A silent-no-op that dropped the
+    // dispatch would leave phase on `'setup'`; this catches it.
+    assert.equal(
+      state.phase,
+      'active-item',
+      `punctuation-start with mode=${entry.mode} must transition phase to active-item`,
+    );
+
+    // (2) session.mode honours the dispatched cluster id. If the
+    // service ever rewrites cluster mode to `'smart'` (regression
+    // risk the plan flags), this fails loudly.
+    assert.equal(
+      state.session?.mode,
+      entry.mode,
+      `session.mode must equal the dispatched cluster mode for ${entry.mode}`,
+    );
+
+    // (3) The current item belongs to a skill that maps to the cluster.
+    // `skillIds[0]` is the canonical skill for per-item routing (the
+    // multi-skill clusters carry additional ids on paragraph items).
+    const currentSkillId = state.session?.currentItem?.skillIds?.[0];
+    assert.ok(
+      typeof currentSkillId === 'string' && currentSkillId,
+      `session must carry a concrete currentItem.skillIds[0] for mode=${entry.mode}`,
+    );
+    assert.ok(
+      entry.skillIdsSubset.includes(currentSkillId),
+      `session.currentItem.skillIds[0] (${currentSkillId}) must belong to the ${entry.mode} cluster ` +
+      `(expected one of: ${entry.skillIdsSubset.join(', ')})`,
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- New `tests/react-punctuation-child-copy.test.js` fixture-driven sweep: 5 child phases (setup / active-item / feedback / summary / map) × `PUNCTUATION_CHILD_FORBIDDEN_TERMS` + `/\bWorker\b/i` whole-word catch-all = 0 hits. Word-boundary catches the bare noun; substring matches catch the frozen compound entries. Skill Detail modal sweeps all 14 skills × 2 tabs = 28 render states.
- 6 cluster modes (`endmarks` / `apostrophe` / `speech` / `comma_flow` / `boundary` / `structure`) get behavioural golden-path tests in `tests/react-punctuation-scene.test.js`: direct `punctuation-start` dispatch lands `phase === 'active-item'` AND `session.mode === <cluster>` AND `session.currentItem.skillIds[0]` belongs to the cluster's skill subset. Paired state-level assertions close the silent-no-op gap (learning #7).
- `styles/app.css` dedicated `/* Punctuation — Phase 3 */` block: setup / session / summary / map / modal namespaced classes; mobile-first stacking at `max-width: 760px`; `@media (prefers-reduced-motion: reduce)` disables scene transitions. Existing U6 minimal modal styles folded into the full block; no drift on the 44×44 close-button touch target.

## Plan reference
U10. Closes Phase 3.

## Release-id impact
`release-id impact: none` — pure client UX + tests + CSS.

## Test plan
- [x] 5 child-phase × forbidden-term sweep (0 hits) + frozen-fixture integrity + unknown-phase throws.
- [x] Skill Detail Modal 14 skills × 2 tabs sweep (28 render states) — every tab renders with zero leaks; paired state-level assertions confirm `mapUi.detailOpenSkillId` and `mapUi.detailTab` actually updated before each render (silent-no-op guard).
- [x] 6 cluster-mode behavioural goldens — frozen matrix + enum-presence guard + per-mode phase / session.mode / cluster-membership assertions.
- [x] Phase 2 legacy parity byte-for-byte preserved (`tests/punctuation-legacy-parity.test.js` unchanged).
- [x] Bundle audit green (`shared/punctuation/*` still quarantined from client bundle).
- [x] `npm run build` compiles the bundles without CSS syntax errors; 1920 open / 1920 close brace count balanced.

## Known follow-ups (out of U10 scope)
- Worker-side `guidedTeachBox` serves adult-register `rule` from `shared/punctuation/content.js` into Guided sessions while U6 Modal uses a child-register mirror. Two surfaces disagree. Requires editing shared content (engine-adjacent) — deferred to a dedicated Phase 4 content pass.
- Back-to-dashboard / Continue escape-hatch disabled under `pendingCommand` across scenes — flagged across prior review rounds; U10 does not touch `composeIsDisabled` behaviour.

## Pre-existing CI failures unrelated to U10
Two tests fail on `origin/main` as of this branch's fork-point and reproduce identically before these changes are applied:
- `tests/grammar-production-smoke.test.js` — flags `grammar.startModel.stats.templates` as a forbidden-key leak.
- `tests/punctuation-release-smoke.test.js` — `JSON.parse` error reading `wrangler.jsonc` comments.

Both are outside the Punctuation U10 scope (Grammar-side smoke + JSON-with-comments parser drift in the release-smoke helper).