### PR TITLE
feat(grammar): U8 shared confidence module

### DIFF
--- a/shared/grammar/confidence.js
+++ b/shared/grammar/confidence.js
@@ -1,0 +1,151 @@
+// Grammar confidence — single source of truth for the five-label taxonomy,
+// the derivation function, the status machine, and all child-facing copy
+// mapping. Imported by both the Worker (`worker/src/subjects/grammar/*.js`)
+// and the client (`src/subjects/grammar/*.js`) via relative paths. Keeping
+// this module free of any Worker- or client-specific deps (no engine.js,
+// no view-model.js) means both environments can consume it without import
+// cycles or bundler surprises.
+//
+// Before U8 this taxonomy was defined in three places:
+//   - worker/src/subjects/grammar/read-models.js (authoritative array + deriveGrammarConfidence)
+//   - src/subjects/grammar/components/GrammarAnalyticsScene.jsx (adult chip validation)
+//   - src/subjects/grammar/components/grammar-view-model.js (child-mapping key set)
+// plus two copies of `grammarConceptStatus` (engine.js + client read-model.js).
+// U8 consolidates all of them here. Drift becomes impossible by construction.
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+// The five internal confidence labels emitted by `deriveGrammarConfidence`.
+// Order is "weakest-to-strongest then needs-repair" by semantic intent —
+// consumers iterating the frozen array get that semantic order.
+//
+// Notes:
+// - Low-strength detection is delegated to `status === 'weak'`, not to a raw
+//   strength threshold. The grammarConceptStatus machine is the authoritative
+//   source for "weak"; if it declares a node weak, needs-repair follows.
+//   Raw strength alone does not trigger needs-repair because strength can
+//   drift below a threshold momentarily after a single wrong answer without
+//   the status machine escalating it.
+export const GRAMMAR_CONFIDENCE_LABELS = Object.freeze([
+  'emerging',
+  'building',
+  'consolidating',
+  'secure',
+  'needs-repair',
+]);
+
+// Shared horizon for "recent" windows in the confidence projection. Exposed
+// so parent hubs and other consumers can describe the signal consistently
+// ("missed 2 of the last N attempts"). The engine caps state.recentAttempts
+// at 80 at write time; this is the read-side slice.
+export const GRAMMAR_RECENT_ATTEMPT_HORIZON = 12;
+
+// Child-facing copy for each of the five internal labels. Adult surfaces
+// must never render these — they surface the raw internal label. Keys MUST
+// align with GRAMMAR_CONFIDENCE_LABELS.
+export const GRAMMAR_CHILD_CONFIDENCE_LABEL_MAP = Object.freeze({
+  emerging: 'New',
+  building: 'Learning',
+  'needs-repair': 'Trouble spot',
+  consolidating: 'Nearly secure',
+  secure: 'Secure',
+});
+
+const CONFIDENCE_LABEL_SET = new Set(GRAMMAR_CONFIDENCE_LABELS);
+
+/**
+ * Returns `true` iff `label` is one of the five canonical internal labels.
+ * Used by adult chip components to distinguish in-taxonomy labels from
+ * out-of-taxonomy garbage (the latter must render `'Unknown'`, never silently
+ * fall back to `'emerging'`).
+ */
+export function isGrammarConfidenceLabel(label) {
+  return typeof label === 'string' && CONFIDENCE_LABEL_SET.has(label);
+}
+
+/**
+ * Translates the five internal labels into child-friendly copy. Accepts
+ * `{ label }` so callers can pass the entire confidence projection. Unknown
+ * labels fall back to `'Learning'`, matching the Spelling wording default.
+ */
+export function grammarChildConfidenceLabel({ label } = {}) {
+  if (typeof label !== 'string') return 'Learning';
+  return GRAMMAR_CHILD_CONFIDENCE_LABEL_MAP[label] || 'Learning';
+}
+
+// --- Status machine --------------------------------------------------------
+
+function normaliseMasteryNodeForStatus(value) {
+  const raw = isPlainObject(value) ? value : {};
+  const attemptsRaw = Number(raw.attempts);
+  const correctRaw = Number(raw.correct);
+  const wrongRaw = Number(raw.wrong);
+  const strengthRaw = Number(raw.strength);
+  const intervalRaw = Number(raw.intervalDays);
+  const dueAtRaw = Number(raw.dueAt);
+  const streakRaw = Number(raw.correctStreak);
+  return {
+    attempts: Math.max(0, Math.floor(Number.isFinite(attemptsRaw) ? attemptsRaw : 0)),
+    correct: Math.max(0, Math.floor(Number.isFinite(correctRaw) ? correctRaw : 0)),
+    wrong: Math.max(0, Math.floor(Number.isFinite(wrongRaw) ? wrongRaw : 0)),
+    strength: clamp(Number.isFinite(strengthRaw) ? strengthRaw : 0.25, 0.02, 0.99),
+    intervalDays: Math.max(0, Number.isFinite(intervalRaw) ? intervalRaw : 0),
+    dueAt: Math.max(0, Number.isFinite(dueAtRaw) ? dueAtRaw : 0),
+    correctStreak: Math.max(0, Math.floor(Number.isFinite(streakRaw) ? streakRaw : 0)),
+  };
+}
+
+/**
+ * Canonical status machine. Matches the previously-duplicated versions in
+ * both `worker/src/subjects/grammar/engine.js` and
+ * `src/subjects/grammar/read-model.js` — the thresholds (0.42 weak floor,
+ * 0.82 secured floor, 7-day interval, streak ≥ 3) are identical across
+ * both; U8 proves that and pins it here.
+ *
+ * Returns one of: `'new' | 'weak' | 'due' | 'secured' | 'learning'`.
+ */
+export function grammarConceptStatus(node, now = Date.now()) {
+  const current = Number.isFinite(Number(now)) ? Number(now) : Date.now();
+  const value = normaliseMasteryNodeForStatus(node);
+  if (!value.attempts) return 'new';
+  if (value.strength < 0.42 || value.wrong > value.correct + 1) return 'weak';
+  if ((value.dueAt || 0) <= current) return 'due';
+  if (value.strength >= 0.82 && value.intervalDays >= 7 && value.correctStreak >= 3) return 'secured';
+  return 'learning';
+}
+
+// --- Confidence derivation -------------------------------------------------
+
+/**
+ * Projects a mastery node's coarse stats into one of the five internal
+ * confidence labels. Lifted verbatim from the Worker read-model U6 work;
+ * both client and Worker now import from here.
+ *
+ * Precedence:
+ *   1. attempts ≤ 2                        → 'emerging'    (thin evidence wins)
+ *   2. status === 'weak' OR ≥ 2 misses     → 'needs-repair'
+ *   3. strength ≥ 0.82, streak ≥ 3, >=7d   → 'secure'
+ *   4. strength ≥ 0.82, streak ≥ 3, <7d    → 'consolidating'
+ *   5. default                             → 'building'
+ */
+export function deriveGrammarConfidence(raw) {
+  const input = isPlainObject(raw) ? raw : {};
+  const { status, attempts, strength, correctStreak, intervalDays, recentMisses } = input;
+  const attemptCount = Math.max(0, Number(attempts) || 0);
+  const strengthValue = Number.isFinite(Number(strength)) ? Number(strength) : 0.25;
+  const streak = Math.max(0, Number(correctStreak) || 0);
+  const spacingDays = Math.max(0, Number(intervalDays) || 0);
+  const misses = Math.max(0, Number(recentMisses) || 0);
+
+  if (attemptCount <= 2) return 'emerging';
+  if (status === 'weak' || misses >= 2) return 'needs-repair';
+  if (strengthValue >= 0.82 && streak >= 3 && spacingDays >= 7) return 'secure';
+  if (strengthValue >= 0.82 && streak >= 3 && spacingDays < 7) return 'consolidating';
+  return 'building';
+}

--- a/shared/grammar/confidence.js
+++ b/shared/grammar/confidence.js
@@ -111,7 +111,12 @@ function normaliseMasteryNodeForStatus(value) {
  * Returns one of: `'new' | 'weak' | 'due' | 'secured' | 'learning'`.
  */
 export function grammarConceptStatus(node, now = Date.now()) {
-  const current = Number.isFinite(Number(now)) ? Number(now) : Date.now();
+  // Preserve the pre-U8 Worker semantics exactly: `Number(now) || Date.now()`
+  // treats 0 (and NaN / non-numeric) as "missing" and falls back to the
+  // real wall clock. A stricter `Number.isFinite` check would silently
+  // honour `0` as the Unix epoch, which no production caller passes but
+  // which would be a subtle behavioural regression versus the original.
+  const current = Number(now) || Date.now();
   const value = normaliseMasteryNodeForStatus(node);
   if (!value.attempts) return 'new';
   if (value.strength < 0.42 || value.wrong > value.correct + 1) return 'weak';

--- a/src/subjects/grammar/components/GrammarAnalyticsScene.jsx
+++ b/src/subjects/grammar/components/GrammarAnalyticsScene.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { isGrammarConfidenceLabel } from '../../../../shared/grammar/confidence.js';
 import { progressForGrammarMonster } from '../../../platform/game/monster-system.js';
 import { monsterAsset, monsterAssetSrcSet } from '../../../platform/game/monsters.js';
 import {
@@ -91,21 +92,16 @@ function ParentSummaryDraft({ enrichment }) {
 // sampleSize}` shape or the older flat `confidenceLabel` that some fixtures
 // still seed; falls back to `status` if neither is present so the chip always
 // renders something diagnostic.
-const ADULT_CONFIDENCE_LABELS = new Set([
-  'emerging',
-  'building',
-  'needs-repair',
-  'consolidating',
-  'secure',
-]);
-
+//
+// The set of valid labels comes from `shared/grammar/confidence.js`
+// (U8) — this component only validates, never redefines.
 function adultConfidenceFromRow(row) {
   if (!row || typeof row !== 'object') return null;
   const confidence = isPlainObject(row.confidence) ? row.confidence : null;
   const rawLabel = (typeof confidence?.label === 'string' && confidence.label)
     || (typeof row.confidenceLabel === 'string' && row.confidenceLabel)
     || '';
-  const label = ADULT_CONFIDENCE_LABELS.has(rawLabel) ? rawLabel : '';
+  const label = isGrammarConfidenceLabel(rawLabel) ? rawLabel : '';
   const rawSample = confidence?.sampleSize ?? row.attempts;
   const sampleSize = Number.isFinite(Number(rawSample)) ? Number(rawSample) : 0;
   if (!label && sampleSize <= 0) return null;

--- a/src/subjects/grammar/components/grammar-view-model.js
+++ b/src/subjects/grammar/components/grammar-view-model.js
@@ -11,6 +11,10 @@
 // inline. When new forbidden terms appear we add them here once and every
 // child surface inherits the guard through U10's fixture-driven test.
 
+import {
+  grammarChildConfidenceLabel as grammarChildConfidenceLabelShared,
+  isGrammarConfidenceLabel,
+} from '../../../../shared/grammar/confidence.js';
 import { GRAMMAR_CLIENT_CONCEPTS } from '../metadata.js';
 import {
   GRAMMAR_AGGREGATE_CONCEPTS,
@@ -326,14 +330,11 @@ export function isGrammarChildCopy(text) {
 }
 
 // --- Child confidence label mapping -----------------------------------------
-
-const CHILD_CONFIDENCE_LABELS = Object.freeze({
-  emerging: 'New',
-  building: 'Learning',
-  'needs-repair': 'Trouble spot',
-  consolidating: 'Nearly secure',
-  secure: 'Secure',
-});
+// The internal-label → child-copy mapping lives in `shared/grammar/confidence.js`
+// (U8 consolidation). The tone map stays local because tone is CSS-class
+// vocabulary the shared module has no opinion about. Validation of incoming
+// labels uses `isGrammarConfidenceLabel` so we never silently accept an
+// out-of-taxonomy label.
 
 const CHILD_CONFIDENCE_TONES = Object.freeze({
   emerging: 'new',
@@ -344,15 +345,15 @@ const CHILD_CONFIDENCE_TONES = Object.freeze({
 });
 
 /**
- * Translates the internal five-label taxonomy (`emerging | building |
- * consolidating | secure | needs-repair`) into child-friendly copy. Input
- * shape accepts `{ label }` so callers can pass the entire confidence
- * projection. Unknown labels fall back to `Learning`, matching the Spelling
- * wording default.
+ * Translates the internal five-label taxonomy into child-friendly copy.
+ * Thin wrapper over the shared helper so existing view-model imports
+ * continue to work; validates the incoming label via
+ * `isGrammarConfidenceLabel` first (defensive against fixture drift) and
+ * delegates the actual mapping to `shared/grammar/confidence.js`.
  */
 export function grammarChildConfidenceLabel({ label } = {}) {
-  if (typeof label !== 'string') return 'Learning';
-  return CHILD_CONFIDENCE_LABELS[label] || 'Learning';
+  if (!isGrammarConfidenceLabel(label)) return 'Learning';
+  return grammarChildConfidenceLabelShared({ label });
 }
 
 /**

--- a/src/subjects/grammar/read-model.js
+++ b/src/subjects/grammar/read-model.js
@@ -1,3 +1,4 @@
+import { grammarConceptStatus } from '../../../shared/grammar/confidence.js';
 import { GRAMMAR_CLIENT_CONCEPTS } from './metadata.js';
 
 const QUESTION_TYPE_LABELS = Object.freeze({
@@ -47,15 +48,6 @@ function normaliseMasteryNode(rawValue) {
     lastWrongAt: typeof raw.lastWrongAt === 'string' ? raw.lastWrongAt : null,
     correctStreak: Math.max(0, Math.floor(Number(raw.correctStreak) || 0)),
   };
-}
-
-function grammarConceptStatus(node, nowTs) {
-  const value = normaliseMasteryNode(node);
-  if (!value.attempts) return 'new';
-  if (value.strength < 0.42 || value.wrong > value.correct + 1) return 'weak';
-  if ((value.dueAt || 0) <= nowTs) return 'due';
-  if (value.strength >= 0.82 && value.intervalDays >= 7 && value.correctStreak >= 3) return 'secured';
-  return 'learning';
 }
 
 function accuracyPercent(correct, wrong) {

--- a/tests/grammar-confidence-shared.test.js
+++ b/tests/grammar-confidence-shared.test.js
@@ -182,6 +182,51 @@ test('U8: grammarConceptStatus threshold pin — 0.82 / 7-day / streak-3 boundar
   }, now), 'weak', 'wrong > correct + 1 forces weak even with high strength');
 });
 
+test('U8: grammarConceptStatus(now=0) falls back to Date.now() — preserves pre-U8 Worker semantics', () => {
+  // Pre-U8 Worker code used `Number(now) || Date.now()`, which treats 0 as
+  // "missing" and falls back to the real wall clock. The shared refactor
+  // must preserve this contract: callers that pass literal 0 must NOT be
+  // silently anchored to the Unix epoch (1970-01-01), which would mark
+  // every non-zero `dueAt` as "due" even when the true wall clock is
+  // decades later. This test pins the contract so the drift cannot
+  // re-occur.
+  //
+  // Construct a node whose `dueAt` is a normal present-day timestamp
+  // (well past epoch but in the "not yet due" future relative to the real
+  // wall clock). If `now=0` were honoured literally, `dueAt <= current`
+  // would be true (dueAt >> 0) and the status would be 'due'. With the
+  // fallback, `current = Date.now()` and `dueAt > current`, so the node
+  // lands in its natural status ('secured' here, given the thresholds).
+  const realNow = Date.now();
+  const futureDueAt = realNow + 7 * 24 * 60 * 60 * 1000; // +7 days
+  const securedNode = {
+    attempts: 10,
+    strength: 0.9,
+    correct: 9,
+    wrong: 1,
+    correctStreak: 5,
+    intervalDays: 10,
+    dueAt: futureDueAt,
+  };
+  assert.equal(
+    grammarConceptStatus(securedNode, 0),
+    'secured',
+    'now=0 must fall back to Date.now(); a future dueAt must not be reported as due',
+  );
+  // Same expectation for NaN / non-numeric — the falsy-fallback covers
+  // both shapes uniformly (this mirrors the pre-U8 Worker behaviour).
+  assert.equal(
+    grammarConceptStatus(securedNode, Number.NaN),
+    'secured',
+    'now=NaN must fall back to Date.now()',
+  );
+  assert.equal(
+    grammarConceptStatus(securedNode, 'not-a-number'),
+    'secured',
+    'now=non-numeric string must fall back to Date.now()',
+  );
+});
+
 // --- Drift guard ----------------------------------------------------------
 // After U8, the five-label taxonomy must live in exactly ONE place in
 // production code: `shared/grammar/confidence.js`. Any additional

--- a/tests/grammar-confidence-shared.test.js
+++ b/tests/grammar-confidence-shared.test.js
@@ -1,0 +1,260 @@
+// U8: Shared confidence module — single-source-of-truth invariants.
+// Asserts the five-label taxonomy, derivation function, status machine,
+// and drift guard against duplicate DEFINITIONS in production code.
+//
+// This complements `grammar-confidence.test.js` which tests the
+// derivation-function semantics. Here we focus on module-shape invariants
+// and the drift guard (no duplicate constant definitions in Worker or
+// client code after U8's consolidation).
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  deriveGrammarConfidence,
+  GRAMMAR_CHILD_CONFIDENCE_LABEL_MAP,
+  GRAMMAR_CONFIDENCE_LABELS,
+  GRAMMAR_RECENT_ATTEMPT_HORIZON,
+  grammarChildConfidenceLabel,
+  grammarConceptStatus,
+  isGrammarConfidenceLabel,
+} from '../shared/grammar/confidence.js';
+
+const THIS_FILE_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(THIS_FILE_DIR, '..');
+
+test('U8: GRAMMAR_CONFIDENCE_LABELS has exactly five entries in the canonical Worker order', () => {
+  assert.equal(GRAMMAR_CONFIDENCE_LABELS.length, 5);
+  assert.deepEqual([...GRAMMAR_CONFIDENCE_LABELS], [
+    'emerging',
+    'building',
+    'consolidating',
+    'secure',
+    'needs-repair',
+  ]);
+});
+
+test('U8: GRAMMAR_CONFIDENCE_LABELS is frozen at runtime', () => {
+  assert.ok(Object.isFrozen(GRAMMAR_CONFIDENCE_LABELS));
+  assert.throws(() => { GRAMMAR_CONFIDENCE_LABELS[0] = 'tampered'; });
+});
+
+test('U8: GRAMMAR_RECENT_ATTEMPT_HORIZON is 12 (matches Worker engine write-time slice)', () => {
+  assert.equal(GRAMMAR_RECENT_ATTEMPT_HORIZON, 12);
+});
+
+test('U8: GRAMMAR_CHILD_CONFIDENCE_LABEL_MAP covers all five internal labels', () => {
+  assert.ok(Object.isFrozen(GRAMMAR_CHILD_CONFIDENCE_LABEL_MAP));
+  for (const label of GRAMMAR_CONFIDENCE_LABELS) {
+    assert.equal(typeof GRAMMAR_CHILD_CONFIDENCE_LABEL_MAP[label], 'string',
+      `missing child copy for label '${label}'`);
+  }
+  // Exact mapping — locked to child copy the analytics surface has shipped.
+  assert.deepEqual({ ...GRAMMAR_CHILD_CONFIDENCE_LABEL_MAP }, {
+    emerging: 'New',
+    building: 'Learning',
+    'needs-repair': 'Trouble spot',
+    consolidating: 'Nearly secure',
+    secure: 'Secure',
+  });
+});
+
+test('U8: grammarChildConfidenceLabel maps all five internal labels', () => {
+  assert.equal(grammarChildConfidenceLabel({ label: 'emerging' }), 'New');
+  assert.equal(grammarChildConfidenceLabel({ label: 'building' }), 'Learning');
+  assert.equal(grammarChildConfidenceLabel({ label: 'needs-repair' }), 'Trouble spot');
+  assert.equal(grammarChildConfidenceLabel({ label: 'consolidating' }), 'Nearly secure');
+  assert.equal(grammarChildConfidenceLabel({ label: 'secure' }), 'Secure');
+});
+
+test('U8: grammarChildConfidenceLabel falls back to Learning for unknown / missing input', () => {
+  assert.equal(grammarChildConfidenceLabel({ label: 'unknown' }), 'Learning');
+  assert.equal(grammarChildConfidenceLabel({}), 'Learning');
+  assert.equal(grammarChildConfidenceLabel({ label: null }), 'Learning');
+  assert.equal(grammarChildConfidenceLabel({ label: 42 }), 'Learning');
+  assert.equal(grammarChildConfidenceLabel(), 'Learning');
+});
+
+test('U8: isGrammarConfidenceLabel accepts exactly the five canonical labels', () => {
+  for (const label of GRAMMAR_CONFIDENCE_LABELS) {
+    assert.equal(isGrammarConfidenceLabel(label), true, `expected '${label}' to be valid`);
+  }
+  assert.equal(isGrammarConfidenceLabel('unknown'), false);
+  assert.equal(isGrammarConfidenceLabel(''), false);
+  assert.equal(isGrammarConfidenceLabel(null), false);
+  assert.equal(isGrammarConfidenceLabel(undefined), false);
+  assert.equal(isGrammarConfidenceLabel(42), false);
+  assert.equal(isGrammarConfidenceLabel('Secure'), false, 'case-sensitive; child copy not valid');
+});
+
+test('U8: deriveGrammarConfidence output is always one of the canonical labels', () => {
+  const inputs = [
+    // Emerging — thin evidence
+    { attempts: 0 },
+    { attempts: 1 },
+    { attempts: 2, strength: 0.95 },
+    // Needs-repair — weak status or ≥ 2 misses
+    { status: 'weak', attempts: 8, strength: 0.3 },
+    { status: 'learning', attempts: 10, strength: 0.7, recentMisses: 2 },
+    { status: 'secured', attempts: 20, strength: 0.9, correctStreak: 4, intervalDays: 10, recentMisses: 3 },
+    // Secure — all thresholds met
+    { status: 'secured', attempts: 10, strength: 0.95, correctStreak: 5, intervalDays: 10 },
+    { status: 'secured', attempts: 9, strength: 0.82, correctStreak: 3, intervalDays: 7 },
+    // Consolidating — strength+streak secured but interval < 7
+    { status: 'learning', attempts: 100, strength: 0.95, correctStreak: 10, intervalDays: 3 },
+    // Building — default
+    { status: 'learning', attempts: 4, strength: 0.55, correctStreak: 1, intervalDays: 1 },
+    // Malformed
+    null,
+    undefined,
+    {},
+    { attempts: 'garbage', strength: NaN },
+  ];
+  for (const input of inputs) {
+    const label = deriveGrammarConfidence(input);
+    assert.ok(
+      GRAMMAR_CONFIDENCE_LABELS.includes(label),
+      `deriveGrammarConfidence(${JSON.stringify(input)}) returned '${label}' which is not in GRAMMAR_CONFIDENCE_LABELS`,
+    );
+  }
+});
+
+test('U8: grammarConceptStatus returns canonical statuses ("new" | "weak" | "due" | "secured" | "learning")', () => {
+  const validStatuses = new Set(['new', 'weak', 'due', 'secured', 'learning']);
+  const now = 1_700_000_000_000;
+  // No attempts → new
+  assert.equal(grammarConceptStatus(null, now), 'new');
+  assert.equal(grammarConceptStatus({}, now), 'new');
+  assert.equal(grammarConceptStatus({ attempts: 0 }, now), 'new');
+  // Low strength → weak
+  assert.equal(grammarConceptStatus({ attempts: 5, strength: 0.3, correct: 1, wrong: 4, dueAt: now + 1 }, now), 'weak');
+  // Wrong > correct + 1 → weak
+  assert.equal(grammarConceptStatus({ attempts: 5, strength: 0.6, correct: 1, wrong: 4, dueAt: now + 1 }, now), 'weak');
+  // Due — dueAt <= now
+  assert.equal(grammarConceptStatus({ attempts: 5, strength: 0.6, correct: 4, wrong: 1, dueAt: now - 1 }, now), 'due');
+  // Secured
+  assert.equal(grammarConceptStatus({
+    attempts: 10, strength: 0.9, correct: 9, wrong: 1, correctStreak: 5, intervalDays: 10, dueAt: now + 1,
+  }, now), 'secured');
+  // Learning default
+  assert.equal(grammarConceptStatus({
+    attempts: 5, strength: 0.6, correct: 4, wrong: 1, correctStreak: 1, intervalDays: 1, dueAt: now + 1,
+  }, now), 'learning');
+  // Sanity: all returns are in the allowed set
+  for (const status of ['new', 'weak', 'due', 'secured', 'learning']) {
+    assert.ok(validStatuses.has(status));
+  }
+});
+
+test('U8: grammarConceptStatus threshold pin — 0.82 / 7-day / streak-3 boundaries are canonical', () => {
+  const now = 2_000_000_000_000;
+  // Exactly at the secured boundary
+  assert.equal(grammarConceptStatus({
+    attempts: 10, strength: 0.82, correct: 8, wrong: 2, correctStreak: 3, intervalDays: 7, dueAt: now + 1,
+  }, now), 'secured');
+  // Just below the strength threshold
+  assert.equal(grammarConceptStatus({
+    attempts: 10, strength: 0.819, correct: 8, wrong: 2, correctStreak: 3, intervalDays: 7, dueAt: now + 1,
+  }, now), 'learning');
+  // Just below the streak threshold
+  assert.equal(grammarConceptStatus({
+    attempts: 10, strength: 0.9, correct: 8, wrong: 2, correctStreak: 2, intervalDays: 7, dueAt: now + 1,
+  }, now), 'learning');
+  // Just below the interval threshold
+  assert.equal(grammarConceptStatus({
+    attempts: 10, strength: 0.9, correct: 8, wrong: 2, correctStreak: 3, intervalDays: 6.99, dueAt: now + 1,
+  }, now), 'learning');
+  // 0.42 weak floor: strictly below is weak
+  assert.equal(grammarConceptStatus({
+    attempts: 5, strength: 0.419, correct: 3, wrong: 2, dueAt: now + 1,
+  }, now), 'weak', 'strength strictly below 0.42 is weak');
+  // Exactly 0.42 and wrong <= correct+1 is not weak; falls through to
+  // due (dueAt > now+1 suppresses due, so it becomes 'learning' here)
+  assert.equal(grammarConceptStatus({
+    attempts: 5, strength: 0.42, correct: 3, wrong: 2, dueAt: now + 1,
+  }, now), 'learning', 'strength exactly at 0.42 is not weak (< is strict)');
+  // wrong > correct + 1 (wrong=4, correct=2) forces weak regardless of strength
+  assert.equal(grammarConceptStatus({
+    attempts: 6, strength: 0.9, correct: 2, wrong: 4, dueAt: now + 1,
+  }, now), 'weak', 'wrong > correct + 1 forces weak even with high strength');
+});
+
+// --- Drift guard ----------------------------------------------------------
+// After U8, the five-label taxonomy must live in exactly ONE place in
+// production code: `shared/grammar/confidence.js`. Any additional
+// definition — array of all five strings, map keyed by all five, Set with
+// all five — is drift. We scan a curated list of production files for the
+// five-literal signature; only the shared module and test files are
+// allowed to contain it.
+
+const PRODUCTION_FILES_TO_SCAN = [
+  'worker/src/subjects/grammar/read-models.js',
+  'worker/src/subjects/grammar/engine.js',
+  'src/subjects/grammar/read-model.js',
+  'src/subjects/grammar/components/GrammarAnalyticsScene.jsx',
+  'src/subjects/grammar/components/grammar-view-model.js',
+];
+
+async function loadFile(relPath) {
+  const absolute = path.join(REPO_ROOT, relPath);
+  return readFile(absolute, 'utf8');
+}
+
+// Detects the historical drift shape: an ARRAY literal (or `new Set([...])`)
+// that enumerates all five internal labels as STRING VALUES. This is the
+// precise drift that U8 lifts out of `GrammarAnalyticsScene.jsx`'s
+// `ADULT_CONFIDENCE_LABELS` and `read-models.js`'s `GRAMMAR_CONFIDENCE_LABELS`.
+// Legitimate per-label maps (object literals keyed by label, mapping each
+// to a distinct value like a CSS tone or child copy) are NOT drift — each
+// label is a key, not a value. The distinction: drift repeats the taxonomy;
+// per-label maps consume it.
+const LABEL_LITERALS = Object.freeze(['emerging', 'building', 'consolidating', 'secure', 'needs-repair']);
+
+function countDuplicateLabelArrays(source) {
+  // Match any [ ... ] or Set(... [...]) block where all five labels appear
+  // as quoted strings inside the brackets within a 400-char window. We
+  // constrain the match to ARRAY / SET CONSTRUCTOR shape so that per-label
+  // maps (object literals with label keys) do not trigger the guard.
+  const WINDOW = 400;
+  const quotedVariants = LABEL_LITERALS.map((label) => [`'${label}'`, `"${label}"`, `\`${label}\``]);
+  let hits = 0;
+  // Scan every '[' as a potential array-literal start.
+  for (let start = 0; start < source.length; start += 1) {
+    if (source[start] !== '[') continue;
+    const window = source.slice(start, start + WINDOW);
+    let allPresent = true;
+    for (const variants of quotedVariants) {
+      if (!variants.some((v) => window.includes(v))) {
+        allPresent = false;
+        break;
+      }
+    }
+    if (!allPresent) continue;
+    // This array literal contains all five labels as quoted values —
+    // this is the duplicate-taxonomy drift shape.
+    hits += 1;
+    start += WINDOW;
+  }
+  return hits;
+}
+
+test('U8 drift guard: no production file outside shared/grammar defines all five labels as an array', async () => {
+  for (const file of PRODUCTION_FILES_TO_SCAN) {
+    const source = await loadFile(file);
+    const hits = countDuplicateLabelArrays(source);
+    assert.equal(
+      hits,
+      0,
+      `${file} contains an array literal of all five confidence labels — this duplicates GRAMMAR_CONFIDENCE_LABELS in shared/grammar/confidence.js. Remove the duplicate and import from shared.`,
+    );
+  }
+});
+
+test('U8 drift guard: shared/grammar/confidence.js itself contains the canonical array', async () => {
+  const source = await loadFile('shared/grammar/confidence.js');
+  const hits = countDuplicateLabelArrays(source);
+  assert.equal(hits, 1, 'shared/grammar/confidence.js should contain exactly one array of all five labels (GRAMMAR_CONFIDENCE_LABELS)');
+});

--- a/tests/grammar-confidence.test.js
+++ b/tests/grammar-confidence.test.js
@@ -4,7 +4,7 @@ import assert from 'node:assert/strict';
 import {
   deriveGrammarConfidence,
   GRAMMAR_CONFIDENCE_LABELS,
-} from '../worker/src/subjects/grammar/read-models.js';
+} from '../shared/grammar/confidence.js';
 
 test('U6: GRAMMAR_CONFIDENCE_LABELS lists all five labels', () => {
   assert.deepEqual(GRAMMAR_CONFIDENCE_LABELS.slice().sort(), [

--- a/worker/src/subjects/grammar/engine.js
+++ b/worker/src/subjects/grammar/engine.js
@@ -2,6 +2,7 @@ import {
   cloneSerialisable,
   normalisePracticeSessionRecord,
 } from '../../../../src/platform/core/repositories/helpers.js';
+import { grammarConceptStatus } from '../../../../shared/grammar/confidence.js';
 import { BadRequestError, NotFoundError } from '../../errors.js';
 import { compileGrammarAiEnrichment } from './ai-enrichment.js';
 import {
@@ -332,16 +333,6 @@ export function normaliseServerGrammarData(rawValue) {
     transferEvidence: isPlainObject(raw.transferEvidence) ? cloneSerialisable(raw.transferEvidence) : {},
     aiEnrichment: normalisePersistentAiEnrichment(raw.aiEnrichment),
   };
-}
-
-export function grammarConceptStatus(node, now = Date.now()) {
-  const current = Number(now) || Date.now();
-  const value = normaliseNode(node);
-  if (!value.attempts) return 'new';
-  if (value.strength < 0.42 || value.wrong > value.correct + 1) return 'weak';
-  if ((value.dueAt || 0) <= current) return 'due';
-  if (value.strength >= 0.82 && value.intervalDays >= 7 && value.correctStreak >= 3) return 'secured';
-  return 'learning';
 }
 
 export function createInitialGrammarState(data = {}) {
@@ -1921,3 +1912,8 @@ export {
   LOCKED_MODES as GRAMMAR_LOCKED_MODES,
   SERVER_AUTHORITY as GRAMMAR_SERVER_AUTHORITY,
 };
+
+// Re-export the status machine from the shared module so Worker-side consumers
+// that import from engine.js (e.g., `./read-models.js`, tests) keep working.
+// The single source of truth lives in `shared/grammar/confidence.js`.
+export { grammarConceptStatus };

--- a/worker/src/subjects/grammar/read-models.js
+++ b/worker/src/subjects/grammar/read-models.js
@@ -9,8 +9,13 @@ import {
   GRAMMAR_ENABLED_MODES,
   GRAMMAR_LOCKED_MODES,
   GRAMMAR_SERVER_AUTHORITY,
-  grammarConceptStatus,
 } from './engine.js';
+import {
+  deriveGrammarConfidence,
+  GRAMMAR_CONFIDENCE_LABELS,
+  GRAMMAR_RECENT_ATTEMPT_HORIZON,
+  grammarConceptStatus,
+} from '../../../../shared/grammar/confidence.js';
 import {
   GRAMMAR_TRANSFER_PROMPTS,
   GRAMMAR_TRANSFER_MAX_PROMPTS as GRAMMAR_TRANSFER_MAX_PROMPTS_LIMIT,
@@ -384,7 +389,9 @@ function safeSession(session, now = Date.now()) {
 }
 
 // U6 confidence taxonomy — five labels driven by strength, streak, recent
-// misses, and spacing. Derived read-model projection; never mutates state.
+// misses, and spacing. See `shared/grammar/confidence.js` for the single
+// source of truth (U8 lifted the derivation + label array + status machine
+// into that shared module so client and Worker can never drift).
 //
 //   emerging     <= 2 attempts (thin evidence, show as "Emerging")
 //   needs-repair weak status OR >= 2 recent misses
@@ -392,29 +399,6 @@ function safeSession(session, now = Date.now()) {
 //   consolidating strength >= 0.82 AND correctStreak >= 3 AND intervalDays < 7
 //                (heavy same-week practice, not yet spaced)
 //   building     everything else
-//
-// Notes:
-// - Low-strength detection is delegated to `status === 'weak'`, not to a raw
-//   strength threshold. The grammarConceptStatus machine is the authoritative
-//   source for "weak"; if it declares a node weak, needs-repair follows.
-//   Raw strength alone does not trigger needs-repair because strength can
-//   drift below a threshold momentarily after a single wrong answer without
-//   the status machine escalating it.
-// - The label order is "weakest-to-strongest then needs-repair" by semantic
-//   intent. Consumers iterating the frozen array get that semantic order.
-export const GRAMMAR_CONFIDENCE_LABELS = Object.freeze([
-  'emerging',
-  'building',
-  'consolidating',
-  'secure',
-  'needs-repair',
-]);
-
-// Shared horizon for "recent" windows in the confidence projection.
-// Exposed so parent hubs and other consumers can describe the signal
-// consistently ("missed 2 of the last N attempts"). The engine caps
-// state.recentAttempts at 80 at write time; this is the read-side slice.
-export const GRAMMAR_RECENT_ATTEMPT_HORIZON = 12;
 
 function intervalDaysFromNode(node) {
   if (!node) return 0;
@@ -457,22 +441,6 @@ function distinctTemplatesFor(recentAttempts, matcher) {
     }
   }
   return seen.size;
-}
-
-export function deriveGrammarConfidence(raw) {
-  const input = isPlainObject(raw) ? raw : {};
-  const { status, attempts, strength, correctStreak, intervalDays, recentMisses } = input;
-  const attemptCount = Math.max(0, Number(attempts) || 0);
-  const strengthValue = Number.isFinite(Number(strength)) ? Number(strength) : 0.25;
-  const streak = Math.max(0, Number(correctStreak) || 0);
-  const spacingDays = Math.max(0, Number(intervalDays) || 0);
-  const misses = Math.max(0, Number(recentMisses) || 0);
-
-  if (attemptCount <= 2) return 'emerging';
-  if (status === 'weak' || misses >= 2) return 'needs-repair';
-  if (strengthValue >= 0.82 && streak >= 3 && spacingDays >= 7) return 'secure';
-  if (strengthValue >= 0.82 && streak >= 3 && spacingDays < 7) return 'consolidating';
-  return 'building';
 }
 
 function conceptMap(state, now) {


### PR DESCRIPTION
## Summary

Phase 4 U8: extract Grammar's 5-label confidence taxonomy, derivation, and status machine into a single shared module at `shared/grammar/confidence.js`. Matches the `shared/spelling/` and `shared/punctuation/` pattern. Worker and client both import via relative paths — drift becomes impossible by construction.

**Before U8** — the taxonomy was defined in three places:
- `worker/src/subjects/grammar/read-models.js` (authoritative `GRAMMAR_CONFIDENCE_LABELS` + `deriveGrammarConfidence`)
- `src/subjects/grammar/components/GrammarAnalyticsScene.jsx` (`ADULT_CONFIDENCE_LABELS` Set — duplicate)
- `src/subjects/grammar/components/grammar-view-model.js` (`CHILD_CONFIDENCE_LABELS` map — duplicate, child-mapped)

Plus `grammarConceptStatus` was duplicated across `worker/src/subjects/grammar/engine.js` and `src/subjects/grammar/read-model.js`.

**After U8** — all definitions live in `shared/grammar/confidence.js`. Worker re-exports `grammarConceptStatus` from engine.js for back-compat (tests/grammar-engine.test.js imports it from there).

## Threshold divergence check

**No divergence found.** Worker and client `grammarConceptStatus` have identical thresholds:
- 0.42 weak floor (`value.strength < 0.42`)
- 0.82 secured floor
- interval ≥ 7 days
- streak ≥ 3

Node-normalisation code paths differed cosmetically (`clamp()` vs inline `Math.max/Math.min`, looped vs explicit field list) but produced identical output for every input shape Worker emits. Worker's version was retained as canonical and unified in `shared/grammar/confidence.js`. The `secured` status regression-pin is covered by new boundary tests in `tests/grammar-confidence-shared.test.js`.

## Module exports

`shared/grammar/confidence.js`:
- `GRAMMAR_CONFIDENCE_LABELS` — frozen 5-entry array (Worker canonical order: emerging, building, consolidating, secure, needs-repair)
- `GRAMMAR_CHILD_CONFIDENCE_LABEL_MAP` — frozen object mapping each internal label to child copy
- `GRAMMAR_RECENT_ATTEMPT_HORIZON = 12`
- `isGrammarConfidenceLabel(label)` — membership check
- `grammarChildConfidenceLabel({ label })` — child copy mapper (fallback `'Learning'`)
- `grammarConceptStatus(node, now)` — status machine
- `deriveGrammarConfidence({ status, attempts, strength, correctStreak, intervalDays, recentMisses })` — confidence projection

## Test plan

- [x] `tests/grammar-confidence-shared.test.js` — 12 tests cover module invariants + drift guard. Drift guard scans 5 production files for array-literal definitions of all 5 labels and asserts zero hits outside `shared/grammar/confidence.js`.
- [x] `tests/grammar-confidence.test.js` — 9 existing tests pass with import redirected to shared.
- [x] `tests/grammar-engine.test.js` — 32 tests pass (grammarConceptStatus re-exported from engine.js).
- [x] `tests/grammar-ui-model.test.js` — 81 tests pass (grammarChildConfidenceLabel wraps shared helper).
- [x] `tests/react-grammar-surface.test.js` + `tests/worker-grammar-subject-runtime.test.js` — 136 tests pass.
- [x] `npm run check` — build + audit clean.

## Files changed

- New: `shared/grammar/confidence.js`, `tests/grammar-confidence-shared.test.js`
- Modified: `worker/src/subjects/grammar/{read-models,engine}.js`, `src/subjects/grammar/read-model.js`, `src/subjects/grammar/components/{GrammarAnalyticsScene.jsx,grammar-view-model.js}`, `tests/grammar-confidence.test.js`

## Follow-ups

- U7 (parent/admin-hub confidence surfacing) depends on this landing. U7 can now consume `isGrammarConfidenceLabel` and the shared child-label map directly.