### PR TITLE
feat(spelling): U9 durable persistence warning (P2)

### DIFF
--- a/shared/spelling/service.js
+++ b/shared/spelling/service.js
@@ -34,6 +34,7 @@ import {
   defaultLearningStatus,
   isGuardianEligibleSlug,
   normaliseBoolean,
+  normaliseDurablePersistenceWarning,
   normaliseFeedback,
   normaliseGuardianMap,
   normaliseGuardianRecord,
@@ -283,6 +284,11 @@ const PROGRESS_KEY_PREFIX = 'ks2-spell-progress-';
 // suffix convention as the other three siblings so `parseStorageKey` in the
 // repository can route the write through the subject-state bundle.
 const POST_MEGA_KEY_PREFIX = 'ks2-spell-post-mega-';
+// P2 U9: durable persistence-warning sibling key. Must stay byte-identical
+// with PERSISTENCE_WARNING_STORAGE_PREFIX in src/subjects/spelling/repository.js
+// and worker/src/subjects/spelling/engine.js — all three route reads/writes
+// under this key through the `data.persistenceWarning` sibling of the bundle.
+const PERSISTENCE_WARNING_KEY_PREFIX = 'ks2-spell-persistence-warning-';
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 function createNoopStorage() {
@@ -312,6 +318,13 @@ function progressMapKey(learnerId) {
 // `data.postMega` sibling of the subject-state bundle.
 function postMegaKey(learnerId) {
   return `${POST_MEGA_KEY_PREFIX}${learnerId || 'default'}`;
+}
+
+// P2 U9: storage key for the durable persistence-warning record. The client
+// and Worker storage proxies route reads/writes under this prefix through the
+// `data.persistenceWarning` sibling of the subject-state bundle.
+function persistenceWarningKey(learnerId) {
+  return `${PERSISTENCE_WARNING_KEY_PREFIX}${learnerId || 'default'}`;
 }
 
 function intervalForLevel(level) {
@@ -1100,6 +1113,85 @@ export function createSpellingService({ repository, storage, tts, now, random, c
     const normalised = normalisePostMegaRecord(record);
     if (!normalised) return { ok: true };
     return saveJson(resolvedStorage, postMegaKey(learnerId), normalised);
+  }
+
+  // P2 U9: load/save helpers for the durable `data.persistenceWarning` sibling.
+  // Uses the same `saveJson` contract as the other siblings so bare-storage
+  // hosts (no platform repositories) behave identically to a production host
+  // that wires `createSpellingPersistence`. Unlike `savePostMegaToStorage`,
+  // this helper is explicitly non-sticky — a second failure overwrites the
+  // previous `reason` + `occurredAt` and resets `acknowledged: false`.
+  function loadPersistenceWarningFromStorage(learnerId) {
+    const raw = loadJson(resolvedStorage, persistenceWarningKey(learnerId), null);
+    return normaliseDurablePersistenceWarning(raw);
+  }
+
+  function savePersistenceWarningToStorage(learnerId, record) {
+    const normalised = normaliseDurablePersistenceWarning(record);
+    if (!normalised) return { ok: true };
+    return saveJson(resolvedStorage, persistenceWarningKey(learnerId), normalised);
+  }
+
+  // P2 U9: durable-warning writer. Called from the submit paths whenever
+  // `feedback.persistenceWarning` surfaces on a round. The write itself is
+  // bounded-retry: if the FIRST attempt to persist the warning fails (because
+  // the underlying storage is the very thing that is broken), we make ONE
+  // retry attempt; if that also fails, we fall back to a `console.warn` so
+  // the app never crashes. This matches the P2 U9 plan requirement:
+  // "bounded retry ... never crash the app."
+  //
+  // The record shape is `{ reason, occurredAt: currentTodayDay(),
+  // acknowledged: false }`. A subsequent new failure overwrites `reason` +
+  // `occurredAt` and resets `acknowledged` to false (the plan invariant).
+  function writePersistenceWarning(learnerId, reason) {
+    const record = {
+      reason,
+      occurredAt: currentTodayDay(),
+      acknowledged: false,
+    };
+    const firstAttempt = savePersistenceWarningToStorage(learnerId, record);
+    if (firstAttempt.ok === true) return firstAttempt;
+    // Bounded retry once. If the first failure was transient (e.g. a race
+    // inside the persistence channel), a retry may succeed. If the retry
+    // also fails, swallow into console.warn so the host does not crash.
+    const retry = savePersistenceWarningToStorage(learnerId, record);
+    if (retry.ok === true) return retry;
+    try {
+      globalThis.console?.warn?.('Spelling persistence-warning write failed after retry.', {
+        learnerId,
+        reason,
+        firstError: firstAttempt?.error?.message,
+        retryError: retry?.error?.message,
+      });
+    } catch {
+      // A thrown console.warn (very unusual — some sandboxes wrap console)
+      // is not actionable for the learner; absorb silently so the submit
+      // path does not crash on a diagnostic side-effect.
+    }
+    return retry;
+  }
+
+  // P2 U9: acknowledge dispatcher. Sets `acknowledged: true` while
+  // preserving `reason` + `occurredAt` for audit. If no warning is
+  // currently persisted this is a silent no-op (no banner to dismiss).
+  // A subsequent new failure resets `acknowledged: false` via
+  // `writePersistenceWarning`.
+  function acknowledgePersistenceWarning(learnerId) {
+    const current = loadPersistenceWarningFromStorage(learnerId);
+    if (!current) return { ok: true };
+    const acknowledgedRecord = {
+      reason: current.reason,
+      occurredAt: current.occurredAt,
+      acknowledged: true,
+    };
+    return savePersistenceWarningToStorage(learnerId, acknowledgedRecord);
+  }
+
+  // P2 U9: read-side helper for the UI. Returns the normalised record or
+  // null. Consumed by `buildSpellingContext` so setup + session scenes can
+  // branch on a single helper rather than re-running `loadJson` themselves.
+  function getPersistenceWarning(learnerId) {
+    return loadPersistenceWarningFromStorage(learnerId);
   }
 
   // U8: returns `{ ok, reason? }` so submit paths can raise a
@@ -1961,6 +2053,14 @@ export function createSpellingService({ repository, storage, tts, now, random, c
     const persistenceWarning = (!progressSave?.ok || !guardianSave?.ok || lastErrorChanged)
       ? { reason: SPELLING_PERSISTENCE_WARNING_REASON.STORAGE_SAVE_FAILED }
       : null;
+    // P2 U9: mirror the session-scoped `feedback.persistenceWarning` into
+    // the durable `data.persistenceWarning` sibling so the banner survives
+    // tab close. Write is bounded-retry + console.warn fallback — the
+    // service path never crashes the submit even if the storage is
+    // fundamentally broken (the very condition we're warning about).
+    if (persistenceWarning) {
+      writePersistenceWarning(learnerId, persistenceWarning.reason);
+    }
 
     // Record the per-word outcome so the finalisation step can emit the
     // mission-completed event with accurate aggregate counts.
@@ -2284,6 +2384,10 @@ export function createSpellingService({ repository, storage, tts, now, random, c
     const persistenceWarning = (!probeSave?.ok || midErrorChanged)
       ? { reason: SPELLING_PERSISTENCE_WARNING_REASON.STORAGE_SAVE_FAILED }
       : null;
+    // P2 U9: durable mirror on the Smart Review / SATs submit path too.
+    if (persistenceWarning) {
+      writePersistenceWarning(learnerId, persistenceWarning.reason);
+    }
 
     const eventTime = clock();
     const events = [];
@@ -2626,6 +2730,10 @@ export function createSpellingService({ repository, storage, tts, now, random, c
     const persistenceWarning = (!progressSave?.ok || !guardianSave?.ok || lastErrorChanged)
       ? { reason: SPELLING_PERSISTENCE_WARNING_REASON.STORAGE_SAVE_FAILED }
       : null;
+    // P2 U9: durable mirror on the "I don't know" skipWord branch.
+    if (persistenceWarning) {
+      writePersistenceWarning(learnerId, persistenceWarning.reason);
+    }
 
     // Record the per-word outcome so guardianMissionEventsForSession counts
     // this as a wobble on the final mission-completed event.
@@ -2779,6 +2887,15 @@ export function createSpellingService({ repository, storage, tts, now, random, c
       // API on the persistence adapter above has already cleared the
       // production path via `writeSpellingData(repositories, learnerId, {})`.
     }
+    // P2 U9: clear the durable persistence-warning too. A fresh learner
+    // should not inherit a previous learner's storage-failure banner after
+    // a reset. Same best-effort try/catch applies.
+    try {
+      resolvedStorage?.removeItem?.(persistenceWarningKey(learnerId));
+    } catch {
+      // Swallow — reset is best-effort; a stale warning is a minor UX
+      // inconvenience, not a data-loss hazard.
+    }
   }
 
   return {
@@ -2801,5 +2918,15 @@ export function createSpellingService({ repository, storage, tts, now, random, c
     // write sites (e.g. U4's "I don't know" branch) can call it directly
     // instead of going through a whole-map load/mutate/save.
     saveGuardianRecord,
+    // P2 U9: durable persistence-warning surface. `getPersistenceWarning`
+    // is the read-side helper for `buildSpellingContext` (setup + session
+    // scene banners). `acknowledgePersistenceWarning` is the dispatcher
+    // target for the "I understand" button — sets `acknowledged: true` and
+    // keeps the record for audit. `writePersistenceWarning` is internal
+    // (called from the submit paths) but exposed here so tests can drive
+    // it directly without constructing a full submit round.
+    getPersistenceWarning,
+    acknowledgePersistenceWarning,
+    writePersistenceWarning,
   };
 }

--- a/shared/spelling/service.js
+++ b/shared/spelling/service.js
@@ -1176,6 +1176,16 @@ export function createSpellingService({ repository, storage, tts, now, random, c
   // currently persisted this is a silent no-op (no banner to dismiss).
   // A subsequent new failure resets `acknowledged: false` via
   // `writePersistenceWarning`.
+  //
+  // Reviewer-feedback fix (PR #279 HIGH): apply the same bounded-retry +
+  // console.warn fallback pattern that `writePersistenceWarning` uses. The
+  // whole point of the banner is to surface a broken-storage condition, so
+  // when the learner clicks "I understand" and storage is STILL broken, we
+  // must not silently no-op — the previous behaviour dropped the error and
+  // left the record at `acknowledged: false`, making the click feel like a
+  // black hole. The dispatchers surface `{ ok: false, reason: 'persist-failed' }`
+  // by setting a runtime error so the learner sees the click did not take
+  // effect.
   function acknowledgePersistenceWarning(learnerId) {
     const current = loadPersistenceWarningFromStorage(learnerId);
     if (!current) return { ok: true };
@@ -1184,7 +1194,29 @@ export function createSpellingService({ repository, storage, tts, now, random, c
       occurredAt: current.occurredAt,
       acknowledged: true,
     };
-    return savePersistenceWarningToStorage(learnerId, acknowledgedRecord);
+    const firstAttempt = savePersistenceWarningToStorage(learnerId, acknowledgedRecord);
+    if (firstAttempt.ok === true) return { ok: true };
+    // Bounded retry once. If the first failure was transient (e.g. a race
+    // inside the persistence channel), a retry may succeed.
+    const retryAttempt = savePersistenceWarningToStorage(learnerId, acknowledgedRecord);
+    if (retryAttempt.ok === true) return { ok: true };
+    // Double failure — warn and return ok:false. The banner will re-render
+    // on the next selector pass (storage still reports acknowledged=false),
+    // but that is honest: storage is still broken. The dispatcher surfaces
+    // a runtime error so the click is not silently dropped.
+    try {
+      globalThis.console?.warn?.('Spelling persistence-warning acknowledge failed after retry.', {
+        learnerId,
+        reason: acknowledgedRecord.reason,
+        firstError: firstAttempt?.error?.message,
+        retryError: retryAttempt?.error?.message,
+      });
+    } catch {
+      // A thrown console.warn (very unusual — some sandboxes wrap console)
+      // is not actionable for the learner; absorb silently so the ack path
+      // does not crash on a diagnostic side-effect.
+    }
+    return { ok: false, reason: 'persist-failed' };
   }
 
   // P2 U9: read-side helper for the UI. Returns the normalised record or

--- a/src/subjects/spelling/components/SpellingSessionScene.jsx
+++ b/src/subjects/spelling/components/SpellingSessionScene.jsx
@@ -8,7 +8,7 @@ import {
   spellingSessionVoiceNote,
 } from '../session-ui.js';
 import {
-  SPELLING_PERSISTENCE_WARNING_COPY,
+  SPELLING_DURABLE_PERSISTENCE_WARNING_COPY,
   SPELLING_PERSISTENCE_WARNING_REASON,
 } from '../service-contract.js';
 import { ArrowRightIcon, SpeakerIcon, SpeakerSlowIcon } from './spelling-icons.jsx';
@@ -40,6 +40,14 @@ export function SpellingSessionScene({
   actions,
   previousHeroBg = '',
   runtimeReadOnly = false,
+  // P2 U9: durable persistence-warning sibling threaded from
+  // `buildSpellingContext`. When non-null AND `!acknowledged` the banner
+  // renders across sessions; the "I understand" button dispatches
+  // `spelling-acknowledge-persistence-warning` which sets
+  // `acknowledged: true` on the persisted record (data is retained for
+  // audit). A subsequent new failure overwrites `acknowledged: false` and
+  // re-surfaces the banner.
+  persistenceWarning = null,
 }) {
   const prefs = service.getPrefs(learner.id);
   const session = ui.session;
@@ -120,26 +128,29 @@ export function SpellingSessionScene({
   const sessionClasses = ['spelling-in-session'];
   sessionClasses.push(questionRevealed ? 'is-question-revealed' : 'is-entering-session');
 
-  // U8: storage-failure warning surface. The service attaches
-  // `feedback.persistenceWarning` on submit when a local-storage write fails
-  // (progress or guardian). We render a subtle polite-live banner above the
-  // card so the warning is announced once per submit (the aria-live region
-  // reads the new content on mount); Mega is never demoted. On the next
-  // successful submit the feedback re-renders without the warning and the
-  // banner unmounts. Accepted MVP gap: if the child closes the tab before
-  // another submit, the warning does not persist across sessions — a durable
-  // cross-session surface is deferred to a later plan.
+  // P2 U9: storage-failure warning surface migrated from the session-scoped
+  // `feedback.persistenceWarning` to the durable `data.persistenceWarning`
+  // sibling. The service writes `{ reason, occurredAt, acknowledged: false }`
+  // on any `saveJson` failure via `PersistenceSetItemError`; the banner
+  // renders until the learner clicks "I understand" (dispatches
+  // `spelling-acknowledge-persistence-warning`, sets `acknowledged: true`).
+  // Mega is never demoted on any failure path.
   //
-  // Review fix: banner copy is sourced from `SPELLING_PERSISTENCE_WARNING_COPY`
-  // in service-contract.js so a single edit updates every site. The reason
-  // key is the enum from `SPELLING_PERSISTENCE_WARNING_REASON` — the
-  // normaliser guarantees the reason is one of the allow-listed values, so
-  // the copy map always resolves.
-  const persistenceWarning = ui.feedback?.persistenceWarning || null;
-  const persistenceWarningCopy = persistenceWarning
+  // Accepted the P1.5 U8 gap: the previous session-scoped warning died on
+  // tab close. The durable sibling now survives, so a learner who closes
+  // the tab mid-failure still sees the banner on their next visit.
+  //
+  // Review fix: banner copy is sourced from
+  // `SPELLING_DURABLE_PERSISTENCE_WARNING_COPY` in service-contract.js so a
+  // single edit updates every site. The reason key is the enum from
+  // `SPELLING_PERSISTENCE_WARNING_REASON` — the durable-record normaliser
+  // guarantees the reason is one of the allow-listed values, so the copy
+  // map always resolves.
+  const showPersistenceBanner = persistenceWarning && !persistenceWarning.acknowledged;
+  const persistenceWarningCopy = showPersistenceBanner
     ? (persistenceWarning.reason === SPELLING_PERSISTENCE_WARNING_REASON.STORAGE_SAVE_FAILED
-      ? SPELLING_PERSISTENCE_WARNING_COPY.STORAGE_SAVE_FAILED
-      : SPELLING_PERSISTENCE_WARNING_COPY.STORAGE_SAVE_FAILED)
+      ? SPELLING_DURABLE_PERSISTENCE_WARNING_COPY.STORAGE_SAVE_FAILED
+      : SPELLING_DURABLE_PERSISTENCE_WARNING_COPY.STORAGE_SAVE_FAILED)
     : '';
 
   return (
@@ -151,14 +162,22 @@ export function SpellingSessionScene({
           <span className="path-count">Word {progressCurrent} of {progressTotal}</span>
         </header>
 
-        {persistenceWarning ? (
+        {showPersistenceBanner ? (
           <div
             className="spelling-persistence-warning"
             role="status"
             aria-live="polite"
             data-testid="spelling-persistence-warning"
           >
-            {persistenceWarningCopy}
+            <span className="spelling-persistence-warning-text">{persistenceWarningCopy}</span>
+            <button
+              type="button"
+              className="spelling-persistence-warning-ack"
+              data-action="spelling-acknowledge-persistence-warning"
+              onClick={(event) => renderAction(actions, event, 'spelling-acknowledge-persistence-warning')}
+            >
+              I understand
+            </button>
           </div>
         ) : null}
 

--- a/src/subjects/spelling/components/SpellingSessionScene.jsx
+++ b/src/subjects/spelling/components/SpellingSessionScene.jsx
@@ -9,7 +9,6 @@ import {
 } from '../session-ui.js';
 import {
   SPELLING_DURABLE_PERSISTENCE_WARNING_COPY,
-  SPELLING_PERSISTENCE_WARNING_REASON,
 } from '../service-contract.js';
 import { ArrowRightIcon, SpeakerIcon, SpeakerSlowIcon } from './spelling-icons.jsx';
 import {
@@ -146,11 +145,18 @@ export function SpellingSessionScene({
   // `SPELLING_PERSISTENCE_WARNING_REASON` — the durable-record normaliser
   // guarantees the reason is one of the allow-listed values, so the copy
   // map always resolves.
+  // Reviewer-feedback fix (PR #279 LOW): the previous ternary had identical
+  // branches — a dead-code placeholder for when future reasons are added.
+  // Use a forward-compatible lookup so adding a new reason is just a key in
+  // `SPELLING_DURABLE_PERSISTENCE_WARNING_COPY` plus (optionally) the enum;
+  // no edit to the scenes is required. Fall back to STORAGE_SAVE_FAILED
+  // copy if the reason is absent from the map (defensive: the normaliser
+  // guarantees the reason is allow-listed but we keep the fallback so a
+  // future map-edit mistake does not blank the banner).
   const showPersistenceBanner = persistenceWarning && !persistenceWarning.acknowledged;
   const persistenceWarningCopy = showPersistenceBanner
-    ? (persistenceWarning.reason === SPELLING_PERSISTENCE_WARNING_REASON.STORAGE_SAVE_FAILED
-      ? SPELLING_DURABLE_PERSISTENCE_WARNING_COPY.STORAGE_SAVE_FAILED
-      : SPELLING_DURABLE_PERSISTENCE_WARNING_COPY.STORAGE_SAVE_FAILED)
+    ? (SPELLING_DURABLE_PERSISTENCE_WARNING_COPY[persistenceWarning.reason]
+      ?? SPELLING_DURABLE_PERSISTENCE_WARNING_COPY.STORAGE_SAVE_FAILED)
     : '';
 
   return (

--- a/src/subjects/spelling/components/SpellingSetupScene.jsx
+++ b/src/subjects/spelling/components/SpellingSetupScene.jsx
@@ -3,7 +3,11 @@ import { useMonsterVisualConfig } from '../../../platform/game/MonsterVisualConf
 import { SpellingHeroBackdrop } from './SpellingHeroBackdrop.jsx';
 import { ArrowRightIcon, CheckIcon } from './spelling-icons.jsx';
 import { useSetupHeroContrast } from './useSetupHeroContrast.js';
-import { BOSS_DEFAULT_ROUND_LENGTH } from '../service-contract.js';
+import {
+  BOSS_DEFAULT_ROUND_LENGTH,
+  SPELLING_DURABLE_PERSISTENCE_WARNING_COPY,
+  SPELLING_PERSISTENCE_WARNING_REASON,
+} from '../service-contract.js';
 import {
   MODE_CARDS,
   POST_MEGA_MODE_CARDS,
@@ -319,6 +323,11 @@ export function SpellingSetupScene({
   // Defaults to empty string so a prop-less caller (tests, legacy shells)
   // renders the child-safe view with the link absent.
   platformRole = '',
+  // P2 U9: durable persistence-warning sibling threaded from
+  // `buildSpellingContext`. Rendered on the setup scene so a learner who
+  // closed the tab mid-failure sees the warning the instant they re-open
+  // the app. Same "I understand" button + copy as the session scene.
+  persistenceWarning = null,
 }) {
   const statsFilter = prefs.mode === 'test' ? 'core' : prefs.yearFilter;
   const stats = service.getStats(learner.id, statsFilter);
@@ -351,6 +360,20 @@ export function SpellingSetupScene({
   // to the admin hub where the post-mega debug panel explains the counts.
   const showPostMasteryDebugLink = adultCanSeePostMasteryDebug(platformRole) && !isPostMega;
 
+  // P2 U9: banner gate — rendered when the durable `data.persistenceWarning`
+  // sibling exists and the learner has not yet acknowledged. Copy + button
+  // mirror the session scene exactly so the surface feels consistent
+  // whether the failure surfaced on setup (prefs write) or session
+  // (progress / guardian write). "I understand" dispatches the
+  // `spelling-acknowledge-persistence-warning` action handled in module.js
+  // (local) and remote-actions.js (remote-sync parity).
+  const showPersistenceBanner = persistenceWarning && !persistenceWarning.acknowledged;
+  const persistenceWarningCopy = showPersistenceBanner
+    ? (persistenceWarning.reason === SPELLING_PERSISTENCE_WARNING_REASON.STORAGE_SAVE_FAILED
+      ? SPELLING_DURABLE_PERSISTENCE_WARNING_COPY.STORAGE_SAVE_FAILED
+      : SPELLING_DURABLE_PERSISTENCE_WARNING_COPY.STORAGE_SAVE_FAILED)
+    : '';
+
   return (
     <div className="setup-grid" style={{ gridColumn: '1/-1' }}>
       <section
@@ -364,6 +387,24 @@ export function SpellingSetupScene({
       >
         <SpellingHeroBackdrop url={heroBg} previousUrl={previousHeroBg} />
         <div className={contentClasses.join(' ')}>
+          {showPersistenceBanner ? (
+            <div
+              className="spelling-persistence-warning"
+              role="status"
+              aria-live="polite"
+              data-testid="spelling-persistence-warning"
+            >
+              <span className="spelling-persistence-warning-text">{persistenceWarningCopy}</span>
+              <button
+                type="button"
+                className="spelling-persistence-warning-ack"
+                data-action="spelling-acknowledge-persistence-warning"
+                onClick={(event) => renderAction(actions, event, 'spelling-acknowledge-persistence-warning')}
+              >
+                I understand
+              </button>
+            </div>
+          ) : null}
           {isPostMega ? (
             <PostMegaSetupContent
               prefs={prefs}

--- a/src/subjects/spelling/components/SpellingSetupScene.jsx
+++ b/src/subjects/spelling/components/SpellingSetupScene.jsx
@@ -6,7 +6,6 @@ import { useSetupHeroContrast } from './useSetupHeroContrast.js';
 import {
   BOSS_DEFAULT_ROUND_LENGTH,
   SPELLING_DURABLE_PERSISTENCE_WARNING_COPY,
-  SPELLING_PERSISTENCE_WARNING_REASON,
 } from '../service-contract.js';
 import {
   MODE_CARDS,
@@ -367,11 +366,15 @@ export function SpellingSetupScene({
   // (progress / guardian write). "I understand" dispatches the
   // `spelling-acknowledge-persistence-warning` action handled in module.js
   // (local) and remote-actions.js (remote-sync parity).
+  // Reviewer-feedback fix (PR #279 LOW): the previous ternary had identical
+  // branches — a dead-code placeholder. Use a forward-compatible lookup so
+  // adding a new reason is just a key in `SPELLING_DURABLE_PERSISTENCE_WARNING_COPY`
+  // plus (optionally) the enum; no edit to the scenes is required. Fall
+  // back to STORAGE_SAVE_FAILED copy if the reason is absent from the map.
   const showPersistenceBanner = persistenceWarning && !persistenceWarning.acknowledged;
   const persistenceWarningCopy = showPersistenceBanner
-    ? (persistenceWarning.reason === SPELLING_PERSISTENCE_WARNING_REASON.STORAGE_SAVE_FAILED
-      ? SPELLING_DURABLE_PERSISTENCE_WARNING_COPY.STORAGE_SAVE_FAILED
-      : SPELLING_DURABLE_PERSISTENCE_WARNING_COPY.STORAGE_SAVE_FAILED)
+    ? (SPELLING_DURABLE_PERSISTENCE_WARNING_COPY[persistenceWarning.reason]
+      ?? SPELLING_DURABLE_PERSISTENCE_WARNING_COPY.STORAGE_SAVE_FAILED)
     : '';
 
   return (

--- a/src/subjects/spelling/components/spelling-view-model.js
+++ b/src/subjects/spelling/components/spelling-view-model.js
@@ -950,6 +950,16 @@ export function buildSpellingContext({ appState, service, repositories, subject 
         ...createLockedPostMasteryState(),
         todayDay: Math.floor(Date.now() / DAY_MS),
       };
+  // P2 U9: durable persistence-warning sibling. Read on every context build
+  // so the banner surfaces the instant the service writes a new record
+  // (submit-path failure) and disappears the instant it is acknowledged.
+  // The normaliser in service-contract.js drops garbage back to null, so
+  // `persistenceWarning` is either a `{ reason, occurredAt, acknowledged }`
+  // record or `null`. Setup + session scenes branch on `!acknowledged` to
+  // decide whether to render the banner.
+  const persistenceWarning = typeof service.getPersistenceWarning === 'function'
+    ? service.getPersistenceWarning(learner.id)
+    : null;
   return {
     learner,
     ui,
@@ -957,6 +967,7 @@ export function buildSpellingContext({ appState, service, repositories, subject 
     prefs: service.getPrefs(learner.id),
     analytics,
     postMastery,
+    persistenceWarning,
     codex: ui.phase === 'dashboard' && analytics
       ? monsterSummaryFromSpellingAnalytics(analytics, {
           learnerId: learner.id,

--- a/src/subjects/spelling/module.js
+++ b/src/subjects/spelling/module.js
@@ -479,6 +479,23 @@ export const spellingModule = {
       return true;
     }
 
+    // P2 U9: "I understand" button on the durable persistence-warning banner
+    // dispatches this action. The service sets `acknowledged: true` on the
+    // persisted `data.persistenceWarning` record; the banner re-renders as
+    // absent on the next tick because `buildSpellingContext` re-reads the
+    // record each call. A subsequent new failure overwrites with
+    // `acknowledged: false`, re-surfacing the banner.
+    if (action === 'spelling-acknowledge-persistence-warning') {
+      if (typeof service.acknowledgePersistenceWarning === 'function') {
+        service.acknowledgePersistenceWarning(learnerId);
+      }
+      // Touch the subject UI so the view-model selector re-runs and the
+      // banner unmounts. No error-clearing is needed — the banner lives
+      // outside the feedback/error surfaces.
+      store.updateSubjectUi('spelling', { error: '' });
+      return true;
+    }
+
     return false;
   },
 };

--- a/src/subjects/spelling/module.js
+++ b/src/subjects/spelling/module.js
@@ -485,14 +485,25 @@ export const spellingModule = {
     // absent on the next tick because `buildSpellingContext` re-reads the
     // record each call. A subsequent new failure overwrites with
     // `acknowledged: false`, re-surfacing the banner.
+    //
+    // Reviewer-feedback fix (PR #279 HIGH): when the service reports
+    // `{ ok: false }` (storage is still broken during the ack write), we
+    // MUST surface a runtime error so the click does not silently drop.
+    // The banner will re-render on the next selector pass because storage
+    // still records `acknowledged: false`, which is honest — but the
+    // learner now sees a clear "try again" message rather than a mystery.
     if (action === 'spelling-acknowledge-persistence-warning') {
+      let ackResult = { ok: true };
       if (typeof service.acknowledgePersistenceWarning === 'function') {
-        service.acknowledgePersistenceWarning(learnerId);
+        ackResult = service.acknowledgePersistenceWarning(learnerId) || { ok: true };
       }
-      // Touch the subject UI so the view-model selector re-runs and the
-      // banner unmounts. No error-clearing is needed — the banner lives
-      // outside the feedback/error surfaces.
-      store.updateSubjectUi('spelling', { error: '' });
+      const nextError = ackResult.ok === false
+        ? 'Could not save — try again when storage is available.'
+        : '';
+      // Touch the subject UI so the view-model selector re-runs. The error
+      // slot reflects whether the ack persisted: on success we clear, on
+      // failure we surface child-friendly copy.
+      store.updateSubjectUi('spelling', { error: nextError });
       return true;
     }
 

--- a/src/subjects/spelling/remote-actions.js
+++ b/src/subjects/spelling/remote-actions.js
@@ -52,6 +52,10 @@ const SPELLING_IN_FLIGHT_DEDUPE_COMMANDS = new Set([
   'continue-session',
   'skip-word',
   'end-session',
+  // P2 U9 reviewer-feedback fix (LOW): dedupe double-click on the
+  // "I understand" button. Without this, a fast double-click fires two
+  // acknowledge commands; the second is a no-op but still round-trips.
+  'acknowledge-persistence-warning',
 ]);
 
 const SPELLING_UI_LOCAL_ACTIONS = new Set([
@@ -90,6 +94,13 @@ function pendingCommandBlocksAction(action, appState = {}) {
   const pendingCommand = spellingPendingCommand(appState);
   if (!pendingCommand || !SPELLING_COMMAND_ACTIONS.has(action)) return false;
   if (pendingCommand === 'save-prefs' && SPELLING_SETUP_PREF_ACTIONS.has(action)) return false;
+  // P2 U9 reviewer-feedback fix (LOW): acknowledge writes to a different
+  // sibling (`data.persistenceWarning`) than submit-answer (`data.progress`
+  // + `data.guardian`), so structurally they do not conflict. Blocking the
+  // banner dismissal during an in-flight submit is unnecessary and degrades
+  // UX — the learner sees the banner linger until submit completes. Bypass
+  // the pending-command block specifically for the acknowledge action.
+  if (action === 'spelling-acknowledge-persistence-warning') return false;
   return true;
 }
 
@@ -568,6 +579,7 @@ export function createRemoteSpellingActionHandler({
     const {
       learnerId: requestedLearnerId = '',
       errorLearnerId = '',
+      errorMessage = '',
       beforeSend = null,
       onSuccess = null,
       onError = null,
@@ -586,9 +598,15 @@ export function createRemoteSpellingActionHandler({
     }).catch((error) => {
       onError?.(error);
       globalThis.console?.warn?.('Spelling command failed.', error);
+      // P2 U9 reviewer-feedback fix: `errorMessage` is a caller-provided
+      // override so specific commands (e.g. acknowledge-persistence-warning)
+      // can surface child-friendly copy instead of the generic fallback.
+      // Fall back to `commandErrorMessage` so existing callers keep the
+      // previous behaviour (no caller has to opt into the override).
+      const fallback = errorMessage || 'The spelling command could not be completed.';
       setRuntimeErrorForLearner(
         errorLearnerId || commandLearnerId,
-        commandErrorMessage(error, 'The spelling command could not be completed.'),
+        errorMessage || commandErrorMessage(error, fallback),
       );
     }).finally(() => {
       releasePendingCommand(command, pending.dedupeKey);
@@ -1056,8 +1074,18 @@ export function createRemoteSpellingActionHandler({
     // The local service is also updated optimistically via the command
     // response (Worker twin's `acknowledge-persistence-warning` command
     // writes `acknowledged: true` and returns fresh `data`).
+    //
+    // Reviewer-feedback fix (PR #279 HIGH): if the Worker round-trip fails
+    // (network, 5xx, or degraded mode) `runCommand`'s default error handler
+    // would emit a generic "The spelling command could not be completed." —
+    // we override with child-friendly copy that matches the local-mode
+    // dispatcher in `module.js`, so the banner re-renders but the learner
+    // sees a clear "try again" message instead of a mystery.
     if (action === 'spelling-acknowledge-persistence-warning') {
-      runCommand('acknowledge-persistence-warning');
+      runCommand('acknowledge-persistence-warning', {}, {
+        errorLearnerId: learnerId,
+        errorMessage: 'Could not save — try again when storage is available.',
+      });
       return true;
     }
 

--- a/src/subjects/spelling/remote-actions.js
+++ b/src/subjects/spelling/remote-actions.js
@@ -33,6 +33,10 @@ const SPELLING_COMMAND_ACTIONS = new Set([
   'spelling-end-early',
   'spelling-drill-all',
   'spelling-drill-single',
+  // P2 U9: durable persistence-warning acknowledge. Goes through the same
+  // command channel so remote-sync learners dismiss the banner via a
+  // Worker-side command, keeping server `data.persistenceWarning` in sync.
+  'spelling-acknowledge-persistence-warning',
 ]);
 
 const SPELLING_SETUP_PREF_ACTIONS = new Set([
@@ -1042,6 +1046,18 @@ export function createRemoteSpellingActionHandler({
         length: 1,
         practiceOnly: originMode === 'guardian',
       });
+      return true;
+    }
+
+    // P2 U9: remote-sync parity for the durable persistence-warning
+    // acknowledge. Mirrors the `module.js` dispatcher exactly — routes
+    // through the Worker command boundary so server-side
+    // `data.persistenceWarning.acknowledged` stays in sync with the client.
+    // The local service is also updated optimistically via the command
+    // response (Worker twin's `acknowledge-persistence-warning` command
+    // writes `acknowledged: true` and returns fresh `data`).
+    if (action === 'spelling-acknowledge-persistence-warning') {
+      runCommand('acknowledge-persistence-warning');
       return true;
     }
 

--- a/src/subjects/spelling/repository.js
+++ b/src/subjects/spelling/repository.js
@@ -1,5 +1,9 @@
 import { cloneSerialisable, normalisePracticeSessionRecord } from '../../platform/core/repositories/helpers.js';
-import { normaliseGuardianMap, normalisePostMegaRecord } from './service-contract.js';
+import {
+  normaliseDurablePersistenceWarning,
+  normaliseGuardianMap,
+  normalisePostMegaRecord,
+} from './service-contract.js';
 
 const SUBJECT_ID = 'spelling';
 const PREF_STORAGE_PREFIX = 'ks2-platform-v2.spelling-prefs.';
@@ -8,6 +12,13 @@ const GUARDIAN_STORAGE_PREFIX = 'ks2-spell-guardian-';
 // P2 U2: sticky-graduation sibling. Mirrors POST_MEGA_KEY_PREFIX in
 // shared/spelling/service.js — must stay byte-identical with that constant.
 const POST_MEGA_STORAGE_PREFIX = 'ks2-spell-post-mega-';
+// P2 U9: durable persistence-warning sibling. Mirrors PERSISTENCE_WARNING_KEY_PREFIX
+// in shared/spelling/service.js — must stay byte-identical. The prefix
+// intentionally differs from the shorter `ks2-spell-` family used by the other
+// four siblings (prefs / progress / guardian / post-mega); we pick
+// `ks2-spell-persistence-warning-` so the `parseStorageKey` startsWith dispatch
+// cannot collide with `ks2-spell-progress-` or `ks2-spell-post-mega-`.
+const PERSISTENCE_WARNING_STORAGE_PREFIX = 'ks2-spell-persistence-warning-';
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 function todayDayForNow(now) {
@@ -41,6 +52,11 @@ function postMegaKey(learnerId) {
   return `${POST_MEGA_STORAGE_PREFIX}${learnerId || 'default'}`;
 }
 
+// P2 U9: durable persistence-warning sibling key.
+function persistenceWarningKey(learnerId) {
+  return `${PERSISTENCE_WARNING_STORAGE_PREFIX}${learnerId || 'default'}`;
+}
+
 function parseStorageKey(key) {
   if (typeof key !== 'string') return null;
   if (key.startsWith(PREF_STORAGE_PREFIX)) {
@@ -48,6 +64,12 @@ function parseStorageKey(key) {
   }
   if (key.startsWith(GUARDIAN_STORAGE_PREFIX)) {
     return { type: 'guardian', learnerId: key.slice(GUARDIAN_STORAGE_PREFIX.length) || 'default' };
+  }
+  // P2 U9: persistence-warning is checked before post-mega and progress
+  // because `ks2-spell-persistence-warning-` shares `ks2-spell-p` with both.
+  // The longer, unique second-segment keeps the prefixes disambiguated.
+  if (key.startsWith(PERSISTENCE_WARNING_STORAGE_PREFIX)) {
+    return { type: 'persistenceWarning', learnerId: key.slice(PERSISTENCE_WARNING_STORAGE_PREFIX.length) || 'default' };
   }
   // P2 U2: order matters — POST_MEGA_STORAGE_PREFIX must be checked BEFORE
   // PROGRESS_STORAGE_PREFIX because `ks2-spell-post-mega-` starts with
@@ -96,6 +118,13 @@ export function normaliseSpellingSubjectData(rawValue, todayDay = 0) {
   // for pre-graduation learners (no `postMega` key at all).
   const postMega = normalisePostMegaRecord(raw.postMega);
   if (postMega) output.postMega = postMega;
+  // P2 U9: `persistenceWarning` is a durable sibling that survives tab close.
+  // It is written whenever a `saveJson` throws a `PersistenceSetItemError`
+  // and cleared on learner acknowledgement. Storage format:
+  // `data.persistenceWarning = { reason, occurredAt, acknowledged }`. Attach
+  // only when non-null so pre-failure bundles stay compact.
+  const persistenceWarning = normaliseDurablePersistenceWarning(raw.persistenceWarning);
+  if (persistenceWarning) output.persistenceWarning = persistenceWarning;
   return output;
 }
 
@@ -202,6 +231,12 @@ export function createSpellingPersistence({ repositories, now } = {}) {
       // P2 U2: postMega is null for never-graduated learners; stringify
       // preserves null-vs-object distinction for the service-layer reader.
       if (parsed.type === 'postMega') return data.postMega ? JSON.stringify(data.postMega) : 'null';
+      // P2 U9: persistenceWarning is null for learners who have never seen
+      // a save failure; the null-vs-object distinction matters so the
+      // service can use a missing record as the "no active warning" marker.
+      if (parsed.type === 'persistenceWarning') {
+        return data.persistenceWarning ? JSON.stringify(data.persistenceWarning) : 'null';
+      }
       return null;
     },
     setItem(key, value) {
@@ -245,6 +280,17 @@ export function createSpellingPersistence({ repositories, now } = {}) {
           }, day);
         }
       }
+      if (parsed.type === 'persistenceWarning') {
+        // P2 U9: unlike `postMega`, the persistence-warning record IS
+        // overwrite-ful. A subsequent failure overwrites `reason` +
+        // `occurredAt` and resets `acknowledged: false`; an acknowledge
+        // dispatcher overwrites with `acknowledged: true`. We persist the
+        // parsed payload directly so the callers (service) own the shape.
+        writeSpellingData(repositories, parsed.learnerId, {
+          ...current,
+          persistenceWarning: parseStoredJson(value, null),
+        }, day);
+      }
       const afterError = readPersistenceError();
       if (errorSignatureChanged(beforeError, afterError)) {
         const message = afterError?.message || 'storage-setItem-failed';
@@ -268,6 +314,15 @@ export function createSpellingPersistence({ repositories, now } = {}) {
       if (parsed.type === 'guardian') {
         writeSpellingData(repositories, parsed.learnerId, { ...current, guardian: {} }, day);
       }
+      // P2 U9: persistenceWarning can be removed via `resetLearner` (below)
+      // which clears the whole bundle. A direct removeItem on this key is
+      // also honoured — strip the sibling from the normalised bundle. No
+      // sticky-lock constraint applies (the record is overwritable anyway).
+      if (parsed.type === 'persistenceWarning') {
+        const next = { ...current };
+        delete next.persistenceWarning;
+        writeSpellingData(repositories, parsed.learnerId, next, day);
+      }
       // P2 U2: postMega cannot be removed through this path — sticky is
       // permanent by contract. `resetLearner` (below) is the only surface
       // that clears postMega, and it goes through writeSpellingData with an
@@ -281,6 +336,7 @@ export function createSpellingPersistence({ repositories, now } = {}) {
     prefsKey,
     guardianKey,
     postMegaKey,
+    persistenceWarningKey,
     // U8 review fix: expose the platform persistence channel's `lastError`
     // signal so the spelling service can detect legacy-engine's silent-
     // swallow on Smart Review / SATs submits. Legacy-engine's

--- a/src/subjects/spelling/service-contract.js
+++ b/src/subjects/spelling/service-contract.js
@@ -317,6 +317,32 @@ export const SPELLING_PERSISTENCE_WARNING_REASON = Object.freeze({
 });
 
 /**
+ * P2 U9: Normalise the durable `data.persistenceWarning` sibling. Unlike the
+ * session-scoped `feedback.persistenceWarning` (which carries only `{ reason }`
+ * for the current-round banner), the persisted record also carries `occurredAt`
+ * (day number) and `acknowledged` (boolean) so the banner survives tab close
+ * and dismisses once the learner clicks "I understand". Returns `null` for
+ * garbage / missing input so `data.persistenceWarning === null` is the
+ * unambiguous "no warning" marker for the sibling record writer.
+ *
+ * Shape: `{ reason, occurredAt, acknowledged }`.
+ *  - `reason`: must be a member of `SPELLING_PERSISTENCE_WARNING_REASONS`.
+ *  - `occurredAt`: non-negative integer day number (floor of Date.now() / DAY_MS).
+ *  - `acknowledged`: boolean; defaults to false when missing.
+ */
+export function normaliseDurablePersistenceWarning(raw) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const reason = typeof raw.reason === 'string' ? raw.reason : '';
+  if (!SPELLING_PERSISTENCE_WARNING_REASONS.includes(reason)) return null;
+  const occurredAtRaw = Number(raw.occurredAt);
+  const occurredAt = Number.isFinite(occurredAtRaw) && occurredAtRaw >= 0
+    ? Math.floor(occurredAtRaw)
+    : 0;
+  const acknowledged = raw.acknowledged === true;
+  return { reason, occurredAt, acknowledged };
+}
+
+/**
  * U8 review fix: banner copy extracted so future wording tweaks live in one
  * place. The wording was updated from the original "Progress could not be
  * saved on this device. Export or free storage." to the more accurate
@@ -328,6 +354,18 @@ export const SPELLING_PERSISTENCE_WARNING_REASON = Object.freeze({
  */
 export const SPELLING_PERSISTENCE_WARNING_COPY = Object.freeze({
   STORAGE_SAVE_FAILED: 'We could not save your progress on this device. Your answer counted for this round, but you may see this word again after a reload. Free up storage or export your progress.',
+});
+
+/**
+ * P2 U9: copy for the durable persistence-warning banner. The wording is
+ * deliberately more compact than `SPELLING_PERSISTENCE_WARNING_COPY` because
+ * the durable banner may surface on the setup scene (learner arrives fresh,
+ * no active round) — the "Your answer counted for this round" phrasing from
+ * U8 does not apply there. The U9 copy centres on what the learner needs to
+ * do: export data or free up storage.
+ */
+export const SPELLING_DURABLE_PERSISTENCE_WARNING_COPY = Object.freeze({
+  STORAGE_SAVE_FAILED: 'Your progress could not be saved on this device. Export your data or free up storage.',
 });
 
 function normalisePersistenceWarning(raw) {

--- a/src/subjects/spelling/service-contract.js
+++ b/src/subjects/spelling/service-contract.js
@@ -363,8 +363,16 @@ export const SPELLING_PERSISTENCE_WARNING_COPY = Object.freeze({
  * no active round) — the "Your answer counted for this round" phrasing from
  * U8 does not apply there. The U9 copy centres on what the learner needs to
  * do: export data or free up storage.
+ *
+ * Reviewer-feedback fix (PR #279 LOW): keys are indexed by the reason enum
+ * VALUE (kebab-case, e.g. `'storage-save-failed'`) so the UI can do a direct
+ * `COPY[reason]` lookup and adding a future reason is a one-line change in
+ * `SPELLING_PERSISTENCE_WARNING_REASONS` + here. Legacy UPPER_SNAKE key is
+ * kept as an alias so any downstream consumer that relied on the symbolic
+ * name keeps working.
  */
 export const SPELLING_DURABLE_PERSISTENCE_WARNING_COPY = Object.freeze({
+  'storage-save-failed': 'Your progress could not be saved on this device. Export your data or free up storage.',
   STORAGE_SAVE_FAILED: 'Your progress could not be saved on this device. Export your data or free up storage.',
 });
 

--- a/styles/app.css
+++ b/styles/app.css
@@ -2294,6 +2294,49 @@ textarea:focus-visible {
 }
 .persistence-banner-action:hover { background: color-mix(in oklab, var(--warn) 14%, transparent); }
 
+/* P2 U9: durable spelling persistence-warning banner — surfaces on both
+ * setup and session scenes, persists across tab close until the learner
+ * clicks "I understand". Uses the same warn palette as `.persistence-banner`
+ * so the two surfaces feel coordinated; prominent-but-not-alarming per the
+ * plan's UX direction. */
+.spelling-persistence-warning {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  margin: 0 0 16px;
+  border-radius: var(--radius-sm);
+  background: var(--warn-soft);
+  border: 1px solid color-mix(in oklab, var(--warn) 45%, transparent);
+  color: var(--warn-strong);
+  font-size: 0.92rem;
+  line-height: 1.4;
+}
+.spelling-persistence-warning-text {
+  flex: 1 1 240px;
+}
+.spelling-persistence-warning-ack {
+  appearance: none;
+  border: 1px solid color-mix(in oklab, var(--warn) 55%, transparent);
+  background: transparent;
+  color: var(--warn-strong);
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.spelling-persistence-warning-ack:hover {
+  background: color-mix(in oklab, var(--warn) 14%, transparent);
+}
+.spelling-persistence-warning-ack:focus-visible {
+  outline: 2px solid var(--warn);
+  outline-offset: 2px;
+}
+
 /* ---------- Profile settings surface ---------- */
 .sr-only {
   position: absolute;

--- a/tests/helpers/memory-storage.js
+++ b/tests/helpers/memory-storage.js
@@ -6,6 +6,11 @@ export class MemoryStorage {
     // resets so subsequent writes succeed normally. Used by the storage-
     // failure warning-surface tests to drive the `feedback.persistenceWarning`
     // path without monkey-patching individual storage instances.
+    //
+    // P2 U9 reviewer-feedback-fix: the hook now carries a `count` so the
+    // caller can arm multiple consecutive throws (needed for the
+    // `acknowledgePersistenceWarning` bounded-retry test — both the first
+    // attempt AND the retry must throw).
     this._throwNext = null;
   }
 
@@ -17,7 +22,8 @@ export class MemoryStorage {
     if (this._throwNext) {
       const { keyFilter, error } = this._throwNext;
       if (!keyFilter || keyFilter === key) {
-        this._throwNext = null;
+        this._throwNext.count = (this._throwNext.count ?? 1) - 1;
+        if (this._throwNext.count <= 0) this._throwNext = null;
         throw error;
       }
     }
@@ -42,14 +48,20 @@ export class MemoryStorage {
 
   /**
    * Arm the storage to throw on the NEXT matching `setItem` call. After it
-   * fires once, subsequent writes succeed. Pass `{ key: 'ks2-...' }` to only
-   * throw on writes to a specific storage key; omit to throw on any next
-   * write. Pass `{ error: new Error(...) }` to customise the thrown value
-   * (defaults to a QuotaExceededError-shaped Error).
+   * fires `count` times (default 1), subsequent writes succeed. Pass
+   * `{ key: 'ks2-...' }` to only throw on writes to a specific storage key;
+   * omit to throw on any next write. Pass `{ error: new Error(...) }` to
+   * customise the thrown value (defaults to a QuotaExceededError-shaped
+   * Error). Pass `{ count: 2 }` to arm consecutive throws — used by the
+   * P2 U9 `acknowledgePersistenceWarning` bounded-retry test.
    */
-  throwOnNextSet({ key: keyFilter = '', error = null } = {}) {
+  throwOnNextSet({ key: keyFilter = '', error = null, count = 1 } = {}) {
     const thrown = error || Object.assign(new Error('QuotaExceededError'), { name: 'QuotaExceededError' });
-    this._throwNext = { keyFilter: keyFilter ? String(keyFilter) : '', error: thrown };
+    this._throwNext = {
+      keyFilter: keyFilter ? String(keyFilter) : '',
+      error: thrown,
+      count: Number.isFinite(count) && count > 0 ? Math.floor(count) : 1,
+    };
   }
 }
 

--- a/tests/react-spelling-scene-spike.test.js
+++ b/tests/react-spelling-scene-spike.test.js
@@ -109,14 +109,15 @@ test('spelling replay uses a server audio cue when the prompt word is redacted',
   assert.deepEqual(spoken, [{ ...audio, slow: true }]);
 });
 
-// ----- U8: persistenceWarning banner renders above the card --------------------
+// ----- P2 U9: durable persistenceWarning banner renders above the card ------
 //
-// Wires a happy-path session into the harness, then patches the spelling UI
-// state to inject `feedback.persistenceWarning`. The scene must render a
-// polite-live banner with the planned copy, and NOT render it on the
-// happy-path where persistenceWarning is absent.
+// Migrated from U8 (session-scoped `feedback.persistenceWarning`) to U9
+// (durable `data.persistenceWarning` sibling). The U9 scene reads the
+// warning from the persisted subject-state record via the service getter,
+// so these fixture tests seed `data.persistenceWarning` through the
+// repository rather than patching `subjectUi.spelling.feedback`.
 
-test('U8 session scene renders storage-failure banner when feedback.persistenceWarning is present', () => {
+test('P2 U9 session scene renders storage-failure banner when data.persistenceWarning is present', () => {
   const harness = createAppHarness({ storage: installMemoryStorage() });
   const learnerId = harness.store.getState().learners.selectedId;
 
@@ -124,45 +125,37 @@ test('U8 session scene renders storage-failure banner when feedback.persistenceW
   harness.dispatch('open-subject', { subjectId: 'spelling' });
   harness.dispatch('spelling-start');
 
-  // Happy path render: banner absent.
+  // Happy path render: banner absent (no data.persistenceWarning).
   const happyHtml = harness.render();
   assert.doesNotMatch(happyHtml, /spelling-persistence-warning/,
-    'banner absent when feedback has no persistenceWarning');
+    'banner absent when data.persistenceWarning is unset');
 
-  // Patch the spelling UI to inject a persistenceWarning on the current
-  // feedback. This simulates a state where U8's service code has set the
-  // warning after a storage throw.
-  harness.store.patch((current) => ({
-    subjectUi: {
-      ...current.subjectUi,
-      spelling: {
-        ...current.subjectUi.spelling,
-        feedback: {
-          kind: 'info',
-          headline: 'Guardian strong.',
-          answer: 'possess',
-          attemptedAnswer: '',
-          body: '',
-          footer: '',
-          familyWords: [],
-          persistenceWarning: { reason: 'storage-save-failed' },
-        },
-      },
+  // Seed the durable sibling through the repository — the service's
+  // `getPersistenceWarning` reads from the same storage path, so
+  // `buildSpellingContext` will pick it up on the next render.
+  const existing = harness.repositories.subjectStates.read(learnerId, 'spelling').data || {};
+  harness.repositories.subjectStates.writeData(learnerId, 'spelling', {
+    ...existing,
+    persistenceWarning: {
+      reason: 'storage-save-failed',
+      occurredAt: 19_500,
+      acknowledged: false,
     },
-  }));
+  });
 
   const warningHtml = harness.render();
   assert.match(warningHtml, /spelling-persistence-warning/,
-    'banner element renders when feedback.persistenceWarning is set');
-  // Review fix: banner copy now warns explicitly that the answer counted
-  // but may re-appear after a reload. Copy is sourced from
-  // SPELLING_PERSISTENCE_WARNING_COPY.STORAGE_SAVE_FAILED.
-  assert.match(warningHtml, /could not save your progress on this device/,
+    'banner element renders when data.persistenceWarning is set');
+  // P2 U9 copy: prominent-but-not-alarming — the message tells the learner
+  // what happened and what to do without demoting Mega.
+  assert.match(warningHtml, /could not be saved on this device/,
     'banner copy matches the planned wording (opening phrase)');
-  assert.match(warningHtml, /Your answer counted for this round/,
-    'banner copy acknowledges that the in-memory answer was recorded');
-  assert.match(warningHtml, /see this word again after a reload/,
-    'banner copy warns about the partial-write re-ask');
+  assert.match(warningHtml, /Export your data or free up storage/,
+    'banner copy gives the learner two actionable options');
+  assert.match(warningHtml, /I understand/,
+    'banner includes the "I understand" acknowledge button');
+  assert.match(warningHtml, /data-action="spelling-acknowledge-persistence-warning"/,
+    'acknowledge button wires to the durable acknowledge dispatcher');
   assert.match(warningHtml, /role="status"/,
     'banner uses role="status" (ARIA live-polite)');
   assert.match(warningHtml, /aria-live="polite"/,
@@ -171,14 +164,7 @@ test('U8 session scene renders storage-failure banner when feedback.persistenceW
     'banner exposes a data-testid for downstream integration tests');
 });
 
-// ----- U8 review fix: banner unmounts when warning clears ----------------------
-//
-// The banner is conditionally rendered on `ui.feedback?.persistenceWarning`.
-// When the next submit produces feedback without the warning, the banner
-// element must disappear from the DOM. Advisory fix for the sev-60 test
-// finding that exercises the set → undefined unmount contract.
-
-test('U8 session scene unmounts persistenceWarning banner when feedback clears', () => {
+test('P2 U9 session scene hides banner when data.persistenceWarning.acknowledged is true', () => {
   const harness = createAppHarness({ storage: installMemoryStorage() });
   const learnerId = harness.store.getState().learners.selectedId;
 
@@ -186,63 +172,34 @@ test('U8 session scene unmounts persistenceWarning banner when feedback clears',
   harness.dispatch('open-subject', { subjectId: 'spelling' });
   harness.dispatch('spelling-start');
 
-  // Inject warning.
-  harness.store.patch((current) => ({
-    subjectUi: {
-      ...current.subjectUi,
-      spelling: {
-        ...current.subjectUi.spelling,
-        feedback: {
-          kind: 'info',
-          headline: 'Guardian strong.',
-          answer: 'possess',
-          attemptedAnswer: '',
-          body: '',
-          footer: '',
-          familyWords: [],
-          persistenceWarning: { reason: 'storage-save-failed' },
-        },
-      },
+  // Seed unacknowledged warning — banner should render.
+  const existing = harness.repositories.subjectStates.read(learnerId, 'spelling').data || {};
+  harness.repositories.subjectStates.writeData(learnerId, 'spelling', {
+    ...existing,
+    persistenceWarning: {
+      reason: 'storage-save-failed',
+      occurredAt: 19_500,
+      acknowledged: false,
     },
-  }));
+  });
   assert.match(harness.render(), /data-testid="spelling-persistence-warning"/,
-    'banner mounts on first inject');
+    'banner mounts for unacknowledged warning');
 
-  // Transition feedback to a warning-free shape — the service returns a new
-  // feedback object after the next successful submit.
-  harness.store.patch((current) => ({
-    subjectUi: {
-      ...current.subjectUi,
-      spelling: {
-        ...current.subjectUi.spelling,
-        feedback: {
-          kind: 'info',
-          headline: 'Guardian strong.',
-          answer: 'possess',
-          attemptedAnswer: '',
-          body: '',
-          footer: '',
-          familyWords: [],
-          // persistenceWarning intentionally absent.
-        },
-      },
+  // Flip acknowledged true — banner unmounts but record is retained for
+  // audit (the repository still holds the warning).
+  const current = harness.repositories.subjectStates.read(learnerId, 'spelling').data || {};
+  harness.repositories.subjectStates.writeData(learnerId, 'spelling', {
+    ...current,
+    persistenceWarning: {
+      ...current.persistenceWarning,
+      acknowledged: true,
     },
-  }));
+  });
   assert.doesNotMatch(harness.render(), /data-testid="spelling-persistence-warning"/,
-    'banner unmounts when feedback.persistenceWarning is cleared');
-
-  // Also verify feedback → null removes the banner.
-  harness.store.patch((current) => ({
-    subjectUi: {
-      ...current.subjectUi,
-      spelling: {
-        ...current.subjectUi.spelling,
-        feedback: null,
-      },
-    },
-  }));
-  assert.doesNotMatch(harness.render(), /data-testid="spelling-persistence-warning"/,
-    'banner unmounts when feedback itself is null');
+    'banner unmounts when acknowledged=true');
+  const afterAck = harness.repositories.subjectStates.read(learnerId, 'spelling').data || {};
+  assert.equal(afterAck.persistenceWarning?.acknowledged, true,
+    'record retained for audit after dismissal');
 });
 
 test('word-bank modal spike keeps drill isolated and Escape closes back to the word bank', () => {

--- a/tests/spelling-persistence-warning.test.js
+++ b/tests/spelling-persistence-warning.test.js
@@ -341,6 +341,91 @@ test('P2 U9 subsequent-failure-after-ack: resets acknowledged to false', () => {
     'new failure resets acknowledged false so banner re-surfaces');
 });
 
+// ---- HIGH-fix: acknowledge path also has bounded retry + console.warn ------
+
+// Reviewer-feedback fix (PR #279 HIGH): `acknowledgePersistenceWarning` used
+// to silently no-op on broken storage — the banner re-rendered because
+// storage still recorded `{ acknowledged: false }` but the click looked like
+// a black hole to the learner. It now applies the same bounded-retry +
+// console.warn fallback that `writePersistenceWarning` uses, and returns
+// `{ ok: false, reason: 'persist-failed' }` so the dispatcher can surface a
+// runtime error.
+test('P2 U9 acknowledge HIGH-fix: twice-failing returns ok:false, warns, keeps acknowledged=false', () => {
+  // Arm a hostile storage that returns the seeded warning on getItem but
+  // throws on every setItem. This is the only way to exercise the ack
+  // double-failure path: `savePersistenceWarningToStorage` is the only
+  // writer, and it calls `resolvedStorage.setItem` directly (no persistAll
+  // wrapper for the bare-storage service path).
+  const persistenceKey = 'ks2-spell-persistence-warning-learner-a';
+  const seededRecord = {
+    reason: 'storage-save-failed',
+    occurredAt: TODAY_DAY,
+    acknowledged: false,
+  };
+  const backing = new Map();
+  backing.set(persistenceKey, JSON.stringify(seededRecord));
+  const hostileStorage = {
+    getItem(key) {
+      return backing.has(key) ? backing.get(key) : null;
+    },
+    setItem() {
+      // Every write fails so both the first attempt AND the retry throw.
+      throw Object.assign(new Error('QuotaExceededError'), { name: 'QuotaExceededError' });
+    },
+    removeItem(key) { backing.delete(key); },
+  };
+
+  const originalWarn = globalThis.console?.warn;
+  const warnings = [];
+  globalThis.console = globalThis.console || {};
+  globalThis.console.warn = (...args) => { warnings.push(args); };
+
+  try {
+    const hostile = createSpellingService({
+      storage: hostileStorage,
+      now: () => TODAY_MS,
+      random: () => 0.5,
+      tts: { speak() {}, stop() {}, warmup() {} },
+    });
+
+    // (a) call MUST NOT throw.
+    let thrown = null;
+    let result = null;
+    try {
+      result = hostile.acknowledgePersistenceWarning('learner-a');
+    } catch (error) {
+      thrown = error;
+    }
+    assert.equal(thrown, null,
+      'acknowledgePersistenceWarning must not throw on double-failure storage');
+
+    // (b) returns `{ ok: false, reason: 'persist-failed' }`.
+    assert.ok(result, 'returns a result object');
+    assert.equal(result.ok, false, 'ok: false on double-failure');
+    assert.equal(result.reason, 'persist-failed', 'reason: persist-failed');
+
+    // (c) on-disk record still shows `acknowledged: false`. The ack
+    // attempts both failed so the seeded record is untouched — the banner
+    // will re-render on the next selector pass, which is honest.
+    const onDisk = JSON.parse(backing.get(persistenceKey));
+    assert.equal(onDisk.acknowledged, false,
+      'record unchanged — acknowledged stays false when write fails');
+    assert.equal(onDisk.reason, 'storage-save-failed',
+      'reason preserved');
+
+    // (d) console.warn was called at least once (the diagnostic fallback).
+    assert.ok(warnings.length >= 1, 'console.warn fallback fired');
+    const firstWarn = warnings[0];
+    assert.ok(
+      firstWarn && typeof firstWarn[0] === 'string'
+        && firstWarn[0].includes('acknowledge'),
+      'console.warn message mentions acknowledge path',
+    );
+  } finally {
+    globalThis.console.warn = originalWarn;
+  }
+});
+
 // ---- Bounded retry for writePersistenceWarning itself -----------------------
 
 test('P2 U9 bounded retry: writePersistenceWarning twice-failing falls through to console.warn', () => {

--- a/tests/spelling-persistence-warning.test.js
+++ b/tests/spelling-persistence-warning.test.js
@@ -1,0 +1,454 @@
+// P2 U9 — Durable persistence-warning sibling.
+//
+// Plan: docs/plans/2026-04-26-006-feat-post-mega-spelling-p2-visibility-pattern-foundation-plan.md (U9)
+//
+// Contract under test:
+//   1. On any `saveJson` failure through the spelling storage proxy the
+//      service writes `data.persistenceWarning = { reason, occurredAt,
+//      acknowledged: false }` — the DURABLE sibling, not just the
+//      session-scoped `feedback.persistenceWarning`.
+//   2. The durable record survives tab close: a fresh service instance
+//      reading the same repositories sees the banner.
+//   3. `acknowledgePersistenceWarning(learnerId)` sets `acknowledged: true`
+//      while preserving `reason` + `occurredAt` for audit; banner dismisses.
+//   4. A second `saveJson` failure while unacknowledged overwrites
+//      `occurredAt` and keeps `acknowledged: false` (the learner already
+//      knows something is wrong — no "double-banner" fatigue).
+//   5. A second failure AFTER acknowledge overwrites `acknowledged: false`
+//      so the banner re-surfaces.
+//   6. When `writePersistenceWarning` itself fails, the bounded retry +
+//      `console.warn` fallback stops the submit path from crashing.
+//   7. Worker twin's `normaliseServerSpellingData` preserves
+//      `data.persistenceWarning` through command round-trips.
+//   8. The `acknowledge-persistence-warning` Worker command mirrors
+//      `service.acknowledgePersistenceWarning` behaviour.
+//
+// Tests use `createLocalPlatformRepositories` (the P1.5 U8 dead-code
+// learning: bare `MemoryStorage` misses the `persistAll` wrapper that the
+// production code path actually hits). `MemoryStorage.throwOnNextSet` arms
+// a one-shot throw on the underlying raw storage; the platform repository's
+// `persistAll` detects the throw via `persistBundle` and surfaces it through
+// the proxy's `PersistenceSetItemError`, which is exactly the production
+// signature the service reacts to.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { installMemoryStorage, MemoryStorage } from './helpers/memory-storage.js';
+import { createLocalPlatformRepositories } from '../src/platform/core/repositories/index.js';
+import { createSpellingService } from '../src/subjects/spelling/service.js';
+import {
+  createSpellingPersistence,
+  normaliseSpellingSubjectData,
+} from '../src/subjects/spelling/repository.js';
+import { WORDS } from '../src/subjects/spelling/data/word-data.js';
+import {
+  SPELLING_PERSISTENCE_WARNING_REASON,
+  normaliseDurablePersistenceWarning,
+} from '../src/subjects/spelling/service-contract.js';
+import {
+  createServerSpellingEngine,
+  normaliseServerSpellingData,
+} from '../worker/src/subjects/spelling/engine.js';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const TODAY_MS = Date.UTC(2026, 3, 26);
+const TODAY_DAY = Math.floor(TODAY_MS / DAY_MS);
+const CORE_WORDS = WORDS.filter((word) => word.spellingPool !== 'extra');
+const CORE_SLUGS = CORE_WORDS.map((word) => word.slug);
+
+function makeServiceWithRepositories({ now = () => TODAY_MS, random = () => 0.5 } = {}) {
+  const storage = new MemoryStorage();
+  globalThis.localStorage = storage;
+  const repositories = createLocalPlatformRepositories({ storage });
+  const service = createSpellingService({
+    repository: createSpellingPersistence({ repositories, now }),
+    now,
+    random,
+    tts: {
+      speak() {},
+      stop() {},
+      warmup() {},
+    },
+  });
+  return { storage, repositories, service };
+}
+
+function seedAllCoreMega(repositories, learnerId, todayDay) {
+  const progress = Object.fromEntries(
+    CORE_SLUGS.map((slug, index) => [slug, {
+      stage: 4,
+      attempts: 6 + (index % 4),
+      correct: 5 + (index % 4),
+      wrong: 1,
+      dueDay: todayDay + 60,
+      lastDay: todayDay - 7,
+      lastResult: 'correct',
+    }]),
+  );
+  repositories.subjectStates.writeData(learnerId, 'spelling', { progress, guardian: {} });
+}
+
+// ---- Normaliser contract -----------------------------------------------------
+
+test('P2 U9 normaliser: returns null for garbage / missing input', () => {
+  assert.equal(normaliseDurablePersistenceWarning(null), null);
+  assert.equal(normaliseDurablePersistenceWarning(undefined), null);
+  assert.equal(normaliseDurablePersistenceWarning('not-an-object'), null);
+  assert.equal(normaliseDurablePersistenceWarning([]), null);
+  assert.equal(normaliseDurablePersistenceWarning({}), null);
+  assert.equal(normaliseDurablePersistenceWarning({ reason: 'unknown-kind' }), null);
+});
+
+test('P2 U9 normaliser: accepts well-formed record with defaults', () => {
+  const out = normaliseDurablePersistenceWarning({
+    reason: 'storage-save-failed',
+    occurredAt: 19_500,
+    acknowledged: true,
+  });
+  assert.deepEqual(out, {
+    reason: 'storage-save-failed',
+    occurredAt: 19_500,
+    acknowledged: true,
+  });
+});
+
+test('P2 U9 normaliser: defaults acknowledged=false, occurredAt=0 when absent/invalid', () => {
+  const out = normaliseDurablePersistenceWarning({ reason: 'storage-save-failed' });
+  assert.deepEqual(out, {
+    reason: 'storage-save-failed',
+    occurredAt: 0,
+    acknowledged: false,
+  });
+  const clampedNeg = normaliseDurablePersistenceWarning({
+    reason: 'storage-save-failed',
+    occurredAt: -5,
+  });
+  assert.equal(clampedNeg.occurredAt, 0);
+  const nonBoolean = normaliseDurablePersistenceWarning({
+    reason: 'storage-save-failed',
+    acknowledged: 'yes',
+  });
+  assert.equal(nonBoolean.acknowledged, false);
+});
+
+// ---- normaliseSpellingSubjectData parity (client + worker) ------------------
+
+test('P2 U9 client normaliser: preserves data.persistenceWarning sibling', () => {
+  const input = {
+    progress: {},
+    guardian: {},
+    persistenceWarning: {
+      reason: 'storage-save-failed',
+      occurredAt: 19_500,
+      acknowledged: false,
+    },
+  };
+  const out = normaliseSpellingSubjectData(input, TODAY_DAY);
+  assert.deepEqual(out.persistenceWarning, {
+    reason: 'storage-save-failed',
+    occurredAt: 19_500,
+    acknowledged: false,
+  });
+});
+
+test('P2 U9 client normaliser: drops persistenceWarning sibling when invalid', () => {
+  const out = normaliseSpellingSubjectData({
+    progress: {},
+    guardian: {},
+    persistenceWarning: { reason: 'unknown' },
+  }, TODAY_DAY);
+  assert.equal(out.persistenceWarning, undefined);
+});
+
+test('P2 U9 worker normaliser: preserves data.persistenceWarning sibling', () => {
+  const input = {
+    progress: {},
+    guardian: {},
+    persistenceWarning: {
+      reason: 'storage-save-failed',
+      occurredAt: 19_500,
+      acknowledged: false,
+    },
+  };
+  const out = normaliseServerSpellingData(input, TODAY_MS);
+  assert.deepEqual(out.persistenceWarning, {
+    reason: 'storage-save-failed',
+    occurredAt: 19_500,
+    acknowledged: false,
+  });
+});
+
+// ---- Happy path: no warning ------------------------------------------------
+
+test('P2 U9 happy path: clean submit leaves persistenceWarning unset', () => {
+  const { service, repositories } = makeServiceWithRepositories();
+  seedAllCoreMega(repositories, 'learner-a', TODAY_DAY);
+  const started = service.startSession('learner-a', { mode: 'guardian' });
+  const answer = started.state.session.currentCard.word.word;
+  const submitted = service.submitAnswer('learner-a', started.state, answer);
+  assert.equal(submitted.ok, true);
+  assert.equal(service.getPersistenceWarning('learner-a'), null,
+    'no banner for a successful submit');
+});
+
+// ---- Write on storage failure (durable sibling) -----------------------------
+
+test('P2 U9 write path: Guardian submit storage failure writes durable warning', () => {
+  const { service, repositories, storage } = makeServiceWithRepositories();
+  seedAllCoreMega(repositories, 'learner-a', TODAY_DAY);
+
+  const started = service.startSession('learner-a', { mode: 'guardian' });
+  const answer = started.state.session.currentCard.word.word;
+
+  // Arm the underlying raw storage to throw on the guardian-key write.
+  // The platform repository wraps setItem inside persistAll → persistBundle;
+  // a throw there surfaces via the persistence channel's lastError AND the
+  // proxy's `PersistenceSetItemError` (see repository.js L249), which is
+  // exactly the production signal the service reacts to.
+  storage.throwOnNextSet();
+
+  const submitted = service.submitAnswer('learner-a', started.state, answer);
+  assert.equal(submitted.ok, true, 'submit stays ok: true on storage failure');
+
+  // Feedback banner still surfaces (session-scoped, legacy behaviour).
+  assert.equal(submitted.state.feedback?.persistenceWarning?.reason,
+    'storage-save-failed');
+
+  // Durable sibling IS written.
+  const durable = service.getPersistenceWarning('learner-a');
+  assert.ok(durable, 'durable persistenceWarning is non-null after failure');
+  assert.equal(durable.reason, SPELLING_PERSISTENCE_WARNING_REASON.STORAGE_SAVE_FAILED);
+  assert.equal(durable.acknowledged, false);
+  assert.equal(typeof durable.occurredAt, 'number');
+  assert.ok(durable.occurredAt >= 0);
+});
+
+// ---- Cross-session survival (integration with createLocalPlatformRepositories)
+
+test('P2 U9 durable survival: fresh service instance reads persisted warning', () => {
+  const storage = new MemoryStorage();
+  globalThis.localStorage = storage;
+  const reposA = createLocalPlatformRepositories({ storage });
+  const serviceA = createSpellingService({
+    repository: createSpellingPersistence({ repositories: reposA, now: () => TODAY_MS }),
+    now: () => TODAY_MS,
+    random: () => 0.5,
+    tts: { speak() {}, stop() {}, warmup() {} },
+  });
+  seedAllCoreMega(reposA, 'learner-a', TODAY_DAY);
+  const started = serviceA.startSession('learner-a', { mode: 'guardian' });
+  storage.throwOnNextSet();
+  serviceA.submitAnswer('learner-a', started.state, started.state.session.currentCard.word.word);
+
+  // Sanity — first service wrote the warning.
+  const warningA = serviceA.getPersistenceWarning('learner-a');
+  assert.ok(warningA, 'warning is present on service A');
+  assert.equal(warningA.acknowledged, false);
+
+  // Simulate tab reopen: build a fresh repository + service wrapping the
+  // SAME raw storage. The underlying platform repositories re-hydrate from
+  // localStorage on construction, so a fresh instance should see the
+  // warning that service A wrote.
+  const reposB = createLocalPlatformRepositories({ storage });
+  const serviceB = createSpellingService({
+    repository: createSpellingPersistence({ repositories: reposB, now: () => TODAY_MS + 60_000 }),
+    now: () => TODAY_MS + 60_000,
+    random: () => 0.5,
+    tts: { speak() {}, stop() {}, warmup() {} },
+  });
+  const warningB = serviceB.getPersistenceWarning('learner-a');
+  assert.ok(warningB, 'warning survives into fresh service B (tab close simulation)');
+  assert.equal(warningB.reason, warningA.reason);
+  assert.equal(warningB.acknowledged, false,
+    'banner still wants to show in the new tab until acknowledged');
+});
+
+// ---- Acknowledge dispatcher -------------------------------------------------
+
+test('P2 U9 acknowledge: sets acknowledged=true, keeps reason + occurredAt', () => {
+  const { service, repositories, storage } = makeServiceWithRepositories();
+  seedAllCoreMega(repositories, 'learner-a', TODAY_DAY);
+  const started = service.startSession('learner-a', { mode: 'guardian' });
+  storage.throwOnNextSet();
+  service.submitAnswer('learner-a', started.state, started.state.session.currentCard.word.word);
+
+  const before = service.getPersistenceWarning('learner-a');
+  assert.ok(before);
+  assert.equal(before.acknowledged, false);
+
+  service.acknowledgePersistenceWarning('learner-a');
+
+  const after = service.getPersistenceWarning('learner-a');
+  assert.ok(after, 'record retained for audit after acknowledge');
+  assert.equal(after.acknowledged, true, 'acknowledged flipped true');
+  assert.equal(after.reason, before.reason, 'reason preserved');
+  assert.equal(after.occurredAt, before.occurredAt, 'occurredAt preserved');
+});
+
+test('P2 U9 acknowledge: no-op when no warning exists', () => {
+  const { service } = makeServiceWithRepositories();
+  // Never triggered a failure; no warning present.
+  const result = service.acknowledgePersistenceWarning('learner-fresh');
+  assert.equal(result.ok, true);
+  assert.equal(service.getPersistenceWarning('learner-fresh'), null);
+});
+
+// ---- Subsequent-failure semantics -------------------------------------------
+
+test('P2 U9 subsequent-failure-unacknowledged: overwrites occurredAt, keeps ack=false', () => {
+  const clock = { now: TODAY_MS };
+  const { service, repositories, storage } = makeServiceWithRepositories({ now: () => clock.now });
+  seedAllCoreMega(repositories, 'learner-a', TODAY_DAY);
+
+  // First failure on day T.
+  let started = service.startSession('learner-a', { mode: 'guardian' });
+  storage.throwOnNextSet();
+  service.submitAnswer('learner-a', started.state, started.state.session.currentCard.word.word);
+  const first = service.getPersistenceWarning('learner-a');
+  assert.ok(first);
+  assert.equal(first.occurredAt, TODAY_DAY);
+
+  // Advance clock by 2 days, trigger second failure.
+  clock.now = TODAY_MS + 2 * DAY_MS;
+  started = service.startSession('learner-a', { mode: 'guardian' });
+  storage.throwOnNextSet();
+  service.submitAnswer('learner-a', started.state, started.state.session.currentCard.word.word);
+
+  const second = service.getPersistenceWarning('learner-a');
+  assert.ok(second);
+  assert.equal(second.acknowledged, false, 'still unacknowledged');
+  assert.equal(second.occurredAt, TODAY_DAY + 2, 'occurredAt bumped to latest failure day');
+});
+
+test('P2 U9 subsequent-failure-after-ack: resets acknowledged to false', () => {
+  const { service, repositories, storage } = makeServiceWithRepositories();
+  seedAllCoreMega(repositories, 'learner-a', TODAY_DAY);
+  let started = service.startSession('learner-a', { mode: 'guardian' });
+  storage.throwOnNextSet();
+  service.submitAnswer('learner-a', started.state, started.state.session.currentCard.word.word);
+  service.acknowledgePersistenceWarning('learner-a');
+  assert.equal(service.getPersistenceWarning('learner-a').acknowledged, true);
+
+  // New failure after acknowledge.
+  started = service.startSession('learner-a', { mode: 'guardian' });
+  storage.throwOnNextSet();
+  service.submitAnswer('learner-a', started.state, started.state.session.currentCard.word.word);
+
+  const after = service.getPersistenceWarning('learner-a');
+  assert.ok(after);
+  assert.equal(after.acknowledged, false,
+    'new failure resets acknowledged false so banner re-surfaces');
+});
+
+// ---- Bounded retry for writePersistenceWarning itself -----------------------
+
+test('P2 U9 bounded retry: writePersistenceWarning twice-failing falls through to console.warn', () => {
+  const { service } = makeServiceWithRepositories();
+
+  // Replace console.warn with a spy so we can observe the fallback without
+  // stomping the console. Restored after the assertion.
+  const originalWarn = globalThis.console?.warn;
+  const warnings = [];
+  globalThis.console = globalThis.console || {};
+  globalThis.console.warn = (...args) => { warnings.push(args); };
+
+  try {
+    // Directly monkeypatch the service's resolvedStorage.setItem so BOTH
+    // the first attempt AND the retry throw. We reach into the repository
+    // by using a brand-new service with an always-throwing storage.
+    const throwingStorage = {
+      getItem() { return null; },
+      setItem() {
+        throw Object.assign(new Error('QuotaExceededError'), { name: 'QuotaExceededError' });
+      },
+      removeItem() {},
+    };
+    const hostile = createSpellingService({
+      storage: throwingStorage,
+      now: () => TODAY_MS,
+      random: () => 0.5,
+      tts: { speak() {}, stop() {}, warmup() {} },
+    });
+
+    // writePersistenceWarning should NOT throw — the bounded retry catches
+    // and falls through to console.warn.
+    let thrown = null;
+    try {
+      hostile.writePersistenceWarning('learner-a', 'storage-save-failed');
+    } catch (error) {
+      thrown = error;
+    }
+    assert.equal(thrown, null, 'writePersistenceWarning must not throw on double-failure');
+    assert.ok(warnings.length >= 1, 'console.warn fallback fired');
+  } finally {
+    globalThis.console.warn = originalWarn;
+  }
+});
+
+// ---- Worker twin parity -----------------------------------------------------
+
+test('P2 U9 worker twin: acknowledge-persistence-warning command flips acknowledged', () => {
+  const engine = createServerSpellingEngine({
+    now: () => TODAY_MS,
+    random: () => 0.5,
+  });
+  const subjectRecord = {
+    ui: null,
+    data: {
+      progress: {},
+      guardian: {},
+      persistenceWarning: {
+        reason: 'storage-save-failed',
+        occurredAt: TODAY_DAY,
+        acknowledged: false,
+      },
+    },
+  };
+  const response = engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord,
+    command: 'acknowledge-persistence-warning',
+    payload: {},
+  });
+  assert.equal(response.ok, true);
+  assert.ok(response.data.persistenceWarning,
+    'worker command preserves the sibling with acknowledged=true');
+  assert.equal(response.data.persistenceWarning.acknowledged, true);
+  assert.equal(response.data.persistenceWarning.reason, 'storage-save-failed');
+  assert.equal(response.data.persistenceWarning.occurredAt, TODAY_DAY);
+});
+
+test('P2 U9 worker twin: no-op acknowledge when no warning present', () => {
+  const engine = createServerSpellingEngine({
+    now: () => TODAY_MS,
+    random: () => 0.5,
+  });
+  const subjectRecord = { ui: null, data: { progress: {}, guardian: {} } };
+  const response = engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord,
+    command: 'acknowledge-persistence-warning',
+    payload: {},
+  });
+  assert.equal(response.ok, true);
+  assert.equal(response.data.persistenceWarning, undefined);
+});
+
+// ---- Mega-never-revoked invariant on storage failure -----------------------
+
+test('P2 U9 Mega-never-revoked: stage=4 preserved on storage failure', () => {
+  const { service, repositories, storage } = makeServiceWithRepositories();
+  seedAllCoreMega(repositories, 'learner-a', TODAY_DAY);
+  const started = service.startSession('learner-a', { mode: 'guardian' });
+  const currentSlug = started.state.session.currentSlug;
+  storage.throwOnNextSet();
+  service.submitAnswer('learner-a', started.state, started.state.session.currentCard.word.word);
+
+  // Read progress through the platform layer — the stored stage must stay
+  // at 4 (Mega) even though the guardian write failed. The warning is the
+  // only observable side-effect the learner feels.
+  const data = repositories.subjectStates.read('learner-a', 'spelling').data || {};
+  assert.equal(data.progress?.[currentSlug]?.stage, 4,
+    'progress.stage still 4 after storage-failure write');
+});

--- a/worker/src/subjects/spelling/engine.js
+++ b/worker/src/subjects/spelling/engine.js
@@ -4,6 +4,7 @@ import {
 } from '../../../../src/platform/core/repositories/helpers.js';
 import {
   createInitialSpellingState,
+  normaliseDurablePersistenceWarning,
   normaliseGuardianMap,
   normalisePostMegaRecord,
 } from '../../../../src/subjects/spelling/service-contract.js';
@@ -19,6 +20,8 @@ const PROGRESS_STORAGE_PREFIX = 'ks2-spell-progress-';
 const GUARDIAN_STORAGE_PREFIX = 'ks2-spell-guardian-';
 // P2 U2: mirror client POST_MEGA_STORAGE_PREFIX in src/subjects/spelling/repository.js.
 const POST_MEGA_STORAGE_PREFIX = 'ks2-spell-post-mega-';
+// P2 U9: mirror client PERSISTENCE_WARNING_STORAGE_PREFIX in src/subjects/spelling/repository.js.
+const PERSISTENCE_WARNING_STORAGE_PREFIX = 'ks2-spell-persistence-warning-';
 
 function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -52,6 +55,11 @@ export function normaliseServerSpellingData(rawValue, nowTs = Date.now()) {
   // through Worker commands without loss.
   const postMega = normalisePostMegaRecord(raw.postMega);
   if (postMega) output.postMega = postMega;
+  // P2 U9: persistenceWarning sibling survives through the Worker twin so
+  // a learner who saw a local storage failure and switched tabs to a
+  // remote-sync session does not lose their banner.
+  const persistenceWarning = normaliseDurablePersistenceWarning(raw.persistenceWarning);
+  if (persistenceWarning) output.persistenceWarning = persistenceWarning;
   return output;
 }
 
@@ -62,6 +70,11 @@ function parseStorageKey(key) {
   }
   if (key.startsWith(GUARDIAN_STORAGE_PREFIX)) {
     return { type: 'guardian', learnerId: key.slice(GUARDIAN_STORAGE_PREFIX.length) || 'default' };
+  }
+  // P2 U9: persistence-warning prefix must be checked before post-mega and
+  // progress for the same reason — all three start with `ks2-spell-p`.
+  if (key.startsWith(PERSISTENCE_WARNING_STORAGE_PREFIX)) {
+    return { type: 'persistenceWarning', learnerId: key.slice(PERSISTENCE_WARNING_STORAGE_PREFIX.length) || 'default' };
   }
   // P2 U2: post-mega prefix must be checked before progress because the two
   // share the first 10 chars (`ks2-spell-`) but diverge at the 11th.
@@ -172,6 +185,12 @@ function createServerPersistence({ learnerId, data, latestSession, now }) {
         // null vs object distinction so the service-layer reader can gate
         // on it without special-casing the string literal.
         if (parsed.type === 'postMega') return current.postMega ? JSON.stringify(current.postMega) : 'null';
+        // P2 U9: persistenceWarning is null for learners who have never
+        // encountered a local-storage failure; null vs object distinction
+        // lets the service-layer reader skip the banner cleanly.
+        if (parsed.type === 'persistenceWarning') {
+          return current.persistenceWarning ? JSON.stringify(current.persistenceWarning) : 'null';
+        }
         return null;
       },
       setItem(key, value) {
@@ -207,6 +226,15 @@ function createServerPersistence({ learnerId, data, latestSession, now }) {
             }, resolveNow());
           }
         }
+        if (parsed.type === 'persistenceWarning') {
+          // P2 U9: persistence-warning is overwrite-ful. A new failure
+          // overwrites `reason` + `occurredAt` and resets acknowledged; an
+          // acknowledge dispatcher overwrites with `acknowledged: true`.
+          nextData = normaliseServerSpellingData({
+            ...nextData,
+            persistenceWarning: parseStoredJson(value, null),
+          }, resolveNow());
+        }
       },
       removeItem(key) {
         const parsed = parseStorageKey(key);
@@ -214,6 +242,13 @@ function createServerPersistence({ learnerId, data, latestSession, now }) {
         if (parsed.type === 'prefs') nextData = normaliseServerSpellingData({ ...nextData, prefs: {} }, resolveNow());
         if (parsed.type === 'progress') nextData = normaliseServerSpellingData({ ...nextData, progress: {} }, resolveNow());
         if (parsed.type === 'guardian') nextData = normaliseServerSpellingData({ ...nextData, guardian: {} }, resolveNow());
+        if (parsed.type === 'persistenceWarning') {
+          // P2 U9: removable — e.g. a future admin-ops tool may want to
+          // clear a resolved warning. Strip the sibling from the bundle.
+          const stripped = { ...nextData };
+          delete stripped.persistenceWarning;
+          nextData = normaliseServerSpellingData(stripped, resolveNow());
+        }
         // postMega intentionally not removable — sticky by contract.
       },
     },
@@ -355,6 +390,13 @@ export function createServerSpellingEngine({
       } else if (command === 'reset-learner') {
         service.resetLearner(learnerId);
         transition = buildTransition(createInitialSpellingState());
+      } else if (command === 'acknowledge-persistence-warning') {
+        // P2 U9: durable-warning acknowledgement. Service sets
+        // `data.persistenceWarning.acknowledged: true` but keeps the record
+        // for audit. Worker twin honours the same contract so remote-sync
+        // learners can dismiss the banner without a local-storage write.
+        service.acknowledgePersistenceWarning(learnerId);
+        transition = buildTransition(currentState, { events: [], audio: null });
       } else {
         throw new BadRequestError('Unsupported spelling command.', {
           code: 'spelling_command_unsupported',


### PR DESCRIPTION
## Summary

- Migrates the spelling storage-failure banner from the session-scoped `feedback.persistenceWarning` (which died on tab close) to a durable `data.persistenceWarning` sibling that survives across sessions.
- Banner renders on both setup + session scenes with "I understand" acknowledge button; mega is never demoted on any failure path.
- Bounded retry + `console.warn` fallback means a broken storage can never crash the submit path.

## What changed

**Durable sibling contract:** `data.persistenceWarning = { reason, occurredAt, acknowledged: false }`. Extended through `normaliseSpellingSubjectData` (client) and `normaliseServerSpellingData` (Worker) with a new `ks2-spell-persistence-warning-` storage prefix, routed through the existing subject-state bundle. Follows the P2 U2 sticky-graduation pattern — client + Worker byte-identical, per-learner suffix.

**Service layer:** `writePersistenceWarning(learnerId, reason)` called from every submit path where a `saveJson` failure is detected (Guardian correct/wrong, smart-review, SATs, "I don't know"). Bounded to one retry, then falls through to `console.warn` so a hostile storage never crashes the app. `acknowledgePersistenceWarning(learnerId)` flips `acknowledged: true` while preserving `reason` + `occurredAt` for audit. `getPersistenceWarning(learnerId)` is the read-side helper for `buildSpellingContext`. A subsequent new failure overwrites `occurredAt` and resets `acknowledged: false` so the banner re-surfaces.

**Dispatcher parity:** `spelling-acknowledge-persistence-warning` action wired in BOTH `module.js` (local) and `remote-actions.js` (remote-sync), with a matching `acknowledge-persistence-warning` Worker command twin. Follows the U2 plan's module.js + remote-actions.js parity rule.

**UI:** `SpellingSessionScene` + `SpellingSetupScene` render the banner using the existing `.card` + warn palette, with a new `SPELLING_DURABLE_PERSISTENCE_WARNING_COPY` constant: *"Your progress could not be saved on this device. Export your data or free up storage."* Banner reads `data.persistenceWarning` via `buildSpellingContext` and hides instantly on `acknowledged === true` (record retained for audit).

**Reset hygiene:** `resetLearner` clears the persistence-warning sibling (best-effort try/catch) so a fresh learner does not inherit a previous learner's banner.

## Test plan

- `tests/spelling-persistence-warning.test.js` (new, 17 tests): normaliser shape, client + worker twin parity, happy path, durable survival across fresh service instances (tab-close simulation via real `createLocalPlatformRepositories`), acknowledge preserves audit fields, subsequent-failure-unacknowledged bumps `occurredAt`, subsequent-failure-after-ack resets `acknowledged: false`, bounded-retry + `console.warn` fallback never throws, Worker command acknowledge-persistence-warning parity, Mega stage=4 preserved through storage failure.
- `tests/react-spelling-scene-spike.test.js`: migrated the U8 session-scene banner tests from patching `feedback.persistenceWarning` to seeding `data.persistenceWarning` through the repository (fixture now matches the U9 service contract).
- Plan-specified tests green: `tests/spelling-persistence-warning.test.js` `tests/spelling-guardian.test.js` `tests/react-spelling-surface.test.js` `tests/persistence.test.js` `tests/spelling-parity.test.js` `tests/server-spelling-engine-parity.test.js` — 262/262 pass.
- Broader suites verified green: `tests/spelling.test.js` `tests/spelling-sticky-graduation.test.js` `tests/spelling-mega-invariant.test.js` `tests/spelling-boss.test.js` `tests/spelling-post-mastery-debug.test.js` `tests/repositories.test.js` `tests/state-integrity.test.js` `tests/store.test.js` `tests/spelling-optimistic-prefs.test.js` `tests/spelling-content.test.js` `tests/subject-contract.test.js`.