### PR TITLE
docs(grammar): U12 content-expansion audit (inventory)

### DIFF
--- a/docs/plans/james/grammar/grammar-content-expansion-audit.md
+++ b/docs/plans/james/grammar/grammar-content-expansion-audit.md
@@ -126,7 +126,7 @@ Each thin-pool concept below has five proposed new templates. Proposals are writ
 
 ### subject_object (currently `identify`, SR 2 / CR 0) — HIGHEST priority
 
-1. **`subject_object_choice`** — `choose` — Pick which of four sentences has a particular noun as its subject (distinct from the existing `identify` pattern which asks for the subject in one named sentence). `answerSpec.kind: exact`.
+1. **`subject_object_choice`** — `choose` — Pick which of four sentences has a particular noun as its subject (distinct from the existing `identify` pattern which asks for the subject in one named sentence). `answerSpec.kind: exact`. (Rename to `subject_object_choose_between` — see collision note below.)
 2. **`subject_object_fill`** — `fill` — Complete a sentence by filling the subject slot with a noun phrase that fits the context. `answerSpec.kind: normalisedText`.
 3. **`subject_object_rewrite_topicalise`** — `rewrite` — Rewrite a sentence so that the original object becomes the subject (topicalisation; an active-to-passive-adjacent skill). `answerSpec.kind: acceptedSet`.
 4. **`subject_object_classify_table`** — `classify` — Tick `subject`, `object`, or `neither` for each of four underlined noun phrases across four sentences. `answerSpec.kind: multiField`.
@@ -187,7 +187,7 @@ When Phase 5 lands any of these proposals, the PR author must:
 - Templates audited: **51**
 - Thin-pool concepts (ground truth): **6**
 - Single-question-type thin-pool concepts (HIGHEST priority): **2** (`active_passive`, `subject_object`)
-- Concepts with an `explain` template today: **2** (`adverbials` via `explain_reason_choice`; `boundary_punctuation` via `proc2_boundary_punctuation_explain`; `standard_english` also shares `explain_reason_choice` so it is counted as 3 concept rows with `explain` coverage in the table above, but only two templates carry the type)
+- Concepts with an `explain` template today: **3 (represented by 2 templates)** — `adverbials` and `standard_english` both via `explain_reason_choice`; `boundary_punctuation` via `proc2_boundary_punctuation_explain`. The concept-table shows three rows with `explain` coverage, but only two distinct templates carry the type.
 - New template ideas proposed: **30** (five per thin-pool concept × six thin-pool concepts)
 - Phase 5 release-id bumps implied (one per new-template PR landed, assuming each ships atomically): up to **30**
 - `contentReleaseId` bumps produced by this audit: **0**

--- a/docs/plans/james/grammar/grammar-content-expansion-audit.md
+++ b/docs/plans/james/grammar/grammar-content-expansion-audit.md
@@ -1,0 +1,203 @@
+---
+title: "Grammar content-expansion audit (Phase 5 backlog)"
+type: audit
+status: inventory-only
+date: 2026-04-26
+plan: docs/plans/2026-04-26-001-feat-grammar-phase4-learning-hardening-plan.md
+unit: U12
+contentReleaseId: grammar-legacy-reviewed-2026-04-24
+contentReleaseBump: none
+---
+
+# Grammar content-expansion audit (Phase 5 backlog)
+
+This document is the Phase 5 content-expansion backlog for the Grammar subject. It is **inventory only**: no new templates are introduced, no existing templates are changed, and the `GRAMMAR_CONTENT_RELEASE_ID` constant is **not** bumped. Every proposal below is a Phase 5 candidate that will require paired oracle-fixture refresh, per-template answer-spec migration (see `grammar-answer-spec-audit.md`), and a `contentReleaseId` bump when it lands.
+
+The audit is produced by reading `worker/src/subjects/grammar/content.js` at release id `grammar-legacy-reviewed-2026-04-24` and cross-referencing `GRAMMAR_AGGREGATE_CONCEPTS` in `src/platform/game/mastery/grammar.js`. There are 18 aggregate concepts and 51 templates in the pool at the time of the audit.
+
+---
+
+## How to read the concept table
+
+Each concept row records the eight audit fields required by the Phase 4 plan (`§U12` of `docs/plans/2026-04-26-001-feat-grammar-phase4-learning-hardening-plan.md`, line 942). The fields are:
+
+- **Concept id** — matches a member of `GRAMMAR_AGGREGATE_CONCEPTS`.
+- **Templates** — the count of templates whose `skillIds` array includes this concept id.
+- **Types present** — the distinct `questionType` values across those templates, drawn from the eight-member family `{classify, identify, choose, fill, fix, rewrite, build, explain}`.
+- **Types absent** — the complement: question-type families not currently represented for this concept.
+- **Misconceptions covered** — the misconception ids (from `GRAMMAR_MISCONCEPTIONS`) that template evaluators can emit for this concept. Cross-concept misconceptions such as `punctuation_precision` (emitted by every constructed-response template that uses `markStringAnswer`) and `misread_question` (generic across the subject) are noted only when they provide the primary signal.
+- **SR / CR balance** — selected-response (`isSelectedResponse: true`) versus constructed-response counts; the total equals the **Templates** field.
+- **Thin-pool flag** — `true` when the concept has `<= 2` templates. Ground truth: exactly six concepts are thin-pool. This matches the Phase 4 plan's scope-lock list (`pronouns_cohesion`, `formality`, `active_passive`, `subject_object`, `modal_verbs`, `hyphen_ambiguity`).
+- **Priority** — `high` for thin-pool concepts and for the `explain` question-type expansion; `medium` for single-question-type structural concerns outside the thin-pool; `low` otherwise.
+
+---
+
+## Concept table
+
+| Concept id | Templates | Types present | Types absent | Misconceptions covered | SR / CR | Thin-pool | Priority |
+|---|---|---|---|---|---|---|---|
+| sentence_functions | 3 | classify, identify, choose | fill, fix, rewrite, build, explain | sentence_function_confusion | 3 / 0 | false | low |
+| word_classes | 3 | identify, choose | classify, fill, fix, rewrite, build, explain | word_class_confusion | 3 / 0 | false | low |
+| noun_phrases | 3 | choose, build | classify, identify, fill, fix, rewrite, explain | noun_phrase_confusion | 1 / 2 | false | low |
+| adverbials | 5 | choose, fix, explain, build | classify, identify, fill, rewrite | fronted_adverbial_confusion | 2 / 3 | false | low |
+| clauses | 3 | identify, rewrite | classify, choose, fill, fix, build, explain | subordinate_clause_confusion | 1 / 2 | false | low |
+| relative_clauses | 3 | choose, build, identify | classify, fill, fix, rewrite, explain | relative_clause_confusion | 3 / 0 | false | low |
+| tense_aspect | 3 | fill, rewrite | classify, identify, choose, fix, build, explain | tense_confusion | 2 / 1 | false | low |
+| standard_english | 5 | choose, explain, fix | classify, identify, fill, rewrite, build | standard_english_confusion | 3 / 2 | false | low |
+| pronouns_cohesion | 2 | choose | classify, identify, fill, fix, rewrite, build, explain | pronoun_cohesion_confusion | 2 / 0 | true | high |
+| formality | 2 | choose | classify, identify, fill, fix, rewrite, build, explain | formality_confusion | 2 / 0 | true | high |
+| active_passive | 2 | rewrite | classify, identify, choose, fill, fix, build, explain | active_passive_confusion | 0 / 2 | true | high |
+| subject_object | 2 | identify | classify, choose, fill, fix, rewrite, build, explain | subject_object_confusion | 2 / 0 | true | high |
+| modal_verbs | 2 | choose, fill | classify, identify, fix, rewrite, build, explain | modal_verb_confusion | 2 / 0 | true | high |
+| parenthesis_commas | 3 | choose, fix | classify, identify, fill, rewrite, build, explain | parenthesis_confusion | 1 / 2 | false | low |
+| speech_punctuation | 3 | identify, fix | classify, choose, fill, rewrite, build, explain | speech_punctuation_confusion | 1 / 2 | false | low |
+| apostrophes_possession | 3 | choose, rewrite | classify, identify, fill, fix, build, explain | apostrophe_possession_confusion | 2 / 1 | false | low |
+| boundary_punctuation | 4 | choose, fix, explain | classify, identify, fill, rewrite, build | boundary_punctuation_confusion | 2 / 2 | false | low |
+| hyphen_ambiguity | 2 | choose, fix | classify, identify, fill, rewrite, build, explain | hyphen_ambiguity_confusion | 1 / 1 | true | high |
+
+Row count: **18**. Thin-pool rows where the flag is `true`: **6** (`pronouns_cohesion`, `formality`, `active_passive`, `subject_object`, `modal_verbs`, `hyphen_ambiguity`). Every other concept is `false`.
+
+---
+
+## Especially brittle — single-question-type thin-pool concepts
+
+Two thin-pool concepts are not only at the two-template floor: both of their templates share a single `questionType`. Phase 5 must lift these first because any template retirement or seed bug leaves the concept with no usable variety at all, and the adaptive selector (`worker/src/subjects/grammar/selection.js`) cannot honour the "mixed question type" retrieval-science floor (R6) with only one type available.
+
+### `active_passive` — both templates are `rewrite` (HIGHEST priority)
+
+| Template id | Question type | Response shape |
+|---|---|---|
+| `active_passive_rewrite` | rewrite | constructed (textarea) |
+| `proc2_passive_to_active` | rewrite | constructed (textarea) |
+
+No selected-response cover. No identification, classification, choice, fill, fix, build, or explain variety. A learner who is weak on active-passive voice sees only two rewrite prompts, with no lower-cost SR entry point and no higher-level explain prompt.
+
+### `subject_object` — both templates are `identify` (HIGHEST priority)
+
+| Template id | Question type | Response shape |
+|---|---|---|
+| `subject_object_choice` | identify | selected (single_choice) |
+| `proc2_subject_object_identify` | identify | selected (single_choice) |
+
+No constructed-response cover. No rewrite, build, fix, explain, or even `choose` variety. Every practice interaction is the same "pick the subject / pick the object from four options" pattern. The "Build / transform" and "Explain why" rungs of the learning ladder are absent.
+
+---
+
+## Expanded `explain` question type — second cross-cutting priority
+
+Only two templates in the entire pool use `questionType: 'explain'`:
+
+| Template id | Concept(s) |
+|---|---|
+| `explain_reason_choice` | adverbials, standard_english |
+| `proc2_boundary_punctuation_explain` | boundary_punctuation |
+
+Sixteen of the 18 concepts have no `explain` template. This is a cross-cutting gap: Phase 5 should add at least one `explain` template per thin-pool concept (and prioritise mid-pool concepts where an explain variant would raise the metacognitive ceiling, especially `word_classes`, `noun_phrases`, `clauses`, `relative_clauses`, `tense_aspect`, `apostrophes_possession`, `parenthesis_commas`, `speech_punctuation`, `hyphen_ambiguity`). Priority: **high**.
+
+---
+
+## New template ideas by thin-pool concept
+
+Each thin-pool concept below has five proposed new templates. Proposals are written to lift the concept out of thin-pool status (exits at `templates > 2`) and to introduce at least two new question-type families per concept so that the "single question type" trap cannot recur. Each proposal states the target `questionType`, a one-line intent, the expected `skillIds` binding, and a realistic `answerSpec.kind` (see `grammar-answer-spec-audit.md`) so Phase 5 can migrate both audits in one pass.
+
+### pronouns_cohesion (currently `choose`, SR 2 / CR 0)
+
+1. **`pronoun_referent_identify`** — `identify` — "Which noun does the underlined pronoun refer to?" Options list candidate noun phrases from the passage. Single-choice. `answerSpec.kind: exact`.
+2. **`pronoun_fix_ambiguity`** — `fix` — Given a sentence with an ambiguous pronoun, rewrite so the referent is unambiguous. `answerSpec.kind: acceptedSet` (2–3 accepted rewrites).
+3. **`pronoun_cohesion_build`** — `build` — Build a two-sentence passage that uses a pronoun for one of two named nouns, preserving clarity. `answerSpec.kind: normalisedText`.
+4. **`pronoun_cohesion_explain`** — `explain` — Pick the best reason why one of two versions is clearer (not just "sounds nicer"). Single-choice from three explanations. `answerSpec.kind: exact`.
+5. **`pronoun_fill_subject_object`** — `fill` — Given a sentence with a missing pronoun and a context showing a prior noun, pick from `he/him/she/her/they/them` etc. to preserve cohesion. `answerSpec.kind: exact`.
+
+### formality (currently `choose`, SR 2 / CR 0)
+
+1. **`formality_classify`** — `classify` — Classify each of four sentences as `formal` or `informal` in a two-column table (mirrors `sentence_type_table`). `answerSpec.kind: multiField`.
+2. **`formality_rewrite`** — `rewrite` — Rewrite an informal sentence in formal register for a school newsletter. `answerSpec.kind: acceptedSet`.
+3. **`formality_identify_marker`** — `identify` — Pick out the word or phrase that makes a sentence informal (contraction, idiom, slang). Multi-select checkbox list. `answerSpec.kind: multiField`.
+4. **`formality_fill_register`** — `fill` — Given a sentence with a blank, pick the word that matches the specified register (formal letter vs message to a friend). `answerSpec.kind: exact`.
+5. **`formality_explain`** — `explain` — Pick the best explanation for why a sentence belongs in a formal register (precision / distance / audience). `answerSpec.kind: exact`.
+
+### active_passive (currently `rewrite`, SR 0 / CR 2) — HIGHEST priority
+
+1. **`active_passive_choice`** — `choose` — Pick which of four sentences is in the passive voice (introduces the critical SR entry point that the concept is currently missing). `answerSpec.kind: exact`.
+2. **`active_passive_identify_agent`** — `identify` — Pick the agent (doer) in a passive-voice sentence that may or may not include a `by ...` phrase. `answerSpec.kind: exact`.
+3. **`active_passive_fill_aux`** — `fill` — Given a passive-voice skeleton `The door ___ by the caretaker.`, choose the auxiliary (`was / is / were / had been`). `answerSpec.kind: exact`.
+4. **`active_passive_build_from_prompt`** — `build` — Build a passive-voice sentence from three prompt words: subject (patient), past participle, agent. `answerSpec.kind: normalisedText`.
+5. **`active_passive_explain`** — `explain` — Pick the best reason why a writer would choose the passive voice here (focus on the patient, agent unknown, register). `answerSpec.kind: exact`.
+
+### subject_object (currently `identify`, SR 2 / CR 0) — HIGHEST priority
+
+1. **`subject_object_choice`** — `choose` — Pick which of four sentences has a particular noun as its subject (distinct from the existing `identify` pattern which asks for the subject in one named sentence). `answerSpec.kind: exact`.
+2. **`subject_object_fill`** — `fill` — Complete a sentence by filling the subject slot with a noun phrase that fits the context. `answerSpec.kind: normalisedText`.
+3. **`subject_object_rewrite_topicalise`** — `rewrite` — Rewrite a sentence so that the original object becomes the subject (topicalisation; an active-to-passive-adjacent skill). `answerSpec.kind: acceptedSet`.
+4. **`subject_object_classify_table`** — `classify` — Tick `subject`, `object`, or `neither` for each of four underlined noun phrases across four sentences. `answerSpec.kind: multiField`.
+5. **`subject_object_explain`** — `explain` — Pick the best explanation for why a named noun phrase is the subject (agreement with verb, agency, position before the finite verb). `answerSpec.kind: exact`.
+
+### modal_verbs (currently `choose, fill`, SR 2 / CR 0)
+
+1. **`modal_verb_identify`** — `identify` — Pick out all modal verbs in a paragraph (multi-select token-checkbox, mirrors `identify_words_in_sentence`). `answerSpec.kind: multiField`.
+2. **`modal_verb_classify_strength`** — `classify` — Classify four modals into `possibility / obligation / certainty / permission` buckets in a table. `answerSpec.kind: multiField`.
+3. **`modal_verb_rewrite_strength`** — `rewrite` — Rewrite a sentence by replacing the modal with one of a different strength and adjust meaning accordingly. `answerSpec.kind: acceptedSet`.
+4. **`modal_verb_build`** — `build` — Build a sentence using a given modal that must express a specified meaning (e.g. "advice", "distant possibility"). `answerSpec.kind: normalisedText`.
+5. **`modal_verb_explain`** — `explain` — Pick the best explanation for why a particular modal is chosen in the context (not just "it sounds right"). `answerSpec.kind: exact`.
+
+### hyphen_ambiguity (currently `choose, fix`, SR 1 / CR 1)
+
+1. **`hyphen_ambiguity_identify`** — `identify` — Pick the word pair that should be hyphenated from a list of underlined candidates. Multi-select. `answerSpec.kind: multiField`.
+2. **`hyphen_ambiguity_classify`** — `classify` — Classify four candidate hyphenations as `needed`, `optional`, or `incorrect` for clarity. `answerSpec.kind: multiField`.
+3. **`hyphen_ambiguity_rewrite`** — `rewrite` — Rewrite a sentence whose meaning shifts with or without the hyphen, so the hyphenated version is clearer (pairs with the existing fix template). `answerSpec.kind: acceptedSet`.
+4. **`hyphen_ambiguity_build`** — `build` — Build a short noun phrase using a given compound adjective, and explain briefly whether a hyphen is needed before the noun. `answerSpec.kind: normalisedText`.
+5. **`hyphen_ambiguity_explain`** — `explain` — Pick the best explanation for why the hyphen changes the meaning (compound adjective before noun vs phrase after noun). `answerSpec.kind: exact`.
+
+---
+
+## Phase 5 release-id discipline
+
+Every proposal above is a **Phase 5** candidate. Phase 4 unit U12 ships this audit without touching `content.js`, without touching `worker/src/subjects/grammar/answer-spec.js`, and without bumping `GRAMMAR_CONTENT_RELEASE_ID` (which stays at `grammar-legacy-reviewed-2026-04-24`). The `release-id impact: none` statement from the Phase 4 plan (§"Key Technical Decisions") is preserved.
+
+When Phase 5 lands any of these proposals, the PR author must:
+
+1. **Bump `GRAMMAR_CONTENT_RELEASE_ID`** in `worker/src/subjects/grammar/content.js` for every PR that adds a new template or removes an existing one. A PR that adds two templates is still a single bump; a PR that adds a template *and* removes a template is still a single bump. The bump marks any behaviour-visible change to the pool.
+2. **Refresh the oracle fixtures** under `tests/fixtures/grammar-legacy-oracle/` so the new release id has a matching baseline. The existing baseline at `grammar-legacy-reviewed-2026-04-24` must continue to pass against the frozen oracle, so Phase 5 authors should generate a new baseline file rather than overwrite the legacy one (see `scripts/extract-grammar-legacy-oracle.mjs`).
+3. **Pair with the answer-spec migration** from U11's audit doc (`grammar-answer-spec-audit.md`). Each new template must declare a typed `answerSpec` from day one; the adapter path (`markStringAnswer` → `markByAnswerSpec`) is deprecated for new content.
+4. **Update this audit** if the new template resolves a thin-pool flag. A post-merge hook is not required — the Phase 5 follow-up PR refreshes this doc as part of its own CI.
+5. **Run the Phase 4 gates** that are orthogonal to content: the composite Concordium invariant test, the learning-flow matrix, and the completeness gate must all pass on the new release id unchanged.
+
+### Release-id bump triggers (explicit list)
+
+- Adding a new template to `TEMPLATES` — **bump required**.
+- Removing a template from `TEMPLATES` — **bump required**.
+- Changing a template's `questionType`, `skillIds`, `isSelectedResponse`, `difficulty`, or `marks` — **bump required**.
+- Changing an `accepted` / `correct` / `distractors` list so answers that were previously correct become incorrect (or vice versa) — **bump required**.
+- Adding a new `answerSpec` declaration that changes marking behaviour — **bump required** (see U11 audit).
+- Copy-only edits to `stemHtml` or `solutionLines` that do not change answer acceptance — **no bump** (documented by the PR reviewer).
+
+---
+
+## Audit completeness cross-check
+
+- Every template id enumerated in the new-template-ideas section is **new** (does not already appear in `GRAMMAR_TEMPLATES`). The lone exception is `subject_object_choice`, which is a proposed future template id that happens to collide with an existing id; the implementer must rename the new proposal (suggested: `subject_object_choose_between`) before shipping. The audit keeps the current name to preserve reviewer recognition.
+- The Phase 4 plan's scope-lock claim that 51 templates cover 18 concepts matches the enumeration above: the 18 rows in the concept table sum to 53 template-concept pair-assignments. Two templates map to two concepts each (`question_mark_select` on `sentence_functions` + `speech_punctuation`; `explain_reason_choice` on `adverbials` + `standard_english`), so 51 distinct templates inflate to 53 pair-assignments.
+- The Phase 3 aggregate counts referenced in the Phase 4 plan (31 SR + 20 CR = 51) describe **distinct templates**, not pair-assignments. Counting distinct templates from `GRAMMAR_TEMPLATES`: 31 have `isSelectedResponse: true` and 20 have `isSelectedResponse: false`, totalling 51. The SR column in the table above sums to 33 (not 31) because the two multi-concept templates are both SR and therefore counted in two rows.
+
+---
+
+## Summary counts
+
+- Concepts audited: **18**
+- Templates audited: **51**
+- Thin-pool concepts (ground truth): **6**
+- Single-question-type thin-pool concepts (HIGHEST priority): **2** (`active_passive`, `subject_object`)
+- Concepts with an `explain` template today: **2** (`adverbials` via `explain_reason_choice`; `boundary_punctuation` via `proc2_boundary_punctuation_explain`; `standard_english` also shares `explain_reason_choice` so it is counted as 3 concept rows with `explain` coverage in the table above, but only two templates carry the type)
+- New template ideas proposed: **30** (five per thin-pool concept × six thin-pool concepts)
+- Phase 5 release-id bumps implied (one per new-template PR landed, assuming each ships atomically): up to **30**
+- `contentReleaseId` bumps produced by this audit: **0**
+
+---
+
+## References
+
+- Plan: `docs/plans/2026-04-26-001-feat-grammar-phase4-learning-hardening-plan.md` §U12 (~line 929).
+- Invariants: `docs/plans/james/grammar/grammar-phase4-invariants.md`.
+- Answer-spec audit (sibling Phase 5 backlog): `docs/plans/james/grammar/grammar-answer-spec-audit.md`.
+- Content source: `worker/src/subjects/grammar/content.js` at `GRAMMAR_CONTENT_RELEASE_ID = 'grammar-legacy-reviewed-2026-04-24'`.
+- Concept list: `src/platform/game/mastery/grammar.js` — `GRAMMAR_AGGREGATE_CONCEPTS`.

--- a/tests/grammar-content-expansion-audit.test.js
+++ b/tests/grammar-content-expansion-audit.test.js
@@ -28,6 +28,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { GRAMMAR_AGGREGATE_CONCEPTS } from '../src/platform/game/mastery/grammar.js';
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DOC_PATH = path.resolve(
   __dirname,
@@ -39,26 +41,10 @@ const DOC_PATH = path.resolve(
   'grammar-content-expansion-audit.md',
 );
 
-const EXPECTED_CONCEPTS = [
-  'sentence_functions',
-  'word_classes',
-  'noun_phrases',
-  'adverbials',
-  'clauses',
-  'relative_clauses',
-  'tense_aspect',
-  'standard_english',
-  'pronouns_cohesion',
-  'formality',
-  'active_passive',
-  'subject_object',
-  'modal_verbs',
-  'parenthesis_commas',
-  'speech_punctuation',
-  'apostrophes_possession',
-  'boundary_punctuation',
-  'hyphen_ambiguity',
-];
+// Import from the source of truth so a Phase 5 bump of
+// GRAMMAR_AGGREGATE_CONCEPTS (e.g. 18 -> 19) surfaces drift in both the
+// doc and this gate at the same time rather than silently passing here.
+const EXPECTED_CONCEPTS = [...GRAMMAR_AGGREGATE_CONCEPTS];
 
 const EXPECTED_THIN_POOL = new Set([
   'pronouns_cohesion',

--- a/tests/grammar-content-expansion-audit.test.js
+++ b/tests/grammar-content-expansion-audit.test.js
@@ -1,0 +1,278 @@
+// Phase 4 U12 — doc-gate for the Grammar content-expansion audit.
+//
+// The audit file at `docs/plans/james/grammar/grammar-content-expansion-audit.md`
+// is the Phase 5 backlog. This gate asserts the doc exists, parses the concept
+// table, and verifies the structural claims that drive Phase 5 prioritisation:
+//
+//   * Exactly 18 concept rows (one per member of GRAMMAR_AGGREGATE_CONCEPTS).
+//   * Thin-pool flag is `true` for exactly the six ground-truth concepts
+//     (pronouns_cohesion, formality, active_passive, subject_object,
+//     modal_verbs, hyphen_ambiguity) and `false` for the other twelve.
+//   * `active_passive` and `subject_object` are flagged as
+//     single-question-type in the "Especially brittle" section with HIGHEST
+//     priority.
+//   * Each of the six thin-pool concepts has at least five new template
+//     ideas listed in its dedicated new-template-ideas subsection.
+//
+// The gate deliberately does NOT inspect `content.js` — it characterises the
+// doc alone. A Phase 5 migration that adds templates will update this doc in
+// the same PR and the gate will continue to pass so long as the concept row
+// count stays at 18 and the thin-pool list is refreshed to match the new
+// template counts.
+//
+// UK English; no emojis.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DOC_PATH = path.resolve(
+  __dirname,
+  '..',
+  'docs',
+  'plans',
+  'james',
+  'grammar',
+  'grammar-content-expansion-audit.md',
+);
+
+const EXPECTED_CONCEPTS = [
+  'sentence_functions',
+  'word_classes',
+  'noun_phrases',
+  'adverbials',
+  'clauses',
+  'relative_clauses',
+  'tense_aspect',
+  'standard_english',
+  'pronouns_cohesion',
+  'formality',
+  'active_passive',
+  'subject_object',
+  'modal_verbs',
+  'parenthesis_commas',
+  'speech_punctuation',
+  'apostrophes_possession',
+  'boundary_punctuation',
+  'hyphen_ambiguity',
+];
+
+const EXPECTED_THIN_POOL = new Set([
+  'pronouns_cohesion',
+  'formality',
+  'active_passive',
+  'subject_object',
+  'modal_verbs',
+  'hyphen_ambiguity',
+]);
+
+function readDoc() {
+  return fs.readFileSync(DOC_PATH, 'utf8');
+}
+
+function parseConceptTable(source) {
+  // The concept table lives under the `## Concept table` heading and ends at
+  // the next `##` heading. It is a standard pipe-separated Markdown table.
+  const start = source.indexOf('## Concept table');
+  assert.ok(start !== -1, 'Concept table heading is missing from the audit doc.');
+  const nextHeadingIndex = source.indexOf('\n## ', start + '## Concept table'.length);
+  const body = nextHeadingIndex === -1 ? source.slice(start) : source.slice(start, nextHeadingIndex);
+  const lines = body.split('\n');
+
+  const rowLines = lines.filter((line) => {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('|')) return false;
+    // Header + separator + concept row all start with |. Skip the separator.
+    if (/^\|\s*-+/.test(trimmed) || /^\|\s*:?-+/.test(trimmed)) return false;
+    return true;
+  });
+
+  // First row is the header; everything else is a concept row.
+  assert.ok(rowLines.length >= 2, 'Concept table has no rows.');
+  const header = rowLines[0];
+  const rows = rowLines.slice(1);
+
+  const columns = header
+    .split('|')
+    .map((cell) => cell.trim())
+    .filter(Boolean);
+  const expectedColumns = [
+    'Concept id',
+    'Templates',
+    'Types present',
+    'Types absent',
+    'Misconceptions covered',
+    'SR / CR',
+    'Thin-pool',
+    'Priority',
+  ];
+  assert.deepEqual(columns, expectedColumns, 'Concept-table header does not match the expected column layout.');
+
+  return rows.map((line) => {
+    const cells = line
+      .split('|')
+      .map((cell) => cell.trim())
+      .filter((cell, index, arr) => !(index === 0 && cell === '') && !(index === arr.length - 1 && cell === ''));
+    return {
+      conceptId: cells[0],
+      templates: Number(cells[1]),
+      typesPresent: cells[2]
+        .split(',')
+        .map((x) => x.trim())
+        .filter(Boolean),
+      typesAbsent: cells[3]
+        .split(',')
+        .map((x) => x.trim())
+        .filter(Boolean),
+      misconceptions: cells[4]
+        .split(',')
+        .map((x) => x.trim())
+        .filter(Boolean),
+      srCr: cells[5],
+      thinPool: cells[6].toLowerCase() === 'true',
+      priority: cells[7].toLowerCase(),
+    };
+  });
+}
+
+function countNewTemplateIdeas(source, conceptId) {
+  // Each thin-pool subsection has a heading of the form
+  // `### <conceptId> (currently ...)`. Ideas are numbered `1.` through `N.`.
+  const headingRe = new RegExp(`### ${conceptId}[^\n]*`);
+  const headingMatch = headingRe.exec(source);
+  assert.ok(headingMatch, `Thin-pool subsection for ${conceptId} is missing.`);
+  const start = headingMatch.index;
+  const afterHeading = source.indexOf('\n', start) + 1;
+  const nextSubheading = source.indexOf('\n### ', afterHeading);
+  const nextHeading = source.indexOf('\n## ', afterHeading);
+  let end = source.length;
+  if (nextSubheading !== -1) end = Math.min(end, nextSubheading);
+  if (nextHeading !== -1) end = Math.min(end, nextHeading);
+  const block = source.slice(afterHeading, end);
+  const numbered = block.match(/^\d+\.\s+\*\*/gm) || [];
+  return numbered.length;
+}
+
+test('audit doc exists at the declared repo path', () => {
+  assert.ok(fs.existsSync(DOC_PATH), `Expected audit doc at ${DOC_PATH}`);
+});
+
+test('audit doc declares zero contentReleaseId bump in its frontmatter', () => {
+  const source = readDoc();
+  // Strict match on the frontmatter key=value pair. If the doc is rewritten to
+  // accompany a Phase 5 migration, the implementer must change this line.
+  assert.match(source, /contentReleaseBump:\s*none/, 'contentReleaseBump must be declared as `none`.');
+  assert.match(
+    source,
+    /contentReleaseId:\s*grammar-legacy-reviewed-2026-04-24/,
+    'contentReleaseId must still be the Phase 4 legacy-reviewed id.',
+  );
+});
+
+test('concept table has exactly 18 rows, one per GRAMMAR_AGGREGATE_CONCEPTS entry', () => {
+  const rows = parseConceptTable(readDoc());
+  assert.equal(rows.length, 18, 'Expected 18 concept rows.');
+  const ids = rows.map((row) => row.conceptId);
+  assert.deepEqual(
+    ids.slice().sort(),
+    EXPECTED_CONCEPTS.slice().sort(),
+    'Concept ids in the audit doc must match GRAMMAR_AGGREGATE_CONCEPTS exactly.',
+  );
+});
+
+test('thin-pool flag is true for exactly the six ground-truth concepts, false for the other twelve', () => {
+  const rows = parseConceptTable(readDoc());
+  const trueSet = new Set(rows.filter((row) => row.thinPool).map((row) => row.conceptId));
+  const falseSet = new Set(rows.filter((row) => !row.thinPool).map((row) => row.conceptId));
+  assert.equal(trueSet.size, 6, 'Thin-pool should fire for exactly six concepts.');
+  assert.equal(falseSet.size, 12, 'Non-thin-pool should cover the other twelve concepts.');
+  for (const id of EXPECTED_THIN_POOL) {
+    assert.ok(trueSet.has(id), `${id} is missing from the thin-pool set.`);
+  }
+  for (const id of EXPECTED_CONCEPTS) {
+    if (EXPECTED_THIN_POOL.has(id)) continue;
+    assert.ok(falseSet.has(id), `${id} must be marked thin-pool=false.`);
+  }
+});
+
+test('thin-pool concepts all carry the `high` priority label', () => {
+  const rows = parseConceptTable(readDoc());
+  for (const row of rows) {
+    if (EXPECTED_THIN_POOL.has(row.conceptId)) {
+      assert.equal(row.priority, 'high', `${row.conceptId} must be priority=high because it is thin-pool.`);
+    }
+  }
+});
+
+test('audit flags active_passive and subject_object as single-question-type (HIGHEST priority)', () => {
+  const source = readDoc();
+  // The "Especially brittle" section must exist, must name both concepts, and
+  // must mark them as HIGHEST priority in the heading.
+  const sectionStart = source.indexOf('## Especially brittle');
+  assert.ok(sectionStart !== -1, 'Missing "Especially brittle" section.');
+  const sectionEnd = source.indexOf('\n## ', sectionStart + 1);
+  const section = sectionEnd === -1 ? source.slice(sectionStart) : source.slice(sectionStart, sectionEnd);
+
+  assert.match(section, /### `active_passive` — both templates are `rewrite` \(HIGHEST priority\)/);
+  assert.match(section, /### `subject_object` — both templates are `identify` \(HIGHEST priority\)/);
+
+  // Double-check the concept table agrees: both concepts should have exactly
+  // one entry in "Types present".
+  const rows = parseConceptTable(source);
+  const ap = rows.find((row) => row.conceptId === 'active_passive');
+  const so = rows.find((row) => row.conceptId === 'subject_object');
+  assert.ok(ap, 'active_passive row missing.');
+  assert.ok(so, 'subject_object row missing.');
+  assert.equal(ap.typesPresent.length, 1, 'active_passive must have exactly one question type present.');
+  assert.equal(ap.typesPresent[0], 'rewrite');
+  assert.equal(so.typesPresent.length, 1, 'subject_object must have exactly one question type present.');
+  assert.equal(so.typesPresent[0], 'identify');
+});
+
+test('each thin-pool concept lists at least five new template ideas', () => {
+  const source = readDoc();
+  for (const conceptId of EXPECTED_THIN_POOL) {
+    const count = countNewTemplateIdeas(source, conceptId);
+    assert.ok(
+      count >= 5,
+      `${conceptId} must propose at least five new template ideas (found ${count}).`,
+    );
+  }
+});
+
+test('expanded `explain` question-type backlog is called out with high priority', () => {
+  const source = readDoc();
+  // The doc must carry a dedicated "Expanded `explain` question type" section
+  // and must declare its priority as high.
+  const sectionStart = source.indexOf('## Expanded `explain` question type');
+  assert.ok(sectionStart !== -1, 'Missing expanded-explain section.');
+  const sectionEnd = source.indexOf('\n## ', sectionStart + 1);
+  const section = sectionEnd === -1 ? source.slice(sectionStart) : source.slice(sectionStart, sectionEnd);
+  assert.match(section, /Priority: \*\*high\*\*/);
+  // It must also name the two existing explain templates so the baseline is
+  // explicit.
+  assert.match(section, /explain_reason_choice/);
+  assert.match(section, /proc2_boundary_punctuation_explain/);
+});
+
+test('Phase 5 release-id discipline is documented explicitly', () => {
+  const source = readDoc();
+  assert.match(
+    source,
+    /Bump `GRAMMAR_CONTENT_RELEASE_ID`/,
+    'The release-id bump instruction must be documented for Phase 5.',
+  );
+  assert.match(
+    source,
+    /Adding a new template to `TEMPLATES` — \*\*bump required\*\*/,
+    'Add-template bump trigger must be listed.',
+  );
+  assert.match(
+    source,
+    /Removing a template from `TEMPLATES` — \*\*bump required\*\*/,
+    'Remove-template bump trigger must be listed.',
+  );
+});


### PR DESCRIPTION
## Summary

Phase 4 U12: ships the Grammar content-expansion audit as a Phase 5 backlog doc and a doc-gate test. Inventory only — zero content changes, zero `contentReleaseId` bump.

- Audit: `docs/plans/james/grammar/grammar-content-expansion-audit.md`
- Test: `tests/grammar-content-expansion-audit.test.js`

## Priority breakdown

**HIGHEST priority — single-question-type thin-pool concepts**
- `active_passive` — both templates are `rewrite` (no SR cover, no identify/choose/fill/build/explain variety)
- `subject_object` — both templates are `identify` (no CR cover, no choose/fill/rewrite/build/explain variety)

**High priority — remaining thin-pool concepts** (2 templates each, not single-QT)
- `pronouns_cohesion`, `formality`, `modal_verbs`, `hyphen_ambiguity`

**High priority — cross-cutting `explain` gap**
- Only 2 templates in the whole 51-template pool use `questionType: 'explain'`. 16 of 18 concepts have no `explain` template at all. Phase 5 should add one per thin-pool concept plus strategic mid-pool concepts.

**Low priority — twelve non-thin-pool concepts**
- Structural coverage is adequate; Phase 5 may widen individual question-type families where a specific pedagogy motivates it, but there is no floor-risk.

## New template ideas

Five proposals per thin-pool concept (30 total), each naming the target `questionType`, a one-line intent, the expected `skillIds` binding, and a realistic `answerSpec.kind` so Phase 5 can migrate content + answer-spec in one pass.

## Release-id discipline

Explicitly documented in the audit:
- Adding a new template → bump required.
- Removing a template → bump required.
- Changing `questionType`/`skillIds`/`isSelectedResponse`/`difficulty`/`marks` → bump required.
- Changing answer acceptance (accepted / correct / distractors) → bump required.
- Copy-only edits to stem or solution lines → no bump.

Phase 4 `release-id impact: none` preserved — `GRAMMAR_CONTENT_RELEASE_ID` stays at `grammar-legacy-reviewed-2026-04-24`.

## Test plan

- [x] `npm test -- tests/grammar-content-expansion-audit.test.js` — 9/9 pass
  - Asserts the doc exists and declares `contentReleaseBump: none` in its frontmatter.
  - Parses the concept table, asserts exactly 18 rows (one per `GRAMMAR_AGGREGATE_CONCEPTS` entry).
  - Asserts thin-pool flag is `true` for exactly the six ground-truth concepts and `false` for the other twelve.
  - Asserts `active_passive` and `subject_object` are flagged as single-question-type in the "Especially brittle" section with HIGHEST priority, cross-checked against the concept table's "Types present" count.
  - Asserts every thin-pool concept has at least five new template ideas listed.
  - Asserts the `explain` question-type backlog section exists with explicit high-priority label.
  - Asserts the release-id bump-trigger list is documented explicitly.
- [x] No changes to `worker/src/subjects/grammar/content.js` or `answer-spec.js` — verified via `git diff --stat origin/main...HEAD`.