### PR TITLE
fix(grammar): U6 — dashboard model passes evidence to monster strip

### DIFF
--- a/src/subjects/grammar/components/GrammarSetupScene.jsx
+++ b/src/subjects/grammar/components/GrammarSetupScene.jsx
@@ -166,7 +166,7 @@ export function GrammarSetupScene({ learner, grammar, rewardState, actions, runt
       conceptNodesMap[c.id] = c;
     }
   }
-  const recentAttempts = Array.isArray(grammar?.recentAttempts) ? grammar.recentAttempts : [];
+  const recentAttempts = Array.isArray(grammar?.analytics?.recentAttempts) ? grammar.analytics.recentAttempts : [];
 
   const dashboard = buildGrammarDashboardModel(grammar, learner, rewardState, conceptNodesMap, recentAttempts);
   const selectedMode = dashboard.primaryMode;

--- a/src/subjects/grammar/components/GrammarSetupScene.jsx
+++ b/src/subjects/grammar/components/GrammarSetupScene.jsx
@@ -12,7 +12,6 @@ import {
   GRAMMAR_SECONDARY_MODE_LINKS,
   GRAMMAR_MONSTER_STRIP_CHILD_COPY,
   buildGrammarDashboardModel,
-  buildGrammarMonsterStripModel,
 } from './grammar-view-model.js';
 // SH2-U5: fresh-learner `dashboard.isEmpty` branch surfaces the canonical
 // three-part copy through the shared primitive. The pre-U5 bespoke
@@ -155,21 +154,10 @@ function MoreModeCard({ card, selected, disabled, actions }) {
 }
 
 export function GrammarSetupScene({ learner, grammar, rewardState, actions, runtimeReadOnly }) {
-  const dashboard = buildGrammarDashboardModel(grammar, learner, rewardState);
-  const selectedMode = dashboard.primaryMode;
-  const miniTestMode = selectedMode === 'satsset';
-  const setupDisabled = runtimeReadOnly || Boolean(grammar.pendingCommand);
-  const lengthOptions = miniTestMode ? [8, 12] : [3, 5, 8, 10, 15];
-  const selectedLength = miniTestMode
-    ? (Number(grammar.prefs?.roundLength) >= 10 ? 12 : 8)
-    : (Number(grammar.prefs?.roundLength) || 5);
-  const selectedSpeechRate = normaliseGrammarSpeechRate(grammar.prefs?.speechRate);
-  const { title: heroTitle, subtitle: heroSubtitle } = GRAMMAR_DASHBOARD_HERO;
-
-  // U7 Phase 5: build monster strip from reward state + mastery concept nodes.
-  // The grammar read-model carries concept nodes under analytics.concepts as
-  // a flat array; we index by id for the strip builder. recentAttempts come
-  // from the engine state if available.
+  // U6 Phase 6: build concept nodes map + recent attempts from the grammar
+  // read-model, then thread them into the dashboard model so that
+  // dashboard.monsterStrip reflects live evidence derivation rather than
+  // only the persisted starHighWater latch.
   const conceptNodesMap = {};
   const analyticsConcepts = Array.isArray(grammar?.analytics?.concepts)
     ? grammar.analytics.concepts : [];
@@ -179,7 +167,17 @@ export function GrammarSetupScene({ learner, grammar, rewardState, actions, runt
     }
   }
   const recentAttempts = Array.isArray(grammar?.recentAttempts) ? grammar.recentAttempts : [];
-  const monsterStrip = buildGrammarMonsterStripModel(rewardState, conceptNodesMap, recentAttempts);
+
+  const dashboard = buildGrammarDashboardModel(grammar, learner, rewardState, conceptNodesMap, recentAttempts);
+  const selectedMode = dashboard.primaryMode;
+  const miniTestMode = selectedMode === 'satsset';
+  const setupDisabled = runtimeReadOnly || Boolean(grammar.pendingCommand);
+  const lengthOptions = miniTestMode ? [8, 12] : [3, 5, 8, 10, 15];
+  const selectedLength = miniTestMode
+    ? (Number(grammar.prefs?.roundLength) >= 10 ? 12 : 8)
+    : (Number(grammar.prefs?.roundLength) || 5);
+  const selectedSpeechRate = normaliseGrammarSpeechRate(grammar.prefs?.speechRate);
+  const { title: heroTitle, subtitle: heroSubtitle } = GRAMMAR_DASHBOARD_HERO;
 
   return (
     <section
@@ -207,7 +205,7 @@ export function GrammarSetupScene({ learner, grammar, rewardState, actions, runt
 
       {/* U7: Monster strip — 4 active monsters with Star progress */}
       <section className="grammar-monster-strip" aria-label="Your Grammar creatures">
-        {monsterStrip.map((entry) => (
+        {dashboard.monsterStrip.map((entry) => (
           <MonsterStripEntry entry={entry} key={entry.monsterId} />
         ))}
         <p className="grammar-monster-strip-hint">{GRAMMAR_MONSTER_STRIP_CHILD_COPY}</p>

--- a/src/subjects/grammar/components/grammar-view-model.js
+++ b/src/subjects/grammar/components/grammar-view-model.js
@@ -518,7 +518,7 @@ function concordiumProgressFromReward(rewardState) {
  * `concordiumProgress.mastered / total`. New Star-aware consumers read
  * `monsterStrip[i].stars / starMax` instead.
  */
-export function buildGrammarDashboardModel(grammar, _learner, rewardState) {
+export function buildGrammarDashboardModel(grammar, _learner, rewardState, masteryConceptNodes = null, recentAttempts = null) {
   const safeGrammar = grammar && typeof grammar === 'object' && !Array.isArray(grammar) ? grammar : {};
   const progressSnapshot = safeGrammar.analytics?.progressSnapshot && typeof safeGrammar.analytics.progressSnapshot === 'object'
     ? safeGrammar.analytics.progressSnapshot
@@ -555,7 +555,7 @@ export function buildGrammarDashboardModel(grammar, _learner, rewardState) {
     todayCards: Object.freeze(todayCards),
     isEmpty,
     concordiumProgress: concordiumProgressFromReward(rewardState),
-    monsterStrip: buildGrammarMonsterStripModel(rewardState, null, null),
+    monsterStrip: buildGrammarMonsterStripModel(rewardState, masteryConceptNodes, recentAttempts),
     primaryMode,
     moreModes: GRAMMAR_MORE_PRACTICE_MODES,
     writingTryAvailable: aiEnabled,

--- a/tests/grammar-ui-model.test.js
+++ b/tests/grammar-ui-model.test.js
@@ -1160,3 +1160,111 @@ test('P5-U10 view-model: reserved monsters never leak into monsterStrip from das
   assert.equal(ids.includes('loomrill'), false, 'loomrill excluded from dashboard monsterStrip');
   assert.equal(ids.length, 4, 'exactly 4 active monsters in strip');
 });
+
+// =============================================================================
+// P6-U6: Dashboard model passes evidence to monster strip
+// =============================================================================
+
+test('P6-U6 view-model: dashboard model with evidence → monsterStrip Stars match live derivation', () => {
+  // Bracehart has 6 concepts. Provide mastery nodes showing a secured concept
+  // with 2 independent corrects across 2 templates → all 5 evidence tiers
+  // should be true for that concept, yielding floor(100/6 * 1.0) = 16 Stars.
+  const rewardState = {
+    bracehart: { mastered: [], caught: false, starHighWater: 0 },
+  };
+  const conceptNodes = {
+    clauses: { attempts: 12, correct: 11, wrong: 1, strength: 0.88, intervalDays: 14, correctStreak: 6 },
+  };
+  const recentAttempts = [
+    { conceptIds: ['clauses'], result: { correct: true }, templateId: 'tmpl-a', firstAttemptIndependent: true, supportLevelAtScoring: 0 },
+    { conceptIds: ['clauses'], result: { correct: true }, templateId: 'tmpl-b', firstAttemptIndependent: true, supportLevelAtScoring: 0 },
+  ];
+  const model = buildGrammarDashboardModel({}, null, rewardState, conceptNodes, recentAttempts);
+  const bracehart = model.monsterStrip.find((e) => e.monsterId === 'bracehart');
+  // 1 concept fully evidenced out of 6: floor(100/6 * 1.0) = floor(16.667) = 16
+  assert.equal(bracehart.stars, 16, 'Live evidence yields 16 Stars for 1 fully-evidenced concept');
+  assert.equal(bracehart.stageName, 'Hatched', '16 Stars = Hatched stage');
+});
+
+test('P6-U6 view-model: dashboard model without evidence (null, null) → graceful fallback to starHighWater', () => {
+  const rewardState = {
+    bracehart: { mastered: [], caught: true, starHighWater: 42 },
+  };
+  // No evidence args — the 4th and 5th parameters default to null.
+  const model = buildGrammarDashboardModel({}, null, rewardState);
+  const bracehart = model.monsterStrip.find((e) => e.monsterId === 'bracehart');
+  assert.equal(bracehart.stars, 42, 'Falls back to persisted starHighWater when no evidence supplied');
+  assert.equal(bracehart.stageName, 'Growing', '42 Stars = Growing stage');
+});
+
+test('P6-U6 view-model: live evidence > persisted starHighWater → dashboard shows higher Stars', () => {
+  // starHighWater is 5, but live evidence computes to more than 5.
+  const rewardState = {
+    couronnail: { mastered: [], caught: true, starHighWater: 5 },
+  };
+  // Couronnail has 3 concepts. Give word_classes all 5 tiers:
+  // floor(100/3 * 1.0) = floor(33.333) = 33 Stars.
+  const conceptNodes = {
+    word_classes: { attempts: 12, correct: 11, wrong: 1, strength: 0.88, intervalDays: 14, correctStreak: 6 },
+  };
+  const recentAttempts = [
+    { conceptIds: ['word_classes'], result: { correct: true }, templateId: 'tmpl-a', firstAttemptIndependent: true, supportLevelAtScoring: 0 },
+    { conceptIds: ['word_classes'], result: { correct: true }, templateId: 'tmpl-b', firstAttemptIndependent: true, supportLevelAtScoring: 0 },
+  ];
+  const model = buildGrammarDashboardModel({}, null, rewardState, conceptNodes, recentAttempts);
+  const couronnail = model.monsterStrip.find((e) => e.monsterId === 'couronnail');
+  assert.ok(couronnail.stars > 5, `Live evidence (${couronnail.stars}) must exceed persisted starHighWater (5)`);
+  assert.equal(couronnail.stars, 33, '1 fully-evidenced Couronnail concept = 33 Stars');
+});
+
+test('P6-U6 view-model: live evidence < persisted starHighWater → dashboard shows starHighWater (latch holds)', () => {
+  // starHighWater is 50, but live evidence only computes to 1 Star
+  // (one concept with firstIndependentWin only → floor guarantee 1).
+  // The latch must hold — display should be 50.
+  const rewardState = {
+    bracehart: { mastered: [], caught: true, starHighWater: 50 },
+  };
+  const conceptNodes = {
+    clauses: { attempts: 1, correct: 1, wrong: 0, strength: 0.5, intervalDays: 1, correctStreak: 1 },
+  };
+  const recentAttempts = [
+    { conceptIds: ['clauses'], result: { correct: true }, templateId: 'tmpl-a', firstAttemptIndependent: true, supportLevelAtScoring: 0 },
+  ];
+  const model = buildGrammarDashboardModel({}, null, rewardState, conceptNodes, recentAttempts);
+  const bracehart = model.monsterStrip.find((e) => e.monsterId === 'bracehart');
+  assert.equal(bracehart.stars, 50, 'Latch holds — starHighWater 50 preserved despite lower live evidence');
+  assert.equal(bracehart.stageName, 'Growing', '50 Stars = Growing stage');
+});
+
+test('P6-U6 view-model: dashboard Stars match direct buildGrammarMonsterStripModel Stars when same evidence supplied', () => {
+  // Integration test: the dashboard model and the direct strip builder must
+  // produce identical results when given the same inputs.
+  const rewardState = {
+    bracehart: { mastered: [], caught: true, starHighWater: 10 },
+    chronalyx: { mastered: [], caught: false, starHighWater: 0 },
+    couronnail: { mastered: [], caught: true, starHighWater: 20 },
+    concordium: { mastered: [], caught: false, starHighWater: 0 },
+  };
+  const conceptNodes = {
+    clauses: { attempts: 12, correct: 11, wrong: 1, strength: 0.88, intervalDays: 14, correctStreak: 6 },
+    word_classes: { attempts: 12, correct: 11, wrong: 1, strength: 0.88, intervalDays: 14, correctStreak: 6 },
+  };
+  const recentAttempts = [
+    { conceptIds: ['clauses'], result: { correct: true }, templateId: 'tmpl-a', firstAttemptIndependent: true, supportLevelAtScoring: 0 },
+    { conceptIds: ['clauses'], result: { correct: true }, templateId: 'tmpl-b', firstAttemptIndependent: true, supportLevelAtScoring: 0 },
+    { conceptIds: ['word_classes'], result: { correct: true }, templateId: 'tmpl-c', firstAttemptIndependent: true, supportLevelAtScoring: 0 },
+    { conceptIds: ['word_classes'], result: { correct: true }, templateId: 'tmpl-d', firstAttemptIndependent: true, supportLevelAtScoring: 0 },
+  ];
+  const dashboardModel = buildGrammarDashboardModel({}, null, rewardState, conceptNodes, recentAttempts);
+  const directStrip = buildGrammarMonsterStripModel(rewardState, conceptNodes, recentAttempts);
+
+  assert.equal(dashboardModel.monsterStrip.length, directStrip.length, 'Same number of entries');
+  for (let i = 0; i < directStrip.length; i++) {
+    const dashEntry = dashboardModel.monsterStrip[i];
+    const directEntry = directStrip[i];
+    assert.equal(dashEntry.monsterId, directEntry.monsterId, `Same monster id at index ${i}`);
+    assert.equal(dashEntry.stars, directEntry.stars, `${dashEntry.monsterId}: dashboard Stars match direct strip Stars`);
+    assert.equal(dashEntry.stageName, directEntry.stageName, `${dashEntry.monsterId}: dashboard stageName matches direct strip`);
+    assert.equal(dashEntry.stageIndex, directEntry.stageIndex, `${dashEntry.monsterId}: dashboard stageIndex matches direct strip`);
+  }
+});


### PR DESCRIPTION
## Summary
- Thread `masteryConceptNodes` and `recentAttempts` through `buildGrammarDashboardModel` so `dashboard.monsterStrip` reflects live evidence derivation, not just the persisted `starHighWater` latch
- `GrammarSetupScene` now passes evidence into the dashboard model and reads `dashboard.monsterStrip` instead of calling `buildGrammarMonsterStripModel` directly — removes the bypass
- 5 new tests covering: happy-path evidence, null fallback, evidence > starHighWater, evidence < starHighWater (latch holds), dashboard-vs-direct-strip parity

## Changes
### `src/subjects/grammar/components/grammar-view-model.js`
- `buildGrammarDashboardModel` gains two optional parameters: `masteryConceptNodes` (default `null`) and `recentAttempts` (default `null`)
- These are passed through to `buildGrammarMonsterStripModel` instead of the previous hardcoded `null, null`
- Fully backward compatible — callers that omit the new params get identical behaviour

### `src/subjects/grammar/components/GrammarSetupScene.jsx`
- Evidence extraction (conceptNodesMap, recentAttempts) moved before `buildGrammarDashboardModel` call
- Evidence threaded into dashboard model instead of calling `buildGrammarMonsterStripModel` directly
- JSX reads `dashboard.monsterStrip` instead of a separate `monsterStrip` variable
- Removed unused `buildGrammarMonsterStripModel` import

### `tests/grammar-ui-model.test.js`
- 5 new P6-U6 tests (all passing, 116 total)

## Test plan
- [x] `npx vitest run tests/grammar-ui-model.test.js` — 116 pass, 0 fail
- [x] `npx vitest run tests/grammar-stars.test.js` — 75 pass, 0 fail (no regression)

## Plan Deviations
None. The implementation follows the U6 plan exactly.