### PR TITLE
security(csp): add enforcement decision gate and mode constant

### DIFF
--- a/docs/hardening/csp-enforcement-decision.md
+++ b/docs/hardening/csp-enforcement-decision.md
@@ -59,6 +59,26 @@ The flip PR is in scope IF AND ONLY IF all of the following are true:
 3. The operator has added an `Operator sign-off` row under **Sign-off** below dated within the 7 days preceding the flip PR's open date.
 4. `tests/csp-inline-style-budget.test.js` still passes (the migration from SH2-U8 has not regressed).
 
+### Violation volume thresholds (P4-U4 addendum)
+
+The flip criteria above require zero unexpected violations. The following
+thresholds formalise what "unexpected" means in terms of volume and origin:
+
+| Category | Threshold | Action |
+| --- | --- | --- |
+| **Third-party** `violated-directive` + `blocked-uri` pairs (e.g. CDN, analytics, browser extension) | **≤ 5 unique pairs** across the full 7-day window | Add each pair to ALLOWLIST.md with adversarial-reviewer sign-off; proceed with flip. |
+| **Third-party** pairs | **> 5 unique pairs** | Defer flip; investigate whether the CSP allowlist is incomplete for the production request mix. Restart the observation window after allowlist PR lands. |
+| **First-party** violation — any `blocked-uri` that is `self`, relative, or matches the repo production domain | **Any (≥ 1)** | **Defer flip unconditionally.** First-party blocks mean the policy is stricter than our own assets require. The correct response is an inventory-driven migration (style/script extraction) or a narrow allowlist, not the enforcement flip. |
+
+#### Inline style count prerequisite
+
+The enforcement flip additionally requires `tests/csp-inline-style-budget.test.js`
+to pass at merge time. This test guards the `style-src 'unsafe-inline'`
+surface — if the inline-style count has regressed above the committed budget,
+enforcement would generate a flood of first-party `style-src-elem` violations
+that drown genuine attack signal. The budget test acts as a mechanical gate:
+no ratchet regression, no flip.
+
 ### Deferral criteria (no flip — stay on Report-Only)
 
 The flip does NOT happen in a follow-up PR if any of the following appear during the window:

--- a/tests/security-headers.test.js
+++ b/tests/security-headers.test.js
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
+  CSP_ENFORCEMENT_MODE,
   CSP_INLINE_SCRIPT_HASH,
   CSP_POLICY_VALUE,
   REPORT_TO_VALUE,
@@ -720,4 +721,61 @@ test('_headers repo file contains the CSP Report-Only line (pre-substitution via
   assert.match(content, /report-uri \/api\/security\/csp-report/);
   assert.match(content, /Report-To:[^\n]*csp-endpoint/);
   assert.match(content, /Reporting-Endpoints:[^\n]*csp-endpoint/);
+});
+
+// ---------------------------------------------------------------------------
+// P4-U4: CSP enforcement decision gate — mode constant and header assertions.
+// ---------------------------------------------------------------------------
+
+test('CSP_ENFORCEMENT_MODE export equals "report-only" (P4-U4 decision gate)', () => {
+  assert.equal(
+    CSP_ENFORCEMENT_MODE,
+    'report-only',
+    'CSP_ENFORCEMENT_MODE must be "report-only" until the observation window '
+      + 'closes and the enforcement flip PR lands. See '
+      + 'docs/hardening/csp-enforcement-decision.md.',
+  );
+});
+
+test('SECURITY_HEADERS contains Content-Security-Policy-Report-Only, not Content-Security-Policy (P4-U4)', () => {
+  assert.ok(
+    SECURITY_HEADERS['Content-Security-Policy-Report-Only'],
+    'SECURITY_HEADERS must carry the Report-Only key while CSP_ENFORCEMENT_MODE is "report-only".',
+  );
+  assert.equal(
+    SECURITY_HEADERS['Content-Security-Policy'],
+    undefined,
+    'SECURITY_HEADERS must NOT carry the enforced Content-Security-Policy key '
+      + 'while in report-only mode.',
+  );
+});
+
+test('upgrade-insecure-requests is NOT present in CSP directives while in report-only mode (P4-U4)', () => {
+  // Per CSP3, upgrade-insecure-requests is ignored in Report-Only delivery
+  // and Chrome emits a console warning. It should only be restored in the
+  // same PR that flips the header to enforced.
+  assert.ok(
+    !CSP_POLICY_VALUE.includes('upgrade-insecure-requests'),
+    'upgrade-insecure-requests must not appear in CSP while delivery is '
+      + 'Report-Only. Re-add it in the enforcement flip PR.',
+  );
+});
+
+test('applySecurityHeaders response contains Content-Security-Policy-Report-Only header (P4-U4)', () => {
+  const response = new Response('test', {
+    status: 200,
+    headers: { 'content-type': 'text/plain' },
+  });
+  const wrapped = applySecurityHeaders(response, { path: '/test' });
+  assert.ok(
+    wrapped.headers.get('content-security-policy-report-only'),
+    'applySecurityHeaders must stamp Content-Security-Policy-Report-Only '
+      + 'on every response while in report-only mode.',
+  );
+  assert.equal(
+    wrapped.headers.get('content-security-policy'),
+    null,
+    'applySecurityHeaders must NOT stamp the enforced Content-Security-Policy '
+      + 'header while CSP_ENFORCEMENT_MODE is "report-only".',
+  );
 });

--- a/worker/src/security-headers.js
+++ b/worker/src/security-headers.js
@@ -37,6 +37,12 @@ function warnOnPlaceholderHashOnce() {
   );
 }
 
+// P4-U4: CSP enforcement mode constant. Tests and operational tooling import
+// this to assert the header name matches the intended delivery mode. The flip
+// from 'report-only' to 'enforced' ships in a dedicated PR gated on the
+// observation window documented in docs/hardening/csp-enforcement-decision.md.
+export const CSP_ENFORCEMENT_MODE = 'report-only';
+
 export const HSTS_VALUE = 'max-age=63072000; includeSubDomains';
 
 export const PERMISSIONS_POLICY = [


### PR DESCRIPTION
## Summary

- Add exported `CSP_ENFORCEMENT_MODE = 'report-only'` constant to `worker/src/security-headers.js` so tests and operational tooling can programmatically assert the current CSP delivery mode
- Extend `docs/hardening/csp-enforcement-decision.md` with violation volume thresholds (≤5 unique third-party pairs -> ALLOWLIST, any first-party -> defer) and an explicit inline style count prerequisite reference to `tests/csp-inline-style-budget.test.js`
- Add 4 new test assertions to `tests/security-headers.test.js`:
  - `CSP_ENFORCEMENT_MODE` export equals `'report-only'`
  - `SECURITY_HEADERS` contains `Content-Security-Policy-Report-Only` key (not enforced `Content-Security-Policy`)
  - `upgrade-insecure-requests` is NOT present in CSP directives while in report-only mode
  - `applySecurityHeaders` response carries the Report-Only header, not the enforced header

This is a **gate only** — CSP is NOT flipped to enforced. The enforcement flip ships in a separate PR after the 7-day observation window closes on or after 2026-05-04 with zero unexpected violations.

Plan reference: `docs/plans/james/sys-hardening/sys-hardening-p4.md` P4-U4.

## Test plan

- [x] All 40 `tests/security-headers.test.js` tests pass (36 existing + 4 new P4-U4 assertions)
- [x] No changes to CSP header value or delivery mode — zero regression risk
- [x] `CSP_ENFORCEMENT_MODE` is exported and testable by downstream tooling
- [x] Decision doc extended (not duplicated) with quantified violation thresholds and inline style prerequisite