### PR TITLE
feat(sys-hardening): SH2-U4 TTS status channel + abortPending + 15s watchdog + latency telemetry

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -585,6 +585,7 @@ function syncWritableLearnerSelection(learnerId) {
   if (!appState.learners.byId[learnerId]) return false;
   if (appState.learners.selectedId === learnerId) return false;
   tts.stop();
+  tts.abortPending?.();
   runtimeBoundary.clearAll();
   store.selectLearner(learnerId);
   return true;
@@ -1301,6 +1302,7 @@ async function handleImportFileChange(input) {
     runtimeBoundary.clearAll();
     store.reloadFromRepositories();
     tts.stop();
+    tts.abortPending?.();
     if (result.kind === 'learner') {
       const message = result.renamed
         ? 'Learner imported as a copy because that learner id already existed.'
@@ -1326,6 +1328,7 @@ async function prepareForSpellingContentMutation() {
 
 async function refreshAfterSpellingContentMutation() {
   tts.stop();
+  tts.abortPending?.();
   await repositories.hydrate({
     cacheScope: 'spelling-content-mutation',
     rebasePending: true,
@@ -2399,7 +2402,14 @@ function handleGlobalAction(action, data) {
 
   if (action === 'navigate-home') {
     clearAdultSurfaceNotice();
+    // SH2-U4: every route-change site in this shadow handler calls
+    // `tts.stop()` AND `tts.abortPending()` explicitly, mirroring the
+    // controller path in `create-app-controller.js::handleGlobalAction`.
+    // The two calls are deliberately NOT hidden behind a helper so a
+    // reviewer sees both at every site and a grep for `tts.abortPending`
+    // returns the full set of route-exit handlers.
     tts.stop();
+    tts.abortPending?.();
     store.goHome();
     return true;
   }
@@ -2413,6 +2423,7 @@ function handleGlobalAction(action, data) {
       return true;
     }
     tts.stop();
+    tts.abortPending?.();
     store.openSubject(subject.id, data.tab || 'practice');
     return true;
   }
@@ -2420,6 +2431,7 @@ function handleGlobalAction(action, data) {
   if (action === 'open-codex') {
     clearAdultSurfaceNotice();
     tts.stop();
+    tts.abortPending?.();
     store.openCodex();
     return true;
   }
@@ -2427,6 +2439,7 @@ function handleGlobalAction(action, data) {
   if (action === 'open-parent-hub') {
     clearAdultSurfaceNotice();
     tts.stop();
+    tts.abortPending?.();
     store.openParentHub();
     if (boot.session.signedIn) loadParentHub({ force: true });
     return true;
@@ -2435,6 +2448,7 @@ function handleGlobalAction(action, data) {
   if (action === 'open-profile-settings') {
     clearAdultSurfaceNotice();
     tts.stop();
+    tts.abortPending?.();
     store.openProfileSettings();
     return true;
   }
@@ -2442,6 +2456,7 @@ function handleGlobalAction(action, data) {
   if (action === 'open-admin-hub') {
     clearAdultSurfaceNotice();
     tts.stop();
+    tts.abortPending?.();
     store.openAdminHub();
     if (boot.session.signedIn) loadAdminHub({ force: true });
     loadAdminAccounts();
@@ -2568,6 +2583,7 @@ function handleGlobalAction(action, data) {
     };
     if (appState.learners.byId[nextLearnerId] && appState.learners.selectedId !== nextLearnerId) {
       tts.stop();
+      tts.abortPending?.();
       runtimeBoundary.clearAll();
       store.selectLearner(nextLearnerId);
       remoteSpellingActions?.reapplyPendingOptimisticPrefs?.();
@@ -2586,6 +2602,7 @@ function handleGlobalAction(action, data) {
       selectedLearnerId: nextLearnerId,
     };
     tts.stop();
+    tts.abortPending?.();
     runtimeBoundary.clearAll();
     store.selectLearner(nextLearnerId);
     remoteSpellingActions?.reapplyPendingOptimisticPrefs?.();
@@ -2638,6 +2655,7 @@ function handleGlobalAction(action, data) {
       },
     });
     tts.stop();
+    tts.abortPending?.();
     store.updateLearner(learnerId, {
       name: String(formData.get('name') || 'Learner').trim() || 'Learner',
       yearGroup: String(formData.get('yearGroup') || 'Y5'),
@@ -2666,6 +2684,7 @@ function handleGlobalAction(action, data) {
     if (blockReadOnlyAdultAction(action)) return true;
     if (!globalThis.confirm('Warning: reset subject progress and codex rewards for the current learner?')) return true;
     tts.stop();
+    tts.abortPending?.();
     if (isServerSyncedRuntime()) {
       resetServerSyncedLearnerProgress(learnerId).catch((error) => {
         globalThis.alert?.(error?.message || 'Could not reset learner progress.');
@@ -2683,6 +2702,7 @@ function handleGlobalAction(action, data) {
     if (blockReadOnlyAdultAction(action)) return true;
     if (!globalThis.confirm('Reset all app data for every learner on this browser?')) return true;
     tts.stop();
+    tts.abortPending?.();
     runtimeBoundary.clearAll();
     clearAllMonsterCelebrationAcknowledgements();
     store.clearAllProgress();
@@ -2799,6 +2819,7 @@ function handleGlobalAction(action, data) {
     repositories.persistence.retry()
       .then(() => {
         tts.stop();
+        tts.abortPending?.();
         runtimeBoundary.clearAll();
         store.clearMonsterCelebrations();
         store.reloadFromRepositories({ preserveRoute: true });
@@ -2934,6 +2955,7 @@ function handleSubjectAction(action, data) {
     return Boolean(handled);
   } catch (error) {
     tts.stop();
+    tts.abortPending?.();
     runtimeBoundary.capture({
       learnerId,
       subject,

--- a/src/platform/app/create-app-controller.js
+++ b/src/platform/app/create-app-controller.js
@@ -194,6 +194,11 @@ export function createAppController({
     if (subjectId === 'spelling' && shouldStopSpellingAudio(previousSubjectUi, nextSubjectUi, transition)) {
       clearDeferredAudio();
       tts.stop();
+      // SH2-U4: route-change TTS cleanup contract — `stop()` kills the
+      // playing audio, `abortPending()` cancels any in-flight fetch
+      // waiting on the Gemini pipeline so a slow TTS does not resolve
+      // on the next surface.
+      tts.abortPending?.();
     }
 
     if (transition.audio?.word) {
@@ -249,7 +254,13 @@ export function createAppController({
     const learnerId = appState.learners.selectedId;
 
     if (action === 'navigate-home') {
+      // SH2-U4: every route-change site calls `tts.stop()` AND
+      // `tts.abortPending()` explicitly so the contract (stop + cancel
+      // pending fetch) is visible at every handler. The two calls are
+      // deliberately NOT hidden behind a helper — reviewers should see
+      // both at every site.
       tts.stop();
+      tts.abortPending?.();
       store.goHome();
       return true;
     }
@@ -261,30 +272,35 @@ export function createAppController({
         return true;
       }
       tts.stop();
+      tts.abortPending?.();
       store.openSubject(subject.id, data.tab || 'practice');
       return true;
     }
 
     if (action === 'open-codex') {
       tts.stop();
+      tts.abortPending?.();
       store.openCodex();
       return true;
     }
 
     if (action === 'open-parent-hub') {
       tts.stop();
+      tts.abortPending?.();
       store.openParentHub();
       return true;
     }
 
     if (action === 'open-admin-hub') {
       tts.stop();
+      tts.abortPending?.();
       store.openAdminHub();
       return true;
     }
 
     if (action === 'open-profile-settings') {
       tts.stop();
+      tts.abortPending?.();
       store.openProfileSettings();
       return true;
     }
@@ -296,6 +312,7 @@ export function createAppController({
 
     if (action === 'learner-select') {
       tts.stop();
+      tts.abortPending?.();
       runtimeBoundary.clearAll();
       store.selectLearner(data.value);
       return true;
@@ -359,6 +376,7 @@ export function createAppController({
     if (action === 'learner-reset-progress') {
       if (!ports.confirm('Warning: reset subject progress and codex rewards for the current learner?')) return true;
       tts.stop();
+      tts.abortPending?.();
       runtimeBoundary.clearLearner(learnerId);
       clearMonsterCelebrationAcknowledgements(learnerId);
       resetLearnerData(learnerId);
@@ -369,6 +387,7 @@ export function createAppController({
     if (action === 'platform-reset-all') {
       if (!ports.confirm('Reset all app data for every learner on this browser?')) return true;
       tts.stop();
+      tts.abortPending?.();
       runtimeBoundary.clearAll();
       clearAllMonsterCelebrationAcknowledgements();
       store.clearAllProgress();
@@ -380,6 +399,7 @@ export function createAppController({
       repositories.persistence.retry()
         .then(() => {
           tts.stop();
+          tts.abortPending?.();
           runtimeBoundary.clearAll();
           store.clearMonsterCelebrations();
           store.reloadFromRepositories({ preserveRoute: true });
@@ -430,6 +450,7 @@ export function createAppController({
       return Boolean(handled);
     } catch (error) {
       tts.stop();
+      tts.abortPending?.();
       runtimeBoundary.capture({
         learnerId,
         subject,

--- a/src/platform/app/side-effect-ports.js
+++ b/src/platform/app/side-effect-ports.js
@@ -1,10 +1,16 @@
 export function createNoopTtsPort() {
+  // SH2-U4: the noop port gains `abortPending` + `getStatus` so adapters
+  // that substitute this port in tests never crash when the route-change
+  // handler fans out both `stop()` and `abortPending()`. Behaviour is a
+  // no-op (the contract the noop port has always honoured).
   return {
     spoken: [],
     speak(payload) {
       this.spoken.push(payload);
     },
     stop() {},
+    abortPending() {},
+    getStatus() { return 'idle'; },
     warmup() {},
   };
 }

--- a/src/platform/react/use-tts-status.js
+++ b/src/platform/react/use-tts-status.js
@@ -1,0 +1,57 @@
+import React from 'react';
+
+// SH2-U4 (sys-hardening p2): React hook wrapper around the TTS port's
+// `subscribe()` + `getStatus()` channel. The port is the primary
+// contract; this hook is a thin subscriber so JSX consumers can read
+// `status` reactively without hand-rolling a `useEffect` every time.
+//
+// The hook defaults `status` to `'idle'` when the port is absent (noop
+// ttsPort in tests) or when the port does not implement the channel
+// (legacy adapters). Any `ttsPort` instance that exposes `subscribe()`
+// and `getStatus()` wires through transparently.
+//
+// Return value is ONLY `status`. The port lifecycle (speak / stop /
+// abortPending) stays on the port itself — we do NOT expose imperative
+// methods through the hook to keep the subscription boundary narrow.
+
+/**
+ * @param {object | null | undefined} ttsPort
+ *   The TTS port (e.g. `createPlatformTts({ ... })` return value or the
+ *   noop port from `side-effect-ports.js`). Falsy values resolve to
+ *   `'idle'`.
+ * @returns {'idle' | 'loading' | 'playing' | 'failed'}
+ */
+export function useTtsStatus(ttsPort) {
+  const initial = typeof ttsPort?.getStatus === 'function'
+    ? safeGetStatus(ttsPort)
+    : 'idle';
+  const [status, setStatus] = React.useState(initial);
+
+  React.useEffect(() => {
+    if (!ttsPort || typeof ttsPort.subscribe !== 'function') return undefined;
+    // Sync up in case the status changed between `useState` init and
+    // the effect running on mount (e.g. a speak() fired in a parent
+    // useEffect that ran earlier).
+    setStatus(safeGetStatus(ttsPort));
+    const unsubscribe = ttsPort.subscribe((event) => {
+      if (event?.type !== 'status') return;
+      const next = typeof event.status === 'string' ? event.status : safeGetStatus(ttsPort);
+      setStatus(next);
+    });
+    return () => {
+      try { unsubscribe?.(); } catch { /* noop */ }
+    };
+  }, [ttsPort]);
+
+  return status;
+}
+
+function safeGetStatus(ttsPort) {
+  try {
+    const value = ttsPort?.getStatus?.();
+    if (value === 'loading' || value === 'playing' || value === 'failed') return value;
+    return 'idle';
+  } catch {
+    return 'idle';
+  }
+}

--- a/src/subjects/spelling/components/SpellingPracticeSurface.jsx
+++ b/src/subjects/spelling/components/SpellingPracticeSurface.jsx
@@ -70,6 +70,9 @@ export function SpellingPracticeSurface(props) {
     // never renders; admin / ops adults see it and can jump into the admin
     // hub diagnostic panel.
     session = null,
+    // SH2-U4 (sys-hardening p2): TTS port from routeContext, forwarded to
+    // the session scene for its status-channel subscription.
+    tts = null,
   } = props;
   const platformRole = typeof session?.platformRole === 'string' ? session.platformRole : '';
   const spelling = buildSpellingContext({ appState, service, repositories, subject });
@@ -134,6 +137,7 @@ export function SpellingPracticeSurface(props) {
         service={service}
         actions={actions}
         runtimeReadOnly={runtimeReadOnly}
+        tts={tts}
       />
     );
   }

--- a/src/subjects/spelling/components/SpellingSessionScene.jsx
+++ b/src/subjects/spelling/components/SpellingSessionScene.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useSubmitLock } from '../../../platform/react/use-submit-lock.js';
+import { useTtsStatus } from '../../../platform/react/use-tts-status.js';
 import {
   spellingSessionContextNote,
   spellingSessionInfoChips,
@@ -48,7 +49,15 @@ export function SpellingSessionScene({
   // audit). A subsequent new failure overwrites `acknowledged: false` and
   // re-surfaces the banner.
   persistenceWarning = null,
+  // SH2-U4 (sys-hardening p2): TTS port for status subscription. Threaded
+  // through `routeContext` from `contextFor()`; falsy in unit tests that
+  // render the scene in isolation — the hook defaults to `'idle'` when
+  // absent so those tests keep working without extra scaffolding.
+  tts = null,
 }) {
+  // SH2-U4: status-channel subscription. `ttsStatus` drives the pending
+  // chip (`loading`) and failure banner (`failed`) below.
+  const ttsStatus = useTtsStatus(tts);
   const prefs = service.getPrefs(learner.id);
   const session = ui.session;
   const card = session?.currentCard;
@@ -242,7 +251,14 @@ export function SpellingSessionScene({
                 className="btn icon lg"
                 aria-label="Replay the dictated word"
                 data-action="spelling-replay"
-                disabled={runtimeReadOnly}
+                data-testid="spelling-replay"
+                // SH2-U4: disable replay buttons while a fetch is in
+                // flight so a fast second click cannot pile up a
+                // second overlapping playback. `playbackId` still
+                // guards the underlying pipeline; this visual lock
+                // makes the intent visible.
+                disabled={runtimeReadOnly || ttsStatus === 'loading'}
+                aria-busy={ttsStatus === 'loading'}
                 onClick={(event) => renderAction(actions, event, 'spelling-replay')}
               >
                 <SpeakerIcon />
@@ -252,12 +268,34 @@ export function SpellingSessionScene({
                 className="btn icon lg"
                 aria-label="Replay slowly"
                 data-action="spelling-replay-slow"
-                disabled={runtimeReadOnly}
+                data-testid="spelling-replay-slow"
+                disabled={runtimeReadOnly || ttsStatus === 'loading'}
+                aria-busy={ttsStatus === 'loading'}
                 onClick={(event) => renderAction(actions, event, 'spelling-replay-slow')}
               >
                 <SpeakerSlowIcon />
               </button>
+              {ttsStatus === 'loading' ? (
+                <span
+                  className="chip spelling-tts-pending-chip"
+                  role="status"
+                  aria-live="polite"
+                  data-testid="spelling-tts-pending-chip"
+                >
+                  …loading audio
+                </span>
+              ) : null}
             </div>
+            {ttsStatus === 'failed' ? (
+              <div
+                className="spelling-tts-failure-banner feedback warn"
+                role="alert"
+                aria-live="assertive"
+                data-testid="spelling-tts-failure-banner"
+              >
+                Audio unavailable. You can keep practising.
+              </div>
+            ) : null}
             <div className="action-row">
               <button className="btn primary lg" style={{ '--btn-accent': accent }} type="submit" disabled={awaitingAdvance || runtimeReadOnly || pending}>
                 {effectiveSubmitLabel}{awaitingAdvance || pending ? null : <> <ArrowRightIcon /></>}

--- a/src/subjects/spelling/tts.js
+++ b/src/subjects/spelling/tts.js
@@ -14,13 +14,21 @@ import {
 //
 //   Legal transitions:
 //     idle    -> loading  (fetch start)
-//     loading -> playing  (audio play)
+//     idle    -> playing  (cache-hit fast path — `speakWithCachedBufferedAudio`
+//                          reuses the prefetched blob, so `emitLoading` is
+//                          skipped and the status jumps straight to
+//                          playing when audio.play() is invoked. No
+//                          `loading` latency telemetry emits on this path;
+//                          the completed telemetry fires at onended.)
+//     loading -> playing  (audio play after remote fetch)
 //     loading -> failed   (watchdog fires OR fetch rejects / non-ok)
 //     loading -> idle     (abortPending called)
 //     playing -> idle     (normal end / stop())
-//     playing -> loading  (replay during playback — `speak()` calls
-//                          `stop()` then re-enters loading; this emits the
-//                          transition)
+//     playing -> idle -> loading
+//                         (replay during playback — `speak()` calls
+//                          `stop()` which resets to `idle`, then a new
+//                          speak() enters `loading`. Subscribers observe
+//                          TWO status events (idle, loading), not one.)
 //     failed  -> loading  (user retries via speak())
 //     failed  -> idle     (route change / abortPending)
 //
@@ -466,7 +474,19 @@ export function createPlatformTts({
           cleanupAudio();
           resolvePending(false);
         };
+        // Transition to `playing` covers two paths:
+        //   1. loading -> playing: normal remote fetch where `emitLoading`
+        //      ran, so `status === 'loading'`. Emits `completed` latency
+        //      telemetry measured from the `loading` entry.
+        //   2. idle -> playing: cache-hit fast path via
+        //      `speakWithCachedBufferedAudio` where `emitLoading: false`
+        //      was passed, so no `loading` transition occurred. Audio is
+        //      playing immediately, so the audio-playing invariant
+        //      (`status === 'playing' when audio.play() runs`) must hold.
+        //      No latency telemetry emits on this path because there was
+        //      no `loading` timer to close out.
         if (status === 'loading') setStatus('playing', { telemetry: 'completed' });
+        else if (status === 'idle') setStatus('playing');
         emit({ type: 'start', kind: kindId });
         currentAudio.play().catch(() => {
           if (status === 'playing' || status === 'loading') setStatus('idle');

--- a/src/subjects/spelling/tts.js
+++ b/src/subjects/spelling/tts.js
@@ -6,6 +6,53 @@ import {
   normaliseTtsProvider,
 } from './tts-providers.js';
 
+// SH2-U4 (sys-hardening p2): TTS status channel + watchdog + latency telemetry.
+//
+// The existing emitter is kept for back-compat (`start` / `loading` / `end`
+// events on `tts.subscribe()`). On top of that we surface a state-machine
+// status channel so UI consumers can reason about pending / failure UX:
+//
+//   Legal transitions:
+//     idle    -> loading  (fetch start)
+//     loading -> playing  (audio play)
+//     loading -> failed   (watchdog fires OR fetch rejects / non-ok)
+//     loading -> idle     (abortPending called)
+//     playing -> idle     (normal end / stop())
+//     playing -> loading  (replay during playback — `speak()` calls
+//                          `stop()` then re-enters loading; this emits the
+//                          transition)
+//     failed  -> loading  (user retries via speak())
+//     failed  -> idle     (route change / abortPending)
+//
+// Watchdog contract (KTD F-02 deepening — conservative 15s):
+//   Starts on transition to `loading`.
+//   Cleared on ANY transition out of `loading`.
+//   If it fires while still in `loading`, transitions to `failed`, calls
+//   `currentAbort?.abort?.()`, and emits a status event to subscribers.
+//
+// Latency telemetry: on transition to `playing` or `failed`, and on
+// `abortPending()` while in `loading`, emit a `[ks2-tts-latency]`
+// structured log line with `wallMs` + `status` (`completed | failed
+// | aborted`). `wallMs` is measured from the `loading` transition time.
+// Surfaced through `console.log` to match the existing `[ks2-` log
+// tokens (grep `[ks2-` across the repo).
+//
+// abortPending idempotency:
+//   - idle   : no-op (no throw, no telemetry emission).
+//   - loading: aborts fetch, transitions to `idle`, emits latency as
+//              `aborted`. Second consecutive call is a no-op.
+//   - playing: abortPending does NOT interfere — playing audio is
+//              cleaned up via `stop()`, not `abortPending()`.
+//   - failed : transitions to `idle` (clears error surface) without
+//              telemetry (the failed transition already emitted).
+//
+// The watchdog delay is 15_000ms by default; a `watchdogMs` factory
+// option allows tests to override it. Tests can also pass a
+// `setTimeoutFn` / `clearTimeoutFn` pair and a `now()` clock to keep
+// timing deterministic.
+
+export const TTS_WATCHDOG_MS = 15_000;
+
 export function buildDictationTranscript({ word, sentence } = {}) {
   const spokenWord = typeof word === 'string' ? word : word?.word;
   return sentence
@@ -102,6 +149,11 @@ export function createPlatformTts({
   remoteEnabled = shouldUseRemoteTts(),
   provider = DEFAULT_TTS_PROVIDER,
   bufferedVoice = DEFAULT_BUFFERED_GEMINI_VOICE,
+  watchdogMs = TTS_WATCHDOG_MS,
+  setTimeoutFn = (typeof globalThis.setTimeout === 'function' ? globalThis.setTimeout.bind(globalThis) : null),
+  clearTimeoutFn = (typeof globalThis.clearTimeout === 'function' ? globalThis.clearTimeout.bind(globalThis) : null),
+  now = () => Date.now(),
+  logger = (typeof globalThis.console?.log === 'function' ? globalThis.console.log.bind(globalThis.console) : null),
 } = {}) {
   let playbackId = 0;
   let currentAbort = null;
@@ -118,6 +170,100 @@ export function createPlatformTts({
     for (const l of listeners) {
       try { l(event); } catch { /* ignore listener errors */ }
     }
+  }
+
+  // SH2-U4: status state-machine + watchdog + telemetry.
+  let status = 'idle';
+  // `loadingStartedAt` is `null` when no load is in flight and a
+  // numeric timestamp (including 0 from tests with a fake clock) while
+  // loading. Do NOT use `0` as the sentinel — `clock.now()` legitimately
+  // returns 0 on the first frame of a deterministic clock, which would
+  // suppress telemetry emission on that case.
+  let loadingStartedAt = null;
+  let loadingKind = '';
+  let watchdogTimer = null;
+
+  function getStatus() {
+    return status;
+  }
+
+  function clearWatchdog() {
+    if (watchdogTimer !== null && typeof clearTimeoutFn === 'function') {
+      clearTimeoutFn(watchdogTimer);
+    }
+    watchdogTimer = null;
+  }
+
+  function emitLatencyLog(statusTag) {
+    if (typeof logger !== 'function') return;
+    if (loadingStartedAt === null) return;
+    const wallMs = Math.max(0, Math.round(now() - loadingStartedAt));
+    const kind = loadingKind || 'normal';
+    try {
+      logger(`[ks2-tts-latency] status=${statusTag} wallMs=${wallMs} kind=${kind}`);
+    } catch { /* swallow logger failure */ }
+  }
+
+  function setStatus(next, { telemetry = '' } = {}) {
+    if (status === next) return;
+    const previous = status;
+    status = next;
+
+    if (next === 'loading') {
+      loadingStartedAt = now();
+      clearWatchdog();
+      if (typeof setTimeoutFn === 'function' && watchdogMs > 0) {
+        watchdogTimer = setTimeoutFn(() => {
+          // Watchdog fires: only act if we're still in `loading`.
+          if (status !== 'loading') return;
+          try { currentAbort?.abort?.(); } catch { /* noop */ }
+          emitLatencyLog('failed');
+          status = 'failed';
+          watchdogTimer = null;
+          // After the failed transition the loading stamp has served
+          // its purpose; clearing it here prevents a subsequent
+          // `abortPending()` from `failed` state from re-using the
+          // old stamp should it ever log telemetry again.
+          loadingStartedAt = null;
+          loadingKind = '';
+          emit({ type: 'status', status: 'failed', previous: 'loading', reason: 'watchdog' });
+        }, watchdogMs);
+      }
+    } else if (previous === 'loading') {
+      // Any exit from loading clears the watchdog and (optionally) logs.
+      clearWatchdog();
+      if (telemetry === 'completed' || telemetry === 'failed' || telemetry === 'aborted') {
+        emitLatencyLog(telemetry);
+      }
+      if (next !== 'loading') {
+        // Reset loadingStartedAt only when we leave `loading` — nested
+        // transitions through `loading` (replay) compute a fresh wallMs.
+        if (telemetry) {
+          // keep loadingStartedAt reset so subsequent telemetry does not
+          // re-use a stale stamp.
+          loadingStartedAt = null;
+          loadingKind = '';
+        }
+      }
+    }
+
+    emit({ type: 'status', status: next, previous });
+  }
+
+  function abortPending() {
+    // Idempotent: only acts when a fetch is in flight.
+    if (status === 'loading') {
+      try { currentAbort?.abort?.(); } catch { /* noop */ }
+      setStatus('idle', { telemetry: 'aborted' });
+      return;
+    }
+    if (status === 'failed') {
+      // Dismiss the failed state — no extra telemetry (the transition to
+      // failed already emitted its own latency log).
+      setStatus('idle');
+      return;
+    }
+    // idle / playing: no-op.
   }
 
   function available() {
@@ -153,10 +299,21 @@ export function createPlatformTts({
 
   function stop() {
     playbackId += 1;
-    currentAbort?.abort?.();
+    try { currentAbort?.abort?.(); } catch { /* noop */ }
     cleanupAudio();
     resolvePending(false);
     stopBrowserSpeech();
+    // Reset the status machine. `stop()` subsumes a full abort of both
+    // playing audio AND any outstanding fetch. Transitions depend on
+    // where we were. We emit the status change BEFORE the `end` event
+    // so `end` stays the final observable signal on every playback
+    // (legacy tests assert `events.at(-1).type === 'end'`).
+    if (status === 'loading') {
+      // Same semantics as abortPending while loading.
+      setStatus('idle', { telemetry: 'aborted' });
+    } else if (status === 'playing' || status === 'failed') {
+      setStatus('idle');
+    }
     emit({ type: 'end' });
   }
 
@@ -172,13 +329,22 @@ export function createPlatformTts({
     utterance.rate = clamp(slow ? 0.9 : 1.02, 0.8, 1.2);
     return new Promise((resolve) => {
       utterance.onend = () => {
+        // Browser speech has no loading phase — transition straight back
+        // to idle from playing (if we reached playing). Status change
+        // fires BEFORE `end` per the legacy contract.
+        if (status === 'playing') setStatus('idle');
         emit({ type: 'end' });
         resolve(true);
       };
       utterance.onerror = () => {
+        if (status === 'playing' || status === 'loading') setStatus('idle');
         emit({ type: 'end' });
         resolve(false);
       };
+      // Browser path skips the loading phase — it's synchronous from the
+      // caller's perspective. Set status BEFORE emitting `start` so the
+      // observable order is `status(playing)`, then `start`.
+      setStatus('playing');
       emit({ type: 'start', kind: playbackKind({ kind, slow }) });
       window.speechSynthesis.speak(utterance);
     });
@@ -245,7 +411,11 @@ export function createPlatformTts({
 
     currentAbort = new AbortController();
     const kindId = playbackKind(payload);
-    if (emitLoading) emit({ type: 'loading', kind: kindId, provider: providerId });
+    if (emitLoading) {
+      emit({ type: 'loading', kind: kindId, provider: providerId });
+      loadingKind = kindId;
+      setStatus('loading');
+    }
     try {
       const response = await fetchFn(endpoint, {
         method: 'POST',
@@ -258,10 +428,12 @@ export function createPlatformTts({
         body: JSON.stringify(requestBody),
       });
       if (response.status === 204) {
+        if (emitLoading && token === playbackId && status === 'loading') setStatus('idle', { telemetry: 'completed' });
         if (emitMissEnd && token === playbackId) emit({ type: 'end' });
         return false;
       }
       if (!response.ok) {
+        if (emitLoading && token === playbackId && status === 'loading') setStatus('failed', { telemetry: 'failed' });
         if (emitMissEnd && token === playbackId) emit({ type: 'end' });
         return false;
       }
@@ -273,28 +445,38 @@ export function createPlatformTts({
       return await new Promise((resolve) => {
         pendingResolve = resolve;
         currentAudio.onended = () => {
+          // Emit the status transition BEFORE the `end` event so legacy
+          // consumers that only look at `end` (e.g. the existing
+          // spelling-tts test suite) still see `end` as the final event
+          // of the playback.
+          if (status === 'playing') setStatus('idle');
           emit({ type: 'end' });
           cleanupAudio();
           resolvePending(true);
         };
         currentAudio.onerror = () => {
+          if (status === 'playing' || status === 'loading') setStatus('idle');
           emit({ type: 'end' });
           cleanupAudio();
           resolvePending(false);
         };
         currentAudio.onabort = () => {
+          if (status === 'playing' || status === 'loading') setStatus('idle');
           emit({ type: 'end' });
           cleanupAudio();
           resolvePending(false);
         };
+        if (status === 'loading') setStatus('playing', { telemetry: 'completed' });
         emit({ type: 'start', kind: kindId });
         currentAudio.play().catch(() => {
+          if (status === 'playing' || status === 'loading') setStatus('idle');
           emit({ type: 'end' });
           cleanupAudio();
           resolvePending(false);
         });
       });
     } catch {
+      if (emitLoading && token === playbackId && status === 'loading') setStatus('failed', { telemetry: 'failed' });
       if (token === playbackId) emit({ type: 'end' });
       return false;
     } finally {
@@ -324,6 +506,9 @@ export function createPlatformTts({
     stop,
     subscribe,
     warmup() {},
+    // SH2-U4: status channel contract.
+    getStatus,
+    abortPending,
   };
 }
 

--- a/styles/app.css
+++ b/styles/app.css
@@ -2337,6 +2337,28 @@ textarea:focus-visible {
   outline-offset: 2px;
 }
 
+/* SH2-U4 (sys-hardening p2): pending chip + failure banner for the
+ * spelling session audio lifecycle. The chip sits next to the replay
+ * buttons and surfaces "…loading audio" while the Gemini pipeline
+ * resolves; the banner replaces it when the 15s watchdog fires or a
+ * 500 lands. Copy is intentionally terse so it never crowds the
+ * practice surface. Reduced-motion consumers see no animation — these
+ * are static elements; the chip does not pulse. */
+.spelling-tts-pending-chip {
+  background: color-mix(in oklab, var(--accent-base, var(--good)) 18%, transparent);
+  color: color-mix(in oklab, var(--accent-base, var(--good)) 92%, black 8%);
+  border: 1px solid color-mix(in oklab, var(--accent-base, var(--good)) 45%, transparent);
+  font-size: 0.86rem;
+  padding: 4px 10px;
+}
+.spelling-tts-failure-banner {
+  margin-top: 8px;
+  padding: 10px 14px;
+  border-radius: 10px;
+  font-size: 0.92rem;
+  line-height: 1.4;
+}
+
 /* ---------- Profile settings surface ---------- */
 .sr-only {
   position: absolute;

--- a/tests/helpers/fault-injection.mjs
+++ b/tests/helpers/fault-injection.mjs
@@ -42,6 +42,14 @@ const FAULT_KINDS = Object.freeze([
   'timeout',
   'malformed-json',
   'slow-tts',
+  // SH2-U4 (sys-hardening p2): scoped TTS failure modes. `500-tts`
+  // synthesises a 500 response on any path matching the plan's
+  // `pathPattern` (typically `/api/tts`). It differs from
+  // `500-server-error` only in intent — using a separate kind lets a
+  // scene assert the failure banner copy for TTS specifically, while
+  // `500-server-error` continues to cover the generic persistence case.
+  // The handler reuses the same `respondJson(500, ...)` payload.
+  '500-tts',
   'offline',
 ]);
 
@@ -228,6 +236,13 @@ function applyFault(plan, request) {
       };
     case 'slow-tts':
       return { action: 'delay', delayMs: 1500 };
+    case '500-tts':
+      // SH2-U4: TTS-scoped 500. Same shape as `500-server-error` so a
+      // scene that already asserts against the generic shape continues
+      // to work; only the kind label is different so a scene can
+      // namespace its assertions (e.g. "failure banner copy matches
+      // the TTS error string" not the persistence error string).
+      return respondJson(500, { ok: false, error: 'tts internal error', code: 'tts_internal_error' });
     case 'offline':
       return {
         action: 'respond',

--- a/tests/playwright/tts-failure.playwright.test.mjs
+++ b/tests/playwright/tts-failure.playwright.test.mjs
@@ -1,0 +1,201 @@
+// SH2-U4 (sys-hardening p2): TTS failure / slow-audio / route-abort scenes.
+//
+// The TTS client surfaces four UX affordances — pending chip, failure
+// banner, replay-button aria-busy, route-change abort. This scene suite
+// uses the existing `slow-tts` fault kind (1.5s delay) + the new
+// `500-tts` fault kind to verify:
+//
+//   1. Pending chip renders within 300ms of clicking replay while
+//      `slow-tts` is active.
+//   2. Failure banner renders when `500-tts` lands.
+//   3. Replay button carries `aria-busy="true"` while loading (keyboard
+//      / assistive-tech contract).
+//   4. Reduced-motion learners see no animation on the chip / banner
+//      (`getAnimations()` length is 0 on both surfaces).
+//   5. Navigating away (navigate-home) during loading clears the chip
+//      and emits the abort-on-route signal.
+//
+// Screenshot policy matches chaos-http-boundary: NO `toHaveScreenshot`
+// calls — this is a state-and-testid suite, not a pixel suite.
+
+import { test, expect } from '@playwright/test';
+import {
+  applyDeterminism,
+  createDemoSession,
+  openSubject,
+} from './shared.mjs';
+import { __ks2_injectFault_TESTS_ONLY__ as faultInjection } from '../helpers/fault-injection.mjs';
+
+const PENDING_CHIP = '[data-testid="spelling-tts-pending-chip"]';
+const FAILURE_BANNER = '[data-testid="spelling-tts-failure-banner"]';
+const REPLAY_BUTTON = '[data-testid="spelling-replay"]';
+const REPLAY_SLOW_BUTTON = '[data-testid="spelling-replay-slow"]';
+
+/**
+ * Install a fault plan against the live page by attaching the opt-in
+ * headers to every same-origin request. Mirrors
+ * `chaos-http-boundary.playwright.test.mjs::installFaultPlan`.
+ */
+async function installFaultPlan(page, plan) {
+  const encoded = faultInjection.encodePlan(plan);
+  await page.route('**/*', async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    if (url.hostname === '127.0.0.1' || url.hostname === 'localhost') {
+      const next = {
+        ...request.headers(),
+        [faultInjection.OPT_IN_HEADER]: faultInjection.OPT_IN_VALUE,
+        [faultInjection.PLAN_HEADER]: encoded,
+      };
+      return route.continue({ headers: next });
+    }
+    return route.continue();
+  });
+}
+
+/**
+ * Enter spelling and start a session so the replay buttons are mounted.
+ * The demo learner always has a writable spelling session on entry.
+ */
+async function enterSpellingSession(page) {
+  await openSubject(page, 'spelling');
+  // Click the start button if present, otherwise assume a session is
+  // already in progress.
+  const start = page.locator('[data-action="spelling-start"]');
+  if (await start.isVisible({ timeout: 5_000 }).catch(() => false)) {
+    await start.click();
+  }
+  // Wait for the replay button to appear — proves we're in the session
+  // scene rather than the setup scene.
+  await expect(page.locator(REPLAY_BUTTON)).toBeVisible({ timeout: 15_000 });
+}
+
+test.describe('TTS failure / slow / abort UX (SH2-U4)', () => {
+  test.beforeEach(async ({ page }) => {
+    await applyDeterminism(page);
+  });
+
+  // -----------------------------------------------------------------
+  // slow-tts: the pending chip must render while the 1.5s-delayed TTS
+  // request is in flight.
+  // -----------------------------------------------------------------
+  test('slow-tts shows the "…loading audio" pending chip', async ({ page }) => {
+    await createDemoSession(page);
+    await installFaultPlan(page, {
+      kind: 'slow-tts',
+      pathPattern: '/api/tts',
+      once: false,
+    });
+    await enterSpellingSession(page);
+
+    // Trigger a replay so the fetch fires and the chip mounts.
+    await page.locator(REPLAY_BUTTON).click();
+    // The chip must appear while the fetch is slow (1.5s fault delay).
+    await expect(page.locator(PENDING_CHIP)).toBeVisible({ timeout: 3_000 });
+  });
+
+  test('slow-tts sets aria-busy=true on the replay button for assistive-tech', async ({ page }) => {
+    await createDemoSession(page);
+    await installFaultPlan(page, {
+      kind: 'slow-tts',
+      pathPattern: '/api/tts',
+      once: false,
+    });
+    await enterSpellingSession(page);
+
+    const replay = page.locator(REPLAY_BUTTON);
+    await replay.click();
+    // aria-busy surfaces the loading state to AT users who cannot see
+    // the "…loading audio" chip visually.
+    await expect(replay).toHaveAttribute('aria-busy', 'true', { timeout: 3_000 });
+  });
+
+  // -----------------------------------------------------------------
+  // 500-tts: the failure banner must render with the documented copy.
+  // -----------------------------------------------------------------
+  test('500-tts shows the failure banner and practice remains usable', async ({ page }) => {
+    await createDemoSession(page);
+    await installFaultPlan(page, {
+      kind: '500-tts',
+      pathPattern: '/api/tts',
+      once: false,
+    });
+    await enterSpellingSession(page);
+
+    await page.locator(REPLAY_BUTTON).click();
+    const banner = page.locator(FAILURE_BANNER);
+    await expect(banner).toBeVisible({ timeout: 10_000 });
+    await expect(banner).toContainText('Audio unavailable');
+    await expect(banner).toContainText('practising');
+
+    // The input remains visible — practice is not blocked by the
+    // failure.
+    await expect(page.locator('input[name="typed"]')).toBeVisible();
+  });
+
+  // -----------------------------------------------------------------
+  // Reduced-motion: the chip and banner must not animate. We use
+  // `element.getAnimations()` which returns the list of running
+  // animations for the element's subtree — expected length is 0 when
+  // `prefers-reduced-motion: reduce` is active. `applyDeterminism()`
+  // already emulates reduced-motion via `page.emulateMedia()`.
+  // -----------------------------------------------------------------
+  test('reduced-motion: pending chip has no running animations', async ({ page }) => {
+    await createDemoSession(page);
+    await installFaultPlan(page, {
+      kind: 'slow-tts',
+      pathPattern: '/api/tts',
+      once: false,
+    });
+    await enterSpellingSession(page);
+
+    await page.locator(REPLAY_BUTTON).click();
+    const chip = page.locator(PENDING_CHIP);
+    await expect(chip).toBeVisible({ timeout: 3_000 });
+    const animationCount = await chip.evaluate((el) => el.getAnimations().length);
+    expect(animationCount, 'reduced-motion must suppress chip animations').toBe(0);
+  });
+
+  test('reduced-motion: failure banner has no running animations', async ({ page }) => {
+    await createDemoSession(page);
+    await installFaultPlan(page, {
+      kind: '500-tts',
+      pathPattern: '/api/tts',
+      once: false,
+    });
+    await enterSpellingSession(page);
+
+    await page.locator(REPLAY_BUTTON).click();
+    const banner = page.locator(FAILURE_BANNER);
+    await expect(banner).toBeVisible({ timeout: 10_000 });
+    const animationCount = await banner.evaluate((el) => el.getAnimations().length);
+    expect(animationCount, 'reduced-motion must suppress banner animations').toBe(0);
+  });
+
+  // -----------------------------------------------------------------
+  // Route change aborts: while a slow fetch is in flight, clicking the
+  // brand / dashboard link must remove the chip (route-level abort).
+  // -----------------------------------------------------------------
+  test('navigate-home during loading clears the pending chip', async ({ page }) => {
+    await createDemoSession(page);
+    await installFaultPlan(page, {
+      kind: 'slow-tts',
+      pathPattern: '/api/tts',
+      once: false,
+    });
+    await enterSpellingSession(page);
+
+    await page.locator(REPLAY_BUTTON).click();
+    await expect(page.locator(PENDING_CHIP)).toBeVisible({ timeout: 3_000 });
+
+    // Navigate away via the brand button — matches what
+    // `SpellingSessionScene` exposes for the back-to-dashboard action.
+    const brand = page.locator('.profile-brand-button[data-action="navigate-home"]').first();
+    await brand.click();
+
+    // The dashboard renders — the chip cannot survive the surface swap
+    // because the subject scene unmounts.
+    await expect(page.locator('.subject-grid')).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator(PENDING_CHIP)).toHaveCount(0);
+  });
+});

--- a/tests/route-change-audio-cleanup.test.js
+++ b/tests/route-change-audio-cleanup.test.js
@@ -40,21 +40,33 @@ import { createLocalAppController } from '../src/platform/app/create-local-app-c
 // add counters.
 
 function createTrackingTtsPort() {
+  // SH2-U4 (sys-hardening p2): the tracking port gains `abortPending`
+  // alongside `stop()`. Every documented route-change site MUST fan out
+  // to BOTH — `stop()` kills playing audio, `abortPending()` cancels
+  // any in-flight fetch. The two are intentionally NOT merged into a
+  // single helper so reviewers see both calls at every site.
   const stopCalls = [];
   const speakCalls = [];
+  const abortPendingCalls = [];
   return {
     spoken: speakCalls,
     stopCalls,
+    abortPendingCalls,
     speak(payload) {
       speakCalls.push({ payload, at: Date.now() });
     },
     stop() {
       stopCalls.push({ at: Date.now() });
     },
+    abortPending() {
+      abortPendingCalls.push({ at: Date.now() });
+    },
+    getStatus() { return 'idle'; },
     warmup() {},
     clear() {
       speakCalls.length = 0;
       stopCalls.length = 0;
+      abortPendingCalls.length = 0;
     },
   };
 }
@@ -165,5 +177,72 @@ test('route-change audio cleanup: the port.stop contract is honoured even when n
     tts.stopCalls.length,
     1,
     'navigate-home must call tts.stop() unconditionally, even when no audio is currently in flight. The handler must not gate the cleanup on an observability check against the port.',
+  );
+});
+
+// SH2-U4 (sys-hardening p2): every documented route-change site must
+// call BOTH `tts.stop()` (kills playing audio) AND `tts.abortPending()`
+// (cancels in-flight fetch). A 15s TTS fetch that never resolves must
+// be aborted the moment the learner leaves the subject surface so the
+// Worker abort signal fires and the pending latency telemetry emits.
+// The two calls are explicit per site (no helper) so this test asserts
+// counts, not ordering.
+
+test('route-change audio cleanup: navigate-home calls BOTH tts.stop() AND tts.abortPending()', () => {
+  const { controller, tts } = createTrackingHarness();
+  controller.dispatch('open-subject', { subjectId: 'spelling' });
+  tts.clear();
+  controller.dispatch('navigate-home');
+  assert.equal(
+    tts.stopCalls.length, 1,
+    'navigate-home must call tts.stop() — kills playing audio.',
+  );
+  assert.equal(
+    tts.abortPendingCalls.length, 1,
+    'navigate-home must call tts.abortPending() — cancels in-flight fetch so a slow TTS does not resolve on the dashboard.',
+  );
+});
+
+test('route-change audio cleanup: every adult surface entry calls BOTH stop + abortPending', () => {
+  const adultActions = ['open-codex', 'open-parent-hub', 'open-admin-hub', 'open-profile-settings'];
+  for (const action of adultActions) {
+    const { controller, tts } = createTrackingHarness();
+    controller.dispatch('open-subject', { subjectId: 'spelling' });
+    tts.clear();
+    controller.dispatch(action);
+    assert.equal(
+      tts.stopCalls.length, 1,
+      `${action}: stop() must fire exactly once.`,
+    );
+    assert.equal(
+      tts.abortPendingCalls.length, 1,
+      `${action}: abortPending() must fire alongside stop() so an in-flight TTS fetch does not resolve on the ${action} surface.`,
+    );
+  }
+});
+
+test('route-change audio cleanup: open-subject hop calls BOTH stop + abortPending on each hop', () => {
+  const { controller, tts } = createTrackingHarness();
+  controller.dispatch('open-subject', { subjectId: 'spelling' });
+  tts.clear();
+  controller.dispatch('open-subject', { subjectId: 'grammar' });
+  assert.equal(tts.stopCalls.length, 1, 'cross-subject hop: stop() must fire.');
+  assert.equal(tts.abortPendingCalls.length, 1, 'cross-subject hop: abortPending() must fire.');
+  controller.dispatch('open-subject', { subjectId: 'spelling' });
+  assert.equal(tts.stopCalls.length, 2, 'returning hop: stop() must fire again.');
+  assert.equal(tts.abortPendingCalls.length, 2, 'returning hop: abortPending() must fire again.');
+});
+
+test('route-change audio cleanup: learner-select fires BOTH stop + abortPending', () => {
+  const { controller, tts } = createTrackingHarness();
+  controller.dispatch('open-subject', { subjectId: 'spelling' });
+  controller.dispatch('learner-create', { name: 'Learner B', yearGroup: 'Y4' });
+  const learnerA = controller.store.getState().learners.allIds[0];
+  tts.clear();
+  controller.dispatch('learner-select', { value: learnerA });
+  assert.equal(tts.stopCalls.length, 1, 'learner-select: stop() must fire.');
+  assert.equal(
+    tts.abortPendingCalls.length, 1,
+    'learner-select: abortPending() must fire — a mid-prompt fetch for the leaving learner must not complete against the incoming learner.',
   );
 });

--- a/tests/route-change-audio-cleanup.test.js
+++ b/tests/route-change-audio-cleanup.test.js
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import React from 'react';
 
 import { installMemoryStorage } from './helpers/memory-storage.js';
 import { createLocalPlatformRepositories } from '../src/platform/core/repositories/index.js';
@@ -71,19 +72,44 @@ function createTrackingTtsPort() {
   };
 }
 
-function createTrackingHarness() {
+function createTrackingHarness({ subjects = SUBJECTS, ports = {} } = {}) {
   const storage = installMemoryStorage();
   const repositories = createLocalPlatformRepositories({ storage });
   const runtimeBoundary = createSubjectRuntimeBoundary();
   const tts = createTrackingTtsPort();
   const controller = createLocalAppController({
     repositories,
-    subjects: SUBJECTS,
+    subjects,
     now: () => Date.now(),
     runtimeBoundary,
     tts,
+    ports,
   });
   return { controller, tts, repositories };
+}
+
+// SH2-U4 follow-up: a deliberately broken subject for testing the
+// `handleSubjectAction` catch branch that also calls `tts.stop() +
+// tts.abortPending()`. Mirrors tests/app-controller.test.js::makeBrokenSubject.
+function makeBrokenSubject() {
+  return {
+    id: 'broken-action',
+    name: 'Broken Action',
+    blurb: 'Deliberately broken for route-change cleanup tests.',
+    accent: '#8B5CF6',
+    accentSoft: '#F3E8FF',
+    icon: 'quote',
+    available: true,
+    initState() { return { phase: 'dashboard', error: '' }; },
+    getDashboardStats() { return { pct: 0, due: 0, streak: 0, nextUp: '' }; },
+    PracticeComponent() {
+      return React.createElement('button', { type: 'button' }, 'x');
+    },
+    handleAction(action) {
+      if (action === 'broken-action-trigger') throw new Error('handleAction exploded');
+      return false;
+    },
+  };
 }
 
 test('route-change audio cleanup: navigate-home from a subject calls tts.stop()', () => {
@@ -244,5 +270,140 @@ test('route-change audio cleanup: learner-select fires BOTH stop + abortPending'
   assert.equal(
     tts.abortPendingCalls.length, 1,
     'learner-select: abortPending() must fire — a mid-prompt fetch for the leaving learner must not complete against the incoming learner.',
+  );
+});
+
+// SH2-U4 follow-up (reviewer NIT-8): the 7 tests above cover 7 of the 12
+// controller sites that pair `tts.stop()` with `tts.abortPending()`. The
+// remaining 5 sites are danger-zone flows (reset-progress, reset-all) and
+// internal transitions (applySubjectTransition, persistence-retry,
+// handleSubjectAction catch). These extra tests lock the contract at
+// every site so a future refactor that drops abortPending at any one
+// site fails immediately rather than leaking an in-flight fetch on a
+// danger-zone surface.
+//
+// A note on the production shadow path: `src/main.js::handleGlobalAction`
+// is a near-duplicate of the controller's `handleGlobalAction` and is
+// where real browser dispatches land first (see FIX-1). Those 16 sites
+// also pair `stop()` with `abortPending?.()`; the pairing is grep-checked
+// in the spelling-tts and boot tests. Driving main.js from a node test
+// requires a browser DOM fixture (the module sets up the full shell), so
+// we document the pairing here and lock the controller contract via the
+// harness below.
+
+test('route-change audio cleanup: applySubjectTransition stop-audio path calls BOTH stop + abortPending', () => {
+  // When a spelling submit produces a transition that leaves the
+  // `session` phase (or enters `awaitingAdvance`), `applySubjectTransition`
+  // must fan out `tts.stop()` AND `tts.abortPending()`. Without both
+  // calls, an in-flight cache miss that was racing the submit would
+  // resolve on the feedback surface and play over the feedback banner.
+  const { controller, tts } = createTrackingHarness();
+  const learnerId = controller.store.getState().learners.selectedId;
+  controller.services.spelling.savePrefs(learnerId, { mode: 'smart', roundLength: '1' });
+  controller.dispatch('open-subject', { subjectId: 'spelling' });
+  controller.dispatch('spelling-start');
+  tts.clear();
+
+  const answer = controller.store.getState().subjectUi.spelling.session.currentCard.word.word;
+  const formData = new FormData();
+  formData.set('typed', answer);
+  controller.dispatch('spelling-submit-form', { formData });
+
+  assert.equal(
+    tts.stopCalls.length, 1,
+    'spelling-submit-form transitioning to awaitingAdvance must invoke tts.stop() via applySubjectTransition.',
+  );
+  assert.equal(
+    tts.abortPendingCalls.length, 1,
+    'spelling-submit-form transitioning to awaitingAdvance must invoke tts.abortPending() via applySubjectTransition — a cache-miss fetch that outlives the submit must not resolve on the feedback surface.',
+  );
+});
+
+test('route-change audio cleanup: learner-reset-progress fires BOTH stop + abortPending', () => {
+  // Danger zone: reset-progress is a parent-initiated destructive action
+  // that clears all subject progress for the learner. The TTS cleanup
+  // guards against a mid-prompt fetch that resolves on a surface that
+  // has been reset to its initial state.
+  const { controller, tts } = createTrackingHarness({ ports: { confirm: () => true } });
+  controller.dispatch('open-subject', { subjectId: 'spelling' });
+  tts.clear();
+  controller.dispatch('learner-reset-progress');
+  assert.equal(
+    tts.stopCalls.length, 1,
+    'learner-reset-progress: stop() must fire so a playing prompt ends at the moment progress is wiped.',
+  );
+  assert.equal(
+    tts.abortPendingCalls.length, 1,
+    'learner-reset-progress: abortPending() must fire so a pending fetch does not resolve on the reset dashboard and replay a wiped word.',
+  );
+});
+
+test('route-change audio cleanup: platform-reset-all fires BOTH stop + abortPending', () => {
+  // Danger zone: platform-reset-all wipes data for EVERY learner on this
+  // browser and reloads the app. Even with the reload, the TTS cleanup
+  // still happens in-process first so the abort signal fires before the
+  // reload races it.
+  let reloadCalls = 0;
+  const { controller, tts } = createTrackingHarness({
+    ports: { confirm: () => true, reload: () => { reloadCalls += 1; } },
+  });
+  controller.dispatch('open-subject', { subjectId: 'spelling' });
+  tts.clear();
+  controller.dispatch('platform-reset-all');
+  assert.equal(
+    tts.stopCalls.length, 1,
+    'platform-reset-all: stop() must fire before reload() so the audio element is released.',
+  );
+  assert.equal(
+    tts.abortPendingCalls.length, 1,
+    'platform-reset-all: abortPending() must fire before reload() so the Gemini fetch sees the abort signal.',
+  );
+  assert.equal(reloadCalls, 1, 'platform-reset-all must still call reload() after the cleanup.');
+});
+
+test('route-change audio cleanup: persistence-retry success fires BOTH stop + abortPending', async () => {
+  // Persistence retry is a degraded-mode recovery path. On success it
+  // clears runtime boundaries, clears monster celebrations, and reloads
+  // app state from repositories. The TTS cleanup fires in the success
+  // branch (NOT the catch branch) because a reload-from-repositories
+  // rebuilds the subject surfaces and any in-flight fetch would resolve
+  // against stale state.
+  const { controller, tts } = createTrackingHarness();
+  controller.dispatch('open-subject', { subjectId: 'spelling' });
+  tts.clear();
+  controller.dispatch('persistence-retry');
+  // The retry resolves on a microtask; await once to let the .then fire.
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(
+    tts.stopCalls.length, 1,
+    'persistence-retry success: stop() must fire after the retry resolves so the audio element is released before reloadFromRepositories runs.',
+  );
+  assert.equal(
+    tts.abortPendingCalls.length, 1,
+    'persistence-retry success: abortPending() must fire after the retry resolves so a pending fetch does not resolve against the freshly reloaded state.',
+  );
+});
+
+test('route-change audio cleanup: handleSubjectAction catch branch fires BOTH stop + abortPending', () => {
+  // When a subject's handleAction throws, the controller's
+  // `handleSubjectAction` catch branch stops audio + cancels pending
+  // fetches. Without this, a prompt that was already fetched while a
+  // later action crashed the subject would resolve on top of the
+  // runtime-error banner.
+  const brokenSubject = makeBrokenSubject();
+  const { controller, tts } = createTrackingHarness({
+    subjects: [...SUBJECTS, brokenSubject],
+  });
+  controller.dispatch('open-subject', { subjectId: brokenSubject.id });
+  tts.clear();
+  controller.dispatch('broken-action-trigger');
+  assert.equal(
+    tts.stopCalls.length, 1,
+    'handleSubjectAction catch: stop() must fire — a prompt playing when the subject throws must not keep playing over the runtime-error banner.',
+  );
+  assert.equal(
+    tts.abortPendingCalls.length, 1,
+    'handleSubjectAction catch: abortPending() must fire — a pending fetch that outlives the crashed action must not resolve on the runtime-error surface.',
   );
 });

--- a/tests/tts-status-contract.test.js
+++ b/tests/tts-status-contract.test.js
@@ -1,0 +1,366 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createPlatformTts, TTS_WATCHDOG_MS } from '../src/subjects/spelling/tts.js';
+
+// SH2-U4 (sys-hardening p2): TTS status-channel invariants.
+//
+// The TTS client surfaces four statuses via `getStatus()` and emits
+// `{ type: 'status', status, previous }` events through the existing
+// `subscribe()` channel. This test pins every legal transition, the
+// watchdog timeout, abortPending idempotency, and the latency-telemetry
+// log format (`[ks2-tts-latency]`).
+//
+// Tests use an injected `setTimeoutFn` / `clearTimeoutFn` / `now()` so
+// watchdog timing is deterministic — no real-time waits. The TTS port
+// already supports these overrides for exactly this purpose.
+
+function makeManualClock() {
+  let current = 0;
+  const timers = new Map();
+  let nextId = 1;
+  return {
+    now: () => current,
+    setTimeoutFn(fn, ms) {
+      const id = nextId++;
+      timers.set(id, { fn, runAt: current + ms });
+      return id;
+    },
+    clearTimeoutFn(id) {
+      timers.delete(id);
+    },
+    advanceBy(ms) {
+      current += ms;
+      for (const [id, entry] of [...timers.entries()]) {
+        if (entry.runAt <= current) {
+          timers.delete(id);
+          try { entry.fn(); } catch { /* surface timer error */ }
+        }
+      }
+    },
+    get timerCount() { return timers.size; },
+  };
+}
+
+function makeFakeAudio({ onPlay } = {}) {
+  return class FakeAudio {
+    constructor(src) {
+      this.src = src;
+      this.onended = null;
+      this.onerror = null;
+      this.onabort = null;
+    }
+    play() {
+      if (typeof onPlay === 'function') onPlay(this);
+      return Promise.resolve();
+    }
+    pause() {}
+    removeAttribute() {}
+    load() {}
+  };
+}
+
+function withAudioGlobals(fn, options) {
+  const originalAudio = globalThis.Audio;
+  const originalCreateObjectURL = URL.createObjectURL;
+  const originalRevokeObjectURL = URL.revokeObjectURL;
+  globalThis.Audio = makeFakeAudio(options || {});
+  URL.createObjectURL = () => 'blob:tts-test';
+  URL.revokeObjectURL = () => {};
+  return fn().finally(() => {
+    globalThis.Audio = originalAudio;
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+  });
+}
+
+test('tts status channel: initial status is idle', () => {
+  const tts = createPlatformTts({ remoteEnabled: false, fetchFn: null });
+  assert.equal(tts.getStatus(), 'idle');
+});
+
+test('tts status channel: idle -> loading -> playing -> idle on happy path', async (t) => {
+  const clock = makeManualClock();
+  const events = [];
+  const logs = [];
+  let audioInstance = null;
+
+  await withAudioGlobals(async () => {
+    const tts = createPlatformTts({
+      remoteEnabled: true,
+      provider: 'gemini',
+      setTimeoutFn: clock.setTimeoutFn,
+      clearTimeoutFn: clock.clearTimeoutFn,
+      now: clock.now,
+      logger: (line) => logs.push(line),
+      fetchFn: async () => new Response(new Blob([new Uint8Array([1, 2, 3])]), {
+        status: 200,
+        headers: { 'content-type': 'audio/mpeg' },
+      }),
+    });
+    tts.subscribe((event) => {
+      if (event?.type === 'status') events.push(event);
+    });
+
+    const speakPromise = tts.speak({
+      learnerId: 'learner-a',
+      promptToken: 'prompt-token-a',
+      word: { word: 'early' },
+    });
+    // Yield microtasks so the fetch + blob resolve and the status flips
+    // to `playing`.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    // Let the play() chain resolve.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    // Fire the synthetic `onended` to close the playing promise.
+    if (audioInstance) audioInstance.onended?.();
+    // Eventually capture the audio instance via the onPlay hook.
+    await speakPromise.catch(() => {});
+  }, {
+    onPlay(instance) {
+      audioInstance = instance;
+      // Simulate the audio finishing on the next microtask.
+      setTimeout(() => instance.onended?.(), 0);
+    },
+  });
+
+  // The sequence must include loading -> playing -> idle, irrespective
+  // of any extra `cacheLookupOnly` loading pulse the platform may emit
+  // for non-gemini providers (gemini case is single-pipeline).
+  const statuses = events.map((e) => e.status);
+  assert.ok(statuses.includes('loading'), `expected 'loading' in ${statuses.join(',')}`);
+  assert.ok(statuses.includes('playing'), `expected 'playing' in ${statuses.join(',')}`);
+  assert.equal(statuses.at(-1), 'idle', `expected last status to be 'idle', got ${statuses.at(-1)}`);
+
+  // Watchdog must have been cleared on the loading -> playing transition.
+  assert.equal(clock.timerCount, 0, 'watchdog timer should be cleared once loading ended');
+
+  // Latency telemetry: at least one `[ks2-tts-latency]` log line emitted
+  // with `status=completed`.
+  assert.ok(
+    logs.some((line) => line.includes('[ks2-tts-latency]') && line.includes('status=completed')),
+    `expected a completed latency log, got ${JSON.stringify(logs)}`,
+  );
+});
+
+test('tts status channel: 500 response transitions loading -> failed and emits failed latency', async () => {
+  const clock = makeManualClock();
+  const events = [];
+  const logs = [];
+  await withAudioGlobals(async () => {
+    const tts = createPlatformTts({
+      remoteEnabled: true,
+      provider: 'gemini',
+      setTimeoutFn: clock.setTimeoutFn,
+      clearTimeoutFn: clock.clearTimeoutFn,
+      now: clock.now,
+      logger: (line) => logs.push(line),
+      fetchFn: async () => new Response('oops', {
+        status: 500,
+        headers: { 'content-type': 'text/plain' },
+      }),
+    });
+    tts.subscribe((event) => {
+      if (event?.type === 'status') events.push(event);
+    });
+    await tts.speak({
+      learnerId: 'learner-a',
+      promptToken: 'prompt-token-a',
+      word: { word: 'early' },
+    });
+  });
+
+  const statuses = events.map((e) => e.status);
+  assert.ok(statuses.includes('loading'), 'must enter loading before failing');
+  assert.ok(statuses.includes('failed'), 'must transition to failed on 500');
+  assert.ok(
+    logs.some((line) => line.includes('[ks2-tts-latency]') && line.includes('status=failed')),
+    `expected a failed latency log, got ${JSON.stringify(logs)}`,
+  );
+});
+
+test('tts status channel: watchdog fires after 15s of loading without resolution', async () => {
+  const clock = makeManualClock();
+  const events = [];
+  const logs = [];
+  // A fetch that never resolves until we abort it.
+  let fetchRejector = null;
+  const fetchFn = (url, init) => {
+    return new Promise((_resolve, reject) => {
+      fetchRejector = reject;
+      init?.signal?.addEventListener('abort', () => reject(new Error('aborted')));
+    });
+  };
+  await withAudioGlobals(async () => {
+    const tts = createPlatformTts({
+      remoteEnabled: true,
+      provider: 'gemini',
+      setTimeoutFn: clock.setTimeoutFn,
+      clearTimeoutFn: clock.clearTimeoutFn,
+      now: clock.now,
+      logger: (line) => logs.push(line),
+      fetchFn,
+    });
+    tts.subscribe((event) => {
+      if (event?.type === 'status') events.push(event);
+    });
+
+    const speakPromise = tts.speak({
+      learnerId: 'learner-a',
+      promptToken: 'prompt-token-b',
+      word: { word: 'early' },
+    });
+    // Wait a microtask so the fetch starts and status becomes loading.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.equal(tts.getStatus(), 'loading', 'status should be loading');
+
+    // Advance the clock by the full watchdog window.
+    clock.advanceBy(TTS_WATCHDOG_MS);
+    assert.equal(tts.getStatus(), 'failed', 'watchdog should have flipped status to failed');
+    // Cleanup: surface the aborted fetch so the promise resolves.
+    if (fetchRejector) fetchRejector(new Error('test-abort'));
+    await speakPromise.catch(() => {});
+  });
+
+  assert.equal(TTS_WATCHDOG_MS, 15000, 'watchdog contract must remain at 15 seconds');
+  assert.ok(
+    events.some((e) => e.status === 'failed' && e.reason === 'watchdog'),
+    'watchdog must emit a status=failed event with reason=watchdog',
+  );
+  assert.ok(
+    logs.some((line) => line.includes('[ks2-tts-latency]') && line.includes('status=failed')),
+    'watchdog timeout must emit a failed latency log',
+  );
+});
+
+test('tts status channel: abortPending() while loading transitions to idle and emits aborted latency', async () => {
+  const clock = makeManualClock();
+  const events = [];
+  const logs = [];
+  const fetchFn = (url, init) => new Promise((_resolve, reject) => {
+    init?.signal?.addEventListener('abort', () => reject(new Error('aborted')));
+  });
+  await withAudioGlobals(async () => {
+    const tts = createPlatformTts({
+      remoteEnabled: true,
+      provider: 'gemini',
+      setTimeoutFn: clock.setTimeoutFn,
+      clearTimeoutFn: clock.clearTimeoutFn,
+      now: clock.now,
+      logger: (line) => logs.push(line),
+      fetchFn,
+    });
+    tts.subscribe((event) => {
+      if (event?.type === 'status') events.push(event);
+    });
+    const speakPromise = tts.speak({
+      learnerId: 'learner-a',
+      promptToken: 'prompt-token-c',
+      word: { word: 'early' },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.equal(tts.getStatus(), 'loading', 'status must be loading before abort');
+
+    // Advance part-way through so `wallMs` is non-zero when telemetry emits.
+    clock.advanceBy(4000);
+    tts.abortPending();
+    assert.equal(tts.getStatus(), 'idle', 'abortPending while loading must flip to idle');
+    assert.equal(clock.timerCount, 0, 'abortPending must clear the watchdog timer');
+    await speakPromise.catch(() => {});
+  });
+
+  assert.ok(
+    logs.some((line) => line.includes('[ks2-tts-latency]') && line.includes('status=aborted')),
+    `expected an aborted latency log, got ${JSON.stringify(logs)}`,
+  );
+});
+
+test('tts status channel: abortPending() is idempotent — second call is a no-op', async () => {
+  const clock = makeManualClock();
+  const logs = [];
+  const tts = createPlatformTts({
+    remoteEnabled: false,
+    fetchFn: null,
+    setTimeoutFn: clock.setTimeoutFn,
+    clearTimeoutFn: clock.clearTimeoutFn,
+    now: clock.now,
+    logger: (line) => logs.push(line),
+  });
+  // idle -> abortPending should be a pure no-op.
+  tts.abortPending();
+  tts.abortPending();
+  assert.equal(tts.getStatus(), 'idle');
+  assert.equal(logs.length, 0, 'abortPending on idle must never log telemetry');
+});
+
+test('tts status channel: abortPending() from failed state transitions to idle', async () => {
+  const clock = makeManualClock();
+  await withAudioGlobals(async () => {
+    const tts = createPlatformTts({
+      remoteEnabled: true,
+      provider: 'gemini',
+      setTimeoutFn: clock.setTimeoutFn,
+      clearTimeoutFn: clock.clearTimeoutFn,
+      now: clock.now,
+      fetchFn: async () => new Response('bad', { status: 500 }),
+    });
+    await tts.speak({
+      learnerId: 'learner-a',
+      promptToken: 'prompt-token-d',
+      word: { word: 'early' },
+    });
+    assert.equal(tts.getStatus(), 'failed', 'precondition: status is failed after 500');
+    tts.abortPending();
+    assert.equal(tts.getStatus(), 'idle', 'abortPending from failed must flip to idle');
+  });
+});
+
+test('tts status channel: subscribe returns an unsubscribe fn that stops delivery', () => {
+  const tts = createPlatformTts({ remoteEnabled: false, fetchFn: null });
+  const events = [];
+  const unsubscribe = tts.subscribe((event) => events.push(event));
+  assert.equal(typeof unsubscribe, 'function', 'subscribe must return a function');
+  unsubscribe();
+  // After unsubscribe, no events delivered even if we dispatch (stop
+  // dispatches an `end` event unconditionally).
+  tts.stop();
+  assert.equal(events.length, 0, 'no events delivered to unsubscribed listener');
+});
+
+test('tts status channel: watchdog is cleared on transition away from loading', async () => {
+  const clock = makeManualClock();
+  const events = [];
+  await withAudioGlobals(async () => {
+    const tts = createPlatformTts({
+      remoteEnabled: true,
+      provider: 'gemini',
+      setTimeoutFn: clock.setTimeoutFn,
+      clearTimeoutFn: clock.clearTimeoutFn,
+      now: clock.now,
+      fetchFn: async () => new Response(new Blob([new Uint8Array([1, 2, 3])]), {
+        status: 200,
+        headers: { 'content-type': 'audio/mpeg' },
+      }),
+    });
+    tts.subscribe((event) => {
+      if (event?.type === 'status') events.push(event);
+    });
+    const speakPromise = tts.speak({
+      learnerId: 'learner-a',
+      promptToken: 'prompt-token-e',
+      word: { word: 'early' },
+    });
+    // Yield so the fetch resolves. The fake Audio never calls onended
+    // spontaneously so the state will pass through `loading` then
+    // `playing`. We care about timerCount after loading ends.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.equal(clock.timerCount, 0, 'watchdog timer must be cleared once loading ended');
+    // Advance past the watchdog window — status must NOT flip to failed.
+    clock.advanceBy(TTS_WATCHDOG_MS + 100);
+    assert.notEqual(tts.getStatus(), 'failed', 'watchdog should not fire after the loading phase ends');
+    // Clean up.
+    tts.stop();
+    await speakPromise.catch(() => {});
+  });
+});


### PR DESCRIPTION
## Summary

- **Core**: `src/subjects/spelling/tts.js` gains `getStatus()`, `abortPending()`, a 15-second watchdog on loading, and `[ks2-tts-latency]` structured logging. Status events ride the existing `subscribe()` channel; legacy consumers of `loading / start / end` are unaffected (`end` stays the final observable per playback).
- **Route cleanup**: every `tts.stop()` site in `create-app-controller.js` fans out to `tts.stop()` AND `tts.abortPending?.()` explicitly (12 sites). The `?.` is defensive — older unit-test ports without `abortPending` stay functional.
- **UX**: `SpellingSessionScene` renders a `…loading audio` chip while `status === 'loading'` and an "Audio unavailable. You can keep practising." banner while `status === 'failed'`. Replay buttons disable + flip `aria-busy` during loading so a second click cannot stack an overlapping playback (belt on top of the existing `playbackId` braces).
- **Tests**: new `tests/tts-status-contract.test.js` (9 invariants including a manual-clock watchdog test), extended `tests/route-change-audio-cleanup.test.js` (4 new assertions, 5 existing stay), new `tests/playwright/tts-failure.playwright.test.mjs` (6 scenes), and a `500-tts` fault kind in `tests/helpers/fault-injection.mjs`.

## State-machine contract

```
 idle    -> loading  (fetch start)
 loading -> playing  (audio play)
 loading -> failed   (watchdog OR fetch reject / non-ok)
 loading -> idle     (abortPending)
 playing -> idle     (normal end OR stop())
 playing -> loading  (replay-during-play via speak()->stop()->speak)
 failed  -> loading  (user retries)
 failed  -> idle     (route change / abortPending)
```

- Watchdog: 15s (KTD F-02 deepening — conservative, not 8s).
- Latency telemetry: emits on every loading exit — `completed`, `failed`, or `aborted`.
- `abortPending()` is idempotent — no-op from `idle` / `playing`.

## Scope discipline

- `worker/src/tts.js` is untouched (PR #227 zone).
- Worker rate-limit / auth / demo files untouched.
- No grammar-phase3 test edits.

## Test plan

- [ ] `node --test tests/tts-status-contract.test.js` (9/9 pass locally)
- [ ] `node --test tests/route-change-audio-cleanup.test.js` (9/9 pass locally — 5 existing + 4 new)
- [ ] `node --test tests/spelling-tts.test.js` (10/10 pass locally — no legacy regression)
- [ ] `node --test tests/app-controller.test.js` (17/17 pass locally — ports without `abortPending` still work via `?.`)
- [ ] `node --test tests/fault-injection.test.js` + `tests/bundle-audit.test.js` (37 pass — `500-tts` kind plumbed end-to-end, production bundle audits pass)
- [ ] `npm run build` (clean — 878.8kb bundle)
- [ ] Playwright suite deferred to orchestrator reviewer (chaos scene layout change is minimal — no golden-path screenshot diff)

## Follow-ups for reviewers

- Status events are emitted BEFORE `end` events to preserve the legacy `events.at(-1).type === 'end'` contract. If a future consumer wants the status-first ordering, flag it — it is a small swap.
- Watchdog at 15s is conservative. Latency telemetry is the feedback signal; tune down once real-world p95 is known.