### PR TITLE
[codex] Fix admin hub hook order

### DIFF
--- a/src/surfaces/hubs/AdminHubSurface.jsx
+++ b/src/surfaces/hubs/AdminHubSurface.jsx
@@ -37,6 +37,16 @@ function useAdminDirtyRegistry() {
 export function AdminHubSurface({ appState, model, hubState = {}, accountDirectory = {}, accessContext = {}, actions, initialSection }) {
   const [activeSection, setActiveSection] = React.useState(initialSection || DEFAULT_SECTION);
   const dirtyRegistry = useAdminDirtyRegistry();
+  // Keep every AdminHubSurface hook above the remote-loading / access guards.
+  // The admin route can render the loading guard first, then re-render with the
+  // loaded model in the same component instance; adding hooks after those guards
+  // trips React's hook-order invariant.
+  const sectionActions = React.useMemo(() => ({
+    ...actions,
+    registerAccountOpsMetadataRowDirty: (accountId, isDirty) => {
+      dirtyRegistry.setDirty(accountId, isDirty);
+    },
+  }), [actions, dirtyRegistry]);
 
   const loadingRemote = accessContext?.shellAccess?.source === 'worker-session' && hubState.status === 'loading' && !model;
   if (loadingRemote) {
@@ -93,15 +103,6 @@ export function AdminHubSurface({ appState, model, hubState = {}, accountDirecto
     setActiveSection(nextSection);
     actions.dispatch('admin-section-change', { section: nextSection });
   };
-
-  // Augment actions with dirty-registry callback so AccountOpsMetadataRow
-  // can register/clear its dirty state.
-  const sectionActions = React.useMemo(() => ({
-    ...actions,
-    registerAccountOpsMetadataRowDirty: (accountId, isDirty) => {
-      dirtyRegistry.setDirty(accountId, isDirty);
-    },
-  }), [actions, dirtyRegistry]);
 
   const sectionProps = {
     model,

--- a/tests/react-admin-hook-order.test.js
+++ b/tests/react-admin-hook-order.test.js
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const surfacePath = path.join(rootDir, 'src/surfaces/hubs/AdminHubSurface.jsx');
+
+test('AdminHubSurface calls all shell-level hooks before loading and access guards', async () => {
+  const source = await readFile(surfacePath, 'utf8');
+  const componentStart = source.indexOf('export function AdminHubSurface');
+  assert.notEqual(componentStart, -1, 'AdminHubSurface export should exist');
+
+  const componentSource = source.slice(componentStart);
+  const sectionActionsMemo = componentSource.indexOf('const sectionActions = React.useMemo');
+  const loadingGuard = componentSource.indexOf('if (loadingRemote)');
+  const errorGuard = componentSource.indexOf("if (!model && hubState.status === 'error')");
+  const accessGuard = componentSource.indexOf('if (!model?.permissions?.canViewAdminHub)');
+  const sectionProps = componentSource.indexOf('const sectionProps = {');
+
+  assert.notEqual(sectionActionsMemo, -1, 'sectionActions memo should be present');
+  assert.notEqual(loadingGuard, -1, 'loading guard should be present');
+  assert.notEqual(errorGuard, -1, 'error guard should be present');
+  assert.notEqual(accessGuard, -1, 'access guard should be present');
+  assert.notEqual(sectionProps, -1, 'sectionProps should be present');
+
+  assert.ok(
+    sectionActionsMemo < loadingGuard,
+    'sectionActions useMemo must run before the remote-loading guard to preserve hook order',
+  );
+  assert.ok(sectionActionsMemo < errorGuard, 'sectionActions useMemo must run before the error guard');
+  assert.ok(sectionActionsMemo < accessGuard, 'sectionActions useMemo must run before the access guard');
+  assert.ok(sectionActionsMemo < sectionProps, 'sectionActions memo should still feed sectionProps');
+});


### PR DESCRIPTION
## Summary
- Move the AdminHubSurface section action memo above the remote loading, error, and access guards so every render calls the same shell-level hooks.
- Add a regression test that pins the hook-order placement around those guards.

## Root cause
The admin surface can first render the loading guard with no model, then re-render the loaded admin console in the same component instance. `sectionActions` used `React.useMemo` after the early returns, so the loaded render called more hooks than the previous loading render and React raised invariant #310.

## Validation
- node scripts/worktree-setup.mjs
- node --test tests/react-admin-hook-order.test.js tests/react-admin-hub-kpi-split.test.js tests/react-admin-metadata-row-dirty.test.js tests/react-admin-hub-characterization.test.js
- npm run build
- node ./scripts/assert-build-public.mjs && node ./scripts/audit-client-bundle.mjs && git diff --check
- npm run check