### PR TITLE
feat(grammar): U1 fix production-smoke stats.templates leak

### DIFF
--- a/src/subjects/grammar/metadata.js
+++ b/src/subjects/grammar/metadata.js
@@ -252,9 +252,13 @@ function statsFromConcepts(concepts) {
       : 'new';
     counts[status] += 1;
   }
+  // Phase 4 U1: client mirror of the Worker's `contentStats` emit. The key is
+  // renamed from the forbidden `templates` so the universal forbidden-key
+  // floor is honoured end-to-end; see worker/src/subjects/grammar/read-models.js
+  // `statsFromConcepts` for the authoritative shape.
   return {
     concepts: counts,
-    templates: {
+    contentStats: {
       total: 51,
       selectedResponse: 31,
       constructedResponse: 20,
@@ -592,14 +596,27 @@ function normaliseAiEnrichment(rawValue) {
 export function normaliseGrammarReadModel(rawValue = {}, learnerId = '') {
   const raw = rawValue && typeof rawValue === 'object' && !Array.isArray(rawValue) ? rawValue : {};
   const concepts = mergeConcepts(raw.analytics?.concepts);
-  const stats = raw.stats && typeof raw.stats === 'object' && !Array.isArray(raw.stats)
-    ? {
-      ...statsFromConcepts(concepts),
-      ...raw.stats,
-      concepts: { ...statsFromConcepts(concepts).concepts, ...(raw.stats.concepts || {}) },
-      templates: { ...statsFromConcepts(concepts).templates, ...(raw.stats.templates || {}) },
-    }
-    : statsFromConcepts(concepts);
+  // Phase 4 U1: explicit allow-list picker. The previous `{ ...statsFromConcepts(), ...raw.stats }`
+  // spread silently re-introduced any forbidden keys the Worker might still
+  // emit (historically `templates`) by merging them back onto the client
+  // read-model. The allow-list below keeps only the two keys the UI actually
+  // consumes (`stats.concepts` and `stats.contentStats`); `raw.stats` itself
+  // is never spread, so legacy or mis-shaped Worker payloads cannot leak
+  // forbidden keys through this path.
+  const fallbackStats = statsFromConcepts(concepts);
+  const rawStats = raw.stats && typeof raw.stats === 'object' && !Array.isArray(raw.stats)
+    ? raw.stats
+    : {};
+  const rawStatsConcepts = rawStats.concepts && typeof rawStats.concepts === 'object' && !Array.isArray(rawStats.concepts)
+    ? rawStats.concepts
+    : {};
+  const rawStatsContentStats = rawStats.contentStats && typeof rawStats.contentStats === 'object' && !Array.isArray(rawStats.contentStats)
+    ? rawStats.contentStats
+    : {};
+  const stats = {
+    concepts: { ...fallbackStats.concepts, ...rawStatsConcepts },
+    contentStats: { ...fallbackStats.contentStats, ...rawStatsContentStats },
+  };
   // Phase 3 U1 widens the whitelist to accept `'bank'` and `'transfer'` so
   // that the U1 dashboard can dispatch `grammar-open-concept-bank` /
   // `grammar-open-transfer` before U2 + U6b land. The downstream scene files

--- a/tests/grammar-production-smoke.test.js
+++ b/tests/grammar-production-smoke.test.js
@@ -93,7 +93,7 @@ test('Grammar production smoke rejects extra production option fields', () => {
 
 test('Grammar production smoke scans feedback and summary models for forbidden keys', () => {
   assert.doesNotThrow(() => assertNoForbiddenGrammarReadModelKeys({
-    stats: { templates: { total: 44, selectedResponse: 20 } },
+    stats: { contentStats: { total: 51, selectedResponse: 31, constructedResponse: 20 } },
     session: {
       currentItem: {
         templateId: 'fronted_adverbial_choose',

--- a/tests/grammar-stats-rename.test.js
+++ b/tests/grammar-stats-rename.test.js
@@ -1,0 +1,59 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildGrammarReadModel } from '../worker/src/subjects/grammar/read-models.js';
+import { normaliseGrammarReadModel } from '../src/subjects/grammar/metadata.js';
+import { assertNoForbiddenGrammarReadModelKeys } from '../scripts/grammar-production-smoke.mjs';
+
+// Phase 4 U1 composition test. Neither the Worker-emit unit test nor the
+// client-normaliser unit test in isolation catches the case where the Worker
+// emits a clean read-model but the client normaliser's deep-merge re-introduces
+// a forbidden key (or vice versa). This end-to-end test threads the Worker's
+// actual `buildGrammarReadModel` output through the client's
+// `normaliseGrammarReadModel` and asserts the round-trip is clean against the
+// shared forbidden-key universal floor. It is the load-bearing guard for the
+// two-layer rename.
+
+test('U1: buildGrammarReadModel → normaliseGrammarReadModel round-trip exposes no forbidden keys', () => {
+  const workerRm = buildGrammarReadModel({ learnerId: 'learner-a', state: {} });
+  const clientRm = normaliseGrammarReadModel(workerRm, 'learner-a');
+
+  assert.doesNotThrow(() => assertNoForbiddenGrammarReadModelKeys(clientRm, 'grammar.composition'));
+});
+
+test('U1: Worker-emitted stats uses contentStats, never templates', () => {
+  const workerRm = buildGrammarReadModel({ learnerId: 'learner-a', state: {} });
+
+  assert.ok(workerRm.stats, 'Worker read-model should expose a stats block.');
+  assert.equal(workerRm.stats.templates, undefined, 'Worker stats must not expose the forbidden `templates` key.');
+  assert.ok(workerRm.stats.contentStats, 'Worker stats should expose the renamed `contentStats` block.');
+  assert.equal(typeof workerRm.stats.contentStats.total, 'number', '`contentStats.total` should be numeric.');
+  assert.equal(typeof workerRm.stats.contentStats.selectedResponse, 'number', '`contentStats.selectedResponse` should be numeric.');
+  assert.equal(typeof workerRm.stats.contentStats.constructedResponse, 'number', '`contentStats.constructedResponse` should be numeric.');
+});
+
+test('U1: normaliseGrammarReadModel drops a legacy `stats.templates` payload via allow-list picker', () => {
+  // Legacy raw payload simulating a pre-P4 Worker emit that still carries
+  // `stats.templates`. The allow-list picker must drop the forbidden key and
+  // never let it leak into the client read-model.
+  const legacyRaw = {
+    stats: {
+      concepts: { total: 18, new: 18, learning: 0, weak: 0, due: 0, secured: 0 },
+      templates: { total: 51, selectedResponse: 31, constructedResponse: 20 },
+    },
+  };
+  const clientRm = normaliseGrammarReadModel(legacyRaw, 'learner-a');
+
+  assert.equal(clientRm.stats.templates, undefined, 'Legacy `templates` must be dropped by the picker.');
+  assert.ok(clientRm.stats.contentStats, 'Picker must still expose `contentStats` (from the fallback).');
+  assert.equal(clientRm.stats.concepts.total, 18, 'Picker must preserve `stats.concepts.total` from raw input.');
+
+  assert.doesNotThrow(() => assertNoForbiddenGrammarReadModelKeys(clientRm, 'grammar.legacy'));
+});
+
+test('U1: normaliseGrammarReadModel passes through Worker `contentStats` unchanged', () => {
+  const workerRm = buildGrammarReadModel({ learnerId: 'learner-a', state: {} });
+  const clientRm = normaliseGrammarReadModel(workerRm, 'learner-a');
+
+  assert.deepEqual(clientRm.stats.contentStats, workerRm.stats.contentStats, 'Client should mirror Worker `contentStats` verbatim.');
+});

--- a/worker/src/subjects/grammar/read-models.js
+++ b/worker/src/subjects/grammar/read-models.js
@@ -522,9 +522,14 @@ function statsFromConcepts(concepts) {
   for (const concept of concepts) {
     counts[concept.status] = (counts[concept.status] || 0) + 1;
   }
+  // Phase 4 U1: internal template counts are surfaced under `contentStats` so
+  // the client read-model contract never exposes a `templates` key. The
+  // forbidden-key universal floor bans `templates` on every authenticated
+  // response surface; renaming the emit here is the Worker-side half of the
+  // two-layer fix (the client normaliser's allow-list picker is the other).
   return {
     concepts: counts,
-    templates: {
+    contentStats: {
       total: GRAMMAR_TEMPLATE_METADATA.length,
       selectedResponse: GRAMMAR_TEMPLATE_METADATA.filter((template) => template.isSelectedResponse).length,
       constructedResponse: GRAMMAR_TEMPLATE_METADATA.filter((template) => !template.isSelectedResponse).length,


### PR DESCRIPTION
## Summary

- Phase 4 U1: rename the internal template counts from `stats.templates` to `stats.contentStats` at three sites (Worker emit, client mirror, client normaliser deep-merge). The universal forbidden-key floor in `tests/helpers/forbidden-keys.mjs` bans `templates` on every authenticated read-model surface; the Worker was leaking it through `grammar.startModel.stats.templates` and the client's `{ ...raw.stats, templates: {...} }` spread re-introduced it on the client side.
- Replace the client normaliser's `raw.stats` spread with an explicit allow-list picker (`{ concepts, contentStats }` only). Legacy Worker payloads that still carry `stats.templates` are now silently dropped instead of merged back onto the client read-model — no backfill migration needed.
- Add `tests/grammar-stats-rename.test.js` — an end-to-end composition test that threads `buildGrammarReadModel({ state: {} })` through `normaliseGrammarReadModel` and asserts the round-trip is forbidden-key clean. Neither the Worker-emit unit test nor the client-normaliser unit test in isolation catches the case where one layer emits cleanly but the other re-introduces a leak; this composition test is the load-bearing guard.

Closes the only persistent red test on `main` (`tests/grammar-production-smoke.test.js`). No `contentReleaseId` bump; no change to the forbidden-keys universal floor (invariant 12 preserved).

## Test plan

- [x] `npm test -- tests/grammar-production-smoke.test.js` — 6 pass, 0 fail (was 5 pass, 1 fail on baseline)
- [x] `npm test -- tests/grammar-stats-rename.test.js` — 4 pass, 0 fail (new composition test)
- [x] `npm test -- tests/redaction-access-matrix.test.js` — 35 pass, 0 fail
- [x] `npm test -- "tests/grammar-*.test.js"` — 335 pass, 0 fail (full Grammar suite)
- [x] `npm test` — 2755 pass, 2 skip, 1 fail; the one failure is `tests/punctuation-release-smoke.test.js` (`readWranglerVars` JSON parse) which reproduces identically on `origin/main` and is unrelated to U1 scope.
- [x] `grep -r "stats\.templates" src/ worker/src/` — 0 hits (was 1 hit in `src/subjects/grammar/metadata.js:600` pre-rename)

Downstream-consumer audit: `grep` for `stats\.(concepts|contentStats)` confirms the four readers (`src/subjects/grammar/module.js:324`, `src/subjects/grammar/components/grammar-view-model.js:478`, `src/subjects/grammar/components/GrammarAnalyticsScene.jsx:137`, `tests/helpers/grammar-subject-harness.js:82`) all read `stats.concepts` only — none read `stats.templates` — so the rename has no UI side-effect.