### PR TITLE
test(spelling): pin seed rate-limit window

### DIFF
--- a/tests/spelling-seed-harness.test.js
+++ b/tests/spelling-seed-harness.test.js
@@ -625,8 +625,13 @@ test('[U3 HIGH adversarial] admin with membership can overwrite their own learne
 
 test('[U3 P2 security] 11th POST in 60s window from same IP returns 429 post_mega_seed_rate_limited', async () => {
   const server = createWorkerRepositoryServer();
+  const originalDateNow = Date.now;
   try {
     seedAdultAccount(server, { id: 'adult-admin', email: 'admin@example.com', platformRole: 'admin' });
+    // Pin the limiter clock away from a minute boundary. Under the full
+    // parallel Node suite this test can otherwise straddle a 60s bucket
+    // boundary and falsely see the 11th request start a fresh window.
+    Date.now = () => Date.UTC(2026, 3, 28, 10, 15, 30);
     // Fire 10 allowed requests from the same `cf-connecting-ip`. Each uses
     // a distinct requestId so the mutation-receipt preflight does not
     // short-circuit them; the 11th should 429.
@@ -678,6 +683,7 @@ test('[U3 P2 security] 11th POST in 60s window from same IP returns 429 post_meg
     // Sanity: the previous attempts (lastOkStatus) all cleared.
     assert.equal(lastOkStatus, 200);
   } finally {
+    Date.now = originalDateNow;
     server.close();
   }
 });


### PR DESCRIPTION
## Summary
- fixes the full `npm test` spelling seed harness failure where the 11th POST sometimes returned `200` instead of `429`
- pins the test's rate-limiter clock inside one 60s bucket, then restores `Date.now` during cleanup

## Failure
- `tests/spelling-seed-harness.test.js:626`
- expected `429 post_mega_seed_rate_limited`
- actual full-suite failure: 11th request returned `200` when the loop crossed a minute boundary

## Verification
- `node --test tests/spelling-seed-harness.test.js`
- `git diff --check`
