### PR TITLE
refactor(punctuation): extract canonical client-safe manifest (P7-U1)

### DIFF
--- a/src/subjects/punctuation/components/punctuation-view-model.js
+++ b/src/subjects/punctuation/components/punctuation-view-model.js
@@ -172,8 +172,8 @@ export const PUNCTUATION_PRIMARY_MODE_CARDS = Object.freeze([
 
 // --- Punctuation Map filter lists ------------------------------------------
 //
-// Status, monster, and detail-tab id lists moved to service-contract.js in U5
-// (adv-219-005 layer fix). The view-model re-exports them via the top-of-file
+// Status, monster, and detail-tab id lists canonical source is now
+// punctuation-manifest.js. The view-model re-exports them via the top-of-file
 // `export { ... }` block so downstream imports keep working.
 
 // Short, child-facing rule one-liners for the Punctuation Map scene's skill

--- a/src/subjects/punctuation/components/punctuation-view-model.js
+++ b/src/subjects/punctuation/components/punctuation-view-model.js
@@ -20,19 +20,21 @@
 // (AGENTS.md:14).
 
 import { resolveMonsterVisual } from '../../../platform/game/monster-visual-config.js';
-import { MONSTERS_BY_SUBJECT } from '../../../platform/game/monsters.js';
-import { PUNCTUATION_CLIENT_SKILLS } from '../read-model.js';
 import {
+  PUNCTUATION_CLIENT_SKILLS,
+  PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER,
+  ACTIVE_PUNCTUATION_MONSTER_IDS,
+  ACTIVE_PUNCTUATION_MONSTER_ID_SET,
   PUNCTUATION_MAP_DETAIL_TAB_IDS,
   PUNCTUATION_MAP_MONSTER_FILTER_IDS,
   PUNCTUATION_MAP_STATUS_FILTER_IDS,
-} from '../service-contract.js';
+} from '../punctuation-manifest.js';
 
-// U5 layer fix (adv-219-005): the Map filter + detail-tab id lists are the
-// service-contract's single source of truth. The view-model re-exports them
-// under their existing names so renderers / tests keep their current import
-// paths while the one-way `contract → view-model` dependency is restored.
 export {
+  PUNCTUATION_CLIENT_SKILLS,
+  PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER,
+  ACTIVE_PUNCTUATION_MONSTER_IDS,
+  ACTIVE_PUNCTUATION_MONSTER_ID_SET,
   PUNCTUATION_MAP_DETAIL_TAB_IDS,
   PUNCTUATION_MAP_MONSTER_FILTER_IDS,
   PUNCTUATION_MAP_STATUS_FILTER_IDS,
@@ -218,47 +220,9 @@ export function punctuationSkillRuleOneLiner(skillId) {
   return typeof line === 'string' && line ? line : 'Practise this punctuation skill.';
 }
 
-// Client-safe cluster → monster mapping. The Worker canonical source of truth
-// is `shared/punctuation/content.js`'s `PUNCTUATION_CLUSTERS`, which the
-// bundle-audit rules forbid from the browser bundle. This constant is the
-// client mirror of that mapping for U5's Map scene — it must stay in lock-step
-// with the shared content's `monsterId` field on every cluster. Skills whose
-// cluster maps to `structure` land on Curlune (List / Structure cluster); the
-// grand monster (Quoral) is reserved for the "published release" aggregate
-// and is the fallback target for any skill whose cluster is unknown (see
-// `buildPunctuationMapModel`).
-export const PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER = Object.freeze({
-  endmarks: 'pealark',
-  speech: 'pealark',
-  boundary: 'pealark',
-  apostrophe: 'claspin',
-  comma_flow: 'curlune',
-  structure: 'curlune',
-});
-
-// --- Active monster roster -------------------------------------------------
-
-// The four learner-facing Punctuation monsters. Read from
-// `MONSTERS_BY_SUBJECT.punctuation` so the order stays in lock-step with
-// `src/platform/game/monsters.js:186-203`. Reserved monsters are never
-// included. If the code-level roster changes, this list follows automatically.
-const PUNCTUATION_ACTIVE_ROSTER_SOURCE = Object.freeze(
-  Array.isArray(MONSTERS_BY_SUBJECT?.punctuation)
-    ? [...MONSTERS_BY_SUBJECT.punctuation]
-    : ['pealark', 'curlune', 'claspin', 'quoral'],
-);
-
-export const ACTIVE_PUNCTUATION_MONSTER_IDS = Object.freeze(PUNCTUATION_ACTIVE_ROSTER_SOURCE);
-
-// Phase 4 U5 review follow-on (FINDING F — maintainability MEDIUM): shared
-// Set over `ACTIVE_PUNCTUATION_MONSTER_IDS` for O(1) membership checks from
-// any consumer that needs to filter payloads against the active roster.
-// Previously the Summary scene kept a scene-local duplicate
-// (`ACTIVE_MONSTER_ID_SET`) which drifted from this view-model export whenever
-// the roster changed. Exporting here means U9's Worker-side telemetry
-// filters, U2's Home companion filter, and any future non-React consumer can
-// all read the same frozen value.
-export const ACTIVE_PUNCTUATION_MONSTER_ID_SET = new Set(ACTIVE_PUNCTUATION_MONSTER_IDS);
+// Active monster roster, cluster→monster mapping, and monster ID set are all
+// imported from punctuation-manifest.js and re-exported above for backward
+// compatibility.
 
 // Phase 4 U5 review follow-on (FINDING F): detect an "advancing" stage delta
 // for the monster-progress teaser + `monster-progress-changed` telemetry.

--- a/src/subjects/punctuation/punctuation-manifest.js
+++ b/src/subjects/punctuation/punctuation-manifest.js
@@ -1,0 +1,155 @@
+// Canonical client-safe Punctuation metadata manifest.
+//
+// LEAF MODULE — imports only from platform constants (monsters.js).
+// Zero imports from read-model, star-projection, service-contract,
+// or any other punctuation module. This breaks the circular dependency
+// that previously forced inlined mirrors of skill/cluster/monster data
+// across 4+ modules.
+//
+// All downstream punctuation modules re-export from here for backward
+// compatibility.
+
+import { MONSTERS_BY_SUBJECT } from '../../platform/game/monsters.js';
+
+// ── Active monster roster ────────────────────────────────────────────
+
+export const ACTIVE_PUNCTUATION_MONSTER_IDS = Object.freeze(
+  Array.isArray(MONSTERS_BY_SUBJECT?.punctuation)
+    ? [...MONSTERS_BY_SUBJECT.punctuation]
+    : ['pealark', 'curlune', 'claspin', 'quoral'],
+);
+
+export const ACTIVE_PUNCTUATION_MONSTER_ID_SET = Object.freeze(
+  new Set(ACTIVE_PUNCTUATION_MONSTER_IDS),
+);
+
+export const PUNCTUATION_GRAND_MONSTER_ID = 'quoral';
+
+export const DIRECT_PUNCTUATION_MONSTER_IDS = Object.freeze(
+  ACTIVE_PUNCTUATION_MONSTER_IDS.filter((id) => id !== PUNCTUATION_GRAND_MONSTER_ID),
+);
+
+// ── Cluster → monster mapping ────────────────────────────────────────
+
+export const PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER = Object.freeze({
+  endmarks: 'pealark',
+  speech: 'pealark',
+  boundary: 'pealark',
+  apostrophe: 'claspin',
+  comma_flow: 'curlune',
+  structure: 'curlune',
+});
+
+export const PUNCTUATION_CLUSTER_IDS = Object.freeze(
+  Object.keys(PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER),
+);
+
+// ── Published skills (14) ────────────────────────────────────────────
+
+export const PUNCTUATION_CLIENT_SKILLS = Object.freeze([
+  { id: 'sentence_endings', name: 'Capital letters and sentence endings', clusterId: 'endmarks' },
+  { id: 'list_commas', name: 'Commas in lists', clusterId: 'comma_flow' },
+  { id: 'apostrophe_contractions', name: 'Apostrophes for contraction', clusterId: 'apostrophe' },
+  { id: 'apostrophe_possession', name: 'Apostrophes for possession', clusterId: 'apostrophe' },
+  { id: 'speech', name: 'Inverted commas and speech punctuation', clusterId: 'speech' },
+  { id: 'fronted_adverbial', name: 'Commas after starter phrases', clusterId: 'comma_flow' },
+  { id: 'parenthesis', name: 'Parenthesis with commas, brackets or dashes', clusterId: 'structure' },
+  { id: 'comma_clarity', name: 'Commas for clarity', clusterId: 'comma_flow' },
+  { id: 'colon_list', name: 'Colon before a list', clusterId: 'structure' },
+  { id: 'semicolon', name: 'Semi-colons between related clauses', clusterId: 'boundary' },
+  { id: 'dash_clause', name: 'Dashes between related clauses', clusterId: 'boundary' },
+  { id: 'semicolon_list', name: 'Semi-colons within lists', clusterId: 'structure' },
+  { id: 'bullet_points', name: 'Punctuation of bullet points', clusterId: 'structure' },
+  { id: 'hyphen', name: 'Hyphens to avoid ambiguity', clusterId: 'boundary' },
+]);
+
+export const PUNCTUATION_CLIENT_SKILL_IDS = Object.freeze(
+  PUNCTUATION_CLIENT_SKILLS.map((s) => s.id),
+);
+
+export const PUNCTUATION_CLIENT_SKILL_ID_SET = Object.freeze(
+  new Set(PUNCTUATION_CLIENT_SKILL_IDS),
+);
+
+// ── Skill → cluster lookup ───────────────────────────────────────────
+
+export const SKILL_TO_CLUSTER = Object.freeze(
+  new Map(PUNCTUATION_CLIENT_SKILLS.map((s) => [s.id, s.clusterId])),
+);
+
+// ── Reward units (14) ────────────────────────────────────────────────
+
+export const PUNCTUATION_CLIENT_REWARD_UNITS = Object.freeze([
+  { clusterId: 'endmarks', rewardUnitId: 'sentence-endings-core' },
+  { clusterId: 'apostrophe', rewardUnitId: 'apostrophe-contractions-core' },
+  { clusterId: 'apostrophe', rewardUnitId: 'apostrophe-possession-core' },
+  { clusterId: 'speech', rewardUnitId: 'speech-core' },
+  { clusterId: 'comma_flow', rewardUnitId: 'list-commas-core' },
+  { clusterId: 'comma_flow', rewardUnitId: 'fronted-adverbials-core' },
+  { clusterId: 'comma_flow', rewardUnitId: 'comma-clarity-core' },
+  { clusterId: 'boundary', rewardUnitId: 'semicolons-core' },
+  { clusterId: 'boundary', rewardUnitId: 'dash-clauses-core' },
+  { clusterId: 'boundary', rewardUnitId: 'hyphens-core' },
+  { clusterId: 'structure', rewardUnitId: 'parenthesis-core' },
+  { clusterId: 'structure', rewardUnitId: 'colons-core' },
+  { clusterId: 'structure', rewardUnitId: 'semicolon-lists-core' },
+  { clusterId: 'structure', rewardUnitId: 'bullet-points-core' },
+]);
+
+export const RU_TO_CLUSTERS = Object.freeze(
+  new Map(PUNCTUATION_CLIENT_REWARD_UNITS.map((ru) => [
+    ru.rewardUnitId,
+    new Set([ru.clusterId]),
+  ])),
+);
+
+// ── Derived: Claspin required skills ─────────────────────────────────
+
+export const CLASPIN_REQUIRED_SKILLS = Object.freeze(
+  Array.from(SKILL_TO_CLUSTER.entries())
+    .filter(([, c]) => c === 'apostrophe')
+    .map(([s]) => s),
+);
+
+// ── Reverse lookups ──────────────────────────────────────────────────
+
+export const MONSTER_CLUSTERS = Object.freeze(
+  (() => {
+    const m = new Map();
+    for (const [clusterId, monsterId] of Object.entries(PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER)) {
+      if (!m.has(monsterId)) m.set(monsterId, new Set());
+      m.get(monsterId).add(clusterId);
+    }
+    return m;
+  })(),
+);
+
+export const MONSTER_UNIT_COUNT = Object.freeze(
+  (() => {
+    const counts = {};
+    for (const [, monsterId] of Object.entries(PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER)) {
+      const clusterSet = MONSTER_CLUSTERS.get(monsterId);
+      if (!clusterSet) continue;
+      let total = 0;
+      for (const cId of clusterSet) {
+        for (const ru of PUNCTUATION_CLIENT_REWARD_UNITS) {
+          if (ru.clusterId === cId) total++;
+        }
+      }
+      counts[monsterId] = total;
+    }
+    return counts;
+  })(),
+);
+
+// ── Map filter IDs ───────────────────────────────────────────────────
+
+export const PUNCTUATION_MAP_STATUS_FILTER_IDS = Object.freeze([
+  'all', 'new', 'learning', 'due', 'weak', 'secure', 'unknown',
+]);
+
+export const PUNCTUATION_MAP_MONSTER_FILTER_IDS = Object.freeze([
+  'all', 'pealark', 'claspin', 'curlune', 'quoral',
+]);
+
+export const PUNCTUATION_MAP_DETAIL_TAB_IDS = Object.freeze(['learn', 'practise']);

--- a/src/subjects/punctuation/read-model.js
+++ b/src/subjects/punctuation/read-model.js
@@ -1,49 +1,16 @@
 import { projectPunctuationStars } from './star-projection.js';
 import { stageFor, PUNCTUATION_STAR_THRESHOLDS, PUNCTUATION_GRAND_STAR_THRESHOLDS } from '../../platform/game/monsters.js';
+import {
+  PUNCTUATION_CLIENT_SKILLS,
+  PUNCTUATION_CLIENT_REWARD_UNITS,
+} from './punctuation-manifest.js';
+
+export { PUNCTUATION_CLIENT_SKILLS };
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const CURRENT_RELEASE_ID = 'punctuation-r4-full-14-skill-structure';
 const TOTAL_REWARD_UNITS = 14;
 const DAILY_TARGET_ATTEMPTS = 4;
-
-export const PUNCTUATION_CLIENT_SKILLS = Object.freeze([
-  { id: 'sentence_endings', name: 'Capital letters and sentence endings', clusterId: 'endmarks' },
-  { id: 'list_commas', name: 'Commas in lists', clusterId: 'comma_flow' },
-  { id: 'apostrophe_contractions', name: 'Apostrophes for contraction', clusterId: 'apostrophe' },
-  { id: 'apostrophe_possession', name: 'Apostrophes for possession', clusterId: 'apostrophe' },
-  { id: 'speech', name: 'Inverted commas and speech punctuation', clusterId: 'speech' },
-  // Phase 4 U7: child-register name. Prior "Commas after fronted
-  // adverbials" used adult grammar terminology; the new name matches
-  // the `punctuationChildRegisterOverride` table swap so the rendered
-  // surface is consistent whether the skill name is read from this
-  // client mirror or passed through the override helper.
-  { id: 'fronted_adverbial', name: 'Commas after starter phrases', clusterId: 'comma_flow' },
-  { id: 'parenthesis', name: 'Parenthesis with commas, brackets or dashes', clusterId: 'structure' },
-  { id: 'comma_clarity', name: 'Commas for clarity', clusterId: 'comma_flow' },
-  { id: 'colon_list', name: 'Colon before a list', clusterId: 'structure' },
-  { id: 'semicolon', name: 'Semi-colons between related clauses', clusterId: 'boundary' },
-  { id: 'dash_clause', name: 'Dashes between related clauses', clusterId: 'boundary' },
-  { id: 'semicolon_list', name: 'Semi-colons within lists', clusterId: 'structure' },
-  { id: 'bullet_points', name: 'Punctuation of bullet points', clusterId: 'structure' },
-  { id: 'hyphen', name: 'Hyphens to avoid ambiguity', clusterId: 'boundary' },
-]);
-
-const PUNCTUATION_CLIENT_REWARD_UNITS = Object.freeze([
-  { clusterId: 'endmarks', rewardUnitId: 'sentence-endings-core' },
-  { clusterId: 'apostrophe', rewardUnitId: 'apostrophe-contractions-core' },
-  { clusterId: 'apostrophe', rewardUnitId: 'apostrophe-possession-core' },
-  { clusterId: 'speech', rewardUnitId: 'speech-core' },
-  { clusterId: 'comma_flow', rewardUnitId: 'list-commas-core' },
-  { clusterId: 'comma_flow', rewardUnitId: 'fronted-adverbials-core' },
-  { clusterId: 'comma_flow', rewardUnitId: 'comma-clarity-core' },
-  { clusterId: 'boundary', rewardUnitId: 'semicolons-core' },
-  { clusterId: 'boundary', rewardUnitId: 'dash-clauses-core' },
-  { clusterId: 'boundary', rewardUnitId: 'hyphens-core' },
-  { clusterId: 'structure', rewardUnitId: 'parenthesis-core' },
-  { clusterId: 'structure', rewardUnitId: 'colons-core' },
-  { clusterId: 'structure', rewardUnitId: 'semicolon-lists-core' },
-  { clusterId: 'structure', rewardUnitId: 'bullet-points-core' },
-]);
 
 function clientMasteryKey({ clusterId, rewardUnitId } = {}) {
   return `punctuation:${CURRENT_RELEASE_ID}:${clusterId}:${rewardUnitId}`;

--- a/src/subjects/punctuation/service-contract.js
+++ b/src/subjects/punctuation/service-contract.js
@@ -1,6 +1,7 @@
 import { SESSION_EPHEMERAL_FIELDS } from '../../platform/core/subject-contract.js';
 import {
   PUNCTUATION_CLIENT_SKILL_IDS,
+  PUNCTUATION_CLIENT_SKILL_ID_SET,
   PUNCTUATION_MAP_STATUS_FILTER_IDS,
   PUNCTUATION_MAP_MONSTER_FILTER_IDS,
   PUNCTUATION_MAP_DETAIL_TAB_IDS,
@@ -38,8 +39,6 @@ export const PUNCTUATION_PHASES = Object.freeze([
 // the transition to prevent an orphan session / stale feedback from leaking
 // into phase=map (adversarial reviewer adv-219-002).
 export const PUNCTUATION_OPEN_MAP_ALLOWED_PHASES = Object.freeze(['setup', 'summary']);
-
-const PUNCTUATION_CLIENT_SKILL_ID_SET = new Set(PUNCTUATION_CLIENT_SKILL_IDS);
 
 export function isPublishedPunctuationSkillId(value) {
   return typeof value === 'string' && PUNCTUATION_CLIENT_SKILL_ID_SET.has(value);

--- a/src/subjects/punctuation/service-contract.js
+++ b/src/subjects/punctuation/service-contract.js
@@ -1,4 +1,17 @@
 import { SESSION_EPHEMERAL_FIELDS } from '../../platform/core/subject-contract.js';
+import {
+  PUNCTUATION_CLIENT_SKILL_IDS,
+  PUNCTUATION_MAP_STATUS_FILTER_IDS,
+  PUNCTUATION_MAP_MONSTER_FILTER_IDS,
+  PUNCTUATION_MAP_DETAIL_TAB_IDS,
+} from './punctuation-manifest.js';
+
+export {
+  PUNCTUATION_CLIENT_SKILL_IDS,
+  PUNCTUATION_MAP_STATUS_FILTER_IDS,
+  PUNCTUATION_MAP_MONSTER_FILTER_IDS,
+  PUNCTUATION_MAP_DETAIL_TAB_IDS,
+};
 
 export const PUNCTUATION_SERVICE_STATE_VERSION = 1;
 export const PUNCTUATION_CURRENT_RELEASE_ID = 'punctuation-r4-full-14-skill-structure';
@@ -25,54 +38,6 @@ export const PUNCTUATION_PHASES = Object.freeze([
 // the transition to prevent an orphan session / stale feedback from leaking
 // into phase=map (adversarial reviewer adv-219-002).
 export const PUNCTUATION_OPEN_MAP_ALLOWED_PHASES = Object.freeze(['setup', 'summary']);
-
-// U5: Map filter chip rows and detail-tab ids. These frozen lists are the
-// single source of truth — `normalisePunctuationMapUi` validates inputs
-// against them, module handlers guard dispatched values against them, and
-// the view-model / scene re-exports them for render-time chip iteration.
-// Reserved Punctuation monsters (Colisk / Hyphang / Carillon) are absent
-// from the monster filter list so a rogue payload cannot surface a retired
-// name as a filter option.
-//
-// Phase 4 U3 (review follow-on): `'unknown'` is included so the filter chip
-// row stays consistent with the skill-row status enum once the upstream
-// worker starts emitting `analytics.available === false`. Without this
-// entry the degraded state would trap a learner on any non-"All" chip
-// (every skill is `'unknown'`, but the filter has no matching id → the
-// Map renders zero cards with no empty-state message). The chip is a
-// harmless extra slot while the upstream wiring is still deferred.
-export const PUNCTUATION_MAP_STATUS_FILTER_IDS = Object.freeze([
-  'all', 'new', 'learning', 'due', 'weak', 'secure', 'unknown',
-]);
-
-export const PUNCTUATION_MAP_MONSTER_FILTER_IDS = Object.freeze([
-  'all', 'pealark', 'claspin', 'curlune', 'quoral',
-]);
-
-export const PUNCTUATION_MAP_DETAIL_TAB_IDS = Object.freeze(['learn', 'practise']);
-
-// U5: Published skill ids. Client-safe mirror of the 14 skills that ship in
-// the current Punctuation release. Defined here (rather than read-model.js)
-// so the normaliser + module handler can validate a dispatched `skillId`
-// without reaching into a client-only module. The full skill metadata (name +
-// clusterId) lives on `PUNCTUATION_CLIENT_SKILLS` in read-model.js; this set
-// must stay in lock-step with that list (drift-tested).
-export const PUNCTUATION_CLIENT_SKILL_IDS = Object.freeze([
-  'sentence_endings',
-  'list_commas',
-  'apostrophe_contractions',
-  'apostrophe_possession',
-  'speech',
-  'fronted_adverbial',
-  'parenthesis',
-  'comma_clarity',
-  'colon_list',
-  'semicolon',
-  'dash_clause',
-  'semicolon_list',
-  'bullet_points',
-  'hyphen',
-]);
 
 const PUNCTUATION_CLIENT_SKILL_ID_SET = new Set(PUNCTUATION_CLIENT_SKILL_IDS);
 

--- a/src/subjects/punctuation/star-projection.js
+++ b/src/subjects/punctuation/star-projection.js
@@ -33,11 +33,6 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 // Internal constants
 // ---------------------------------------------------------------------------
 
-const DIRECT_MONSTER_IDS = DIRECT_PUNCTUATION_MONSTER_IDS;
-
-// Build a cluster-to-monster lookup from the manifest constant.
-const CLUSTER_TO_MONSTER = { ...PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER };
-
 // Star category caps per direct monster.
 const TRY_CAP = 10;
 const PRACTICE_CAP = 30;
@@ -61,8 +56,6 @@ const GRAND_STAR_CAP = 100;
 //
 // The multiplier is applied inside computeSecureStars and computeMasteryStars
 // so that raw score scales inversely with cluster size.
-
-// MONSTER_UNIT_COUNT imported from punctuation-manifest.js.
 
 // Reference cluster size for normalisation (Pealark = 5 units).
 const REFERENCE_UNIT_COUNT = 5;
@@ -144,7 +137,7 @@ function clustersForAttempt(attempt) {
  * Determine which monster a cluster belongs to.
  */
 function monsterForCluster(clusterId) {
-  return CLUSTER_TO_MONSTER[clusterId] || null;
+  return PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER[clusterId] || null;
 }
 
 // ---------------------------------------------------------------------------
@@ -518,7 +511,7 @@ function computeGrandStars(progress, releaseId) {
 
   // Breadth: count distinct direct monsters with secured evidence.
   const directMonstersWithEvidence = [...monstersWithSecured].filter(
-    (id) => DIRECT_MONSTER_IDS.includes(id),
+    (id) => DIRECT_PUNCTUATION_MONSTER_IDS.includes(id),
   ).length;
 
   // Determine the highest tier the learner qualifies for, then interpolate
@@ -609,7 +602,7 @@ export function projectPunctuationStars(progress, releaseId) {
 
   // Build per-monster attempt arrays.
   const monsterAttempts = new Map();
-  for (const monsterId of DIRECT_MONSTER_IDS) {
+  for (const monsterId of DIRECT_PUNCTUATION_MONSTER_IDS) {
     monsterAttempts.set(monsterId, []);
   }
   for (const attempt of attempts) {
@@ -624,7 +617,7 @@ export function projectPunctuationStars(progress, releaseId) {
 
   // Project per-monster Stars.
   const perMonster = {};
-  for (const monsterId of DIRECT_MONSTER_IDS) {
+  for (const monsterId of DIRECT_PUNCTUATION_MONSTER_IDS) {
     const clusterIds = MONSTER_CLUSTERS.get(monsterId) || new Set();
     const mAttempts = monsterAttempts.get(monsterId) || [];
     const mItems = itemsForMonster(items, attempts, clusterIds);

--- a/src/subjects/punctuation/star-projection.js
+++ b/src/subjects/punctuation/star-projection.js
@@ -14,31 +14,17 @@
 // Grand Stars derive from breadth + deep-secure evidence across ALL clusters,
 // not from summing direct Stars.
 
-import { MONSTERS_BY_SUBJECT } from '../../platform/game/monsters.js';
+import {
+  ACTIVE_PUNCTUATION_MONSTER_IDS,
+  PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER,
+  CLASPIN_REQUIRED_SKILLS,
+  SKILL_TO_CLUSTER,
+  RU_TO_CLUSTERS,
+  MONSTER_CLUSTERS,
+  MONSTER_UNIT_COUNT,
+  DIRECT_PUNCTUATION_MONSTER_IDS,
+} from './punctuation-manifest.js';
 
-// U4: import monster roster and cluster→monster mapping directly from
-// monsters.js / inline to avoid circular dependency. read-model.js imports
-// star-projection.js, and punctuation-view-model.js imports from
-// read-model.js — routing through punctuation-view-model.js creates a TDZ.
-const ACTIVE_PUNCTUATION_MONSTER_IDS = Object.freeze(
-  Array.isArray(MONSTERS_BY_SUBJECT?.punctuation)
-    ? [...MONSTERS_BY_SUBJECT.punctuation]
-    : ['pealark', 'curlune', 'claspin', 'quoral'],
-);
-
-// Client-safe cluster → monster mapping. Must stay in lock-step with
-// `PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER` in `punctuation-view-model.js`.
-const PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER = Object.freeze({
-  endmarks: 'pealark',
-  speech: 'pealark',
-  boundary: 'pealark',
-  apostrophe: 'claspin',
-  comma_flow: 'curlune',
-  structure: 'curlune',
-});
-
-// Re-export the mapping so downstream consumers can import from this
-// module without reaching into the view-model.
 export { PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER, ACTIVE_PUNCTUATION_MONSTER_IDS, CLASPIN_REQUIRED_SKILLS };
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -47,72 +33,10 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 // Internal constants
 // ---------------------------------------------------------------------------
 
-const DIRECT_MONSTER_IDS = ACTIVE_PUNCTUATION_MONSTER_IDS.filter(
-  (id) => id !== 'quoral',
-);
+const DIRECT_MONSTER_IDS = DIRECT_PUNCTUATION_MONSTER_IDS;
 
-// Build a cluster-to-monster lookup from the view-model constant.
+// Build a cluster-to-monster lookup from the manifest constant.
 const CLUSTER_TO_MONSTER = { ...PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER };
-
-// Reverse: monster -> Set<clusterId>
-const MONSTER_CLUSTERS = new Map();
-for (const [clusterId, monsterId] of Object.entries(CLUSTER_TO_MONSTER)) {
-  if (!MONSTER_CLUSTERS.has(monsterId)) MONSTER_CLUSTERS.set(monsterId, new Set());
-  MONSTER_CLUSTERS.get(monsterId).add(clusterId);
-}
-
-// Skill -> clusterId lookup. Inlined here (rather than imported from
-// read-model.js) to avoid a circular dependency: read-model.js imports
-// star-projection.js (U4), and star-projection.js previously imported
-// PUNCTUATION_CLIENT_SKILLS from read-model.js, causing a TDZ error.
-// This mirror must stay in lock-step with `PUNCTUATION_CLIENT_SKILLS`
-// in `read-model.js`; the star-projection tests validate the mapping.
-const SKILL_TO_CLUSTER = new Map([
-  ['sentence_endings', 'endmarks'],
-  ['list_commas', 'comma_flow'],
-  ['apostrophe_contractions', 'apostrophe'],
-  ['apostrophe_possession', 'apostrophe'],
-  ['speech', 'speech'],
-  ['fronted_adverbial', 'comma_flow'],
-  ['parenthesis', 'structure'],
-  ['comma_clarity', 'comma_flow'],
-  ['colon_list', 'structure'],
-  ['semicolon', 'boundary'],
-  ['dash_clause', 'boundary'],
-  ['semicolon_list', 'structure'],
-  ['bullet_points', 'structure'],
-  ['hyphen', 'boundary'],
-]);
-
-// P6-U6: Derive the set of skill IDs required for the Claspin Mega gate
-// from the canonical SKILL_TO_CLUSTER mapping rather than hardcoding them.
-// If a new apostrophe skill is added to SKILL_TO_CLUSTER, this constant
-// will automatically include it — no code change needed.
-const CLASPIN_REQUIRED_SKILLS = Object.freeze(
-  Array.from(SKILL_TO_CLUSTER.entries())
-    .filter(([, c]) => c === 'apostrophe')
-    .map(([s]) => s),
-);
-
-// Exact rewardUnitId -> Set<clusterId> lookup.
-// Mirrors `PUNCTUATION_CLIENT_REWARD_UNITS` from read-model.js (not exported).
-// Eliminates substring-match collisions (e.g. `semicolon` vs `semicolon-lists`).
-const RU_TO_CLUSTERS = new Map([
-  ['sentence-endings-core', new Set(['endmarks'])],
-  ['apostrophe-contractions-core', new Set(['apostrophe'])],
-  ['apostrophe-possession-core', new Set(['apostrophe'])],
-  ['speech-core', new Set(['speech'])],
-  ['list-commas-core', new Set(['comma_flow'])],
-  ['fronted-adverbials-core', new Set(['comma_flow'])],
-  ['comma-clarity-core', new Set(['comma_flow'])],
-  ['semicolons-core', new Set(['boundary'])],
-  ['dash-clauses-core', new Set(['boundary'])],
-  ['hyphens-core', new Set(['boundary'])],
-  ['parenthesis-core', new Set(['structure'])],
-  ['colons-core', new Set(['structure'])],
-  ['semicolon-lists-core', new Set(['structure'])],
-  ['bullet-points-core', new Set(['structure'])],
-]);
 
 // Star category caps per direct monster.
 const TRY_CAP = 10;
@@ -138,11 +62,7 @@ const GRAND_STAR_CAP = 100;
 // The multiplier is applied inside computeSecureStars and computeMasteryStars
 // so that raw score scales inversely with cluster size.
 
-const MONSTER_UNIT_COUNT = Object.freeze({
-  pealark: 5,
-  claspin: 2,
-  curlune: 7,
-});
+// MONSTER_UNIT_COUNT imported from punctuation-manifest.js.
 
 // Reference cluster size for normalisation (Pealark = 5 units).
 const REFERENCE_UNIT_COUNT = 5;

--- a/tests/punctuation-manifest-drift.test.js
+++ b/tests/punctuation-manifest-drift.test.js
@@ -18,7 +18,12 @@ import {
   PUNCTUATION_MAP_STATUS_FILTER_IDS,
   PUNCTUATION_MAP_MONSTER_FILTER_IDS,
   PUNCTUATION_MAP_DETAIL_TAB_IDS,
+  PUNCTUATION_GRAND_MONSTER_ID,
 } from '../src/subjects/punctuation/punctuation-manifest.js';
+
+import {
+  PUNCTUATION_GRAND_MONSTER_ID as SHARED_GRAND_MONSTER_ID,
+} from '../src/platform/game/mastery/shared.js';
 
 // ---------------------------------------------------------------------------
 // Manifest drift tests — pin the canonical constants so any accidental
@@ -127,13 +132,16 @@ test('MONSTER_CLUSTERS covers all direct monsters', () => {
   }
 });
 
-test('MONSTER_UNIT_COUNT covers all direct monsters', () => {
+test('MONSTER_UNIT_COUNT covers all direct monsters with pinned values', () => {
   for (const id of DIRECT_PUNCTUATION_MONSTER_IDS) {
     assert.ok(
       typeof MONSTER_UNIT_COUNT[id] === 'number' && MONSTER_UNIT_COUNT[id] > 0,
       `MONSTER_UNIT_COUNT["${id}"] should be a positive number`,
     );
   }
+  assert.equal(MONSTER_UNIT_COUNT.pealark, 5);
+  assert.equal(MONSTER_UNIT_COUNT.claspin, 2);
+  assert.equal(MONSTER_UNIT_COUNT.curlune, 7);
 });
 
 test('map filter IDs are frozen arrays', () => {
@@ -143,4 +151,8 @@ test('map filter IDs are frozen arrays', () => {
   assert.ok(PUNCTUATION_MAP_STATUS_FILTER_IDS.length > 0);
   assert.ok(PUNCTUATION_MAP_MONSTER_FILTER_IDS.length > 0);
   assert.ok(PUNCTUATION_MAP_DETAIL_TAB_IDS.length > 0);
+});
+
+test('PUNCTUATION_GRAND_MONSTER_ID is identical in manifest and mastery shared', () => {
+  assert.strictEqual(PUNCTUATION_GRAND_MONSTER_ID, SHARED_GRAND_MONSTER_ID);
 });

--- a/tests/punctuation-manifest-drift.test.js
+++ b/tests/punctuation-manifest-drift.test.js
@@ -1,0 +1,146 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  PUNCTUATION_CLIENT_SKILLS,
+  PUNCTUATION_CLIENT_SKILL_IDS,
+  SKILL_TO_CLUSTER,
+  RU_TO_CLUSTERS,
+  ACTIVE_PUNCTUATION_MONSTER_IDS,
+  PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER,
+  CLASPIN_REQUIRED_SKILLS,
+  PUNCTUATION_CLIENT_REWARD_UNITS,
+  PUNCTUATION_CLUSTER_IDS,
+  ACTIVE_PUNCTUATION_MONSTER_ID_SET,
+  DIRECT_PUNCTUATION_MONSTER_IDS,
+  MONSTER_CLUSTERS,
+  MONSTER_UNIT_COUNT,
+  PUNCTUATION_MAP_STATUS_FILTER_IDS,
+  PUNCTUATION_MAP_MONSTER_FILTER_IDS,
+  PUNCTUATION_MAP_DETAIL_TAB_IDS,
+} from '../src/subjects/punctuation/punctuation-manifest.js';
+
+// ---------------------------------------------------------------------------
+// Manifest drift tests — pin the canonical constants so any accidental
+// addition / removal fails loudly before landing.
+// ---------------------------------------------------------------------------
+
+test('PUNCTUATION_CLIENT_SKILLS has exactly 14 entries', () => {
+  assert.equal(PUNCTUATION_CLIENT_SKILLS.length, 14);
+});
+
+test('PUNCTUATION_CLIENT_SKILL_IDS matches skill IDs from PUNCTUATION_CLIENT_SKILLS', () => {
+  const idsFromSkills = PUNCTUATION_CLIENT_SKILLS.map((s) => s.id);
+  assert.deepStrictEqual(PUNCTUATION_CLIENT_SKILL_IDS, idsFromSkills);
+});
+
+test('SKILL_TO_CLUSTER has entries for all 14 skill IDs', () => {
+  assert.equal(SKILL_TO_CLUSTER.size, 14);
+  for (const skillId of PUNCTUATION_CLIENT_SKILL_IDS) {
+    assert.ok(
+      SKILL_TO_CLUSTER.has(skillId),
+      `SKILL_TO_CLUSTER missing entry for "${skillId}"`,
+    );
+  }
+});
+
+test('SKILL_TO_CLUSTER values match clusterId from PUNCTUATION_CLIENT_SKILLS', () => {
+  for (const skill of PUNCTUATION_CLIENT_SKILLS) {
+    assert.equal(
+      SKILL_TO_CLUSTER.get(skill.id),
+      skill.clusterId,
+      `SKILL_TO_CLUSTER["${skill.id}"] should be "${skill.clusterId}"`,
+    );
+  }
+});
+
+test('RU_TO_CLUSTERS has 14 entries', () => {
+  assert.equal(RU_TO_CLUSTERS.size, 14);
+});
+
+test('ACTIVE_PUNCTUATION_MONSTER_IDS has 4 entries (pealark, curlune, claspin, quoral)', () => {
+  assert.equal(ACTIVE_PUNCTUATION_MONSTER_IDS.length, 4);
+  assert.ok(ACTIVE_PUNCTUATION_MONSTER_IDS.includes('pealark'));
+  assert.ok(ACTIVE_PUNCTUATION_MONSTER_IDS.includes('curlune'));
+  assert.ok(ACTIVE_PUNCTUATION_MONSTER_IDS.includes('claspin'));
+  assert.ok(ACTIVE_PUNCTUATION_MONSTER_IDS.includes('quoral'));
+});
+
+test('PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER maps all 6 cluster IDs', () => {
+  const clusterIds = Object.keys(PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER);
+  assert.equal(clusterIds.length, 6);
+  const expected = ['endmarks', 'speech', 'boundary', 'apostrophe', 'comma_flow', 'structure'];
+  for (const id of expected) {
+    assert.ok(
+      clusterIds.includes(id),
+      `PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER missing cluster "${id}"`,
+    );
+  }
+});
+
+test('CLASPIN_REQUIRED_SKILLS contains exactly the apostrophe-cluster skills', () => {
+  const apostropheSkills = PUNCTUATION_CLIENT_SKILLS
+    .filter((s) => s.clusterId === 'apostrophe')
+    .map((s) => s.id);
+  assert.deepStrictEqual(
+    [...CLASPIN_REQUIRED_SKILLS].sort(),
+    [...apostropheSkills].sort(),
+  );
+});
+
+test('every clusterId in PUNCTUATION_CLIENT_SKILLS appears in PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER', () => {
+  const validClusters = new Set(Object.keys(PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER));
+  for (const skill of PUNCTUATION_CLIENT_SKILLS) {
+    assert.ok(
+      validClusters.has(skill.clusterId),
+      `skill "${skill.id}" has clusterId "${skill.clusterId}" not in PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER`,
+    );
+  }
+});
+
+test('PUNCTUATION_CLIENT_REWARD_UNITS has 14 entries', () => {
+  assert.equal(PUNCTUATION_CLIENT_REWARD_UNITS.length, 14);
+});
+
+test('PUNCTUATION_CLUSTER_IDS matches the keys of PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER', () => {
+  assert.deepStrictEqual(
+    PUNCTUATION_CLUSTER_IDS,
+    Object.keys(PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER),
+  );
+});
+
+test('ACTIVE_PUNCTUATION_MONSTER_ID_SET matches ACTIVE_PUNCTUATION_MONSTER_IDS', () => {
+  assert.equal(ACTIVE_PUNCTUATION_MONSTER_ID_SET.size, ACTIVE_PUNCTUATION_MONSTER_IDS.length);
+  for (const id of ACTIVE_PUNCTUATION_MONSTER_IDS) {
+    assert.ok(ACTIVE_PUNCTUATION_MONSTER_ID_SET.has(id));
+  }
+});
+
+test('DIRECT_PUNCTUATION_MONSTER_IDS excludes quoral', () => {
+  assert.ok(!DIRECT_PUNCTUATION_MONSTER_IDS.includes('quoral'));
+  assert.equal(DIRECT_PUNCTUATION_MONSTER_IDS.length, ACTIVE_PUNCTUATION_MONSTER_IDS.length - 1);
+});
+
+test('MONSTER_CLUSTERS covers all direct monsters', () => {
+  for (const id of DIRECT_PUNCTUATION_MONSTER_IDS) {
+    assert.ok(MONSTER_CLUSTERS.has(id), `MONSTER_CLUSTERS missing "${id}"`);
+  }
+});
+
+test('MONSTER_UNIT_COUNT covers all direct monsters', () => {
+  for (const id of DIRECT_PUNCTUATION_MONSTER_IDS) {
+    assert.ok(
+      typeof MONSTER_UNIT_COUNT[id] === 'number' && MONSTER_UNIT_COUNT[id] > 0,
+      `MONSTER_UNIT_COUNT["${id}"] should be a positive number`,
+    );
+  }
+});
+
+test('map filter IDs are frozen arrays', () => {
+  assert.ok(Object.isFrozen(PUNCTUATION_MAP_STATUS_FILTER_IDS));
+  assert.ok(Object.isFrozen(PUNCTUATION_MAP_MONSTER_FILTER_IDS));
+  assert.ok(Object.isFrozen(PUNCTUATION_MAP_DETAIL_TAB_IDS));
+  assert.ok(PUNCTUATION_MAP_STATUS_FILTER_IDS.length > 0);
+  assert.ok(PUNCTUATION_MAP_MONSTER_FILTER_IDS.length > 0);
+  assert.ok(PUNCTUATION_MAP_DETAIL_TAB_IDS.length > 0);
+});


### PR DESCRIPTION
## Summary

- Introduces `src/subjects/punctuation/punctuation-manifest.js` as the single canonical source of truth for all client-safe Punctuation metadata: skills (14), clusters (6), monsters (4), reward units (14), map filter IDs, and derived lookups (SKILL_TO_CLUSTER, RU_TO_CLUSTERS, MONSTER_CLUSTERS, MONSTER_UNIT_COUNT).
- Replaces 4 inlined copies of the same data across `star-projection.js`, `read-model.js`, `service-contract.js`, and `punctuation-view-model.js` with imports from the manifest.
- All downstream modules re-export for backward compatibility -- zero import-path changes needed for existing consumers.
- The manifest is a LEAF module (imports only from `platform/game/monsters.js`), breaking the circular dependency that previously forced inlined mirrors.

## Changed files

| File | Change |
|------|--------|
| `punctuation-manifest.js` | **New** -- canonical manifest (leaf module) |
| `star-projection.js` | Import SKILL_TO_CLUSTER, RU_TO_CLUSTERS, MONSTER_CLUSTERS, MONSTER_UNIT_COUNT, CLASPIN_REQUIRED_SKILLS, DIRECT_PUNCTUATION_MONSTER_IDS from manifest; remove ~80 lines of inlined data |
| `read-model.js` | Import PUNCTUATION_CLIENT_SKILLS + PUNCTUATION_CLIENT_REWARD_UNITS from manifest; re-export PUNCTUATION_CLIENT_SKILLS |
| `service-contract.js` | Import PUNCTUATION_CLIENT_SKILL_IDS + map filter IDs from manifest; re-export all four |
| `punctuation-view-model.js` | Import PUNCTUATION_CLIENT_SKILLS, cluster-to-monster map, active monster roster + ID set, map filter IDs from manifest; re-export all for backward compat |
| `punctuation-manifest-drift.test.js` | **New** -- 17 assertions pinning the manifest shape (14 skills, 6 clusters, 4 monsters, 14 RUs, apostrophe gate, map filter IDs) |

## Test plan

- [x] All 546 punctuation-pattern tests pass (zero regressions)
- [x] All 318 manifest/star-projection tests pass
- [x] New drift test validates manifest internal consistency (skill IDs match skills, SKILL_TO_CLUSTER covers all 14, RU_TO_CLUSTERS has 14 entries, CLASPIN_REQUIRED_SKILLS matches apostrophe cluster, all clusterIds appear in cluster-to-monster map)
- [x] 4 pre-existing failures on main are unrelated (button-label-consistency, csp-inline-style-budget, 2x grammar-ui-model)