### PR TITLE
test(playwright): scope spelling subject focus

### DIFF
--- a/tests/playwright/accessibility-golden.playwright.test.mjs
+++ b/tests/playwright/accessibility-golden.playwright.test.mjs
@@ -42,6 +42,7 @@ import { test, expect } from '@playwright/test';
 import {
   applyDeterminism,
   createDemoSession,
+  focusSubjectCard,
 } from './shared.mjs';
 
 const TOAST_SHELF = '[data-testid="toast-shelf"]';
@@ -91,7 +92,7 @@ test.describe('accessibility golden — keyboard-only spelling round-trip', () =
     // card programmatically, then press Enter to activate it. The
     // keyboard-only contract we actually care about is that Enter on
     // the focused card opens the subject.
-    await page.locator('[data-action="open-subject"][data-subject-id="spelling"]').focus();
+    await focusSubjectCard(page, 'spelling');
     await page.keyboard.press('Enter');
 
     const start = page.locator('[data-action="spelling-start"]');
@@ -125,7 +126,7 @@ test.describe('accessibility golden — keyboard-only spelling round-trip', () =
   // ---------------------------------------------------------------
   test('Enter inside the session input submits the form and feedback renders', async ({ page }) => {
     await createDemoSession(page);
-    await page.locator('[data-action="open-subject"][data-subject-id="spelling"]').focus();
+    await focusSubjectCard(page, 'spelling');
     await page.keyboard.press('Enter');
     const start = page.locator('[data-action="spelling-start"]');
     await expect(start).toBeVisible();
@@ -171,7 +172,7 @@ test.describe('accessibility golden — keyboard-only spelling round-trip', () =
     // does not, the positive branch is skipped (the container-less
     // null render is itself compliant — there is no element to
     // announce).
-    await page.locator('[data-action="open-subject"][data-subject-id="spelling"]').focus();
+    await focusSubjectCard(page, 'spelling');
     await page.keyboard.press('Enter');
     const start = page.locator('[data-action="spelling-start"]');
     await expect(start).toBeVisible();

--- a/tests/playwright/shared.mjs
+++ b/tests/playwright/shared.mjs
@@ -113,6 +113,17 @@ export async function openSubject(page, subjectId) {
   await card.click();
 }
 
+export async function focusSubjectCard(page, subjectId) {
+  if (!SUBJECT_IDS.includes(subjectId)) {
+    throw new Error(`focusSubjectCard: unknown subjectId ${subjectId}`);
+  }
+  const card = page.locator(
+    `.subject-card[data-action="open-subject"][data-subject-id="${subjectId}"]`,
+  );
+  await expect(card).toBeVisible();
+  await card.focus();
+}
+
 /**
  * Navigate back to the home grid via the brand / breadcrumb button that
  * every subject surface ships. Used between subject scenes and after


### PR DESCRIPTION
## Failure fixed

Playwright PR CI failed in the spelling accessibility golden tests with:

locator.focus strict mode violation for [data-action="open-subject"][data-subject-id="spelling"]

The selector matched both the hero CTA (Begin today's round) and the spelling subject card (The Scribe Downs Spelling).

## Change

- Added focusSubjectCard() beside the existing scoped openSubject() helper.
- Updated the spelling keyboard-only Playwright test to focus the subject-grid card explicitly before pressing Enter.

## Verification

- npx playwright test tests/playwright/accessibility-golden.playwright.test.mjs --project mobile-390 — 4 passed
- git diff --check
