### PR TITLE
Fix Playwright double-submit flows

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2435,7 +2435,14 @@ function buildSurfaceChromeModel(appState) {
 
 function buildHomeModel(appState, context) {
   const learnerId = appState.learners.selectedId;
-  const canOpenParentHub = Boolean(context.parentHub?.permissions?.canViewParentHub) || !boot.session.signedIn;
+  const roleCanOpenParentHub = ['parent', 'admin'].includes(normalisePlatformRole(shellPlatformRole));
+  const signedInParentCanOpenHub = boot.session.signedIn
+    && !boot.session.demo
+    && Boolean(learnerId)
+    && roleCanOpenParentHub;
+  const canOpenParentHub = Boolean(context.parentHub?.permissions?.canViewParentHub)
+    || !boot.session.signedIn
+    || signedInParentCanOpenHub;
   const visibleSubjects = context.subjects || exposedSubjects(SUBJECTS, subjectExposureGates);
 
   return {

--- a/tests/playwright/double-submit-guard.playwright.test.mjs
+++ b/tests/playwright/double-submit-guard.playwright.test.mjs
@@ -43,11 +43,96 @@ import { test, expect } from '@playwright/test';
 import {
   applyDeterminism,
   createDemoSession,
-  grammarAnswer,
+  fillGrammarAnswer,
   openSubject,
   punctuationAnswer,
   spellingAnswer,
 } from './shared.mjs';
+
+const PUNCTUATION_START_SELECTOR = '[data-punctuation-cta], [data-punctuation-start]';
+
+async function waitForSpellingContinue(page) {
+  const continueBtn = page.locator('[data-action="spelling-continue"]');
+  if (await continueBtn.isVisible({ timeout: 1_000 }).catch(() => false)) {
+    return continueBtn;
+  }
+  const feedback = page.locator('.feedback-slot:not(.is-placeholder)');
+  const deadline = Date.now() + 10_000;
+  let correction = '';
+  while (Date.now() < deadline && !correction) {
+    const feedbackText = await feedback.innerText({ timeout: 1_000 }).catch(() => '');
+    const match = feedbackText.match(/“([^”]+)”/);
+    correction = match?.[1]?.trim() || '';
+    if (!correction) await page.waitForTimeout(100);
+  }
+  if (!correction) {
+    throw new Error('Spelling correction did not expose a curly-quoted model word.');
+  }
+  await spellingAnswer(page, correction);
+  await expect(continueBtn).toBeVisible({ timeout: 10_000 });
+  return continueBtn;
+}
+
+async function submitOneGrammarAnswer(page) {
+  await fillGrammarAnswer(page, { typed: 'x' });
+  const submit = page.locator('.grammar-answer-form button[type="submit"].primary').first();
+  await expect(submit).toBeEnabled({ timeout: 5_000 });
+  await submit.click();
+}
+
+async function seedParentHubAccount(page) {
+  const origin = new URL(page.url()).origin === 'null'
+    ? 'http://127.0.0.1:4173'
+    : new URL(page.url()).origin;
+  const email = `parent-export-${Date.now()}-${Math.random().toString(36).slice(2)}@example.test`;
+  const learnerId = `learner-export-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const createdAt = Date.now();
+  const register = await page.request.post('/api/auth/register', {
+    headers: {
+      origin,
+      'sec-fetch-site': 'same-origin',
+    },
+    data: {
+      email,
+      password: 'password-1234',
+    },
+  });
+  expect(register.status()).toBe(201);
+
+  const learners = {
+    byId: {
+      [learnerId]: {
+        id: learnerId,
+        name: 'Export Learner',
+        yearGroup: 'Y5',
+        avatarColor: '#3E6FA8',
+        goal: 'sats',
+        dailyMinutes: 15,
+        weakSubjects: [],
+        createdAt,
+      },
+    },
+    allIds: [learnerId],
+    selectedId: learnerId,
+  };
+  const save = await page.request.put('/api/learners', {
+    headers: {
+      origin,
+      'sec-fetch-site': 'same-origin',
+      'x-ks2-request-id': `playwright-parent-export-${createdAt}`,
+      'x-ks2-correlation-id': `playwright-parent-export-${createdAt}`,
+    },
+    data: {
+      learners,
+      mutation: {
+        requestId: `playwright-parent-export-${createdAt}`,
+        correlationId: `playwright-parent-export-${createdAt}`,
+        expectedAccountRevision: 0,
+      },
+    },
+  });
+  expect(save.status()).toBe(200);
+}
 
 test.describe('SH2-U1 double-submit guard', () => {
   test.beforeEach(async ({ page }) => {
@@ -89,8 +174,7 @@ test.describe('SH2-U1 double-submit guard', () => {
       .toBeVisible({ timeout: 10_000 });
     await spellingAnswer(page, 'qqqqqqqqqq');
 
-    const continueBtn = page.locator('[data-action="spelling-continue"]');
-    await expect(continueBtn).toBeVisible({ timeout: 10_000 });
+    const continueBtn = await waitForSpellingContinue(page);
     await expect(continueBtn).toBeEnabled();
 
     // Snapshot request count BEFORE the burst so we can assert delta.
@@ -193,8 +277,7 @@ test.describe('SH2-U1 double-submit guard', () => {
       .toBeVisible({ timeout: 10_000 });
     await spellingAnswer(page, 'qqqqqqqqqq');
 
-    const continueBtn = page.locator('[data-action="spelling-continue"]');
-    await expect(continueBtn).toBeVisible({ timeout: 10_000 });
+    const continueBtn = await waitForSpellingContinue(page);
 
     const before = commandRequests.length;
     await Promise.all([
@@ -235,23 +318,22 @@ test.describe('SH2-U1 double-submit guard', () => {
     const dashboard = page.locator('.grammar-dashboard');
     await expect(dashboard).toBeVisible({ timeout: 15_000 });
 
-    // Drive into an in-session round: smart mode is the default
-    // GrammarDashboard entry point. Fall back to any "Begin round"
-    // button the dashboard exposes first.
-    const beginRound = page.getByRole('button', { name: /Begin round/ });
-    await expect(beginRound.first()).toBeVisible({ timeout: 10_000 });
-    await beginRound.first().click();
+    // Drive into an in-session round: Smart Practice is the default
+    // GrammarDashboard entry point and exposes the featured primary CTA.
+    const startButton = dashboard.locator('.grammar-start-row button[data-featured="true"]').first();
+    await expect(startButton).toBeVisible({ timeout: 10_000 });
+    await startButton.click();
 
     const session = page.locator('.grammar-answer-form').first();
     await expect(session).toBeVisible({ timeout: 15_000 });
 
-    // Submit an empty-ish answer to force a wrong, which lands us on
-    // the feedback frame where Continue is visible. Grammar accepts a
-    // short text answer on most question types.
-    await grammarAnswer(page, { typed: 'x' });
+    // Submit one deterministic answer, whatever input shape the live
+    // Grammar item renders, to land on the feedback frame where the
+    // advance button is visible.
+    await submitOneGrammarAnswer(page);
 
     // Wait for feedback frame with Continue / Next question button.
-    const continueBtn = page.locator('.grammar-answer-form button.secondary[type="button"]').first();
+    const continueBtn = page.getByRole('button', { name: /Next question|Finish round/ }).first();
     await expect(continueBtn).toBeVisible({ timeout: 15_000 });
     await expect(continueBtn).toBeEnabled();
 
@@ -278,7 +360,7 @@ test.describe('SH2-U1 double-submit guard', () => {
     await createDemoSession(page);
     await openSubject(page, 'punctuation');
 
-    const startBtn = page.locator('[data-punctuation-start]');
+    const startBtn = page.locator(PUNCTUATION_START_SELECTOR).first();
     await expect(startBtn).toBeVisible({ timeout: 15_000 });
     await startBtn.click();
 
@@ -372,7 +454,9 @@ test.describe('SH2-U1 double-submit guard', () => {
       downloads.push(download.suggestedFilename());
     });
 
-    await createDemoSession(page);
+    await page.goto('/', { waitUntil: 'networkidle' });
+    await seedParentHubAccount(page);
+    await page.goto('/', { waitUntil: 'networkidle' });
     await expect(page.locator('.subject-grid')).toBeVisible();
 
     // Navigate to Parent Hub via the section link on home.

--- a/tests/playwright/visual-baselines.playwright.test.mjs
+++ b/tests/playwright/visual-baselines.playwright.test.mjs
@@ -621,13 +621,13 @@ test.describe('SH2-U6 visual baselines — five-viewport matrix', () => {
 
     // ---------- Parent Hub (deferred for demo learners) ----------
     // Review-blocker-5: the Parent Hub entry CTA (`Parent hub →`) is
-    // gated by `canOpenParentHub` in src/main.js, which is
-    // `context.parentHub?.permissions?.canViewParentHub || !boot.session.signedIn`.
-    // Demo learners ARE `signedIn: true` (demo-sync mode) and the
-    // Worker's parent-hub read model does NOT grant canViewParentHub
-    // to demo accounts — so the button is genuinely not rendered on
-    // the demo surface. Reaching the parent-hub route at all from a
-    // demo context would require either:
+    // gated by `canOpenParentHub` in src/main.js. Real signed-in
+    // parent/admin shells with a selected learner can open it directly;
+    // demo learners ARE `signedIn: true` (demo-sync mode) and are
+    // explicitly excluded because the Worker's parent-hub read model
+    // does NOT grant canViewParentHub to demo accounts — so the button
+    // is genuinely not rendered on the demo surface. Reaching the
+    // parent-hub route at all from a demo context would require either:
     //   1. Seeding a non-demo parent role (outside SH2-U6's scope;
     //      PR #227 boundary + would expand the test harness), OR
     //   2. Exposing a dispatch back-door on `window.__ks2_test_store`


### PR DESCRIPTION
## Failure
- CI Playwright mobile-390 double-submit guard had stale flows after the live Grammar, Punctuation, Spelling feedback, and Parent Hub surfaces changed.
- Parent Hub export could not be reached for a real signed-in parent/admin shell with a selected learner because the Home gate depended on parentHub context that only loads after entering Parent Hub.

## Fix
- Refresh the double-submit Playwright helpers to answer live spelling and grammar feedback shapes deterministically.
- Use the current Punctuation start CTA selectors.
- Seed a real parent/admin account for the Parent Hub export guard and allow signed-in parent/admin shells with a selected learner to open Parent Hub directly while keeping demo learners excluded.

## Verification
- CI=1 npx playwright test tests/playwright/double-submit-guard.playwright.test.mjs --project mobile-390 --reporter=line
- npm test
- npm run check
- git diff --check