### PR TITLE
fix(spelling): decouple events factory from word dataset (hotfix)

### DIFF
--- a/src/subjects/spelling/events.js
+++ b/src/subjects/spelling/events.js
@@ -1,4 +1,31 @@
-import { WORD_BY_SLUG as DEFAULT_WORD_BY_SLUG } from './data/word-data.js';
+// Hotfix (2026-04-26): a previous version statically imported
+// `WORD_BY_SLUG` from `./data/word-data.js` to provide a default for
+// `wordMeta`. That import dragged the full 200k-line spelling content
+// dataset (`data/word-data.js` -> `data/content-data.js`) into
+// `src/bundles/app.bundle.js` through the chain
+// `entry.jsx -> main.js -> create-app-controller -> spelling/shortcuts
+//  -> service-contract -> achievements -> events.js -> data/word-data.js`.
+// The `audit:client` check fails the deploy because the dataset modules
+// are on `FORBIDDEN_MODULES` in `scripts/audit-client-bundle.mjs`.
+//
+// Production server callers in `shared/spelling/service.js` already pass
+// `wordMeta: runtimeWordBySlug` at every call site, so they are unaffected.
+// Tests that previously relied on the implicit default now seed it once via
+// `__setDefaultSpellingWordBySlug` from
+// `tests/helpers/seed-spelling-events-default.js`.
+let __defaultWordBySlug = null;
+
+/**
+ * Seed the module-scoped fallback `wordMeta` map used by factories below.
+ * Only invoked by a test-support helper; production callers always pass
+ * `wordMeta` explicitly. Accepts `null` to clear the seed (useful in tests
+ * that need to assert the "no-map" path). Values other than objects are
+ * coerced to `null` so a misuse surfaces as "unknown slug -> null event"
+ * rather than a silent `undefined` dereference.
+ */
+export function __setDefaultSpellingWordBySlug(wordBySlug) {
+  __defaultWordBySlug = wordBySlug && typeof wordBySlug === 'object' ? wordBySlug : null;
+}
 
 export const SPELLING_EVENT_TYPES = Object.freeze({
   RETRY_CLEARED: 'spelling.retry-cleared',
@@ -21,8 +48,10 @@ function safeTimestamp(value) {
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : Date.now();
 }
 
-function wordFields(slug, wordMeta = DEFAULT_WORD_BY_SLUG) {
-  const word = wordMeta[slug];
+function wordFields(slug, wordMeta) {
+  const map = wordMeta || __defaultWordBySlug;
+  if (!map) return null;
+  const word = map[slug];
   if (!word) return null;
   return {
     wordSlug: word.slug,

--- a/src/subjects/spelling/events.js
+++ b/src/subjects/spelling/events.js
@@ -1,28 +1,13 @@
-// Hotfix (2026-04-26): a previous version statically imported
-// `WORD_BY_SLUG` from `./data/word-data.js` to provide a default for
-// `wordMeta`. That import dragged the full 200k-line spelling content
-// dataset (`data/word-data.js` -> `data/content-data.js`) into
-// `src/bundles/app.bundle.js` through the chain
-// `entry.jsx -> main.js -> create-app-controller -> spelling/shortcuts
-//  -> service-contract -> achievements -> events.js -> data/word-data.js`.
-// The `audit:client` check fails the deploy because the dataset modules
-// are on `FORBIDDEN_MODULES` in `scripts/audit-client-bundle.mjs`.
-//
-// Production server callers in `shared/spelling/service.js` already pass
-// `wordMeta: runtimeWordBySlug` at every call site, so they are unaffected.
-// Tests that previously relied on the implicit default now seed it once via
-// `__setDefaultSpellingWordBySlug` from
-// `tests/helpers/seed-spelling-events-default.js`.
+// No static import of the spelling content dataset here: it is reachable
+// from the client entry via `achievements.js` and would fail `audit:client`
+// (see scripts/audit-client-bundle.mjs FORBIDDEN_MODULES). Production
+// callers pass `wordMeta` explicitly; tests seed a default via the setter
+// below from `tests/helpers/seed-spelling-events-default.js`.
 let __defaultWordBySlug = null;
 
-/**
- * Seed the module-scoped fallback `wordMeta` map used by factories below.
- * Only invoked by a test-support helper; production callers always pass
- * `wordMeta` explicitly. Accepts `null` to clear the seed (useful in tests
- * that need to assert the "no-map" path). Values other than objects are
- * coerced to `null` so a misuse surfaces as "unknown slug -> null event"
- * rather than a silent `undefined` dereference.
- */
+// Test-only setter. Non-object inputs coerce to `null` so a misuse surfaces
+// as the documented "unknown slug -> null event" path instead of a silent
+// `undefined` dereference. In production the seed stays `null`.
 export function __setDefaultSpellingWordBySlug(wordBySlug) {
   __defaultWordBySlug = wordBySlug && typeof wordBySlug === 'object' ? wordBySlug : null;
 }

--- a/tests/bundle-audit.test.js
+++ b/tests/bundle-audit.test.js
@@ -422,24 +422,56 @@ test('worker spelling runtime imports the shared domain service instead of the b
   assert.match(browserService, /shared\/spelling\/service\.js/);
 });
 
-// Regression for the 2026-04-26 deploy failure. `src/subjects/spelling/
-// events.js` was statically importing `./data/word-data.js` to provide a
-// default for `wordMeta`. That pulled the 200k-line spelling content
-// dataset into `src/bundles/app.bundle.js` via the chain
-// `entry.jsx -> main.js -> create-app-controller -> spelling/shortcuts
-//  -> service-contract -> achievements -> events.js -> data/word-data.js`
-// and failed `audit:client` on deploy. This source-level pin fires at
-// `npm test` without a build step, so a future edit that reinstates the
-// static import is caught before it ever reaches wrangler.
-test('spelling events factory does not static-import the word dataset', async () => {
+// Regression pin for the 2026-04-26 deploy failure: events.js is reachable
+// from the client entry via achievements.js, so any reference to the
+// `./data/` dataset modules drags the full spelling content dataset into
+// `src/bundles/app.bundle.js`. The pin runs at `npm test`, so a regression
+// fails locally without waiting for `audit:client` to run on deploy.
+//
+// The regex is path-anchored (not import-keyword-anchored) so it catches
+// every reachable form: static `import`, `import ... from`, re-export
+// (`export ... from`), dynamic `await import(...)`, and side-effect
+// import. Every one of those produces an esbuild edge that `audit:client`
+// would reject, and every one of them is caught by `WORD_DATA_PIN_REGEX`.
+const WORD_DATA_PIN_REGEX = /['"]\.\/data\/(?:word-data|content-data)\.js['"]/;
+
+test('spelling events factory does not reference the spelling content dataset', async () => {
   const events = await readFile('src/subjects/spelling/events.js', 'utf8');
   assert.doesNotMatch(
     events,
-    /^\s*import[\s\S]*?['"].\/data\/word-data\.js['"]/m,
-    'src/subjects/spelling/events.js must not import ./data/word-data.js — '
-      + 'the dataset is reachable from the client entry and would inflate '
-      + 'app.bundle.js past the audit boundary (see scripts/audit-client-bundle.mjs).',
+    WORD_DATA_PIN_REGEX,
+    'src/subjects/spelling/events.js must not reference ./data/word-data.js '
+      + 'or ./data/content-data.js — the dataset is reachable from the client '
+      + 'entry and would inflate app.bundle.js past the audit boundary '
+      + '(see scripts/audit-client-bundle.mjs).',
   );
+});
+
+// Self-test: verify the pin's regex would actually catch each bypass form.
+// Without this, a future typo (e.g. `world-data` for `word-data`) silently
+// passes the pin above forever. Mirrors the positive+negative pattern used
+// by the FORBIDDEN_SHARED_PUNCTUATION_MODULES loop earlier in this file.
+const FORBIDDEN_EVENTS_DATASET_SOURCE_FIXTURES = [
+  `import { WORD_BY_SLUG } from './data/word-data.js';`,
+  `import WORDS from "./data/word-data.js";`,
+  `import { SEEDED_SPELLING_PUBLISHED_SNAPSHOT } from './data/content-data.js';`,
+  `export { WORD_BY_SLUG } from './data/word-data.js';`,
+  `const { WORD_BY_SLUG } = await import('./data/word-data.js');`,
+  `import './data/word-data.js';`,
+];
+
+for (const fixture of FORBIDDEN_EVENTS_DATASET_SOURCE_FIXTURES) {
+  test(`WORD_DATA_PIN_REGEX matches forbidden form: ${fixture}`, () => {
+    assert.match(fixture, WORD_DATA_PIN_REGEX);
+  });
+}
+
+test('WORD_DATA_PIN_REGEX does not match benign references', () => {
+  // Benign strings that should not trip the pin — a neighbouring path, a
+  // comment mentioning the module, and a different relative-path root.
+  assert.doesNotMatch(`import x from './data/other.js';`, WORD_DATA_PIN_REGEX);
+  assert.doesNotMatch(`// previously imported ./data/word-data.js here`, WORD_DATA_PIN_REGEX);
+  assert.doesNotMatch(`import x from '../data/word-data.js';`, WORD_DATA_PIN_REGEX);
 });
 
 test('worker-first asset routing keeps demo and source lockdown routes out of SPA fallback', async () => {

--- a/tests/bundle-audit.test.js
+++ b/tests/bundle-audit.test.js
@@ -422,6 +422,26 @@ test('worker spelling runtime imports the shared domain service instead of the b
   assert.match(browserService, /shared\/spelling\/service\.js/);
 });
 
+// Regression for the 2026-04-26 deploy failure. `src/subjects/spelling/
+// events.js` was statically importing `./data/word-data.js` to provide a
+// default for `wordMeta`. That pulled the 200k-line spelling content
+// dataset into `src/bundles/app.bundle.js` via the chain
+// `entry.jsx -> main.js -> create-app-controller -> spelling/shortcuts
+//  -> service-contract -> achievements -> events.js -> data/word-data.js`
+// and failed `audit:client` on deploy. This source-level pin fires at
+// `npm test` without a build step, so a future edit that reinstates the
+// static import is caught before it ever reaches wrangler.
+test('spelling events factory does not static-import the word dataset', async () => {
+  const events = await readFile('src/subjects/spelling/events.js', 'utf8');
+  assert.doesNotMatch(
+    events,
+    /^\s*import[\s\S]*?['"].\/data\/word-data\.js['"]/m,
+    'src/subjects/spelling/events.js must not import ./data/word-data.js — '
+      + 'the dataset is reachable from the client entry and would inflate '
+      + 'app.bundle.js past the audit boundary (see scripts/audit-client-bundle.mjs).',
+  );
+});
+
 test('worker-first asset routing keeps demo and source lockdown routes out of SPA fallback', async () => {
   const expectedRoutes = [
     '/api/*',

--- a/tests/bundle-audit.test.js
+++ b/tests/bundle-audit.test.js
@@ -430,10 +430,11 @@ test('worker spelling runtime imports the shared domain service instead of the b
 //
 // The regex is path-anchored (not import-keyword-anchored) so it catches
 // every reachable form: static `import`, `import ... from`, re-export
-// (`export ... from`), dynamic `await import(...)`, and side-effect
-// import. Every one of those produces an esbuild edge that `audit:client`
-// would reject, and every one of them is caught by `WORD_DATA_PIN_REGEX`.
-const WORD_DATA_PIN_REGEX = /['"]\.\/data\/(?:word-data|content-data)\.js['"]/;
+// (`export ... from`), dynamic `await import(...)`, side-effect import,
+// and template-literal dynamic import (esbuild bundles these when they
+// contain no interpolation). Every one of those produces an esbuild edge
+// that `audit:client` would reject, and every one is caught here.
+const WORD_DATA_PIN_REGEX = /['"`]\.\/data\/(?:word-data|content-data)\.js['"`]/;
 
 test('spelling events factory does not reference the spelling content dataset', async () => {
   const events = await readFile('src/subjects/spelling/events.js', 'utf8');
@@ -458,6 +459,7 @@ const FORBIDDEN_EVENTS_DATASET_SOURCE_FIXTURES = [
   `export { WORD_BY_SLUG } from './data/word-data.js';`,
   `const { WORD_BY_SLUG } = await import('./data/word-data.js');`,
   `import './data/word-data.js';`,
+  'const { WORD_BY_SLUG } = await import(`./data/word-data.js`);',
 ];
 
 for (const fixture of FORBIDDEN_EVENTS_DATASET_SOURCE_FIXTURES) {

--- a/tests/helpers/seed-spelling-events-default.js
+++ b/tests/helpers/seed-spelling-events-default.js
@@ -1,0 +1,19 @@
+// Seed the module-scoped default `wordMeta` for the spelling event factories.
+//
+// Background: `src/subjects/spelling/events.js` no longer statically imports
+// `WORD_BY_SLUG` from the content dataset, because doing so dragged the full
+// 200k-line content dataset into the production client bundle via
+// `achievements.js` -> `events.js` and failed `audit:client`. Production
+// server callers in `shared/spelling/service.js` always pass `wordMeta`
+// explicitly, so they are unaffected by the removal.
+//
+// The node test suite has ~50 call sites that previously relied on the
+// implicit default. Rather than thread `wordMeta: WORD_BY_SLUG` through
+// every call, importing this helper once at the top of a test file seeds the
+// module-scoped default. Node's `--test` runner executes each test file in a
+// child process, so the seed is scoped to the file — there is no inter-file
+// state leakage.
+import { WORD_BY_SLUG } from '../../src/subjects/spelling/data/word-data.js';
+import { __setDefaultSpellingWordBySlug } from '../../src/subjects/spelling/events.js';
+
+__setDefaultSpellingWordBySlug(WORD_BY_SLUG);

--- a/tests/helpers/seed-spelling-events-default.js
+++ b/tests/helpers/seed-spelling-events-default.js
@@ -1,18 +1,8 @@
-// Seed the module-scoped default `wordMeta` for the spelling event factories.
-//
-// Background: `src/subjects/spelling/events.js` no longer statically imports
-// `WORD_BY_SLUG` from the content dataset, because doing so dragged the full
-// 200k-line content dataset into the production client bundle via
-// `achievements.js` -> `events.js` and failed `audit:client`. Production
-// server callers in `shared/spelling/service.js` always pass `wordMeta`
-// explicitly, so they are unaffected by the removal.
-//
-// The node test suite has ~50 call sites that previously relied on the
-// implicit default. Rather than thread `wordMeta: WORD_BY_SLUG` through
-// every call, importing this helper once at the top of a test file seeds the
-// module-scoped default. Node's `--test` runner executes each test file in a
-// child process, so the seed is scoped to the file — there is no inter-file
-// state leakage.
+// Side-effect import: seeds the module-scoped `wordMeta` fallback on
+// `src/subjects/spelling/events.js` so event factories can resolve slugs
+// without every caller threading `wordMeta: WORD_BY_SLUG`. Node's `--test`
+// runs each test file in its own subprocess, so this seed is per-file and
+// does not leak across tests.
 import { WORD_BY_SLUG } from '../../src/subjects/spelling/data/word-data.js';
 import { __setDefaultSpellingWordBySlug } from '../../src/subjects/spelling/events.js';
 

--- a/tests/spelling-achievements.test.js
+++ b/tests/spelling-achievements.test.js
@@ -31,6 +31,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
+// Seed the module-scoped default `wordMeta` for the spelling event factories.
+// See tests/helpers/seed-spelling-events-default.js for the rationale.
+import './helpers/seed-spelling-events-default.js';
+
 import {
   ACHIEVEMENT_DEFINITIONS,
   ACHIEVEMENT_IDS,

--- a/tests/spelling-achievements.test.js
+++ b/tests/spelling-achievements.test.js
@@ -31,8 +31,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-// Seed the module-scoped default `wordMeta` for the spelling event factories.
-// See tests/helpers/seed-spelling-events-default.js for the rationale.
 import './helpers/seed-spelling-events-default.js';
 
 import {

--- a/tests/spelling-events-factory-contract.test.js
+++ b/tests/spelling-events-factory-contract.test.js
@@ -1,0 +1,115 @@
+// Contract tests for `src/subjects/spelling/events.js` factories and the
+// `__setDefaultSpellingWordBySlug` test-only setter introduced in the
+// 2026-04-26 hotfix that decoupled events.js from the content dataset.
+//
+// Deliberately does NOT import `tests/helpers/seed-spelling-events-default.js`
+// — these tests own the seed lifecycle via the setter and assert both the
+// seeded and unseeded paths. Node's `--test` runs each test file in its own
+// subprocess, so the setter's module-scoped state is scoped to this file
+// and cannot leak into other test files.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  __setDefaultSpellingWordBySlug,
+  createSpellingGuardianRenewedEvent,
+  createSpellingWordSecuredEvent,
+} from '../src/subjects/spelling/events.js';
+import { WORD_BY_SLUG } from '../src/subjects/spelling/data/word-data.js';
+
+const SESSION = Object.freeze({ id: 'session-1', mode: 'guardian', type: 'learning', uniqueWords: ['possess'] });
+
+// Every test resets the seed explicitly so the file's test order does not
+// affect the outcome and a future append can reorder freely.
+function resetSeed() {
+  __setDefaultSpellingWordBySlug(null);
+}
+
+test('no seed + no explicit wordMeta: factory returns null for a known slug', () => {
+  resetSeed();
+  const event = createSpellingGuardianRenewedEvent({
+    learnerId: 'a', session: SESSION, slug: 'possess', reviewLevel: 1, createdAt: 1,
+  });
+  assert.equal(event, null);
+});
+
+test('explicit wordMeta wins over the seeded default', () => {
+  // Seed a stub that maps "possess" to a fake family, then pass an explicit
+  // map with the real family for the same slug. The event must carry the
+  // explicit map's values — proving callers can override the seed.
+  __setDefaultSpellingWordBySlug({ possess: { slug: 'possess', word: 'possess', family: 'STUB', year: '5-6', spellingPool: 'core' } });
+  const explicit = { possess: { slug: 'possess', word: 'possess', family: 'REAL', year: '5-6', spellingPool: 'core' } };
+  const event = createSpellingGuardianRenewedEvent({
+    learnerId: 'a', session: SESSION, slug: 'possess', reviewLevel: 1, createdAt: 1, wordMeta: explicit,
+  });
+  assert.equal(event.family, 'REAL');
+  resetSeed();
+});
+
+test('seeded default is used when no explicit wordMeta is passed', () => {
+  __setDefaultSpellingWordBySlug(WORD_BY_SLUG);
+  const event = createSpellingGuardianRenewedEvent({
+    learnerId: 'a', session: SESSION, slug: 'possess', reviewLevel: 1, createdAt: 1,
+  });
+  assert.ok(event);
+  assert.equal(event.wordSlug, 'possess');
+  resetSeed();
+});
+
+test('__setDefaultSpellingWordBySlug(null) clears the seed', () => {
+  __setDefaultSpellingWordBySlug(WORD_BY_SLUG);
+  __setDefaultSpellingWordBySlug(null);
+  const event = createSpellingWordSecuredEvent({
+    learnerId: 'a', session: SESSION, slug: 'possess', stage: 4, createdAt: 1,
+  });
+  assert.equal(event, null);
+});
+
+// Coercion contract — every non-plain-object input must collapse to the
+// "no-map" state (factories return null). This prevents a future refactor
+// that "helpfully" accepts Maps/arrays from silently changing behaviour.
+const NON_OBJECT_INPUTS = [
+  ['undefined', undefined],
+  ['string', 'not-a-map'],
+  ['number', 42],
+  ['true', true],
+  ['false', false],
+];
+
+for (const [label, value] of NON_OBJECT_INPUTS) {
+  test(`__setDefaultSpellingWordBySlug coerces ${label} to the no-map state`, () => {
+    __setDefaultSpellingWordBySlug(WORD_BY_SLUG);
+    __setDefaultSpellingWordBySlug(value);
+    const event = createSpellingGuardianRenewedEvent({
+      learnerId: 'a', session: SESSION, slug: 'possess', reviewLevel: 1, createdAt: 1,
+    });
+    assert.equal(event, null);
+    resetSeed();
+  });
+}
+
+// Arrays and Maps DO pass `typeof === 'object'`, so they are retained by
+// the setter. The factory's `map[slug]` lookup then returns undefined
+// (Arrays: numeric-only indexing; Maps: must use `.get()`), and the
+// factory collapses to `null`. Documents the edge-case: test code that
+// misuses these shapes fails closed, not silently with wrong data.
+test('array input passes the setter but factory still returns null (fail-closed)', () => {
+  __setDefaultSpellingWordBySlug([]);
+  const event = createSpellingGuardianRenewedEvent({
+    learnerId: 'a', session: SESSION, slug: 'possess', reviewLevel: 1, createdAt: 1,
+  });
+  assert.equal(event, null);
+  resetSeed();
+});
+
+test('Map instance passes the setter but factory still returns null (fail-closed)', () => {
+  const map = new Map();
+  map.set('possess', { slug: 'possess', word: 'possess', family: 'x', year: '5-6', spellingPool: 'core' });
+  __setDefaultSpellingWordBySlug(map);
+  const event = createSpellingGuardianRenewedEvent({
+    learnerId: 'a', session: SESSION, slug: 'possess', reviewLevel: 1, createdAt: 1,
+  });
+  assert.equal(event, null);
+  resetSeed();
+});

--- a/tests/spelling-events-factory-contract.test.js
+++ b/tests/spelling-events-factory-contract.test.js
@@ -1,12 +1,7 @@
-// Contract tests for `src/subjects/spelling/events.js` factories and the
-// `__setDefaultSpellingWordBySlug` test-only setter introduced in the
-// 2026-04-26 hotfix that decoupled events.js from the content dataset.
-//
-// Deliberately does NOT import `tests/helpers/seed-spelling-events-default.js`
-// — these tests own the seed lifecycle via the setter and assert both the
-// seeded and unseeded paths. Node's `--test` runs each test file in its own
-// subprocess, so the setter's module-scoped state is scoped to this file
-// and cannot leak into other test files.
+// Contract tests for `__setDefaultSpellingWordBySlug` and the fallback
+// path in `src/subjects/spelling/events.js`. Deliberately does NOT import
+// `tests/helpers/seed-spelling-events-default.js` — these tests own the
+// seed lifecycle via the setter and assert both seeded and unseeded paths.
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
@@ -52,8 +47,13 @@ test('seeded default is used when no explicit wordMeta is passed', () => {
   const event = createSpellingGuardianRenewedEvent({
     learnerId: 'a', session: SESSION, slug: 'possess', reviewLevel: 1, createdAt: 1,
   });
-  assert.ok(event);
-  assert.equal(event.wordSlug, 'possess');
+  // Pin against the real seeded record (not just truthiness) so a future
+  // fallback stub returning `{ wordSlug: slug }` cannot pass silently.
+  const seeded = WORD_BY_SLUG.possess;
+  assert.equal(event.wordSlug, seeded.slug);
+  assert.equal(event.word, seeded.word);
+  assert.equal(event.family, seeded.family);
+  assert.equal(event.yearBand, seeded.year);
   resetSeed();
 });
 
@@ -66,9 +66,9 @@ test('__setDefaultSpellingWordBySlug(null) clears the seed', () => {
   assert.equal(event, null);
 });
 
-// Coercion contract — every non-plain-object input must collapse to the
-// "no-map" state (factories return null). This prevents a future refactor
-// that "helpfully" accepts Maps/arrays from silently changing behaviour.
+// Coercion contract — every non-object primitive must collapse to the
+// "no-map" state at the setter boundary (factories return null). Object-
+// shaped misuse (Arrays, Maps) is covered separately below.
 const NON_OBJECT_INPUTS = [
   ['undefined', undefined],
   ['string', 'not-a-map'],

--- a/tests/spelling-guardian.test.js
+++ b/tests/spelling-guardian.test.js
@@ -1,6 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
+// Seed the module-scoped default `wordMeta` for the spelling event factories.
+// See tests/helpers/seed-spelling-events-default.js for the rationale.
+import './helpers/seed-spelling-events-default.js';
+
 import {
   GUARDIAN_INTERVALS,
   GUARDIAN_MAX_REVIEW_LEVEL,

--- a/tests/spelling-guardian.test.js
+++ b/tests/spelling-guardian.test.js
@@ -1,8 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-// Seed the module-scoped default `wordMeta` for the spelling event factories.
-// See tests/helpers/seed-spelling-events-default.js for the rationale.
 import './helpers/seed-spelling-events-default.js';
 
 import {

--- a/tests/spelling-reward-subscriber.test.js
+++ b/tests/spelling-reward-subscriber.test.js
@@ -16,8 +16,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-// Seed the module-scoped default `wordMeta` for the spelling event factories.
-// See tests/helpers/seed-spelling-events-default.js for the rationale.
 import './helpers/seed-spelling-events-default.js';
 
 import {

--- a/tests/spelling-reward-subscriber.test.js
+++ b/tests/spelling-reward-subscriber.test.js
@@ -16,6 +16,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
+// Seed the module-scoped default `wordMeta` for the spelling event factories.
+// See tests/helpers/seed-spelling-events-default.js for the rationale.
+import './helpers/seed-spelling-events-default.js';
+
 import {
   SPELLING_EVENT_TYPES,
   createSpellingBossCompletedEvent,


### PR DESCRIPTION
## Summary

- Fixes the Cloudflare deploy failure (`audit:client` flagging `src/subjects/spelling/data/content-data.js` + `data/word-data.js` in the client bundle).
- Removes the static `WORD_BY_SLUG` import from `src/subjects/spelling/events.js` so the 200k-line spelling content dataset stops being pulled into `src/bundles/app.bundle.js` via the chain `entry.jsx → main.js → create-app-controller → spelling/shortcuts → service-contract → achievements → events.js → data/word-data.js`.
- Adds a source-level regression pin in `tests/bundle-audit.test.js` so `npm test` fails loudly if the static import is ever reinstated.

## Why

From the failing deploy log at `2026-04-26T17:52:34.192Z`:

```
Forbidden production-client module (full spelling content dataset): src/subjects/spelling/data/content-data.js
Forbidden production-client module (full spelling content dataset): src/subjects/spelling/data/word-data.js
Forbidden production-client module (derived word dataset): src/subjects/spelling/data/word-data.js
```

`tests/build-public.test.js` was already red on `main` for the same reason — the static `DEFAULT_WORD_BY_SLUG` default-parameter in `events.js` kept the content dataset on the esbuild input graph even after tree-shaking removed the bytes from the final bundle. The `audit:client` check inspects `inputs`, not bytes — by design, so it catches *any* path that could leak at runtime via a later code-path change.

## What changed

**Production code**
- `src/subjects/spelling/events.js`
  - Drops `import { WORD_BY_SLUG as DEFAULT_WORD_BY_SLUG } from './data/word-data.js';`
  - Adds a module-scoped `__defaultWordBySlug = null` and an opt-in `__setDefaultSpellingWordBySlug(map)` setter.
  - `wordFields(slug, wordMeta)` now reads from the explicit `wordMeta` argument, falls back to the seeded default, and returns `null` when neither is present (matches the existing "unknown slug → null event" semantics, so no behavioural change for callers).

In production the seed stays `null`. Every call site in `shared/spelling/service.js` already passes `wordMeta: runtimeWordBySlug` explicitly — 7 call sites verified across Guardian, Boss Dictation, and the submit-answer path — so no runtime behaviour changes.

**Test support**
- `tests/helpers/seed-spelling-events-default.js` (new) imports `WORD_BY_SLUG` and calls the setter. Node's `--test` runner executes each test file in its own subprocess, so the seed is scoped per-file — no inter-file state leakage.
- `tests/spelling-guardian.test.js`, `tests/spelling-achievements.test.js`, `tests/spelling-reward-subscriber.test.js` import the helper once at the top. These were the only three test files relying on the implicit default (~52 call sites total).

**Regression coverage**
- `tests/bundle-audit.test.js` adds a source-level pin: `src/subjects/spelling/events.js` must not contain `import … './data/word-data.js'`. Fires at `npm test` without needing a full build.

## Verification

- `npm run build` ✅ (bundle size unchanged at 927.0kb — minifier already dead-code-eliminated the dataset bytes; the audit inspects resolved inputs, not bytes)
- `npm run audit:client` ✅ — previously failed with three Forbidden module errors; now passes
- `node --test tests/spelling-guardian.test.js tests/spelling-reward-subscriber.test.js tests/bundle-audit.test.js` → **215/215 pass**, including the new regression test
- `npm test` → delta vs `main` baseline: 2 pre-existing failures **fixed** (`build-public.test.js` and `worker-capacity-overhead.test.js`, both of which were red on `main` for the same audit reason); 0 new failures introduced. Other pre-existing failures on `main` (e.g. `repository.js:493` `ReferenceError: current is not defined`) are unrelated and out of scope for this hotfix.

## Test plan

- [x] `npm run build && npm run audit:client` passes locally
- [x] Targeted test files all green (spelling-guardian, spelling-reward-subscriber, bundle-audit)
- [x] Full `npm test` has no new failures vs `main` baseline
- [x] Source-level regression pin fires if the static import is reinstated
- [ ] Cloudflare preview deploy succeeds once CI runs