### PR TITLE
feat(grammar): U5 Grammar Bank focus allowlist + Mixed practice label

### DIFF
--- a/src/subjects/grammar/components/GrammarSetupScene.jsx
+++ b/src/subjects/grammar/components/GrammarSetupScene.jsx
@@ -89,6 +89,13 @@ function MoreModeCard({ card, selected, disabled, actions }) {
   const classes = ['grammar-secondary-mode'];
   if (selected) classes.push('selected');
   if (disabled) classes.push('is-disabled');
+  // U5 Phase 4: Surgery and Builder cards carry a "Mixed practice" label
+  // from `GRAMMAR_MORE_PRACTICE_MODES` so the dashboard surfaces the
+  // child-facing truth that these modes do not honour a focused concept
+  // id. Label renders under the mode title with `data-mode-label` so
+  // tests and QA can scope by the mode id. The label is decorative and
+  // does not change mode behaviour.
+  const label = typeof card.label === 'string' && card.label ? card.label : '';
   return (
     <button
       type="button"
@@ -103,6 +110,9 @@ function MoreModeCard({ card, selected, disabled, actions }) {
       }}
     >
       <h5 className="grammar-secondary-mode-title">{card.title}</h5>
+      {label ? (
+        <span className="grammar-secondary-mode-label" data-mode-label={card.id}>{label}</span>
+      ) : null}
       <p className="grammar-secondary-mode-desc">{card.desc}</p>
     </button>
   );

--- a/src/subjects/grammar/components/grammar-view-model.js
+++ b/src/subjects/grammar/components/grammar-view-model.js
@@ -26,6 +26,28 @@ import { GRAMMAR_GRAND_MONSTER_ID } from '../../../platform/game/mastery/shared.
 
 // --- Frozen option lists ----------------------------------------------------
 
+// U5 Phase 4: Grammar Bank focus dispatch is allowlisted to Smart + Learn only.
+// Surgery and Builder are legitimately global/mixed modes — a focused concept
+// dispatch into those modes would silently drop the learner's focus because
+// Worker's `NO_SESSION_FOCUS_MODES` safety net strips it before the engine
+// reads it. James's 2026-04-26 decision: "No focused UI action silently
+// becomes mixed practice." The client enforces the allowlist on every
+// Practise 5 button + `grammar-focus-concept` dispatch; the Worker's existing
+// `NO_SESSION_FOCUS_MODES` and `NO_STORED_FOCUS_MODES` remain as safety net.
+//
+// Frozen Set so module/UI checks are O(1) and cannot be mutated at runtime.
+export const GRAMMAR_FOCUS_ALLOWED_MODES = Object.freeze(new Set(['smart', 'learn']));
+
+/**
+ * Returns `true` iff `mode` is one of `GRAMMAR_FOCUS_ALLOWED_MODES`. The
+ * client JSX layer + module dispatcher both call this helper so the truth
+ * table lives in a single place. Unknown / missing input returns `false`.
+ */
+export function isGrammarFocusAllowedMode(mode) {
+  if (typeof mode !== 'string' || !mode) return false;
+  return GRAMMAR_FOCUS_ALLOWED_MODES.has(mode);
+}
+
 // The dashboard's four primary mode cards. `Smart Practice` sits first so it
 // is the obvious default action (R2). `Grammar Bank` is the fourth card and
 // routes into U2's new bank scene. `satsset` maps to the existing mode id so
@@ -59,11 +81,15 @@ export const GRAMMAR_PRIMARY_MODE_CARDS = Object.freeze([
 
 // Secondary modes disclosed under the dashboard's "More practice" details
 // block. Order follows the plan: Learn → Sentence Surgery → Sentence Builder
-// → Worked Examples → Faded Guidance.
+// → Worked Examples → Faded Guidance. U5 Phase 4: Surgery and Builder carry
+// a `label: 'Mixed practice'` so the dashboard surfaces the child-facing
+// truth that these modes do not honour a focused concept id. The label is
+// ~12 chars and does not change the mode's behaviour — it is rendered by
+// `GrammarSetupScene.jsx` under the mode title.
 export const GRAMMAR_MORE_PRACTICE_MODES = Object.freeze([
   Object.freeze({ id: 'learn', title: 'Learn a concept', desc: 'Focused retrieval on one concept at a time.' }),
-  Object.freeze({ id: 'surgery', title: 'Sentence Surgery', desc: 'Fix and rewrite sentence-level errors.' }),
-  Object.freeze({ id: 'builder', title: 'Sentence Builder', desc: 'Build sentences from structured prompts.' }),
+  Object.freeze({ id: 'surgery', title: 'Sentence Surgery', desc: 'Fix and rewrite sentence-level errors.', label: 'Mixed practice' }),
+  Object.freeze({ id: 'builder', title: 'Sentence Builder', desc: 'Build sentences from structured prompts.', label: 'Mixed practice' }),
   Object.freeze({ id: 'worked', title: 'Worked Examples', desc: 'See a modelled answer before your turn.' }),
   Object.freeze({ id: 'faded', title: 'Faded Guidance', desc: 'Less help each round. You do the reasoning.' }),
 ]);

--- a/src/subjects/grammar/module.js
+++ b/src/subjects/grammar/module.js
@@ -478,20 +478,44 @@ export const grammarModule = {
     if (action === 'grammar-focus-concept') {
       // Dispatched from bank concept cards + detail modal. Routes into a
       // focused practice round by mirroring the existing `grammar-set-focus`
-      // + `grammar-start` combination (with a `learn` mode fallback so
-      // `grammarModeUsesFocus` picks up the focusConceptId on start). The
-      // `pendingCommand` guard prevents double-tap races.
+      // + `grammar-start` combination. The `pendingCommand` guard prevents
+      // double-tap races.
       if (ui.pendingCommand) return true;
       const conceptId = String(context.data?.conceptId || context.data?.value || '').slice(0, 64);
       if (!conceptId) return true;
 
-      // Persist the focus preference; fall back to `learn` mode so the start
-      // payload carries the focusConceptId (smart / mini-set modes drop
-      // focus via `grammarModeUsesFocus`). The bank UI slice is cleared so
-      // reopening the bank does not re-apply stale filter state from the
-      // previous visit.
+      // U5 Phase 4: Grammar Bank focus dispatch is allowlisted to Smart +
+      // Learn only (`GRAMMAR_FOCUS_ALLOWED_MODES`). James's 2026-04-26
+      // decision: "No focused UI action silently becomes mixed practice."
+      //
+      // When the learner's current mode is Surgery, Builder, or Trouble
+      // (the three modes where `grammarModeUsesFocus` returns false —
+      // Worker's `NO_SESSION_FOCUS_MODES` drops focus for surgery/builder
+      // and `NO_STORED_FOCUS_MODES` drops it for trouble too) we silently
+      // override to `smart` so Practise 5 preserves the learner's intent:
+      // focused concept practice always lands in Smart Practice. The
+      // override is silent (no toast) because the dashboard already
+      // surfaces the "Mixed practice" label on the Surgery/Builder mode
+      // cards so the expectation of focus-carry is never set. The Worker's
+      // `NO_SESSION_FOCUS_MODES` + `NO_STORED_FOCUS_MODES` remain as the
+      // belt-and-braces safety net.
+      //
+      // Worked Examples and Faded Guidance are focus-using modes on Worker
+      // (`grammarModeUsesFocus` returns true) but not in the stricter
+      // client allowlist (`GRAMMAR_FOCUS_ALLOWED_MODES = {smart, learn}`).
+      // We preserve them here so a focused round still runs in the
+      // learner's preferred scaffold surface — they are not the "mixed
+      // practice" targets this unit guards against.
+      //
+      // Accepting a `mode` override in `context.data` lets callers (e.g.
+      // tests, future scene dispatches) request a specific target; the
+      // check runs against that requested mode so no caller can sneak
+      // Surgery/Builder in without being overridden to Smart.
       const existingMode = ui.prefs?.mode || DEFAULT_GRAMMAR_PREFS.mode;
-      const targetMode = grammarModeUsesFocus(existingMode) ? existingMode : 'learn';
+      const requestedMode = typeof context.data?.mode === 'string' && context.data.mode
+        ? context.data.mode
+        : existingMode;
+      const targetMode = grammarModeUsesFocus(requestedMode) ? requestedMode : 'smart';
       const prefsPatch = { mode: targetMode, focusConceptId: conceptId };
       const payload = {
         mode: targetMode,

--- a/tests/grammar-bank-focus-routing.test.js
+++ b/tests/grammar-bank-focus-routing.test.js
@@ -1,0 +1,352 @@
+// U5 Phase 4 — Grammar Bank focus routing.
+//
+// These tests pin the "Grammar Bank Practise 5 focus is allowlisted to Smart
+// + Learn" contract (James 2026-04-26 decision). The UX choice for U5 is
+// **silent override to Smart Practice** when the learner's current mode is
+// Surgery, Builder, or Trouble — the three modes where `grammarModeUsesFocus`
+// returns false and Worker's `NO_SESSION_FOCUS_MODES` / `NO_STORED_FOCUS_MODES`
+// would otherwise strip the focus before the engine reads it. The override is
+// silent (no toast) because the dashboard already surfaces the "Mixed practice"
+// label on Surgery/Builder cards — the expectation of focus-carry is never
+// set for those modes.
+//
+// Coverage principles:
+//  - Happy paths: Smart + Learn preserve the learner's current mode.
+//  - Edge cases: Surgery, Builder, Trouble silently override to Smart, with
+//    the focus concept still carried through.
+//  - Worked / Faded preserve the learner's choice (Worker honours focus in
+//    those modes; they are not the "mixed practice" targets this unit guards).
+//  - Unknown conceptId / empty conceptId → no-op (regression-lock).
+//  - Active session ends cleanly when a new focused round starts.
+//  - Integration: Grammar Bank → Trouble filter → Practise 5 lands in Smart
+//    with the focus concept id set.
+//
+// Test harness: `createGrammarHarness` wires the full server grammar engine
+// so `service.savePrefs` + `service.startSession` run synchronously and the
+// resulting session state (`grammar.session.mode`, `grammar.session.focusConceptId`)
+// is observable right after dispatch.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createGrammarHarness } from './helpers/grammar-subject-harness.js';
+import { installMemoryStorage } from './helpers/memory-storage.js';
+import {
+  GRAMMAR_FOCUS_ALLOWED_MODES,
+  isGrammarFocusAllowedMode,
+} from '../src/subjects/grammar/components/grammar-view-model.js';
+
+// --- GRAMMAR_FOCUS_ALLOWED_MODES — pure-function contract -------------------
+
+test('U5: GRAMMAR_FOCUS_ALLOWED_MODES is a frozen Set of exactly {smart, learn}', () => {
+  assert.ok(GRAMMAR_FOCUS_ALLOWED_MODES instanceof Set);
+  assert.equal(GRAMMAR_FOCUS_ALLOWED_MODES.size, 2);
+  assert.equal(GRAMMAR_FOCUS_ALLOWED_MODES.has('smart'), true);
+  assert.equal(GRAMMAR_FOCUS_ALLOWED_MODES.has('learn'), true);
+  // Negative roster — explicit to catch an accidental widening.
+  for (const mode of ['surgery', 'builder', 'trouble', 'worked', 'faded', 'satsset', 'bank']) {
+    assert.equal(GRAMMAR_FOCUS_ALLOWED_MODES.has(mode), false, `${mode} must not be in the allowlist`);
+  }
+  // Frozen so a runtime mutation throws (in strict mode) instead of silently
+  // weakening the contract.
+  assert.equal(Object.isFrozen(GRAMMAR_FOCUS_ALLOWED_MODES), true);
+});
+
+test('U5: isGrammarFocusAllowedMode returns true only for smart and learn', () => {
+  assert.equal(isGrammarFocusAllowedMode('smart'), true);
+  assert.equal(isGrammarFocusAllowedMode('learn'), true);
+  for (const mode of ['surgery', 'builder', 'trouble', 'worked', 'faded', 'satsset', 'bank']) {
+    assert.equal(isGrammarFocusAllowedMode(mode), false, `${mode} must not be allowed`);
+  }
+  // Defensive inputs — never crash, always return false.
+  assert.equal(isGrammarFocusAllowedMode(''), false);
+  assert.equal(isGrammarFocusAllowedMode(null), false);
+  assert.equal(isGrammarFocusAllowedMode(undefined), false);
+  assert.equal(isGrammarFocusAllowedMode(123), false);
+  assert.equal(isGrammarFocusAllowedMode({}), false);
+});
+
+// --- Happy paths ------------------------------------------------------------
+
+test('U5 happy: Practise 5 while prefs.mode=smart keeps Smart Practice and sets focus', () => {
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+
+  // Default mode is smart; confirm for rigour before dispatching.
+  let grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.prefs.mode, 'smart');
+
+  harness.dispatch('grammar-focus-concept', { conceptId: 'relative_clauses' });
+
+  grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.prefs.mode, 'smart', 'mode stays smart');
+  assert.equal(grammar.prefs.focusConceptId, 'relative_clauses', 'focus concept persists on prefs');
+  assert.equal(grammar.phase, 'session', 'start-session transition flips phase to session');
+  assert.equal(grammar.session?.mode, 'smart', 'session runs in smart mode');
+  assert.equal(grammar.session?.focusConceptId, 'relative_clauses', 'session carries focus concept id');
+});
+
+test('U5 happy: Practise 5 while prefs.mode=learn keeps Learn mode and sets focus', () => {
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-set-mode', { value: 'learn' });
+
+  let grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.prefs.mode, 'learn');
+
+  harness.dispatch('grammar-focus-concept', { conceptId: 'relative_clauses' });
+
+  grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.prefs.mode, 'learn', 'mode stays learn');
+  assert.equal(grammar.prefs.focusConceptId, 'relative_clauses');
+  assert.equal(grammar.session?.mode, 'learn');
+  assert.equal(grammar.session?.focusConceptId, 'relative_clauses');
+});
+
+// --- Silent override edge cases --------------------------------------------
+
+test('U5 edge: Practise 5 while prefs.mode=surgery silently overrides to Smart + preserves focus', () => {
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-set-mode', { value: 'surgery' });
+
+  let grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.prefs.mode, 'surgery');
+  // `grammar-set-mode` clears focus for non-focus-using modes — this is the
+  // pre-existing contract (preserved by U5).
+  assert.equal(grammar.prefs.focusConceptId, '');
+  // No error is set by the set-mode transition.
+  assert.equal(grammar.error, '');
+
+  harness.dispatch('grammar-focus-concept', { conceptId: 'relative_clauses' });
+
+  grammar = harness.store.getState().subjectUi.grammar;
+  // Silent override — no toast, no error banner.
+  assert.equal(grammar.error, '', 'silent override — no error surfaced');
+  // Mode flipped to smart (allowlisted), focus concept preserved.
+  assert.equal(grammar.prefs.mode, 'smart', 'silent override routes to smart');
+  assert.equal(grammar.prefs.focusConceptId, 'relative_clauses');
+  // Session runs in smart with the requested focus concept.
+  assert.equal(grammar.session?.mode, 'smart');
+  assert.equal(grammar.session?.focusConceptId, 'relative_clauses');
+});
+
+test('U5 edge: Practise 5 while prefs.mode=builder silently overrides to Smart + preserves focus', () => {
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-set-mode', { value: 'builder' });
+
+  harness.dispatch('grammar-focus-concept', { conceptId: 'noun_phrases' });
+
+  const grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.error, '', 'silent override — no error surfaced');
+  assert.equal(grammar.prefs.mode, 'smart');
+  assert.equal(grammar.prefs.focusConceptId, 'noun_phrases');
+  assert.equal(grammar.session?.mode, 'smart');
+  assert.equal(grammar.session?.focusConceptId, 'noun_phrases');
+});
+
+test('U5 edge: Practise 5 while prefs.mode=trouble silently overrides to Smart + preserves focus', () => {
+  // Trouble drops focus on Worker too (`NO_STORED_FOCUS_MODES`). The plan's
+  // intent is that any Practise 5 tap lands in a focus-bearing Smart round —
+  // trouble is rejected by `grammarModeUsesFocus` and falls to the same
+  // silent-override path.
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-set-mode', { value: 'trouble' });
+
+  harness.dispatch('grammar-focus-concept', { conceptId: 'clauses' });
+
+  const grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.error, '', 'silent override — no error surfaced');
+  assert.equal(grammar.prefs.mode, 'smart');
+  assert.equal(grammar.prefs.focusConceptId, 'clauses');
+  assert.equal(grammar.session?.mode, 'smart');
+  assert.equal(grammar.session?.focusConceptId, 'clauses');
+});
+
+test('U5 edge: Practise 5 while prefs.mode=worked preserves Worked Examples (focus-using)', () => {
+  // Worked is a focus-using mode on Worker and sits outside the client
+  // allowlist — but it is not a "mixed practice" mode, so the dispatcher
+  // preserves the learner's scaffold preference rather than overriding.
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-set-mode', { value: 'worked' });
+
+  harness.dispatch('grammar-focus-concept', { conceptId: 'relative_clauses' });
+
+  const grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.prefs.mode, 'worked');
+  assert.equal(grammar.prefs.focusConceptId, 'relative_clauses');
+  assert.equal(grammar.session?.mode, 'worked');
+  assert.equal(grammar.session?.focusConceptId, 'relative_clauses');
+});
+
+test('U5 edge: Practise 5 while prefs.mode=faded preserves Faded Guidance (focus-using)', () => {
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-set-mode', { value: 'faded' });
+
+  harness.dispatch('grammar-focus-concept', { conceptId: 'tense_aspect' });
+
+  const grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.prefs.mode, 'faded');
+  assert.equal(grammar.prefs.focusConceptId, 'tense_aspect');
+  assert.equal(grammar.session?.mode, 'faded');
+  assert.equal(grammar.session?.focusConceptId, 'tense_aspect');
+});
+
+// --- In-flight session → Practise 5 ends the current session cleanly -------
+
+test('U5 edge: Practise 5 during an active Surgery session ends it cleanly + starts a fresh Smart round', () => {
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-set-mode', { value: 'surgery' });
+  // Start a Surgery round — note Surgery's session type is `sentence-surgery`.
+  harness.dispatch('grammar-start', {
+    payload: { roundLength: 1, seed: 7 },
+  });
+
+  let grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.phase, 'session');
+  assert.equal(grammar.session.mode, 'surgery');
+  const priorSessionId = grammar.session.id || grammar.session.startedAt || null;
+
+  // Now tap Practise 5 mid-Surgery — the silent override should end the
+  // Surgery session cleanly and drop the learner into a focused Smart round.
+  harness.dispatch('grammar-focus-concept', { conceptId: 'relative_clauses' });
+
+  grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.error, '', 'no error banner — transition is clean');
+  assert.equal(grammar.prefs.mode, 'smart');
+  assert.equal(grammar.prefs.focusConceptId, 'relative_clauses');
+  assert.equal(grammar.session?.mode, 'smart', 'new session runs in smart');
+  assert.equal(grammar.session?.focusConceptId, 'relative_clauses');
+  // The session identity changed (either id or startedAt must differ) so we
+  // know the prior Surgery session was replaced rather than mutated.
+  const newSessionId = grammar.session.id || grammar.session.startedAt || null;
+  if (priorSessionId && newSessionId) {
+    assert.notEqual(newSessionId, priorSessionId, 'new session replaces prior one');
+  }
+});
+
+// --- Error path: unknown / empty conceptId ---------------------------------
+
+test('U5 error: grammar-focus-concept with empty conceptId is a no-op (no session mutation)', () => {
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+
+  const before = harness.store.getState().subjectUi.grammar;
+  const beforeSnapshot = JSON.stringify({
+    phase: before.phase,
+    mode: before.prefs?.mode,
+    focus: before.prefs?.focusConceptId,
+    session: Boolean(before.session),
+  });
+
+  // Missing conceptId — the dispatcher must short-circuit without mutating
+  // prefs or starting a session.
+  harness.dispatch('grammar-focus-concept', { conceptId: '' });
+
+  const after = harness.store.getState().subjectUi.grammar;
+  const afterSnapshot = JSON.stringify({
+    phase: after.phase,
+    mode: after.prefs?.mode,
+    focus: after.prefs?.focusConceptId,
+    session: Boolean(after.session),
+  });
+  assert.equal(beforeSnapshot, afterSnapshot, 'empty conceptId leaves state untouched');
+  assert.equal(after.error, '', 'no toast / error surfaced');
+});
+
+test('U5 error: grammar-focus-concept with an unknown conceptId starts a session but does not crash', () => {
+  // Unknown concept ids are tolerated — the Worker selection engine will
+  // pick a nearest-valid concept. This test locks in that the dispatcher
+  // itself does NOT crash or set an error banner. The focus concept id
+  // still lands on prefs (engine decides how to handle the unknown id
+  // downstream; the client must not pre-validate against a hard-coded list).
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+
+  assert.doesNotThrow(() => {
+    harness.dispatch('grammar-focus-concept', { conceptId: 'not_a_real_concept' });
+  });
+
+  const after = harness.store.getState().subjectUi.grammar;
+  // Silent — no toast / error banner.
+  assert.equal(after.error, '');
+});
+
+// --- Integration: Grammar Bank → Trouble filter → Practise 5 --------------
+
+test('U5 integration: Grammar Bank Trouble filter → Practise 5 lands in Smart with focus concept', () => {
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-open-concept-bank');
+  harness.dispatch('grammar-concept-bank-filter', { value: 'trouble' });
+
+  let grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.phase, 'bank');
+  assert.equal(grammar.bank.statusFilter, 'trouble');
+
+  // Tap Practise 5 on a real concept id (the bank view-model falls back to
+  // all 18 concepts when analytics is empty, so any valid id works here).
+  harness.dispatch('grammar-focus-concept', { conceptId: 'relative_clauses' });
+
+  grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.prefs.mode, 'smart', 'lands in Smart (allowlisted mode)');
+  assert.equal(grammar.prefs.focusConceptId, 'relative_clauses');
+  assert.equal(grammar.session?.mode, 'smart');
+  assert.equal(grammar.session?.focusConceptId, 'relative_clauses');
+  assert.equal(grammar.phase, 'session', 'bank phase replaced by the new session');
+  // Bank filter state is cleared on session start so re-opening the bank
+  // does not carry the previous visit's "trouble" filter forward.
+  assert.equal(grammar.bank.statusFilter, 'all');
+});
+
+// --- Explicit `mode` override in context.data -----------------------------
+
+test('U5: grammar-focus-concept with data.mode=surgery is silently overridden to Smart', () => {
+  // Defensive test: even if a caller explicitly passes `mode: 'surgery'` in
+  // the dispatch data, the allowlist check overrides it to Smart. This
+  // guards against a future scene passing a stale mode from some other
+  // cache / memoised view.
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  // Start from smart so the only mode signal is the explicit data.mode.
+  harness.dispatch('grammar-set-mode', { value: 'smart' });
+
+  harness.dispatch('grammar-focus-concept', { conceptId: 'clauses', mode: 'surgery' });
+
+  const grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.prefs.mode, 'smart', 'data.mode=surgery is overridden');
+  assert.equal(grammar.prefs.focusConceptId, 'clauses');
+  assert.equal(grammar.session?.mode, 'smart');
+});
+
+test('U5: grammar-focus-concept with data.mode=learn is honoured (allowlisted)', () => {
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  // Start from smart so the only mode signal is the explicit data.mode.
+  harness.dispatch('grammar-set-mode', { value: 'smart' });
+
+  harness.dispatch('grammar-focus-concept', { conceptId: 'clauses', mode: 'learn' });
+
+  const grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.prefs.mode, 'learn');
+  assert.equal(grammar.prefs.focusConceptId, 'clauses');
+  assert.equal(grammar.session?.mode, 'learn');
+});

--- a/tests/grammar-ui-model.test.js
+++ b/tests/grammar-ui-model.test.js
@@ -29,6 +29,7 @@ import {
   GRAMMAR_BANK_CLUSTER_FILTER_IDS,
   GRAMMAR_DASHBOARD_HERO,
   GRAMMAR_CHILD_FORBIDDEN_TERMS,
+  GRAMMAR_FOCUS_ALLOWED_MODES,
   grammarChildConfidenceLabel,
   grammarChildConfidenceTone,
   grammarMonsterClusterForConcept,
@@ -37,6 +38,7 @@ import {
   buildGrammarBankModel,
   grammarSummaryCards,
   isGrammarChildCopy,
+  isGrammarFocusAllowedMode,
 } from '../src/subjects/grammar/components/grammar-view-model.js';
 
 // -----------------------------------------------------------------------------
@@ -303,6 +305,82 @@ test('U8 view-model: GRAMMAR_MORE_PRACTICE_MODES are frozen', () => {
   for (const mode of GRAMMAR_MORE_PRACTICE_MODES) {
     assert.equal(Object.isFrozen(mode), true);
   }
+});
+
+// -----------------------------------------------------------------------------
+// U5 Phase 4: Mixed practice labels + focus allowlist
+// -----------------------------------------------------------------------------
+
+test('U5 view-model: GRAMMAR_MORE_PRACTICE_MODES carries "Mixed practice" label on Surgery and Builder only', () => {
+  const byId = Object.fromEntries(GRAMMAR_MORE_PRACTICE_MODES.map((mode) => [mode.id, mode]));
+  // Surgery + Builder are the two legitimately global/mixed modes per
+  // Worker's `NO_SESSION_FOCUS_MODES` — they must surface the "Mixed
+  // practice" label so the child is told up front that focused concepts
+  // will not stick in these modes.
+  assert.equal(byId.surgery.label, 'Mixed practice');
+  assert.equal(byId.builder.label, 'Mixed practice');
+  // Learn / Worked / Faded all honour focus — no label required.
+  assert.equal(byId.learn.label ?? '', '', 'learn has no Mixed practice label');
+  assert.equal(byId.worked.label ?? '', '', 'worked has no Mixed practice label');
+  assert.equal(byId.faded.label ?? '', '', 'faded has no Mixed practice label');
+});
+
+test('U5 view-model: Mixed practice label stays ~12 chars to fit under the mode title', () => {
+  // Plan-specified wording ("Mixed practice") — 14 chars including space.
+  // Pinned so a later copy tweak that pushes this past ~20 chars (e.g.,
+  // "Mixed-mode practice round") would fail loudly rather than silently
+  // break the dashboard card layout.
+  for (const mode of GRAMMAR_MORE_PRACTICE_MODES) {
+    if (typeof mode.label !== 'string' || !mode.label) continue;
+    assert.ok(
+      mode.label.length <= 20,
+      `label "${mode.label}" on mode ${mode.id} exceeds 20 chars`,
+    );
+  }
+});
+
+test('U5 view-model: GRAMMAR_FOCUS_ALLOWED_MODES is a frozen Set of exactly {smart, learn}', () => {
+  assert.ok(GRAMMAR_FOCUS_ALLOWED_MODES instanceof Set);
+  assert.equal(GRAMMAR_FOCUS_ALLOWED_MODES.size, 2);
+  assert.equal(GRAMMAR_FOCUS_ALLOWED_MODES.has('smart'), true);
+  assert.equal(GRAMMAR_FOCUS_ALLOWED_MODES.has('learn'), true);
+  // Non-members — pinned to catch an accidental widening of the allowlist.
+  // Any new member here would silently contradict James's 2026-04-26
+  // decision that Practise 5 routes into Smart + Learn only.
+  for (const mode of ['surgery', 'builder', 'trouble', 'worked', 'faded', 'satsset', 'bank']) {
+    assert.equal(GRAMMAR_FOCUS_ALLOWED_MODES.has(mode), false, `${mode} must not be allowed`);
+  }
+  assert.equal(Object.isFrozen(GRAMMAR_FOCUS_ALLOWED_MODES), true);
+});
+
+test('U5 view-model: isGrammarFocusAllowedMode is a pure predicate over mode strings', () => {
+  assert.equal(isGrammarFocusAllowedMode('smart'), true);
+  assert.equal(isGrammarFocusAllowedMode('learn'), true);
+  for (const mode of ['surgery', 'builder', 'trouble', 'worked', 'faded', 'satsset', 'bank', 'unknown']) {
+    assert.equal(isGrammarFocusAllowedMode(mode), false, `${mode} must not be allowed`);
+  }
+  // Defensive inputs — never crash.
+  assert.equal(isGrammarFocusAllowedMode(''), false);
+  assert.equal(isGrammarFocusAllowedMode(null), false);
+  assert.equal(isGrammarFocusAllowedMode(undefined), false);
+  assert.equal(isGrammarFocusAllowedMode(123), false);
+  assert.equal(isGrammarFocusAllowedMode({}), false);
+  assert.equal(isGrammarFocusAllowedMode([]), false);
+});
+
+test('U5 view-model: allowlist intersects with GRAMMAR_PRIMARY_MODE_CARDS for Smart only', () => {
+  // Smart sits on the primary dashboard card row — allowlisted. Learn is
+  // a secondary "More practice" mode — allowlisted but not a primary card.
+  // This pinning asserts the narrow primary-card intersection.
+  const primaryIds = GRAMMAR_PRIMARY_MODE_CARDS.map((card) => card.id);
+  const primaryAllowlisted = primaryIds.filter((id) => GRAMMAR_FOCUS_ALLOWED_MODES.has(id));
+  assert.deepEqual(primaryAllowlisted, ['smart']);
+});
+
+test('U5 view-model: allowlist intersects with GRAMMAR_MORE_PRACTICE_MODES for Learn only', () => {
+  const moreIds = GRAMMAR_MORE_PRACTICE_MODES.map((mode) => mode.id);
+  const moreAllowlisted = moreIds.filter((id) => GRAMMAR_FOCUS_ALLOWED_MODES.has(id));
+  assert.deepEqual(moreAllowlisted, ['learn']);
 });
 
 // -----------------------------------------------------------------------------

--- a/tests/react-grammar-surface.test.js
+++ b/tests/react-grammar-surface.test.js
@@ -1403,6 +1403,82 @@ test('Grammar "More practice" disclosure exposes secondary modes without locked 
   assert.doesNotMatch(html, /<button[^>]*class="grammar-secondary-mode[^"]* is-disabled"[^>]*disabled=""/);
 });
 
+// --- U5 Phase 4: Mixed practice labels on Surgery / Builder cards ---------
+
+test('U5: Grammar dashboard renders "Mixed practice" label on Surgery and Builder secondary-mode cards', () => {
+  const storage = installMemoryStorage();
+  const harness = createAppHarness({ storage });
+
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  const html = harness.render();
+
+  // Scope to the More practice disclosure so a stray "Mixed practice"
+  // somewhere else in the app shell does not false-positive the assertion.
+  const disclosureMatch = html.match(/<details class="grammar-more-practice"[\s\S]*?<\/details>/);
+  assert.ok(disclosureMatch, 'More practice disclosure renders');
+  const disclosure = disclosureMatch[0];
+
+  // Surgery and Builder both carry the label under the mode title. The
+  // span is scoped by `data-mode-label="<id>"` so the test can narrow
+  // without matching unrelated spans.
+  assert.match(disclosure, /data-mode-label="surgery"[^>]*>Mixed practice</);
+  assert.match(disclosure, /data-mode-label="builder"[^>]*>Mixed practice</);
+  // The label renders exactly twice on the dashboard (one per mode).
+  const labelCount = (disclosure.match(/Mixed practice/g) || []).length;
+  assert.equal(labelCount, 2, 'Mixed practice label appears on exactly two cards');
+});
+
+test('U5: Grammar dashboard does NOT render "Mixed practice" on Learn, Worked, or Faded cards', () => {
+  const storage = installMemoryStorage();
+  const harness = createAppHarness({ storage });
+
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  const html = harness.render();
+
+  const disclosureMatch = html.match(/<details class="grammar-more-practice"[\s\S]*?<\/details>/);
+  assert.ok(disclosureMatch, 'More practice disclosure renders');
+  const disclosure = disclosureMatch[0];
+
+  // Learn / Worked / Faded cards honour focus — no "Mixed practice" tag.
+  for (const modeId of ['learn', 'worked', 'faded']) {
+    const cardMatch = disclosure.match(
+      new RegExp(`<button[^>]*data-mode-id="${modeId}"[\\s\\S]*?</button>`),
+    );
+    assert.ok(cardMatch, `${modeId} card renders`);
+    assert.doesNotMatch(cardMatch[0], /Mixed practice/);
+    assert.doesNotMatch(cardMatch[0], /data-mode-label="[^"]+"/);
+  }
+});
+
+test('U5: Grammar primary cards (Smart, Trouble, Mini Test, Bank) never render the "Mixed practice" label', () => {
+  const storage = installMemoryStorage();
+  const harness = createAppHarness({ storage });
+
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  const html = harness.render();
+
+  // Primary mode cards live outside the "More practice" disclosure. Scope
+  // to the primary section and assert no Mixed practice copy leaks into
+  // Smart / Trouble / Mini Test / Bank cards.
+  const primaryMatch = html.match(/<section class="grammar-primary-modes"[\s\S]*?<\/section>/);
+  assert.ok(primaryMatch, 'primary modes section renders');
+  assert.doesNotMatch(primaryMatch[0], /Mixed practice/);
+  assert.doesNotMatch(primaryMatch[0], /data-mode-label="/);
+});
+
+test('U5: data-grammar-phase-root="dashboard" landmark is preserved with the Mixed practice labels', () => {
+  // U2 Phase 4 hardened the dashboard landmark — this test ensures U5's
+  // label addition does not disturb the root wrapper. Regression-lock.
+  const storage = installMemoryStorage();
+  const harness = createAppHarness({ storage });
+
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  const html = harness.render();
+  assert.match(html, /data-grammar-phase-root="dashboard"/);
+  // And the label is still rendered inside the dashboard.
+  assert.match(html, /data-mode-label="surgery"/);
+});
+
 test('Grammar setup can start trouble drill mode', () => {
   const storage = installMemoryStorage();
   const harness = createGrammarHarness({ storage });


### PR DESCRIPTION
## Summary

- Add `GRAMMAR_FOCUS_ALLOWED_MODES = {smart, learn}` to the Grammar view-model and expose `isGrammarFocusAllowedMode` as the single-source predicate for scenes and tests.
- Add `label: 'Mixed practice'` to Surgery and Builder entries in `GRAMMAR_MORE_PRACTICE_MODES`; `GrammarSetupScene.jsx` renders the label under the mode title (`data-mode-label`).
- Harden `grammar-focus-concept` dispatcher (`src/subjects/grammar/module.js`) so Practise 5 silently overrides to Smart Practice when the requested mode is Surgery, Builder, or Trouble. Worked / Faded preserve the learner's scaffold choice because Worker honours focus there.
- Worker's existing `NO_SESSION_FOCUS_MODES` / `NO_STORED_FOCUS_MODES` safety net is unchanged — this unit adds the UI-level allowlist above it.

## UX choice: silent override (plan's preferred option)

The dashboard's "Mixed practice" label on Surgery/Builder cards sets the expectation up front so a learner in those modes already knows focus will not stick. The silent override therefore never surprises the child: taps on Practise 5 always land in a Smart round with the chosen concept as `prefs.focusConceptId`. No toast is surfaced because there is no expectation to correct.

Confirms James's 2026-04-26 decision: \"No focused UI action silently becomes mixed practice.\"

## Invariants preserved

- Invariant 10 (English Spelling parity) — Grammar-only changes; no shared helpers or cross-subject enumerators touched.
- Invariant 12 (forbidden-keys universal floor) — no changes to `tests/helpers/forbidden-keys.mjs`.
- No `contentReleaseId` bump (Invariant 9).
- U2 `data-grammar-phase-root=\"dashboard\"` landmark preserved (asserted).

## Test plan

- [x] `tests/grammar-bank-focus-routing.test.js` — 15 new tests covering the allowlist contract, happy paths (smart/learn), silent-override edges (surgery/builder/trouble), focus-preserving edges (worked/faded), in-flight session replacement, empty/unknown conceptId no-op, bank-filter integration, explicit `data.mode` override, and pure predicate rigour.
- [x] `tests/grammar-ui-model.test.js` — 6 new tests covering `GRAMMAR_FOCUS_ALLOWED_MODES` frozen Set + `isGrammarFocusAllowedMode` predicate, Mixed-practice label presence on Surgery/Builder only, label length cap, primary-card and more-practice-card intersection.
- [x] `tests/react-grammar-surface.test.js` — 4 new tests asserting the Mixed practice label renders on Surgery/Builder, is absent on Learn/Worked/Faded, is absent on the primary Smart/Trouble/Mini Test/Bank cards, and that the `data-grammar-phase-root=\"dashboard\"` landmark still fires.
- [x] `npm test -- tests/grammar-bank-focus-routing.test.js` — 15/15 pass.
- [x] `npm test -- tests/grammar-ui-model.test.js` — 87/87 pass (81 pre-existing + 6 new).
- [x] `npm test -- tests/react-grammar-surface.test.js` — 108/108 pass (104 pre-existing + 4 new).
- [x] `npm test -- tests/grammar-functionality-completeness.test.js` — 15/15 pass (regression-lock).
- [x] `npm test -- tests/grammar-phase3-child-copy.test.js tests/grammar-phase3-scopers.test.js tests/grammar-production-smoke.test.js` — all pass.
- [x] `npm run build` + `npm run assert:build-public` + `npm run audit:client` — pass. (`npm run check` asset-copy step hits an unrelated local ENOSPC; build + audit succeed on their own.)

## Files

- `src/subjects/grammar/components/grammar-view-model.js` — add `GRAMMAR_FOCUS_ALLOWED_MODES` + `isGrammarFocusAllowedMode`; add `label: 'Mixed practice'` to Surgery/Builder entries.
- `src/subjects/grammar/module.js` — `grammar-focus-concept` silent override to Smart for non-focus-using modes; accepts optional `data.mode` override that still passes through the allowlist check.
- `src/subjects/grammar/components/GrammarSetupScene.jsx` — `MoreModeCard` renders the `label` span with `data-mode-label`.
- `tests/grammar-bank-focus-routing.test.js` (new) — 15 tests.
- `tests/grammar-ui-model.test.js` — 6 new U5 tests.
- `tests/react-grammar-surface.test.js` — 4 new U5 tests.