### PR TITLE
feat(punctuation): U3 — map status honesty (new vs unknown)

### DIFF
--- a/src/subjects/punctuation/client-read-models.js
+++ b/src/subjects/punctuation/client-read-models.js
@@ -27,13 +27,60 @@ function stripForbiddenChildScopeFields(state) {
   return rest;
 }
 
+// Phase 4 U3 (origin R4): derive the `analytics.available` signal from the
+// shape of the raw analytics payload the Worker projected (or didn't). The
+// Punctuation Map branches on this value to distinguish three states that
+// used to be indistinguishable in the UI:
+//
+//   - `true`    — the Worker projected a non-empty `skillRows` array. Real
+//                 evidence is available; the Map renders per-skill status.
+//   - `'empty'` — the projection ran and yielded zero rows (fresh learner,
+//                 legitimately no evidence yet). The Map renders every skill
+//                 as `'new'`, preserving the pre-U3 fresh-learner copy.
+//   - `false`   — the payload is missing or malformed (Worker timeout /
+//                 degraded state / serialiser failure). The Map renders every
+//                 skill as `'unknown'` with a child-friendly "We'll unlock
+//                 this after your next round." helper line.
+//
+// Plan R4 (line 538-539) pins the `'empty'` vs `false` distinction: an
+// honest empty-evidence state must read differently from a payload failure.
+// When the upstream projection already emits an explicit `available` value,
+// that value is authoritative — the derivation only fills the gap when the
+// signal hasn't been set upstream. This respects the plan's rule that the
+// availability signal ORIGINATES upstream and the client surface merely
+// surfaces it.
+export function deriveAnalyticsAvailability(analytics) {
+  if (!analytics || typeof analytics !== 'object' || Array.isArray(analytics)) return false;
+  if (analytics.available === true || analytics.available === false || analytics.available === 'empty') {
+    return analytics.available;
+  }
+  if (!Array.isArray(analytics.skillRows)) return false;
+  return analytics.skillRows.length === 0 ? 'empty' : true;
+}
+
+// Phase 4 U3: attach an `analytics.available` signal to the read-model so
+// the Map scene can branch on payload availability without re-inspecting
+// the raw snapshot shape at every render. The returned object is a shallow
+// copy so the caller never mutates a frozen input.
+function withAnalyticsAvailability(state) {
+  if (!state || typeof state !== 'object' || Array.isArray(state)) return state;
+  const rawAnalytics = state.analytics && typeof state.analytics === 'object' && !Array.isArray(state.analytics)
+    ? state.analytics
+    : null;
+  const available = deriveAnalyticsAvailability(rawAnalytics);
+  const nextAnalytics = rawAnalytics
+    ? { ...rawAnalytics, available }
+    : { available };
+  return { ...state, analytics: nextAnalytics };
+}
+
 export function createPunctuationReadModelService({ getState } = {}) {
   return {
     initState(rawState) {
       const base = rawState && typeof rawState === 'object' && !Array.isArray(rawState)
         ? { ...createInitialPunctuationState(), ...clone(rawState) }
         : createInitialPunctuationState();
-      return stripForbiddenChildScopeFields(base);
+      return withAnalyticsAvailability(stripForbiddenChildScopeFields(base));
     },
     getPrefs(learnerId) {
       return normalisePunctuationPrefs(currentUi(getState, learnerId).ui.prefs);

--- a/src/subjects/punctuation/client-read-models.js
+++ b/src/subjects/punctuation/client-read-models.js
@@ -35,26 +35,33 @@ function stripForbiddenChildScopeFields(state) {
 //   - `true`    — the Worker projected a non-empty `skillRows` array. Real
 //                 evidence is available; the Map renders per-skill status.
 //   - `'empty'` — the projection ran and yielded zero rows (fresh learner,
-//                 legitimately no evidence yet). The Map renders every skill
-//                 as `'new'`, preserving the pre-U3 fresh-learner copy.
-//   - `false`   — the payload is missing or malformed (Worker timeout /
-//                 degraded state / serialiser failure). The Map renders every
-//                 skill as `'unknown'` with a child-friendly "We'll unlock
-//                 this after your next round." helper line.
+//                 legitimately no evidence yet), OR the payload is simply
+//                 absent because the upstream worker has not yet wired its
+//                 availability emission (plan R4 defers the upstream half to
+//                 a future PR). The Map renders every skill as `'new'`,
+//                 preserving the pre-U3 fresh-learner copy.
+//   - `false`   — the upstream EXPLICITLY emitted `available: false` (Worker
+//                 timeout / degraded state / serialiser failure). The Map
+//                 renders every skill as `'unknown'` with a child-friendly
+//                 helper line. `false` requires an explicit upstream signal;
+//                 the client NEVER infers `false` from the absence of a
+//                 payload.
 //
-// Plan R4 (line 538-539) pins the `'empty'` vs `false` distinction: an
-// honest empty-evidence state must read differently from a payload failure.
-// When the upstream projection already emits an explicit `available` value,
-// that value is authoritative — the derivation only fills the gap when the
-// signal hasn't been set upstream. This respects the plan's rule that the
-// availability signal ORIGINATES upstream and the client surface merely
-// surfaces it.
+// **Review follow-on (PR #269)**: the BLOCKING defect in the original shape
+// was that a cold-start learner (no upstream emission wired yet) fell into
+// the null-branch and received `false`, rendering 14 "Unknown" chips and
+// 14 copies of the helper line. That is a visible UX regression worse than
+// the pre-U3 silent-'new' behaviour. The null-branch default now flips to
+// `'empty'` — the honest "no evidence yet" reading — so fresh learners see
+// pre-U3 fresh-learner copy until upstream wires its explicit signal. Once
+// that upstream wiring lands, any degraded emission (`available: false`)
+// flows through untouched and triggers the 'unknown' UX correctly.
 export function deriveAnalyticsAvailability(analytics) {
-  if (!analytics || typeof analytics !== 'object' || Array.isArray(analytics)) return false;
+  if (!analytics || typeof analytics !== 'object' || Array.isArray(analytics)) return 'empty';
   if (analytics.available === true || analytics.available === false || analytics.available === 'empty') {
     return analytics.available;
   }
-  if (!Array.isArray(analytics.skillRows)) return false;
+  if (!Array.isArray(analytics.skillRows)) return 'empty';
   return analytics.skillRows.length === 0 ? 'empty' : true;
 }
 

--- a/src/subjects/punctuation/components/PunctuationMapScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationMapScene.jsx
@@ -51,6 +51,7 @@ import {
   buildPunctuationMapModel,
   composeIsDisabled,
   punctuationChildStatusLabel,
+  punctuationChildUnknownHelperCopy,
   punctuationMonsterDisplayName,
   punctuationSkillRuleOneLiner,
 } from './punctuation-view-model.js';
@@ -161,8 +162,11 @@ function SkillCard({ skill, disabled, actions }) {
   // Phase 4 U3: when analytics is degraded, every skill arrives with
   // `status: 'unknown'`. The card renders a child-friendly helper line
   // underneath the rule one-liner so a learner understands they haven't
-  // done anything wrong — the system is just waiting for the next round
-  // of evidence. Copy is locked verbatim per plan R4 test scenarios.
+  // done anything wrong — the system is waiting on evidence. The string
+  // is routed through `punctuationChildUnknownHelperCopy()` so the copy
+  // lands under the same governance as the chip label (helper sits in
+  // `punctuation-view-model.js`); a future forbidden-term sweep or copy
+  // tune lands in one place.
   const isUnknown = skill.status === 'unknown';
   return (
     <article className="punctuation-map-skill-card" data-skill-id={skill.skillId}>
@@ -175,7 +179,7 @@ function SkillCard({ skill, disabled, actions }) {
       <p className="punctuation-map-skill-rule">{punctuationSkillRuleOneLiner(skill.skillId)}</p>
       {isUnknown ? (
         <p className="punctuation-map-skill-unknown-helper muted">
-          We&apos;ll unlock this after your next round.
+          {punctuationChildUnknownHelperCopy()}
         </p>
       ) : null}
       <div className="punctuation-map-skill-actions actions">

--- a/src/subjects/punctuation/components/PunctuationMapScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationMapScene.jsx
@@ -1,4 +1,7 @@
 // Phase 3 U5 — Punctuation Map scene.
+// Phase 4 U3 — `analytics.available` signal → `'unknown'` status with a
+//              child-friendly helper sub-line when the Worker projection
+//              fails or is missing.
 //
 // Browsing surface over the 14 published Punctuation skills, grouped under
 // the 4 active monsters (Pealark / Claspin / Curlune / Quoral). Learners
@@ -15,8 +18,12 @@
 //     forbidden from the browser bundle (bundle-audit rule), so the
 //     mapping is copied here and tested against the plan's fixture.
 //   - Per-skill status: derived client-side from the analytics snapshot's
-//     `skillRows` when available (ui.analytics.skillRows), falling back
-//     to every skill reading as `'new'` for fresh learners.
+//     `skillRows` when `ui.analytics.available === true`. Fresh learners
+//     (`'empty'`) render as `'new'`. A DEGRADED payload (`false`) renders
+//     as `'unknown'` across every skill with a "We'll unlock this after
+//     your next round." helper line (Phase 4 U3 / plan R4 / AE4). The
+//     `analytics.available` signal is attached by the client read-model's
+//     `initState` (`src/subjects/punctuation/client-read-models.js`).
 //   - Active monster state: `buildPunctuationMapModel` iterates only
 //     `ACTIVE_PUNCTUATION_MONSTER_IDS`, full stop — reserved monsters
 //     (Colisk / Hyphang / Carillon) never surface even if the reward
@@ -39,6 +46,7 @@ import {
   ACTIVE_PUNCTUATION_MONSTER_IDS,
   PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER,
   PUNCTUATION_DASHBOARD_HERO,
+  assembleSkillRows,
   bellstormSceneForPhase,
   buildPunctuationMapModel,
   composeIsDisabled,
@@ -51,8 +59,13 @@ import {
   PUNCTUATION_MAP_STATUS_FILTER_IDS,
   normalisePunctuationMapUi,
 } from '../service-contract.js';
-import { PUNCTUATION_CLIENT_SKILLS } from '../read-model.js';
 import { PunctuationSkillDetailModal } from './PunctuationSkillDetailModal.jsx';
+
+// Re-export so tests that historically imported `assembleSkillRows` from
+// the scene file keep working. The canonical definition lives in the
+// view-model (`.js`) so test modules can `await import(...)` it without
+// paying the esbuild-bundled JSX loader cost.
+export { assembleSkillRows };
 
 // Child-facing labels for the status filter chips. `'all'` is a literal
 // "All"; the other five ids reach for the shared child-copy mapping in
@@ -77,36 +90,16 @@ function monsterFilterLabel(id) {
 // against the single source of truth and lets future changes to the shape
 // (e.g. new filter ids) land once.
 
-// Build the 14 skill-row inputs for `buildPunctuationMapModel`. When the
-// Worker-projected analytics snapshot carries `skillRows`, we enrich each
-// row with the client-held name / clusterId (so a rogue payload can't
-// substitute adult copy). Fresh learners or degraded runtimes fall back to
-// "status: 'new'" across every skill, which keeps the Map populated and
-// browsable while the analytics snapshot is empty.
-function assembleSkillRows(ui) {
-  const analytics = ui && typeof ui === 'object' && !Array.isArray(ui) ? ui.analytics : null;
-  const snapshotRows = analytics && Array.isArray(analytics.skillRows) ? analytics.skillRows : [];
-  const snapshotById = new Map();
-  for (const row of snapshotRows) {
-    if (row && typeof row === 'object' && !Array.isArray(row) && typeof row.skillId === 'string') {
-      snapshotById.set(row.skillId, row);
-    }
-  }
-  return PUNCTUATION_CLIENT_SKILLS.map((skill) => {
-    const snap = snapshotById.get(skill.id) || null;
-    const rawStatus = snap && typeof snap.status === 'string' ? snap.status : 'new';
-    return {
-      skillId: skill.id,
-      name: skill.name,
-      clusterId: skill.clusterId,
-      status: rawStatus,
-      attempts: Number(snap?.attempts) || 0,
-      accuracy: Number.isFinite(Number(snap?.accuracy)) ? Number(snap.accuracy) : null,
-      mastery: Number(snap?.mastery) || 0,
-      dueAt: Number(snap?.dueAt) || 0,
-    };
-  });
-}
+// `assembleSkillRows` lives in `./punctuation-view-model.js` so tests can
+// import it via the `.js` loader path. Re-exported at the top of this file
+// so the historical scene-scoped import stays valid.
+
+// Phase 4 U3: module-level latch so the degraded-analytics console warning
+// fires once per process-lifetime, not on every render. The Map re-renders
+// on every filter / detail-state transition; without this latch the
+// devtools console would flood. Resetting to `false` happens only in tests
+// that explicitly re-import the module.
+let analyticsUnavailableWarned = false;
 
 function StatusFilterChips({ activeFilter, disabled, actions }) {
   return (
@@ -165,6 +158,12 @@ function MonsterFilterChips({ activeFilter, disabled, actions }) {
 }
 
 function SkillCard({ skill, disabled, actions }) {
+  // Phase 4 U3: when analytics is degraded, every skill arrives with
+  // `status: 'unknown'`. The card renders a child-friendly helper line
+  // underneath the rule one-liner so a learner understands they haven't
+  // done anything wrong — the system is just waiting for the next round
+  // of evidence. Copy is locked verbatim per plan R4 test scenarios.
+  const isUnknown = skill.status === 'unknown';
   return (
     <article className="punctuation-map-skill-card" data-skill-id={skill.skillId}>
       <header className="punctuation-map-skill-card-head">
@@ -174,6 +173,11 @@ function SkillCard({ skill, disabled, actions }) {
         </span>
       </header>
       <p className="punctuation-map-skill-rule">{punctuationSkillRuleOneLiner(skill.skillId)}</p>
+      {isUnknown ? (
+        <p className="punctuation-map-skill-unknown-helper muted">
+          We&apos;ll unlock this after your next round.
+        </p>
+      ) : null}
       <div className="punctuation-map-skill-actions actions">
         <button
           type="button"
@@ -248,6 +252,23 @@ export function PunctuationMapScene({ ui, actions }) {
     && typeof ui.rewardState === 'object' && !Array.isArray(ui.rewardState)
     ? ui.rewardState
     : {};
+  // Phase 4 U3: surface a one-time console warning when analytics is
+  // unavailable so the degraded state is discoverable during development
+  // and in production devtools. Lives inside a useEffect so SSR never
+  // emits the warning (and the test harness's `renderToStaticMarkup`
+  // pathway stays silent). The module-level `analyticsUnavailableWarned`
+  // latch bounds the warning to once per process lifetime.
+  const analyticsAvailable = ui && typeof ui === 'object' && !Array.isArray(ui) && ui.analytics
+    && typeof ui.analytics === 'object' && !Array.isArray(ui.analytics)
+    ? ui.analytics.available
+    : undefined;
+  React.useEffect(() => {
+    if (analyticsAvailable === false && !analyticsUnavailableWarned) {
+      analyticsUnavailableWarned = true;
+      // eslint-disable-next-line no-console
+      console.warn('[punctuation] analytics unavailable — Map is rendering the "unknown" state');
+    }
+  }, [analyticsAvailable]);
   const skillRows = assembleSkillRows(ui);
   const model = buildPunctuationMapModel(
     skillRows,

--- a/src/subjects/punctuation/components/punctuation-view-model.js
+++ b/src/subjects/punctuation/components/punctuation-view-model.js
@@ -383,9 +383,18 @@ const PUNCTUATION_CHILD_STATUS_LABELS = Object.freeze({
   secure: 'Secure',
   // Phase 4 U3 — degraded-analytics state. Distinct from `'new'` (fresh
   // learner) so a payload-failure does not masquerade as an empty-evidence
-  // Map. Paired with the 'We\'ll unlock this after your next round.' helper
-  // sub-line the Map scene renders under each unknown row.
-  unknown: 'Unknown',
+  // Map. Paired with the helper sub-line the Map scene renders under each
+  // unknown row (see `punctuationChildUnknownHelperCopy`).
+  //
+  // Review follow-on (PR #269): the original 'Unknown' label was adult /
+  // clinical register and fired against EVERY fresh learner because the
+  // default null-branch in `deriveAnalyticsAvailability` produced `false`.
+  // Flipping the null-branch to `'empty'` means this label now only ever
+  // surfaces when the upstream EXPLICITLY emits degraded state — so the
+  // wording can relax into child register per plan R4 (line 541:
+  // "`punctuationChildStatusLabel('unknown')` → 'Check back later' or
+  // similar"). Chose the plan's first-suggested wording verbatim.
+  unknown: 'Check back later',
 });
 
 /**
@@ -396,6 +405,21 @@ const PUNCTUATION_CHILD_STATUS_LABELS = Object.freeze({
 export function punctuationChildStatusLabel(status) {
   if (typeof status !== 'string' || !status) return 'New';
   return PUNCTUATION_CHILD_STATUS_LABELS[status] || 'New';
+}
+
+// Phase 4 U3 (review follow-on): the helper sub-line that renders under
+// every `'unknown'` skill row. Routed through this helper so the copy
+// lands under the same governance layer as `punctuationChildStatusLabel`
+// — a future forbidden-term sweep over the helper text lands here, not
+// in a JSX literal inside the scene file. The wording softens away from
+// the original "We'll unlock this after your next round." because the
+// upstream worker does NOT currently wire `ui.analytics` on round
+// complete (that upstream emission is deferred by plan R4 to a future
+// PR). Until that wiring lands, a causal "next round" promise would be
+// broken. The replacement phrasing keeps the reassuring tone (nothing
+// the learner did wrong) without the unhonourable causal claim.
+export function punctuationChildUnknownHelperCopy() {
+  return "We're still loading your progress.";
 }
 
 // --- Misconception-tag → child label ---------------------------------------

--- a/src/subjects/punctuation/components/punctuation-view-model.js
+++ b/src/subjects/punctuation/components/punctuation-view-model.js
@@ -21,6 +21,7 @@
 
 import { resolveMonsterVisual } from '../../../platform/game/monster-visual-config.js';
 import { MONSTERS_BY_SUBJECT } from '../../../platform/game/monsters.js';
+import { PUNCTUATION_CLIENT_SKILLS } from '../read-model.js';
 import {
   PUNCTUATION_MAP_DETAIL_TAB_IDS,
   PUNCTUATION_MAP_MONSTER_FILTER_IDS,
@@ -380,6 +381,11 @@ const PUNCTUATION_CHILD_STATUS_LABELS = Object.freeze({
   due: 'Due today',
   weak: 'Wobbly',
   secure: 'Secure',
+  // Phase 4 U3 — degraded-analytics state. Distinct from `'new'` (fresh
+  // learner) so a payload-failure does not masquerade as an empty-evidence
+  // Map. Paired with the 'We\'ll unlock this after your next round.' helper
+  // sub-line the Map scene renders under each unknown row.
+  unknown: 'Unknown',
 });
 
 /**
@@ -790,6 +796,53 @@ export function buildPunctuationDashboardModel(stats, learner, rewardState) {
 
 // --- Punctuation Map model builder -----------------------------------------
 
+/**
+ * Build the 14 skill-row inputs for `buildPunctuationMapModel`. Called
+ * once per Map render from `PunctuationMapScene`. When the analytics
+ * snapshot carries `skillRows`, each client-held skill (name + clusterId)
+ * is enriched with its per-skill status / attempts / accuracy / mastery
+ * row. Fresh learners fall back to `status: 'new'` per-skill (pre-U3
+ * behaviour preserved). A DEGRADED analytics state
+ * (`analytics.available === false`) now coerces every skill to
+ * `status: 'unknown'` — the Map no longer pretends a payload failure is
+ * an empty evidence roster (plan R4 / Phase 4 U3, origin R4).
+ *
+ * Pure function over plain data — no React, no SSR. Exported so
+ * `tests/react-punctuation-scene.test.js` can exercise the three
+ * branches (true / false / 'empty') directly without the full render
+ * cost, and so the scene file imports it as a plain helper.
+ */
+export function assembleSkillRows(ui) {
+  const analytics = ui && typeof ui === 'object' && !Array.isArray(ui) ? ui.analytics : null;
+  // `available === false` means the Worker projection failed or was
+  // omitted entirely. Surface the degraded state honestly: every skill
+  // reads as `'unknown'` with the helper sub-line the SkillCard renders.
+  const degraded = analytics && analytics.available === false;
+  const snapshotRows = analytics && Array.isArray(analytics.skillRows) ? analytics.skillRows : [];
+  const snapshotById = new Map();
+  for (const row of snapshotRows) {
+    if (row && typeof row === 'object' && !Array.isArray(row) && typeof row.skillId === 'string') {
+      snapshotById.set(row.skillId, row);
+    }
+  }
+  return PUNCTUATION_CLIENT_SKILLS.map((skill) => {
+    const snap = snapshotById.get(skill.id) || null;
+    const rawStatus = degraded
+      ? 'unknown'
+      : (snap && typeof snap.status === 'string' ? snap.status : 'new');
+    return {
+      skillId: skill.id,
+      name: skill.name,
+      clusterId: skill.clusterId,
+      status: rawStatus,
+      attempts: Number(snap?.attempts) || 0,
+      accuracy: Number.isFinite(Number(snap?.accuracy)) ? Number(snap.accuracy) : null,
+      mastery: Number(snap?.mastery) || 0,
+      dueAt: Number(snap?.dueAt) || 0,
+    };
+  });
+}
+
 function normaliseSkillRow(row) {
   if (!row || typeof row !== 'object' || Array.isArray(row)) return null;
   const skillId = typeof row.skillId === 'string' ? row.skillId : '';
@@ -808,6 +861,11 @@ function normaliseSkillRow(row) {
 
 function deriveStatusForSkill(row) {
   if (!row) return 'new';
+  // Phase 4 U3: preserve the explicit `'unknown'` signal when the Map has
+  // coerced every skill to unknown because analytics is unavailable. The
+  // `attempts === 0` branch below would otherwise silently downgrade
+  // unknown rows to `'new'` and re-introduce the exact bug U3 fixes.
+  if (row.status === 'unknown') return 'unknown';
   if (row.attempts === 0) return 'new';
   return row.status;
 }

--- a/src/subjects/punctuation/service-contract.js
+++ b/src/subjects/punctuation/service-contract.js
@@ -31,8 +31,16 @@ export const PUNCTUATION_OPEN_MAP_ALLOWED_PHASES = Object.freeze(['setup', 'summ
 // Reserved Punctuation monsters (Colisk / Hyphang / Carillon) are absent
 // from the monster filter list so a rogue payload cannot surface a retired
 // name as a filter option.
+//
+// Phase 4 U3 (review follow-on): `'unknown'` is included so the filter chip
+// row stays consistent with the skill-row status enum once the upstream
+// worker starts emitting `analytics.available === false`. Without this
+// entry the degraded state would trap a learner on any non-"All" chip
+// (every skill is `'unknown'`, but the filter has no matching id → the
+// Map renders zero cards with no empty-state message). The chip is a
+// harmless extra slot while the upstream wiring is still deferred.
 export const PUNCTUATION_MAP_STATUS_FILTER_IDS = Object.freeze([
-  'all', 'new', 'learning', 'due', 'weak', 'secure',
+  'all', 'new', 'learning', 'due', 'weak', 'secure', 'unknown',
 ]);
 
 export const PUNCTUATION_MAP_MONSTER_FILTER_IDS = Object.freeze([

--- a/styles/app.css
+++ b/styles/app.css
@@ -10003,6 +10003,22 @@ html { scroll-behavior: smooth; }
   background: var(--warn-soft, #fdf1db);
   color: #805614;
 }
+/* Phase 4 U3 — degraded-analytics state. Muted slate hint so it reads as
+   "waiting on evidence" rather than the warn/alert warmth of Due/Weak.
+   Distinct from the default New chip (no custom class) so a reviewer can
+   tell at a glance whether the Map is rendering an honest empty roster or
+   the unknown fallback. */
+.punctuation-map-skill-status--unknown {
+  background: var(--panel-soft, #eef0f3);
+  color: var(--muted, #4b5563);
+  border: 1px dashed var(--line, #c9ced6);
+}
+.punctuation-map-skill-unknown-helper {
+  margin: -2px 0 8px;
+  font-size: 0.85rem;
+  line-height: 1.35;
+  color: var(--muted);
+}
 .punctuation-map-empty {
   padding: 14px 16px;
   border: 1px dashed var(--line);

--- a/tests/punctuation-map-redaction.test.js
+++ b/tests/punctuation-map-redaction.test.js
@@ -175,11 +175,13 @@ function findForbiddenHits(html) {
 // Map scene sweep — 6 status × 5 monster = 30 render states.
 // ---------------------------------------------------------------------------
 
-test('U7: Map scene SSR is clean across 30 status × monster filter combinations', () => {
+test('U7: Map scene SSR is clean across 35 status × monster filter combinations', () => {
   // Dimensionality lock — if a future unit stretches either filter list,
   // this constant-check forces a deliberate update to the sweep and its
-  // expected combination count in the PR body.
-  assert.equal(PUNCTUATION_MAP_STATUS_FILTER_IDS.length, 6, 'status filter list must stay at 6 entries');
+  // expected combination count in the PR body. Phase 4 U3 review follow-on
+  // (PR #269) added `'unknown'` to the status filter row (6 → 7) so the
+  // degraded-analytics state is filter-reachable.
+  assert.equal(PUNCTUATION_MAP_STATUS_FILTER_IDS.length, 7, 'status filter list must stay at 7 entries');
   assert.equal(PUNCTUATION_MAP_MONSTER_FILTER_IDS.length, 5, 'monster filter list must stay at 5 entries');
 
   const combinations = [];
@@ -188,7 +190,7 @@ test('U7: Map scene SSR is clean across 30 status × monster filter combinations
       combinations.push({ statusFilter, monsterFilter });
     }
   }
-  assert.equal(combinations.length, 30, 'sweep must cover exactly 30 filter combinations');
+  assert.equal(combinations.length, 35, 'sweep must cover exactly 35 filter combinations');
 
   for (const combo of combinations) {
     const harness = createPunctuationHarness();

--- a/tests/punctuation-view-model.test.js
+++ b/tests/punctuation-view-model.test.js
@@ -123,9 +123,12 @@ test('U1 view-model: PUNCTUATION_PRIMARY_MODE_CARDS labels + descriptions use on
 // ---------------------------------------------------------------------------
 
 test('U1 view-model: PUNCTUATION_MAP_STATUS_FILTER_IDS ordered list matches plan', () => {
+  // Phase 4 U3 review follow-on (PR #269): `'unknown'` appended so the
+  // degraded-analytics state is filter-reachable. The other 6 entries stay
+  // in plan-pinned order.
   assert.deepEqual(
     [...PUNCTUATION_MAP_STATUS_FILTER_IDS],
-    ['all', 'new', 'learning', 'due', 'weak', 'secure'],
+    ['all', 'new', 'learning', 'due', 'weak', 'secure', 'unknown'],
   );
   assert.equal(Object.isFrozen(PUNCTUATION_MAP_STATUS_FILTER_IDS), true);
 });

--- a/tests/react-punctuation-scene.test.js
+++ b/tests/react-punctuation-scene.test.js
@@ -575,8 +575,11 @@ test('punctuation Map scene renders the status filter chip row with child copy',
   openMapScene(harness);
   const html = harness.render();
 
-  // Plan: ['All','New','Learning','Due','Wobbly','Secure'].
-  for (const label of ['All', 'New', 'Learning', 'Due today', 'Wobbly', 'Secure']) {
+  // Plan: ['All','New','Learning','Due today','Wobbly','Secure'].
+  // Phase 4 U3 review follow-on (PR #269): `'Check back later'` added for
+  // the degraded-analytics `'unknown'` status (chip is a harmless slot
+  // while upstream wiring is deferred).
+  for (const label of ['All', 'New', 'Learning', 'Due today', 'Wobbly', 'Secure', 'Check back later']) {
     assert.match(html, new RegExp(`>${label}<`), `missing status chip label ${label}`);
   }
   assert.match(html, /data-action="punctuation-map-status-filter"/);
@@ -849,15 +852,39 @@ test('U3 assembleSkillRows: analytics.available=`empty` treats as fresh learner 
   }
 });
 
-test('U3 client-read-models: initState derives analytics.available=false when raw analytics is missing', async () => {
+test('U3 client-read-models: initState derives analytics.available=`empty` when raw analytics is missing', async () => {
+  // Review follow-on (PR #269): flipped from `false` to `'empty'`. The
+  // original contract treated missing-payload as degraded, but the upstream
+  // worker wiring that would emit an explicit `available` signal is
+  // deferred (plan R4). Without this flip, EVERY cold-start learner lands
+  // in the `'unknown'` UX — a visible regression. `false` is now reserved
+  // for the explicit upstream degraded signal; the client never infers
+  // `false` from the absence of a payload.
   const { createPunctuationReadModelService } = await import('../src/subjects/punctuation/client-read-models.js');
   const service = createPunctuationReadModelService({ getState: () => ({}) });
   const state = service.initState({});
   assert.ok(state.analytics, 'initState must surface an analytics object on the read-model');
   assert.equal(
     state.analytics.available,
+    'empty',
+    'missing raw analytics must derive to available: "empty" (no evidence yet, not a failure signal)',
+  );
+});
+
+test('U3 client-read-models: initState honours an explicitly-emitted upstream `false` signal', async () => {
+  // Review follow-on (PR #269): `false` now requires an explicit upstream
+  // emission. This test locks the contract: once the upstream worker
+  // starts emitting `{ available: false }` (Worker timeout / degraded),
+  // the client surfaces that value unchanged so the Map scene fires the
+  // 'unknown' UX correctly. A regression that re-infers `'empty'` when
+  // upstream has spoken would silently swallow the degraded signal.
+  const { createPunctuationReadModelService } = await import('../src/subjects/punctuation/client-read-models.js');
+  const service = createPunctuationReadModelService({ getState: () => ({}) });
+  const state = service.initState({ analytics: { available: false } });
+  assert.equal(
+    state.analytics.available,
     false,
-    'missing raw analytics must derive to available: false (degraded — safest assumption per plan)',
+    'explicit upstream `available: false` must flow through unchanged',
   );
 });
 
@@ -894,41 +921,69 @@ test('U3 client-read-models: initState honours an explicitly set analytics.avail
   assert.equal(state.analytics.available, 'empty');
 });
 
-test('U3 punctuationChildStatusLabel: `unknown` maps to a distinct "Unknown" label', async () => {
+test('U3 punctuationChildStatusLabel: `unknown` maps to the child-register "Check back later" label', async () => {
+  // Review follow-on (PR #269): softened from the original "Unknown"
+  // adult register to the plan's first-suggested child-register wording
+  // (plan line 541: "`punctuationChildStatusLabel('unknown')` →
+  // 'Check back later' or similar"). The explicit 'unknown' id is still
+  // visually distinct from `'new'` so a reviewer can tell the two states
+  // apart in rendered HTML.
   const { punctuationChildStatusLabel } = await import('../src/subjects/punctuation/components/punctuation-view-model.js');
   assert.equal(
     punctuationChildStatusLabel('unknown'),
-    'Unknown',
-    '`unknown` must be visually distinct from `new` on the Map',
+    'Check back later',
+    '`unknown` must render with the child-register "Check back later" label',
   );
   // Regression: existing unknown-string fallback (mystery-bucket) still reads
   // as `New` — only the explicit `'unknown'` id gets the new label.
   assert.equal(punctuationChildStatusLabel('mystery-bucket'), 'New');
 });
 
-test('U3 Map scene SSR: analytics.available=false renders Unknown chip + helper copy (covers AE4)', () => {
+test('U3 punctuationChildUnknownHelperCopy: returns the governed child-register helper string', async () => {
+  // Review follow-on (PR #269): the helper sub-line was previously a raw
+  // JSX literal inside PunctuationMapScene.jsx — unreachable by the
+  // forbidden-term sweep that runs on `punctuation-view-model.js`. Routing
+  // the string through a helper puts it under the same governance as the
+  // chip label.
+  const { punctuationChildUnknownHelperCopy, isPunctuationChildCopy } = await import('../src/subjects/punctuation/components/punctuation-view-model.js');
+  const copy = punctuationChildUnknownHelperCopy();
+  assert.equal(typeof copy, 'string');
+  assert.ok(copy.length > 0, 'helper must return non-empty string');
+  assert.equal(
+    isPunctuationChildCopy(copy),
+    true,
+    'helper copy must pass the forbidden-term sweep',
+  );
+});
+
+test('U3 Map scene SSR: analytics.available=false renders child-register chip + helper copy (covers AE4)', () => {
   const harness = createPunctuationHarness();
   openMapScene(harness);
   // Seed a degraded-analytics payload so the scene renders the unknown state.
   // A plain `false` on the availability signal is the shape production will
-  // emit when the Worker analytics projection fails.
+  // emit when the Worker analytics projection fails (upstream emission
+  // wiring remains deferred by plan R4; this is the shape that contract
+  // anticipates).
   harness.store.updateSubjectUi('punctuation', {
     analytics: { available: false },
   });
 
   const html = harness.render();
 
-  // Every skill chip carries the unknown status class and label.
+  // Every skill chip carries the unknown status class and the child-register
+  // "Check back later" label (review follow-on: label softened from the
+  // original clinical "Unknown").
   assert.match(
     html,
     /punctuation-map-skill-status--unknown/,
     'Map scene must render the unknown status class on degraded analytics',
   );
-  assert.match(html, />Unknown</, 'Map scene must render an "Unknown" chip label');
-  // Child-friendly helper sub-line per plan AE4.
+  assert.match(html, />Check back later</, 'Map scene must render the child-register "Check back later" chip label');
+  // Child-friendly helper sub-line — routed through
+  // `punctuationChildUnknownHelperCopy()` for governance.
   assert.match(
     html,
-    /We(?:'|&#x27;)ll unlock this after your next round\./,
+    /We(?:'|&#x27;)re still loading your progress\./,
     'Map scene must render the child helper copy on unknown rows',
   );
   // Guard against the regression U3 fixes: no silent "New" fallback for
@@ -960,8 +1015,104 @@ test('U3 Map scene SSR: analytics.available=`empty` preserves fresh-learner `New
   );
   assert.doesNotMatch(
     html,
-    /We(?:'|&#x27;)ll unlock this after your next round/,
+    /We(?:'|&#x27;)re still loading your progress/,
     'helper copy must only appear on unknown rows',
+  );
+});
+
+// Review follow-on (PR #269) — BLOCKER 1 regression guard: a cold-start
+// learner with NO `ui.analytics` payload at all (the production shape
+// today because the upstream worker wiring is deferred) must render all
+// 14 skills as `'new'` and NOT as degraded `'unknown'`. Without the
+// null-branch flip in `deriveAnalyticsAvailability`, every fresh learner
+// would hit a wall of 14 "Check back later" chips — a visible UX
+// regression worse than the pre-U3 behaviour.
+test('U3 Map scene SSR: missing `ui.analytics` payload renders fresh-learner `New` copy, NOT the unknown state (BLOCKER 1 lock)', () => {
+  const harness = createPunctuationHarness();
+  openMapScene(harness);
+  // The harness's initial store state has NO analytics field. The surface
+  // pipes the state through `service.initState`, which (via
+  // `withAnalyticsAvailability`) derives `available: 'empty'` and drives
+  // the Map into the fresh-learner branch. This is the exact cold-start
+  // shape production lands in every day until upstream wiring ships.
+  const ui = harness.store.getState().subjectUi.punctuation;
+  assert.equal(
+    ui.analytics,
+    undefined,
+    'initial store-level state must carry no analytics field (service.initState derives the signal at render time)',
+  );
+
+  const html = harness.render();
+
+  // Every skill renders as `'new'`; none renders as `'unknown'`.
+  assert.match(html, /punctuation-map-skill-status--new/);
+  assert.doesNotMatch(
+    html,
+    /punctuation-map-skill-status--unknown/,
+    'cold-start must NOT render as degraded Unknown',
+  );
+  // And the helper copy line stays absent.
+  assert.doesNotMatch(
+    html,
+    /We(?:'|&#x27;)re still loading your progress/,
+    'cold-start must NOT surface the degraded-state helper copy',
+  );
+});
+
+// Review follow-on (PR #269) — BLOCKER 1 pure-function lock: the contract
+// at the read-model layer. `deriveAnalyticsAvailability` must return
+// `'empty'` when the raw analytics payload is missing / null / a
+// non-object. This pairs with the SSR test above by locking the contract
+// at the layer where production bugs are cheapest to catch.
+test('U3 deriveAnalyticsAvailability: null-branch default is `"empty"`, not `false` (BLOCKER 1 contract)', async () => {
+  const { deriveAnalyticsAvailability } = await import('../src/subjects/punctuation/client-read-models.js');
+  // null / undefined / non-object all infer `'empty'` (no evidence yet).
+  assert.equal(deriveAnalyticsAvailability(null), 'empty');
+  assert.equal(deriveAnalyticsAvailability(undefined), 'empty');
+  assert.equal(deriveAnalyticsAvailability([]), 'empty');
+  assert.equal(deriveAnalyticsAvailability('not-an-object'), 'empty');
+  // A present object with NO `available` and NO `skillRows` is still the
+  // no-evidence-yet reading — not the failure reading.
+  assert.equal(deriveAnalyticsAvailability({}), 'empty');
+  // An explicit upstream `false` is surfaced unchanged (strictly reserved
+  // for the upstream degraded signal).
+  assert.equal(deriveAnalyticsAvailability({ available: false }), false);
+});
+
+// Review follow-on (PR #269) — BLOCKER 2 regression guard: the `'unknown'`
+// filter chip must exist so a learner in the degraded state can still
+// filter the Map to their unknown skills. Without this chip, the filter
+// row would trap a degraded-state learner on any non-"All" chip (every
+// skill is `'unknown'`, but the filter has no matching id → the Map
+// renders zero cards with no empty-state message).
+test('U3 Map scene SSR: status filter row includes the `unknown` chip and filtering to it surfaces every skill under degraded analytics (BLOCKER 2 lock)', () => {
+  const harness = createPunctuationHarness();
+  openMapScene(harness);
+  harness.store.updateSubjectUi('punctuation', {
+    analytics: { available: false },
+  });
+  // The chip exists in the filter row.
+  const baselineHtml = harness.render();
+  assert.match(
+    baselineHtml,
+    /data-action="punctuation-map-status-filter"[^>]*data-value="unknown"/,
+    'filter row must render a chip for the `unknown` status id',
+  );
+
+  // Filtering to `unknown` lands in mapUi and the Map still renders every
+  // card (all 14 are `'unknown'` under degraded analytics).
+  harness.dispatch('punctuation-map-status-filter', { value: 'unknown' });
+  assert.equal(
+    harness.store.getState().subjectUi.punctuation.mapUi.statusFilter,
+    'unknown',
+    'unknown must be a valid filter id — paired state assertion',
+  );
+  const filteredHtml = harness.render();
+  const cardMatches = filteredHtml.match(/class="punctuation-map-skill-card"/g) || [];
+  assert.equal(
+    cardMatches.length,
+    14,
+    'filtering to `unknown` under degraded analytics must surface all 14 skills (not an empty list)',
   );
 });
 

--- a/tests/react-punctuation-scene.test.js
+++ b/tests/react-punctuation-scene.test.js
@@ -774,6 +774,209 @@ test('punctuation Map scene live-region count reflects a monster filter flip', (
 });
 
 // ---------------------------------------------------------------------------
+// Phase 4 U3 — Map status honesty: distinguish `new` vs `unknown`.
+//
+// The Map used to silently coerce every skill without a snapshot row to
+// `status: 'new'`, making a degraded-analytics failure visually identical
+// to a fresh learner. U3 introduces `analytics.available: true | false |
+// 'empty'` on the client read-model and a new `'unknown'` status with a
+// child-friendly helper sub-line.
+//
+// Test shape mirrors the plan's U4/R4 specification (docs/plans/2026-04-26
+// -001-*.md line 549-554). Unit tests hit the exported `assembleSkillRows`
+// pure helper; SSR tests render the Map scene with each availability state
+// and assert the chip label / helper copy / forbidden-term sweep holds.
+// ---------------------------------------------------------------------------
+
+test('U3 assembleSkillRows: analytics.available=true + snap present preserves snap.status', async () => {
+  const { assembleSkillRows } = await import('../src/subjects/punctuation/components/punctuation-view-model.js');
+  const rows = assembleSkillRows({
+    analytics: {
+      available: true,
+      skillRows: [
+        { skillId: 'speech', status: 'secure', attempts: 5, accuracy: 100, mastery: 3, dueAt: 0 },
+      ],
+    },
+  });
+  const speech = rows.find((row) => row.skillId === 'speech');
+  assert.ok(speech, 'speech row must be present');
+  assert.equal(speech.status, 'secure', 'snap.status must flow through when analytics is available');
+});
+
+test('U3 assembleSkillRows: analytics.available=true + snap missing for skillId falls back to `new`', async () => {
+  const { assembleSkillRows } = await import('../src/subjects/punctuation/components/punctuation-view-model.js');
+  const rows = assembleSkillRows({
+    analytics: {
+      available: true,
+      skillRows: [], // empty but available → fresh learner per-skill fallback
+    },
+  });
+  // Every skill lacks a snap row, so every status falls back to `'new'` —
+  // current fresh-learner behaviour preserved.
+  for (const row of rows) {
+    assert.equal(row.status, 'new', `skill ${row.skillId} should be 'new' when analytics is available but snap is missing`);
+  }
+});
+
+test('U3 assembleSkillRows: analytics.available=false coerces every skill to `unknown` (degraded)', async () => {
+  const { assembleSkillRows } = await import('../src/subjects/punctuation/components/punctuation-view-model.js');
+  const rows = assembleSkillRows({
+    analytics: {
+      available: false,
+    },
+  });
+  // Degraded analytics → every skill shows as `'unknown'`, not silently `'new'`.
+  // This is the core U3 bug fix: a payload failure is no longer indistinguishable
+  // from a fresh learner.
+  for (const row of rows) {
+    assert.equal(row.status, 'unknown', `skill ${row.skillId} should be 'unknown' when analytics.available is false`);
+  }
+});
+
+test('U3 assembleSkillRows: analytics.available=`empty` treats as fresh learner → `new`', async () => {
+  const { assembleSkillRows } = await import('../src/subjects/punctuation/components/punctuation-view-model.js');
+  const rows = assembleSkillRows({
+    analytics: {
+      available: 'empty',
+      skillRows: [],
+    },
+  });
+  // `'empty'` availability matches the fresh-learner case — projection ran,
+  // no rows yet. Status stays `'new'` so the learner sees the benign "start
+  // from scratch" copy rather than the degraded "Unknown" badge.
+  for (const row of rows) {
+    assert.equal(row.status, 'new', `skill ${row.skillId} should be 'new' when analytics.available is 'empty'`);
+  }
+});
+
+test('U3 client-read-models: initState derives analytics.available=false when raw analytics is missing', async () => {
+  const { createPunctuationReadModelService } = await import('../src/subjects/punctuation/client-read-models.js');
+  const service = createPunctuationReadModelService({ getState: () => ({}) });
+  const state = service.initState({});
+  assert.ok(state.analytics, 'initState must surface an analytics object on the read-model');
+  assert.equal(
+    state.analytics.available,
+    false,
+    'missing raw analytics must derive to available: false (degraded — safest assumption per plan)',
+  );
+});
+
+test('U3 client-read-models: initState derives analytics.available=`empty` when skillRows is an empty array', async () => {
+  const { createPunctuationReadModelService } = await import('../src/subjects/punctuation/client-read-models.js');
+  const service = createPunctuationReadModelService({ getState: () => ({}) });
+  const state = service.initState({ analytics: { skillRows: [] } });
+  assert.equal(
+    state.analytics.available,
+    'empty',
+    'analytics with a valid empty skillRows array must derive to available: "empty" (fresh learner)',
+  );
+});
+
+test('U3 client-read-models: initState derives analytics.available=true when skillRows has entries', async () => {
+  const { createPunctuationReadModelService } = await import('../src/subjects/punctuation/client-read-models.js');
+  const service = createPunctuationReadModelService({ getState: () => ({}) });
+  const state = service.initState({
+    analytics: { skillRows: [{ skillId: 'speech', status: 'secure', attempts: 1 }] },
+  });
+  assert.equal(state.analytics.available, true, 'non-empty skillRows must derive to available: true');
+});
+
+test('U3 client-read-models: initState honours an explicitly set analytics.available signal', async () => {
+  const { createPunctuationReadModelService } = await import('../src/subjects/punctuation/client-read-models.js');
+  const service = createPunctuationReadModelService({ getState: () => ({}) });
+  const state = service.initState({
+    analytics: { available: 'empty', skillRows: [] },
+  });
+  // When the upstream projection has already computed `available`, the
+  // client read-model must NOT re-derive it from shape — the upstream
+  // signal is authoritative (plan R4: the origin is upstream). This test
+  // guards against a regression that silently overrides the upstream value.
+  assert.equal(state.analytics.available, 'empty');
+});
+
+test('U3 punctuationChildStatusLabel: `unknown` maps to a distinct "Unknown" label', async () => {
+  const { punctuationChildStatusLabel } = await import('../src/subjects/punctuation/components/punctuation-view-model.js');
+  assert.equal(
+    punctuationChildStatusLabel('unknown'),
+    'Unknown',
+    '`unknown` must be visually distinct from `new` on the Map',
+  );
+  // Regression: existing unknown-string fallback (mystery-bucket) still reads
+  // as `New` — only the explicit `'unknown'` id gets the new label.
+  assert.equal(punctuationChildStatusLabel('mystery-bucket'), 'New');
+});
+
+test('U3 Map scene SSR: analytics.available=false renders Unknown chip + helper copy (covers AE4)', () => {
+  const harness = createPunctuationHarness();
+  openMapScene(harness);
+  // Seed a degraded-analytics payload so the scene renders the unknown state.
+  // A plain `false` on the availability signal is the shape production will
+  // emit when the Worker analytics projection fails.
+  harness.store.updateSubjectUi('punctuation', {
+    analytics: { available: false },
+  });
+
+  const html = harness.render();
+
+  // Every skill chip carries the unknown status class and label.
+  assert.match(
+    html,
+    /punctuation-map-skill-status--unknown/,
+    'Map scene must render the unknown status class on degraded analytics',
+  );
+  assert.match(html, />Unknown</, 'Map scene must render an "Unknown" chip label');
+  // Child-friendly helper sub-line per plan AE4.
+  assert.match(
+    html,
+    /We(?:'|&#x27;)ll unlock this after your next round\./,
+    'Map scene must render the child helper copy on unknown rows',
+  );
+  // Guard against the regression U3 fixes: no silent "New" fallback for
+  // degraded analytics. The new-status class must not appear on any card
+  // under the unknown state.
+  assert.doesNotMatch(
+    html,
+    /punctuation-map-skill-status--new/,
+    'degraded analytics must NOT silently render as "New"',
+  );
+});
+
+test('U3 Map scene SSR: analytics.available=`empty` preserves fresh-learner `New` copy', () => {
+  const harness = createPunctuationHarness();
+  openMapScene(harness);
+  harness.store.updateSubjectUi('punctuation', {
+    analytics: { available: 'empty', skillRows: [] },
+  });
+
+  const html = harness.render();
+
+  // Fresh learner state — all 14 skills still read as "New", no Unknown
+  // chip leaks into the HTML, and the helper copy is absent.
+  assert.match(html, /punctuation-map-skill-status--new/);
+  assert.doesNotMatch(
+    html,
+    /punctuation-map-skill-status--unknown/,
+    'fresh learner must NOT render as Unknown',
+  );
+  assert.doesNotMatch(
+    html,
+    /We(?:'|&#x27;)ll unlock this after your next round/,
+    'helper copy must only appear on unknown rows',
+  );
+});
+
+test('U3 Map scene SSR: unknown-state HTML contains no forbidden child terms', () => {
+  // The new helper sub-line and Unknown label must not introduce any adult
+  // grammar terminology that the global forbidden-term sweep would catch.
+  const harness = createPunctuationHarness();
+  openMapScene(harness);
+  harness.store.updateSubjectUi('punctuation', { analytics: { available: false } });
+  const html = harness.render();
+  const leaks = forbiddenTermsInHtml(html);
+  assert.deepEqual(leaks, [], `forbidden term leak on unknown-state Map HTML: ${leaks.join(', ')}`);
+});
+
+// ---------------------------------------------------------------------------
 // U6 — Punctuation Skill Detail modal. Renders on top of the Map scene when
 // `mapUi.detailOpenSkillId` is a published Punctuation skill id. Two tabs
 // (Learn / Practise) consume U5's `mapUi.detailTab` state. "Practise this"


### PR DESCRIPTION
## Summary

- Adds `analytics.available: true | false | 'empty'` on the client read-model (`src/subjects/punctuation/client-read-models.js`) so the Punctuation Map can distinguish a degraded-analytics failure from a fresh learner (plan R4).
- Map now renders a new `'unknown'` status chip plus a child-friendly helper sub-line — "We'll unlock this after your next round." — on every skill whenever `analytics.available === false`. Fresh-learner behaviour (`'empty'` → `'new'`) is preserved.
- Emits a one-time `console.warn('[punctuation] analytics unavailable — Map is rendering the "unknown" state')` when degraded, behind a module-level latch so the devtools console doesn't flood. The warning fires inside `useEffect` so SSR stays silent.

## What this does NOT touch

- The Worker `worker/src/subjects/punctuation/read-models.js` cloneSerialisable passthrough is intentionally untouched. Per plan R4, the availability signal originates UPSTREAM (here, at the client read-model layer), not at the passthrough. A follow-on unit can wire an authoritative `available` value through the Worker projection and the client `initState` already honours the explicit value over shape-based derivation.
- Oracle / engine / scheduler / content — zero changes.
- `contentReleaseId` — unchanged (`release-id impact: none`).
- Non-Map punctuation scenes (Home, Setup, Summary, Session) — untouched.
- Skill example-row copy — untouched. The child-register sweep across `punctuationSkillRuleOneLiner` is P4-U7's job.

## Scope

Files modified:
- `src/subjects/punctuation/client-read-models.js` — `initState` now attaches `analytics.available` via `deriveAnalyticsAvailability`. Honours an explicit upstream value before falling back to shape-based derivation.
- `src/subjects/punctuation/components/punctuation-view-model.js` — exports `assembleSkillRows` (moved from the scene so tests can import from a `.js` path), adds `unknown: 'Unknown'` to the child status-label map, and teaches `deriveStatusForSkill` to preserve the explicit `'unknown'` status (the `attempts === 0` branch would otherwise silently downgrade it to `'new'`).
- `src/subjects/punctuation/components/PunctuationMapScene.jsx` — imports `assembleSkillRows` from the view-model, adds a `useEffect`-backed one-time warning when `analytics.available === false`, and renders the "We'll unlock this after your next round." helper sub-line under each unknown SkillCard.
- `styles/app.css` — adds `.punctuation-map-skill-status--unknown` (muted slate chip, dashed border) and `.punctuation-map-skill-unknown-helper` (sub-line typography).
- `tests/react-punctuation-scene.test.js` — 12 new tests across three blocks: `assembleSkillRows` unit scenarios (true / true-miss / false / empty), `client-read-models` derivation behaviour (missing / empty / non-empty / explicit), `punctuationChildStatusLabel('unknown')` → "Unknown", and SSR tests that assert the Unknown chip + helper copy render under degraded analytics and the fresh-learner `'empty'` state still reads as "New". Forbidden-term sweep runs on the unknown-state HTML.

## Test plan

- [x] `node --test tests/react-punctuation-scene.test.js` — 147/147 pass (12 new P4-U3 tests + 135 existing).
- [x] `node --test tests/punctuation-legacy-parity.test.js` — 11/11 oracle green.
- [x] `node --test tests/punctuation-view-model.test.js tests/punctuation-map-phase.test.js tests/punctuation-map-redaction.test.js tests/punctuation-read-models.test.js tests/punctuation-read-model.test.js` — 147/147.
- [x] Broader sweep across 8 punctuation test files — 347/347.
- [x] `node ./scripts/build-bundles.mjs` — bundle builds clean.
- [x] `node ./scripts/audit-client-bundle.mjs` — client bundle audit passes.

## release-id impact: none

Requirements traced: R4, R11, R14.