### PR TITLE
feat(punctuation): U4 — client telemetry emitter (12-kind allowlist)

### DIFF
--- a/src/subjects/punctuation/command-actions.js
+++ b/src/subjects/punctuation/command-actions.js
@@ -64,6 +64,35 @@ export function createPunctuationOnCommandError({
     if (context?.command === 'save-prefs') {
       store.updateSubjectUi('punctuation', { prefsMigrated: false });
     }
+    // Phase 4 U4 BLOCKER fix (convergent adversarial + correctness finding on
+    // PR #280). Cascade identified: Setup mount → `card-opened` telemetry
+    // emit → `punctuation-record-event` dispatch → Worker
+    // `PUNCTUATION_COMMANDS` allowlist at
+    // `worker/src/subjects/punctuation/commands.js:13` does NOT yet include
+    // `record-event` (U9 scope) → rejection with
+    // `subject_command_not_found` → without this short-circuit,
+    // `setSubjectError` would paint a red `Subject message: Punctuation
+    // command is not available.` banner on every Setup mount (and re-paint
+    // it on every session-back because `cardOpenedRef` is per-mount).
+    //
+    // Telemetry is FIRE-AND-FORGET by design (plan R10 / R11). A dispatch
+    // failure must never surface to the learner. Emit a dev-only
+    // console.debug for ops visibility, then early-return BEFORE the
+    // shared `setSubjectError` path fires.
+    //
+    // Matches the `save-prefs` bespoke branch precedent above (which
+    // adjusts ui state before the shared surfacing path). Difference: this
+    // branch also SKIPS the shared surfacing path entirely.
+    if (context?.action === 'punctuation-record-event' || context?.command === 'record-event') {
+      if (typeof console !== 'undefined' && typeof console?.debug === 'function') {
+        const code = error?.payload?.code || error?.code || '';
+        console.debug('[punctuation.telemetry] record-event dispatch failed', {
+          code,
+          action: context?.action || '',
+        });
+      }
+      return;
+    }
     setSubjectError(error?.payload?.message || error?.message || fallbackMessage);
   };
 }
@@ -154,9 +183,12 @@ export const punctuationSubjectCommandActions = Object.freeze({
   // Today (pre-U9), the Worker's `PUNCTUATION_COMMANDS` list at
   // `worker/src/subjects/punctuation/commands.js:13` does NOT yet
   // include `record-event`, so a real Worker round-trip returns
-  // `subject_command_not_found`. That failure is logged via
-  // `createPunctuationOnCommandError` but never propagates to the
-  // learner — telemetry is fire-and-forget by design.
+  // `subject_command_not_found`. That failure is short-circuited inside
+  // `createPunctuationOnCommandError` (see the
+  // `action === 'punctuation-record-event'` early-return branch) so it
+  // is NEVER surfaced to the learner — telemetry is fire-and-forget by
+  // design. Without that short-circuit, the shared `setSubjectError`
+  // path would paint a red banner on every Setup mount.
   'punctuation-record-event': {
     mutates: false,
     command: 'record-event',

--- a/src/subjects/punctuation/command-actions.js
+++ b/src/subjects/punctuation/command-actions.js
@@ -1,4 +1,5 @@
 import { parseChoiceIndex } from '../../../shared/punctuation/choice-index.js';
+import { sanitisePunctuationTelemetryPayload } from './telemetry.js';
 
 export function punctuationSubmitAnswerPayload(data = {}) {
   if (data?.formData?.get) return { typed: data.formData.get('typed') || '' };
@@ -130,6 +131,46 @@ export const punctuationSubjectCommandActions = Object.freeze({
     command: 'save-prefs',
     payload({ data }) {
       return { prefs: { mode: data?.value || data?.mode || 'smart' } };
+    },
+  },
+  // Phase 4 U4 — client-side telemetry emission hook.
+  //
+  // `mutates: false` is the same signal that `punctuation-context-pack`
+  // above uses (line ~120). It bypasses the read-only guard in
+  // `createSubjectCommandActionHandler` (so a degraded-sync learner can
+  // still emit observability signal) AND — by routing through the
+  // command-actions mapping rather than `punctuationModule.handleAction`
+  // — it keeps the dispatch off the `runPunctuationSessionCommand`
+  // pending-wrapper path (so telemetry emission never stalls the
+  // learner's active interaction).
+  //
+  // **Authz invariant (R10 / R11):** the `{ mutates: false }` flag is
+  // CLIENT-SIDE ONLY. The dispatch still routes through
+  // `subjectCommands.send(...)` → the `/api/subjects/punctuation/command`
+  // endpoint → `repository.runSubjectCommand` → `requireLearnerWriteAccess`
+  // at `worker/src/repository.js:4919`. When U9 lands the Worker
+  // `record-event` handler, that authz chain fires unchanged.
+  //
+  // Today (pre-U9), the Worker's `PUNCTUATION_COMMANDS` list at
+  // `worker/src/subjects/punctuation/commands.js:13` does NOT yet
+  // include `record-event`, so a real Worker round-trip returns
+  // `subject_command_not_found`. That failure is logged via
+  // `createPunctuationOnCommandError` but never propagates to the
+  // learner — telemetry is fire-and-forget by design.
+  'punctuation-record-event': {
+    mutates: false,
+    command: 'record-event',
+    payload({ data }) {
+      // Defence-in-depth: re-run the per-kind allowlist here even if the
+      // caller went through `emitPunctuationEvent`. A rogue dispatch that
+      // bypasses the emitter (direct `actions.dispatch(...)` with a raw
+      // payload) still gets stripped to the allowlisted shape before the
+      // Worker round-trip fires.
+      const { event, payload } = sanitisePunctuationTelemetryPayload(
+        data?.kind,
+        data?.payload,
+      );
+      return { event, payload };
     },
   },
 });

--- a/src/subjects/punctuation/components/PunctuationSetupScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationSetupScene.jsx
@@ -52,6 +52,7 @@ import {
   punctuationPrimaryModeFromPrefs,
 } from './punctuation-view-model.js';
 import { progressForPunctuationMonster } from '../../../platform/game/mastery/punctuation.js';
+import { emitPunctuationEvent } from '../telemetry.js';
 
 // The 6 Phase 2 cluster mode ids + `guided` — the set that triggers the
 // one-shot stored-prefs migration. Local to this scene because the
@@ -273,6 +274,30 @@ export function PunctuationSetupScene({ ui, actions, prefs, stats, learner, rewa
   // `legacyCluster` is computed from the raw stored mode, not the
   // display collapse, so a reverted state is detected only the first
   // time before `prefsMigrated` latches.
+  // Phase 4 U4 — telemetry smoke integration.
+  //
+  // Setup-mount is the first of 12 telemetry emission sites in the plan's
+  // emission-site table (line 832-842). Firing the `card-opened` event at
+  // render-time (guarded by `cardOpenedRef`) gives U4 a real production
+  // touchpoint; the remaining 11 emission sites land in follow-on units
+  // (Session mount, submit-answer dispatch, feedback render, summary,
+  // map, etc.).
+  //
+  // A useRef gate is used (not useEffect) because `renderToStaticMarkup`
+  // never runs effects. The gate prevents React 18 strict-mode's
+  // double-invoke from firing the emit twice per mount. The emitter is
+  // fire-and-forget and routes through the subject-command-actions
+  // mapping — it cannot stall the render (see `telemetry.js` for the
+  // authz invariant).
+  const cardOpenedRef = useRef(false);
+  if (!cardOpenedRef.current) {
+    cardOpenedRef.current = true;
+    emitPunctuationEvent('card-opened', { cardId: 'smart' }, {
+      actions,
+      learnerId: learner && typeof learner === 'object' ? learner.id : null,
+    });
+  }
+
   const migratedRef = useRef(false);
   const prefsMigrated = Boolean(ui && typeof ui === 'object' && !Array.isArray(ui) && ui.prefsMigrated);
   const storedMode = prefs && typeof prefs === 'object' && !Array.isArray(prefs)

--- a/src/subjects/punctuation/telemetry.js
+++ b/src/subjects/punctuation/telemetry.js
@@ -107,8 +107,11 @@ function buildAllowlistedPayload(kind, payload) {
  * Returns `true` when a dispatch fired, `false` when the kind was not
  * on the whitelist or the context was too degraded to dispatch. The
  * emitter is fire-and-forget: any downstream failure (Worker 4xx / 5xx /
- * network timeout) is handled by the existing `onCommandError` path in
- * `command-actions.js` and never propagates to the learner.
+ * network timeout) is routed through
+ * `createPunctuationOnCommandError`, which has a dedicated early-return
+ * branch for `punctuation-record-event` that short-circuits BEFORE the
+ * shared `setSubjectError` path fires — so telemetry dispatch failures
+ * never surface to the learner.
  *
  * @param {string} kind One of PUNCTUATION_TELEMETRY_EVENT_KINDS.
  * @param {object} payload Raw payload; non-allowlisted fields are stripped.

--- a/src/subjects/punctuation/telemetry.js
+++ b/src/subjects/punctuation/telemetry.js
@@ -1,0 +1,146 @@
+// Phase 4 U4 — Punctuation telemetry emitter (client half).
+//
+// Ships the client-side `emitPunctuationEvent(kind, payload, context)`
+// helper plus the 12-kind event whitelist and per-kind payload allowlist
+// (plan R10). The emitter validates client-side before dispatching
+// `punctuation-record-event` through the subject-command-actions mapping.
+//
+// U9 (future) lands the Worker `record-event` command handler, the D1
+// `punctuation_events` table, the per-event shape enforcement at the
+// Worker boundary, the feature flag, and the docs rewrite. U4 is the
+// client scaffold only — when a dispatch reaches the Worker today, the
+// existing `PUNCTUATION_COMMANDS` allowlist at
+// `worker/src/subjects/punctuation/commands.js:13` will reject it with
+// `subject_command_not_found`; that is the expected no-op until U9.
+//
+// Authz invariant (R10 / R11): the `{ mutates: false }` flag on the
+// `punctuation-record-event` mapping is CLIENT-SIDE ONLY. It bypasses
+// the subject-command-actions read-only guard and keeps the dispatch off
+// the `runPunctuationSessionCommand` pending-wrapper path (so telemetry
+// emission never stalls the child's interaction). It does NOT bypass
+// Worker-side authz: when U9 lands, `repository.runSubjectCommand` still
+// invokes `requireLearnerWriteAccess` at `worker/src/repository.js:4919`.
+// Any implementation shortcut that calls `env.DB.prepare('INSERT ...')`
+// directly from a request handler without routing through
+// `repository.runSubjectCommand` would be a security regression.
+//
+// Per-event-kind allowlist (HIGH security): each of the 12 event kinds
+// has an explicit property allowlist. Catch-all sanitisers are rejected
+// on security grounds (a compromised client could smuggle answer text or
+// prompt text through a denylist). The `answer-submitted` allowlist
+// explicitly excludes `answerText`, `promptText`, and `typed`.
+
+const EVENT_KINDS = Object.freeze([
+  'card-opened',
+  'start-smart-review',
+  'first-item-rendered',
+  'answer-submitted',
+  'feedback-rendered',
+  'summary-reached',
+  'map-opened',
+  'skill-detail-opened',
+  'guided-practice-started',
+  'unit-secured',
+  'monster-progress-changed',
+  'command-failed',
+]);
+
+// Per-event-kind payload allowlist. Shapes sourced verbatim from the
+// plan's Key Technical Decisions table (docs/plans/...p4...:807-820).
+// Worker enforcement of these same shapes lands in U9.
+const PAYLOAD_ALLOWLIST = Object.freeze({
+  'card-opened': Object.freeze(['cardId']),
+  'start-smart-review': Object.freeze(['roundLength']),
+  'first-item-rendered': Object.freeze(['sessionId', 'itemMode']),
+  // No answerText / promptText / typed — security invariant.
+  'answer-submitted': Object.freeze(['sessionId', 'itemId', 'correct']),
+  'feedback-rendered': Object.freeze(['sessionId', 'itemId', 'correct']),
+  'summary-reached': Object.freeze(['sessionId', 'total', 'correct', 'accuracy']),
+  // map-opened carries no payload per plan (empty object).
+  'map-opened': Object.freeze([]),
+  'skill-detail-opened': Object.freeze(['skillId']),
+  'guided-practice-started': Object.freeze(['skillId', 'roundLength']),
+  'unit-secured': Object.freeze(['clusterId', 'monsterId']),
+  'monster-progress-changed': Object.freeze(['monsterId', 'stageFrom', 'stageTo']),
+  // No raw error messages or stack traces — security invariant.
+  'command-failed': Object.freeze(['command', 'errorCode']),
+});
+
+const EVENT_KIND_SET = new Set(EVENT_KINDS);
+
+export const PUNCTUATION_TELEMETRY_EVENT_KINDS = EVENT_KINDS;
+export const PUNCTUATION_TELEMETRY_PAYLOAD_ALLOWLIST = PAYLOAD_ALLOWLIST;
+
+// Strip every field that is not on the per-kind allowlist. Returns a
+// fresh plain object so callers cannot mutate the internal allowlist
+// table. Oversized string fields are capped (256 chars) so a rogue
+// caller cannot push unbounded payloads at the Worker. Non-string /
+// non-number / non-boolean values are dropped — the Worker allowlist
+// (U9) re-validates types, but the client emitter is the first defence.
+function buildAllowlistedPayload(kind, payload) {
+  const allowed = PAYLOAD_ALLOWLIST[kind];
+  if (!allowed) return {};
+  const source = payload && typeof payload === 'object' && !Array.isArray(payload)
+    ? payload
+    : {};
+  const next = {};
+  for (const field of allowed) {
+    if (!Object.prototype.hasOwnProperty.call(source, field)) continue;
+    const raw = source[field];
+    if (raw === null || raw === undefined) continue;
+    if (typeof raw === 'string') {
+      next[field] = raw.length > 256 ? raw.slice(0, 256) : raw;
+    } else if (typeof raw === 'number' && Number.isFinite(raw)) {
+      next[field] = raw;
+    } else if (typeof raw === 'boolean') {
+      next[field] = raw;
+    }
+    // else: drop silently (objects / arrays / functions never pass the
+    // allowlist — the Worker half at U9 would reject them anyway).
+  }
+  return next;
+}
+
+/**
+ * Emit a Punctuation telemetry event.
+ *
+ * Returns `true` when a dispatch fired, `false` when the kind was not
+ * on the whitelist or the context was too degraded to dispatch. The
+ * emitter is fire-and-forget: any downstream failure (Worker 4xx / 5xx /
+ * network timeout) is handled by the existing `onCommandError` path in
+ * `command-actions.js` and never propagates to the learner.
+ *
+ * @param {string} kind One of PUNCTUATION_TELEMETRY_EVENT_KINDS.
+ * @param {object} payload Raw payload; non-allowlisted fields are stripped.
+ * @param {object} context `{ actions, learnerId }`.
+ */
+export function emitPunctuationEvent(kind, payload = {}, context = {}) {
+  if (typeof kind !== 'string' || !EVENT_KIND_SET.has(kind)) return false;
+  const actions = context && typeof context === 'object' ? context.actions : null;
+  if (!actions || typeof actions.dispatch !== 'function') return false;
+  const sanitised = buildAllowlistedPayload(kind, payload);
+  try {
+    actions.dispatch('punctuation-record-event', {
+      kind,
+      payload: sanitised,
+      // mutates:false is the signal the subject-command-actions handler
+      // reads to bypass the read-only guard (mirrors `punctuation-context-pack`).
+      // This flag is CLIENT-SIDE ONLY and does NOT bypass Worker authz.
+      mutates: false,
+    });
+  } catch {
+    // Telemetry must never stall the learner. Swallow dispatch errors.
+    return false;
+  }
+  return true;
+}
+
+// Exported for the command-actions payload builder so both sides apply
+// the same allowlist — defence-in-depth in case a caller dispatches
+// `punctuation-record-event` directly without going through the emitter.
+export function sanitisePunctuationTelemetryPayload(kind, payload) {
+  if (typeof kind !== 'string' || !EVENT_KIND_SET.has(kind)) {
+    return { event: '', payload: {} };
+  }
+  return { event: kind, payload: buildAllowlistedPayload(kind, payload) };
+}

--- a/tests/react-punctuation-telemetry.test.js
+++ b/tests/react-punctuation-telemetry.test.js
@@ -6,7 +6,10 @@ import {
   PUNCTUATION_TELEMETRY_PAYLOAD_ALLOWLIST,
   emitPunctuationEvent,
 } from '../src/subjects/punctuation/telemetry.js';
-import { punctuationSubjectCommandActions } from '../src/subjects/punctuation/command-actions.js';
+import {
+  createPunctuationOnCommandError,
+  punctuationSubjectCommandActions,
+} from '../src/subjects/punctuation/command-actions.js';
 import { createAppHarness } from './helpers/app-harness.js';
 import { installMemoryStorage } from './helpers/memory-storage.js';
 import { renderPunctuationSetupSceneStandalone } from './helpers/punctuation-scene-render.js';
@@ -234,15 +237,181 @@ test('PunctuationSetupScene mount emits a card-opened event with the subject id'
   });
 
   const emitted = calls.filter((entry) => entry.action === 'punctuation-record-event');
-  assert.ok(
-    emitted.some((entry) => entry.data && entry.data.kind === 'card-opened'),
-    `Setup mount must emit a card-opened telemetry event; saw ${JSON.stringify(calls)}`,
+  // Testing FIX follow-on (U4 review): tighten from `.some()` → exact-count
+  // equality so a future regression that fires `card-opened` twice per mount
+  // (e.g. a dropped useRef latch, or a StrictMode dual-invoke leaking through)
+  // fails loudly instead of silently doubling the telemetry volume.
+  const cardOpenedEmits = emitted.filter((entry) => entry.data && entry.data.kind === 'card-opened');
+  assert.strictEqual(
+    cardOpenedEmits.length,
+    1,
+    `Setup mount must emit exactly ONE card-opened telemetry event; saw ${cardOpenedEmits.length} in ${JSON.stringify(calls)}`,
   );
-  const cardOpenedCall = emitted.find((entry) => entry.data && entry.data.kind === 'card-opened');
+  const cardOpenedCall = cardOpenedEmits[0];
   assert.equal(cardOpenedCall.data.mutates, false);
   assert.ok(
     cardOpenedCall.data.payload,
     'card-opened payload must be an object',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Phase 4 U4 review follow-on — testing FIX coverage (HIGH × 2, MEDIUM × 2).
+//
+// The U4 PR shipped the emitter + command-actions mapping + one Setup-mount
+// call site. Reviewers converged on four coverage gaps the original tests
+// missed:
+//
+//   1. HIGH: the `try / catch` swallow at `telemetry.js:122-134` had no test.
+//      A dispatch that throws (e.g. a controller mid-teardown) is supposed to
+//      return `false` without surfacing the error — pin that contract.
+//
+//   2. HIGH: the 256-char string-field cap at `telemetry.js:92` had no test.
+//      A rogue caller pushing a 300-char `skillId` at the Worker would bloat
+//      the U9 `punctuation_events` row without a guard. Pin the cap.
+//
+//   3. BLOCKER regression guard (MEDIUM → promoted): the convergent adv +
+//      correctness finding on PR #280. Without a direct test on
+//      `createPunctuationOnCommandError`, a future refactor could reintroduce
+//      the red-banner cascade. Pin the short-circuit on a
+//      `punctuation-record-event` context.
+//
+//   4. MEDIUM: the `PAYLOAD_ALLOWLIST` freeze contract at `telemetry.js:51`
+//      had no runtime assertion. A future hand-edit that drops `Object.freeze`
+//      on a per-kind entry would let a caller mutate the shared allowlist at
+//      runtime. Pin the freeze at root + per-kind.
+// ---------------------------------------------------------------------------
+
+test('emitPunctuationEvent returns false and does not throw when actions.dispatch throws', () => {
+  // Telemetry invariant (plan R10): fire-and-forget. If `actions.dispatch`
+  // throws mid-dispatch (e.g. the controller tore down between the emit site
+  // and the reducer, or a downstream reducer threw), the emitter must swallow
+  // the error and return `false` — never stall the caller.
+  let result;
+  assert.doesNotThrow(() => {
+    result = emitPunctuationEvent('card-opened', { cardId: 'smart' }, {
+      actions: {
+        dispatch: () => {
+          throw new Error('boom');
+        },
+      },
+      learnerId: 'learner-1',
+    });
+  });
+  assert.strictEqual(result, false, 'dispatch-throws branch must return false');
+});
+
+test('emitPunctuationEvent caps allowlisted string fields at 256 chars', () => {
+  // Plan R10 security invariant: string payload fields are capped at 256
+  // chars before dispatch so a rogue caller cannot push unbounded payloads
+  // at the Worker. The Worker half (U9) re-caps server-side, but the client
+  // emitter is the first line of defence.
+  const calls = [];
+  const longId = 'a'.repeat(300);
+  emitPunctuationEvent('skill-detail-opened', { skillId: longId }, {
+    actions: { dispatch: (action, data) => calls.push({ action, data }) },
+    learnerId: 'learner-1',
+  });
+  assert.strictEqual(calls.length, 1, 'dispatch must fire on a valid kind');
+  assert.strictEqual(
+    calls[0].data.payload.skillId.length,
+    256,
+    'skillId must be truncated to exactly 256 chars',
+  );
+  assert.strictEqual(
+    calls[0].data.payload.skillId,
+    'a'.repeat(256),
+    'truncation must preserve the leading 256 chars verbatim',
+  );
+});
+
+test('PUNCTUATION_TELEMETRY_PAYLOAD_ALLOWLIST is frozen at the root and per-kind', () => {
+  // Defence-in-depth freeze contract (plan R10): the shared allowlist table
+  // and every per-kind entry must be `Object.isFrozen` so a future caller
+  // cannot mutate the table at runtime. Without this pin, a hand-edit that
+  // dropped `Object.freeze` on a per-kind entry would silently open the
+  // door to per-caller allowlist drift.
+  assert.strictEqual(
+    Object.isFrozen(PUNCTUATION_TELEMETRY_PAYLOAD_ALLOWLIST),
+    true,
+    'root allowlist table must be frozen',
+  );
+  for (const kind of PUNCTUATION_TELEMETRY_EVENT_KINDS) {
+    assert.strictEqual(
+      Object.isFrozen(PUNCTUATION_TELEMETRY_PAYLOAD_ALLOWLIST[kind]),
+      true,
+      `allowlist for kind '${kind}' must be frozen`,
+    );
+  }
+});
+
+test('createPunctuationOnCommandError does NOT call setSubjectError for a record-event rejection', () => {
+  // BLOCKER regression guard (convergent adv + correctness finding on PR
+  // #280). Cascade identified: Setup mount → `card-opened` telemetry emit →
+  // `punctuation-record-event` dispatch → Worker
+  // `PUNCTUATION_COMMANDS` allowlist at
+  // `worker/src/subjects/punctuation/commands.js:13` does NOT yet include
+  // `record-event` (U9 scope) → rejection with `subject_command_not_found`.
+  // Without the short-circuit, `setSubjectError` would paint a red
+  // `Subject message: Punctuation command is not available.` banner on every
+  // Setup mount (and re-paint on every session-back).
+  //
+  // Contract: for a rejection landing in `onCommandError` with
+  // `action === 'punctuation-record-event'` (or `command === 'record-event'`)
+  // the handler MUST short-circuit BEFORE calling `setSubjectError`.
+  const setSubjectErrorCalls = [];
+  const updateSubjectUiCalls = [];
+  const onError = createPunctuationOnCommandError({
+    store: {
+      updateSubjectUi(subjectId, patch) {
+        updateSubjectUiCalls.push({ subjectId, patch });
+      },
+    },
+    setSubjectError(message) {
+      setSubjectErrorCalls.push(message);
+    },
+    warn: () => {},
+  });
+  const error = {
+    payload: {
+      code: 'subject_command_not_found',
+      message: 'Punctuation command is not available.',
+    },
+  };
+  onError(error, {
+    action: 'punctuation-record-event',
+    data: { kind: 'card-opened', payload: { cardId: 'smart' } },
+    learnerId: 'learner-1',
+    subjectId: 'punctuation',
+    command: 'record-event',
+    payload: { event: 'card-opened', payload: { cardId: 'smart' } },
+  });
+  assert.strictEqual(
+    setSubjectErrorCalls.length,
+    0,
+    'setSubjectError must NOT fire for a record-event rejection — telemetry is fire-and-forget',
+  );
+  // Non-record-event rejections (e.g. a save-prefs failure) must still
+  // surface — pin the default path stays intact.
+  onError(error, {
+    action: 'punctuation-set-mode',
+    data: {},
+    learnerId: 'learner-1',
+    subjectId: 'punctuation',
+    command: 'save-prefs',
+    payload: {},
+  });
+  assert.strictEqual(
+    setSubjectErrorCalls.length,
+    1,
+    'non-record-event rejections must still surface via setSubjectError',
+  );
+  // The save-prefs branch also clears the prefsMigrated latch — preserved.
+  assert.ok(
+    updateSubjectUiCalls.some(
+      (entry) => entry.subjectId === 'punctuation' && entry.patch && entry.patch.prefsMigrated === false,
+    ),
+    'save-prefs branch must still clear prefsMigrated (preserved behaviour)',
   );
 });
 

--- a/tests/react-punctuation-telemetry.test.js
+++ b/tests/react-punctuation-telemetry.test.js
@@ -1,0 +1,269 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  PUNCTUATION_TELEMETRY_EVENT_KINDS,
+  PUNCTUATION_TELEMETRY_PAYLOAD_ALLOWLIST,
+  emitPunctuationEvent,
+} from '../src/subjects/punctuation/telemetry.js';
+import { punctuationSubjectCommandActions } from '../src/subjects/punctuation/command-actions.js';
+import { createAppHarness } from './helpers/app-harness.js';
+import { installMemoryStorage } from './helpers/memory-storage.js';
+import { renderPunctuationSetupSceneStandalone } from './helpers/punctuation-scene-render.js';
+import { SUBJECT_EXPOSURE_GATES } from '../src/platform/core/subject-availability.js';
+
+// Phase 4 U4 — client-side telemetry emitter for the Punctuation subject.
+//
+// U4 ships the client half only: `emitPunctuationEvent(kind, payload, ctx)`
+// + per-event-kind payload allowlist + a `punctuation-record-event` entry in
+// `punctuationSubjectCommandActions` with `{ mutates: false }` so the dispatch
+// bypasses the read-only guard AND does NOT thread `pendingCommand` (which
+// would block other learner affordances). The Worker-side `record-event`
+// command handler, D1 `punctuation_events` table, query surface, and docs
+// rewrite all land in U9.
+//
+// Authz invariant (R10): the `{ mutates: false }` flag is CLIENT-SIDE ONLY.
+// When U9 lands the Worker handler, `repository.runSubjectCommand` still
+// invokes `requireLearnerWriteAccess` at `worker/src/repository.js:4919`. The
+// flag controls pending-UI wrapping, not authz.
+
+function createDispatchSpy() {
+  const calls = [];
+  const spy = {
+    dispatch(action, data) {
+      calls.push({ action, data });
+    },
+  };
+  return { spy, calls };
+}
+
+function createPunctuationHarness() {
+  return createAppHarness({
+    storage: installMemoryStorage(),
+    subjectExposureGates: { [SUBJECT_EXPOSURE_GATES.punctuation]: true },
+  });
+}
+
+test('emitPunctuationEvent exposes a frozen 12-kind whitelist covering the plan R10 set', () => {
+  assert.equal(Object.isFrozen(PUNCTUATION_TELEMETRY_EVENT_KINDS), true);
+  assert.equal(PUNCTUATION_TELEMETRY_EVENT_KINDS.length, 12);
+  const expected = [
+    'card-opened',
+    'start-smart-review',
+    'first-item-rendered',
+    'answer-submitted',
+    'feedback-rendered',
+    'summary-reached',
+    'map-opened',
+    'skill-detail-opened',
+    'guided-practice-started',
+    'unit-secured',
+    'monster-progress-changed',
+    'command-failed',
+  ];
+  for (const name of expected) {
+    assert.ok(
+      PUNCTUATION_TELEMETRY_EVENT_KINDS.includes(name),
+      `expected event kind '${name}' in the whitelist`,
+    );
+  }
+});
+
+test('emitPunctuationEvent ignores event kinds not on the whitelist', () => {
+  const { spy, calls } = createDispatchSpy();
+  const result = emitPunctuationEvent('unknown-kind', { foo: 'bar' }, {
+    actions: spy,
+    learnerId: 'learner-1',
+  });
+  assert.equal(result, false);
+  assert.equal(calls.length, 0, 'dispatch must NOT fire for an unknown kind');
+});
+
+test('emitPunctuationEvent dispatches punctuation-record-event with the mutates:false flag on a valid kind', () => {
+  const { spy, calls } = createDispatchSpy();
+  const result = emitPunctuationEvent('card-opened', { cardId: 'smart' }, {
+    actions: spy,
+    learnerId: 'learner-1',
+  });
+  assert.equal(result, true);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].action, 'punctuation-record-event');
+  assert.equal(calls[0].data.kind, 'card-opened');
+  assert.deepEqual(calls[0].data.payload, { cardId: 'smart' });
+  assert.equal(calls[0].data.mutates, false);
+});
+
+test('emitPunctuationEvent strips fields not on the per-kind allowlist', () => {
+  const { spy, calls } = createDispatchSpy();
+  emitPunctuationEvent('card-opened', {
+    cardId: 'smart',
+    // These are NOT on the card-opened allowlist and must be stripped.
+    answerText: 'child answer text',
+    sessionId: 's1',
+  }, { actions: spy, learnerId: 'learner-1' });
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0].data.payload, { cardId: 'smart' });
+  assert.equal('answerText' in calls[0].data.payload, false);
+  assert.equal('sessionId' in calls[0].data.payload, false);
+});
+
+test('emitPunctuationEvent strips answerText and prompt text from answer-submitted payloads (security)', () => {
+  // Plan R10 Key Technical Decision: the answer-submitted event MUST NOT
+  // carry raw answer text or prompt text. If a future caller accidentally
+  // includes one, the allowlist must reject / strip it before dispatch.
+  const { spy, calls } = createDispatchSpy();
+  emitPunctuationEvent('answer-submitted', {
+    sessionId: 's1',
+    itemId: 'i1',
+    correct: true,
+    answerText: 'raw child answer',
+    promptText: 'raw prompt text',
+    typed: 'raw typed',
+  }, { actions: spy, learnerId: 'learner-1' });
+  assert.equal(calls.length, 1);
+  const payload = calls[0].data.payload;
+  assert.equal('answerText' in payload, false, 'answerText must be stripped');
+  assert.equal('promptText' in payload, false, 'promptText must be stripped');
+  assert.equal('typed' in payload, false, 'typed must be stripped');
+  assert.deepEqual(payload, { sessionId: 's1', itemId: 'i1', correct: true });
+  // Allowlist exposes the shape explicitly so the Worker half (U9) can
+  // mirror it server-side.
+  assert.deepEqual(
+    PUNCTUATION_TELEMETRY_PAYLOAD_ALLOWLIST['answer-submitted'].slice().sort(),
+    ['correct', 'itemId', 'sessionId'],
+  );
+});
+
+test('emitPunctuationEvent tolerates a missing actions.dispatch gracefully (fire-and-forget)', () => {
+  // Plan R10: telemetry failures must never stall the learner. If the
+  // caller somehow invokes the emitter without an actions object, the
+  // emitter returns false rather than throwing.
+  assert.doesNotThrow(() => emitPunctuationEvent('map-opened', {}, { actions: null }));
+  assert.doesNotThrow(() => emitPunctuationEvent('map-opened', {}, { actions: {} }));
+});
+
+test('punctuationSubjectCommandActions registers punctuation-record-event with mutates:false', () => {
+  // Precedent: `punctuation-context-pack` at command-actions.js:120-128 uses
+  // `mutates: false` to bypass the subject-command-actions read-only gate
+  // WITHOUT bypassing the Worker-side authz chain (which runs in
+  // `repository.runSubjectCommand` → `requireLearnerWriteAccess`).
+  // `punctuation-record-event` must follow the same shape; it is the
+  // client-side hook that U9's Worker handler will fulfil.
+  const entry = punctuationSubjectCommandActions['punctuation-record-event'];
+  assert.ok(entry, 'command-actions must register punctuation-record-event');
+  assert.equal(entry.mutates, false);
+  assert.equal(entry.command, 'record-event');
+  assert.equal(typeof entry.payload, 'function');
+});
+
+test('punctuation-record-event payload builder forwards kind and allowlisted payload verbatim', () => {
+  const entry = punctuationSubjectCommandActions['punctuation-record-event'];
+  const built = entry.payload({ data: { kind: 'card-opened', payload: { cardId: 'smart' } } });
+  assert.equal(built.event, 'card-opened');
+  assert.deepEqual(built.payload, { cardId: 'smart' });
+});
+
+test('punctuation-record-event drops fields not on the per-kind allowlist at the command-actions boundary', () => {
+  // Defence-in-depth: even if a caller bypasses the emitter and dispatches
+  // `punctuation-record-event` directly with a raw payload, the
+  // command-actions payload builder still strips non-allowlisted fields.
+  // This mirrors the emitter behaviour so the Worker (U9) never receives
+  // a smuggled field.
+  const entry = punctuationSubjectCommandActions['punctuation-record-event'];
+  const built = entry.payload({
+    data: {
+      kind: 'answer-submitted',
+      payload: {
+        sessionId: 's1',
+        itemId: 'i1',
+        correct: true,
+        answerText: 'smuggled',
+      },
+    },
+  });
+  assert.equal('answerText' in built.payload, false);
+  assert.deepEqual(built.payload, { sessionId: 's1', itemId: 'i1', correct: true });
+});
+
+test('punctuation-record-event rejects an unknown kind at the command-actions boundary', () => {
+  const entry = punctuationSubjectCommandActions['punctuation-record-event'];
+  const built = entry.payload({ data: { kind: 'unknown-kind', payload: { foo: 'bar' } } });
+  // Unknown kind → payload builder returns a benign shape that the Worker
+  // will refuse at U9's allowlist gate. No exception, no thrown error —
+  // telemetry must never stall the UI.
+  assert.equal(built.event, '');
+  assert.deepEqual(built.payload, {});
+});
+
+test('PunctuationSetupScene mount emits a card-opened event with the subject id', () => {
+  // Smoke integration: U4 wires ONE call site (Setup mount) so the emitter
+  // has production reach beyond the unit tests above. The remaining 11
+  // event kinds land in follow-on units per the plan's emission-site
+  // table (plan line 832-842).
+  //
+  // Uses `renderPunctuationSetupSceneStandalone` (the standalone SSR
+  // renderer at `tests/helpers/punctuation-scene-render.js`) because
+  // `renderToStaticMarkup` drives the same render-time emit path as
+  // production React; the app-harness's `render()` path builds its
+  // `actions` object from the internal `controller.dispatch` reference
+  // and so cannot surface a dispatch spy without deeper wiring.
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  const appState = harness.store.getState();
+  const learnerId = appState.learners.selectedId;
+  const learner = learnerId ? appState.learners.byId[learnerId] : null;
+  const ui = appState.subjectUi.punctuation;
+  const prefs = harness.services.punctuation.getPrefs(learnerId);
+  const stats = harness.services.punctuation.getStats(learnerId);
+
+  const calls = [];
+  const actions = {
+    dispatch(action, data) {
+      calls.push({ action, data });
+    },
+    updateSubjectUi() {},
+  };
+
+  renderPunctuationSetupSceneStandalone({
+    ui,
+    actions,
+    prefs,
+    stats,
+    learner,
+    rewardState: null,
+  });
+
+  const emitted = calls.filter((entry) => entry.action === 'punctuation-record-event');
+  assert.ok(
+    emitted.some((entry) => entry.data && entry.data.kind === 'card-opened'),
+    `Setup mount must emit a card-opened telemetry event; saw ${JSON.stringify(calls)}`,
+  );
+  const cardOpenedCall = emitted.find((entry) => entry.data && entry.data.kind === 'card-opened');
+  assert.equal(cardOpenedCall.data.mutates, false);
+  assert.ok(
+    cardOpenedCall.data.payload,
+    'card-opened payload must be an object',
+  );
+});
+
+test('punctuation-record-event does NOT thread pendingCommand (non-stalling UI)', () => {
+  // Plan R10 risk row: telemetry emits must never stall the UI via
+  // `pendingCommand`. The `{ mutates: false }` flag on the mapping keeps
+  // the dispatch off the `runPunctuationSessionCommand` path. If a caller
+  // emits telemetry during an active session, `ui.pendingCommand` stays
+  // unchanged.
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.render();
+  const before = harness.store.getState().subjectUi.punctuation.pendingCommand || '';
+  emitPunctuationEvent('map-opened', {}, {
+    actions: { dispatch: (action, data) => harness.dispatch(action, data) },
+    learnerId: harness.store.getState().learners.selectedId,
+  });
+  const after = harness.store.getState().subjectUi.punctuation.pendingCommand || '';
+  assert.equal(
+    after,
+    before,
+    'telemetry emit must not set pendingCommand (non-stalling UI invariant)',
+  );
+});


### PR DESCRIPTION
## Summary

Phase 4 U4 ships the **client-side** half of Punctuation telemetry: a subject-local `emitPunctuationEvent(kind, payload, context)` helper with a 12-kind whitelist and per-kind payload allowlist, wired through a new `punctuation-record-event` entry in `punctuationSubjectCommandActions` with `{ mutates: false }` (mirrors the `punctuation-context-pack` precedent).

- **Client emitter** (`src/subjects/punctuation/telemetry.js`): 12-kind frozen whitelist + per-kind property allowlist + oversized-string cap (256 chars) + type-safe value filter. `answer-submitted` payload explicitly excludes `answerText`, `promptText`, `typed` (security invariant).
- **Command-actions mapping** (`src/subjects/punctuation/command-actions.js`): registers `punctuation-record-event` with `{ mutates: false, command: 'record-event' }`. Payload builder re-runs the allowlist (defence-in-depth) so a direct dispatch bypass still strips smuggled fields.
- **Smoke integration** (`src/subjects/punctuation/components/PunctuationSetupScene.jsx`): Setup-mount emits `card-opened` via a `useRef`-guarded render-time call (mirrors the `migratedRef` pattern). Remaining 11 emission sites wire in follow-on units.

## Authz invariant (R10 / R11) — preserved

`{ mutates: false }` is **CLIENT-SIDE ONLY**. It bypasses:
1. The `createSubjectCommandActionHandler` read-only guard at `src/platform/runtime/subject-command-actions.js:43` — so a degraded-sync learner can still emit observability signal.
2. The `runPunctuationSessionCommand` pending-command wrapper path in `module.js:52-60` — because the dispatch is handled by the command-actions mapping rather than falling through to `module.handleAction`. Telemetry emission therefore cannot stall the child's active interaction.

It does **NOT** bypass:
- Worker-side `repository.runSubjectCommand` at `worker/src/repository.js:5144` → `requireLearnerWriteAccess` at `worker/src/repository.js:4919`. When U9 lands the Worker `record-event` handler, that authz chain fires unchanged.

Pre-U9, a real Worker round-trip returns `subject_command_not_found` (the existing `PUNCTUATION_COMMANDS` allowlist at `worker/src/subjects/punctuation/commands.js:13` does not yet include `record-event`). That failure is logged via `createPunctuationOnCommandError` but never propagates to the learner — telemetry is fire-and-forget by design.

## Scope boundaries honoured (U4 vs U9)

U4 ships ONLY:
- `src/subjects/punctuation/telemetry.js` (new)
- `src/subjects/punctuation/command-actions.js` (add `punctuation-record-event` mapping)
- `src/subjects/punctuation/components/PunctuationSetupScene.jsx` (one emission site)
- `tests/react-punctuation-telemetry.test.js` (new, 12 tests)

U4 does **NOT** touch (all are U9's scope):
- `worker/src/subjects/punctuation/commands.js` — `record-event` handler.
- `worker/migrations/0011_punctuation_events.sql` — D1 schema.
- Worker-side per-event allowlist rejection at the D1 boundary.
- `PUNCTUATION_EVENTS_ENABLED` feature flag.
- Query surface / dashboards.
- `docs/punctuation-production.md` rewrite (Wired vs Aspirational).

U4 also does NOT touch (all are out of P4 scope or U5-U8):
- Oracle (`tests/punctuation-legacy-parity.test.js`) — byte-for-byte preserved.
- Engine (`shared/punctuation/marking.js`, `generators.js`, `scheduler.js`, `content.js`).
- Home / Map / Summary surfaces (U5/U6).
- `contentReleaseId` — unchanged (R11).
- Any new npm devDeps.

## Test plan

- [x] `npm test -- tests/react-punctuation-telemetry.test.js` — 12/12 green.
- [x] `npm test -- tests/react-punctuation-scene.test.js tests/react-punctuation-telemetry.test.js tests/punctuation-legacy-parity.test.js` — 175/175 green (oracle replay preserved).
- [x] `npm test -- tests/bundle-audit.test.js tests/punctuation-read-models.test.js tests/react-punctuation-child-copy.test.js` — 85/85 green.
- [x] `npm test -- tests/punctuation-view-model.test.js tests/punctuation-map-phase.test.js tests/react-punctuation-assets.test.js` — 125/125 green.
- [x] `npm test` (full suite, background) — exit code 0.

## Key test scenarios

1. Whitelist enforcement: `emitPunctuationEvent('unknown-kind', {}, ctx)` returns `false`; no dispatch.
2. Dispatch shape: valid emit produces `{action: 'punctuation-record-event', data: {kind, payload, mutates: false}}`.
3. Per-kind allowlist: `card-opened` with extra `answerText` strips the extra field.
4. Answer-submitted security: `answerText` / `promptText` / `typed` are stripped; payload reduces to `{sessionId, itemId, correct}`.
5. Fire-and-forget: missing / null `actions` does not throw.
6. Command-actions mapping: registered with `mutates: false`, `command: 'record-event'`.
7. Payload-builder defence-in-depth: direct dispatch with smuggled field still strips.
8. Unknown kind at command-actions boundary returns benign `{event: '', payload: {}}`.
9. Setup-mount SSR smoke: `renderPunctuationSetupSceneStandalone` with a dispatch spy captures a `card-opened` emit with `mutates: false`.
10. Non-stalling UI: `pendingCommand` unchanged after telemetry emit during active session.
11. 12-kind whitelist matches plan R10 set exactly; list is frozen.
12. `answer-submitted` allowlist exposes only `['correct', 'itemId', 'sessionId']`.

## release-id impact: none

No `PUNCTUATION_CONTENT_RELEASE_ID` bump. Telemetry emit is a passive observation — no change to content, scoring, mastery, marking, or the read-model shape. `FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS` unchanged (extension for the `punctuation_events` payload lands in U9).

## Requirements traced

- **R10** (client half): emitter + 12-kind whitelist + per-kind payload allowlist + `punctuation-record-event` action + `{mutates: false}` client-side behaviour.
- **R11**: `contentReleaseId` unchanged; dispatch routes through subject-command-client (so U9's Worker handler will inherit `requireLearnerWriteAccess`); oracle replay preserved.
- **R12**: no Phase 3 invariant regression — no new phase handler added, no `PUNCTUATION_PHASES` change, no `mapUi` / `phase: 'map'` rehydrate delta.

Refs: `docs/plans/2026-04-26-001-feat-punctuation-phase4-visible-child-journey-plan.md` §U9 (task's U4).