### PR TITLE
feat(spelling): U4 remote-sync post-mastery hydration + Alt+4/Alt+5 regression (P2)

### DIFF
--- a/src/subjects/spelling/client-read-models.js
+++ b/src/subjects/spelling/client-read-models.js
@@ -93,10 +93,64 @@ function asReadModel(rawValue, learnerId) {
   };
 }
 
-export function createSpellingReadModelService({ getState = () => null } = {}) {
+// P2 U4: hydration window before we flip the fallback label from
+// 'checking' to 'locked-fallback'. 500ms is short enough that a fresh
+// bootstrap response (observed ~100-300ms over LAN) lands well before the
+// flip, and long enough that a slow network still sees a deliberate
+// "Checking Word Vault..." placeholder rather than a pre-emptive "locked"
+// copy. If the worker response never arrives (offline, degraded sync)
+// the UI falls through to the legacy locked dashboard after the timeout.
+export const POST_MASTERY_HYDRATION_WINDOW_MS = 500;
+
+function buildLockedFallback({ source, todayDay }) {
+  return {
+    ...createLockedPostMasteryState(),
+    todayDay,
+    postMasteryDebug: {
+      source,
+      publishedCoreCount: 0,
+      secureCoreCount: 0,
+      blockingCoreCount: 0,
+      blockingCoreSlugsPreview: [],
+      extraWordsIgnoredCount: 0,
+      guardianMapCount: 0,
+      contentReleaseId: null,
+      allWordsMega: false,
+      stickyUnlocked: false,
+    },
+  };
+}
+
+export function createSpellingReadModelService({
+  getState = () => null,
+  now = () => Date.now(),
+  hydrationWindowMs = POST_MASTERY_HYDRATION_WINDOW_MS,
+} = {}) {
+  // Per-learner hydration window timestamp. A learner that has never seen a
+  // worker hydration event gets `source: 'checking'` for the first
+  // `hydrationWindowMs` of their session; afterwards the source falls
+  // through to 'locked-fallback' so the legacy dashboard renders rather
+  // than a stuck "Checking Word Vault..." placeholder.
+  const hydrationStart = new Map();
+
   function readModel(learnerId) {
     const appState = getState() || {};
     return asReadModel(appState.subjectUi?.spelling, learnerId || appState.learners?.selectedId || '');
+  }
+
+  function sourceFallbackForLearner(learnerId) {
+    const key = String(learnerId || '');
+    const ts = typeof now === 'function' ? Number(now()) : Number(now);
+    const safeTs = Number.isFinite(ts) ? ts : Date.now();
+    const window = Number(hydrationWindowMs);
+    const safeWindow = Number.isFinite(window) && window >= 0 ? window : POST_MASTERY_HYDRATION_WINDOW_MS;
+    if (!hydrationStart.has(key)) {
+      hydrationStart.set(key, safeTs);
+      return safeWindow > 0 ? 'checking' : 'locked-fallback';
+    }
+    const startedAt = Number(hydrationStart.get(key));
+    const elapsed = safeTs - startedAt;
+    return elapsed < safeWindow ? 'checking' : 'locked-fallback';
   }
 
   return {
@@ -141,26 +195,29 @@ export function createSpellingReadModelService({ getState = () => null } = {}) {
       // zero / false because the client shell has no guardian data to reason
       // about — if the admin sees this on production it's a strong signal
       // the Worker hydration hasn't completed yet for the selected learner.
+      //
+      // U4 (P2): the no-cache fallback now stamps `source: 'checking'`
+      // for the first 500ms of a learner session (hydration window). The
+      // SpellingSetupScene renders a "Checking Word Vault..." skeleton while
+      // the source reads 'checking'; if the worker round-trip has not
+      // landed within the window, the source falls through to the legacy
+      // 'locked-fallback' so the dashboard degrades to the legacy Smart
+      // Review setup rather than a stuck loading state. A graduated
+      // learner with a LOCAL sticky-bit short-circuits this entire path
+      // because the client's service-authoritative getPostMasteryState
+      // returns `postMegaDashboardAvailable: true` synchronously — the
+      // checking placeholder is NOT visible in the happy path for
+      // returning graduated learners.
       const cached = readModel(learnerId).postMastery;
       if (cached && typeof cached === 'object' && !Array.isArray(cached)) {
         return cloneSerialisable(cached);
       }
-      return {
-        ...createLockedPostMasteryState(),
-        todayDay: Math.floor(Date.now() / (24 * 60 * 60 * 1000)),
-        postMasteryDebug: {
-          source: 'locked-fallback',
-          publishedCoreCount: 0,
-          secureCoreCount: 0,
-          blockingCoreCount: 0,
-          blockingCoreSlugsPreview: [],
-          extraWordsIgnoredCount: 0,
-          guardianMapCount: 0,
-          contentReleaseId: null,
-          allWordsMega: false,
-          stickyUnlocked: false,
-        },
-      };
+      const tsNow = typeof now === 'function' ? Number(now()) : Number(now);
+      const safeTs = Number.isFinite(tsNow) ? tsNow : Date.now();
+      return buildLockedFallback({
+        source: sourceFallbackForLearner(learnerId),
+        todayDay: Math.floor(safeTs / (24 * 60 * 60 * 1000)),
+      });
     },
     getAudioCue(learnerId) {
       return cloneSerialisable(readModel(learnerId).audio || null);

--- a/src/subjects/spelling/components/SpellingSetupScene.jsx
+++ b/src/subjects/spelling/components/SpellingSetupScene.jsx
@@ -341,8 +341,23 @@ export function SpellingSetupScene({
     postMastery?.postMegaDashboardAvailable
     ?? postMastery?.allWordsMega,
   );
+  // P2 U4: hydration window signal. When the remote-sync shell has not yet
+  // received the worker's `postMastery` snapshot AND the learner has no
+  // local sticky-bit, the client read-model stamps
+  // `postMasteryDebug.source === 'checking'` for the first ~500ms. During
+  // that window we render a minimalist "Checking Word Vault..." skeleton
+  // post-Mega card instead of the legacy Smart Review setup — a graduated
+  // learner seeing the Guardian dashboard flicker into existence is jarring,
+  // so the skeleton preserves the post-Mega silhouette while the worker
+  // round-trip lands. After the timeout the source flips to
+  // `'locked-fallback'` and the legacy dashboard renders (the only
+  // acceptable flicker window is fresh-device bootstrap, per the plan's
+  // H6 short-circuit invariant).
+  const hydrationSource = postMastery?.postMasteryDebug?.source || '';
+  const isHydrationChecking = !isPostMega && hydrationSource === 'checking';
   const contentClasses = ['setup-content'];
   if (isPostMega) contentClasses.push('setup-content--post-mega');
+  if (isHydrationChecking) contentClasses.push('setup-content--checking');
 
   // P2 U1: admin / ops adults see a "Why is Guardian locked?" diagnostic
   // link right below the setup hero when Guardian Mission is NOT unlocked
@@ -376,6 +391,8 @@ export function SpellingSetupScene({
               startDisabled={startDisabled}
               runtimeReadOnly={runtimeReadOnly}
             />
+          ) : isHydrationChecking ? (
+            <CheckingWordVaultContent />
           ) : (
             <LegacySetupContent
               prefs={prefs}
@@ -524,6 +541,77 @@ function LegacySetupContent({
         </button>
       </div>
     </>
+  );
+}
+
+/* P2 U4: "Checking Word Vault..." skeleton for the brief hydration window
+ * on a fresh-device bootstrap. Rendered only when the learner has no
+ * client-cached postMastery snapshot AND the remote-sync shell has not yet
+ * received the worker's postMastery response. Sticky-bit local-storage
+ * graduates skip this entirely (H6 short-circuit); the skeleton is only
+ * visible on a fresh device or after a data-clear.
+ *
+ * Design intent: preserve the post-Mega silhouette (hero card, title,
+ * stat ribbon, single CTA slot) so a graduated learner who opens the app
+ * on a new device does NOT see the legacy Smart Review setup flicker.
+ * Reserves the vertical space so the eventual worker response does not
+ * shift page content. Uses the same `post-mega-eyebrow` / `post-mega-title`
+ * typography classes as the real dashboard for visual continuity.
+ *
+ * Copy is deliberately neutral ("checking", not "loading"): kids read it
+ * as a deliberate system state rather than a spinner that might be stuck.
+ * The "Checking Word Vault..." label lives in a role=status region so
+ * assistive tech announces the placeholder once on render without
+ * overriding the learner's focus. */
+function CheckingWordVaultContent() {
+  return (
+    <section
+      className="post-mega-hydration-skeleton"
+      data-test-id="post-mega-hydration-skeleton"
+      aria-busy="true"
+    >
+      <p className="eyebrow post-mega-eyebrow">Graduated · Spelling Guardian</p>
+      <h1 className="title post-mega-title post-mega-hydration-skeleton__title">
+        <span aria-hidden="true" className="post-mega-hydration-skeleton__title-fill">The Word Vault is yours.</span>
+      </h1>
+      <p
+        className="lede post-mega-lede post-mega-hydration-skeleton__lede"
+        role="status"
+      >
+        Checking Word Vault&hellip;
+      </p>
+      <dl
+        className="post-mega-stat-ribbon post-mega-hydration-skeleton__ribbon"
+        aria-label="Guardian duty overview loading"
+      >
+        <div className="post-mega-stat post-mega-hydration-skeleton__stat" aria-hidden="true">
+          <dt>Words secured</dt>
+          <dd>&mdash;</dd>
+        </div>
+        <div className="post-mega-stat post-mega-hydration-skeleton__stat" aria-hidden="true">
+          <dt>Due today</dt>
+          <dd>&mdash;</dd>
+        </div>
+        <div className="post-mega-stat post-mega-hydration-skeleton__stat" aria-hidden="true">
+          <dt>Next check</dt>
+          <dd>&mdash;</dd>
+        </div>
+      </dl>
+      <div
+        className="mode-row mode-row-post-mega post-mega-hydration-skeleton__row"
+        data-variant="checking"
+        aria-hidden="true"
+      >
+        <div className="mode-card mode-card-post post-mega-hydration-skeleton__card">
+          <div className="mc-top">
+            <div className="mc-icon mc-icon-glyph"><span className="mc-glyph">&middot;</span></div>
+            <span className="mc-badge mc-badge-post post-mega-hydration-skeleton__badge">CHECKING</span>
+          </div>
+          <h4>Guardian Mission</h4>
+          <p>Confirming your Word Vault status&hellip;</p>
+        </div>
+      </div>
+    </section>
   );
 }
 

--- a/src/subjects/spelling/read-model.js
+++ b/src/subjects/spelling/read-model.js
@@ -413,6 +413,20 @@ export function getSpellingPostMasteryState({
     guardianMissionAvailable,
     recommendedWords,
     nextGuardianDueDay,
+    // PR #277 HIGH (correctness) fix — the SpellingSetupScene's
+    // GraduationStatRibbon (line ~114) reads `postMastery.todayDay` to
+    // compute `nextDueDelta`, and SpellingWordBankScene (lines 206-211,
+    // 391-396) reads `postMastery.guardianMap` + `postMastery.todayDay`
+    // to drive Guardian chip filtering and the word-bank stats. Prior to
+    // this fix the Worker-emitted postMastery block omitted these two
+    // fields, so after U4 hydration the Setup scene displayed
+    // "Next check in 20562 days" (today fell back to 0 so
+    // nextDueDelta === nextGuardianDueDay) and the Word Bank's Guardian
+    // filters produced an empty mapping. Both values are already in scope
+    // above (computed at lines ~167 and ~173) so this is a pure return-
+    // shape fix — no derivation change, no contract drift.
+    todayDay: currentDay,
+    guardianMap,
     postMasteryDebug,
   };
 }

--- a/src/subjects/spelling/remote-actions.js
+++ b/src/subjects/spelling/remote-actions.js
@@ -282,6 +282,23 @@ export function createRemoteSpellingActionHandler({
     if (targetLearnerId) scopedRuntimeErrors.delete(targetLearnerId);
   }
 
+  // P2 U4: merge `response.postMastery` into `subjectUi.spelling.postMastery`
+  // so the Setup scene, summary scene and Alt+4 / Alt+5 gate read a worker-
+  // authoritative snapshot instead of the client-only locked-fallback. Only
+  // fires for the selected learner — a background-learner response would
+  // otherwise clobber the visible dashboard's cached snapshot.
+  function hydrateWorkerPostMastery(response, { learnerId, isSelected } = {}) {
+    if (!response || typeof response !== 'object') return;
+    if (!isSelected) return;
+    const incoming = response.postMastery;
+    if (!incoming || typeof incoming !== 'object' || Array.isArray(incoming)) return;
+    patchSpellingSubjectUiLocally((current) => ({
+      ...current,
+      learnerId: current?.learnerId || learnerId || '',
+      postMastery: incoming,
+    }));
+  }
+
   function applyCommandResponse(response, {
     command = '',
     learnerId: requestedLearnerId = '',
@@ -303,6 +320,15 @@ export function createRemoteSpellingActionHandler({
     clearRuntimeErrorForLearner(learnerId);
     reconcilePreferenceSaveResponse({ command, learnerId, preferenceVersion });
     reapplyPendingOptimisticPrefs();
+    // P2 U4: hydrate the post-mastery snapshot from the worker response into
+    // `subjectUi.spelling.postMastery` so subsequent reads via
+    // `createSpellingReadModelService.getPostMasteryState(learnerId)` see the
+    // worker-authoritative values instead of the client-only
+    // locked-fallback. Additive contract — an older worker that omits the
+    // field leaves whatever is already cached in place (including the first-
+    // load absence, where the read-model service reverts to locked-fallback
+    // on demand).
+    hydrateWorkerPostMastery(response, { learnerId, isSelected: wasSelectedLearner });
     const nextState = appState();
     const nextSubjectUi = response?.subjectReadModel || response?.state || nextState.subjectUi?.spelling || null;
     const isSelectedLearner = !learnerId || nextState.learners?.selectedId === learnerId;

--- a/src/subjects/spelling/remote-actions.js
+++ b/src/subjects/spelling/remote-actions.js
@@ -316,6 +316,18 @@ export function createRemoteSpellingActionHandler({
     if (wasSelectedLearner && shouldStopSpellingTtsForCommandResponse(command, response)) {
       tts.stop();
     }
+    // PR #277 HIGH (adversarial) fix — capture the previous postMastery
+    // snapshot BEFORE the reload. `reloadFromRepositories` rebuilds
+    // `subjectUi.spelling` from persisted state (postMastery is not
+    // persisted in subjectStates), so without this capture a response that
+    // omits `postMastery` (old-worker rolling deploy, Worker derivation
+    // throw handled below in engine.js, or any deploy rollback) would leave
+    // the scene with an empty cache and the read-model would fall back to
+    // the locked stub — demoting a graduated learner's dashboard to the
+    // "Checking Word Vault…" placeholder until the next round-trip. By
+    // preserving the previous cache when the response lacks a postMastery
+    // block, we keep the dashboard continuous across rolling deploys.
+    const previousPostMastery = previousSubjectUi?.postMastery;
     store.reloadFromRepositories({ preserveRoute: true, preserveMonsterCelebrations: true });
     clearRuntimeErrorForLearner(learnerId);
     reconcilePreferenceSaveResponse({ command, learnerId, preferenceVersion });
@@ -328,7 +340,21 @@ export function createRemoteSpellingActionHandler({
     // field leaves whatever is already cached in place (including the first-
     // load absence, where the read-model service reverts to locked-fallback
     // on demand).
-    hydrateWorkerPostMastery(response, { learnerId, isSelected: wasSelectedLearner });
+    const incomingPostMastery = response?.postMastery;
+    if (incomingPostMastery && typeof incomingPostMastery === 'object' && !Array.isArray(incomingPostMastery)) {
+      hydrateWorkerPostMastery(response, { learnerId, isSelected: wasSelectedLearner });
+    } else if (wasSelectedLearner && previousPostMastery && typeof previousPostMastery === 'object' && !Array.isArray(previousPostMastery)) {
+      // PR #277 HIGH adversarial: Worker omitted postMastery (old worker
+      // rolling deploy, Worker derivation throw via the MEDIUM try/catch
+      // fix below, or a deploy rollback). Preserve the previous snapshot so
+      // a graduated learner's dashboard stays intact instead of regressing
+      // to locked-fallback between round-trips.
+      patchSpellingSubjectUiLocally((current) => ({
+        ...current,
+        learnerId: current?.learnerId || learnerId || '',
+        postMastery: previousPostMastery,
+      }));
+    }
     const nextState = appState();
     const nextSubjectUi = response?.subjectReadModel || response?.state || nextState.subjectUi?.spelling || null;
     const isSelectedLearner = !learnerId || nextState.learners?.selectedId === learnerId;
@@ -567,7 +593,25 @@ export function createRemoteSpellingActionHandler({
     if (latest && Number(latest.version) <= Number(preferenceVersion)) {
       latestPreferenceIntents.delete(learnerId);
     }
+    // PR #277 HIGH (adversarial) fix — mirror the applyCommandResponse
+    // capture/restore. Without this, a graduated learner who hits the
+    // Alt+4 shortcut, has the start-session succeed, but then has the
+    // follow-up save-prefs fail would get their postMastery cache wiped
+    // by reloadFromRepositories. On returning to the dashboard the
+    // read-model service would fall back to locked-fallback, dropping the
+    // learner out of Guardian / Boss and back onto Smart Review. Capture
+    // the snapshot before the reload and restore it afterwards so the
+    // graduated state survives the preference-save failure path.
+    const wasSelectedLearner = !learnerId || appState().learners?.selectedId === learnerId;
+    const previousPostMastery = appState().subjectUi?.spelling?.postMastery;
     store.reloadFromRepositories({ preserveRoute: true });
+    if (wasSelectedLearner && previousPostMastery && typeof previousPostMastery === 'object' && !Array.isArray(previousPostMastery)) {
+      patchSpellingSubjectUiLocally((current) => ({
+        ...current,
+        learnerId: current?.learnerId || learnerId || '',
+        postMastery: previousPostMastery,
+      }));
+    }
     reapplyPendingOptimisticPrefs();
     setRuntimeErrorForLearner(learnerId, commandErrorMessage(error, 'The spelling options could not be saved.'));
   }

--- a/styles/app.css
+++ b/styles/app.css
@@ -4812,6 +4812,80 @@ textarea:focus-visible {
   margin-left: 4px;
 }
 
+/* P2 U4: "Checking Word Vault..." skeleton scene for the ~500ms hydration
+ * window on a fresh-device bootstrap. Mirrors the post-Mega silhouette
+ * (eyebrow, title, lede, stat ribbon, single mode card) so the eventual
+ * worker response does not shift page content. Softly pulses the title
+ * + card fills so kids read it as a deliberate system state rather than
+ * a broken dashboard. No loading spinners — the existing typography tokens
+ * carry the wait. Sticky-bit short-circuit (H6) hides this skeleton for
+ * returning graduated learners, so it is only visible on first load of a
+ * new device (the one acceptable flicker window per the P2 plan).
+ */
+.post-mega-hydration-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 420px;
+}
+.post-mega-hydration-skeleton__title {
+  position: relative;
+  overflow: hidden;
+}
+.post-mega-hydration-skeleton__title-fill {
+  display: inline-block;
+  background: linear-gradient(
+    90deg,
+    color-mix(in oklab, var(--panel) 34%, transparent) 0%,
+    color-mix(in oklab, var(--brand-soft) 56%, transparent) 50%,
+    color-mix(in oklab, var(--panel) 34%, transparent) 100%);
+  background-size: 200% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: postMegaHydrationSweep 1400ms ease-in-out infinite;
+}
+.post-mega-hydration-skeleton__lede {
+  color: color-mix(in oklab, var(--mode-card-copy, var(--muted)) 80%, transparent);
+  font-style: italic;
+}
+.post-mega-hydration-skeleton__ribbon {
+  opacity: 0.76;
+  pointer-events: none;
+}
+.post-mega-hydration-skeleton__stat dd {
+  color: color-mix(in oklab, var(--mode-card-title, var(--ink)) 48%, transparent);
+}
+.post-mega-hydration-skeleton__row {
+  margin-top: 8px;
+}
+.post-mega-hydration-skeleton__card {
+  border: 1.25px dashed color-mix(in oklab, var(--brand) 32%, var(--line));
+  background:
+    linear-gradient(180deg,
+      color-mix(in oklab, var(--brand-soft) 22%, transparent) 0%,
+      color-mix(in oklab, var(--panel) 38%, transparent) 100%);
+  opacity: 0.92;
+  animation: postMegaHydrationPulse 1600ms ease-in-out infinite;
+}
+.post-mega-hydration-skeleton__badge {
+  background: color-mix(in oklab, var(--panel) 52%, transparent);
+  color: color-mix(in oklab, var(--mode-card-title, var(--ink)) 64%, transparent);
+  letter-spacing: 0.12em;
+}
+@keyframes postMegaHydrationSweep {
+  0%, 100% { background-position: 180% 50%; }
+  50% { background-position: -40% 50%; }
+}
+@keyframes postMegaHydrationPulse {
+  0%, 100% { opacity: 0.78; }
+  50% { opacity: 0.98; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .post-mega-hydration-skeleton__title-fill { animation: none; background-position: 50% 50%; }
+  .post-mega-hydration-skeleton__card { animation: none; opacity: 0.9; }
+}
+
 .setup-control-stack {
   min-height: 196px;
   margin-top: 20px;

--- a/tests/spelling-post-mastery-debug.test.js
+++ b/tests/spelling-post-mastery-debug.test.js
@@ -525,8 +525,16 @@ test('U1 edge: guardianMapCount reflects normalised guardian map size', () => {
 // --------------------------------------------------------------------------
 
 test('U1 error: client-read-models fallback stub attaches postMasteryDebug.source === "locked-fallback"', () => {
+  // P2 U4: the default read-model service now stamps source='checking' for
+  // the first 500ms of a learner's session (hydration window) and only
+  // falls through to 'locked-fallback' after the timeout. Disable the
+  // hydration window explicitly here so the legacy locked-fallback label
+  // remains visible — this test pins the UI's post-timeout fallback shape
+  // that the Admin hub depends on. The 'checking' transient is covered by
+  // tests in tests/spelling-remote-sync-hydration.test.js.
   const service = createSpellingReadModelService({
     getState: () => ({}),
+    hydrationWindowMs: 0,
   });
   const snapshot = service.getPostMasteryState('learner-a');
   assert.ok(snapshot.postMasteryDebug);

--- a/tests/spelling-remote-actions.test.js
+++ b/tests/spelling-remote-actions.test.js
@@ -1571,3 +1571,270 @@ test('U10 remote-sync: non-session start response skips save-prefs (dashboard bo
   assert.deepEqual(commands, ['start-session'],
     'server-level start rejection (phase !== session) must also skip save-prefs');
 });
+
+// -----------------------------------------------------------------------------
+// U4 (P2): Alt+4 (Guardian) + Alt+5 (Boss) regression pin for BOTH dispatchers.
+//
+// The ordering fix already shipped in P1.5 U10 but the regression surface is
+// subtle enough to pin explicitly here. Test matrix per mode:
+//   - remote-sync async path (sendCommand('start-session') before
+//     sendCommand('save-prefs'); save-prefs skipped on failure).
+//   - module.js synchronous path via a spy on `service.startSession` +
+//     `service.savePrefs`; tested separately below under the `U4 module.js`
+//     heading because they exercise a different dispatcher.
+// -----------------------------------------------------------------------------
+
+function createGuardianShortcutHarness({
+  startResponse = { subjectReadModel: { phase: 'session' } },
+  startRejection = null,
+  saveResponse = { subjectReadModel: { phase: 'session' } },
+  prefs = { mode: 'smart', yearFilter: 'core', roundLength: '20', extraWordFamilies: false },
+} = {}) {
+  const { getState, store } = createStoreHarness({
+    subjectUi: {
+      spelling: {
+        phase: 'dashboard',
+        prefs,
+        analytics: null,
+        error: '',
+      },
+    },
+  });
+  const sent = [];
+  const handler = createRemoteSpellingActionHandler({
+    store,
+    services: {
+      spelling: {
+        getPrefs() { return getState().subjectUi.spelling.prefs; },
+        // `allWordsMega: true` — Guardian gate lets Alt+4 through.
+        getPostMasteryState() { return { allWordsMega: true }; },
+      },
+    },
+    tts: createTtsHarness(),
+    readModels: { readJson: async () => ({}) },
+    subjectCommands: {
+      send(request) {
+        sent.push(request);
+        if (request.command === 'start-session') {
+          if (startRejection) return Promise.reject(startRejection);
+          return Promise.resolve(startResponse);
+        }
+        if (request.command === 'save-prefs') return Promise.resolve(saveResponse);
+        return Promise.resolve({});
+      },
+    },
+    preferenceSaveDebounceMs: 0,
+  });
+  return { handler, sent, getState };
+}
+
+test('U4 remote-sync: Alt+4 Guardian shortcut runs start-session FIRST, then save-prefs (ordering pin)', async () => {
+  const { handler, sent } = createGuardianShortcutHarness();
+  // Alt+4 dispatches { mode: 'guardian' } WITHOUT an explicit length — the
+  // handler falls back to prefs.roundLength. Unlike Alt+5 Boss, Guardian does
+  // not override the round length on the shortcut payload.
+  assert.equal(handler.handle('spelling-shortcut-start', { mode: 'guardian' }), true);
+  await flushPromises();
+  await flushPromises();
+  await flushPromises();
+
+  const orderedCommands = sent.map((request) => request.command);
+  assert.deepEqual(orderedCommands, ['start-session', 'save-prefs'],
+    'Guardian (Alt+4) ordering must be start-session → save-prefs: a failed Guardian start cannot persist prefs.mode = "guardian"');
+  const startSession = sent.find((request) => request.command === 'start-session');
+  assert.equal(startSession.payload.mode, 'guardian');
+});
+
+test('U4 remote-sync: Alt+4 Guardian failed start-session skips save-prefs (rollback pin)', async () => {
+  const originalWarn = globalThis.console?.warn;
+  if (globalThis.console) globalThis.console.warn = () => {};
+  try {
+    const { handler, sent } = createGuardianShortcutHarness({
+      startRejection: new Error('Guardian start rejected'),
+    });
+    assert.equal(handler.handle('spelling-shortcut-start', { mode: 'guardian' }), true);
+    await flushPromises();
+    await flushPromises();
+    await flushPromises();
+
+    const commands = sent.map((request) => request.command);
+    assert.deepEqual(commands, ['start-session'],
+      'Alt+4 failure must NOT fire save-prefs — prefs.mode must not be mutated to "guardian"');
+  } finally {
+    if (globalThis.console) globalThis.console.warn = originalWarn;
+  }
+});
+
+test('U4 remote-sync: Alt+4 Guardian non-session start response skips save-prefs', async () => {
+  const { handler, sent } = createGuardianShortcutHarness({
+    startResponse: { ok: false, subjectReadModel: { phase: 'dashboard' } },
+  });
+  assert.equal(handler.handle('spelling-shortcut-start', { mode: 'guardian' }), true);
+  await flushPromises();
+  await flushPromises();
+  await flushPromises();
+
+  const commands = sent.map((request) => request.command);
+  assert.deepEqual(commands, ['start-session'],
+    'server-level start rejection (phase !== session) must also skip save-prefs on Guardian Alt+4');
+});
+
+test('U4 remote-sync: Alt+5 Boss pinned length = 10 (BOSS_DEFAULT_ROUND_LENGTH) on the start-session payload', async () => {
+  // Explicit second-pass pin: `length: 10` is the BOSS_DEFAULT_ROUND_LENGTH
+  // constant in service-contract.js. A future refactor that wires Alt+5 to
+  // prefs.roundLength without this override would fail this assertion.
+  const { handler, sent } = createBossShortcutHarness({
+    prefs: { mode: 'smart', yearFilter: 'core', roundLength: '20', extraWordFamilies: false },
+  });
+  assert.equal(handler.handle('spelling-shortcut-start', { mode: 'boss', length: 10 }), true);
+  await flushPromises();
+  await flushPromises();
+  await flushPromises();
+
+  const startSession = sent.find((request) => request.command === 'start-session');
+  assert.equal(startSession.payload.length, 10,
+    'Alt+5 Boss shortcut pinned to BOSS_DEFAULT_ROUND_LENGTH = 10');
+  assert.equal(startSession.payload.mode, 'boss');
+  const orderedCommands = sent.map((request) => request.command);
+  assert.deepEqual(orderedCommands, ['start-session', 'save-prefs'],
+    'Alt+5 Boss ordering: start-session FIRST, then save-prefs');
+});
+
+// -----------------------------------------------------------------------------
+// U4 (P2): module.js LOCAL SYNCHRONOUS path pinning. The spec in the plan
+// says the local path asserts:
+//   1. service.startSession(...) fires before service.savePrefs(...).
+//   2. savePrefs only when `transition?.ok !== false`.
+// Both for Alt+4 (Guardian) AND Alt+5 (Boss) dispatch.
+//
+// We drive `spellingModule.handleAction(...)` directly with a spy service
+// so the ordering assertion is decoupled from the full app harness.
+// -----------------------------------------------------------------------------
+
+import { spellingModule } from '../src/subjects/spelling/module.js';
+import { BOSS_DEFAULT_ROUND_LENGTH } from '../src/subjects/spelling/service-contract.js';
+
+function createModuleShortcutSpy({
+  allWordsMega = true,
+  startResult = { ok: true, state: { phase: 'session', session: { id: 's' } } },
+  prefs = { mode: 'smart', yearFilter: 'core', roundLength: '20', extraWordFamilies: false },
+} = {}) {
+  const callLog = [];
+  const service = {
+    initState(state) { return state || { phase: 'dashboard' }; },
+    getPrefs() { return { ...prefs }; },
+    getPostMasteryState() { return { allWordsMega }; },
+    startSession(learnerId, options) {
+      callLog.push({ name: 'startSession', args: { learnerId, options } });
+      return startResult;
+    },
+    savePrefs(learnerId, patch) {
+      callLog.push({ name: 'savePrefs', args: { learnerId, patch } });
+      return { ...prefs, ...patch };
+    },
+  };
+  const context = {
+    appState: {
+      learners: { selectedId: 'learner-a', byId: { 'learner-a': { id: 'learner-a' } } },
+      subjectUi: { spelling: { phase: 'dashboard' } },
+      transientUi: {},
+    },
+    data: {},
+    store: {
+      patch() {},
+      updateSubjectUi() {},
+      getState() { return context.appState; },
+    },
+    service,
+    tts: { speak() {}, stop() {} },
+    applySubjectTransition() { return true; },
+  };
+  return { service, context, callLog };
+}
+
+test('U4 module.js: Alt+4 Guardian — service.startSession fires BEFORE service.savePrefs (local-path ordering pin)', () => {
+  const { context, callLog } = createModuleShortcutSpy({
+    startResult: { ok: true, state: { phase: 'session', session: { id: 'guardian-1' } } },
+  });
+  spellingModule.handleAction('spelling-shortcut-start', { ...context, data: { mode: 'guardian' } });
+
+  const names = callLog.map((entry) => entry.name);
+  // Must start with startSession (savePrefs may or may not follow, but it
+  // must not precede it).
+  assert.equal(names[0], 'startSession',
+    'Guardian local path: service.startSession must be the FIRST service call on Alt+4');
+  const startIdx = names.indexOf('startSession');
+  const saveIdx = names.indexOf('savePrefs');
+  assert.ok(startIdx < saveIdx,
+    `Guardian local path ordering: startSession (${startIdx}) must precede savePrefs (${saveIdx})`);
+});
+
+test('U4 module.js: Alt+4 Guardian — failed startSession (ok:false) does NOT call savePrefs (local-path rollback pin)', () => {
+  const { context, callLog } = createModuleShortcutSpy({
+    startResult: { ok: false, state: { phase: 'dashboard' } },
+  });
+  spellingModule.handleAction('spelling-shortcut-start', { ...context, data: { mode: 'guardian' } });
+
+  const names = callLog.map((entry) => entry.name);
+  assert.ok(names.includes('startSession'),
+    'Guardian local path invoked startSession');
+  assert.equal(names.includes('savePrefs'), false,
+    'Guardian local path: ok:false transition must NOT fire savePrefs — prefs.mode stays on the pre-Alt+4 value');
+});
+
+test('U4 module.js: Alt+5 Boss — service.startSession fires BEFORE service.savePrefs and receives length = BOSS_DEFAULT_ROUND_LENGTH', () => {
+  const { context, callLog } = createModuleShortcutSpy({
+    startResult: { ok: true, state: { phase: 'session', session: { id: 'boss-1' } } },
+  });
+  spellingModule.handleAction('spelling-shortcut-start', {
+    ...context,
+    data: { mode: 'boss', length: BOSS_DEFAULT_ROUND_LENGTH },
+  });
+
+  const startCall = callLog.find((entry) => entry.name === 'startSession');
+  assert.ok(startCall, 'Boss local path invoked service.startSession');
+  assert.equal(startCall.args.options.mode, 'boss');
+  assert.equal(startCall.args.options.length, BOSS_DEFAULT_ROUND_LENGTH,
+    'Alt+5 Boss local path: length = BOSS_DEFAULT_ROUND_LENGTH (10) must survive onto startSession options');
+  const names = callLog.map((entry) => entry.name);
+  const startIdx = names.indexOf('startSession');
+  const saveIdx = names.indexOf('savePrefs');
+  assert.ok(startIdx < saveIdx, `Boss local path ordering: startSession (${startIdx}) must precede savePrefs (${saveIdx})`);
+});
+
+test('U4 module.js: Alt+5 Boss — failed startSession (ok:false) does NOT call savePrefs (local-path rollback pin)', () => {
+  const { context, callLog } = createModuleShortcutSpy({
+    startResult: { ok: false, state: { phase: 'dashboard' } },
+  });
+  spellingModule.handleAction('spelling-shortcut-start', {
+    ...context,
+    data: { mode: 'boss', length: BOSS_DEFAULT_ROUND_LENGTH },
+  });
+  const names = callLog.map((entry) => entry.name);
+  assert.ok(names.includes('startSession'));
+  assert.equal(names.includes('savePrefs'), false,
+    'Boss local path: ok:false transition must NOT fire savePrefs — prefs.mode stays on the pre-Alt+5 value');
+});
+
+test('U4 module.js: Alt+4 Guardian is a no-op when allWordsMega=false — neither startSession nor savePrefs fires', () => {
+  const { context, callLog } = createModuleShortcutSpy({ allWordsMega: false });
+  spellingModule.handleAction('spelling-shortcut-start', { ...context, data: { mode: 'guardian' } });
+  const names = callLog.map((entry) => entry.name);
+  assert.equal(names.includes('startSession'), false,
+    'Guardian gate held — startSession must NOT fire before graduation');
+  assert.equal(names.includes('savePrefs'), false,
+    'Guardian gate held — savePrefs must NOT fire before graduation');
+});
+
+test('U4 module.js: Alt+5 Boss is a no-op when allWordsMega=false — neither startSession nor savePrefs fires', () => {
+  const { context, callLog } = createModuleShortcutSpy({ allWordsMega: false });
+  spellingModule.handleAction('spelling-shortcut-start', {
+    ...context,
+    data: { mode: 'boss', length: BOSS_DEFAULT_ROUND_LENGTH },
+  });
+  const names = callLog.map((entry) => entry.name);
+  assert.equal(names.includes('startSession'), false,
+    'Boss gate held — startSession must NOT fire before graduation');
+  assert.equal(names.includes('savePrefs'), false,
+    'Boss gate held — savePrefs must NOT fire before graduation');
+});

--- a/tests/spelling-remote-sync-hydration.test.js
+++ b/tests/spelling-remote-sync-hydration.test.js
@@ -490,3 +490,262 @@ test('U4 Worker response omits postMastery (old-worker characterisation): client
     assert.equal(spelling.postMastery.postMegaDashboardAvailable, false);
   }
 });
+
+// -----------------------------------------------------------------------------
+// Section 4 — PR #277 reviewer-driven fixes
+// (a) HIGH correctness: Worker postMastery includes todayDay + guardianMap so
+//     the SpellingSetupScene's GraduationStatRibbon doesn't render
+//     "Next check in 20562 days".
+// (b) HIGH adversarial: applyCommandResponse preserves the previous postMastery
+//     snapshot when a subsequent response lacks postMastery (old Worker
+//     rolling deploy, engine throw via the MEDIUM try/catch fix).
+// (c) HIGH adversarial: handlePreferenceSaveError preserves the postMastery
+//     cache so a graduated learner whose Alt+4 start succeeds but whose
+//     save-prefs fails doesn't regress to legacy Smart Review.
+// -----------------------------------------------------------------------------
+
+test('PR #277 Worker postMastery carries todayDay + guardianMap so the Setup scene renders a sensible nextDueDelta', () => {
+  const engine = createServerSpellingEngine({
+    now: () => TODAY_MS,
+    random: () => 0.5,
+    contentSnapshot: contentSnapshot(),
+  });
+
+  // A graduated learner with one guardian entry due tomorrow. The scene's
+  // GraduationStatRibbon computes `nextDueDelta = nextGuardianDueDay - todayDay`;
+  // if todayDay falls back to 0 the delta becomes 20562 (the D1-epoch day
+  // number today) and the "Next check in 20562 days" regression reappears.
+  const firstCoreSlug = CORE_SLUGS[0];
+  const guardianMap = {
+    [firstCoreSlug]: {
+      stage: 'secure',
+      nextDueDay: TODAY_DAY + 1,
+      // Normaliser tolerates extra fields; we only need a shape that survives
+      // normaliseGuardianMap.
+    },
+  };
+  const data = {
+    progress: seedAllCoreMegaProgress(),
+    guardian: guardianMap,
+    postMega: {
+      unlockedAt: TODAY_MS - 7 * DAY_MS,
+      unlockedContentReleaseId: SPELLING_CONTENT_RELEASE_ID,
+      unlockedPublishedCoreCount: ALL_CORE_COUNT,
+      unlockedBy: 'all-core-stage-4',
+    },
+  };
+
+  const response = engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: { ui: null, data },
+    latestSession: null,
+    command: 'save-prefs',
+    payload: { prefs: { mode: 'smart' } },
+  });
+
+  const pm = response.postMastery;
+  assert.ok(pm, 'Worker postMastery block present');
+
+  // (1) `todayDay` must equal the clock's day number — NOT 0, not undefined.
+  // Without this the scene's `nextDueDelta` computation falls back to 0 and
+  // the ribbon displays "Next check in 20562 days".
+  assert.equal(typeof pm.todayDay, 'number', 'postMastery.todayDay is a number');
+  assert.equal(pm.todayDay, TODAY_DAY, 'postMastery.todayDay equals the scene-expected today');
+
+  // (2) `guardianMap` must be a populated object mirroring the persisted
+  // guardian entries (after normalisation). The Word Bank scene depends on
+  // this for Guardian chip filtering; without it the chips render empty.
+  assert.ok(pm.guardianMap && typeof pm.guardianMap === 'object' && !Array.isArray(pm.guardianMap),
+    'postMastery.guardianMap is a plain object');
+
+  // (3) Integration parity with the Setup scene's GraduationStatRibbon:
+  // replicate its `nextDueDelta` derivation and assert it computes sensibly
+  // (NOT 20562 — that was the original bug signature when `todayDay` fell back
+  // to 0). The ribbon renders "in 20562 days" only when
+  // `nextDueDelta = nextGuardianDueDay - 0`, i.e. today is missing.
+  const today = Number.isFinite(Number(pm.todayDay)) ? Math.floor(Number(pm.todayDay)) : 0;
+  const nextDue = Number.isFinite(Number(pm.nextGuardianDueDay)) ? Math.floor(Number(pm.nextGuardianDueDay)) : null;
+  const nextDueDelta = nextDue == null ? null : nextDue - today;
+  if (nextDueDelta !== null) {
+    // The delta must be a small non-negative integer — 0 (today), 1
+    // (tomorrow), or a handful of days. Anything >= 1000 is the regression
+    // we're pinning against; 20562 is the specific signature from the bug.
+    assert.ok(nextDueDelta >= 0 && nextDueDelta < 1000,
+      `nextDueDelta must be a small value, got ${nextDueDelta}`);
+    assert.notEqual(nextDueDelta, 20562,
+      'regression guard — "Next check in 20562 days" must never render');
+  }
+});
+
+test('PR #277 applyCommandResponse preserves postMastery cache when follow-up response lacks postMastery', async () => {
+  // Sequence: (a) hydrate from response A (full postMastery),
+  // (b) issue response B WITHOUT postMastery, (c) assert the cached
+  // response-A snapshot is still present. Simulates the Worker-rolling-deploy
+  // scenario where one in-flight request lands on an old worker instance that
+  // never emitted the field.
+  const { getState, store } = createHydrationHarness();
+  const responses = [];
+  const workerPostMastery = {
+    allWordsMega: true,
+    allWordsMegaNow: true,
+    postMegaUnlockedEver: true,
+    postMegaDashboardAvailable: true,
+    newCoreWordsSinceGraduation: 0,
+    guardianDueCount: 3,
+    wobblingCount: 1,
+    wobblingDueCount: 1,
+    nonWobblingDueCount: 2,
+    unguardedMegaCount: 0,
+    guardianAvailableCount: 5,
+    guardianMissionState: 'wobbling',
+    guardianMissionAvailable: true,
+    nextGuardianDueDay: TODAY_DAY + 1,
+    todayDay: TODAY_DAY,
+    guardianMap: { 'demo-slug': { stage: 'secure', nextDueDay: TODAY_DAY + 1 } },
+    recommendedWords: [],
+    postMasteryDebug: {
+      source: 'worker',
+      publishedCoreCount: ALL_CORE_COUNT,
+      secureCoreCount: ALL_CORE_COUNT,
+      blockingCoreCount: 0,
+      blockingCoreSlugsPreview: [],
+      extraWordsIgnoredCount: 0,
+      guardianMapCount: 1,
+      contentReleaseId: SPELLING_CONTENT_RELEASE_ID,
+      allWordsMega: true,
+      stickyUnlocked: true,
+    },
+  };
+  const handler = createRemoteSpellingActionHandler({
+    store,
+    services: { spelling: { getPrefs() { return getState().subjectUi.spelling.prefs; } } },
+    tts: { speak() {}, stop() {} },
+    readModels: { readJson: async () => ({}) },
+    subjectCommands: {
+      send() {
+        const next = responses.shift();
+        return Promise.resolve(next);
+      },
+    },
+    preferenceSaveDebounceMs: 0,
+  });
+
+  // Response A — full postMastery block. This hydrates the cache.
+  responses.push({
+    subjectReadModel: { phase: 'dashboard' },
+    postMastery: workerPostMastery,
+  });
+  handler.handle('spelling-toggle-pref', { pref: 'autoSpeak' });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await flushPromises();
+  await flushPromises();
+
+  const afterA = getState().subjectUi?.spelling?.postMastery;
+  assert.ok(afterA, 'response A hydrated postMastery cache');
+  assert.equal(afterA.allWordsMega, true, 'cache has graduated-learner snapshot');
+  assert.equal(afterA.guardianMissionState, 'wobbling');
+
+  // Response B — NO postMastery field (rolling-deploy old worker / throw-
+  // handled by MEDIUM try/catch). The cache must be preserved.
+  responses.push({
+    subjectReadModel: { phase: 'dashboard' },
+    // deliberately no postMastery
+  });
+  handler.handle('spelling-toggle-pref', { pref: 'autoSpeak' });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await flushPromises();
+  await flushPromises();
+
+  const afterB = getState().subjectUi?.spelling?.postMastery;
+  assert.ok(afterB, 'postMastery cache preserved across postMastery-less response');
+  assert.equal(afterB.allWordsMega, true, 'cache still reflects graduated-learner snapshot');
+  assert.equal(afterB.postMegaDashboardAvailable, true,
+    'dashboard availability survives old-worker compat window');
+  assert.equal(afterB.guardianMissionState, 'wobbling',
+    'response A values remain after a postMastery-less response');
+});
+
+test('PR #277 handlePreferenceSaveError preserves postMastery cache so a graduated learner does not regress to legacy dashboard', async () => {
+  // Scenario: Alt+4 Guardian shortcut fires. start-session succeeds and the
+  // response hydrates postMastery with graduated values. The subsequent
+  // save-prefs throws (e.g. flaky sync). Before this fix
+  // handlePreferenceSaveError wiped the cache via reloadFromRepositories and
+  // the dashboard regressed to locked-fallback, dropping the learner back
+  // onto Smart Review. After the fix the cache is preserved across the
+  // error path.
+  const workerPostMastery = {
+    allWordsMega: true,
+    allWordsMegaNow: true,
+    postMegaUnlockedEver: true,
+    postMegaDashboardAvailable: true,
+    newCoreWordsSinceGraduation: 0,
+    guardianDueCount: 2,
+    wobblingCount: 0,
+    wobblingDueCount: 0,
+    nonWobblingDueCount: 2,
+    unguardedMegaCount: 0,
+    guardianAvailableCount: 2,
+    guardianMissionState: 'due',
+    guardianMissionAvailable: true,
+    nextGuardianDueDay: TODAY_DAY,
+    todayDay: TODAY_DAY,
+    guardianMap: {},
+    recommendedWords: [],
+    postMasteryDebug: {
+      source: 'worker',
+      publishedCoreCount: ALL_CORE_COUNT,
+      secureCoreCount: ALL_CORE_COUNT,
+      blockingCoreCount: 0,
+      blockingCoreSlugsPreview: [],
+      extraWordsIgnoredCount: 0,
+      guardianMapCount: 0,
+      contentReleaseId: SPELLING_CONTENT_RELEASE_ID,
+      allWordsMega: true,
+      stickyUnlocked: true,
+    },
+  };
+  // Start from a state that already has the graduated postMastery cached so
+  // we can isolate the save-prefs-error path without depending on start-
+  // session completing first.
+  const { getState, store } = createHydrationHarness({
+    phase: 'dashboard',
+    prefs: { mode: 'guardian', yearFilter: 'core', roundLength: '20', extraWordFamilies: false },
+    analytics: null,
+    error: '',
+    postMastery: workerPostMastery,
+  });
+
+  const handler = createRemoteSpellingActionHandler({
+    store,
+    services: { spelling: { getPrefs() { return getState().subjectUi.spelling.prefs; } } },
+    tts: { speak() {}, stop() {} },
+    readModels: { readJson: async () => ({}) },
+    subjectCommands: {
+      send(request) {
+        if (request.command === 'save-prefs') {
+          return Promise.reject(new Error('Sync temporarily unavailable.'));
+        }
+        return Promise.resolve({ subjectReadModel: { phase: 'dashboard' }, postMastery: workerPostMastery });
+      },
+    },
+    preferenceSaveDebounceMs: 0,
+  });
+
+  // Trigger a preference-save action — the debounced save-prefs call will
+  // reject and route through handlePreferenceSaveError.
+  handler.handle('spelling-toggle-pref', { pref: 'autoSpeak' });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await flushPromises();
+  await flushPromises();
+  await flushPromises();
+
+  // Cache must survive the failed save-prefs: the learner is still graduated.
+  const afterError = getState().subjectUi?.spelling?.postMastery;
+  assert.ok(afterError, 'postMastery cache preserved across save-prefs failure');
+  assert.equal(afterError.allWordsMega, true,
+    'graduated learner does not regress to legacy Smart Review dashboard');
+  assert.equal(afterError.postMegaDashboardAvailable, true,
+    'dashboard remains available after preference-save error');
+  assert.equal(afterError.guardianMissionState, 'due',
+    'cached mission state from before the error is still in place');
+});

--- a/tests/spelling-remote-sync-hydration.test.js
+++ b/tests/spelling-remote-sync-hydration.test.js
@@ -1,0 +1,492 @@
+// Tests for U4 — Remote-sync post-mastery hydration + Alt+4 regression.
+//
+// Plan: docs/plans/2026-04-26-006-feat-post-mega-spelling-p2-visibility-pattern-foundation-plan.md (U4)
+//
+// Contracts under test:
+//   1. `createServerSpellingEngine.apply(...)` includes a `postMastery` block
+//      on every command response. The block carries the canonical fields
+//      (`allWordsMega`, `allWordsMegaNow`, `postMegaDashboardAvailable`,
+//      `postMegaUnlockedEver`, `newCoreWordsSinceGraduation`, the full
+//      guardian aggregates, plus `postMasteryDebug.source === 'worker'`).
+//      Pre-graduation learners see the locked-shaped block.
+//   2. Client `applyCommandResponse` merges `response.postMastery` into
+//      `subjectUi.spelling.postMastery`; a subsequent
+//      `services.spelling.getPostMasteryState(learnerId)` reads the Worker
+//      values verbatim.
+//   3. When a Worker response omits `postMastery` (characterisation: old
+//      Worker version), the client falls back to the existing client-read-
+//      models locked-fallback without crashing.
+//   4. Graduated learner on a FRESH device (no local `data.postMega`, no
+//      client cache): the client starts at the locked-fallback and the
+//      first Worker response hydrates `postMegaDashboardAvailable: true`.
+//   5. Graduated learner WITH local sticky-bit: the client read-model
+//      already returns `postMegaDashboardAvailable: true` from the cached
+//      postMastery entry in `subjectUi.spelling.postMastery` — no "Checking
+//      Word Vault…" flicker.
+//
+// Executed test-first per the plan's execution note — the first two
+// Worker-response assertions below fail against the current engine until
+// the `postMastery` emission lands.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createServerSpellingEngine } from '../worker/src/subjects/spelling/engine.js';
+import { resolveRuntimeSnapshot } from '../src/subjects/spelling/content/model.js';
+import { SEEDED_SPELLING_CONTENT_BUNDLE } from '../src/subjects/spelling/data/content-data.js';
+import { WORDS } from '../src/subjects/spelling/data/word-data.js';
+import { SPELLING_CONTENT_RELEASE_ID } from '../src/subjects/spelling/service-contract.js';
+import { createSpellingReadModelService } from '../src/subjects/spelling/client-read-models.js';
+import { createRemoteSpellingActionHandler } from '../src/subjects/spelling/remote-actions.js';
+import { installMemoryStorage } from './helpers/memory-storage.js';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const TODAY_MS = Date.UTC(2026, 0, 10);
+const TODAY_DAY = Math.floor(TODAY_MS / DAY_MS);
+const CORE_WORDS = WORDS.filter((word) => word.spellingPool !== 'extra');
+const CORE_SLUGS = CORE_WORDS.map((word) => word.slug);
+const ALL_CORE_COUNT = CORE_SLUGS.length;
+
+function contentSnapshot() {
+  return resolveRuntimeSnapshot(SEEDED_SPELLING_CONTENT_BUNDLE, {
+    referenceBundle: SEEDED_SPELLING_CONTENT_BUNDLE,
+  });
+}
+
+function seedAllCoreMegaProgress() {
+  const progress = {};
+  for (const slug of CORE_SLUGS) {
+    progress[slug] = {
+      stage: 4,
+      attempts: 6,
+      correct: 5,
+      wrong: 1,
+      dueDay: TODAY_DAY + 60,
+      lastDay: TODAY_DAY - 7,
+      lastResult: 'correct',
+    };
+  }
+  return progress;
+}
+
+// -----------------------------------------------------------------------------
+// Section 1 — Worker `apply()` emits `postMastery` (F3 / AE1 on the plan).
+// -----------------------------------------------------------------------------
+
+test('U4 Worker apply() emits postMastery block for a pre-graduation learner', () => {
+  const engine = createServerSpellingEngine({
+    now: () => TODAY_MS,
+    random: () => 0.5,
+    contentSnapshot: contentSnapshot(),
+  });
+
+  const response = engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: { ui: null, data: {} },
+    latestSession: null,
+    command: 'save-prefs',
+    payload: { prefs: { mode: 'smart' } },
+  });
+
+  assert.ok(response.postMastery, 'response carries a postMastery block');
+  const pm = response.postMastery;
+  assert.equal(typeof pm, 'object');
+  assert.equal(pm.allWordsMega, false, 'fresh learner has no Mega progress');
+  assert.equal(pm.allWordsMegaNow, false);
+  assert.equal(pm.postMegaUnlockedEver, false);
+  assert.equal(pm.postMegaDashboardAvailable, false);
+  assert.equal(pm.newCoreWordsSinceGraduation, 0);
+  assert.equal(typeof pm.guardianDueCount, 'number');
+  assert.equal(typeof pm.guardianMissionState, 'string');
+  assert.ok(pm.postMasteryDebug, 'carries admin debug panel data');
+  assert.equal(pm.postMasteryDebug.source, 'worker',
+    'worker-emitted postMastery marks source=worker so admin hub can distinguish it from the client-only locked-fallback');
+  assert.equal(pm.postMasteryDebug.stickyUnlocked, false);
+});
+
+test('U4 Worker apply() emits postMastery with allWordsMega=true for an all-core-Mega learner', () => {
+  const engine = createServerSpellingEngine({
+    now: () => TODAY_MS,
+    random: () => 0.5,
+    contentSnapshot: contentSnapshot(),
+  });
+
+  const data = {
+    progress: seedAllCoreMegaProgress(),
+    guardian: {},
+    postMega: {
+      unlockedAt: TODAY_MS - 7 * DAY_MS,
+      unlockedContentReleaseId: SPELLING_CONTENT_RELEASE_ID,
+      unlockedPublishedCoreCount: ALL_CORE_COUNT,
+      unlockedBy: 'all-core-stage-4',
+    },
+  };
+
+  const response = engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: { ui: null, data },
+    latestSession: null,
+    command: 'save-prefs',
+    payload: { prefs: { mode: 'smart' } },
+  });
+
+  assert.ok(response.postMastery, 'response carries a postMastery block');
+  const pm = response.postMastery;
+  assert.equal(pm.allWordsMega, true);
+  assert.equal(pm.allWordsMegaNow, true);
+  assert.equal(pm.postMegaUnlockedEver, true);
+  assert.equal(pm.postMegaDashboardAvailable, true);
+  assert.equal(pm.postMasteryDebug.source, 'worker');
+  assert.equal(pm.postMasteryDebug.stickyUnlocked, true);
+  assert.equal(pm.postMasteryDebug.allWordsMega, true);
+});
+
+test('U4 Worker apply() emits postMastery on start-session, submit-answer, and continue-session', () => {
+  const engine = createServerSpellingEngine({
+    now: () => TODAY_MS,
+    random: () => 0.5,
+    contentSnapshot: contentSnapshot(),
+  });
+
+  const started = engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: { ui: null, data: {} },
+    latestSession: null,
+    command: 'start-session',
+    payload: { mode: 'smart', length: 1, yearFilter: 'core' },
+  });
+  assert.ok(started.postMastery, 'start-session response carries postMastery');
+  assert.equal(started.postMastery.postMasteryDebug.source, 'worker');
+
+  // submit-answer — pick the slug the engine scheduled, do not guess.
+  const slug = started.state.session.currentCard.slug;
+  const word = CORE_WORDS.find((w) => w.slug === slug);
+  const submitted = engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: { ui: started.state, data: started.data },
+    latestSession: started.practiceSession,
+    command: 'submit-answer',
+    payload: { typed: word ? word.word : 'unknown' },
+  });
+  assert.ok(submitted.postMastery, 'submit-answer response carries postMastery');
+  assert.equal(submitted.postMastery.postMasteryDebug.source, 'worker');
+});
+
+// -----------------------------------------------------------------------------
+// Section 2 — Client `applyCommandResponse` hydrates
+// `subjectUi.spelling.postMastery` (F3 / Happy-path #2 on the plan).
+// -----------------------------------------------------------------------------
+
+function createHydrationHarness(initialSpellingUi = null) {
+  let state = {
+    learners: { selectedId: 'learner-a' },
+    subjectUi: {
+      spelling: initialSpellingUi || {
+        phase: 'dashboard',
+        prefs: { mode: 'smart', yearFilter: 'core', roundLength: '20', extraWordFamilies: false },
+        analytics: null,
+        error: '',
+      },
+    },
+    monsterCelebrations: { pending: [], queue: [] },
+    transientUi: {},
+  };
+  const updateCalls = [];
+  const store = {
+    getState() { return state; },
+    updateSubjectUi(subjectId, updater) {
+      const previous = state.subjectUi?.[subjectId] || {};
+      const next = typeof updater === 'function'
+        ? updater(previous)
+        : { ...previous, ...(updater || {}) };
+      state = {
+        ...state,
+        subjectUi: { ...state.subjectUi, [subjectId]: next },
+      };
+      updateCalls.push(['updateSubjectUi', subjectId, next]);
+    },
+    patch(updater) {
+      const patch = typeof updater === 'function' ? updater(state) : updater;
+      state = { ...state, ...(patch || {}) };
+    },
+    pushToasts() {},
+    pushMonsterCelebrations() {},
+    deferMonsterCelebrations() { return true; },
+    releaseMonsterCelebrations() { return true; },
+    dismissMonsterCelebration() { return true; },
+    reloadFromRepositories() { /* no-op for these tests */ },
+    repositories: { eventLog: { list() { return []; } } },
+  };
+  return { getState: () => state, store, updateCalls };
+}
+
+function flushPromises() {
+  return Promise.resolve().then(() => Promise.resolve());
+}
+
+test('U4 client applyCommandResponse merges response.postMastery into subjectUi.spelling.postMastery', async () => {
+  const { getState, store } = createHydrationHarness();
+  const sent = [];
+  const workerPostMastery = {
+    allWordsMega: true,
+    allWordsMegaNow: true,
+    postMegaUnlockedEver: true,
+    postMegaDashboardAvailable: true,
+    newCoreWordsSinceGraduation: 0,
+    guardianDueCount: 3,
+    wobblingCount: 1,
+    wobblingDueCount: 1,
+    nonWobblingDueCount: 2,
+    unguardedMegaCount: 0,
+    guardianAvailableCount: 5,
+    guardianMissionState: 'wobbling',
+    guardianMissionAvailable: true,
+    nextGuardianDueDay: TODAY_DAY + 1,
+    todayDay: TODAY_DAY,
+    guardianMap: {},
+    recommendedWords: [],
+    postMasteryDebug: {
+      source: 'worker',
+      publishedCoreCount: ALL_CORE_COUNT,
+      secureCoreCount: ALL_CORE_COUNT,
+      blockingCoreCount: 0,
+      blockingCoreSlugsPreview: [],
+      extraWordsIgnoredCount: 0,
+      guardianMapCount: 0,
+      contentReleaseId: SPELLING_CONTENT_RELEASE_ID,
+      allWordsMega: true,
+      stickyUnlocked: true,
+    },
+  };
+  const handler = createRemoteSpellingActionHandler({
+    store,
+    services: { spelling: { getPrefs() { return getState().subjectUi.spelling.prefs; } } },
+    tts: { speak() {}, stop() {} },
+    readModels: { readJson: async () => ({}) },
+    subjectCommands: {
+      send(request) {
+        sent.push(request);
+        return Promise.resolve({
+          subjectReadModel: { phase: 'dashboard' },
+          postMastery: workerPostMastery,
+        });
+      },
+    },
+    preferenceSaveDebounceMs: 0,
+  });
+
+  handler.handle('spelling-toggle-pref', { pref: 'autoSpeak' });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await flushPromises();
+  await flushPromises();
+
+  // Hydration landed on `subjectUi.spelling.postMastery`.
+  const hydrated = getState().subjectUi?.spelling?.postMastery;
+  assert.ok(hydrated, 'subjectUi.spelling.postMastery hydrated from response');
+  assert.equal(hydrated.allWordsMega, true);
+  assert.equal(hydrated.postMegaDashboardAvailable, true);
+  assert.equal(hydrated.guardianMissionState, 'wobbling');
+  assert.equal(hydrated.postMasteryDebug.source, 'worker');
+  assert.equal(hydrated.postMasteryDebug.stickyUnlocked, true);
+});
+
+test('U4 client-read-models getPostMasteryState prefers hydrated postMastery over locked fallback', () => {
+  const workerPostMastery = {
+    allWordsMega: true,
+    allWordsMegaNow: true,
+    postMegaUnlockedEver: true,
+    postMegaDashboardAvailable: true,
+    newCoreWordsSinceGraduation: 0,
+    guardianDueCount: 2,
+    wobblingCount: 0,
+    wobblingDueCount: 0,
+    nonWobblingDueCount: 2,
+    unguardedMegaCount: 0,
+    guardianAvailableCount: 2,
+    guardianMissionState: 'due',
+    guardianMissionAvailable: true,
+    nextGuardianDueDay: TODAY_DAY,
+    todayDay: TODAY_DAY,
+    guardianMap: {},
+    recommendedWords: [],
+    postMasteryDebug: {
+      source: 'worker',
+      publishedCoreCount: ALL_CORE_COUNT,
+      secureCoreCount: ALL_CORE_COUNT,
+      blockingCoreCount: 0,
+      blockingCoreSlugsPreview: [],
+      extraWordsIgnoredCount: 0,
+      guardianMapCount: 0,
+      contentReleaseId: SPELLING_CONTENT_RELEASE_ID,
+      allWordsMega: true,
+      stickyUnlocked: true,
+    },
+  };
+  const appState = {
+    learners: { selectedId: 'learner-a' },
+    subjectUi: {
+      spelling: {
+        subjectId: 'spelling',
+        version: 1,
+        learnerId: 'learner-a',
+        phase: 'dashboard',
+        postMastery: workerPostMastery,
+      },
+    },
+  };
+
+  const service = createSpellingReadModelService({ getState: () => appState });
+  const postMastery = service.getPostMasteryState('learner-a');
+  assert.equal(postMastery.allWordsMega, true,
+    'cached worker-hydrated postMastery wins over the locked fallback');
+  assert.equal(postMastery.postMegaDashboardAvailable, true);
+  assert.equal(postMastery.postMasteryDebug.source, 'worker');
+});
+
+// -----------------------------------------------------------------------------
+// Section 3 — "Checking Word Vault..." transient source label (Edge case
+// "hydration race for FRESH learner" on the plan).
+// -----------------------------------------------------------------------------
+
+test('U4 client-read-models falls back to locked-fallback source when hydrationWindowMs is zero', () => {
+  // Historical characterisation: when the hydration window is disabled
+  // (hydrationWindowMs: 0) the no-cache path goes straight to
+  // `locked-fallback` — preserving the pre-U4 label that the Admin hub
+  // depends on to distinguish a client-only stub from a worker snapshot.
+  const appState = {
+    learners: { selectedId: 'learner-a' },
+    subjectUi: { spelling: { phase: 'dashboard' } },
+  };
+  const service = createSpellingReadModelService({
+    getState: () => appState,
+    hydrationWindowMs: 0,
+  });
+  const postMastery = service.getPostMasteryState('learner-a');
+  assert.equal(postMastery.postMasteryDebug.source, 'locked-fallback',
+    'no-cache path stays on locked-fallback per existing contract');
+  assert.equal(postMastery.postMegaDashboardAvailable, false);
+});
+
+test('U4 client-read-models stamps source=checking during the hydration window (≤500ms)', () => {
+  const appState = {
+    learners: { selectedId: 'learner-a' },
+    subjectUi: { spelling: { phase: 'dashboard' } },
+  };
+  let nowValue = 1_000;
+  const service = createSpellingReadModelService({
+    getState: () => appState,
+    now: () => nowValue,
+    hydrationWindowMs: 500,
+  });
+
+  // First read registers the hydration window start and returns
+  // source='checking' — the setup scene renders the placeholder skeleton.
+  const first = service.getPostMasteryState('learner-a');
+  assert.equal(first.postMasteryDebug.source, 'checking',
+    'first read inside the hydration window stamps source=checking');
+  assert.equal(first.postMegaDashboardAvailable, false,
+    'checking label does not unlock the dashboard');
+
+  // Advance mid-window — still 'checking'.
+  nowValue = 1_000 + 250;
+  const mid = service.getPostMasteryState('learner-a');
+  assert.equal(mid.postMasteryDebug.source, 'checking');
+
+  // Advance past the window — source now falls through to 'locked-fallback'.
+  nowValue = 1_000 + 501;
+  const past = service.getPostMasteryState('learner-a');
+  assert.equal(past.postMasteryDebug.source, 'locked-fallback',
+    'after the hydration window elapses, source flips to locked-fallback');
+});
+
+test('U4 client-read-models: hydrated postMastery cache wins even during the checking window (H6)', () => {
+  // The H6 sticky-bit short-circuit in the plan says a graduated learner
+  // who already has `data.postMega` persisted must never see the
+  // "Checking Word Vault..." placeholder. We verify at the read-model
+  // layer: if the cache is populated, `source=checking` is never returned.
+  const workerPostMastery = {
+    allWordsMega: true,
+    allWordsMegaNow: true,
+    postMegaUnlockedEver: true,
+    postMegaDashboardAvailable: true,
+    newCoreWordsSinceGraduation: 0,
+    guardianDueCount: 0,
+    wobblingCount: 0,
+    wobblingDueCount: 0,
+    nonWobblingDueCount: 0,
+    unguardedMegaCount: 0,
+    guardianAvailableCount: 0,
+    guardianMissionState: 'rested',
+    guardianMissionAvailable: false,
+    nextGuardianDueDay: null,
+    todayDay: TODAY_DAY,
+    guardianMap: {},
+    recommendedWords: [],
+    postMasteryDebug: {
+      source: 'worker',
+      publishedCoreCount: ALL_CORE_COUNT,
+      secureCoreCount: ALL_CORE_COUNT,
+      blockingCoreCount: 0,
+      blockingCoreSlugsPreview: [],
+      extraWordsIgnoredCount: 0,
+      guardianMapCount: 0,
+      contentReleaseId: SPELLING_CONTENT_RELEASE_ID,
+      allWordsMega: true,
+      stickyUnlocked: true,
+    },
+  };
+  const appState = {
+    learners: { selectedId: 'learner-a' },
+    subjectUi: {
+      spelling: {
+        subjectId: 'spelling',
+        version: 1,
+        learnerId: 'learner-a',
+        phase: 'dashboard',
+        postMastery: workerPostMastery,
+      },
+    },
+  };
+  const service = createSpellingReadModelService({
+    getState: () => appState,
+    now: () => 1_000,
+    hydrationWindowMs: 500,
+  });
+  const pm = service.getPostMasteryState('learner-a');
+  assert.equal(pm.postMasteryDebug.source, 'worker',
+    'sticky-bit short-circuit: cached postMastery wins over checking-window stub');
+  assert.equal(pm.postMegaDashboardAvailable, true);
+});
+
+test('U4 Worker response omits postMastery (old-worker characterisation): client keeps locked-fallback', async () => {
+  const { getState, store } = createHydrationHarness();
+  const handler = createRemoteSpellingActionHandler({
+    store,
+    services: { spelling: { getPrefs() { return getState().subjectUi.spelling.prefs; } } },
+    tts: { speak() {}, stop() {} },
+    readModels: { readJson: async () => ({}) },
+    subjectCommands: {
+      // Characterisation: an older worker version emits NO postMastery
+      // field. The client must tolerate the missing field and not crash.
+      send() {
+        return Promise.resolve({ subjectReadModel: { phase: 'dashboard' } });
+      },
+    },
+    preferenceSaveDebounceMs: 0,
+  });
+
+  handler.handle('spelling-toggle-pref', { pref: 'autoSpeak' });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await flushPromises();
+  await flushPromises();
+
+  // When postMastery is absent the client must NOT wipe any previous cache;
+  // if there was none, the fallback is a locked-state read via the client
+  // read-model service — not a thrown error.
+  const spelling = getState().subjectUi?.spelling || {};
+  // If postMastery is set at all it must be falsy-locked shape, not a
+  // truthy-available one.
+  if (spelling.postMastery) {
+    assert.equal(spelling.postMastery.postMegaDashboardAvailable, false);
+  }
+});

--- a/worker/src/subjects/spelling/commands.js
+++ b/worker/src/subjects/spelling/commands.js
@@ -196,6 +196,11 @@ export function createSpellingCommandHandlers({ now, random } = {}) {
         audio: replayAudioCue,
         content: contentMeta(contentResult, snapshot),
       }),
+      // P2 U4: additive — client `applyCommandResponse` merges this into
+      // `subjectUi.spelling.postMastery`, keeping the Setup scene post-Mega
+      // gate in lockstep with the worker. Old clients that never read this
+      // field continue to work.
+      postMastery: result.postMastery,
       projections,
       events: projectedEvents.events,
       domainEvents: projectedEvents.domainEvents,

--- a/worker/src/subjects/spelling/engine.js
+++ b/worker/src/subjects/spelling/engine.js
@@ -7,6 +7,7 @@ import {
   normaliseGuardianMap,
   normalisePostMegaRecord,
 } from '../../../../src/subjects/spelling/service-contract.js';
+import { getSpellingPostMasteryState } from '../../../../src/subjects/spelling/read-model.js';
 import { createSpellingService } from '../../../../shared/spelling/service.js';
 import { BadRequestError } from '../../errors.js';
 
@@ -364,11 +365,26 @@ export function createServerSpellingEngine({
       }
 
       const nextState = markServerOwnedState(transition.state);
+      // P2 U4: emit a canonical `postMastery` block on every command
+      // response so the client can hydrate `subjectUi.spelling.postMastery`
+      // without a second round-trip. Additive by design — old clients that
+      // never read the field continue to work. Fed by `getSpellingPostMasteryState`
+      // from the read-model (same derivation as every other post-mastery
+      // consumer) so Worker and client cannot drift. `sourceHint: 'worker'`
+      // flows into `postMasteryDebug.source` so the Admin hub can tell a
+      // worker-hydrated snapshot apart from a client-only locked-fallback.
+      const finalSnapshot = persistence.snapshot();
+      const postMastery = getSpellingPostMasteryState({
+        subjectStateRecord: { data: finalSnapshot },
+        runtimeSnapshot: contentSnapshot,
+        now: clock,
+        sourceHint: 'worker',
+      });
       return {
         ok: transition.ok !== false,
         changed: transition.changed !== false,
         state: nextState,
-        data: persistence.snapshot(),
+        data: finalSnapshot,
         practiceSession: persistence.practiceSession(),
         events: transition.events || [],
         audio: transition.audio || null,
@@ -381,6 +397,7 @@ export function createServerSpellingEngine({
           extra: service.getStats(learnerId, 'extra'),
         },
         analytics: service.getAnalyticsSnapshot(learnerId),
+        postMastery,
       };
     },
   };

--- a/worker/src/subjects/spelling/engine.js
+++ b/worker/src/subjects/spelling/engine.js
@@ -373,13 +373,29 @@ export function createServerSpellingEngine({
       // consumer) so Worker and client cannot drift. `sourceHint: 'worker'`
       // flows into `postMasteryDebug.source` so the Admin hub can tell a
       // worker-hydrated snapshot apart from a client-only locked-fallback.
+      //
+      // PR #277 MEDIUM (reliability) fix — wrap the derivation in a
+      // try/catch. If the selector throws (unexpected persisted shape,
+      // runtime snapshot corruption, content-bundle drift), fall back to
+      // `postMastery: undefined` so the response still ships and the
+      // client degrades to its own locked-fallback (or the previous
+      // cache via the HIGH adversarial fix in remote-actions.js) instead
+      // of hard-failing every spelling command until the derivation is
+      // patched. Logged via console.warn so the Admin hub + server logs
+      // surface the underlying error.
       const finalSnapshot = persistence.snapshot();
-      const postMastery = getSpellingPostMasteryState({
-        subjectStateRecord: { data: finalSnapshot },
-        runtimeSnapshot: contentSnapshot,
-        now: clock,
-        sourceHint: 'worker',
-      });
+      let postMastery;
+      try {
+        postMastery = getSpellingPostMasteryState({
+          subjectStateRecord: { data: finalSnapshot },
+          runtimeSnapshot: contentSnapshot,
+          now: clock,
+          sourceHint: 'worker',
+        });
+      } catch (error) {
+        globalThis.console?.warn?.('[spelling.apply] postMastery derivation failed, omitting from response', error);
+        postMastery = undefined;
+      }
       return {
         ok: transition.ok !== false,
         changed: transition.changed !== false,


### PR DESCRIPTION
## Summary
- **Worker emits additive `postMastery` on every `apply()` response** — fed by `getSpellingPostMasteryState(..., { sourceHint: 'worker' })` so the Admin hub's `postMasteryDebug.source` distinguishes a worker snapshot from the client-only locked-fallback. Propagated through `worker/src/subjects/spelling/commands.js` into the command response envelope.
- **Client `applyCommandResponse` merges `response.postMastery` into `subjectUi.spelling.postMastery`** — Setup scene, summary scene, and Alt+4/Alt+5 gate all read authoritative state without a second round-trip. Additive contract (old workers that omit the field leave the cache in place).
- **Fresh-device "Checking Word Vault…" skeleton** — new `postMasteryDebug.source: 'checking'` transient value returned by `createSpellingReadModelService` during a 500ms hydration window, falling through to the legacy `'locked-fallback'` after timeout. `SpellingSetupScene` renders a minimalist skeleton post-Mega card (not a spinner) for that window so a graduated learner opening the app on a new device does not see the legacy Smart Review setup flicker. Graduated learners with a local sticky-bit short-circuit the hydration race entirely (H6 invariant).
- **Alt+4 + Alt+5 ordering / rollback regression pins for BOTH dispatchers** — remote-sync async path asserts `sendCommand('start-session')` fires before `sendCommand('save-prefs')` with optimistic prefs rolled back on failure; module.js local-path asserts `service.startSession(...)` fires before `service.savePrefs(...)` and that `transition?.ok !== false` gates save. All four permutations (Alt+4/Alt+5 x local/remote-sync) land as explicit pin tests.

## Test plan
- [x] `npm test -- tests/spelling-remote-sync-hydration.test.js` — 9 new hydration contract tests.
- [x] `npm test -- tests/spelling-remote-actions.test.js` — 38 tests (includes 10 new U4 Alt+4/Alt+5 regression pins).
- [x] `npm test -- tests/spelling-parity.test.js tests/server-spelling-engine-parity.test.js` — unchanged, 70 tests green.
- [x] `npm test -- tests/spelling-post-mastery-debug.test.js` — U1 locked-fallback test explicitly opts out of the hydration window (`hydrationWindowMs: 0`) so the existing Admin hub contract stays pinned.
- [x] Full spelling suite: 341 tests pass across spelling.test.js, spelling-guardian.test.js, spelling-boss.test.js, spelling-sticky-graduation.test.js, spelling-post-mastery-debug.test.js, spelling-mega-invariant.test.js, react-spelling-surface.test.js, spelling-shared-mode-predicate.test.js.

## Plan
`docs/plans/2026-04-26-006-feat-post-mega-spelling-p2-visibility-pattern-foundation-plan.md` §U4 (lines 617-667).