### PR TITLE
capacity(classroom): P4-U12 60-learner stretch preflight — fail-with-root-cause

### DIFF
--- a/docs/operations/capacity.md
+++ b/docs/operations/capacity.md
@@ -214,6 +214,25 @@ Expected behaviour:
 
 Record dense-history runs by appending a row to the launch-evidence table above with `summary.endpoints['POST /api/subjects/spelling/command'].p95WallMs` populating the P95 Command column and the persisted JSON in the Evidence column. Only rows produced with `--cookie` are meaningful dense-history evidence; demo-mode runs satisfy the contract check only.
 
+## Capacity Preflight
+
+Exploratory load-shape probes that look for the next bottleneck beyond
+the certified tier. Preflight rows are NOT certification evidence — they
+exist to flag the capacity discontinuity that a future hardening unit
+should investigate. Schema is intentionally lighter than the
+`## Capacity Evidence` table; rows here are skipped by
+`verify-capacity-evidence.mjs`.
+
+| Target | Status | Date | Commit | Evidence |
+| --- | --- | --- | --- | --- |
+| 60-learner stretch | **Preflight: fail** | 2026-04-28 | `42ec29b` | [json](../../reports/capacity/evidence/60-learner-stretch-preflight-20260428.json) |
+
+> **P4-U12 preflight (2026-04-28, fail-with-root-cause).** The 60-learner stretch shape needs 60 demo sessions, one per virtual learner. Production trusts only the Cloudflare-signed `CF-Connecting-IP` header (see `worker/src/rate-limit.js::normaliseRateLimitSubject`), so a single load-generator host shares one IP-aggregated bucket against `/api/demo/session`. With `DEMO_LIMITS.createIp = 30` per 10-minute window (`worker/src/demo/sessions.js`), virtual `learner-31` and every subsequent learner are rejected with HTTP 429 (`code: demo_rate_limited`) before any `/api/bootstrap` or subject-command load runs. The driver detects the setup failure and aborts cleanly rather than reusing global auth, which would silently corrupt threshold readings.
+>
+> **Top bottleneck:** `demo-session-create-ip-rate-limit` (test-infrastructure, NOT production-traffic). Real classroom traffic at 60 students has 60 distinct `CF-Connecting-IP` values (one per device on the school's network egress, in the worst case clustered across a small NAT pool) and does not share the same per-IP rate-limit bucket; the preflight exposes a load-test infrastructure bottleneck rather than a production-capacity one.
+>
+> **Next step:** Extend the load-test driver with a multi-IP source mode (e.g. a small per-IP CF Worker proxy fan-out, or N independent runners) before re-attempting the 60-learner shape. Until that lands, `/api/bootstrap`, subject-command, and projection-path bottlenecks beyond 30 learners stay unmeasured; the existing 30-learner cert run on commit `d2d9c29` (decision=fail on `maxBootstrapP95Ms`) remains the highest-evidence claim and should be re-run after the bootstrap-P95 regression is investigated.
+
 ## Operational Thresholds
 
 Treat any of these as release blockers until investigated:

--- a/reports/capacity/evidence/60-learner-stretch-preflight-20260428.json
+++ b/reports/capacity/evidence/60-learner-stretch-preflight-20260428.json
@@ -1,0 +1,48 @@
+{
+  "ok": false,
+  "decision": "fail",
+  "rootCause": "demo-session-create-ip-rate-limit",
+  "shape": {
+    "learners": 60,
+    "bootstrapBurst": 30,
+    "rounds": 1,
+    "demoSessions": true,
+    "origin": "https://ks2.eugnel.uk",
+    "config": "reports/capacity/configs/60-learner-stretch.json"
+  },
+  "setupFailure": {
+    "phase": "demo-session-setup",
+    "abortedAtLearner": "learner-31",
+    "endpoint": "POST /api/demo/session",
+    "driverErrorMessage": "Demo session setup failed for learner-31; refusing to reuse global auth for an isolated load context.",
+    "demoLimits": {
+      "createIp": 30,
+      "windowMs": 600000,
+      "source": "worker/src/demo/sessions.js (DEMO_LIMITS.createIp)"
+    },
+    "interpretation": [
+      "The 60-learner stretch shape needs 60 demo sessions, one per virtual learner.",
+      "Production trusts only the Cloudflare-signed CF-Connecting-IP header, so a single load-generator host shares one IP-aggregated bucket against /api/demo/session.",
+      "DEMO_LIMITS.createIp = 30 per 10-minute window means the 31st virtual learner (and every subsequent one) is rejected with HTTP 429 (code: demo_rate_limited) before any /api/bootstrap or subject-command load is exercised.",
+      "The classroom-load-test driver detects the setup failure and aborts before the load phase rather than retrying with reused auth, which would invalidate per-learner isolation and silently corrupt the threshold readings.",
+      "Real classroom traffic at 60 students has 60 distinct CF-Connecting-IP values (one per device on the school's network egress, in the worst case clustered across a small NAT pool) and does not share the same per-IP rate-limit bucket; this preflight therefore exposes a load-test infrastructure bottleneck rather than a production-capacity bottleneck."
+    ]
+  },
+  "topBottleneck": "demo-session-create-ip-rate-limit (test-infrastructure, NOT production-traffic)",
+  "nextStep": [
+    "Extend the load-test driver with a multi-IP source mode (e.g. a small per-IP CF Worker proxy fan-out, or N independent runners) before re-attempting the 60-learner shape.",
+    "Until that lands, /api/bootstrap, subject-command, and projection-path bottlenecks beyond 30 learners stay unmeasured; the existing 30-learner cert run remains the highest-evidence claim."
+  ],
+  "reportMeta": {
+    "commit": "42ec29b41ba9cca9fc39d38cc29f08e6c71d4cf9",
+    "environment": "production",
+    "origin": "https://ks2.eugnel.uk",
+    "authMode": "demo-sessions",
+    "learners": 60,
+    "bootstrapBurst": 30,
+    "rounds": 1,
+    "abortedAt": "2026-04-28T10:05:00Z",
+    "evidenceSchemaVersion": "preflight-v1",
+    "operator": "jamesto"
+  }
+}


### PR DESCRIPTION
## Summary

Issue #456 (P4-U12). Exploratory preflight to identify the next capacity bottleneck beyond 30 learners.

**Outcome: fail-with-root-cause.** The 60-learner shape cannot run from a single load-generator IP — the test aborts during setup at virtual `learner-31`, well before `/api/bootstrap` or subject-command load can be exercised.

**Top bottleneck: `demo-session-create-ip-rate-limit`** (test-infrastructure, NOT production-traffic).

## Mechanism

- The 60-learner shape needs 60 demo sessions, one per virtual learner.
- Production trusts only the Cloudflare-signed `CF-Connecting-IP` header (see `worker/src/rate-limit.js::normaliseRateLimitSubject`).
- A single load-generator host therefore shares one IP-aggregated bucket against `/api/demo/session`.
- `DEMO_LIMITS.createIp = 30` per 10-minute window (`worker/src/demo/sessions.js`) means virtual `learner-31` and every subsequent learner are rejected with HTTP 429 (`code: demo_rate_limited`).
- The classroom-load-test driver correctly detects the setup failure and aborts rather than reusing global auth, which would silently corrupt threshold readings.

Real classroom traffic at 60 students has 60 distinct `CF-Connecting-IP` values (one per device on the school's network egress, in the worst case clustered across a small NAT pool) and does not share the same per-IP rate-limit bucket; the preflight exposes a load-test infrastructure bottleneck rather than a production-capacity bottleneck.

## What's recorded

- `reports/capacity/evidence/60-learner-stretch-preflight-20260428.json` — preflight envelope capturing the shape, the setup-failure phase, the rate-limit constants, and the interpretation. Schema is `preflight-v1` (lighter than the cert evidence schema).
- `docs/operations/capacity.md` — new `## Capacity Preflight` section with the row format the issue spec asks for. Rows here are intentionally skipped by `verify-capacity-evidence.mjs`; they exist to flag the capacity discontinuity, not to claim certification.

## Next step (out of scope)

- Extend the classroom-load-test driver with a multi-IP source mode (per-IP CF Worker proxy fan-out, or N independent runners) before re-attempting the 60-learner shape.
- Until that lands, `/api/bootstrap`, subject-command, and projection-path bottlenecks beyond 30 learners stay unmeasured; the P4-U11 30-learner cert run on commit `d2d9c29` (decision=fail on `maxBootstrapP95Ms`) remains the highest-evidence claim and should be re-run after the bootstrap-P95 regression is investigated.

## Issue-spec deviations

The issue command is missing `--confirm-high-production-load`, which `validateClassroomLoadOptions` requires for production runs with learners ≥ 20 (the issue command would otherwise be rejected upfront). The flag was added; everything else matches the issue spec verbatim.

## Test plan

- [ ] Reviewer runs `npm run capacity:verify-evidence` — the preflight section is intentionally skipped, so the verifier still passes against the merged 30-learner cert row only.
- [ ] Reviewer inspects `reports/capacity/evidence/60-learner-stretch-preflight-20260428.json` for the captured setup-failure provenance.
- [ ] Reviewer agrees the discovered bottleneck is test-infrastructure, not production capacity, and that a follow-up issue should track the multi-IP load-test work.

Closes #456.

🤖 Generated with [Claude Code](https://claude.com/claude-code)