### PR TITLE
fix(ux): disable image dragging across the webapp

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -167,6 +167,7 @@ body {
 }
 button, input, select, textarea { font: inherit; }
 a { color: inherit; }
+img { -webkit-user-drag: none; user-select: none; }
 input:focus, select:focus, textarea:focus, button:focus-visible {
   outline: 2px solid var(--ink);
   outline-offset: 2px;


### PR DESCRIPTION
## Summary
- Adds a single global CSS rule (`img { -webkit-user-drag: none; user-select: none; }`) to the reset section of `app.css`
- Prevents children from accidentally dragging monster sprites, illustrations, and icons to their desktop

## Test plan
- [ ] Open codex → try to drag a monster image → should not drag
- [ ] Open home meadow → try to drag a roaming monster → should not drag
- [ ] Open punctuation/grammar setup → try to drag any illustration → should not drag