### PR TITLE
fix(spelling): resolve session TTS sentence indexes canonically

### DIFF
--- a/tests/worker-tts.test.js
+++ b/tests/worker-tts.test.js
@@ -475,6 +475,60 @@ test('spelling session TTS resolves sentence index from canonical word sentences
   assert.equal(request.sentenceIndex, 5);
 });
 
+test('spelling session TTS avoids content reads when runtime word sentences are complete', async () => {
+  const learnerId = 'learner-a';
+  const sessionId = 'session-a';
+  const word = WORD_BY_SLUG.parliament;
+  const sentence = 'Parliament voted on the change.';
+  const promptToken = await sha256([
+    'spelling-prompt-v1',
+    learnerId,
+    sessionId,
+    word.slug,
+    word.word,
+    sentence,
+  ].join('|'));
+  let contentReads = 0;
+  const repository = {
+    async readSubjectRuntime() {
+      return {
+        subjectRecord: {
+          ui: {
+            phase: 'session',
+            session: {
+              id: sessionId,
+              currentCard: {
+                slug: word.slug,
+                word,
+                prompt: {
+                  sentence,
+                  cloze: '__________ voted on the change.',
+                },
+              },
+            },
+          },
+        },
+      };
+    },
+    async readSpellingRuntimeContent() {
+      contentReads += 1;
+      throw new Error('Session TTS should not read content when runtime sentences are complete.');
+    },
+  };
+
+  const request = await resolveSpellingAudioRequest({
+    repository,
+    accountId: 'adult-a',
+    body: {
+      learnerId,
+      promptToken,
+    },
+  });
+
+  assert.equal(request.sentenceIndex, 5);
+  assert.equal(contentReads, 0);
+});
+
 test('TTS route serves cached audio for lookup-only requests before selected provider fallback', async () => {
   const originalFetch = globalThis.fetch;
   let providerCalls = 0;

--- a/tests/worker-tts.test.js
+++ b/tests/worker-tts.test.js
@@ -6,6 +6,7 @@ import {
   buildSpellingWordBankAudioCue,
   resolveSpellingAudioRequest,
 } from '../worker/src/subjects/spelling/audio.js';
+import { WORD_BY_SLUG } from '../src/subjects/spelling/data/word-data.js';
 import { createWorkerRepositoryServer } from './helpers/worker-server.js';
 
 function seedAccountLearner(DB, { accountId = 'adult-a', learnerId = 'learner-a' } = {}) {
@@ -409,6 +410,69 @@ test('TTS route reads legacy batch-generated spelling audio keys', async () => {
     globalThis.fetch = originalFetch;
     server.close();
   }
+});
+
+test('spelling session TTS resolves sentence index from canonical word sentences', async () => {
+  const learnerId = 'learner-a';
+  const sessionId = 'session-a';
+  const word = WORD_BY_SLUG.parliament;
+  const sentence = 'Parliament voted on the change.';
+  const promptToken = await sha256([
+    'spelling-prompt-v1',
+    learnerId,
+    sessionId,
+    word.slug,
+    word.word,
+    sentence,
+  ].join('|'));
+  const decoratedWord = {
+    ...word,
+    sentence,
+    sentences: [sentence],
+  };
+  const repository = {
+    async readSubjectRuntime() {
+      return {
+        subjectRecord: {
+          ui: {
+            phase: 'session',
+            session: {
+              id: sessionId,
+              currentCard: {
+                slug: word.slug,
+                word: decoratedWord,
+                prompt: {
+                  sentence,
+                  cloze: '__________ voted on the change.',
+                },
+              },
+            },
+          },
+        },
+      };
+    },
+    async readSpellingRuntimeContent() {
+      return {
+        snapshot: {
+          wordBySlug: {
+            [word.slug]: word,
+          },
+        },
+      };
+    },
+  };
+
+  const request = await resolveSpellingAudioRequest({
+    repository,
+    accountId: 'adult-a',
+    body: {
+      learnerId,
+      promptToken,
+    },
+  });
+
+  assert.equal(request.sentence, sentence);
+  assert.equal(request.sentenceIndex, 5);
 });
 
 test('TTS route serves cached audio for lookup-only requests before selected provider fallback', async () => {

--- a/tests/worker-tts.test.js
+++ b/tests/worker-tts.test.js
@@ -442,6 +442,8 @@ test('spelling session TTS resolves sentence index from canonical word sentences
                 slug: word.slug,
                 word: decoratedWord,
                 prompt: {
+                  word: word.word,
+                  accepted: [word.word],
                   sentence,
                   cloze: '__________ voted on the change.',
                 },
@@ -526,6 +528,65 @@ test('spelling session TTS avoids content reads when runtime word sentences are 
   });
 
   assert.equal(request.sentenceIndex, 5);
+  assert.equal(contentReads, 0);
+});
+
+test('spelling session TTS avoids content reads for genuine single-sentence cards', async () => {
+  const learnerId = 'learner-a';
+  const sessionId = 'session-a';
+  const word = {
+    slug: 'single-card',
+    word: 'single',
+    sentence: 'The single card has one sentence.',
+    sentences: ['The single card has one sentence.'],
+  };
+  const sentence = word.sentence;
+  const promptToken = await sha256([
+    'spelling-prompt-v1',
+    learnerId,
+    sessionId,
+    word.slug,
+    word.word,
+    sentence,
+  ].join('|'));
+  let contentReads = 0;
+  const repository = {
+    async readSubjectRuntime() {
+      return {
+        subjectRecord: {
+          ui: {
+            phase: 'session',
+            session: {
+              id: sessionId,
+              currentCard: {
+                slug: word.slug,
+                word,
+                prompt: {
+                  sentence,
+                  cloze: 'The _______ card has one sentence.',
+                },
+              },
+            },
+          },
+        },
+      };
+    },
+    async readSpellingRuntimeContent() {
+      contentReads += 1;
+      throw new Error('Single-sentence runtime cards should not force canonical content reads.');
+    },
+  };
+
+  const request = await resolveSpellingAudioRequest({
+    repository,
+    accountId: 'adult-a',
+    body: {
+      learnerId,
+      promptToken,
+    },
+  });
+
+  assert.equal(request.sentenceIndex, 0);
   assert.equal(contentReads, 0);
 });
 

--- a/worker/src/subjects/spelling/audio.js
+++ b/worker/src/subjects/spelling/audio.js
@@ -8,20 +8,37 @@ function cleanText(value) {
   return String(value || '').replace(/\s+/g, ' ').trim();
 }
 
-function currentPromptParts({ learnerId, state } = {}) {
+function currentPromptParts({ learnerId, state, snapshot = null } = {}) {
   const session = state?.phase === 'session' ? state.session : null;
   const card = session?.currentCard || null;
   const word = card?.word || null;
   const sentence = cleanText(card?.prompt?.sentence);
   if (!session?.id || !word?.word || !sentence) return null;
+  const safeSlug = cleanText(word.slug || card.slug).toLowerCase();
+  const canonicalWord = safeSlug ? snapshot?.wordBySlug?.[safeSlug] : null;
+  const sentenceWord = canonicalWord || word;
   return {
     learnerId,
     sessionId: session.id,
     slug: word.slug || card.slug || '',
     word: cleanText(word.word),
     sentence,
-    sentenceIndex: resolveSentenceIndex(word, sentence),
+    sentenceIndex: resolveSentenceIndex(sentenceWord, sentence),
   };
+}
+
+async function readRuntimeSnapshot({ repository, accountId } = {}) {
+  if (!repository) return null;
+  try {
+    const contentResult = typeof repository.readSpellingRuntimeContent === 'function'
+      ? await repository.readSpellingRuntimeContent(accountId, 'spelling')
+      : await repository.readSubjectContent(accountId, 'spelling');
+    return contentResult.snapshot || resolveRuntimeSnapshot(contentResult.content, {
+      referenceBundle: SEEDED_SPELLING_CONTENT_BUNDLE,
+    });
+  } catch {
+    return null;
+  }
 }
 
 async function sessionPromptToken(parts) {
@@ -124,7 +141,8 @@ export async function resolveSpellingAudioRequest({
 
   const runtime = await repository.readSubjectRuntime(accountId, learnerId, 'spelling');
   const state = runtime.subjectRecord?.ui || null;
-  const parts = currentPromptParts({ learnerId, state });
+  const snapshot = await readRuntimeSnapshot({ repository, accountId });
+  const parts = currentPromptParts({ learnerId, state, snapshot });
   if (!parts) {
     const wordBankParts = await wordBankPromptParts({
       repository,

--- a/worker/src/subjects/spelling/audio.js
+++ b/worker/src/subjects/spelling/audio.js
@@ -12,11 +12,19 @@ function shouldResolveSessionSentenceCanonically(state = null) {
   const session = state?.phase === 'session' ? state.session : null;
   const card = session?.currentCard || null;
   const word = card?.word || null;
+  const prompt = card?.prompt || null;
   const sentence = cleanText(card?.prompt?.sentence);
   if (!word || !sentence) return false;
+  const promptWord = cleanText(prompt?.word);
+  const promptAccepted = Array.isArray(prompt?.accepted)
+    ? prompt.accepted.map((item) => cleanText(item)).filter(Boolean)
+    : [];
+  const wordValue = cleanText(word.word);
+  const promptOverridesWord = Boolean(promptWord && wordValue && promptWord !== wordValue);
+  const promptOverridesAccepted = promptAccepted.length > 0;
   const rawSentences = Array.isArray(word.sentences) ? word.sentences : [];
   const sentences = rawSentences.map((item) => cleanText(item)).filter(Boolean);
-  if (sentences.length <= 1) return true;
+  if (sentences.length <= 1) return promptOverridesWord || promptOverridesAccepted;
   return !sentences.includes(sentence);
 }
 

--- a/worker/src/subjects/spelling/audio.js
+++ b/worker/src/subjects/spelling/audio.js
@@ -8,6 +8,18 @@ function cleanText(value) {
   return String(value || '').replace(/\s+/g, ' ').trim();
 }
 
+function shouldResolveSessionSentenceCanonically(state = null) {
+  const session = state?.phase === 'session' ? state.session : null;
+  const card = session?.currentCard || null;
+  const word = card?.word || null;
+  const sentence = cleanText(card?.prompt?.sentence);
+  if (!word || !sentence) return false;
+  const rawSentences = Array.isArray(word.sentences) ? word.sentences : [];
+  const sentences = rawSentences.map((item) => cleanText(item)).filter(Boolean);
+  if (sentences.length <= 1) return true;
+  return !sentences.includes(sentence);
+}
+
 function currentPromptParts({ learnerId, state, snapshot = null } = {}) {
   const session = state?.phase === 'session' ? state.session : null;
   const card = session?.currentCard || null;
@@ -141,8 +153,11 @@ export async function resolveSpellingAudioRequest({
 
   const runtime = await repository.readSubjectRuntime(accountId, learnerId, 'spelling');
   const state = runtime.subjectRecord?.ui || null;
-  const snapshot = await readRuntimeSnapshot({ repository, accountId });
-  const parts = currentPromptParts({ learnerId, state, snapshot });
+  let parts = currentPromptParts({ learnerId, state });
+  if (parts && shouldResolveSessionSentenceCanonically(state)) {
+    const snapshot = await readRuntimeSnapshot({ repository, accountId });
+    parts = currentPromptParts({ learnerId, state, snapshot });
+  }
   if (!parts) {
     const wordBankParts = await wordBankPromptParts({
       repository,


### PR DESCRIPTION
## Summary
- Fixes spelling session TTS audio key selection by resolving `sentenceIndex` from canonical runtime word content instead of the decorated current card word.
- Preserves the existing `promptToken` contract while preventing displayed sentence 5 from falling back to legacy audio index 0.
- Adds a regression test for the `parliament` case where the displayed sentence is canonical index 5 but the decorated word only carries that one sentence.
- Refines the hot-path performance guard so single-sentence cards only lazy-load canonical content when prompt overrides indicate decoration/truncation; genuine single-sentence runtime cards stay runtime-only.
- Adds regression coverage to prove genuine single-sentence cards avoid canonical content reads.

## Test plan
- PASS: `npm test -- tests/worker-tts.test.js`
- PASS: `git diff --check -- worker/src/subjects/spelling/audio.js tests/worker-tts.test.js`
- CONCERN: `npm test` currently fails outside this hotfix on `tests/app-controller.test.js` (`controller retry preserves the current route and clears runtime boundaries`) and `tests/build-public.test.js`.
- CONCERN: `npm run check` currently fails in `audit:client` because the production client bundle contains forbidden spelling content modules: `src/subjects/spelling/data/content-data.js` and `src/subjects/spelling/data/word-data.js`.