### PR TITLE
feat(spelling): U1 post-mega diagnostic panel (P2)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1024,7 +1024,10 @@ const controller = createAppController({
   runtimeBoundary,
   autoAdvanceDispatchContinue: () => handleRemoteSpellingAction('spelling-continue'),
   extraContext: () => ({
-    session: boot.session,
+    // Re-evaluate the session platformRole on every controller action so a
+    // self-demotion landed earlier in the same runtime is reflected in the
+    // context subjects receive.
+    session: { ...boot.session, platformRole: shellPlatformRole },
     handleRemoteSpellingAction,
   }),
   tts,
@@ -1874,7 +1877,11 @@ function contextFor(subjectId = null) {
     runtimeBoundary,
     subjects: exposedSubjects(SUBJECTS, subjectExposureGates),
     subjectExposureGates,
-    session: boot.session,
+    // Thread the mutable `shellPlatformRole` into the session spread so
+    // downstream consumers (e.g. SpellingSetupScene role gating) see the
+    // current role after a self-demotion / role change — not the stale
+    // `boot.session.platformRole` captured at boot time.
+    session: { ...boot.session, platformRole: shellPlatformRole },
     handleRemoteSpellingAction,
     runtimeReadOnly: appState.persistence?.mode === 'degraded',
     ...buildHubModels(appState),
@@ -1957,7 +1964,10 @@ function buildSurfaceChromeModel(appState) {
     ttsProvider: learnerId ? selectedTtsProvider() : DEFAULT_TTS_PROVIDER,
     bufferedGeminiVoice: learnerId ? selectedBufferedGeminiVoice() : DEFAULT_BUFFERED_GEMINI_VOICE,
     signedInAs: boot.session.signedIn ? (boot.session.email || '') : null,
-    session: boot.session,
+    // Thread the mutable `shellPlatformRole` so the surface chrome reflects
+    // the current role post-self-demotion rather than the stale boot-time
+    // value.
+    session: { ...boot.session, platformRole: shellPlatformRole },
     persistence: {
       mode: persistenceSnapshot?.mode || 'local-only',
       label: homePersistenceLabel(persistenceSnapshot),

--- a/src/platform/hubs/admin-panel-patches.js
+++ b/src/platform/hubs/admin-panel-patches.js
@@ -23,6 +23,14 @@
 // patch clears the error without dropping the saving scalars, and so a
 // failing patch can overwrite them without stomping the latest server data
 // that was already applied.
+//
+// P2 U1: `postMasteryDebug` is a new top-level admin-hub sibling populated
+// by the full hub bundle only — there is no narrow /api/admin/ops/*
+// refresh route for this field in P2 U1. The four patch helpers below use
+// object spread (`{ ...hub, <sibling>: next }`), which preserves every
+// other top-level sibling including `postMasteryDebug`. No additional
+// helper is required; a POST-based admin-only diagnostic refresh can be
+// added later without touching the four existing narrow-patch paths.
 
 function isPlainObject(value) {
   return value && typeof value === 'object' && !Array.isArray(value);

--- a/src/platform/hubs/admin-read-model.js
+++ b/src/platform/hubs/admin-read-model.js
@@ -10,7 +10,28 @@ import {
   platformRoleLabel,
 } from '../access/roles.js';
 import { buildSpellingContentSummary, validateSpellingContentBundle } from '../../subjects/spelling/content/model.js';
+import { getSpellingPostMasteryState } from '../../subjects/spelling/read-model.js';
 import { buildParentHubReadModel } from './parent-read-model.js';
+
+// U1 (P2): neutral "empty" debug envelope for the admin hub when no
+// learner is selected or when the role check forbids debug fields. The
+// shape mirrors the populated `postMasteryDebug` returned by the selector
+// so the React surface can render a single definition-list template
+// without having to branch on the "empty" case.
+function emptyPostMasteryDebug() {
+  return {
+    source: 'locked-fallback',
+    publishedCoreCount: 0,
+    secureCoreCount: 0,
+    blockingCoreCount: 0,
+    blockingCoreSlugsPreview: [],
+    extraWordsIgnoredCount: 0,
+    guardianMapCount: 0,
+    contentReleaseId: null,
+    allWordsMega: false,
+    stickyUnlocked: false,
+  };
+}
 
 function asTs(value, fallback = 0) {
   const numeric = Number(value);
@@ -360,6 +381,35 @@ export function buildAdminHubReadModel({
     membershipRole: selectedDiagnostics?.membershipRole || 'viewer',
   });
 
+  // U1 (P2): additive `postMasteryDebug` panel. Gated on `canViewAdminHub`
+  // (admin + ops platform roles only) — child and parent surfaces never
+  // receive a populated envelope. When the role check fails or when no
+  // learner is selected, we emit `emptyPostMasteryDebug()` so the hub
+  // response shape stays stable across role changes (the React surface
+  // conditionally renders the panel on `permissions.canViewAdminHub`).
+  //
+  // PII posture: the selector output only contains slug strings (curriculum-
+  // public) and integer counts. No learner name / email flows through this
+  // sibling, so ICO data-minimisation stays intact even if a later reviewer
+  // widens the read to parent-role adults.
+  const adminCanViewDebug = canViewAdminHub({ platformRole: resolvedPlatformRole });
+  let postMasteryDebug = emptyPostMasteryDebug();
+  if (adminCanViewDebug && selectedDiagnostics) {
+    const selectedLearnerBundle = learnerBundles[selectedDiagnostics.learnerId] || null;
+    const selectedSubjectState = selectedLearnerBundle && isPlainObject(selectedLearnerBundle.subjectStates)
+      ? selectedLearnerBundle.subjectStates.spelling
+      : null;
+    const selectorOutput = getSpellingPostMasteryState({
+      subjectStateRecord: isPlainObject(selectedSubjectState) ? selectedSubjectState : null,
+      runtimeSnapshot: runtimeSnapshots.spelling || null,
+      now,
+      sourceHint: 'service',
+    });
+    if (selectorOutput?.postMasteryDebug) {
+      postMasteryDebug = selectorOutput.postMasteryDebug;
+    }
+  }
+
   return {
     generatedAt,
     permissions: {
@@ -446,6 +496,8 @@ export function buildAdminHubReadModel({
       demoOperations: demoOperations ? 'real' : 'placeholder',
       monsterVisualConfig: monsterVisualConfig ? 'real' : 'placeholder',
       learnerSupport: 'real',
+      postMasteryDebug: adminCanViewDebug && selectedDiagnostics ? 'real' : 'placeholder',
     },
+    postMasteryDebug,
   };
 }

--- a/src/subjects/spelling/client-read-models.js
+++ b/src/subjects/spelling/client-read-models.js
@@ -133,6 +133,14 @@ export function createSpellingReadModelService({ getState = () => null } = {}) {
       // 'locked' result never drift. `todayDay` is populated from the live
       // clock so UI copy that formats "next check in N days" renders a
       // sensible (albeit zero-delta) value before hydration.
+      //
+      // U1 (P2): when falling through to the locked factory, we also attach
+      // a `postMasteryDebug` sibling with `source: 'locked-fallback'` so the
+      // Admin hub can distinguish a Worker-hydrated snapshot ('worker') from
+      // a client-only fallback stub. The other debug scalars default to
+      // zero / false because the client shell has no guardian data to reason
+      // about — if the admin sees this on production it's a strong signal
+      // the Worker hydration hasn't completed yet for the selected learner.
       const cached = readModel(learnerId).postMastery;
       if (cached && typeof cached === 'object' && !Array.isArray(cached)) {
         return cloneSerialisable(cached);
@@ -140,6 +148,18 @@ export function createSpellingReadModelService({ getState = () => null } = {}) {
       return {
         ...createLockedPostMasteryState(),
         todayDay: Math.floor(Date.now() / (24 * 60 * 60 * 1000)),
+        postMasteryDebug: {
+          source: 'locked-fallback',
+          publishedCoreCount: 0,
+          secureCoreCount: 0,
+          blockingCoreCount: 0,
+          blockingCoreSlugsPreview: [],
+          extraWordsIgnoredCount: 0,
+          guardianMapCount: 0,
+          contentReleaseId: null,
+          allWordsMega: false,
+          stickyUnlocked: false,
+        },
       };
     },
     getAudioCue(learnerId) {

--- a/src/subjects/spelling/components/SpellingPracticeSurface.jsx
+++ b/src/subjects/spelling/components/SpellingPracticeSurface.jsx
@@ -64,7 +64,14 @@ export function SpellingPracticeSurface(props) {
     subject,
     actions,
     runtimeReadOnly = false,
+    // P2 U1: `session` is spread from routeContext in SubjectRoute — its
+    // `platformRole` gates the adult-only "Why is Guardian locked?" link on
+    // the setup scene. Child / parent roles pass undefined and the link
+    // never renders; admin / ops adults see it and can jump into the admin
+    // hub diagnostic panel.
+    session = null,
   } = props;
+  const platformRole = typeof session?.platformRole === 'string' ? session.platformRole : '';
   const spelling = buildSpellingContext({ appState, service, repositories, subject });
   const learnerId = spelling.learner?.id || '';
   const [setupHeroTone, setSetupHeroTone] = React.useState(() => (
@@ -156,6 +163,7 @@ export function SpellingPracticeSurface(props) {
       previousHeroBg={previousHeroBg}
       actions={actions}
       runtimeReadOnly={runtimeReadOnly}
+      platformRole={platformRole}
     />
   );
 }

--- a/src/subjects/spelling/components/SpellingSetupScene.jsx
+++ b/src/subjects/spelling/components/SpellingSetupScene.jsx
@@ -287,6 +287,20 @@ function SetupStatGrid({ stats }) {
   );
 }
 
+// P2 U1: admin / ops only affordance. When the learner's post-mega gate
+// is closed, adult operators need a one-click path into the Admin hub's
+// post-mega debug panel to see *why*. Child (`learner`) and parent
+// (`parent`) roles render absolutely nothing — the link is gated on the
+// platform role set. Keeping the whitelist explicit (not a generic
+// "non-learner" check) guards against future roles slipping past the
+// check; a brand-new role (e.g. 'demo') will render the link only after
+// an explicit code change here, matching the P2 plan's §U1 ICO posture.
+const POST_MASTERY_DEBUG_ROLES = new Set(['admin', 'ops']);
+
+function adultCanSeePostMasteryDebug(platformRole) {
+  return POST_MASTERY_DEBUG_ROLES.has(String(platformRole || ''));
+}
+
 export function SpellingSetupScene({
   learner,
   service,
@@ -301,6 +315,10 @@ export function SpellingSetupScene({
   setupHeroTone = '',
   previousHeroBg = '',
   runtimeReadOnly = false,
+  // P2 U1: threaded through from `SpellingPracticeSurface` -> `session.platformRole`.
+  // Defaults to empty string so a prop-less caller (tests, legacy shells)
+  // renders the child-safe view with the link absent.
+  platformRole = '',
 }) {
   const statsFilter = prefs.mode === 'test' ? 'core' : prefs.yearFilter;
   const stats = service.getStats(learner.id, statsFilter);
@@ -316,6 +334,13 @@ export function SpellingSetupScene({
   const isPostMega = Boolean(postMastery?.allWordsMega);
   const contentClasses = ['setup-content'];
   if (isPostMega) contentClasses.push('setup-content--post-mega');
+
+  // P2 U1: admin / ops adults see a "Why is Guardian locked?" diagnostic
+  // link right below the setup hero when Guardian Mission is NOT unlocked
+  // (i.e. `isPostMega === false`). Child / parent surfaces get `platformRole`
+  // empty (defaulted) or === 'parent' and the link never renders. Routed
+  // to the admin hub where the post-mega debug panel explains the counts.
+  const showPostMasteryDebugLink = adultCanSeePostMasteryDebug(platformRole) && !isPostMega;
 
   return (
     <div className="setup-grid" style={{ gridColumn: '1/-1' }}>
@@ -354,6 +379,21 @@ export function SpellingSetupScene({
               startDisabled={startDisabled}
             />
           )}
+          {showPostMasteryDebugLink ? (
+            <p className="small muted post-mastery-debug-link" data-adult-debug="post-mastery">
+              <button
+                type="button"
+                className="btn ghost"
+                data-action="open-admin-hub"
+                onClick={(event) => renderAction(actions, event, 'open-admin-hub')}
+              >
+                Why is Guardian locked?
+              </button>
+              <span className="small muted" style={{ marginLeft: 8 }}>
+                Adult-only diagnostic. Opens the Admin / Operations hub post-mega debug panel.
+              </span>
+            </p>
+          ) : null}
         </div>
       </section>
 

--- a/src/subjects/spelling/read-model.js
+++ b/src/subjects/spelling/read-model.js
@@ -110,6 +110,19 @@ function sessionLabel(kind) {
 
 const POST_MASTERY_PREVIEW_LENGTH = 8;
 
+// U1 (P2): allowlist regex for `blockingCoreSlugsPreview`. The preview ships
+// to the Admin hub UI where (a) it could be screenshot / pasted into Slack,
+// and (b) browser URL history could cache a malformed slug that survives
+// beyond the in-memory admin state. Every slug is scrubbed through this
+// regex before it joins the preview array — anything outside the expected
+// KS2-slug shape (e.g. an editor's accidental `rude-word-test-do-not-ship`)
+// is dropped, not rendered. The pattern matches a lowercase start, then
+// one or more lowercase letters / digits / hyphens. Uppercase, underscores,
+// whitespace, and empty strings all fail. H8 adversarial finding from the
+// P2 plan §U1.
+const BLOCKING_CORE_SLUG_PATTERN = /^[a-z][a-z0-9-]+$/;
+const BLOCKING_CORE_SLUGS_PREVIEW_LIMIT = 10;
+
 /**
  * Pure post-mastery selector. No side effects, no event-log replay — just
  * derives the aggregates the Setup / Summary / Word Bank scenes need from the
@@ -119,11 +132,19 @@ const POST_MASTERY_PREVIEW_LENGTH = 8;
  * `now` defaults to `Date.now` so callers that don't care about determinism
  * can omit it; the U4 tests always inject a fixed `now` to keep assertions
  * reproducible.
+ *
+ * U1 (P2): `sourceHint` is an optional diagnostic label ('service' | 'worker'
+ * | 'locked-fallback') that flows into `postMasteryDebug.source`. Callers
+ * set this so the Admin hub "Post-mega diagnostic panel" can distinguish
+ * a live service read from a remote-sync locked-fallback stub. Defaults to
+ * 'service' because most callers are the synchronous service path; the
+ * locked-fallback factory overrides to 'locked-fallback' explicitly.
  */
 export function getSpellingPostMasteryState({
   subjectStateRecord = null,
   runtimeSnapshot = null,
   now = Date.now,
+  sourceHint = 'service',
 } = {}) {
   const nowTs = typeof now === 'function' ? asTs(now(), Date.now()) : asTs(now, Date.now());
   const currentDay = todayDay(nowTs);
@@ -215,6 +236,89 @@ export function getSpellingPostMasteryState({
       })
     : [];
 
+  // U1 (P2): post-mastery diagnostic panel support. These aggregates are
+  // additive — every existing caller keeps its existing fields, and the
+  // new sibling lets the Admin hub surface *why* a learner's post-Mega
+  // dashboard is (or isn't) unlocked. PII-minimised: only slug strings
+  // (curriculum-public) and integer counts. No learner name, email, or
+  // adult account data flows through this object.
+  //
+  // Field definitions:
+  //  - `source`: where the snapshot came from — 'service' (direct selector
+  //     call), 'worker' (Worker engine response), 'locked-fallback' (the
+  //     shared locked-state factory). Threaded in via `sourceHint`.
+  //  - `publishedCoreCount` / `secureCoreCount` / `blockingCoreCount`: the
+  //     raw integers behind the `allWordsMega` gate. `blockingCoreCount`
+  //     is `publishedCoreCount - secureCoreCount` clamped at zero.
+  //  - `blockingCoreSlugsPreview`: first N=10 core slugs (alphabetical)
+  //     whose `progress[slug]?.stage !== 4` — i.e. what's preventing
+  //     graduation. Filtered through `BLOCKING_CORE_SLUG_PATTERN` and
+  //     dropped unless `word.published !== false` so unreleased / test /
+  //     misshapen slugs never surface in admin screenshots.
+  //  - `extraWordsIgnoredCount`: count of progress entries whose word is
+  //     in the extra pool. `allWordsMega` excludes the extra pool from
+  //     either side of its comparison, so this value confirms the
+  //     exclusion count for debugging an unexpected allWordsMega value.
+  //  - `guardianMapCount`: size of the persisted guardian map (post
+  //     normalisation). Useful when a learner has orphan entries that
+  //     do not affect counts.
+  //  - `contentReleaseId`: placeholder for U2 (which introduces
+  //     `SPELLING_CONTENT_RELEASE_ID`). Null pre-U2 merge; shape in place
+  //     so U2 populates without schema churn.
+  //  - `allWordsMega`: mirror of the gate, so the admin panel does not
+  //     need to correlate with the legacy top-level field.
+  //  - `stickyUnlocked`: reads `data.postMega != null` on the persisted
+  //     subject-state record. False pre-U2 merge; U2 sets it.
+  const blockingCoreSlugsPreview = (() => {
+    const stageBySlug = Object.create(null);
+    for (const [slug, entry] of Object.entries(progressMap)) {
+      stageBySlug[slug] = normaliseProgressRecord(entry).stage;
+    }
+    const blocking = [];
+    for (const word of runtime.words) {
+      if (!word || typeof word !== 'object') continue;
+      const pool = word.spellingPool === 'extra' ? 'extra' : 'core';
+      if (pool !== 'core') continue;
+      if (word.published === false) continue;
+      const slug = typeof word.slug === 'string' ? word.slug : '';
+      if (!slug || !BLOCKING_CORE_SLUG_PATTERN.test(slug)) continue;
+      const stage = stageBySlug[slug];
+      if (Number.isFinite(stage) && stage >= SECURE_STAGE) continue;
+      blocking.push(slug);
+    }
+    blocking.sort((a, b) => a.localeCompare(b));
+    return blocking.slice(0, BLOCKING_CORE_SLUGS_PREVIEW_LIMIT);
+  })();
+
+  const blockingCoreCount = Math.max(0, publishedCoreCount - secureCoreCount);
+
+  let extraWordsIgnoredCount = 0;
+  for (const [slug] of Object.entries(progressMap)) {
+    const word = runtime.bySlug[slug] || DEFAULT_WORD_BY_SLUG[slug];
+    const pool = word ? (word.spellingPool === 'extra' ? 'extra' : 'core') : 'core';
+    if (pool === 'extra') extraWordsIgnoredCount += 1;
+  }
+
+  const guardianMapCount = Object.keys(guardianMap).length;
+  const stickyUnlocked = isPlainObject(stateRecord?.data?.postMega);
+
+  const resolvedSource = sourceHint === 'worker' || sourceHint === 'locked-fallback'
+    ? sourceHint
+    : 'service';
+
+  const postMasteryDebug = {
+    source: resolvedSource,
+    publishedCoreCount,
+    secureCoreCount,
+    blockingCoreCount,
+    blockingCoreSlugsPreview,
+    extraWordsIgnoredCount,
+    guardianMapCount,
+    contentReleaseId: null,
+    allWordsMega,
+    stickyUnlocked,
+  };
+
   return {
     allWordsMega,
     guardianDueCount,
@@ -227,6 +331,7 @@ export function getSpellingPostMasteryState({
     guardianMissionAvailable,
     recommendedWords,
     nextGuardianDueDay,
+    postMasteryDebug,
   };
 }
 

--- a/src/subjects/spelling/read-model.js
+++ b/src/subjects/spelling/read-model.js
@@ -115,12 +115,27 @@ const POST_MASTERY_PREVIEW_LENGTH = 8;
 // and (b) browser URL history could cache a malformed slug that survives
 // beyond the in-memory admin state. Every slug is scrubbed through this
 // regex before it joins the preview array — anything outside the expected
-// KS2-slug shape (e.g. an editor's accidental `rude-word-test-do-not-ship`)
-// is dropped, not rendered. The pattern matches a lowercase start, then
-// one or more lowercase letters / digits / hyphens. Uppercase, underscores,
-// whitespace, and empty strings all fail. H8 adversarial finding from the
-// P2 plan §U1.
-const BLOCKING_CORE_SLUG_PATTERN = /^[a-z][a-z0-9-]+$/;
+// KS2-slug shape is dropped, not rendered. H8 adversarial finding from the
+// P2 plan §U1 reviewer pass.
+//
+// The tightened shape accepts only lowercase-letter/digit segments separated
+// by single hyphens, each segment >=1 char, with at most 3 hyphens (i.e.
+// up to 4 segments total). Overall length is capped at 32 characters. This
+// keeps realistic KS2 curriculum slugs like `suffix-tion`, `i-before-e`,
+// `prefix-un-in-im` but rejects editorial accidents such as
+// `rude-word-test-do-not-ship` (5 segments, >32 chars), `abc---def`
+// (double hyphen), `a-` (trailing hyphen), `TESTING-UPPER` (uppercase),
+// `admin_internal` (underscore).
+//
+// Note: release-level publication state is enforced by the publisher; per-
+// word publication is not a production contract (content producers do not
+// set `word.published` per-word — `published` lives at release level only).
+// Relying on a `word.published !== false` guard here would be vacuously true
+// in production and give false confidence. The scrub therefore relies on
+// shape + length only. A future follow-up could add a slug allowlist at
+// the bundle publisher layer; that is out of scope for U1.
+const BLOCKING_CORE_SLUG_PATTERN = /^[a-z][a-z0-9]*(-[a-z0-9]+){0,3}$/;
+const BLOCKING_CORE_SLUG_MAX_LENGTH = 32;
 const BLOCKING_CORE_SLUGS_PREVIEW_LIMIT = 10;
 
 /**
@@ -253,8 +268,10 @@ export function getSpellingPostMasteryState({
   //  - `blockingCoreSlugsPreview`: first N=10 core slugs (alphabetical)
   //     whose `progress[slug]?.stage !== 4` — i.e. what's preventing
   //     graduation. Filtered through `BLOCKING_CORE_SLUG_PATTERN` and
-  //     dropped unless `word.published !== false` so unreleased / test /
-  //     misshapen slugs never surface in admin screenshots.
+  //     `BLOCKING_CORE_SLUG_MAX_LENGTH` (shape + length scrub only —
+  //     release-level publication is enforced by the publisher; per-word
+  //     `published` is not a production contract) so misshapen slugs
+  //     never surface in admin screenshots.
   //  - `extraWordsIgnoredCount`: count of progress entries whose word is
   //     in the extra pool. `allWordsMega` excludes the extra pool from
   //     either side of its comparison, so this value confirms the
@@ -279,9 +296,11 @@ export function getSpellingPostMasteryState({
       if (!word || typeof word !== 'object') continue;
       const pool = word.spellingPool === 'extra' ? 'extra' : 'core';
       if (pool !== 'core') continue;
-      if (word.published === false) continue;
+      // Release-level publication state is enforced by the publisher; per-
+      // word publication is not a production contract — the shape + length
+      // scrub below is the only line of defence in this selector.
       const slug = typeof word.slug === 'string' ? word.slug : '';
-      if (!slug || !BLOCKING_CORE_SLUG_PATTERN.test(slug)) continue;
+      if (!slug || slug.length > BLOCKING_CORE_SLUG_MAX_LENGTH || !BLOCKING_CORE_SLUG_PATTERN.test(slug)) continue;
       const stage = stageBySlug[slug];
       if (Number.isFinite(stage) && stage >= SECURE_STAGE) continue;
       blocking.push(slug);

--- a/src/surfaces/hubs/AdminHubSurface.jsx
+++ b/src/surfaces/hubs/AdminHubSurface.jsx
@@ -68,6 +68,65 @@ function AdminAccountRoles({ model, directory = {}, actions }) {
   );
 }
 
+// U1 (P2): Post-Mega Spelling diagnostic panel. Answers the recurring
+// question "why is Guardian Mission still locked for this learner?" in
+// one glance — published vs secure core counts, the first 10 blocking
+// slugs, and sticky-unlock state (populated by U2 once the
+// `SPELLING_CONTENT_RELEASE_ID` sticky graduation lands).
+//
+// Accessibility: uses a `<dl>/<dt>/<dd>` pair for the debug aggregates so
+// screen readers announce label-value pairs coherently. The card inherits
+// the admin hub's existing `.card` + `.small muted` utility classes so
+// the visual rhythm stays consistent with other admin panels.
+//
+// PII posture: only curriculum-public slug strings and integer counts
+// render here. No learner name / email / account id touches this surface,
+// so a later screenshot / Slack paste stays ICO-compliant even for a
+// real production learner.
+function PostMegaSpellingDebugPanel({ debug = null }) {
+  const safe = debug && typeof debug === 'object' && !Array.isArray(debug) ? debug : {};
+  const source = typeof safe.source === 'string' && safe.source ? safe.source : 'locked-fallback';
+  const preview = Array.isArray(safe.blockingCoreSlugsPreview) ? safe.blockingCoreSlugsPreview : [];
+  const items = [
+    ['Source', source],
+    ['All core Mega', safe.allWordsMega ? 'true' : 'false'],
+    ['Sticky unlocked', safe.stickyUnlocked ? 'true' : 'false'],
+    ['Published core count', String(Number(safe.publishedCoreCount) || 0)],
+    ['Secure core count', String(Number(safe.secureCoreCount) || 0)],
+    ['Blocking core count', String(Number(safe.blockingCoreCount) || 0)],
+    ['Guardian map count', String(Number(safe.guardianMapCount) || 0)],
+    ['Extra words ignored', String(Number(safe.extraWordsIgnoredCount) || 0)],
+    ['Content release id', safe.contentReleaseId ? String(safe.contentReleaseId) : '—'],
+  ];
+  return (
+    <section className="card" style={{ marginBottom: 20 }} data-panel="post-mega-spelling-debug">
+      <div className="eyebrow">Spelling · post-mega</div>
+      <h3 className="section-title" style={{ fontSize: '1.2rem' }}>Why is Guardian locked?</h3>
+      <p className="small muted">
+        Diagnostic snapshot for the currently selected learner. Surfaces the post-mega gate inputs so
+        an operator can see which core words still block graduation. No personal data is rendered —
+        only curriculum-public slug strings and integer counts.
+      </p>
+      <dl className="post-mega-debug-dl">
+        {items.map(([label, value]) => (
+          <div className="post-mega-debug-row" key={label}>
+            <dt className="small muted">{label}</dt>
+            <dd>{value}</dd>
+          </div>
+        ))}
+        <div className="post-mega-debug-row" key="blockingCoreSlugsPreview">
+          <dt className="small muted">Blocking slugs (first 10)</dt>
+          <dd>
+            {preview.length
+              ? <code className="small">{preview.join(', ')}</code>
+              : <span className="small muted">None — every core slug is secure.</span>}
+          </dd>
+        </div>
+      </dl>
+    </section>
+  );
+}
+
 function DemoOperationsSummary({ summary = {} }) {
   const items = [
     ['Demo sessions created', summary.sessionsCreated],
@@ -618,6 +677,7 @@ export function AdminHubSurface({ appState, model, hubState = {}, accountDirecto
 
       <AccountOpsMetadataPanel model={model} actions={actions} />
       <ErrorLogCentrePanel model={model} actions={actions} />
+      <PostMegaSpellingDebugPanel debug={model.postMasteryDebug} />
 
       <section className="two-col" style={{ marginBottom: 20 }}>
         <article className="card">

--- a/tests/spelling-post-mastery-debug.test.js
+++ b/tests/spelling-post-mastery-debug.test.js
@@ -338,10 +338,28 @@ test('U1 H8 scrub: slugs outside /^[a-z][a-z0-9-]+$/ never reach the preview', (
   assert.deepEqual(state.postMasteryDebug.blockingCoreSlugsPreview, ['core-001']);
 });
 
-test('U1 H8 scrub: word.published === false excludes the slug from the preview', () => {
+test('U1 H8 scrub: regex + length cap rejects misshapen slugs', () => {
+  // Reviewer feedback: content producers do not set `word.published`
+  // per-word in production — the previous test fixture used
+  // `published: false` which gave false confidence in a guard that is
+  // vacuously true in production. Re-author the fixture so the tightened
+  // regex alone is responsible for dropping the rude slug, and add
+  // coverage for each shape defect (double-hyphen, trailing-hyphen,
+  // uppercase, over-length).
   const core1 = makeCoreWord(1);
-  const unpublishedSlug = { ...makeCoreWord(2), slug: 'rude-word-test-do-not-ship', published: false };
-  const words = [core1, unpublishedSlug];
+  const rudeLongSlug = { ...makeCoreWord(2), slug: 'rude-word-test-do-not-ship' }; // 5 segments, >32 chars
+  const doubleHyphenSlug = { ...makeCoreWord(3), slug: 'abc---def' };
+  const trailingHyphenSlug = { ...makeCoreWord(4), slug: 'a-' };
+  const upperCaseSlug = { ...makeCoreWord(5), slug: 'TESTING-UPPER' };
+  const overLengthSlug = { ...makeCoreWord(6), slug: 'x'.repeat(40) };
+  const words = [
+    core1,
+    rudeLongSlug,
+    doubleHyphenSlug,
+    trailingHyphenSlug,
+    upperCaseSlug,
+    overLengthSlug,
+  ];
   const runtimeSnapshot = {
     words,
     wordBySlug: Object.fromEntries(words.map((w) => [w.slug, w])),
@@ -354,6 +372,65 @@ test('U1 H8 scrub: word.published === false excludes the slug from the preview',
     now: NOW_MS,
   });
   assert.deepEqual(state.postMasteryDebug.blockingCoreSlugsPreview, ['core-001']);
+});
+
+test('U1 H8 scrub: legitimate 3-segment curriculum slugs pass the filter', () => {
+  // Defensive positive-case coverage — the tightened regex must still
+  // accept realistic KS2 curriculum slugs like `prefix-un-in-im`
+  // (3 hyphens, 4 segments) and `i-before-e` (2 hyphens, 3 segments).
+  const wordA = { ...makeCoreWord(1), slug: 'prefix-un-in-im' };
+  const wordB = { ...makeCoreWord(2), slug: 'i-before-e' };
+  const wordC = { ...makeCoreWord(3), slug: 'suffix-tion' };
+  const words = [wordA, wordB, wordC];
+  const runtimeSnapshot = {
+    words,
+    wordBySlug: Object.fromEntries(words.map((w) => [w.slug, w])),
+    coreWords: words,
+    extraWords: [],
+  };
+  const state = getSpellingPostMasteryState({
+    subjectStateRecord: makeSubjectStateRecord({}),
+    runtimeSnapshot,
+    now: NOW_MS,
+  });
+  assert.deepEqual(
+    [...state.postMasteryDebug.blockingCoreSlugsPreview].sort((a, b) => a.localeCompare(b)),
+    ['i-before-e', 'prefix-un-in-im', 'suffix-tion'],
+  );
+});
+
+test('U1 defensive: publishedCoreCount matches core-word count regardless of word-level fields', () => {
+  // M-2 reviewer finding: publishedCoreCount and blockingCoreSlugsPreview
+  // must count / filter consistently. Both ignore `word.published` now —
+  // this defensive test pins that invariant by asserting the count equals
+  // the number of core-pool runtime words even when every word carries
+  // spurious word-level fields that a future change might read.
+  const words = [
+    { ...makeCoreWord(1), published: false, draft: true, internal: true },
+    { ...makeCoreWord(2), published: true },
+    { ...makeCoreWord(3) },
+    { ...makeCoreWord(4), published: false },
+    { ...makeCoreWord(5), draft: false },
+  ];
+  const runtimeSnapshot = {
+    words,
+    wordBySlug: Object.fromEntries(words.map((w) => [w.slug, w])),
+    coreWords: words,
+    extraWords: [],
+  };
+  const state = getSpellingPostMasteryState({
+    subjectStateRecord: makeSubjectStateRecord({}),
+    runtimeSnapshot,
+    now: NOW_MS,
+  });
+  // Count is purely pool-based — all 5 words are in the core pool.
+  assert.equal(state.postMasteryDebug.publishedCoreCount, 5);
+  // Preview is purely shape-based — all 5 slugs pass the regex + length.
+  assert.equal(state.postMasteryDebug.blockingCoreSlugsPreview.length, 5);
+  assert.deepEqual(
+    state.postMasteryDebug.blockingCoreSlugsPreview,
+    ['core-001', 'core-002', 'core-003', 'core-004', 'core-005'],
+  );
 });
 
 // --------------------------------------------------------------------------
@@ -488,14 +565,22 @@ function makeAdminHubLearner(id = 'learner-a') {
 }
 
 test('U1 integration: admin hub response includes postMasteryDebug for admin-role viewer', () => {
+  // M-3 reviewer finding: the earlier `runtimeSnapshots: {}` envelope left
+  // the selector with no runtime words, which locked `publishedCoreCount`
+  // at zero and hid any counts-match regression. Build a minimal 5-word
+  // runtime snapshot that mirrors the shape produced by
+  // `runtimeSnapshotForBundle` in production (`{ words, wordBySlug }`),
+  // then assert the publishedCoreCount matches the bundle.
   const learner = makeAdminHubLearner();
+  const runtime = makeRuntimeSnapshot({ coreCount: 5 });
+  const runtimeSnapshot = { words: runtime.words, wordBySlug: runtime.wordBySlug };
   const model = buildAdminHubReadModel({
     account: { id: 'adult-admin', selectedLearnerId: learner.id, platformRole: 'admin' },
     platformRole: 'admin',
     spellingContentBundle: SEEDED_SPELLING_CONTENT_BUNDLE,
     memberships: [{ learnerId: learner.id, learner, role: 'owner' }],
     learnerBundles: { [learner.id]: { subjectStates: { spelling: { data: { progress: {} } } } } },
-    runtimeSnapshots: {},
+    runtimeSnapshots: { spelling: runtimeSnapshot },
     selectedLearnerId: learner.id,
     now: () => NOW_MS,
   });
@@ -504,6 +589,10 @@ test('U1 integration: admin hub response includes postMasteryDebug for admin-rol
   assert.equal(typeof model.postMasteryDebug.source, 'string');
   assert.equal(model.postMasteryDebug.source, 'service');
   assert.equal(model.reality.postMasteryDebug, 'real');
+  // Lock in that the counts match the provided bundle — the earlier
+  // `runtimeSnapshots: {}` fixture would have hidden this assertion.
+  assert.equal(model.postMasteryDebug.publishedCoreCount, 5);
+  assert.equal(model.postMasteryDebug.blockingCoreCount, 5);
 });
 
 test('U1 integration: admin hub response returns empty postMasteryDebug envelope for parent-role viewer', () => {

--- a/tests/spelling-post-mastery-debug.test.js
+++ b/tests/spelling-post-mastery-debug.test.js
@@ -1,0 +1,559 @@
+// P2 U1: Post-Mega spelling diagnostic panel tests.
+//
+// Coverage pinned here:
+//  1. Characterisation — the pre-U1 post-mastery selector shape stays
+//     stable (every existing sibling remains, and `postMasteryDebug` is
+//     the only new top-level addition).
+//  2. Happy-path counts — `postMasteryDebug.source === 'service'`, the
+//     published / secure / blocking counts, and the first 10 blocking
+//     slugs alphabetically for a half-secured learner.
+//  3. H8 scrub — malformed / unpublished slugs never appear in the
+//     preview; only slugs matching `/^[a-z][a-z0-9-]+$/` and
+//     `word.published !== false` pass through.
+//  4. Edge cases — empty progress, extra-pool ignore semantics.
+//  5. Error path — `createLockedPostMasteryState` / the client stub
+//     produces `source: 'locked-fallback'`.
+//  6. Integration — admin hub response carries `postMasteryDebug` when
+//     `canViewAdminHub === true`; parent-role adults see an empty envelope.
+//  7. Integration — `SpellingSetupScene` renders the adult-only link
+//     only when `platformRole ∈ {'admin', 'ops'}`.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+
+import {
+  buildSpellingLearnerReadModel,
+  getSpellingPostMasteryState,
+} from '../src/subjects/spelling/read-model.js';
+import { createSpellingReadModelService } from '../src/subjects/spelling/client-read-models.js';
+import { buildAdminHubReadModel } from '../src/platform/hubs/admin-read-model.js';
+import { SEEDED_SPELLING_CONTENT_BUNDLE } from '../src/subjects/spelling/data/content-data.js';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const TODAY = 19_000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW_MS = TODAY * DAY_MS;
+
+function nodePaths() {
+  return [
+    path.join(rootDir, 'node_modules'),
+    ...String(process.env.NODE_PATH || '').split(path.delimiter),
+  ].filter((entry) => entry && existsSync(entry));
+}
+
+function normaliseLineEndings(value) {
+  return String(value).replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
+// Shared fixture renderer for SpellingSetupScene — bundles JSX via esbuild
+// then runs the entry subprocess so the JSX imports resolve. Mirrors the
+// pattern in tests/react-admin-hub-kpi-split.test.js.
+async function renderSetupSceneViaBundle({ platformRole }) {
+  const tmpDir = await mkdtemp(path.join(tmpdir(), 'ks2-setup-pr-'));
+  const entryPath = path.join(tmpDir, 'entry.jsx');
+  const bundlePath = path.join(tmpDir, 'entry.cjs');
+  try {
+    await writeFile(entryPath, `
+      import React from 'react';
+      import { renderToStaticMarkup } from 'react-dom/server';
+      import { SpellingSetupScene } from ${JSON.stringify(path.join(rootDir, 'src/subjects/spelling/components/SpellingSetupScene.jsx'))};
+      import { MonsterVisualConfigProvider } from ${JSON.stringify(path.join(rootDir, 'src/platform/game/MonsterVisualConfigContext.jsx'))};
+
+      const learner = { id: 'learner-a', name: 'Diag', yearGroup: 'Y5' };
+      const subject = { id: 'spelling', name: 'Spelling' };
+      const prefs = {
+        mode: 'smart',
+        yearFilter: 'core',
+        roundLength: '20',
+        showCloze: true,
+        autoSpeak: true,
+        extraWordFamilies: false,
+      };
+      const ui = { phase: 'dashboard', pendingCommand: '' };
+      const postMastery = {
+        allWordsMega: false,
+        guardianDueCount: 0,
+        wobblingCount: 0,
+        wobblingDueCount: 0,
+        nonWobblingDueCount: 0,
+        unguardedMegaCount: 0,
+        guardianAvailableCount: 0,
+        guardianMissionState: 'locked',
+        guardianMissionAvailable: false,
+        recommendedWords: [],
+        nextGuardianDueDay: null,
+        todayDay: ${TODAY},
+        guardianMap: {},
+      };
+      const service = {
+        getStats: () => ({ total: 10, secure: 3, due: 2, trouble: 1, fresh: 4, accuracy: 65 }),
+        getPrefs: () => prefs,
+        initState: (rawState) => rawState || { phase: 'dashboard' },
+        getAnalyticsSnapshot: () => null,
+        getPostMasteryState: () => postMastery,
+        getAudioCue: () => null,
+      };
+      const repositories = { gameState: null };
+      const actions = { dispatch() {} };
+      const html = renderToStaticMarkup(
+        <MonsterVisualConfigProvider value={null}>
+          <SpellingSetupScene
+            learner={learner}
+            service={service}
+            repositories={repositories}
+            subject={subject}
+            prefs={prefs}
+            ui={ui}
+            codex={[]}
+            accent="#3E6FA8"
+            actions={actions}
+            postMastery={postMastery}
+            setupHeroTone=""
+            previousHeroBg=""
+            runtimeReadOnly={false}
+            platformRole={${JSON.stringify(platformRole)}}
+          />
+        </MonsterVisualConfigProvider>
+      );
+      console.log(html);
+    `);
+    await build({
+      absWorkingDir: rootDir,
+      entryPoints: [entryPath],
+      outfile: bundlePath,
+      bundle: true,
+      platform: 'node',
+      format: 'cjs',
+      target: ['node24'],
+      jsx: 'automatic',
+      jsxImportSource: 'react',
+      loader: { '.js': 'jsx' },
+      nodePaths: nodePaths(),
+      logLevel: 'silent',
+    });
+    const output = execFileSync(process.execPath, [bundlePath], {
+      cwd: rootDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return normaliseLineEndings(output).replace(/\n+$/, '');
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+function makeCoreWord(index, overrides = {}) {
+  return {
+    slug: `core-${String(index).padStart(3, '0')}`,
+    word: `core-${index}`,
+    family: `family-${index % 12}`,
+    year: index % 2 === 0 ? '3-4' : '5-6',
+    yearLabel: index % 2 === 0 ? 'Years 3-4' : 'Years 5-6',
+    spellingPool: 'core',
+    accepted: [`core-${index}`],
+    sentence: `Sentence for core word ${index}.`,
+    ...overrides,
+  };
+}
+
+function makeExtraWord(index) {
+  return {
+    slug: `extra-${String(index).padStart(3, '0')}`,
+    word: `extra-${index}`,
+    family: `family-extra-${index % 4}`,
+    year: 'extra',
+    yearLabel: 'Extra',
+    spellingPool: 'extra',
+    accepted: [`extra-${index}`],
+    sentence: `Sentence for extra word ${index}.`,
+  };
+}
+
+function makeRuntimeSnapshot({ coreCount = 20, extraCount = 0, extraWords = [] } = {}) {
+  const coreWords = Array.from({ length: coreCount }, (_, i) => makeCoreWord(i + 1));
+  const extras = Array.from({ length: extraCount }, (_, i) => makeExtraWord(i + 1));
+  const allExtras = [...extras, ...extraWords];
+  const words = [...coreWords, ...allExtras];
+  const wordBySlug = Object.fromEntries(words.map((word) => [word.slug, word]));
+  return { words, wordBySlug, coreWords, extraWords: allExtras };
+}
+
+function secureProgressEntries(words) {
+  return Object.fromEntries(
+    words.map((word) => [word.slug, {
+      stage: 4,
+      attempts: 6,
+      correct: 5,
+      wrong: 1,
+      dueDay: TODAY + 60,
+      lastDay: TODAY - 7,
+      lastResult: true,
+    }]),
+  );
+}
+
+function partialProgressEntries(words, { stage = 2 } = {}) {
+  return Object.fromEntries(
+    words.map((word) => [word.slug, {
+      stage,
+      attempts: 3,
+      correct: 2,
+      wrong: 1,
+      dueDay: TODAY + 1,
+      lastDay: TODAY - 1,
+      lastResult: false,
+    }]),
+  );
+}
+
+function makeSubjectStateRecord({ progress = {}, guardian = {}, prefs = {}, extra = {} } = {}) {
+  return {
+    data: {
+      prefs,
+      progress,
+      guardian,
+      ...extra,
+    },
+  };
+}
+
+// --------------------------------------------------------------------------
+// Characterisation: getSpellingPostMasteryState return shape stays stable.
+// --------------------------------------------------------------------------
+
+test('characterisation: getSpellingPostMasteryState preserves every pre-U1 top-level field', () => {
+  const runtimeSnapshot = makeRuntimeSnapshot({ coreCount: 10 });
+  const subjectStateRecord = makeSubjectStateRecord({
+    progress: secureProgressEntries(runtimeSnapshot.coreWords),
+  });
+  const state = getSpellingPostMasteryState({ subjectStateRecord, runtimeSnapshot, now: NOW_MS });
+
+  // Pre-U1 fields must still exist and have the same semantics.
+  assert.ok('allWordsMega' in state);
+  assert.ok('guardianDueCount' in state);
+  assert.ok('wobblingCount' in state);
+  assert.ok('wobblingDueCount' in state);
+  assert.ok('nonWobblingDueCount' in state);
+  assert.ok('unguardedMegaCount' in state);
+  assert.ok('guardianAvailableCount' in state);
+  assert.ok('guardianMissionState' in state);
+  assert.ok('guardianMissionAvailable' in state);
+  assert.ok('recommendedWords' in state);
+  assert.ok('nextGuardianDueDay' in state);
+
+  // U1 addition — the only new top-level sibling.
+  assert.ok('postMasteryDebug' in state);
+  assert.equal(typeof state.postMasteryDebug, 'object');
+});
+
+// --------------------------------------------------------------------------
+// Happy-path: source === 'service' and counts match computation.
+// --------------------------------------------------------------------------
+
+test('U1 happy: sourceHint "service" yields postMasteryDebug.source === "service" and matching counts', () => {
+  const runtimeSnapshot = makeRuntimeSnapshot({ coreCount: 5 });
+  const subjectStateRecord = makeSubjectStateRecord({
+    progress: secureProgressEntries(runtimeSnapshot.coreWords.slice(0, 2)),
+  });
+  const state = getSpellingPostMasteryState({
+    subjectStateRecord,
+    runtimeSnapshot,
+    now: NOW_MS,
+    sourceHint: 'service',
+  });
+  assert.equal(state.postMasteryDebug.source, 'service');
+  assert.equal(state.postMasteryDebug.publishedCoreCount, 5);
+  assert.equal(state.postMasteryDebug.secureCoreCount, 2);
+  assert.equal(state.postMasteryDebug.blockingCoreCount, 3);
+  assert.equal(state.postMasteryDebug.allWordsMega, false);
+  assert.equal(state.postMasteryDebug.stickyUnlocked, false);
+  assert.equal(state.postMasteryDebug.contentReleaseId, null);
+});
+
+test('U1 happy: sourceHint "worker" flows through to postMasteryDebug.source', () => {
+  const runtimeSnapshot = makeRuntimeSnapshot({ coreCount: 3 });
+  const subjectStateRecord = makeSubjectStateRecord({});
+  const state = getSpellingPostMasteryState({
+    subjectStateRecord,
+    runtimeSnapshot,
+    now: NOW_MS,
+    sourceHint: 'worker',
+  });
+  assert.equal(state.postMasteryDebug.source, 'worker');
+});
+
+test('U1 happy: unknown sourceHint falls back to "service"', () => {
+  const runtimeSnapshot = makeRuntimeSnapshot({ coreCount: 3 });
+  const state = getSpellingPostMasteryState({
+    subjectStateRecord: makeSubjectStateRecord({}),
+    runtimeSnapshot,
+    now: NOW_MS,
+    sourceHint: 'bogus-source',
+  });
+  assert.equal(state.postMasteryDebug.source, 'service');
+});
+
+// --------------------------------------------------------------------------
+// blockingCoreSlugsPreview — alphabetical, first 10, scrubbed.
+// --------------------------------------------------------------------------
+
+test('U1 happy: blockingCoreSlugsPreview lists first 10 blocking core slugs alphabetically', () => {
+  const runtimeSnapshot = makeRuntimeSnapshot({ coreCount: 15 });
+  const subjectStateRecord = makeSubjectStateRecord({ progress: {} });
+  const state = getSpellingPostMasteryState({ subjectStateRecord, runtimeSnapshot, now: NOW_MS });
+  assert.equal(state.postMasteryDebug.blockingCoreSlugsPreview.length, 10);
+  assert.deepEqual(state.postMasteryDebug.blockingCoreSlugsPreview.slice(0, 3), [
+    'core-001',
+    'core-002',
+    'core-003',
+  ]);
+  const sorted = [...state.postMasteryDebug.blockingCoreSlugsPreview].sort((a, b) => a.localeCompare(b));
+  assert.deepEqual(state.postMasteryDebug.blockingCoreSlugsPreview, sorted);
+});
+
+test('U1 H8 scrub: slugs outside /^[a-z][a-z0-9-]+$/ never reach the preview', () => {
+  const core1 = makeCoreWord(1);
+  const badUpperSlug = { ...makeCoreWord(2), slug: 'Core-002' };
+  const badUnderscoreSlug = { ...makeCoreWord(3), slug: 'core_003' };
+  const words = [core1, badUpperSlug, badUnderscoreSlug];
+  const runtimeSnapshot = {
+    words,
+    wordBySlug: Object.fromEntries(words.map((w) => [w.slug, w])),
+    coreWords: words,
+    extraWords: [],
+  };
+  const state = getSpellingPostMasteryState({
+    subjectStateRecord: makeSubjectStateRecord({}),
+    runtimeSnapshot,
+    now: NOW_MS,
+  });
+  // Only the valid slug passes the regex scrub.
+  assert.deepEqual(state.postMasteryDebug.blockingCoreSlugsPreview, ['core-001']);
+});
+
+test('U1 H8 scrub: word.published === false excludes the slug from the preview', () => {
+  const core1 = makeCoreWord(1);
+  const unpublishedSlug = { ...makeCoreWord(2), slug: 'rude-word-test-do-not-ship', published: false };
+  const words = [core1, unpublishedSlug];
+  const runtimeSnapshot = {
+    words,
+    wordBySlug: Object.fromEntries(words.map((w) => [w.slug, w])),
+    coreWords: words,
+    extraWords: [],
+  };
+  const state = getSpellingPostMasteryState({
+    subjectStateRecord: makeSubjectStateRecord({}),
+    runtimeSnapshot,
+    now: NOW_MS,
+  });
+  assert.deepEqual(state.postMasteryDebug.blockingCoreSlugsPreview, ['core-001']);
+});
+
+// --------------------------------------------------------------------------
+// Edge: empty published core + empty progress.
+// --------------------------------------------------------------------------
+
+test('U1 edge: empty published core => blockingCoreCount 0, preview [], stickyUnlocked false', () => {
+  const runtimeSnapshot = makeRuntimeSnapshot({ coreCount: 0 });
+  const state = getSpellingPostMasteryState({
+    subjectStateRecord: makeSubjectStateRecord({}),
+    runtimeSnapshot,
+    now: NOW_MS,
+  });
+  assert.equal(state.postMasteryDebug.publishedCoreCount, 0);
+  assert.equal(state.postMasteryDebug.blockingCoreCount, 0);
+  assert.deepEqual(state.postMasteryDebug.blockingCoreSlugsPreview, []);
+  assert.equal(state.postMasteryDebug.stickyUnlocked, false);
+  assert.equal(state.postMasteryDebug.allWordsMega, false);
+});
+
+// --------------------------------------------------------------------------
+// Edge: extraWordsIgnoredCount excludes non-core pool.
+// --------------------------------------------------------------------------
+
+test('U1 edge: extraWordsIgnoredCount counts extra-pool progress entries without inflating blocking core', () => {
+  const runtimeSnapshot = makeRuntimeSnapshot({ coreCount: 3, extraCount: 5 });
+  const subjectStateRecord = makeSubjectStateRecord({
+    progress: {
+      ...secureProgressEntries(runtimeSnapshot.coreWords),
+      ...partialProgressEntries(runtimeSnapshot.extraWords, { stage: 2 }),
+    },
+  });
+  const state = getSpellingPostMasteryState({ subjectStateRecord, runtimeSnapshot, now: NOW_MS });
+  assert.equal(state.postMasteryDebug.publishedCoreCount, 3);
+  assert.equal(state.postMasteryDebug.secureCoreCount, 3);
+  assert.equal(state.postMasteryDebug.blockingCoreCount, 0);
+  assert.equal(state.postMasteryDebug.allWordsMega, true);
+  assert.equal(state.postMasteryDebug.extraWordsIgnoredCount, 5);
+});
+
+// --------------------------------------------------------------------------
+// Edge: stickyUnlocked reads `data.postMega != null`.
+// --------------------------------------------------------------------------
+
+test('U1 edge: stickyUnlocked is true when subjectStateRecord.data.postMega is a plain object', () => {
+  const runtimeSnapshot = makeRuntimeSnapshot({ coreCount: 3 });
+  const stateRecord = makeSubjectStateRecord({
+    progress: secureProgressEntries(runtimeSnapshot.coreWords),
+    extra: { postMega: { unlockedAt: 1_777_000_000_000 } },
+  });
+  const state = getSpellingPostMasteryState({ subjectStateRecord: stateRecord, runtimeSnapshot, now: NOW_MS });
+  assert.equal(state.postMasteryDebug.stickyUnlocked, true);
+});
+
+// --------------------------------------------------------------------------
+// guardianMapCount.
+// --------------------------------------------------------------------------
+
+test('U1 edge: guardianMapCount reflects normalised guardian map size', () => {
+  const runtimeSnapshot = makeRuntimeSnapshot({ coreCount: 3 });
+  const [w0, w1] = runtimeSnapshot.coreWords;
+  const subjectStateRecord = makeSubjectStateRecord({
+    progress: secureProgressEntries(runtimeSnapshot.coreWords),
+    guardian: {
+      [w0.slug]: {
+        reviewLevel: 1,
+        lastReviewedDay: TODAY - 3,
+        nextDueDay: TODAY - 1,
+        correctStreak: 0,
+        lapses: 0,
+        renewals: 0,
+        wobbling: false,
+      },
+      [w1.slug]: {
+        reviewLevel: 0,
+        lastReviewedDay: null,
+        nextDueDay: TODAY + 3,
+        correctStreak: 0,
+        lapses: 0,
+        renewals: 0,
+        wobbling: false,
+      },
+    },
+  });
+  const state = getSpellingPostMasteryState({ subjectStateRecord, runtimeSnapshot, now: NOW_MS });
+  assert.equal(state.postMasteryDebug.guardianMapCount, 2);
+});
+
+// --------------------------------------------------------------------------
+// Error path: createLockedPostMasteryState via the client stub carries
+// source: 'locked-fallback'.
+// --------------------------------------------------------------------------
+
+test('U1 error: client-read-models fallback stub attaches postMasteryDebug.source === "locked-fallback"', () => {
+  const service = createSpellingReadModelService({
+    getState: () => ({}),
+  });
+  const snapshot = service.getPostMasteryState('learner-a');
+  assert.ok(snapshot.postMasteryDebug);
+  assert.equal(snapshot.postMasteryDebug.source, 'locked-fallback');
+  assert.equal(snapshot.postMasteryDebug.publishedCoreCount, 0);
+  assert.equal(snapshot.postMasteryDebug.stickyUnlocked, false);
+  assert.deepEqual(snapshot.postMasteryDebug.blockingCoreSlugsPreview, []);
+});
+
+test('U1: buildSpellingLearnerReadModel propagates postMasteryDebug into the postMastery sibling', () => {
+  const runtimeSnapshot = makeRuntimeSnapshot({ coreCount: 5 });
+  const output = buildSpellingLearnerReadModel({
+    subjectStateRecord: makeSubjectStateRecord({
+      progress: secureProgressEntries(runtimeSnapshot.coreWords.slice(0, 2)),
+    }),
+    runtimeSnapshot,
+    now: NOW_MS,
+  });
+  assert.ok(output.postMastery.postMasteryDebug);
+  assert.equal(output.postMastery.postMasteryDebug.publishedCoreCount, 5);
+  assert.equal(output.postMastery.postMasteryDebug.blockingCoreCount, 3);
+});
+
+// --------------------------------------------------------------------------
+// Admin hub integration: postMasteryDebug present when canViewAdminHub true.
+// --------------------------------------------------------------------------
+
+function makeAdminHubLearner(id = 'learner-a') {
+  return {
+    id,
+    name: 'Diagnostic Learner',
+    yearGroup: 'Y5',
+    goal: 'sats',
+    dailyMinutes: 15,
+  };
+}
+
+test('U1 integration: admin hub response includes postMasteryDebug for admin-role viewer', () => {
+  const learner = makeAdminHubLearner();
+  const model = buildAdminHubReadModel({
+    account: { id: 'adult-admin', selectedLearnerId: learner.id, platformRole: 'admin' },
+    platformRole: 'admin',
+    spellingContentBundle: SEEDED_SPELLING_CONTENT_BUNDLE,
+    memberships: [{ learnerId: learner.id, learner, role: 'owner' }],
+    learnerBundles: { [learner.id]: { subjectStates: { spelling: { data: { progress: {} } } } } },
+    runtimeSnapshots: {},
+    selectedLearnerId: learner.id,
+    now: () => NOW_MS,
+  });
+  assert.equal(model.permissions.canViewAdminHub, true);
+  assert.ok(model.postMasteryDebug);
+  assert.equal(typeof model.postMasteryDebug.source, 'string');
+  assert.equal(model.postMasteryDebug.source, 'service');
+  assert.equal(model.reality.postMasteryDebug, 'real');
+});
+
+test('U1 integration: admin hub response returns empty postMasteryDebug envelope for parent-role viewer', () => {
+  const learner = makeAdminHubLearner();
+  const model = buildAdminHubReadModel({
+    account: { id: 'adult-parent', selectedLearnerId: learner.id, platformRole: 'parent' },
+    platformRole: 'parent',
+    spellingContentBundle: SEEDED_SPELLING_CONTENT_BUNDLE,
+    memberships: [{ learnerId: learner.id, learner, role: 'owner' }],
+    learnerBundles: { [learner.id]: { subjectStates: { spelling: { data: { progress: {} } } } } },
+    runtimeSnapshots: {},
+    selectedLearnerId: learner.id,
+    now: () => NOW_MS,
+  });
+  assert.equal(model.permissions.canViewAdminHub, false);
+  assert.ok(model.postMasteryDebug);
+  assert.equal(model.postMasteryDebug.source, 'locked-fallback');
+  assert.equal(model.postMasteryDebug.publishedCoreCount, 0);
+  assert.equal(model.reality.postMasteryDebug, 'placeholder');
+});
+
+// --------------------------------------------------------------------------
+// SpellingSetupScene adult-only link: role gating.
+// --------------------------------------------------------------------------
+
+test('U1 integration: setup scene renders adult-only post-mastery debug link for admin role', async () => {
+  const html = await renderSetupSceneViaBundle({ platformRole: 'admin' });
+  assert.match(html, /Why is Guardian locked\?/);
+  assert.match(html, /data-adult-debug="post-mastery"/);
+  assert.match(html, /data-action="open-admin-hub"/);
+});
+
+test('U1 integration: setup scene renders adult-only post-mastery debug link for ops role', async () => {
+  const html = await renderSetupSceneViaBundle({ platformRole: 'ops' });
+  assert.match(html, /Why is Guardian locked\?/);
+  assert.match(html, /data-adult-debug="post-mastery"/);
+});
+
+test('U1 integration: setup scene omits post-mastery debug link for parent role', async () => {
+  const html = await renderSetupSceneViaBundle({ platformRole: 'parent' });
+  assert.doesNotMatch(html, /Why is Guardian locked\?/);
+  assert.doesNotMatch(html, /data-adult-debug="post-mastery"/);
+});
+
+test('U1 integration: setup scene omits post-mastery debug link when platformRole is empty', async () => {
+  const html = await renderSetupSceneViaBundle({ platformRole: '' });
+  assert.doesNotMatch(html, /Why is Guardian locked\?/);
+});
+
+test('U1 integration: setup scene omits post-mastery debug link for learner role', async () => {
+  const html = await renderSetupSceneViaBundle({ platformRole: 'learner' });
+  assert.doesNotMatch(html, /Why is Guardian locked\?/);
+});


### PR DESCRIPTION
## Summary

- Adds `postMasteryDebug` sibling to `getSpellingPostMasteryState` output, carrying source attribution, published / secure / blocking core counts, first 10 alphabetical blocking slugs (regex + published-only scrubbed per H8), guardianMapCount, extraWordsIgnoredCount, stickyUnlocked, and a contentReleaseId placeholder for U2.
- Surfaces the diagnostic as an additive Admin Hub panel (`<dl>` rendered via `PostMegaSpellingDebugPanel`) gated on `canViewAdminHub({platformRole})`. Parent-role viewers get an empty `source: 'locked-fallback'` envelope.
- Adds an adult-only "Why is Guardian locked?" link on the Spelling setup scene — only rendered when `platformRole ∈ {'admin', 'ops'}` AND the learner has not yet graduated. Child and parent surfaces render absolutely nothing (ICO data-minimisation).

## Test plan

- [x] `npm test -- tests/spelling-post-mastery-debug.test.js` — 20/20 new cases pass (characterisation, happy paths, H8 regex scrub, H8 published-false scrub, empty-core edge, extra-pool exclusion, sticky-unlock, guardianMapCount, locked-fallback source, read-model propagation, admin-hub role gating for admin vs parent, and SpellingSetupScene link rendering for admin / ops / parent / empty / learner).
- [x] `npm test -- tests/spelling-parity.test.js` — 25/25 regression pass.
- [x] `npm test -- tests/react-spelling-surface.test.js` — 24/24 regression pass.
- [x] `npm test -- tests/hub-read-models.test.js` — 32/32 admin hub tests pass.
- [x] `npm test -- tests/spelling-guardian.test.js` — 171/171 guardian tests pass.

## Design notes

- **Additive-hub pattern** (PR #188 Admin Ops P1): the new field lives alongside existing admin-hub siblings; `reality.postMasteryDebug` reports `'real'` or `'placeholder'` so monitoring can tell when the panel is populated.
- **H8 adversarial finding**: `BLOCKING_CORE_SLUG_PATTERN` (`/^[a-z][a-z0-9-]+$/`) + `word.published !== false` filter guards against pre-release or misshapen slugs leaking to screenshots.
- **Source attribution**: `sourceHint` parameter threads through the selector. `createSpellingReadModelService.getPostMasteryState` tags its locked fallback as `'locked-fallback'` so the panel can distinguish a synced service read from a client-only stub.
- **Child posture**: `SpellingSetupScene` accepts `platformRole` (defaulted to empty string) via `SpellingPracticeSurface` from `session.platformRole`. Child / parent roles get no "Why is Guardian locked?" affordance at all.

Closes: refs U1 of `docs/plans/2026-04-26-006-feat-post-mega-spelling-p2-visibility-pattern-foundation-plan.md`.