### PR TITLE
fix(tests): U9 — assert manifestHash in any bundle chunk (Cluster H)

### DIFF
--- a/tests/build-public.test.js
+++ b/tests/build-public.test.js
@@ -26,13 +26,24 @@ test('public build emits the React app bundle entrypoint', () => {
   const manifestHash = visualManifest.match(/"manifestHash": "([^"]+)"/)?.[1] || '';
   assert.ok(manifestHash, 'expected generated monster visual manifest hash');
   // manifestHash can live in any chunk after SH2-U10 code-split (#322).
-  // Walk every .js chunk and assert at least one contains it.
-  const bundleChunks = readdirSync('dist/public/src/bundles/')
-    .filter((f) => f.endsWith('.js'))
-    .map((f) => readFileSync(`dist/public/src/bundles/${f}`, 'utf8'));
+  // Walk every .js chunk and assert (a) one contains it AND (b) app.bundle.js
+  // imports that chunk by filename, so the manifest is reachable at runtime.
+  const bundlesDir = 'dist/public/src/bundles';
+  assert.ok(existsSync(bundlesDir), 'bundles dir must exist after npm run build');
+  const chunkNames = readdirSync(bundlesDir).filter((f) => f.endsWith('.js'));
+  const chunksWithHash = chunkNames.filter((name) => {
+    const content = readFileSync(`${bundlesDir}/${name}`, 'utf8');
+    return content.includes(manifestHash);
+  });
   assert.ok(
-    bundleChunks.some((content) => content.includes(manifestHash)),
+    chunksWithHash.length > 0,
     'manifestHash must be present in at least one production bundle chunk',
+  );
+  // Entry bundle must reference (by filename) at least one chunk that contains the hash,
+  // so the manifest is actually reachable from app.bundle.js at runtime.
+  assert.ok(
+    chunksWithHash.some((name) => appBundle.includes(name)),
+    'app.bundle.js must import a chunk that contains manifestHash (orphan-chunk guard)',
   );
   assert.match(appBundle, /\/api\/admin\/monster-visual-config\/draft/);
   assert.doesNotMatch(appBundle, /__ks2(HomeSurface|CodexSurface|SubjectTopNavSurface)/);

--- a/tests/build-public.test.js
+++ b/tests/build-public.test.js
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
@@ -25,7 +25,15 @@ test('public build emits the React app bundle entrypoint', () => {
   const visualManifest = readFileSync('src/platform/game/monster-asset-manifest.js', 'utf8');
   const manifestHash = visualManifest.match(/"manifestHash": "([^"]+)"/)?.[1] || '';
   assert.ok(manifestHash, 'expected generated monster visual manifest hash');
-  assert.match(appBundle, new RegExp(manifestHash));
+  // manifestHash can live in any chunk after SH2-U10 code-split (#322).
+  // Walk every .js chunk and assert at least one contains it.
+  const bundleChunks = readdirSync('dist/public/src/bundles/')
+    .filter((f) => f.endsWith('.js'))
+    .map((f) => readFileSync(`dist/public/src/bundles/${f}`, 'utf8'));
+  assert.ok(
+    bundleChunks.some((content) => content.includes(manifestHash)),
+    'manifestHash must be present in at least one production bundle chunk',
+  );
   assert.match(appBundle, /\/api\/admin\/monster-visual-config\/draft/);
   assert.doesNotMatch(appBundle, /__ks2(HomeSurface|CodexSurface|SubjectTopNavSurface)/);
   assert.doesNotMatch(appBundle, /data-home-mount|data-subject-topnav-mount/);


### PR DESCRIPTION
## Summary

- PR #322 (SH2-U10 code-split) relocated the monster visual `manifestHash` out of `app.bundle.js` into `chunk-SZHUV5JR.js`. `tests/build-public.test.js:28` still asserted the hash against `appBundle` only, so every build failed the regex match even though the hash is present in the client bundle graph.
- Fix replaces the narrow regex with a **chunk-walk**: read every `.js` file under `dist/public/src/bundles/` and assert at least one contains `manifestHash`. Invariant preserved (manifest reaches the client) without pinning which chunk hosts it.
- Other `appBundle`-targeted assertions (home/codex/subject-topnav mount markers, SEEDED spelling content, grammar oracle tokens, admin draft endpoint) are intentionally unchanged — they must continue to be absent from the *main entry* specifically.

Design: `docs/superpowers/specs/2026-04-26-main-regression-sweep-design.md` (Cluster H, D9). Part of the 2026-04-26 main regression sweep alongside the spec PR #323. Unblocks `npm test` green on `main`.

## Test plan

- [x] `npm run build` succeeds, emits `app.bundle.js` + `chunk-SZHUV5JR.js`.
- [x] `node --test tests/build-public.test.js` — pass (1 test, ~11s).
- [ ] Reviewer sanity: confirm the other five `doesNotMatch(appBundle, …)` assertions remain unchanged (lines 38-42 in the patched file).