### PR TITLE
docs(grammar): U11 answer-spec migration audit (inventory)

### DIFF
--- a/docs/plans/james/grammar/grammar-answer-spec-audit.md
+++ b/docs/plans/james/grammar/grammar-answer-spec-audit.md
@@ -1,0 +1,213 @@
+---
+title: "Grammar answer-spec migration audit (inventory only)"
+type: audit
+status: inventory
+date: 2026-04-26
+plan: docs/plans/2026-04-26-001-feat-grammar-phase4-learning-hardening-plan.md
+unit: U11
+---
+
+# Grammar answer-spec migration audit (inventory only)
+
+This document is the per-template classification Phase 5 will execute against. It inventories every one of the 51 Grammar templates (31 selected-response + 20 constructed-response) with the target `answerSpec.kind`, a golden accepted answer, near-miss examples that must be rejected, and migration priority. Phase 4 ships **zero** template code changes and does **not** bump `contentReleaseId`; Phase 5 picks this list up and migrates one template at a time, pairing every marking-behaviour change with an oracle-fixture refresh and a `contentReleaseId` bump.
+
+The authoritative answer-spec kind list lives at `worker/src/subjects/grammar/answer-spec.js` (`ANSWER_SPEC_KINDS`). The six kinds are: `exact`, `normalisedText`, `acceptedSet`, `punctuationPattern`, `multiField`, `manualReviewOnly`. Every row below proposes one of those kinds; the gate test asserts the set membership.
+
+This audit is a read-only pass over `worker/src/subjects/grammar/content.js`. It does not modify `content.js`, does not touch `answer-spec.js`, and does not touch any oracle fixture.
+
+---
+
+## 1. Scope and ground rules
+
+- **51 templates total.** Confirmed by `GRAMMAR_TEMPLATES.length === 51` in `worker/src/subjects/grammar/content.js`. Split: 31 `isSelectedResponse: true`, 20 `isSelectedResponse: false`.
+- **Zero template code changes.** Proposed specs are Phase 5 backlog only.
+- **Zero `contentReleaseId` bump.** Any Phase 5 PR that changes marking behaviour (new accepted variants, stricter near-miss rejection, migration from `acceptedSet` adapter to declarative `punctuationPattern`) bumps `contentReleaseId` and refreshes the paired oracle fixture. Phase 4 touches neither.
+- **Thin-pool concepts drive priority.** Six concepts are confirmed thin-pool (from U12 ground truth): `pronouns_cohesion`, `formality`, `active_passive`, `subject_object`, `modal_verbs`, `hyphen_ambiguity`. Every template carrying one of these concept ids in `skillIds` inherits **high** priority, so that any Phase 5 reliability improvement lands on the fragile concepts first.
+- **Selected-response default is `exact`.** All 31 single-choice / checkbox-list / table-choice / multi templates are already marked by option-value equality today. Proposing `exact` is an additive migration: the marking result is byte-identical, so Phase 5 can ship these as a single no-`contentReleaseId`-impact batch if an oracle-fixture refresh proves the shape.
+- **Constructed-response triage is per-concept.** Rewrite templates for `active_passive` and `tense_aspect` migrate to `normalisedText` (whitespace + case tolerance, single golden). Punctuation-surgery templates migrate to `punctuationPattern` (the marker keeps the punctuation characters literal and can opt into `optionalCommas`). Multi-way rewrites (`clauses` combine / join) stay `acceptedSet` until Phase 5 has time to enumerate equivalence classes. Open-ended builders and ambiguous rewrites flag as `manualReviewOnly` candidates for Phase 5 to re-evaluate once the thin-pool concepts have expanded.
+
+---
+
+## 2. Template classification table
+
+Every row records: template id, concept id(s), question type, current marking path, proposed `answerSpec.kind`, a golden accepted answer, at least one near-miss that must be rejected, priority, and whether the migration requires a `contentReleaseId` bump.
+
+Current marking path column legend:
+- `selected: index match` — `isSelectedResponse: true`, the generator's `evaluate` closure compares `resp.answer === item.correct`.
+- `adapter: markStringAnswer` — `isSelectedResponse: false`, the generator's `evaluate` closure calls `markStringAnswer(respText, accepted, opts)`, which constructs a transient `acceptedSet` spec and delegates to `markByAnswerSpec`.
+
+Priority column legend: `high` (thin-pool concept or structurally fragile marking), `medium` (constructed-response migration needs a spec-kind change), `low` (additive migration, no marking-behaviour change).
+
+`Release-id bump` column legend: `YES` when Phase 5 migration changes marking behaviour (new near-miss rejections, new accepted variants, or kind change that alters accept/reject outcomes for stored attempts); `NO` when the migration is purely declarative and preserves accept/reject for every existing attempt.
+
+| Template id | Concept id(s) | Question type | Current marking path | Proposed `answerSpec.kind` | Golden accepted | Near-miss to reject | Priority | Release-id bump |
+|---|---|---|---|---|---|---|---|---|
+| `sentence_type_table` | `sentence_functions` | classify | selected: index match | `exact` | per-row option value (e.g. `statement`) | `Statement` (wrong case); `statement.` (trailing dot) | low | NO |
+| `question_mark_select` | `sentence_functions`, `speech_punctuation` | identify | selected: index match | `exact` | per-checkbox option value (e.g. `Can you help me carry the boxes`) | `can you help me carry the boxes` (wrong case); `Can you help me carry the boxes?` (trailing `?`) | low | NO |
+| `word_class_underlined_choice` | `word_classes` | identify | selected: index match | `exact` | `adjective` | `Adjective` (wrong case); `adjectives` (plural) | low | NO |
+| `identify_words_in_sentence` | `word_classes` | identify | selected: index match | `exact` | each checkbox value (e.g. `carefully`) | `Carefully` (wrong case); `carefully.` (trailing dot) | low | NO |
+| `expanded_noun_phrase_choice` | `noun_phrases` | choose | selected: index match | `exact` | `the silver key under the mat` | `the silver key, under the mat` (stray comma); `The silver key under the mat` (wrong case) | low | NO |
+| `build_noun_phrase` | `noun_phrases` | build | adapter: markStringAnswer | `manualReviewOnly` | `The tall captain with curly hair.` | `the tall captain with curly hair` (creative variant — should NOT be auto-rejected); `A curly-haired tall captain.` (valid alternative phrasing) | medium | YES |
+| `fronted_adverbial_choose` | `adverbials` | choose | selected: index match | `exact` | `After dinner, Kal is going to her room.` | `After dinner Kal is going to her room.` (missing comma); `After dinner, Kal is going to her room` (missing full stop) | low | NO |
+| `fix_fronted_adverbial` | `adverbials` | fix | adapter: markStringAnswer | `punctuationPattern` | `Before sunrise, the campers packed their bags.` | `Before sunrise the campers packed their bags.` (missing comma); `Before, sunrise the campers packed their bags.` (comma in wrong place) | medium | YES |
+| `subordinate_clause_choice` | `clauses` | identify | selected: index match | `exact` | `Although the wind was strong` | `although the wind was strong` (wrong case); `Although the wind was strong.` (trailing dot) | low | NO |
+| `combine_clauses_rewrite` | `clauses` | rewrite | adapter: markStringAnswer | `acceptedSet` | `Although Mia was tired, she finished the race.` (also accepts `Mia finished the race although she was tired.`) | `Mia finished the race although tired.` (ellipted subject); `Although Mia was tired she finished the race` (missing comma and full stop — partial credit under punctuation-precision, not accept) | medium | YES |
+| `relative_clause_identify` | `relative_clauses` | choose | selected: index match | `exact` | `The boy who dropped his hat waved to us.` | `The boy, who dropped his hat, waved to us.` (non-defining punctuation); `The boy who dropped his hat waved to us` (missing full stop) | low | NO |
+| `relative_clause_complete` | `relative_clauses` | build | selected: index match | `exact` | `that was locked outside` | `that locked outside` (missing auxiliary); `that was locked outside.` (trailing dot) | low | NO |
+| `tense_form_choice` | `tense_aspect` | fill | selected: index match | `exact` | `had / started` | `had started` (no separator); `had  /  started` (extra whitespace) | low | NO |
+| `tense_rewrite` | `tense_aspect` | rewrite | adapter: markStringAnswer | `normalisedText` | `The dog was chasing the cat.` | `The dog chased the cat.` (simple past instead of past progressive); `The dog is chasing the cat.` (present progressive) | medium | YES |
+| `standard_english_pairs` | `standard_english` | choose | selected: index match | `exact` | `were; did` (per pair order) | `were, did` (wrong separator); `was; done` (wrong non-standard forms) | low | NO |
+| `pronoun_cohesion_choice` | `pronouns_cohesion` | choose | selected: index match | `exact` | `Mila put her coat on the chair before she zipped her bag.` | `Mila put her coat on the chair before zipping her bag.` (non-finite variant); `Mila put her coat on the chair before Mila zipped her bag.` (repeated noun — the target is cohesive pronoun use) | high | NO |
+| `formality_pairs` | `formality` | choose | selected: index match | `exact` | `established; requested; compete` (per-triple order) | `established, requested, compete` (wrong separator); `made; asked; compete` (informal variants) | high | NO |
+| `active_passive_rewrite` | `active_passive` | rewrite | adapter: markStringAnswer | `normalisedText` | `The council maintains the local park.` | `The local park is maintained by the council.` (original sentence — not a rewrite); `The local park was maintained by the council.` (tense drift) | high | YES |
+| `subject_object_choice` | `subject_object` | identify | selected: index match | `exact` | `the tired goalkeeper` | `tired goalkeeper` (missing determiner); `the tired goalkeeper.` (trailing dot) | high | NO |
+| `modal_verb_choice` | `modal_verbs` | choose | selected: index match | `exact` | `The team might win.` | `The team may win.` (close-meaning modal — but `might` is the targeted form); `The team might wins.` (agreement slip) | high | NO |
+| `parenthesis_replace_choice` | `parenthesis_commas` | choose | selected: index match | `exact` | `dashes` | `dash` (singular); `Dashes` (wrong case) | low | NO |
+| `parenthesis_fix_sentence` | `parenthesis_commas` | fix | adapter: markStringAnswer | `punctuationPattern` | `Our class visited a castle (the oldest in the county) to help with our history project.` | `Our class visited a castle the oldest in the county to help with our history project.` (no brackets); `Our class visited a castle, the oldest in the county, to help with our history project.` (wrong punctuation family — commas instead of brackets) | medium | YES |
+| `speech_punctuation_fix` | `speech_punctuation` | fix | adapter: markStringAnswer | `punctuationPattern` | `“Where are you going?” asked Mum.` | `"Where are you going?" asked Mum.` (straight quotes instead of curly — same pattern, likely accept; retain as candidate for `params.optionalQuoteStyle` Phase 5 knob); `Where are you going? asked Mum.` (missing quotation marks entirely) | medium | YES |
+| `apostrophe_possession_choice` | `apostrophes_possession` | choose | selected: index match | `exact` | `girls'` | `girl's` (singular possessive); `girls` (no apostrophe) | low | NO |
+| `explain_reason_choice` | `adverbials`, `standard_english` | explain | selected: index match | `exact` | `Because the opening words are a fronted adverbial.` | `Because the opening words are fronted adverbials.` (plural noun drift); `Because of the fronted adverbial.` (shortened variant) | medium | NO |
+| `standard_fix_sentence` | `standard_english` | fix | adapter: markStringAnswer | `manualReviewOnly` | `We were walking to school.` | `We was walking to school.` (original non-standard); `We are walking to school.` (tense drift — valid alternative rewrite that preserves Standard English; flag for manual review) | medium | YES |
+| `proc_fronted_adverbial_fix` | `adverbials` | fix | adapter: markStringAnswer | `punctuationPattern` | `Without warning, Zac lifted the picnic basket.` | `Without warning Zac lifted the picnic basket.` (missing comma); `Without, warning Zac lifted the picnic basket.` (comma misplaced) | medium | YES |
+| `proc_semicolon_choice` | `boundary_punctuation` | choose | selected: index match | `exact` | `;` | `:` (colon, wrong boundary mark); `,` (comma splice) | low | NO |
+| `proc_colon_list_fix` | `boundary_punctuation` | fix | adapter: markStringAnswer | `punctuationPattern` | `We still needed two items for camp: a torch, a sleeping bag.` | `We still needed two items for camp; a torch, a sleeping bag.` (semi-colon instead of colon); `We still needed two items for camp, a torch, a sleeping bag.` (comma — no list introducer) | medium | YES |
+| `proc_dash_boundary_fix` | `boundary_punctuation` | fix | adapter: markStringAnswer | `punctuationPattern` | `There was only one answer – turn back at once.` | `There was only one answer - turn back at once.` (hyphen-minus instead of en-dash — candidate for `params.acceptHyphenMinus` Phase 5 knob); `There was only one answer, turn back at once.` (comma splice) | medium | YES |
+| `proc_hyphen_ambiguity_choice` | `hyphen_ambiguity` | choose | selected: index match | `exact` | `We saw a man-eating shark near the rocks.` | `We saw a man eating shark near the rocks.` (missing hyphen — changes meaning); `We saw a man-eating-shark near the rocks.` (over-hyphenation) | high | NO |
+| `proc_speech_punctuation_fix` | `speech_punctuation` | fix | adapter: markStringAnswer | `punctuationPattern` | `"When does the match begin?" shouted Ben.` | `"When does the match begin" shouted Ben.` (missing question mark); `"When does the match begin?" Shouted Ben.` (wrong reporting-verb case) | medium | YES |
+| `proc_apostrophe_possession_choice` | `apostrophes_possession` | choose | selected: index match | `exact` | `the teacher's coats` | `the teachers coats` (no apostrophe); `the teachers' coats` (plural possessive — different meaning) | low | NO |
+| `proc2_standard_english_choice` | `standard_english` | choose | selected: index match | `exact` | `Zac doesn't know how to fold the map.` | `Zac don't know how to fold the map.` (non-standard form); `Zac doesn't knows how to fold the map.` (agreement slip) | low | NO |
+| `proc2_standard_english_fix` | `standard_english` | fix | adapter: markStringAnswer | `normalisedText` | `Zac doesn't know how to fold the map.` | `Zac don't know how to fold the map.` (original non-standard); `Zac does not know how to fold the map.` (full form — accepted as Phase 5 variant under `acceptedSet` migration) | medium | YES |
+| `proc2_tense_aspect_choice` | `tense_aspect` | fill | selected: index match | `exact` | `have finished` | `has finished` (wrong agreement); `had finished` (wrong tense — past perfect) | low | NO |
+| `proc2_modal_choice` | `modal_verbs` | fill | selected: index match | `exact` | `should` | `Should` (wrong case); `shall` (close-meaning modal but wrong targeted form) | high | NO |
+| `proc2_formality_choice` | `formality` | choose | selected: index match | `exact` | `The club was established last year.` | `The club was set up last year.` (informal variant); `The club got established last year.` (colloquial passive) | high | NO |
+| `proc2_pronoun_cohesion_choice` | `pronouns_cohesion` | choose | selected: index match | `exact` | `Amira gave Elsie the note because Elsie needed it for the next lesson.` | `Amira gave Elsie the note because she needed it for the next lesson.` (ambiguous pronoun — the target is disambiguated reference); `Amira gave Elsie the note because Elsie needed it.` (truncated — loses the cohesive tail) | high | NO |
+| `proc2_subject_object_identify` | `subject_object` | identify | selected: index match | `exact` | `Zac` | `Zac.` (trailing dot); `zac` (wrong case) | high | NO |
+| `proc2_passive_to_active` | `active_passive` | rewrite | adapter: markStringAnswer | `normalisedText` | `Amira cleaned the trophy after the match.` | `The trophy was cleaned by Amira after the match.` (original passive); `Amira cleans the trophy after the match.` (tense drift) | high | YES |
+| `proc2_relative_clause_choice` | `relative_clauses` | identify | selected: index match | `exact` | `The bag which stood by the window was easy to spot.` | `The bag, which stood by the window, was easy to spot.` (non-defining punctuation); `The bag that stood by the window was easy to spot.` (relative pronoun variant — target is `which`) | low | NO |
+| `proc2_fronted_adverbial_build` | `adverbials` | build | adapter: markStringAnswer | `manualReviewOnly` | `Without warning, Zac lifted the picnic basket.` | `Zac lifted the picnic basket without warning.` (grammatically correct but does NOT use a fronted adverbial — the target is the fronted structure); `Without warning Zac lifted the picnic basket.` (missing comma — partial credit candidate, not accept) | medium | YES |
+| `proc2_boundary_punctuation_explain` | `boundary_punctuation` | explain | selected: index match | `exact` | `A semi-colon can join two closely related main clauses.` | `A semi-colon joins two sentences.` (close but imprecise); `A colon can join two closely related main clauses.` (wrong punctuation mark) | medium | NO |
+| `proc3_sentence_function_choice` | `sentence_functions` | choose | selected: index match | `exact` | `Bring the blue folder to the hall.` | `Bring the blue folder to the hall` (missing full stop); `Bring the blue folder to the hall!` (exclamation instead of command terminator) | low | NO |
+| `proc3_word_class_contrast_choice` | `word_classes` | choose | selected: index match | `exact` | `preposition` | `Preposition` (wrong case); `prepositions` (plural) | low | NO |
+| `proc3_noun_phrase_build` | `noun_phrases` | build | adapter: markStringAnswer | `manualReviewOnly` | `the heavy red rucksack` | `red heavy rucksack` (wrong adjective order — English convention rejects this); `the rucksack heavy red` (wrong phrase order) | medium | YES |
+| `proc3_clause_join_rewrite` | `clauses` | rewrite | adapter: markStringAnswer | `acceptedSet` | `When the gate opened, the crowd cheered.` (also accepts `The crowd cheered when the gate opened.`) | `The gate opened and the crowd cheered.` (coordination instead of subordination — target is `when`); `When the gate opened the crowd cheered` (missing comma and full stop — partial credit, not accept) | medium | YES |
+| `proc3_parenthesis_commas_fix` | `parenthesis_commas` | fix | adapter: markStringAnswer | `punctuationPattern` | `Our new puppy, to my surprise, slept through the storm.` | `Our new puppy to my surprise slept through the storm.` (no commas); `Our new puppy (to my surprise) slept through the storm.` (wrong punctuation family — target is commas) | medium | YES |
+| `proc3_hyphen_fix_meaning` | `hyphen_ambiguity` | fix | adapter: markStringAnswer | `punctuationPattern` | `The class made a last-minute poster for the hall.` | `The class made a last minute poster for the hall.` (no hyphen — ambiguous); `The class made a last-minute-poster for the hall.` (over-hyphenation) | high | YES |
+| `proc3_apostrophe_rewrite` | `apostrophes_possession` | rewrite | adapter: markStringAnswer | `normalisedText` | `the farmers' coats` | `the farmer's coats` (singular possessive — different meaning); `the farmers coats` (no apostrophe) | medium | YES |
+
+### 2.1 Row count reconciliation
+
+The table above has exactly **51 rows**, one per template. The doc-gate test (§6) parses this table and asserts `rows.length === 51` and that every proposed kind is in `ANSWER_SPEC_KINDS`.
+
+### 2.2 Proposed-spec distribution
+
+- `exact`: **31** rows (all selected-response templates).
+- `normalisedText`: **5** rows (`tense_rewrite`, `active_passive_rewrite`, `proc2_standard_english_fix`, `proc2_passive_to_active`, `proc3_apostrophe_rewrite`).
+- `acceptedSet`: **2** rows (`combine_clauses_rewrite`, `proc3_clause_join_rewrite`).
+- `punctuationPattern`: **9** rows (every punctuation-surgery fix template: `fix_fronted_adverbial`, `parenthesis_fix_sentence`, `speech_punctuation_fix`, `proc_fronted_adverbial_fix`, `proc_colon_list_fix`, `proc_dash_boundary_fix`, `proc_speech_punctuation_fix`, `proc3_parenthesis_commas_fix`, `proc3_hyphen_fix_meaning`).
+- `multiField`: **0** rows (no current template splits a response into named sub-fields; reserved for Phase 5+ expansion).
+- `manualReviewOnly`: **4** rows in the table (`build_noun_phrase`, `standard_fix_sentence`, `proc2_fronted_adverbial_build`, `proc3_noun_phrase_build`). §3 additionally flags **2** explain templates as Phase 5 re-evaluation candidates for migration to `manualReviewOnly` once they become free-text, lifting the candidate list to **6**.
+
+Totals: 31 + 5 + 2 + 9 + 0 + 4 = 51.
+
+### 2.3 Constructed-response triage summary
+
+| Concept family | Template id(s) | Proposed kind | Rationale |
+|---|---|---|---|
+| `active_passive` rewrite | `active_passive_rewrite`, `proc2_passive_to_active` | `normalisedText` | Single fixture golden per seed; whitespace and case tolerance is correct marking; no multi-way enumeration needed. |
+| `tense_aspect` rewrite | `tense_rewrite` | `normalisedText` | Fixture golden is a single targeted form; other tenses are wrong-target, not near-miss. |
+| `apostrophes_possession` rewrite | `proc3_apostrophe_rewrite` | `normalisedText` | Single golden phrase; whitespace/case tolerance is safe. |
+| `standard_english` fix (word-level) | `proc2_standard_english_fix` | `normalisedText` | Single fixture golden; full-form expansion (`does not` vs `doesn't`) is the one multi-way variant — deferred to Phase 5 `acceptedSet` upgrade if needed. |
+| `standard_english` fix (sentence-level) | `standard_fix_sentence` | `manualReviewOnly` | Multiple valid Standard English rewrites of the same non-standard input; teacher judgement needed to distinguish register-correct from content-preserving paraphrase. |
+| `clauses` combine / join | `combine_clauses_rewrite`, `proc3_clause_join_rewrite` | `acceptedSet` | Fixture already lists ≥ 2 valid orderings per seed; keeps partial-credit path for punctuation-only near-misses. |
+| `adverbials` fix (comma surgery) | `fix_fronted_adverbial`, `proc_fronted_adverbial_fix` | `punctuationPattern` | Punctuation-sensitive; accepts byte-identical pattern only; `optionalCommas` knob unused. |
+| `parenthesis_commas` surgery | `parenthesis_fix_sentence`, `proc3_parenthesis_commas_fix` | `punctuationPattern` | Punctuation-sensitive; the bracket variant uses literal `(` `)`, the comma variant uses literal `,`. |
+| `speech_punctuation` surgery | `speech_punctuation_fix`, `proc_speech_punctuation_fix` | `punctuationPattern` | Punctuation-sensitive; curly vs straight quote style flagged for a Phase 5 `params.acceptQuoteStyle` knob. |
+| `boundary_punctuation` surgery | `proc_colon_list_fix`, `proc_dash_boundary_fix` | `punctuationPattern` | Punctuation-sensitive; dash variant flagged for a Phase 5 `params.acceptHyphenMinus` knob. |
+| `hyphen_ambiguity` surgery | `proc3_hyphen_fix_meaning` | `punctuationPattern` | Punctuation-sensitive; hyphen presence changes meaning, so `optionalHyphen` must stay **false**. |
+| Open-ended builders | `build_noun_phrase`, `proc2_fronted_adverbial_build`, `proc3_noun_phrase_build` | `manualReviewOnly` | Free-form construction; multiple linguistically valid answers the fixture cannot enumerate; `acceptedSet` would produce false negatives. |
+
+---
+
+## 3. Manual-review-only candidates (≥ 5)
+
+Phase 5 should land `manualReviewOnly` for at least these candidates before enabling a declarative-only content-release PR. The doc-gate test asserts this list contains **at least 5** entries.
+
+1. `build_noun_phrase` — open-ended builder; any syntactically valid expanded noun phrase with three+ words should count, but the fixture cannot enumerate every adjective/post-modifier combination.
+2. `proc2_fronted_adverbial_build` — free-form sentence building; many valid rewrites preserve the fronted-adverbial target.
+3. `proc3_noun_phrase_build` — re-ordering fragments into an expanded noun phrase; adjective-order variations are all valid when English convention allows.
+4. `standard_fix_sentence` — Standard English rewrites where multiple register-correct paraphrases exist (`We were walking to school.` vs `We walked to school.`); teacher judgement preferred.
+5. `explain_reason_choice` — today a selected-response single-choice, but flagged for Phase 5 re-evaluation: if it migrates to free-text explanation in a future content-release PR, the target kind is `manualReviewOnly` because explanations admit many valid phrasings.
+6. `proc2_boundary_punctuation_explain` — same reasoning as above; today selected-response, but a free-text explanation migration would shift it to `manualReviewOnly`.
+
+---
+
+## 4. Thin-pool concept priority (high)
+
+The six concepts below are confirmed thin-pool (Phase 4 U12 ground truth) and **must** all appear high-priority in Phase 5's migration ordering. Every template carrying one of these concept ids in its `skillIds` inherits **high** priority in the table above.
+
+1. `pronouns_cohesion`
+2. `formality`
+3. `active_passive`
+4. `subject_object`
+5. `modal_verbs`
+6. `hyphen_ambiguity`
+
+The doc-gate test asserts every one of these six concept ids appears in the Phase 5 high-priority section and that the table rows tagged high match this set (plus their associated templates).
+
+Why high priority on thin-pool concepts specifically: each concept has fewer templates in the bank, so any marking fragility on one template disproportionately poisons the concept's mastery signal. Fixing answer-spec fragility here first maximises the learning-integrity return per Phase 5 PR.
+
+---
+
+## 5. `contentReleaseId` impact matrix
+
+Every row where marking behaviour changes bumps `contentReleaseId` and invalidates stored attempt evidence against the prior release. Rows that are purely declarative (selected-response → `exact`, where the mark result is byte-identical for every stored attempt) do not bump.
+
+- **Rows requiring `contentReleaseId` bump: 20.** Every row marked `YES` in the table — all 20 constructed-response templates. Phase 5 should batch these per-concept so one content-release PR covers all templates for a given skill (e.g. one PR for `punctuation_*` surgery, one for `active_passive`, one for `standard_english`). Every such PR pairs with a `tests/fixtures/oracle-grammar-*.json` refresh.
+- **Rows NOT requiring `contentReleaseId` bump: 31.** Every selected-response row marked `NO` — the shift from `item.correct === resp.answer` to `markByAnswerSpec({kind: 'exact', golden: [item.correct]})` produces byte-identical mark results. Phase 5 can ship these in a single batch PR with no release-id bump, as long as the oracle fixture re-verifies the shape.
+- **`explain_reason_choice` and `proc2_boundary_punctuation_explain`:** flagged `medium` priority and `NO` bump because today they are selected-response. If Phase 5 migrates them to free-text explanation, that migration **is** a marking-behaviour change and bumps `contentReleaseId` at that time.
+- **`build_noun_phrase`, `standard_fix_sentence`, `proc2_fronted_adverbial_build`, `proc3_noun_phrase_build`:** `manualReviewOnly` migration **always** bumps `contentReleaseId`: the mark result shifts from `correct: true/false, score: 0..2` (adapter path) to `correct: false, score: 0, maxScore: 0` (manual-review path). Every stored attempt would need a mastery-signal downgrade, so the release-id bump is non-negotiable.
+
+---
+
+## 6. Doc-gate test contract
+
+The test file `tests/grammar-answer-spec-audit.test.js` enforces the following invariants. Any Phase 5 PR touching this doc must keep them green.
+
+- **Doc exists.** `docs/plans/james/grammar/grammar-answer-spec-audit.md` is readable.
+- **Row count.** The classification table in §2 parses to exactly **51** rows.
+- **Template id coverage.** Every template id in the table exists in `GRAMMAR_TEMPLATES` (imported from `worker/src/subjects/grammar/content.js`); no typos, no orphaned rows.
+- **Kind validity.** Every proposed `answerSpec.kind` in the table is in `ANSWER_SPEC_KINDS` (imported from `worker/src/subjects/grammar/answer-spec.js`).
+- **Manual-review-only floor.** §3 lists **at least 5** `manualReviewOnly` candidates.
+- **Thin-pool coverage.** §4 lists all six thin-pool concept ids: `pronouns_cohesion`, `formality`, `active_passive`, `subject_object`, `modal_verbs`, `hyphen_ambiguity`.
+
+The test file does **not** touch `content.js`, `answer-spec.js`, or any oracle fixture. It is a pure doc gate.
+
+---
+
+## 7. Phase 5 execution notes (out of scope for this PR)
+
+These notes guide the Phase 5 backlog and are not enforced by this doc gate:
+
+- **One template per content-release PR** unless the PR batches templates under the same concept with an identical marking-behaviour change. Paired oracle-fixture refresh per PR.
+- **Migration ordering suggestion.**
+  1. Thin-pool `active_passive` rewrites (`normalisedText`) — 2 templates.
+  2. Thin-pool `hyphen_ambiguity` surgery (`punctuationPattern`) — 1 template (`proc3_hyphen_fix_meaning`).
+  3. Remaining punctuation-surgery templates (`punctuationPattern`) — 7 templates.
+  4. Remaining rewrites (`normalisedText`) — 3 templates.
+  5. Clause combine/join (`acceptedSet`) — 2 templates.
+  6. Builders + ambiguous fixes (`manualReviewOnly`) — 4 templates.
+  7. Selected-response batch (`exact`) — 31 templates in one PR.
+  8. Explain-template re-evaluation (potential `manualReviewOnly` migration if they move to free-text) — deferred to Phase 6+ content-expansion work.
+- **Each Phase 5 PR** must land a new row in `tests/fixtures/grammar-phase5-answer-spec-migration/*.json` (per-template migration evidence) plus an `ownerUnit` + `landedIn: "PR #<num>"` row in the Phase 5 baseline. Phase 4's completeness gate (U13) does **not** read these; a new Phase 5 gate will.
+- **`params` usage.** Reserved parameters flagged above (`params.optionalCommas`, `params.acceptHyphenMinus`, `params.acceptQuoteStyle`) are Phase 5 enhancements. None are required for the first migration wave — drop them and rely on declared golden strings matching fixture output byte-for-byte.
+
+---
+
+## 8. References
+
+- Plan: `docs/plans/2026-04-26-001-feat-grammar-phase4-learning-hardening-plan.md` — U11 section.
+- Source of truth: `worker/src/subjects/grammar/content.js` (`GRAMMAR_TEMPLATES`).
+- Answer-spec module: `worker/src/subjects/grammar/answer-spec.js` (`ANSWER_SPEC_KINDS`, `markByAnswerSpec`, `validateAnswerSpec`).
+- Phase 3 deferral of record: `docs/plans/james/grammar/grammar-phase3-implementation-report.md` §5 item 5.
+- Phase 2 deferral of record: `docs/plans/james/grammar/grammar-phase2-implementation-report.md` §U5 scope decision.
+- Invariants: `docs/plans/james/grammar/grammar-phase4-invariants.md` (Invariant 4: AI is post-marking enrichment only — scored specs contain only deterministic template output).

--- a/tests/grammar-answer-spec-audit.test.js
+++ b/tests/grammar-answer-spec-audit.test.js
@@ -1,0 +1,276 @@
+// Phase 4 U11 — Answer-spec migration audit doc gate.
+//
+// This test file is a pure documentation gate. It asserts that
+// `docs/plans/james/grammar/grammar-answer-spec-audit.md` exists, has exactly
+// one row per grammar template (51 rows total), every proposed
+// `answerSpec.kind` belongs to `ANSWER_SPEC_KINDS`, every template id in the
+// doc exists in `GRAMMAR_TEMPLATES`, the manual-review-only candidate list
+// contains at least 5 entries, and all six thin-pool concepts are flagged
+// high-priority. The test does NOT touch `content.js`, `answer-spec.js`, or
+// any oracle fixture — the audit is inventory-only; Phase 5 executes the
+// migration one template at a time.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { ANSWER_SPEC_KINDS } from '../worker/src/subjects/grammar/answer-spec.js';
+import { GRAMMAR_TEMPLATES } from '../worker/src/subjects/grammar/content.js';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const auditDocPath = path.join(rootDir, 'docs/plans/james/grammar/grammar-answer-spec-audit.md');
+
+const THIN_POOL_CONCEPTS = [
+  'pronouns_cohesion',
+  'formality',
+  'active_passive',
+  'subject_object',
+  'modal_verbs',
+  'hyphen_ambiguity',
+];
+
+function readAuditDoc() {
+  return fs.readFileSync(auditDocPath, 'utf8');
+}
+
+function extractClassificationTableRows(doc) {
+  // Locate the classification table by its pipe header. The header row starts
+  // with `| Template id`. The table ends at the first line that does not
+  // begin with `|`. The first two lines after the header are the column
+  // separator row and the actual data rows.
+  const lines = doc.split(/\r?\n/);
+  const headerIdx = lines.findIndex((line) => line.startsWith('| Template id'));
+  assert.notEqual(headerIdx, -1, 'Classification table header not found in audit doc.');
+  const startIdx = headerIdx + 2; // skip header + separator row
+  let endIdx = startIdx;
+  while (endIdx < lines.length && lines[endIdx].startsWith('|')) {
+    endIdx += 1;
+  }
+  return lines.slice(startIdx, endIdx).map((line) => {
+    const cells = line.split('|').map((cell) => cell.trim());
+    // Pipe-delimited Markdown tables have a leading and trailing empty cell.
+    return {
+      id: cells[1].replace(/`/g, ''),
+      concepts: cells[2],
+      questionType: cells[3].replace(/`/g, ''),
+      currentMarkingPath: cells[4],
+      proposedKind: cells[5].replace(/`/g, ''),
+      golden: cells[6],
+      nearMiss: cells[7],
+      priority: cells[8].toLowerCase(),
+      releaseBump: cells[9],
+    };
+  });
+}
+
+function extractManualReviewCandidatesSection(doc) {
+  // Section 3 title: "## 3. Manual-review-only candidates (≥ 5)".
+  // Candidate list items start with a digit + dot and carry a backtick-wrapped
+  // template id at the head. Stop at the next `## ` heading.
+  const sectionStart = doc.indexOf('## 3. Manual-review-only candidates');
+  assert.notEqual(sectionStart, -1, 'Section 3 (manual-review-only candidates) not found.');
+  const after = doc.slice(sectionStart);
+  const sectionEnd = after.indexOf('\n## ');
+  const section = sectionEnd === -1 ? after : after.slice(0, sectionEnd);
+  const items = [];
+  for (const line of section.split(/\r?\n/)) {
+    const match = line.match(/^\d+\.\s+`([a-z0-9_]+)`/i);
+    if (match) items.push(match[1]);
+  }
+  return items;
+}
+
+function extractThinPoolConceptSection(doc) {
+  const sectionStart = doc.indexOf('## 4. Thin-pool concept priority');
+  assert.notEqual(sectionStart, -1, 'Section 4 (thin-pool concept priority) not found.');
+  const after = doc.slice(sectionStart);
+  const sectionEnd = after.indexOf('\n## ');
+  const section = sectionEnd === -1 ? after : after.slice(0, sectionEnd);
+  const concepts = [];
+  for (const line of section.split(/\r?\n/)) {
+    const match = line.match(/^\d+\.\s+`([a-z_]+)`/i);
+    if (match) concepts.push(match[1]);
+  }
+  return concepts;
+}
+
+test('audit doc exists on disk', () => {
+  assert.ok(
+    fs.existsSync(auditDocPath),
+    `audit doc should exist at ${path.relative(rootDir, auditDocPath)}`
+  );
+});
+
+test('classification table has exactly 51 rows — one per template', () => {
+  const doc = readAuditDoc();
+  const rows = extractClassificationTableRows(doc);
+  assert.equal(
+    rows.length,
+    51,
+    `Expected 51 classification rows, got ${rows.length}.`
+  );
+  assert.equal(
+    rows.length,
+    GRAMMAR_TEMPLATES.length,
+    'Audit row count must equal GRAMMAR_TEMPLATES.length.'
+  );
+});
+
+test('every proposed answerSpec.kind is in ANSWER_SPEC_KINDS', () => {
+  const doc = readAuditDoc();
+  const rows = extractClassificationTableRows(doc);
+  const validKinds = new Set(ANSWER_SPEC_KINDS);
+  for (const row of rows) {
+    assert.ok(
+      validKinds.has(row.proposedKind),
+      `Template ${row.id} proposes unknown kind: ${row.proposedKind}. ` +
+        `Valid kinds: ${ANSWER_SPEC_KINDS.join(', ')}.`
+    );
+  }
+});
+
+test('every template id in the audit doc exists in GRAMMAR_TEMPLATES', () => {
+  const doc = readAuditDoc();
+  const rows = extractClassificationTableRows(doc);
+  const templateIds = new Set(GRAMMAR_TEMPLATES.map((template) => template.id));
+  for (const row of rows) {
+    assert.ok(
+      templateIds.has(row.id),
+      `Audit row id "${row.id}" does not exist in GRAMMAR_TEMPLATES.`
+    );
+  }
+  // And reverse: no template is missing from the audit.
+  const auditIds = new Set(rows.map((row) => row.id));
+  for (const template of GRAMMAR_TEMPLATES) {
+    assert.ok(
+      auditIds.has(template.id),
+      `Template "${template.id}" from GRAMMAR_TEMPLATES is missing from the audit doc.`
+    );
+  }
+});
+
+test('no duplicate template ids in the audit doc', () => {
+  const doc = readAuditDoc();
+  const rows = extractClassificationTableRows(doc);
+  const seen = new Set();
+  for (const row of rows) {
+    assert.equal(
+      seen.has(row.id),
+      false,
+      `Duplicate audit row for template "${row.id}".`
+    );
+    seen.add(row.id);
+  }
+});
+
+test('audit lists at least 5 manual-review-only candidates in section 3', () => {
+  const doc = readAuditDoc();
+  const candidates = extractManualReviewCandidatesSection(doc);
+  assert.ok(
+    candidates.length >= 5,
+    `Section 3 must list at least 5 manual-review-only candidates, ` +
+      `got ${candidates.length}: ${candidates.join(', ')}`
+  );
+  // Every candidate in §3 must be a real template id.
+  const templateIds = new Set(GRAMMAR_TEMPLATES.map((template) => template.id));
+  for (const candidate of candidates) {
+    assert.ok(
+      templateIds.has(candidate),
+      `Manual-review candidate "${candidate}" is not a real template id.`
+    );
+  }
+});
+
+test('audit lists all 6 thin-pool concepts as high-priority in section 4', () => {
+  const doc = readAuditDoc();
+  const listed = extractThinPoolConceptSection(doc);
+  for (const concept of THIN_POOL_CONCEPTS) {
+    assert.ok(
+      listed.includes(concept),
+      `Section 4 must list thin-pool concept "${concept}". ` +
+        `Got: ${listed.join(', ')}`
+    );
+  }
+  assert.equal(
+    listed.length,
+    THIN_POOL_CONCEPTS.length,
+    `Section 4 must list exactly the 6 thin-pool concepts. ` +
+      `Got ${listed.length}: ${listed.join(', ')}`
+  );
+});
+
+test('every template carrying a thin-pool concept is priority=high', () => {
+  // Cross-check: the narrative says templates tagged with any of the six
+  // thin-pool concept ids inherit high priority. Catch drift between the
+  // narrative and the table.
+  const doc = readAuditDoc();
+  const rows = extractClassificationTableRows(doc);
+  const thinSet = new Set(THIN_POOL_CONCEPTS);
+  for (const template of GRAMMAR_TEMPLATES) {
+    const hasThin = template.skillIds.some((skill) => thinSet.has(skill));
+    if (!hasThin) continue;
+    const row = rows.find((candidate) => candidate.id === template.id);
+    assert.ok(row, `Audit row missing for thin-pool template ${template.id}.`);
+    assert.equal(
+      row.priority,
+      'high',
+      `Template "${template.id}" carries thin-pool concept(s) ` +
+        `${template.skillIds.filter((skill) => thinSet.has(skill)).join(', ')} ` +
+        `but audit priority is "${row.priority}" — expected "high".`
+    );
+  }
+});
+
+test('release-id bump is YES for every constructed-response row', () => {
+  // Every template with isSelectedResponse=false is routed through
+  // markStringAnswer today. Migrating to a declarative kind changes the mark
+  // result shape (manualReviewOnly) or narrows near-miss acceptance
+  // (punctuationPattern tightens vs. the acceptedSet adapter's bare-strip
+  // partial-credit path). Every such migration must bump contentReleaseId.
+  const doc = readAuditDoc();
+  const rows = extractClassificationTableRows(doc);
+  for (const template of GRAMMAR_TEMPLATES) {
+    if (template.isSelectedResponse) continue;
+    const row = rows.find((candidate) => candidate.id === template.id);
+    assert.ok(row, `Audit row missing for constructed-response template ${template.id}.`);
+    assert.equal(
+      row.releaseBump,
+      'YES',
+      `Constructed-response template "${template.id}" must have release-id bump = YES ` +
+        `(got "${row.releaseBump}") — every marking-behaviour change invalidates stored evidence.`
+    );
+  }
+});
+
+test('release-id bump is NO for every selected-response row', () => {
+  // Selected-response templates marked today by index-equality migrate to
+  // `exact` on option-value. Byte-identical mark result for every stored
+  // attempt, so no release-id bump is required.
+  const doc = readAuditDoc();
+  const rows = extractClassificationTableRows(doc);
+  for (const template of GRAMMAR_TEMPLATES) {
+    if (!template.isSelectedResponse) continue;
+    const row = rows.find((candidate) => candidate.id === template.id);
+    assert.ok(row, `Audit row missing for selected-response template ${template.id}.`);
+    assert.equal(
+      row.releaseBump,
+      'NO',
+      `Selected-response template "${template.id}" must have release-id bump = NO ` +
+        `(got "${row.releaseBump}") — additive migration preserves mark result.`
+    );
+  }
+});
+
+test('audit table proposes exactly 31 exact and 20 non-exact specs', () => {
+  // Sanity: 31 selected-response → `exact`; 20 constructed-response → one of
+  // the other five declarative kinds. Catches a drift where a selected-
+  // response row is proposed anything other than `exact`.
+  const doc = readAuditDoc();
+  const rows = extractClassificationTableRows(doc);
+  const exactCount = rows.filter((row) => row.proposedKind === 'exact').length;
+  const nonExactCount = rows.length - exactCount;
+  assert.equal(exactCount, 31, `Expected 31 rows proposing 'exact', got ${exactCount}.`);
+  assert.equal(nonExactCount, 20, `Expected 20 rows proposing a non-exact kind, got ${nonExactCount}.`);
+});


### PR DESCRIPTION
## Summary

- U11 deliverable for Grammar Phase 4: per-template classification doc covering all 51 Grammar templates (31 selected-response + 20 constructed-response) with proposed `answerSpec.kind`, golden accepted answer, near-miss examples, priority, and `contentReleaseId` bump requirement.
- Doc-gate test (`tests/grammar-answer-spec-audit.test.js`, 11 cases) enforces the audit stays in sync with `GRAMMAR_TEMPLATES` and `ANSWER_SPEC_KINDS`. No template code changes, no `contentReleaseId` bump, no oracle-fixture edits.
- Phase 5 can now execute migrations one template at a time from this backlog, pairing each marking-behaviour change with an oracle-fixture refresh and a release-id bump.

## Priority breakdown

- **High priority (thin-pool concepts):** every template tagged with `pronouns_cohesion`, `formality`, `active_passive`, `subject_object`, `modal_verbs`, or `hyphen_ambiguity`. Gate test cross-checks the table priority column against the actual `skillIds` from `content.js` so drift between the narrative and the table fails CI.
- **Medium priority:** all other constructed-response templates (marking-behaviour change with oracle refresh required).
- **Low priority:** all 31 selected-response templates (migration to `exact` is byte-identical — Phase 5 can batch these in a single no-release-id-bump PR).

## Proposed-spec distribution

- `exact`: 31 rows (selected-response batch).
- `normalisedText`: 5 rows (active/passive rewrites, tense rewrite, apostrophe rewrite, standard-english word-level fix).
- `acceptedSet`: 2 rows (clause combine / join — keep multi-way golden).
- `punctuationPattern`: 9 rows (every punctuation-surgery fix template).
- `multiField`: 0 rows (reserved for Phase 5+ expansion).
- `manualReviewOnly`: 4 rows in the table (open-ended builders + ambiguous standard-english fix) + 2 flagged candidates in §3 for Phase 5 re-evaluation (both explain templates, once they move to free-text).

Total: 31 + 5 + 2 + 9 + 0 + 4 = 51.

## Release-id bump matrix

- 31 rows (selected-response) bump `NO` — additive declarative migration preserves mark result byte-for-byte.
- 20 rows (constructed-response) bump `YES` — narrower near-miss rejection (`punctuationPattern`) or shape change (`manualReviewOnly`) invalidates stored evidence.

## Test plan

- [x] `node --test tests/grammar-answer-spec-audit.test.js` — 11/11 pass locally.
- [x] `npm test -- tests/grammar-answer-spec-audit.test.js` — 11/11 pass via the project test harness.
- [x] `GRAMMAR_TEMPLATES.length === 51` confirmed programmatically.
- [x] Every template id in doc exists in `GRAMMAR_TEMPLATES`; reverse check also passes (no template is missing from the audit).
- [x] Every proposed `answerSpec.kind` in doc is in `ANSWER_SPEC_KINDS`.
- [x] Section 3 lists 6 manual-review-only candidates (≥5 required); section 4 lists all 6 thin-pool concepts.
- [x] Priority cross-check: every template carrying a thin-pool concept has priority=high in the table.
- [x] Release-id bump discipline: YES for all 20 constructed-response rows, NO for all 31 selected-response rows.

## Files

- `docs/plans/james/grammar/grammar-answer-spec-audit.md` (new — the audit deliverable, 213 lines)
- `tests/grammar-answer-spec-audit.test.js` (new — doc-gate test, 11 cases, 276 lines)

No `worker/src/subjects/grammar/content.js` edits. No `answer-spec.js` edits. No oracle fixture edits.

## References

- Plan: `docs/plans/2026-04-26-001-feat-grammar-phase4-learning-hardening-plan.md` — U11 section.
- Phase 3 deferral of record: `docs/plans/james/grammar/grammar-phase3-implementation-report.md` §5 item 5.
- Phase 2 deferral of record: `docs/plans/james/grammar/grammar-phase2-implementation-report.md` §U5.