### PR TITLE
feat(punctuation): stall-punctuation-command fault kind (P7-U9)

### DIFF
--- a/tests/helpers/browser-app-server.js
+++ b/tests/helpers/browser-app-server.js
@@ -188,6 +188,26 @@ export async function startBrowserAppServer({
           await new Promise((resolve) => setTimeout(resolve, faultDecision.delayMs));
         }
 
+        // P7-U9: stall action — hang for `durationMs` without
+        // responding or forwarding. The HTTP socket stays open but
+        // idle, simulating a Worker command that never completes.
+        // After the stall elapses we return early with no response
+        // body so the socket closes cleanly rather than forwarding
+        // to the real handler. This is fundamentally different from
+        // `delay` (which continues to the real handler after sleeping)
+        // and `timeout`/`respond` (which send an immediate response).
+        if (faultDecision.action === 'stall' && Number.isFinite(faultDecision.durationMs)) {
+          await new Promise((resolve) => setTimeout(resolve, faultDecision.durationMs));
+          if (!response.writableEnded) {
+            response.writeHead(504, {
+              'content-type': 'application/json; charset=utf-8',
+              'cache-control': 'no-store',
+            });
+            response.end(JSON.stringify({ ok: false, error: 'stall expired', code: 'stall_expired' }));
+          }
+          return;
+        }
+
         const workerResponse = await workerServer.fetchRaw(`http://${request.headers.host}${request.url || '/'}`, {
           method: request.method,
           headers: fetchHeadersFromNode(request.headers),

--- a/tests/helpers/fault-injection.mjs
+++ b/tests/helpers/fault-injection.mjs
@@ -51,6 +51,16 @@ const FAULT_KINDS = Object.freeze([
   // The handler reuses the same `respondJson(500, ...)` payload.
   '500-tts',
   'offline',
+  // P7-U9: stall-punctuation-command simulates a Worker command that
+  // hangs indefinitely (or for a configurable duration). Unlike
+  // `timeout` which returns a 408 immediately, this kind produces a
+  // true stall — the response promise does not resolve until
+  // `durationMs` elapses. The middleware in browser-app-server.js
+  // neither responds to nor forwards the request during the stall
+  // window. This enables honest testing of pending/degraded navigation
+  // in U11 where mutation buttons must disable while navigation/escape
+  // buttons remain available.
+  'stall-punctuation-command',
 ]);
 
 const PLAN_QUERY_PARAM = '__ks2_fault';
@@ -79,12 +89,21 @@ function decodePlan(encoded) {
     const pathPattern = typeof parsed.pathPattern === 'string' ? parsed.pathPattern : '';
     if (!pathPattern) return null;
     const planId = typeof parsed.planId === 'string' && parsed.planId ? parsed.planId : '';
-    return {
+    // P7-U9: `durationMs` is an optional numeric field used by the
+    // `stall-punctuation-command` kind to configure how long the
+    // middleware hangs before releasing the socket. When absent or
+    // non-numeric, `applyFault` falls back to the 30 000 ms default.
+    const durationMs = typeof parsed.durationMs === 'number' && Number.isFinite(parsed.durationMs)
+      ? parsed.durationMs
+      : undefined;
+    const result = {
       kind,
       pathPattern,
       once: Boolean(parsed.once),
       planId,
     };
+    if (durationMs !== undefined) result.durationMs = durationMs;
+    return result;
   } catch {
     return null;
   }
@@ -102,6 +121,11 @@ function encodePlan(plan) {
   };
   if (typeof plan?.planId === 'string' && plan.planId) {
     canonical.planId = plan.planId;
+  }
+  // P7-U9: preserve durationMs so stall-punctuation-command scenes
+  // can configure the hang duration via the encoded plan transport.
+  if (typeof plan?.durationMs === 'number' && Number.isFinite(plan.durationMs)) {
+    canonical.durationMs = plan.durationMs;
   }
   return Buffer.from(JSON.stringify(canonical), 'utf8').toString('base64');
 }
@@ -176,6 +200,9 @@ function parseFaultPlan(request) {
  *                            / `headers` back to the client.
  *   - action: 'delay'     -> sleep `delayMs` and then continue to the
  *                            real dispatcher.
+ *   - action: 'stall'     -> hang for `durationMs` without responding
+ *                            or forwarding; simulates a command that
+ *                            never completes (P7-U9).
  *   - action: 'forward'   -> no fault applies, forward as normal.
  *
  * The function is pure — the caller owns actually performing the
@@ -252,6 +279,22 @@ function applyFault(plan, request) {
           'cache-control': 'no-store',
         },
         body: JSON.stringify({ ok: false, error: 'offline', code: 'offline' }),
+      };
+    case 'stall-punctuation-command':
+      // P7-U9: true stall — the middleware must neither respond to nor
+      // forward the request for `durationMs`. The caller (browser-app-
+      // server.js) awaits the returned Promise, during which the HTTP
+      // response socket stays open but idle. This differs from `timeout`
+      // (which returns 408 immediately) and `delay` (which sleeps then
+      // forwards to the real handler). The plan's `durationMs` field
+      // allows scenes to choose a duration appropriate for the test;
+      // the default 30 000 ms is long enough for any reasonable UI
+      // assertion without risking CI timeout.
+      return {
+        action: 'stall',
+        durationMs: typeof plan.durationMs === 'number' && Number.isFinite(plan.durationMs)
+          ? plan.durationMs
+          : 30_000,
       };
     default:
       return { action: 'forward' };

--- a/tests/helpers/fault-injection.mjs
+++ b/tests/helpers/fault-injection.mjs
@@ -93,7 +93,7 @@ function decodePlan(encoded) {
     // `stall-punctuation-command` kind to configure how long the
     // middleware hangs before releasing the socket. When absent or
     // non-numeric, `applyFault` falls back to the 30 000 ms default.
-    const durationMs = typeof parsed.durationMs === 'number' && Number.isFinite(parsed.durationMs)
+    const durationMs = typeof parsed.durationMs === 'number' && Number.isFinite(parsed.durationMs) && parsed.durationMs > 0
       ? parsed.durationMs
       : undefined;
     const result = {
@@ -292,7 +292,7 @@ function applyFault(plan, request) {
       // assertion without risking CI timeout.
       return {
         action: 'stall',
-        durationMs: typeof plan.durationMs === 'number' && Number.isFinite(plan.durationMs)
+        durationMs: typeof plan.durationMs === 'number' && Number.isFinite(plan.durationMs) && plan.durationMs > 0
           ? plan.durationMs
           : 30_000,
       };

--- a/tests/punctuation-fault-injection.test.js
+++ b/tests/punctuation-fault-injection.test.js
@@ -285,6 +285,30 @@ test('decodePlan preserves durationMs when the field is a finite number', () => 
 // Test: stall is fundamentally different from timeout (408 immediate)
 // ---------------------------------------------------------------------------
 
+test('decodePlan treats durationMs <= 0 as undefined (falls to default)', () => {
+  const negativeEncoded = Buffer.from(JSON.stringify({
+    kind: 'stall-punctuation-command',
+    pathPattern: '/api/subjects/punctuation/command',
+    durationMs: -1,
+  }), 'utf8').toString('base64');
+  const negativeDecoded = faultInjection.decodePlan(negativeEncoded);
+  assert.ok(negativeDecoded, 'plan with durationMs: -1 must decode successfully');
+  assert.equal(negativeDecoded.durationMs, undefined, 'negative durationMs must be omitted from decoded plan');
+
+  const zeroEncoded = Buffer.from(JSON.stringify({
+    kind: 'stall-punctuation-command',
+    pathPattern: '/api/subjects/punctuation/command',
+    durationMs: 0,
+  }), 'utf8').toString('base64');
+  const zeroDecoded = faultInjection.decodePlan(zeroEncoded);
+  assert.ok(zeroDecoded, 'plan with durationMs: 0 must decode successfully');
+  assert.equal(zeroDecoded.durationMs, undefined, 'zero durationMs must be omitted from decoded plan');
+});
+
+// ---------------------------------------------------------------------------
+// Test: stall is fundamentally different from timeout (408 immediate)
+// ---------------------------------------------------------------------------
+
 test('timeout returns immediate 408 respond; stall returns a stall action', () => {
   const stallPlan = {
     kind: 'stall-punctuation-command',

--- a/tests/punctuation-fault-injection.test.js
+++ b/tests/punctuation-fault-injection.test.js
@@ -1,0 +1,308 @@
+// P7-U9: unit tests for the `stall-punctuation-command` fault kind.
+//
+// These tests lock the contract that U11 depends on for pending/degraded
+// navigation proof:
+//
+//   1. The `stall` action hangs for a configurable duration rather than
+//      responding or forwarding immediately.
+//   2. The fault kind is activatable via the existing base64 query param
+//      and header transport — no new transport is required.
+//   3. Without the opt-in header, the fault plan is ignored.
+//   4. Malformed plans return null — no crash.
+//   5. The `__ks2_injectFault_TESTS_ONLY__` forbidden-text token covers
+//      this module (verified by the existing bundle-audit.test.js; this
+//      file asserts the token is exported as a self-check).
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { __ks2_injectFault_TESTS_ONLY__ as faultInjection } from './helpers/fault-injection.mjs';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRequest(plan, { pathname = '/api/subjects/punctuation/command' } = {}) {
+  const encoded = faultInjection.encodePlan(plan);
+  return {
+    url: pathname,
+    pathname,
+    headers: {
+      [faultInjection.OPT_IN_HEADER]: faultInjection.OPT_IN_VALUE,
+      [faultInjection.PLAN_HEADER]: encoded,
+    },
+  };
+}
+
+function makeRequestWithoutOptIn(plan, { pathname = '/api/subjects/punctuation/command' } = {}) {
+  const encoded = faultInjection.encodePlan(plan);
+  return {
+    url: pathname,
+    pathname,
+    headers: {
+      [faultInjection.PLAN_HEADER]: encoded,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test: stall-punctuation-command is a recognised FAULT_KIND
+// ---------------------------------------------------------------------------
+
+test('stall-punctuation-command is listed in FAULT_KINDS', () => {
+  assert.ok(
+    faultInjection.FAULT_KINDS.includes('stall-punctuation-command'),
+    'FAULT_KINDS must include stall-punctuation-command',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Test: applyFault returns stall action with configurable duration
+// ---------------------------------------------------------------------------
+
+test('applyFault returns stall action with default 30s duration', () => {
+  const plan = {
+    kind: 'stall-punctuation-command',
+    pathPattern: '/api/subjects/punctuation/command',
+    once: false,
+  };
+  const request = {
+    url: '/api/subjects/punctuation/command',
+    pathname: '/api/subjects/punctuation/command',
+  };
+  const decision = faultInjection.applyFault(plan, request);
+  assert.equal(decision.action, 'stall', 'action must be stall');
+  assert.equal(decision.durationMs, 30_000, 'default duration must be 30 000 ms');
+});
+
+test('applyFault returns stall action with custom durationMs from plan', () => {
+  const plan = {
+    kind: 'stall-punctuation-command',
+    pathPattern: '/api/subjects/punctuation/command',
+    once: false,
+    durationMs: 5000,
+  };
+  const request = {
+    url: '/api/subjects/punctuation/command',
+    pathname: '/api/subjects/punctuation/command',
+  };
+  const decision = faultInjection.applyFault(plan, request);
+  assert.equal(decision.action, 'stall');
+  assert.equal(decision.durationMs, 5000, 'custom durationMs must be honoured');
+});
+
+// ---------------------------------------------------------------------------
+// Test: fault hook activatable via existing base64 query param transport
+// ---------------------------------------------------------------------------
+
+test('stall plan round-trips through encodePlan/parseFaultPlan with durationMs preserved', () => {
+  const plan = {
+    kind: 'stall-punctuation-command',
+    pathPattern: '/api/subjects/punctuation/command',
+    once: true,
+    planId: 'stall-scene-1',
+    durationMs: 2000,
+  };
+  const request = makeRequest(plan);
+  const parsed = faultInjection.parseFaultPlan(request);
+  assert.ok(parsed, 'parseFaultPlan must accept a stall-punctuation-command plan');
+  assert.equal(parsed.kind, 'stall-punctuation-command');
+  assert.equal(parsed.pathPattern, '/api/subjects/punctuation/command');
+  assert.equal(parsed.once, true);
+  assert.equal(parsed.planId, 'stall-scene-1');
+  assert.equal(parsed.durationMs, 2000, 'durationMs must survive the encode/decode round-trip');
+});
+
+test('stall plan decodable from base64 query param transport', () => {
+  const plan = {
+    kind: 'stall-punctuation-command',
+    pathPattern: '/api/subjects/punctuation/command',
+    once: false,
+    durationMs: 3000,
+  };
+  const encoded = faultInjection.encodePlan(plan);
+  const request = {
+    url: `/api/subjects/punctuation/command?${faultInjection.PLAN_QUERY_PARAM}=${encoded}`,
+    headers: {
+      [faultInjection.OPT_IN_HEADER]: faultInjection.OPT_IN_VALUE,
+    },
+  };
+  const parsed = faultInjection.parseFaultPlan(request);
+  assert.ok(parsed, 'parseFaultPlan must decode stall plan from query param');
+  assert.equal(parsed.kind, 'stall-punctuation-command');
+  assert.equal(parsed.durationMs, 3000);
+});
+
+// ---------------------------------------------------------------------------
+// Test: fault hook without opt-in header is ignored (no stall)
+// ---------------------------------------------------------------------------
+
+test('stall plan without opt-in header returns null from parseFaultPlan', () => {
+  const plan = {
+    kind: 'stall-punctuation-command',
+    pathPattern: '/api/subjects/punctuation/command',
+    once: false,
+  };
+  const request = makeRequestWithoutOptIn(plan);
+  const parsed = faultInjection.parseFaultPlan(request);
+  assert.equal(parsed, null, 'plan must be ignored when opt-in header is absent');
+});
+
+// ---------------------------------------------------------------------------
+// Test: malformed fault plan returns null (no crash)
+// ---------------------------------------------------------------------------
+
+test('malformed base64 plan returns null from decodePlan', () => {
+  assert.equal(faultInjection.decodePlan('not-valid-base64!!!'), null);
+});
+
+test('plan with unknown kind returns null from decodePlan', () => {
+  const encoded = Buffer.from(JSON.stringify({
+    kind: 'unknown-kind',
+    pathPattern: '/api/test',
+  }), 'utf8').toString('base64');
+  assert.equal(faultInjection.decodePlan(encoded), null);
+});
+
+test('plan missing pathPattern returns null from decodePlan', () => {
+  const encoded = Buffer.from(JSON.stringify({
+    kind: 'stall-punctuation-command',
+  }), 'utf8').toString('base64');
+  assert.equal(faultInjection.decodePlan(encoded), null);
+});
+
+test('null/undefined/empty input to decodePlan returns null', () => {
+  assert.equal(faultInjection.decodePlan(null), null);
+  assert.equal(faultInjection.decodePlan(undefined), null);
+  assert.equal(faultInjection.decodePlan(''), null);
+  assert.equal(faultInjection.decodePlan(42), null);
+});
+
+// ---------------------------------------------------------------------------
+// Test: stall action in the fault registry (once: true fires once)
+// ---------------------------------------------------------------------------
+
+test('createFaultRegistry: stall-punctuation-command once:true fires once then forwards', () => {
+  const registry = faultInjection.createFaultRegistry();
+  const plan = {
+    kind: 'stall-punctuation-command',
+    pathPattern: '/api/subjects/punctuation/command',
+    once: true,
+    planId: 'stall-once-test',
+    durationMs: 100,
+  };
+  const request = {
+    url: '/api/subjects/punctuation/command',
+    pathname: '/api/subjects/punctuation/command',
+    headers: {},
+  };
+
+  const first = registry.decide(plan, request);
+  assert.equal(first.action, 'stall', 'first matching request must produce stall');
+  assert.equal(first.durationMs, 100);
+
+  const second = registry.decide(plan, request);
+  assert.equal(second.action, 'forward', 'second matching request must fall through');
+
+  assert.equal(registry.size, 1, 'exactly one plan identity consumed');
+});
+
+// ---------------------------------------------------------------------------
+// Test: stall does not match non-matching pathnames
+// ---------------------------------------------------------------------------
+
+test('stall plan does not fire for non-matching pathname', () => {
+  const plan = {
+    kind: 'stall-punctuation-command',
+    pathPattern: '/api/subjects/punctuation/command',
+    once: false,
+  };
+  const request = {
+    url: '/api/bootstrap',
+    pathname: '/api/bootstrap',
+  };
+  const decision = faultInjection.applyFault(plan, request);
+  assert.equal(decision.action, 'forward', 'non-matching pathname must forward');
+});
+
+// ---------------------------------------------------------------------------
+// Test: __ks2_injectFault_TESTS_ONLY__ token is present (bundle audit)
+// ---------------------------------------------------------------------------
+
+test('__ks2_injectFault_TESTS_ONLY__ export is present and includes stall kind', () => {
+  assert.ok(
+    typeof faultInjection === 'object' && faultInjection !== null,
+    '__ks2_injectFault_TESTS_ONLY__ must be an object',
+  );
+  assert.ok(
+    faultInjection.FAULT_KINDS.includes('stall-punctuation-command'),
+    'the forbidden-text-guarded export must include the new stall kind',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Test: durationMs defaults correctly when omitted or non-numeric
+// ---------------------------------------------------------------------------
+
+test('applyFault uses default 30s when durationMs is not a number', () => {
+  const plan = {
+    kind: 'stall-punctuation-command',
+    pathPattern: '/api/subjects/punctuation/command',
+    once: false,
+    durationMs: 'not-a-number',
+  };
+  const request = {
+    url: '/api/subjects/punctuation/command',
+    pathname: '/api/subjects/punctuation/command',
+  };
+  const decision = faultInjection.applyFault(plan, request);
+  assert.equal(decision.durationMs, 30_000, 'non-numeric durationMs must fall back to 30 000 ms');
+});
+
+test('decodePlan omits durationMs when the field is not a finite number', () => {
+  const encoded = Buffer.from(JSON.stringify({
+    kind: 'stall-punctuation-command',
+    pathPattern: '/api/subjects/punctuation/command',
+    durationMs: 'bad',
+  }), 'utf8').toString('base64');
+  const decoded = faultInjection.decodePlan(encoded);
+  assert.ok(decoded, 'plan must decode successfully');
+  assert.equal(decoded.durationMs, undefined, 'non-numeric durationMs must be omitted from decoded plan');
+});
+
+test('decodePlan preserves durationMs when the field is a finite number', () => {
+  const encoded = Buffer.from(JSON.stringify({
+    kind: 'stall-punctuation-command',
+    pathPattern: '/api/subjects/punctuation/command',
+    durationMs: 7500,
+  }), 'utf8').toString('base64');
+  const decoded = faultInjection.decodePlan(encoded);
+  assert.ok(decoded);
+  assert.equal(decoded.durationMs, 7500);
+});
+
+// ---------------------------------------------------------------------------
+// Test: stall is fundamentally different from timeout (408 immediate)
+// ---------------------------------------------------------------------------
+
+test('timeout returns immediate 408 respond; stall returns a stall action', () => {
+  const stallPlan = {
+    kind: 'stall-punctuation-command',
+    pathPattern: '/api/test',
+    once: false,
+  };
+  const timeoutPlan = {
+    kind: 'timeout',
+    pathPattern: '/api/test',
+    once: false,
+  };
+  const request = { url: '/api/test', pathname: '/api/test' };
+
+  const stallDecision = faultInjection.applyFault(stallPlan, request);
+  const timeoutDecision = faultInjection.applyFault(timeoutPlan, request);
+
+  assert.equal(stallDecision.action, 'stall', 'stall-punctuation-command must produce stall action');
+  assert.equal(timeoutDecision.action, 'respond', 'timeout must produce respond action');
+  assert.equal(timeoutDecision.status, 408, 'timeout must return 408 status');
+  assert.notEqual(stallDecision.action, timeoutDecision.action, 'stall and timeout actions must differ');
+});


### PR DESCRIPTION
## Summary
- Add `stall-punctuation-command` to `FAULT_KINDS` in `tests/helpers/fault-injection.mjs` with a new `stall` action type that hangs the HTTP response for a configurable duration (default 30s) without responding or forwarding
- Add `stall` action branch to the middleware in `tests/helpers/browser-app-server.js` -- neither responds nor forwards during the stall window, then closes with 504 after expiry
- Add 17 unit tests in `tests/punctuation-fault-injection.test.js` covering: stall action, configurable duration, base64 transport round-trip, opt-in header guard, malformed plan handling, registry once:true contract, and stall-vs-timeout differentiation

## Key design decisions
- The `stall` action is fundamentally different from `timeout` (which returns 408 immediately) and `delay` (which sleeps then forwards to the real handler). The stall holds the socket open idle for `durationMs`.
- `durationMs` is an optional numeric field in the plan JSON, preserved through encode/decode round-trip. Non-numeric or absent values fall back to 30 000 ms.
- Production safety: covered by the existing `__ks2_injectFault_TESTS_ONLY__` forbidden-text token denial (verified by bundle-audit.test.js). Per-request opt-in header required.

## Test plan
- [x] 17/17 new punctuation-fault-injection tests pass
- [x] 10/10 existing fault-injection tests pass (no regression)
- [x] 40/40 bundle-audit tests pass (forbidden-text token still covers the module)
- [x] 47/47 persistence tests pass (downstream consumers unaffected)
- [ ] Unblocks U11 pending/degraded navigation proof