### PR TITLE
feat(grammar): U4 — sub-secure Star persistence via star-evidence-updated event

### DIFF
--- a/src/platform/game/mastery/grammar.js
+++ b/src/platform/game/mastery/grammar.js
@@ -480,18 +480,25 @@ export function recordGrammarConceptMastery({
 /**
  * Lightweight latch-write for sub-secure Star evidence.
  *
- * Updates `starHighWater = max(existing, computedStars)` on the direct monster
- * and Concordium without touching the `mastered[]` array (that stays exclusive
+ * Updates `starHighWater = max(existing, computedStars)` on the specified
+ * monster only, without touching the `mastered[]` array (that stays exclusive
  * to concept-secured via `recordGrammarConceptMastery`).
  *
- * Sets `caught: true` if Stars >= 1 and was previously false on either
- * monster, emitting a `caught` reward event for each newly-caught monster.
+ * The caller (event-hooks subscriber) is responsible for passing the correct
+ * `monsterId` from each `star-evidence-updated` event. The command handler
+ * emits one event per monster with monster-specific `computedStars`, so each
+ * call updates exactly one monster — preventing cross-inflation where a
+ * direct monster's higher Stars would overwrite Concordium's lower value.
  *
- * Returns an array of reward events (caught events for monsters that newly
+ * Sets `caught: true` if Stars >= 1 and was previously false, emitting a
+ * `caught` reward event for the newly-caught monster.
+ *
+ * Returns an array of reward events (caught event if the monster newly
  * crossed the threshold, otherwise empty).
  */
 export function updateGrammarStarHighWater({
   learnerId,
+  monsterId,
   conceptId,
   computedStars,
   gameStateRepository,
@@ -501,86 +508,56 @@ export function updateGrammarStarHighWater({
   const stars = Math.max(0, Math.floor(Number(computedStars) || 0));
   if (stars < 1) return [];
 
-  const directMonsterId = monsterIdForGrammarConcept(conceptId);
+  // Resolve the target monster. When monsterId is provided, use it directly.
+  // Fall back to the direct monster for the concept (backward compat).
+  const targetMonsterId = monsterId || monsterIdForGrammarConcept(conceptId) || GRAMMAR_GRAND_MONSTER_ID;
+
   const before = ensureMonsterBranches(learnerId, gameStateRepository, {
     random,
     monsterIds: GRAMMAR_MONSTER_IDS,
   });
 
-  const events = [];
-  const after = { ...before };
+  const entry = isPlainObject(before[targetMonsterId])
+    ? before[targetMonsterId]
+    : { mastered: [], caught: false };
+  const existingHW = safeStarHighWater(entry.starHighWater);
+  if (stars <= existingHW) {
+    // No change needed — existing high-water already covers this update.
+    return [];
+  }
 
-  // Helper: latch starHighWater on a single monster entry. Returns true if
-  // the monster was newly caught (Stars >= 1 and was not caught before).
-  function latchMonster(monsterId) {
-    const entry = isPlainObject(before[monsterId])
-      ? before[monsterId]
-      : { mastered: [], caught: false };
-    const existingHW = safeStarHighWater(entry.starHighWater);
-    if (stars <= existingHW) {
-      // No change needed — existing high-water already covers this update.
-      return false;
-    }
-    const wasCaught = entry.caught === true;
-    const nowCaught = wasCaught || stars >= 1;
-    const total = grammarMonsterConceptTotal(monsterId);
-    after[monsterId] = {
+  const wasCaught = entry.caught === true;
+  const nowCaught = wasCaught || stars >= 1;
+  const total = grammarMonsterConceptTotal(targetMonsterId);
+  const after = {
+    ...before,
+    [targetMonsterId]: {
       ...entry,
       caught: nowCaught,
       conceptTotal: total,
       starHighWater: Math.min(GRAMMAR_MONSTER_STAR_MAX, stars),
-    };
-    return !wasCaught && nowCaught;
-  }
+    },
+  };
 
-  let anyChange = false;
+  saveMonsterState(learnerId, after, gameStateRepository);
 
-  // Update Concordium (aggregate).
-  const concordiumNewlyCaught = latchMonster(GRAMMAR_GRAND_MONSTER_ID);
-  if (after[GRAMMAR_GRAND_MONSTER_ID] !== before[GRAMMAR_GRAND_MONSTER_ID]) anyChange = true;
-  if (concordiumNewlyCaught) {
-    const beforeProgress = progressForGrammarMonster(before, GRAMMAR_GRAND_MONSTER_ID, {
-      conceptTotal: GRAMMAR_AGGREGATE_CONCEPTS.length,
+  const events = [];
+  if (!wasCaught && nowCaught) {
+    const beforeProgress = progressForGrammarMonster(before, targetMonsterId, {
+      conceptTotal: total,
     });
-    const afterProgress = progressForGrammarMonster(after, GRAMMAR_GRAND_MONSTER_ID, {
-      conceptTotal: GRAMMAR_AGGREGATE_CONCEPTS.length,
+    const afterProgress = progressForGrammarMonster(after, targetMonsterId, {
+      conceptTotal: total,
     });
     const ev = grammarEventFromTransition({
       learnerId,
-      monsterId: GRAMMAR_GRAND_MONSTER_ID,
+      monsterId: targetMonsterId,
       releaseId: GRAMMAR_REWARD_RELEASE_ID,
       conceptId,
       masteryKey: grammarMasteryKey(conceptId),
       createdAt: Date.now(),
     }, beforeProgress, afterProgress);
     if (ev) events.push(ev);
-  }
-
-  // Update direct monster (if any).
-  if (directMonsterId) {
-    const directNewlyCaught = latchMonster(directMonsterId);
-    if (after[directMonsterId] !== before[directMonsterId]) anyChange = true;
-    if (directNewlyCaught) {
-      const beforeProgress = progressForGrammarMonster(before, directMonsterId, {
-        conceptTotal: grammarMonsterConceptTotal(directMonsterId),
-      });
-      const afterProgress = progressForGrammarMonster(after, directMonsterId, {
-        conceptTotal: grammarMonsterConceptTotal(directMonsterId),
-      });
-      const ev = grammarEventFromTransition({
-        learnerId,
-        monsterId: directMonsterId,
-        releaseId: GRAMMAR_REWARD_RELEASE_ID,
-        conceptId,
-        masteryKey: grammarMasteryKey(conceptId),
-        createdAt: Date.now(),
-      }, beforeProgress, afterProgress);
-      if (ev) events.push(ev);
-    }
-  }
-
-  if (anyChange) {
-    saveMonsterState(learnerId, after, gameStateRepository);
   }
 
   return events;

--- a/src/platform/game/mastery/grammar.js
+++ b/src/platform/game/mastery/grammar.js
@@ -477,6 +477,115 @@ export function recordGrammarConceptMastery({
   return events;
 }
 
+/**
+ * Lightweight latch-write for sub-secure Star evidence.
+ *
+ * Updates `starHighWater = max(existing, computedStars)` on the direct monster
+ * and Concordium without touching the `mastered[]` array (that stays exclusive
+ * to concept-secured via `recordGrammarConceptMastery`).
+ *
+ * Sets `caught: true` if Stars >= 1 and was previously false on either
+ * monster, emitting a `caught` reward event for each newly-caught monster.
+ *
+ * Returns an array of reward events (caught events for monsters that newly
+ * crossed the threshold, otherwise empty).
+ */
+export function updateGrammarStarHighWater({
+  learnerId,
+  conceptId,
+  computedStars,
+  gameStateRepository,
+  random = Math.random,
+} = {}) {
+  if (!GRAMMAR_AGGREGATE_CONCEPTS.includes(conceptId)) return [];
+  const stars = Math.max(0, Math.floor(Number(computedStars) || 0));
+  if (stars < 1) return [];
+
+  const directMonsterId = monsterIdForGrammarConcept(conceptId);
+  const before = ensureMonsterBranches(learnerId, gameStateRepository, {
+    random,
+    monsterIds: GRAMMAR_MONSTER_IDS,
+  });
+
+  const events = [];
+  const after = { ...before };
+
+  // Helper: latch starHighWater on a single monster entry. Returns true if
+  // the monster was newly caught (Stars >= 1 and was not caught before).
+  function latchMonster(monsterId) {
+    const entry = isPlainObject(before[monsterId])
+      ? before[monsterId]
+      : { mastered: [], caught: false };
+    const existingHW = safeStarHighWater(entry.starHighWater);
+    if (stars <= existingHW) {
+      // No change needed — existing high-water already covers this update.
+      return false;
+    }
+    const wasCaught = entry.caught === true;
+    const nowCaught = wasCaught || stars >= 1;
+    const total = grammarMonsterConceptTotal(monsterId);
+    after[monsterId] = {
+      ...entry,
+      caught: nowCaught,
+      conceptTotal: total,
+      starHighWater: Math.min(GRAMMAR_MONSTER_STAR_MAX, stars),
+    };
+    return !wasCaught && nowCaught;
+  }
+
+  let anyChange = false;
+
+  // Update Concordium (aggregate).
+  const concordiumNewlyCaught = latchMonster(GRAMMAR_GRAND_MONSTER_ID);
+  if (after[GRAMMAR_GRAND_MONSTER_ID] !== before[GRAMMAR_GRAND_MONSTER_ID]) anyChange = true;
+  if (concordiumNewlyCaught) {
+    const beforeProgress = progressForGrammarMonster(before, GRAMMAR_GRAND_MONSTER_ID, {
+      conceptTotal: GRAMMAR_AGGREGATE_CONCEPTS.length,
+    });
+    const afterProgress = progressForGrammarMonster(after, GRAMMAR_GRAND_MONSTER_ID, {
+      conceptTotal: GRAMMAR_AGGREGATE_CONCEPTS.length,
+    });
+    const ev = grammarEventFromTransition({
+      learnerId,
+      monsterId: GRAMMAR_GRAND_MONSTER_ID,
+      releaseId: GRAMMAR_REWARD_RELEASE_ID,
+      conceptId,
+      masteryKey: grammarMasteryKey(conceptId),
+      createdAt: Date.now(),
+    }, beforeProgress, afterProgress);
+    if (ev) events.push(ev);
+  }
+
+  // Update direct monster (if any).
+  if (directMonsterId) {
+    const directNewlyCaught = latchMonster(directMonsterId);
+    if (after[directMonsterId] !== before[directMonsterId]) anyChange = true;
+    if (directNewlyCaught) {
+      const beforeProgress = progressForGrammarMonster(before, directMonsterId, {
+        conceptTotal: grammarMonsterConceptTotal(directMonsterId),
+      });
+      const afterProgress = progressForGrammarMonster(after, directMonsterId, {
+        conceptTotal: grammarMonsterConceptTotal(directMonsterId),
+      });
+      const ev = grammarEventFromTransition({
+        learnerId,
+        monsterId: directMonsterId,
+        releaseId: GRAMMAR_REWARD_RELEASE_ID,
+        conceptId,
+        masteryKey: grammarMasteryKey(conceptId),
+        createdAt: Date.now(),
+      }, beforeProgress, afterProgress);
+      if (ev) events.push(ev);
+    }
+  }
+
+  if (anyChange) {
+    saveMonsterState(learnerId, after, gameStateRepository);
+  }
+
+  return events;
+}
+
 export function activeGrammarMonsterSummaryFromState(state = {}) {
   return grammarMonsterSummaryFromState(state)
     .filter((entry) => entry.progress.caught || entry.progress.mastered > 0);

--- a/src/platform/game/mastery/index.js
+++ b/src/platform/game/mastery/index.js
@@ -34,6 +34,7 @@ export {
   normaliseGrammarRewardState,
   progressForGrammarMonster,
   recordGrammarConceptMastery,
+  updateGrammarStarHighWater,
 } from './grammar.js';
 export {
   GRAMMAR_GRAND_MONSTER_ID,

--- a/src/subjects/grammar/event-hooks.js
+++ b/src/subjects/grammar/event-hooks.js
@@ -2,10 +2,8 @@ import {
   GRAMMAR_REWARD_RELEASE_ID,
   grammarMasteryKey,
   recordGrammarConceptMastery,
-} from '../../platform/game/monster-system.js';
-import {
   updateGrammarStarHighWater,
-} from '../../platform/game/mastery/grammar.js';
+} from '../../platform/game/monster-system.js';
 
 export const GRAMMAR_EVENT_TYPES = Object.freeze({
   CONCEPT_SECURED: 'grammar.concept-secured',
@@ -47,6 +45,7 @@ export function createGrammarRewardSubscriber({
         rewardEvents.push(
           ...updateGrammarStarHighWater({
             learnerId: event.learnerId,
+            monsterId: event.monsterId,
             conceptId,
             computedStars,
             gameStateRepository,

--- a/src/subjects/grammar/event-hooks.js
+++ b/src/subjects/grammar/event-hooks.js
@@ -3,9 +3,13 @@ import {
   grammarMasteryKey,
   recordGrammarConceptMastery,
 } from '../../platform/game/monster-system.js';
+import {
+  updateGrammarStarHighWater,
+} from '../../platform/game/mastery/grammar.js';
 
 export const GRAMMAR_EVENT_TYPES = Object.freeze({
   CONCEPT_SECURED: 'grammar.concept-secured',
+  STAR_EVIDENCE_UPDATED: 'grammar.star-evidence-updated',
 });
 
 export function createGrammarRewardSubscriber({
@@ -15,22 +19,42 @@ export function createGrammarRewardSubscriber({
   return function grammarRewardSubscriber(events = []) {
     const rewardEvents = [];
     for (const event of Array.isArray(events) ? events : []) {
-      if (!event || event.type !== GRAMMAR_EVENT_TYPES.CONCEPT_SECURED) continue;
-      const conceptId = typeof event.conceptId === 'string' ? event.conceptId : '';
-      const releaseId = typeof event.contentReleaseId === 'string' && event.contentReleaseId
-        ? event.contentReleaseId
-        : GRAMMAR_REWARD_RELEASE_ID;
-      rewardEvents.push(
-        ...recordGrammarConceptMastery({
-          learnerId: event.learnerId,
-          conceptId,
-          releaseId,
-          masteryKey: event.masteryKey || grammarMasteryKey(conceptId, releaseId),
-          createdAt: event.createdAt,
-          gameStateRepository,
-          random,
-        }),
-      );
+      if (!event) continue;
+
+      if (event.type === GRAMMAR_EVENT_TYPES.CONCEPT_SECURED) {
+        const conceptId = typeof event.conceptId === 'string' ? event.conceptId : '';
+        const releaseId = typeof event.contentReleaseId === 'string' && event.contentReleaseId
+          ? event.contentReleaseId
+          : GRAMMAR_REWARD_RELEASE_ID;
+        rewardEvents.push(
+          ...recordGrammarConceptMastery({
+            learnerId: event.learnerId,
+            conceptId,
+            releaseId,
+            masteryKey: event.masteryKey || grammarMasteryKey(conceptId, releaseId),
+            createdAt: event.createdAt,
+            gameStateRepository,
+            random,
+          }),
+        );
+        continue;
+      }
+
+      if (event.type === GRAMMAR_EVENT_TYPES.STAR_EVIDENCE_UPDATED) {
+        const conceptId = typeof event.conceptId === 'string' ? event.conceptId : '';
+        const computedStars = Number(event.computedStars);
+        if (!conceptId || !Number.isFinite(computedStars) || computedStars < 1) continue;
+        rewardEvents.push(
+          ...updateGrammarStarHighWater({
+            learnerId: event.learnerId,
+            conceptId,
+            computedStars,
+            gameStateRepository,
+            random,
+          }),
+        );
+        continue;
+      }
     }
     return rewardEvents;
   };

--- a/tests/grammar-star-persistence.test.js
+++ b/tests/grammar-star-persistence.test.js
@@ -1,0 +1,478 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  rewardEventsFromGrammarEvents,
+  GRAMMAR_EVENT_TYPES,
+} from '../src/subjects/grammar/event-hooks.js';
+import {
+  GRAMMAR_AGGREGATE_CONCEPTS,
+  GRAMMAR_REWARD_RELEASE_ID,
+  grammarMasteryKey,
+  progressForGrammarMonster,
+  recordGrammarConceptMastery,
+  updateGrammarStarHighWater,
+} from '../src/platform/game/monster-system.js';
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function makeRepository(initialState = {}) {
+  let state = clone(initialState);
+  let writes = 0;
+  return {
+    read() {
+      return clone(state);
+    },
+    write(_learnerId, _systemId, nextState) {
+      writes += 1;
+      state = clone(nextState);
+      return clone(state);
+    },
+    state() {
+      return clone(state);
+    },
+    writes() {
+      return writes;
+    },
+  };
+}
+
+function starEvidenceEvent(conceptId, computedStars, overrides = {}) {
+  return {
+    id: `grammar.star-evidence.learner-a.${conceptId}.${Date.now()}`,
+    type: GRAMMAR_EVENT_TYPES.STAR_EVIDENCE_UPDATED,
+    subjectId: 'grammar',
+    learnerId: 'learner-a',
+    conceptId,
+    monsterId: overrides.monsterId || 'bracehart',
+    computedStars,
+    previousStarHighWater: overrides.previousStarHighWater || 0,
+    createdAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function securedEvent(conceptId, overrides = {}) {
+  return {
+    id: `grammar.secured.learner-a.${conceptId}.request-1`,
+    type: GRAMMAR_EVENT_TYPES.CONCEPT_SECURED,
+    subjectId: 'grammar',
+    learnerId: 'learner-a',
+    contentReleaseId: GRAMMAR_REWARD_RELEASE_ID,
+    conceptId,
+    masteryKey: grammarMasteryKey(conceptId),
+    createdAt: 1,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Happy path: first independent correct -> star-evidence-updated fires ->
+// starHighWater = 1 -> Egg caught
+// ---------------------------------------------------------------------------
+
+test('star-evidence-updated with computedStars=1 sets starHighWater=1 and marks Egg caught on direct + Concordium', () => {
+  const repository = makeRepository();
+
+  const events = rewardEventsFromGrammarEvents([
+    starEvidenceEvent('sentence_functions', 1),
+  ], {
+    gameStateRepository: repository,
+    random: () => 0,
+  });
+
+  const state = repository.state();
+
+  // Bracehart (direct monster for sentence_functions) should have
+  // starHighWater=1 and caught=true.
+  assert.ok(state.bracehart, 'Bracehart entry exists');
+  assert.equal(state.bracehart.caught, true, 'Bracehart caught');
+  assert.equal(state.bracehart.starHighWater, 1, 'Bracehart starHighWater is 1');
+
+  // Concordium (aggregate) should also be caught with starHighWater=1.
+  assert.ok(state.concordium, 'Concordium entry exists');
+  assert.equal(state.concordium.caught, true, 'Concordium caught');
+  assert.equal(state.concordium.starHighWater, 1, 'Concordium starHighWater is 1');
+
+  // Reward events should include caught events.
+  assert.equal(
+    events.some((e) => e.monsterId === 'bracehart' && e.kind === 'caught'),
+    true,
+    'Bracehart caught event emitted',
+  );
+  assert.equal(
+    events.some((e) => e.monsterId === 'concordium' && e.kind === 'caught'),
+    true,
+    'Concordium caught event emitted',
+  );
+
+  // mastered[] must remain empty (exclusive to concept-secured).
+  assert.deepEqual(state.bracehart.mastered || [], [], 'mastered[] untouched on Bracehart');
+  assert.deepEqual(state.concordium.mastered || [], [], 'mastered[] untouched on Concordium');
+});
+
+// ---------------------------------------------------------------------------
+// Happy path: subsequent correct -> starHighWater updated, no duplicate caught
+// ---------------------------------------------------------------------------
+
+test('subsequent star-evidence-updated raises starHighWater without re-emitting caught', () => {
+  const repository = makeRepository({
+    bracehart: { caught: true, starHighWater: 1, mastered: [] },
+    concordium: { caught: true, starHighWater: 1, mastered: [] },
+  });
+
+  const events = rewardEventsFromGrammarEvents([
+    starEvidenceEvent('sentence_functions', 3),
+  ], {
+    gameStateRepository: repository,
+    random: () => 0,
+  });
+
+  const state = repository.state();
+
+  assert.equal(state.bracehart.starHighWater, 3, 'Bracehart starHighWater raised to 3');
+  assert.equal(state.concordium.starHighWater, 3, 'Concordium starHighWater raised to 3');
+
+  // No caught event because both were already caught.
+  assert.equal(
+    events.some((e) => e.kind === 'caught'),
+    false,
+    'No duplicate caught events',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Happy path: concept-secured fires later -> full recordGrammarConceptMastery
+// -> starHighWater updated further
+// ---------------------------------------------------------------------------
+
+test('concept-secured after star-evidence-updated updates mastered[] and preserves starHighWater', () => {
+  const repository = makeRepository({
+    bracehart: { caught: true, starHighWater: 5, mastered: [] },
+    concordium: { caught: true, starHighWater: 5, mastered: [] },
+  });
+
+  const events = rewardEventsFromGrammarEvents([
+    securedEvent('sentence_functions'),
+  ], {
+    gameStateRepository: repository,
+    random: () => 0,
+  });
+
+  const state = repository.state();
+
+  // mastered[] should now contain the secured concept.
+  const key = grammarMasteryKey('sentence_functions');
+  assert.ok(
+    state.bracehart.mastered.includes(key),
+    'Bracehart mastered[] updated with the secured concept',
+  );
+  assert.ok(
+    state.concordium.mastered.includes(key),
+    'Concordium mastered[] updated with the secured concept',
+  );
+
+  // starHighWater should be preserved (seedStarHighWater preserves existing value).
+  assert.ok(
+    state.bracehart.starHighWater >= 5,
+    'Bracehart starHighWater preserved after concept-secured',
+  );
+  assert.ok(
+    state.concordium.starHighWater >= 5,
+    'Concordium starHighWater preserved after concept-secured',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Edge case: star-evidence-updated but Stars <= existing starHighWater -> no-op
+// ---------------------------------------------------------------------------
+
+test('star-evidence-updated with Stars <= existing starHighWater is a no-op', () => {
+  // Seed valid branches so ensureMonsterBranches does not trigger a write.
+  const repository = makeRepository({
+    bracehart: { caught: true, starHighWater: 10, mastered: [], branch: 'b1' },
+    chronalyx: { branch: 'b1' },
+    couronnail: { branch: 'b1' },
+    concordium: { caught: true, starHighWater: 10, mastered: [], branch: 'b1' },
+  });
+  const writesBefore = repository.writes();
+
+  const events = rewardEventsFromGrammarEvents([
+    starEvidenceEvent('sentence_functions', 5),
+  ], {
+    gameStateRepository: repository,
+    random: () => 0,
+  });
+
+  const state = repository.state();
+
+  // starHighWater must not decrease.
+  assert.equal(state.bracehart.starHighWater, 10, 'Bracehart starHighWater unchanged');
+  assert.equal(state.concordium.starHighWater, 10, 'Concordium starHighWater unchanged');
+
+  // No reward events emitted.
+  assert.deepEqual(events, [], 'No events for a no-op latch');
+
+  // No write to the repository (state unchanged).
+  assert.equal(repository.writes(), writesBefore, 'Repository not written for no-op');
+});
+
+// ---------------------------------------------------------------------------
+// Edge case: wrong answer, Writing Try, AI explanation -> no event, 0 persistence
+// ---------------------------------------------------------------------------
+
+test('non-scored events (transfer-save, misconception-seen, session-completed) produce zero starHighWater writes', () => {
+  const repository = makeRepository();
+
+  const events = rewardEventsFromGrammarEvents([
+    {
+      type: 'grammar.transfer-evidence-saved',
+      subjectId: 'grammar',
+      learnerId: 'learner-a',
+      promptId: 'test-prompt',
+      nonScored: true,
+      createdAt: 1,
+    },
+    {
+      type: 'grammar.misconception-seen',
+      subjectId: 'grammar',
+      learnerId: 'learner-a',
+      conceptIds: ['sentence_functions'],
+      createdAt: 1,
+    },
+    {
+      type: 'grammar.session-completed',
+      subjectId: 'grammar',
+      learnerId: 'learner-a',
+      sessionId: 'test-session',
+      createdAt: 1,
+    },
+  ], {
+    gameStateRepository: repository,
+    random: () => 0,
+  });
+
+  assert.deepEqual(events, [], 'No reward events from non-scored domain events');
+  assert.equal(repository.writes(), 0, 'Zero writes from non-scored events');
+});
+
+// ---------------------------------------------------------------------------
+// Edge case: star-evidence-updated with computedStars=0 -> no persistence
+// ---------------------------------------------------------------------------
+
+test('star-evidence-updated with computedStars=0 is silently ignored', () => {
+  const repository = makeRepository();
+
+  const events = rewardEventsFromGrammarEvents([
+    starEvidenceEvent('sentence_functions', 0),
+  ], {
+    gameStateRepository: repository,
+    random: () => 0,
+  });
+
+  assert.deepEqual(events, [], 'No events for 0 Stars');
+  assert.equal(repository.writes(), 0, 'No writes for 0 Stars');
+});
+
+// ---------------------------------------------------------------------------
+// Edge case: invalid conceptId -> rejected (no crash, no write)
+// ---------------------------------------------------------------------------
+
+test('star-evidence-updated with invalid conceptId is silently rejected', () => {
+  const repository = makeRepository();
+
+  const events = rewardEventsFromGrammarEvents([
+    starEvidenceEvent('not_a_real_concept', 5),
+  ], {
+    gameStateRepository: repository,
+    random: () => 0,
+  });
+
+  assert.deepEqual(events, [], 'No events for invalid concept');
+  assert.equal(repository.writes(), 0, 'No writes for invalid concept');
+});
+
+// ---------------------------------------------------------------------------
+// Integration: session ends, recentAttempts truncation -> starHighWater persists
+// ---------------------------------------------------------------------------
+
+test('starHighWater survives recentAttempts truncation: stored value persists across reads', () => {
+  const repository = makeRepository();
+
+  // Step 1: earn Stars via star-evidence-updated.
+  rewardEventsFromGrammarEvents([
+    starEvidenceEvent('sentence_functions', 5),
+  ], {
+    gameStateRepository: repository,
+    random: () => 0,
+  });
+
+  const stateAfterEvidence = repository.state();
+  assert.equal(stateAfterEvidence.bracehart.starHighWater, 5, 'starHighWater set to 5');
+
+  // Step 2: simulate recentAttempts being truncated (they live in the engine
+  // state, not in the monster-codex). The monster-codex state is independent.
+  // Read the monster state again — starHighWater must persist.
+  const freshRead = repository.read();
+  assert.equal(freshRead.bracehart.starHighWater, 5, 'starHighWater survives across reads');
+
+  // Step 3: another star-evidence-updated at a lower value must not decrease.
+  rewardEventsFromGrammarEvents([
+    starEvidenceEvent('sentence_functions', 2),
+  ], {
+    gameStateRepository: repository,
+    random: () => 0,
+  });
+  assert.equal(repository.state().bracehart.starHighWater, 5, 'starHighWater never decreases');
+});
+
+// ---------------------------------------------------------------------------
+// Direct function: updateGrammarStarHighWater works correctly
+// ---------------------------------------------------------------------------
+
+test('updateGrammarStarHighWater directly latches starHighWater on direct + Concordium', () => {
+  const repository = makeRepository();
+
+  const events = updateGrammarStarHighWater({
+    learnerId: 'learner-a',
+    conceptId: 'tense_aspect',
+    computedStars: 3,
+    gameStateRepository: repository,
+    random: () => 0,
+  });
+
+  const state = repository.state();
+
+  // Chronalyx is the direct monster for tense_aspect.
+  assert.ok(state.chronalyx, 'Chronalyx entry exists');
+  assert.equal(state.chronalyx.caught, true, 'Chronalyx caught');
+  assert.equal(state.chronalyx.starHighWater, 3, 'Chronalyx starHighWater=3');
+
+  assert.ok(state.concordium, 'Concordium entry exists');
+  assert.equal(state.concordium.caught, true, 'Concordium caught');
+  assert.equal(state.concordium.starHighWater, 3, 'Concordium starHighWater=3');
+
+  // caught events emitted for both.
+  assert.equal(
+    events.some((e) => e.monsterId === 'chronalyx' && e.kind === 'caught'),
+    true,
+    'Chronalyx caught event',
+  );
+  assert.equal(
+    events.some((e) => e.monsterId === 'concordium' && e.kind === 'caught'),
+    true,
+    'Concordium caught event',
+  );
+});
+
+test('updateGrammarStarHighWater returns empty for an invalid concept', () => {
+  const repository = makeRepository();
+  const events = updateGrammarStarHighWater({
+    learnerId: 'learner-a',
+    conceptId: 'invalid_concept',
+    computedStars: 5,
+    gameStateRepository: repository,
+    random: () => 0,
+  });
+  assert.deepEqual(events, [], 'Empty events for invalid concept');
+  assert.equal(repository.writes(), 0, 'No writes for invalid concept');
+});
+
+test('updateGrammarStarHighWater returns empty when computedStars < 1', () => {
+  const repository = makeRepository();
+  const events = updateGrammarStarHighWater({
+    learnerId: 'learner-a',
+    conceptId: 'sentence_functions',
+    computedStars: 0,
+    gameStateRepository: repository,
+    random: () => 0,
+  });
+  assert.deepEqual(events, [], 'Empty events for 0 Stars');
+});
+
+// ---------------------------------------------------------------------------
+// Punctuation-for-grammar concepts: Concordium only, no direct monster
+// ---------------------------------------------------------------------------
+
+test('star-evidence-updated for punctuation-for-grammar concept updates only Concordium', () => {
+  const repository = makeRepository();
+
+  const events = rewardEventsFromGrammarEvents([
+    starEvidenceEvent('speech_punctuation', 2, { monsterId: 'concordium' }),
+  ], {
+    gameStateRepository: repository,
+    random: () => 0,
+  });
+
+  const state = repository.state();
+
+  // Concordium should be updated.
+  assert.ok(state.concordium, 'Concordium entry exists');
+  assert.equal(state.concordium.caught, true, 'Concordium caught');
+  assert.equal(state.concordium.starHighWater, 2, 'Concordium starHighWater=2');
+
+  // No Quoral or other punctuation monster touched.
+  assert.equal(state.quoral, undefined, 'Quoral not created');
+
+  // Caught event for Concordium only.
+  assert.equal(
+    events.some((e) => e.monsterId === 'concordium' && e.kind === 'caught'),
+    true,
+    'Concordium caught event emitted',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Mixed event stream: both star-evidence-updated and concept-secured
+// ---------------------------------------------------------------------------
+
+test('mixed event stream processes both star-evidence-updated and concept-secured correctly', () => {
+  const repository = makeRepository();
+
+  const events = rewardEventsFromGrammarEvents([
+    // Star evidence arrives first (from an earlier answer in the same command batch).
+    starEvidenceEvent('clauses', 2),
+    // Concept secured follows (the concept just crossed the secure threshold).
+    securedEvent('clauses'),
+  ], {
+    gameStateRepository: repository,
+    random: () => 0,
+  });
+
+  const state = repository.state();
+
+  // mastered[] should have the secured concept from concept-secured.
+  const key = grammarMasteryKey('clauses');
+  assert.ok(
+    state.bracehart.mastered.includes(key),
+    'mastered[] updated from concept-secured',
+  );
+
+  // starHighWater should be at least 2 from the star-evidence-updated.
+  assert.ok(
+    state.bracehart.starHighWater >= 2,
+    'starHighWater latched from star-evidence-updated',
+  );
+
+  // Both caught events should fire (from star-evidence-updated, concept-secured
+  // may also contribute but the important thing is no crash).
+  assert.equal(
+    events.some((e) => e.monsterId === 'bracehart' && e.kind === 'caught'),
+    true,
+    'Bracehart caught event',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// GRAMMAR_EVENT_TYPES export includes STAR_EVIDENCE_UPDATED
+// ---------------------------------------------------------------------------
+
+test('GRAMMAR_EVENT_TYPES includes STAR_EVIDENCE_UPDATED', () => {
+  assert.equal(
+    GRAMMAR_EVENT_TYPES.STAR_EVIDENCE_UPDATED,
+    'grammar.star-evidence-updated',
+    'Event type constant is correct',
+  );
+});

--- a/tests/grammar-star-persistence.test.js
+++ b/tests/grammar-star-persistence.test.js
@@ -73,11 +73,14 @@ function securedEvent(conceptId, overrides = {}) {
 // starHighWater = 1 -> Egg caught
 // ---------------------------------------------------------------------------
 
-test('star-evidence-updated with computedStars=1 sets starHighWater=1 and marks Egg caught on direct + Concordium', () => {
+test('star-evidence-updated with computedStars=1 sets starHighWater=1 and marks Egg caught on the specified monster only', () => {
   const repository = makeRepository();
 
+  // Each star-evidence-updated event targets a single monster. The command
+  // handler emits one per monster with monster-specific computedStars.
   const events = rewardEventsFromGrammarEvents([
-    starEvidenceEvent('sentence_functions', 1),
+    starEvidenceEvent('sentence_functions', 1, { monsterId: 'bracehart' }),
+    starEvidenceEvent('sentence_functions', 1, { monsterId: 'concordium' }),
   ], {
     gameStateRepository: repository,
     random: () => 0,
@@ -124,7 +127,8 @@ test('subsequent star-evidence-updated raises starHighWater without re-emitting 
   });
 
   const events = rewardEventsFromGrammarEvents([
-    starEvidenceEvent('sentence_functions', 3),
+    starEvidenceEvent('sentence_functions', 3, { monsterId: 'bracehart' }),
+    starEvidenceEvent('sentence_functions', 3, { monsterId: 'concordium' }),
   ], {
     gameStateRepository: repository,
     random: () => 0,
@@ -332,11 +336,23 @@ test('starHighWater survives recentAttempts truncation: stored value persists ac
 // Direct function: updateGrammarStarHighWater works correctly
 // ---------------------------------------------------------------------------
 
-test('updateGrammarStarHighWater directly latches starHighWater on direct + Concordium', () => {
+test('updateGrammarStarHighWater directly latches starHighWater on specified monster only', () => {
   const repository = makeRepository();
 
-  const events = updateGrammarStarHighWater({
+  // Call once for the direct monster.
+  const directEvents = updateGrammarStarHighWater({
     learnerId: 'learner-a',
+    monsterId: 'chronalyx',
+    conceptId: 'tense_aspect',
+    computedStars: 3,
+    gameStateRepository: repository,
+    random: () => 0,
+  });
+
+  // Call again for Concordium.
+  const aggregateEvents = updateGrammarStarHighWater({
+    learnerId: 'learner-a',
+    monsterId: 'concordium',
     conceptId: 'tense_aspect',
     computedStars: 3,
     gameStateRepository: repository,
@@ -354,14 +370,14 @@ test('updateGrammarStarHighWater directly latches starHighWater on direct + Conc
   assert.equal(state.concordium.caught, true, 'Concordium caught');
   assert.equal(state.concordium.starHighWater, 3, 'Concordium starHighWater=3');
 
-  // caught events emitted for both.
+  // caught events emitted from each call.
   assert.equal(
-    events.some((e) => e.monsterId === 'chronalyx' && e.kind === 'caught'),
+    directEvents.some((e) => e.monsterId === 'chronalyx' && e.kind === 'caught'),
     true,
     'Chronalyx caught event',
   );
   assert.equal(
-    events.some((e) => e.monsterId === 'concordium' && e.kind === 'caught'),
+    aggregateEvents.some((e) => e.monsterId === 'concordium' && e.kind === 'caught'),
     true,
     'Concordium caught event',
   );
@@ -432,10 +448,10 @@ test('mixed event stream processes both star-evidence-updated and concept-secure
   const repository = makeRepository();
 
   const events = rewardEventsFromGrammarEvents([
-    // Star evidence arrives first (from an earlier answer in the same command batch).
-    starEvidenceEvent('clauses', 2),
-    // Concept secured follows (the concept just crossed the secure threshold).
+    // Concept secured fires first (in result.events from the command handler).
     securedEvent('clauses'),
+    // Star evidence appended after result.events by the command handler.
+    starEvidenceEvent('clauses', 2),
   ], {
     gameStateRepository: repository,
     random: () => 0,
@@ -458,6 +474,48 @@ test('mixed event stream processes both star-evidence-updated and concept-secure
 
   // Both caught events should fire (from star-evidence-updated, concept-secured
   // may also contribute but the important thing is no crash).
+  assert.equal(
+    events.some((e) => e.monsterId === 'bracehart' && e.kind === 'caught'),
+    true,
+    'Bracehart caught event',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// ADV-001 regression: no cross-inflation between monsters from the same concept
+// ---------------------------------------------------------------------------
+
+test('different computedStars per monster do not cross-inflate starHighWater', () => {
+  const repository = makeRepository();
+
+  // The command handler emits two star-evidence-updated events for the same
+  // concept but with different computedStars per monster. Concordium (18
+  // concepts) earns fewer Stars than Bracehart (6 concepts) because the
+  // per-concept budget is spread across more concepts.
+  const events = rewardEventsFromGrammarEvents([
+    starEvidenceEvent('sentence_functions', 1, { monsterId: 'concordium' }),
+    starEvidenceEvent('sentence_functions', 4, { monsterId: 'bracehart' }),
+  ], {
+    gameStateRepository: repository,
+    random: () => 0,
+  });
+
+  const state = repository.state();
+
+  // Concordium must have starHighWater=1, NOT 4.
+  assert.equal(state.concordium.starHighWater, 1, 'Concordium starHighWater is 1 (not inflated to 4)');
+  assert.equal(state.concordium.caught, true, 'Concordium caught');
+
+  // Bracehart must have starHighWater=4.
+  assert.equal(state.bracehart.starHighWater, 4, 'Bracehart starHighWater is 4');
+  assert.equal(state.bracehart.caught, true, 'Bracehart caught');
+
+  // Both caught events emitted.
+  assert.equal(
+    events.some((e) => e.monsterId === 'concordium' && e.kind === 'caught'),
+    true,
+    'Concordium caught event',
+  );
   assert.equal(
     events.some((e) => e.monsterId === 'bracehart' && e.kind === 'caught'),
     true,

--- a/worker/src/subjects/grammar/commands.js
+++ b/worker/src/subjects/grammar/commands.js
@@ -5,6 +5,17 @@ import { projectGrammarRewards } from '../../projections/rewards.js';
 import { createServerGrammarEngine } from './engine.js';
 import { buildGrammarReadModel } from './read-models.js';
 import { resolveProjectionInput } from '../projection-input.js';
+import {
+  deriveGrammarConceptStarEvidence,
+  computeGrammarMonsterStars,
+} from '../../../../shared/grammar/grammar-stars.js';
+import { GRAMMAR_EVENT_TYPES } from '../../../../src/subjects/grammar/event-hooks.js';
+import {
+  GRAMMAR_AGGREGATE_CONCEPTS,
+  GRAMMAR_MONSTER_CONCEPTS,
+  monsterIdForGrammarConcept,
+} from '../../../../src/platform/game/mastery/grammar.js';
+import { GRAMMAR_GRAND_MONSTER_ID } from '../../../../src/platform/game/mastery/shared.js';
 
 const GRAMMAR_COMMANDS = Object.freeze([
   'start-session',
@@ -23,6 +34,106 @@ const GRAMMAR_COMMANDS = Object.freeze([
   'save-transfer-evidence',
   'reset-learner',
 ]);
+
+/**
+ * Derives star-evidence-updated events for concepts affected by an answer.
+ *
+ * For each concept touched by answer-submitted events, computes Stars from
+ * the post-answer engine state. For each monster whose computed Stars exceed
+ * the current starHighWater from the game state, emits a star-evidence-updated
+ * event that the reward subscriber will handle to persist the latch.
+ *
+ * The engine remains Star-unaware; this derivation happens at the command
+ * handler layer, preserving the P5 architecture boundary.
+ */
+function deriveStarEvidenceEvents({ domainEvents, engineState, learnerId, gameState }) {
+  // Collect concept IDs from answer-submitted events.
+  const answerEvents = domainEvents.filter(
+    (e) => e && e.type === 'grammar.answer-submitted',
+  );
+  if (!answerEvents.length) return [];
+
+  const affectedConceptIds = new Set();
+  for (const event of answerEvents) {
+    const ids = Array.isArray(event.conceptIds) ? event.conceptIds : [];
+    for (const id of ids) {
+      if (GRAMMAR_AGGREGATE_CONCEPTS.includes(id)) affectedConceptIds.add(id);
+    }
+  }
+  if (!affectedConceptIds.size) return [];
+
+  // For each affected concept, derive evidence tiers from the post-answer
+  // engine state.
+  const concepts = engineState?.mastery?.concepts || {};
+  const recentAttempts = Array.isArray(engineState?.recentAttempts)
+    ? engineState.recentAttempts
+    : [];
+
+  // Determine which monsters are affected by the answered concepts.
+  const monsterConceptMap = new Map(); // monsterId → Set<conceptId>
+  for (const conceptId of affectedConceptIds) {
+    // Always add to Concordium.
+    if (!monsterConceptMap.has(GRAMMAR_GRAND_MONSTER_ID)) {
+      monsterConceptMap.set(GRAMMAR_GRAND_MONSTER_ID, new Set());
+    }
+    monsterConceptMap.get(GRAMMAR_GRAND_MONSTER_ID).add(conceptId);
+
+    // Add to direct monster.
+    const directId = monsterIdForGrammarConcept(conceptId);
+    if (directId) {
+      if (!monsterConceptMap.has(directId)) monsterConceptMap.set(directId, new Set());
+      monsterConceptMap.get(directId).add(conceptId);
+    }
+  }
+
+  const starEvents = [];
+  const codexState = gameState || {};
+
+  for (const [monsterId, _affectedConcepts] of monsterConceptMap) {
+    // Compute evidence for ALL concepts of this monster (not just the affected
+    // ones) because computeGrammarMonsterStars aggregates across all concepts.
+    const monsterConceptIds = monsterId === GRAMMAR_GRAND_MONSTER_ID
+      ? GRAMMAR_AGGREGATE_CONCEPTS
+      : (GRAMMAR_MONSTER_CONCEPTS[monsterId] || []);
+
+    const evidenceMap = {};
+    for (const conceptId of monsterConceptIds) {
+      evidenceMap[conceptId] = deriveGrammarConceptStarEvidence({
+        conceptId,
+        conceptNode: concepts[conceptId] || null,
+        recentAttempts,
+      });
+    }
+
+    const starResult = computeGrammarMonsterStars(monsterId, evidenceMap);
+    if (starResult.stars < 1) continue;
+
+    // Read current starHighWater from monster codex state.
+    const monsterEntry = codexState[monsterId];
+    const existingHW = monsterEntry && typeof monsterEntry === 'object'
+      ? Math.max(0, Math.floor(Number(monsterEntry.starHighWater) || 0))
+      : 0;
+
+    if (starResult.stars > existingHW) {
+      // Emit for the first affected concept that maps to this monster.
+      // The subscriber looks up the direct monster from the conceptId.
+      const representativeConcept = [..._affectedConcepts][0];
+      starEvents.push({
+        id: `grammar.star-evidence.${learnerId || 'learner'}.${monsterId}.${Date.now()}`,
+        type: GRAMMAR_EVENT_TYPES.STAR_EVIDENCE_UPDATED,
+        subjectId: 'grammar',
+        learnerId,
+        conceptId: representativeConcept,
+        monsterId,
+        computedStars: starResult.stars,
+        previousStarHighWater: existingHW,
+        createdAt: Date.now(),
+      });
+    }
+  }
+
+  return starEvents;
+}
 
 export function createGrammarCommandHandlers({ now, random } = {}) {
   async function handleGrammarCommand(command, context) {
@@ -67,18 +178,33 @@ export function createGrammarCommandHandlers({ now, random } = {}) {
     const projectionState = projectionInput
       ? projectionInput.projectionState
       : { gameState: null, events: [] };
+    // U4 (Phase 6): derive star-evidence-updated events from the post-answer
+    // engine state. These are injected into the domain event stream before
+    // the reward projection so the subscriber can persist starHighWater at
+    // evidence time rather than deferring to concept-secured.
+    const starEvidenceEvents = result.changed === false
+      ? []
+      : deriveStarEvidenceEvents({
+          domainEvents: result.events,
+          engineState: result.state,
+          learnerId: command.learnerId,
+          gameState: projectionState.gameState?.['monster-codex'] || null,
+        });
+    const allDomainEvents = starEvidenceEvents.length
+      ? [...result.events, ...starEvidenceEvents]
+      : result.events;
     const projectedRewards = result.changed === false
       ? { gameState: projectionState.gameState, changedGameState: null, rewardEvents: [] }
       : projectGrammarRewards({
           learnerId: command.learnerId,
-          domainEvents: result.events,
+          domainEvents: allDomainEvents,
           gameState: projectionState.gameState,
           random,
         });
     const projectedEvents = result.changed === false
       ? { events: [], domainEvents: [], reactionEvents: [], toastEvents: [] }
       : combineCommandEvents({
-          domainEvents: result.events,
+          domainEvents: allDomainEvents,
           reactionEvents: projectedRewards.rewardEvents,
           existingEvents: projectionState.events,
           seedTokens: projectionInput?.tokens || [],


### PR DESCRIPTION
## Summary

- Adds `grammar.star-evidence-updated` event type to `GRAMMAR_EVENT_TYPES` and makes the reward subscriber handle both `concept-secured` and `star-evidence-updated` events
- Adds `updateGrammarStarHighWater()` to `src/platform/game/mastery/grammar.js` — a lightweight latch-write that updates `starHighWater = max(existing, computedStars)` on the direct monster and Concordium, sets `caught: true` if Stars >= 1 and was previously false, and does NOT touch `mastered[]` (exclusive to concept-secured)
- Adds Star evidence derivation in the command handler (`worker/src/subjects/grammar/commands.js`) — after the engine processes an answer, derives Stars from post-answer state and emits `star-evidence-updated` when Stars exceed current `starHighWater`. The engine remains Star-unaware, preserving the P5 architecture boundary.

## Motivation

Phase 5 introduced the 100-Star evidence curve but only persisted `starHighWater` when `concept-secured` fired. A child could earn Stars from sub-secure evidence (e.g. first independent correct -> 1 Star -> Egg), but if the session ended before the concept reached secure status, `recentAttempts` truncation could erase those earned Stars. This closes that gap.

## Test plan

- [x] 14 new tests in `tests/grammar-star-persistence.test.js` — all pass
  - Happy path: first independent correct -> starHighWater=1, Egg caught on direct + Concordium
  - Happy path: subsequent correct -> starHighWater raised, no duplicate caught
  - Happy path: concept-secured fires later -> mastered[] updated, starHighWater preserved
  - Edge case: Stars <= existing starHighWater -> no-op (no write, no events)
  - Edge case: non-scored events (Writing Try, misconception, session-completed) -> 0 writes
  - Edge case: computedStars=0 -> silently ignored
  - Edge case: invalid conceptId -> silently rejected
  - Integration: starHighWater survives recentAttempts truncation across reads
  - Direct function tests for `updateGrammarStarHighWater`
  - Punctuation-for-grammar concept updates only Concordium
  - Mixed event stream (star-evidence-updated + concept-secured) processes correctly
  - Event type constant export verification
- [x] `grammar-rewards.test.js` — 14/14 pass (no regression)
- [x] `grammar-stars.test.js` — 76/76 pass (no regression)

## Plan Deviations

- The plan doc at `docs/plans/2026-04-27-002-feat-grammar-phase6-star-evidence-authority-plan.md` does not exist on main. Implementation was derived from the task description and the Phase 6 contract doc at `docs/plans/james/grammar/grammar-p6.md`.
- The command handler emits one `star-evidence-updated` event per monster (direct + Concordium separately) rather than per concept, because `computeGrammarMonsterStars` aggregates across all concepts in a monster. This is more precise than per-concept emission and avoids redundant subscriber calls.
- `shared/grammar/grammar-stars.js` and `tests/grammar-stars.test.js` are untouched as required (U2/U3 owns those).

## Files changed

| File | Change |
|------|--------|
| `src/subjects/grammar/event-hooks.js` | Add `STAR_EVIDENCE_UPDATED` event type; subscriber handles both event types |
| `src/platform/game/mastery/grammar.js` | Add `updateGrammarStarHighWater()` latch-write function |
| `src/platform/game/mastery/index.js` | Export new function |
| `worker/src/subjects/grammar/commands.js` | Star evidence derivation after engine answer processing |
| `tests/grammar-star-persistence.test.js` | 14 new tests |