### PR TITLE
capacity(evidence): add provenance fields and anti-fabrication guard

### DIFF
--- a/scripts/lib/capacity-evidence.mjs
+++ b/scripts/lib/capacity-evidence.mjs
@@ -1,5 +1,6 @@
+import { createHash } from 'node:crypto';
 import { execSync } from 'node:child_process';
-import { mkdirSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 
 export const EVIDENCE_SCHEMA_VERSION = 2;
@@ -44,7 +45,75 @@ export function buildReportMeta(options = {}, timings = {}) {
     startedAt: timings.startedAt || null,
     finishedAt: timings.finishedAt || null,
     evidenceSchemaVersion: EVIDENCE_SCHEMA_VERSION,
+    provenance: buildProvenance(options),
   };
+}
+
+/**
+ * Build the provenance sub-block for evidence anti-fabrication.
+ * Every field degrades to `'unknown'` (or a safe default) rather than throwing;
+ * `verify-capacity-evidence.mjs` enforces strictness for certifiable tiers.
+ */
+export function buildProvenance(options = {}) {
+  const serverUrl = process.env.GITHUB_SERVER_URL || '';
+  const repo = process.env.GITHUB_REPOSITORY || '';
+  const runId = process.env.GITHUB_RUN_ID || '';
+  const workflowRunUrl = (serverUrl && repo && runId)
+    ? `${serverUrl}/${repo}/actions/runs/${runId}`
+    : 'unknown';
+
+  return {
+    workflowRunUrl,
+    workflowName: process.env.GITHUB_WORKFLOW || 'unknown',
+    gitSha: resolveCommitSha(),
+    dirtyTreeFlag: resolveGitDirty(),
+    thresholdConfigHash: resolveThresholdConfigHash(options),
+    loadDriverVersion: resolveLoadDriverVersion(),
+    operator: process.env.GITHUB_ACTOR || process.env.USER || process.env.USERNAME || 'unknown',
+    rawLogArtifactPath: options.rawLogArtifactPath || 'none',
+  };
+}
+
+function resolveGitDirty() {
+  try {
+    const status = execSync('git status --porcelain', {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 3000,
+    }).toString().trim();
+    return status.length > 0;
+  } catch {
+    // Cannot determine; degrade to true (conservative — verify will reject
+    // dirty-tree for certifiable tiers).
+    return true;
+  }
+}
+
+/**
+ * SHA-256 of the threshold config file content when a --config path is supplied.
+ * Returns `'none'` when no config was used (e.g. dry-run or CLI-only thresholds).
+ * Returns `'unknown'` when the file cannot be read.
+ */
+function resolveThresholdConfigHash(options = {}) {
+  const configPath = options.configPath;
+  if (!configPath) return 'none';
+  try {
+    const content = readFileSync(resolve(process.cwd(), configPath), 'utf8');
+    return createHash('sha256').update(content).digest('hex');
+  } catch {
+    return 'unknown';
+  }
+}
+
+function resolveLoadDriverVersion() {
+  try {
+    const pkgPath = resolve(import.meta.url.startsWith('file://')
+      ? new URL('../../package.json', import.meta.url).pathname.replace(/^\/([A-Z]:)/i, '$1')
+      : resolve(process.cwd(), 'package.json'));
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+    return pkg.version || 'unknown';
+  } catch {
+    return 'unknown';
+  }
 }
 
 function resolveCommitSha() {

--- a/scripts/lib/capacity-evidence.mjs
+++ b/scripts/lib/capacity-evidence.mjs
@@ -34,8 +34,13 @@ export function validateThresholdConfigKeys(thresholds = {}) {
  * fail just because git metadata or env hints are missing.
  */
 export function buildReportMeta(options = {}, timings = {}) {
+  // ADV-001: resolve the commit SHA once and pass it to buildProvenance so
+  // reportMeta.commit and provenance.gitSha are guaranteed identical. Two
+  // independent calls to resolveCommitSha() created a TOCTOU gap — HEAD could
+  // change between the calls, causing the values to diverge.
+  const commitSha = resolveCommitSha();
   return {
-    commit: resolveCommitSha(),
+    commit: commitSha,
     environment: resolveEnvironmentName(options),
     origin: options.origin || 'unknown',
     authMode: resolveAuthMode(options),
@@ -45,7 +50,7 @@ export function buildReportMeta(options = {}, timings = {}) {
     startedAt: timings.startedAt || null,
     finishedAt: timings.finishedAt || null,
     evidenceSchemaVersion: EVIDENCE_SCHEMA_VERSION,
-    provenance: buildProvenance(options),
+    provenance: buildProvenance(options, commitSha),
   };
 }
 
@@ -54,7 +59,7 @@ export function buildReportMeta(options = {}, timings = {}) {
  * Every field degrades to `'unknown'` (or a safe default) rather than throwing;
  * `verify-capacity-evidence.mjs` enforces strictness for certifiable tiers.
  */
-export function buildProvenance(options = {}) {
+export function buildProvenance(options = {}, cachedCommitSha) {
   const serverUrl = process.env.GITHUB_SERVER_URL || '';
   const repo = process.env.GITHUB_REPOSITORY || '';
   const runId = process.env.GITHUB_RUN_ID || '';
@@ -65,7 +70,9 @@ export function buildProvenance(options = {}) {
   return {
     workflowRunUrl,
     workflowName: process.env.GITHUB_WORKFLOW || 'unknown',
-    gitSha: resolveCommitSha(),
+    // ADV-001: use the cached SHA from buildReportMeta when available, so
+    // provenance.gitSha is always identical to reportMeta.commit.
+    gitSha: cachedCommitSha ?? resolveCommitSha(),
     dirtyTreeFlag: resolveGitDirty(),
     thresholdConfigHash: resolveThresholdConfigHash(options),
     loadDriverVersion: resolveLoadDriverVersion(),

--- a/scripts/verify-capacity-evidence.mjs
+++ b/scripts/verify-capacity-evidence.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { createHash } from 'node:crypto';
 import { execSync, execFileSync } from 'node:child_process';
 import { readFileSync, existsSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
@@ -701,6 +702,82 @@ function checkNumericDrift(row, payload) {
 }
 
 /**
+ * P4 U8: Evidence provenance and anti-fabrication guard.
+ *
+ * Certifiable tiers (30-learner-beta-certified, 60-learner-stretch-certified,
+ * 100-plus-certified) MUST carry a provenance block with:
+ *   - gitSha not 'unknown'
+ *   - dirtyTreeFlag not true
+ *   - thresholdConfigHash matching the committed config file (when config present)
+ *
+ * Lower tiers (smoke-pass, small-pilot-provisional) accept missing provenance
+ * for manual/local runs.
+ *
+ * Returns an array of failure messages; empty on a clean check.
+ */
+function checkProvenance(payload, rowDecision) {
+  const messages = [];
+  const provenance = payload.reportMeta?.provenance;
+  const requiresProvenance = TIERS_ABOVE_SMALL_PILOT.has(rowDecision);
+
+  // Lower tiers tolerate absent provenance.
+  if (!provenance) {
+    if (requiresProvenance) {
+      messages.push(
+        `tier "${rowDecision}" requires reportMeta.provenance for certification traceability. `
+        + 'Evidence must be produced by a CI workflow, not hand-authored.',
+      );
+    }
+    return messages;
+  }
+
+  // When provenance is present, validate its contents for certifiable tiers.
+  if (requiresProvenance) {
+    if (!provenance.gitSha || provenance.gitSha === 'unknown') {
+      messages.push(
+        `provenance.gitSha is "${provenance.gitSha || 'missing'}"; certifiable tiers require a resolved git SHA. `
+        + 'Ensure the capacity run executes within a git repository.',
+      );
+    }
+    if (provenance.dirtyTreeFlag === true) {
+      messages.push(
+        'provenance.dirtyTreeFlag is true; certifiable tiers require a clean git working tree. '
+        + 'Commit all changes before running a certification capacity test.',
+      );
+    }
+  }
+
+  // thresholdConfigHash cross-check: when the evidence records a configPath
+  // AND provenance records a hash, re-hash the committed config and compare.
+  // Mismatch means the config was tampered with after the run or the evidence
+  // was generated against a different config file.
+  const configPath = payload.tier?.configPath;
+  if (configPath && provenance.thresholdConfigHash
+      && provenance.thresholdConfigHash !== 'none'
+      && provenance.thresholdConfigHash !== 'unknown') {
+    const absoluteConfigPath = resolve(process.cwd(), configPath);
+    if (existsSync(absoluteConfigPath)) {
+      try {
+        const content = readFileSync(absoluteConfigPath, 'utf8');
+        const currentHash = createHash('sha256').update(content).digest('hex');
+        if (currentHash !== provenance.thresholdConfigHash) {
+          messages.push(
+            `provenance.thresholdConfigHash mismatch: evidence recorded "${provenance.thresholdConfigHash.slice(0, 16)}..." `
+            + `but committed config "${configPath}" now hashes to "${currentHash.slice(0, 16)}...". `
+            + 'The config file was modified after the evidence was produced; regenerate the evidence.',
+          );
+        }
+      } catch {
+        // Cannot read config for hash comparison — surface but do not fail.
+        // The config-existence check elsewhere will catch missing files.
+      }
+    }
+  }
+
+  return messages;
+}
+
+/**
  * Verify a single evidence row against its persisted JSON file.
  * Returns `{ ok, messages: string[], warnings: string[] }` where `ok: false`
  * means the row fails the cross-check. `warnings` surface non-fatal concerns
@@ -952,6 +1029,15 @@ export function verifyEvidenceRow(row) {
   const coherenceFailures = checkStructuralCoherence(payload);
   if (coherenceFailures.length) {
     messages.push(...coherenceFailures);
+  }
+
+  // Provenance anti-fabrication guard (P4 U8). Certifiable tiers (above
+  // small-pilot-provisional) MUST carry a provenance block with valid CI
+  // metadata. Lower tiers (smoke-pass, small-pilot-provisional) accept
+  // missing provenance for manual/local runs.
+  const provenanceMessages = checkProvenance(payload, row.decision);
+  if (provenanceMessages.length) {
+    messages.push(...provenanceMessages);
   }
 
   // Cross-check numeric cells in the capacity.md row against evidence

--- a/scripts/verify-capacity-evidence.mjs
+++ b/scripts/verify-capacity-evidence.mjs
@@ -745,6 +745,15 @@ function checkProvenance(payload, rowDecision) {
         + 'Commit all changes before running a certification capacity test.',
       );
     }
+    // ADV-002: reject thresholdConfigHash='unknown' for certifiable tiers when
+    // a configPath is present. Previously this value silently skipped the hash
+    // cross-check below, so an attacker could hand-edit evidence to set the
+    // hash to 'unknown' and bypass tamper detection entirely.
+    if (payload.tier?.configPath && provenance.thresholdConfigHash === 'unknown') {
+      messages.push(
+        'provenance.thresholdConfigHash is unknown — config integrity cannot be verified for certifiable tiers',
+      );
+    }
   }
 
   // thresholdConfigHash cross-check: when the evidence records a configPath

--- a/tests/capacity-evidence.test.js
+++ b/tests/capacity-evidence.test.js
@@ -773,3 +773,16 @@ test('buildEvidencePayload includes provenance in reportMeta (P4-U8)', () => {
   assert.equal(typeof payload.reportMeta.provenance.gitSha, 'string');
   assert.equal(typeof payload.reportMeta.provenance.dirtyTreeFlag, 'boolean');
 });
+
+// ---------------------------------------------------------------------------
+// ADV-001: buildReportMeta caches gitSha to prevent TOCTOU divergence
+// ---------------------------------------------------------------------------
+
+test('buildReportMeta.commit is identical to provenance.gitSha (ADV-001 TOCTOU cache)', () => {
+  const meta = buildReportMeta({ mode: 'dry-run' });
+  assert.equal(
+    meta.commit,
+    meta.provenance.gitSha,
+    'reportMeta.commit and provenance.gitSha must be the same value — both derived from a single resolveCommitSha() call',
+  );
+});

--- a/tests/capacity-evidence.test.js
+++ b/tests/capacity-evidence.test.js
@@ -1,6 +1,7 @@
+import { createHash } from 'node:crypto';
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -10,6 +11,7 @@ import {
   REQUEST_SAMPLES_TAIL_LIMIT,
   autoNameEvidencePath,
   buildEvidencePayload,
+  buildProvenance,
   buildReportMeta,
   evaluateThresholds,
   persistEvidenceFile,
@@ -651,4 +653,123 @@ test('end-to-end: summarise then evaluate — pipeline populates capacity for ga
   assert.equal(result.thresholds.requireBootstrapCapacity.passed, true);
   assert.deepEqual(result.thresholds.requireBootstrapCapacity.observed, { queryCount: 7, d1RowsRead: 55 });
   assert.deepEqual(result.failures, []);
+});
+
+// ---------------------------------------------------------------------------
+// P4 U8: Evidence provenance and anti-fabrication guard
+// ---------------------------------------------------------------------------
+
+test('buildReportMeta includes provenance sub-block (P4-U8)', () => {
+  const meta = buildReportMeta({ mode: 'dry-run' });
+  assert.ok(meta.provenance, 'provenance block must be present');
+  assert.equal(typeof meta.provenance.gitSha, 'string');
+  assert.equal(typeof meta.provenance.dirtyTreeFlag, 'boolean');
+  assert.equal(typeof meta.provenance.workflowRunUrl, 'string');
+  assert.equal(typeof meta.provenance.workflowName, 'string');
+  assert.equal(typeof meta.provenance.operator, 'string');
+  assert.equal(typeof meta.provenance.loadDriverVersion, 'string');
+  assert.equal(typeof meta.provenance.rawLogArtifactPath, 'string');
+});
+
+test('buildProvenance degrades workflowRunUrl to unknown without GH env vars (P4-U8)', () => {
+  const saved = {
+    GITHUB_SERVER_URL: process.env.GITHUB_SERVER_URL,
+    GITHUB_REPOSITORY: process.env.GITHUB_REPOSITORY,
+    GITHUB_RUN_ID: process.env.GITHUB_RUN_ID,
+    GITHUB_WORKFLOW: process.env.GITHUB_WORKFLOW,
+    GITHUB_ACTOR: process.env.GITHUB_ACTOR,
+  };
+  delete process.env.GITHUB_SERVER_URL;
+  delete process.env.GITHUB_REPOSITORY;
+  delete process.env.GITHUB_RUN_ID;
+  delete process.env.GITHUB_WORKFLOW;
+  delete process.env.GITHUB_ACTOR;
+  try {
+    const prov = buildProvenance({});
+    assert.equal(prov.workflowRunUrl, 'unknown');
+    assert.equal(prov.workflowName, 'unknown');
+  } finally {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+});
+
+test('buildProvenance constructs workflowRunUrl from GH env vars (P4-U8)', () => {
+  const saved = {
+    GITHUB_SERVER_URL: process.env.GITHUB_SERVER_URL,
+    GITHUB_REPOSITORY: process.env.GITHUB_REPOSITORY,
+    GITHUB_RUN_ID: process.env.GITHUB_RUN_ID,
+    GITHUB_WORKFLOW: process.env.GITHUB_WORKFLOW,
+    GITHUB_ACTOR: process.env.GITHUB_ACTOR,
+  };
+  process.env.GITHUB_SERVER_URL = 'https://github.com';
+  process.env.GITHUB_REPOSITORY = 'fol2/ks2-mastery';
+  process.env.GITHUB_RUN_ID = '12345';
+  process.env.GITHUB_WORKFLOW = 'Capacity CI';
+  process.env.GITHUB_ACTOR = 'test-bot';
+  try {
+    const prov = buildProvenance({});
+    assert.equal(prov.workflowRunUrl, 'https://github.com/fol2/ks2-mastery/actions/runs/12345');
+    assert.equal(prov.workflowName, 'Capacity CI');
+    assert.equal(prov.operator, 'test-bot');
+  } finally {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+});
+
+test('buildProvenance thresholdConfigHash is "none" without configPath (P4-U8)', () => {
+  const prov = buildProvenance({});
+  assert.equal(prov.thresholdConfigHash, 'none');
+});
+
+test('buildProvenance thresholdConfigHash is sha256 of config file content (P4-U8)', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'ks2-prov-'));
+  const configPath = join(tempDir, 'test-config.json');
+  const content = JSON.stringify({ tier: 'test', thresholds: { max5xx: 0 } });
+  writeFileSync(configPath, content);
+  try {
+    const prov = buildProvenance({ configPath });
+    const expectedHash = createHash('sha256').update(content).digest('hex');
+    assert.equal(prov.thresholdConfigHash, expectedHash);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('buildProvenance rawLogArtifactPath defaults to "none" (P4-U8)', () => {
+  const prov = buildProvenance({});
+  assert.equal(prov.rawLogArtifactPath, 'none');
+});
+
+test('buildProvenance rawLogArtifactPath reads from options (P4-U8)', () => {
+  const prov = buildProvenance({ rawLogArtifactPath: 'logs/run-12345.log' });
+  assert.equal(prov.rawLogArtifactPath, 'logs/run-12345.log');
+});
+
+test('buildProvenance loadDriverVersion reads from package.json (P4-U8)', () => {
+  const prov = buildProvenance({});
+  // Should read 0.1.0 from the package.json in the repo.
+  assert.equal(prov.loadDriverVersion, '0.1.0');
+});
+
+test('buildEvidencePayload includes provenance in reportMeta (P4-U8)', () => {
+  const report = {
+    ok: true,
+    summary: makeSummary(),
+    plan: {},
+  };
+  const payload = buildEvidencePayload({
+    report,
+    thresholds: {},
+    options: { mode: 'dry-run' },
+    timings: {},
+  });
+  assert.ok(payload.reportMeta.provenance, 'provenance must be present in evidence payload');
+  assert.equal(typeof payload.reportMeta.provenance.gitSha, 'string');
+  assert.equal(typeof payload.reportMeta.provenance.dirtyTreeFlag, 'boolean');
 });

--- a/tests/verify-capacity-evidence.test.js
+++ b/tests/verify-capacity-evidence.test.js
@@ -2380,6 +2380,66 @@ test('matching thresholdConfigHash passes provenance hash check (P4-U8)', () => 
   }
 });
 
+test('certifiable tier with thresholdConfigHash=unknown and configPath present fails (ADV-002)', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'ks2-verify-adv002-'));
+  const docPath = join(tempDir, 'capacity.md');
+  const evidenceDir = join(tempDir, 'reports', 'capacity');
+  const configsDir = join(evidenceDir, 'configs');
+  mkdirSync(evidenceDir, { recursive: true });
+  mkdirSync(configsDir, { recursive: true });
+  const evidencePath = join(evidenceDir, 'latest-production.json');
+  const configPath = join(configsDir, '30-learner-beta.json');
+  writeFileSync(configPath, JSON.stringify({
+    tier: '30-learner-beta-certified',
+    thresholds: { max5xx: 0, maxBootstrapP95Ms: 1000, maxCommandP95Ms: 750, maxResponseBytes: 600000 },
+  }));
+  // Evidence with provenance that has thresholdConfigHash='unknown' — simulates
+  // an attacker hand-editing the hash to bypass tamper detection.
+  writeFileSync(evidencePath, JSON.stringify(evidenceWithProvenance(
+    { thresholdConfigHash: 'unknown' },
+    {
+      summary: {
+        ok: true,
+        totalRequests: 20,
+        startedAt: '2026-04-27T00:00:00Z',
+        finishedAt: '2026-04-27T00:00:30Z',
+        endpoints: {
+          'GET /api/bootstrap': { count: 10, p50WallMs: 100, p95WallMs: 320, maxResponseBytes: 81000, queryCount: 5, d1RowsRead: 42 },
+          'POST /api/subjects/grammar/command': { count: 10, p50WallMs: 90, p95WallMs: 180, maxResponseBytes: 5000 },
+        },
+        signals: {},
+        failures: [],
+      },
+      tier: {
+        tier: '30-learner-beta-certified',
+        configPath: 'reports/capacity/configs/30-learner-beta.json',
+      },
+      thresholds: {
+        max5xx: { configured: 0, observed: 0, passed: true },
+        maxBootstrapP95Ms: { configured: 1000, observed: 320, passed: true },
+        maxCommandP95Ms: { configured: 750, observed: 180, passed: true },
+        maxResponseBytes: { configured: 600000, observed: 81000, passed: true },
+      },
+    },
+  )));
+  writeFileSync(docPath, makeDoc([
+    ['2026-04-27', 'abc1234', 'prod', 'Free', '30', '30', '3', '320', '180', '81000', '0', 'none', '30-learner-beta-certified', 'reports/capacity/latest-production.json'],
+  ]));
+  const cwd = process.cwd();
+  try {
+    process.chdir(tempDir);
+    const result = verifyCapacityDoc(docPath);
+    assert.equal(result.ok, false);
+    assert.ok(
+      result.report.some((line) => line.includes('thresholdConfigHash is unknown')),
+      `expected thresholdConfigHash unknown rejection; got:\n${result.report.join('\n')}`,
+    );
+  } finally {
+    process.chdir(cwd);
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
 test('100-plus-certified without provenance fails (P4-U8 — all certifiable tiers)', () => {
   const tempDir = mkdtempSync(join(tmpdir(), 'ks2-verify-u8-100-'));
   const docPath = join(tempDir, 'capacity.md');

--- a/tests/verify-capacity-evidence.test.js
+++ b/tests/verify-capacity-evidence.test.js
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
@@ -1974,6 +1975,470 @@ test('small-pilot + forged SHA + SKIP_ANCESTRY=1 + full clone fails closed (r8-0
     process.chdir(cwd);
     if (previousSkip === undefined) delete process.env.CAPACITY_VERIFY_SKIP_ANCESTRY;
     else process.env.CAPACITY_VERIFY_SKIP_ANCESTRY = previousSkip;
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+// ===========================================================================
+// P4 U8: Evidence provenance and anti-fabrication guard
+// ---------------------------------------------------------------------------
+// Certifiable tiers (30-learner-beta-certified, 60-learner-stretch-certified,
+// 100-plus-certified) MUST carry a provenance block. Lower tiers (smoke-pass,
+// small-pilot-provisional) tolerate missing provenance.
+// ===========================================================================
+
+// Helper: build evidence with provenance.
+function evidenceWithProvenance(provenanceOverrides = {}, envelopeOverrides = {}) {
+  const { reportMeta: rmOverride, ...rest } = envelopeOverrides;
+  return evidenceEnvelope({
+    reportMeta: {
+      commit: 'abc1234567890abcdef1234567890abcdef12345',
+      evidenceSchemaVersion: 2,
+      learners: 30,
+      bootstrapBurst: 30,
+      rounds: 3,
+      provenance: {
+        workflowRunUrl: 'https://github.com/fol2/ks2-mastery/actions/runs/12345',
+        workflowName: 'Capacity CI',
+        gitSha: 'abc1234567890abcdef1234567890abcdef12345',
+        dirtyTreeFlag: false,
+        thresholdConfigHash: 'none',
+        loadDriverVersion: '0.1.0',
+        operator: 'ci-bot',
+        rawLogArtifactPath: 'none',
+        ...provenanceOverrides,
+      },
+      ...(rmOverride || {}),
+    },
+    ...rest,
+  });
+}
+
+test('classroom tier without provenance fails verification (P4-U8)', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'ks2-verify-u8-'));
+  const docPath = join(tempDir, 'capacity.md');
+  const evidenceDir = join(tempDir, 'reports', 'capacity');
+  const configsDir = join(evidenceDir, 'configs');
+  mkdirSync(evidenceDir, { recursive: true });
+  mkdirSync(configsDir, { recursive: true });
+  const evidencePath = join(evidenceDir, 'latest-production.json');
+  const configPath = join(configsDir, '30-learner-beta.json');
+  writeFileSync(configPath, JSON.stringify({
+    tier: '30-learner-beta-certified',
+    thresholds: { max5xx: 0, maxBootstrapP95Ms: 1000, maxCommandP95Ms: 750, maxResponseBytes: 600000 },
+  }));
+  // Evidence WITHOUT provenance block.
+  writeFileSync(evidencePath, JSON.stringify(evidenceEnvelope({
+    reportMeta: {
+      commit: 'abc1234567890abcdef1234567890abcdef12345',
+      evidenceSchemaVersion: 2,
+      learners: 30,
+      bootstrapBurst: 30,
+      rounds: 3,
+      // provenance intentionally absent
+    },
+    summary: {
+      ok: true,
+      totalRequests: 20,
+      startedAt: '2026-04-27T00:00:00Z',
+      finishedAt: '2026-04-27T00:00:30Z',
+      endpoints: {
+        'GET /api/bootstrap': { count: 10, p50WallMs: 100, p95WallMs: 320, maxResponseBytes: 81000, queryCount: 5, d1RowsRead: 42 },
+        'POST /api/subjects/grammar/command': { count: 10, p50WallMs: 90, p95WallMs: 180, maxResponseBytes: 5000 },
+      },
+      signals: {},
+      failures: [],
+    },
+    tier: {
+      tier: '30-learner-beta-certified',
+      configPath: 'reports/capacity/configs/30-learner-beta.json',
+    },
+    thresholds: {
+      max5xx: { configured: 0, observed: 0, passed: true },
+      maxBootstrapP95Ms: { configured: 1000, observed: 320, passed: true },
+      maxCommandP95Ms: { configured: 750, observed: 180, passed: true },
+      maxResponseBytes: { configured: 600000, observed: 81000, passed: true },
+    },
+  })));
+  writeFileSync(docPath, makeDoc([
+    ['2026-04-27', 'abc1234', 'prod', 'Free', '30', '30', '3', '320', '180', '81000', '0', 'none', '30-learner-beta-certified', 'reports/capacity/latest-production.json'],
+  ]));
+  const cwd = process.cwd();
+  try {
+    process.chdir(tempDir);
+    const result = verifyCapacityDoc(docPath);
+    assert.equal(result.ok, false);
+    assert.ok(
+      result.report.some((line) => line.includes('provenance') && line.includes('certification')),
+      `expected provenance requirement message; got:\n${result.report.join('\n')}`,
+    );
+  } finally {
+    process.chdir(cwd);
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('smoke-pass without provenance still passes (P4-U8)', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'ks2-verify-u8-smoke-'));
+  const docPath = join(tempDir, 'capacity.md');
+  const evidenceDir = join(tempDir, 'reports', 'capacity');
+  mkdirSync(evidenceDir, { recursive: true });
+  const evidencePath = join(evidenceDir, 'latest-preview.json');
+  // Evidence WITHOUT provenance — smoke-pass must still pass.
+  writeFileSync(evidencePath, JSON.stringify(evidenceEnvelope()));
+  writeFileSync(docPath, makeDoc([
+    ['2026-04-25', 'abc1234', 'preview', 'Free', '10', '10', '1', '320', '180', '81000', '0', 'none', 'smoke-pass', 'reports/capacity/latest-preview.json'],
+  ]));
+  const cwd = process.cwd();
+  try {
+    process.chdir(tempDir);
+    const result = verifyCapacityDoc(docPath);
+    assert.equal(result.ok, true, `smoke-pass without provenance should pass; got: ${JSON.stringify(result.report)}`);
+  } finally {
+    process.chdir(cwd);
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('small-pilot-provisional without provenance still passes (P4-U8)', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'ks2-verify-u8-pilot-'));
+  const docPath = join(tempDir, 'capacity.md');
+  const evidenceDir = join(tempDir, 'reports', 'capacity');
+  const configsDir = join(evidenceDir, 'configs');
+  mkdirSync(evidenceDir, { recursive: true });
+  mkdirSync(configsDir, { recursive: true });
+  const evidencePath = join(evidenceDir, 'latest-preview.json');
+  const configPath = join(configsDir, 'small-pilot.json');
+  writeFileSync(configPath, JSON.stringify({
+    tier: 'small-pilot-provisional',
+    thresholds: { max5xx: 0, maxBootstrapP95Ms: 1000, maxCommandP95Ms: 750 },
+  }));
+  writeFileSync(evidencePath, JSON.stringify(evidenceEnvelope({
+    reportMeta: { commit: 'abc1234567890abcdef1234567890abcdef12345', evidenceSchemaVersion: 1, learners: 10, bootstrapBurst: 10, rounds: 1 },
+    tier: {
+      tier: 'small-pilot-provisional',
+      configPath: 'reports/capacity/configs/small-pilot.json',
+    },
+    thresholds: {
+      max5xx: { configured: 0, observed: 0, passed: true },
+      maxBootstrapP95Ms: { configured: 1000, observed: 320, passed: true },
+      maxCommandP95Ms: { configured: 750, observed: 180, passed: true },
+    },
+  })));
+  writeFileSync(docPath, makeDoc([
+    ['2026-04-25', 'abc1234', 'preview', 'Free', '10', '10', '1', '320', '180', '81000', '0', 'none', 'small-pilot-provisional', 'reports/capacity/latest-preview.json'],
+  ]));
+  const cwd = process.cwd();
+  try {
+    process.chdir(tempDir);
+    const result = verifyCapacityDoc(docPath);
+    assert.equal(result.ok, true, `small-pilot without provenance should pass; got: ${JSON.stringify(result.report)}`);
+  } finally {
+    process.chdir(cwd);
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('classroom tier with provenance.gitSha=unknown fails (P4-U8)', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'ks2-verify-u8-sha-'));
+  const docPath = join(tempDir, 'capacity.md');
+  const evidenceDir = join(tempDir, 'reports', 'capacity');
+  const configsDir = join(evidenceDir, 'configs');
+  mkdirSync(evidenceDir, { recursive: true });
+  mkdirSync(configsDir, { recursive: true });
+  const evidencePath = join(evidenceDir, 'latest-production.json');
+  const configPath = join(configsDir, '30-learner-beta.json');
+  writeFileSync(configPath, JSON.stringify({
+    tier: '30-learner-beta-certified',
+    thresholds: { max5xx: 0, maxBootstrapP95Ms: 1000, maxCommandP95Ms: 750, maxResponseBytes: 600000 },
+  }));
+  writeFileSync(evidencePath, JSON.stringify(evidenceWithProvenance(
+    { gitSha: 'unknown' },
+    {
+      summary: {
+        ok: true,
+        totalRequests: 20,
+        startedAt: '2026-04-27T00:00:00Z',
+        finishedAt: '2026-04-27T00:00:30Z',
+        endpoints: {
+          'GET /api/bootstrap': { count: 10, p50WallMs: 100, p95WallMs: 320, maxResponseBytes: 81000, queryCount: 5, d1RowsRead: 42 },
+          'POST /api/subjects/grammar/command': { count: 10, p50WallMs: 90, p95WallMs: 180, maxResponseBytes: 5000 },
+        },
+        signals: {},
+        failures: [],
+      },
+      tier: {
+        tier: '30-learner-beta-certified',
+        configPath: 'reports/capacity/configs/30-learner-beta.json',
+      },
+      thresholds: {
+        max5xx: { configured: 0, observed: 0, passed: true },
+        maxBootstrapP95Ms: { configured: 1000, observed: 320, passed: true },
+        maxCommandP95Ms: { configured: 750, observed: 180, passed: true },
+        maxResponseBytes: { configured: 600000, observed: 81000, passed: true },
+      },
+    },
+  )));
+  writeFileSync(docPath, makeDoc([
+    ['2026-04-27', 'abc1234', 'prod', 'Free', '30', '30', '3', '320', '180', '81000', '0', 'none', '30-learner-beta-certified', 'reports/capacity/latest-production.json'],
+  ]));
+  const cwd = process.cwd();
+  try {
+    process.chdir(tempDir);
+    const result = verifyCapacityDoc(docPath);
+    assert.equal(result.ok, false);
+    assert.ok(
+      result.report.some((line) => line.includes('provenance.gitSha')),
+      `expected provenance.gitSha failure; got:\n${result.report.join('\n')}`,
+    );
+  } finally {
+    process.chdir(cwd);
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('classroom tier with provenance.dirtyTreeFlag=true fails (P4-U8)', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'ks2-verify-u8-dirty-'));
+  const docPath = join(tempDir, 'capacity.md');
+  const evidenceDir = join(tempDir, 'reports', 'capacity');
+  const configsDir = join(evidenceDir, 'configs');
+  mkdirSync(evidenceDir, { recursive: true });
+  mkdirSync(configsDir, { recursive: true });
+  const evidencePath = join(evidenceDir, 'latest-production.json');
+  const configPath = join(configsDir, '30-learner-beta.json');
+  writeFileSync(configPath, JSON.stringify({
+    tier: '30-learner-beta-certified',
+    thresholds: { max5xx: 0, maxBootstrapP95Ms: 1000, maxCommandP95Ms: 750, maxResponseBytes: 600000 },
+  }));
+  writeFileSync(evidencePath, JSON.stringify(evidenceWithProvenance(
+    { dirtyTreeFlag: true },
+    {
+      summary: {
+        ok: true,
+        totalRequests: 20,
+        startedAt: '2026-04-27T00:00:00Z',
+        finishedAt: '2026-04-27T00:00:30Z',
+        endpoints: {
+          'GET /api/bootstrap': { count: 10, p50WallMs: 100, p95WallMs: 320, maxResponseBytes: 81000, queryCount: 5, d1RowsRead: 42 },
+          'POST /api/subjects/grammar/command': { count: 10, p50WallMs: 90, p95WallMs: 180, maxResponseBytes: 5000 },
+        },
+        signals: {},
+        failures: [],
+      },
+      tier: {
+        tier: '30-learner-beta-certified',
+        configPath: 'reports/capacity/configs/30-learner-beta.json',
+      },
+      thresholds: {
+        max5xx: { configured: 0, observed: 0, passed: true },
+        maxBootstrapP95Ms: { configured: 1000, observed: 320, passed: true },
+        maxCommandP95Ms: { configured: 750, observed: 180, passed: true },
+        maxResponseBytes: { configured: 600000, observed: 81000, passed: true },
+      },
+    },
+  )));
+  writeFileSync(docPath, makeDoc([
+    ['2026-04-27', 'abc1234', 'prod', 'Free', '30', '30', '3', '320', '180', '81000', '0', 'none', '30-learner-beta-certified', 'reports/capacity/latest-production.json'],
+  ]));
+  const cwd = process.cwd();
+  try {
+    process.chdir(tempDir);
+    const result = verifyCapacityDoc(docPath);
+    assert.equal(result.ok, false);
+    assert.ok(
+      result.report.some((line) => line.includes('dirtyTreeFlag')),
+      `expected dirtyTreeFlag failure; got:\n${result.report.join('\n')}`,
+    );
+  } finally {
+    process.chdir(cwd);
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('thresholdConfigHash mismatch between provenance and committed config fails (P4-U8)', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'ks2-verify-u8-hash-'));
+  const docPath = join(tempDir, 'capacity.md');
+  const evidenceDir = join(tempDir, 'reports', 'capacity');
+  const configsDir = join(evidenceDir, 'configs');
+  mkdirSync(evidenceDir, { recursive: true });
+  mkdirSync(configsDir, { recursive: true });
+  const evidencePath = join(evidenceDir, 'latest-preview.json');
+  const configPath = join(configsDir, 'small-pilot.json');
+
+  // Write config with specific content.
+  const configContent = JSON.stringify({
+    tier: 'small-pilot-provisional',
+    thresholds: { max5xx: 0, maxBootstrapP95Ms: 1000, maxCommandP95Ms: 750 },
+  });
+  writeFileSync(configPath, configContent);
+  const configHash = createHash('sha256').update(configContent).digest('hex');
+
+  // Evidence claims a DIFFERENT hash (simulates config tampered after run).
+  const fakeHash = createHash('sha256').update('something else entirely').digest('hex');
+  writeFileSync(evidencePath, JSON.stringify(evidenceEnvelope({
+    reportMeta: {
+      commit: 'abc1234567890abcdef1234567890abcdef12345',
+      evidenceSchemaVersion: 1,
+      learners: 10,
+      bootstrapBurst: 10,
+      rounds: 1,
+      provenance: {
+        workflowRunUrl: 'unknown',
+        workflowName: 'unknown',
+        gitSha: 'abc1234567890abcdef1234567890abcdef12345',
+        dirtyTreeFlag: false,
+        thresholdConfigHash: fakeHash,
+        loadDriverVersion: '0.1.0',
+        operator: 'test',
+        rawLogArtifactPath: 'none',
+      },
+    },
+    tier: {
+      tier: 'small-pilot-provisional',
+      configPath: 'reports/capacity/configs/small-pilot.json',
+    },
+    thresholds: {
+      max5xx: { configured: 0, observed: 0, passed: true },
+      maxBootstrapP95Ms: { configured: 1000, observed: 320, passed: true },
+      maxCommandP95Ms: { configured: 750, observed: 180, passed: true },
+    },
+  })));
+  writeFileSync(docPath, makeDoc([
+    ['2026-04-25', 'abc1234', 'preview', 'Free', '10', '10', '1', '320', '180', '81000', '0', 'none', 'small-pilot-provisional', 'reports/capacity/latest-preview.json'],
+  ]));
+  const cwd = process.cwd();
+  try {
+    process.chdir(tempDir);
+    const result = verifyCapacityDoc(docPath);
+    assert.equal(result.ok, false);
+    assert.ok(
+      result.report.some((line) => line.includes('thresholdConfigHash mismatch')),
+      `expected thresholdConfigHash mismatch failure; got:\n${result.report.join('\n')}`,
+    );
+  } finally {
+    process.chdir(cwd);
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('matching thresholdConfigHash passes provenance hash check (P4-U8)', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'ks2-verify-u8-hashok-'));
+  const docPath = join(tempDir, 'capacity.md');
+  const evidenceDir = join(tempDir, 'reports', 'capacity');
+  const configsDir = join(evidenceDir, 'configs');
+  mkdirSync(evidenceDir, { recursive: true });
+  mkdirSync(configsDir, { recursive: true });
+  const evidencePath = join(evidenceDir, 'latest-preview.json');
+  const configPath = join(configsDir, 'small-pilot.json');
+
+  const configContent = JSON.stringify({
+    tier: 'small-pilot-provisional',
+    thresholds: { max5xx: 0, maxBootstrapP95Ms: 1000, maxCommandP95Ms: 750 },
+  });
+  writeFileSync(configPath, configContent);
+  const configHash = createHash('sha256').update(configContent).digest('hex');
+
+  writeFileSync(evidencePath, JSON.stringify(evidenceEnvelope({
+    reportMeta: {
+      commit: 'abc1234567890abcdef1234567890abcdef12345',
+      evidenceSchemaVersion: 1,
+      learners: 10,
+      bootstrapBurst: 10,
+      rounds: 1,
+      provenance: {
+        workflowRunUrl: 'unknown',
+        workflowName: 'unknown',
+        gitSha: 'abc1234567890abcdef1234567890abcdef12345',
+        dirtyTreeFlag: false,
+        thresholdConfigHash: configHash,
+        loadDriverVersion: '0.1.0',
+        operator: 'test',
+        rawLogArtifactPath: 'none',
+      },
+    },
+    tier: {
+      tier: 'small-pilot-provisional',
+      configPath: 'reports/capacity/configs/small-pilot.json',
+    },
+    thresholds: {
+      max5xx: { configured: 0, observed: 0, passed: true },
+      maxBootstrapP95Ms: { configured: 1000, observed: 320, passed: true },
+      maxCommandP95Ms: { configured: 750, observed: 180, passed: true },
+    },
+  })));
+  writeFileSync(docPath, makeDoc([
+    ['2026-04-25', 'abc1234', 'preview', 'Free', '10', '10', '1', '320', '180', '81000', '0', 'none', 'small-pilot-provisional', 'reports/capacity/latest-preview.json'],
+  ]));
+  const cwd = process.cwd();
+  try {
+    process.chdir(tempDir);
+    const result = verifyCapacityDoc(docPath);
+    assert.equal(result.ok, true, `matching hash should pass; got: ${JSON.stringify(result.report)}`);
+  } finally {
+    process.chdir(cwd);
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('100-plus-certified without provenance fails (P4-U8 — all certifiable tiers)', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'ks2-verify-u8-100-'));
+  const docPath = join(tempDir, 'capacity.md');
+  const evidenceDir = join(tempDir, 'reports', 'capacity');
+  const configsDir = join(evidenceDir, 'configs');
+  mkdirSync(evidenceDir, { recursive: true });
+  mkdirSync(configsDir, { recursive: true });
+  const evidencePath = join(evidenceDir, 'latest-production.json');
+  const configPath = join(configsDir, '100-plus.json');
+  writeFileSync(configPath, JSON.stringify({
+    tier: '100-plus-certified',
+    thresholds: { max5xx: 0, maxBootstrapP95Ms: 1000, maxCommandP95Ms: 750, maxResponseBytes: 600000 },
+  }));
+  writeFileSync(evidencePath, JSON.stringify(evidenceEnvelope({
+    reportMeta: {
+      commit: 'abc1234567890abcdef1234567890abcdef12345',
+      evidenceSchemaVersion: 2,
+      learners: 100,
+      bootstrapBurst: 100,
+      rounds: 3,
+      // provenance intentionally absent
+    },
+    summary: {
+      ok: true,
+      totalRequests: 20,
+      startedAt: '2026-04-27T00:00:00Z',
+      finishedAt: '2026-04-27T00:00:30Z',
+      endpoints: {
+        'GET /api/bootstrap': { count: 10, p50WallMs: 100, p95WallMs: 320, maxResponseBytes: 81000, queryCount: 5, d1RowsRead: 42 },
+        'POST /api/subjects/grammar/command': { count: 10, p50WallMs: 90, p95WallMs: 180, maxResponseBytes: 5000 },
+      },
+      signals: {},
+      failures: [],
+    },
+    tier: {
+      tier: '100-plus-certified',
+      configPath: 'reports/capacity/configs/100-plus.json',
+    },
+    thresholds: {
+      max5xx: { configured: 0, observed: 0, passed: true },
+      maxBootstrapP95Ms: { configured: 1000, observed: 320, passed: true },
+      maxCommandP95Ms: { configured: 750, observed: 180, passed: true },
+      maxResponseBytes: { configured: 600000, observed: 81000, passed: true },
+    },
+  })));
+  writeFileSync(docPath, makeDoc([
+    ['2026-04-27', 'abc1234', 'prod', 'Free', '100', '100', '3', '320', '180', '81000', '0', 'none', '100-plus-certified', 'reports/capacity/latest-production.json'],
+  ]));
+  const cwd = process.cwd();
+  try {
+    process.chdir(tempDir);
+    const result = verifyCapacityDoc(docPath);
+    assert.equal(result.ok, false);
+    assert.ok(
+      result.report.some((line) => line.includes('provenance')),
+      `expected provenance failure for 100-plus-certified; got:\n${result.report.join('\n')}`,
+    );
+  } finally {
+    process.chdir(cwd);
     rmSync(tempDir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary
- Extends `buildReportMeta` in `capacity-evidence.mjs` with a `provenance` sub-block containing 8 fields: `workflowRunUrl`, `workflowName`, `gitSha`, `dirtyTreeFlag`, `thresholdConfigHash`, `loadDriverVersion`, `operator`, `rawLogArtifactPath`
- All provenance fields degrade gracefully (`'unknown'`/`'none'`) when GitHub Actions env vars or git are unavailable
- `verify-capacity-evidence.mjs` now enforces provenance for certifiable tiers (30-learner-beta, 60-learner-stretch, 100-plus): missing provenance, `gitSha:'unknown'`, `dirtyTreeFlag:true` all reject certification; `thresholdConfigHash` mismatch detects post-run config tampering
- Lower tiers (smoke-pass, small-pilot-provisional) tolerate absent provenance for manual/local runs — existing v1 evidence remains valid

## Test plan
- [x] 9 new tests in `capacity-evidence.test.js` covering provenance builder, GH env var construction, hash computation, and evidence payload inclusion
- [x] 8 new tests in `verify-capacity-evidence.test.js` covering: classroom tier without provenance fails, smoke-pass/small-pilot without provenance passes, gitSha=unknown fails, dirtyTreeFlag=true fails, thresholdConfigHash mismatch fails, matching hash passes, 100-plus-certified without provenance fails
- [x] All 226 capacity-related tests pass (zero regression)
- [x] All 327 tests in the repository pass