### PR TITLE
fix(tests): U4 — flush microtasks in persistence-retry tests (Cluster D)

### DIFF
--- a/tests/app-controller.test.js
+++ b/tests/app-controller.test.js
@@ -23,6 +23,7 @@ import {
 import { SUBJECTS } from '../src/platform/core/subject-registry.js';
 import { normaliseGrammarReadModel } from '../src/subjects/grammar/metadata.js';
 import { installMemoryStorage } from './helpers/memory-storage.js';
+import { flushMicrotasks } from './helpers/microtasks.js';
 
 function typedFormData(value) {
   const formData = new FormData();
@@ -482,7 +483,7 @@ test('controller retry preserves the current route and clears runtime boundaries
   });
 
   controller.dispatch('persistence-retry');
-  await Promise.resolve();
+  await flushMicrotasks();
 
   assert.equal(controller.store.getState().route.screen, 'subject');
   assert.equal(controller.runtimeBoundary.list().length, 0);

--- a/tests/helpers/microtasks.js
+++ b/tests/helpers/microtasks.js
@@ -1,0 +1,12 @@
+// U4 (Cluster D): flush pending microtasks up to maxTicks. The
+// persistence-retry dispatcher chains multiple awaits (U5 storage-CAS
+// routes through navigator.locks), so one `await Promise.resolve()` is
+// insufficient; the actual depth depends on the lock-availability
+// feature detect. 8 ticks is generous headroom without introducing
+// timing-dependence.
+export async function flushMicrotasks(maxTicks = 8) {
+  for (let i = 0; i < maxTicks; i += 1) {
+    // eslint-disable-next-line no-await-in-loop -- intentional serial flush
+    await Promise.resolve();
+  }
+}

--- a/tests/route-change-audio-cleanup.test.js
+++ b/tests/route-change-audio-cleanup.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import React from 'react';
 
 import { installMemoryStorage } from './helpers/memory-storage.js';
+import { flushMicrotasks } from './helpers/microtasks.js';
 import { createLocalPlatformRepositories } from '../src/platform/core/repositories/index.js';
 import { createSubjectRuntimeBoundary } from '../src/platform/core/subject-runtime.js';
 import { SUBJECTS } from '../src/platform/core/subject-registry.js';
@@ -372,9 +373,9 @@ test('route-change audio cleanup: persistence-retry success fires BOTH stop + ab
   controller.dispatch('open-subject', { subjectId: 'spelling' });
   tts.clear();
   controller.dispatch('persistence-retry');
-  // The retry resolves on a microtask; await once to let the .then fire.
-  await Promise.resolve();
-  await Promise.resolve();
+  // The retry resolves on a microtask chain; flush generously so the
+  // .then fires regardless of the U5 storage-CAS lock-feature-detect depth.
+  await flushMicrotasks();
   assert.equal(
     tts.stopCalls.length, 1,
     'persistence-retry success: stop() must fire after the retry resolves so the audio element is released before reloadFromRepositories runs.',


### PR DESCRIPTION
## Summary

Part of the 2026-04-26 main-regression sweep (sibling to #331 for Cluster C). After PR #300 (U5 storage-CAS) switched `src/platform/core/repositories/local.js:retryPersistence` to `async function` + `await persistAllLocked`, the `.then(...)` chained off `controller.dispatch('persistence-retry')` now needs a deeper microtask flush than the two tests assumed. Product code is correct (navigator.locks requires await); only the tests under-flushed.

New helper `tests/helpers/microtasks.js` flushes up to 8 microtask ticks in a tight loop — generous headroom without timing dependence. Replaces the ad-hoc `await Promise.resolve()` chains in the two failing tests.

Fixes these previously-failing tests:
- `tests/app-controller.test.js` — `controller retry preserves the current route and clears runtime boundaries`
- `tests/route-change-audio-cleanup.test.js` — `route-change audio cleanup: persistence-retry success fires BOTH stop + abortPending`

Spec: `docs/superpowers/specs/2026-04-26-main-regression-sweep-design.md` (Cluster D, D4)

## Test plan

- [x] `node --test tests/app-controller.test.js tests/route-change-audio-cleanup.test.js` — 31/31 green
- [x] Back-to-back double-run of the same command — 31/31 green both times (no timing dependence)
- [x] `npm test` — 3960 pass / 4 fail, and all 4 failures are pre-existing pending clusters (U5 Cluster E Windows EPERM rename in `tests/build-spelling-word-audio.test.js`, U6 Cluster F benchmark p95 in `tests/worker-capacity-overhead.test.js`); none are U4-adjacent
- [x] Rebased onto latest `origin/main` (includes #327, #328)
- [x] No product-code changes; only 3 files touched (1 new helper + 2 modified tests)