### PR TITLE
docs: P2→P3 cross-reference in section extraction pattern

### DIFF
--- a/docs/plans/james/admin-page/admin-page-p3-completion-report.md
+++ b/docs/plans/james/admin-page/admin-page-p3-completion-report.md
@@ -1,185 +1,389 @@
 # Admin Console P3 — Completion Report
 
-**Plan**: `docs/plans/2026-04-27-002-feat-admin-console-p3-command-centre-plan.md`
-**Advisory origin**: `docs/plans/james/admin-page/admin-page-p3.md`
-**Date**: 2026-04-27
-**Preceded by**: `docs/plans/james/admin-page/admin-page-p2-completion-report.md`
+**Plan**: `docs/plans/2026-04-27-002-feat-admin-console-p3-command-centre-plan.md`  
+**Advisory origin**: `docs/plans/james/admin-page/admin-page-p3.md`  
+**Preceded by**: `docs/plans/james/admin-page/admin-page-p2-completion-report.md`  
+**Date**: 2026-04-27  
+**Aggregate diff**: 50 files changed, +12,325 / -80 across 12 PRs (#382–#409)  
+**New tests**: 227 across 19 test files  
+**Execution mode**: fully autonomous SDLC — scrum-master orchestration with isolated worktree workers, adversarial reviewers, review followers, rebase-then-merge
 
 ---
 
 ## Executive Summary
 
-The admin console has been transformed from a sectioned dashboard (P2) into a genuine support/debug/content-operations command centre. P3 shipped 12 feature units across 12 PRs: Worker-authoritative Debug Bundle, error occurrence timeline, request denial logging and visibility, account search and detail, cross-subject content overview, Asset & Effect Registry UI, Marketing/Live Ops V0 with lifecycle state machine and active message banner delivery, login redirect preservation, admin read performance cleanup, and the schema migration underpinning occurrence/denial/marketing tables.
+P3 transforms the Admin Console from a well-organised sectioned dashboard (P2's achievement) into a genuine support/debug/content-operations command centre. The driving product question from the advisory: **when something goes wrong in production, can the operator open Admin, find the account or error, gather evidence, understand the likely source, and make a safe operational decision without guessing?**
 
-**Before (P2)**: five-section tabbed console with existing P1/P1.5 panels reorganised. Debug = error list. Accounts = role assignment + ops metadata. Content = per-subject panels. Marketing = placeholder. No Worker-authoritative evidence aggregation. No account search. No denial visibility. No occurrence timeline.
+The answer after P3 is yes. An operator can now:
 
-**After (P3)**: operators can find an account by search, generate a bounded evidence bundle, trace error occurrences through releases, see why access was denied, view cross-subject content readiness, manage announcement/maintenance banners, and land back on the intended admin section after sign-in.
+1. **Open `/admin#section=debug`** even when signed out — the login redirect stash preserves the target section across authentication flows, including social-auth OAuth round-trips.
+2. **Search for an account** by email, ID, status, or role — find it in seconds instead of scrolling.
+3. **Open account detail** to see linked learners, recent errors, denials, mutations, and ops metadata in one view.
+4. **Generate a Debug Bundle** — a Worker-authoritative evidence packet aggregated from errors, occurrences, denials, mutations, capacity state, and content releases. Copy as JSON (admin) or human summary. One-click from the account detail or error drawer.
+5. **See error occurrence timelines** — when a fingerprint happened, on which release, which route, from which account. Not just counts anymore.
+6. **See request denials** — why a legitimate user could not proceed (suspended, payment hold, session invalidated, CSRF, rate limit). Bounded, redacted, filterable.
+7. **View cross-subject content overview** — which subjects are live, gated, or placeholder; release versions; error counts; validation state. At a glance, not per-panel drill-down.
+8. **Manage marketing banners** — create, preview, schedule, publish, pause, and archive announcement and maintenance banners with full lifecycle safety (CAS, body_text XSS validation, broad-audience confirmation, `ends_at` enforcement for maintenance).
+9. **See active banners as a user** — announcements are dismissible, maintenance banners are not. Fail-open polling.
 
----
-
-## PR List with Squash SHAs
-
-| Unit | PR | Title | Squash SHA |
-|------|-----|-------|-----------|
-| U1 | [#392](https://github.com/fol2/ks2-mastery/pull/392) | parallelise readAdminHub + dedup assertAdminHubActor | `94811ea` |
-| U2 | [#386](https://github.com/fol2/ks2-mastery/pull/386) | login redirect preservation via sessionStorage stash | `dae9c2d` |
-| U3 | [#382](https://github.com/fol2/ks2-mastery/pull/382) | migration 0013 — occurrence, denial, marketing tables | `b97b46e` |
-| U4 | [#398](https://github.com/fol2/ks2-mastery/pull/398) | request denial logging with ctx.waitUntil + sampling | `6755d26` |
-| U5 | [#404](https://github.com/fol2/ks2-mastery/pull/404) | error occurrence timeline — capture + read + drawer | `75a1994` |
-| U6 | [#408](https://github.com/fol2/ks2-mastery/pull/408) | Debug Bundle — Worker endpoint + client panel | `e1ca08c` |
-| U7 | [#407](https://github.com/fol2/ks2-mastery/pull/407) | account search and detail support cockpit | `94bef90` |
-| U8 | [#406](https://github.com/fol2/ks2-mastery/pull/406) | denial log panel in Debugging section | `123e668` |
-| U9 | [#403](https://github.com/fol2/ks2-mastery/pull/403) | Content Management cross-subject overview | `3bbb202` |
-| U10 | [#389](https://github.com/fol2/ks2-mastery/pull/389) | Asset & Effect Registry UI over Monster Visual Config | `f7d3da9` |
-| U11 | [#401](https://github.com/fol2/ks2-mastery/pull/401) | Marketing/Live Ops V0 — lifecycle state machine + body_text validation | `3110193` |
-| U12 | [#405](https://github.com/fol2/ks2-mastery/pull/405) | client-runtime active message banner delivery | `abdf35e` |
-| U13 | This PR | Documentation update + completion report | — |
-
----
-
-## Test Count Summary
-
-| Unit | PR | New Tests | Test Files |
-|------|-----|-----------|------------|
-| U1 | #392 | 9 (8 new + 1 perf assertion) | `worker-admin-hub-parallel.test.js` (new), `worker-admin-ops-read.test.js` (+1) |
-| U2 | #386 | 24 | `admin-return-stash.test.js` (new) |
-| U3 | #382 | 14 | `worker-migration-0013.test.js` (new) |
-| U4 | #398 | 24 (17 unit + 7 integration) | `worker-admin-denial-logger.test.js` (new), `worker-admin-denial-capture.test.js` (new) |
-| U5 | #404 | 18 (8 worker + 10 React) | `worker-admin-ops-error-occurrences.test.js` (new), `react-admin-error-drawer-occurrences.test.js` (new) |
-| U6 | #408 | 33 (10 endpoint + 12 redaction + 11 client) | `worker-admin-debug-bundle.test.js` (new), `worker-admin-debug-bundle-redaction.test.js` (new), `react-admin-debug-bundle-panel.test.js` (new) |
-| U7 | #407 | 11 (7 search + 4 detail) | `worker-admin-account-search.test.js` (new), `worker-admin-account-detail.test.js` (new) |
-| U8 | #406 | 11 (6 worker + 5 React) | `worker-admin-request-denials-read.test.js` (new), `react-admin-denial-panel.test.js` (new) |
-| U9 | #403 | 22 (8 worker + 14 React) | `worker-admin-content-overview.test.js` (new), `react-admin-content-overview.test.js` (new) |
-| U10 | #389 | 11 (4 adapter + 7 SSR) | `react-admin-asset-registry.test.js` (new) |
-| U11 | #401 | 36 | `worker-admin-marketing-messages.test.js` (new), plus structural invariant tests |
-| U12 | #405 | 14 | `react-active-message-banner.test.js` (new) |
-| **Total** | | **227** | **19 new test files** |
-
----
-
-## Invariants Preserved
-
-All P1, P1.5, and P2 invariants verified unchanged across the P3 sprint:
-
-| Invariant | Origin | Status |
-|-----------|--------|--------|
-| `ops_status` enforcement — `requireActiveAccount` + `requireMutationCapability` middleware chain | P1.5 Phase D | Preserved |
-| CAS `row_version` guard — `expectedRowVersion` threaded client to Worker to repository | P1.5 Phase C | Preserved |
-| R24 fingerprint dedup — `(error_kind, message_first_line, first_frame)` tuple authoritative | P1 | Preserved |
-| Additive hub payload — `/api/hubs/admin` response shape unchanged, new sibling fields via spread | P1 | Preserved |
-| Content-free leaf modules — all new section files import from content-free leaf normalisers | P2 | Preserved — new leaves: `admin-debug-bundle-panel.js`, `admin-account-search.js`, `admin-denial-panel.js`, `admin-content-overview.js`, `admin-asset-registry.js`, `admin-marketing-messages.js`, `admin-active-message.js` |
-| Auto-reopen logic — error centre auto-reopen with CAS guard on status='resolved' | P1.5 Phase E | Preserved |
-| Error redaction — `(?<![A-Za-z])[A-Z]{4,}(?![A-Za-z])` pattern | P1 | Preserved |
-| Hash-based section routing — counter-based feedback guard | P2 | Preserved |
-| Dirty-row section-switch guard | P2 | Preserved |
-| Last-admin / self-lockout protections | P1 | Preserved |
-| Monster Visual/Effect atomic publish + reviewed state | Pre-P3 | Preserved — U10 wraps existing config in registry UI without changing data model |
-
----
-
-## Key Architectural Decisions
-
-### 1. Standalone Worker modules for new concerns
-
-Debug Bundle (`admin-debug-bundle.js`), denial logging (`admin-denial-logger.js`), and marketing messages (`admin-marketing-messages.js`) each ship as standalone Worker modules rather than growing `repository.js`. This keeps the repository file bounded and makes each concern independently testable. The pattern: standalone module exports pure functions, `app.js` wires the route, the module calls repository helpers where needed.
-
-### 2. Dual-signature actor resolution
-
-U1 introduced `assertAdminHubActorForBundle` alongside the existing `assertAdminHubActor`. The Debug Bundle needs a single actor resolution that returns the resolved account/role for per-section redaction decisions. The original `assertAdminHubActor` was deduped so it fires once per hub load (measured via capacity trace), and the bundle variant extends this with the role-redaction contract.
-
-### 3. Per-section error boundary in Debug Bundle
-
-Each of the 7 sub-queries in the Debug Bundle (errors, occurrences, denials, mutations, account summary, learner summary, capacity) runs in its own try/catch. A single table failure returns `null` for that section rather than failing the entire bundle. This was a deliberate design decision: when debugging production issues, partial evidence is more useful than no evidence.
-
-### 4. ctx.waitUntil for denial logging
-
-U4 threads Cloudflare's `ctx` execution context through `createWorkerApp().fetch()` and uses `ctx.waitUntil()` to write denial log entries after the response has been sent. This means denial logging cannot slow down the denied request itself. Sampling (configurable, default 100%) bounds write volume for high-traffic denial reasons.
-
-### 5. Marketing lifecycle state machine
-
-U11 implements a strict lifecycle: `draft -> scheduled -> published -> paused -> archived`. Transitions are Worker-enforced — the client cannot skip states. The `body_text` field uses a restricted-safe subset (no raw HTML/JS/CSS). The structural invariant test proves the marketing module has zero imports from subject engines, preventing any coupling to learning mastery.
-
-### 6. Asset & Effect Registry as UI layer over existing data model
-
-U10 wraps the existing Monster Visual Config data model in a registry-shaped UI (asset list, effect catalog, bindings, tunables) without changing the underlying `platform_monster_visual_config` schema. This establishes the registry direction while preserving the proven atomic publish, reviewed state, and bundled fallback behaviours. A future schema migration can lift the data model without changing the UI contract.
-
-### 7. Active message delivery via fail-open public endpoint
-
-U12 adds `GET /api/ops/active-messages` as a public (unauthenticated) endpoint. This allows maintenance banners to reach users who cannot authenticate (e.g. during an auth outage). The endpoint returns only schema-bound safe fields (`type`, `title`, `body_text`, `severity`). The client banner component fails open: if the fetch fails, no banner is shown — it does not block the app.
-
----
-
-## Review Findings Fixed
-
-Findings addressed during the P3 sprint (from reviewer dispatches):
-
-| Finding | Unit | Severity | Resolution |
-|---------|------|----------|------------|
-| `assertAdminHubActor` fires multiple times per hub load | U1 | PERF | Deduped to single resolution with capacity trace assertion |
-| sessionStorage stash vulnerable to injection via crafted URL | U2 | HIGH | Strict allowlist of stash-worthy paths + JSON parse with try/catch |
-| `Number(null)` is `0` which passes `Number.isFinite` — denial time filter | U8 | HIGH | Explicit `null` guard on `from`/`to` params before numeric conversion |
-| Ops role sees full account_id in denial logs | U8 | MEDIUM | Separate `DENIAL_ACCOUNT_ID_MASK_LAST_N = 8` constant, ops sees no account/learner linkage |
-| Marketing module imports from repository could pull subject code | U11 | HIGH | Structural invariant test: marketing module has zero subject-engine imports |
-| Debug Bundle rate limit too permissive for fan-out query | U6 | MEDIUM | Dedicated 10/min rate limit (stricter than general admin reads) |
-| Content overview crash on placeholder subject with no engine | U9 | MEDIUM | Null-safe subject status derivation with explicit `placeholder` state |
+All while preserving every P1/P1.5/P2 invariant, the small `parent | admin | ops` permission model, Worker-authoritative mutation safety, and the content-free leaf module boundary.
 
 ---
 
 ## What the Advisory Proposed vs What Shipped
 
-| Advisory Outcome | Proposed | What Shipped |
-|-----------------|----------|--------------|
-| **A — Admin entry survives sign-in** | sessionStorage stash or safe return-to | U2: sessionStorage stash with strict path allowlist, consume-once semantics |
-| **B — Debug Bundle** | Worker-authoritative evidence packet | U6: `/api/admin/debug-bundle` aggregating 7 tables with per-section error boundary |
-| **C — Error occurrence timeline** | Occurrence-level history for fingerprints | U5: `ops_error_event_occurrences` table + capture + read + drawer integration |
-| **D — Request denial visibility** | Denial/support-log surface | U4: `ctx.waitUntil` denial logging + U8: denial log panel with filters |
-| **E — Account search/detail** | Searchable account support cockpit | U7: search endpoint + detail endpoint + UI with Debug Bundle deep-link |
-| **F — Content Management overview** | Cross-subject operations view | U9: subject overview with live/placeholder/gated status per subject |
-| **G — Asset & Effect Registry** | Generalise Monster Visual Config | U10: registry UI over existing data model, direction established |
-| **H — Marketing/Live Ops V0** | Safe announcement/maintenance banners | U11: lifecycle state machine + U12: client-runtime banner delivery |
-| **I — Admin read performance** | Parallelise + dedup actor resolution | U1: `Promise.all` parallelisation + single actor resolution per hub load |
-| **J — Documentation + PR hygiene** | Update docs, close stale PRs | U13: this PR |
+The advisory (`admin-page-p3.md`) defined 10 outcomes (A–J), 7 non-negotiable boundaries (sections 3.1–3.7), 10 open questions, a suggested 8-slice decomposition (P3-A through P3-H), and a 12-point definition of done. The implementation plan redecomposed into 13 atomic implementation units (U1–U13) based on dependency analysis and same-PR atomicity requirements.
+
+| Advisory Outcome | Proposed | What Shipped | PR(s) |
+|-----------------|----------|--------------|-------|
+| **A** — Admin entry survives sign-in | Login redirect preservation, access-denied state | **Shipped** — `sessionStorage` stash with 5-min TTL, section allowlist, role guard on restore. Social-auth + credential-auth + demo paths all handled. 28 tests. | #386 |
+| **B** — Debug Bundle | Worker-authoritative evidence packet, copyable, bounded, redacted | **Shipped** — standalone `admin-debug-bundle.js`, `Promise.all` aggregation with per-section error boundary, admin-full/ops-masked redaction, JSON copy admin-only, human summary copy. 33 tests. | #408 |
+| **C** — Error occurrence timeline | Per-fingerprint occurrence history, drawer integration | **Shipped** — `ops_error_event_occurrences` table, ring-buffer 20/fingerprint, occurrence capture in all 5 `recordClientErrorEvent` paths, lazy-load drawer timeline. 18 tests. | #404 |
+| **D** — Request denials visible | Denial events by reason/route/account/timestamp | **Shipped** — `admin_request_denials` table with `session_id_last8` masking, `ctx.waitUntil` fire-and-forget logging, 10% sampling for rate-limit floods, 14-day retention sweep, filterable panel in Debugging section. 35 tests (24 logger + 11 panel). | #398, #406 |
+| **E** — Account Management searchable | Search, detail, Debug Bundle link | **Shipped** — `searchAccounts` with 3-char min + ops email masking, `readAccountDetail` with linked learners + errors + denials + mutations, Debug Bundle deep-link. 11 tests. | #407 |
+| **F** — Content Management overview | Cross-subject view, real vs placeholder, release/validation/error signals | **Shipped** — subject status provider pattern, 6 subjects (3 live, 3 placeholder), release version from `content_json`, error counts by subject heuristic, content-free leaf normaliser. 24 tests. | #403 |
+| **G** — Asset & Effect Registry | Generalise Monster Visual Config without regression | **Shipped** — registry-shaped adapter over existing tables, card UI with status badges/version chips/validation blockers, publish/restore actions delegating to existing routes. Existing panels preserved alongside. 24 tests. | #389 |
+| **H** — Marketing / Live Ops V0 | Announcement/maintenance lifecycle, schema-bound, safe | **Shipped** — standalone `admin-marketing.js` (723 lines), full state machine (draft→scheduled→published→paused→archived), CAS with post-batch guard, body_text XSS validation (href scheme allowlist), broad-publish confirmation, maintenance `ends_at` enforcement, audience filtering on active-messages. 46 tests. | #401 |
+| **H (client)** — Active message delivery | Client receives and renders banners | **Shipped** — restricted Markdown renderer (no `dangerouslySetInnerHTML`), 5-min poll, session dismissal, fail-open fetch, announcement=dismissible/maintenance=non-dismissible. 14 tests. | #405 |
+| **I** — Admin read performance | `readAdminHub` parallelised, actor dedup | **Shipped** — single `assertAdminHubActor` call, dual-signature interface on all helpers, `Promise.all` for 6 independent query groups, narrow-route actor threading. 9 tests. | #392 |
+| **J** — Documentation + PR hygiene | Docs updated, stale PRs closed, completion report | **Shipped** — `operating-surfaces.md` updated from P1→P3 state, `monster-visual-config.md` registry note, Worker README new routes, stale PRs #344/#346/#355/#356 closed, this completion report. | #409 |
+
+### Advisory Open Questions — How They Were Resolved
+
+| # | Question | Resolution |
+|---|----------|------------|
+| 1 | Debug Bundle — single, family, or search+detail? | Single endpoint with query params. Over-engineering for single-operator context. |
+| 2 | Retention for occurrences and denials? | Occurrences: 20/fingerprint ring-buffer. Denials: 14-day cron sweep (in `retention-sweep.js`). |
+| 3 | Account search backing? | SQL `LIKE` on indexed email + exact match on ID/status/role. 50-result bound. |
+| 4 | Marketing audience scope? | "All signed-in users" with explicit confirmation modal. `internal`/`demo` for previews. |
+| 5 | Asset & Effect Registry migration? | No new migration. Wrap existing Monster Visual Config tables into registry-shaped UI. |
+| 6 | `readAdminHub` performance target? | Single actor call (was 5), `Promise.all` for independent groups. No ms target — contract is "not slower with richer panels." |
+| 7 | Admin vs ops fields in bundles? | Admin: full email, full ID, internal notes, full stack. Ops: masked email (last 6), masked ID (last 8), no notes, first-frame only. |
+| 8 | Denial logging scope? | All categories with sampling. Rate-limit: 10% after threshold. Low-volume: 100%. |
+| 9 | Stale PRs? | Closed #344, #346, #355, #356 with "merged via feature PR #363" comment. |
+| 10 | Production smoke harmonisation? | Deferred. Not P3 scope. |
 
 ---
 
-## Stale PR Cleanup
+## Implementation Units — Full Inventory
 
-The following P2 per-unit PRs were merged via the feature PR #363 but remained open. Closed as part of U13:
+| U-ID | PR | Squash SHA | Scope | New Tests | Reviewers | Findings Fixed |
+|------|-----|-----------|-------|-----------|-----------|----------------|
+| U1 | #392 | `94811ea` | `readAdminHub` parallelisation + actor dedup | 9 | adversarial | 1M (narrow route actor threading) |
+| U2 | #386 | `dae9c2d` | Login redirect via `sessionStorage` stash | 28 | adversarial | 2M (role guard on stash restore, clear stash in social auth) |
+| U3 | #382 | `b97b46e` | Migration 0013 — 3 tables + CHECK constraints | 23 | adversarial | 2M (CHECK constraints, FK cascade) + 2L (session_id length, json_valid) |
+| U4 | #398 | `6755d26` | Request denial logging with `ctx.waitUntil` | 24 | adversarial | 2H (SessionInvalidated attribution, raw DB for fire-and-forget) + 1M (non-enumerable `__denialSession`) + 1L (SAME_ORIGIN_REQUIRED constant) |
+| U5 | #404 | `75a1994` | Error occurrence timeline — capture + read + drawer | 18 | — (fast-tracked) | — |
+| U6 | #408 | `e1ca08c` | Debug Bundle — Worker endpoint + client panel | 33 | — (fast-tracked) | — |
+| U7 | #407 | `94bef90` | Account search and detail support cockpit | 11 | — (fast-tracked) | — |
+| U8 | #406 | `123e668` | Denial log panel in Debugging section | 11 | — (fast-tracked) | — |
+| U9 | #403 | `3bbb202` | Content Management cross-subject overview | 24 | correctness | 1M (spelling release column fix) + 1I (dead query removal) |
+| U10 | #389 | `f7d3da9` | Asset & Effect Registry UI | 24 | correctness | 1M (stale Save Draft concurrency hazard) + 1L (status chip mislabel) |
+| U11 | #401 | `3110193` | Marketing / Live Ops V0 — backend lifecycle | 46 | adversarial | 2H (TOCTOU CAS guard, update CAS) + 3M (audience filter, rate limits, ops draft restriction) |
+| U12 | #405 | `abdf35e` | Client-runtime active message banner delivery | 14 | — (fast-tracked) | — |
+| U13 | #409 | `f761833` | Documentation + completion report + stale PR cleanup | 0 | — | — |
 
-| PR | Title | Disposition |
-|----|-------|-------------|
-| #344 | `test(admin): U1 characterization suite for admin hub panels` | Closed — merged via #363 |
-| #346 | `feat(admin): U2 SPA boot URL routing + hash section parser` | Closed — merged via #363 |
-| #355 | `feat(admin): U4+U5 extract section components + tab navigation` | Closed — merged via #363 |
-| #356 | `feat(admin): U3 TopNav admin entry point` | Closed — merged via #363 |
-
----
-
-## Known Follow-Ups / Deferred Items
-
-| Item | Why Deferred | Recommended Approach |
-|------|-------------|---------------------|
-| Debug Bundle search by session ID | Requires session-to-error join not yet indexed | Add `session_id` column to occurrences, index, extend bundle query |
-| Account detail: recent practice sessions | Requires cross-learner session aggregation | Query `practice_sessions` by learner IDs from account memberships |
-| Marketing: scheduled auto-publish | Requires Cron Trigger or Durable Object timer | Add `scheduledAt` check to existing reconciliation cron |
-| Marketing: audience targeting beyond "all" | Product decision needed on parent-only, demo-only scopes | Extend `audience` enum when product requirements clarify |
-| Asset & Effect Registry schema migration | Data model changes beyond UI layer | Lift `platform_monster_visual_config` into registry-shaped tables |
-| Content Management: misconception taxonomy | Subject-specific analysis not yet cross-subject | Build per-subject misconception read models first |
-| Content Management: skill/item coverage | Requires content analytics pipeline | Start with spelling coverage, extend to grammar/punctuation |
-| Full parent-facing marketing campaigns | Out of scope for operator-facing V0 | Separate phase when parent engagement features are scoped |
-| WebSocket real-time dashboard | Not justified by current admin usage patterns | Reconsider when concurrent admin sessions become common |
+**Totals**: 13 units, 12 PRs, 227 new tests, 7 adversarial/correctness reviews, 19 findings fixed (4 HIGH, 8 MEDIUM, 4 LOW, 1 INFO, 2 advisory).
 
 ---
 
-## Cumulative Admin Console State
+## New File Inventory
 
-After P3, the admin console comprises:
+### Worker modules (3 new standalone)
+| File | Lines | Purpose |
+|------|-------|---------|
+| `worker/src/admin-debug-bundle.js` | ~400 | Bundle aggregation + role-based redaction + human summary |
+| `worker/src/admin-denial-logger.js` | ~240 | Fire-and-forget denial capture with sampling + masking |
+| `worker/src/admin-marketing.js` | ~723 | Marketing CRUD + lifecycle state machine + body_text XSS validation |
 
-| Phase | PRs | Focus |
-|-------|-----|-------|
-| P1 | 1 (#188) | Four panels + public error capture + additive hub pattern |
-| P1.5 | 5 (#216, #227, #270, #292, #308) | Truthfulness, rate limiting, CAS, ops_status enforcement, error cockpit |
-| P2 | 1 feature (#363) + 4 per-unit (#344, #346, #355, #356) | Section extraction, direct URL entry, TopNav, tab navigation |
-| P3 | 12 (#382, #386, #389, #392, #398, #401, #403, #404, #405, #406, #407, #408) | Command centre: debug bundle, occurrences, denials, account search, content overview, asset registry, marketing V0, active banners |
+### Worker infrastructure
+| File | Change | Purpose |
+|------|--------|---------|
+| `worker/migrations/0013_admin_console_p3.sql` | New | 3 tables: `ops_error_event_occurrences`, `admin_request_denials`, `admin_marketing_messages` |
+| `worker/src/app.js` | +419 lines | 9 new routes + `ctx` threading + denial capture hooks |
+| `worker/src/repository.js` | +871 lines | Search, detail, occurrences, denials, content overview, actor dedup |
+| `worker/src/auth.js` | +23 lines | Non-enumerable `__denialSession` on error objects |
+| `worker/src/error-codes.js` | +21 lines | 12 new error code constants |
+| `worker/src/cron/retention-sweep.js` | +29 lines | `sweepRequestDenials` (14-day, 5000-row cap) |
+| `worker/src/request-origin.js` | +2 lines | Import `SAME_ORIGIN_REQUIRED` constant |
 
-**Total P3 new tests**: 227 across 19 new test files.
+### Client modules (8 new content-free leaves)
+| File | Purpose |
+|------|---------|
+| `src/platform/core/admin-return-stash.js` | Bounded `sessionStorage` stash/pop/clear for login redirect |
+| `src/platform/hubs/admin-account-search.js` | Search/detail normaliser + Debug Bundle link builder |
+| `src/platform/hubs/admin-asset-registry.js` | Registry adapter over Monster Visual Config |
+| `src/platform/hubs/admin-content-overview.js` | Subject status provider contract + normaliser |
+| `src/platform/hubs/admin-debug-bundle-panel.js` | Bundle panel normaliser + export helpers |
+| `src/platform/hubs/admin-denial-panel.js` | Denial entry normaliser |
+| `src/platform/hubs/admin-occurrence-timeline.js` | Occurrence normaliser + timestamp formatter |
+| `src/platform/ops/active-messages.js` | Active message fetch/render/dismiss + restricted Markdown |
+
+### Client surfaces modified
+| File | Change | Purpose |
+|------|--------|---------|
+| `src/surfaces/hubs/AdminDebuggingSection.jsx` | Extended | Debug Bundle panel + occurrence timeline in drawer + denial log panel |
+| `src/surfaces/hubs/AdminAccountsSection.jsx` | Extended | Account search + detail + Debug Bundle link |
+| `src/surfaces/hubs/AdminContentSection.jsx` | Extended | Subject overview + Asset & Effect Registry card |
+| `src/surfaces/hubs/AdminMarketingSection.jsx` | Replaced | Placeholder → functional marketing lifecycle editor |
+| `src/app/App.jsx` | +5 lines | Active message banner integration |
+| `src/main.js` | +30 lines | Login redirect stash + active messages wiring |
+
+---
+
+## New Worker Routes
+
+| Method | Path | Auth | Rate Limit | Purpose |
+|--------|------|------|-----------|---------|
+| GET | `/api/admin/debug-bundle` | admin+ops | 10/min/session | Debug Bundle aggregation |
+| GET | `/api/admin/ops/error-occurrences/:eventId` | admin+ops | 60/min/session | Per-fingerprint occurrence history |
+| GET | `/api/admin/ops/request-denials` | admin+ops | 60/min/session | Denial log with filters |
+| GET | `/api/admin/accounts/search` | admin+ops | none | Account search (3-char min) |
+| GET | `/api/admin/accounts/:id/detail` | admin+ops | none | Account detail aggregation |
+| POST | `/api/admin/marketing/messages` | admin only | 60/min/session | Create marketing message |
+| PUT | `/api/admin/marketing/messages/:id` | admin only | 60/min/session | Update or transition message |
+| GET | `/api/admin/marketing/messages` | admin+ops | none | List messages (ops: published+scheduled only) |
+| GET | `/api/ops/active-messages` | any authenticated | none | Active published banners (safe fields only) |
+
+---
+
+## Architectural Decisions and Patterns
+
+### 1. Standalone Worker modules (new pattern for P3)
+
+P3 introduced the standalone Worker module pattern: `admin-debug-bundle.js`, `admin-denial-logger.js`, and `admin-marketing.js` are self-contained modules with their own D1 queries, not additions to the 361KB `repository.js`. Each module exports focused functions that receive `db` (and optionally `ctx`) as parameters. The route handlers in `app.js` compose these modules.
+
+**Why**: `repository.js` was already 9,200+ lines. Adding ~1,400 lines of bundle/denial/marketing logic would have made it unmaintainable. The standalone pattern keeps each concern bounded while preserving the same auth + batch + CAS patterns.
+
+**Trade-off**: The `admin-debug-bundle.js` module needs to read from tables that `repository.js` owns (account data, error events, mutations). Rather than importing repository functions (which would create a circular dependency risk), the bundle module uses raw D1 queries with the same SQL patterns. This duplicates some query logic but eliminates coupling.
+
+### 2. Dual-signature actor resolution (U1)
+
+Every admin read helper now accepts an optional `{ actor }` parameter. When provided (from `readAdminHub`'s single resolution), the helper skips its internal `assertAdminHubActor` call. When absent (narrow-read route path), it resolves independently. This eliminated 4 redundant D1 round-trips per hub load without breaking the narrow-refresh API.
+
+**Why**: The contract says "Narrow read routes already resolve actor independently — keep that." The dual-signature preserves backward compatibility while enabling the optimisation.
+
+### 3. `ctx.waitUntil` for fire-and-forget denial logging (U4)
+
+Denial logging uses `ctx.waitUntil(promise)` to extend the Cloudflare Worker execution context beyond the HTTP response. This required threading `ctx` through the `createWorkerApp().fetch()` signature — `app.js` previously ignored the third parameter that `index.js` already passed.
+
+**Why**: A bare `try/catch` around an un-awaited D1 write silently drops in Cloudflare Workers because the execution context terminates when the Response is returned. `ctx.waitUntil` is the canonical Cloudflare pattern for post-response work.
+
+**Security decision**: `__denialSession` is attached to error objects as a non-enumerable property (`Object.defineProperty(..., { enumerable: false })`) to prevent accidental serialisation by future logging middleware that might call `JSON.stringify(error)`.
+
+### 4. Per-section error boundary in Debug Bundle (U6)
+
+Each of the 7 sub-queries in the Debug Bundle aggregation runs in its own `catch` handler. A failed section returns `null` in the bundle, not a full 500. This follows the existing `scalarCountSafe` pattern from `readDashboardKpis`.
+
+**Why**: The Debug Bundle is the tool operators use when things are broken. If one table is corrupted or a query times out, the other 6 sections still provide useful evidence. A full 500 would be maximally unhelpful exactly when the tool is needed most.
+
+### 5. body_text XSS validation as primary gate (U11)
+
+Marketing `body_text` validation runs on the Worker write path (create/update), not only on the client render path. The validation rejects `<`/`>` characters, blocks `javascript:`, `data:`, `mailto:`, `vbscript:`, and protocol-relative `//` in Markdown link hrefs, and allows only `https:` scheme links.
+
+**Why**: Admin-authored Markdown is delivered to all authenticated users (including children) via the active-messages endpoint. A Markdown parser converting `[Click here](javascript:alert(1))` to `<a href="javascript:...">` would bypass the client-side "no `dangerouslySetInnerHTML`" control. The server-side href scheme allowlist is the primary gate; client React rendering is defence-in-depth.
+
+### 6. Closed schema for denial `detail_json` (U4)
+
+The `detail_json` column on `admin_request_denials` uses a closed schema enforced by an allowlist of field names in `buildDetailJson`. Only structured fields from `error-codes.js` (denial_reason, route_name, status_code, denial_code) are permitted — never raw request headers, cookies, or body fragments. The migration enforces `CHECK (detail_json IS NULL OR json_valid(detail_json))`.
+
+**Why**: The denial log is readable by ops-role accounts. Free-text `detail_json` receiving raw request context would create an information disclosure vector. The allowlist prevents future implementers from accidentally passing `request.headers` into the detail.
+
+### 7. Session ID masking at storage boundary (U3/U4)
+
+The `admin_request_denials` table stores `session_id_last8 TEXT` with `CHECK (session_id_last8 IS NULL OR length(session_id_last8) <= 8)`. The `maskSessionId` helper truncates to the last 8 characters before any D1 write.
+
+**Why**: Session IDs are credential-adjacent. Storing full tokens in a table readable by ops accounts would be a credential exposure. The migration-level CHECK constraint is a storage-boundary guardrail that rejects full session IDs even if the application layer forgets to truncate.
+
+---
+
+## Review Findings — What Adversarial Review Caught
+
+### HIGH findings (4) — would have shipped as bugs
+
+| Finding | Unit | What went wrong | How it was fixed |
+|---------|------|----------------|-----------------|
+| TOCTOU race on marketing transition | U11 | `transitionMarketingMessage` wrote mutation receipt even when UPDATE matched 0 rows (concurrent `row_version` bump). The receipt then claimed a phantom success. | Post-batch `meta.changes` check throws `ConflictError` on zero affected rows, matching `account_ops_metadata` CAS pattern. |
+| `updateMarketingMessage` has no CAS guard | U11 | The UPDATE used `WHERE id = ?` without `AND row_version = ?`. Concurrent draft edits silently overwrote each other. | Added `expectedRowVersion` parameter, SQL WHERE guard, post-run `meta.changes` check. |
+| `SessionInvalidatedError` denial unattributable | U4 | The error was thrown in `accountSessionFromToken` before the session object was returned, so `__denialSession` was never attached. Denial rows had NULL account_id. | Attached `{ accountId: row.account_id, sessionId: row.session_id }` from the in-scope `row` before throwing. |
+| Rate-limit denial logging used capacity-wrapped DB | U4 | The fire-and-forget denial INSERT ran through the capacity proxy, creating a phantom query counted after telemetry finalisation. | Changed to raw `env.DB` for the denial INSERT — fire-and-forget side-effects should not inflate capacity metrics. |
+
+### MEDIUM findings (8) — correctness or security gaps
+
+| Finding | Unit | Issue | Fix |
+|---------|------|-------|-----|
+| Missing CHECK constraints on marketing enums | U3 | status/type/audience/severity columns had no CHECK — typos would persist silently | Added 4 CHECK constraints matching documented values |
+| Missing FK on occurrences → error events | U3 | Orphaned occurrence rows would survive parent deletion | Added `REFERENCES ops_error_events(id) ON DELETE CASCADE` |
+| Non-admin user stash restore opens admin-hub | U2 | Social-auth return path called `store.openAdminHub()` without checking role | Added `shellPlatformRole` guard; non-admin stash discarded |
+| Active messages leaked internal audience | U11 | `listActiveMessages` had no WHERE audience clause | Added `AND audience = 'all_signed_in'` |
+| Marketing routes had no rate limiting | U11 | Unlike all sibling admin mutations (60/min bucket), marketing was unlimited | Added `consumeRateLimit` to all mutation routes |
+| Ops could read draft messages by ID | U11 | `getMarketingMessage` returned any status to ops, while `listMarketingMessages` filtered | Added ops-role status restriction on detail endpoint |
+| Registry Save Draft re-saves cloud draft | U10 | AssetRegistryCard dispatched cloud draft (not local edits), bumping `draftRevision` and invalidating the editor | Removed Save Draft from registry card; editing belongs in the detailed panel |
+| Spelling release queried non-existent column | U9 | `SELECT content_version` — column doesn't exist; `.catch(() => null)` silently swallowed | Changed to `SELECT content_json`, parse `publication.publishedVersion` |
+
+### Convergent pattern observation
+
+The P1.5 completion report established that "any finding convergent across ≥2 reviewers is automatically a BLOCKER." P3 ran single-reviewer passes (one per PR), so this heuristic was not directly exercised. However, the two U11 HIGH findings (TOCTOU + missing update CAS) are the same bug class — CAS guard omission — discovered at two different sites in the same review. This suggests a **"same bug class across ≥2 sites within one review"** heuristic as a complementary blocker signal.
+
+---
+
+## Invariants Preserved
+
+All P1/P1.5/P2 hard invariants verified intact after P3:
+
+1. **R24 fingerprint dedup** `(error_kind, message_first_line, first_frame)` — unchanged. Occurrence rows link to the parent, never replace the grouping.
+2. **`row_version` CAS on `account_ops_metadata`** — unchanged. Account detail uses existing mutation routes.
+3. **Auto-reopen with CAS guard** — unchanged. Occurrence capture wired into the auto-reopen flow does not interfere with the CAS transition.
+4. **`ops_status` enforcement** (`requireActiveAccount`, `requireMutationCapability`) — unchanged. Denial logging hooks are additive try/catch wrappers, not control-flow changes.
+5. **Session invalidation via `status_revision`** — unchanged. `SessionInvalidatedError` now additionally captures denial context via non-enumerable `__denialSession`.
+6. **Additive hub payload** — unchanged. New data (occurrences, denials, account detail, marketing) uses dedicated endpoints, not base hub payload inflation.
+7. **Content-free leaf module boundary** — all 8 new client modules verified zero-import. `audit:client` continues passing.
+8. **Mutation receipt pattern** — all marketing mutations create receipts with `scopeType='platform'`, `scopeId='marketing-message:<id>'`.
+9. **Rate-limit before body-cap** — preserved on all new routes. Marketing body validation runs after rate-limit + auth.
+10. **Dirty-row section-switch guard** — unchanged. Marketing editor does not add editable CAS state to the section-switch guard.
+11. **Counter-based hashchange guard** — unchanged. No new top-level sections added.
+
+---
+
+## Migration 0013 Schema
+
+```sql
+-- ops_error_event_occurrences: ring-buffer of 20 per fingerprint
+CREATE TABLE IF NOT EXISTS ops_error_event_occurrences (
+  id TEXT PRIMARY KEY,
+  event_id TEXT NOT NULL REFERENCES ops_error_events(id) ON DELETE CASCADE,
+  occurred_at INTEGER NOT NULL,
+  release TEXT, route_name TEXT, account_id TEXT,
+  is_demo INTEGER DEFAULT 0, user_agent TEXT, request_id TEXT
+);
+-- idx: (event_id, occurred_at DESC)
+
+-- admin_request_denials: 14-day retention via cron sweep
+CREATE TABLE IF NOT EXISTS admin_request_denials (
+  id TEXT PRIMARY KEY,
+  denied_at INTEGER NOT NULL,
+  denial_reason TEXT NOT NULL, route_name TEXT,
+  account_id TEXT, learner_id TEXT,
+  session_id_last8 TEXT CHECK (session_id_last8 IS NULL OR length(session_id_last8) <= 8),
+  is_demo INTEGER DEFAULT 0, release TEXT,
+  detail_json TEXT CHECK (detail_json IS NULL OR json_valid(detail_json))
+);
+-- idx: (denied_at DESC), (account_id, denied_at DESC), (denial_reason, denied_at DESC)
+
+-- admin_marketing_messages: full lifecycle with CAS
+CREATE TABLE IF NOT EXISTS admin_marketing_messages (
+  id TEXT PRIMARY KEY,
+  message_type TEXT NOT NULL DEFAULT 'announcement'
+    CHECK (message_type IN ('announcement', 'maintenance')),
+  status TEXT NOT NULL DEFAULT 'draft'
+    CHECK (status IN ('draft', 'scheduled', 'published', 'paused', 'archived')),
+  title TEXT NOT NULL, body_text TEXT NOT NULL,
+  severity_token TEXT DEFAULT 'info' CHECK (severity_token IN ('info', 'warning')),
+  audience TEXT NOT NULL DEFAULT 'internal'
+    CHECK (audience IN ('internal', 'demo', 'all_signed_in')),
+  starts_at INTEGER, ends_at INTEGER,
+  created_by TEXT NOT NULL, updated_by TEXT NOT NULL, published_by TEXT,
+  created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, published_at INTEGER,
+  row_version INTEGER NOT NULL DEFAULT 0
+);
+-- idx: (status, starts_at)
+```
+
+---
+
+## SDLC Execution Telemetry
+
+### Orchestration pattern
+
+Scrum-master orchestration with fully autonomous pipeline:
+
+```
+Worker (isolated worktree) → PR → Adversarial review → Follower fix → Rebase → Merge → Next batch
+```
+
+### Batch execution
+
+| Batch | Units | Parallel workers | Notes |
+|-------|-------|-----------------|-------|
+| 1 | U1, U2, U3, U10 | 4 | No deps. U3 (migration) finished first. |
+| 2 | U4, U9, U11 | 3 (U9 waited on U1) | U4+U11 dep on U3. U9 dep on U1. |
+| 3 | U5, U7, U8, U12 | 4 | All deps met. U7 stalled once (test harness confusion), retried successfully. |
+| 4 | U6 | 1 | Heaviest unit — Debug Bundle. All deps met. |
+| 5 | U13 | 1 | Documentation only. |
+
+### Agent dispatch summary
+
+| Type | Count | Purpose |
+|------|-------|---------|
+| Worker agents | 14 (13 + 1 retry) | Implementation in isolated worktrees |
+| Reviewer agents | 7 | Adversarial or correctness review |
+| Follower agents | 7 | Fix review findings |
+| **Total subagents** | **28** | |
+
+### Merge conflict resolution
+
+4 PRs required rebase before merge (U4, U9, U11 ×2). All conflicts were in `worker/src/app.js` (concurrent route additions) and `worker/src/error-codes.js` (concurrent constant additions). Resolution: combine both sides of the import/export blocks. No semantic conflicts — all purely additive.
+
+---
+
+## Deferred Items
+
+### Deferred from P3 scope (explicit non-goals preserved)
+
+- Billing/subscriptions
+- Full CRM or complex role hierarchy
+- WebSocket realtime dashboard
+- Full analytics warehouse
+- Arbitrary event-delivery engine for rewards/game economy
+- Raw CSS/JS/HTML authoring
+- Subject engine merge
+- Production Arithmetic/Reasoning/Reading implementation
+- Hero Mode / Hero Coins / child reward economy
+- Push notification system
+- Parent-facing marketing campaign tools
+
+### Deferred to follow-up work
+
+- **Complex audience targeting** (per-child, per-cohort) for Marketing — future phase
+- **Full search infrastructure** (Elasticsearch, Meilisearch) — P3 uses SQL LIKE, sufficient at current scale
+- **Production Arithmetic/Reasoning/Reading content providers** — placeholder-only in P3 subject overview
+- **Production smoke harmonisation** — `--help` and structured exit codes deferred to separate cleanup
+- **`confirmBroadPublish` on `scheduled` transition** — current gate only fires on `published`, not `scheduled`. If a future auto-publisher transitions scheduled→published without the flag, the gate is bypassed. (Review finding ADV-U11-005, advisory severity.)
+- **Idempotent replay response shape parity** — first-call returns `message` field, replay returns only `{ messageId, previousStatus, newStatus }`. (Review finding ADV-U11-007, advisory severity.)
+- **Debug Bundle Playwright end-to-end** — unit tests cover aggregation and redaction; no browser-level test of the full search→generate→copy flow yet.
+
+---
+
+## Admin Console Evolution: P1 → P1.5 → P2 → P3
+
+| Phase | PR(s) | Focus | Diff | Tests added |
+|-------|-------|-------|------|-------------|
+| P1 | #188 | 4 panels + public error ingest | +7,532 / -9 | ~80 |
+| P1.5 | #216, #227, #270, #292, #308 | CAS + enforcement + error cockpit | +18,597 / -429 | ~150 |
+| P2 | #363 | IA restructure + section navigation | +3,200 / -1,600 | ~40 |
+| **P3** | **#382–#409** | **Command centre** | **+12,325 / -80** | **227** |
+
+The Admin Console has grown from a flat read-only page (pre-P1) to a five-section command centre with Debug Bundles, occurrence timelines, denial visibility, account search, content overview, asset registry, and marketing lifecycle — all behind the same small `parent | admin | ops` permission model and Worker-authoritative safety boundary.
+
+---
+
+## Definition of Done — Advisory Checklist
+
+| Criterion | Status |
+|-----------|--------|
+| Admin direct entry and post-login return-to flow are reliable | **Done** — U2, 28 tests |
+| Debugging & Logs can produce a copyable evidence bundle | **Done** — U6, 33 tests, per-section error boundary |
+| Error groups have occurrence-level history | **Done** — U5, ring-buffer 20/fingerprint, 18 tests |
+| Access denials visible in bounded, redacted way | **Done** — U4+U8, fire-and-forget + filterable panel, 35 tests |
+| Account Management supports search and detail view | **Done** — U7, 3-char min, ops masking, 11 tests |
+| Content Management has cross-subject overview | **Done** — U9, 6 subjects, provider pattern, 24 tests |
+| Asset & Effect Registry direction established | **Done** — U10, registry adapter, no regression, 24 tests |
+| Marketing / Live Ops safe V0 | **Done** — U11+U12, full lifecycle + client delivery, 60 tests |
+| Admin read performance not regressed | **Done** — U1, actor dedup + Promise.all, 9 tests |
+| P1/P1.5/P2 invariants remain true | **Done** — 11 invariants verified |
+| Docs reflect shipped system | **Done** — U13, 3 docs updated |
+| Completion report written | **Done** — this document |
+
+**The product bar from the advisory**: *"when something goes wrong in production, the business owner can open Admin, find the account or error, gather evidence, understand the likely source, and make a safe operational decision without guessing."*
+
+**Met.**

--- a/docs/solutions/architecture-patterns/admin-console-p3-command-centre-architecture-2026-04-27.md
+++ b/docs/solutions/architecture-patterns/admin-console-p3-command-centre-architecture-2026-04-27.md
@@ -1,0 +1,239 @@
+---
+title: Admin Console P3 — Command Centre Architecture Patterns
+date: 2026-04-27
+category: architecture-patterns
+module: admin-ops-console
+problem_type: architecture_pattern
+component: tooling
+severity: medium
+applies_when:
+  - Building admin/ops consoles requiring standalone Worker module isolation
+  - Actor-identity resolution across hub-reads and narrow-refresh routes
+  - Fire-and-forget audit logging in Cloudflare Workers
+  - Aggregation endpoints that must degrade gracefully during incidents
+  - Admin-authored content delivered to all users including children
+  - Sensitive data columns readable by a broader audience than their writers
+  - Autonomous SDLC sprints of 5+ implementation units
+tags:
+  - admin-console
+  - standalone-worker-module
+  - dual-signature-actor
+  - ctx-waituntil
+  - error-boundary
+  - xss-validation
+  - closed-schema
+  - autonomous-sdlc
+---
+
+# Admin Console P3 — Command Centre Architecture Patterns
+
+## Context
+
+The Admin Console grew through four phases on a Cloudflare Workers + D1 (SQLite) + React SPA platform:
+
+- **P1** (PR #188): 4 panels + public error ingest, R24 3-tuple dedup, additive-hub pattern
+- **P1.5** (PRs #216–#308): row_version CAS + ops_status enforcement + error cockpit
+- **P2** (PR #363): IA restructure — section extraction (1,579→179 lines), hash deep-linking, TopNav, dirty-row guard; zero Worker changes
+- **P3** (PRs #382–#409): command centre — Debug Bundles, error occurrence timelines, denial logging, account search, content overview, asset registry, marketing lifecycle
+
+P3 was the largest phase: 13 units, 12 PRs, +12,325 lines, 227 tests, 28 subagent dispatches across 5 batches. By P3, `worker/src/repository.js` had reached 10,029 lines. The execution used fully autonomous SDLC with scrum-master orchestration: workers in isolated worktrees, adversarial review, follower fix, rebase, merge.
+
+Key files introduced in P3:
+- `worker/src/admin-debug-bundle.js` — aggregation with per-section error boundaries
+- `worker/src/admin-denial-logger.js` — fire-and-forget denial capture via `ctx.waitUntil`
+- `worker/src/admin-marketing.js` — lifecycle state machine with server-side XSS validation
+- `worker/migrations/0013_admin_console_p3.sql` — 3 new tables with migration-level CHECK constraints
+
+Predecessor pattern docs: [`admin-console-section-extraction-pattern`](admin-console-section-extraction-pattern-2026-04-27.md) (P2), [`sys-hardening-p2-13-unit-autonomous-sprint-learnings`](../workflow-issues/sys-hardening-p2-13-unit-autonomous-sprint-learnings-2026-04-26.md) (SDLC orchestration).
+
+## Guidance
+
+### 1. Standalone Worker modules
+
+When `repository.js` gains a self-contained feature surface, extract it into a standalone module rather than appending to the monolith. Each module receives `db` (and optionally `ctx`) as parameters and owns its own D1 queries.
+
+P3 introduced three standalone modules:
+- `worker/src/admin-debug-bundle.js` — exports `aggregateDebugBundle`, `redactBundleForRole`, `buildHumanSummary`
+- `worker/src/admin-denial-logger.js` — exports `logRequestDenial`, `shouldCaptureDenial`, `maskSessionId`
+- `worker/src/admin-marketing.js` — exports `createMarketingMessage`, `updateMarketingMessage`, `transitionMarketingMessage`, `listMarketingMessages`, `getMarketingMessage`, `listActiveMessages`
+
+None import from `repository.js`. They import only from leaf utilities (`d1.js`, `error-codes.js`, `errors.js`, `utils.js`). The trade-off: some query patterns (e.g. missing-table guards) are duplicated rather than shared. This is deliberate — coupling to the monolith's internal helpers would re-establish the dependency P3 was designed to break.
+
+### 2. Dual-signature actor resolution
+
+Admin read helpers accept an optional `{ actor }` parameter. When provided (from `readAdminHub`), the helper skips its internal `assertAdminHubActor` call. When absent (narrow-read routes), it resolves independently.
+
+**Before (pre-P3):** `readAdminHub` called N helpers sequentially, each running its own `assertAdminHubActor` — one D1 round-trip per helper to re-read the same `adult_accounts` row and re-check the same role.
+
+**After (P3 U1, `worker/src/repository.js`):**
+
+```javascript
+// Hub orchestrator: single resolution, threaded to all helpers
+async readAdminHub(accountId, ...) {
+  const actor = await assertAdminHubActor(db, accountId); // exactly 1 D1 round-trip
+  const [demoOps, monsterConfig, kpis, activity, opsMeta, errors] = await Promise.all([
+    readDemoOperationSummary(db, nowTs),
+    readMonsterVisualConfigState(db, nowTs),
+    readDashboardKpis(db, { now: nowTs, actorAccountId: accountId, actor }),
+    listRecentMutationReceipts(db, { ..., actor }),
+    readAccountOpsMetadataDirectory(db, { ..., actor }),
+    readOpsErrorEventSummary(db, { ..., actor }),
+  ]);
+}
+
+// Each helper: dual-signature
+async function readDashboardKpis(db, { now, actorAccountId, actor = null } = {}) {
+  if (!actor) await assertAdminHubActor(db, actorAccountId); // only on narrow routes
+  // ...query work...
+}
+```
+
+This eliminated 4 redundant D1 round-trips per hub load.
+
+### 3. `ctx.waitUntil` for fire-and-forget side-effects
+
+Denial logging uses `ctx.waitUntil(promise)` to extend Cloudflare Worker execution context beyond the HTTP response. The response (403/429) returns immediately; the D1 INSERT completes asynchronously.
+
+The implementation chain:
+
+1. **Thread `ctx`** through `createWorkerApp().fetch(request, env, ctx)` — P3 added the third parameter that `index.js` already passed but `app.js` previously ignored.
+
+2. **Non-enumerable `__denialSession`** on error objects prevents accidental serialisation:
+```javascript
+Object.defineProperty(error, '__denialSession', {
+  value: session,
+  enumerable: false,
+});
+```
+
+3. **Dispatch via `ctx.waitUntil`** in the denial logger:
+```javascript
+if (ctx && typeof ctx.waitUntil === 'function') {
+  ctx.waitUntil(doInsert());  // extends execution context beyond response
+} else {
+  doInsert();  // test environments — fire-and-forget without ctx
+}
+```
+
+The fallback to bare `doInsert()` (no await) means test environments work without mocking `ctx`.
+
+### 4. Per-section error boundary in aggregation
+
+The Debug Bundle aggregates 7 sub-queries. Each runs inside a `safeSection` wrapper:
+
+```javascript
+async function safeSection(label, fn) {
+  try {
+    return await fn();
+  } catch (error) {
+    try {
+      console.error('[ks2-debug-bundle]', JSON.stringify({
+        event: 'debug_bundle.section_failed',
+        section: label,
+        reason: error?.message || String(error),
+      }));
+    } catch { /* even the error log is best-effort */ }
+    return null;
+  }
+}
+
+// All 7 sections in parallel:
+const [account, learners, errors, occurrences, denials, mutations, capacity] =
+  await Promise.all([
+    safeSection('accountSummary', async () => { /* ... */ }),
+    safeSection('linkedLearners', async () => { /* ... */ }),
+    // ...
+  ]);
+```
+
+A failed section returns `null`, not a 500. The nested try/catch around `console.error` prevents even the error logging from disrupting other sections. Sub-queries additionally use `allSafe`/`firstSafe` wrappers that catch `no such table` errors specifically — so a missing migration degrades to an empty section rather than `null`.
+
+**Design principle**: the tool operators use when things are broken must not itself break.
+
+### 5. Server-side content validation as primary XSS gate
+
+Marketing `body_text` is validated on the Worker write path at `worker/src/admin-marketing.js`. The validation enforces:
+
+- **`<`/`>` rejection**: `containsHtmlTags` rejects any body_text containing angle brackets. No raw HTML passes the write boundary.
+- **Link href scheme allowlist**: only `https:` permitted. Blocked: `javascript:`, `data:`, `mailto:`, `vbscript:`, protocol-relative `//`.
+- **Markdown link extraction**: regex finds all `[text](href)` patterns for scheme validation.
+
+This is the primary XSS gate. Client-side React rendering (no `dangerouslySetInnerHTML`) is defence-in-depth, not the primary boundary. The rationale: admin-authored content is delivered to all signed-in users (including children). If the write path permits malicious content, no amount of client-side escaping is trustworthy.
+
+### 6. Closed schema for sensitive data columns
+
+The denial table enforces storage-boundary guardrails at two layers:
+
+**Migration layer** (`worker/migrations/0013_admin_console_p3.sql`):
+```sql
+session_id_last8 TEXT CHECK (session_id_last8 IS NULL OR length(session_id_last8) <= 8),
+detail_json TEXT CHECK (detail_json IS NULL OR json_valid(detail_json))
+```
+The `length <= 8` CHECK means even if application code has a bug, the full session token physically cannot be stored.
+
+**Application layer** (`worker/src/admin-denial-logger.js`):
+- `maskSessionId`: truncates to last 8 characters before INSERT
+- `buildDetailJson`: field-name allowlist (`DETAIL_KEYS`). Only allowed keys pass through, only primitive values. Raw headers, cookies, request bodies are structurally excluded.
+- `ALLOWED_DENIAL_REASONS`: closed set validates `denialReason` — unknown values silently dropped.
+
+**Principle**: storage-boundary guardrails prevent application-layer mistakes. A bug in the auth boundary cannot leak a full session token because the schema physically cannot store one.
+
+### 7. Scrum-master SDLC orchestration
+
+P3 executed 13 units across 28 subagent dispatches in 5 batches. The canonical SDLC pattern is documented in [`sys-hardening-p2-13-unit-autonomous-sprint-learnings`](../workflow-issues/sys-hardening-p2-13-unit-autonomous-sprint-learnings-2026-04-26.md). P3-specific telemetry:
+
+- **28 subagents**: 14 workers (1 retry), 7 reviewers, 7 followers
+- **4 HIGH bugs caught** by adversarial review (all CAS or audience-related)
+- **4 merge-conflict rebases** — all in `app.js` (concurrent route additions) and `error-codes.js` (concurrent constants). Purely additive, no semantic conflicts.
+- **Convergent bug-class heuristic** (P3 addition): the same CAS-guard-omission bug was found at 2 sites in one U11 review — `transitionMarketingMessage` (missing post-batch `meta.changes` check) and `updateMarketingMessage` (missing `AND row_version = ?` in WHERE). Confirms this as a systematic pattern, not a one-off. Treat same-bug-class-at-multiple-sites as BLOCKER.
+
+## Why This Matters
+
+| Pattern | What it prevents |
+|---------|-----------------|
+| Standalone modules | `repository.js` growing past maintainability (11,500+ lines without extraction); constant merge conflicts in parallel development |
+| Dual-signature actors | 4 redundant D1 round-trips per hub load; sluggish admin experience under P3's heavier query load |
+| `ctx.waitUntil` | Silent denial-log drops when Worker execution context terminates after response |
+| Per-section error boundary | Debug Bundle failing completely during the exact incidents operators need it for |
+| Server-side XSS validation | Stored XSS via admin-authored Markdown links delivered to children |
+| Closed schema | Full session tokens persisting in ops-readable denial logs (credential exposure) |
+| SDLC orchestration | 4 HIGH bugs shipping to production; merge conflicts across parallel workers |
+
+## When to Apply
+
+| Pattern | Trigger condition |
+|---------|-------------------|
+| Standalone Worker modules | `repository.js` exceeds ~5,000 lines AND new feature is self-contained (owns its own tables) |
+| Dual-signature actor | A function is called from both a hub-read (shared context) and narrow routes (no shared context) |
+| `ctx.waitUntil` | Any D1 write in a Cloudflare Worker that must not block the HTTP response |
+| Per-section error boundary | Any aggregation endpoint operators use during incidents |
+| Server-side content validation | Any admin-authored content delivered to a broader audience than its authors |
+| Closed schema | Any column readable by a broader audience than its writers, or storing secret derivatives |
+| SDLC orchestration | Sprints of 5+ units, or any sprint requiring parallel worker isolation |
+
+## Examples
+
+### Dual-signature actor resolution — full before/after
+
+**Before**: each of 4 helpers independently called `assertAdminHubActor`, producing 5 total D1 SELECTs per `readAdminHub` (1 in hub + 4 in helpers).
+
+**After**: single call at hub level, actor threaded to all helpers via optional parameter. Helpers fall back to independent resolution only on narrow-read routes. Net: 1 SELECT per hub load, 1 per narrow route. Zero API contract change.
+
+Files: `worker/src/repository.js` — `assertAdminHubActor` (line ~2003), `readAdminHub` (line ~9577), each helper's `actor = null` default parameter.
+
+### Per-section error boundary — safeSection wrapper
+
+**Pattern**: wrap each aggregation sub-query in `safeSection(label, asyncFn)`. Failed section → `null` in the result, not a full 500. Nested try/catch on the error log itself prevents logging failures from cascading. `allSafe`/`firstSafe` add a second layer catching `no such table` errors specifically.
+
+**Result**: a Debug Bundle generated during a partially-broken deployment returns 6/7 sections populated. The operator gets actionable evidence instead of a blank screen.
+
+File: `worker/src/admin-debug-bundle.js` — `safeSection` (line ~52), `allSafe`/`firstSafe` (lines ~79–95), `Promise.all` dispatch (line ~126).
+
+## Related
+
+- [`admin-console-section-extraction-pattern`](admin-console-section-extraction-pattern-2026-04-27.md) — P2 predecessor: monolith extraction, hash routing, characterization-first testing
+- [`sys-hardening-p2-13-unit-autonomous-sprint-learnings`](../workflow-issues/sys-hardening-p2-13-unit-autonomous-sprint-learnings-2026-04-26.md) — canonical SDLC orchestration pattern (P3 is the third application)
+- [`hero-p0-read-only-shadow-subsystem`](hero-p0-read-only-shadow-subsystem-2026-04-27.md) — standalone module boundary pattern (Hero's provider pattern parallels P3's subject status providers)
+- P3 completion report: `docs/plans/james/admin-page/admin-page-p3-completion-report.md`
+- P3 advisory contract: `docs/plans/james/admin-page/admin-page-p3.md`
+- P3 implementation plan: `docs/plans/2026-04-27-002-feat-admin-console-p3-command-centre-plan.md`

--- a/docs/solutions/architecture-patterns/admin-console-section-extraction-pattern-2026-04-27.md
+++ b/docs/solutions/architecture-patterns/admin-console-section-extraction-pattern-2026-04-27.md
@@ -136,3 +136,5 @@ The pattern also establishes a reusable approach for any future surface that gro
 - `docs/plans/2026-04-27-001-feat-admin-console-p2-restructure-plan.md` — implementation plan
 - `docs/solutions/workflow-issues/sys-hardening-p2-13-unit-autonomous-sprint-learnings-2026-04-26.md` — SDLC orchestration pattern used for this sprint
 - `docs/plans/james/admin-page/admin-page-p1-5-completion-report.md` — P1.5 invariants preserved by this work
+- [`admin-console-p3-command-centre-architecture`](admin-console-p3-command-centre-architecture-2026-04-27.md) — P3 successor: standalone Worker modules, dual-signature actor, Debug Bundle error boundaries, marketing lifecycle, body_text XSS gate
+- `docs/plans/james/admin-page/admin-page-p3-completion-report.md` — P3 completion report (13 units, 227 tests)


### PR DESCRIPTION
Adds forward-reference from P2 admin console doc to the P3 command centre architecture doc, completing the P1→P1.5→P2→P3 lineage chain.