### PR TITLE
feat(grammar): U7 Parent/Admin hub confidence chips

### DIFF
--- a/src/platform/hubs/parent-read-model.js
+++ b/src/platform/hubs/parent-read-model.js
@@ -33,6 +33,16 @@ function orderDueWork(entries = []) {
     .sort((a, b) => Number(isActionableFocus(b)) - Number(isActionableFocus(a)));
 }
 
+// Phase 4 U7: `conceptStatus`, `dueConcepts`, and `weakConcepts` each
+// contain concept rows whose client read-model projection now includes a
+// `confidence: { label, sampleSize, intervalDays, distinctTemplates,
+// recentMisses }` sub-object (see `src/subjects/grammar/read-model.js`
+// `normaliseConceptRow`). The pass-through is structural — each array is
+// forwarded verbatim — so Parent Hub + Admin Hub inherit the confidence
+// projection without any additional shaping work here. The `AdultConfidenceChip`
+// component consumes `confidence` directly. Child surfaces never read the
+// `confidence` field (they use `grammarChildConfidenceLabel` from the
+// view-model).
 function grammarEvidenceFromReadModel(grammar = {}) {
   return {
     subjectId: 'grammar',

--- a/src/subjects/grammar/components/AdultConfidenceChip.jsx
+++ b/src/subjects/grammar/components/AdultConfidenceChip.jsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { isGrammarConfidenceLabel } from '../../../../shared/grammar/confidence.js';
+
+// Phase 4 U7: the AdultConfidenceChip lives in its own module so every adult
+// surface (GrammarAnalyticsScene, ParentHubSurface, AdminHubSurface) can import
+// it directly. Extracted verbatim (in behaviour) from
+// `GrammarAnalyticsScene.jsx` at the inline declaration that previously lived
+// at lines 88-124. Two important deltas from the pre-U7 inline version:
+//
+//   1. Accepts a structured `confidence` prop — `{ label, sampleSize,
+//      intervalDays, distinctTemplates, recentMisses }` — rather than an
+//      opaque `row`. The shape matches Worker's read-model projection and the
+//      client read-model output (U7 extends the client read-model to produce
+//      it).  The chip is now a pure renderer of that projection, not a
+//      collection of row-normalisation heuristics.
+//   2. Out-of-taxonomy labels render `'Unknown'` with a neutral tone — NEVER
+//      silently fall back to `'emerging'`. The pre-U7 inline version defaulted
+//      to `'emerging'`, which silently hid emission drift. Named in the plan
+//      under R17.
+//
+// Child surfaces MUST NOT import this component — grammar-view-model.js
+// provides the child-facing label mapping (`grammarChildConfidenceLabel`).
+// See `tests/grammar-parent-hub-confidence.test.js` for the regression lock
+// that greps child surfaces for any import of this module.
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normaliseCount(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric >= 0 ? Math.floor(numeric) : 0;
+}
+
+// Convert a raw `confidence` projection into a renderable shape. Returns
+// null when there is no signal to surface at all — callers then render
+// nothing. Any non-canonical label is coerced to `'unknown'` so the chip
+// renders the neutral `'Unknown'` tone; the plan names this behaviour
+// explicitly as a contrast with the pre-U7 silent fallback to `'emerging'`.
+function normaliseConfidence(confidence) {
+  if (!isPlainObject(confidence)) return null;
+  const rawLabel = typeof confidence.label === 'string' ? confidence.label : '';
+  const canonical = isGrammarConfidenceLabel(rawLabel);
+  const label = canonical ? rawLabel : (rawLabel ? 'unknown' : '');
+  const sampleSize = normaliseCount(confidence.sampleSize);
+  if (!label && sampleSize <= 0) return null;
+  return {
+    label: label || 'emerging',
+    sampleSize,
+    canonical,
+    intervalDays: Number.isFinite(Number(confidence.intervalDays))
+      ? Math.max(0, Number(confidence.intervalDays)) : 0,
+    distinctTemplates: normaliseCount(confidence.distinctTemplates),
+    recentMisses: normaliseCount(confidence.recentMisses),
+  };
+}
+
+/**
+ * Renders an adult-facing confidence chip.
+ *
+ * Output format (flat text inside a single `<span>`) matches the pre-U7
+ * inline chip: `"<label> &middot; <N> attempt(s)"`. Admin surfaces that
+ * pass `showAdminExtras` also get `" &middot; <N>d spacing &middot; <N>
+ * template(s)"`. Recent-miss counts are appended when positive. Keeping
+ * the text flat (no nested spans between label and sample count) lets
+ * existing Phase 3 U7 tests on `GrammarAnalyticsScene` keep matching
+ * their regex patterns unchanged — the extraction is a refactor, not a
+ * text-shape change.
+ *
+ * @param {object} props
+ * @param {object|null} props.confidence - `{ label, sampleSize,
+ *   intervalDays, distinctTemplates, recentMisses }` projection from a
+ *   client or Worker grammar read model. `null` renders nothing.
+ * @param {boolean} [props.showAdminExtras=false] - when true, render the
+ *   admin-only extras: `intervalDays` and `distinctTemplates`. Parent Hub
+ *   leaves this off so parents see the headline label + sample context
+ *   only.
+ */
+export function AdultConfidenceChip({ confidence, showAdminExtras = false }) {
+  const normalised = normaliseConfidence(confidence);
+  if (!normalised) return null;
+  const displayLabel = normalised.canonical ? normalised.label : 'Unknown';
+  const sampleSuffix = normalised.sampleSize === 1 ? 'attempt' : 'attempts';
+  const missSuffix = normalised.recentMisses === 1 ? 'miss' : 'misses';
+  const toneClass = normalised.canonical ? normalised.label : 'unknown';
+  const parts = [`${displayLabel} · ${normalised.sampleSize} ${sampleSuffix}`];
+  if (normalised.recentMisses > 0) {
+    parts.push(`${normalised.recentMisses} recent ${missSuffix}`);
+  }
+  if (showAdminExtras) {
+    parts.push(`${normalised.intervalDays}d spacing`);
+    parts.push(`${normalised.distinctTemplates} template${normalised.distinctTemplates === 1 ? '' : 's'}`);
+  }
+  return (
+    <span
+      className={`grammar-adult-confidence ${toneClass}`}
+      data-confidence-label={displayLabel}
+      data-sample-size={normalised.sampleSize}
+      data-recent-misses={normalised.recentMisses}
+      data-interval-days={normalised.intervalDays}
+      data-distinct-templates={normalised.distinctTemplates}
+    >
+      {parts.join(' · ')}
+    </span>
+  );
+}
+
+// Back-compat helper — existing callers that render chips from a concept-row
+// shape (e.g. `GrammarAnalyticsScene.jsx`'s evidence-summary grid) can keep
+// their call site unchanged while the chip itself consumes the richer prop.
+// Accepts `{ confidence, confidenceLabel, attempts }` style shapes — the
+// canonical path is the `confidence` sub-object.
+export function adultConfidenceFromRow(row) {
+  if (!row || typeof row !== 'object') return null;
+  if (isPlainObject(row.confidence)) return row.confidence;
+  if (typeof row.confidenceLabel === 'string' && row.confidenceLabel) {
+    return {
+      label: row.confidenceLabel,
+      sampleSize: Number(row.attempts) || 0,
+    };
+  }
+  if (Number(row.attempts) > 0) {
+    return { label: 'emerging', sampleSize: Number(row.attempts) };
+  }
+  return null;
+}

--- a/src/subjects/grammar/components/GrammarAnalyticsScene.jsx
+++ b/src/subjects/grammar/components/GrammarAnalyticsScene.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { isGrammarConfidenceLabel } from '../../../../shared/grammar/confidence.js';
+import { AdultConfidenceChip, adultConfidenceFromRow } from './AdultConfidenceChip.jsx';
 import { progressForGrammarMonster } from '../../../platform/game/monster-system.js';
 import { monsterAsset, monsterAssetSrcSet } from '../../../platform/game/monsters.js';
 import {
@@ -85,42 +85,11 @@ function ParentSummaryDraft({ enrichment }) {
   );
 }
 
-// Phase 3 U7: confidence chips surface the Worker's internal 5-label taxonomy
-// (emerging / building / needs-repair / consolidating / secure) plus the
-// sample size. Adult copy only — child surfaces keep the friendly mapping in
-// `grammar-view-model.js`. Accepts either Worker's new `confidence: {label,
-// sampleSize}` shape or the older flat `confidenceLabel` that some fixtures
-// still seed; falls back to `status` if neither is present so the chip always
-// renders something diagnostic.
-//
-// The set of valid labels comes from `shared/grammar/confidence.js`
-// (U8) — this component only validates, never redefines.
-function adultConfidenceFromRow(row) {
-  if (!row || typeof row !== 'object') return null;
-  const confidence = isPlainObject(row.confidence) ? row.confidence : null;
-  const rawLabel = (typeof confidence?.label === 'string' && confidence.label)
-    || (typeof row.confidenceLabel === 'string' && row.confidenceLabel)
-    || '';
-  const label = isGrammarConfidenceLabel(rawLabel) ? rawLabel : '';
-  const rawSample = confidence?.sampleSize ?? row.attempts;
-  const sampleSize = Number.isFinite(Number(rawSample)) ? Number(rawSample) : 0;
-  if (!label && sampleSize <= 0) return null;
-  return { label: label || 'emerging', sampleSize };
-}
-
-function AdultConfidenceChip({ row }) {
-  const confidence = adultConfidenceFromRow(row);
-  if (!confidence) return null;
-  const suffix = confidence.sampleSize === 1 ? 'attempt' : 'attempts';
-  return (
-    <span
-      className={`grammar-adult-confidence ${confidence.label}`}
-      data-confidence-label={confidence.label}
-      data-sample-size={confidence.sampleSize}
-    >
-      {confidence.label} &middot; {confidence.sampleSize} {suffix}
-    </span>
-  );
+// Phase 3 U7: the adult confidence chip now lives in its own module at
+// `./AdultConfidenceChip.jsx` so Parent Hub + Admin Hub can import it too.
+// Scene-local helper keeps the existing evidence-row call sites unchanged.
+function SceneConfidenceChip({ row }) {
+  return <AdultConfidenceChip confidence={adultConfidenceFromRow(row)} />;
 }
 
 export function GrammarAnalyticsScene({
@@ -237,7 +206,7 @@ export function GrammarAnalyticsScene({
                     data-concept-id={concept.id}
                   >
                     <span className="grammar-mini-concept-name">{concept.name}</span>
-                    <AdultConfidenceChip row={concept} />
+                    <SceneConfidenceChip row={concept} />
                   </span>
                 ))}
               </div>
@@ -296,7 +265,7 @@ export function GrammarAnalyticsScene({
                 <li key={entry.id} data-question-type-id={entry.id}>
                   <strong>{entry.label}</strong>
                   <span>{entry.correct || 0}/{entry.attempts || 0} correct &middot; {entry.status || 'learning'}</span>
-                  <AdultConfidenceChip row={entry} />
+                  <SceneConfidenceChip row={entry} />
                 </li>
               ))}
             </ol>

--- a/src/subjects/grammar/read-model.js
+++ b/src/subjects/grammar/read-model.js
@@ -1,4 +1,8 @@
-import { grammarConceptStatus } from '../../../shared/grammar/confidence.js';
+import {
+  deriveGrammarConfidence,
+  GRAMMAR_RECENT_ATTEMPT_HORIZON,
+  grammarConceptStatus,
+} from '../../../shared/grammar/confidence.js';
 import { GRAMMAR_CLIENT_CONCEPTS } from './metadata.js';
 
 const QUESTION_TYPE_LABELS = Object.freeze({
@@ -84,12 +88,76 @@ function sortTop(entries, scoreFn, limit = 3) {
     .slice(0, limit);
 }
 
-function normaliseConceptRow(rawValue, concept, nowTs) {
+// Phase 4 U7: recent-window helpers mirror the Worker read-model
+// (`worker/src/subjects/grammar/read-models.js` recentMissCountForConcept +
+// distinctTemplatesFor). Aligned to GRAMMAR_RECENT_ATTEMPT_HORIZON so
+// `distinctTemplates` and `recentMisses` are directly comparable "recent"
+// signals — same contract as Worker.
+function recentAttemptsWindow(recentAttempts) {
+  return Array.isArray(recentAttempts)
+    ? recentAttempts.slice(-GRAMMAR_RECENT_ATTEMPT_HORIZON)
+    : [];
+}
+
+function recentMissCountForConceptId(recentAttempts, conceptId) {
+  if (!conceptId) return 0;
+  let count = 0;
+  for (const attempt of recentAttemptsWindow(recentAttempts)) {
+    const conceptIds = Array.isArray(attempt?.conceptIds) ? attempt.conceptIds : [];
+    const result = isPlainObject(attempt?.result) ? attempt.result : {};
+    if (conceptIds.includes(conceptId) && result.correct === false) count += 1;
+  }
+  return count;
+}
+
+function distinctTemplatesForConceptId(recentAttempts, conceptId) {
+  if (!conceptId) return 0;
+  const seen = new Set();
+  for (const attempt of recentAttemptsWindow(recentAttempts)) {
+    const conceptIds = Array.isArray(attempt?.conceptIds) ? attempt.conceptIds : [];
+    if (conceptIds.includes(conceptId) && typeof attempt?.templateId === 'string' && attempt.templateId) {
+      seen.add(attempt.templateId);
+    }
+  }
+  return seen.size;
+}
+
+function confidenceForConcept({
+  conceptId, status, attempts, strength, correctStreak, intervalDays, recentAttempts,
+}) {
+  const recentMisses = recentMissCountForConceptId(recentAttempts, conceptId);
+  const distinctTemplates = distinctTemplatesForConceptId(recentAttempts, conceptId);
+  const label = deriveGrammarConfidence({
+    status, attempts, strength, correctStreak, intervalDays, recentMisses,
+  });
+  return {
+    label,
+    sampleSize: attempts,
+    intervalDays,
+    distinctTemplates,
+    recentMisses,
+  };
+}
+
+function normaliseConceptRow(rawValue, concept, nowTs, recentAttempts = []) {
   const raw = isPlainObject(rawValue) ? rawValue : {};
   const node = normaliseMasteryNode(raw);
   const status = VALID_CONCEPT_STATUSES.has(raw.status)
     ? raw.status
     : grammarConceptStatus(node, nowTs);
+  // Phase 4 U7: client read-model now emits per-concept `confidence` via the
+  // shared `deriveGrammarConfidence`. Parent Hub + Admin Hub read this field
+  // (they receive the client read-model, NOT the Worker payload). Without
+  // this extension adult hubs have no access to the confidence projection.
+  const confidence = confidenceForConcept({
+    conceptId: concept.id,
+    status,
+    attempts: node.attempts,
+    strength: node.strength,
+    correctStreak: node.correctStreak,
+    intervalDays: node.intervalDays,
+    recentAttempts,
+  });
   return {
     ...concept,
     subjectId: 'grammar',
@@ -103,6 +171,8 @@ function normaliseConceptRow(rawValue, concept, nowTs) {
     lastSeenAt: node.lastSeenAt,
     lastWrongAt: node.lastWrongAt,
     correctStreak: node.correctStreak,
+    intervalDays: node.intervalDays,
+    confidence,
   };
 }
 
@@ -113,18 +183,19 @@ function analyticsFromStateOrUi(state, ui) {
 }
 
 function conceptRowsFromState(state, nowTs, ui = null) {
+  const recentAttempts = Array.isArray(state?.recentAttempts) ? state.recentAttempts : [];
   const mastery = isPlainObject(state?.mastery?.concepts) ? state.mastery.concepts : null;
   if (mastery) {
-    return GRAMMAR_CLIENT_CONCEPTS.map((concept) => normaliseConceptRow(mastery[concept.id], concept, nowTs));
+    return GRAMMAR_CLIENT_CONCEPTS.map((concept) => normaliseConceptRow(mastery[concept.id], concept, nowTs, recentAttempts));
   }
   const analytics = analyticsFromStateOrUi(state, ui);
   if (Array.isArray(analytics.concepts) && analytics.concepts.length) {
     const rowsById = new Map(analytics.concepts
       .filter((entry) => typeof entry?.id === 'string')
       .map((entry) => [entry.id, entry]));
-    return GRAMMAR_CLIENT_CONCEPTS.map((concept) => normaliseConceptRow(rowsById.get(concept.id), concept, nowTs));
+    return GRAMMAR_CLIENT_CONCEPTS.map((concept) => normaliseConceptRow(rowsById.get(concept.id), concept, nowTs, recentAttempts));
   }
-  return GRAMMAR_CLIENT_CONCEPTS.map((concept) => normaliseConceptRow(null, concept, nowTs));
+  return GRAMMAR_CLIENT_CONCEPTS.map((concept) => normaliseConceptRow(null, concept, nowTs, recentAttempts));
 }
 
 function progressSnapshotFromConcepts(concepts) {

--- a/src/surfaces/hubs/AdminHubSurface.jsx
+++ b/src/surfaces/hubs/AdminHubSurface.jsx
@@ -7,6 +7,8 @@ import { AccessDeniedCard, formatTimestamp, isBlocked, selectedWritableLearner }
 import { PanelHeader } from './admin-panel-header.jsx';
 import { decideDirtyResetOnServerUpdate } from '../../platform/hubs/admin-metadata-dirty-registry.js';
 import { useSubmitLock } from '../../platform/react/use-submit-lock.js';
+import { AdultConfidenceChip } from '../../subjects/grammar/components/AdultConfidenceChip.jsx';
+import { GRAMMAR_RECENT_ATTEMPT_HORIZON } from '../../../shared/grammar/confidence.js';
 
 function AdminAccountRoles({ model, directory = {}, actions }) {
   const isAdmin = model?.permissions?.platformRole === 'admin';
@@ -280,6 +282,47 @@ function DemoOperationsSummary({ summary = {} }) {
           </div>
         ))}
       </div>
+    </section>
+  );
+}
+
+// Phase 4 U7: Admin Hub "Grammar concepts" confidence panel. Admins see the
+// full 5-field confidence projection — label, sample size, recent-miss
+// count, interval-days spacing, and distinct-template coverage — for every
+// tracked Grammar concept on the selected learner. Child surfaces MUST NOT
+// import `AdultConfidenceChip`; `tests/grammar-parent-hub-confidence.test.js`
+// greps the dashboard / bank / summary / transfer scene code to lock this.
+function GrammarConceptConfidencePanel({ evidence }) {
+  const rows = Array.isArray(evidence?.conceptStatus) ? evidence.conceptStatus : [];
+  return (
+    <section className="card" style={{ marginBottom: 20 }} data-panel="grammar-concept-confidence">
+      <div className="eyebrow">Grammar · concept confidence</div>
+      <h3 className="section-title" style={{ fontSize: '1.2rem' }}>Grammar concepts</h3>
+      <p className="small muted">
+        Adult-facing confidence label per concept for the selected learner, with the full evidence shape: sample size, recent misses, interval-days spacing, and distinct-template coverage over the last {GRAMMAR_RECENT_ATTEMPT_HORIZON} attempts.
+      </p>
+      {rows.length ? (
+        <ul className="admin-grammar-confidence-list" aria-label="Grammar concept confidence chips">
+          {rows.map((row) => (
+            <li
+              className="admin-grammar-confidence-row skill-row"
+              key={row.id || row.name}
+              data-concept-id={row.id || ''}
+            >
+              <div>
+                <strong>{row.name || row.id}</strong>
+                <div className="small muted">{row.domain || 'Grammar'}</div>
+              </div>
+              <div>
+                <AdultConfidenceChip
+                  confidence={row.confidence || null}
+                  showAdminExtras
+                />
+              </div>
+            </li>
+          ))}
+        </ul>
+      ) : <p className="small muted">No Grammar concept evidence has been recorded for this learner.</p>}
     </section>
   );
 }
@@ -822,6 +865,7 @@ export function AdminHubSurface({ appState, model, hubState = {}, accountDirecto
       <ErrorLogCentrePanel model={model} actions={actions} />
       <PostMegaSpellingDebugPanel debug={model.postMasteryDebug} />
       <PostMegaSeedHarnessPanel model={model} actions={actions} />
+      <GrammarConceptConfidencePanel evidence={selectedGrammarEvidence} />
 
       <section className="two-col" style={{ marginBottom: 20 }}>
         <article className="card">

--- a/src/surfaces/hubs/ParentHubSurface.jsx
+++ b/src/surfaces/hubs/ParentHubSurface.jsx
@@ -3,6 +3,7 @@ import { AdultLearnerSelect } from './AdultLearnerSelect.jsx';
 import { ReadOnlyLearnerNotice } from './ReadOnlyLearnerNotice.jsx';
 import { AccessDeniedCard, formatTimestamp, isBlocked, selectedWritableLearner } from './hub-utils.js';
 import { useSubmitLock } from '../../platform/react/use-submit-lock.js';
+import { AdultConfidenceChip } from '../../subjects/grammar/components/AdultConfidenceChip.jsx';
 
 function snapshotSubjectId(snapshot = {}) {
   if (snapshot.subjectId) return snapshot.subjectId;
@@ -277,6 +278,47 @@ function GrammarActivityEvidence({ evidence }) {
   );
 }
 
+// Phase 4 U7: "Grammar concepts" — per-concept confidence chips grid. The
+// client `buildGrammarLearnerReadModel` surfaces a `confidence` projection
+// on every row in `conceptStatus`; that is the single source the chips read
+// from. Parents see the headline label + sample context + recent-miss count;
+// `intervalDays` and `distinctTemplates` are reserved for the Admin Hub
+// surface (`showAdminExtras`) and are not rendered here.
+function GrammarConceptConfidenceGrid({ evidence, showAdminExtras = false }) {
+  const rows = Array.isArray(evidence?.conceptStatus) ? evidence.conceptStatus : [];
+  return (
+    <article className="card parent-hub-card parent-hub-grammar-concepts">
+      <div className="parent-hub-card-head">
+        <p className="eyebrow">Concept confidence</p>
+        <h3 className="parent-hub-card-title">Grammar concepts</h3>
+        <p className="parent-hub-card-lede small muted">
+          Adult-facing confidence label plus sample size for every tracked Grammar concept. Sample size is the number of answered attempts that fed the label.
+        </p>
+      </div>
+      {rows.length ? (
+        <ul className="parent-hub-grammar-confidence-list" aria-label="Grammar concept confidence chips">
+          {rows.map((row) => (
+            <li
+              className="parent-hub-grammar-confidence-row"
+              key={row.id || row.name}
+              data-concept-id={row.id || ''}
+            >
+              <div className="parent-hub-grammar-confidence-main">
+                <strong>{row.name || row.id}</strong>
+                <span className="parent-hub-row-detail">{row.domain || 'Grammar'}</span>
+              </div>
+              <AdultConfidenceChip
+                confidence={row.confidence || null}
+                showAdminExtras={showAdminExtras}
+              />
+            </li>
+          ))}
+        </ul>
+      ) : <p className="parent-hub-empty small muted">No Grammar concept evidence has been recorded yet.</p>}
+    </article>
+  );
+}
+
 function GrammarEvidencePanel({ evidence }) {
   return (
     <>
@@ -284,6 +326,9 @@ function GrammarEvidencePanel({ evidence }) {
         title="Grammar evidence"
         note="Concept status, question-type weakness, recent Grammar activity, and adult-facing summary drafts."
       />
+      <section className="parent-hub-grid parent-hub-grammar-evidence">
+        <GrammarConceptConfidenceGrid evidence={evidence} />
+      </section>
       <section className="two-col parent-hub-grid parent-hub-grammar-evidence">
         <GrammarConceptEvidence evidence={evidence} />
         <GrammarActivityEvidence evidence={evidence} />

--- a/tests/grammar-adult-confidence-chip.test.js
+++ b/tests/grammar-adult-confidence-chip.test.js
@@ -1,0 +1,166 @@
+// Phase 4 U7 — AdultConfidenceChip SSR unit tests.
+//
+// Focused assertions on the extracted `AdultConfidenceChip` module itself:
+//   - Renders nothing when `confidence` is null / undefined / empty.
+//   - Renders the canonical label + sampleSize text when a canonical
+//     projection is supplied.
+//   - Renders `'Unknown'` (neutral tone) when the label is out-of-taxonomy —
+//     NEVER silently falls back to `'emerging'`.
+//   - Singular vs plural ("attempt" vs "attempts", "miss" vs "misses",
+//     "template" vs "templates").
+//   - Admin extras render only when `showAdminExtras` is true.
+//
+// SSR via bundled esbuild/React subprocess — same pattern as the hub tests.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function nodePaths() {
+  return [
+    path.join(rootDir, 'node_modules'),
+    ...String(process.env.NODE_PATH || '').split(path.delimiter),
+  ].filter((entry) => entry && existsSync(entry));
+}
+
+async function renderChip({ confidence, showAdminExtras = false }) {
+  const tmpDir = await mkdtemp(path.join(tmpdir(), 'ks2-adult-chip-'));
+  const entryPath = path.join(tmpDir, 'entry.jsx');
+  const bundlePath = path.join(tmpDir, 'entry.cjs');
+  try {
+    await writeFile(entryPath, `
+      import React from 'react';
+      import { renderToStaticMarkup } from 'react-dom/server';
+      import { AdultConfidenceChip } from ${JSON.stringify(path.join(rootDir, 'src/subjects/grammar/components/AdultConfidenceChip.jsx'))};
+
+      const confidence = ${JSON.stringify(confidence)};
+      const showAdminExtras = ${JSON.stringify(showAdminExtras)};
+      const html = renderToStaticMarkup(
+        <div data-harness="adult-chip"><AdultConfidenceChip confidence={confidence} showAdminExtras={showAdminExtras} /></div>,
+      );
+      console.log(html);
+    `);
+    await build({
+      absWorkingDir: rootDir,
+      entryPoints: [entryPath],
+      outfile: bundlePath,
+      bundle: true,
+      platform: 'node',
+      format: 'cjs',
+      target: ['node24'],
+      jsx: 'automatic',
+      jsxImportSource: 'react',
+      loader: { '.js': 'jsx' },
+      nodePaths: nodePaths(),
+      logLevel: 'silent',
+    });
+    return execFileSync(process.execPath, [bundlePath], { cwd: rootDir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+test('U7 chip: confidence=null renders nothing (harness wrapper stays empty)', async () => {
+  const html = await renderChip({ confidence: null });
+  const wrapper = html.match(/<div data-harness="adult-chip">[\s\S]*?<\/div>/)?.[0] || '';
+  assert.ok(wrapper.length > 0);
+  assert.doesNotMatch(wrapper, /grammar-adult-confidence/);
+});
+
+test('U7 chip: confidence={} (no label, no samples) renders nothing', async () => {
+  const html = await renderChip({ confidence: {} });
+  assert.doesNotMatch(html, /grammar-adult-confidence/);
+});
+
+test('U7 chip: canonical label renders label + sample count with proper tone class', async () => {
+  const html = await renderChip({
+    confidence: { label: 'secure', sampleSize: 10, intervalDays: 14, distinctTemplates: 5, recentMisses: 0 },
+  });
+  assert.match(html, /grammar-adult-confidence secure/);
+  assert.match(html, /secure · 10 attempts/);
+  assert.match(html, /data-confidence-label="secure"/);
+  assert.match(html, /data-sample-size="10"/);
+});
+
+test('U7 chip (R17): out-of-taxonomy label renders "Unknown" with neutral tone — NOT emerging', async () => {
+  const html = await renderChip({
+    confidence: { label: 'garbage-label', sampleSize: 4, intervalDays: 0, distinctTemplates: 0, recentMisses: 0 },
+  });
+  assert.match(html, /grammar-adult-confidence unknown/);
+  assert.match(html, /Unknown · 4 attempts/);
+  assert.match(html, /data-confidence-label="Unknown"/);
+  // MUST NOT render the emerging tone class or the garbage label verbatim
+  assert.doesNotMatch(html, /grammar-adult-confidence emerging/);
+  assert.doesNotMatch(html, /grammar-adult-confidence garbage-label/);
+});
+
+test('U7 chip: singular "1 attempt" when sampleSize === 1', async () => {
+  const html = await renderChip({
+    confidence: { label: 'emerging', sampleSize: 1, intervalDays: 0, distinctTemplates: 1, recentMisses: 0 },
+  });
+  assert.match(html, /emerging · 1 attempt</);
+});
+
+test('U7 chip: plural "attempts" when sampleSize > 1', async () => {
+  const html = await renderChip({
+    confidence: { label: 'building', sampleSize: 4, intervalDays: 1, distinctTemplates: 2, recentMisses: 0 },
+  });
+  assert.match(html, /building · 4 attempts/);
+});
+
+test('U7 chip: recent-miss count is appended with singular/plural forms', async () => {
+  const one = await renderChip({
+    confidence: { label: 'needs-repair', sampleSize: 3, intervalDays: 0, distinctTemplates: 1, recentMisses: 1 },
+  });
+  assert.match(one, /1 recent miss</);
+  assert.doesNotMatch(one, /1 recent misses/);
+
+  const many = await renderChip({
+    confidence: { label: 'needs-repair', sampleSize: 5, intervalDays: 0, distinctTemplates: 2, recentMisses: 3 },
+  });
+  assert.match(many, /3 recent misses/);
+});
+
+test('U7 chip: admin extras are OFF by default — no intervalDays or distinctTemplates text', async () => {
+  const html = await renderChip({
+    confidence: { label: 'secure', sampleSize: 10, intervalDays: 14, distinctTemplates: 5, recentMisses: 0 },
+    showAdminExtras: false,
+  });
+  assert.doesNotMatch(html, /14d spacing/);
+  assert.doesNotMatch(html, /5 templates/);
+});
+
+test('U7 chip: admin extras render intervalDays + distinctTemplates when showAdminExtras=true', async () => {
+  const html = await renderChip({
+    confidence: { label: 'secure', sampleSize: 10, intervalDays: 14, distinctTemplates: 5, recentMisses: 0 },
+    showAdminExtras: true,
+  });
+  assert.match(html, /14d spacing/);
+  assert.match(html, /5 templates/);
+});
+
+test('U7 chip: admin extras singular "1 template"', async () => {
+  const html = await renderChip({
+    confidence: { label: 'building', sampleSize: 3, intervalDays: 0, distinctTemplates: 1, recentMisses: 0 },
+    showAdminExtras: true,
+  });
+  assert.match(html, /1 template</);
+  assert.doesNotMatch(html, /1 templates/);
+});
+
+test('U7 chip: malformed sampleSize (NaN / negative) coerces to 0', async () => {
+  const html = await renderChip({
+    confidence: { label: 'emerging', sampleSize: NaN, intervalDays: -4, distinctTemplates: -1, recentMisses: -2 },
+  });
+  assert.match(html, /emerging · 0 attempts/);
+  // Negative recent misses coerced to 0 — so no recent-miss suffix appears
+  assert.doesNotMatch(html, /recent miss/);
+});

--- a/tests/grammar-parent-hub-confidence.test.js
+++ b/tests/grammar-parent-hub-confidence.test.js
@@ -1,0 +1,226 @@
+// Phase 4 U7 — Parent Hub confidence label parity with Worker read model.
+//
+// This is a load-bearing regression lock: both the client read-model and the
+// Worker read-model must produce the SAME `confidence.label` for the SAME
+// input state. U8 lifted `deriveGrammarConfidence` into
+// `shared/grammar/confidence.js`; U7 wires the client read-model to use the
+// shared derivation so Parent Hub / Admin Hub never see a divergent label
+// vs the Worker.
+//
+// We exercise this by:
+//   1. Seeding a raw grammar subject state (mastery + recentAttempts).
+//   2. Running the client `buildGrammarLearnerReadModel` on it.
+//   3. Running the Worker `buildGrammarReadModel` on the same state.
+//   4. Asserting `clientConcept.confidence.label ===
+//      workerConcept.confidence.label` for every concept.
+//
+// A divergence would indicate the shared derivation has been bypassed on
+// one side (e.g., a local reimplementation re-emerged during a merge), or
+// that the recentMisses / distinctTemplates window shapes drifted — both
+// of which would corrupt Parent Hub's label against the Worker's scoring.
+//
+// Additionally this file regression-locks the child-surface-free constraint:
+// no dashboard / bank / summary / transfer Grammar scene imports
+// `AdultConfidenceChip`. The chip is an adult-only component; the
+// view-model provides `grammarChildConfidenceLabel` for child surfaces.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildGrammarLearnerReadModel } from '../src/subjects/grammar/read-model.js';
+import { buildGrammarReadModel } from '../worker/src/subjects/grammar/read-models.js';
+import { GRAMMAR_CONFIDENCE_LABELS } from '../shared/grammar/confidence.js';
+
+const THIS_FILE_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(THIS_FILE_DIR, '..');
+
+function seededGrammarState(nowTs) {
+  return {
+    mastery: {
+      concepts: {
+        // Mix of statuses — exercises each precedence rung in deriveGrammarConfidence.
+        adverbials: {
+          attempts: 6, correct: 2, wrong: 4, strength: 0.35,
+          intervalDays: 0, dueAt: nowTs - 1, correctStreak: 0,
+        },
+        relative_clauses: {
+          attempts: 10, correct: 10, wrong: 0, strength: 0.92,
+          intervalDays: 14, dueAt: nowTs + 86_400_000, correctStreak: 5,
+        },
+        word_classes: {
+          attempts: 12, correct: 11, wrong: 1, strength: 0.88,
+          intervalDays: 3, dueAt: nowTs + 86_400_000, correctStreak: 4,
+        },
+        clauses: {
+          attempts: 1, correct: 1, wrong: 0, strength: 0.4,
+          intervalDays: 0, dueAt: nowTs + 86_400_000, correctStreak: 1,
+        },
+        noun_phrases: {
+          attempts: 4, correct: 3, wrong: 1, strength: 0.6,
+          intervalDays: 2, dueAt: nowTs + 86_400_000, correctStreak: 2,
+        },
+        tense_aspect: {
+          attempts: 0, correct: 0, wrong: 0, strength: 0.25,
+          intervalDays: 0, dueAt: 0, correctStreak: 0,
+        },
+        sentence_functions: {
+          attempts: 8, correct: 6, wrong: 2, strength: 0.85,
+          intervalDays: 10, dueAt: nowTs + 86_400_000, correctStreak: 3,
+        },
+      },
+    },
+    recentAttempts: [
+      // Two misses on adverbials — triggers needs-repair via recentMisses path
+      { templateId: 'adv-1', conceptIds: ['adverbials'], result: { correct: false }, createdAt: nowTs - 3_000_000 },
+      { templateId: 'adv-2', conceptIds: ['adverbials'], result: { correct: false }, createdAt: nowTs - 2_000_000 },
+      { templateId: 'adv-3', conceptIds: ['adverbials'], result: { correct: false }, createdAt: nowTs - 1_000_000 },
+      // Correct hits on relative_clauses — leaves it in the secure path
+      { templateId: 'rc-1', conceptIds: ['relative_clauses'], result: { correct: true }, createdAt: nowTs - 900_000 },
+      { templateId: 'rc-2', conceptIds: ['relative_clauses'], result: { correct: true }, createdAt: nowTs - 800_000 },
+      // One correct on clauses
+      { templateId: 'cl-1', conceptIds: ['clauses'], result: { correct: true }, createdAt: nowTs - 600_000 },
+      // Mixed noun_phrases — 1 miss keeps it in `building`
+      { templateId: 'np-1', conceptIds: ['noun_phrases'], result: { correct: true }, createdAt: nowTs - 500_000 },
+      { templateId: 'np-2', conceptIds: ['noun_phrases'], result: { correct: false }, createdAt: nowTs - 400_000 },
+    ],
+  };
+}
+
+function workerConceptsById(state, nowTs) {
+  const workerModel = buildGrammarReadModel({ state, now: nowTs });
+  const concepts = Array.isArray(workerModel?.analytics?.concepts) ? workerModel.analytics.concepts : [];
+  return new Map(concepts.map((concept) => [concept.id, concept]));
+}
+
+test('U7 parity: client Parent-Hub read-model label matches Worker label for every concept', () => {
+  const nowTs = 1_780_000_000_000;
+  const state = seededGrammarState(nowTs);
+  const workerById = workerConceptsById(state, nowTs);
+
+  const clientModel = buildGrammarLearnerReadModel({
+    subjectStateRecord: { data: state, updatedAt: nowTs },
+    now: () => nowTs,
+  });
+  const clientConcepts = Array.isArray(clientModel.conceptStatus) ? clientModel.conceptStatus : [];
+  assert.equal(clientConcepts.length, 18, 'client read-model emits exactly 18 concept rows (metadata denominator)');
+
+  for (const clientConcept of clientConcepts) {
+    const workerConcept = workerById.get(clientConcept.id);
+    assert.ok(workerConcept, `Worker must know about concept '${clientConcept.id}'`);
+    assert.ok(clientConcept.confidence, `client concept '${clientConcept.id}' has confidence projection`);
+    assert.ok(workerConcept.confidence, `Worker concept '${clientConcept.id}' has confidence projection`);
+    assert.equal(
+      clientConcept.confidence.label,
+      workerConcept.confidence.label,
+      `client and Worker must produce the same confidence label for '${clientConcept.id}'; `
+      + `client=${clientConcept.confidence.label}, Worker=${workerConcept.confidence.label}`,
+    );
+  }
+});
+
+test('U7: client read-model includes the full confidence projection shape on every concept', () => {
+  const nowTs = 1_780_000_000_000;
+  const state = seededGrammarState(nowTs);
+  const clientModel = buildGrammarLearnerReadModel({
+    subjectStateRecord: { data: state, updatedAt: nowTs },
+    now: () => nowTs,
+  });
+  for (const concept of clientModel.conceptStatus) {
+    assert.ok(concept.confidence, `concept '${concept.id}' has confidence`);
+    const keys = Object.keys(concept.confidence);
+    assert.deepEqual(
+      keys.sort(),
+      ['distinctTemplates', 'intervalDays', 'label', 'recentMisses', 'sampleSize'],
+      `concept '${concept.id}' exposes the canonical confidence keys`,
+    );
+    assert.ok(
+      GRAMMAR_CONFIDENCE_LABELS.includes(concept.confidence.label),
+      `concept '${concept.id}' confidence.label '${concept.confidence.label}' must be a canonical label`,
+    );
+    assert.ok(
+      concept.confidence.sampleSize >= 0 && Number.isInteger(concept.confidence.sampleSize),
+      `concept '${concept.id}' sampleSize is a non-negative integer`,
+    );
+  }
+});
+
+test('U7: adverbials with 3 recent misses emits needs-repair label on BOTH client and Worker', () => {
+  const nowTs = 1_780_000_000_000;
+  const state = seededGrammarState(nowTs);
+  const workerById = workerConceptsById(state, nowTs);
+  const clientModel = buildGrammarLearnerReadModel({
+    subjectStateRecord: { data: state, updatedAt: nowTs },
+    now: () => nowTs,
+  });
+  const clientAdverbials = clientModel.conceptStatus.find((concept) => concept.id === 'adverbials');
+  const workerAdverbials = workerById.get('adverbials');
+  assert.equal(clientAdverbials.confidence.label, 'needs-repair');
+  assert.equal(workerAdverbials.confidence.label, 'needs-repair');
+  // sampleSize and recentMisses must agree numerically
+  assert.equal(clientAdverbials.confidence.sampleSize, workerAdverbials.confidence.sampleSize);
+  assert.equal(clientAdverbials.confidence.recentMisses, workerAdverbials.confidence.recentMisses);
+  assert.equal(clientAdverbials.confidence.distinctTemplates, workerAdverbials.confidence.distinctTemplates);
+});
+
+test('U7: untouched concept emits emerging label with sampleSize=0 on BOTH client and Worker', () => {
+  const nowTs = 1_780_000_000_000;
+  const state = seededGrammarState(nowTs);
+  const workerById = workerConceptsById(state, nowTs);
+  const clientModel = buildGrammarLearnerReadModel({
+    subjectStateRecord: { data: state, updatedAt: nowTs },
+    now: () => nowTs,
+  });
+  const clientUntouched = clientModel.conceptStatus.find((concept) => concept.id === 'tense_aspect');
+  const workerUntouched = workerById.get('tense_aspect');
+  assert.equal(clientUntouched.confidence.label, 'emerging');
+  assert.equal(workerUntouched.confidence.label, 'emerging');
+  assert.equal(clientUntouched.confidence.sampleSize, 0);
+  assert.equal(workerUntouched.confidence.sampleSize, 0);
+});
+
+// --- Child-surface regression lock ---------------------------------------
+// The adult confidence chip must NOT be imported by any child-facing
+// Grammar scene. Child labels go through `grammarChildConfidenceLabel` in
+// `grammar-view-model.js`. This is a straight text grep against the scene
+// files the plan names.
+
+// Child-facing scenes (dashboard, bank, session, summary, transfer, and the
+// view-model itself). The chip is adult-only — `grammarChildConfidenceLabel`
+// from the view-model provides the child copy mapping.
+const CHILD_SURFACE_FILES = [
+  'src/subjects/grammar/components/GrammarSetupScene.jsx',
+  'src/subjects/grammar/components/GrammarConceptBankScene.jsx',
+  'src/subjects/grammar/components/GrammarConceptDetailModal.jsx',
+  'src/subjects/grammar/components/GrammarMiniTestReview.jsx',
+  'src/subjects/grammar/components/GrammarPracticeSurface.jsx',
+  'src/subjects/grammar/components/GrammarSessionScene.jsx',
+  'src/subjects/grammar/components/GrammarSummaryScene.jsx',
+  'src/subjects/grammar/components/GrammarTransferScene.jsx',
+  'src/subjects/grammar/components/grammar-view-model.js',
+];
+
+async function safeReadFile(relPath) {
+  try {
+    return await readFile(path.join(REPO_ROOT, relPath), 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+test('U7 regression lock: child-facing Grammar scenes MUST NOT import AdultConfidenceChip', async () => {
+  for (const file of CHILD_SURFACE_FILES) {
+    const source = await safeReadFile(file);
+    assert.ok(
+      source !== null,
+      `expected child-surface file '${file}' to exist; if it has been renamed, update the regression lock too`,
+    );
+    assert.doesNotMatch(
+      source,
+      /AdultConfidenceChip/,
+      `${file} must not reference AdultConfidenceChip — that component is adult-hub only. Use grammarChildConfidenceLabel for child surfaces.`,
+    );
+  }
+});

--- a/tests/react-admin-hub-grammar.test.js
+++ b/tests/react-admin-hub-grammar.test.js
@@ -1,0 +1,244 @@
+// Phase 4 U7 — React Admin Hub Grammar confidence chip rendering.
+//
+// Covers the admin-specific variant of the Parent Hub chips:
+//   - Happy path (F3): Admin Hub renders a Grammar concept confidence panel
+//     with the same chip shape as Parent Hub + the `intervalDays` /
+//     `distinctTemplates` extras.
+//   - Edge case: 18 concepts seeded render 18 rows.
+//   - Edge case (R17): out-of-taxonomy label renders `'Unknown'` with
+//     neutral tone, NEVER silently falls back to `'emerging'`.
+//   - Error path: `confidence: null` is tolerated without NPE.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function nodePaths() {
+  return [
+    path.join(rootDir, 'node_modules'),
+    ...String(process.env.NODE_PATH || '').split(path.delimiter),
+  ].filter((entry) => entry && existsSync(entry));
+}
+
+async function renderAdminHub({ conceptStatus }) {
+  const tmpDir = await mkdtemp(path.join(tmpdir(), 'ks2-admin-grammar-'));
+  const entryPath = path.join(tmpDir, 'entry.jsx');
+  const bundlePath = path.join(tmpDir, 'entry.cjs');
+  try {
+    await writeFile(entryPath, `
+      import React from 'react';
+      import { renderToStaticMarkup } from 'react-dom/server';
+      import { AdminHubSurface } from ${JSON.stringify(path.join(rootDir, 'src/surfaces/hubs/AdminHubSurface.jsx'))};
+      import { BUNDLED_MONSTER_VISUAL_CONFIG } from ${JSON.stringify(path.join(rootDir, 'src/platform/game/monster-visual-config.js'))};
+
+      const conceptStatus = ${JSON.stringify(conceptStatus)};
+      const adminNow = Date.UTC(2026, 3, 22, 12, 0);
+      const model = {
+        account: { id: 'adult-admin', repoRevision: 1, selectedLearnerId: 'learner-a' },
+        permissions: { canViewAdminHub: true, platformRole: 'admin', platformRoleLabel: 'Admin', canManageMonsterVisualConfig: true },
+        monsterVisualConfig: {
+          permissions: { canManageMonsterVisualConfig: true, canViewMonsterVisualConfig: true },
+          status: {
+            schemaVersion: 1,
+            manifestHash: BUNDLED_MONSTER_VISUAL_CONFIG.manifestHash,
+            draftRevision: 0,
+            publishedVersion: 1,
+            publishedAt: adminNow,
+            validation: { ok: true, errorCount: 0, warningCount: 0, errors: [], warnings: [] },
+          },
+          draft: BUNDLED_MONSTER_VISUAL_CONFIG,
+          published: BUNDLED_MONSTER_VISUAL_CONFIG,
+          versions: [],
+          mutation: {},
+        },
+        contentReleaseStatus: { publishedVersion: 1, publishedReleaseId: 'r', runtimeWordCount: 0, runtimeSentenceCount: 0, currentDraftId: 'd', currentDraftVersion: 1, draftUpdatedAt: 0 },
+        importValidationStatus: { ok: true, errorCount: 0, warningCount: 0, source: '', importedAt: 0, errors: [] },
+        auditLogLookup: { available: false, note: '', entries: [] },
+        dashboardKpis: { generatedAt: adminNow, accounts: { total: 0 }, learners: { total: 0 }, demos: { active: 0 }, practiceSessions: { last7d: 0, last30d: 0 }, eventLog: { last7d: 0 }, mutationReceipts: { last7d: 0 }, errorEvents: { byStatus: { open: 0, investigating: 0, resolved: 0, ignored: 0 } }, accountOpsUpdates: { total: 0 } },
+        opsActivityStream: { generatedAt: adminNow, entries: [] },
+        accountOpsMetadata: { generatedAt: adminNow, accounts: [] },
+        errorLogSummary: { generatedAt: adminNow, totals: { open: 0, investigating: 0, resolved: 0, ignored: 0, all: 0 }, entries: [] },
+        demoOperations: { sessionsCreated: 0, activeSessions: 0, conversions: 0, cleanupCount: 0, rateLimitBlocks: 0, ttsFallbacks: 0, updatedAt: 0 },
+        learnerSupport: {
+          selectedLearnerId: 'learner-a',
+          selectedDiagnostics: {
+            learnerId: 'learner-a',
+            learnerName: 'Ava',
+            overview: { secureWords: 0, dueWords: 0, troubleWords: 0, secureGrammarConcepts: 0, dueGrammarConcepts: 0, weakGrammarConcepts: 0, securePunctuationUnits: 0, duePunctuationItems: 0, weakPunctuationItems: 0 },
+            currentFocus: null,
+            grammarEvidence: {
+              subjectId: 'grammar',
+              hasEvidence: true,
+              progressSnapshot: { subjectId: 'grammar', trackedConcepts: conceptStatus.length, totalConcepts: conceptStatus.length, securedConcepts: 0, dueConcepts: 0, weakConcepts: 0 },
+              conceptStatus,
+              dueConcepts: [],
+              weakConcepts: [],
+              questionTypeSummary: [],
+              misconceptionPatterns: [],
+              recentActivity: [],
+              recentSessions: [],
+              parentSummaryDraft: null,
+            },
+            punctuationEvidence: { subjectId: 'punctuation', hasEvidence: false, progressSnapshot: null },
+          },
+          accessibleLearners: [{
+            learnerId: 'learner-a', learnerName: 'Ava', yearGroup: 'Y5', membershipRoleLabel: 'Viewer',
+            accessModeLabel: 'Read-only learner', writable: false, overview: {}, grammarEvidence: {}, punctuationEvidence: {},
+          }],
+          punctuationReleaseDiagnostics: null,
+          entryPoints: [],
+        },
+      };
+      const actions = { dispatch() {}, navigateHome() {}, openSubject() {}, registerAccountOpsMetadataRowDirty() {} };
+      const appState = { learners: { selectedId: 'learner-a', byId: { 'learner-a': { id: 'learner-a', name: 'Ava', yearGroup: 'Y5' } }, allIds: ['learner-a'] }, persistence: { mode: 'remote-sync' }, toasts: [], monsterCelebrations: { queue: [] } };
+      const accessContext = { shellAccess: { source: 'worker-session' }, activeAdultLearnerContext: null };
+      const accountDirectory = { status: 'loaded', accounts: [] };
+      const html = renderToStaticMarkup(
+        <AdminHubSurface
+          appState={appState}
+          model={model}
+          hubState={{ status: 'loaded' }}
+          accountDirectory={accountDirectory}
+          accessContext={accessContext}
+          actions={actions}
+        />,
+      );
+      console.log(html);
+    `);
+    await build({
+      absWorkingDir: rootDir,
+      entryPoints: [entryPath],
+      outfile: bundlePath,
+      bundle: true,
+      platform: 'node',
+      format: 'cjs',
+      target: ['node24'],
+      jsx: 'automatic',
+      jsxImportSource: 'react',
+      loader: { '.js': 'jsx' },
+      nodePaths: nodePaths(),
+      logLevel: 'silent',
+    });
+    return execFileSync(process.execPath, [bundlePath], { cwd: rootDir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+function makeRow(id, name, overrides = {}) {
+  return {
+    id,
+    name,
+    domain: overrides.domain || 'Grammar',
+    status: overrides.status || 'learning',
+    attempts: overrides.attempts ?? 0,
+    correct: overrides.correct ?? 0,
+    wrong: overrides.wrong ?? 0,
+    accuracyPercent: overrides.accuracyPercent ?? null,
+    confidence: overrides.confidence === null
+      ? null
+      : overrides.confidence || {
+        label: 'emerging',
+        sampleSize: overrides.attempts ?? 0,
+        intervalDays: 0,
+        distinctTemplates: 0,
+        recentMisses: 0,
+      },
+  };
+}
+
+test('U7: Admin Hub renders Grammar concept confidence panel with chip + admin extras (intervalDays + distinctTemplates)', async () => {
+  const conceptStatus = [
+    makeRow('relative_clauses', 'Relative clauses', {
+      status: 'secured',
+      attempts: 10,
+      correct: 10,
+      wrong: 0,
+      confidence: { label: 'secure', sampleSize: 10, intervalDays: 14, distinctTemplates: 5, recentMisses: 0 },
+    }),
+    makeRow('adverbials', 'Adverbials', {
+      status: 'weak',
+      attempts: 6,
+      correct: 2,
+      wrong: 4,
+      confidence: { label: 'needs-repair', sampleSize: 6, intervalDays: 2, distinctTemplates: 3, recentMisses: 3 },
+    }),
+  ];
+  const html = await renderAdminHub({ conceptStatus });
+
+  // Panel heading
+  assert.match(html, /Grammar concepts/);
+  assert.match(html, /Grammar · concept confidence/);
+  assert.match(html, /data-panel="grammar-concept-confidence"/);
+
+  // Both rows with chip + admin extras
+  assert.match(html, /data-concept-id="relative_clauses"/);
+  assert.match(html, /grammar-adult-confidence secure/);
+  assert.match(html, /secure · 10 attempts/);
+  // Admin extras — intervalDays + distinctTemplates must be rendered
+  assert.match(html, /14d spacing/);
+  assert.match(html, /5 templates/);
+
+  assert.match(html, /data-concept-id="adverbials"/);
+  assert.match(html, /grammar-adult-confidence needs-repair/);
+  assert.match(html, /needs-repair · 6 attempts/);
+  assert.match(html, /3 recent misses/);
+  assert.match(html, /2d spacing/);
+  assert.match(html, /3 templates/);
+});
+
+test('U7: Admin Hub renders all 18 concepts when full concept list is seeded', async () => {
+  const conceptStatus = [];
+  for (let i = 0; i < 18; i += 1) {
+    conceptStatus.push(makeRow(`concept_${i}`, `Concept ${i}`, {
+      attempts: i,
+      confidence: { label: i > 2 ? 'building' : 'emerging', sampleSize: i, intervalDays: i, distinctTemplates: Math.min(i, 3), recentMisses: 0 },
+    }));
+  }
+  const html = await renderAdminHub({ conceptStatus });
+  for (let i = 0; i < 18; i += 1) {
+    assert.match(html, new RegExp(`data-concept-id="concept_${i}"`), `concept_${i} row rendered`);
+  }
+});
+
+test('U7 (R17): Admin Hub — out-of-taxonomy label renders "Unknown" neutral tone, NOT emerging', async () => {
+  const conceptStatus = [makeRow('weird_concept', 'Weird', {
+    attempts: 4,
+    confidence: { label: 'garbage-label', sampleSize: 4, intervalDays: 1, distinctTemplates: 2, recentMisses: 0 },
+  })];
+  const html = await renderAdminHub({ conceptStatus });
+  assert.match(html, /grammar-adult-confidence unknown/);
+  assert.match(html, /Unknown · 4 attempts/);
+  assert.match(html, /1d spacing/);
+  assert.match(html, /2 templates/);
+  // The panel region itself must not contain an `emerging` tone or the raw garbage label
+  const panelHtml = html.match(/data-panel="grammar-concept-confidence"[\s\S]*?<\/section>/)?.[0] || '';
+  assert.ok(panelHtml.length > 0, 'admin grammar panel rendered');
+  assert.doesNotMatch(panelHtml, /grammar-adult-confidence emerging/);
+  assert.doesNotMatch(panelHtml, /grammar-adult-confidence garbage-label/);
+});
+
+test('U7: Admin Hub — confidence: null on a row renders no chip and no NPE', async () => {
+  const conceptStatus = [
+    makeRow('relative_clauses', 'Relative clauses', { attempts: 0, confidence: null }),
+    makeRow('adverbials', 'Adverbials', { attempts: 3, confidence: { label: 'building', sampleSize: 3, intervalDays: 1, distinctTemplates: 1, recentMisses: 0 } }),
+  ];
+  const html = await renderAdminHub({ conceptStatus });
+  assert.match(html, /Grammar concepts/);
+  // Scoping: relative_clauses row exists, has no chip; adverbials row has a building chip
+  const rc = html.match(/data-concept-id="relative_clauses"[\s\S]*?<\/li>/)?.[0] || '';
+  assert.ok(rc.length > 0, 'relative_clauses row rendered');
+  assert.doesNotMatch(rc, /grammar-adult-confidence/);
+  assert.match(html, /grammar-adult-confidence building/);
+  assert.match(html, /building · 3 attempts/);
+  assert.match(html, /1d spacing/);
+  assert.match(html, /1 template</);
+});

--- a/tests/react-parent-hub-grammar.test.js
+++ b/tests/react-parent-hub-grammar.test.js
@@ -1,0 +1,244 @@
+// Phase 4 U7 — React Parent Hub Grammar confidence chip rendering.
+//
+// Covers the following plan-named scenarios:
+//   - Happy path (F3): Parent Hub renders a row per tracked Grammar concept,
+//     each row carries an <AdultConfidenceChip> with the confidence label +
+//     sample-size text.
+//   - Edge case: concept with 1 attempt surfaces `"1 attempt"` (singular).
+//   - Edge case: concept with zero attempts renders the default `'emerging'`
+//     label with `"0 attempts"`.
+//   - Edge case (R17): an out-of-taxonomy label renders `'Unknown'` with the
+//     `unknown` tone class — NEVER silently falls back to `'emerging'`.
+//   - Error path: `confidence: null` renders no chip and causes no NPE.
+//   - 18 concepts: when the full concept list is seeded, every row appears.
+//
+// We drive the surface through the same bundled-subprocess SSR harness used
+// by `react-hub-surfaces.test.js` so we exercise `ParentHubSurface` end-to-
+// end, not just the chip component in isolation.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function nodePaths() {
+  return [
+    path.join(rootDir, 'node_modules'),
+    ...String(process.env.NODE_PATH || '').split(path.delimiter),
+  ].filter((entry) => entry && existsSync(entry));
+}
+
+async function renderParentHub({ conceptStatus }) {
+  const tmpDir = await mkdtemp(path.join(tmpdir(), 'ks2-parent-grammar-'));
+  const entryPath = path.join(tmpDir, 'entry.jsx');
+  const bundlePath = path.join(tmpDir, 'entry.cjs');
+  try {
+    await writeFile(entryPath, `
+      import React from 'react';
+      import { renderToStaticMarkup } from 'react-dom/server';
+      import { ParentHubSurface } from ${JSON.stringify(path.join(rootDir, 'src/surfaces/hubs/ParentHubSurface.jsx'))};
+
+      const conceptStatus = ${JSON.stringify(conceptStatus)};
+      const model = {
+        learner: { id: 'learner-a', name: 'Ava', lastActivityAt: 0 },
+        learnerOverview: {
+          secureWords: 0, dueWords: 0, troubleWords: 0,
+          secureGrammarConcepts: 2, dueGrammarConcepts: 1, weakGrammarConcepts: 1,
+          grammarAccuracyPercent: 67,
+          securePunctuationUnits: 0, duePunctuationItems: 0, weakPunctuationItems: 0,
+          punctuationAccuracyPercent: null,
+          accuracyPercent: null,
+        },
+        dueWork: [],
+        recentSessions: [],
+        strengths: [],
+        weaknesses: [],
+        misconceptionPatterns: [],
+        progressSnapshots: [],
+        grammarEvidence: {
+          subjectId: 'grammar',
+          hasEvidence: true,
+          progressSnapshot: { subjectId: 'grammar', trackedConcepts: conceptStatus.length, totalConcepts: conceptStatus.length, securedConcepts: 0, dueConcepts: 0, weakConcepts: 0 },
+          conceptStatus,
+          dueConcepts: [],
+          weakConcepts: [],
+          questionTypeSummary: [],
+          misconceptionPatterns: [],
+          recentActivity: [],
+          recentSessions: [],
+          parentSummaryDraft: null,
+        },
+        punctuationEvidence: { subjectId: 'punctuation', hasEvidence: false, progressSnapshot: null },
+        exportEntryPoints: [],
+        accessibleLearners: [],
+        selectedLearnerId: 'learner-a',
+        permissions: {
+          canViewParentHub: true,
+          canMutateLearnerData: false,
+          platformRoleLabel: 'Parent',
+          membershipRoleLabel: 'Viewer',
+          accessModeLabel: 'Read-only learner',
+        },
+      };
+      const appState = { learners: { selectedId: 'learner-a', byId: { 'learner-a': { id: 'learner-a', name: 'Ava', yearGroup: 'Y5' } }, allIds: ['learner-a'] }, persistence: { mode: 'remote-sync' }, toasts: [], monsterCelebrations: { queue: [] } };
+      const accessContext = { shellAccess: { source: 'worker-session' }, activeAdultLearnerContext: { learnerId: 'learner-a', writable: false } };
+      const actions = { navigateHome() {}, openSubject() {}, dispatch() {} };
+      const html = renderToStaticMarkup(
+        <ParentHubSurface
+          appState={appState}
+          model={model}
+          hubState={{ status: 'loaded' }}
+          accessContext={accessContext}
+          actions={actions}
+        />,
+      );
+      console.log(html);
+    `);
+    await build({
+      absWorkingDir: rootDir,
+      entryPoints: [entryPath],
+      outfile: bundlePath,
+      bundle: true,
+      platform: 'node',
+      format: 'cjs',
+      target: ['node24'],
+      jsx: 'automatic',
+      jsxImportSource: 'react',
+      loader: { '.js': 'jsx' },
+      nodePaths: nodePaths(),
+      logLevel: 'silent',
+    });
+    return execFileSync(process.execPath, [bundlePath], { cwd: rootDir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+function makeRow(id, name, overrides = {}) {
+  return {
+    id,
+    name,
+    domain: overrides.domain || 'Grammar',
+    status: overrides.status || 'learning',
+    attempts: overrides.attempts ?? 0,
+    correct: overrides.correct ?? 0,
+    wrong: overrides.wrong ?? 0,
+    accuracyPercent: overrides.accuracyPercent ?? null,
+    confidence: overrides.confidence === null
+      ? null
+      : overrides.confidence || {
+        label: 'emerging',
+        sampleSize: overrides.attempts ?? 0,
+        intervalDays: 0,
+        distinctTemplates: 0,
+        recentMisses: 0,
+      },
+  };
+}
+
+test('U7: Parent Hub renders a Grammar concepts confidence panel with the 5-label taxonomy chip per row', async () => {
+  const conceptStatus = [
+    makeRow('adverbials', 'Adverbials', { status: 'weak', attempts: 5, correct: 1, wrong: 4, confidence: { label: 'needs-repair', sampleSize: 5, intervalDays: 0, distinctTemplates: 2, recentMisses: 3 } }),
+    makeRow('relative_clauses', 'Relative clauses', { status: 'secured', attempts: 10, correct: 10, wrong: 0, confidence: { label: 'secure', sampleSize: 10, intervalDays: 14, distinctTemplates: 5, recentMisses: 0 } }),
+  ];
+  const html = await renderParentHub({ conceptStatus });
+
+  // Section heading
+  assert.match(html, /Grammar concepts/);
+  assert.match(html, /Concept confidence/);
+
+  // Both concept rows appear with chip + sample size
+  assert.match(html, /data-concept-id="adverbials"/);
+  assert.match(html, /grammar-adult-confidence needs-repair/);
+  assert.match(html, /needs-repair.*?5 attempts/);
+  assert.match(html, /3 recent misses/);
+
+  assert.match(html, /data-concept-id="relative_clauses"/);
+  assert.match(html, /grammar-adult-confidence secure/);
+  assert.match(html, /secure.*?10 attempts/);
+
+  // Parent Hub MUST NOT render admin-only extras (intervalDays / distinctTemplates text)
+  assert.doesNotMatch(html, /14d spacing/);
+  assert.doesNotMatch(html, /5 templates/);
+});
+
+test('U7: Parent Hub renders all 18 concepts when the full concept list is seeded', async () => {
+  const conceptStatus = [];
+  for (let i = 0; i < 18; i += 1) {
+    conceptStatus.push(makeRow(`concept_${i}`, `Concept ${i}`, {
+      attempts: i,
+      confidence: { label: i > 2 ? 'building' : 'emerging', sampleSize: i, intervalDays: 0, distinctTemplates: 0, recentMisses: 0 },
+    }));
+  }
+  const html = await renderParentHub({ conceptStatus });
+  for (let i = 0; i < 18; i += 1) {
+    assert.match(html, new RegExp(`data-concept-id="concept_${i}"`), `concept_${i} row rendered`);
+  }
+  // Chip sample size counts rendered: at least one singular + plural variant
+  assert.match(html, /1 attempt</);
+  assert.match(html, /17 attempts</);
+});
+
+test('U7: Parent Hub — zero-attempt concept row renders emerging chip with "0 attempts"', async () => {
+  const conceptStatus = [makeRow('sentence_functions', 'Sentence functions', { attempts: 0 })];
+  const html = await renderParentHub({ conceptStatus });
+  assert.match(html, /grammar-adult-confidence emerging/);
+  assert.match(html, /emerging · 0 attempts/);
+});
+
+test('U7 (R17): Parent Hub — out-of-taxonomy label renders "Unknown" with neutral tone, NOT emerging', async () => {
+  const conceptStatus = [makeRow('weird_concept', 'Weird concept', {
+    attempts: 4,
+    confidence: { label: 'not-a-real-label', sampleSize: 4, intervalDays: 0, distinctTemplates: 0, recentMisses: 0 },
+  })];
+  const html = await renderParentHub({ conceptStatus });
+  // Chip class uses `unknown` tone, not `emerging` or the garbage label name
+  assert.match(html, /grammar-adult-confidence unknown/);
+  assert.match(html, /Unknown · 4 attempts/);
+  // MUST NOT render the legitimate `emerging` tone or the raw garbage label name
+  assert.doesNotMatch(html, /grammar-adult-confidence emerging/);
+  assert.doesNotMatch(html, /grammar-adult-confidence not-a-real-label/);
+});
+
+test('U7: Parent Hub — confidence: null on a row renders no chip and no NPE', async () => {
+  const conceptStatus = [
+    makeRow('adverbials', 'Adverbials', { attempts: 0, confidence: null }),
+    makeRow('relative_clauses', 'Relative clauses', { attempts: 3, confidence: { label: 'building', sampleSize: 3 } }),
+  ];
+  const html = await renderParentHub({ conceptStatus });
+  // Page still renders — no NPE
+  assert.match(html, /Grammar concepts/);
+  // Chip exists for the row with a non-null confidence
+  assert.match(html, /grammar-adult-confidence building/);
+  assert.match(html, /3 attempts/);
+  // Scoping: the adverbials row exists but has NO adult-confidence span inside it
+  const adverbialsRow = html.match(/data-concept-id="adverbials"[\s\S]*?<\/li>/)?.[0] || '';
+  assert.ok(adverbialsRow.length > 0, 'adverbials row rendered');
+  assert.doesNotMatch(adverbialsRow, /grammar-adult-confidence/);
+});
+
+test('U7: Parent Hub — singular "1 attempt" on a single-attempt concept row', async () => {
+  const conceptStatus = [makeRow('clauses', 'Subordinate clauses', {
+    attempts: 1,
+    confidence: { label: 'emerging', sampleSize: 1, intervalDays: 0, distinctTemplates: 1, recentMisses: 0 },
+  })];
+  const html = await renderParentHub({ conceptStatus });
+  assert.match(html, /emerging · 1 attempt</);
+});
+
+test('U7: Parent Hub — single recent miss uses singular "miss" (not "misses")', async () => {
+  const conceptStatus = [makeRow('formality', 'Formal and informal', {
+    attempts: 4,
+    confidence: { label: 'building', sampleSize: 4, intervalDays: 0, distinctTemplates: 2, recentMisses: 1 },
+  })];
+  const html = await renderParentHub({ conceptStatus });
+  assert.match(html, /1 recent miss</);
+  assert.doesNotMatch(html, /1 recent misses/);
+});


### PR DESCRIPTION
## Summary
- Extract the adult confidence chip into its own module (`src/subjects/grammar/components/AdultConfidenceChip.jsx`) so Parent Hub, Admin Hub, and `GrammarAnalyticsScene` all import from one canonical source; out-of-taxonomy labels now render `'Unknown'` with a neutral tone instead of silently falling back to `'emerging'` (plan R17).
- Extend the client `buildGrammarLearnerReadModel` to emit a per-concept `confidence: { label, sampleSize, intervalDays, distinctTemplates, recentMisses }` projection via the shared `deriveGrammarConfidence` from `shared/grammar/confidence.js`. This is the load-bearing wiring: Parent Hub reads the client read-model, not the Worker payload, so without this the adult hubs have no access to the confidence projection.
- Wire Parent Hub's "Grammar concepts" section (chip + sample size + recent-miss count) and Admin Hub's "Grammar concept confidence" panel (same chip + `intervalDays` spacing + `distinctTemplates` via `showAdminExtras`).

## UX / layout choices
- Parent Hub: new `GrammarConceptConfidenceGrid` panel surfaces before the existing concept / activity evidence cards, with a single-column list (one concept per row) so the chip + sample context reads cleanly on mobile.
- Admin Hub: new `GrammarConceptConfidencePanel` sits between the Spelling post-mega panel and the audit / diagnostics section, matching the admin-card rhythm (`.card` + `.skill-row` utilities).
- Chip output is flat plain-text inside a single `<span>` ("`<label> · <N> attempt(s)` [`· <N> recent miss(es)`] [`· <N>d spacing · <N> template(s)`]") to preserve the pre-U7 Phase 3 analytics-scene regex tests.

## Invariants preserved
- Invariant 10 (English Spelling parity) — only Grammar-scoped files touched plus the additive hub surfaces.
- Invariant 9 (no `contentReleaseId` bump) — no release-id changes.
- Invariant 12 (forbidden-keys floor unchanged).
- R15 / R16 / R17 named in the plan — adult-facing evidence surfaced; out-of-taxonomy label never silently becomes `'emerging'`.

## Test plan
- [x] `tests/grammar-adult-confidence-chip.test.js` (new) — 11 chip-module unit tests (null → nothing, out-of-taxonomy → Unknown, singular/plural, admin extras).
- [x] `tests/react-parent-hub-grammar.test.js` (new) — 7 Parent Hub tests (chip presence, 18-concept grid, zero / one / R17 unknown / null row / singular miss).
- [x] `tests/react-admin-hub-grammar.test.js` (new) — 4 Admin Hub tests (chip + admin extras, 18 concepts, R17 Unknown, null row).
- [x] `tests/grammar-parent-hub-confidence.test.js` (new) — 5 parity tests: client vs Worker label agrees for every concept on a seeded state; child-surface regression lock greps dashboard / bank / summary / transfer / session / view-model files for `AdultConfidenceChip` import (zero hits expected).
- [x] `tests/grammar-confidence-shared.test.js` — 13 existing tests still pass (shared module untouched).
- [x] `tests/grammar-confidence.test.js` — 9 existing tests still pass.
- [x] `tests/react-hub-surfaces.test.js` — 3 existing hub tests still pass.
- [x] `tests/react-grammar-surface.test.js` — 104 existing Grammar scene tests still pass (flat chip text preserves Phase 3 U7 regex matches).
- [x] `tests/hub-read-models.test.js` — 32 hub read-model tests still pass.
- [x] `npm run check` (wrangler dry-run deploy) — worker bundle assembles cleanly with the shared confidence module imports.