### PR TITLE
feat(punctuation): replace lifetime telemetry caps with 7-day rolling window (P7-U6)

### DIFF
--- a/tests/punctuation-telemetry-audit.test.js
+++ b/tests/punctuation-telemetry-audit.test.js
@@ -1,0 +1,168 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createWorkerApp } from '../worker/src/app.js';
+import { createWorkerSubjectRuntime } from '../worker/src/subjects/runtime.js';
+import { createMigratedSqliteD1Database } from './helpers/sqlite-d1.js';
+
+// P7-U6 — Audit trail assertion for event timeline reads.
+//
+// When a caller reads a learner's punctuation event timeline via
+// GET /api/subjects/punctuation/events, a `punctuation.telemetry-read`
+// mutation receipt must be recorded in the ops audit surface so the
+// read is auditable.
+
+function seedAccountLearner(DB, { accountId = 'adult-a', learnerId = 'learner-a' } = {}) {
+  const now = Date.UTC(2026, 0, 1);
+  DB.db.prepare(`
+    INSERT INTO learner_profiles (id, name, year_group, avatar_color, goal, daily_minutes, created_at, updated_at, state_revision)
+    VALUES (?, 'Learner A', 'Y5', '#3E6FA8', 'sats', 15, ?, ?, 0)
+  `).run(learnerId, now, now);
+  DB.db.prepare(`
+    INSERT INTO adult_accounts (id, email, display_name, platform_role, selected_learner_id, created_at, updated_at, repo_revision)
+    VALUES (?, ?, ?, 'parent', ?, ?, ?, 0)
+  `).run(accountId, `${accountId}@example.test`, 'Adult A', learnerId, now, now);
+  DB.db.prepare(`
+    INSERT INTO account_learner_memberships (account_id, learner_id, role, sort_index, created_at, updated_at)
+    VALUES (?, ?, 'owner', 0, ?, ?)
+  `).run(accountId, learnerId, now, now);
+}
+
+function createHarness() {
+  const nowRef = { value: Date.UTC(2026, 0, 1) };
+  const DB = createMigratedSqliteD1Database();
+  seedAccountLearner(DB);
+  const app = createWorkerApp({
+    now: () => nowRef.value,
+    subjectRuntime: createWorkerSubjectRuntime({ punctuation: { random: () => 0 } }),
+  });
+  const env = {
+    DB,
+    AUTH_MODE: 'development-stub',
+    ENVIRONMENT: 'test',
+    PUNCTUATION_SUBJECT_ENABLED: 'true',
+    PUNCTUATION_EVENTS_ENABLED: 'true',
+  };
+  let sequence = 0;
+
+  async function recordEvent({ kind, payload = {}, learnerId = 'learner-a' } = {}) {
+    sequence += 1;
+    const response = await app.fetch(new Request('https://repo.test/api/subjects/punctuation/command', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        origin: 'https://repo.test',
+        'x-ks2-dev-account-id': 'adult-a',
+      },
+      body: JSON.stringify({
+        command: 'record-event',
+        learnerId,
+        requestId: `punctuation-event-${sequence}`,
+        expectedLearnerRevision: 0,
+        payload: { event: kind, payload },
+      }),
+    }), env, {});
+    return response.json();
+  }
+
+  async function getEvents({ learnerId = 'learner-a', kind = null, limit = null } = {}) {
+    const params = new URLSearchParams();
+    if (learnerId) params.set('learner', learnerId);
+    if (kind) params.set('kind', kind);
+    if (limit != null) params.set('limit', String(limit));
+    const url = `https://repo.test/api/subjects/punctuation/events?${params.toString()}`;
+    const response = await app.fetch(new Request(url, {
+      method: 'GET',
+      headers: {
+        origin: 'https://repo.test',
+        'x-ks2-dev-account-id': 'adult-a',
+      },
+    }), env, {});
+    return { response, body: await response.json() };
+  }
+
+  function auditReceipts() {
+    const rows = DB.db.prepare(
+      "SELECT * FROM mutation_receipts WHERE mutation_kind = 'punctuation.telemetry-read' ORDER BY applied_at DESC",
+    ).all();
+    return rows;
+  }
+
+  return { DB, nowRef, recordEvent, getEvents, auditReceipts, close() { DB.close(); } };
+}
+
+test('P7-U6 audit: event timeline read fires a mutation receipt with correct learnerId', async () => {
+  const h = createHarness();
+  try {
+    // Seed some events so the read returns data.
+    await h.recordEvent({ kind: 'card-opened', payload: { cardId: 'a' } });
+    await h.recordEvent({ kind: 'card-opened', payload: { cardId: 'b' } });
+
+    // Read events — this should fire the audit trail.
+    const { response } = await h.getEvents();
+    assert.equal(response.status, 200);
+
+    // Check audit receipt.
+    const receipts = h.auditReceipts();
+    assert.ok(receipts.length >= 1, 'at least one telemetry-read receipt exists');
+    const receipt = receipts[0];
+    assert.equal(receipt.account_id, 'adult-a');
+    assert.equal(receipt.scope_type, 'learner');
+    assert.equal(receipt.scope_id, 'learner-a');
+    assert.equal(receipt.mutation_kind, 'punctuation.telemetry-read');
+    assert.equal(receipt.status_code, 200);
+
+    // The response_json should include the resultCount.
+    const responsePayload = JSON.parse(receipt.response_json);
+    assert.equal(responsePayload.resultCount, 2);
+  } finally {
+    h.close();
+  }
+});
+
+test('P7-U6 audit: event timeline read with kind filter records audit', async () => {
+  const h = createHarness();
+  try {
+    await h.recordEvent({ kind: 'card-opened', payload: { cardId: 'a' } });
+    await h.recordEvent({ kind: 'map-opened', payload: {} });
+
+    // Read only card-opened events.
+    const { response } = await h.getEvents({ kind: 'card-opened' });
+    assert.equal(response.status, 200);
+
+    const receipts = h.auditReceipts();
+    assert.ok(receipts.length >= 1, 'audit receipt exists for filtered read');
+    assert.equal(receipts[0].mutation_kind, 'punctuation.telemetry-read');
+  } finally {
+    h.close();
+  }
+});
+
+test('P7-U6 audit: empty learner (no events) still fires audit receipt', async () => {
+  const h = createHarness();
+  try {
+    // Read with no events inserted.
+    const { response } = await h.getEvents();
+    assert.equal(response.status, 200);
+
+    const receipts = h.auditReceipts();
+    assert.ok(receipts.length >= 1, 'audit receipt fires even for empty result');
+    const responsePayload = JSON.parse(receipts[0].response_json);
+    assert.equal(responsePayload.resultCount, 0);
+  } finally {
+    h.close();
+  }
+});
+
+test('P7-U6 audit: GET events hard-limits to 500 rows', async () => {
+  const h = createHarness();
+  try {
+    // Request a limit above 500.
+    const { response, body } = await h.getEvents({ limit: 999 });
+    assert.equal(response.status, 200);
+    // P7-U6: hard ceiling is 500.
+    assert.equal(body.appliedLimit, 500, 'limit clamped to 500 hard ceiling');
+  } finally {
+    h.close();
+  }
+});

--- a/tests/worker-punctuation-telemetry.test.js
+++ b/tests/worker-punctuation-telemetry.test.js
@@ -304,12 +304,12 @@ test('GET events filters by kind when the kind query parameter is supplied', asy
   }
 });
 
-test('GET events clamps the limit to the documented maximum (1000)', async () => {
+test('GET events clamps the limit to the documented maximum (500, P7-U6 hard ceiling)', async () => {
   const h = createHarness();
   try {
     const { body } = await h.getEvents({ limit: 5000 });
-    // The response should include an `appliedLimit` that clamps to 1000.
-    assert.equal(body.appliedLimit, 1000);
+    // P7-U6: hard ceiling reduced from 1000 to 500 per R4 "bounded reads".
+    assert.equal(body.appliedLimit, 500);
   } finally {
     h.close();
   }
@@ -784,6 +784,230 @@ test('rate limit: feature flag OFF skips rate-limit check (no D1 count query)', 
     assert.equal(body.enabled, false);
     assert.equal(body.recorded, false);
     assert.equal(body.rateLimited, undefined, 'no rateLimited flag when feature is off');
+  } finally {
+    h.close();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Phase 7 U6 — Rolling 7-day window for sessionless telemetry (R4)
+// ---------------------------------------------------------------------------
+
+test('P7-U6: sessionless event accepted when window count < 50', async () => {
+  const h = createHarness();
+  try {
+    // Insert 10 card-opened events — well under the 50 cap.
+    for (let i = 0; i < 10; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      const { response, body } = await h.recordEvent({
+        kind: 'card-opened',
+        payload: { cardId: `card-${i}` },
+      });
+      assert.equal(response.status, 200, `event ${i}: ${JSON.stringify(body)}`);
+      assert.equal(body.recorded, true, `event ${i} should be recorded`);
+      assert.equal(body.rateLimited, undefined, `event ${i} should not be rate limited`);
+    }
+    assert.equal(h.eventRowCount(), 10);
+  } finally {
+    h.close();
+  }
+});
+
+test('P7-U6: sessionless event rate-limited when window count >= 50', async () => {
+  const h = createHarness();
+  try {
+    // Fill to the cap within the current window.
+    for (let i = 0; i < 50; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await h.recordEvent({
+        kind: 'card-opened',
+        payload: { cardId: `card-${i}` },
+      });
+    }
+    assert.equal(h.eventRowCount(), 50);
+
+    // 51st event should be rate-limited.
+    const { response, body } = await h.recordEvent({
+      kind: 'card-opened',
+      payload: { cardId: 'overflow' },
+    });
+    assert.equal(response.status, 200, JSON.stringify(body));
+    assert.equal(body.ok, true);
+    assert.equal(body.recorded, false, '51st event must not be recorded');
+    assert.equal(body.rateLimited, true, '51st event must report rateLimited');
+    assert.equal(h.eventRowCount(), 50);
+  } finally {
+    h.close();
+  }
+});
+
+test('P7-U6: after 7 days, old events fall out of window — learner can emit again', async () => {
+  const { SESSIONLESS_RATE_LIMIT_WINDOW_MS } = await import(
+    '../worker/src/subjects/punctuation/events.js'
+  );
+  const h = createHarness();
+  try {
+    const dayZero = Date.UTC(2026, 0, 1);
+    h.nowRef.value = dayZero;
+
+    // Fill 50 card-opened events on day zero.
+    for (let i = 0; i < 50; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await h.recordEvent({
+        kind: 'card-opened',
+        payload: { cardId: `old-${i}` },
+      });
+    }
+    assert.equal(h.eventRowCount(), 50);
+
+    // Confirm rate-limited at day zero.
+    const { body: capped } = await h.recordEvent({
+      kind: 'card-opened',
+      payload: { cardId: 'blocked' },
+    });
+    assert.equal(capped.rateLimited, true, 'day-zero cap reached');
+
+    // Advance past the 7-day window. All 50 events are now outside
+    // the window, so the next event should be accepted.
+    h.nowRef.value = dayZero + SESSIONLESS_RATE_LIMIT_WINDOW_MS + 1;
+    const { body: fresh } = await h.recordEvent({
+      kind: 'card-opened',
+      payload: { cardId: 'fresh-after-window' },
+    });
+    assert.equal(fresh.recorded, true, 'event after window expiry should be recorded');
+    assert.equal(fresh.rateLimited, undefined, 'no rate limit after window expiry');
+    assert.equal(h.eventRowCount(), 51);
+  } finally {
+    h.close();
+  }
+});
+
+test('P7-U6: per-session cap unchanged (sessionId present path)', async () => {
+  // Per-session cap is NOT windowed — it counts ALL events for the
+  // (learner, kind, sessionId) triple regardless of age. Verify by
+  // filling a session to 50 and confirming the 51st is dropped even
+  // when time has advanced.
+  const h = createHarness();
+  try {
+    const dayZero = Date.UTC(2026, 0, 1);
+    h.nowRef.value = dayZero;
+
+    for (let i = 0; i < 50; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await h.recordEvent({
+        kind: 'answer-submitted',
+        payload: { sessionId: 'sess-fixed', itemId: `item-${i}`, correct: true },
+      });
+    }
+
+    // Advance 8 days — past the sessionless window, but per-session
+    // cap does not use a time window.
+    h.nowRef.value = dayZero + 8 * 86_400_000;
+    const { body: capped } = await h.recordEvent({
+      kind: 'answer-submitted',
+      payload: { sessionId: 'sess-fixed', itemId: 'item-overflow', correct: true },
+    });
+    assert.equal(capped.rateLimited, true, 'per-session cap is not time-windowed');
+    assert.equal(capped.recorded, false);
+    assert.equal(h.eventRowCount(), 50);
+  } finally {
+    h.close();
+  }
+});
+
+test('P7-U6: 50 events from 8 days ago — all expired, next event accepted', async () => {
+  const { SESSIONLESS_RATE_LIMIT_WINDOW_MS } = await import(
+    '../worker/src/subjects/punctuation/events.js'
+  );
+  const h = createHarness();
+  try {
+    const eightDaysAgo = Date.UTC(2026, 0, 1);
+    h.nowRef.value = eightDaysAgo;
+
+    // Insert exactly 50 card-opened events 8 days ago.
+    for (let i = 0; i < 50; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await h.recordEvent({
+        kind: 'card-opened',
+        payload: { cardId: `ancient-${i}` },
+      });
+    }
+    assert.equal(h.eventRowCount(), 50);
+
+    // Now = 8 days later. All 50 events are outside the 7-day window.
+    h.nowRef.value = eightDaysAgo + SESSIONLESS_RATE_LIMIT_WINDOW_MS + 86_400_000;
+    const { body } = await h.recordEvent({
+      kind: 'card-opened',
+      payload: { cardId: 'new-after-expiry' },
+    });
+    assert.equal(body.recorded, true, 'all 50 expired → next event accepted');
+    assert.equal(body.rateLimited, undefined);
+    assert.equal(h.eventRowCount(), 51);
+  } finally {
+    h.close();
+  }
+});
+
+test('P7-U6: 49 events from 6 days ago + 1 from today — next event rate-limited (total 50 in window)', async () => {
+  const h = createHarness();
+  try {
+    const sixDaysAgo = Date.UTC(2026, 0, 1);
+    h.nowRef.value = sixDaysAgo;
+
+    // Insert 49 card-opened events 6 days ago.
+    for (let i = 0; i < 49; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await h.recordEvent({
+        kind: 'card-opened',
+        payload: { cardId: `six-day-${i}` },
+      });
+    }
+    assert.equal(h.eventRowCount(), 49);
+
+    // Advance to "today" (6 days later, still within the 7-day window).
+    h.nowRef.value = sixDaysAgo + 6 * 86_400_000;
+
+    // Insert 1 event today → total 50 in window.
+    const { body: fiftiethBody } = await h.recordEvent({
+      kind: 'card-opened',
+      payload: { cardId: 'today-50th' },
+    });
+    assert.equal(fiftiethBody.recorded, true, '50th event is accepted');
+    assert.equal(h.eventRowCount(), 50);
+
+    // 51st event → rate-limited.
+    const { body: overflowBody } = await h.recordEvent({
+      kind: 'card-opened',
+      payload: { cardId: 'today-51st' },
+    });
+    assert.equal(overflowBody.rateLimited, true, '51st event in window is rate-limited');
+    assert.equal(overflowBody.recorded, false);
+    assert.equal(h.eventRowCount(), 50);
+  } finally {
+    h.close();
+  }
+});
+
+test('P7-U6: rate-limited response returns correct shape { ok: true, recorded: false, rateLimited: true }', async () => {
+  const h = createHarness();
+  try {
+    for (let i = 0; i < 50; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await h.recordEvent({
+        kind: 'card-opened',
+        payload: { cardId: `fill-${i}` },
+      });
+    }
+    const { response, body } = await h.recordEvent({
+      kind: 'card-opened',
+      payload: { cardId: 'overflow' },
+    });
+    assert.equal(response.status, 200, 'status 200 — no learner disruption');
+    assert.equal(body.ok, true);
+    assert.equal(body.recorded, false);
+    assert.equal(body.rateLimited, true);
+    assert.equal(body.enabled, true);
+    assert.equal(body.eventKind, 'card-opened');
   } finally {
     h.close();
   }

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -8435,6 +8435,7 @@ export function createWorkerRepository({ env = {}, now = Date.now, capacity = nu
         kind: options.kind || null,
         sinceMs: options.sinceMs ?? null,
         limit: options.limit ?? null,
+        nowMs: nowFactory(),
         audit: async ({ resultCount, readAtMs }) => {
           const appliedAt = Number.isFinite(readAtMs) ? readAtMs : nowFactory();
           await db.prepare(`
@@ -8445,7 +8446,7 @@ export function createWorkerRepository({ env = {}, now = Date.now, capacity = nu
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
           `).bind(
             accountId,
-            `telemetry-read-${appliedAt}`,
+            `telemetry-read-${appliedAt}-${Math.random().toString(36).slice(2, 8)}`,
             'learner',
             learnerId,
             'punctuation.telemetry-read',

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -8417,12 +8417,16 @@ export function createWorkerRepository({ env = {}, now = Date.now, capacity = nu
     async readSpellingWordBank(accountId, learnerId, filters = {}) {
       return readSpellingWordBankBundle(db, accountId, learnerId, filters, nowFactory());
     },
-    // U9: Punctuation telemetry read. Fires the same
+    // U9 → P7-U6: Punctuation telemetry read. Fires the same
     // `requireLearnerReadAccess` gate the spelling word-bank read uses
     // so a parent / admin with membership can query their learner's
     // telemetry, but a caller without membership gets a 403. The SQL
     // SELECT is delegated to `worker/src/subjects/punctuation/events.js`
     // for test reachability; the repository layer owns the authz gate.
+    //
+    // P7-U6: the read now fires an audit callback that inserts a
+    // `punctuation.telemetry-read` mutation receipt so event timeline
+    // reads are auditable in the ops activity stream.
     async readPunctuationEvents(accountId, learnerId, options = {}) {
       await requireLearnerReadAccess(db, accountId, learnerId);
       return listPunctuationEvents({
@@ -8431,6 +8435,27 @@ export function createWorkerRepository({ env = {}, now = Date.now, capacity = nu
         kind: options.kind || null,
         sinceMs: options.sinceMs ?? null,
         limit: options.limit ?? null,
+        audit: async ({ resultCount, readAtMs }) => {
+          const appliedAt = Number.isFinite(readAtMs) ? readAtMs : nowFactory();
+          await db.prepare(`
+            INSERT INTO mutation_receipts (
+              account_id, request_id, scope_type, scope_id,
+              mutation_kind, request_hash, response_json,
+              status_code, correlation_id, applied_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          `).bind(
+            accountId,
+            `telemetry-read-${appliedAt}`,
+            'learner',
+            learnerId,
+            'punctuation.telemetry-read',
+            '',
+            JSON.stringify({ resultCount }),
+            200,
+            null,
+            appliedAt,
+          ).run();
+        },
       });
     },
     async readParentRecentSessions(accountId, options = {}) {

--- a/worker/src/subjects/punctuation/events.js
+++ b/worker/src/subjects/punctuation/events.js
@@ -46,16 +46,24 @@ import {
 import { BadRequestError, BackendUnavailableError } from '../../errors.js';
 import { batch, bindStatement } from '../../d1.js';
 
-// Phase 6 U9 — Per-session, per-event-kind rate limiting (R16).
+// Phase 6 U9 → Phase 7 U6 — Per-session / rolling-window rate limiting.
 //
-// A generous cap (50 events per session per kind = 600 per session across
-// all 12 kinds) that stops a runaway or compromised client from flooding
-// the D1 ingest path. Legitimate sessions (20-30 items) never approach
-// the limit. The sessionId is extracted from the inner sanitised payload
-// for kinds that carry one (answer-submitted, first-item-rendered,
-// feedback-rendered, summary-reached); for kinds without a sessionId the
-// cap scopes to (learner_id, event_kind) with a NULL session — effectively
-// a per-learner per-kind cap.
+// Per-session kinds: a generous cap (50 events per session per kind = 600
+// per session across all 12 kinds) that stops a runaway or compromised
+// client from flooding the D1 ingest path. Legitimate sessions (20-30
+// items) never approach the limit. The sessionId is extracted from the
+// inner sanitised payload for kinds that carry one (answer-submitted,
+// first-item-rendered, feedback-rendered, summary-reached).
+//
+// Sessionless kinds (P7-U6): for kinds without a sessionId the cap scopes
+// to a rolling 7-day window of (learner_id, event_kind). Previously this
+// was a lifetime per-learner cap which permanently rate-limited learners
+// after normal long-term use. The rolling window uses
+// `AND occurred_at_ms > ?` with `Date.now() - 7 * 86400000` — epoch ms
+// arithmetic against the `occurred_at_ms INTEGER` column. The composite
+// index `idx_punctuation_events_learner_kind_time` covers
+// `(learner_id, event_kind, occurred_at_ms DESC)` so the added range
+// clause narrows the scan.
 //
 // When the cap is hit the handler returns a success response with
 // `{recorded: false, rateLimited: true}` — the client's fire-and-forget
@@ -304,6 +312,7 @@ export async function applyRecordEventCommand({ command, context }) {
     command.learnerId,
     kind,
     sessionId,
+    now,
   );
   if (existingCount >= MAX_TELEMETRY_EVENTS_PER_SESSION_PER_KIND) {
     return {
@@ -374,18 +383,31 @@ export async function applyRecordEventCommand({ command, context }) {
 }
 
 /**
+ * Rolling 7-day window duration in milliseconds.
+ * Sessionless telemetry kinds are rate-limited within this window
+ * rather than against all-time counts, so a learner is never
+ * permanently rate-limited for normal long-term use.
+ */
+export const SESSIONLESS_RATE_LIMIT_WINDOW_MS = 7 * 86_400_000;
+
+/**
  * Count existing events in `punctuation_events` for the rate limiter.
  *
  * When `sessionId` is non-null, the count scopes to events whose stored
  * `payload_json` contains the same `sessionId` via `json_extract`. When
  * `sessionId` is null (the event kind does not carry one), the count
- * scopes to `(learner_id, event_kind)` alone.
+ * scopes to a rolling 7-day window of `(learner_id, event_kind)` using
+ * the `occurred_at_ms` column (epoch ms). This replaces the previous
+ * lifetime count which permanently rate-limited learners after 50
+ * cumulative events.
  *
  * The query uses the `idx_punctuation_events_learner_kind_time` index
- * for the (learner_id, event_kind) prefix so the plan is a covering
- * index scan even when the table grows.
+ * for the `(learner_id, event_kind, occurred_at_ms DESC)` prefix so
+ * the added range clause narrows the scan rather than widening it.
+ *
+ * `nowMs` allows test injection; defaults to `Date.now()`.
  */
-async function countExistingEventsForRateLimit(db, learnerId, eventKind, sessionId) {
+async function countExistingEventsForRateLimit(db, learnerId, eventKind, sessionId, nowMs = Date.now()) {
   if (sessionId) {
     const result = await db.prepare(`
       SELECT COUNT(*) AS n FROM punctuation_events
@@ -394,19 +416,31 @@ async function countExistingEventsForRateLimit(db, learnerId, eventKind, session
     `).bind(learnerId, eventKind, sessionId).first();
     return Number(result?.n) || 0;
   }
+  // P7-U6: rolling 7-day window instead of lifetime count.
+  const windowStart = nowMs - SESSIONLESS_RATE_LIMIT_WINDOW_MS;
   const result = await db.prepare(`
     SELECT COUNT(*) AS n FROM punctuation_events
     WHERE learner_id = ? AND event_kind = ?
-  `).bind(learnerId, eventKind).first();
+      AND occurred_at_ms > ?
+  `).bind(learnerId, eventKind, windowStart).first();
   return Number(result?.n) || 0;
 }
+
+/**
+ * Hard ceiling on event timeline reads (P7-U6 R4). Even when the caller
+ * passes `limit: 1000`, the query never exceeds this bound. Prevents
+ * unbounded scans of the events table.
+ */
+const EVENT_TIMELINE_READ_HARD_LIMIT = 500;
 
 /**
  * Read punctuation events for a learner. Invoked by the query
  * endpoint after `requireLearnerReadAccess` has fired in the
  * repository helper.
  *
- * `limit` is clamped to [1, 1000] with a default of 100.
+ * `limit` is clamped to [1, 500] with a default of 100. The hard
+ * ceiling is `EVENT_TIMELINE_READ_HARD_LIMIT` (500) per P7-U6 R4
+ * ("bounded and audited").
  *
  * Review follow-on 2026-04-26:
  *   - Unknown `kind` values now raise a 400 `punctuation_event_unknown_kind`
@@ -416,6 +450,10 @@ async function countExistingEventsForRateLimit(db, learnerId, eventKind, session
  *   - The ORDER BY adds `id DESC` as a tiebreaker on `occurred_at_ms`
  *     so same-ms events (handler emits back-to-back with the same
  *     `context.now`) return in deterministic insertion order.
+ *
+ * P7-U6: `audit` callback. When provided, called after the query with
+ * `{ learnerId, kind, appliedLimit, resultCount, readAtMs }` so the
+ * caller (repository layer) can record the read in the ops audit surface.
  */
 export async function listPunctuationEvents({
   db,
@@ -423,6 +461,7 @@ export async function listPunctuationEvents({
   kind = null,
   sinceMs = null,
   limit = null,
+  audit = null,
 }) {
   const cleanLearner = typeof learnerId === 'string' ? learnerId : '';
   if (!cleanLearner) {
@@ -463,20 +502,40 @@ export async function listPunctuationEvents({
   `;
   const result = await db.prepare(sql).bind(...params).all();
   const rows = Array.isArray(result?.results) ? result.results : [];
+
+  const events = rows.map((row) => ({
+    kind: row.event_kind,
+    occurredAtMs: Number(row.occurred_at_ms) || 0,
+    payload: safeParseJson(row.payload_json),
+  }));
+
+  // P7-U6: fire audit callback so the repository layer can record
+  // this read in the ops audit surface. Best-effort — audit failures
+  // must not break the read path.
+  if (typeof audit === 'function') {
+    try {
+      await audit({
+        learnerId: cleanLearner,
+        kind: kind || null,
+        appliedLimit,
+        resultCount: events.length,
+        readAtMs: Date.now(),
+      });
+    } catch {
+      // Audit write failure is non-fatal — the read still returns.
+    }
+  }
+
   return {
     appliedLimit,
-    events: rows.map((row) => ({
-      kind: row.event_kind,
-      occurredAtMs: Number(row.occurred_at_ms) || 0,
-      payload: safeParseJson(row.payload_json),
-    })),
+    events,
   };
 }
 
 function clampLimit(value) {
   const raw = Number(value);
   if (!Number.isFinite(raw) || raw <= 0) return 100;
-  if (raw > 1000) return 1000;
+  if (raw > EVENT_TIMELINE_READ_HARD_LIMIT) return EVENT_TIMELINE_READ_HARD_LIMIT;
   return Math.floor(raw);
 }
 

--- a/worker/src/subjects/punctuation/events.js
+++ b/worker/src/subjects/punctuation/events.js
@@ -454,6 +454,11 @@ const EVENT_TIMELINE_READ_HARD_LIMIT = 500;
  * P7-U6: `audit` callback. When provided, called after the query with
  * `{ learnerId, kind, appliedLimit, resultCount, readAtMs }` so the
  * caller (repository layer) can record the read in the ops audit surface.
+ *
+ * `nowMs` injectable clock for the audit `readAtMs` value. When finite
+ * the callback receives this value instead of `Date.now()`, keeping the
+ * read timestamp consistent with the repository's injectable clock for
+ * testability. Falls back to `Date.now()` when omitted.
  */
 export async function listPunctuationEvents({
   db,
@@ -462,6 +467,7 @@ export async function listPunctuationEvents({
   sinceMs = null,
   limit = null,
   audit = null,
+  nowMs = null,
 }) {
   const cleanLearner = typeof learnerId === 'string' ? learnerId : '';
   if (!cleanLearner) {
@@ -519,7 +525,7 @@ export async function listPunctuationEvents({
         kind: kind || null,
         appliedLimit,
         resultCount: events.length,
-        readAtMs: Date.now(),
+        readAtMs: Number.isFinite(nowMs) ? nowMs : Date.now(),
       });
     } catch {
       // Audit write failure is non-fatal — the read still returns.


### PR DESCRIPTION
## Summary
- **Rolling 7-day window for sessionless telemetry**: replaces the lifetime per-learner cap that permanently rate-limited learners after 50 cumulative `card-opened` events. Uses `AND occurred_at_ms > ?` with epoch-ms arithmetic against the indexed `occurred_at_ms` column. Per-session caps remain unchanged.
- **Audit trail for event reads**: `GET /api/subjects/punctuation/events` now records a `punctuation.telemetry-read` mutation receipt in the ops audit surface with learnerId, resultCount, and reader identity.
- **Hard ceiling on timeline reads**: event timeline queries capped at `LIMIT 500` (previously 1000) per R4 "bounded and audited".

## Key changes
| File | Change |
|------|--------|
| `worker/src/subjects/punctuation/events.js` | `countExistingEventsForRateLimit`: sessionless path adds `AND occurred_at_ms > ?` with `nowMs - 7*86400000`; `listPunctuationEvents`: accepts `audit` callback, hard-limits to 500; exports `SESSIONLESS_RATE_LIMIT_WINDOW_MS` |
| `worker/src/repository.js` | `readPunctuationEvents`: wires audit callback that inserts a `punctuation.telemetry-read` mutation receipt |
| `tests/worker-punctuation-telemetry.test.js` | 7 new P7-U6 tests: window < 50 accepted, window >= 50 rate-limited, 7-day expiry, per-session unchanged, 8-day-old expiry, mixed-age window, response shape |
| `tests/punctuation-telemetry-audit.test.js` | New file: 4 audit trail tests: receipt fires with correct learnerId, kind filter, empty result, hard limit 500 |

## Test plan
- [x] 43 telemetry tests pass (32 existing + 7 new windowed + 4 audit)
- [x] 906 punctuation-related tests pass (zero failures)
- [x] Existing per-session rate limit behaviour verified unchanged
- [x] Rolling window verified: events older than 7 days fall out, learner can emit again
- [x] Audit receipt verified: correct mutation_kind, scope_type, scope_id, resultCount