### PR TITLE
ci(playwright): make PR browser gate opt-in

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -70,11 +70,36 @@ Concretely this means no nightly or scheduled workflow may run any of:
 Reviewers should grep every nightly or schedule-trigger workflow for the
 patterns above before approving a change in this directory.
 
+## Pull request Playwright policy
+
+`playwright.yml` is an opt-in PR workflow. It triggers on pull request
+events so GitHub can report the `Chromium + mobile-390 golden paths`
+check, but the job runs only when one of these is true:
+
+- the PR has the `run-playwright` label
+- a maintainer starts the workflow with `workflow_dispatch`
+
+This is deliberately a job-level `if`, not a path filter, branch filter,
+or skipped-workflow pattern. GitHub treats a conditionally skipped job as
+successful for required-check purposes, while a skipped workflow can leave
+the check pending and block a merge.
+
+Default PR gates are therefore:
+
+- `npm test + npm run check`
+- `npm run audit:client`
+
+Browser evidence remains expected for browser-facing changes, but the
+owner of that slice should run the targeted local Playwright command and
+include the command/result in the PR body. Use the `run-playwright` label
+when a reviewer wants GitHub-hosted confirmation before merge. The full
+matrix remains covered by `playwright-nightly.yml`.
+
 ## Current workflows
 
 | File | Trigger | Purpose |
 | --- | --- | --- |
-| `playwright.yml` | `pull_request` | Chromium + `mobile-390` golden paths on every PR. |
+| `playwright.yml` | `pull_request` + `workflow_dispatch` | Opt-in Chromium + `mobile-390` golden paths via `run-playwright` label or manual dispatch. |
 | `playwright-nightly.yml` | `schedule` (03:07 UTC) | Full 5-viewport Playwright matrix. |
 | `node-test.yml` | `pull_request` | `npm test` + `npm run check` (schema-drift canary). |
 | `audit.yml` | `pull_request` | `npm run audit:client`. |

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,11 +1,13 @@
-# SH2-U11: Playwright golden-path scenes on every PR.
+# SH2-U11: Playwright golden-path scenes for requested PR browser QA.
 #
 # Plan: docs/plans/2026-04-26-001-feat-sys-hardening-p2-plan.md (lines 747-799, R11).
 #
-# Runs the PR-time Playwright subset: Chromium only on the `mobile-390`
-# project — the existing default baseline surface from U5. The full
-# 5-viewport matrix runs nightly in `playwright-nightly.yml` so PR
-# latency stays bounded.
+# Runs the requested PR-time Playwright subset: Chromium only on the
+# `mobile-390` project — the existing default baseline surface from U5.
+# The job is intentionally opt-in via the `run-playwright` label or a
+# manual workflow dispatch because the full mobile-390 suite is slower
+# than the Node/audit gates and can surface unrelated golden-path debt.
+# The full 5-viewport matrix runs nightly in `playwright-nightly.yml`.
 #
 # Security posture (deepening S-02 + S-03):
 #  - `permissions: contents: read` only. No `packages`, no `issues`, no
@@ -33,6 +35,13 @@ name: Playwright (PR)
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - labeled
+      - unlabeled
   # Reviewer NIT-A3 (cli-agent #3): `workflow_dispatch` lets a maintainer
   # manually re-run the Playwright job (e.g. transient Chromium download
   # failure) without pushing a new commit.
@@ -49,6 +58,10 @@ jobs:
   playwright:
     name: Chromium + mobile-390 golden paths
     runs-on: ubuntu-latest
+    # Keep this as a job-level condition, not a workflow/path filter.
+    # A skipped job reports success for required-check purposes; a
+    # skipped workflow can remain pending and block merges.
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-playwright')) }}
     timeout-minutes: 20
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Make the PR Playwright workflow opt-in via the `run-playwright` label or manual `workflow_dispatch`.
- Keep the check name/job present, but skip it with a job-level condition so required-check setups do not get stuck pending.
- Document the new default PR gates and local targeted Playwright evidence policy.

## Why
The current mobile-390 Playwright suite takes several minutes and repeatedly surfaces unrelated golden-path debt on small PRs. Keeping browser checks available but opt-in preserves coverage without slowing every development slice.

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/playwright.yml"); puts "yaml-ok"'
- git diff --check