### PR TITLE
feat(home): U2 — route hero CTA to today's best round

### DIFF
--- a/src/surfaces/home/HomeSurface.jsx
+++ b/src/surfaces/home/HomeSurface.jsx
@@ -10,7 +10,6 @@ import {
   greetForHour,
   randomHeroBackground,
   selectTodaysBestRound,
-  subjectName,
 } from './data.js';
 
 export function HomeSurface({ model, actions, shellClassName = 'app-shell' }) {
@@ -47,7 +46,7 @@ export function HomeSurface({ model, actions, shellClassName = 'app-shell' }) {
   const companionName = pickCompanionName(model.monsterSummary || []);
   const ctaSubjectId = recommendation?.subjectId || 'spelling';
   const ctaLabel = recommendation
-    ? `Start ${recommendation.subjectName || subjectName(recommendation.subjectId)}`
+    ? `Start ${recommendation.subjectName}`
     : "Begin today's round";
 
   return (

--- a/src/surfaces/home/HomeSurface.jsx
+++ b/src/surfaces/home/HomeSurface.jsx
@@ -9,6 +9,8 @@ import {
   dueCopy,
   greetForHour,
   randomHeroBackground,
+  selectTodaysBestRound,
+  subjectName,
 } from './data.js';
 
 export function HomeSurface({ model, actions, shellClassName = 'app-shell' }) {
@@ -26,12 +28,27 @@ export function HomeSurface({ model, actions, shellClassName = 'app-shell' }) {
     () => buildSubjectCards(model.subjects || [], model.dashboardStats || {}),
     [model.subjects, model.dashboardStats],
   );
+  // Phase 4 U2 (R2): recommendation is computed from dashboardStats by a
+  // pure helper. The returned shape drives the "Today's best round" card
+  // and the primary CTA's target subject + label. When the helper returns
+  // null (every subject has zero due work) we keep the pre-U2 hero copy
+  // and the Spelling-first CTA so fresh learners see identical output.
+  const recommendation = useMemo(
+    () => selectTodaysBestRound(model.dashboardStats || {}, {
+      monsterSummary: model.monsterSummary || [],
+    }),
+    [model.dashboardStats, model.monsterSummary],
+  );
 
   const now = model.now || new Date();
   const greet = greetForHour(now.getHours());
   const dueTotal = model.dueTotal || 0;
 
   const companionName = pickCompanionName(model.monsterSummary || []);
+  const ctaSubjectId = recommendation?.subjectId || 'spelling';
+  const ctaLabel = recommendation
+    ? `Start ${recommendation.subjectName || subjectName(recommendation.subjectId)}`
+    : "Begin today's round";
 
   return (
     <div className={shellClassName}>
@@ -58,18 +75,38 @@ export function HomeSurface({ model, actions, shellClassName = 'app-shell' }) {
             <b>{greet}, {model.learner?.name || 'there'}.</b>{' '}
             {companionName ? `${companionName} is ready for round ${model.roundNumber || 1}.` : 'A fresh round is waiting.'}
           </div>
-          <h1 className="mission">
-            Today's words are <em>waiting.</em>
-            <br />
-            {dueCopy(dueTotal)}
-          </h1>
+          {recommendation ? (
+            <>
+              <h1 className="mission">
+                Today's practice is <em>waiting.</em>
+              </h1>
+              <div className="hero-best-round" data-best-round-subject={recommendation.subjectId}>
+                <div className="hero-best-round-label">Today's best round:{' '}
+                  <strong>{recommendation.subjectName}</strong>
+                </div>
+                <div className="hero-best-round-detail">
+                  {recommendation.monsterCompanion
+                    ? `${recommendation.monsterCompanion} has ${formatDueCount(recommendation.due)} due.`
+                    : `${formatDueCount(recommendation.due)} due for you.`}
+                </div>
+              </div>
+            </>
+          ) : (
+            <h1 className="mission">
+              Today's words are <em>waiting.</em>
+              <br />
+              {dueCopy(dueTotal)}
+            </h1>
+          )}
           <div className="hero-cta-row">
             <button
               type="button"
               className="btn primary xl"
-              onClick={() => actions.openSubject('spelling')}
+              data-action="open-subject"
+              data-subject-id={ctaSubjectId}
+              onClick={() => actions.openSubject(ctaSubjectId)}
             >
-              Begin today's round <IconArrowRight />
+              {ctaLabel} <IconArrowRight />
             </button>
             <button
               type="button"
@@ -108,4 +145,10 @@ function pickCompanionName(summary) {
   const caught = summary.find((entry) => entry.progress?.caught && entry.progress.stage >= 1);
   if (caught) return caught.monster.nameByStage?.[caught.progress.stage] || caught.monster.name;
   return null;
+}
+
+function formatDueCount(due) {
+  const n = Math.max(0, Number(due) || 0);
+  if (n === 1) return '1 skill';
+  return `${n} skills`;
 }

--- a/src/surfaces/home/data.js
+++ b/src/surfaces/home/data.js
@@ -855,12 +855,18 @@ function pickSubjectCompanion(monsterSummary, subjectId) {
     const monsterId = entry?.monster?.id;
     const progress = entry?.progress;
     if (!monsterId || !progress?.caught) continue;
-    // Match either by explicit subjectId annotation (preferred — game state
-    // carries it for Punctuation / Grammar) or by roster membership (legacy
-    // Spelling summaries that don't annotate subjectId per entry).
+    // Roster membership is the hard gate — stale state may carry an explicit
+    // `entry.subjectId` annotation for a reserved monster id (e.g. pre-flip
+    // `{ monster.id:'colisk', subjectId:'punctuation' }`), which would
+    // otherwise bypass the active roster via the annotation branch alone.
+    // Require the monster id to appear in `MONSTERS_BY_SUBJECT[subjectId]`
+    // first; then accept either explicit subject annotation or legacy
+    // unannotated Spelling entries that rely on roster membership. Mirrors
+    // plan U2 R6's "reserved monsters are never learner-facing" invariant.
+    if (!rosterSet.has(monsterId)) continue;
     const isForSubject = entry.subjectId
       ? entry.subjectId === subjectId
-      : rosterSet.has(monsterId);
+      : true;
     if (!isForSubject) continue;
     const stage = Math.max(0, Math.min(4, Number(progress.stage) || 0));
     if (!best || stage > best.stage) {

--- a/src/surfaces/home/data.js
+++ b/src/surfaces/home/data.js
@@ -774,6 +774,107 @@ function subjectPriority(subjectId) {
   return idx === -1 ? 999 : idx;
 }
 
+/**
+ * Phase 4 U2 — pick the subject that should drive today's hero CTA.
+ *
+ * Pure helper over `model.dashboardStats` (which is keyed by subjectId and
+ * holds the `{ pct, due, streak, nextUp }` projection each subject module
+ * emits from `getDashboardStats`). Ranks subjects by the `due` scalar
+ * descending, clamped to a non-negative integer. Ties are broken by
+ * `SUBJECT_PRIORITY_ORDER` so Spelling wins a straight three-way tie
+ * (preserves the pre-U2 Spelling-first CTA for fresh learners whose stats
+ * happen to collide on due counts). The caller can override the tiebreak
+ * via `options.tiebreakSubjectId` — e.g. a future phase that wants to
+ * promote Punctuation first while Bellstorm launches.
+ *
+ * Ranking is intentionally `due`-only. A future cross-subject extension
+ * will add a `wobbly` / `weak` scalar to each subject module's
+ * `getDashboardStats`; once that ships, `selectTodaysBestRound` will
+ * consume it as a secondary ranking key. Until then the plan (R2) locks
+ * ranking to the scalar that already exists on every module.
+ *
+ * Returns `{ subjectId, subjectName, due, monsterCompanion }` when at
+ * least one subject has a positive due count; returns `null` when every
+ * subject has zero (or missing) due work. The caller is expected to fall
+ * back to the pre-U2 hero copy + Spelling CTA when the result is `null`.
+ *
+ * `monsterCompanion` is the learner's highest-stage caught monster for the
+ * recommended subject (used in the "Today's best round: {Subject}.
+ * {Companion} has {due} skills due." card copy). It is `null` when no
+ * monster is caught for that subject — the consumer then hides the
+ * companion clause. We never invent a companion from uncaught monsters:
+ * the card prefers honesty over filler.
+ */
+export function selectTodaysBestRound(dashboardStats, options = {}) {
+  const tiebreakSubjectId = typeof options.tiebreakSubjectId === 'string'
+    ? options.tiebreakSubjectId
+    : 'spelling';
+  const monsterSummary = Array.isArray(options.monsterSummary) ? options.monsterSummary : [];
+
+  if (!dashboardStats || typeof dashboardStats !== 'object') return null;
+
+  const entries = [];
+  for (const subjectId of SUBJECT_PRIORITY_ORDER) {
+    const stats = dashboardStats[subjectId];
+    const due = clampDue(stats && stats.due);
+    if (due > 0) entries.push({ subjectId, due });
+  }
+  if (!entries.length) return null;
+
+  entries.sort((left, right) => {
+    if (left.due !== right.due) return right.due - left.due;
+    // Tiebreak: preferred subject first, otherwise canonical priority order.
+    const leftPreferred = left.subjectId === tiebreakSubjectId ? 0 : 1;
+    const rightPreferred = right.subjectId === tiebreakSubjectId ? 0 : 1;
+    if (leftPreferred !== rightPreferred) return leftPreferred - rightPreferred;
+    return subjectPriority(left.subjectId) - subjectPriority(right.subjectId);
+  });
+
+  const winner = entries[0];
+  return {
+    subjectId: winner.subjectId,
+    subjectName: subjectName(winner.subjectId),
+    due: winner.due,
+    monsterCompanion: pickSubjectCompanion(monsterSummary, winner.subjectId),
+  };
+}
+
+function clampDue(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return 0;
+  return Math.max(0, Math.floor(numeric));
+}
+
+function pickSubjectCompanion(monsterSummary, subjectId) {
+  if (!Array.isArray(monsterSummary) || !monsterSummary.length || !subjectId) return null;
+  const rosterIds = MONSTERS_BY_SUBJECT[subjectId] || [];
+  if (!rosterIds.length) return null;
+  const rosterSet = new Set(rosterIds);
+  let best = null;
+  for (const entry of monsterSummary) {
+    const monsterId = entry?.monster?.id;
+    const progress = entry?.progress;
+    if (!monsterId || !progress?.caught) continue;
+    // Match either by explicit subjectId annotation (preferred — game state
+    // carries it for Punctuation / Grammar) or by roster membership (legacy
+    // Spelling summaries that don't annotate subjectId per entry).
+    const isForSubject = entry.subjectId
+      ? entry.subjectId === subjectId
+      : rosterSet.has(monsterId);
+    if (!isForSubject) continue;
+    const stage = Math.max(0, Math.min(4, Number(progress.stage) || 0));
+    if (!best || stage > best.stage) {
+      best = { monster: entry.monster, stage };
+    }
+  }
+  if (!best) return null;
+  const { monster, stage } = best;
+  if (Array.isArray(monster.nameByStage) && monster.nameByStage[stage]) {
+    return monster.nameByStage[stage];
+  }
+  return monster.name || null;
+}
+
 function secureProgressLabel(subjectId, mastered) {
   const count = Math.max(0, Number(mastered) || 0);
   if (subjectId === 'punctuation' || subjectId === 'grammar') {

--- a/tests/helpers/home-surface-render.js
+++ b/tests/helpers/home-surface-render.js
@@ -1,0 +1,88 @@
+// Standalone SSR renderer for the HomeSurface. Mirrors the approach in
+// `punctuation-scene-render.js`: compile once via esbuild, reuse the bundle
+// for subsequent renders. HomeSurface takes a `model` + `actions` shape so
+// tests can inject crafted dashboardStats + monsterSummary payloads without
+// standing up the full app controller.
+//
+// Unlike the app-harness render path (which goes through App + runtime +
+// buildHomeModel), this helper calls HomeSurface directly with a caller-
+// supplied model. Phase 4 U2 tests use it to assert that the rendered CTA
+// carries the right `data-subject-id` for arbitrary dashboardStats
+// permutations — the harness path does not expose a knob for dashboardStats
+// because `buildHomeModel` populates it from the subject modules.
+
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildSync } from 'esbuild';
+
+const moduleUrl = typeof import.meta.url === 'string' ? import.meta.url : null;
+const rootDir = moduleUrl ? path.resolve(path.dirname(fileURLToPath(moduleUrl)), '../..') : process.cwd();
+const require = createRequire(moduleUrl || path.join(rootDir, 'tests/helpers/home-surface-render.js'));
+
+let renderer = null;
+let rendererDir = null;
+
+function nodePaths() {
+  return [
+    path.join(rootDir, 'node_modules'),
+    ...String(process.env.NODE_PATH || '').split(path.delimiter),
+  ].filter((entry) => entry && existsSync(entry));
+}
+
+function loadRenderer() {
+  if (renderer) return renderer;
+  rendererDir = mkdtempSync(path.join(tmpdir(), 'ks2-home-surface-render-'));
+  const entryPath = path.join(rendererDir, 'entry.jsx');
+  const bundlePath = path.join(rendererDir, 'entry.cjs');
+  writeFileSync(entryPath, `
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { HomeSurface } from ${JSON.stringify(path.join(rootDir, 'src/surfaces/home/HomeSurface.jsx'))};
+
+    function noopActions() {
+      return {
+        toggleTheme() {},
+        navigateHome() {},
+        selectLearner() {},
+        openProfileSettings() {},
+        logout() {},
+        openSubject() {},
+        openCodex() {},
+        openParentHub() {},
+      };
+    }
+
+    export function renderHomeSurfaceStandalone({ model, actions = noopActions() }) {
+      return renderToStaticMarkup(React.createElement(HomeSurface, { model, actions }));
+    }
+  `);
+  buildSync({
+    absWorkingDir: rootDir,
+    entryPoints: [entryPath],
+    outfile: bundlePath,
+    bundle: true,
+    platform: 'node',
+    format: 'cjs',
+    target: ['node24'],
+    jsx: 'automatic',
+    jsxImportSource: 'react',
+    loader: { '.js': 'jsx' },
+    nodePaths: nodePaths(),
+    logLevel: 'silent',
+  });
+  renderer = require(bundlePath);
+  return renderer;
+}
+
+export function renderHomeSurfaceStandalone(options) {
+  return loadRenderer().renderHomeSurfaceStandalone(options);
+}
+
+export function cleanupHomeSurfaceRenderer() {
+  renderer = null;
+  if (rendererDir) rmSync(rendererDir, { recursive: true, force: true });
+  rendererDir = null;
+}

--- a/tests/react-home-surface.test.js
+++ b/tests/react-home-surface.test.js
@@ -161,6 +161,34 @@ test('selectTodaysBestRound surfaces the caught monster companion when one exist
   assert.equal(result.monsterCompanion, 'Chimewing');
 });
 
+test('selectTodaysBestRound refuses a reserved-monster companion even when stale state annotates its subjectId', () => {
+  // Regression guard for U2 review finding (R6 "reserved monsters are never
+  // learner-facing"): a pre-flip learner's stored `monsterSummary` might
+  // carry `{ monster.id:'colisk', subjectId:'punctuation', caught:true }`
+  // after a legacy migration. Without a roster cross-check in
+  // `pickSubjectCompanion`, the explicit-subjectId branch would match and
+  // surface the reserved creature on the hero card. The hardened helper
+  // gates on `MONSTERS_BY_SUBJECT[subjectId]` membership first, so colisk
+  // never becomes the companion regardless of the annotation.
+  const stats = { punctuation: { due: 2 } };
+  const monsterSummary = [
+    // Reserved Punctuation monster with stale explicit annotation — must be
+    // ignored by the companion picker.
+    {
+      monster: {
+        id: 'colisk',
+        name: 'Colisk',
+        nameByStage: ['Colisk Egg', 'Colisk', 'Colisk II', 'Colisk III'],
+      },
+      progress: { caught: true, stage: 2, branch: 'b1' },
+      subjectId: 'punctuation',
+    },
+  ];
+  const result = selectTodaysBestRound(stats, { monsterSummary });
+  assert.equal(result.subjectId, 'punctuation');
+  assert.equal(result.monsterCompanion ?? null, null);
+});
+
 test('selectTodaysBestRound leaves monsterCompanion null when no caught monster exists for the recommended subject', () => {
   const stats = { grammar: { due: 2 } };
   const monsterSummary = [

--- a/tests/react-home-surface.test.js
+++ b/tests/react-home-surface.test.js
@@ -1,0 +1,251 @@
+// Tests for the Phase 4 U2 home-hero recommendation routing.
+//
+// Two layers:
+//   1. Pure-helper tests for `selectTodaysBestRound` in
+//      `src/surfaces/home/data.js` — ranking, Spelling tiebreak, empty-state
+//      fallback, malformed dashboardStats entries, missing subjects.
+//   2. SSR-level integration tests that render `HomeSurface` with crafted
+//      stub models and assert that the rendered CTA carries the expected
+//      subject via `data-action="open-subject"` + `data-subject-id="…"` and
+//      the visible copy flips between the "Today's best round" card (when a
+//      recommendation exists) and the pre-U2 fresh-learner copy (when no
+//      subject has any due work).
+//
+// The SSR helper `tests/helpers/home-surface-render.js` mirrors
+// `tests/helpers/punctuation-scene-render.js` — renderToStaticMarkup via
+// esbuild so tests can drive HomeSurface directly with a crafted `model`.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { selectTodaysBestRound } from '../src/surfaces/home/data.js';
+import {
+  cleanupHomeSurfaceRenderer,
+  renderHomeSurfaceStandalone,
+} from './helpers/home-surface-render.js';
+
+const SUBJECTS = [
+  { id: 'spelling', name: 'Spelling', blurb: 'Spelling', available: true },
+  { id: 'punctuation', name: 'Punctuation', blurb: 'Punctuation', available: true },
+  { id: 'grammar', name: 'Grammar', blurb: 'Grammar', available: true },
+];
+
+function baseModel(overrides = {}) {
+  return {
+    theme: 'light',
+    learner: { id: 'learner-a', name: 'Ava' },
+    learnerLabel: 'Ava · Y5',
+    learnerOptions: [{ id: 'learner-a', name: 'Ava', yearGroup: 'Y5' }],
+    signedInAs: null,
+    subjects: SUBJECTS,
+    monsterSummary: [],
+    dashboardStats: {},
+    dueTotal: 0,
+    roundNumber: 1,
+    now: new Date('2026-04-22T12:00:00Z'),
+    permissions: { canOpenParentHub: true },
+    persistence: { mode: 'local-only', label: 'Local-only' },
+    ...overrides,
+  };
+}
+
+test.after(() => {
+  cleanupHomeSurfaceRenderer();
+});
+
+// ---------- Pure-helper tests ---------- //
+
+test('selectTodaysBestRound returns null when every subject has no due work', () => {
+  const stats = {
+    spelling: { due: 0 },
+    punctuation: { due: 0 },
+    grammar: { due: 0 },
+  };
+  const result = selectTodaysBestRound(stats);
+  assert.equal(result, null);
+});
+
+test('selectTodaysBestRound returns the subject with the highest due scalar', () => {
+  const stats = {
+    spelling: { due: 0 },
+    punctuation: { due: 2 },
+    grammar: { due: 1 },
+  };
+  const result = selectTodaysBestRound(stats);
+  assert.equal(result.subjectId, 'punctuation');
+  assert.equal(result.subjectName, 'Punctuation');
+  assert.equal(result.due, 2);
+});
+
+test('selectTodaysBestRound breaks ties by Spelling-first priority order', () => {
+  // All three subjects equal → Spelling wins the tiebreak (default
+  // tiebreakSubjectId), matching pre-U2 behaviour for fresh learners whose
+  // stats happen to collide on due counts.
+  const stats = {
+    spelling: { due: 1 },
+    punctuation: { due: 1 },
+    grammar: { due: 1 },
+  };
+  const result = selectTodaysBestRound(stats);
+  assert.equal(result.subjectId, 'spelling');
+  assert.equal(result.due, 1);
+});
+
+test('selectTodaysBestRound respects the Spelling → Punctuation → Grammar order on partial ties', () => {
+  // Spelling has no signal, Punctuation and Grammar both have due=2 → the
+  // priority order says Punctuation wins the tie.
+  const stats = {
+    spelling: { due: 0 },
+    punctuation: { due: 2 },
+    grammar: { due: 2 },
+  };
+  const result = selectTodaysBestRound(stats);
+  assert.equal(result.subjectId, 'punctuation');
+});
+
+test('selectTodaysBestRound clamps missing / negative / non-numeric due values to zero', () => {
+  const stats = {
+    spelling: { due: null },
+    punctuation: { due: -5 },
+    grammar: { /* missing due */ },
+  };
+  const result = selectTodaysBestRound(stats);
+  assert.equal(result, null);
+});
+
+test('selectTodaysBestRound copes with a completely missing dashboardStats', () => {
+  const result = selectTodaysBestRound(undefined);
+  assert.equal(result, null);
+  const empty = selectTodaysBestRound({});
+  assert.equal(empty, null);
+});
+
+test('selectTodaysBestRound honours an explicit tiebreakSubjectId option', () => {
+  // If the caller asks for Punctuation-first tiebreak, an all-equal stats
+  // payload should route to Punctuation. Spelling is only the default.
+  const stats = {
+    spelling: { due: 1 },
+    punctuation: { due: 1 },
+    grammar: { due: 1 },
+  };
+  const result = selectTodaysBestRound(stats, { tiebreakSubjectId: 'punctuation' });
+  assert.equal(result.subjectId, 'punctuation');
+});
+
+test('selectTodaysBestRound surfaces the caught monster companion when one exists for the recommended subject', () => {
+  const stats = { punctuation: { due: 3 } };
+  const monsterSummary = [
+    // A caught punctuation monster — should bubble up into the result.
+    {
+      monster: {
+        id: 'pealark',
+        name: 'Pealark',
+        nameByStage: ['Pealark Egg', 'Pealark', 'Chimewing', 'Bellcrest'],
+      },
+      progress: { caught: true, stage: 2, branch: 'b1' },
+      subjectId: 'punctuation',
+    },
+    // A caught spelling monster — should not pollute the punctuation result.
+    {
+      monster: {
+        id: 'inklet',
+        name: 'Inklet',
+        nameByStage: ['Inklet Egg', 'Inklet'],
+      },
+      progress: { caught: true, stage: 1, branch: 'b1' },
+      subjectId: 'spelling',
+    },
+  ];
+  const result = selectTodaysBestRound(stats, { monsterSummary });
+  assert.equal(result.subjectId, 'punctuation');
+  assert.equal(result.monsterCompanion, 'Chimewing');
+});
+
+test('selectTodaysBestRound leaves monsterCompanion null when no caught monster exists for the recommended subject', () => {
+  const stats = { grammar: { due: 2 } };
+  const monsterSummary = [
+    {
+      monster: { id: 'inklet', name: 'Inklet', nameByStage: ['Inklet Egg', 'Inklet'] },
+      progress: { caught: true, stage: 1, branch: 'b1' },
+      subjectId: 'spelling',
+    },
+  ];
+  const result = selectTodaysBestRound(stats, { monsterSummary });
+  assert.equal(result.subjectId, 'grammar');
+  assert.equal(result.monsterCompanion ?? null, null);
+});
+
+// ---------- SSR integration tests ---------- //
+
+test('HomeSurface renders the "Today\'s best round" card and routes the CTA to the recommended subject', () => {
+  const model = baseModel({
+    dashboardStats: {
+      spelling: { pct: 10, due: 0, streak: 0, nextUp: 'Fresh spellings' },
+      punctuation: { pct: 20, due: 3, streak: 1, nextUp: 'Due review' },
+      grammar: { pct: 5, due: 0, streak: 0, nextUp: 'Start Grammar retrieval' },
+    },
+  });
+
+  const html = renderHomeSurfaceStandalone({ model });
+
+  // Subject-neutral hero copy when recommendation is non-null. The
+  // renderToStaticMarkup pipeline HTML-escapes apostrophes as `&#x27;`,
+  // so we match on `Today&#x27;s practice` rather than the literal `Today's`.
+  assert.doesNotMatch(html, /Today&#x27;s words are <em>waiting\./);
+  assert.match(html, /Today&#x27;s practice is <em>waiting\.<\/em>/);
+  // The new sub-card names the recommended subject and its due count.
+  assert.match(html, /Today&#x27;s best round:\s*<strong>Punctuation<\/strong>/);
+  assert.match(html, /3 skills due|3 skills due for you/);
+
+  // CTA label is "Start Punctuation".
+  assert.match(html, /Start Punctuation/);
+  // CTA carries the correct data-action + data-subject-id so tests (and
+  // any future delegated-click wiring in main.js) can observe the routing
+  // without needing jsdom. The hardcoded `openSubject('spelling')` path is
+  // gone.
+  assert.match(html, /data-action="open-subject"\s+data-subject-id="punctuation"/);
+  assert.doesNotMatch(html, /data-subject-id="spelling"[^>]*>Begin today&#x27;s round/);
+
+  // Open codex ghost button preserved.
+  assert.match(html, />\s*Open codex\s*</);
+});
+
+test('HomeSurface renders the pre-U2 copy + Spelling CTA when no subject has any due work', () => {
+  const model = baseModel({
+    dashboardStats: {
+      spelling: { pct: 0, due: 0, streak: 0, nextUp: 'Fresh spellings' },
+      punctuation: { pct: 0, due: 0, streak: 0, nextUp: 'Smart Review' },
+      grammar: { pct: 0, due: 0, streak: 0, nextUp: 'Start Grammar retrieval' },
+    },
+    dueTotal: 0,
+  });
+
+  const html = renderHomeSurfaceStandalone({ model });
+
+  // Regression guard: fresh-learner hero copy stays byte-identical to
+  // pre-U2 output. `renderToStaticMarkup` escapes the apostrophe as
+  // `&#x27;` on every rendered pass.
+  assert.match(html, /Today&#x27;s words are <em>waiting\.<\/em>/);
+  assert.match(html, /Begin today&#x27;s round/);
+  assert.match(html, /data-action="open-subject"\s+data-subject-id="spelling"/);
+  assert.doesNotMatch(html, /Today&#x27;s best round:/);
+});
+
+test('HomeSurface labels the CTA with the picked subject name when Spelling is ahead', () => {
+  // Covers the Spelling-wins branch. We expect the subject-neutral hero
+  // card to still appear (not the fresh-learner fallback) and the CTA to
+  // read "Start Spelling".
+  const model = baseModel({
+    dashboardStats: {
+      spelling: { pct: 50, due: 5, streak: 2, nextUp: 'Due review' },
+      punctuation: { pct: 0, due: 0, streak: 0, nextUp: 'Smart Review' },
+      grammar: { pct: 0, due: 0, streak: 0, nextUp: 'Start Grammar retrieval' },
+    },
+  });
+
+  const html = renderHomeSurfaceStandalone({ model });
+
+  assert.match(html, /Today&#x27;s best round:\s*<strong>Spelling<\/strong>/);
+  assert.match(html, /Start Spelling/);
+  assert.match(html, /data-action="open-subject"\s+data-subject-id="spelling"/);
+});


### PR DESCRIPTION
## Summary

- Phase 4 U2 — home hero CTA is now data-driven from `model.dashboardStats`. A new pure helper `selectTodaysBestRound(dashboardStats, options)` in `src/surfaces/home/data.js` ranks subjects by the `due` scalar (descending), falls back to a Spelling-first tiebreak on equal signal, and returns `null` when no subject has due work.
- `HomeSurface.jsx` now renders two hero states: a subject-neutral copy + "Today's best round" card + `Start <Subject>` CTA when a recommendation exists, and the byte-identical pre-U2 "Today's words are waiting" / "Begin today's round" copy when no subject has any due work. The primary CTA carries `data-action="open-subject"` + `data-subject-id="<recommended>"` so tests (and any future delegated-click wiring) can observe the routing without jsdom.
- No Worker projection change; ranking stays on `due`-only until the cross-subject `weak` / `wobbly` scalar extension lands. Spelling fallback + the ghost "Open codex" CTA are preserved.

## Test plan

- [x] `npm test -- tests/react-home-surface.test.js` — 12/12 (9 unit assertions on the helper, 3 SSR assertions on the rendered CTA / hero copy)
- [x] `npm test -- tests/punctuation-legacy-parity.test.js` — oracle 11/11
- [x] `npm test -- tests/react-app-shell.test.js tests/render.test.js` — 34/34 (no hero regression)
- [x] `npm test -- tests/react-punctuation-child-copy.test.js` — 42/42 (no forbidden-term leak)
- [x] `npm test -- tests/build-public.test.js` — 1/1 (React bundle still builds)

Out-of-scope failures observed that pre-date this branch (reproduce on origin/main@4793790):
- `tests/punctuation-release-smoke.test.js` "Punctuation production rollout config intentionally enables the exposure gate" — reads wrangler.toml, fails with a JSON parse error unrelated to home surface.
- `tests/button-label-consistency.test.js` flags "Why is Guardian locked?" in `SpellingSetupScene.jsx` — pre-existing allowlist gap on Spelling copy, not on files touched here.

## release-id impact: none

`contentReleaseId` is unchanged. The oracle replay is untouched (punctuation-legacy-parity 11/11 stays green).

## Scope boundaries honoured

- Only touched: `src/surfaces/home/HomeSurface.jsx`, `src/surfaces/home/data.js`, `tests/react-home-surface.test.js` (new), `tests/helpers/home-surface-render.js` (new SSR helper, mirrors `tests/helpers/punctuation-scene-render.js`).
- Did not touch: `SubjectCard.jsx`, `MonsterMeadow.jsx`, icons, any other home surface files; Spelling / Punctuation / Grammar subject modules; subject scenes; engine files (`shared/punctuation/marking.js`, `generators.js`, `scheduler.js`, `content.js`); oracle tests.
- Did not bump `contentReleaseId`.

Requirements traced: R2, R11, R13