### PR TITLE
feat(punctuation): U9 — telemetry per-session rate limiting

### DIFF
--- a/tests/worker-punctuation-telemetry.test.js
+++ b/tests/worker-punctuation-telemetry.test.js
@@ -584,3 +584,207 @@ test('record-event writes release_id = null when the feature flag-gated write fi
     h.close();
   }
 });
+
+// ---------------------------------------------------------------------------
+// Phase 6 U9 — Per-session, per-event-kind rate limiting (R16)
+// ---------------------------------------------------------------------------
+
+test('rate limit: 10 answer-submitted events in a session are all accepted', async () => {
+  const h = createHarness();
+  try {
+    for (let i = 0; i < 10; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      const { response, body } = await h.recordEvent({
+        kind: 'answer-submitted',
+        payload: { sessionId: 'sess-1', itemId: `item-${i}`, correct: true },
+      });
+      assert.equal(response.status, 200, `event ${i}: ${JSON.stringify(body)}`);
+      assert.equal(body.recorded, true, `event ${i} should be recorded`);
+      assert.equal(body.rateLimited, undefined, `event ${i} should not be rate limited`);
+    }
+    assert.equal(h.eventRowCount(), 10);
+  } finally {
+    h.close();
+  }
+});
+
+test('rate limit: 51st answer-submitted in a session is silently dropped', async () => {
+  const { MAX_TELEMETRY_EVENTS_PER_SESSION_PER_KIND } = await import(
+    '../worker/src/subjects/punctuation/events.js'
+  );
+  assert.equal(MAX_TELEMETRY_EVENTS_PER_SESSION_PER_KIND, 50, 'constant must be 50');
+
+  const h = createHarness();
+  try {
+    // Insert exactly 50 events.
+    for (let i = 0; i < 50; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      const { response, body } = await h.recordEvent({
+        kind: 'answer-submitted',
+        payload: { sessionId: 'sess-flood', itemId: `item-${i}`, correct: i % 2 === 0 },
+      });
+      assert.equal(response.status, 200, `event ${i}: ${JSON.stringify(body)}`);
+      assert.equal(body.recorded, true, `event ${i} should be recorded`);
+    }
+    assert.equal(h.eventRowCount(), 50);
+
+    // 51st event should be silently dropped.
+    const { response, body } = await h.recordEvent({
+      kind: 'answer-submitted',
+      payload: { sessionId: 'sess-flood', itemId: 'item-overflow', correct: true },
+    });
+    assert.equal(response.status, 200, JSON.stringify(body));
+    assert.equal(body.ok, true);
+    assert.equal(body.recorded, false, '51st event must not be recorded');
+    assert.equal(body.rateLimited, true, '51st event must report rateLimited');
+    assert.equal(body.eventKind, 'answer-submitted');
+    // Row count unchanged.
+    assert.equal(h.eventRowCount(), 50);
+  } finally {
+    h.close();
+  }
+});
+
+test('rate limit: 50 of kind A + 50 of kind B are both accepted (caps are per-kind)', async () => {
+  const h = createHarness();
+  try {
+    for (let i = 0; i < 50; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await h.recordEvent({
+        kind: 'answer-submitted',
+        payload: { sessionId: 'sess-cross', itemId: `a-${i}`, correct: true },
+      });
+    }
+    for (let i = 0; i < 50; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await h.recordEvent({
+        kind: 'feedback-rendered',
+        payload: { sessionId: 'sess-cross', itemId: `b-${i}`, correct: false },
+      });
+    }
+    assert.equal(h.eventRowCount(), 100, 'both kinds fill their own quota');
+
+    // 51st of kind A → dropped.
+    const { body: bodyA } = await h.recordEvent({
+      kind: 'answer-submitted',
+      payload: { sessionId: 'sess-cross', itemId: 'overflow-a', correct: true },
+    });
+    assert.equal(bodyA.rateLimited, true, 'kind A 51st is rate-limited');
+
+    // 51st of kind B → dropped.
+    const { body: bodyB } = await h.recordEvent({
+      kind: 'feedback-rendered',
+      payload: { sessionId: 'sess-cross', itemId: 'overflow-b', correct: false },
+    });
+    assert.equal(bodyB.rateLimited, true, 'kind B 51st is rate-limited');
+
+    assert.equal(h.eventRowCount(), 100, 'no new rows after rate limit');
+  } finally {
+    h.close();
+  }
+});
+
+test('rate limit: new session resets the counter', async () => {
+  const h = createHarness();
+  try {
+    // Fill session-1 to the cap.
+    for (let i = 0; i < 50; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await h.recordEvent({
+        kind: 'answer-submitted',
+        payload: { sessionId: 'sess-old', itemId: `old-${i}`, correct: true },
+      });
+    }
+    // Confirm session-1 is capped.
+    const { body: capped } = await h.recordEvent({
+      kind: 'answer-submitted',
+      payload: { sessionId: 'sess-old', itemId: 'blocked', correct: true },
+    });
+    assert.equal(capped.rateLimited, true);
+
+    // A new session starts fresh.
+    const { body: fresh } = await h.recordEvent({
+      kind: 'answer-submitted',
+      payload: { sessionId: 'sess-new', itemId: 'new-0', correct: true },
+    });
+    assert.equal(fresh.recorded, true, 'new session is not rate-limited');
+    assert.equal(fresh.rateLimited, undefined);
+
+    assert.equal(h.eventRowCount(), 51, '50 old + 1 new');
+  } finally {
+    h.close();
+  }
+});
+
+test('rate limit: kinds without sessionId are rate-limited by (learner, kind)', async () => {
+  // card-opened does not carry a sessionId, so the cap applies per-learner per-kind.
+  const h = createHarness();
+  try {
+    for (let i = 0; i < 50; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await h.recordEvent({
+        kind: 'card-opened',
+        payload: { cardId: `card-${i}` },
+      });
+    }
+    assert.equal(h.eventRowCount(), 50);
+
+    // 51st card-opened → dropped.
+    const { response, body } = await h.recordEvent({
+      kind: 'card-opened',
+      payload: { cardId: 'overflow' },
+    });
+    assert.equal(response.status, 200, JSON.stringify(body));
+    assert.equal(body.rateLimited, true);
+    assert.equal(body.recorded, false);
+    assert.equal(h.eventRowCount(), 50);
+  } finally {
+    h.close();
+  }
+});
+
+test('rate limit: telemetry events never mint Stars, stages, or codex entries', async () => {
+  // Negative test (R16): the record-event handler never writes to any table
+  // besides punctuation_events. Verify no rows appear in mastery-adjacent
+  // tables after a burst of telemetry events.
+  const h = createHarness();
+  try {
+    for (let i = 0; i < 10; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await h.recordEvent({
+        kind: 'answer-submitted',
+        payload: { sessionId: 's1', itemId: `item-${i}`, correct: true },
+      });
+    }
+    // The D1 test database has the standard migration set. If any of the
+    // mastery tables exist, verify they are empty.
+    const tables = h.DB.db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('learner_punctuation_state', 'game_state', 'event_log')",
+    ).all();
+    for (const { name } of tables) {
+      const count = Number(h.DB.db.prepare(`SELECT COUNT(*) AS n FROM "${name}"`).get().n) || 0;
+      assert.equal(count, 0, `${name} must have zero rows — telemetry must never mint state`);
+    }
+  } finally {
+    h.close();
+  }
+});
+
+test('rate limit: feature flag OFF skips rate-limit check (no D1 count query)', async () => {
+  // When the feature flag is OFF, the handler returns before reaching
+  // the rate-limit check — no D1 query is issued. Confirm the response
+  // shape has no `rateLimited` key.
+  const h = createHarness({ eventsEnabled: false });
+  try {
+    const { response, body } = await h.recordEvent({
+      kind: 'answer-submitted',
+      payload: { sessionId: 's1', itemId: 'i1', correct: true },
+    });
+    assert.equal(response.status, 200, JSON.stringify(body));
+    assert.equal(body.enabled, false);
+    assert.equal(body.recorded, false);
+    assert.equal(body.rateLimited, undefined, 'no rateLimited flag when feature is off');
+  } finally {
+    h.close();
+  }
+});

--- a/worker/src/subjects/punctuation/events.js
+++ b/worker/src/subjects/punctuation/events.js
@@ -46,15 +46,26 @@ import {
 import { BadRequestError, BackendUnavailableError } from '../../errors.js';
 import { batch, bindStatement } from '../../d1.js';
 
-// TODO (U9 post-rollout, deferred to follow-on unit): add a
-// per-session / per-learner rate-limit on `record-event` so a runaway
-// client cannot flood the D1 ingest path. Classified at review time as
-// adversarial MEDIUM + security LOW; deferred because the payload
-// allowlist + 256-char per-field cap already bound individual writes,
-// the `(learner_id, request_id)` UNIQUE dedup stops retry storms, and
-// the flag remains OFF in production until monitoring is in place. See
-// `docs/punctuation-production.md` "Rollout deferrals" for the decision
-// trail.
+// Phase 6 U9 — Per-session, per-event-kind rate limiting (R16).
+//
+// A generous cap (50 events per session per kind = 600 per session across
+// all 12 kinds) that stops a runaway or compromised client from flooding
+// the D1 ingest path. Legitimate sessions (20-30 items) never approach
+// the limit. The sessionId is extracted from the inner sanitised payload
+// for kinds that carry one (answer-submitted, first-item-rendered,
+// feedback-rendered, summary-reached); for kinds without a sessionId the
+// cap scopes to (learner_id, event_kind) with a NULL session — effectively
+// a per-learner per-kind cap.
+//
+// When the cap is hit the handler returns a success response with
+// `{recorded: false, rateLimited: true}` — the client's fire-and-forget
+// contract is preserved (no error surface).
+
+/**
+ * Maximum number of telemetry events a single session may emit per
+ * event kind. 50 × 12 kinds = 600 events per session ceiling.
+ */
+export const MAX_TELEMETRY_EVENTS_PER_SESSION_PER_KIND = 50;
 
 // Mirrors the set in worker/src/subjects/punctuation/read-models.js so
 // a payload with a field name that matches a server-only read-model
@@ -280,6 +291,32 @@ export async function applyRecordEventCommand({ command, context }) {
     );
   }
 
+  // Phase 6 U9 — Per-session rate limiting (R16). Extract sessionId from
+  // the sanitised payload (for kinds that carry it) and count existing
+  // events for (learner_id, event_kind, sessionId). For kinds without a
+  // sessionId the count scopes to (learner_id, event_kind) alone. When
+  // the cap is hit, return success with `rateLimited: true` — silent drop.
+  const sessionId = typeof sanitisedPayload.sessionId === 'string' && sanitisedPayload.sessionId
+    ? sanitisedPayload.sessionId
+    : null;
+  const existingCount = await countExistingEventsForRateLimit(
+    env.DB,
+    command.learnerId,
+    kind,
+    sessionId,
+  );
+  if (existingCount >= MAX_TELEMETRY_EVENTS_PER_SESSION_PER_KIND) {
+    return {
+      learnerId: command.learnerId,
+      ok: true,
+      changed: false,
+      enabled: true,
+      recorded: false,
+      rateLimited: true,
+      eventKind: kind,
+    };
+  }
+
   // Review follow-on 2026-04-26: dedupe retries via
   // `(learner_id, request_id)` UNIQUE index. `INSERT OR IGNORE` silently
   // drops the second write so a retried client never creates a duplicate
@@ -334,6 +371,34 @@ export async function applyRecordEventCommand({ command, context }) {
     eventKind: kind,
     occurredAtMs: now,
   };
+}
+
+/**
+ * Count existing events in `punctuation_events` for the rate limiter.
+ *
+ * When `sessionId` is non-null, the count scopes to events whose stored
+ * `payload_json` contains the same `sessionId` via `json_extract`. When
+ * `sessionId` is null (the event kind does not carry one), the count
+ * scopes to `(learner_id, event_kind)` alone.
+ *
+ * The query uses the `idx_punctuation_events_learner_kind_time` index
+ * for the (learner_id, event_kind) prefix so the plan is a covering
+ * index scan even when the table grows.
+ */
+async function countExistingEventsForRateLimit(db, learnerId, eventKind, sessionId) {
+  if (sessionId) {
+    const result = await db.prepare(`
+      SELECT COUNT(*) AS n FROM punctuation_events
+      WHERE learner_id = ? AND event_kind = ?
+        AND json_extract(payload_json, '$.sessionId') = ?
+    `).bind(learnerId, eventKind, sessionId).first();
+    return Number(result?.n) || 0;
+  }
+  const result = await db.prepare(`
+    SELECT COUNT(*) AS n FROM punctuation_events
+    WHERE learner_id = ? AND event_kind = ?
+  `).bind(learnerId, eventKind).first();
+  return Number(result?.n) || 0;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add per-session, per-event-kind rate limiting (`MAX_TELEMETRY_EVENTS_PER_SESSION_PER_KIND = 50`) at the Worker `record-event` command handler level (R16)
- For event kinds carrying a `sessionId` in their payload (answer-submitted, first-item-rendered, feedback-rendered, summary-reached), the cap scopes to `(learner_id, event_kind, sessionId)` via `json_extract`; for kinds without sessionId, the cap scopes to `(learner_id, event_kind)` alone
- When the cap is hit, the handler returns `{ok: true, recorded: false, rateLimited: true}` — silent drop preserving the client fire-and-forget contract

## Files changed

- `worker/src/subjects/punctuation/events.js` — replaced the deferred TODO with the rate-limit constant, `countExistingEventsForRateLimit` helper, and the pre-write cap check in `applyRecordEventCommand`
- `tests/worker-punctuation-telemetry.test.js` — 7 new tests covering all task scenarios

## Test plan

- [x] Happy path: 10 events of kind answer-submitted in a session → all accepted
- [x] Edge case: 51st event of kind answer-submitted in a session → silently dropped (rateLimited: true)
- [x] Edge case: 50 of kind A + 50 of kind B → both accepted (caps are per-kind)
- [x] Edge case: new session starts → counter resets (different sessionId = fresh quota)
- [x] Edge case: kinds without sessionId (card-opened) → rate-limited by (learner, kind)
- [x] Negative: telemetry events never mint Stars, stages, or codex entries
- [x] Feature flag OFF → rate-limit check is skipped entirely (no D1 count query)
- [x] All 32 tests pass (25 existing + 7 new), zero regressions