### PR TITLE
feat(spelling): replace Workshop popover with Vault ↔ Workshop view switch

### DIFF
--- a/src/subjects/spelling/components/SpellingSetupScene.jsx
+++ b/src/subjects/spelling/components/SpellingSetupScene.jsx
@@ -458,6 +458,21 @@ export function SpellingSetupScene({
       ?? SPELLING_DURABLE_PERSISTENCE_WARNING_COPY.STORAGE_SAVE_FAILED)
     : '';
 
+  // Post-Mega setup view switch (2026-04-27 redesign): a graduated learner
+  // can flip between the Vault layer (Guardian / Boss / Pattern Quest cards
+  // with inline CTAs) and the Workshop layer (full legacy setup with round
+  // length / pool / showCloze / autoSpeak controls). Defaults to Vault for
+  // post-Mega learners; the switch hides entirely for pre-Mega so they
+  // only ever see the Workshop. Local React state keeps the toggle simple
+  // — resets on navigation, no schema bump.
+  const [postMegaView, setPostMegaView] = React.useState('vault');
+  // Render the Vault layer only when the learner is post-Mega AND has
+  // chosen the Vault view. Otherwise fall through to the legacy Workshop
+  // layer (which carries every legacy mode + tweak control). The
+  // hydration-checking placeholder stays gated on the Vault view too.
+  const showVaultLayer = isPostMega && postMegaView === 'vault';
+  const showWorkshopLayer = !showVaultLayer && !isHydrationChecking;
+
   return (
     <div className="setup-grid" style={{ gridColumn: '1/-1' }}>
       <SoftLockoutBanner
@@ -495,6 +510,11 @@ export function SpellingSetupScene({
             </div>
           ) : null}
           {isPostMega ? (
+            <SetupViewSwitch view={postMegaView} onChange={setPostMegaView} />
+          ) : null}
+          {isHydrationChecking ? (
+            <CheckingWordVaultContent />
+          ) : showVaultLayer ? (
             <PostMegaSetupContent
               prefs={prefs}
               accent={accent}
@@ -506,8 +526,6 @@ export function SpellingSetupScene({
               startDisabled={startDisabled}
               runtimeReadOnly={runtimeReadOnly}
             />
-          ) : isHydrationChecking ? (
-            <CheckingWordVaultContent />
           ) : (
             <LegacySetupContent
               prefs={prefs}
@@ -1002,127 +1020,54 @@ function PostMegaSetupContent({
           </span>
         </p>
       ) : null}
-      <WorkshopSection
-        prefs={prefs}
-        actions={actions}
-        startDisabled={startDisabled}
-        runtimeReadOnly={runtimeReadOnly}
-      />
     </>
   );
 }
 
-/* The Workshop — floating upper-right toggle on the post-Mega hero card.
+/* SetupViewSwitch — a two-tab segmented control floating in the upper-right
+ * clear zone of the post-Mega hero card.
  *
- * Design intent (revised after first ship):
- *  - The original below-the-fold section was clipped by the hero card's
- *    `min-height: 610px; overflow: hidden;` envelope. Moving the toggle
- *    into the upper-right clear zone keeps the affordance discoverable
- *    without growing the card. The popover floats above the layout, so
- *    nothing else moves.
- *  - Place metaphor still matches the post-Mega vocabulary (Word Vault,
- *    Codex, Meadow). "The Workshop" reads as a small tool shed in the
- *    corner of the hero, not a demoted classics rack.
- *  - The chip is a quiet pill with paper-translucent backdrop blur. The
- *    chevron telegraphs the open/closed state; rotating it on toggle is
- *    the only animation the chip itself needs.
- *  - Popover anchors to the chip's bottom edge, ~320px wide, with three
- *    list-row cards. Clicking a card dispatches the same
- *    `spelling-shortcut-start` payload that Alt+1/2/3 use, so the engine
- *    path is byte-identical and Mega never drops.
- *  - Auto-dismiss on outside click + Esc keeps the popover from competing
- *    with the rest of the hero. Selecting a card also closes the popover
- *    before the session navigation kicks in. */
-function WorkshopSection({ prefs, actions, startDisabled, runtimeReadOnly }) {
-  const [open, setOpen] = React.useState(false);
-  const sectionRef = React.useRef(null);
-  const disabled = Boolean(startDisabled || runtimeReadOnly);
-  const popoverId = 'spelling-workshop-popover';
-
-  React.useEffect(() => {
-    if (!open || typeof document === 'undefined') return undefined;
-    function handlePointerDown(event) {
-      const root = sectionRef.current;
-      if (!root || root.contains(event.target)) return;
-      setOpen(false);
-    }
-    function handleKeyDown(event) {
-      if (event.key === 'Escape') {
-        event.stopPropagation();
-        setOpen(false);
-      }
-    }
-    document.addEventListener('mousedown', handlePointerDown);
-    document.addEventListener('keydown', handleKeyDown);
-    return () => {
-      document.removeEventListener('mousedown', handlePointerDown);
-      document.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [open]);
-
-  function handleCardClick(event, modeId) {
-    if (disabled) {
-      event?.preventDefault?.();
-      event?.stopPropagation?.();
-      return;
-    }
-    setOpen(false);
-    renderAction(actions, event, 'spelling-shortcut-start', { mode: modeId });
-  }
-
+ * Replaces the earlier Workshop popover (which only quick-launched legacy
+ * modes — graduated learners still wanted access to round length / pool /
+ * showCloze / autoSpeak controls). The switch flips the entire setup
+ * content between two layers:
+ *
+ *   - Vault: PostMegaSetupContent (Guardian / Boss / Pattern Quest cards
+ *     with inline Begin pills). The graduation surface.
+ *   - Workshop: LegacySetupContent (Smart / Trouble / Test cards with
+ *     full tweak controls). Same layer pre-Mega learners see.
+ *
+ * Hidden entirely for pre-Mega learners — they only ever see the Workshop
+ * layer, so a switch with one option is just chrome. */
+function SetupViewSwitch({ view, onChange }) {
+  const tabs = [
+    { id: 'vault', label: 'Vault' },
+    { id: 'workshop', label: 'Workshop' },
+  ];
   return (
     <div
-      ref={sectionRef}
-      className={`workshop-section${open ? ' is-open' : ''}`}
-      data-test-id="spelling-workshop"
-      data-state={open ? 'open' : 'closed'}
+      className="setup-view-switch"
+      role="tablist"
+      aria-label="Setup view"
+      data-test-id="setup-view-switch"
     >
-      <button
-        type="button"
-        className="workshop-chip"
-        aria-expanded={open}
-        aria-haspopup="true"
-        aria-controls={popoverId}
-        onClick={() => setOpen((prev) => !prev)}
-      >
-        <span className="workshop-chip-label">Workshop</span>
-        <span className="workshop-chip-chevron" aria-hidden="true" />
-      </button>
-      <div
-        id={popoverId}
-        className="workshop-popover"
-        role="region"
-        aria-label="The Workshop — earlier practice modes"
-        data-mode-current={prefs?.mode || ''}
-        hidden={!open}
-      >
-        <p className="workshop-popover-eyebrow">Earlier modes · keep them sharp</p>
-        <ul className="workshop-popover-list">
-          {MODE_CARDS.map((mode) => (
-            <li key={mode.id}>
-              <button
-                type="button"
-                className="workshop-popover-card"
-                data-action="spelling-shortcut-start"
-                data-mode={mode.id}
-                data-test-id={`workshop-card-${mode.id}`}
-                disabled={disabled}
-                onClick={(event) => handleCardClick(event, mode.id)}
-              >
-                <span className="workshop-popover-card-title">{mode.title}</span>
-                <span className="workshop-popover-card-desc">{mode.desc}</span>
-              </button>
-            </li>
-          ))}
-        </ul>
-        <p className="workshop-popover-hint" aria-hidden="true">
-          <span className="workshop-popover-hint-prefix">Quick keys</span>
-          <kbd>Alt</kbd>
-          <kbd>1</kbd>
-          <kbd>2</kbd>
-          <kbd>3</kbd>
-        </p>
-      </div>
+      {tabs.map((tab) => {
+        const isActive = view === tab.id;
+        return (
+          <button
+            key={tab.id}
+            type="button"
+            role="tab"
+            className={`setup-view-switch-tab${isActive ? ' is-active' : ''}`}
+            aria-selected={isActive}
+            data-tab={tab.id}
+            data-test-id={`setup-view-switch-${tab.id}`}
+            onClick={() => onChange(tab.id)}
+          >
+            {tab.label}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/styles/app.css
+++ b/styles/app.css
@@ -5059,218 +5059,76 @@ textarea:focus-visible {
   .post-mega-hydration-skeleton__card { animation: none; opacity: 0.9; }
 }
 
-/* The Workshop — floating upper-right toggle on the post-Mega hero card.
- * Anchors to `.setup-main` (which already has `position: relative`) so the
- * chip + popover float over the hero backdrop without growing the card or
- * pushing siblings. Aesthetic notes:
- *  - Chip is a paper-translucent pill with backdrop-blur. Fraunces serif
- *    label + chevron. Subtle border. Hover lifts and warms the border.
- *  - Popover anchors to the chip's bottom-right corner, paper-cream with
- *    drop shadow + backdrop blur, ~320px wide. Three list-rows.
- *  - Each list-row has a dotted indent stripe revealed on hover — the
- *    workshop-drawer affordance, not another mode card.
- *  - kbd hint at the foot rewards keyboard explorers (Alt+1/2/3 still
- *    work whether the popover is open or closed). */
-.workshop-section {
+/* Setup view switch — segmented two-tab pill in the upper-right clear
+ * zone of the post-Mega hero card. Lets a graduated learner flip the
+ * entire setup content between the Vault layer (Guardian / Boss / Pattern
+ * Quest) and the Workshop layer (full legacy setup with round length,
+ * pool, showCloze, autoSpeak controls). Replaces the earlier Workshop
+ * popover, which only quick-launched modes without exposing any options.
+ *
+ * Anchors absolute to `.setup-main` (which already has `position: relative`)
+ * so the switch floats over the hero backdrop without affecting layout.
+ * Paper-translucent pill with backdrop blur; the active tab gets the
+ * brand fill + white text while the inactive tab stays subdued. */
+.setup-view-switch {
   position: absolute;
   top: 24px;
   right: 28px;
   z-index: 4;
-}
-.workshop-chip {
   display: inline-flex;
   align-items: center;
-  gap: 10px;
-  padding: 6px 14px 6px 16px;
+  gap: 2px;
+  padding: 3px;
   background: color-mix(in oklab, var(--panel) 60%, transparent);
   border: 1px solid color-mix(in oklab, var(--brand) 26%, var(--line));
   border-radius: 999px;
-  cursor: pointer;
-  font: inherit;
-  color: inherit;
   backdrop-filter: blur(14px) saturate(1.1);
   -webkit-backdrop-filter: blur(14px) saturate(1.1);
-  transition:
-    transform 200ms ease,
-    border-color 200ms ease,
-    background 200ms ease,
-    box-shadow 200ms ease;
+  box-shadow: 0 4px 14px -10px color-mix(in oklab, var(--ink) 30%, transparent);
 }
-.workshop-chip:hover {
-  transform: translateY(-1px);
-  border-color: color-mix(in oklab, var(--brand) 50%, transparent);
-  background: color-mix(in oklab, var(--panel) 78%, transparent);
-  box-shadow: 0 8px 20px -16px color-mix(in oklab, var(--brand) 56%, transparent);
-}
-.workshop-chip:focus-visible {
-  outline: 2px solid color-mix(in oklab, var(--brand) 64%, transparent);
-  outline-offset: 3px;
-}
-.workshop-chip-label {
-  font-family: var(--font-serif);
-  font-size: 0.95rem;
-  font-weight: 500;
-  letter-spacing: -0.005em;
-  color: color-mix(in oklab, var(--brand) 78%, var(--ink));
-}
-.workshop-chip-chevron {
-  display: inline-block;
-  width: 7px;
-  height: 7px;
-  margin-bottom: 1px;
-  border-right: 1.5px solid color-mix(in oklab, var(--brand) 70%, var(--ink));
-  border-bottom: 1.5px solid color-mix(in oklab, var(--brand) 70%, var(--ink));
-  transform: rotate(45deg);
-  transition: transform 220ms ease;
-}
-.workshop-section.is-open .workshop-chip-chevron {
-  transform: rotate(-135deg);
-  margin-bottom: -3px;
-}
-.workshop-popover {
-  position: absolute;
-  top: calc(100% + 8px);
-  right: 0;
-  width: 320px;
-  padding: 18px 18px 14px;
-  background: color-mix(in oklab, var(--panel) 92%, white 8%);
-  border: 1px solid color-mix(in oklab, var(--brand) 20%, var(--line));
-  border-radius: var(--radius);
-  box-shadow:
-    0 24px 48px -22px color-mix(in oklab, var(--ink) 32%, transparent),
-    0 4px 8px -4px color-mix(in oklab, var(--ink) 18%, transparent);
-  backdrop-filter: blur(18px) saturate(1.2);
-  -webkit-backdrop-filter: blur(18px) saturate(1.2);
-  animation: workshopPopoverReveal 200ms ease both;
-  z-index: 12;
-}
-.workshop-popover[hidden] { display: none; }
-.workshop-popover-eyebrow {
-  margin: 0 0 12px;
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: color-mix(in oklab, var(--brand) 60%, var(--muted));
-}
-.workshop-popover-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-.workshop-popover-card {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  width: 100%;
-  padding: 10px 12px 10px 18px;
+.setup-view-switch-tab {
+  display: inline-flex;
+  align-items: center;
+  padding: 5px 14px;
   background: transparent;
-  border: 1px solid transparent;
-  border-radius: calc(var(--radius) - 6px);
-  text-align: left;
+  border: 0;
+  border-radius: 999px;
   cursor: pointer;
   font: inherit;
-  color: inherit;
+  font-family: var(--font-serif);
+  font-size: 0.86rem;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  color: color-mix(in oklab, var(--brand) 60%, var(--ink));
   transition:
-    background 180ms ease,
-    border-color 180ms ease,
-    transform 180ms ease;
+    background 200ms ease,
+    color 200ms ease,
+    transform 200ms ease;
 }
-.workshop-popover-card::before {
-  content: '';
-  position: absolute;
-  left: 6px;
-  top: 12px;
-  bottom: 12px;
-  width: 2px;
-  border-radius: 2px;
-  background: color-mix(in oklab, var(--brand) 40%, transparent);
-  opacity: 0;
-  transition: opacity 180ms ease;
+.setup-view-switch-tab:hover {
+  color: color-mix(in oklab, var(--brand) 86%, var(--ink));
 }
-.workshop-popover-card:hover {
-  background: color-mix(in oklab, var(--brand-soft) 28%, transparent);
-  border-color: color-mix(in oklab, var(--brand) 28%, var(--line));
-  transform: translateX(1px);
-}
-.workshop-popover-card:hover::before { opacity: 1; }
-.workshop-popover-card:focus-visible {
+.setup-view-switch-tab:focus-visible {
   outline: 2px solid color-mix(in oklab, var(--brand) 64%, transparent);
   outline-offset: 2px;
 }
-.workshop-popover-card[disabled] {
-  cursor: not-allowed;
-  opacity: 0.55;
-  filter: saturate(0.7);
-}
-.workshop-popover-card[disabled]:hover {
-  background: transparent;
-  border-color: transparent;
-  transform: none;
-}
-.workshop-popover-card-title {
-  font-family: var(--font-serif);
-  font-size: 1rem;
-  font-weight: 500;
-  letter-spacing: -0.005em;
-  color: color-mix(in oklab, var(--brand) 78%, var(--ink));
-}
-.workshop-popover-card-desc {
-  font-size: 0.8rem;
-  line-height: 1.45;
-  color: color-mix(in oklab, var(--ink) 70%, var(--muted));
-}
-.workshop-popover-hint {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  margin: 12px 0 0;
-  padding-top: 10px;
-  border-top: 1px dashed color-mix(in oklab, var(--brand) 16%, var(--line));
-  font-size: 0.7rem;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: color-mix(in oklab, var(--ink) 60%, var(--muted));
-}
-.workshop-popover-hint-prefix {
-  margin-right: 4px;
-  font-weight: 700;
-  opacity: 0.78;
-}
-.workshop-popover-hint kbd {
-  display: inline-block;
-  padding: 1px 6px;
-  border-radius: 4px;
-  font-family: var(--font-mono, ui-monospace, 'SFMono-Regular', Menlo, monospace);
-  font-size: 0.68rem;
-  font-weight: 600;
-  line-height: 1.1;
-  background: color-mix(in oklab, var(--panel) 38%, transparent);
-  border: 1px solid color-mix(in oklab, var(--brand) 22%, transparent);
-  color: color-mix(in oklab, var(--brand) 72%, var(--ink));
-}
-@keyframes workshopPopoverReveal {
-  from { opacity: 0; transform: translateY(-4px) scale(0.98); }
-  to { opacity: 1; transform: translateY(0) scale(1); }
+.setup-view-switch-tab.is-active {
+  background: color-mix(in oklab, var(--brand) 88%, transparent);
+  color: #fff;
+  box-shadow: 0 6px 14px -10px color-mix(in oklab, var(--brand) 58%, transparent);
 }
 @media (max-width: 540px) {
-  .workshop-section {
+  .setup-view-switch {
     top: 18px;
     right: 18px;
   }
-  .workshop-popover {
-    width: min(calc(100vw - 48px), 320px);
+  .setup-view-switch-tab {
+    padding: 4px 12px;
+    font-size: 0.82rem;
   }
 }
 @media (prefers-reduced-motion: reduce) {
-  .workshop-chip,
-  .workshop-chip-chevron,
-  .workshop-popover,
-  .workshop-popover-card { transition: none; animation: none; }
+  .setup-view-switch-tab { transition: none; }
 }
 
 .setup-control-stack {

--- a/tests/react-spelling-surface.test.js
+++ b/tests/react-spelling-surface.test.js
@@ -495,18 +495,19 @@ test('U3 edge case: Guardian summary with zero mistakes does not render the Prac
   assert.doesNotMatch(html, /summary-drill-chips/, 'zero-mistake Guardian summary must not render the drill chips container');
 });
 
-// ----- The Workshop — floating upper-right toggle on the post-Mega scene ----
+// ----- Setup view switch — Vault ↔ Workshop on the post-Mega scene -----------
 //
-// Lets a graduated learner reach the legacy practice modes (Smart Review /
-// Trouble Drill / SATs Test) without exiting the post-Mega dashboard. The
-// chip lives in the hero card's upper-right clear zone (top:24, right:28)
-// so it does not push siblings or overflow the card's `min-height: 610px`
-// envelope. Popover anchors to the chip's bottom-right corner and is
-// hidden via the HTML `hidden` attribute until the chip is clicked. Cards
-// dispatch `spelling-shortcut-start` with the legacy mode payload so the
-// entry-point parity with Alt+1/2/3 stays byte-identical. Mega never drops.
+// Lets a graduated learner flip the entire setup content between two
+// layers without exiting the page:
+//   - Vault: Guardian / Boss / Pattern Quest cards with inline Begin
+//     pills (the post-Mega graduation surface).
+//   - Workshop: full legacy setup with round length / pool / showCloze /
+//     autoSpeak controls + Smart / Trouble / SATs Test cards (the same
+//     layer pre-Mega learners see).
+// Hidden entirely for pre-Mega learners — they only ever see the Workshop
+// layer, so a single-option switch would just be chrome.
 
-test('Workshop chip renders on the post-Mega setup scene, default-closed', async () => {
+test('Setup view switch renders on the post-Mega scene with Vault active by default', async () => {
   const today = Math.floor(Date.now() / (24 * 60 * 60 * 1000));
   const html = await renderSpellingSurfaceFixture({
     phase: 'setup',
@@ -525,63 +526,32 @@ test('Workshop chip renders on the post-Mega setup scene, default-closed', async
     },
   });
 
-  // Section + chip render alongside the post-Mega dashboard.
-  assert.match(html, /data-test-id="spelling-workshop"/);
-  assert.match(html, /class="workshop-chip"[^>]*aria-expanded="false"/);
-  assert.match(html, /data-state="closed"/);
-  assert.match(html, /aria-haspopup="true"/);
-  // Place metaphor (paper aesthetic place vocabulary) survives the render.
-  assert.match(html, />Workshop</);
-  // Popover is hidden on first render — markup exists in the DOM but the
-  // `hidden` attribute keeps it out of the accessibility tree until the
-  // learner clicks the chip.
-  assert.match(html, /id="spelling-workshop-popover"[^>]*hidden/);
+  // Switch shell + both tabs render with role="tablist".
+  assert.match(html, /data-test-id="setup-view-switch"/);
+  assert.match(html, /role="tablist"/);
+  // Both tab buttons present.
+  assert.match(html, /data-test-id="setup-view-switch-vault"/);
+  assert.match(html, /data-test-id="setup-view-switch-workshop"/);
+  // Vault is the default active tab on first render for a graduated learner.
+  const vaultTab = html.match(/<button[^>]*data-test-id="setup-view-switch-vault"[^>]*>/);
+  const workshopTab = html.match(/<button[^>]*data-test-id="setup-view-switch-workshop"[^>]*>/);
+  assert.ok(vaultTab, 'Vault tab must render');
+  assert.ok(workshopTab, 'Workshop tab must render');
+  assert.match(vaultTab[0], /aria-selected="true"/);
+  assert.match(vaultTab[0], /class="[^"]*\bis-active\b/);
+  assert.match(workshopTab[0], /aria-selected="false"/);
+  assert.doesNotMatch(workshopTab[0], /class="[^"]*\bis-active\b/);
+  // The Vault layer (post-Mega cards) is what renders by default; the
+  // legacy Smart Review setup ledes are absent.
+  assert.match(html, /Graduated · Spelling Guardian/);
+  assert.doesNotMatch(html, /Choose today/, 'Workshop layer copy must not appear under Vault view');
 });
 
-test('Workshop chip is absent when the legacy dashboard renders (allWordsMega=false)', async () => {
-  // Pre-Mega learner: setup scene renders the legacy 3-mode row directly. The
-  // Workshop is post-Mega-only — surfacing it on the legacy view would
-  // duplicate the same three cards twice on the same page.
+test('Setup view switch is absent when the legacy dashboard renders (allWordsMega=false)', async () => {
+  // Pre-Mega learner: setup scene renders the legacy 3-mode row directly.
+  // The view switch is post-Mega-only — pre-Mega learners only have one
+  // layer, so a switch with one option would just be chrome.
   const html = await renderSpellingSurfaceFixture({ phase: 'setup' });
-  assert.doesNotMatch(html, /data-test-id="spelling-workshop"/);
-  assert.doesNotMatch(html, /class="workshop-chip"/);
-});
-
-test('Workshop popover wires Smart / Trouble / Test through spelling-shortcut-start', async () => {
-  const today = Math.floor(Date.now() / (24 * 60 * 60 * 1000));
-  const html = await renderSpellingSurfaceFixture({
-    phase: 'setup',
-    postMega: {
-      guardian: {
-        possess: {
-          reviewLevel: 2,
-          lastReviewedDay: today - 7,
-          nextDueDay: today,
-          correctStreak: 2,
-          lapses: 0,
-          renewals: 0,
-          wobbling: false,
-        },
-      },
-    },
-  });
-
-  // All three legacy modes get a list-row inside the popover, each wired
-  // through the same `spelling-shortcut-start` action that Alt+1/2/3 use.
-  // React's renderer does not preserve a stable JSX-prop attribute order, so
-  // assert each attribute independently rather than as a single ordered run.
-  for (const modeId of ['smart', 'trouble', 'test']) {
-    const cardRegex = new RegExp(`<button[^>]*data-test-id="workshop-card-${modeId}"[^>]*>`);
-    const match = html.match(cardRegex);
-    assert.ok(match, `Workshop popover card for mode "${modeId}" should render`);
-    const cardOpenTag = match[0];
-    assert.match(cardOpenTag, /data-action="spelling-shortcut-start"/);
-    assert.match(cardOpenTag, new RegExp(`data-mode="${modeId}"`));
-  }
-  // The Alt+1/2/3 quick-key hint sits at the foot of the popover so kids
-  // can discover the keyboard parity without pressing the button.
-  assert.match(html, /<kbd>Alt<\/kbd>/);
-  assert.match(html, /<kbd>1<\/kbd>/);
-  assert.match(html, /<kbd>2<\/kbd>/);
-  assert.match(html, /<kbd>3<\/kbd>/);
+  assert.doesNotMatch(html, /data-test-id="setup-view-switch"/);
+  assert.doesNotMatch(html, /class="setup-view-switch"/);
 });


### PR DESCRIPTION
## Summary

The Workshop popover from PR #350 only quick-launched the legacy modes — graduated learners couldn't reach round length / pool / showCloze / autoSpeak controls without exiting the post-Mega scene. Replace it with a simple two-tab segmented switch in the same upper-right clear zone.

| Tab | Layer | Surface |
|-----|-------|---------|
| **Vault** (default for post-Mega) | `PostMegaSetupContent` | Guardian / Boss / Pattern Quest cards with inline Begin pills |
| **Workshop** | `LegacySetupContent` | Smart / Trouble / SATs Test cards + every tweak control (same layer pre-Mega learners see) |

Pre-Mega learners never see the switch — they only have one layer, so a single-option control would just be chrome.

## Why simple

- Local `React.useState` for the active tab, no schema bump, resets on navigation.
- No popover, no auto-dismiss handlers, no outside-click logic.
- Reuses the `LegacySetupContent` component — every option a child can twiddle pre-graduation is reachable post-graduation.

## Verify

- [x] `npm run build` — 705.8 KB main bundle (down ~1 KB; popover CSS removal nets out the new switch styles)
- [x] 27/27 react-spelling-surface tests (3 updated to assert the switch shell, the active Vault tab, and absence on pre-Mega)
- [x] 325-test broad spelling sweep green
- [ ] Browser smoke (post-merge) — Eugenia hard refresh → expect the switch in the upper-right; clicking **Workshop** swaps the entire content to the legacy setup with all controls; clicking **Vault** swaps back

## Notes

- The Alt+1/2/3 keyboard shortcuts still work via the existing resolver — the popover-only kbd hint goes away with the popover. If the kbd hint should resurface, a small text line under the active tab is the simplest follow-up.
- `MODE_CARDS` import stays — it's still used by `LegacySetupContent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)