### PR TITLE
feat(punctuation): full Worker-backed Playwright journey proof with star consistency (P7-U10)

### DIFF
--- a/tests/journeys/README.md
+++ b/tests/journeys/README.md
@@ -15,7 +15,7 @@ first one that responds to `status` (bb-browser) or `--help` (agent-browser)
 wins. Playwright is not loaded; the existing Playwright golden-path specs
 under `tests/playwright/` are orthogonal and keep working.
 
-## Six journeys
+## Six journeys (bb-browser driver)
 
 | Script                              | Journey                                                  |
 | ----------------------------------- | -------------------------------------------------------- |
@@ -25,6 +25,29 @@ under `tests/playwright/` are orthogonal and keep working.
 | `map-guided-skill.mjs`              | Map -> skill card -> Practise this -> Guided Q1          |
 | `summary-back-while-pending.mjs`    | SKIPPED: needs dev-only stall endpoint (see below)       |
 | `reward-parity-visual.mjs`          | Map + Setup + Summary reward-state parity                |
+
+## Playwright golden-path coverage (P7-U10)
+
+The Playwright golden-path test at `tests/playwright/punctuation-golden-path.playwright.test.mjs`
+exercises the **full Worker-backed journey** through the real Worker/D1 command
+path in a Chromium browser. This is separate from the bb-browser journeys above
+and runs via `npx playwright test`. Coverage added in P7-U10:
+
+| Test name                                          | Journey                                                      |
+| -------------------------------------------------- | ------------------------------------------------------------ |
+| complete journey (star consistency)                 | Home -> landing -> session -> summary -> landing -> refresh -> map; star meter consistency across all surfaces |
+| refresh after full journey (SH2-U2 regression)     | Full session -> summary -> reload -> clean setup; zombie-phase guard |
+| map opens from landing and closes back to landing   | Landing -> open map -> map body visible -> close map -> landing CTA |
+| telemetry disabled journey                          | Session to summary with telemetry rate-limited via route intercept; no console errors |
+
+**Star consistency contract (§5.5):** After completing a round, Star counts
+from the landing monster meters, the summary monster meters, and the map
+monster-group headers must agree (within display rounding). The test reads
+`.punctuation-monster-meter-count` elements on each surface and compares
+parsed numeric values.
+
+**Mobile-390 baseline:** All Playwright tests run against the `mobile-390`
+project (390 x 844 viewport). Desktop/tablet matrix deferred to follow-up.
 
 ## Prerequisites
 

--- a/tests/playwright/punctuation-golden-path.playwright.test.mjs
+++ b/tests/playwright/punctuation-golden-path.playwright.test.mjs
@@ -462,6 +462,11 @@ test.describe('P7-U10: full Worker-backed Punctuation journey', () => {
     // ---------------------------------------------------------------
     // Step 10: Star meter consistency
     // ---------------------------------------------------------------
+
+    // Hard-fail if any meter array is empty — prevents vacuous passes.
+    expect(landingMetersAfter.length, 'Post-session landing must have star meters').toBeGreaterThan(0);
+    expect(landingMetersRefreshed.length, 'Post-refresh landing must have star meters').toBeGreaterThan(0);
+
     // Post-session landing and post-refresh landing must agree.
     // Star counts extracted as numbers must be identical.
     if (landingMetersAfter.length > 0 && landingMetersRefreshed.length > 0) {
@@ -487,6 +492,8 @@ test.describe('P7-U10: full Worker-backed Punctuation journey', () => {
     // that mirrors the setup scene's monster meters. Both read from the same
     // starView + rewardState + mergeMonotonicDisplay pipeline, so counts
     // must be identical.
+    expect(summaryMeters.length, 'Summary must have star meters').toBeGreaterThan(0);
+
     if (summaryMeters.length > 0 && landingMetersAfter.length > 0) {
       // Build lookup by monster name for comparison (order may differ).
       const summaryByName = Object.fromEntries(summaryMeters.map((m) => [m.name, m]));
@@ -510,6 +517,8 @@ test.describe('P7-U10: full Worker-backed Punctuation journey', () => {
     // and verify they match the landing meters for the same monsters.
     // Map headers contain text like "Pealark12 / 100 Stars · Getting started"
     // so parsing requires a broader pattern.
+    expect(mapHeaders.length, 'Map must have monster-group headers').toBeGreaterThan(0);
+
     if (mapHeaders.length > 0 && landingMetersAfter.length > 0) {
       for (const header of mapHeaders) {
         const mapStars = parseStarCount(header.text.replace(/^[A-Za-z\s]+/, ''));
@@ -529,6 +538,18 @@ test.describe('P7-U10: full Worker-backed Punctuation journey', () => {
         }
       }
     }
+
+    // ---------------------------------------------------------------
+    // Star progression: at least one monster must show progress
+    // after completing a session (prevents vacuous all-zero passes).
+    // ---------------------------------------------------------------
+    const anyProgression = landingMetersAfter.some((m, i) =>
+      landingMetersBefore[i] && parseStarCount(m.text) > parseStarCount(landingMetersBefore[i].text),
+    );
+    expect(
+      anyProgression,
+      'At least one monster should show star progress after completing a session',
+    ).toBeTruthy();
   });
 
   // ---------------------------------------------------------------

--- a/tests/playwright/punctuation-golden-path.playwright.test.mjs
+++ b/tests/playwright/punctuation-golden-path.playwright.test.mjs
@@ -7,16 +7,152 @@
 //
 // Baselines in U5 are captured only at `mobile-390`. Full matrix
 // lands in U10/U12.
+//
+// P7-U10: Full Worker-backed Playwright journey proof (§5.5).
+// Extends the golden path to cover the complete journey:
+//   1. Home/dashboard → Punctuation landing
+//   2. Start today's round (mission-dashboard CTA)
+//   3. First item render
+//   4. Submit answer
+//   5. Feedback (or GPS delayed path)
+//   6. Summary + star meter read
+//   7. Return to landing + star meter read
+//   8. Refresh/bootstrap
+//   9. Open Punctuation Map + star meter read
+//  10. Star meter consistency across all surfaces
+//  11. Telemetry write path: no disruption when telemetry enabled/disabled
 
 import { test, expect } from '@playwright/test';
 import {
   applyDeterminism,
   createDemoSession,
   openSubject,
+  navigateHome,
   punctuationAnswer,
   punctuationContinue,
   reload,
 } from './shared.mjs';
+
+// -----------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------
+
+/**
+ * Read Star counts from the `.punctuation-monster-meter-count` elements
+ * on the current surface. Returns a sorted array of `{ name, text }`
+ * objects. The `text` value is the raw content, e.g. `"0 / 100 Stars"`.
+ * The Monster-meter class is shared across setup, summary, and map
+ * headers so this helper works on all three surfaces.
+ */
+async function readStarMeters(page) {
+  await page.waitForSelector('.punctuation-monster-meter-count', { timeout: 10_000 }).catch(() => null);
+  const meters = page.locator('.punctuation-monster-meter-count');
+  const count = await meters.count();
+  const result = [];
+  for (let i = 0; i < count; i += 1) {
+    const text = ((await meters.nth(i).textContent()) || '').trim();
+    // Walk up to find the meter-name sibling.
+    const parent = meters.nth(i).locator('..');
+    const nameEl = parent.locator('.punctuation-monster-meter-name');
+    const name = (await nameEl.count()) > 0
+      ? ((await nameEl.first().textContent()) || '').trim()
+      : `meter-${i}`;
+    result.push({ name, text });
+  }
+  return result.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Read map monster-group header star text (e.g. "12 / 100 Stars · Getting
+ * started"). Returns an array of `{ monsterId, text }` from the
+ * `.punctuation-map-monster-group` headers.
+ */
+async function readMapStarHeaders(page) {
+  const groups = page.locator('.punctuation-map-monster-group');
+  const count = await groups.count();
+  const result = [];
+  for (let i = 0; i < count; i += 1) {
+    const monsterId = (await groups.nth(i).getAttribute('data-monster-id')) || `group-${i}`;
+    const head = groups.nth(i).locator('.punctuation-map-monster-group-head');
+    const text = (await head.count()) > 0
+      ? ((await head.first().textContent()) || '').trim()
+      : '';
+    result.push({ monsterId, text });
+  }
+  return result.sort((a, b) => a.monsterId.localeCompare(b.monsterId));
+}
+
+/**
+ * Extract the numeric star value from a meter text string.
+ * "12 / 100 Stars" → 12, "3 / 100 Grand Stars" → 3.
+ */
+function parseStarCount(text) {
+  const match = (text || '').match(/^(\d+)\s*\/\s*\d+/);
+  return match ? Number(match[1]) : NaN;
+}
+
+/**
+ * Drive the Punctuation session to completion (summary). Answers items
+ * and uses "Finish now" when available. Returns once the summary scene
+ * is visible. Handles the variable queue length the deterministic seed
+ * produces.
+ */
+async function driveSessionToSummary(page) {
+  // First answer.
+  await punctuationAnswer(page, {
+    typed: 'full-journey-answer-attempt',
+    choiceIndex: 0,
+  });
+  await expect(page.locator('[data-punctuation-continue]')).toBeVisible({ timeout: 10_000 });
+
+  // Try to finish early via "Finish now" on the feedback card.
+  const finishNow = page.getByRole('button', { name: /Finish now/ });
+  if (await finishNow.count()) {
+    await finishNow.first().click();
+  } else {
+    await punctuationContinue(page);
+  }
+
+  // The session may present more items before summary. Loop up to a
+  // reasonable bound to drive through any remaining items.
+  for (let i = 0; i < 12; i += 1) {
+    const summaryOrSubmit = page.locator(
+      '[data-punctuation-summary], [data-punctuation-submit]',
+    ).first();
+    await expect(summaryOrSubmit).toBeVisible({ timeout: 15_000 });
+
+    // If summary already visible, we are done.
+    if (await page.locator('[data-punctuation-summary]').count()) break;
+
+    // Still in session — answer and try to finish again.
+    await punctuationAnswer(page, {
+      typed: 'another-journey-attempt',
+      choiceIndex: 0,
+    });
+    const continueBtn = page.locator('[data-punctuation-continue]');
+    await expect(continueBtn).toBeVisible({ timeout: 10_000 });
+
+    const finish = page.getByRole('button', { name: /Finish now/ });
+    if (await finish.count()) {
+      await finish.first().click();
+    } else {
+      await punctuationContinue(page);
+    }
+  }
+
+  await expect(page.locator('[data-punctuation-summary]')).toBeVisible({ timeout: 15_000 });
+}
+
+/**
+ * Start CTA selector — the mission-dashboard primary CTA carries
+ * `data-punctuation-cta`; legacy paths used `[data-punctuation-start]`.
+ * Match either for robustness.
+ */
+const START_CTA_SELECTOR = '[data-punctuation-cta], [data-punctuation-start]';
+
+// -----------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------
 
 test.describe('punctuation golden path', () => {
   test.beforeEach(async ({ page }) => {
@@ -31,7 +167,7 @@ test.describe('punctuation golden path', () => {
     await openSubject(page, 'punctuation');
 
     // Setup hero for punctuation practice.
-    const startBtn = page.locator('[data-punctuation-start]');
+    const startBtn = page.locator(START_CTA_SELECTOR).first();
     await expect(startBtn).toBeVisible({ timeout: 15_000 });
     await startBtn.click();
 
@@ -75,7 +211,7 @@ test.describe('punctuation golden path', () => {
     // "progress preserved".
     await reload(page);
     const reloadedMarker = page.locator(
-      '[data-punctuation-start], [data-punctuation-summary], .subject-grid [data-action="open-subject"][data-subject-id="punctuation"]',
+      `${START_CTA_SELECTOR}, [data-punctuation-summary], .subject-grid [data-action="open-subject"][data-subject-id="punctuation"]`,
     );
     await expect(reloadedMarker.first()).toBeVisible({ timeout: 15_000 });
   });
@@ -92,7 +228,7 @@ test.describe('punctuation golden path', () => {
     await expect(page.locator('.subject-grid')).toBeVisible();
     await openSubject(page, 'punctuation');
 
-    const startBtn = page.locator('[data-punctuation-start]');
+    const startBtn = page.locator(START_CTA_SELECTOR).first();
     await expect(startBtn).toBeVisible({ timeout: 15_000 });
     await startBtn.click();
 
@@ -124,7 +260,7 @@ test.describe('punctuation golden path', () => {
     // A safe fallback is either the Punctuation setup (start button) or
     // the home subject grid.
     const safeMarker = page.locator(
-      '.subject-grid [data-action="open-subject"][data-subject-id="punctuation"], [data-punctuation-start]',
+      `.subject-grid [data-action="open-subject"][data-subject-id="punctuation"], ${START_CTA_SELECTOR}`,
     ).first();
     await expect(safeMarker).toBeVisible({ timeout: 15_000 });
 
@@ -143,8 +279,378 @@ test.describe('punctuation golden path', () => {
     if (await onGrid.count()) {
       await onGrid.first().click();
     }
-    await expect(page.locator('[data-punctuation-start]')).toBeVisible({ timeout: 15_000 });
+    await expect(page.locator(START_CTA_SELECTOR).first()).toBeVisible({ timeout: 15_000 });
     // Summary surface MUST NOT reappear after re-opening Punctuation.
     await expect(page.locator('[data-punctuation-summary]')).toHaveCount(0);
+  });
+});
+
+// -----------------------------------------------------------------------
+// P7-U10: Full Worker-backed Playwright journey proof (§5.5)
+//
+// Exercises the complete Punctuation journey through the real Worker/D1
+// command path end-to-end in a browser. Every assertion fires against
+// actual DOM rendered from Worker responses — NOT SSR or direct dispatch.
+//
+// Star consistency contract: after completing a round, Star counts read
+// from the landing (setup) monster meters, the summary monster meters,
+// and the map monster-group headers must agree (within display rounding).
+//
+// Telemetry write path: the journey completes without errors regardless
+// of whether telemetry events are accepted or rate-limited.
+//
+// Mobile-390 baseline consistent with existing tests. Desktop/tablet
+// matrix deferred to follow-up.
+// -----------------------------------------------------------------------
+
+test.describe('P7-U10: full Worker-backed Punctuation journey', () => {
+  test.beforeEach(async ({ page }) => {
+    await applyDeterminism(page);
+  });
+
+  test('complete journey: home → landing → session → summary → landing → refresh → map with star consistency', async ({ page }) => {
+    // ---------------------------------------------------------------
+    // Step 1: Home/dashboard → Punctuation landing
+    // ---------------------------------------------------------------
+    await createDemoSession(page);
+    await expect(page.locator('.subject-grid')).toBeVisible();
+
+    // The home dashboard must show the punctuation subject card.
+    const punctuationCard = page.locator(
+      '.subject-card[data-action="open-subject"][data-subject-id="punctuation"]',
+    );
+    await expect(punctuationCard).toBeVisible();
+    await openSubject(page, 'punctuation');
+
+    // Landing (setup phase) must render the mission-dashboard CTA and
+    // the monster-meter row.
+    const startBtn = page.locator(START_CTA_SELECTOR).first();
+    await expect(startBtn).toBeVisible({ timeout: 15_000 });
+    await expect(page.locator('[data-punctuation-phase="setup"]')).toBeVisible();
+
+    // Read pre-session star meters from the landing for baseline.
+    const landingMetersBefore = await readStarMeters(page);
+
+    // ---------------------------------------------------------------
+    // Step 2: Start today's round (mission-dashboard CTA)
+    // ---------------------------------------------------------------
+    await startBtn.click();
+
+    // ---------------------------------------------------------------
+    // Step 3: First item renders
+    // ---------------------------------------------------------------
+    const sessionScene = page.locator('[data-punctuation-session-scene]').first();
+    await expect(sessionScene).toBeVisible({ timeout: 15_000 });
+
+    // The session must present either a choice or text input.
+    const inputPresent = page.locator(
+      '[data-punctuation-submit], .choice-card, textarea[name="typed"]',
+    ).first();
+    await expect(inputPresent).toBeVisible({ timeout: 10_000 });
+
+    // ---------------------------------------------------------------
+    // Step 4: Submit answer
+    // ---------------------------------------------------------------
+    await punctuationAnswer(page, {
+      typed: 'full-journey-first-answer',
+      choiceIndex: 0,
+    });
+
+    // ---------------------------------------------------------------
+    // Step 5: Feedback renders (or GPS delayed path)
+    // ---------------------------------------------------------------
+    const feedbackOrContinue = page.locator(
+      '[data-punctuation-continue], [data-punctuation-session-feedback-live]',
+    ).first();
+    await expect(feedbackOrContinue).toBeVisible({ timeout: 10_000 });
+
+    // ---------------------------------------------------------------
+    // Step 6: Drive to summary
+    // ---------------------------------------------------------------
+    // Use the helper to drive through remaining items to summary.
+    const finishNow = page.getByRole('button', { name: /Finish now/ });
+    if (await finishNow.count()) {
+      await finishNow.first().click();
+    } else {
+      await punctuationContinue(page);
+    }
+
+    // Handle any remaining session items.
+    for (let i = 0; i < 12; i += 1) {
+      const summaryOrSubmit = page.locator(
+        '[data-punctuation-summary], [data-punctuation-submit]',
+      ).first();
+      await expect(summaryOrSubmit).toBeVisible({ timeout: 15_000 });
+
+      if (await page.locator('[data-punctuation-summary]').count()) break;
+
+      await punctuationAnswer(page, {
+        typed: 'journey-follow-up',
+        choiceIndex: 0,
+      });
+      const cont = page.locator('[data-punctuation-continue]');
+      await expect(cont).toBeVisible({ timeout: 10_000 });
+
+      const fin = page.getByRole('button', { name: /Finish now/ });
+      if (await fin.count()) {
+        await fin.first().click();
+      } else {
+        await punctuationContinue(page);
+      }
+    }
+
+    await expect(page.locator('[data-punctuation-summary]')).toBeVisible({ timeout: 15_000 });
+
+    // Read summary star meters.
+    const summaryMeters = await readStarMeters(page);
+
+    // ---------------------------------------------------------------
+    // Step 7: Return to landing
+    // ---------------------------------------------------------------
+    // Navigate back via the home brand button, then re-open punctuation.
+    await navigateHome(page);
+    await expect(page.locator('.subject-grid')).toBeVisible();
+    await openSubject(page, 'punctuation');
+    await expect(page.locator(START_CTA_SELECTOR).first()).toBeVisible({ timeout: 15_000 });
+
+    // Read post-session landing star meters.
+    const landingMetersAfter = await readStarMeters(page);
+
+    // ---------------------------------------------------------------
+    // Step 8: Refresh/bootstrap
+    // ---------------------------------------------------------------
+    await reload(page);
+
+    // After reload the learner must land on either the subject grid
+    // or the punctuation setup — never on summary.
+    const reloadedSurface = page.locator(
+      `${START_CTA_SELECTOR}, .subject-grid [data-action="open-subject"][data-subject-id="punctuation"]`,
+    ).first();
+    await expect(reloadedSurface).toBeVisible({ timeout: 15_000 });
+    await expect(page.locator('[data-punctuation-summary]')).toHaveCount(0);
+
+    // If landed on home grid, re-open punctuation.
+    const onGridAfterReload = page.locator(
+      '.subject-grid [data-action="open-subject"][data-subject-id="punctuation"]',
+    );
+    if (await onGridAfterReload.count()) {
+      await onGridAfterReload.first().click();
+      await expect(page.locator(START_CTA_SELECTOR).first()).toBeVisible({ timeout: 15_000 });
+    }
+
+    // Read post-refresh landing star meters.
+    const landingMetersRefreshed = await readStarMeters(page);
+
+    // ---------------------------------------------------------------
+    // Step 9: Open Punctuation Map
+    // ---------------------------------------------------------------
+    const openMapBtn = page.locator('[data-action="punctuation-open-map"]').first();
+    await expect(openMapBtn).toBeVisible({ timeout: 10_000 });
+    await openMapBtn.click();
+
+    await expect(page.locator('[data-punctuation-map]')).toBeVisible({ timeout: 15_000 });
+
+    // Read map star headers.
+    const mapHeaders = await readMapStarHeaders(page);
+
+    // Close map — back to landing.
+    const closeMapBtn = page.locator('[data-action="punctuation-close-map"]').first();
+    await expect(closeMapBtn).toBeVisible();
+    await closeMapBtn.click();
+    await expect(page.locator(START_CTA_SELECTOR).first()).toBeVisible({ timeout: 15_000 });
+
+    // ---------------------------------------------------------------
+    // Step 10: Star meter consistency
+    // ---------------------------------------------------------------
+    // Post-session landing and post-refresh landing must agree.
+    // Star counts extracted as numbers must be identical.
+    if (landingMetersAfter.length > 0 && landingMetersRefreshed.length > 0) {
+      expect(
+        landingMetersAfter.length,
+        'Post-session and post-refresh landing must show the same number of monster meters',
+      ).toBe(landingMetersRefreshed.length);
+
+      for (let i = 0; i < landingMetersAfter.length; i += 1) {
+        const afterStars = parseStarCount(landingMetersAfter[i].text);
+        const refreshedStars = parseStarCount(landingMetersRefreshed[i].text);
+        if (!Number.isNaN(afterStars) && !Number.isNaN(refreshedStars)) {
+          expect(
+            afterStars,
+            `Star count for "${landingMetersAfter[i].name}" must agree between post-session and post-refresh landing`,
+          ).toBe(refreshedStars);
+        }
+      }
+    }
+
+    // Summary meters vs post-session landing meters: the same monsters
+    // must show the same Star counts. Summary includes a MonsterProgressStrip
+    // that mirrors the setup scene's monster meters. Both read from the same
+    // starView + rewardState + mergeMonotonicDisplay pipeline, so counts
+    // must be identical.
+    if (summaryMeters.length > 0 && landingMetersAfter.length > 0) {
+      // Build lookup by monster name for comparison (order may differ).
+      const summaryByName = Object.fromEntries(summaryMeters.map((m) => [m.name, m]));
+      const landingByName = Object.fromEntries(landingMetersAfter.map((m) => [m.name, m]));
+
+      for (const [name, summaryMeter] of Object.entries(summaryByName)) {
+        const landingMeter = landingByName[name];
+        if (!landingMeter) continue; // Skip monsters only on one surface.
+        const summaryStars = parseStarCount(summaryMeter.text);
+        const landingStars = parseStarCount(landingMeter.text);
+        if (!Number.isNaN(summaryStars) && !Number.isNaN(landingStars)) {
+          expect(
+            summaryStars,
+            `Star count for "${name}" must agree between summary and landing (within display rounding)`,
+          ).toBe(landingStars);
+        }
+      }
+    }
+
+    // Map headers vs landing meters: extract star counts from map headers
+    // and verify they match the landing meters for the same monsters.
+    // Map headers contain text like "Pealark12 / 100 Stars · Getting started"
+    // so parsing requires a broader pattern.
+    if (mapHeaders.length > 0 && landingMetersAfter.length > 0) {
+      for (const header of mapHeaders) {
+        const mapStars = parseStarCount(header.text.replace(/^[A-Za-z\s]+/, ''));
+        if (Number.isNaN(mapStars)) continue;
+        // Find matching landing meter by checking if header text starts
+        // with a name from the landing meters.
+        const matchingLanding = landingMetersAfter.find((m) =>
+          header.text.toLowerCase().includes(m.name.toLowerCase()),
+        );
+        if (!matchingLanding) continue;
+        const landingStars = parseStarCount(matchingLanding.text);
+        if (!Number.isNaN(landingStars)) {
+          expect(
+            mapStars,
+            `Map star count for monster "${header.monsterId}" must agree with landing meter`,
+          ).toBe(landingStars);
+        }
+      }
+    }
+  });
+
+  // ---------------------------------------------------------------
+  // P7-U10: SH2-U2 refresh regression guard. After completing a
+  // session, reload must land on a clean setup phase — not re-render
+  // the summary. This is a dedicated proof distinct from the SH2-U2
+  // test above because it runs through the full journey first.
+  // ---------------------------------------------------------------
+  test('refresh after full journey returns to clean setup state (SH2-U2 regression)', async ({ page }) => {
+    await createDemoSession(page);
+    await expect(page.locator('.subject-grid')).toBeVisible();
+    await openSubject(page, 'punctuation');
+
+    const startBtn = page.locator(START_CTA_SELECTOR).first();
+    await expect(startBtn).toBeVisible({ timeout: 15_000 });
+    await startBtn.click();
+
+    await driveSessionToSummary(page);
+
+    // Reload from summary.
+    await reload(page);
+
+    // Must NOT land on summary.
+    await expect(page.locator('[data-punctuation-summary]')).toHaveCount(0);
+
+    // Must land on either home grid or setup.
+    const safeTarget = page.locator(
+      `${START_CTA_SELECTOR}, .subject-grid [data-action="open-subject"][data-subject-id="punctuation"]`,
+    ).first();
+    await expect(safeTarget).toBeVisible({ timeout: 15_000 });
+
+    // Re-open Punctuation if on home grid.
+    const gridCard = page.locator(
+      '.subject-grid [data-action="open-subject"][data-subject-id="punctuation"]',
+    );
+    if (await gridCard.count()) {
+      await gridCard.first().click();
+    }
+    await expect(page.locator(START_CTA_SELECTOR).first()).toBeVisible({ timeout: 15_000 });
+    await expect(page.locator('[data-punctuation-summary]')).toHaveCount(0);
+  });
+
+  // ---------------------------------------------------------------
+  // P7-U10: Map open/close round-trip from landing.
+  // ---------------------------------------------------------------
+  test('map opens from landing and closes back to landing', async ({ page }) => {
+    await createDemoSession(page);
+    await expect(page.locator('.subject-grid')).toBeVisible();
+    await openSubject(page, 'punctuation');
+
+    await expect(page.locator(START_CTA_SELECTOR).first()).toBeVisible({ timeout: 15_000 });
+
+    // Open map.
+    const openMapBtn = page.locator('[data-action="punctuation-open-map"]').first();
+    await expect(openMapBtn).toBeVisible({ timeout: 10_000 });
+    await openMapBtn.click();
+
+    await expect(page.locator('[data-punctuation-map]')).toBeVisible({ timeout: 15_000 });
+
+    // Map must show the map body.
+    await expect(page.locator('[data-punctuation-map-body]')).toBeVisible();
+
+    // Close map.
+    const closeMapBtn = page.locator('[data-action="punctuation-close-map"]').first();
+    await expect(closeMapBtn).toBeVisible();
+    await closeMapBtn.click();
+
+    // Must return to landing — setup phase with CTA visible.
+    await expect(page.locator(START_CTA_SELECTOR).first()).toBeVisible({ timeout: 15_000 });
+    await expect(page.locator('[data-punctuation-map]')).toHaveCount(0);
+  });
+
+  // ---------------------------------------------------------------
+  // P7-U10: Telemetry disabled path — journey completes without
+  // errors when telemetry events are absent or rate-limited.
+  // The contract says "verify no learner disruption when telemetry
+  // is enabled/disabled". We intercept the telemetry route and
+  // force 429 responses, then run the session to summary and verify
+  // no console errors disrupt the journey.
+  // ---------------------------------------------------------------
+  test('telemetry disabled: journey completes without errors when telemetry is rate-limited', async ({ page }) => {
+    const consoleErrors = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+    page.on('pageerror', (err) => {
+      consoleErrors.push(err.message);
+    });
+
+    // Intercept telemetry event recording route and return rate-limited.
+    await page.route('**/api/subjects/punctuation/command', async (route) => {
+      const postData = route.request().postData() || '';
+      // Only intercept record-event commands; let other commands through.
+      if (postData.includes('"record-event"') || postData.includes("'record-event'")) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ ok: true, recorded: false, rateLimited: true }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await createDemoSession(page);
+    await expect(page.locator('.subject-grid')).toBeVisible();
+    await openSubject(page, 'punctuation');
+
+    const startBtn = page.locator(START_CTA_SELECTOR).first();
+    await expect(startBtn).toBeVisible({ timeout: 15_000 });
+    await startBtn.click();
+
+    await driveSessionToSummary(page);
+
+    // The journey must complete without page errors. Filter out
+    // benign telemetry-related messages (rate-limit logs are expected).
+    const realErrors = consoleErrors.filter(
+      (msg) => !msg.includes('rate') && !msg.includes('telemetry') && !msg.includes('Rate'),
+    );
+    expect(
+      realErrors,
+      'No console errors should disrupt the journey when telemetry is rate-limited',
+    ).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

- Extend the Playwright golden-path test to prove the complete Punctuation journey through the real Worker/D1 command path end-to-end in a browser
- Add star meter consistency contract: after a round, Star counts from landing, summary, and map must agree
- Add telemetry rate-limited path test proving no learner disruption when record-event is intercepted
- Add map open/close round-trip and SH2-U2 refresh regression guard after full journey
- Update journey README with Playwright golden-path coverage table

## Test plan

- [ ] Verify `npm test` passes (unit tests unaffected by Playwright test changes)
- [ ] Run `npx playwright test --project mobile-390 tests/playwright/punctuation-golden-path.playwright.test.mjs` to exercise the full journey
- [ ] Verify star consistency assertions fire across landing, summary, and map surfaces
- [ ] Verify telemetry-disabled test completes without page errors
- [ ] Verify no `.skip` markers in the test file