### PR TITLE
feat(admin): U8 denial log panel in Debugging section

### DIFF
--- a/src/platform/hubs/admin-denial-panel.js
+++ b/src/platform/hubs/admin-denial-panel.js
@@ -1,0 +1,55 @@
+// U8 (P3): denial normaliser — content-free leaf module.
+//
+// Normalises the raw denial log response from the server into a shape
+// the DenialLogPanel can consume directly. Deliberately kept free of
+// any content-heavy or role-helper imports so it can be pulled into the
+// production client bundle without triggering the forbidden-module
+// audit in `scripts/audit-client-bundle.mjs`.
+
+function isPlainObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * Normalise a single denial entry from the server response.
+ * Missing or unexpected fields get safe defaults.
+ */
+export function normaliseDenialEntry(raw) {
+  if (!isPlainObject(raw)) {
+    return {
+      id: '',
+      deniedAt: 0,
+      denialReason: '',
+      routeName: null,
+      accountIdMasked: null,
+      isDemo: false,
+      release: null,
+    };
+  }
+  return {
+    id: typeof raw.id === 'string' ? raw.id : '',
+    deniedAt: Number.isFinite(Number(raw.deniedAt)) ? Number(raw.deniedAt) : 0,
+    denialReason: typeof raw.denialReason === 'string' ? raw.denialReason : '',
+    routeName: typeof raw.routeName === 'string' ? raw.routeName : null,
+    accountIdMasked: typeof raw.accountIdMasked === 'string' ? raw.accountIdMasked : null,
+    isDemo: Boolean(raw.isDemo),
+    release: typeof raw.release === 'string' ? raw.release : null,
+  };
+}
+
+/**
+ * Normalise the full denial log response envelope.
+ * Returns { generatedAt, entries[] } — always safe to render.
+ */
+export function normaliseDenialLogResponse(raw) {
+  if (!isPlainObject(raw)) {
+    return { generatedAt: 0, entries: [] };
+  }
+  const entries = Array.isArray(raw.entries)
+    ? raw.entries.map(normaliseDenialEntry)
+    : [];
+  return {
+    generatedAt: Number.isFinite(Number(raw.generatedAt)) ? Number(raw.generatedAt) : 0,
+    entries,
+  };
+}

--- a/src/platform/hubs/admin-panel-patches.js
+++ b/src/platform/hubs/admin-panel-patches.js
@@ -129,6 +129,18 @@ export function applyAdminHubAccountOpsMetadataPatch(adminHub, rawDirectory) {
   };
 }
 
+// U8 (P3): narrow-refresh patch for the denial log panel. Mirrors the
+// four existing sibling patch helpers above. The denial panel has no
+// in-flight saving scalars, so no `preserveKeys` are needed.
+export function applyAdminHubDenialPatch(adminHub, rawDenials) {
+  const hub = coerceAdminHub(adminHub);
+  if (!hub) return adminHub;
+  const next = stripOkEnvelope(rawDenials);
+  if (!isPlainObject(next)) return hub;
+  const previous = isPlainObject(hub.denialLog) ? hub.denialLog : null;
+  return { ...hub, denialLog: composeSuccess(previous, next) };
+}
+
 // P1.5 Phase A (U1): failure-case patch — record the refresh error on the
 // target panel without touching any other sibling. The refreshedAt scalar
 // is preserved verbatim (whatever timestamp the UI was displaying from the
@@ -139,6 +151,7 @@ const PANEL_KEYS = Object.freeze({
   opsActivityStream: 'opsActivityStream',
   errorLogSummary: 'errorLogSummary',
   accountOpsMetadata: 'accountOpsMetadata',
+  denialLog: 'denialLog',
 });
 
 export function applyAdminHubPanelRefreshError(adminHub, panelKey, refreshError) {

--- a/src/surfaces/hubs/AdminDebuggingSection.jsx
+++ b/src/surfaces/hubs/AdminDebuggingSection.jsx
@@ -2,9 +2,11 @@ import React from 'react';
 import { formatTimestamp, isBlocked } from './hub-utils.js';
 import { PanelHeader } from './admin-panel-header.jsx';
 import { formatOccurrenceTimestamp } from '../../platform/hubs/admin-occurrence-timeline.js';
+import { normaliseDenialEntry } from '../../platform/hubs/admin-denial-panel.js';
 
 // U4+U5: Debugging & Logs section — error log centre + learner support /
 // diagnostics panels. Extracted from AdminHubSurface.jsx.
+// U8 (P3): + denial log panel below error centre.
 
 const ERROR_EVENT_STATUS_OPTIONS = ['open', 'investigating', 'resolved', 'ignored'];
 
@@ -476,10 +478,183 @@ function LearnerSupportPanel({ model, appState, accessContext, actions }) {
   );
 }
 
+// ---------------------------------------------------------------------------
+// U8 (P3): Denial log panel — surfaces request denial events (R8).
+// R8 visibility: admin sees account_id (masked last 8); ops sees reason +
+// route only — NO account or learner linkage (prevents child activity
+// disclosure).
+// ---------------------------------------------------------------------------
+
+const DENIAL_REASON_OPTIONS = [
+  'suspended_account',
+  'rate_limited',
+  'forbidden',
+  'invalid_session',
+  'demo_expired',
+];
+
+function DenialLogPanel({ model, actions }) {
+  const denialLog = model?.denialLog || {};
+  const rawEntries = Array.isArray(denialLog.entries) ? denialLog.entries : [];
+  const entries = rawEntries.map(normaliseDenialEntry);
+  const canViewAccount = model?.permissions?.platformRole === 'admin';
+
+  const [filterReason, setFilterReason] = React.useState('');
+  const [filterRoute, setFilterRoute] = React.useState('');
+  const [filterFrom, setFilterFrom] = React.useState('');
+  const [filterTo, setFilterTo] = React.useState('');
+
+  const dispatchRefresh = () => {
+    const payload = {};
+    if (filterReason) payload.reason = filterReason;
+    if (filterRoute.trim()) payload.route = filterRoute.trim();
+    const fromTs = Date.parse(filterFrom);
+    if (Number.isFinite(fromTs)) payload.from = fromTs;
+    const toTs = Date.parse(filterTo);
+    if (Number.isFinite(toTs)) payload.to = toTs;
+    actions.dispatch('admin-ops-request-denials-refresh', payload);
+  };
+
+  const clearFilters = () => {
+    setFilterReason('');
+    setFilterRoute('');
+    setFilterFrom('');
+    setFilterTo('');
+    actions.dispatch('admin-ops-request-denials-refresh', {});
+  };
+
+  const filtersActive = Boolean(filterReason || filterRoute || filterFrom || filterTo);
+
+  const headerExtras = (
+    <>
+      <div
+        className="filters"
+        style={{ marginTop: 10, display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))', gap: 8 }}
+        data-testid="denial-panel-filters"
+      >
+        <label className="field">
+          <span>Denial reason</span>
+          <select
+            className="select"
+            name="denialFilterReason"
+            value={filterReason}
+            onChange={(event) => setFilterReason(event.target.value)}
+            data-testid="denial-filter-reason"
+          >
+            <option value="">All reasons</option>
+            {DENIAL_REASON_OPTIONS.map((reason) => (
+              <option value={reason} key={reason}>{reason}</option>
+            ))}
+          </select>
+        </label>
+        <label className="field">
+          <span>Route contains</span>
+          <input
+            type="text"
+            className="input"
+            name="denialFilterRoute"
+            value={filterRoute}
+            maxLength={64}
+            onChange={(event) => setFilterRoute(event.target.value)}
+            placeholder="/api/"
+            data-testid="denial-filter-route"
+          />
+        </label>
+        <label className="field">
+          <span>From</span>
+          <input
+            type="datetime-local"
+            className="input"
+            name="denialFilterFrom"
+            value={filterFrom}
+            onChange={(event) => setFilterFrom(event.target.value)}
+            data-testid="denial-filter-from"
+          />
+        </label>
+        <label className="field">
+          <span>To</span>
+          <input
+            type="datetime-local"
+            className="input"
+            name="denialFilterTo"
+            value={filterTo}
+            onChange={(event) => setFilterTo(event.target.value)}
+            data-testid="denial-filter-to"
+          />
+        </label>
+      </div>
+      <div className="chip-row" style={{ marginTop: 8 }}>
+        <button
+          className="btn"
+          type="button"
+          data-testid="denial-filter-apply"
+          onClick={dispatchRefresh}
+        >
+          Apply filters
+        </button>
+        <button
+          className="btn ghost"
+          type="button"
+          data-testid="denial-filter-reset"
+          onClick={clearFilters}
+        >
+          Clear filters
+        </button>
+        {filtersActive && (
+          <span
+            className="chip warn"
+            data-testid="denial-filters-active-chip"
+          >
+            Filters active
+          </span>
+        )}
+      </div>
+    </>
+  );
+
+  return (
+    <section className="card" style={{ marginBottom: 20 }} data-testid="denial-log-panel">
+      <PanelHeader
+        eyebrow="Request denials"
+        title="Denial log"
+        refreshedAt={denialLog.refreshedAt ?? denialLog.generatedAt}
+        refreshError={denialLog.refreshError || null}
+        onRefresh={() => actions.dispatch('admin-ops-request-denials-refresh', {})}
+        headerExtras={headerExtras}
+      />
+      {entries.length ? entries.map((entry) => (
+        <div className="skill-row" key={entry.id} data-testid={`denial-row-${entry.id}`}>
+          <div>
+            <strong>{entry.denialReason || 'unknown'}</strong>
+          </div>
+          <div className="small muted">{entry.routeName || '—'}</div>
+          <div className="small muted">{formatTimestamp(entry.deniedAt)}</div>
+          {canViewAccount ? (
+            <div className="small muted" data-testid={`denial-account-${entry.id}`}>
+              {entry.accountIdMasked || 'anonymous'}
+            </div>
+          ) : null}
+          {entry.isDemo ? <span className="chip">demo</span> : null}
+        </div>
+      )) : (
+        <p
+          className="small muted"
+          data-testid="denial-panel-empty-state"
+        >
+          {filtersActive
+            ? 'No denials match the current filters.'
+            : 'No request denials recorded.'}
+        </p>
+      )}
+    </section>
+  );
+}
+
 export function AdminDebuggingSection({ model, appState, accessContext, actions }) {
   return (
     <>
       <ErrorLogCentrePanel model={model} actions={actions} />
+      <DenialLogPanel model={model} actions={actions} />
       <LearnerSupportPanel model={model} appState={appState} accessContext={accessContext} actions={actions} />
     </>
   );

--- a/tests/react-admin-denial-panel.test.js
+++ b/tests/react-admin-denial-panel.test.js
@@ -1,0 +1,226 @@
+// U8 (P3): SSR render contract for the DenialLogPanel inside AdminDebuggingSection.
+//
+// Test scenarios from the plan:
+//   1. Denial panel renders with filters (reason dropdown, route text, time range)
+//   2. Denial entries render with expected fields
+//   3. Empty state renders when no denials
+//   4. Admin sees account id; ops does not
+//   5. Normaliser handles missing/malformed entries
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function nodePaths() {
+  return [
+    path.join(rootDir, 'node_modules'),
+    ...String(process.env.NODE_PATH || '').split(path.delimiter),
+  ].filter((entry) => entry && existsSync(entry));
+}
+
+function normaliseLineEndings(value) {
+  return String(value).replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
+async function renderFixture(entrySource) {
+  const tmpDir = await mkdtemp(path.join(tmpdir(), 'ks2-denial-panel-'));
+  const entryPath = path.join(tmpDir, 'entry.jsx');
+  const bundlePath = path.join(tmpDir, 'entry.cjs');
+  try {
+    await writeFile(entryPath, entrySource);
+    await build({
+      absWorkingDir: rootDir,
+      entryPoints: [entryPath],
+      outfile: bundlePath,
+      bundle: true,
+      platform: 'node',
+      format: 'cjs',
+      target: ['node24'],
+      jsx: 'automatic',
+      jsxImportSource: 'react',
+      loader: { '.js': 'jsx' },
+      nodePaths: nodePaths(),
+      logLevel: 'silent',
+    });
+    const output = execFileSync(process.execPath, [bundlePath], {
+      cwd: rootDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return normaliseLineEndings(output).replace(/\n+$/, '');
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+const debuggingSectionPath = path.join(rootDir, 'src/surfaces/hubs/AdminDebuggingSection.jsx');
+
+function denialPanelFixture({ platformRole, denialLog = {} } = {}) {
+  return renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { AdminDebuggingSection } from ${JSON.stringify(debuggingSectionPath)};
+    const model = {
+      permissions: { canViewAdminHub: true, platformRole: ${JSON.stringify(platformRole)}, platformRoleLabel: ${JSON.stringify(platformRole)} },
+      errorLogSummary: { entries: [], totals: {} },
+      denialLog: ${JSON.stringify(denialLog)},
+      learnerSupport: { accessibleLearners: [], entryPoints: [] },
+    };
+    const actions = { dispatch: () => {} };
+    const html = renderToStaticMarkup(
+      <AdminDebuggingSection model={model} appState={{}} accessContext={{}} actions={actions} />
+    );
+    console.log(html);
+  `);
+}
+
+test('denial panel renders with filter controls', async () => {
+  const html = await denialPanelFixture({ platformRole: 'admin' });
+
+  // Panel container
+  assert.ok(html.includes('data-testid="denial-log-panel"'), 'denial panel container missing');
+  // Filter controls
+  assert.ok(html.includes('data-testid="denial-panel-filters"'), 'filter container missing');
+  assert.ok(html.includes('data-testid="denial-filter-reason"'), 'reason dropdown missing');
+  assert.ok(html.includes('data-testid="denial-filter-route"'), 'route filter missing');
+  assert.ok(html.includes('data-testid="denial-filter-from"'), 'from filter missing');
+  assert.ok(html.includes('data-testid="denial-filter-to"'), 'to filter missing');
+  assert.ok(html.includes('data-testid="denial-filter-apply"'), 'apply button missing');
+  assert.ok(html.includes('data-testid="denial-filter-reset"'), 'reset button missing');
+  // Panel header
+  assert.ok(html.includes('Denial log'), 'panel title missing');
+  assert.ok(html.includes('Request denials'), 'panel eyebrow missing');
+});
+
+test('denial panel renders entries with expected fields', async () => {
+  const denialLog = {
+    generatedAt: Date.now(),
+    entries: [
+      {
+        id: 'deny-1',
+        deniedAt: 1700000000000,
+        denialReason: 'suspended_account',
+        routeName: '/api/bootstrap',
+        accountIdMasked: 'abcd1234',
+        isDemo: false,
+        release: null,
+      },
+      {
+        id: 'deny-2',
+        deniedAt: 1700000001000,
+        denialReason: 'rate_limited',
+        routeName: '/api/subject/command',
+        accountIdMasked: 'efgh5678',
+        isDemo: true,
+        release: null,
+      },
+    ],
+  };
+
+  const html = await denialPanelFixture({ platformRole: 'admin', denialLog });
+
+  assert.ok(html.includes('data-testid="denial-row-deny-1"'), 'first denial row missing');
+  assert.ok(html.includes('data-testid="denial-row-deny-2"'), 'second denial row missing');
+  assert.ok(html.includes('suspended_account'), 'denial reason missing');
+  assert.ok(html.includes('rate_limited'), 'second denial reason missing');
+  assert.ok(html.includes('/api/bootstrap'), 'route name missing');
+  // Admin sees account id
+  assert.ok(html.includes('data-testid="denial-account-deny-1"'), 'admin account id missing');
+  assert.ok(html.includes('abcd1234'), 'masked account id missing');
+  // Demo chip
+  assert.ok(html.includes('demo'), 'demo chip missing');
+});
+
+test('denial panel shows empty state when no denials', async () => {
+  const html = await denialPanelFixture({
+    platformRole: 'admin',
+    denialLog: { generatedAt: Date.now(), entries: [] },
+  });
+
+  assert.ok(html.includes('data-testid="denial-panel-empty-state"'), 'empty state missing');
+  assert.ok(html.includes('No request denials recorded'), 'empty state text missing');
+});
+
+test('ops role does not see account linkage in denial panel', async () => {
+  const denialLog = {
+    generatedAt: Date.now(),
+    entries: [
+      {
+        id: 'deny-ops-1',
+        deniedAt: 1700000000000,
+        denialReason: 'suspended_account',
+        routeName: '/api/bootstrap',
+        accountIdMasked: 'abcd1234',
+        isDemo: false,
+        release: null,
+      },
+    ],
+  };
+
+  const html = await denialPanelFixture({ platformRole: 'ops', denialLog });
+
+  // Ops sees the denial row
+  assert.ok(html.includes('data-testid="denial-row-deny-ops-1"'), 'denial row missing for ops');
+  assert.ok(html.includes('suspended_account'), 'reason missing for ops');
+  assert.ok(html.includes('/api/bootstrap'), 'route missing for ops');
+  // Ops does NOT see account id column
+  assert.ok(!html.includes('data-testid="denial-account-deny-ops-1"'), 'ops should not see account linkage');
+});
+
+// Normaliser unit tests
+test('normaliseDenialEntry handles missing/malformed entries', async () => {
+  const output = await renderFixture(`
+    import { normaliseDenialEntry } from ${JSON.stringify(path.join(rootDir, 'src/platform/hubs/admin-denial-panel.js'))};
+
+    const nullResult = normaliseDenialEntry(null);
+    console.log(JSON.stringify(nullResult));
+
+    const emptyResult = normaliseDenialEntry({});
+    console.log(JSON.stringify(emptyResult));
+
+    const validResult = normaliseDenialEntry({
+      id: 'test-1',
+      deniedAt: 1700000000000,
+      denialReason: 'forbidden',
+      routeName: '/api/test',
+      accountIdMasked: 'last8chr',
+      isDemo: true,
+      release: 'abc1234',
+    });
+    console.log(JSON.stringify(validResult));
+  `);
+
+  const lines = output.split('\n');
+  const nullResult = JSON.parse(lines[0]);
+  const emptyResult = JSON.parse(lines[1]);
+  const validResult = JSON.parse(lines[2]);
+
+  // Null input
+  assert.equal(nullResult.id, '');
+  assert.equal(nullResult.deniedAt, 0);
+  assert.equal(nullResult.denialReason, '');
+  assert.equal(nullResult.routeName, null);
+  assert.equal(nullResult.accountIdMasked, null);
+  assert.equal(nullResult.isDemo, false);
+
+  // Empty object
+  assert.equal(emptyResult.id, '');
+  assert.equal(emptyResult.denialReason, '');
+
+  // Valid entry
+  assert.equal(validResult.id, 'test-1');
+  assert.equal(validResult.deniedAt, 1700000000000);
+  assert.equal(validResult.denialReason, 'forbidden');
+  assert.equal(validResult.routeName, '/api/test');
+  assert.equal(validResult.accountIdMasked, 'last8chr');
+  assert.equal(validResult.isDemo, true);
+  assert.equal(validResult.release, 'abc1234');
+});

--- a/tests/worker-admin-request-denials-read.test.js
+++ b/tests/worker-admin-request-denials-read.test.js
@@ -1,0 +1,313 @@
+// U8 (P3): Worker-level tests for GET /api/admin/ops/request-denials.
+//
+// Test scenarios from the plan:
+//   1. Happy path: denial read returns recent denials ordered by timestamp desc
+//   2. Happy path: filter by reason returns only matching denials
+//   3. Happy path: filter by route returns only matching denials
+//   4. Happy path: admin sees masked account ID; ops sees no account linkage
+//   5. Edge case: no denials in range -> empty state
+//   6. Parent role cannot access the endpoint
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createWorkerRepositoryServer } from './helpers/worker-server.js';
+
+function seedAdultAccount(server, {
+  id,
+  email,
+  displayName,
+  platformRole = 'parent',
+  now = 1,
+  accountType = 'real',
+  demoExpiresAt = null,
+} = {}) {
+  server.DB.db.prepare(`
+    INSERT INTO adult_accounts (
+      id, email, display_name, platform_role, selected_learner_id,
+      created_at, updated_at, repo_revision, account_type, demo_expires_at
+    )
+    VALUES (?, ?, ?, ?, NULL, ?, ?, 0, ?, ?)
+  `).run(id, email, displayName, platformRole, now, now, accountType, demoExpiresAt);
+}
+
+function insertRequestDenial(server, {
+  id,
+  deniedAt,
+  denialReason,
+  routeName = null,
+  accountId = null,
+  learnerId = null,
+  sessionIdLast8 = null,
+  isDemo = 0,
+  release = null,
+  detailJson = null,
+}) {
+  server.DB.db.prepare(`
+    INSERT INTO admin_request_denials (
+      id, denied_at, denial_reason, route_name, account_id,
+      learner_id, session_id_last8, is_demo, release, detail_json
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    id,
+    deniedAt,
+    denialReason,
+    routeName,
+    accountId,
+    learnerId,
+    sessionIdLast8,
+    isDemo,
+    release,
+    detailJson,
+  );
+}
+
+function seedAdminAndOps(server, now = 1_700_000_000_000) {
+  seedAdultAccount(server, {
+    id: 'adult-admin',
+    email: 'admin@example.com',
+    displayName: 'Admin',
+    platformRole: 'admin',
+    now,
+  });
+  seedAdultAccount(server, {
+    id: 'adult-ops',
+    email: 'ops@example.com',
+    displayName: 'Ops',
+    platformRole: 'ops',
+    now,
+  });
+  seedAdultAccount(server, {
+    id: 'adult-parent',
+    email: 'parent@example.com',
+    displayName: 'Parent',
+    platformRole: 'parent',
+    now,
+  });
+}
+
+test('GET /api/admin/ops/request-denials returns recent denials ordered by denied_at DESC', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    const now = Date.now();
+    seedAdminAndOps(server, now);
+
+    insertRequestDenial(server, {
+      id: 'deny-1',
+      deniedAt: now - 3000,
+      denialReason: 'suspended_account',
+      routeName: '/api/bootstrap',
+      accountId: 'adult-account-aaaa1111',
+    });
+    insertRequestDenial(server, {
+      id: 'deny-2',
+      deniedAt: now - 1000,
+      denialReason: 'rate_limited',
+      routeName: '/api/subject/command',
+      accountId: 'adult-account-bbbb2222',
+    });
+    insertRequestDenial(server, {
+      id: 'deny-3',
+      deniedAt: now - 2000,
+      denialReason: 'forbidden',
+      routeName: '/api/admin/accounts/role',
+      accountId: 'adult-account-cccc3333',
+    });
+
+    const response = await server.fetchAs(
+      'adult-admin',
+      'https://repo.test/api/admin/ops/request-denials',
+      {},
+      { 'x-ks2-dev-platform-role': 'admin' },
+    );
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.ok, true);
+    assert.equal(typeof payload.generatedAt, 'number');
+    assert.equal(Array.isArray(payload.entries), true);
+    assert.equal(payload.entries.length, 3);
+
+    // Ordered by denied_at DESC — deny-2 (most recent) first
+    assert.equal(payload.entries[0].id, 'deny-2');
+    assert.equal(payload.entries[1].id, 'deny-3');
+    assert.equal(payload.entries[2].id, 'deny-1');
+
+    // Fields present
+    assert.equal(payload.entries[0].denialReason, 'rate_limited');
+    assert.equal(payload.entries[0].routeName, '/api/subject/command');
+    assert.equal(typeof payload.entries[0].deniedAt, 'number');
+  } finally {
+    server.close();
+  }
+});
+
+test('GET /api/admin/ops/request-denials filter by reason returns only matching', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    const now = Date.now();
+    seedAdminAndOps(server, now);
+
+    insertRequestDenial(server, {
+      id: 'deny-a',
+      deniedAt: now - 2000,
+      denialReason: 'suspended_account',
+      routeName: '/api/bootstrap',
+    });
+    insertRequestDenial(server, {
+      id: 'deny-b',
+      deniedAt: now - 1000,
+      denialReason: 'rate_limited',
+      routeName: '/api/subject/command',
+    });
+
+    const response = await server.fetchAs(
+      'adult-admin',
+      'https://repo.test/api/admin/ops/request-denials?reason=suspended_account',
+      {},
+      { 'x-ks2-dev-platform-role': 'admin' },
+    );
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.entries.length, 1);
+    assert.equal(payload.entries[0].id, 'deny-a');
+    assert.equal(payload.entries[0].denialReason, 'suspended_account');
+  } finally {
+    server.close();
+  }
+});
+
+test('GET /api/admin/ops/request-denials filter by route returns only matching', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    const now = Date.now();
+    seedAdminAndOps(server, now);
+
+    insertRequestDenial(server, {
+      id: 'deny-x',
+      deniedAt: now - 2000,
+      denialReason: 'forbidden',
+      routeName: '/api/admin/accounts/role',
+    });
+    insertRequestDenial(server, {
+      id: 'deny-y',
+      deniedAt: now - 1000,
+      denialReason: 'rate_limited',
+      routeName: '/api/subject/command',
+    });
+
+    const response = await server.fetchAs(
+      'adult-admin',
+      'https://repo.test/api/admin/ops/request-denials?route=subject',
+      {},
+      { 'x-ks2-dev-platform-role': 'admin' },
+    );
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.entries.length, 1);
+    assert.equal(payload.entries[0].id, 'deny-y');
+    assert.equal(payload.entries[0].routeName, '/api/subject/command');
+  } finally {
+    server.close();
+  }
+});
+
+test('admin sees masked account ID (last 8); ops sees no account linkage', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    const now = Date.now();
+    seedAdminAndOps(server, now);
+
+    insertRequestDenial(server, {
+      id: 'deny-acl-1',
+      deniedAt: now - 1000,
+      denialReason: 'suspended_account',
+      routeName: '/api/bootstrap',
+      accountId: 'adult-account-abcd1234',
+    });
+
+    // Admin request — should see masked account id (last 8 chars)
+    const adminResponse = await server.fetchAs(
+      'adult-admin',
+      'https://repo.test/api/admin/ops/request-denials',
+      {},
+      { 'x-ks2-dev-platform-role': 'admin' },
+    );
+    const adminPayload = await adminResponse.json();
+
+    assert.equal(adminResponse.status, 200);
+    assert.equal(adminPayload.entries.length, 1);
+    assert.equal(adminPayload.entries[0].accountIdMasked, 'abcd1234');
+
+    // Ops request — should see null account id (no linkage)
+    const opsResponse = await server.fetchAs(
+      'adult-ops',
+      'https://repo.test/api/admin/ops/request-denials',
+      {},
+      { 'x-ks2-dev-platform-role': 'ops' },
+    );
+    const opsPayload = await opsResponse.json();
+
+    assert.equal(opsResponse.status, 200);
+    assert.equal(opsPayload.entries.length, 1);
+    assert.equal(opsPayload.entries[0].accountIdMasked, null);
+    // Ops still sees reason + route
+    assert.equal(opsPayload.entries[0].denialReason, 'suspended_account');
+    assert.equal(opsPayload.entries[0].routeName, '/api/bootstrap');
+  } finally {
+    server.close();
+  }
+});
+
+test('no denials in range returns empty entries array', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    const now = Date.now();
+    seedAdminAndOps(server, now);
+
+    // Insert a denial outside the requested time range
+    insertRequestDenial(server, {
+      id: 'deny-old',
+      deniedAt: now - 100_000,
+      denialReason: 'forbidden',
+      routeName: '/api/admin/accounts',
+    });
+
+    const response = await server.fetchAs(
+      'adult-admin',
+      `https://repo.test/api/admin/ops/request-denials?from=${now - 1000}&to=${now}`,
+      {},
+      { 'x-ks2-dev-platform-role': 'admin' },
+    );
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.entries.length, 0);
+  } finally {
+    server.close();
+  }
+});
+
+test('parent role cannot access denial log endpoint', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    const now = Date.now();
+    seedAdminAndOps(server, now);
+
+    const response = await server.fetchAs(
+      'adult-parent',
+      'https://repo.test/api/admin/ops/request-denials',
+      {},
+      { 'x-ks2-dev-platform-role': 'parent' },
+    );
+
+    // Parent should be rejected — either 403 or the admin hub access gate
+    assert.ok(response.status >= 400, `Expected 4xx status, got ${response.status}`);
+  } finally {
+    server.close();
+  }
+});

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -1709,6 +1709,29 @@ export function createWorkerApp({
           return json({ ok: true, ...result });
         }
 
+        // U8 (P3): denial log panel read route. Filters mirror the panel's
+        // dropdown (reason), text (route), text (account_id), and time range.
+        // R8: admin sees masked account_id (last 8); ops sees reason + route
+        // only — no account or learner linkage.
+        if (url.pathname === '/api/admin/ops/request-denials' && request.method === 'GET') {
+          requireSameOrigin(request, env);
+          const reason = url.searchParams.get('reason') || null;
+          const route = url.searchParams.get('route') || null;
+          const accountIdFilter = url.searchParams.get('account_id') || null;
+          const from = url.searchParams.get('from') || null;
+          const to = url.searchParams.get('to') || null;
+          const limit = Number(url.searchParams.get('limit')) || undefined;
+          const result = await repository.readAdminRequestDenials(session.accountId, {
+            reason,
+            route,
+            accountId: accountIdFilter,
+            from: from !== null && Number.isFinite(Number(from)) ? Number(from) : null,
+            to: to !== null && Number.isFinite(Number(to)) ? Number(to) : null,
+            limit,
+          });
+          return json({ ok: true, ...result });
+        }
+
         // PR #188 H1: dedicated narrow GET for the account-ops-metadata panel.
         // Mirrors the three sibling /api/admin/ops/* reads so each of the four
         // admin ops panels can refresh independently (R18 extended to 4 panels).

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -1970,7 +1970,10 @@ const OPS_ERROR_EVENTS_DEFAULT_LIMIT = 50;
 const OPS_ERROR_EVENTS_MAX_LIMIT = 50;
 const OPS_ACCOUNT_DIRECTORY_LIMIT = 200;
 const ACCOUNT_ID_MASK_LAST_N = 6;
+const DENIAL_ACCOUNT_ID_MASK_LAST_N = 8;
 const LEARNER_SCOPE_ID_MASK_LAST_N = 8;
+const DENIAL_DEFAULT_LIMIT = 50;
+const DENIAL_MAX_LIMIT = 200;
 const KPI_WINDOW_7D_MS = 7 * 24 * 60 * 60 * 1000;
 const KPI_WINDOW_30D_MS = 30 * 24 * 60 * 60 * 1000;
 const KPI_ERROR_STATUS_METRIC_PREFIX = 'ops_error_events.status.';
@@ -2919,6 +2922,91 @@ async function readOpsErrorEventSummary(db, {
   } catch (error) {
     if (!isMissingTableError(error, 'ops_error_events')) throw error;
     return emptyOpsErrorEventSummary(nowTs);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// U8 (P3): Request denial log read helper.
+// Reads from `admin_request_denials` (migration 0013). R8 visibility:
+//   - admin sees accountIdMasked (last 8 chars) so they can cross-reference.
+//   - ops sees denial_reason + route only — NO account or learner linkage.
+// Soft-fails with isMissingTableError so the panel loads pre-migration.
+// ---------------------------------------------------------------------------
+
+async function readAdminRequestDenials(db, {
+  now,
+  actorAccountId,
+  actor: preResolvedActor = null,
+  reason = null,
+  route = null,
+  accountId: filterAccountId = null,
+  from = null,
+  to = null,
+  limit = DENIAL_DEFAULT_LIMIT,
+} = {}) {
+  const actor = preResolvedActor || await assertAdminHubActor(db, actorAccountId);
+  const actorPlatformRole = normalisePlatformRole(actor?.platform_role);
+  const nowTs = Number.isFinite(Number(now)) ? Number(now) : Date.now();
+  const safeLimit = Math.max(1, Math.min(DENIAL_MAX_LIMIT, Number(limit) || DENIAL_DEFAULT_LIMIT));
+  const isAdmin = actorPlatformRole === 'admin';
+
+  const whereClauses = [];
+  const whereParams = [];
+
+  if (typeof reason === 'string' && reason) {
+    whereClauses.push('denial_reason = ?');
+    whereParams.push(reason);
+  }
+  if (typeof route === 'string' && route) {
+    whereClauses.push('route_name LIKE ?');
+    whereParams.push(`%${route}%`);
+  }
+  // R9: only admin can filter by account_id — ops never touches account linkage.
+  if (isAdmin && typeof filterAccountId === 'string' && filterAccountId) {
+    whereClauses.push('account_id LIKE ?');
+    whereParams.push(`%${filterAccountId}%`);
+  }
+  if (from != null && Number.isFinite(Number(from))) {
+    whereClauses.push('denied_at >= ?');
+    whereParams.push(Number(from));
+  }
+  if (to != null && Number.isFinite(Number(to))) {
+    whereClauses.push('denied_at <= ?');
+    whereParams.push(Number(to));
+  }
+
+  const whereSql = whereClauses.length > 0
+    ? `WHERE ${whereClauses.join(' AND ')}`
+    : '';
+
+  try {
+    const rows = await all(db, `
+      SELECT id, denied_at, denial_reason, route_name, account_id,
+             learner_id, session_id_last8, is_demo, release, detail_json
+      FROM admin_request_denials
+      ${whereSql}
+      ORDER BY denied_at DESC, id DESC
+      LIMIT ?
+    `, [...whereParams, safeLimit]);
+
+    return {
+      generatedAt: nowTs,
+      entries: rows.map((row) => ({
+        id: typeof row?.id === 'string' ? row.id : '',
+        deniedAt: Number(row?.denied_at) || 0,
+        denialReason: typeof row?.denial_reason === 'string' ? row.denial_reason : '',
+        routeName: typeof row?.route_name === 'string' ? row.route_name : null,
+        // R8: admin sees last-8 masked account_id; ops sees null.
+        accountIdMasked: isAdmin && row?.account_id
+          ? maskAccountIdLastN(row.account_id, DENIAL_ACCOUNT_ID_MASK_LAST_N)
+          : null,
+        isDemo: Boolean(row?.is_demo),
+        release: typeof row?.release === 'string' ? row.release : null,
+      })),
+    };
+  } catch (error) {
+    if (!isMissingTableError(error, 'admin_request_denials')) throw error;
+    return { generatedAt: nowTs, entries: [] };
   }
 }
 
@@ -9346,6 +9434,28 @@ export function createWorkerRepository({ env = {}, now = Date.now, capacity = nu
         now: nowFactory(),
         actorAccountId: accountId,
         actor,
+      });
+    },
+    // U8 (P3): narrow read for the denial log panel in Debugging section.
+    // R8 visibility: admin sees masked account_id (last 8); ops sees
+    // denial_reason + route only (no account or learner linkage).
+    async readAdminRequestDenials(accountId, {
+      reason = null,
+      route = null,
+      accountId: filterAccountId = null,
+      from = null,
+      to = null,
+      limit = DENIAL_DEFAULT_LIMIT,
+    } = {}) {
+      return readAdminRequestDenials(db, {
+        now: nowFactory(),
+        actorAccountId: accountId,
+        reason,
+        route,
+        accountId: filterAccountId,
+        from,
+        to,
+        limit,
       });
     },
     async bumpAdminKpiMetric(key, delta = 1) {


### PR DESCRIPTION
## Summary
- Surfaces request denial events from `admin_request_denials` (migration 0013) in the admin Debugging & Logs section
- Worker: `GET /api/admin/ops/request-denials` with `reason`, `route`, `account_id`, `from`, `to`, `limit` query params
- Repository: `readAdminRequestDenials` helper with `isMissingTableError` soft-fail for pre-migration deploys
- R8 visibility: admin sees account_id (masked last 8 chars); ops sees denial_reason + route only (no account or learner linkage — prevents child activity disclosure)
- `DenialLogPanel` with filters (reason dropdown, route text, time range) below `ErrorLogCentrePanel` in `AdminDebuggingSection`
- `admin-denial-panel.js` normaliser (content-free leaf — safe for client bundle audit)
- `applyAdminHubDenialPatch` for narrow refresh in `admin-panel-patches.js`; `denialLog` added to `PANEL_KEYS` for error-case refresh routing

## Files changed
- `worker/src/app.js` — new `GET /api/admin/ops/request-denials` route
- `worker/src/repository.js` — `readAdminRequestDenials` helper + `DENIAL_*` constants
- `src/surfaces/hubs/AdminDebuggingSection.jsx` — `DenialLogPanel` component
- `src/platform/hubs/admin-denial-panel.js` — normaliser (new file)
- `src/platform/hubs/admin-panel-patches.js` — `applyAdminHubDenialPatch` + `denialLog` panel key
- `tests/worker-admin-request-denials-read.test.js` — 6 worker tests (new file)
- `tests/react-admin-denial-panel.test.js` — 5 React SSR tests (new file)

## Plan deviations
- `DENIAL_ACCOUNT_ID_MASK_LAST_N = 8` — plan says "masked last 8" for denials vs the existing `ACCOUNT_ID_MASK_LAST_N = 6` for error events. Separate constant to avoid changing existing masking behaviour.
- Added `null` guard on `from`/`to` params in both `app.js` and `repository.js` — `Number(null)` is `0` which is `Number.isFinite`, so bare `Number.isFinite(Number(from))` would incorrectly add `denied_at >= 0` when no time range is supplied.

## Test plan
- [x] 6 worker tests: happy path (ordered DESC), filter by reason, filter by route, admin vs ops visibility, empty range, parent 403
- [x] 5 React SSR tests: panel renders with filters, entries render, empty state, ops no account linkage, normaliser edge cases
- [x] 56 existing admin tests pass (ops-read, hub-parallel, ops-mutations)