### PR TITLE
test(spelling): wait for rebase queue drain

### DIFF
--- a/tests/spelling-content-api.test.js
+++ b/tests/spelling-content-api.test.js
@@ -12,10 +12,13 @@ import { installMemoryStorage } from './helpers/memory-storage.js';
 import { coreOnlyVersionOneContent } from './helpers/spelling-content.js';
 import { createWorkerRepositoryServer } from './helpers/worker-server.js';
 
-async function waitForPersistenceIdle(repositories, attempts = 60) {
+async function waitForPersistenceFullyDrained(repositories, attempts = 200) {
   await Promise.resolve();
   for (let index = 0; index < attempts; index += 1) {
-    if (repositories.persistence.read().inFlightWriteCount === 0) break;
+    const snapshot = repositories.persistence.read();
+    // Stale-write rebase can briefly expose inFlight=0 while the
+    // retried write is still queued.
+    if (snapshot.inFlightWriteCount === 0 && snapshot.pendingWriteCount === 0) break;
     await new Promise((resolve) => setTimeout(resolve, 0));
   }
   await new Promise((resolve) => setTimeout(resolve, 0));
@@ -353,7 +356,7 @@ test('content writes share the account revision without leaving later learner wr
     assert.equal(content.getAccountRevision(), 2);
 
     platform.learners.write(learnerSnapshot('Ava Rebased'));
-    await waitForPersistenceIdle(platform);
+    await waitForPersistenceFullyDrained(platform);
 
     const persistence = platform.persistence.read();
     assert.equal(persistence.mode, 'remote-sync');


### PR DESCRIPTION
## Failure fixed

Node CI failed in `tests/spelling-content-api.test.js`:

`content writes share the account revision without leaving later learner writes degraded`

The assertion saw `pendingWriteCount` as `1` instead of `0` because the helper stopped as soon as `inFlightWriteCount` reached zero. A stale-write rebase can briefly expose `inFlight=0` while the rebased write is still queued for retry.

## Change

- Replaced the test wait helper with `waitForPersistenceFullyDrained()`.
- The helper now waits for both `inFlightWriteCount === 0` and `pendingWriteCount === 0` before asserting the final remote-sync state.

## Verification

- `node --test tests/spelling-content-api.test.js` — 10 passed
- `npm test` — 5594 tests, 5592 passed, 0 failed, 2 skipped
- `git diff --check`
