### PR TITLE
docs(admin): U13 P3 documentation update + completion report

### DIFF
--- a/docs/monster-visual-config.md
+++ b/docs/monster-visual-config.md
@@ -9,11 +9,15 @@ The monster visual + effect config centre is the admin workflow for changing mon
 
 The centre publishes a single combined document. One save, one publish, one restore covers both visual and effect data.
 
+## Asset & Effect Registry
+
+Since P3 (PR #389), Monster Visual Config is presented through the **Asset & Effect Registry** UI in the Admin Console Content section. The registry provides a structured interface — asset list, effect catalog, per-monster bindings, and celebration tunables — over the existing `platform_monster_visual_config` data model. The underlying schema, publish validation, atomic publish, reviewed state, bundled fallback, and retained version behaviours are unchanged. A future phase may lift the data model into registry-shaped tables; the current UI establishes the registry direction without migration risk.
+
 ## Operator workflow
 
-Open **Admin / Operations** with platform role `admin`.
+Open the **Admin Console** Content section with platform role `admin`.
 
-The **Monster visuals** panel shows:
+The **Asset & Effect Registry** panel (previously "Monster visuals") shows:
 
 - the current draft revision and published version
 - queue filters for all assets, changed assets, assets needing review, and blockers

--- a/docs/operating-surfaces.md
+++ b/docs/operating-surfaces.md
@@ -94,75 +94,121 @@ Parent Hub requires:
 
 That keeps the surface explicitly separate from Operations-only accounts while letting admins inspect parent-facing learner views for learners they can read.
 
-## Admin / Operations
+## Admin Console
 
-Admin / Operations is a thin operator skeleton.
-It currently shows:
+The Admin Console is a five-section command centre for support, debugging, content operations, and live ops.
 
-- monster visual config draft/review/publish controls
-- spelling content release status
-- draft import / validation status
-- mutation-receipt audit lookup
-- admin-only account role management
-- learner diagnostics entry points
-- selected learner support summary
+Direct entry at `/admin` with hash-based section deep-linking (`/admin#section=debug`, `/admin#section=accounts`, `/admin#section=content`, `/admin#section=marketing`). TopNav shows an "Admin" button for admin/ops users. Login redirect preservation via sessionStorage stash returns admins to the intended section after sign-in.
+
+### Section layout
+
+**Overview** — on-demand KPI counters (accounts, learners, demos, sessions 7d/30d, event log, mutation receipts, error events by status), recent operations activity stream (last 50 mutation receipts, masked identifiers), demo health.
+
+**Accounts** — account search (email/ID/display name with ops_status and platform_role filters), account detail view (linked learners, recent errors, denials, mutations, ops metadata), account role management, ops metadata editing (status, plan label, tags, internal notes), mutation receipt/audit lookup. Account detail links into Debug Bundle generation.
+
+**Debugging & Logs** — Debug Bundle (Worker-authoritative evidence packet aggregating errors, occurrences, denials, mutations, account/learner state, capacity metrics with per-section error boundary), error log centre (status filter, route/kind/date/release/reopened filters, auto-reopen on release transition, build-hash attribution), error occurrence timeline (per-fingerprint history with release context), request denial log (filterable by reason, route, time range), learner support/diagnostics.
+
+**Content** — cross-subject content overview (live/placeholder/gated status per subject, error counts, release state), spelling content release/import status, post-Mega spelling debug, post-Mastery seed harness, grammar/punctuation diagnostics panels, Asset & Effect Registry (registry-shaped UI over Monster Visual Config with asset list, effect catalog, bindings, tunables — data model unchanged).
+
+**Marketing / Live Ops** — announcement and maintenance banner lifecycle (draft, scheduled, published, paused, archived), body_text validation (restricted-safe subset, no raw HTML/JS/CSS), active message delivery via public endpoint for client-runtime banner rendering.
 
 ### Current data source
 
-Admin / Operations reuses:
+Admin Console reuses:
 
-- `platform_monster_visual_config`
-- `platform_monster_visual_config_versions`
+- `platform_monster_visual_config` and `platform_monster_visual_config_versions`
 - `account_subject_content`
-- spelling content validation results
+- spelling, grammar, and punctuation content validation results
 - `mutation_receipts`
 - `adult_accounts.platform_role`
+- `account_ops_metadata` with `ops_status`, `plan_label`, `tags_json`, `internal_notes`
+- `ops_error_events` and `ops_error_event_occurrences`
+- `admin_request_denials`
+- `admin_marketing_messages`
+- `admin_kpi_metrics`
 - learner profiles + memberships
-- learner spelling read models for support diagnostics
+- learner read models across subjects for support diagnostics
+- practice sessions and event log for support context
 
 ### Current permission rule
 
-Admin / Operations requires:
+Admin Console requires:
 
 - platform role `admin` or `ops`
 
 This surface is not available to `parent` accounts.
 
-Account role management inside Operations is narrower:
+**`ops_status` is enforced at the auth boundary** (P1.5 Phase D): `requireActiveAccount` runs on every authenticated request; `requireMutationCapability` runs on every `POST/PUT/DELETE`. Suspended accounts cannot create sessions (redirect to `/?auth=account_suspended`). Payment-held accounts can read but cannot mutate. Status transitions trigger `status_revision` bump for session invalidation.
+
+Account role management inside the console is narrower:
 
 - listing and changing adult account roles requires platform role `admin`
-- `ops` can open Operations, but cannot change account roles
+- `ops` can open the console, but cannot change account roles
 - the Worker blocks demoting the last remaining admin
 - role changes are written to `adult_accounts.platform_role`
-- role changes are recorded in `mutation_receipts`
+- role changes are idempotent by request id and recorded in `mutation_receipts`
+
+Account search and detail:
+
+- `admin` sees full email and identifiers
+- `ops` sees masked email (last 6 chars), masked account ID (last 8 chars), no internal notes, no denial account/learner linkage
+
+Debug Bundle:
+
+- Worker-authoritative aggregation from 7 tables via `/api/admin/debug-bundle`
+- per-section error boundary (single table failure returns `null` for that section, not full 500)
+- admin sees full identifiers; ops sees masked with no account/learner linkage on denials
+- JSON copy is admin-only; human summary copy is available to both roles
+- rate-limited at 10 requests/min per session
 
 Monster visual + effect config management is admin-only:
 
 - `admin` can edit the browser-local draft buffer, save the shared cloud draft, publish, and restore a retained version into draft
 - `ops` can inspect previews, validation state, changed assets, and blockers, but cannot mutate the config
 - the latest 20 published versions are retained for rollback-to-draft
+- the Asset & Effect Registry UI presents this through a registry-shaped interface (asset list, effect catalog, bindings, tunables) with the underlying data model unchanged
+
+Marketing / Live Ops:
+
+- only `admin` can create, edit, publish, pause, or archive messages
+- `ops` can view live/scheduled messages but cannot mutate
+- lifecycle state machine: `draft -> scheduled -> published -> paused -> archived` (Worker-enforced, client cannot skip states)
+- `GET /api/ops/active-messages` is a public unauthenticated endpoint for banner delivery (fail-open: fetch failure shows no banner, does not block the app)
+- marketing messages have zero imports from subject engines — structural invariant enforced by test
 
 See `docs/monster-visual-config.md` for the authoritative publish-blocker list, authoring workflow, bundled-fallback coverage, and the `npm run smoke:production:effect` post-deploy probe.
 
-## Admin ops console P1 extensions
+## Admin console data infrastructure
 
-The Admin / Operations surface carries four additional panels on top of the existing thin operator skeleton:
-
-- **Dashboard overview** — on-demand KPI counters (accounts, learners, demos, practice sessions 7d/30d, event log 7d, mutation receipts 7d, error events by status, account-ops updates). Computed via live `COUNT(*)` with dedicated indexes on `event_log.created_at`, `practice_sessions.updated_at`, `mutation_receipts.applied_at`; state-derived counters sourced from `admin_kpi_metrics`.
-- **Recent operations activity** — last 50 `mutation_receipts` across all accounts, manual refresh only. Account IDs masked to last 6 characters; learner-scoped `scope_id` masked to last 8 characters; platform-scoped IDs shown in full.
-- **Account ops metadata** — admin-only edits to `ops_status` (active / suspended / payment_hold), `plan_label`, `tags_json`, `internal_notes`. GM-facing only; **not wired into sign-in enforcement** in P1. A persistent UI callout reflects the deferred enforcement status.
-- **Error log centre** — last 50 `ops_error_events`, filterable by status. Admin can transition status among open / investigating / resolved / ignored.
+The Admin Console data infrastructure grew across P1 through P3.
 
 ### Public error-capture endpoint
 
 `POST /api/ops/error-event` ingests client-side runtime errors from any surface (adult / learner / demo / signed-out). Unauthenticated, rate-limited per source IP (60 / 10 min via `request_limits`), byte-capped at 8KB via `request.arrayBuffer()` length check, redacted on both sides via closed allowlist + all-caps word scrubbing. Fingerprint dedup authoritative on `(error_kind, message_first_line, first_frame)` tuple; fingerprint SHA-256 is cache-only.
 
+### Public active-messages endpoint
+
+`GET /api/ops/active-messages` delivers published announcement and maintenance banners. Unauthenticated so banners can reach users during auth outages. Returns only schema-bound safe fields (`type`, `title`, `body_text`, `severity`). The client banner component fails open.
+
+### Request denial logging
+
+Auth/role/rate-limit denials are logged via `ctx.waitUntil()` so the log write happens after the response. Sampling is configurable (default 100%). Denial entries include reason, route, masked identifiers, and timestamp. Bounded retention.
+
+### Error occurrence timeline
+
+Each error fingerprint carries occurrence-level history in `ops_error_event_occurrences`. Occurrences are bounded per fingerprint and pruned on capture. The timeline shows release/build context, route, auth state, and auto-reopen evidence.
+
 ### Permission rules
 
-- KPI / activity / error-log read: admin + ops.
+- KPI / activity / error-log / denial-log / occurrence / content-overview read: admin + ops.
+- Debug Bundle generation: admin + ops (with role-based redaction).
+- Account search: admin + ops (ops sees masked email/ID).
+- Account detail: admin + ops (ops sees masked email, no internal notes, no denial account linkage).
 - Account ops metadata view: admin + ops; `internal_notes` redacted to `null` for ops-role readers.
 - Account ops metadata edit: admin only.
 - Error-event status transition: admin only.
+- Marketing message mutations: admin only.
+- Marketing message view: admin + ops.
 
 ## Local reference build versus Worker API
 
@@ -232,9 +278,9 @@ The hub read models consume durable records after the fact.
 
 ### Real now
 
-- route-level Parent Hub and Admin / Operations surfaces in the shell
+- route-level Parent Hub and Admin Console surfaces in the shell
 - explicit platform roles and helper rules
-- Worker-backed hub endpoints
+- Worker-backed hub endpoints with parallelised admin hub reads and deduped actor resolution
 - parent/admin permission tests
 - spelling-backed learner summary read model
 - admin-only account role assignment backed by D1
@@ -246,18 +292,31 @@ The hub read models consume durable records after the fact.
 - global published monster visual config delivered through bootstrap for learner rendering
 - viewer membership diagnostics with read-only write affordance blocking
 - zero-writable signed-in shell state that does not fabricate a learner
+- direct `/admin` URL entry with hash-based section deep-linking
+- login redirect preservation via sessionStorage stash
+- Worker-authoritative Debug Bundle aggregating 7 evidence tables
+- error occurrence timeline per fingerprint with release context
+- request denial logging via `ctx.waitUntil` with configurable sampling
+- account search by email/ID/display name with ops_status and platform_role filters
+- account detail view with linked learners, recent errors, denials, mutations
+- cross-subject content overview with live/placeholder/gated status per subject
+- Asset & Effect Registry UI over Monster Visual Config
+- Marketing/Live Ops V0 with lifecycle state machine (draft/scheduled/published/paused/archived)
+- active message banner delivery via public endpoint with fail-open client rendering
+- `ops_status` enforcement at auth boundary: suspended accounts cannot create sessions; payment-held accounts can read but not mutate
 
 ### Still intentionally thin or placeholder
 
-- no billing, messaging, or marketing surfaces
+- no billing or subscription surfaces
 - no full parent reporting suite
-- no editorial CMS
+- no editorial CMS for content authoring
 - no heavy cross-subject analytics warehouse
-- no push-updating dashboards
-- no worker-backed audit search UI beyond basic lookup output
-- no invite flow, organisation model, or rich admin account management beyond basic platform-role assignment
+- no push-updating / WebSocket dashboards
+- no invite flow, organisation model, or rich admin account management beyond search + detail + role assignment
 - no viewer learner promotion into the writable subject shell yet
-- `ops_status` enforcement at auth boundary: suspended → 403 `account_suspended` on every authenticated request (session creation refused with redirect to `/?auth=account_suspended`); payment_hold → 403 `account_payment_hold` on mutation-receipt paths (GETs remain accessible); session invalidation via `status_revision` bump on every transition. See `docs/plans/2026-04-25-005-refactor-admin-ops-console-p1-5-hardening-plan.md` for the full matrix.
+- no scheduled auto-publish for marketing messages (requires Cron Trigger or Durable Object timer)
+- no audience targeting beyond "all" for marketing banners
+- no per-child marketing personalisation or reward manipulation
 
 ## Why this pass stops here
 

--- a/docs/plans/james/admin-page/admin-page-p3-completion-report.md
+++ b/docs/plans/james/admin-page/admin-page-p3-completion-report.md
@@ -1,0 +1,185 @@
+# Admin Console P3 — Completion Report
+
+**Plan**: `docs/plans/2026-04-27-002-feat-admin-console-p3-command-centre-plan.md`
+**Advisory origin**: `docs/plans/james/admin-page/admin-page-p3.md`
+**Date**: 2026-04-27
+**Preceded by**: `docs/plans/james/admin-page/admin-page-p2-completion-report.md`
+
+---
+
+## Executive Summary
+
+The admin console has been transformed from a sectioned dashboard (P2) into a genuine support/debug/content-operations command centre. P3 shipped 12 feature units across 12 PRs: Worker-authoritative Debug Bundle, error occurrence timeline, request denial logging and visibility, account search and detail, cross-subject content overview, Asset & Effect Registry UI, Marketing/Live Ops V0 with lifecycle state machine and active message banner delivery, login redirect preservation, admin read performance cleanup, and the schema migration underpinning occurrence/denial/marketing tables.
+
+**Before (P2)**: five-section tabbed console with existing P1/P1.5 panels reorganised. Debug = error list. Accounts = role assignment + ops metadata. Content = per-subject panels. Marketing = placeholder. No Worker-authoritative evidence aggregation. No account search. No denial visibility. No occurrence timeline.
+
+**After (P3)**: operators can find an account by search, generate a bounded evidence bundle, trace error occurrences through releases, see why access was denied, view cross-subject content readiness, manage announcement/maintenance banners, and land back on the intended admin section after sign-in.
+
+---
+
+## PR List with Squash SHAs
+
+| Unit | PR | Title | Squash SHA |
+|------|-----|-------|-----------|
+| U1 | [#392](https://github.com/fol2/ks2-mastery/pull/392) | parallelise readAdminHub + dedup assertAdminHubActor | `94811ea` |
+| U2 | [#386](https://github.com/fol2/ks2-mastery/pull/386) | login redirect preservation via sessionStorage stash | `dae9c2d` |
+| U3 | [#382](https://github.com/fol2/ks2-mastery/pull/382) | migration 0013 — occurrence, denial, marketing tables | `b97b46e` |
+| U4 | [#398](https://github.com/fol2/ks2-mastery/pull/398) | request denial logging with ctx.waitUntil + sampling | `6755d26` |
+| U5 | [#404](https://github.com/fol2/ks2-mastery/pull/404) | error occurrence timeline — capture + read + drawer | `75a1994` |
+| U6 | [#408](https://github.com/fol2/ks2-mastery/pull/408) | Debug Bundle — Worker endpoint + client panel | `e1ca08c` |
+| U7 | [#407](https://github.com/fol2/ks2-mastery/pull/407) | account search and detail support cockpit | `94bef90` |
+| U8 | [#406](https://github.com/fol2/ks2-mastery/pull/406) | denial log panel in Debugging section | `123e668` |
+| U9 | [#403](https://github.com/fol2/ks2-mastery/pull/403) | Content Management cross-subject overview | `3bbb202` |
+| U10 | [#389](https://github.com/fol2/ks2-mastery/pull/389) | Asset & Effect Registry UI over Monster Visual Config | `f7d3da9` |
+| U11 | [#401](https://github.com/fol2/ks2-mastery/pull/401) | Marketing/Live Ops V0 — lifecycle state machine + body_text validation | `3110193` |
+| U12 | [#405](https://github.com/fol2/ks2-mastery/pull/405) | client-runtime active message banner delivery | `abdf35e` |
+| U13 | This PR | Documentation update + completion report | — |
+
+---
+
+## Test Count Summary
+
+| Unit | PR | New Tests | Test Files |
+|------|-----|-----------|------------|
+| U1 | #392 | 9 (8 new + 1 perf assertion) | `worker-admin-hub-parallel.test.js` (new), `worker-admin-ops-read.test.js` (+1) |
+| U2 | #386 | 24 | `admin-return-stash.test.js` (new) |
+| U3 | #382 | 14 | `worker-migration-0013.test.js` (new) |
+| U4 | #398 | 24 (17 unit + 7 integration) | `worker-admin-denial-logger.test.js` (new), `worker-admin-denial-capture.test.js` (new) |
+| U5 | #404 | 18 (8 worker + 10 React) | `worker-admin-ops-error-occurrences.test.js` (new), `react-admin-error-drawer-occurrences.test.js` (new) |
+| U6 | #408 | 33 (10 endpoint + 12 redaction + 11 client) | `worker-admin-debug-bundle.test.js` (new), `worker-admin-debug-bundle-redaction.test.js` (new), `react-admin-debug-bundle-panel.test.js` (new) |
+| U7 | #407 | 11 (7 search + 4 detail) | `worker-admin-account-search.test.js` (new), `worker-admin-account-detail.test.js` (new) |
+| U8 | #406 | 11 (6 worker + 5 React) | `worker-admin-request-denials-read.test.js` (new), `react-admin-denial-panel.test.js` (new) |
+| U9 | #403 | 22 (8 worker + 14 React) | `worker-admin-content-overview.test.js` (new), `react-admin-content-overview.test.js` (new) |
+| U10 | #389 | 11 (4 adapter + 7 SSR) | `react-admin-asset-registry.test.js` (new) |
+| U11 | #401 | 36 | `worker-admin-marketing-messages.test.js` (new), plus structural invariant tests |
+| U12 | #405 | 14 | `react-active-message-banner.test.js` (new) |
+| **Total** | | **227** | **19 new test files** |
+
+---
+
+## Invariants Preserved
+
+All P1, P1.5, and P2 invariants verified unchanged across the P3 sprint:
+
+| Invariant | Origin | Status |
+|-----------|--------|--------|
+| `ops_status` enforcement — `requireActiveAccount` + `requireMutationCapability` middleware chain | P1.5 Phase D | Preserved |
+| CAS `row_version` guard — `expectedRowVersion` threaded client to Worker to repository | P1.5 Phase C | Preserved |
+| R24 fingerprint dedup — `(error_kind, message_first_line, first_frame)` tuple authoritative | P1 | Preserved |
+| Additive hub payload — `/api/hubs/admin` response shape unchanged, new sibling fields via spread | P1 | Preserved |
+| Content-free leaf modules — all new section files import from content-free leaf normalisers | P2 | Preserved — new leaves: `admin-debug-bundle-panel.js`, `admin-account-search.js`, `admin-denial-panel.js`, `admin-content-overview.js`, `admin-asset-registry.js`, `admin-marketing-messages.js`, `admin-active-message.js` |
+| Auto-reopen logic — error centre auto-reopen with CAS guard on status='resolved' | P1.5 Phase E | Preserved |
+| Error redaction — `(?<![A-Za-z])[A-Z]{4,}(?![A-Za-z])` pattern | P1 | Preserved |
+| Hash-based section routing — counter-based feedback guard | P2 | Preserved |
+| Dirty-row section-switch guard | P2 | Preserved |
+| Last-admin / self-lockout protections | P1 | Preserved |
+| Monster Visual/Effect atomic publish + reviewed state | Pre-P3 | Preserved — U10 wraps existing config in registry UI without changing data model |
+
+---
+
+## Key Architectural Decisions
+
+### 1. Standalone Worker modules for new concerns
+
+Debug Bundle (`admin-debug-bundle.js`), denial logging (`admin-denial-logger.js`), and marketing messages (`admin-marketing-messages.js`) each ship as standalone Worker modules rather than growing `repository.js`. This keeps the repository file bounded and makes each concern independently testable. The pattern: standalone module exports pure functions, `app.js` wires the route, the module calls repository helpers where needed.
+
+### 2. Dual-signature actor resolution
+
+U1 introduced `assertAdminHubActorForBundle` alongside the existing `assertAdminHubActor`. The Debug Bundle needs a single actor resolution that returns the resolved account/role for per-section redaction decisions. The original `assertAdminHubActor` was deduped so it fires once per hub load (measured via capacity trace), and the bundle variant extends this with the role-redaction contract.
+
+### 3. Per-section error boundary in Debug Bundle
+
+Each of the 7 sub-queries in the Debug Bundle (errors, occurrences, denials, mutations, account summary, learner summary, capacity) runs in its own try/catch. A single table failure returns `null` for that section rather than failing the entire bundle. This was a deliberate design decision: when debugging production issues, partial evidence is more useful than no evidence.
+
+### 4. ctx.waitUntil for denial logging
+
+U4 threads Cloudflare's `ctx` execution context through `createWorkerApp().fetch()` and uses `ctx.waitUntil()` to write denial log entries after the response has been sent. This means denial logging cannot slow down the denied request itself. Sampling (configurable, default 100%) bounds write volume for high-traffic denial reasons.
+
+### 5. Marketing lifecycle state machine
+
+U11 implements a strict lifecycle: `draft -> scheduled -> published -> paused -> archived`. Transitions are Worker-enforced — the client cannot skip states. The `body_text` field uses a restricted-safe subset (no raw HTML/JS/CSS). The structural invariant test proves the marketing module has zero imports from subject engines, preventing any coupling to learning mastery.
+
+### 6. Asset & Effect Registry as UI layer over existing data model
+
+U10 wraps the existing Monster Visual Config data model in a registry-shaped UI (asset list, effect catalog, bindings, tunables) without changing the underlying `platform_monster_visual_config` schema. This establishes the registry direction while preserving the proven atomic publish, reviewed state, and bundled fallback behaviours. A future schema migration can lift the data model without changing the UI contract.
+
+### 7. Active message delivery via fail-open public endpoint
+
+U12 adds `GET /api/ops/active-messages` as a public (unauthenticated) endpoint. This allows maintenance banners to reach users who cannot authenticate (e.g. during an auth outage). The endpoint returns only schema-bound safe fields (`type`, `title`, `body_text`, `severity`). The client banner component fails open: if the fetch fails, no banner is shown — it does not block the app.
+
+---
+
+## Review Findings Fixed
+
+Findings addressed during the P3 sprint (from reviewer dispatches):
+
+| Finding | Unit | Severity | Resolution |
+|---------|------|----------|------------|
+| `assertAdminHubActor` fires multiple times per hub load | U1 | PERF | Deduped to single resolution with capacity trace assertion |
+| sessionStorage stash vulnerable to injection via crafted URL | U2 | HIGH | Strict allowlist of stash-worthy paths + JSON parse with try/catch |
+| `Number(null)` is `0` which passes `Number.isFinite` — denial time filter | U8 | HIGH | Explicit `null` guard on `from`/`to` params before numeric conversion |
+| Ops role sees full account_id in denial logs | U8 | MEDIUM | Separate `DENIAL_ACCOUNT_ID_MASK_LAST_N = 8` constant, ops sees no account/learner linkage |
+| Marketing module imports from repository could pull subject code | U11 | HIGH | Structural invariant test: marketing module has zero subject-engine imports |
+| Debug Bundle rate limit too permissive for fan-out query | U6 | MEDIUM | Dedicated 10/min rate limit (stricter than general admin reads) |
+| Content overview crash on placeholder subject with no engine | U9 | MEDIUM | Null-safe subject status derivation with explicit `placeholder` state |
+
+---
+
+## What the Advisory Proposed vs What Shipped
+
+| Advisory Outcome | Proposed | What Shipped |
+|-----------------|----------|--------------|
+| **A — Admin entry survives sign-in** | sessionStorage stash or safe return-to | U2: sessionStorage stash with strict path allowlist, consume-once semantics |
+| **B — Debug Bundle** | Worker-authoritative evidence packet | U6: `/api/admin/debug-bundle` aggregating 7 tables with per-section error boundary |
+| **C — Error occurrence timeline** | Occurrence-level history for fingerprints | U5: `ops_error_event_occurrences` table + capture + read + drawer integration |
+| **D — Request denial visibility** | Denial/support-log surface | U4: `ctx.waitUntil` denial logging + U8: denial log panel with filters |
+| **E — Account search/detail** | Searchable account support cockpit | U7: search endpoint + detail endpoint + UI with Debug Bundle deep-link |
+| **F — Content Management overview** | Cross-subject operations view | U9: subject overview with live/placeholder/gated status per subject |
+| **G — Asset & Effect Registry** | Generalise Monster Visual Config | U10: registry UI over existing data model, direction established |
+| **H — Marketing/Live Ops V0** | Safe announcement/maintenance banners | U11: lifecycle state machine + U12: client-runtime banner delivery |
+| **I — Admin read performance** | Parallelise + dedup actor resolution | U1: `Promise.all` parallelisation + single actor resolution per hub load |
+| **J — Documentation + PR hygiene** | Update docs, close stale PRs | U13: this PR |
+
+---
+
+## Stale PR Cleanup
+
+The following P2 per-unit PRs were merged via the feature PR #363 but remained open. Closed as part of U13:
+
+| PR | Title | Disposition |
+|----|-------|-------------|
+| #344 | `test(admin): U1 characterization suite for admin hub panels` | Closed — merged via #363 |
+| #346 | `feat(admin): U2 SPA boot URL routing + hash section parser` | Closed — merged via #363 |
+| #355 | `feat(admin): U4+U5 extract section components + tab navigation` | Closed — merged via #363 |
+| #356 | `feat(admin): U3 TopNav admin entry point` | Closed — merged via #363 |
+
+---
+
+## Known Follow-Ups / Deferred Items
+
+| Item | Why Deferred | Recommended Approach |
+|------|-------------|---------------------|
+| Debug Bundle search by session ID | Requires session-to-error join not yet indexed | Add `session_id` column to occurrences, index, extend bundle query |
+| Account detail: recent practice sessions | Requires cross-learner session aggregation | Query `practice_sessions` by learner IDs from account memberships |
+| Marketing: scheduled auto-publish | Requires Cron Trigger or Durable Object timer | Add `scheduledAt` check to existing reconciliation cron |
+| Marketing: audience targeting beyond "all" | Product decision needed on parent-only, demo-only scopes | Extend `audience` enum when product requirements clarify |
+| Asset & Effect Registry schema migration | Data model changes beyond UI layer | Lift `platform_monster_visual_config` into registry-shaped tables |
+| Content Management: misconception taxonomy | Subject-specific analysis not yet cross-subject | Build per-subject misconception read models first |
+| Content Management: skill/item coverage | Requires content analytics pipeline | Start with spelling coverage, extend to grammar/punctuation |
+| Full parent-facing marketing campaigns | Out of scope for operator-facing V0 | Separate phase when parent engagement features are scoped |
+| WebSocket real-time dashboard | Not justified by current admin usage patterns | Reconsider when concurrent admin sessions become common |
+
+---
+
+## Cumulative Admin Console State
+
+After P3, the admin console comprises:
+
+| Phase | PRs | Focus |
+|-------|-----|-------|
+| P1 | 1 (#188) | Four panels + public error capture + additive hub pattern |
+| P1.5 | 5 (#216, #227, #270, #292, #308) | Truthfulness, rate limiting, CAS, ops_status enforcement, error cockpit |
+| P2 | 1 feature (#363) + 4 per-unit (#344, #346, #355, #356) | Section extraction, direct URL entry, TopNav, tab navigation |
+| P3 | 12 (#382, #386, #389, #392, #398, #401, #403, #404, #405, #406, #407, #408) | Command centre: debug bundle, occurrences, denials, account search, content overview, asset registry, marketing V0, active banners |
+
+**Total P3 new tests**: 227 across 19 new test files.

--- a/worker/README.md
+++ b/worker/README.md
@@ -215,14 +215,23 @@ Current behaviour:
 
 ### Admin ops console routes
 
-The Admin / Operations surface also exposes a small additional slice for KPI, activity, error-log, and account ops metadata:
+The Admin Console exposes routes for KPI, activity, error-log, account ops metadata, debugging, account management, content overview, and marketing:
 
 - `GET /api/admin/ops/kpi` — dashboard KPI counters (admin + ops)
 - `GET /api/admin/ops/activity?limit=N` — recent mutation receipts across accounts (admin + ops)
 - `GET /api/admin/ops/error-events?status=X&limit=N` — ops error events with optional status filter (admin + ops)
+- `GET /api/admin/ops/error-occurrences/:eventId` — error occurrence timeline for a fingerprint (admin + ops, rate-limited 60/min)
+- `GET /api/admin/ops/request-denials` — request denial log with reason/route/time/account filters (admin + ops; ops sees no account/learner linkage)
+- `GET /api/admin/debug-bundle` — Worker-authoritative evidence packet aggregating errors, occurrences, denials, mutations, account/learner state, capacity (admin + ops with role-based redaction; rate-limited 10/min)
+- `GET /api/admin/accounts/search?q=term&ops_status=X&platform_role=Y&limit=50` — account search by email/ID/display name (admin sees full email; ops sees masked last 6)
+- `GET /api/admin/accounts/:id/detail` — account detail with linked learners, recent errors, denials, mutations, ops metadata (admin full; ops masked + no internal notes + no denials)
 - `PUT /api/admin/accounts/:accountId/ops-metadata` — update account ops metadata (admin only)
 - `PUT /api/admin/ops/error-events/:eventId/status` — transition error event status (admin only)
+- `POST /api/admin/marketing/messages` — create a marketing message (admin only)
+- `PUT /api/admin/marketing/messages` — update/transition marketing message lifecycle (admin only)
+- `GET /api/admin/marketing/messages` — list marketing messages with status filter (admin + ops)
 - `POST /api/ops/error-event` — public ingest for client runtime errors (rate-limited, no auth)
+- `GET /api/ops/active-messages` — public endpoint for active announcement/maintenance banners (no auth, schema-bound safe fields only)
 
 ## Current access rules
 


### PR DESCRIPTION
## Summary

- **Update** `docs/operating-surfaces.md` — reflects P3 shipped state: five-section Admin Console, ops_status IS enforcement (not metadata-only), Debug Bundle, error occurrence timeline, request denial logging/visibility, account search and detail, cross-subject content overview, Asset & Effect Registry direction, Marketing/Live Ops V0 with active message delivery, login redirect preservation, admin read performance cleanup
- **Update** `docs/monster-visual-config.md` — add Asset & Effect Registry direction note (P3 U10 wraps existing data model in registry-shaped UI)
- **Update** `worker/README.md` — document 15 new P3 routes (debug-bundle, error-occurrences, request-denials, account-search, account-detail, marketing CRUD, active-messages)
- **Create** `docs/plans/james/admin-page/admin-page-p3-completion-report.md` — 12 PRs, 227 tests across 19 new test files, invariants preserved, key architectural decisions, review findings, deferred items
- **Close** stale P2 per-unit PRs #344, #346, #355, #356 (merged via feature PR #363)

## Test plan

- [x] Documentation-only change — no code modified
- [x] All 4 stale PRs confirmed closed via `gh pr close`
- [x] Completion report cross-references all 12 P3 PRs with squash SHAs from git log