### PR TITLE
fix(spelling): wire post-Mega vista into scenes that recompute their own hero bg

### DIFF
--- a/src/subjects/spelling/components/PatternQuestScene.jsx
+++ b/src/subjects/spelling/components/PatternQuestScene.jsx
@@ -18,8 +18,10 @@ import {
   spellingAnswerInputProps,
 } from './SpellingCommon.jsx';
 import { SpellingHeroBackdrop } from './SpellingHeroBackdrop.jsx';
+import { isPostMasteryMode } from '../service-contract.js';
 import {
   heroBgForSession,
+  normalisePostMegaBranch,
   heroBgStyle,
   renderAction,
   renderFormAction,
@@ -44,6 +46,22 @@ import {
  * "Card X of 5 • Pattern: <title>" WITHOUT slot-machine dynamics —
  * it is a static label, never animating a roll.
  */
+// Phaeton anchors the post-Mega vista; the branch falls through to the
+// `f`-region URL builder. Inlined defaults so the module file does not
+// have to import the bigger monsters constants surface.
+const SPELLING_GRAND_MASTER_MONSTER_ID = 'phaeton';
+const MONSTER_CODEX_SYSTEM_ID = 'monster-codex';
+
+function postMegaBranchFromRepositories(repositories, learnerId) {
+  if (!learnerId || !repositories?.gameState?.read) return normalisePostMegaBranch();
+  try {
+    const state = repositories.gameState.read(learnerId, MONSTER_CODEX_SYSTEM_ID);
+    return normalisePostMegaBranch(state?.[SPELLING_GRAND_MASTER_MONSTER_ID]?.branch);
+  } catch (_error) {
+    return normalisePostMegaBranch();
+  }
+}
+
 export function PatternQuestScene({
   learner,
   service,
@@ -52,6 +70,11 @@ export function PatternQuestScene({
   actions,
   previousHeroBg = '',
   runtimeReadOnly = false,
+  // P2 hotfix 2026-04-27: receive repositories so the post-Mega branch
+  // lookup can resolve Phaeton's branch from monster-codex state. Pattern
+  // Quest is always post-Mega so we always swap to the f-region — branch
+  // just decides which painting (b1 / b2).
+  repositories = null,
 }) {
   const session = ui.session;
   const questCard = session?.patternQuestCard || null;
@@ -85,7 +108,19 @@ export function PatternQuestScene({
   const contextNote = spellingSessionContextNote(session);
   const footerNote = spellingSessionFooterNote(session);
   const infoChips = spellingSessionInfoChips(session);
-  const heroBg = heroBgForSession(learner.id, session, { awaitingAdvance });
+  // Pattern Quest only runs as a post-Mega mode, so the f-region vista
+  // always applies. `isPostMasteryMode` covers the canonical guardian /
+  // boss / pattern-quest set; if a stale or unknown mode slips through
+  // we still fall through to legacy regions cleanly.
+  const isPostMegaSession = isPostMasteryMode(session?.mode);
+  const sessionPostMegaBranch = isPostMegaSession
+    ? postMegaBranchFromRepositories(repositories, learner.id)
+    : '';
+  const heroBg = heroBgForSession(learner.id, session, {
+    awaitingAdvance,
+    postMega: isPostMegaSession,
+    postMegaBranch: sessionPostMegaBranch,
+  });
 
   const persistenceWarning = ui.feedback?.persistenceWarning || null;
   const persistenceWarningCopy = persistenceWarning

--- a/src/subjects/spelling/components/SpellingPracticeSurface.jsx
+++ b/src/subjects/spelling/components/SpellingPracticeSurface.jsx
@@ -172,6 +172,7 @@ export function SpellingPracticeSurface(props) {
       <SpellingSummaryScene
         {...spelling}
         previousHeroBg={previousHeroBg}
+        repositories={repositories}
         actions={actions}
         runtimeReadOnly={runtimeReadOnly}
       />
@@ -189,6 +190,7 @@ export function SpellingPracticeSurface(props) {
           {...spelling}
           previousHeroBg={previousHeroBg}
           service={service}
+          repositories={repositories}
           actions={actions}
           runtimeReadOnly={runtimeReadOnly}
         />

--- a/src/subjects/spelling/components/SpellingSessionScene.jsx
+++ b/src/subjects/spelling/components/SpellingSessionScene.jsx
@@ -29,10 +29,29 @@ import {
 import {
   heroBgForSession,
   heroBgStyle,
+  normalisePostMegaBranch,
   renderAction,
   renderFormAction,
   spellingSessionProgressIndex,
 } from './spelling-view-model.js';
+import { isPostMasteryMode } from '../service-contract.js';
+
+// Self-contained post-Mega branch lookup — Phaeton (the spelling grand
+// master) anchors the f-region vista regardless of the rest of the
+// monster set. Pulling it inside the scene keeps the hero swap working
+// even if a future caller forgets to thread `postMega` props.
+const SPELLING_GRAND_MASTER_MONSTER_ID = 'phaeton';
+const MONSTER_CODEX_SYSTEM_ID = 'monster-codex';
+
+function postMegaBranchFromRepositories(repositories, learnerId) {
+  if (!learnerId || !repositories?.gameState?.read) return normalisePostMegaBranch();
+  try {
+    const state = repositories.gameState.read(learnerId, MONSTER_CODEX_SYSTEM_ID);
+    return normalisePostMegaBranch(state?.[SPELLING_GRAND_MASTER_MONSTER_ID]?.branch);
+  } catch (_error) {
+    return normalisePostMegaBranch();
+  }
+}
 
 export function SpellingSessionScene({
   learner,
@@ -119,7 +138,19 @@ export function SpellingSessionScene({
     : spellingSessionProgressIndex(session, { awaitingAdvance });
   const pathDone = Math.min(progressTotal, done);
   const pathCurrent = Math.min(Math.max(progressCurrent - 1, 0), progressTotal);
-  const heroBg = heroBgForSession(learner.id, session, { awaitingAdvance });
+  // Post-Mega session vista swap. Guardian / Boss / Pattern Quest sessions
+  // always belong to a graduated learner so the f-region is correct
+  // (mode-driven post-Mega vs legacy split). Pre-Mega sessions stay on
+  // the legacy regions.
+  const isPostMegaSession = isPostMasteryMode(session?.mode);
+  const sessionPostMegaBranch = isPostMegaSession
+    ? postMegaBranchFromRepositories(repositories, learner.id)
+    : '';
+  const heroBg = heroBgForSession(learner.id, session, {
+    awaitingAdvance,
+    postMega: isPostMegaSession,
+    postMegaBranch: sessionPostMegaBranch,
+  });
   const isCompletingRound = awaitingAdvance && progressTotal > 0 && done >= progressTotal;
   const showingCorrection = session.phase === 'correction';
   const promptInstr = session.type === 'test'

--- a/src/subjects/spelling/components/SpellingSetupScene.jsx
+++ b/src/subjects/spelling/components/SpellingSetupScene.jsx
@@ -18,8 +18,27 @@ import {
   heroBgStyle,
   heroToneForBg,
   monsterImageVisual,
+  normalisePostMegaBranch,
   renderAction,
 } from './spelling-view-model.js';
+
+// Setup scene picks the post-Mega vista (`f` region) directly when it
+// detects a graduated learner, so the parent surface does not need to
+// thread separate `postMega` props down. The branch is read once from the
+// monster-codex state — Phaeton is the spelling grand master — so the
+// vista stays in sync with the Codex creature on the learner's home tile.
+const SPELLING_GRAND_MASTER_MONSTER_ID = 'phaeton';
+const MONSTER_CODEX_SYSTEM_ID = 'monster-codex';
+
+function postMegaBranchFromRepositories(repositories, learnerId) {
+  if (!learnerId || !repositories?.gameState?.read) return normalisePostMegaBranch();
+  try {
+    const state = repositories.gameState.read(learnerId, MONSTER_CODEX_SYSTEM_ID);
+    return normalisePostMegaBranch(state?.[SPELLING_GRAND_MASTER_MONSTER_ID]?.branch);
+  } catch (_error) {
+    return normalisePostMegaBranch();
+  }
+}
 
 function ModeCard({ mode, selected, disabled = false, description, badge, actions, textTone = 'dark' }) {
   const desc = description != null ? description : mode.desc;
@@ -356,7 +375,22 @@ export function SpellingSetupScene({
 }) {
   const statsFilter = prefs.mode === 'test' ? 'core' : prefs.yearFilter;
   const stats = service.getStats(learner.id, statsFilter);
-  const heroBg = heroBgForSetup(learner.id, prefs, { tone: setupHeroTone });
+  // Post-Mega gating for the hero backdrop. When the learner has a sticky
+  // graduation record (or is currently fully Mega), swap the legacy
+  // mode-driven region for the post-Mega `f` vista bound to Phaeton's
+  // branch (b1 / b2). Pre-Mega learners stay on the legacy regions.
+  const isPostMegaSetup = Boolean(
+    postMastery?.postMegaDashboardAvailable
+    ?? postMastery?.allWordsMega,
+  );
+  const setupPostMegaBranch = isPostMegaSetup
+    ? postMegaBranchFromRepositories(repositories, learner.id)
+    : '';
+  const heroBg = heroBgForSetup(learner.id, prefs, {
+    tone: setupHeroTone,
+    postMega: isPostMegaSetup,
+    postMegaBranch: setupPostMegaBranch,
+  });
   const mergedHeroStyle = { ...heroBgStyle(heroBg) };
   const heroContrast = useSetupHeroContrast(heroBg, prefs.mode);
   const heroTone = heroContrast.contrast.tone || heroToneForBg(heroBg);

--- a/src/subjects/spelling/components/SpellingSummaryScene.jsx
+++ b/src/subjects/spelling/components/SpellingSummaryScene.jsx
@@ -9,10 +9,25 @@ import {
   guardianSummaryCopy,
   heroBgForSession,
   heroBgStyle,
+  normalisePostMegaBranch,
   renderAction,
   summaryHeadline,
   summaryRibbonSub,
 } from './spelling-view-model.js';
+import { isPostMasteryMode } from '../service-contract.js';
+
+const SPELLING_GRAND_MASTER_MONSTER_ID = 'phaeton';
+const MONSTER_CODEX_SYSTEM_ID = 'monster-codex';
+
+function postMegaBranchFromRepositories(repositories, learnerId) {
+  if (!learnerId || !repositories?.gameState?.read) return normalisePostMegaBranch();
+  try {
+    const state = repositories.gameState.read(learnerId, MONSTER_CODEX_SYSTEM_ID);
+    return normalisePostMegaBranch(state?.[SPELLING_GRAND_MASTER_MONSTER_ID]?.branch);
+  } catch (_error) {
+    return normalisePostMegaBranch();
+  }
+}
 
 function SummaryStatGrid({ cards = [] }) {
   return (
@@ -132,7 +147,7 @@ function SummaryPatternQuestMissList({ mistakes = [] }) {
   );
 }
 
-export function SpellingSummaryScene({ learner, ui, accent, actions, postMastery = null, previousHeroBg = '', runtimeReadOnly = false }) {
+export function SpellingSummaryScene({ learner, ui, accent, actions, postMastery = null, previousHeroBg = '', runtimeReadOnly = false, repositories = null }) {
   const summary = ui.summary;
   // SH2-U1: JSX-layer guard for non-destructive next-action buttons.
   // Drill/Start-again/Drill-all all route through the subject adapter
@@ -147,10 +162,22 @@ export function SpellingSummaryScene({ learner, ui, accent, actions, postMastery
   const pendingCommand = ui.pendingCommand || '';
   const pending = Boolean(pendingCommand);
   const progressTotal = Math.max(1, summary.totalWords || 1);
+  // Post-Mega summary swap. The Worker stamps `summary.mode` from the
+  // session that produced the summary, so guardian / boss / pattern-quest
+  // results flow through the f-region vista. Pre-Mega summaries (smart /
+  // trouble / test) keep the legacy region.
+  const isPostMegaSummary = isPostMasteryMode(summary.mode);
+  const summaryPostMegaBranch = isPostMegaSummary
+    ? postMegaBranchFromRepositories(repositories, learner.id)
+    : '';
   const heroBg = heroBgForSession(learner.id, {
     mode: summary.mode,
     progress: { done: progressTotal, total: progressTotal },
-  }, { complete: true });
+  }, {
+    complete: true,
+    postMega: isPostMegaSummary,
+    postMegaBranch: summaryPostMegaBranch,
+  });
   const toneGood = !summary.mistakes.length;
   const isGuardianSummary = summary.mode === 'guardian';
   // U10: Boss rounds render a dedicated summary branch — no drill-all, no

--- a/tests/react-spelling-surface.test.js
+++ b/tests/react-spelling-surface.test.js
@@ -198,6 +198,20 @@ test('React spelling setup scene renders the post-Mega dashboard with Guardian M
   assert.match(html, /The Word Vault is yours/);
   assert.match(html, /Guardian Mission/);
   assert.match(html, /Boss Dictation/);
+  // Post-Mega vista: setup hero must render the f-region URL with the
+  // learner's grand-master Phaeton branch suffix. The fixture skips
+  // seeding monster-codex state so the branch falls through to the
+  // default b1 — but the f-region prefix must always be present.
+  assert.match(
+    html,
+    /the-scribe-downs-f[1-3]-b[12]\.1280\.webp/,
+    'post-Mega setup hero must use the f-region vista, not the legacy a-c regions',
+  );
+  assert.doesNotMatch(
+    html,
+    /the-scribe-downs-[a-e][1-3]\.1280\.webp/,
+    'post-Mega setup hero must NOT fall back to the legacy mode-driven regions',
+  );
   // Roadmap placeholders (Word Detective / Story Challenge) collapse from
   // full mode cards into a single quiet "Coming next" footer line so the
   // post-Mega scene no longer carries two empty striped cards on row 2.


### PR DESCRIPTION
## Summary

PR #359 plumbed the f-region picker through `SpellingPracticeSurface` but every scene component recomputes its own hero URL via `heroBgForSetup` / `heroBgForSession` locally — so the `postMega` flag never reached the URL builder and graduated learners (Eugenia) still saw the legacy `a / b / c` regions on Setup, Session, Summary, and Pattern Quest.

This PR wires each scene to derive the post-Mega flag + Phaeton branch from its own props, so the swap is self-contained and works regardless of whether the surface threads the flags through.

## Per-scene fix

| Scene | Predicate | Branch source |
|-------|-----------|---------------|
| `SpellingSetupScene` | `postMastery.postMegaDashboardAvailable ?? allWordsMega` | `repositories.gameState.read(learnerId, 'monster-codex').phaeton.branch` |
| `SpellingSessionScene` | `isPostMasteryMode(session.mode)` | same |
| `SpellingSummaryScene` | `isPostMasteryMode(summary.mode)` | same — now receives `repositories` from surface |
| `PatternQuestScene` | `isPostMasteryMode(session.mode)` | same — now receives `repositories` from surface |

## Regression test

`tests/react-spelling-surface.test.js` — the existing post-Mega setup SSR fixture now asserts the rendered HTML:
- **must contain** a `the-scribe-downs-f[1-3]-b[12]\.1280\.webp` URL (f-region landed)
- **must NOT contain** a `the-scribe-downs-[a-e][1-3]\.1280\.webp` URL (no fallback to legacy)

Catches the exact bug #359 shipped.

## Verify

- [x] `npm run build` — 707 KB main bundle (+1 KB for the per-scene lookup helpers)
- [x] `tests/react-spelling-surface.test.js` — 27/27 pass (with the new f-region regex assertion)
- [x] Broad spelling sweep (`spelling-view-model` / `spelling-parity` / `spelling-guardian` / `spelling-boss`) — 326/326 pass
- [ ] Browser smoke (post-merge) — Eugenia hard refresh → expect `f{1,2,3}-b2` on the Setup landing, Guardian session, and Guardian summary scenes

🤖 Generated with [Claude Code](https://claude.com/claude-code)