### PR TITLE
feat(spelling): U3 production audio smoke probe

### DIFF
--- a/docs/plans/2026-04-26-001-feat-spelling-word-audio-cache-plan.md
+++ b/docs/plans/2026-04-26-001-feat-spelling-word-audio-cache-plan.md
@@ -1422,3 +1422,37 @@ completion report)
   distinct from the Gemini API-error budget. The retry budget knob
   (`--max-retries`) is currently reserved for upload-side 5xx; this
   future lane would also consume from it.
+
+### Tech debt deferred from U3 review (2026-04-26)
+
+* **Demo session cleanup.** Three new demo sessions are created per smoke
+  run (one for word/sentence probes + two for the cross-account probe)
+  with no teardown. Future: confirm `/api/demo/session` is server-side
+  TTL-bounded; if not, add a teardown POST or document the leak so the
+  smoke does not silently inflate the demo-account table on each run.
+* **Single-retry on transient 5xx.** Current zero-retry policy makes a
+  single 0.1% blip an `EXIT_TRANSPORT`. Future: at most one retry per
+  probe with 500ms delay, gated behind an explicit flag (default 0 to
+  preserve current behaviour) so the smoke stays deterministic by
+  default but operators can opt into modest noise tolerance.
+* **Real binary body-bytes test.** Cross-account body-bytes assertion
+  uses mock UTF-8 fixtures via the test harness's infinitely-re-readable
+  `arrayBuffer()`. Production responses are one-shot binary streams.
+  Future: add a test using a real binary buffer + one-shot stream
+  consumption to exercise the actual `arrayBuffer()` semantics.
+* **Defensive validator coverage.** `runWordProbe` carries new
+  `model !== SPELLING_AUDIO_MODEL` and `responseVoice !== voice`
+  validators with no test coverage. Future: add tests for both mismatch
+  branches so a regression in the response-header schema cannot slip
+  past CI.
+* **Fetch-throw classification test.** `postTtsRequest` catch block
+  converts thrown errors (timeout AbortError, DNS failure) into
+  `transportError`, but no test exercises the throwing-fetch path.
+  Future: add a fetch-spy that throws and assert the resulting probe is
+  tagged `kind: 'transport'`.
+* **R2 key parity overstated.** Header comment claims "byte-matches
+  Worker's `bufferedAudioKey`" but the test only asserts smoke-side
+  self-consistency, not parity with the Worker symbol. Future: import
+  the Worker helper directly (or re-export via `shared/`) and assert
+  byte-equal output for the same input. This pairs with maint-001
+  (test-only re-exports from `worker/src/tts.js`).

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "smoke:production:punctuation": "node ./scripts/punctuation-production-smoke.mjs",
     "smoke:production:admin-ops": "node ./scripts/admin-ops-production-smoke.mjs",
     "smoke:production:spelling-dense": "node ./scripts/spelling-dense-history-smoke.mjs",
+    "smoke:production:spelling-audio": "node ./scripts/spelling-audio-production-smoke.mjs",
     "spelling:word-audio": "node ./scripts/build-spelling-word-audio.mjs",
     "pretest": "node ./scripts/preflight-test.mjs",
     "test": "node ./scripts/run-node-tests.mjs",

--- a/scripts/lib/production-smoke.mjs
+++ b/scripts/lib/production-smoke.mjs
@@ -43,7 +43,7 @@ async function readJsonResponse(response) {
   }
 }
 
-function configuredTimeoutMs() {
+export function configuredTimeoutMs() {
   const value = Number(argValue('--timeout-ms') || process.env.KS2_SMOKE_TIMEOUT_MS || DEFAULT_SMOKE_TIMEOUT_MS);
   return Number.isFinite(value) && value > 0 ? value : DEFAULT_SMOKE_TIMEOUT_MS;
 }

--- a/scripts/spelling-audio-production-smoke.mjs
+++ b/scripts/spelling-audio-production-smoke.mjs
@@ -1,0 +1,813 @@
+#!/usr/bin/env node
+
+// U3 (spelling word audio cache): production smoke probe for the
+// `/api/tts` cache lookup contract introduced by the U1/U2 word-only
+// pipeline + PR 252's legacy sentence fallback.
+//
+// Three distinct probes:
+//   1. Word-only primary probe — for each --word-sample × 2 voices, build
+//      a word-bank prompt token via the canonical `sha256` from
+//      `worker/src/auth.js` and POST `/api/tts` with `cacheLookupOnly: true`.
+//      Expect HTTP 200 + `x-ks2-tts-cache: hit` + `x-ks2-tts-cache-source: primary`.
+//   2. Sentence legacy probe — POSTs the session-style payload for known
+//      seeded sentence cards and asserts the legacy R2 fallback fires
+//      (PR 252). Without `--require-legacy-hit` a `primary` source is
+//      reported as INFO ("legacy fallback no longer required").
+//   3. Cross-account invariant probe — two real demo learners produce
+//      two distinct word-bank prompt tokens but the smoke runner derives
+//      the SAME expected R2 key (the `bufferedAudioMetadata` deliberately
+//      omits `accountId` for `wordOnly: true` per PR 252 design). Both
+//      requests cache-hit AND their response bodies must be byte-identical;
+//      a third probe for a different word must produce distinct bytes.
+//
+// Mirrors the canonical patterns:
+//   - `scripts/punctuation-production-smoke.mjs` for overall structure +
+//     entry guard + JSON output shape.
+//   - `scripts/spelling-dense-history-smoke.mjs` for argv parser style +
+//     `EXIT_*` taxonomy + tagged `error.kind` classifier.
+//   - `scripts/lib/production-smoke.mjs` for origin / demo-session / fetch
+//     helpers (`configuredOrigin`, `createDemoSession`, `loadBootstrap`,
+//     `argValue`).
+//
+// All side-effecting helpers funnel through `globalThis.fetch` so unit
+// tests can stub them via `jsonResponse(payload, init)` without ever
+// hitting the network.
+
+import { Buffer } from 'node:buffer';
+import { pathToFileURL } from 'node:url';
+
+import {
+  argValue,
+  configuredOrigin,
+  createDemoSession,
+  DEFAULT_PRODUCTION_ORIGIN,
+  loadBootstrap,
+} from './lib/production-smoke.mjs';
+import { sha256 } from '../worker/src/auth.js';
+import {
+  BUFFERED_GEMINI_VOICE_OPTIONS,
+  SPELLING_AUDIO_MODEL,
+  buildWordAudioAssetKey,
+} from '../shared/spelling-audio.js';
+
+// --- Exit-code taxonomy --------------------------------------------------
+//
+// Mirrors `scripts/spelling-dense-history-smoke.mjs:134-176`. The CLI banner
+// promises:
+//   0 — smoke passed
+//   1 — validation failure (header missing, miss with --require-word-hit,
+//        cross-account invariant break, etc.)
+//   2 — usage error (bad flag, missing smoke learner credentials)
+//   3 — transport failure (5xx, network error, fetch timeout)
+export const EXIT_OK = 0;
+export const EXIT_VALIDATION = 1;
+export const EXIT_USAGE = 2;
+export const EXIT_TRANSPORT = 3;
+
+const DEFAULT_WORD_SAMPLE = ['accident', 'accidentally', 'knowledge', 'thought'];
+const DEFAULT_SENTENCE_SAMPLE = ['accident', 'knowledge'];
+const VOICE_IDS = BUFFERED_GEMINI_VOICE_OPTIONS.map((voice) => voice.id);
+const CROSS_ACCOUNT_FIXTURE_WORD = 'accident';
+const CROSS_ACCOUNT_DISTINCT_WORD = 'thought';
+
+const HELP_BANNER = [
+  'Usage: node ./scripts/spelling-audio-production-smoke.mjs [options]',
+  '',
+  'Probes the production /api/tts cache lookup contract for the spelling',
+  'word-only audio path (U1/U2) and PR 252 legacy sentence fallback. Runs',
+  'three distinct probes:',
+  '  - word-only primary probe (per word × per voice)',
+  '  - sentence legacy probe (per sentence)',
+  '  - cross-account invariant probe (two learners, byte-identical body bytes,',
+  '    distinct body bytes for a different word)',
+  '',
+  'Options:',
+  '  --origin <url>, --url <url>       Origin to probe (default https://ks2.eugnel.uk).',
+  '  --word-sample <csv>               Comma-separated word slugs (default accident,accidentally,knowledge,thought).',
+  '  --sentence-sample <csv>           Comma-separated sentence slugs (default accident,knowledge).',
+  '  --require-word-hit                Fail (EXIT_VALIDATION) when a word probe misses cache.',
+  '  --require-legacy-hit              Fail (EXIT_VALIDATION) when a sentence probe falls back to primary.',
+  '  --json                            Emit machine-readable JSON only.',
+  '  --timeout-ms <ms>                 Per-request timeout (default 15000; consumed by lib/production-smoke.mjs).',
+  '  --help, -h                        Show this banner.',
+  '',
+  'Exit codes:',
+  '  0  smoke passed',
+  '  1  validation failure (header missing, hit-required miss, invariant break)',
+  '  2  usage error (bad flag, missing smoke learner credentials)',
+  '  3  transport failure (5xx, fetch timeout, network error)',
+].join('\n');
+
+// --- Error tagging -------------------------------------------------------
+
+function validationError(message, cause) {
+  const error = new Error(message);
+  error.kind = 'validation';
+  if (cause) error.cause = cause;
+  return error;
+}
+
+function transportError(message, cause) {
+  const error = new Error(message);
+  error.kind = 'transport';
+  if (cause) error.cause = cause;
+  return error;
+}
+
+function usageError(message, cause) {
+  const error = new Error(message);
+  error.kind = 'usage';
+  if (cause) error.cause = cause;
+  return error;
+}
+
+function classifyErrorForExitCode(error) {
+  if (!error) return EXIT_TRANSPORT;
+  if (error.kind === 'validation') return EXIT_VALIDATION;
+  if (error.kind === 'usage') return EXIT_USAGE;
+  if (error.kind === 'transport') return EXIT_TRANSPORT;
+  if (error.name === 'AssertionError') return EXIT_VALIDATION;
+  return EXIT_TRANSPORT;
+}
+
+// --- argv parser ---------------------------------------------------------
+//
+// Mirrors `parseSpellingDenseArgs`: hand-rolled (no `node:util parseArgs`),
+// rejects unknown flags with EXIT_USAGE, and rejects duplicates so a
+// later value cannot silently override an earlier one.
+
+function readOptionValue(argv, index, optionName) {
+  const value = argv[index + 1];
+  if (value == null || value.startsWith('--')) {
+    throw new Error(`${optionName} requires a value.`);
+  }
+  return value;
+}
+
+function splitCsv(raw) {
+  return String(raw || '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+export function parseArgs(argv = process.argv.slice(2)) {
+  const options = {
+    origin: '',
+    wordSample: DEFAULT_WORD_SAMPLE.slice(),
+    sentenceSample: DEFAULT_SENTENCE_SAMPLE.slice(),
+    requireWordHit: false,
+    requireLegacyHit: false,
+    json: false,
+    help: false,
+  };
+
+  const assigned = new Set();
+  const assignOnce = (flag) => {
+    if (assigned.has(flag)) {
+      throw new Error(`${flag} specified more than once; refusing to let later value silently override the earlier one.`);
+    }
+    assigned.add(flag);
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+    } else if (arg === '--origin' || arg === '--url') {
+      assignOnce('--origin');
+      options.origin = readOptionValue(argv, index, arg);
+      index += 1;
+    } else if (arg === '--word-sample') {
+      assignOnce(arg);
+      const sample = splitCsv(readOptionValue(argv, index, arg));
+      if (!sample.length) throw new Error('--word-sample requires at least one slug.');
+      options.wordSample = sample;
+      index += 1;
+    } else if (arg === '--sentence-sample') {
+      assignOnce(arg);
+      const sample = splitCsv(readOptionValue(argv, index, arg));
+      if (!sample.length) throw new Error('--sentence-sample requires at least one slug.');
+      options.sentenceSample = sample;
+      index += 1;
+    } else if (arg === '--require-word-hit') {
+      options.requireWordHit = true;
+    } else if (arg === '--require-legacy-hit') {
+      options.requireLegacyHit = true;
+    } else if (arg === '--json') {
+      options.json = true;
+    } else if (arg === '--timeout-ms') {
+      // Consumed by `scripts/lib/production-smoke.mjs` via process.argv;
+      // we only need to skip the value so the parser does not fault.
+      index += 1;
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+// --- Prompt token + R2 key derivation -----------------------------------
+//
+// Byte-equal mirror of `worker/src/subjects/spelling/audio.js` salt
+// prefixes:
+//   `wordBankPromptToken({ learnerId, slug, word, sentence })`
+//      → `sha256('spelling-word-bank-prompt-v1' | learnerId | slug | word | sentence)`
+//   `sessionPromptToken({ learnerId, sessionId, slug, word, sentence })`
+//      → `sha256('spelling-prompt-v1' | learnerId | sessionId | slug | word | sentence)`
+// The cross-account R2 key derivation mirrors `bufferedAudioMetadata`:
+//   `contentKey = sha256('spelling-audio-word-v1' | slug | word)`
+// — deliberately omits `accountId` so two learners share the same R2 key
+// per PR 252 design.
+
+function cleanText(value) {
+  return String(value || '').replace(/\s+/g, ' ').trim();
+}
+
+export async function computeWordBankPromptToken({ learnerId, slug, word, sentence = '' } = {}) {
+  return sha256([
+    'spelling-word-bank-prompt-v1',
+    cleanText(learnerId),
+    cleanText(slug),
+    cleanText(word),
+    cleanText(sentence),
+  ].join('|'));
+}
+
+export async function computeSessionPromptToken({ learnerId, sessionId, slug, word, sentence } = {}) {
+  return sha256([
+    'spelling-prompt-v1',
+    cleanText(learnerId),
+    cleanText(sessionId),
+    cleanText(slug),
+    cleanText(word),
+    cleanText(sentence),
+  ].join('|'));
+}
+
+export async function computeWordContentKey(slug, word) {
+  return sha256([
+    'spelling-audio-word-v1',
+    cleanText(slug).toLowerCase(),
+    cleanText(word),
+  ].join('|'));
+}
+
+export async function expectedWordR2Key({ slug, word, voice, model = SPELLING_AUDIO_MODEL, extension = 'mp3' } = {}) {
+  const contentKey = await computeWordContentKey(slug, word);
+  return buildWordAudioAssetKey({
+    model,
+    voice,
+    contentKey,
+    slug: cleanText(slug).toLowerCase(),
+    extension,
+  });
+}
+
+// --- HTTP helpers --------------------------------------------------------
+//
+// We call `globalThis.fetch` directly (rather than `postJson` from the
+// shared lib) because:
+//   - we need the raw `Response` object to read response body bytes for
+//     the cross-account invariant probe (`response.arrayBuffer()`),
+//   - we need the per-request response headers (`x-ks2-tts-cache`,
+//     `x-ks2-tts-cache-source`, model, voice).
+// The same-origin headers + JSON encoding mirror `postJson`.
+
+async function postTtsRequest({ origin, cookie, body }) {
+  const url = new URL('/api/tts', origin);
+  let response;
+  try {
+    response = await globalThis.fetch(url, {
+      method: 'POST',
+      headers: {
+        accept: 'application/json, audio/*;q=0.9',
+        'content-type': 'application/json',
+        origin,
+        ...(cookie ? { cookie } : {}),
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (error) {
+    throw transportError(`POST /api/tts failed or timed out: ${error?.message || error}`, error);
+  }
+
+  return response;
+}
+
+function readResponseHeader(response, name) {
+  const value = response.headers?.get?.(name);
+  return value == null ? '' : String(value);
+}
+
+async function readResponseBytes(response) {
+  if (typeof response.arrayBuffer === 'function') {
+    const buffer = await response.arrayBuffer();
+    return Buffer.from(buffer);
+  }
+  if (typeof response.text === 'function') {
+    return Buffer.from(await response.text(), 'utf8');
+  }
+  return Buffer.alloc(0);
+}
+
+async function bodyExcerpt(response, maxBytes = 200) {
+  try {
+    const text = typeof response.text === 'function' ? await response.text() : '';
+    if (!text) return '';
+    return text.length > maxBytes ? `${text.slice(0, maxBytes)}…` : text;
+  } catch {
+    return '';
+  }
+}
+
+function looksLikeServerError(status) {
+  return Number(status) >= 500;
+}
+
+// --- Probe: word-only primary -------------------------------------------
+
+async function runWordProbe({
+  origin,
+  cookie,
+  learnerId,
+  slug,
+  voice,
+  requireWordHit,
+}) {
+  const word = cleanText(slug);
+  const sentence = '';
+  const promptToken = await computeWordBankPromptToken({ learnerId, slug, word, sentence });
+  const expectedKey = await expectedWordR2Key({ slug, word, voice });
+
+  const response = await postTtsRequest({
+    origin,
+    cookie,
+    body: {
+      wordOnly: true,
+      scope: 'word-bank',
+      slug,
+      learnerId,
+      promptToken,
+      bufferedGeminiVoice: voice,
+      cacheLookupOnly: true,
+    },
+  });
+
+  if (looksLikeServerError(response.status)) {
+    const excerpt = await bodyExcerpt(response);
+    throw transportError(`/api/tts word probe ${slug}/${voice} returned HTTP ${response.status}: ${excerpt}`);
+  }
+  if (response.status !== 200) {
+    const excerpt = await bodyExcerpt(response);
+    throw validationError(`/api/tts word probe ${slug}/${voice} returned HTTP ${response.status}: ${excerpt}`);
+  }
+
+  const cache = readResponseHeader(response, 'x-ks2-tts-cache');
+  const source = readResponseHeader(response, 'x-ks2-tts-cache-source');
+  const model = readResponseHeader(response, 'x-ks2-tts-model');
+  const responseVoice = readResponseHeader(response, 'x-ks2-tts-voice');
+
+  const probe = {
+    kind: 'word',
+    slug,
+    voice,
+    promptToken,
+    expectedR2Key: expectedKey,
+    cache,
+    source,
+    model,
+    voiceHeader: responseVoice,
+    status: response.status,
+    notes: [],
+    ok: true,
+  };
+
+  if (cache !== 'hit') {
+    if (requireWordHit) {
+      probe.ok = false;
+      probe.notes.push(`cache=${cache || '(missing)'} (expected hit)`);
+      throw validationError(`Word probe ${slug}/${voice} cache=${cache || '(missing)'} but --require-word-hit is set.`);
+    }
+    probe.notes.push(`WARN: cache=${cache || '(missing)'} (pre-fill baseline; suppress with --require-word-hit once U4 lands)`);
+    return probe;
+  }
+
+  // Cache hit: source MUST be present (regression of PR 252 if missing).
+  if (!source) {
+    probe.ok = false;
+    probe.notes.push('missing x-ks2-tts-cache-source header');
+    throw validationError(
+      `Word probe ${slug}/${voice} hit cache but x-ks2-tts-cache-source header is missing — PR 252 regression.`,
+    );
+  }
+  if (source !== 'primary') {
+    probe.ok = false;
+    probe.notes.push(`source=${source} (expected primary)`);
+    throw validationError(`Word probe ${slug}/${voice} cache-source=${source} (expected primary).`);
+  }
+  if (model !== SPELLING_AUDIO_MODEL) {
+    probe.ok = false;
+    probe.notes.push(`model=${model} (expected ${SPELLING_AUDIO_MODEL})`);
+    throw validationError(
+      `Word probe ${slug}/${voice} model=${model} but expected ${SPELLING_AUDIO_MODEL}.`,
+    );
+  }
+  if (responseVoice !== voice) {
+    probe.ok = false;
+    probe.notes.push(`voice=${responseVoice} (expected ${voice})`);
+    throw validationError(`Word probe ${slug}/${voice} voice header=${responseVoice} (expected ${voice}).`);
+  }
+
+  return probe;
+}
+
+// --- Probe: sentence legacy ----------------------------------------------
+
+async function runSentenceProbe({
+  origin,
+  cookie,
+  learnerId,
+  slug,
+  requireLegacyHit,
+}) {
+  const word = cleanText(slug);
+  // For legacy sentence probes we still need a session-style prompt token;
+  // since the smoke runner does not have an active session id (no spelling
+  // round was started), the Worker validates the prompt against the
+  // word-bank fallback in `resolveSpellingAudioRequest`. We compute the
+  // word-bank token here so the Worker accepts the request and then runs
+  // the cache lookup on the legacy R2 key shape (the legacy fallback
+  // applies to sentence-shaped metadata, not the wordOnly path).
+  const promptToken = await computeWordBankPromptToken({
+    learnerId,
+    slug,
+    word,
+    sentence: '',
+  });
+
+  const response = await postTtsRequest({
+    origin,
+    cookie,
+    body: {
+      slug,
+      learnerId,
+      promptToken,
+      cacheLookupOnly: true,
+    },
+  });
+
+  if (looksLikeServerError(response.status)) {
+    const excerpt = await bodyExcerpt(response);
+    throw transportError(`/api/tts sentence probe ${slug} returned HTTP ${response.status}: ${excerpt}`);
+  }
+  if (response.status !== 200) {
+    const excerpt = await bodyExcerpt(response);
+    throw validationError(`/api/tts sentence probe ${slug} returned HTTP ${response.status}: ${excerpt}`);
+  }
+
+  const cache = readResponseHeader(response, 'x-ks2-tts-cache');
+  const source = readResponseHeader(response, 'x-ks2-tts-cache-source');
+
+  const probe = {
+    kind: 'sentence',
+    slug,
+    promptToken,
+    cache,
+    source,
+    status: response.status,
+    notes: [],
+    ok: true,
+  };
+
+  if (cache !== 'hit') {
+    if (requireLegacyHit) {
+      probe.ok = false;
+      probe.notes.push(`cache=${cache || '(missing)'} (expected hit, --require-legacy-hit set)`);
+      throw validationError(
+        `Sentence probe ${slug} cache=${cache || '(missing)'} but --require-legacy-hit is set.`,
+      );
+    }
+    probe.notes.push(`WARN: cache=${cache || '(missing)'} (legacy fallback unavailable for ${slug})`);
+    return probe;
+  }
+
+  if (!source) {
+    probe.ok = false;
+    probe.notes.push('missing x-ks2-tts-cache-source header');
+    throw validationError(
+      `Sentence probe ${slug} hit cache but x-ks2-tts-cache-source header is missing — PR 252 regression.`,
+    );
+  }
+
+  if (source === 'legacy') {
+    return probe;
+  }
+  if (source === 'primary') {
+    if (requireLegacyHit) {
+      probe.ok = false;
+      probe.notes.push(`source=${source} (expected legacy, --require-legacy-hit set)`);
+      throw validationError(
+        `Sentence probe ${slug} cache-source=${source} but --require-legacy-hit demands legacy.`,
+      );
+    }
+    probe.notes.push('INFO: legacy fallback no longer required (cache-source=primary)');
+    return probe;
+  }
+  probe.ok = false;
+  probe.notes.push(`source=${source} (expected legacy or primary)`);
+  throw validationError(`Sentence probe ${slug} cache-source=${source} (expected legacy or primary).`);
+}
+
+// --- Probe: cross-account invariant -------------------------------------
+
+async function runCrossAccountProbe({
+  origin,
+  fixtureWord = CROSS_ACCOUNT_FIXTURE_WORD,
+  distinctWord = CROSS_ACCOUNT_DISTINCT_WORD,
+  voice = VOICE_IDS[0],
+}) {
+  // Two real demo sessions — Worker validates `learnerId` against the
+  // session at `worker/src/subjects/spelling/audio.js:114-118`, so faked
+  // learner ids would be rejected.
+  const sessionA = await createDemoSession(origin);
+  const bootstrapA = await loadBootstrap(origin, sessionA.cookie, { expectedSession: sessionA.session });
+  const sessionB = await createDemoSession(origin);
+  const bootstrapB = await loadBootstrap(origin, sessionB.cookie, { expectedSession: sessionB.session });
+
+  const tokenA = await computeWordBankPromptToken({
+    learnerId: bootstrapA.learnerId,
+    slug: fixtureWord,
+    word: fixtureWord,
+    sentence: '',
+  });
+  const tokenB = await computeWordBankPromptToken({
+    learnerId: bootstrapB.learnerId,
+    slug: fixtureWord,
+    word: fixtureWord,
+    sentence: '',
+  });
+  const expectedKeyA = await expectedWordR2Key({ slug: fixtureWord, word: fixtureWord, voice });
+  const expectedKeyB = await expectedWordR2Key({ slug: fixtureWord, word: fixtureWord, voice });
+  const expectedKeyDistinct = await expectedWordR2Key({
+    slug: distinctWord,
+    word: distinctWord,
+    voice,
+  });
+
+  // Per-learner token salt: tokens MUST differ.
+  if (tokenA === tokenB) {
+    throw validationError(
+      `Cross-account probe: prompt tokens collapsed (per-learner salt regression). tokenA === tokenB`,
+    );
+  }
+  // Cross-account R2 reuse: keys MUST match.
+  if (expectedKeyA !== expectedKeyB) {
+    throw validationError(
+      `Cross-account probe: expected R2 keys diverged for the same word (accountId leaked into wordOnly metadata). keyA=${expectedKeyA} keyB=${expectedKeyB}`,
+    );
+  }
+
+  const responseA = await postTtsRequest({
+    origin,
+    cookie: sessionA.cookie,
+    body: {
+      wordOnly: true,
+      scope: 'word-bank',
+      slug: fixtureWord,
+      learnerId: bootstrapA.learnerId,
+      promptToken: tokenA,
+      bufferedGeminiVoice: voice,
+      // Fetch real bytes — `cacheLookupOnly` returns 204; we want 200 +
+      // body bytes so the byte-identity assertion has something to compare.
+    },
+  });
+  const responseB = await postTtsRequest({
+    origin,
+    cookie: sessionB.cookie,
+    body: {
+      wordOnly: true,
+      scope: 'word-bank',
+      slug: fixtureWord,
+      learnerId: bootstrapB.learnerId,
+      promptToken: tokenB,
+      bufferedGeminiVoice: voice,
+    },
+  });
+  const responseDistinct = await postTtsRequest({
+    origin,
+    cookie: sessionA.cookie,
+    body: {
+      wordOnly: true,
+      scope: 'word-bank',
+      slug: distinctWord,
+      learnerId: bootstrapA.learnerId,
+      promptToken: await computeWordBankPromptToken({
+        learnerId: bootstrapA.learnerId,
+        slug: distinctWord,
+        word: distinctWord,
+        sentence: '',
+      }),
+      bufferedGeminiVoice: voice,
+    },
+  });
+
+  for (const [label, response] of [
+    ['A', responseA],
+    ['B', responseB],
+    ['distinct', responseDistinct],
+  ]) {
+    if (looksLikeServerError(response.status)) {
+      const excerpt = await bodyExcerpt(response);
+      throw transportError(`Cross-account probe ${label} returned HTTP ${response.status}: ${excerpt}`);
+    }
+    if (response.status !== 200) {
+      const excerpt = await bodyExcerpt(response);
+      throw validationError(`Cross-account probe ${label} returned HTTP ${response.status}: ${excerpt}`);
+    }
+  }
+  for (const [label, response] of [['A', responseA], ['B', responseB]]) {
+    const cache = readResponseHeader(response, 'x-ks2-tts-cache');
+    if (cache !== 'hit') {
+      throw validationError(
+        `Cross-account probe ${label} cache=${cache || '(missing)'} (expected hit; pre-fill not yet run for ${fixtureWord}?)`,
+      );
+    }
+    const source = readResponseHeader(response, 'x-ks2-tts-cache-source');
+    if (!source) {
+      throw validationError(
+        `Cross-account probe ${label} hit cache but x-ks2-tts-cache-source header is missing — PR 252 regression.`,
+      );
+    }
+  }
+
+  const bytesA = await readResponseBytes(responseA);
+  const bytesB = await readResponseBytes(responseB);
+  const bytesDistinct = await readResponseBytes(responseDistinct);
+
+  if (!bytesA.length || !bytesA.equals(bytesB)) {
+    throw validationError(
+      `Cross-account probe: response bodies diverged for the same word (R2 key resolution broken). lenA=${bytesA.length} lenB=${bytesB.length}`,
+    );
+  }
+  if (bytesDistinct.equals(bytesA)) {
+    throw validationError(
+      `Cross-account probe: distinct word ${distinctWord} produced byte-identical body to ${fixtureWord} (key resolution collapsed).`,
+    );
+  }
+
+  return {
+    kind: 'cross-account',
+    learnerA: bootstrapA.learnerId,
+    learnerB: bootstrapB.learnerId,
+    fixtureWord,
+    distinctWord,
+    voice,
+    tokenA,
+    tokenB,
+    expectedR2Key: expectedKeyA,
+    expectedR2KeyDistinct: expectedKeyDistinct,
+    bytesAlength: bytesA.length,
+    bytesBLength: bytesB.length,
+    bytesDistinctLength: bytesDistinct.length,
+    notes: ['per-learner tokens distinct; same R2 key; byte-identical bodies; distinct word produces distinct bytes'],
+    ok: true,
+  };
+}
+
+// --- Top-level runner ----------------------------------------------------
+
+export async function runSpellingAudioSmoke(options = {}) {
+  const origin = options.origin || configuredOrigin();
+  const startedAt = new Date().toISOString();
+
+  // Primary demo session — used for word-only + sentence probes. The
+  // cross-account probe internally creates two more demo sessions.
+  let demo;
+  try {
+    demo = await createDemoSession(origin);
+  } catch (error) {
+    const message = String(error?.message || '');
+    if (/failed with (\d+)/.test(message)) {
+      const status = Number(message.match(/failed with (\d+)/)[1]);
+      if (status >= 500) throw transportError(`Demo session creation ${message}`, error);
+      // 4xx — the credentials path is broken; surface as USAGE so the
+      // operator gets the setup hint rather than a generic validation.
+      throw usageError(
+        `Demo session creation ${message}. Confirm production demo credentials are configured (KS2_SMOKE_ORIGIN + a reachable demo endpoint).`,
+        error,
+      );
+    }
+    throw transportError(`Demo session creation failed: ${message}`, error);
+  }
+  const bootstrap = await loadBootstrap(origin, demo.cookie, { expectedSession: demo.session });
+
+  const probes = [];
+  for (const slug of options.wordSample) {
+    for (const voice of VOICE_IDS) {
+      probes.push(await runWordProbe({
+        origin,
+        cookie: demo.cookie,
+        learnerId: bootstrap.learnerId,
+        slug,
+        voice,
+        requireWordHit: options.requireWordHit,
+      }));
+    }
+  }
+  for (const slug of options.sentenceSample) {
+    probes.push(await runSentenceProbe({
+      origin,
+      cookie: demo.cookie,
+      learnerId: bootstrap.learnerId,
+      slug,
+      requireLegacyHit: options.requireLegacyHit,
+    }));
+  }
+  probes.push(await runCrossAccountProbe({ origin }));
+
+  const finishedAt = new Date().toISOString();
+  const ok = probes.every((probe) => probe.ok !== false);
+  return {
+    ok,
+    startedAt,
+    finishedAt,
+    origin,
+    accountId: demo.session?.accountId || null,
+    learnerId: bootstrap.learnerId,
+    probes,
+  };
+}
+
+function renderHumanReadableReport(report) {
+  const lines = [];
+  lines.push(`spelling-audio-production-smoke @ ${report.origin}`);
+  lines.push(`  account: ${report.accountId || '(none)'}  learner: ${report.learnerId}`);
+  lines.push(`  ${report.startedAt} → ${report.finishedAt}`);
+  for (const probe of report.probes) {
+    if (probe.kind === 'word') {
+      lines.push(`  [word] ${probe.slug} ${probe.voice} cache=${probe.cache || '-'} source=${probe.source || '-'} model=${probe.model || '-'}`);
+    } else if (probe.kind === 'sentence') {
+      lines.push(`  [sentence] ${probe.slug} cache=${probe.cache || '-'} source=${probe.source || '-'}`);
+    } else if (probe.kind === 'cross-account') {
+      lines.push(`  [cross-account] ${probe.fixtureWord} (${probe.voice}) tokensDistinct=true sameR2Key=true bytesIdentical=true distinctWord=${probe.distinctWord}`);
+    }
+    for (const note of probe.notes || []) {
+      lines.push(`      - ${note}`);
+    }
+  }
+  lines.push(`  ok=${report.ok}`);
+  return lines.join('\n');
+}
+
+export async function runCli(argv = process.argv.slice(2)) {
+  let options;
+  try {
+    options = parseArgs(argv);
+  } catch (error) {
+    console.error(JSON.stringify({ ok: false, exit_code: EXIT_USAGE, error: error?.message || String(error) }, null, 2));
+    return EXIT_USAGE;
+  }
+  if (options.help) {
+    console.log(HELP_BANNER);
+    return EXIT_OK;
+  }
+
+  let report;
+  try {
+    report = await runSpellingAudioSmoke(options);
+  } catch (error) {
+    const exitCode = classifyErrorForExitCode(error);
+    console.error(JSON.stringify({
+      ok: false,
+      exit_code: exitCode,
+      error: error?.message || String(error),
+    }, null, 2));
+    return exitCode;
+  }
+
+  if (options.json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log(renderHumanReadableReport(report));
+  }
+  return report.ok ? EXIT_OK : EXIT_VALIDATION;
+}
+
+async function main() {
+  const origin = argValue('--origin', '--url') || process.env.KS2_SMOKE_ORIGIN || DEFAULT_PRODUCTION_ORIGIN;
+  const code = await runCli();
+  process.exitCode = code;
+  // Reference `origin` so it shows up in stack traces if a downstream
+  // helper throws before logging — runtime cost is negligible and it
+  // keeps the variable from being tree-shaken away by future refactors.
+  if (process.env.KS2_SMOKE_DEBUG) console.error(`[spelling-audio-production-smoke] origin=${origin}`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error('[spelling-audio-production-smoke] ' + (error?.stack || error?.message || error));
+    process.exit(error?.kind === 'transport' ? EXIT_TRANSPORT : EXIT_VALIDATION);
+  });
+}

--- a/scripts/spelling-audio-production-smoke.mjs
+++ b/scripts/spelling-audio-production-smoke.mjs
@@ -39,6 +39,7 @@ import { pathToFileURL } from 'node:url';
 import {
   argValue,
   configuredOrigin,
+  configuredTimeoutMs,
   createDemoSession,
   DEFAULT_PRODUCTION_ORIGIN,
   loadBootstrap,
@@ -49,6 +50,7 @@ import {
   SPELLING_AUDIO_MODEL,
   buildWordAudioAssetKey,
 } from '../shared/spelling-audio.js';
+import { SEEDED_SPELLING_PUBLISHED_SNAPSHOT } from '../src/subjects/spelling/data/content-data.js';
 
 // --- Exit-code taxonomy --------------------------------------------------
 //
@@ -160,6 +162,7 @@ export function parseArgs(argv = process.argv.slice(2)) {
     requireLegacyHit: false,
     json: false,
     help: false,
+    timeoutMs: 0,
   };
 
   const assigned = new Set();
@@ -197,8 +200,15 @@ export function parseArgs(argv = process.argv.slice(2)) {
     } else if (arg === '--json') {
       options.json = true;
     } else if (arg === '--timeout-ms') {
-      // Consumed by `scripts/lib/production-smoke.mjs` via process.argv;
-      // we only need to skip the value so the parser does not fault.
+      // Plumbed into both `runSpellingAudioSmoke(options)` and the
+      // shared `lib/production-smoke.mjs` helpers (which read it back via
+      // `configuredTimeoutMs()` from process.argv / env).
+      assignOnce(arg);
+      const parsed = Number(readOptionValue(argv, index, arg));
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        throw new Error('--timeout-ms requires a positive number of milliseconds.');
+      }
+      options.timeoutMs = parsed;
       index += 1;
     } else {
       throw new Error(`Unknown option: ${arg}`);
@@ -211,11 +221,16 @@ export function parseArgs(argv = process.argv.slice(2)) {
 // --- Prompt token + R2 key derivation -----------------------------------
 //
 // Byte-equal mirror of `worker/src/subjects/spelling/audio.js` salt
-// prefixes:
+// prefix:
 //   `wordBankPromptToken({ learnerId, slug, word, sentence })`
 //      → `sha256('spelling-word-bank-prompt-v1' | learnerId | slug | word | sentence)`
-//   `sessionPromptToken({ learnerId, sessionId, slug, word, sentence })`
-//      → `sha256('spelling-prompt-v1' | learnerId | sessionId | slug | word | sentence)`
+// The Worker reads the sentence from the published snapshot
+// (`snapshot.wordBySlug[slug].sentence` then `cleanText`) before computing
+// its expected token, so the smoke MUST supply the matching sentence or
+// the Worker rejects the request with `tts_prompt_stale` (HTTP 400).
+// `lookupSeedWord(slug)` reads from `SEEDED_SPELLING_PUBLISHED_SNAPSHOT`
+// — the same source the Worker pins for runtime reads.
+//
 // The cross-account R2 key derivation mirrors `bufferedAudioMetadata`:
 //   `contentKey = sha256('spelling-audio-word-v1' | slug | word)`
 // — deliberately omits `accountId` so two learners share the same R2 key
@@ -225,21 +240,21 @@ function cleanText(value) {
   return String(value || '').replace(/\s+/g, ' ').trim();
 }
 
+export function lookupSeedWord(slug) {
+  const safeSlug = cleanText(slug).toLowerCase();
+  const entry = SEEDED_SPELLING_PUBLISHED_SNAPSHOT?.wordBySlug?.[safeSlug] || null;
+  if (!entry) return null;
+  return {
+    slug: entry.slug || safeSlug,
+    word: cleanText(entry.word),
+    sentence: cleanText(entry.sentence),
+  };
+}
+
 export async function computeWordBankPromptToken({ learnerId, slug, word, sentence = '' } = {}) {
   return sha256([
     'spelling-word-bank-prompt-v1',
     cleanText(learnerId),
-    cleanText(slug),
-    cleanText(word),
-    cleanText(sentence),
-  ].join('|'));
-}
-
-export async function computeSessionPromptToken({ learnerId, sessionId, slug, word, sentence } = {}) {
-  return sha256([
-    'spelling-prompt-v1',
-    cleanText(learnerId),
-    cleanText(sessionId),
     cleanText(slug),
     cleanText(word),
     cleanText(sentence),
@@ -275,8 +290,25 @@ export async function expectedWordR2Key({ slug, word, voice, model = SPELLING_AU
 //     `x-ks2-tts-cache-source`, model, voice).
 // The same-origin headers + JSON encoding mirror `postJson`.
 
-async function postTtsRequest({ origin, cookie, body }) {
+function abortSignalFor(timeoutMs) {
+  if (typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function') {
+    return AbortSignal.timeout(timeoutMs);
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  if (typeof timer?.unref === 'function') timer.unref();
+  return controller.signal;
+}
+
+async function postTtsRequest({ origin, cookie, body, timeoutMs }) {
   const url = new URL('/api/tts', origin);
+  // `--timeout-ms` (parsed by `parseArgs`, also honoured via env
+  // `KS2_SMOKE_TIMEOUT_MS`) is plumbed through `configuredTimeoutMs()` so
+  // production hangs (Gemini outage, Worker cold-start) bound the smoke
+  // run rather than wedging it indefinitely.
+  const effectiveTimeoutMs = Number.isFinite(timeoutMs) && timeoutMs > 0
+    ? timeoutMs
+    : configuredTimeoutMs();
   let response;
   try {
     response = await globalThis.fetch(url, {
@@ -288,9 +320,12 @@ async function postTtsRequest({ origin, cookie, body }) {
         ...(cookie ? { cookie } : {}),
       },
       body: JSON.stringify(body),
+      signal: abortSignalFor(effectiveTimeoutMs),
     });
   } catch (error) {
-    throw transportError(`POST /api/tts failed or timed out: ${error?.message || error}`, error);
+    // `AbortError` from `AbortSignal.timeout` should still classify as
+    // EXIT_TRANSPORT — keep the kind tag stable.
+    throw transportError(`POST /api/tts failed or timed out after ${effectiveTimeoutMs}ms: ${error?.message || error}`, error);
   }
 
   return response;
@@ -335,15 +370,29 @@ async function runWordProbe({
   slug,
   voice,
   requireWordHit,
+  timeoutMs,
 }) {
-  const word = cleanText(slug);
-  const sentence = '';
+  // BLOCKER fix (2026-04-26 review): the Worker's `wordBankPromptParts`
+  // (`worker/src/subjects/spelling/audio.js:87-107`) reads the seed
+  // snapshot and includes `cleanText(word.sentence)` in its expected
+  // token. An empty-sentence token mismatches → 400 `tts_prompt_stale`.
+  // Look up the canonical `(word, sentence)` pair from the published
+  // snapshot so the smoke's token matches what the Worker computes.
+  const seed = lookupSeedWord(slug);
+  if (!seed || !seed.word) {
+    throw validationError(
+      `Word probe ${slug}/${voice}: slug missing from SEEDED_SPELLING_PUBLISHED_SNAPSHOT.wordBySlug — update the smoke fixture or seed.`,
+    );
+  }
+  const word = seed.word;
+  const sentence = seed.sentence;
   const promptToken = await computeWordBankPromptToken({ learnerId, slug, word, sentence });
   const expectedKey = await expectedWordR2Key({ slug, word, voice });
 
   const response = await postTtsRequest({
     origin,
     cookie,
+    timeoutMs,
     body: {
       wordOnly: true,
       scope: 'word-bank',
@@ -431,8 +480,8 @@ async function runSentenceProbe({
   learnerId,
   slug,
   requireLegacyHit,
+  timeoutMs,
 }) {
-  const word = cleanText(slug);
   // For legacy sentence probes we still need a session-style prompt token;
   // since the smoke runner does not have an active session id (no spelling
   // round was started), the Worker validates the prompt against the
@@ -440,16 +489,26 @@ async function runSentenceProbe({
   // word-bank token here so the Worker accepts the request and then runs
   // the cache lookup on the legacy R2 key shape (the legacy fallback
   // applies to sentence-shaped metadata, not the wordOnly path).
+  // Sentence is loaded from the snapshot to match what the Worker computes
+  // (see BLOCKER fix in `runWordProbe`).
+  const seed = lookupSeedWord(slug);
+  if (!seed || !seed.word) {
+    throw validationError(
+      `Sentence probe ${slug}: slug missing from SEEDED_SPELLING_PUBLISHED_SNAPSHOT.wordBySlug — update the smoke fixture or seed.`,
+    );
+  }
+  const word = seed.word;
   const promptToken = await computeWordBankPromptToken({
     learnerId,
     slug,
     word,
-    sentence: '',
+    sentence: seed.sentence,
   });
 
   const response = await postTtsRequest({
     origin,
     cookie,
+    timeoutMs,
     body: {
       slug,
       learnerId,
@@ -527,6 +586,7 @@ async function runCrossAccountProbe({
   fixtureWord = CROSS_ACCOUNT_FIXTURE_WORD,
   distinctWord = CROSS_ACCOUNT_DISTINCT_WORD,
   voice = VOICE_IDS[0],
+  timeoutMs,
 }) {
   // Two real demo sessions — Worker validates `learnerId` against the
   // session at `worker/src/subjects/spelling/audio.js:114-118`, so faked
@@ -536,23 +596,42 @@ async function runCrossAccountProbe({
   const sessionB = await createDemoSession(origin);
   const bootstrapB = await loadBootstrap(origin, sessionB.cookie, { expectedSession: sessionB.session });
 
+  // BLOCKER fix: load fixture/distinct sentences from the snapshot so the
+  // tokens match what the Worker computes (see `runWordProbe`).
+  const fixtureSeed = lookupSeedWord(fixtureWord);
+  const distinctSeed = lookupSeedWord(distinctWord);
+  if (!fixtureSeed || !fixtureSeed.word) {
+    throw validationError(
+      `Cross-account probe: fixture word ${fixtureWord} missing from SEEDED_SPELLING_PUBLISHED_SNAPSHOT.wordBySlug.`,
+    );
+  }
+  if (!distinctSeed || !distinctSeed.word) {
+    throw validationError(
+      `Cross-account probe: distinct word ${distinctWord} missing from SEEDED_SPELLING_PUBLISHED_SNAPSHOT.wordBySlug.`,
+    );
+  }
+  const fixtureWordText = fixtureSeed.word;
+  const fixtureSentence = fixtureSeed.sentence;
+  const distinctWordText = distinctSeed.word;
+  const distinctSentence = distinctSeed.sentence;
+
   const tokenA = await computeWordBankPromptToken({
     learnerId: bootstrapA.learnerId,
     slug: fixtureWord,
-    word: fixtureWord,
-    sentence: '',
+    word: fixtureWordText,
+    sentence: fixtureSentence,
   });
   const tokenB = await computeWordBankPromptToken({
     learnerId: bootstrapB.learnerId,
     slug: fixtureWord,
-    word: fixtureWord,
-    sentence: '',
+    word: fixtureWordText,
+    sentence: fixtureSentence,
   });
-  const expectedKeyA = await expectedWordR2Key({ slug: fixtureWord, word: fixtureWord, voice });
-  const expectedKeyB = await expectedWordR2Key({ slug: fixtureWord, word: fixtureWord, voice });
+  const expectedKeyA = await expectedWordR2Key({ slug: fixtureWord, word: fixtureWordText, voice });
+  const expectedKeyB = await expectedWordR2Key({ slug: fixtureWord, word: fixtureWordText, voice });
   const expectedKeyDistinct = await expectedWordR2Key({
     slug: distinctWord,
-    word: distinctWord,
+    word: distinctWordText,
     voice,
   });
 
@@ -572,6 +651,7 @@ async function runCrossAccountProbe({
   const responseA = await postTtsRequest({
     origin,
     cookie: sessionA.cookie,
+    timeoutMs,
     body: {
       wordOnly: true,
       scope: 'word-bank',
@@ -586,6 +666,7 @@ async function runCrossAccountProbe({
   const responseB = await postTtsRequest({
     origin,
     cookie: sessionB.cookie,
+    timeoutMs,
     body: {
       wordOnly: true,
       scope: 'word-bank',
@@ -598,6 +679,7 @@ async function runCrossAccountProbe({
   const responseDistinct = await postTtsRequest({
     origin,
     cookie: sessionA.cookie,
+    timeoutMs,
     body: {
       wordOnly: true,
       scope: 'word-bank',
@@ -606,8 +688,8 @@ async function runCrossAccountProbe({
       promptToken: await computeWordBankPromptToken({
         learnerId: bootstrapA.learnerId,
         slug: distinctWord,
-        word: distinctWord,
-        sentence: '',
+        word: distinctWordText,
+        sentence: distinctSentence,
       }),
       bufferedGeminiVoice: voice,
     },
@@ -678,12 +760,58 @@ async function runCrossAccountProbe({
 
 // --- Top-level runner ----------------------------------------------------
 
+// Wrap a probe runner so a thrown error becomes a structured probe entry
+// rather than short-circuiting the entire run. Operator gets the full
+// matrix of pass/fail in one report instead of "first failure only" —
+// makes triage faster when several probes regress at once.
+async function safeRunProbe(kindLabel, runner) {
+  try {
+    return await runner();
+  } catch (error) {
+    const kind = error?.kind === 'transport'
+      ? 'transport'
+      : error?.kind === 'usage'
+        ? 'usage'
+        : 'validation';
+    return {
+      kind: kindLabel,
+      ok: false,
+      error: {
+        kind,
+        message: error?.message || String(error),
+      },
+      notes: [`error[${kind}]: ${error?.message || String(error)}`],
+    };
+  }
+}
+
+// Compute the worst-classification exit code from the failed probes:
+// validation > transport (validation surfaces a contract regression while
+// transport may resolve on retry; we want validation to dominate so the
+// operator's eye lands on the contract break first).
+function worstProbeExitCode(probes) {
+  let worst = EXIT_OK;
+  for (const probe of probes) {
+    if (probe.ok !== false) continue;
+    const kind = probe.error?.kind || 'validation';
+    if (kind === 'validation') return EXIT_VALIDATION;
+    if (kind === 'transport' && worst !== EXIT_VALIDATION) worst = EXIT_TRANSPORT;
+    if (kind === 'usage' && worst === EXIT_OK) worst = EXIT_USAGE;
+  }
+  return worst;
+}
+
 export async function runSpellingAudioSmoke(options = {}) {
   const origin = options.origin || configuredOrigin();
   const startedAt = new Date().toISOString();
+  const timeoutMs = Number.isFinite(options.timeoutMs) && options.timeoutMs > 0
+    ? options.timeoutMs
+    : configuredTimeoutMs();
 
   // Primary demo session — used for word-only + sentence probes. The
   // cross-account probe internally creates two more demo sessions.
+  // Demo + bootstrap failures still throw (no point producing a probe
+  // matrix when we cannot authenticate at all).
   let demo;
   try {
     demo = await createDemoSession(origin);
@@ -706,26 +834,28 @@ export async function runSpellingAudioSmoke(options = {}) {
   const probes = [];
   for (const slug of options.wordSample) {
     for (const voice of VOICE_IDS) {
-      probes.push(await runWordProbe({
+      probes.push(await safeRunProbe('word', () => runWordProbe({
         origin,
         cookie: demo.cookie,
         learnerId: bootstrap.learnerId,
         slug,
         voice,
         requireWordHit: options.requireWordHit,
-      }));
+        timeoutMs,
+      })));
     }
   }
   for (const slug of options.sentenceSample) {
-    probes.push(await runSentenceProbe({
+    probes.push(await safeRunProbe('sentence', () => runSentenceProbe({
       origin,
       cookie: demo.cookie,
       learnerId: bootstrap.learnerId,
       slug,
       requireLegacyHit: options.requireLegacyHit,
-    }));
+      timeoutMs,
+    })));
   }
-  probes.push(await runCrossAccountProbe({ origin }));
+  probes.push(await safeRunProbe('cross-account', () => runCrossAccountProbe({ origin, timeoutMs })));
 
   const finishedAt = new Date().toISOString();
   const ok = probes.every((probe) => probe.ok !== false);
@@ -792,7 +922,10 @@ export async function runCli(argv = process.argv.slice(2)) {
   } else {
     console.log(renderHumanReadableReport(report));
   }
-  return report.ok ? EXIT_OK : EXIT_VALIDATION;
+  if (report.ok) return EXIT_OK;
+  // Map exit code from the worst probe.kind classification — validation
+  // dominates transport so contract regressions are visible first.
+  return worstProbeExitCode(report.probes);
 }
 
 async function main() {

--- a/tests/spelling-audio-production-smoke.test.js
+++ b/tests/spelling-audio-production-smoke.test.js
@@ -1,0 +1,639 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  EXIT_OK,
+  EXIT_TRANSPORT,
+  EXIT_USAGE,
+  EXIT_VALIDATION,
+  computeWordBankPromptToken,
+  computeWordContentKey,
+  expectedWordR2Key,
+  parseArgs,
+  runCli,
+  runSpellingAudioSmoke,
+} from '../scripts/spelling-audio-production-smoke.mjs';
+import { sha256 } from '../worker/src/auth.js';
+import { SPELLING_AUDIO_MODEL, buildWordAudioAssetKey } from '../shared/spelling-audio.js';
+
+// Mirrors the seam used by tests/spelling-dense-history-smoke.test.js: a
+// fake Response object that exposes the same headers / arrayBuffer / text
+// shape as a real `fetch` response. `bytes` is optional and defaults to a
+// deterministic per-payload buffer so the cross-account body-byte assertion
+// can be exercised without the test having to track raw bytes.
+function jsonResponse(payload, init = {}) {
+  const status = Number(init.status) || 200;
+  const headers = Object.fromEntries(
+    Object.entries({
+      'content-type': 'application/json',
+      ...(init.headers || {}),
+    }).map(([key, value]) => [key.toLowerCase(), value]),
+  );
+  const bytes = init.bytes instanceof Uint8Array
+    ? init.bytes
+    : new TextEncoder().encode(JSON.stringify(payload));
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get(name) {
+        return headers[String(name).toLowerCase()] || null;
+      },
+      getSetCookie() {
+        const value = headers['set-cookie'];
+        if (Array.isArray(value)) return value;
+        return value ? [value] : [];
+      },
+    },
+    async text() {
+      return JSON.stringify(payload);
+    },
+    async arrayBuffer() {
+      return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+    },
+  };
+}
+
+// `installDemoBootstrapHandlers` covers the demo-session + bootstrap +
+// /api/tts paths. The /api/tts handler is parameterisable so individual
+// tests can dictate per-probe cache headers and body bytes.
+function installDemoBootstrapHandlers({
+  ttsHandler,
+  bootstrapStatus = 200,
+  demoStatus = 201,
+  demoSessions,
+} = {}) {
+  const calls = [];
+  const previousFetch = globalThis.fetch;
+  // Multiple demo sessions for the cross-account probe — popped per-call so
+  // the two demo creations get learners A and B respectively.
+  const demoSessionQueue = (demoSessions || [
+    { accountId: 'account-a', learnerId: 'learner-a', cookie: 'ks2_session=demoA' },
+    { accountId: 'account-b', learnerId: 'learner-b', cookie: 'ks2_session=demoB' },
+    { accountId: 'account-a', learnerId: 'learner-a', cookie: 'ks2_session=demoA' },
+  ]).slice();
+
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url: String(url), init });
+    const pathname = new URL(String(url)).pathname;
+
+    if (pathname === '/api/demo/session') {
+      if (demoStatus >= 400) {
+        return jsonResponse({ ok: false, error: 'demo-broken' }, { status: demoStatus });
+      }
+      const next = demoSessionQueue.shift() || demoSessionQueue.at(-1) || {
+        accountId: 'account-a',
+        learnerId: 'learner-a',
+        cookie: 'ks2_session=demoA',
+      };
+      return jsonResponse({
+        ok: true,
+        session: { demo: true, accountId: next.accountId, learnerId: next.learnerId },
+      }, {
+        status: demoStatus,
+        headers: { 'set-cookie': [`${next.cookie}; Path=/; HttpOnly`] },
+      });
+    }
+    if (pathname === '/api/bootstrap') {
+      if (bootstrapStatus >= 400) {
+        return jsonResponse({ ok: false, error: 'bootstrap-broken' }, { status: bootstrapStatus });
+      }
+      const cookieHeader = String(init.headers?.cookie || '');
+      // Match the cookie back to the queued demo session so the cross-
+      // account probe sees stable learner ids per cookie.
+      const learnerId = cookieHeader.includes('demoB') ? 'learner-b' : 'learner-a';
+      const accountId = learnerId === 'learner-b' ? 'account-b' : 'account-a';
+      return jsonResponse({
+        ok: true,
+        session: { demo: true, accountId },
+        learners: {
+          selectedId: learnerId,
+          byId: { [learnerId]: { stateRevision: 1 } },
+        },
+      });
+    }
+    if (pathname === '/api/tts' && typeof ttsHandler === 'function') {
+      const body = JSON.parse(init.body || '{}');
+      return ttsHandler(body, init, calls);
+    }
+    return jsonResponse({ ok: false, error: 'unexpected' }, { status: 500 });
+  };
+
+  return {
+    calls,
+    restore() {
+      globalThis.fetch = previousFetch;
+    },
+  };
+}
+
+function silenceLogs() {
+  const previousLog = console.log;
+  const previousError = console.error;
+  console.log = () => {};
+  console.error = () => {};
+  return () => {
+    console.log = previousLog;
+    console.error = previousError;
+  };
+}
+
+// --- argv parser ---------------------------------------------------------
+
+test('parseArgs returns defaults when no flags supplied', () => {
+  const options = parseArgs([]);
+  assert.deepEqual(options.wordSample, ['accident', 'accidentally', 'knowledge', 'thought']);
+  assert.deepEqual(options.sentenceSample, ['accident', 'knowledge']);
+  assert.equal(options.requireWordHit, false);
+  assert.equal(options.requireLegacyHit, false);
+  assert.equal(options.json, false);
+  assert.equal(options.help, false);
+});
+
+test('parseArgs accepts CSV samples and require flags', () => {
+  const options = parseArgs([
+    '--origin', 'https://preview.example.test',
+    '--word-sample', 'foo,bar,baz',
+    '--sentence-sample', 'qux',
+    '--require-word-hit',
+    '--require-legacy-hit',
+    '--json',
+  ]);
+  assert.equal(options.origin, 'https://preview.example.test');
+  assert.deepEqual(options.wordSample, ['foo', 'bar', 'baz']);
+  assert.deepEqual(options.sentenceSample, ['qux']);
+  assert.equal(options.requireWordHit, true);
+  assert.equal(options.requireLegacyHit, true);
+  assert.equal(options.json, true);
+});
+
+test('parseArgs rejects unknown flags', () => {
+  assert.throws(() => parseArgs(['--weird']), /Unknown option: --weird/);
+});
+
+test('parseArgs rejects duplicate origin flags', () => {
+  assert.throws(
+    () => parseArgs(['--origin', 'https://a.test', '--origin', 'https://b.test']),
+    /--origin specified more than once/,
+  );
+});
+
+test('parseArgs --help returns help flag', () => {
+  const options = parseArgs(['--help']);
+  assert.equal(options.help, true);
+});
+
+// --- Integration: byte-equality with Worker -----------------------------
+
+test('computeWordBankPromptToken byte-matches a direct sha256 with the canonical Worker salt', async () => {
+  const learnerId = 'learner-a';
+  const slug = 'accident';
+  const word = 'accident';
+  const sentence = '';
+  const expected = await sha256(['spelling-word-bank-prompt-v1', learnerId, slug, word, sentence].join('|'));
+  const actual = await computeWordBankPromptToken({ learnerId, slug, word, sentence });
+  assert.equal(actual, expected);
+});
+
+test('expectedWordR2Key byte-matches a direct buildWordAudioAssetKey call', async () => {
+  const slug = 'accident';
+  const word = 'accident';
+  const voice = 'Iapetus';
+  const contentKey = await computeWordContentKey(slug, word);
+  const expected = buildWordAudioAssetKey({
+    model: SPELLING_AUDIO_MODEL,
+    voice,
+    contentKey,
+    slug,
+    extension: 'mp3',
+  });
+  const actual = await expectedWordR2Key({ slug, word, voice });
+  assert.equal(actual, expected);
+});
+
+// --- Helpers for /api/tts handlers --------------------------------------
+
+function buildPrimaryHitHandler({ voice = 'Iapetus' } = {}) {
+  return (body) => {
+    if (body.wordOnly === true) {
+      return jsonResponse({ ok: true }, {
+        status: 200,
+        headers: {
+          'x-ks2-tts-cache': 'hit',
+          'x-ks2-tts-cache-source': 'primary',
+          'x-ks2-tts-model': SPELLING_AUDIO_MODEL,
+          'x-ks2-tts-voice': body.bufferedGeminiVoice || voice,
+        },
+        bytes: new TextEncoder().encode(`audio-bytes-for-${body.slug}-${body.bufferedGeminiVoice || voice}`),
+      });
+    }
+    return jsonResponse({ ok: true }, {
+      status: 200,
+      headers: {
+        'x-ks2-tts-cache': 'hit',
+        'x-ks2-tts-cache-source': 'legacy',
+      },
+    });
+  };
+}
+
+// --- Happy path ---------------------------------------------------------
+
+test('runSpellingAudioSmoke happy path reports all probes succeeded', async () => {
+  const fixture = installDemoBootstrapHandlers({ ttsHandler: buildPrimaryHitHandler() });
+  try {
+    const report = await runSpellingAudioSmoke({
+      origin: 'https://preview.example.test',
+      wordSample: ['accident', 'thought'],
+      sentenceSample: ['accident'],
+      requireWordHit: true,
+      requireLegacyHit: true,
+    });
+    assert.equal(report.ok, true);
+    // 2 words × 2 voices + 1 sentence + 1 cross-account probe = 6 entries.
+    assert.equal(report.probes.length, 6);
+    const wordProbes = report.probes.filter((probe) => probe.kind === 'word');
+    assert.equal(wordProbes.length, 4);
+    assert.equal(wordProbes.every((probe) => probe.cache === 'hit' && probe.source === 'primary'), true);
+    const sentenceProbe = report.probes.find((probe) => probe.kind === 'sentence');
+    assert.equal(sentenceProbe.cache, 'hit');
+    assert.equal(sentenceProbe.source, 'legacy');
+    const crossAccount = report.probes.find((probe) => probe.kind === 'cross-account');
+    assert.ok(crossAccount, 'expected a cross-account probe');
+    assert.notEqual(crossAccount.tokenA, crossAccount.tokenB);
+    assert.equal(crossAccount.expectedR2Key, await expectedWordR2Key({
+      slug: crossAccount.fixtureWord,
+      word: crossAccount.fixtureWord,
+      voice: crossAccount.voice,
+    }));
+  } finally {
+    fixture.restore();
+  }
+});
+
+// --- Edge: word miss without --require-word-hit -------------------------
+
+test('runSpellingAudioSmoke reports WARN on word miss without --require-word-hit', async () => {
+  const ttsHandler = (body) => {
+    if (body.wordOnly === true) {
+      return jsonResponse({ ok: true }, {
+        status: 200,
+        headers: { 'x-ks2-tts-cache': 'miss' },
+      });
+    }
+    return jsonResponse({ ok: true }, {
+      status: 200,
+      headers: { 'x-ks2-tts-cache': 'hit', 'x-ks2-tts-cache-source': 'legacy' },
+    });
+  };
+  const primaryFixture = installDemoBootstrapHandlers({ ttsHandler: buildPrimaryHitHandler() });
+  // Swap the handler after demo bootstrap responds; we want word probes to
+  // miss but the cross-account probe (which shares the same handler) to
+  // still hit. Simpler: install a single combined handler that misses on
+  // word probes when the slug matches the sample, and hits on the cross-
+  // account fixture word. To keep this test focused on the WARN path we
+  // restrict the sample to a single word DISTINCT from the fixture.
+  primaryFixture.restore();
+  const fixture = installDemoBootstrapHandlers({
+    ttsHandler: (body) => {
+      if (body.wordOnly === true && body.slug === 'beginning') {
+        return jsonResponse({ ok: true }, {
+          status: 200,
+          headers: { 'x-ks2-tts-cache': 'miss' },
+        });
+      }
+      return ttsHandler === ttsHandler ? buildPrimaryHitHandler()(body) : ttsHandler(body);
+    },
+  });
+  try {
+    const report = await runSpellingAudioSmoke({
+      origin: 'https://preview.example.test',
+      wordSample: ['beginning'],
+      sentenceSample: ['accident'],
+      requireWordHit: false,
+      requireLegacyHit: false,
+    });
+    assert.equal(report.ok, true);
+    const wordProbes = report.probes.filter((probe) => probe.kind === 'word');
+    assert.ok(wordProbes.every((probe) => probe.cache === 'miss'));
+    assert.ok(wordProbes.every((probe) => probe.notes.some((note) => note.startsWith('WARN'))));
+  } finally {
+    fixture.restore();
+  }
+});
+
+test('runSpellingAudioSmoke throws validation when word probe misses with --require-word-hit', async () => {
+  const fixture = installDemoBootstrapHandlers({
+    ttsHandler: (body) => {
+      if (body.wordOnly === true) {
+        return jsonResponse({ ok: true }, {
+          status: 200,
+          headers: { 'x-ks2-tts-cache': 'miss' },
+        });
+      }
+      return buildPrimaryHitHandler()(body);
+    },
+  });
+  try {
+    await assert.rejects(
+      () => runSpellingAudioSmoke({
+        origin: 'https://preview.example.test',
+        wordSample: ['accident'],
+        sentenceSample: ['accident'],
+        requireWordHit: true,
+      }),
+      /--require-word-hit/,
+    );
+  } finally {
+    fixture.restore();
+  }
+});
+
+// --- Edge: legacy → primary surfaces INFO -------------------------------
+
+test('runSpellingAudioSmoke reports INFO when sentence cache-source is primary (legacy fallback no longer required)', async () => {
+  const fixture = installDemoBootstrapHandlers({
+    ttsHandler: (body) => {
+      if (body.wordOnly === true) {
+        return buildPrimaryHitHandler()(body);
+      }
+      return jsonResponse({ ok: true }, {
+        status: 200,
+        headers: { 'x-ks2-tts-cache': 'hit', 'x-ks2-tts-cache-source': 'primary' },
+      });
+    },
+  });
+  try {
+    const report = await runSpellingAudioSmoke({
+      origin: 'https://preview.example.test',
+      wordSample: ['accident'],
+      sentenceSample: ['accident'],
+      requireWordHit: false,
+      requireLegacyHit: false,
+    });
+    assert.equal(report.ok, true);
+    const sentenceProbe = report.probes.find((probe) => probe.kind === 'sentence');
+    assert.equal(sentenceProbe.cache, 'hit');
+    assert.equal(sentenceProbe.source, 'primary');
+    assert.ok(sentenceProbe.notes.some((note) => /legacy fallback no longer required/i.test(note)));
+  } finally {
+    fixture.restore();
+  }
+});
+
+// --- Edge: cross-account invariant --------------------------------------
+
+test('runSpellingAudioSmoke cross-account probe asserts byte-identical bodies + distinct word distinct bytes', async () => {
+  // Three consecutive demo sessions — first for the main flow, then two
+  // for the cross-account probe. We seed the queue explicitly so the
+  // learner ids are distinct for the cross-account assertion.
+  const fixture = installDemoBootstrapHandlers({
+    demoSessions: [
+      { accountId: 'account-a', learnerId: 'learner-a', cookie: 'ks2_session=demoA' },
+      { accountId: 'account-b', learnerId: 'learner-b', cookie: 'ks2_session=demoB' },
+      { accountId: 'account-a', learnerId: 'learner-a', cookie: 'ks2_session=demoA' },
+    ],
+    ttsHandler: (body) => {
+      // Same bytes for the cross-account fixture word; distinct bytes for
+      // a different word so the third probe's body comparison fails the
+      // collapse-to-wrong-key check (i.e., succeeds the assertion).
+      const audioBytes = new TextEncoder().encode(`audio-bytes-for-${body.slug}`);
+      return jsonResponse({ ok: true }, {
+        status: 200,
+        headers: {
+          'x-ks2-tts-cache': 'hit',
+          'x-ks2-tts-cache-source': 'primary',
+          'x-ks2-tts-model': SPELLING_AUDIO_MODEL,
+          'x-ks2-tts-voice': body.bufferedGeminiVoice || 'Iapetus',
+        },
+        bytes: audioBytes,
+      });
+    },
+  });
+  try {
+    const report = await runSpellingAudioSmoke({
+      origin: 'https://preview.example.test',
+      wordSample: ['accident'],
+      sentenceSample: [],
+      requireWordHit: true,
+    });
+    const probe = report.probes.find((entry) => entry.kind === 'cross-account');
+    assert.ok(probe);
+    assert.notEqual(probe.tokenA, probe.tokenB);
+    assert.equal(probe.bytesAlength, probe.bytesBLength);
+    assert.notEqual(probe.bytesDistinctLength, 0);
+  } finally {
+    fixture.restore();
+  }
+});
+
+test('runSpellingAudioSmoke cross-account probe rejects when fixture-word bodies diverge', async () => {
+  const fixture = installDemoBootstrapHandlers({
+    demoSessions: [
+      { accountId: 'account-a', learnerId: 'learner-a', cookie: 'ks2_session=demoA' },
+      { accountId: 'account-b', learnerId: 'learner-b', cookie: 'ks2_session=demoB' },
+      { accountId: 'account-a', learnerId: 'learner-a', cookie: 'ks2_session=demoA' },
+    ],
+    ttsHandler: (body, init, calls) => {
+      // For the cross-account fixture word, return DIFFERENT bytes per
+      // learner — simulates an R2 key resolution bug where per-learner
+      // tokens accidentally route to different objects.
+      const cookie = String(init.headers?.cookie || '');
+      const audioBytes = new TextEncoder().encode(`audio-${body.slug}-${cookie.includes('demoB') ? 'B' : 'A'}`);
+      return jsonResponse({ ok: true }, {
+        status: 200,
+        headers: {
+          'x-ks2-tts-cache': 'hit',
+          'x-ks2-tts-cache-source': 'primary',
+          'x-ks2-tts-model': SPELLING_AUDIO_MODEL,
+          'x-ks2-tts-voice': body.bufferedGeminiVoice || 'Iapetus',
+        },
+        bytes: audioBytes,
+      });
+    },
+  });
+  try {
+    await assert.rejects(
+      () => runSpellingAudioSmoke({
+        origin: 'https://preview.example.test',
+        wordSample: [],
+        sentenceSample: [],
+      }),
+      /response bodies diverged/,
+    );
+  } finally {
+    fixture.restore();
+  }
+});
+
+test('runSpellingAudioSmoke cross-account probe rejects when distinct-word body collapses to fixture bytes', async () => {
+  const fixture = installDemoBootstrapHandlers({
+    demoSessions: [
+      { accountId: 'account-a', learnerId: 'learner-a', cookie: 'ks2_session=demoA' },
+      { accountId: 'account-b', learnerId: 'learner-b', cookie: 'ks2_session=demoB' },
+      { accountId: 'account-a', learnerId: 'learner-a', cookie: 'ks2_session=demoA' },
+    ],
+    ttsHandler: () => {
+      // Same bytes for ALL words — simulates a key-resolution collapse.
+      const audioBytes = new TextEncoder().encode('always-same-bytes');
+      return jsonResponse({ ok: true }, {
+        status: 200,
+        headers: {
+          'x-ks2-tts-cache': 'hit',
+          'x-ks2-tts-cache-source': 'primary',
+          'x-ks2-tts-model': SPELLING_AUDIO_MODEL,
+          'x-ks2-tts-voice': 'Iapetus',
+        },
+        bytes: audioBytes,
+      });
+    },
+  });
+  try {
+    await assert.rejects(
+      () => runSpellingAudioSmoke({
+        origin: 'https://preview.example.test',
+        wordSample: [],
+        sentenceSample: [],
+      }),
+      /produced byte-identical body/,
+    );
+  } finally {
+    fixture.restore();
+  }
+});
+
+// --- Error: 5xx → EXIT_TRANSPORT ----------------------------------------
+
+test('runCli returns EXIT_TRANSPORT when /api/tts replies with HTTP 503', async () => {
+  const fixture = installDemoBootstrapHandlers({
+    ttsHandler: () => jsonResponse({ ok: false, error: 'degraded' }, { status: 503 }),
+  });
+  const restoreLogs = silenceLogs();
+  try {
+    const code = await runCli([
+      '--origin', 'https://preview.example.test',
+      '--word-sample', 'accident',
+      '--sentence-sample', 'accident',
+    ]);
+    assert.equal(code, EXIT_TRANSPORT);
+  } finally {
+    restoreLogs();
+    fixture.restore();
+  }
+});
+
+// --- Error: missing demo credentials → EXIT_USAGE -----------------------
+
+test('runCli returns EXIT_USAGE when demo session creation replies with HTTP 401', async () => {
+  const fixture = installDemoBootstrapHandlers({
+    demoStatus: 401,
+    ttsHandler: () => jsonResponse({ ok: true }, { status: 200 }),
+  });
+  const restoreLogs = silenceLogs();
+  try {
+    const code = await runCli([
+      '--origin', 'https://preview.example.test',
+      '--word-sample', 'accident',
+    ]);
+    assert.equal(code, EXIT_USAGE);
+  } finally {
+    restoreLogs();
+    fixture.restore();
+  }
+});
+
+// --- Error: missing x-ks2-tts-cache-source header (PR 252 regression) --
+
+test('runCli returns EXIT_VALIDATION when response is a cache hit but cache-source header is missing', async () => {
+  const fixture = installDemoBootstrapHandlers({
+    ttsHandler: (body) => {
+      if (body.wordOnly === true) {
+        return jsonResponse({ ok: true }, {
+          status: 200,
+          headers: {
+            'x-ks2-tts-cache': 'hit',
+            // Deliberately omit x-ks2-tts-cache-source.
+            'x-ks2-tts-model': SPELLING_AUDIO_MODEL,
+            'x-ks2-tts-voice': 'Iapetus',
+          },
+        });
+      }
+      return buildPrimaryHitHandler()(body);
+    },
+  });
+  const restoreLogs = silenceLogs();
+  try {
+    const code = await runCli([
+      '--origin', 'https://preview.example.test',
+      '--word-sample', 'accident',
+      '--require-word-hit',
+    ]);
+    assert.equal(code, EXIT_VALIDATION);
+  } finally {
+    restoreLogs();
+    fixture.restore();
+  }
+});
+
+// --- runCli happy path → EXIT_OK ----------------------------------------
+
+test('runCli happy path returns EXIT_OK and emits JSON when --json supplied', async () => {
+  const fixture = installDemoBootstrapHandlers({ ttsHandler: buildPrimaryHitHandler() });
+  const previousLog = console.log;
+  const logged = [];
+  console.log = (...args) => logged.push(args.map(String).join(' '));
+  try {
+    const code = await runCli([
+      '--origin', 'https://preview.example.test',
+      '--word-sample', 'accident',
+      '--sentence-sample', 'accident',
+      '--require-word-hit',
+      '--require-legacy-hit',
+      '--json',
+    ]);
+    assert.equal(code, EXIT_OK);
+    const payload = JSON.parse(logged.join('\n'));
+    assert.equal(payload.ok, true);
+    assert.equal(payload.origin, 'https://preview.example.test');
+    assert.ok(Array.isArray(payload.probes));
+    assert.ok(payload.probes.length > 0);
+  } finally {
+    console.log = previousLog;
+    fixture.restore();
+  }
+});
+
+// --- runCli unknown flag → EXIT_USAGE -----------------------------------
+
+test('runCli returns EXIT_USAGE on unknown flag without calling fetch', async () => {
+  const previousFetch = globalThis.fetch;
+  let fetchCalled = false;
+  globalThis.fetch = async () => {
+    fetchCalled = true;
+    return jsonResponse({ ok: false }, { status: 500 });
+  };
+  const restoreLogs = silenceLogs();
+  try {
+    const code = await runCli(['--totally-unknown']);
+    assert.equal(code, EXIT_USAGE);
+    assert.equal(fetchCalled, false);
+  } finally {
+    restoreLogs();
+    globalThis.fetch = previousFetch;
+  }
+});
+
+// --- runCli --help → EXIT_OK --------------------------------------------
+
+test('runCli --help exits EXIT_OK and prints the help banner', async () => {
+  const previousLog = console.log;
+  const logged = [];
+  console.log = (...args) => logged.push(args.map(String).join(' '));
+  try {
+    const code = await runCli(['--help']);
+    assert.equal(code, EXIT_OK);
+    assert.ok(logged.some((line) => line.includes('Usage: node ./scripts/spelling-audio-production-smoke.mjs')));
+  } finally {
+    console.log = previousLog;
+  }
+});

--- a/tests/spelling-audio-production-smoke.test.js
+++ b/tests/spelling-audio-production-smoke.test.js
@@ -9,12 +9,14 @@ import {
   computeWordBankPromptToken,
   computeWordContentKey,
   expectedWordR2Key,
+  lookupSeedWord,
   parseArgs,
   runCli,
   runSpellingAudioSmoke,
 } from '../scripts/spelling-audio-production-smoke.mjs';
 import { sha256 } from '../worker/src/auth.js';
 import { SPELLING_AUDIO_MODEL, buildWordAudioAssetKey } from '../shared/spelling-audio.js';
+import { SEEDED_SPELLING_PUBLISHED_SNAPSHOT } from '../src/subjects/spelling/data/content-data.js';
 
 // Mirrors the seam used by tests/spelling-dense-history-smoke.test.js: a
 // fake Response object that exposes the same headers / arrayBuffer / text
@@ -211,6 +213,176 @@ test('expectedWordR2Key byte-matches a direct buildWordAudioAssetKey call', asyn
   assert.equal(actual, expected);
 });
 
+// FIX 3 (review 2026-04-26): the previous byte-equality assertion was
+// self-referential — both sides called the same `sha256` on the same
+// joined string. Pin a hand-computed base64url digest to a hard-coded
+// constant so a regression in the salt prefix or argument order would
+// break this test even if `sha256`/`computeWordBankPromptToken` are both
+// changed in lockstep.
+const PINNED_WORD_BANK_TOKEN_LEARNER_A_ACCIDENT = 'vCuCsAZITLWJ5G17uLwjKRIbcIbrgQArXcrfwCf1KGY';
+
+test('computeWordBankPromptToken matches a hand-pinned base64url constant for fixture (learner-a, accident, full sentence)', async () => {
+  // Pre-computed once via:
+  //   sha256('spelling-word-bank-prompt-v1|learner-a|accident|accident|We saw an accident on the road.')
+  // — see Plan U1 demand for a hand-computed pinned digest.
+  const token = await computeWordBankPromptToken({
+    learnerId: 'learner-a',
+    slug: 'accident',
+    word: 'accident',
+    sentence: 'We saw an accident on the road.',
+  });
+  // Shape: base64url alphabet, no padding.
+  assert.match(token, /^[A-Za-z0-9_-]+$/);
+  assert.ok(!token.includes('='), 'pinned digest must be base64url with no `=` padding');
+  // Exact pinned value.
+  assert.equal(token, PINNED_WORD_BANK_TOKEN_LEARNER_A_ACCIDENT);
+});
+
+// BLOCKER 1 fix (review 2026-04-26): the smoke MUST send the canonical
+// snapshot sentence so the Worker's expected token (which it computes
+// from `cleanText(snapshot.wordBySlug[slug].sentence)` per
+// `worker/src/subjects/spelling/audio.js:87-107`) matches. This test
+// asserts the smoke's `computeWordBankPromptToken` produces a digest
+// byte-identical to a direct `sha256` call against the same salt formula
+// as the Worker, given the exact `(learnerId, slug, word, sentence)`
+// tuple read from the published snapshot.
+test('computeWordBankPromptToken byte-matches Worker-side salt formula when sentence comes from SEEDED_SPELLING_PUBLISHED_SNAPSHOT', async () => {
+  const learnerId = 'learner-a';
+  const slug = 'accident';
+  const seed = lookupSeedWord(slug);
+  assert.ok(seed, 'fixture slug must exist in published snapshot');
+  // Direct sha256 call mirrors `wordBankPromptToken(parts)` in
+  // `worker/src/subjects/spelling/audio.js`.
+  const workerEquivalentToken = await sha256([
+    'spelling-word-bank-prompt-v1',
+    learnerId,
+    seed.slug,
+    seed.word,
+    seed.sentence,
+  ].join('|'));
+  const smokeToken = await computeWordBankPromptToken({
+    learnerId,
+    slug,
+    word: seed.word,
+    sentence: seed.sentence,
+  });
+  assert.equal(smokeToken, workerEquivalentToken);
+});
+
+test('lookupSeedWord exposes the canonical (word, sentence) pair the Worker uses for the published snapshot', () => {
+  const accident = lookupSeedWord('accident');
+  assert.equal(accident.slug, 'accident');
+  assert.equal(accident.word, 'accident');
+  assert.equal(accident.sentence, 'We saw an accident on the road.');
+  // Mismatch with the canonical snapshot would silently break the smoke
+  // — assert all 4 default sample slugs round-trip.
+  for (const slug of ['accident', 'accidentally', 'knowledge', 'thought']) {
+    const seed = lookupSeedWord(slug);
+    assert.ok(seed, `${slug} must exist in published snapshot`);
+    assert.equal(seed.slug, slug);
+    assert.ok(seed.word.length > 0, `${slug} must have a word`);
+    assert.ok(seed.sentence.length > 0, `${slug} must have a sentence`);
+    // Sentence stripped via the same `cleanText` rule as the Worker.
+    assert.equal(seed.sentence, String(SEEDED_SPELLING_PUBLISHED_SNAPSHOT.wordBySlug[slug].sentence || '').replace(/\s+/g, ' ').trim());
+  }
+});
+
+test('lookupSeedWord returns null for unknown slug', () => {
+  assert.equal(lookupSeedWord('definitely-not-a-real-spelling-word'), null);
+});
+
+// BLOCKER 2 fix (review 2026-04-26): the previous `postTtsRequest` skipped
+// `--timeout-ms` entirely. Plumb a fetch spy into the smoke runner and
+// assert the resulting `init.signal` is an AbortSignal so a hung Worker
+// or upstream Gemini stall cannot wedge the smoke run indefinitely.
+test('runSpellingAudioSmoke passes an AbortSignal to /api/tts fetch (timeout plumbing)', async () => {
+  const fixture = installDemoBootstrapHandlers({ ttsHandler: buildPrimaryHitHandler() });
+  try {
+    await runSpellingAudioSmoke({
+      origin: 'https://preview.example.test',
+      wordSample: ['accident'],
+      sentenceSample: [],
+      requireWordHit: true,
+      timeoutMs: 5000,
+    });
+    const ttsCalls = fixture.calls.filter((entry) => new URL(entry.url).pathname === '/api/tts');
+    assert.ok(ttsCalls.length > 0, 'expected at least one /api/tts call');
+    for (const entry of ttsCalls) {
+      const signal = entry.init?.signal;
+      assert.ok(signal, '/api/tts fetch init must include an AbortSignal');
+      // AbortSignal duck-typing — `aborted` boolean + addEventListener.
+      assert.equal(typeof signal.aborted, 'boolean');
+      assert.equal(typeof signal.addEventListener, 'function');
+    }
+  } finally {
+    fixture.restore();
+  }
+});
+
+// FIX 5 (review 2026-04-26): a probe failure must NOT short-circuit the
+// rest of the run. Sentence + cross-account probes still execute even
+// when the first word probe fails its --require-word-hit check. The
+// resulting report has `ok: false` with the failed word probe recorded
+// alongside successful sentence + cross-account probes.
+test('runSpellingAudioSmoke continues running probes after the first word probe fails', async () => {
+  const fixture = installDemoBootstrapHandlers({
+    ttsHandler: (body) => {
+      // Word probes always miss; sentence + cross-account probes still
+      // hit primary so the test can assert they ran.
+      if (body.wordOnly === true && body.cacheLookupOnly === true) {
+        return jsonResponse({ ok: true }, {
+          status: 200,
+          headers: { 'x-ks2-tts-cache': 'miss' },
+        });
+      }
+      return buildPrimaryHitHandler()(body);
+    },
+  });
+  try {
+    const report = await runSpellingAudioSmoke({
+      origin: 'https://preview.example.test',
+      wordSample: ['accident'],
+      sentenceSample: ['accident'],
+      requireWordHit: true,
+    });
+    assert.equal(report.ok, false);
+    // Must contain ALL 3 probe kinds, not just the failing one.
+    const kinds = new Set(report.probes.map((probe) => probe.kind));
+    assert.ok(kinds.has('word'));
+    assert.ok(kinds.has('sentence'));
+    assert.ok(kinds.has('cross-account'));
+    // Word probe failed (ok: false + tagged validation), but sentence +
+    // cross-account probes succeeded (ok !== false).
+    const wordProbe = report.probes.find((entry) => entry.kind === 'word');
+    assert.equal(wordProbe.ok, false);
+    assert.equal(wordProbe.error.kind, 'validation');
+    const sentenceProbe = report.probes.find((entry) => entry.kind === 'sentence');
+    assert.notEqual(sentenceProbe.ok, false);
+    const crossAccount = report.probes.find((entry) => entry.kind === 'cross-account');
+    assert.notEqual(crossAccount.ok, false);
+  } finally {
+    fixture.restore();
+  }
+});
+
+test('runCli maps a partial-failure transport probe to EXIT_TRANSPORT (validation absent)', async () => {
+  const fixture = installDemoBootstrapHandlers({
+    ttsHandler: () => jsonResponse({ ok: false, error: 'degraded' }, { status: 503 }),
+  });
+  const restoreLogs = silenceLogs();
+  try {
+    const code = await runCli([
+      '--origin', 'https://preview.example.test',
+      '--word-sample', 'accident',
+      '--sentence-sample', 'accident',
+    ]);
+    assert.equal(code, EXIT_TRANSPORT);
+  } finally {
+    restoreLogs();
+    fixture.restore();
+  }
+});
+
 // --- Helpers for /api/tts handlers --------------------------------------
 
 function buildPrimaryHitHandler({ voice = 'Iapetus' } = {}) {
@@ -274,41 +446,25 @@ test('runSpellingAudioSmoke happy path reports all probes succeeded', async () =
 // --- Edge: word miss without --require-word-hit -------------------------
 
 test('runSpellingAudioSmoke reports WARN on word miss without --require-word-hit', async () => {
-  const ttsHandler = (body) => {
-    if (body.wordOnly === true) {
-      return jsonResponse({ ok: true }, {
-        status: 200,
-        headers: { 'x-ks2-tts-cache': 'miss' },
-      });
-    }
-    return jsonResponse({ ok: true }, {
-      status: 200,
-      headers: { 'x-ks2-tts-cache': 'hit', 'x-ks2-tts-cache-source': 'legacy' },
-    });
-  };
-  const primaryFixture = installDemoBootstrapHandlers({ ttsHandler: buildPrimaryHitHandler() });
-  // Swap the handler after demo bootstrap responds; we want word probes to
-  // miss but the cross-account probe (which shares the same handler) to
-  // still hit. Simpler: install a single combined handler that misses on
-  // word probes when the slug matches the sample, and hits on the cross-
-  // account fixture word. To keep this test focused on the WARN path we
-  // restrict the sample to a single word DISTINCT from the fixture.
-  primaryFixture.restore();
+  // The sample MUST exist in SEEDED_SPELLING_PUBLISHED_SNAPSHOT.wordBySlug
+  // so the smoke can derive the canonical sentence (Worker-parity); we
+  // pick `actual` since it is a stable slug distinct from the cross-
+  // account fixture word `accident`.
   const fixture = installDemoBootstrapHandlers({
     ttsHandler: (body) => {
-      if (body.wordOnly === true && body.slug === 'beginning') {
+      if (body.wordOnly === true && body.slug === 'actual') {
         return jsonResponse({ ok: true }, {
           status: 200,
           headers: { 'x-ks2-tts-cache': 'miss' },
         });
       }
-      return ttsHandler === ttsHandler ? buildPrimaryHitHandler()(body) : ttsHandler(body);
+      return buildPrimaryHitHandler()(body);
     },
   });
   try {
     const report = await runSpellingAudioSmoke({
       origin: 'https://preview.example.test',
-      wordSample: ['beginning'],
+      wordSample: ['actual'],
       sentenceSample: ['accident'],
       requireWordHit: false,
       requireLegacyHit: false,
@@ -322,7 +478,10 @@ test('runSpellingAudioSmoke reports WARN on word miss without --require-word-hit
   }
 });
 
-test('runSpellingAudioSmoke throws validation when word probe misses with --require-word-hit', async () => {
+test('runSpellingAudioSmoke records validation probe entry when word probe misses with --require-word-hit', async () => {
+  // After the partial-failure fix, errors no longer short-circuit the run
+  // — they are recorded as `{ ok: false, error: { kind, message } }` so
+  // operators see the full pass/fail matrix.
   const fixture = installDemoBootstrapHandlers({
     ttsHandler: (body) => {
       if (body.wordOnly === true) {
@@ -335,15 +494,18 @@ test('runSpellingAudioSmoke throws validation when word probe misses with --requ
     },
   });
   try {
-    await assert.rejects(
-      () => runSpellingAudioSmoke({
-        origin: 'https://preview.example.test',
-        wordSample: ['accident'],
-        sentenceSample: ['accident'],
-        requireWordHit: true,
-      }),
-      /--require-word-hit/,
-    );
+    const report = await runSpellingAudioSmoke({
+      origin: 'https://preview.example.test',
+      wordSample: ['accident'],
+      sentenceSample: ['accident'],
+      requireWordHit: true,
+    });
+    assert.equal(report.ok, false);
+    const wordProbe = report.probes.find((entry) => entry.kind === 'word');
+    assert.ok(wordProbe);
+    assert.equal(wordProbe.ok, false);
+    assert.equal(wordProbe.error.kind, 'validation');
+    assert.match(wordProbe.error.message, /--require-word-hit/);
   } finally {
     fixture.restore();
   }
@@ -427,14 +589,14 @@ test('runSpellingAudioSmoke cross-account probe asserts byte-identical bodies + 
   }
 });
 
-test('runSpellingAudioSmoke cross-account probe rejects when fixture-word bodies diverge', async () => {
+test('runSpellingAudioSmoke cross-account probe records validation probe entry when fixture-word bodies diverge', async () => {
   const fixture = installDemoBootstrapHandlers({
     demoSessions: [
       { accountId: 'account-a', learnerId: 'learner-a', cookie: 'ks2_session=demoA' },
       { accountId: 'account-b', learnerId: 'learner-b', cookie: 'ks2_session=demoB' },
       { accountId: 'account-a', learnerId: 'learner-a', cookie: 'ks2_session=demoA' },
     ],
-    ttsHandler: (body, init, calls) => {
+    ttsHandler: (body, init) => {
       // For the cross-account fixture word, return DIFFERENT bytes per
       // learner — simulates an R2 key resolution bug where per-learner
       // tokens accidentally route to different objects.
@@ -453,20 +615,23 @@ test('runSpellingAudioSmoke cross-account probe rejects when fixture-word bodies
     },
   });
   try {
-    await assert.rejects(
-      () => runSpellingAudioSmoke({
-        origin: 'https://preview.example.test',
-        wordSample: [],
-        sentenceSample: [],
-      }),
-      /response bodies diverged/,
-    );
+    const report = await runSpellingAudioSmoke({
+      origin: 'https://preview.example.test',
+      wordSample: [],
+      sentenceSample: [],
+    });
+    assert.equal(report.ok, false);
+    const probe = report.probes.find((entry) => entry.kind === 'cross-account');
+    assert.ok(probe);
+    assert.equal(probe.ok, false);
+    assert.equal(probe.error.kind, 'validation');
+    assert.match(probe.error.message, /response bodies diverged/);
   } finally {
     fixture.restore();
   }
 });
 
-test('runSpellingAudioSmoke cross-account probe rejects when distinct-word body collapses to fixture bytes', async () => {
+test('runSpellingAudioSmoke cross-account probe records validation probe entry when distinct-word body collapses', async () => {
   const fixture = installDemoBootstrapHandlers({
     demoSessions: [
       { accountId: 'account-a', learnerId: 'learner-a', cookie: 'ks2_session=demoA' },
@@ -489,14 +654,17 @@ test('runSpellingAudioSmoke cross-account probe rejects when distinct-word body 
     },
   });
   try {
-    await assert.rejects(
-      () => runSpellingAudioSmoke({
-        origin: 'https://preview.example.test',
-        wordSample: [],
-        sentenceSample: [],
-      }),
-      /produced byte-identical body/,
-    );
+    const report = await runSpellingAudioSmoke({
+      origin: 'https://preview.example.test',
+      wordSample: [],
+      sentenceSample: [],
+    });
+    assert.equal(report.ok, false);
+    const probe = report.probes.find((entry) => entry.kind === 'cross-account');
+    assert.ok(probe);
+    assert.equal(probe.ok, false);
+    assert.equal(probe.error.kind, 'validation');
+    assert.match(probe.error.message, /produced byte-identical body/);
   } finally {
     fixture.restore();
   }


### PR DESCRIPTION
## Summary

U3 of the spelling word audio cache plan — adds `npm run smoke:production:spelling-audio`, a peer of the existing per-subject `smoke:production:*` family, that probes `/api/tts` on production along three axes:

- **Word-only primary probe** — for each `--word-sample` × Iapetus + Sulafat, builds the word-bank prompt token via the canonical `sha256` from `worker/src/auth.js` and asserts `200` + `x-ks2-tts-cache: hit` + `x-ks2-tts-cache-source: primary` + the `gemini-3.1-flash-tts-preview` model header + the requested voice header. Misses are reported as `WARN` unless `--require-word-hit` is set so the probe runs pre-fill as a baseline.
- **Sentence legacy probe** — live-validates PR 252's R2 fallback. `cache-source: primary` surfaces an `INFO: legacy fallback no longer required` note unless `--require-legacy-hit` is set.
- **Cross-account invariant probe** — two real demo learners (created via `createDemoSession` so the Worker's `learnerId` check at `worker/src/subjects/spelling/audio.js:114-118` accepts them) must produce distinct prompt tokens but the smoke runner derives the same expected R2 key. Both responses must be cache hits AND byte-identical bodies; a third probe for a different word must produce distinct bytes (rules out collapse-to-wrong-key regression).

EXIT taxonomy (`EXIT_OK=0`, `EXIT_VALIDATION=1`, `EXIT_USAGE=2`, `EXIT_TRANSPORT=3`) mirrors `scripts/spelling-dense-history-smoke.mjs`.

Plan: `docs/plans/2026-04-26-001-feat-spelling-word-audio-cache-plan.md` (section U3).

## Review follow-up (2026-04-26)

Resolves four CE review blockers + advisories (commit `1764c74`):

- **BLOCKER 1 (correctness, anchor 75)** — Word/sentence/cross-account probes now load the canonical sentence from `SEEDED_SPELLING_PUBLISHED_SNAPSHOT.wordBySlug` via the new `lookupSeedWord()` helper. The Worker's `wordBankPromptParts` (`worker/src/subjects/spelling/audio.js:87-107`) reads `cleanText(snapshot.wordBySlug[slug].sentence)` when computing its expected token; the previous empty-sentence token would have been rejected as `tts_prompt_stale` (HTTP 400) for every default-sample word probe AND the cross-account probe.
- **BLOCKER 2 (reliability, anchor 90)** — `postTtsRequest` now plumbs `--timeout-ms` into `globalThis.fetch` via `AbortSignal.timeout(timeoutMs)`. Previously the flag was parsed but discarded, leaving the smoke vulnerable to indefinite hangs on Gemini outages or Worker cold-starts. `configuredTimeoutMs()` is now exported from `scripts/lib/production-smoke.mjs`. AbortError on timeout still classifies as `EXIT_TRANSPORT`.
- **FIX 3 (testing, anchor 70)** — New unit test pins the base64url digest of `'spelling-word-bank-prompt-v1|learner-a|accident|accident|We saw an accident on the road.'` against a hand-computed constant (`vCuCsAZITLWJ5G17uLwjKRIbcIbrgQArXcrfwCf1KGY`), plus shape regex (`/^[A-Za-z0-9_-]+$/`, no `=`). Previous byte-equality test was self-referential.
- **FIX 4 (correctness, anchor 75 advisory)** — Deleted dead `computeSessionPromptToken()`. The sentence probe deliberately uses `computeWordBankPromptToken` to test the legacy R2 fallback (legacy keys were generated under word-bank shape per pre-PR-71 conventions).
- **FIX 5 (reliability, anchor 75)** — Each probe is wrapped in `safeRunProbe(kind, runner)`; failures no longer short-circuit the run. Each probe records `{ ok: false, error: { kind, message } }` and `worstProbeExitCode()` maps the report to EXIT based on the worst classification (validation > transport > usage). Sentence + cross-account probes still execute when the first word probe fails — operator sees the full pass/fail matrix in one report.

6 advisory items deferred to `docs/plans/2026-04-26-001-feat-spelling-word-audio-cache-plan.md` under the new **"Tech debt deferred from U3 review (2026-04-26)"** subsection (demo session cleanup, single-retry on transient 5xx, real binary body-bytes test, defensive validator coverage, fetch-throw classification test, R2 key parity assertion).

No Worker / shared / U1-U2 changes — all edits are smoke-script + smoke-test + plan-doc only (`scripts/lib/production-smoke.mjs` adds an `export` keyword to an already-internal helper).

## Test plan

- [x] `npm test -- tests/spelling-audio-production-smoke.test.js` — 27/27 pass (original 16 + 5 new for fixes 1-5 + 6 updated for partial-failure shape)
- [x] `npm test -- tests/spelling-word-prompt.test.js tests/build-spelling-word-audio.test.js tests/worker-tts.test.js` — 97/97 pass (no regression)
- [x] `npm run check` (deploy --dry-run) passes
- [x] `node --check scripts/spelling-audio-production-smoke.mjs` passes
- [ ] `npm run smoke:production:spelling-audio -- --json` against `ks2.eugnel.uk` (operator step at U4 preflight; pre-fill word probes will report `miss` as `WARN`, sentence-legacy probes should already pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)