### PR TITLE
fix(scripts): U5 — retry-on-EPERM for concurrent rename (Cluster E)

### DIFF
--- a/scripts/build-spelling-word-audio.mjs
+++ b/scripts/build-spelling-word-audio.mjs
@@ -388,6 +388,46 @@ export async function readStateFile(statePath) {
   }
 }
 
+// `renameWithRetry` shields `writeStateFile` from a Windows-specific race.
+// Under `Promise.all` with eight concurrent workers (see the "full simulated
+// generate run lands 472 uploaded entries" test), Windows `MoveFileEx`
+// briefly surfaces `EPERM`/`EACCES`/`EBUSY` when the target file is still
+// held open for an instant by another worker's own `rename` call. POSIX
+// `rename(2)` is atomic and does not surface these codes on this path, so
+// this retry is a no-op on Linux and macOS. Pattern follows the memory
+// playbook at `memory/project_windows_nodejs_pitfalls.md` (concurrent test
+// temp-dir races, NUL-byte merge playbook) — eight attempts with linear
+// backoff (10 / 20 / 30 / … / 80 ms), narrow error-code allowlist, anything
+// else rethrows immediately. Under contention from eight workers a single
+// state-file slot can queue 5-7 would-be overwriters behind it before the
+// OS releases the handle, so the ceiling is generous by design.
+async function renameWithRetry(from, to, maxAttempts = 8, baseDelayMs = 10) {
+  let lastErr;
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    try {
+      await rename(from, to);
+      return;
+    } catch (error) {
+      const code = error?.code;
+      // Retry only Windows-style concurrent-target contention.
+      // EPERM / EACCES / EBUSY surface when another worker in the
+      // Promise.all batch still has the target open for an instant
+      // around its own rename call. Linux/macOS `rename(2)` is
+      // atomic and would not surface these codes on this path, so
+      // the retry is a no-op on POSIX.
+      if (code !== 'EPERM' && code !== 'EACCES' && code !== 'EBUSY') {
+        throw error;
+      }
+      lastErr = error;
+      if (attempt === maxAttempts - 1) break;
+      // Small async wait so the other worker's rename completes.
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise((resolve) => setTimeout(resolve, baseDelayMs * (attempt + 1)));
+    }
+  }
+  throw lastErr;
+}
+
 // `writeStateFile` writes atomically: stage to a unique `<path>.tmp.<n>`,
 // then `rename()` over the target. POSIX `rename(2)` is atomic when source
 // and target are on the same filesystem (always true here — both under
@@ -408,7 +448,7 @@ export async function writeStateFile(statePath, state) {
   writeTmpCounter += 1;
   const tmpPath = `${statePath}.tmp.${process.pid}.${writeTmpCounter}`;
   await writeFile(tmpPath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
-  await rename(tmpPath, statePath);
+  await renameWithRetry(tmpPath, statePath);
   return payload;
 }
 


### PR DESCRIPTION
## Summary

- **Cluster E / D5** — fixes the Windows-only EPERM regression in `writeStateFile`'s atomic rename path that caused `tests/build-spelling-word-audio.test.js:350` ("full simulated generate run lands 472 uploaded entries") to land 463-467 uploaded entries instead of 472 on this Windows worktree.
- Wraps `rename(tmpPath, statePath)` with `renameWithRetry` — 8 attempts, 10/20/30/…/80 ms linear backoff, narrow allow-list for `EPERM` / `EACCES` / `EBUSY` only. All other error codes rethrow immediately so genuine failures still surface.
- POSIX `rename(2)` is atomic and does not surface these codes on this path, so the retry is a **no-op on Linux / macOS** — pure defensive widening for the 8-concurrent-worker `Promise.all` pattern that `commandGenerate` uses for per-entry state-file flushes.

## Spec

`docs/superpowers/specs/2026-04-26-main-regression-sweep-design.md` (Cluster E, D5)

## Memory

Pattern matches the playbook at `memory/project_windows_nodejs_pitfalls.md` (concurrent test temp-dir races, NUL-byte merge). Windows `MoveFileEx` surfaces EPERM when the target file is briefly still held open for an instant by another worker's own rename call; retry-on-EPERM is the documented remedy.

## Test plan

- [x] `node --test tests/build-spelling-word-audio.test.js` — green on this Windows worktree (46 / 46 pass, stable across 3 re-runs of the full-simulated test).
- [x] `npm test` — 3989 / 3992 pass. The one remaining failure (`tests/worker-capacity-overhead.test.js` — U6 benchmark threshold) is the separately-tracked Cluster F task, not caused by this change.
- [x] No other files touched — single-file diff to `scripts/build-spelling-word-audio.mjs`.
- [x] Windows-specific; POSIX CI path unaffected (retry loop enters only on EPERM / EACCES / EBUSY which POSIX `rename(2)` does not surface on atomic same-filesystem moves).