### PR TITLE
fix(spelling): cache word-bank word audio

### DIFF
--- a/shared/spelling-audio.js
+++ b/shared/spelling-audio.js
@@ -141,14 +141,13 @@ export function buildAudioAssetKey({
 }
 
 export function buildLegacyAudioAssetKey({
-  model = SPELLING_AUDIO_MODEL,
   voice,
   speed,
   slug,
   sentenceIndex,
   extension = DEFAULT_AUDIO_EXTENSION,
 }) {
-  const safeModel = encodeURIComponent(String(model || SPELLING_AUDIO_MODEL).trim());
+  const safeModel = encodeURIComponent(SPELLING_AUDIO_MODEL);
   const safeVoice = encodeURIComponent(String(voice || '').trim());
   const safeSpeed = encodeURIComponent(String(speed || '').trim());
   const safeSlug = encodeURIComponent(String(slug || '').trim());

--- a/shared/spelling-audio.js
+++ b/shared/spelling-audio.js
@@ -140,6 +140,55 @@ export function buildAudioAssetKey({
   return `${SPELLING_AUDIO_ROOT_PREFIX}/${safeModel}/${safeVoice}/${safeSpeed}/${safeContentKey}/${safeSlug}/${safeSentenceIndex}.${safeExtension}`;
 }
 
+export function buildLegacyAudioAssetKey({
+  model = SPELLING_AUDIO_MODEL,
+  voice,
+  speed,
+  slug,
+  sentenceIndex,
+  extension = DEFAULT_AUDIO_EXTENSION,
+}) {
+  const safeModel = encodeURIComponent(String(model || SPELLING_AUDIO_MODEL).trim());
+  const safeVoice = encodeURIComponent(String(voice || '').trim());
+  const safeSpeed = encodeURIComponent(String(speed || '').trim());
+  const safeSlug = encodeURIComponent(String(slug || '').trim());
+  const safeSentenceIndex = Number(sentenceIndex);
+  const safeExtension = String(extension || DEFAULT_AUDIO_EXTENSION).replace(/^\./, '');
+
+  if (
+    !safeModel
+    || !safeVoice
+    || !safeSpeed
+    || !safeSlug
+    || !Number.isInteger(safeSentenceIndex)
+    || safeSentenceIndex < 0
+  ) {
+    throw new Error('A valid model, voice, speed, slug, and sentence index are required.');
+  }
+
+  return `${SPELLING_AUDIO_ROOT_PREFIX}/${safeModel}/${safeVoice}/${safeSpeed}/${safeSlug}/${safeSentenceIndex}.${safeExtension}`;
+}
+
+export function buildWordAudioAssetKey({
+  model = SPELLING_AUDIO_MODEL,
+  voice,
+  contentKey,
+  slug,
+  extension = DEFAULT_AUDIO_EXTENSION,
+}) {
+  const safeModel = encodeURIComponent(String(model || SPELLING_AUDIO_MODEL).trim());
+  const safeVoice = encodeURIComponent(String(voice || '').trim());
+  const safeContentKey = encodeURIComponent(String(contentKey || '').trim());
+  const safeSlug = encodeURIComponent(String(slug || '').trim());
+  const safeExtension = String(extension || DEFAULT_AUDIO_EXTENSION).replace(/^\./, '');
+
+  if (!safeModel || !safeVoice || !safeContentKey || !safeSlug) {
+    throw new Error('A valid model, voice, content key, and slug are required.');
+  }
+
+  return `${SPELLING_AUDIO_ROOT_PREFIX}/${safeModel}/${safeVoice}/word/${safeContentKey}/${safeSlug}.${safeExtension}`;
+}
+
 export function buildIndexedAudioFilename({
   sentenceIndex,
   sentence,

--- a/src/subjects/spelling/tts.js
+++ b/src/subjects/spelling/tts.js
@@ -188,7 +188,6 @@ export function createPlatformTts({
     if (
       providerId === 'gemini'
       || isProviderTestPayload(payload)
-      || payload.wordOnly
       || !remoteEnabled
       || typeof fetchFn !== 'function'
       || !payload.promptToken
@@ -214,8 +213,7 @@ export function createPlatformTts({
 
   async function speakWithCachedBufferedAudio(payload = {}, bufferedVoiceId, token) {
     if (
-      payload.wordOnly
-      || !remoteEnabled
+      !remoteEnabled
       || typeof fetchFn !== 'function'
       || typeof Audio === 'undefined'
       || typeof URL === 'undefined'

--- a/tests/spelling-tts.test.js
+++ b/tests/spelling-tts.test.js
@@ -192,6 +192,83 @@ test('platform TTS plays cached Gemini audio before the selected provider', asyn
   }
 });
 
+test('platform TTS uses cached Gemini audio for word-bank word replay', async () => {
+  const originalAudio = globalThis.Audio;
+  const originalCreateObjectUrl = URL.createObjectURL;
+  const originalRevokeObjectUrl = URL.revokeObjectURL;
+  const played = [];
+
+  globalThis.Audio = class MockAudio {
+    constructor(src) {
+      this.src = src;
+      this.onended = null;
+      this.onerror = null;
+    }
+
+    play() {
+      played.push(this.src);
+      setTimeout(() => this.onended?.(), 0);
+      return Promise.resolve();
+    }
+
+    pause() {}
+    removeAttribute() {}
+    load() {}
+  };
+  URL.createObjectURL = () => 'blob:cached-word-audio';
+  URL.revokeObjectURL = () => {};
+
+  const calls = [];
+  const tts = createPlatformTts({
+    remoteEnabled: true,
+    provider: 'openai',
+    fetchFn: async (url, init = {}) => {
+      calls.push({
+        url,
+        body: JSON.parse(init.body),
+      });
+      return new Response(new Blob([new Uint8Array([5, 4, 3])], { type: 'audio/mpeg' }), {
+        status: 200,
+        headers: {
+          'content-type': 'audio/mpeg',
+          'x-ks2-tts-cache': 'hit',
+        },
+      });
+    },
+  });
+
+  try {
+    const result = await tts.speak({
+      learnerId: 'learner-a',
+      promptToken: 'word-bank-token',
+      slug: 'early',
+      scope: 'word-bank',
+      word: 'early',
+      wordOnly: true,
+    });
+
+    assert.equal(result, true);
+    assert.deepEqual(played, ['blob:cached-word-audio']);
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0].body, {
+      learnerId: 'learner-a',
+      promptToken: 'word-bank-token',
+      slow: false,
+      provider: 'gemini',
+      bufferedGeminiVoice: 'Iapetus',
+      wordOnly: true,
+      cacheLookupOnly: true,
+      slug: 'early',
+      scope: 'word-bank',
+    });
+  } finally {
+    tts.stop();
+    globalThis.Audio = originalAudio;
+    URL.createObjectURL = originalCreateObjectUrl;
+    URL.revokeObjectURL = originalRevokeObjectUrl;
+  }
+});
+
 test('platform TTS does not warm or fall back after cancelled cache lookup', async () => {
   const originalAudio = globalThis.Audio;
   globalThis.Audio = class MockAudio {};

--- a/tests/worker-tts.test.js
+++ b/tests/worker-tts.test.js
@@ -130,6 +130,18 @@ async function seedRateLimit(server, bucket, identifier, count) {
   `).run(`${bucket}:${await sha256(identifier)}`, windowStartedAt, count, now);
 }
 
+function ttsLimiterCounts(server) {
+  const rows = server.DB.db.prepare(`
+    SELECT limiter_key, request_count
+    FROM request_limits
+    WHERE limiter_key LIKE 'tts-%'
+  `).all();
+  return new Map(rows.map((row) => [
+    row.limiter_key.split(':')[0],
+    Number(row.request_count),
+  ]));
+}
+
 function geminiAudioResponse(bytes = [1, 0, 2, 0]) {
   return new Response(JSON.stringify({
     candidates: [{
@@ -148,7 +160,7 @@ function geminiAudioResponse(bytes = [1, 0, 2, 0]) {
   });
 }
 
-function createMemoryR2Bucket({ hit = null, failGet = false } = {}) {
+function createMemoryR2Bucket({ hit = null, failGet = false, failPut = false } = {}) {
   const objects = new Map();
   const gets = [];
   const puts = [];
@@ -173,6 +185,7 @@ function createMemoryR2Bucket({ hit = null, failGet = false } = {}) {
       };
     },
     async put(key, value, options = {}) {
+      if (failPut) throw new Error('R2 put failed.');
       const bytes = new Uint8Array(await new Response(value).arrayBuffer());
       puts.push({ key, bytes, options });
       objects.set(key, {
@@ -366,6 +379,7 @@ test('TTS route reads legacy batch-generated spelling audio keys', async () => {
 
   const server = createWorkerRepositoryServer({
     env: {
+      GEMINI_TTS_MODEL: 'gemini-custom-tts-preview',
       SPELLING_AUDIO_BUCKET: bucket,
     },
   });
@@ -380,11 +394,16 @@ test('TTS route reads legacy batch-generated spelling audio keys', async () => {
     const bytes = new Uint8Array(await response.arrayBuffer());
 
     assert.equal(response.status, 200);
+    assert.equal(response.headers.get('content-type'), 'audio/mpeg');
     assert.equal(response.headers.get('x-ks2-tts-cache'), 'hit');
+    assert.equal(response.headers.get('x-ks2-tts-cache-source'), 'legacy');
+    assert.equal(response.headers.get('x-ks2-tts-model'), 'gemini-3.1-flash-tts-preview');
+    assert.equal(response.headers.get('x-ks2-tts-voice'), 'Sulafat');
+    assert.equal(response.headers.get('cache-control'), 'private, max-age=86400');
     assert.deepEqual([...bytes], [7, 8, 9]);
     assert.equal(bucket.gets.length, 2);
-    assert.match(bucket.gets[0], /\/Sulafat\/standard\/[^/]+\/early\/\d+\.mp3$/);
-    assert.match(bucket.gets[1], /\/Sulafat\/standard\/early\/\d+\.mp3$/);
+    assert.match(bucket.gets[0], /\/gemini-custom-tts-preview\/Sulafat\/standard\/[^/]+\/early\/\d+\.mp3$/);
+    assert.match(bucket.gets[1], /\/gemini-3\.1-flash-tts-preview\/Sulafat\/standard\/early\/\d+\.mp3$/);
     assert.equal(bucket.puts.length, 0);
   } finally {
     globalThis.fetch = originalFetch;
@@ -484,11 +503,17 @@ test('TTS route serves cached word-bank word audio for lookup-only requests', as
     assert.equal(response.status, 200);
     assert.equal(response.headers.get('content-type'), 'audio/mpeg');
     assert.equal(response.headers.get('x-ks2-tts-cache'), 'hit');
+    assert.equal(response.headers.get('x-ks2-tts-cache-source'), 'primary');
     assert.equal(response.headers.get('x-ks2-tts-voice'), 'Sulafat');
     assert.deepEqual([...bytes], [4, 3, 2]);
     assert.equal(bucket.gets.length, 1);
     assert.match(bucket.gets[0], /\/Sulafat\/word\/[^/]+\/early\.mp3$/);
     assert.equal(bucket.puts.length, 0);
+    const limiterCounts = ttsLimiterCounts(server);
+    assert.equal(limiterCounts.get('tts-lookup-account'), 1);
+    assert.equal(limiterCounts.get('tts-lookup-ip'), 1);
+    assert.equal(limiterCounts.get('tts-account'), 1);
+    assert.equal(limiterCounts.get('tts-ip'), 1);
   } finally {
     globalThis.fetch = originalFetch;
     server.close();
@@ -819,12 +844,73 @@ test('TTS buffered Gemini cache reuses matching published content across account
   }
 });
 
-test('TTS route falls back to provider generation when R2 reads fail', async () => {
+test('TTS buffered Gemini word cache reuses matching vocabulary audio across accounts', async () => {
   const originalFetch = globalThis.fetch;
   let providerCalls = 0;
   globalThis.fetch = async () => {
     providerCalls += 1;
     return geminiAudioResponse();
+  };
+  const bucket = createMemoryR2Bucket();
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      GEMINI_API_KEY: 'test-gemini-key',
+      SPELLING_AUDIO_BUCKET: bucket,
+    },
+  });
+  try {
+    seedAccountLearner(server.DB, { accountId: 'adult-a', learnerId: 'learner-a' });
+    seedAccountLearner(server.DB, { accountId: 'adult-b', learnerId: 'learner-b' });
+    const detailAResponse = await server.fetchAs('adult-a', 'https://repo.test/api/subjects/spelling/word-bank?learnerId=learner-a&detailSlug=early');
+    const detailBResponse = await server.fetchAs('adult-b', 'https://repo.test/api/subjects/spelling/word-bank?learnerId=learner-b&detailSlug=early');
+    const detailA = await detailAResponse.json();
+    const detailB = await detailBResponse.json();
+    const cueA = detailA.wordBank.detail.audio.word;
+    const cueB = detailB.wordBank.detail.audio.word;
+
+    const responseA = await server.fetchAs('adult-a', 'https://repo.test/api/tts', ttsRequest({
+      learnerId: cueA.learnerId,
+      promptToken: cueA.promptToken,
+      slug: cueA.slug,
+      wordOnly: true,
+      provider: 'gemini',
+      bufferedGeminiVoice: 'Iapetus',
+    }));
+    const responseB = await server.fetchAs('adult-b', 'https://repo.test/api/tts', ttsRequest({
+      learnerId: cueB.learnerId,
+      promptToken: cueB.promptToken,
+      slug: cueB.slug,
+      wordOnly: true,
+      provider: 'gemini',
+      bufferedGeminiVoice: 'Iapetus',
+    }));
+
+    assert.equal(responseA.status, 200);
+    assert.equal(responseA.headers.get('x-ks2-tts-cache'), 'stored');
+    assert.equal(responseB.status, 200);
+    assert.equal(responseB.headers.get('x-ks2-tts-cache'), 'hit');
+    assert.equal(responseB.headers.get('x-ks2-tts-cache-source'), 'primary');
+    assert.equal(providerCalls, 1);
+    assert.equal(bucket.puts.length, 1);
+    assert.match(bucket.puts[0].key, /\/Iapetus\/word\/[^/]+\/early\.wav$/);
+  } finally {
+    globalThis.fetch = originalFetch;
+    server.close();
+  }
+});
+
+test('TTS route falls back to provider generation when R2 reads fail', async () => {
+  const originalFetch = globalThis.fetch;
+  const originalConsoleError = console.error;
+  let providerCalls = 0;
+  const errors = [];
+  globalThis.fetch = async () => {
+    providerCalls += 1;
+    return geminiAudioResponse();
+  };
+  console.error = (...args) => {
+    errors.push(args);
   };
   const bucket = createMemoryR2Bucket({ failGet: true });
 
@@ -849,8 +935,13 @@ test('TTS route falls back to provider generation when R2 reads fail', async () 
     assert.equal(String.fromCharCode(...bytes.slice(0, 4)), 'RIFF');
     assert.equal(providerCalls, 1);
     assert.equal(bucket.puts.length, 0);
+    assert.equal(errors.length, 2);
+    assert.equal(errors[0][0], '[ks2-tts] R2 audio read failed');
+    assert.equal(errors[0][1].keyKind, 'sentence');
+    assert.equal(errors[0][1].message, 'R2 get failed.');
   } finally {
     globalThis.fetch = originalFetch;
+    console.error = originalConsoleError;
     server.close();
   }
 });
@@ -1302,12 +1393,118 @@ test('TTS route stores Gemini word-bank word audio in the word cache', async () 
     assert.equal(calls[0].url, 'https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-tts-preview:generateContent');
     assert.match(calls[0].body.contents[0].parts[0].text, /Read exactly this KS2 spelling word once/);
     assert.equal(bucket.puts.length, 1);
+    assert.ok(bucket.gets.length >= 2);
+    assert.ok(bucket.gets.every((key) => /\/Iapetus\/word\/[^/]+\/early\.(mp3|wav)$/.test(key)));
     assert.match(bucket.puts[0].key, /spelling-audio\/v1\/gemini-3\.1-flash-tts-preview\/Iapetus\/word\/[^/]+\/early\.wav$/);
     assert.equal(bucket.puts[0].options.customMetadata.kind, 'word');
     assert.equal(bucket.puts[0].options.customMetadata.slug, 'early');
     assert.equal(bucket.puts[0].options.customMetadata.sentenceIndex, undefined);
+    const limiterCounts = ttsLimiterCounts(server);
+    assert.equal(limiterCounts.get('tts-account'), 1);
+    assert.equal(limiterCounts.get('tts-ip'), 1);
+    assert.equal(limiterCounts.get('tts-lookup-account'), undefined);
+    assert.equal(limiterCounts.get('tts-warmup-account'), undefined);
   } finally {
     globalThis.fetch = originalFetch;
+    server.close();
+  }
+});
+
+test('TTS cache-only requests warm Gemini word-bank word audio without playback quota', async () => {
+  const originalFetch = globalThis.fetch;
+  let providerCalls = 0;
+  globalThis.fetch = async () => {
+    providerCalls += 1;
+    return geminiAudioResponse();
+  };
+  const bucket = createMemoryR2Bucket();
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      GEMINI_API_KEY: 'test-gemini-key',
+      SPELLING_AUDIO_BUCKET: bucket,
+    },
+  });
+  try {
+    seedAccountLearner(server.DB);
+    const detailResponse = await server.fetch('https://repo.test/api/subjects/spelling/word-bank?learnerId=learner-a&detailSlug=early');
+    const detail = await detailResponse.json();
+    const cue = detail.wordBank.detail.audio.word;
+    const response = await server.fetch('https://repo.test/api/tts', ttsRequest({
+      learnerId: cue.learnerId,
+      promptToken: cue.promptToken,
+      slug: cue.slug,
+      wordOnly: true,
+      provider: 'gemini',
+      bufferedGeminiVoice: 'Iapetus',
+      cacheOnly: true,
+    }));
+    const bytes = new Uint8Array(await response.arrayBuffer());
+
+    assert.equal(response.status, 204);
+    assert.equal(response.headers.get('x-ks2-tts-cache'), 'stored');
+    assert.equal(bytes.length, 0);
+    assert.equal(providerCalls, 1);
+    assert.equal(bucket.puts.length, 1);
+    assert.ok(bucket.gets.every((key) => /\/Iapetus\/word\/[^/]+\/early\.(mp3|wav)$/.test(key)));
+    assert.match(bucket.puts[0].key, /\/Iapetus\/word\/[^/]+\/early\.wav$/);
+    const limiterCounts = ttsLimiterCounts(server);
+    assert.equal(limiterCounts.get('tts-warmup-account'), 1);
+    assert.equal(limiterCounts.get('tts-warmup-ip'), 1);
+    assert.equal(limiterCounts.get('tts-account'), undefined);
+    assert.equal(limiterCounts.get('tts-ip'), undefined);
+  } finally {
+    globalThis.fetch = originalFetch;
+    server.close();
+  }
+});
+
+test('TTS route reports word-bank word cache store failures without hiding playback audio', async () => {
+  const originalFetch = globalThis.fetch;
+  const originalConsoleError = console.error;
+  let providerCalls = 0;
+  const errors = [];
+  globalThis.fetch = async () => {
+    providerCalls += 1;
+    return geminiAudioResponse();
+  };
+  console.error = (...args) => {
+    errors.push(args);
+  };
+  const bucket = createMemoryR2Bucket({ failPut: true });
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      GEMINI_API_KEY: 'test-gemini-key',
+      SPELLING_AUDIO_BUCKET: bucket,
+    },
+  });
+  try {
+    seedAccountLearner(server.DB);
+    const detailResponse = await server.fetch('https://repo.test/api/subjects/spelling/word-bank?learnerId=learner-a&detailSlug=early');
+    const detail = await detailResponse.json();
+    const cue = detail.wordBank.detail.audio.word;
+    const response = await server.fetch('https://repo.test/api/tts', ttsRequest({
+      learnerId: cue.learnerId,
+      promptToken: cue.promptToken,
+      slug: cue.slug,
+      wordOnly: true,
+      provider: 'gemini',
+      bufferedGeminiVoice: 'Iapetus',
+    }));
+    const bytes = new Uint8Array(await response.arrayBuffer());
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('x-ks2-tts-cache'), 'store_failed');
+    assert.equal(String.fromCharCode(...bytes.slice(0, 4)), 'RIFF');
+    assert.equal(providerCalls, 1);
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0][0], '[ks2-tts] R2 audio write failed');
+    assert.equal(errors[0][1].keyKind, 'word');
+    assert.equal(errors[0][1].message, 'R2 put failed.');
+  } finally {
+    globalThis.fetch = originalFetch;
+    console.error = originalConsoleError;
     server.close();
   }
 });

--- a/tests/worker-tts.test.js
+++ b/tests/worker-tts.test.js
@@ -342,6 +342,56 @@ test('TTS route serves pre-cached Gemini audio before provider generation', asyn
   }
 });
 
+test('TTS route reads legacy batch-generated spelling audio keys', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    throw new Error('Provider should not be called for legacy cached audio.');
+  };
+  const bucket = {
+    gets: [],
+    puts: [],
+    async get(key) {
+      this.gets.push(key);
+      if (!/\/Sulafat\/standard\/early\/\d+\.mp3$/.test(key)) return null;
+      return {
+        body: Uint8Array.from([7, 8, 9]),
+        httpMetadata: { contentType: 'audio/mpeg' },
+        customMetadata: {},
+      };
+    },
+    async put() {
+      this.puts.push(arguments);
+    },
+  };
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      SPELLING_AUDIO_BUCKET: bucket,
+    },
+  });
+  try {
+    const prompt = await startSpellingPrompt(server);
+    const response = await server.fetch('https://repo.test/api/tts', ttsRequest({
+      learnerId: prompt.learnerId,
+      promptToken: prompt.promptToken,
+      provider: 'gemini',
+      bufferedGeminiVoice: 'Sulafat',
+    }));
+    const bytes = new Uint8Array(await response.arrayBuffer());
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('x-ks2-tts-cache'), 'hit');
+    assert.deepEqual([...bytes], [7, 8, 9]);
+    assert.equal(bucket.gets.length, 2);
+    assert.match(bucket.gets[0], /\/Sulafat\/standard\/[^/]+\/early\/\d+\.mp3$/);
+    assert.match(bucket.gets[1], /\/Sulafat\/standard\/early\/\d+\.mp3$/);
+    assert.equal(bucket.puts.length, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+    server.close();
+  }
+});
+
 test('TTS route serves cached audio for lookup-only requests before selected provider fallback', async () => {
   const originalFetch = globalThis.fetch;
   let providerCalls = 0;
@@ -393,6 +443,52 @@ test('TTS route serves cached audio for lookup-only requests before selected pro
     assert.equal(limiterCounts.get('tts-lookup-ip'), 1);
     assert.equal(limiterCounts.get('tts-account'), 1);
     assert.equal(limiterCounts.get('tts-ip'), 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+    server.close();
+  }
+});
+
+test('TTS route serves cached word-bank word audio for lookup-only requests', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    throw new Error('Provider should not be called for cached word audio.');
+  };
+  const bucket = createMemoryR2Bucket({
+    hit: {
+      bytes: [4, 3, 2],
+      contentType: 'audio/mpeg',
+    },
+  });
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      SPELLING_AUDIO_BUCKET: bucket,
+    },
+  });
+  try {
+    seedAccountLearner(server.DB);
+    const detailResponse = await server.fetch('https://repo.test/api/subjects/spelling/word-bank?learnerId=learner-a&detailSlug=early');
+    const detail = await detailResponse.json();
+    const cue = detail.wordBank.detail.audio.word;
+    const response = await server.fetch('https://repo.test/api/tts', ttsRequest({
+      learnerId: cue.learnerId,
+      promptToken: cue.promptToken,
+      slug: cue.slug,
+      wordOnly: true,
+      cacheLookupOnly: true,
+      bufferedGeminiVoice: 'Sulafat',
+    }));
+    const bytes = new Uint8Array(await response.arrayBuffer());
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('content-type'), 'audio/mpeg');
+    assert.equal(response.headers.get('x-ks2-tts-cache'), 'hit');
+    assert.equal(response.headers.get('x-ks2-tts-voice'), 'Sulafat');
+    assert.deepEqual([...bytes], [4, 3, 2]);
+    assert.equal(bucket.gets.length, 1);
+    assert.match(bucket.gets[0], /\/Sulafat\/word\/[^/]+\/early\.mp3$/);
+    assert.equal(bucket.puts.length, 0);
   } finally {
     globalThis.fetch = originalFetch;
     server.close();
@@ -470,7 +566,7 @@ test('TTS route returns a lookup-only cache miss without generating audio', asyn
     assert.equal(response.status, 204);
     assert.equal(response.headers.get('x-ks2-tts-cache'), 'miss');
     assert.equal(providerCalls, 0);
-    assert.equal(bucket.gets.length, 2);
+    assert.equal(bucket.gets.length, 3);
     assert.equal(bucket.puts.length, 0);
   } finally {
     globalThis.fetch = originalFetch;
@@ -525,7 +621,7 @@ test('TTS route charges cold-cache fallback playback quota only once', async () 
     assert.equal(lookupResponse.headers.get('x-ks2-tts-cache'), 'miss');
     assert.equal(playbackResponse.status, 200);
     assert.equal(providerCalls, 1);
-    assert.equal(bucket.gets.length, 2);
+    assert.equal(bucket.gets.length, 3);
     assert.equal(limiterCounts.get('tts-lookup-account'), 1);
     assert.equal(limiterCounts.get('tts-lookup-ip'), 1);
     assert.equal(limiterCounts.get('tts-account'), 1);
@@ -984,7 +1080,7 @@ test('TTS cache-only warmups are skipped when the warmup quota is exhausted', as
     assert.equal(response.status, 204);
     assert.equal(response.headers.get('x-ks2-tts-cache'), 'skipped_rate_limited');
     assert.equal(providerCalls, 0);
-    assert.equal(bucket.gets.length, 2);
+    assert.equal(bucket.gets.length, 3);
     assert.equal(bucket.puts.length, 0);
   } finally {
     globalThis.fetch = originalFetch;
@@ -1162,6 +1258,54 @@ test('TTS route supports server-tokened word bank vocabulary audio', async () =>
     assert.equal(calls[0].url, 'https://api.openai.com/v1/audio/speech');
     assert.equal(calls[0].body.input, 'early');
     assert.match(calls[0].body.instructions, /Read exactly the supplied word once/);
+  } finally {
+    globalThis.fetch = originalFetch;
+    server.close();
+  }
+});
+
+test('TTS route stores Gemini word-bank word audio in the word cache', async () => {
+  const originalFetch = globalThis.fetch;
+  const calls = [];
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({
+      url,
+      body: JSON.parse(init.body),
+    });
+    return geminiAudioResponse();
+  };
+  const bucket = createMemoryR2Bucket();
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      GEMINI_API_KEY: 'test-gemini-key',
+      SPELLING_AUDIO_BUCKET: bucket,
+    },
+  });
+  try {
+    seedAccountLearner(server.DB);
+    const detailResponse = await server.fetch('https://repo.test/api/subjects/spelling/word-bank?learnerId=learner-a&detailSlug=early');
+    const detail = await detailResponse.json();
+    const cue = detail.wordBank.detail.audio.word;
+    const response = await server.fetch('https://repo.test/api/tts', ttsRequest({
+      learnerId: cue.learnerId,
+      promptToken: cue.promptToken,
+      slug: cue.slug,
+      wordOnly: true,
+      provider: 'gemini',
+      bufferedGeminiVoice: 'Iapetus',
+    }));
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('x-ks2-tts-cache'), 'stored');
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, 'https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-tts-preview:generateContent');
+    assert.match(calls[0].body.contents[0].parts[0].text, /Read exactly this KS2 spelling word once/);
+    assert.equal(bucket.puts.length, 1);
+    assert.match(bucket.puts[0].key, /spelling-audio\/v1\/gemini-3\.1-flash-tts-preview\/Iapetus\/word\/[^/]+\/early\.wav$/);
+    assert.equal(bucket.puts[0].options.customMetadata.kind, 'word');
+    assert.equal(bucket.puts[0].options.customMetadata.slug, 'early');
+    assert.equal(bucket.puts[0].options.customMetadata.sentenceIndex, undefined);
   } finally {
     globalThis.fetch = originalFetch;
     server.close();
@@ -1536,7 +1680,7 @@ test('demo lookup-only cache misses use lookup guards instead of playback guards
     assert.equal(response.status, 204);
     assert.equal(response.headers.get('x-ks2-tts-cache'), 'miss');
     assert.equal(providerCalls, 0);
-    assert.equal(bucket.gets.length, 2);
+    assert.equal(bucket.gets.length, 3);
     assert.equal(fallbackMetric, undefined);
     assert.deepEqual(limiterPrefixes, [
       'demo-tts-lookup-account',

--- a/worker/src/generated-csp-hash.js
+++ b/worker/src/generated-csp-hash.js
@@ -2,4 +2,4 @@
 // This file is committed so fresh clones can run `npm test` before
 // `npm run build` has produced a real hash. Build overwrites this.
 
-export const CSP_INLINE_SCRIPT_HASH = 'sha256-06SFOq2Wj74Ww4wfCm1nJLKf6sUYs9usIiwlCVmZLfg=';
+export const CSP_INLINE_SCRIPT_HASH = 'sha256-d5B0kdrkvmMBHcWJ8TUVFkTDTxk/ACGS+ezi8RwKeZE=';

--- a/worker/src/tts.js
+++ b/worker/src/tts.js
@@ -9,6 +9,8 @@ import {
   SPELLING_AUDIO_MODEL,
   buildAudioAssetKey,
   buildBufferedSpeechPrompt,
+  buildLegacyAudioAssetKey,
+  buildWordAudioAssetKey,
   normaliseBufferedGeminiVoice,
   speedIdForSlow,
 } from '../../shared/spelling-audio.js';
@@ -278,15 +280,31 @@ function contentTypeForExtension(extension) {
 }
 
 async function bufferedAudioMetadata(payload = {}, { model = SPELLING_AUDIO_MODEL } = {}) {
-  if (payload.wordOnly) return null;
   const cacheModel = cleanGeminiModel(model) || SPELLING_AUDIO_MODEL;
   const slug = cleanText(payload.slug).toLowerCase();
-  const sentenceIndex = Number(payload.sentenceIndex);
   const accountId = cleanText(payload.accountId);
   const word = cleanText(payload.word);
-  const sentence = cleanText(payload.sentence);
-  if (!accountId || !slug || !word || !sentence || !Number.isInteger(sentenceIndex) || sentenceIndex < 0) return null;
+  if (!accountId || !slug || !word) return null;
   const voice = normaliseBufferedGeminiVoice(payload.bufferedGeminiVoice);
+
+  if (payload.wordOnly) {
+    const contentKey = await sha256([
+      'spelling-audio-word-v1',
+      slug,
+      word,
+    ].join('|'));
+    return {
+      kind: 'word',
+      model: cacheModel,
+      voice,
+      contentKey,
+      slug,
+    };
+  }
+
+  const sentenceIndex = Number(payload.sentenceIndex);
+  const sentence = cleanText(payload.sentence);
+  if (!sentence || !Number.isInteger(sentenceIndex) || sentenceIndex < 0) return null;
   const speed = speedIdForSlow(payload.slow);
   const contentKey = await sha256([
     'spelling-audio-content-v2',
@@ -306,7 +324,21 @@ async function bufferedAudioMetadata(payload = {}, { model = SPELLING_AUDIO_MODE
 }
 
 function bufferedAudioKey(metadata, extension = 'mp3') {
+  if (metadata?.kind === 'word') {
+    return buildWordAudioAssetKey({
+      ...metadata,
+      extension,
+    });
+  }
   return buildAudioAssetKey({
+    ...metadata,
+    extension,
+  });
+}
+
+function legacyBufferedAudioKey(metadata, extension = 'mp3') {
+  if (metadata?.kind === 'word') return '';
+  return buildLegacyAudioAssetKey({
     ...metadata,
     extension,
   });
@@ -348,9 +380,15 @@ async function readBufferedGeminiAudio(env, payload, options = {}) {
 
   for (const extension of BUFFERED_AUDIO_EXTENSIONS) {
     const key = bufferedAudioKey(metadata, extension);
+    const fallbackKey = extension === 'mp3' ? legacyBufferedAudioKey(metadata, extension) : '';
     let object = null;
+    let objectKey = key;
     try {
       object = await bucket.get(key);
+      if (!object && fallbackKey) {
+        object = await bucket.get(fallbackKey);
+        objectKey = fallbackKey;
+      }
     } catch {
       return {
         object: null,
@@ -365,7 +403,7 @@ async function readBufferedGeminiAudio(env, payload, options = {}) {
     return {
       object,
       metadata,
-      key,
+      key: objectKey,
       extension,
       contentType: objectContentType(object, extension),
     };
@@ -434,18 +472,22 @@ async function storeBufferedGeminiAudio(env, payload, response, options = {}) {
 
   const contentType = response.headers.get('content-type') || 'audio/wav';
   const bytes = await response.arrayBuffer();
+  const customMetadata = {
+    model: cacheSlot.metadata.model,
+    voice: cacheSlot.metadata.voice,
+    contentKey: cacheSlot.metadata.contentKey,
+    slug: cacheSlot.metadata.slug,
+    source: 'worker-gemini-tts',
+  };
+  if (cacheSlot.metadata.kind) customMetadata.kind = cacheSlot.metadata.kind;
+  if (cacheSlot.metadata.speed) customMetadata.speed = cacheSlot.metadata.speed;
+  if (Number.isInteger(cacheSlot.metadata.sentenceIndex)) {
+    customMetadata.sentenceIndex = String(cacheSlot.metadata.sentenceIndex);
+  }
   try {
     await spellingAudioBucket(env).put(cacheSlot.key, bytes, {
       httpMetadata: { contentType },
-      customMetadata: {
-        model: cacheSlot.metadata.model,
-        voice: cacheSlot.metadata.voice,
-        speed: cacheSlot.metadata.speed,
-        contentKey: cacheSlot.metadata.contentKey,
-        slug: cacheSlot.metadata.slug,
-        sentenceIndex: String(cacheSlot.metadata.sentenceIndex),
-        source: 'worker-gemini-tts',
-      },
+      customMetadata,
     });
     return {
       response: new Response(bytes, {
@@ -686,7 +728,6 @@ export async function handleTextToSpeechRequest({
     ...gemini,
     voice: payload.bufferedGeminiVoice || gemini.voice,
   };
-  if ((cacheOnly || cacheLookupOnly) && payload.wordOnly) return cacheOnlyResponse('uncacheable');
   let protectedRequest = false;
   let protectedLookup = false;
   async function protectAudioRequest() {
@@ -707,26 +748,24 @@ export async function handleTextToSpeechRequest({
   }
 
   async function tryGemini(fallbackFrom = '') {
-    if (!payload.wordOnly) {
-      if (cacheLookupOnly) await protectLookupRequest();
-      else if (!cacheOnly) await protectAudioRequest();
-      const cacheHit = await readBufferedGeminiAudio(env, payload, { model: geminiForPayload.model });
-      if (cacheHit?.object) {
-        if (cacheLookupOnly) await protectAudioRequest();
-        const output = cacheOnly ? cacheOnlyResponse('hit', cacheHit) : cachedGeminiAudioResponse(cacheHit);
-        return cacheOnly ? output : await finish(output, fallbackFrom);
-      }
-      if (cacheLookupOnly && cacheHit?.cacheUnavailable) return cacheOnlyResponse('unavailable', cacheHit);
-      if (cacheLookupOnly && !cacheHit?.metadata) return cacheOnlyResponse('uncacheable');
-      if (cacheLookupOnly) return cacheOnlyResponse('miss', cacheHit);
-      if (cacheOnly && cacheHit?.cacheUnavailable) return cacheOnlyResponse('unavailable', cacheHit);
-      if (cacheOnly && !cacheHit?.metadata) return cacheOnlyResponse('uncacheable');
-      if (cacheOnly) {
-        if (!geminiForPayload.apiKey) return cacheOnlyResponse('unavailable');
-        const warmupAllowed = await allowTtsWarmup(env, request, session, now);
-        if (!warmupAllowed) return cacheOnlyResponse('skipped_rate_limited');
-        await protectDemoTtsFallback({ env, request, session, payload, now });
-      }
+    if (cacheLookupOnly) await protectLookupRequest();
+    else if (!cacheOnly) await protectAudioRequest();
+    const cacheHit = await readBufferedGeminiAudio(env, payload, { model: geminiForPayload.model });
+    if (cacheHit?.object) {
+      if (cacheLookupOnly) await protectAudioRequest();
+      const output = cacheOnly ? cacheOnlyResponse('hit', cacheHit) : cachedGeminiAudioResponse(cacheHit);
+      return cacheOnly ? output : await finish(output, fallbackFrom);
+    }
+    if (cacheLookupOnly && cacheHit?.cacheUnavailable) return cacheOnlyResponse('unavailable', cacheHit);
+    if (cacheLookupOnly && !cacheHit?.metadata) return cacheOnlyResponse('uncacheable');
+    if (cacheLookupOnly) return cacheOnlyResponse('miss', cacheHit);
+    if (cacheOnly && cacheHit?.cacheUnavailable) return cacheOnlyResponse('unavailable', cacheHit);
+    if (cacheOnly && !cacheHit?.metadata) return cacheOnlyResponse('uncacheable');
+    if (cacheOnly) {
+      if (!geminiForPayload.apiKey) return cacheOnlyResponse('unavailable');
+      const warmupAllowed = await allowTtsWarmup(env, request, session, now);
+      if (!warmupAllowed) return cacheOnlyResponse('skipped_rate_limited');
+      await protectDemoTtsFallback({ env, request, session, payload, now });
     }
     if (!geminiForPayload.apiKey) {
       if (cacheOnly) return cacheOnlyResponse('unavailable');
@@ -734,9 +773,7 @@ export async function handleTextToSpeechRequest({
     }
     if (!cacheOnly) await protectAudioRequest();
     const response = await requestGeminiSpeech({ config: geminiForPayload, payload, fetchFn });
-    const stored = payload.wordOnly
-      ? { response, cacheState: 'uncacheable' }
-      : await storeBufferedGeminiAudio(env, payload, response, { model: geminiForPayload.model });
+    const stored = await storeBufferedGeminiAudio(env, payload, response, { model: geminiForPayload.model });
     const output = cacheOnly
       ? cacheOnlyResponse(stored.cacheState, { metadata: stored.metadata })
       : stored.response;
@@ -751,7 +788,6 @@ export async function handleTextToSpeechRequest({
   }
 
   function canTryGemini() {
-    if (payload.wordOnly) return Boolean(geminiForPayload.apiKey);
     return Boolean(geminiForPayload.apiKey || spellingAudioBucket(env));
   }
 

--- a/worker/src/tts.js
+++ b/worker/src/tts.js
@@ -337,15 +337,20 @@ function bufferedAudioKey(metadata, extension = 'mp3') {
 }
 
 function legacyBufferedAudioKey(metadata, extension = 'mp3') {
-  if (metadata?.kind === 'word') return '';
+  if (metadata?.kind === 'word') return null;
   return buildLegacyAudioAssetKey({
     ...metadata,
     extension,
   });
 }
 
-function bufferedAudioHeaders({ metadata, cacheState, contentType }) {
-  return {
+function bufferedAudioHeaders({
+  metadata,
+  cacheState,
+  contentType,
+  cacheSource = '',
+}) {
+  const headers = {
     'content-type': contentType,
     'cache-control': 'private, max-age=86400',
     'x-ks2-tts-provider': 'gemini',
@@ -353,6 +358,8 @@ function bufferedAudioHeaders({ metadata, cacheState, contentType }) {
     'x-ks2-tts-voice': metadata.voice,
     'x-ks2-tts-cache': cacheState,
   };
+  if (cacheSource) headers['x-ks2-tts-cache-source'] = cacheSource;
+  return headers;
 }
 
 function objectContentType(object, extension) {
@@ -361,6 +368,17 @@ function objectContentType(object, extension) {
       || object?.httpMetadata?.content_type
       || object?.customMetadata?.contentType,
   ) || contentTypeForExtension(extension);
+}
+
+function audioCacheErrorFields(error) {
+  const name = cleanText(error?.name);
+  const message = cleanText(error?.message || error);
+  const stack = cleanText(error?.stack);
+  return {
+    ...(name ? { name } : {}),
+    ...(message ? { message } : {}),
+    ...(stack ? { stack: stack.slice(0, 1000) } : {}),
+  };
 }
 
 async function readBufferedGeminiAudio(env, payload, options = {}) {
@@ -380,16 +398,24 @@ async function readBufferedGeminiAudio(env, payload, options = {}) {
 
   for (const extension of BUFFERED_AUDIO_EXTENSIONS) {
     const key = bufferedAudioKey(metadata, extension);
-    const fallbackKey = extension === 'mp3' ? legacyBufferedAudioKey(metadata, extension) : '';
+    const fallbackKey = extension === 'mp3' ? legacyBufferedAudioKey(metadata, extension) : null;
     let object = null;
     let objectKey = key;
+    let source = 'primary';
     try {
       object = await bucket.get(key);
       if (!object && fallbackKey) {
         object = await bucket.get(fallbackKey);
         objectKey = fallbackKey;
+        if (object) source = 'legacy';
       }
-    } catch {
+    } catch (error) {
+      console.error('[ks2-tts] R2 audio read failed', {
+        extension,
+        keyKind: metadata.kind || 'sentence',
+        triedFallback: Boolean(fallbackKey),
+        ...audioCacheErrorFields(error),
+      });
       return {
         object: null,
         metadata,
@@ -400,12 +426,16 @@ async function readBufferedGeminiAudio(env, payload, options = {}) {
       };
     }
     if (!object) continue;
+    const responseMetadata = source === 'legacy'
+      ? { ...metadata, model: SPELLING_AUDIO_MODEL }
+      : metadata;
     return {
       object,
-      metadata,
+      metadata: responseMetadata,
       key: objectKey,
       extension,
       contentType: objectContentType(object, extension),
+      source,
     };
   }
   return {
@@ -424,6 +454,7 @@ function cachedGeminiAudioResponse(cacheHit) {
       metadata: cacheHit.metadata,
       cacheState: 'hit',
       contentType: cacheHit.contentType,
+      cacheSource: cacheHit.source,
     }),
   });
 }
@@ -435,6 +466,7 @@ function cacheOnlyResponse(cacheState, cacheHit = null) {
   });
   if (cacheHit?.metadata?.model) headers.set('x-ks2-tts-model', cacheHit.metadata.model);
   if (cacheHit?.metadata?.voice) headers.set('x-ks2-tts-voice', cacheHit.metadata.voice);
+  if (cacheHit?.source) headers.set('x-ks2-tts-cache-source', cacheHit.source);
   return new Response(null, { status: 204, headers });
 }
 
@@ -502,7 +534,12 @@ async function storeBufferedGeminiAudio(env, payload, response, options = {}) {
       key: cacheSlot.key,
       metadata: cacheSlot.metadata,
     };
-  } catch {
+  } catch (error) {
+    console.error('[ks2-tts] R2 audio write failed', {
+      extension: cacheSlot.extension,
+      keyKind: cacheSlot.metadata.kind || 'sentence',
+      ...audioCacheErrorFields(error),
+    });
     const headers = new Headers(response.headers);
     headers.set('x-ks2-tts-cache', 'store_failed');
     return {


### PR DESCRIPTION
## Summary
- allow word-bank word-only TTS cues to use the cached Gemini lookup/store path
- add a word-audio R2 key contract and metadata for pre-cached vocabulary playback
- fall back to the legacy sentence-audio R2 path so existing batch-generated files can be served by the current content-keyed Worker contract
- add R2 read/write failure logging, legacy cache-source reporting, and word-only quota/cache regression coverage

## Review follow-up
- R2 read/write failures now emit bounded `[ks2-tts]` logs while preserving fallback/store_failed behaviour
- legacy fallback ignores model overrides and reports `x-ks2-tts-cache-source: legacy`
- word-only lookup hits, cold stores, cache-only warmups, cross-account reuse, no-legacy probes, and store failures are covered in Worker tests
- React word-bank does not mount fan-out cache warmups; cache-only warmup is only triggered after `tts.speak()`

## Verification
- node --check shared/spelling-audio.js && node --check worker/src/tts.js && node --check src/subjects/spelling/tts.js
- node --test tests/spelling-tts.test.js tests/worker-tts.test.js (49/49)
- git diff --check
- npm run check

## Notes
- npm test previously had 3 unrelated failures outside this PR diff: grammar production smoke forbidden-key fixture, punctuation wrangler JSON parse, and worker capacity overhead benchmark.