### PR TITLE
feat(admin): U4 request denial logging with ctx.waitUntil + sampling

### DIFF
--- a/tests/worker-admin-denial-capture.test.js
+++ b/tests/worker-admin-denial-capture.test.js
@@ -1,0 +1,270 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createWorkerRepositoryServer } from './helpers/worker-server.js';
+
+function seedAdultAccount(server, {
+  id,
+  email = null,
+  displayName = null,
+  platformRole = 'parent',
+  now = 1,
+  accountType = 'real',
+  demoExpiresAt = null,
+} = {}) {
+  server.DB.db.prepare(`
+    INSERT INTO adult_accounts (
+      id, email, display_name, platform_role, selected_learner_id,
+      created_at, updated_at, repo_revision, account_type, demo_expires_at
+    )
+    VALUES (?, ?, ?, ?, NULL, ?, ?, 0, ?, ?)
+  `).run(id, email, displayName, platformRole, now, now, accountType, demoExpiresAt);
+}
+
+function seedOpsMetadata(server, {
+  accountId,
+  opsStatus = 'active',
+  statusRevision = 0,
+  now = 1,
+} = {}) {
+  server.DB.db.prepare(`
+    INSERT INTO account_ops_metadata (
+      account_id, ops_status, status_revision, plan_label, tags_json,
+      internal_notes, updated_at, updated_by_account_id, row_version
+    )
+    VALUES (?, ?, ?, NULL, '[]', NULL, ?, ?, 0)
+  `).run(accountId, opsStatus, statusRevision, now, accountId);
+}
+
+function readDenials(server) {
+  return server.DB.db.prepare(
+    'SELECT * FROM admin_request_denials ORDER BY denied_at DESC',
+  ).all();
+}
+
+test('integration: account_suspended denial appears after auth rejection', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    seedAdultAccount(server, {
+      id: 'adult-suspended',
+      email: 'suspended@example.com',
+      platformRole: 'parent',
+      now: 1000,
+    });
+    seedOpsMetadata(server, {
+      accountId: 'adult-suspended',
+      opsStatus: 'suspended',
+      statusRevision: 1,
+      now: 1000,
+    });
+
+    const response = await server.fetchAs(
+      'adult-suspended',
+      'http://localhost/api/bootstrap',
+      { method: 'GET' },
+    );
+    assert.equal(response.status, 403);
+    const body = await response.json();
+    assert.equal(body.code, 'account_suspended');
+
+    // Wait for the fire-and-forget denial insert to settle.
+    await new Promise((resolve) => { setTimeout(resolve, 100); });
+
+    const denials = readDenials(server);
+    assert.ok(denials.length >= 1, 'at least one denial row inserted');
+    const denial = denials.find((d) => d.denial_reason === 'account_suspended');
+    assert.ok(denial, 'account_suspended denial found');
+    assert.equal(denial.route_name, '/api/bootstrap');
+    assert.equal(denial.account_id, 'adult-suspended');
+    assert.equal(denial.is_demo, 0);
+    // session_id_last8 should be the last 8 chars of the dev-stub session ID.
+    // dev-stub generates `dev:<accountId>` = `dev:adult-suspended`
+    assert.equal(denial.session_id_last8, 'uspended');
+  } finally {
+    server.close();
+  }
+});
+
+test('integration: payment_hold denial appears after mutation rejection', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    seedAdultAccount(server, {
+      id: 'adult-held',
+      email: 'held@example.com',
+      platformRole: 'parent',
+      now: 1000,
+    });
+    seedOpsMetadata(server, {
+      accountId: 'adult-held',
+      opsStatus: 'payment_hold',
+      statusRevision: 0,
+      now: 1000,
+    });
+
+    // A mutation route that triggers requireMutationCapability.
+    const response = await server.fetchAs(
+      'adult-held',
+      'http://localhost/api/learners',
+      {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ learners: [] }),
+      },
+    );
+    assert.equal(response.status, 403);
+    const body = await response.json();
+    assert.equal(body.code, 'account_payment_hold');
+
+    await new Promise((resolve) => { setTimeout(resolve, 100); });
+
+    const denials = readDenials(server);
+    const denial = denials.find((d) => d.denial_reason === 'payment_hold');
+    assert.ok(denial, 'payment_hold denial found');
+    assert.equal(denial.route_name, '/api/learners');
+    assert.equal(denial.account_id, 'adult-held');
+  } finally {
+    server.close();
+  }
+});
+
+test('integration: denial logging failure does not affect the 403 response', async () => {
+  // Use a server with the normal DB — the denial insert may fail due to
+  // any number of reasons, but the 403 response must still be returned.
+  const server = createWorkerRepositoryServer();
+  try {
+    seedAdultAccount(server, {
+      id: 'adult-suspended-2',
+      email: 'susp2@example.com',
+      platformRole: 'parent',
+      now: 1000,
+    });
+    seedOpsMetadata(server, {
+      accountId: 'adult-suspended-2',
+      opsStatus: 'suspended',
+      statusRevision: 1,
+      now: 1000,
+    });
+
+    // Drop the table to force a denial-insert failure.
+    server.DB.db.prepare('DROP TABLE IF EXISTS admin_request_denials').run();
+
+    const response = await server.fetchAs(
+      'adult-suspended-2',
+      'http://localhost/api/session',
+      { method: 'GET' },
+    );
+    // The auth rejection must still succeed — denial logging failure is fire-and-forget.
+    assert.equal(response.status, 403);
+    const body = await response.json();
+    assert.equal(body.code, 'account_suspended');
+  } finally {
+    server.close();
+  }
+});
+
+test('integration: csrf_rejection denial captured from requireSameOrigin', async () => {
+  const server = createWorkerRepositoryServer({
+    env: { AUTH_MODE: 'development-stub', ENVIRONMENT: 'test' },
+  });
+  try {
+    seedAdultAccount(server, {
+      id: 'adult-csrf',
+      email: 'csrf@example.com',
+      platformRole: 'parent',
+      now: 1000,
+    });
+
+    // Send a cross-site request to a route that calls requireSameOrigin in strict mode.
+    // The /api/auth/register route calls requireSameOrigin(request, env) explicitly.
+    const response = await server.fetchAs(
+      'adult-csrf',
+      'http://localhost/api/auth/register',
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'sec-fetch-site': 'cross-site',
+        },
+        body: JSON.stringify({ email: 'test@test.com', password: 'password123' }),
+      },
+    );
+    assert.equal(response.status, 403);
+    const body = await response.json();
+    assert.equal(body.code, 'same_origin_required');
+
+    await new Promise((resolve) => { setTimeout(resolve, 100); });
+
+    const denials = readDenials(server);
+    const denial = denials.find((d) => d.denial_reason === 'csrf_rejection');
+    assert.ok(denial, 'csrf_rejection denial found');
+    assert.equal(denial.route_name, '/api/auth/register');
+  } finally {
+    server.close();
+  }
+});
+
+test('integration: retention sweep removes old denials', async () => {
+  const { sweepRequestDenials, REQUEST_DENIALS_RETENTION_MS } = await import(
+    '../worker/src/cron/retention-sweep.js'
+  );
+  const server = createWorkerRepositoryServer();
+  try {
+    const now = Date.now();
+    const old = now - REQUEST_DENIALS_RETENTION_MS - 1000;
+    // Insert an old denial row directly.
+    server.DB.db.prepare(`
+      INSERT INTO admin_request_denials (
+        id, denied_at, denial_reason, route_name, account_id,
+        learner_id, session_id_last8, is_demo, release, detail_json
+      )
+      VALUES (?, ?, ?, ?, ?, NULL, NULL, 0, NULL, NULL)
+    `).run('denial-old-1', old, 'account_suspended', '/api/bootstrap', 'adult-x');
+
+    // Insert a recent denial row.
+    server.DB.db.prepare(`
+      INSERT INTO admin_request_denials (
+        id, denied_at, denial_reason, route_name, account_id,
+        learner_id, session_id_last8, is_demo, release, detail_json
+      )
+      VALUES (?, ?, ?, ?, ?, NULL, NULL, 0, NULL, NULL)
+    `).run('denial-new-1', now, 'payment_hold', '/api/learners', 'adult-y');
+
+    const result = await sweepRequestDenials(server.DB, now);
+    assert.equal(result.deleted, 1, 'one old denial deleted');
+
+    const remaining = readDenials(server);
+    assert.equal(remaining.length, 1);
+    assert.equal(remaining[0].id, 'denial-new-1');
+  } finally {
+    server.close();
+  }
+});
+
+test('integration: retention sweep tolerates missing table', async () => {
+  const { sweepRequestDenials } = await import(
+    '../worker/src/cron/retention-sweep.js'
+  );
+  const server = createWorkerRepositoryServer();
+  try {
+    server.DB.db.prepare('DROP TABLE IF EXISTS admin_request_denials').run();
+    const result = await sweepRequestDenials(server.DB, Date.now());
+    assert.equal(result.deleted, 0, 'missing table returns 0 deleted');
+  } finally {
+    server.close();
+  }
+});
+
+test('integration: runRetentionSweeps includes request denials sweep', async () => {
+  const { runRetentionSweeps } = await import(
+    '../worker/src/cron/retention-sweep.js'
+  );
+  const server = createWorkerRepositoryServer();
+  try {
+    const result = await runRetentionSweeps(server.DB, Date.now());
+    const denialSweep = result.completed.find((s) => s.sweep === 'admin_request_denials');
+    assert.ok(denialSweep, 'admin_request_denials sweep is in the completed list');
+    assert.equal(typeof denialSweep.deleted, 'number');
+  } finally {
+    server.close();
+  }
+});

--- a/tests/worker-admin-denial-logger.test.js
+++ b/tests/worker-admin-denial-logger.test.js
@@ -1,0 +1,287 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  logRequestDenial,
+  maskSessionId,
+  shouldCaptureDenial,
+  __resetSamplingCountersForTests,
+  __setSamplingRngForTests,
+} from '../worker/src/admin-denial-logger.js';
+import { createMigratedSqliteD1Database } from './helpers/sqlite-d1.js';
+
+function createDb() {
+  return createMigratedSqliteD1Database();
+}
+
+function readDenials(db) {
+  return db.db.prepare('SELECT * FROM admin_request_denials ORDER BY denied_at DESC').all();
+}
+
+test('maskSessionId: returns last 8 chars of a long session ID', () => {
+  assert.equal(maskSessionId('session-abcdefghijklmnop'), 'ijklmnop');
+});
+
+test('maskSessionId: returns short session ID unchanged', () => {
+  assert.equal(maskSessionId('abc'), 'abc');
+});
+
+test('maskSessionId: returns exactly 8 chars unchanged', () => {
+  assert.equal(maskSessionId('12345678'), '12345678');
+});
+
+test('maskSessionId: returns null for null/undefined/empty', () => {
+  assert.equal(maskSessionId(null), null);
+  assert.equal(maskSessionId(undefined), null);
+  assert.equal(maskSessionId(''), null);
+  assert.equal(maskSessionId('  '), null);
+});
+
+test('shouldCaptureDenial: low-volume reasons always captured', () => {
+  __resetSamplingCountersForTests();
+  for (let i = 0; i < 50; i += 1) {
+    assert.equal(shouldCaptureDenial('account_suspended', '/api/bootstrap', Date.now()), true);
+  }
+});
+
+test('shouldCaptureDenial: high-volume rate_limit_exceeded captured at 100% for first 10', () => {
+  __resetSamplingCountersForTests();
+  const now = Date.now();
+  for (let i = 0; i < 10; i += 1) {
+    assert.equal(shouldCaptureDenial('rate_limit_exceeded', '/api/ops/error-event', now), true);
+  }
+});
+
+test('shouldCaptureDenial: high-volume rate_limit_exceeded sampled after threshold', () => {
+  __resetSamplingCountersForTests();
+  const now = Date.now();
+  // Exhaust the first 10.
+  for (let i = 0; i < 10; i += 1) {
+    shouldCaptureDenial('rate_limit_exceeded', '/api/test', now);
+  }
+  // With RNG returning 0.5 (> 0.1 sample rate), the 11th should be rejected.
+  __setSamplingRngForTests(() => 0.5);
+  assert.equal(shouldCaptureDenial('rate_limit_exceeded', '/api/test', now), false);
+  // With RNG returning 0.05 (< 0.1 sample rate), the 12th should be accepted.
+  __setSamplingRngForTests(() => 0.05);
+  assert.equal(shouldCaptureDenial('rate_limit_exceeded', '/api/test', now), true);
+  __setSamplingRngForTests(null);
+});
+
+test('shouldCaptureDenial: new window resets sampling', () => {
+  __resetSamplingCountersForTests();
+  const windowMs = 10 * 60 * 1000;
+  const now = Date.now();
+  // Exhaust threshold in current window.
+  for (let i = 0; i < 10; i += 1) {
+    shouldCaptureDenial('rate_limit_exceeded', '/api/x', now);
+  }
+  // Next window — counter resets, so the 11th overall (1st in new window) passes.
+  const nextWindow = now + windowMs;
+  assert.equal(shouldCaptureDenial('rate_limit_exceeded', '/api/x', nextWindow), true);
+});
+
+test('logRequestDenial: account_suspended creates a row', async () => {
+  const db = createDb();
+  try {
+    logRequestDenial(db, null, {
+      denialReason: 'account_suspended',
+      routeName: '/api/bootstrap',
+      accountId: 'adult-123',
+      sessionId: 'session-abcdefghijklmnop',
+      isDemo: false,
+      release: 'v1.0.0',
+      detail: { code: 'account_suspended', opsStatus: 'suspended' },
+      now: 1000,
+    });
+    // Wait for the fire-and-forget promise to settle.
+    await new Promise((resolve) => { setTimeout(resolve, 50); });
+    const rows = readDenials(db);
+    assert.equal(rows.length, 1);
+    const row = rows[0];
+    assert.equal(row.denial_reason, 'account_suspended');
+    assert.equal(row.route_name, '/api/bootstrap');
+    assert.equal(row.account_id, 'adult-123');
+    assert.equal(row.session_id_last8, 'ijklmnop');
+    assert.equal(row.is_demo, 0);
+    assert.equal(row.release, 'v1.0.0');
+    assert.equal(row.denied_at, 1000);
+    const detail = JSON.parse(row.detail_json);
+    assert.equal(detail.code, 'account_suspended');
+    assert.equal(detail.opsStatus, 'suspended');
+  } finally {
+    db.close();
+  }
+});
+
+test('logRequestDenial: payment_hold creates a row with correct fields', async () => {
+  const db = createDb();
+  try {
+    logRequestDenial(db, null, {
+      denialReason: 'payment_hold',
+      routeName: '/api/subjects/spelling/command',
+      accountId: 'adult-456',
+      sessionId: 'sess-short',
+      isDemo: false,
+      detail: { code: 'account_payment_hold', opsStatus: 'payment_hold' },
+      now: 2000,
+    });
+    await new Promise((resolve) => { setTimeout(resolve, 50); });
+    const rows = readDenials(db);
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].denial_reason, 'payment_hold');
+    assert.equal(rows[0].session_id_last8, 'ss-short');
+  } finally {
+    db.close();
+  }
+});
+
+test('logRequestDenial: session_invalidated captured with no account context', async () => {
+  const db = createDb();
+  try {
+    logRequestDenial(db, null, {
+      denialReason: 'session_invalidated',
+      routeName: '/api/session',
+      detail: { code: 'session_invalidated' },
+      now: 3000,
+    });
+    await new Promise((resolve) => { setTimeout(resolve, 50); });
+    const rows = readDenials(db);
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].denial_reason, 'session_invalidated');
+    assert.equal(rows[0].account_id, null);
+    assert.equal(rows[0].session_id_last8, null);
+  } finally {
+    db.close();
+  }
+});
+
+test('logRequestDenial: rate-limit denial captured with route context', async () => {
+  __resetSamplingCountersForTests();
+  const db = createDb();
+  try {
+    logRequestDenial(db, null, {
+      denialReason: 'rate_limit_exceeded',
+      routeName: '/api/ops/error-event',
+      release: 'v2.0.0',
+      detail: { code: 'ops_error_rate_limited', bucket: 'ops-error-capture-ip', retryAfterSeconds: 30 },
+      now: 4000,
+    });
+    await new Promise((resolve) => { setTimeout(resolve, 50); });
+    const rows = readDenials(db);
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].denial_reason, 'rate_limit_exceeded');
+    assert.equal(rows[0].route_name, '/api/ops/error-event');
+    const detail = JSON.parse(rows[0].detail_json);
+    assert.equal(detail.retryAfterSeconds, 30);
+    assert.equal(detail.bucket, 'ops-error-capture-ip');
+  } finally {
+    db.close();
+  }
+});
+
+test('logRequestDenial: demo session marked is_demo = 1', async () => {
+  const db = createDb();
+  try {
+    logRequestDenial(db, null, {
+      denialReason: 'csrf_rejection',
+      routeName: '/api/demo/session',
+      isDemo: true,
+      detail: { code: 'same_origin_required' },
+      now: 5000,
+    });
+    await new Promise((resolve) => { setTimeout(resolve, 50); });
+    const rows = readDenials(db);
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].is_demo, 1);
+  } finally {
+    db.close();
+  }
+});
+
+test('logRequestDenial: unknown denial reason silently skipped', async () => {
+  const db = createDb();
+  try {
+    logRequestDenial(db, null, {
+      denialReason: 'unknown_bad_reason',
+      routeName: '/api/bootstrap',
+      now: 6000,
+    });
+    await new Promise((resolve) => { setTimeout(resolve, 50); });
+    const rows = readDenials(db);
+    assert.equal(rows.length, 0);
+  } finally {
+    db.close();
+  }
+});
+
+test('logRequestDenial: DB failure does not throw', async () => {
+  // Use a mock DB that always throws on prepare().
+  const brokenDb = {
+    prepare() {
+      throw new Error('DB is down');
+    },
+  };
+  // This must not throw.
+  logRequestDenial(brokenDb, null, {
+    denialReason: 'account_suspended',
+    routeName: '/api/bootstrap',
+    now: 7000,
+  });
+  // Wait for the fire-and-forget promise.
+  await new Promise((resolve) => { setTimeout(resolve, 50); });
+  // If we reached here, the test passes — the error was swallowed.
+  assert.ok(true, 'DB failure did not propagate');
+});
+
+test('logRequestDenial: ctx.waitUntil is called when present', async () => {
+  const db = createDb();
+  try {
+    let waitUntilCalled = false;
+    const ctx = {
+      waitUntil(promise) {
+        waitUntilCalled = true;
+        // Still await to let the insert complete.
+        promise.catch(() => {});
+      },
+    };
+    logRequestDenial(db, ctx, {
+      denialReason: 'account_suspended',
+      routeName: '/api/bootstrap',
+      now: 8000,
+    });
+    assert.equal(waitUntilCalled, true, 'ctx.waitUntil was called');
+    await new Promise((resolve) => { setTimeout(resolve, 50); });
+    const rows = readDenials(db);
+    assert.equal(rows.length, 1);
+  } finally {
+    db.close();
+  }
+});
+
+test('logRequestDenial: detail_json only includes allowed keys', async () => {
+  const db = createDb();
+  try {
+    logRequestDenial(db, null, {
+      denialReason: 'account_suspended',
+      routeName: '/api/bootstrap',
+      detail: {
+        code: 'account_suspended',
+        opsStatus: 'suspended',
+        secretToken: 'should-not-appear',
+        rawHeaders: { cookie: 'leaked' },
+      },
+      now: 9000,
+    });
+    await new Promise((resolve) => { setTimeout(resolve, 50); });
+    const rows = readDenials(db);
+    assert.equal(rows.length, 1);
+    const detail = JSON.parse(rows[0].detail_json);
+    assert.equal(detail.code, 'account_suspended');
+    assert.equal(detail.opsStatus, 'suspended');
+    assert.equal(detail.secretToken, undefined, 'unknown key excluded');
+    assert.equal(detail.rawHeaders, undefined, 'object value excluded');
+  } finally {
+    db.close();
+  }
+});

--- a/worker/src/admin-denial-logger.js
+++ b/worker/src/admin-denial-logger.js
@@ -1,0 +1,238 @@
+// P3 U4: shared denial capture helper. Logs auth/role/rate-limit denials
+// as structured events in `admin_request_denials` for operator visibility
+// (R8) and debug-bundle evidence (R9).
+//
+// Security constraints enforced at this layer:
+//   - `session_id_last8`: only the last 8 chars of the session ID are
+//     stored. The migration CHECK enforces `length <= 8`; this module
+//     truncates before the INSERT so a bug higher up cannot leak the
+//     full token.
+//   - `detail_json`: closed schema — only structured fields from
+//     `error-codes.js` constants. Never raw headers/cookies/body.
+//   - Fire-and-forget: all writes are dispatched via `ctx.waitUntil`
+//     wrapped in try/catch so a DB outage never blocks the 403/429
+//     response.
+
+import { bindStatement } from './d1.js';
+import {
+  DENIAL_ACCOUNT_SUSPENDED,
+  DENIAL_PAYMENT_HOLD,
+  DENIAL_SESSION_INVALIDATED,
+  DENIAL_CSRF_REJECTION,
+  DENIAL_RATE_LIMIT_EXCEEDED,
+} from './error-codes.js';
+
+// Canonical closed set of denial reasons. Any value not in this set is
+// rejected at the `logRequestDenial` boundary so the `detail_json`
+// column stays machine-parseable and the table remains queryable by a
+// known set of enum values.
+const ALLOWED_DENIAL_REASONS = new Set([
+  DENIAL_ACCOUNT_SUSPENDED,
+  DENIAL_PAYMENT_HOLD,
+  DENIAL_SESSION_INVALIDATED,
+  DENIAL_CSRF_REJECTION,
+  DENIAL_RATE_LIMIT_EXCEEDED,
+]);
+
+// High-volume categories are sampled at 10% after the first 10 per
+// route per 10-minute window. This prevents rate-limit storms from
+// filling the denials table while keeping the first few events for
+// diagnostics. The sampling state is in-memory per isolate — this is
+// intentionally imprecise (Workers are multi-tenant) but sufficient
+// for volume control.
+const HIGH_VOLUME_REASONS = new Set([
+  DENIAL_RATE_LIMIT_EXCEEDED,
+]);
+
+const SAMPLE_WINDOW_MS = 10 * 60 * 1000;
+const SAMPLE_THRESHOLD = 10;
+const SAMPLE_RATE = 0.1;
+
+// Per-isolate sampling counters. Shape:
+// Map<string, { windowStart: number, count: number }>
+const samplingCounters = new Map();
+
+// Expose for tests so they can reset sampling state between runs.
+export function __resetSamplingCountersForTests() {
+  samplingCounters.clear();
+}
+
+// Deterministic for tests: default to Math.random, overridable.
+let samplingRng = Math.random;
+
+export function __setSamplingRngForTests(fn) {
+  samplingRng = typeof fn === 'function' ? fn : Math.random;
+}
+
+/**
+ * Determine whether this denial should be captured based on sampling
+ * rules. Low-volume categories are always captured. High-volume
+ * categories are captured at 100% for the first `SAMPLE_THRESHOLD`
+ * events per route per window, then at `SAMPLE_RATE` thereafter.
+ *
+ * @param {string} denialReason
+ * @param {string} routeName
+ * @param {number} now
+ * @returns {boolean}
+ */
+export function shouldCaptureDenial(denialReason, routeName, now) {
+  if (!HIGH_VOLUME_REASONS.has(denialReason)) return true;
+
+  const key = `${denialReason}:${routeName || 'unknown'}`;
+  const windowStart = Math.floor(now / SAMPLE_WINDOW_MS) * SAMPLE_WINDOW_MS;
+
+  let counter = samplingCounters.get(key);
+  if (!counter || counter.windowStart !== windowStart) {
+    counter = { windowStart, count: 0 };
+    samplingCounters.set(key, counter);
+  }
+  counter.count += 1;
+
+  if (counter.count <= SAMPLE_THRESHOLD) return true;
+  return samplingRng() < SAMPLE_RATE;
+}
+
+/**
+ * Generate a unique ID for a denial row. Uses crypto.randomUUID when
+ * available (Workers runtime), falls back to a timestamp-based ID for
+ * test environments.
+ */
+function generateDenialId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `denial-${crypto.randomUUID()}`;
+  }
+  return `denial-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * Mask a session ID to its last 8 characters. Returns null when the
+ * session ID is missing or empty.
+ *
+ * @param {string|null|undefined} sessionId
+ * @returns {string|null}
+ */
+export function maskSessionId(sessionId) {
+  if (!sessionId || typeof sessionId !== 'string') return null;
+  const trimmed = sessionId.trim();
+  if (!trimmed) return null;
+  return trimmed.length <= 8 ? trimmed : trimmed.slice(-8);
+}
+
+/**
+ * Build a closed-schema detail_json value from structured fields.
+ * Only known keys are included; everything else is dropped.
+ *
+ * @param {object} fields
+ * @returns {string|null}
+ */
+function buildDetailJson(fields) {
+  if (!fields || typeof fields !== 'object') return null;
+  const allowed = {};
+  // Only include known structured keys.
+  const DETAIL_KEYS = [
+    'code', 'opsStatus', 'retryAfterSeconds', 'bucket',
+    'routeName', 'fetchSite', 'origin',
+  ];
+  for (const key of DETAIL_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(fields, key) && fields[key] != null) {
+      const value = fields[key];
+      // Ensure only primitives land in the JSON.
+      if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+        allowed[key] = value;
+      }
+    }
+  }
+  if (Object.keys(allowed).length === 0) return null;
+  return JSON.stringify(allowed);
+}
+
+/**
+ * Log a request denial to `admin_request_denials`. Fire-and-forget:
+ * the INSERT is dispatched via `ctx.waitUntil` (when `ctx` is present)
+ * and wrapped in try/catch so a DB outage never blocks the response.
+ *
+ * @param {object} db - D1 database handle.
+ * @param {object|null} ctx - Cloudflare execution context (for waitUntil).
+ * @param {object} params
+ * @param {string} params.denialReason - One of the DENIAL_* constants.
+ * @param {string} [params.routeName] - Route that was denied.
+ * @param {string} [params.accountId] - Account ID (if known).
+ * @param {string} [params.learnerId] - Learner ID (if known).
+ * @param {string} [params.sessionId] - Full session ID (will be masked).
+ * @param {boolean} [params.isDemo] - Whether this is a demo session.
+ * @param {string} [params.release] - Release tag / commit hash.
+ * @param {object} [params.detail] - Structured detail fields.
+ * @param {number} [params.now] - Current epoch ms.
+ */
+export function logRequestDenial(db, ctx, {
+  denialReason,
+  routeName = null,
+  accountId = null,
+  learnerId = null,
+  sessionId = null,
+  isDemo = false,
+  release = null,
+  detail = null,
+  now = Date.now(),
+} = {}) {
+  // Validate denial reason against closed set.
+  if (!ALLOWED_DENIAL_REASONS.has(denialReason)) {
+    // Unknown reason — silently skip. Never throw from a logging path.
+    return;
+  }
+
+  // Apply sampling.
+  if (!shouldCaptureDenial(denialReason, routeName, now)) {
+    return;
+  }
+
+  const id = generateDenialId();
+  const sessionIdLast8 = maskSessionId(sessionId);
+  const detailJson = buildDetailJson(detail);
+  const isDemoInt = isDemo ? 1 : 0;
+
+  const doInsert = async () => {
+    try {
+      const statement = bindStatement(db, `
+        INSERT INTO admin_request_denials (
+          id, denied_at, denial_reason, route_name, account_id, learner_id,
+          session_id_last8, is_demo, release, detail_json
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `, [
+        id,
+        now,
+        denialReason,
+        routeName,
+        accountId,
+        learnerId,
+        sessionIdLast8,
+        isDemoInt,
+        release,
+        detailJson,
+      ]);
+      await statement.run();
+    } catch (error) {
+      // Fire-and-forget: log the failure but never re-throw.
+      try {
+        // eslint-disable-next-line no-console
+        console.error('[ks2-denial-logger]', JSON.stringify({
+          event: 'denial_logger.insert_failed',
+          denialReason,
+          routeName,
+          reason: error?.message || String(error),
+        }));
+      } catch {
+        // Swallow — even the error log is best-effort.
+      }
+    }
+  };
+
+  // Dispatch via ctx.waitUntil when available (production Workers),
+  // otherwise fire and forget (test environments).
+  if (ctx && typeof ctx.waitUntil === 'function') {
+    ctx.waitUntil(doInsert());
+  } else {
+    doInsert();
+  }
+}

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -32,11 +32,22 @@ import {
 } from './demo/sessions.js';
 import { normaliseSubjectCommandRequest } from './subjects/command-contract.js';
 import { createWorkerSubjectRuntime } from './subjects/runtime.js';
-import { ConflictError, ForbiddenError, NotFoundError } from './errors.js';
+import {
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+  AccountSuspendedError,
+  AccountPaymentHoldError,
+  SessionInvalidatedError,
+} from './errors.js';
 import { SUBJECT_EXPOSURE_GATES } from '../../src/platform/core/subject-availability.js';
 import { consumeRateLimit, rateLimitResponse, rateLimitSubject } from './rate-limit.js';
 import { handleHeroReadModel } from './hero/routes.js';
 import { resolveHeroStartTaskCommand } from './hero/launch.js';
+import { logRequestDenial } from './admin-denial-logger.js';
+import {
+  DENIAL_RATE_LIMIT_EXCEEDED,
+} from './error-codes.js';
 
 
 // U7 (sys-hardening p1): CSP report endpoint constants. The endpoint
@@ -628,7 +639,7 @@ export function createWorkerApp({
   subjectRuntime = createWorkerSubjectRuntime(),
 } = {}) {
   return {
-    async fetch(request, env) {
+    async fetch(request, env, ctx) {
       const url = new URL(request.url);
 
       // U3: validate incoming x-ks2-request-id ingress; reject non-matching
@@ -919,6 +930,14 @@ export function createWorkerApp({
               capacity,
               now,
             });
+            // P3 U4: capture rate-limit denial for operator visibility.
+            logRequestDenial(db, ctx, {
+              denialReason: DENIAL_RATE_LIMIT_EXCEEDED,
+              routeName: url.pathname,
+              release: env.RELEASE || null,
+              detail: { code: 'ops_error_global_budget_exhausted', bucket: 'ops-error-capture-global', retryAfterSeconds: globalLimit.retryAfterSeconds },
+              now: nowTs,
+            });
             return rateLimitResponse({
               code: 'ops_error_global_budget_exhausted',
               retryAfterSeconds: globalLimit.retryAfterSeconds,
@@ -942,6 +961,14 @@ export function createWorkerApp({
               retryAfterSeconds: rateLimit.retryAfterSeconds,
               capacity,
               now,
+            });
+            // P3 U4: capture per-IP rate-limit denial.
+            logRequestDenial(db, ctx, {
+              denialReason: DENIAL_RATE_LIMIT_EXCEEDED,
+              routeName: url.pathname,
+              release: env.RELEASE || null,
+              detail: { code: 'ops_error_rate_limited', bucket: 'ops-error-capture-ip', retryAfterSeconds: rateLimit.retryAfterSeconds },
+              now: nowTs,
             });
             return rateLimitResponse({
               code: 'ops_error_rate_limited',
@@ -2024,6 +2051,57 @@ export function createWorkerApp({
       } catch (error) {
         errorCaught = error;
         response = errorResponse(error);
+
+        // P3 U4: capture auth-boundary denials as structured events in
+        // `admin_request_denials`. Fire-and-forget via ctx.waitUntil —
+        // the 403/401 response is never blocked by the INSERT.
+        try {
+          const db = env?.DB && typeof env.DB.prepare === 'function' ? env.DB : null;
+          if (db) {
+            const denialSession = error?.__denialSession || null;
+            if (error instanceof AccountSuspendedError) {
+              logRequestDenial(db, ctx, {
+                denialReason: 'account_suspended',
+                routeName: url.pathname,
+                accountId: denialSession?.accountId || null,
+                sessionId: denialSession?.sessionId || null,
+                isDemo: Boolean(denialSession?.demo),
+                release: env.RELEASE || null,
+                detail: { code: 'account_suspended', opsStatus: 'suspended' },
+                now: now(),
+              });
+            } else if (error instanceof AccountPaymentHoldError) {
+              logRequestDenial(db, ctx, {
+                denialReason: 'payment_hold',
+                routeName: url.pathname,
+                accountId: denialSession?.accountId || null,
+                sessionId: denialSession?.sessionId || null,
+                isDemo: Boolean(denialSession?.demo),
+                release: env.RELEASE || null,
+                detail: { code: 'account_payment_hold', opsStatus: 'payment_hold' },
+                now: now(),
+              });
+            } else if (error instanceof SessionInvalidatedError) {
+              logRequestDenial(db, ctx, {
+                denialReason: 'session_invalidated',
+                routeName: url.pathname,
+                release: env.RELEASE || null,
+                detail: { code: 'session_invalidated' },
+                now: now(),
+              });
+            } else if (error instanceof ForbiddenError && error?.extra?.code === 'same_origin_required') {
+              logRequestDenial(db, ctx, {
+                denialReason: 'csrf_rejection',
+                routeName: url.pathname,
+                release: env.RELEASE || null,
+                detail: { code: 'same_origin_required' },
+                now: now(),
+              });
+            }
+          }
+        } catch {
+          // Denial logging is best-effort — never block the response.
+        }
       }
 
       // U3: capacity telemetry emit. All paths land here — including

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -47,6 +47,7 @@ import { resolveHeroStartTaskCommand } from './hero/launch.js';
 import { logRequestDenial } from './admin-denial-logger.js';
 import {
   DENIAL_RATE_LIMIT_EXCEEDED,
+  SAME_ORIGIN_REQUIRED,
 } from './error-codes.js';
 
 
@@ -931,7 +932,9 @@ export function createWorkerApp({
               now,
             });
             // P3 U4: capture rate-limit denial for operator visibility.
-            logRequestDenial(db, ctx, {
+            // ADV-U4-007: use raw env.DB — fire-and-forget INSERT must not
+            // inflate capacity telemetry via the wrapped `db`.
+            logRequestDenial(env.DB, ctx, {
               denialReason: DENIAL_RATE_LIMIT_EXCEEDED,
               routeName: url.pathname,
               release: env.RELEASE || null,
@@ -963,7 +966,9 @@ export function createWorkerApp({
               now,
             });
             // P3 U4: capture per-IP rate-limit denial.
-            logRequestDenial(db, ctx, {
+            // ADV-U4-007: use raw env.DB — fire-and-forget INSERT must not
+            // inflate capacity telemetry via the wrapped `db`.
+            logRequestDenial(env.DB, ctx, {
               denialReason: DENIAL_RATE_LIMIT_EXCEEDED,
               routeName: url.pathname,
               release: env.RELEASE || null,
@@ -2085,16 +2090,18 @@ export function createWorkerApp({
               logRequestDenial(db, ctx, {
                 denialReason: 'session_invalidated',
                 routeName: url.pathname,
+                accountId: denialSession?.accountId || null,
+                sessionId: denialSession?.sessionId || null,
                 release: env.RELEASE || null,
                 detail: { code: 'session_invalidated' },
                 now: now(),
               });
-            } else if (error instanceof ForbiddenError && error?.extra?.code === 'same_origin_required') {
+            } else if (error instanceof ForbiddenError && error?.extra?.code === SAME_ORIGIN_REQUIRED) {
               logRequestDenial(db, ctx, {
                 denialReason: 'csrf_rejection',
                 routeName: url.pathname,
                 release: env.RELEASE || null,
-                detail: { code: 'same_origin_required' },
+                detail: { code: SAME_ORIGIN_REQUIRED },
                 now: now(),
               });
             }

--- a/worker/src/auth.js
+++ b/worker/src/auth.js
@@ -1471,7 +1471,11 @@ export function requireActiveAccount(session) {
     } catch {
       // Swallow - telemetry is best-effort.
     }
-    throw new AccountSuspendedError();
+    const error = new AccountSuspendedError();
+    // P3 U4: attach the session so app.js denial capture can extract
+    // accountId / sessionId without re-reading from DB.
+    error.__denialSession = session;
+    throw error;
   }
 }
 
@@ -1507,7 +1511,10 @@ export function requireMutationCapability(session) {
     } catch {
       // Swallow - telemetry is best-effort.
     }
-    throw new AccountSuspendedError();
+    const error = new AccountSuspendedError();
+    // P3 U4: attach the session so app.js denial capture can extract context.
+    error.__denialSession = session;
+    throw error;
   }
   if (session.opsStatus === 'payment_hold') {
     try {
@@ -1520,7 +1527,10 @@ export function requireMutationCapability(session) {
     } catch {
       // Swallow - telemetry is best-effort.
     }
-    throw new AccountPaymentHoldError();
+    const error = new AccountPaymentHoldError();
+    // P3 U4: attach the session so app.js denial capture can extract context.
+    error.__denialSession = session;
+    throw error;
   }
 }
 

--- a/worker/src/auth.js
+++ b/worker/src/auth.js
@@ -709,7 +709,12 @@ async function accountSessionFromToken(env, token, now = Date.now(), capacity = 
   const enforcementAvailable = Number.isFinite(currentStatusRevision)
     && Number.isFinite(statusRevisionAtIssue);
   if (enforcementAvailable && statusRevisionAtIssue < currentStatusRevision) {
-    throw new SessionInvalidatedError();
+    const err = new SessionInvalidatedError();
+    Object.defineProperty(err, '__denialSession', {
+      value: { accountId: row.account_id, sessionId: row.session_id },
+      enumerable: false,
+    });
+    throw err;
   }
   return {
     accountId: row.account_id,
@@ -1474,7 +1479,7 @@ export function requireActiveAccount(session) {
     const error = new AccountSuspendedError();
     // P3 U4: attach the session so app.js denial capture can extract
     // accountId / sessionId without re-reading from DB.
-    error.__denialSession = session;
+    Object.defineProperty(error, '__denialSession', { value: session, enumerable: false });
     throw error;
   }
 }
@@ -1513,7 +1518,7 @@ export function requireMutationCapability(session) {
     }
     const error = new AccountSuspendedError();
     // P3 U4: attach the session so app.js denial capture can extract context.
-    error.__denialSession = session;
+    Object.defineProperty(error, '__denialSession', { value: session, enumerable: false });
     throw error;
   }
   if (session.opsStatus === 'payment_hold') {
@@ -1529,7 +1534,7 @@ export function requireMutationCapability(session) {
     }
     const error = new AccountPaymentHoldError();
     // P3 U4: attach the session so app.js denial capture can extract context.
-    error.__denialSession = session;
+    Object.defineProperty(error, '__denialSession', { value: session, enumerable: false });
     throw error;
   }
 }

--- a/worker/src/cron/retention-sweep.js
+++ b/worker/src/cron/retention-sweep.js
@@ -24,6 +24,9 @@ export const MUTATION_RECEIPT_MAX_DELETE_BATCH = 5000;
 export const REQUEST_LIMITS_RETENTION_MS = 24 * 60 * 60 * 1000; // 24 hours
 export const REQUEST_LIMITS_MAX_DELETE_BATCH = 5000;
 export const ACCOUNT_SESSIONS_MAX_DELETE_BATCH = 5000;
+// P3 U4: request denials retention — 14-day rolling window.
+export const REQUEST_DENIALS_RETENTION_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
+export const REQUEST_DENIALS_MAX_DELETE_BATCH = 5000;
 
 // Private copy of the repository's `isMissingTableError` so partial-deploy
 // soft-fail stays local to the cron module (no new export surface).
@@ -138,7 +141,29 @@ export async function sweepStaleSessions(db, now = Date.now()) {
 }
 
 /**
- * Run all three sweeps sequentially and return an aggregated summary.
+ * P3 U4: prune stale request denials. 14-day rolling window, bounded-
+ * delete (5000-row cap), `swallowMissingTable` pattern. The table may
+ * not exist on instances that have not yet applied migration 0013.
+ */
+export async function sweepRequestDenials(db, now = Date.now()) {
+  const cutoff = Math.max(0, Number(now) || 0) - REQUEST_DENIALS_RETENTION_MS;
+  try {
+    const result = await run(db, `
+      DELETE FROM admin_request_denials
+      WHERE rowid IN (
+        SELECT rowid FROM admin_request_denials
+        WHERE denied_at < ?
+        LIMIT ?
+      )
+    `, [cutoff, REQUEST_DENIALS_MAX_DELETE_BATCH]);
+    return { deleted: Math.max(0, Number(result?.meta?.changes) || 0) };
+  } catch (error) {
+    return swallowMissingTable(error, 'admin_request_denials');
+  }
+}
+
+/**
+ * Run all four sweeps sequentially and return an aggregated summary.
  * A sweep failure aborts the remainder so the failure surfaces in the
  * cron's error telemetry; partial successes are reported via the
  * `completed` array.
@@ -151,6 +176,8 @@ export async function runRetentionSweeps(db, now = Date.now()) {
   completed.push({ sweep: 'request_limits', ...requestLimits });
   const sessions = await sweepStaleSessions(db, now);
   completed.push({ sweep: 'account_sessions', ...sessions });
+  const denials = await sweepRequestDenials(db, now);
+  completed.push({ sweep: 'admin_request_denials', ...denials });
   return {
     completed,
     totalDeleted: completed.reduce((sum, entry) => sum + entry.deleted, 0),

--- a/worker/src/error-codes.js
+++ b/worker/src/error-codes.js
@@ -15,3 +15,12 @@ export const SELF_SUSPEND_FORBIDDEN = 'self_suspend_forbidden';
 export const LAST_ADMIN_LOCKED_OUT = 'last_admin_locked_out';
 export const ACCOUNT_OPS_METADATA_STALE = 'account_ops_metadata_stale';
 export const RECONCILE_IN_PROGRESS = 'reconcile_in_progress';
+
+// P3 U4: denial-reason codes captured in `admin_request_denials`.
+// Each constant is the canonical `denial_reason` column value and the
+// only value `logRequestDenial` accepts — never raw strings.
+export const DENIAL_ACCOUNT_SUSPENDED = 'account_suspended';
+export const DENIAL_PAYMENT_HOLD = 'payment_hold';
+export const DENIAL_SESSION_INVALIDATED = 'session_invalidated';
+export const DENIAL_CSRF_REJECTION = 'csrf_rejection';
+export const DENIAL_RATE_LIMIT_EXCEEDED = 'rate_limit_exceeded';

--- a/worker/src/error-codes.js
+++ b/worker/src/error-codes.js
@@ -24,3 +24,6 @@ export const DENIAL_PAYMENT_HOLD = 'payment_hold';
 export const DENIAL_SESSION_INVALIDATED = 'session_invalidated';
 export const DENIAL_CSRF_REJECTION = 'csrf_rejection';
 export const DENIAL_RATE_LIMIT_EXCEEDED = 'rate_limit_exceeded';
+
+// ADV-U4-004: shared origin-check code used by request-origin.js and app.js.
+export const SAME_ORIGIN_REQUIRED = 'same_origin_required';

--- a/worker/src/request-origin.js
+++ b/worker/src/request-origin.js
@@ -9,6 +9,7 @@
 // that both callers delegate to.
 
 import { ForbiddenError } from './errors.js';
+import { SAME_ORIGIN_REQUIRED } from './error-codes.js';
 
 function cleanText(value) {
   return String(value || '').trim();
@@ -84,7 +85,7 @@ export function requireSameOrigin(
   // site, so cross-site here is not a CSRF surface.
   if (fetchSite === 'cross-site' && !allowMissingOrigin) {
     throw new ForbiddenError('This request must come from the KS2 Mastery app origin.', {
-      code: 'same_origin_required',
+      code: SAME_ORIGIN_REQUIRED,
     });
   }
 
@@ -107,14 +108,14 @@ export function requireSameOrigin(
   if (!origin) {
     if (!allowMissingOrigin && isProductionRuntime(env)) {
       throw new ForbiddenError('This request must come from the KS2 Mastery app origin.', {
-        code: 'same_origin_required',
+        code: SAME_ORIGIN_REQUIRED,
       });
     }
     return;
   }
   if (!appOrigins(env, request).has(origin)) {
     throw new ForbiddenError('This request must come from the KS2 Mastery app origin.', {
-      code: 'same_origin_required',
+      code: SAME_ORIGIN_REQUIRED,
     });
   }
 }


### PR DESCRIPTION
## Summary
- Captures auth/role/rate-limit denials as structured events in `admin_request_denials` (migration 0013) for operator visibility (R8) and debug-bundle evidence (R9).
- Creates `worker/src/admin-denial-logger.js` — fire-and-forget logging via `ctx.waitUntil`, session_id masked to last 8 chars, closed-schema `detail_json`, 10% sampling after threshold for high-volume rate-limit denials.
- Threads `ctx` (Cloudflare execution context) through `createWorkerApp().fetch()` — previously ignored despite being passed from `index.js`.
- Hooks denial capture into `AccountSuspendedError`, `AccountPaymentHoldError`, `SessionInvalidatedError`, CSRF rejection (ForbiddenError `same_origin_required`), and ops-error rate-limit 429 paths.
- Adds `sweepRequestDenials` to `runRetentionSweeps` (14-day rolling window, 5000-row bounded delete, `swallowMissingTable` pattern).
- 17 unit tests + 7 integration tests (24 total, all passing).

## Files changed
- **New:** `worker/src/admin-denial-logger.js` — shared denial capture helper
- **New:** `tests/worker-admin-denial-logger.test.js` — 17 unit tests
- **New:** `tests/worker-admin-denial-capture.test.js` — 7 integration tests
- **Modified:** `worker/src/app.js` — thread `ctx`, add denial capture hooks
- **Modified:** `worker/src/auth.js` — attach `__denialSession` to auth errors
- **Modified:** `worker/src/cron/retention-sweep.js` — add `sweepRequestDenials`
- **Modified:** `worker/src/error-codes.js` — add denial reason constants

## Security constraints enforced
- `session_id_last8` — only last 8 chars stored (migration CHECK enforced)
- `detail_json` — closed schema, only known structured keys from `error-codes.js`
- Fire-and-forget — `ctx.waitUntil` + try/catch, never blocks the 403/429 response
- No raw headers/cookies/body ever reach `detail_json`

## Plan Deviations
- `worker/src/index.js` was not modified — it already passes `ctx` correctly to `app.fetch(request, env, ctx)`. The deviation is that `app.js:fetch()` now accepts the third `ctx` parameter instead of ignoring it.
- Rate-limit denial logging was added to the two highest-value ops-error 429 paths (global budget + per-IP) rather than every admin-ops-mutation 429 path, to keep the diff focused. Additional 429 paths can be instrumented incrementally.

## Test plan
- [x] `account_suspended` denial creates a row with correct fields
- [x] `payment_hold` denial creates a row with session context
- [x] `session_invalidated` denial captured without account context
- [x] Rate-limit denial captured with route and bucket context
- [x] High-volume rate-limit denials sampled at 10% after threshold
- [x] Denial logging failure does not affect the 403/429 response
- [x] Demo session denial marked `is_demo = 1`
- [x] Integration: denial appears in table after actual auth rejection
- [x] Integration: retention sweep removes 14-day-old denials
- [x] Integration: missing table tolerant (swallowMissingTable)
- [x] `ctx.waitUntil` called when execution context is present
- [x] Closed-schema detail_json excludes unknown keys