### PR TITLE
feat(grammar): U7+U8 monster strip and landing page simplification

### DIFF
--- a/docs/hardening/csp-inline-style-inventory.md
+++ b/docs/hardening/csp-inline-style-inventory.md
@@ -49,11 +49,11 @@ Future migration PRs should:
 
 | Category | Count |
 | --- | --- |
-| `shared-pattern-available` | 146 |
+| `shared-pattern-available` | 147 |
 | `dynamic-content-driven` | 111 |
 | `css-var-ready` | 3 |
 | `third-party-boundary` | 2 |
-| **TOTAL** | **262** |
+| **TOTAL** | **263** |
 
 ## Per-file inventory
 
@@ -76,6 +76,7 @@ Future migration PRs should:
 | `src/surfaces/home/SubjectCard.jsx` | 3 | `dynamic-content-driven` | no |
 | `src/surfaces/hubs/MonsterVisualPreviewGrid.jsx` | 3 | `dynamic-content-driven` | no |
 | `src/platform/game/render/effects/celebration-shell.js` | 2 | `third-party-boundary` | no |
+| `src/subjects/grammar/components/GrammarSetupScene.jsx` | 2 | `shared-pattern-available` | no |
 | `src/subjects/spelling/components/SpellingCommon.jsx` | 2 | `css-var-ready` | no |
 | `src/subjects/spelling/components/SpellingWordDetailModal.jsx` | 2 | `dynamic-content-driven` | no |
 | `src/surfaces/home/CodexCard.jsx` | 2 | `dynamic-content-driven` | no |
@@ -87,7 +88,6 @@ Future migration PRs should:
 | `src/platform/game/render/BaseSprite.jsx` | 1 | `dynamic-content-driven` | no |
 | `src/platform/game/render/MonsterRender.jsx` | 1 | `dynamic-content-driven` | no |
 | `src/platform/ui/LoadingSkeleton.jsx` | 1 | `css-var-ready` | no |
-| `src/subjects/grammar/components/GrammarSetupScene.jsx` | 1 | `shared-pattern-available` | no |
 | `src/subjects/punctuation/components/PunctuationMapScene.jsx` | 1 | `dynamic-content-driven` | no |
 | `src/subjects/punctuation/components/PunctuationSetupScene.jsx` | 1 | `shared-pattern-available` | no |
 | `src/subjects/spelling/components/SpellingHeroBackdrop.jsx` | 1 | `dynamic-content-driven` | no |

--- a/scripts/inventory-inline-styles.mjs
+++ b/scripts/inventory-inline-styles.mjs
@@ -196,9 +196,11 @@ export const MIGRATED_THIS_PR = Object.freeze(new Set([
 // degraded-state banners. These are `shared-pattern-available` and remain candidates
 // for a future migration PR; the budget is bumped from 282 to 287 to record the
 // post-merge baseline honestly.
-export const PRE_MIGRATION_TOTAL = 287;
+// P5-U7: Monster strip progress bar uses 1 inline `style={{ width, backgroundColor }}`
+// site in GrammarSetupScene.jsx for accent-coloured star bars. Budget 287 → 288.
+export const PRE_MIGRATION_TOTAL = 288;
 export const SITES_MIGRATED_THIS_PR = 25;
-export const POST_MIGRATION_TOTAL = PRE_MIGRATION_TOTAL - SITES_MIGRATED_THIS_PR; // 262
+export const POST_MIGRATION_TOTAL = PRE_MIGRATION_TOTAL - SITES_MIGRATED_THIS_PR; // 263
 
 function classifyFile(relativePath) {
   return CLASSIFICATION[relativePath] || 'unclassified';

--- a/src/subjects/grammar/components/GrammarSetupScene.jsx
+++ b/src/subjects/grammar/components/GrammarSetupScene.jsx
@@ -9,7 +9,10 @@ import {
   GRAMMAR_DASHBOARD_HERO,
   GRAMMAR_MORE_PRACTICE_MODES,
   GRAMMAR_PRIMARY_MODE_CARDS,
+  GRAMMAR_SECONDARY_MODE_LINKS,
+  GRAMMAR_MONSTER_STRIP_CHILD_COPY,
   buildGrammarDashboardModel,
+  buildGrammarMonsterStripModel,
 } from './grammar-view-model.js';
 // SH2-U5: fresh-learner `dashboard.isEmpty` branch surfaces the canonical
 // three-part copy through the shared primitive. The pre-U5 bespoke
@@ -59,6 +62,32 @@ function TodayCard({ card }) {
   );
 }
 
+// U7 Phase 5: Monster strip entry — one per active Grammar monster.
+function MonsterStripEntry({ entry }) {
+  const pct = entry.starMax > 0 ? Math.round((entry.stars / entry.starMax) * 100) : 0;
+  return (
+    <div className="grammar-monster-entry" data-monster-id={entry.monsterId}>
+      <img
+        className="grammar-monster-entry-image"
+        src={grammarMonsterAsset(entry.monsterId, 160)}
+        alt=""
+        aria-hidden="true"
+      />
+      <div className="grammar-monster-entry-info">
+        <span className="grammar-monster-entry-name">{entry.name}</span>
+        <span className="grammar-monster-entry-stage">{entry.stageName}</span>
+        <div className="grammar-star-bar" aria-label={`${entry.stars} of ${entry.starMax} Stars`}>
+          <div
+            className="grammar-star-bar-fill"
+            style={{ width: `${pct}%`, backgroundColor: entry.accentColor }}
+          />
+        </div>
+        <span className="grammar-monster-entry-stars">{`${entry.stars} / ${entry.starMax} Stars`}</span>
+      </div>
+    </div>
+  );
+}
+
 function PrimaryModeCard({ card, selected, disabled, actions }) {
   const featured = card.featured === true;
   const classes = ['grammar-primary-mode'];
@@ -102,16 +131,24 @@ function MoreModeCard({ card, selected, disabled, actions }) {
   // tests and QA can scope by the mode id. The label is decorative and
   // does not change mode behaviour.
   const label = typeof card.label === 'string' && card.label ? card.label : '';
+  // U8 Phase 5: Writing Try (id: 'transfer') dispatches 'grammar-open-transfer'
+  // instead of 'grammar-set-mode' since it routes to the transfer scene.
+  const isTransfer = card.id === 'transfer';
+  const action = isTransfer ? 'grammar-open-transfer' : 'grammar-set-mode';
   return (
     <button
       type="button"
       className={classes.join(' ')}
       data-mode-id={card.id}
-      data-action="grammar-set-mode"
+      data-action={action}
       aria-pressed={selected ? 'true' : 'false'}
       disabled={disabled}
       onClick={() => {
         if (disabled) return;
+        if (isTransfer) {
+          actions.dispatch('grammar-open-transfer');
+          return;
+        }
         actions.dispatch('grammar-set-mode', { value: card.id });
       }}
     >
@@ -135,7 +172,21 @@ export function GrammarSetupScene({ learner, grammar, rewardState, actions, runt
     : (Number(grammar.prefs?.roundLength) || 5);
   const selectedSpeechRate = normaliseGrammarSpeechRate(grammar.prefs?.speechRate);
   const { title: heroTitle, subtitle: heroSubtitle } = GRAMMAR_DASHBOARD_HERO;
-  const concordium = dashboard.concordiumProgress;
+
+  // U7 Phase 5: build monster strip from reward state + mastery concept nodes.
+  // The grammar read-model carries concept nodes under analytics.concepts as
+  // a flat array; we index by id for the strip builder. recentAttempts come
+  // from the engine state if available.
+  const conceptNodesMap = {};
+  const analyticsConcepts = Array.isArray(grammar?.analytics?.concepts)
+    ? grammar.analytics.concepts : [];
+  for (const c of analyticsConcepts) {
+    if (c && typeof c === 'object' && typeof c.id === 'string') {
+      conceptNodesMap[c.id] = c;
+    }
+  }
+  const recentAttempts = Array.isArray(grammar?.recentAttempts) ? grammar.recentAttempts : [];
+  const monsterStrip = buildGrammarMonsterStripModel(rewardState, conceptNodesMap, recentAttempts);
 
   return (
     <section
@@ -143,6 +194,7 @@ export function GrammarSetupScene({ learner, grammar, rewardState, actions, runt
       aria-labelledby="grammar-dashboard-title"
       data-grammar-phase-root="dashboard"
     >
+      {/* Hero section */}
       <div
         className="grammar-hero"
         style={{ '--grammar-hero-bg': `url(${GRAMMAR_REGION_IMAGE})` }}
@@ -160,39 +212,21 @@ export function GrammarSetupScene({ learner, grammar, rewardState, actions, runt
         </div>
       </div>
 
-      <section className="grammar-today" aria-label="Today at a glance">
-        {dashboard.isEmpty ? (
-          <div className="grammar-today-empty" data-testid="grammar-today-empty">
-            <EmptyState
-              title="No rounds yet"
-              body="No rounds yet. Progress is saved as you practise. Start your first round to see your scores here."
-            />
-          </div>
-        ) : (
-          <div className="grammar-today-grid">
-            {dashboard.todayCards.map((card) => (
-              <TodayCard card={card} key={card.id} />
-            ))}
-          </div>
-        )}
-        <div className="grammar-concordium-progress" data-testid="grammar-concordium-progress">
-          <img
-            className="grammar-concordium-image"
-            src={grammarMonsterAsset('concordium', 320)}
-            alt=""
-            aria-hidden="true"
-          />
-          <span className="grammar-concordium-label">Grow Concordium</span>
-          <strong className="grammar-concordium-value">{`${concordium.mastered}/${concordium.total}`}</strong>
-        </div>
+      {/* U7: Monster strip — 4 active monsters with Star progress */}
+      <section className="grammar-monster-strip" aria-label="Your Grammar creatures">
+        {monsterStrip.map((entry) => (
+          <MonsterStripEntry entry={entry} key={entry.monsterId} />
+        ))}
+        <p className="grammar-monster-strip-hint">{GRAMMAR_MONSTER_STRIP_CHILD_COPY}</p>
       </section>
 
-      <section className="grammar-primary-modes" aria-label="Choose a round">
+      {/* U8: Primary CTA — Smart Practice only */}
+      <section className="grammar-primary-modes" aria-label="Start practising">
         <div className="grammar-primary-grid">
           {GRAMMAR_PRIMARY_MODE_CARDS.map((card) => (
             <PrimaryModeCard
               card={card}
-              selected={card.id !== 'bank' && card.id === selectedMode}
+              selected={card.id === selectedMode}
               disabled={setupDisabled}
               actions={actions}
               key={card.id}
@@ -238,25 +272,58 @@ export function GrammarSetupScene({ learner, grammar, rewardState, actions, runt
           <button
             className="btn primary xl"
             type="button"
+            data-featured="true"
             disabled={setupDisabled}
             onClick={() => actions.dispatch('grammar-start')}
           >
-            {grammar.pendingCommand === 'start-session' ? 'Starting...' : 'Begin round'}
+            {grammar.pendingCommand === 'start-session' ? 'Starting...' : 'Start Smart Practice'}
           </button>
-          {dashboard.writingTryAvailable ? (
-            <button
-              className="btn secondary"
-              type="button"
-              data-action="grammar-open-transfer"
-              disabled={setupDisabled}
-              onClick={() => actions.dispatch('grammar-open-transfer')}
-            >
-              Writing Try · non-scored
-            </button>
-          ) : null}
         </div>
       </section>
 
+      {/* U8: Today cards — repositioned below primary CTA, above secondary links */}
+      <section className="grammar-today" aria-label="Today at a glance">
+        {dashboard.isEmpty ? (
+          <div className="grammar-today-empty" data-testid="grammar-today-empty">
+            <EmptyState
+              title="No rounds yet"
+              body="No rounds yet. Progress is saved as you practise. Start your first round to see your scores here."
+            />
+          </div>
+        ) : (
+          <div className="grammar-today-grid">
+            {dashboard.todayCards.map((card) => (
+              <TodayCard card={card} key={card.id} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* U8: Secondary links — Grammar Bank, Mini Test, Fix Trouble Spots */}
+      <nav className="grammar-secondary-links" aria-label="Other practice modes">
+        {GRAMMAR_SECONDARY_MODE_LINKS.map((link) => (
+          <button
+            type="button"
+            className="grammar-secondary-link"
+            key={link.id}
+            data-mode-id={link.id}
+            data-action={link.action}
+            disabled={setupDisabled}
+            onClick={() => {
+              if (setupDisabled) return;
+              if (link.action === 'grammar-open-concept-bank') {
+                actions.dispatch('grammar-open-concept-bank');
+              } else {
+                actions.dispatch('grammar-set-mode', { value: link.id });
+              }
+            }}
+          >
+            {link.title}
+          </button>
+        ))}
+      </nav>
+
+      {/* U8: More practice disclosure — Learn, Surgery, Builder, Worked, Faded, Writing Try */}
       <details className="grammar-more-practice">
         <summary>More practice</summary>
         <div className="grammar-more-practice-grid">

--- a/src/subjects/grammar/components/GrammarSetupScene.jsx
+++ b/src/subjects/grammar/components/GrammarSetupScene.jsx
@@ -21,22 +21,20 @@ import {
 // grammar-phase3-child-copy test continues to find the anchor.
 import { EmptyState } from '../../../platform/ui/EmptyState.jsx';
 
-// Phase 3 U1: Child-facing Grammar dashboard. Every label, mode id, and
-// card comes from the U8 view-model (`grammar-view-model.js`). The JSX
+// Phase 5 U7+U8: Child-facing Grammar dashboard. Every label, mode id,
+// and card comes from the view-model (`grammar-view-model.js`). The JSX
 // layer is a layout-only component — we do not restate copy, filter ids,
 // or mode ids inline. Hero copy is driven by `GRAMMAR_DASHBOARD_HERO` so
 // James can swap the wording in one place after review.
 //
-// Structure mirrors `SpellingSetupScene.jsx`:
+// Layout (top → bottom):
 //   - Hero (headline + subheadline)
-//   - Today cards row (Due / Trouble spots / Secure / Streak)
-//   - Concordium progress (drawn from `buildGrammarDashboardModel` →
-//     `concordiumProgress`)
-//   - Primary mode cards (4 cards from `GRAMMAR_PRIMARY_MODE_CARDS`)
-//   - Writing Try secondary entry (dispatches `grammar-open-transfer` —
-//     U6b renders the scene)
-//   - More practice <details> disclosure (5 cards from
-//     `GRAMMAR_MORE_PRACTICE_MODES`). Closed by default.
+//   - Monster strip (active creatures with Star progress bars)
+//   - Primary CTA (Start Smart Practice button)
+//   - Today cards (Due / Trouble spots / Secure / Streak)
+//   - Secondary links (Grammar Bank, Mini Test, Fix Trouble Spots)
+//   - More practice <details> disclosure (Learn, Surgery, Builder,
+//     Worked, Faded, Writing Try). Closed by default.
 //   - Quiet round-length + speech-rate controls.
 //
 // Everything the old adult-diagnostic surface said (`Worker-marked modes`,
@@ -69,7 +67,7 @@ function MonsterStripEntry({ entry }) {
     <div className="grammar-monster-entry" data-monster-id={entry.monsterId}>
       <img
         className="grammar-monster-entry-image"
-        src={grammarMonsterAsset(entry.monsterId, 160)}
+        src={grammarMonsterAsset(entry.monsterId, 320)}
         alt=""
         aria-hidden="true"
       />
@@ -94,22 +92,17 @@ function PrimaryModeCard({ card, selected, disabled, actions }) {
   if (selected) classes.push('selected');
   if (disabled) classes.push('is-disabled');
   if (featured) classes.push('is-recommended');
-  const action = card.id === 'bank' ? 'grammar-open-concept-bank' : 'grammar-set-mode';
   return (
     <button
       type="button"
       className={classes.join(' ')}
       data-mode-id={card.id}
-      data-action={action}
+      data-action="grammar-set-mode"
       data-featured={featured ? 'true' : 'false'}
       aria-pressed={selected ? 'true' : 'false'}
       disabled={disabled}
       onClick={() => {
         if (disabled) return;
-        if (card.id === 'bank') {
-          actions.dispatch('grammar-open-concept-bank');
-          return;
-        }
         actions.dispatch('grammar-set-mode', { value: card.id });
       }}
     >
@@ -304,7 +297,8 @@ export function GrammarSetupScene({ learner, grammar, rewardState, actions, runt
         {GRAMMAR_SECONDARY_MODE_LINKS.map((link) => (
           <button
             type="button"
-            className="grammar-secondary-link"
+            className={`grammar-secondary-link${selectedMode === link.id ? ' selected' : ''}`}
+            aria-pressed={selectedMode === link.id ? 'true' : 'false'}
             key={link.id}
             data-mode-id={link.id}
             data-action={link.action}
@@ -327,7 +321,9 @@ export function GrammarSetupScene({ learner, grammar, rewardState, actions, runt
       <details className="grammar-more-practice">
         <summary>More practice</summary>
         <div className="grammar-more-practice-grid">
-          {GRAMMAR_MORE_PRACTICE_MODES.map((card) => (
+          {GRAMMAR_MORE_PRACTICE_MODES.filter(
+            (m) => m.id !== 'transfer' || dashboard.writingTryAvailable
+          ).map((card) => (
             <MoreModeCard
               card={card}
               selected={card.id === selectedMode}

--- a/src/subjects/grammar/components/grammar-view-model.js
+++ b/src/subjects/grammar/components/grammar-view-model.js
@@ -15,14 +15,22 @@ import {
   grammarChildConfidenceLabel as grammarChildConfidenceLabelShared,
   isGrammarConfidenceLabel,
 } from '../../../../shared/grammar/confidence.js';
+import {
+  grammarStarStageName,
+  grammarStarDisplayStage,
+  GRAMMAR_MONSTER_STAR_MAX,
+} from '../../../../shared/grammar/grammar-stars.js';
 import { GRAMMAR_CLIENT_CONCEPTS } from '../metadata.js';
 import {
   GRAMMAR_AGGREGATE_CONCEPTS,
   GRAMMAR_CONCEPT_TO_MONSTER,
   GRAMMAR_REWARD_RELEASE_ID,
   grammarConceptIdFromMasteryKey,
+  progressForGrammarMonster,
+  GRAMMAR_MONSTER_CONCEPTS,
 } from '../../../platform/game/mastery/grammar.js';
 import { GRAMMAR_GRAND_MONSTER_ID } from '../../../platform/game/mastery/shared.js';
+import { MONSTERS } from '../../../platform/game/monsters.js';
 
 // --- Frozen option lists ----------------------------------------------------
 
@@ -48,10 +56,10 @@ export function isGrammarFocusAllowedMode(mode) {
   return GRAMMAR_FOCUS_ALLOWED_MODES.has(mode);
 }
 
-// The dashboard's four primary mode cards. `Smart Practice` sits first so it
-// is the obvious default action (R2). `Grammar Bank` is the fourth card and
-// routes into U2's new bank scene. `satsset` maps to the existing mode id so
-// the module dispatcher does not need renaming.
+// U8 Phase 5: Smart Practice is the sole primary CTA. The dashboard renders
+// this as a prominent button above the fold with `data-featured="true"`.
+// Grammar Bank, Mini Test, and Fix Trouble Spots are demoted to secondary
+// links below the monster strip.
 export const GRAMMAR_PRIMARY_MODE_CARDS = Object.freeze([
   Object.freeze({
     id: 'smart',
@@ -59,39 +67,45 @@ export const GRAMMAR_PRIMARY_MODE_CARDS = Object.freeze([
     desc: 'Due · weak · one fresh concept.',
     featured: true,
   }),
+]);
+
+// U8 Phase 5: Three modes demoted from primary cards to secondary links.
+// Order: Grammar Bank · Mini Test · Fix Trouble Spots. The JSX renders these
+// as text links below the monster strip — still accessible, but no longer
+// primary decision-weight buttons.
+export const GRAMMAR_SECONDARY_MODE_LINKS = Object.freeze([
   Object.freeze({
-    id: 'trouble',
-    title: 'Fix Trouble Spots',
-    desc: 'Only the concepts you usually miss.',
-    featured: false,
+    id: 'bank',
+    title: 'Grammar Bank',
+    desc: 'Browse every concept with child-friendly statuses.',
+    action: 'grammar-open-concept-bank',
   }),
   Object.freeze({
     id: 'satsset',
     title: 'Mini Test',
     desc: 'Short timed set. Marks at the end.',
-    featured: false,
+    action: 'grammar-set-mode',
   }),
   Object.freeze({
-    id: 'bank',
-    title: 'Grammar Bank',
-    desc: 'Browse every concept with child-friendly statuses.',
-    featured: false,
+    id: 'trouble',
+    title: 'Fix Trouble Spots',
+    desc: 'Only the concepts you usually miss.',
+    action: 'grammar-set-mode',
   }),
 ]);
 
 // Secondary modes disclosed under the dashboard's "More practice" details
-// block. Order follows the plan: Learn → Sentence Surgery → Sentence Builder
-// → Worked Examples → Faded Guidance. U5 Phase 4: Surgery and Builder carry
-// a `label: 'Mixed practice'` so the dashboard surfaces the child-facing
-// truth that these modes do not honour a focused concept id. The label is
-// ~12 chars and does not change the mode's behaviour — it is rendered by
-// `GrammarSetupScene.jsx` under the mode title.
+// block. U8 Phase 5: Writing Try moves here from the primary area, joining
+// Learn → Sentence Surgery → Sentence Builder → Worked Examples → Faded
+// Guidance → Writing Try. Surgery and Builder carry a `label: 'Mixed
+// practice'` per Phase 4 U5 decision.
 export const GRAMMAR_MORE_PRACTICE_MODES = Object.freeze([
   Object.freeze({ id: 'learn', title: 'Learn a concept', desc: 'Focused retrieval on one concept at a time.' }),
   Object.freeze({ id: 'surgery', title: 'Sentence Surgery', desc: 'Fix and rewrite sentence-level errors.', label: 'Mixed practice' }),
   Object.freeze({ id: 'builder', title: 'Sentence Builder', desc: 'Build sentences from structured prompts.', label: 'Mixed practice' }),
   Object.freeze({ id: 'worked', title: 'Worked Examples', desc: 'See a modelled answer before your turn.' }),
   Object.freeze({ id: 'faded', title: 'Faded Guidance', desc: 'Less help each round. You do the reasoning.' }),
+  Object.freeze({ id: 'transfer', title: 'Writing Try', desc: 'Non-scored free writing with grammar targets.' }),
 ]);
 
 // Grammar Bank status filter ids. `all` is the default; `due` surfaces
@@ -530,6 +544,7 @@ export function buildGrammarDashboardModel(grammar, _learner, rewardState) {
 
   return {
     modeCards: GRAMMAR_PRIMARY_MODE_CARDS,
+    secondaryLinks: GRAMMAR_SECONDARY_MODE_LINKS,
     todayCards: Object.freeze(todayCards),
     isEmpty,
     concordiumProgress: concordiumProgressFromReward(rewardState),
@@ -720,6 +735,68 @@ function masteredSummaryFromReward(rewardState) {
  * (4 active only). Reserved monsters never appear in the monster progress
  * entry, matching R15. Safe on empty summary and empty reward state.
  */
+// --- Monster strip child-facing copy ------------------------------------------
+
+export const GRAMMAR_MONSTER_STRIP_CHILD_COPY = Object.freeze(
+  'Get 1 Star to find the Egg. Reach 100 Stars for Mega.',
+);
+
+// --- Monster strip model builder ---------------------------------------------
+
+/**
+ * Builds the compact monster progress strip for the Grammar dashboard.
+ * Returns an array of 4 entries (one per active Grammar monster) in the
+ * canonical order: Bracehart, Chronalyx, Couronnail, Concordium.
+ *
+ * Each entry:
+ *   {
+ *     monsterId:   string,
+ *     name:        string,
+ *     stageName:   string,   // child-facing label from grammarStarStageName
+ *     stars:       number,   // 0–100
+ *     starMax:     100,
+ *     stageIndex:  number,   // display stage 0–5
+ *     accentColor: string,   // CSS hex colour from MONSTERS registry
+ *   }
+ *
+ * @param {object} rewardState — learner's Grammar reward state (monster entries)
+ * @param {object} masteryConceptNodes — map of conceptId → mastery node
+ * @param {Array}  recentAttempts — engine recentAttempts array
+ */
+export function buildGrammarMonsterStripModel(rewardState, masteryConceptNodes, recentAttempts) {
+  const safeReward = rewardState && typeof rewardState === 'object' && !Array.isArray(rewardState)
+    ? rewardState : {};
+  const safeConcepts = masteryConceptNodes && typeof masteryConceptNodes === 'object'
+    && !Array.isArray(masteryConceptNodes) ? masteryConceptNodes : null;
+  const safeAttempts = Array.isArray(recentAttempts) ? recentAttempts : [];
+
+  return ACTIVE_GRAMMAR_MONSTER_IDS.map((monsterId) => {
+    const conceptTotal = ACTIVE_GRAMMAR_MONSTER_CONCEPT_COUNTS[monsterId] || 1;
+    const progress = progressForGrammarMonster(safeReward, monsterId, {
+      conceptTotal,
+      conceptNodes: safeConcepts,
+      recentAttempts: safeAttempts,
+    });
+
+    const stars = typeof progress.stars === 'number' && Number.isFinite(progress.stars)
+      ? progress.stars : 0;
+    const monster = MONSTERS[monsterId];
+    const accentColor = monster?.accent || '#888888';
+
+    return Object.freeze({
+      monsterId,
+      name: ACTIVE_GRAMMAR_MONSTER_DISPLAY_NAMES[monsterId] || monsterId,
+      stageName: grammarStarStageName(stars),
+      stars,
+      starMax: GRAMMAR_MONSTER_STAR_MAX,
+      stageIndex: grammarStarDisplayStage(stars),
+      accentColor,
+    });
+  });
+}
+
+// --- Summary cards builder --------------------------------------------------
+
 export function grammarSummaryCards(summary, rewardState) {
   const safeSummary = summary && typeof summary === 'object' && !Array.isArray(summary) ? summary : {};
   const answered = safeNumber(safeSummary.answered, 0);

--- a/styles/app.css
+++ b/styles/app.css
@@ -8258,6 +8258,242 @@ textarea:focus-visible {
   font-size: 0.88rem;
 }
 
+/* ---------- Grammar Phase 5 — dashboard landing ---------- */
+
+/* Monster strip — horizontal row of active grammar creatures */
+.grammar-monster-strip {
+  display: flex;
+  gap: 0.75rem;
+  padding: 1rem 0;
+}
+
+.grammar-monster-entry {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 5rem;
+}
+
+.grammar-monster-entry-image {
+  width: 48px;
+  height: 48px;
+  object-fit: contain;
+}
+
+.grammar-monster-entry-name {
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.grammar-monster-entry-stage {
+  font-size: 0.7rem;
+  color: #666;
+}
+
+.grammar-star-bar {
+  height: 6px;
+  background: #e0e0e0;
+  border-radius: 3px;
+  width: 100%;
+  max-width: 6rem;
+}
+
+.grammar-star-bar-fill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.3s;
+}
+
+.grammar-monster-entry-stars {
+  font-size: 0.7rem;
+  color: #888;
+}
+
+.grammar-monster-strip-hint {
+  font-size: 0.75rem;
+  color: #888;
+  text-align: center;
+  margin-top: 0.5rem;
+}
+
+/* Primary CTA — featured start button */
+.grammar-start-row [data-featured="true"] {
+  font-size: 1.1rem;
+  padding: 0.9rem 2rem;
+  font-weight: 700;
+  max-width: 20rem;
+  width: 100%;
+  margin: 0.75rem auto;
+}
+
+/* Secondary mode links — Grammar Bank, Mini Test, Fix Trouble Spots */
+.grammar-secondary-links {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  margin: 0.75rem 0;
+}
+
+.grammar-secondary-link {
+  font-size: 0.85rem;
+  color: var(--accent, #3E6FA8);
+  background: none;
+  border: 1px solid currentColor;
+  border-radius: 6px;
+  padding: 0.4rem 0.8rem;
+  cursor: pointer;
+  min-height: 44px;
+}
+
+.grammar-secondary-link.selected,
+.grammar-secondary-link[aria-pressed="true"] {
+  background: color-mix(in srgb, currentColor 10%, transparent);
+  font-weight: 600;
+}
+
+/* Today cards grid */
+.grammar-today-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.75rem;
+}
+
+.grammar-today-card {
+  display: grid;
+  gap: 4px;
+  text-align: center;
+  padding: 0.75rem;
+  border: 1px solid var(--line, #e0e0e0);
+  border-radius: 8px;
+}
+
+.grammar-today-label {
+  font-size: 0.78rem;
+  color: var(--muted, #666);
+}
+
+.grammar-today-value {
+  font-size: 1.3rem;
+  font-weight: 700;
+}
+
+.grammar-today-detail {
+  font-size: 0.75rem;
+  color: var(--muted, #666);
+}
+
+/* Primary mode cards grid */
+.grammar-primary-grid {
+  display: grid;
+  gap: 12px;
+}
+
+.grammar-primary-mode {
+  display: grid;
+  gap: 6px;
+  padding: 12px 16px;
+  border: 1px solid var(--line, #e0e0e0);
+  border-radius: 8px;
+  background: var(--panel-soft, #fafafa);
+  cursor: pointer;
+  text-align: left;
+}
+
+.grammar-primary-mode.selected {
+  border-color: var(--accent, #3E6FA8);
+  background: color-mix(in srgb, var(--accent, #3E6FA8) 6%, transparent);
+}
+
+.grammar-primary-mode.is-disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.grammar-primary-mode.is-recommended {
+  border-color: var(--accent, #3E6FA8);
+}
+
+.grammar-primary-mode-eyebrow {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--accent, #3E6FA8);
+}
+
+.grammar-primary-mode-title {
+  font-size: 1rem;
+  margin: 0;
+}
+
+.grammar-primary-mode-desc {
+  font-size: 0.85rem;
+  color: var(--muted, #666);
+  margin: 0;
+}
+
+/* Round controls — length + speech rate selectors */
+.grammar-round-controls {
+  display: flex;
+  gap: 1rem;
+  margin-top: 0.75rem;
+}
+
+/* More practice disclosure */
+.grammar-more-practice {
+  margin-top: 0.75rem;
+}
+
+.grammar-more-practice summary {
+  cursor: pointer;
+  font-weight: 600;
+  padding: 0.5rem 0;
+}
+
+.grammar-more-practice-grid {
+  display: grid;
+  gap: 10px;
+  margin-top: 0.5rem;
+}
+
+.grammar-secondary-mode {
+  display: grid;
+  gap: 4px;
+  padding: 10px 14px;
+  border: 1px solid var(--line, #e0e0e0);
+  border-radius: 8px;
+  background: var(--panel-soft, #fafafa);
+  cursor: pointer;
+  text-align: left;
+}
+
+.grammar-secondary-mode.selected {
+  border-color: var(--accent, #3E6FA8);
+  background: color-mix(in srgb, var(--accent, #3E6FA8) 6%, transparent);
+}
+
+.grammar-secondary-mode.is-disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.grammar-secondary-mode-title {
+  font-size: 0.92rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.grammar-secondary-mode-label {
+  font-size: 0.75rem;
+  color: var(--muted, #666);
+}
+
+.grammar-secondary-mode-desc {
+  font-size: 0.82rem;
+  color: var(--muted, #666);
+  margin: 0;
+}
+
 @media (max-width: 980px) {
   .grammar-setup-grid,
   .grammar-analytics-grid,
@@ -8298,6 +8534,20 @@ textarea:focus-visible {
   .grammar-choice-list.tokens,
   .grammar-choice-list.compact {
     grid-template-columns: 1fr;
+  }
+}
+
+/* Phase 5 dashboard responsive — narrow screens */
+@media (max-width: 600px) {
+  .grammar-monster-strip {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+  .grammar-today-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .grammar-secondary-links {
+    flex-wrap: wrap;
   }
 }
 

--- a/tests/grammar-ui-model.test.js
+++ b/tests/grammar-ui-model.test.js
@@ -24,7 +24,9 @@ import {
 } from '../src/subjects/grammar/session-ui.js';
 import {
   GRAMMAR_PRIMARY_MODE_CARDS,
+  GRAMMAR_SECONDARY_MODE_LINKS,
   GRAMMAR_MORE_PRACTICE_MODES,
+  GRAMMAR_MONSTER_STRIP_CHILD_COPY,
   GRAMMAR_BANK_STATUS_FILTER_IDS,
   GRAMMAR_BANK_CLUSTER_FILTER_IDS,
   GRAMMAR_DASHBOARD_HERO,
@@ -36,6 +38,7 @@ import {
   grammarBankFilterMatchesStatus,
   buildGrammarDashboardModel,
   buildGrammarBankModel,
+  buildGrammarMonsterStripModel,
   grammarSummaryCards,
   isGrammarChildCopy,
   isGrammarFocusAllowedMode,
@@ -257,34 +260,49 @@ test('U8 session-ui: grammarFeedbackTone neutral returns neutral', () => {
 // GRAMMAR_PRIMARY_MODE_CARDS — roster + shape contract
 // -----------------------------------------------------------------------------
 
-test('U8 view-model: GRAMMAR_PRIMARY_MODE_CARDS has exactly four cards (plan requirement)', () => {
-  assert.equal(GRAMMAR_PRIMARY_MODE_CARDS.length, 4);
+// U8 Phase 5: GRAMMAR_PRIMARY_MODE_CARDS is now Smart Practice only.
+test('P5-U8 view-model: GRAMMAR_PRIMARY_MODE_CARDS has exactly one card (Smart Practice)', () => {
+  assert.equal(GRAMMAR_PRIMARY_MODE_CARDS.length, 1);
+  assert.equal(GRAMMAR_PRIMARY_MODE_CARDS[0].id, 'smart');
+  assert.equal(GRAMMAR_PRIMARY_MODE_CARDS[0].featured, true);
 });
 
-test('U8 view-model: GRAMMAR_PRIMARY_MODE_CARDS ids match active-mode set', () => {
-  const ids = GRAMMAR_PRIMARY_MODE_CARDS.map((card) => card.id);
-  assert.deepEqual(ids, ['smart', 'trouble', 'satsset', 'bank']);
+test('P5-U8 view-model: GRAMMAR_PRIMARY_MODE_CARDS title is Smart Practice', () => {
+  assert.equal(GRAMMAR_PRIMARY_MODE_CARDS[0].title, 'Smart Practice');
 });
 
-test('U8 view-model: GRAMMAR_PRIMARY_MODE_CARDS titles match child copy', () => {
-  const titles = Object.fromEntries(GRAMMAR_PRIMARY_MODE_CARDS.map((card) => [card.id, card.title]));
-  assert.equal(titles.smart, 'Smart Practice');
-  assert.equal(titles.trouble, 'Fix Trouble Spots');
-  assert.equal(titles.satsset, 'Mini Test');
-  assert.equal(titles.bank, 'Grammar Bank');
-});
-
-test('U8 view-model: GRAMMAR_PRIMARY_MODE_CARDS is frozen and deeply frozen', () => {
+test('P5-U8 view-model: GRAMMAR_PRIMARY_MODE_CARDS is frozen and deeply frozen', () => {
   assert.equal(Object.isFrozen(GRAMMAR_PRIMARY_MODE_CARDS), true);
   for (const card of GRAMMAR_PRIMARY_MODE_CARDS) {
     assert.equal(Object.isFrozen(card), true);
   }
 });
 
-test('U8 view-model: GRAMMAR_PRIMARY_MODE_CARDS titles use only child copy', () => {
+test('P5-U8 view-model: GRAMMAR_PRIMARY_MODE_CARDS titles use only child copy', () => {
   for (const card of GRAMMAR_PRIMARY_MODE_CARDS) {
     assert.equal(isGrammarChildCopy(card.title), true, `title "${card.title}" contains forbidden term`);
     assert.equal(isGrammarChildCopy(card.desc), true, `desc "${card.desc}" contains forbidden term`);
+  }
+});
+
+// U8 Phase 5: Three demoted modes as secondary links.
+test('P5-U8 view-model: GRAMMAR_SECONDARY_MODE_LINKS has Grammar Bank, Mini Test, Fix Trouble Spots', () => {
+  assert.equal(GRAMMAR_SECONDARY_MODE_LINKS.length, 3);
+  const ids = GRAMMAR_SECONDARY_MODE_LINKS.map((link) => link.id);
+  assert.deepEqual(ids, ['bank', 'satsset', 'trouble']);
+});
+
+test('P5-U8 view-model: GRAMMAR_SECONDARY_MODE_LINKS is frozen and deeply frozen', () => {
+  assert.equal(Object.isFrozen(GRAMMAR_SECONDARY_MODE_LINKS), true);
+  for (const link of GRAMMAR_SECONDARY_MODE_LINKS) {
+    assert.equal(Object.isFrozen(link), true);
+  }
+});
+
+test('P5-U8 view-model: GRAMMAR_SECONDARY_MODE_LINKS titles use only child copy', () => {
+  for (const link of GRAMMAR_SECONDARY_MODE_LINKS) {
+    assert.equal(isGrammarChildCopy(link.title), true, `title "${link.title}" contains forbidden term`);
+    assert.equal(isGrammarChildCopy(link.desc), true, `desc "${link.desc}" contains forbidden term`);
   }
 });
 
@@ -292,15 +310,15 @@ test('U8 view-model: GRAMMAR_PRIMARY_MODE_CARDS titles use only child copy', () 
 // GRAMMAR_MORE_PRACTICE_MODES
 // -----------------------------------------------------------------------------
 
-test('U8 view-model: GRAMMAR_MORE_PRACTICE_MODES has exactly five secondary modes', () => {
-  assert.equal(GRAMMAR_MORE_PRACTICE_MODES.length, 5);
+test('P5-U8 view-model: GRAMMAR_MORE_PRACTICE_MODES has exactly six secondary modes (Writing Try added)', () => {
+  assert.equal(GRAMMAR_MORE_PRACTICE_MODES.length, 6);
   assert.deepEqual(
     GRAMMAR_MORE_PRACTICE_MODES.map((mode) => mode.id),
-    ['learn', 'surgery', 'builder', 'worked', 'faded'],
+    ['learn', 'surgery', 'builder', 'worked', 'faded', 'transfer'],
   );
 });
 
-test('U8 view-model: GRAMMAR_MORE_PRACTICE_MODES are frozen', () => {
+test('P5-U8 view-model: GRAMMAR_MORE_PRACTICE_MODES are frozen', () => {
   assert.equal(Object.isFrozen(GRAMMAR_MORE_PRACTICE_MODES), true);
   for (const mode of GRAMMAR_MORE_PRACTICE_MODES) {
     assert.equal(Object.isFrozen(mode), true);
@@ -319,10 +337,11 @@ test('U5 view-model: GRAMMAR_MORE_PRACTICE_MODES carries "Mixed practice" label 
   // will not stick in these modes.
   assert.equal(byId.surgery.label, 'Mixed practice');
   assert.equal(byId.builder.label, 'Mixed practice');
-  // Learn / Worked / Faded all honour focus — no label required.
+  // Learn / Worked / Faded / Transfer all honour focus or are non-scored — no label required.
   assert.equal(byId.learn.label ?? '', '', 'learn has no Mixed practice label');
   assert.equal(byId.worked.label ?? '', '', 'worked has no Mixed practice label');
   assert.equal(byId.faded.label ?? '', '', 'faded has no Mixed practice label');
+  assert.equal(byId.transfer.label ?? '', '', 'transfer has no Mixed practice label');
 });
 
 test('U5 view-model: Mixed practice label stays ~12 chars to fit under the mode title', () => {
@@ -568,24 +587,25 @@ test('U8 view-model: isGrammarChildCopy safe on empty / non-string', () => {
 // buildGrammarDashboardModel
 // -----------------------------------------------------------------------------
 
-test('U8 view-model: buildGrammarDashboardModel returns safe empty shape on null inputs', () => {
+test('P5-U8 view-model: buildGrammarDashboardModel returns safe empty shape on null inputs', () => {
   const model = buildGrammarDashboardModel(null, null, null);
   assert.equal(Array.isArray(model.modeCards), true);
-  assert.equal(model.modeCards.length, 4);
+  // U8 Phase 5: modeCards now contains only Smart Practice.
+  assert.equal(model.modeCards.length, 1);
+  assert.equal(model.modeCards[0].id, 'smart');
+  assert.equal(model.modeCards[0].featured, true);
   assert.equal(model.todayCards.length, 4);
   assert.equal(model.isEmpty, true);
   assert.equal(model.concordiumProgress.mastered, 0);
   assert.equal(model.concordiumProgress.total, 18);
   assert.equal(model.primaryMode, 'smart');
   assert.equal(Array.isArray(model.moreModes), true);
-  assert.equal(model.moreModes.length, 5);
+  // U8 Phase 5: moreModes now includes Writing Try (6 total).
+  assert.equal(model.moreModes.length, 6);
   assert.equal(typeof model.writingTryAvailable, 'boolean');
-  // U1 follower: Smart Practice card is flagged as featured so U9 can style it.
-  const smartCard = model.modeCards.find((card) => card.id === 'smart');
-  assert.equal(smartCard.featured, true);
-  for (const card of model.modeCards) {
-    if (card.id !== 'smart') assert.notEqual(card.featured, true);
-  }
+  // U8 Phase 5: secondaryLinks has 3 demoted modes.
+  assert.equal(Array.isArray(model.secondaryLinks), true);
+  assert.equal(model.secondaryLinks.length, 3);
 });
 
 test('U8 view-model: buildGrammarDashboardModel surfaces concept counts', () => {
@@ -877,4 +897,154 @@ test('U2 view-model: buildGrammarBankModel exposes clusterCounts for chip badges
   assert.equal(model.clusterCounts.chronalyx, 4);
   assert.equal(model.clusterCounts.couronnail, 3);
   assert.equal(model.clusterCounts.concordium, 18);
+});
+
+// =============================================================================
+// P5-U7: buildGrammarMonsterStripModel — monster strip view-model
+// =============================================================================
+
+test('P5-U7 view-model: buildGrammarMonsterStripModel returns 4 active monsters in order', () => {
+  const strip = buildGrammarMonsterStripModel(null, null, null);
+  assert.equal(strip.length, 4);
+  assert.deepEqual(strip.map((e) => e.monsterId), ['bracehart', 'chronalyx', 'couronnail', 'concordium']);
+});
+
+test('P5-U7 view-model: monster with 0 Stars shows "Not found yet"', () => {
+  const strip = buildGrammarMonsterStripModel({}, null, null);
+  for (const entry of strip) {
+    assert.equal(entry.stars, 0);
+    assert.equal(entry.stageName, 'Not found yet');
+    assert.equal(entry.starMax, 100);
+    assert.equal(entry.stageIndex, 0);
+  }
+});
+
+test('P5-U7 view-model: monster with starHighWater=42 shows "Growing" (42 Stars)', () => {
+  const rewardState = {
+    bracehart: { mastered: [], caught: true, starHighWater: 42 },
+  };
+  const strip = buildGrammarMonsterStripModel(rewardState, null, null);
+  const bracehart = strip.find((e) => e.monsterId === 'bracehart');
+  assert.equal(bracehart.stars, 42);
+  assert.equal(bracehart.stageName, 'Growing');
+  assert.equal(bracehart.stageIndex, 3);
+});
+
+test('P5-U7 view-model: monster with starHighWater=100 shows "Mega"', () => {
+  const rewardState = {
+    couronnail: { mastered: [], caught: true, starHighWater: 100 },
+  };
+  const strip = buildGrammarMonsterStripModel(rewardState, null, null);
+  const couronnail = strip.find((e) => e.monsterId === 'couronnail');
+  assert.equal(couronnail.stars, 100);
+  assert.equal(couronnail.stageName, 'Mega');
+  assert.equal(couronnail.stageIndex, 5);
+});
+
+test('P5-U7 view-model: reserved monsters never appear in strip', () => {
+  const rewardState = {
+    glossbloom: { mastered: ['something'], caught: true, starHighWater: 50 },
+    loomrill: { mastered: ['something'], caught: true, starHighWater: 30 },
+    mirrane: { mastered: ['something'], caught: true, starHighWater: 20 },
+  };
+  const strip = buildGrammarMonsterStripModel(rewardState, null, null);
+  const ids = strip.map((e) => e.monsterId);
+  assert.equal(ids.includes('glossbloom'), false);
+  assert.equal(ids.includes('loomrill'), false);
+  assert.equal(ids.includes('mirrane'), false);
+  assert.equal(ids.length, 4);
+});
+
+test('P5-U7 view-model: child-facing copy in monster strip contains no forbidden terms', () => {
+  const strip = buildGrammarMonsterStripModel({}, null, null);
+  for (const entry of strip) {
+    assert.equal(isGrammarChildCopy(entry.name), true, `name "${entry.name}" contains forbidden term`);
+    assert.equal(isGrammarChildCopy(entry.stageName), true, `stageName "${entry.stageName}" contains forbidden term`);
+  }
+  assert.equal(isGrammarChildCopy(GRAMMAR_MONSTER_STRIP_CHILD_COPY), true);
+});
+
+test('P5-U7 view-model: each monster entry has a valid accentColor from MONSTERS registry', () => {
+  const strip = buildGrammarMonsterStripModel({}, null, null);
+  for (const entry of strip) {
+    assert.ok(typeof entry.accentColor === 'string');
+    assert.match(entry.accentColor, /^#[0-9A-Fa-f]{6}$/, `${entry.monsterId} accent must be hex colour`);
+  }
+});
+
+test('P5-U7 view-model: monster strip entries are frozen', () => {
+  const strip = buildGrammarMonsterStripModel({}, null, null);
+  for (const entry of strip) {
+    assert.equal(Object.isFrozen(entry), true, `${entry.monsterId} entry must be frozen`);
+  }
+});
+
+test('P5-U7 view-model: GRAMMAR_MONSTER_STRIP_CHILD_COPY is correct child-facing sentence', () => {
+  assert.equal(GRAMMAR_MONSTER_STRIP_CHILD_COPY, 'Get 1 Star to find the Egg. Reach 100 Stars for Mega.');
+});
+
+test('P5-U7 view-model: buildGrammarMonsterStripModel + buildGrammarDashboardModel compose without conflict', () => {
+  const dashboard = buildGrammarDashboardModel({}, null, {});
+  const strip = buildGrammarMonsterStripModel({}, null, null);
+  // Both return valid shapes without overwriting each other.
+  assert.equal(dashboard.modeCards.length, 1);
+  assert.equal(strip.length, 4);
+  assert.equal(dashboard.concordiumProgress.total, 18);
+});
+
+// =============================================================================
+// P5-U8: Landing page simplification — Smart Practice sole CTA
+// =============================================================================
+
+test('P5-U8 view-model: Smart Practice is the only data-featured=true element', () => {
+  // In GRAMMAR_PRIMARY_MODE_CARDS, only Smart Practice has featured=true.
+  const featuredCards = GRAMMAR_PRIMARY_MODE_CARDS.filter((c) => c.featured === true);
+  assert.equal(featuredCards.length, 1);
+  assert.equal(featuredCards[0].id, 'smart');
+});
+
+test('P5-U8 view-model: Grammar Bank, Mini Test, Fix Trouble Spots appear as secondary links', () => {
+  const ids = GRAMMAR_SECONDARY_MODE_LINKS.map((link) => link.id);
+  assert.ok(ids.includes('bank'), 'Grammar Bank in secondary links');
+  assert.ok(ids.includes('satsset'), 'Mini Test in secondary links');
+  assert.ok(ids.includes('trouble'), 'Fix Trouble Spots in secondary links');
+});
+
+test('P5-U8 view-model: Writing Try appears inside collapsed More practice', () => {
+  const moreIds = GRAMMAR_MORE_PRACTICE_MODES.map((mode) => mode.id);
+  assert.ok(moreIds.includes('transfer'), 'Writing Try (transfer) in More practice');
+  // Writing Try is NOT in primary or secondary.
+  const primaryIds = GRAMMAR_PRIMARY_MODE_CARDS.map((c) => c.id);
+  const secondaryIds = GRAMMAR_SECONDARY_MODE_LINKS.map((l) => l.id);
+  assert.equal(primaryIds.includes('transfer'), false, 'Writing Try not in primary');
+  assert.equal(secondaryIds.includes('transfer'), false, 'Writing Try not in secondary links');
+});
+
+test('P5-U8 view-model: More practice disclosure contains all 6 secondary modes', () => {
+  assert.deepEqual(
+    GRAMMAR_MORE_PRACTICE_MODES.map((mode) => mode.id),
+    ['learn', 'surgery', 'builder', 'worked', 'faded', 'transfer'],
+  );
+});
+
+test('P5-U8 view-model: fresh learner (no progress) still produces valid dashboard with Smart Practice accessible', () => {
+  const model = buildGrammarDashboardModel({}, null, null);
+  assert.equal(model.isEmpty, true);
+  assert.equal(model.modeCards.length, 1);
+  assert.equal(model.modeCards[0].id, 'smart');
+  assert.equal(model.secondaryLinks.length, 3);
+  assert.equal(model.moreModes.length, 6);
+});
+
+test('P5-U8 view-model: all forbidden terms absent from simplified layout labels', () => {
+  // Primary, secondary, and more-practice titles + descs.
+  const allLabels = [
+    ...GRAMMAR_PRIMARY_MODE_CARDS.flatMap((c) => [c.title, c.desc]),
+    ...GRAMMAR_SECONDARY_MODE_LINKS.flatMap((l) => [l.title, l.desc]),
+    ...GRAMMAR_MORE_PRACTICE_MODES.flatMap((m) => [m.title, m.desc]),
+    GRAMMAR_MONSTER_STRIP_CHILD_COPY,
+  ];
+  for (const label of allLabels) {
+    assert.equal(isGrammarChildCopy(label), true, `"${label}" contains forbidden term`);
+  }
 });

--- a/tests/react-grammar-surface.test.js
+++ b/tests/react-grammar-surface.test.js
@@ -38,8 +38,9 @@ test('Grammar opens as the child-facing Grammar Garden dashboard', () => {
   // Phase 3 U1: hero copy comes from `GRAMMAR_DASHBOARD_HERO`.
   assert.match(html, /Grammar Garden/);
   assert.match(html, /Grow your Grammar creatures/);
-  // Four primary mode cards are present exactly.
+  // U8 Phase 5: Smart Practice is the sole primary CTA.
   assert.match(html, /Smart Practice/);
+  // U8 Phase 5: Grammar Bank, Mini Test, Fix Trouble Spots are secondary links.
   assert.match(html, /Fix Trouble Spots/);
   assert.match(html, /Mini Test/);
   assert.match(html, /Grammar Bank/);
@@ -50,16 +51,19 @@ test('Grammar opens as the child-facing Grammar Garden dashboard', () => {
   assert.match(html, /data-mode-id="smart"[^>]*data-featured="true"/);
   assert.match(html, /class="grammar-primary-mode[^"]*is-recommended[^"]*"[^>]*data-mode-id="smart"/);
   assert.match(html, /Recommended/);
-  // Concordium progress string (U1 follower: renamed "Grow Concordium").
-  assert.match(html, /Grow Concordium/);
-  assert.match(html, /\d+\/18/);
+  // U7 Phase 5: Monster strip with 4 active creatures + child-facing copy.
+  assert.match(html, /grammar-monster-strip/);
+  assert.match(html, /data-monster-id="bracehart"/);
+  assert.match(html, /data-monster-id="concordium"/);
+  assert.match(html, /0 \/ 100 Stars/);
+  assert.match(html, /Get 1 Star to find the Egg\. Reach 100 Stars for Mega\./);
   // More practice disclosure is present and closed by default.
   assert.match(html, /<details class="grammar-more-practice"><summary>More practice<\/summary>/);
-  // Writing Try secondary entry.
+  // U8 Phase 5: Writing Try now inside More practice (not primary area).
   assert.match(html, /data-action="grammar-open-transfer"/);
   assert.match(html, /Writing Try/);
-  // Primary Begin round CTA.
-  assert.match(html, /Begin round/);
+  // U8 Phase 5: Primary CTA is "Start Smart Practice".
+  assert.match(html, /Start Smart Practice/);
   assert.doesNotMatch(html, /Future subject module/);
 });
 
@@ -838,13 +842,12 @@ test('Grammar dashboard disables mode cards, controls, and Begin button while a 
   }));
 
   const html = harness.render();
-  // Primary mode cards carry `disabled` when setup is pending. Smart card
-  // also carries `is-recommended` + `data-featured="true"` (U1 follower).
+  // U8 Phase 5: Smart Practice is the sole primary card, disabled during pending.
   assert.match(html, /<button type="button" class="grammar-primary-mode selected is-disabled is-recommended" data-mode-id="smart" data-action="grammar-set-mode" data-featured="true" aria-pressed="true" disabled="">/);
   // Round length select is disabled and shows the default 5 value selected.
   assert.match(html, /<select class="input" disabled=""[^>]*><option value="3">3<\/option><option value="5" selected="">5<\/option>/);
-  // Begin button renders the pending label.
-  assert.match(html, /<button class="btn primary xl" type="button" disabled="">Starting\.\.\.<\/button>/);
+  // U8 Phase 5: Begin button renders the pending label.
+  assert.match(html, /<button class="btn primary xl" type="button" data-featured="true" disabled="">Starting\.\.\.<\/button>/);
 });
 
 test('Grammar dashboard hides adult-diagnostic goal/teaching toggles but preserves the preference round-trip', () => {
@@ -1491,9 +1494,10 @@ test('Grammar setup can start trouble drill mode', () => {
   assert.equal(harness.store.getState().subjectUi.grammar.prefs.mode, 'trouble');
   assert.equal(harness.store.getState().subjectUi.grammar.prefs.focusConceptId, '');
 
-  // U1 dashboard: `Fix Trouble Spots` card reflects the selected mode.
+  // U8 Phase 5: `Fix Trouble Spots` is now a secondary link, not a primary card.
+  // Verify the mode is set correctly (dispatch still works).
   const html = harness.render();
-  assert.match(html, /<button type="button" class="grammar-primary-mode selected" data-mode-id="trouble"/);
+  assert.match(html, /data-mode-id="trouble"/);
 
   harness.dispatch('grammar-set-focus', { value: 'word_classes' });
   assert.equal(harness.store.getState().subjectUi.grammar.prefs.focusConceptId, '');


### PR DESCRIPTION
## Summary

- **U7 — Dashboard monster strip:** Adds `buildGrammarMonsterStripModel()` to `grammar-view-model.js` returning all 4 active Grammar monsters with Stars/100 progress, child-facing stage names, and accent colours. `MonsterStripEntry` component renders below the hero with progress bars coloured by each monster's accent.
- **U8 — Landing page simplification:** Smart Practice becomes the sole primary CTA (`data-featured="true"`). Grammar Bank, Mini Test, and Fix Trouble Spots demoted to a secondary links row. Writing Try moved into the collapsed More practice disclosure (now 6 modes). Today cards repositioned below the CTA. Old Concordium progress section replaced by the monster strip.
- CSP inline style budget bumped 262 → 263 for the progress bar accent colour.

## Test plan

- [x] `buildGrammarMonsterStripModel` returns 4 active monsters in order (Bracehart, Chronalyx, Couronnail, Concordium)
- [x] Monster with 0 Stars → "Not found yet"; 42 Stars → "Growing"; 100 Stars → "Mega"
- [x] Reserved monsters (Glossbloom, Loomrill, Mirrane) never appear in strip
- [x] Child-facing copy contains no forbidden terms
- [x] Smart Practice is the only `data-featured="true"` element
- [x] Grammar Bank, Mini Test, Fix Trouble Spots appear as secondary links (not primary cards)
- [x] Writing Try appears inside collapsed More practice (not primary area)
- [x] More practice disclosure contains all 6 secondary modes
- [x] Fresh learner → empty state, Smart Practice still accessible
- [x] All 4211 tests pass (0 failures)