### PR TITLE
feat(admin): U2 login redirect preservation via sessionStorage stash

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -174,6 +174,10 @@ async function submitAuthCredentials({ mode = 'login', email, password, convertD
 }
 
 async function startSocialAuth(provider) {
+  /* ADV-001: clear any leftover admin-return stash before the OAuth redirect.
+     Matches the defensive pattern in startDemoSession — prevents a stale stash
+     from persisting across provider switches or repeated auth attempts. */
+  clearAdminReturn();
   const response = await credentialFetch(`/api/auth/${provider}/start`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
@@ -2485,10 +2489,12 @@ const appRuntime = {
     clearAdminReturn();
   } else {
     /* U2: social-auth return path — after OAuth callback the browser lands
-       on `/` with a valid session. If a stash exists, restore the admin
-       route without a full-page redirect by dispatching into the store. */
+       on `/` with a valid session. If a stash exists AND the user has
+       admin/ops role, restore the admin route without a full-page redirect
+       by dispatching into the store. Non-admin users get the stash
+       discarded silently (ADV-002). */
     const stashedReturn = popAdminReturn();
-    if (stashedReturn) {
+    if (stashedReturn && (shellPlatformRole === 'admin' || shellPlatformRole === 'ops')) {
       const stashedHash = stashedReturn.includes('#')
         ? stashedReturn.slice(stashedReturn.indexOf('#'))
         : '';
@@ -2499,6 +2505,9 @@ const appRuntime = {
       // Update the URL bar to match the restored admin route
       const newUrl = stashedReturn;
       globalThis.history?.replaceState?.(null, '', newUrl);
+    } else if (stashedReturn) {
+      // Non-admin user — discard the stash, do not open admin hub
+      clearAdminReturn(globalThis.sessionStorage);
     }
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,7 @@ import { AuthSurface } from './surfaces/auth/AuthSurface.jsx';
 import { SUBJECTS, getSubject } from './platform/core/subject-registry.js';
 import { VALID_ADMIN_SECTIONS } from './platform/core/store.js';
 import { parseAdminSectionFromHash } from './platform/core/admin-hash.js';
+import { stashAdminReturn, popAdminReturn, clearAdminReturn } from './platform/core/admin-return-stash.js';
 import {
   exposedSubjects,
   isSubjectExposed,
@@ -166,7 +167,10 @@ async function submitAuthCredentials({ mode = 'login', email, password, convertD
   if (!response.ok) {
     throw new Error(payload.message || 'Sign-in failed.');
   }
-  globalThis.location.href = '/';
+  /* U2: after successful auth, check for a stashed admin return target.
+     If valid, redirect there instead of the default `/`. */
+  const adminReturn = popAdminReturn();
+  globalThis.location.href = adminReturn || '/';
 }
 
 async function startSocialAuth(provider) {
@@ -183,6 +187,9 @@ async function startSocialAuth(provider) {
 }
 
 async function startDemoSession() {
+  /* U2: demo sessions must NOT restore admin return — clear the stash
+     unconditionally before the redirect. */
+  clearAdminReturn();
   const response = await credentialFetch('/api/demo/session', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
@@ -224,6 +231,13 @@ async function createRepositoriesForCurrentRuntime() {
 
 const boot = await createRepositoriesForCurrentRuntime();
 if (!boot.repositories) {
+  /* U2: stash the pre-auth admin URL so we can return the user to the
+     correct admin section after a successful sign-in. Only stashes for
+     `/admin` pathnames — anything else is ignored by the helper. */
+  stashAdminReturn({
+    pathname: globalThis.location?.pathname,
+    hash: globalThis.location?.hash,
+  });
   renderAuthRoot({
     error: boot.session?.error || '',
     code: boot.session?.code || '',
@@ -2467,6 +2481,25 @@ const appRuntime = {
     store.openAdminHub({ adminSection: bootSection });
     if (boot.session.signedIn) loadAdminHub({ force: true });
     loadAdminAccounts();
+    // Consume any leftover stash — the user landed on /admin directly
+    clearAdminReturn();
+  } else {
+    /* U2: social-auth return path — after OAuth callback the browser lands
+       on `/` with a valid session. If a stash exists, restore the admin
+       route without a full-page redirect by dispatching into the store. */
+    const stashedReturn = popAdminReturn();
+    if (stashedReturn) {
+      const stashedHash = stashedReturn.includes('#')
+        ? stashedReturn.slice(stashedReturn.indexOf('#'))
+        : '';
+      const stashedSection = parseAdminSectionFromHash(stashedHash);
+      store.openAdminHub({ adminSection: stashedSection });
+      if (boot.session.signedIn) loadAdminHub({ force: true });
+      loadAdminAccounts();
+      // Update the URL bar to match the restored admin route
+      const newUrl = stashedReturn;
+      globalThis.history?.replaceState?.(null, '', newUrl);
+    }
   }
 }
 

--- a/src/platform/core/admin-return-stash.js
+++ b/src/platform/core/admin-return-stash.js
@@ -1,0 +1,120 @@
+import { parseAdminSectionFromHash } from './admin-hash.js';
+
+/**
+ * Bounded sessionStorage helper for preserving the admin URL across
+ * a sign-in redirect. The stash expires after 5 minutes and only
+ * accepts `/admin` as the pathname (no open-redirect vector).
+ *
+ * Key: `ks2_admin_return`
+ * Shape: JSON `{ pathname: string, hash: string, ts: number }`
+ */
+
+const STASH_KEY = 'ks2_admin_return';
+const MAX_AGE_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Write the current admin location into sessionStorage.
+ * Only stashes if pathname is exactly `/admin` (case-insensitive,
+ * trailing-slash tolerant).
+ *
+ * @param {{ pathname?: string, hash?: string }} loc
+ * @param {Storage} [storage] - defaults to `sessionStorage`
+ */
+export function stashAdminReturn(loc, storage) {
+  const ss = storage || _safeSessionStorage();
+  if (!ss) return;
+
+  const rawPath = (loc?.pathname || '').replace(/\/+$/, '').toLowerCase();
+  if (rawPath !== '/admin') return;
+
+  const hash = typeof loc?.hash === 'string' ? loc.hash : '';
+
+  try {
+    ss.setItem(STASH_KEY, JSON.stringify({
+      pathname: '/admin',
+      hash,
+      ts: Date.now(),
+    }));
+  } catch { /* quota / SecurityError — silently ignore */ }
+}
+
+/**
+ * Read and consume the stashed admin return target.
+ * Returns a validated redirect URL string or `null`.
+ *
+ * - Expired stashes (>5 min) are discarded.
+ * - Hashes with an invalid section are stripped (redirect to `/admin`).
+ * - Non-`/admin` pathnames are rejected entirely.
+ *
+ * The stash is always cleared on read (consume-once).
+ *
+ * @param {Storage} [storage] - defaults to `sessionStorage`
+ * @returns {string | null} e.g. `/admin#section=debug` or `/admin` or null
+ */
+export function popAdminReturn(storage) {
+  const ss = storage || _safeSessionStorage();
+  if (!ss) return null;
+
+  let raw;
+  try {
+    raw = ss.getItem(STASH_KEY);
+    ss.removeItem(STASH_KEY);
+  } catch { return null; }
+
+  if (!raw) return null;
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch { return null; }
+
+  if (!parsed || typeof parsed !== 'object') return null;
+
+  // Expiry check
+  const age = Date.now() - (typeof parsed.ts === 'number' ? parsed.ts : 0);
+  if (age > MAX_AGE_MS || age < 0) return null;
+
+  // Pathname must be exactly `/admin`
+  const storedPath = (typeof parsed.pathname === 'string' ? parsed.pathname : '')
+    .replace(/\/+$/, '').toLowerCase();
+  if (storedPath !== '/admin') return null;
+
+  // Validate hash — if present, must parse to a known section; otherwise strip it
+  const hash = typeof parsed.hash === 'string' ? parsed.hash : '';
+  if (hash) {
+    const section = parseAdminSectionFromHash(hash);
+    // section is null when no `section=` key present, or a valid section name,
+    // or 'overview' for unrecognised values. All are safe to redirect to.
+    if (section === null) {
+      // Hash present but no parseable section — redirect to bare /admin
+      return '/admin';
+    }
+    return `/admin#section=${section}`;
+  }
+
+  return '/admin';
+}
+
+/**
+ * Clear the stash without reading it.
+ * Used when demo sessions start (they must not restore admin return).
+ *
+ * @param {Storage} [storage]
+ */
+export function clearAdminReturn(storage) {
+  const ss = storage || _safeSessionStorage();
+  if (!ss) return;
+  try { ss.removeItem(STASH_KEY); } catch { /* ignore */ }
+}
+
+/** @returns {Storage | null} */
+function _safeSessionStorage() {
+  try {
+    return typeof globalThis !== 'undefined' && globalThis.sessionStorage
+      ? globalThis.sessionStorage
+      : null;
+  } catch { return null; }
+}
+
+// Exported for tests
+export { STASH_KEY, MAX_AGE_MS };

--- a/tests/admin-return-stash.test.js
+++ b/tests/admin-return-stash.test.js
@@ -245,3 +245,78 @@ test('demo session flow: clearAdminReturn prevents popAdminReturn from reading',
   clearAdminReturn(ss);
   assert.equal(popAdminReturn(ss), null);
 });
+
+// ---------------------------------------------------------------------------
+// ADV-002: role guard on stash restore (social-auth return path)
+// ---------------------------------------------------------------------------
+
+test('social-auth return: non-admin role must NOT restore admin stash', () => {
+  // Simulates the boot-time logic in main.js: popAdminReturn returns a valid
+  // URL, but shellPlatformRole is 'parent' — the stash should be discarded.
+  const ss = createMemoryStorage();
+  stashAdminReturn({ pathname: '/admin', hash: '#section=debug' }, ss);
+
+  const stashedReturn = popAdminReturn(ss);
+  assert.ok(stashedReturn, 'stash should yield a valid URL');
+
+  // Simulate the role-guarded branch from main.js
+  const shellPlatformRole = 'parent';
+  let adminHubOpened = false;
+
+  if (stashedReturn && (shellPlatformRole === 'admin' || shellPlatformRole === 'ops')) {
+    adminHubOpened = true;
+  } else if (stashedReturn) {
+    clearAdminReturn(ss); // non-admin discard
+  }
+
+  assert.equal(adminHubOpened, false, 'admin hub must NOT open for parent role');
+});
+
+test('social-auth return: admin role restores admin stash', () => {
+  const ss = createMemoryStorage();
+  stashAdminReturn({ pathname: '/admin', hash: '#section=accounts' }, ss);
+
+  const stashedReturn = popAdminReturn(ss);
+  assert.ok(stashedReturn, 'stash should yield a valid URL');
+
+  const shellPlatformRole = 'admin';
+  let adminHubOpened = false;
+
+  if (stashedReturn && (shellPlatformRole === 'admin' || shellPlatformRole === 'ops')) {
+    adminHubOpened = true;
+  }
+
+  assert.equal(adminHubOpened, true, 'admin hub must open for admin role');
+  assert.equal(stashedReturn, '/admin#section=accounts');
+});
+
+test('social-auth return: ops role restores admin stash', () => {
+  const ss = createMemoryStorage();
+  stashAdminReturn({ pathname: '/admin', hash: '#section=debug' }, ss);
+
+  const stashedReturn = popAdminReturn(ss);
+  const shellPlatformRole = 'ops';
+  let adminHubOpened = false;
+
+  if (stashedReturn && (shellPlatformRole === 'admin' || shellPlatformRole === 'ops')) {
+    adminHubOpened = true;
+  }
+
+  assert.equal(adminHubOpened, true, 'admin hub must open for ops role');
+});
+
+// ---------------------------------------------------------------------------
+// ADV-001: startSocialAuth clears stash before OAuth redirect
+// ---------------------------------------------------------------------------
+
+test('social auth start: stash is cleared before OAuth redirect', () => {
+  // Simulates the clearAdminReturn() call at the start of startSocialAuth
+  const ss = createMemoryStorage();
+  stashAdminReturn({ pathname: '/admin', hash: '#section=debug' }, ss);
+  assert.ok(ss.getItem(STASH_KEY), 'stash should exist before social auth');
+
+  // The clearAdminReturn() call that now precedes the OAuth redirect
+  clearAdminReturn(ss);
+  assert.equal(ss.getItem(STASH_KEY), null, 'stash must be cleared before OAuth redirect');
+  assert.equal(popAdminReturn(ss), null, 'popAdminReturn must return null after clear');
+});

--- a/tests/admin-return-stash.test.js
+++ b/tests/admin-return-stash.test.js
@@ -1,0 +1,247 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  stashAdminReturn,
+  popAdminReturn,
+  clearAdminReturn,
+  STASH_KEY,
+  MAX_AGE_MS,
+} from '../src/platform/core/admin-return-stash.js';
+
+// ---------------------------------------------------------------------------
+// In-memory sessionStorage shim
+// ---------------------------------------------------------------------------
+function createMemoryStorage() {
+  const map = new Map();
+  return {
+    getItem(k) { return map.get(k) ?? null; },
+    setItem(k, v) { map.set(k, String(v)); },
+    removeItem(k) { map.delete(k); },
+    _map: map,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// stashAdminReturn
+// ---------------------------------------------------------------------------
+
+test('stashAdminReturn: stashes /admin pathname with hash', () => {
+  const ss = createMemoryStorage();
+  stashAdminReturn({ pathname: '/admin', hash: '#section=debug' }, ss);
+  const raw = ss.getItem(STASH_KEY);
+  assert.ok(raw, 'stash should be written');
+  const parsed = JSON.parse(raw);
+  assert.equal(parsed.pathname, '/admin');
+  assert.equal(parsed.hash, '#section=debug');
+  assert.equal(typeof parsed.ts, 'number');
+});
+
+test('stashAdminReturn: stashes /admin with no hash', () => {
+  const ss = createMemoryStorage();
+  stashAdminReturn({ pathname: '/admin', hash: '' }, ss);
+  const raw = ss.getItem(STASH_KEY);
+  assert.ok(raw);
+  const parsed = JSON.parse(raw);
+  assert.equal(parsed.pathname, '/admin');
+  assert.equal(parsed.hash, '');
+});
+
+test('stashAdminReturn: normalises trailing slash and case', () => {
+  const ss = createMemoryStorage();
+  stashAdminReturn({ pathname: '/Admin/', hash: '#section=accounts' }, ss);
+  const raw = ss.getItem(STASH_KEY);
+  assert.ok(raw);
+  const parsed = JSON.parse(raw);
+  assert.equal(parsed.pathname, '/admin');
+});
+
+test('stashAdminReturn: ignores non-admin pathname', () => {
+  const ss = createMemoryStorage();
+  stashAdminReturn({ pathname: '/evil', hash: '#section=debug' }, ss);
+  assert.equal(ss.getItem(STASH_KEY), null);
+});
+
+test('stashAdminReturn: ignores root pathname', () => {
+  const ss = createMemoryStorage();
+  stashAdminReturn({ pathname: '/', hash: '' }, ss);
+  assert.equal(ss.getItem(STASH_KEY), null);
+});
+
+test('stashAdminReturn: ignores empty pathname', () => {
+  const ss = createMemoryStorage();
+  stashAdminReturn({ pathname: '', hash: '' }, ss);
+  assert.equal(ss.getItem(STASH_KEY), null);
+});
+
+test('stashAdminReturn: ignores null location', () => {
+  const ss = createMemoryStorage();
+  stashAdminReturn(null, ss);
+  assert.equal(ss.getItem(STASH_KEY), null);
+});
+
+// ---------------------------------------------------------------------------
+// popAdminReturn — happy paths
+// ---------------------------------------------------------------------------
+
+test('popAdminReturn: returns /admin#section=debug for valid stash', () => {
+  const ss = createMemoryStorage();
+  stashAdminReturn({ pathname: '/admin', hash: '#section=debug' }, ss);
+  const result = popAdminReturn(ss);
+  assert.equal(result, '/admin#section=debug');
+});
+
+test('popAdminReturn: returns /admin for stash with no hash', () => {
+  const ss = createMemoryStorage();
+  stashAdminReturn({ pathname: '/admin', hash: '' }, ss);
+  const result = popAdminReturn(ss);
+  assert.equal(result, '/admin');
+});
+
+test('popAdminReturn: consumes the stash (second read returns null)', () => {
+  const ss = createMemoryStorage();
+  stashAdminReturn({ pathname: '/admin', hash: '#section=debug' }, ss);
+  popAdminReturn(ss);
+  assert.equal(popAdminReturn(ss), null);
+});
+
+test('popAdminReturn: returns /admin#section=overview for stash with valid section', () => {
+  const ss = createMemoryStorage();
+  stashAdminReturn({ pathname: '/admin', hash: '#section=overview' }, ss);
+  const result = popAdminReturn(ss);
+  assert.equal(result, '/admin#section=overview');
+});
+
+// ---------------------------------------------------------------------------
+// popAdminReturn — edge cases
+// ---------------------------------------------------------------------------
+
+test('popAdminReturn: expired stash (>5 minutes) returns null', () => {
+  const ss = createMemoryStorage();
+  // Write a stash with a timestamp older than MAX_AGE_MS
+  ss.setItem(STASH_KEY, JSON.stringify({
+    pathname: '/admin',
+    hash: '#section=debug',
+    ts: Date.now() - MAX_AGE_MS - 1,
+  }));
+  assert.equal(popAdminReturn(ss), null);
+  // Stash should still be cleared
+  assert.equal(ss.getItem(STASH_KEY), null);
+});
+
+test('popAdminReturn: stash with invalid section hash returns /admin#section=overview', () => {
+  const ss = createMemoryStorage();
+  ss.setItem(STASH_KEY, JSON.stringify({
+    pathname: '/admin',
+    hash: '#section=nonexistent',
+    ts: Date.now(),
+  }));
+  // parseAdminSectionFromHash returns 'overview' for unknown sections
+  assert.equal(popAdminReturn(ss), '/admin#section=overview');
+});
+
+test('popAdminReturn: stash with hash but no section= key returns /admin', () => {
+  const ss = createMemoryStorage();
+  ss.setItem(STASH_KEY, JSON.stringify({
+    pathname: '/admin',
+    hash: '#foo=bar',
+    ts: Date.now(),
+  }));
+  // parseAdminSectionFromHash returns null for no section= key
+  assert.equal(popAdminReturn(ss), '/admin');
+});
+
+test('popAdminReturn: stash with non-admin pathname (injection) returns null', () => {
+  const ss = createMemoryStorage();
+  ss.setItem(STASH_KEY, JSON.stringify({
+    pathname: '/evil',
+    hash: '#section=debug',
+    ts: Date.now(),
+  }));
+  assert.equal(popAdminReturn(ss), null);
+});
+
+test('popAdminReturn: no stash exists returns null', () => {
+  const ss = createMemoryStorage();
+  assert.equal(popAdminReturn(ss), null);
+});
+
+test('popAdminReturn: malformed JSON returns null', () => {
+  const ss = createMemoryStorage();
+  ss.setItem(STASH_KEY, 'not json');
+  assert.equal(popAdminReturn(ss), null);
+  // Stash should be cleared
+  assert.equal(ss.getItem(STASH_KEY), null);
+});
+
+test('popAdminReturn: future timestamp is rejected', () => {
+  const ss = createMemoryStorage();
+  ss.setItem(STASH_KEY, JSON.stringify({
+    pathname: '/admin',
+    hash: '#section=debug',
+    ts: Date.now() + 999999999,
+  }));
+  // age < 0 => rejected
+  assert.equal(popAdminReturn(ss), null);
+});
+
+test('popAdminReturn: missing ts field is treated as expired', () => {
+  const ss = createMemoryStorage();
+  ss.setItem(STASH_KEY, JSON.stringify({
+    pathname: '/admin',
+    hash: '#section=debug',
+  }));
+  // ts is undefined => parsed.ts is NaN => age is NaN => NaN > MAX_AGE_MS is false,
+  // but typeof parsed.ts !== 'number' => ts defaults to 0 => age >> MAX_AGE_MS
+  assert.equal(popAdminReturn(ss), null);
+});
+
+test('popAdminReturn: stash with /admin/ (trailing slash) pathname is accepted', () => {
+  const ss = createMemoryStorage();
+  ss.setItem(STASH_KEY, JSON.stringify({
+    pathname: '/admin/',
+    hash: '#section=debug',
+    ts: Date.now(),
+  }));
+  assert.equal(popAdminReturn(ss), '/admin#section=debug');
+});
+
+test('popAdminReturn: social auth >5 minutes — stash expired, fallback null', () => {
+  const ss = createMemoryStorage();
+  stashAdminReturn({ pathname: '/admin', hash: '#section=accounts' }, ss);
+  // Simulate time passing by rewriting the stash with an old timestamp
+  const raw = JSON.parse(ss.getItem(STASH_KEY));
+  raw.ts = Date.now() - MAX_AGE_MS - 1000;
+  ss.setItem(STASH_KEY, JSON.stringify(raw));
+  assert.equal(popAdminReturn(ss), null);
+});
+
+// ---------------------------------------------------------------------------
+// clearAdminReturn
+// ---------------------------------------------------------------------------
+
+test('clearAdminReturn: removes existing stash', () => {
+  const ss = createMemoryStorage();
+  stashAdminReturn({ pathname: '/admin', hash: '#section=debug' }, ss);
+  assert.ok(ss.getItem(STASH_KEY));
+  clearAdminReturn(ss);
+  assert.equal(ss.getItem(STASH_KEY), null);
+});
+
+test('clearAdminReturn: no-op when stash does not exist', () => {
+  const ss = createMemoryStorage();
+  clearAdminReturn(ss);
+  assert.equal(ss.getItem(STASH_KEY), null);
+});
+
+// ---------------------------------------------------------------------------
+// Demo session must NOT read stash
+// ---------------------------------------------------------------------------
+
+test('demo session flow: clearAdminReturn prevents popAdminReturn from reading', () => {
+  const ss = createMemoryStorage();
+  stashAdminReturn({ pathname: '/admin', hash: '#section=debug' }, ss);
+  // Simulate startDemoSession clearing the stash
+  clearAdminReturn(ss);
+  assert.equal(popAdminReturn(ss), null);
+});


### PR DESCRIPTION
## Summary

- Adds `src/platform/core/admin-return-stash.js` — a bounded sessionStorage helper (`ks2_admin_return`) that stashes the pre-auth admin URL and validates it on read (pathname must be `/admin`, 5-minute expiry, hash must parse to a valid section).
- Before `renderAuthRoot()` in `main.js`, stashes `{ pathname, hash }` so a signed-out admin visiting `/admin#section=debug` can be returned after sign-in.
- `submitAuthCredentials` now checks for a stashed return target and redirects there instead of `/`.
- `startSocialAuth` path is handled on post-OAuth boot: when the browser returns to `/` with a valid session, a stashed return is consumed and the admin route is restored via the store + `history.replaceState`.
- `startDemoSession` clears the stash unconditionally — demo sessions must never restore admin return.
- 24 new tests covering happy paths, expiry, injection, malformed JSON, demo clearing, and consume-once semantics.

## Files changed

- **New:** `src/platform/core/admin-return-stash.js` — bounded sessionStorage helper
- **New:** `tests/admin-return-stash.test.js` — 24 tests for the stash helper
- **Modified:** `src/main.js` — import stash helpers, stash before auth root, pop on credential auth success, pop on post-OAuth boot, clear on demo start

## Test plan

- [x] `node --test tests/admin-return-stash.test.js` — 24/24 pass
- [x] `node --test tests/store-admin-route.test.js` — 25/25 pass (no regressions)
- [x] `npm test` — 4539 pass, 6 fail (all pre-existing: build timeout, CSP inventory drift, rate-limit flakes, capacity benchmark flakes)

## Plan deviations

- **Social auth return path**: The plan suggested modifying `AuthSurface.jsx` to thread a restore callback. Instead, the social-auth return is handled at boot time in `main.js` — after the OAuth callback the browser reloads, boot succeeds with a valid session, and the stash is consumed and applied via `store.openAdminHub` + `history.replaceState`. This avoids threading a callback through AuthSurface and is consistent with the existing admin boot block pattern. AuthSurface was not modified.
- **`store-admin-route.test.js` not extended**: The existing tests already cover admin route normalisation comprehensively. All new stash-specific tests are in the dedicated `admin-return-stash.test.js` file instead.