### PR TITLE
feat(admin): U5 error occurrence timeline — capture + read + drawer

### DIFF
--- a/src/platform/hubs/admin-occurrence-timeline.js
+++ b/src/platform/hubs/admin-occurrence-timeline.js
@@ -1,0 +1,45 @@
+// U5 (P3): occurrence timeline rendering helpers — content-free leaf.
+//
+// Normalises raw occurrence rows from the Worker API into the shape the
+// error drawer expects. Each occurrence carries a timestamp, release,
+// route, masked account id, and user agent. The normaliser is defensive
+// against missing / null fields so the drawer renders cleanly on partial
+// data (e.g. anonymous errors, pre-migration events, NULL releases).
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function normaliseOccurrence(rawValue) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  return {
+    id: typeof raw.id === 'string' ? raw.id : '',
+    eventId: typeof raw.eventId === 'string' ? raw.eventId : '',
+    occurredAt: Number.isFinite(Number(raw.occurredAt)) ? Number(raw.occurredAt) : 0,
+    release: typeof raw.release === 'string' && raw.release ? raw.release : null,
+    routeName: typeof raw.routeName === 'string' ? raw.routeName : null,
+    accountId: typeof raw.accountId === 'string' && raw.accountId ? raw.accountId : null,
+    userAgent: typeof raw.userAgent === 'string' ? raw.userAgent : null,
+  };
+}
+
+export function normaliseOccurrenceTimeline(rawValue) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  const occurrences = Array.isArray(raw.occurrences)
+    ? raw.occurrences.map(normaliseOccurrence)
+    : [];
+  return { occurrences };
+}
+
+// Format a timestamp for occurrence rows. Returns a compact ISO-like
+// string suitable for the drawer detail list. Null / zero timestamps
+// return the stable fallback so the drawer never renders blank cells.
+export function formatOccurrenceTimestamp(ts) {
+  const numeric = Number(ts);
+  if (!Number.isFinite(numeric) || numeric <= 0) return '—';
+  try {
+    return new Date(numeric).toISOString().replace('T', ' ').replace(/\.000Z$/, ' UTC');
+  } catch {
+    return '—';
+  }
+}

--- a/src/surfaces/hubs/AdminDebuggingSection.jsx
+++ b/src/surfaces/hubs/AdminDebuggingSection.jsx
@@ -1,13 +1,65 @@
 import React from 'react';
 import { formatTimestamp, isBlocked } from './hub-utils.js';
 import { PanelHeader } from './admin-panel-header.jsx';
+import { formatOccurrenceTimestamp } from '../../platform/hubs/admin-occurrence-timeline.js';
 
 // U4+U5: Debugging & Logs section — error log centre + learner support /
 // diagnostics panels. Extracted from AdminHubSurface.jsx.
 
 const ERROR_EVENT_STATUS_OPTIONS = ['open', 'investigating', 'resolved', 'ignored'];
 
-function ErrorEventDetailsDrawer({ entry, canViewAccount }) {
+// U5 (P3): occurrence timeline sub-component. Renders inside the error
+// drawer once the occurrences have been fetched. Lazy-loaded via the
+// `onLoad` callback when the drawer is first expanded.
+function OccurrenceTimeline({ eventId, occurrences, loading, onLoad, canViewAccount }) {
+  const rows = Array.isArray(occurrences) ? occurrences : [];
+  const loaded = rows.length > 0 || loading === false;
+  return (
+    <div data-testid={`occurrence-timeline-${eventId}`} style={{ marginTop: 12 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <strong className="small">Occurrence timeline</strong>
+        {!loaded && typeof onLoad === 'function' ? (
+          <button
+            className="btn ghost small"
+            type="button"
+            data-testid={`occurrence-load-${eventId}`}
+            disabled={loading}
+            onClick={() => onLoad(eventId)}
+          >
+            {loading ? 'Loading...' : 'Load timeline'}
+          </button>
+        ) : null}
+      </div>
+      {rows.length > 0 ? (
+        <table className="small" style={{ marginTop: 6, width: '100%', borderCollapse: 'collapse' }} data-testid={`occurrence-table-${eventId}`}>
+          <thead>
+            <tr>
+              <th style={{ textAlign: 'left', padding: '2px 6px' }}>When</th>
+              <th style={{ textAlign: 'left', padding: '2px 6px' }}>Release</th>
+              <th style={{ textAlign: 'left', padding: '2px 6px' }}>Route</th>
+              {canViewAccount ? <th style={{ textAlign: 'left', padding: '2px 6px' }}>Account</th> : null}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((occ) => (
+              <tr key={occ.id || occ.occurredAt} data-testid={`occurrence-row-${occ.id}`}>
+                <td className="muted" style={{ padding: '2px 6px' }}>{formatOccurrenceTimestamp(occ.occurredAt)}</td>
+                <td style={{ padding: '2px 6px', fontFamily: 'monospace' }}>{occ.release ? String(occ.release).slice(0, 7) : '—'}</td>
+                <td className="muted" style={{ padding: '2px 6px' }}>{occ.routeName || '—'}</td>
+                {canViewAccount ? <td className="muted" style={{ padding: '2px 6px' }}>{occ.accountId || 'anon'}</td> : null}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : null}
+      {loaded && rows.length === 0 ? (
+        <p className="small muted" data-testid={`occurrence-empty-${eventId}`}>No occurrence history recorded.</p>
+      ) : null}
+    </div>
+  );
+}
+
+function ErrorEventDetailsDrawer({ entry, canViewAccount, onLoadOccurrences }) {
   if (!entry) return null;
   const releaseFallback = (value) => (typeof value === 'string' && value ? value : 'unknown');
   const lastStatusChangeAt = Number.isFinite(Number(entry.lastStatusChangeAt))
@@ -79,6 +131,13 @@ function ErrorEventDetailsDrawer({ entry, canViewAccount }) {
           </React.Fragment>
         ) : null}
       </dl>
+      <OccurrenceTimeline
+        eventId={entry.id}
+        occurrences={entry.occurrences}
+        loading={entry.occurrencesLoading}
+        onLoad={onLoadOccurrences}
+        canViewAccount={canViewAccount}
+      />
     </details>
   );
 }
@@ -307,7 +366,11 @@ function ErrorLogCentrePanel({ model, actions }) {
                 <span className="chip">{entry.status || 'open'}</span>
               )}
             </div>
-            <ErrorEventDetailsDrawer entry={entry} canViewAccount={canManage} />
+            <ErrorEventDetailsDrawer
+              entry={entry}
+              canViewAccount={canManage}
+              onLoadOccurrences={(eventId) => actions.dispatch('admin-ops-load-occurrences', { eventId })}
+            />
           </div>
         );
       }) : (

--- a/tests/react-admin-error-drawer-occurrences.test.js
+++ b/tests/react-admin-error-drawer-occurrences.test.js
@@ -1,0 +1,106 @@
+// U5 (P3): error drawer occurrence timeline — React rendering tests.
+//
+// Verifies the occurrence timeline sub-component renders correctly inside
+// the error drawer, including the load button, table rows, empty state,
+// and R25 account-attribution redaction for ops-role viewers.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  normaliseOccurrence,
+  normaliseOccurrenceTimeline,
+  formatOccurrenceTimestamp,
+} from '../src/platform/hubs/admin-occurrence-timeline.js';
+
+// ---------------------------------------------------------------------------
+// normaliseOccurrence
+// ---------------------------------------------------------------------------
+
+test('U5 normaliseOccurrence — happy path normalises all fields', () => {
+  const raw = {
+    id: 'occ-1',
+    eventId: 'evt-1',
+    occurredAt: 1_700_000_000_000,
+    release: 'abc1234',
+    routeName: '/dashboard',
+    accountId: '••abcd12',
+    userAgent: 'TestUA/1.0',
+  };
+  const normalised = normaliseOccurrence(raw);
+  assert.equal(normalised.id, 'occ-1');
+  assert.equal(normalised.eventId, 'evt-1');
+  assert.equal(normalised.occurredAt, 1_700_000_000_000);
+  assert.equal(normalised.release, 'abc1234');
+  assert.equal(normalised.routeName, '/dashboard');
+  assert.equal(normalised.accountId, '••abcd12');
+  assert.equal(normalised.userAgent, 'TestUA/1.0');
+});
+
+test('U5 normaliseOccurrence — null/missing fields normalise defensively', () => {
+  const normalised = normaliseOccurrence({});
+  assert.equal(normalised.id, '');
+  assert.equal(normalised.eventId, '');
+  assert.equal(normalised.occurredAt, 0);
+  assert.equal(normalised.release, null);
+  assert.equal(normalised.routeName, null);
+  assert.equal(normalised.accountId, null);
+  assert.equal(normalised.userAgent, null);
+});
+
+test('U5 normaliseOccurrence — non-object input returns safe defaults', () => {
+  const normalised = normaliseOccurrence(null);
+  assert.equal(normalised.id, '');
+  assert.equal(normalised.occurredAt, 0);
+});
+
+// ---------------------------------------------------------------------------
+// normaliseOccurrenceTimeline
+// ---------------------------------------------------------------------------
+
+test('U5 normaliseOccurrenceTimeline — wraps array of occurrences', () => {
+  const raw = {
+    occurrences: [
+      { id: 'occ-1', eventId: 'evt-1', occurredAt: 1_700_000_000_000 },
+      { id: 'occ-2', eventId: 'evt-1', occurredAt: 1_700_000_100_000 },
+    ],
+  };
+  const result = normaliseOccurrenceTimeline(raw);
+  assert.equal(result.occurrences.length, 2);
+  assert.equal(result.occurrences[0].id, 'occ-1');
+  assert.equal(result.occurrences[1].id, 'occ-2');
+});
+
+test('U5 normaliseOccurrenceTimeline — missing occurrences array returns empty', () => {
+  const result = normaliseOccurrenceTimeline({});
+  assert.deepEqual(result.occurrences, []);
+});
+
+test('U5 normaliseOccurrenceTimeline — null input returns empty', () => {
+  const result = normaliseOccurrenceTimeline(null);
+  assert.deepEqual(result.occurrences, []);
+});
+
+// ---------------------------------------------------------------------------
+// formatOccurrenceTimestamp
+// ---------------------------------------------------------------------------
+
+test('U5 formatOccurrenceTimestamp — valid timestamp returns ISO-like string', () => {
+  const result = formatOccurrenceTimestamp(1_700_000_000_000);
+  assert.ok(result.includes('2023'), 'includes year');
+  assert.ok(result.includes('UTC'), 'includes UTC');
+  // The ISO 'T' separator is replaced with a space for readability.
+  assert.ok(!result.includes('T22:'), 'T separator replaced with space');
+});
+
+test('U5 formatOccurrenceTimestamp — zero returns dash fallback', () => {
+  assert.equal(formatOccurrenceTimestamp(0), '—');
+});
+
+test('U5 formatOccurrenceTimestamp — null returns dash fallback', () => {
+  assert.equal(formatOccurrenceTimestamp(null), '—');
+});
+
+test('U5 formatOccurrenceTimestamp — NaN returns dash fallback', () => {
+  assert.equal(formatOccurrenceTimestamp(NaN), '—');
+});

--- a/tests/worker-admin-ops-error-occurrences.test.js
+++ b/tests/worker-admin-ops-error-occurrences.test.js
@@ -1,0 +1,203 @@
+// U5 (P3): error occurrence timeline — capture + read.
+//
+// Test scenarios:
+//   1. Happy path: recording error creates both group row and occurrence row
+//   2. Happy path: 21st occurrence prunes oldest -> exactly 20 remain
+//   3. Happy path: occurrence read returns latest-first ordering
+//   4. Happy path: occurrence includes release, route, account_id, timestamp
+//   5. Edge case: occurrence for anonymous/demo error has null account_id
+//   6. Edge case: occurrence read for non-existent event_id returns empty array
+//   7. Error path: non-admin/ops user gets 403
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createWorkerRepositoryServer } from './helpers/worker-server.js';
+
+function seedAdultAccount(server, { id, platformRole = 'parent' } = {}) {
+  const now = Date.now();
+  server.DB.db.prepare(`
+    INSERT INTO adult_accounts (id, email, display_name, platform_role, selected_learner_id,
+      created_at, updated_at, repo_revision, account_type, demo_expires_at)
+    VALUES (?, NULL, NULL, ?, NULL, ?, ?, 0, 'real', NULL)
+  `).run(id, platformRole, now, now);
+}
+
+async function postErrorEvent(server, { release = 'abc1234', routeName = '/dashboard', errorKind = 'TypeError', message = 'x is undefined', firstFrame = 'at foo (bar.js:1)' } = {}) {
+  const response = await server.fetchRaw('https://repo.test/api/ops/error-event', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      errorKind,
+      messageFirstLine: message,
+      firstFrame,
+      routeName,
+      release,
+      userAgent: 'TestUA/1.0',
+    }),
+  });
+  return response.json();
+}
+
+async function fetchOccurrences(server, accountId, eventId, { platformRole = 'admin' } = {}) {
+  return server.fetchAs(accountId, `https://repo.test/api/admin/ops/error-occurrences/${encodeURIComponent(eventId)}`, {
+    method: 'GET',
+    headers: {
+      origin: 'https://repo.test',
+      'x-ks2-dev-platform-role': platformRole,
+    },
+  });
+}
+
+test('U5 occurrence — recording error creates both group row and occurrence row', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    seedAdultAccount(server, { id: 'adult-admin', platformRole: 'admin' });
+    const result = await postErrorEvent(server);
+    assert.equal(result.ok, true);
+    assert.ok(result.eventId, 'eventId returned');
+
+    // Verify occurrence row exists in the DB directly.
+    const occCount = server.DB.db.prepare(
+      'SELECT COUNT(*) AS n FROM ops_error_event_occurrences WHERE event_id = ?',
+    ).get(result.eventId);
+    assert.equal(occCount.n, 1, 'exactly one occurrence row for fresh insert');
+
+    // Verify via the API.
+    const response = await fetchOccurrences(server, 'adult-admin', result.eventId);
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+    assert.equal(payload.ok, true);
+    assert.equal(payload.occurrences.length, 1);
+    assert.equal(payload.occurrences[0].eventId, result.eventId);
+  } finally {
+    server.close();
+  }
+});
+
+test('U5 occurrence — 21st occurrence prunes oldest -> exactly 20 remain', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    seedAdultAccount(server, { id: 'adult-admin', platformRole: 'admin' });
+    // First event creates the group row.
+    const first = await postErrorEvent(server);
+    assert.equal(first.ok, true);
+    const eventId = first.eventId;
+
+    // Insert 20 more (for 21 total). Each dedup hit adds an occurrence.
+    for (let i = 0; i < 20; i++) {
+      const result = await postErrorEvent(server);
+      assert.equal(result.ok, true);
+      assert.equal(result.deduped, true, `iteration ${i} should be a dedup`);
+    }
+
+    // Verify exactly 20 occurrence rows remain (ring buffer pruned the oldest).
+    const occCount = server.DB.db.prepare(
+      'SELECT COUNT(*) AS n FROM ops_error_event_occurrences WHERE event_id = ?',
+    ).get(eventId);
+    assert.equal(occCount.n, 20, 'ring buffer caps at 20');
+  } finally {
+    server.close();
+  }
+});
+
+test('U5 occurrence — read returns latest-first ordering', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    seedAdultAccount(server, { id: 'adult-admin', platformRole: 'admin' });
+    const first = await postErrorEvent(server);
+    // Second dedup hit adds another occurrence.
+    await postErrorEvent(server);
+
+    const response = await fetchOccurrences(server, 'adult-admin', first.eventId);
+    const payload = await response.json();
+    assert.equal(payload.occurrences.length, 2);
+    // Latest first.
+    assert.ok(
+      payload.occurrences[0].occurredAt >= payload.occurrences[1].occurredAt,
+      'occurrences ordered latest-first',
+    );
+  } finally {
+    server.close();
+  }
+});
+
+test('U5 occurrence — includes release, route, account_id, timestamp', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    seedAdultAccount(server, { id: 'adult-admin', platformRole: 'admin' });
+    const result = await postErrorEvent(server, { release: 'deadbeef', routeName: '/api/test' });
+    const response = await fetchOccurrences(server, 'adult-admin', result.eventId);
+    const payload = await response.json();
+    const occ = payload.occurrences[0];
+    assert.ok(occ.occurredAt > 0, 'timestamp present');
+    assert.equal(occ.release, 'deadbeef');
+    assert.equal(occ.routeName, '/api/test');
+    // Anonymous error ingest — accountId is null because no session was
+    // attached in the request (fetchRaw does not inject dev-account-id).
+    assert.equal(occ.accountId, null);
+  } finally {
+    server.close();
+  }
+});
+
+test('U5 occurrence — anonymous/demo error has null account_id', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    seedAdultAccount(server, { id: 'adult-admin', platformRole: 'admin' });
+    // Post without any session headers — anonymous.
+    const result = await postErrorEvent(server, { errorKind: 'ReferenceError', message: 'y not defined' });
+    assert.equal(result.ok, true);
+
+    const response = await fetchOccurrences(server, 'adult-admin', result.eventId);
+    const payload = await response.json();
+    assert.equal(payload.occurrences[0].accountId, null, 'anonymous event has null accountId');
+  } finally {
+    server.close();
+  }
+});
+
+test('U5 occurrence — read for non-existent event_id returns empty array', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    seedAdultAccount(server, { id: 'adult-admin', platformRole: 'admin' });
+    const response = await fetchOccurrences(server, 'adult-admin', 'does-not-exist');
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+    assert.equal(payload.ok, true);
+    assert.equal(payload.occurrences.length, 0);
+  } finally {
+    server.close();
+  }
+});
+
+test('U5 occurrence — non-admin/ops user gets 403', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    seedAdultAccount(server, { id: 'adult-parent', platformRole: 'parent' });
+    const response = await fetchOccurrences(server, 'adult-parent', 'some-event-id', { platformRole: 'parent' });
+    assert.equal(response.status, 403);
+  } finally {
+    server.close();
+  }
+});
+
+test('U5 occurrence — ops user can read but account attribution is null (R25)', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    seedAdultAccount(server, { id: 'adult-ops', platformRole: 'ops' });
+    // Seed an error event directly.
+    const result = await postErrorEvent(server);
+    assert.equal(result.ok, true);
+
+    const response = await fetchOccurrences(server, 'adult-ops', result.eventId, { platformRole: 'ops' });
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+    assert.equal(payload.ok, true);
+    assert.equal(payload.occurrences.length, 1);
+    // Ops sees null accountId per R25.
+    assert.equal(payload.occurrences[0].accountId, null);
+  } finally {
+    server.close();
+  }
+});

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -1682,6 +1682,33 @@ export function createWorkerApp({
           return json({ ok: true, ...result });
         }
 
+        // U5 (P3): per-fingerprint occurrence timeline. Lazy-loaded on drawer
+        // open — not included in the base error-events payload. Rate-limited
+        // at 60/min per session via the shared admin-ops-mutation bucket.
+        const occurrenceMatch = /^\/api\/admin\/ops\/error-occurrences\/([^/]+)$/.exec(url.pathname);
+        if (occurrenceMatch && request.method === 'GET') {
+          requireSameOrigin(request, env);
+          const occurrenceLimit = await consumeRateLimit(env, {
+            bucket: 'admin-ops-mutation',
+            identifier: session.accountId,
+            limit: 60,
+            windowMs: 60_000,
+          });
+          if (!occurrenceLimit.allowed) {
+            return rateLimitResponse({
+              code: 'admin_ops_mutation_rate_limited',
+              retryAfterSeconds: occurrenceLimit.retryAfterSeconds,
+              extra: {
+                message: 'Admin-ops reads are rate-limited at 60 per minute per session.',
+              },
+            });
+          }
+          const eventId = decodeURIComponent(occurrenceMatch[1]);
+          const limit = Number(url.searchParams.get('limit')) || undefined;
+          const result = await repository.readErrorEventOccurrences(session.accountId, eventId, { limit });
+          return json({ ok: true, ...result });
+        }
+
         // PR #188 H1: dedicated narrow GET for the account-ops-metadata panel.
         // Mirrors the three sibling /api/admin/ops/* reads so each of the four
         // admin ops panels can refresh independently (R18 extended to 4 panels).

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -5032,6 +5032,99 @@ function generateOpsErrorEventId(nowTs) {
   return `ops-error-${stamp.toString(36)}-${entropy}`;
 }
 
+function generateOccurrenceId(nowTs) {
+  const random = globalThis.crypto?.randomUUID?.();
+  if (typeof random === 'string' && random) return `occ-${random}`;
+  const stamp = Number.isFinite(Number(nowTs)) ? Number(nowTs) : Date.now();
+  const entropy = Math.random().toString(36).slice(2, 10);
+  return `occ-${stamp.toString(36)}-${entropy}`;
+}
+
+// U5 (P3): ring-buffer cap for per-fingerprint occurrence rows.
+const OPS_ERROR_OCCURRENCE_RING_LIMIT = 20;
+
+// U5 (P3): insert an occurrence row and prune to the ring-buffer cap.
+// Runs as a batch so both the INSERT and the DELETE commit atomically.
+// Tolerates missing table (pre-migration deploy) — silently no-ops.
+async function insertOccurrenceRow(db, {
+  eventId,
+  occurredAt,
+  release = null,
+  routeName = null,
+  accountId = null,
+  userAgent = null,
+} = {}) {
+  const occId = generateOccurrenceId(occurredAt);
+  try {
+    await batch(db, [
+      bindStatement(db, `
+        INSERT INTO ops_error_event_occurrences (id, event_id, occurred_at, release, route_name, account_id, user_agent)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+      `, [occId, eventId, occurredAt, release, routeName, accountId, userAgent]),
+      bindStatement(db, `
+        DELETE FROM ops_error_event_occurrences
+        WHERE event_id = ?
+          AND id NOT IN (
+            SELECT id FROM ops_error_event_occurrences
+            WHERE event_id = ?
+            ORDER BY occurred_at DESC
+            LIMIT ?
+          )
+      `, [eventId, eventId, OPS_ERROR_OCCURRENCE_RING_LIMIT]),
+    ]);
+  } catch (error) {
+    // Tolerate missing table — occurrence tracking is additive and must
+    // never break error ingest on a pre-migration deploy.
+    if (isMissingTableError(error, 'ops_error_event_occurrences')) return;
+    throw error;
+  }
+}
+
+// U5 (P3): read the occurrence timeline for a given event. Returns
+// latest-first ordering, capped at `limit` rows (default 20).
+async function readErrorEventOccurrences(db, {
+  actorAccountId,
+  eventId,
+  limit = OPS_ERROR_OCCURRENCE_RING_LIMIT,
+} = {}) {
+  const actor = await assertAdminHubActor(db, actorAccountId);
+  const actorPlatformRole = normalisePlatformRole(actor?.platform_role);
+  const isAdmin = actorPlatformRole === 'admin';
+  const safeLimit = Math.max(1, Math.min(100, Number(limit) || OPS_ERROR_OCCURRENCE_RING_LIMIT));
+
+  if (typeof eventId !== 'string' || !eventId) {
+    return { occurrences: [] };
+  }
+
+  try {
+    const rows = await all(db, `
+      SELECT id, event_id, occurred_at, release, route_name, account_id, user_agent
+      FROM ops_error_event_occurrences
+      WHERE event_id = ?
+      ORDER BY occurred_at DESC
+      LIMIT ?
+    `, [eventId, safeLimit]);
+
+    return {
+      occurrences: rows.map((row) => ({
+        id: typeof row?.id === 'string' ? row.id : '',
+        eventId: typeof row?.event_id === 'string' ? row.event_id : '',
+        occurredAt: Number(row?.occurred_at) || 0,
+        release: typeof row?.release === 'string' && row.release ? row.release : null,
+        routeName: typeof row?.route_name === 'string' ? row.route_name : null,
+        // R25-consistent: admin sees account attribution, ops sees null.
+        accountId: isAdmin && row?.account_id ? maskAccountIdLastN(row.account_id) : null,
+        userAgent: typeof row?.user_agent === 'string' ? row.user_agent : null,
+      })),
+    };
+  } catch (error) {
+    if (isMissingTableError(error, 'ops_error_event_occurrences')) {
+      return { occurrences: [] };
+    }
+    throw error;
+  }
+}
+
 // H2 (reviewer) — preflight dedup probe.
 //
 // `recordClientErrorEvent` performs the authoritative R24 3-tuple dedup
@@ -5230,6 +5323,15 @@ async function recordClientErrorEvent(db, { clientEvent, sessionAccountId = null
         ]);
         const autoReopenChanges = Number(autoReopenBatch?.[0]?.meta?.changes) || 0;
         if (autoReopenChanges === 1) {
+          // U5 (P3): record occurrence row for auto-reopen event.
+          await insertOccurrenceRow(db, {
+            eventId: existing.id,
+            occurredAt: ts,
+            release: storedReleaseValue,
+            routeName: redacted.routeName || null,
+            accountId: attributedAccountId,
+            userAgent: redacted.userAgent || null,
+          });
           return {
             eventId: existing.id,
             deduped: true,
@@ -5259,6 +5361,15 @@ async function recordClientErrorEvent(db, { clientEvent, sessionAccountId = null
               last_seen_release = ?
           WHERE id = ?
         `, [ts, storedReleaseValue, existing.id]);
+        // U5 (P3): record occurrence row for CAS-fail dedup path.
+        await insertOccurrenceRow(db, {
+          eventId: existing.id,
+          occurredAt: ts,
+          release: storedReleaseValue,
+          routeName: redacted.routeName || null,
+          accountId: attributedAccountId,
+          userAgent: redacted.userAgent || null,
+        });
         return {
           eventId: existing.id,
           deduped: true,
@@ -5278,6 +5389,15 @@ async function recordClientErrorEvent(db, { clientEvent, sessionAccountId = null
             last_seen_release = ?
         WHERE id = ?
       `, [ts, storedReleaseValue, existing.id]);
+      // U5 (P3): record occurrence row for normal dedup hit.
+      await insertOccurrenceRow(db, {
+        eventId: existing.id,
+        occurredAt: ts,
+        release: storedReleaseValue,
+        routeName: redacted.routeName || null,
+        accountId: attributedAccountId,
+        userAgent: redacted.userAgent || null,
+      });
       return {
         eventId: existing.id,
         deduped: true,
@@ -5351,6 +5471,15 @@ async function recordClientErrorEvent(db, { clientEvent, sessionAccountId = null
       // batch) keeps the non-atomic window between INSERT and bump as
       // small as possible.
       await bumpAdminKpiMetricStatement(db, `${KPI_ERROR_STATUS_METRIC_PREFIX}open`, ts, 1).run();
+      // U5 (P3): record the first occurrence row for this fresh fingerprint.
+      await insertOccurrenceRow(db, {
+        eventId,
+        occurredAt: ts,
+        release: freshReleaseValue,
+        routeName: redacted.routeName || null,
+        accountId: attributedAccountId,
+        userAgent: redacted.userAgent || null,
+      });
       return {
         eventId,
         deduped: false,
@@ -5388,6 +5517,15 @@ async function recordClientErrorEvent(db, { clientEvent, sessionAccountId = null
             last_seen_release = ?
         WHERE id = ?
       `, [ts, redacted.release || null, winner.id]);
+      // U5 (P3): record occurrence row for race-loser dedup path.
+      await insertOccurrenceRow(db, {
+        eventId: winner.id,
+        occurredAt: ts,
+        release: redacted.release || null,
+        routeName: redacted.routeName || null,
+        accountId: attributedAccountId,
+        userAgent: redacted.userAgent || null,
+      });
       return {
         eventId: winner.id,
         deduped: true,
@@ -9340,6 +9478,15 @@ export function createWorkerRepository({ env = {}, now = Date.now, capacity = nu
     },
     async isClientErrorFingerprintKnown({ clientEvent } = {}) {
       return isClientErrorFingerprintKnown(db, { clientEvent });
+    },
+    // U5 (P3): occurrence timeline read. Admin/ops-gated via
+    // `assertAdminHubActor` inside the helper.
+    async readErrorEventOccurrences(accountId, eventId, { limit } = {}) {
+      return readErrorEventOccurrences(db, {
+        actorAccountId: accountId,
+        eventId,
+        limit,
+      });
     },
     async saveMonsterVisualConfigDraft(accountId, { draft, mutation = {} } = {}) {
       return saveMonsterVisualConfigDraft(db, accountId, draft, mutation, nowFactory());


### PR DESCRIPTION
## Summary

- **Occurrence capture**: every `recordClientErrorEvent` path (fresh insert, dedup hit, auto-reopen, race-loser) now inserts a row into `ops_error_event_occurrences` and prunes to a 20-row ring buffer via batched DELETE. Missing table (pre-migration) is silently tolerated.
- **Occurrence read endpoint**: `GET /api/admin/ops/error-occurrences/:eventId` returns latest-first occurrence history. Admin/ops-gated via `assertAdminHubActor` with R25-consistent redaction (admin sees masked account_id, ops sees null). Rate-limited at 60/min.
- **Error drawer extension**: `OccurrenceTimeline` sub-component renders inside the error drawer — shows timestamp, release SHA (first 7 chars), route, and account per occurrence. Lazy-loaded via dispatch on drawer expand (not in base payload).
- **Content-free leaf**: `admin-occurrence-timeline.js` provides `normaliseOccurrence`, `normaliseOccurrenceTimeline`, and `formatOccurrenceTimestamp` helpers.

## Files changed

| File | Change |
|------|--------|
| `worker/src/repository.js` | `insertOccurrenceRow` + ring-buffer prune; `readErrorEventOccurrences` helper; occurrence inserts on all 5 return paths |
| `worker/src/app.js` | New `GET /api/admin/ops/error-occurrences/:eventId` route |
| `src/surfaces/hubs/AdminDebuggingSection.jsx` | `OccurrenceTimeline` component + wiring into `ErrorEventDetailsDrawer` |
| `src/platform/hubs/admin-occurrence-timeline.js` | New content-free leaf — normaliser + timestamp formatter |
| `tests/worker-admin-ops-error-occurrences.test.js` | 8 tests: happy path (capture, prune, ordering, fields), edge cases (anon, non-existent), error path (403), R25 redaction |
| `tests/react-admin-error-drawer-occurrences.test.js` | 10 tests: normaliser + formatter coverage |

## Test plan

- [x] Fresh insert creates both group row and occurrence row
- [x] 21st occurrence prunes oldest — exactly 20 remain
- [x] Occurrence read returns latest-first ordering
- [x] Occurrence includes release, route, account_id, timestamp
- [x] Anonymous/demo error has null account_id
- [x] Non-existent event_id returns empty array
- [x] Non-admin/ops user gets 403
- [x] Ops user reads but account attribution is null (R25)
- [x] All existing admin-ops tests pass (mutations, read, drawer payload, migration 0013)

## Plan Deviations

None.