### PR TITLE
capacity(local): restructure Worker exports for workerd compatibility

### DIFF
--- a/tests/security-headers.test.js
+++ b/tests/security-headers.test.js
@@ -13,7 +13,7 @@ import {
   applySecurityHeaders,
   serialiseHeadersBlock,
 } from '../worker/src/security-headers.js';
-import { applySecurityHeadersSafely } from '../worker/src/index.js';
+import { applySecurityHeadersSafely } from '../worker/src/security-headers-safe.js';
 import { assertHeadersBlockIsFresh } from '../scripts/lib/headers-drift.mjs';
 import { createWorkerRepositoryServer } from './helpers/worker-server.js';
 

--- a/tests/worker-cron-trigger-reconcile.test.js
+++ b/tests/worker-cron-trigger-reconcile.test.js
@@ -10,12 +10,13 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { createMigratedSqliteD1Database } from './helpers/sqlite-d1.js';
-import workerModule, {
+import workerModule from '../worker/src/index.js';
+import {
   runScheduledHandler,
   CRON_METRIC_SUCCESS_COUNTER,
   CRON_METRIC_LAST_SUCCESS_AT,
   CRON_METRIC_LAST_FAILURE_AT,
-} from '../worker/src/index.js';
+} from '../worker/src/cron/scheduled.js';
 import { reconcileLockHashForRequestId } from '../worker/src/repository.js';
 
 function seedAdultAccount(db, {

--- a/tests/worker-index-exports.test.js
+++ b/tests/worker-index-exports.test.js
@@ -1,0 +1,40 @@
+// Capacity (local harness) contract: the Worker entry module
+// (`worker/src/index.js`) must export ONLY the surface that workerd
+// validates — `default { fetch, scheduled }` and the `LearnerLock`
+// Durable Object class. Any additional named exports (utility functions,
+// constants) cause workerd to reject the module during `wrangler dev
+// --local`, blocking the local capacity harness.
+//
+// This test acts as a regression gate: if a future PR accidentally
+// re-exports a helper or constant from index.js, this assertion fails
+// before the change reaches the capacity harness or production deploy.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import * as indexModule from '../worker/src/index.js';
+
+// The set of named exports workerd expects from the main module.
+// `default` is the module's default export (the { fetch, scheduled }
+// handler object) and is always present on the namespace object.
+// `LearnerLock` is the Durable Object class declared in wrangler.jsonc.
+const ALLOWED_EXPORTS = new Set(['default', 'LearnerLock']);
+
+test('worker/src/index.js exports only the workerd-compatible surface (default + LearnerLock)', () => {
+  const actualExports = new Set(Object.keys(indexModule));
+  const unexpected = [...actualExports].filter((key) => !ALLOWED_EXPORTS.has(key));
+
+  assert.deepStrictEqual(
+    unexpected,
+    [],
+    `index.js must not export anything beyond ${[...ALLOWED_EXPORTS].join(', ')}. ` +
+    `Found unexpected exports: ${unexpected.join(', ')}. ` +
+    'Move helpers/constants to a separate module and import them from there.',
+  );
+
+  // Positive assertions: the required exports are present and shaped correctly.
+  assert.ok(indexModule.default, 'default export must be present');
+  assert.equal(typeof indexModule.default.fetch, 'function', 'default.fetch must be a function');
+  assert.equal(typeof indexModule.default.scheduled, 'function', 'default.scheduled must be a function');
+  assert.equal(typeof indexModule.LearnerLock, 'function', 'LearnerLock must be a class/function');
+});

--- a/worker/src/cron/scheduled.js
+++ b/worker/src/cron/scheduled.js
@@ -1,0 +1,199 @@
+/**
+ * Cron scheduled handler — extracted from index.js so the Worker entry
+ * point exports only the workerd-required surface: `default { fetch,
+ * scheduled }` + the `LearnerLock` Durable Object class.
+ *
+ * All cron metric constants, telemetry helpers, and the
+ * `runScheduledHandler` entrypoint live here. index.js imports and
+ * delegates to `runScheduledHandler`; tests import directly from this
+ * module.
+ */
+
+import { reconcileAdminKpiMetricsInternal } from '../repository.js';
+import { runRetentionSweeps } from './retention-sweep.js';
+import { run } from '../d1.js';
+
+// U11: capacity-telemetry metric keys for cron success / failure.
+// Surfaced on the admin dashboard; failure timestamp being ahead of the
+// success timestamp triggers a warn banner.
+export const CRON_METRIC_SUCCESS_COUNTER = 'capacity.cron.reconcile.success';
+export const CRON_METRIC_LAST_SUCCESS_AT = 'capacity.cron.reconcile.last_success_at';
+export const CRON_METRIC_LAST_FAILURE_AT = 'capacity.cron.reconcile.last_failure_at';
+// H1 (Phase C reviewer): separate telemetry channel for the retention
+// sweep arm. A sweep failure used to be a console.error-only path, which
+// meant the admin dashboard showed the reconciliation arm green while
+// `mutation_receipts` / `request_limits` overflowed silently. The
+// retention-specific metric lets the banner light up on either arm.
+export const CRON_METRIC_RETENTION_LAST_FAILURE_AT = 'capacity.cron.retention.last_failure_at';
+
+async function bumpCronMetricCounter(db, key, now) {
+  try {
+    await run(db, `
+      INSERT INTO admin_kpi_metrics (metric_key, metric_count, updated_at)
+      VALUES (?, 1, ?)
+      ON CONFLICT(metric_key) DO UPDATE SET
+        metric_count = admin_kpi_metrics.metric_count + 1,
+        updated_at = ?
+    `, [key, now, now]);
+  } catch (error) {
+    // I5 (Phase C reviewer): distinct structured event so operators can
+    // grep for "telemetry write failed" separately from "cron itself
+    // failed". When this fires, the dashboard's success/failure banner
+    // may lag one cycle; the next run reconciles.
+    console.error('[ks2-cron]', JSON.stringify({
+      event: 'cron.telemetry.write_failed',
+      channel: 'counter',
+      key,
+      reason: error?.message || String(error),
+    }));
+  }
+}
+
+async function writeCronMetricTimestamp(db, key, now) {
+  try {
+    await run(db, `
+      INSERT INTO admin_kpi_metrics (metric_key, metric_count, updated_at)
+      VALUES (?, ?, ?)
+      ON CONFLICT(metric_key) DO UPDATE SET
+        metric_count = ?,
+        updated_at = ?
+    `, [key, now, now, now, now]);
+  } catch (error) {
+    // I5 (Phase C reviewer): same distinct structured event.
+    console.error('[ks2-cron]', JSON.stringify({
+      event: 'cron.telemetry.write_failed',
+      channel: 'timestamp',
+      key,
+      reason: error?.message || String(error),
+    }));
+  }
+}
+
+/**
+ * U11 scheduled handler.
+ *
+ * Runs reconciliation through the shared internal helper (bypasses HTTP);
+ * if reconciliation succeeds, runs retention sweeps. Success/failure is
+ * published to `admin_kpi_metrics` keyed on `capacity.cron.reconcile.*` so
+ * the admin dashboard surfaces cron health without a separate query.
+ * Collisions with a manual HTTP reconciliation are logged as informational
+ * (not escalated to failure telemetry).
+ */
+const CRON_ACTOR_ACCOUNT_ID = 'ks2-cron';
+
+async function ensureCronActorAccount(db, nowTs) {
+  // `mutation_receipts.account_id` has an FK to `adult_accounts`. Cron runs
+  // pre-seed a minimal system row so every reconciliation receipt resolves
+  // its FK cleanly. Idempotent via `INSERT OR IGNORE`.
+  //
+  // C4 (Phase C reviewer fix): the cron actor is seeded with `platform_role
+  // = 'ops'` — NOT `'admin'`. An `admin` cron actor counts toward the
+  // `last_admin_required` invariant in `updateManagedAccountRole`, letting
+  // a genuine human admin demote themselves to a non-admin role with the
+  // cron row providing the "last admin" cover. `ops` is an existing role
+  // with admin-hub VIEW access (see `canViewAdminHub`) but NOT
+  // `canManageAccountRoles`, which exactly matches the cron's needs: the
+  // reconciliation path calls `reconcileAdminKpiMetricsInternal` directly
+  // and bypasses every HTTP-layer role gate; retention sweeps never touch
+  // role management; the `mutation_receipts` FK only requires the
+  // `adult_accounts.id` row to exist, independent of role.
+  try {
+    await run(db, `
+      INSERT OR IGNORE INTO adult_accounts (
+        id, email, display_name, platform_role, selected_learner_id,
+        created_at, updated_at, repo_revision, account_type, demo_expires_at
+      )
+      VALUES (?, NULL, 'Cron', 'ops', NULL, ?, ?, 0, 'real', NULL)
+    `, [CRON_ACTOR_ACCOUNT_ID, nowTs, nowTs]);
+  } catch (error) {
+    console.error('[ks2-cron] actor-account bootstrap failed', error?.message);
+  }
+}
+
+export async function runScheduledHandler(event, env, ctx, {
+  now = Date.now,
+  uuid = () => (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `cron-${Math.random().toString(36).slice(2)}-${Date.now()}`),
+} = {}) {
+  const nowTs = typeof now === 'function' ? now() : Date.now();
+  const requestId = `cron-reconcile-${uuid()}`;
+  const correlationId = requestId;
+  const db = env?.DB;
+  if (!db) {
+    console.error('[ks2-cron] DB binding is missing; scheduled handler aborted');
+    return { ok: false, reason: 'db_missing' };
+  }
+
+  try {
+    await ensureCronActorAccount(db, nowTs);
+    const reconcileResult = await reconcileAdminKpiMetricsInternal(db, {
+      actorAccountId: CRON_ACTOR_ACCOUNT_ID,
+      requestId,
+      correlationId,
+      clientComputed: null,
+      nowTs,
+    });
+    // H1 (Phase C reviewer): a retention-sweep failure was previously
+    // swallowed into console.error only while the reconcile arm still
+    // marked LAST_SUCCESS_AT — the dashboard then stayed green while
+    // `mutation_receipts` / `request_limits` silently overflowed.
+    // Now the sweep arm has its own failure metric
+    // (CRON_METRIC_RETENTION_LAST_FAILURE_AT) AND the overall success
+    // gate bumps LAST_SUCCESS_AT only when BOTH arms succeed.
+    let retention = null;
+    let retentionError = null;
+    try {
+      retention = await runRetentionSweeps(db, nowTs);
+    } catch (sweepError) {
+      retentionError = sweepError;
+      const reason = String(sweepError?.message || sweepError);
+      retention = { error: reason };
+      await writeCronMetricTimestamp(db, CRON_METRIC_RETENTION_LAST_FAILURE_AT, nowTs);
+      console.error('[ks2-cron]', JSON.stringify({
+        event: 'cron.retention.failure',
+        requestId,
+        nowTs,
+        reason,
+      }));
+    }
+    await bumpCronMetricCounter(db, CRON_METRIC_SUCCESS_COUNTER, nowTs);
+    if (!retentionError) {
+      await writeCronMetricTimestamp(db, CRON_METRIC_LAST_SUCCESS_AT, nowTs);
+    }
+    console.log('[ks2-cron]', JSON.stringify({
+      event: retentionError ? 'cron.reconcile.partial' : 'cron.reconcile.success',
+      requestId,
+      nowTs,
+      retention,
+    }));
+    return {
+      ok: !retentionError,
+      requestId,
+      nowTs,
+      reconcile: reconcileResult,
+      retention,
+      ...(retentionError ? { reason: `retention_sweep_failed: ${String(retentionError?.message || retentionError)}` } : {}),
+    };
+  } catch (error) {
+    const code = typeof error?.extra?.code === 'string' ? error.extra.code : null;
+    if (code === 'reconcile_in_progress') {
+      // Collision with a manual HTTP reconciliation — informational only.
+      console.log('[ks2-cron]', JSON.stringify({
+        event: 'cron.reconcile.collision',
+        requestId,
+        nowTs,
+        message: 'manual reconciliation in flight; cron skipped',
+      }));
+      return { ok: true, skipped: 'reconcile_in_progress', requestId, nowTs };
+    }
+    await writeCronMetricTimestamp(db, CRON_METRIC_LAST_FAILURE_AT, nowTs);
+    console.error('[ks2-cron]', JSON.stringify({
+      event: 'cron.reconcile.failure',
+      requestId,
+      nowTs,
+      reason: error?.message || String(error),
+    }));
+    return { ok: false, requestId, nowTs, reason: error?.message || String(error) };
+  }
+}

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -1,31 +1,20 @@
+/**
+ * Worker entry point.
+ *
+ * workerd module validation requires that the main module exports ONLY:
+ *   - default { fetch, scheduled }        (the Worker handler object)
+ *   - Named class exports for Durable Objects declared in wrangler.jsonc
+ *
+ * All other functionality (cron telemetry, security-header helpers) is
+ * extracted to dedicated modules that index.js imports but does NOT
+ * re-export.  This keeps the workerd module surface clean and unblocks
+ * `wrangler dev --local` for the local capacity harness.
+ */
+
 import { createWorkerApp } from './app.js';
 import { json } from './http.js';
-import { applySecurityHeaders } from './security-headers.js';
-import { reconcileAdminKpiMetricsInternal } from './repository.js';
-import { runRetentionSweeps } from './cron/retention-sweep.js';
-import { run } from './d1.js';
-
-/**
- * Apply the security wrapper defensively. If `wrap` (by default
- * `applySecurityHeaders`) throws, return the underlying response unchanged
- * so the Worker never emits a 1101 just because header composition failed.
- *
- * Exported so tests can drive the throw path with a stubbed wrapper
- * (review reliability-1).
- *
- * @param {Response} response
- * @param {{ path?: string }} options
- * @param {(response: Response, options: { path?: string }) => Response} [wrap]
- * @returns {Response}
- */
-export function applySecurityHeadersSafely(response, options, wrap = applySecurityHeaders) {
-  try {
-    return wrap(response, options);
-  } catch (error) {
-    console.error('[ks2-security-headers] wrapper failed', error?.message);
-    return response;
-  }
-}
+import { applySecurityHeadersSafely } from './security-headers-safe.js';
+import { runScheduledHandler } from './cron/scheduled.js';
 
 export class LearnerLock {
   constructor(state, env) {
@@ -47,191 +36,6 @@ export class LearnerLock {
 }
 
 const app = createWorkerApp();
-
-// U11: capacity-telemetry metric keys for cron success / failure.
-// Surfaced on the admin dashboard; failure timestamp being ahead of the
-// success timestamp triggers a warn banner.
-export const CRON_METRIC_SUCCESS_COUNTER = 'capacity.cron.reconcile.success';
-export const CRON_METRIC_LAST_SUCCESS_AT = 'capacity.cron.reconcile.last_success_at';
-export const CRON_METRIC_LAST_FAILURE_AT = 'capacity.cron.reconcile.last_failure_at';
-// H1 (Phase C reviewer): separate telemetry channel for the retention
-// sweep arm. A sweep failure used to be a console.error-only path, which
-// meant the admin dashboard showed the reconciliation arm green while
-// `mutation_receipts` / `request_limits` overflowed silently. The
-// retention-specific metric lets the banner light up on either arm.
-export const CRON_METRIC_RETENTION_LAST_FAILURE_AT = 'capacity.cron.retention.last_failure_at';
-
-async function bumpCronMetricCounter(db, key, now) {
-  try {
-    await run(db, `
-      INSERT INTO admin_kpi_metrics (metric_key, metric_count, updated_at)
-      VALUES (?, 1, ?)
-      ON CONFLICT(metric_key) DO UPDATE SET
-        metric_count = admin_kpi_metrics.metric_count + 1,
-        updated_at = ?
-    `, [key, now, now]);
-  } catch (error) {
-    // I5 (Phase C reviewer): distinct structured event so operators can
-    // grep for "telemetry write failed" separately from "cron itself
-    // failed". When this fires, the dashboard's success/failure banner
-    // may lag one cycle; the next run reconciles.
-    console.error('[ks2-cron]', JSON.stringify({
-      event: 'cron.telemetry.write_failed',
-      channel: 'counter',
-      key,
-      reason: error?.message || String(error),
-    }));
-  }
-}
-
-async function writeCronMetricTimestamp(db, key, now) {
-  try {
-    await run(db, `
-      INSERT INTO admin_kpi_metrics (metric_key, metric_count, updated_at)
-      VALUES (?, ?, ?)
-      ON CONFLICT(metric_key) DO UPDATE SET
-        metric_count = ?,
-        updated_at = ?
-    `, [key, now, now, now, now]);
-  } catch (error) {
-    // I5 (Phase C reviewer): same distinct structured event.
-    console.error('[ks2-cron]', JSON.stringify({
-      event: 'cron.telemetry.write_failed',
-      channel: 'timestamp',
-      key,
-      reason: error?.message || String(error),
-    }));
-  }
-}
-
-/**
- * U11 scheduled handler.
- *
- * Runs reconciliation through the shared internal helper (bypasses HTTP);
- * if reconciliation succeeds, runs retention sweeps. Success/failure is
- * published to `admin_kpi_metrics` keyed on `capacity.cron.reconcile.*` so
- * the admin dashboard surfaces cron health without a separate query.
- * Collisions with a manual HTTP reconciliation are logged as informational
- * (not escalated to failure telemetry).
- */
-const CRON_ACTOR_ACCOUNT_ID = 'ks2-cron';
-
-async function ensureCronActorAccount(db, nowTs) {
-  // `mutation_receipts.account_id` has an FK to `adult_accounts`. Cron runs
-  // pre-seed a minimal system row so every reconciliation receipt resolves
-  // its FK cleanly. Idempotent via `INSERT OR IGNORE`.
-  //
-  // C4 (Phase C reviewer fix): the cron actor is seeded with `platform_role
-  // = 'ops'` — NOT `'admin'`. An `admin` cron actor counts toward the
-  // `last_admin_required` invariant in `updateManagedAccountRole`, letting
-  // a genuine human admin demote themselves to a non-admin role with the
-  // cron row providing the "last admin" cover. `ops` is an existing role
-  // with admin-hub VIEW access (see `canViewAdminHub`) but NOT
-  // `canManageAccountRoles`, which exactly matches the cron's needs: the
-  // reconciliation path calls `reconcileAdminKpiMetricsInternal` directly
-  // and bypasses every HTTP-layer role gate; retention sweeps never touch
-  // role management; the `mutation_receipts` FK only requires the
-  // `adult_accounts.id` row to exist, independent of role.
-  try {
-    await run(db, `
-      INSERT OR IGNORE INTO adult_accounts (
-        id, email, display_name, platform_role, selected_learner_id,
-        created_at, updated_at, repo_revision, account_type, demo_expires_at
-      )
-      VALUES (?, NULL, 'Cron', 'ops', NULL, ?, ?, 0, 'real', NULL)
-    `, [CRON_ACTOR_ACCOUNT_ID, nowTs, nowTs]);
-  } catch (error) {
-    console.error('[ks2-cron] actor-account bootstrap failed', error?.message);
-  }
-}
-
-export async function runScheduledHandler(event, env, ctx, {
-  now = Date.now,
-  uuid = () => (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
-    ? crypto.randomUUID()
-    : `cron-${Math.random().toString(36).slice(2)}-${Date.now()}`),
-} = {}) {
-  const nowTs = typeof now === 'function' ? now() : Date.now();
-  const requestId = `cron-reconcile-${uuid()}`;
-  const correlationId = requestId;
-  const db = env?.DB;
-  if (!db) {
-    console.error('[ks2-cron] DB binding is missing; scheduled handler aborted');
-    return { ok: false, reason: 'db_missing' };
-  }
-
-  try {
-    await ensureCronActorAccount(db, nowTs);
-    const reconcileResult = await reconcileAdminKpiMetricsInternal(db, {
-      actorAccountId: CRON_ACTOR_ACCOUNT_ID,
-      requestId,
-      correlationId,
-      clientComputed: null,
-      nowTs,
-    });
-    // H1 (Phase C reviewer): a retention-sweep failure was previously
-    // swallowed into console.error only while the reconcile arm still
-    // marked LAST_SUCCESS_AT — the dashboard then stayed green while
-    // `mutation_receipts` / `request_limits` silently overflowed.
-    // Now the sweep arm has its own failure metric
-    // (CRON_METRIC_RETENTION_LAST_FAILURE_AT) AND the overall success
-    // gate bumps LAST_SUCCESS_AT only when BOTH arms succeed.
-    let retention = null;
-    let retentionError = null;
-    try {
-      retention = await runRetentionSweeps(db, nowTs);
-    } catch (sweepError) {
-      retentionError = sweepError;
-      const reason = String(sweepError?.message || sweepError);
-      retention = { error: reason };
-      await writeCronMetricTimestamp(db, CRON_METRIC_RETENTION_LAST_FAILURE_AT, nowTs);
-      console.error('[ks2-cron]', JSON.stringify({
-        event: 'cron.retention.failure',
-        requestId,
-        nowTs,
-        reason,
-      }));
-    }
-    await bumpCronMetricCounter(db, CRON_METRIC_SUCCESS_COUNTER, nowTs);
-    if (!retentionError) {
-      await writeCronMetricTimestamp(db, CRON_METRIC_LAST_SUCCESS_AT, nowTs);
-    }
-    console.log('[ks2-cron]', JSON.stringify({
-      event: retentionError ? 'cron.reconcile.partial' : 'cron.reconcile.success',
-      requestId,
-      nowTs,
-      retention,
-    }));
-    return {
-      ok: !retentionError,
-      requestId,
-      nowTs,
-      reconcile: reconcileResult,
-      retention,
-      ...(retentionError ? { reason: `retention_sweep_failed: ${String(retentionError?.message || retentionError)}` } : {}),
-    };
-  } catch (error) {
-    const code = typeof error?.extra?.code === 'string' ? error.extra.code : null;
-    if (code === 'reconcile_in_progress') {
-      // Collision with a manual HTTP reconciliation — informational only.
-      console.log('[ks2-cron]', JSON.stringify({
-        event: 'cron.reconcile.collision',
-        requestId,
-        nowTs,
-        message: 'manual reconciliation in flight; cron skipped',
-      }));
-      return { ok: true, skipped: 'reconcile_in_progress', requestId, nowTs };
-    }
-    await writeCronMetricTimestamp(db, CRON_METRIC_LAST_FAILURE_AT, nowTs);
-    console.error('[ks2-cron]', JSON.stringify({
-      event: 'cron.reconcile.failure',
-      requestId,
-      nowTs,
-      reason: error?.message || String(error),
-    }));
-    return { ok: false, requestId, nowTs, reason: error?.message || String(error) };
-  }
-}
 
 export default {
   async fetch(request, env, ctx) {

--- a/worker/src/security-headers-safe.js
+++ b/worker/src/security-headers-safe.js
@@ -1,0 +1,28 @@
+/**
+ * Defensive security-header wrapper — extracted from index.js so the
+ * Worker entry point exports only the workerd-required surface.
+ *
+ * Exported so tests can drive the throw path with a stubbed wrapper
+ * (review reliability-1).
+ */
+
+import { applySecurityHeaders } from './security-headers.js';
+
+/**
+ * Apply the security wrapper defensively. If `wrap` (by default
+ * `applySecurityHeaders`) throws, return the underlying response unchanged
+ * so the Worker never emits a 1101 just because header composition failed.
+ *
+ * @param {Response} response
+ * @param {{ path?: string }} options
+ * @param {(response: Response, options: { path?: string }) => Response} [wrap]
+ * @returns {Response}
+ */
+export function applySecurityHeadersSafely(response, options, wrap = applySecurityHeaders) {
+  try {
+    return wrap(response, options);
+  } catch (error) {
+    console.error('[ks2-security-headers] wrapper failed', error?.message);
+    return response;
+  }
+}


### PR DESCRIPTION
## Summary

- **Extracted cron scheduled handler** (`runScheduledHandler`, `CRON_METRIC_*` constants, telemetry helpers, actor-account bootstrap) from `worker/src/index.js` into `worker/src/cron/scheduled.js`
- **Extracted `applySecurityHeadersSafely`** from `worker/src/index.js` into `worker/src/security-headers-safe.js`
- **`worker/src/index.js` now exports only the workerd-compatible surface**: `default { fetch, scheduled }` + `LearnerLock` Durable Object class — no utility functions, no string constants
- **Added regression gate test** (`tests/worker-index-exports.test.js`) that asserts the export surface is exactly `{ default, LearnerLock }` — any future accidental re-export fails the test before it reaches the capacity harness or production deploy
- **Updated test imports**: `tests/worker-cron-trigger-reconcile.test.js` and `tests/security-headers.test.js` now import from the new module paths

This unblocks `npm run capacity:local-worker` which was previously rejected by `workerd` module validation due to non-handler named exports (`CRON_METRIC_*`, `applySecurityHeadersSafely`, `runScheduledHandler`) on the main Worker module.

## Test plan

- [x] `tests/worker-index-exports.test.js` — asserts only `default` + `LearnerLock` are exported from index.js (1 test, pass)
- [x] `tests/worker-cron-trigger-reconcile.test.js` — all 9 cron/scheduled tests pass with new import path
- [x] `tests/security-headers.test.js` — all 36 security-header tests pass with new import path
- [x] `tests/worker-backend.test.js` — end-to-end Worker routes unchanged (6 tests, pass)
- [x] `tests/worker-hubs.test.js` — admin/parent hub routes unchanged (7 tests, pass)
- [x] `tests/worker-access.test.js` — access control unchanged (pass)
- [x] `tests/capacity-circuit-breakers.test.js` — capacity circuit breakers unchanged (pass)