### PR TITLE
Fix punctuation choice session autofocus

### DIFF
--- a/src/subjects/punctuation/components/PunctuationSessionScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationSessionScene.jsx
@@ -133,7 +133,7 @@ function ChoiceItem({ item, disabled, submitLabel, onSubmit, errorMessageId = ''
         aria-describedby={errorMessageId || undefined}
         aria-invalid={errorMessageId ? 'true' : undefined}
       >
-        {(item.options || []).map((option) => (
+        {(item.options || []).map((option, index) => (
           <label className="choice-card" key={`${item.id}-${option.index}`}>
             <input
               type="radio"
@@ -141,6 +141,7 @@ function ChoiceItem({ item, disabled, submitLabel, onSubmit, errorMessageId = ''
               value={option.index}
               checked={String(choiceIndex) === String(option.index)}
               disabled={disabled}
+              data-autofocus={index === 0 ? 'true' : undefined}
               onChange={() => setChoiceIndex(String(option.index))}
             />
             <span style={newlineTextStyle(option.text)}>{option.text}</span>

--- a/tests/react-accessibility-contract.test.js
+++ b/tests/react-accessibility-contract.test.js
@@ -606,6 +606,38 @@ test('Punctuation session textarea carries the autofocus shim and feedback live 
   );
 });
 
+test('Punctuation session choice items autofocus the first radio for keyboard-only entry', () => {
+  const html = renderPunctuationSessionSceneStandalone({
+    ui: {
+      phase: 'active-item',
+      session: {
+        id: 'sess-a11y-choice',
+        mode: 'smart',
+        answeredCount: 0,
+        length: 4,
+        currentItem: {
+          id: 'item-a11y-choice',
+          prompt: 'Which sentence is punctuated correctly?',
+          inputKind: 'choice',
+          mode: 'identify',
+          skillIds: [],
+          options: [
+            { index: 0, text: 'Hello, world!' },
+            { index: 1, text: 'Hello world!' },
+          ],
+        },
+      },
+    },
+    actions: { dispatch() {} },
+  });
+
+  assert.match(
+    html,
+    /<input[^>]*type="radio"[^>]*data-autofocus="true"/,
+    'punctuation choice sessions must autofocus the first radio for keyboard-only learners',
+  );
+});
+
 test('Punctuation feedback heading block exposes role="status" + aria-live="polite" for assistive tech', () => {
   const html = renderPunctuationSessionSceneStandalone({
     ui: {


### PR DESCRIPTION
## Summary
- autofocus the first punctuation choice radio so keyboard-only Playwright sessions land on an actionable control
- add a React accessibility contract for choice-mode session autofocus

## Failure
- `CI=1 npx playwright test tests/playwright/punctuation-accessibility-golden.playwright.test.mjs --project mobile-390` failed because focus stayed on `body` after starting the punctuation choice-mode session.

## Verification
- `node --test tests/react-accessibility-contract.test.js`
- `CI=1 npx playwright test tests/playwright/punctuation-accessibility-golden.playwright.test.mjs --project mobile-390`
- `npm test`
- `npm run check`
- `git diff --check`
