### PR TITLE
fix(admin): U5 — idempotent replay response-shape parity

### DIFF
--- a/tests/worker-admin-marketing-mutations.test.js
+++ b/tests/worker-admin-marketing-mutations.test.js
@@ -414,6 +414,111 @@ test('U11 Marketing Lifecycle Mutations', async (t) => {
     assert.equal(d2.mutation.replayed, true);
   });
 
+  await t.test('ADV-U11-007: first transition returns message field with full details', async () => {
+    const createRes = await createMessage(server, 'adult-admin', {
+      title: 'Shape parity first-call',
+      body_text: 'First call message field.',
+    });
+    const { message: msg } = await createRes.json();
+
+    const res = await transitionMessage(server, 'adult-admin', msg.id, {
+      action: 'scheduled', expectedRowVersion: 0, requestId: 'shape-first-1',
+    });
+    assert.equal(res.status, 200);
+    const data = await res.json();
+    assert.equal(data.mutation.replayed, false);
+    assert.ok(data.message, 'first-call must include message field');
+    assert.equal(data.message.id, msg.id);
+    assert.equal(data.message.status, 'scheduled');
+    assert.equal(data.message.title, 'Shape parity first-call');
+    assert.equal(typeof data.message.row_version, 'number');
+  });
+
+  await t.test('ADV-U11-007: replay returns message field with current state and replayed: true', async () => {
+    const createRes = await createMessage(server, 'adult-admin', {
+      title: 'Shape parity replay',
+      body_text: 'Replay message field.',
+    });
+    const { message: msg } = await createRes.json();
+
+    await transitionMessage(server, 'adult-admin', msg.id, {
+      action: 'scheduled', expectedRowVersion: 0, requestId: 'shape-replay-1',
+    });
+
+    const res2 = await transitionMessage(server, 'adult-admin', msg.id, {
+      action: 'scheduled', expectedRowVersion: 0, requestId: 'shape-replay-1',
+    });
+    assert.equal(res2.status, 200);
+    const data = await res2.json();
+    assert.equal(data.mutation.replayed, true);
+    assert.ok(data.message, 'replay must include message field');
+    assert.equal(data.message.id, msg.id);
+    assert.equal(data.message.status, 'scheduled');
+  });
+
+  await t.test('ADV-U11-007: first-call and replay have identical top-level and message keys', async () => {
+    const createRes = await createMessage(server, 'adult-admin', {
+      title: 'Key parity test',
+      body_text: 'Key parity.',
+    });
+    const { message: msg } = await createRes.json();
+
+    const res1 = await transitionMessage(server, 'adult-admin', msg.id, {
+      action: 'scheduled', expectedRowVersion: 0, requestId: 'keyparity-1',
+    });
+    const d1 = await res1.json();
+
+    const res2 = await transitionMessage(server, 'adult-admin', msg.id, {
+      action: 'scheduled', expectedRowVersion: 0, requestId: 'keyparity-1',
+    });
+    const d2 = await res2.json();
+
+    // Strict top-level key parity
+    assert.deepEqual(
+      Object.keys(d1).sort(),
+      Object.keys(d2).sort(),
+      'first-call and replay must have identical top-level keys',
+    );
+    // Strict message-field key parity
+    assert.deepEqual(
+      Object.keys(d1.message).sort(),
+      Object.keys(d2.message).sort(),
+      'first-call and replay message fields must have identical keys',
+    );
+  });
+
+  await t.test('ADV-U11-007: replay after subsequent modification returns current state, not stale cache', async () => {
+    const createRes = await createMessage(server, 'adult-admin', {
+      title: 'Stale cache test',
+      body_text: 'Original body.',
+    });
+    const { message: msg } = await createRes.json();
+
+    // First transition: draft → scheduled (row_version 0 → 1)
+    const res1 = await transitionMessage(server, 'adult-admin', msg.id, {
+      action: 'scheduled', expectedRowVersion: 0, requestId: 'stalecache-1',
+    });
+    const d1 = await res1.json();
+    assert.equal(d1.message.status, 'scheduled');
+    assert.equal(d1.message.row_version, 1);
+
+    // Subsequent transition: scheduled → published (row_version 1 → 2)
+    await transitionMessage(server, 'adult-admin', msg.id, {
+      action: 'published', expectedRowVersion: 1, requestId: 'stalecache-2',
+    });
+
+    // Replay the original draft → scheduled transition
+    const res3 = await transitionMessage(server, 'adult-admin', msg.id, {
+      action: 'scheduled', expectedRowVersion: 0, requestId: 'stalecache-1',
+    });
+    const d3 = await res3.json();
+    assert.equal(d3.mutation.replayed, true);
+    // The message field must reflect the CURRENT DB state (published, row_version 2),
+    // not the stale cached state from the original transition.
+    assert.equal(d3.message.status, 'published');
+    assert.equal(d3.message.row_version, 2);
+  });
+
   await t.test('ADV-U11-001: transition post-batch CAS detects concurrent row_version bump', async () => {
     // This exercises the post-batch meta.changes check. We simulate a
     // concurrent writer by directly bumping row_version in the DB between

--- a/worker/src/admin-marketing.js
+++ b/worker/src/admin-marketing.js
@@ -604,7 +604,12 @@ export async function transitionMarketingMessage(db, {
       });
     }
     const stored = JSON.parse(existingReceipt.response_json || '{}');
-    return { ...stored, mutation: { requestId, correlationId, replayed: true } };
+    const currentRow = await first(db, 'SELECT * FROM admin_marketing_messages WHERE id = ?', [stored.messageId]);
+    return {
+      ...stored,
+      message: currentRow ? adminMessageFields(currentRow) : null,
+      mutation: { requestId, correlationId, replayed: true },
+    };
   }
 
   const row = await first(db, 'SELECT * FROM admin_marketing_messages WHERE id = ?', [messageId]);


### PR DESCRIPTION
## Summary
- **ADV-U11-007 fix**: The idempotent replay path for marketing transitions was missing the `message` field, causing a response-shape mismatch between first-call and replay.
- The replay path now re-reads the current message row from the DB via `adminMessageFields()` before returning, with a null guard for defensive completeness.
- The `message` field intentionally reflects **current** DB state (not historical), so replays after subsequent modifications return up-to-date data rather than stale cached snapshots.

## Test plan
- [x] First transition returns `message` field with full message details
- [x] Replay of same `requestId` returns `message` field with current message state and `replayed: true`
- [x] `Object.keys(firstCallResponse).sort()` deep-equals `Object.keys(replayResponse).sort()` — strict key-by-key shape parity
- [x] Both first-call and replay `message` fields have the same set of keys
- [x] Replayed transition where message was subsequently modified returns current state, not stale cached state