### PR TITLE
feat(punctuation): rebuild landing page as mission dashboard

### DIFF
--- a/src/subjects/punctuation/components/PunctuationSetupScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationSetupScene.jsx
@@ -1,57 +1,36 @@
-// Phase 3 U2 — Punctuation Setup scene (child dashboard).
+// Phase 5 U7 — Punctuation mission dashboard.
 //
-// Replaces the Phase 2 `SetupView`'s 10-button mode grid with a Hero +
-// Today cards + three primary journey cards (Smart Review / Wobbly Spots
-// / GPS Check) + one "Open Punctuation Map" secondary card + compact
-// round-length toggle (4 / 8 / 12) + active-monster strip. Reserved
-// monsters (Colisk / Hyphang / Carillon) are NEVER rendered — the
-// iterator is `ACTIVE_PUNCTUATION_MONSTER_IDS` full stop (plan R10 /
-// learning #5).
+// Replaces the Phase 3 U2 three-card button wall with a mission dashboard
+// modelled on the Spelling Setup's hero + side-panel pattern, adapted for
+// Bellstorm Coast. Layout:
 //
-// Mode display: `aria-pressed` on the primary cards is driven by
-// `punctuationPrimaryModeFromPrefs(prefs)`, which collapses the 6
-// Phase 2 cluster modes (endmarks / apostrophe / speech / comma_flow /
-// boundary / structure) AND `guided` to `'smart'` for display. That
-// normaliser is display-only — stored prefs still carry the stale
-// value until the one-shot migration below persists the collapse.
+//   Hero: Bellstorm Coast backdrop + headline + primary CTA
+//   Progress row: Due today | Wobbly | Stars earned (compact)
+//   Monster row: 4 active monsters with star meters (X / 100 Stars)
+//     and stage labels (Not caught / Egg Found / Hatch / Evolve / Strong / Mega)
+//   Map link: "Open Punctuation Map"
+//   Secondary drawer: Wobbly Spots | GPS Check | Round length toggle
 //
-// Stale-prefs migration (R1, plan line 408): on first render, if the
-// stored `prefs.mode` is one of the 6 cluster values or `'guided'`, the
-// scene dispatches `punctuation-set-mode` with `{ value: 'smart' }` to
-// migrate the stored value once. Two gates combine to guarantee exactly
-// one dispatch per session:
-//   - A `useRef` gate protects the same component instance from
-//     re-dispatching across React-level re-renders (including React 18
-//     strict-mode's double-invoke).
-//   - A store-level `ui.prefsMigrated` latch (set by the module's
-//     `punctuation-set-mode` handler) protects against component
-//     tear-down + rebuild — SSR renders produce fresh trees each time,
-//     so the useRef gate alone would re-fire on every server-side
-//     render.
-// Without this migration, `punctuation-start-again` (dispatched from
-// Summary) would silently start a cluster-focus session the learner
-// can no longer configure.
+// R7: Single primary CTA above the fold — Smart Review default, Wobbly if
+//     weaknesses exist, Continue if active session.
+// R8: Invariant skeleton — fresh learner and post-session render the SAME
+//     layout with different content only (no structural divergence).
+// R9: Star meters per monster from starView (U4 wired).
 //
-// Every mutation control threads `composeIsDisabled(ui)` so the
-// dashboard pauses visually whenever a command is in flight, the
-// runtime is degraded/unavailable, or the platform has flipped the
-// subject read-only (plan R11 — the same signal wired through Map,
-// Session, Feedback, and Summary scenes).
+// Every major section carries a `data-section` landmark for journey spec
+// testing (U9). The primary CTA carries `data-punctuation-cta`.
 
 import React, { useMemo, useRef } from 'react';
 
 import {
   ACTIVE_PUNCTUATION_MONSTER_IDS,
-  PUNCTUATION_DASHBOARD_HERO,
-  PUNCTUATION_PRIMARY_MODE_CARDS,
   PUNCTUATION_SETUP_ROUND_LENGTH_OPTIONS,
   bellstormSceneForPhase,
   buildPunctuationDashboardModel,
   composeIsDisabled,
   punctuationMonsterDisplayName,
-  punctuationPrimaryModeFromPrefs,
+  punctuationStageLabel,
 } from './punctuation-view-model.js';
-import { progressForPunctuationMonster } from '../../../platform/game/mastery/punctuation.js';
 import { emitPunctuationEvent } from '../telemetry.js';
 
 // The 6 Phase 2 cluster mode ids + `guided` — the set that triggers the
@@ -68,52 +47,55 @@ const LEGACY_PUNCTUATION_MODE_IDS = Object.freeze(new Set([
   'guided',
 ]));
 
-// Compact three-option toggle for the Setup scene. Default 4 (per plan);
-// 8 and 12 are the other two stops. Mirrors the Spelling LengthPicker's
-// radiogroup shape so screen readers land on the same familiar control.
-// Shared as `PUNCTUATION_SETUP_ROUND_LENGTH_OPTIONS` from the view-model so
-// the module's `punctuation-set-round-length` handler can validate against
-// the same narrow enum (adv-234-001).
+// --- CTA resolution --------------------------------------------------------
+//
+// R7: the primary CTA above the fold resolves to one of three labels:
+//   - "Continue your round" when an active session exists
+//   - "Tackle wobbly spots" when weaknesses exist (weak > 0) and no session
+//   - "Start today's round" as the default smart-review entry
+// The dispatch mode follows the same ladder: continue → weak → smart.
 
-function TodayCard({ card }) {
-  return (
-    <div className="punctuation-today-card" data-today-id={card.id}>
-      <div className="punctuation-today-label">{card.label}</div>
-      <div className="punctuation-today-value">{card.value}</div>
-      <div className="punctuation-today-detail">{card.detail}</div>
-    </div>
+function resolvePrimaryCta(stats, ui) {
+  const hasActiveSession = Boolean(
+    ui && typeof ui === 'object' && !Array.isArray(ui) && ui.session && ui.session.id,
   );
+  if (hasActiveSession) {
+    return { label: 'Continue your round', mode: 'continue' };
+  }
+  const weakCount = Number(stats?.weak) || 0;
+  if (weakCount > 0) {
+    return { label: 'Tackle wobbly spots', mode: 'weak' };
+  }
+  return { label: "Start today's round", mode: 'smart' };
 }
 
-// Exported so `tests/react-punctuation-scene.test.js` can exercise the real
-// onClick closure directly (calling the component as a plain function and
-// invoking the returned element's `props.onClick`). The Phase 3 SSR harness
-// could only grep the rendered HTML, so a regression that swapped the click
-// dispatch target (`punctuation-start` → `punctuation-set-mode`) slipped
-// through. The click-through test below that export is U1's guard.
-//
-// U1 (Phase 4, R1): primary cards are ACTION buttons, not radio buttons.
-// Tapping one starts a session immediately via `punctuation-start` with
-// `{ mode, roundLength }` — NOT `punctuation-set-mode` (which is a
-// preference-save no-op from Setup's perspective). `aria-pressed` is
-// intentionally omitted for the same reason: no "selected" state to
-// announce, because the click fires a session rather than toggling a
-// preference. The only remaining caller of `punctuation-set-mode` from
-// this scene is the one-shot stale-prefs migration (lines 251-270).
-//
-// `data-round-length` encodes the parent-threaded `roundLength` on the
-// button DOM so SSR tests can verify the parent → card prop threading
-// without needing to fire the onClick closure. Without this attribute
-// the click-through tests (which mount PrimaryModeCard in isolation
-// with a directly-supplied roundLength) would still pass if a future
-// regression dropped the `roundLength={selectedLengthValue}` prop from
-// the parent — production would dispatch `{mode, roundLength: undefined}`
-// but unit tests would stay green. See the "parent prop-threading"
-// SSR assertions in `tests/react-punctuation-scene.test.js`.
-export function PrimaryModeCard({ card, selected, disabled, roundLength, actions }) {
+// --- Fresh learner CTA override -------------------------------------------
+// A fresh learner (zero attempts, zero secure, zero due) gets a warmer
+// invitation instead of the default "Start today's round".
+function freshLearnerCtaLabel(isEmpty) {
+  return isEmpty ? 'Find your first punctuation egg' : null;
+}
+
+function selectedRoundLength(prefs) {
+  const raw = prefs && typeof prefs === 'object' && !Array.isArray(prefs)
+    ? prefs.roundLength
+    : null;
+  const candidate = typeof raw === 'string' && raw ? raw : '4';
+  return PUNCTUATION_SETUP_ROUND_LENGTH_OPTIONS.includes(candidate) ? candidate : '4';
+}
+
+// --- Legacy PrimaryModeCard export (backward compat) -----------------------
+// Phase 5 U7 replaces the three primary mode cards with a single CTA +
+// secondary drawer. The `PrimaryModeCard` component is no longer rendered
+// in the mission dashboard, but it is exported so the U1 click-through
+// tests in `tests/react-punctuation-scene.test.js` and the standalone
+// renderer in `tests/helpers/punctuation-scene-render.js` keep working.
+// These tests exercise the component's onClick closure in isolation and
+// are structurally valid even though the component is off the render tree.
+export function PrimaryModeCard({ card, selected, disabled: isDisabled, roundLength, actions }) {
   const classes = ['punctuation-primary-mode'];
   if (selected) classes.push('selected');
-  if (disabled) classes.push('is-disabled');
+  if (isDisabled) classes.push('is-disabled');
   if (card.badge) classes.push('is-recommended');
   return (
     <button
@@ -123,10 +105,10 @@ export function PrimaryModeCard({ card, selected, disabled, roundLength, actions
       data-action="punctuation-start"
       data-value={card.id}
       data-round-length={roundLength}
-      disabled={disabled}
-      aria-disabled={disabled ? 'true' : undefined}
+      disabled={isDisabled}
+      aria-disabled={isDisabled ? 'true' : undefined}
       onClick={() => {
-        if (disabled) return;
+        if (isDisabled) return;
         actions.dispatch('punctuation-start', { mode: card.id, roundLength });
       }}
     >
@@ -137,28 +119,7 @@ export function PrimaryModeCard({ card, selected, disabled, roundLength, actions
   );
 }
 
-function OpenMapCard({ disabled, actions }) {
-  const classes = ['punctuation-secondary-mode'];
-  if (disabled) classes.push('is-disabled');
-  return (
-    <button
-      type="button"
-      className={classes.join(' ')}
-      data-action="punctuation-open-map"
-      disabled={disabled}
-      aria-disabled={disabled ? 'true' : undefined}
-      onClick={() => {
-        if (disabled) return;
-        actions.dispatch('punctuation-open-map');
-      }}
-    >
-      <h4 className="punctuation-secondary-mode-title">Open Punctuation Map</h4>
-      <p className="punctuation-secondary-mode-desc">
-        Browse the 14 skills by monster and status.
-      </p>
-    </button>
-  );
-}
+// --- Sub-components --------------------------------------------------------
 
 function RoundLengthToggle({ selectedValue, disabled, actions }) {
   return (
@@ -192,103 +153,83 @@ function RoundLengthToggle({ selectedValue, disabled, actions }) {
   );
 }
 
-function ActiveMonsterStrip({ rewardState }) {
-  // Iterate `ACTIVE_PUNCTUATION_MONSTER_IDS` only — reserved monsters
-  // (colisk / hyphang / carillon) never surface even if the reward
-  // state carries entries for them (plan R10).
+function MonsterStarMeter({ monster }) {
+  const cap = monster.id === 'quoral' ? 100 : 100;
+  const starsLabel = monster.id === 'quoral' ? 'Grand Stars' : 'Stars';
+  const pct = Math.min(100, Math.max(0, Math.round((monster.totalStars / cap) * 100)));
+  const stageText = punctuationStageLabel(monster.starDerivedStage, monster.totalStars);
+
   return (
-    <div className="punctuation-active-monsters" aria-label="Active monsters">
-      {ACTIVE_PUNCTUATION_MONSTER_IDS.map((monsterId) => {
-        const progress = progressForPunctuationMonster(rewardState, monsterId);
-        return (
-          <div
-            className="punctuation-active-monster"
-            data-monster-id={monsterId}
-            key={monsterId}
-          >
-            <div className="punctuation-active-monster-name">
-              {punctuationMonsterDisplayName(monsterId)}
-            </div>
-            <div className="punctuation-active-monster-progress muted">
-              {`${progress.mastered}/${progress.publishedTotal} secure`}
-            </div>
-          </div>
-        );
-      })}
+    <div className="punctuation-monster-meter" data-monster-id={monster.id}>
+      <div className="punctuation-monster-meter-name">{monster.name}</div>
+      <div className="punctuation-monster-meter-stage">{stageText}</div>
+      <div className="punctuation-monster-meter-bar" aria-hidden="true">
+        <div
+          className="punctuation-monster-meter-fill"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <div className="punctuation-monster-meter-count">
+        {`${monster.totalStars} / ${cap} ${starsLabel}`}
+      </div>
     </div>
   );
 }
 
-function selectedRoundLength(prefs) {
-  const raw = prefs && typeof prefs === 'object' && !Array.isArray(prefs)
-    ? prefs.roundLength
-    : null;
-  const candidate = typeof raw === 'string' && raw ? raw : '4';
-  return PUNCTUATION_SETUP_ROUND_LENGTH_OPTIONS.includes(candidate) ? candidate : '4';
+function SecondaryModeButton({ label, mode, roundLength, disabled, actions }) {
+  const classes = ['punctuation-secondary-action'];
+  if (disabled) classes.push('is-disabled');
+  return (
+    <button
+      type="button"
+      className={classes.join(' ')}
+      data-action="punctuation-start"
+      data-value={mode}
+      disabled={disabled}
+      onClick={() => {
+        if (disabled) return;
+        actions.dispatch('punctuation-start', { mode, roundLength });
+      }}
+    >
+      {label}
+    </button>
+  );
 }
+
+// --- Main scene ------------------------------------------------------------
 
 export function PunctuationSetupScene({ ui, actions, prefs, stats, learner, rewardState }) {
   const scene = bellstormSceneForPhase('setup');
   const disabled = composeIsDisabled(ui);
 
-  // Display-only collapse of legacy cluster / `guided` prefs to `'smart'`.
-  // Stored value stays untouched until the migration effect below
-  // persists the collapse via dispatch.
-  const primaryMode = useMemo(() => punctuationPrimaryModeFromPrefs(prefs), [prefs]);
+  // U4: thread starView from ui into the dashboard model builder.
+  // The read-model populates ui.starView on the Worker round-trip;
+  // fresh learners have no starView — null is safe (builder handles it).
+  const starView = ui && typeof ui === 'object' && !Array.isArray(ui)
+    ? ui.starView || null
+    : null;
+
   const dashboard = useMemo(
-    () => buildPunctuationDashboardModel(stats, { prefs }, rewardState),
-    [stats, prefs, rewardState],
+    () => buildPunctuationDashboardModel(stats, { prefs }, rewardState, starView),
+    [stats, prefs, rewardState, starView],
   );
 
-  // One-shot stale-prefs migration. Three gates combine to guarantee
-  // exactly one dispatch per session:
-  //
-  //   1. `migratedRef` — React-level gate. Persists across every
-  //      re-render of the same component instance (including React
-  //      18's strict-mode double-invoke) so a client-side re-render
-  //      never fires the dispatch twice.
-  //   2. `ui.prefsMigrated` — store-level gate. Survives component
-  //      tear-down and rebuild (SSR renders produce fresh trees each
-  //      time; `migratedRef` alone would re-fire on every SSR call).
-  //      Latched CLIENT-SIDE below via `actions.updateSubjectUi` BEFORE
-  //      the dispatch fires — see adv-234 HIGH 1 for the detail. The
-  //      module's `punctuation-set-mode` handler also sets this latch
-  //      as part of its store update, but in production the dispatch
-  //      routes through `handleRemotePunctuationAction` → the Worker
-  //      `save-prefs` command, which returns true and short-circuits
-  //      the fall-through to `handleSubjectAction` → module handler.
-  //      Landing the latch here keeps both the harness (module-handler
-  //      path) and production (Worker-command path) in lock-step.
-  //   3. Reload-from-repositories after the Worker response rehydrates
-  //      `prefs.mode` to 'smart' — so even if the client-side latch is
-  //      somehow lost, the next render's `legacyCluster` check is
-  //      false.
-  //
-  // The check runs synchronously in the component body rather than
-  // an effect — `renderToStaticMarkup` does not execute effects, so a
-  // useEffect-based migration would never fire server-side. Dispatch
-  // to the store is safe during render because it goes to the app
-  // store (not component state) and the guards above prevent a
-  // re-entrant loop.
-  //
-  // `legacyCluster` is computed from the raw stored mode, not the
-  // display collapse, so a reverted state is detected only the first
-  // time before `prefsMigrated` latches.
-  // Phase 4 U4 — telemetry smoke integration.
-  //
-  // Setup-mount is the first of 12 telemetry emission sites in the plan's
-  // emission-site table (line 832-842). Firing the `card-opened` event at
-  // render-time (guarded by `cardOpenedRef`) gives U4 a real production
-  // touchpoint; the remaining 11 emission sites land in follow-on units
-  // (Session mount, submit-answer dispatch, feedback render, summary,
-  // map, etc.).
-  //
-  // A useRef gate is used (not useEffect) because `renderToStaticMarkup`
-  // never runs effects. The gate prevents React 18 strict-mode's
-  // double-invoke from firing the emit twice per mount. The emitter is
-  // fire-and-forget and routes through the subject-command-actions
-  // mapping — it cannot stall the render (see `telemetry.js` for the
-  // authz invariant).
+  // One-shot stale-prefs migration (unchanged from Phase 3 U2).
+  const migratedRef = useRef(false);
+  const prefsMigrated = Boolean(ui && typeof ui === 'object' && !Array.isArray(ui) && ui.prefsMigrated);
+  const storedMode = prefs && typeof prefs === 'object' && !Array.isArray(prefs)
+    ? prefs.mode
+    : null;
+  const legacyCluster = typeof storedMode === 'string' && LEGACY_PUNCTUATION_MODE_IDS.has(storedMode);
+  if (legacyCluster && !migratedRef.current && !prefsMigrated) {
+    migratedRef.current = true;
+    if (typeof actions.updateSubjectUi === 'function') {
+      actions.updateSubjectUi('punctuation', { prefsMigrated: true });
+    }
+    actions.dispatch('punctuation-set-mode', { value: 'smart' });
+  }
+
+  // Phase 4 U4 telemetry smoke — Setup mount.
   const cardOpenedRef = useRef(false);
   if (!cardOpenedRef.current) {
     cardOpenedRef.current = true;
@@ -298,40 +239,43 @@ export function PunctuationSetupScene({ ui, actions, prefs, stats, learner, rewa
     });
   }
 
-  const migratedRef = useRef(false);
-  const prefsMigrated = Boolean(ui && typeof ui === 'object' && !Array.isArray(ui) && ui.prefsMigrated);
-  const storedMode = prefs && typeof prefs === 'object' && !Array.isArray(prefs)
-    ? prefs.mode
-    : null;
-  const legacyCluster = typeof storedMode === 'string' && LEGACY_PUNCTUATION_MODE_IDS.has(storedMode);
-  if (legacyCluster && !migratedRef.current && !prefsMigrated) {
-    migratedRef.current = true;
-    // adv-234 HIGH 1: latch the store-level gate BEFORE dispatching so the
-    // production Worker-command path (which never falls through to the
-    // module handler) still gets the `prefsMigrated: true` store update.
-    // `updateSubjectUi` is exposed on `actions` by both the production
-    // `buildSurfaceActions` in main.js and the tests/helpers/react-app-ssr
-    // renderer. Safe to call during render — it is a plain store merge,
-    // not a dispatch through `handleSubjectAction`, so no re-entrant loop.
-    if (typeof actions.updateSubjectUi === 'function') {
-      actions.updateSubjectUi('punctuation', { prefsMigrated: true });
-    }
-    actions.dispatch('punctuation-set-mode', { value: 'smart' });
-  }
-
   const selectedLengthValue = selectedRoundLength(prefs);
+
+  // CTA resolution
+  const cta = resolvePrimaryCta(stats, ui);
+  const freshLabel = freshLearnerCtaLabel(dashboard.isEmpty);
+  const ctaLabel = freshLabel || cta.label;
+  const ctaMode = cta.mode;
+
+  // Progress row values
+  const dueCount = Number(stats?.due) || 0;
+  const weakCount = Number(stats?.weak) || 0;
+  const totalStarsEarned = dashboard.activeMonsters.reduce(
+    (sum, m) => sum + (m.totalStars || 0), 0,
+  );
+
   const learnerName = learner && typeof learner === 'object' && !Array.isArray(learner)
     && typeof learner.name === 'string' && learner.name.trim()
     ? learner.name.trim()
     : '';
 
+  function handlePrimaryCta() {
+    if (disabled) return;
+    if (ctaMode === 'continue') {
+      actions.dispatch('punctuation-continue');
+      return;
+    }
+    actions.dispatch('punctuation-start', { mode: ctaMode, roundLength: selectedLengthValue });
+  }
+
   return (
     <section
-      className="card border-top punctuation-surface punctuation-setup-scene"
+      className="card border-top punctuation-surface punctuation-setup-scene punctuation-mission-dashboard"
       data-punctuation-phase="setup"
       style={{ borderTopColor: '#B8873F' }}
     >
-      <div className="punctuation-hero">
+      {/* Hero area — Bellstorm Coast backdrop + headline + primary CTA */}
+      <div className="punctuation-dashboard-hero" data-section="hero">
         <img
           src={scene.src}
           srcSet={scene.srcSet}
@@ -339,50 +283,89 @@ export function PunctuationSetupScene({ ui, actions, prefs, stats, learner, rewa
           alt=""
           aria-hidden="true"
         />
-        <div>
-          <div className="eyebrow">{PUNCTUATION_DASHBOARD_HERO.eyebrow}</div>
-          <h2 className="section-title">{PUNCTUATION_DASHBOARD_HERO.headline}</h2>
-          <p className="subtitle">{PUNCTUATION_DASHBOARD_HERO.subtitle}</p>
+        <div className="punctuation-dashboard-hero-content">
+          <div className="eyebrow">Bellstorm Coast</div>
+          <h2 className="section-title">Today's punctuation mission</h2>
           {learnerName ? (
             <p className="punctuation-hero-welcome">
               {`Hi ${learnerName} — ready for a short round?`}
             </p>
           ) : null}
+          <div className="punctuation-dashboard-cta-row">
+            <button
+              type="button"
+              className="btn primary xl"
+              style={{ '--btn-accent': '#B8873F' }}
+              data-punctuation-cta
+              data-action={ctaMode === 'continue' ? 'punctuation-continue' : 'punctuation-start'}
+              disabled={disabled}
+              onClick={handlePrimaryCta}
+            >
+              {ctaLabel}
+            </button>
+          </div>
         </div>
       </div>
 
-      <section className="punctuation-today" aria-label="Today at a glance">
-        {dashboard.isEmpty ? (
-          <div className="punctuation-today-empty" data-testid="punctuation-today-empty">
-            Start your first round to see your scores here.
+      {/* Progress row — compact stats strip */}
+      <section className="punctuation-progress-row" data-section="progress-row" aria-label="Today at a glance">
+        <dl className="punctuation-progress-strip">
+          <div className="punctuation-progress-item">
+            <dt>Due today</dt>
+            <dd>{dueCount}</dd>
           </div>
-        ) : (
-          <div className="punctuation-today-grid">
-            {dashboard.todayCards.map((card) => (
-              <TodayCard card={card} key={card.id} />
-            ))}
+          <div className="punctuation-progress-item">
+            <dt>Wobbly</dt>
+            <dd>{weakCount}</dd>
           </div>
-        )}
+          <div className="punctuation-progress-item">
+            <dt>Stars earned</dt>
+            <dd>{totalStarsEarned}</dd>
+          </div>
+        </dl>
       </section>
 
-      <section className="punctuation-primary-modes" aria-label="Choose a round">
-        <div className="punctuation-primary-grid">
-          {PUNCTUATION_PRIMARY_MODE_CARDS.map((card) => (
-            <PrimaryModeCard
-              card={card}
-              selected={card.id === primaryMode}
-              disabled={disabled}
-              roundLength={selectedLengthValue}
-              actions={actions}
-              key={card.id}
-            />
-          ))}
-        </div>
+      {/* Monster row — 4 active monsters with star meters */}
+      <section className="punctuation-monster-row" data-section="monster-row" aria-label="Your monsters">
+        {dashboard.activeMonsters.map((monster) => (
+          <MonsterStarMeter monster={monster} key={monster.id} />
+        ))}
+      </section>
 
-        <div className="punctuation-secondary-grid">
-          <OpenMapCard disabled={disabled} actions={actions} />
-        </div>
+      {/* Map link */}
+      <div data-section="map-link">
+        <button
+          type="button"
+          className="punctuation-map-link"
+          data-action="punctuation-open-map"
+          disabled={disabled}
+          onClick={() => {
+            if (disabled) return;
+            actions.dispatch('punctuation-open-map');
+          }}
+        >
+          Open Punctuation Map
+        </button>
+      </div>
 
+      {/* Secondary practice drawer */}
+      <section className="punctuation-secondary-drawer" data-section="secondary" aria-label="More practice options">
+        <div className="punctuation-secondary-modes">
+          <SecondaryModeButton
+            label="Wobbly Spots"
+            mode="weak"
+            roundLength={selectedLengthValue}
+            disabled={disabled}
+            actions={actions}
+          />
+          <SecondaryModeButton
+            label="GPS Check"
+            mode="gps"
+            roundLength={selectedLengthValue}
+            disabled={disabled}
+            actions={actions}
+          />
+        </div>
         <div className="punctuation-round-controls">
           <span className="punctuation-round-label">Round length</span>
           <RoundLengthToggle
@@ -391,11 +374,6 @@ export function PunctuationSetupScene({ ui, actions, prefs, stats, learner, rewa
             actions={actions}
           />
         </div>
-      </section>
-
-      <section className="punctuation-monsters-section" aria-label="Your monsters">
-        <h3 className="punctuation-monsters-heading">Your monsters</h3>
-        <ActiveMonsterStrip rewardState={rewardState} />
       </section>
     </section>
   );

--- a/src/subjects/punctuation/components/PunctuationSetupScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationSetupScene.jsx
@@ -185,6 +185,7 @@ function SecondaryModeButton({ label, mode, roundLength, disabled, actions }) {
       className={classes.join(' ')}
       data-action="punctuation-start"
       data-value={mode}
+      data-round-length={roundLength}
       disabled={disabled}
       onClick={() => {
         if (disabled) return;

--- a/src/subjects/punctuation/components/punctuation-view-model.js
+++ b/src/subjects/punctuation/components/punctuation-view-model.js
@@ -342,7 +342,7 @@ export function punctuationSummaryHeadline(summary) {
 // only — U10's sweep validates.
 export const PUNCTUATION_DASHBOARD_HERO = Object.freeze({
   eyebrow: 'Bellstorm Coast',
-  headline: 'Punctuation practice',
+  headline: "Today's punctuation mission",
   subtitle: "Pick a short round — we'll queue what matters next.",
 });
 
@@ -1105,6 +1105,39 @@ const PUNCTUATION_MULTI_SKILL_ITEM_SKILLS = Object.freeze(new Set([
 export function punctuationSkillHasMultiSkillItems(skillId) {
   if (typeof skillId !== 'string' || !skillId) return false;
   return PUNCTUATION_MULTI_SKILL_ITEM_SKILLS.has(skillId);
+}
+
+// --- Monster stage labels (child-facing) -----------------------------------
+
+// Child-facing label for a monster's current stage, derived from
+// `starDerivedStage` (0-5 for direct monsters, 0-5 for grand). The labels
+// read as warm adventure-world status rather than clinical stage numbers.
+// Stage 0 with zero stars is "Not caught" (fresh learner); Stage 0 with
+// any stars is "Egg Found" (the learner has started but not hatched).
+const PUNCTUATION_MONSTER_STAGE_LABELS = Object.freeze([
+  'Not caught',
+  'Egg Found',
+  'Hatch',
+  'Evolve',
+  'Strong',
+  'Mega',
+]);
+
+/**
+ * Returns a child-facing label for the monster's current stage.
+ * `stage` is the `starDerivedStage` integer (0-5). `totalStars` is
+ * used to distinguish "Not caught" (0 stars at stage 0) from
+ * "Egg Found" (>0 stars at stage 0). Unknown/out-of-range stages
+ * fall back to "Not caught".
+ */
+export function punctuationStageLabel(stage, totalStars = 0) {
+  const s = Number(stage);
+  const stars = Number(totalStars) || 0;
+  if (!Number.isFinite(s) || s < 0 || s > 5) return PUNCTUATION_MONSTER_STAGE_LABELS[0];
+  // Stage 0 splits: zero stars → "Not caught"; any stars → "Egg Found"
+  if (s === 0 && stars > 0) return PUNCTUATION_MONSTER_STAGE_LABELS[1];
+  if (s === 0) return PUNCTUATION_MONSTER_STAGE_LABELS[0];
+  return PUNCTUATION_MONSTER_STAGE_LABELS[s] || PUNCTUATION_MONSTER_STAGE_LABELS[0];
 }
 
 // --- Dashboard model builder -----------------------------------------------

--- a/styles/app.css
+++ b/styles/app.css
@@ -10125,6 +10125,187 @@ html { scroll-behavior: smooth; }
   font-size: 0.82rem;
 }
 
+/* --- Setup — mission dashboard (Phase 5 U7) ------------------------------ */
+/* The mission dashboard replaces the three-card button wall with a hero +
+   progress row + monster star meters + map link + secondary drawer. Layout
+   mirrors the Spelling Setup's hero pattern, adapted for Bellstorm Coast. */
+
+.punctuation-mission-dashboard {
+  display: grid;
+  gap: 20px;
+}
+
+/* Hero: Bellstorm backdrop + headline + primary CTA */
+.punctuation-dashboard-hero {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.95fr) minmax(0, 1.05fr);
+  align-items: center;
+  gap: 18px;
+}
+.punctuation-dashboard-hero img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--panel-soft);
+}
+.punctuation-dashboard-hero-content {
+  display: grid;
+  gap: 10px;
+}
+.punctuation-dashboard-cta-row {
+  margin-top: 8px;
+}
+@media (max-width: 760px) {
+  .punctuation-dashboard-hero {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Progress row — compact stats strip */
+.punctuation-progress-row {
+  padding: 0;
+}
+.punctuation-progress-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 20px;
+  margin: 0;
+  padding: 14px 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--panel-soft);
+}
+.punctuation-progress-item {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+.punctuation-progress-item dt {
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: var(--muted);
+}
+.punctuation-progress-item dd {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+/* Monster row — 4 monsters with star-meter progress bars */
+.punctuation-monster-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+.punctuation-monster-meter {
+  display: grid;
+  gap: 6px;
+  padding: 14px 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--panel-soft);
+}
+.punctuation-monster-meter-name {
+  font-weight: 800;
+  font-size: 1rem;
+}
+.punctuation-monster-meter-stage {
+  font-size: 0.82rem;
+  color: var(--muted);
+  font-weight: 600;
+}
+.punctuation-monster-meter-bar {
+  height: 8px;
+  border-radius: 4px;
+  background: var(--line);
+  overflow: hidden;
+}
+.punctuation-monster-meter-fill {
+  height: 100%;
+  border-radius: 4px;
+  background: #B8873F;
+  transition: width var(--dur-slow) var(--ease-out);
+}
+.punctuation-monster-meter-count {
+  font-size: 0.82rem;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+/* Map link */
+.punctuation-map-link {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--panel-soft);
+  color: var(--ink);
+  font-weight: 800;
+  cursor: pointer;
+  font-size: 0.95rem;
+}
+.punctuation-map-link:hover:not(:disabled),
+.punctuation-map-link:focus-visible {
+  border-color: #B8873F;
+  box-shadow: 0 0 0 3px color-mix(in oklab, #B8873F 18%, transparent);
+}
+.punctuation-map-link:disabled {
+  cursor: not-allowed;
+  opacity: 0.64;
+}
+
+/* Secondary practice drawer */
+.punctuation-secondary-drawer {
+  display: grid;
+  gap: 14px;
+  padding: 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--panel-soft);
+}
+.punctuation-secondary-modes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+.punctuation-secondary-action {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 18px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--panel);
+  color: var(--ink);
+  font-weight: 700;
+  cursor: pointer;
+  font-size: 0.95rem;
+}
+.punctuation-secondary-action:hover:not(:disabled),
+.punctuation-secondary-action:focus-visible {
+  border-color: #B8873F;
+  box-shadow: 0 0 0 3px color-mix(in oklab, #B8873F 18%, transparent);
+}
+.punctuation-secondary-action.is-disabled,
+.punctuation-secondary-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.64;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .punctuation-monster-meter-fill {
+    transition: none;
+  }
+}
+
 /* --- Session — teach box, source block, feedback reveals --------------- */
 .punctuation-session-scene {
   display: grid;

--- a/tests/browser-react-migration-smoke.test.js
+++ b/tests/browser-react-migration-smoke.test.js
@@ -158,7 +158,7 @@ test('browser migration smoke covers the React app root, Grammar completeness co
 
     assert.match(output, /Your subjects/);
     assert.doesNotMatch(output, /data-home-mount/);
-    assert.match(output, /Punctuation practice/);
+    assert.match(output, /punctuation mission/);
     // U4 follower: summary headline is now the accuracy-bucketed celebration
     // copy from `punctuationSummaryHeadline`, replacing the adult
     // "Punctuation session summary" default. Match any of the 3 buckets so

--- a/tests/punctuation-view-model.test.js
+++ b/tests/punctuation-view-model.test.js
@@ -252,7 +252,7 @@ test('U1 view-model: punctuationMonsterDisplayName falls back to titlecase for u
 
 test('U1 view-model: PUNCTUATION_DASHBOARD_HERO has child-friendly copy', () => {
   assert.equal(PUNCTUATION_DASHBOARD_HERO.eyebrow, 'Bellstorm Coast');
-  assert.equal(PUNCTUATION_DASHBOARD_HERO.headline, 'Punctuation practice');
+  assert.equal(PUNCTUATION_DASHBOARD_HERO.headline, "Today's punctuation mission");
   assert.equal(typeof PUNCTUATION_DASHBOARD_HERO.subtitle, 'string');
   assert.ok(PUNCTUATION_DASHBOARD_HERO.subtitle.length > 0);
   assert.equal(isPunctuationChildCopy(PUNCTUATION_DASHBOARD_HERO.eyebrow), true);

--- a/tests/punctuation-view-model.test.js
+++ b/tests/punctuation-view-model.test.js
@@ -43,6 +43,7 @@ import {
   punctuationSkillHasMultiSkillItems,
   punctuationSkillModalContent,
   punctuationSkillModalPreferredExample,
+  punctuationStageLabel,
   punctuationSummaryHeadline,
 } from '../src/subjects/punctuation/components/punctuation-view-model.js';
 import { MONSTERS_BY_SUBJECT } from '../src/platform/game/monsters.js';
@@ -1114,4 +1115,50 @@ test('U7 Summary copy: punctuationChildSkillBadgeLabel falls back safely on unkn
   assert.equal(punctuationChildSkillBadgeLabel(undefined), '');
   assert.equal(punctuationChildSkillBadgeLabel(''), '');
   assert.equal(punctuationChildSkillBadgeLabel('bogus-status'), '');
+});
+
+// ---------------------------------------------------------------------------
+// U7 review: punctuationStageLabel — child-facing label for the monster's
+// current `starDerivedStage` (0-5). Stage 0 splits on `totalStars` to
+// distinguish "Not caught" (zero stars) from "Egg Found" (any stars).
+// ---------------------------------------------------------------------------
+
+test('U7 view-model: punctuationStageLabel(0, 0) → Not caught', () => {
+  assert.equal(punctuationStageLabel(0, 0), 'Not caught');
+});
+
+test('U7 view-model: punctuationStageLabel(0, 5) → Egg Found', () => {
+  assert.equal(punctuationStageLabel(0, 5), 'Egg Found');
+});
+
+test('U7 view-model: punctuationStageLabel(1) → Egg Found', () => {
+  assert.equal(punctuationStageLabel(1), 'Egg Found');
+});
+
+test('U7 view-model: punctuationStageLabel(2) → Hatch', () => {
+  assert.equal(punctuationStageLabel(2), 'Hatch');
+});
+
+test('U7 view-model: punctuationStageLabel(3) → Evolve', () => {
+  assert.equal(punctuationStageLabel(3), 'Evolve');
+});
+
+test('U7 view-model: punctuationStageLabel(4) → Strong', () => {
+  assert.equal(punctuationStageLabel(4), 'Strong');
+});
+
+test('U7 view-model: punctuationStageLabel(4, 65) → Strong (totalStars ignored for non-zero stages)', () => {
+  assert.equal(punctuationStageLabel(4, 65), 'Strong');
+});
+
+test('U7 view-model: punctuationStageLabel(5) → Mega', () => {
+  assert.equal(punctuationStageLabel(5), 'Mega');
+});
+
+test('U7 view-model: punctuationStageLabel(-1) → Not caught (negative out-of-range)', () => {
+  assert.equal(punctuationStageLabel(-1), 'Not caught');
+});
+
+test('U7 view-model: punctuationStageLabel(NaN) → Not caught (non-finite fallback)', () => {
+  assert.equal(punctuationStageLabel(NaN), 'Not caught');
 });

--- a/tests/react-punctuation-scene.test.js
+++ b/tests/react-punctuation-scene.test.js
@@ -51,26 +51,21 @@ function answerCurrentItemCorrectly(harness) {
 }
 
 test('punctuation React surface renders setup, active item, feedback and summary states', () => {
-  // Phase 3 U2 replaces the Phase 2 ten-button mode grid with a
-  // dashboard hero + three primary mode cards (Smart Review / Wobbly
-  // Spots / GPS Check) + one Open Map secondary card + round-length
-  // toggle. The old `data-punctuation-*-start` data attributes and
-  // `Endmarks focus` / `Apostrophe focus` / etc. labels are gone —
-  // the U2 describe block below tests the new dashboard shape
-  // explicitly, so this smoke test only asserts the hero + the
-  // three primary card labels land on Setup.
+  // Phase 5 U7 replaces the three-card button wall with a mission
+  // dashboard: hero + primary CTA + progress row + monster star meters
+  // + map link + secondary drawer with Wobbly / GPS / round length.
   const harness = createPunctuationHarness();
   harness.dispatch('open-subject', { subjectId: 'punctuation' });
 
   const setupHtml = harness.render();
   assert.match(setupHtml, /Bellstorm Coast/);
-  assert.match(setupHtml, /Punctuation practice/);
-  assert.match(setupHtml, />Smart Review</);
+  assert.match(setupHtml, /punctuation mission/);
+  // Primary CTA
+  assert.match(setupHtml, /data-punctuation-cta/);
+  // Secondary drawer still carries Wobbly Spots and GPS Check
   assert.match(setupHtml, />Wobbly Spots</);
   assert.match(setupHtml, />GPS Check</);
-  // U1 (Phase 4, R1): primary cards dispatch `punctuation-start` on click,
-  // not `punctuation-set-mode`. The old assertion was the SSR blind spot
-  // the Phase 3 regression slipped through.
+  // Secondary buttons dispatch punctuation-start
   assert.match(setupHtml, /data-action="punctuation-start"/);
 
   startOneItemPunctuationSession(harness);
@@ -441,12 +436,9 @@ test('punctuation text-item controls disable when runtime is degraded', () => {
   assert.match(html, /<button[^>]*disabled[^>]*data-punctuation-submit/);
 });
 
-test('punctuation setup view disables primary mode cards when availability is degraded', () => {
-  // Phase 3 U2: the old `data-punctuation-start` Start practice button
-  // is replaced with three primary mode cards + an Open Map secondary
-  // card. Every mutation control threads `composeIsDisabled(ui)`, so
-  // degraded availability disables the Smart Review card (and every
-  // other card beside it).
+test('punctuation setup view disables primary CTA when availability is degraded', () => {
+  // Phase 5 U7: the mission dashboard's primary CTA threads
+  // `composeIsDisabled(ui)`, so degraded availability disables it.
   const harness = createPunctuationHarness();
   harness.dispatch('open-subject', { subjectId: 'punctuation' });
   harness.store.updateSubjectUi('punctuation', {
@@ -454,12 +446,10 @@ test('punctuation setup view disables primary mode cards when availability is de
     availability: { status: 'degraded', code: 'runtime_degraded', message: 'paused' },
   });
   const html = harness.render();
-  // U1 (Phase 4): `data-action` is now `punctuation-start`. The disabled
-  // guard itself is unchanged.
   assert.match(
     html,
-    /<button[^>]*disabled[^>]*data-action="punctuation-start"[^>]*data-value="smart"|<button[^>]*data-action="punctuation-start"[^>]*data-value="smart"[^>]*disabled/,
-    'Smart Review card must be disabled under degraded availability',
+    /<button[^>]*disabled[^>]*data-punctuation-cta|<button[^>]*data-punctuation-cta[^>]*disabled/,
+    'Primary CTA must be disabled under degraded availability',
   );
 });
 
@@ -2790,28 +2780,33 @@ function forbiddenTermsInSetupHtml(html) {
   return leaks;
 }
 
-test('punctuation Setup scene renders 3 primary mode cards + Open Map secondary card', () => {
+test('punctuation Setup scene renders mission dashboard with primary CTA + secondary drawer + map link', () => {
   const harness = createPunctuationHarness();
   harness.dispatch('open-subject', { subjectId: 'punctuation' });
   const html = harness.render();
 
-  // Three primary journey cards, each tagged by mode id. U1 (Phase 4):
-  // tapping a card starts a session — `data-action` is `punctuation-start`.
-  for (const modeId of ['smart', 'weak', 'gps']) {
+  // R7: Single primary CTA above the fold.
+  assert.match(html, /data-punctuation-cta/, 'missing primary CTA');
+  // Secondary drawer carries Wobbly Spots and GPS Check.
+  for (const modeId of ['weak', 'gps']) {
     assert.match(
       html,
       new RegExp(`data-action="punctuation-start"[^>]*data-value="${modeId}"`),
-      `missing primary mode card for ${modeId}`,
+      `missing secondary mode button for ${modeId}`,
     );
   }
-  // Child-facing labels land too.
-  assert.match(html, />Smart Review</);
   assert.match(html, />Wobbly Spots</);
   assert.match(html, />GPS Check</);
-  // Exactly one Open Map secondary card.
+  // Exactly one Open Punctuation Map affordance.
   const openMapMatches = html.match(/data-action="punctuation-open-map"/g) || [];
   assert.equal(openMapMatches.length, 1, 'expected exactly one Open Map affordance');
   assert.match(html, />Open Punctuation Map</);
+  // R8: data-section landmarks for journey spec testing.
+  assert.match(html, /data-section="hero"/, 'missing hero landmark');
+  assert.match(html, /data-section="progress-row"/, 'missing progress-row landmark');
+  assert.match(html, /data-section="monster-row"/, 'missing monster-row landmark');
+  assert.match(html, /data-section="map-link"/, 'missing map-link landmark');
+  assert.match(html, /data-section="secondary"/, 'missing secondary landmark');
 });
 
 test('punctuation Setup scene does not render the 6 cluster focus buttons (plan R1)', () => {
@@ -2834,53 +2829,85 @@ test('punctuation Setup scene does not render the 6 cluster focus buttons (plan 
   assert.doesNotMatch(html, /data-punctuation-gps-start/);
 });
 
-// U1 (Phase 4, R1): primary cards are action buttons, not radio buttons,
-// so `aria-pressed` is removed from the primary-card element. The
-// display-collapse signal (Smart Review "feels selected" when prefs
-// collapse to smart) is now the `selected` CSS class — the tests below
-// assert on that class instead. The legacy cluster-mode → `'smart'`
-// migration still runs through `punctuation-set-mode` (unchanged).
-test('punctuation Setup scene Smart Review card carries `selected` class when prefs.mode is smart', () => {
-  const harness = createPunctuationHarness();
-  const learnerId = harness.store.getState().learners.selectedId;
-  harness.services.punctuation.savePrefs(learnerId, { mode: 'smart', roundLength: '4' });
-  harness.dispatch('open-subject', { subjectId: 'punctuation' });
-  // Force a fresh dispatch so ui.prefs mirrors the stored mode.
-  harness.dispatch('punctuation-set-mode', { value: 'smart' });
-  const html = harness.render();
+// Phase 5 U7: mission dashboard — the three primary mode cards are replaced
+// by a single primary CTA + secondary drawer. The CTA label adapts to the
+// learner's state (fresh / returning with wobbly / post-session continue).
+// Mode-dispatch tests below verify that `punctuation-set-mode` still updates
+// stored prefs, which feeds the CTA resolution logic.
 
-  assert.match(
-    html,
-    /class="punctuation-primary-mode selected[^"]*"[^>]*data-mode-id="smart"/,
-    'Smart Review card should carry the `selected` class when prefs.mode === "smart"',
-  );
-});
-
-test('punctuation Setup scene Wobbly card carries `selected` class when prefs.mode is weak', () => {
+test('punctuation Setup scene: fresh learner single CTA reads "Find your first punctuation egg" with all monsters at 0/100 Stars', () => {
   const harness = createPunctuationHarness();
   harness.dispatch('open-subject', { subjectId: 'punctuation' });
-  harness.dispatch('punctuation-set-mode', { value: 'weak' });
   const html = harness.render();
-  assert.match(
-    html,
-    /class="punctuation-primary-mode selected[^"]*"[^>]*data-mode-id="weak"/,
-    'Wobbly Spots card should carry the `selected` class when prefs.mode === "weak"',
-  );
+
+  assert.match(html, /Find your first punctuation egg/, 'fresh learner CTA label');
+  // All four active monsters at 0 / 100 Stars
+  for (const name of ['Pealark', 'Claspin', 'Curlune', 'Quoral']) {
+    assert.match(html, new RegExp(name), `monster ${name} must render`);
+  }
+  assert.match(html, /0 \/ 100 Stars/, 'fresh learner monsters show 0/100');
+  // No "Stage X of 4" anywhere
+  assert.doesNotMatch(html, /Stage \d+ of \d+/, 'no "Stage X of Y" in rendered output');
 });
 
-test('punctuation Setup scene GPS card carries `selected` class when prefs.mode is gps', () => {
+test('punctuation Setup scene: post-session render — same layout with updated stars and mission text', async () => {
+  // Use the standalone renderer so we can control stats + starView directly
+  // without going through the service layer (which doesn't populate weak from
+  // updateSubjectUi alone).
+  const { renderPunctuationSetupSceneStandalone } = await import(
+    './helpers/punctuation-scene-render.js'
+  );
+  const html = renderPunctuationSetupSceneStandalone({
+    ui: {
+      availability: { status: 'ready' },
+      starView: {
+        perMonster: {
+          pealark: { total: 22, starDerivedStage: 1 },
+          claspin: { total: 0, starDerivedStage: 0 },
+          curlune: { total: 12, starDerivedStage: 1 },
+        },
+        grand: { grandStars: 3, starDerivedStage: 0, total: 100 },
+      },
+    },
+    actions: { dispatch: () => {}, updateSubjectUi: () => {} },
+    prefs: { mode: 'smart', roundLength: '4' },
+    stats: { total: 14, secure: 3, due: 2, weak: 1, fresh: 8, attempts: 20, correct: 15, accuracy: 75 },
+    learner: { id: 'test', name: 'Tester' },
+    rewardState: {},
+  });
+
+  // R8: same data-section landmarks as fresh learner
+  assert.match(html, /data-section="hero"/, 'hero landmark present post-session');
+  assert.match(html, /data-section="progress-row"/, 'progress-row present post-session');
+  assert.match(html, /data-section="monster-row"/, 'monster-row present post-session');
+  assert.match(html, /data-section="map-link"/, 'map-link present post-session');
+  assert.match(html, /data-section="secondary"/, 'secondary present post-session');
+  // R7: CTA adapts — weak > 0, so CTA reads "Tackle wobbly spots"
+  assert.match(html, /Tackle wobbly spots/, 'post-session CTA with wobbly spots');
+  // Star meters update
+  assert.match(html, /22 \/ 100 Stars/, 'pealark stars updated');
+  // No "Stage X of 4" anywhere
+  assert.doesNotMatch(html, /Stage \d+ of \d+/, 'no "Stage X of Y" in rendered output');
+});
+
+test('punctuation Setup scene: round-length preference accessible via secondary drawer', () => {
   const harness = createPunctuationHarness();
   harness.dispatch('open-subject', { subjectId: 'punctuation' });
-  harness.dispatch('punctuation-set-mode', { value: 'gps' });
   const html = harness.render();
-  assert.match(
-    html,
-    /class="punctuation-primary-mode selected[^"]*"[^>]*data-mode-id="gps"/,
-    'GPS Check card should carry the `selected` class when prefs.mode === "gps"',
-  );
+  // Round length toggle lives inside the secondary drawer
+  assert.match(html, /data-section="secondary"[^]*role="radiogroup"/, 'round length radiogroup inside secondary');
+  assert.match(html, /Round length/, 'round length label present');
 });
 
-test('punctuation Setup scene: clicking Smart Review sets state.subjectUi.punctuation.prefs.mode to smart', () => {
+test('punctuation Setup scene: Punctuation Map link present', () => {
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  const html = harness.render();
+  assert.match(html, /data-section="map-link"/, 'map-link landmark');
+  assert.match(html, />Open Punctuation Map</, 'map link text');
+});
+
+test('punctuation Setup scene: mode dispatch still updates stored prefs', () => {
   const harness = createPunctuationHarness();
   harness.dispatch('open-subject', { subjectId: 'punctuation' });
   harness.dispatch('punctuation-set-mode', { value: 'smart' });
@@ -2888,7 +2915,7 @@ test('punctuation Setup scene: clicking Smart Review sets state.subjectUi.punctu
   assert.equal(state.prefs.mode, 'smart');
 });
 
-test('punctuation Setup scene: clicking Wobbly sets state.subjectUi.punctuation.prefs.mode to weak', () => {
+test('punctuation Setup scene: weak mode dispatch updates stored prefs', () => {
   const harness = createPunctuationHarness();
   harness.dispatch('open-subject', { subjectId: 'punctuation' });
   harness.dispatch('punctuation-set-mode', { value: 'weak' });
@@ -2896,7 +2923,7 @@ test('punctuation Setup scene: clicking Wobbly sets state.subjectUi.punctuation.
   assert.equal(state.prefs.mode, 'weak');
 });
 
-test('punctuation Setup scene: clicking GPS sets state.subjectUi.punctuation.prefs.mode to gps', () => {
+test('punctuation Setup scene: gps mode dispatch updates stored prefs', () => {
   const harness = createPunctuationHarness();
   harness.dispatch('open-subject', { subjectId: 'punctuation' });
   harness.dispatch('punctuation-set-mode', { value: 'gps' });
@@ -2915,7 +2942,7 @@ test('punctuation Setup scene: Open Map dispatch transitions phase setup → map
   assert.equal(harness.store.getState().subjectUi.punctuation.phase, 'map');
 });
 
-test('punctuation Setup scene: degraded availability disables every primary and secondary card', () => {
+test('punctuation Setup scene: degraded availability disables primary CTA + secondary buttons + map link', () => {
   const harness = createPunctuationHarness();
   harness.dispatch('open-subject', { subjectId: 'punctuation' });
   harness.store.updateSubjectUi('punctuation', {
@@ -2923,24 +2950,29 @@ test('punctuation Setup scene: degraded availability disables every primary and 
   });
   const html = harness.render();
 
-  // Each primary mode card is disabled. U1 (Phase 4): `data-action` is
-  // now `punctuation-start`.
-  for (const modeId of ['smart', 'weak', 'gps']) {
+  // Primary CTA disabled.
+  assert.match(
+    html,
+    /<button[^>]*disabled[^>]*data-punctuation-cta|<button[^>]*data-punctuation-cta[^>]*disabled/,
+    'primary CTA should be disabled under degraded availability',
+  );
+  // Secondary drawer mode buttons disabled.
+  for (const modeId of ['weak', 'gps']) {
     assert.match(
       html,
       new RegExp(`<button[^>]*disabled[^>]*data-action="punctuation-start"[^>]*data-value="${modeId}"|<button[^>]*data-action="punctuation-start"[^>]*data-value="${modeId}"[^>]*disabled`),
-      `primary mode card ${modeId} should be disabled under degraded availability`,
+      `secondary button ${modeId} should be disabled under degraded availability`,
     );
   }
-  // Open Map secondary card is disabled.
+  // Map link disabled.
   assert.match(
     html,
     /<button[^>]*disabled[^>]*data-action="punctuation-open-map"|<button[^>]*data-action="punctuation-open-map"[^>]*disabled/,
-    'Open Map card should be disabled under degraded availability',
+    'Map link should be disabled under degraded availability',
   );
 });
 
-test('punctuation Setup scene: pendingCommand disables every primary and secondary card', () => {
+test('punctuation Setup scene: pendingCommand disables primary CTA + secondary buttons + map link', () => {
   const harness = createPunctuationHarness();
   harness.dispatch('open-subject', { subjectId: 'punctuation' });
   harness.store.updateSubjectUi('punctuation', {
@@ -2948,14 +2980,18 @@ test('punctuation Setup scene: pendingCommand disables every primary and seconda
   });
   const html = harness.render();
 
-  // U1 (Phase 4): `data-action` is now `punctuation-start`, not
-  // `punctuation-set-mode`. The pending-command guard is unchanged —
-  // still renders each card with `disabled`.
-  for (const modeId of ['smart', 'weak', 'gps']) {
+  // Primary CTA disabled.
+  assert.match(
+    html,
+    /<button[^>]*disabled[^>]*data-punctuation-cta|<button[^>]*data-punctuation-cta[^>]*disabled/,
+    'primary CTA should be disabled while pendingCommand is set',
+  );
+  // Secondary drawer mode buttons disabled.
+  for (const modeId of ['weak', 'gps']) {
     assert.match(
       html,
       new RegExp(`<button[^>]*disabled[^>]*data-action="punctuation-start"[^>]*data-value="${modeId}"|<button[^>]*data-action="punctuation-start"[^>]*data-value="${modeId}"[^>]*disabled`),
-      `primary mode card ${modeId} should be disabled while pendingCommand is set`,
+      `secondary button ${modeId} should be disabled while pendingCommand is set`,
     );
   }
   assert.match(
@@ -2965,17 +3001,18 @@ test('punctuation Setup scene: pendingCommand disables every primary and seconda
   );
 });
 
-test('punctuation Setup scene: fresh learner renders zero-state copy (guards Phase 2 hasEvidence fix)', () => {
-  // A fresh learner with no stats should NOT see "1 skill due" or any
-  // inflated Today counter. The empty-state copy lives in a dedicated
-  // data-testid hook so this test stays resilient to copy tweaks.
+test('punctuation Setup scene: fresh learner renders zero-state progress row (guards Phase 2 hasEvidence fix)', () => {
+  // A fresh learner with no stats should see zeroes in the progress row,
+  // not inflated counters. The mission dashboard always renders the
+  // progress row (R8 invariant skeleton).
   const harness = createPunctuationHarness();
   harness.dispatch('open-subject', { subjectId: 'punctuation' });
   const html = harness.render();
 
-  // Zero-state copy lands — every count is zero, so the dashboard
-  // shows the empty-state prompt instead of the grid.
-  assert.match(html, /data-testid="punctuation-today-empty"/);
+  // Progress row renders with all zeroes.
+  assert.match(html, /data-section="progress-row"/, 'progress row renders for fresh learner');
+  // The CTA reads the fresh-learner label.
+  assert.match(html, /Find your first punctuation egg/, 'fresh learner CTA');
 });
 
 test('punctuation Setup scene: reserved monster ids NEVER appear in the active monster strip', () => {
@@ -3020,32 +3057,16 @@ test('punctuation Setup scene SSR HTML contains no forbidden child terms', () =>
 });
 
 test('punctuation Setup scene stale-prefs migration: endmarks prefs collapse to smart on first render', () => {
-  // Pre-Phase-3 stored `prefs.mode === 'endmarks'` → the display
-  // normaliser collapses legacy cluster values to `'smart'` so the
-  // Smart Review card visually reads as the active selection, AND
-  // first render dispatches `punctuation-set-mode` with
-  // `{ value: 'smart' }` to migrate stored state once.
-  //
-  // U1 (Phase 4): primary cards are action buttons (no `aria-pressed`
-  // — R1), so the visual-selection signal is the `selected` CSS class
-  // on the Smart Review button rather than an ARIA attribute. The
-  // migration behaviour itself (stored prefs collapse to `'smart'`)
-  // is unchanged.
+  // Pre-Phase-3 stored `prefs.mode === 'endmarks'` → first render
+  // dispatches `punctuation-set-mode` with `{ value: 'smart' }` to
+  // migrate stored state once.
   const harness = createPunctuationHarness();
   const learnerId = harness.store.getState().learners.selectedId;
   harness.services.punctuation.savePrefs(learnerId, { mode: 'endmarks', roundLength: '4' });
   harness.dispatch('open-subject', { subjectId: 'punctuation' });
 
-  // First render — the effect dispatches the migration.
-  const html = harness.render();
-  // Display collapse: Smart Review receives the `selected` CSS class
-  // (U1 replaces the removed `aria-pressed` attribute as the visual-
-  // selection signal).
-  assert.match(
-    html,
-    /class="punctuation-primary-mode selected[^"]*"[^>]*data-mode-id="smart"|class="punctuation-primary-mode[^"]* selected"[^>]*data-mode-id="smart"/,
-    'Smart Review must render with the `selected` class when prefs.mode is a legacy cluster value',
-  );
+  // First render — the migration dispatches.
+  harness.render();
   // Migration persisted — stored prefs.mode is now 'smart'.
   assert.equal(harness.store.getState().subjectUi.punctuation.prefs.mode, 'smart');
 });
@@ -3758,7 +3779,11 @@ test('U1 primary card data-action is "punctuation-start" and does NOT carry aria
 //     selectedRoundLength().
 // ---------------------------------------------------------------------------
 
-function extractPrimaryCardRoundLengths(html) {
+// Phase 5 U7: the mission dashboard moves Wobbly Spots and GPS Check into
+// the secondary drawer. The `extractSecondaryButtonRoundLengths` helper
+// extracts the `data-round-length` attribute from each secondary button so
+// prop-threading tests still verify the parent → button contract.
+function extractSecondaryButtonRoundLengths(html) {
   const regex = /<button\b[^>]*\bdata-action="punctuation-start"[^>]*?>/g;
   const cards = [];
   let match;
@@ -3774,26 +3799,7 @@ function extractPrimaryCardRoundLengths(html) {
   return cards;
 }
 
-test('U1 follow-on: parent threads prefs.roundLength="4" to every primary card (default)', () => {
-  const harness = createPunctuationHarness();
-  const learnerId = harness.store.getState().learners.selectedId;
-  harness.services.punctuation.savePrefs(learnerId, { mode: 'smart', roundLength: '4' });
-  harness.dispatch('open-subject', { subjectId: 'punctuation' });
-  harness.dispatch('punctuation-set-round-length', { value: '4' });
-  const html = harness.render();
-
-  const cards = extractPrimaryCardRoundLengths(html);
-  assert.equal(cards.length, 3, 'expected exactly three primary-mode cards to render');
-  for (const card of cards) {
-    assert.equal(
-      card.roundLength,
-      '4',
-      `primary card ${card.mode} must carry data-round-length="4" (parent prop-threading regression if missing)`,
-    );
-  }
-});
-
-test('U1 follow-on: parent threads prefs.roundLength="8" to every primary card', () => {
+test('U7 follow-on: round-length toggle threads value to secondary drawer buttons', () => {
   const harness = createPunctuationHarness();
   const learnerId = harness.store.getState().learners.selectedId;
   harness.services.punctuation.savePrefs(learnerId, { mode: 'smart', roundLength: '8' });
@@ -3801,45 +3807,11 @@ test('U1 follow-on: parent threads prefs.roundLength="8" to every primary card',
   harness.dispatch('punctuation-set-round-length', { value: '8' });
   const html = harness.render();
 
-  const cards = extractPrimaryCardRoundLengths(html);
-  assert.equal(cards.length, 3, 'expected exactly three primary-mode cards to render');
-  for (const card of cards) {
-    assert.equal(
-      card.roundLength,
-      '8',
-      `primary card ${card.mode} must carry data-round-length="8" (parent prop-threading regression if missing)`,
-    );
-  }
-});
-
-test('U1 follow-on: parent falls back to "4" when prefs.roundLength is absent', async () => {
-  // Bypass `createPunctuationHarness` so we control `prefs` exactly and
-  // exercise `selectedRoundLength()`'s default branch (no roundLength key
-  // at all). Uses the standalone SSR helper so the full parent tree runs.
-  const { renderPunctuationSetupSceneStandalone } = await import(
-    './helpers/punctuation-scene-render.js'
-  );
-  const html = renderPunctuationSetupSceneStandalone({
-    ui: { availability: { status: 'ready' } },
-    actions: {
-      dispatch: () => {},
-      updateSubjectUi: () => {},
-    },
-    prefs: { mode: 'smart' }, // deliberately omit roundLength
-    stats: {},
-    learner: null,
-    rewardState: {},
-  });
-
-  const cards = extractPrimaryCardRoundLengths(html);
-  assert.equal(cards.length, 3, 'expected exactly three primary-mode cards to render');
-  for (const card of cards) {
-    assert.equal(
-      card.roundLength,
-      '4',
-      `primary card ${card.mode} must fall back to data-round-length="4" when prefs.roundLength is absent`,
-    );
-  }
+  // The secondary drawer carries 2 buttons: weak and gps.
+  const buttons = extractSecondaryButtonRoundLengths(html);
+  assert.ok(buttons.length >= 2, 'expected at least two secondary buttons');
+  // Round length radiogroup present inside the secondary drawer.
+  assert.match(html, /role="radiogroup"/, 'round length toggle present');
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/react-punctuation-scene.test.js
+++ b/tests/react-punctuation-scene.test.js
@@ -2890,6 +2890,36 @@ test('punctuation Setup scene: post-session render — same layout with updated 
   assert.doesNotMatch(html, /Stage \d+ of \d+/, 'no "Stage X of Y" in rendered output');
 });
 
+test('punctuation Setup scene: active session triggers "Continue your round" CTA with punctuation-continue action', async () => {
+  // Use the standalone renderer so we can inject ui.session.id directly
+  // — the harness render pipeline strips session on phase=setup.
+  const { renderPunctuationSetupSceneStandalone } = await import(
+    './helpers/punctuation-scene-render.js'
+  );
+  const html = renderPunctuationSetupSceneStandalone({
+    ui: {
+      availability: { status: 'ready' },
+      session: { id: 'test-session' },
+    },
+    actions: { dispatch: () => {}, updateSubjectUi: () => {} },
+    prefs: { mode: 'smart', roundLength: '4' },
+    // Non-zero stats so the dashboard isEmpty is false — a fresh learner
+    // would override the CTA label with "Find your first punctuation egg".
+    stats: { total: 10, secure: 2, due: 3, weak: 0, attempts: 5, correct: 4, accuracy: 80 },
+    learner: { id: 'test', name: 'Tester' },
+    rewardState: {},
+  });
+
+  // CTA label must read "Continue your round".
+  assert.match(html, /Continue your round/, 'continue CTA label when active session exists');
+  // CTA button must dispatch punctuation-continue (not punctuation-start).
+  assert.match(
+    html,
+    /data-action="punctuation-continue"/,
+    'CTA carries data-action="punctuation-continue" for the continue branch',
+  );
+});
+
 test('punctuation Setup scene: round-length preference accessible via secondary drawer', () => {
   const harness = createPunctuationHarness();
   harness.dispatch('open-subject', { subjectId: 'punctuation' });
@@ -3808,8 +3838,15 @@ test('U7 follow-on: round-length toggle threads value to secondary drawer button
   const html = harness.render();
 
   // The secondary drawer carries 2 buttons: weak and gps.
-  const buttons = extractSecondaryButtonRoundLengths(html);
+  // Filter to buttons with a data-value (excludes the primary CTA which
+  // also renders data-action="punctuation-start" but without data-value).
+  const allButtons = extractSecondaryButtonRoundLengths(html);
+  const buttons = allButtons.filter((b) => b.mode !== null);
   assert.ok(buttons.length >= 2, 'expected at least two secondary buttons');
+  // Every secondary button must carry the threaded round-length value.
+  for (const btn of buttons) {
+    assert.equal(btn.roundLength, '8', `secondary button ${btn.mode} must carry data-round-length="8"`);
+  }
   // Round length radiogroup present inside the secondary drawer.
   assert.match(html, /role="radiogroup"/, 'round length toggle present');
 });

--- a/tests/react-punctuation-summary-ux.test.js
+++ b/tests/react-punctuation-summary-ux.test.js
@@ -281,7 +281,11 @@ test('U5 Reward parity: one secured speech-core unit surfaces coherent progress 
     rewardState: monsterCodexState,
   });
   assert.match(setupHtml, /data-monster-id="pealark"/);
-  assert.match(setupHtml, /1\/5 secure/);
+  // Phase 5 U7: the Setup scene no longer shows "X/Y secure" per monster.
+  // Instead it renders star meters (X / 100 Stars) via starView. With no
+  // starView seeded, the meter reads "0 / 100 Stars" — still proves the
+  // monster renders and the reserved-monster filter is intact.
+  assert.match(setupHtml, /Pealark/);
   assert.doesNotMatch(setupHtml, /data-monster-id="colisk"/);
 
   // Summary — same rewardState prop; the strip reads pealark's stage.

--- a/tests/subject-expansion.test.js
+++ b/tests/subject-expansion.test.js
@@ -238,7 +238,7 @@ const punctuationSpec = {
   createHarness: createPunctuationHarness,
   prepareHarness: preparePunctuationHarness,
   expectReactPractice: true,
-  practiceMatcher: /Punctuation practice/,
+  practiceMatcher: /punctuation mission/,
   sessionMatcher: /Choose the best punctuated sentence|Punctuate the sentence accurately|Correct the punctuation/,
   // U4 follower (design-lens HIGH 2): summary headline is now the
   // accuracy-bucketed celebration copy from `punctuationSummaryHeadline`.


### PR DESCRIPTION
## Summary

- **Rebuilt `PunctuationSetupScene.jsx`** from a three-card button wall into a mission dashboard modelled on the Spelling Setup's hero pattern, adapted for Bellstorm Coast
- **Hero area**: Bellstorm Coast backdrop + "Today's punctuation mission" headline + single primary CTA that adapts label (fresh learner: "Find your first punctuation egg" / wobbly: "Tackle wobbly spots" / default: "Start today's round")
- **Progress row**: compact stats strip — Due today | Wobbly | Stars earned
- **Monster row**: 4 active monsters with star-meter progress bars (X / 100 Stars) and child-facing stage labels (Not caught / Egg Found / Hatch / Evolve / Strong / Mega) powered by `starView` from U4
- **Map link**: "Open Punctuation Map" button
- **Secondary drawer**: Wobbly Spots + GPS Check buttons + round-length toggle (4/8/12)
- **View-model**: added `punctuationStageLabel(stage, totalStars)` helper; updated `PUNCTUATION_DASHBOARD_HERO` headline; `buildPunctuationDashboardModel` now threads `starView` from `ui.starView`
- **CSS**: full mission dashboard layout styles — hero, progress row, monster meters with animated fill bars, map link, secondary drawer
- **Landmark attributes**: `data-section="hero|progress-row|monster-row|map-link|secondary"` + `data-punctuation-cta` on primary CTA — ready for U9 journey specs
- **`PrimaryModeCard` export preserved** for backward-compatible U1 click-through tests

### Design invariants
- R7: one primary CTA above the fold
- R8: fresh learner and post-session render identical layout skeleton with different content
- R9: star meters per monster, stage labels from starView
- No "Stage X of 4", no Accuracy or Secure count as primary visual elements
- UK English throughout

## Test plan

- [x] Fresh learner: single CTA "Find your first punctuation egg", all monsters at 0/100 Stars
- [x] Post-session: same layout landmarks, updated stars, CTA adapts to "Tackle wobbly spots"
- [x] SSR landmark comparison: same `data-section` attributes between fresh and post-session
- [x] No `Stage X of 4` in rendered output
- [x] Round-length preference accessible in secondary drawer
- [x] Punctuation Map link present with `data-section="map-link"`
- [x] Degraded availability / pendingCommand disable primary CTA + secondary buttons + map link
- [x] Reserved monsters (colisk/hyphang/carillon) never leak into monster row
- [x] No forbidden child terms in Setup SSR HTML
- [x] Stale-prefs migration (legacy cluster modes → smart) still works
- [x] All 4296 tests pass (1 unrelated benchmark timing flake)