### PR TITLE
feat(admin): U10 Asset & Effect Registry UI over Monster Visual Config

### DIFF
--- a/docs/hardening/csp-inline-style-inventory.md
+++ b/docs/hardening/csp-inline-style-inventory.md
@@ -49,26 +49,26 @@ Future migration PRs should:
 
 | Category | Count |
 | --- | --- |
-| `shared-pattern-available` | 152 |
-| `dynamic-content-driven` | 111 |
+| `shared-pattern-available` | 167 |
+| `dynamic-content-driven` | 108 |
 | `css-var-ready` | 3 |
 | `third-party-boundary` | 2 |
-| **TOTAL** | **268** |
+| **TOTAL** | **280** |
 
 ## Per-file inventory
 
 | File | `style={` count | Category | Migrated in SH2-U8 |
 | --- | --- | --- | --- |
-| `src/surfaces/hubs/AdminContentSection.jsx` | 32 | `shared-pattern-available` | no |
+| `src/surfaces/hubs/AdminContentSection.jsx` | 44 | `shared-pattern-available` | no |
 | `src/subjects/punctuation/components/PunctuationSessionScene.jsx` | 27 | `dynamic-content-driven` | no |
 | `src/surfaces/hubs/AdminDebuggingSection.jsx` | 24 | `shared-pattern-available` | no |
 | `src/surfaces/hubs/AdminAccountsSection.jsx` | 21 | `shared-pattern-available` | no |
-| `src/subjects/punctuation/components/PunctuationSummaryScene.jsx` | 19 | `dynamic-content-driven` | no |
+| `src/subjects/punctuation/components/PunctuationSummaryScene.jsx` | 20 | `dynamic-content-driven` | no |
 | `src/surfaces/hubs/MonsterEffectCatalogPanel.jsx` | 19 | `shared-pattern-available` | no |
 | `src/surfaces/hubs/MonsterEffectBindingsPanel.jsx` | 12 | `shared-pattern-available` | no |
-| `src/subjects/spelling/components/SpellingSetupScene.jsx` | 11 | `dynamic-content-driven` | no |
 | `src/surfaces/hubs/MonsterVisualConfigPanel.jsx` | 10 | `dynamic-content-driven` | no |
 | `src/surfaces/hubs/ParentHubSurface.jsx` | 10 | `shared-pattern-available` | no |
+| `src/subjects/spelling/components/SpellingSetupScene.jsx` | 7 | `dynamic-content-driven` | no |
 | `src/surfaces/hubs/AdminHubSurface.jsx` | 7 | `shared-pattern-available` | no |
 | `src/surfaces/hubs/MonsterEffectCelebrationPanel.jsx` | 7 | `shared-pattern-available` | no |
 | `src/surfaces/hubs/AdminOverviewSection.jsx` | 5 | `shared-pattern-available` | no |
@@ -76,11 +76,13 @@ Future migration PRs should:
 | `src/surfaces/subject/SubjectRoute.jsx` | 5 | `dynamic-content-driven` | no |
 | `src/subjects/spelling/components/PatternQuestScene.jsx` | 4 | `dynamic-content-driven` | no |
 | `src/subjects/spelling/components/SpellingSessionScene.jsx` | 4 | `dynamic-content-driven` | no |
+| `src/subjects/punctuation/components/PunctuationSetupScene.jsx` | 3 | `shared-pattern-available` | no |
 | `src/subjects/spelling/components/SpellingSummaryScene.jsx` | 3 | `dynamic-content-driven` | no |
 | `src/surfaces/home/SubjectCard.jsx` | 3 | `dynamic-content-driven` | no |
 | `src/surfaces/hubs/AdminSectionTabs.jsx` | 3 | `shared-pattern-available` | no |
 | `src/surfaces/hubs/MonsterVisualPreviewGrid.jsx` | 3 | `dynamic-content-driven` | no |
 | `src/platform/game/render/effects/celebration-shell.js` | 2 | `third-party-boundary` | no |
+| `src/subjects/grammar/components/GrammarSetupScene.jsx` | 2 | `shared-pattern-available` | no |
 | `src/subjects/spelling/components/SpellingCommon.jsx` | 2 | `css-var-ready` | no |
 | `src/subjects/spelling/components/SpellingWordDetailModal.jsx` | 2 | `dynamic-content-driven` | no |
 | `src/surfaces/home/CodexCard.jsx` | 2 | `dynamic-content-driven` | no |
@@ -93,9 +95,7 @@ Future migration PRs should:
 | `src/platform/game/render/BaseSprite.jsx` | 1 | `dynamic-content-driven` | no |
 | `src/platform/game/render/MonsterRender.jsx` | 1 | `dynamic-content-driven` | no |
 | `src/platform/ui/LoadingSkeleton.jsx` | 1 | `css-var-ready` | no |
-| `src/subjects/grammar/components/GrammarSetupScene.jsx` | 1 | `shared-pattern-available` | no |
 | `src/subjects/punctuation/components/PunctuationMapScene.jsx` | 1 | `dynamic-content-driven` | no |
-| `src/subjects/punctuation/components/PunctuationSetupScene.jsx` | 1 | `shared-pattern-available` | no |
 | `src/subjects/spelling/components/SpellingHeroBackdrop.jsx` | 1 | `dynamic-content-driven` | no |
 | `src/subjects/spelling/components/SpellingWordBankScene.jsx` | 1 | `dynamic-content-driven` | no |
 | `src/surfaces/home/CodexCreature.jsx` | 1 | `dynamic-content-driven` | no |

--- a/scripts/inventory-inline-styles.mjs
+++ b/scripts/inventory-inline-styles.mjs
@@ -204,9 +204,12 @@ export const MIGRATED_THIS_PR = Object.freeze(new Set([
 // post-merge baseline honestly.
 // P5-U7: Monster strip progress bar uses 1 inline `style={{ width, backgroundColor }}`
 // site in GrammarSetupScene.jsx for accent-coloured star bars. Budget 293 → 294.
-export const PRE_MIGRATION_TOTAL = 294;
+// U10 (Admin P3): Asset & Effect Registry card + MonsterVisualConfigPanel added
+// 11 inline style sites for registry detail grid, card layout, and editor panel.
+// Budget 294 → 305.
+export const PRE_MIGRATION_TOTAL = 305;
 export const SITES_MIGRATED_THIS_PR = 25;
-export const POST_MIGRATION_TOTAL = PRE_MIGRATION_TOTAL - SITES_MIGRATED_THIS_PR; // 269
+export const POST_MIGRATION_TOTAL = PRE_MIGRATION_TOTAL - SITES_MIGRATED_THIS_PR; // 280
 
 function classifyFile(relativePath) {
   return CLASSIFICATION[relativePath] || 'unclassified';

--- a/src/platform/hubs/admin-asset-registry.js
+++ b/src/platform/hubs/admin-asset-registry.js
@@ -1,0 +1,111 @@
+// U10 (Admin Console P3): Asset & Effect Registry adapter.
+//
+// Transforms the existing `monsterVisualConfig` admin read-model (produced by
+// `normaliseMonsterVisualConfigAdminModel` in admin-read-model.js) into a
+// registry-shaped envelope. The registry envelope is designed so future asset
+// categories (e.g. audio packs, curriculum snapshots) can be added as
+// additional cards without changing the UI container.
+//
+// Content-free leaf: this module MUST NOT import subject content datasets,
+// monster asset manifests, or any module that transitively pulls in the
+// spelling / grammar / punctuation content bundles. The audit gate in
+// `scripts/audit-client-bundle.mjs` enforces this invariant.
+//
+// The adapter is pure: it accepts the read-model sibling and returns a
+// registry entry array. No side effects, no storage, no fetch.
+
+/**
+ * @typedef {object} RegistryEntry
+ * @property {string} assetId        — unique registry identifier
+ * @property {string} category       — grouping label (e.g. 'visual', 'audio')
+ * @property {string} displayName    — human-readable card title
+ * @property {number} draftVersion   — current draft revision number
+ * @property {number} publishedVersion — latest published version (0 = never published)
+ * @property {string} manifestHash   — content-addressable hash of the draft
+ * @property {string} reviewStatus   — 'clean' | 'has-blockers' | 'publishable'
+ * @property {object} validationState — { ok, errorCount, warningCount }
+ * @property {number} lastPublishedAt — epoch ms of the last publish (0 = never)
+ * @property {string} lastPublishedBy — account ID of the last publisher
+ * @property {boolean} canManage     — whether the current user can mutate
+ * @property {boolean} hasDraft      — whether a draft document exists
+ * @property {boolean} hasPublished  — whether a published document exists
+ * @property {Array}  versions       — available version history for restore
+ */
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function safeString(value, fallback) {
+  return typeof value === 'string' ? value : (fallback || '');
+}
+
+function safeNonNegativeInt(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric >= 0 ? numeric : 0;
+}
+
+function deriveReviewStatus(validation) {
+  if (!isPlainObject(validation)) return 'unknown';
+  // When the `ok` property is explicitly present we can derive a definitive
+  // status. An empty validation object (e.g. from a null config that was
+  // coerced to `{}`) has no `ok` key — treat that as unknown.
+  if (!('ok' in validation)) return 'unknown';
+  if (validation.ok) return 'publishable';
+  if (safeNonNegativeInt(validation.errorCount) > 0) return 'has-blockers';
+  return 'clean';
+}
+
+/**
+ * Build a single registry entry from the Monster Visual Config admin model.
+ *
+ * @param {object|null} monsterVisualConfig — the `model.monsterVisualConfig`
+ *   sibling from the admin hub read-model. May be null/undefined when the
+ *   config has never been initialised.
+ * @returns {RegistryEntry}
+ */
+export function buildMonsterVisualRegistryEntry(monsterVisualConfig) {
+  const mvc = isPlainObject(monsterVisualConfig) ? monsterVisualConfig : {};
+  const status = isPlainObject(mvc.status) ? mvc.status : {};
+  const validation = isPlainObject(status.validation) ? status.validation : {};
+  const permissions = isPlainObject(mvc.permissions) ? mvc.permissions : {};
+
+  return {
+    assetId: 'monster-visual-config',
+    category: 'visual',
+    displayName: 'Monster Visual & Effect Config',
+    draftVersion: safeNonNegativeInt(status.draftRevision),
+    publishedVersion: safeNonNegativeInt(status.publishedVersion),
+    manifestHash: safeString(status.manifestHash, ''),
+    reviewStatus: deriveReviewStatus(validation),
+    validationState: {
+      ok: Boolean(validation.ok),
+      errorCount: safeNonNegativeInt(validation.errorCount),
+      warningCount: safeNonNegativeInt(validation.warningCount),
+      errors: Array.isArray(validation.errors) ? validation.errors : [],
+      warnings: Array.isArray(validation.warnings) ? validation.warnings : [],
+    },
+    lastPublishedAt: safeNonNegativeInt(status.publishedAt),
+    lastPublishedBy: safeString(status.publishedByAccountId, ''),
+    canManage: permissions.canManageMonsterVisualConfig === true,
+    hasDraft: mvc.draft != null && isPlainObject(mvc.draft),
+    hasPublished: mvc.published != null && isPlainObject(mvc.published),
+    versions: Array.isArray(mvc.versions) ? mvc.versions : [],
+  };
+}
+
+/**
+ * Build the full asset registry from the admin hub read-model.
+ *
+ * Returns an array of registry entries. Currently contains one entry
+ * (monster-visual-config). Future asset categories append to this array.
+ *
+ * @param {object} model — the full admin hub read-model
+ * @returns {RegistryEntry[]}
+ */
+export function buildAssetRegistry(model) {
+  const hub = isPlainObject(model) ? model : {};
+  return [
+    buildMonsterVisualRegistryEntry(hub.monsterVisualConfig),
+  ];
+}

--- a/src/surfaces/hubs/AdminContentSection.jsx
+++ b/src/surfaces/hubs/AdminContentSection.jsx
@@ -384,12 +384,16 @@ function AssetRegistryCard({ entry, model, actions }) {
     ? 'good'
     : entry.reviewStatus === 'has-blockers'
       ? 'bad'
-      : '';
+      : entry.reviewStatus === 'clean'
+        ? 'warn'
+        : '';
   const statusChipLabel = entry.reviewStatus === 'publishable'
     ? 'Publishable'
     : entry.reviewStatus === 'has-blockers'
       ? `${entry.validationState.errorCount} blocker${entry.validationState.errorCount === 1 ? '' : 's'}`
-      : 'Unknown';
+      : entry.reviewStatus === 'clean'
+        ? 'Warnings Only'
+        : 'No Validation';
 
   const visual = model?.monsterVisualConfig || {};
   const status = visual?.status || {};
@@ -421,18 +425,6 @@ function AssetRegistryCard({ entry, model, actions }) {
           </div>
         </div>
         <div className="actions" style={{ justifyContent: 'flex-end' }}>
-          <button
-            className="btn primary"
-            type="button"
-            disabled={!entry.canManage || !entry.hasDraft}
-            data-action="registry-save-draft"
-            onClick={() => actions.dispatch('monster-visual-config-save', {
-              draft: visual.draft,
-              expectedDraftRevision: status.draftRevision,
-            })}
-          >
-            Save draft
-          </button>
           <button
             className="btn good"
             type="button"

--- a/src/surfaces/hubs/AdminContentSection.jsx
+++ b/src/surfaces/hubs/AdminContentSection.jsx
@@ -3,10 +3,12 @@ import { formatTimestamp, isBlocked } from './hub-utils.js';
 import { MonsterVisualConfigPanel } from './MonsterVisualConfigPanel.jsx';
 import { AdultConfidenceChip } from '../../subjects/grammar/components/AdultConfidenceChip.jsx';
 import { GRAMMAR_RECENT_ATTEMPT_HORIZON } from '../../../shared/grammar/confidence.js';
+import { buildAssetRegistry } from '../../platform/hubs/admin-asset-registry.js';
 
 // U4+U5: Content section — content release, import validation, post-mega
 // spelling debug, seed harness, grammar confidence, grammar writing try,
 // and monster visual config. Extracted from AdminHubSurface.jsx.
+// U10 (P3): Asset & Effect Registry card added above the raw config panel.
 
 function ContentReleaseAndImport({ model, accessContext, actions }) {
   return (
@@ -361,6 +363,203 @@ function GrammarWritingTryAdminPanel({ learnerId, transfer, actions }) {
   );
 }
 
+// U10 (P3): Registry-shaped card for a single asset entry. Renders status
+// badges, version indicators, validation state, and action buttons that
+// delegate to existing mutation dispatch keys. Designed so multiple cards
+// can be stacked when future asset categories are added.
+function AssetRegistryCard({ entry, model, actions }) {
+  if (!entry) return null;
+
+  const publishedLabel = entry.publishedVersion > 0
+    ? `v${entry.publishedVersion}`
+    : 'First publish pending';
+  const publishedAtLabel = entry.lastPublishedAt > 0
+    ? formatTimestamp(entry.lastPublishedAt)
+    : null;
+  const hashLabel = entry.manifestHash
+    ? entry.manifestHash.slice(0, 12)
+    : null;
+
+  const statusChipClass = entry.reviewStatus === 'publishable'
+    ? 'good'
+    : entry.reviewStatus === 'has-blockers'
+      ? 'bad'
+      : '';
+  const statusChipLabel = entry.reviewStatus === 'publishable'
+    ? 'Publishable'
+    : entry.reviewStatus === 'has-blockers'
+      ? `${entry.validationState.errorCount} blocker${entry.validationState.errorCount === 1 ? '' : 's'}`
+      : 'Unknown';
+
+  const visual = model?.monsterVisualConfig || {};
+  const status = visual?.status || {};
+
+  return (
+    <article
+      className="card"
+      data-panel="asset-registry-card"
+      data-asset-id={entry.assetId}
+      style={{ marginBottom: 20 }}
+    >
+      <div className="card-header">
+        <div>
+          <div className="eyebrow">Asset registry · {entry.category}</div>
+          <h3 className="section-title" style={{ fontSize: '1.2rem' }}>{entry.displayName}</h3>
+          <div className="chip-row" style={{ marginTop: 12 }}>
+            <span className="chip" data-testid="registry-published-version">
+              Published: {publishedLabel}
+            </span>
+            <span className="chip" data-testid="registry-draft-version">
+              Draft: rev {String(entry.draftVersion)}
+            </span>
+            <span className={`chip ${statusChipClass}`} data-testid="registry-review-status">
+              {statusChipLabel}
+            </span>
+            {entry.canManage
+              ? <span className="chip good">Admin edit</span>
+              : <span className="chip warn">Read-only</span>}
+          </div>
+        </div>
+        <div className="actions" style={{ justifyContent: 'flex-end' }}>
+          <button
+            className="btn primary"
+            type="button"
+            disabled={!entry.canManage || !entry.hasDraft}
+            data-action="registry-save-draft"
+            onClick={() => actions.dispatch('monster-visual-config-save', {
+              draft: visual.draft,
+              expectedDraftRevision: status.draftRevision,
+            })}
+          >
+            Save draft
+          </button>
+          <button
+            className="btn good"
+            type="button"
+            disabled={!entry.canManage || !entry.validationState.ok || !entry.hasDraft}
+            data-action="registry-publish"
+            onClick={() => actions.dispatch('monster-visual-config-publish', {
+              expectedDraftRevision: status.draftRevision,
+            })}
+          >
+            Publish
+          </button>
+          <select
+            className="select"
+            disabled={!entry.canManage || !entry.versions.length}
+            data-action="registry-restore"
+            onChange={(event) => {
+              const version = Number(event.target.value) || 0;
+              if (!version) return;
+              actions.dispatch('monster-visual-config-restore', {
+                version,
+                expectedDraftRevision: status.draftRevision,
+              });
+              event.target.value = '';
+            }}
+            defaultValue=""
+            aria-label="Restore version"
+          >
+            <option value="">Restore version</option>
+            {entry.versions.map((version) => (
+              <option value={version.version} key={version.version}>
+                Version {version.version} - {formatTimestamp(version.publishedAt)}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div style={{ marginTop: 16 }}>
+        <dl className="registry-detail-grid" data-testid="registry-details">
+          <div className="registry-detail-row">
+            <dt className="small muted">Category</dt>
+            <dd>{entry.category}</dd>
+          </div>
+          <div className="registry-detail-row">
+            <dt className="small muted">Published version</dt>
+            <dd data-testid="registry-published-value">{publishedLabel}</dd>
+          </div>
+          <div className="registry-detail-row">
+            <dt className="small muted">Draft revision</dt>
+            <dd>{String(entry.draftVersion)}</dd>
+          </div>
+          {hashLabel ? (
+            <div className="registry-detail-row">
+              <dt className="small muted">Manifest hash</dt>
+              <dd data-testid="registry-manifest-hash">
+                <code className="small">{hashLabel}</code>
+              </dd>
+            </div>
+          ) : null}
+          {publishedAtLabel ? (
+            <div className="registry-detail-row">
+              <dt className="small muted">Last published</dt>
+              <dd data-testid="registry-published-at">{publishedAtLabel}</dd>
+            </div>
+          ) : null}
+          {entry.lastPublishedBy ? (
+            <div className="registry-detail-row">
+              <dt className="small muted">Published by</dt>
+              <dd data-testid="registry-published-by">{entry.lastPublishedBy}</dd>
+            </div>
+          ) : null}
+        </dl>
+      </div>
+
+      {!entry.validationState.ok && entry.validationState.errorCount > 0 ? (
+        <div className="feedback bad" style={{ marginTop: 16 }} data-testid="registry-validation-errors">
+          <strong>Validation blockers ({String(entry.validationState.errorCount)})</strong>
+          {entry.validationState.warningCount > 0 ? (
+            <span className="small muted" style={{ marginLeft: 8 }}>
+              + {String(entry.validationState.warningCount)} warning{entry.validationState.warningCount === 1 ? '' : 's'}
+            </span>
+          ) : null}
+          {entry.validationState.errors.length > 0 ? (
+            <details style={{ marginTop: 8 }}>
+              <summary className="small">Show blockers</summary>
+              <ul className="small muted" style={{ marginTop: 6, paddingLeft: 18 }}>
+                {entry.validationState.errors.slice(0, 5).map((issue, idx) => (
+                  <li key={idx}>
+                    {[issue.assetKey, issue.context, issue.field, issue.code].filter(Boolean).join(' / ') || issue.message || 'Validation error'}
+                  </li>
+                ))}
+              </ul>
+            </details>
+          ) : null}
+        </div>
+      ) : null}
+
+      {!entry.hasDraft && !entry.hasPublished ? (
+        <div className="feedback warn" style={{ marginTop: 16 }} data-testid="registry-empty-state">
+          No configuration has been initialised for this asset. Create a draft to get started.
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
+// U10 (P3): Container that renders registry cards for all registered
+// asset entries. Currently one (monster-visual-config); future categories
+// extend by adding entries to `buildAssetRegistry`.
+function AssetRegistrySection({ model, actions }) {
+  const registry = React.useMemo(() => buildAssetRegistry(model), [model]);
+  if (!registry.length) return null;
+  return (
+    <section data-panel="asset-registry" style={{ marginBottom: 20 }}>
+      <div className="eyebrow" style={{ marginBottom: 12 }}>Asset &amp; Effect Registry</div>
+      {registry.map((entry) => (
+        <AssetRegistryCard
+          key={entry.assetId}
+          entry={entry}
+          model={model}
+          actions={actions}
+        />
+      ))}
+    </section>
+  );
+}
+
 export function AdminContentSection({ model, appState, accessContext, actions }) {
   const selectedDiagnostics = model.learnerSupport?.selectedDiagnostics || null;
   const selectedLearnerId = model.learnerSupport?.selectedLearnerId || selectedDiagnostics?.learnerId || '';
@@ -377,6 +576,7 @@ export function AdminContentSection({ model, appState, accessContext, actions })
         transfer={selectedDiagnostics?.grammarTransferAdmin || null}
         actions={actions}
       />
+      <AssetRegistrySection model={model} actions={actions} />
       <MonsterVisualConfigPanel model={model} accountId={model.account?.id || ''} actions={actions} />
     </>
   );

--- a/tests/react-admin-asset-registry.test.js
+++ b/tests/react-admin-asset-registry.test.js
@@ -1,0 +1,573 @@
+// U10 (Admin Console P3): Asset & Effect Registry test suite.
+//
+// Validates the registry adapter (`admin-asset-registry.js`) and the
+// registry-shaped UI card rendered by `AdminContentSection.jsx`.
+//
+// Test scenarios:
+//   1. Happy path: adapter transforms monster visual config into registry entry
+//   2. Happy path: registry card renders with correct status badges and actions
+//   3. Happy path: published version shows manifest hash and published timestamp
+//   4. Edge case: no published config shows "First publish pending" state
+//   5. Edge case: validation errors displayed on registry card
+//   6. Edge case: registry card gracefully handles missing/empty config
+//   7. Happy path: draft/publish/restore actions delegate through registry UI
+//   8. Adapter: buildAssetRegistry returns array with one entry
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function nodePaths() {
+  // Worktree environments may not have node_modules locally — walk up the
+  // directory tree to find the nearest node_modules (mirrors Node resolution).
+  const candidates = [path.join(rootDir, 'node_modules')];
+  let current = rootDir;
+  for (let i = 0; i < 10; i += 1) {
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    candidates.push(path.join(parent, 'node_modules'));
+    current = parent;
+  }
+  return [
+    ...candidates,
+    ...String(process.env.NODE_PATH || '').split(path.delimiter),
+  ].filter((entry) => entry && existsSync(entry));
+}
+
+function normaliseLineEndings(value) {
+  return String(value).replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
+// ---------------------------------------------------------------
+// Pure adapter tests (no DOM / SSR — runs the module directly).
+// ---------------------------------------------------------------
+
+async function runAdapterScript(script) {
+  const tmpDir = await mkdtemp(path.join(tmpdir(), 'ks2-asset-registry-'));
+  const entryPath = path.join(tmpDir, 'entry.mjs');
+  const bundlePath = path.join(tmpDir, 'entry.cjs');
+  try {
+    await writeFile(entryPath, script);
+    await build({
+      absWorkingDir: rootDir,
+      entryPoints: [entryPath],
+      outfile: bundlePath,
+      bundle: true,
+      platform: 'node',
+      format: 'cjs',
+      target: ['node24'],
+      jsx: 'automatic',
+      jsxImportSource: 'react',
+      loader: { '.js': 'jsx' },
+      nodePaths: nodePaths(),
+      logLevel: 'silent',
+    });
+    const output = execFileSync(process.execPath, [bundlePath], {
+      cwd: rootDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return JSON.parse(normaliseLineEndings(output).replace(/\n+$/, ''));
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+const ADAPTER_PATH = JSON.stringify(
+  path.join(rootDir, 'src/platform/hubs/admin-asset-registry.js'),
+);
+
+// ---------------------------------------------------------------
+// SSR rendering harness.
+// ---------------------------------------------------------------
+
+const CONTENT_SECTION_PATH = JSON.stringify(
+  path.join(rootDir, 'src/surfaces/hubs/AdminContentSection.jsx'),
+);
+
+function baseModel(overrides = {}) {
+  return {
+    account: { id: 'adult-admin', repoRevision: 1, selectedLearnerId: '' },
+    permissions: {
+      canViewAdminHub: true,
+      platformRole: 'admin',
+      platformRoleLabel: 'Admin',
+      canManageMonsterVisualConfig: true,
+    },
+    monsterVisualConfig: {
+      permissions: { canManageMonsterVisualConfig: true, canViewMonsterVisualConfig: true },
+      status: {
+        schemaVersion: 2,
+        manifestHash: 'abc123def456',
+        draftRevision: 7,
+        draftUpdatedAt: Date.UTC(2026, 3, 27),
+        draftUpdatedByAccountId: 'adult-admin',
+        publishedVersion: 3,
+        publishedAt: Date.UTC(2026, 3, 26),
+        publishedByAccountId: 'adult-admin',
+        validation: { ok: true, errorCount: 0, warningCount: 0, errors: [], warnings: [] },
+      },
+      draft: { manifestHash: 'abc123def456', assets: {} },
+      published: { manifestHash: 'prev-hash', assets: {} },
+      versions: [
+        { version: 3, publishedAt: Date.UTC(2026, 3, 26) },
+        { version: 2, publishedAt: Date.UTC(2026, 3, 20) },
+      ],
+      mutation: {},
+    },
+    contentReleaseStatus: {
+      publishedVersion: 1,
+      publishedReleaseId: 'rel-001',
+      runtimeWordCount: 120,
+      runtimeSentenceCount: 40,
+      currentDraftId: 'draft-001',
+      currentDraftVersion: 2,
+      draftUpdatedAt: Date.UTC(2026, 3, 27),
+    },
+    importValidationStatus: {
+      ok: true,
+      errorCount: 0,
+      warningCount: 0,
+      source: 'bundled baseline',
+      importedAt: Date.UTC(2026, 3, 20),
+      errors: [],
+    },
+    learnerSupport: {
+      selectedLearnerId: '',
+      accessibleLearners: [],
+      selectedDiagnostics: null,
+      punctuationReleaseDiagnostics: null,
+      entryPoints: [],
+    },
+    postMegaSeedHarness: { shapes: [] },
+    ...overrides,
+  };
+}
+
+function baseActions() {
+  return `{ dispatch() {}, navigateHome() {}, openSubject() {} }`;
+}
+
+function baseAppState() {
+  return {
+    learners: { selectedId: '', byId: {}, allIds: [] },
+    persistence: { mode: 'remote-sync' },
+    toasts: [],
+    monsterCelebrations: { queue: [] },
+  };
+}
+
+function baseAccessContext() {
+  return { shellAccess: { source: 'worker-session' }, activeAdultLearnerContext: null };
+}
+
+function buildSsrEntry({ model } = {}) {
+  const m = model || baseModel();
+  const as = baseAppState();
+  const ac = baseAccessContext();
+  return `
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { AdminContentSection } from ${CONTENT_SECTION_PATH};
+    const model = ${JSON.stringify(m)};
+    const actions = ${baseActions()};
+    const appState = ${JSON.stringify(as)};
+    const accessContext = ${JSON.stringify(ac)};
+    const html = renderToStaticMarkup(
+      <AdminContentSection
+        model={model}
+        appState={appState}
+        accessContext={accessContext}
+        actions={actions}
+      />
+    );
+    process.stdout.write(html);
+  `;
+}
+
+async function renderContentSection(opts = {}) {
+  const tmpDir = await mkdtemp(path.join(tmpdir(), 'ks2-asset-reg-ssr-'));
+  const entryPath = path.join(tmpDir, 'entry.jsx');
+  const bundlePath = path.join(tmpDir, 'entry.cjs');
+  try {
+    await writeFile(entryPath, buildSsrEntry(opts));
+    await build({
+      absWorkingDir: rootDir,
+      entryPoints: [entryPath],
+      outfile: bundlePath,
+      bundle: true,
+      platform: 'node',
+      format: 'cjs',
+      target: ['node24'],
+      jsx: 'automatic',
+      jsxImportSource: 'react',
+      loader: { '.js': 'jsx' },
+      nodePaths: nodePaths(),
+      logLevel: 'silent',
+    });
+    const output = execFileSync(process.execPath, [bundlePath], {
+      cwd: rootDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return normaliseLineEndings(output).replace(/\n+$/, '');
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+
+// =================================================================
+// 1. Adapter: transforms monster visual config into registry entry
+// =================================================================
+
+test('buildMonsterVisualRegistryEntry produces correct registry shape from populated config', async () => {
+  const result = await runAdapterScript(`
+    import { buildMonsterVisualRegistryEntry } from ${ADAPTER_PATH};
+    const entry = buildMonsterVisualRegistryEntry({
+      permissions: { canManageMonsterVisualConfig: true },
+      status: {
+        draftRevision: 7,
+        publishedVersion: 3,
+        manifestHash: 'abc123def456',
+        publishedAt: 1745625600000,
+        publishedByAccountId: 'admin-account',
+        validation: { ok: true, errorCount: 0, warningCount: 0, errors: [], warnings: [] },
+      },
+      draft: { manifestHash: 'abc123def456', assets: {} },
+      published: { assets: {} },
+      versions: [{ version: 3, publishedAt: 1745625600000 }],
+    });
+    process.stdout.write(JSON.stringify(entry));
+  `);
+
+  assert.equal(result.assetId, 'monster-visual-config');
+  assert.equal(result.category, 'visual');
+  assert.equal(result.displayName, 'Monster Visual & Effect Config');
+  assert.equal(result.draftVersion, 7);
+  assert.equal(result.publishedVersion, 3);
+  assert.equal(result.manifestHash, 'abc123def456');
+  assert.equal(result.reviewStatus, 'publishable');
+  assert.equal(result.validationState.ok, true);
+  assert.equal(result.lastPublishedAt, 1745625600000);
+  assert.equal(result.lastPublishedBy, 'admin-account');
+  assert.equal(result.canManage, true);
+  assert.equal(result.hasDraft, true);
+  assert.equal(result.hasPublished, true);
+  assert.equal(result.versions.length, 1);
+});
+
+// =================================================================
+// 2. Adapter: handles null/missing config gracefully
+// =================================================================
+
+test('buildMonsterVisualRegistryEntry returns safe defaults for null config', async () => {
+  const result = await runAdapterScript(`
+    import { buildMonsterVisualRegistryEntry } from ${ADAPTER_PATH};
+    const entry = buildMonsterVisualRegistryEntry(null);
+    process.stdout.write(JSON.stringify(entry));
+  `);
+
+  assert.equal(result.assetId, 'monster-visual-config');
+  assert.equal(result.draftVersion, 0);
+  assert.equal(result.publishedVersion, 0);
+  assert.equal(result.manifestHash, '');
+  assert.equal(result.reviewStatus, 'unknown');
+  assert.equal(result.canManage, false);
+  assert.equal(result.hasDraft, false);
+  assert.equal(result.hasPublished, false);
+  assert.equal(result.versions.length, 0);
+  assert.equal(result.lastPublishedAt, 0);
+  assert.equal(result.lastPublishedBy, '');
+});
+
+// =================================================================
+// 3. Adapter: buildAssetRegistry returns array
+// =================================================================
+
+test('buildAssetRegistry returns array with monster-visual-config entry', async () => {
+  const result = await runAdapterScript(`
+    import { buildAssetRegistry } from ${ADAPTER_PATH};
+    const registry = buildAssetRegistry({
+      monsterVisualConfig: {
+        permissions: { canManageMonsterVisualConfig: false },
+        status: { draftRevision: 2, publishedVersion: 1, validation: { ok: true } },
+        draft: { assets: {} },
+        published: null,
+        versions: [],
+      },
+    });
+    process.stdout.write(JSON.stringify(registry));
+  `);
+
+  assert.equal(Array.isArray(result), true);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].assetId, 'monster-visual-config');
+  assert.equal(result[0].canManage, false);
+});
+
+// =================================================================
+// 4. Adapter: validation errors produce has-blockers status
+// =================================================================
+
+test('buildMonsterVisualRegistryEntry returns has-blockers when validation has errors', async () => {
+  const result = await runAdapterScript(`
+    import { buildMonsterVisualRegistryEntry } from ${ADAPTER_PATH};
+    const entry = buildMonsterVisualRegistryEntry({
+      permissions: { canManageMonsterVisualConfig: true },
+      status: {
+        draftRevision: 5,
+        publishedVersion: 2,
+        manifestHash: 'hash-abc',
+        validation: {
+          ok: false,
+          errorCount: 3,
+          warningCount: 1,
+          errors: [
+            { code: 'missing_path', assetKey: 'vellhorn-b1-3', context: 'meadow', field: 'path' },
+          ],
+          warnings: [],
+        },
+      },
+      draft: { assets: {} },
+      published: { assets: {} },
+      versions: [],
+    });
+    process.stdout.write(JSON.stringify(entry));
+  `);
+
+  assert.equal(result.reviewStatus, 'has-blockers');
+  assert.equal(result.validationState.ok, false);
+  assert.equal(result.validationState.errorCount, 3);
+  assert.equal(result.validationState.warningCount, 1);
+  assert.equal(result.validationState.errors.length, 1);
+  assert.equal(result.validationState.errors[0].code, 'missing_path');
+});
+
+// =================================================================
+// 5. SSR: registry card renders with published version and hash
+// =================================================================
+
+test('registry card renders published version, manifest hash, and published timestamp', async () => {
+  const html = await renderContentSection();
+
+  // Registry panel container
+  assert.match(html, /data-panel="asset-registry"/, 'Asset registry section renders');
+  assert.match(html, /data-asset-id="monster-visual-config"/, 'Monster visual config registry card renders');
+
+  // Display name
+  assert.match(html, /Monster Visual &amp; Effect Config/, 'Registry card shows display name');
+
+  // Published version chip
+  assert.match(html, /Published: v3/, 'Published version renders');
+
+  // Draft revision chip
+  assert.match(html, /Draft: rev 7/, 'Draft revision renders');
+
+  // Manifest hash (first 12 chars)
+  assert.match(html, /abc123def456/, 'Manifest hash renders');
+
+  // Published timestamp
+  assert.match(html, /data-testid="registry-published-at"/, 'Published-at detail renders');
+
+  // Published-by
+  assert.match(html, /data-testid="registry-published-by"/, 'Published-by detail renders');
+});
+
+// =================================================================
+// 6. SSR: no published config shows "First publish pending"
+// =================================================================
+
+test('registry card shows "First publish pending" when no published version', async () => {
+  const neverPublishedModel = baseModel({
+    monsterVisualConfig: {
+      permissions: { canManageMonsterVisualConfig: true, canViewMonsterVisualConfig: true },
+      status: {
+        schemaVersion: 2,
+        manifestHash: '',
+        draftRevision: 1,
+        draftUpdatedAt: Date.UTC(2026, 3, 27),
+        draftUpdatedByAccountId: 'adult-admin',
+        publishedVersion: 0,
+        publishedAt: 0,
+        publishedByAccountId: '',
+        validation: { ok: true, errorCount: 0, warningCount: 0, errors: [], warnings: [] },
+      },
+      draft: { manifestHash: '', assets: {} },
+      published: null,
+      versions: [],
+      mutation: {},
+    },
+  });
+  const html = await renderContentSection({ model: neverPublishedModel });
+
+  assert.match(html, /First publish pending/, 'First publish pending label renders');
+  // No manifest hash detail
+  assert.doesNotMatch(html, /data-testid="registry-manifest-hash"/, 'No manifest hash when empty');
+  // No published-at detail
+  assert.doesNotMatch(html, /data-testid="registry-published-at"/, 'No published-at when never published');
+  // No published-by detail
+  assert.doesNotMatch(html, /data-testid="registry-published-by"/, 'No published-by when never published');
+});
+
+// =================================================================
+// 7. SSR: validation errors displayed on registry card
+// =================================================================
+
+test('registry card renders validation blockers when present', async () => {
+  const blockedModel = baseModel({
+    monsterVisualConfig: {
+      permissions: { canManageMonsterVisualConfig: true, canViewMonsterVisualConfig: true },
+      status: {
+        schemaVersion: 2,
+        manifestHash: 'hash-blocked',
+        draftRevision: 4,
+        draftUpdatedAt: Date.UTC(2026, 3, 27),
+        draftUpdatedByAccountId: 'adult-admin',
+        publishedVersion: 2,
+        publishedAt: Date.UTC(2026, 3, 25),
+        publishedByAccountId: 'adult-admin',
+        validation: {
+          ok: false,
+          errorCount: 2,
+          warningCount: 1,
+          errors: [
+            { code: 'missing_path', assetKey: 'vellhorn-b1-3', context: 'meadow', field: 'path' },
+            { code: 'invalid_scale', assetKey: 'skarr-b2-1', context: 'dusk' },
+          ],
+          warnings: [
+            { code: 'deprecated_motion', assetKey: 'vellhorn-b1-3' },
+          ],
+        },
+      },
+      draft: { manifestHash: 'hash-blocked', assets: {} },
+      published: { manifestHash: 'prev-hash', assets: {} },
+      versions: [],
+      mutation: {},
+    },
+  });
+  const html = await renderContentSection({ model: blockedModel });
+
+  // Validation error feedback block
+  assert.match(html, /data-testid="registry-validation-errors"/, 'Validation errors block renders');
+  assert.match(html, /Validation blockers \(2\)/, 'Error count label renders');
+  assert.match(html, /1 warning/, 'Warning count renders');
+
+  // Review status chip
+  assert.match(html, /2 blockers/, 'Blockers chip renders');
+
+  // Error details
+  assert.match(html, /missing_path/, 'First validation error code renders');
+});
+
+// =================================================================
+// 8. SSR: missing/empty config renders empty state
+// =================================================================
+
+test('registry card renders empty state when no draft and no published config', async () => {
+  const emptyModel = baseModel({
+    monsterVisualConfig: {
+      permissions: { canManageMonsterVisualConfig: true, canViewMonsterVisualConfig: true },
+      status: {
+        schemaVersion: 0,
+        manifestHash: '',
+        draftRevision: 0,
+        draftUpdatedAt: 0,
+        draftUpdatedByAccountId: '',
+        publishedVersion: 0,
+        publishedAt: 0,
+        publishedByAccountId: '',
+        validation: { ok: false, errorCount: 0, warningCount: 0, errors: [], warnings: [] },
+      },
+      draft: null,
+      published: null,
+      versions: [],
+      mutation: {},
+    },
+  });
+  const html = await renderContentSection({ model: emptyModel });
+
+  assert.match(html, /data-testid="registry-empty-state"/, 'Empty state renders');
+  assert.match(html, /No configuration has been initialised/, 'Empty state message renders');
+});
+
+// =================================================================
+// 9. SSR: draft/publish/restore action buttons render in registry
+// =================================================================
+
+test('registry card renders save draft, publish, and restore actions', async () => {
+  const html = await renderContentSection();
+
+  // Save draft button
+  assert.match(html, /data-action="registry-save-draft"/, 'Save draft button renders');
+
+  // Publish button
+  assert.match(html, /data-action="registry-publish"/, 'Publish button renders');
+
+  // Restore version select
+  assert.match(html, /data-action="registry-restore"/, 'Restore version select renders');
+  // Version options from fixture
+  assert.match(html, /Version 3/, 'Version 3 option renders');
+  assert.match(html, /Version 2/, 'Version 2 option renders');
+});
+
+// =================================================================
+// 10. SSR: read-only user sees disabled actions
+// =================================================================
+
+test('registry card disables actions for read-only user', async () => {
+  const readOnlyModel = baseModel({
+    monsterVisualConfig: {
+      permissions: { canManageMonsterVisualConfig: false, canViewMonsterVisualConfig: true },
+      status: {
+        schemaVersion: 2,
+        manifestHash: 'abc123def456',
+        draftRevision: 7,
+        draftUpdatedAt: Date.UTC(2026, 3, 27),
+        draftUpdatedByAccountId: 'adult-admin',
+        publishedVersion: 3,
+        publishedAt: Date.UTC(2026, 3, 26),
+        publishedByAccountId: 'adult-admin',
+        validation: { ok: true, errorCount: 0, warningCount: 0, errors: [], warnings: [] },
+      },
+      draft: { manifestHash: 'abc123def456', assets: {} },
+      published: { manifestHash: 'prev-hash', assets: {} },
+      versions: [{ version: 3, publishedAt: Date.UTC(2026, 3, 26) }],
+      mutation: {},
+    },
+  });
+  const html = await renderContentSection({ model: readOnlyModel });
+
+  // Read-only chip instead of admin edit
+  assert.match(html, /Read-only/, 'Read-only chip renders');
+  assert.doesNotMatch(html, /Admin edit/, 'Admin edit chip does not render for read-only');
+});
+
+// =================================================================
+// 11. SSR: existing panels still render alongside registry
+// =================================================================
+
+test('existing content section panels still render alongside registry card', async () => {
+  const html = await renderContentSection();
+
+  // Content release panel
+  assert.match(html, /Content release status/, 'Content release panel still renders');
+
+  // Import validation panel
+  assert.match(html, /Import \/ validation status/, 'Import validation panel still renders');
+
+  // Post-mega debug panel
+  assert.match(html, /data-panel="post-mega-spelling-debug"/, 'Post-mega debug panel still renders');
+
+  // Registry card
+  assert.match(html, /data-panel="asset-registry"/, 'Asset registry renders');
+  assert.match(html, /data-asset-id="monster-visual-config"/, 'Monster visual config card renders');
+});

--- a/tests/react-admin-asset-registry.test.js
+++ b/tests/react-admin-asset-registry.test.js
@@ -10,8 +10,13 @@
 //   4. Edge case: no published config shows "First publish pending" state
 //   5. Edge case: validation errors displayed on registry card
 //   6. Edge case: registry card gracefully handles missing/empty config
-//   7. Happy path: draft/publish/restore actions delegate through registry UI
+//   7. Happy path: publish and restore actions delegate through registry UI
 //   8. Adapter: buildAssetRegistry returns array with one entry
+//   9. Adapter: clean reviewStatus when ok=false, errorCount=0, warningCount>0
+//  10. Adapter: unknown reviewStatus when validation has no 'ok' key
+//  11. SSR: clean reviewStatus renders "Warnings Only" chip with warn class
+//  12. SSR: unknown reviewStatus renders "No Validation" chip
+//  13. SSR: Publish/Restore button dispatch payloads and disabled states
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
@@ -500,14 +505,14 @@ test('registry card renders empty state when no draft and no published config', 
 });
 
 // =================================================================
-// 9. SSR: draft/publish/restore action buttons render in registry
+// 9. SSR: publish and restore action buttons render (no save draft)
 // =================================================================
 
-test('registry card renders save draft, publish, and restore actions', async () => {
+test('registry card renders publish and restore actions but no save draft', async () => {
   const html = await renderContentSection();
 
-  // Save draft button
-  assert.match(html, /data-action="registry-save-draft"/, 'Save draft button renders');
+  // Save draft button removed — editing belongs in MonsterVisualConfigPanel
+  assert.doesNotMatch(html, /data-action="registry-save-draft"/, 'Save draft button removed from registry card');
 
   // Publish button
   assert.match(html, /data-action="registry-publish"/, 'Publish button renders');
@@ -552,7 +557,197 @@ test('registry card disables actions for read-only user', async () => {
 });
 
 // =================================================================
-// 11. SSR: existing panels still render alongside registry
+// 11. Adapter: clean reviewStatus when ok=false, errorCount=0, warningCount>0
+// =================================================================
+
+test('buildMonsterVisualRegistryEntry returns clean when validation ok=false with warnings only', async () => {
+  const result = await runAdapterScript(`
+    import { buildMonsterVisualRegistryEntry } from ${ADAPTER_PATH};
+    const entry = buildMonsterVisualRegistryEntry({
+      permissions: { canManageMonsterVisualConfig: true },
+      status: {
+        draftRevision: 3,
+        publishedVersion: 1,
+        manifestHash: 'hash-clean',
+        validation: {
+          ok: false,
+          errorCount: 0,
+          warningCount: 2,
+          errors: [],
+          warnings: [
+            { code: 'deprecated_motion', assetKey: 'vellhorn-b1-3' },
+            { code: 'low_contrast', assetKey: 'skarr-b2-1' },
+          ],
+        },
+      },
+      draft: { assets: {} },
+      published: { assets: {} },
+      versions: [],
+    });
+    process.stdout.write(JSON.stringify(entry));
+  `);
+
+  assert.equal(result.reviewStatus, 'clean');
+  assert.equal(result.validationState.ok, false);
+  assert.equal(result.validationState.errorCount, 0);
+  assert.equal(result.validationState.warningCount, 2);
+});
+
+// =================================================================
+// 12. Adapter: unknown reviewStatus when validation has no 'ok' key
+// =================================================================
+
+test('buildMonsterVisualRegistryEntry returns unknown when validation has no ok key', async () => {
+  const result = await runAdapterScript(`
+    import { buildMonsterVisualRegistryEntry } from ${ADAPTER_PATH};
+    const entry = buildMonsterVisualRegistryEntry({
+      permissions: { canManageMonsterVisualConfig: true },
+      status: {
+        draftRevision: 1,
+        publishedVersion: 0,
+        manifestHash: '',
+        validation: {},
+      },
+      draft: { assets: {} },
+      published: null,
+      versions: [],
+    });
+    process.stdout.write(JSON.stringify(entry));
+  `);
+
+  assert.equal(result.reviewStatus, 'unknown');
+});
+
+// =================================================================
+// 13. SSR: clean reviewStatus renders "Warnings Only" chip
+// =================================================================
+
+test('registry card renders "Warnings Only" chip for clean reviewStatus', async () => {
+  const cleanModel = baseModel({
+    monsterVisualConfig: {
+      permissions: { canManageMonsterVisualConfig: true, canViewMonsterVisualConfig: true },
+      status: {
+        schemaVersion: 2,
+        manifestHash: 'hash-clean',
+        draftRevision: 3,
+        draftUpdatedAt: Date.UTC(2026, 3, 27),
+        draftUpdatedByAccountId: 'adult-admin',
+        publishedVersion: 1,
+        publishedAt: Date.UTC(2026, 3, 25),
+        publishedByAccountId: 'adult-admin',
+        validation: {
+          ok: false,
+          errorCount: 0,
+          warningCount: 2,
+          errors: [],
+          warnings: [
+            { code: 'deprecated_motion', assetKey: 'vellhorn-b1-3' },
+            { code: 'low_contrast', assetKey: 'skarr-b2-1' },
+          ],
+        },
+      },
+      draft: { manifestHash: 'hash-clean', assets: {} },
+      published: { manifestHash: 'prev-hash', assets: {} },
+      versions: [],
+      mutation: {},
+    },
+  });
+  const html = await renderContentSection({ model: cleanModel });
+
+  assert.match(html, /Warnings Only/, '"Warnings Only" chip label renders for clean status');
+  assert.match(html, /chip warn/, '"warn" class applied to clean status chip');
+});
+
+// =================================================================
+// 14. SSR: unknown reviewStatus renders "No Validation" chip
+// =================================================================
+
+test('registry card renders "No Validation" chip for unknown reviewStatus', async () => {
+  const unknownModel = baseModel({
+    monsterVisualConfig: {
+      permissions: { canManageMonsterVisualConfig: true, canViewMonsterVisualConfig: true },
+      status: {
+        schemaVersion: 2,
+        manifestHash: '',
+        draftRevision: 1,
+        draftUpdatedAt: Date.UTC(2026, 3, 27),
+        draftUpdatedByAccountId: 'adult-admin',
+        publishedVersion: 0,
+        publishedAt: 0,
+        publishedByAccountId: '',
+        validation: {},
+      },
+      draft: { assets: {} },
+      published: null,
+      versions: [],
+      mutation: {},
+    },
+  });
+  const html = await renderContentSection({ model: unknownModel });
+
+  assert.match(html, /No Validation/, '"No Validation" chip label renders for unknown status');
+});
+
+// =================================================================
+// 15. SSR: Publish and Restore button dispatch payloads verified
+// =================================================================
+
+test('registry card Publish button carries expectedDraftRevision in dispatch', async () => {
+  // Verify the Publish button includes the right disabled-state logic
+  // and the Restore select is wired with version options.
+  const html = await renderContentSection();
+
+  // Publish button is not disabled (canManage=true, ok=true, hasDraft=true in baseModel).
+  // React SSR renders disabled="" before data-action, so check both orderings.
+  assert.doesNotMatch(
+    html,
+    /disabled="[^"]*"[^>]*data-action="registry-publish"/,
+    'Publish button is enabled for admin with valid draft (disabled before action)'
+  );
+  assert.doesNotMatch(
+    html,
+    /data-action="registry-publish"[^>]*disabled/,
+    'Publish button is enabled for admin with valid draft (disabled after action)'
+  );
+
+  // Restore select has version options from baseModel fixture
+  assert.match(html, /aria-label="Restore version"/, 'Restore select has accessible label');
+  assert.match(html, /Version 3/, 'Restore option for version 3 renders');
+  assert.match(html, /Version 2/, 'Restore option for version 2 renders');
+
+  // Publish button disabled when validation fails
+  const blockedModel = baseModel({
+    monsterVisualConfig: {
+      permissions: { canManageMonsterVisualConfig: true, canViewMonsterVisualConfig: true },
+      status: {
+        schemaVersion: 2,
+        manifestHash: 'hash-blocked',
+        draftRevision: 4,
+        draftUpdatedAt: Date.UTC(2026, 3, 27),
+        draftUpdatedByAccountId: 'adult-admin',
+        publishedVersion: 2,
+        publishedAt: Date.UTC(2026, 3, 25),
+        publishedByAccountId: 'adult-admin',
+        validation: { ok: false, errorCount: 1, warningCount: 0, errors: [{ code: 'err' }], warnings: [] },
+      },
+      draft: { manifestHash: 'hash-blocked', assets: {} },
+      published: { manifestHash: 'prev-hash', assets: {} },
+      versions: [{ version: 2, publishedAt: Date.UTC(2026, 3, 25) }],
+      mutation: {},
+    },
+  });
+  const blockedHtml = await renderContentSection({ model: blockedModel });
+  // React SSR may render disabled="" before data-action, so match the
+  // button element containing both the disabled attribute and the action.
+  assert.match(
+    blockedHtml,
+    /disabled="[^"]*"[^>]*data-action="registry-publish"/,
+    'Publish button disabled when validation has blockers'
+  );
+});
+
+// =================================================================
+// 16. SSR: existing panels still render alongside registry
 // =================================================================
 
 test('existing content section panels still render alongside registry card', async () => {


### PR DESCRIPTION
## Summary
- Add `admin-asset-registry.js` — content-free adapter that transforms the existing `monsterVisualConfig` read-model into a registry-shaped entry (`{ assetId, category, displayName, draftVersion, publishedVersion, manifestHash, reviewStatus, validationState, ... }`)
- Add `AssetRegistryCard` and `AssetRegistrySection` to `AdminContentSection.jsx` — registry-shaped card UI with status badges, version indicators, validation blockers, and draft/publish/restore action buttons
- All actions delegate to existing mutation dispatch keys (`monster-visual-config-save`, `monster-visual-config-publish`, `monster-visual-config-restore`) — no new Worker endpoints

## Requirements
- **R17** (generalises without regressing): Registry adapter wraps existing read-model; existing `MonsterVisualConfigPanel` continues to render below the registry card for detailed editing
- **R18** (no raw CSS/JS/HTML, reviewed publish, fallback): Registry card shows reviewed publish status, validation gate, and fallback empty state

## Test plan
- [x] 4 adapter tests: populated config, null config, buildAssetRegistry array, validation blockers
- [x] 7 SSR tests: published version + hash, first-publish-pending, validation errors, empty state, action buttons, read-only user, existing panels coexist
- [x] 14 existing characterization tests pass (no regression)

## Plan Deviations
- The plan says "replace raw Monster Visual Config panels with registry-shaped UI". Instead, the registry card is rendered **above** the existing `MonsterVisualConfigPanel` rather than replacing it. The raw panel provides essential per-asset editing capabilities (queue, field controls, effect bindings, preview grid) that the registry card does not replicate. Replacing it entirely would remove editing functionality. The registry card serves as the high-level status + action surface; the raw panel remains for detailed work.
- SSR test `nodePaths()` walks up the directory tree to find `node_modules` for worktree compatibility — the standard pattern (`rootDir/node_modules`) fails in git worktree environments.