### PR TITLE
fix(tests): U7 — widen client-error-capture flake wait (Cluster G)

### DIFF
--- a/tests/client-error-capture.test.js
+++ b/tests/client-error-capture.test.js
@@ -407,8 +407,8 @@ test('consecutive-failure counter resets on 2xx success (Finding 4)', async (t) 
   await new Promise((resolve) => setTimeout(resolve, 20));
   assert.equal(_peekErrorCaptureBackoffState().consecutiveFailures, 1);
 
-  // Wait for the scheduled retry (~2s under failures=1, base = 2000ms, mid-jitter 0.5).
-  await new Promise((resolve) => setTimeout(resolve, 2800));
+  // Wait 4s (base=2000ms + jitter + scheduler-delay headroom under concurrent test load).
+  await new Promise((resolve) => setTimeout(resolve, 4000));
   const finalState = _peekErrorCaptureBackoffState();
   assert.equal(finalState.consecutiveFailures, 0, 'a 2xx must reset the failure counter');
   assert.equal(finalState.backoffUntil, 0, 'a 2xx must clear the backoff window');


### PR DESCRIPTION
## Summary
- `tests/client-error-capture.test.js` test `consecutive-failure counter resets on 2xx success (Finding 4)` waits 2800 ms for a scheduled retry. Under full-suite concurrent-test load on Windows, scheduler delay occasionally pushes the retry slightly past the wait (observed isolation time: 2838 ms — already over the old cap).
- Widened the wait to 4000 ms and updated the comment to explain the headroom rationale. The assertion is on eventual state (counter reset after 2xx); a larger wait cannot mask a real regression — it only absorbs scheduler noise.

## Test plan
- [x] `node --test tests/client-error-capture.test.js` — green in isolation (24/24 pass).
- [x] `npm test` run 1 — 3990 pass, 0 fail, 2 skipped.
- [x] `npm test` run 2 — 3989 pass, 1 fail (`public build emits the React app bundle entrypoint` — transient build-script flake on Windows, unrelated to this change).
- [x] `npm test` run 3 — 3990 pass, 0 fail, 2 skipped.

Spec: `docs/superpowers/specs/2026-04-26-main-regression-sweep-design.md` (Cluster G, D7).