### PR TITLE
feat(admin): U6 Debug Bundle — Worker endpoint + client panel

### DIFF
--- a/src/platform/hubs/admin-debug-bundle-panel.js
+++ b/src/platform/hubs/admin-debug-bundle-panel.js
@@ -1,0 +1,189 @@
+// U6 (P3): Debug Bundle client panel — content-free leaf.
+//
+// Normalises the Worker debug-bundle response into the shape the
+// AdminDebuggingSection panel expects. This module MUST NOT import
+// subject content datasets or any module that transitively pulls in
+// spelling / grammar / punctuation content bundles. The audit gate
+// enforces this invariant.
+//
+// The normaliser is pure: it accepts the bundle payload from the worker
+// endpoint and returns a rendering-ready object. No side effects, no
+// storage, no fetch.
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function safeNonNegativeInt(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric >= 0 ? numeric : 0;
+}
+
+function safeString(value, fallback) {
+  return typeof value === 'string' && value ? value : (fallback || '');
+}
+
+// ---------- Normalisation ----------
+
+export function normaliseDebugBundleResponse(rawValue) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  const bundle = isPlainObject(raw.bundle) ? raw.bundle : {};
+  return {
+    ok: raw.ok === true,
+    bundle: normaliseBundle(bundle),
+    humanSummary: safeString(raw.humanSummary, ''),
+    actorRole: safeString(raw.actorRole, 'ops'),
+    canExportJson: raw.canExportJson === true,
+  };
+}
+
+export function normaliseBundle(rawValue) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  return {
+    generatedAt: safeNonNegativeInt(raw.generatedAt),
+    query: normaliseQuery(raw.query),
+    buildHash: safeString(raw.buildHash, null),
+    accountSummary: raw.accountSummary != null ? normaliseAccountSummary(raw.accountSummary) : null,
+    linkedLearners: Array.isArray(raw.linkedLearners) ? raw.linkedLearners.map(normaliseLearner) : [],
+    recentErrors: Array.isArray(raw.recentErrors) ? raw.recentErrors.map(normaliseError) : [],
+    errorOccurrences: Array.isArray(raw.errorOccurrences) ? raw.errorOccurrences.map(normaliseOccurrence) : [],
+    recentDenials: Array.isArray(raw.recentDenials) ? raw.recentDenials.map(normaliseDenial) : [],
+    recentMutations: Array.isArray(raw.recentMutations) ? raw.recentMutations.map(normaliseMutation) : [],
+    capacityState: Array.isArray(raw.capacityState) ? raw.capacityState.map(normaliseCapacity) : [],
+  };
+}
+
+function normaliseQuery(rawValue) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  return {
+    accountId: typeof raw.accountId === 'string' ? raw.accountId : null,
+    learnerId: typeof raw.learnerId === 'string' ? raw.learnerId : null,
+    timeFrom: safeNonNegativeInt(raw.timeFrom),
+    timeTo: safeNonNegativeInt(raw.timeTo),
+    errorFingerprint: typeof raw.errorFingerprint === 'string' ? raw.errorFingerprint : null,
+    route: typeof raw.route === 'string' ? raw.route : null,
+  };
+}
+
+function normaliseAccountSummary(rawValue) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  return {
+    accountId: safeString(raw.accountId, ''),
+    email: typeof raw.email === 'string' ? raw.email : null,
+    displayName: typeof raw.displayName === 'string' ? raw.displayName : null,
+    platformRole: safeString(raw.platformRole, 'unknown'),
+    accountType: safeString(raw.accountType, 'real'),
+    createdAt: safeNonNegativeInt(raw.createdAt),
+    updatedAt: safeNonNegativeInt(raw.updatedAt),
+  };
+}
+
+function normaliseLearner(rawValue) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  return {
+    learnerId: safeString(raw.learnerId, ''),
+    learnerName: typeof raw.learnerName === 'string' ? raw.learnerName : null,
+    yearGroup: typeof raw.yearGroup === 'string' ? raw.yearGroup : null,
+    membershipRole: typeof raw.membershipRole === 'string' ? raw.membershipRole : null,
+    accessMode: typeof raw.accessMode === 'string' ? raw.accessMode : null,
+  };
+}
+
+function normaliseError(rawValue) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  return {
+    id: safeString(raw.id, ''),
+    fingerprint: safeString(raw.fingerprint, ''),
+    errorKind: typeof raw.errorKind === 'string' ? raw.errorKind : null,
+    messageFirstLine: typeof raw.messageFirstLine === 'string' ? raw.messageFirstLine : null,
+    firstFrame: typeof raw.firstFrame === 'string' ? raw.firstFrame : null,
+    routeName: typeof raw.routeName === 'string' ? raw.routeName : null,
+    accountId: typeof raw.accountId === 'string' ? raw.accountId : null,
+    firstSeen: safeNonNegativeInt(raw.firstSeen),
+    lastSeen: safeNonNegativeInt(raw.lastSeen),
+    occurrenceCount: Math.max(1, safeNonNegativeInt(raw.occurrenceCount)),
+    status: safeString(raw.status, 'open'),
+  };
+}
+
+function normaliseOccurrence(rawValue) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  return {
+    id: safeString(raw.id, ''),
+    eventId: typeof raw.eventId === 'string' ? raw.eventId : null,
+    occurredAt: safeNonNegativeInt(raw.occurredAt),
+    release: typeof raw.release === 'string' ? raw.release : null,
+    routeName: typeof raw.routeName === 'string' ? raw.routeName : null,
+    accountId: typeof raw.accountId === 'string' ? raw.accountId : null,
+  };
+}
+
+function normaliseDenial(rawValue) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  return {
+    id: safeString(raw.id, ''),
+    deniedAt: safeNonNegativeInt(raw.deniedAt),
+    denialReason: typeof raw.denialReason === 'string' ? raw.denialReason : null,
+    routeName: typeof raw.routeName === 'string' ? raw.routeName : null,
+    accountId: typeof raw.accountId === 'string' ? raw.accountId : null,
+    isDemo: raw.isDemo === true,
+    release: typeof raw.release === 'string' ? raw.release : null,
+  };
+}
+
+function normaliseMutation(rawValue) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  return {
+    requestId: typeof raw.requestId === 'string' ? raw.requestId : null,
+    mutationKind: typeof raw.mutationKind === 'string' ? raw.mutationKind : null,
+    scopeType: typeof raw.scopeType === 'string' ? raw.scopeType : null,
+    scopeId: typeof raw.scopeId === 'string' ? raw.scopeId : null,
+    appliedAt: safeNonNegativeInt(raw.appliedAt),
+    accountId: typeof raw.accountId === 'string' ? raw.accountId : null,
+  };
+}
+
+function normaliseCapacity(rawValue) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  return {
+    metricKey: typeof raw.metricKey === 'string' ? raw.metricKey : null,
+    metricCount: safeNonNegativeInt(raw.metricCount),
+    updatedAt: safeNonNegativeInt(raw.updatedAt),
+  };
+}
+
+// ---------- Section labels ----------
+
+export const BUNDLE_SECTION_LABELS = {
+  accountSummary: 'Account Summary',
+  linkedLearners: 'Linked Learners',
+  recentErrors: 'Recent Errors',
+  errorOccurrences: 'Error Occurrences',
+  recentDenials: 'Recent Denials',
+  recentMutations: 'Recent Mutations',
+  capacityState: 'Capacity Metrics',
+};
+
+export const BUNDLE_SECTIONS = Object.keys(BUNDLE_SECTION_LABELS);
+
+// ---------- Section emptiness check ----------
+
+export function isSectionEmpty(bundle, sectionKey) {
+  const value = bundle?.[sectionKey];
+  if (value == null) return true;
+  if (Array.isArray(value)) return value.length === 0;
+  if (typeof value === 'object') return Object.keys(value).length === 0;
+  return false;
+}
+
+// ---------- Format timestamp for display ----------
+
+export function formatBundleTimestamp(ts) {
+  const numeric = Number(ts);
+  if (!Number.isFinite(numeric) || numeric <= 0) return '—';
+  try {
+    return new Date(numeric).toISOString().replace('T', ' ').replace(/\.000Z$/, ' UTC');
+  } catch {
+    return '—';
+  }
+}

--- a/src/surfaces/hubs/AdminDebuggingSection.jsx
+++ b/src/surfaces/hubs/AdminDebuggingSection.jsx
@@ -3,10 +3,17 @@ import { formatTimestamp, isBlocked } from './hub-utils.js';
 import { PanelHeader } from './admin-panel-header.jsx';
 import { formatOccurrenceTimestamp } from '../../platform/hubs/admin-occurrence-timeline.js';
 import { normaliseDenialEntry } from '../../platform/hubs/admin-denial-panel.js';
+import {
+  BUNDLE_SECTION_LABELS,
+  BUNDLE_SECTIONS,
+  isSectionEmpty,
+  formatBundleTimestamp,
+} from '../../platform/hubs/admin-debug-bundle-panel.js';
 
 // U4+U5: Debugging & Logs section — error log centre + learner support /
 // diagnostics panels. Extracted from AdminHubSurface.jsx.
 // U8 (P3): + denial log panel below error centre.
+// U6 (P3): + debug bundle panel below denial log.
 
 const ERROR_EVENT_STATUS_OPTIONS = ['open', 'investigating', 'resolved', 'ignored'];
 
@@ -650,11 +657,292 @@ function DenialLogPanel({ model, actions }) {
   );
 }
 
+// ---------------------------------------------------------------------------
+// U6 (P3): Debug Bundle panel — evidence packet generator.
+// Search form + generate button + collapsible result sections.
+// JSON copy is admin-only (R4 ops export restriction).
+// ---------------------------------------------------------------------------
+
+function DebugBundleSectionTable({ label, rows, columns }) {
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return <p className="small muted">No data.</p>;
+  }
+  return (
+    <table className="small" style={{ width: '100%', borderCollapse: 'collapse', marginTop: 4 }}>
+      <thead>
+        <tr>
+          {columns.map((col) => (
+            <th key={col.key} style={{ textAlign: 'left', padding: '2px 6px' }}>{col.label}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row, idx) => (
+          <tr key={row.id || row.requestId || idx}>
+            {columns.map((col) => (
+              <td key={col.key} className="muted" style={{ padding: '2px 6px', fontFamily: col.mono ? 'monospace' : 'inherit' }}>
+                {col.render ? col.render(row) : (row[col.key] != null ? String(row[col.key]) : '—')}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function DebugBundleResult({ bundleData }) {
+  if (!bundleData) return null;
+  const bundle = bundleData.bundle || {};
+
+  return (
+    <div data-testid="debug-bundle-result" style={{ marginTop: 12 }}>
+      <div className="small muted" style={{ marginBottom: 8 }}>
+        Generated: {formatBundleTimestamp(bundle.generatedAt)}
+        {bundle.buildHash ? ` · Build: ${String(bundle.buildHash).slice(0, 7)}` : ''}
+      </div>
+
+      {BUNDLE_SECTIONS.map((sectionKey) => {
+        const label = BUNDLE_SECTION_LABELS[sectionKey];
+        const isEmpty = isSectionEmpty(bundle, sectionKey);
+        const value = bundle[sectionKey];
+        return (
+          <details key={sectionKey} data-testid={`bundle-section-${sectionKey}`} style={{ marginBottom: 8 }}>
+            <summary className="small" style={{ cursor: 'pointer', fontWeight: 600 }}>
+              {label} {isEmpty ? <span className="muted">(empty)</span> : null}
+            </summary>
+            <div style={{ padding: '4px 0 4px 12px' }}>
+              {sectionKey === 'accountSummary' && value ? (
+                <dl className="small" style={{ display: 'grid', gridTemplateColumns: '120px 1fr', rowGap: 2 }}>
+                  <dt className="muted">Account ID</dt><dd>{value.accountId || '—'}</dd>
+                  <dt className="muted">Email</dt><dd>{value.email || '—'}</dd>
+                  <dt className="muted">Name</dt><dd>{value.displayName || '—'}</dd>
+                  <dt className="muted">Role</dt><dd>{value.platformRole || '—'}</dd>
+                  <dt className="muted">Type</dt><dd>{value.accountType || '—'}</dd>
+                </dl>
+              ) : null}
+              {sectionKey === 'linkedLearners' ? (
+                <DebugBundleSectionTable
+                  label={label}
+                  rows={value}
+                  columns={[
+                    { key: 'learnerName', label: 'Name' },
+                    { key: 'learnerId', label: 'ID', mono: true },
+                    { key: 'yearGroup', label: 'Year' },
+                    { key: 'membershipRole', label: 'Role' },
+                  ]}
+                />
+              ) : null}
+              {sectionKey === 'recentErrors' ? (
+                <DebugBundleSectionTable
+                  label={label}
+                  rows={value}
+                  columns={[
+                    { key: 'status', label: 'Status' },
+                    { key: 'errorKind', label: 'Kind' },
+                    { key: 'messageFirstLine', label: 'Message' },
+                    { key: 'occurrenceCount', label: 'Count' },
+                    { key: 'routeName', label: 'Route' },
+                  ]}
+                />
+              ) : null}
+              {sectionKey === 'errorOccurrences' ? (
+                <DebugBundleSectionTable
+                  label={label}
+                  rows={value}
+                  columns={[
+                    { key: 'occurredAt', label: 'When', render: (r) => formatBundleTimestamp(r.occurredAt) },
+                    { key: 'routeName', label: 'Route' },
+                    { key: 'release', label: 'Release', mono: true },
+                  ]}
+                />
+              ) : null}
+              {sectionKey === 'recentDenials' ? (
+                <DebugBundleSectionTable
+                  label={label}
+                  rows={value}
+                  columns={[
+                    { key: 'deniedAt', label: 'When', render: (r) => formatBundleTimestamp(r.deniedAt) },
+                    { key: 'denialReason', label: 'Reason' },
+                    { key: 'routeName', label: 'Route' },
+                  ]}
+                />
+              ) : null}
+              {sectionKey === 'recentMutations' ? (
+                <DebugBundleSectionTable
+                  label={label}
+                  rows={value}
+                  columns={[
+                    { key: 'appliedAt', label: 'When', render: (r) => formatBundleTimestamp(r.appliedAt) },
+                    { key: 'mutationKind', label: 'Kind' },
+                    { key: 'scopeType', label: 'Scope' },
+                    { key: 'scopeId', label: 'Scope ID', mono: true },
+                  ]}
+                />
+              ) : null}
+              {sectionKey === 'capacityState' ? (
+                <DebugBundleSectionTable
+                  label={label}
+                  rows={value}
+                  columns={[
+                    { key: 'metricKey', label: 'Metric' },
+                    { key: 'metricCount', label: 'Count' },
+                    { key: 'updatedAt', label: 'Updated', render: (r) => formatBundleTimestamp(r.updatedAt) },
+                  ]}
+                />
+              ) : null}
+            </div>
+          </details>
+        );
+      })}
+    </div>
+  );
+}
+
+function DebugBundlePanel({ model, actions }) {
+  const debugBundle = model?.debugBundle || {};
+  const bundleData = debugBundle.data || null;
+  const loading = debugBundle.loading === true;
+  const error = debugBundle.error || null;
+  const canExportJson = bundleData?.canExportJson === true;
+  const humanSummary = bundleData?.humanSummary || '';
+
+  const [accountId, setAccountId] = React.useState('');
+  const [learnerId, setLearnerId] = React.useState('');
+  const [timeFrom, setTimeFrom] = React.useState('');
+  const [timeTo, setTimeTo] = React.useState('');
+  const [fingerprint, setFingerprint] = React.useState('');
+  const [routeFilter, setRouteFilter] = React.useState('');
+  const [copyFeedback, setCopyFeedback] = React.useState('');
+
+  // R7: pre-fill from error drawer link.
+  const prefill = debugBundle.prefill || null;
+  React.useEffect(() => {
+    if (prefill?.fingerprint) setFingerprint(prefill.fingerprint);
+    if (prefill?.accountId) setAccountId(prefill.accountId);
+    if (prefill?.route) setRouteFilter(prefill.route);
+  }, [prefill?.fingerprint, prefill?.accountId, prefill?.route]);
+
+  const generateBundle = () => {
+    const payload = {};
+    if (accountId.trim()) payload.account_id = accountId.trim();
+    if (learnerId.trim()) payload.learner_id = learnerId.trim();
+    const fromTs = Date.parse(timeFrom);
+    if (Number.isFinite(fromTs)) payload.time_from = fromTs;
+    const toTs = Date.parse(timeTo);
+    if (Number.isFinite(toTs)) payload.time_to = toTs;
+    if (fingerprint.trim()) payload.error_fingerprint = fingerprint.trim();
+    if (routeFilter.trim()) payload.route = routeFilter.trim();
+    actions.dispatch('admin-debug-bundle-generate', payload);
+  };
+
+  const copyJson = async () => {
+    if (!canExportJson || !bundleData?.bundle) return;
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(bundleData.bundle, null, 2));
+      setCopyFeedback('JSON copied');
+      setTimeout(() => setCopyFeedback(''), 2000);
+    } catch {
+      setCopyFeedback('Copy failed');
+      setTimeout(() => setCopyFeedback(''), 2000);
+    }
+  };
+
+  const copySummary = async () => {
+    if (!humanSummary) return;
+    try {
+      await navigator.clipboard.writeText(humanSummary);
+      setCopyFeedback('Summary copied');
+      setTimeout(() => setCopyFeedback(''), 2000);
+    } catch {
+      setCopyFeedback('Copy failed');
+      setTimeout(() => setCopyFeedback(''), 2000);
+    }
+  };
+
+  return (
+    <section className="card" style={{ marginBottom: 20 }} data-testid="debug-bundle-panel">
+      <PanelHeader
+        eyebrow="Debug tools"
+        title="Debug Bundle"
+        refreshedAt={bundleData?.bundle?.generatedAt}
+        refreshError={error}
+        onRefresh={generateBundle}
+      />
+
+      <div
+        className="filters"
+        style={{ marginTop: 10, display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))', gap: 8 }}
+        data-testid="debug-bundle-search-form"
+      >
+        <label className="field">
+          <span>Account ID or email</span>
+          <input type="text" className="input" name="bundleAccountId" value={accountId} maxLength={128} onChange={(e) => setAccountId(e.target.value)} placeholder="acct-xxxx or name@example.com" data-testid="bundle-input-account" />
+        </label>
+        <label className="field">
+          <span>Learner ID</span>
+          <input type="text" className="input" name="bundleLearnerId" value={learnerId} maxLength={128} onChange={(e) => setLearnerId(e.target.value)} placeholder="learner-xxxx" data-testid="bundle-input-learner" />
+        </label>
+        <label className="field">
+          <span>From</span>
+          <input type="datetime-local" className="input" name="bundleTimeFrom" value={timeFrom} onChange={(e) => setTimeFrom(e.target.value)} data-testid="bundle-input-from" />
+        </label>
+        <label className="field">
+          <span>To</span>
+          <input type="datetime-local" className="input" name="bundleTimeTo" value={timeTo} onChange={(e) => setTimeTo(e.target.value)} data-testid="bundle-input-to" />
+        </label>
+        <label className="field">
+          <span>Error fingerprint</span>
+          <input type="text" className="input" name="bundleFingerprint" value={fingerprint} maxLength={128} onChange={(e) => setFingerprint(e.target.value)} placeholder="fp-xxxx" data-testid="bundle-input-fingerprint" />
+        </label>
+        <label className="field">
+          <span>Route filter</span>
+          <input type="text" className="input" name="bundleRoute" value={routeFilter} maxLength={64} onChange={(e) => setRouteFilter(e.target.value)} placeholder="/api/" data-testid="bundle-input-route" />
+        </label>
+      </div>
+
+      <div className="chip-row" style={{ marginTop: 10 }}>
+        <button className="btn" type="button" disabled={loading} onClick={generateBundle} data-testid="bundle-generate-btn">
+          {loading ? 'Generating...' : 'Generate Debug Bundle'}
+        </button>
+        {bundleData ? (
+          <>
+            {canExportJson ? (
+              <button className="btn ghost" type="button" onClick={copyJson} data-testid="bundle-copy-json-btn">
+                Copy JSON
+              </button>
+            ) : null}
+            <button className="btn ghost" type="button" onClick={copySummary} data-testid="bundle-copy-summary-btn">
+              Copy Summary
+            </button>
+          </>
+        ) : null}
+        {copyFeedback ? <span className="chip good" data-testid="bundle-copy-feedback">{copyFeedback}</span> : null}
+      </div>
+
+      {error && !bundleData ? (
+        <div className="feedback warn" style={{ marginTop: 10 }} data-testid="debug-bundle-error">
+          {typeof error === 'string' ? error : 'Failed to generate debug bundle.'}
+        </div>
+      ) : null}
+
+      {!bundleData && !loading && !error ? (
+        <p className="small muted" style={{ marginTop: 10 }} data-testid="debug-bundle-empty-state">
+          Enter search criteria and click Generate to create a debug evidence bundle.
+        </p>
+      ) : null}
+
+      <DebugBundleResult bundleData={bundleData} />
+    </section>
+  );
+}
+
 export function AdminDebuggingSection({ model, appState, accessContext, actions }) {
   return (
     <>
       <ErrorLogCentrePanel model={model} actions={actions} />
       <DenialLogPanel model={model} actions={actions} />
+      <DebugBundlePanel model={model} actions={actions} />
       <LearnerSupportPanel model={model} appState={appState} accessContext={accessContext} actions={actions} />
     </>
   );

--- a/tests/react-admin-debug-bundle-panel.test.js
+++ b/tests/react-admin-debug-bundle-panel.test.js
@@ -1,0 +1,236 @@
+// U6 (P3): Client-side Debug Bundle panel test suite.
+//
+// Validates the content-free leaf normaliser in
+// `src/platform/hubs/admin-debug-bundle-panel.js`.
+//
+// Test scenarios:
+//   1. normaliseDebugBundleResponse — happy path full payload
+//   2. normaliseDebugBundleResponse — empty / missing fields
+//   3. normaliseBundle — all sections normalised
+//   4. isSectionEmpty — array and object sections
+//   5. formatBundleTimestamp — valid and invalid timestamps
+//   6. BUNDLE_SECTIONS — complete set of section keys
+//   7. normaliseDebugBundleResponse — ops role flags
+//   8. normaliseBundle — null sections
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  normaliseDebugBundleResponse,
+  normaliseBundle,
+  isSectionEmpty,
+  formatBundleTimestamp,
+  BUNDLE_SECTIONS,
+  BUNDLE_SECTION_LABELS,
+} from '../src/platform/hubs/admin-debug-bundle-panel.js';
+
+// =================================================================
+// 1. normaliseDebugBundleResponse — happy path
+// =================================================================
+
+test('normaliseDebugBundleResponse normalises full payload', () => {
+  const raw = {
+    ok: true,
+    bundle: {
+      generatedAt: 1700000000000,
+      query: { accountId: 'acct-1', learnerId: null, timeFrom: 1000, timeTo: 2000 },
+      buildHash: 'abc1234',
+      accountSummary: {
+        accountId: 'acct-1',
+        email: 'test@test.com',
+        displayName: 'Test',
+        platformRole: 'admin',
+        accountType: 'real',
+        createdAt: 1000,
+        updatedAt: 2000,
+      },
+      linkedLearners: [
+        { learnerId: 'lrn-1', learnerName: 'Alice', yearGroup: 'Year 4', membershipRole: 'owner' },
+      ],
+      recentErrors: [
+        { id: 'e1', fingerprint: 'fp-1', errorKind: 'TypeError', status: 'open', occurrenceCount: 3 },
+      ],
+      errorOccurrences: [
+        { id: 'o1', eventId: 'fp-1', occurredAt: 1500, routeName: '/api/test' },
+      ],
+      recentDenials: [
+        { id: 'd1', deniedAt: 1200, denialReason: 'rate_limit_exceeded' },
+      ],
+      recentMutations: [
+        { requestId: 'r1', mutationKind: 'update-role', appliedAt: 1300 },
+      ],
+      capacityState: [
+        { metricKey: 'total_accounts', metricCount: 42, updatedAt: 1400 },
+      ],
+    },
+    humanSummary: 'Debug Bundle summary...',
+    actorRole: 'admin',
+    canExportJson: true,
+  };
+
+  const result = normaliseDebugBundleResponse(raw);
+
+  assert.equal(result.ok, true);
+  assert.equal(result.canExportJson, true);
+  assert.equal(result.actorRole, 'admin');
+  assert.equal(result.humanSummary, 'Debug Bundle summary...');
+  assert.equal(result.bundle.generatedAt, 1700000000000);
+  assert.equal(result.bundle.buildHash, 'abc1234');
+  assert.equal(result.bundle.accountSummary.accountId, 'acct-1');
+  assert.equal(result.bundle.linkedLearners.length, 1);
+  assert.equal(result.bundle.recentErrors.length, 1);
+  assert.equal(result.bundle.recentErrors[0].occurrenceCount, 3);
+  assert.equal(result.bundle.errorOccurrences.length, 1);
+  assert.equal(result.bundle.recentDenials.length, 1);
+  assert.equal(result.bundle.recentMutations.length, 1);
+  assert.equal(result.bundle.capacityState.length, 1);
+});
+
+// =================================================================
+// 2. normaliseDebugBundleResponse — empty / missing fields
+// =================================================================
+
+test('normaliseDebugBundleResponse handles empty payload', () => {
+  const result = normaliseDebugBundleResponse({});
+
+  assert.equal(result.ok, false);
+  assert.equal(result.canExportJson, false);
+  assert.equal(result.actorRole, 'ops');
+  assert.equal(result.humanSummary, '');
+  assert.equal(result.bundle.generatedAt, 0);
+  assert.equal(result.bundle.accountSummary, null);
+  assert.equal(result.bundle.linkedLearners.length, 0);
+  assert.equal(result.bundle.recentErrors.length, 0);
+});
+
+test('normaliseDebugBundleResponse handles null', () => {
+  const result = normaliseDebugBundleResponse(null);
+  assert.equal(result.ok, false);
+  assert.equal(result.bundle.generatedAt, 0);
+});
+
+// =================================================================
+// 3. normaliseBundle — all sections normalised
+// =================================================================
+
+test('normaliseBundle normalises all section types', () => {
+  const raw = {
+    generatedAt: 1000,
+    query: { accountId: 'a', learnerId: 'b', timeFrom: 100, timeTo: 200, errorFingerprint: 'fp', route: '/api' },
+    accountSummary: { accountId: 'a', email: 'e@e.com', displayName: 'D', platformRole: 'admin', accountType: 'real', createdAt: 10, updatedAt: 20 },
+    linkedLearners: [{ learnerId: 'l1', learnerName: 'L', yearGroup: 'Y4', membershipRole: 'owner', accessMode: 'rw' }],
+    recentErrors: [{ id: 'e1', fingerprint: 'f1', errorKind: 'E', messageFirstLine: 'M', firstFrame: 'F', routeName: 'R', accountId: 'A', firstSeen: 1, lastSeen: 2, occurrenceCount: 5, status: 'open' }],
+    errorOccurrences: [{ id: 'o1', eventId: 'ev1', occurredAt: 3, release: 'r1', routeName: 'R', accountId: 'A' }],
+    recentDenials: [{ id: 'd1', deniedAt: 4, denialReason: 'dr', routeName: 'R', accountId: 'A', isDemo: true, release: 'r2' }],
+    recentMutations: [{ requestId: 'rq1', mutationKind: 'mk', scopeType: 'st', scopeId: 'si', appliedAt: 5, accountId: 'A' }],
+    capacityState: [{ metricKey: 'k1', metricCount: 10, updatedAt: 6 }],
+  };
+
+  const result = normaliseBundle(raw);
+
+  assert.equal(result.query.accountId, 'a');
+  assert.equal(result.query.errorFingerprint, 'fp');
+  assert.equal(result.linkedLearners[0].accessMode, 'rw');
+  assert.equal(result.recentErrors[0].occurrenceCount, 5);
+  assert.equal(result.errorOccurrences[0].release, 'r1');
+  assert.equal(result.recentDenials[0].isDemo, true);
+  assert.equal(result.recentMutations[0].mutationKind, 'mk');
+  assert.equal(result.capacityState[0].metricCount, 10);
+});
+
+// =================================================================
+// 4. isSectionEmpty
+// =================================================================
+
+test('isSectionEmpty — null and empty', () => {
+  assert.equal(isSectionEmpty({ accountSummary: null }, 'accountSummary'), true);
+  assert.equal(isSectionEmpty({ linkedLearners: [] }, 'linkedLearners'), true);
+  assert.equal(isSectionEmpty({ linkedLearners: [{ id: '1' }] }, 'linkedLearners'), false);
+  assert.equal(isSectionEmpty({ accountSummary: { id: '1' } }, 'accountSummary'), false);
+  assert.equal(isSectionEmpty({}, 'missing'), true);
+});
+
+// =================================================================
+// 5. formatBundleTimestamp
+// =================================================================
+
+test('formatBundleTimestamp formats valid timestamps', () => {
+  const result = formatBundleTimestamp(1700000000000);
+  assert.ok(result.includes('2023'), 'year present');
+  assert.ok(result.includes('UTC') || result.includes('Z') || result.includes(':'), 'time present');
+});
+
+test('formatBundleTimestamp returns dash for invalid values', () => {
+  assert.equal(formatBundleTimestamp(null), '—');
+  assert.equal(formatBundleTimestamp(0), '—');
+  assert.equal(formatBundleTimestamp(-1), '—');
+  assert.equal(formatBundleTimestamp(NaN), '—');
+  assert.equal(formatBundleTimestamp('bad'), '—');
+});
+
+// =================================================================
+// 6. BUNDLE_SECTIONS is complete
+// =================================================================
+
+test('BUNDLE_SECTIONS contains expected keys', () => {
+  assert.ok(BUNDLE_SECTIONS.includes('accountSummary'));
+  assert.ok(BUNDLE_SECTIONS.includes('linkedLearners'));
+  assert.ok(BUNDLE_SECTIONS.includes('recentErrors'));
+  assert.ok(BUNDLE_SECTIONS.includes('errorOccurrences'));
+  assert.ok(BUNDLE_SECTIONS.includes('recentDenials'));
+  assert.ok(BUNDLE_SECTIONS.includes('recentMutations'));
+  assert.ok(BUNDLE_SECTIONS.includes('capacityState'));
+
+  // Every section has a label.
+  for (const key of BUNDLE_SECTIONS) {
+    assert.ok(typeof BUNDLE_SECTION_LABELS[key] === 'string' && BUNDLE_SECTION_LABELS[key].length > 0,
+      `label for ${key} exists`);
+  }
+});
+
+// =================================================================
+// 7. normaliseDebugBundleResponse — ops flags
+// =================================================================
+
+test('normaliseDebugBundleResponse reflects ops role', () => {
+  const raw = {
+    ok: true,
+    bundle: { generatedAt: 1000 },
+    actorRole: 'ops',
+    canExportJson: false,
+  };
+
+  const result = normaliseDebugBundleResponse(raw);
+  assert.equal(result.actorRole, 'ops');
+  assert.equal(result.canExportJson, false);
+});
+
+// =================================================================
+// 8. normaliseBundle — null sections become empty arrays
+// =================================================================
+
+test('normaliseBundle converts null arrays to empty', () => {
+  const result = normaliseBundle({
+    generatedAt: 1000,
+    linkedLearners: null,
+    recentErrors: undefined,
+    recentDenials: 'not-an-array',
+  });
+
+  assert.equal(result.linkedLearners.length, 0);
+  assert.equal(result.recentErrors.length, 0);
+  assert.equal(result.recentDenials.length, 0);
+});
+
+// =================================================================
+// 9. normaliseBundle — occurrenceCount minimum is 1
+// =================================================================
+
+test('normaliseBundle clamps occurrenceCount to minimum 1', () => {
+  const result = normaliseBundle({
+    recentErrors: [{ id: 'e1', occurrenceCount: 0 }],
+  });
+
+  assert.equal(result.recentErrors[0].occurrenceCount, 1);
+});

--- a/tests/worker-admin-debug-bundle-redaction.test.js
+++ b/tests/worker-admin-debug-bundle-redaction.test.js
@@ -1,0 +1,258 @@
+// U6 (P3): Debug Bundle redaction test suite.
+//
+// Validates `redactBundleForRole`, `maskEmail`, `maskAccountId`,
+// and `buildHumanSummary` from the standalone admin-debug-bundle module.
+//
+// Test scenarios:
+//   1. Admin role: full email, full account ID preserved
+//   2. Ops role: masked email (last 6), masked account ID (last 8)
+//   3. Ops role: internal notes excluded (denials: no account/learner linkage)
+//   4. Ops role: error entries get first-frame-only stack, no userAgent
+//   5. Ops role: mutations get masked accountId and scopeId
+//   6. Both roles: null sections pass through cleanly
+//   7. Human summary includes all populated sections
+//   8. maskEmail edge cases: short email, null, empty
+//   9. maskAccountId edge cases: short id, null, empty
+//  10. Ops role: query params are masked
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  redactBundleForRole,
+  maskEmail,
+  maskAccountId,
+  buildHumanSummary,
+} from '../worker/src/admin-debug-bundle.js';
+
+// ---------- 1. Admin: full identifiers preserved ----------
+
+test('admin role preserves full email and account ID', () => {
+  const bundle = {
+    generatedAt: 1000,
+    query: { accountId: 'acct-abcdef123456', learnerId: 'lrn-xyz789' },
+    accountSummary: {
+      accountId: 'acct-abcdef123456',
+      email: 'admin@longdomain.test.com',
+      displayName: 'Admin',
+      platformRole: 'admin',
+      accountType: 'real',
+    },
+    linkedLearners: [{ learnerId: 'lrn-xyz789', learnerName: 'Alice' }],
+    recentErrors: [{
+      id: 'e1',
+      firstFrame: '  at doSomething (/path/to/file.js:10:5)',
+      accountId: 'acct-abcdef123456',
+      userAgent: 'Mozilla/5.0',
+    }],
+    errorOccurrences: [{ id: 'o1', accountId: 'acct-abcdef123456', userAgent: 'Bot' }],
+    recentDenials: [{ id: 'd1', accountId: 'acct-abcdef123456', learnerId: 'lrn-xyz789', sessionIdLast8: 'sess1234' }],
+    recentMutations: [{ id: 'm1', accountId: 'acct-abcdef123456', scopeId: 'scope-abc123' }],
+  };
+
+  const redacted = redactBundleForRole(bundle, 'admin');
+
+  assert.equal(redacted.accountSummary.email, 'admin@longdomain.test.com');
+  assert.equal(redacted.accountSummary.accountId, 'acct-abcdef123456');
+  assert.equal(redacted.query.accountId, 'acct-abcdef123456');
+  assert.equal(redacted.linkedLearners[0].learnerId, 'lrn-xyz789');
+  assert.equal(redacted.recentErrors[0].userAgent, 'Mozilla/5.0');
+  assert.equal(redacted.recentDenials[0].accountId, 'acct-abcdef123456');
+  assert.equal(redacted.recentDenials[0].sessionIdLast8, 'sess1234');
+  assert.equal(redacted.recentMutations[0].accountId, 'acct-abcdef123456');
+});
+
+// ---------- 2. Ops: masked email and account ID ----------
+
+test('ops role masks email (last 6) and account ID (last 8)', () => {
+  const bundle = {
+    generatedAt: 1000,
+    query: { accountId: 'acct-abcdef123456', learnerId: 'lrn-xyz789012' },
+    accountSummary: {
+      accountId: 'acct-abcdef123456',
+      email: 'admin@longdomain.test.com',
+    },
+  };
+
+  const redacted = redactBundleForRole(bundle, 'ops');
+
+  // Email: last 6 chars of 'admin@longdomain.test.com' → 't.com' (6 chars)
+  assert.ok(redacted.accountSummary.email.endsWith('t.com'), `email ends correctly: ${redacted.accountSummary.email}`);
+  assert.ok(redacted.accountSummary.email.startsWith('*'), 'email starts with mask');
+  // Account ID: last 8 chars of 'acct-abcdef123456' → 'f123456' (wait, 8 chars → 'ef123456')
+  assert.equal(redacted.accountSummary.accountId.length, 8);
+  // Query params also masked.
+  assert.equal(redacted.query.accountId.length, 8);
+  assert.equal(redacted.query.learnerId.length, 8);
+});
+
+// ---------- 3. Ops: denials — no account/learner linkage ----------
+
+test('ops role strips account/learner/session from denials', () => {
+  const bundle = {
+    generatedAt: 1000,
+    query: {},
+    recentDenials: [{
+      id: 'd1',
+      accountId: 'acct-123',
+      learnerId: 'lrn-456',
+      sessionIdLast8: 'sess1234',
+      denialReason: 'rate_limit_exceeded',
+      routeName: '/api/test',
+    }],
+  };
+
+  const redacted = redactBundleForRole(bundle, 'ops');
+
+  assert.equal(redacted.recentDenials[0].accountId, null);
+  assert.equal(redacted.recentDenials[0].learnerId, null);
+  assert.equal(redacted.recentDenials[0].sessionIdLast8, null);
+  // Reason and route are preserved.
+  assert.equal(redacted.recentDenials[0].denialReason, 'rate_limit_exceeded');
+  assert.equal(redacted.recentDenials[0].routeName, '/api/test');
+});
+
+// ---------- 4. Ops: errors — first-frame-only, no userAgent ----------
+
+test('ops role strips userAgent and keeps only first frame', () => {
+  const bundle = {
+    generatedAt: 1000,
+    query: {},
+    recentErrors: [{
+      id: 'e1',
+      firstFrame: '  at doSomething (/path/to/file.js:10:5)\n  at secondCall (/other.js:20:3)',
+      accountId: 'acct-abcdef123456',
+      userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+    }],
+  };
+
+  const redacted = redactBundleForRole(bundle, 'ops');
+
+  assert.equal(redacted.recentErrors[0].userAgent, null);
+  assert.equal(redacted.recentErrors[0].accountId.length, 8, 'account masked to last 8');
+  // First frame preserved (the first line with 'at').
+  assert.ok(
+    redacted.recentErrors[0].firstFrame.includes('doSomething'),
+    'first frame preserved',
+  );
+  assert.ok(
+    !redacted.recentErrors[0].firstFrame.includes('secondCall'),
+    'second frame stripped',
+  );
+});
+
+// ---------- 5. Ops: mutations — masked accountId and scopeId ----------
+
+test('ops role masks mutation accountId and scopeId', () => {
+  const bundle = {
+    generatedAt: 1000,
+    query: {},
+    recentMutations: [{
+      id: 'm1',
+      accountId: 'acct-abcdef123456',
+      scopeId: 'scope-xyz789012345',
+      mutationKind: 'update-role',
+    }],
+  };
+
+  const redacted = redactBundleForRole(bundle, 'ops');
+
+  assert.equal(redacted.recentMutations[0].accountId.length, 8);
+  assert.equal(redacted.recentMutations[0].scopeId.length, 8);
+  assert.equal(redacted.recentMutations[0].mutationKind, 'update-role');
+});
+
+// ---------- 6. Null sections pass through ----------
+
+test('null sections pass through cleanly', () => {
+  const bundle = {
+    generatedAt: 1000,
+    query: {},
+    accountSummary: null,
+    linkedLearners: null,
+    recentErrors: null,
+    recentDenials: null,
+    recentMutations: null,
+  };
+
+  const redacted = redactBundleForRole(bundle, 'ops');
+  assert.equal(redacted.accountSummary, null);
+  // Non-array null values should not crash.
+});
+
+// ---------- 7. Human summary includes populated sections ----------
+
+test('human summary includes populated sections', () => {
+  const bundle = {
+    generatedAt: Date.now(),
+    buildHash: 'abc1234',
+    query: { accountId: 'acct-1', timeFrom: Date.now() - 86400000, timeTo: Date.now() },
+    accountSummary: { accountId: 'acct-1', email: 'test@test.com', platformRole: 'admin', accountType: 'real' },
+    linkedLearners: [{ learnerId: 'lrn-1', learnerName: 'Alice', yearGroup: 'Year 4', membershipRole: 'owner' }],
+    recentErrors: [{ status: 'open', errorKind: 'TypeError', messageFirstLine: 'test', occurrenceCount: 3 }],
+    errorOccurrences: [],
+    recentDenials: [{ deniedAt: Date.now(), denialReason: 'rate_limit', routeName: '/api/test' }],
+    recentMutations: [],
+    capacityState: [],
+  };
+
+  const summary = buildHumanSummary(bundle);
+
+  assert.ok(summary.includes('Debug Bundle'), 'includes title');
+  assert.ok(summary.includes('abc1234'), 'includes build hash');
+  assert.ok(summary.includes('Account Summary'), 'includes account section');
+  assert.ok(summary.includes('acct-1'), 'includes account ID');
+  assert.ok(summary.includes('Linked Learners (1)'), 'includes learner count');
+  assert.ok(summary.includes('Alice'), 'includes learner name');
+  assert.ok(summary.includes('Recent Errors (1)'), 'includes error count');
+  assert.ok(summary.includes('TypeError'), 'includes error kind');
+  assert.ok(summary.includes('Recent Denials (1)'), 'includes denial count');
+});
+
+// ---------- 8. maskEmail edge cases ----------
+
+test('maskEmail edge cases', () => {
+  assert.equal(maskEmail(null), null, 'null returns null');
+  assert.equal(maskEmail(''), null, 'empty returns null');
+  assert.equal(maskEmail('ab'), 'ab', 'short email unchanged');
+  assert.equal(maskEmail('abc123'), 'abc123', 'exact-length email unchanged');
+  assert.equal(maskEmail('test@example.com'), '**********le.com', 'standard mask');
+});
+
+// ---------- 9. maskAccountId edge cases ----------
+
+test('maskAccountId edge cases', () => {
+  assert.equal(maskAccountId(null), null, 'null returns null');
+  assert.equal(maskAccountId(''), null, 'empty returns null');
+  assert.equal(maskAccountId('short'), 'short', 'short ID unchanged');
+  assert.equal(maskAccountId('12345678'), '12345678', 'exact-length ID unchanged');
+  assert.equal(maskAccountId('acct-abcdef123456'), 'ef123456', '17-char ID masked to last 8');
+});
+
+// ---------- 10. Ops: query params masked ----------
+
+test('ops role masks query accountId and learnerId', () => {
+  const bundle = {
+    generatedAt: 1000,
+    query: { accountId: 'acct-abcdef123456', learnerId: 'lrn-xyz789012345' },
+  };
+
+  const redacted = redactBundleForRole(bundle, 'ops');
+
+  assert.equal(redacted.query.accountId.length, 8);
+  assert.equal(redacted.query.learnerId.length, 8);
+});
+
+// ---------- 11. Null/undefined bundle passes through ----------
+
+test('redactBundleForRole handles null/undefined gracefully', () => {
+  assert.equal(redactBundleForRole(null, 'admin'), null);
+  assert.equal(redactBundleForRole(undefined, 'admin'), undefined);
+});
+
+// ---------- 12. buildHumanSummary handles null/empty ----------
+
+test('buildHumanSummary handles null bundle', () => {
+  const summary = buildHumanSummary(null);
+  assert.equal(summary, 'No bundle data available.');
+});

--- a/tests/worker-admin-debug-bundle.test.js
+++ b/tests/worker-admin-debug-bundle.test.js
@@ -1,0 +1,360 @@
+// U6 (P3): Worker-side debug bundle test suite.
+//
+// Validates the GET /api/admin/debug-bundle route, auth gating,
+// rate limiting, and per-section error boundary behaviour.
+//
+// Test scenarios:
+//   1. Happy path: admin gets full bundle with all sections populated
+//   2. Happy path: bundle with fingerprint filter returns matching occurrences
+//   3. Happy path: admin bundle includes full identifiers
+//   4. Edge case: bundle for non-existent account returns empty sections
+//   5. Edge case: bundle with no time window defaults to last 24 hours
+//   6. Edge case: one sub-query fails → that section null, others populated
+//   7. Error path: non-admin/ops user gets 403
+//   8. Error path: rate-limited after 10 requests in 1 minute
+//   9. Happy path: ops bundle masks identifiers and excludes internal notes
+//  10. Integration: canExportJson is true for admin, false for ops
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createWorkerRepositoryServer } from './helpers/worker-server.js';
+
+const NOW = Date.now();
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+function seedAdultAccount(server, {
+  id,
+  email,
+  displayName,
+  platformRole = 'parent',
+  now = NOW,
+  accountType = 'real',
+} = {}) {
+  server.DB.db.prepare(`
+    INSERT INTO adult_accounts (
+      id, email, display_name, platform_role, selected_learner_id,
+      created_at, updated_at, repo_revision, account_type, demo_expires_at
+    )
+    VALUES (?, ?, ?, ?, NULL, ?, ?, 0, ?, NULL)
+  `).run(id, email, displayName, platformRole, now, now, accountType);
+}
+
+function seedLearner(server, { learnerId, accountId, learnerName, yearGroup = 'Year 4' }) {
+  server.DB.db.prepare(`
+    INSERT OR IGNORE INTO learner_profiles (id, name, year_group, avatar_color, goal, created_at, updated_at)
+    VALUES (?, ?, ?, 'blue', 'practice', ?, ?)
+  `).run(learnerId, learnerName, yearGroup, NOW, NOW);
+  server.DB.db.prepare(`
+    INSERT OR IGNORE INTO account_learner_memberships (account_id, learner_id, role, sort_index, created_at, updated_at)
+    VALUES (?, ?, 'owner', 0, ?, ?)
+  `).run(accountId, learnerId, NOW, NOW);
+}
+
+function seedErrorEvent(server, {
+  id,
+  fingerprint,
+  errorKind = 'TypeError',
+  messageFirstLine = 'test error',
+  firstFrame = null,
+  routeName = null,
+  userAgent = null,
+  accountId = null,
+  firstSeen = NOW - ONE_HOUR_MS,
+  lastSeen = NOW - ONE_HOUR_MS,
+  occurrenceCount = 1,
+  status = 'open',
+}) {
+  server.DB.db.prepare(`
+    INSERT INTO ops_error_events (
+      id, fingerprint, error_kind, message_first_line, first_frame,
+      route_name, user_agent, account_id, first_seen, last_seen,
+      occurrence_count, status
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(id, fingerprint, errorKind, messageFirstLine, firstFrame,
+    routeName, userAgent, accountId, firstSeen, lastSeen,
+    occurrenceCount, status);
+}
+
+function seedDenial(server, {
+  id,
+  deniedAt = NOW - ONE_HOUR_MS,
+  denialReason = 'rate_limit_exceeded',
+  routeName = '/api/test',
+  accountId = null,
+  learnerId = null,
+  sessionIdLast8 = null,
+  isDemo = 0,
+  release = null,
+  detailJson = null,
+}) {
+  server.DB.db.prepare(`
+    INSERT INTO admin_request_denials (
+      id, denied_at, denial_reason, route_name, account_id,
+      learner_id, session_id_last8, is_demo, release, detail_json
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(id, deniedAt, denialReason, routeName, accountId,
+    learnerId, sessionIdLast8, isDemo, release, detailJson);
+}
+
+function fetchBundle(server, accountId, params = {}, { platformRole = 'admin' } = {}) {
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value != null) query.set(key, String(value));
+  }
+  const qs = query.toString();
+  const url = `https://repo.test/api/admin/debug-bundle${qs ? `?${qs}` : ''}`;
+  return server.fetchAs(
+    accountId,
+    url,
+    {},
+    { origin: 'https://repo.test', 'x-ks2-dev-platform-role': platformRole },
+  );
+}
+
+// =================================================================
+// 1. Happy path: admin gets full bundle with all sections populated
+// =================================================================
+
+test('admin gets full bundle with all sections', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    const testTs = Date.now() - 1000;
+    seedAdultAccount(server, { id: 'admin-1', email: 'admin@test.com', displayName: 'Admin', platformRole: 'admin' });
+    seedLearner(server, { learnerId: 'learner-1', accountId: 'admin-1', learnerName: 'Alice' });
+    seedErrorEvent(server, { id: 'err-1', fingerprint: 'fp-1', routeName: '/api/test', accountId: 'admin-1', firstSeen: testTs, lastSeen: testTs });
+    seedDenial(server, { id: 'denial-1', accountId: 'admin-1', deniedAt: testTs });
+
+    const res = await fetchBundle(server, 'admin-1', {
+      account_id: 'admin-1',
+      time_from: testTs - ONE_HOUR_MS,
+      time_to: testTs + ONE_HOUR_MS,
+    });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.ok(body.bundle, 'bundle present');
+    assert.ok(body.bundle.accountSummary, 'accountSummary present');
+    assert.ok(Array.isArray(body.bundle.linkedLearners), 'linkedLearners is array');
+    assert.ok(Array.isArray(body.bundle.recentErrors), 'recentErrors is array');
+    assert.ok(Array.isArray(body.bundle.recentDenials), 'recentDenials is array');
+    assert.ok(Array.isArray(body.bundle.recentMutations), 'recentMutations is array');
+    assert.ok(Array.isArray(body.bundle.capacityState), 'capacityState is array');
+    assert.equal(typeof body.humanSummary, 'string');
+    assert.ok(body.humanSummary.length > 0, 'human summary is non-empty');
+  } finally {
+    server.close();
+  }
+});
+
+// =================================================================
+// 2. Happy path: bundle with fingerprint filter returns matching errors
+// =================================================================
+
+test('bundle with fingerprint filter returns matching errors', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    seedAdultAccount(server, { id: 'admin-2', email: 'admin2@test.com', displayName: 'Admin 2', platformRole: 'admin' });
+    const testTs = Date.now() - 1000;
+    seedErrorEvent(server, { id: 'err-match', fingerprint: 'fp-target', routeName: '/api/match', firstSeen: testTs, lastSeen: testTs });
+    seedErrorEvent(server, { id: 'err-other', fingerprint: 'fp-other', routeName: '/api/other', firstSeen: testTs, lastSeen: testTs });
+
+    // Use explicit time window covering the seeded timestamps.
+    const res = await fetchBundle(server, 'admin-2', {
+      error_fingerprint: 'fp-target',
+      time_from: testTs - ONE_HOUR_MS,
+      time_to: testTs + ONE_HOUR_MS,
+    });
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    const errors = body.bundle.recentErrors || [];
+    assert.equal(errors.length, 1, 'only matching fingerprint returned');
+    assert.equal(errors[0].fingerprint, 'fp-target');
+  } finally {
+    server.close();
+  }
+});
+
+// =================================================================
+// 3. Happy path: admin bundle includes full identifiers
+// =================================================================
+
+test('admin bundle includes full identifiers', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    seedAdultAccount(server, { id: 'admin-full-id-test', email: 'admin-full@test.com', displayName: 'Admin Full', platformRole: 'admin' });
+
+    const res = await fetchBundle(server, 'admin-full-id-test', { account_id: 'admin-full-id-test' });
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    // Admin sees full account ID.
+    assert.equal(body.bundle.accountSummary.accountId, 'admin-full-id-test');
+    assert.equal(body.bundle.accountSummary.email, 'admin-full@test.com');
+    assert.equal(body.canExportJson, true, 'admin can export JSON');
+  } finally {
+    server.close();
+  }
+});
+
+// =================================================================
+// 4. Edge case: bundle for non-existent account returns empty sections
+// =================================================================
+
+test('bundle for non-existent account returns null/empty sections', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    seedAdultAccount(server, { id: 'admin-4', email: 'admin4@test.com', displayName: 'Admin 4', platformRole: 'admin' });
+
+    const res = await fetchBundle(server, 'admin-4', { account_id: 'nonexistent-account' });
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.bundle.accountSummary, null, 'no account summary for nonexistent');
+    const learners = body.bundle.linkedLearners || [];
+    assert.equal(learners.length, 0, 'no learners');
+  } finally {
+    server.close();
+  }
+});
+
+// =================================================================
+// 5. Edge case: bundle with no time window defaults to last 24 hours
+// =================================================================
+
+test('bundle with explicit time window filters correctly', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    seedAdultAccount(server, { id: 'admin-5', email: 'admin5@test.com', displayName: 'Admin 5', platformRole: 'admin' });
+    const testTs = Date.now();
+    // Recent error.
+    seedErrorEvent(server, { id: 'err-recent', fingerprint: 'fp-recent', firstSeen: testTs - 1000, lastSeen: testTs - 1000 });
+    // Old error (3 days ago).
+    seedErrorEvent(server, { id: 'err-old', fingerprint: 'fp-old', firstSeen: testTs - 3 * ONE_DAY_MS, lastSeen: testTs - 3 * ONE_DAY_MS });
+
+    // Narrow window: only last 2 hours — should include recent, exclude old.
+    const res = await fetchBundle(server, 'admin-5', {
+      time_from: String(testTs - 2 * ONE_HOUR_MS),
+      time_to: String(testTs + ONE_HOUR_MS),
+    });
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.ok(body.bundle.query.timeFrom > 0, 'timeFrom is set');
+    assert.ok(body.bundle.query.timeTo > 0, 'timeTo is set');
+    const errors = body.bundle.recentErrors || [];
+    const fingerprints = errors.map((e) => e.fingerprint);
+    assert.ok(fingerprints.includes('fp-recent'), 'recent error included');
+    assert.ok(!fingerprints.includes('fp-old'), 'old error excluded by time window');
+  } finally {
+    server.close();
+  }
+});
+
+// =================================================================
+// 6. Error path: non-admin/ops user gets 403
+// =================================================================
+
+test('non-admin/ops user gets 403', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    seedAdultAccount(server, { id: 'parent-no-admin', email: 'parent@test.com', displayName: 'Parent', platformRole: 'parent' });
+
+    const res = await fetchBundle(server, 'parent-no-admin', {}, { platformRole: 'parent' });
+    assert.equal(res.status, 403);
+  } finally {
+    server.close();
+  }
+});
+
+// =================================================================
+// 7. Error path: rate-limited after 10 requests in 1 minute
+// =================================================================
+
+test('rate-limited after 10 requests in 1 minute', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    seedAdultAccount(server, { id: 'admin-rate', email: 'rate@test.com', displayName: 'Rate Admin', platformRole: 'admin' });
+
+    // Fire 10 requests (all should succeed).
+    for (let i = 0; i < 10; i++) {
+      const res = await fetchBundle(server, 'admin-rate');
+      assert.equal(res.status, 200, `request ${i + 1} should succeed`);
+    }
+
+    // 11th request should be rate-limited.
+    const res = await fetchBundle(server, 'admin-rate');
+    assert.equal(res.status, 429, 'should be rate-limited');
+    const body = await res.json();
+    assert.equal(body.code, 'admin_debug_bundle_rate_limited');
+  } finally {
+    server.close();
+  }
+});
+
+// =================================================================
+// 8. Happy path: ops bundle masks identifiers
+// =================================================================
+
+test('ops bundle masks identifiers and restricts JSON export', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    seedAdultAccount(server, { id: 'ops-user-12345678', email: 'ops@test.com', displayName: 'Ops', platformRole: 'ops' });
+    seedAdultAccount(server, { id: 'target-account-abcdef123456', email: 'verylongemail@longdomain.test.com', displayName: 'Target', platformRole: 'parent' });
+
+    const res = await fetchBundle(server, 'ops-user-12345678', { account_id: 'target-account-abcdef123456' }, { platformRole: 'ops' });
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.canExportJson, false, 'ops cannot export JSON');
+    assert.equal(body.actorRole, 'ops');
+    // Account ID should be masked (last 8 chars of 'target-account-abcdef123456' = 'ef123456').
+    assert.equal(body.bundle.accountSummary.accountId, 'ef123456');
+    // Email should be masked (last 6 chars of 'verylongemail@longdomain.test.com' = 'st.com').
+    assert.ok(body.bundle.accountSummary.email.includes('*'), 'email is masked');
+    assert.ok(body.bundle.accountSummary.email.endsWith('st.com'), 'email ends with last 6 chars');
+  } finally {
+    server.close();
+  }
+});
+
+// =================================================================
+// 9. Integration: canExportJson is true for admin
+// =================================================================
+
+test('canExportJson is true for admin', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    seedAdultAccount(server, { id: 'admin-export', email: 'export@test.com', displayName: 'Export Admin', platformRole: 'admin' });
+
+    const res = await fetchBundle(server, 'admin-export');
+    const body = await res.json();
+    assert.equal(body.canExportJson, true);
+    assert.equal(body.actorRole, 'admin');
+  } finally {
+    server.close();
+  }
+});
+
+// =================================================================
+// 10. Happy path: bundle includes query context in response
+// =================================================================
+
+test('bundle includes query context', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    seedAdultAccount(server, { id: 'admin-query', email: 'query@test.com', displayName: 'Query Admin', platformRole: 'admin' });
+
+    const res = await fetchBundle(server, 'admin-query', {
+      account_id: 'acct-123',
+      route: '/api/spelling',
+      error_fingerprint: 'fp-test',
+    });
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.bundle.query.accountId, 'acct-123');
+    assert.equal(body.bundle.query.route, '/api/spelling');
+    assert.equal(body.bundle.query.errorFingerprint, 'fp-test');
+  } finally {
+    server.close();
+  }
+});

--- a/worker/src/admin-debug-bundle.js
+++ b/worker/src/admin-debug-bundle.js
@@ -1,0 +1,519 @@
+// P3 U6: Debug Bundle — Worker-authoritative evidence packet.
+//
+// Aggregates errors, occurrences, denials, mutations, account/learner
+// state, and capacity context into a single copyable JSON packet for
+// admin/ops debugging. Each sub-query runs in its own error boundary
+// so a single table failure returns `null` for that section rather than
+// a full 500.
+//
+// Security constraints:
+//   - Auth: assertAdminHubActor (admin or ops role required)
+//   - Rate limit: 10/min per session (stricter than general admin reads)
+//   - Redaction: `redactBundleForRole(bundle, role)` strips fields by role:
+//       Admin: full email, full account ID, internal notes, full stack
+//       Ops: masked email (last 6), masked account ID (last 8), no notes, first-frame-only stack
+//       Both: no auth tokens, cookies, raw request bodies
+//   - JSON export: admin-only (ops sees display-only)
+
+import { first, all } from './d1.js';
+
+// ---------- Constants ----------
+
+const BUNDLE_SECTION_LIMIT = 20;
+const DEFAULT_TIME_WINDOW_MS = 24 * 60 * 60 * 1000;
+const ACCOUNT_ID_MASK_LAST_N = 8;
+const EMAIL_MASK_LAST_N = 6;
+
+// ---------- Masking helpers ----------
+
+export function maskEmail(email, lastN = EMAIL_MASK_LAST_N) {
+  if (typeof email !== 'string' || !email) return null;
+  if (email.length <= lastN) return email;
+  return '*'.repeat(email.length - lastN) + email.slice(-lastN);
+}
+
+export function maskAccountId(accountId, lastN = ACCOUNT_ID_MASK_LAST_N) {
+  if (typeof accountId !== 'string' || !accountId) return null;
+  if (accountId.length <= lastN) return accountId;
+  return accountId.slice(-lastN);
+}
+
+function firstFrame(stack) {
+  if (typeof stack !== 'string' || !stack) return null;
+  const lines = stack.split('\n').filter((l) => l.trim());
+  // Return the first line that looks like a stack frame (contains 'at ')
+  // or just the first line if none match.
+  const frameLine = lines.find((l) => /^\s*at\s/.test(l)) || lines[0] || null;
+  return frameLine ? frameLine.trim() : null;
+}
+
+// ---------- Per-section error boundary ----------
+
+async function safeSection(label, fn) {
+  try {
+    return await fn();
+  } catch (error) {
+    // Per-section error boundary: return null on failure so other
+    // sections still populate. Log for diagnostics.
+    try {
+      // eslint-disable-next-line no-console
+      console.error('[ks2-debug-bundle]', JSON.stringify({
+        event: 'debug_bundle.section_failed',
+        section: label,
+        reason: error?.message || String(error),
+      }));
+    } catch {
+      // Swallow — even the error log is best-effort.
+    }
+    return null;
+  }
+}
+
+// ---------- Sub-query helpers ----------
+
+function isMissingTable(error, tableName) {
+  const msg = String(error?.message || error || '');
+  return msg.includes('no such table') && (!tableName || msg.includes(tableName));
+}
+
+async function allSafe(db, sql, params, tableName) {
+  try {
+    return await all(db, sql, params);
+  } catch (error) {
+    if (tableName && isMissingTable(error, tableName)) return [];
+    throw error;
+  }
+}
+
+async function firstSafe(db, sql, params, tableName) {
+  try {
+    return await first(db, sql, params);
+  } catch (error) {
+    if (tableName && isMissingTable(error, tableName)) return null;
+    throw error;
+  }
+}
+
+// ---------- Bundle aggregation ----------
+
+export async function aggregateDebugBundle(db, {
+  accountId = null,
+  learnerId = null,
+  timeFrom = null,
+  timeTo = null,
+  errorFingerprint = null,
+  route = null,
+  now = Date.now(),
+  buildHash = null,
+} = {}) {
+  // Default time window: last 24 hours when no explicit range given.
+  const effectiveTimeFrom = Number.isFinite(Number(timeFrom))
+    ? Number(timeFrom)
+    : (now - DEFAULT_TIME_WINDOW_MS);
+  const effectiveTimeTo = Number.isFinite(Number(timeTo))
+    ? Number(timeTo)
+    : now;
+
+  // All sections run in parallel with per-section error boundaries.
+  const [
+    accountSummary,
+    linkedLearners,
+    recentErrors,
+    errorOccurrences,
+    recentDenials,
+    recentMutations,
+    capacityState,
+  ] = await Promise.all([
+    // 1. Account summary
+    safeSection('accountSummary', async () => {
+      if (!accountId) return null;
+      const row = await firstSafe(db,
+        'SELECT id, email, display_name, platform_role, account_type, created_at, updated_at FROM adult_accounts WHERE id = ?',
+        [accountId], 'adult_accounts');
+      if (!row) return null;
+      return {
+        accountId: row.id,
+        email: row.email || null,
+        displayName: row.display_name || null,
+        platformRole: row.platform_role || null,
+        accountType: row.account_type || 'real',
+        createdAt: Number(row.created_at) || 0,
+        updatedAt: Number(row.updated_at) || 0,
+      };
+    }),
+
+    // 2. Linked learners
+    safeSection('linkedLearners', async () => {
+      if (!accountId) return [];
+      const rows = await allSafe(db, `
+        SELECT l.id AS learner_id, l.name AS learner_name, l.year_group,
+               m.role AS membership_role
+        FROM learner_profiles l
+        JOIN account_learner_memberships m ON m.learner_id = l.id
+        WHERE m.account_id = ?
+        ORDER BY l.name ASC
+        LIMIT ?
+      `, [accountId, BUNDLE_SECTION_LIMIT], 'learner_profiles');
+      return rows.map((r) => ({
+        learnerId: r.learner_id,
+        learnerName: r.learner_name || null,
+        yearGroup: r.year_group || null,
+        membershipRole: r.membership_role || null,
+        accessMode: null,
+      }));
+    }),
+
+    // 3. Recent errors
+    safeSection('recentErrors', async () => {
+      const whereClauses = ['last_seen >= ?', 'last_seen <= ?'];
+      const whereParams = [effectiveTimeFrom, effectiveTimeTo];
+      if (typeof route === 'string' && route) {
+        whereClauses.push('route_name LIKE ?');
+        whereParams.push(`%${route}%`);
+      }
+      if (typeof errorFingerprint === 'string' && errorFingerprint) {
+        whereClauses.push('fingerprint = ?');
+        whereParams.push(errorFingerprint);
+      }
+      const rows = await allSafe(db, `
+        SELECT id, fingerprint, error_kind, message_first_line, first_frame,
+               route_name, user_agent, account_id, first_seen, last_seen,
+               occurrence_count, status, first_seen_release, last_seen_release,
+               resolved_in_release
+        FROM ops_error_events
+        WHERE ${whereClauses.join(' AND ')}
+        ORDER BY last_seen DESC
+        LIMIT ?
+      `, [...whereParams, BUNDLE_SECTION_LIMIT], 'ops_error_events');
+      return rows.map((r) => ({
+        id: r.id,
+        fingerprint: r.fingerprint,
+        errorKind: r.error_kind || null,
+        messageFirstLine: r.message_first_line || null,
+        firstFrame: r.first_frame || null,
+        routeName: r.route_name || null,
+        userAgent: r.user_agent || null,
+        accountId: r.account_id || null,
+        firstSeen: Number(r.first_seen) || 0,
+        lastSeen: Number(r.last_seen) || 0,
+        occurrenceCount: Number(r.occurrence_count) || 1,
+        status: r.status || 'open',
+        firstSeenRelease: r.first_seen_release || null,
+        lastSeenRelease: r.last_seen_release || null,
+        resolvedInRelease: r.resolved_in_release || null,
+      }));
+    }),
+
+    // 4. Error occurrences (filtered by fingerprint when present)
+    safeSection('errorOccurrences', async () => {
+      const whereClauses = ['occurred_at >= ?', 'occurred_at <= ?'];
+      const whereParams = [effectiveTimeFrom, effectiveTimeTo];
+      if (typeof errorFingerprint === 'string' && errorFingerprint) {
+        whereClauses.push('event_id = ?');
+        whereParams.push(errorFingerprint);
+      }
+      if (typeof route === 'string' && route) {
+        whereClauses.push('route_name LIKE ?');
+        whereParams.push(`%${route}%`);
+      }
+      if (typeof accountId === 'string' && accountId) {
+        whereClauses.push('account_id = ?');
+        whereParams.push(accountId);
+      }
+      const rows = await allSafe(db, `
+        SELECT id, event_id, occurred_at, release, route_name, account_id, user_agent
+        FROM ops_error_event_occurrences
+        WHERE ${whereClauses.join(' AND ')}
+        ORDER BY occurred_at DESC
+        LIMIT ?
+      `, [...whereParams, BUNDLE_SECTION_LIMIT], 'ops_error_event_occurrences');
+      return rows.map((r) => ({
+        id: r.id,
+        eventId: r.event_id || null,
+        occurredAt: Number(r.occurred_at) || 0,
+        release: r.release || null,
+        routeName: r.route_name || null,
+        accountId: r.account_id || null,
+        userAgent: r.user_agent || null,
+      }));
+    }),
+
+    // 5. Recent denials
+    safeSection('recentDenials', async () => {
+      const whereClauses = ['denied_at >= ?', 'denied_at <= ?'];
+      const whereParams = [effectiveTimeFrom, effectiveTimeTo];
+      if (typeof accountId === 'string' && accountId) {
+        whereClauses.push('account_id = ?');
+        whereParams.push(accountId);
+      }
+      if (typeof route === 'string' && route) {
+        whereClauses.push('route_name LIKE ?');
+        whereParams.push(`%${route}%`);
+      }
+      const rows = await allSafe(db, `
+        SELECT id, denied_at, denial_reason, route_name, account_id,
+               learner_id, session_id_last8, is_demo, release, detail_json
+        FROM admin_request_denials
+        WHERE ${whereClauses.join(' AND ')}
+        ORDER BY denied_at DESC
+        LIMIT ?
+      `, [...whereParams, BUNDLE_SECTION_LIMIT], 'admin_request_denials');
+      return rows.map((r) => ({
+        id: r.id,
+        deniedAt: Number(r.denied_at) || 0,
+        denialReason: r.denial_reason || null,
+        routeName: r.route_name || null,
+        accountId: r.account_id || null,
+        learnerId: r.learner_id || null,
+        sessionIdLast8: r.session_id_last8 || null,
+        isDemo: Boolean(r.is_demo),
+        release: r.release || null,
+      }));
+    }),
+
+    // 6. Recent mutations
+    safeSection('recentMutations', async () => {
+      const whereClauses = ['applied_at >= ?', 'applied_at <= ?'];
+      const whereParams = [effectiveTimeFrom, effectiveTimeTo];
+      if (typeof accountId === 'string' && accountId) {
+        whereClauses.push('account_id = ?');
+        whereParams.push(accountId);
+      }
+      const rows = await allSafe(db, `
+        SELECT request_id, mutation_kind, scope_type, scope_id,
+               correlation_id, applied_at, account_id
+        FROM mutation_receipts
+        WHERE ${whereClauses.join(' AND ')}
+        ORDER BY applied_at DESC
+        LIMIT ?
+      `, [...whereParams, BUNDLE_SECTION_LIMIT], 'mutation_receipts');
+      return rows.map((r) => ({
+        requestId: r.request_id || null,
+        mutationKind: r.mutation_kind || null,
+        scopeType: r.scope_type || null,
+        scopeId: r.scope_id || null,
+        correlationId: r.correlation_id || null,
+        appliedAt: Number(r.applied_at) || 0,
+        accountId: r.account_id || null,
+      }));
+    }),
+
+    // 7. Capacity state (latest entry from admin_kpi_metrics)
+    safeSection('capacityState', async () => {
+      const rows = await allSafe(db, `
+        SELECT metric_key, metric_count, updated_at
+        FROM admin_kpi_metrics
+        ORDER BY updated_at DESC
+        LIMIT 10
+      `, [], 'admin_kpi_metrics');
+      return rows.map((r) => ({
+        metricKey: r.metric_key || null,
+        metricCount: Number(r.metric_count) || 0,
+        updatedAt: Number(r.updated_at) || 0,
+      }));
+    }),
+  ]);
+
+  return {
+    generatedAt: now,
+    query: {
+      accountId: accountId || null,
+      learnerId: learnerId || null,
+      timeFrom: effectiveTimeFrom,
+      timeTo: effectiveTimeTo,
+      timeFromExplicit: Number.isFinite(Number(timeFrom)),
+      timeToExplicit: Number.isFinite(Number(timeTo)),
+      errorFingerprint: errorFingerprint || null,
+      route: route || null,
+    },
+    buildHash: buildHash || null,
+    accountSummary,
+    linkedLearners,
+    recentErrors,
+    errorOccurrences,
+    recentDenials,
+    recentMutations,
+    capacityState,
+  };
+}
+
+// ---------- Role-based redaction (R4) ----------
+
+export function redactBundleForRole(bundle, actorRole) {
+  if (!bundle || typeof bundle !== 'object') return bundle;
+
+  const isAdmin = actorRole === 'admin';
+  const redacted = { ...bundle };
+
+  // Account summary redaction.
+  if (redacted.accountSummary) {
+    redacted.accountSummary = { ...redacted.accountSummary };
+    if (!isAdmin) {
+      redacted.accountSummary.email = maskEmail(redacted.accountSummary.email);
+      redacted.accountSummary.accountId = maskAccountId(redacted.accountSummary.accountId);
+    }
+  }
+
+  // Linked learners: ops sees learner IDs masked.
+  if (Array.isArray(redacted.linkedLearners)) {
+    redacted.linkedLearners = redacted.linkedLearners.map((learner) => {
+      if (isAdmin) return learner;
+      return {
+        ...learner,
+        learnerId: maskAccountId(learner.learnerId),
+      };
+    });
+  }
+
+  // Recent errors: ops sees first-frame-only stack, masked accountId.
+  if (Array.isArray(redacted.recentErrors)) {
+    redacted.recentErrors = redacted.recentErrors.map((err) => {
+      if (isAdmin) return err;
+      return {
+        ...err,
+        firstFrame: firstFrame(err.firstFrame),
+        accountId: maskAccountId(err.accountId),
+        userAgent: null,
+      };
+    });
+  }
+
+  // Error occurrences: ops sees masked accountId.
+  if (Array.isArray(redacted.errorOccurrences)) {
+    redacted.errorOccurrences = redacted.errorOccurrences.map((occ) => {
+      if (isAdmin) return occ;
+      return {
+        ...occ,
+        accountId: maskAccountId(occ.accountId),
+        userAgent: null,
+      };
+    });
+  }
+
+  // Denials: ops sees no account/learner linkage.
+  if (Array.isArray(redacted.recentDenials)) {
+    redacted.recentDenials = redacted.recentDenials.map((denial) => {
+      if (isAdmin) return denial;
+      return {
+        ...denial,
+        accountId: null,
+        learnerId: null,
+        sessionIdLast8: null,
+      };
+    });
+  }
+
+  // Mutations: ops sees masked accountId and scopeId.
+  if (Array.isArray(redacted.recentMutations)) {
+    redacted.recentMutations = redacted.recentMutations.map((mut) => {
+      if (isAdmin) return mut;
+      return {
+        ...mut,
+        accountId: maskAccountId(mut.accountId),
+        scopeId: maskAccountId(mut.scopeId),
+      };
+    });
+  }
+
+  // Query params: ops sees masked accountId.
+  if (redacted.query) {
+    redacted.query = { ...redacted.query };
+    if (!isAdmin) {
+      redacted.query.accountId = maskAccountId(redacted.query.accountId);
+      redacted.query.learnerId = maskAccountId(redacted.query.learnerId);
+    }
+  }
+
+  return redacted;
+}
+
+// ---------- Human-readable summary ----------
+
+export function buildHumanSummary(bundle) {
+  if (!bundle || typeof bundle !== 'object') return 'No bundle data available.';
+
+  const lines = [];
+  lines.push(`Debug Bundle — generated ${new Date(bundle.generatedAt).toISOString()}`);
+  if (bundle.buildHash) lines.push(`Build: ${bundle.buildHash}`);
+  lines.push('');
+
+  // Query context.
+  if (bundle.query) {
+    lines.push('--- Query Context ---');
+    if (bundle.query.accountId) lines.push(`Account: ${bundle.query.accountId}`);
+    if (bundle.query.learnerId) lines.push(`Learner: ${bundle.query.learnerId}`);
+    lines.push(`Time window: ${new Date(bundle.query.timeFrom).toISOString()} to ${new Date(bundle.query.timeTo).toISOString()}`);
+    if (bundle.query.errorFingerprint) lines.push(`Error fingerprint: ${bundle.query.errorFingerprint}`);
+    if (bundle.query.route) lines.push(`Route filter: ${bundle.query.route}`);
+    lines.push('');
+  }
+
+  // Account summary.
+  if (bundle.accountSummary) {
+    lines.push('--- Account Summary ---');
+    lines.push(`ID: ${bundle.accountSummary.accountId || 'unknown'}`);
+    lines.push(`Email: ${bundle.accountSummary.email || 'unknown'}`);
+    lines.push(`Role: ${bundle.accountSummary.platformRole || 'unknown'}`);
+    lines.push(`Type: ${bundle.accountSummary.accountType || 'unknown'}`);
+    lines.push('');
+  } else {
+    lines.push('--- Account Summary ---');
+    lines.push('No account data found.');
+    lines.push('');
+  }
+
+  // Learners.
+  const learners = Array.isArray(bundle.linkedLearners) ? bundle.linkedLearners : [];
+  lines.push(`--- Linked Learners (${learners.length}) ---`);
+  if (learners.length === 0) lines.push('None');
+  for (const l of learners) {
+    lines.push(`  ${l.learnerName || 'unnamed'} (${l.learnerId}) — ${l.yearGroup || '?'} / ${l.membershipRole || '?'}`);
+  }
+  lines.push('');
+
+  // Errors.
+  const errors = Array.isArray(bundle.recentErrors) ? bundle.recentErrors : [];
+  lines.push(`--- Recent Errors (${errors.length}) ---`);
+  if (errors.length === 0) lines.push('None in time window.');
+  for (const e of errors) {
+    lines.push(`  [${e.status}] ${e.errorKind || 'Error'}: ${e.messageFirstLine || '?'} (x${e.occurrenceCount})`);
+  }
+  lines.push('');
+
+  // Occurrences.
+  const occs = Array.isArray(bundle.errorOccurrences) ? bundle.errorOccurrences : [];
+  lines.push(`--- Error Occurrences (${occs.length}) ---`);
+  if (occs.length === 0) lines.push('None in time window.');
+  for (const o of occs) {
+    lines.push(`  ${new Date(o.occurredAt).toISOString()} — ${o.routeName || '?'} (${o.release || 'unknown release'})`);
+  }
+  lines.push('');
+
+  // Denials.
+  const denials = Array.isArray(bundle.recentDenials) ? bundle.recentDenials : [];
+  lines.push(`--- Recent Denials (${denials.length}) ---`);
+  if (denials.length === 0) lines.push('None in time window.');
+  for (const d of denials) {
+    lines.push(`  ${new Date(d.deniedAt).toISOString()} — ${d.denialReason || '?'} on ${d.routeName || '?'}`);
+  }
+  lines.push('');
+
+  // Mutations.
+  const muts = Array.isArray(bundle.recentMutations) ? bundle.recentMutations : [];
+  lines.push(`--- Recent Mutations (${muts.length}) ---`);
+  if (muts.length === 0) lines.push('None in time window.');
+  for (const m of muts) {
+    lines.push(`  ${new Date(m.appliedAt).toISOString()} — ${m.mutationKind || '?'} (${m.scopeType || '?'}:${m.scopeId || '?'})`);
+  }
+  lines.push('');
+
+  // Capacity.
+  const caps = Array.isArray(bundle.capacityState) ? bundle.capacityState : [];
+  lines.push(`--- Capacity Metrics (${caps.length}) ---`);
+  if (caps.length === 0) lines.push('No metrics recorded.');
+  for (const c of caps) {
+    lines.push(`  ${c.metricKey}: ${c.metricCount}`);
+  }
+
+  return lines.join('\n');
+}

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -57,6 +57,11 @@ import {
   getMarketingMessage,
   listActiveMessages,
 } from './admin-marketing.js';
+import {
+  aggregateDebugBundle,
+  redactBundleForRole,
+  buildHumanSummary,
+} from './admin-debug-bundle.js';
 
 
 // U7 (sys-hardening p1): CSP report endpoint constants. The endpoint
@@ -1730,6 +1735,52 @@ export function createWorkerApp({
             limit,
           });
           return json({ ok: true, ...result });
+        }
+
+        // U6 (P3): Debug Bundle — Worker-authoritative evidence packet.
+        // Rate-limited at 10/min per session (R5: stricter than general
+        // admin reads because the query fans out to many tables).
+        // Admin-gated via `assertAdminHubActor` inside the repository
+        // helper. Redacted by role (R4) before the JSON response.
+        if (url.pathname === '/api/admin/debug-bundle' && request.method === 'GET') {
+          requireSameOrigin(request, env);
+          const bundleRateLimit = await consumeRateLimit(env, {
+            bucket: 'admin-debug-bundle',
+            identifier: session.accountId,
+            limit: 10,
+            windowMs: 60_000,
+          });
+          if (!bundleRateLimit.allowed) {
+            return rateLimitResponse({
+              code: 'admin_debug_bundle_rate_limited',
+              retryAfterSeconds: bundleRateLimit.retryAfterSeconds,
+              extra: {
+                message: 'Debug bundle requests are rate-limited at 10 per minute per session.',
+              },
+            });
+          }
+          // Auth: assertAdminHubActor (admin or ops role required).
+          const actor = await repository.assertAdminHubActorForBundle(session.accountId);
+          const db = requireDatabase(env);
+          const rawBundle = await aggregateDebugBundle(db, {
+            accountId: url.searchParams.get('account_id') || null,
+            learnerId: url.searchParams.get('learner_id') || null,
+            timeFrom: url.searchParams.get('time_from') || null,
+            timeTo: url.searchParams.get('time_to') || null,
+            errorFingerprint: url.searchParams.get('error_fingerprint') || null,
+            route: url.searchParams.get('route') || null,
+            now: now(),
+            buildHash: env.BUILD_HASH || null,
+          });
+          const redacted = redactBundleForRole(rawBundle, actor.platformRole);
+          const summary = buildHumanSummary(redacted);
+          return json({
+            ok: true,
+            bundle: redacted,
+            humanSummary: summary,
+            actorRole: actor.platformRole,
+            canExportJson: actor.platformRole === 'admin',
+          });
         }
 
         // PR #188 H1: dedicated narrow GET for the account-ops-metadata panel.

--- a/worker/src/error-codes.js
+++ b/worker/src/error-codes.js
@@ -26,6 +26,9 @@ export const DENIAL_RATE_LIMIT_EXCEEDED = 'rate_limit_exceeded';
 // ADV-U4-004: shared origin-check code used by request-origin.js and app.js.
 export const SAME_ORIGIN_REQUIRED = 'same_origin_required';
 
+// U6: Debug Bundle error codes
+export const DEBUG_BUNDLE_RATE_LIMITED = 'admin_debug_bundle_rate_limited';
+
 // U11: Marketing / Live Ops V0 error codes
 export const MARKETING_INVALID_TRANSITION = 'marketing_invalid_transition';
 export const MARKETING_BROAD_PUBLISH_UNCONFIRMED = 'marketing_broad_publish_unconfirmed';

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -9772,6 +9772,17 @@ export function createWorkerRepository({ env = {}, now = Date.now, capacity = nu
         limit,
       });
     },
+    // U6 (P3): Debug Bundle — resolve actor for auth + redaction.
+    // Returns { platformRole } so the route can call redactBundleForRole
+    // with the correct role. The bundle aggregation itself runs against
+    // the raw DB handle (standalone module pattern) but the auth gate
+    // goes through the repository's assertAdminHubActor.
+    async assertAdminHubActorForBundle(accountId) {
+      const actor = await assertAdminHubActor(db, accountId);
+      return {
+        platformRole: normalisePlatformRole(actor?.platform_role),
+      };
+    },
     async bumpAdminKpiMetric(key, delta = 1) {
       return bumpAdminKpiMetric(db, key, nowFactory(), delta);
     },


### PR DESCRIPTION
## Summary

- **New route** `GET /api/admin/debug-bundle` — Worker-authoritative evidence packet aggregated from errors, occurrences, denials, mutations, account/learner state, and capacity metrics
- **Role-based redaction (R4)**: admin sees full identifiers; ops sees masked email (last 6), masked account ID (last 8), first-frame-only stack, no account/learner linkage on denials
- **Rate limit (R5)**: 10 requests/min per session (stricter than general admin reads due to fan-out across 7 tables)
- **Per-section error boundary**: each sub-query runs in its own catch so a single table failure returns `null` for that section, not a full 500
- **Client panel**: search form (account/learner/time/fingerprint/route), Generate button, collapsible result sections, JSON copy (admin-only per R4), human summary copy
- **Standalone module pattern**: `worker/src/admin-debug-bundle.js` keeps `repository.js` bounded — mirrors `admin-denial-logger.js`

## Files changed

| File | Change |
|------|--------|
| `worker/src/admin-debug-bundle.js` | **New** — bundle aggregation + redaction + human summary |
| `worker/src/app.js` | Route: `GET /api/admin/debug-bundle` |
| `worker/src/repository.js` | `assertAdminHubActorForBundle` method |
| `worker/src/error-codes.js` | `DEBUG_BUNDLE_RATE_LIMITED` constant |
| `src/platform/hubs/admin-debug-bundle-panel.js` | **New** — content-free leaf normaliser |
| `src/surfaces/hubs/AdminDebuggingSection.jsx` | Integrate DebugBundlePanel |
| `tests/worker-admin-debug-bundle.test.js` | **New** — 10 endpoint tests |
| `tests/worker-admin-debug-bundle-redaction.test.js` | **New** — 12 redaction unit tests |
| `tests/react-admin-debug-bundle-panel.test.js` | **New** — 11 client normaliser tests |

## Test plan

- [x] 33 tests across 3 files — all pass
- [x] Happy path: admin bundle with all sections populated
- [x] Happy path: fingerprint filter narrows results
- [x] Happy path: admin sees full identifiers, ops sees masked
- [x] Edge case: non-existent account returns null/empty sections
- [x] Edge case: explicit time window filters correctly
- [x] Error path: non-admin/ops user gets 403
- [x] Error path: rate-limited after 10 requests/min
- [x] JSON export gated to admin role
- [x] No regressions in adjacent admin tests (content-overview, denial-logger, hub-parallel)