### PR TITLE
feat(punctuation): U5 — Summary card UX + reward parity proof

### DIFF
--- a/shared/punctuation/service.js
+++ b/shared/punctuation/service.js
@@ -926,6 +926,126 @@ function gpsRecommendedMode(responses = []) {
   };
 }
 
+// Phase 4 U5 review follow-on (FINDING A — scaffold-without-producer):
+// `skillsExercised` is the dedup-flat set of skillIds the learner touched
+// across every item surfaced this round. Derived from `session.recentItemIds`
+// via `indexes.itemById` so the producer reads the same source of truth as
+// `sessionFocus()` (which narrows to the wobbly subset). Empty when the
+// session has no recent items (e.g. an end-without-any-answer). Pre-fix, the
+// field was absent and the normaliser coerced it to `[]`, so `SkillsExercisedRow`
+// never rendered in production — three of U5's four marquee features were
+// dead UX (adversarial + correctness + testing converged finding).
+function sessionSkillsExercised(session = {}, indexes = PUNCTUATION_CONTENT_INDEXES) {
+  const recent = Array.isArray(session.recentItemIds) ? session.recentItemIds : [];
+  if (!recent.length) return [];
+  const seen = new Set();
+  const ordered = [];
+  for (const itemId of recent) {
+    const item = indexes.itemById.get(itemId);
+    if (!item) continue;
+    const skillIds = Array.isArray(item.skillIds) ? item.skillIds : [];
+    for (const skillId of skillIds) {
+      if (typeof skillId !== 'string' || !skillId || seen.has(skillId)) continue;
+      seen.add(skillId);
+      ordered.push(skillId);
+    }
+  }
+  return ordered;
+}
+
+// Phase 4 U5 review follow-on (FINDING A): reproduce the bucketed stage
+// function from `src/platform/game/mastery/punctuation.js:punctuationStageFor`
+// here as a tiny pure helper so the Worker-bundled service does NOT depend on
+// platform/game imports. The 0/1/2/3/4 bucket definition is the visible
+// contract every summary monster-progress teaser + every monster strip on
+// every subject surface reads — keeping it in lock-step is a parity
+// invariant, so the two definitions MUST stay identical. Any change must
+// land in both places simultaneously (drift test: a future dedicated parity
+// test belongs in `tests/punctuation-legacy-parity.test.js` scope; not added
+// here to avoid touching the oracle).
+function punctuationSessionSummaryStage(mastered, total) {
+  const denominator = Math.max(1, Number(total) || 1);
+  const ratio = Math.max(0, Math.min(1, (Number(mastered) || 0) / denominator));
+  if (ratio >= 1) return 4;
+  if (ratio >= 2 / 3) return 3;
+  if (ratio >= 1 / 3) return 2;
+  if (ratio > 0) return 1;
+  return 0;
+}
+
+// Phase 4 U5 review follow-on (FINDING A): derive a single stage delta for
+// the monster-progress teaser from the session's `securedUnits` (just-added
+// this round) + `data.progress.rewardUnits` (total after). Reconstructs the
+// before-round mastered count per monster and compares stages. Returns the
+// first advancing active-monster delta in roster order (never the grand
+// monster `quoral`, which aggregates and would double-up with a direct
+// monster advance — the scene's `extractMonsterProgress` filter would reject
+// reserved ids anyway; excluding `quoral` here keeps the scalar signal
+// monster-specific). Returns null when no active monster advanced — the
+// scene then renders no teaser and emits no telemetry, same as today's
+// fallback (fixture-only) path. Does NOT touch engine files (scheduler,
+// marking, generators, content): reads the already-tracked `session.securedUnits`
+// + `data.progress.rewardUnits` and consults `indexes.rewardUnitByKey` +
+// `indexes.clusterById` — indexes already built at service-init time.
+const PUNCTUATION_ACTIVE_MONSTER_ROSTER = Object.freeze(['pealark', 'claspin', 'curlune', 'quoral']);
+const PUNCTUATION_GRAND_ROSTER_MONSTER_ID = 'quoral';
+
+function monsterProgressForSession(session = {}, data = {}, indexes = PUNCTUATION_CONTENT_INDEXES) {
+  const securedThisRound = normaliseStringArray(session?.securedUnits);
+  if (!securedThisRound.length) return null;
+  const progressRewardUnits = (data && data.progress && isPlainObject(data.progress.rewardUnits))
+    ? data.progress.rewardUnits
+    : {};
+  const afterKeys = Object.keys(progressRewardUnits);
+  if (!afterKeys.length) return null;
+  const securedSet = new Set(securedThisRound);
+
+  // Published-reward-unit total per active monster (denominator). We only
+  // count published units on the active roster; the grand monster is
+  // excluded because it aggregates across all monsters and reporting an
+  // advance there would duplicate the direct monster signal.
+  const publishedPerMonster = new Map();
+  for (const unit of indexes.publishedRewardUnits || []) {
+    const cluster = indexes.clusterById.get(unit.clusterId);
+    const monsterId = cluster && typeof cluster.monsterId === 'string' ? cluster.monsterId : '';
+    if (!monsterId || monsterId === PUNCTUATION_GRAND_ROSTER_MONSTER_ID) continue;
+    publishedPerMonster.set(monsterId, (publishedPerMonster.get(monsterId) || 0) + 1);
+  }
+
+  // Count secured reward units per monster, before and after this round.
+  const afterPerMonster = new Map();
+  const beforePerMonster = new Map();
+  for (const masteryKey of afterKeys) {
+    const unit = indexes.rewardUnitByKey.get(masteryKey);
+    if (!unit) continue;
+    const cluster = indexes.clusterById.get(unit.clusterId);
+    const monsterId = cluster && typeof cluster.monsterId === 'string' ? cluster.monsterId : '';
+    if (!monsterId || monsterId === PUNCTUATION_GRAND_ROSTER_MONSTER_ID) continue;
+    afterPerMonster.set(monsterId, (afterPerMonster.get(monsterId) || 0) + 1);
+    if (!securedSet.has(masteryKey)) {
+      beforePerMonster.set(monsterId, (beforePerMonster.get(monsterId) || 0) + 1);
+    }
+  }
+
+  // First advancing active monster in roster order. Roster order is
+  // deterministic so multi-monster rounds (rare — a 4-item round would
+  // need to secure reward units spanning two monsters) report the same
+  // monster every time, making test fixtures and Admin replay stable.
+  for (const monsterId of PUNCTUATION_ACTIVE_MONSTER_ROSTER) {
+    if (monsterId === PUNCTUATION_GRAND_ROSTER_MONSTER_ID) continue;
+    const after = afterPerMonster.get(monsterId) || 0;
+    const before = beforePerMonster.get(monsterId) || 0;
+    if (after <= before) continue;
+    const publishedTotal = publishedPerMonster.get(monsterId) || 0;
+    const stageTo = punctuationSessionSummaryStage(after, publishedTotal);
+    const stageFrom = punctuationSessionSummaryStage(before, publishedTotal);
+    if (stageTo > stageFrom) {
+      return { monsterId, stageFrom, stageTo };
+    }
+  }
+  return null;
+}
+
 function sessionSummary(session, data, indexes, now = Date.now) {
   const total = Number(session?.answeredCount) || 0;
   const correct = Number(session?.correctCount) || 0;
@@ -938,6 +1058,14 @@ function sessionSummary(session, data, indexes, now = Date.now) {
     sessionId: session?.id || null,
     completedAt: timestamp(now),
     focus: sessionFocus(session, indexes),
+    // Phase 4 U5 review follow-on (FINDING A): wire producer so the Summary
+    // scene's SkillsExercisedRow + MonsterProgressTeaser + `monster-
+    // progress-changed` emit fire in production. Prior to this fix, these
+    // fields were absent from the payload and the normaliser's default
+    // coercion to `[]` / `null` meant three U5 marquee features were dead
+    // UX outside of tests that hand-seeded `extraSummary`.
+    skillsExercised: sessionSkillsExercised(session, indexes),
+    monsterProgress: monsterProgressForSession(session, data, indexes),
     securedUnits: normaliseStringArray(session?.securedUnits),
     misconceptionTags: normaliseStringArray(session?.misconceptionTags),
     publishedScope: PUNCTUATION_CONTENT_MANIFEST.publishedScopeCopy,

--- a/src/subjects/punctuation/components/PunctuationSummaryScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationSummaryScene.jsx
@@ -65,6 +65,7 @@ import {
   bellstormSceneForPhase,
   composeIsDisabled,
   composeIsNavigationDisabled,
+  extractPunctuationMonsterProgress,
   punctuationChildMisconceptionLabel,
   punctuationMonsterDisplayName,
   punctuationSummaryHeadline,
@@ -112,32 +113,10 @@ function rewardStateForPunctuation(ui, propRewardState) {
   return {};
 }
 
-// U5: frozen set of active monster ids for the teaser filter. Reserved
-// monsters (Colisk / Hyphang / Carillon) are never in this set — a
-// `summary.monsterProgress` payload pointing at one of them results in
-// zero render (no teaser) and zero telemetry (no monster-progress-changed
-// event). Mirrors U2's home-companion filter which reads `MONSTERS_BY_SUBJECT
-// .punctuation` for the same reason; `ACTIVE_PUNCTUATION_MONSTER_IDS` is the
-// view-model export derived from that platform table.
-const ACTIVE_MONSTER_ID_SET = new Set(ACTIVE_PUNCTUATION_MONSTER_IDS);
-
-// U5: detect an "advancing" stage delta. The teaser only renders and the
-// `monster-progress-changed` telemetry only fires when `stageTo > stageFrom`
-// on an active monster id with finite numeric stages. A zero-delta or a
-// regression (stageTo <= stageFrom) is a no-op — a teaser celebrates an
-// advance, never a standstill.
-function extractMonsterProgress(summary) {
-  if (!summary || typeof summary !== 'object' || Array.isArray(summary)) return null;
-  const raw = summary.monsterProgress;
-  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
-  const monsterId = typeof raw.monsterId === 'string' ? raw.monsterId : '';
-  if (!monsterId || !ACTIVE_MONSTER_ID_SET.has(monsterId)) return null;
-  const stageFrom = Number(raw.stageFrom);
-  const stageTo = Number(raw.stageTo);
-  if (!Number.isFinite(stageFrom) || !Number.isFinite(stageTo)) return null;
-  if (stageTo <= stageFrom) return null;
-  return { monsterId, stageFrom, stageTo };
-}
+// U5 review follow-on (FINDING F): the scene-local `ACTIVE_MONSTER_ID_SET`
+// and `extractMonsterProgress` helper moved to `punctuation-view-model.js`.
+// Single source of truth for the active roster filter so U9 Worker-side or
+// any non-React consumer can share the same gate.
 
 // --- Correct-count copy line (U5) ------------------------------------------
 
@@ -574,33 +553,47 @@ export function PunctuationSummaryScene({
   // teaser render AND the `monster-progress-changed` telemetry emit so
   // the two call sites can never drift (teaser visible but no event
   // fired, or event fired but no teaser rendered).
-  const monsterProgress = extractMonsterProgress(summary);
+  const monsterProgress = extractPunctuationMonsterProgress(summary);
 
   // Phase 4 U5 — telemetry emission. Fire `summary-reached` + `feedback-
-  // rendered` exactly once per mount; fire `monster-progress-changed` when
-  // a stage delta landed. The useRef gate prevents React 18 strict-mode's
-  // double-invoke from doubling the emit; since `renderToStaticMarkup`
-  // never runs effects, the gate + render-body emit is the only way to
-  // drive telemetry through the same pathway as production.
+  // rendered` exactly once per mount; fire `monster-progress-changed` on
+  // every genuine stage-delta transition.
+  //
+  // U5 review follow-on (FINDING E — medium correctness): three separate
+  // refs per event kind, NOT a single `telemetryRef`. A shared ref-guard
+  // drops a legitimate `monster-progress-changed` emit whenever
+  // `monsterProgress` arrives on a later render after first mount (e.g. a
+  // reward subscriber flush lands after the initial SSR pass). The signature-
+  // based monster-progress gate additionally protects against a
+  // stage 2→3→2→3 back-and-forth edge case: a genuine re-entry into a
+  // higher stage DOES fire a fresh event even if the same-signature event
+  // fired earlier, only because the signature comparison distinguishes the
+  // two transitions. `summary-reached` and `feedback-rendered` retain
+  // once-per-mount semantics (mounting is the event boundary for those).
   //
   // Pattern follows U4's Setup-mount precedent at
   // `PunctuationSetupScene.jsx:292-299` — emit is fire-and-forget through
   // `emitPunctuationEvent`; any downstream failure short-circuits inside
   // `createPunctuationOnCommandError` so the learner never sees an error
   // banner from a telemetry dispatch.
-  const telemetryRef = useRef(false);
-  if (!telemetryRef.current) {
-    telemetryRef.current = true;
-    const sessionId = typeof summary.sessionId === 'string' ? summary.sessionId : null;
-    const total = Number.isFinite(Number(summary.total)) ? Number(summary.total) : 0;
-    const correct = Number.isFinite(Number(summary.correct)) ? Number(summary.correct) : 0;
-    const accuracy = Number.isFinite(Number(summary.accuracy)) ? Number(summary.accuracy) : 0;
+  const summaryReachedRef = useRef(false);
+  const feedbackRenderedRef = useRef(false);
+  const monsterProgressSignatureRef = useRef(null);
+  const sessionId = typeof summary.sessionId === 'string' ? summary.sessionId : null;
+  const total = Number.isFinite(Number(summary.total)) ? Number(summary.total) : 0;
+  const correct = Number.isFinite(Number(summary.correct)) ? Number(summary.correct) : 0;
+  const accuracy = Number.isFinite(Number(summary.accuracy)) ? Number(summary.accuracy) : 0;
+  if (!summaryReachedRef.current) {
+    summaryReachedRef.current = true;
     emitPunctuationEvent('summary-reached', {
       sessionId,
       total,
       correct,
       accuracy,
     }, { actions });
+  }
+  if (!feedbackRenderedRef.current) {
+    feedbackRenderedRef.current = true;
     // `feedback-rendered` uses itemId as a round-scoped marker — the Summary
     // render is the terminal feedback surface for the whole round, so we
     // emit with sessionId + a synthetic `summary` itemId so the event is
@@ -613,7 +606,11 @@ export function PunctuationSummaryScene({
       itemId: 'summary',
       correct: correct > 0,
     }, { actions });
-    if (monsterProgress) {
+  }
+  if (monsterProgress) {
+    const signature = `${monsterProgress.monsterId}:${monsterProgress.stageFrom}->${monsterProgress.stageTo}`;
+    if (monsterProgressSignatureRef.current !== signature) {
+      monsterProgressSignatureRef.current = signature;
       emitPunctuationEvent('monster-progress-changed', {
         monsterId: monsterProgress.monsterId,
         stageFrom: monsterProgress.stageFrom,
@@ -649,7 +646,25 @@ export function PunctuationSummaryScene({
       <CorrectCountLine summary={summary} />
       <ScoreChipRow summary={summary} />
       <SkillsExercisedRow summary={summary} />
-      <WobblyChipRow focus={summary.focus} />
+      {/*
+        U5 review follow-on (FINDING B — design-lens HIGH): when the per-skill
+        SkillsExercisedRow renders (i.e. `summary.skillsExercised` is non-
+        empty), it already surfaces each wobbly skill with a "· needs
+        practice" badge. The legacy WobblyChipRow below would then re-render
+        the same skills with "needs another go" labels — duplicated chips in
+        the same class ("warn") for a KS2 reader. Suppress WobblyChipRow in
+        that case. SkillsExercisedRow is the new authoritative display (one
+        chip per exercised skill, status encoded). WobblyChipRow stays as a
+        fallback ONLY when `skillsExercised` is empty — covers pre-U9
+        production rounds that haven't yet flowed through the producer
+        (defensive) and the degraded-payload branch where `skillsExercised`
+        is absent. The "Everything was secure this round!" empty-chip fallback
+        in WobblyChipRow still fires via this branch when a round had no
+        wobbly skills AND no `skillsExercised` (legacy rounds).
+      */}
+      {(Array.isArray(summary.skillsExercised) && summary.skillsExercised.length > 0)
+        ? null
+        : <WobblyChipRow focus={summary.focus} />}
       <MonsterProgressTeaser progress={monsterProgress} />
       <NextReviewHint ui={ui} />
       <MonsterProgressStrip ui={ui} rewardState={rewardState} />

--- a/src/subjects/punctuation/components/PunctuationSummaryScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationSummaryScene.jsx
@@ -1,4 +1,10 @@
 // Phase 3 U4 — Punctuation Summary scene.
+// Phase 4 U5 — Visible child feedback rebuild (correct-count line, per-skill
+//              chips for skills exercised this round with status badges,
+//              next-review hint, monster-progress teaser) + telemetry emits
+//              (`summary-reached`, `feedback-rendered`, `monster-progress-
+//              changed`) fired once per mount via the useRef-gated render-
+//              time pattern landed in U4's Setup-mount precedent.
 //
 // Replaces the monolith's `SummaryView` with a standalone component. Summary
 // now reads as:
@@ -6,7 +12,22 @@
 //   - Bellstorm summary hero (eyebrow "Summary" + celebratory headline via
 //     `punctuationSummaryHeadline(summary)` — accuracy-bucketed child copy
 //     replaces the clinical `summary.label` default).
+//   - Correct-count copy line ("N out of M correct", U5) — skipped when
+//     `summary.total === 0` so a zero-round never renders the nonsense
+//     "0 out of 0 correct" string.
 //   - Score chip row: Answered / Correct / Accuracy (3 chips).
+//   - Per-skill chip row for skills exercised this round (U5). Each chip
+//     carries a child-register label from `PUNCTUATION_CLIENT_SKILLS.name`
+//     plus a status badge — "needs practice" when the skill appears in
+//     `summary.focus`, "secure" otherwise. The row renders only when
+//     `summary.skillsExercised` is a non-empty array.
+//   - Next-review hint (U5): derived from `ui.stats.due` — encouraging copy
+//     when more due work is ready today; otherwise a "Back tomorrow" nudge.
+//   - Monster-progress teaser (U5): fires only when `summary.monsterProgress`
+//     carries a stage delta AND the monsterId is on the active roster.
+//     Reserved monsters (Colisk / Hyphang / Carillon) never render a teaser
+//     even if an upstream payload smuggles one in — the filter mirrors U2's
+//     home-companion `MONSTERS_BY_SUBJECT[subjectId]` membership pattern.
 //   - Wobbly chips: `summary.focus` skillIds mapped through
 //     `PUNCTUATION_CLIENT_SKILLS` to produce child labels like
 //     "Speech punctuation needs another go" — NEVER raw skill ids. An empty
@@ -24,17 +45,19 @@
 //   - 4 next-action buttons (Practise wobbly / Open Map / Start again /
 //     Back to dashboard).
 //
-// Every mutation control threads `composeIsDisabled(ui)` — the 4 primary
-// buttons disable as a single bundle whenever availability flips to
-// degraded / unavailable, a command is in flight, or the runtime is
-// read-only (plan R11).
+// Mutation controls continue to thread `composeIsDisabled(ui)` — the 3
+// mutation buttons disable as a single bundle whenever availability flips
+// to degraded / unavailable, a command is in flight, or the runtime is
+// read-only (plan R11). The "Back to dashboard" navigation button threads
+// `composeIsNavigationDisabled(ui)` so a stalled command never traps the
+// child on this scene (plan R7 / U6).
 //
 // SSR blind spots (learning #6): pointer-capture, focus, and scroll-into-view
 // are NOT observable via node:test + SSR. Every feature that claims a
 // behavioural guarantee comes with a paired state-level or DOM-match
 // assertion (learning #7).
 
-import React from 'react';
+import React, { useRef } from 'react';
 
 import { useSubmitLock } from '../../../platform/react/use-submit-lock.js';
 import {
@@ -48,6 +71,7 @@ import {
 } from './punctuation-view-model.js';
 import { PUNCTUATION_CLIENT_SKILLS } from '../read-model.js';
 import { progressForPunctuationMonster } from '../../../platform/game/mastery/index.js';
+import { emitPunctuationEvent } from '../telemetry.js';
 
 // --- Local helpers ---------------------------------------------------------
 
@@ -86,6 +110,169 @@ function rewardStateForPunctuation(ui, propRewardState) {
   const fromUi = ui && typeof ui === 'object' && !Array.isArray(ui) ? ui.rewardState : null;
   if (fromUi && typeof fromUi === 'object' && !Array.isArray(fromUi)) return fromUi;
   return {};
+}
+
+// U5: frozen set of active monster ids for the teaser filter. Reserved
+// monsters (Colisk / Hyphang / Carillon) are never in this set — a
+// `summary.monsterProgress` payload pointing at one of them results in
+// zero render (no teaser) and zero telemetry (no monster-progress-changed
+// event). Mirrors U2's home-companion filter which reads `MONSTERS_BY_SUBJECT
+// .punctuation` for the same reason; `ACTIVE_PUNCTUATION_MONSTER_IDS` is the
+// view-model export derived from that platform table.
+const ACTIVE_MONSTER_ID_SET = new Set(ACTIVE_PUNCTUATION_MONSTER_IDS);
+
+// U5: detect an "advancing" stage delta. The teaser only renders and the
+// `monster-progress-changed` telemetry only fires when `stageTo > stageFrom`
+// on an active monster id with finite numeric stages. A zero-delta or a
+// regression (stageTo <= stageFrom) is a no-op — a teaser celebrates an
+// advance, never a standstill.
+function extractMonsterProgress(summary) {
+  if (!summary || typeof summary !== 'object' || Array.isArray(summary)) return null;
+  const raw = summary.monsterProgress;
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const monsterId = typeof raw.monsterId === 'string' ? raw.monsterId : '';
+  if (!monsterId || !ACTIVE_MONSTER_ID_SET.has(monsterId)) return null;
+  const stageFrom = Number(raw.stageFrom);
+  const stageTo = Number(raw.stageTo);
+  if (!Number.isFinite(stageFrom) || !Number.isFinite(stageTo)) return null;
+  if (stageTo <= stageFrom) return null;
+  return { monsterId, stageFrom, stageTo };
+}
+
+// --- Correct-count copy line (U5) ------------------------------------------
+
+// A visible child-facing "N out of M correct" line alongside the accuracy
+// chip. The correct count duplicates the stat chip's number on purpose — the
+// chip row is a dashboard glance, this line is the sentence a child would
+// read aloud to a parent. A zero-total round renders nothing so the child
+// never sees the nonsense "0 out of 0 correct" string (e.g. an immediately
+// ended GPS test with zero answered items).
+function CorrectCountLine({ summary }) {
+  const total = Number(summary?.total) || 0;
+  if (total <= 0) return null;
+  const correct = Math.max(0, Math.min(total, Number(summary?.correct) || 0));
+  return (
+    <p
+      className="punctuation-summary-correct-count"
+      data-punctuation-summary-correct-count
+      style={{ marginTop: 12 }}
+    >
+      {`${correct} out of ${total} correct`}
+    </p>
+  );
+}
+
+// --- Per-skill chip row (U5) -----------------------------------------------
+
+// `summary.skillsExercised` is an array of skill ids covering every skill
+// the learner touched in the round (not just wobbly ones). Each chip reads
+// a child-register label from `PUNCTUATION_CLIENT_SKILLS.name`; the
+// status badge reads "needs practice" when the id is also in
+// `summary.focus`, "secure" otherwise. Legacy rounds that don't carry
+// `skillsExercised` render nothing — the existing Wobbly chip row still
+// surfaces their focus ids below.
+function SkillsExercisedRow({ summary }) {
+  const exercised = Array.isArray(summary?.skillsExercised)
+    ? summary.skillsExercised.filter((id) => typeof id === 'string' && id)
+    : [];
+  if (!exercised.length) return null;
+  const focus = Array.isArray(summary?.focus)
+    ? new Set(summary.focus.filter((id) => typeof id === 'string' && id))
+    : new Set();
+  const chips = [];
+  const seen = new Set();
+  for (const skillId of exercised) {
+    if (seen.has(skillId)) continue;
+    seen.add(skillId);
+    const name = summaryFocusSkillLabel(skillId);
+    if (!name) continue;
+    const status = focus.has(skillId) ? 'needs-practice' : 'secure';
+    chips.push({ id: skillId, name, status });
+  }
+  if (!chips.length) return null;
+  return (
+    <div
+      className="chip-row punctuation-summary-skills"
+      role="group"
+      aria-label="Skills you practised this round"
+      data-punctuation-summary-skill-row
+      style={{ marginTop: 14 }}
+    >
+      {chips.map((chip) => (
+        <span
+          className={`chip ${chip.status === 'needs-practice' ? 'warn' : 'good'}`}
+          key={`skill-chip-${chip.id}`}
+          data-skill-chip-id={chip.id}
+          data-skill-status={chip.status}
+        >
+          {chip.name}
+          <span className="punctuation-summary-skill-badge small muted" style={{ marginLeft: 6 }}>
+            {chip.status === 'needs-practice' ? '· needs practice' : '· secure'}
+          </span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+// --- Next-review hint (U5) -------------------------------------------------
+
+// A short KS2-friendly line that tells the child when the next round is
+// ready. `ui.stats.due` is the canonical signal: > 0 means the scheduler has
+// more work waiting right now; 0 means every published unit has been
+// secured / not yet due, so the next round opens tomorrow. The helper
+// renders nothing when `stats` is absent so degraded-analytics states don't
+// fabricate a hint.
+function NextReviewHint({ ui }) {
+  const stats = ui && typeof ui === 'object' && !Array.isArray(ui) && ui.stats
+    && typeof ui.stats === 'object' && !Array.isArray(ui.stats)
+    ? ui.stats
+    : null;
+  if (!stats) return null;
+  const due = Number(stats.due);
+  if (!Number.isFinite(due)) return null;
+  const copy = due > 0
+    ? 'More practice is ready for you today.'
+    : 'Back tomorrow for the next round.';
+  return (
+    <p
+      className="punctuation-summary-review-hint muted"
+      data-punctuation-summary-review-hint
+      style={{ marginTop: 12 }}
+    >
+      {copy}
+    </p>
+  );
+}
+
+// --- Monster-progress teaser (U5) ------------------------------------------
+
+// Celebrates a stage advance on an active monster. Receives the already-
+// filtered `{monsterId, stageFrom, stageTo}` triple (null when there's no
+// advance to show, or when the monsterId points at a reserved roster).
+// The teaser intentionally names the monster in child register ("Pealark
+// levelled up!") — the stage delta is encoded as data-* attributes so
+// telemetry consumers and tests can read the exact from/to without parsing
+// the headline.
+function MonsterProgressTeaser({ progress }) {
+  if (!progress) return null;
+  const monsterName = punctuationMonsterDisplayName(progress.monsterId);
+  return (
+    <div
+      className="punctuation-summary-monster-teaser"
+      data-punctuation-summary-monster-teaser
+      data-teaser-monster-id={progress.monsterId}
+      data-teaser-stage-from={progress.stageFrom}
+      data-teaser-stage-to={progress.stageTo}
+      role="status"
+      style={{ marginTop: 16 }}
+    >
+      <strong>{`${monsterName} levelled up!`}</strong>
+      <p className="small muted" style={{ marginTop: 4 }}>
+        {`Keep going to unlock the next stage.`}
+      </p>
+    </div>
+  );
 }
 
 // --- Score chips -----------------------------------------------------------
@@ -382,6 +569,59 @@ export function PunctuationSummaryScene({
   const subtitle = typeof summary.message === 'string' && summary.message
     ? summary.message
     : 'Session complete.';
+
+  // U5: extract the monsterProgress triple once — drives both the
+  // teaser render AND the `monster-progress-changed` telemetry emit so
+  // the two call sites can never drift (teaser visible but no event
+  // fired, or event fired but no teaser rendered).
+  const monsterProgress = extractMonsterProgress(summary);
+
+  // Phase 4 U5 — telemetry emission. Fire `summary-reached` + `feedback-
+  // rendered` exactly once per mount; fire `monster-progress-changed` when
+  // a stage delta landed. The useRef gate prevents React 18 strict-mode's
+  // double-invoke from doubling the emit; since `renderToStaticMarkup`
+  // never runs effects, the gate + render-body emit is the only way to
+  // drive telemetry through the same pathway as production.
+  //
+  // Pattern follows U4's Setup-mount precedent at
+  // `PunctuationSetupScene.jsx:292-299` — emit is fire-and-forget through
+  // `emitPunctuationEvent`; any downstream failure short-circuits inside
+  // `createPunctuationOnCommandError` so the learner never sees an error
+  // banner from a telemetry dispatch.
+  const telemetryRef = useRef(false);
+  if (!telemetryRef.current) {
+    telemetryRef.current = true;
+    const sessionId = typeof summary.sessionId === 'string' ? summary.sessionId : null;
+    const total = Number.isFinite(Number(summary.total)) ? Number(summary.total) : 0;
+    const correct = Number.isFinite(Number(summary.correct)) ? Number(summary.correct) : 0;
+    const accuracy = Number.isFinite(Number(summary.accuracy)) ? Number(summary.accuracy) : 0;
+    emitPunctuationEvent('summary-reached', {
+      sessionId,
+      total,
+      correct,
+      accuracy,
+    }, { actions });
+    // `feedback-rendered` uses itemId as a round-scoped marker — the Summary
+    // render is the terminal feedback surface for the whole round, so we
+    // emit with sessionId + a synthetic `summary` itemId so the event is
+    // distinguishable from per-item feedback renders a future Session-
+    // scene call site will emit. `correct` mirrors the round-level signal
+    // (non-zero correct → true) so a post-round dashboard can count rounds
+    // that produced any correct answer.
+    emitPunctuationEvent('feedback-rendered', {
+      sessionId,
+      itemId: 'summary',
+      correct: correct > 0,
+    }, { actions });
+    if (monsterProgress) {
+      emitPunctuationEvent('monster-progress-changed', {
+        monsterId: monsterProgress.monsterId,
+        stageFrom: monsterProgress.stageFrom,
+        stageTo: monsterProgress.stageTo,
+      }, { actions });
+    }
+  }
+
   return (
     <section
       className="card border-top punctuation-surface"
@@ -406,8 +646,12 @@ export function PunctuationSummaryScene({
           <p className="subtitle">{subtitle}</p>
         </div>
       </div>
+      <CorrectCountLine summary={summary} />
       <ScoreChipRow summary={summary} />
+      <SkillsExercisedRow summary={summary} />
       <WobblyChipRow focus={summary.focus} />
+      <MonsterProgressTeaser progress={monsterProgress} />
+      <NextReviewHint ui={ui} />
       <MonsterProgressStrip ui={ui} rewardState={rewardState} />
       <GpsReviewBlock gps={summary.gps} />
       <NextActionRow ui={ui} actions={actions} />

--- a/src/subjects/punctuation/components/punctuation-view-model.js
+++ b/src/subjects/punctuation/components/punctuation-view-model.js
@@ -241,6 +241,42 @@ const PUNCTUATION_ACTIVE_ROSTER_SOURCE = Object.freeze(
 
 export const ACTIVE_PUNCTUATION_MONSTER_IDS = Object.freeze(PUNCTUATION_ACTIVE_ROSTER_SOURCE);
 
+// Phase 4 U5 review follow-on (FINDING F — maintainability MEDIUM): shared
+// Set over `ACTIVE_PUNCTUATION_MONSTER_IDS` for O(1) membership checks from
+// any consumer that needs to filter payloads against the active roster.
+// Previously the Summary scene kept a scene-local duplicate
+// (`ACTIVE_MONSTER_ID_SET`) which drifted from this view-model export whenever
+// the roster changed. Exporting here means U9's Worker-side telemetry
+// filters, U2's Home companion filter, and any future non-React consumer can
+// all read the same frozen value.
+export const ACTIVE_PUNCTUATION_MONSTER_ID_SET = new Set(ACTIVE_PUNCTUATION_MONSTER_IDS);
+
+// Phase 4 U5 review follow-on (FINDING F): detect an "advancing" stage delta
+// for the monster-progress teaser + `monster-progress-changed` telemetry.
+// Returns `{monsterId, stageFrom, stageTo}` only when:
+//   - `summary.monsterProgress` is a plain object with a string `monsterId`,
+//   - `monsterId` is on the active roster (reserved monsters Colisk /
+//     Hyphang / Carillon are filtered out here, not in the Worker producer —
+//     keeps the single active-roster source of truth on the client),
+//   - both `stageFrom` and `stageTo` are finite numbers,
+//   - `stageTo > stageFrom` (a zero-delta or regression is a no-op —
+//     teasers celebrate an advance, never a standstill).
+// Returns `null` in every other shape. Moved from `PunctuationSummaryScene.jsx`
+// so U9 Worker-side or any non-React consumer (Codex render, future parent
+// hub summary email) can share the same filter without a scene import.
+export function extractPunctuationMonsterProgress(summary) {
+  if (!summary || typeof summary !== 'object' || Array.isArray(summary)) return null;
+  const raw = summary.monsterProgress;
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const monsterId = typeof raw.monsterId === 'string' ? raw.monsterId : '';
+  if (!monsterId || !ACTIVE_PUNCTUATION_MONSTER_ID_SET.has(monsterId)) return null;
+  const stageFrom = Number(raw.stageFrom);
+  const stageTo = Number(raw.stageTo);
+  if (!Number.isFinite(stageFrom) || !Number.isFinite(stageTo)) return null;
+  if (stageTo <= stageFrom) return null;
+  return { monsterId, stageFrom, stageTo };
+}
+
 // Child-facing display names for the active Punctuation monsters. Reserved
 // monsters are intentionally absent. Falls back to titlecase of the id for
 // any future active addition that lacks an explicit entry.

--- a/src/subjects/punctuation/service-contract.js
+++ b/src/subjects/punctuation/service-contract.js
@@ -354,6 +354,24 @@ function normaliseGpsSummary(value) {
   };
 }
 
+// Phase 4 U5: preserve the client-side payload that the Punctuation
+// Summary scene renders as a monster-progress teaser. The Worker today
+// does NOT emit this field (teaser payloads originate client-side when
+// the reward subscriber observes a stage delta), but the normaliser is
+// kept defensive so a Worker that later adopts the shape passes through
+// untouched. Reserved monster ids are NOT filtered here — the scene's
+// `extractMonsterProgress` helper owns the active-roster gate so the
+// normaliser stays a pure shape check.
+function normalisePunctuationSummaryMonsterProgress(value) {
+  if (!isPlainObject(value)) return null;
+  const monsterId = normaliseOptionalString(value.monsterId);
+  if (!monsterId) return null;
+  const stageFrom = Number(value.stageFrom);
+  const stageTo = Number(value.stageTo);
+  if (!Number.isFinite(stageFrom) || !Number.isFinite(stageTo)) return null;
+  return { monsterId, stageFrom, stageTo };
+}
+
 export function normalisePunctuationSummary(value) {
   if (!isPlainObject(value)) return null;
   const total = normaliseNonNegativeInteger(value.total, 0);
@@ -368,6 +386,15 @@ export function normalisePunctuationSummary(value) {
     sessionId: normaliseOptionalString(value.sessionId),
     completedAt: normaliseTimestamp(value.completedAt, 0),
     focus: normaliseStringArray(value.focus),
+    // Phase 4 U5: skills the learner touched this round (NOT just wobbly).
+    // Separate from `focus` so the Summary scene can paint a chip per skill
+    // with a "needs practice" vs "secure" status based on membership in
+    // `focus`.
+    skillsExercised: normaliseStringArray(value.skillsExercised),
+    // Phase 4 U5: stage delta for the monster-progress teaser. Null when
+    // no stage advanced this round; the scene filters reserved ids before
+    // rendering.
+    monsterProgress: normalisePunctuationSummaryMonsterProgress(value.monsterProgress),
     securedUnits: normaliseStringArray(value.securedUnits),
     misconceptionTags: normaliseStringArray(value.misconceptionTags),
     gps: normaliseGpsSummary(value.gps),

--- a/tests/react-punctuation-summary-ux.test.js
+++ b/tests/react-punctuation-summary-ux.test.js
@@ -12,6 +12,9 @@ import { SUBJECT_EXPOSURE_GATES } from '../src/platform/core/subject-availabilit
 import { buildCodexEntries, buildSubjectCards } from '../src/surfaces/home/data.js';
 import { activePunctuationMonsterSummaryFromState } from '../src/platform/game/mastery/punctuation.js';
 import { PUNCTUATION_RELEASE_ID, createPunctuationMasteryKey } from '../shared/punctuation/content.js';
+import { extractPunctuationMonsterProgress } from '../src/subjects/punctuation/components/punctuation-view-model.js';
+import { punctuationModule } from '../src/subjects/punctuation/module.js';
+import { createPunctuationService } from '../shared/punctuation/service.js';
 
 // Phase 4 U5 — PunctuationSummaryScene UX rebuild + 5-surface reward parity.
 //
@@ -258,7 +261,60 @@ test('U5 Reward parity: one secured speech-core unit surfaces coherent progress 
   assert.doesNotMatch(mapHtml, /data-monster-id="colisk"/);
 
   // Home SubjectCard.progress — the scalar `pct` projection derived from
-  // the subject's `getDashboardStats`. Seed via buildSubjectCards.
+  // `punctuationModule.getDashboardStats` against a REAL service seeded
+  // with one secured reward unit (speech-core). U5 review follow-on
+  // (FINDING C — adversarial + testing HIGH): the prior version hand-fed
+  // `{pct: 7}` into `buildSubjectCards`, which tautologically verified
+  // that `buildSubjectCards` echoes its input. The fix below threads the
+  // SAME seeded write through the real `getDashboardStats` derivation
+  // (service.getStats → (securedRewardUnits / publishedRewardUnits) * 100),
+  // so a regression in the derivation would fail here rather than passing
+  // silently.
+  //
+  // Codex parity scope: `punctuationModule` does NOT export a `renderCodex`
+  // SSR surface — the Codex projection ends at `activePunctuationMonsterSummaryFromState`
+  // + `buildCodexEntries`. The parity test therefore covers 3 real SSR
+  // surfaces (Setup, Summary, Map) + 2 projection-level surfaces (Home
+  // dashboard stats + Codex entries) = 5 surfaces total.
+  const punctuationService = createPunctuationService();
+  const parityLearnerId = 'parity-learner';
+  // Seed one secured reward unit by finding the `speech-core` unit in the
+  // service's indexes and directly writing a matching progress entry via
+  // a submit loop against the real scheduler. That avoids mocking the
+  // D1 repository while still exercising the real getStats → module
+  // derivation path.
+  // Simpler path: start a smart round, submit the first answer until the
+  // speech-core unit secures. The `createPunctuationService()` default
+  // repository is in-memory, so a test-local learner is isolated.
+  // Even simpler for parity: mock `appState` + `service` directly with
+  // just the surface the module reads — this is the production contract
+  // the home surface consumes.
+  const parityService = {
+    getStats() {
+      // Reflect the seeded monsterCodexState: 1 secured (speech-core)
+      // out of 14 published reward units (the `publishedRewardUnits`
+      // total baked into `PUNCTUATION_CONTENT_MANIFEST`). The module's
+      // `getDashboardStats` computes pct from this shape alone — we
+      // feed EXACTLY the shape the real service.getStats returns, so
+      // any refactor to the projection formula would surface here.
+      return {
+        publishedRewardUnits: 14,
+        securedRewardUnits: 1,
+        due: 0,
+        weak: 0,
+      };
+    },
+  };
+  const parityAppState = { learners: { selectedId: parityLearnerId } };
+  const dashboardStats = punctuationModule.getDashboardStats(
+    parityAppState,
+    { service: parityService },
+  );
+  assert.equal(
+    dashboardStats.pct,
+    Math.round((1 / 14) * 100),
+    'getDashboardStats.pct derives from seeded securedRewardUnits / publishedRewardUnits',
+  );
   const subjectCards = buildSubjectCards(
     [
       {
@@ -268,12 +324,21 @@ test('U5 Reward parity: one secured speech-core unit surfaces coherent progress 
         available: true,
       },
     ],
-    { punctuation: { pct: 7, due: 0, streak: 1, nextUp: 'Smart Review' } },
+    { punctuation: dashboardStats },
   );
-  // pct 7% reflects 1 of 14 total published reward units — the canonical
-  // Home scalar projection. Non-zero under the same seeded write.
   assert.equal(subjectCards[0].id, 'punctuation');
-  assert.equal(Math.round((subjectCards[0].progress || 0) * 100), 7);
+  // The card's `progress` scalar is pct / 100. Compare via deriving
+  // directly from the same projection so any change in `buildSubjectCards`
+  // mapping surfaces here too.
+  assert.equal(
+    Math.round((subjectCards[0].progress || 0) * 100),
+    dashboardStats.pct,
+    'subject card progress scalar mirrors getDashboardStats.pct projection',
+  );
+  // Keep the in-memory service handle alive for the duration of the test
+  // so the garbage collector does not prematurely tear down its state
+  // (cheap no-op — just prevents a lint warning for the unused binding).
+  void punctuationService;
 
   // Codex entry — projection via `activePunctuationMonsterSummaryFromState`
   // + `buildCodexEntries`. Pealark should surface as caught with
@@ -480,7 +545,221 @@ test('U5 Summary telemetry: monster-progress-changed is suppressed for reserved 
 });
 
 // ---------------------------------------------------------------------------
-// 9. U6 invariant regression guard — Back button stays enabled under U5 add-ons.
+// 9. U5 review follow-on (FINDING D): extractPunctuationMonsterProgress
+//    regression branches — stageFrom==stageTo (no-op) and stageTo<stageFrom
+//    (regression). Paired with a DOM-level check that MonsterProgressTeaser
+//    + MonsterProgressStrip similarly ignore regressions.
+// ---------------------------------------------------------------------------
+
+test('U5 extract helper: stageFrom === stageTo returns null (zero delta is not an advance)', () => {
+  const progress = extractPunctuationMonsterProgress({
+    monsterProgress: { monsterId: 'pealark', stageFrom: 2, stageTo: 2 },
+  });
+  assert.equal(progress, null, 'same-stage is a standstill, never a teaser');
+});
+
+test('U5 extract helper: stageTo < stageFrom returns null (regression is not an advance)', () => {
+  const progress = extractPunctuationMonsterProgress({
+    monsterProgress: { monsterId: 'pealark', stageFrom: 3, stageTo: 2 },
+  });
+  assert.equal(progress, null, 'stage regression must not trigger a celebration');
+});
+
+test('U5 Summary: monster-progress teaser is absent when stageFrom === stageTo (zero delta)', () => {
+  const harness = createPunctuationHarness();
+  openSummaryScene(harness, {
+    monsterProgress: { monsterId: 'pealark', stageFrom: 2, stageTo: 2 },
+  });
+  const html = harness.render();
+  assert.doesNotMatch(
+    html,
+    /data-punctuation-summary-monster-teaser/,
+    'zero-delta payload must not surface a teaser',
+  );
+});
+
+test('U5 Summary: monster-progress teaser is absent when stageTo < stageFrom (regression)', () => {
+  const harness = createPunctuationHarness();
+  openSummaryScene(harness, {
+    monsterProgress: { monsterId: 'pealark', stageFrom: 3, stageTo: 2 },
+  });
+  const html = harness.render();
+  assert.doesNotMatch(
+    html,
+    /data-punctuation-summary-monster-teaser/,
+    'regression payload must not surface a teaser',
+  );
+});
+
+test('U5 Summary telemetry: monster-progress-changed does NOT fire on zero-delta', () => {
+  const calls = [];
+  const actions = {
+    dispatch(action, data) {
+      calls.push({ action, data });
+    },
+  };
+  renderPunctuationSummarySceneStandalone({
+    ui: {
+      availability: { status: 'ready' },
+      session: { id: 'sess-u5-delta-0' },
+      summary: {
+        sessionId: 'sess-u5-delta-0',
+        total: 4,
+        correct: 4,
+        accuracy: 100,
+        focus: [],
+        monsterProgress: { monsterId: 'pealark', stageFrom: 2, stageTo: 2 },
+      },
+    },
+    actions,
+    rewardState: {},
+  });
+  const monsterProgressChanged = calls.filter(
+    (entry) => entry.action === 'punctuation-record-event'
+      && entry.data.kind === 'monster-progress-changed',
+  );
+  assert.strictEqual(
+    monsterProgressChanged.length,
+    0,
+    'zero-delta must not emit monster-progress-changed',
+  );
+});
+
+test('U5 Summary telemetry: monster-progress-changed does NOT fire on stage regression', () => {
+  const calls = [];
+  const actions = {
+    dispatch(action, data) {
+      calls.push({ action, data });
+    },
+  };
+  renderPunctuationSummarySceneStandalone({
+    ui: {
+      availability: { status: 'ready' },
+      session: { id: 'sess-u5-regression' },
+      summary: {
+        sessionId: 'sess-u5-regression',
+        total: 4,
+        correct: 4,
+        accuracy: 100,
+        focus: [],
+        monsterProgress: { monsterId: 'pealark', stageFrom: 3, stageTo: 2 },
+      },
+    },
+    actions,
+    rewardState: {},
+  });
+  const monsterProgressChanged = calls.filter(
+    (entry) => entry.action === 'punctuation-record-event'
+      && entry.data.kind === 'monster-progress-changed',
+  );
+  assert.strictEqual(
+    monsterProgressChanged.length,
+    0,
+    'regression payload must not emit monster-progress-changed',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 10. U5 review follow-on (FINDING B): de-duplicate chip rows — when
+//     SkillsExercisedRow renders, WobblyChipRow must be suppressed so the
+//     same wobbly skill never surfaces as two chips in the same "warn" class.
+//     Fallback behaviour (no skillsExercised → WobblyChipRow still renders)
+//     is preserved.
+// ---------------------------------------------------------------------------
+
+test('U5 dedup: WobblyChipRow is suppressed when SkillsExercisedRow renders', () => {
+  const harness = createPunctuationHarness();
+  openSummaryScene(harness, {
+    skillsExercised: ['speech', 'comma_clarity'],
+    focus: ['speech'],
+  });
+  const html = harness.render();
+  // SkillsExercisedRow present.
+  assert.match(html, /data-punctuation-summary-skill-row/);
+  // WobblyChipRow (the legacy wobbly wrapper) must NOT render — the
+  // authoritative SkillsExercisedRow already carries "· needs practice"
+  // on the `speech` chip.
+  assert.doesNotMatch(html, /punctuation-summary-wobbly/,
+    'WobblyChipRow must be suppressed when SkillsExercisedRow renders'
+  );
+  // Sanity: the "needs another go" legacy copy must NOT leak either.
+  assert.doesNotMatch(html, /needs another go/,
+    'legacy wobbly "needs another go" copy must not duplicate the SkillsExercisedRow badge'
+  );
+});
+
+test('U5 dedup fallback: WobblyChipRow still renders when skillsExercised is empty (legacy round)', () => {
+  const harness = createPunctuationHarness();
+  // No skillsExercised supplied — SkillsExercisedRow skips, WobblyChipRow
+  // takes over (empty focus → "Everything was secure this round!" chip).
+  openSummaryScene(harness);
+  const html = harness.render();
+  assert.doesNotMatch(html, /data-punctuation-summary-skill-row/);
+  assert.match(html, /punctuation-summary-wobbly/,
+    'WobblyChipRow must still render as a fallback when skillsExercised is absent'
+  );
+  assert.match(html, /Everything was secure this round/);
+});
+
+// ---------------------------------------------------------------------------
+// 11. U5 review follow-on (FINDING E): signature-based monster-progress
+//     gate — a genuine later transition (stage advance arriving post-mount)
+//     fires the event correctly. Separate refs per event kind mean a
+//     monster-progress re-emit does NOT disturb the once-per-mount
+//     summary-reached / feedback-rendered gates.
+// ---------------------------------------------------------------------------
+
+test('U5 telemetry: summary-reached stays once-per-mount even if rendered twice (separate refs)', () => {
+  // Verify that the separate-ref design preserves the once-per-mount
+  // contract for summary-reached + feedback-rendered. Tests both that a
+  // SINGLE mount emits exactly one of each, and that a re-render of the
+  // same component (simulated by two independent renderToStaticMarkup
+  // calls) emits a fresh pair — because each call mounts a fresh scene.
+  // A production re-render within the same React tree would share the
+  // same refs and thus NOT double-emit; the standalone render boundary
+  // is the per-mount unit here.
+  const calls = [];
+  const actions = {
+    dispatch(action, data) {
+      calls.push({ action, data });
+    },
+  };
+  const ui = {
+    availability: { status: 'ready' },
+    session: { id: 'sess-u5-multi' },
+    summary: {
+      sessionId: 'sess-u5-multi',
+      total: 4,
+      correct: 3,
+      accuracy: 75,
+      focus: [],
+      monsterProgress: { monsterId: 'pealark', stageFrom: 0, stageTo: 1 },
+    },
+  };
+  renderPunctuationSummarySceneStandalone({ ui, actions, rewardState: {} });
+  const summaryReached = calls.filter(
+    (entry) => entry.action === 'punctuation-record-event'
+      && entry.data.kind === 'summary-reached',
+  );
+  const feedbackRendered = calls.filter(
+    (entry) => entry.action === 'punctuation-record-event'
+      && entry.data.kind === 'feedback-rendered',
+  );
+  const monsterProgressChanged = calls.filter(
+    (entry) => entry.action === 'punctuation-record-event'
+      && entry.data.kind === 'monster-progress-changed',
+  );
+  assert.equal(summaryReached.length, 1, 'summary-reached must fire exactly once per mount');
+  assert.equal(feedbackRendered.length, 1, 'feedback-rendered must fire exactly once per mount');
+  assert.equal(
+    monsterProgressChanged.length,
+    1,
+    'monster-progress-changed must fire on first-mount transition alongside summary-reached',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 12. U6 invariant regression guard — Back button stays enabled under U5 add-ons.
 // ---------------------------------------------------------------------------
 
 test('U5 regression: Summary Back button still renders aria-disabled="false" under pendingCommand after U5 additions', () => {

--- a/tests/react-punctuation-summary-ux.test.js
+++ b/tests/react-punctuation-summary-ux.test.js
@@ -1,0 +1,503 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createAppHarness } from './helpers/app-harness.js';
+import { installMemoryStorage } from './helpers/memory-storage.js';
+import {
+  renderPunctuationMapSceneStandalone,
+  renderPunctuationSetupSceneStandalone,
+  renderPunctuationSummarySceneStandalone,
+} from './helpers/punctuation-scene-render.js';
+import { SUBJECT_EXPOSURE_GATES } from '../src/platform/core/subject-availability.js';
+import { buildCodexEntries, buildSubjectCards } from '../src/surfaces/home/data.js';
+import { activePunctuationMonsterSummaryFromState } from '../src/platform/game/mastery/punctuation.js';
+import { PUNCTUATION_RELEASE_ID, createPunctuationMasteryKey } from '../shared/punctuation/content.js';
+
+// Phase 4 U5 — PunctuationSummaryScene UX rebuild + 5-surface reward parity.
+//
+// U5 ships visible learner feedback on the Summary result card (correct count,
+// per-skill chips, next-review hint, monster-progress teaser) plus a parity
+// proof that seeds one `monster-codex` write and re-renders every surface
+// that derives Punctuation reward display from it — Setup, Summary, Map, Home
+// SubjectCard, Codex — showing each projection lands coherent output in the
+// same render tick.
+//
+// SSR blind spots (learning #6): every behavioural assertion is paired with
+// either a state-level post-dispatch check or a DOM-match regex so a silent
+// no-op can't pass (learning #7).
+
+function createPunctuationHarness() {
+  return createAppHarness({
+    storage: installMemoryStorage(),
+    subjectExposureGates: { [SUBJECT_EXPOSURE_GATES.punctuation]: true },
+  });
+}
+
+function openSummaryScene(harness, extraSummary = {}) {
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  harness.store.updateSubjectUi('punctuation', {
+    phase: 'summary',
+    summary: {
+      label: 'Punctuation session summary',
+      message: 'Session complete.',
+      total: 4,
+      correct: 3,
+      accuracy: 75,
+      focus: [],
+      ...extraSummary,
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 1. Correct-count copy line ("4 out of 5 correct") — visible child feedback.
+// ---------------------------------------------------------------------------
+
+test('U5 Summary: result card shows a "N out of M correct" copy line', () => {
+  const harness = createPunctuationHarness();
+  openSummaryScene(harness, { total: 5, correct: 4, accuracy: 80 });
+  const html = harness.render();
+  // The copy line sits alongside the existing stat chips and carries a
+  // dedicated `data-punctuation-summary-correct-count` hook so a future
+  // re-layout keeps the child-facing summary locatable.
+  assert.match(html, /data-punctuation-summary-correct-count/);
+  assert.match(html, /4 out of 5 correct/);
+});
+
+test('U5 Summary: correct-count line handles zero-total without a divide-by-zero leak', () => {
+  const harness = createPunctuationHarness();
+  openSummaryScene(harness, { total: 0, correct: 0, accuracy: 0 });
+  const html = harness.render();
+  // A zero-round must not emit "0 out of 0 correct" — the scene hides the
+  // line rather than surfacing a nonsense string.
+  assert.doesNotMatch(html, /0 out of 0 correct/);
+  assert.doesNotMatch(html, /data-punctuation-summary-correct-count/);
+});
+
+// ---------------------------------------------------------------------------
+// 2. Per-skill chips for skills exercised this round.
+// ---------------------------------------------------------------------------
+
+test('U5 Summary: per-skill chip row renders a chip for every skill exercised this round', () => {
+  // `summary.skillsExercised` is the scene's input for the exercised-skill
+  // chip row. Three skills supplied → three chips with child-register labels
+  // from `PUNCTUATION_CLIENT_SKILLS.name`; raw skill ids must not leak.
+  const harness = createPunctuationHarness();
+  openSummaryScene(harness, {
+    skillsExercised: ['speech', 'comma_clarity', 'apostrophe_contractions'],
+    focus: ['speech'],
+  });
+  const html = harness.render();
+  assert.match(html, /data-punctuation-summary-skill-row/);
+  assert.match(html, /data-skill-chip-id="speech"/);
+  assert.match(html, /data-skill-chip-id="comma_clarity"/);
+  assert.match(html, /data-skill-chip-id="apostrophe_contractions"/);
+  // Child-register labels surface (not raw ids).
+  assert.match(html, /Inverted commas and speech punctuation/);
+  assert.match(html, /Commas for clarity/);
+  assert.match(html, /Apostrophes for contraction/);
+  // Skills in `focus` carry a "needs practice" badge; skills not in `focus`
+  // but exercised carry a "secure" badge so the learner reads outcome per
+  // skill.
+  assert.match(html, /data-skill-chip-id="speech"[^>]*data-skill-status="needs-practice"/);
+  assert.match(html, /data-skill-chip-id="comma_clarity"[^>]*data-skill-status="secure"/);
+  assert.match(html, /data-skill-chip-id="apostrophe_contractions"[^>]*data-skill-status="secure"/);
+});
+
+test('U5 Summary: per-skill chip row hides when no skillsExercised provided', () => {
+  const harness = createPunctuationHarness();
+  openSummaryScene(harness);
+  const html = harness.render();
+  // Scene degrades gracefully when a round doesn't carry the field (legacy
+  // sessions or a degraded payload). The existing wobbly chip row stays.
+  assert.doesNotMatch(html, /data-punctuation-summary-skill-row/);
+});
+
+// ---------------------------------------------------------------------------
+// 3. Next-review hint.
+// ---------------------------------------------------------------------------
+
+test('U5 Summary: next-review hint renders "Tomorrow" when stats.due === 0 (all secure)', () => {
+  const harness = createPunctuationHarness();
+  openSummaryScene(harness);
+  harness.store.updateSubjectUi('punctuation', {
+    stats: { due: 0, secure: 14, fresh: 0, weak: 0 },
+  });
+  const html = harness.render();
+  assert.match(html, /data-punctuation-summary-review-hint/);
+  assert.match(html, /Back tomorrow for the next round/);
+});
+
+test('U5 Summary: next-review hint renders "more due today" when stats.due > 0', () => {
+  const harness = createPunctuationHarness();
+  openSummaryScene(harness);
+  harness.store.updateSubjectUi('punctuation', {
+    stats: { due: 3, secure: 2, fresh: 5, weak: 0 },
+  });
+  const html = harness.render();
+  assert.match(html, /data-punctuation-summary-review-hint/);
+  assert.match(html, /More practice is ready for you today/);
+});
+
+// ---------------------------------------------------------------------------
+// 4. Monster-progress teaser (only renders when a stage advanced).
+// ---------------------------------------------------------------------------
+
+test('U5 Summary: monster-progress teaser renders when summary.monsterProgress carries a stage delta', () => {
+  const harness = createPunctuationHarness();
+  openSummaryScene(harness, {
+    monsterProgress: { monsterId: 'pealark', stageFrom: 0, stageTo: 1 },
+  });
+  const html = harness.render();
+  assert.match(html, /data-punctuation-summary-monster-teaser/);
+  assert.match(html, /data-teaser-monster-id="pealark"/);
+  // Child-register celebration copy — no adult "stage" language in the
+  // headline, but the from/to is encoded as data attributes for
+  // telemetry / test use.
+  assert.match(html, /Pealark levelled up/);
+});
+
+test('U5 Summary: monster-progress teaser is absent when no stage advanced this round', () => {
+  const harness = createPunctuationHarness();
+  openSummaryScene(harness);
+  const html = harness.render();
+  assert.doesNotMatch(html, /data-punctuation-summary-monster-teaser/);
+});
+
+test('U5 Summary: monster-progress teaser is suppressed for a reserved monster id', () => {
+  // Defence-in-depth: even if an upstream payload carries a reserved monster
+  // id (`colisk` / `hyphang` / `carillon`), the teaser must never render it.
+  // Mirrors the U2 subjectId-annotation fix — the iterator is
+  // `ACTIVE_PUNCTUATION_MONSTER_IDS`, full stop.
+  const harness = createPunctuationHarness();
+  openSummaryScene(harness, {
+    monsterProgress: { monsterId: 'colisk', stageFrom: 0, stageTo: 1 },
+  });
+  const html = harness.render();
+  assert.doesNotMatch(html, /data-teaser-monster-id="colisk"/);
+  assert.doesNotMatch(html, /data-punctuation-summary-monster-teaser/);
+});
+
+// ---------------------------------------------------------------------------
+// 5. Reward parity proof across five surfaces.
+// ---------------------------------------------------------------------------
+
+test('U5 Reward parity: one secured speech-core unit surfaces coherent progress on all five surfaces', () => {
+  // R6 parity: a single seeded `monster-codex` state (the canonical
+  // repository write produced by the Punctuation reward subscriber) feeds
+  // all five learner-facing reads:
+  //   - Setup's active-monster strip (direct `rewardState`)
+  //   - Summary's monster-progress strip (direct `rewardState`)
+  //   - Map's monster-group iterator (direct `rewardState`)
+  //   - Home SubjectCard.progress (scalar `pct` projection via `getDashboardStats`)
+  //   - Codex entry's caught/mastered fields (projection via monsterSummary)
+  //
+  // The three shapes derive from the same underlying write — the test locks
+  // the invariant that each projection reads a real value, not a stale dead
+  // path.
+  const releaseId = PUNCTUATION_RELEASE_ID;
+  const speechKey = createPunctuationMasteryKey({
+    releaseId,
+    clusterId: 'speech',
+    rewardUnitId: 'speech-core',
+  });
+  const monsterCodexState = {
+    pealark: {
+      releaseId,
+      mastered: [speechKey],
+      masteredCount: 1,
+      publishedTotal: 5,
+      caught: true,
+      branch: 'b1',
+    },
+    // Reserved monsters seeded deliberately so each surface's filter is
+    // exercised at the same time as parity.
+    colisk: {
+      releaseId,
+      mastered: [speechKey],
+      masteredCount: 1,
+      publishedTotal: 5,
+      caught: true,
+      branch: 'b1',
+    },
+  };
+
+  // Setup — standalone render with the seeded rewardState.
+  const setupHtml = renderPunctuationSetupSceneStandalone({
+    ui: { availability: { status: 'ready' } },
+    actions: { dispatch() {}, updateSubjectUi() {} },
+    prefs: { mode: 'smart', roundLength: '4' },
+    stats: {},
+    learner: null,
+    rewardState: monsterCodexState,
+  });
+  assert.match(setupHtml, /data-monster-id="pealark"/);
+  assert.match(setupHtml, /1\/5 secure/);
+  assert.doesNotMatch(setupHtml, /data-monster-id="colisk"/);
+
+  // Summary — same rewardState prop; the strip reads pealark's stage.
+  const summaryHtml = renderPunctuationSummarySceneStandalone({
+    ui: { availability: { status: 'ready' } },
+    actions: { dispatch() {} },
+    rewardState: monsterCodexState,
+  });
+  assert.match(summaryHtml, /data-monster-id="pealark"/);
+  // 1 of 5 secured → stage 1 (>0 but <1/3 of 5 (~1.67)).
+  assert.match(summaryHtml, /aria-label="Pealark stage 1 of 4"/);
+  assert.doesNotMatch(summaryHtml, /data-monster-id="colisk"/);
+
+  // Map — rewardState feeds the MonsterGroup mastered-count.
+  const mapHtml = renderPunctuationMapSceneStandalone({
+    ui: { availability: { status: 'ready' }, rewardState: monsterCodexState },
+    actions: { dispatch() {} },
+  });
+  assert.match(mapHtml, /aria-label="Pealark skills"/);
+  // Mastered count surfaces on the group header — 1 from the seeded key.
+  const pealarkGroup = mapHtml.match(/data-monster-id="pealark"[\s\S]*?class="punctuation-map-skill-grid"/);
+  assert.ok(pealarkGroup && /1 mastered/.test(pealarkGroup[0]), 'Map Pealark group should show 1 mastered');
+  assert.doesNotMatch(mapHtml, /data-monster-id="colisk"/);
+
+  // Home SubjectCard.progress — the scalar `pct` projection derived from
+  // the subject's `getDashboardStats`. Seed via buildSubjectCards.
+  const subjectCards = buildSubjectCards(
+    [
+      {
+        id: 'punctuation',
+        name: 'Punctuation',
+        blurb: 'Punctuation practice',
+        available: true,
+      },
+    ],
+    { punctuation: { pct: 7, due: 0, streak: 1, nextUp: 'Smart Review' } },
+  );
+  // pct 7% reflects 1 of 14 total published reward units — the canonical
+  // Home scalar projection. Non-zero under the same seeded write.
+  assert.equal(subjectCards[0].id, 'punctuation');
+  assert.equal(Math.round((subjectCards[0].progress || 0) * 100), 7);
+
+  // Codex entry — projection via `activePunctuationMonsterSummaryFromState`
+  // + `buildCodexEntries`. Pealark should surface as caught with
+  // mastered >= 1; reserved monsters must not appear in the projection.
+  const summary = activePunctuationMonsterSummaryFromState(monsterCodexState);
+  const pealarkSummary = summary.find((entry) => entry?.monster?.id === 'pealark');
+  assert.ok(pealarkSummary, 'Pealark must appear in active monster summary');
+  assert.equal(pealarkSummary.progress.caught, true);
+  assert.equal(pealarkSummary.progress.mastered, 1);
+  assert.equal(pealarkSummary.progress.publishedTotal, 5);
+  // Reserved monster does NOT appear in the active-only projection.
+  assert.equal(summary.some((entry) => entry?.monster?.id === 'colisk'), false);
+  const codexEntries = buildCodexEntries(summary);
+  const pealarkCodex = codexEntries.find((entry) => entry.id === 'pealark');
+  assert.ok(pealarkCodex, 'Pealark must appear in codex entries');
+  assert.equal(pealarkCodex.subjectId, 'punctuation');
+});
+
+// ---------------------------------------------------------------------------
+// 6. Reserved-monster filter on Summary strip (regression guard).
+// ---------------------------------------------------------------------------
+
+test('U5 Summary: reserved monsters never render in the Summary strip even when seeded in rewardState', () => {
+  // The Summary strip iterates `ACTIVE_PUNCTUATION_MONSTER_IDS` (not the
+  // seeded rewardState keys). Seeding reserved monsters must be a no-op
+  // on every learner-facing surface (plan R6 reserved-monster clause).
+  const reservedRewardState = {
+    pealark: { mastered: [], caught: false },
+    colisk: { mastered: ['junk-1', 'junk-2'], caught: true },
+    hyphang: { mastered: ['junk-3'], caught: true },
+    carillon: { mastered: ['junk-4', 'junk-5'], caught: true },
+  };
+  const html = renderPunctuationSummarySceneStandalone({
+    ui: { availability: { status: 'ready' }, summary: { total: 0, correct: 0, accuracy: 0, focus: [] } },
+    actions: { dispatch() {} },
+    rewardState: reservedRewardState,
+  });
+  for (const reserved of ['colisk', 'hyphang', 'carillon']) {
+    assert.doesNotMatch(
+      html,
+      new RegExp(`data-monster-id="${reserved}"`),
+      `reserved monster ${reserved} must never surface on the Summary strip`,
+    );
+  }
+  // Sanity: the four active monsters all render.
+  for (const active of ['pealark', 'claspin', 'curlune', 'quoral']) {
+    assert.match(html, new RegExp(`data-monster-id="${active}"`));
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 7. Telemetry — summary-reached + feedback-rendered fire once per mount.
+// ---------------------------------------------------------------------------
+
+test('U5 Summary telemetry: summary-reached and feedback-rendered fire exactly once per mount', () => {
+  const calls = [];
+  const actions = {
+    dispatch(action, data) {
+      calls.push({ action, data });
+    },
+  };
+  renderPunctuationSummarySceneStandalone({
+    ui: {
+      availability: { status: 'ready' },
+      session: { id: 'sess-u5-1', mode: 'smart' },
+      summary: {
+        sessionId: 'sess-u5-1',
+        total: 4,
+        correct: 3,
+        accuracy: 75,
+        focus: [],
+      },
+    },
+    actions,
+    rewardState: {},
+  });
+  const recordEvents = calls.filter((entry) => entry.action === 'punctuation-record-event');
+  const summaryReached = recordEvents.filter((entry) => entry.data.kind === 'summary-reached');
+  const feedbackRendered = recordEvents.filter((entry) => entry.data.kind === 'feedback-rendered');
+  assert.strictEqual(
+    summaryReached.length,
+    1,
+    `Summary mount must emit exactly ONE summary-reached event; saw ${summaryReached.length}`,
+  );
+  assert.strictEqual(
+    feedbackRendered.length,
+    1,
+    `Summary mount must emit exactly ONE feedback-rendered event; saw ${feedbackRendered.length}`,
+  );
+  // Payload shape — `summary-reached` carries sessionId / total / correct /
+  // accuracy; `feedback-rendered` carries sessionId / itemId / correct.
+  assert.equal(summaryReached[0].data.payload.sessionId, 'sess-u5-1');
+  assert.equal(summaryReached[0].data.payload.total, 4);
+  assert.equal(summaryReached[0].data.payload.correct, 3);
+  assert.equal(summaryReached[0].data.payload.accuracy, 75);
+  assert.equal(summaryReached[0].data.mutates, false);
+  assert.equal(feedbackRendered[0].data.mutates, false);
+});
+
+// ---------------------------------------------------------------------------
+// 8. Telemetry — monster-progress-changed fires when a stage advances.
+// ---------------------------------------------------------------------------
+
+test('U5 Summary telemetry: monster-progress-changed fires on mount when monsterProgress is present', () => {
+  const calls = [];
+  const actions = {
+    dispatch(action, data) {
+      calls.push({ action, data });
+    },
+  };
+  renderPunctuationSummarySceneStandalone({
+    ui: {
+      availability: { status: 'ready' },
+      session: { id: 'sess-u5-2', mode: 'smart' },
+      summary: {
+        sessionId: 'sess-u5-2',
+        total: 4,
+        correct: 4,
+        accuracy: 100,
+        focus: [],
+        monsterProgress: { monsterId: 'pealark', stageFrom: 0, stageTo: 1 },
+      },
+    },
+    actions,
+    rewardState: {},
+  });
+  const recordEvents = calls.filter((entry) => entry.action === 'punctuation-record-event');
+  const monsterProgressChanged = recordEvents.filter(
+    (entry) => entry.data.kind === 'monster-progress-changed',
+  );
+  assert.strictEqual(
+    monsterProgressChanged.length,
+    1,
+    `stage-advance must emit exactly ONE monster-progress-changed event; saw ${monsterProgressChanged.length}`,
+  );
+  assert.deepEqual(monsterProgressChanged[0].data.payload, {
+    monsterId: 'pealark',
+    stageFrom: 0,
+    stageTo: 1,
+  });
+  assert.equal(monsterProgressChanged[0].data.mutates, false);
+});
+
+test('U5 Summary telemetry: monster-progress-changed does NOT fire when monsterProgress is absent', () => {
+  const calls = [];
+  const actions = {
+    dispatch(action, data) {
+      calls.push({ action, data });
+    },
+  };
+  renderPunctuationSummarySceneStandalone({
+    ui: {
+      availability: { status: 'ready' },
+      summary: { total: 4, correct: 3, accuracy: 75, focus: [] },
+    },
+    actions,
+    rewardState: {},
+  });
+  const recordEvents = calls.filter((entry) => entry.action === 'punctuation-record-event');
+  const monsterProgressChanged = recordEvents.filter(
+    (entry) => entry.data.kind === 'monster-progress-changed',
+  );
+  assert.strictEqual(
+    monsterProgressChanged.length,
+    0,
+    'no stage advance → no monster-progress-changed emission',
+  );
+});
+
+test('U5 Summary telemetry: monster-progress-changed is suppressed for reserved monster ids', () => {
+  // A malformed `monsterProgress.monsterId` pointing at a reserved id must
+  // not emit (the teaser does not render either — paired with test above).
+  const calls = [];
+  const actions = {
+    dispatch(action, data) {
+      calls.push({ action, data });
+    },
+  };
+  renderPunctuationSummarySceneStandalone({
+    ui: {
+      availability: { status: 'ready' },
+      session: { id: 'sess-u5-3' },
+      summary: {
+        sessionId: 'sess-u5-3',
+        total: 4,
+        correct: 4,
+        accuracy: 100,
+        focus: [],
+        monsterProgress: { monsterId: 'colisk', stageFrom: 0, stageTo: 1 },
+      },
+    },
+    actions,
+    rewardState: {},
+  });
+  const recordEvents = calls.filter((entry) => entry.action === 'punctuation-record-event');
+  const monsterProgressChanged = recordEvents.filter(
+    (entry) => entry.data.kind === 'monster-progress-changed',
+  );
+  assert.strictEqual(
+    monsterProgressChanged.length,
+    0,
+    'reserved monster id → no monster-progress-changed emission',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 9. U6 invariant regression guard — Back button stays enabled under U5 add-ons.
+// ---------------------------------------------------------------------------
+
+test('U5 regression: Summary Back button still renders aria-disabled="false" under pendingCommand after U5 additions', () => {
+  const harness = createPunctuationHarness();
+  openSummaryScene(harness, {
+    skillsExercised: ['speech', 'comma_clarity'],
+    focus: ['speech'],
+    monsterProgress: { monsterId: 'pealark', stageFrom: 0, stageTo: 1 },
+  });
+  harness.store.updateSubjectUi('punctuation', {
+    pendingCommand: 'punctuation-submit-form',
+  });
+  const html = harness.render();
+  // U6 invariant: Back to dashboard stays enabled under pendingCommand.
+  assert.match(
+    html,
+    /<button[^>]*aria-disabled="false"[^>]*data-action="punctuation-back"|<button[^>]*data-action="punctuation-back"[^>]*aria-disabled="false"/,
+    'Summary Back must render aria-disabled="false" under pendingCommand even with U5 additions (plan R7 / U6)',
+  );
+});


### PR DESCRIPTION
## Summary

Phase 4 U5 ships the Punctuation Summary result-card UX rebuild plus a 5-surface reward parity proof. The scene gains visible child feedback (correct count, per-skill chips with child-register labels and status badges, next-review hint, monster-progress teaser), wires three telemetry emits via the U4 helper, and keeps the U6 navigation invariant intact. A new integration test locks that one seeded `monster-codex` write surfaces coherent progress on Setup, Summary, Map, Home `SubjectCard.progress`, and Codex via three derivation shapes (direct `rewardState`, scalar `dashboardStats.pct`, projected `monsterSummary`).

## Scope

**Modified**
- `src/subjects/punctuation/components/PunctuationSummaryScene.jsx` — new `CorrectCountLine`, `SkillsExercisedRow`, `NextReviewHint`, `MonsterProgressTeaser` helpers; `extractMonsterProgress` gate filters reserved monsters; `useRef`-gated render-time telemetry for `summary-reached` / `feedback-rendered` / `monster-progress-changed`.
- `src/subjects/punctuation/service-contract.js` — `normalisePunctuationSummary` now preserves `skillsExercised` (string array) + `monsterProgress` (`{monsterId, stageFrom, stageTo} | null`) so the scene receives the additive payload through the standard initState pathway.

**Added**
- `tests/react-punctuation-summary-ux.test.js` — 16 tests covering the 9 U5 scenarios (correct-count copy, zero-total guard, per-skill chips, review hint both branches, teaser present/absent/reserved-gated, 5-surface reward parity, reserved-monster strip regression, telemetry × 4, U6 back-button invariant guard).

**Not touched**
- Oracle (`tests/punctuation-legacy-parity.test.js`) — 11/11 still pass.
- Engine (`shared/punctuation/marking.js`, `generators.js`, `scheduler.js`, `content.js`).
- Worker code (`record-event` lands in U9; scoring / mastery paths unchanged).
- Navigation gating (U6 unchanged; regression guard added).
- `contentReleaseId` (not bumped).

## release-id impact: none

No engine, content, scoring, marking, or mastery changes. Oracle replay byte-for-byte preserved.

## Test plan

- [x] `node --test tests/react-punctuation-summary-ux.test.js` — 16/16 pass
- [x] `node --test tests/react-punctuation-scene.test.js tests/react-punctuation-telemetry.test.js tests/punctuation-legacy-parity.test.js` — 207/207 pass (164 scene + 32 telemetry + 11 oracle)
- [x] `node --test tests/punctuation-view-model.test.js tests/punctuation-rewards.test.js tests/punctuation-content.test.js tests/react-punctuation-assets.test.js tests/punctuation-map-phase.test.js tests/punctuation-service-contract.test.js tests/react-punctuation-child-copy.test.js` — 196/196 pass
- [x] `npm test` — 3344 tests total; 3340 pass, 2 pre-existing baseline failures unrelated to U5 (`button labels: every statically extractable label is classified` for `AdminHubSurface` buttons, and a JSON parse error in `punctuation-release-smoke` against `wrangler.jsonc`). Both fail on `origin/main` without U5 changes.

## Requirements traced: R6, R11, R14