### PR TITLE
feat(punctuation): star-evidence latch writer advances starHighWater on evidence change (P7-U4)

### DIFF
--- a/shared/punctuation/events.js
+++ b/shared/punctuation/events.js
@@ -7,6 +7,7 @@ export const PUNCTUATION_EVENT_TYPES = Object.freeze({
   UNIT_SECURED: 'punctuation.unit-secured',
   SESSION_COMPLETED: 'punctuation.session-completed',
   AVAILABILITY_DENIED: 'punctuation.availability-denied',
+  STAR_EVIDENCE_UPDATED: 'punctuation.star-evidence-updated',
 });
 
 function safeTimestamp(value) {

--- a/src/platform/game/mastery/index.js
+++ b/src/platform/game/mastery/index.js
@@ -20,6 +20,7 @@ export {
   progressForPunctuationMonster,
   punctuationMonsterSummaryFromState,
   recordPunctuationRewardUnitMastery,
+  updatePunctuationStarHighWater,
 } from './punctuation.js';
 export {
   GRAMMAR_AGGREGATE_CONCEPTS,

--- a/src/platform/game/mastery/punctuation.js
+++ b/src/platform/game/mastery/punctuation.js
@@ -354,6 +354,73 @@ export function recordPunctuationRewardUnitMastery({
   return events;
 }
 
+/**
+ * Lightweight latch-write for sub-secure Star evidence.
+ *
+ * Updates `starHighWater = max(existing, computedStars)` on the specified
+ * monster only, without touching the `mastered[]` array (that stays exclusive
+ * to unit-secured via `recordPunctuationRewardUnitMastery`).
+ *
+ * The caller (event-hooks subscriber) is responsible for passing the correct
+ * `monsterId` from each `star-evidence-updated` event. The command handler
+ * emits one event per monster with monster-specific `computedStars`, so each
+ * call updates exactly one monster — preventing cross-inflation where a
+ * direct monster's higher Stars would overwrite Quoral's lower value.
+ *
+ * Also ratchets `maxStageEver = max(existing, derivedStage)` using the
+ * appropriate threshold table (GRAND for Quoral, STAR for direct monsters).
+ *
+ * Returns an array of reward events (empty — latch writes do NOT emit toast
+ * events; toast timing stays on reward-unit mastery only).
+ */
+export function updatePunctuationStarHighWater({
+  learnerId,
+  monsterId,
+  computedStars,
+  gameStateRepository,
+  random = Math.random,
+} = {}) {
+  const stars = Math.floor((Number(computedStars) || 0) + 1e-9);
+  if (stars < 1) return [];
+  if (!MONSTERS[monsterId]) return [];
+
+  const before = ensureMonsterBranches(learnerId, gameStateRepository, {
+    random,
+    monsterIds: PUNCTUATION_MONSTER_IDS,
+  });
+
+  const entry = isPlainObject(before[monsterId])
+    ? before[monsterId]
+    : { mastered: [], caught: false };
+  const existingHW = safeStarHighWater(entry.starHighWater);
+  if (stars <= existingHW) {
+    // No change needed — existing high-water already covers this update.
+    return [];
+  }
+
+  // Derive stage from the new starHighWater using the correct threshold table.
+  const thresholds = monsterId === PUNCTUATION_GRAND_MONSTER_ID
+    ? PUNCTUATION_GRAND_STAR_THRESHOLDS
+    : PUNCTUATION_STAR_THRESHOLDS;
+  const derivedStage = stageFor(stars, thresholds);
+  const existingMaxStage = Math.max(0, Math.floor(Number(entry.maxStageEver) || 0));
+
+  const after = {
+    ...before,
+    [monsterId]: {
+      ...entry,
+      starHighWater: stars,
+      maxStageEver: Math.max(existingMaxStage, derivedStage),
+    },
+  };
+
+  saveMonsterState(learnerId, after, gameStateRepository);
+
+  // Latch writes do NOT emit toast events — toast timing stays on
+  // reward-unit mastery only. Child-facing celebration timing is unchanged.
+  return [];
+}
+
 export function punctuationMonsterSummaryFromState(state = {}, { clusterTotals = {}, aggregateTotal = 1, releaseId = PUNCTUATION_CURRENT_RELEASE_ID } = {}) {
   return PUNCTUATION_MONSTER_IDS.map((monsterId) => ({
     subjectId: 'punctuation',

--- a/src/subjects/punctuation/event-hooks.js
+++ b/src/subjects/punctuation/event-hooks.js
@@ -3,7 +3,10 @@ import {
   PUNCTUATION_CONTENT_MANIFEST,
 } from '../../../shared/punctuation/content.js';
 import { PUNCTUATION_EVENT_TYPES } from '../../../shared/punctuation/events.js';
-import { recordPunctuationRewardUnitMastery } from '../../platform/game/monster-system.js';
+import {
+  recordPunctuationRewardUnitMastery,
+  updatePunctuationStarHighWater,
+} from '../../platform/game/monster-system.js';
 
 function clusterTotals(indexes) {
   const totals = {};
@@ -27,7 +30,24 @@ export function createPunctuationRewardSubscriber({
   return function punctuationRewardSubscriber(events = []) {
     const rewardEvents = [];
     for (const event of Array.isArray(events) ? events : []) {
-      if (!event || event.type !== PUNCTUATION_EVENT_TYPES.UNIT_SECURED) continue;
+      if (!event) continue;
+
+      if (event.type === PUNCTUATION_EVENT_TYPES.STAR_EVIDENCE_UPDATED) {
+        const computedStars = Number(event.computedStars);
+        if (!event.monsterId || !Number.isFinite(computedStars) || computedStars < 1) continue;
+        rewardEvents.push(
+          ...updatePunctuationStarHighWater({
+            learnerId: event.learnerId,
+            monsterId: event.monsterId,
+            computedStars,
+            gameStateRepository,
+            random,
+          }),
+        );
+        continue;
+      }
+
+      if (event.type !== PUNCTUATION_EVENT_TYPES.UNIT_SECURED) continue;
       const unit = indexes.rewardUnitByKey.get(event.masteryKey)
         || indexes.rewardUnitById.get(event.rewardUnitId);
       const cluster = indexes.clusterById.get(event.clusterId || unit?.clusterId);

--- a/tests/punctuation-mastery.test.js
+++ b/tests/punctuation-mastery.test.js
@@ -16,6 +16,7 @@ import {
   progressForPunctuationMonster,
   recordPunctuationRewardUnitMastery,
   punctuationMonsterSummaryFromState,
+  updatePunctuationStarHighWater,
 } from '../src/platform/game/monster-system.js';
 import { monsterSummaryFromState } from '../src/platform/game/mastery/spelling.js';
 
@@ -1278,4 +1279,369 @@ test('ADV-U8-1: Pealark (direct) starHighWater=28 -> starStage 1 (STAR threshold
   const progress = progressForPunctuationMonster(state, 'pealark', { publishedTotal: 5 });
   assert.equal(progress.starStage, 1,
     'Pealark starHighWater=28 must remain stage 1 via STAR thresholds (28 < 30)');
+});
+
+// ---------------------------------------------------------------------------
+// 12. P7-U4: updatePunctuationStarHighWater — star-evidence latch writer
+// ---------------------------------------------------------------------------
+
+test('P7-U4: updatePunctuationStarHighWater advances starHighWater from 3 to 8', () => {
+  // Learner completes practice items (no unit secured) -> starHighWater advances.
+  const repository = makeRepository({
+    pealark: {
+      mastered: [],
+      caught: false,
+      publishedTotal: 5,
+      starHighWater: 3,
+      branch: 'b1',
+    },
+    quoral: {
+      mastered: [],
+      caught: false,
+      publishedTotal: 14,
+      starHighWater: 0,
+      branch: 'b1',
+    },
+  });
+  const events = updatePunctuationStarHighWater({
+    learnerId: 'learner-u4-1',
+    monsterId: 'pealark',
+    computedStars: 8,
+    gameStateRepository: repository,
+    random: () => 0,
+  });
+  const state = repository.state();
+  assert.equal(state.pealark.starHighWater, 8, 'starHighWater must advance from 3 to 8');
+  assert.deepEqual(events, [], 'latch writes must NOT emit toast events');
+});
+
+test('P7-U4: computedStars equals starHighWater -> no latch write', () => {
+  // Provide all 4 monster entries with branches to avoid ensureMonsterBranches writes.
+  const repository = makeRepository({
+    pealark: {
+      mastered: [masteryKey('endmarks', 'sentence-endings-core')],
+      caught: true,
+      publishedTotal: 5,
+      starHighWater: 15,
+      branch: 'b1',
+    },
+    claspin: { mastered: [], caught: false, branch: 'b1' },
+    curlune: { mastered: [], caught: false, branch: 'b1' },
+    quoral: {
+      mastered: [masteryKey('endmarks', 'sentence-endings-core')],
+      caught: true,
+      publishedTotal: 14,
+      starHighWater: 15,
+      branch: 'b1',
+    },
+  });
+  const events = updatePunctuationStarHighWater({
+    learnerId: 'learner-u4-2',
+    monsterId: 'pealark',
+    computedStars: 15,
+    gameStateRepository: repository,
+    random: () => 0,
+  });
+  assert.deepEqual(events, [], 'equal stars must not produce events');
+  assert.equal(repository.writes(), 0, 'repository must not be written when stars <= HW');
+});
+
+test('P7-U4: computedStars below starHighWater -> no latch write', () => {
+  // Provide all 4 monster entries with branches to avoid ensureMonsterBranches writes.
+  const repository = makeRepository({
+    pealark: {
+      mastered: [],
+      caught: false,
+      publishedTotal: 5,
+      starHighWater: 20,
+      branch: 'b1',
+    },
+    claspin: { mastered: [], caught: false, branch: 'b1' },
+    curlune: { mastered: [], caught: false, branch: 'b1' },
+    quoral: {
+      mastered: [],
+      caught: false,
+      publishedTotal: 14,
+      branch: 'b1',
+    },
+  });
+  const events = updatePunctuationStarHighWater({
+    learnerId: 'learner-u4-3',
+    monsterId: 'pealark',
+    computedStars: 10,
+    gameStateRepository: repository,
+    random: () => 0,
+  });
+  assert.deepEqual(events, [], 'lower stars must not produce events');
+  assert.equal(repository.writes(), 0, 'repository must not be written when stars < HW');
+});
+
+test('P7-U4: Quoral uses GRAND thresholds for maxStageEver', () => {
+  // GRAND thresholds: [1, 10, 25, 50, 100]
+  // STAR thresholds:  [1, 10, 30, 60, 100]
+  // At 28 stars: GRAND -> stage 2 (28 >= 25), STAR -> stage 1 (28 < 30)
+  const repository = makeRepository({
+    pealark: {
+      mastered: [],
+      caught: false,
+      publishedTotal: 5,
+      branch: 'b1',
+    },
+    quoral: {
+      mastered: [],
+      caught: false,
+      publishedTotal: 14,
+      starHighWater: 0,
+      branch: 'b1',
+    },
+  });
+  updatePunctuationStarHighWater({
+    learnerId: 'learner-u4-4',
+    monsterId: 'quoral',
+    computedStars: 28,
+    gameStateRepository: repository,
+    random: () => 0,
+  });
+  const state = repository.state();
+  assert.equal(state.quoral.starHighWater, 28, 'starHighWater must be 28');
+  assert.equal(state.quoral.maxStageEver, 2,
+    'Quoral maxStageEver must be 2 via GRAND thresholds (28 >= 25), not 1');
+});
+
+test('P7-U4: direct monster uses STAR thresholds for maxStageEver', () => {
+  // At 28 stars: STAR thresholds -> stage 1 (28 < 30)
+  const repository = makeRepository({
+    pealark: {
+      mastered: [],
+      caught: false,
+      publishedTotal: 5,
+      starHighWater: 0,
+      branch: 'b1',
+    },
+    quoral: {
+      mastered: [],
+      caught: false,
+      publishedTotal: 14,
+      branch: 'b1',
+    },
+  });
+  updatePunctuationStarHighWater({
+    learnerId: 'learner-u4-5',
+    monsterId: 'pealark',
+    computedStars: 28,
+    gameStateRepository: repository,
+    random: () => 0,
+  });
+  const state = repository.state();
+  assert.equal(state.pealark.starHighWater, 28, 'starHighWater must be 28');
+  assert.equal(state.pealark.maxStageEver, 1,
+    'Pealark maxStageEver must be 1 via STAR thresholds (28 < 30)');
+});
+
+test('P7-U4: epsilon guard — 7.9999 floors to 7, no advance beyond existing HW of 7', () => {
+  // Provide all 4 monster entries with branches to avoid ensureMonsterBranches writes.
+  const repository = makeRepository({
+    pealark: {
+      mastered: [],
+      caught: false,
+      publishedTotal: 5,
+      starHighWater: 7,
+      branch: 'b1',
+    },
+    claspin: { mastered: [], caught: false, branch: 'b1' },
+    curlune: { mastered: [], caught: false, branch: 'b1' },
+    quoral: {
+      mastered: [],
+      caught: false,
+      publishedTotal: 14,
+      branch: 'b1',
+    },
+  });
+  // 7.9999 + 1e-9 = 7.9999000001 -> Math.floor = 7
+  // 7 is not > 7 -> no write.
+  updatePunctuationStarHighWater({
+    learnerId: 'learner-u4-6',
+    monsterId: 'pealark',
+    computedStars: 7.9999,
+    gameStateRepository: repository,
+    random: () => 0,
+  });
+  assert.equal(repository.writes(), 0, 'no write when floor(7.9999 + 1e-9) = 7 <= existing 7');
+  assert.equal(repository.state().pealark.starHighWater, 7, 'starHighWater unchanged');
+});
+
+test('P7-U4: epsilon guard — 7.999999999 rounds to 8 and advances', () => {
+  // Provide all 4 monster entries with branches to avoid ensureMonsterBranches writes.
+  const repository = makeRepository({
+    pealark: {
+      mastered: [],
+      caught: false,
+      publishedTotal: 5,
+      starHighWater: 7,
+      branch: 'b1',
+    },
+    claspin: { mastered: [], caught: false, branch: 'b1' },
+    curlune: { mastered: [], caught: false, branch: 'b1' },
+    quoral: {
+      mastered: [],
+      caught: false,
+      publishedTotal: 14,
+      branch: 'b1',
+    },
+  });
+  // 7.999999999 + 1e-9 = 8.000000000 -> floor = 8 > 7 -> should write.
+  updatePunctuationStarHighWater({
+    learnerId: 'learner-u4-7',
+    monsterId: 'pealark',
+    computedStars: 7.999999999,
+    gameStateRepository: repository,
+    random: () => 0,
+  });
+  const state = repository.state();
+  assert.equal(state.pealark.starHighWater, 8,
+    'starHighWater must advance to 8 (epsilon-guarded from 7.999999999)');
+});
+
+test('P7-U4: idempotent under retry — same computedStars twice produces single latch write', () => {
+  // Provide all 4 monster entries with branches to avoid ensureMonsterBranches writes.
+  const repository = makeRepository({
+    pealark: {
+      mastered: [],
+      caught: false,
+      publishedTotal: 5,
+      starHighWater: 5,
+      branch: 'b1',
+    },
+    claspin: { mastered: [], caught: false, branch: 'b1' },
+    curlune: { mastered: [], caught: false, branch: 'b1' },
+    quoral: {
+      mastered: [],
+      caught: false,
+      publishedTotal: 14,
+      branch: 'b1',
+    },
+  });
+  // First call: 5 -> 12
+  updatePunctuationStarHighWater({
+    learnerId: 'learner-u4-8',
+    monsterId: 'pealark',
+    computedStars: 12,
+    gameStateRepository: repository,
+    random: () => 0,
+  });
+  assert.equal(repository.writes(), 1, 'first call must write exactly once');
+  assert.equal(repository.state().pealark.starHighWater, 12);
+
+  // Second call (retry): same computedStars — should not write.
+  updatePunctuationStarHighWater({
+    learnerId: 'learner-u4-8',
+    monsterId: 'pealark',
+    computedStars: 12,
+    gameStateRepository: repository,
+    random: () => 0,
+  });
+  assert.equal(repository.writes(), 1, 'retry with same stars must not produce a second write');
+  assert.equal(repository.state().pealark.starHighWater, 12, 'starHighWater unchanged after retry');
+});
+
+test('P7-U4: maxStageEver ratchets — never decreases', () => {
+  const repository = makeRepository({
+    pealark: {
+      mastered: [],
+      caught: false,
+      publishedTotal: 5,
+      starHighWater: 0,
+      maxStageEver: 0,
+      branch: 'b1',
+    },
+    quoral: {
+      mastered: [],
+      caught: false,
+      publishedTotal: 14,
+      branch: 'b1',
+    },
+  });
+
+  // Advance to 35 stars -> stage 2 (STAR thresholds: 35 >= 30)
+  updatePunctuationStarHighWater({
+    learnerId: 'learner-u4-9',
+    monsterId: 'pealark',
+    computedStars: 35,
+    gameStateRepository: repository,
+    random: () => 0,
+  });
+  assert.equal(repository.state().pealark.maxStageEver, 2);
+
+  // Advance to 65 stars -> stage 3 (STAR thresholds: 65 >= 60)
+  updatePunctuationStarHighWater({
+    learnerId: 'learner-u4-9',
+    monsterId: 'pealark',
+    computedStars: 65,
+    gameStateRepository: repository,
+    random: () => 0,
+  });
+  assert.equal(repository.state().pealark.maxStageEver, 3);
+  assert.equal(repository.state().pealark.starHighWater, 65);
+});
+
+test('P7-U4: invalid monsterId -> returns empty, no crash', () => {
+  const repository = makeRepository();
+  const events = updatePunctuationStarHighWater({
+    learnerId: 'learner-u4-10',
+    monsterId: 'nonexistent-monster',
+    computedStars: 50,
+    gameStateRepository: repository,
+    random: () => 0,
+  });
+  assert.deepEqual(events, []);
+  assert.equal(repository.writes(), 0);
+});
+
+test('P7-U4: computedStars < 1 -> returns empty, no write', () => {
+  // computedStars: 0.5 -> floor(0.5 + 1e-9) = 0 < 1 -> early return.
+  const repository = makeRepository({
+    pealark: { mastered: [], caught: false, branch: 'b1' },
+    claspin: { mastered: [], caught: false, branch: 'b1' },
+    curlune: { mastered: [], caught: false, branch: 'b1' },
+    quoral: { mastered: [], caught: false, branch: 'b1' },
+  });
+  const events = updatePunctuationStarHighWater({
+    learnerId: 'learner-u4-11',
+    monsterId: 'pealark',
+    computedStars: 0.5,
+    gameStateRepository: repository,
+    random: () => 0,
+  });
+  assert.deepEqual(events, []);
+  // stars < 1 returns before ensureMonsterBranches, so truly 0 writes.
+  assert.equal(repository.writes(), 0);
+});
+
+test('P7-U4: monster-targeted — updating pealark does not touch quoral', () => {
+  const repository = makeRepository({
+    pealark: {
+      mastered: [],
+      caught: false,
+      publishedTotal: 5,
+      starHighWater: 5,
+      branch: 'b1',
+    },
+    quoral: {
+      mastered: [],
+      caught: false,
+      publishedTotal: 14,
+      starHighWater: 3,
+      branch: 'b1',
+    },
+  });
+  updatePunctuationStarHighWater({
+    learnerId: 'learner-u4-12',
+    monsterId: 'pealark',
+    computedStars: 20,
+    gameStateRepository: repository,
+    random: () => 0,
+  });
+  const state = repository.state();
+  assert.equal(state.pealark.starHighWater, 20, 'pealark advances');
+  assert.equal(state.quoral.starHighWater, 3, 'quoral unchanged by pealark update');
 });

--- a/tests/punctuation-star-parity-worker-backed.test.js
+++ b/tests/punctuation-star-parity-worker-backed.test.js
@@ -29,6 +29,9 @@ import {
   mergeMonotonicDisplay,
 } from '../src/subjects/punctuation/components/punctuation-view-model.js';
 import { stageFor, PUNCTUATION_STAR_THRESHOLDS } from '../src/platform/game/monsters.js';
+import { PUNCTUATION_EVENT_TYPES } from '../shared/punctuation/events.js';
+import { updatePunctuationStarHighWater } from '../src/platform/game/monster-system.js';
+import { createPunctuationRewardSubscriber } from '../src/subjects/punctuation/event-hooks.js';
 
 const CURRENT_RELEASE_ID = 'punctuation-r4-full-14-skill-structure';
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -474,6 +477,88 @@ test('negative: Worker forbidden-key scan passes on fresh/null data payload', ()
       data: null,
     });
   }, 'buildPunctuationReadModel must not throw on null data payload');
+});
+
+// ---------------------------------------------------------------------------
+// P7-U4: Star-evidence event derivation parity
+// ---------------------------------------------------------------------------
+
+test('P7-U4 parity: PUNCTUATION_EVENT_TYPES includes STAR_EVIDENCE_UPDATED', () => {
+  assert.equal(
+    PUNCTUATION_EVENT_TYPES.STAR_EVIDENCE_UPDATED,
+    'punctuation.star-evidence-updated',
+    'STAR_EVIDENCE_UPDATED must be defined in PUNCTUATION_EVENT_TYPES',
+  );
+});
+
+test('P7-U4 parity: updatePunctuationStarHighWater is exported from monster-system', () => {
+  assert.equal(typeof updatePunctuationStarHighWater, 'function',
+    'updatePunctuationStarHighWater must be exported from monster-system.js');
+});
+
+test('P7-U4 parity: event-hooks subscriber handles STAR_EVIDENCE_UPDATED events', () => {
+  // Create a subscriber with a mock repository.
+  let writesCalled = 0;
+  const mockRepo = {
+    read() { return { pealark: { mastered: [], caught: false, starHighWater: 5, branch: 'b1' }, quoral: { mastered: [], caught: false, branch: 'b1' } }; },
+    write(_id, _sys, state) { writesCalled++; return state; },
+  };
+
+  const subscriber = createPunctuationRewardSubscriber({
+    gameStateRepository: mockRepo,
+  });
+
+  // Send a star-evidence-updated event with computedStars > existing HW.
+  const events = subscriber([{
+    type: PUNCTUATION_EVENT_TYPES.STAR_EVIDENCE_UPDATED,
+    learnerId: 'test-learner-parity',
+    monsterId: 'pealark',
+    computedStars: 20,
+    createdAt: Date.now(),
+  }]);
+
+  // The subscriber should have called the mastery writer.
+  assert.ok(writesCalled > 0, 'subscriber must invoke updatePunctuationStarHighWater on STAR_EVIDENCE_UPDATED');
+  // latch writes return empty events (no toast).
+  assert.deepEqual(events, [], 'latch write must not emit toast events');
+});
+
+test('P7-U4 parity: event-hooks subscriber ignores STAR_EVIDENCE_UPDATED with invalid data', () => {
+  let writesCalled = 0;
+  const mockRepo = {
+    read() { return {}; },
+    write(_id, _sys, state) { writesCalled++; return state; },
+  };
+
+  const subscriber = createPunctuationRewardSubscriber({
+    gameStateRepository: mockRepo,
+  });
+
+  // Missing monsterId
+  subscriber([{
+    type: PUNCTUATION_EVENT_TYPES.STAR_EVIDENCE_UPDATED,
+    learnerId: 'test-learner-parity',
+    computedStars: 20,
+  }]);
+  assert.equal(writesCalled, 0, 'missing monsterId must not write');
+
+  // computedStars < 1
+  subscriber([{
+    type: PUNCTUATION_EVENT_TYPES.STAR_EVIDENCE_UPDATED,
+    learnerId: 'test-learner-parity',
+    monsterId: 'pealark',
+    computedStars: 0,
+  }]);
+  assert.equal(writesCalled, 0, 'computedStars < 1 must not write');
+
+  // NaN computedStars
+  subscriber([{
+    type: PUNCTUATION_EVENT_TYPES.STAR_EVIDENCE_UPDATED,
+    learnerId: 'test-learner-parity',
+    monsterId: 'pealark',
+    computedStars: NaN,
+  }]);
+  assert.equal(writesCalled, 0, 'NaN computedStars must not write');
 });
 
 // ---------------------------------------------------------------------------

--- a/worker/src/subjects/punctuation/commands.js
+++ b/worker/src/subjects/punctuation/commands.js
@@ -1,11 +1,18 @@
 import {
   PUNCTUATION_CONTENT_MANIFEST,
   PUNCTUATION_MANIFEST_VALIDATION,
+  PUNCTUATION_RELEASE_ID,
 } from '../../../../shared/punctuation/content.js';
+import { PUNCTUATION_EVENT_TYPES } from '../../../../shared/punctuation/events.js';
 import { NotFoundError } from '../../errors.js';
 import { combineCommandEvents } from '../../projections/events.js';
 import { buildCommandProjectionReadModel } from '../../projections/read-models.js';
 import { projectPunctuationRewards } from '../../projections/rewards.js';
+import { projectPunctuationStars } from '../../../../src/subjects/punctuation/star-projection.js';
+import {
+  ACTIVE_PUNCTUATION_MONSTER_IDS,
+  PUNCTUATION_GRAND_MONSTER_ID,
+} from '../../../../src/subjects/punctuation/punctuation-manifest.js';
 import { requestPunctuationContextPack } from './ai-enrichment.js';
 import { createServerPunctuationEngine } from './engine.js';
 import { buildPunctuationReadModel } from './read-models.js';
@@ -48,6 +55,64 @@ function contentMeta() {
         clusterId: skill.clusterId,
       })),
   };
+}
+
+/**
+ * Derives star-evidence-updated events for monsters affected by a command.
+ *
+ * Computes Stars from the post-command engine data via `projectPunctuationStars`.
+ * For each monster whose computed Stars exceed the current `starHighWater` from
+ * the persisted codex, emits a `punctuation.star-evidence-updated` event that
+ * the reward subscriber will handle to persist the latch.
+ *
+ * The engine remains Star-unaware; this derivation happens at the command
+ * handler layer, preserving the P5 architecture boundary.
+ */
+function deriveStarEvidenceEvents({ engineData, learnerId, gameState }) {
+  const progress = engineData?.progress;
+  if (!progress) return [];
+
+  const starLedger = projectPunctuationStars(progress, PUNCTUATION_RELEASE_ID);
+  if (!starLedger?.perMonster) return [];
+
+  const codexState = gameState || {};
+  const starEvents = [];
+
+  // Check each direct monster.
+  for (const monsterId of ACTIVE_PUNCTUATION_MONSTER_IDS) {
+    // For direct monsters read from perMonster; for grand (quoral) read from grand.
+    let liveStars;
+    if (monsterId === PUNCTUATION_GRAND_MONSTER_ID) {
+      liveStars = starLedger.grand?.grandStars ?? 0;
+    } else {
+      liveStars = starLedger.perMonster[monsterId]?.total ?? 0;
+    }
+
+    // IEEE 754 epsilon guard: floor with epsilon before comparison.
+    const computedStars = Math.floor(liveStars + 1e-9);
+    if (computedStars < 1) continue;
+
+    // Read current starHighWater from monster codex state.
+    const monsterEntry = codexState[monsterId];
+    const existingHW = monsterEntry && typeof monsterEntry === 'object'
+      ? Math.max(0, Math.floor((Number(monsterEntry.starHighWater) || 0) + 1e-9))
+      : 0;
+
+    if (computedStars > existingHW) {
+      starEvents.push({
+        id: `punctuation.star-evidence.${learnerId || 'learner'}.${monsterId}.${Date.now()}`,
+        type: PUNCTUATION_EVENT_TYPES.STAR_EVIDENCE_UPDATED,
+        subjectId: 'punctuation',
+        learnerId,
+        monsterId,
+        computedStars,
+        previousStarHighWater: existingHW,
+        createdAt: Date.now(),
+      });
+    }
+  }
+
+  return starEvents;
 }
 
 export function createPunctuationCommandHandlers({ now, random } = {}) {
@@ -117,18 +182,32 @@ export function createPunctuationCommandHandlers({ now, random } = {}) {
     const projectionState = projectionInput
       ? projectionInput.projectionState
       : { gameState: null, events: [] };
+    // P7-U4: derive star-evidence-updated events from the post-command
+    // engine data. These are injected into the domain event stream before
+    // the reward projection so the subscriber can persist starHighWater at
+    // evidence time rather than deferring to unit-secured.
+    const starEvidenceEvents = result.changed === false
+      ? []
+      : deriveStarEvidenceEvents({
+          engineData: result.data,
+          learnerId: command.learnerId,
+          gameState: projectionState.gameState?.['monster-codex'] || null,
+        });
+    const allDomainEvents = starEvidenceEvents.length
+      ? [...result.events, ...starEvidenceEvents]
+      : result.events;
     const projectedRewards = result.changed === false
       ? { gameState: projectionState.gameState, changedGameState: null, rewardEvents: [] }
       : projectPunctuationRewards({
           learnerId: command.learnerId,
-          domainEvents: result.events,
+          domainEvents: allDomainEvents,
           gameState: projectionState.gameState,
           random,
         });
     const projectedEvents = result.changed === false
       ? { events: [], domainEvents: [], reactionEvents: [], toastEvents: [] }
       : combineCommandEvents({
-          domainEvents: result.events,
+          domainEvents: allDomainEvents,
           reactionEvents: projectedRewards.rewardEvents,
           existingEvents: projectionState.events,
           seedTokens: projectionInput?.tokens || [],


### PR DESCRIPTION
## Summary
- Closes the gap where `starHighWater` only advances on reward-unit mastery events — the persisted latch now advances whenever live Star evidence increases, even without a new unit-secured event
- Follows the Grammar P6 `deriveStarEvidenceEvents` + `updateGrammarStarHighWater` pattern exactly: command handler derives events, mastery layer subscribes and ratchets
- Monster-targeted writes with epsilon guard (`Math.floor(n + 1e-9)`), no toast emission (toast timing stays on reward-unit mastery only)

## Changes
- **`shared/punctuation/events.js`** — add `STAR_EVIDENCE_UPDATED` to `PUNCTUATION_EVENT_TYPES`
- **`worker/src/subjects/punctuation/commands.js`** — add `deriveStarEvidenceEvents()` that computes star projection from post-command engine data and emits events when `liveStars > starHighWater` per monster
- **`src/subjects/punctuation/event-hooks.js`** — add `STAR_EVIDENCE_UPDATED` branch to `createPunctuationRewardSubscriber`
- **`src/platform/game/mastery/punctuation.js`** — add `updatePunctuationStarHighWater()` that ratchets `starHighWater` and `maxStageEver` with correct threshold tables (GRAND for Quoral, STAR for direct)
- **`src/platform/game/mastery/index.js`** — export `updatePunctuationStarHighWater`

## Test plan
- [x] 12 new mastery tests covering: latch advance, no-write when equal/lower, Quoral GRAND thresholds, direct STAR thresholds, epsilon guard, idempotent retry, maxStageEver ratchet, invalid inputs, monster-targeted isolation
- [x] 4 new parity tests: event type wiring, export verification, subscriber integration, invalid data rejection
- [x] All 154 punctuation tests pass (mastery + rewards + star-projection + parity)
- [x] All 53 worker runtime tests pass
- [x] All 228 wider punctuation tests pass (read-model, view-model, bundle audit, manifest drift)