### PR TITLE
refactor(punctuation): clean stale test and comment semantics to mission-dashboard (P7-U3)

### DIFF
--- a/tests/journeys/README.md
+++ b/tests/journeys/README.md
@@ -3,9 +3,9 @@
 Six end-to-end journey scripts that exercise the **real child critical-path
 click flow** against a live dev server. These are the regression-catching
 surface the Phase 3 SSR harness missed: every assertion in
-`tests/react-punctuation-scene.test.js` passed while the primary-mode
-`onClick` dispatched the wrong action. Journey specs here click with a real
-browser — the wire cannot lie.
+`tests/react-punctuation-scene.test.js` passed while the mission-dashboard
+CTA `onClick` dispatched the wrong action. Journey specs here click with a
+real browser — the wire cannot lie.
 
 ## Driver priority
 
@@ -19,9 +19,9 @@ under `tests/playwright/` are orthogonal and keep working.
 
 | Script                              | Journey                                                  |
 | ----------------------------------- | -------------------------------------------------------- |
-| `smart-review.mjs`                  | Home -> Punctuation -> Smart Review -> Q1 renders        |
-| `wobbly-spots.mjs`                  | Home -> Punctuation -> Wobbly Spots -> Q1 OR left-setup  |
-| `gps-check.mjs`                     | Home -> Punctuation -> GPS Check -> Q1 with test banner  |
+| `smart-review.mjs`                  | Home -> Punctuation -> Smart Review CTA -> Q1 renders    |
+| `wobbly-spots.mjs`                  | Home -> Punctuation -> Wobbly Spots CTA -> Q1 OR left-setup |
+| `gps-check.mjs`                     | Home -> Punctuation -> GPS Check CTA -> Q1 with test banner |
 | `map-guided-skill.mjs`              | Map -> skill card -> Practise this -> Guided Q1          |
 | `summary-back-while-pending.mjs`    | SKIPPED: needs dev-only stall endpoint (see below)       |
 | `reward-parity-visual.mjs`          | Map + Setup + Summary reward-state parity                |

--- a/tests/journeys/gps-check.mjs
+++ b/tests/journeys/gps-check.mjs
@@ -2,7 +2,7 @@
 //
 // R9 journey 3: Home -> Punctuation -> GPS Check -> Q1 with test-mode banner.
 //
-// GPS Check is the `gps` primary mode. The child-visible contract is
+// GPS Check is the `gps` mode, entered via the mission-dashboard CTA. The child-visible contract is
 // that the Session scene exposes a "test mode" banner — answers at the
 // end, not after each item. We assert both:
 //   - The submit button mounts (Q1 rendered)
@@ -28,7 +28,7 @@ export default async function run({ driver, artifacts, log, assert }) {
   await driver.waitForSelector('[data-punctuation-phase="setup"]', 10_000);
   await driver.screenshot(artifacts.path('02-setup'));
 
-  log('click GPS Check primary-mode card');
+  log('click GPS Check CTA');
   await driver.click('[data-action="punctuation-start"][data-mode-id="gps"]');
 
   log('wait for Session submit + test-mode banner');

--- a/tests/journeys/smart-review.mjs
+++ b/tests/journeys/smart-review.mjs
@@ -5,7 +5,7 @@
 // This is the journey the Phase 3 SSR harness missed. The unit test in
 // `tests/react-punctuation-scene.test.js` asserted on the rendered HTML
 // after dispatching `punctuation-start` directly — it never exercised the
-// primary-mode card's onClick, which was wiring `punctuation-set-mode`
+// mission-dashboard CTA's onClick, which was wiring `punctuation-set-mode`
 // (preference save) instead of `punctuation-start` (session open). The
 // bug shipped green. This spec clicks the real button.
 //
@@ -13,7 +13,7 @@
 //   1. clearStorage() — wipe prior journey's cookies + localStorage.
 //   2. Open /demo — seeds a demo learner and redirects to /.
 //   3. Click Home's Punctuation card ([data-subject-id="punctuation"]).
-//   4. Click the Smart Review primary-mode card
+//   4. Click the Smart Review mission-dashboard CTA
 //      ([data-action="punctuation-start"][data-mode-id="smart"]).
 //   5. Assert the Session scene is mounted: the `[data-punctuation-submit]`
 //      button appears within 10s (this is the first child-visible proof
@@ -37,7 +37,7 @@ export default async function run({ driver, artifacts, log, assert }) {
   await driver.waitForSelector('[data-punctuation-phase="setup"]', 10_000);
   await driver.screenshot(artifacts.path('02-setup'));
 
-  log('click Start Smart Review primary-mode card');
+  log('click Start Smart Review CTA');
   await driver.click('[data-action="punctuation-start"][data-mode-id="smart"]');
 
   log('wait for Session scene submit button to mount');

--- a/tests/journeys/wobbly-spots.mjs
+++ b/tests/journeys/wobbly-spots.mjs
@@ -2,7 +2,7 @@
 //
 // R9 journey 2: Home -> Punctuation -> Wobbly Spots -> Q1 OR empty state.
 //
-// The Wobbly Spots card (data-mode-id="weak") runs a `weak` cohort. On a
+// The Wobbly Spots CTA (data-mode-id="weak") runs a `weak` cohort. On a
 // fresh demo learner with no weak skills the Session scene is still
 // expected to mount an empty state or defer to Smart Review; whichever
 // path the engine picks, the child must land somewhere that is NOT still
@@ -24,7 +24,7 @@ export default async function run({ driver, artifacts, log, assert }) {
   await driver.waitForSelector('[data-punctuation-phase="setup"]', 10_000);
   await driver.screenshot(artifacts.path('02-setup'));
 
-  log('click Wobbly Spots primary-mode card');
+  log('click Wobbly Spots CTA');
   await driver.click('[data-action="punctuation-start"][data-mode-id="weak"]');
 
   log('wait for Setup to unmount OR empty-state surface');

--- a/tests/playwright/punctuation-accessibility-golden.playwright.test.mjs
+++ b/tests/playwright/punctuation-accessibility-golden.playwright.test.mjs
@@ -11,9 +11,9 @@
 //
 //   1. Focus the punctuation subject card on the home dashboard and
 //      activate it via Enter.
-//   2. Focus a primary-mode card (Smart / Weak / GPS etc.) and press
-//      Enter to start a session — the first keyboard-only session
-//      entry path on the setup scene.
+//   2. Focus the mission-dashboard CTA and press Enter to start a
+//      session — the first keyboard-only session entry path on the
+//      setup scene.
 //   3. For a choice item: focus the first choice card, press Space to
 //      select the radio, Tab to the primary Submit, press Enter to
 //      submit. For a text item: type into the autofocused
@@ -63,13 +63,12 @@ test.describe('punctuation accessibility golden — keyboard-only round-trip', (
   });
 
   // ---------------------------------------------------------------
-  // Keyboard-only punctuation entry + primary mode start.
+  // Keyboard-only punctuation entry via the mission-dashboard CTA.
   //
-  // The setup scene renders `[data-action="punctuation-start"]`
-  // primary mode cards (one per mode: Smart / Weak / GPS etc.). They
-  // are native `<button>` elements so they are tab-reachable; we
-  // focus the first card and press Enter to start a session without
-  // ever using the mouse.
+  // The setup scene renders `[data-action="punctuation-start"]` as
+  // the single primary CTA on the mission dashboard. It is a native
+  // `<button>` element so it is tab-reachable; we focus the CTA and
+  // press Enter to start a session without ever using the mouse.
   // ---------------------------------------------------------------
   test('keyboard-only learner opens punctuation and can start a session', async ({ page }) => {
     await createDemoSession(page);
@@ -78,7 +77,7 @@ test.describe('punctuation accessibility golden — keyboard-only round-trip', (
     await page.locator('[data-action="open-subject"][data-subject-id="punctuation"]').focus();
     await page.keyboard.press('Enter');
 
-    // Setup scene must render the primary mode cards.
+    // Setup scene must render the mission-dashboard CTA.
     const startCard = page.locator('[data-action="punctuation-start"]').first();
     await expect(startCard).toBeVisible({ timeout: 15_000 });
 

--- a/tests/punctuation-view-model.test.js
+++ b/tests/punctuation-view-model.test.js
@@ -459,7 +459,7 @@ test('U1 view-model: punctuationPrimaryModeFromPrefs collapses cluster modes to 
   }
 });
 
-test('U1 view-model: punctuationPrimaryModeFromPrefs preserves primary modes', () => {
+test('U1 view-model: punctuationPrimaryModeFromPrefs preserves active mode ids', () => {
   assert.equal(punctuationPrimaryModeFromPrefs({ mode: 'smart' }), 'smart');
   assert.equal(punctuationPrimaryModeFromPrefs({ mode: 'weak' }), 'weak');
   assert.equal(punctuationPrimaryModeFromPrefs({ mode: 'gps' }), 'gps');
@@ -638,8 +638,8 @@ test('U1 view-model: buildPunctuationDashboardModel activeMonsters iterate only 
 });
 
 test('U1 view-model: buildPunctuationDashboardModel normalises stale cluster-mode prefs', () => {
-  // Returning learners with a legacy cluster mode see the Smart Review card
-  // as the pressed option; U2's scene migrates the stored value.
+  // Returning learners with a legacy cluster mode see Smart Review as the
+  // pre-selected CTA option; U2's scene migrates the stored value.
   const model = buildPunctuationDashboardModel(
     {},
     { prefs: { mode: 'endmarks' } },

--- a/tests/react-punctuation-scene.test.js
+++ b/tests/react-punctuation-scene.test.js
@@ -104,7 +104,7 @@ test('punctuation React surface keeps server-only fields out of active HTML', ()
 
 test('punctuation React surface renders Guided teach box during an active session', () => {
   // Phase 3 U2: the setup-surface Guided dropdown + Weak / GPS buttons
-  // are removed (the new dashboard uses three primary mode cards +
+  // are removed (the mission dashboard uses a single primary CTA +
   // Open Map). This test keeps the active-item Guided teach-box
   // regression coverage — the current session's guided teach-box
   // payload still renders rule + worked example + common mistake.
@@ -2322,9 +2322,10 @@ test('Punctuation summary scene: active monster strip renders 4 monsters, no res
   // flat path that `PunctuationMapScene` uses and that
   // `PunctuationPracticeSurface` threads in via the resolved prop. The
   // pre-fix path `ui.rewards.monsters.punctuation` was fixture-only;
-  // production always rendered "Stage 0 of 4" because no code wrote that
-  // shape. Seed at the real path so a reserved-monster leak is still
-  // caught AND the roster iteration is driven off the path production uses.
+  // production rendered star meters (not the old "Stage 0 of 4") because
+  // no code wrote that shape. Seed at the real path so a reserved-monster
+  // leak is still caught AND the roster iteration is driven off the path
+  // production uses.
   harness.dispatch('open-subject', { subjectId: 'punctuation' });
   harness.store.updateSubjectUi('punctuation', {
     phase: 'summary',
@@ -2827,11 +2828,11 @@ test('punctuation Setup scene does not render the 6 cluster focus buttons (plan 
   assert.doesNotMatch(html, /data-punctuation-gps-start/);
 });
 
-// Phase 5 U7: mission dashboard — the three primary mode cards are replaced
-// by a single primary CTA + secondary drawer. The CTA label adapts to the
-// learner's state (fresh / returning with wobbly / post-session continue).
-// Mode-dispatch tests below verify that `punctuation-set-mode` still updates
-// stored prefs, which feeds the CTA resolution logic.
+// Phase 5 U7: mission dashboard — a single primary CTA with a secondary
+// drawer. The CTA label adapts to the learner's state (fresh / returning
+// with wobbly / post-session continue). Mode-dispatch tests below verify
+// that `punctuation-set-mode` still updates stored prefs, which feeds the
+// CTA resolution logic.
 
 test('punctuation Setup scene: fresh learner single CTA reads "Find your first punctuation egg" with all monsters at 0/100 Stars', () => {
   const harness = createPunctuationHarness();

--- a/tests/react-punctuation-scene.test.js
+++ b/tests/react-punctuation-scene.test.js
@@ -3685,26 +3685,26 @@ for (const entry of PUNCTUATION_CLUSTER_MODE_MATRIX) {
 }
 
 // ---------------------------------------------------------------------------
-// Phase 4 U1 — primary-mode card click-through (R1, R14).
+// Phase 4 U1 — mission-dashboard CTA click-through (R1, R14).
 //
 // The Phase 3 SSR harness could only grep the rendered HTML — it could not
-// fire an onClick handler, so a regression that swapped the primary card's
-// dispatch target from `punctuation-start` to `punctuation-set-mode` slipped
-// through.  The fix: tapping a primary card must start a session immediately
-// with `{ mode: <cardId>, roundLength: <prefs.roundLength> }`.
+// fire an onClick handler, so a regression that swapped the mission-dashboard
+// CTA's dispatch target from `punctuation-start` to `punctuation-set-mode`
+// slipped through.  The fix: tapping a mission-dashboard CTA must start a
+// session immediately with `{ mode: <ctaId>, roundLength: <prefs.roundLength> }`.
 //
 // These tests exercise the REAL onClick closure (via
-// `renderPrimaryModeCardElement`, which returns the React element straight
+// `renderMissionDashboardCTAElement`, which returns the React element straight
 // from the component function).  Invoking `element.props.onClick()` is the
 // same code path the browser would run — no SSR blind spot.
 //
 // Coverage matrix:
-//   - Each of the three primary card ids (smart / weak / gps) must dispatch
-//     `punctuation-start` with `{ mode: <id>, roundLength: '4' }`.
+//   - Each of the three mission-dashboard CTA ids (smart / weak / gps) must
+//     dispatch `punctuation-start` with `{ mode: <id>, roundLength: '4' }`.
 //   - Non-default round lengths ('8', '12') flow through to the payload.
 //   - `disabled=true` short-circuits the dispatch entirely.
-//   - The button MUST NOT carry `aria-pressed` — primary cards are action
-//     buttons, not radio buttons.
+//   - The button MUST NOT carry `aria-pressed` — mission-dashboard CTAs are
+//     action buttons, not radio buttons.
 //   - `data-action` must be `"punctuation-start"` (not `"punctuation-set-mode"`).
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Updated 7 test/journey files to replace stale "primary mode card" terminology with current "mission-dashboard CTA" language
- Cleaned references to the old three-card layout pattern (Smart Review card / Wobbly Spots card / GPS Check card) in comments, log messages, and test descriptions
- Clarified a historical "Stage 0 of 4" comment to reference current star meters
- No test logic changes — only comments, descriptions, and log strings updated

## Files changed

- `tests/playwright/punctuation-accessibility-golden.playwright.test.mjs` — contract comments and inline comments
- `tests/react-punctuation-scene.test.js` — 3 stale comments updated
- `tests/punctuation-view-model.test.js` — 1 test description + 1 comment
- `tests/journeys/README.md` — intro paragraph + journey table
- `tests/journeys/smart-review.mjs` — comments + log string
- `tests/journeys/wobbly-spots.mjs` — comment + log string
- `tests/journeys/gps-check.mjs` — comment + log string

## What was NOT changed (and why)

- **Grammar test files** (`react-grammar-surface.test.js`, `grammar-phase3-baseline.json`, `playwright/shared.mjs`): reference "primary mode cards" correctly because Grammar still uses that UI pattern
- **Reserved monster names** (`colisk`, `hyphang`, `carillon`): appear only in negative assertions (verifying they do NOT leak) or migration/asset tests — all legitimate
- **XP references** in `punctuation-reward-parity.test.js` and `punctuation-star-parity-worker-backed.test.js`: these are negative guard tests asserting XP does NOT appear — correct as-is

## Test plan

- [x] `node --test tests/punctuation-view-model.test.js` — 107 pass
- [x] `node --test tests/react-punctuation-scene.test.js` — 164 pass
- [x] `node --test tests/punctuation-reward-parity.test.js` — 11 pass
- [x] `node --test tests/punctuation-star-parity-worker-backed.test.js` — 15 pass
- [x] `node --test tests/react-punctuation-summary-ux.test.js` — 27 pass
- [x] All 785 punctuation tests pass (zero failures)