### PR TITLE
test(bundle): ignore playwright test-mode artefact

### DIFF
--- a/tests/bundle-byte-budget.test.js
+++ b/tests/bundle-byte-budget.test.js
@@ -62,6 +62,11 @@ const REPO_ROOT = path.resolve(__dirname, '..');
 // gate when ~50 KB of adult-only JS sneaks back into the critical path.
 const BASELINE_GZIP_BYTES = 203_227;
 const BUDGET_GZIP_BYTES = 215_000;
+const TEST_MODE_BUNDLE_MARKER = '__ks2_capacityMeta__';
+
+function isPlaywrightTestModeBundle(bundleBytes) {
+  return Buffer.isBuffer(bundleBytes) && bundleBytes.includes(TEST_MODE_BUNDLE_MARKER);
+}
 
 test('SH2-U10 baseline + budget constants stay in a sensible ratio', () => {
   // Guard rail: budget must exceed baseline, or every build fails.
@@ -92,6 +97,14 @@ test('real post-split app.bundle.js gzip size sits under the committed budget', 
     // contract the rest of the bundle-audit tests follow.
     return;
   }
+  if (isPlaywrightTestModeBundle(bundleBytes)) {
+    console.log(
+      'SH2-U10 budget note: skipping the real bundle-size assertion because '
+      + 'src/bundles/app.bundle.js is a Playwright KS2_BUILD_MODE=test artefact, '
+      + 'not the production bundle audited by npm run check.',
+    );
+    return;
+  }
   const gzipBytes = gzipSync(bundleBytes).byteLength;
   assert.ok(
     gzipBytes < BUDGET_GZIP_BYTES,
@@ -106,6 +119,11 @@ test('real post-split app.bundle.js gzip size sits under the committed budget', 
       + `${BASELINE_GZIP_BYTES}-byte committed baseline. Consider re-baselining.`,
     );
   }
+});
+
+test('bundle budget recognises Playwright test-mode bundle artefacts', () => {
+  assert.equal(isPlaywrightTestModeBundle(Buffer.from('globalThis.__ks2_capacityMeta__ = {};')), true);
+  assert.equal(isPlaywrightTestModeBundle(Buffer.from('console.log("production bundle");')), false);
 });
 
 test('runClientBundleAudit accepts a bundle below the passed budget', async () => {


### PR DESCRIPTION
## Summary
- fixes the local full-suite failure where `bundle-byte-budget.test.js` reads a Playwright `KS2_BUILD_MODE=test` bundle artefact and reports `260218 > 215000`
- detects the test-mode bundle marker `__ks2_capacityMeta__` and skips only the real production-size assertion for that non-production artefact
- keeps the production bundle budget enforced by `npm run check` / `audit:client`

## Failure
- `tests/bundle-byte-budget.test.js:83`
- actual failure after running Playwright first: `main bundle gzip 260218 must stay under budget 215000`
- root cause: Playwright writes a test-mode bundle to ignored `src/bundles/app.bundle.js`; the Node test can read that stale artefact before a production build rewrites it

## Verification
- `KS2_BUILD_MODE=test node ./scripts/build-bundles.mjs && node --test tests/bundle-byte-budget.test.js`
- `npm test`
- `npm run check`
- `git diff --check`
