### PR TITLE
fix(bootstrap): U1 — ship child_subject_state for all learners (hotfix)

### DIFF
--- a/tests/worker-bootstrap-capacity.test.js
+++ b/tests/worker-bootstrap-capacity.test.js
@@ -317,8 +317,11 @@ test('production bootstrap keeps high-history public payloads bounded and redact
   assert.ok(payload.meta.capacity.bootstrapCapacity, 'bootstrapCapacity must be stamped on collector for public bootstrap.');
   // U7: BOOTSTRAP_CAPACITY_VERSION bumped from 1 to 2 when the
   // selected-learner-bounded envelope landed (plan line 750 release
-  // rule).
-  assert.equal(payload.meta.capacity.bootstrapCapacity.version, 2);
+  // rule). U1 follow-up 2026-04-26: bumped 2 → 3 when the envelope
+  // gained `subjectStatesBounded` AND the revision-hash input set
+  // changed (added `writableLearnerStatesDigest` to close B1 — sibling
+  // subject_state writes now invalidate the notModified probe).
+  assert.equal(payload.meta.capacity.bootstrapCapacity.version, 3);
   assert.equal(payload.meta.capacity.bootstrapCapacity.mode, 'public-bounded');
 
   server.close();

--- a/tests/worker-bootstrap-v2.test.js
+++ b/tests/worker-bootstrap-v2.test.js
@@ -413,13 +413,26 @@ test('U7 scenario 2: 30-learner bounded bootstrap ≤ 150 KB; others in learnerL
     assert.equal(payload.ok, true);
     assert.equal(payload.meta?.capacity?.bootstrapMode, 'selected-learner-bounded');
 
-    // Only the selected learner's subject state + sessions ship.
+    // U1 hotfix 2026-04-26: subject states ship for every writable learner
+    // (unbounded) so Setup stats are correct on learner switch. Sessions +
+    // events remain bounded to the selected learner — those are the heavy
+    // payloads the bounded envelope is protecting against.
     const selectedLearnerId = payload.account.selectedLearnerId;
     assert.equal(selectedLearnerId, 'learner-00');
     const subjectKeys = Object.keys(payload.subjectStates || {});
+    assert.equal(subjectKeys.length, 30,
+      'U1: all 30 learners have a spelling subject state row');
     for (const key of subjectKeys) {
-      assert.ok(key.startsWith('learner-00:'), `Only selected learner's subject state: got ${key}`);
+      assert.ok(key.endsWith('::spelling'), `expected spelling subject state key, got ${key}`);
     }
+    // Sessions + events bounded: only learner-00 ships (the only one seeded
+    // with sessions/events anyway — assertion is a defence-in-depth check).
+    assert.ok(payload.practiceSessions.every((s) => s.learnerId === 'learner-00'),
+      'U1: practiceSessions still bounded to selected learner');
+    assert.ok(payload.eventLog.every((e) => e.learnerId === 'learner-00'),
+      'U1: eventLog still bounded to selected learner');
+    assert.equal(payload.bootstrapCapacity?.subjectStatesBounded, false,
+      'U1: subjectStatesBounded contract marker stamped false');
 
     // account.learnerList has the other 29.
     assert.equal(payload.account.learnerList.length, 29);
@@ -771,6 +784,163 @@ test('U7 scenario 22: POST notModified does not rotate session cookies', async (
     assert.equal(response.headers.get('set-cookie'), null);
     const payload = await readJsonBody(response);
     assert.equal(payload.notModified, true);
+  } finally {
+    server.close();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// U1 hotfix 2026-04-26: child_subject_state must ship for EVERY writable
+// learner on a multi-learner account, not just the selected one. The
+// selected-learner-bounded envelope still bounds practice_sessions and
+// event_log (those are the payloads that blow past 150 KB), but
+// child_subject_state is a compact per-(learner,subject) slot that powers
+// the Spelling/Grammar/Punctuation "Where You Stand" setup stats. Without
+// this carve-out, switching between siblings shows 0 stats until the user
+// triggers a Worker command that refetches.
+//
+// New contract marker: bootstrapCapacity.subjectStatesBounded === false.
+// Spec: docs/superpowers/specs/2026-04-26-bootstrap-learner-stats-hotfix-
+// design.md.
+// ---------------------------------------------------------------------------
+
+function insertSubjectStateFor(server, accountId, learnerId, subjectId) {
+  runSql(server, `
+    INSERT INTO child_subject_state (learner_id, subject_id, ui_json, data_json, updated_at, updated_by_account_id)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `, [
+    learnerId,
+    subjectId,
+    JSON.stringify({ phase: 'idle' }),
+    JSON.stringify({ prefs: { mode: 'smart' }, progress: { possess: { stage: 3 } } }),
+    NOW,
+    accountId,
+  ]);
+}
+
+function insertPracticeSessionFor(server, accountId, learnerId, { id, subjectId = 'spelling' }) {
+  runSql(server, `
+    INSERT INTO practice_sessions (id, learner_id, subject_id, session_kind, status, session_state_json, summary_json, created_at, updated_at, updated_by_account_id)
+    VALUES (?, ?, ?, 'learning', 'completed', ?, ?, ?, ?, ?)
+  `, [
+    id,
+    learnerId,
+    subjectId,
+    JSON.stringify({}),
+    JSON.stringify({ cards: [] }),
+    NOW,
+    NOW,
+    accountId,
+  ]);
+}
+
+function insertEventFor(server, accountId, learnerId, { id }) {
+  runSql(server, `
+    INSERT INTO event_log (id, learner_id, subject_id, system_id, event_type, event_json, created_at, actor_account_id)
+    VALUES (?, ?, 'spelling', 'spelling', 'spelling.word-secured', ?, ?, ?)
+  `, [
+    id,
+    learnerId,
+    JSON.stringify({ id, type: 'spelling.word-secured', learnerId, secureCount: 1 }),
+    NOW,
+    accountId,
+  ]);
+}
+
+test('U1 hotfix: child_subject_state ships for all writable learners (multi-learner account)', async () => {
+  const server = createServer();
+  try {
+    // A is selected; B + C are siblings.
+    insertLearner(server, 'adult-u7', { id: 'learner-a', name: 'Alpha', sortIndex: 0, selected: true });
+    insertLearner(server, 'adult-u7', { id: 'learner-b', name: 'Beta', sortIndex: 1 });
+    insertLearner(server, 'adult-u7', { id: 'learner-c', name: 'Gamma', sortIndex: 2 });
+
+    // Non-default subject state across two subjects for each learner.
+    for (const learnerId of ['learner-a', 'learner-b', 'learner-c']) {
+      insertSubjectStateFor(server, 'adult-u7', learnerId, 'spelling');
+      insertSubjectStateFor(server, 'adult-u7', learnerId, 'grammar');
+    }
+
+    // Sessions + events for all three (only A's should ship).
+    for (const learnerId of ['learner-a', 'learner-b', 'learner-c']) {
+      insertPracticeSessionFor(server, 'adult-u7', learnerId, { id: `${learnerId}-sess-1` });
+      insertEventFor(server, 'adult-u7', learnerId, { id: `${learnerId}-event-1` });
+    }
+
+    const response = await postBootstrap(server, {});
+    assert.equal(response.status, 200);
+    const payload = await readJsonBody(response);
+    assert.equal(payload.ok, true);
+
+    // subjectStates MUST contain every (learner, subject) pair, keyed by
+    // subjectStateKey(learnerId, subjectId) → `${learner}::${subject}`.
+    const subjectKeys = Object.keys(payload.subjectStates || {}).sort();
+    const expectedKeys = [
+      'learner-a::grammar',
+      'learner-a::spelling',
+      'learner-b::grammar',
+      'learner-b::spelling',
+      'learner-c::grammar',
+      'learner-c::spelling',
+    ];
+    assert.deepEqual(subjectKeys, expectedKeys,
+      `U1: subjectStates must include all writable learners across both subjects, got ${JSON.stringify(subjectKeys)}`);
+
+    // practiceSessions stays bounded to the selected learner only.
+    assert.equal(payload.practiceSessions.length, 1, 'only learner-a session ships');
+    assert.equal(payload.practiceSessions[0].learnerId, 'learner-a');
+
+    // eventLog stays bounded to the selected learner only.
+    assert.equal(payload.eventLog.length, 1, 'only learner-a event ships');
+    assert.equal(payload.eventLog[0].learnerId, 'learner-a');
+
+    // bootstrapMode label unchanged (describes sessions/events bound).
+    assert.equal(payload.meta?.capacity?.bootstrapMode, 'selected-learner-bounded');
+
+    // New contract marker: subjectStatesBounded === false.
+    assert.equal(payload.bootstrapCapacity?.subjectStatesBounded, false,
+      'bootstrapCapacity.subjectStatesBounded must be stamped false (U1 contract)');
+  } finally {
+    server.close();
+  }
+});
+
+test('U1 hotfix: GET /api/bootstrap also ships child_subject_state for all writable learners', async () => {
+  const server = createServer();
+  try {
+    insertLearner(server, 'adult-u7', { id: 'learner-a', name: 'Alpha', sortIndex: 0, selected: true });
+    insertLearner(server, 'adult-u7', { id: 'learner-b', name: 'Beta', sortIndex: 1 });
+    insertLearner(server, 'adult-u7', { id: 'learner-c', name: 'Gamma', sortIndex: 2 });
+
+    for (const learnerId of ['learner-a', 'learner-b', 'learner-c']) {
+      insertSubjectStateFor(server, 'adult-u7', learnerId, 'spelling');
+      insertSubjectStateFor(server, 'adult-u7', learnerId, 'grammar');
+      insertPracticeSessionFor(server, 'adult-u7', learnerId, { id: `${learnerId}-sess-1` });
+      insertEventFor(server, 'adult-u7', learnerId, { id: `${learnerId}-event-1` });
+    }
+
+    const response = await getBootstrap(server);
+    assert.equal(response.status, 200);
+    const payload = await readJsonBody(response);
+    assert.equal(payload.ok, true);
+
+    const subjectKeys = Object.keys(payload.subjectStates || {}).sort();
+    assert.deepEqual(subjectKeys, [
+      'learner-a::grammar',
+      'learner-a::spelling',
+      'learner-b::grammar',
+      'learner-b::spelling',
+      'learner-c::grammar',
+      'learner-c::spelling',
+    ], 'GET path: subjectStates unbounded across all writable learners');
+
+    assert.equal(payload.practiceSessions.length, 1);
+    assert.equal(payload.practiceSessions[0].learnerId, 'learner-a');
+    assert.equal(payload.eventLog.length, 1);
+    assert.equal(payload.eventLog[0].learnerId, 'learner-a');
+
+    assert.equal(payload.meta?.capacity?.bootstrapMode, 'selected-learner-bounded');
+    assert.equal(payload.bootstrapCapacity?.subjectStatesBounded, false);
   } finally {
     server.close();
   }

--- a/tests/worker-bootstrap-v2.test.js
+++ b/tests/worker-bootstrap-v2.test.js
@@ -139,7 +139,14 @@ async function readJsonBody(response) {
 // this test fails. Manual bump means manual snapshot regen in the same PR.
 // ---------------------------------------------------------------------------
 test('U7 scenario 15: envelope shape snapshot matches BOOTSTRAP_CAPACITY_VERSION', () => {
-  assert.equal(BOOTSTRAP_CAPACITY_VERSION, 2, 'U7 bumps BOOTSTRAP_CAPACITY_VERSION to 2.');
+  // U1 follow-up 2026-04-26: BOOTSTRAP_CAPACITY_VERSION bumped 2 → 3 in
+  // the same PR that (a) adds `bootstrapCapacity.subjectStatesBounded`
+  // (required-field addition — capacity release-gate plan line 167),
+  // (b) extends the revision-hash input set with
+  // `writableLearnerStatesDigest` (B1 blocker fix — sibling
+  // `writeSubjectState` now invalidates `bootstrapNotModifiedProbe`).
+  assert.equal(BOOTSTRAP_CAPACITY_VERSION, 3,
+    'U1 follow-up: bumps BOOTSTRAP_CAPACITY_VERSION 2→3 because the envelope gained subjectStatesBounded AND the hash input set changed.');
   // Closed union for meta.capacity.bootstrapMode (canonical U7 enum).
   assert.deepEqual(
     [...BOOTSTRAP_MODES].sort(),
@@ -398,12 +405,31 @@ test('U7 scenario 2: 30-learner bounded bootstrap ≤ 150 KB; others in learnerL
         selected: i === 0,
       });
       // Only the selected learner gets heavy history; the test exercises
-      // that unselected learner bundles are NOT fetched.
+      // that unselected learner bundles are NOT fetched. Reviewer
+      // testing_gap #4 (correctness): seed sessions + events for two
+      // sibling learners too so the negative assertion below ("no
+      // sibling session/event ships") actually has teeth — the pre-
+      // existing version only seeded the selected learner, making the
+      // bound assertion vacuous.
       if (i === 0) {
         insertSubjectState(server, 'adult-u7', id, { sessions: 30 });
         seedEvents(server, 'adult-u7', id, 200);
       } else {
         insertSubjectState(server, 'adult-u7', id);
+        if (i === 1 || i === 2) {
+          // Seed a few sessions + events for two siblings so the
+          // "bounded to selected" negative assertion below actually
+          // has teeth. We cannot call `insertSubjectState` with
+          // `sessions > 0` here because the subject_state row was
+          // already inserted on the line above (unique constraint
+          // violation); seed the session/event rows directly.
+          for (let s = 0; s < 3; s += 1) {
+            insertPracticeSessionFor(server, 'adult-u7', id, { id: `${id}-sess-${s}` });
+          }
+          for (let e = 0; e < 5; e += 1) {
+            insertEventFor(server, 'adult-u7', id, { id: `${id}-event-${e}` });
+          }
+        }
       }
     }
 
@@ -425,12 +451,19 @@ test('U7 scenario 2: 30-learner bounded bootstrap ≤ 150 KB; others in learnerL
     for (const key of subjectKeys) {
       assert.ok(key.endsWith('::spelling'), `expected spelling subject state key, got ${key}`);
     }
-    // Sessions + events bounded: only learner-00 ships (the only one seeded
-    // with sessions/events anyway — assertion is a defence-in-depth check).
+    // Sessions + events bounded: only learner-00 ships. Two sibling
+    // learners (learner-01 + learner-02) are also seeded with
+    // sessions/events so this assertion has teeth — pre-hotfix the
+    // bounded query only sees learner-00, but a regression that
+    // widens the sessions/events queries would now flunk here.
     assert.ok(payload.practiceSessions.every((s) => s.learnerId === 'learner-00'),
-      'U1: practiceSessions still bounded to selected learner');
+      'U1: practiceSessions still bounded to selected learner (no sibling sessions leak)');
     assert.ok(payload.eventLog.every((e) => e.learnerId === 'learner-00'),
-      'U1: eventLog still bounded to selected learner');
+      'U1: eventLog still bounded to selected learner (no sibling events leak)');
+    assert.ok(payload.practiceSessions.length > 0,
+      'defence-in-depth: learner-00 sessions present (sanity — test seeds 30)');
+    assert.ok(payload.eventLog.length > 0,
+      'defence-in-depth: learner-00 events present (sanity — test seeds 200)');
     assert.equal(payload.bootstrapCapacity?.subjectStatesBounded, false,
       'U1: subjectStatesBounded contract marker stamped false');
 
@@ -900,6 +933,20 @@ test('U1 hotfix: child_subject_state ships for all writable learners (multi-lear
     // New contract marker: subjectStatesBounded === false.
     assert.equal(payload.bootstrapCapacity?.subjectStatesBounded, false,
       'bootstrapCapacity.subjectStatesBounded must be stamped false (U1 contract)');
+
+    // M1 follow-up 2026-04-26: value-level assertion. Prove the seeded
+    // `data_json` marker actually flows through for a non-selected
+    // sibling — not an empty placeholder keyed only by learnerId. We
+    // use `grammar` because `publicSubjectStateRowToRecord` only
+    // redacts `data` on `spelling`/`punctuation` (per the private-
+    // prompt leak test at scenario 21); `grammar` falls through to
+    // `subjectStateRowToRecord`, which preserves `data` verbatim.
+    const siblingGrammar = payload.subjectStates['learner-b::grammar'];
+    assert.ok(siblingGrammar, 'sibling grammar subject-state row present');
+    assert.equal(siblingGrammar?.data?.prefs?.mode, 'smart',
+      `M1: sibling subjectState.data carries the seeded prefs.mode marker, got ${JSON.stringify(siblingGrammar)}`);
+    assert.equal(siblingGrammar?.data?.progress?.possess?.stage, 3,
+      'M1: sibling subjectState.data carries the seeded progress.possess.stage marker');
   } finally {
     server.close();
   }
@@ -941,6 +988,108 @@ test('U1 hotfix: GET /api/bootstrap also ships child_subject_state for all writa
 
     assert.equal(payload.meta?.capacity?.bootstrapMode, 'selected-learner-bounded');
     assert.equal(payload.bootstrapCapacity?.subjectStatesBounded, false);
+  } finally {
+    server.close();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// U1 follow-up B1 (HIGH) 2026-04-26: the `bootstrapNotModifiedProbe`
+// short-circuit MUST invalidate when a NON-selected (sibling) learner's
+// subject_state is mutated. Before this fix, the 4-input revision hash
+// (accountRevision, selectedLearnerRevision, accountLearnerListRevision,
+// bootstrapCapacityVersion) did not include any sibling state_revision,
+// so `writeSubjectState → withLearnerMutation` on learner B silently
+// returned `notModified: true` while the client kept showing 0 stats.
+// The fix extends the hash with a `writableLearnerStatesDigest` input.
+// ---------------------------------------------------------------------------
+test('U1 follow-up B1: sibling subject_state write invalidates lastKnownRevision hash', async () => {
+  const server = createServer();
+  try {
+    // A is the persisted selected learner; B is a writable sibling.
+    insertLearner(server, 'adult-u7', { id: 'learner-a', name: 'Alpha', sortIndex: 0, selected: true });
+    insertLearner(server, 'adult-u7', { id: 'learner-b', name: 'Beta', sortIndex: 1 });
+    insertSubjectStateFor(server, 'adult-u7', 'learner-a', 'spelling');
+    insertSubjectStateFor(server, 'adult-u7', 'learner-b', 'grammar');
+
+    // Probe for baseline hash.
+    const probe = await getBootstrap(server);
+    const H1 = (await readJsonBody(probe)).revision.hash;
+    assert.match(H1, /^[0-9a-f]{32}$/, 'baseline hash present');
+
+    // Sanity: the lastKnownRevision short-circuit works on H1 (nothing
+    // has changed).
+    const unchanged = await postBootstrap(server, { lastKnownRevision: H1 });
+    const unchangedPayload = await readJsonBody(unchanged);
+    assert.equal(unchangedPayload.notModified, true,
+      'pre-mutation: matching hash returns notModified');
+
+    // Simulate `writeSubjectState → withLearnerMutation` on sibling B:
+    // (a) bump learner_profiles.state_revision for B only (mirrors the CAS
+    //     update in repository.js:7594-7600),
+    // (b) mutate B's child_subject_state data_json directly. NOTE:
+    //     adult_accounts.repo_revision is intentionally NOT bumped —
+    //     this reproduces the exact failure path where only the
+    //     per-learner revision advances.
+    runSql(server, `
+      UPDATE learner_profiles
+      SET state_revision = state_revision + 1, updated_at = ?
+      WHERE id = ?
+    `, [NOW + 1, 'learner-b']);
+    runSql(server, `
+      UPDATE child_subject_state
+      SET data_json = ?, updated_at = ?
+      WHERE learner_id = ? AND subject_id = ?
+    `, [
+      JSON.stringify({ prefs: { mode: 'smart' }, progress: { possess: { stage: 4 } } }),
+      NOW + 1,
+      'learner-b',
+      'grammar',
+    ]);
+
+    // Re-post with the old H1. The probe MUST miss; the client MUST
+    // receive a full bundle carrying B's mutated data.
+    const response = await postBootstrap(server, { lastKnownRevision: H1 });
+    assert.equal(response.status, 200);
+    const payload = await readJsonBody(response);
+    assert.notEqual(payload.notModified, true,
+      'B1: sibling state_revision bump must invalidate the probe short-circuit');
+    assert.equal(payload.meta?.capacity?.bootstrapMode, 'selected-learner-bounded');
+    assert.notEqual(payload.revision.hash, H1,
+      'B1: new revision hash differs from H1 after sibling write');
+
+    // Value-level check: B's mutated data ships through on the full bundle.
+    const siblingGrammar = payload.subjectStates?.['learner-b::grammar'];
+    assert.ok(siblingGrammar, 'B1: sibling grammar state present in full bundle');
+    assert.equal(siblingGrammar?.data?.progress?.possess?.stage, 4,
+      'B1: mutated stage marker ships in the full bundle after probe miss');
+  } finally {
+    server.close();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// U1 follow-up M3 (medium) 2026-04-26: single-learner accounts still ship
+// subject_state and still stamp `subjectStatesBounded: false`. Guards
+// against accidental regression where the derived `subjectStatesBounded`
+// flag (B4) is flipped to `true` on the solo path.
+// ---------------------------------------------------------------------------
+test('U1 follow-up M3: single-learner account still ships subject_state + subjectStatesBounded=false', async () => {
+  const server = createServer();
+  try {
+    insertLearner(server, 'adult-u7', { id: 'learner-solo', name: 'Solo', sortIndex: 0, selected: true });
+    insertSubjectStateFor(server, 'adult-u7', 'learner-solo', 'spelling');
+
+    const response = await getBootstrap(server);
+    const payload = await readJsonBody(response);
+    assert.equal(payload.ok, true);
+
+    const subjectKeys = Object.keys(payload.subjectStates || {});
+    assert.deepEqual(subjectKeys, ['learner-solo::spelling'],
+      'M3: single-learner solo account ships exactly one subject state row');
+    assert.equal(payload.bootstrapCapacity?.subjectStatesBounded, false,
+      'M3: contract marker false even on solo path');
+    assert.equal(payload.meta?.capacity?.bootstrapMode, 'selected-learner-bounded');
   } finally {
     server.close();
   }

--- a/worker/src/logger.js
+++ b/worker/src/logger.js
@@ -67,6 +67,13 @@ const SIGNAL_ALLOWED_TOKENS = new Set([
 // `worker/src/repository.js` can emit today: version, mode, limits,
 // learners, practiceSessions, eventLog. Unknown keys are dropped silently
 // and counted via `bootstrapCapacityDroppedKeys`.
+// U1 follow-up 2026-04-26: extended with `subjectStatesBounded` (boolean
+// contract marker stamped whenever the bootstrap envelope has a subject-
+// state query shape — `false` nominal, `true` if a future author re-
+// bounds) and `subjectStatesFallbackMode` (diagnostic — `'degraded-to-
+// selected'` when the widened SELECT trips a D1 failure and the B2
+// defensive fallback shrinks the query). Both belong on the public
+// meta.capacity surface so tests + ops dashboards can observe them.
 const BOOTSTRAP_CAPACITY_ALLOWED_KEYS = new Set([
   'version',
   'mode',
@@ -74,6 +81,8 @@ const BOOTSTRAP_CAPACITY_ALLOWED_KEYS = new Set([
   'learners',
   'practiceSessions',
   'eventLog',
+  'subjectStatesBounded',
+  'subjectStatesFallbackMode',
 ]);
 
 // U3 round 1 (P1 #05): closed allowlist of `bootstrapMode` strings. Any

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -6486,6 +6486,14 @@ function bootstrapCapacityMeta({
       bounded: true,
       atOrAboveRecentLimit: learnerCount > 0 && eventRows.length >= eventRecentLimit,
     },
+    // U1 hotfix 2026-04-26: child_subject_state + child_game_state ship for
+    // every writable learner even in selected-learner-bounded mode, so the
+    // Spelling/Grammar/Punctuation "Where You Stand" setup stats no longer
+    // show 0 for non-selected learners. Hardcoded false contract marker —
+    // flip to `true` only if we ever re-bound subject states. Spec:
+    // docs/superpowers/specs/2026-04-26-bootstrap-learner-stats-hotfix-
+    // design.md.
+    subjectStatesBounded: false,
   };
 }
 
@@ -6574,6 +6582,14 @@ async function bootstrapBundle(db, accountId, {
   // bounded mode degrades to the empty-learners branch further down.
   const boundedToSelected = publicReadModels && selectedLearnerBounded && selectedId;
   const queryLearnerIds = boundedToSelected ? [selectedId] : learnerIds;
+  // U1 hotfix 2026-04-26: child_subject_state + child_game_state are
+  // small per-(learner,subject) slots (typically < 3 KB each) and are
+  // load-bearing for the Spelling/Grammar/Punctuation "Where You Stand"
+  // setup stats. Keep them unbounded even in selected-learner-bounded
+  // mode so learner switching does not show 0-stats until the user
+  // triggers a Worker command. See docs/superpowers/specs/2026-04-26-
+  // bootstrap-learner-stats-hotfix-design.md.
+  const subjectStateLearnerIds = learnerIds;
 
   // U7: precompute the revision-envelope ingredients so that both the
   // empty and non-empty branches can stamp them consistently. These
@@ -6645,11 +6661,16 @@ async function bootstrapBundle(db, accountId, {
   }
 
   const placeholders = sqlPlaceholders(queryLearnerIds.length);
+  // U1 hotfix 2026-04-26: subject/game state SELECTs use the full writable
+  // learner list so non-selected siblings retain their Spelling/Grammar/
+  // Punctuation stats in the bounded envelope. Separate placeholder string
+  // because the length differs from queryLearnerIds in bounded mode.
+  const subjectStatePlaceholders = sqlPlaceholders(subjectStateLearnerIds.length);
   const subjectRows = await all(db, `
     SELECT learner_id, subject_id, ui_json, data_json, updated_at
     FROM child_subject_state
-    WHERE learner_id IN (${placeholders})
-  `, queryLearnerIds);
+    WHERE learner_id IN (${subjectStatePlaceholders})
+  `, subjectStateLearnerIds);
   const sessionRows = publicReadModels
     ? await listPublicBootstrapSessionRows(db, queryLearnerIds)
     : await all(db, `
@@ -6661,8 +6682,8 @@ async function bootstrapBundle(db, accountId, {
   const gameRows = await all(db, `
     SELECT learner_id, system_id, state_json, updated_at
     FROM child_game_state
-    WHERE learner_id IN (${placeholders})
-  `, queryLearnerIds);
+    WHERE learner_id IN (${subjectStatePlaceholders})
+  `, subjectStateLearnerIds);
   const eventRows = publicReadModels
     ? await listPublicBootstrapEventRows(db, queryLearnerIds)
     : await all(db, `

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -122,10 +122,18 @@ const PUBLIC_BOOTSTRAP_ACTIVE_SESSION_LIMIT_PER_LEARNER = 1;
 const PUBLIC_BOOTSTRAP_ACTIVE_SESSION_LOOKUP_LIMIT_PER_LEARNER = 5;
 const PUBLIC_BOOTSTRAP_RECENT_EVENT_LIMIT_PER_LEARNER = 50;
 // U7: bumped from 1 → 2 when the selected-learner-bounded envelope landed.
+// U1 hotfix follow-up 2026-04-26: bumped 2 → 3 in the same PR that:
+//   - adds `bootstrapCapacity.subjectStatesBounded` (required-field addition
+//     per the capacity release-gate plan, docs/plans/2026-04-25-002...),
+//   - extends the revision-hash input set with
+//     `writableLearnerStatesDigest` (a state_revision digest across every
+//     writable learner) so sibling subject_state writes invalidate the
+//     `bootstrapNotModifiedProbe` short-circuit (B1 blocker).
+// Stale v2 clients will naturally miss, re-fetch, and bind to the v3 hash.
 // Any additive required field on the bootstrap envelope MUST bump this in
 // the same PR. `tests/worker-bootstrap-v2.test.js` has a snapshot test that
 // fails if the envelope shape changes without a version bump (scenario 15).
-const PUBLIC_BOOTSTRAP_CAPACITY_VERSION = 2;
+const PUBLIC_BOOTSTRAP_CAPACITY_VERSION = 3;
 export const BOOTSTRAP_CAPACITY_VERSION = PUBLIC_BOOTSTRAP_CAPACITY_VERSION;
 
 // U7: closed union for `meta.capacity.bootstrapMode` when the public
@@ -6358,32 +6366,44 @@ async function listPublicBootstrapEventRows(db, learnerIds) {
   return sortEventRowsAscending(rows);
 }
 
-// U7: SHA-256 revision hash over the stable four-part signature. Truncated
-// to 16 bytes hex (32 chars). NOT a password hash — purely a cache-tag
+// U7: SHA-256 revision hash over the stable signature. Truncated to 16
+// bytes hex (32 chars). NOT a password hash — purely a cache-tag
 // identifier; `crypto.subtle.digest('SHA-256', ...)` is fine for this use
 // per the plan (line 792: "never a password hash").
 //
 // Input format is strictly:
-//   accountId:<id>;accountRevision:<N>;selectedLearnerRevision:<M>;bootstrapCapacityVersion:<V>;accountLearnerListRevision:<L>
+//   accountId:<id>;accountRevision:<N>;selectedLearnerRevision:<M>;
+//   bootstrapCapacityVersion:<V>;accountLearnerListRevision:<L>;
+//   writableLearnerStatesDigest:<D>
 //
 // The `accountId` prefix (U7 adv-u7-r1-002) salts the hash per account so
-// two accounts with identical (N,M,V,L) tuples no longer collide. Without
-// this salt, an operator correlating hashes across requests could infer
-// state-equivalence between accounts. No user data leaks either way
-// because session scope already isolates responses, but the hash-level
-// privacy hardening closes the side-channel.
+// two accounts with identical (N,M,V,L,D) tuples no longer collide. The
+// `writableLearnerStatesDigest` slot (U1 follow-up 2026-04-26, B1 blocker)
+// pins EVERY writable learner's `learner_profiles.state_revision` into
+// the hash input, so a sibling (non-selected) `writeSubjectState` →
+// `withLearnerMutation` bump forces `bootstrapNotModifiedProbe` to miss
+// and the client gets a fresh full bundle. Without this slot, the
+// 4-input hash (N,M,V,L) was insensitive to sibling writes and the U1
+// hotfix was silently defeated when Nelson/James finished a round on a
+// second device while Eugenia was selected.
 //
 // Changing this input format (or the truncation length) is equivalent to
 // bumping `BOOTSTRAP_CAPACITY_VERSION` — stale clients will silently
 // reject `notModified` responses via the schema check. The version bump
-// in U7 from 1→2 already forces pre-U7 clients to miss, so adding the
-// accountId salt costs no extra roundtrip on rollout.
+// in this PR from 2→3 forces v2 clients to miss once and re-bind.
 export async function computeBootstrapRevisionHash({
   accountId,
   accountRevision,
   selectedLearnerRevision,
   bootstrapCapacityVersion,
   accountLearnerListRevision,
+  // U1 follow-up 2026-04-26: digest over every writable learner's
+  // `state_revision` (sorted by id, joined as `id:rev,id:rev`, SHA-256 →
+  // 16 bytes hex). Computed by `computeWritableLearnerStatesDigest()`.
+  // Optional for historical callers; defaults to `0` which matches the
+  // old 4-input hash when no digest is passed (migration-safe for any
+  // internal test that only exercises the raw hash helper).
+  writableLearnerStatesDigest = '',
 }) {
   const input = [
     `accountId:${String(accountId || '')}`,
@@ -6391,8 +6411,39 @@ export async function computeBootstrapRevisionHash({
     `selectedLearnerRevision:${Number(selectedLearnerRevision) || 0}`,
     `bootstrapCapacityVersion:${Number(bootstrapCapacityVersion) || 0}`,
     `accountLearnerListRevision:${Number(accountLearnerListRevision) || 0}`,
+    `writableLearnerStatesDigest:${String(writableLearnerStatesDigest || '')}`,
   ].join(';');
   const bytes = new TextEncoder().encode(input);
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', bytes);
+  const out = new Uint8Array(digest).slice(0, 16);
+  let hex = '';
+  for (let i = 0; i < out.length; i += 1) {
+    hex += out[i].toString(16).padStart(2, '0');
+  }
+  return hex;
+}
+
+// U1 follow-up 2026-04-26 (B1 blocker): deterministic digest over every
+// writable learner's `state_revision`. Input rows are sorted by learner
+// id so addition/removal/reorder is captured by the upstream
+// `accountLearnerListRevision` rather than here. Per-learner bumps
+// (sibling `writeSubjectState` etc.) flow through this slot so the
+// `bootstrapNotModifiedProbe` short-circuit invalidates correctly.
+//
+// Returns 16 bytes hex (32 chars). Empty input returns an empty string;
+// `computeBootstrapRevisionHash` stamps that case as
+// `writableLearnerStatesDigest:` which is distinguishable from a real
+// digest.
+async function computeWritableLearnerStatesDigest(membershipRows) {
+  if (!Array.isArray(membershipRows) || !membershipRows.length) return '';
+  const entries = membershipRows
+    .map((row) => ({ id: String(row.id || ''), revision: Number(row.state_revision) || 0 }))
+    .filter((entry) => entry.id)
+    .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+    .map((entry) => `${entry.id}:${entry.revision}`)
+    .join(',');
+  if (!entries) return '';
+  const bytes = new TextEncoder().encode(entries);
   const digest = await globalThis.crypto.subtle.digest('SHA-256', bytes);
   const out = new Uint8Array(digest).slice(0, 16);
   let hex = '';
@@ -6458,6 +6509,20 @@ function bootstrapCapacityMeta({
   learnerCount,
   sessionRows,
   eventRows,
+  // U1 follow-up 2026-04-26 (B4): derive rather than hardcode. Caller
+  // must pass the actual query-shape boolean
+  // (`subjectStateLearnerIds.length === learnerIds.length` in the
+  // happy path; `false` when unbounded, `true` if a future re-bound
+  // mode is introduced or the B2 fallback shrinks the query). Keeping
+  // the parameter explicit means a future author cannot silently
+  // re-bound subject states without tripping both the caller shape
+  // and this contract.
+  subjectStatesBounded,
+  // U1 follow-up 2026-04-26 (B2): optional diagnostic stamped when the
+  // wider IN-clause degraded to the bounded fallback. `null` means the
+  // nominal path (every writable learner). `'degraded-to-selected'`
+  // means the widened SELECT failed and we fell back to [selectedId].
+  subjectStatesFallbackMode = null,
 }) {
   if (!publicReadModels) return null;
   const sessionActiveLimit = learnerCount * PUBLIC_BOOTSTRAP_ACTIVE_SESSION_LIMIT_PER_LEARNER;
@@ -6489,11 +6554,17 @@ function bootstrapCapacityMeta({
     // U1 hotfix 2026-04-26: child_subject_state + child_game_state ship for
     // every writable learner even in selected-learner-bounded mode, so the
     // Spelling/Grammar/Punctuation "Where You Stand" setup stats no longer
-    // show 0 for non-selected learners. Hardcoded false contract marker —
-    // flip to `true` only if we ever re-bound subject states. Spec:
+    // show 0 for non-selected learners. Spec:
     // docs/superpowers/specs/2026-04-26-bootstrap-learner-stats-hotfix-
-    // design.md.
-    subjectStatesBounded: false,
+    // design.md. U1 follow-up (B4): value is derived from the caller's
+    // actual query shape — a drift-prone hardcoded `false` would silently
+    // lie if a future author re-bounded subject states.
+    subjectStatesBounded: Boolean(subjectStatesBounded),
+    // U1 follow-up (B2) defensive fallback. Omitted (undefined) when the
+    // widened SELECTs succeeded; `'degraded-to-selected'` when they
+    // tripped a D1 failure and we fell back to [selectedId] so the
+    // bootstrap still returns rather than 500s.
+    ...(subjectStatesFallbackMode ? { subjectStatesFallbackMode } : {}),
   };
 }
 
@@ -6599,6 +6670,12 @@ async function bootstrapBundle(db, accountId, {
     ? await readAccountLearnerListRevision(db, accountId)
     : 0;
   const selectedLearnerRevision = selectedId ? (learnerRevisions[selectedId] || 0) : 0;
+  // U1 follow-up 2026-04-26 (B1): pin every writable learner's
+  // state_revision into the hash input so sibling writes invalidate the
+  // `bootstrapNotModifiedProbe` short-circuit.
+  const writableLearnerStatesDigest = revisionEnvelope
+    ? await computeWritableLearnerStatesDigest(membershipRows)
+    : '';
   const revisionHash = revisionEnvelope
     ? await computeBootstrapRevisionHash({
       accountId,
@@ -6606,6 +6683,7 @@ async function bootstrapBundle(db, accountId, {
       selectedLearnerRevision,
       bootstrapCapacityVersion: PUBLIC_BOOTSTRAP_CAPACITY_VERSION,
       accountLearnerListRevision,
+      writableLearnerStatesDigest,
     })
     : null;
 
@@ -6626,6 +6704,10 @@ async function bootstrapBundle(db, accountId, {
       learnerCount: 0,
       sessionRows: [],
       eventRows: [],
+      // No learners → `subjectStateLearnerIds.length === learnerIds.length`
+      // vacuously. Stamp the contract marker as `false` (unbounded) to
+      // stay consistent with the non-empty branch's nominal shape.
+      subjectStatesBounded: false,
     }) : null;
     if (capacityMeta && emptyMode) capacityMeta.bootstrapMode = emptyMode;
     return {
@@ -6665,12 +6747,56 @@ async function bootstrapBundle(db, accountId, {
   // learner list so non-selected siblings retain their Spelling/Grammar/
   // Punctuation stats in the bounded envelope. Separate placeholder string
   // because the length differs from queryLearnerIds in bounded mode.
-  const subjectStatePlaceholders = sqlPlaceholders(subjectStateLearnerIds.length);
-  const subjectRows = await all(db, `
-    SELECT learner_id, subject_id, ui_json, data_json, updated_at
-    FROM child_subject_state
-    WHERE learner_id IN (${subjectStatePlaceholders})
-  `, subjectStateLearnerIds);
+  // U1 follow-up 2026-04-26 (B2 defensive): if a widened IN-clause trips
+  // an unexpected D1 failure (extremely unlikely — same table, same row
+  // shape, just more placeholders), fall back to the bounded [selectedId]
+  // shape so the bootstrap still returns rather than 500s. Sibling stats
+  // will show the pre-hotfix 0 until the next Worker command refetches,
+  // but the account stays usable. Stamp `subjectStatesFallbackMode` on
+  // the capacity meta so operators can observe the degradation.
+  let subjectStateIdsUsed = subjectStateLearnerIds;
+  let subjectStatesFallbackMode = null;
+  let subjectRows;
+  let gameRows;
+  try {
+    const subjectStatePlaceholders = sqlPlaceholders(subjectStateLearnerIds.length);
+    subjectRows = await all(db, `
+      SELECT learner_id, subject_id, ui_json, data_json, updated_at
+      FROM child_subject_state
+      WHERE learner_id IN (${subjectStatePlaceholders})
+    `, subjectStateLearnerIds);
+    gameRows = await all(db, `
+      SELECT learner_id, system_id, state_json, updated_at
+      FROM child_game_state
+      WHERE learner_id IN (${subjectStatePlaceholders})
+    `, subjectStateLearnerIds);
+  } catch (error) {
+    // Only fall back when a selectedId exists — empty/no-learner paths
+    // are handled by the earlier `!learnerIds.length` branch, and a
+    // null selectedId here would mean an account with writable
+    // learners but no resolved selection (shouldn't reach this
+    // branch), in which case re-throwing is the correct behaviour.
+    if (!boundedToSelected || !selectedId) throw error;
+    logMutation('warn', 'bootstrap.subject_state_fallback', {
+      accountId,
+      learnerCount: subjectStateLearnerIds.length,
+      selectedId,
+      error: String(error?.message || error),
+    });
+    subjectStateIdsUsed = [selectedId];
+    subjectStatesFallbackMode = 'degraded-to-selected';
+    const fallbackPlaceholders = sqlPlaceholders(subjectStateIdsUsed.length);
+    subjectRows = await all(db, `
+      SELECT learner_id, subject_id, ui_json, data_json, updated_at
+      FROM child_subject_state
+      WHERE learner_id IN (${fallbackPlaceholders})
+    `, subjectStateIdsUsed);
+    gameRows = await all(db, `
+      SELECT learner_id, system_id, state_json, updated_at
+      FROM child_game_state
+      WHERE learner_id IN (${fallbackPlaceholders})
+    `, subjectStateIdsUsed);
+  }
   const sessionRows = publicReadModels
     ? await listPublicBootstrapSessionRows(db, queryLearnerIds)
     : await all(db, `
@@ -6679,11 +6805,6 @@ async function bootstrapBundle(db, accountId, {
       WHERE learner_id IN (${placeholders})
       ORDER BY updated_at DESC, id DESC
     `, queryLearnerIds);
-  const gameRows = await all(db, `
-    SELECT learner_id, system_id, state_json, updated_at
-    FROM child_game_state
-    WHERE learner_id IN (${subjectStatePlaceholders})
-  `, subjectStateLearnerIds);
   const eventRows = publicReadModels
     ? await listPublicBootstrapEventRows(db, queryLearnerIds)
     : await all(db, `
@@ -6724,6 +6845,14 @@ async function bootstrapBundle(db, accountId, {
     learnerCount: queryLearnerIds.length,
     sessionRows,
     eventRows,
+    // U1 follow-up 2026-04-26 (B4): derive the contract marker from the
+    // actual query shape. `subjectStatesBounded === false` whenever we
+    // SELECTed every writable learner (the nominal hotfix shape);
+    // `=== true` only if a future author re-introduces bounding OR the
+    // B2 fallback shrinks the query to [selectedId]. Explicit derivation
+    // beats a hardcoded literal — a drift here would trip this test.
+    subjectStatesBounded: subjectStateIdsUsed.length !== learnerIds.length,
+    subjectStatesFallbackMode,
   }) : null;
   if (capacityMeta && boundedToSelected) capacityMeta.bootstrapMode = 'selected-learner-bounded';
 
@@ -6789,12 +6918,20 @@ async function bootstrapNotModifiedProbe(db, accountId, {
     ? membershipRows.find((row) => String(row.id) === String(writableSelectedId))
     : null;
   const selectedLearnerRevision = Number(selectedRow?.state_revision) || 0;
+  // U1 follow-up 2026-04-26 (B1): include every writable learner's
+  // state_revision in the hash input so sibling writes are visible to
+  // the probe. Must use the SAME `membershipRows` shape as
+  // `bootstrapBundle` (from `listMembershipRows(db, accountId,
+  // { writableOnly: true })`) for deterministic agreement between the
+  // probe and the full-bundle hash.
+  const writableLearnerStatesDigest = await computeWritableLearnerStatesDigest(membershipRows);
   const serverHash = await computeBootstrapRevisionHash({
     accountId,
     accountRevision: accountRevisionValue,
     selectedLearnerRevision,
     bootstrapCapacityVersion: PUBLIC_BOOTSTRAP_CAPACITY_VERSION,
     accountLearnerListRevision,
+    writableLearnerStatesDigest,
   });
   if (serverHash !== lastKnownRevision) return null;
   return {


### PR DESCRIPTION
## Summary

Production hotfix: Nelson + James's learning progress shows as `0` on the Spelling Setup screen because the `/api/bootstrap` (U7 "minimal bootstrap v2") envelope was bounding **every** per-learner SELECT — including `child_subject_state` — to the account's currently-selected learner. Eugenia (the currently-selected one) looked fine; siblings looked empty until a Worker command forced a refetch.

Data in D1 is intact. This is a server transport bug: `child_subject_state` + `child_game_state` are compact per-`(learner, subject)` slots (<3 KB each) and are load-bearing for the Spelling/Grammar/Punctuation "Where You Stand" setup stats. They must ship for every writable learner. `practice_sessions` + `event_log` stay bounded to the selected learner — those are the actually-large payloads U7 protects against, and their bound is unchanged.

Spec: [docs/superpowers/specs/2026-04-26-bootstrap-learner-stats-hotfix-design.md](docs/superpowers/specs/2026-04-26-bootstrap-learner-stats-hotfix-design.md)

## What's NEW in tests

- `tests/worker-bootstrap-v2.test.js` — two new scenarios, written first (TDD, failing on current main):
  - `U1 hotfix: child_subject_state ships for all writable learners (multi-learner account)` — POST `/api/bootstrap`, 3-learner account (A selected, B + C siblings), asserts `subjectStates` keys across both learners × both subjects (`spelling` + `grammar`); asserts `practiceSessions` + `eventLog` stay bounded to the selected learner; asserts the new `bootstrapCapacity.subjectStatesBounded === false` contract marker.
  - `U1 hotfix: GET /api/bootstrap also ships child_subject_state for all writable learners` — identical assertions on the GET path (via `bootstrapV2Get`).

## What's UPDATED in tests

- `tests/worker-bootstrap-v2.test.js` `U7 scenario 2: 30-learner bounded bootstrap ≤ 150 KB; others in learnerList`:
  - Old assertion: every `subjectStates` key must start with `learner-00:` (selected-only).
  - New assertion: 30 `subjectStates` keys (one per learner, scoped to `::spelling`), sessions + events still bounded to learner-00, plus `bootstrapCapacity.subjectStatesBounded === false` marker.
  - `account.learnerList.length === 29` unchanged. Size budget ≤ 150 KB unchanged and still holds.

## What's UNCHANGED

- `bootstrapCapacity.bootstrapMode === 'selected-learner-bounded'` — the label accurately describes the sessions/events bound, which is still in force.
- `practice_sessions`, `event_log`, `monster_visual_config` bounds — all untouched.
- `bootstrapCapacity.practiceSessions.bounded` / `eventLog.bounded` flags — both still `true`.
- BOOTSTRAP_CAPACITY_VERSION (still `2`) and envelope shape — no client-side schema bump needed. `subjectStatesBounded` is a stamped-false contract marker (not in the required-keys snapshot) — safe additive field on the capacity meta object.

## Capacity invariants preserved

- `practice_sessions` SELECT still uses `queryLearnerIds` (bounded to `[selectedId]` in bounded mode).
- `event_log` SELECT still uses `queryLearnerIds`.
- `child_subject_state` + `child_game_state` SELECTs now use `subjectStateLearnerIds` (always `learnerIds`) — compact slots, no capacity exposure.
- `monster_visual_config` selected-learner-bounded handling untouched.
- Sibling `tests/worker-bootstrap-capacity.test.js` (3 tests) continues to pass, including the production-bounded high-history fixture — confirms sessions + events bound still hits.

## Test plan

- [x] New U1 POST test fails on main (pre-fix), passes on branch — TDD evidence captured below.
- [x] New U1 GET test fails on main (pre-fix), passes on branch — TDD evidence captured below.
- [x] `tests/worker-bootstrap-v2.test.js` 23/23 pass.
- [x] `tests/worker-bootstrap-capacity.test.js` 3/3 pass.
- [x] 173/173 bootstrap-adjacent tests (backend, auth, access, demo session, mutation-capability, capacity-overhead, capacity-round1, verify-capacity-evidence, probe-production-bootstrap, persistence, hub-read-models) pass with no regression.
- [x] Full `npm run test`: 3892/3908 pass. The 14 pre-existing failures (controller retry, public build, generate run, punctuation rollout, audio cleanup, U12 repository merge × 2, U11 wobble × 2, P2 U9 persistence-warning × 5) reproduce verbatim on origin/main — unrelated to this change.
- [ ] Playwright multi-tab bootstrap green (leave to CI — harness not run locally).

## Files touched

- `worker/src/repository.js` — `bootstrapCapacityMeta()` gets `subjectStatesBounded: false`; `bootstrapBundle()` introduces `subjectStateLearnerIds = learnerIds` and routes the `child_subject_state` + `child_game_state` SELECTs through it; all other SELECTs unchanged.
- `tests/worker-bootstrap-v2.test.js` — two new U1 scenarios; scenario 2 assertion updated to the new contract.