### PR TITLE
feat(spelling): editorial cleanup of the post-Mega hero (busy layout + text contrast)

### DIFF
--- a/src/subjects/spelling/components/SpellingSetupScene.jsx
+++ b/src/subjects/spelling/components/SpellingSetupScene.jsx
@@ -70,6 +70,7 @@ function PostMegaModeCard({
   textTone = 'dark',
   disabled = false,
   active = false,
+  cta = null,
 }) {
   const classes = ['mode-card', 'mode-card-post'];
   if (variant) classes.push(`mode-card-post--${variant}`);
@@ -96,11 +97,34 @@ function PostMegaModeCard({
       </div>
       <h4>{mode.title}</h4>
       <p>{description != null ? description : mode.desc}</p>
-      {/* The Guardian card intentionally does NOT host an inline Begin button
-       * — a single primary CTA lives in the setup-begin-row below so there
-       * is one clear "start now" affordance per scene. In the rested state
-       * we surface a static "Rested" chip instead. */}
-      {variant === 'rested' ? (
+      {/* Inline CTA + kbd hint. Each active card now carries its own "Begin →"
+       * affordance so the scene no longer needs three stacked Begin buttons
+       * underneath. The kbd hint pairs with the CTA visually so kids can
+       * connect the click and the keyboard shortcut at the point of action. */}
+      {cta ? (
+        <div className="mode-card-post-cta-row">
+          <button
+            type="button"
+            className="mode-card-post-cta"
+            data-action={cta.action || 'spelling-shortcut-start'}
+            data-mode={cta.modeId || mode.id}
+            data-pattern-id={cta.patternId || undefined}
+            data-testid={cta.testId || undefined}
+            aria-label={cta.ariaLabel || mode.ariaLabel || `Begin ${mode.title}`}
+            disabled={cta.disabled || false}
+            onClick={cta.onClick}
+          >
+            <span>{cta.label || 'Begin'}</span>
+            <ArrowRightIcon />
+          </button>
+          {cta.altKey ? (
+            <span className="mode-card-post-cta-key" aria-hidden="true">
+              <kbd>Alt</kbd>
+              <kbd>{cta.altKey}</kbd>
+            </span>
+          ) : null}
+        </div>
+      ) : variant === 'rested' ? (
         <span className="mode-card-post-status" role="status">Rested</span>
       ) : null}
     </div>
@@ -803,22 +827,11 @@ function PostMegaSetupContent({
   }
 
   const beginDisabled = startDisabled || runtimeReadOnly || !guardianActive;
-  const beginText = pendingCommand === 'start-session'
-    ? 'Starting...'
-    : pendingCommand === 'save-prefs'
-      ? 'Saving...'
-      : 'Begin Guardian Mission';
-  // U10: Boss Begin button shares the same pending-command gating as the
-  // Guardian Begin — both go through `spelling-shortcut-start` and both
-  // collide on the same `start-session` pending slot. Sharing `beginText`'s
-  // "Starting..." branch would conflate which button is spinning, so Boss
-  // owns its own label but reuses the same disable predicate.
+  // Boss Dictation Begin gate. Each card now hosts its own inline CTA so
+  // there is no separate Begin button row — the per-card CTA reads its
+  // disabled state from these gates and labels itself locally via the
+  // shared "pendingCommand === 'start-session'" branch in the cta prop.
   const bossBeginDisabled = startDisabled || runtimeReadOnly || !bossActive;
-  const bossBeginText = pendingCommand === 'start-session'
-    ? 'Starting...'
-    : pendingCommand === 'save-prefs'
-      ? 'Saving...'
-      : 'Begin Boss Dictation';
 
   // U11: Pattern Quest Begin gate. Requires at least one launched pattern
   // (≥4 tagged core words). `launchedPatternIds` comes from
@@ -832,11 +845,6 @@ function PostMegaSetupContent({
   const patternQuestActive = bossActive && launchedPatternIds.length > 0;
   const firstLaunchedPatternId = launchedPatternIds[0] || '';
   const patternQuestBeginDisabled = startDisabled || runtimeReadOnly || !patternQuestActive;
-  const patternQuestBeginText = pendingCommand === 'start-session'
-    ? 'Starting...'
-    : pendingCommand === 'save-prefs'
-      ? 'Saving...'
-      : 'Begin Pattern Quest';
 
   function handleBegin(event) {
     if (beginDisabled) {
@@ -906,15 +914,17 @@ function PostMegaSetupContent({
           textTone={heroContrast.contrast.cards?.[0] || heroContrast.contrast.shell}
           active={guardianActive}
           disabled={!guardianActive}
+          cta={guardianActive ? {
+            label: pendingCommand === 'start-session' ? 'Starting…' : 'Begin patrol',
+            onClick: handleBegin,
+            disabled: beginDisabled,
+            altKey: '4',
+            ariaLabel: 'Begin Guardian Mission',
+          } : null}
         />
-        {/* U10: Boss Dictation active card. The variant matches Guardian's
-            active/rested split — `active` when `allWordsMega === true`
-            (always true inside PostMegaSetupContent), `rested` otherwise. We
-            pass the Boss description straight from POST_MEGA_MODE_CARDS so a
-            future copy tweak is a one-line change in the view-model, and keep
-            the badge in this file so a future variant (e.g. "RECENT SCORE
-            9/10") can render conditionally without touching the view-model
-            frozen array. */}
+        {/* U10: Boss Dictation card now hosts its own inline Begin CTA
+            ("Begin Boss") + Alt+5 hint when active, replacing the previous
+            stacked button under the row. */}
         {bossCard ? (
           <PostMegaModeCard
             mode={bossCard}
@@ -924,12 +934,18 @@ function PostMegaSetupContent({
             textTone={heroContrast.contrast.cards?.[1] || heroContrast.contrast.shell}
             active={bossActive}
             disabled={!bossActive}
+            cta={bossActive ? {
+              label: pendingCommand === 'start-session' ? 'Starting…' : 'Begin Boss',
+              onClick: handleBossBegin,
+              disabled: bossBeginDisabled,
+              altKey: '5',
+              ariaLabel: bossCard.ariaLabel || 'Begin Boss Dictation',
+            } : null}
           />
         ) : null}
-        {/* U11: Pattern Quest active card — sits alongside Guardian + Boss
-            on the post-Mega dashboard. Active variant when at least one
-            pattern has ≥4 tagged core words (launchedPatternIds.length > 0);
-            rested otherwise with copy explaining the threshold. */}
+        {/* U11: Pattern Quest card — `active` when at least one pattern has
+            ≥4 tagged core words. Rested state shows the threshold copy
+            without a CTA; active state surfaces the inline Begin Quest. */}
         {patternQuestCard ? (
           <PostMegaModeCard
             mode={patternQuestCard}
@@ -941,90 +957,38 @@ function PostMegaSetupContent({
             textTone={heroContrast.contrast.cards?.[2] || heroContrast.contrast.shell}
             active={patternQuestActive}
             disabled={!patternQuestActive}
+            cta={patternQuestActive ? {
+              label: pendingCommand === 'start-session' ? 'Starting…' : 'Begin Quest',
+              onClick: handlePatternQuestBegin,
+              disabled: patternQuestBeginDisabled,
+              modeId: 'pattern-quest',
+              patternId: firstLaunchedPatternId,
+              testId: 'pattern-quest-begin',
+              ariaLabel: patternQuestCard.ariaLabel || 'Begin Pattern Quest',
+            } : null}
           />
         ) : null}
-        {placeholderCards.map((mode, index) => (
-          <PostMegaModeCard
-            mode={mode}
-            variant="placeholder"
-            // Roadmap index bumps to 3 / 4 because Guardian (#0), Boss (#1),
-            // and Pattern Quest (#2) occupy slots 0, 1, 2; the "Next 04" /
-            // "Next 05" chips on the placeholders communicate the P2
-            // roadmap position.
-            index={index + 3}
-            textTone={heroContrast.contrast.cards?.[index + 3] || heroContrast.contrast.shell}
-            disabled
-            key={mode.id}
-          />
-        ))}
       </div>
-      <div className="setup-begin-row post-mega-begin-row">
-        <div className="post-mega-begin-hint" aria-hidden={guardianActive ? undefined : 'true'}>
-          <kbd>Alt</kbd>
-          <span className="post-mega-begin-hint-join">+</span>
-          <kbd>4</kbd>
-          <span className="post-mega-begin-hint-label">quick-start Guardian Mission</span>
-        </div>
-        <button
-          type="button"
-          className="btn primary xl"
-          style={{ '--btn-accent': accent }}
-          data-action="spelling-shortcut-start"
-          data-mode="guardian"
-          disabled={beginDisabled}
-          onClick={handleBegin}
+      {/* Coming-next footer — placeholder modes (Word Detective / Story
+          Challenge) collapse from full mode cards into a single quiet line
+          that preserves the roadmap signal without taking real estate. The
+          eyebrow + serif italic titles read as a magazine "Up next" footer. */}
+      {placeholderCards.length > 0 ? (
+        <p
+          className="post-mega-coming-next"
+          data-test-id="post-mega-coming-next"
         >
-          {beginText} <ArrowRightIcon />
-        </button>
-        {/* U10: Boss Begin row. Mirrors the Guardian begin-row structure —
-            hint chip + primary CTA — but dispatches `spelling-shortcut-start`
-            with `{ mode: 'boss', length: BOSS_DEFAULT_ROUND_LENGTH }`. The
-            Alt+5 hint is aria-hidden when Boss is inactive so screen readers
-            don't announce a shortcut that won't work; the begin button
-            itself stays disabled with a conservative CTA label. */}
-        {bossCard ? (
-          <>
-            <div className="post-mega-begin-hint" aria-hidden={bossActive ? undefined : 'true'}>
-              <kbd>Alt</kbd>
-              <span className="post-mega-begin-hint-join">+</span>
-              <kbd>5</kbd>
-              <span className="post-mega-begin-hint-label">quick-start Boss Dictation</span>
-            </div>
-            <button
-              type="button"
-              className="btn primary xl"
-              style={{ '--btn-accent': accent }}
-              data-action="spelling-shortcut-start"
-              data-mode="boss"
-              disabled={bossBeginDisabled}
-              onClick={handleBossBegin}
-              aria-label={bossCard.ariaLabel || 'Begin Boss Dictation'}
-            >
-              {bossBeginText} <ArrowRightIcon />
-            </button>
-          </>
-        ) : null}
-        {/* U11: Pattern Quest Begin row. Alt+6 shortcut is deferred to a
-            follow-up; the button still dispatches `spelling-shortcut-start`
-            with `{ mode: 'pattern-quest', patternId }` so the service
-            selector receives the first launched pattern id. */}
-        {patternQuestCard ? (
-          <button
-            type="button"
-            className="btn primary xl"
-            style={{ '--btn-accent': accent }}
-            data-action="spelling-shortcut-start"
-            data-mode="pattern-quest"
-            data-pattern-id={firstLaunchedPatternId}
-            data-testid="pattern-quest-begin"
-            disabled={patternQuestBeginDisabled}
-            onClick={handlePatternQuestBegin}
-            aria-label={patternQuestCard.ariaLabel || 'Begin Pattern Quest'}
-          >
-            {patternQuestBeginText} <ArrowRightIcon />
-          </button>
-        ) : null}
-      </div>
+          <span className="post-mega-coming-next-eyebrow">Coming next</span>
+          <span className="post-mega-coming-next-list">
+            {placeholderCards.map((mode, idx) => (
+              <React.Fragment key={mode.id}>
+                {idx > 0 ? <span className="post-mega-coming-next-sep" aria-hidden="true">·</span> : null}
+                <span className="post-mega-coming-next-title">{mode.title}</span>
+              </React.Fragment>
+            ))}
+          </span>
+        </p>
+      ) : null}
       <WorkshopSection
         prefs={prefs}
         actions={actions}

--- a/src/subjects/spelling/components/SpellingSetupScene.jsx
+++ b/src/subjects/spelling/components/SpellingSetupScene.jsx
@@ -323,11 +323,12 @@ function SetupStatGrid({ stats }) {
 // "non-learner" check) guards against future roles slipping past the
 // check; a brand-new role (e.g. 'demo') will render the link only after
 // an explicit code change here, matching the P2 plan's §U1 ICO posture.
-const POST_MASTERY_DEBUG_ROLES = new Set(['admin', 'ops']);
-
-function adultCanSeePostMasteryDebug(platformRole) {
-  return POST_MASTERY_DEBUG_ROLES.has(String(platformRole || ''));
-}
+//
+// 2026-04-27 update: the inline "Why is Guardian locked?" link is removed.
+// The diagnostic panel itself stays in the Admin hub for ops use; we just
+// stop pitching it from the spelling setup scene. Admins land in the Admin
+// hub through the existing nav, so the inline footnote was redundant noise
+// for the very small audience that could see it.
 
 export function SpellingSetupScene({
   learner,
@@ -391,13 +392,6 @@ export function SpellingSetupScene({
   const contentClasses = ['setup-content'];
   if (isPostMega) contentClasses.push('setup-content--post-mega');
   if (isHydrationChecking) contentClasses.push('setup-content--checking');
-
-  // P2 U1: admin / ops adults see a "Why is Guardian locked?" diagnostic
-  // link right below the setup hero when Guardian Mission is NOT unlocked
-  // (i.e. `isPostMega === false`). Child / parent surfaces get `platformRole`
-  // empty (defaulted) or === 'parent' and the link never renders. Routed
-  // to the admin hub where the post-mega debug panel explains the counts.
-  const showPostMasteryDebugLink = adultCanSeePostMasteryDebug(platformRole) && !isPostMega;
 
   // P2 U5: soft-lockout banner state. Renders above the setup hero when a
   // sibling tab holds the write lock, or when the browser has no Web Locks
@@ -492,21 +486,6 @@ export function SpellingSetupScene({
               startDisabled={startDisabled}
             />
           )}
-          {showPostMasteryDebugLink ? (
-            <p className="small muted post-mastery-debug-link" data-adult-debug="post-mastery">
-              <button
-                type="button"
-                className="btn ghost"
-                data-action="open-admin-hub"
-                onClick={(event) => renderAction(actions, event, 'open-admin-hub')}
-              >
-                Why is Guardian locked?
-              </button>
-              <span className="small muted" style={{ marginLeft: 8 }}>
-                Adult-only diagnostic. Opens the Admin / Operations hub post-mega debug panel.
-              </span>
-            </p>
-          ) : null}
         </div>
       </section>
 

--- a/styles/app.css
+++ b/styles/app.css
@@ -4645,16 +4645,24 @@ textarea:focus-visible {
   letter-spacing: 0.22em;
   font-weight: 700;
   color: color-mix(in oklab, var(--brand) 72%, var(--ink));
+  /* Resilience shadow — engine sets `--mode-card-copy-shadow` per shell
+     tone (light shadow for dark hero, dark shadow for light hero). The
+     fallback handles the rare case where the engine misdetects luminance
+     on a mixed backdrop image (e.g. light sky + dark mountains). */
+  text-shadow: var(--mode-card-copy-shadow, 0 1px 10px rgba(0, 0, 0, 0.22));
 }
 .setup-content--post-mega .title.post-mega-title {
   font-family: var(--font-serif);
   letter-spacing: -0.018em;
   line-height: 1.05;
   max-width: 22ch;
+  color: var(--mode-card-title, var(--ink));
+  text-shadow: var(--mode-card-heading-shadow, 0 1px 12px rgba(0, 0, 0, 0.22));
 }
 .setup-content--post-mega .lede.post-mega-lede {
   max-width: 58ch;
-  color: var(--mode-card-copy, var(--muted));
+  color: var(--mode-card-copy, var(--ink));
+  text-shadow: var(--mode-card-copy-shadow, 0 1px 10px rgba(0, 0, 0, 0.22));
 }
 .post-mega-stat-ribbon {
   margin: 18px 0 4px;
@@ -4699,8 +4707,11 @@ textarea:focus-visible {
 .post-mega-stat--wobbling dd { color: color-mix(in oklab, var(--bad-strong, #b3372c) 88%, var(--ink)); }
 
 .mode-row.mode-row-post-mega {
-  grid-template-columns: minmax(0, 1.6fr) repeat(3, minmax(0, 1fr));
-  grid-auto-rows: minmax(196px, auto);
+  /* Three-column layout — Guardian wide (1.6fr) + Boss + Pattern Quest.
+     Roadmap placeholders moved to the `.post-mega-coming-next` footer
+     line so the active triad sits on a single row at most viewports. */
+  grid-template-columns: minmax(0, 1.6fr) repeat(2, minmax(0, 1fr));
+  grid-auto-rows: minmax(204px, auto);
   gap: 14px;
   margin-top: 22px;
 }
@@ -4845,12 +4856,81 @@ textarea:focus-visible {
   letter-spacing: 0.02em;
   color: color-mix(in oklab, var(--brand) 72%, var(--ink));
 }
-.mode-card-post-cta {
+/* Inline mode-card CTA — each active post-Mega card carries its own
+   "Begin →" pill at the bottom of the card, paired with a small Alt+N
+   kbd hint. Replaces the old stacked Begin button row beneath the cards
+   (see post-Mega Workshop redesign 2026-04-27). The pill is anchored to
+   the brand accent so the eye reads it as the primary action regardless
+   of hero backdrop tone. */
+.mode-card-post-cta-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
   margin-top: auto;
-  align-self: flex-start;
-  padding: 8px 14px;
-  font-size: 0.92rem;
-  border-radius: calc(var(--radius) - 6px);
+  padding-top: 12px;
+}
+.mode-card-post-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 14px 7px 16px;
+  background: color-mix(in oklab, var(--brand) 88%, transparent);
+  border: 1px solid color-mix(in oklab, white 36%, transparent);
+  border-radius: 999px;
+  color: #fff;
+  font: inherit;
+  font-size: 0.86rem;
+  font-weight: 500;
+  letter-spacing: 0.005em;
+  cursor: pointer;
+  transition:
+    transform 200ms ease,
+    background 200ms ease,
+    box-shadow 200ms ease;
+}
+.mode-card-post-cta:hover {
+  transform: translateY(-1px);
+  background: color-mix(in oklab, var(--brand) 96%, transparent);
+  box-shadow: 0 14px 26px -18px color-mix(in oklab, var(--brand) 70%, transparent);
+}
+.mode-card-post-cta:focus-visible {
+  outline: 2px solid color-mix(in oklab, white 78%, transparent);
+  outline-offset: 2px;
+}
+.mode-card-post-cta[disabled] {
+  cursor: not-allowed;
+  opacity: 0.55;
+  filter: saturate(0.7);
+  box-shadow: none;
+  transform: none;
+}
+.mode-card-post-cta svg {
+  width: 14px;
+  height: 14px;
+}
+.mode-card-post-cta-key {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  flex-shrink: 0;
+  font-size: 0.66rem;
+  letter-spacing: 0.05em;
+  color: var(--mode-card-copy, color-mix(in oklab, var(--brand) 60%, var(--muted)));
+  opacity: 0.78;
+  text-shadow: var(--mode-card-copy-shadow, none);
+}
+.mode-card-post-cta-key kbd {
+  display: inline-block;
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-family: var(--font-mono, ui-monospace, 'SFMono-Regular', Menlo, monospace);
+  font-size: 0.66rem;
+  font-weight: 600;
+  line-height: 1.1;
+  background: color-mix(in oklab, var(--panel) 40%, transparent);
+  border: 1px solid color-mix(in oklab, var(--brand) 22%, transparent);
+  color: color-mix(in oklab, var(--brand) 78%, var(--ink));
 }
 .mode-card-post-status {
   margin-top: auto;
@@ -4864,39 +4944,45 @@ textarea:focus-visible {
   letter-spacing: 0.04em;
   border: 1px dashed color-mix(in oklab, var(--brand) 36%, transparent);
 }
-.setup-begin-row.post-mega-begin-row {
-  justify-content: space-between;
-  align-items: center;
-  margin-top: 28px;
-  gap: 18px;
+
+/* Coming-next footer — placeholder modes (Word Detective / Story Challenge)
+   collapse into a single quiet line so the post-Mega scene no longer carries
+   two empty striped cards on a second row. Eyebrow + serif italic titles
+   read as a magazine "Up next" footer rather than a carousel of stubs. */
+.post-mega-coming-next {
+  display: flex;
+  align-items: baseline;
   flex-wrap: wrap;
+  gap: 12px;
+  margin: 22px 0 0;
+  padding-top: 14px;
+  border-top: 1px dashed color-mix(in oklab, var(--brand) 16%, var(--line));
+  font-size: 0.84rem;
+  color: var(--mode-card-copy, var(--muted));
+  text-shadow: var(--mode-card-copy-shadow, none);
 }
-.post-mega-begin-hint {
+.post-mega-coming-next-eyebrow {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: color-mix(in oklab, var(--brand) 56%, var(--muted));
+  opacity: 0.92;
+}
+.post-mega-coming-next-list {
   display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 0.8rem;
-  color: color-mix(in oklab, var(--mode-card-copy, var(--muted)) 88%, transparent);
-  opacity: 0.86;
+  align-items: baseline;
+  gap: 10px;
+  flex-wrap: wrap;
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: 0.96rem;
+  letter-spacing: -0.005em;
+  color: color-mix(in oklab, var(--mode-card-copy, var(--ink)) 88%, transparent);
 }
-.post-mega-begin-hint[aria-hidden="true"] { opacity: 0.3; }
-.post-mega-begin-hint kbd {
-  display: inline-block;
-  padding: 2px 6px;
-  border-radius: 5px;
-  font-family: var(--font-mono, ui-monospace, 'SFMono-Regular', Menlo, monospace);
-  font-size: 0.72rem;
-  font-weight: 600;
-  line-height: 1.1;
-  background: color-mix(in oklab, var(--panel) 45%, transparent);
-  border: 1px solid color-mix(in oklab, var(--brand) 28%, transparent);
-  color: color-mix(in oklab, var(--brand) 80%, var(--ink));
-  box-shadow: inset 0 -1px 0 color-mix(in oklab, black 10%, transparent);
-}
-.post-mega-begin-hint-join { opacity: 0.55; font-weight: 600; }
-.post-mega-begin-hint-label {
-  letter-spacing: 0.02em;
-  margin-left: 4px;
+.post-mega-coming-next-sep {
+  opacity: 0.45;
+  font-style: normal;
 }
 
 /* P2 U4: "Checking Word Vault..." skeleton scene for the ~500ms hydration

--- a/tests/button-label-consistency.test.js
+++ b/tests/button-label-consistency.test.js
@@ -438,9 +438,6 @@ test('button labels: every statically extractable label is classified', () => {
     'Refresh',
     'Retry refresh',
     'Save learner profile',
-    // P2 U1: admin / ops post-mega diagnostic link — bespoke debug affordance
-    // that opens the Admin Hub post-mega panel. Not a canonical verb.
-    'Why is Guardian locked?',
     // P2 U5: soft-lockout banner "Use this tab anyway" action. Drives the
     // `navigator.locks.request({ steal: true })` path to force ownership
     // when a sibling tab holds the write lock.

--- a/tests/react-spelling-surface.test.js
+++ b/tests/react-spelling-surface.test.js
@@ -198,14 +198,21 @@ test('React spelling setup scene renders the post-Mega dashboard with Guardian M
   assert.match(html, /The Word Vault is yours/);
   assert.match(html, /Guardian Mission/);
   assert.match(html, /Boss Dictation/);
+  // Roadmap placeholders (Word Detective / Story Challenge) collapse from
+  // full mode cards into a single quiet "Coming next" footer line so the
+  // post-Mega scene no longer carries two empty striped cards on row 2.
+  // The titles remain in the markup (still part of the journey signal),
+  // just rendered as inline serif italic items instead of cards.
   assert.match(html, /Word Detective/);
   assert.match(html, /Story Challenge/);
-  // Placeholder roadmap labels should show "Next 02/03/04" rather than a
-  // single generic "Coming soon" shield, so the codex reads as planned steps.
-  assert.match(html, /mc-badge-roadmap/);
-  // The begin button explicitly routes through spelling-shortcut-start with
-  // mode=guardian so the module-level gate is the one source of truth.
+  assert.match(html, /post-mega-coming-next/);
+  assert.match(html, />Coming next</);
+  // The Guardian Begin CTA now lives INSIDE the Guardian mode card as an
+  // inline pill, replacing the previous stacked Begin button row beneath
+  // the cards. Still routes through spelling-shortcut-start so the
+  // module-level gate stays the single source of truth.
   assert.match(html, /data-action="spelling-shortcut-start"[^>]*data-mode="guardian"/);
+  assert.match(html, /class="mode-card-post-cta"/);
   assert.match(html, /ACTIVE DUTY/);
   assert.doesNotMatch(html, /Choose today/);
 });
@@ -241,9 +248,11 @@ test('U1: React setup scene shows optional-patrol copy when post-Mega but no wor
   assert.match(html, /No urgent duties\. Optional patrol available/);
   assert.match(html, /OPTIONAL PATROL/);
   assert.match(html, /data-mission-state="optional-patrol"/);
-  // The Begin CTA must be enabled in optional-patrol so the learner can
-  // choose to run a warm-up round.
-  assert.match(html, /<button[^>]*data-action="spelling-shortcut-start"[^>]*data-mode="guardian"[^>]*>Begin Guardian Mission/);
+  // The Begin CTA (now an inline pill inside the Guardian card) must be
+  // enabled in optional-patrol so the learner can choose to run a warm-up
+  // round. Label is "Begin patrol" — the inline-card scope no longer needs
+  // to repeat "Guardian Mission" because the surrounding card carries it.
+  assert.match(html, /<button[^>]*data-action="spelling-shortcut-start"[^>]*data-mode="guardian"[^>]*>(?:[^<]|<(?!\/button))*Begin patrol/);
   assert.doesNotMatch(html, /<button[^>]*data-action="spelling-shortcut-start"[^>]*data-mode="guardian"[^>]*disabled=""/);
 });
 

--- a/tests/spelling-boss.test.js
+++ b/tests/spelling-boss.test.js
@@ -936,8 +936,16 @@ test('U10 dashboard: Alt+5 hint microcopy present when Boss card is active', () 
   harness.dispatch('open-subject', { subjectId: 'spelling' });
 
   const html = harness.render();
-  // Alt+5 hint mirrors Alt+4 hint ("quick-start Guardian Mission").
-  assert.match(html, /quick-start Boss Dictation/i, 'Alt+5 hint microcopy rendered');
+  // Post-redesign (2026-04-27): the standalone "quick-start Boss Dictation"
+  // hint label was retired together with the begin-row beneath the cards.
+  // The Alt+5 hint now lives inline next to the Boss card's "Begin Boss"
+  // pill — assert the kbd pair is present alongside the Boss card itself.
+  const bossCardRegex = /<div[^>]*data-mode-id="boss-dictation"[\s\S]*?<\/div>\s*<\/div>/;
+  const bossCardMatch = html.match(bossCardRegex);
+  assert.ok(bossCardMatch, 'Boss card markup rendered');
+  const bossCardMarkup = bossCardMatch[0];
+  assert.match(bossCardMarkup, /<kbd>Alt<\/kbd><kbd>5<\/kbd>/, 'Alt+5 inline kbd hint rendered next to Boss card CTA');
+  assert.match(bossCardMarkup, /class="mode-card-post-cta-key"/, 'inline cta-key span wraps the kbd hint');
 });
 
 test('U10 dashboard: dispatch via spelling-shortcut-start mode=boss lands on Boss session (alt+5 wiring)', () => {

--- a/tests/spelling-post-mastery-debug.test.js
+++ b/tests/spelling-post-mastery-debug.test.js
@@ -623,34 +623,27 @@ test('U1 integration: admin hub response returns empty postMasteryDebug envelope
 });
 
 // --------------------------------------------------------------------------
-// SpellingSetupScene adult-only link: role gating.
+// SpellingSetupScene adult-only link: removed 2026-04-27.
 // --------------------------------------------------------------------------
+// The inline "Why is Guardian locked?" link previously rendered for admin
+// and ops roles when `isPostMega === false`. It pitched the Admin hub's
+// post-mastery diagnostic panel from the spelling setup scene. The panel
+// itself remains in the Admin hub (under the same heading), but the inline
+// link was redundant chrome for the small audience that could see it, so
+// the setup scene no longer surfaces it for any role.
 
-test('U1 integration: setup scene renders adult-only post-mastery debug link for admin role', async () => {
-  const html = await renderSetupSceneViaBundle({ platformRole: 'admin' });
-  assert.match(html, /Why is Guardian locked\?/);
-  assert.match(html, /data-adult-debug="post-mastery"/);
-  assert.match(html, /data-action="open-admin-hub"/);
-});
-
-test('U1 integration: setup scene renders adult-only post-mastery debug link for ops role', async () => {
-  const html = await renderSetupSceneViaBundle({ platformRole: 'ops' });
-  assert.match(html, /Why is Guardian locked\?/);
-  assert.match(html, /data-adult-debug="post-mastery"/);
-});
-
-test('U1 integration: setup scene omits post-mastery debug link for parent role', async () => {
-  const html = await renderSetupSceneViaBundle({ platformRole: 'parent' });
-  assert.doesNotMatch(html, /Why is Guardian locked\?/);
-  assert.doesNotMatch(html, /data-adult-debug="post-mastery"/);
-});
-
-test('U1 integration: setup scene omits post-mastery debug link when platformRole is empty', async () => {
-  const html = await renderSetupSceneViaBundle({ platformRole: '' });
-  assert.doesNotMatch(html, /Why is Guardian locked\?/);
-});
-
-test('U1 integration: setup scene omits post-mastery debug link for learner role', async () => {
-  const html = await renderSetupSceneViaBundle({ platformRole: 'learner' });
-  assert.doesNotMatch(html, /Why is Guardian locked\?/);
+test('setup scene never renders the post-mastery debug inline link, regardless of role', async () => {
+  for (const platformRole of ['admin', 'ops', 'parent', 'learner', '']) {
+    const html = await renderSetupSceneViaBundle({ platformRole });
+    assert.doesNotMatch(
+      html,
+      /data-adult-debug="post-mastery"/,
+      `inline post-mastery debug link must not render for role="${platformRole}"`,
+    );
+    assert.doesNotMatch(
+      html,
+      /class="[^"]*post-mastery-debug-link/,
+      `inline post-mastery debug link CSS class must not render for role="${platformRole}"`,
+    );
+  }
 });


### PR DESCRIPTION
## Summary

Two issues surfaced after the Workshop chip relocation:

1. **Busy layout** — five mode cards across two rows + three stacked Begin buttons + two Alt-key hint lines = visual noise, especially on a Y6 graduate's recurring practice surface.
2. **Text contrast** — on light hero backdrops the `useSetupHeroContrast` engine could misdetect luminance and leave the lede + ribbon labels light-on-light.

This PR is a coordinated cleanup that addresses both, plus a small chrome removal the user flagged in the same review.

## Three coordinated moves

### 1. Inline mode-card CTAs

Each active card now hosts its own `Begin patrol / Begin Boss / Begin Quest` pill plus a small `Alt+N` kbd hint anchored to the card. The stacked Begin button row beneath the cards is gone — **one CTA per card, one source of truth**.

### 2. Roadmap placeholders → coming-next footer

Word Detective and Story Challenge collapse from full mode cards into a single quiet `Coming next: Word Detective · Story Challenge` line below the active triad. The mode row settles into a clean three-column layout (Guardian wide + Boss + Pattern Quest); placeholders preserve the roadmap signal in a magazine "up next" footer instead of two empty striped cards on row 2.

### 3. Engine-token text shadows on hero copy

`.post-mega-eyebrow` / `.post-mega-title` / `.post-mega-lede` finally bind to `--mode-card-*-shadow` so the engine's per-tone shadow tokens reach them. Defensive fallback shadows (`0 1px 10px rgba(0,0,0,0.22)`) keep the copy readable on misdetected mixed backdrops too.

## Bonus removal

Dropped the inline **"Why is Guardian locked?"** admin/ops debug link that pre-Mega learners' adult viewers saw under the legacy setup scene. The Admin hub keeps the same diagnostic panel — admins reach it through the nav — so the inline pitch was redundant for the small audience that could see it.

## Verify

- [x] `npm run build` — 704.9 KB main bundle (down ~1 KB from 706 KB; begin-row CSS removal nets out the new card-CTA / coming-next styles)
- [x] `node ./scripts/run-node-tests.mjs tests/react-spelling-surface.test.js tests/spelling-boss.test.js tests/spelling-post-mastery-debug.test.js tests/button-label-consistency.test.js` — full green
- [x] Broader spelling sweep (`spelling-parity` / `view-model` / `guardian` / `mega-invariant` / `remote-actions`) — 294/294 pass
- [ ] Browser smoke (post-merge) — Eugenia logs in → expect three active cards on one row, each with its own Begin pill + Alt+N inline hint, "Coming next" footer below, Workshop chip top-right, lede + stat ribbon readable across hero brightness

## Notes

- Engine-token cascade was already correct for `mode-card[data-text-tone]`. This PR just extends the binding into the bare hero copy — no engine changes.
- `platformRole` prop kept on the scene signature for callers; only the inline link consumer was removed. Future callers can re-bind without needing a new prop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)