### PR TITLE
feat(punctuation): U6 — derive Claspin Mega gate from cluster mapping

### DIFF
--- a/src/subjects/punctuation/star-projection.js
+++ b/src/subjects/punctuation/star-projection.js
@@ -39,7 +39,7 @@ const PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER = Object.freeze({
 
 // Re-export the mapping so downstream consumers can import from this
 // module without reaching into the view-model.
-export { PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER, ACTIVE_PUNCTUATION_MONSTER_IDS };
+export { PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER, ACTIVE_PUNCTUATION_MONSTER_IDS, CLASPIN_REQUIRED_SKILLS };
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -83,6 +83,16 @@ const SKILL_TO_CLUSTER = new Map([
   ['bullet_points', 'structure'],
   ['hyphen', 'boundary'],
 ]);
+
+// P6-U6: Derive the set of skill IDs required for the Claspin Mega gate
+// from the canonical SKILL_TO_CLUSTER mapping rather than hardcoding them.
+// If a new apostrophe skill is added to SKILL_TO_CLUSTER, this constant
+// will automatically include it — no code change needed.
+const CLASPIN_REQUIRED_SKILLS = Object.freeze(
+  Array.from(SKILL_TO_CLUSTER.entries())
+    .filter(([, c]) => c === 'apostrophe')
+    .map(([s]) => s),
+);
 
 // Exact rewardUnitId -> Set<clusterId> lookup.
 // Mirrors `PUNCTUATION_CLIENT_REWARD_UNITS` from read-model.js (not exported).
@@ -412,8 +422,7 @@ function computeMasteryStars(monsterClusterIds, facets, rewardUnits, monsterId) 
     const totalUnitsForMonster = MONSTER_UNIT_COUNT.claspin; // 2
     const hasAllUnitsSecured = securedUnitCount >= totalUnitsForMonster;
     const hasBothSkillsDeepSecure =
-      skillsWithDeepSecure.has('apostrophe_contractions') &&
-      skillsWithDeepSecure.has('apostrophe_possession');
+      CLASPIN_REQUIRED_SKILLS.every(s => skillsWithDeepSecure.has(s));
     const hasMixedModes = itemModes.size >= 2;
 
     const meetsDeepSecureGate =

--- a/tests/punctuation-star-projection.test.js
+++ b/tests/punctuation-star-projection.test.js
@@ -5,6 +5,7 @@ import {
   projectPunctuationStars,
   PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER,
   ACTIVE_PUNCTUATION_MONSTER_IDS,
+  CLASPIN_REQUIRED_SKILLS,
 } from '../src/subjects/punctuation/star-projection.js';
 import { PUNCTUATION_CLIENT_SKILLS } from '../src/subjects/punctuation/read-model.js';
 import {
@@ -1331,4 +1332,46 @@ test('U6: interpolation within a tier band — partial progress yields intermedi
     `Grand Stars should be below Hatch (35) with only 4 secured, got ${result.grand.grandStars}`);
   assert.ok(result.grand.grandStars > 15,
     `Grand Stars should interpolate above Egg floor with partial progress, got ${result.grand.grandStars}`);
+});
+
+// ---------------------------------------------------------------------------
+// P6-U6: CLASPIN_REQUIRED_SKILLS derivation parity tests
+// ---------------------------------------------------------------------------
+
+test('P6-U6: CLASPIN_REQUIRED_SKILLS contains exactly apostrophe_contractions and apostrophe_possession', () => {
+  // Verify the derived constant matches the expected hardcoded values.
+  const expected = ['apostrophe_contractions', 'apostrophe_possession'];
+  assert.deepStrictEqual(
+    [...CLASPIN_REQUIRED_SKILLS].sort(),
+    [...expected].sort(),
+    `CLASPIN_REQUIRED_SKILLS must contain exactly ${JSON.stringify(expected)}, got ${JSON.stringify([...CLASPIN_REQUIRED_SKILLS])}`,
+  );
+});
+
+test('P6-U6: CLASPIN_REQUIRED_SKILLS is frozen (immutable)', () => {
+  assert.ok(Object.isFrozen(CLASPIN_REQUIRED_SKILLS),
+    'CLASPIN_REQUIRED_SKILLS must be frozen');
+});
+
+test('P6-U6: CLASPIN_REQUIRED_SKILLS derivation — hypothetical 3rd apostrophe skill auto-included', () => {
+  // Simulate what would happen if SKILL_TO_CLUSTER gained a 3rd apostrophe
+  // entry by replicating the derivation logic on an extended Map.
+  const extendedMap = new Map([
+    ['apostrophe_contractions', 'apostrophe'],
+    ['apostrophe_possession', 'apostrophe'],
+    ['apostrophe_plural', 'apostrophe'], // hypothetical new skill
+  ]);
+
+  const derived = Array.from(extendedMap.entries())
+    .filter(([, c]) => c === 'apostrophe')
+    .map(([s]) => s);
+
+  assert.equal(derived.length, 3,
+    'Adding a 3rd apostrophe skill to the mapping must yield 3 entries');
+  assert.ok(derived.includes('apostrophe_plural'),
+    'The hypothetical skill must appear in the derived set');
+  assert.ok(derived.includes('apostrophe_contractions'),
+    'Existing skills must still be present');
+  assert.ok(derived.includes('apostrophe_possession'),
+    'Existing skills must still be present');
 });


### PR DESCRIPTION
## Summary
- Replace hardcoded `'apostrophe_contractions'` and `'apostrophe_possession'` string literals in the Claspin Mega gate with derivation from `SKILL_TO_CLUSTER`, so the gate automatically survives curriculum changes (R19)
- Add `CLASPIN_REQUIRED_SKILLS` as a frozen module-level constant derived via `SKILL_TO_CLUSTER.entries().filter(apostrophe)`
- Export the constant for test parity verification

## Changes
- **`src/subjects/punctuation/star-projection.js`**: Add `CLASPIN_REQUIRED_SKILLS` derived from `SKILL_TO_CLUSTER`, replace two hardcoded `.has()` checks with `.every()` over the derived array, export the new constant
- **`tests/punctuation-star-projection.test.js`**: 3 new parity tests — exact content match, frozen check, hypothetical 3rd skill auto-inclusion proof

## Test plan
- [x] All 52 existing star-projection tests pass (no regressions)
- [x] All 23 read-model tests pass (no regressions)
- [x] Parity: `CLASPIN_REQUIRED_SKILLS` contains exactly `['apostrophe_contractions', 'apostrophe_possession']`
- [x] Parity: constant is frozen (immutable)
- [x] Parity: derivation logic auto-includes hypothetical 3rd apostrophe skill
- [x] No engine files or contentReleaseId changed