### PR TITLE
fix(punctuation): correct securedRewardUnits conflation in read-model

### DIFF
--- a/shared/punctuation/service.js
+++ b/shared/punctuation/service.js
@@ -453,7 +453,10 @@ function statsFromData(data, indexes = PUNCTUATION_CONTENT_INDEXES, now = Date.n
   const snaps = publishedItems.map((item) => memorySnapshot(data.progress.items[item.id], now));
   const attempts = data.progress.attempts.length;
   const correct = data.progress.attempts.filter((attempt) => attempt.correct).length;
-  const securedRewardUnits = currentPublishedRewardUnits(data, indexes);
+  const trackedRewardUnits = currentPublishedRewardUnits(data, indexes);
+  const securedRewardUnitCount = trackedRewardUnits.filter(
+    (entry) => normaliseTimestamp(entry.securedAt, 0) > 0,
+  ).length;
   return {
     total: publishedItems.length,
     secure: snaps.filter((snap) => snap.bucket === 'secure').length,
@@ -464,7 +467,8 @@ function statsFromData(data, indexes = PUNCTUATION_CONTENT_INDEXES, now = Date.n
     correct,
     accuracy: attempts ? Math.round((correct / attempts) * 100) : 0,
     publishedRewardUnits: indexes.publishedRewardUnits.length,
-    securedRewardUnits: securedRewardUnits.length,
+    trackedRewardUnits: trackedRewardUnits.length,
+    securedRewardUnits: securedRewardUnitCount,
     sessionsCompleted: data.progress.sessionsCompleted,
   };
 }

--- a/src/subjects/punctuation/read-model.js
+++ b/src/subjects/punctuation/read-model.js
@@ -438,7 +438,7 @@ export function buildPunctuationLearnerReadModel({
   const trackedRewardUnitEntries = currentPublishedRewardUnits(rewardUnits);
   const trackedRewardUnitCount = trackedRewardUnitEntries.length;
   const securedRewardUnitCount = trackedRewardUnitEntries.filter(
-    (entry) => Number.isFinite(Number(entry.securedAt)) && Number(entry.securedAt) > 0,
+    (entry) => asTs(entry.securedAt, 0) > 0,
   ).length;
   // Placeholder for U3 — deep-secure projection not yet wired.
   const deepSecuredRewardUnitCount = 0;

--- a/src/subjects/punctuation/read-model.js
+++ b/src/subjects/punctuation/read-model.js
@@ -435,7 +435,13 @@ export function buildPunctuationLearnerReadModel({
   const secureItems = itemSnapshots.filter((entry) => entry.bucket === 'secure').length;
   const dueItems = itemSnapshots.filter((entry) => entry.bucket === 'due').length;
   const weakItems = itemSnapshots.filter((entry) => entry.bucket === 'weak').length;
-  const publishedRewardUnits = currentPublishedRewardUnits(rewardUnits);
+  const trackedRewardUnitEntries = currentPublishedRewardUnits(rewardUnits);
+  const trackedRewardUnitCount = trackedRewardUnitEntries.length;
+  const securedRewardUnitCount = trackedRewardUnitEntries.filter(
+    (entry) => Number.isFinite(Number(entry.securedAt)) && Number(entry.securedAt) > 0,
+  ).length;
+  // Placeholder for U3 — deep-secure projection not yet wired.
+  const deepSecuredRewardUnitCount = 0;
   const weakestFacets = facetRows(progress, skills, nowTs);
   const skillRows = skillRowsFromAttempts(attempts, skills);
   const strengths = buildStrengths(skillRows);
@@ -504,8 +510,9 @@ export function buildPunctuationLearnerReadModel({
       subjectId: 'punctuation',
       releaseId: CURRENT_RELEASE_ID,
       totalRewardUnits: TOTAL_REWARD_UNITS,
-      trackedRewardUnits: publishedRewardUnits.length,
-      securedRewardUnits: publishedRewardUnits.length,
+      trackedRewardUnits: trackedRewardUnitCount,
+      securedRewardUnits: securedRewardUnitCount,
+      deepSecuredRewardUnits: deepSecuredRewardUnitCount,
       trackedItems: itemSnapshots.length,
       secureItems,
       dueItems,
@@ -518,7 +525,7 @@ export function buildPunctuationLearnerReadModel({
       correct,
       accuracyPercent: accuracy,
       sessionsCompleted: Math.max(0, Number(progress.sessionsCompleted) || 0),
-      securedRewardUnits: publishedRewardUnits.length,
+      securedRewardUnits: securedRewardUnitCount,
       dueItems,
       weakItems,
       lastActivityAt,
@@ -539,7 +546,7 @@ export function buildPunctuationLearnerReadModel({
       releaseId: CURRENT_RELEASE_ID,
       publishedSkillCount: PUNCTUATION_CLIENT_SKILLS.length,
       publishedRewardUnitCount: TOTAL_REWARD_UNITS,
-      trackedRewardUnitCount: publishedRewardUnits.length,
+      trackedRewardUnitCount: trackedRewardUnitCount,
       sessionCount: sessions.length,
       weakPatternCount: patterns.length,
       productionExposureStatus: 'enabled',

--- a/tests/punctuation-read-model.test.js
+++ b/tests/punctuation-read-model.test.js
@@ -136,6 +136,106 @@ test('hasEvidence ignores stored item snapshots without attempts or sessions', (
   );
 });
 
+test('three units tracked but only one has securedAt — tracked 3, secured 1', () => {
+  const now = Date.UTC(2026, 3, 25);
+  const subjectState = freshSubjectState();
+  const k1 = masteryKey('endmarks', 'sentence-endings-core');
+  const k2 = masteryKey('apostrophe', 'apostrophe-contractions-core');
+  const k3 = masteryKey('apostrophe', 'apostrophe-possession-core');
+  subjectState.data.progress.rewardUnits[k1] = {
+    masteryKey: k1,
+    releaseId: CURRENT_RELEASE_ID,
+    clusterId: 'endmarks',
+    rewardUnitId: 'sentence-endings-core',
+    securedAt: now - 10_000,
+  };
+  // Tracked but securedAt is 0 — not secured
+  subjectState.data.progress.rewardUnits[k2] = {
+    masteryKey: k2,
+    releaseId: CURRENT_RELEASE_ID,
+    clusterId: 'apostrophe',
+    rewardUnitId: 'apostrophe-contractions-core',
+    securedAt: 0,
+  };
+  // Tracked but securedAt is absent — not secured
+  subjectState.data.progress.rewardUnits[k3] = {
+    masteryKey: k3,
+    releaseId: CURRENT_RELEASE_ID,
+    clusterId: 'apostrophe',
+    rewardUnitId: 'apostrophe-possession-core',
+  };
+  const model = buildPunctuationLearnerReadModel({
+    subjectStateRecord: subjectState,
+    practiceSessions: [],
+    now: () => now,
+  });
+  assert.equal(model.progressSnapshot.trackedRewardUnits, 3, 'three entries exist in the progress store');
+  assert.equal(model.progressSnapshot.securedRewardUnits, 1, 'only the entry with a valid securedAt is secured');
+  assert.equal(model.overview.securedRewardUnits, 1, 'overview must match progressSnapshot');
+  assert.equal(model.releaseDiagnostics.trackedRewardUnitCount, 3, 'diagnostics must reflect tracked count');
+  assert.equal(model.progressSnapshot.deepSecuredRewardUnits, 0, 'deep-secured placeholder is 0 until U3');
+});
+
+test('reward unit entry with null securedAt is tracked but not secured', () => {
+  const now = Date.UTC(2026, 3, 25);
+  const subjectState = freshSubjectState();
+  const k1 = masteryKey('speech', 'speech-core');
+  subjectState.data.progress.rewardUnits[k1] = {
+    masteryKey: k1,
+    releaseId: CURRENT_RELEASE_ID,
+    clusterId: 'speech',
+    rewardUnitId: 'speech-core',
+    securedAt: null,
+  };
+  const model = buildPunctuationLearnerReadModel({
+    subjectStateRecord: subjectState,
+    practiceSessions: [],
+    now: () => now,
+  });
+  assert.equal(model.progressSnapshot.trackedRewardUnits, 1, 'entry exists so tracked');
+  assert.equal(model.progressSnapshot.securedRewardUnits, 0, 'null securedAt must not count as secured');
+  assert.equal(model.overview.securedRewardUnits, 0);
+});
+
+test('module.js pct derives from corrected securedRewardUnits, not tracked count', () => {
+  // Simulate the getDashboardStats logic from module.js using read-model output
+  const now = Date.UTC(2026, 3, 25);
+  const subjectState = freshSubjectState();
+  // Add 5 tracked units, only 2 with valid securedAt
+  const units = [
+    { clusterId: 'endmarks', rewardUnitId: 'sentence-endings-core', securedAt: now - 10_000 },
+    { clusterId: 'apostrophe', rewardUnitId: 'apostrophe-contractions-core', securedAt: now - 5_000 },
+    { clusterId: 'apostrophe', rewardUnitId: 'apostrophe-possession-core', securedAt: 0 },
+    { clusterId: 'speech', rewardUnitId: 'speech-core', securedAt: null },
+    { clusterId: 'comma_flow', rewardUnitId: 'list-commas-core' },
+  ];
+  for (const u of units) {
+    const k = masteryKey(u.clusterId, u.rewardUnitId);
+    subjectState.data.progress.rewardUnits[k] = {
+      masteryKey: k,
+      releaseId: CURRENT_RELEASE_ID,
+      clusterId: u.clusterId,
+      rewardUnitId: u.rewardUnitId,
+      ...(u.securedAt !== undefined ? { securedAt: u.securedAt } : {}),
+    };
+  }
+  const model = buildPunctuationLearnerReadModel({
+    subjectStateRecord: subjectState,
+    practiceSessions: [],
+    now: () => now,
+  });
+  // Replicate the module.js getDashboardStats formula:
+  // pct = securedRewardUnits / totalRewardUnits * 100
+  const stats = model.progressSnapshot;
+  const pct = stats.totalRewardUnits
+    ? Math.round((stats.securedRewardUnits / stats.totalRewardUnits) * 100)
+    : 0;
+  // 2 secured out of 14 total = ~14%
+  assert.equal(stats.securedRewardUnits, 2, 'only 2 of 5 tracked units have valid securedAt');
+  assert.equal(stats.trackedRewardUnits, 5);
+  assert.equal(pct, 14, 'dashboard pct must derive from secured count (2/14), not tracked count (5/14)');
+});
+
 test('fourteen published units with zero secured keeps overview and dashboard accurate', () => {
   const model = buildPunctuationLearnerReadModel({
     subjectStateRecord: freshSubjectState(),

--- a/tests/punctuation-read-model.test.js
+++ b/tests/punctuation-read-model.test.js
@@ -224,13 +224,17 @@ test('module.js pct derives from corrected securedRewardUnits, not tracked count
     practiceSessions: [],
     now: () => now,
   });
-  // Replicate the module.js getDashboardStats formula:
-  // pct = securedRewardUnits / totalRewardUnits * 100
+  // Mirrors the module.js getDashboardStats formula:
+  //   pct = securedRewardUnits / publishedRewardUnits * 100
+  // (read-model exposes publishedRewardUnitCount via releaseDiagnostics;
+  // totalRewardUnits is the same constant but the service denominator is
+  // publishedRewardUnits — use it here to stay faithful to the code path)
   const stats = model.progressSnapshot;
-  const pct = stats.totalRewardUnits
-    ? Math.round((stats.securedRewardUnits / stats.totalRewardUnits) * 100)
+  const publishedRewardUnits = model.releaseDiagnostics.publishedRewardUnitCount;
+  const pct = publishedRewardUnits
+    ? Math.round((stats.securedRewardUnits / publishedRewardUnits) * 100)
     : 0;
-  // 2 secured out of 14 total = ~14%
+  // 2 secured out of 14 published = ~14%
   assert.equal(stats.securedRewardUnits, 2, 'only 2 of 5 tracked units have valid securedAt');
   assert.equal(stats.trackedRewardUnits, 5);
   assert.equal(pct, 14, 'dashboard pct must derive from secured count (2/14), not tracked count (5/14)');

--- a/tests/punctuation-service.test.js
+++ b/tests/punctuation-service.test.js
@@ -245,3 +245,62 @@ test('spaced clean attempts emit a secure-unit event once', () => {
   }));
   assert.equal(service.getStats('learner-a').securedRewardUnits, 1);
 });
+
+test('getStats securedRewardUnits counts only entries with securedAt > 0 (defensive edge case)', () => {
+  // Seed reward-unit entries where tracked != secured: 5 tracked, only 2
+  // genuinely secured (positive securedAt). securedAt: 0, null, and missing
+  // cannot occur after Writer normalisation but the filter is defensive.
+  const repository = makeRepository();
+  const now = Date.UTC(2026, 3, 25);
+  repository.writeData('learner-a', {
+    prefs: { mode: 'smart', roundLength: '4' },
+    progress: {
+      items: {},
+      facets: {},
+      rewardUnits: {
+        [createPunctuationMasteryKey({ clusterId: 'endmarks', rewardUnitId: 'sentence-endings-core' })]: {
+          masteryKey: createPunctuationMasteryKey({ clusterId: 'endmarks', rewardUnitId: 'sentence-endings-core' }),
+          releaseId: PUNCTUATION_RELEASE_ID,
+          clusterId: 'endmarks',
+          rewardUnitId: 'sentence-endings-core',
+          securedAt: now - 10_000,
+        },
+        [createPunctuationMasteryKey({ clusterId: 'apostrophe', rewardUnitId: 'apostrophe-contractions-core' })]: {
+          masteryKey: createPunctuationMasteryKey({ clusterId: 'apostrophe', rewardUnitId: 'apostrophe-contractions-core' }),
+          releaseId: PUNCTUATION_RELEASE_ID,
+          clusterId: 'apostrophe',
+          rewardUnitId: 'apostrophe-contractions-core',
+          securedAt: now - 5_000,
+        },
+        [createPunctuationMasteryKey({ clusterId: 'apostrophe', rewardUnitId: 'apostrophe-possession-core' })]: {
+          masteryKey: createPunctuationMasteryKey({ clusterId: 'apostrophe', rewardUnitId: 'apostrophe-possession-core' }),
+          releaseId: PUNCTUATION_RELEASE_ID,
+          clusterId: 'apostrophe',
+          rewardUnitId: 'apostrophe-possession-core',
+          securedAt: 0,
+        },
+        [createPunctuationMasteryKey({ clusterId: 'speech', rewardUnitId: 'speech-core' })]: {
+          masteryKey: createPunctuationMasteryKey({ clusterId: 'speech', rewardUnitId: 'speech-core' }),
+          releaseId: PUNCTUATION_RELEASE_ID,
+          clusterId: 'speech',
+          rewardUnitId: 'speech-core',
+          securedAt: null,
+        },
+        [createPunctuationMasteryKey({ clusterId: 'comma_flow', rewardUnitId: 'list-commas-core' })]: {
+          masteryKey: createPunctuationMasteryKey({ clusterId: 'comma_flow', rewardUnitId: 'list-commas-core' }),
+          releaseId: PUNCTUATION_RELEASE_ID,
+          clusterId: 'comma_flow',
+          rewardUnitId: 'list-commas-core',
+        },
+      },
+      attempts: [],
+      sessionsCompleted: 0,
+    },
+  });
+  const service = createPunctuationService({ repository, now: () => now, random: () => 0 });
+  const stats = service.getStats('learner-a');
+
+  assert.equal(stats.trackedRewardUnits, 5, 'all 5 tracked entries present');
+  assert.equal(stats.securedRewardUnits, 2, 'only 2 entries with securedAt > 0 count as secured');
+  assert.equal(stats.publishedRewardUnits, 14, 'published denominator unchanged');
+});


### PR DESCRIPTION
## Summary
- **Phase 5 U1**: Fixes the read-model bug where `securedRewardUnits` was set to `publishedRewardUnits.length`, conflating tracked and secured reward units
- All four bug sites corrected (progressSnapshot, overview, releaseDiagnostics)
- Computes four distinct counts: published (14), tracked, secured (has valid `securedAt`), deepSecured (placeholder 0)
- 3 new tests covering tracked-vs-secured distinction and module.js pct derivation

## Requirements
- R6: tracked, secured, and deep-secured counts are distinct
- R10: No regression — oracle replay 11/11, zero engine file changes

## Files changed
- `src/subjects/punctuation/read-model.js` — fix secured count logic
- `tests/punctuation-read-model.test.js` — 3 new test scenarios

## release-id impact: none
## engine files touched: none

## Test plan
- [x] Oracle replay 11/11
- [x] Fresh learner: 14 published, 0 tracked, 0 secured
- [x] 3 tracked, 1 secured (only entry with valid securedAt counts)
- [x] null/missing securedAt → tracked but not secured
- [x] module.js pct derives from corrected securedRewardUnits