### PR TITLE
feat(admin): U7 account search and detail support cockpit

### DIFF
--- a/src/platform/hubs/admin-account-search.js
+++ b/src/platform/hubs/admin-account-search.js
@@ -1,0 +1,94 @@
+// U7 (Admin Console P3): Account search and detail support cockpit.
+//
+// Content-free leaf: this module MUST NOT import subject content
+// datasets, subject engines, or any module that transitively pulls in
+// spelling / grammar / punctuation content bundles. The audit gate in
+// `scripts/audit-client-bundle.mjs` enforces this invariant.
+//
+// Pure normalisers for the search results and account detail payloads
+// returned by the worker endpoints. No side effects, no storage, no
+// fetch. The AdminAccountsSection.jsx surface consumes these helpers
+// to render search results and the detail panel.
+
+/**
+ * Normalise a single search result row from the worker payload.
+ *
+ * @param {object} row — raw result from /api/admin/accounts/search
+ * @returns {object}   — rendering-ready row
+ */
+export function normaliseSearchResult(row) {
+  if (!row || typeof row !== 'object') return null;
+  return {
+    id: typeof row.id === 'string' ? row.id : '',
+    email: typeof row.email === 'string' ? row.email : null,
+    displayName: typeof row.displayName === 'string' ? row.displayName : null,
+    platformRole: typeof row.platformRole === 'string' ? row.platformRole : 'parent',
+    opsStatus: typeof row.opsStatus === 'string' ? row.opsStatus : 'active',
+    planLabel: typeof row.planLabel === 'string' ? row.planLabel : null,
+    learnerCount: Number(row.learnerCount) || 0,
+    createdAt: Number(row.createdAt) || 0,
+    updatedAt: Number(row.updatedAt) || 0,
+  };
+}
+
+/**
+ * Normalise the full search response payload.
+ *
+ * @param {object} payload — raw JSON from /api/admin/accounts/search
+ * @returns {object}       — { results, truncated, error }
+ */
+export function normaliseSearchPayload(payload) {
+  if (!payload || typeof payload !== 'object') {
+    return { results: [], truncated: false, error: null };
+  }
+  return {
+    results: Array.isArray(payload.results)
+      ? payload.results.map(normaliseSearchResult).filter(Boolean)
+      : [],
+    truncated: Boolean(payload.truncated),
+    error: typeof payload.error === 'string' ? payload.error : null,
+  };
+}
+
+/**
+ * Normalise the account detail response payload.
+ *
+ * @param {object} payload — raw JSON from /api/admin/accounts/:id/detail
+ * @returns {object}       — rendering-ready detail object
+ */
+export function normaliseAccountDetail(payload) {
+  if (!payload || typeof payload !== 'object') return null;
+  const account = payload.account && typeof payload.account === 'object'
+    ? payload.account
+    : {};
+  return {
+    account: {
+      id: typeof account.id === 'string' ? account.id : '',
+      email: typeof account.email === 'string' ? account.email : null,
+      displayName: typeof account.displayName === 'string' ? account.displayName : null,
+      platformRole: typeof account.platformRole === 'string' ? account.platformRole : 'parent',
+      accountType: typeof account.accountType === 'string' ? account.accountType : 'real',
+      repoRevision: Number(account.repoRevision) || 0,
+      createdAt: Number(account.createdAt) || 0,
+      updatedAt: Number(account.updatedAt) || 0,
+    },
+    learners: Array.isArray(payload.learners) ? payload.learners : [],
+    recentErrors: Array.isArray(payload.recentErrors) ? payload.recentErrors : [],
+    recentDenials: Array.isArray(payload.recentDenials) ? payload.recentDenials : [],
+    recentMutations: Array.isArray(payload.recentMutations) ? payload.recentMutations : [],
+    opsMetadata: payload.opsMetadata && typeof payload.opsMetadata === 'object'
+      ? payload.opsMetadata
+      : null,
+  };
+}
+
+/**
+ * Build a debug bundle deep-link URL for a given account.
+ *
+ * @param {string} accountId
+ * @returns {string}
+ */
+export function debugBundleLinkForAccount(accountId) {
+  if (typeof accountId !== 'string' || !accountId) return '#';
+  return `/admin#debug-bundle?accountId=${encodeURIComponent(accountId)}`;
+}

--- a/src/surfaces/hubs/AdminAccountsSection.jsx
+++ b/src/surfaces/hubs/AdminAccountsSection.jsx
@@ -16,6 +16,10 @@ import {
   decideAccountOpsSave,
   defaultConfirmOpsStatusChange,
 } from '../../platform/hubs/admin-ops-confirm.js';
+import {
+  normaliseSearchResult,
+  debugBundleLinkForAccount,
+} from '../../platform/hubs/admin-account-search.js';
 
 // U4+U5: Accounts section — role management, ops metadata, and audit log.
 // Extracted from AdminHubSurface.jsx. All inline components preserved
@@ -381,9 +385,222 @@ function AuditLogLookup({ model }) {
   );
 }
 
+// ---------------------------------------------------------------------------
+// U7 (P3): Account search bar + results + detail drawer.
+// ---------------------------------------------------------------------------
+
+function AccountSearchResultRow({ result, onSelect }) {
+  const row = normaliseSearchResult(result);
+  if (!row) return null;
+  return (
+    <div
+      className="skill-row"
+      data-testid="account-search-result"
+      data-account-id={row.id}
+      role="button"
+      tabIndex={0}
+      onClick={() => onSelect(row.id)}
+      onKeyDown={(e) => { if (e.key === 'Enter') onSelect(row.id); }}
+    >
+      <div>
+        <strong>{row.email || row.id}</strong>
+        <div className="small muted">{row.displayName || 'No display name'}</div>
+      </div>
+      <div><span className="chip">{platformRoleLabel(row.platformRole)}</span></div>
+      <div><span className="chip">{row.opsStatus}</span></div>
+      <div className="small muted">{row.learnerCount} learner{row.learnerCount === 1 ? '' : 's'}</div>
+      <div className="small muted">Updated {formatTimestamp(row.updatedAt)}</div>
+    </div>
+  );
+}
+
+function AccountDetailPanel({ detail, onClose, onDebugBundle }) {
+  if (!detail || !detail.account) return null;
+  const { account, learners, recentErrors, recentDenials, recentMutations, opsMetadata } = detail;
+  return (
+    <section className="card" style={{ marginBottom: 20 }} data-testid="account-detail-panel">
+      <div className="card-header">
+        <div>
+          <div className="eyebrow">Account detail</div>
+          <h3 className="section-title" style={{ fontSize: '1.2rem' }}>{account.email || account.id}</h3>
+          <p className="subtitle">{account.displayName || 'No display name'} &middot; {platformRoleLabel(account.platformRole)} &middot; {account.accountType}</p>
+        </div>
+        <div className="actions">
+          <button className="btn secondary" type="button" onClick={onDebugBundle} data-testid="detail-debug-bundle-link">Debug Bundle</button>
+          <button className="btn secondary" type="button" onClick={onClose}>Close</button>
+        </div>
+      </div>
+      <div className="small muted" style={{ marginBottom: 8 }}>
+        Created {formatTimestamp(account.createdAt)} &middot; Updated {formatTimestamp(account.updatedAt)} &middot; Rev {account.repoRevision}
+      </div>
+
+      {opsMetadata && (
+        <div style={{ marginBottom: 12 }}>
+          <div className="eyebrow">Ops metadata</div>
+          <div className="small muted">
+            Status: <strong>{opsMetadata.opsStatus}</strong>
+            {opsMetadata.planLabel ? ` | Plan: ${opsMetadata.planLabel}` : ''}
+            {opsMetadata.tags?.length ? ` | Tags: ${opsMetadata.tags.join(', ')}` : ''}
+          </div>
+          {opsMetadata.internalNotes && <div className="small muted" style={{ marginTop: 4 }}>Notes: {opsMetadata.internalNotes}</div>}
+        </div>
+      )}
+
+      <div className="eyebrow" style={{ marginTop: 8 }}>Learners ({learners.length})</div>
+      {learners.length ? learners.map((l) => (
+        <div className="skill-row" key={l.id}>
+          <div><strong>{l.displayName || l.id}</strong></div>
+          <div className="small muted">Year {l.yearGroup ?? '?'} &middot; {l.membershipRole}</div>
+          <div className="small muted">Updated {formatTimestamp(l.updatedAt)}</div>
+        </div>
+      )) : <p className="small muted">No linked learners.</p>}
+
+      <div className="eyebrow" style={{ marginTop: 12 }}>Recent errors ({recentErrors.length})</div>
+      {recentErrors.length ? recentErrors.map((e) => (
+        <div className="skill-row" key={e.id}>
+          <div><strong>{e.errorKind}</strong>: {e.messageFirstLine}</div>
+          <div className="small muted">{e.status} &middot; {e.occurrenceCount}x</div>
+          <div className="small muted">Last seen {formatTimestamp(e.lastSeen)}</div>
+        </div>
+      )) : <p className="small muted">No recent errors.</p>}
+
+      {recentDenials.length > 0 && (
+        <>
+          <div className="eyebrow" style={{ marginTop: 12 }}>Recent denials ({recentDenials.length})</div>
+          {recentDenials.map((d) => (
+            <div className="skill-row" key={d.id}>
+              <div><strong>{d.denialReason}</strong></div>
+              <div className="small muted">{d.routeName}</div>
+              <div className="small muted">{formatTimestamp(d.deniedAt)}</div>
+            </div>
+          ))}
+        </>
+      )}
+
+      <div className="eyebrow" style={{ marginTop: 12 }}>Recent mutations ({recentMutations.length})</div>
+      {recentMutations.length ? recentMutations.map((m) => (
+        <div className="skill-row" key={m.requestId || `${m.mutationKind}-${m.appliedAt}`}>
+          <div><strong>{m.mutationKind}</strong></div>
+          <div className="small muted">{m.scopeType} &middot; {m.scopeId}</div>
+          <div className="small muted">{formatTimestamp(m.appliedAt)}</div>
+        </div>
+      )) : <p className="small muted">No recent mutations.</p>}
+    </section>
+  );
+}
+
+function AccountSearchPanel({ model, actions }) {
+  const search = model?.accountSearch || {};
+  const results = Array.isArray(search.results) ? search.results : [];
+  const status = search.status || 'idle';
+  const detail = search.detail || null;
+  const [query, setQuery] = React.useState(search.query || '');
+  const [opsStatusFilter, setOpsStatusFilter] = React.useState('');
+  const [platformRoleFilter, setPlatformRoleFilter] = React.useState('');
+
+  const handleSearch = () => {
+    actions.dispatch('account-search', {
+      query: query.trim(),
+      opsStatus: opsStatusFilter || null,
+      platformRole: platformRoleFilter || null,
+    });
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter') handleSearch();
+  };
+
+  const handleSelectAccount = (accountId) => {
+    actions.dispatch('account-detail-load', { accountId });
+  };
+
+  const handleCloseDetail = () => {
+    actions.dispatch('account-detail-close');
+  };
+
+  const handleDebugBundle = () => {
+    if (detail?.account?.id) {
+      const link = debugBundleLinkForAccount(detail.account.id);
+      if (typeof window !== 'undefined') {
+        window.location.hash = link.replace(/^\/admin/, '');
+      }
+    }
+  };
+
+  if (detail) {
+    return (
+      <AccountDetailPanel
+        detail={detail}
+        onClose={handleCloseDetail}
+        onDebugBundle={handleDebugBundle}
+      />
+    );
+  }
+
+  return (
+    <section className="card" style={{ marginBottom: 20 }} data-testid="account-search-panel">
+      <div className="eyebrow">Account search</div>
+      <h3 className="section-title" style={{ fontSize: '1.2rem' }}>Find accounts</h3>
+      <p className="subtitle">Search by email, account ID, or display name. Minimum 3 characters.</p>
+      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 12 }}>
+        <input
+          className="input"
+          type="text"
+          placeholder="Email, ID, or name..."
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={handleKeyDown}
+          data-testid="account-search-input"
+          style={{ flex: '1 1 200px', minWidth: 200 }}
+        />
+        <select
+          className="select"
+          value={opsStatusFilter}
+          onChange={(e) => setOpsStatusFilter(e.target.value)}
+          data-testid="account-search-ops-status"
+          style={{ minWidth: 120 }}
+        >
+          <option value="">Any status</option>
+          <option value="active">Active</option>
+          <option value="suspended">Suspended</option>
+          <option value="payment_hold">Payment hold</option>
+        </select>
+        <select
+          className="select"
+          value={platformRoleFilter}
+          onChange={(e) => setPlatformRoleFilter(e.target.value)}
+          data-testid="account-search-platform-role"
+          style={{ minWidth: 120 }}
+        >
+          <option value="">Any role</option>
+          <option value="admin">Admin</option>
+          <option value="ops">Ops</option>
+          <option value="parent">Parent</option>
+        </select>
+        <button
+          className="btn secondary"
+          type="button"
+          onClick={handleSearch}
+          disabled={status === 'loading'}
+          data-testid="account-search-submit"
+        >
+          {status === 'loading' ? 'Searching...' : 'Search'}
+        </button>
+      </div>
+      {search.error && <div className="feedback warn" style={{ marginBottom: 8 }}>{search.error}</div>}
+      {search.truncated && <div className="feedback warn" style={{ marginBottom: 8 }}>Results truncated to 50. Refine your search for more specific results.</div>}
+      {status === 'loaded' && results.length === 0 && <p className="small muted">No accounts matched your search.</p>}
+      {results.map((result) => (
+        <AccountSearchResultRow key={result.id} result={result} onSelect={handleSelectAccount} />
+      ))}
+    </section>
+  );
+}
+
 export function AdminAccountsSection({ model, accountDirectory, actions }) {
   return (
     <>
+      <AccountSearchPanel model={model} actions={actions} />
       <AdminAccountRoles model={model} directory={accountDirectory} actions={actions} />
       <AccountOpsMetadataPanel model={model} actions={actions} />
       <AuditLogLookup model={model} />

--- a/tests/worker-admin-account-detail.test.js
+++ b/tests/worker-admin-account-detail.test.js
@@ -1,0 +1,262 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createWorkerRepositoryServer } from './helpers/worker-server.js';
+
+function seedAdultAccount(server, {
+  id,
+  email,
+  displayName,
+  platformRole = 'parent',
+  now = 1,
+  accountType = 'real',
+  demoExpiresAt = null,
+} = {}) {
+  server.DB.db.prepare(`
+    INSERT INTO adult_accounts (
+      id, email, display_name, platform_role, selected_learner_id,
+      created_at, updated_at, repo_revision, account_type, demo_expires_at
+    )
+    VALUES (?, ?, ?, ?, NULL, ?, ?, 0, ?, ?)
+  `).run(id, email, displayName, platformRole, now, now, accountType, demoExpiresAt);
+}
+
+function seedLearner(server, { id, name, yearGroup = '3', createdAt, updatedAt }) {
+  server.DB.db.prepare(`
+    INSERT INTO learner_profiles (id, name, year_group, avatar_color, goal, daily_minutes, created_at, updated_at)
+    VALUES (?, ?, ?, 'blue', 'improve', 15, ?, ?)
+  `).run(id, name, yearGroup, createdAt, updatedAt);
+}
+
+function seedMembership(server, { accountId, learnerId, role = 'owner', now = 1 }) {
+  server.DB.db.prepare(`
+    INSERT INTO account_learner_memberships (account_id, learner_id, role, sort_index, created_at, updated_at)
+    VALUES (?, ?, ?, 0, ?, ?)
+  `).run(accountId, learnerId, role, now, now);
+}
+
+function insertMutationReceipt(server, {
+  accountId,
+  requestId,
+  scopeType,
+  scopeId,
+  mutationKind,
+  response = { ok: true },
+  statusCode = 200,
+  correlationId = null,
+  appliedAt,
+  requestHash = 'hash',
+}) {
+  server.DB.db.prepare(`
+    INSERT INTO mutation_receipts (
+      account_id, request_id, scope_type, scope_id, mutation_kind,
+      request_hash, response_json, status_code, correlation_id, applied_at
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    accountId,
+    requestId,
+    scopeType,
+    scopeId,
+    mutationKind,
+    requestHash,
+    JSON.stringify(response),
+    statusCode,
+    correlationId,
+    appliedAt,
+  );
+}
+
+function insertAccountOpsMetadata(server, {
+  accountId,
+  opsStatus = 'active',
+  planLabel = null,
+  tagsJson = '[]',
+  internalNotes = null,
+  updatedAt,
+  updatedByAccountId = null,
+}) {
+  server.DB.db.prepare(`
+    INSERT INTO account_ops_metadata (
+      account_id, ops_status, plan_label, tags_json, internal_notes,
+      updated_at, updated_by_account_id
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run(accountId, opsStatus, planLabel, tagsJson, internalNotes, updatedAt, updatedByAccountId);
+}
+
+function seedBaseAccounts(server, now) {
+  seedAdultAccount(server, {
+    id: 'adult-admin',
+    email: 'admin@example.com',
+    displayName: 'Admin User',
+    platformRole: 'admin',
+    now,
+  });
+  seedAdultAccount(server, {
+    id: 'adult-ops',
+    email: 'ops@example.com',
+    displayName: 'Ops User',
+    platformRole: 'ops',
+    now,
+  });
+  seedAdultAccount(server, {
+    id: 'adult-parent',
+    email: 'parent@example.com',
+    displayName: 'Parent User',
+    platformRole: 'parent',
+    now,
+  });
+}
+
+test('GET /api/admin/accounts/:id/detail happy path — admin sees full detail', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    const now = Date.now();
+    seedBaseAccounts(server, now);
+    seedLearner(server, {
+      id: 'learner-1',
+      name: 'Child One',
+      yearGroup: '4',
+      createdAt: now,
+      updatedAt: now,
+    });
+    seedMembership(server, {
+      accountId: 'adult-parent',
+      learnerId: 'learner-1',
+      role: 'owner',
+      now,
+    });
+    insertMutationReceipt(server, {
+      accountId: 'adult-parent',
+      requestId: 'req-1',
+      scopeType: 'account',
+      scopeId: 'adult-parent',
+      mutationKind: 'account.update',
+      appliedAt: now,
+    });
+    insertAccountOpsMetadata(server, {
+      accountId: 'adult-parent',
+      opsStatus: 'active',
+      planLabel: 'Standard',
+      tagsJson: JSON.stringify(['vip']),
+      internalNotes: 'Admin-only note',
+      updatedAt: now,
+      updatedByAccountId: 'adult-admin',
+    });
+
+    const response = await server.fetchAs(
+      'adult-admin',
+      'https://repo.test/api/admin/accounts/adult-parent/detail',
+      {},
+      { 'x-ks2-dev-platform-role': 'admin' },
+    );
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.ok, true);
+
+    // Account summary
+    assert.equal(payload.account.id, 'adult-parent');
+    assert.equal(payload.account.email, 'parent@example.com');
+    assert.equal(payload.account.platformRole, 'parent');
+
+    // Learners
+    assert.equal(payload.learners.length, 1);
+    assert.equal(payload.learners[0].id, 'learner-1');
+    assert.equal(payload.learners[0].displayName, 'Child One');
+    assert.equal(payload.learners[0].yearGroup, '4');
+    assert.equal(payload.learners[0].membershipRole, 'owner');
+
+    // Recent mutations
+    assert.equal(payload.recentMutations.length, 1);
+    assert.equal(payload.recentMutations[0].requestId, 'req-1');
+
+    // Ops metadata — admin sees internal notes.
+    assert.equal(payload.opsMetadata.opsStatus, 'active');
+    assert.equal(payload.opsMetadata.planLabel, 'Standard');
+    assert.deepEqual(payload.opsMetadata.tags, ['vip']);
+    assert.equal(payload.opsMetadata.internalNotes, 'Admin-only note');
+  } finally {
+    server.close();
+  }
+});
+
+test('GET /api/admin/accounts/:id/detail — ops sees masked email and no internal notes', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    const now = Date.now();
+    seedBaseAccounts(server, now);
+    insertAccountOpsMetadata(server, {
+      accountId: 'adult-parent',
+      opsStatus: 'suspended',
+      internalNotes: 'Secret ops note',
+      updatedAt: now,
+    });
+
+    const response = await server.fetchAs(
+      'adult-ops',
+      'https://repo.test/api/admin/accounts/adult-parent/detail',
+      {},
+      { 'x-ks2-dev-platform-role': 'ops' },
+    );
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.ok, true);
+
+    // Ops sees masked email.
+    assert.equal(payload.account.email, '***le.com');
+
+    // Ops sees null internal notes.
+    assert.equal(payload.opsMetadata.internalNotes, null);
+    assert.equal(payload.opsMetadata.opsStatus, 'suspended');
+
+    // Ops sees empty denials array.
+    assert.deepEqual(payload.recentDenials, []);
+  } finally {
+    server.close();
+  }
+});
+
+test('GET /api/admin/accounts/:id/detail as parent returns 403', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    const now = Date.now();
+    seedBaseAccounts(server, now);
+
+    const response = await server.fetchAs(
+      'adult-parent',
+      'https://repo.test/api/admin/accounts/adult-parent/detail',
+      {},
+      { 'x-ks2-dev-platform-role': 'parent' },
+    );
+    const payload = await response.json();
+
+    assert.equal(response.status, 403);
+    assert.equal(payload.code, 'admin_hub_forbidden');
+  } finally {
+    server.close();
+  }
+});
+
+test('GET /api/admin/accounts/:id/detail returns 404 for unknown account', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    const now = Date.now();
+    seedBaseAccounts(server, now);
+
+    const response = await server.fetchAs(
+      'adult-admin',
+      'https://repo.test/api/admin/accounts/nonexistent-id/detail',
+      {},
+      { 'x-ks2-dev-platform-role': 'admin' },
+    );
+    const payload = await response.json();
+
+    assert.equal(response.status, 404);
+    assert.equal(payload.code, 'account_not_found');
+  } finally {
+    server.close();
+  }
+});

--- a/tests/worker-admin-account-search.test.js
+++ b/tests/worker-admin-account-search.test.js
@@ -1,0 +1,243 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createWorkerRepositoryServer } from './helpers/worker-server.js';
+
+function seedAdultAccount(server, {
+  id,
+  email,
+  displayName,
+  platformRole = 'parent',
+  now = 1,
+  accountType = 'real',
+  demoExpiresAt = null,
+} = {}) {
+  server.DB.db.prepare(`
+    INSERT INTO adult_accounts (
+      id, email, display_name, platform_role, selected_learner_id,
+      created_at, updated_at, repo_revision, account_type, demo_expires_at
+    )
+    VALUES (?, ?, ?, ?, NULL, ?, ?, 0, ?, ?)
+  `).run(id, email, displayName, platformRole, now, now, accountType, demoExpiresAt);
+}
+
+function insertAccountOpsMetadata(server, {
+  accountId,
+  opsStatus = 'active',
+  planLabel = null,
+  tagsJson = '[]',
+  internalNotes = null,
+  updatedAt,
+  updatedByAccountId = null,
+}) {
+  server.DB.db.prepare(`
+    INSERT INTO account_ops_metadata (
+      account_id, ops_status, plan_label, tags_json, internal_notes,
+      updated_at, updated_by_account_id
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run(accountId, opsStatus, planLabel, tagsJson, internalNotes, updatedAt, updatedByAccountId);
+}
+
+function seedBaseAccounts(server, now) {
+  seedAdultAccount(server, {
+    id: 'adult-admin',
+    email: 'admin@example.com',
+    displayName: 'Admin User',
+    platformRole: 'admin',
+    now,
+  });
+  seedAdultAccount(server, {
+    id: 'adult-ops',
+    email: 'ops@example.com',
+    displayName: 'Ops User',
+    platformRole: 'ops',
+    now,
+  });
+  seedAdultAccount(server, {
+    id: 'adult-parent',
+    email: 'parent@example.com',
+    displayName: 'Parent User',
+    platformRole: 'parent',
+    now,
+  });
+}
+
+test('GET /api/admin/accounts/search happy path — admin sees full email', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    const now = Date.now();
+    seedBaseAccounts(server, now);
+
+    const response = await server.fetchAs(
+      'adult-admin',
+      'https://repo.test/api/admin/accounts/search?q=example',
+      {},
+      { 'x-ks2-dev-platform-role': 'admin' },
+    );
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.ok, true);
+    assert.ok(Array.isArray(payload.results));
+    assert.equal(payload.results.length, 3);
+    // Admin sees full email addresses.
+    const adminResult = payload.results.find((r) => r.id === 'adult-admin');
+    assert.ok(adminResult);
+    assert.equal(adminResult.email, 'admin@example.com');
+  } finally {
+    server.close();
+  }
+});
+
+test('GET /api/admin/accounts/search — ops sees masked email', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    const now = Date.now();
+    seedBaseAccounts(server, now);
+
+    const response = await server.fetchAs(
+      'adult-ops',
+      'https://repo.test/api/admin/accounts/search?q=example',
+      {},
+      { 'x-ks2-dev-platform-role': 'ops' },
+    );
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.results.length, 3);
+    // Ops sees masked email (last 6 chars prefixed with ***).
+    const adminResult = payload.results.find((r) => r.id === 'adult-admin');
+    assert.ok(adminResult);
+    assert.equal(adminResult.email, '***le.com');
+  } finally {
+    server.close();
+  }
+});
+
+test('GET /api/admin/accounts/search rejects query under 3 chars', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    const now = Date.now();
+    seedBaseAccounts(server, now);
+
+    const response = await server.fetchAs(
+      'adult-admin',
+      'https://repo.test/api/admin/accounts/search?q=ab',
+      {},
+      { 'x-ks2-dev-platform-role': 'admin' },
+    );
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.results.length, 0);
+    assert.equal(payload.error, 'Query must be at least 3 characters.');
+  } finally {
+    server.close();
+  }
+});
+
+test('GET /api/admin/accounts/search as parent returns 403', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    const now = Date.now();
+    seedBaseAccounts(server, now);
+
+    const response = await server.fetchAs(
+      'adult-parent',
+      'https://repo.test/api/admin/accounts/search?q=example',
+      {},
+      { 'x-ks2-dev-platform-role': 'parent' },
+    );
+    const payload = await response.json();
+
+    assert.equal(response.status, 403);
+    assert.equal(payload.code, 'admin_hub_forbidden');
+  } finally {
+    server.close();
+  }
+});
+
+test('GET /api/admin/accounts/search filters by ops_status', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    const now = Date.now();
+    seedBaseAccounts(server, now);
+    insertAccountOpsMetadata(server, {
+      accountId: 'adult-parent',
+      opsStatus: 'suspended',
+      updatedAt: now,
+    });
+
+    const response = await server.fetchAs(
+      'adult-admin',
+      'https://repo.test/api/admin/accounts/search?q=example&ops_status=suspended',
+      {},
+      { 'x-ks2-dev-platform-role': 'admin' },
+    );
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.results.length, 1);
+    assert.equal(payload.results[0].id, 'adult-parent');
+    assert.equal(payload.results[0].opsStatus, 'suspended');
+  } finally {
+    server.close();
+  }
+});
+
+test('GET /api/admin/accounts/search filters by platform_role', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    const now = Date.now();
+    seedBaseAccounts(server, now);
+
+    const response = await server.fetchAs(
+      'adult-admin',
+      'https://repo.test/api/admin/accounts/search?q=example&platform_role=ops',
+      {},
+      { 'x-ks2-dev-platform-role': 'admin' },
+    );
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.results.length, 1);
+    assert.equal(payload.results[0].id, 'adult-ops');
+  } finally {
+    server.close();
+  }
+});
+
+test('GET /api/admin/accounts/search excludes demo accounts', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    const now = Date.now();
+    seedBaseAccounts(server, now);
+    seedAdultAccount(server, {
+      id: 'demo-user',
+      email: 'demo-example@test.com',
+      displayName: 'Demo Example',
+      platformRole: 'parent',
+      now,
+      accountType: 'demo',
+      demoExpiresAt: now + 60_000,
+    });
+
+    const response = await server.fetchAs(
+      'adult-admin',
+      'https://repo.test/api/admin/accounts/search?q=example',
+      {},
+      { 'x-ks2-dev-platform-role': 'admin' },
+    );
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    // Should only see the 3 real accounts, not the demo.
+    assert.equal(payload.results.length, 3);
+    assert.ok(!payload.results.find((r) => r.id === 'demo-user'));
+  } finally {
+    server.close();
+  }
+});

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -1741,6 +1741,39 @@ export function createWorkerApp({
           return json({ ok: true, ...result });
         }
 
+        // U7 (P3): account search. GET with query-string filters.
+        // Admin/ops gated via `searchAccounts` which calls
+        // `assertAdminHubActor` internally. 3-char minimum query.
+        if (url.pathname === '/api/admin/accounts/search' && request.method === 'GET') {
+          requireSameOrigin(request, env);
+          const q = url.searchParams.get('q') || '';
+          const opsStatusFilter = url.searchParams.get('ops_status') || null;
+          const platformRoleFilter = url.searchParams.get('platform_role') || null;
+          const searchLimit = Number(url.searchParams.get('limit')) || undefined;
+          const result = await repository.searchAccounts(session.accountId, {
+            query: q,
+            opsStatus: opsStatusFilter,
+            platformRole: platformRoleFilter,
+            limit: searchLimit,
+          });
+          return json({ ok: true, ...result });
+        }
+
+        // U7 (P3): account detail. Parameterised GET for a single account.
+        // Admin/ops gated via `readAccountDetail` which calls
+        // `assertAdminHubActor` internally. 404 for unknown account.
+        {
+          const accountDetailMatch = /^\/api\/admin\/accounts\/([^/]+)\/detail$/.exec(url.pathname);
+          if (accountDetailMatch && request.method === 'GET') {
+            requireSameOrigin(request, env);
+            const targetAccountId = decodeURIComponent(accountDetailMatch[1]);
+            const result = await repository.readAccountDetail(session.accountId, {
+              targetAccountId,
+            });
+            return json({ ok: true, ...result });
+          }
+        }
+
         // U9 (P3): cross-subject content overview. Read-only narrow GET
         // matching the existing /api/admin/ops/* panel-per-route pattern.
         // Admin-gated via `readSubjectContentOverview` which calls

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -3010,6 +3010,320 @@ async function readAdminRequestDenials(db, {
   }
 }
 
+// ---------------------------------------------------------------------------
+// U7 (P3): Account search + detail read helpers.
+// Search: queries adult_accounts by email/ID/display_name substring match.
+//   - 3-char minimum query length to avoid full-table scans.
+//   - Admin sees full email; ops sees last 6 chars only.
+//   - Bounded to 50 results, filterable by ops_status and platform_role.
+// Detail: aggregates account summary, linked learners, recent errors (10),
+//   recent denials (10), recent mutations (10), and ops metadata for a
+//   single account.  Admin sees full detail; ops sees masked email, no
+//   internal notes.
+// ---------------------------------------------------------------------------
+
+const ACCOUNT_SEARCH_MIN_QUERY_LENGTH = 3;
+const ACCOUNT_SEARCH_DEFAULT_LIMIT = 50;
+const ACCOUNT_SEARCH_MAX_LIMIT = 50;
+const ACCOUNT_DETAIL_SUB_LIMIT = 10;
+
+function maskEmailLastN(email, lastN = 6) {
+  if (typeof email !== 'string' || !email) return null;
+  return email.length <= lastN ? email : `***${email.slice(-lastN)}`;
+}
+
+async function searchAccounts(db, {
+  now,
+  actorAccountId,
+  actor: preResolvedActor = null,
+  query = '',
+  opsStatus = null,
+  platformRole = null,
+  limit = ACCOUNT_SEARCH_DEFAULT_LIMIT,
+} = {}) {
+  const actor = preResolvedActor || await assertAdminHubActor(db, actorAccountId);
+  const actorPlatformRole = normalisePlatformRole(actor?.platform_role);
+  const nowTs = Number.isFinite(Number(now)) ? Number(now) : Date.now();
+  const isAdmin = actorPlatformRole === 'admin';
+  const safeLimit = Math.max(1, Math.min(ACCOUNT_SEARCH_MAX_LIMIT, Number(limit) || ACCOUNT_SEARCH_DEFAULT_LIMIT));
+
+  const trimmedQuery = typeof query === 'string' ? query.trim() : '';
+  if (trimmedQuery.length < ACCOUNT_SEARCH_MIN_QUERY_LENGTH) {
+    return {
+      generatedAt: nowTs,
+      results: [],
+      truncated: false,
+      error: 'Query must be at least 3 characters.',
+    };
+  }
+
+  const whereClauses = [
+    '(a.email LIKE ? OR a.id LIKE ? OR a.display_name LIKE ?)',
+  ];
+  const likePattern = `%${trimmedQuery}%`;
+  const whereParams = [likePattern, likePattern, likePattern];
+
+  if (typeof opsStatus === 'string' && opsStatus) {
+    whereClauses.push('COALESCE(om.ops_status, \'active\') = ?');
+    whereParams.push(opsStatus);
+  }
+  if (typeof platformRole === 'string' && platformRole) {
+    whereClauses.push('a.platform_role = ?');
+    whereParams.push(platformRole);
+  }
+
+  // Exclude demo accounts from search results — mirrors the ops metadata
+  // directory and the KPI counters (demo accounts have their own panel).
+  whereClauses.push('COALESCE(a.account_type, \'real\') <> \'demo\'');
+
+  const whereSql = whereClauses.join(' AND ');
+
+  try {
+    const rows = await all(db, `
+      SELECT
+        a.id,
+        a.email,
+        a.display_name,
+        a.platform_role,
+        a.created_at,
+        a.updated_at,
+        COALESCE(om.ops_status, 'active') AS ops_status,
+        om.plan_label,
+        COUNT(DISTINCT m.learner_id) AS learner_count
+      FROM adult_accounts a
+      LEFT JOIN account_ops_metadata om ON om.account_id = a.id
+      LEFT JOIN account_learner_memberships m ON m.account_id = a.id
+      WHERE ${whereSql}
+      GROUP BY a.id
+      ORDER BY a.updated_at DESC, a.id ASC
+      LIMIT ?
+    `, [...whereParams, safeLimit + 1]);
+
+    const truncated = rows.length > safeLimit;
+    const displayRows = truncated ? rows.slice(0, safeLimit) : rows;
+
+    return {
+      generatedAt: nowTs,
+      results: displayRows.map((row) => ({
+        id: typeof row?.id === 'string' ? row.id : '',
+        email: isAdmin
+          ? (typeof row?.email === 'string' ? row.email : null)
+          : maskEmailLastN(row?.email),
+        displayName: typeof row?.display_name === 'string' ? row.display_name : null,
+        platformRole: normalisePlatformRole(row?.platform_role),
+        opsStatus: typeof row?.ops_status === 'string' ? row.ops_status : 'active',
+        planLabel: typeof row?.plan_label === 'string' ? row.plan_label : null,
+        learnerCount: Number(row?.learner_count) || 0,
+        createdAt: Number(row?.created_at) || 0,
+        updatedAt: Number(row?.updated_at) || 0,
+      })),
+      truncated,
+    };
+  } catch (error) {
+    if (isMissingTableError(error, 'account_ops_metadata')) {
+      // Soft-fail: fall back to search without ops_metadata join.
+      const fallbackRows = await all(db, `
+        SELECT
+          a.id,
+          a.email,
+          a.display_name,
+          a.platform_role,
+          a.created_at,
+          a.updated_at,
+          'active' AS ops_status,
+          NULL AS plan_label,
+          COUNT(DISTINCT m.learner_id) AS learner_count
+        FROM adult_accounts a
+        LEFT JOIN account_learner_memberships m ON m.account_id = a.id
+        WHERE (a.email LIKE ? OR a.id LIKE ? OR a.display_name LIKE ?)
+          AND COALESCE(a.account_type, 'real') <> 'demo'
+        GROUP BY a.id
+        ORDER BY a.updated_at DESC, a.id ASC
+        LIMIT ?
+      `, [likePattern, likePattern, likePattern, safeLimit]);
+      return {
+        generatedAt: nowTs,
+        results: fallbackRows.map((row) => ({
+          id: typeof row?.id === 'string' ? row.id : '',
+          email: isAdmin
+            ? (typeof row?.email === 'string' ? row.email : null)
+            : maskEmailLastN(row?.email),
+          displayName: typeof row?.display_name === 'string' ? row.display_name : null,
+          platformRole: normalisePlatformRole(row?.platform_role),
+          opsStatus: 'active',
+          planLabel: null,
+          learnerCount: Number(row?.learner_count) || 0,
+          createdAt: Number(row?.created_at) || 0,
+          updatedAt: Number(row?.updated_at) || 0,
+        })),
+        truncated: false,
+      };
+    }
+    throw error;
+  }
+}
+
+async function readAccountDetail(db, {
+  now,
+  actorAccountId,
+  targetAccountId,
+  actor: preResolvedActor = null,
+} = {}) {
+  const actor = preResolvedActor || await assertAdminHubActor(db, actorAccountId);
+  const actorPlatformRole = normalisePlatformRole(actor?.platform_role);
+  const nowTs = Number.isFinite(Number(now)) ? Number(now) : Date.now();
+  const isAdmin = actorPlatformRole === 'admin';
+
+  if (typeof targetAccountId !== 'string' || !targetAccountId) {
+    throw new NotFoundError('Account not found.', { code: 'account_not_found' });
+  }
+
+  // 1. Account summary
+  const account = await first(db, `
+    SELECT
+      a.id, a.email, a.display_name, a.platform_role, a.created_at, a.updated_at,
+      a.account_type, a.repo_revision
+    FROM adult_accounts a
+    WHERE a.id = ?
+  `, [targetAccountId]);
+
+  if (!account) {
+    throw new NotFoundError('Account not found.', { code: 'account_not_found' });
+  }
+
+  // 2. Linked learners
+  const learners = await all(db, `
+    SELECT
+      l.id, l.name, l.year_group, l.created_at, l.updated_at,
+      m.role AS membership_role
+    FROM account_learner_memberships m
+    JOIN learner_profiles l ON l.id = m.learner_id
+    WHERE m.account_id = ?
+    ORDER BY l.updated_at DESC
+  `, [targetAccountId]);
+
+  // 3. Recent errors (linked by account_id in ops_error_events)
+  let recentErrors = [];
+  try {
+    recentErrors = await all(db, `
+      SELECT id, fingerprint, error_kind, message_first_line, route_name,
+             first_seen, last_seen, occurrence_count, status
+      FROM ops_error_events
+      WHERE account_id = ?
+      ORDER BY last_seen DESC
+      LIMIT ?
+    `, [targetAccountId, ACCOUNT_DETAIL_SUB_LIMIT]);
+  } catch (error) {
+    if (!isMissingTableError(error, 'ops_error_events')) throw error;
+  }
+
+  // 4. Recent denials (linked by account_id in admin_request_denials)
+  let recentDenials = [];
+  try {
+    recentDenials = await all(db, `
+      SELECT id, denied_at, denial_reason, route_name
+      FROM admin_request_denials
+      WHERE account_id = ?
+      ORDER BY denied_at DESC
+      LIMIT ?
+    `, [targetAccountId, ACCOUNT_DETAIL_SUB_LIMIT]);
+  } catch (error) {
+    if (!isMissingTableError(error, 'admin_request_denials')) throw error;
+  }
+
+  // 5. Recent mutations
+  const recentMutations = await all(db, `
+    SELECT request_id, mutation_kind, scope_type, scope_id, status_code, applied_at
+    FROM mutation_receipts
+    WHERE account_id = ?
+    ORDER BY applied_at DESC
+    LIMIT ?
+  `, [targetAccountId, ACCOUNT_DETAIL_SUB_LIMIT]);
+
+  // 6. Ops metadata
+  let opsMetadata = null;
+  try {
+    opsMetadata = await first(db, `
+      SELECT ops_status, plan_label, tags_json, internal_notes,
+             updated_at, updated_by_account_id, row_version
+      FROM account_ops_metadata
+      WHERE account_id = ?
+    `, [targetAccountId]);
+  } catch (error) {
+    if (!isMissingTableError(error, 'account_ops_metadata')) throw error;
+  }
+
+  return {
+    generatedAt: nowTs,
+    account: {
+      id: account.id,
+      email: isAdmin
+        ? (typeof account.email === 'string' ? account.email : null)
+        : maskEmailLastN(account.email),
+      displayName: typeof account.display_name === 'string' ? account.display_name : null,
+      platformRole: normalisePlatformRole(account.platform_role),
+      accountType: account.account_type || 'real',
+      repoRevision: Number(account.repo_revision) || 0,
+      createdAt: Number(account.created_at) || 0,
+      updatedAt: Number(account.updated_at) || 0,
+    },
+    learners: learners.map((l) => ({
+      id: l.id,
+      displayName: typeof l.name === 'string' ? l.name : null,
+      yearGroup: l.year_group ?? null,
+      membershipRole: l.membership_role || 'owner',
+      createdAt: Number(l.created_at) || 0,
+      updatedAt: Number(l.updated_at) || 0,
+    })),
+    recentErrors: recentErrors.map((e) => ({
+      id: e.id,
+      fingerprint: e.fingerprint,
+      errorKind: e.error_kind,
+      messageFirstLine: e.message_first_line,
+      routeName: e.route_name,
+      firstSeen: Number(e.first_seen) || 0,
+      lastSeen: Number(e.last_seen) || 0,
+      occurrenceCount: Number(e.occurrence_count) || 0,
+      status: e.status,
+    })),
+    recentDenials: isAdmin ? recentDenials.map((d) => ({
+      id: d.id,
+      deniedAt: Number(d.denied_at) || 0,
+      denialReason: d.denial_reason,
+      routeName: d.route_name,
+    })) : [],
+    recentMutations: recentMutations.map((m) => ({
+      requestId: m.request_id,
+      mutationKind: m.mutation_kind,
+      scopeType: m.scope_type,
+      scopeId: m.scope_id,
+      statusCode: m.status_code,
+      appliedAt: Number(m.applied_at) || 0,
+    })),
+    opsMetadata: opsMetadata ? {
+      opsStatus: opsMetadata.ops_status || 'active',
+      planLabel: typeof opsMetadata.plan_label === 'string' ? opsMetadata.plan_label : null,
+      tags: normaliseTagsJson(opsMetadata.tags_json),
+      internalNotes: isAdmin
+        ? (typeof opsMetadata.internal_notes === 'string' ? opsMetadata.internal_notes : null)
+        : null,
+      updatedAt: Number(opsMetadata.updated_at) || 0,
+      updatedByAccountId: typeof opsMetadata.updated_by_account_id === 'string'
+        ? opsMetadata.updated_by_account_id
+        : null,
+      rowVersion: Math.max(0, Number(opsMetadata.row_version) || 0),
+    } : {
+      opsStatus: 'active',
+      planLabel: null,
+      tags: [],
+      internalNotes: null,
+      updatedAt: 0,
+      updatedByAccountId: null,
+      rowVersion: 0,
+    },
+  };
+}
+
 async function bumpAdminKpiMetric(db, key, nowTs, delta = 1) {
   if (!(typeof key === 'string' && key)) return;
   const resolvedDelta = Number.isFinite(Number(delta)) ? Number(delta) : 1;
@@ -9463,6 +9777,30 @@ export function createWorkerRepository({ env = {}, now = Date.now, capacity = nu
     },
     async listAdminAccounts(accountId) {
       return listAccountDirectory(db, accountId);
+    },
+    // U7 (P3): account search — admin/ops gated via assertAdminHubActor.
+    async searchAccounts(accountId, {
+      query = '',
+      opsStatus = null,
+      platformRole = null,
+      limit = ACCOUNT_SEARCH_DEFAULT_LIMIT,
+    } = {}) {
+      return searchAccounts(db, {
+        now: nowFactory(),
+        actorAccountId: accountId,
+        query,
+        opsStatus,
+        platformRole,
+        limit,
+      });
+    },
+    // U7 (P3): account detail — admin/ops gated via assertAdminHubActor.
+    async readAccountDetail(accountId, { targetAccountId } = {}) {
+      return readAccountDetail(db, {
+        now: nowFactory(),
+        actorAccountId: accountId,
+        targetAccountId,
+      });
     },
     async updateAdminAccountRole(accountId, { targetAccountId, platformRole, expectedRepoRevision = null, requestId, correlationId = null } = {}) {
       return updateManagedAccountRole(db, {


### PR DESCRIPTION
## Summary
- **Search endpoint** (`GET /api/admin/accounts/search?q=term&ops_status=X&platform_role=Y&limit=50`): 3-char minimum query, searches email/ID/display_name with optional filters, admin sees full email, ops sees masked (last 6 chars), excludes demo accounts, bounded to 50 results
- **Detail endpoint** (`GET /api/admin/accounts/:id/detail`): aggregates account summary, linked learners, recent errors (10), recent denials (10), recent mutations (10), and ops metadata; admin sees full detail, ops sees masked email + no internal notes + no denials; 404 for unknown accounts
- **UI**: `AccountSearchPanel` with search input, ops_status/platform_role filter dropdowns, results table with click-to-detail, detail panel with Debug Bundle deep-link; content-free leaf normaliser at `src/platform/hubs/admin-account-search.js`

## Files changed
| File | Change |
|------|--------|
| `worker/src/repository.js` | `searchAccounts`, `readAccountDetail` helpers + `maskEmailLastN` |
| `worker/src/app.js` | Search + detail route handlers |
| `src/surfaces/hubs/AdminAccountsSection.jsx` | Search panel + detail panel UI |
| `src/platform/hubs/admin-account-search.js` | Content-free leaf normalisers (new) |
| `tests/worker-admin-account-search.test.js` | 7 tests (new) |
| `tests/worker-admin-account-detail.test.js` | 4 tests (new) |

## Test plan
- [x] 7 search tests pass: happy path admin, ops masking, 3-char minimum, 403 for parent, ops_status filter, platform_role filter, demo exclusion
- [x] 4 detail tests pass: happy path admin full detail, ops masking + redaction, 403 for parent, 404 for unknown
- [x] 18 existing admin-ops-read tests still pass (zero regressions)