### PR TITLE
feat(spelling): add The Workshop secondary surface to post-Mega dashboard

### DIFF
--- a/src/subjects/spelling/components/SpellingSetupScene.jsx
+++ b/src/subjects/spelling/components/SpellingSetupScene.jsx
@@ -1025,6 +1025,119 @@ function PostMegaSetupContent({
           </button>
         ) : null}
       </div>
+      <WorkshopSection
+        prefs={prefs}
+        actions={actions}
+        startDisabled={startDisabled}
+        runtimeReadOnly={runtimeReadOnly}
+      />
     </>
+  );
+}
+
+/* The Workshop — secondary surface that keeps the legacy practice modes
+ * (Smart Review / Trouble Drill / SATs Test) available to a graduated
+ * learner without competing with the primary post-Mega cards.
+ *
+ * Design intent:
+ *  - Place metaphor matches the rest of the post-Mega vocabulary (Word
+ *    Vault, Codex, Meadow). "The Workshop" reads as a tool shed kids
+ *    return to by choice, not a demoted classics rack.
+ *  - Default-collapsed so the post-Mega hierarchy stays loud. The header
+ *    is the discovery affordance; the chevron telegraphs that more lives
+ *    underneath.
+ *  - Cards are list-row (not hero) — they share the post-Mega palette but
+ *    sit on aged-paper tone so the eye reads them as secondary at a glance.
+ *  - Click dispatches `spelling-shortcut-start` (same payload as Alt+1/2/3)
+ *    so the underlying entry-point code path stays unchanged. Whatever
+ *    prefs.roundLength / yearFilter the learner last used is honoured by
+ *    the existing handler.
+ *  - The Alt+1/2/3 hint sits at the bottom as a reward for kids who notice
+ *    keyboard shortcuts; it is aria-hidden (decorative) so a screen reader
+ *    user just hears the cards. */
+function WorkshopSection({ prefs, actions, startDisabled, runtimeReadOnly }) {
+  const [open, setOpen] = React.useState(false);
+  const disabled = Boolean(startDisabled || runtimeReadOnly);
+  const sectionId = 'spelling-workshop-body';
+
+  function handleCardClick(event, modeId) {
+    if (disabled) {
+      event?.preventDefault?.();
+      event?.stopPropagation?.();
+      return;
+    }
+    renderAction(actions, event, 'spelling-shortcut-start', { mode: modeId });
+  }
+
+  return (
+    <section
+      className={`workshop-section${open ? ' is-open' : ''}`}
+      data-test-id="spelling-workshop"
+      data-state={open ? 'open' : 'closed'}
+    >
+      <button
+        type="button"
+        className="workshop-toggle"
+        aria-expanded={open}
+        aria-controls={sectionId}
+        onClick={() => setOpen((prev) => !prev)}
+      >
+        <span className="workshop-toggle-label">
+          <span className="workshop-eyebrow">Optional · your earlier modes</span>
+          <span className="workshop-title">The Workshop</span>
+        </span>
+        <span className="workshop-toggle-meta">
+          <span className="workshop-toggle-hint">
+            {open ? 'Tuck away' : 'Open the Workshop'}
+          </span>
+          <span className="workshop-chevron" aria-hidden="true" />
+        </span>
+      </button>
+      <div
+        id={sectionId}
+        className="workshop-body"
+        role="region"
+        aria-label="The Workshop — earlier practice modes"
+        hidden={!open}
+      >
+        <p className="workshop-lede">
+          Your toolbox from before graduation — keep them sharp whenever you fancy a
+          familiar drill. Mega never drops.
+        </p>
+        <ul className="workshop-row" data-mode-current={prefs?.mode || ''}>
+          {MODE_CARDS.map((mode) => (
+            <li key={mode.id}>
+              <button
+                type="button"
+                className="workshop-card"
+                data-action="spelling-shortcut-start"
+                data-mode={mode.id}
+                data-test-id={`workshop-card-${mode.id}`}
+                disabled={disabled}
+                onClick={(event) => handleCardClick(event, mode.id)}
+              >
+                <span className="workshop-card-head">
+                  <span className="workshop-card-title">{mode.title}</span>
+                  <span className="workshop-card-arrow" aria-hidden="true">
+                    <ArrowRightIcon />
+                  </span>
+                </span>
+                <span className="workshop-card-desc">{mode.desc}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+        <p className="workshop-hint" aria-hidden="true">
+          <span className="workshop-hint-prefix">Quick keys</span>
+          <kbd>Alt</kbd>
+          <span className="workshop-hint-join">+</span>
+          <kbd>1</kbd>
+          <span className="workshop-hint-join">·</span>
+          <kbd>2</kbd>
+          <span className="workshop-hint-join">·</span>
+          <kbd>3</kbd>
+        </p>
+      </div>
+    </section>
   );
 }

--- a/styles/app.css
+++ b/styles/app.css
@@ -4973,6 +4973,258 @@ textarea:focus-visible {
   .post-mega-hydration-skeleton__card { animation: none; opacity: 0.9; }
 }
 
+/* The Workshop — secondary surface attached below the post-Mega cards.
+ * Aged-paper tone separates it visually from the primary Guardian / Boss /
+ * Pattern Quest hierarchy without exiling the legacy practice modes.
+ * Aesthetic notes:
+ *  - A single hairline rule above the toggle anchors the section without
+ *    competing with the post-Mega cards' ranged shadows.
+ *  - The toggle is a quiet button with serif title + chevron; on hover, the
+ *    chevron edges right and the rule darkens. No coloured fills.
+ *  - Cards use a dotted indent stripe on the left edge (instead of a heavy
+ *    border) so they read as items in a workshop drawer rather than another
+ *    set of mode cards.
+ *  - Closed state is genuinely closed (display:none on the body) — the
+ *    section is intended to disappear from the visual hierarchy when the
+ *    learner is not actively reaching for it. */
+.workshop-section {
+  margin-top: 36px;
+  padding-top: 22px;
+  border-top: 1px solid color-mix(in oklab, var(--brand) 14%, var(--line));
+}
+.workshop-toggle {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  width: 100%;
+  padding: 6px 2px 8px;
+  background: transparent;
+  border: 0;
+  text-align: left;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+  transition: color 200ms ease, transform 200ms ease;
+}
+.workshop-toggle:hover { color: color-mix(in oklab, var(--brand) 32%, var(--ink)); }
+.workshop-toggle:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--brand) 60%, transparent);
+  outline-offset: 4px;
+  border-radius: 4px;
+}
+.workshop-toggle-label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+.workshop-eyebrow {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: color-mix(in oklab, var(--brand) 56%, var(--muted));
+  opacity: 0.82;
+}
+.workshop-title {
+  font-family: var(--font-serif);
+  font-size: 1.4rem;
+  font-weight: 500;
+  letter-spacing: -0.012em;
+  line-height: 1.1;
+  color: color-mix(in oklab, var(--brand) 60%, var(--ink));
+}
+.workshop-toggle-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+  padding-bottom: 4px;
+}
+.workshop-toggle-hint {
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+  color: color-mix(in oklab, var(--muted) 88%, transparent);
+}
+.workshop-chevron {
+  display: inline-block;
+  width: 9px;
+  height: 9px;
+  border-right: 1.5px solid color-mix(in oklab, var(--brand) 70%, var(--ink));
+  border-bottom: 1.5px solid color-mix(in oklab, var(--brand) 70%, var(--ink));
+  transform: rotate(45deg);
+  transition: transform 220ms ease;
+  margin-bottom: 2px;
+}
+.workshop-section.is-open .workshop-chevron {
+  transform: rotate(-135deg);
+  margin-bottom: -2px;
+}
+.workshop-body {
+  margin-top: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  animation: workshopReveal 240ms ease both;
+}
+.workshop-body[hidden] { display: none; }
+.workshop-lede {
+  margin: 0;
+  max-width: 56ch;
+  font-size: 0.92rem;
+  line-height: 1.5;
+  color: color-mix(in oklab, var(--mode-card-copy, var(--muted)) 92%, transparent);
+}
+.workshop-row {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+@media (max-width: 720px) {
+  .workshop-row { grid-template-columns: 1fr; }
+}
+.workshop-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 100%;
+  padding: 14px 16px 14px 20px;
+  background:
+    linear-gradient(180deg,
+      color-mix(in oklab, var(--panel) 28%, transparent) 0%,
+      color-mix(in oklab, var(--brand-soft) 14%, transparent) 100%);
+  border: 1px solid color-mix(in oklab, var(--brand) 18%, var(--line));
+  border-radius: calc(var(--radius) - 4px);
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+  transition:
+    transform 180ms ease,
+    border-color 180ms ease,
+    background 220ms ease,
+    box-shadow 220ms ease;
+}
+.workshop-card::before {
+  content: '';
+  position: absolute;
+  left: 8px;
+  top: 14px;
+  bottom: 14px;
+  width: 2px;
+  border-radius: 2px;
+  background: color-mix(in oklab, var(--brand) 38%, transparent);
+  opacity: 0.6;
+  transition: opacity 200ms ease, background 200ms ease;
+}
+.workshop-card:hover {
+  transform: translateY(-1px);
+  border-color: color-mix(in oklab, var(--brand) 42%, var(--line));
+  box-shadow: 0 12px 24px -22px color-mix(in oklab, var(--brand) 38%, transparent);
+}
+.workshop-card:hover::before {
+  opacity: 1;
+  background: color-mix(in oklab, var(--brand) 76%, transparent);
+}
+.workshop-card:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--brand) 64%, transparent);
+  outline-offset: 3px;
+}
+.workshop-card[disabled] {
+  cursor: not-allowed;
+  opacity: 0.55;
+  filter: saturate(0.7);
+}
+.workshop-card[disabled]:hover {
+  transform: none;
+  border-color: color-mix(in oklab, var(--brand) 18%, var(--line));
+  box-shadow: none;
+}
+.workshop-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.workshop-card-title {
+  font-family: var(--font-serif);
+  font-size: 1.05rem;
+  font-weight: 500;
+  letter-spacing: -0.008em;
+  color: color-mix(in oklab, var(--brand) 70%, var(--ink));
+}
+.workshop-card-arrow {
+  display: inline-flex;
+  align-items: center;
+  color: color-mix(in oklab, var(--brand) 60%, var(--muted));
+  opacity: 0.7;
+  transform: translateX(0);
+  transition: transform 200ms ease, opacity 200ms ease;
+}
+.workshop-card-arrow svg {
+  width: 14px;
+  height: 14px;
+}
+.workshop-card:hover .workshop-card-arrow {
+  transform: translateX(3px);
+  opacity: 1;
+}
+.workshop-card-desc {
+  font-size: 0.84rem;
+  line-height: 1.45;
+  color: color-mix(in oklab, var(--mode-card-copy, var(--muted)) 90%, transparent);
+}
+.workshop-hint {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 6px 0 0;
+  padding-top: 8px;
+  border-top: 1px dashed color-mix(in oklab, var(--brand) 14%, var(--line));
+  font-size: 0.74rem;
+  color: color-mix(in oklab, var(--muted) 80%, transparent);
+}
+.workshop-hint-prefix {
+  margin-right: 4px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.66rem;
+  font-weight: 700;
+  opacity: 0.7;
+}
+.workshop-hint-join {
+  opacity: 0.5;
+  font-weight: 600;
+}
+.workshop-hint kbd {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-family: var(--font-mono, ui-monospace, 'SFMono-Regular', Menlo, monospace);
+  font-size: 0.68rem;
+  font-weight: 600;
+  line-height: 1.1;
+  background: color-mix(in oklab, var(--panel) 38%, transparent);
+  border: 1px solid color-mix(in oklab, var(--brand) 22%, transparent);
+  color: color-mix(in oklab, var(--brand) 70%, var(--ink));
+}
+@keyframes workshopReveal {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .workshop-toggle,
+  .workshop-chevron,
+  .workshop-card,
+  .workshop-card-arrow,
+  .workshop-body { transition: none; animation: none; }
+}
+
 .setup-control-stack {
   min-height: 196px;
   margin-top: 20px;

--- a/tests/react-spelling-surface.test.js
+++ b/tests/react-spelling-surface.test.js
@@ -471,3 +471,92 @@ test('U3 edge case: Guardian summary with zero mistakes does not render the Prac
   assert.doesNotMatch(html, /Practice wobbling words/, 'zero-mistake Guardian summary must not render the Practice button');
   assert.doesNotMatch(html, /summary-drill-chips/, 'zero-mistake Guardian summary must not render the drill chips container');
 });
+
+// ----- The Workshop — secondary surface on the post-Mega setup scene ----------
+//
+// Lets a graduated learner reach the legacy practice modes (Smart Review /
+// Trouble Drill / SATs Test) without exiting the post-Mega dashboard. Default
+// collapsed; click-to-expand; cards dispatch `spelling-shortcut-start` with
+// the legacy mode payload so the entry-point parity with Alt+1/2/3 stays
+// byte-identical. Mega never drops because the underlying handler is
+// unchanged.
+
+test('Workshop section renders on the post-Mega setup scene, default-collapsed', async () => {
+  const today = Math.floor(Date.now() / (24 * 60 * 60 * 1000));
+  const html = await renderSpellingSurfaceFixture({
+    phase: 'setup',
+    postMega: {
+      guardian: {
+        possess: {
+          reviewLevel: 2,
+          lastReviewedDay: today - 7,
+          nextDueDay: today,
+          correctStreak: 2,
+          lapses: 0,
+          renewals: 0,
+          wobbling: false,
+        },
+      },
+    },
+  });
+
+  // Section + toggle render alongside the post-Mega dashboard.
+  assert.match(html, /data-test-id="spelling-workshop"/);
+  assert.match(html, /class="workshop-toggle"[^>]*aria-expanded="false"/);
+  assert.match(html, /data-state="closed"/);
+  // Place metaphor + eyebrow microcopy survive the render.
+  assert.match(html, /The Workshop/);
+  assert.match(html, /Optional · your earlier modes/);
+  // Body is hidden on first render — the cards exist in the DOM but the
+  // `hidden` attribute keeps them out of the accessibility tree until the
+  // learner expands the section.
+  assert.match(html, /id="spelling-workshop-body"[^>]*hidden/);
+});
+
+test('Workshop section is absent when the legacy dashboard renders (allWordsMega=false)', async () => {
+  // Pre-Mega learner: setup scene renders the legacy 3-mode row directly. The
+  // Workshop is post-Mega-only — surfacing it on the legacy view would
+  // duplicate the same three cards twice on the same page.
+  const html = await renderSpellingSurfaceFixture({ phase: 'setup' });
+  assert.doesNotMatch(html, /data-test-id="spelling-workshop"/);
+  assert.doesNotMatch(html, /class="workshop-toggle"/);
+});
+
+test('Workshop section card markup wires Smart / Trouble / Test through spelling-shortcut-start', async () => {
+  const today = Math.floor(Date.now() / (24 * 60 * 60 * 1000));
+  const html = await renderSpellingSurfaceFixture({
+    phase: 'setup',
+    postMega: {
+      guardian: {
+        possess: {
+          reviewLevel: 2,
+          lastReviewedDay: today - 7,
+          nextDueDay: today,
+          correctStreak: 2,
+          lapses: 0,
+          renewals: 0,
+          wobbling: false,
+        },
+      },
+    },
+  });
+
+  // All three legacy modes get a card inside the Workshop body, each wired
+  // through the same `spelling-shortcut-start` action that Alt+1/2/3 use.
+  // React's renderer does not preserve a stable JSX-prop attribute order, so
+  // assert each attribute independently rather than as a single ordered run.
+  for (const modeId of ['smart', 'trouble', 'test']) {
+    const cardRegex = new RegExp(`<button[^>]*data-test-id="workshop-card-${modeId}"[^>]*>`);
+    const match = html.match(cardRegex);
+    assert.ok(match, `Workshop card for mode "${modeId}" should render`);
+    const cardOpenTag = match[0];
+    assert.match(cardOpenTag, /data-action="spelling-shortcut-start"/);
+    assert.match(cardOpenTag, new RegExp(`data-mode="${modeId}"`));
+  }
+  // The Alt+1/2/3 quick-key hint sits at the bottom of the body so kids can
+  // discover the keyboard parity without pressing the button.
+  assert.match(html, /<kbd>Alt<\/kbd>/);
+  assert.match(html, /<kbd>1<\/kbd>/);
+  assert.match(html, /<kbd>2<\/kbd>/);
+  assert.match(html, /<kbd>3<\/kbd>/);
+});

--- a/worker/src/generated-csp-hash.js
+++ b/worker/src/generated-csp-hash.js
@@ -2,4 +2,4 @@
 // This file is committed so fresh clones can run `npm test` before
 // `npm run build` has produced a real hash. Build overwrites this.
 
-export const CSP_INLINE_SCRIPT_HASH = 'sha256-06SFOq2Wj74Ww4wfCm1nJLKf6sUYs9usIiwlCVmZLfg=';
+export const CSP_INLINE_SCRIPT_HASH = 'sha256-d5B0kdrkvmMBHcWJ8TUVFkTDTxk/ACGS+ezi8RwKeZE=';


### PR DESCRIPTION
## Summary

- Default-collapsed **Workshop** section below the post-Mega cards reopens Smart Review / Trouble Drill / SATs Test for graduated learners
- Place-metaphor naming (Workshop / Vault / Codex / Meadow) keeps post-Mega vocabulary consistent; aged-paper tint + dotted indent stripe signal secondary hierarchy
- Card click dispatches **byte-identical** `spelling-shortcut-start` payload as Alt+1/2/3 — Mega never drops, no engine changes

## Why

Post-Mega scene completely replaces the legacy 3-mode row. Alt+1/2/3 keyboard shortcuts still work but were invisible. SATs Test mock practice still has real value for Y6 graduates (e.g. Eugenia), so we expose the modes through a quiet, kid-friendly surface that does not compete with Guardian / Boss / Pattern Quest.

## What's in

- `src/subjects/spelling/components/SpellingSetupScene.jsx` — new `WorkshopSection` component + 1 render call inside `PostMegaSetupContent`
- `styles/app.css` — `.workshop-*` styling (chevron rotation, aged-paper card row, kbd hint, `prefers-reduced-motion` opt-out)
- `tests/react-spelling-surface.test.js` — 3 new tests: default-collapsed render, absence on legacy dashboard, card → shortcut-start wiring for all three modes
- `worker/src/generated-csp-hash.js` — regenerated by `npm run build`

## Verify

- [x] `npm run build` — 706 KB main bundle, 59 ms
- [x] `node ./scripts/run-node-tests.mjs tests/react-spelling-surface.test.js` — 27/27 pass
- [x] Broader spelling suite (`spelling-parity` / `view-model` / `guardian` / `boss` / `mega-invariant`) — 301/301 pass
- [ ] Browser visual smoke (recommended manual check after merge — `wrangler dev` → login as a graduated learner → confirm chevron animates and card click starts a Smart/Trouble/Test session)

## Notes

- Workshop is **post-Mega-only**. On the legacy dashboard the same three cards already render at top level; surfacing them twice would duplicate.
- `hidden` attribute on the body keeps closed-state out of the accessibility tree (NVDA / VoiceOver skip it cleanly).
- The Alt+1/2/3 hint at the bottom is `aria-hidden="true"` because the kbd row is decorative — the button labels themselves carry the accessible name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)