### PR TITLE
fix(spelling): align TTS sentence index with display after PR 314

### DIFF
--- a/tests/worker-tts.test.js
+++ b/tests/worker-tts.test.js
@@ -2,11 +2,11 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { sha256 } from '../worker/src/auth.js';
+import { WORD_BY_SLUG } from '../src/subjects/spelling/data/word-data.js';
 import {
   buildSpellingWordBankAudioCue,
   resolveSpellingAudioRequest,
 } from '../worker/src/subjects/spelling/audio.js';
-import { WORD_BY_SLUG } from '../src/subjects/spelling/data/word-data.js';
 import { createWorkerRepositoryServer } from './helpers/worker-server.js';
 
 function seedAccountLearner(DB, { accountId = 'adult-a', learnerId = 'learner-a' } = {}) {
@@ -412,7 +412,7 @@ test('TTS route reads legacy batch-generated spelling audio keys', async () => {
   }
 });
 
-test('spelling session TTS resolves sentence index from canonical word sentences', async () => {
+test('spelling session TTS uses canonical sentence index when runtime carries only one sentence (no prompt.accepted)', async () => {
   const learnerId = 'learner-a';
   const sessionId = 'session-a';
   const word = WORD_BY_SLUG.parliament;
@@ -442,8 +442,6 @@ test('spelling session TTS resolves sentence index from canonical word sentences
                 slug: word.slug,
                 word: decoratedWord,
                 prompt: {
-                  word: word.word,
-                  accepted: [word.word],
                   sentence,
                   cloze: '__________ voted on the change.',
                 },
@@ -531,14 +529,14 @@ test('spelling session TTS avoids content reads when runtime word sentences are 
   assert.equal(contentReads, 0);
 });
 
-test('spelling session TTS avoids content reads for genuine single-sentence cards', async () => {
+test('spelling session TTS may read content once for a genuine single-sentence card (trade-off for correctness elsewhere)', async () => {
   const learnerId = 'learner-a';
   const sessionId = 'session-a';
   const word = {
-    slug: 'single-card',
-    word: 'single',
-    sentence: 'The single card has one sentence.',
-    sentences: ['The single card has one sentence.'],
+    slug: 'genuine-one',
+    word: 'only',
+    sentence: 'A single-sentence item.',
+    sentences: ['A single-sentence item.'],
   };
   const sentence = word.sentence;
   const promptToken = await sha256([
@@ -561,10 +559,7 @@ test('spelling session TTS avoids content reads for genuine single-sentence card
               currentCard: {
                 slug: word.slug,
                 word,
-                prompt: {
-                  sentence,
-                  cloze: 'The _______ card has one sentence.',
-                },
+                prompt: { sentence, cloze: 'A _________-sentence item.' },
               },
             },
           },
@@ -573,21 +568,18 @@ test('spelling session TTS avoids content reads for genuine single-sentence card
     },
     async readSpellingRuntimeContent() {
       contentReads += 1;
-      throw new Error('Single-sentence runtime cards should not force canonical content reads.');
+      return { snapshot: { wordBySlug: { [word.slug]: word } } };
     },
   };
 
   const request = await resolveSpellingAudioRequest({
     repository,
     accountId: 'adult-a',
-    body: {
-      learnerId,
-      promptToken,
-    },
+    body: { learnerId, promptToken },
   });
 
   assert.equal(request.sentenceIndex, 0);
-  assert.equal(contentReads, 0);
+  assert.equal(contentReads, 1);
 });
 
 test('TTS route serves cached audio for lookup-only requests before selected provider fallback', async () => {

--- a/worker/src/subjects/spelling/audio.js
+++ b/worker/src/subjects/spelling/audio.js
@@ -8,23 +8,25 @@ function cleanText(value) {
   return String(value || '').replace(/\s+/g, ' ').trim();
 }
 
+/**
+ * The session card can carry a `wordForPrompt` view-model where `word.sentences`
+ * is collapsed to a single display sentence, which makes `resolveSentenceIndex` fall
+ * back to 0. We only trust `word.sentences` when it clearly contains the active
+ * sentence in a list with more than one entry.
+ *
+ * Do not use `prompt.accepted` (or other prompt fields) to infer truncation:
+ * stored runtime prompts may legitimately omit those fields, which would skip the
+ * canonical snapshot and reintroduce the wrong-audio key bug.
+ */
 function shouldResolveSessionSentenceCanonically(state = null) {
   const session = state?.phase === 'session' ? state.session : null;
   const card = session?.currentCard || null;
   const word = card?.word || null;
-  const prompt = card?.prompt || null;
   const sentence = cleanText(card?.prompt?.sentence);
   if (!word || !sentence) return false;
-  const promptWord = cleanText(prompt?.word);
-  const promptAccepted = Array.isArray(prompt?.accepted)
-    ? prompt.accepted.map((item) => cleanText(item)).filter(Boolean)
-    : [];
-  const wordValue = cleanText(word.word);
-  const promptOverridesWord = Boolean(promptWord && wordValue && promptWord !== wordValue);
-  const promptOverridesAccepted = promptAccepted.length > 0;
   const rawSentences = Array.isArray(word.sentences) ? word.sentences : [];
   const sentences = rawSentences.map((item) => cleanText(item)).filter(Boolean);
-  if (sentences.length <= 1) return promptOverridesWord || promptOverridesAccepted;
+  if (sentences.length <= 1) return true;
   return !sentences.includes(sentence);
 }
 


### PR DESCRIPTION
## Summary
PR 314 introduced a performance optimisation that used `prompt.accepted` / word overrides to decide whether to call `readRuntimeSnapshot` for the canonical `word.sentences` list. In production, persisted session prompts often omit `accepted` and `word` even when the in-memory card still has the one-sentence `wordForPrompt` view. The worker then skipped the snapshot, fell back to index 0 for R2, and the spoken sentence no longer matched the on-screen sentence.

## Changes
- **Gating:** Resolve canonically when cleaned `word.sentences` has length &lt;= 1, or when the current `sentence` text is not in that list. Do not gate on `prompt.accepted` alone.
- **Comments:** Note in `audio.js` why `prompt.accepted` is an unreliable signal for D1-persisted prompts.
- **Test:** Add a `parliament` case where the prompt only has `sentence` + `cloze` (no `word` / `accepted`); TTS must still use sentence index 5.

## Verification
`npm test -- tests/worker-tts.test.js`

Made with [Cursor](https://cursor.com)