### PR TITLE
ops(breakers): fix learner-fetch recovery after breaker reset

### DIFF
--- a/docs/operations/breaker-reset-runbook.md
+++ b/docs/operations/breaker-reset-runbook.md
@@ -1,0 +1,62 @@
+# Circuit Breaker Reset Runbook
+
+## Overview
+
+The `bootstrapCapacityMetadata` circuit breaker has `cooldownMaxMs: Infinity`, meaning it never auto-recovers. After three consecutive bootstrap responses arrive without `meta.capacity.bootstrapCapacity`, the breaker trips open and stays open until an operator explicitly resets it.
+
+While the breaker is open, sibling learner stat fetches (the `selectLearner` auto-refetch defence-in-depth path) may fail and get recorded in the store's sticky `attemptedLearnerFetches` Set. Without clearing, those learners would never be retried for the remainder of the session.
+
+## Symptoms
+
+- Parent Hub / Classroom Summary show "data unavailable" banners for capacity metadata.
+- Sibling learner stats (for learners added after initial bootstrap) remain at 0 even after the underlying server issue is resolved.
+- The `breakersDegraded.bootstrapCapacity` flag reads `true` in the persistence snapshot.
+
+## Diagnosis
+
+1. Open the Admin Hub > Debug panel.
+2. Check the `breakers` section in the persistence snapshot:
+   - `bootstrapCapacityMetadata.state` will read `open`.
+   - `bootstrapCapacityMetadata.cooldownUntil` will be `null` (Infinity is serialised as null).
+3. If the server issue has been resolved, proceed with the reset.
+
+## Reset Procedure
+
+### Option A: Server-side operator reset (recommended)
+
+The server includes a `forceBreakerReset` field in the bootstrap response's `meta.capacity` object when an admin header is present.
+
+1. Set the admin header on the next bootstrap request:
+   ```
+   X-KS2-Force-Breaker-Reset: bootstrapCapacityMetadata
+   ```
+2. The client's composition root reads `meta.capacity.forceBreakerReset`, validates the name against the closed `RESETABLE_BREAKER_NAME_SET`, and calls `breaker.reset()`.
+3. The reset fires the registered `breakerResetListeners`, which clears the store's `attemptedLearnerFetches` Set.
+4. The next `selectLearner` call on any empty-cache sibling learner fires a fresh fetch.
+
+### Option B: Natural recovery via successful bootstrap
+
+When the server starts returning valid `meta.capacity.bootstrapCapacity` data again, the bootstrap handler resets the breaker automatically:
+
+1. The `consecutiveMissingBootstrapMetadata` counter resets to 0.
+2. `breakers.bootstrapCapacityMetadata.reset()` fires.
+3. The registered `breakerResetListeners` fire, clearing the sticky learner-fetch guard.
+4. Sibling learner stats become fetchable again on the next `selectLearner`.
+
+## Recovery Verification
+
+After either reset path:
+
+1. The `breakersDegraded.bootstrapCapacity` flag reads `false`.
+2. Switch between learners in the Parent Hub.
+3. Any learner whose stats previously showed 0 (due to stale fetch guards) will now trigger a fresh fetch and display correct stats.
+
+## Side Effects of Reset
+
+- `attemptedLearnerFetches.clear()` removes ALL entries, not just those that failed during the outage. This is safe: the worst case is a redundant fetch for a learner whose cache is already populated (the cache-hit check short-circuits before the fetch fires).
+- `inFlightLearnerFetches` is NOT cleared — any in-flight fetch at the moment of reset continues normally and cleans up via its `.finally()` handler.
+
+## Constraints
+
+- Only breaker names in `RESETABLE_BREAKER_NAME_SET` (`bootstrapCapacityMetadata`) can be force-reset via the admin path. Other breakers use standard cooldown recovery.
+- The `clearStaleFetchGuards()` call is wired in the composition root (api.js), NOT in the breaker primitive's `onTransition` callback. This keeps the breaker state machine generic and the recovery side-effect scoped to the application layer.

--- a/src/platform/core/repositories/api.js
+++ b/src/platform/core/repositories/api.js
@@ -1530,6 +1530,20 @@ export function createApiPlatformRepositories({
     }),
   };
 
+  // P4/U7: registered listeners for breaker-reset events. Fired from the
+  // composition root's explicit `reset()` call sites (NOT from the
+  // breaker primitive's `onTransition`) whenever a breaker transitions
+  // to `closed`. The store's `clearStaleFetchGuards()` is the primary
+  // consumer — it clears the sticky per-session learner-fetch guard so
+  // sibling learner stats can be re-fetched after recovery.
+  const breakerResetListeners = new Set();
+
+  function fireBreakerResetListeners(breakerName) {
+    for (const listener of breakerResetListeners) {
+      try { listener({ breakerName }); } catch { /* listener throw swallowed */ }
+    }
+  }
+
   function currentBreakersSnapshot() {
     const output = {};
     for (const [key, breaker] of Object.entries(breakers)) {
@@ -2144,6 +2158,10 @@ export function createApiPlatformRepositories({
         consecutiveMissingBootstrapMetadata = 0;
         bootstrapMetadataOperatorError = null;
         breakers.bootstrapCapacityMetadata.reset();
+        // P4/U7: fire reset listeners so the store clears its sticky
+        // learner-fetch guard. Sibling learner stats that failed to
+        // fetch while the breaker was open can now be retried.
+        fireBreakerResetListeners('bootstrapCapacityMetadata');
       }
       // U9.1 item 2: `forceBreakerReset` via bootstrap response. When an
       // admin header triggers the server to include this field, the client
@@ -2156,6 +2174,10 @@ export function createApiPlatformRepositories({
         const targetBreaker = breakers[forceBreakerResetName];
         if (targetBreaker && typeof targetBreaker.reset === 'function') {
           targetBreaker.reset();
+          // P4/U7: fire reset listeners for operator-initiated resets
+          // (the `forceBreakerReset` admin path). Same rationale as
+          // the auto-recovery path above.
+          fireBreakerResetListeners(forceBreakerResetName);
         }
       }
       // U9.1 item 3: surface server-side `readModelDerivedWrite` breaker
@@ -2352,6 +2374,15 @@ export function createApiPlatformRepositories({
       // UI components MUST NOT import this — they read the aggregate
       // `breakersDegraded` boolean map from `read()` instead.
       breakers,
+      // P4/U7: register a callback that fires whenever a breaker is
+      // explicitly reset to `closed` from a composition-root call site.
+      // Returns an unsubscribe function. Primary consumer is the
+      // store's `clearStaleFetchGuards()`.
+      registerBreakerResetHook(listener) {
+        if (typeof listener !== 'function') return () => {};
+        breakerResetListeners.add(listener);
+        return () => breakerResetListeners.delete(listener);
+      },
       async retry() {
         const blocked = hasBlockedOperations(pendingOperations);
         await repositories.hydrate({

--- a/src/platform/core/repositories/api.js
+++ b/src/platform/core/repositories/api.js
@@ -2141,6 +2141,10 @@ export function createApiPlatformRepositories({
       // and let the higher layer decide whether to surface it (plan
       // line 752).
       const capacityMeta = payload?.meta?.capacity;
+      // adv-u7-001: track whether the natural recovery path already fired
+      // reset listeners for a breaker name in this bootstrap handler, so
+      // the forceBreakerReset path below can skip the duplicate fire.
+      let naturalResetFiredFor = null;
       if (!capacityMeta || !capacityMeta.bootstrapCapacity) {
         consecutiveMissingBootstrapMetadata += 1;
         if (consecutiveMissingBootstrapMetadata >= BOOTSTRAP_MISSING_METADATA_ESCALATION_LIMIT) {
@@ -2157,11 +2161,20 @@ export function createApiPlatformRepositories({
       } else {
         consecutiveMissingBootstrapMetadata = 0;
         bootstrapMetadataOperatorError = null;
+        // adv-u7-002: only fire reset listeners when actually recovering
+        // from an open/half-open breaker, not on every normal bootstrap.
+        // Firing unconditionally clears attemptedLearnerFetches on every
+        // cycle, partially defeating the R2 storm-prevention contract.
+        const wasNonClosed = breakers.bootstrapCapacityMetadata.isOpen
+          || breakers.bootstrapCapacityMetadata.state === 'half-open';
         breakers.bootstrapCapacityMetadata.reset();
-        // P4/U7: fire reset listeners so the store clears its sticky
-        // learner-fetch guard. Sibling learner stats that failed to
-        // fetch while the breaker was open can now be retried.
-        fireBreakerResetListeners('bootstrapCapacityMetadata');
+        if (wasNonClosed) {
+          // P4/U7: fire reset listeners so the store clears its sticky
+          // learner-fetch guard. Sibling learner stats that failed to
+          // fetch while the breaker was open can now be retried.
+          fireBreakerResetListeners('bootstrapCapacityMetadata');
+          naturalResetFiredFor = 'bootstrapCapacityMetadata';
+        }
       }
       // U9.1 item 2: `forceBreakerReset` via bootstrap response. When an
       // admin header triggers the server to include this field, the client
@@ -2174,10 +2187,17 @@ export function createApiPlatformRepositories({
         const targetBreaker = breakers[forceBreakerResetName];
         if (targetBreaker && typeof targetBreaker.reset === 'function') {
           targetBreaker.reset();
-          // P4/U7: fire reset listeners for operator-initiated resets
-          // (the `forceBreakerReset` admin path). Same rationale as
-          // the auto-recovery path above.
-          fireBreakerResetListeners(forceBreakerResetName);
+          // adv-u7-001: skip duplicate fire if the natural recovery path
+          // above already fired listeners for this same breaker name.
+          // Without this guard, every listener executes twice when a
+          // bootstrap response has both valid bootstrapCapacity AND
+          // forceBreakerReset targeting the same breaker.
+          if (forceBreakerResetName !== naturalResetFiredFor) {
+            // P4/U7: fire reset listeners for operator-initiated resets
+            // (the `forceBreakerReset` admin path). Same rationale as
+            // the auto-recovery path above.
+            fireBreakerResetListeners(forceBreakerResetName);
+          }
         }
       }
       // U9.1 item 3: surface server-side `readModelDerivedWrite` breaker

--- a/src/platform/core/store.js
+++ b/src/platform/core/store.js
@@ -488,6 +488,21 @@ export function createStore(
     return true;
   }
 
+  // P4/U7: wire clearStaleFetchGuards into the composition root's breaker
+  // reset hook. When the api repositories provide `registerBreakerResetHook`,
+  // every breaker transition to `closed` from an explicit reset() call site
+  // clears the sticky learner-fetch guard so sibling learner stats can be
+  // re-fetched. Local-only repositories do not expose this hook, so the
+  // guard degrades to no-op (no breakers exist in local-only mode).
+  function clearStaleFetchGuards() {
+    attemptedLearnerFetches.clear();
+  }
+  if (typeof resolvedRepositories.persistence?.registerBreakerResetHook === 'function') {
+    resolvedRepositories.persistence.registerBreakerResetHook(() => {
+      clearStaleFetchGuards();
+    });
+  }
+
   return {
     repositories: resolvedRepositories,
     getState() {
@@ -781,5 +796,13 @@ export function createStore(
       reloadFromRepositories();
     },
     resetSubjectUi,
+    // P4/U7: clear the sticky per-session "already attempted" guard so that
+    // the next `selectLearner` on an empty-cache sibling fires a fresh
+    // fetch. Called by the composition root after a breaker transitions
+    // to `closed` (e.g. operator reset of `bootstrapCapacityMetadata`).
+    // The breaker outage may have caused sibling learner fetches to fail
+    // and get recorded in the sticky Set — without clearing, the store
+    // would never retry those learners for the remainder of the session.
+    clearStaleFetchGuards,
   };
 }

--- a/tests/store-breaker-reset-learner-fetch-recovery.test.js
+++ b/tests/store-breaker-reset-learner-fetch-recovery.test.js
@@ -1,0 +1,341 @@
+// P4/U7 — Breaker reset and sticky learner-fetch recovery.
+//
+// When the `bootstrapCapacityMetadata` breaker (cooldownMaxMs: Infinity)
+// trips open, sibling learner stat fetches may fail and get recorded in
+// the store's sticky `attemptedLearnerFetches` Set. After operator reset
+// (or natural recovery), `clearStaleFetchGuards()` fires via the
+// composition root's `breakerResetListeners` hook, allowing the next
+// `selectLearner` to retry those learners.
+//
+// These tests cover:
+//   T1: breaker open -> sticky guard blocks -> reset -> clearStaleFetchGuards -> refetch
+//   T2: 4-learner account with transient sibling fetch failure -> recovery
+//   T3: clearStaleFetchGuards when Set is empty -> no-op
+//   T4: existing infinite-refetch guard still passes (via store-select-learner-refetch.test.js)
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { installMemoryStorage } from './helpers/memory-storage.js';
+import { createStore } from '../src/platform/core/store.js';
+import { SUBJECTS } from '../src/platform/core/subject-registry.js';
+import { createLocalPlatformRepositories } from '../src/platform/core/repositories/index.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildRepositoriesWithReadForLearner(perLearner) {
+  const storage = installMemoryStorage();
+  const base = createLocalPlatformRepositories({ storage });
+  const proxy = {
+    ...base,
+    subjectStates: {
+      ...base.subjectStates,
+      readForLearner(learnerId) {
+        if (Object.prototype.hasOwnProperty.call(perLearner, learnerId)) {
+          return perLearner[learnerId];
+        }
+        return base.subjectStates.readForLearner.call(base.subjectStates, learnerId);
+      },
+    },
+  };
+  return { repositories: proxy, base, perLearner };
+}
+
+function createStoreWithTwoLearners({ readForLearner = {}, fetchLearnerSubjectState } = {}) {
+  const { repositories, base, perLearner } = buildRepositoriesWithReadForLearner({});
+
+  const setupStore = createStore(SUBJECTS, { repositories });
+  const learnerA = setupStore.getState().learners.selectedId;
+  const learnerB = setupStore.createLearner({ name: 'Nelson' }).id;
+  setupStore.selectLearner(learnerA);
+
+  for (const [aliasKey, value] of Object.entries(readForLearner)) {
+    const resolvedId = aliasKey === 'A' ? learnerA : aliasKey === 'B' ? learnerB : aliasKey;
+    perLearner[resolvedId] = value;
+  }
+
+  const store = createStore(SUBJECTS, {
+    repositories,
+    ...(fetchLearnerSubjectState ? { fetchLearnerSubjectState } : {}),
+  });
+
+  return { store, learnerA, learnerB, repositories, base, perLearner };
+}
+
+function createStoreWithFourLearners({ readForLearner = {}, fetchLearnerSubjectState } = {}) {
+  const { repositories, base, perLearner } = buildRepositoriesWithReadForLearner({});
+
+  const setupStore = createStore(SUBJECTS, { repositories });
+  const learnerA = setupStore.getState().learners.selectedId;
+  const learnerB = setupStore.createLearner({ name: 'Nelson' }).id;
+  const learnerC = setupStore.createLearner({ name: 'Mei' }).id;
+  const learnerD = setupStore.createLearner({ name: 'Suki' }).id;
+  setupStore.selectLearner(learnerA);
+
+  for (const [aliasKey, value] of Object.entries(readForLearner)) {
+    const resolvedId = aliasKey === 'A' ? learnerA
+      : aliasKey === 'B' ? learnerB
+        : aliasKey === 'C' ? learnerC
+          : aliasKey === 'D' ? learnerD
+            : aliasKey;
+    perLearner[resolvedId] = value;
+  }
+
+  const store = createStore(SUBJECTS, {
+    repositories,
+    ...(fetchLearnerSubjectState ? { fetchLearnerSubjectState } : {}),
+  });
+
+  return { store, learnerA, learnerB, learnerC, learnerD, repositories, base, perLearner };
+}
+
+async function flushMicrotasks(rounds = 5) {
+  for (let i = 0; i < rounds; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    await Promise.resolve();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// T1: breaker open -> sticky guard blocks -> reset -> clearStaleFetchGuards -> refetch
+// ---------------------------------------------------------------------------
+
+test('breaker open -> attemptedLearnerFetches blocks -> operator reset -> clearStaleFetchGuards -> refetch succeeds', async () => {
+  const spyCalls = [];
+  const { store, learnerA, learnerB } = createStoreWithTwoLearners({
+    readForLearner: {
+      B: {},
+      A: { spelling: { ui: { phase: 'dashboard' }, data: {}, writeVersion: 1, updatedAt: 1 } },
+    },
+    fetchLearnerSubjectState: (id) => {
+      spyCalls.push(id);
+      // Simulate a failure during breaker-open window.
+      if (spyCalls.length === 1) {
+        return Promise.reject(new Error('breaker open — fetch blocked'));
+      }
+      // After reset, the fetch succeeds.
+      return Promise.resolve();
+    },
+  });
+
+  // 1. Select B — fetch fires and fails (simulating breaker-open window).
+  store.selectLearner(learnerB);
+  await flushMicrotasks(10);
+  assert.equal(spyCalls.length, 1, 'first fetch fires for B');
+
+  // 2. The sticky guard now holds B. Switching back and re-selecting B
+  //    does NOT fire a second fetch (the R2 invariant).
+  store.selectLearner(learnerA);
+  await flushMicrotasks(5);
+  store.selectLearner(learnerB);
+  await flushMicrotasks(5);
+  assert.equal(spyCalls.length, 1, 'sticky guard blocks refetch for B');
+
+  // 3. Operator resets the breaker -> clearStaleFetchGuards fires.
+  store.clearStaleFetchGuards();
+
+  // 4. Now selecting B again fires a fresh fetch.
+  store.selectLearner(learnerA);
+  await flushMicrotasks(5);
+  store.selectLearner(learnerB);
+  await flushMicrotasks(5);
+  assert.equal(spyCalls.length, 2, 'after clearStaleFetchGuards, refetch succeeds for B');
+  assert.equal(spyCalls[1], learnerB, 'second fetch is for B');
+});
+
+// ---------------------------------------------------------------------------
+// T2: 4-learner account with transient sibling fetch failure -> recovery
+// ---------------------------------------------------------------------------
+
+test('4-learner account: transient sibling fetch failure recovers after clearStaleFetchGuards', async () => {
+  const spyCalls = [];
+  let failFetches = true;
+  const { store, learnerA, learnerB, learnerC, learnerD } = createStoreWithFourLearners({
+    readForLearner: {
+      A: { spelling: { ui: { phase: 'dashboard' }, data: {}, writeVersion: 1, updatedAt: 1 } },
+      B: {},
+      C: {},
+      D: {},
+    },
+    fetchLearnerSubjectState: (id) => {
+      spyCalls.push(id);
+      if (failFetches) {
+        return Promise.reject(new Error('transient failure'));
+      }
+      return Promise.resolve();
+    },
+  });
+
+  // 1. Select B, C, D in sequence — all fail during the outage.
+  store.selectLearner(learnerB);
+  await flushMicrotasks(10);
+  store.selectLearner(learnerC);
+  await flushMicrotasks(10);
+  store.selectLearner(learnerD);
+  await flushMicrotasks(10);
+  assert.equal(spyCalls.length, 3, 'three fetches fired (B, C, D)');
+
+  // 2. All three are now sticky-guarded. Switching back does not refetch.
+  store.selectLearner(learnerB);
+  await flushMicrotasks(5);
+  store.selectLearner(learnerC);
+  await flushMicrotasks(5);
+  store.selectLearner(learnerD);
+  await flushMicrotasks(5);
+  assert.equal(spyCalls.length, 3, 'sticky guard blocks all three during outage');
+
+  // 3. Server recovers. Clear the fetch guards.
+  failFetches = false;
+  store.clearStaleFetchGuards();
+
+  // 4. Now all three can be retried.
+  store.selectLearner(learnerA);
+  await flushMicrotasks(5);
+  store.selectLearner(learnerB);
+  await flushMicrotasks(10);
+  assert.equal(spyCalls.length, 4, 'B refetched after recovery');
+
+  store.selectLearner(learnerC);
+  await flushMicrotasks(10);
+  assert.equal(spyCalls.length, 5, 'C refetched after recovery');
+
+  store.selectLearner(learnerD);
+  await flushMicrotasks(10);
+  assert.equal(spyCalls.length, 6, 'D refetched after recovery');
+});
+
+// ---------------------------------------------------------------------------
+// T3: clearStaleFetchGuards when Set is empty -> no-op
+// ---------------------------------------------------------------------------
+
+test('clearStaleFetchGuards is a no-op when no learner fetches have been attempted', () => {
+  const storage = installMemoryStorage();
+  const repositories = createLocalPlatformRepositories({ storage });
+  const store = createStore(SUBJECTS, { repositories });
+
+  // No selectLearner calls — the attemptedLearnerFetches Set is empty.
+  // clearStaleFetchGuards must not throw.
+  assert.doesNotThrow(() => store.clearStaleFetchGuards(),
+    'clearStaleFetchGuards on empty Set must not throw');
+});
+
+// ---------------------------------------------------------------------------
+// T4: clearStaleFetchGuards does NOT break the infinite-refetch guard
+// ---------------------------------------------------------------------------
+//
+// After clearStaleFetchGuards, the R2 contract still holds for NEW
+// attempts: a learner whose fetch fails AFTER the clear is still
+// sticky-guarded until the next clear. This test pins that the clear
+// is a one-shot reset, not a permanent disable.
+
+test('clearStaleFetchGuards resets the guard but new attempts re-arm it (R2 contract preserved)', async () => {
+  const spyCalls = [];
+  const { store, learnerA, learnerB } = createStoreWithTwoLearners({
+    readForLearner: {
+      B: {},
+      A: { spelling: { ui: { phase: 'dashboard' }, data: {}, writeVersion: 1, updatedAt: 1 } },
+    },
+    fetchLearnerSubjectState: (id) => {
+      spyCalls.push(id);
+      // Always resolve with no side-effect (cache stays empty).
+      return Promise.resolve();
+    },
+  });
+
+  // 1. First attempt for B.
+  store.selectLearner(learnerB);
+  await flushMicrotasks(10);
+  assert.equal(spyCalls.length, 1, 'first fetch fires');
+
+  // 2. Clear the guard.
+  store.clearStaleFetchGuards();
+
+  // 3. Second attempt fires (guard was cleared).
+  store.selectLearner(learnerA);
+  await flushMicrotasks(5);
+  store.selectLearner(learnerB);
+  await flushMicrotasks(10);
+  assert.equal(spyCalls.length, 2, 'second fetch fires after clear');
+
+  // 4. Without another clear, the R2 infinite-refetch guard re-arms.
+  store.selectLearner(learnerA);
+  await flushMicrotasks(5);
+  store.selectLearner(learnerB);
+  await flushMicrotasks(5);
+  assert.equal(spyCalls.length, 2, 'R2 guard re-armed — no third fetch without another clear');
+});
+
+// ---------------------------------------------------------------------------
+// T5: registerBreakerResetHook wires clearStaleFetchGuards automatically
+// ---------------------------------------------------------------------------
+//
+// Verify that when the repositories expose `registerBreakerResetHook`,
+// the store auto-registers and the hook fires clearStaleFetchGuards.
+
+test('store auto-registers with registerBreakerResetHook when available', async () => {
+  const registeredListeners = new Set();
+
+  // Phase 1: build repos with a mock registerBreakerResetHook.
+  const { repositories: baseRepos, perLearner } = buildRepositoriesWithReadForLearner({});
+  const repositories = {
+    ...baseRepos,
+    persistence: {
+      ...baseRepos.persistence,
+      registerBreakerResetHook(listener) {
+        registeredListeners.add(listener);
+        return () => registeredListeners.delete(listener);
+      },
+    },
+  };
+
+  // Phase 2: seed two learners WITHOUT the fetch hook (same pattern
+  // as createStoreWithTwoLearners).
+  const setupStore = createStore(SUBJECTS, { repositories });
+  const learnerA = setupStore.getState().learners.selectedId;
+  const learnerB = setupStore.createLearner({ name: 'Test' }).id;
+  setupStore.selectLearner(learnerA);
+
+  // Install per-learner overrides now that ids are known.
+  perLearner[learnerA] = { spelling: { ui: { phase: 'dashboard' }, data: {}, writeVersion: 1, updatedAt: 1 } };
+  perLearner[learnerB] = {};
+
+  // Phase 3: construct the store under test with the fetch hook wired.
+  const spyCalls = [];
+  const store = createStore(SUBJECTS, {
+    repositories,
+    fetchLearnerSubjectState: (id) => {
+      spyCalls.push(id);
+      return Promise.resolve();
+    },
+  });
+
+  // The store must have registered exactly one listener.
+  assert.equal(registeredListeners.size, 2,
+    'both setup and test stores registered a listener (2 createStore calls)');
+
+  // Select B — triggers fetch, records in attemptedLearnerFetches.
+  store.selectLearner(learnerB);
+  await flushMicrotasks(10);
+  assert.equal(spyCalls.length, 1, 'first fetch fired for B');
+
+  // Sticky guard blocks refetch.
+  store.selectLearner(learnerA);
+  await flushMicrotasks(5);
+  store.selectLearner(learnerB);
+  await flushMicrotasks(5);
+  assert.equal(spyCalls.length, 1, 'sticky guard active');
+
+  // Fire the registered listeners (simulating breaker reset in api.js).
+  for (const listener of registeredListeners) {
+    listener({ breakerName: 'bootstrapCapacityMetadata' });
+  }
+
+  // Now the guard is cleared — refetch fires.
+  store.selectLearner(learnerA);
+  await flushMicrotasks(5);
+  store.selectLearner(learnerB);
+  await flushMicrotasks(10);
+  assert.equal(spyCalls.length, 2, 'refetch fires after hook-triggered clear');
+});


### PR DESCRIPTION
## Summary

- **Store**: Add `clearStaleFetchGuards()` method that clears the sticky `attemptedLearnerFetches` Set, allowing sibling learner stats to be refetched after a breaker outage.
- **API composition root**: Add `registerBreakerResetHook` on `repositories.persistence` and fire it from both explicit `reset()` call sites (`bootstrapCapacityMetadata` natural recovery and `forceBreakerReset` admin path). The store auto-registers during construction.
- **Runbook**: `docs/operations/breaker-reset-runbook.md` documents the operator procedure for both server-side admin reset and natural recovery.
- **5 new tests**: full reset-to-refetch cycle, 4-learner transient failure recovery, empty-Set no-op, R2 re-arm contract preserved, and hook auto-registration wiring.

## Context

The `bootstrapCapacityMetadata` breaker has `cooldownMaxMs: Infinity` (never auto-recovers). After a `forceBreakerReset` or natural recovery, the `attemptedLearnerFetches` Set in the store had no clearing mechanism, leaving sibling learner stats permanently stale at 0 for the remainder of the session.

## Test plan

- [x] 5 new tests in `tests/store-breaker-reset-learner-fetch-recovery.test.js` all pass
- [x] All 12 existing `tests/store-select-learner-refetch.test.js` tests pass (zero regression on infinite-refetch guard)
- [x] 97 store + breaker tests pass
- [x] 302 capacity + persistence + hub tests pass
- [x] 6 repository integration tests pass