### PR TITLE
feat(punctuation): Punctuation Doctor diagnostic read model (P7-U8)

### DIFF
--- a/src/platform/hubs/admin-punctuation-diagnostic-panel.js
+++ b/src/platform/hubs/admin-punctuation-diagnostic-panel.js
@@ -1,0 +1,185 @@
+// P7-U8: Punctuation Doctor diagnostic normaliser — content-free leaf.
+//
+// Normalises the Worker punctuation-diagnostic response into the shape
+// an admin panel expects. This module MUST NOT import subject content
+// datasets or any module that transitively pulls in punctuation content
+// bundles. The audit gate enforces this invariant.
+//
+// The normaliser is pure: it accepts the diagnostic payload from the
+// worker endpoint and returns a rendering-ready object. No side
+// effects, no storage, no fetch.
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function safeNonNegativeInt(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric >= 0 ? numeric : 0;
+}
+
+function safeString(value, fallback) {
+  return typeof value === 'string' && value ? value : (fallback || '');
+}
+
+function safeBool(value) {
+  return value === true;
+}
+
+function safeStringArray(value) {
+  return (Array.isArray(value) ? value : []).filter((entry) => typeof entry === 'string');
+}
+
+// ---------- Per-monster normalisation ----------
+
+function normaliseMonsterDiagnostic(rawValue) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  return {
+    monsterId: safeString(raw.monsterId, ''),
+    liveStars: safeNonNegativeInt(raw.liveStars),
+    starHighWater: safeNonNegativeInt(raw.starHighWater),
+    delta: Number.isFinite(Number(raw.delta)) ? Number(raw.delta) : 0,
+    stage: safeNonNegativeInt(raw.stage),
+    maxStageEver: safeNonNegativeInt(raw.maxStageEver),
+    tryStars: safeNonNegativeInt(raw.tryStars),
+    practiceStars: safeNonNegativeInt(raw.practiceStars),
+    secureStars: safeNonNegativeInt(raw.secureStars),
+    masteryStars: safeNonNegativeInt(raw.masteryStars),
+    megaBlocked: safeStringArray(raw.megaBlocked),
+    rewardUnitsTracked: safeNonNegativeInt(raw.rewardUnitsTracked),
+    rewardUnitsSecured: safeNonNegativeInt(raw.rewardUnitsSecured),
+    rewardUnitsDeepSecured: safeNonNegativeInt(raw.rewardUnitsDeepSecured),
+  };
+}
+
+// ---------- Grand monster normalisation ----------
+
+function normaliseGrandDiagnostic(rawValue) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  return {
+    monsterId: safeString(raw.monsterId, 'quoral'),
+    grandStars: safeNonNegativeInt(raw.grandStars),
+    grandStage: safeNonNegativeInt(raw.grandStage),
+    grandStarHighWater: safeNonNegativeInt(raw.grandStarHighWater),
+    grandMaxStageEver: safeNonNegativeInt(raw.grandMaxStageEver),
+    grandDelta: Number.isFinite(Number(raw.grandDelta)) ? Number(raw.grandDelta) : 0,
+    monstersWithSecured: safeStringArray(raw.monstersWithSecured),
+    totalSecured: safeNonNegativeInt(raw.totalSecured),
+    totalDeepSecured: safeNonNegativeInt(raw.totalDeepSecured),
+    totalRewardUnits: safeNonNegativeInt(raw.totalRewardUnits),
+  };
+}
+
+// ---------- Latch state normalisation ----------
+
+function normaliseLatchEntry(rawValue) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  return {
+    latchLeadsLive: safeBool(raw.latchLeadsLive),
+    liveLeadsLatch: safeBool(raw.liveLeadsLatch),
+  };
+}
+
+function normaliseLatchState(rawValue) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  const result = {};
+  for (const [monsterId, entry] of Object.entries(raw)) {
+    result[monsterId] = normaliseLatchEntry(entry);
+  }
+  return result;
+}
+
+// ---------- Session context normalisation ----------
+
+function normaliseSessionContext(rawValue) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  return {
+    sessionId: typeof raw.sessionId === 'string' ? raw.sessionId : null,
+    commandCount: safeNonNegativeInt(raw.commandCount),
+    lastCommandAt: safeNonNegativeInt(raw.lastCommandAt),
+  };
+}
+
+// ---------- Telemetry summary normalisation ----------
+
+function normaliseTelemetryKind(rawValue) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  return {
+    eventsAccepted: safeNonNegativeInt(raw.eventsAccepted),
+    eventsDropped: safeNonNegativeInt(raw.eventsDropped),
+    eventsDeduped: safeNonNegativeInt(raw.eventsDeduped),
+    eventsRateLimited: safeNonNegativeInt(raw.eventsRateLimited),
+    lastEventAt: safeNonNegativeInt(raw.lastEventAt),
+  };
+}
+
+function normaliseTelemetrySummary(rawValue) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  const result = {};
+  for (const [kind, stats] of Object.entries(raw)) {
+    result[kind] = normaliseTelemetryKind(stats);
+  }
+  return result;
+}
+
+// ---------- Top-level normalisation ----------
+
+export function normalisePunctuationDiagnostic(rawValue) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+
+  // Normalise per-monster entries.
+  const monstersRaw = isPlainObject(raw.monsters) ? raw.monsters : {};
+  const monsters = {};
+  for (const [monsterId, entry] of Object.entries(monstersRaw)) {
+    monsters[monsterId] = normaliseMonsterDiagnostic(entry);
+  }
+
+  return {
+    subjectId: safeString(raw.subjectId, 'punctuation'),
+    generatedAt: safeNonNegativeInt(raw.generatedAt),
+    releaseId: safeString(raw.releaseId, ''),
+    monsters,
+    grand: normaliseGrandDiagnostic(raw.grand),
+    latchState: normaliseLatchState(raw.latchState),
+    sessionContext: normaliseSessionContext(raw.sessionContext),
+    telemetrySummary: normaliseTelemetrySummary(raw.telemetrySummary),
+    projectionSource: safeString(raw.projectionSource, 'fresh'),
+    totalPublishedRewardUnits: safeNonNegativeInt(raw.totalPublishedRewardUnits),
+    activeMonsterIds: safeStringArray(raw.activeMonsterIds),
+    directMonsterIds: safeStringArray(raw.directMonsterIds),
+  };
+}
+
+// ---------- Section labels ----------
+
+export const DIAGNOSTIC_SECTION_LABELS = {
+  monsters: 'Per-Monster Diagnostic',
+  grand: 'Grand Monster (Quoral)',
+  latchState: 'Latch State',
+  sessionContext: 'Session Context',
+  telemetrySummary: 'Telemetry Summary',
+};
+
+export const DIAGNOSTIC_SECTIONS = Object.keys(DIAGNOSTIC_SECTION_LABELS);
+
+// ---------- Section emptiness check ----------
+
+export function isDiagnosticSectionEmpty(diagnostic, sectionKey) {
+  const value = diagnostic?.[sectionKey];
+  if (value == null) return true;
+  if (Array.isArray(value)) return value.length === 0;
+  if (typeof value === 'object') return Object.keys(value).length === 0;
+  return false;
+}
+
+// ---------- Format timestamp for display ----------
+
+export function formatDiagnosticTimestamp(ts) {
+  const numeric = Number(ts);
+  if (!Number.isFinite(numeric) || numeric <= 0) return '—';
+  try {
+    return new Date(numeric).toISOString().replace('T', ' ').replace(/\.000Z$/, ' UTC');
+  } catch {
+    return '—';
+  }
+}

--- a/tests/punctuation-diagnostic.test.js
+++ b/tests/punctuation-diagnostic.test.js
@@ -1,0 +1,546 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildPunctuationDiagnostic } from '../worker/src/subjects/punctuation/diagnostic.js';
+import { normalisePunctuationDiagnostic } from '../src/platform/hubs/admin-punctuation-diagnostic-panel.js';
+import { buildPunctuationLearnerReadModel } from '../src/subjects/punctuation/read-model.js';
+import {
+  ACTIVE_PUNCTUATION_MONSTER_IDS,
+  DIRECT_PUNCTUATION_MONSTER_IDS,
+  PUNCTUATION_GRAND_MONSTER_ID,
+  PUNCTUATION_CLIENT_REWARD_UNITS,
+} from '../src/subjects/punctuation/punctuation-manifest.js';
+
+const CURRENT_RELEASE_ID = 'punctuation-r4-full-14-skill-structure';
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Forbidden-key scan (mirrors read-models.js contract)
+// ---------------------------------------------------------------------------
+
+const FORBIDDEN_READ_MODEL_KEYS = new Set([
+  'accepted',
+  'answers',
+  'correctIndex',
+  'rubric',
+  'validator',
+  'seed',
+  'generator',
+  'hiddenQueue',
+  'unpublished',
+  'rawGenerator',
+  'queueItemIds',
+  'responses',
+  'acceptedAnswers',
+  'answerBanks',
+  'validators',
+  'generatorSeeds',
+  'hiddenQueues',
+]);
+
+function assertNoForbiddenReadModelKeys(value, path = 'diagnostic') {
+  if (value == null || typeof value !== 'object') return;
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index += 1) {
+      assertNoForbiddenReadModelKeys(value[index], `${path}[${index}]`);
+    }
+    return;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    if (FORBIDDEN_READ_MODEL_KEYS.has(key)) {
+      throw new Error(`Diagnostic payload exposed forbidden key at ${path}.${key}`);
+    }
+    assertNoForbiddenReadModelKeys(child, `${path}.${key}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function masteryKey(clusterId, rewardUnitId) {
+  return `punctuation:${CURRENT_RELEASE_ID}:${clusterId}:${rewardUnitId}`;
+}
+
+function makeAttempt(overrides = {}) {
+  return {
+    ts: Date.UTC(2026, 3, 25, 10, 0, 0),
+    itemId: 'test-item-01',
+    skillIds: ['sentence_endings'],
+    rewardUnitId: 'sentence-endings-core',
+    correct: true,
+    supportLevel: 0,
+    supportKind: null,
+    itemMode: 'choose',
+    sessionMode: 'smart',
+    testMode: null,
+    ...overrides,
+  };
+}
+
+function secureItemState(overrides = {}) {
+  const now = Date.UTC(2026, 3, 25);
+  return {
+    attempts: 10,
+    correct: 9,
+    incorrect: 1,
+    streak: 4,
+    lapses: 0,
+    dueAt: 0,
+    firstCorrectAt: now - (14 * DAY_MS),
+    lastCorrectAt: now,
+    lastSeen: now,
+    ...overrides,
+  };
+}
+
+function secureFacetState(skillId, itemMode, overrides = {}) {
+  const now = Date.UTC(2026, 3, 25);
+  return {
+    [`${skillId}::${itemMode}`]: {
+      attempts: 10,
+      correct: 9,
+      streak: 4,
+      lapses: 0,
+      firstCorrectAt: now - (14 * DAY_MS),
+      lastCorrectAt: now,
+      ...overrides,
+    },
+  };
+}
+
+function securedRewardUnit(clusterId, rewardUnitId) {
+  const key = masteryKey(clusterId, rewardUnitId);
+  return {
+    [key]: {
+      masteryKey: key,
+      releaseId: CURRENT_RELEASE_ID,
+      clusterId,
+      rewardUnitId,
+      securedAt: Date.UTC(2026, 3, 24),
+    },
+  };
+}
+
+function freshProgress() {
+  return {
+    items: {},
+    facets: {},
+    rewardUnits: {},
+    attempts: [],
+  };
+}
+
+// Build a seeded learner with some Pealark progress.
+function seededPealarkProgress() {
+  const now = Date.UTC(2026, 3, 25);
+  const attempts = [];
+  // Generate varied attempts for Pealark skills across multiple days.
+  const pealarkSkills = [
+    { skillId: 'sentence_endings', ruId: 'sentence-endings-core', clusterId: 'endmarks' },
+    { skillId: 'speech', ruId: 'speech-core', clusterId: 'speech' },
+    { skillId: 'semicolon', ruId: 'semicolons-core', clusterId: 'boundary' },
+    { skillId: 'dash_clause', ruId: 'dash-clauses-core', clusterId: 'boundary' },
+    { skillId: 'hyphen', ruId: 'hyphens-core', clusterId: 'boundary' },
+  ];
+
+  let itemCounter = 0;
+  for (const skill of pealarkSkills) {
+    for (let day = 0; day < 3; day++) {
+      for (let i = 0; i < 5; i++) {
+        itemCounter++;
+        attempts.push(makeAttempt({
+          ts: now - ((3 - day) * DAY_MS) + (i * 60000),
+          itemId: `item-pealark-${itemCounter}`,
+          skillIds: [skill.skillId],
+          rewardUnitId: skill.ruId,
+          correct: i < 4, // 80% accuracy
+          itemMode: i % 2 === 0 ? 'choose' : 'fix',
+        }));
+      }
+    }
+  }
+
+  // Items with memory state.
+  const items = {};
+  for (let i = 1; i <= itemCounter; i++) {
+    items[`item-pealark-${i}`] = secureItemState({
+      attempts: 3,
+      correct: i % 5 === 0 ? 2 : 3,
+      streak: i % 5 === 0 ? 1 : 3,
+    });
+  }
+
+  // Facets — secure for endmarks and speech.
+  const facets = {
+    ...secureFacetState('sentence_endings', 'choose'),
+    ...secureFacetState('sentence_endings', 'fix'),
+    ...secureFacetState('speech', 'choose'),
+    ...secureFacetState('speech', 'fix'),
+    ...secureFacetState('semicolon', 'choose'),
+    ...secureFacetState('dash_clause', 'choose'),
+    ...secureFacetState('hyphen', 'choose'),
+  };
+
+  // Reward units — all 5 Pealark units secured.
+  const rewardUnits = {
+    ...securedRewardUnit('endmarks', 'sentence-endings-core'),
+    ...securedRewardUnit('speech', 'speech-core'),
+    ...securedRewardUnit('boundary', 'semicolons-core'),
+    ...securedRewardUnit('boundary', 'dash-clauses-core'),
+    ...securedRewardUnit('boundary', 'hyphens-core'),
+  };
+
+  return { items, facets, rewardUnits, attempts };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test('diagnostic reports correct Stars/highwater/delta for seeded learner', () => {
+  const progress = seededPealarkProgress();
+  const subjectState = { data: { progress } };
+  const codexEntries = {
+    pealark: { starHighWater: 42, maxStageEver: 2 },
+    claspin: { starHighWater: 0, maxStageEver: 0 },
+    curlune: { starHighWater: 0, maxStageEver: 0 },
+    quoral: { starHighWater: 5, maxStageEver: 1 },
+  };
+
+  const diagnostic = buildPunctuationDiagnostic(subjectState, codexEntries, {});
+
+  // Pealark should have non-zero live stars.
+  const pealark = diagnostic.monsters.pealark;
+  assert.ok(pealark, 'Pealark entry must exist');
+  assert.ok(pealark.liveStars > 0, `Pealark liveStars must be positive, got ${pealark.liveStars}`);
+  assert.equal(pealark.starHighWater, 42);
+  assert.equal(pealark.delta, pealark.liveStars - 42);
+  assert.ok(pealark.stage >= 0 && pealark.stage <= 4, 'Stage must be 0-4');
+  assert.equal(pealark.maxStageEver, 2);
+
+  // Star breakdown should add up.
+  const breakdownTotal = pealark.tryStars + pealark.practiceStars + pealark.secureStars + pealark.masteryStars;
+  assert.equal(pealark.liveStars, breakdownTotal, 'Star breakdown must sum to liveStars');
+
+  // Reward unit counts.
+  assert.equal(pealark.rewardUnitsSecured, 5, 'All 5 Pealark units should be secured');
+});
+
+test('identifies "Mega blocked: insufficient breadth" for Curlune with 4/7 deep-secured', () => {
+  const now = Date.UTC(2026, 3, 25);
+  const curluneSkills = [
+    { skillId: 'list_commas', ruId: 'list-commas-core', clusterId: 'comma_flow' },
+    { skillId: 'fronted_adverbial', ruId: 'fronted-adverbials-core', clusterId: 'comma_flow' },
+    { skillId: 'comma_clarity', ruId: 'comma-clarity-core', clusterId: 'comma_flow' },
+    { skillId: 'parenthesis', ruId: 'parenthesis-core', clusterId: 'structure' },
+  ];
+
+  // Build attempts and items for 4 skills.
+  const attempts = [];
+  const items = {};
+  const facets = {};
+  const rewardUnits = {};
+  let itemCounter = 0;
+
+  for (const skill of curluneSkills) {
+    for (let day = 0; day < 3; day++) {
+      for (let i = 0; i < 5; i++) {
+        itemCounter++;
+        attempts.push(makeAttempt({
+          ts: now - ((3 - day) * DAY_MS) + (i * 60000),
+          itemId: `item-curlune-${itemCounter}`,
+          skillIds: [skill.skillId],
+          rewardUnitId: skill.ruId,
+          correct: true,
+          itemMode: i % 2 === 0 ? 'choose' : 'fix',
+        }));
+      }
+    }
+    // Secure facets for each skill.
+    Object.assign(facets, secureFacetState(skill.skillId, 'choose'));
+    Object.assign(facets, secureFacetState(skill.skillId, 'fix'));
+    // Secured reward unit.
+    Object.assign(rewardUnits, securedRewardUnit(skill.clusterId, skill.ruId));
+  }
+
+  for (let i = 1; i <= itemCounter; i++) {
+    items[`item-curlune-${i}`] = secureItemState();
+  }
+
+  const progress = { items, facets, rewardUnits, attempts };
+  const subjectState = { data: { progress } };
+  const codexEntries = { curlune: { starHighWater: 0, maxStageEver: 0 } };
+
+  const diagnostic = buildPunctuationDiagnostic(subjectState, codexEntries, {});
+  const curlune = diagnostic.monsters.curlune;
+
+  assert.ok(curlune, 'Curlune entry must exist');
+  assert.equal(curlune.rewardUnitsSecured, 4);
+  assert.equal(curlune.rewardUnitsDeepSecured, 4);
+
+  // With only 4/7 deep-secured (need 5), Mega should be blocked.
+  const hasBreadthReason = curlune.megaBlocked.some(
+    (reason) => reason.includes('insufficient breadth'),
+  );
+  assert.ok(hasBreadthReason, `Expected 'insufficient breadth' in megaBlocked, got: ${JSON.stringify(curlune.megaBlocked)}`);
+});
+
+test('reports Quoral grand stage from cross-monster evidence', () => {
+  // Build a learner with secured units across all 3 direct monsters.
+  const progress = seededPealarkProgress();
+
+  // Add some Claspin and Curlune secured units.
+  Object.assign(progress.rewardUnits, securedRewardUnit('apostrophe', 'apostrophe-contractions-core'));
+  Object.assign(progress.rewardUnits, securedRewardUnit('apostrophe', 'apostrophe-possession-core'));
+  Object.assign(progress.rewardUnits, securedRewardUnit('comma_flow', 'list-commas-core'));
+
+  const subjectState = { data: { progress } };
+  const codexEntries = {
+    pealark: { starHighWater: 30, maxStageEver: 2 },
+    claspin: { starHighWater: 10, maxStageEver: 1 },
+    curlune: { starHighWater: 5, maxStageEver: 1 },
+    quoral: { starHighWater: 10, maxStageEver: 1 },
+  };
+
+  const diagnostic = buildPunctuationDiagnostic(subjectState, codexEntries, {});
+
+  // Grand should have non-zero stars since we have evidence across 3 monsters.
+  assert.ok(diagnostic.grand.grandStars >= 0, 'Grand stars must be non-negative');
+  assert.ok(diagnostic.grand.grandStage >= 0 && diagnostic.grand.grandStage <= 4, 'Grand stage must be 0-4');
+  assert.ok(diagnostic.grand.monstersWithSecured.length > 0, 'Should have at least one monster with secured units');
+  assert.equal(diagnostic.grand.totalSecured, 8, 'Total secured should be 8 (5 Pealark + 2 Claspin + 1 Curlune)');
+});
+
+test('fresh learner returns valid all-zero diagnostic', () => {
+  const subjectState = { data: { progress: freshProgress() } };
+  const codexEntries = {};
+
+  const diagnostic = buildPunctuationDiagnostic(subjectState, codexEntries, {});
+
+  // All direct monsters should exist with zero values.
+  for (const monsterId of DIRECT_PUNCTUATION_MONSTER_IDS) {
+    const entry = diagnostic.monsters[monsterId];
+    assert.ok(entry, `Monster ${monsterId} must exist`);
+    assert.equal(entry.liveStars, 0, `${monsterId} liveStars should be 0`);
+    assert.equal(entry.starHighWater, 0, `${monsterId} starHighWater should be 0`);
+    assert.equal(entry.delta, 0, `${monsterId} delta should be 0`);
+    assert.equal(entry.stage, 0, `${monsterId} stage should be 0`);
+    assert.equal(entry.tryStars, 0, `${monsterId} tryStars should be 0`);
+    assert.equal(entry.practiceStars, 0, `${monsterId} practiceStars should be 0`);
+    assert.equal(entry.secureStars, 0, `${monsterId} secureStars should be 0`);
+    assert.equal(entry.masteryStars, 0, `${monsterId} masteryStars should be 0`);
+    assert.equal(entry.rewardUnitsTracked, 0);
+    assert.equal(entry.rewardUnitsSecured, 0);
+    assert.equal(entry.rewardUnitsDeepSecured, 0);
+  }
+
+  // Grand should be zero.
+  assert.equal(diagnostic.grand.grandStars, 0);
+  assert.equal(diagnostic.grand.grandStage, 0);
+  assert.deepEqual(diagnostic.grand.monstersWithSecured, []);
+  assert.equal(diagnostic.grand.totalSecured, 0);
+  assert.equal(diagnostic.grand.totalDeepSecured, 0);
+
+  // Latch state should show no divergence.
+  for (const monsterId of ACTIVE_PUNCTUATION_MONSTER_IDS) {
+    const latch = diagnostic.latchState[monsterId];
+    assert.ok(latch, `Latch state for ${monsterId} must exist`);
+    assert.equal(latch.latchLeadsLive, false);
+    assert.equal(latch.liveLeadsLatch, false);
+  }
+
+  // Structural fields.
+  assert.equal(diagnostic.subjectId, 'punctuation');
+  assert.ok(diagnostic.generatedAt > 0);
+  assert.ok(diagnostic.releaseId.length > 0);
+  assert.equal(diagnostic.totalPublishedRewardUnits, PUNCTUATION_CLIENT_REWARD_UNITS.length);
+});
+
+test('latch-leads-live shows correctly after lapse', () => {
+  // A learner whose starHighWater is higher than current live stars
+  // (e.g. after a lapse that reduced live projection).
+  const progress = freshProgress();
+  // Minimal attempts — just enough for a few try stars.
+  progress.attempts = [
+    makeAttempt({ itemId: 'item-1', correct: true }),
+    makeAttempt({ itemId: 'item-2', correct: true }),
+  ];
+
+  const subjectState = { data: { progress } };
+  const codexEntries = {
+    pealark: { starHighWater: 50, maxStageEver: 3 },
+  };
+
+  const diagnostic = buildPunctuationDiagnostic(subjectState, codexEntries, {});
+
+  const pealark = diagnostic.monsters.pealark;
+  assert.ok(pealark.liveStars < 50, `Live stars (${pealark.liveStars}) should be less than starHighWater (50)`);
+  assert.equal(pealark.starHighWater, 50);
+  assert.ok(pealark.delta < 0, 'Delta should be negative when latch leads live');
+
+  // Latch state.
+  assert.equal(diagnostic.latchState.pealark.latchLeadsLive, true, 'latchLeadsLive should be true');
+  assert.equal(diagnostic.latchState.pealark.liveLeadsLatch, false, 'liveLeadsLatch should be false');
+});
+
+test('forbidden-key scan passes on diagnostic payload', () => {
+  // Seeded learner with real progress.
+  const progress = seededPealarkProgress();
+  const subjectState = { data: { progress } };
+  const codexEntries = {
+    pealark: { starHighWater: 42, maxStageEver: 2 },
+    claspin: {},
+    curlune: {},
+    quoral: { starHighWater: 5 },
+  };
+
+  const diagnostic = buildPunctuationDiagnostic(subjectState, codexEntries, {
+    perKind: {
+      'card-opened': { accepted: 10, dropped: 2, deduped: 1, rateLimited: 0, lastEventAt: Date.now() },
+      'session-started': { accepted: 5, dropped: 0, deduped: 0, rateLimited: 0, lastEventAt: Date.now() },
+    },
+  });
+
+  // The recursive scan must not throw.
+  assert.doesNotThrow(
+    () => assertNoForbiddenReadModelKeys(diagnostic),
+    'Diagnostic payload must not contain forbidden keys',
+  );
+});
+
+test('totals agree with starView from same progress data', () => {
+  const progress = seededPealarkProgress();
+
+  // Compute diagnostic.
+  const subjectState = { data: { progress } };
+  const codexEntries = {
+    pealark: { starHighWater: 42, maxStageEver: 2 },
+    claspin: {},
+    curlune: {},
+    quoral: { starHighWater: 5 },
+  };
+  const diagnostic = buildPunctuationDiagnostic(subjectState, codexEntries, {});
+
+  // Compute the read model starView from the same progress.
+  const readModel = buildPunctuationLearnerReadModel({
+    subjectStateRecord: { data: { progress } },
+  });
+
+  // Per-monster star totals must agree.
+  for (const monsterId of DIRECT_PUNCTUATION_MONSTER_IDS) {
+    const diagEntry = diagnostic.monsters[monsterId];
+    const starEntry = readModel.starView.perMonster[monsterId];
+
+    if (diagEntry && starEntry) {
+      assert.equal(
+        diagEntry.liveStars,
+        starEntry.total,
+        `${monsterId}: diagnostic liveStars (${diagEntry.liveStars}) must equal starView total (${starEntry.total})`,
+      );
+      assert.equal(
+        diagEntry.tryStars,
+        starEntry.tryStars,
+        `${monsterId}: tryStars must agree`,
+      );
+      assert.equal(
+        diagEntry.practiceStars,
+        starEntry.practiceStars,
+        `${monsterId}: practiceStars must agree`,
+      );
+      assert.equal(
+        diagEntry.secureStars,
+        starEntry.secureStars,
+        `${monsterId}: secureStars must agree`,
+      );
+      assert.equal(
+        diagEntry.masteryStars,
+        starEntry.masteryStars,
+        `${monsterId}: masteryStars must agree`,
+      );
+    }
+  }
+
+  // Grand stars must agree.
+  assert.equal(
+    diagnostic.grand.grandStars,
+    readModel.starView.grand.grandStars,
+    `Grand stars must agree: diagnostic=${diagnostic.grand.grandStars}, readModel=${readModel.starView.grand.grandStars}`,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Admin normaliser tests
+// ---------------------------------------------------------------------------
+
+test('normalisePunctuationDiagnostic produces valid shape from raw diagnostic', () => {
+  const progress = seededPealarkProgress();
+  const subjectState = { data: { progress } };
+  const raw = buildPunctuationDiagnostic(subjectState, {
+    pealark: { starHighWater: 42, maxStageEver: 2 },
+  }, {});
+
+  const normalised = normalisePunctuationDiagnostic(raw);
+
+  assert.equal(normalised.subjectId, 'punctuation');
+  assert.ok(normalised.generatedAt > 0);
+  assert.ok(normalised.monsters.pealark);
+  assert.equal(typeof normalised.monsters.pealark.liveStars, 'number');
+  assert.equal(typeof normalised.monsters.pealark.starHighWater, 'number');
+  assert.equal(typeof normalised.grand.grandStars, 'number');
+  assert.ok(Array.isArray(normalised.activeMonsterIds));
+  assert.ok(Array.isArray(normalised.directMonsterIds));
+});
+
+test('normalisePunctuationDiagnostic handles null/undefined input gracefully', () => {
+  const normalised = normalisePunctuationDiagnostic(null);
+
+  assert.equal(normalised.subjectId, 'punctuation');
+  assert.equal(normalised.generatedAt, 0);
+  assert.deepEqual(normalised.monsters, {});
+  assert.equal(normalised.grand.grandStars, 0);
+  assert.equal(normalised.grand.grandStage, 0);
+  assert.deepEqual(normalised.latchState, {});
+  assert.equal(normalised.sessionContext.sessionId, null);
+  assert.deepEqual(normalised.telemetrySummary, {});
+  assert.deepEqual(normalised.activeMonsterIds, []);
+  assert.deepEqual(normalised.directMonsterIds, []);
+});
+
+test('normalisePunctuationDiagnostic coerces malformed values defensively', () => {
+  const normalised = normalisePunctuationDiagnostic({
+    subjectId: 123,           // wrong type
+    generatedAt: 'not-a-number',
+    monsters: {
+      pealark: {
+        liveStars: 'forty-five',
+        starHighWater: null,
+        delta: undefined,
+        megaBlocked: 'not-an-array',
+      },
+    },
+    grand: {
+      grandStars: -5,
+      monstersWithSecured: 'not-array',
+    },
+    latchState: {
+      pealark: {
+        latchLeadsLive: 'yes',  // not boolean
+      },
+    },
+    sessionContext: {
+      sessionId: 42, // not string
+    },
+  });
+
+  assert.equal(normalised.subjectId, 'punctuation');
+  assert.equal(normalised.generatedAt, 0);
+  assert.equal(normalised.monsters.pealark.liveStars, 0);
+  assert.equal(normalised.monsters.pealark.starHighWater, 0);
+  assert.equal(normalised.monsters.pealark.delta, 0);
+  assert.deepEqual(normalised.monsters.pealark.megaBlocked, []);
+  assert.equal(normalised.grand.grandStars, 0);
+  assert.deepEqual(normalised.grand.monstersWithSecured, []);
+  assert.equal(normalised.latchState.pealark.latchLeadsLive, false);
+  assert.equal(normalised.sessionContext.sessionId, null);
+});

--- a/worker/src/subjects/punctuation/commands.js
+++ b/worker/src/subjects/punctuation/commands.js
@@ -145,9 +145,9 @@ export function createPunctuationCommandHandlers({ now, random } = {}) {
     // P7-U8: Punctuation Doctor diagnostic read model. Reads state but
     // does NOT mutate it — branches early like `record-event` to bypass
     // the engine/projection pipeline. Gated behind admin auth: the
-    // caller must have `isAdmin: true` in the session context.
+    // caller must have `platformRole: 'admin'` in the session context.
     if (command.command === PUNCTUATION_DIAGNOSTIC_COMMAND) {
-      if (!context.session?.isAdmin) {
+      if (context.session?.platformRole !== 'admin') {
         throw new NotFoundError('Punctuation diagnostic requires admin access.', {
           code: 'subject_command_not_found',
           subjectId: 'punctuation',
@@ -160,7 +160,14 @@ export function createPunctuationCommandHandlers({ now, random } = {}) {
         'punctuation',
         { skipAccessCheck: true },
       );
-      const codexEntries = runtimeRecord.gameState?.['monster-codex'] || {};
+      // readSubjectRuntimeBundle returns { subjectRecord, latestSession } —
+      // it does NOT include gameState. Load the learner's projection state
+      // separately to get the monster-codex entries (starHighWater, maxStageEver).
+      const projectionBundle = await context.repository.readLearnerProjectionState(
+        context.session.accountId,
+        command.learnerId,
+      );
+      const codexEntries = projectionBundle?.gameState?.['monster-codex'] || {};
       const rawStats = command.payload?.telemetryStats;
       const telemetryStats = rawStats && typeof rawStats === 'object' && !Array.isArray(rawStats)
         ? rawStats

--- a/worker/src/subjects/punctuation/commands.js
+++ b/worker/src/subjects/punctuation/commands.js
@@ -17,6 +17,7 @@ import { requestPunctuationContextPack } from './ai-enrichment.js';
 import { createServerPunctuationEngine } from './engine.js';
 import { buildPunctuationReadModel } from './read-models.js';
 import { applyRecordEventCommand } from './events.js';
+import { buildPunctuationDiagnostic } from './diagnostic.js';
 import { resolveProjectionInput } from '../projection-input.js';
 
 // U9: `record-event` is a new telemetry-only command. It routes through
@@ -26,6 +27,12 @@ import { resolveProjectionInput } from '../projection-input.js';
 // `./events.js:applyRecordEventCommand` validates the per-kind payload
 // allowlist and writes a single row to `punctuation_events`.
 const PUNCTUATION_TELEMETRY_COMMAND = 'record-event';
+
+// P7-U8: Punctuation Doctor diagnostic read model. Routes through the
+// same `repository.runSubjectCommand` path (so `requireLearnerWriteAccess`
+// fires) but does NOT engage the engine/projection pipeline — its handler
+// reads state and returns a safe diagnostic payload.
+const PUNCTUATION_DIAGNOSTIC_COMMAND = 'punctuation-diagnostic';
 
 const PUNCTUATION_COMMANDS = Object.freeze([
   'start-session',
@@ -37,6 +44,7 @@ const PUNCTUATION_COMMANDS = Object.freeze([
   'reset-learner',
   'request-context-pack',
   PUNCTUATION_TELEMETRY_COMMAND,
+  PUNCTUATION_DIAGNOSTIC_COMMAND,
 ]);
 
 function contentMeta() {
@@ -132,6 +140,42 @@ export function createPunctuationCommandHandlers({ now, random } = {}) {
     // transiently fails validation (e.g. during a content hotfix).
     if (command.command === PUNCTUATION_TELEMETRY_COMMAND) {
       return applyRecordEventCommand({ command, context });
+    }
+
+    // P7-U8: Punctuation Doctor diagnostic read model. Reads state but
+    // does NOT mutate it — branches early like `record-event` to bypass
+    // the engine/projection pipeline. Gated behind admin auth: the
+    // caller must have `isAdmin: true` in the session context.
+    if (command.command === PUNCTUATION_DIAGNOSTIC_COMMAND) {
+      if (!context.session?.isAdmin) {
+        throw new NotFoundError('Punctuation diagnostic requires admin access.', {
+          code: 'subject_command_not_found',
+          subjectId: 'punctuation',
+          command: command.command,
+        });
+      }
+      const runtimeRecord = await context.repository.readSubjectRuntime(
+        context.session.accountId,
+        command.learnerId,
+        'punctuation',
+        { skipAccessCheck: true },
+      );
+      const codexEntries = runtimeRecord.gameState?.['monster-codex'] || {};
+      const rawStats = command.payload?.telemetryStats;
+      const telemetryStats = rawStats && typeof rawStats === 'object' && !Array.isArray(rawStats)
+        ? rawStats
+        : {};
+      const diagnostic = buildPunctuationDiagnostic(
+        runtimeRecord.subjectRecord,
+        codexEntries,
+        telemetryStats,
+      );
+      return {
+        learnerId: command.learnerId,
+        ok: true,
+        changed: false,
+        diagnostic,
+      };
     }
 
     if (!PUNCTUATION_MANIFEST_VALIDATION.ok) {

--- a/worker/src/subjects/punctuation/diagnostic.js
+++ b/worker/src/subjects/punctuation/diagnostic.js
@@ -1,0 +1,328 @@
+// P7-U8: Punctuation Doctor diagnostic read model.
+//
+// Server-side only — lives under `worker/src/` and is forbidden from the
+// client bundle by the `FORBIDDEN_MODULES` audit pattern.
+//
+// Computes a safe diagnostic snapshot that developers/operators can use
+// to explain Punctuation state without exposing answer banks, validators,
+// or learner answers. Only IDs, counts, booleans, timestamps, and safe
+// labels appear in the output.
+
+import { projectPunctuationStars } from '../../../../src/subjects/punctuation/star-projection.js';
+import {
+  ACTIVE_PUNCTUATION_MONSTER_IDS,
+  DIRECT_PUNCTUATION_MONSTER_IDS,
+  PUNCTUATION_GRAND_MONSTER_ID,
+  PUNCTUATION_CLIENT_REWARD_UNITS,
+  MONSTER_CLUSTERS,
+  MONSTER_UNIT_COUNT,
+  SKILL_TO_CLUSTER,
+} from '../../../../src/subjects/punctuation/punctuation-manifest.js';
+import {
+  stageFor,
+  PUNCTUATION_STAR_THRESHOLDS,
+  PUNCTUATION_GRAND_STAR_THRESHOLDS,
+} from '../../../../src/platform/game/monsters.js';
+import {
+  PUNCTUATION_RELEASE_ID,
+} from '../../../../shared/punctuation/content.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function safeInt(value, fallback = 0) {
+  const n = Number(value);
+  return Number.isFinite(n) ? Math.floor(n + 1e-9) : fallback;
+}
+
+function safeNonNegInt(value) {
+  return Math.max(0, safeInt(value, 0));
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Mirrors star-projection.js memorySnapshot — secure bucket check. */
+function isSecureFacet(facetState) {
+  const raw = isPlainObject(facetState) ? facetState : {};
+  const attempts = Math.max(0, Number(raw.attempts) || 0);
+  const correct = Math.max(0, Number(raw.correct) || 0);
+  const streak = Math.max(0, Number(raw.streak) || 0);
+  const lapses = Math.max(0, Number(raw.lapses) || 0);
+  const firstCorrectAt = Number.isFinite(Number(raw.firstCorrectAt)) ? Number(raw.firstCorrectAt) : null;
+  const lastCorrectAt = Number.isFinite(Number(raw.lastCorrectAt)) ? Number(raw.lastCorrectAt) : null;
+  const accuracy = attempts ? correct / attempts : 0;
+  const correctSpanDays = firstCorrectAt != null && lastCorrectAt != null
+    ? Math.floor((lastCorrectAt - firstCorrectAt) / DAY_MS)
+    : 0;
+  const secure = streak >= 3 && accuracy >= 0.8 && correctSpanDays >= 7;
+  return { secure, lapses };
+}
+
+// ---------------------------------------------------------------------------
+// Per-monster reward-unit counting
+// ---------------------------------------------------------------------------
+
+function countRewardUnitsForMonster(rewardUnits, monsterClusterIds) {
+  const entries = isPlainObject(rewardUnits) ? rewardUnits : {};
+  let tracked = 0;
+  let secured = 0;
+  let deepSecured = 0;
+
+  // We cannot check deep-secure here (needs facets), so return partial.
+  for (const [, entry] of Object.entries(entries)) {
+    if (!isPlainObject(entry)) continue;
+    const clusterId = typeof entry.clusterId === 'string' ? entry.clusterId : '';
+    if (!monsterClusterIds.has(clusterId)) continue;
+    tracked += 1;
+    const securedAt = Number(entry.securedAt);
+    if (Number.isFinite(securedAt) && securedAt > 0) {
+      secured += 1;
+    }
+  }
+
+  return { tracked, secured, deepSecured };
+}
+
+function countDeepSecuredForMonster(rewardUnits, facets, monsterClusterIds) {
+  const rewardEntries = isPlainObject(rewardUnits) ? rewardUnits : {};
+  const facetEntries = isPlainObject(facets) ? facets : {};
+
+  // Build cluster -> skill lookup.
+  const clusterToSkills = new Map();
+  for (const [skillId, clusterId] of SKILL_TO_CLUSTER.entries()) {
+    if (!monsterClusterIds.has(clusterId)) continue;
+    if (!clusterToSkills.has(clusterId)) clusterToSkills.set(clusterId, new Set());
+    clusterToSkills.get(clusterId).add(skillId);
+  }
+
+  let deepSecuredCount = 0;
+  for (const [, entry] of Object.entries(rewardEntries)) {
+    if (!isPlainObject(entry)) continue;
+    const clusterId = typeof entry.clusterId === 'string' ? entry.clusterId : '';
+    if (!monsterClusterIds.has(clusterId)) continue;
+    const securedAt = Number(entry.securedAt);
+    if (!Number.isFinite(securedAt) || securedAt <= 0) continue;
+
+    const skillIds = clusterToSkills.get(clusterId);
+    if (!skillIds) continue;
+
+    let hasDeepSecureFacet = false;
+    for (const [facetId, facetState] of Object.entries(facetEntries)) {
+      const [skillId] = facetId.split('::');
+      if (!skillIds.has(skillId)) continue;
+      const snap = isSecureFacet(facetState);
+      if (snap.secure && snap.lapses === 0) {
+        hasDeepSecureFacet = true;
+        break;
+      }
+    }
+    if (hasDeepSecureFacet) deepSecuredCount += 1;
+  }
+
+  return deepSecuredCount;
+}
+
+// ---------------------------------------------------------------------------
+// Mega-blocked reasons
+// ---------------------------------------------------------------------------
+
+function megaBlockedReasons(monsterId, monsterStar, rewardUnitCounts) {
+  const reasons = [];
+  const totalUnits = MONSTER_UNIT_COUNT[monsterId] || 0;
+
+  if (monsterStar.total < 100) {
+    reasons.push('insufficient total stars');
+  }
+
+  if (monsterId === 'claspin') {
+    if (rewardUnitCounts.secured < totalUnits) {
+      reasons.push('insufficient secured units');
+    }
+    if (rewardUnitCounts.deepSecured < totalUnits) {
+      reasons.push('insufficient deep-secured units');
+    }
+  }
+
+  if (monsterId === 'curlune') {
+    const minDeepSecured = Math.ceil(totalUnits * 0.71); // 5 of 7
+    if (rewardUnitCounts.deepSecured < minDeepSecured) {
+      reasons.push(`insufficient breadth (${rewardUnitCounts.deepSecured}/${minDeepSecured} deep-secured)`);
+    }
+    if (rewardUnitCounts.secured < minDeepSecured) {
+      reasons.push(`insufficient secured units (${rewardUnitCounts.secured}/${minDeepSecured})`);
+    }
+  }
+
+  if (monsterId === 'pealark') {
+    if (rewardUnitCounts.secured < totalUnits) {
+      reasons.push('insufficient secured units');
+    }
+    if (rewardUnitCounts.deepSecured < totalUnits) {
+      reasons.push('insufficient deep-secured units');
+    }
+  }
+
+  return reasons;
+}
+
+// ---------------------------------------------------------------------------
+// Main diagnostic builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a safe Punctuation diagnostic snapshot.
+ *
+ * @param {Object} subjectState - The subject state record (contains `data.progress`).
+ * @param {Object} codexEntries - Per-monster codex state (starHighWater, maxStageEver, etc.).
+ * @param {Object} [telemetryStats] - Optional telemetry statistics.
+ * @returns {Object} Diagnostic payload — safe for operator consumption.
+ */
+export function buildPunctuationDiagnostic(subjectState, codexEntries, telemetryStats) {
+  const state = isPlainObject(subjectState) ? subjectState : {};
+  const data = isPlainObject(state.data) ? state.data : {};
+  const progress = isPlainObject(data.progress) ? data.progress : {};
+  const codex = isPlainObject(codexEntries) ? codexEntries : {};
+  const telemetry = isPlainObject(telemetryStats) ? telemetryStats : {};
+
+  // Project live stars.
+  const starLedger = projectPunctuationStars(progress, PUNCTUATION_RELEASE_ID, { debug: true });
+  const rewardUnits = isPlainObject(progress.rewardUnits) ? progress.rewardUnits : {};
+  const facets = isPlainObject(progress.facets) ? progress.facets : {};
+
+  // Build per-monster diagnostic entries.
+  const monsters = {};
+  for (const monsterId of DIRECT_PUNCTUATION_MONSTER_IDS) {
+    const monsterStar = starLedger.perMonster[monsterId] || {
+      tryStars: 0, practiceStars: 0, secureStars: 0, masteryStars: 0, total: 0,
+    };
+    const clusterIds = MONSTER_CLUSTERS.get(monsterId) || new Set();
+
+    // Codex state for this monster.
+    const monsterCodex = isPlainObject(codex[monsterId]) ? codex[monsterId] : {};
+    const starHighWater = safeNonNegInt(monsterCodex.starHighWater);
+    const maxStageEver = safeNonNegInt(monsterCodex.maxStageEver);
+    const liveStars = Math.floor(monsterStar.total + 1e-9);
+    const stage = stageFor(liveStars, PUNCTUATION_STAR_THRESHOLDS);
+    const delta = liveStars - starHighWater;
+
+    // Reward unit counts.
+    const ruCounts = countRewardUnitsForMonster(rewardUnits, clusterIds);
+    ruCounts.deepSecured = countDeepSecuredForMonster(rewardUnits, facets, clusterIds);
+
+    monsters[monsterId] = {
+      monsterId,
+      liveStars,
+      starHighWater,
+      delta,
+      stage,
+      maxStageEver,
+      tryStars: Math.floor(monsterStar.tryStars + 1e-9),
+      practiceStars: Math.floor(monsterStar.practiceStars + 1e-9),
+      secureStars: Math.floor(monsterStar.secureStars + 1e-9),
+      masteryStars: Math.floor(monsterStar.masteryStars + 1e-9),
+      megaBlocked: megaBlockedReasons(monsterId, monsterStar, ruCounts),
+      rewardUnitsTracked: ruCounts.tracked,
+      rewardUnitsSecured: ruCounts.secured,
+      rewardUnitsDeepSecured: ruCounts.deepSecured,
+    };
+  }
+
+  // Quoral (grand monster).
+  const grandCodex = isPlainObject(codex[PUNCTUATION_GRAND_MONSTER_ID])
+    ? codex[PUNCTUATION_GRAND_MONSTER_ID]
+    : {};
+  const grandStars = Math.floor((starLedger.grand?.grandStars ?? 0) + 1e-9);
+  const grandStage = stageFor(grandStars, PUNCTUATION_GRAND_STAR_THRESHOLDS);
+  const grandStarHighWater = safeNonNegInt(grandCodex.starHighWater);
+  const grandMaxStageEver = safeNonNegInt(grandCodex.maxStageEver);
+
+  // Cross-monster breadth for grand.
+  let totalSecured = 0;
+  let totalDeepSecured = 0;
+  const monstersWithSecured = [];
+
+  for (const monsterId of DIRECT_PUNCTUATION_MONSTER_IDS) {
+    const entry = monsters[monsterId];
+    if (entry && entry.rewardUnitsSecured > 0) {
+      monstersWithSecured.push(monsterId);
+    }
+    totalSecured += (entry?.rewardUnitsSecured || 0);
+    totalDeepSecured += (entry?.rewardUnitsDeepSecured || 0);
+  }
+
+  const grand = {
+    monsterId: PUNCTUATION_GRAND_MONSTER_ID,
+    grandStars,
+    grandStage,
+    grandStarHighWater,
+    grandMaxStageEver,
+    grandDelta: grandStars - grandStarHighWater,
+    monstersWithSecured,
+    totalSecured,
+    totalDeepSecured,
+    totalRewardUnits: PUNCTUATION_CLIENT_REWARD_UNITS.length,
+  };
+
+  // Latch state per monster.
+  const latchState = {};
+  for (const monsterId of ACTIVE_PUNCTUATION_MONSTER_IDS) {
+    if (monsterId === PUNCTUATION_GRAND_MONSTER_ID) {
+      latchState[monsterId] = {
+        latchLeadsLive: grandStarHighWater > grandStars,
+        liveLeadsLatch: grandStars > grandStarHighWater,
+      };
+    } else {
+      const entry = monsters[monsterId];
+      if (entry) {
+        latchState[monsterId] = {
+          latchLeadsLive: entry.starHighWater > entry.liveStars,
+          liveLeadsLatch: entry.liveStars > entry.starHighWater,
+        };
+      }
+    }
+  }
+
+  // Session context from state.
+  const sessionCtx = {
+    sessionId: typeof state.sessionId === 'string' ? state.sessionId : null,
+    commandCount: safeNonNegInt(state.commandCount),
+    lastCommandAt: safeNonNegInt(state.lastCommandAt),
+  };
+
+  // Telemetry summary (safe counts only).
+  const telemetrySummary = {};
+  if (isPlainObject(telemetry.perKind)) {
+    for (const [kind, stats] of Object.entries(telemetry.perKind)) {
+      telemetrySummary[kind] = {
+        eventsAccepted: safeNonNegInt(stats.accepted),
+        eventsDropped: safeNonNegInt(stats.dropped),
+        eventsDeduped: safeNonNegInt(stats.deduped),
+        eventsRateLimited: safeNonNegInt(stats.rateLimited),
+        lastEventAt: safeNonNegInt(stats.lastEventAt),
+      };
+    }
+  }
+
+  // Projection metadata from the debug star ledger.
+  const projectionSource = starLedger._debugMeta?.source || 'fresh';
+
+  return {
+    subjectId: 'punctuation',
+    generatedAt: Date.now(),
+    releaseId: PUNCTUATION_RELEASE_ID,
+    monsters,
+    grand,
+    latchState,
+    sessionContext: sessionCtx,
+    telemetrySummary,
+    projectionSource,
+    totalPublishedRewardUnits: PUNCTUATION_CLIENT_REWARD_UNITS.length,
+    activeMonsterIds: [...ACTIVE_PUNCTUATION_MONSTER_IDS],
+    directMonsterIds: [...DIRECT_PUNCTUATION_MONSTER_IDS],
+  };
+}

--- a/worker/src/subjects/punctuation/diagnostic.js
+++ b/worker/src/subjects/punctuation/diagnostic.js
@@ -14,6 +14,7 @@ import {
   DIRECT_PUNCTUATION_MONSTER_IDS,
   PUNCTUATION_GRAND_MONSTER_ID,
   PUNCTUATION_CLIENT_REWARD_UNITS,
+  CLASPIN_REQUIRED_SKILLS,
   MONSTER_CLUSTERS,
   MONSTER_UNIT_COUNT,
   SKILL_TO_CLUSTER,
@@ -128,15 +129,74 @@ function countDeepSecuredForMonster(rewardUnits, facets, monsterClusterIds) {
 }
 
 // ---------------------------------------------------------------------------
+// Per-monster facet summary for Mega gate diagnostics
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute facet-level signals that mirror the Mega gate checks in
+ * star-projection.js:computeMasteryStars. Returns a summary object
+ * with boolean flags consumed by `megaBlockedReasons`.
+ */
+function computeFacetMegaSummary(facets, monsterClusterIds, monsterId) {
+  const facetEntries = isPlainObject(facets) ? facets : {};
+  const itemModes = new Set();
+  const skillsWithDeepSecure = new Set();
+  let hasSpacedReturn = false;
+
+  for (const [facetId, facetState] of Object.entries(facetEntries)) {
+    const [skillId] = facetId.split('::');
+    const itemMode = facetId.split('::')[1] || '';
+    const skillCluster = SKILL_TO_CLUSTER.get(skillId);
+    if (!skillCluster || !monsterClusterIds.has(skillCluster)) continue;
+
+    const snap = isSecureFacet(facetState);
+    if (snap.secure) {
+      itemModes.add(itemMode);
+      if (snap.lapses === 0) {
+        skillsWithDeepSecure.add(skillId);
+      }
+    }
+    // correctSpanDays check — mirrors memorySnapshot in star-projection.js.
+    const raw = isPlainObject(facetState) ? facetState : {};
+    const firstCorrectAt = Number.isFinite(Number(raw.firstCorrectAt)) ? Number(raw.firstCorrectAt) : null;
+    const lastCorrectAt = Number.isFinite(Number(raw.lastCorrectAt)) ? Number(raw.lastCorrectAt) : null;
+    if (firstCorrectAt != null && lastCorrectAt != null) {
+      const correctSpanDays = Math.floor((lastCorrectAt - firstCorrectAt) / DAY_MS);
+      if (correctSpanDays >= 7) hasSpacedReturn = true;
+    }
+  }
+
+  const hasMixedModes = itemModes.size >= 2;
+
+  // Claspin-specific: both contraction AND possession skills must be deep-secure.
+  const hasBothSkillsDeepSecure = monsterId === 'claspin'
+    ? CLASPIN_REQUIRED_SKILLS.every(s => skillsWithDeepSecure.has(s))
+    : true; // non-Claspin monsters do not have this requirement
+
+  return { hasMixedModes, hasSpacedReturn, hasBothSkillsDeepSecure };
+}
+
+// ---------------------------------------------------------------------------
 // Mega-blocked reasons
 // ---------------------------------------------------------------------------
 
-function megaBlockedReasons(monsterId, monsterStar, rewardUnitCounts) {
+function megaBlockedReasons(monsterId, monsterStar, rewardUnitCounts, facetSummary) {
   const reasons = [];
   const totalUnits = MONSTER_UNIT_COUNT[monsterId] || 0;
+  const fs = facetSummary || {};
 
   if (monsterStar.total < 100) {
     reasons.push('insufficient total stars');
+  }
+
+  // Cross-monster Mega gate conditions from star-projection.js:
+  // mixed item-mode variety and spaced return are required by Claspin
+  // and Curlune gates, but are good diagnostic signals for all monsters.
+  if (!fs.hasMixedModes) {
+    reasons.push('insufficient item-mode variety (need 2+ modes with secure facets)');
+  }
+  if (!fs.hasSpacedReturn) {
+    reasons.push('insufficient spaced return (need 7+ day correctSpanDays)');
   }
 
   if (monsterId === 'claspin') {
@@ -145,6 +205,9 @@ function megaBlockedReasons(monsterId, monsterStar, rewardUnitCounts) {
     }
     if (rewardUnitCounts.deepSecured < totalUnits) {
       reasons.push('insufficient deep-secured units');
+    }
+    if (!fs.hasBothSkillsDeepSecure) {
+      reasons.push('not both apostrophe skills deep-secure');
     }
   }
 
@@ -214,6 +277,9 @@ export function buildPunctuationDiagnostic(subjectState, codexEntries, telemetry
     const ruCounts = countRewardUnitsForMonster(rewardUnits, clusterIds);
     ruCounts.deepSecured = countDeepSecuredForMonster(rewardUnits, facets, clusterIds);
 
+    // Facet-level Mega gate signals (mixed modes, spaced return, deep-secure skills).
+    const facetSummary = computeFacetMegaSummary(facets, clusterIds, monsterId);
+
     monsters[monsterId] = {
       monsterId,
       liveStars,
@@ -225,7 +291,7 @@ export function buildPunctuationDiagnostic(subjectState, codexEntries, telemetry
       practiceStars: Math.floor(monsterStar.practiceStars + 1e-9),
       secureStars: Math.floor(monsterStar.secureStars + 1e-9),
       masteryStars: Math.floor(monsterStar.masteryStars + 1e-9),
-      megaBlocked: megaBlockedReasons(monsterId, monsterStar, ruCounts),
+      megaBlocked: megaBlockedReasons(monsterId, monsterStar, ruCounts, facetSummary),
       rewardUnitsTracked: ruCounts.tracked,
       rewardUnitsSecured: ruCounts.secured,
       rewardUnitsDeepSecured: ruCounts.deepSecured,


### PR DESCRIPTION
## Summary
- Add `buildPunctuationDiagnostic()` server-side function that computes a safe diagnostic snapshot of Punctuation state — per-monster Stars/highwater/delta/stage, Mega-blocked reasons, Quoral grand metrics, latch divergence, and session context
- Wire `punctuation-diagnostic` admin command into the command handler with early-branch pattern (bypasses engine/projection pipeline), gated behind `isAdmin` auth
- Add `normalisePunctuationDiagnostic()` admin normaliser panel following the `admin-debug-bundle-panel.js` pattern with defensive type coercion

## Test plan
- [x] Diagnostic reports correct Stars/highwater/delta for seeded Pealark learner
- [x] Identifies "Mega blocked: insufficient breadth" for Curlune with 4/7 deep-secured
- [x] Reports Quoral grand stage from cross-monster secured evidence
- [x] Fresh learner returns valid all-zero diagnostic with correct structure
- [x] Latch-leads-live shows correctly after lapse (starHighWater > liveStars)
- [x] Forbidden-key scan passes on entire diagnostic payload (no acceptedAnswers, answerBanks, correctIndex, validators, generatorSeeds, etc.)
- [x] Star totals agree with starView from same progress data via `buildPunctuationLearnerReadModel`
- [x] Admin normaliser produces valid shape from raw diagnostic
- [x] Admin normaliser handles null/undefined input gracefully
- [x] Admin normaliser coerces malformed types defensively
- [x] Bundle audit confirms diagnostic module not in client bundle (`worker/src/subjects/punctuation/` pattern)
- [x] 215 existing punctuation tests pass, 40 bundle audit tests pass