### PR TITLE
fix(tests): U3 — strip JSONC comments before JSON.parse (Cluster C)

### DIFF
--- a/tests/punctuation-release-smoke.test.js
+++ b/tests/punctuation-release-smoke.test.js
@@ -12,9 +12,46 @@ import {
 import { createSession } from '../worker/src/auth.js';
 import { createWorkerRepositoryServer } from './helpers/worker-server.js';
 
+// wrangler.jsonc is JSONC, not JSON: it permits `//` line comments and
+// `/* ... */` block comments that the native JSON.parse rejects. We strip
+// comments here (string-aware so we do not eat `//` inside a quoted value)
+// rather than pulling in a dependency — Wrangler itself uses jsonc-parser
+// upstream, but this single test only needs to read the `vars` block.
+function stripJsonComments(source) {
+  let result = '';
+  let inString = false;
+  let escaped = false;
+  let inLineComment = false;
+  let inBlockComment = false;
+  for (let i = 0; i < source.length; i += 1) {
+    const c = source[i];
+    const n = source[i + 1];
+    if (inLineComment) {
+      if (c === '\n') { inLineComment = false; result += c; }
+      continue;
+    }
+    if (inBlockComment) {
+      if (c === '*' && n === '/') { inBlockComment = false; i += 1; }
+      continue;
+    }
+    if (inString) {
+      result += c;
+      if (escaped) { escaped = false; continue; }
+      if (c === '\\') { escaped = true; continue; }
+      if (c === '"') inString = false;
+      continue;
+    }
+    if (c === '"') { inString = true; result += c; continue; }
+    if (c === '/' && n === '/') { inLineComment = true; i += 1; continue; }
+    if (c === '/' && n === '*') { inBlockComment = true; i += 1; continue; }
+    result += c;
+  }
+  return result;
+}
+
 async function readWranglerVars() {
   const source = await readFile(new URL('../wrangler.jsonc', import.meta.url), 'utf8');
-  return JSON.parse(source).vars || {};
+  return JSON.parse(stripJsonComments(source)).vars || {};
 }
 
 function productionServer({ punctuationEnabled = false } = {}) {


### PR DESCRIPTION
## Summary

- Fixes `Punctuation production rollout config intentionally enables the exposure gate` — it read `wrangler.jsonc` (renamed from `wrangler.toml` around 2026-04-19) and called `JSON.parse` directly, which threw `SyntaxError at position 270` on the `//` line comments.
- Adds a string-aware `stripJsonComments` helper (line + block comments) local to `tests/punctuation-release-smoke.test.js`. Wrangler itself uses `jsonc-parser` upstream; keeping the footprint local avoids a new dependency for one caller.
- Part of the 2026-04-26 main regression sweep, alongside #323 (Cluster A — `current` ReferenceError).

## Spec

`docs/superpowers/specs/2026-04-26-main-regression-sweep-design.md` — Cluster C, D3.

## Test plan

- [x] `node --test tests/punctuation-release-smoke.test.js` → 3/3 pass (target test + 2 siblings).
- [x] `npm test` → 3961/3966 pass; the 3 failures are pre-existing Cluster D (async microtask) and Cluster E (Windows EPERM rename) covered by separate units in this sweep — none involve `wrangler.jsonc` or `JSON.parse`.
- [x] No new dependency added.
- [x] Generated files untouched (`src/platform/game/monster-asset-manifest.js`, `worker/src/generated-csp-hash.js`).