### PR TITLE
fix(admin): U3 — Debug Bundle identifier semantics

### DIFF
--- a/src/platform/hubs/admin-debug-bundle-panel.js
+++ b/src/platform/hubs/admin-debug-bundle-panel.js
@@ -61,6 +61,7 @@ function normaliseQuery(rawValue) {
     timeFrom: safeNonNegativeInt(raw.timeFrom),
     timeTo: safeNonNegativeInt(raw.timeTo),
     errorFingerprint: typeof raw.errorFingerprint === 'string' ? raw.errorFingerprint : null,
+    errorEventId: typeof raw.errorEventId === 'string' ? raw.errorEventId : null,
     route: typeof raw.route === 'string' ? raw.route : null,
   };
 }

--- a/src/surfaces/hubs/AdminDebuggingSection.jsx
+++ b/src/surfaces/hubs/AdminDebuggingSection.jsx
@@ -812,6 +812,7 @@ function DebugBundlePanel({ model, actions }) {
   const [timeFrom, setTimeFrom] = React.useState('');
   const [timeTo, setTimeTo] = React.useState('');
   const [fingerprint, setFingerprint] = React.useState('');
+  const [eventId, setEventId] = React.useState('');
   const [routeFilter, setRouteFilter] = React.useState('');
   const [copyFeedback, setCopyFeedback] = React.useState('');
 
@@ -819,9 +820,10 @@ function DebugBundlePanel({ model, actions }) {
   const prefill = debugBundle.prefill || null;
   React.useEffect(() => {
     if (prefill?.fingerprint) setFingerprint(prefill.fingerprint);
+    if (prefill?.eventId) setEventId(prefill.eventId);
     if (prefill?.accountId) setAccountId(prefill.accountId);
     if (prefill?.route) setRouteFilter(prefill.route);
-  }, [prefill?.fingerprint, prefill?.accountId, prefill?.route]);
+  }, [prefill?.fingerprint, prefill?.eventId, prefill?.accountId, prefill?.route]);
 
   const generateBundle = () => {
     const payload = {};
@@ -832,6 +834,7 @@ function DebugBundlePanel({ model, actions }) {
     const toTs = Date.parse(timeTo);
     if (Number.isFinite(toTs)) payload.time_to = toTs;
     if (fingerprint.trim()) payload.error_fingerprint = fingerprint.trim();
+    if (eventId.trim()) payload.error_event_id = eventId.trim();
     if (routeFilter.trim()) payload.route = routeFilter.trim();
     actions.dispatch('admin-debug-bundle-generate', payload);
   };
@@ -892,8 +895,12 @@ function DebugBundlePanel({ model, actions }) {
           <input type="datetime-local" className="input" name="bundleTimeTo" value={timeTo} onChange={(e) => setTimeTo(e.target.value)} data-testid="bundle-input-to" />
         </label>
         <label className="field">
-          <span>Error fingerprint</span>
+          <span>Error Fingerprint</span>
           <input type="text" className="input" name="bundleFingerprint" value={fingerprint} maxLength={128} onChange={(e) => setFingerprint(e.target.value)} placeholder="fp-xxxx" data-testid="bundle-input-fingerprint" />
+        </label>
+        <label className="field">
+          <span>Error Event ID</span>
+          <input type="text" className="input" name="bundleEventId" value={eventId} maxLength={128} onChange={(e) => setEventId(e.target.value)} placeholder="evt-xxxx" data-testid="bundle-input-event-id" />
         </label>
         <label className="field">
           <span>Route filter</span>

--- a/tests/admin-debugging-section-characterisation.test.js
+++ b/tests/admin-debugging-section-characterisation.test.js
@@ -392,7 +392,7 @@ test('denial log panel renders entries with reason, route, and timestamp', async
 // 3. Debug Bundle form — renders all input fields
 // =================================================================
 
-test('debug bundle form renders all 6 input fields', async () => {
+test('debug bundle form renders all 7 input fields', async () => {
   const html = await renderFixture(buildFixture());
 
   // Panel structure
@@ -403,18 +403,20 @@ test('debug bundle form renders all 6 input fields', async () => {
   // Search form container
   assert.match(html, /data-testid="debug-bundle-search-form"/, 'Search form container renders');
 
-  // All 6 input fields
+  // All 7 input fields
   assert.match(html, /data-testid="bundle-input-account"/, 'Account ID input renders');
   assert.match(html, /data-testid="bundle-input-learner"/, 'Learner ID input renders');
   assert.match(html, /data-testid="bundle-input-from"/, 'Time from input renders');
   assert.match(html, /data-testid="bundle-input-to"/, 'Time to input renders');
   assert.match(html, /data-testid="bundle-input-fingerprint"/, 'Error fingerprint input renders');
+  assert.match(html, /data-testid="bundle-input-event-id"/, 'Error event ID input renders');
   assert.match(html, /data-testid="bundle-input-route"/, 'Route filter input renders');
 
   // Labels
   assert.match(html, /Account ID or email/, 'Account input label renders');
   assert.match(html, /Learner ID/, 'Learner input label renders');
-  assert.match(html, /Error fingerprint/, 'Fingerprint input label renders');
+  assert.match(html, /Error Fingerprint/, 'Fingerprint input label renders');
+  assert.match(html, /Error Event ID/, 'Event ID input label renders');
   assert.match(html, /Route filter/, 'Route filter input label renders');
 
   // Generate button
@@ -463,6 +465,7 @@ test('debug bundle pre-fills fingerprint, accountId, and route from prefill', as
   // This is the current behaviour we are pinning — the prefill only
   // activates after hydration on the client.
   assert.match(html, /name="bundleFingerprint"/, 'Fingerprint input name attribute present');
+  assert.match(html, /name="bundleEventId"/, 'Event ID input name attribute present');
   assert.match(html, /name="bundleAccountId"/, 'Account input name attribute present');
   assert.match(html, /name="bundleRoute"/, 'Route input name attribute present');
 });

--- a/tests/worker-admin-debug-bundle.test.js
+++ b/tests/worker-admin-debug-bundle.test.js
@@ -100,6 +100,23 @@ function seedDenial(server, {
     learnerId, sessionIdLast8, isDemo, release, detailJson);
 }
 
+function seedOccurrence(server, {
+  id,
+  eventId,
+  occurredAt = NOW - ONE_HOUR_MS,
+  release = null,
+  routeName = null,
+  accountId = null,
+  userAgent = null,
+}) {
+  server.DB.db.prepare(`
+    INSERT INTO ops_error_event_occurrences (
+      id, event_id, occurred_at, release, route_name, account_id, user_agent
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run(id, eventId, occurredAt, release, routeName, accountId, userAgent);
+}
+
 function fetchBundle(server, accountId, params = {}, { platformRole = 'admin' } = {}) {
   const query = new URLSearchParams();
   for (const [key, value] of Object.entries(params)) {
@@ -339,7 +356,7 @@ test('canExportJson is true for admin', async () => {
 // 10. Happy path: bundle includes query context in response
 // =================================================================
 
-test('bundle includes query context', async () => {
+test('bundle includes query context with both fingerprint and event ID', async () => {
   const server = createWorkerRepositoryServer();
   try {
     seedAdultAccount(server, { id: 'admin-query', email: 'query@test.com', displayName: 'Query Admin', platformRole: 'admin' });
@@ -348,12 +365,311 @@ test('bundle includes query context', async () => {
       account_id: 'acct-123',
       route: '/api/spelling',
       error_fingerprint: 'fp-test',
+      error_event_id: 'evt-test',
     });
     const body = await res.json();
     assert.equal(body.ok, true);
     assert.equal(body.bundle.query.accountId, 'acct-123');
     assert.equal(body.bundle.query.route, '/api/spelling');
     assert.equal(body.bundle.query.errorFingerprint, 'fp-test');
+    assert.equal(body.bundle.query.errorEventId, 'evt-test');
+  } finally {
+    server.close();
+  }
+});
+
+// =================================================================
+// 11. Identifier semantics: fingerprint returns matching occurrences
+// =================================================================
+
+test('search by fingerprint returns matching error events AND their occurrences', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    const testTs = Date.now() - 1000;
+    seedAdultAccount(server, { id: 'admin-fp', email: 'fp@test.com', displayName: 'FP Admin', platformRole: 'admin' });
+    seedErrorEvent(server, { id: 'evt-fp-1', fingerprint: 'fp-target', firstSeen: testTs, lastSeen: testTs });
+    seedErrorEvent(server, { id: 'evt-fp-2', fingerprint: 'fp-other', firstSeen: testTs, lastSeen: testTs });
+    seedOccurrence(server, { id: 'occ-1', eventId: 'evt-fp-1', occurredAt: testTs, routeName: '/api/a' });
+    seedOccurrence(server, { id: 'occ-2', eventId: 'evt-fp-2', occurredAt: testTs, routeName: '/api/b' });
+
+    const res = await fetchBundle(server, 'admin-fp', {
+      error_fingerprint: 'fp-target',
+      time_from: testTs - ONE_HOUR_MS,
+      time_to: testTs + ONE_HOUR_MS,
+    });
+    const body = await res.json();
+    assert.equal(body.ok, true);
+
+    // recentErrors: only the matching fingerprint
+    const errors = body.bundle.recentErrors || [];
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].fingerprint, 'fp-target');
+
+    // errorOccurrences: only occurrences linked to the matched event
+    const occs = body.bundle.errorOccurrences || [];
+    assert.equal(occs.length, 1);
+    assert.equal(occs[0].eventId, 'evt-fp-1');
+    assert.equal(occs[0].routeName, '/api/a');
+  } finally {
+    server.close();
+  }
+});
+
+// =================================================================
+// 12. Identifier semantics: event ID returns the specific event and occurrences
+// =================================================================
+
+test('search by event ID returns the specific event and its occurrences', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    const testTs = Date.now() - 1000;
+    seedAdultAccount(server, { id: 'admin-eid', email: 'eid@test.com', displayName: 'EID Admin', platformRole: 'admin' });
+    seedErrorEvent(server, { id: 'evt-id-1', fingerprint: 'fp-a', firstSeen: testTs, lastSeen: testTs });
+    seedErrorEvent(server, { id: 'evt-id-2', fingerprint: 'fp-b', firstSeen: testTs, lastSeen: testTs });
+    seedOccurrence(server, { id: 'occ-eid-1', eventId: 'evt-id-1', occurredAt: testTs });
+    seedOccurrence(server, { id: 'occ-eid-2', eventId: 'evt-id-2', occurredAt: testTs });
+
+    const res = await fetchBundle(server, 'admin-eid', {
+      error_event_id: 'evt-id-1',
+      time_from: testTs - ONE_HOUR_MS,
+      time_to: testTs + ONE_HOUR_MS,
+    });
+    const body = await res.json();
+    assert.equal(body.ok, true);
+
+    const errors = body.bundle.recentErrors || [];
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].id, 'evt-id-1');
+
+    const occs = body.bundle.errorOccurrences || [];
+    assert.equal(occs.length, 1);
+    assert.equal(occs[0].eventId, 'evt-id-1');
+  } finally {
+    server.close();
+  }
+});
+
+// =================================================================
+// 13. Identifier semantics: both fingerprint and event ID = intersection
+// =================================================================
+
+test('search by both fingerprint and event ID returns intersection', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    const testTs = Date.now() - 1000;
+    seedAdultAccount(server, { id: 'admin-both', email: 'both@test.com', displayName: 'Both Admin', platformRole: 'admin' });
+    // Two events with distinct fingerprints.
+    seedErrorEvent(server, { id: 'evt-both-1', fingerprint: 'fp-alpha', firstSeen: testTs, lastSeen: testTs });
+    seedErrorEvent(server, { id: 'evt-both-2', fingerprint: 'fp-beta', firstSeen: testTs, lastSeen: testTs });
+    seedOccurrence(server, { id: 'occ-both-1', eventId: 'evt-both-1', occurredAt: testTs });
+    seedOccurrence(server, { id: 'occ-both-2', eventId: 'evt-both-2', occurredAt: testTs });
+
+    // Both fingerprint and event ID: event must match both constraints.
+    // fp-alpha resolves to evt-both-1, AND event ID is evt-both-1 → match.
+    const res = await fetchBundle(server, 'admin-both', {
+      error_fingerprint: 'fp-alpha',
+      error_event_id: 'evt-both-1',
+      time_from: testTs - ONE_HOUR_MS,
+      time_to: testTs + ONE_HOUR_MS,
+    });
+    const body = await res.json();
+    assert.equal(body.ok, true);
+
+    // recentErrors: both constraints AND'd in section 3
+    const errors = body.bundle.recentErrors || [];
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].id, 'evt-both-1');
+
+    // errorOccurrences: intersection of resolved FP IDs with explicit event ID
+    const occs = body.bundle.errorOccurrences || [];
+    assert.equal(occs.length, 1);
+    assert.equal(occs[0].eventId, 'evt-both-1');
+
+    // Mismatch case: fp-alpha resolves to evt-both-1 but event ID is evt-both-2.
+    // The intersection is empty → zero results.
+    const res2 = await fetchBundle(server, 'admin-both', {
+      error_fingerprint: 'fp-alpha',
+      error_event_id: 'evt-both-2',
+      time_from: testTs - ONE_HOUR_MS,
+      time_to: testTs + ONE_HOUR_MS,
+    });
+    const body2 = await res2.json();
+    assert.equal(body2.ok, true);
+
+    // recentErrors: fp-alpha AND id=evt-both-2 — no row matches both.
+    const errors2 = body2.bundle.recentErrors || [];
+    assert.equal(errors2.length, 0, 'mismatched fingerprint+eventId → no events');
+
+    // errorOccurrences: intersection is empty → empty array.
+    const occs2 = body2.bundle.errorOccurrences;
+    assert.ok(Array.isArray(occs2), 'errorOccurrences is array on mismatch');
+    assert.equal(occs2.length, 0, 'mismatched fingerprint+eventId → no occurrences');
+  } finally {
+    server.close();
+  }
+});
+
+// =================================================================
+// 14. Neither fingerprint nor event ID returns all in time window
+// =================================================================
+
+test('search with neither fingerprint nor event ID returns all in time window', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    const testTs = Date.now() - 1000;
+    seedAdultAccount(server, { id: 'admin-neither', email: 'neither@test.com', displayName: 'Neither Admin', platformRole: 'admin' });
+    seedErrorEvent(server, { id: 'evt-all-1', fingerprint: 'fp-x', firstSeen: testTs, lastSeen: testTs });
+    seedErrorEvent(server, { id: 'evt-all-2', fingerprint: 'fp-y', firstSeen: testTs, lastSeen: testTs });
+    seedOccurrence(server, { id: 'occ-all-1', eventId: 'evt-all-1', occurredAt: testTs });
+    seedOccurrence(server, { id: 'occ-all-2', eventId: 'evt-all-2', occurredAt: testTs });
+
+    const res = await fetchBundle(server, 'admin-neither', {
+      time_from: testTs - ONE_HOUR_MS,
+      time_to: testTs + ONE_HOUR_MS,
+    });
+    const body = await res.json();
+    assert.equal(body.ok, true);
+
+    const errors = body.bundle.recentErrors || [];
+    assert.equal(errors.length, 2, 'both events returned without filter');
+
+    const occs = body.bundle.errorOccurrences || [];
+    assert.equal(occs.length, 2, 'both occurrences returned without filter');
+  } finally {
+    server.close();
+  }
+});
+
+// =================================================================
+// 15. CRITICAL: fingerprint matches zero events → empty occurrences, not SQL error
+// =================================================================
+
+test('fingerprint matching zero events returns empty occurrences (not SQL error)', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    const testTs = Date.now() - 1000;
+    seedAdultAccount(server, { id: 'admin-zero', email: 'zero@test.com', displayName: 'Zero Admin', platformRole: 'admin' });
+    // Seed an event and occurrence, but with a different fingerprint.
+    seedErrorEvent(server, { id: 'evt-z', fingerprint: 'fp-exists', firstSeen: testTs, lastSeen: testTs });
+    seedOccurrence(server, { id: 'occ-z', eventId: 'evt-z', occurredAt: testTs });
+
+    const res = await fetchBundle(server, 'admin-zero', {
+      error_fingerprint: 'fp-nonexistent',
+      time_from: testTs - ONE_HOUR_MS,
+      time_to: testTs + ONE_HOUR_MS,
+    });
+    assert.equal(res.status, 200, 'should not be a server error');
+    const body = await res.json();
+    assert.equal(body.ok, true);
+
+    // recentErrors: empty because fingerprint does not match any event
+    const errors = body.bundle.recentErrors || [];
+    assert.equal(errors.length, 0, 'no matching error events');
+
+    // CRITICAL: errorOccurrences must be empty array, NOT null (SQL error)
+    const occs = body.bundle.errorOccurrences;
+    assert.ok(Array.isArray(occs), 'errorOccurrences is an array (not null from SQL error)');
+    assert.equal(occs.length, 0, 'zero occurrences — empty-match guard triggered');
+  } finally {
+    server.close();
+  }
+});
+
+// =================================================================
+// 16. Fingerprint resolves to event and returns all its occurrences
+// =================================================================
+
+test('fingerprint resolves to event and returns all its occurrences', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    const testTs = Date.now() - 1000;
+    seedAdultAccount(server, { id: 'admin-multi', email: 'multi@test.com', displayName: 'Multi Admin', platformRole: 'admin' });
+    // One event with multiple occurrences, and a second unrelated event.
+    seedErrorEvent(server, { id: 'evt-m1', fingerprint: 'fp-multi', routeName: '/api/a', firstSeen: testTs, lastSeen: testTs });
+    seedErrorEvent(server, { id: 'evt-m2', fingerprint: 'fp-unrelated', routeName: '/api/b', firstSeen: testTs, lastSeen: testTs });
+    seedOccurrence(server, { id: 'occ-m1', eventId: 'evt-m1', occurredAt: testTs });
+    seedOccurrence(server, { id: 'occ-m2', eventId: 'evt-m1', occurredAt: testTs - 500 });
+    seedOccurrence(server, { id: 'occ-m3', eventId: 'evt-m1', occurredAt: testTs - 1000 });
+    seedOccurrence(server, { id: 'occ-m4', eventId: 'evt-m2', occurredAt: testTs });
+
+    const res = await fetchBundle(server, 'admin-multi', {
+      error_fingerprint: 'fp-multi',
+      time_from: testTs - ONE_HOUR_MS,
+      time_to: testTs + ONE_HOUR_MS,
+    });
+    const body = await res.json();
+    assert.equal(body.ok, true);
+
+    const errors = body.bundle.recentErrors || [];
+    assert.equal(errors.length, 1, 'only the matching event returned');
+    assert.equal(errors[0].fingerprint, 'fp-multi');
+
+    const occs = body.bundle.errorOccurrences || [];
+    assert.equal(occs.length, 3, 'all 3 occurrences for that event returned');
+    const eventIds = [...new Set(occs.map((o) => o.eventId))];
+    assert.deepStrictEqual(eventIds, ['evt-m1'], 'all occurrences belong to the matched event');
+  } finally {
+    server.close();
+  }
+});
+
+// =================================================================
+// 17. Event ID that does not exist → empty occurrences (not error)
+// =================================================================
+
+test('non-existent event ID returns empty occurrences (not error)', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    const testTs = Date.now() - 1000;
+    seedAdultAccount(server, { id: 'admin-noevt', email: 'noevt@test.com', displayName: 'NoEvt Admin', platformRole: 'admin' });
+    seedErrorEvent(server, { id: 'evt-exists', fingerprint: 'fp-e', firstSeen: testTs, lastSeen: testTs });
+    seedOccurrence(server, { id: 'occ-exists', eventId: 'evt-exists', occurredAt: testTs });
+
+    const res = await fetchBundle(server, 'admin-noevt', {
+      error_event_id: 'evt-does-not-exist',
+      time_from: testTs - ONE_HOUR_MS,
+      time_to: testTs + ONE_HOUR_MS,
+    });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+
+    // recentErrors: empty because id does not match
+    const errors = body.bundle.recentErrors || [];
+    assert.equal(errors.length, 0);
+
+    // errorOccurrences: empty because no occurrence has this event_id
+    const occs = body.bundle.errorOccurrences || [];
+    assert.equal(occs.length, 0);
+  } finally {
+    server.close();
+  }
+});
+
+// =================================================================
+// 18. safeSection catches DB failure gracefully
+// =================================================================
+
+test('safeSection catches DB failure gracefully in error occurrences', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    seedAdultAccount(server, { id: 'admin-dbfail', email: 'dbfail@test.com', displayName: 'DBFail Admin', platformRole: 'admin' });
+
+    // Drop the occurrences table to simulate a DB failure.
+    server.DB.db.prepare('DROP TABLE IF EXISTS ops_error_event_occurrences').run();
+
+    const res = await fetchBundle(server, 'admin-dbfail', { account_id: 'admin-dbfail' });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+
+    // errorOccurrences section returns empty array (allSafe catches
+    // missing table) — other sections still populate.
+    const occs = body.bundle.errorOccurrences;
+    assert.ok(Array.isArray(occs), 'errorOccurrences is array even when table missing');
+    assert.equal(occs.length, 0, 'empty array from missing table');
+    // Other sections (accountSummary) still populated.
+    assert.ok(body.bundle.accountSummary, 'accountSummary still populated');
   } finally {
     server.close();
   }

--- a/worker/src/admin-debug-bundle.js
+++ b/worker/src/admin-debug-bundle.js
@@ -102,6 +102,7 @@ export async function aggregateDebugBundle(db, {
   timeFrom = null,
   timeTo = null,
   errorFingerprint = null,
+  errorEventId = null,
   route = null,
   now = Date.now(),
   buildHash = null,
@@ -175,6 +176,10 @@ export async function aggregateDebugBundle(db, {
         whereClauses.push('fingerprint = ?');
         whereParams.push(errorFingerprint);
       }
+      if (typeof errorEventId === 'string' && errorEventId) {
+        whereClauses.push('id = ?');
+        whereParams.push(errorEventId);
+      }
       const rows = await allSafe(db, `
         SELECT id, fingerprint, error_kind, message_first_line, first_frame,
                route_name, user_agent, account_id, first_seen, last_seen,
@@ -204,13 +209,46 @@ export async function aggregateDebugBundle(db, {
       }));
     }),
 
-    // 4. Error occurrences (filtered by fingerprint when present)
+    // 4. Error occurrences (filtered by fingerprint → resolved event IDs,
+    //    or directly by errorEventId when present).
+    //    CRITICAL: fingerprint is resolved to event IDs inside this
+    //    safeSection callback so the Promise.all parallel structure is
+    //    preserved and a resolution failure is caught by safeSection.
     safeSection('errorOccurrences', async () => {
+      // --- Resolve fingerprint → event IDs ---
+      let resolvedEventIds = null;
+      if (typeof errorFingerprint === 'string' && errorFingerprint) {
+        const eventRows = await allSafe(db,
+          'SELECT id FROM ops_error_events WHERE fingerprint = ?',
+          [errorFingerprint], 'ops_error_events');
+        resolvedEventIds = eventRows.map((r) => r.id);
+        // EMPTY-MATCH GUARD: fingerprint matched zero events →
+        // return empty immediately to avoid `WHERE event_id IN ()`.
+        if (resolvedEventIds.length === 0) return [];
+      }
+
+      // --- Build event ID set from both sources ---
+      let eventIdSet = null;
+      if (resolvedEventIds && typeof errorEventId === 'string' && errorEventId) {
+        // Both provided: intersection (AND). Only include errorEventId
+        // if it is among the resolved set.
+        const intersection = resolvedEventIds.includes(errorEventId)
+          ? [errorEventId]
+          : [];
+        if (intersection.length === 0) return [];
+        eventIdSet = intersection;
+      } else if (resolvedEventIds) {
+        eventIdSet = resolvedEventIds;
+      } else if (typeof errorEventId === 'string' && errorEventId) {
+        eventIdSet = [errorEventId];
+      }
+
       const whereClauses = ['occurred_at >= ?', 'occurred_at <= ?'];
       const whereParams = [effectiveTimeFrom, effectiveTimeTo];
-      if (typeof errorFingerprint === 'string' && errorFingerprint) {
-        whereClauses.push('event_id = ?');
-        whereParams.push(errorFingerprint);
+      if (eventIdSet) {
+        const placeholders = eventIdSet.map(() => '?').join(', ');
+        whereClauses.push(`event_id IN (${placeholders})`);
+        whereParams.push(...eventIdSet);
       }
       if (typeof route === 'string' && route) {
         whereClauses.push('route_name LIKE ?');
@@ -324,6 +362,7 @@ export async function aggregateDebugBundle(db, {
       timeFromExplicit: Number.isFinite(Number(timeFrom)),
       timeToExplicit: Number.isFinite(Number(timeTo)),
       errorFingerprint: errorFingerprint || null,
+      errorEventId: errorEventId || null,
       route: route || null,
     },
     buildHash: buildHash || null,
@@ -444,6 +483,7 @@ export function buildHumanSummary(bundle) {
     if (bundle.query.learnerId) lines.push(`Learner: ${bundle.query.learnerId}`);
     lines.push(`Time window: ${new Date(bundle.query.timeFrom).toISOString()} to ${new Date(bundle.query.timeTo).toISOString()}`);
     if (bundle.query.errorFingerprint) lines.push(`Error fingerprint: ${bundle.query.errorFingerprint}`);
+    if (bundle.query.errorEventId) lines.push(`Error event ID: ${bundle.query.errorEventId}`);
     if (bundle.query.route) lines.push(`Route filter: ${bundle.query.route}`);
     lines.push('');
   }

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -1772,6 +1772,7 @@ export function createWorkerApp({
             timeFrom: url.searchParams.get('time_from') || null,
             timeTo: url.searchParams.get('time_to') || null,
             errorFingerprint: url.searchParams.get('error_fingerprint') || null,
+            errorEventId: url.searchParams.get('error_event_id') || null,
             route: url.searchParams.get('route') || null,
             now: now(),
             buildHash: env.BUILD_HASH || null,


### PR DESCRIPTION
## Summary
- **Bug**: Debug Bundle section 4 (occurrences) used `errorFingerprint` as `event_id = ?`, but `event_id` is a FK referencing `ops_error_events.id` (a UUID-style PK), not a fingerprint string. Operators entering `fp-xxxx` always got zero occurrence results.
- **Fix**: Split the overloaded `errorFingerprint` parameter into two distinct fields: `errorFingerprint` (matches `ops_error_events.fingerprint`) and `errorEventId` (matches `ops_error_events.id`). Section 4 now resolves fingerprint to event IDs via a sub-query before filtering occurrences by `event_id IN (?)`.
- **Empty-match guard**: When fingerprint resolves to zero events, return `[]` immediately instead of constructing `WHERE event_id IN ()` (SQLite syntax error).

### Changes across 6 files
- `worker/src/admin-debug-bundle.js` — accept `errorEventId` param; section 3 filters by `id = ?`; section 4 resolves fingerprint to event IDs with empty-match guard
- `worker/src/app.js` — pass `error_event_id` query param through
- `src/surfaces/hubs/AdminDebuggingSection.jsx` — add "Error Event ID" input field alongside "Error Fingerprint"
- `src/platform/hubs/admin-debug-bundle-panel.js` — normalise `errorEventId` in query context
- `tests/worker-admin-debug-bundle.test.js` — 8 new identifier correctness tests (18 total)
- `tests/admin-debugging-section-characterisation.test.js` — updated for 7-field form

## Test plan
- [x] Search by fingerprint returns matching events and their occurrences (via resolved event IDs)
- [x] Search by event ID returns the specific event and its occurrences
- [x] Search by both returns intersection; mismatch returns empty
- [x] Search with neither returns all in time window
- [x] Fingerprint matching zero events returns empty array (not SQL error)
- [x] Fingerprint resolves to event with multiple occurrences — all returned
- [x] Non-existent event ID returns empty (not error)
- [x] safeSection catches DB failure gracefully
- [x] Characterisation tests pass with 7-field form (13/13)
- [x] Redaction tests unaffected (12/12)
- [x] React bundle panel normaliser tests unaffected (11/11)