### PR TITLE
feat(punctuation): clarify landing metric as Grand Stars (P7-U7)

### DIFF
--- a/src/subjects/punctuation/components/PunctuationSetupScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationSetupScene.jsx
@@ -261,14 +261,13 @@ export function PunctuationSetupScene({ ui, actions, prefs, stats, learner, rewa
   // Progress row values
   const dueCount = Number(stats?.due) || 0;
   const weakCount = Number(stats?.weak) || 0;
-  // U3 review follow-up (HIGH 1): use displayStars (monotonic) for the
-  // aggregate, matching MonsterStarMeter which already reads displayStars.
-  // Prior code used raw totalStars, causing a mismatch between the
-  // progress-row aggregate and the individual meter values after evidence
-  // lapse.
-  const totalStarsEarned = dashboard.activeMonsters.reduce(
-    (sum, m) => sum + (m.displayStars ?? m.totalStars ?? 0), 0,
-  );
+  // P7-U7: replaced the ambiguous "Stars earned" aggregate (which summed
+  // direct monster Stars + Grand Stars into one confusing number) with
+  // Quoral's Grand Stars — the cross-monster overall progress metric.
+  // Individual monster meters already show per-monster Star totals, so
+  // the aggregate was redundant. Grand Stars is the only metric that
+  // represents whole-subject progress without double-counting.
+  const grandStars = dashboard.grandStars;
 
   const learnerName = learner && typeof learner === 'object' && !Array.isArray(learner)
     && typeof learner.name === 'string' && learner.name.trim()
@@ -334,9 +333,9 @@ export function PunctuationSetupScene({ ui, actions, prefs, stats, learner, rewa
             <dt>Wobbly</dt>
             <dd>{weakCount}</dd>
           </div>
-          <div className="punctuation-progress-item">
-            <dt>Stars earned</dt>
-            <dd>{totalStarsEarned}</dd>
+          <div className="punctuation-progress-item" data-metric="grand-stars">
+            <dt>Grand Stars</dt>
+            <dd>{grandStars}</dd>
           </div>
         </dl>
       </section>

--- a/src/subjects/punctuation/components/PunctuationSetupScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationSetupScene.jsx
@@ -5,7 +5,7 @@
 // Bellstorm Coast. Layout:
 //
 //   Hero: Bellstorm Coast backdrop + headline + primary CTA
-//   Progress row: Due today | Wobbly | Stars earned (compact)
+//   Progress row: Due today | Wobbly | Grand Stars (compact)
 //   Monster row: 4 active monsters with star meters (X / 100 Stars)
 //     and stage labels (Not caught / Egg Found / Hatch / Evolve / Strong / Mega)
 //   Map link: "Open Punctuation Map"

--- a/src/subjects/punctuation/components/punctuation-view-model.js
+++ b/src/subjects/punctuation/components/punctuation-view-model.js
@@ -1197,6 +1197,7 @@ function activeMonsterProgressFromReward(rewardState, starView) {
  *     activeMonsters:  Frozen array of { id, name, mastered },
  *     primaryMode:     string,  // normalised via punctuationPrimaryModeFromPrefs
  *     isEmpty:         boolean, // true when every Today count is zero
+ *     grandStars:      number,  // Quoral Grand Stars (P7-U7)
  *   }
  */
 export function buildPunctuationDashboardModel(stats, learner, rewardState, starView) {
@@ -1226,11 +1227,22 @@ export function buildPunctuationDashboardModel(stats, learner, rewardState, star
   // Fresh learner: zero attempts, zero secure units, zero wobbly, zero due.
   const isEmpty = (dueCount + weakCount + secureCount + accuracyValue) === 0;
 
+  const activeMonsters = Object.freeze(activeMonsterProgressFromReward(rewardState, starView));
+
+  // P7-U7: extract Quoral's Grand Stars for the progress row. The previous
+  // aggregate summed direct monster Stars + Grand Stars into one ambiguous
+  // number. Now the progress row shows Quoral Grand Stars only — overall
+  // cross-monster progress. Individual monster meters already carry per-
+  // monster Star totals, so the aggregate is redundant and confusing.
+  const quoralEntry = activeMonsters.find((m) => m.id === 'quoral');
+  const grandStars = quoralEntry ? (quoralEntry.displayStars ?? quoralEntry.totalStars ?? 0) : 0;
+
   return {
     todayCards,
-    activeMonsters: Object.freeze(activeMonsterProgressFromReward(rewardState, starView)),
+    activeMonsters,
     primaryMode,
     isEmpty,
+    grandStars,
   };
 }
 

--- a/tests/punctuation-view-model.test.js
+++ b/tests/punctuation-view-model.test.js
@@ -577,6 +577,8 @@ test('U1 view-model: buildPunctuationDashboardModel returns safe empty shape on 
   assert.equal(Array.isArray(model.activeMonsters), true);
   assert.equal(model.activeMonsters.length, 4);
   assert.equal(model.primaryMode, 'smart');
+  // P7-U7: grandStars field defaults to 0 for fresh learner.
+  assert.equal(model.grandStars, 0);
 });
 
 test('U1 view-model: buildPunctuationDashboardModel surfaces non-zero stats', () => {
@@ -1303,4 +1305,63 @@ test('U3 view-model: all four monsters receive displayStage and displayStars fie
     assert.ok(monster.displayStage >= 0, `${monster.id} displayStage must be >= 0`);
     assert.ok(monster.displayStars >= 0, `${monster.id} displayStars must be >= 0`);
   }
+});
+
+// ---------------------------------------------------------------------------
+// P7-U7 — Landing QoL metric clarification: Grand Stars replaces ambiguous
+// aggregate. The progress row now shows Quoral's Grand Stars (cross-monster
+// overall progress) instead of the sum of all direct + grand Stars.
+// ---------------------------------------------------------------------------
+
+test('P7-U7: grandStars equals Quoral displayStars from starView', () => {
+  const rewardState = {
+    quoral: { mastered: ['m1'], starHighWater: 30 },
+  };
+  const starView = {
+    perMonster: {
+      pealark: { total: 22, starDerivedStage: 1 },
+      claspin: { total: 10, starDerivedStage: 1 },
+    },
+    grand: { grandStars: 25, total: 100, starDerivedStage: 1 },
+  };
+  const model = buildPunctuationDashboardModel({}, null, rewardState, starView);
+  // grandStars = max(grandStars 25, starHighWater 30) = 30 (monotonic merge)
+  assert.equal(model.grandStars, 30, 'grandStars should reflect monotonic Quoral displayStars');
+  // Verify it does NOT equal the sum of all monsters.
+  const allStarsSum = model.activeMonsters.reduce(
+    (sum, m) => sum + (m.displayStars ?? m.totalStars ?? 0), 0,
+  );
+  assert.notEqual(model.grandStars, allStarsSum, 'grandStars must not be the ambiguous all-monster sum');
+});
+
+test('P7-U7: grandStars is 0 for a fresh learner with no starView', () => {
+  const model = buildPunctuationDashboardModel({}, null, {}, null);
+  assert.equal(model.grandStars, 0, 'fresh learner grandStars must be 0');
+});
+
+test('P7-U7: grandStars uses monotonic displayStars (starHighWater wins over live)', () => {
+  const rewardState = {
+    quoral: { mastered: ['m1'], starHighWater: 50 },
+  };
+  const starView = {
+    perMonster: {},
+    grand: { grandStars: 35, total: 100, starDerivedStage: 2 },
+  };
+  const model = buildPunctuationDashboardModel({}, null, rewardState, starView);
+  // starHighWater 50 > live grandStars 35
+  assert.equal(model.grandStars, 50, 'grandStars should use the monotonic high-water mark');
+});
+
+test('P7-U7: grandStars does not include direct monster Stars (Pealark only has Stars)', () => {
+  // Scenario: Pealark has 40 Stars, Quoral grand has 5 Grand Stars.
+  // grandStars should be 5, NOT 45.
+  const rewardState = {};
+  const starView = {
+    perMonster: {
+      pealark: { total: 40, starDerivedStage: 2 },
+    },
+    grand: { grandStars: 5, total: 100, starDerivedStage: 0 },
+  };
+  const model = buildPunctuationDashboardModel({}, null, rewardState, starView);
+  assert.equal(model.grandStars, 5, 'grandStars must be Quoral-only, not include direct monster Stars');
 });

--- a/tests/react-punctuation-scene.test.js
+++ b/tests/react-punctuation-scene.test.js
@@ -3044,6 +3044,97 @@ test('punctuation Setup scene: fresh learner renders zero-state progress row (gu
   assert.match(html, /Find your first punctuation egg/, 'fresh learner CTA');
 });
 
+// ---------------------------------------------------------------------------
+// P7-U7 — Landing QoL metric clarification: Grand Stars replaces the
+// ambiguous "Stars earned" aggregate. The progress row now shows Quoral's
+// Grand Stars (cross-monster overall progress) instead of the sum of
+// all direct + grand Stars.
+// ---------------------------------------------------------------------------
+
+test('P7-U7: progress row shows "Grand Stars" label, not "Stars earned"', () => {
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  const html = harness.render();
+
+  // The ambiguous aggregate label must not appear.
+  assert.doesNotMatch(html, /Stars earned/, 'ambiguous "Stars earned" aggregate must not appear');
+  // The progress row shows "Grand Stars" instead.
+  assert.match(html, /Grand Stars/, 'progress row must display "Grand Stars" label');
+  // The data-metric landmark is present for journey spec testing.
+  assert.match(html, /data-metric="grand-stars"/, 'grand-stars data-metric landmark present');
+});
+
+test('P7-U7: fresh learner sees Grand Stars = 0 in the progress row', () => {
+  const harness = createPunctuationHarness();
+  harness.dispatch('open-subject', { subjectId: 'punctuation' });
+  const html = harness.render();
+
+  // The Grand Stars metric should show 0 for a fresh learner.
+  assert.match(html, /Grand Stars/, 'Grand Stars label renders');
+  // Layout skeleton unchanged — same data-section landmarks.
+  assert.match(html, /data-section="progress-row"/, 'progress row present');
+  assert.match(html, /data-section="monster-row"/, 'monster row present');
+});
+
+test('P7-U7: post-session learner sees Grand Stars consistent with Quoral meter', async () => {
+  const { renderPunctuationSetupSceneStandalone } = await import(
+    './helpers/punctuation-scene-render.js'
+  );
+  const html = renderPunctuationSetupSceneStandalone({
+    ui: {
+      availability: { status: 'ready' },
+      starView: {
+        perMonster: {
+          pealark: { total: 30, starDerivedStage: 2 },
+          claspin: { total: 15, starDerivedStage: 1 },
+          curlune: { total: 10, starDerivedStage: 1 },
+        },
+        grand: { grandStars: 8, starDerivedStage: 0, total: 100 },
+      },
+    },
+    actions: { dispatch: () => {}, updateSubjectUi: () => {} },
+    prefs: { mode: 'smart', roundLength: '4' },
+    stats: { total: 14, secure: 3, due: 2, weak: 1, fresh: 8, attempts: 20, correct: 15, accuracy: 75 },
+    learner: { id: 'test', name: 'Tester' },
+    rewardState: {},
+  });
+
+  // "Grand Stars" label rendered — not "Stars earned".
+  assert.match(html, /Grand Stars/, 'Grand Stars label renders post-session');
+  assert.doesNotMatch(html, /Stars earned/, '"Stars earned" must not appear post-session');
+  // Quoral meter uses "Grand Stars" label (the MonsterStarMeter already does this).
+  assert.match(html, /8 \/ 100 Grand Stars/, 'Quoral meter shows Grand Stars count');
+  // Layout skeleton same as fresh learner.
+  assert.match(html, /data-section="progress-row"/, 'progress row present post-session');
+  assert.match(html, /data-section="monster-row"/, 'monster row present post-session');
+});
+
+test('P7-U7: Quoral meter is visually distinct with "Grand Stars" vs direct monster "Stars"', async () => {
+  const { renderPunctuationSetupSceneStandalone } = await import(
+    './helpers/punctuation-scene-render.js'
+  );
+  const html = renderPunctuationSetupSceneStandalone({
+    ui: {
+      availability: { status: 'ready' },
+      starView: {
+        perMonster: {
+          pealark: { total: 20, starDerivedStage: 1 },
+        },
+        grand: { grandStars: 5, starDerivedStage: 0, total: 100 },
+      },
+    },
+    actions: { dispatch: () => {}, updateSubjectUi: () => {} },
+    prefs: { mode: 'smart', roundLength: '4' },
+    stats: {},
+    learner: { id: 'test' },
+    rewardState: {},
+  });
+
+  // Direct monsters show "Stars", Quoral shows "Grand Stars".
+  assert.match(html, /20 \/ 100 Stars/, 'direct monster shows "Stars"');
+  assert.match(html, /5 \/ 100 Grand Stars/, 'Quoral shows "Grand Stars"');
+});
+
 test('punctuation Setup scene: reserved monster ids NEVER appear in the active monster strip', () => {
   // Smuggle reserved monster entries into the reward state. The
   // iterator is `ACTIVE_PUNCTUATION_MONSTER_IDS` only (plan R10), so


### PR DESCRIPTION
## Summary

- Replace the ambiguous "Stars earned" aggregate in the progress row with Quoral's **Grand Stars** — the cross-monster overall progress metric
- The old aggregate summed direct monster Stars + Grand Stars into one number, making it unclear what it represented
- Individual monster meters already show per-monster Star totals, so the aggregate was redundant
- MonsterStarMeter already distinguishes "Grand Stars" (Quoral) from "Stars" (direct monsters) — no display change needed there

## Changes

- **View-model** (`punctuation-view-model.js`): `buildPunctuationDashboardModel` now exposes `grandStars` (Quoral's monotonic `displayStars`) instead of letting the scene sum all monsters
- **Scene** (`PunctuationSetupScene.jsx`): Progress row label changed from "Stars earned" to "Grand Stars" with a `data-metric="grand-stars"` landmark for journey spec testing
- **Tests**: 4 new view-model tests (Grand Stars value, fresh learner, monotonic merge, no direct-monster inclusion) + 4 new scene tests (label present, fresh learner, post-session consistency, Quoral visual distinction)

## Contract compliance (R7)

- Fresh learner, post-session, refresh, and return-from-map preserve the same page skeleton — only numbers update
- Quoral meter visually distinct from direct monster meters (uses "Grand Stars" label)
- Secondary actions remain secondary
- No test references ambiguous "Stars earned" aggregate

## Test plan

- [x] `tests/punctuation-view-model.test.js` — 111 pass (4 new P7-U7 tests)
- [x] `tests/react-punctuation-scene.test.js` — 168 pass (4 new P7-U7 tests)
- [x] No regressions in existing tests