### PR TITLE
docs(spelling): U5 word-audio runbook + learning + plan close-out

### DIFF
--- a/docs/plans/2026-04-26-001-feat-spelling-word-audio-cache-plan.md
+++ b/docs/plans/2026-04-26-001-feat-spelling-word-audio-cache-plan.md
@@ -1,7 +1,7 @@
 ---
 title: Spelling Word Bank Audio Cache Generation
 type: feat
-status: active
+status: completed
 date: 2026-04-26
 deepened: 2026-04-26
 ---
@@ -1456,3 +1456,7 @@ completion report)
   the Worker helper directly (or re-export via `shared/`) and assert
   byte-equal output for the same input. This pairs with maint-001
   (test-only re-exports from `worker/src/tts.js`).
+
+---
+
+**Plan completed 2026-04-26.** All 5 implementation units shipped via PRs #286 (U1), #297 (U2 — bulk script via direct push as `1050111` + cleanup PR), #299 (U3), #302 (U4 template), #<U5-PR-NUMBER> (U5). Operator must run §4 of `docs/reports/2026-04-26-spelling-word-audio-generation-report.md` against production to actually generate the 472 audio files; this plan ships the infrastructure + verification, not the executed run.

--- a/docs/plans/2026-04-26-001-feat-spelling-word-audio-cache-plan.md
+++ b/docs/plans/2026-04-26-001-feat-spelling-word-audio-cache-plan.md
@@ -1459,4 +1459,4 @@ completion report)
 
 ---
 
-**Plan completed 2026-04-26.** All 5 implementation units shipped via PRs #286 (U1), #297 (U2 — bulk script via direct push as `1050111` + cleanup PR), #299 (U3), #302 (U4 template), #<U5-PR-NUMBER> (U5). Operator must run §4 of `docs/reports/2026-04-26-spelling-word-audio-generation-report.md` against production to actually generate the 472 audio files; this plan ships the infrastructure + verification, not the executed run.
+**Plan completed 2026-04-26.** All 5 implementation units shipped via PRs #286 (U1), #297 (U2 — bulk script via direct push as `1050111` + cleanup PR), #299 (U3), #302 (U4 template), #304 (U5). Operator must run §4 of `docs/reports/2026-04-26-spelling-word-audio-generation-report.md` against production to actually generate the 472 audio files; this plan ships the infrastructure + verification, not the executed run.

--- a/docs/solutions/learning-spelling-audio-cache-contract.md
+++ b/docs/solutions/learning-spelling-audio-cache-contract.md
@@ -123,7 +123,7 @@ The mitigations:
   in `shared/spelling-audio.js` is imported by both sides.
 - **Hash algorithm: 4-line shim, not import.** The generator
   duplicates the SHA-256 + base64url logic from
-  `worker/src/auth.js:156-185` as a 4-line shim
+  `worker/src/auth.js:162-191` as a 4-line shim
   (`crypto.subtle.digest('SHA-256', ...)` +
   URL-safe alphabet rewrite). Direct import was avoided because the
   Worker module pulls Worker-runtime dependencies that may not
@@ -143,7 +143,7 @@ The mitigations:
   path the Worker would never read.
 - **`cleanText` normalisation, not bare `.trim()`.** Worker hashes
   `cleanText(value) = String(value || '').replace(/\s+/g, ' ').trim()`
-  (`worker/src/tts.js:38-40`). This collapses NBSP (`U+00A0`),
+  (`worker/src/tts.js:39-41`). This collapses NBSP (`U+00A0`),
   double-space, and tabs to a single space *before* trimming. Bare
   `.trim()` diverges silently on any input containing internal NBSP
   or double-space — and the U1 fixture suite includes those cases
@@ -345,7 +345,7 @@ So future readers know the boundary of this entry:
 - **OpenAI provider audio.** This work strictly fills the buffered
   Gemini cache lane. The OpenAI path
   (`requestOpenAiSpeech` in `worker/src/tts.js`, `ttsInstructions`
-  wordOnly variant on line 154) is unaffected.
+  wordOnly variant on line 156) is unaffected.
 - **Browser TTS fallback** (`speakWithBrowser`). Untouched.
 - **Word-bank prompt token shape** (`wordBankPromptToken` salt
   prefix `'spelling-word-bank-prompt-v1'`). Untouched.
@@ -367,7 +367,7 @@ So future readers know the boundary of this entry:
 - Cache contract: `shared/spelling-audio.js`,
   `worker/src/tts.js:282-448`,
   `worker/src/subjects/spelling/audio.js`
-- Hash digest helper: `worker/src/auth.js:156-185`
+- Hash digest helper: `worker/src/auth.js:162-191`
 - Word source: `src/subjects/spelling/data/word-data.js` (236
   entries)
 - Snapshot lookup: `src/subjects/spelling/data/content-data.js`

--- a/docs/solutions/learning-spelling-audio-cache-contract.md
+++ b/docs/solutions/learning-spelling-audio-cache-contract.md
@@ -1,0 +1,379 @@
+---
+type: learning
+domain: audio, caching, r2, content-addressed-cache, spelling
+created: 2026-04-26
+plan: docs/plans/2026-04-26-001-feat-spelling-word-audio-cache-plan.md
+prs: ["#252", "#286", "#297", "#299", "#302"]
+status: established
+---
+
+<!--
+  Convention note (FIRST entry in docs/solutions/, sets directory + frontmatter
+  precedent for subsequent entries):
+
+  - File naming: `learning-<topic>.md` (kebab-case topic, prefixed with
+    `learning-` to make the intent obvious in directory listings).
+  - Frontmatter (YAML) is mandatory and follows Compound Engineering shape:
+      type:    `learning` (literal)
+      domain:  comma-separated tags (lowercase, kebab where multi-word)
+      created: ISO 8601 date `YYYY-MM-DD`
+      plan:    repo-relative path to the originating plan, if any
+      prs:     YAML array of PR shorthand strings (`"#NNN"`)
+      status:  `established` | `superseded` | `withdrawn`
+  - The frontmatter `---` markers MUST be the very first lines of the
+    file (no preceding whitespace, no preceding HTML comment) so that
+    standard markdown frontmatter parsers (Hugo, Jekyll, Pandoc, MDX)
+    detect them. This convention note therefore lives BETWEEN the
+    closing `---` and the first H1 heading.
+  - Body is structured prose: numbered sections with H2 headings; fenced
+    code blocks for hash inputs / key shapes; a final "What this learning
+    DOES NOT cover" section to bound scope for future readers.
+  - Subsequent entries should follow the same shape unless a stronger
+    convention emerges (in which case update this comment in the next
+    entry, not this one).
+-->
+
+# Spelling audio cache contract — content-addressed R2 + legacy fallback
+
+Distilled lessons from the 2026-04-26 spelling Word Bank audio cache
+work (PR #252 Worker contract + PRs #286, #297, #299, #302 generator,
+smoke probe, and operational scaffolding). Pair with the operator
+runbook at [`docs/spelling-word-audio.md`](../spelling-word-audio.md)
+for the recipe; this entry captures *why* the contract is shaped the
+way it is.
+
+---
+
+## 1. Cache key contract evolution
+
+The R2 key for spelling audio has been re-shaped twice. Each
+generation deliberately invalidated the previous one (orphaned R2
+objects remain until explicitly cleaned).
+
+| Generation | Key shape | Notes |
+|------------|-----------|-------|
+| pre-PR-71 | `spelling-audio/v1/{model}/{voice}/{speed}/{slug}.{mp3\|wav}` | 4 segments, no `contentKey`. ~8 612 sentence files exist under this shape and continue to serve via PR 252's `legacyBufferedAudioKey` fallback. |
+| PR 71 | `spelling-audio/v1/{model}/{voice}/{speed}/{contentKey}/{slug}.{mp3\|wav}` | Adds content-addressed `contentKey = sha256('spelling-audio-sentence-v1' \| slug \| sentenceIndex \| word \| sentence)`. Sentence-only; word-only path did not yet exist. |
+| PR 252 | `spelling-audio/v1/{model}/{voice}/word/{contentKey}/{slug}.{mp3\|wav}` | Adds **word-only** key shape with `contentKey = sha256('spelling-audio-word-v1' \| cleanText(slug).toLowerCase() \| cleanText(word))`. Deliberately omits accountId for cross-account R2 reuse. Legacy fallback in Worker continues to serve old sentence files until they are regenerated. |
+
+The word-only key is **structurally distinct** from the sentence key:
+the segment immediately after `{voice}` is the literal `word`, not a
+`{speed}` value. This is what lets the Worker route a `kind: 'word'`
+request straight to a separate cache slot without colliding with any
+sentence object.
+
+---
+
+## 2. Why content-addressed?
+
+Hashing the exact `(slug, word)` text into the R2 path gives us
+**change-detection without manual versioning**:
+
+- If the word text changes (typo fix, casing tweak), the new
+  `contentKey` lands at a different R2 path. The Worker cache-misses
+  cleanly and live-regen produces fresh audio. No manual cache bust
+  required.
+- The old (orphaned) object remains in R2 until cleaned. Cost is
+  bounded (cents per orphan); the failure mode is invisible to
+  learners.
+- No `version: N` integer on every R2 path that has to be maintained
+  by hand and risks getting stale.
+
+Trade-off: orphans accumulate. Acceptable at the planned word-list
+stability cadence (effectively static); a future janitorial sweep
+can drop them.
+
+---
+
+## 3. Why a separate word-only key shape?
+
+Word-only audio is **single-pace by pedagogic intent**. There is no
+`speed` axis (no slow / normal variants), because the Word Bank UX
+plays the word once at a natural read-aloud pace; slow-pace lives
+on the dictation drill lane, which uses the sentence cache.
+
+Encoding this distinction in the key shape (literal `word` segment
+instead of a `{speed}` segment) makes the contract self-documenting:
+no caller can accidentally request a slow word-only variant, because
+no key shape exists for it. If pedagogy later requests a slow
+variant, the contract evolves first (likely a fourth generation in
+§1).
+
+---
+
+## 4. Why batch generator + Worker share helpers?
+
+The generator (`scripts/build-spelling-word-audio.mjs`) and the
+Worker (`worker/src/tts.js`) write to the same R2 bucket under the
+same key shape. Any divergence in either the prompt template or the
+hash algorithm produces silent correctness bugs:
+
+- A prompt drift means batch-uploaded audio sounds different from
+  Worker-regenerated audio for the same word.
+- A hash drift means batch-uploaded audio lives at a path the Worker
+  never reads (100 % cache miss).
+
+The mitigations:
+
+- **Shared prompt builder.** `buildBufferedWordSpeechPrompt({ wordText })`
+  in `shared/spelling-audio.js` (introduced by U1) is imported by
+  both Worker `geminiPrompt` and the batch generator. One source of
+  truth.
+- **Shared key builder.** `buildWordAudioAssetKey({ model, voice, contentKey, slug })`
+  in `shared/spelling-audio.js` is imported by both sides.
+- **Hash algorithm: 4-line shim, not import.** The generator
+  duplicates the SHA-256 + base64url logic from
+  `worker/src/auth.js:156-185` as a 4-line shim
+  (`crypto.subtle.digest('SHA-256', ...)` +
+  URL-safe alphabet rewrite). Direct import was avoided because the
+  Worker module pulls Worker-runtime dependencies that may not
+  resolve cleanly from `scripts/`. The drift defence is **not** the
+  import path — it is the fixture-pinned test in
+  `tests/spelling-word-prompt.test.js` that asserts the digest
+  `_71BbbYsUhNeilGccY6U4YPJ8-8tMfGXZT7P6m6bkls` for
+  `(slug:'accident', word:'accident')`. Any future change to either
+  the Worker `bytesToBase64Url` encoding or the generator shim trips
+  this test before reaching production R2.
+
+### Specific gotchas
+
+- **`bytesToBase64Url`, not hex.** Worker's `sha256()` returns
+  base64url (`+`→`-`, `/`→`_`, no `=` padding). Generator using
+  Node's `createHash('sha256').digest('hex')` would write to a hex
+  path the Worker would never read.
+- **`cleanText` normalisation, not bare `.trim()`.** Worker hashes
+  `cleanText(value) = String(value || '').replace(/\s+/g, ' ').trim()`
+  (`worker/src/tts.js:38-40`). This collapses NBSP (`U+00A0`),
+  double-space, and tabs to a single space *before* trimming. Bare
+  `.trim()` diverges silently on any input containing internal NBSP
+  or double-space — and the U1 fixture suite includes those cases
+  precisely because that is the regression most likely to slip past
+  unit-of-work review.
+- **Hash input shape.** The exact join is
+  `['spelling-audio-word-v1', cleanText(slug).toLowerCase(), cleanText(word)].join('|')`.
+  All three components matter; an extra trailing `|`, a different
+  salt prefix, or any case difference in `slug` produces a
+  different digest.
+
+---
+
+## 5. Two-source-of-truth assertion pattern
+
+The generator reads `WORDS[i].word` from
+`src/subjects/spelling/data/word-data.js` (the bundle source). The
+Worker reads `snapshot.wordBySlug[slug].word` from the published
+spelling snapshot (`SEEDED_SPELLING_PUBLISHED_SNAPSHOT.wordBySlug`
+in `src/subjects/spelling/data/content-data.js`) when validating
+prompt tokens (`worker/src/subjects/spelling/audio.js:96-103`).
+
+Today both come from the same seed pipeline, but **no contract
+guarantees they remain equal**. If they ever diverge for a slug,
+the Worker's prompt token validation rejects requests for that slug
+and / or the Worker's contentKey hash differs from the batch's hash
+for the same slug — silent cache miss at best, silent correctness
+bug at worst.
+
+The mitigation: U2 generator preflight asserts
+`cleanText(WORDS[i].word) === cleanText(wordBySlug[WORDS[i].slug].word)`
+for **all** 236 slugs before any per-entry work. Mismatch hard-stops
+the run with a clear error naming the divergent slug. No Gemini
+spend until parity is restored.
+
+This is a generalisable pattern: whenever two materialisations of
+"the same data" exist for legitimate reasons (one for the bundle,
+one for the runtime snapshot), an explicit cross-check at any
+process boundary that depends on their equality is cheap insurance
+against silent drift.
+
+---
+
+## 6. Legacy-fallback escape hatch
+
+PR 252 introduced `legacyBufferedAudioKey({ kind, ... })`:
+
+- For `kind: 'word'` it returns `null` (no pre-existing word cache
+  to fall back to; word-only path is brand new).
+- For `kind: 'sentence'` it returns the pre-PR-71 4-segment key
+  path (`spelling-audio/v1/{model}/{voice}/{speed}/{slug}.{mp3|wav}`).
+
+The Worker's `readBufferedGeminiAudio` tries the new
+content-addressed path first; on miss it falls back to the legacy
+key (when `legacyBufferedAudioKey` returns non-null). A successful
+legacy hit returns `200` with header
+`x-ks2-tts-cache-source: legacy` (vs `primary` for new-path hits) —
+the U3 production smoke probe asserts both code paths against real
+R2 inventory.
+
+The fallback is removable when all 8 612 sentence files have been
+regenerated under the new key shape. That work is **not in scope**
+of this plan; until then, the fallback is the only thing keeping
+the existing sentence cache serving traffic.
+
+---
+
+## 7. Smoke contract
+
+The U3 production smoke
+(`scripts/spelling-audio-production-smoke.mjs`) is the verification
+primitive for any future audio cache change. It asserts the
+following response headers per request shape:
+
+| Header | Allowed values |
+|--------|----------------|
+| `x-ks2-tts-cache` | `hit` \| `miss` \| `stored` \| `store_failed` \| `unavailable` |
+| `x-ks2-tts-cache-source` | `primary` \| `legacy` |
+| `x-ks2-tts-model` | the deployed `SPELLING_AUDIO_MODEL` value (currently `gemini-3.1-flash-tts-preview`) |
+| `x-ks2-tts-voice` | the requested voice (`Iapetus` or `Sulafat`) |
+
+### Cross-account invariant probe
+
+For the same fixture word, two distinct learner ids produce two
+distinct `wordBankPromptToken` values (per-learner salt) but
+**must** resolve to the same R2 key path (Worker hash deliberately
+omits `accountId` for cross-account cache reuse, per PR 252
+design). The smoke asserts:
+
+1. `token_A !== token_B` (per-learner tokens differ).
+2. Both probes cache-hit.
+3. `await response_A.arrayBuffer() === await response_B.arrayBuffer()`
+   byte-identical (catches a regression that breaks per-learner
+   token but accidentally maps both to the same WRONG R2 key).
+4. A third probe for a **different** word produces distinct body
+   bytes (rules out collapse-to-wrong-key regression).
+
+This four-step assertion is the only practical way to detect a key
+collapse that still passes the per-learner-token-distinct check.
+Re-use the pattern for any future cross-account cache work.
+
+---
+
+## 8. Live-regen race mitigation pattern
+
+R2 PUT is last-writer-wins; Worker's `storeBufferedGeminiAudio`
+calls `bucket.put(key, bytes, ...)` with no `onlyIf` precondition.
+Concurrent learner traffic during a batch fill can overwrite a
+just-uploaded batch object with a slightly different live take —
+silently.
+
+The default mitigation is **operational**: schedule the full run in
+a low-traffic UTC window. This is statistical, not structural —
+KS2 is publicly accessible globally — but sufficient for the
+99 % case and avoids Worker-side complexity.
+
+The escalation pattern, when the operational window is unavailable,
+is `onlyIf: { etagDoesNotMatch: '*' }` as a generic write-side
+guard for batch-fill operations against R2:
+
+- Wrap Worker `storeBufferedGeminiAudio`'s `bucket.put(...)` in
+  `onlyIf: { etagDoesNotMatch: '*' }` when the
+  `WORD_ONLY_BATCH_FILL_GUARD` env-flag is set (one-line Worker
+  change behind a feature flag).
+- Worker live regen no longer overwrites existing R2 objects for the
+  duration of the batch fill.
+- Toggle off + redeploy after fill completes.
+- Open a follow-up TODO PR to remove the flag entirely once
+  steady-state stability is confirmed.
+
+This is documented as **escalation-only** in the runbook
+(Appendix B of the U4 report template); the default is the
+operational window. The pattern itself — `etagDoesNotMatch: '*'` as
+a write-side guard against last-writer-wins R2 overwrites — is
+re-usable for any future batch-fill-vs-live-regen race.
+
+---
+
+## 9. Operational discipline
+
+These are the cross-cutting habits that this work proved valuable.
+Apply them to any future batch-fill or stateful generator work.
+
+### 9.1 Idempotent state file with atomic write
+
+State file under `.spelling-audio/word-runs/<runId>/state.json`
+recording per-entry status. Writes use `.tmp.<pid>.<n>` + rename for
+atomicity, so a crash during write never produces a partially
+overwritten state file. Persistence is **per-entry**, not just
+end-of-run, so a crash mid-run never loses more than one in-flight
+entry.
+
+`SIGINT` and `SIGTERM` handlers flush state before exiting.
+
+### 9.2 Quota / rotation budget independent of retry budget
+
+`--max-retries 0` should fail fast on real errors but **still**
+rotate keys on quota errors (HTTP 429 or 403 with
+`RESOURCE_EXHAUSTED`-style payload). A key-pool exhaustion is not a
+retry candidate, it is a different operator decision; conflating
+the two budgets makes both misbehave.
+
+### 9.3 Audit blocklist coverage via substring matcher
+
+The audit blocklists (`scripts/audit-client-bundle.mjs:145`,
+`scripts/production-bundle-audit.mjs:135`) use
+`text.includes(token)` substring matching. The existing
+`'GEMINI_API_KEY'` token already catches `GEMINI_API_KEY_2`,
+`GEMINI_API_KEY_20`, `GEMINI_API_KEYS`, etc. — no per-name
+additions are required when a new env-var variant is introduced.
+
+U2 added a unit test pinning the substring behaviour as a defence
+against future matcher tightening (e.g., a switch to exact-match)
+that would silently drop coverage.
+
+### 9.4 Generator preflight hard-stops, not warnings
+
+Every preflight check (env-var presence, ffmpeg, wrangler OAuth,
+WORDS / snapshot parity, contract version) **aborts** the run
+rather than warns. The cost of a wrong-prompt full run vastly
+exceeds the cost of an over-strict preflight that occasionally
+needs an operator to widen the gate.
+
+---
+
+## 10. What this learning DOES NOT cover
+
+So future readers know the boundary of this entry:
+
+- **Sentence audio regeneration** (the 8 612 files served via PR
+  252's legacy fallback). Out of scope for this plan; would be a
+  separate plan that decommissions the legacy fallback.
+- **Worker-side performance tuning** of the cache lookup path
+  (e.g., stale-while-revalidate, edge caching layered above R2).
+- **Migration of existing R2 buckets to new physical names.** The
+  current bucket (`ks2-spelling-buffers`) is assumed stable; a
+  bucket rename would require its own plan with cut-over
+  procedure.
+- **OpenAI provider audio.** This work strictly fills the buffered
+  Gemini cache lane. The OpenAI path
+  (`requestOpenAiSpeech` in `worker/src/tts.js`, `ttsInstructions`
+  wordOnly variant on line 154) is unaffected.
+- **Browser TTS fallback** (`speakWithBrowser`). Untouched.
+- **Word-bank prompt token shape** (`wordBankPromptToken` salt
+  prefix `'spelling-word-bank-prompt-v1'`). Untouched.
+- **Multi-account observability dashboard** for cross-account
+  cache hits. PR 252's correctness invariant is covered by U3
+  smoke; a metrics dashboard for actual cross-account hit rates is
+  a separate observability plan.
+
+---
+
+## Sources
+
+- Plan: [`docs/plans/2026-04-26-001-feat-spelling-word-audio-cache-plan.md`](../plans/2026-04-26-001-feat-spelling-word-audio-cache-plan.md)
+- PR #252 — Worker word-only cache contract (merged 2026-04-26)
+- PR #286 — U1 shared word-only TTS prompt helper
+- PR #297 — U2 generator script + retry/concurrency hardening
+- PR #299 — U3 production audio smoke probe
+- PR #302 — U4 generation report template
+- Cache contract: `shared/spelling-audio.js`,
+  `worker/src/tts.js:282-448`,
+  `worker/src/subjects/spelling/audio.js`
+- Hash digest helper: `worker/src/auth.js:156-185`
+- Word source: `src/subjects/spelling/data/word-data.js` (236
+  entries)
+- Snapshot lookup: `src/subjects/spelling/data/content-data.js`
+  (`SEEDED_SPELLING_PUBLISHED_SNAPSHOT.wordBySlug`)
+- Fixture-pinned hash test:
+  `tests/spelling-word-prompt.test.js`
+- Operator runbook: [`docs/spelling-word-audio.md`](../spelling-word-audio.md)
+- Run report template:
+  [`docs/reports/2026-04-26-spelling-word-audio-generation-report.md`](../reports/2026-04-26-spelling-word-audio-generation-report.md)

--- a/docs/spelling-word-audio.md
+++ b/docs/spelling-word-audio.md
@@ -347,7 +347,7 @@ about contentKey or R2 key shape:
     (deliberately omits accountId for cross-account R2 reuse).
   - `resolveSpellingAudioRequest` (line 109) — the only resolver
     path; do not modify.
-- **Canonical SHA-256 helper** — `worker/src/auth.js:156-185`:
+- **Canonical SHA-256 helper** — `worker/src/auth.js:162-191`:
   - `bytesToBase64Url` (line 162) — URL-safe base64 encoding (no `=`
     padding, `+`→`-`, `/`→`_`).
   - `sha256(value)` (line 188) — returns base64url, **not hex**.
@@ -414,7 +414,7 @@ The Worker normalises every hashable text input via:
 const cleanText = (value) => String(value || '').replace(/\s+/g, ' ').trim();
 ```
 
-Source: `worker/src/tts.js:38-40` (and the duplicate in
+Source: `worker/src/tts.js:39-41` (and the duplicate in
 `worker/src/subjects/spelling/audio.js:7-9`). Both definitions are
 byte-equal; the helper is **not** bare `.trim()` — it collapses
 internal whitespace (NBSP `U+00A0`, double-space, tabs) to a single

--- a/docs/spelling-word-audio.md
+++ b/docs/spelling-word-audio.md
@@ -1,0 +1,429 @@
+# Spelling Word Bank audio cache — operator runbook
+
+## Overview
+
+This runbook covers the end-to-end procedure for (re)generating the
+236-word × 2-voice = 472-object Word Bank audio cache that backs
+`tts.speak({ wordOnly: true })` on production R2 (bucket
+`ks2-spelling-buffers`).
+
+It is the operator-facing companion to plan
+[`docs/plans/2026-04-26-001-feat-spelling-word-audio-cache-plan.md`](./plans/2026-04-26-001-feat-spelling-word-audio-cache-plan.md)
+and the per-run completion-report template
+[`docs/reports/2026-04-26-spelling-word-audio-generation-report.md`](./reports/2026-04-26-spelling-word-audio-generation-report.md).
+The institutional learning that documents the cache contract itself
+lives at
+[`docs/solutions/learning-spelling-audio-cache-contract.md`](./solutions/learning-spelling-audio-cache-contract.md).
+
+Use this runbook when any of the triggers in **§1 When to regenerate**
+fire. Maintained by whoever currently owns the spelling subject; see
+the institutional learning entry for the contract-level details.
+
+---
+
+## 1. When to regenerate
+
+Trigger a regeneration whenever any of the following changes:
+
+1. **Word list change** — any edit to `WORDS` in
+   `src/subjects/spelling/data/word-data.js` (additions, removals, or
+   text changes to existing entries). The `contentKey` is content-addressed,
+   so a different `word` text produces a different R2 path; the old object
+   becomes orphaned and the new path is empty until regenerated.
+2. **Cache key contract version bump** — any change to
+   `SPELLING_AUDIO_VERSION` (`shared/spelling-audio.js:4`),
+   `SPELLING_AUDIO_ROOT_PREFIX` (`shared/spelling-audio.js:6`),
+   `SPELLING_AUDIO_MODEL`, or the contentKey hash input shape
+   (`'spelling-audio-word-v1' | slug | word`). Any of these invalidates
+   every existing object under the new key shape.
+3. **R2 bucket migration** — any change to the binding
+   `SPELLING_AUDIO_BUCKET` or the physical bucket
+   (`ks2-spelling-buffers`) in `wrangler.jsonc` `r2_buckets[0]`. New
+   bucket starts empty; existing objects must be re-uploaded.
+4. **Published spelling snapshot version bump** — any change to
+   `SEEDED_SPELLING_PUBLISHED_SNAPSHOT.wordBySlug` in
+   `src/subjects/spelling/data/content-data.js` that affects
+   `(slug, word, sentence)` for any of the 236 words. The Worker
+   validates Word Bank prompt tokens against the snapshot's
+   `wordBySlug[slug].word`, which is the exact text used to compute
+   `contentKey`; if `WORDS[i].word` and snapshot diverge, the
+   generator's preflight assertion will hard-stop the run before any
+   Gemini spend.
+
+> **Sentence audio (the 8 612 pre-PR-71 files) is out of scope.** Those
+> files are served via PR 252's `legacyBufferedAudioKey` fallback; this
+> runbook does not cover their regeneration.
+
+---
+
+## 2. Preflight checklist
+
+Run these checks before starting any generation pass.
+
+### 2.1 Environment variables
+
+In `.env` (or shell environment):
+
+- **Gemini key rotation pool.** At least one of:
+  - `GEMINI_API_KEY` (primary)
+  - `GEMINI_API_KEY_2`, `GEMINI_API_KEY_3`, ..., `GEMINI_API_KEY_N`
+    (rotation pool — generator fans these out automatically)
+  - `GEMINI_API_KEYS` (comma-separated list as a single env var)
+
+  All three name shapes are accepted; the generator merges them into a
+  single rotation pool and round-robins per request.
+- **Cloudflare reconcile credentials** (only required for
+  `reconcile` / `--from-r2-inventory` paths; not needed for plain
+  `generate` runs):
+  - `CLOUDFLARE_ACCOUNT_ID`
+  - `CLOUDFLARE_API_TOKEN` (R2 read scope)
+
+### 2.2 Tooling
+
+```bash
+# Wrangler OAuth alive
+node ./scripts/wrangler-oauth.mjs whoami
+
+# ffmpeg installed
+ffmpeg -version
+```
+
+Both commands must exit `0`. The generator runs the same checks as a
+preflight gate, so a missing tool aborts before any Gemini spend.
+
+### 2.3 Contract sanity
+
+```bash
+# Eyeball-confirm word count
+node -e "import('./src/subjects/spelling/data/word-data.js').then(m => console.log(m.WORDS.length))"
+# Expected: 236
+```
+
+The generator's preflight asserts this plus per-slug `cleanText`
+parity between `WORDS[i].word` and
+`SEEDED_SPELLING_PUBLISHED_SNAPSHOT.wordBySlug[slug].word` for all
+236 entries.
+
+---
+
+## 3. Standard run recipe
+
+Follow this sequence for any production fill. Do **not** skip the
+small-sample step. The cost of a wrong-prompt full run (472 wasted
+Gemini calls + 472 corrupt R2 objects requiring batch deletion +
+regen) far exceeds the 30-minute small-sample loop.
+
+Detailed Appendix A command reference lives in the run report
+template:
+[`docs/reports/2026-04-26-spelling-word-audio-generation-report.md`](./reports/2026-04-26-spelling-word-audio-generation-report.md)
+(§Appendix A — Command reference).
+
+### 3.1 Baseline smoke (5 min)
+
+```bash
+npm run smoke:production:spelling-audio -- --json > .spelling-audio/baseline-smoke.json
+```
+
+Pre-fill expectations: word probes report `WARN miss`;
+sentence-legacy probes pass. If sentence-legacy probes fail, **stop**
+and investigate before proceeding — that is a higher-priority
+incident than this fill.
+
+### 3.2 Small sample (15 min)
+
+```bash
+npm run spelling:word-audio -- generate --slug accident,accidentally
+```
+
+Listen to all 4 mp3s under `.spelling-audio/word-runs/<runId>/`. If
+voice quality is unacceptable for classroom use, escalate before the
+full run.
+
+### 3.3 Small-sample smoke (5 min)
+
+```bash
+npm run smoke:production:spelling-audio \
+  -- --word-sample accident,accidentally --require-word-hit \
+  --json > .spelling-audio/sample-smoke.json
+```
+
+All 4 word probes must hit; sentence-legacy probes must still pass;
+cross-account invariant probe must pass.
+
+### 3.4 Full run (60–90 min)
+
+Confirm chosen race-mitigation policy from §6 is in effect.
+
+```bash
+npm run spelling:word-audio -- generate --concurrency 4
+```
+
+No `--slug` filter → all 236 words; auto-skips the 4 already-uploaded
+from §3.2. Operator monitors logs; on transient 429/502, the script
+auto-retries.
+
+### 3.5 Post-run smoke (15 min)
+
+```bash
+npm run spelling:word-audio -- status --run-id <RUNID>
+# Expected: 472 uploaded / 0 failed
+
+npm run smoke:production:spelling-audio \
+  -- --require-word-hit \
+  --json > .spelling-audio/post-fill-smoke.json
+```
+
+Exit `EXIT_OK`. All sample word probes hit; sentence-legacy probes
+still pass; cross-account invariant holds.
+
+### 3.6 Run report (30 min)
+
+Copy the template at
+`docs/reports/2026-04-26-spelling-word-audio-generation-report.md`,
+fill in run-id, timestamps, race window chosen, totals, smoke JSON
+snapshots, and any deviations.
+
+---
+
+## 4. Resume on failure
+
+The generator state file lives at
+`.spelling-audio/word-runs/<runId>/state.json` and is the source of
+truth for resumability. Each entry records
+`status: 'pending' | 'generated' | 'uploaded' | 'failed'` plus
+`attempts` and `lastError`. Writes are atomic (`.tmp.<pid>.<n>` +
+rename) and per-entry, not just end-of-run, so a crash never loses
+more than one in-flight entry. The generator installs `SIGINT` and
+`SIGTERM` handlers that flush state before exiting.
+
+### 4.1 Re-run with the same `--run-id`
+
+```bash
+npm run spelling:word-audio -- generate --run-id <RUNID>
+```
+
+Skips entries with `status: uploaded`. Retries `failed` and `pending`
+entries.
+
+### 4.2 Inspect state
+
+```bash
+npm run spelling:word-audio -- status --run-id <RUNID>
+```
+
+Prints planned / succeeded / failed / uploaded counts and any
+`lastError` per entry.
+
+### 4.3 State-file loss → mandatory reconcile
+
+If the state file is lost (accidental `rm -rf .spelling-audio/`, OS
+sync failure, machine reset), do **not** simply re-run `generate` —
+that would re-call Gemini for every word and burn quota. Instead:
+
+```bash
+npm run spelling:word-audio -- reconcile --run-id <NEW-RUNID>
+```
+
+`reconcile` lists existing objects under
+`spelling-audio/v1/{model}/{voice}/word/` via the Cloudflare REST API
+(requires `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_API_TOKEN`) and seeds
+the new state file with `status: uploaded` for every present key.
+After reconcile, run `generate` against the same `--run-id` to fill
+any remaining gaps.
+
+`--from-r2-inventory` is the same operation rolled into a `generate`
+preflight.
+
+---
+
+## 5. Quota / cost reference
+
+> **Placeholder until the first operator run.** Fill in from the
+> completion report after first operator run; estimate ~$0.0X per
+> word audio × 472 = ~$X total one-time spend. Once the steady-state
+> cache is filled, per-month cost goes from ~$X (live calls on every
+> warmup) to ~$0 (R2 storage + Worker egress only).
+
+Quota / rotation budget is **independent** of the retry budget:
+`--max-retries 0` fails fast on real errors but still rotates keys on
+quota errors (HTTP 429 or 403 with `RESOURCE_EXHAUSTED`-style
+payload). This is intentional — a key-pool exhaustion is not a retry
+candidate, it is a different operator decision.
+
+---
+
+## 6. Live-regen race mitigation lifecycle
+
+R2 PUT is last-writer-wins; Worker `storeBufferedGeminiAudio`
+(`worker/src/tts.js:486`) calls `bucket.put(key, bytes, ...)` with no
+`onlyIf` precondition. If a learner triggers
+`tts.speak({ wordOnly: true })` (non-`cacheLookupOnly`) during the
+60–90 min full run, the Worker's live regen could overwrite a
+just-uploaded batch object with a slightly different live take —
+silently.
+
+### 6.1 Default policy: low-traffic UTC window
+
+Schedule §3.4 in an agreed low-traffic window (typically
+04:00–05:30 UTC — UK-night, mid-day in Asia-Pacific). KS2 is
+publicly accessible globally; a window is statistical, not
+structural — but it is sufficient for the 99 % case and avoids
+Worker-side complexity.
+
+Document the chosen window in the run report.
+
+### 6.2 Escalation: `WORD_ONLY_BATCH_FILL_GUARD` env-flag
+
+Use only if §6.1 cannot be honoured. Full procedure in
+[`docs/reports/2026-04-26-spelling-word-audio-generation-report.md`
+§Appendix B](./reports/2026-04-26-spelling-word-audio-generation-report.md).
+Summary:
+
+1. Open small follow-up PR adding the env-flag to Worker
+   `storeBufferedGeminiAudio` so its `bucket.put(...)` call wraps in
+   `onlyIf: { etagDoesNotMatch: '*' }` when the env var is set.
+2. Deploy via `npm run deploy`. Note commit SHA + deploy time.
+3. Run §3.4 full word-bank generation under the flag.
+4. After §3.5 post-run verification passes, **toggle off** + redeploy
+   + confirm Worker live-regen path resumes normal store behaviour.
+5. Open a follow-up TODO PR to remove the flag entirely once a
+   future audit confirms steady-state stability (no further need for
+   batch fills).
+
+The flag is **escalation only**. Do not introduce it as a default;
+each instance is a small explicit Worker change with an explicit
+removal TODO.
+
+---
+
+## 7. Where the audio plays
+
+The pre-cached word audio is consumed by the Word Bank UI lane via
+`tts.speak({ wordOnly: true })`:
+
+- `'spelling-word-bank-word-replay'` action handler at
+  `src/subjects/spelling/remote-actions.js:79` (registered in the
+  remote-actions allowlist) and
+  `src/subjects/spelling/module.js:499-509` (where the actual
+  `tts.speak({ word, wordOnly: true })` call is made).
+
+The Worker resolves the request via
+`resolveSpellingAudioRequest({ wordOnly: true, ... })` and looks up
+the cache slot keyed by `(model, voice, contentKey, slug)`.
+
+Other UI surfaces that touch `tts.speak` (e.g., dictation drill
+replay, drill replay-slow) consume the **sentence** cache lane and
+are out of scope for this runbook.
+
+---
+
+## 8. Where the contract lives
+
+The cache contract is split between the shared package and the
+Worker. Treat all four locations as a single unit when reasoning
+about contentKey or R2 key shape:
+
+- **Shared key + prompt builders** —
+  `shared/spelling-audio.js`:
+  - `SPELLING_AUDIO_VERSION` (line 4),
+    `SPELLING_AUDIO_ROOT_PREFIX` (line 6),
+    `SPELLING_AUDIO_MODEL`.
+  - `buildWordAudioAssetKey({ model, voice, contentKey, slug })` —
+    canonical R2 key builder.
+  - `buildBufferedWordSpeechPrompt({ wordText })` — canonical Gemini
+    prompt template (used by both Worker live regen and batch
+    generator; introduced by U1).
+- **Worker TTS internals** — `worker/src/tts.js`:
+  - `bufferedAudioMetadata` (line 284) — computes `contentKey`,
+    routes wordOnly vs sentence.
+  - `geminiPrompt` (line 556) — wraps
+    `buildBufferedWordSpeechPrompt` for the wordOnly branch.
+  - `storeBufferedGeminiAudio` (line 486) and
+    `readBufferedGeminiAudio` (line 386) — write/read paths against
+    R2.
+- **Worker spelling resolver** —
+  `worker/src/subjects/spelling/audio.js`:
+  - `wordBankPromptToken` (line 38) — per-learner prompt token
+    (deliberately omits accountId for cross-account R2 reuse).
+  - `resolveSpellingAudioRequest` (line 109) — the only resolver
+    path; do not modify.
+- **Canonical SHA-256 helper** — `worker/src/auth.js:156-185`:
+  - `bytesToBase64Url` (line 162) — URL-safe base64 encoding (no `=`
+    padding, `+`→`-`, `/`→`_`).
+  - `sha256(value)` (line 188) — returns base64url, **not hex**.
+
+Any future change to any of these locations triggers a regeneration;
+see §1 *When to regenerate*.
+
+---
+
+## 9. Why we use `wrangler-oauth.mjs` not raw `npx wrangler`
+
+All wrangler invocations against production go through
+`node ./scripts/wrangler-oauth.mjs <subcommand>`. The wrapper:
+
+1. Reads `WORKERS_CI` / `CLOUDFLARE_API_TOKEN` from the environment.
+2. **Cleans up `CLOUDFLARE_API_TOKEN`** when not in a Workers CI
+   context (`WORKERS_CI !== '1'`) — otherwise the local OAuth
+   credentials wrangler maintains in `~/.wrangler/` are bypassed in
+   favour of an inferior token-only auth.
+3. Spawns `npx wrangler` with the cleaned env, inheriting stdio.
+4. On Windows, uses `npx.cmd` + `shell: true` per Node 20+ EINVAL
+   hardening.
+
+Raw `npx wrangler` is acceptable only for `--local` /
+read-only operations against Miniflare. Production R2 / D1 work must
+go through the wrapper to preserve OAuth handling and the
+CI-token cleanup. The same pattern is used by `db:migrate:remote`
+(`package.json:29`) and `deploy` (`package.json:36`); the spelling
+generator follows the same convention.
+
+The `--remote` flag MUST be passed explicitly to every
+`r2 object put` invocation. `wrangler` 4.x has no documented default
+for `r2 object put`; omitting both `--remote` and `--local` may
+silently target Miniflare local persistence. The generator and any
+hand-typed commands in this runbook always pass `--remote`.
+
+---
+
+## 10. `contentKey` digest format note
+
+The `contentKey` is **base64url** (no `=` padding,
+`+`→`-`, `/`→`_`), produced by `worker/src/auth.js`
+`bytesToBase64Url`. It is **not hex**.
+
+Anyone hand-constructing or grepping R2 keys must NOT expect hex
+digests. Example shapes:
+
+- Correct (base64url): `_71BbbYsUhNeilGccY6U4YPJ8-8tMfGXZT7P6m6bkls`
+  (the `(slug:'accident', word:'accident')` fixture digest pinned in
+  `tests/spelling-word-prompt.test.js`).
+- Wrong (hex): `563d4793b7...` — the Worker would never read this
+  path.
+
+The digest matches the regex `/^[A-Za-z0-9_-]+$/` (no `=` padding,
+no `+`, no `/`).
+
+---
+
+## 11. `cleanText` normalisation rule
+
+The Worker normalises every hashable text input via:
+
+```js
+const cleanText = (value) => String(value || '').replace(/\s+/g, ' ').trim();
+```
+
+Source: `worker/src/tts.js:38-40` (and the duplicate in
+`worker/src/subjects/spelling/audio.js:7-9`). Both definitions are
+byte-equal; the helper is **not** bare `.trim()` — it collapses
+internal whitespace (NBSP `U+00A0`, double-space, tabs) to a single
+space **before** trimming, so `'accident word'` and
+`'accident  word'` both normalise to `'accident word'`.
+
+Generator MUST apply the same normalisation to both `slug` (lowercased
++ cleaned) and `word` (cleaned) before hashing. Bare `.trim()` would
+diverge silently on any NBSP-bearing or double-space-bearing input —
+the U1 + U2 fixture suites include explicit NBSP cases as a
+regression backstop. See
+`tests/spelling-word-prompt.test.js` for the pinned fixtures.


### PR DESCRIPTION
## Summary

Final unit (U5) of the KS2 Spelling Word Bank Audio Cache plan
(`docs/plans/2026-04-26-001-feat-spelling-word-audio-cache-plan.md`):

- Ships `docs/spelling-word-audio.md` — operator runbook for (re)generating the 236-word x 2-voice = 472-object Word Bank audio cache, covering when-to-regenerate triggers, preflight, standard run recipe, resume-on-failure flow, live-regen race mitigation lifecycle (default low-traffic window + `WORD_ONLY_BATCH_FILL_GUARD` escalation), contract locations, and the base64url / cleanText gotchas.
- Establishes the `docs/solutions/` directory with its FIRST entry, `learning-spelling-audio-cache-contract.md` (Compound Engineering frontmatter + convention note for subsequent entries) capturing the cache key contract evolution (pre-PR-71 -> PR 71 -> PR 252), why content-addressed, the two-source-of-truth assertion pattern, the legacy-fallback escape hatch, and the cross-account invariant smoke pattern.
- Flips plan frontmatter `status: active` -> `status: completed` and appends a close-out line crediting PRs #286 (U1), #297 (U2), #299 (U3), #302 (U4), and this PR (U5).

Test plan: markdown render check + plan-status-flip verification

- [ ] `docs/spelling-word-audio.md` renders cleanly on GitHub
- [ ] `docs/solutions/learning-spelling-audio-cache-contract.md` renders cleanly on GitHub; YAML frontmatter parses
- [ ] Plan frontmatter shows `status: completed` on GitHub
- [ ] All file-path references in the runbook resolve in this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)