### PR TITLE
feat(admin): U3 TopNav admin entry point

### DIFF
--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -80,7 +80,7 @@ function SharedOverlays({ appState, actions, controller }) {
   );
 }
 
-function SubjectTopNav({ chrome, actions }) {
+function SubjectTopNav({ chrome, actions, currentScreen }) {
   return (
     <TopNav
       theme={chrome.theme}
@@ -95,6 +95,9 @@ function SubjectTopNav({ chrome, actions }) {
       onLogout={actions.logout}
       persistenceMode={chrome.persistence?.mode || 'local-only'}
       persistenceLabel={chrome.persistence?.label || ''}
+      platformRole={chrome.session?.platformRole}
+      onOpenAdmin={actions.openAdminHub}
+      currentScreen={currentScreen}
     />
   );
 }
@@ -226,7 +229,7 @@ export function App({ controller, runtime }) {
 
       {screen === 'subject' && (
         <div className={subjectShellClassName}>
-          <SubjectTopNav chrome={runtime.buildSurfaceChromeModel(appState)} actions={actions} />
+          <SubjectTopNav chrome={runtime.buildSurfaceChromeModel(appState)} actions={actions} currentScreen={screen} />
           <PersistenceBanner snapshot={appState.persistence} onRetry={actions.retryPersistence} />
           <SubjectRoute key={routedSubjectId} appState={appState} context={context} actions={actions} />
           <SharedOverlays appState={appState} actions={actions} controller={controller} />
@@ -248,7 +251,7 @@ export function App({ controller, runtime }) {
 
       {screen === 'parent-hub' && (
         <div className="app-shell">
-          <SubjectTopNav chrome={runtime.buildSurfaceChromeModel(appState)} actions={actions} />
+          <SubjectTopNav chrome={runtime.buildSurfaceChromeModel(appState)} actions={actions} currentScreen={screen} />
           <PersistenceBanner snapshot={appState.persistence} onRetry={actions.retryPersistence} />
           <Suspense fallback={<LoadingSkeleton rows={6} />}>
             <ParentHubSurface
@@ -265,7 +268,7 @@ export function App({ controller, runtime }) {
 
       {screen === 'admin-hub' && (
         <div className="app-shell">
-          <SubjectTopNav chrome={runtime.buildSurfaceChromeModel(appState)} actions={actions} />
+          <SubjectTopNav chrome={runtime.buildSurfaceChromeModel(appState)} actions={actions} currentScreen={screen} />
           <PersistenceBanner snapshot={appState.persistence} onRetry={actions.retryPersistence} />
           <Suspense fallback={<LoadingSkeleton rows={6} />}>
             <AdminHubSurface
@@ -283,7 +286,7 @@ export function App({ controller, runtime }) {
 
       {!REACT_ROUTES.has(screen) && (
         <div className="app-shell">
-          <SubjectTopNav chrome={runtime.buildSurfaceChromeModel(appState)} actions={actions} />
+          <SubjectTopNav chrome={runtime.buildSurfaceChromeModel(appState)} actions={actions} currentScreen={screen} />
           <PersistenceBanner snapshot={appState.persistence} onRetry={actions.retryPersistence} />
           <UnknownRouteSurface screen={screen} actions={actions} />
           <SharedOverlays appState={appState} actions={actions} controller={controller} />

--- a/src/surfaces/home/CodexSurface.jsx
+++ b/src/surfaces/home/CodexSurface.jsx
@@ -61,6 +61,9 @@ export function CodexSurface({ model, actions }) {
         onLogout={actions.logout}
         persistenceMode={model.persistence?.mode || 'local-only'}
         persistenceLabel={model.persistence?.label || ''}
+        platformRole={model.session?.platformRole}
+        onOpenAdmin={actions.openAdminHub}
+        currentScreen="codex"
       />
 
       <main className="codex-page">

--- a/src/surfaces/home/HomeSurface.jsx
+++ b/src/surfaces/home/HomeSurface.jsx
@@ -64,6 +64,9 @@ export function HomeSurface({ model, actions, shellClassName = 'app-shell' }) {
         onLogout={actions.logout}
         persistenceMode={model.persistence?.mode || 'local-only'}
         persistenceLabel={model.persistence?.label || ''}
+        platformRole={model.session?.platformRole}
+        onOpenAdmin={actions.openAdminHub}
+        currentScreen="dashboard"
       />
 
       <div className="hero-paper" style={{ '--hero-bg': `url('${heroBg}')` }}>

--- a/src/surfaces/profile/ProfileSettingsSurface.jsx
+++ b/src/surfaces/profile/ProfileSettingsSurface.jsx
@@ -113,6 +113,9 @@ function ProfileShell({ chrome, actions, children, appState }) {
         onLogout={actions.logout}
         persistenceMode={chrome.persistence?.mode || 'local-only'}
         persistenceLabel={chrome.persistence?.label || ''}
+        platformRole={chrome.session?.platformRole}
+        onOpenAdmin={actions.openAdminHub}
+        currentScreen="profile-settings"
       />
       <PersistenceBanner snapshot={appState.persistence} onRetry={actions.retryPersistence} />
       {children}

--- a/src/surfaces/shell/TopNav.jsx
+++ b/src/surfaces/shell/TopNav.jsx
@@ -120,7 +120,13 @@ export function TopNav({
   onLogout,
   persistenceMode,
   persistenceLabel,
+  platformRole,
+  onOpenAdmin,
+  currentScreen,
 }) {
+  const showAdminLink = platformRole === 'admin' || platformRole === 'ops';
+  const adminActive = currentScreen === 'admin-hub';
+
   return (
     <header className="topnav">
       <button
@@ -136,6 +142,17 @@ export function TopNav({
         </span>
       </button>
       <div className="nav-right">
+        {showAdminLink && (
+          <button
+            type="button"
+            className={'topnav-admin-link' + (adminActive ? ' is-active' : '')}
+            data-action="open-admin-hub"
+            aria-current={adminActive ? 'page' : undefined}
+            onClick={onOpenAdmin}
+          >
+            Admin
+          </button>
+        )}
         <PersistenceDot mode={persistenceMode} label={persistenceLabel} />
         <UserPill
           learners={learners}

--- a/tests/button-label-consistency.test.js
+++ b/tests/button-label-consistency.test.js
@@ -481,6 +481,10 @@ test('button labels: every statically extractable label is classified', () => {
     // filter form (route / kind / date-range / release / reopened).
     'Apply filters',
     'Clear filters',
+    // P2 U3: TopNav admin entry point — visible only to admin/ops platform
+    // roles. Bespoke label: "Admin" is the short navigation affordance, not
+    // a canonical verb.
+    'Admin',
   ]);
   // Additional unknowns: dump and fail with the full list so U12+ can
   // decide which to promote and which to allowlist. Do NOT add to

--- a/tests/helpers/react-render.js
+++ b/tests/helpers/react-render.js
@@ -1041,6 +1041,40 @@ export function renderSpellingClozeFixture({ sentence, answer = '', revealAnswer
   `);
 }
 
+export function renderTopNavFixture({
+  platformRole = 'parent',
+  currentScreen = 'dashboard',
+  demo = false,
+} = {}) {
+  return renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { TopNav } from ${JSON.stringify(absoluteSpecifier('src/surfaces/shell/TopNav.jsx'))};
+
+    let adminClicked = false;
+    const html = renderToStaticMarkup(
+      <TopNav
+        theme="light"
+        onToggleTheme={() => {}}
+        learners={[{ id: 'learner-a', name: 'Ava', yearGroup: 'Y5' }]}
+        selectedLearnerId="learner-a"
+        learnerLabel="Ava · Y5"
+        signedInAs=${JSON.stringify(demo ? '' : 'user@example.test')}
+        onNavigateHome={() => {}}
+        onSelectLearner={() => {}}
+        onOpenProfileSettings={() => {}}
+        onLogout={() => {}}
+        persistenceMode="local-only"
+        persistenceLabel="Local-only"
+        platformRole={${JSON.stringify(platformRole)}}
+        onOpenAdmin={() => { adminClicked = true; }}
+        currentScreen={${JSON.stringify(currentScreen)}}
+      />
+    );
+    console.log(html);
+  `);
+}
+
 export function renderAppFixture({ route = 'dashboard' } = {}) {
   return renderFixture(`
     import React from 'react';

--- a/tests/react-topnav-admin-link.test.js
+++ b/tests/react-topnav-admin-link.test.js
@@ -1,0 +1,66 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { renderTopNavFixture } from './helpers/react-render.js';
+
+test('Admin user sees "Admin" link in TopNav', async () => {
+  const html = await renderTopNavFixture({ platformRole: 'admin' });
+
+  assert.match(html, /class="topnav-admin-link"/);
+  assert.match(html, /data-action="open-admin-hub"/);
+  assert.match(html, />Admin<\/button>/);
+});
+
+test('Ops user sees "Admin" link in TopNav', async () => {
+  const html = await renderTopNavFixture({ platformRole: 'ops' });
+
+  assert.match(html, /class="topnav-admin-link"/);
+  assert.match(html, /data-action="open-admin-hub"/);
+  assert.match(html, />Admin<\/button>/);
+});
+
+test('Parent user does NOT see "Admin" link in TopNav', async () => {
+  const html = await renderTopNavFixture({ platformRole: 'parent' });
+
+  assert.doesNotMatch(html, /topnav-admin-link/);
+  assert.doesNotMatch(html, /data-action="open-admin-hub"/);
+});
+
+test('Demo session does NOT see "Admin" link in TopNav', async () => {
+  const html = await renderTopNavFixture({ platformRole: 'parent', demo: true });
+
+  assert.doesNotMatch(html, /topnav-admin-link/);
+  assert.doesNotMatch(html, /data-action="open-admin-hub"/);
+});
+
+test('Undefined platformRole does NOT show "Admin" link', async () => {
+  const html = await renderTopNavFixture({ platformRole: undefined });
+
+  assert.doesNotMatch(html, /topnav-admin-link/);
+  assert.doesNotMatch(html, /data-action="open-admin-hub"/);
+});
+
+test('Clicking Admin link targets open-admin-hub action', async () => {
+  const html = await renderTopNavFixture({ platformRole: 'admin' });
+
+  // SSR cannot fire click handlers, but the data-action attribute confirms
+  // the button is wired to the correct action dispatch target.
+  assert.match(html, /data-action="open-admin-hub"/);
+  // The button must also be a real <button> element for accessibility.
+  assert.match(html, /<button[^>]*class="topnav-admin-link"[^>]*>/);
+});
+
+test('When on admin screen, link shows active state', async () => {
+  const html = await renderTopNavFixture({ platformRole: 'admin', currentScreen: 'admin-hub' });
+
+  assert.match(html, /topnav-admin-link is-active/);
+  assert.match(html, /aria-current="page"/);
+});
+
+test('When NOT on admin screen, link does not show active state', async () => {
+  const html = await renderTopNavFixture({ platformRole: 'admin', currentScreen: 'dashboard' });
+
+  assert.match(html, /class="topnav-admin-link"/);
+  assert.doesNotMatch(html, /is-active/);
+  assert.doesNotMatch(html, /aria-current/);
+});


### PR DESCRIPTION
## Summary

- Adds a visible **Admin** link in TopNav for users with `admin` or `ops` platform roles
- Threads `platformRole`, `onOpenAdmin`, and `currentScreen` props through TopNav and all call sites (App.jsx SubjectTopNav, HomeSurface, CodexSurface, ProfileSettingsSurface)
- The link dispatches `open-admin-hub` via the existing `actions.openAdminHub` callback
- When the user is already on the admin-hub screen, the link shows an active state (`is-active` class + `aria-current="page"`)
- Parent users and demo sessions see no Admin link

## Changes

| File | What changed |
|---|---|
| `src/surfaces/shell/TopNav.jsx` | Accept `platformRole`, `onOpenAdmin`, `currentScreen` props; render conditional Admin button |
| `src/app/App.jsx` | Thread `currentScreen` to `SubjectTopNav`; pass new props from chrome model |
| `src/surfaces/home/HomeSurface.jsx` | Pass `platformRole`, `onOpenAdmin`, `currentScreen` to TopNav |
| `src/surfaces/home/CodexSurface.jsx` | Pass `platformRole`, `onOpenAdmin`, `currentScreen` to TopNav |
| `src/surfaces/profile/ProfileSettingsSurface.jsx` | Pass `platformRole`, `onOpenAdmin`, `currentScreen` to TopNav |
| `tests/react-topnav-admin-link.test.js` | **New** — 8 SSR tests covering admin/ops visibility, parent/demo exclusion, active state, action wiring |
| `tests/helpers/react-render.js` | Add `renderTopNavFixture()` helper |
| `tests/button-label-consistency.test.js` | Add "Admin" to `LABELS_NOT_BLOCKING` allowlist |

## Test plan

- [x] Admin user sees "Admin" link
- [x] Ops user sees "Admin" link
- [x] Parent user does NOT see "Admin" link
- [x] Demo session does NOT see "Admin" link
- [x] Undefined platformRole does NOT show link
- [x] Button wired to `open-admin-hub` data-action
- [x] Active state when `currentScreen === 'admin-hub'`
- [x] No active state on other screens
- [x] Existing react-app-shell tests pass (no regression)
- [x] Button-label consistency test passes
- [x] `npm run audit:client` passes

## Plan Deviations

- **No CSS changes**: The plan mentioned "keep it consistent with existing TopNav styling". The `topnav-admin-link` class is added but no CSS is defined in this PR — the existing app stylesheet likely needs a small addition for the `.topnav-admin-link` class. This is intentionally left to a follow-up styling pass or the CSS is expected to be defined elsewhere.
- **`canViewAdminHub` from roles.js not used directly**: The plan suggested reading `roles.js` for role checking patterns. Rather than importing `canViewAdminHub` into the React component (which would add a module dependency to the shell), the check is done inline with `platformRole === 'admin' || platformRole === 'ops'` — the same logic as `canViewAdminHub` but without the import. This keeps TopNav dependency-light.