### PR TITLE
feat(punctuation): U5 — Curlune breadth gate for Mega

### DIFF
--- a/src/subjects/punctuation/star-projection.js
+++ b/src/subjects/punctuation/star-projection.js
@@ -424,6 +424,36 @@ function computeMasteryStars(monsterClusterIds, facets, rewardUnits, monsterId) 
     }
   }
 
+  // P6-U5: Curlune Mega breadth gate — Curlune owns 7 reward units across
+  // comma_flow (3) and structure (4). Without broad deep-secure evidence
+  // (5/7 skills), Mastery Stars are capped at 15 so the maximum total is
+  // 10 + 30 + 35 + 15 = 90 (< 100 Mega).
+  if (monsterId === 'curlune') {
+    const totalUnitsForMonster = MONSTER_UNIT_COUNT.curlune; // 7
+    const minDeepSecuredForMega = Math.ceil(totalUnitsForMonster * 0.71); // 5
+
+    // Count deep-secured skills within Curlune's clusters.  Each Curlune
+    // skill maps 1:1 to a reward unit, so this is equivalent to counting
+    // deep-secured reward units.  Using skills (not cluster-level) avoids
+    // over-counting when only a subset of skills in a cluster are deep-secure.
+    let deepSecuredSkillCount = 0;
+    for (const skillId of skillsWithDeepSecure) {
+      const cluster = SKILL_TO_CLUSTER.get(skillId);
+      if (cluster && monsterClusterIds.has(cluster)) {
+        deepSecuredSkillCount += 1;
+      }
+    }
+
+    const hasMixedModes = itemModes.size >= 2;
+
+    const meetsCurluneMegaGate =
+      deepSecuredSkillCount >= minDeepSecuredForMega && hasMixedModes && hasSpacedReturn;
+
+    if (!meetsCurluneMegaGate) {
+      stars = Math.min(stars, 15);
+    }
+  }
+
   return stars;
 }
 

--- a/src/subjects/punctuation/star-projection.js
+++ b/src/subjects/punctuation/star-projection.js
@@ -446,7 +446,12 @@ function computeMasteryStars(monsterClusterIds, facets, rewardUnits, monsterId) 
 
     const hasMixedModes = itemModes.size >= 2;
 
+    // Structural parity with Claspin gate: require a minimum number of
+    // secured reward units (securedAt > 0) in addition to deep-secure
+    // skill evidence.  In practice deep-secure implies secured, but the
+    // gate enforces it explicitly so both monsters share the same shape.
     const meetsCurluneMegaGate =
+      securedUnitCount >= minDeepSecuredForMega &&
       deepSecuredSkillCount >= minDeepSecuredForMega && hasMixedModes && hasSpacedReturn;
 
     if (!meetsCurluneMegaGate) {

--- a/tests/punctuation-star-projection.test.js
+++ b/tests/punctuation-star-projection.test.js
@@ -964,6 +964,172 @@ test('U5: Claspin Mega gate — missing possession skill blocks full Mastery', (
 });
 
 // ---------------------------------------------------------------------------
+// P6-U5: Curlune Mega breadth gate tests
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a Curlune journey with a specific number of deep-secured units.
+ * @param {number} deepSecuredCount — how many of 7 units have deep-secure facets
+ * @param {Object} [opts] — { mixedModes, spacedReturn }
+ */
+function curluneJourney(deepSecuredCount, { mixedModes = true, spacedReturn = true } = {}) {
+  const progress = freshProgress();
+  const now = Date.UTC(2026, 3, 25);
+
+  // All 7 Curlune reward units in order.
+  const curluneUnits = [
+    { skillId: 'list_commas', cluster: 'comma_flow', ru: 'list-commas-core' },
+    { skillId: 'fronted_adverbial', cluster: 'comma_flow', ru: 'fronted-adverbials-core' },
+    { skillId: 'comma_clarity', cluster: 'comma_flow', ru: 'comma-clarity-core' },
+    { skillId: 'parenthesis', cluster: 'structure', ru: 'parenthesis-core' },
+    { skillId: 'colon_list', cluster: 'structure', ru: 'colons-core' },
+    { skillId: 'semicolon_list', cluster: 'structure', ru: 'semicolon-lists-core' },
+    { skillId: 'bullet_points', cluster: 'structure', ru: 'bullet-points-core' },
+  ];
+
+  // All 7 units are secured (securedAt > 0).
+  for (const { cluster, ru, skillId } of curluneUnits) {
+    progress.rewardUnits = {
+      ...progress.rewardUnits,
+      ...securedRewardUnit(cluster, ru),
+    };
+
+    // Add items and attempts for Try/Practice/Secure evidence.
+    for (let i = 0; i < 10; i++) {
+      const itemId = `curlune_${skillId}_item_${i}`;
+      progress.items[itemId] = secureItemState();
+      for (let d = 0; d < 4; d++) {
+        const modes = mixedModes ? ['choose', 'insert'] : ['choose'];
+        progress.attempts.push(makeAttempt({
+          ts: Date.UTC(2026, 3, 25 - d, 10, 0, i),
+          itemId,
+          skillIds: [skillId],
+          rewardUnitId: ru,
+          correct: true,
+          supportLevel: 0,
+          itemMode: modes[d % modes.length],
+        }));
+      }
+    }
+  }
+
+  // Deep-secure facets for the first N units.
+  const deepSecuredUnits = curluneUnits.slice(0, deepSecuredCount);
+  const modes = mixedModes ? ['choose', 'insert'] : ['choose'];
+  for (const { skillId } of deepSecuredUnits) {
+    for (const mode of modes) {
+      progress.facets[`${skillId}::${mode}`] = secureItemState({
+        lapses: 0,
+        firstCorrectAt: spacedReturn ? now - (14 * DAY_MS) : now - DAY_MS,
+        lastCorrectAt: now,
+      });
+    }
+  }
+
+  // Non-deep-secure facets for the remaining units (secure but with lapses).
+  const nonDeepUnits = curluneUnits.slice(deepSecuredCount);
+  for (const { skillId } of nonDeepUnits) {
+    for (const mode of modes) {
+      progress.facets[`${skillId}::${mode}`] = secureItemState({
+        lapses: 1,  // Has lapse — not deep-secure
+        streak: 3,  // Still secure (streak >= 3)
+        firstCorrectAt: spacedReturn ? now - (14 * DAY_MS) : now - DAY_MS,
+        lastCorrectAt: now,
+      });
+    }
+  }
+
+  return progress;
+}
+
+test('P6-U5: Curlune 5/7 deep-secure + mixed + spaced return — 100 Stars achievable', () => {
+  const progress = curluneJourney(5, { mixedModes: true, spacedReturn: true });
+  const result = projectPunctuationStars(progress, CURRENT_RELEASE_ID);
+  const curlune = result.perMonster.curlune;
+
+  assert.equal(curlune.total, 100,
+    `Curlune with 5/7 deep-secure must reach 100 (Mega), got ${curlune.total}`);
+  assert.ok(curlune.masteryStars > 15,
+    `Curlune Mastery Stars must exceed the capped value of 15, got ${curlune.masteryStars}`);
+});
+
+test('P6-U5: Curlune 7/7 deep-secure — Mega reached', () => {
+  const progress = curluneJourney(7, { mixedModes: true, spacedReturn: true });
+  const result = projectPunctuationStars(progress, CURRENT_RELEASE_ID);
+  const curlune = result.perMonster.curlune;
+
+  assert.equal(curlune.total, 100,
+    `Curlune with 7/7 deep-secure must reach 100 (Mega), got ${curlune.total}`);
+});
+
+test('P6-U5: Curlune 3/7 deep-secure — Mastery capped at 15, total max 90', () => {
+  const progress = curluneJourney(3, { mixedModes: true, spacedReturn: true });
+  const result = projectPunctuationStars(progress, CURRENT_RELEASE_ID);
+  const curlune = result.perMonster.curlune;
+
+  assert.ok(curlune.masteryStars <= 15,
+    `Curlune Mastery must be capped at 15 with 3/7 deep-secure, got ${curlune.masteryStars}`);
+  assert.ok(curlune.total <= 90,
+    `Curlune total must be <= 90 with 3/7 deep-secure, got ${curlune.total}`);
+  assert.ok(curlune.total < 100,
+    `Curlune must NOT reach Mega (100) with 3/7 deep-secure, got ${curlune.total}`);
+});
+
+test('P6-U5: Curlune 4/7 deep-secure — still capped (threshold is 5)', () => {
+  const progress = curluneJourney(4, { mixedModes: true, spacedReturn: true });
+  const result = projectPunctuationStars(progress, CURRENT_RELEASE_ID);
+  const curlune = result.perMonster.curlune;
+
+  assert.ok(curlune.masteryStars <= 15,
+    `Curlune Mastery must be capped at 15 with 4/7 deep-secure, got ${curlune.masteryStars}`);
+  assert.ok(curlune.total < 100,
+    `Curlune must NOT reach Mega (100) with 4/7 deep-secure, got ${curlune.total}`);
+});
+
+test('P6-U5: Curlune 5/7 deep-secure but no mixed modes — Mastery blocked by itemModes gate', () => {
+  const progress = curluneJourney(5, { mixedModes: false, spacedReturn: true });
+  const result = projectPunctuationStars(progress, CURRENT_RELEASE_ID);
+  const curlune = result.perMonster.curlune;
+
+  assert.equal(curlune.masteryStars, 0,
+    `Curlune Mastery must be 0 without mixed modes (itemModes.size < 2), got ${curlune.masteryStars}`);
+  assert.ok(curlune.total < 100,
+    `Curlune must NOT reach Mega without mixed modes, got ${curlune.total}`);
+});
+
+test('P6-U5: Pealark and Claspin unaffected by Curlune breadth gate', () => {
+  // Verify Pealark and Claspin simple-secure journeys are unchanged.
+  const pealarkResult = projectPunctuationStars(simpleSecureJourney('pealark'), CURRENT_RELEASE_ID);
+  const claspinResult = projectPunctuationStars(simpleSecureJourney('claspin'), CURRENT_RELEASE_ID);
+
+  // These should produce the same results as before the Curlune gate was added.
+  // Pealark: simple secure journey has 1 mode, so Mastery = 0.
+  assert.equal(pealarkResult.perMonster.pealark.masteryStars, 0,
+    'Pealark Mastery Stars must be 0 with single mode (unaffected by Curlune gate)');
+  // Claspin: simple secure journey has 1 mode, so Mastery = 0.
+  assert.equal(claspinResult.perMonster.claspin.masteryStars, 0,
+    'Claspin Mastery Stars must be 0 with single mode (unaffected by Curlune gate)');
+
+  // Neither monster has Curlune's gate applied.
+  assert.ok(pealarkResult.perMonster.pealark.total > 0,
+    'Pealark total must be > 0');
+  assert.ok(claspinResult.perMonster.claspin.total > 0,
+    'Claspin total must be > 0');
+});
+
+test('P6-U5: Curlune simple-secure journey (1 mode) cannot reach Mega', () => {
+  // The existing simpleSecureJourney helper uses single mode.
+  const result = projectPunctuationStars(simpleSecureJourney('curlune'), CURRENT_RELEASE_ID);
+  const curlune = result.perMonster.curlune;
+
+  assert.ok(curlune.total < 100,
+    `Curlune simple secure (single mode) must not reach Mega, got ${curlune.total}`);
+  // Mastery Stars should be 0 due to the itemModes.size < 2 gate.
+  assert.equal(curlune.masteryStars, 0,
+    'Curlune Mastery Stars must be 0 with single item mode');
+});
+
+// ---------------------------------------------------------------------------
 // U6: Grand Star tier gate tests
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add Curlune Mega breadth gate in `computeMasteryStars` (P6-U5, R18/R8): Curlune requires at least 5 of 7 skills deep-secured (facet secure + lapses === 0) before Mastery Stars can push the total to 100
- Without the gate, Mastery Stars are capped at 15, giving a maximum of 10+30+35+15 = 90 (< 100 Mega)
- Threshold derived from `MONSTER_UNIT_COUNT.curlune` via `ceil(7 * 0.71) = 5`, not hardcoded
- Counts deep-secured skills (not cluster-level) to avoid over-counting when only a subset of skills in a cluster are deep-secure

## Test plan
- [x] Curlune 5/7 deep-secure + mixed + spaced return reaches 100 Stars (Mega)
- [x] Curlune 7/7 deep-secure reaches Mega
- [x] Curlune 3/7 deep-secure: Mastery capped at 15, total max 90
- [x] Curlune 4/7 deep-secure: still capped (threshold is 5)
- [x] Curlune 5/7 deep-secure but no mixed modes: Mastery blocked by existing itemModes gate
- [x] Pealark and Claspin unaffected by Curlune breadth gate
- [x] Curlune simple-secure journey (1 mode) cannot reach Mega
- [x] All existing star-projection tests pass (49/49)
- [x] All read-model tests pass (13/13) — no regressions