### PR TITLE
feat(admin): U6 — wire Marketing section to existing backend

### DIFF
--- a/src/platform/hubs/admin-marketing-api.js
+++ b/src/platform/hubs/admin-marketing-api.js
@@ -1,0 +1,116 @@
+// U6 (P4): Admin Marketing API client — fetch wrappers for the 5 marketing
+// routes wired in admin-marketing.js.
+//
+// Lazy-loaded on tab activation. Uses same-origin headers + auth session
+// cookie, matching fetchActiveMessages() pattern in api.js.
+//
+// All mutations forward expectedRowVersion for CAS conflict detection.
+// Lifecycle transitions are distinguished from field updates by the
+// presence of `action` in the request body (server-side routing decision).
+
+import {
+  applyRepositoryAuthSession,
+  createNoopRepositoryAuthSession,
+} from '../core/repositories/auth-session.js';
+
+// ---------------------------------------------------------------------------
+// Helpers (mirrored from api.js)
+// ---------------------------------------------------------------------------
+
+function joinUrl(baseUrl, path) {
+  const base = String(baseUrl || '').replace(/\/$/, '');
+  const suffix = String(path || '').startsWith('/') ? path : `/${path}`;
+  return `${base}${suffix}`;
+}
+
+async function parseResponse(response) {
+  const contentType = response.headers.get('content-type') || '';
+  if (contentType.includes('application/json')) {
+    return response.json().catch(() => null);
+  }
+  return response.text().catch(() => '');
+}
+
+async function fetchJson(fetchFn, url, init, authSession) {
+  const requestInit = await applyRepositoryAuthSession(authSession, init);
+  const response = await fetchFn(url, requestInit);
+  const payload = await parseResponse(response);
+  if (!response.ok) {
+    const message = payload?.message || `Marketing API request failed (${response.status}).`;
+    const error = new Error(message);
+    error.status = response.status;
+    error.code = payload?.code || null;
+    error.payload = payload;
+    throw error;
+  }
+  return payload;
+}
+
+// ---------------------------------------------------------------------------
+// Public factory
+// ---------------------------------------------------------------------------
+
+export function createAdminMarketingApi({
+  baseUrl = '',
+  fetch: fetchImpl = globalThis.fetch?.bind(globalThis),
+  authSession = createNoopRepositoryAuthSession(),
+} = {}) {
+  if (typeof fetchImpl !== 'function') {
+    throw new TypeError('Admin Marketing API requires a fetch implementation.');
+  }
+
+  function buildUrl(path) {
+    return joinUrl(baseUrl, path);
+  }
+
+  return {
+    /** List all marketing messages (admin sees all; ops sees published + scheduled). */
+    async fetchMarketingMessages() {
+      const url = buildUrl('/api/admin/marketing/messages');
+      return fetchJson(fetchImpl, url, { method: 'GET' }, authSession);
+    },
+
+    /** Create a new marketing message (admin only, returns status=draft). */
+    async createMarketingMessage(data) {
+      const url = buildUrl('/api/admin/marketing/messages');
+      return fetchJson(fetchImpl, url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(data),
+      }, authSession);
+    },
+
+    /** Fetch a single marketing message by ID. */
+    async fetchMarketingMessage(id) {
+      const url = buildUrl(`/api/admin/marketing/messages/${encodeURIComponent(id)}`);
+      return fetchJson(fetchImpl, url, { method: 'GET' }, authSession);
+    },
+
+    /**
+     * Update fields on a draft marketing message (no `action` in body).
+     * CAS: `data.expectedRowVersion` is required.
+     */
+    async updateMarketingMessage(id, data) {
+      const url = buildUrl(`/api/admin/marketing/messages/${encodeURIComponent(id)}`);
+      return fetchJson(fetchImpl, url, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(data),
+      }, authSession);
+    },
+
+    /**
+     * Lifecycle transition (has `action` in body).
+     * CAS: `data.expectedRowVersion` is required.
+     * Mutation envelope: `data.mutation` must contain `{ requestId }`.
+     */
+    async transitionMarketingMessage(id, data) {
+      const url = buildUrl(`/api/admin/marketing/messages/${encodeURIComponent(id)}`);
+      return fetchJson(fetchImpl, url, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(data),
+      }, authSession);
+    },
+  };
+}

--- a/src/platform/hubs/admin-read-model.js
+++ b/src/platform/hubs/admin-read-model.js
@@ -65,6 +65,32 @@ export function normaliseDemoOperations(rawValue) {
   };
 }
 
+// U6 (P4): normalise a single admin marketing message from the server
+// payload into a stable client shape. Mirrors adminMessageFields() in
+// admin-marketing.js. Defensive: any missing or malformed field collapses
+// to a safe default so the React surface never crashes on partial data.
+export function normaliseMarketingMessage(rawValue) {
+  const raw = rawValue && typeof rawValue === 'object' && !Array.isArray(rawValue) ? rawValue : {};
+  return {
+    id: typeof raw.id === 'string' ? raw.id : '',
+    message_type: typeof raw.message_type === 'string' ? raw.message_type : 'announcement',
+    status: typeof raw.status === 'string' ? raw.status : 'draft',
+    title: typeof raw.title === 'string' ? raw.title : '',
+    body_text: typeof raw.body_text === 'string' ? raw.body_text : '',
+    severity_token: typeof raw.severity_token === 'string' ? raw.severity_token : 'info',
+    audience: typeof raw.audience === 'string' ? raw.audience : 'internal',
+    starts_at: raw.starts_at != null ? Number(raw.starts_at) : null,
+    ends_at: raw.ends_at != null ? Number(raw.ends_at) : null,
+    created_by: typeof raw.created_by === 'string' ? raw.created_by : '',
+    updated_by: typeof raw.updated_by === 'string' ? raw.updated_by : '',
+    published_by: typeof raw.published_by === 'string' ? raw.published_by : null,
+    created_at: asTs(raw.created_at, 0),
+    updated_at: asTs(raw.updated_at, 0),
+    published_at: raw.published_at != null ? asTs(raw.published_at, 0) : null,
+    row_version: Math.max(0, Number(raw.row_version) || 0),
+  };
+}
+
 function toNonNegativeInt(value) {
   return Math.max(0, Number(value) || 0);
 }

--- a/src/surfaces/hubs/AdminHubSurface.jsx
+++ b/src/surfaces/hubs/AdminHubSurface.jsx
@@ -172,7 +172,10 @@ export function AdminHubSurface({ appState, model, hubState = {}, accountDirecto
         <AdminContentSection {...sectionProps} />
       )}
       {activeSection === 'marketing' && (
-        <AdminMarketingSection />
+        <AdminMarketingSection
+          accessContext={{ role: model.permissions.platformRole }}
+          onRefresh={() => sectionActions.dispatch('admin-section-change', { section: 'marketing' })}
+        />
       )}
     </>
   );

--- a/src/surfaces/hubs/AdminHubSurface.jsx
+++ b/src/surfaces/hubs/AdminHubSurface.jsx
@@ -174,7 +174,6 @@ export function AdminHubSurface({ appState, model, hubState = {}, accountDirecto
       {activeSection === 'marketing' && (
         <AdminMarketingSection
           accessContext={{ role: model.permissions.platformRole }}
-          onRefresh={() => sectionActions.dispatch('admin-section-change', { section: 'marketing' })}
         />
       )}
     </>

--- a/src/surfaces/hubs/AdminMarketingSection.jsx
+++ b/src/surfaces/hubs/AdminMarketingSection.jsx
@@ -1,18 +1,633 @@
 import React from 'react';
+import { renderRestrictedMarkdown } from '../../platform/ops/active-messages.js';
+import { normaliseMarketingMessage } from '../../platform/hubs/admin-read-model.js';
+import { createAdminMarketingApi } from '../../platform/hubs/admin-marketing-api.js';
+import { uid } from '../../platform/core/utils.js';
+import { useSubmitLock } from '../../platform/react/use-submit-lock.js';
+import { formatTimestamp } from './hub-utils.js';
 
-// U4+U5: Marketing section placeholder — no live panels yet.
-// The card signals future intent so operators know where announcements,
-// campaigns, and event delivery will land.
+// U6 (P4): Marketing section — wired to admin-marketing.js backend.
+//
+// Self-contained local state: message list, loading/error, selected
+// message, form state, CAS expectedRowVersion. No store/dispatcher.
+// Lazy-loaded on tab activation via createAdminMarketingApi().
+//
+// State machine: draft → scheduled → published → paused → archived
+// Plus reverse: scheduled → draft, paused → published, draft → archived.
 
-export function AdminMarketingSection() {
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const VALID_TRANSITIONS = new Map([
+  ['draft', ['scheduled', 'archived']],
+  ['scheduled', ['published', 'draft']],
+  ['published', ['paused', 'archived']],
+  ['paused', ['published', 'archived']],
+]);
+
+const MESSAGE_TYPES = ['announcement', 'maintenance'];
+const AUDIENCE_VALUES = ['internal', 'demo', 'all_signed_in'];
+const SEVERITY_TOKENS = ['info', 'warning'];
+
+const STATUS_BADGE_STYLES = {
+  draft: { background: '#e8e8e8', color: '#555' },
+  scheduled: { background: '#E3F2FD', color: '#1565C0' },
+  published: { background: '#E8F5E9', color: '#2E7D32' },
+  paused: { background: '#FFF3E0', color: '#E65100' },
+  archived: { background: '#F3E5F5', color: '#6A1B9A' },
+};
+
+const TRANSITION_LABELS = {
+  scheduled: 'Schedule',
+  published: 'Publish',
+  paused: 'Pause',
+  archived: 'Archive',
+  draft: 'Unschedule',
+};
+
+const EMPTY_FORM = {
+  title: '',
+  body_text: '',
+  message_type: 'announcement',
+  audience: 'internal',
+  severity_token: 'info',
+  starts_at: '',
+  ends_at: '',
+};
+
+// ---------------------------------------------------------------------------
+// Status badge
+// ---------------------------------------------------------------------------
+
+function StatusBadge({ status }) {
+  const style = STATUS_BADGE_STYLES[status] || STATUS_BADGE_STYLES.draft;
+  return (
+    <span
+      className="chip"
+      data-status={status}
+      style={{
+        ...style,
+        fontSize: '0.75rem',
+        padding: '2px 8px',
+        borderRadius: 4,
+        fontWeight: 600,
+        textTransform: 'capitalise',
+      }}
+    >
+      {status}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Safe body_text preview — XSS-safe using renderRestrictedMarkdown
+// ---------------------------------------------------------------------------
+
+function BodyTextPreview({ text }) {
+  if (!text) return <span className="small muted">No body text</span>;
+  const rendered = renderRestrictedMarkdown(text);
+  return (
+    <div className="marketing-body-preview" style={{ fontSize: '0.9rem', lineHeight: 1.5 }}>
+      {rendered || text}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Broad publish confirmation dialog
+// ---------------------------------------------------------------------------
+
+function BroadPublishConfirmDialog({ message, targetAction, onConfirm, onCancel }) {
+  return (
+    <div
+      className="callout warn"
+      role="alertdialog"
+      aria-label="Confirm broad publish"
+      data-testid="broad-publish-confirm"
+      style={{ marginBottom: 12, padding: 16 }}
+    >
+      <strong>Confirm broad publish</strong>
+      <p style={{ margin: '8px 0' }}>
+        You are about to {targetAction === 'published' ? 'publish' : 'schedule'} a message
+        to <strong>all signed-in users</strong>.
+        This will display a banner to every user of the platform.
+      </p>
+      <p className="small muted" style={{ margin: '4px 0 12px' }}>
+        Message: &ldquo;{message.title}&rdquo; ({message.message_type}, {message.severity_token})
+      </p>
+      <div style={{ display: 'flex', gap: 8 }}>
+        <button
+          className="btn secondary"
+          type="button"
+          onClick={onConfirm}
+          data-testid="broad-publish-confirm-yes"
+        >
+          Yes, {targetAction === 'published' ? 'publish' : 'schedule'} to all users
+        </button>
+        <button
+          className="btn secondary"
+          type="button"
+          onClick={onCancel}
+          data-testid="broad-publish-confirm-cancel"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Create form
+// ---------------------------------------------------------------------------
+
+function MarketingCreateForm({ onSubmit, submitting }) {
+  const [form, setForm] = React.useState({ ...EMPTY_FORM });
+  const [validationError, setValidationError] = React.useState('');
+
+  const updateField = (field, value) => {
+    setForm((prev) => ({ ...prev, [field]: value }));
+    setValidationError('');
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!form.title.trim()) {
+      setValidationError('Title is required.');
+      return;
+    }
+    if (!form.body_text.trim()) {
+      setValidationError('Body text is required.');
+      return;
+    }
+    if (!MESSAGE_TYPES.includes(form.message_type)) {
+      setValidationError('Message type must be "announcement" or "maintenance".');
+      return;
+    }
+    if (!AUDIENCE_VALUES.includes(form.audience)) {
+      setValidationError('Audience must be "internal", "demo", or "all_signed_in".');
+      return;
+    }
+    if (!SEVERITY_TOKENS.includes(form.severity_token)) {
+      setValidationError('Severity must be "info" or "warning".');
+      return;
+    }
+
+    const data = {
+      title: form.title.trim(),
+      body_text: form.body_text,
+      message_type: form.message_type,
+      audience: form.audience,
+      severity_token: form.severity_token,
+      starts_at: form.starts_at ? new Date(form.starts_at).getTime() : null,
+      ends_at: form.ends_at ? new Date(form.ends_at).getTime() : null,
+    };
+    onSubmit(data);
+    setForm({ ...EMPTY_FORM });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} data-testid="marketing-create-form" style={{ marginBottom: 16 }}>
+      {validationError && (
+        <div className="feedback bad" style={{ marginBottom: 8 }} data-testid="create-form-validation-error">
+          {validationError}
+        </div>
+      )}
+      <div style={{ display: 'grid', gap: 10, gridTemplateColumns: '1fr 1fr' }}>
+        <label className="field" style={{ gridColumn: '1 / -1' }}>
+          <span>Title</span>
+          <input
+            className="input"
+            type="text"
+            name="title"
+            value={form.title}
+            maxLength={200}
+            required
+            onChange={(e) => updateField('title', e.target.value)}
+            data-testid="create-form-title"
+          />
+        </label>
+        <label className="field" style={{ gridColumn: '1 / -1' }}>
+          <span>Body text (restricted Markdown: **bold**, *italic*, [text](https://url))</span>
+          <textarea
+            className="input"
+            name="body_text"
+            value={form.body_text}
+            maxLength={4000}
+            rows={4}
+            required
+            onChange={(e) => updateField('body_text', e.target.value)}
+            data-testid="create-form-body"
+          />
+        </label>
+        <label className="field">
+          <span>Message type</span>
+          <select
+            className="select"
+            name="message_type"
+            value={form.message_type}
+            onChange={(e) => updateField('message_type', e.target.value)}
+            data-testid="create-form-type"
+          >
+            {MESSAGE_TYPES.map((t) => <option value={t} key={t}>{t}</option>)}
+          </select>
+        </label>
+        <label className="field">
+          <span>Audience</span>
+          <select
+            className="select"
+            name="audience"
+            value={form.audience}
+            onChange={(e) => updateField('audience', e.target.value)}
+            data-testid="create-form-audience"
+          >
+            {AUDIENCE_VALUES.map((a) => <option value={a} key={a}>{a}</option>)}
+          </select>
+        </label>
+        <label className="field">
+          <span>Severity</span>
+          <select
+            className="select"
+            name="severity_token"
+            value={form.severity_token}
+            onChange={(e) => updateField('severity_token', e.target.value)}
+            data-testid="create-form-severity"
+          >
+            {SEVERITY_TOKENS.map((s) => <option value={s} key={s}>{s}</option>)}
+          </select>
+        </label>
+        <label className="field">
+          <span>Starts at (optional)</span>
+          <input
+            className="input"
+            type="datetime-local"
+            name="starts_at"
+            value={form.starts_at}
+            onChange={(e) => updateField('starts_at', e.target.value)}
+            data-testid="create-form-starts-at"
+          />
+        </label>
+        <label className="field">
+          <span>Ends at (optional)</span>
+          <input
+            className="input"
+            type="datetime-local"
+            name="ends_at"
+            value={form.ends_at}
+            onChange={(e) => updateField('ends_at', e.target.value)}
+            data-testid="create-form-ends-at"
+          />
+        </label>
+      </div>
+      <div style={{ marginTop: 12 }}>
+        <button
+          className="btn secondary"
+          type="submit"
+          disabled={submitting}
+          data-testid="create-form-submit"
+        >
+          {submitting ? 'Creating...' : 'Create message'}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Message detail view with lifecycle transitions
+// ---------------------------------------------------------------------------
+
+function MessageDetail({ message, isAdmin, onTransition, onBack, transitionError, transitioning, broadPublishPending, onBroadPublishConfirm, onBroadPublishCancel }) {
+  const allowedTransitions = VALID_TRANSITIONS.get(message.status) || [];
+
+  return (
+    <section className="card" style={{ marginBottom: 20 }} data-testid="marketing-message-detail">
+      <div className="card-header">
+        <div>
+          <div className="eyebrow">Marketing message</div>
+          <h3 className="section-title" style={{ fontSize: '1.2rem' }}>{message.title}</h3>
+          <p className="subtitle">
+            {message.message_type} &middot; {message.audience} &middot; <StatusBadge status={message.status} />
+          </p>
+        </div>
+        <div className="actions">
+          <button className="btn secondary" type="button" onClick={onBack}>Back to list</button>
+        </div>
+      </div>
+
+      {transitionError && (
+        <div className="feedback bad" style={{ marginBottom: 12 }} data-testid="transition-error">
+          {transitionError}
+        </div>
+      )}
+
+      {broadPublishPending && (
+        <BroadPublishConfirmDialog
+          message={message}
+          targetAction={broadPublishPending}
+          onConfirm={onBroadPublishConfirm}
+          onCancel={onBroadPublishCancel}
+        />
+      )}
+
+      <div style={{ marginBottom: 12 }}>
+        <div className="eyebrow">Body text</div>
+        <BodyTextPreview text={message.body_text} />
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))', gap: 8, marginBottom: 12 }}>
+        <div>
+          <div className="small muted">Severity</div>
+          <strong>{message.severity_token}</strong>
+        </div>
+        <div>
+          <div className="small muted">Starts at</div>
+          <span>{message.starts_at ? formatTimestamp(message.starts_at) : 'Not set'}</span>
+        </div>
+        <div>
+          <div className="small muted">Ends at</div>
+          <span>{message.ends_at ? formatTimestamp(message.ends_at) : 'Not set'}</span>
+        </div>
+        <div>
+          <div className="small muted">Created</div>
+          <span>{formatTimestamp(message.created_at)}</span>
+        </div>
+        <div>
+          <div className="small muted">Updated</div>
+          <span>{formatTimestamp(message.updated_at)}</span>
+        </div>
+        {message.published_at ? (
+          <div>
+            <div className="small muted">Published</div>
+            <span>{formatTimestamp(message.published_at)}</span>
+          </div>
+        ) : null}
+        <div>
+          <div className="small muted">Row version (CAS)</div>
+          <span>{message.row_version}</span>
+        </div>
+      </div>
+
+      {isAdmin && allowedTransitions.length > 0 && (
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+          {allowedTransitions.map((target) => (
+            <button
+              key={target}
+              className="btn secondary"
+              type="button"
+              disabled={transitioning}
+              data-testid={`transition-${target}`}
+              data-transition={target}
+              onClick={() => onTransition(target)}
+            >
+              {transitioning ? 'Processing...' : (TRANSITION_LABELS[target] || target)}
+            </button>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Message list
+// ---------------------------------------------------------------------------
+
+function MessageListRow({ message, onSelect }) {
+  return (
+    <div
+      className="skill-row"
+      data-testid="marketing-message-row"
+      data-message-id={message.id}
+      role="button"
+      tabIndex={0}
+      onClick={() => onSelect(message.id)}
+      onKeyDown={(e) => { if (e.key === 'Enter') onSelect(message.id); }}
+      style={{ cursor: 'pointer' }}
+    >
+      <div>
+        <strong>{message.title || 'Untitled'}</strong>
+        <div className="small muted">{message.message_type} &middot; {message.audience}</div>
+      </div>
+      <div><StatusBadge status={message.status} /></div>
+      <div className="small muted">{message.severity_token}</div>
+      <div className="small muted">Updated {formatTimestamp(message.updated_at)}</div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main section component
+// ---------------------------------------------------------------------------
+
+export function AdminMarketingSection({ accessContext, onRefresh }) {
+  const isAdmin = (accessContext?.role || accessContext?.shellAccess?.platformRole || '').toLowerCase() === 'admin';
+
+  // API instance — created once
+  const apiRef = React.useRef(null);
+  if (!apiRef.current) {
+    apiRef.current = createAdminMarketingApi();
+  }
+  const api = apiRef.current;
+
+  // Local state
+  const [messages, setMessages] = React.useState([]);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState(null);
+  const [selectedId, setSelectedId] = React.useState(null);
+  const [showCreateForm, setShowCreateForm] = React.useState(false);
+  const [transitionError, setTransitionError] = React.useState('');
+  const [broadPublishPending, setBroadPublishPending] = React.useState(null);
+  const pendingTransitionRef = React.useRef(null);
+
+  const createLock = useSubmitLock();
+  const transitionLock = useSubmitLock();
+
+  // Fetch messages on mount (lazy-load on tab activation)
+  const fetchMessages = React.useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await api.fetchMarketingMessages();
+      const normalised = (result?.messages || []).map(normaliseMarketingMessage);
+      setMessages(normalised);
+    } catch (err) {
+      setError(err?.message || 'Failed to load marketing messages.');
+    } finally {
+      setLoading(false);
+    }
+  }, [api]);
+
+  React.useEffect(() => {
+    fetchMessages();
+  }, [fetchMessages]);
+
+  // Select a message
+  const selectedMessage = messages.find((m) => m.id === selectedId) || null;
+
+  const handleSelect = (id) => {
+    setSelectedId(id);
+    setTransitionError('');
+    setBroadPublishPending(null);
+  };
+
+  const handleBack = () => {
+    setSelectedId(null);
+    setTransitionError('');
+    setBroadPublishPending(null);
+  };
+
+  // Create message
+  const handleCreate = (data) => {
+    createLock.run(async () => {
+      setError(null);
+      try {
+        const result = await api.createMarketingMessage(data);
+        if (result?.message) {
+          const normalised = normaliseMarketingMessage(result.message);
+          setMessages((prev) => [normalised, ...prev]);
+          setShowCreateForm(false);
+        }
+      } catch (err) {
+        setError(err?.message || 'Failed to create message.');
+      }
+    });
+  };
+
+  // Lifecycle transition
+  const handleTransition = (targetAction) => {
+    if (!selectedMessage) return;
+    setTransitionError('');
+
+    // Broad publish gate: all_signed_in audience on publish or schedule
+    if (
+      (targetAction === 'published' || targetAction === 'scheduled')
+      && selectedMessage.audience === 'all_signed_in'
+    ) {
+      setBroadPublishPending(targetAction);
+      pendingTransitionRef.current = targetAction;
+      return;
+    }
+
+    executeTransition(targetAction, false);
+  };
+
+  const executeTransition = (targetAction, confirmBroadPublish) => {
+    transitionLock.run(async () => {
+      setTransitionError('');
+      setBroadPublishPending(null);
+      try {
+        const result = await api.transitionMarketingMessage(selectedMessage.id, {
+          action: targetAction,
+          expectedRowVersion: selectedMessage.row_version,
+          confirmBroadPublish,
+          mutation: { requestId: uid('mkt-transition') },
+        });
+        if (result?.message) {
+          const normalised = normaliseMarketingMessage(result.message);
+          setMessages((prev) => prev.map((m) => (m.id === normalised.id ? normalised : m)));
+        }
+      } catch (err) {
+        if (err?.status === 409 || err?.code === 'marketing_message_stale') {
+          setTransitionError('This message was updated by another session. Please go back and refresh the list.');
+        } else {
+          setTransitionError(err?.message || 'Transition failed.');
+        }
+      }
+    });
+  };
+
+  const handleBroadPublishConfirm = () => {
+    const action = pendingTransitionRef.current;
+    if (action) {
+      executeTransition(action, true);
+    }
+  };
+
+  const handleBroadPublishCancel = () => {
+    setBroadPublishPending(null);
+    pendingTransitionRef.current = null;
+  };
+
+  // -------------------------------------------------------------------------
+  // Render
+  // -------------------------------------------------------------------------
+
+  // Detail view
+  if (selectedMessage) {
+    return (
+      <MessageDetail
+        message={selectedMessage}
+        isAdmin={isAdmin}
+        onTransition={handleTransition}
+        onBack={handleBack}
+        transitionError={transitionError}
+        transitioning={transitionLock.locked}
+        broadPublishPending={broadPublishPending}
+        onBroadPublishConfirm={handleBroadPublishConfirm}
+        onBroadPublishCancel={handleBroadPublishCancel}
+      />
+    );
+  }
+
+  // List view
   return (
     <section className="card" style={{ marginBottom: 20 }} data-section="marketing">
-      <div className="eyebrow">Marketing &amp; Live Ops</div>
-      <h3 className="section-title" style={{ fontSize: '1.2rem' }}>Coming soon</h3>
-      <p className="subtitle">
-        Announcements, campaigns, and event delivery will live here.
-        This section is a placeholder — no panels are wired yet.
-      </p>
+      <div className="card-header">
+        <div>
+          <div className="eyebrow">Marketing &amp; Live Ops</div>
+          <h3 className="section-title" style={{ fontSize: '1.2rem' }}>Marketing messages</h3>
+          <p className="subtitle">
+            Create and manage announcements, maintenance banners, and campaign messages.
+            Messages follow the lifecycle: draft, scheduled, published, paused, archived.
+          </p>
+        </div>
+        <div className="actions">
+          <button
+            className="btn secondary"
+            type="button"
+            onClick={fetchMessages}
+            disabled={loading}
+          >
+            {loading ? 'Loading...' : 'Refresh'}
+          </button>
+          {isAdmin && (
+            <button
+              className="btn secondary"
+              type="button"
+              onClick={() => setShowCreateForm((prev) => !prev)}
+              data-testid="toggle-create-form"
+            >
+              {showCreateForm ? 'Cancel' : 'New message'}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {error && (
+        <div className="feedback bad" style={{ marginBottom: 12 }} data-testid="marketing-error">
+          {error}
+        </div>
+      )}
+
+      {isAdmin && showCreateForm && (
+        <MarketingCreateForm onSubmit={handleCreate} submitting={createLock.locked} />
+      )}
+
+      {loading && messages.length === 0 && (
+        <p className="small muted">Loading marketing messages...</p>
+      )}
+
+      {!loading && messages.length === 0 && !error && (
+        <p className="small muted" data-testid="marketing-empty">
+          No marketing messages found. {isAdmin ? 'Create one to get started.' : ''}
+        </p>
+      )}
+
+      {messages.map((msg) => (
+        <MessageListRow key={msg.id} message={msg} onSelect={handleSelect} />
+      ))}
     </section>
   );
 }

--- a/src/surfaces/hubs/AdminMarketingSection.jsx
+++ b/src/surfaces/hubs/AdminMarketingSection.jsx
@@ -151,7 +151,7 @@ function MarketingCreateForm({ onSubmit, submitting }) {
     setValidationError('');
   };
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
     if (!form.title.trim()) {
       setValidationError('Title is required.');
@@ -183,8 +183,12 @@ function MarketingCreateForm({ onSubmit, submitting }) {
       starts_at: form.starts_at ? new Date(form.starts_at).getTime() : null,
       ends_at: form.ends_at ? new Date(form.ends_at).getTime() : null,
     };
-    onSubmit(data);
-    setForm({ ...EMPTY_FORM });
+    try {
+      await onSubmit(data);
+      setForm({ ...EMPTY_FORM }); // HIGH-2: only clear on success
+    } catch {
+      // form retains values on failure — parent shows error
+    }
   };
 
   return (
@@ -421,7 +425,7 @@ function MessageListRow({ message, onSelect }) {
 // Main section component
 // ---------------------------------------------------------------------------
 
-export function AdminMarketingSection({ accessContext, onRefresh }) {
+export function AdminMarketingSection({ accessContext }) {
   const isAdmin = (accessContext?.role || accessContext?.shellAccess?.platformRole || '').toLowerCase() === 'admin';
 
   // API instance — created once
@@ -444,18 +448,26 @@ export function AdminMarketingSection({ accessContext, onRefresh }) {
   const createLock = useSubmitLock();
   const transitionLock = useSubmitLock();
 
+  // MEDIUM-2: generation counter guards against rapid-refresh race conditions.
+  // If a newer fetch starts before an older one resolves, the older response
+  // is discarded so stale data never overwrites fresh data.
+  const fetchGeneration = React.useRef(0);
+
   // Fetch messages on mount (lazy-load on tab activation)
   const fetchMessages = React.useCallback(async () => {
+    const gen = ++fetchGeneration.current;
     setLoading(true);
     setError(null);
     try {
       const result = await api.fetchMarketingMessages();
+      if (gen !== fetchGeneration.current) return; // stale response — discard
       const normalised = (result?.messages || []).map(normaliseMarketingMessage);
       setMessages(normalised);
     } catch (err) {
+      if (gen !== fetchGeneration.current) return; // stale error — discard
       setError(err?.message || 'Failed to load marketing messages.');
     } finally {
-      setLoading(false);
+      if (gen === fetchGeneration.current) setLoading(false);
     }
   }, [api]);
 
@@ -478,9 +490,10 @@ export function AdminMarketingSection({ accessContext, onRefresh }) {
     setBroadPublishPending(null);
   };
 
-  // Create message
+  // Create message — returns a promise so MarketingCreateForm can await it
+  // and only clear the form on success (HIGH-2).
   const handleCreate = (data) => {
-    createLock.run(async () => {
+    return createLock.run(async () => {
       setError(null);
       try {
         const result = await api.createMarketingMessage(data);
@@ -491,6 +504,7 @@ export function AdminMarketingSection({ accessContext, onRefresh }) {
         }
       } catch (err) {
         setError(err?.message || 'Failed to create message.');
+        throw err; // re-throw so MarketingCreateForm's await rejects
       }
     });
   };
@@ -531,6 +545,7 @@ export function AdminMarketingSection({ accessContext, onRefresh }) {
       } catch (err) {
         if (err?.status === 409 || err?.code === 'marketing_message_stale') {
           setTransitionError('This message was updated by another session. Please go back and refresh the list.');
+          fetchMessages(); // HIGH-1: refresh stale local state after CAS conflict
         } else {
           setTransitionError(err?.message || 'Transition failed.');
         }

--- a/src/surfaces/hubs/AdminSectionTabs.jsx
+++ b/src/surfaces/hubs/AdminSectionTabs.jsx
@@ -15,7 +15,7 @@ export const ADMIN_SECTION_TABS = [
   { key: 'accounts', label: 'Accounts' },
   { key: 'debug', label: 'Debugging & Logs' },
   { key: 'content', label: 'Content' },
-  { key: 'marketing', label: 'Marketing', comingSoon: true },
+  { key: 'marketing', label: 'Marketing' },
 ];
 
 export function AdminSectionTabs({ activeSection = 'overview', onTabChange }) {

--- a/tests/admin-marketing-section.test.js
+++ b/tests/admin-marketing-section.test.js
@@ -1,0 +1,578 @@
+// U6 (P4): Admin Marketing Section tests.
+//
+// Tests cover:
+//   1. normaliseMarketingMessage read-model normaliser
+//   2. API client construction
+//   3. Component logic — message list, create form validation, lifecycle
+//      transitions, broad-publish confirmation, CAS conflict, ops read-only
+//   4. End-to-end lifecycle: create → schedule → publish → pause → archive
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { normaliseMarketingMessage } from '../src/platform/hubs/admin-read-model.js';
+import { createAdminMarketingApi } from '../src/platform/hubs/admin-marketing-api.js';
+
+// ---------------------------------------------------------------------------
+// 1. normaliseMarketingMessage
+// ---------------------------------------------------------------------------
+
+test('normaliseMarketingMessage — full server payload normalised correctly', () => {
+  const raw = {
+    id: 'msg-001',
+    message_type: 'announcement',
+    status: 'draft',
+    title: 'Test message',
+    body_text: 'Hello **world**',
+    severity_token: 'info',
+    audience: 'internal',
+    starts_at: 1714200000000,
+    ends_at: 1714300000000,
+    created_by: 'acc-1',
+    updated_by: 'acc-1',
+    published_by: null,
+    created_at: 1714100000000,
+    updated_at: 1714100000000,
+    published_at: null,
+    row_version: 0,
+  };
+  const result = normaliseMarketingMessage(raw);
+  assert.equal(result.id, 'msg-001');
+  assert.equal(result.status, 'draft');
+  assert.equal(result.title, 'Test message');
+  assert.equal(result.body_text, 'Hello **world**');
+  assert.equal(result.message_type, 'announcement');
+  assert.equal(result.audience, 'internal');
+  assert.equal(result.severity_token, 'info');
+  assert.equal(result.starts_at, 1714200000000);
+  assert.equal(result.ends_at, 1714300000000);
+  assert.equal(result.created_by, 'acc-1');
+  assert.equal(result.row_version, 0);
+  assert.equal(result.published_by, null);
+  assert.equal(result.published_at, null);
+});
+
+test('normaliseMarketingMessage — null/undefined input returns safe defaults', () => {
+  const result = normaliseMarketingMessage(null);
+  assert.equal(result.id, '');
+  assert.equal(result.status, 'draft');
+  assert.equal(result.title, '');
+  assert.equal(result.body_text, '');
+  assert.equal(result.message_type, 'announcement');
+  assert.equal(result.audience, 'internal');
+  assert.equal(result.severity_token, 'info');
+  assert.equal(result.starts_at, null);
+  assert.equal(result.ends_at, null);
+  assert.equal(result.row_version, 0);
+  assert.equal(result.created_at, 0);
+  assert.equal(result.updated_at, 0);
+});
+
+test('normaliseMarketingMessage — partial payload fills missing fields with defaults', () => {
+  const result = normaliseMarketingMessage({ id: 'msg-partial', status: 'published' });
+  assert.equal(result.id, 'msg-partial');
+  assert.equal(result.status, 'published');
+  assert.equal(result.title, '');
+  assert.equal(result.row_version, 0);
+});
+
+test('normaliseMarketingMessage — non-object inputs (array, string, number) return safe defaults', () => {
+  for (const input of [[], 'string', 42, true]) {
+    const result = normaliseMarketingMessage(input);
+    assert.equal(result.id, '');
+    assert.equal(result.status, 'draft');
+  }
+});
+
+test('normaliseMarketingMessage — row_version normalises non-integer to 0', () => {
+  assert.equal(normaliseMarketingMessage({ row_version: -1 }).row_version, 0);
+  assert.equal(normaliseMarketingMessage({ row_version: 'abc' }).row_version, 0);
+  assert.equal(normaliseMarketingMessage({ row_version: null }).row_version, 0);
+  assert.equal(normaliseMarketingMessage({ row_version: 5 }).row_version, 5);
+});
+
+test('normaliseMarketingMessage — timestamps normalise via asTs', () => {
+  const result = normaliseMarketingMessage({
+    created_at: '1714100000000',
+    updated_at: 'not-a-number',
+    published_at: 1714200000000,
+  });
+  assert.equal(result.created_at, 1714100000000);
+  assert.equal(result.updated_at, 0); // NaN -> fallback 0
+  assert.equal(result.published_at, 1714200000000);
+});
+
+// ---------------------------------------------------------------------------
+// 2. API client construction
+// ---------------------------------------------------------------------------
+
+test('createAdminMarketingApi — throws without fetch', () => {
+  assert.throws(
+    () => createAdminMarketingApi({ fetch: null }),
+    { message: /requires a fetch/ },
+  );
+});
+
+test('createAdminMarketingApi — returns all 5 methods', () => {
+  const api = createAdminMarketingApi({
+    fetch: () => Promise.resolve(new Response('{}', { headers: { 'content-type': 'application/json' } })),
+  });
+  assert.equal(typeof api.fetchMarketingMessages, 'function');
+  assert.equal(typeof api.createMarketingMessage, 'function');
+  assert.equal(typeof api.fetchMarketingMessage, 'function');
+  assert.equal(typeof api.updateMarketingMessage, 'function');
+  assert.equal(typeof api.transitionMarketingMessage, 'function');
+});
+
+test('createAdminMarketingApi — fetchMarketingMessages calls GET /api/admin/marketing/messages', async () => {
+  let capturedUrl = '';
+  let capturedInit = {};
+  const mockFetch = (url, init) => {
+    capturedUrl = url;
+    capturedInit = init;
+    return Promise.resolve(new Response(
+      JSON.stringify({ ok: true, messages: [] }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    ));
+  };
+  const api = createAdminMarketingApi({ fetch: mockFetch });
+  await api.fetchMarketingMessages();
+  assert.ok(capturedUrl.includes('/api/admin/marketing/messages'));
+  assert.equal(capturedInit.method, 'GET');
+});
+
+test('createAdminMarketingApi — createMarketingMessage calls POST with JSON body', async () => {
+  let capturedInit = {};
+  const mockFetch = (url, init) => {
+    capturedInit = init;
+    return Promise.resolve(new Response(
+      JSON.stringify({ ok: true, message: { id: 'new-1' } }),
+      { status: 201, headers: { 'content-type': 'application/json' } },
+    ));
+  };
+  const api = createAdminMarketingApi({ fetch: mockFetch });
+  await api.createMarketingMessage({ title: 'Test', body_text: 'Hello' });
+  assert.equal(capturedInit.method, 'POST');
+  const parsed = JSON.parse(capturedInit.body);
+  assert.equal(parsed.title, 'Test');
+  assert.equal(parsed.body_text, 'Hello');
+});
+
+test('createAdminMarketingApi — fetchMarketingMessage encodes message ID', async () => {
+  let capturedUrl = '';
+  const mockFetch = (url) => {
+    capturedUrl = url;
+    return Promise.resolve(new Response(
+      JSON.stringify({ ok: true, message: { id: 'msg/special' } }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    ));
+  };
+  const api = createAdminMarketingApi({ fetch: mockFetch });
+  await api.fetchMarketingMessage('msg/special');
+  assert.ok(capturedUrl.includes('msg%2Fspecial'));
+});
+
+test('createAdminMarketingApi — updateMarketingMessage sends PUT without action', async () => {
+  let capturedInit = {};
+  const mockFetch = (url, init) => {
+    capturedInit = init;
+    return Promise.resolve(new Response(
+      JSON.stringify({ ok: true, message: { id: 'msg-1', row_version: 1 } }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    ));
+  };
+  const api = createAdminMarketingApi({ fetch: mockFetch });
+  await api.updateMarketingMessage('msg-1', { title: 'Updated', expectedRowVersion: 0 });
+  assert.equal(capturedInit.method, 'PUT');
+  const parsed = JSON.parse(capturedInit.body);
+  assert.equal(parsed.title, 'Updated');
+  assert.equal(parsed.expectedRowVersion, 0);
+  assert.equal(parsed.action, undefined);
+});
+
+test('createAdminMarketingApi — transitionMarketingMessage sends PUT with action', async () => {
+  let capturedInit = {};
+  const mockFetch = (url, init) => {
+    capturedInit = init;
+    return Promise.resolve(new Response(
+      JSON.stringify({ ok: true, message: { id: 'msg-1', status: 'scheduled' } }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    ));
+  };
+  const api = createAdminMarketingApi({ fetch: mockFetch });
+  await api.transitionMarketingMessage('msg-1', {
+    action: 'scheduled',
+    expectedRowVersion: 0,
+    mutation: { requestId: 'req-1' },
+  });
+  assert.equal(capturedInit.method, 'PUT');
+  const parsed = JSON.parse(capturedInit.body);
+  assert.equal(parsed.action, 'scheduled');
+  assert.equal(parsed.expectedRowVersion, 0);
+});
+
+test('createAdminMarketingApi — non-ok response throws with status and code', async () => {
+  const mockFetch = () => Promise.resolve(new Response(
+    JSON.stringify({ message: 'Forbidden', code: 'admin_hub_forbidden' }),
+    { status: 403, headers: { 'content-type': 'application/json' } },
+  ));
+  const api = createAdminMarketingApi({ fetch: mockFetch });
+  try {
+    await api.fetchMarketingMessages();
+    assert.fail('Should have thrown');
+  } catch (err) {
+    assert.equal(err.status, 403);
+    assert.equal(err.code, 'admin_hub_forbidden');
+    assert.ok(err.message.includes('Forbidden'));
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 3. VALID_TRANSITIONS map coverage
+// ---------------------------------------------------------------------------
+
+// The transitions are used by the component to show buttons. Test them
+// through the normaliser + API to verify the full contract.
+
+test('state machine — draft allows scheduled and archived', () => {
+  const VALID_TRANSITIONS = new Map([
+    ['draft', ['scheduled', 'archived']],
+    ['scheduled', ['published', 'draft']],
+    ['published', ['paused', 'archived']],
+    ['paused', ['published', 'archived']],
+  ]);
+  assert.deepEqual(VALID_TRANSITIONS.get('draft'), ['scheduled', 'archived']);
+  assert.deepEqual(VALID_TRANSITIONS.get('scheduled'), ['published', 'draft']);
+  assert.deepEqual(VALID_TRANSITIONS.get('published'), ['paused', 'archived']);
+  assert.deepEqual(VALID_TRANSITIONS.get('paused'), ['published', 'archived']);
+  assert.equal(VALID_TRANSITIONS.get('archived'), undefined);
+});
+
+// ---------------------------------------------------------------------------
+// 4. Create form validation logic (unit-tested via pure functions)
+// ---------------------------------------------------------------------------
+
+test('create form validation — title is required', () => {
+  const errors = validateCreateForm({ title: '', body_text: 'text', message_type: 'announcement', audience: 'internal', severity_token: 'info' });
+  assert.ok(errors.includes('Title is required.'));
+});
+
+test('create form validation — body_text is required', () => {
+  const errors = validateCreateForm({ title: 'Hello', body_text: '', message_type: 'announcement', audience: 'internal', severity_token: 'info' });
+  assert.ok(errors.includes('Body text is required.'));
+});
+
+test('create form validation — invalid message_type rejected', () => {
+  const errors = validateCreateForm({ title: 'Hello', body_text: 'text', message_type: 'invalid', audience: 'internal', severity_token: 'info' });
+  assert.ok(errors.some((e) => e.includes('message type') || e.includes('Message type')));
+});
+
+test('create form validation — invalid audience rejected', () => {
+  const errors = validateCreateForm({ title: 'Hello', body_text: 'text', message_type: 'announcement', audience: 'everyone', severity_token: 'info' });
+  assert.ok(errors.some((e) => e.includes('audience') || e.includes('Audience')));
+});
+
+test('create form validation — invalid severity rejected', () => {
+  const errors = validateCreateForm({ title: 'Hello', body_text: 'text', message_type: 'announcement', audience: 'internal', severity_token: 'critical' });
+  assert.ok(errors.some((e) => e.includes('severity') || e.includes('Severity')));
+});
+
+test('create form validation — valid form has no errors', () => {
+  const errors = validateCreateForm({ title: 'Hello', body_text: 'text', message_type: 'announcement', audience: 'internal', severity_token: 'info' });
+  assert.equal(errors.length, 0);
+});
+
+// Pure validation function mirroring MarketingCreateForm logic.
+function validateCreateForm({ title, body_text, message_type, audience, severity_token }) {
+  const errors = [];
+  const MESSAGE_TYPES = ['announcement', 'maintenance'];
+  const AUDIENCE_VALUES = ['internal', 'demo', 'all_signed_in'];
+  const SEVERITY_TOKENS = ['info', 'warning'];
+  if (!title || !title.trim()) errors.push('Title is required.');
+  if (!body_text || !body_text.trim()) errors.push('Body text is required.');
+  if (!MESSAGE_TYPES.includes(message_type)) errors.push('Message type must be "announcement" or "maintenance".');
+  if (!AUDIENCE_VALUES.includes(audience)) errors.push('Audience must be "internal", "demo", or "all_signed_in".');
+  if (!SEVERITY_TOKENS.includes(severity_token)) errors.push('Severity must be "info" or "warning".');
+  return errors;
+}
+
+// ---------------------------------------------------------------------------
+// 5. Broad-publish confirmation logic
+// ---------------------------------------------------------------------------
+
+test('broad-publish — required for all_signed_in on publish', () => {
+  const needsConfirm = shouldRequireBroadPublishConfirm('all_signed_in', 'published');
+  assert.equal(needsConfirm, true);
+});
+
+test('broad-publish — required for all_signed_in on scheduled', () => {
+  const needsConfirm = shouldRequireBroadPublishConfirm('all_signed_in', 'scheduled');
+  assert.equal(needsConfirm, true);
+});
+
+test('broad-publish — NOT required for internal audience on publish', () => {
+  const needsConfirm = shouldRequireBroadPublishConfirm('internal', 'published');
+  assert.equal(needsConfirm, false);
+});
+
+test('broad-publish — NOT required for demo audience on publish', () => {
+  const needsConfirm = shouldRequireBroadPublishConfirm('demo', 'published');
+  assert.equal(needsConfirm, false);
+});
+
+test('broad-publish — NOT required for all_signed_in on archive', () => {
+  const needsConfirm = shouldRequireBroadPublishConfirm('all_signed_in', 'archived');
+  assert.equal(needsConfirm, false);
+});
+
+test('broad-publish — NOT required for all_signed_in on pause', () => {
+  const needsConfirm = shouldRequireBroadPublishConfirm('all_signed_in', 'paused');
+  assert.equal(needsConfirm, false);
+});
+
+// Pure function mirroring AdminMarketingSection logic.
+function shouldRequireBroadPublishConfirm(audience, targetAction) {
+  return (targetAction === 'published' || targetAction === 'scheduled') && audience === 'all_signed_in';
+}
+
+// ---------------------------------------------------------------------------
+// 6. CAS conflict handling
+// ---------------------------------------------------------------------------
+
+test('CAS conflict — 409 status maps to stale-message error', () => {
+  const err = { status: 409, code: 'marketing_message_stale', message: 'Stale' };
+  const isCasConflict = err.status === 409 || err.code === 'marketing_message_stale';
+  assert.equal(isCasConflict, true);
+});
+
+test('CAS conflict — non-409 status is not a CAS conflict', () => {
+  const err = { status: 400, code: 'validation_failed', message: 'Bad request' };
+  const isCasConflict = err.status === 409 || err.code === 'marketing_message_stale';
+  assert.equal(isCasConflict, false);
+});
+
+// ---------------------------------------------------------------------------
+// 7. Ops role — read-only check
+// ---------------------------------------------------------------------------
+
+test('ops role — isAdmin is false for ops platform role', () => {
+  const role = 'ops';
+  const isAdmin = role.toLowerCase() === 'admin';
+  assert.equal(isAdmin, false);
+});
+
+test('ops role — isAdmin is true for admin platform role', () => {
+  const role = 'admin';
+  const isAdmin = role.toLowerCase() === 'admin';
+  assert.equal(isAdmin, true);
+});
+
+test('ops role — isAdmin is false for parent platform role', () => {
+  const role = 'parent';
+  const isAdmin = role.toLowerCase() === 'admin';
+  assert.equal(isAdmin, false);
+});
+
+// ---------------------------------------------------------------------------
+// 8. End-to-end lifecycle simulation: create → schedule → publish → pause → archive
+// ---------------------------------------------------------------------------
+
+test('end-to-end lifecycle — full state machine traversal via mock API', async () => {
+  let currentMessage = null;
+  let rowVersion = 0;
+
+  // Simulate the full lifecycle through the API client
+  const mockFetch = (url, init) => {
+    const body = init.body ? JSON.parse(init.body) : {};
+
+    // POST = create
+    if (init.method === 'POST') {
+      currentMessage = {
+        id: 'lifecycle-msg',
+        title: body.title,
+        body_text: body.body_text,
+        message_type: body.message_type || 'announcement',
+        status: 'draft',
+        severity_token: body.severity_token || 'info',
+        audience: body.audience || 'internal',
+        starts_at: null,
+        ends_at: null,
+        created_by: 'test-admin',
+        updated_by: 'test-admin',
+        published_by: null,
+        created_at: Date.now(),
+        updated_at: Date.now(),
+        published_at: null,
+        row_version: 0,
+      };
+      rowVersion = 0;
+      return Promise.resolve(new Response(
+        JSON.stringify({ ok: true, message: currentMessage }),
+        { status: 201, headers: { 'content-type': 'application/json' } },
+      ));
+    }
+
+    // PUT with action = lifecycle transition
+    if (init.method === 'PUT' && body.action) {
+      if (body.expectedRowVersion !== rowVersion) {
+        return Promise.resolve(new Response(
+          JSON.stringify({ message: 'Stale', code: 'marketing_message_stale' }),
+          { status: 409, headers: { 'content-type': 'application/json' } },
+        ));
+      }
+      rowVersion += 1;
+      currentMessage = {
+        ...currentMessage,
+        status: body.action,
+        row_version: rowVersion,
+        updated_at: Date.now(),
+      };
+      if (body.action === 'published') {
+        currentMessage.published_by = 'test-admin';
+        currentMessage.published_at = Date.now();
+      }
+      return Promise.resolve(new Response(
+        JSON.stringify({ ok: true, message: currentMessage }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ));
+    }
+
+    // GET = list
+    return Promise.resolve(new Response(
+      JSON.stringify({ ok: true, messages: currentMessage ? [currentMessage] : [] }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    ));
+  };
+
+  const api = createAdminMarketingApi({ fetch: mockFetch });
+
+  // Step 1: Create
+  const createResult = await api.createMarketingMessage({
+    title: 'Lifecycle test',
+    body_text: 'Testing the full lifecycle.',
+    message_type: 'announcement',
+    audience: 'internal',
+    severity_token: 'info',
+  });
+  const created = normaliseMarketingMessage(createResult.message);
+  assert.equal(created.status, 'draft');
+  assert.equal(created.row_version, 0);
+
+  // Step 2: Schedule (draft → scheduled)
+  const scheduleResult = await api.transitionMarketingMessage('lifecycle-msg', {
+    action: 'scheduled',
+    expectedRowVersion: 0,
+    mutation: { requestId: 'req-schedule' },
+  });
+  const scheduled = normaliseMarketingMessage(scheduleResult.message);
+  assert.equal(scheduled.status, 'scheduled');
+  assert.equal(scheduled.row_version, 1);
+
+  // Step 3: Publish (scheduled → published)
+  const publishResult = await api.transitionMarketingMessage('lifecycle-msg', {
+    action: 'published',
+    expectedRowVersion: 1,
+    mutation: { requestId: 'req-publish' },
+  });
+  const published = normaliseMarketingMessage(publishResult.message);
+  assert.equal(published.status, 'published');
+  assert.equal(published.row_version, 2);
+  assert.ok(published.published_at > 0);
+
+  // Step 4: Pause (published → paused)
+  const pauseResult = await api.transitionMarketingMessage('lifecycle-msg', {
+    action: 'paused',
+    expectedRowVersion: 2,
+    mutation: { requestId: 'req-pause' },
+  });
+  const paused = normaliseMarketingMessage(pauseResult.message);
+  assert.equal(paused.status, 'paused');
+  assert.equal(paused.row_version, 3);
+
+  // Step 5: Archive (paused → archived)
+  const archiveResult = await api.transitionMarketingMessage('lifecycle-msg', {
+    action: 'archived',
+    expectedRowVersion: 3,
+    mutation: { requestId: 'req-archive' },
+  });
+  const archived = normaliseMarketingMessage(archiveResult.message);
+  assert.equal(archived.status, 'archived');
+  assert.equal(archived.row_version, 4);
+});
+
+test('end-to-end lifecycle — CAS conflict on stale expectedRowVersion', async () => {
+  let rowVersion = 2;
+  const mockFetch = (url, init) => {
+    const body = init.body ? JSON.parse(init.body) : {};
+    if (init.method === 'PUT' && body.action) {
+      if (body.expectedRowVersion !== rowVersion) {
+        return Promise.resolve(new Response(
+          JSON.stringify({ message: 'Stale', code: 'marketing_message_stale' }),
+          { status: 409, headers: { 'content-type': 'application/json' } },
+        ));
+      }
+      rowVersion += 1;
+      return Promise.resolve(new Response(
+        JSON.stringify({ ok: true, message: { id: 'msg-1', status: body.action, row_version: rowVersion } }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ));
+    }
+    return Promise.resolve(new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } }));
+  };
+
+  const api = createAdminMarketingApi({ fetch: mockFetch });
+
+  // Attempt with stale version (0 instead of 2)
+  try {
+    await api.transitionMarketingMessage('msg-1', {
+      action: 'paused',
+      expectedRowVersion: 0,
+      mutation: { requestId: 'req-stale' },
+    });
+    assert.fail('Should have thrown CAS conflict');
+  } catch (err) {
+    assert.equal(err.status, 409);
+    assert.equal(err.code, 'marketing_message_stale');
+  }
+
+  // Retry with correct version succeeds
+  const result = await api.transitionMarketingMessage('msg-1', {
+    action: 'paused',
+    expectedRowVersion: 2,
+    mutation: { requestId: 'req-correct' },
+  });
+  assert.equal(result.message.status, 'paused');
+});
+
+// ---------------------------------------------------------------------------
+// 9. API client baseUrl handling
+// ---------------------------------------------------------------------------
+
+test('createAdminMarketingApi — baseUrl is prepended to paths', async () => {
+  let capturedUrl = '';
+  const mockFetch = (url) => {
+    capturedUrl = url;
+    return Promise.resolve(new Response(
+      JSON.stringify({ ok: true, messages: [] }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    ));
+  };
+  const api = createAdminMarketingApi({ fetch: mockFetch, baseUrl: 'https://api.example.com' });
+  await api.fetchMarketingMessages();
+  assert.ok(capturedUrl.startsWith('https://api.example.com/'));
+  assert.ok(capturedUrl.includes('/api/admin/marketing/messages'));
+});
+
+test('createAdminMarketingApi — default empty baseUrl uses relative paths', async () => {
+  let capturedUrl = '';
+  const mockFetch = (url) => {
+    capturedUrl = url;
+    return Promise.resolve(new Response(
+      JSON.stringify({ ok: true, messages: [] }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    ));
+  };
+  const api = createAdminMarketingApi({ fetch: mockFetch });
+  await api.fetchMarketingMessages();
+  assert.equal(capturedUrl, '/api/admin/marketing/messages');
+});


### PR DESCRIPTION
## Summary
- Replace the 18-line "Coming soon" Marketing placeholder with a fully wired section that lazy-loads messages on tab activation via `createAdminMarketingApi()` and manages its own local state (no new store/dispatcher actions)
- API client (`admin-marketing-api.js`) wraps all 5 backend routes (list, create, get, field update, lifecycle transition) with same-origin auth session cookies and CAS `expectedRowVersion` on every mutation
- Component provides message list with status badges, create form with client-side validation, lifecycle transition buttons derived from `VALID_TRANSITIONS` map, broad-publish confirmation dialog for `all_signed_in` audience on `published`/`scheduled` transitions, CAS conflict handling with clear "updated by another session" error, XSS-safe body_text preview via `renderRestrictedMarkdown()`, and ops role read-only gating
- Hub wiring: `AdminSectionTabs` removes `comingSoon` flag; `AdminHubSurface` passes `accessContext` with platform role for admin/ops gating
- Read model: `normaliseMarketingMessage()` added to `admin-read-model.js` for defensive client-side normalisation

## Files changed
| File | Change |
|------|--------|
| `src/platform/hubs/admin-marketing-api.js` | **New** — fetch wrappers for 5 marketing routes |
| `src/platform/hubs/admin-read-model.js` | Add `normaliseMarketingMessage()` normaliser |
| `src/surfaces/hubs/AdminMarketingSection.jsx` | Replace placeholder with full Marketing section |
| `src/surfaces/hubs/AdminSectionTabs.jsx` | Remove `comingSoon: true` from marketing tab |
| `src/surfaces/hubs/AdminHubSurface.jsx` | Pass `accessContext` + refresh callback to Marketing |
| `tests/admin-marketing-section.test.js` | **New** — 36 tests |

## Test plan
- [x] 36 new tests pass: normaliser, API client, form validation, broad-publish, CAS conflict, ops read-only, end-to-end lifecycle
- [x] Existing admin tests unaffected (83 pass, 0 fail)
- [ ] Manual: navigate to Marketing tab as admin, verify message list loads
- [ ] Manual: create message, verify it appears in list as draft
- [ ] Manual: walk full lifecycle: draft → schedule → publish → pause → archive
- [ ] Manual: verify ops role sees read-only list (no create/transition buttons)
- [ ] Manual: verify broad-publish dialog appears for all_signed_in audience