### PR TITLE
fix(admin): recover stale admin chunk loads

### DIFF
--- a/src/platform/hubs/admin-marketing-message.js
+++ b/src/platform/hubs/admin-marketing-message.js
@@ -1,0 +1,29 @@
+function asTs(value, fallback = 0) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric >= 0 ? numeric : fallback;
+}
+
+// Normalise a single admin marketing message from the server payload into a
+// stable client shape. Kept separate from admin-read-model.js so the browser
+// admin chunk does not import server-side hub aggregation or spelling content.
+export function normaliseMarketingMessage(rawValue) {
+  const raw = rawValue && typeof rawValue === 'object' && !Array.isArray(rawValue) ? rawValue : {};
+  return {
+    id: typeof raw.id === 'string' ? raw.id : '',
+    message_type: typeof raw.message_type === 'string' ? raw.message_type : 'announcement',
+    status: typeof raw.status === 'string' ? raw.status : 'draft',
+    title: typeof raw.title === 'string' ? raw.title : '',
+    body_text: typeof raw.body_text === 'string' ? raw.body_text : '',
+    severity_token: typeof raw.severity_token === 'string' ? raw.severity_token : 'info',
+    audience: typeof raw.audience === 'string' ? raw.audience : 'internal',
+    starts_at: raw.starts_at != null ? Number(raw.starts_at) : null,
+    ends_at: raw.ends_at != null ? Number(raw.ends_at) : null,
+    created_by: typeof raw.created_by === 'string' ? raw.created_by : '',
+    updated_by: typeof raw.updated_by === 'string' ? raw.updated_by : '',
+    published_by: typeof raw.published_by === 'string' ? raw.published_by : null,
+    created_at: asTs(raw.created_at, 0),
+    updated_at: asTs(raw.updated_at, 0),
+    published_at: raw.published_at != null ? asTs(raw.published_at, 0) : null,
+    row_version: Math.max(0, Number(raw.row_version) || 0),
+  };
+}

--- a/src/platform/hubs/admin-read-model.js
+++ b/src/platform/hubs/admin-read-model.js
@@ -13,6 +13,7 @@ import { buildSpellingContentSummary, validateSpellingContentBundle } from '../.
 import { getSpellingPostMasteryState } from '../../subjects/spelling/read-model.js';
 import { POST_MEGA_SEED_SHAPES } from '../../../shared/spelling/post-mastery-seed-shapes.js';
 import { buildParentHubReadModel } from './parent-read-model.js';
+export { normaliseMarketingMessage } from './admin-marketing-message.js';
 
 // U1 (P2): neutral "empty" debug envelope for the admin hub when no
 // learner is selected or when the role check forbids debug fields. The
@@ -62,32 +63,6 @@ export function normaliseDemoOperations(rawValue) {
     rateLimitBlocks: Math.max(0, Number(raw.rateLimitBlocks) || 0),
     ttsFallbacks: Math.max(0, Number(raw.ttsFallbacks) || 0),
     updatedAt: asTs(raw.updatedAt, 0),
-  };
-}
-
-// U6 (P4): normalise a single admin marketing message from the server
-// payload into a stable client shape. Mirrors adminMessageFields() in
-// admin-marketing.js. Defensive: any missing or malformed field collapses
-// to a safe default so the React surface never crashes on partial data.
-export function normaliseMarketingMessage(rawValue) {
-  const raw = rawValue && typeof rawValue === 'object' && !Array.isArray(rawValue) ? rawValue : {};
-  return {
-    id: typeof raw.id === 'string' ? raw.id : '',
-    message_type: typeof raw.message_type === 'string' ? raw.message_type : 'announcement',
-    status: typeof raw.status === 'string' ? raw.status : 'draft',
-    title: typeof raw.title === 'string' ? raw.title : '',
-    body_text: typeof raw.body_text === 'string' ? raw.body_text : '',
-    severity_token: typeof raw.severity_token === 'string' ? raw.severity_token : 'info',
-    audience: typeof raw.audience === 'string' ? raw.audience : 'internal',
-    starts_at: raw.starts_at != null ? Number(raw.starts_at) : null,
-    ends_at: raw.ends_at != null ? Number(raw.ends_at) : null,
-    created_by: typeof raw.created_by === 'string' ? raw.created_by : '',
-    updated_by: typeof raw.updated_by === 'string' ? raw.updated_by : '',
-    published_by: typeof raw.published_by === 'string' ? raw.published_by : null,
-    created_at: asTs(raw.created_at, 0),
-    updated_at: asTs(raw.updated_at, 0),
-    published_at: raw.published_at != null ? asTs(raw.published_at, 0) : null,
-    row_version: Math.max(0, Number(raw.row_version) || 0),
   };
 }
 

--- a/src/platform/react/ErrorBoundary.jsx
+++ b/src/platform/react/ErrorBoundary.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { isChunkLoadError } from './chunk-load-detect.js';
+import { clearChunkReloadAttempt, scheduleChunkReloadOnce } from './chunk-load-recovery.js';
 
 export function DefaultErrorFallback({ error }) {
   // SH2-U8: inline style prop migrated to `.error-boundary-body` class
@@ -46,6 +47,7 @@ export function ChunkLoadErrorFallback() {
 export class ErrorBoundary extends React.Component {
   constructor(props) {
     super(props);
+    clearChunkReloadAttempt();
     this.state = { error: null, isChunkError: false };
   }
 
@@ -55,6 +57,7 @@ export class ErrorBoundary extends React.Component {
 
   componentDidCatch(error, info) {
     this.props.onError?.(error, info);
+    scheduleChunkReloadOnce(error);
   }
 
   render() {

--- a/src/platform/react/chunk-load-recovery.js
+++ b/src/platform/react/chunk-load-recovery.js
@@ -1,0 +1,51 @@
+import { isChunkLoadError } from './chunk-load-detect.js';
+
+export const CHUNK_RELOAD_SESSION_KEY = 'ks2_chunk_reload_attempted';
+
+function readSessionStorage() {
+  try {
+    return globalThis.sessionStorage || null;
+  } catch {
+    return null;
+  }
+}
+
+function readLocation() {
+  try {
+    return globalThis.location || null;
+  } catch {
+    return null;
+  }
+}
+
+export function clearChunkReloadAttempt(storage = readSessionStorage()) {
+  try {
+    storage?.removeItem?.(CHUNK_RELOAD_SESSION_KEY);
+  } catch {
+    // Storage can be unavailable in privacy-restricted browser contexts.
+  }
+}
+
+export function scheduleChunkReloadOnce(error, {
+  storage = readSessionStorage(),
+  location = readLocation(),
+  setTimeoutFn = globalThis.setTimeout,
+} = {}) {
+  if (!isChunkLoadError(error)) return false;
+  if (!storage || typeof storage.getItem !== 'function' || typeof storage.setItem !== 'function') return false;
+  if (!location || typeof location.reload !== 'function') return false;
+  try {
+    if (storage.getItem(CHUNK_RELOAD_SESSION_KEY) === '1') return false;
+    storage.setItem(CHUNK_RELOAD_SESSION_KEY, '1');
+  } catch {
+    return false;
+  }
+
+  const reload = () => location.reload();
+  if (typeof setTimeoutFn === 'function') {
+    setTimeoutFn(reload, 0);
+  } else {
+    reload();
+  }
+  return true;
+}

--- a/src/surfaces/hubs/AdminMarketingSection.jsx
+++ b/src/surfaces/hubs/AdminMarketingSection.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { renderRestrictedMarkdown } from '../../platform/ops/active-messages.js';
-import { normaliseMarketingMessage } from '../../platform/hubs/admin-read-model.js';
+import { normaliseMarketingMessage } from '../../platform/hubs/admin-marketing-message.js';
 import { createAdminMarketingApi } from '../../platform/hubs/admin-marketing-api.js';
 import { uid } from '../../platform/core/utils.js';
 import { useSubmitLock } from '../../platform/react/use-submit-lock.js';

--- a/src/surfaces/shell/TopNav.jsx
+++ b/src/surfaces/shell/TopNav.jsx
@@ -121,7 +121,6 @@ export function TopNav({
   persistenceMode,
   persistenceLabel,
   platformRole,
-  onOpenAdmin,
   currentScreen,
 }) {
   const showAdminLink = platformRole === 'admin' || platformRole === 'ops';
@@ -143,15 +142,14 @@ export function TopNav({
       </button>
       <div className="nav-right">
         {showAdminLink && (
-          <button
-            type="button"
-            className={'topnav-admin-link' + (adminActive ? ' is-active' : '')}
+          <a
+            className={'topnav-link topnav-admin-link' + (adminActive ? ' is-active' : '')}
             data-action="open-admin-hub"
+            href="/admin"
             aria-current={adminActive ? 'page' : undefined}
-            onClick={onOpenAdmin}
           >
             Admin
-          </button>
+          </a>
         )}
         <PersistenceDot mode={persistenceMode} label={persistenceLabel} />
         <UserPill

--- a/styles/app.css
+++ b/styles/app.css
@@ -2453,6 +2453,8 @@ textarea:focus-visible {
 .topnav-link,
 .profile-nav-link {
   appearance: none;
+  display: inline-flex;
+  align-items: center;
   min-height: 38px;
   padding: 7px 13px;
   border: 1px solid var(--line);
@@ -2462,6 +2464,7 @@ textarea:focus-visible {
   font-size: 0.9rem;
   font-weight: 800;
   cursor: pointer;
+  text-decoration: none;
   transition: border-color var(--dur) var(--ease-out), background var(--dur) var(--ease-out);
 }
 
@@ -11590,4 +11593,3 @@ html { scroll-behavior: smooth; }
 .admin-registry-section-eyebrow {
   margin-bottom: 12px;
 }
-

--- a/tests/admin-marketing-section.test.js
+++ b/tests/admin-marketing-section.test.js
@@ -10,7 +10,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { normaliseMarketingMessage } from '../src/platform/hubs/admin-read-model.js';
+import { normaliseMarketingMessage } from '../src/platform/hubs/admin-marketing-message.js';
 import { createAdminMarketingApi } from '../src/platform/hubs/admin-marketing-api.js';
 
 // ---------------------------------------------------------------------------

--- a/tests/error-boundary-chunk-load.test.js
+++ b/tests/error-boundary-chunk-load.test.js
@@ -7,6 +7,26 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { isChunkLoadError } from '../src/platform/react/chunk-load-detect.js';
+import {
+  CHUNK_RELOAD_SESSION_KEY,
+  clearChunkReloadAttempt,
+  scheduleChunkReloadOnce,
+} from '../src/platform/react/chunk-load-recovery.js';
+
+function memoryStorage(initial = {}) {
+  const values = new Map(Object.entries(initial));
+  return {
+    getItem(key) {
+      return values.has(key) ? values.get(key) : null;
+    },
+    setItem(key, value) {
+      values.set(key, String(value));
+    },
+    removeItem(key) {
+      values.delete(key);
+    },
+  };
+}
 
 // --- isChunkLoadError detection tests ---
 
@@ -63,4 +83,84 @@ test('isChunkLoadError matches "Failed to fetch dynamically imported module" wit
     'Failed to fetch dynamically imported module: https://ks2.eugnel.uk/src/bundles/ParentHubSurface-ZYHGNFPW.js',
   );
   assert.equal(isChunkLoadError(error), true);
+});
+
+test('scheduleChunkReloadOnce reloads once for a chunk-load failure', () => {
+  const storage = memoryStorage();
+  let reloads = 0;
+  const scheduled = scheduleChunkReloadOnce(
+    new TypeError('Failed to fetch dynamically imported module: /src/bundles/AdminHubSurface-OLD.js'),
+    {
+      storage,
+      location: { reload() { reloads += 1; } },
+      setTimeoutFn(callback) { callback(); },
+    },
+  );
+
+  assert.equal(scheduled, true);
+  assert.equal(reloads, 1);
+  assert.equal(storage.getItem(CHUNK_RELOAD_SESSION_KEY), '1');
+});
+
+test('scheduleChunkReloadOnce does not reload repeatedly in the same page session', () => {
+  const storage = memoryStorage({ [CHUNK_RELOAD_SESSION_KEY]: '1' });
+  let reloads = 0;
+  const scheduled = scheduleChunkReloadOnce(
+    new Error('Loading chunk admin failed'),
+    {
+      storage,
+      location: { reload() { reloads += 1; } },
+      setTimeoutFn(callback) { callback(); },
+    },
+  );
+
+  assert.equal(scheduled, false);
+  assert.equal(reloads, 0);
+});
+
+test('scheduleChunkReloadOnce ignores non-chunk errors', () => {
+  const storage = memoryStorage();
+  let reloads = 0;
+  const scheduled = scheduleChunkReloadOnce(
+    new TypeError("Cannot read properties of undefined (reading 'foo')"),
+    {
+      storage,
+      location: { reload() { reloads += 1; } },
+      setTimeoutFn(callback) { callback(); },
+    },
+  );
+
+  assert.equal(scheduled, false);
+  assert.equal(reloads, 0);
+  assert.equal(storage.getItem(CHUNK_RELOAD_SESSION_KEY), null);
+});
+
+test('scheduleChunkReloadOnce leaves the fallback visible when storage is unavailable', () => {
+  let reloads = 0;
+  const scheduled = scheduleChunkReloadOnce(
+    new Error('Loading chunk admin failed'),
+    {
+      storage: {
+        getItem() {
+          throw new Error('sessionStorage unavailable');
+        },
+        setItem() {
+          throw new Error('sessionStorage unavailable');
+        },
+      },
+      location: { reload() { reloads += 1; } },
+      setTimeoutFn(callback) { callback(); },
+    },
+  );
+
+  assert.equal(scheduled, false);
+  assert.equal(reloads, 0);
+});
+
+test('clearChunkReloadAttempt removes the reload guard after a successful boot', () => {
+  const storage = memoryStorage({ [CHUNK_RELOAD_SESSION_KEY]: '1' });
+
+  clearChunkReloadAttempt(storage);
+
+  assert.equal(storage.getItem(CHUNK_RELOAD_SESSION_KEY), null);
 });

--- a/tests/react-topnav-admin-link.test.js
+++ b/tests/react-topnav-admin-link.test.js
@@ -6,17 +6,19 @@ import { renderTopNavFixture } from './helpers/react-render.js';
 test('Admin user sees "Admin" link in TopNav', async () => {
   const html = await renderTopNavFixture({ platformRole: 'admin' });
 
-  assert.match(html, /class="topnav-admin-link"/);
+  assert.match(html, /class="topnav-link topnav-admin-link"/);
   assert.match(html, /data-action="open-admin-hub"/);
-  assert.match(html, />Admin<\/button>/);
+  assert.match(html, /href="\/admin"/);
+  assert.match(html, />Admin<\/a>/);
 });
 
 test('Ops user sees "Admin" link in TopNav', async () => {
   const html = await renderTopNavFixture({ platformRole: 'ops' });
 
-  assert.match(html, /class="topnav-admin-link"/);
+  assert.match(html, /class="topnav-link topnav-admin-link"/);
   assert.match(html, /data-action="open-admin-hub"/);
-  assert.match(html, />Admin<\/button>/);
+  assert.match(html, /href="\/admin"/);
+  assert.match(html, />Admin<\/a>/);
 });
 
 test('Parent user does NOT see "Admin" link in TopNav', async () => {
@@ -40,14 +42,13 @@ test('Undefined platformRole does NOT show "Admin" link', async () => {
   assert.doesNotMatch(html, /data-action="open-admin-hub"/);
 });
 
-test('Clicking Admin link targets open-admin-hub action', async () => {
+test('Clicking Admin link targets the no-store /admin document route', async () => {
   const html = await renderTopNavFixture({ platformRole: 'admin' });
 
-  // SSR cannot fire click handlers, but the data-action attribute confirms
-  // the button is wired to the correct action dispatch target.
+  // Use a document navigation so stale app shells do not fetch an old
+  // code-split AdminHubSurface chunk after a deploy.
   assert.match(html, /data-action="open-admin-hub"/);
-  // The button must also be a real <button> element for accessibility.
-  assert.match(html, /<button[^>]*class="topnav-admin-link"[^>]*>/);
+  assert.match(html, /<a[^>]*class="topnav-link topnav-admin-link"[^>]*href="\/admin"[^>]*>/);
 });
 
 test('When on admin screen, link shows active state', async () => {
@@ -60,7 +61,7 @@ test('When on admin screen, link shows active state', async () => {
 test('When NOT on admin screen, link does not show active state', async () => {
   const html = await renderTopNavFixture({ platformRole: 'admin', currentScreen: 'dashboard' });
 
-  assert.match(html, /class="topnav-admin-link"/);
+  assert.match(html, /class="topnav-link topnav-admin-link"/);
   assert.doesNotMatch(html, /is-active/);
   assert.doesNotMatch(html, /aria-current/);
 });


### PR DESCRIPTION
## Summary
- make the top-nav Admin entry use the no-store `/admin` document route so stale app shells do not request retired code-split chunks
- auto-reload once on chunk-load failures with a session guard, preserving the fallback when storage is unavailable
- move admin marketing message normalisation into a client-safe module so the Admin chunk no longer pulls server read-model/spelling content into the production bundle

## Verification
- `node --test tests/build-public.test.js tests/admin-marketing-section.test.js tests/error-boundary-chunk-load.test.js tests/react-topnav-admin-link.test.js`
- `node --test tests/build-hash-injection.test.js tests/admin-marketing-section.test.js tests/error-boundary-chunk-load.test.js tests/react-topnav-admin-link.test.js tests/react-hub-surfaces.test.js`
- `node --test tests/spelling-dense-history-smoke.test.js`
- `npm run check`

## Notes
- Full `npm test` currently fails on existing `origin/main` failures, confirmed in a detached `origin/main` worktree: CSP inline-style/oracle budget failures, Grammar star expectation failures, the Marketing tab “Soon” expectation, and worker admin-marketing mutation 429 expectations. Those failures are outside this hotfix diff.