### PR TITLE
fix(admin): U2 — denial reason filter mismatch

### DIFF
--- a/src/surfaces/hubs/AdminDebuggingSection.jsx
+++ b/src/surfaces/hubs/AdminDebuggingSection.jsx
@@ -501,6 +501,11 @@ const DENIAL_REASON_OPTIONS = [
   { value: 'rate_limit_exceeded', label: 'Rate Limited' },
 ];
 
+/** Reverse-lookup: code → friendly label for denial row rendering. */
+const DENIAL_REASON_LABEL_MAP = Object.fromEntries(
+  DENIAL_REASON_OPTIONS.map(({ value, label }) => [value, label]),
+);
+
 function DenialLogPanel({ model, actions }) {
   const denialLog = model?.denialLog || {};
   const rawEntries = Array.isArray(denialLog.entries) ? denialLog.entries : [];
@@ -633,7 +638,7 @@ function DenialLogPanel({ model, actions }) {
       {entries.length ? entries.map((entry) => (
         <div className="skill-row" key={entry.id} data-testid={`denial-row-${entry.id}`}>
           <div>
-            <strong>{entry.denialReason || 'unknown'}</strong>
+            <strong>{DENIAL_REASON_LABEL_MAP[entry.denialReason] || entry.denialReason || 'unknown'}</strong>
           </div>
           <div className="small muted">{entry.routeName || '—'}</div>
           <div className="small muted">{formatTimestamp(entry.deniedAt)}</div>

--- a/src/surfaces/hubs/AdminDebuggingSection.jsx
+++ b/src/surfaces/hubs/AdminDebuggingSection.jsx
@@ -492,12 +492,13 @@ function LearnerSupportPanel({ model, appState, accessContext, actions }) {
 // disclosure).
 // ---------------------------------------------------------------------------
 
+// Values must match DENIAL_* constants in worker/src/error-codes.js (lines 20-24).
 const DENIAL_REASON_OPTIONS = [
-  'suspended_account',
-  'rate_limited',
-  'forbidden',
-  'invalid_session',
-  'demo_expired',
+  { value: 'account_suspended',   label: 'Account Suspended' },
+  { value: 'payment_hold',        label: 'Payment Hold' },
+  { value: 'session_invalidated', label: 'Session Invalidated' },
+  { value: 'csrf_rejection',      label: 'CSRF / Same-Origin' },
+  { value: 'rate_limit_exceeded', label: 'Rate Limited' },
 ];
 
 function DenialLogPanel({ model, actions }) {
@@ -549,8 +550,8 @@ function DenialLogPanel({ model, actions }) {
             data-testid="denial-filter-reason"
           >
             <option value="">All reasons</option>
-            {DENIAL_REASON_OPTIONS.map((reason) => (
-              <option value={reason} key={reason}>{reason}</option>
+            {DENIAL_REASON_OPTIONS.map(({ value, label }) => (
+              <option value={value} key={value}>{label}</option>
             ))}
           </select>
         </label>

--- a/tests/admin-debugging-section-characterisation.test.js
+++ b/tests/admin-debugging-section-characterisation.test.js
@@ -176,7 +176,7 @@ function fullModel(overrides = {}) {
         {
           id: 'deny-char-001',
           deniedAt: Date.UTC(2026, 3, 26, 10, 30),
-          denialReason: 'suspended_account',
+          denialReason: 'account_suspended',
           routeName: '/api/bootstrap',
           accountIdMasked: 'abcd1234',
           isDemo: false,
@@ -185,7 +185,7 @@ function fullModel(overrides = {}) {
         {
           id: 'deny-char-002',
           deniedAt: Date.UTC(2026, 3, 26, 11, 0),
-          denialReason: 'rate_limited',
+          denialReason: 'rate_limit_exceeded',
           routeName: '/api/subject/command',
           accountIdMasked: 'efgh5678',
           isDemo: true,
@@ -194,7 +194,7 @@ function fullModel(overrides = {}) {
         {
           id: 'deny-char-003',
           deniedAt: Date.UTC(2026, 3, 26, 12, 0),
-          denialReason: 'forbidden',
+          denialReason: 'csrf_rejection',
           routeName: '/api/admin/hub',
           accountIdMasked: null,
           isDemo: false,
@@ -371,10 +371,10 @@ test('denial log panel renders entries with reason, route, and timestamp', async
   assert.match(html, /data-testid="denial-row-deny-char-002"/, 'Second denial row renders');
   assert.match(html, /data-testid="denial-row-deny-char-003"/, 'Third denial row renders');
 
-  // Denial reasons
-  assert.match(html, /suspended_account/, 'First denial reason renders');
-  assert.match(html, /rate_limited/, 'Second denial reason renders');
-  assert.match(html, /forbidden/, 'Third denial reason renders');
+  // Denial reasons (canonical DENIAL_* codes)
+  assert.match(html, /account_suspended/, 'First denial reason renders');
+  assert.match(html, /rate_limit_exceeded/, 'Second denial reason renders');
+  assert.match(html, /csrf_rejection/, 'Third denial reason renders');
 
   // Routes
   assert.match(html, /\/api\/bootstrap/, 'Route renders for first denial');
@@ -585,12 +585,19 @@ test('denial filter reason dropdown has exactly 5 entries matching current value
   // "All reasons" default option (React SSR may add selected="" attribute)
   assert.match(html, /<option value=""[^>]*>All reasons<\/option>/, 'Default "All reasons" option renders');
 
-  // The 5 denial reason values (pinning current codebase values)
-  assert.match(html, /<option value="suspended_account"/, 'suspended_account option renders');
-  assert.match(html, /<option value="rate_limited"/, 'rate_limited option renders');
-  assert.match(html, /<option value="forbidden"/, 'forbidden option renders');
-  assert.match(html, /<option value="invalid_session"/, 'invalid_session option renders');
-  assert.match(html, /<option value="demo_expired"/, 'demo_expired option renders');
+  // The 5 denial reason values — canonical DENIAL_* codes from worker/src/error-codes.js
+  assert.match(html, /<option value="account_suspended"/, 'account_suspended option renders');
+  assert.match(html, /<option value="payment_hold"/, 'payment_hold option renders');
+  assert.match(html, /<option value="session_invalidated"/, 'session_invalidated option renders');
+  assert.match(html, /<option value="csrf_rejection"/, 'csrf_rejection option renders');
+  assert.match(html, /<option value="rate_limit_exceeded"/, 'rate_limit_exceeded option renders');
+
+  // Operator-friendly display labels
+  assert.match(html, />Account Suspended<\/option>/, 'Account Suspended label renders');
+  assert.match(html, />Payment Hold<\/option>/, 'Payment Hold label renders');
+  assert.match(html, />Session Invalidated<\/option>/, 'Session Invalidated label renders');
+  assert.match(html, />CSRF \/ Same-Origin<\/option>/, 'CSRF / Same-Origin label renders');
+  assert.match(html, />Rate Limited<\/option>/, 'Rate Limited label renders');
 
   // Count the option elements inside the denial reason select to confirm
   // exactly 6 total (1 default "All reasons" + 5 reason values). We extract
@@ -719,7 +726,7 @@ test('ops role does not see account linkage in error drawer or denial rows', asy
 
   // Denial rows render
   assert.match(html, /data-testid="denial-row-deny-char-001"/, 'Denial row renders for ops');
-  assert.match(html, /suspended_account/, 'Denial reason renders for ops');
+  assert.match(html, /account_suspended/, 'Denial reason renders for ops');
 
   // Ops does NOT see account linkage in denial rows
   assert.ok(

--- a/tests/react-admin-denial-panel.test.js
+++ b/tests/react-admin-denial-panel.test.js
@@ -107,7 +107,7 @@ test('denial panel renders entries with expected fields', async () => {
       {
         id: 'deny-1',
         deniedAt: 1700000000000,
-        denialReason: 'suspended_account',
+        denialReason: 'account_suspended',
         routeName: '/api/bootstrap',
         accountIdMasked: 'abcd1234',
         isDemo: false,
@@ -116,7 +116,7 @@ test('denial panel renders entries with expected fields', async () => {
       {
         id: 'deny-2',
         deniedAt: 1700000001000,
-        denialReason: 'rate_limited',
+        denialReason: 'rate_limit_exceeded',
         routeName: '/api/subject/command',
         accountIdMasked: 'efgh5678',
         isDemo: true,
@@ -129,8 +129,8 @@ test('denial panel renders entries with expected fields', async () => {
 
   assert.ok(html.includes('data-testid="denial-row-deny-1"'), 'first denial row missing');
   assert.ok(html.includes('data-testid="denial-row-deny-2"'), 'second denial row missing');
-  assert.ok(html.includes('suspended_account'), 'denial reason missing');
-  assert.ok(html.includes('rate_limited'), 'second denial reason missing');
+  assert.ok(html.includes('account_suspended'), 'denial reason missing');
+  assert.ok(html.includes('rate_limit_exceeded'), 'second denial reason missing');
   assert.ok(html.includes('/api/bootstrap'), 'route name missing');
   // Admin sees account id
   assert.ok(html.includes('data-testid="denial-account-deny-1"'), 'admin account id missing');
@@ -156,7 +156,7 @@ test('ops role does not see account linkage in denial panel', async () => {
       {
         id: 'deny-ops-1',
         deniedAt: 1700000000000,
-        denialReason: 'suspended_account',
+        denialReason: 'account_suspended',
         routeName: '/api/bootstrap',
         accountIdMasked: 'abcd1234',
         isDemo: false,
@@ -169,7 +169,7 @@ test('ops role does not see account linkage in denial panel', async () => {
 
   // Ops sees the denial row
   assert.ok(html.includes('data-testid="denial-row-deny-ops-1"'), 'denial row missing for ops');
-  assert.ok(html.includes('suspended_account'), 'reason missing for ops');
+  assert.ok(html.includes('account_suspended'), 'reason missing for ops');
   assert.ok(html.includes('/api/bootstrap'), 'route missing for ops');
   // Ops does NOT see account id column
   assert.ok(!html.includes('data-testid="denial-account-deny-ops-1"'), 'ops should not see account linkage');
@@ -189,7 +189,7 @@ test('normaliseDenialEntry handles missing/malformed entries', async () => {
     const validResult = normaliseDenialEntry({
       id: 'test-1',
       deniedAt: 1700000000000,
-      denialReason: 'forbidden',
+      denialReason: 'csrf_rejection',
       routeName: '/api/test',
       accountIdMasked: 'last8chr',
       isDemo: true,
@@ -218,7 +218,7 @@ test('normaliseDenialEntry handles missing/malformed entries', async () => {
   // Valid entry
   assert.equal(validResult.id, 'test-1');
   assert.equal(validResult.deniedAt, 1700000000000);
-  assert.equal(validResult.denialReason, 'forbidden');
+  assert.equal(validResult.denialReason, 'csrf_rejection');
   assert.equal(validResult.routeName, '/api/test');
   assert.equal(validResult.accountIdMasked, 'last8chr');
   assert.equal(validResult.isDemo, true);

--- a/tests/worker-admin-denial-filter.test.js
+++ b/tests/worker-admin-denial-filter.test.js
@@ -1,0 +1,182 @@
+// U2 (Admin Console P4): round-trip denial-filter test.
+//
+// Verifies the SQL WHERE clause correctly honours all 5 canonical
+// DENIAL_* reason codes from worker/src/error-codes.js (lines 20-24).
+//
+// Scenarios:
+//   1. Each canonical reason code filters to exact matches only
+//   2. "All" / no-filter returns every record
+//   3. Unknown reason code returns zero results
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createWorkerRepositoryServer } from './helpers/worker-server.js';
+
+// Canonical DENIAL_* reason codes (must match worker/src/error-codes.js).
+const CANONICAL_DENIAL_CODES = [
+  'account_suspended',
+  'payment_hold',
+  'session_invalidated',
+  'csrf_rejection',
+  'rate_limit_exceeded',
+];
+
+function seedAdultAccount(server, {
+  id,
+  email,
+  displayName,
+  platformRole = 'parent',
+  now = 1,
+  accountType = 'real',
+  demoExpiresAt = null,
+} = {}) {
+  server.DB.db.prepare(`
+    INSERT INTO adult_accounts (
+      id, email, display_name, platform_role, selected_learner_id,
+      created_at, updated_at, repo_revision, account_type, demo_expires_at
+    )
+    VALUES (?, ?, ?, ?, NULL, ?, ?, 0, ?, ?)
+  `).run(id, email, displayName, platformRole, now, now, accountType, demoExpiresAt);
+}
+
+function insertRequestDenial(server, {
+  id,
+  deniedAt,
+  denialReason,
+  routeName = null,
+  accountId = null,
+  learnerId = null,
+  sessionIdLast8 = null,
+  isDemo = 0,
+  release = null,
+  detailJson = null,
+}) {
+  server.DB.db.prepare(`
+    INSERT INTO admin_request_denials (
+      id, denied_at, denial_reason, route_name, account_id,
+      learner_id, session_id_last8, is_demo, release, detail_json
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    id,
+    deniedAt,
+    denialReason,
+    routeName,
+    accountId,
+    learnerId,
+    sessionIdLast8,
+    isDemo,
+    release,
+    detailJson,
+  );
+}
+
+function seedAdmin(server, now) {
+  seedAdultAccount(server, {
+    id: 'adult-admin',
+    email: 'admin@example.com',
+    displayName: 'Admin',
+    platformRole: 'admin',
+    now,
+  });
+}
+
+// Insert one denial record per canonical reason code.
+function seedAllCanonicalDenials(server, now) {
+  CANONICAL_DENIAL_CODES.forEach((code, i) => {
+    insertRequestDenial(server, {
+      id: `deny-${code}`,
+      deniedAt: now - (i + 1) * 1000,
+      denialReason: code,
+      routeName: `/api/route-for-${code}`,
+      accountId: `adult-account-${code}`,
+    });
+  });
+}
+
+// ---------------------------------------------------------------
+// 1. Each canonical reason code filters to exact matches
+// ---------------------------------------------------------------
+
+for (const expectedCode of CANONICAL_DENIAL_CODES) {
+  test(`filter by reason=${expectedCode} returns only that code`, async () => {
+    const server = createWorkerRepositoryServer();
+    try {
+      const now = Date.now();
+      seedAdmin(server, now);
+      seedAllCanonicalDenials(server, now);
+
+      const response = await server.fetchAs(
+        'adult-admin',
+        `https://repo.test/api/admin/ops/request-denials?reason=${expectedCode}`,
+        {},
+        { 'x-ks2-dev-platform-role': 'admin' },
+      );
+      const payload = await response.json();
+
+      assert.equal(response.status, 200, `HTTP 200 for reason=${expectedCode}`);
+      assert.equal(payload.entries.length, 1, `Exactly 1 result for reason=${expectedCode}`);
+      assert.equal(payload.entries[0].id, `deny-${expectedCode}`);
+      assert.equal(payload.entries[0].denialReason, expectedCode);
+    } finally {
+      server.close();
+    }
+  });
+}
+
+// ---------------------------------------------------------------
+// 2. No-filter returns all records
+// ---------------------------------------------------------------
+
+test('no reason filter returns all 5 canonical denial records', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    const now = Date.now();
+    seedAdmin(server, now);
+    seedAllCanonicalDenials(server, now);
+
+    const response = await server.fetchAs(
+      'adult-admin',
+      'https://repo.test/api/admin/ops/request-denials',
+      {},
+      { 'x-ks2-dev-platform-role': 'admin' },
+    );
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.entries.length, CANONICAL_DENIAL_CODES.length);
+
+    // Every canonical code is present in the results
+    const returnedCodes = payload.entries.map((e) => e.denialReason).sort();
+    assert.deepStrictEqual(returnedCodes, [...CANONICAL_DENIAL_CODES].sort());
+  } finally {
+    server.close();
+  }
+});
+
+// ---------------------------------------------------------------
+// 3. Unknown reason code returns zero results
+// ---------------------------------------------------------------
+
+test('unknown reason code returns empty entries', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    const now = Date.now();
+    seedAdmin(server, now);
+    seedAllCanonicalDenials(server, now);
+
+    const response = await server.fetchAs(
+      'adult-admin',
+      'https://repo.test/api/admin/ops/request-denials?reason=nonexistent_phantom',
+      {},
+      { 'x-ks2-dev-platform-role': 'admin' },
+    );
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.entries.length, 0);
+  } finally {
+    server.close();
+  }
+});

--- a/tests/worker-admin-request-denials-read.test.js
+++ b/tests/worker-admin-request-denials-read.test.js
@@ -96,21 +96,21 @@ test('GET /api/admin/ops/request-denials returns recent denials ordered by denie
     insertRequestDenial(server, {
       id: 'deny-1',
       deniedAt: now - 3000,
-      denialReason: 'suspended_account',
+      denialReason: 'account_suspended',
       routeName: '/api/bootstrap',
       accountId: 'adult-account-aaaa1111',
     });
     insertRequestDenial(server, {
       id: 'deny-2',
       deniedAt: now - 1000,
-      denialReason: 'rate_limited',
+      denialReason: 'rate_limit_exceeded',
       routeName: '/api/subject/command',
       accountId: 'adult-account-bbbb2222',
     });
     insertRequestDenial(server, {
       id: 'deny-3',
       deniedAt: now - 2000,
-      denialReason: 'forbidden',
+      denialReason: 'csrf_rejection',
       routeName: '/api/admin/accounts/role',
       accountId: 'adult-account-cccc3333',
     });
@@ -135,7 +135,7 @@ test('GET /api/admin/ops/request-denials returns recent denials ordered by denie
     assert.equal(payload.entries[2].id, 'deny-1');
 
     // Fields present
-    assert.equal(payload.entries[0].denialReason, 'rate_limited');
+    assert.equal(payload.entries[0].denialReason, 'rate_limit_exceeded');
     assert.equal(payload.entries[0].routeName, '/api/subject/command');
     assert.equal(typeof payload.entries[0].deniedAt, 'number');
   } finally {
@@ -152,19 +152,19 @@ test('GET /api/admin/ops/request-denials filter by reason returns only matching'
     insertRequestDenial(server, {
       id: 'deny-a',
       deniedAt: now - 2000,
-      denialReason: 'suspended_account',
+      denialReason: 'account_suspended',
       routeName: '/api/bootstrap',
     });
     insertRequestDenial(server, {
       id: 'deny-b',
       deniedAt: now - 1000,
-      denialReason: 'rate_limited',
+      denialReason: 'rate_limit_exceeded',
       routeName: '/api/subject/command',
     });
 
     const response = await server.fetchAs(
       'adult-admin',
-      'https://repo.test/api/admin/ops/request-denials?reason=suspended_account',
+      'https://repo.test/api/admin/ops/request-denials?reason=account_suspended',
       {},
       { 'x-ks2-dev-platform-role': 'admin' },
     );
@@ -173,7 +173,7 @@ test('GET /api/admin/ops/request-denials filter by reason returns only matching'
     assert.equal(response.status, 200);
     assert.equal(payload.entries.length, 1);
     assert.equal(payload.entries[0].id, 'deny-a');
-    assert.equal(payload.entries[0].denialReason, 'suspended_account');
+    assert.equal(payload.entries[0].denialReason, 'account_suspended');
   } finally {
     server.close();
   }
@@ -188,13 +188,13 @@ test('GET /api/admin/ops/request-denials filter by route returns only matching',
     insertRequestDenial(server, {
       id: 'deny-x',
       deniedAt: now - 2000,
-      denialReason: 'forbidden',
+      denialReason: 'csrf_rejection',
       routeName: '/api/admin/accounts/role',
     });
     insertRequestDenial(server, {
       id: 'deny-y',
       deniedAt: now - 1000,
-      denialReason: 'rate_limited',
+      denialReason: 'rate_limit_exceeded',
       routeName: '/api/subject/command',
     });
 
@@ -224,7 +224,7 @@ test('admin sees masked account ID (last 8); ops sees no account linkage', async
     insertRequestDenial(server, {
       id: 'deny-acl-1',
       deniedAt: now - 1000,
-      denialReason: 'suspended_account',
+      denialReason: 'account_suspended',
       routeName: '/api/bootstrap',
       accountId: 'adult-account-abcd1234',
     });
@@ -255,7 +255,7 @@ test('admin sees masked account ID (last 8); ops sees no account linkage', async
     assert.equal(opsPayload.entries.length, 1);
     assert.equal(opsPayload.entries[0].accountIdMasked, null);
     // Ops still sees reason + route
-    assert.equal(opsPayload.entries[0].denialReason, 'suspended_account');
+    assert.equal(opsPayload.entries[0].denialReason, 'account_suspended');
     assert.equal(opsPayload.entries[0].routeName, '/api/bootstrap');
   } finally {
     server.close();
@@ -272,7 +272,7 @@ test('no denials in range returns empty entries array', async () => {
     insertRequestDenial(server, {
       id: 'deny-old',
       deniedAt: now - 100_000,
-      denialReason: 'forbidden',
+      denialReason: 'csrf_rejection',
       routeName: '/api/admin/accounts',
     });
 


### PR DESCRIPTION
## Summary
- **Fixed 5 mismatched denial reason codes** in the `DENIAL_REASON_OPTIONS` dropdown (`AdminDebuggingSection.jsx` line 495-501) so the UI filter values match the canonical `DENIAL_*` constants from `worker/src/error-codes.js`
- **Added operator-friendly display labels** (e.g. "CSRF / Same-Origin" instead of raw `csrf_rejection`) while keeping the correct wire values
- **Updated characterisation tests** (`admin-debugging-section-characterisation.test.js`, `react-admin-denial-panel.test.js`) to pin the corrected codes and verify labels render
- **Created round-trip filter test** (`worker-admin-denial-filter.test.js`) — 7 tests confirming each canonical code filters to exact matches, no-filter returns all, and unknown codes return empty

## Mapping
| Old (wrong)         | New (canonical)          | Label              |
|---------------------|--------------------------|--------------------|
| `suspended_account` | `account_suspended`      | Account Suspended  |
| `rate_limited`      | `rate_limit_exceeded`    | Rate Limited       |
| `forbidden`         | `csrf_rejection`         | CSRF / Same-Origin |
| `invalid_session`   | `session_invalidated`    | Session Invalidated|
| `demo_expired`      | `payment_hold`           | Payment Hold       |

## Test plan
- [x] `node --test tests/admin-debugging-section-characterisation.test.js` — 13/13 pass
- [x] `node --test tests/react-admin-denial-panel.test.js` — 5/5 pass
- [x] `node --test tests/worker-admin-denial-filter.test.js` — 7/7 pass (new)