### PR TITLE
test(hero): pin worker read model v3 contract

### DIFF
--- a/tests/worker-hero-read-model.test.js
+++ b/tests/worker-hero-read-model.test.js
@@ -55,10 +55,10 @@ test('hero read-model: flag on + authenticated returns shadow read model', async
   assert.equal(payload.hero.childVisible, false);
   assert.equal(payload.hero.coinsEnabled, false);
   assert.equal(payload.hero.writesEnabled, false);
-  assert.equal(payload.hero.version, 2);
+  assert.equal(payload.hero.version, 3);
   assert.equal(typeof payload.hero.dateKey, 'string');
   assert.equal(payload.hero.timezone, 'Europe/London');
-  assert.equal(payload.hero.schedulerVersion, 'hero-p1-launch-v1');
+  assert.equal(payload.hero.schedulerVersion, 'hero-p2-child-ui-v1');
 
   server.close();
 });


### PR DESCRIPTION
## Summary
- Updates the Worker Hero read-model route contract test from the old v2/P1 values to the current v3/P2 read-model contract.

## Failure Fixed
- `npm test`: `tests/worker-hero-read-model.test.js` failed on `hero read-model: flag on + authenticated returns shadow read model` because the route now returns `version: 3`, not `2`.

## Verification
- `node --test tests/worker-hero-read-model.test.js`
- `npm test`
- `npm run check`
- `git diff --check`