### PR TITLE
feat(punctuation): U3 — monotonic displayStage and displayStars in view-model

### DIFF
--- a/src/subjects/punctuation/components/PunctuationMapScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationMapScene.jsx
@@ -51,6 +51,7 @@ import {
   buildPunctuationMapModel,
   composeIsDisabled,
   composeIsNavigationDisabled,
+  mergeMonotonicDisplay,
   punctuationChildStatusLabel,
   punctuationChildUnknownHelperCopy,
   punctuationMonsterDisplayName,
@@ -244,14 +245,11 @@ function MonsterGroup({ monster, statusFilter, disabled, actions, starView, rewa
   const starDerivedStage = starEntry
     ? Math.max(0, Math.floor(Number(starEntry.starDerivedStage) || 0))
     : 0;
-  // U3 (Phase 6): monotonic display — merge codex high-water marks so the
-  // Map scene never shows a monster at a lower stage than previously seen.
+  // U3 review follow-up (MEDIUM ADV-395-2/3): use shared monotonic merge
+  // helper so sanitisation is consistent with the view-model and Summary.
   const safeReward = rewardState && typeof rewardState === 'object' && !Array.isArray(rewardState) ? rewardState : {};
   const codexEntry = safeReward[monster.monsterId];
-  const maxStageEver = Math.max(0, Math.floor(Number(codexEntry?.maxStageEver) || 0));
-  const starHighWater = Math.max(0, Math.floor(Number(codexEntry?.starHighWater) || 0));
-  const displayStars = Math.max(totalStars, starHighWater);
-  const displayStage = Math.max(starDerivedStage, maxStageEver);
+  const { displayStars, displayStage } = mergeMonotonicDisplay(totalStars, starDerivedStage, codexEntry);
   const starsLabel = isGrand ? 'Grand Stars' : 'Stars';
   const stageText = punctuationStageLabel(displayStage, displayStars);
   return (

--- a/src/subjects/punctuation/components/PunctuationMapScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationMapScene.jsx
@@ -218,7 +218,7 @@ function SkillCard({ skill, disabled, actions }) {
   );
 }
 
-function MonsterGroup({ monster, statusFilter, disabled, actions, starView }) {
+function MonsterGroup({ monster, statusFilter, disabled, actions, starView, rewardState }) {
   const filteredSkills = statusFilter === 'all'
     ? monster.skills
     : monster.skills.filter((skill) => skill.status === statusFilter);
@@ -244,8 +244,16 @@ function MonsterGroup({ monster, statusFilter, disabled, actions, starView }) {
   const starDerivedStage = starEntry
     ? Math.max(0, Math.floor(Number(starEntry.starDerivedStage) || 0))
     : 0;
+  // U3 (Phase 6): monotonic display — merge codex high-water marks so the
+  // Map scene never shows a monster at a lower stage than previously seen.
+  const safeReward = rewardState && typeof rewardState === 'object' && !Array.isArray(rewardState) ? rewardState : {};
+  const codexEntry = safeReward[monster.monsterId];
+  const maxStageEver = Math.max(0, Math.floor(Number(codexEntry?.maxStageEver) || 0));
+  const starHighWater = Math.max(0, Math.floor(Number(codexEntry?.starHighWater) || 0));
+  const displayStars = Math.max(totalStars, starHighWater);
+  const displayStage = Math.max(starDerivedStage, maxStageEver);
   const starsLabel = isGrand ? 'Grand Stars' : 'Stars';
-  const stageText = punctuationStageLabel(starDerivedStage, totalStars);
+  const stageText = punctuationStageLabel(displayStage, displayStars);
   return (
     <section
       className="punctuation-map-monster-group"
@@ -255,7 +263,7 @@ function MonsterGroup({ monster, statusFilter, disabled, actions, starView }) {
       <header className="punctuation-map-monster-group-head">
         <h3>{monster.name}</h3>
         <p className="muted">
-          {`${totalStars} / 100 ${starsLabel}`} · {stageText}
+          {`${displayStars} / 100 ${starsLabel}`} · {stageText}
         </p>
       </header>
       <div className="punctuation-map-skill-grid">
@@ -408,6 +416,7 @@ export function PunctuationMapScene({ ui, actions }) {
               disabled={disabled}
               actions={actions}
               starView={starView}
+              rewardState={rewardState}
             />
           ))
           : <div className="punctuation-map-empty muted">No matching skills yet.</div>}

--- a/src/subjects/punctuation/components/PunctuationSetupScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationSetupScene.jsx
@@ -255,8 +255,13 @@ export function PunctuationSetupScene({ ui, actions, prefs, stats, learner, rewa
   // Progress row values
   const dueCount = Number(stats?.due) || 0;
   const weakCount = Number(stats?.weak) || 0;
+  // U3 review follow-up (HIGH 1): use displayStars (monotonic) for the
+  // aggregate, matching MonsterStarMeter which already reads displayStars.
+  // Prior code used raw totalStars, causing a mismatch between the
+  // progress-row aggregate and the individual meter values after evidence
+  // lapse.
   const totalStarsEarned = dashboard.activeMonsters.reduce(
-    (sum, m) => sum + (m.totalStars || 0), 0,
+    (sum, m) => sum + (m.displayStars ?? m.totalStars ?? 0), 0,
   );
 
   const learnerName = learner && typeof learner === 'object' && !Array.isArray(learner)

--- a/src/subjects/punctuation/components/PunctuationSetupScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationSetupScene.jsx
@@ -156,8 +156,12 @@ function RoundLengthToggle({ selectedValue, disabled, actions }) {
 function MonsterStarMeter({ monster }) {
   const cap = monster.id === 'quoral' ? 100 : 100;
   const starsLabel = monster.id === 'quoral' ? 'Grand Stars' : 'Stars';
-  const pct = Math.min(100, Math.max(0, Math.round((monster.totalStars / cap) * 100)));
-  const stageText = punctuationStageLabel(monster.starDerivedStage, monster.totalStars);
+  // U3 (Phase 6): use monotonic displayStars / displayStage so a monster
+  // never appears to de-evolve after evidence lapse.
+  const stars = monster.displayStars ?? monster.totalStars;
+  const stage = monster.displayStage ?? monster.starDerivedStage;
+  const pct = Math.min(100, Math.max(0, Math.round((stars / cap) * 100)));
+  const stageText = punctuationStageLabel(stage, stars);
 
   return (
     <div className="punctuation-monster-meter" data-monster-id={monster.id}>
@@ -170,7 +174,7 @@ function MonsterStarMeter({ monster }) {
         />
       </div>
       <div className="punctuation-monster-meter-count">
-        {`${monster.totalStars} / ${cap} ${starsLabel}`}
+        {`${stars} / ${cap} ${starsLabel}`}
       </div>
     </div>
   );

--- a/src/subjects/punctuation/components/PunctuationSummaryScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationSummaryScene.jsx
@@ -66,6 +66,7 @@ import {
   composeIsDisabled,
   composeIsNavigationDisabled,
   extractPunctuationMonsterProgress,
+  mergeMonotonicDisplay,
   punctuationChildMisconceptionLabel,
   punctuationChildNextReviewCopy,
   punctuationChildRegisterOverrideString,
@@ -391,16 +392,12 @@ function MonsterProgressStrip({ ui, rewardState: propRewardState }) {
         const starDerivedStage = starEntry
           ? Math.max(0, Math.floor(Number(starEntry.starDerivedStage) || 0))
           : 0;
-        // U3 (Phase 6): monotonic display — merge codex high-water marks
-        // so the Summary scene never shows a monster at a lower stage than
-        // previously seen. rewardState carries maxStageEver / starHighWater
-        // persisted by the mastery layer.
-        const safeReward = rewardState && typeof rewardState === 'object' && !Array.isArray(rewardState) ? rewardState : {};
-        const codexEntry = safeReward[monsterId];
-        const maxStageEver = Math.max(0, Math.floor(Number(codexEntry?.maxStageEver) || 0));
-        const starHighWater = Math.max(0, Math.floor(Number(codexEntry?.starHighWater) || 0));
-        const displayStars = Math.max(totalStars, starHighWater);
-        const displayStage = Math.max(starDerivedStage, maxStageEver);
+        // U3 review follow-up (MEDIUM ADV-395-2/3): use shared monotonic
+        // merge helper so sanitisation is consistent across all scenes.
+        // Finding 3: rewardState is already resolved at the function top
+        // via rewardStateForPunctuation — no redundant re-validation needed.
+        const codexEntry = rewardState?.[monsterId];
+        const { displayStars, displayStage } = mergeMonotonicDisplay(totalStars, starDerivedStage, codexEntry);
         const cap = 100;
         const starsLabel = isGrand ? 'Grand Stars' : 'Stars';
         const stageText = punctuationStageLabel(displayStage, displayStars);

--- a/src/subjects/punctuation/components/PunctuationSummaryScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationSummaryScene.jsx
@@ -391,10 +391,20 @@ function MonsterProgressStrip({ ui, rewardState: propRewardState }) {
         const starDerivedStage = starEntry
           ? Math.max(0, Math.floor(Number(starEntry.starDerivedStage) || 0))
           : 0;
+        // U3 (Phase 6): monotonic display — merge codex high-water marks
+        // so the Summary scene never shows a monster at a lower stage than
+        // previously seen. rewardState carries maxStageEver / starHighWater
+        // persisted by the mastery layer.
+        const safeReward = rewardState && typeof rewardState === 'object' && !Array.isArray(rewardState) ? rewardState : {};
+        const codexEntry = safeReward[monsterId];
+        const maxStageEver = Math.max(0, Math.floor(Number(codexEntry?.maxStageEver) || 0));
+        const starHighWater = Math.max(0, Math.floor(Number(codexEntry?.starHighWater) || 0));
+        const displayStars = Math.max(totalStars, starHighWater);
+        const displayStage = Math.max(starDerivedStage, maxStageEver);
         const cap = 100;
         const starsLabel = isGrand ? 'Grand Stars' : 'Stars';
-        const stageText = punctuationStageLabel(starDerivedStage, totalStars);
-        const pct = Math.min(100, Math.max(0, Math.round((totalStars / cap) * 100)));
+        const stageText = punctuationStageLabel(displayStage, displayStars);
+        const pct = Math.min(100, Math.max(0, Math.round((displayStars / cap) * 100)));
         return (
           <div
             className="punctuation-summary-monster punctuation-monster-meter"
@@ -411,9 +421,9 @@ function MonsterProgressStrip({ ui, rewardState: propRewardState }) {
             </div>
             <div
               className="punctuation-monster-meter-count"
-              aria-label={`${name} ${totalStars} of ${cap} ${starsLabel}`}
+              aria-label={`${name} ${displayStars} of ${cap} ${starsLabel}`}
             >
-              {`${totalStars} / ${cap} ${starsLabel}`}
+              {`${displayStars} / ${cap} ${starsLabel}`}
             </div>
           </div>
         );

--- a/src/subjects/punctuation/components/punctuation-view-model.js
+++ b/src/subjects/punctuation/components/punctuation-view-model.js
@@ -1147,6 +1147,31 @@ function safeNumber(value, fallback = 0) {
   return Number.isFinite(num) && num >= 0 ? Math.floor(num) : fallback;
 }
 
+// U3 review follow-up: shared monotonic merge helper. Combines live Star
+// projection values (from starView) with persisted codex high-water marks
+// (maxStageEver / starHighWater from rewardState) so every scene displays
+// the max of (live, persisted) for both stage and Stars. This guarantees a
+// monster never appears to de-evolve after evidence lapse.
+//
+// Parameters:
+//   liveStars      — current Star total from the read-model (starView)
+//   liveStage      — current starDerivedStage from the read-model
+//   codexEntry     — the rewardState entry for this monster (carries
+//                    maxStageEver + starHighWater)
+//
+// Returns: { displayStars, displayStage } — the monotonic-max values
+//          safe for child-facing rendering.
+export function mergeMonotonicDisplay(liveStars, liveStage, codexEntry) {
+  const stars = safeNumber(liveStars, 0);
+  const stage = safeNumber(liveStage, 0);
+  const maxStageEver = safeNumber(codexEntry?.maxStageEver, 0);
+  const starHighWater = safeNumber(codexEntry?.starHighWater, 0);
+  return {
+    displayStars: Math.max(stars, starHighWater),
+    displayStage: Math.max(stage, maxStageEver),
+  };
+}
+
 function activeMonsterProgressFromReward(rewardState, starView) {
   const safeReward = rewardState && typeof rewardState === 'object' && !Array.isArray(rewardState)
     ? rewardState
@@ -1178,15 +1203,12 @@ function activeMonsterProgressFromReward(rewardState, starView) {
       : 0;
     const starDerivedStage = starEntry ? safeNumber(starEntry.starDerivedStage, 0) : 0;
 
-    // U3 (Phase 6): monotonic display values. The codex (rewardState)
-    // persists maxStageEver and starHighWater per monster — these survive
-    // evidence lapse so the child never sees a monster de-evolve. The
-    // read-model computes live Star values; the view-model merges the
-    // codex high-water marks here for child-facing display.
-    const maxStageEver = safeNumber(entry?.maxStageEver, 0);
-    const starHighWater = safeNumber(entry?.starHighWater, 0);
-    const displayStage = Math.max(starDerivedStage, maxStageEver);
-    const displayStars = Math.max(totalStars, starHighWater);
+    // U3 (Phase 6): monotonic display values via shared helper. The codex
+    // (rewardState) persists maxStageEver and starHighWater per monster —
+    // these survive evidence lapse so the child never sees a monster
+    // de-evolve. mergeMonotonicDisplay centralises the Math.max merge so
+    // Setup, Map, and Summary all use one sanitisation path.
+    const { displayStage, displayStars } = mergeMonotonicDisplay(totalStars, starDerivedStage, entry);
 
     return Object.freeze({
       id: monsterId,

--- a/src/subjects/punctuation/components/punctuation-view-model.js
+++ b/src/subjects/punctuation/components/punctuation-view-model.js
@@ -1178,12 +1178,24 @@ function activeMonsterProgressFromReward(rewardState, starView) {
       : 0;
     const starDerivedStage = starEntry ? safeNumber(starEntry.starDerivedStage, 0) : 0;
 
+    // U3 (Phase 6): monotonic display values. The codex (rewardState)
+    // persists maxStageEver and starHighWater per monster — these survive
+    // evidence lapse so the child never sees a monster de-evolve. The
+    // read-model computes live Star values; the view-model merges the
+    // codex high-water marks here for child-facing display.
+    const maxStageEver = safeNumber(entry?.maxStageEver, 0);
+    const starHighWater = safeNumber(entry?.starHighWater, 0);
+    const displayStage = Math.max(starDerivedStage, maxStageEver);
+    const displayStars = Math.max(totalStars, starHighWater);
+
     return Object.freeze({
       id: monsterId,
       name: punctuationMonsterDisplayName(monsterId),
       mastered,
       totalStars,
       starDerivedStage,
+      displayStage,
+      displayStars,
     });
   });
 }

--- a/tests/punctuation-view-model.test.js
+++ b/tests/punctuation-view-model.test.js
@@ -1162,3 +1162,145 @@ test('U7 view-model: punctuationStageLabel(-1) → Not caught (negative out-of-r
 test('U7 view-model: punctuationStageLabel(NaN) → Not caught (non-finite fallback)', () => {
   assert.equal(punctuationStageLabel(NaN), 'Not caught');
 });
+
+// ---------------------------------------------------------------------------
+// U3 (Phase 6) — monotonic displayStage and displayStars in view-model.
+// The view-model merges codex high-water marks (maxStageEver, starHighWater)
+// so a child's monster never appears to de-evolve after evidence lapse.
+// ---------------------------------------------------------------------------
+
+test('U3 view-model: displayStage = max(starDerivedStage, maxStageEver) — maxStageEver wins', () => {
+  const rewardState = {
+    pealark: { mastered: ['m1'], maxStageEver: 3 },
+  };
+  const starView = {
+    perMonster: { pealark: { total: 15, starDerivedStage: 2, tryStars: 5, practiceStars: 5, secureStars: 3, masteryStars: 2 } },
+    grand: { grandStars: 0, total: 100, starDerivedStage: 0 },
+  };
+  const model = buildPunctuationDashboardModel({}, null, rewardState, starView);
+  const pealark = model.activeMonsters.find((m) => m.id === 'pealark');
+  assert.equal(pealark.displayStage, 3, 'maxStageEver 3 > starDerivedStage 2');
+  assert.equal(pealark.starDerivedStage, 2, 'raw starDerivedStage preserved');
+});
+
+test('U3 view-model: displayStage = max(starDerivedStage, maxStageEver) — starDerivedStage wins', () => {
+  const rewardState = {
+    claspin: { mastered: ['m1'], maxStageEver: 2 },
+  };
+  const starView = {
+    perMonster: { claspin: { total: 40, starDerivedStage: 3, tryStars: 10, practiceStars: 10, secureStars: 10, masteryStars: 10 } },
+    grand: { grandStars: 0, total: 100, starDerivedStage: 0 },
+  };
+  const model = buildPunctuationDashboardModel({}, null, rewardState, starView);
+  const claspin = model.activeMonsters.find((m) => m.id === 'claspin');
+  assert.equal(claspin.displayStage, 3, 'starDerivedStage 3 > maxStageEver 2');
+});
+
+test('U3 view-model: fresh learner (no maxStageEver) → displayStage = starDerivedStage', () => {
+  const rewardState = {};
+  const starView = {
+    perMonster: { curlune: { total: 10, starDerivedStage: 1, tryStars: 5, practiceStars: 3, secureStars: 2, masteryStars: 0 } },
+    grand: { grandStars: 0, total: 100, starDerivedStage: 0 },
+  };
+  const model = buildPunctuationDashboardModel({}, null, rewardState, starView);
+  const curlune = model.activeMonsters.find((m) => m.id === 'curlune');
+  assert.equal(curlune.displayStage, 1, 'no maxStageEver → displayStage equals starDerivedStage');
+});
+
+test('U3 view-model: evidence lapse reduces starDerivedStage but displayStage holds', () => {
+  // Simulate: learner once reached stage 2, but evidence lapsed and
+  // star-derived stage dropped to 1. displayStage must stay at 2.
+  const rewardState = {
+    pealark: { mastered: ['m1'], maxStageEver: 2, starHighWater: 25 },
+  };
+  const starView = {
+    perMonster: { pealark: { total: 12, starDerivedStage: 1, tryStars: 5, practiceStars: 4, secureStars: 2, masteryStars: 1 } },
+    grand: { grandStars: 0, total: 100, starDerivedStage: 0 },
+  };
+  const model = buildPunctuationDashboardModel({}, null, rewardState, starView);
+  const pealark = model.activeMonsters.find((m) => m.id === 'pealark');
+  assert.equal(pealark.displayStage, 2, 'displayStage stays at maxStageEver despite lapse');
+  assert.equal(pealark.starDerivedStage, 1, 'raw value reflects the lapse');
+});
+
+test('U3 view-model: displayStars = max(totalStars, starHighWater) — starHighWater wins', () => {
+  const rewardState = {
+    pealark: { mastered: ['m1'], starHighWater: 45 },
+  };
+  const starView = {
+    perMonster: { pealark: { total: 38, starDerivedStage: 2, tryStars: 10, practiceStars: 10, secureStars: 10, masteryStars: 8 } },
+    grand: { grandStars: 0, total: 100, starDerivedStage: 0 },
+  };
+  const model = buildPunctuationDashboardModel({}, null, rewardState, starView);
+  const pealark = model.activeMonsters.find((m) => m.id === 'pealark');
+  assert.equal(pealark.displayStars, 45, 'starHighWater 45 > totalStars 38');
+  assert.equal(pealark.totalStars, 38, 'raw totalStars preserved');
+});
+
+test('U3 view-model: displayStars = max(totalStars, starHighWater) — totalStars wins', () => {
+  const rewardState = {
+    claspin: { mastered: ['m1'], starHighWater: 20 },
+  };
+  const starView = {
+    perMonster: { claspin: { total: 35, starDerivedStage: 2, tryStars: 10, practiceStars: 10, secureStars: 10, masteryStars: 5 } },
+    grand: { grandStars: 0, total: 100, starDerivedStage: 0 },
+  };
+  const model = buildPunctuationDashboardModel({}, null, rewardState, starView);
+  const claspin = model.activeMonsters.find((m) => m.id === 'claspin');
+  assert.equal(claspin.displayStars, 35, 'totalStars 35 > starHighWater 20');
+});
+
+test('U3 view-model: NaN / missing maxStageEver and starHighWater treated as 0', () => {
+  const rewardState = {
+    pealark: { mastered: [], maxStageEver: NaN, starHighWater: undefined },
+  };
+  const starView = {
+    perMonster: { pealark: { total: 10, starDerivedStage: 1, tryStars: 5, practiceStars: 3, secureStars: 2, masteryStars: 0 } },
+    grand: { grandStars: 0, total: 100, starDerivedStage: 0 },
+  };
+  const model = buildPunctuationDashboardModel({}, null, rewardState, starView);
+  const pealark = model.activeMonsters.find((m) => m.id === 'pealark');
+  assert.equal(pealark.displayStage, 1, 'NaN maxStageEver → treated as 0, starDerivedStage wins');
+  assert.equal(pealark.displayStars, 10, 'undefined starHighWater → treated as 0, totalStars wins');
+});
+
+test('U3 view-model: grand monster (quoral) also gets monotonic display fields', () => {
+  const rewardState = {
+    quoral: { mastered: ['m1', 'm2'], maxStageEver: 2, starHighWater: 30 },
+  };
+  const starView = {
+    perMonster: {},
+    grand: { grandStars: 20, total: 100, starDerivedStage: 1 },
+  };
+  const model = buildPunctuationDashboardModel({}, null, rewardState, starView);
+  const quoral = model.activeMonsters.find((m) => m.id === 'quoral');
+  assert.equal(quoral.displayStage, 2, 'grand monster maxStageEver 2 > starDerivedStage 1');
+  assert.equal(quoral.displayStars, 30, 'grand monster starHighWater 30 > grandStars 20');
+});
+
+test('U3 view-model: punctuationStageLabel(displayStage, displayStars) produces correct label after lapse', () => {
+  // Scenario: monster was at stage 3 (Evolve) with 45 stars. Lapse dropped
+  // starDerivedStage to 1 and totalStars to 12. displayStage/displayStars
+  // should still yield "Evolve".
+  const rewardState = {
+    pealark: { mastered: ['m1'], maxStageEver: 3, starHighWater: 45 },
+  };
+  const starView = {
+    perMonster: { pealark: { total: 12, starDerivedStage: 1, tryStars: 5, practiceStars: 4, secureStars: 2, masteryStars: 1 } },
+    grand: { grandStars: 0, total: 100, starDerivedStage: 0 },
+  };
+  const model = buildPunctuationDashboardModel({}, null, rewardState, starView);
+  const pealark = model.activeMonsters.find((m) => m.id === 'pealark');
+  const label = punctuationStageLabel(pealark.displayStage, pealark.displayStars);
+  assert.equal(label, 'Evolve', 'stage 3 = Evolve even after evidence lapse');
+});
+
+test('U3 view-model: all four monsters receive displayStage and displayStars fields', () => {
+  const model = buildPunctuationDashboardModel({}, null, {}, null);
+  for (const monster of model.activeMonsters) {
+    assert.equal(typeof monster.displayStage, 'number', `${monster.id} must have displayStage`);
+    assert.equal(typeof monster.displayStars, 'number', `${monster.id} must have displayStars`);
+    assert.ok(monster.displayStage >= 0, `${monster.id} displayStage must be >= 0`);
+    assert.ok(monster.displayStars >= 0, `${monster.id} displayStars must be >= 0`);
+  }
+});


### PR DESCRIPTION
## Summary
- Adds monotonic `displayStage` and `displayStars` fields to the view-model's `activeMonsterProgressFromReward` output, computed as `max(starDerivedStage, maxStageEver)` and `max(totalStars, starHighWater)` respectively
- Updates all three scene consumers (PunctuationSetupScene, PunctuationSummaryScene, PunctuationMapScene) to render via the monotonic display values so a child's monster never appears to de-evolve after evidence lapse
- Adds 11 test scenarios covering happy paths, lapse recovery, NaN/missing codex fields, grand monster, and integration with `punctuationStageLabel`

## Requirement
R13 — monotonic child reward display. The read-model computes live Star values; the view-model merges codex `maxStageEver`/`starHighWater` high-water marks (persisted by U1) for child-facing display.

## Test plan
- [x] `node --test tests/punctuation-view-model.test.js` — 107 pass (11 new U3 tests)
- [x] `node --test tests/punctuation-read-model.test.js` — 23 pass (no changes needed)
- [x] No read-model or engine file changes — release-id impact: none