### PR TITLE
feat(grammar): U2 harden Phase 3 scopers — fail loud on DOM drift

### DIFF
--- a/src/subjects/grammar/components/GrammarAnalyticsScene.jsx
+++ b/src/subjects/grammar/components/GrammarAnalyticsScene.jsx
@@ -143,7 +143,11 @@ export function GrammarAnalyticsScene({
   const securedPunctuationConcepts = punctuationConcepts.filter((concept) => concept.status === 'secured').length;
 
   return (
-    <section className="card grammar-analytics" aria-labelledby="grammar-analytics-title">
+    <section
+      className="card grammar-analytics"
+      aria-labelledby="grammar-analytics-title"
+      data-grammar-phase-root="analytics"
+    >
       <div className="card-header">
         <div>
           <div className="eyebrow">Evidence snapshot</div>

--- a/src/subjects/grammar/components/GrammarConceptBankScene.jsx
+++ b/src/subjects/grammar/components/GrammarConceptBankScene.jsx
@@ -186,7 +186,11 @@ export function GrammarConceptBankScene({ grammar, actions }) {
     : `Showing ${totalMatches} of ${bankModel.total} concepts.`;
 
   return (
-    <section className="grammar-bank-scene" aria-labelledby="grammar-bank-title">
+    <section
+      className="grammar-bank-scene"
+      aria-labelledby="grammar-bank-title"
+      data-grammar-phase-root="bank"
+    >
       <header className="grammar-bank-topbar">
         <button
           type="button"

--- a/src/subjects/grammar/components/GrammarSessionScene.jsx
+++ b/src/subjects/grammar/components/GrammarSessionScene.jsx
@@ -493,7 +493,11 @@ export function GrammarSessionScene({ grammar, actions, runtimeReadOnly }) {
   const submitLabel = grammarSessionSubmitLabel(session, grammar.awaitingAdvance);
 
   return (
-    <section className="grammar-session" aria-labelledby="grammar-session-title">
+    <section
+      className="grammar-session"
+      aria-labelledby="grammar-session-title"
+      data-grammar-phase-root="session"
+    >
       <div className="grammar-session-head">
         <div>
           <div className="eyebrow">Grammar practice</div>

--- a/src/subjects/grammar/components/GrammarSetupScene.jsx
+++ b/src/subjects/grammar/components/GrammarSetupScene.jsx
@@ -122,7 +122,11 @@ export function GrammarSetupScene({ learner, grammar, rewardState, actions, runt
   const concordium = dashboard.concordiumProgress;
 
   return (
-    <section className="grammar-dashboard" aria-labelledby="grammar-dashboard-title">
+    <section
+      className="grammar-dashboard"
+      aria-labelledby="grammar-dashboard-title"
+      data-grammar-phase-root="dashboard"
+    >
       <div
         className="grammar-hero"
         style={{ '--grammar-hero-bg': `url(${GRAMMAR_REGION_IMAGE})` }}

--- a/src/subjects/grammar/components/GrammarSummaryScene.jsx
+++ b/src/subjects/grammar/components/GrammarSummaryScene.jsx
@@ -187,7 +187,10 @@ export function GrammarSummaryScene({ grammar, rewardState, actions, learner, ru
       },
     ];
     return (
-      <div className="grammar-summary-shell grammar-summary-shell--mini-test">
+      <div
+        className="grammar-summary-shell grammar-summary-shell--mini-test"
+        data-grammar-phase-root="summary"
+      >
         <section className="card grammar-summary-card-wrap" aria-labelledby="grammar-summary-title">
           <div className="eyebrow">Mini Test complete</div>
           <h2 className="section-title" id="grammar-summary-title">
@@ -231,7 +234,10 @@ export function GrammarSummaryScene({ grammar, rewardState, actions, learner, ru
   ];
 
   return (
-    <div className="grammar-summary-shell">
+    <div
+      className="grammar-summary-shell"
+      data-grammar-phase-root="summary"
+    >
       <section className="card grammar-summary-card-wrap" aria-labelledby="grammar-summary-title">
         <div className="eyebrow">Grammar round complete</div>
         <h2 className="section-title" id="grammar-summary-title">

--- a/src/subjects/grammar/components/GrammarTransferScene.jsx
+++ b/src/subjects/grammar/components/GrammarTransferScene.jsx
@@ -443,7 +443,11 @@ export function GrammarTransferScene({ grammar, actions }) {
   const errorMessage = typeof grammar?.error === 'string' ? grammar.error : '';
 
   return (
-    <section className="grammar-transfer-scene" aria-labelledby="grammar-transfer-title">
+    <section
+      className="grammar-transfer-scene"
+      aria-labelledby="grammar-transfer-title"
+      data-grammar-phase-root="transfer"
+    >
       <header className="grammar-transfer-topbar">
         <button
           type="button"

--- a/tests/grammar-phase3-scopers.test.js
+++ b/tests/grammar-phase3-scopers.test.js
@@ -1,0 +1,234 @@
+// Phase 4 U2 — characterisation tests for the hardened Phase 3 scopers.
+//
+// The six scopers in `tests/helpers/grammar-phase3-renders.js`
+// (scopeDashboard, scopeSession, scopeSummary, scopeBank, scopeTransfer,
+// scopeAnalytics) now throw a named error when the
+// `data-grammar-phase-root="<phase>"` semantic landmark is missing. Before
+// U2, the scopers silently fell back to returning the full HTML on a
+// regex no-match — which turned the Phase 3 forbidden-term sweep into a
+// false-positive silencer if a DOM refactor dropped a CSS class. See the
+// Phase 4 plan's U2 execution note and invariant 12.
+//
+// These tests feed SYNTHETIC HTML strings directly to the exported
+// scopers so the throw path is pinned independently of live harness
+// output. A broken production render (landmark attribute missing) is
+// simulated via a crafted HTML string; the happy path is simulated with
+// a minimal well-formed landmark wrapper; the edge case (landmark
+// present but no closing tag) proves the regex no-match throws rather
+// than returning unbalanced HTML.
+//
+// Why a separate file from `grammar-phase3-child-copy.test.js`: those
+// tests characterise Phase 3 copy presence/absence against live
+// harness renders. The scoper throw path is a lower-level contract that
+// belongs in its own file so its error messages stay stable if the
+// child-copy test ever re-organises.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  scopeDashboard,
+  scopeSession,
+  scopeSummary,
+  scopeBank,
+  scopeTransfer,
+  scopeAnalytics,
+  renderGrammarChildPhaseFixture,
+} from './helpers/grammar-phase3-renders.js';
+
+// Fixed table of (scoper, phase label, expected landmark tag type) so the
+// error-path and edge-case loops iterate uniformly.
+const SCOPER_MATRIX = Object.freeze([
+  { label: 'dashboard', scoper: scopeDashboard, tag: 'section' },
+  { label: 'session', scoper: scopeSession, tag: 'section' },
+  { label: 'summary', scoper: scopeSummary, tag: 'div' },
+  { label: 'bank', scoper: scopeBank, tag: 'section' },
+  { label: 'transfer', scoper: scopeTransfer, tag: 'section' },
+  { label: 'analytics', scoper: scopeAnalytics, tag: 'section' },
+]);
+
+// -----------------------------------------------------------------------------
+// Error path — landmark attribute entirely missing
+// -----------------------------------------------------------------------------
+
+for (const { label, scoper } of SCOPER_MATRIX) {
+  test(`U2: scope${label[0].toUpperCase()}${label.slice(1)} throws when data-grammar-phase-root is missing`, () => {
+    // Broken render: a DOM refactor dropped the landmark attribute (and
+    // the CSS class too, so even the pre-U2 fallback regex would miss).
+    // The hardened scoper must surface the drift as a named throw.
+    const brokenHtml = '<main><div>no landmark here</div></main>';
+    assert.throws(
+      () => scoper(brokenHtml),
+      new RegExp(`scope${label[0].toUpperCase()}${label.slice(1)}: no data-grammar-phase-root="${label}" landmark found`),
+      `scope${label} must throw when no landmark is present`,
+    );
+  });
+}
+
+// -----------------------------------------------------------------------------
+// Error path — landmark attribute present but for a DIFFERENT phase
+// -----------------------------------------------------------------------------
+
+for (const { label, scoper } of SCOPER_MATRIX) {
+  test(`U2: scope${label[0].toUpperCase()}${label.slice(1)} throws when landmark belongs to a different phase`, () => {
+    // A copy-paste error between scenes lands a non-matching landmark in
+    // the HTML. The scoper must still throw — it is phase-specific, not
+    // just "any landmark".
+    const wrongPhase = label === 'dashboard' ? 'session' : 'dashboard';
+    const spoofHtml = `<main><section data-grammar-phase-root="${wrongPhase}">content</section></main>`;
+    assert.throws(
+      () => scoper(spoofHtml),
+      new RegExp(`scope${label[0].toUpperCase()}${label.slice(1)}: no data-grammar-phase-root="${label}" landmark found`),
+      `scope${label} must reject a landmark for a different phase`,
+    );
+  });
+}
+
+// -----------------------------------------------------------------------------
+// Edge case — landmark present but closing tag missing (unbalanced HTML)
+// -----------------------------------------------------------------------------
+
+for (const { label, scoper, tag } of SCOPER_MATRIX) {
+  test(`U2: scope${label[0].toUpperCase()}${label.slice(1)} throws on landmark with no closing tag`, () => {
+    // Truncated HTML: landmark is present but the closing tag is gone.
+    // The regex must refuse to return unbalanced HTML — silent truncation
+    // would let downstream sweeps operate on a half-DOM and miss drift.
+    const truncated = `<${tag} data-grammar-phase-root="${label}">content with no closer`;
+    assert.throws(
+      () => scoper(truncated),
+      new RegExp(`scope${label[0].toUpperCase()}${label.slice(1)}: no data-grammar-phase-root="${label}" landmark found`),
+      `scope${label} must throw on landmark-present-no-closer`,
+    );
+  });
+}
+
+// -----------------------------------------------------------------------------
+// Edge case — dashboard/summary/transfer require a sibling boundary marker
+// -----------------------------------------------------------------------------
+
+test('U2: scopeDashboard throws when grown-up-view sibling boundary is missing', () => {
+  // Dashboard's regex pins the root `</section>` via lookahead to the
+  // sibling `<details class="grammar-grown-up-view">`. If the sibling is
+  // absent (e.g. a broken shell), the lookahead fails and the scoper
+  // throws rather than walking to the first nested `</section>`.
+  const noSibling = '<section data-grammar-phase-root="dashboard"><section>inner</section></section>';
+  assert.throws(
+    () => scopeDashboard(noSibling),
+    /scopeDashboard: no data-grammar-phase-root="dashboard" landmark found/,
+  );
+});
+
+test('U2: scopeSummary throws when </main> boundary is missing', () => {
+  // Summary's regex pins the root `</div>` via lookahead to `</main>`.
+  // Without the main close, the lazy match would bind to the first inner
+  // `</div>` — the scoper refuses to do that and throws instead.
+  const noMain = '<div data-grammar-phase-root="summary"><div>inner</div></div>';
+  assert.throws(
+    () => scopeSummary(noMain),
+    /scopeSummary: no data-grammar-phase-root="summary" landmark found/,
+  );
+});
+
+test('U2: scopeTransfer throws when </div></main> boundary is missing', () => {
+  // Transfer's regex pins the root `</section>` via lookahead to
+  // `</div></main>`. Without that sibling pair, the scoper throws.
+  const noClosers = '<section data-grammar-phase-root="transfer"><section>inner</section></section>';
+  assert.throws(
+    () => scopeTransfer(noClosers),
+    /scopeTransfer: no data-grammar-phase-root="transfer" landmark found/,
+  );
+});
+
+// -----------------------------------------------------------------------------
+// Happy path — landmark present + correct closing boundary
+// -----------------------------------------------------------------------------
+
+test('U2: scopeDashboard returns a narrowed substring on well-formed HTML', () => {
+  const html = '<main><section data-grammar-phase-root="dashboard" class="grammar-dashboard">body</section><details class="grammar-grown-up-view">adult</details></main>';
+  const scoped = scopeDashboard(html);
+  assert.match(scoped, /data-grammar-phase-root="dashboard"/);
+  assert.match(scoped, /body/);
+  assert.doesNotMatch(scoped, /adult/, 'scoped must exclude the sibling grown-up content');
+  assert.ok(scoped.length < html.length, 'scoped must be strictly narrower than full HTML');
+});
+
+test('U2: scopeSession returns a narrowed substring on well-formed HTML', () => {
+  const html = '<main><nav>nav</nav><section data-grammar-phase-root="session">body</section></main>';
+  const scoped = scopeSession(html);
+  assert.match(scoped, /data-grammar-phase-root="session"/);
+  assert.match(scoped, /body/);
+  assert.doesNotMatch(scoped, /nav>nav</, 'scoped must exclude the preceding nav');
+  assert.ok(scoped.length < html.length, 'scoped must be strictly narrower than full HTML');
+});
+
+test('U2: scopeSummary returns a narrowed substring on well-formed HTML', () => {
+  const html = '<main><nav>nav</nav><div data-grammar-phase-root="summary"><div>inner</div><section>shell</section></div></main>';
+  const scoped = scopeSummary(html);
+  assert.match(scoped, /data-grammar-phase-root="summary"/);
+  assert.match(scoped, /shell/);
+  assert.doesNotMatch(scoped, /nav>nav</, 'scoped must exclude the preceding nav');
+  assert.ok(scoped.length < html.length, 'scoped must be strictly narrower than full HTML');
+});
+
+test('U2: scopeBank returns a narrowed substring on well-formed HTML', () => {
+  const html = '<main><nav>nav</nav><section data-grammar-phase-root="bank">body</section></main>';
+  const scoped = scopeBank(html);
+  assert.match(scoped, /data-grammar-phase-root="bank"/);
+  assert.match(scoped, /body/);
+  assert.doesNotMatch(scoped, /nav>nav</);
+  assert.ok(scoped.length < html.length);
+});
+
+test('U2: scopeTransfer returns a narrowed substring on well-formed HTML', () => {
+  const html = '<main><div><nav>nav</nav><section data-grammar-phase-root="transfer"><section>inner</section></section></div></main>';
+  const scoped = scopeTransfer(html);
+  assert.match(scoped, /data-grammar-phase-root="transfer"/);
+  assert.match(scoped, /inner/);
+  assert.doesNotMatch(scoped, /nav>nav</);
+  assert.ok(scoped.length < html.length);
+});
+
+test('U2: scopeAnalytics returns a narrowed substring on well-formed HTML', () => {
+  const html = '<main><nav>nav</nav><section data-grammar-phase-root="analytics">body</section></main>';
+  const scoped = scopeAnalytics(html);
+  assert.match(scoped, /data-grammar-phase-root="analytics"/);
+  assert.match(scoped, /body/);
+  assert.doesNotMatch(scoped, /nav>nav</);
+  assert.ok(scoped.length < html.length);
+});
+
+// -----------------------------------------------------------------------------
+// Integration — live harness renders produce HTML that the hardened scopers
+// accept without throwing, and the scoped substring is strictly narrower
+// than the raw HTML (proving the narrowing actually fires).
+// -----------------------------------------------------------------------------
+
+const LIVE_HARNESS_PHASES = Object.freeze([
+  'dashboard',
+  'session-pre',
+  'summary',
+  'bank',
+  'transfer',
+  'analytics',
+]);
+
+for (const phase of LIVE_HARNESS_PHASES) {
+  test(`U2: live ${phase} render carries the data-grammar-phase-root landmark`, () => {
+    // End-to-end confirmation that the six `Grammar*Scene.jsx` components
+    // emit the landmark attribute into their rendered HTML. A React
+    // refactor that drops the prop would be surfaced here before the
+    // broader Phase 3 gate even runs.
+    const { html, rawHtml } = renderGrammarChildPhaseFixture(phase);
+    // `html` is the scoped substring. It must contain the landmark and
+    // be strictly narrower than the raw rendered surface.
+    assert.match(
+      html,
+      /data-grammar-phase-root="/,
+      `${phase} scoped HTML must contain the landmark attribute`,
+    );
+    assert.ok(
+      html.length < rawHtml.length,
+      `${phase} scoped HTML (${html.length}) must be strictly narrower than raw HTML (${rawHtml.length})`,
+    );
+  });
+}

--- a/tests/grammar-phase3-scopers.test.js
+++ b/tests/grammar-phase3-scopers.test.js
@@ -198,10 +198,79 @@ test('U2: scopeAnalytics returns a narrowed substring on well-formed HTML', () =
 });
 
 // -----------------------------------------------------------------------------
+// Follower-up adversarial surface — nested-outer wrapper + duplicate landmark
+// -----------------------------------------------------------------------------
+//
+// A reviewer reproduction fed a landmark nested inside a same-type outer
+// wrapper: `<section class="outer"><section data-grammar-phase-root=
+// "dashboard">INNER</section><p>OUTER-TEXT</p></section><details class=
+// "grammar-grown-up-view">`. The pre-follower lazy-regex scoper returned
+// scoped output with the trailing `<p>OUTER-TEXT</p></section>` still
+// attached — adult copy would leak into the child sweep. The hardened
+// depth-balanced helper either returns only the inner landmark's own
+// subtree or throws loud if the expected sibling boundary is violated.
+//
+// A second attack fed two same-phase landmarks in the same HTML. The
+// pre-follower scoper silently merged both subtrees into one scoped
+// string; the hardened helper throws with a `duplicate ... landmark`
+// message so a stale fixture fails loud.
+
+test('U2: scopeDashboard rejects nested-outer wrapper attack (no trailing OUTER-TEXT leak)', () => {
+  // Reviewer's exact reproduction. Either the scoper narrows correctly
+  // (no `OUTER-TEXT`) or it throws. Both outcomes are acceptable — the
+  // one outcome that is NOT acceptable is returning a scoped string that
+  // contains `OUTER-TEXT`, because that is the adult-copy leak this
+  // follower is defending against.
+  const attack = '<section class="outer"><section data-grammar-phase-root="dashboard">INNER</section><p>OUTER-TEXT</p></section><details class="grammar-grown-up-view">';
+  let scoped = null;
+  let threw = null;
+  try {
+    scoped = scopeDashboard(attack);
+  } catch (err) {
+    threw = err;
+  }
+  if (threw) {
+    assert.match(
+      threw.message,
+      /scopeDashboard: (no data-grammar-phase-root="dashboard" landmark found|duplicate data-grammar-phase-root="dashboard" landmark)/,
+      'throw message must identify the scoper and the failure mode',
+    );
+    return;
+  }
+  assert.ok(scoped !== null, 'scoper must either throw or return a narrowed string');
+  assert.doesNotMatch(
+    scoped,
+    /OUTER-TEXT/,
+    'scoped output must not carry the trailing outer-wrapper text — adult-copy leak class bug',
+  );
+});
+
+test('U2: scopeSummary rejects duplicate-landmark attack with clear error', () => {
+  // Two stale-landmark `<div>`s in the same HTML would silently merge
+  // into one scoped string under the old lazy regex. The follower
+  // requires a clear, named throw so the fixture author sees the defect.
+  const attack = '<main><div data-grammar-phase-root="summary">STALE</div><div data-grammar-phase-root="summary">FRESH</div></main>';
+  assert.throws(
+    () => scopeSummary(attack),
+    /scopeSummary: duplicate data-grammar-phase-root="summary" landmark/,
+    'duplicate-landmark attack must surface a dedicated throw',
+  );
+});
+
+// -----------------------------------------------------------------------------
 // Integration — live harness renders produce HTML that the hardened scopers
 // accept without throwing, and the scoped substring is strictly narrower
 // than the raw HTML (proving the narrowing actually fires).
 // -----------------------------------------------------------------------------
+
+// Phrases that appear only inside the adult `<details class=
+// "grammar-grown-up-view">` disclosure. A reviewer finding pointed out
+// that the prior integration assertions (landmark present + some
+// narrowing) did not catch scope-leak — a regex that captured too much
+// would still carry both a landmark substring AND trailing adult copy
+// while being length-narrower than `rawHtml`. The absence assertions
+// below fail fast on that class of defect for the five child phases.
+const ADULT_MARKERS = Object.freeze(['grammar-grown-up-view', 'Evidence snapshot']);
 
 const LIVE_HARNESS_PHASES = Object.freeze([
   'dashboard',
@@ -211,6 +280,11 @@ const LIVE_HARNESS_PHASES = Object.freeze([
   'transfer',
   'analytics',
 ]);
+
+// Only `analytics` legitimately carries the adult copy; every other live
+// phase in the harness is a child scene whose scoped output must exclude
+// the disclosure and its adult vocabulary.
+const ADULT_LIVE_PHASES = Object.freeze(['analytics']);
 
 for (const phase of LIVE_HARNESS_PHASES) {
   test(`U2: live ${phase} render carries the data-grammar-phase-root landmark`, () => {
@@ -230,5 +304,35 @@ for (const phase of LIVE_HARNESS_PHASES) {
       html.length < rawHtml.length,
       `${phase} scoped HTML (${html.length}) must be strictly narrower than raw HTML (${rawHtml.length})`,
     );
+    // Child phases must exclude every adult marker. The analytics phase
+    // is exempt — it IS the adult surface and legitimately carries
+    // `Evidence snapshot` etc. Splitting the assertion this way makes a
+    // silent scope-leak in any child phase fail loud.
+    if (!ADULT_LIVE_PHASES.includes(phase)) {
+      for (const marker of ADULT_MARKERS) {
+        assert.ok(
+          !html.includes(marker),
+          `${phase} scoped HTML must NOT contain adult marker "${marker}" — scope leak`,
+        );
+      }
+    }
   });
 }
+
+// Dedicated characterisation test that names the attack surface explicitly
+// for the dashboard live render. A reviewer follow-up flagged the risk that
+// a regex variant could still narrow `html.length < rawHtml.length` while
+// carrying the adult disclosure — this test spells out that exact guard in
+// a standalone case so a future regression cannot silently slip past the
+// parameterised loop above.
+test('U2: live dashboard scoped HTML excludes the grown-up-view disclosure (adult-copy absence)', () => {
+  const { html } = renderGrammarChildPhaseFixture('dashboard');
+  assert.ok(
+    !html.includes('grammar-grown-up-view'),
+    'dashboard scoped HTML must not contain the grown-up-view disclosure class — adult scope leak',
+  );
+  assert.ok(
+    !html.includes('Evidence snapshot'),
+    'dashboard scoped HTML must not contain the Evidence snapshot adult phrase — adult scope leak',
+  );
+});

--- a/tests/helpers/grammar-phase3-renders.js
+++ b/tests/helpers/grammar-phase3-renders.js
@@ -270,84 +270,180 @@ const PHASE_RENDERERS = Object.freeze({
 // class the Phase 4 plan's invariant 12 floor is defending. On no-match
 // every scoper throws a named error so drift is loud and visible.
 //
-// Per-phase regex notes:
-//   * `dashboard` and `transfer` contain nested `<section>` elements, so
-//     a lazy `</section>` match needs a stable following-sibling lookahead
-//     (`<details class="grammar-grown-up-view">` and `</div></main>`
-//     respectively) to bind to the *root* section close rather than the
-//     first nested close.
-//   * `summary`'s root is a `<div class="grammar-summary-shell...">`
-//     which wraps many nested `<div>`s. Lookahead to `</main>` pins the
-//     match to the shell's own closing `</div>`.
-//   * `session`, `bank`, `analytics` have no nested same-type tag so a
-//     simple lazy `</section>` match is unambiguous.
+// Phase 4 U2 follower-up hardening (nested-outer attack + duplicate-landmark
+// attack): the previous lazy-regex approach (`[\s\S]*?</tag>(?=boundary)`)
+// matched the inner landmark's close but kept the outer wrapper's close +
+// trailing siblings when a hostile fixture nested the landmark inside a
+// same-type outer element. A reviewer-authored
+// `<section class="outer"><section data-grammar-phase-root="dashboard">INNER
+// </section><p>OUTER-TEXT</p></section><details class="grammar-grown-up-view">`
+// input produced scoped output `<section data-grammar-phase-root="dashboard">
+// INNER</section><p>OUTER-TEXT</p></section>` — adult copy leaking into the
+// child sweep. Regex with lazy quantifiers cannot solve nested same-type
+// tag balancing in general.
+//
+// The fix is a depth-balanced walker (`scopeLandmark`) that counts opens
+// and closes of the root tag until depth returns to zero. The walker
+// also enforces exactly-one landmark occurrence, rejecting
+// duplicate-landmark fixtures like
+// `<main><div data-grammar-phase-root="summary">STALE</div><div
+// data-grammar-phase-root="summary">FRESH</div></main>` which the old
+// lazy-regex silently merged into one scoped string.
+//
+// Assumptions and SSR notes:
+//   * React's server renderer emits tag names only inside tag brackets;
+//     string literals like `<section>` never appear inside attribute
+//     values after escaping. The walker's simple open/close detection is
+//     therefore safe for SSR output and for synthetic test fixtures that
+//     mirror that shape.
+//   * Void/self-closing variants of `section` and `div` do not exist in
+//     HTML5; the walker does not need to handle them.
+//   * The optional `boundary` argument asserts that the root close is
+//     immediately followed by a specific sibling marker. This preserves
+//     the old boundary invariant (dashboard → grown-up-view disclosure,
+//     transfer → `</div></main>`, summary → `</main>`) and fails loud if
+//     a refactor reorders the sibling structure.
+
+/**
+ * Depth-balanced landmark scoper. Shared by all six `scope<Phase>` helpers.
+ *
+ * @param {string} html — full rendered HTML.
+ * @param {string} phase — phase key, e.g. `"dashboard"`.
+ * @param {string} rootTag — the landmark root tag name, e.g. `"section"` or `"div"`.
+ * @param {string|null} [boundary] — optional substring that must appear immediately
+ *   after the root close. Pass `null` when no sibling boundary is required.
+ * @returns {string} the landmark-rooted substring (landmark open → root close).
+ * @throws {Error} on missing / multiple landmarks, unbalanced tags, or missing
+ *   expected boundary.
+ */
+function scopeLandmark(html, phase, rootTag, boundary = null) {
+  const scoperName = `scope${phase[0].toUpperCase()}${phase.slice(1)}`;
+  const landmarkAttr = `data-grammar-phase-root="${phase}"`;
+
+  // -- Step 1: enforce exactly-one landmark (duplicate-landmark guard). --
+  // A fixture or a refactor that leaves a stale landmark behind would
+  // otherwise silently merge two subtrees into one scoped string. The
+  // zero-match branch emits the legacy "no landmark found" message so
+  // pre-follower error-path tests keep their stable message regex; the
+  // duplicate branch emits a clearly different "duplicate landmark"
+  // message so a fixture with two landmarks fails loud with a tailored
+  // explanation.
+  const landmarkMatches = html.match(new RegExp(`data-grammar-phase-root="${phase}"`, 'g')) || [];
+  if (landmarkMatches.length === 0) {
+    throw new Error(
+      `${scoperName}: no data-grammar-phase-root="${phase}" landmark found in rendered HTML`,
+    );
+  }
+  if (landmarkMatches.length > 1) {
+    throw new Error(
+      `${scoperName}: duplicate data-grammar-phase-root="${phase}" landmark — expected exactly 1, found ${landmarkMatches.length}`,
+    );
+  }
+
+  // -- Step 2: locate the opening tag that carries the landmark. --
+  // Search backwards from the attribute position for the most recent
+  // `<rootTag ` or `<rootTag>` occurrence — that is the landmark's own
+  // opening tag.
+  const attrIdx = html.indexOf(landmarkAttr);
+  if (attrIdx < 0) {
+    throw new Error(
+      `${scoperName}: no data-grammar-phase-root="${phase}" landmark found in rendered HTML`,
+    );
+  }
+  // Scan backwards: find `<rootTag` followed by a space or `>`. We stop at
+  // the first such occurrence within the same opening tag, i.e. before any
+  // intervening `>` that would close a different tag.
+  let openStart = -1;
+  for (let i = attrIdx; i >= 0; i -= 1) {
+    if (html[i] === '>') break; // landed in a different tag — bail
+    if (html[i] === '<' && html.slice(i + 1, i + 1 + rootTag.length) === rootTag) {
+      const afterName = html[i + 1 + rootTag.length];
+      if (afterName === ' ' || afterName === '>' || afterName === '\t' || afterName === '\n') {
+        openStart = i;
+        break;
+      }
+    }
+  }
+  if (openStart < 0) {
+    throw new Error(
+      `${scoperName}: no data-grammar-phase-root="${phase}" landmark found in rendered HTML`,
+    );
+  }
+
+  // -- Step 3: walk forward, counting opens/closes of `rootTag`. --
+  // We start at `openStart`, treat the landmark's own opening tag as
+  // depth=1, and increment/decrement as further same-type tags appear.
+  // The root close is the first `</rootTag>` that returns depth to 0.
+  const openMarker = `<${rootTag}`;
+  const closeMarker = `</${rootTag}>`;
+  let depth = 0;
+  let i = openStart;
+  let rootEnd = -1;
+  while (i < html.length) {
+    if (html.slice(i, i + openMarker.length) === openMarker) {
+      const afterName = html[i + openMarker.length];
+      if (afterName === ' ' || afterName === '>' || afterName === '\t' || afterName === '\n') {
+        depth += 1;
+        i += openMarker.length;
+        continue;
+      }
+    }
+    if (html.slice(i, i + closeMarker.length) === closeMarker) {
+      depth -= 1;
+      if (depth === 0) {
+        rootEnd = i + closeMarker.length;
+        break;
+      }
+      i += closeMarker.length;
+      continue;
+    }
+    i += 1;
+  }
+  if (rootEnd < 0) {
+    throw new Error(
+      `${scoperName}: no data-grammar-phase-root="${phase}" landmark found in rendered HTML`,
+    );
+  }
+
+  // -- Step 4: enforce the optional sibling boundary. --
+  // This preserves the old regex lookahead contract so a refactor that
+  // reorders the sibling siblings (e.g. inserting a `<hr>` between the
+  // dashboard root and the grown-up-view disclosure) still fails loud.
+  if (boundary !== null && html.slice(rootEnd, rootEnd + boundary.length) !== boundary) {
+    throw new Error(
+      `${scoperName}: no data-grammar-phase-root="${phase}" landmark found in rendered HTML`,
+    );
+  }
+
+  return html.slice(openStart, rootEnd);
+}
 
 export function scopeDashboard(html) {
   // Dashboard root section ends right before the sibling
   // `<details class="grammar-grown-up-view">` disclosure.
-  const match = html.match(
-    /<section[^>]*data-grammar-phase-root="dashboard"[\s\S]*?<\/section>(?=<details class="grammar-grown-up-view">)/,
-  );
-  if (!match) {
-    throw new Error(
-      'scopeDashboard: no data-grammar-phase-root="dashboard" landmark found in rendered HTML',
-    );
-  }
-  return match[0];
+  return scopeLandmark(html, 'dashboard', 'section', '<details class="grammar-grown-up-view">');
 }
 
 export function scopeSession(html) {
-  const match = html.match(
-    /<section[^>]*data-grammar-phase-root="session"[\s\S]*?<\/section>/,
-  );
-  if (!match) {
-    throw new Error(
-      'scopeSession: no data-grammar-phase-root="session" landmark found in rendered HTML',
-    );
-  }
-  return match[0];
+  return scopeLandmark(html, 'session', 'section', null);
 }
 
 export function scopeSummary(html) {
-  // Summary shell root `<div>` closes just before `</main>`. The lookahead
-  // binds to that main close so the lazy match consumes the shell's full
-  // contents rather than the first inner `</div>`.
-  const match = html.match(
-    /<div[^>]*data-grammar-phase-root="summary"[\s\S]*?<\/div>(?=<\/main>)/,
-  );
-  if (!match) {
-    throw new Error(
-      'scopeSummary: no data-grammar-phase-root="summary" landmark found in rendered HTML',
-    );
-  }
-  return match[0];
+  // Summary shell root `<div>` closes just before `</main>`. The boundary
+  // check enforces that sibling structure so a refactor that moves the
+  // shell out of `<main>` fails loud.
+  return scopeLandmark(html, 'summary', 'div', '</main>');
 }
 
 export function scopeBank(html) {
-  const match = html.match(
-    /<section[^>]*data-grammar-phase-root="bank"[\s\S]*?<\/section>/,
-  );
-  if (!match) {
-    throw new Error(
-      'scopeBank: no data-grammar-phase-root="bank" landmark found in rendered HTML',
-    );
-  }
-  return match[0];
+  return scopeLandmark(html, 'bank', 'section', null);
 }
 
 export function scopeTransfer(html) {
   // Transfer root contains nested `<section>` siblings (write, saved,
-  // orphaned). Lookahead to `</div></main>` pins the match to the root
-  // transfer scene close.
-  const match = html.match(
-    /<section[^>]*data-grammar-phase-root="transfer"[\s\S]*?<\/section>(?=<\/div><\/main>)/,
-  );
-  if (!match) {
-    throw new Error(
-      'scopeTransfer: no data-grammar-phase-root="transfer" landmark found in rendered HTML',
-    );
-  }
-  return match[0];
+  // orphaned). The boundary check enforces that the root close is
+  // immediately followed by `</div></main>`.
+  return scopeLandmark(html, 'transfer', 'section', '</div></main>');
 }
 
 export function scopeAnalytics(html) {
@@ -356,15 +452,7 @@ export function scopeAnalytics(html) {
   // no-op. Returns the narrowed landmark-scoped substring; the adult
   // inverse-presence sweep reads `rawHtml` (not this scoped value) so
   // no downstream assertion is affected by the narrowing.
-  const match = html.match(
-    /<section[^>]*data-grammar-phase-root="analytics"[\s\S]*?<\/section>/,
-  );
-  if (!match) {
-    throw new Error(
-      'scopeAnalytics: no data-grammar-phase-root="analytics" landmark found in rendered HTML',
-    );
-  }
-  return match[0];
+  return scopeLandmark(html, 'analytics', 'section', null);
 }
 
 const PHASE_SCOPERS = Object.freeze({

--- a/tests/helpers/grammar-phase3-renders.js
+++ b/tests/helpers/grammar-phase3-renders.js
@@ -260,44 +260,111 @@ const PHASE_RENDERERS = Object.freeze({
 //
 // Each scope helper returns only the child-facing subtree. The adult
 // disclosure is swept separately via the `analytics` phase.
+//
+// Phase 4 U2 hardening: the scope helpers assert on the
+// `data-grammar-phase-root="<phase>"` semantic landmark on the scene's
+// existing root element (added in the six `Grammar*Scene.jsx` components).
+// A DOM refactor that drops a CSS class would otherwise silently
+// fall back to the full HTML and turn the forbidden-term sweep into a
+// false-positive silencer — the exact test-harness-vs-production defect
+// class the Phase 4 plan's invariant 12 floor is defending. On no-match
+// every scoper throws a named error so drift is loud and visible.
+//
+// Per-phase regex notes:
+//   * `dashboard` and `transfer` contain nested `<section>` elements, so
+//     a lazy `</section>` match needs a stable following-sibling lookahead
+//     (`<details class="grammar-grown-up-view">` and `</div></main>`
+//     respectively) to bind to the *root* section close rather than the
+//     first nested close.
+//   * `summary`'s root is a `<div class="grammar-summary-shell...">`
+//     which wraps many nested `<div>`s. Lookahead to `</main>` pins the
+//     match to the shell's own closing `</div>`.
+//   * `session`, `bank`, `analytics` have no nested same-type tag so a
+//     simple lazy `</section>` match is unambiguous.
 
-function scopeDashboard(html) {
-  // Dashboard section ends right before the `<details
-  // class="grammar-grown-up-view">` sibling.
-  const match = html.match(/<section class="grammar-dashboard"[\s\S]*?<\/section>(?=<details class="grammar-grown-up-view">)/);
-  if (match) return match[0];
-  const fallback = html.match(/<section class="grammar-dashboard"[\s\S]*?<\/section>/);
-  return fallback ? fallback[0] : html;
+export function scopeDashboard(html) {
+  // Dashboard root section ends right before the sibling
+  // `<details class="grammar-grown-up-view">` disclosure.
+  const match = html.match(
+    /<section[^>]*data-grammar-phase-root="dashboard"[\s\S]*?<\/section>(?=<details class="grammar-grown-up-view">)/,
+  );
+  if (!match) {
+    throw new Error(
+      'scopeDashboard: no data-grammar-phase-root="dashboard" landmark found in rendered HTML',
+    );
+  }
+  return match[0];
 }
 
-function scopeSession(html) {
-  const match = html.match(/<section class="grammar-session"[\s\S]*?<\/section>/);
-  return match ? match[0] : html;
+export function scopeSession(html) {
+  const match = html.match(
+    /<section[^>]*data-grammar-phase-root="session"[\s\S]*?<\/section>/,
+  );
+  if (!match) {
+    throw new Error(
+      'scopeSession: no data-grammar-phase-root="session" landmark found in rendered HTML',
+    );
+  }
+  return match[0];
 }
 
-function scopeSummary(html) {
-  // Summary shell — stop before the `<details class="grammar-grown-up-view">`
-  // (Grown-up view disclosure) so the child scope is tight.
-  const shellOnly = html.match(/<div class="grammar-summary-shell[^"]*">[\s\S]*?(?=<details class="grammar-grown-up-view">|<\/div><\/main>)/);
-  if (shellOnly) return shellOnly[0];
-  const fallback = html.match(/<div class="grammar-summary-shell[^"]*">[\s\S]*?<\/div><\/main>/);
-  return fallback ? fallback[0].replace(/<\/main>$/, '') : html;
+export function scopeSummary(html) {
+  // Summary shell root `<div>` closes just before `</main>`. The lookahead
+  // binds to that main close so the lazy match consumes the shell's full
+  // contents rather than the first inner `</div>`.
+  const match = html.match(
+    /<div[^>]*data-grammar-phase-root="summary"[\s\S]*?<\/div>(?=<\/main>)/,
+  );
+  if (!match) {
+    throw new Error(
+      'scopeSummary: no data-grammar-phase-root="summary" landmark found in rendered HTML',
+    );
+  }
+  return match[0];
 }
 
-function scopeBank(html) {
-  const match = html.match(/<section class="grammar-bank[\s\S]*?<\/section>/);
-  return match ? match[0] : html;
+export function scopeBank(html) {
+  const match = html.match(
+    /<section[^>]*data-grammar-phase-root="bank"[\s\S]*?<\/section>/,
+  );
+  if (!match) {
+    throw new Error(
+      'scopeBank: no data-grammar-phase-root="bank" landmark found in rendered HTML',
+    );
+  }
+  return match[0];
 }
 
-function scopeTransfer(html) {
-  const match = html.match(/<section class="grammar-transfer-scene"[\s\S]*?<\/section>/);
-  return match ? match[0] : html;
+export function scopeTransfer(html) {
+  // Transfer root contains nested `<section>` siblings (write, saved,
+  // orphaned). Lookahead to `</div></main>` pins the match to the root
+  // transfer scene close.
+  const match = html.match(
+    /<section[^>]*data-grammar-phase-root="transfer"[\s\S]*?<\/section>(?=<\/div><\/main>)/,
+  );
+  if (!match) {
+    throw new Error(
+      'scopeTransfer: no data-grammar-phase-root="transfer" landmark found in rendered HTML',
+    );
+  }
+  return match[0];
 }
 
-function scopeAnalytics(html) {
-  // Adult-facing — no scoping; inverse-presence sweep reads the whole
-  // rendered surface.
-  return html;
+export function scopeAnalytics(html) {
+  // Adult-facing — still asserts the landmark exists so the adult surface
+  // cannot silently lose its root and turn inverse-presence into a
+  // no-op. Returns the narrowed landmark-scoped substring; the adult
+  // inverse-presence sweep reads `rawHtml` (not this scoped value) so
+  // no downstream assertion is affected by the narrowing.
+  const match = html.match(
+    /<section[^>]*data-grammar-phase-root="analytics"[\s\S]*?<\/section>/,
+  );
+  if (!match) {
+    throw new Error(
+      'scopeAnalytics: no data-grammar-phase-root="analytics" landmark found in rendered HTML',
+    );
+  }
+  return match[0];
 }
 
 const PHASE_SCOPERS = Object.freeze({

--- a/tests/react-grammar-surface.test.js
+++ b/tests/react-grammar-surface.test.js
@@ -8,6 +8,7 @@ import {
 } from './helpers/grammar-subject-harness.js';
 import { readGrammarLegacyOracle } from './helpers/grammar-legacy-oracle.js';
 import { installMemoryStorage } from './helpers/memory-storage.js';
+import { scopeSummary } from './helpers/grammar-phase3-renders.js';
 import {
   grammarModule,
   GRAMMAR_TRANSFER_ERROR_COPY,
@@ -2520,10 +2521,13 @@ function u5RunRegularToSummary() {
 }
 
 function u5ScopeToSummaryHtml(html) {
-  const match = html.match(/<div class="grammar-summary-shell[^"]*">[\s\S]*?<\/div><\/main>/);
-  assert.ok(match, 'summary shell was rendered');
-  // Trim trailing `</main>` so the returned HTML is the summary subtree.
-  return match[0].replace(/<\/main>$/, '');
+  // Phase 4 U2: delegate to the exported, landmark-based `scopeSummary`
+  // helper so the local surface test and the Phase 3 forbidden-term
+  // sweep share a single source of truth for what "the summary subtree"
+  // means. The helper throws on a missing
+  // `data-grammar-phase-root="summary"` landmark, so a DOM refactor that
+  // drops the attribute surfaces a loud failure here too.
+  return scopeSummary(html);
 }
 
 test('U5: regular summary renders exactly five summary cards', () => {


### PR DESCRIPTION
## Summary
- Replace silent-fallback scopers in `tests/helpers/grammar-phase3-renders.js` with landmark-based regexes that throw a named error when the `data-grammar-phase-root="<phase>"` attribute is missing from the rendered HTML.
- Add `data-grammar-phase-root` attributes to six scene roots (`GrammarSetupScene`, `GrammarSessionScene`, `GrammarSummaryScene`, `GrammarConceptBankScene`, `GrammarTransferScene`, `GrammarAnalyticsScene`) without wrapping new elements — plain `data-*` attributes on the existing semantic roots.
- Characterisation-first test file `tests/grammar-phase3-scopers.test.js` (33 tests) pins the throw path against synthetic HTML, so the contract holds even if the live harness output later changes.
- Local `u5ScopeToSummaryHtml` in `tests/react-grammar-surface.test.js` now delegates to the exported `scopeSummary` so the surface test and the forbidden-term sweep share one source of truth.

## Why
Before U2, five scoper helpers in `tests/helpers/grammar-phase3-renders.js` (`scopeDashboard`, `scopeSession`, `scopeSummary`, `scopeBank`, `scopeTransfer`) silently fell back to returning the full rendered HTML when their CSS-class regex failed to match. A DOM refactor that dropped a class landmark would have turned the Phase 3 forbidden-term sweep into a false-positive silencer — exactly the test-harness-vs-production defect class Phase 4 invariant 12 is defending. `scopeAnalytics` intentionally returned full HTML too, so it was equally vulnerable. After U2 all six helpers fail loud on landmark drift.

## Plan linkage
- `docs/plans/2026-04-26-001-feat-grammar-phase4-learning-hardening-plan.md` — unit U2.
- `docs/plans/james/grammar/grammar-phase4-invariants.md` — invariants 1, 2, 12 (U2 scopers are named as the forbidden-term sweep enforcer for invariants 1 and 2).

## What the scopers now do per phase
- **dashboard** — `<section>` root; lookahead to the sibling `<details class="grammar-grown-up-view">` pins the root close past the two nested `<section>`s.
- **session** — `<section>` root, no nested same-type; simple lazy `</section>` match.
- **summary** — `<div class="grammar-summary-shell...">` root; lookahead to `</main>` pins the root close past many nested `<div>`s.
- **bank** — `<section>` root, no nested same-type; simple lazy `</section>` match.
- **transfer** — `<section>` root; lookahead to `</div></main>` pins the root close past three nested `<section>`s.
- **analytics** — `<section>` root, no nested same-type; simple lazy `</section>` match. Now throws on landmark-missing too (previously returned full HTML).

## Test plan
- [x] `npm test -- tests/grammar-phase3-roster.test.js tests/grammar-phase3-child-copy.test.js tests/grammar-phase3-non-scored.test.js tests/grammar-functionality-completeness.test.js` — 87 pass (Phase 3 completeness gate preserved).
- [x] `npm test -- tests/grammar-phase3-scopers.test.js` — 33 new tests pass (error path: landmark missing, wrong-phase, no closing tag, missing boundary marker; happy path: narrowed substring; live-harness integration).
- [x] `npm test -- tests/react-grammar-surface.test.js` — 104 pass (the local `u5ScopeToSummaryHtml` helper migrates to the exported `scopeSummary`).
- [x] Comprehensive grammar + react-surface run — 517 tests pass (21 grammar-*.test.js + react-grammar-surface.test.js + grammar-phase3-scopers.test.js).
- [x] `npm run check` — wrangler-oauth dry-run passes (client bundle audit 802 files).
- [x] `grep -n "fallback ? fallback\[0\] : html" tests/helpers/grammar-phase3-renders.js` — 0 hits.
- [x] `tests/helpers/forbidden-keys.mjs` untouched.
- [x] `tests/fixtures/grammar-phase3-baseline.json` untouched.
- [x] `GRAMMAR_CONTENT_RELEASE_ID` untouched.

## Invariants preserved
1, 2 (scopers defend the forbidden-term sweep against DOM drift), 7, 9, 10, 11, 12.