### PR TITLE
ci(audit): U8 — promote client-bundle audit to hard PR gate

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -55,13 +55,8 @@ jobs:
         run: npm run build
 
       - name: Run client-bundle audit
-        # Known: PRE-EXISTING forbidden-import violations in src/subjects/spelling/data/
-        # (content-data.js + word-data.js imported by events.js / read-model.js / content/*.js).
-        # Tracking follow-up: sanitise spelling data imports so content/word datasets ship via
-        # Worker boundary only, not the client bundle.
-        # Until the follow-up lands, audit.yml runs as informational — it still produces
-        # artifacts + logs but does not gate PRs.
-        # SH2-U11 NOTE: this continue-on-error is TEMPORARY — remove it once spelling data
-        # imports are resolved.
-        continue-on-error: true
+        # Hard PR gate since PR #320 landed the seeded-default pattern that removed
+        # the static spelling dataset imports from src/subjects/spelling/events.js.
+        # Any PR that reintroduces a heavy dataset import into the client bundle
+        # will fail this step rather than warn in the log.
         run: npm run audit:client


### PR DESCRIPTION
## Summary

- Closes the final unit (U8) of the 2026-04-26 main regression sweep: flip `.github/workflows/audit.yml` off `continue-on-error: true`, making the client-bundle audit a hard PR gate.
- SH2-U11 (PR #321) shipped `audit.yml` with a temporary soft gate because `src/subjects/spelling/events.js` statically imported the full spelling dataset (pulled ~1.2 MB of content into the client bundle). PR #320 resolved that import chain via a seeded-default pattern, so the gate is now safe to harden.
- Replaces the TEMPORARY comment block with a short UK-English note citing PR #320 as the fix that made the hard gate safe. Locally verified `npm run build && npm run audit:client` on origin/main exits 0.

## Design context

- Spec: `docs/superpowers/specs/2026-04-26-main-regression-sweep-design.md` — Cluster "Ecosystem gap", D8.
- Closes the regression sweep: U1 (ReferenceError), U3 (wrangler parse), U4 (async microtask), U5 (Windows EPERM), U6 (benchmark threshold), U7 (client-error-capture flake), U9 (code-split manifestHash), U8 (this PR).

## Test plan

- [x] `git checkout -b fix/u8-audit-ci-hard-gate origin/main`
- [x] `npm run build` (green: 697.9kb main bundle, 145ms)
- [x] `npm run audit:client` (green: 203665 / 214000 bytes gzip; allowlist entries intact)
- [ ] CI (`Client Bundle Audit (PR)`) completes and reports success on this PR
- [ ] CI (`node-test.yml`) remains green