### PR TITLE
fix(audit): unbreak CF Workers Builds — _headers cache append + logout HEAD probe

### DIFF
--- a/_headers
+++ b/_headers
@@ -9,7 +9,6 @@
   Content-Security-Policy-Report-Only: default-src 'none'; script-src 'self' 'sha256-BUILD_TIME_HASH' 'strict-dynamic' https://challenges.cloudflare.com; script-src-elem 'self' 'sha256-BUILD_TIME_HASH' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com; media-src 'self' blob:; form-action 'self'; frame-ancestors 'none'; frame-src https://challenges.cloudflare.com; base-uri 'none'; object-src 'none'; manifest-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri /api/security/csp-report; report-to csp-endpoint
   Report-To: {"group":"csp-endpoint","max_age":10886400,"endpoints":[{"url":"/api/security/csp-report"}]}
   Reporting-Endpoints: csp-endpoint="/api/security/csp-report"
-  Cache-Control: no-store
 
 /assets/bundles/*
   Strict-Transport-Security: max-age=63072000; includeSubDomains

--- a/scripts/lib/headers-drift.mjs
+++ b/scripts/lib/headers-drift.mjs
@@ -108,8 +108,19 @@ export function assertHeadersBlockIsFresh(headersContent, { allowPlaceholderHash
 //   - `worker/src/security-headers.js` (`/src/bundles/*` immutable override)
 //   - `scripts/production-bundle-audit.mjs` (live HEAD checks)
 //   - `docs/operations/capacity.md` (post-deploy cache-split check)
+//
+// Note: the `/*` block intentionally carries NO `Cache-Control`. Cloudflare
+// Workers Static Assets merges matching `_headers` blocks by appending
+// distinct values for the same header name, so a `/*` `Cache-Control` is
+// concatenated onto every more-specific block (observed live as
+// `no-store, public, max-age=...` on `/manifest.webmanifest`,
+// `/assets/app-icons/*`, etc., breaking the production audit). Fallback
+// for paths matched only by `/*` is supplied by
+// `worker/src/security-headers.js::FALLBACK_CACHE_CONTROL` for any path
+// routed through `run_worker_first`; ASSETS-direct unmatched paths fall
+// back to the browser's heuristic cache, which is acceptable because
+// every cacheable asset in `dist/public` already has its own block.
 export const CACHE_SPLIT_RULES = Object.freeze([
-  { path: '/*', cacheControl: 'no-store' },
   { path: '/assets/bundles/*', cacheControl: 'public, max-age=31536000, immutable' },
   { path: '/assets/app-icons/*', cacheControl: 'public, max-age=31536000, immutable' },
   { path: '/styles/*', cacheControl: 'public, max-age=31536000, immutable' },
@@ -178,6 +189,20 @@ export function assertCacheSplitRules(headersContent, { rules = CACHE_SPLIT_RULE
       throw new Error(`Published _headers has duplicate path group: ${block.path}`);
     }
     byPath.set(block.path, block);
+  }
+  // The `/*` block must NOT carry a `Cache-Control` line. Cloudflare Workers
+  // Static Assets appends matching block headers, so a `/*` `Cache-Control`
+  // would prepend onto every more-specific block (observed live as
+  // `no-store, public, max-age=3600` on `/manifest.webmanifest`,
+  // breaking the production cache-split audit).
+  const wildcardBlock = byPath.get('/*');
+  if (wildcardBlock) {
+    const wildcardCacheLines = wildcardBlock.body.match(/^\s*Cache-Control:\s*(.+)$/gmu) || [];
+    if (wildcardCacheLines.length > 0) {
+      throw new Error(
+        `Published _headers /* block must NOT have a Cache-Control line (Cloudflare appends it onto every more-specific block); found: ${wildcardCacheLines.join(', ')}`,
+      );
+    }
   }
   for (const rule of rules) {
     const block = byPath.get(rule.path);

--- a/scripts/production-bundle-audit.mjs
+++ b/scripts/production-bundle-audit.mjs
@@ -324,7 +324,19 @@ async function auditProduction(origin) {
   for (const check of SECURITY_HEADER_CHECKS) {
     const target = new URL(check.path, base);
     try {
-      const response = await fetch(target.href, { method: 'HEAD' });
+      // Logout is a same-origin POST mutation in production
+      // (`worker/src/app.js` `/api/auth/logout` accepts POST only and gates on
+      // `requireSameOrigin`). A HEAD probe falls through and never reaches
+      // the handler that emits Clear-Site-Data, so the audit must mirror the
+      // browser's real call shape: POST + same-origin Origin + JSON content
+      // type. The handler is idempotent for unauthenticated probes —
+      // `deleteCurrentSession` is a no-op without a session cookie — so this
+      // adds no production side effect beyond an extra capacity log line.
+      const probeMethod = check.expectClearSiteData ? 'POST' : 'HEAD';
+      const probeHeaders = check.expectClearSiteData
+        ? { origin: base.origin, 'content-type': 'application/json' }
+        : undefined;
+      const response = await fetch(target.href, { method: probeMethod, headers: probeHeaders });
       if (!check.allowAnyStatus && (response.status < 200 || response.status >= 400)) {
         failures.push(`Security header HEAD check failed (${response.status}): ${target.href}`);
         continue;

--- a/tests/bundle-audit.test.js
+++ b/tests/bundle-audit.test.js
@@ -757,10 +757,14 @@ test('assertCacheSplitRules rejects duplicate path groups (adv-2)', () => {
 });
 
 test('assertCacheSplitRules rejects multiple Cache-Control lines in one block (adv-3)', () => {
+  // The `/*` block intentionally has no `Cache-Control` line — Cloudflare
+  // Workers Static Assets appends matching block headers, so a wildcard
+  // `Cache-Control` would prepend onto every more-specific block. The
+  // assertion under test (multiple `Cache-Control` in the manifest block)
+  // is unrelated to that contract and must still fire.
   const doubleCacheManifest = [
     '/*',
     '  X-Content-Type-Options: nosniff',
-    '  Cache-Control: no-store',
     '',
     '/manifest.webmanifest',
     '  Cache-Control: public, max-age=3600',


### PR DESCRIPTION
## Summary
- CI builds marked `fail` for ~6 days (100+ commits) — Worker deploy actually succeeded, but post-deploy `audit:production` failed on two independent regressions both introduced by PR #202 (commit `dfc910a`).
- Cause 1: `_headers` `/*` block `Cache-Control: no-store` got appended onto every more-specific block by Cloudflare Workers Static Assets — live `/manifest.webmanifest` returned `no-store, public, max-age=3600`, etc.
- Cause 2: audit's logout security-header check used HEAD probe, but worker handler at `worker/src/app.js:827` only accepts POST + same-origin → fallthrough never set Clear-Site-Data.

## Changes
- `_headers`: remove `/*` `Cache-Control: no-store` (specific blocks already declare their own; Worker fallback covers routed paths).
- `scripts/lib/headers-drift.mjs`: drop `/*` from `CACHE_SPLIT_RULES`; add negative assertion that `/*` must NOT carry `Cache-Control` (regression lock with explainer comment about Cloudflare append semantics).
- `scripts/production-bundle-audit.mjs`: logout probe uses POST + same-origin Origin + `application/json` content-type; other paths still HEAD.
- `tests/bundle-audit.test.js`: update adv-3 fixture so it no longer puts `Cache-Control` on `/*`.

## Verification
- `npm run build`, `assert:build-public`, `audit:client` pass.
- `tests/bundle-audit.test.js` 40/40, `tests/security-headers.test.js` 36/36 pass.
- Audit script run against live `ks2.eugnel.uk` — logout failure resolved (POST fix verified). Cache-split failures will clear once this `_headers` ships through the build pipeline.
- Full `npm test` fail count: 5 → 4 (no new failures; the 4 remaining are pre-existing on main and unrelated).

## Test plan
- [ ] Merge PR; watch the next Cloudflare Workers Build for an `audit:production` clean run on `main`.
- [ ] Curl spot-check after deploy:
  - `curl -sI https://ks2.eugnel.uk/manifest.webmanifest | grep -i cache-control` → expect single `public, max-age=3600`
  - `curl -sI https://ks2.eugnel.uk/ | grep -i cache-control` → expect single `no-store`
  - `curl -sI -X POST -H "origin: https://ks2.eugnel.uk" -H "content-type: application/json" https://ks2.eugnel.uk/api/auth/logout | grep -i clear-site-data` → expect `"cache", "cookies", "storage"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)