### PR TITLE
Fix Playwright demo rate-limit buckets

### DIFF
--- a/tests/playwright-shared.test.mjs
+++ b/tests/playwright-shared.test.mjs
@@ -1,0 +1,15 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { syntheticDemoClientIpForIndex } from './playwright/shared.mjs';
+
+test('Playwright demo client IP helper gives each demo seed a distinct IPv4 bucket', () => {
+  const ips = Array.from({ length: 310 }, (_, index) => syntheticDemoClientIpForIndex(index));
+
+  assert.equal(ips[0], '203.0.0.1');
+  assert.equal(ips[249], '203.0.0.250');
+  assert.equal(ips[250], '203.0.1.1');
+  assert.equal(new Set(ips).size, ips.length);
+  for (const ip of ips) {
+    assert.match(ip, /^203\.0\.\d+\.(?:[1-9]\d?|1\d\d|2[0-4]\d|250)$/);
+  }
+});

--- a/tests/playwright/shared.mjs
+++ b/tests/playwright/shared.mjs
@@ -27,6 +27,23 @@ export {
 
 export const SUBJECT_IDS = ['spelling', 'grammar', 'punctuation'];
 
+let syntheticDemoClientIndex = 0;
+
+export function syntheticDemoClientIpForIndex(index) {
+  const safeIndex = Math.max(0, Number(index) || 0);
+  const thirdOctet = Math.floor(safeIndex / 250);
+  const fourthOctet = (safeIndex % 250) + 1;
+  return `203.0.${thirdOctet}.${fourthOctet}`;
+}
+
+async function applySyntheticDemoClientIp(page) {
+  const clientIp = syntheticDemoClientIpForIndex(syntheticDemoClientIndex);
+  syntheticDemoClientIndex += 1;
+  await page.setExtraHTTPHeaders({
+    'CF-Connecting-IP': clientIp,
+  });
+}
+
 // Screenshot-only CSS override. Injected via `page.addStyleTag()` in
 // `applyDeterminism()` + `reload()` to hide non-deterministic surfaces
 // that otherwise blow past the 2% pixel-diff budget. Kept at module
@@ -74,8 +91,17 @@ const SCREENSHOT_DETERMINISM_CSS = `
  * `networkidle` alone returns before the font-swap frame, so screenshots
  * would otherwise capture the fallback font on one run and the loaded
  * face on the next. See `waitForFontsReady()`.
+ *
+ * The local worker harness still enforces the production demo-create
+ * rate limit. Full PR-time Playwright runs create many fresh browser
+ * contexts from the same loopback connection, so the helper stamps a
+ * deterministic synthetic client IP before `/demo`. Production rate
+ * limiting remains covered by Worker tests; browser scenes get isolated
+ * demo clients instead of competing for one shared `unknown:missing`
+ * bucket.
  */
 export async function createDemoSession(page) {
+  await applySyntheticDemoClientIp(page);
   await page.goto('/demo', { waitUntil: 'networkidle' });
   await expect(page.locator('.subject-grid')).toBeVisible({ timeout: 15_000 });
   // Re-inject the determinism stylesheet AFTER the first real

--- a/tests/playwright/visual-baselines.playwright.test.mjs
+++ b/tests/playwright/visual-baselines.playwright.test.mjs
@@ -27,26 +27,22 @@
 // Demo-rate-limit design (CRITICAL)
 // ---------------------------------
 //
-// Every `createDemoSession()` call consumes one token from the demo
-// endpoint's 30-request / 10-minute rate limit (worker/src/demo/
-// sessions.js:24 `DEMO_LIMITS.createIp = 30`). Playwright runs each
-// test in its own browser context (fresh cookie jar) so EVERY test's
-// `createDemoSession()` hits a fresh demo mint.
+// Every `createDemoSession()` call goes through the real `/demo`
+// endpoint. Playwright runs each test in its own browser context
+// (fresh cookie jar) so EVERY test's `createDemoSession()` hits a
+// fresh demo mint.
 //
 // With 5 projects running serially in a single worker (playwright
-// config says `workers: 1` for this exact reason) and ~30 demo-
-// consuming tests in the full suite (grammar golden: 10, spelling
-// golden: 3, punctuation golden: 3, chaos/access/reduced-motion: 6,
-// and this scene), a naive "one demo per test" shape in SH2-U6 would
-// bust the limit long before the matrix finishes.
+// config says `workers: 1` for this exact reason), a naive "one demo
+// per test from the same loopback bucket" shape would bust the
+// production 30-request / 10-minute demo-create rate limit long before
+// the PR-time suite finishes.
 //
-// We batch AGGRESSIVELY: ONE demo-consuming test drives ~10 surfaces
-// per project via in-flight navigation. Non-demo surfaces (auth,
-// synthetic over-mask guard, DOM-fixture overlays after the main
-// walk completes) live in their own tests but consume zero demo
-// tokens after the primary walk. This keeps each project under 3
-// demo creates; 5 × 3 = 15 tokens total, well below the 30 ceiling
-// and leaving headroom for parallel test sessions on the same host.
+// `shared.createDemoSession()` stamps a deterministic synthetic
+// `CF-Connecting-IP` per browser seed so the test harness models
+// distinct clients while the Worker still exercises the real `/demo`
+// create path. Worker-level tests remain the source of truth for the
+// production limiter contract.
 //
 // Baseline environment expectations (Linux-CI mismatch)
 // -----------------------------------------------------


### PR DESCRIPTION
## Summary
- stamp a deterministic synthetic `CF-Connecting-IP` before Playwright `/demo` seeding so full PR suites do not share one `unknown:missing` rate-limit bucket
- document the updated Playwright demo-rate-limit model and add a unit guard for unique synthetic buckets

## Failure
- PR Playwright run `25048631256` failed 47 scenes after `/demo` returned `demo_rate_limited` once the suite exceeded the production 30-request / 10-minute create-IP budget from one loopback connection.

## Verification
- `node --test tests/playwright-shared.test.mjs`
- 35 synthetic browser demo clients reached `.subject-grid` without `demo_rate_limited`
- `npm test`
- `npm run check`
- `git diff --check`
