### PR TITLE
feat(sys-hardening): SH2-U5 EmptyState/LoadingSkeleton/ErrorCard primitives + 6-surface re-skin

### DIFF
--- a/src/platform/ui/EmptyState.jsx
+++ b/src/platform/ui/EmptyState.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+// SH2-U5: shared empty-state primitive. Three-part copy pattern:
+//   1. what happened (neutral, past tense)
+//   2. is progress safe (explicit reassurance)
+//   3. what action is available (imperative CTA, or nothing)
+//
+// `role="status"` + `aria-live="polite"` so assistive tech announces the
+// empty branch without interrupting the learner's current focus. The CTA
+// is only rendered when `action` is supplied; callers that need a
+// throttled click-handler can wrap `action.onClick` with `useSubmitLock`
+// on their side — the primitive stays pure so it can be imported by any
+// surface without dragging in submit-lock state.
+//
+// `dataAction` is an optional debugging / event-wiring hint that becomes
+// the button's `data-action` attribute, mirroring the convention the
+// subject renderers use elsewhere.
+
+export function EmptyState({ title, body, action = null, className = '' }) {
+  const hasAction = action && typeof action.onClick === 'function' && action.label;
+  const classes = ['empty-state'];
+  if (className) classes.push(className);
+  return (
+    <section
+      className={classes.join(' ')}
+      role="status"
+      aria-live="polite"
+      data-testid="empty-state"
+    >
+      <span className="empty-state-icon" aria-hidden="true">
+        <svg
+          width="22"
+          height="22"
+          viewBox="0 0 22 22"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          focusable="false"
+        >
+          <circle cx="11" cy="11" r="8.25" strokeDasharray="2 3" />
+          <line x1="7.5" y1="11" x2="14.5" y2="11" />
+        </svg>
+      </span>
+      <div className="empty-state-body">
+        {title ? <h3 className="empty-state-title">{title}</h3> : null}
+        {body ? <p className="empty-state-lede">{body}</p> : null}
+      </div>
+      {hasAction ? (
+        <div className="actions empty-state-actions">
+          <button
+            className="btn secondary"
+            type="button"
+            onClick={action.onClick}
+            {...(action.dataAction ? { 'data-action': action.dataAction } : {})}
+          >
+            {action.label}
+          </button>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/platform/ui/EmptyState.jsx
+++ b/src/platform/ui/EmptyState.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 // SH2-U5: shared empty-state primitive. Three-part copy pattern:
 //   1. what happened (neutral, past tense)
 //   2. is progress safe (explicit reassurance)

--- a/src/platform/ui/ErrorCard.jsx
+++ b/src/platform/ui/ErrorCard.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+// SH2-U5: shared error-card primitive. Never renders `code` in visible
+// copy — that is SH2-U12's oracle. `code` is surfaced ONLY as a
+// `data-error-code` attribute for debugging + future telemetry, which
+// keeps the visible copy readable to non-technical learners while still
+// giving operators a stable selector to inspect.
+//
+// `onRetry` is optional: when the caller omits the handler, the action
+// row is not rendered (an error banner with a dead button is worse than
+// no button). `role="alert"` + `aria-live="polite"` so the card is
+// announced politely rather than interrupting — mid-session surfaces
+// rely on polite announcement so an error toast never speaks over a
+// learner typing an answer.
+
+export function ErrorCard({ title, body, onRetry = null, retryLabel = 'Try again', code = '', className = '' }) {
+  const hasRetry = typeof onRetry === 'function';
+  const classes = ['error-card'];
+  if (className) classes.push(className);
+  const extraAttrs = {};
+  if (code) extraAttrs['data-error-code'] = String(code);
+  return (
+    <section
+      className={classes.join(' ')}
+      role="alert"
+      aria-live="polite"
+      data-testid="error-card"
+      {...extraAttrs}
+    >
+      <span className="error-card-icon" aria-hidden="true">
+        <svg
+          width="22"
+          height="22"
+          viewBox="0 0 22 22"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          focusable="false"
+        >
+          <path d="M11 2.75 20.25 18.5H1.75L11 2.75Z" />
+          <line x1="11" y1="9" x2="11" y2="13" />
+          <circle cx="11" cy="16" r="0.6" fill="currentColor" stroke="none" />
+        </svg>
+      </span>
+      <div className="error-card-body">
+        {title ? <h3 className="error-card-title">{title}</h3> : null}
+        {body ? <p className="error-card-lede">{body}</p> : null}
+      </div>
+      {hasRetry ? (
+        <div className="actions error-card-actions">
+          <button className="btn secondary" type="button" onClick={onRetry}>
+            {retryLabel}
+          </button>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/platform/ui/ErrorCard.jsx
+++ b/src/platform/ui/ErrorCard.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 // SH2-U5: shared error-card primitive. Never renders `code` in visible
 // copy — that is SH2-U12's oracle. `code` is surfaced ONLY as a
 // `data-error-code` attribute for debugging + future telemetry, which

--- a/src/platform/ui/LoadingSkeleton.jsx
+++ b/src/platform/ui/LoadingSkeleton.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+// SH2-U5: shared loading-skeleton primitive. CSS-only shimmer built from
+// a moving background-position gradient (compositor-cheap, no layout).
+// The `@media (prefers-reduced-motion: reduce)` carve-out in
+// `styles/ui-states.css` cancels the animation and flattens the rows to
+// a solid neutral `var(--line-soft)` so learners who asked for motion to
+// stop see a static placeholder instead of a 1.4s pulse.
+//
+// Rows default to 3 — matches the "a few lines of copy" rhythm of most
+// list-backed panels. Callers that want denser / sparser skeletons pass
+// a specific number. Non-integer / non-positive values fall back to 3.
+
+const ROW_WIDTHS = ['78%', '92%', '58%', '84%', '70%', '46%'];
+
+function clampRows(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return 3;
+  const rounded = Math.round(numeric);
+  if (rounded < 1) return 3;
+  if (rounded > 8) return 8;
+  return rounded;
+}
+
+export function LoadingSkeleton({ rows = 3, className = '' }) {
+  const count = clampRows(rows);
+  const classes = ['loading-skeleton'];
+  if (className) classes.push(className);
+  return (
+    <div
+      className={classes.join(' ')}
+      role="status"
+      aria-live="polite"
+      aria-label="Loading"
+      data-testid="loading-skeleton"
+    >
+      <span className="loading-skeleton-sr">Loading…</span>
+      {Array.from({ length: count }, (_, index) => (
+        <span
+          key={index}
+          className="loading-skeleton-row"
+          aria-hidden="true"
+          style={{ width: ROW_WIDTHS[index % ROW_WIDTHS.length] }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/platform/ui/LoadingSkeleton.jsx
+++ b/src/platform/ui/LoadingSkeleton.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 // SH2-U5: shared loading-skeleton primitive. CSS-only shimmer built from
 // a moving background-position gradient (compositor-cheap, no layout).
 // The `@media (prefers-reduced-motion: reduce)` carve-out in

--- a/src/subjects/grammar/components/GrammarSetupScene.jsx
+++ b/src/subjects/grammar/components/GrammarSetupScene.jsx
@@ -11,6 +11,12 @@ import {
   GRAMMAR_PRIMARY_MODE_CARDS,
   buildGrammarDashboardModel,
 } from './grammar-view-model.js';
+// SH2-U5: fresh-learner `dashboard.isEmpty` branch surfaces the canonical
+// three-part copy through the shared primitive. The pre-U5 bespoke
+// `.grammar-today-empty` div kept a single sentence and no reassurance —
+// the primitive also preserves the existing `data-testid` so the
+// grammar-phase3-child-copy test continues to find the anchor.
+import { EmptyState } from '../../../platform/ui/EmptyState.jsx';
 
 // Phase 3 U1: Child-facing Grammar dashboard. Every label, mode id, and
 // card comes from the U8 view-model (`grammar-view-model.js`). The JSX
@@ -157,7 +163,10 @@ export function GrammarSetupScene({ learner, grammar, rewardState, actions, runt
       <section className="grammar-today" aria-label="Today at a glance">
         {dashboard.isEmpty ? (
           <div className="grammar-today-empty" data-testid="grammar-today-empty">
-            Start your first round to see your scores here.
+            <EmptyState
+              title="Grammar is ready"
+              body="Grammar is ready. Progress is saved as you practise. Start your first round to see your scores here."
+            />
           </div>
         ) : (
           <div className="grammar-today-grid">

--- a/src/subjects/grammar/components/GrammarSetupScene.jsx
+++ b/src/subjects/grammar/components/GrammarSetupScene.jsx
@@ -164,8 +164,8 @@ export function GrammarSetupScene({ learner, grammar, rewardState, actions, runt
         {dashboard.isEmpty ? (
           <div className="grammar-today-empty" data-testid="grammar-today-empty">
             <EmptyState
-              title="Grammar is ready"
-              body="Grammar is ready. Progress is saved as you practise. Start your first round to see your scores here."
+              title="No rounds yet"
+              body="No rounds yet. Progress is saved as you practise. Start your first round to see your scores here."
             />
           </div>
         ) : (

--- a/src/subjects/spelling/components/SpellingWordBankScene.jsx
+++ b/src/subjects/spelling/components/SpellingWordBankScene.jsx
@@ -3,6 +3,12 @@ import { SearchIcon } from './spelling-icons.jsx';
 import { CountUpValue, SummaryCards } from './SpellingCommon.jsx';
 import { SpellingHeroBackdrop } from './SpellingHeroBackdrop.jsx';
 import { SpellingWordDetailModal } from './SpellingWordDetailModal.jsx';
+// SH2-U5: the "no words tracked yet" branch surfaces the shared empty
+// primitive with the canonical copy. The existing `wb-empty` div
+// continues to cover the "filters matched nothing" branch (progress is
+// fine, just a filter change away) — that's not an empty state, just a
+// narrowed view, so it keeps its inline muted copy.
+import { EmptyState } from '../../../platform/ui/EmptyState.jsx';
 import {
   WORD_BANK_FILTER_IDS,
   WORD_BANK_GUARDIAN_CHIP_LABELS,
@@ -221,6 +227,11 @@ function WordBankCard({ learner, analytics, appState, actions, postMastery = nul
   const groups = Array.isArray(analytics.wordGroups) ? analytics.wordGroups : [];
   const wordBankMeta = analytics.wordBank || {};
   const allWords = groups.flatMap((group) => Array.isArray(group.words) ? group.words : []);
+  // SH2-U5: when the learner has zero tracked words we short-circuit to
+  // the shared empty-state card. No filters, no toolbar, no group head —
+  // the progress is genuinely empty so the canonical "what happened /
+  // progress safe / action" copy is the whole panel.
+  const totalTrackedWords = allWords.length;
   const categoryWords = allWords.filter((word) => wordBankYearFilterMatches(activeYearFilter, word));
   // U2 orphan-sanitiser context: wordBankFilterMatchesStatus uses these when
   // checking `guardianDue` / `wobbling` so a row whose slug no longer
@@ -314,6 +325,23 @@ function WordBankCard({ learner, analytics, appState, actions, postMastery = nul
       ? `Showing ${visibleWords.length} of ${totalWords} tracked spellings.`
       : `Showing ${visibleWords.length} of ${categoryTotal} ${categoryLabel} spellings.`;
   const learnerName = learner?.name ? `${learner.name}’s` : 'Learner';
+
+  if (totalTrackedWords === 0) {
+    return (
+      <section className="word-bank-card word-bank-card-empty">
+        <div className="wb-card">
+          <header className="wb-head">
+            <p className="eyebrow">Word bank progress</p>
+            <h1 className="title">{learnerName} word bank</h1>
+          </header>
+          <EmptyState
+            title="No words yet"
+            body="No words yet. Your progress is saved. Play a spelling round to add your first word."
+          />
+        </div>
+      </section>
+    );
+  }
 
   return (
     <section className="word-bank-card">

--- a/src/subjects/spelling/components/SpellingWordBankScene.jsx
+++ b/src/subjects/spelling/components/SpellingWordBankScene.jsx
@@ -337,6 +337,11 @@ function WordBankCard({ learner, analytics, appState, actions, postMastery = nul
           <EmptyState
             title="No words yet"
             body="No words yet. Your progress is saved. Play a spelling round to add your first word."
+            action={{
+              label: 'Back to spelling',
+              onClick: (event) => renderAction(actions, event, 'spelling-close-word-bank'),
+              dataAction: 'spelling-close-word-bank',
+            }}
           />
         </div>
       </section>

--- a/src/surfaces/home/CodexCreatureLightbox.jsx
+++ b/src/surfaces/home/CodexCreatureLightbox.jsx
@@ -5,9 +5,39 @@ import {
   codexEntryStateClassName,
   codexLightboxStyle,
 } from './codex-view-model.js';
+// SH2-U5: when the lightbox is asked to render a missing entry (the
+// upstream codex has not produced a matching row yet — for example a
+// fresh learner with zero progress) we render the shared primitive
+// instead of throwing on `entry.name`. The caller normally guards this
+// branch, but surfacing a consistent empty state here is belt-and-braces
+// and also satisfies the parity test's "every panel with an empty branch
+// imports the primitive" invariant.
+import { EmptyState } from '../../platform/ui/EmptyState.jsx';
 
 export function CodexCreatureLightbox({ entry, onClose }) {
   const monsterVisualConfig = useMonsterVisualConfig();
+  if (!entry) {
+    return (
+      <div
+        className="codex-lightbox codex-lightbox-empty"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Creature preview unavailable"
+        onClick={onClose}
+      >
+        <button type="button" className="codex-lightbox-close" aria-label="Close preview" onClick={onClose}>
+          ×
+        </button>
+        <div className="codex-lightbox-stage" onClick={(event) => event.stopPropagation()}>
+          <EmptyState
+            title="Nothing to preview yet"
+            body="Nothing caught yet. Your meadow stays tidy. Finish a round to unlock this creature's preview."
+            action={{ label: 'Close', onClick: onClose, dataAction: 'codex-lightbox-close' }}
+          />
+        </div>
+      </div>
+    );
+  }
   return (
     <div
       className="codex-lightbox"

--- a/src/surfaces/home/CodexSurface.jsx
+++ b/src/surfaces/home/CodexSurface.jsx
@@ -12,6 +12,11 @@ import {
   subjectName,
 } from './data.js';
 import { codexTotals } from './codex-view-model.js';
+// SH2-U5: fresh-learner branch — when no codex entries exist we surface
+// the shared empty-state primitive instead of rendering the bare section
+// heading. Canonical copy: "Codex is empty. Progress is stored safely.
+// Complete a round to unlock your first entry."
+import { EmptyState } from '../../platform/ui/EmptyState.jsx';
 
 export function CodexSurface({ model, actions }) {
   const [previewEntry, setPreviewEntry] = useState(null);
@@ -82,14 +87,26 @@ export function CodexSurface({ model, actions }) {
         </div>
 
         <div className="codex-subject-stack">
-          {subjectGroups.map((group) => (
-            <CodexSubjectSection
-              key={group.subjectId}
-              group={group}
-              onPractice={openPractice}
-              onPreview={setPreviewEntry}
+          {subjectGroups.length ? (
+            subjectGroups.map((group) => (
+              <CodexSubjectSection
+                key={group.subjectId}
+                group={group}
+                onPractice={openPractice}
+                onPreview={setPreviewEntry}
+              />
+            ))
+          ) : (
+            <EmptyState
+              title="Codex is empty"
+              body="Codex is empty. Progress is stored safely. Complete a round to unlock your first entry."
+              action={{
+                label: `Start ${subjectName(primaryPracticeSubjectId)}`,
+                onClick: () => openPractice(primaryPracticeSubjectId),
+                dataAction: 'codex-start-fresh-round',
+              }}
             />
-          ))}
+          )}
         </div>
       </main>
 

--- a/src/surfaces/home/MonsterMeadow.jsx
+++ b/src/surfaces/home/MonsterMeadow.jsx
@@ -20,8 +20,13 @@ export function MonsterMeadow({ monsters = [], maxSlots = 10 }) {
     // empty-state card non-interactive and invisible behind the hero
     // copy. `.monster-meadow-empty` is a static-flow block that sits in
     // the hero's normal layout order; the primitive keeps its role=status.
+    //
+    // Post-review: no `aria-label` on the wrapper because the inner
+    // EmptyState already carries `role="status"` with its own announced
+    // copy. Adding an outer label would duplicate-announce without a
+    // matching role, which AT engines read as a dead landmark.
     return (
-      <div className="monster-meadow-empty" aria-label="Meadow is empty">
+      <div className="monster-meadow-empty">
         <EmptyState
           title="Nothing caught yet"
           body="Nothing caught yet. Your meadow stays tidy. Finish a round to see your first monster appear."

--- a/src/surfaces/home/MonsterMeadow.jsx
+++ b/src/surfaces/home/MonsterMeadow.jsx
@@ -2,11 +2,33 @@ import React from 'react';
 import { useMonsterVisualConfig } from '../../platform/game/MonsterVisualConfigContext.jsx';
 import { resolveMonsterVisual } from '../../platform/game/monster-visual-config.js';
 import { eggBreatheStyle } from './data.js';
+// SH2-U5: fresh learners land on the home hero with zero caught monsters.
+// Before the re-skin the meadow rendered `null`, which meant learners saw
+// an empty stretch of grass with no copy explaining the state. The shared
+// primitive surfaces the canonical three-part copy (what happened /
+// progress safe / what action).
+import { EmptyState } from '../../platform/ui/EmptyState.jsx';
 
 export function MonsterMeadow({ monsters = [], maxSlots = 10 }) {
   const monsterVisualConfig = useMonsterVisualConfig();
   const shown = monsters.slice(0, maxSlots);
-  if (!shown.length) return null;
+  if (!shown.length) {
+    // The fresh-meadow empty branch uses a dedicated wrapper instead of
+    // reusing `.monster-meadow` because the base meadow class declares
+    // `position: absolute` + `pointer-events: none`. Those constraints
+    // are correct for the decorative sprite layer but would make the
+    // empty-state card non-interactive and invisible behind the hero
+    // copy. `.monster-meadow-empty` is a static-flow block that sits in
+    // the hero's normal layout order; the primitive keeps its role=status.
+    return (
+      <div className="monster-meadow-empty" aria-label="Meadow is empty">
+        <EmptyState
+          title="Nothing caught yet"
+          body="Nothing caught yet. Your meadow stays tidy. Finish a round to see your first monster appear."
+        />
+      </div>
+    );
+  }
   return (
     <div className="monster-meadow" aria-label={`${shown.length} codex creatures in the hero meadow`}>
       {shown.map((m) => {

--- a/src/surfaces/hubs/ParentHubSurface.jsx
+++ b/src/surfaces/hubs/ParentHubSurface.jsx
@@ -4,6 +4,11 @@ import { ReadOnlyLearnerNotice } from './ReadOnlyLearnerNotice.jsx';
 import { AccessDeniedCard, formatTimestamp, isBlocked, selectedWritableLearner } from './hub-utils.js';
 import { useSubmitLock } from '../../platform/react/use-submit-lock.js';
 import { AdultConfidenceChip } from '../../subjects/grammar/components/AdultConfidenceChip.jsx';
+// SH2-U5: the `RecentSessionList` + `CurrentFocus` empty branches re-skin
+// through the shared primitive so the three-part copy pattern (what
+// happened / is progress safe / what action is available) is consistent
+// with MonsterMeadow, Codex, WordBank, Grammar dashboard.
+import { EmptyState } from '../../platform/ui/EmptyState.jsx';
 
 function snapshotSubjectId(snapshot = {}) {
   if (snapshot.subjectId) return snapshot.subjectId;
@@ -81,14 +86,24 @@ function CurrentFocus({ items }) {
             </li>
           ))}
         </ol>
-      ) : <p className="parent-hub-empty small muted">No due work is surfaced yet.</p>}
+      ) : (
+        <EmptyState
+          title="No due work yet"
+          body="No due work is surfaced yet. Progress is recorded safely. Check back after a few rounds complete."
+        />
+      )}
     </div>
   );
 }
 
 function RecentSessionList({ sessions }) {
   if (!sessions.length) {
-    return <p className="parent-hub-empty small muted">No completed or active sessions are stored yet.</p>;
+    return (
+      <EmptyState
+        title="No sessions yet"
+        body="No completed or active sessions are stored yet. Progress stays safe. You'll see activity here as learners practise."
+      />
+    );
   }
   return (
     <ol className="parent-hub-session-list">

--- a/src/surfaces/hubs/hub-utils.js
+++ b/src/surfaces/hubs/hub-utils.js
@@ -1,4 +1,12 @@
 import { readOnlyLearnerActionBlockReason } from '../../platform/hubs/shell-access.js';
+// SH2-U5: the AccessDeniedCard is Admin + Parent Hub's load-failure
+// fallback (cited by the plan as one of the two ErrorCard consumers).
+// We re-skin the inner feedback block on top of the shared primitive so
+// a future `data-error-code` debug hook is already wired in. The outer
+// `.card` chrome + "Back to dashboard" action row stay bespoke because
+// this fallback specifically navigates back to the dashboard rather
+// than offering a retry — different semantic than ErrorCard's onRetry.
+import { ErrorCard } from '../../platform/ui/ErrorCard.jsx';
 
 export function formatTimestamp(value) {
   const numeric = Number(value);
@@ -25,13 +33,10 @@ export function isBlocked(action, accessContext) {
   return Boolean(readOnlyLearnerActionBlockReason(action, accessContext?.activeAdultLearnerContext || null));
 }
 
-export function AccessDeniedCard({ title, detail, onBack }) {
+export function AccessDeniedCard({ title, detail, onBack, code = '' }) {
   return (
-    <section className="card">
-      <div className="feedback warn">
-        <strong>{title}</strong>
-        <div style={{ marginTop: 8 }}>{detail}</div>
-      </div>
+    <section className="card access-denied-card">
+      <ErrorCard title={title} body={detail} code={code} />
       <div className="actions" style={{ marginTop: 16 }}>
         <button className="btn secondary" type="button" onClick={onBack}>Back to dashboard</button>
       </div>

--- a/src/surfaces/subject/SubjectRuntimeFallback.jsx
+++ b/src/surfaces/subject/SubjectRuntimeFallback.jsx
@@ -1,24 +1,36 @@
 import React from 'react';
 import { subjectTabLabel } from '../../platform/core/subject-runtime.js';
+// SH2-U5: the subject runtime-error fallback re-skins on top of the
+// shared ErrorCard primitive. The bespoke `.border-top` subject-accent
+// wrapper is preserved so the subject's accent colour still reads at a
+// glance; ErrorCard drives the copy / retry button / data-error-code.
+// The `Failure point: …` diagnostic line stays outside the primitive
+// because it's load-bearing context operators need during triage but
+// the primitive's copy contract doesn't surface it.
+import { ErrorCard } from '../../platform/ui/ErrorCard.jsx';
 
 export function SubjectRuntimeFallback({ subject, runtimeEntry = null, activeTab = 'practice', onRetry }) {
   const methodName = runtimeEntry?.phase === 'action'
     ? runtimeEntry?.action || runtimeEntry?.methodName || 'last action'
     : runtimeEntry?.methodName || `render${subjectTabLabel(activeTab)}`;
+  const title = `${subject?.name || 'Subject'} · ${subjectTabLabel(activeTab)} temporarily unavailable`;
+  const body = runtimeEntry?.message
+    || `${subject?.name || 'This subject'} hit an unexpected error. Your progress stays saved — try this tab again to recover.`;
 
   return (
-    <section className="card border-top" style={{ borderTopColor: subject?.accent || '#3E6FA8' }} role="alert" aria-live="polite">
-      <div className="feedback bad">
-        <strong>{subject?.name || 'Subject'} · {subjectTabLabel(activeTab)} temporarily unavailable</strong>
-        <div style={{ marginTop: 8 }}>
-          {runtimeEntry?.message || `${subject?.name || 'This subject'} hit an unexpected error.`}
-        </div>
-        <div className="small muted" style={{ marginTop: 8 }}>
-          Failure point: {methodName}
-        </div>
-      </div>
-      <div className="actions" style={{ marginTop: 16 }}>
-        <button className="btn secondary" type="button" onClick={onRetry}>Try this tab again</button>
+    <section
+      className="card border-top subject-runtime-fallback"
+      style={{ borderTopColor: subject?.accent || '#3E6FA8' }}
+    >
+      <ErrorCard
+        title={title}
+        body={body}
+        onRetry={onRetry}
+        retryLabel="Try this tab again"
+        code={runtimeEntry?.code || runtimeEntry?.methodName || methodName}
+      />
+      <div className="small muted" style={{ marginTop: 12 }}>
+        Failure point: {methodName}
       </div>
     </section>
   );

--- a/styles/app.css
+++ b/styles/app.css
@@ -2961,6 +2961,16 @@ textarea:focus-visible {
   padding: 0 24px;
   text-align: center;
 }
+/* SH2-U5: fresh-meadow empty-state wrapper. NOT based on `.monster-meadow`
+ * because that class is absolute-positioned + pointer-events: none for
+ * the decorative sprite layer. The empty-state wrapper sits in the hero's
+ * normal flow so the primitive's `role="status"` announcement lands and
+ * the CTA (when supplied) remains clickable. */
+.monster-meadow-empty {
+  position: relative;
+  margin: 12px 0 16px;
+  z-index: 1;
+}
 .meadow-monster {
   --meadow-render-size: var(--size, 64px);
   position: absolute;
@@ -10303,5 +10313,194 @@ html { scroll-behavior: smooth; }
   .punctuation-setup-scene {
     animation: none;
     transition: none;
+  }
+}
+
+/* --- SH2-U5: shared empty / loading / error state primitives ---------- */
+/* Three small surface templates that every visible panel reuses so loading
+ * / empty / error / read-only copy follows the same three-part pattern:
+ *   1. what happened (neutral),
+ *   2. is progress safe (reassurance),
+ *   3. what action is available (if any).
+ * Only colour tokens already in the palette (`--panel-soft`, `--line`,
+ * `--muted`, `--ink`, `--ink-2`, `--bad`, `--bad-soft`, `--bad-strong`,
+ * `--radius-sm`). No new hex values. Mobile-360 safe via box-sizing + no
+ * fixed widths + wrapping actions. Reduced-motion carve-out below cancels
+ * the skeleton shimmer so learners who asked for motion to stop never see
+ * a 1.4s pulse running underneath a placeholder card. */
+
+.empty-state {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 24px 22px;
+  margin: 0;
+  background: var(--panel-soft);
+  border: 1px dashed var(--line);
+  border-radius: var(--radius-sm);
+  color: var(--ink);
+  max-width: 100%;
+  overflow-wrap: anywhere;
+}
+
+.empty-state-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+  line-height: 0;
+}
+
+.empty-state-body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-width: 100%;
+}
+
+.empty-state-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--ink);
+  line-height: 1.35;
+}
+
+.empty-state-lede {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
+.empty-state-actions {
+  margin-top: 4px;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 380px) {
+  .empty-state {
+    padding: 18px 16px;
+    gap: 10px;
+  }
+}
+
+/* --- Loading skeleton ------------------------------------------------- */
+
+.loading-skeleton {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 20px 18px;
+  margin: 0;
+  background: var(--panel);
+  border-radius: var(--radius-sm);
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.loading-skeleton-sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.loading-skeleton-row {
+  display: block;
+  height: 14px;
+  border-radius: 6px;
+  background: linear-gradient(
+    90deg,
+    var(--panel-soft) 0%,
+    var(--line-soft) 50%,
+    var(--panel-soft) 100%
+  );
+  background-size: 200% 100%;
+  animation: loading-skeleton-shimmer 1.4s ease-in-out infinite;
+  max-width: 100%;
+}
+
+@keyframes loading-skeleton-shimmer {
+  0% { background-position: 150% 0; }
+  100% { background-position: -50% 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .loading-skeleton-row {
+    animation: none;
+    background: var(--line-soft);
+  }
+}
+
+@media (max-width: 380px) {
+  .loading-skeleton {
+    padding: 16px 14px;
+  }
+}
+
+/* --- Error card ------------------------------------------------------- */
+
+.error-card {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 22px 20px;
+  margin: 0;
+  background: color-mix(in oklab, var(--bad-soft) 55%, var(--panel));
+  border: 1px solid color-mix(in oklab, var(--bad) 28%, var(--line));
+  border-radius: var(--radius-sm);
+  color: var(--ink);
+  max-width: 100%;
+  overflow-wrap: anywhere;
+}
+
+.error-card-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--bad-strong);
+  line-height: 0;
+}
+
+.error-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-width: 100%;
+}
+
+.error-card-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--bad-strong);
+  line-height: 1.35;
+}
+
+.error-card-lede {
+  margin: 0;
+  color: var(--ink-2);
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
+.error-card-actions {
+  margin-top: 4px;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 380px) {
+  .error-card {
+    padding: 18px 16px;
+    gap: 10px;
   }
 }

--- a/tests/empty-state-consumer-integration.test.js
+++ b/tests/empty-state-consumer-integration.test.js
@@ -1,0 +1,281 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+
+// SH2-U5 post-review: parity test (`tests/empty-state-parity.test.js`)
+// was source-text only — it asserted that each consumer imports the
+// shared `EmptyState` primitive and that the canonical copy strings
+// appear, but it never exercised the rendered HTML. A broken
+// `action.onClick` wiring or a mis-spelled `data-action` would still
+// pass the source-text grep.
+//
+// This file plugs that gap: for every consumer whose empty branch is
+// expected to surface a CTA button, we SSR-render the consumer with
+// empty input data and assert the rendered HTML carries the expected
+// `data-action` on an actual `<button>` element. If a future edit drops
+// `action=` from an EmptyState call site (the same defect ce-design-lens
+// flagged on WordBank), this test fails where parity alone would not.
+//
+// Consumers exercised:
+//   1. CodexSurface — empty `model.monsterSummary` → codex-start-fresh-round
+//   2. MonsterMeadow — empty `monsters` → no CTA (intentional: hero copy
+//      already carries the "Start a round" CTA above the meadow; doubling
+//      it would clutter the hero). Asserted as absence so a future edit
+//      that adds an action prop here trips a deliberate re-review.
+//   3. CodexCreatureLightbox — `entry=null` branch → codex-lightbox-close
+//   4. SpellingWordBankScene — empty `analytics.wordGroups` →
+//      spelling-close-word-bank (the DESIGN-BLOCKER-1 fix)
+//
+// ParentHub empty branches are intentionally action-less ("check back
+// later" pattern) so they are NOT exercised here. Grammar's dashboard
+// empty branch is action-less too (the hero already renders a
+// `Begin round` primary CTA below the empty state) and stays out of
+// this test's scope.
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function nodePaths() {
+  return [
+    path.join(rootDir, 'node_modules'),
+    ...String(process.env.NODE_PATH || '').split(path.delimiter),
+  ].filter((entry) => entry && existsSync(entry));
+}
+
+async function renderFixture(entrySource) {
+  const tmpDir = await mkdtemp(path.join(tmpdir(), 'ks2-empty-consumer-'));
+  const entryPath = path.join(tmpDir, 'entry.jsx');
+  const bundlePath = path.join(tmpDir, 'entry.cjs');
+  try {
+    await writeFile(entryPath, entrySource);
+    await build({
+      absWorkingDir: rootDir,
+      entryPoints: [entryPath],
+      outfile: bundlePath,
+      bundle: true,
+      platform: 'node',
+      format: 'cjs',
+      target: ['node24'],
+      jsx: 'automatic',
+      jsxImportSource: 'react',
+      loader: { '.js': 'jsx' },
+      nodePaths: nodePaths(),
+      logLevel: 'silent',
+    });
+    return execFileSync(process.execPath, [bundlePath], {
+      cwd: rootDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+function absoluteSpecifier(relativePath) {
+  return JSON.stringify(path.join(rootDir, relativePath));
+}
+
+// ---------- CodexSurface ---------- //
+
+test('CodexSurface empty branch JSX wires codex-start-fresh-round CTA through EmptyState.action', async () => {
+  // `CodexSurface` can't be made to hit the empty branch through normal
+  // SSR because `buildCodexEntries` always synthesises uncaught monster
+  // entries for every known subject — the empty branch is defensive
+  // code for edge cases (subject-registry churn, stripped monster sets).
+  //
+  // We instead drive the equivalent assertion by rendering the
+  // `EmptyState` primitive directly with the exact `action` shape the
+  // source hands it, and verifying the rendered HTML carries the
+  // expected data-action + button element. The parser-level parity
+  // test in `tests/empty-state-parity.test.js` already pins the
+  // presence of the canonical copy; this test pins the runtime shape
+  // of `action` so a broken `onClick` (not a function) would still
+  // register as a missing button — matching the defect ce-design-lens
+  // flagged on WordBank.
+  //
+  // Any future edit to the CodexSurface empty branch that changes the
+  // `dataAction` string or drops the action prop will desync this
+  // test's literal from the source, so we also assert (below) that
+  // the source still contains the same literal.
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { EmptyState } from ${absoluteSpecifier('src/platform/ui/EmptyState.jsx')};
+    const openPractice = () => {};
+    const html = renderToStaticMarkup(
+      <EmptyState
+        title="Codex is empty"
+        body="Codex is empty. Progress is stored safely. Complete a round to unlock your first entry."
+        action={{
+          label: 'Start Spelling',
+          onClick: () => openPractice('spelling'),
+          dataAction: 'codex-start-fresh-round',
+        }}
+      />
+    );
+    console.log(html);
+  `);
+  assert.match(html, /data-testid="empty-state"/, 'EmptyState must render with the stable testid');
+  assert.match(
+    html,
+    /<button[^>]*data-action="codex-start-fresh-round"/,
+    'The CodexSurface action shape must render a real <button> — a broken onClick (non-function) would collapse the CTA',
+  );
+  assert.match(html, /Codex is empty/, 'Canonical empty copy must appear');
+  // Source-level lock: if the CodexSurface file ever drops this exact
+  // action shape, the integration test would stop covering the real
+  // consumer. Pin the literal so drift trips the test.
+  const { readFileSync } = await import('node:fs');
+  const { fileURLToPath } = await import('node:url');
+  const { default: path } = await import('node:path');
+  const selfUrl = import.meta.url;
+  const testDir = path.dirname(fileURLToPath(selfUrl));
+  const rootDir = path.resolve(testDir, '..');
+  const source = readFileSync(path.join(rootDir, 'src/surfaces/home/CodexSurface.jsx'), 'utf8');
+  assert.match(
+    source,
+    /dataAction:\s*['"]codex-start-fresh-round['"]/,
+    'CodexSurface must keep wiring codex-start-fresh-round on the EmptyState action prop',
+  );
+  assert.match(
+    source,
+    /onClick:\s*\(\)\s*=>\s*openPractice\s*\(/,
+    'CodexSurface action.onClick must still invoke openPractice so the button is not a dead sentence',
+  );
+});
+
+// ---------- MonsterMeadow ---------- //
+
+test('MonsterMeadow empty branch renders EmptyState WITHOUT an action CTA (intentional)', async () => {
+  // The home hero already renders "Start a round" — doubling the CTA
+  // on the meadow would clutter the layout and split the learner's
+  // attention. MonsterMeadow therefore passes no `action` prop.
+  // This test pins the decision: if a future edit starts wiring an
+  // action here, the assertion trips so the choice is re-reviewed.
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { MonsterVisualConfigProvider } from ${absoluteSpecifier('src/platform/game/MonsterVisualConfigContext.jsx')};
+    import { BUNDLED_MONSTER_VISUAL_CONFIG } from ${absoluteSpecifier('src/platform/game/monster-visual-config.js')};
+    import { MonsterMeadow } from ${absoluteSpecifier('src/surfaces/home/MonsterMeadow.jsx')};
+    const html = renderToStaticMarkup(
+      <MonsterVisualConfigProvider value={{ config: BUNDLED_MONSTER_VISUAL_CONFIG }}>
+        <MonsterMeadow monsters={[]} />
+      </MonsterVisualConfigProvider>
+    );
+    console.log(html);
+  `);
+  assert.match(html, /data-testid="empty-state"/, 'MonsterMeadow empty branch must render the shared EmptyState primitive');
+  assert.match(html, /Nothing caught yet/, 'MonsterMeadow empty copy must appear');
+  // Intentional action-less branch — belt-and-braces guard: no CTA
+  // button is emitted inside the MonsterMeadow wrapper. Scope the
+  // absence check to the meadow wrapper so the assertion stays stable
+  // if the surrounding hero later gains its own buttons.
+  const meadowMatch = html.match(/<div class="monster-meadow-empty">([\s\S]*?)<\/div>\s*<\/div>/);
+  const meadowMarkup = meadowMatch ? meadowMatch[0] : html;
+  assert.doesNotMatch(
+    meadowMarkup,
+    /<button/,
+    'MonsterMeadow empty wrapper must NOT render a button — the hero already carries the "Start a round" CTA',
+  );
+  // Also confirm the NIT-C1 fix: no aria-label on the outer wrapper
+  // (the inner EmptyState already announces via role=status).
+  assert.doesNotMatch(
+    meadowMarkup,
+    /<div class="monster-meadow-empty"[^>]*aria-label=/,
+    'MonsterMeadow wrapper must not carry aria-label (the inner EmptyState role=status already announces)',
+  );
+});
+
+// ---------- CodexCreatureLightbox ---------- //
+
+test('CodexCreatureLightbox empty branch renders codex-lightbox-close CTA button', async () => {
+  // When the caller passes `entry={null}` (e.g. the upstream codex
+  // has not produced a matching row yet) the lightbox renders the
+  // primitive with a Close action. We assert the button renders and
+  // carries the expected data-action.
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { MonsterVisualConfigProvider } from ${absoluteSpecifier('src/platform/game/MonsterVisualConfigContext.jsx')};
+    import { BUNDLED_MONSTER_VISUAL_CONFIG } from ${absoluteSpecifier('src/platform/game/monster-visual-config.js')};
+    import { CodexCreatureLightbox } from ${absoluteSpecifier('src/surfaces/home/CodexCreatureLightbox.jsx')};
+    const html = renderToStaticMarkup(
+      <MonsterVisualConfigProvider value={{ config: BUNDLED_MONSTER_VISUAL_CONFIG }}>
+        <CodexCreatureLightbox entry={null} onClose={() => {}} />
+      </MonsterVisualConfigProvider>
+    );
+    console.log(html);
+  `);
+  assert.match(html, /data-testid="empty-state"/, 'CodexCreatureLightbox empty branch must render the shared EmptyState primitive');
+  assert.match(html, /data-action="codex-lightbox-close"/, 'CodexCreatureLightbox empty branch must expose codex-lightbox-close data-action');
+  assert.match(
+    html,
+    /<button[^>]*data-action="codex-lightbox-close"/,
+    'CodexCreatureLightbox empty CTA must be a <button> element',
+  );
+  assert.match(html, /Nothing to preview yet/, 'CodexCreatureLightbox empty copy must appear');
+});
+
+// ---------- SpellingWordBankScene ---------- //
+
+test('SpellingWordBankScene empty branch renders spelling-close-word-bank CTA button (DESIGN-BLOCKER-1 fix)', async () => {
+  // Direct render of WordBankCard with an empty analytics.wordGroups
+  // triggers the `totalTrackedWords === 0` short-circuit → the
+  // EmptyState branch. Pre-review, this branch rendered the canonical
+  // three-sentence copy but omitted the `action` prop, so the button
+  // was silently missing. This test pins the DESIGN-BLOCKER-1 fix.
+  //
+  // WordBankCard is an internal component of SpellingWordBankScene —
+  // we render the internal module directly rather than the whole scene
+  // because the scene also needs full learner fixtures and hero
+  // backdrops that add noise to this narrow assertion. The private
+  // import is acceptable for an SSR parity test; the exported
+  // boundary it's guarding (the EmptyState contract) is what matters.
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { SpellingWordBankScene } from ${absoluteSpecifier('src/subjects/spelling/components/SpellingWordBankScene.jsx')};
+    const learner = { id: 'learner-a', name: 'Ava', accent: '#3E6FA8' };
+    const analytics = { wordGroups: [], wordBank: {} };
+    const appState = { transientUi: {} };
+    const actions = { dispatch() {} };
+    const html = renderToStaticMarkup(
+      <SpellingWordBankScene
+        appState={appState}
+        learner={learner}
+        analytics={analytics}
+        accent="#3E6FA8"
+        actions={actions}
+      />
+    );
+    console.log(html);
+  `);
+  assert.match(html, /data-testid="empty-state"/, 'WordBank empty branch must render the shared EmptyState primitive');
+  assert.match(html, /data-action="spelling-close-word-bank"/, 'WordBank empty branch must expose spelling-close-word-bank data-action');
+  // The WordBank topbar also renders a spelling-close-word-bank button
+  // ("← Back to setup"), so we look for the empty-state scoped CTA.
+  // Both must be `<button>` elements, and the empty-state copy +
+  // button should co-render (the three-sentence lede next to a button
+  // labelled "Back to spelling").
+  assert.match(html, /No words yet/, 'WordBank empty copy headline must appear');
+  assert.match(html, /Your progress is saved/, 'WordBank empty copy reassurance must appear');
+  const emptyCtaMatch = html.match(
+    /class="actions empty-state-actions"[\s\S]*?<button[^>]*data-action="spelling-close-word-bank"[^>]*>([^<]+)<\/button>/,
+  );
+  assert.ok(
+    emptyCtaMatch,
+    'WordBank empty branch must render the CTA button INSIDE the EmptyState actions row with label text',
+  );
+  assert.match(
+    emptyCtaMatch[1],
+    /Back to spelling/,
+    'WordBank empty CTA label must read "Back to spelling"',
+  );
+});

--- a/tests/empty-state-parity.test.js
+++ b/tests/empty-state-parity.test.js
@@ -85,6 +85,41 @@ test('WordBank empty copy follows the canonical three-part structure', () => {
   );
 });
 
+test('WordBank empty EmptyState wires an action CTA (post-review fix)', () => {
+  // Design-review found that the WordBank empty branch rendered the
+  // canonical action sentence ("Play a spelling round to add your first
+  // word") but without a button — learners read an instruction with
+  // nothing to click. The fix wires `action.onClick` to the existing
+  // `spelling-close-word-bank` dispatch so the CTA returns the learner
+  // to the setup scene where they can start a round.
+  //
+  // This parser-level assertion keeps the fix load-bearing: if a future
+  // edit drops the action prop, the source-text parity test alone
+  // wouldn't notice (the three-sentence copy still parses). A separate
+  // SSR integration test in `empty-state-consumer-integration.test.js`
+  // verifies the button actually renders with the right data-action.
+  const source = readFile('src/subjects/spelling/components/SpellingWordBankScene.jsx');
+  // The empty branch passes an `action=` prop to EmptyState that
+  // dispatches `spelling-close-word-bank`. We scope the match to the
+  // empty-branch block so accidentally matching the topbar's existing
+  // `spelling-close-word-bank` button would fail.
+  const emptyBranchMatch = source.match(
+    /if\s*\(\s*totalTrackedWords\s*===\s*0\s*\)[\s\S]*?<\/section>\s*\)\s*;\s*\}/,
+  );
+  assert.ok(emptyBranchMatch, 'WordBank empty-branch block must be detectable');
+  const emptyBranch = emptyBranchMatch[0];
+  assert.match(
+    emptyBranch,
+    /action\s*=\s*\{/,
+    'WordBank EmptyState must pass an `action=` prop (no dead CTA)',
+  );
+  assert.match(
+    emptyBranch,
+    /dataAction:\s*['"]spelling-close-word-bank['"]/,
+    'WordBank EmptyState CTA must wire to `spelling-close-word-bank`',
+  );
+});
+
 test('MonsterMeadow empty copy follows the canonical three-part structure', () => {
   const source = readFile('src/surfaces/home/MonsterMeadow.jsx');
   assert.match(source, /Nothing caught yet/, 'MonsterMeadow empty headline "Nothing caught yet"');
@@ -119,7 +154,13 @@ test('Grammar dashboard-empty copy keeps the existing anchor AND adds reassuranc
   // The pre-U5 "Start your first round…" anchor stays because the
   // existing child-copy regression tests assert on it. The U5 upgrade
   // wraps it in EmptyState + adds the reassurance sentence.
-  assert.match(source, /Grammar is ready/, 'Grammar dashboard-empty headline');
+  //
+  // Post-review: the title changed from the promotional "Grammar is
+  // ready" to the neutral "No rounds yet" so the six EmptyState
+  // surfaces share a single voice (neutral "No X yet" / "Nothing yet"
+  // pattern). The anchor + reassurance + action copy are unchanged so
+  // the downstream child-copy tests keep their existing regex.
+  assert.match(source, /No rounds yet/, 'Grammar dashboard-empty headline follows the neutral "No X yet" baseline');
   assert.match(source, /Progress is saved as you practise/, 'Grammar dashboard-empty reassurance');
   assert.match(source, /Start your first round to see your scores here/);
 });

--- a/tests/empty-state-parity.test.js
+++ b/tests/empty-state-parity.test.js
@@ -1,0 +1,152 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// SH2-U5: parser-level parity test. Every production surface that hosts
+// a genuinely-empty branch must import the shared `EmptyState` primitive
+// so the canonical three-part copy pattern (what happened / is progress
+// safe / what action is available) stays consistent across Parent Hub,
+// MonsterMeadow, Codex, WordBank, and Grammar dashboard.
+//
+// Also asserts `ErrorCard` lands in ≥ 2 production sites. The error
+// primitive is the paired counterpart to EmptyState — keeping the count
+// at 2 right now prevents a regression where a new surface invents its
+// own error banner (a bespoke `<div class="error">` styled red) instead
+// of adopting the primitive.
+//
+// Allowlist exists so surfaces that intentionally don't use the
+// primitive (e.g. subject-internal chips like Punctuation's "Everything
+// was secure" which is positive feedback, not an empty branch) can be
+// added deliberately rather than accidentally going unnoticed.
+//
+// Parser strategy mirrors `tests/toast-positioning-contract.test.js`:
+// read source files as text, grep for imports + selector patterns, no
+// module-resolution loader required.
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const EMPTY_STATE_CONSUMERS = [
+  'src/surfaces/hubs/ParentHubSurface.jsx',
+  'src/surfaces/home/MonsterMeadow.jsx',
+  'src/surfaces/home/CodexSurface.jsx',
+  'src/surfaces/home/CodexCreatureLightbox.jsx',
+  'src/subjects/spelling/components/SpellingWordBankScene.jsx',
+  'src/subjects/grammar/components/GrammarSetupScene.jsx',
+];
+
+function readFile(relative) {
+  return readFileSync(path.join(rootDir, relative), 'utf8');
+}
+
+test('every plan-mandated surface imports the shared EmptyState primitive', () => {
+  for (const file of EMPTY_STATE_CONSUMERS) {
+    const source = readFile(file);
+    assert.match(
+      source,
+      /import\s*\{[^}]*\bEmptyState\b[^}]*\}\s*from\s*['"][^'"]*platform\/ui\/EmptyState\.jsx?['"]/,
+      `${file} must import EmptyState from the shared primitive at src/platform/ui/EmptyState.jsx. ` +
+      'If this surface legitimately no longer needs the primitive, update the EMPTY_STATE_CONSUMERS allowlist in this test deliberately.',
+    );
+    // Belt-and-braces: the surface must actually render the primitive.
+    // A stray import without a call site would leave the canonical copy
+    // pattern unenforced.
+    assert.match(
+      source,
+      /<EmptyState\b/,
+      `${file} imports EmptyState but never uses it — a tree-shake would remove the import. ` +
+      'Either render the primitive in the empty branch or remove the import.',
+    );
+  }
+});
+
+test('EmptyState has ≥ 6 unique production import sites', () => {
+  // Six is the plan-mandated minimum. The allowlist above is the
+  // canonical count. If a future unit adds a seventh consumer, add it
+  // to the list so the test catches accidental removals.
+  assert.ok(
+    EMPTY_STATE_CONSUMERS.length >= 6,
+    `Plan-mandated minimum is 6 EmptyState consumers; got ${EMPTY_STATE_CONSUMERS.length}.`,
+  );
+});
+
+test('WordBank empty copy follows the canonical three-part structure', () => {
+  const source = readFile('src/subjects/spelling/components/SpellingWordBankScene.jsx');
+  // Canonical copy from the plan, part 1: what happened.
+  assert.match(source, /No words yet/, 'WordBank empty must say "No words yet"');
+  // Part 2: is progress safe (reassurance phrase).
+  assert.match(source, /Your progress is saved/, 'WordBank empty must include "Your progress is saved" reassurance');
+  // Part 3: what action is available.
+  assert.match(
+    source,
+    /Play a spelling round to add your first word/,
+    'WordBank empty must include the canonical action copy "Play a spelling round to add your first word"',
+  );
+});
+
+test('MonsterMeadow empty copy follows the canonical three-part structure', () => {
+  const source = readFile('src/surfaces/home/MonsterMeadow.jsx');
+  assert.match(source, /Nothing caught yet/, 'MonsterMeadow empty headline "Nothing caught yet"');
+  assert.match(source, /meadow stays tidy/i, 'MonsterMeadow empty reassurance "Your meadow stays tidy"');
+  assert.match(
+    source,
+    /Finish a round to see your first monster appear/,
+    'MonsterMeadow empty action "Finish a round to see your first monster appear"',
+  );
+});
+
+test('Codex fresh-learner copy follows the canonical three-part structure', () => {
+  const source = readFile('src/surfaces/home/CodexSurface.jsx');
+  assert.match(source, /Codex is empty/);
+  assert.match(source, /Progress is stored safely/);
+  assert.match(source, /Complete a round to unlock your first entry/);
+});
+
+test('Parent Hub Recent Sessions + Current Focus copy includes reassurance (progress is safe)', () => {
+  const source = readFile('src/surfaces/hubs/ParentHubSurface.jsx');
+  // Recent Sessions empty (canonical Parent Hub copy that the plan cites
+  // as the voice template).
+  assert.match(source, /No completed or active sessions are stored yet/);
+  assert.match(source, /Progress stays safe/, 'Parent Hub Recent Sessions reassurance is explicit');
+  // Current Focus empty.
+  assert.match(source, /No due work is surfaced yet/);
+  assert.match(source, /Progress is recorded safely/, 'Parent Hub Current Focus reassurance is explicit');
+});
+
+test('Grammar dashboard-empty copy keeps the existing anchor AND adds reassurance', () => {
+  const source = readFile('src/subjects/grammar/components/GrammarSetupScene.jsx');
+  // The pre-U5 "Start your first round…" anchor stays because the
+  // existing child-copy regression tests assert on it. The U5 upgrade
+  // wraps it in EmptyState + adds the reassurance sentence.
+  assert.match(source, /Grammar is ready/, 'Grammar dashboard-empty headline');
+  assert.match(source, /Progress is saved as you practise/, 'Grammar dashboard-empty reassurance');
+  assert.match(source, /Start your first round to see your scores here/);
+});
+
+// ---------- ErrorCard parity ---------- //
+
+const ERROR_CARD_CONSUMERS = [
+  'src/surfaces/subject/SubjectRuntimeFallback.jsx',
+  'src/surfaces/hubs/hub-utils.js',
+];
+
+test('ErrorCard has ≥ 2 production import sites', () => {
+  assert.ok(
+    ERROR_CARD_CONSUMERS.length >= 2,
+    `ErrorCard is meant to ship in ≥ 2 production sites; allowlist has ${ERROR_CARD_CONSUMERS.length}.`,
+  );
+  for (const file of ERROR_CARD_CONSUMERS) {
+    const source = readFile(file);
+    assert.match(
+      source,
+      /import\s*\{[^}]*\bErrorCard\b[^}]*\}\s*from\s*['"][^'"]*platform\/ui\/ErrorCard\.jsx?['"]/,
+      `${file} must import ErrorCard from the shared primitive at src/platform/ui/ErrorCard.jsx`,
+    );
+    assert.match(
+      source,
+      /<ErrorCard\b/,
+      `${file} imports ErrorCard but never renders it`,
+    );
+  }
+});

--- a/tests/empty-state-primitive.test.js
+++ b/tests/empty-state-primitive.test.js
@@ -1,0 +1,326 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+
+// SH2-U5: parser-level + SSR contract tests for the three shared state
+// primitives. We render each primitive through
+// `renderToStaticMarkup` exactly as production does (one-shot entry
+// script + esbuild bundle + `execFileSync`), then assert on the rendered
+// HTML. CSS invariants (reduced-motion carve-out, mobile-360 padding
+// clamp) are parser-level — read `styles/app.css` as text and regex.
+//
+// Test surface:
+//   1. EmptyState — title + body + CTA wiring, role=status, optional action.
+//   2. LoadingSkeleton — row count default + clamp, prefers-reduced-motion
+//      carve-out cancels the animation.
+//   3. ErrorCard — `code` never appears in visible copy, `data-error-code`
+//      attribute present, optional onRetry button.
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CSS_PATH = path.join(rootDir, 'styles', 'app.css');
+
+function nodePaths() {
+  return [
+    path.join(rootDir, 'node_modules'),
+    ...String(process.env.NODE_PATH || '').split(path.delimiter),
+  ].filter((entry) => entry && existsSync(entry));
+}
+
+async function renderFixture(entrySource) {
+  const tmpDir = await mkdtemp(path.join(tmpdir(), 'ks2-ui-primitive-'));
+  const entryPath = path.join(tmpDir, 'entry.jsx');
+  const bundlePath = path.join(tmpDir, 'entry.cjs');
+  try {
+    await writeFile(entryPath, entrySource);
+    await build({
+      absWorkingDir: rootDir,
+      entryPoints: [entryPath],
+      outfile: bundlePath,
+      bundle: true,
+      platform: 'node',
+      format: 'cjs',
+      target: ['node24'],
+      jsx: 'automatic',
+      jsxImportSource: 'react',
+      loader: { '.js': 'jsx' },
+      nodePaths: nodePaths(),
+      logLevel: 'silent',
+    });
+    return execFileSync(process.execPath, [bundlePath], {
+      cwd: rootDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+function absoluteSpecifier(relativePath) {
+  return JSON.stringify(path.join(rootDir, relativePath));
+}
+
+function extractRuleBlock(source, selector) {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const ruleRegex = new RegExp(`(^|\\n)\\s*${escaped}\\s*\\{`, 'g');
+  const match = ruleRegex.exec(source);
+  if (!match) return null;
+  const braceOpen = source.indexOf('{', match.index);
+  if (braceOpen === -1) return null;
+  let depth = 1;
+  let i = braceOpen + 1;
+  while (i < source.length && depth > 0) {
+    const ch = source[i];
+    if (ch === '{') depth += 1;
+    else if (ch === '}') depth -= 1;
+    i += 1;
+  }
+  return source.slice(braceOpen + 1, i - 1);
+}
+
+// ---------- EmptyState ---------- //
+
+test('EmptyState renders role=status + title + body + CTA when action provided', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { EmptyState } from ${absoluteSpecifier('src/platform/ui/EmptyState.jsx')};
+    const html = renderToStaticMarkup(
+      <EmptyState
+        title="No words yet"
+        body="No words yet. Your progress is saved. Play a spelling round to add your first word."
+        action={{ label: 'Start spelling', onClick: () => {}, dataAction: 'empty-state-start-spelling' }}
+      />
+    );
+    console.log(html);
+  `);
+  assert.match(html, /role="status"/, 'EmptyState must render role="status" for AT announcement');
+  assert.match(html, /aria-live="polite"/, 'EmptyState must use polite live region');
+  assert.match(html, /No words yet/, 'EmptyState renders the title');
+  assert.match(html, /Play a spelling round to add your first word/, 'EmptyState renders the body');
+  assert.match(html, /<button[^>]*class="btn secondary"[^>]*>Start spelling<\/button>/, 'EmptyState renders the CTA button');
+  assert.match(html, /data-action="empty-state-start-spelling"/, 'EmptyState forwards the dataAction');
+  assert.match(html, /data-testid="empty-state"/, 'EmptyState carries the stable testid');
+});
+
+test('EmptyState omits the action row when no action prop is supplied but still announces', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { EmptyState } from ${absoluteSpecifier('src/platform/ui/EmptyState.jsx')};
+    const html = renderToStaticMarkup(
+      <EmptyState title="Nothing to show" body="Progress is safe." />
+    );
+    console.log(html);
+  `);
+  assert.match(html, /role="status"/, 'EmptyState still announces when action is absent');
+  assert.match(html, /Nothing to show/);
+  assert.match(html, /Progress is safe\./);
+  assert.doesNotMatch(html, /empty-state-actions/, 'EmptyState must not render the .actions row when no action is supplied');
+  assert.doesNotMatch(html, /<button/, 'EmptyState must not render any button when no action is supplied');
+});
+
+test('EmptyState does NOT render an icon with text content visible to AT (icon is aria-hidden)', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { EmptyState } from ${absoluteSpecifier('src/platform/ui/EmptyState.jsx')};
+    const html = renderToStaticMarkup(<EmptyState title="t" body="b" />);
+    console.log(html);
+  `);
+  // The icon slot is marked aria-hidden so screen readers don't announce
+  // the decorative glyph alongside the copy. If the icon ever becomes
+  // load-bearing (e.g. status-only glyph), the primitive should accept an
+  // explicit label — don't silently drop the hidden flag.
+  assert.match(html, /<span class="empty-state-icon" aria-hidden="true"/, 'icon slot must be aria-hidden decorative');
+});
+
+// ---------- LoadingSkeleton ---------- //
+
+test('LoadingSkeleton renders 3 rows by default', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { LoadingSkeleton } from ${absoluteSpecifier('src/platform/ui/LoadingSkeleton.jsx')};
+    const html = renderToStaticMarkup(<LoadingSkeleton />);
+    console.log(html);
+  `);
+  const rowMatches = html.match(/loading-skeleton-row/g) || [];
+  assert.equal(rowMatches.length, 3, 'default rows should be 3');
+  assert.match(html, /role="status"/, 'LoadingSkeleton announces loading politely');
+  assert.match(html, /aria-label="Loading"/);
+  assert.match(html, /Loading…/, 'sr-only text for screen readers');
+});
+
+test('LoadingSkeleton honours an explicit rows count', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { LoadingSkeleton } from ${absoluteSpecifier('src/platform/ui/LoadingSkeleton.jsx')};
+    const html = renderToStaticMarkup(<LoadingSkeleton rows={5} />);
+    console.log(html);
+  `);
+  const rowMatches = html.match(/loading-skeleton-row/g) || [];
+  assert.equal(rowMatches.length, 5, 'rows=5 should render 5 rows');
+});
+
+test('LoadingSkeleton clamps nonsense rows back to the default', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { LoadingSkeleton } from ${absoluteSpecifier('src/platform/ui/LoadingSkeleton.jsx')};
+    const html = renderToStaticMarkup(<LoadingSkeleton rows="junk" />);
+    console.log(html);
+  `);
+  const rowMatches = html.match(/loading-skeleton-row/g) || [];
+  assert.equal(rowMatches.length, 3, 'non-numeric rows should fall back to 3');
+});
+
+test('LoadingSkeleton shimmer respects prefers-reduced-motion (CSS carve-out cancels the animation)', () => {
+  const css = readFileSync(CSS_PATH, 'utf8');
+  const reducedMotionBlocks = css.match(/@media\s*\(\s*prefers-reduced-motion\s*:\s*reduce\s*\)\s*\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}/g) || [];
+  assert.ok(reducedMotionBlocks.length > 0, 'app.css must declare at least one reduced-motion block');
+  const skeletonOverride = reducedMotionBlocks.find((block) => /\.loading-skeleton-row\b/.test(block));
+  assert.ok(
+    skeletonOverride,
+    'A reduced-motion block must override .loading-skeleton-row. Without this, learners who asked motion to stop still see the 1.4s shimmer pulse on every placeholder.',
+  );
+  assert.match(
+    skeletonOverride,
+    /\.loading-skeleton-row\b[^{]*\{[^}]*animation\s*:\s*none/,
+    'the reduced-motion override must set `animation: none` — shortening the duration is not enough',
+  );
+});
+
+test('LoadingSkeleton shimmer keyframes animate only background-position (compositor-cheap)', () => {
+  const css = readFileSync(CSS_PATH, 'utf8');
+  // The shimmer keyframes are named `loading-skeleton-shimmer` and should
+  // animate only the gradient's background-position (cheap, compositor-
+  // only). No width/height/top/left animation — those would trigger
+  // per-frame layout for every placeholder, which becomes noticeable as
+  // soon as two or three skeletons stack on a panel.
+  const marker = '@keyframes loading-skeleton-shimmer';
+  const start = css.indexOf(marker);
+  assert.ok(start >= 0, 'expected @keyframes loading-skeleton-shimmer in app.css');
+  const braceOpen = css.indexOf('{', start);
+  let depth = 1;
+  let i = braceOpen + 1;
+  while (i < css.length && depth > 0) {
+    const ch = css[i];
+    if (ch === '{') depth += 1;
+    else if (ch === '}') depth -= 1;
+    i += 1;
+  }
+  const block = css.slice(braceOpen + 1, i - 1);
+  const props = new Set();
+  const re = /(?:^|[{;\s])\s*([a-z-]+)\s*:/g;
+  let m;
+  while ((m = re.exec(block)) !== null) props.add(m[1]);
+  const forbidden = [...props].filter((p) => !['background-position'].includes(p));
+  assert.deepEqual(forbidden, [], `loading-skeleton-shimmer should animate only background-position. Found: ${JSON.stringify(forbidden)}`);
+});
+
+// ---------- ErrorCard ---------- //
+
+test('ErrorCard renders title + body + retry button when onRetry is provided', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { ErrorCard } from ${absoluteSpecifier('src/platform/ui/ErrorCard.jsx')};
+    const html = renderToStaticMarkup(
+      <ErrorCard
+        title="Couldn't load"
+        body="We'll keep the last saved progress visible. Retry to fetch the latest."
+        onRetry={() => {}}
+        code="remote_error_503"
+      />
+    );
+    console.log(html);
+  `);
+  assert.match(html, /role="alert"/, 'ErrorCard must use role=alert so AT announces the failure');
+  assert.match(html, /aria-live="polite"/, 'polite announcement so mid-session keystrokes are not interrupted');
+  assert.match(html, /Couldn&#x27;t load/);
+  assert.match(html, /We&#x27;ll keep the last saved progress visible/);
+  assert.match(html, /<button[^>]*class="btn secondary"[^>]*>Try again<\/button>/, 'retry button defaults to "Try again"');
+  assert.match(html, /data-error-code="remote_error_503"/, '`code` must be surfaced ONLY as data-error-code');
+});
+
+test('ErrorCard never renders `code` in visible copy — belt-and-braces for SH2-U12 oracle', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { ErrorCard } from ${absoluteSpecifier('src/platform/ui/ErrorCard.jsx')};
+    const html = renderToStaticMarkup(
+      <ErrorCard
+        title="Temporary network blip"
+        body="Progress is saved locally."
+        code="CRITICAL_DB_FAIL_ABCD1234"
+      />
+    );
+    console.log(html);
+  `);
+  // The raw code token must only live on the data attribute — never in
+  // the text the learner reads. Strip the data attribute and assert.
+  const stripped = html.replace(/data-error-code="[^"]*"/g, '');
+  assert.doesNotMatch(stripped, /CRITICAL_DB_FAIL_ABCD1234/, 'visible copy must not leak the raw error code');
+});
+
+test('ErrorCard omits the retry button when onRetry is absent', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { ErrorCard } from ${absoluteSpecifier('src/platform/ui/ErrorCard.jsx')};
+    const html = renderToStaticMarkup(<ErrorCard title="Oh" body="Safe." />);
+    console.log(html);
+  `);
+  assert.doesNotMatch(html, /<button/, 'ErrorCard without onRetry must not render a dead button');
+  assert.doesNotMatch(html, /error-card-actions/);
+});
+
+test('ErrorCard accepts a custom retryLabel', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { ErrorCard } from ${absoluteSpecifier('src/platform/ui/ErrorCard.jsx')};
+    const html = renderToStaticMarkup(
+      <ErrorCard title="x" body="y" onRetry={() => {}} retryLabel="Retry sync" />
+    );
+    console.log(html);
+  `);
+  assert.match(html, /Retry sync/);
+});
+
+// ---------- Mobile-360 overflow contract ---------- //
+
+test('All three primitives declare box-sizing: border-box + max-width: 100% to stay within mobile-360 viewport', () => {
+  const css = readFileSync(CSS_PATH, 'utf8');
+  for (const selector of ['.empty-state', '.loading-skeleton', '.error-card']) {
+    const block = extractRuleBlock(css, selector);
+    assert.ok(block !== null, `expected ${selector} rule in app.css`);
+    assert.match(block, /box-sizing\s*:\s*border-box/, `${selector} must declare box-sizing: border-box so padding does not push the panel past the viewport on mobile-360`);
+    assert.match(block, /max-width\s*:\s*100%/, `${selector} must declare max-width: 100% so the primitive stays inside its parent column on narrow screens`);
+  }
+});
+
+test('Primitives keep padding sane at mobile-360 (≤ 380px viewport clamp block present)', () => {
+  const css = readFileSync(CSS_PATH, 'utf8');
+  // Each primitive has a narrow-viewport media block that shrinks the
+  // padding so a 360px-wide viewport doesn't consume half the panel on
+  // padding alone. The rule shape is not dictated here — just the
+  // presence of at least one `.empty-state { padding: ... }` override
+  // inside a `@media (max-width: 380px)` block.
+  const narrowBlocks = css.match(/@media\s*\(\s*max-width\s*:\s*380px\s*\)\s*\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}/g) || [];
+  assert.ok(narrowBlocks.length > 0, 'expected at least one @media (max-width: 380px) block');
+  const emptyBlockPresent = narrowBlocks.some((block) => /\.empty-state\s*\{[^}]*padding/.test(block));
+  const loadingBlockPresent = narrowBlocks.some((block) => /\.loading-skeleton\s*\{[^}]*padding/.test(block));
+  const errorBlockPresent = narrowBlocks.some((block) => /\.error-card\s*\{[^}]*padding/.test(block));
+  assert.ok(emptyBlockPresent, '.empty-state must have a narrow-viewport padding override so mobile-360 stays breathable');
+  assert.ok(loadingBlockPresent, '.loading-skeleton must have a narrow-viewport padding override');
+  assert.ok(errorBlockPresent, '.error-card must have a narrow-viewport padding override');
+});


### PR DESCRIPTION
## Summary

Introduces three shared state primitives at `src/platform/ui/` and re-skins six surfaces so every visible panel follows the same three-part empty/loading/error copy pattern (what happened → is progress safe → what action is available).

Plan: `docs/plans/2026-04-26-001-feat-sys-hardening-p2-plan.md` lines 490-531 (SH2-U5), requirement R5.

## What shipped

**Primitives (new)**
- `EmptyState({ title, body, action? })` — `role=status`, optional CTA, icon slot (decorative, `aria-hidden`). `action.onClick` stays caller-owned so surfaces wrap it with `useSubmitLock` on their side.
- `LoadingSkeleton({ rows=3 })` — CSS-only `background-position` shimmer, clamped row count, `prefers-reduced-motion` carve-out flattens to `var(--line-soft)`.
- `ErrorCard({ title, body, onRetry?, code? })` — `role=alert`; `code` surfaces **only** as `data-error-code` and never leaks to visible copy (belt-and-braces for SH2-U12's oracle); retry button hidden when `onRetry` is absent.

**EmptyState consumers (6, matches plan-mandated minimum)**
- `ParentHubSurface` — RecentSessionList + CurrentFocus empty branches
- `MonsterMeadow` — fresh-learner hero (dedicated `.monster-meadow-empty` wrapper; the base class is `position: absolute; pointer-events: none` and would swallow the primitive)
- `CodexSurface` — fresh codex with Start-practice CTA wired through `action.onClick`
- `CodexCreatureLightbox` — missing-entry safe fallback (belt-and-braces for parity invariant)
- `SpellingWordBankScene` — canonical copy `No words yet. Your progress is saved. Play a spelling round to add your first word.`
- `GrammarSetupScene` — `dashboard.isEmpty` branch wraps the existing `Start your first round…` anchor so the existing `grammar-phase3-child-copy` regression test still locks that sentence

**ErrorCard consumers (2)**
- `SubjectRuntimeFallback` — keeps the `Try this tab again` button + `Failure point:` diagnostic line; the primitive wraps the feedback block
- `hub-utils` `AccessDeniedCard` — Admin/Parent Hub load-failure fallback

**Styles**
- `styles/app.css` — `.empty-state` / `.loading-skeleton` / `.error-card` using only existing CSS custom properties (`--panel-soft`, `--line`, `--muted`, `--ink`, `--ink-2`, `--bad`, `--bad-soft`, `--bad-strong`, `--line-soft`, `--radius-sm`). Reduced-motion override cancels the shimmer animation. `@media (max-width: 380px)` padding clamp guarantees no horizontal overflow at mobile-360.

## Test plan

- [x] `node --test tests/empty-state-primitive.test.js tests/empty-state-parity.test.js` — 22 new assertions, all pass (happy path + edge cases + CSS contracts)
- [x] Primitive contracts (role, copy absence of `code`, CTA wiring, row clamp, reduced-motion override, compositor-only keyframes)
- [x] Parity invariant: each surface imports AND renders the primitive; canonical three-part copy pinned per surface; ErrorCard has ≥ 2 consumers
- [x] `npm test` — 3428 tests, 2 pre-existing failures unchanged (`button-label-consistency: I understand / Why is Guardian locked? / Apply seed` + `punctuation-release-smoke: wrangler JSON parse`). No regressions introduced; 0 of my 22 new tests fail.
- [x] `npm run build` — clean, bundle size delta `+3790 bytes` (`+0.42%`) well under the 1% ceiling

## Adversarial-proof notes

- **Baseline row (copy canonicalisation):** every re-skinned empty branch emits the same three-part pattern. Parity test locks each surface's canonical phrase so a future refactor cannot silently drop the "is progress safe" reassurance.
- **Primitives stay pure:** no submit-lock, no persisted state, no async. Callers own `action.onClick` so the primitive composes cleanly with SH2-U1's `useSubmitLock` without importing it.
- **`code` never leaks:** `ErrorCard never renders 'code' in visible copy` test strips the `data-error-code` attribute and asserts the raw token is absent everywhere else — a regression that replaces `data-error-code` with a visible `<small>` would fail.
- **Mobile-360 guardrail:** every primitive declares `box-sizing: border-box` + `max-width: 100%` + narrow-viewport padding clamp. The parser test fails if any primitive drops those invariants.
- **Reduced-motion carve-out:** the shimmer keyframes animate only `background-position` (compositor-only) AND a `@media (prefers-reduced-motion: reduce)` block sets `animation: none` on the row element. Both are asserted.
- **SH2-U3 boundary:** `DemoExpiryBanner`/`ForbiddenNotice`/`AuthTransientErrorNotice` stay bespoke (specialised auth context) — not replaced by the generic primitives. `PunctuationSummaryScene`'s "Everything was secure" positive-feedback chip stays untouched.
- **SH2-U4 boundary:** TTS pending chip + "Audio unavailable" banner in `SpellingSessionScene` stay bespoke for now; consolidation is deferred future work (noted in primitive JSDoc comments).