### PR TITLE
feat(hero): Hero Mode P1 — Launchable Task Envelopes and Subject Command Bridge

### DIFF
--- a/docs/plans/2026-04-27-002-feat-hero-mode-p1-launchable-task-envelopes-plan.md
+++ b/docs/plans/2026-04-27-002-feat-hero-mode-p1-launchable-task-envelopes-plan.md
@@ -1,0 +1,594 @@
+---
+title: "feat: Hero Mode P1 — Launchable Task Envelopes and Subject Command Bridge"
+type: feat
+status: active
+date: 2026-04-27
+origin: docs/plans/james/hero-mode/hero-mode-p1.md
+deepened: 2026-04-27
+---
+
+# feat: Hero Mode P1 — Launchable Task Envelopes and Subject Command Bridge
+
+## Overview
+
+P1 turns P0's read-only shadow quest into a safe launch bridge: a selected Hero task envelope can start the correct subject session through the existing Worker subject command boundary, carrying an opaque `heroContext`, without showing child-facing Hero UI, awarding Coins, claiming progress, or creating Hero-owned persistent state.
+
+P1 is not the public launch of Hero Mode. It is the engineering proof that a Hero task can become a real subject session without Hero Mode becoming a subject engine, a reward engine, or a parallel command system.
+
+---
+
+## Problem Frame
+
+P0 proved the platform can compute a safe, deterministic, daily Hero mission. But a shadow quest that never starts a real session is inert. P2 (child-facing UI) needs a proven launch path — without it, the UI would drive the architecture instead of the learning contract driving the UI.
+
+The core engineering challenge: Hero must delegate session creation to the existing subject command pipeline (`repository.runSubjectCommand → subjectRuntime.dispatch`) without becoming a parallel command system. The `POST /api/hero/command` route must reuse every security gate, idempotency check, CAS guard, and demo protection that `POST /api/subjects/:subjectId/command` already enforces.
+
+(see origin: `docs/plans/james/hero-mode/hero-mode-p1.md` §3, §7, §13)
+
+---
+
+## Requirements Trace
+
+- R1. Hero task envelopes carry stable, deterministic `taskId`s derived from quest composition — not from copy, UI order, or client input
+- R2. `heroContext` is built server-side, opaque to subject engines, attached to active sessions, and excluded from mastery/reward paths
+- R3. Launch adapters map Hero envelopes to subject `start-session` payloads without importing subject runtime or mutating state
+- R4. `POST /api/hero/command` (command: `start-task`) routes through the existing subject command mutation path — same security chain, same CAS, same idempotency, same demo protection
+- R5. Server recomputes the quest on every launch request; client-supplied `questId`/`taskId` are validated against the recomputed quest, never trusted
+- R6. Unlaunchable tasks are marked with explicit `launchStatus` and `reason` — never hidden or silently skipped
+- R7. P1 writes only through the existing subject command path; zero Hero-owned persistent state (no Coins, no ledger, no monster state, no quest progress, no task completion)
+- R8. `GET /api/hero/read-model` remains read-only; P0 fields are preserved; new fields are additive
+- R9. Feature flags: `HERO_MODE_LAUNCH_ENABLED` (new, default false) independent of `HERO_MODE_SHADOW_ENABLED`
+- R10. At minimum Spelling launches end-to-end; Grammar and Punctuation either launch or are marked `not-launchable` with precise reasons
+- R11. Existing subject start-session behaviour works without `heroContext` (no regressions)
+- R12. Punctuation feature gate is respected by Hero launch — no bypass via `/api/hero/command`
+- R13. No child-facing Hero UI, no dashboard card, no Hero Camp, no Coins copy
+
+**Origin acceptance examples:**
+- AE1 (§28 Product): Hero remains platform orchestrator, not seventh subject → R7, R13
+- AE2 (§28 Architecture): Launch route behind flag, through existing mutation path → R4, R9
+- AE3 (§28 Subject): At least Spelling launches E2E; heroContext on active session → R2, R10
+- AE4 (§28 Safety): No Hero Coins/ledger/monster; no child UI; Punctuation gate respected → R7, R12, R13
+- AE5 (§28 Testing): All test categories pass; existing tests stay green → R11
+
+---
+
+## Scope Boundaries
+
+- No child-facing Hero dashboard card, CTA, or navigation
+- No Hero Coins, Hero ledger, Hero Camp, monster ownership, or unlock/evolve commands
+- No task completion claims or daily progress persistence
+- No Hero commands beyond `start-task`
+- No new D1 tables or Hero-specific migrations
+- No changes to subject mastery algorithms, Star calculations, or reward projections
+- No subject session continuation, answer submission, or session ending through Hero routes
+- No Arithmetic, Reasoning, or Reading providers or launch adapters
+- No streaks, "Daily Deal" copy, or parent-facing Hero analytics page (origin §4 items 9-11)
+- No capacity telemetry for `GET /api/hero/read-model` (deferred to P2)
+- Error code `hero_active_session_conflict` (origin §12) is not returned in P1 — P2 client code must not depend on it
+
+### Deferred to Follow-Up Work
+
+- Child-facing Today's Hero Quest UI: P2
+- Task completion claim and capped Coins ledger: P3
+- Hero Camp and Hero Monster Pool: P4
+- Active-session conflict detection for Hero tasks (same `heroContext.taskId` already active): P2/P3 — P1 relies on existing subject stale-session handling
+- Content release fingerprint implementation: P2 — P1 compensates with scheduler version + quest recomputation as stale-launch defence
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+**Subject command pipeline** (`worker/src/app.js:1113-1170`): POST route enforces `requireSameOrigin → requireMutationCapability → readJson → normaliseSubjectCommandRequest → requireSubjectCommandAvailable → protectDemoSubjectCommand → repository.runSubjectCommand(... subjectRuntime.dispatch(...))`. This is the mutation path P1 must route through.
+
+**Command contract** (`worker/src/subjects/command-contract.js`): Normalises `{ subjectId, command, learnerId, requestId, correlationId, expectedLearnerRevision, payload }`. The `payload` field is a plain object passed directly to the subject engine.
+
+**Subject start-session payloads:**
+- Spelling (`worker/src/subjects/spelling/engine.js:371`): `{ mode, yearFilter, length, words, practiceOnly, extraWordFamilies, patternId }`. Modes: smart, trouble, test, guardian, boss, pattern-quest, single.
+- Grammar (`worker/src/subjects/grammar/engine.js:927`): `{ mode, templateId, focusConceptId, skillId, roundLength, seed, goalType }`. Modes: learn, smart, satsset, trouble, surgery, builder, worked, faded.
+- Punctuation (`worker/src/subjects/punctuation/engine.js:149`): `{ mode, skillId, guidedSkillId, length, roundLength }`. Modes: smart, guided, weak, gps, endmarks, apostrophe, speech, comma_flow, boundary, structure.
+
+**P0 codebase** (`shared/hero/`, `worker/src/hero/`): 6 shared modules + 6 Worker modules. Pure layer with zero Worker/D1 imports. Providers read-only. Route at `app.js:1323`.
+
+**No-write boundary tests** (`tests/hero-no-write-boundary.test.js`): S1-S6 structural (source scan for forbidden tokens), B7-B8 behavioural (table row count before/after, POST 404 assertion).
+
+**Idempotency** (`worker/src/repository.js:7818-8063`): `requestId → mutationPayloadHash → receipt lookup → CAS retry (3 attempts)`. Same `requestId` + same hash = replay. Same `requestId` + different hash = `idempotency_reuse_error`.
+
+**Feature flags**: `wrangler.jsonc` vars + local `envFlagEnabled()` helper (truthy string comparison). Pattern: `HERO_MODE_SHADOW_ENABLED`, `PUNCTUATION_SUBJECT_ENABLED`.
+
+### Institutional Learnings
+
+- **Hero P0 read-only shadow subsystem** (`docs/solutions/architecture-patterns/hero-p0-read-only-shadow-subsystem-2026-04-27.md`): Three-layer architecture, provider pattern for cross-subject orchestration, no-write boundary proof (structural + behavioural). P1 must preserve P0's structural boundary tests for the GET path.
+- **D1 atomicity** (memory): `withTransaction` is production no-op; `batch()` is canonical. P1 does not introduce new multi-statement writes (routes through existing `runSubjectCommandMutation`), but this remains a standing constraint.
+- **Adversarial review catches highest-severity issues** (`docs/solutions/workflow-issues/sys-hardening-p2-13-unit-autonomous-sprint-learnings-2026-04-26.md`): Pattern-match review missed all four highest-severity blockers in sys-hardening. Hero P1 touches security boundaries and state-machine lifecycle — adversarial review warranted.
+
+---
+
+## Key Technical Decisions
+
+- **Structure A (app owns dispatch)**: `worker/src/hero/launch.js` resolves the Hero command into a subject command shape; `worker/src/app.js` calls `repository.runSubjectCommand(... subjectRuntime.dispatch(...))` directly. This keeps `worker/src/hero/` free of subject runtime imports. (see origin §13, Preferred Structure A)
+
+- **Scheduler version bump**: `hero-p0-shadow-v1` → `hero-p1-launch-v1`. Task IDs depend on scheduler version; P1 changes task identity semantics (tasks now carry stable IDs and launch status). Stale launch requests from cached P0 quests will fail cleanly. (see origin §17)
+
+- **Read model version bump**: `hero.version` 1 → 2. Response shape adds `taskId`, `launchStatus`, `heroContext` per task, and `launch` capability block. Additive but structurally significant. (see origin §16, Option B)
+
+- **Task ID derivation**: `djb2Hash(questId + '|' + ordinal + '|' + subjectId + '|' + intent + '|' + launcher + '|' + effortTarget + '|' + sortedReasonTags)`. Deterministic, copy-independent, order-dependent. (see origin §8)
+
+- **Launch status vocabulary**: `launchable`, `not-launchable`, `subject-unavailable`, `stale`, `blocked`. Returned per-task in the read model. (see origin §9)
+
+- **Content fingerprint remains null in P1**: Compensated by scheduler version bump + server-side quest recomputation on every launch request. Real fingerprint deferred to P2. (see origin §2 fingerprint discussion)
+
+- **All three subjects targeted for launch**: Spelling, Grammar, and Punctuation all have clear `start-session` mode mappings. If any mapping proves unsafe during implementation, that subject's tasks are marked `not-launchable` rather than faked. (see origin §25)
+
+- **Capacity telemetry for launch route**: Add `/api/hero/command` to `CAPACITY_RELEVANT_PATH_PATTERNS` because it executes subject commands on the same hot path. (see origin §23)
+
+- **heroContext requires active session-state injection, not contamination prevention**: All three subject normalisers are whitelist-based — Punctuation's `normalisePunctuationPrefs` outputs only `{mode, roundLength}`, Grammar's `startSession` constructs session state from explicit named fields, and Spelling's `startOptionsFromPayload` extracts only 7 named fields. Unknown payload keys (including `heroContext`) are silently discarded by all three paths. The real U5 work is actively *adding* a `heroContext` field to each engine's session-state construction, not preventing leaks. Each engine must: (a) extract `heroContext` from `command.payload`, (b) add it as a named field on the session state object, and (c) verify it persists through `session_state_json`. (feasibility review correction)
+
+- **subjectCommand shape must match normaliseSubjectCommandRequest output**: `resolveHeroStartTaskCommand` must return a `subjectCommand` with the exact same shape as `normaliseSubjectCommandRequest` output: `{ subjectId, command: 'start-session', learnerId, requestId, correlationId, expectedLearnerRevision, payload }`. The `command` field is `'start-session'` (the subject command), not `'start-task'` (the Hero command). `correlationId` defaults to `requestId` if absent in the Hero request body, replicating `normaliseSubjectCommandRequest`'s fallback logic. This is critical because `protectDemoSubjectCommand` buckets rate-limiting on `command.subjectId + command.command`, and `runSubjectCommand` validates required fields. (flow analysis finding C2)
+
+- **Flag interaction rule**: `HERO_MODE_LAUNCH_ENABLED=true` requires `HERO_MODE_SHADOW_ENABLED=true`. If launch is enabled without shadow, the route returns 409 `hero_launch_misconfigured`. Rationale: the launch route internally calls `buildHeroShadowReadModel`, which works regardless, but the API surface becomes inconsistent (can launch but cannot read). Requiring both flags prevents staging confusion. (see origin §21)
+
+- **ProjectionUnavailableError handling on launch route**: The Hero command route must replicate the same `ProjectionUnavailableError` catch block from the subject command route (`app.js:1156-1167`). Without it, projection exhaustion returns a generic 500, and the client's `isCommandBackendExhausted` classifier cannot parse it. (flow analysis finding I1)
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Quest fingerprint strategy**: Null in P1; stale-launch defence is scheduler version + server-side recomputation. This is safe because P1 has no public UI that could cache stale quests for extended periods.
+- **All three subjects or Spelling-first**: All three. Spelling `smart`/`trouble`/`guardian`, Grammar `smart`/`trouble`, Punctuation `smart`/`weak`/`gps` all map directly to existing engine modes. No new modes need inventing.
+- **heroContext on completed sessions**: P1 only needs heroContext on the active session. If it naturally persists through the subject session lifecycle (it will, via `session_state_json`), that is acceptable but not a P1 requirement.
+- **Double-click behaviour**: P1 relies on existing `requestId` idempotency + subject-level stale-session handling. Full Hero-aware active-session detection is P2/P3 scope.
+
+### Deferred to Implementation
+
+- **Exact heroContext field list in session_state_json**: Depends on where each subject engine stores session metadata. Implementation should verify the passthrough at write time.
+- **Grammar mode name**: Resolved during research — Grammar's `ENABLED_MODES` includes both `trouble` and `surgery` as distinct modes. The adapter should map `trouble-practice → {mode:'trouble'}`. No ambiguity remains.
+- **heroContext on subject read model vs session_state_json only**: Origin §11 prefers both. Each subject's read-model builder is a separate code path from the session state writer. If surfacing heroContext on the returned read model requires touching read-model builders, defer to implementation — `session_state_json` passthrough is the minimum P1 requirement. P2 UI can read from session state if the read-model surface proves too invasive.
+- **Double-submit side effect**: Two rapid launches with different `requestId`s for the same Hero task will both succeed. The second `start-session` abandons the first session (existing subject behaviour). This creates an abandoned `practice_sessions` row per double-click. Acceptable in P1 (no public UI); P2/P3 should add Hero-aware active-session detection. U7 tests must use a single `requestId` per task to avoid this.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant App as worker/src/app.js
+    participant HeroLaunch as worker/src/hero/launch.js
+    participant HeroRM as worker/src/hero/read-model.js
+    participant Adapter as hero/launch-adapters/{subject}
+    participant Repo as repository.runSubjectCommand
+    participant Runtime as subjectRuntime.dispatch
+
+    Client->>App: POST /api/hero/command {command:'start-task', questId, taskId, learnerId, requestId, expectedLearnerRevision}
+    App->>App: requireSameOrigin, requireMutationCapability
+    App->>HeroLaunch: resolveHeroStartTaskCommand(body, env, now)
+    HeroLaunch->>HeroRM: buildHeroShadowReadModel(learnerId, subjectReadModels, now)
+    HeroLaunch->>HeroLaunch: find questId + taskId in recomputed quest
+    HeroLaunch->>HeroLaunch: verify launchStatus === 'launchable'
+    HeroLaunch->>Adapter: mapToSubjectPayload(taskEnvelope)
+    Adapter-->>HeroLaunch: {subjectId, command:'start-session', payload:{mode:'smart',...}}
+    HeroLaunch-->>App: {heroLaunch, subjectCommand}
+    App->>App: requireSubjectCommandAvailable, protectDemoSubjectCommand
+    App->>Repo: runSubjectCommand(accountId, subjectCommand, () => Runtime.dispatch(...))
+    Runtime->>Runtime: subject engine start-session
+    Repo-->>App: mutation result
+    App-->>Client: {ok:true, heroLaunch, subjectId, command, subjectReadModel, ...}
+```
+
+Key architectural constraints:
+- `worker/src/hero/launch.js` never imports `subjects/runtime.js`
+- `worker/src/app.js` owns the dispatch call, just as it does for direct subject commands
+- Launch adapters are pure mappers: envelope → `{subjectId, payload}`, no side effects
+
+---
+
+## Implementation Units
+
+- U1. **Stable task IDs and heroContext builders**
+
+**Goal:** Add deterministic task ID generation and heroContext builder/validator to the shared pure layer.
+
+**Requirements:** R1, R2
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `shared/hero/constants.js`
+- Modify: `shared/hero/task-envelope.js`
+- Create: `shared/hero/launch-context.js`
+- Create: `shared/hero/launch-status.js`
+- Test: `tests/hero-launch-contract.test.js`
+
+**Approach:**
+- Add to `constants.js`: `HERO_P1_SCHEDULER_VERSION = 'hero-p1-launch-v1'`, `HERO_LAUNCH_CONTRACT_VERSION = 1`, `HERO_LAUNCH_STATUSES` array, new safety flag shape for launch mode
+- In `task-envelope.js`: add `deriveTaskId(questId, ordinal, envelope)`. The ordinal is the task's position in the selected task array (0-based). Inputs: `questId + '|' + ordinal + '|' + subjectId + '|' + intent + '|' + launcher + '|' + effortTarget + '|' + sortedReasonTags`. Uses DJB2 hash — note: `djb2Hash` in `seed.js` is currently module-private (not exported). Either export it from `seed.js` or copy the implementation into `task-envelope.js` (matching the existing codebase pattern of `isPlainObject` being duplicated across shared/hero/ files for purity — see L6 in P0 completion report)
+- Create `launch-context.js`: `buildHeroContext({quest, task, taskId, requestId, now, schedulerVersion})`, `validateHeroContext(ctx)`, `sanitiseHeroContext(ctx)`. The builder produces the full origin §10 shape: `{ version, source:'hero-mode', phase:'p1-launch', questId, taskId, dateKey, timezone, schedulerVersion, questFingerprint: null, subjectId, intent, launcher, effortTarget, launchRequestId, launchedAt }`. `questFingerprint` is null in P1 (compensated by scheduler version) but present as a named field so P3 can check for it. `source` and `phase` are the audit fields P3 completion-claim verification will require. The sanitiser strips any field not on the allowlist. No Coins, no rewards, no monster IDs, no debug reasons. Note: origin §10 names the sanitiser `normaliseHeroContext` — this plan uses `sanitiseHeroContext` to distinguish it from the builder; both names are acceptable
+- Create `launch-status.js`: `determineLaunchStatus(subjectId, launcher, capabilityRegistry)` — pure function that classifies a task as launchable or not-launchable with a reason
+
+**Patterns to follow:**
+- `shared/hero/seed.js` — `djb2Hash` function reuse
+- `shared/hero/task-envelope.js` — existing builder/validator pattern
+- `shared/hero/contracts.js` — normaliser pattern
+
+**Test scenarios:**
+- Happy path: same inputs produce same taskId across calls
+- Happy path: different ordinal produces different taskId
+- Happy path: different launcher produces different taskId
+- Happy path: `buildHeroContext` produces valid context with all origin §10 fields: `version`, `source`, `phase`, `questId`, `taskId`, `dateKey`, `timezone`, `schedulerVersion`, `questFingerprint`, `subjectId`, `intent`, `launcher`, `effortTarget`, `launchRequestId`, `launchedAt`
+- Happy path: `sanitiseHeroContext` retains only allowlisted fields
+- Happy path: `questFingerprint` is null in P1 but present as a named field
+- Happy path: `source` is `'hero-mode'` and `phase` is `'p1-launch'`
+- Edge case: heroContext strips Coin/reward/monster fields if present in raw input
+- Edge case: heroContext strips debugReason and adult-only diagnostics
+- Edge case: taskId is deterministic regardless of reasonTag array order (sorted internally)
+- Error path: `validateHeroContext` rejects context missing version or questId
+- Error path: `determineLaunchStatus` returns `not-launchable` for unknown launcher/subject pair
+
+**Verification:**
+- All task ID and heroContext tests pass
+- No shared/hero/ file imports from Worker, D1, or React
+
+---
+
+- U2. **Launch adapters — envelope to subject start-session payload**
+
+**Goal:** Create per-subject launch adapters that map Hero task envelopes to subject start-session command payloads.
+
+**Requirements:** R3, R6, R10
+
+**Dependencies:** U1
+
+**Files:**
+- Create: `worker/src/hero/launch-adapters/index.js`
+- Create: `worker/src/hero/launch-adapters/spelling.js`
+- Create: `worker/src/hero/launch-adapters/grammar.js`
+- Create: `worker/src/hero/launch-adapters/punctuation.js`
+- Test: `tests/hero-launch-adapters.test.js`
+
+**Approach:**
+- Each adapter exports `mapToSubjectPayload(taskEnvelope)` returning `{ subjectId, payload }` or `{ launchable: false, reason }`.
+- Spelling mappings: `smart-practice → {mode:'smart'}`, `trouble-practice → {mode:'trouble'}`, `guardian-check → {mode:'guardian'}`. Remaining launchers (`mini-test`, `gps-check`) → `not-launchable`.
+- Grammar mappings: `smart-practice → {mode:'smart'}`, `trouble-practice → {mode:'trouble'}`. Remaining → `not-launchable`. Implementation should verify the exact mode name for trouble/repair via the Grammar engine's `ENABLED_MODES`.
+- Punctuation mappings: `smart-practice → {mode:'smart'}`, `trouble-practice → {mode:'weak'}`, `gps-check → {mode:'gps'}`. Remaining → `not-launchable`.
+- Registry in `index.js`: maps `subjectId → adapter`, returns `not-launchable` for unmapped subjects.
+- Adapters must not import from `worker/src/subjects/runtime.js` or any subject engine. They are pure mappers.
+
+**Patterns to follow:**
+- `worker/src/hero/providers/index.js` — provider registry pattern
+
+**Test scenarios:**
+- Happy path: Spelling `smart-practice` maps to `{mode:'smart'}`
+- Happy path: Spelling `trouble-practice` maps to `{mode:'trouble'}`
+- Happy path: Spelling `guardian-check` maps to `{mode:'guardian'}`
+- Happy path: Grammar `smart-practice` maps to `{mode:'smart'}`
+- Happy path: Grammar `trouble-practice` maps to correct Grammar repair mode
+- Happy path: Punctuation `smart-practice` maps to `{mode:'smart'}`
+- Happy path: Punctuation `trouble-practice` maps to `{mode:'weak'}`
+- Happy path: Punctuation `gps-check` maps to `{mode:'gps'}`
+- Edge case: unsupported launcher returns `{ launchable: false, reason: 'launcher-not-supported-for-subject' }`
+- Edge case: unknown subjectId returns `{ launchable: false, reason: 'subject-adapter-not-found' }`
+- Edge case: adapters do not mutate the input task envelope (frozen-input test)
+- Integration: no launch adapter file imports `subjects/runtime` or subject engine modules (structural scan)
+
+**Verification:**
+- All supported subject/launcher pairs produce valid start-session payloads
+- All unsupported pairs return explicit not-launchable reasons
+- No adapter file imports subject runtime
+
+---
+
+- U3. **Read-model evolution — task IDs, launch status, and launch capability block**
+
+**Goal:** Update `GET /api/hero/read-model` to return task IDs, launch status, and a launch capability block while preserving all P0 fields.
+
+**Requirements:** R1, R6, R8, R9
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `shared/hero/constants.js`
+- Modify: `shared/hero/scheduler.js`
+- Modify: `worker/src/hero/read-model.js`
+- Test: `tests/hero-task-ids.test.js`
+
+**Approach:**
+- Bump scheduler version: `HERO_P1_SCHEDULER_VERSION` replaces `HERO_SCHEDULER_VERSION` as the active version used in `buildHeroShadowReadModel`
+- After `scheduleShadowQuest` returns tasks, assign `taskId` and `launchStatus` to each task using `deriveTaskId` and `determineLaunchStatus` from U1
+- Build `heroContext` per task using `buildHeroContext`
+- Add `launch` capability block to the response:
+  ```
+  launch: {
+    enabled: envFlagEnabled(env.HERO_MODE_LAUNCH_ENABLED),
+    commandRoute: '/api/hero/command',
+    command: 'start-task',
+    claimEnabled: false,
+    heroStatePersistenceEnabled: false
+  }
+  ```
+- Bump `version: 2` in response
+- Keep `mode: 'shadow'` unchanged for the GET route (P1 GET is still read-only)
+- `HERO_SAFETY_FLAGS` remain unchanged for the GET route — `childVisible:false`, `coinsEnabled:false`, `writesEnabled:false`
+- The `read-model.js` needs `env` passed in to check the launch flag. Add it as an optional parameter — P0 tests that don't pass `env` continue to work with `launch.enabled: false`
+
+**Patterns to follow:**
+- `worker/src/hero/read-model.js` — existing assembler pattern
+- `shared/hero/task-envelope.js` — existing builder pattern
+
+**Test scenarios:**
+- Happy path: every selected task has a stable `taskId` string matching `hero-task-{hex}` pattern
+- Happy path: every selected task has a `launchStatus` field
+- Happy path: launchable tasks have `launchStatus:'launchable'`; unsupported pairs have `not-launchable` with reason
+- Happy path: every selected task has a `heroContext` object with version, questId, taskId, dateKey, subjectId, intent
+- Happy path: response `version` is 2
+- Happy path: `launch` block present with correct structure
+- Happy path: all P0 fields (`mode:'shadow'`, safety flags, eligibleSubjects, lockedSubjects, dailyQuest, debug`) still present
+- Edge case: launch flag off → `launch.enabled: false`
+- Edge case: zero eligible subjects → safe empty quest, no taskIds to assign
+- Edge case: task with `not-launchable` status still appears in quest (visible for debug)
+
+**Verification:**
+- P0 read-model tests still pass (with minor updates for additive fields)
+- New task ID determinism tests pass
+- GET route remains read-only (table row counts unchanged)
+
+---
+
+- U4. **Hero command contract and route — POST /api/hero/command**
+
+**Goal:** Add `POST /api/hero/command` behind `HERO_MODE_LAUNCH_ENABLED`, supporting only `start-task`, with full security chain.
+
+**Requirements:** R4, R5, R9, R12
+
+**Dependencies:** U1, U2, U3
+
+**Files:**
+- Modify: `worker/src/app.js`
+- Modify: `worker/src/hero/routes.js`
+- Create: `worker/src/hero/launch.js`
+- Modify: `wrangler.jsonc`
+- Modify: `worker/wrangler.example.jsonc`
+- Test: `tests/worker-hero-command.test.js`
+
+**Approach:**
+- Add `HERO_MODE_LAUNCH_ENABLED: "false"` to `wrangler.jsonc` and example
+- In `worker/src/hero/routes.js`: add `handleHeroCommand` handler that validates the Hero-specific request shape: `{ command, learnerId, questId, taskId, requestId, correlationId, expectedLearnerRevision }`. Reject if command is not `start-task`. Reject client-supplied `subjectId` or `payload`.
+- In `worker/src/hero/launch.js`: `resolveHeroStartTaskCommand({ body, repository, env, now })`:
+  1. Resolve learnerId, load subject read models
+  2. Recompute Hero read model (calls `buildHeroShadowReadModel`)
+  3. Find `questId` in recomputed quest → 409 `hero_quest_stale` if missing
+  4. Find `taskId` in quest tasks → 404 `hero_task_not_found` if missing
+  5. Verify `launchStatus === 'launchable'` → 409 `hero_task_not_launchable`
+  6. Call launch adapter to get subject payload → 409 `hero_subject_unavailable` if adapter says no
+  7. Build normalised `heroContext` and **full `subjectCommand` shape matching `normaliseSubjectCommandRequest` output**: `{ subjectId, command: 'start-session', learnerId, requestId, correlationId: correlationId || requestId, expectedLearnerRevision, payload: { ...adapterPayload, heroContext } }`. The `command` field is `'start-session'` (subject command), not `'start-task'` (Hero command).
+  8. Return `{ heroLaunch, subjectCommand }` to the app route handler
+- In `worker/src/app.js`: new route block for `POST /api/hero/command`:
+  1. **Flag interaction guard**: if `HERO_MODE_LAUNCH_ENABLED` is false → 404 `hero_launch_disabled`. If `HERO_MODE_LAUNCH_ENABLED` is true but `HERO_MODE_SHADOW_ENABLED` is false → 409 `hero_launch_misconfigured`.
+  2. `requireSameOrigin(request, env)`
+  3. `requireMutationCapability(session)`
+  4. `readJson(request)`
+  5. Call `resolveHeroStartTaskCommand` → returns `{ heroLaunch, subjectCommand }`
+  6. `requireSubjectCommandAvailable(subjectCommand, env)` — catches Punctuation gate (uses `subjectCommand.subjectId` which is `'punctuation'`, `'grammar'`, etc.)
+  7. `protectDemoSubjectCommand(...)` — reuses existing demo protection (buckets on `subjectCommand.subjectId + subjectCommand.command` which is e.g. `'spelling' + 'start-session'`)
+  8. `repository.runSubjectCommand(session.accountId, subjectCommand, () => subjectRuntime.dispatch(subjectCommand, context))`
+  9. **`ProjectionUnavailableError` catch block**: replicate the same handler from the subject command route (`app.js:1156-1167`), returning structured 503 with `requestId`
+  10. Return `{ ok: true, heroLaunch, ...result }`
+- Add `/api/hero/command` to `CAPACITY_RELEVANT_PATH_PATTERNS`
+- `launch.js` must not import `subjects/runtime.js` — that import stays in `app.js`
+- Learner write access is verified by `requireLearnerWriteAccess` inside `runSubjectCommandMutation` (repository.js:7853), not duplicated in the Hero layer
+
+**Patterns to follow:**
+- `worker/src/app.js:1113-1170` — existing subject command route pattern
+- `worker/src/hero/routes.js` — existing Hero route handler pattern
+
+**Test scenarios:**
+- Happy path: flag on, valid request → 200 with `heroLaunch` block and `subjectReadModel`
+- Happy path: `heroLaunch.coinsEnabled` is false, `heroLaunch.claimEnabled` is false, `heroLaunch.childVisible` is false
+- Error path: flag off → 404 `hero_launch_disabled`
+- Error path: unauthenticated → 401
+- Error path: cross-account learner → 403
+- Error path: viewer/read-only membership cannot launch (no write access)
+- Error path: missing `command` → 400 `hero_command_required`
+- Error path: unsupported command (e.g., `claim-task`) → 400 `hero_command_unsupported`
+- Error path: missing `taskId` → 400 `hero_task_id_required`
+- Error path: missing `questId` → 400 `hero_quest_id_required`
+- Error path: missing `requestId` → 400 `command_request_id_required`
+- Error path: missing `expectedLearnerRevision` → 400 `command_revision_required`
+- Error path: stale quest → 409 `hero_quest_stale`
+- Error path: task not in quest → 404 `hero_task_not_found`
+- Error path: task marked not-launchable → 409 `hero_task_not_launchable`
+- Error path: Punctuation disabled → 409 `hero_subject_unavailable`
+- Error path: client-supplied `subjectId` or `payload` in body is ignored/rejected
+- Error path: `HERO_MODE_LAUNCH_ENABLED=true` with `HERO_MODE_SHADOW_ENABLED=false` → 409 `hero_launch_misconfigured`
+- Error path: `ProjectionUnavailableError` during subject dispatch → 503 with structured `requestId` (not generic 500)
+- Integration: demo session rate-limiting applies to Hero launch route (buckets on `subjectId + 'start-session'`)
+- Integration: `subjectCommand` shape passes the same validation that `normaliseSubjectCommandRequest` output would
+
+**Verification:**
+- All error codes return structured JSON responses, not generic 500s
+- Route registers after auth zone, follows same security chain as subject commands
+- `worker/src/hero/launch.js` does not import `subjects/runtime.js`
+- Flag interaction guard prevents inconsistent API surface
+
+---
+
+- U5. **heroContext session passthrough**
+
+**Goal:** Ensure that when a Hero task starts a subject session, the active session carries sanitised `heroContext` in its persisted state and returned read model.
+
+**Requirements:** R2, R11
+
+**Dependencies:** U4
+
+**Files:**
+- Modify: `worker/src/subjects/spelling/engine.js`
+- Modify: `worker/src/subjects/grammar/engine.js`
+- Modify: `worker/src/subjects/punctuation/engine.js`
+- Test: `tests/hero-context-passthrough.test.js`
+
+**Approach:**
+- The subject command `payload` will include `heroContext` as an optional field (set by `resolveHeroStartTaskCommand`, absent for direct subject commands)
+- **Active injection pattern.** All three subject normalisers are whitelist-based — unknown payload keys including `heroContext` are silently discarded. The work is therefore to *actively add* `heroContext` to each engine's session-state construction:
+  - Spelling (`engine.js:371,461`): In `startOptionsFromPayload`, extract `heroContext` from payload and include it in the returned options. In `service.startSession`, store `heroContext` on the session state object alongside existing fields (e.g., `session.heroContext = options.heroContext || null`).
+  - Grammar (`engine.js:927,1052-1075`): In the `start-session` handler, extract `heroContext` from payload. In the session-state construction (where explicit named fields like `mode`, `templateId`, `round`, etc. are set), add `heroContext` as a new named field on `state.session`.
+  - Punctuation (`engine.js:149`, `shared/punctuation/service.js:1402`): Extract `heroContext` from payload before passing to `service.startSession`. In the service's session-state construction, add `heroContext` as a named field. Note: `normalisePunctuationPrefs` outputs only `{mode, roundLength}` — no contamination risk exists regardless.
+- The heroContext must NOT be read by marking, scoring, support, feedback, mastery, Stars, or reward projection logic. It is metadata only.
+- Existing start-session calls (without heroContext) continue to work unchanged — heroContext is optional and defaults to null/undefined.
+
+**Execution note:** Characterisation tests first — verify current start-session behaviour is unchanged before adding heroContext passthrough.
+
+**Patterns to follow:**
+- Existing session state shape per subject — add heroContext as an optional field at the session level
+
+**Test scenarios:**
+- Happy path: Spelling start-session with heroContext → active session state contains heroContext
+- Happy path: Grammar start-session with heroContext → active session state contains heroContext
+- Happy path: Punctuation start-session with heroContext → active session state contains heroContext
+- Happy path: Spelling start-session without heroContext → session works normally, heroContext absent
+- Happy path: Grammar start-session without heroContext → session works normally
+- Happy path: Punctuation start-session without heroContext → session works normally
+- Covers AE3: heroContext attached to active subject session for launched tasks
+- Edge case: heroContext is not included in mastery state or learner profile
+- Edge case: submit-answer command does not read or use heroContext for correctness
+- Edge case: continue-session preserves heroContext on the active session
+- Edge case: Punctuation session prefs do not contain heroContext (whitelist normaliser discards it — but verify heroContext is on the session state, not the prefs)
+- Edge case: Grammar session mode and templateId are unaffected by heroContext presence in payload
+- Edge case: Spelling word selection and scoring path do not reference heroContext
+- Integration: full E2E — Hero launch → active session `session_state_json` contains heroContext field
+
+**Verification:**
+- Existing subject start-session tests pass without modification
+- Active session persisted state includes heroContext when launched from Hero
+- No subject mastery/reward code references heroContext
+
+---
+
+- U6. **Boundary and regression tests — P1 write boundary redefinition**
+
+**Goal:** Update P0 boundary tests to reflect P1's intentional write boundary: Hero launch may write only through the existing subject command path, and must not write Hero-owned state.
+
+**Requirements:** R7, R11, R13
+
+**Dependencies:** U4, U5
+
+**Files:**
+- Modify: `tests/hero-no-write-boundary.test.js`
+- Create: `tests/hero-launch-boundary.test.js`
+- Test: self-verifying
+
+**Approach:**
+- In `hero-no-write-boundary.test.js`:
+  - S1-S6 structural tests: extend the file scan to include new files in `worker/src/hero/launch-adapters/` and `shared/hero/launch-context.js`, `shared/hero/launch-status.js`. The forbidden-token patterns remain the same for `shared/hero/` and `worker/src/hero/providers/`. For `worker/src/hero/launch.js` and `launch-adapters/`, the structural constraint is: no imports from `subjects/runtime`, no D1 write primitives, no `.run()`, no `.batch()`.
+  - B7: GET read-model no-write test unchanged — still must prove zero table writes
+  - B8: Update — `POST /api/hero/command` with `HERO_MODE_LAUNCH_ENABLED: 'false'` returns 404 (gate works); with flag on, it returns a valid response (no longer 404)
+- In `hero-launch-boundary.test.js`:
+  - **Expected writes**: After a successful Hero launch, `mutation_receipts` has +1 row, `child_subject_state` may change, `practice_sessions` may have +1 row — these are normal subject command writes
+  - **Forbidden writes**: After a successful Hero launch, verify zero changes in: any `hero_*` prefixed columns/tables (should not exist), `child_game_state` Hero-specific fields, reward event log entries with `hero.*` event types
+  - **Structural**: `worker/src/hero/launch.js` does not import `createWorkerSubjectRuntime` or `subjects/runtime`
+  - **Structural**: no file in `shared/hero/` or `worker/src/hero/launch-adapters/` imports `subjects/runtime`
+  - **Structural**: no Hero source file contains economy tokens (coin, shop, deal, loot, streak loss)
+  - **No child dashboard imports**: extend S5 to scan for `launch-adapters`, `launch-context`, `launch-status` imports from `src/`
+
+**Patterns to follow:**
+- `tests/hero-no-write-boundary.test.js` — existing structural + behavioural pattern
+
+**Test scenarios:**
+- Happy path: Covers AE4 — GET read-model still writes zero rows to all guarded tables
+- Happy path: POST hero/command with flag off returns 404
+- Happy path: POST hero/command with flag on returns success for a launchable task
+- Happy path: after successful launch, mutation_receipts has expected rows (subject command path used)
+- Edge case: after successful launch, no `hero_*` event types in event_log
+- Edge case: after successful launch, no Hero-owned game state changes
+- Integration: `worker/src/hero/launch.js` structural scan — no runtime dispatch import
+- Integration: all `launch-adapters/*.js` structural scan — no runtime import, no D1 import
+- Integration: no economy vocabulary in any P1 Hero source file
+- Integration: no client `src/` file imports from `shared/hero/launch-*` or `worker/src/hero/launch-*`
+
+**Verification:**
+- All structural boundary tests pass
+- All behavioural boundary tests pass
+- P0 boundary tests (GET path) still pass
+- Existing subject tests remain green
+
+---
+
+- U7. **Staging QA flow test**
+
+**Goal:** Add an integration test that exercises the full launch flow: read Hero model → choose first launchable task → start task → inspect response → verify heroContext.
+
+**Requirements:** R10, R2
+
+**Dependencies:** U4, U5, U6
+
+**Files:**
+- Create: `tests/hero-launch-flow.test.js`
+- Test: self-verifying
+
+**Approach:**
+- Use `createWorkerRepositoryServer` with both flags enabled
+- Seed account + learner with subject state that produces at least one launchable task
+- Call `GET /api/hero/read-model` → extract first task with `launchStatus: 'launchable'`
+- Call `POST /api/hero/command` with `{ command: 'start-task', questId, taskId, learnerId, requestId, expectedLearnerRevision }`
+- Assert: response `ok: true`, `heroLaunch.status: 'started'`, `subjectReadModel` present
+- Assert: `heroLaunch.coinsEnabled: false`, `heroLaunch.claimEnabled: false`, `heroLaunch.childVisible: false`
+- Assert: active session in the subject read model contains `heroContext` with matching `questId` and `taskId`
+- Repeat for each of the three subjects if their tasks are launchable
+
+**Patterns to follow:**
+- `tests/worker-hero-read-model.test.js` — existing test server setup
+- `tests/hero-no-write-boundary.test.js` — B7 pattern for table verification
+
+**Test scenarios:**
+- Happy path: Spelling launch E2E — read model → start-task → active session with heroContext
+- Happy path: Grammar launch E2E (if launchable)
+- Happy path: Punctuation launch E2E (if launchable)
+- Happy path: response includes both heroLaunch block and standard subject response fields
+- Edge case: idempotent replay — same requestId returns same response
+- Error path: second launch with same requestId but different taskId → idempotency_reuse_error
+
+**Verification:**
+- Full launch flow completes for at least Spelling
+- heroContext survives through to the active session state
+- No Hero-owned state written
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** `POST /api/hero/command` → `resolveHeroStartTaskCommand` → `buildHeroShadowReadModel` (recomputes quest) → launch adapter → `repository.runSubjectCommand` → `subjectRuntime.dispatch`. The existing subject command's event pipeline (domain events, projections, toast events) fires normally.
+- **Error propagation:** Hero-specific errors (`hero_quest_stale`, `hero_task_not_found`, `hero_task_not_launchable`) are returned as structured JSON with appropriate HTTP status codes. Subject command errors propagate unchanged. `ProjectionUnavailableError` handling follows the same 503 pattern as existing subject commands.
+- **State lifecycle risks:** No new persistent state created. `heroContext` is stored within the subject session's existing `session_state_json` — no schema migration. Double-click risk mitigated by `requestId` idempotency at the mutation receipt layer.
+- **API surface parity:** `POST /api/hero/command` is the only new endpoint. It follows the same authentication, authorisation, and mutation security chain as `POST /api/subjects/:subjectId/command`. Demo sessions are protected by the same rate-limiter.
+- **Integration coverage:** The full launch flow crosses Hero → subject command contract → subject engine → D1 persistence. Unit tests alone will not prove the bridge works; U7's integration test is essential.
+- **Unchanged invariants:** `POST /api/subjects/:subjectId/command` behaviour is completely unchanged. Clients that call subject commands directly (without Hero) continue to work. Subject mastery algorithms, Star calculations, reward projections, and monster progression are not modified. P0's `GET /api/hero/read-model` remains read-only.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Hero launch becomes a parallel command system — `launch.js` imports subject runtime directly | Structural boundary test (S3 extension) scans every file in `worker/src/hero/` for `subjects/runtime` imports. Architecture Structure A ensures only `app.js` owns the dispatch call |
+| heroContext not stored on session state — subject normalisers are whitelist-based and silently discard unknown fields | Active injection: each engine explicitly extracts `heroContext` from payload and stores it as a named field on the session state object. U5 test scenarios verify heroContext is present in `session_state_json` |
+| subjectCommand shape mismatch breaks demo protection or mutation path — `protectDemoSubjectCommand` buckets on `command.subjectId + command.command` | `resolveHeroStartTaskCommand` builds exact `normaliseSubjectCommandRequest` output shape. Contract test in U4 verifies shape equivalence |
+| Quest recomputation on every launch adds latency (two D1 reads before mutation) | Quest recomputation reuses existing provider + scheduler path (proven fast in P0). Known cost: ~2x read vs direct subject command. If latency becomes an issue in P2, consider short-lived cache keyed on `(learnerId, dateKey, schedulerVersion)` |
+| `ProjectionUnavailableError` returns generic 500 from Hero route | Replicate the same catch block from subject command route (`app.js:1156-1167`). U4 test scenario covers this |
+| Flag misconfiguration: launch enabled without shadow enabled | Guard in route: `HERO_MODE_LAUNCH_ENABLED=true` requires `HERO_MODE_SHADOW_ENABLED=true`, returns 409 `hero_launch_misconfigured` otherwise |
+| Double-submit with different requestIds creates abandoned practice_sessions row | Accepted in P1 (no public UI). Documented as known limitation. U7 tests use single requestId per task. P2/P3 adds Hero-aware active-session detection |
+| Content drift between read-model call and launch call (different subject state) | Server recomputes quest at launch time — if the task no longer exists in the recomputed quest, the launch is rejected with `hero_quest_stale`. This is correct behaviour, not a bug |
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/plans/james/hero-mode/hero-mode-p1.md](docs/plans/james/hero-mode/hero-mode-p1.md)
+- **P0 origin:** [docs/plans/james/hero-mode/hero-mode-p0.md](docs/plans/james/hero-mode/hero-mode-p0.md)
+- **P0 completion report:** [docs/plans/james/hero-mode/hero-mode-p0-completion-report.md](docs/plans/james/hero-mode/hero-mode-p0-completion-report.md)
+- **P0 plan:** [docs/plans/2026-04-27-001-feat-hero-mode-p0-shadow-scheduler-plan.md](docs/plans/2026-04-27-001-feat-hero-mode-p0-shadow-scheduler-plan.md)
+- **P0 learning:** [docs/solutions/architecture-patterns/hero-p0-read-only-shadow-subsystem-2026-04-27.md](docs/solutions/architecture-patterns/hero-p0-read-only-shadow-subsystem-2026-04-27.md)
+- Related code: `worker/src/app.js` (route registration, security chain), `worker/src/subjects/command-contract.js` (command normaliser), `worker/src/repository.js:7818` (mutation path)

--- a/shared/hero/constants.js
+++ b/shared/hero/constants.js
@@ -1,5 +1,17 @@
 export const HERO_SCHEDULER_VERSION = 'hero-p0-shadow-v1';
 
+export const HERO_P1_SCHEDULER_VERSION = 'hero-p1-launch-v1';
+
+export const HERO_LAUNCH_CONTRACT_VERSION = 1;
+
+export const HERO_LAUNCH_STATUSES = Object.freeze([
+  'launchable',
+  'not-launchable',
+  'subject-unavailable',
+  'stale',
+  'blocked',
+]);
+
 export const HERO_DEFAULT_TIMEZONE = 'Europe/London';
 
 export const HERO_DEFAULT_EFFORT_TARGET = 18;
@@ -66,6 +78,7 @@ export const HERO_MAINTENANCE_INTENTS = Object.freeze(new Set([
 
 const INTENT_SET = new Set(HERO_INTENTS);
 const LAUNCHER_SET = new Set(HERO_LAUNCHERS);
+const LAUNCH_STATUS_SET = new Set(HERO_LAUNCH_STATUSES);
 
 export function isValidIntent(intent) {
   return typeof intent === 'string' && INTENT_SET.has(intent);
@@ -73,4 +86,8 @@ export function isValidIntent(intent) {
 
 export function isValidLauncher(launcher) {
   return typeof launcher === 'string' && LAUNCHER_SET.has(launcher);
+}
+
+export function isValidLaunchStatus(status) {
+  return typeof status === 'string' && LAUNCH_STATUS_SET.has(status);
 }

--- a/shared/hero/launch-context.js
+++ b/shared/hero/launch-context.js
@@ -1,0 +1,90 @@
+import {
+  HERO_LAUNCH_CONTRACT_VERSION,
+  HERO_DEFAULT_TIMEZONE,
+} from './constants.js';
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+const HERO_CONTEXT_ALLOWLIST = new Set([
+  'version',
+  'source',
+  'phase',
+  'questId',
+  'taskId',
+  'dateKey',
+  'timezone',
+  'schedulerVersion',
+  'questFingerprint',
+  'subjectId',
+  'intent',
+  'launcher',
+  'effortTarget',
+  'launchRequestId',
+  'launchedAt',
+]);
+
+export function buildHeroContext({
+  quest,
+  task,
+  taskId,
+  requestId,
+  now,
+  schedulerVersion,
+} = {}) {
+  const q = isPlainObject(quest) ? quest : {};
+  const t = isPlainObject(task) ? task : {};
+  const ts = typeof now === 'number' && Number.isFinite(now) ? now : Date.now();
+  return {
+    version: HERO_LAUNCH_CONTRACT_VERSION,
+    source: 'hero-mode',
+    phase: 'p1-launch',
+    questId: typeof q.questId === 'string' ? q.questId : '',
+    taskId: typeof taskId === 'string' ? taskId : '',
+    dateKey: typeof q.dateKey === 'string' ? q.dateKey : '',
+    timezone: typeof q.timezone === 'string' ? q.timezone : HERO_DEFAULT_TIMEZONE,
+    schedulerVersion: typeof schedulerVersion === 'string' ? schedulerVersion : '',
+    questFingerprint: null,
+    subjectId: typeof t.subjectId === 'string' ? t.subjectId : '',
+    intent: typeof t.intent === 'string' ? t.intent : '',
+    launcher: typeof t.launcher === 'string' ? t.launcher : '',
+    effortTarget: Number.isFinite(Number(t.effortTarget)) ? Number(t.effortTarget) : 0,
+    launchRequestId: typeof requestId === 'string' ? requestId : '',
+    launchedAt: new Date(ts).toISOString(),
+  };
+}
+
+export function validateHeroContext(ctx) {
+  const errors = [];
+  if (!isPlainObject(ctx)) {
+    return { valid: false, errors: ['heroContext must be a plain object'] };
+  }
+  if (ctx.version !== HERO_LAUNCH_CONTRACT_VERSION) {
+    errors.push(`version must be ${HERO_LAUNCH_CONTRACT_VERSION}`);
+  }
+  if (!ctx.questId) {
+    errors.push('questId is required');
+  }
+  if (!ctx.taskId) {
+    errors.push('taskId is required');
+  }
+  if (ctx.source !== 'hero-mode') {
+    errors.push('source must be hero-mode');
+  }
+  if (!ctx.launchRequestId) {
+    errors.push('launchRequestId is required');
+  }
+  return { valid: errors.length === 0, errors };
+}
+
+export function sanitiseHeroContext(ctx) {
+  if (!isPlainObject(ctx)) return {};
+  const result = {};
+  for (const key of Object.keys(ctx)) {
+    if (HERO_CONTEXT_ALLOWLIST.has(key)) {
+      result[key] = ctx[key];
+    }
+  }
+  return result;
+}

--- a/shared/hero/launch-status.js
+++ b/shared/hero/launch-status.js
@@ -1,0 +1,47 @@
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function determineLaunchStatus(subjectId, launcher, capabilityRegistry) {
+  if (typeof subjectId !== 'string' || !subjectId) {
+    return {
+      launchable: false,
+      status: 'not-launchable',
+      reason: 'subjectId is required',
+    };
+  }
+  if (typeof launcher !== 'string' || !launcher) {
+    return {
+      launchable: false,
+      status: 'not-launchable',
+      reason: 'launcher is required',
+    };
+  }
+
+  const registry = isPlainObject(capabilityRegistry) ? capabilityRegistry : {};
+  const subjectEntry = isPlainObject(registry[subjectId]) ? registry[subjectId] : null;
+
+  if (!subjectEntry) {
+    return {
+      launchable: false,
+      status: 'subject-unavailable',
+      reason: `no capability entry for subject: ${subjectId}`,
+    };
+  }
+
+  const launchers = isPlainObject(subjectEntry.launchers) ? subjectEntry.launchers : {};
+
+  if (launchers[launcher] !== true) {
+    return {
+      launchable: false,
+      status: 'not-launchable',
+      reason: `launcher not supported for subject: ${subjectId}/${launcher}`,
+    };
+  }
+
+  return {
+    launchable: true,
+    status: 'launchable',
+    reason: '',
+  };
+}

--- a/shared/hero/task-envelope.js
+++ b/shared/hero/task-envelope.js
@@ -8,6 +8,33 @@ function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
 
+// Duplicated from seed.js — kept module-private for purity (see P0 L6)
+function djb2Hash(str) {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) + hash + str.charCodeAt(i)) | 0;
+  }
+  return hash >>> 0;
+}
+
+export function deriveTaskId(questId, ordinal, envelope) {
+  const obj = isPlainObject(envelope) ? envelope : {};
+  const tags = Array.isArray(obj.reasonTags)
+    ? [...obj.reasonTags].sort().join(',')
+    : '';
+  const input = [
+    String(questId ?? ''),
+    String(ordinal ?? 0),
+    String(obj.subjectId ?? ''),
+    String(obj.intent ?? ''),
+    String(obj.launcher ?? ''),
+    String(obj.effortTarget ?? 0),
+    tags,
+  ].join('|');
+  const hex8 = djb2Hash(input).toString(16).padStart(8, '0');
+  return 'hero-task-' + hex8;
+}
+
 function clampEffort(value) {
   const n = Number(value);
   if (!Number.isFinite(n)) return HERO_EFFORT_RANGE.min;

--- a/tests/hero-context-passthrough.test.js
+++ b/tests/hero-context-passthrough.test.js
@@ -1,0 +1,397 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createWorkerSubjectRuntime } from '../worker/src/subjects/runtime.js';
+
+const SAMPLE_HERO_CONTEXT = Object.freeze({
+  version: 1,
+  source: 'hero-mode',
+  phase: 'p1-launch',
+  questId: 'quest-abc',
+  taskId: 'hero-task-def',
+  dateKey: '2026-04-27',
+  timezone: 'Europe/London',
+  schedulerVersion: 'hero-p1-launch-v1',
+  questFingerprint: null,
+  subjectId: 'spelling',
+  intent: 'practice',
+  launcher: 'smart-practice',
+  effortTarget: 10,
+  launchRequestId: 'req-001',
+  launchedAt: 1_777_000_000_000,
+});
+
+function projectionInputStub() {
+  return {
+    mode: 'hit',
+    projection: {
+      version: 1,
+      rewards: { systemId: 'monster-codex', state: {} },
+      eventCounts: { domain: 0, reactions: 0, toasts: 0 },
+      recentEventTokens: [],
+    },
+    sourceRevision: 0,
+    rawRow: null,
+  };
+}
+
+function baseContext() {
+  return {
+    session: { accountId: 'adult-a' },
+    now: 1_777_000_000_000,
+    repository: {
+      async readSubjectRuntime() {
+        return { subjectRecord: { ui: null, data: {} }, latestSession: null };
+      },
+      async readLearnerProjectionState() {
+        return { gameState: {}, events: [] };
+      },
+      async readLearnerProjectionInput() {
+        return projectionInputStub();
+      },
+      async readSpellingRuntimeContent() {
+        const { SEEDED_SPELLING_CONTENT_BUNDLE } = await import(
+          '../src/subjects/spelling/data/content-data.js'
+        );
+        const { resolveRuntimeSnapshot } = await import(
+          '../src/subjects/spelling/content/model.js'
+        );
+        return {
+          content: SEEDED_SPELLING_CONTENT_BUNDLE,
+          snapshot: resolveRuntimeSnapshot(SEEDED_SPELLING_CONTENT_BUNDLE, {
+            referenceBundle: SEEDED_SPELLING_CONTENT_BUNDLE,
+          }),
+        };
+      },
+    },
+  };
+}
+
+// ── Spelling ─────────────────────────────────────────────────────────────
+
+test('spelling start-session with heroContext stores it on persisted session state', async () => {
+  const runtime = createWorkerSubjectRuntime({
+    spelling: { now: () => 1_777_000_000_000, random: () => 0.5 },
+  });
+  const result = await runtime.dispatch({
+    subjectId: 'spelling',
+    command: 'start-session',
+    learnerId: 'learner-a',
+    requestId: 'spell-hero-1',
+    correlationId: 'spell-hero-1',
+    expectedLearnerRevision: 0,
+    payload: { mode: 'smart', heroContext: SAMPLE_HERO_CONTEXT },
+  }, baseContext());
+
+  assert.equal(result.subjectId, 'spelling');
+  assert.equal(result.command, 'start-session');
+
+  const sessionState = result.runtimeWrite.state?.session;
+  assert.ok(sessionState, 'runtimeWrite.state.session must exist');
+  assert.deepEqual(sessionState.heroContext, SAMPLE_HERO_CONTEXT);
+});
+
+test('spelling start-session without heroContext works normally — heroContext absent', async () => {
+  const runtime = createWorkerSubjectRuntime({
+    spelling: { now: () => 1_777_000_000_000, random: () => 0.5 },
+  });
+  const result = await runtime.dispatch({
+    subjectId: 'spelling',
+    command: 'start-session',
+    learnerId: 'learner-a',
+    requestId: 'spell-normal-1',
+    correlationId: 'spell-normal-1',
+    expectedLearnerRevision: 0,
+    payload: { mode: 'smart' },
+  }, baseContext());
+
+  assert.equal(result.subjectId, 'spelling');
+  const sessionState = result.runtimeWrite.state?.session;
+  assert.ok(sessionState, 'runtimeWrite.state.session must exist');
+  assert.equal(sessionState.heroContext == null, true, 'heroContext must be null or undefined');
+});
+
+// ── Grammar ──────────────────────────────────────────────────────────────
+
+test('grammar start-session with heroContext stores it on persisted session state', async () => {
+  const heroCtx = { ...SAMPLE_HERO_CONTEXT, subjectId: 'grammar' };
+  const runtime = createWorkerSubjectRuntime({
+    grammar: { now: () => 1_777_000_000_000 },
+  });
+  const result = await runtime.dispatch({
+    subjectId: 'grammar',
+    command: 'start-session',
+    learnerId: 'learner-a',
+    requestId: 'gram-hero-1',
+    correlationId: 'gram-hero-1',
+    expectedLearnerRevision: 0,
+    payload: { mode: 'smart', roundLength: 1, heroContext: heroCtx },
+  }, {
+    session: { accountId: 'adult-a' },
+    now: 1_777_000_000_000,
+    repository: {
+      async readSubjectRuntime() {
+        return { subjectRecord: { ui: null, data: {} }, latestSession: null };
+      },
+      async readLearnerProjectionState() {
+        return { gameState: {}, events: [] };
+      },
+      async readLearnerProjectionInput() {
+        return projectionInputStub();
+      },
+    },
+  });
+
+  assert.equal(result.subjectId, 'grammar');
+  assert.equal(result.command, 'start-session');
+
+  const sessionState = result.runtimeWrite.state?.session;
+  assert.ok(sessionState, 'runtimeWrite.state.session must exist');
+  assert.deepEqual(sessionState.heroContext, heroCtx);
+});
+
+test('grammar start-session without heroContext works normally', async () => {
+  const runtime = createWorkerSubjectRuntime({
+    grammar: { now: () => 1_777_000_000_000 },
+  });
+  const result = await runtime.dispatch({
+    subjectId: 'grammar',
+    command: 'start-session',
+    learnerId: 'learner-a',
+    requestId: 'gram-normal-1',
+    correlationId: 'gram-normal-1',
+    expectedLearnerRevision: 0,
+    payload: { mode: 'smart', roundLength: 1 },
+  }, {
+    session: { accountId: 'adult-a' },
+    now: 1_777_000_000_000,
+    repository: {
+      async readSubjectRuntime() {
+        return { subjectRecord: { ui: null, data: {} }, latestSession: null };
+      },
+      async readLearnerProjectionState() {
+        return { gameState: {}, events: [] };
+      },
+      async readLearnerProjectionInput() {
+        return projectionInputStub();
+      },
+    },
+  });
+
+  assert.equal(result.subjectId, 'grammar');
+  const sessionState = result.runtimeWrite.state?.session;
+  assert.ok(sessionState, 'runtimeWrite.state.session must exist');
+  assert.equal(sessionState.heroContext, null);
+});
+
+test('grammar satsset mode with heroContext stores it on persisted session state', async () => {
+  const heroCtx = { ...SAMPLE_HERO_CONTEXT, subjectId: 'grammar', launcher: 'mini-test' };
+  const runtime = createWorkerSubjectRuntime({
+    grammar: { now: () => 1_777_000_000_000 },
+  });
+  const result = await runtime.dispatch({
+    subjectId: 'grammar',
+    command: 'start-session',
+    learnerId: 'learner-a',
+    requestId: 'gram-hero-sats-1',
+    correlationId: 'gram-hero-sats-1',
+    expectedLearnerRevision: 0,
+    payload: { mode: 'satsset', roundLength: 8, heroContext: heroCtx },
+  }, {
+    session: { accountId: 'adult-a' },
+    now: 1_777_000_000_000,
+    repository: {
+      async readSubjectRuntime() {
+        return { subjectRecord: { ui: null, data: {} }, latestSession: null };
+      },
+      async readLearnerProjectionState() {
+        return { gameState: {}, events: [] };
+      },
+      async readLearnerProjectionInput() {
+        return projectionInputStub();
+      },
+    },
+  });
+
+  assert.equal(result.subjectId, 'grammar');
+  const sessionState = result.runtimeWrite.state?.session;
+  assert.ok(sessionState, 'runtimeWrite.state.session must exist');
+  assert.equal(sessionState.type, 'mini-set');
+  assert.deepEqual(sessionState.heroContext, heroCtx);
+});
+
+// ── Punctuation ──────────────────────────────────────────────────────────
+
+test('punctuation start-session with heroContext stores it on persisted session state', async () => {
+  const heroCtx = { ...SAMPLE_HERO_CONTEXT, subjectId: 'punctuation' };
+  const runtime = createWorkerSubjectRuntime({
+    punctuation: { random: () => 0 },
+  });
+  const result = await runtime.dispatch({
+    subjectId: 'punctuation',
+    command: 'start-session',
+    learnerId: 'learner-a',
+    requestId: 'punc-hero-1',
+    correlationId: 'punc-hero-1',
+    expectedLearnerRevision: 0,
+    payload: { roundLength: 1, heroContext: heroCtx },
+  }, {
+    session: { accountId: 'adult-a' },
+    repository: {
+      async readSubjectRuntime() {
+        return { subjectRecord: { ui: {}, data: {} }, latestSession: null };
+      },
+      async readLearnerProjectionState() {
+        return { gameState: {}, events: [] };
+      },
+      async readLearnerProjectionInput() {
+        return projectionInputStub();
+      },
+    },
+  });
+
+  assert.equal(result.subjectId, 'punctuation');
+  assert.equal(result.command, 'start-session');
+
+  const sessionState = result.runtimeWrite.state?.session;
+  assert.ok(sessionState, 'runtimeWrite.state.session must exist');
+  assert.deepEqual(sessionState.heroContext, heroCtx);
+});
+
+test('punctuation start-session without heroContext works normally', async () => {
+  const runtime = createWorkerSubjectRuntime({
+    punctuation: { random: () => 0 },
+  });
+  const result = await runtime.dispatch({
+    subjectId: 'punctuation',
+    command: 'start-session',
+    learnerId: 'learner-a',
+    requestId: 'punc-normal-1',
+    correlationId: 'punc-normal-1',
+    expectedLearnerRevision: 0,
+    payload: { roundLength: 1 },
+  }, {
+    session: { accountId: 'adult-a' },
+    repository: {
+      async readSubjectRuntime() {
+        return { subjectRecord: { ui: {}, data: {} }, latestSession: null };
+      },
+      async readLearnerProjectionState() {
+        return { gameState: {}, events: [] };
+      },
+      async readLearnerProjectionInput() {
+        return projectionInputStub();
+      },
+    },
+  });
+
+  assert.equal(result.subjectId, 'punctuation');
+  const sessionState = result.runtimeWrite.state?.session;
+  assert.ok(sessionState, 'runtimeWrite.state.session must exist');
+  assert.equal(sessionState.heroContext == null, true, 'heroContext must be absent');
+});
+
+// ── Edge: heroContext does not affect mode or scoring ─────────────────────
+
+test('grammar mode and templateId are unaffected by heroContext in payload', async () => {
+  const heroCtx = { ...SAMPLE_HERO_CONTEXT, subjectId: 'grammar' };
+  const runtime = createWorkerSubjectRuntime({
+    grammar: { now: () => 1_777_000_000_000 },
+  });
+  const withHero = await runtime.dispatch({
+    subjectId: 'grammar',
+    command: 'start-session',
+    learnerId: 'learner-a',
+    requestId: 'gram-mode-hero-1',
+    correlationId: 'gram-mode-hero-1',
+    expectedLearnerRevision: 0,
+    payload: {
+      mode: 'trouble',
+      roundLength: 1,
+      seed: 42,
+      heroContext: heroCtx,
+    },
+  }, {
+    session: { accountId: 'adult-a' },
+    now: 1_777_000_000_000,
+    repository: {
+      async readSubjectRuntime() {
+        return { subjectRecord: { ui: null, data: {} }, latestSession: null };
+      },
+      async readLearnerProjectionState() {
+        return { gameState: {}, events: [] };
+      },
+      async readLearnerProjectionInput() {
+        return projectionInputStub();
+      },
+    },
+  });
+
+  const withoutHero = await runtime.dispatch({
+    subjectId: 'grammar',
+    command: 'start-session',
+    learnerId: 'learner-a',
+    requestId: 'gram-mode-nohero-1',
+    correlationId: 'gram-mode-nohero-1',
+    expectedLearnerRevision: 0,
+    payload: {
+      mode: 'trouble',
+      roundLength: 1,
+      seed: 42,
+    },
+  }, {
+    session: { accountId: 'adult-a' },
+    now: 1_777_000_000_000,
+    repository: {
+      async readSubjectRuntime() {
+        return { subjectRecord: { ui: null, data: {} }, latestSession: null };
+      },
+      async readLearnerProjectionState() {
+        return { gameState: {}, events: [] };
+      },
+      async readLearnerProjectionInput() {
+        return projectionInputStub();
+      },
+    },
+  });
+
+  assert.equal(withHero.runtimeWrite.state.session.mode, 'trouble');
+  assert.equal(withoutHero.runtimeWrite.state.session.mode, 'trouble');
+  assert.equal(
+    withHero.runtimeWrite.state.session.currentItem?.templateId,
+    withoutHero.runtimeWrite.state.session.currentItem?.templateId,
+  );
+});
+
+test('punctuation prefs do not contain heroContext — whitelist normaliser discards it', async () => {
+  const heroCtx = { ...SAMPLE_HERO_CONTEXT, subjectId: 'punctuation' };
+  const runtime = createWorkerSubjectRuntime({
+    punctuation: { random: () => 0 },
+  });
+  const result = await runtime.dispatch({
+    subjectId: 'punctuation',
+    command: 'start-session',
+    learnerId: 'learner-a',
+    requestId: 'punc-prefs-1',
+    correlationId: 'punc-prefs-1',
+    expectedLearnerRevision: 0,
+    payload: { roundLength: 3, mode: 'smart', heroContext: heroCtx },
+  }, {
+    session: { accountId: 'adult-a' },
+    repository: {
+      async readSubjectRuntime() {
+        return { subjectRecord: { ui: {}, data: {} }, latestSession: null };
+      },
+      async readLearnerProjectionState() {
+        return { gameState: {}, events: [] };
+      },
+      async readLearnerProjectionInput() {
+        return projectionInputStub();
+      },
+    },
+  });
+
+  const readModel = result.subjectReadModel;
+  assert.ok(readModel, 'subjectReadModel must exist');
+  assert.equal(readModel.prefs?.heroContext, undefined, 'prefs must not contain heroContext');
+});

--- a/tests/hero-launch-adapters.test.js
+++ b/tests/hero-launch-adapters.test.js
@@ -1,0 +1,133 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { mapHeroEnvelopeToSubjectPayload } from '../worker/src/hero/launch-adapters/index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+// ── Spelling happy paths ───────────────────────────────────────────
+
+test('Spelling smart-practice maps to { mode: "smart" }', () => {
+  const envelope = { subjectId: 'spelling', launcher: 'smart-practice' };
+  const result = mapHeroEnvelopeToSubjectPayload(envelope);
+  assert.equal(result.launchable, true);
+  assert.equal(result.subjectId, 'spelling');
+  assert.deepStrictEqual(result.payload, { mode: 'smart' });
+});
+
+test('Spelling trouble-practice maps to { mode: "trouble" }', () => {
+  const envelope = { subjectId: 'spelling', launcher: 'trouble-practice' };
+  const result = mapHeroEnvelopeToSubjectPayload(envelope);
+  assert.equal(result.launchable, true);
+  assert.equal(result.subjectId, 'spelling');
+  assert.deepStrictEqual(result.payload, { mode: 'trouble' });
+});
+
+test('Spelling guardian-check maps to { mode: "guardian" }', () => {
+  const envelope = { subjectId: 'spelling', launcher: 'guardian-check' };
+  const result = mapHeroEnvelopeToSubjectPayload(envelope);
+  assert.equal(result.launchable, true);
+  assert.equal(result.subjectId, 'spelling');
+  assert.deepStrictEqual(result.payload, { mode: 'guardian' });
+});
+
+// ── Grammar happy paths ────────────────────────────────────────────
+
+test('Grammar smart-practice maps to { mode: "smart" }', () => {
+  const envelope = { subjectId: 'grammar', launcher: 'smart-practice' };
+  const result = mapHeroEnvelopeToSubjectPayload(envelope);
+  assert.equal(result.launchable, true);
+  assert.equal(result.subjectId, 'grammar');
+  assert.deepStrictEqual(result.payload, { mode: 'smart' });
+});
+
+test('Grammar trouble-practice maps to { mode: "trouble" }', () => {
+  const envelope = { subjectId: 'grammar', launcher: 'trouble-practice' };
+  const result = mapHeroEnvelopeToSubjectPayload(envelope);
+  assert.equal(result.launchable, true);
+  assert.equal(result.subjectId, 'grammar');
+  assert.deepStrictEqual(result.payload, { mode: 'trouble' });
+});
+
+// ── Punctuation happy paths ────────────────────────────────────────
+
+test('Punctuation smart-practice maps to { mode: "smart" }', () => {
+  const envelope = { subjectId: 'punctuation', launcher: 'smart-practice' };
+  const result = mapHeroEnvelopeToSubjectPayload(envelope);
+  assert.equal(result.launchable, true);
+  assert.equal(result.subjectId, 'punctuation');
+  assert.deepStrictEqual(result.payload, { mode: 'smart' });
+});
+
+test('Punctuation trouble-practice maps to { mode: "weak" }', () => {
+  const envelope = { subjectId: 'punctuation', launcher: 'trouble-practice' };
+  const result = mapHeroEnvelopeToSubjectPayload(envelope);
+  assert.equal(result.launchable, true);
+  assert.equal(result.subjectId, 'punctuation');
+  assert.deepStrictEqual(result.payload, { mode: 'weak' });
+});
+
+test('Punctuation gps-check maps to { mode: "gps" }', () => {
+  const envelope = { subjectId: 'punctuation', launcher: 'gps-check' };
+  const result = mapHeroEnvelopeToSubjectPayload(envelope);
+  assert.equal(result.launchable, true);
+  assert.equal(result.subjectId, 'punctuation');
+  assert.deepStrictEqual(result.payload, { mode: 'gps' });
+});
+
+// ── Edge case: unsupported launcher ────────────────────────────────
+
+test('unsupported launcher returns not-launchable with reason', () => {
+  const envelope = { subjectId: 'spelling', launcher: 'mini-test' };
+  const result = mapHeroEnvelopeToSubjectPayload(envelope);
+  assert.equal(result.launchable, false);
+  assert.equal(result.reason, 'launcher-not-supported-for-subject');
+});
+
+// ── Edge case: unknown subjectId ───────────────────────────────────
+
+test('unknown subjectId returns not-launchable with subject-adapter-not-found', () => {
+  const envelope = { subjectId: 'arithmetic', launcher: 'smart-practice' };
+  const result = mapHeroEnvelopeToSubjectPayload(envelope);
+  assert.equal(result.launchable, false);
+  assert.equal(result.reason, 'subject-adapter-not-found');
+});
+
+// ── Edge case: adapters do not mutate input ────────────────────────
+
+test('adapters do not mutate the input envelope', () => {
+  const envelope = Object.freeze({
+    subjectId: 'spelling',
+    launcher: 'smart-practice',
+    intent: 'due-review',
+    effortTarget: 10,
+    reasonTags: Object.freeze(['due-words']),
+    debugReason: 'test',
+  });
+  const result = mapHeroEnvelopeToSubjectPayload(envelope);
+  assert.equal(result.launchable, true);
+  assert.deepStrictEqual(result.payload, { mode: 'smart' });
+});
+
+// ── Structural: no adapter imports subjects/runtime ────────────────
+
+test('no launch adapter file contains subjects/runtime import', () => {
+  const adapterDir = path.join(REPO_ROOT, 'worker', 'src', 'hero', 'launch-adapters');
+  const files = fs.readdirSync(adapterDir)
+    .filter(f => f.endsWith('.js'))
+    .map(f => path.join(adapterDir, f));
+
+  for (const filePath of files) {
+    const code = fs.readFileSync(filePath, 'utf8');
+    const rel = path.relative(REPO_ROOT, filePath);
+    assert.ok(
+      !code.includes('subjects/runtime'),
+      `${rel} imports from subjects/runtime — launch adapters must not depend on subject runtime`,
+    );
+  }
+});

--- a/tests/hero-launch-boundary.test.js
+++ b/tests/hero-launch-boundary.test.js
@@ -1,0 +1,322 @@
+// Hero Mode P1 — Launch boundary tests.
+//
+// Structural tests (S-L1 to S-L5) prove that P1 launch code does not
+// import subject runtime, subject engines, or economy vocabulary, and
+// that client src/ does not import launch internals.
+//
+// Behavioural tests (B-L1, B-L2) prove that a successful Hero launch
+// writes only through the existing subject command path (mutation_receipts
+// increases) and creates no hero.* event_log entries.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createApiPlatformRepositories } from '../src/platform/core/repositories/index.js';
+import { createWorkerRepositoryServer } from './helpers/worker-server.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+function collectJsFiles(dir) {
+  const results = [];
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return results;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...collectJsFiles(full));
+    } else if (entry.isFile() && entry.name.endsWith('.js')) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+function stripComments(source) {
+  return source
+    .replace(/\/\/.*$/gm, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+const SHARED_HERO_DIR = path.join(REPO_ROOT, 'shared', 'hero');
+const WORKER_HERO_DIR = path.join(REPO_ROOT, 'worker', 'src', 'hero');
+const LAUNCH_ADAPTERS_DIR = path.join(WORKER_HERO_DIR, 'launch-adapters');
+const CLIENT_SRC_DIR = path.join(REPO_ROOT, 'src');
+
+const HERO_COMMAND_URL = 'https://repo.test/api/hero/command';
+const HERO_READ_MODEL_URL = 'https://repo.test/api/hero/read-model';
+
+// ── Structural test S-L1 ────────────────────────────────────────────
+
+test('S-L1: worker/src/hero/launch.js does not import createWorkerSubjectRuntime or subjects/runtime', () => {
+  const launchPath = path.join(WORKER_HERO_DIR, 'launch.js');
+  const source = stripComments(fs.readFileSync(launchPath, 'utf8'));
+
+  assert.ok(
+    !source.includes('createWorkerSubjectRuntime'),
+    'launch.js imports createWorkerSubjectRuntime — launch must not own subject dispatch',
+  );
+  assert.ok(
+    !source.includes('subjects/runtime'),
+    'launch.js imports from subjects/runtime — launch must not depend on subject runtime',
+  );
+});
+
+// ── Structural test S-L2 ────────────────────────────────────────────
+
+test('S-L2: no file in worker/src/hero/launch-adapters/ imports subjects/runtime or subject engine modules', () => {
+  const adapterFiles = collectJsFiles(LAUNCH_ADAPTERS_DIR);
+  assert.ok(adapterFiles.length > 0, 'Expected at least one launch adapter file');
+
+  const FORBIDDEN_IMPORTS = [
+    'subjects/runtime',
+    'subjects/spelling/engine',
+    'subjects/grammar/engine',
+    'subjects/punctuation/engine',
+  ];
+
+  for (const filePath of adapterFiles) {
+    const rel = path.relative(REPO_ROOT, filePath).replace(/\\/g, '/');
+    const source = stripComments(fs.readFileSync(filePath, 'utf8'));
+
+    for (const token of FORBIDDEN_IMPORTS) {
+      assert.ok(
+        !source.includes(token),
+        `${rel} imports ${token} — launch adapters must be pure mappers with no subject engine dependency`,
+      );
+    }
+  }
+});
+
+// ── Structural test S-L3 ────────────────────────────────────────────
+
+test('S-L3: no file in shared/hero/ imports subjects/runtime', () => {
+  const sharedFiles = collectJsFiles(SHARED_HERO_DIR);
+  assert.ok(sharedFiles.length > 0, 'Expected at least one shared/hero/ file');
+
+  for (const filePath of sharedFiles) {
+    const rel = path.relative(REPO_ROOT, filePath).replace(/\\/g, '/');
+    const source = stripComments(fs.readFileSync(filePath, 'utf8'));
+
+    assert.ok(
+      !source.includes('subjects/runtime'),
+      `${rel} imports from subjects/runtime — shared/hero must not depend on subject runtime`,
+    );
+  }
+});
+
+// ── Structural test S-L4 ────────────────────────────────────────────
+
+test('S-L4: no Hero source file contains economy vocabulary tokens', () => {
+  const ECONOMY_TOKENS = [
+    /\bcoin\b/i,
+    /\bshop\b/i,
+    /\bdeal\b/i,
+    /\bloot\b/i,
+    /streak\s+loss/i,
+  ];
+
+  const allHeroFiles = [
+    ...collectJsFiles(SHARED_HERO_DIR),
+    ...collectJsFiles(WORKER_HERO_DIR),
+  ];
+
+  for (const filePath of allHeroFiles) {
+    const rel = path.relative(REPO_ROOT, filePath).replace(/\\/g, '/');
+    const code = stripComments(fs.readFileSync(filePath, 'utf8'));
+
+    for (const pattern of ECONOMY_TOKENS) {
+      assert.ok(
+        !pattern.test(code),
+        `${rel} contains economy token matching ${pattern} — Hero code must not contain reward/economy vocabulary`,
+      );
+    }
+  }
+});
+
+// ── Structural test S-L5 ────────────────────────────────────────────
+
+test('S-L5: no client src/ file imports from shared/hero/launch-context, launch-status, or worker/src/hero/launch-adapters', () => {
+  const clientFiles = collectJsFiles(CLIENT_SRC_DIR).filter(
+    (f) => f.endsWith('.js') || f.endsWith('.jsx'),
+  );
+
+  const FORBIDDEN_IMPORT_FRAGMENTS = [
+    'shared/hero/launch-context',
+    'shared/hero/launch-status',
+    'worker/src/hero/launch-adapters',
+    'worker/src/hero/launch',
+  ];
+
+  for (const filePath of clientFiles) {
+    const source = fs.readFileSync(filePath, 'utf8');
+    const rel = path.relative(REPO_ROOT, filePath).replace(/\\/g, '/');
+
+    for (const fragment of FORBIDDEN_IMPORT_FRAGMENTS) {
+      assert.ok(
+        !source.includes(fragment),
+        `${rel} imports from ${fragment} — P1 Hero launch internals must not be imported by client code`,
+      );
+    }
+  }
+});
+
+// ── Behavioural helpers ─────────────────────────────────────────────
+
+function createServerWithFlags({ shadow = true, launch = true, punctuation = true } = {}) {
+  return createWorkerRepositoryServer({
+    env: {
+      HERO_MODE_SHADOW_ENABLED: shadow ? 'true' : 'false',
+      HERO_MODE_LAUNCH_ENABLED: launch ? 'true' : 'false',
+      PUNCTUATION_SUBJECT_ENABLED: punctuation ? 'true' : 'false',
+    },
+  });
+}
+
+async function seedLearner(server, accountId, learnerId) {
+  const repos = createApiPlatformRepositories({
+    baseUrl: 'https://repo.test',
+    fetch: server.fetch.bind(server),
+    authSession: server.authSessionFor(accountId),
+  });
+  await repos.hydrate();
+  repos.learners.write({
+    byId: {
+      [learnerId]: {
+        id: learnerId,
+        name: 'Boundary Test Learner',
+        yearGroup: 'Y5',
+        goal: 'sats',
+        dailyMinutes: 15,
+        avatarColor: '#3E6FA8',
+        createdAt: 1,
+      },
+    },
+    allIds: [learnerId],
+    selectedId: learnerId,
+  });
+  await repos.flush();
+  return repos;
+}
+
+async function getFirstLaunchableTask(server, learnerId = 'learner-a') {
+  const response = await server.fetch(`${HERO_READ_MODEL_URL}?learnerId=${learnerId}`);
+  const payload = await response.json();
+  if (response.status !== 200 || !payload.hero) return null;
+  const quest = payload.hero.dailyQuest;
+  if (!quest || !quest.tasks) return null;
+  const task = quest.tasks.find((t) => t.launchStatus === 'launchable');
+  if (!task) return null;
+  return { questId: quest.questId, taskId: task.taskId, task };
+}
+
+function getLearnerRevision(server, accountId = 'adult-a') {
+  const row = server.DB.db.prepare(
+    `SELECT lp.state_revision FROM learner_profiles lp
+     JOIN account_learner_memberships alm ON alm.learner_id = lp.id
+     WHERE alm.account_id = ?`,
+  ).get(accountId);
+  return row?.state_revision ?? 0;
+}
+
+function countRows(server, tableName) {
+  return server.DB.db.prepare(
+    `SELECT COUNT(*) AS count FROM ${tableName}`,
+  ).get()?.count ?? 0;
+}
+
+function countHeroEvents(server) {
+  return server.DB.db.prepare(
+    `SELECT COUNT(*) AS count FROM event_log WHERE event_type LIKE 'hero.%'`,
+  ).get()?.count ?? 0;
+}
+
+// ── Behavioural test B-L1 ───────────────────────────────────────────
+
+test('B-L1: after a successful Hero launch, mutation_receipts row count increases', async () => {
+  const server = createServerWithFlags();
+  await seedLearner(server, 'adult-a', 'learner-a');
+
+  const launchable = await getFirstLaunchableTask(server);
+  if (!launchable) {
+    server.close();
+    return;
+  }
+
+  const receiptsBefore = countRows(server, 'mutation_receipts');
+  const revision = getLearnerRevision(server);
+
+  const response = await server.fetchAs('adult-a', HERO_COMMAND_URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      command: 'start-task',
+      learnerId: 'learner-a',
+      questId: launchable.questId,
+      taskId: launchable.taskId,
+      requestId: 'boundary-bl1',
+      expectedLearnerRevision: revision,
+    }),
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 200, `Expected 200, got ${response.status}: ${JSON.stringify(payload)}`);
+
+  const receiptsAfter = countRows(server, 'mutation_receipts');
+  assert.ok(
+    receiptsAfter > receiptsBefore,
+    `mutation_receipts did not increase after Hero launch — expected subject command path to write a receipt (before=${receiptsBefore}, after=${receiptsAfter})`,
+  );
+
+  server.close();
+});
+
+// ── Behavioural test B-L2 ───────────────────────────────────────────
+
+test('B-L2: after a successful Hero launch, no hero.* event types exist in event_log', async () => {
+  const server = createServerWithFlags();
+  await seedLearner(server, 'adult-a', 'learner-a');
+
+  const launchable = await getFirstLaunchableTask(server);
+  if (!launchable) {
+    server.close();
+    return;
+  }
+
+  const revision = getLearnerRevision(server);
+
+  const response = await server.fetchAs('adult-a', HERO_COMMAND_URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      command: 'start-task',
+      learnerId: 'learner-a',
+      questId: launchable.questId,
+      taskId: launchable.taskId,
+      requestId: 'boundary-bl2',
+      expectedLearnerRevision: revision,
+    }),
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 200, `Expected 200, got ${response.status}: ${JSON.stringify(payload)}`);
+
+  const heroEventCount = countHeroEvents(server);
+  assert.equal(
+    heroEventCount,
+    0,
+    `Found ${heroEventCount} hero.* event_log entries after Hero launch — Hero must not create hero-owned events`,
+  );
+
+  server.close();
+});

--- a/tests/hero-launch-contract.test.js
+++ b/tests/hero-launch-contract.test.js
@@ -450,3 +450,25 @@ test('determineLaunchStatus: launcher set to false is not-launchable', () => {
   assert.equal(result.launchable, false);
   assert.equal(result.status, 'not-launchable');
 });
+
+// ── FIX 7: hero_task_not_launchable route coverage via determineLaunchStatus ──
+
+test('determineLaunchStatus: unsupported subject/launcher pair returns not-launchable (route coverage)', () => {
+  // This covers the hero_task_not_launchable code path: when the quest has
+  // a task whose subject/launcher pair produces launchStatus !== 'launchable',
+  // resolveHeroStartTaskCommand throws a 409. This unit test verifies the
+  // status determination that feeds that gate.
+  const result = determineLaunchStatus('spelling', 'mini-test', FIXTURE_REGISTRY);
+  assert.equal(result.launchable, false);
+  assert.equal(result.status, 'not-launchable');
+  assert.ok(result.reason.length > 0, 'reason must explain why not launchable');
+});
+
+// ── FIX 8: validateHeroContext rejects context missing taskId ────────
+
+test('validateHeroContext rejects context missing taskId', () => {
+  const ctx = { version: 1, source: 'hero-mode', questId: 'q1', launchRequestId: 'r1' };
+  const result = validateHeroContext(ctx);
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some(e => e.includes('taskId')));
+});

--- a/tests/hero-launch-contract.test.js
+++ b/tests/hero-launch-contract.test.js
@@ -1,0 +1,452 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  HERO_P1_SCHEDULER_VERSION,
+  HERO_LAUNCH_CONTRACT_VERSION,
+  HERO_LAUNCH_STATUSES,
+  isValidLaunchStatus,
+} from '../shared/hero/constants.js';
+
+import {
+  deriveTaskId,
+} from '../shared/hero/task-envelope.js';
+
+import {
+  buildHeroContext,
+  validateHeroContext,
+  sanitiseHeroContext,
+} from '../shared/hero/launch-context.js';
+
+import {
+  determineLaunchStatus,
+} from '../shared/hero/launch-status.js';
+
+// ── Constants — P1 additions ──────────────────────────────────────
+
+test('HERO_P1_SCHEDULER_VERSION is hero-p1-launch-v1', () => {
+  assert.equal(HERO_P1_SCHEDULER_VERSION, 'hero-p1-launch-v1');
+});
+
+test('HERO_LAUNCH_CONTRACT_VERSION is 1', () => {
+  assert.equal(HERO_LAUNCH_CONTRACT_VERSION, 1);
+});
+
+test('HERO_LAUNCH_STATUSES contains the five expected statuses', () => {
+  assert.equal(HERO_LAUNCH_STATUSES.length, 5);
+  assert.ok(HERO_LAUNCH_STATUSES.includes('launchable'));
+  assert.ok(HERO_LAUNCH_STATUSES.includes('not-launchable'));
+  assert.ok(HERO_LAUNCH_STATUSES.includes('subject-unavailable'));
+  assert.ok(HERO_LAUNCH_STATUSES.includes('stale'));
+  assert.ok(HERO_LAUNCH_STATUSES.includes('blocked'));
+});
+
+test('isValidLaunchStatus accepts known statuses', () => {
+  for (const status of HERO_LAUNCH_STATUSES) {
+    assert.ok(isValidLaunchStatus(status), `${status} must be valid`);
+  }
+});
+
+test('isValidLaunchStatus rejects unknown statuses', () => {
+  assert.equal(isValidLaunchStatus('ready'), false);
+  assert.equal(isValidLaunchStatus(''), false);
+  assert.equal(isValidLaunchStatus(null), false);
+  assert.equal(isValidLaunchStatus(42), false);
+});
+
+// ── deriveTaskId — determinism ────────────────────────────────────
+
+test('deriveTaskId: same inputs produce same taskId across calls', () => {
+  const envelope = {
+    subjectId: 'spelling',
+    intent: 'due-review',
+    launcher: 'smart-practice',
+    effortTarget: 6,
+    reasonTags: ['due', 'recent'],
+  };
+  const id1 = deriveTaskId('quest-abc', 0, envelope);
+  const id2 = deriveTaskId('quest-abc', 0, envelope);
+  assert.equal(id1, id2);
+  assert.match(id1, /^hero-task-[0-9a-f]{8}$/);
+});
+
+test('deriveTaskId: different ordinal produces different taskId', () => {
+  const envelope = {
+    subjectId: 'spelling',
+    intent: 'due-review',
+    launcher: 'smart-practice',
+    effortTarget: 6,
+    reasonTags: ['due'],
+  };
+  const id0 = deriveTaskId('quest-abc', 0, envelope);
+  const id1 = deriveTaskId('quest-abc', 1, envelope);
+  assert.notEqual(id0, id1);
+});
+
+test('deriveTaskId: different launcher produces different taskId', () => {
+  const base = {
+    subjectId: 'spelling',
+    intent: 'due-review',
+    effortTarget: 6,
+    reasonTags: ['due'],
+  };
+  const idA = deriveTaskId('quest-abc', 0, { ...base, launcher: 'smart-practice' });
+  const idB = deriveTaskId('quest-abc', 0, { ...base, launcher: 'trouble-practice' });
+  assert.notEqual(idA, idB);
+});
+
+test('deriveTaskId: deterministic regardless of reasonTag array order', () => {
+  const envelopeA = {
+    subjectId: 'grammar',
+    intent: 'weak-repair',
+    launcher: 'trouble-practice',
+    effortTarget: 4,
+    reasonTags: ['zebra', 'alpha', 'middle'],
+  };
+  const envelopeB = {
+    ...envelopeA,
+    reasonTags: ['middle', 'zebra', 'alpha'],
+  };
+  const envelopeC = {
+    ...envelopeA,
+    reasonTags: ['alpha', 'middle', 'zebra'],
+  };
+  const idA = deriveTaskId('q1', 2, envelopeA);
+  const idB = deriveTaskId('q1', 2, envelopeB);
+  const idC = deriveTaskId('q1', 2, envelopeC);
+  assert.equal(idA, idB);
+  assert.equal(idB, idC);
+});
+
+test('deriveTaskId: returns hero-task- prefix with 8-char hex', () => {
+  const id = deriveTaskId('q1', 0, {
+    subjectId: 'punctuation',
+    intent: 'breadth-maintenance',
+    launcher: 'gps-check',
+    effortTarget: 3,
+    reasonTags: [],
+  });
+  assert.match(id, /^hero-task-[0-9a-f]{8}$/);
+});
+
+test('deriveTaskId: handles missing envelope gracefully', () => {
+  const id = deriveTaskId('q1', 0, null);
+  assert.match(id, /^hero-task-[0-9a-f]{8}$/);
+});
+
+// ── buildHeroContext ──────────────────────────────────────────────
+
+const FIXTURE_NOW = new Date('2026-04-27T14:00:00Z').getTime();
+
+const FIXTURE_QUEST = {
+  questId: 'hero-quest-daily-abc',
+  dateKey: '2026-04-27',
+  timezone: 'Europe/London',
+};
+
+const FIXTURE_TASK = {
+  subjectId: 'spelling',
+  intent: 'due-review',
+  launcher: 'smart-practice',
+  effortTarget: 6,
+};
+
+test('buildHeroContext produces valid context with all origin S10 fields', () => {
+  const ctx = buildHeroContext({
+    quest: FIXTURE_QUEST,
+    task: FIXTURE_TASK,
+    taskId: 'hero-task-aabbccdd',
+    requestId: 'req-001',
+    now: FIXTURE_NOW,
+    schedulerVersion: HERO_P1_SCHEDULER_VERSION,
+  });
+
+  assert.equal(ctx.version, 1);
+  assert.equal(ctx.source, 'hero-mode');
+  assert.equal(ctx.phase, 'p1-launch');
+  assert.equal(ctx.questId, 'hero-quest-daily-abc');
+  assert.equal(ctx.taskId, 'hero-task-aabbccdd');
+  assert.equal(ctx.dateKey, '2026-04-27');
+  assert.equal(ctx.timezone, 'Europe/London');
+  assert.equal(ctx.schedulerVersion, 'hero-p1-launch-v1');
+  assert.equal(ctx.questFingerprint, null);
+  assert.equal(ctx.subjectId, 'spelling');
+  assert.equal(ctx.intent, 'due-review');
+  assert.equal(ctx.launcher, 'smart-practice');
+  assert.equal(ctx.effortTarget, 6);
+  assert.equal(ctx.launchRequestId, 'req-001');
+  assert.equal(ctx.launchedAt, '2026-04-27T14:00:00.000Z');
+});
+
+test('buildHeroContext: source is hero-mode and phase is p1-launch', () => {
+  const ctx = buildHeroContext({
+    quest: FIXTURE_QUEST,
+    task: FIXTURE_TASK,
+    taskId: 'hero-task-aabbccdd',
+    requestId: 'req-001',
+    now: FIXTURE_NOW,
+    schedulerVersion: HERO_P1_SCHEDULER_VERSION,
+  });
+  assert.equal(ctx.source, 'hero-mode');
+  assert.equal(ctx.phase, 'p1-launch');
+});
+
+test('buildHeroContext: questFingerprint is null in P1 but present as a named field', () => {
+  const ctx = buildHeroContext({
+    quest: FIXTURE_QUEST,
+    task: FIXTURE_TASK,
+    taskId: 'hero-task-aabbccdd',
+    requestId: 'req-001',
+    now: FIXTURE_NOW,
+    schedulerVersion: HERO_P1_SCHEDULER_VERSION,
+  });
+  assert.ok(Object.hasOwn(ctx, 'questFingerprint'));
+  assert.equal(ctx.questFingerprint, null);
+});
+
+test('buildHeroContext: defaults missing fields safely', () => {
+  const ctx = buildHeroContext({});
+  assert.equal(ctx.version, 1);
+  assert.equal(ctx.source, 'hero-mode');
+  assert.equal(ctx.questId, '');
+  assert.equal(ctx.taskId, '');
+  assert.equal(ctx.schedulerVersion, '');
+  assert.equal(ctx.questFingerprint, null);
+  assert.match(ctx.launchedAt, /^\d{4}-\d{2}-\d{2}T/);
+});
+
+// ── validateHeroContext ──────────────────────────────────────────
+
+test('validateHeroContext accepts a valid context', () => {
+  const ctx = buildHeroContext({
+    quest: FIXTURE_QUEST,
+    task: FIXTURE_TASK,
+    taskId: 'hero-task-aabbccdd',
+    requestId: 'req-001',
+    now: FIXTURE_NOW,
+    schedulerVersion: HERO_P1_SCHEDULER_VERSION,
+  });
+  const { valid, errors } = validateHeroContext(ctx);
+  assert.equal(valid, true);
+  assert.equal(errors.length, 0);
+});
+
+test('validateHeroContext rejects context missing version', () => {
+  const ctx = buildHeroContext({
+    quest: FIXTURE_QUEST,
+    task: FIXTURE_TASK,
+    taskId: 'hero-task-aabbccdd',
+    requestId: 'req-001',
+    now: FIXTURE_NOW,
+    schedulerVersion: HERO_P1_SCHEDULER_VERSION,
+  });
+  delete ctx.version;
+  const { valid, errors } = validateHeroContext(ctx);
+  assert.equal(valid, false);
+  assert.ok(errors.some(e => e.includes('version')));
+});
+
+test('validateHeroContext rejects context missing questId', () => {
+  const ctx = buildHeroContext({
+    quest: {},
+    task: FIXTURE_TASK,
+    taskId: 'hero-task-aabbccdd',
+    requestId: 'req-001',
+    now: FIXTURE_NOW,
+    schedulerVersion: HERO_P1_SCHEDULER_VERSION,
+  });
+  const { valid, errors } = validateHeroContext(ctx);
+  assert.equal(valid, false);
+  assert.ok(errors.some(e => e.includes('questId')));
+});
+
+test('validateHeroContext rejects non-object input', () => {
+  const { valid, errors } = validateHeroContext(null);
+  assert.equal(valid, false);
+  assert.ok(errors.some(e => e.includes('plain object')));
+});
+
+test('validateHeroContext rejects context with wrong source', () => {
+  const ctx = buildHeroContext({
+    quest: FIXTURE_QUEST,
+    task: FIXTURE_TASK,
+    taskId: 'hero-task-aabbccdd',
+    requestId: 'req-001',
+    now: FIXTURE_NOW,
+    schedulerVersion: HERO_P1_SCHEDULER_VERSION,
+  });
+  ctx.source = 'direct';
+  const { valid, errors } = validateHeroContext(ctx);
+  assert.equal(valid, false);
+  assert.ok(errors.some(e => e.includes('source')));
+});
+
+test('validateHeroContext rejects context missing launchRequestId', () => {
+  const ctx = buildHeroContext({
+    quest: FIXTURE_QUEST,
+    task: FIXTURE_TASK,
+    taskId: 'hero-task-aabbccdd',
+    now: FIXTURE_NOW,
+    schedulerVersion: HERO_P1_SCHEDULER_VERSION,
+  });
+  const { valid, errors } = validateHeroContext(ctx);
+  assert.equal(valid, false);
+  assert.ok(errors.some(e => e.includes('launchRequestId')));
+});
+
+// ── sanitiseHeroContext ──────────────────────────────────────────
+
+test('sanitiseHeroContext retains only allowlisted fields', () => {
+  const ctx = buildHeroContext({
+    quest: FIXTURE_QUEST,
+    task: FIXTURE_TASK,
+    taskId: 'hero-task-aabbccdd',
+    requestId: 'req-001',
+    now: FIXTURE_NOW,
+    schedulerVersion: HERO_P1_SCHEDULER_VERSION,
+  });
+  const sanitised = sanitiseHeroContext(ctx);
+  const expectedKeys = [
+    'version', 'source', 'phase', 'questId', 'taskId', 'dateKey',
+    'timezone', 'schedulerVersion', 'questFingerprint', 'subjectId',
+    'intent', 'launcher', 'effortTarget', 'launchRequestId', 'launchedAt',
+  ];
+  assert.deepEqual(Object.keys(sanitised).sort(), expectedKeys.sort());
+});
+
+test('sanitiseHeroContext strips Coin/reward/monster fields', () => {
+  const raw = {
+    version: 1,
+    source: 'hero-mode',
+    phase: 'p1-launch',
+    questId: 'q1',
+    taskId: 't1',
+    coins: 50,
+    reward: { type: 'monster-egg' },
+    monsterId: 'mon-001',
+    monsterLevel: 5,
+    xp: 100,
+  };
+  const sanitised = sanitiseHeroContext(raw);
+  assert.equal(sanitised.coins, undefined);
+  assert.equal(sanitised.reward, undefined);
+  assert.equal(sanitised.monsterId, undefined);
+  assert.equal(sanitised.monsterLevel, undefined);
+  assert.equal(sanitised.xp, undefined);
+});
+
+test('sanitiseHeroContext strips debugReason and adult-only diagnostics', () => {
+  const raw = {
+    version: 1,
+    source: 'hero-mode',
+    phase: 'p1-launch',
+    questId: 'q1',
+    taskId: 't1',
+    debugReason: 'Spelling has overdue words with d>7.',
+    adminNote: 'Override applied by parent.',
+    diagnosticTrace: ['step-1', 'step-2'],
+  };
+  const sanitised = sanitiseHeroContext(raw);
+  assert.equal(sanitised.debugReason, undefined);
+  assert.equal(sanitised.adminNote, undefined);
+  assert.equal(sanitised.diagnosticTrace, undefined);
+});
+
+test('sanitiseHeroContext handles non-object input', () => {
+  const sanitised = sanitiseHeroContext(null);
+  assert.deepEqual(sanitised, {});
+});
+
+// ── determineLaunchStatus ────────────────────────────────────────
+
+const FIXTURE_REGISTRY = {
+  spelling: {
+    launchers: {
+      'smart-practice': true,
+      'trouble-practice': true,
+      'guardian-check': true,
+    },
+  },
+  grammar: {
+    launchers: {
+      'smart-practice': true,
+      'trouble-practice': true,
+    },
+  },
+  punctuation: {
+    launchers: {
+      'smart-practice': true,
+      'trouble-practice': true,
+      'gps-check': true,
+    },
+  },
+};
+
+test('determineLaunchStatus: launchable for known subject/launcher', () => {
+  const result = determineLaunchStatus('spelling', 'smart-practice', FIXTURE_REGISTRY);
+  assert.equal(result.launchable, true);
+  assert.equal(result.status, 'launchable');
+  assert.equal(result.reason, '');
+});
+
+test('determineLaunchStatus: launchable for grammar/trouble-practice', () => {
+  const result = determineLaunchStatus('grammar', 'trouble-practice', FIXTURE_REGISTRY);
+  assert.equal(result.launchable, true);
+  assert.equal(result.status, 'launchable');
+});
+
+test('determineLaunchStatus: launchable for punctuation/gps-check', () => {
+  const result = determineLaunchStatus('punctuation', 'gps-check', FIXTURE_REGISTRY);
+  assert.equal(result.launchable, true);
+  assert.equal(result.status, 'launchable');
+});
+
+test('determineLaunchStatus: not-launchable for unknown launcher on known subject', () => {
+  const result = determineLaunchStatus('spelling', 'mini-test', FIXTURE_REGISTRY);
+  assert.equal(result.launchable, false);
+  assert.equal(result.status, 'not-launchable');
+  assert.ok(result.reason.includes('launcher not supported'));
+});
+
+test('determineLaunchStatus: subject-unavailable for unknown subject', () => {
+  const result = determineLaunchStatus('arithmetic', 'smart-practice', FIXTURE_REGISTRY);
+  assert.equal(result.launchable, false);
+  assert.equal(result.status, 'subject-unavailable');
+  assert.ok(result.reason.includes('no capability entry'));
+});
+
+test('determineLaunchStatus: not-launchable for empty subjectId', () => {
+  const result = determineLaunchStatus('', 'smart-practice', FIXTURE_REGISTRY);
+  assert.equal(result.launchable, false);
+  assert.equal(result.status, 'not-launchable');
+});
+
+test('determineLaunchStatus: not-launchable for empty launcher', () => {
+  const result = determineLaunchStatus('spelling', '', FIXTURE_REGISTRY);
+  assert.equal(result.launchable, false);
+  assert.equal(result.status, 'not-launchable');
+});
+
+test('determineLaunchStatus: handles null registry gracefully', () => {
+  const result = determineLaunchStatus('spelling', 'smart-practice', null);
+  assert.equal(result.launchable, false);
+  assert.equal(result.status, 'subject-unavailable');
+});
+
+test('determineLaunchStatus: handles registry entry with missing launchers object', () => {
+  const registry = { spelling: {} };
+  const result = determineLaunchStatus('spelling', 'smart-practice', registry);
+  assert.equal(result.launchable, false);
+  assert.equal(result.status, 'not-launchable');
+});
+
+test('determineLaunchStatus: launcher set to false is not-launchable', () => {
+  const registry = {
+    spelling: {
+      launchers: { 'smart-practice': false },
+    },
+  };
+  const result = determineLaunchStatus('spelling', 'smart-practice', registry);
+  assert.equal(result.launchable, false);
+  assert.equal(result.status, 'not-launchable');
+});

--- a/tests/hero-launch-flow.test.js
+++ b/tests/hero-launch-flow.test.js
@@ -1,0 +1,320 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createApiPlatformRepositories } from '../src/platform/core/repositories/index.js';
+import { createWorkerRepositoryServer } from './helpers/worker-server.js';
+
+const HERO_COMMAND_URL = 'https://repo.test/api/hero/command';
+const HERO_READ_MODEL_URL = 'https://repo.test/api/hero/read-model';
+
+function createServer() {
+  return createWorkerRepositoryServer({
+    env: {
+      HERO_MODE_SHADOW_ENABLED: 'true',
+      HERO_MODE_LAUNCH_ENABLED: 'true',
+      PUNCTUATION_SUBJECT_ENABLED: 'true',
+    },
+  });
+}
+
+async function seedLearnerWithSubjectState(server, accountId, learnerId) {
+  const repos = createApiPlatformRepositories({
+    baseUrl: 'https://repo.test',
+    fetch: server.fetch.bind(server),
+    authSession: server.authSessionFor(accountId),
+  });
+  await repos.hydrate();
+  repos.learners.write({
+    byId: {
+      [learnerId]: {
+        id: learnerId,
+        name: 'Flow Test Learner',
+        yearGroup: 'Y5',
+        goal: 'sats',
+        dailyMinutes: 15,
+        avatarColor: '#3E6FA8',
+        createdAt: 1,
+      },
+    },
+    allIds: [learnerId],
+    selectedId: learnerId,
+  });
+  await repos.flush();
+
+  // Seed spelling subject state so the Hero spelling provider produces
+  // launchable envelopes. The provider reads stats.core — we need
+  // total > 0 with due and trouble words to generate multiple tasks.
+  const spellingData = {
+    stats: {
+      core: { total: 50, secure: 30, due: 10, fresh: 5, trouble: 5, attempts: 200, correct: 160, accuracy: 0.8 },
+      all: { total: 50, secure: 30, due: 10, fresh: 5, trouble: 5, attempts: 200, correct: 160, accuracy: 0.8 },
+    },
+  };
+  const now = Date.now();
+  server.DB.db.prepare(`
+    INSERT INTO child_subject_state (learner_id, subject_id, ui_json, data_json, updated_at, updated_by_account_id)
+    VALUES (?, 'spelling', '{}', ?, ?, ?)
+  `).run(learnerId, JSON.stringify(spellingData), now, accountId);
+
+  return repos;
+}
+
+async function getReadModel(server, learnerId = 'learner-a') {
+  const response = await server.fetch(`${HERO_READ_MODEL_URL}?learnerId=${learnerId}`);
+  const payload = await response.json();
+  assert.equal(response.status, 200, `Read model returned ${response.status}: ${JSON.stringify(payload)}`);
+  assert.ok(payload.hero, 'Read model must contain hero block');
+  return payload;
+}
+
+function findFirstLaunchableTask(heroPayload) {
+  const quest = heroPayload.hero.dailyQuest;
+  if (!quest || !quest.tasks) return null;
+  const task = quest.tasks.find((t) => t.launchStatus === 'launchable');
+  if (!task) return null;
+  return { questId: quest.questId, taskId: task.taskId, task };
+}
+
+function getLearnerRevision(server, accountId = 'adult-a') {
+  const row = server.DB.db.prepare(
+    `SELECT lp.state_revision FROM learner_profiles lp
+     JOIN account_learner_memberships alm ON alm.learner_id = lp.id
+     WHERE alm.account_id = ?`,
+  ).get(accountId);
+  return row?.state_revision ?? 0;
+}
+
+async function postHeroCommand(server, body, accountId = 'adult-a') {
+  return server.fetchAs(accountId, HERO_COMMAND_URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+// heroContext lives on the subject state (ui_json.session.heroContext) because
+// the engine adds it after service.startSession returns. The practice_sessions
+// snapshot is taken before that point, so we verify via child_subject_state.
+function getSubjectSessionState(server, learnerId, subjectId) {
+  const row = server.DB.db.prepare(
+    `SELECT ui_json FROM child_subject_state
+     WHERE learner_id = ? AND subject_id = ?`,
+  ).get(learnerId, subjectId);
+  if (!row) return null;
+  const ui = JSON.parse(row.ui_json);
+  return ui?.session || null;
+}
+
+// ── Full E2E launch flow ────────────────────────────────────────────
+
+test('E2E launch: read model → pick launchable task → start-task → verify heroLaunch + subject response', async () => {
+  const server = createServer();
+  await seedLearnerWithSubjectState(server, 'adult-a', 'learner-a');
+
+  const readModelPayload = await getReadModel(server);
+  const launchable = findFirstLaunchableTask(readModelPayload);
+  if (!launchable) {
+    server.close();
+    assert.fail('No launchable task found in read model — cannot exercise E2E flow');
+  }
+
+  const revision = getLearnerRevision(server);
+  const response = await postHeroCommand(server, {
+    command: 'start-task',
+    learnerId: 'learner-a',
+    questId: launchable.questId,
+    taskId: launchable.taskId,
+    requestId: 'hero-flow-e2e-1',
+    expectedLearnerRevision: revision,
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 200, `Expected 200, got ${response.status}: ${JSON.stringify(payload)}`);
+  assert.equal(payload.ok, true);
+
+  assert.ok(payload.heroLaunch, 'Response must include heroLaunch block');
+  assert.equal(payload.heroLaunch.status, 'started');
+  assert.equal(payload.heroLaunch.questId, launchable.questId);
+  assert.equal(payload.heroLaunch.taskId, launchable.taskId);
+  assert.equal(payload.heroLaunch.subjectCommand, 'start-session');
+  assert.equal(typeof payload.heroLaunch.subjectId, 'string');
+
+  assert.equal(payload.subjectId, payload.heroLaunch.subjectId);
+  assert.equal(payload.command, 'start-session');
+  assert.ok(payload.changed === true || payload.subjectReadModel != null,
+    'Response must include subject read model data');
+
+  server.close();
+});
+
+// ── Safety flags ────────────────────────────────────────────────────
+
+test('E2E launch: heroLaunch safety flags are all false/disabled', async () => {
+  const server = createServer();
+  await seedLearnerWithSubjectState(server, 'adult-a', 'learner-a');
+
+  const readModelPayload = await getReadModel(server);
+  const launchable = findFirstLaunchableTask(readModelPayload);
+  if (!launchable) {
+    server.close();
+    assert.fail('No launchable task found — cannot verify safety flags');
+  }
+
+  const revision = getLearnerRevision(server);
+  const response = await postHeroCommand(server, {
+    command: 'start-task',
+    learnerId: 'learner-a',
+    questId: launchable.questId,
+    taskId: launchable.taskId,
+    requestId: 'hero-flow-safety-1',
+    expectedLearnerRevision: revision,
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(payload.heroLaunch.coinsEnabled, false, 'coinsEnabled must be false');
+  assert.equal(payload.heroLaunch.claimEnabled, false, 'claimEnabled must be false');
+  assert.equal(payload.heroLaunch.childVisible, false, 'childVisible must be false');
+
+  server.close();
+});
+
+// ── heroContext on active session ────────────────────────────────────
+
+test('E2E launch: active session carries heroContext with matching questId and taskId', async () => {
+  const server = createServer();
+  await seedLearnerWithSubjectState(server, 'adult-a', 'learner-a');
+
+  const readModelPayload = await getReadModel(server);
+  const launchable = findFirstLaunchableTask(readModelPayload);
+  if (!launchable) {
+    server.close();
+    assert.fail('No launchable task found — cannot verify heroContext on session');
+  }
+
+  const revision = getLearnerRevision(server);
+  const response = await postHeroCommand(server, {
+    command: 'start-task',
+    learnerId: 'learner-a',
+    questId: launchable.questId,
+    taskId: launchable.taskId,
+    requestId: 'hero-flow-ctx-1',
+    expectedLearnerRevision: revision,
+  });
+  const payload = await response.json();
+  assert.equal(response.status, 200);
+
+  const subjectId = payload.heroLaunch.subjectId;
+  const session = getSubjectSessionState(server, 'learner-a', subjectId);
+  assert.ok(session, 'Subject state must contain an active session after Hero launch');
+  assert.ok(session.heroContext, 'Active session state must carry heroContext');
+  assert.equal(session.heroContext.questId, launchable.questId);
+  assert.equal(session.heroContext.taskId, launchable.taskId);
+  assert.equal(session.heroContext.source, 'hero-mode');
+  assert.equal(session.heroContext.phase, 'p1-launch');
+
+  server.close();
+});
+
+// ── Idempotent replay ───────────────────────────────────────────────
+// The launch route recomputes the quest on every call (R5). After a
+// successful launch the subject state changes, which shifts the quest
+// hash and produces a new questId. A replay of the original questId
+// therefore hits the hero_quest_stale guard before the repository-layer
+// idempotency check is reached. This is the correct safety behaviour:
+// stale quests are rejected rather than silently replayed.
+
+test('E2E launch: replay with stale questId after state change → hero_quest_stale', async () => {
+  const server = createServer();
+  await seedLearnerWithSubjectState(server, 'adult-a', 'learner-a');
+
+  const readModelPayload = await getReadModel(server);
+  const launchable = findFirstLaunchableTask(readModelPayload);
+  if (!launchable) {
+    server.close();
+    assert.fail('No launchable task found — cannot verify replay behaviour');
+  }
+
+  const revision = getLearnerRevision(server);
+  const commandBody = {
+    command: 'start-task',
+    learnerId: 'learner-a',
+    questId: launchable.questId,
+    taskId: launchable.taskId,
+    requestId: 'hero-flow-idem-1',
+    expectedLearnerRevision: revision,
+  };
+
+  const firstResp = await postHeroCommand(server, commandBody);
+  const firstPayload = await firstResp.json();
+  assert.equal(firstResp.status, 200);
+  assert.equal(firstPayload.ok, true);
+
+  const updatedRevision = getLearnerRevision(server);
+  const replayResp = await postHeroCommand(server, {
+    ...commandBody,
+    expectedLearnerRevision: updatedRevision,
+  });
+  const replayPayload = await replayResp.json();
+
+  assert.equal(replayResp.status, 409);
+  assert.equal(replayPayload.code, 'hero_quest_stale',
+    'Replay after state change must be rejected as stale quest');
+
+  server.close();
+});
+
+// ── Idempotency violation (repository layer) ────────────────────────
+// The mutation receipt layer rejects a second command that reuses the
+// same requestId with a different payload hash. We verify this through
+// two successive launches (each with a fresh quest read) that share
+// the same requestId but resolve to different subject payloads.
+
+test('E2E launch: same requestId with different task payloads → idempotency_reuse', async () => {
+  const server = createServer();
+  await seedLearnerWithSubjectState(server, 'adult-a', 'learner-a');
+
+  const rm1 = await getReadModel(server);
+  const launchable1 = findFirstLaunchableTask(rm1);
+  if (!launchable1) {
+    server.close();
+    assert.fail('No launchable task found — cannot verify idempotency violation');
+  }
+
+  const rev1 = getLearnerRevision(server);
+  const firstResp = await postHeroCommand(server, {
+    command: 'start-task',
+    learnerId: 'learner-a',
+    questId: launchable1.questId,
+    taskId: launchable1.taskId,
+    requestId: 'hero-flow-idem-clash-1',
+    expectedLearnerRevision: rev1,
+  });
+  assert.equal(firstResp.status, 200);
+
+  // Re-read the model after the launch changed subject state.
+  // The new quest has a different questId and potentially different tasks.
+  const rm2 = await getReadModel(server);
+  const launchable2 = findFirstLaunchableTask(rm2);
+  if (!launchable2) {
+    server.close();
+    return;
+  }
+
+  const rev2 = getLearnerRevision(server);
+  const clashResp = await postHeroCommand(server, {
+    command: 'start-task',
+    learnerId: 'learner-a',
+    questId: launchable2.questId,
+    taskId: launchable2.taskId,
+    requestId: 'hero-flow-idem-clash-1',
+    expectedLearnerRevision: rev2,
+  });
+  const clashPayload = await clashResp.json();
+
+  assert.equal(clashResp.status, 409);
+  assert.equal(clashPayload.code, 'idempotency_reuse',
+    'Same requestId with different subject payload must be rejected');
+
+  server.close();
+});

--- a/tests/hero-no-write-boundary.test.js
+++ b/tests/hero-no-write-boundary.test.js
@@ -1,16 +1,19 @@
-// Hero Mode P0 — No-write boundary tests.
+// Hero Mode — No-write boundary tests.
 //
-// Structural and behavioural tests proving the P0 Hero code layer cannot
-// write reward or subject state. These guard against accidental future
-// drift that would violate the read-only contract.
+// Structural and behavioural tests proving the Hero code layer cannot
+// directly write reward or subject state. These guard against accidental
+// drift that would violate the architectural contract.
 //
-// Structural tests (1-6): use fs.readFileSync to scan the import graph
+// Structural tests (S1-S6): use fs.readFileSync to scan the import graph
 // and source content of every .js file under shared/hero/ and
 // worker/src/hero/. No file IO at test-time beyond reading local source.
+// New P1 files (launch.js, launch-adapters/, launch-context.js,
+// launch-status.js) are automatically included via collectJsFiles().
 //
-// Behavioural tests (7-8): use the Worker test server to prove the
-// route does not mutate any database table and that no command endpoint
-// exists.
+// Behavioural tests (B7-B8): B7 proves GET read-model writes zero rows.
+// B8 proves POST /api/hero/command returns 404 when the launch flag is
+// off. The flag-on path is covered in worker-hero-command.test.js and
+// hero-launch-boundary.test.js.
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
@@ -277,11 +280,14 @@ test('B7: GET /api/hero/read-model does not write to any state table', async () 
   server.close();
 });
 
-// ── Behavioural test 8: POST /api/hero/command returns 404 ───────────────────
+// ── Behavioural test 8: POST /api/hero/command gate — flag off returns 404 ────
 
-test('B8: POST /api/hero/command returns 404 (route does not exist)', async () => {
+test('B8: POST /api/hero/command with HERO_MODE_LAUNCH_ENABLED=false returns 404', async () => {
   const server = createWorkerRepositoryServer({
-    env: { HERO_MODE_SHADOW_ENABLED: 'true' },
+    env: {
+      HERO_MODE_SHADOW_ENABLED: 'true',
+      HERO_MODE_LAUNCH_ENABLED: 'false',
+    },
   });
 
   const response = await server.fetch(
@@ -289,15 +295,17 @@ test('B8: POST /api/hero/command returns 404 (route does not exist)', async () =
     {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ action: 'test' }),
+      body: JSON.stringify({ command: 'start-task' }),
     },
   );
+  const payload = await response.json();
 
   assert.equal(
     response.status,
     404,
-    `POST /api/hero/command must return 404 — P0 Hero has no write endpoint; got ${response.status}`,
+    `POST /api/hero/command with launch flag off must return 404; got ${response.status}`,
   );
+  assert.equal(payload.code, 'hero_launch_disabled');
 
   server.close();
 });

--- a/tests/hero-task-ids.test.js
+++ b/tests/hero-task-ids.test.js
@@ -1,0 +1,221 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildHeroShadowReadModel } from '../worker/src/hero/read-model.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+function makeSubjectReadModel(subjectId) {
+  if (subjectId === 'spelling') {
+    return {
+      stats: {
+        core: { total: 20, secure: 10, due: 5, fresh: 3, trouble: 2, attempts: 100 },
+      },
+    };
+  }
+  if (subjectId === 'grammar') {
+    return {
+      stats: {
+        concepts: { total: 15, new: 2, learning: 3, weak: 2, due: 4, secured: 4 },
+      },
+    };
+  }
+  if (subjectId === 'punctuation') {
+    return {
+      availability: { status: 'ready' },
+      stats: { total: 12, secure: 4, due: 3, fresh: 2, weak: 2, attempts: 60, correct: 45, accuracy: 75 },
+    };
+  }
+  return {};
+}
+
+function buildReadModelWithSubjects(subjectIds, env) {
+  const subjectReadModels = {};
+  for (const id of subjectIds) {
+    subjectReadModels[id] = makeSubjectReadModel(id);
+  }
+  return buildHeroShadowReadModel({
+    learnerId: 'learner-test',
+    subjectReadModels,
+    now: Date.UTC(2026, 3, 27, 10, 0, 0),
+    env,
+  });
+}
+
+// ── Happy path: task IDs ─────────────────────────────────────────────────
+
+test('every task has a taskId string matching /^hero-task-[0-9a-f]{8}$/', () => {
+  const result = buildReadModelWithSubjects(['spelling', 'grammar', 'punctuation']);
+  const tasks = result.dailyQuest.tasks;
+
+  assert.ok(tasks.length > 0, 'quest must have at least one task');
+  for (const task of tasks) {
+    assert.match(task.taskId, /^hero-task-[0-9a-f]{8}$/);
+  }
+});
+
+test('every task has a launchStatus string field', () => {
+  const result = buildReadModelWithSubjects(['spelling', 'grammar', 'punctuation']);
+  for (const task of result.dailyQuest.tasks) {
+    assert.equal(typeof task.launchStatus, 'string');
+    assert.ok(task.launchStatus.length > 0);
+  }
+});
+
+test('launchable tasks have launchStatus: launchable', () => {
+  const result = buildReadModelWithSubjects(['spelling', 'grammar', 'punctuation']);
+  const launchable = result.dailyQuest.tasks.filter(
+    (t) => t.launchStatus === 'launchable',
+  );
+  assert.ok(launchable.length > 0, 'at least one task should be launchable');
+  for (const task of launchable) {
+    assert.equal(task.launchStatus, 'launchable');
+    assert.equal(task.launchStatusReason, null);
+  }
+});
+
+// ── Happy path: heroContext per task ─────────────────────────────────────
+
+test('every task has a heroContext object with required fields', () => {
+  const result = buildReadModelWithSubjects(['spelling', 'grammar', 'punctuation']);
+  const requiredFields = [
+    'version', 'questId', 'taskId', 'dateKey',
+    'subjectId', 'intent', 'source', 'phase',
+  ];
+  for (const task of result.dailyQuest.tasks) {
+    assert.equal(typeof task.heroContext, 'object');
+    assert.ok(task.heroContext !== null);
+    for (const field of requiredFields) {
+      assert.ok(
+        field in task.heroContext,
+        `heroContext must have field: ${field}`,
+      );
+    }
+    assert.equal(task.heroContext.source, 'hero-mode');
+    assert.equal(task.heroContext.phase, 'p1-launch');
+    assert.equal(task.heroContext.version, 1);
+    assert.equal(task.heroContext.questId, result.dailyQuest.questId);
+    assert.equal(task.heroContext.taskId, task.taskId);
+    assert.equal(task.heroContext.subjectId, task.subjectId);
+    assert.equal(task.heroContext.questFingerprint, null);
+  }
+});
+
+// ── Happy path: response version ─────────────────────────────────────────
+
+test('response version is 2', () => {
+  const result = buildReadModelWithSubjects(['spelling']);
+  assert.equal(result.version, 2);
+});
+
+// ── Happy path: launch capability block ──────────────────────────────────
+
+test('launch block present with correct structure', () => {
+  const result = buildReadModelWithSubjects(
+    ['spelling'],
+    { HERO_MODE_LAUNCH_ENABLED: 'true' },
+  );
+  assert.equal(typeof result.launch, 'object');
+  assert.equal(result.launch.enabled, true);
+  assert.equal(result.launch.commandRoute, '/api/hero/command');
+  assert.equal(result.launch.command, 'start-task');
+  assert.equal(result.launch.claimEnabled, false);
+  assert.equal(result.launch.heroStatePersistenceEnabled, false);
+});
+
+// ── Happy path: all P0 fields preserved ──────────────────────────────────
+
+test('all P0 fields still present', () => {
+  const result = buildReadModelWithSubjects(['spelling', 'grammar', 'punctuation']);
+  assert.equal(result.mode, 'shadow');
+  assert.equal(result.childVisible, false);
+  assert.equal(result.coinsEnabled, false);
+  assert.equal(result.writesEnabled, false);
+  assert.ok(Array.isArray(result.eligibleSubjects));
+  assert.ok(Array.isArray(result.lockedSubjects));
+  assert.equal(typeof result.dailyQuest, 'object');
+  assert.equal(typeof result.debug, 'object');
+  assert.equal(typeof result.dateKey, 'string');
+  assert.equal(result.timezone, 'Europe/London');
+  assert.equal(result.schedulerVersion, 'hero-p1-launch-v1');
+});
+
+// ── Edge case: launch flag off ───────────────────────────────────────────
+
+test('launch.enabled is false when no env provided', () => {
+  const result = buildReadModelWithSubjects(['spelling']);
+  assert.equal(result.launch.enabled, false);
+});
+
+test('launch.enabled is false when env has no HERO_MODE_LAUNCH_ENABLED', () => {
+  const result = buildReadModelWithSubjects(['spelling'], {});
+  assert.equal(result.launch.enabled, false);
+});
+
+test('launch.enabled is false when flag is "false"', () => {
+  const result = buildReadModelWithSubjects(
+    ['spelling'],
+    { HERO_MODE_LAUNCH_ENABLED: 'false' },
+  );
+  assert.equal(result.launch.enabled, false);
+});
+
+// ── Edge case: zero eligible subjects ────────────────────────────────────
+
+test('zero eligible subjects produces safe empty quest with no taskIds', () => {
+  const result = buildHeroShadowReadModel({
+    learnerId: 'learner-empty',
+    subjectReadModels: {},
+    now: Date.UTC(2026, 3, 27, 10, 0, 0),
+  });
+  assert.equal(result.dailyQuest.tasks.length, 0);
+  assert.equal(result.dailyQuest.effortPlanned, 0);
+  assert.equal(typeof result.dailyQuest.questId, 'string');
+  assert.ok(result.dailyQuest.questId.startsWith('hero-quest-'));
+  assert.equal(result.version, 2);
+  assert.equal(typeof result.launch, 'object');
+});
+
+// ── Edge case: not-launchable tasks appear with explicit reason ──────────
+
+test('not-launchable tasks still appear in quest with explicit reason', () => {
+  const result = buildReadModelWithSubjects(['spelling', 'grammar', 'punctuation']);
+  const notLaunchable = result.dailyQuest.tasks.filter(
+    (t) => t.launchStatus !== 'launchable',
+  );
+  for (const task of notLaunchable) {
+    assert.equal(typeof task.launchStatus, 'string');
+    assert.ok(task.launchStatus.length > 0);
+    assert.equal(typeof task.launchStatusReason, 'string');
+    assert.ok(task.launchStatusReason.length > 0);
+    assert.match(task.taskId, /^hero-task-[0-9a-f]{8}$/);
+  }
+});
+
+// ── Determinism: same inputs produce same taskIds ────────────────────────
+
+test('same inputs produce same taskIds on consecutive calls', () => {
+  const args = {
+    learnerId: 'learner-determinism',
+    subjectReadModels: {
+      spelling: makeSubjectReadModel('spelling'),
+      grammar: makeSubjectReadModel('grammar'),
+    },
+    now: Date.UTC(2026, 3, 27, 10, 0, 0),
+  };
+
+  const result1 = buildHeroShadowReadModel(args);
+  const result2 = buildHeroShadowReadModel(args);
+
+  assert.equal(result1.dailyQuest.questId, result2.dailyQuest.questId);
+  assert.equal(
+    result1.dailyQuest.tasks.length,
+    result2.dailyQuest.tasks.length,
+  );
+  for (let i = 0; i < result1.dailyQuest.tasks.length; i++) {
+    assert.equal(
+      result1.dailyQuest.tasks[i].taskId,
+      result2.dailyQuest.tasks[i].taskId,
+    );
+  }
+});

--- a/tests/worker-hero-command.test.js
+++ b/tests/worker-hero-command.test.js
@@ -1,0 +1,420 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createApiPlatformRepositories } from '../src/platform/core/repositories/index.js';
+import { createWorkerRepositoryServer } from './helpers/worker-server.js';
+
+const HERO_COMMAND_URL = 'https://repo.test/api/hero/command';
+const HERO_READ_MODEL_URL = 'https://repo.test/api/hero/read-model';
+
+function createServerWithFlags({ shadow = true, launch = true, punctuation = true } = {}) {
+  return createWorkerRepositoryServer({
+    env: {
+      HERO_MODE_SHADOW_ENABLED: shadow ? 'true' : 'false',
+      HERO_MODE_LAUNCH_ENABLED: launch ? 'true' : 'false',
+      PUNCTUATION_SUBJECT_ENABLED: punctuation ? 'true' : 'false',
+    },
+  });
+}
+
+async function seedLearner(server, accountId, learnerId) {
+  const repos = createApiPlatformRepositories({
+    baseUrl: 'https://repo.test',
+    fetch: server.fetch.bind(server),
+    authSession: server.authSessionFor(accountId),
+  });
+  await repos.hydrate();
+  repos.learners.write({
+    byId: {
+      [learnerId]: {
+        id: learnerId,
+        name: 'Hero Test Learner',
+        yearGroup: 'Y5',
+        goal: 'sats',
+        dailyMinutes: 15,
+        avatarColor: '#3E6FA8',
+        createdAt: 1,
+      },
+    },
+    allIds: [learnerId],
+    selectedId: learnerId,
+  });
+  await repos.flush();
+  return repos;
+}
+
+async function postHeroCommand(server, body, accountId = 'adult-a') {
+  return server.fetchAs(accountId, HERO_COMMAND_URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+async function getFirstLaunchableTask(server, learnerId = 'learner-a') {
+  const response = await server.fetch(`${HERO_READ_MODEL_URL}?learnerId=${learnerId}`);
+  const payload = await response.json();
+  if (response.status !== 200 || !payload.hero) return null;
+  const quest = payload.hero.dailyQuest;
+  if (!quest || !quest.tasks) return null;
+  const task = quest.tasks.find((t) => t.launchStatus === 'launchable');
+  if (!task) return null;
+  return {
+    questId: quest.questId,
+    taskId: task.taskId,
+    task,
+  };
+}
+
+function getLearnerRevision(server, accountId = 'adult-a') {
+  const learnerMembership = server.DB.db.prepare(
+    `SELECT lp.state_revision FROM learner_profiles lp
+     JOIN account_learner_memberships alm ON alm.learner_id = lp.id
+     WHERE alm.account_id = ?`,
+  ).get(accountId);
+  return learnerMembership?.state_revision ?? 0;
+}
+
+// ── Happy path ────────────────────────────────────────────────────────
+
+test('hero command: happy path — both flags on, valid request returns 200 with heroLaunch', async () => {
+  const server = createServerWithFlags();
+  await seedLearner(server, 'adult-a', 'learner-a');
+
+  const launchable = await getFirstLaunchableTask(server);
+  if (!launchable) {
+    server.close();
+    return;
+  }
+
+  const revision = getLearnerRevision(server);
+  const response = await postHeroCommand(server, {
+    command: 'start-task',
+    learnerId: 'learner-a',
+    questId: launchable.questId,
+    taskId: launchable.taskId,
+    requestId: 'hero-cmd-1',
+    expectedLearnerRevision: revision,
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 200, `Expected 200, got ${response.status}: ${JSON.stringify(payload)}`);
+  assert.equal(payload.ok, true);
+  assert.ok(payload.heroLaunch, 'Response must include heroLaunch block');
+  assert.equal(payload.heroLaunch.status, 'started');
+  assert.equal(payload.heroLaunch.questId, launchable.questId);
+  assert.equal(payload.heroLaunch.taskId, launchable.taskId);
+  assert.equal(payload.heroLaunch.subjectCommand, 'start-session');
+  assert.equal(typeof payload.heroLaunch.subjectId, 'string');
+  assert.equal(typeof payload.heroLaunch.intent, 'string');
+  assert.equal(typeof payload.heroLaunch.launcher, 'string');
+  assert.equal(payload.subjectId, payload.heroLaunch.subjectId);
+  assert.equal(payload.command, 'start-session');
+
+  server.close();
+});
+
+test('hero command: heroLaunch safety flags are all false', async () => {
+  const server = createServerWithFlags();
+  await seedLearner(server, 'adult-a', 'learner-a');
+
+  const launchable = await getFirstLaunchableTask(server);
+  if (!launchable) {
+    server.close();
+    return;
+  }
+
+  const revision = getLearnerRevision(server);
+  const response = await postHeroCommand(server, {
+    command: 'start-task',
+    learnerId: 'learner-a',
+    questId: launchable.questId,
+    taskId: launchable.taskId,
+    requestId: 'hero-cmd-2',
+    expectedLearnerRevision: revision,
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(payload.heroLaunch.coinsEnabled, false);
+  assert.equal(payload.heroLaunch.claimEnabled, false);
+  assert.equal(payload.heroLaunch.childVisible, false);
+
+  server.close();
+});
+
+// ── Error path: flags ──────────────────────────────────────────────────
+
+test('hero command: launch flag off returns 404 hero_launch_disabled', async () => {
+  const server = createServerWithFlags({ shadow: true, launch: false });
+  await seedLearner(server, 'adult-a', 'learner-a');
+
+  const response = await postHeroCommand(server, {
+    command: 'start-task',
+    learnerId: 'learner-a',
+    questId: 'q-1',
+    taskId: 't-1',
+    requestId: 'cmd-1',
+    expectedLearnerRevision: 0,
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 404);
+  assert.equal(payload.code, 'hero_launch_disabled');
+
+  server.close();
+});
+
+test('hero command: launch on but shadow off returns 409 hero_launch_misconfigured', async () => {
+  const server = createServerWithFlags({ shadow: false, launch: true });
+  await seedLearner(server, 'adult-a', 'learner-a');
+
+  const response = await postHeroCommand(server, {
+    command: 'start-task',
+    learnerId: 'learner-a',
+    questId: 'q-1',
+    taskId: 't-1',
+    requestId: 'cmd-1',
+    expectedLearnerRevision: 0,
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 409);
+  assert.equal(payload.code, 'hero_launch_misconfigured');
+
+  server.close();
+});
+
+// ── Error path: auth ───────────────────────────────────────────────────
+
+test('hero command: unauthenticated request returns 401', async () => {
+  const server = createServerWithFlags();
+
+  const response = await server.fetchRaw(HERO_COMMAND_URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ command: 'start-task' }),
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 401);
+  assert.equal(payload.code, 'unauthenticated');
+
+  server.close();
+});
+
+// ── Error path: missing fields ─────────────────────────────────────────
+
+test('hero command: missing command returns 400 hero_command_required', async () => {
+  const server = createServerWithFlags();
+  await seedLearner(server, 'adult-a', 'learner-a');
+
+  const response = await postHeroCommand(server, {
+    learnerId: 'learner-a',
+    questId: 'q-1',
+    taskId: 't-1',
+    requestId: 'cmd-1',
+    expectedLearnerRevision: 0,
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.code, 'hero_command_required');
+
+  server.close();
+});
+
+test('hero command: unsupported command returns 400 hero_command_unsupported', async () => {
+  const server = createServerWithFlags();
+  await seedLearner(server, 'adult-a', 'learner-a');
+
+  const response = await postHeroCommand(server, {
+    command: 'claim-task',
+    learnerId: 'learner-a',
+    questId: 'q-1',
+    taskId: 't-1',
+    requestId: 'cmd-1',
+    expectedLearnerRevision: 0,
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.code, 'hero_command_unsupported');
+
+  server.close();
+});
+
+test('hero command: missing questId returns 400 hero_quest_id_required', async () => {
+  const server = createServerWithFlags();
+  await seedLearner(server, 'adult-a', 'learner-a');
+
+  const response = await postHeroCommand(server, {
+    command: 'start-task',
+    learnerId: 'learner-a',
+    taskId: 't-1',
+    requestId: 'cmd-1',
+    expectedLearnerRevision: 0,
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.code, 'hero_quest_id_required');
+
+  server.close();
+});
+
+test('hero command: missing taskId returns 400 hero_task_id_required', async () => {
+  const server = createServerWithFlags();
+  await seedLearner(server, 'adult-a', 'learner-a');
+
+  const response = await postHeroCommand(server, {
+    command: 'start-task',
+    learnerId: 'learner-a',
+    questId: 'q-1',
+    requestId: 'cmd-1',
+    expectedLearnerRevision: 0,
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.code, 'hero_task_id_required');
+
+  server.close();
+});
+
+test('hero command: missing requestId returns 400 command_request_id_required', async () => {
+  const server = createServerWithFlags();
+  await seedLearner(server, 'adult-a', 'learner-a');
+
+  const response = await postHeroCommand(server, {
+    command: 'start-task',
+    learnerId: 'learner-a',
+    questId: 'q-1',
+    taskId: 't-1',
+    expectedLearnerRevision: 0,
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.code, 'command_request_id_required');
+
+  server.close();
+});
+
+test('hero command: missing expectedLearnerRevision returns 400 command_revision_required', async () => {
+  const server = createServerWithFlags();
+  await seedLearner(server, 'adult-a', 'learner-a');
+
+  const response = await postHeroCommand(server, {
+    command: 'start-task',
+    learnerId: 'learner-a',
+    questId: 'q-1',
+    taskId: 't-1',
+    requestId: 'cmd-1',
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.code, 'command_revision_required');
+
+  server.close();
+});
+
+// ── Error path: stale quest ────────────────────────────────────────────
+
+test('hero command: wrong questId returns 409 hero_quest_stale', async () => {
+  const server = createServerWithFlags();
+  await seedLearner(server, 'adult-a', 'learner-a');
+
+  const response = await postHeroCommand(server, {
+    command: 'start-task',
+    learnerId: 'learner-a',
+    questId: 'hero-quest-nonexistent',
+    taskId: 'hero-task-00000000',
+    requestId: 'cmd-1',
+    expectedLearnerRevision: 0,
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 409);
+  assert.equal(payload.code, 'hero_quest_stale');
+
+  server.close();
+});
+
+// ── Error path: task not found ─────────────────────────────────────────
+
+test('hero command: wrong taskId returns 404 hero_task_not_found', async () => {
+  const server = createServerWithFlags();
+  await seedLearner(server, 'adult-a', 'learner-a');
+
+  const readModelResponse = await server.fetch(`${HERO_READ_MODEL_URL}?learnerId=learner-a`);
+  const readModelPayload = await readModelResponse.json();
+  const questId = readModelPayload.hero?.dailyQuest?.questId;
+
+  if (!questId) {
+    server.close();
+    return;
+  }
+
+  const response = await postHeroCommand(server, {
+    command: 'start-task',
+    learnerId: 'learner-a',
+    questId,
+    taskId: 'hero-task-nonexistent',
+    requestId: 'cmd-1',
+    expectedLearnerRevision: 0,
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 404);
+  assert.equal(payload.code, 'hero_task_not_found');
+
+  server.close();
+});
+
+// ── Error path: client-supplied subjectId or payload ───────────────────
+
+test('hero command: client-supplied subjectId is rejected', async () => {
+  const server = createServerWithFlags();
+  await seedLearner(server, 'adult-a', 'learner-a');
+
+  const response = await postHeroCommand(server, {
+    command: 'start-task',
+    learnerId: 'learner-a',
+    questId: 'q-1',
+    taskId: 't-1',
+    requestId: 'cmd-1',
+    expectedLearnerRevision: 0,
+    subjectId: 'spelling',
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.code, 'hero_client_field_rejected');
+  assert.equal(payload.field, 'subjectId');
+
+  server.close();
+});
+
+test('hero command: client-supplied payload is rejected', async () => {
+  const server = createServerWithFlags();
+  await seedLearner(server, 'adult-a', 'learner-a');
+
+  const response = await postHeroCommand(server, {
+    command: 'start-task',
+    learnerId: 'learner-a',
+    questId: 'q-1',
+    taskId: 't-1',
+    requestId: 'cmd-1',
+    expectedLearnerRevision: 0,
+    payload: { mode: 'smart' },
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.code, 'hero_client_field_rejected');
+  assert.equal(payload.field, 'payload');
+
+  server.close();
+});

--- a/tests/worker-hero-command.test.js
+++ b/tests/worker-hero-command.test.js
@@ -17,6 +17,15 @@ function createServerWithFlags({ shadow = true, launch = true, punctuation = tru
   });
 }
 
+// Minimal spelling data shape that produces at least one Hero task envelope
+// (due > 0 triggers "due-review" / "smart-practice" from the spelling provider).
+const HERO_SPELLING_DATA = {
+  stats: {
+    core: { total: 20, secure: 14, due: 3, fresh: 2, trouble: 1, attempts: 80, correct: 60, accuracy: 75 },
+    all:  { total: 20, secure: 14, due: 3, fresh: 2, trouble: 1, attempts: 80, correct: 60, accuracy: 75 },
+  },
+};
+
 async function seedLearner(server, accountId, learnerId) {
   const repos = createApiPlatformRepositories({
     baseUrl: 'https://repo.test',
@@ -40,6 +49,13 @@ async function seedLearner(server, accountId, learnerId) {
     selectedId: learnerId,
   });
   await repos.flush();
+
+  // Seed spelling subject state so the Hero scheduler generates tasks.
+  server.DB.db.prepare(`
+    INSERT OR REPLACE INTO child_subject_state (learner_id, subject_id, ui_json, data_json, updated_at)
+    VALUES (?, 'spelling', '{}', ?, ?)
+  `).run(learnerId, JSON.stringify(HERO_SPELLING_DATA), Date.now());
+
   return repos;
 }
 
@@ -82,10 +98,7 @@ test('hero command: happy path — both flags on, valid request returns 200 with
   await seedLearner(server, 'adult-a', 'learner-a');
 
   const launchable = await getFirstLaunchableTask(server);
-  if (!launchable) {
-    server.close();
-    return;
-  }
+  assert.ok(launchable, 'No launchable task found — test infrastructure broken');
 
   const revision = getLearnerRevision(server);
   const response = await postHeroCommand(server, {
@@ -119,10 +132,7 @@ test('hero command: heroLaunch safety flags are all false', async () => {
   await seedLearner(server, 'adult-a', 'learner-a');
 
   const launchable = await getFirstLaunchableTask(server);
-  if (!launchable) {
-    server.close();
-    return;
-  }
+  assert.ok(launchable, 'No launchable task found — test infrastructure broken');
 
   const revision = getLearnerRevision(server);
   const response = await postHeroCommand(server, {
@@ -240,6 +250,28 @@ test('hero command: unsupported command returns 400 hero_command_unsupported', a
 
   assert.equal(response.status, 400);
   assert.equal(payload.code, 'hero_command_unsupported');
+
+  server.close();
+});
+
+test('hero command: missing learnerId is rejected by learner access gate (403)', async () => {
+  const server = createServerWithFlags();
+  await seedLearner(server, 'adult-a', 'learner-a');
+
+  const response = await postHeroCommand(server, {
+    command: 'start-task',
+    questId: 'q-1',
+    taskId: 't-1',
+    requestId: 'cmd-1',
+    expectedLearnerRevision: 0,
+  });
+  const payload = await response.json();
+
+  // The requireLearnerReadAccess gate fires before the resolver, so an
+  // empty learnerId hits 403 (access denied) rather than the resolver's
+  // 400 hero_learner_id_required. The resolver validation is a
+  // defence-in-depth layer for direct calls outside the route.
+  assert.equal(response.status, 403);
 
   server.close();
 });

--- a/tests/worker-hero-read-model.test.js
+++ b/tests/worker-hero-read-model.test.js
@@ -55,10 +55,10 @@ test('hero read-model: flag on + authenticated returns shadow read model', async
   assert.equal(payload.hero.childVisible, false);
   assert.equal(payload.hero.coinsEnabled, false);
   assert.equal(payload.hero.writesEnabled, false);
-  assert.equal(payload.hero.version, 1);
+  assert.equal(payload.hero.version, 2);
   assert.equal(typeof payload.hero.dateKey, 'string');
   assert.equal(payload.hero.timezone, 'Europe/London');
-  assert.equal(payload.hero.schedulerVersion, 'hero-p0-shadow-v1');
+  assert.equal(payload.hero.schedulerVersion, 'hero-p1-launch-v1');
 
   server.close();
 });

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -35,7 +35,7 @@ import { createWorkerSubjectRuntime } from './subjects/runtime.js';
 import { ConflictError, ForbiddenError, NotFoundError } from './errors.js';
 import { SUBJECT_EXPOSURE_GATES } from '../../src/platform/core/subject-availability.js';
 import { consumeRateLimit, rateLimitResponse, rateLimitSubject } from './rate-limit.js';
-import { handleHeroReadModel, handleHeroCommand } from './hero/routes.js';
+import { handleHeroReadModel } from './hero/routes.js';
 import { resolveHeroStartTaskCommand } from './hero/launch.js';
 
 
@@ -1340,6 +1340,8 @@ export function createWorkerApp({
           requireSameOrigin(request, env);
           requireMutationCapability(session);
           const body = await readJson(request);
+          const heroLearnerId = body?.learnerId || '';
+          await repository.requireLearnerReadAccess(session.accountId, heroLearnerId);
           const { heroLaunch, subjectCommand } = await resolveHeroStartTaskCommand({
             body,
             repository,
@@ -1383,7 +1385,7 @@ export function createWorkerApp({
                 ok: false,
                 error: 'projection_unavailable',
                 retryable: false,
-                requestId: validatedRequestId,
+                requestId: body?.requestId || '',
                 ...(error.extra && typeof error.extra === 'object' ? { cause: error.extra.cause } : {}),
               }, 503);
             }

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -32,10 +32,11 @@ import {
 } from './demo/sessions.js';
 import { normaliseSubjectCommandRequest } from './subjects/command-contract.js';
 import { createWorkerSubjectRuntime } from './subjects/runtime.js';
-import { ForbiddenError, NotFoundError } from './errors.js';
+import { ConflictError, ForbiddenError, NotFoundError } from './errors.js';
 import { SUBJECT_EXPOSURE_GATES } from '../../src/platform/core/subject-availability.js';
 import { consumeRateLimit, rateLimitResponse, rateLimitSubject } from './rate-limit.js';
-import { handleHeroReadModel } from './hero/routes.js';
+import { handleHeroReadModel, handleHeroCommand } from './hero/routes.js';
+import { resolveHeroStartTaskCommand } from './hero/launch.js';
 
 
 // U7 (sys-hardening p1): CSP report endpoint constants. The endpoint
@@ -560,6 +561,7 @@ async function opsErrorThrottleTelemetry(env, subject, { code, bucketKey, retryA
 const CAPACITY_RELEVANT_PATH_PATTERNS = [
   /^\/api\/bootstrap$/,
   /^\/api\/subjects\/[^/]+\/command$/,
+  /^\/api\/hero\/command$/,
   /^\/api\/hubs\/parent(\/.*)?$/,
   /^\/api\/classroom(\/.*)?$/,
 ];
@@ -1322,6 +1324,71 @@ export function createWorkerApp({
 
         if (url.pathname === '/api/hero/read-model' && request.method === 'GET') {
           return handleHeroReadModel({ request, url, session, account, repository, env, now, capacity });
+        }
+
+        if (url.pathname === '/api/hero/command' && request.method === 'POST') {
+          if (!envFlagEnabled(env.HERO_MODE_LAUNCH_ENABLED)) {
+            throw new NotFoundError('Hero launch is not available.', {
+              code: 'hero_launch_disabled',
+            });
+          }
+          if (!envFlagEnabled(env.HERO_MODE_SHADOW_ENABLED)) {
+            throw new ConflictError('Hero launch requires shadow mode to be enabled.', {
+              code: 'hero_launch_misconfigured',
+            });
+          }
+          requireSameOrigin(request, env);
+          requireMutationCapability(session);
+          const body = await readJson(request);
+          const { heroLaunch, subjectCommand } = await resolveHeroStartTaskCommand({
+            body,
+            repository,
+            env,
+            now: now(),
+          });
+          requireSubjectCommandAvailable(subjectCommand, env);
+          await protectDemoSubjectCommand({
+            env,
+            request,
+            session,
+            command: subjectCommand,
+            now: now(),
+            capacity,
+          });
+          try {
+            const result = await repository.runSubjectCommand(
+              session.accountId,
+              subjectCommand,
+              () => subjectRuntime.dispatch(subjectCommand, {
+                env,
+                request,
+                session,
+                account,
+                repository,
+                now: now(),
+                capacity,
+              }),
+            );
+            return json({
+              ok: true,
+              heroLaunch,
+              ...result,
+            });
+          } catch (error) {
+            if (error?.name === 'ProjectionUnavailableError') {
+              if (typeof capacity?.setProjectionFallback === 'function') {
+                capacity.setProjectionFallback('rejected');
+              }
+              return json({
+                ok: false,
+                error: 'projection_unavailable',
+                retryable: false,
+                requestId: validatedRequestId,
+                ...(error.extra && typeof error.extra === 'object' ? { cause: error.extra.cause } : {}),
+              }, 503);
+            }
+            throw error;
+          }
         }
 
         if (url.pathname === '/api/demo/reset' && request.method === 'POST') {

--- a/worker/src/hero/launch-adapters/grammar.js
+++ b/worker/src/hero/launch-adapters/grammar.js
@@ -1,0 +1,12 @@
+const LAUNCHER_TO_MODE = Object.freeze({
+  'smart-practice': 'smart',
+  'trouble-practice': 'trouble',
+});
+
+export function mapToSubjectPayload(taskEnvelope) {
+  const mode = LAUNCHER_TO_MODE[taskEnvelope?.launcher];
+  if (!mode) {
+    return { launchable: false, reason: 'launcher-not-supported-for-subject' };
+  }
+  return { launchable: true, subjectId: 'grammar', payload: { mode } };
+}

--- a/worker/src/hero/launch-adapters/index.js
+++ b/worker/src/hero/launch-adapters/index.js
@@ -1,0 +1,18 @@
+import { mapToSubjectPayload as spellingAdapter } from './spelling.js';
+import { mapToSubjectPayload as grammarAdapter } from './grammar.js';
+import { mapToSubjectPayload as punctuationAdapter } from './punctuation.js';
+
+const ADAPTER_MAP = Object.freeze({
+  spelling: spellingAdapter,
+  grammar: grammarAdapter,
+  punctuation: punctuationAdapter,
+});
+
+export function mapHeroEnvelopeToSubjectPayload(taskEnvelope) {
+  const subjectId = taskEnvelope?.subjectId;
+  const adapter = ADAPTER_MAP[subjectId];
+  if (!adapter) {
+    return { launchable: false, reason: 'subject-adapter-not-found' };
+  }
+  return adapter(taskEnvelope);
+}

--- a/worker/src/hero/launch-adapters/punctuation.js
+++ b/worker/src/hero/launch-adapters/punctuation.js
@@ -1,0 +1,13 @@
+const LAUNCHER_TO_MODE = Object.freeze({
+  'smart-practice': 'smart',
+  'trouble-practice': 'weak',
+  'gps-check': 'gps',
+});
+
+export function mapToSubjectPayload(taskEnvelope) {
+  const mode = LAUNCHER_TO_MODE[taskEnvelope?.launcher];
+  if (!mode) {
+    return { launchable: false, reason: 'launcher-not-supported-for-subject' };
+  }
+  return { launchable: true, subjectId: 'punctuation', payload: { mode } };
+}

--- a/worker/src/hero/launch-adapters/spelling.js
+++ b/worker/src/hero/launch-adapters/spelling.js
@@ -1,0 +1,13 @@
+const LAUNCHER_TO_MODE = Object.freeze({
+  'smart-practice': 'smart',
+  'trouble-practice': 'trouble',
+  'guardian-check': 'guardian',
+});
+
+export function mapToSubjectPayload(taskEnvelope) {
+  const mode = LAUNCHER_TO_MODE[taskEnvelope?.launcher];
+  if (!mode) {
+    return { launchable: false, reason: 'launcher-not-supported-for-subject' };
+  }
+  return { launchable: true, subjectId: 'spelling', payload: { mode } };
+}

--- a/worker/src/hero/launch.js
+++ b/worker/src/hero/launch.js
@@ -16,9 +16,10 @@ export async function resolveHeroStartTaskCommand({ body, repository, env, now }
     });
   }
   if (command !== 'start-task') {
-    throw new BadRequestError(`Unsupported Hero command: ${command}`, {
+    const safeCommand = String(command).slice(0, 64).replace(/[^a-zA-Z0-9_-]/g, '');
+    throw new BadRequestError(`Unsupported Hero command: ${safeCommand}`, {
       code: 'hero_command_unsupported',
-      command,
+      command: safeCommand,
     });
   }
 
@@ -44,6 +45,11 @@ export async function resolveHeroStartTaskCommand({ body, repository, env, now }
     : requestId;
   const expectedLearnerRevision = Number(body.expectedLearnerRevision);
 
+  if (!learnerId) {
+    throw new BadRequestError('learnerId is required for Hero start-task.', {
+      code: 'hero_learner_id_required',
+    });
+  }
   if (!questId) {
     throw new BadRequestError('questId is required for Hero start-task.', {
       code: 'hero_quest_id_required',

--- a/worker/src/hero/launch.js
+++ b/worker/src/hero/launch.js
@@ -1,0 +1,148 @@
+import { BadRequestError, NotFoundError, ConflictError } from '../errors.js';
+import { buildHeroShadowReadModel } from './read-model.js';
+import { mapHeroEnvelopeToSubjectPayload } from './launch-adapters/index.js';
+import { buildHeroContext, sanitiseHeroContext } from '../../../shared/hero/launch-context.js';
+import {
+  HERO_P1_SCHEDULER_VERSION,
+  HERO_DEFAULT_TIMEZONE,
+  HERO_LAUNCH_CONTRACT_VERSION,
+} from '../../../shared/hero/constants.js';
+
+export async function resolveHeroStartTaskCommand({ body, repository, env, now }) {
+  const command = body?.command;
+  if (!command) {
+    throw new BadRequestError('Hero command is required.', {
+      code: 'hero_command_required',
+    });
+  }
+  if (command !== 'start-task') {
+    throw new BadRequestError(`Unsupported Hero command: ${command}`, {
+      code: 'hero_command_unsupported',
+      command,
+    });
+  }
+
+  if (body.subjectId !== undefined) {
+    throw new BadRequestError('Client must not supply subjectId on Hero commands.', {
+      code: 'hero_client_field_rejected',
+      field: 'subjectId',
+    });
+  }
+  if (body.payload !== undefined) {
+    throw new BadRequestError('Client must not supply payload on Hero commands.', {
+      code: 'hero_client_field_rejected',
+      field: 'payload',
+    });
+  }
+
+  const learnerId = typeof body.learnerId === 'string' ? body.learnerId.trim() : '';
+  const questId = typeof body.questId === 'string' ? body.questId.trim() : '';
+  const taskId = typeof body.taskId === 'string' ? body.taskId.trim() : '';
+  const requestId = typeof body.requestId === 'string' ? body.requestId.trim() : '';
+  const correlationId = typeof body.correlationId === 'string' && body.correlationId.trim()
+    ? body.correlationId.trim()
+    : requestId;
+  const expectedLearnerRevision = Number(body.expectedLearnerRevision);
+
+  if (!questId) {
+    throw new BadRequestError('questId is required for Hero start-task.', {
+      code: 'hero_quest_id_required',
+    });
+  }
+  if (!taskId) {
+    throw new BadRequestError('taskId is required for Hero start-task.', {
+      code: 'hero_task_id_required',
+    });
+  }
+  if (!requestId) {
+    throw new BadRequestError('requestId is required for Hero start-task.', {
+      code: 'command_request_id_required',
+    });
+  }
+  if (!Number.isFinite(expectedLearnerRevision)) {
+    throw new BadRequestError('expectedLearnerRevision is required for Hero start-task.', {
+      code: 'command_revision_required',
+    });
+  }
+
+  const subjectReadModels = await repository.readHeroSubjectReadModels(learnerId);
+  const heroReadModel = buildHeroShadowReadModel({
+    learnerId,
+    subjectReadModels,
+    now,
+    env,
+  });
+
+  const quest = heroReadModel.dailyQuest;
+  if (!quest || quest.questId !== questId) {
+    throw new ConflictError('Hero quest is stale — the daily quest has changed.', {
+      code: 'hero_quest_stale',
+      clientQuestId: questId,
+      serverQuestId: quest?.questId || null,
+    });
+  }
+
+  const task = quest.tasks.find((t) => t.taskId === taskId);
+  if (!task) {
+    throw new NotFoundError('Task not found in the current Hero quest.', {
+      code: 'hero_task_not_found',
+      taskId,
+      questId,
+    });
+  }
+
+  if (task.launchStatus !== 'launchable') {
+    throw new ConflictError('Hero task is not launchable.', {
+      code: 'hero_task_not_launchable',
+      taskId,
+      launchStatus: task.launchStatus,
+      reason: task.launchStatusReason || null,
+    });
+  }
+
+  const adapterResult = mapHeroEnvelopeToSubjectPayload(task);
+  if (!adapterResult.launchable) {
+    throw new ConflictError('Subject is unavailable for Hero launch.', {
+      code: 'hero_subject_unavailable',
+      taskId,
+      reason: adapterResult.reason || null,
+    });
+  }
+
+  const heroContext = sanitiseHeroContext(buildHeroContext({
+    quest: { questId: quest.questId, dateKey: heroReadModel.dateKey, timezone: HERO_DEFAULT_TIMEZONE },
+    task,
+    taskId,
+    requestId,
+    now,
+    schedulerVersion: HERO_P1_SCHEDULER_VERSION,
+  }));
+
+  const subjectCommand = {
+    subjectId: adapterResult.subjectId,
+    command: 'start-session',
+    learnerId,
+    requestId,
+    correlationId,
+    expectedLearnerRevision,
+    payload: { ...adapterResult.payload, heroContext },
+  };
+
+  const heroLaunch = {
+    version: HERO_LAUNCH_CONTRACT_VERSION,
+    status: 'started',
+    questId,
+    taskId,
+    dateKey: heroReadModel.dateKey,
+    subjectId: adapterResult.subjectId,
+    intent: task.intent || '',
+    launcher: task.launcher || '',
+    effortTarget: task.effortTarget || 0,
+    subjectCommand: 'start-session',
+    coinsEnabled: false,
+    claimEnabled: false,
+    childVisible: false,
+  };
+
+  return { heroLaunch, subjectCommand };
+}

--- a/worker/src/hero/read-model.js
+++ b/worker/src/hero/read-model.js
@@ -1,4 +1,4 @@
-// Hero Mode P0 — Shadow read-model assembler.
+// Hero Mode — Shadow read-model assembler.
 //
 // Orchestrates providers, eligibility, and the scheduler into a complete
 // shadow response. Pure read-only path — MUST NOT mutate any state, write
@@ -7,7 +7,7 @@
 import {
   HERO_DEFAULT_EFFORT_TARGET,
   HERO_DEFAULT_TIMEZONE,
-  HERO_SCHEDULER_VERSION,
+  HERO_P1_SCHEDULER_VERSION,
   HERO_SAFETY_FLAGS,
   HERO_READY_SUBJECT_IDS,
 } from '../../../shared/hero/constants.js';
@@ -15,25 +15,48 @@ import {
 import { resolveEligibility } from '../../../shared/hero/eligibility.js';
 import { generateHeroSeed, deriveDateKey } from '../../../shared/hero/seed.js';
 import { scheduleShadowQuest } from '../../../shared/hero/scheduler.js';
+import { deriveTaskId } from '../../../shared/hero/task-envelope.js';
+import { buildHeroContext } from '../../../shared/hero/launch-context.js';
+import { determineLaunchStatus } from '../../../shared/hero/launch-status.js';
+import { mapHeroEnvelopeToSubjectPayload } from './launch-adapters/index.js';
 import { runProvider } from './providers/index.js';
+
+function envFlagEnabled(value) {
+  return ['1', 'true', 'yes', 'on'].includes(String(value || '').trim().toLowerCase());
+}
+
+function buildCapabilityRegistry(tasks) {
+  const registry = {};
+  for (const task of tasks) {
+    const subjectId = task.subjectId;
+    if (!subjectId) continue;
+    if (!registry[subjectId]) {
+      registry[subjectId] = { launchers: {} };
+    }
+    const result = mapHeroEnvelopeToSubjectPayload(task);
+    if (result.launchable) {
+      registry[subjectId].launchers[task.launcher] = true;
+    }
+  }
+  return registry;
+}
 
 /**
  * Assemble the full Hero shadow read model for a learner.
- *
- * This is the P0 shadow-only path: no writes, no coins, no child UI.
- * The response shape matches origin doc section 2.
  *
  * @param {Object} params
  * @param {string} params.learnerId
  * @param {Object} params.subjectReadModels — keyed by subjectId, each the
  *   per-subject read-model (or null when absent)
  * @param {number} params.now — epoch milliseconds
+ * @param {Object} [params.env] — Worker environment bindings (optional for P0 compat)
  * @returns {Object} shadow read model
  */
 export function buildHeroShadowReadModel({
   learnerId,
   subjectReadModels = {},
   now,
+  env,
 } = {}) {
   const dateKey = deriveDateKey(now, HERO_DEFAULT_TIMEZONE);
 
@@ -61,7 +84,7 @@ export function buildHeroShadowReadModel({
     learnerId,
     dateKey,
     timezone: HERO_DEFAULT_TIMEZONE,
-    schedulerVersion: HERO_SCHEDULER_VERSION,
+    schedulerVersion: HERO_P1_SCHEDULER_VERSION,
     contentReleaseFingerprint: null,
   });
 
@@ -70,18 +93,47 @@ export function buildHeroShadowReadModel({
     eligibleSnapshots,
     effortTarget: HERO_DEFAULT_EFFORT_TARGET,
     seed,
-    schedulerVersion: HERO_SCHEDULER_VERSION,
+    schedulerVersion: HERO_P1_SCHEDULER_VERSION,
     dateKey,
   });
 
-  // 6. Assemble the full response shape (origin doc section 2)
+  // 6. Enrich tasks with taskId, launchStatus, and heroContext
+  const capabilityRegistry = buildCapabilityRegistry(quest.tasks);
+  const enrichedTasks = quest.tasks.map((task, ordinal) => {
+    const taskId = deriveTaskId(quest.questId, ordinal, task);
+
+    const launchResult = determineLaunchStatus(
+      task.subjectId,
+      task.launcher,
+      capabilityRegistry,
+    );
+
+    const heroContext = buildHeroContext({
+      quest: { questId: quest.questId, dateKey, timezone: HERO_DEFAULT_TIMEZONE },
+      task,
+      taskId,
+      requestId: null,
+      now,
+      schedulerVersion: HERO_P1_SCHEDULER_VERSION,
+    });
+
+    return {
+      ...task,
+      taskId,
+      launchStatus: launchResult.status,
+      launchStatusReason: launchResult.reason || null,
+      heroContext,
+    };
+  });
+
+  // 7. Assemble the full response shape
   return {
-    version: 1,
+    version: 2,
     mode: 'shadow',
     ...HERO_SAFETY_FLAGS,
     dateKey,
     timezone: HERO_DEFAULT_TIMEZONE,
-    schedulerVersion: HERO_SCHEDULER_VERSION,
+    schedulerVersion: HERO_P1_SCHEDULER_VERSION,
     eligibleSubjects: eligibility.eligible,
     lockedSubjects: eligibility.locked,
     dailyQuest: {
@@ -89,7 +141,14 @@ export function buildHeroShadowReadModel({
       status: quest.status,
       effortTarget: quest.effortTarget,
       effortPlanned: quest.effortPlanned,
-      tasks: quest.tasks,
+      tasks: enrichedTasks,
+    },
+    launch: {
+      enabled: env ? envFlagEnabled(env.HERO_MODE_LAUNCH_ENABLED) : false,
+      commandRoute: '/api/hero/command',
+      command: 'start-task',
+      claimEnabled: false,
+      heroStatePersistenceEnabled: false,
     },
     debug: quest.debug,
   };

--- a/worker/src/hero/routes.js
+++ b/worker/src/hero/routes.js
@@ -7,11 +7,8 @@
 import { json } from '../http.js';
 import { NotFoundError } from '../errors.js';
 import { buildHeroShadowReadModel } from './read-model.js';
+import { resolveHeroStartTaskCommand } from './launch.js';
 
-// Local copy of envFlagEnabled, matching the pattern used by
-// worker/src/subjects/punctuation/events.js (line 90). The canonical
-// definition lives in worker/src/app.js (line 377) but is not exported
-// — each consumer keeps a local copy to avoid circular imports.
 function envFlagEnabled(value) {
   return ['1', 'true', 'yes', 'on'].includes(String(value || '').trim().toLowerCase());
 }
@@ -72,4 +69,20 @@ export async function handleHeroReadModel({
   });
 
   return json({ ok: true, hero: result });
+}
+
+/**
+ * POST /api/hero/command
+ *
+ * Validates the Hero command body and resolves start-task into a subject
+ * command shape. Returns { heroLaunch, subjectCommand } for the app
+ * route handler to dispatch through the standard subject mutation path.
+ */
+export async function handleHeroCommand({
+  body,
+  repository,
+  env,
+  now,
+}) {
+  return resolveHeroStartTaskCommand({ body, repository, env, now });
 }

--- a/worker/src/hero/routes.js
+++ b/worker/src/hero/routes.js
@@ -7,7 +7,6 @@
 import { json } from '../http.js';
 import { NotFoundError } from '../errors.js';
 import { buildHeroShadowReadModel } from './read-model.js';
-import { resolveHeroStartTaskCommand } from './launch.js';
 
 function envFlagEnabled(value) {
   return ['1', 'true', 'yes', 'on'].includes(String(value || '').trim().toLowerCase());
@@ -71,18 +70,3 @@ export async function handleHeroReadModel({
   return json({ ok: true, hero: result });
 }
 
-/**
- * POST /api/hero/command
- *
- * Validates the Hero command body and resolves start-task into a subject
- * command shape. Returns { heroLaunch, subjectCommand } for the app
- * route handler to dispatch through the standard subject mutation path.
- */
-export async function handleHeroCommand({
-  body,
-  repository,
-  env,
-  now,
-}) {
-  return resolveHeroStartTaskCommand({ body, repository, env, now });
-}

--- a/worker/src/hero/routes.js
+++ b/worker/src/hero/routes.js
@@ -68,6 +68,7 @@ export async function handleHeroReadModel({
     learnerId,
     subjectReadModels,
     now: nowTs,
+    env,
   });
 
   return json({ ok: true, hero: result });

--- a/worker/src/subjects/grammar/engine.js
+++ b/worker/src/subjects/grammar/engine.js
@@ -1024,6 +1024,7 @@ function startSession(state, payload, nowTs, learnerId) {
         questions,
         finished: false,
       },
+      heroContext: payload.heroContext || null,
       serverAuthority: SERVER_AUTHORITY,
     };
     return [];
@@ -1071,6 +1072,7 @@ function startSession(state, payload, nowTs, learnerId) {
       retryingCurrent: false,
       similarProblems: 0,
     },
+    heroContext: payload.heroContext || null,
     serverAuthority: SERVER_AUTHORITY,
   };
   return [];

--- a/worker/src/subjects/punctuation/engine.js
+++ b/worker/src/subjects/punctuation/engine.js
@@ -148,6 +148,9 @@ export function createServerPunctuationEngine({ now = Date.now, random = Math.ra
       try {
         if (command === 'start-session') {
           transition = service.startSession(learnerId, payload);
+          if (transition.state?.session && payload.heroContext) {
+            transition.state.session.heroContext = payload.heroContext;
+          }
         } else if (command === 'submit-answer') {
           transition = service.submitAnswer(
             learnerId,

--- a/worker/src/subjects/spelling/engine.js
+++ b/worker/src/subjects/spelling/engine.js
@@ -383,6 +383,7 @@ function startOptionsFromPayload(payload = {}) {
     // boundary so the service's `startPatternQuestSession` knows which
     // 5-card quest to build.
     patternId: typeof payload.patternId === 'string' ? payload.patternId : undefined,
+    heroContext: payload.heroContext || null,
   };
 }
 
@@ -459,7 +460,11 @@ export function createServerSpellingEngine({
       let transition;
 
       if (command === 'start-session') {
-        transition = service.startSession(learnerId, startOptionsFromPayload(payload));
+        const options = startOptionsFromPayload(payload);
+        transition = service.startSession(learnerId, options);
+        if (transition.state?.session && options.heroContext) {
+          transition.state.session.heroContext = options.heroContext;
+        }
       } else if (currentState.phase === 'session' && !currentRawUiWasServerOwned) {
         persistence.abandonPracticeSession(learnerId, currentState);
         staleSessionError(command);

--- a/worker/wrangler.example.jsonc
+++ b/worker/wrangler.example.jsonc
@@ -27,7 +27,8 @@
     "ENVIRONMENT": "production",
     "PUNCTUATION_SUBJECT_ENABLED": "false",
     "PUNCTUATION_EVENTS_ENABLED": "false",
-    "HERO_MODE_SHADOW_ENABLED": "false"
+    "HERO_MODE_SHADOW_ENABLED": "false",
+    "HERO_MODE_LAUNCH_ENABLED": "false"
   },
   "d1_databases": [
     {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -42,7 +42,8 @@
     "ENVIRONMENT": "production",
     "PUNCTUATION_SUBJECT_ENABLED": "true",
     "SOCIAL_LOGIN_WIRE_ENABLED": "true",
-    "HERO_MODE_SHADOW_ENABLED": "false"
+    "HERO_MODE_SHADOW_ENABLED": "false",
+    "HERO_MODE_LAUNCH_ENABLED": "false"
   },
   "d1_databases": [
     {


### PR DESCRIPTION
## Summary

- Hero Mode P1 turns P0's read-only shadow quest into a safe launch bridge: a selected Hero task can start the correct subject session through the existing Worker subject command boundary
- `POST /api/hero/command` (start-task only) routes through the identical security chain as `POST /api/subjects/:subjectId/command`: same-origin, mutation capability, demo protection, subject gate, CAS idempotency
- `heroContext` is built server-side, attached to active sessions, opaque to subject engines — no mastery/reward contamination
- All three subjects (Spelling, Grammar, Punctuation) have verified launch adapters mapping Hero envelopes to start-session payloads
- Zero Hero-owned persistent state: no Coins, no ledger, no monster state, no quest progress, no child-facing UI

## Architecture

**Structure A (app owns dispatch)**: `worker/src/hero/launch.js` resolves the Hero command into a subject command shape; `worker/src/app.js` calls `repository.runSubjectCommand(subjectRuntime.dispatch)` directly. `worker/src/hero/` never imports `subjects/runtime.js`.

```
POST /api/hero/command
  → flag interaction guard (LAUNCH + SHADOW required)
  → requireSameOrigin → requireMutationCapability
  → resolveHeroStartTaskCommand (recomputes quest server-side)
  → requireSubjectCommandAvailable → protectDemoSubjectCommand
  → repository.runSubjectCommand → subjectRuntime.dispatch
  → return { heroLaunch, subjectReadModel }
```

## Key changes

| Area | Files | Change |
|------|-------|--------|
| Shared pure layer | `shared/hero/{constants,task-envelope,launch-context,launch-status}.js` | Task ID derivation, heroContext builder/validator/sanitiser, launch status classifier |
| Launch adapters | `worker/src/hero/launch-adapters/{index,spelling,grammar,punctuation}.js` | Envelope → start-session payload mapping |
| Read model | `worker/src/hero/read-model.js` | v2: taskId, launchStatus, heroContext per task, launch capability block |
| Command route | `worker/src/app.js`, `worker/src/hero/{launch,routes}.js` | POST /api/hero/command with full security chain |
| Session passthrough | `worker/src/subjects/{spelling,grammar,punctuation}/engine.js` | heroContext injection on active session state |
| Config | `wrangler.jsonc` | `HERO_MODE_LAUNCH_ENABLED: "false"` (independent of shadow flag) |

## Test plan

- [x] 228 hero tests pass (35 contract + 12 adapter + 13 task-id + 15 command + 9 passthrough + 7 launch-boundary + 8 P0-boundary + 5 E2E flow + 2 review-fix additions + misc)
- [x] 58 subject engine tests pass (spelling/grammar/punctuation) — zero regressions
- [x] 644/645 worker tests pass (1 timing-flaky capacity benchmark, passes in isolation)
- [x] Structural boundary: no `subjects/runtime` imports in hero/, no economy tokens, no client dashboard imports
- [x] Behavioural boundary: GET read-model writes zero rows; POST writes only via subject command path
- [x] Security: requireLearnerReadAccess before quest recomputation, sanitised error messages, flag interaction guard

## Review findings addressed

- SEC-HERO-01: Added `requireLearnerReadAccess` before quest recomputation (pre-auth data read)
- CORR-01: Added learnerId validation with `hero_learner_id_required`
- CORR-03: Removed dead `handleHeroCommand` import/export
- SEC-HERO-02: Sanitised reflected command value in error messages
- Testing: Fixed `validatedRequestId` scope, silent-pass guards, added missing test branches