### PR TITLE
fix(admin): harden stale chunk recovery

### DIFF
--- a/docs/operations/capacity.md
+++ b/docs/operations/capacity.md
@@ -518,8 +518,10 @@ Expected values on every path:
 
 Path-specific cache expectations:
 
-- `/src/bundles/app.bundle.js` — `Cache-Control: public, max-age=31536000, immutable` (Worker
-  wrapper explicitly overrides the `no-store` that ASSETS applies from the `_headers` `/*` group).
+- `/src/bundles/app.bundle.js` — `Cache-Control: no-store`. The public HTML adds a content-hash
+  `?v=` query to this stable entry filename so browsers do not keep an entry bundle that points at
+  retired lazy chunks.
+- `/src/bundles/*-HASH.js` split chunks — `Cache-Control: public, max-age=31536000, immutable`.
 - `/manifest.webmanifest` — `Cache-Control: public, max-age=3600` (1-hour cache updated in U8
   so app-manifest churn is visible to installed PWAs within the hour).
 - `/favicon.ico` — `Cache-Control: public, max-age=86400`.
@@ -537,7 +539,7 @@ Manual spot-check (use when the audit script is unavailable):
 
 ```bash
 curl -sI https://ks2.eugnel.uk/                                  | grep -i cache-control   # expect: no-store
-curl -sI https://ks2.eugnel.uk/src/bundles/app.bundle.js         | grep -i cache-control   # expect: public, max-age=31536000, immutable
+curl -sI https://ks2.eugnel.uk/src/bundles/app.bundle.js         | grep -i cache-control   # expect: no-store
 curl -sI https://ks2.eugnel.uk/assets/app-icons/favicon-32.png   | grep -i cache-control   # expect: public, max-age=31536000, immutable
 curl -sI https://ks2.eugnel.uk/api/bootstrap                     | grep -i cache-control   # expect: no-store
 curl -sI https://ks2.eugnel.uk/manifest.webmanifest              | grep -i cache-control   # expect: public, max-age=3600

--- a/scripts/assert-build-public.mjs
+++ b/scripts/assert-build-public.mjs
@@ -1,6 +1,7 @@
 import { access, readFile, readdir } from 'node:fs/promises';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { createHash } from 'node:crypto';
 import { assertCacheSplitRules, assertHeadersBlockIsFresh } from './lib/headers-drift.mjs';
 
 const rootDir = process.cwd();
@@ -169,20 +170,25 @@ assertHeadersBlockIsFresh(publishedHeadersContent);
 assertCacheSplitRules(publishedHeadersContent);
 
 const indexHtml = await readFile(path.join(publicDir, 'index.html'), 'utf8');
+const appBundle = await readFile(path.join(publicDir, 'src/bundles/app.bundle.js'), 'utf8');
 if (!indexHtml.includes('/manifest.webmanifest')) {
   throw new Error('Public index.html must link the web app manifest.');
 }
 if (!indexHtml.includes('/assets/app-icons/apple-touch-icon.png')) {
   throw new Error('Public index.html must link the Apple home-screen icon.');
 }
-if (!indexHtml.includes('./src/bundles/app.bundle.js')) {
-  throw new Error('Public index.html must load the React app bundle.');
+const appBundleVersionMatch = indexHtml.match(/\.\/src\/bundles\/app\.bundle\.js\?v=([a-f0-9]{12})/);
+if (!appBundleVersionMatch) {
+  throw new Error('Public index.html must load the React app bundle with a content-hash query string.');
+}
+const expectedAppBundleVersion = createHash('sha256').update(appBundle).digest('hex').slice(0, 12);
+if (appBundleVersionMatch[1] !== expectedAppBundleVersion) {
+  throw new Error('Public index.html app.bundle.js version query does not match the bundle content hash.');
 }
 if (indexHtml.includes('home.bundle.js') || indexHtml.includes('src/main.js')) {
   throw new Error('Public index.html must not load legacy home islands or the raw source entry.');
 }
 
-const appBundle = await readFile(path.join(publicDir, 'src/bundles/app.bundle.js'), 'utf8');
 for (const token of [
   '__ks2HomeSurface',
   '__ks2CodexSurface',

--- a/scripts/audit-client-bundle.mjs
+++ b/scripts/audit-client-bundle.mjs
@@ -22,14 +22,15 @@ const DEFAULT_PUBLIC_DIR = 'dist/public';
 // was 203,227 bytes vs the 253,181 bytes pre-split main bundle on
 // `main`. That is a ~50 KB first-paint reduction — the adult-only
 // Admin Hub + Parent Hub hubs now ship as lazy-loaded chunks.
-// Budget is `baseline × 1.05 ≈ 213,390` rounded up to 214,000 so the
-// main-bundle gzip has a tiny amount of headroom for line-count
-// growth without admitting a regression that pulls ~50 KB of adult
-// surface JS back into the learner-first critical path. Override via
-// CLI `--main-bundle-budget-bytes` for experimentation. See
+// Budget was originally `baseline × 1.05 ≈ 213,390`, rounded up to
+// 214,000. Node 24's zlib output for the current Hero P2 baseline sits
+// just above that at ~214,020 bytes, so the committed ceiling is 215,000:
+// still tight enough to catch an adult-surface re-import, without
+// blocking on a sub-kilobyte compression/runtime drift. Override via CLI
+// `--main-bundle-budget-bytes` for experimentation. See
 // `tests/bundle-byte-budget.test.js` for the committed baseline +
 // rationale.
-const DEFAULT_MAIN_BUNDLE_GZIP_BUDGET_BYTES = 214_000;
+const DEFAULT_MAIN_BUNDLE_GZIP_BUDGET_BYTES = 215_000;
 
 const FORBIDDEN_MODULES = [
   { pattern: /^src\/subjects\/spelling\/data\//, reason: 'full spelling content dataset' },

--- a/scripts/build-client.mjs
+++ b/scripts/build-client.mjs
@@ -111,14 +111,12 @@ export async function runBuildClient({ buildHash } = {}) {
   //
   // `splitting: true` requires `format: 'esm'` (already in place) and
   // uses `outdir` instead of `outfile`. `entryNames: 'app.bundle'`
-  // keeps the entry name stable at `app.bundle.js` so the Worker
-  // allowlist, `_headers` `/src/bundles/` cache rules, and the
-  // `index.html` `<script type="module" src="./src/bundles/app.bundle.js">`
-  // reference continue to resolve to the same filename. Chunk names
-  // (`chunkNames: '[name]-[hash]'`) give each split chunk a content-
-  // hashed filename so the immutable cache in
-  // `worker/src/security-headers.js::isImmutableBundlePath` is safe
-  // across redeploys.
+  // keeps the entry name stable at `app.bundle.js` so the Worker allowlist
+  // and `index.html` can point at one entry. `scripts/build-public.mjs`
+  // appends a content-hash query string to that script URL, and
+  // `worker/src/security-headers.js` serves the stable entry with no-store.
+  // Chunk names (`chunkNames: '[name]-[hash]'`) give each split chunk a
+  // content-hashed filename so immutable caching is safe across redeploys.
   //
   // F-01 (same-PR atomicity): `worker/src/app.js::publicSourceAssetResponse`
   // is updated in the same commit to match `/src/bundles/*.js` by prefix,

--- a/scripts/build-public.mjs
+++ b/scripts/build-public.mjs
@@ -1,5 +1,6 @@
 import { cp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import { createHash } from 'node:crypto';
 import { computeInlineScriptHash } from './compute-inline-script-hash.mjs';
 
 const rootDir = process.cwd();
@@ -21,6 +22,11 @@ const tmpDir = path.join(rootDir, 'dist', 'public.tmp');
 const generatedCspHashPath = path.join(rootDir, 'worker', 'src', 'generated-csp-hash.js');
 const publicCspHashArtefactPath = path.join(outputDir, '.csp-theme-hash');
 const publicHeadersPath = path.join(outputDir, '_headers');
+const appBundleScriptSrc = './src/bundles/app.bundle.js';
+
+function shortContentHash(buffer) {
+  return createHash('sha256').update(buffer).digest('hex').slice(0, 12);
+}
 
 const entries = [
   '_headers',
@@ -108,14 +114,31 @@ try {
     { force: true },
   );
 
+  // `app.bundle.js` has a stable filename because index.html is the only
+  // entry point. Stamp the public HTML with the bundle content hash so a
+  // no-store HTML refresh never reuses a browser-cached stale entry bundle
+  // that points at retired lazy chunks.
+  const appBundlePath = path.join(tmpDir, 'src', 'bundles', 'app.bundle.js');
+  const appBundleBytes = await readFile(appBundlePath);
+  const appBundleVersion = shortContentHash(appBundleBytes);
+  const tmpIndexPath = path.join(tmpDir, 'index.html');
+  const tmpIndexHtml = await readFile(tmpIndexPath, 'utf8');
+  if (!tmpIndexHtml.includes(appBundleScriptSrc)) {
+    throw new Error(`index.html must reference ${appBundleScriptSrc} before build-public can version it.`);
+  }
+  await writeFile(
+    tmpIndexPath,
+    tmpIndexHtml.replaceAll(appBundleScriptSrc, `${appBundleScriptSrc}?v=${appBundleVersion}`),
+    'utf8',
+  );
+
   await rm(outputDir, { recursive: true, force: true });
   await cp(tmpDir, outputDir, { recursive: true, force: true });
   await rm(tmpDir, { recursive: true, force: true });
 
   // U7: compute the inline theme-script SHA-256 from the canonical
-  // source (`index.html` at repo root). The build already asserts the
-  // copied dist/public/index.html is byte-identical; we hash the
-  // repo-root copy so a failing copy step surfaces elsewhere.
+  // source (`index.html` at repo root). The public HTML rewrites only the
+  // external module script URL, so the inline theme script hash is unchanged.
   const sourceHtml = await readFile(path.join(rootDir, 'index.html'), 'utf8');
   const cspThemeHash = computeInlineScriptHash(sourceHtml);
 

--- a/scripts/lib/headers-drift.mjs
+++ b/scripts/lib/headers-drift.mjs
@@ -107,7 +107,8 @@ export function assertHeadersBlockIsFresh(headersContent, { allowPlaceholderHash
 //
 // The list is kept in sync with:
 //   - `_headers` (single source of truth at repo root)
-//   - `worker/src/security-headers.js` (`/src/bundles/*` immutable override)
+//   - `worker/src/security-headers.js` (`/src/bundles/app.bundle.js`
+//     no-store + split-chunk immutable override)
 //   - `scripts/production-bundle-audit.mjs` (live HEAD checks)
 //   - `docs/operations/capacity.md` (post-deploy cache-split check)
 //

--- a/scripts/production-bundle-audit.mjs
+++ b/scripts/production-bundle-audit.mjs
@@ -204,6 +204,16 @@ function assertNoForbiddenText(label, text, failures) {
   }
 }
 
+function firstSourceSplitChunkPath(paths) {
+  return Array.from(paths)
+    .sort()
+    .find((path) => (
+      path.startsWith('/src/bundles/')
+      && path.endsWith('.js')
+      && path !== '/src/bundles/app.bundle.js'
+    )) || null;
+}
+
 async function auditProduction(origin) {
   const failures = [];
   const base = new URL(origin);
@@ -292,7 +302,7 @@ async function auditProduction(origin) {
   // origin. We hit paths that cover each response-construction lane:
   //   - `/` — static HTML served by ASSETS (`_headers` `/` group).
   //   - `/src/bundles/app.bundle.js` — run_worker_first path that flows
-  //     through applySecurityHeaders with explicit immutable cache.
+  //     through applySecurityHeaders with explicit no-store entry caching.
   //   - `/manifest.webmanifest` — ASSETS direct with `_headers` manifest rule.
   //   - `/api/auth/logout` — Worker-produced 4xx/2xx that must carry
   //     Clear-Site-Data plus the full security set (review testing-gap-4).
@@ -401,7 +411,8 @@ async function auditProduction(origin) {
   // origin. Covers one representative per cache lane so a regression in
   // `_headers` or the Worker wrapper surfaces immediately:
   //   - `/` — HTML must never be cached (no-store).
-  //   - `/src/bundles/app.bundle.js` — Worker-wrapped hashed bundle (immutable).
+  //   - `/src/bundles/app.bundle.js` — stable Worker-wrapped entry (no-store).
+  //   - a discovered `/src/bundles/*-HASH.js` split chunk — immutable.
   //   - `/assets/app-icons/favicon-32.png` — ASSETS-direct hashed asset (immutable).
   //   - `/manifest.webmanifest` — intentional 1-hour short cache (neither
   //     immutable nor no-store).
@@ -411,12 +422,19 @@ async function auditProduction(origin) {
   // would always pass against the fallback path rather than the real GET
   // handler. `json()`'s hardcoded cache-control already makes the GET
   // endpoint no-store by construction (adv-1).
+  const splitChunkPath = firstSourceSplitChunkPath(visitedChunks);
+  if (!splitChunkPath) {
+    failures.push('Cache-split HEAD check could not discover any /src/bundles/ split chunk to verify immutable caching.');
+  }
   const CACHE_SPLIT_CHECKS = [
     { path: '/', label: 'root index', expected: 'no-store' },
-    { path: '/src/bundles/app.bundle.js', label: 'Worker-wrapped bundle', expected: 'public, max-age=31536000, immutable' },
+    { path: '/src/bundles/app.bundle.js', label: 'Worker-wrapped entry bundle', expected: 'no-store' },
+    splitChunkPath
+      ? { path: splitChunkPath, label: 'Worker-wrapped split chunk', expected: 'public, max-age=31536000, immutable' }
+      : null,
     { path: '/assets/app-icons/favicon-32.png', label: 'ASSETS app icon', expected: 'public, max-age=31536000, immutable' },
     { path: '/manifest.webmanifest', label: 'web app manifest', expected: 'public, max-age=3600' },
-  ];
+  ].filter(Boolean);
   let cacheChecksPassed = 0;
   for (const check of CACHE_SPLIT_CHECKS) {
     const target = new URL(check.path, base);

--- a/tests/build-public.test.js
+++ b/tests/build-public.test.js
@@ -1,5 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
@@ -10,7 +11,12 @@ test('public build emits the React app bundle entrypoint', () => {
   execFileSync(process.execPath, ['./scripts/audit-client-bundle.mjs'], { stdio: 'ignore' });
 
   const indexHtml = readFileSync('dist/public/index.html', 'utf8');
-  assert.match(indexHtml, /type="module" src="\.\/src\/bundles\/app\.bundle\.js"/);
+  const appBundle = readFileSync('dist/public/src/bundles/app.bundle.js', 'utf8');
+  const expectedAppBundleVersion = createHash('sha256').update(appBundle).digest('hex').slice(0, 12);
+  assert.match(
+    indexHtml,
+    new RegExp(`type="module" src="\\.\\/src\\/bundles\\/app\\.bundle\\.js\\?v=${expectedAppBundleVersion}"`),
+  );
   assert.doesNotMatch(indexHtml, /home\.bundle\.js/);
   assert.doesNotMatch(indexHtml, /src\/main\.js/);
 
@@ -21,7 +27,6 @@ test('public build emits the React app bundle entrypoint', () => {
   assert.equal(existsSync('dist/public/src/subjects/spelling/data/content-data.js'), false);
   assert.equal(existsSync('dist/public/worker/src/app.js'), false);
 
-  const appBundle = readFileSync('dist/public/src/bundles/app.bundle.js', 'utf8');
   const visualManifest = readFileSync('src/platform/game/monster-asset-manifest.js', 'utf8');
   const manifestHash = visualManifest.match(/"manifestHash": "([^"]+)"/)?.[1] || '';
   assert.ok(manifestHash, 'expected generated monster visual manifest hash');

--- a/tests/bundle-audit.test.js
+++ b/tests/bundle-audit.test.js
@@ -821,23 +821,23 @@ test('production bundle audit fails when live manifest Cache-Control drifts off 
     const url = request.url || '/';
     if (url === '/' || url === '/index.html') {
       response.writeHead(200, { 'content-type': 'text/html', 'cache-control': 'no-store' });
-      response.end('<!doctype html><script src="/assets/app.js"></script>');
+      response.end('<!doctype html><script type="module" src="/src/bundles/app.bundle.js?v=test"></script>');
       return;
     }
-    if (url === '/assets/app.js') {
+    if (url === '/src/bundles/app.bundle.js' || url === '/src/bundles/app.bundle.js?v=test') {
+      response.writeHead(200, {
+        'content-type': 'application/javascript',
+        'cache-control': 'no-store',
+      });
+      response.end('import"./chunk-CLEAN.js"; console.log("ok");');
+      return;
+    }
+    if (url === '/src/bundles/chunk-CLEAN.js') {
       response.writeHead(200, {
         'content-type': 'application/javascript',
         'cache-control': 'public, max-age=31536000, immutable',
       });
-      response.end('console.log("ok");');
-      return;
-    }
-    if (url === '/src/bundles/app.bundle.js') {
-      response.writeHead(200, {
-        'content-type': 'application/javascript',
-        'cache-control': 'public, max-age=31536000, immutable',
-      });
-      response.end('console.log("ok");');
+      response.end('console.log("clean");');
       return;
     }
     if (url === '/assets/app-icons/favicon-32.png') {
@@ -913,7 +913,7 @@ test('production bundle audit walks dynamic import chunks referenced only via im
       // split chunk. Esbuild emits `import("./chunk-CAFEBABE.js")` here.
       response.writeHead(200, {
         'content-type': 'application/javascript',
-        'cache-control': 'public, max-age=31536000, immutable',
+        'cache-control': 'no-store',
       });
       response.end('const m = import("./chunk-CAFEBABE.js"); console.log(m);');
       return;
@@ -998,7 +998,7 @@ test('production audit walks chunks referenced via minified static imports (no w
       // static import AND a side-effect import — both zero-whitespace.
       response.writeHead(200, {
         'content-type': 'application/javascript',
-        'cache-control': 'public, max-age=31536000, immutable',
+        'cache-control': 'no-store',
       });
       response.end(
         'import{X as a,Y as b}from"./chunk-static.js";import"./side-effect.js";console.log(a,b);',

--- a/tests/bundle-byte-budget.test.js
+++ b/tests/bundle-byte-budget.test.js
@@ -12,11 +12,13 @@
 //     That is a ~50 KB reduction — the adult-only hub chunks (Admin Hub
 //     + Parent Hub) now live in their own lazy-loaded chunks instead of
 //     the main bundle.
-// Budget is `baseline × 1.05 ≈ 213,389`, rounded up to the committed
-// `214_000`. The 5% headroom admits small copy / utility growth but
-// fails the gate when ~50 KB of adult-only JS sneaks back into the
-// critical path (the exact regression the code-split protects
-// against). The audit driver re-reads
+// Budget was `baseline × 1.05 ≈ 213,389`, rounded up to `214_000`.
+// Node 24's zlib output for the current Hero P2 baseline sits just
+// above that at ~214,020 bytes, so the committed ceiling is now
+// `215_000`. That keeps the headroom narrow while avoiding a
+// sub-kilobyte compression/runtime false blocker. The audit still fails
+// when ~50 KB of adult-only JS sneaks back into the critical path (the
+// exact regression the code-split protects against). The audit driver re-reads
 // `DEFAULT_MAIN_BUNDLE_GZIP_BUDGET_BYTES` from
 // `scripts/audit-client-bundle.mjs` via `runClientBundleAudit()`, so
 // any future budget adjustment flows through this test's constants.
@@ -52,13 +54,14 @@ const REPO_ROOT = path.resolve(__dirname, '..');
 // Measured on SH2-U10 first post-split build. If this figure drifts up
 // by more than a few kilobytes the committed budget needs a deliberate
 // re-evaluation — not a silent bump. Baseline × 1.05 = ~213,389,
-// rounded up to 214,000 (matches `DEFAULT_MAIN_BUNDLE_GZIP_BUDGET_BYTES`
-// in `scripts/audit-client-bundle.mjs`). The 5% headroom lets the team
-// land small copy / utility growth without an audit bump, but trips
-// the gate when ~50 KB of adult-only JS sneaks back into the critical
-// path.
+// rounded up to 214,000. Node 24's zlib output for the current Hero P2
+// baseline sits just above that, so the committed ceiling is 215,000
+// (matches `DEFAULT_MAIN_BUNDLE_GZIP_BUDGET_BYTES` in
+// `scripts/audit-client-bundle.mjs`). The narrow headroom lets the team
+// land small copy / utility growth without an audit bump, but trips the
+// gate when ~50 KB of adult-only JS sneaks back into the critical path.
 const BASELINE_GZIP_BYTES = 203_227;
-const BUDGET_GZIP_BYTES = 214_000;
+const BUDGET_GZIP_BYTES = 215_000;
 
 test('SH2-U10 baseline + budget constants stay in a sensible ratio', () => {
   // Guard rail: budget must exceed baseline, or every build fails.

--- a/tests/security-headers.test.js
+++ b/tests/security-headers.test.js
@@ -153,20 +153,37 @@ test('applySecurityHeaders treats x-ks2-tts-* metadata as TTS signal even when c
   assert.equal(wrapped.headers.get('cache-control'), 'no-store');
 });
 
-test('applySecurityHeaders forces immutable cache on /src/bundles/*', () => {
+test('applySecurityHeaders keeps the stable app entry bundle no-store', () => {
   const response = new Response('console.log("bundle")', {
     status: 200,
     headers: {
       'content-type': 'application/javascript',
-      'cache-control': 'no-store',
+      'cache-control': 'public, max-age=31536000, immutable',
     },
   });
   const wrapped = applySecurityHeaders(response, { path: '/src/bundles/app.bundle.js' });
   assertHasAllSecurityHeaders(wrapped);
   assert.equal(
     wrapped.headers.get('cache-control'),
+    'no-store',
+    'The stable entry filename must not strand clients on stale lazy chunk names.',
+  );
+});
+
+test('applySecurityHeaders forces immutable cache on hashed /src/bundles/* split chunks', () => {
+  const response = new Response('console.log("chunk")', {
+    status: 200,
+    headers: {
+      'content-type': 'application/javascript',
+      'cache-control': 'no-store',
+    },
+  });
+  const wrapped = applySecurityHeaders(response, { path: '/src/bundles/AdminHubSurface-ABC12345.js' });
+  assertHasAllSecurityHeaders(wrapped);
+  assert.equal(
+    wrapped.headers.get('cache-control'),
     'public, max-age=31536000, immutable',
-    'Bundle path explicitly overrides ASSETS-response no-store via set()',
+    'Content-hashed split chunks explicitly override ASSETS-response no-store via set()',
   );
 });
 
@@ -226,6 +243,72 @@ test('Worker 404 plaintext from publicSourceAssetResponse carries all seven secu
   const server = createWorkerRepositoryServer();
   const response = await server.fetchRaw('https://repo.test/src/main.js');
   assert.equal(response.status, 404);
+  assertHasAllSecurityHeaders(response);
+  server.close();
+});
+
+test('Worker bundle allowlist refuses ASSETS SPA fallback HTML for missing chunks', async () => {
+  const server = createWorkerRepositoryServer({
+    env: {
+      ASSETS: {
+        async fetch() {
+          return new Response('<!doctype html><div id="app"></div>', {
+            status: 200,
+            headers: { 'content-type': 'text/html' },
+          });
+        },
+      },
+    },
+  });
+  const response = await server.fetchRaw('https://repo.test/src/bundles/AdminHubSurface-OLD.js');
+  assert.equal(response.status, 404);
+  assert.equal(response.headers.get('content-type'), 'text/plain; charset=utf-8');
+  assert.equal(response.headers.get('cache-control'), 'no-store');
+  assertHasAllSecurityHeaders(response);
+  server.close();
+});
+
+test('Worker bundle allowlist serves JavaScript chunks through ASSETS with split-chunk cache policy', async () => {
+  const server = createWorkerRepositoryServer({
+    env: {
+      ASSETS: {
+        async fetch() {
+          return new Response('export default 1;', {
+            status: 200,
+            headers: {
+              'content-type': 'text/javascript',
+              'cache-control': 'no-store',
+            },
+          });
+        },
+      },
+    },
+  });
+  const response = await server.fetchRaw('https://repo.test/src/bundles/AdminHubSurface-OK123456.js');
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get('cache-control'), 'public, max-age=31536000, immutable');
+  assertHasAllSecurityHeaders(response);
+  server.close();
+});
+
+test('Worker bundle allowlist preserves ASSETS 304 responses for conditional chunk requests', async () => {
+  const server = createWorkerRepositoryServer({
+    env: {
+      ASSETS: {
+        async fetch() {
+          return new Response(null, {
+            status: 304,
+            headers: { etag: '"chunk-etag"' },
+          });
+        },
+      },
+    },
+  });
+  const response = await server.fetchRaw('https://repo.test/src/bundles/AdminHubSurface-CACHED12.js', {
+    headers: { 'if-none-match': '"chunk-etag"' },
+  });
+  assert.equal(response.status, 304);
+  assert.equal(response.headers.get('cache-control'), 'no-store');
   assertHasAllSecurityHeaders(response);
   server.close();
 });
@@ -481,7 +564,7 @@ test('applySecurityHeaders does NOT apply immutable cache to non-2xx bundle resp
       'cache-control': 'private, max-age=30',
     },
   });
-  const wrapped500 = applySecurityHeaders(serverError, { path: '/src/bundles/app.bundle.js' });
+  const wrapped500 = applySecurityHeaders(serverError, { path: '/src/bundles/chunk-ERROR123.js' });
   assertHasAllSecurityHeaders(wrapped500);
   assert.equal(
     wrapped500.headers.get('cache-control'),
@@ -499,7 +582,7 @@ test('applySecurityHeaders does NOT apply immutable cache to non-2xx bundle resp
     status: 304,
     headers: {},
   });
-  const wrapped304 = applySecurityHeaders(notModified, { path: '/src/bundles/app.bundle.js' });
+  const wrapped304 = applySecurityHeaders(notModified, { path: '/src/bundles/chunk-NOTMOD12.js' });
   assert.notEqual(
     wrapped304.headers.get('cache-control'),
     'public, max-age=31536000, immutable',

--- a/tests/worker-admin-marketing-read.test.js
+++ b/tests/worker-admin-marketing-read.test.js
@@ -355,3 +355,17 @@ test('U11 Marketing Read Routes', async (t) => {
     assert.equal(data.message.title, 'Hidden Draft');
   });
 });
+
+test('active-messages soft-fails open when the marketing table is not migrated', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    server.DB.db.exec('DROP TABLE admin_marketing_messages;');
+    const res = await getActiveMessages(server, 'adult-parent');
+    assert.equal(res.status, 200);
+    const data = await res.json();
+    assert.equal(data.ok, true);
+    assert.deepEqual(data.messages, []);
+  } finally {
+    server.close();
+  }
+});

--- a/worker/src/admin-marketing.js
+++ b/worker/src/admin-marketing.js
@@ -59,6 +59,10 @@ const VALID_TRANSITIONS = new Map([
 const TITLE_MAX_LENGTH = 200;
 const BODY_MAX_LENGTH = 4000;
 
+function isMissingMarketingMessagesTableError(error) {
+  return /no such table:\s*admin_marketing_messages\b/i.test(String(error?.message || ''));
+}
+
 // ---------------------------------------------------------------------------
 // body_text validation (XSS gate)
 // ---------------------------------------------------------------------------
@@ -781,14 +785,22 @@ export async function listActiveMessages(db, { nowTs }) {
   // ADV-U11-003: filter by audience = 'all_signed_in' so internal and demo
   // audience messages are only visible in the admin list view, never in
   // the public client delivery endpoint.
-  const rows = await all(db, `
-    SELECT * FROM admin_marketing_messages
-    WHERE status = 'published'
-      AND audience = 'all_signed_in'
-      AND (starts_at IS NULL OR starts_at <= ?)
-      AND (ends_at IS NULL OR ends_at >= ?)
-    ORDER BY created_at DESC
-  `, [ts, ts]);
+  let rows;
+  try {
+    rows = await all(db, `
+      SELECT * FROM admin_marketing_messages
+      WHERE status = 'published'
+        AND audience = 'all_signed_in'
+        AND (starts_at IS NULL OR starts_at <= ?)
+        AND (ends_at IS NULL OR ends_at >= ?)
+      ORDER BY created_at DESC
+    `, [ts, ts]);
+  } catch (error) {
+    if (isMissingMarketingMessagesTableError(error)) {
+      return { messages: [] };
+    }
+    throw error;
+  }
 
   return { messages: rows.map(safeMessageFields) };
 }

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -466,7 +466,16 @@ async function publicSourceAssetResponse(request, env = {}) {
     && url.pathname.endsWith('.js')
     && env.ASSETS
   ) {
-    return env.ASSETS.fetch(request);
+    const assetResponse = await env.ASSETS.fetch(request);
+    const contentType = String(assetResponse.headers.get('content-type') || '').toLowerCase();
+    const isJavaScript = contentType.includes('javascript') || contentType.includes('ecmascript');
+    if (assetResponse.status === 304) {
+      return assetResponse;
+    }
+    if (assetResponse.status >= 200 && assetResponse.status < 300 && isJavaScript) {
+      return assetResponse;
+    }
+    return new Response('Not found.', { status: 404, headers });
   }
   return new Response('Not found.', { status: 404, headers });
 }

--- a/worker/src/security-headers.js
+++ b/worker/src/security-headers.js
@@ -143,18 +143,26 @@ export const SECURITY_HEADERS = Object.freeze({
   'Reporting-Endpoints': REPORTING_ENDPOINTS_VALUE,
 });
 
-// Path segments that receive the hashed-bundle immutable cache policy.
-// The Worker response wrapper matches these with explicit `set()` so that
-// ASSETS responses carrying `no-store` from `_headers` are overridden, not
-// appended to (security F-01 + feasibility Claim 5).
-const IMMUTABLE_BUNDLE_PREFIXES = ['/src/bundles/', '/assets/bundles/'];
+// Path segments that receive the content-hashed immutable cache policy.
+// `app.bundle.js` is deliberately excluded: it is a stable entry filename
+// referenced by HTML, so caching it as immutable can strand clients on stale
+// dynamic-import chunk names after a deploy.
+const IMMUTABLE_ASSET_BUNDLE_PREFIX = '/assets/bundles/';
+const SOURCE_BUNDLE_PREFIX = '/src/bundles/';
+const STABLE_SOURCE_ENTRY_BUNDLES = new Set(['/src/bundles/app.bundle.js']);
 
 const IMMUTABLE_CACHE_CONTROL = 'public, max-age=31536000, immutable';
 const FALLBACK_CACHE_CONTROL = 'no-store';
 
+function isStableSourceEntryBundlePath(pathname) {
+  return STABLE_SOURCE_ENTRY_BUNDLES.has(pathname);
+}
+
 function isImmutableBundlePath(pathname) {
   if (!pathname) return false;
-  return IMMUTABLE_BUNDLE_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+  if (pathname.startsWith(IMMUTABLE_ASSET_BUNDLE_PREFIX)) return true;
+  if (!pathname.startsWith(SOURCE_BUNDLE_PREFIX)) return false;
+  return pathname.endsWith('.js') && !isStableSourceEntryBundlePath(pathname);
 }
 
 function isTtsBinaryResponse(response) {
@@ -190,16 +198,17 @@ export function applySecurityHeaders(response, { path: pathname = '' } = {}) {
     headers.set(name, value);
   }
 
-  // Path-specific cache rules. Order matters: bundle immutable takes
-  // precedence over any existing `Cache-Control` because ASSETS responses
-  // arrive with `no-store` from the `_headers` `/*` rule.
+  // Path-specific cache rules. Order matters: the stable entry bundle must be
+  // no-store even on 2xx, while content-hashed split chunks can be immutable.
   //
   // Security residual (review security-residual-1): the immutable cache must
   // only bind to 2xx responses. A 404 or 5xx under `/src/bundles/<unknown>.js`
   // would otherwise poison client caches for a year. Non-2xx bundle responses
   // fall through to the normal preservation/fallback logic below.
   const isSuccess = response.status >= 200 && response.status < 300;
-  if (isImmutableBundlePath(pathname) && isSuccess) {
+  if (isStableSourceEntryBundlePath(pathname)) {
+    headers.set('Cache-Control', FALLBACK_CACHE_CONTROL);
+  } else if (isImmutableBundlePath(pathname) && isSuccess) {
     headers.set('Cache-Control', IMMUTABLE_CACHE_CONTROL);
   } else if (isTtsBinaryResponse(response)) {
     // TTS preserves its existing Cache-Control; do nothing.


### PR DESCRIPTION
## Summary
- version the public `app.bundle.js` script URL with a content hash so refreshed HTML cannot reuse an immutable-cached stale entry bundle
- keep stable `/src/bundles/app.bundle.js` no-store while preserving immutable cache for content-hashed split chunks
- reject ASSETS SPA fallback HTML for missing JS chunks so stale chunk URLs return 404/no-store instead of `text/html`
- make `/api/ops/active-messages` fail open with an empty list when the remote `admin_marketing_messages` table has not migrated yet
- re-baseline the main-bundle gzip gate from 214,000 to 215,000 after confirming latest `origin/main` already exceeds 214,000 under Node 24 zlib by ~20 bytes

## Verification
- `npm run build`
- `node ./scripts/assert-build-public.mjs`
- `node ./scripts/audit-client-bundle.mjs`
- `node --test tests/build-public.test.js tests/bundle-byte-budget.test.js`
- `node --test tests/security-headers.test.js tests/worker-admin-marketing-read.test.js tests/worker-admin-marketing-no-mastery.test.js tests/bundle-audit.test.js tests/build-public.test.js tests/bundle-byte-budget.test.js tests/worker-backend.test.js`
- `npm run check`
- `git diff --check`

## Full test note
- `npm test` still exits non-zero on inherited latest-main failures unrelated to this hotfix: button label/CSP inventories, error-copy oracle admin placeholders, Grammar star expectations, marketing tab Soon chip, spelling dense-history P95 CLI expectation, marketing mutation rate-limit/CAS expectations, capacity overhead benchmark, and Hero read-model task count.
- Confirmed the same targeted failures on a clean `origin/main` worktree under Node 24 before treating them as inherited baseline rather than hotfix regressions.

## Production evidence before fix
- `/src/bundles/AdminHubSurface-ZP3QO5Z4.js` returned `text/html` with immutable caching.
- `/src/bundles/app.bundle.js` was also immutable despite being a stable filename.
- `/api/ops/active-messages` returned 500 for an authenticated demo cookie because `admin_marketing_messages` is missing in production D1.
