### PR TITLE
fix(spelling): emit postMastery on bootstrap so graduated learners see the dashboard on first render

### DIFF
--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -36,6 +36,7 @@ import { buildAdminHubReadModel } from '../../src/platform/hubs/admin-read-model
 import { buildParentHubReadModel } from '../../src/platform/hubs/parent-read-model.js';
 import { monsterIdForSpellingWord } from '../../src/platform/game/monster-system.js';
 import { buildSpellingProgressPools, buildSpellingWordBankReadModel } from './content/spelling-read-models.js';
+import { getSpellingPostMasteryState } from '../../src/subjects/spelling/read-model.js';
 import {
   activityFeedRowFromEventRow,
   appendRecentEventTokens,
@@ -322,6 +323,31 @@ function redactSpellingUiForClient(ui, data = {}, learnerId = '', {
   const progressPools = contentSnapshot
     ? buildSpellingProgressPools({ contentSnapshot, data, now })
     : null;
+  // P2 hotfix: derive `postMastery` on the bootstrap path so a graduated
+  // learner whose D1 record has the sticky bit lands on the post-Mega
+  // dashboard on first render — without waiting for the first command
+  // round-trip to populate `subjectUi.spelling.postMastery`. Pre-v3
+  // graduates (sticky bit minted via the read-model backfill on first
+  // hydration, or seeded directly into D1) would otherwise stay on the
+  // legacy Smart Review setup until they fired a command. The selector is
+  // shared with the `applyCommandResponse` path (engine.js), so the
+  // bootstrap-derived snapshot and the Worker authoritative response use
+  // byte-identical logic. `sourceHint: 'worker'` matches the existing
+  // hydrated path so the Admin diagnostic panel does not need to branch.
+  let postMastery = null;
+  if (contentSnapshot) {
+    try {
+      postMastery = getSpellingPostMasteryState({
+        subjectStateRecord: { data, ui: raw },
+        runtimeSnapshot: contentSnapshot,
+        now,
+        sourceHint: 'worker',
+      });
+    } catch (error) {
+      globalThis.console?.warn?.('[spelling.bootstrap] postMastery derivation failed, omitting from response', error);
+      postMastery = null;
+    }
+  }
   return {
     subjectId: 'spelling',
     learnerId,
@@ -353,6 +379,7 @@ function redactSpellingUiForClient(ui, data = {}, learnerId = '', {
     analytics: publicSpellingAnalytics(progressPools, now),
     audio: audio ? cloneSerialisable(audio) : null,
     content: null,
+    postMastery,
   };
 }
 


### PR DESCRIPTION
## Summary

- **Bootstrap response now derives `postMastery`** for the spelling subject — closes the gap that left graduated learners stuck on the legacy Smart Review setup until their first command fired
- Reproduced against Eugenia (Y6, 213/213 core mastered, sticky bit in D1) — without this fix she lands on the legacy dashboard despite qualifying
- Selector is the **same** `getSpellingPostMasteryState` the `applyCommandResponse` path uses; bootstrap and command responses now use byte-identical logic

## Root cause

`subjectUi.spelling.postMastery` was only populated by `remote-actions.js::hydrateWorkerPostMastery` (PR #277, P2 U4) — fired exclusively from `applyCommandResponse`. Bootstrap path (`worker/src/repository.js::redactSpellingUiForClient`) never ran the selector, so the cache stayed null and `client-read-models.js::getPostMasteryState` returned the locked-fallback. Pre-v3 graduates (P1/P1.5 cohort + manual D1 sticky writes) had no command to fire on dashboard mount, so they were trapped.

## Fix

Run the selector inside `redactSpellingUiForClient` and ship the result via `record.ui.postMastery`. The existing `buildSubjectUiState` shallow-merge surfaces it as `appState.subjectUi.spelling.postMastery` — zero client changes needed. `sourceHint: 'worker'` matches the existing hydrated path so the Admin diagnostic panel does not need to branch.

Defensive try/catch mirrors `engine.js:524` — selector throws ⇒ omit field ⇒ client falls through to locked-fallback (existing behaviour).

## Verify

- [x] `npm run build` — 706 KB main bundle unchanged (Worker-side derivation, zero client bundle weight)
- [x] `node ./scripts/run-node-tests.mjs tests/react-spelling-surface.test.js tests/spelling-parity.test.js tests/server-spelling-engine-parity.test.js` — 58/58 pass
- [x] `node ./scripts/run-node-tests.mjs tests/spelling-guardian.test.js tests/spelling-mega-invariant.test.js tests/spelling-sticky-graduation.test.js tests/spelling-remote-sync-hydration.test.js` — 214/214 pass
- [ ] Browser smoke (post-merge) — login as Eugenia, expect the post-Mega dashboard on first render with `data-mission-state="first-patrol"`

## Notes

- This is the missing piece behind PR #347 (The Workshop). Without bootstrap emission, graduates never reached the post-Mega scene to see the new section either.
- The hub paths (`buildAdminHubReadModel` / `buildParentHubReadModel`) already derive their own postMastery snapshot independently and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)