### PR TITLE
fix(spelling): float Workshop toggle into the post-Mega hero clear zone

### DIFF
--- a/src/subjects/spelling/components/SpellingSetupScene.jsx
+++ b/src/subjects/spelling/components/SpellingSetupScene.jsx
@@ -1035,30 +1035,53 @@ function PostMegaSetupContent({
   );
 }
 
-/* The Workshop — secondary surface that keeps the legacy practice modes
- * (Smart Review / Trouble Drill / SATs Test) available to a graduated
- * learner without competing with the primary post-Mega cards.
+/* The Workshop — floating upper-right toggle on the post-Mega hero card.
  *
- * Design intent:
- *  - Place metaphor matches the rest of the post-Mega vocabulary (Word
- *    Vault, Codex, Meadow). "The Workshop" reads as a tool shed kids
- *    return to by choice, not a demoted classics rack.
- *  - Default-collapsed so the post-Mega hierarchy stays loud. The header
- *    is the discovery affordance; the chevron telegraphs that more lives
- *    underneath.
- *  - Cards are list-row (not hero) — they share the post-Mega palette but
- *    sit on aged-paper tone so the eye reads them as secondary at a glance.
- *  - Click dispatches `spelling-shortcut-start` (same payload as Alt+1/2/3)
- *    so the underlying entry-point code path stays unchanged. Whatever
- *    prefs.roundLength / yearFilter the learner last used is honoured by
- *    the existing handler.
- *  - The Alt+1/2/3 hint sits at the bottom as a reward for kids who notice
- *    keyboard shortcuts; it is aria-hidden (decorative) so a screen reader
- *    user just hears the cards. */
+ * Design intent (revised after first ship):
+ *  - The original below-the-fold section was clipped by the hero card's
+ *    `min-height: 610px; overflow: hidden;` envelope. Moving the toggle
+ *    into the upper-right clear zone keeps the affordance discoverable
+ *    without growing the card. The popover floats above the layout, so
+ *    nothing else moves.
+ *  - Place metaphor still matches the post-Mega vocabulary (Word Vault,
+ *    Codex, Meadow). "The Workshop" reads as a small tool shed in the
+ *    corner of the hero, not a demoted classics rack.
+ *  - The chip is a quiet pill with paper-translucent backdrop blur. The
+ *    chevron telegraphs the open/closed state; rotating it on toggle is
+ *    the only animation the chip itself needs.
+ *  - Popover anchors to the chip's bottom edge, ~320px wide, with three
+ *    list-row cards. Clicking a card dispatches the same
+ *    `spelling-shortcut-start` payload that Alt+1/2/3 use, so the engine
+ *    path is byte-identical and Mega never drops.
+ *  - Auto-dismiss on outside click + Esc keeps the popover from competing
+ *    with the rest of the hero. Selecting a card also closes the popover
+ *    before the session navigation kicks in. */
 function WorkshopSection({ prefs, actions, startDisabled, runtimeReadOnly }) {
   const [open, setOpen] = React.useState(false);
+  const sectionRef = React.useRef(null);
   const disabled = Boolean(startDisabled || runtimeReadOnly);
-  const sectionId = 'spelling-workshop-body';
+  const popoverId = 'spelling-workshop-popover';
+
+  React.useEffect(() => {
+    if (!open || typeof document === 'undefined') return undefined;
+    function handlePointerDown(event) {
+      const root = sectionRef.current;
+      if (!root || root.contains(event.target)) return;
+      setOpen(false);
+    }
+    function handleKeyDown(event) {
+      if (event.key === 'Escape') {
+        event.stopPropagation();
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open]);
 
   function handleCardClick(event, modeId) {
     if (disabled) {
@@ -1066,78 +1089,63 @@ function WorkshopSection({ prefs, actions, startDisabled, runtimeReadOnly }) {
       event?.stopPropagation?.();
       return;
     }
+    setOpen(false);
     renderAction(actions, event, 'spelling-shortcut-start', { mode: modeId });
   }
 
   return (
-    <section
+    <div
+      ref={sectionRef}
       className={`workshop-section${open ? ' is-open' : ''}`}
       data-test-id="spelling-workshop"
       data-state={open ? 'open' : 'closed'}
     >
       <button
         type="button"
-        className="workshop-toggle"
+        className="workshop-chip"
         aria-expanded={open}
-        aria-controls={sectionId}
+        aria-haspopup="true"
+        aria-controls={popoverId}
         onClick={() => setOpen((prev) => !prev)}
       >
-        <span className="workshop-toggle-label">
-          <span className="workshop-eyebrow">Optional · your earlier modes</span>
-          <span className="workshop-title">The Workshop</span>
-        </span>
-        <span className="workshop-toggle-meta">
-          <span className="workshop-toggle-hint">
-            {open ? 'Tuck away' : 'Open the Workshop'}
-          </span>
-          <span className="workshop-chevron" aria-hidden="true" />
-        </span>
+        <span className="workshop-chip-label">Workshop</span>
+        <span className="workshop-chip-chevron" aria-hidden="true" />
       </button>
       <div
-        id={sectionId}
-        className="workshop-body"
+        id={popoverId}
+        className="workshop-popover"
         role="region"
         aria-label="The Workshop — earlier practice modes"
+        data-mode-current={prefs?.mode || ''}
         hidden={!open}
       >
-        <p className="workshop-lede">
-          Your toolbox from before graduation — keep them sharp whenever you fancy a
-          familiar drill. Mega never drops.
-        </p>
-        <ul className="workshop-row" data-mode-current={prefs?.mode || ''}>
+        <p className="workshop-popover-eyebrow">Earlier modes · keep them sharp</p>
+        <ul className="workshop-popover-list">
           {MODE_CARDS.map((mode) => (
             <li key={mode.id}>
               <button
                 type="button"
-                className="workshop-card"
+                className="workshop-popover-card"
                 data-action="spelling-shortcut-start"
                 data-mode={mode.id}
                 data-test-id={`workshop-card-${mode.id}`}
                 disabled={disabled}
                 onClick={(event) => handleCardClick(event, mode.id)}
               >
-                <span className="workshop-card-head">
-                  <span className="workshop-card-title">{mode.title}</span>
-                  <span className="workshop-card-arrow" aria-hidden="true">
-                    <ArrowRightIcon />
-                  </span>
-                </span>
-                <span className="workshop-card-desc">{mode.desc}</span>
+                <span className="workshop-popover-card-title">{mode.title}</span>
+                <span className="workshop-popover-card-desc">{mode.desc}</span>
               </button>
             </li>
           ))}
         </ul>
-        <p className="workshop-hint" aria-hidden="true">
-          <span className="workshop-hint-prefix">Quick keys</span>
+        <p className="workshop-popover-hint" aria-hidden="true">
+          <span className="workshop-popover-hint-prefix">Quick keys</span>
           <kbd>Alt</kbd>
-          <span className="workshop-hint-join">+</span>
           <kbd>1</kbd>
-          <span className="workshop-hint-join">·</span>
           <kbd>2</kbd>
-          <span className="workshop-hint-join">·</span>
           <kbd>3</kbd>
         </p>
       </div>
-    </section>
+    </div>
   );
 }

--- a/styles/app.css
+++ b/styles/app.css
@@ -4973,235 +4973,189 @@ textarea:focus-visible {
   .post-mega-hydration-skeleton__card { animation: none; opacity: 0.9; }
 }
 
-/* The Workshop — secondary surface attached below the post-Mega cards.
- * Aged-paper tone separates it visually from the primary Guardian / Boss /
- * Pattern Quest hierarchy without exiling the legacy practice modes.
- * Aesthetic notes:
- *  - A single hairline rule above the toggle anchors the section without
- *    competing with the post-Mega cards' ranged shadows.
- *  - The toggle is a quiet button with serif title + chevron; on hover, the
- *    chevron edges right and the rule darkens. No coloured fills.
- *  - Cards use a dotted indent stripe on the left edge (instead of a heavy
- *    border) so they read as items in a workshop drawer rather than another
- *    set of mode cards.
- *  - Closed state is genuinely closed (display:none on the body) — the
- *    section is intended to disappear from the visual hierarchy when the
- *    learner is not actively reaching for it. */
+/* The Workshop — floating upper-right toggle on the post-Mega hero card.
+ * Anchors to `.setup-main` (which already has `position: relative`) so the
+ * chip + popover float over the hero backdrop without growing the card or
+ * pushing siblings. Aesthetic notes:
+ *  - Chip is a paper-translucent pill with backdrop-blur. Fraunces serif
+ *    label + chevron. Subtle border. Hover lifts and warms the border.
+ *  - Popover anchors to the chip's bottom-right corner, paper-cream with
+ *    drop shadow + backdrop blur, ~320px wide. Three list-rows.
+ *  - Each list-row has a dotted indent stripe revealed on hover — the
+ *    workshop-drawer affordance, not another mode card.
+ *  - kbd hint at the foot rewards keyboard explorers (Alt+1/2/3 still
+ *    work whether the popover is open or closed). */
 .workshop-section {
-  margin-top: 36px;
-  padding-top: 22px;
-  border-top: 1px solid color-mix(in oklab, var(--brand) 14%, var(--line));
+  position: absolute;
+  top: 24px;
+  right: 28px;
+  z-index: 4;
 }
-.workshop-toggle {
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 16px;
-  width: 100%;
-  padding: 6px 2px 8px;
-  background: transparent;
-  border: 0;
-  text-align: left;
-  cursor: pointer;
-  color: inherit;
-  font: inherit;
-  transition: color 200ms ease, transform 200ms ease;
-}
-.workshop-toggle:hover { color: color-mix(in oklab, var(--brand) 32%, var(--ink)); }
-.workshop-toggle:focus-visible {
-  outline: 2px solid color-mix(in oklab, var(--brand) 60%, transparent);
-  outline-offset: 4px;
-  border-radius: 4px;
-}
-.workshop-toggle-label {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  min-width: 0;
-}
-.workshop-eyebrow {
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.22em;
-  text-transform: uppercase;
-  color: color-mix(in oklab, var(--brand) 56%, var(--muted));
-  opacity: 0.82;
-}
-.workshop-title {
-  font-family: var(--font-serif);
-  font-size: 1.4rem;
-  font-weight: 500;
-  letter-spacing: -0.012em;
-  line-height: 1.1;
-  color: color-mix(in oklab, var(--brand) 60%, var(--ink));
-}
-.workshop-toggle-meta {
+.workshop-chip {
   display: inline-flex;
   align-items: center;
   gap: 10px;
-  flex-shrink: 0;
-  padding-bottom: 4px;
+  padding: 6px 14px 6px 16px;
+  background: color-mix(in oklab, var(--panel) 60%, transparent);
+  border: 1px solid color-mix(in oklab, var(--brand) 26%, var(--line));
+  border-radius: 999px;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+  backdrop-filter: blur(14px) saturate(1.1);
+  -webkit-backdrop-filter: blur(14px) saturate(1.1);
+  transition:
+    transform 200ms ease,
+    border-color 200ms ease,
+    background 200ms ease,
+    box-shadow 200ms ease;
 }
-.workshop-toggle-hint {
-  font-size: 0.78rem;
-  letter-spacing: 0.04em;
-  color: color-mix(in oklab, var(--muted) 88%, transparent);
+.workshop-chip:hover {
+  transform: translateY(-1px);
+  border-color: color-mix(in oklab, var(--brand) 50%, transparent);
+  background: color-mix(in oklab, var(--panel) 78%, transparent);
+  box-shadow: 0 8px 20px -16px color-mix(in oklab, var(--brand) 56%, transparent);
 }
-.workshop-chevron {
+.workshop-chip:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--brand) 64%, transparent);
+  outline-offset: 3px;
+}
+.workshop-chip-label {
+  font-family: var(--font-serif);
+  font-size: 0.95rem;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  color: color-mix(in oklab, var(--brand) 78%, var(--ink));
+}
+.workshop-chip-chevron {
   display: inline-block;
-  width: 9px;
-  height: 9px;
+  width: 7px;
+  height: 7px;
+  margin-bottom: 1px;
   border-right: 1.5px solid color-mix(in oklab, var(--brand) 70%, var(--ink));
   border-bottom: 1.5px solid color-mix(in oklab, var(--brand) 70%, var(--ink));
   transform: rotate(45deg);
   transition: transform 220ms ease;
-  margin-bottom: 2px;
 }
-.workshop-section.is-open .workshop-chevron {
+.workshop-section.is-open .workshop-chip-chevron {
   transform: rotate(-135deg);
-  margin-bottom: -2px;
+  margin-bottom: -3px;
 }
-.workshop-body {
-  margin-top: 14px;
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-  animation: workshopReveal 240ms ease both;
+.workshop-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  width: 320px;
+  padding: 18px 18px 14px;
+  background: color-mix(in oklab, var(--panel) 92%, white 8%);
+  border: 1px solid color-mix(in oklab, var(--brand) 20%, var(--line));
+  border-radius: var(--radius);
+  box-shadow:
+    0 24px 48px -22px color-mix(in oklab, var(--ink) 32%, transparent),
+    0 4px 8px -4px color-mix(in oklab, var(--ink) 18%, transparent);
+  backdrop-filter: blur(18px) saturate(1.2);
+  -webkit-backdrop-filter: blur(18px) saturate(1.2);
+  animation: workshopPopoverReveal 200ms ease both;
+  z-index: 12;
 }
-.workshop-body[hidden] { display: none; }
-.workshop-lede {
-  margin: 0;
-  max-width: 56ch;
-  font-size: 0.92rem;
-  line-height: 1.5;
-  color: color-mix(in oklab, var(--mode-card-copy, var(--muted)) 92%, transparent);
+.workshop-popover[hidden] { display: none; }
+.workshop-popover-eyebrow {
+  margin: 0 0 12px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: color-mix(in oklab, var(--brand) 60%, var(--muted));
 }
-.workshop-row {
+.workshop-popover-list {
   list-style: none;
   margin: 0;
   padding: 0;
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 10px;
-}
-@media (max-width: 720px) {
-  .workshop-row { grid-template-columns: 1fr; }
-}
-.workshop-card {
-  position: relative;
   display: flex;
   flex-direction: column;
   gap: 4px;
+}
+.workshop-popover-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
   width: 100%;
-  padding: 14px 16px 14px 20px;
-  background:
-    linear-gradient(180deg,
-      color-mix(in oklab, var(--panel) 28%, transparent) 0%,
-      color-mix(in oklab, var(--brand-soft) 14%, transparent) 100%);
-  border: 1px solid color-mix(in oklab, var(--brand) 18%, var(--line));
-  border-radius: calc(var(--radius) - 4px);
+  padding: 10px 12px 10px 18px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: calc(var(--radius) - 6px);
   text-align: left;
   cursor: pointer;
   font: inherit;
   color: inherit;
   transition:
-    transform 180ms ease,
+    background 180ms ease,
     border-color 180ms ease,
-    background 220ms ease,
-    box-shadow 220ms ease;
+    transform 180ms ease;
 }
-.workshop-card::before {
+.workshop-popover-card::before {
   content: '';
   position: absolute;
-  left: 8px;
-  top: 14px;
-  bottom: 14px;
+  left: 6px;
+  top: 12px;
+  bottom: 12px;
   width: 2px;
   border-radius: 2px;
-  background: color-mix(in oklab, var(--brand) 38%, transparent);
-  opacity: 0.6;
-  transition: opacity 200ms ease, background 200ms ease;
+  background: color-mix(in oklab, var(--brand) 40%, transparent);
+  opacity: 0;
+  transition: opacity 180ms ease;
 }
-.workshop-card:hover {
-  transform: translateY(-1px);
-  border-color: color-mix(in oklab, var(--brand) 42%, var(--line));
-  box-shadow: 0 12px 24px -22px color-mix(in oklab, var(--brand) 38%, transparent);
+.workshop-popover-card:hover {
+  background: color-mix(in oklab, var(--brand-soft) 28%, transparent);
+  border-color: color-mix(in oklab, var(--brand) 28%, var(--line));
+  transform: translateX(1px);
 }
-.workshop-card:hover::before {
-  opacity: 1;
-  background: color-mix(in oklab, var(--brand) 76%, transparent);
-}
-.workshop-card:focus-visible {
+.workshop-popover-card:hover::before { opacity: 1; }
+.workshop-popover-card:focus-visible {
   outline: 2px solid color-mix(in oklab, var(--brand) 64%, transparent);
-  outline-offset: 3px;
+  outline-offset: 2px;
 }
-.workshop-card[disabled] {
+.workshop-popover-card[disabled] {
   cursor: not-allowed;
   opacity: 0.55;
   filter: saturate(0.7);
 }
-.workshop-card[disabled]:hover {
+.workshop-popover-card[disabled]:hover {
+  background: transparent;
+  border-color: transparent;
   transform: none;
-  border-color: color-mix(in oklab, var(--brand) 18%, var(--line));
-  box-shadow: none;
 }
-.workshop-card-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-}
-.workshop-card-title {
+.workshop-popover-card-title {
   font-family: var(--font-serif);
-  font-size: 1.05rem;
+  font-size: 1rem;
   font-weight: 500;
-  letter-spacing: -0.008em;
-  color: color-mix(in oklab, var(--brand) 70%, var(--ink));
+  letter-spacing: -0.005em;
+  color: color-mix(in oklab, var(--brand) 78%, var(--ink));
 }
-.workshop-card-arrow {
-  display: inline-flex;
-  align-items: center;
-  color: color-mix(in oklab, var(--brand) 60%, var(--muted));
-  opacity: 0.7;
-  transform: translateX(0);
-  transition: transform 200ms ease, opacity 200ms ease;
-}
-.workshop-card-arrow svg {
-  width: 14px;
-  height: 14px;
-}
-.workshop-card:hover .workshop-card-arrow {
-  transform: translateX(3px);
-  opacity: 1;
-}
-.workshop-card-desc {
-  font-size: 0.84rem;
+.workshop-popover-card-desc {
+  font-size: 0.8rem;
   line-height: 1.45;
-  color: color-mix(in oklab, var(--mode-card-copy, var(--muted)) 90%, transparent);
+  color: color-mix(in oklab, var(--ink) 70%, var(--muted));
 }
-.workshop-hint {
+.workshop-popover-hint {
   display: flex;
   align-items: center;
-  gap: 6px;
-  margin: 6px 0 0;
-  padding-top: 8px;
-  border-top: 1px dashed color-mix(in oklab, var(--brand) 14%, var(--line));
-  font-size: 0.74rem;
-  color: color-mix(in oklab, var(--muted) 80%, transparent);
-}
-.workshop-hint-prefix {
-  margin-right: 4px;
-  letter-spacing: 0.08em;
+  gap: 5px;
+  margin: 12px 0 0;
+  padding-top: 10px;
+  border-top: 1px dashed color-mix(in oklab, var(--brand) 16%, var(--line));
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
-  font-size: 0.66rem;
+  color: color-mix(in oklab, var(--ink) 60%, var(--muted));
+}
+.workshop-popover-hint-prefix {
+  margin-right: 4px;
   font-weight: 700;
-  opacity: 0.7;
+  opacity: 0.78;
 }
-.workshop-hint-join {
-  opacity: 0.5;
-  font-weight: 600;
-}
-.workshop-hint kbd {
+.workshop-popover-hint kbd {
   display: inline-block;
   padding: 1px 6px;
   border-radius: 4px;
@@ -5211,18 +5165,26 @@ textarea:focus-visible {
   line-height: 1.1;
   background: color-mix(in oklab, var(--panel) 38%, transparent);
   border: 1px solid color-mix(in oklab, var(--brand) 22%, transparent);
-  color: color-mix(in oklab, var(--brand) 70%, var(--ink));
+  color: color-mix(in oklab, var(--brand) 72%, var(--ink));
 }
-@keyframes workshopReveal {
-  from { opacity: 0; transform: translateY(-4px); }
-  to { opacity: 1; transform: translateY(0); }
+@keyframes workshopPopoverReveal {
+  from { opacity: 0; transform: translateY(-4px) scale(0.98); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+@media (max-width: 540px) {
+  .workshop-section {
+    top: 18px;
+    right: 18px;
+  }
+  .workshop-popover {
+    width: min(calc(100vw - 48px), 320px);
+  }
 }
 @media (prefers-reduced-motion: reduce) {
-  .workshop-toggle,
-  .workshop-chevron,
-  .workshop-card,
-  .workshop-card-arrow,
-  .workshop-body { transition: none; animation: none; }
+  .workshop-chip,
+  .workshop-chip-chevron,
+  .workshop-popover,
+  .workshop-popover-card { transition: none; animation: none; }
 }
 
 .setup-control-stack {

--- a/tests/react-spelling-surface.test.js
+++ b/tests/react-spelling-surface.test.js
@@ -472,16 +472,18 @@ test('U3 edge case: Guardian summary with zero mistakes does not render the Prac
   assert.doesNotMatch(html, /summary-drill-chips/, 'zero-mistake Guardian summary must not render the drill chips container');
 });
 
-// ----- The Workshop — secondary surface on the post-Mega setup scene ----------
+// ----- The Workshop — floating upper-right toggle on the post-Mega scene ----
 //
 // Lets a graduated learner reach the legacy practice modes (Smart Review /
-// Trouble Drill / SATs Test) without exiting the post-Mega dashboard. Default
-// collapsed; click-to-expand; cards dispatch `spelling-shortcut-start` with
-// the legacy mode payload so the entry-point parity with Alt+1/2/3 stays
-// byte-identical. Mega never drops because the underlying handler is
-// unchanged.
+// Trouble Drill / SATs Test) without exiting the post-Mega dashboard. The
+// chip lives in the hero card's upper-right clear zone (top:24, right:28)
+// so it does not push siblings or overflow the card's `min-height: 610px`
+// envelope. Popover anchors to the chip's bottom-right corner and is
+// hidden via the HTML `hidden` attribute until the chip is clicked. Cards
+// dispatch `spelling-shortcut-start` with the legacy mode payload so the
+// entry-point parity with Alt+1/2/3 stays byte-identical. Mega never drops.
 
-test('Workshop section renders on the post-Mega setup scene, default-collapsed', async () => {
+test('Workshop chip renders on the post-Mega setup scene, default-closed', async () => {
   const today = Math.floor(Date.now() / (24 * 60 * 60 * 1000));
   const html = await renderSpellingSurfaceFixture({
     phase: 'setup',
@@ -500,29 +502,29 @@ test('Workshop section renders on the post-Mega setup scene, default-collapsed',
     },
   });
 
-  // Section + toggle render alongside the post-Mega dashboard.
+  // Section + chip render alongside the post-Mega dashboard.
   assert.match(html, /data-test-id="spelling-workshop"/);
-  assert.match(html, /class="workshop-toggle"[^>]*aria-expanded="false"/);
+  assert.match(html, /class="workshop-chip"[^>]*aria-expanded="false"/);
   assert.match(html, /data-state="closed"/);
-  // Place metaphor + eyebrow microcopy survive the render.
-  assert.match(html, /The Workshop/);
-  assert.match(html, /Optional · your earlier modes/);
-  // Body is hidden on first render — the cards exist in the DOM but the
-  // `hidden` attribute keeps them out of the accessibility tree until the
-  // learner expands the section.
-  assert.match(html, /id="spelling-workshop-body"[^>]*hidden/);
+  assert.match(html, /aria-haspopup="true"/);
+  // Place metaphor (paper aesthetic place vocabulary) survives the render.
+  assert.match(html, />Workshop</);
+  // Popover is hidden on first render — markup exists in the DOM but the
+  // `hidden` attribute keeps it out of the accessibility tree until the
+  // learner clicks the chip.
+  assert.match(html, /id="spelling-workshop-popover"[^>]*hidden/);
 });
 
-test('Workshop section is absent when the legacy dashboard renders (allWordsMega=false)', async () => {
+test('Workshop chip is absent when the legacy dashboard renders (allWordsMega=false)', async () => {
   // Pre-Mega learner: setup scene renders the legacy 3-mode row directly. The
   // Workshop is post-Mega-only — surfacing it on the legacy view would
   // duplicate the same three cards twice on the same page.
   const html = await renderSpellingSurfaceFixture({ phase: 'setup' });
   assert.doesNotMatch(html, /data-test-id="spelling-workshop"/);
-  assert.doesNotMatch(html, /class="workshop-toggle"/);
+  assert.doesNotMatch(html, /class="workshop-chip"/);
 });
 
-test('Workshop section card markup wires Smart / Trouble / Test through spelling-shortcut-start', async () => {
+test('Workshop popover wires Smart / Trouble / Test through spelling-shortcut-start', async () => {
   const today = Math.floor(Date.now() / (24 * 60 * 60 * 1000));
   const html = await renderSpellingSurfaceFixture({
     phase: 'setup',
@@ -541,20 +543,20 @@ test('Workshop section card markup wires Smart / Trouble / Test through spelling
     },
   });
 
-  // All three legacy modes get a card inside the Workshop body, each wired
+  // All three legacy modes get a list-row inside the popover, each wired
   // through the same `spelling-shortcut-start` action that Alt+1/2/3 use.
   // React's renderer does not preserve a stable JSX-prop attribute order, so
   // assert each attribute independently rather than as a single ordered run.
   for (const modeId of ['smart', 'trouble', 'test']) {
     const cardRegex = new RegExp(`<button[^>]*data-test-id="workshop-card-${modeId}"[^>]*>`);
     const match = html.match(cardRegex);
-    assert.ok(match, `Workshop card for mode "${modeId}" should render`);
+    assert.ok(match, `Workshop popover card for mode "${modeId}" should render`);
     const cardOpenTag = match[0];
     assert.match(cardOpenTag, /data-action="spelling-shortcut-start"/);
     assert.match(cardOpenTag, new RegExp(`data-mode="${modeId}"`));
   }
-  // The Alt+1/2/3 quick-key hint sits at the bottom of the body so kids can
-  // discover the keyboard parity without pressing the button.
+  // The Alt+1/2/3 quick-key hint sits at the foot of the popover so kids
+  // can discover the keyboard parity without pressing the button.
   assert.match(html, /<kbd>Alt<\/kbd>/);
   assert.match(html, /<kbd>1<\/kbd>/);
   assert.match(html, /<kbd>2<\/kbd>/);


### PR DESCRIPTION
## Summary

- The Workshop section from PR #347 was clipped off-screen because the post-Mega hero card has `min-height: 610px; overflow: hidden;`. Graduated learners saw the dashboard but no visible affordance to reach Smart / Trouble / Test.
- **Move the toggle into the hero card's upper-right clear zone as a floating pill chip.** Click opens a popover anchored to the chip's bottom-right corner. The popover floats above siblings and costs zero hero-card height.
- Cards inside the popover dispatch byte-identical `spelling-shortcut-start` payloads to Alt+1/2/3 — engine unchanged, Mega never drops.

## What changed

- `SpellingSetupScene.jsx::WorkshopSection` — re-shape from below-fold section to floating chip + popover. Adds outside-click + Esc auto-dismiss via a single `useEffect`.
- `styles/app.css` — replace the `.workshop-toggle` / `.workshop-row` block (~250 lines) with `.workshop-chip` + `.workshop-popover` (paper-translucent backdrop blur, dotted indent stripe on list-row hover, paper-cream popover with drop shadow).
- `tests/react-spelling-surface.test.js` — update 3 tests to match the new markup (chip default-closed, absence on legacy dashboard, popover card → shortcut-start wiring).

## Verify

- [x] `npm run build` — 706 KB main bundle (unchanged from baseline)
- [x] `node ./scripts/run-node-tests.mjs tests/react-spelling-surface.test.js` — 27/27 pass
- [ ] Browser smoke (post-merge) — Eugenia logs in → expect chip visible upper-right of hero, click opens popover with 3 modes, Esc / outside-click closes, selecting a mode starts a session

## Notes

- Auto-dismiss handles three close cases: (a) outside-click via `mousedown` listener on `document`, (b) `Escape` key via `keydown` listener on `document`, (c) after selecting a mode (state set to closed before the session-start dispatch fires). Listeners only attach while `open === true` so there's no idle-time cost.
- `useRef(sectionRef)` anchors the click-outside check; the chip + popover share the same wrapper so clicks on either count as inside.
- `prefers-reduced-motion` opts out of the chevron rotation + popover reveal transitions.
- A separate text-contrast issue is visible on light hero backdrops (lede + stat ribbon labels using `--mode-card-copy` cascade incorrectly when `useSetupHeroContrast` returns light shell). I'll address that in a follow-up PR — it's a different concern from the Workshop placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)