### PR TITLE
fix(admin): tolerate missing marketing table on reads

### DIFF
--- a/tests/worker-admin-marketing-read.test.js
+++ b/tests/worker-admin-marketing-read.test.js
@@ -369,3 +369,43 @@ test('active-messages soft-fails open when the marketing table is not migrated',
     server.close();
   }
 });
+
+test('admin marketing list soft-fails open when the marketing table is not migrated', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    seedCore(server, 1000);
+    server.DB.db.exec('DROP TABLE admin_marketing_messages;');
+
+    const adminRes = await listAdmin(server, 'adult-admin');
+    assert.equal(adminRes.status, 200);
+    const adminData = await adminRes.json();
+    assert.equal(adminData.ok, true);
+    assert.deepEqual(adminData.messages, []);
+
+    const opsRes = await listAdmin(server, 'adult-ops', 'ops');
+    assert.equal(opsRes.status, 200);
+    const opsData = await opsRes.json();
+    assert.equal(opsData.ok, true);
+    assert.deepEqual(opsData.messages, []);
+
+    const parentRes = await listAdmin(server, 'adult-parent', 'parent');
+    assert.equal(parentRes.status, 403);
+  } finally {
+    server.close();
+  }
+});
+
+test('admin marketing detail hides missing marketing table as not found', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    seedCore(server, 1000);
+    server.DB.db.exec('DROP TABLE admin_marketing_messages;');
+
+    const res = await getMessage(server, 'adult-admin', 'msg-any');
+    assert.equal(res.status, 404);
+    const data = await res.json();
+    assert.equal(data.code, 'not_found');
+  } finally {
+    server.close();
+  }
+});

--- a/worker/src/admin-marketing.js
+++ b/worker/src/admin-marketing.js
@@ -738,19 +738,26 @@ export async function listMarketingMessages(db, { actorAccountId }) {
   const role = (actor.platform_role || '').toLowerCase();
 
   let rows;
-  if (role === 'admin') {
-    // Admin sees all messages
-    rows = await all(db, `
-      SELECT * FROM admin_marketing_messages
-      ORDER BY updated_at DESC
-    `);
-  } else {
-    // Ops sees only published + scheduled
-    rows = await all(db, `
-      SELECT * FROM admin_marketing_messages
-      WHERE status IN ('published', 'scheduled')
-      ORDER BY updated_at DESC
-    `);
+  try {
+    if (role === 'admin') {
+      // Admin sees all messages
+      rows = await all(db, `
+        SELECT * FROM admin_marketing_messages
+        ORDER BY updated_at DESC
+      `);
+    } else {
+      // Ops sees only published + scheduled
+      rows = await all(db, `
+        SELECT * FROM admin_marketing_messages
+        WHERE status IN ('published', 'scheduled')
+        ORDER BY updated_at DESC
+      `);
+    }
+  } catch (error) {
+    if (isMissingMarketingMessagesTableError(error)) {
+      return { messages: [] };
+    }
+    throw error;
   }
 
   return { messages: rows.map(adminMessageFields) };
@@ -760,7 +767,15 @@ export async function getMarketingMessage(db, { actorAccountId, messageId }) {
   const actor = await loadActor(db, actorAccountId);
   requireAdminOrOpsRole(actor);
 
-  const row = await first(db, 'SELECT * FROM admin_marketing_messages WHERE id = ?', [messageId]);
+  let row;
+  try {
+    row = await first(db, 'SELECT * FROM admin_marketing_messages WHERE id = ?', [messageId]);
+  } catch (error) {
+    if (isMissingMarketingMessagesTableError(error)) {
+      throw new NotFoundError('Marketing message not found.', { code: 'not_found', messageId });
+    }
+    throw error;
+  }
   if (!row) {
     throw new NotFoundError('Marketing message not found.', { code: 'not_found', messageId });
   }


### PR DESCRIPTION
## Summary
- Return an empty admin marketing message list when the marketing table is not available during a migration window.
- Map marketing detail reads against a missing table to the existing not-found response instead of leaking a server error.
- Add regression coverage for admin, ops, and parent-role read behaviour when `admin_marketing_messages` is absent.

## Verification
- `node --test tests/worker-admin-marketing-read.test.js tests/worker-migration-0013.test.js` ✅
- `git diff --check` ✅
- `npm run check` ✅
- `npm test` ⚠️ currently fails on unrelated mainline issues outside this patch, including stale Admin Marketing "Soon" tab expectation, CSP inline-style budget drift, error-copy oracle allowlist drift, Grammar star expectation drift, Hero task-count expectation drift, and existing Marketing mutation rate-limit assertions.

## Production note
- The immediate production 500 was resolved by applying the pending remote D1 migrations (`0010` through `0013`). This PR prevents the admin marketing read route from returning 500 during a future schema-lag window.
