### PR TITLE
fix(punctuation): align star-based monster display

### DIFF
--- a/docs/plans/james/punctuation/punctuation-A-architecture-product.md
+++ b/docs/plans/james/punctuation/punctuation-A-architecture-product.md
@@ -312,10 +312,10 @@ Subject landing、Codex card、Home dashboard / MonsterMeadow 唔可以用 first
 
 Reward narrative 決定：
 
-- 新增 `egg-found` event / light celebration，喺 first Star / first `displayState: egg-found` moment 觸發。呢個係 emotional safety moment：小朋友知道自己已經搵到蛋。
-- `egg-found` 只可以由 genuine Star evidence 觸發；skip、empty、duplicate replay、unsupported fake attempt、telemetry-only event 都唔可以 mint egg。
-- Legacy `caught` event / toast 如果保留，就應該只做 first-secured reward-unit celebration；唔再做 UI found truth。
-- Hatch / Evolve / Strong / Mega 呢類較大 celebration animation 要留到 session end，避免題目中途打斷 learning flow。State update / analytics event 可以即時記錄，但 visual animation 應該 queue 到 Summary / session end 先播。
+- Event kind 統一跟 Spelling 既有 vocabulary：first-found reward event 用 `caught`。喺 Punctuation，`caught` 喺 first Star / first `displayState: egg-found` moment 觸發；child-facing label 仍然可以係 Egg Found。呢個係 emotional safety moment：小朋友知道自己已經搵到蛋；toast 可以即時出，但 overlay celebration 要跟其他 monster celebration 一樣排到 session end。
+- `caught` 只可以由 genuine Star evidence 觸發；skip、empty、duplicate replay、unsupported fake attempt、telemetry-only event 都唔可以 mint egg。
+- Punctuation 唔再需要 legacy first-secured `caught` celebration；first-secured reward unit 只應該透過 Star/display-stage transition 觸發 Hatch / Evolve / Strong / Mega（如有 stage advance）。
+- 所有 monster celebration overlay animation（Egg Found / Hatch / Evolve / Strong / Mega）要留到 session end，避免題目中途打斷 learning flow。State update / analytics event / toast 可以即時記錄，但 visual animation 應該 queue 到 Summary / session end 先播。
 - Codex display 仍然要跟 `displayState`，唔可以跟 legacy `caught` boolean。
 
 ### 6.3 Game aim

--- a/docs/plans/james/punctuation/punctuation-B-engineering-system-code.md
+++ b/docs/plans/james/punctuation/punctuation-B-engineering-system-code.md
@@ -133,11 +133,11 @@ displayState =
 
 Reward event contract：
 
-- Add a new `egg-found` event for the first transition into `displayState: egg-found`.
-- `egg-found` is a light celebration only. It must not imply secured/mastered evidence.
-- `egg-found` must only fire after genuine Star evidence mints `displayStars >= 1`; skips, empty answers, duplicate replay, unsupported fake attempts, and telemetry-only events must not mint the event.
-- Keep legacy `caught` for first secured reward-unit narrative if the event remains in use; do not use it as UI found truth.
-- Hatch / Evolve / Strong / Mega state transitions and analytics may be recorded immediately, but their celebration animations should be queued for session end, not interrupt the active learning question flow.
+- Use the existing cross-subject `caught` reward event kind for the first transition into `displayState: egg-found`. This aligns Punctuation with Spelling's first-found vocabulary while keeping the child-facing display label as Egg Found.
+- `caught` is a first-found event only in Punctuation. It must not imply secured/mastered evidence; its toast may appear immediately, while its overlay celebration follows the session-end queue.
+- Punctuation `caught` must only fire after genuine Star evidence mints `displayStars >= 1`; skips, empty answers, duplicate replay, unsupported fake attempts, and telemetry-only events must not mint the event.
+- Do not emit legacy first-secured `caught` for Punctuation. First-secured reward units only create a monster celebration when the shared Star/display-stage transition advances to Hatch / Evolve / Strong / Mega.
+- Egg Found / Hatch / Evolve / Strong / Mega state transitions and analytics may be recorded immediately, but their celebration overlays should be queued for session end, not interrupt the active learning question flow.
 - Codex / Home display must consume `displayState`, not legacy `caught`.
 
 ### Seam 問題仍可能存在

--- a/scripts/audit-client-bundle.mjs
+++ b/scripts/audit-client-bundle.mjs
@@ -26,13 +26,14 @@ const DEFAULT_PUBLIC_DIR = 'dist/public';
 // 214,000. Node 24's zlib output for the current Hero P2 baseline sits
 // just above that at ~214,020 bytes. Phase 7's Punctuation remote-summary
 // safety and radio-focus accessibility fixes lift the Node 22 build to
-// ~215.1 KB, so the committed ceiling is 215,500: still tight enough to
-// catch an adult-surface re-import, without blocking on a sub-kilobyte
-// compression/runtime drift. Override via CLI
+// ~215.1 KB. Punctuation's Star-based display parity added a small
+// first-paint utility footprint, so the committed ceiling is 216,000: still
+// tight enough to catch an adult-surface re-import, without blocking on
+// sub-kilobyte compression/runtime drift. Override via CLI
 // `--main-bundle-budget-bytes` for experimentation. See
 // `tests/bundle-byte-budget.test.js` for the committed baseline +
 // rationale.
-const DEFAULT_MAIN_BUNDLE_GZIP_BUDGET_BYTES = 215_500;
+const DEFAULT_MAIN_BUNDLE_GZIP_BUDGET_BYTES = 216_000;
 
 const FORBIDDEN_MODULES = [
   { pattern: /^src\/subjects\/spelling\/data\//, reason: 'full spelling content dataset' },

--- a/shared/punctuation/service.js
+++ b/shared/punctuation/service.js
@@ -185,6 +185,7 @@ export function normalisePunctuationData(value) {
               supportKind: typeof attempt.supportKind === 'string'
                 ? attempt.supportKind
                 : (normaliseNonNegativeInteger(attempt.supportLevel, 0) > 0 ? 'guided' : null),
+              meaningful: attempt.meaningful !== false,
               correct: attempt.correct === true,
               misconceptionTags: normaliseStringArray(attempt.misconceptionTags),
               facetOutcomes: Array.isArray(attempt.facetOutcomes)
@@ -789,6 +790,21 @@ function answerDisplayText(item, answer = {}) {
   return normaliseAnswerText(answer.typed ?? answer.answer ?? '');
 }
 
+function punctuationAnswerTextHasContent(value) {
+  return normaliseAnswerText(value).length > 0;
+}
+
+function isMeaningfulPunctuationAnswer(item, answer = {}) {
+  if (item?.inputKind === 'choice' || item?.mode === 'choose') {
+    const raw = isPlainObject(answer) ? answer.choiceIndex ?? answer.value ?? answer.typed : answer;
+    return parseChoiceIndex(raw) != null;
+  }
+  const rawText = isPlainObject(answer)
+    ? answer.typed ?? answer.answer ?? answer.paragraph ?? answer.text ?? ''
+    : answer;
+  return punctuationAnswerTextHasContent(rawText);
+}
+
 function reviewItemFromResult({ item, answer, result }) {
   return {
     itemId: item.id,
@@ -824,6 +840,7 @@ function applyMarkedAttemptToProgress({
   result,
   nowValue,
   supportLevel = 0,
+  meaningfulAttempt = true,
 } = {}) {
   const guidedSupport = supportLevel > 0;
   const rewardUnit = rewardUnitForItem(indexes, item);
@@ -865,6 +882,7 @@ function applyMarkedAttemptToProgress({
     testMode: session.mode === 'gps' ? 'gps' : null,
     supportLevel,
     supportKind: supportLevel > 0 ? 'guided' : null,
+    meaningful: meaningfulAttempt !== false,
     correct: result.correct,
     misconceptionTags: result.misconceptionTags || [],
     facetOutcomes: Array.isArray(result.facets)
@@ -1332,6 +1350,7 @@ export function createPunctuationService({
         result: resultFromReviewResponse(response),
         nowValue,
         supportLevel: 0,
+        meaningfulAttempt: punctuationAnswerTextHasContent(response.attemptedAnswer),
       });
       securedRows.push(...applied.securedRows);
     }
@@ -1463,6 +1482,7 @@ export function createPunctuationService({
         ? normaliseNonNegativeInteger(state.session.guidedSupportLevel, 0)
         : 0;
       const reviewResponse = reviewItemFromResult({ item, answer, result });
+      const meaningfulAttempt = isMeaningfulPunctuationAnswer(item, answer);
       if (state.session.mode === 'gps') {
         const gps = normaliseGpsSession(state.session.gps);
         const nextResponses = [...gps.responses, reviewResponse].slice(0, MAX_GPS_QUEUE_LENGTH);
@@ -1515,6 +1535,7 @@ export function createPunctuationService({
         result,
         nowValue,
         supportLevel,
+        meaningfulAttempt,
       });
       const securedUnits = securedRows.map((entry) => entry.masteryKey);
       writeData(repository, learnerId, data);

--- a/src/main.js
+++ b/src/main.js
@@ -61,6 +61,10 @@ import {
   monsterSummary,
   monsterSummaryFromSpellingAnalytics,
 } from './platform/game/monster-system.js';
+import {
+  shouldDelayMonsterCelebrations,
+  subjectSessionEnded,
+} from './platform/game/monster-celebrations.js';
 import { createMonsterEffectConfigGetter } from './platform/game/monster-effect-runtime.js';
 import {
   acknowledgeMonsterCelebrationEvents,
@@ -3440,6 +3444,7 @@ function setPunctuationRuntimeError(message) {
 }
 
 function applyPunctuationCommandResponse(response) {
+  const previousPunctuationUi = store.getState().subjectUi?.punctuation || null;
   const subjectReadModel = response?.subjectReadModel;
   if (subjectReadModel) {
     store.reloadFromRepositories({ preserveRoute: true, preserveMonsterCelebrations: true });
@@ -3448,12 +3453,21 @@ function applyPunctuationCommandResponse(response) {
   if (subjectReadModel) {
     store.updateSubjectUi('punctuation', subjectReadModel);
   }
+  const nextPunctuationUi = store.getState().subjectUi?.punctuation || null;
   const rewards = response?.projections?.rewards;
   if (rewards?.toastEvents?.length) {
     store.pushToasts(rewards.toastEvents);
   }
-  if (rewards?.events?.length) {
-    store.pushMonsterCelebrations(rewards.events);
+  const monsterEvents = rewards?.events || [];
+  if (monsterEvents.length) {
+    if (shouldDelayMonsterCelebrations('punctuation', previousPunctuationUi, nextPunctuationUi)) {
+      store.deferMonsterCelebrations(monsterEvents);
+    } else {
+      store.pushMonsterCelebrations(monsterEvents);
+    }
+  }
+  if (subjectSessionEnded('punctuation', previousPunctuationUi, nextPunctuationUi)) {
+    store.releaseMonsterCelebrations();
   }
 }
 

--- a/src/platform/app/create-app-controller.js
+++ b/src/platform/app/create-app-controller.js
@@ -11,7 +11,7 @@ import {
 import {
   isMonsterCelebrationEvent,
   shouldDelayMonsterCelebrations,
-  spellingSessionEnded,
+  subjectSessionEnded,
 } from '../game/monster-celebrations.js';
 import {
   acknowledgeMonsterCelebrationEvents,
@@ -177,7 +177,7 @@ export function createAppController({
       renderedSideEffect = true;
     }
 
-    if (spellingSessionEnded(previousSubjectUi, nextSubjectUi)) {
+    if (subjectSessionEnded(subjectId, previousSubjectUi, nextSubjectUi)) {
       renderedSideEffect = store.releaseMonsterCelebrations() || renderedSideEffect;
     }
 

--- a/src/platform/game/mastery/punctuation.js
+++ b/src/platform/game/mastery/punctuation.js
@@ -1,8 +1,15 @@
-import { MONSTERS, stageFor, PUNCTUATION_MASTERED_THRESHOLDS, PUNCTUATION_STAR_THRESHOLDS, PUNCTUATION_GRAND_STAR_THRESHOLDS } from '../monsters.js';
+import {
+  MONSTERS,
+  stageFor,
+  punctuationDisplayStateForStars,
+  PUNCTUATION_MASTERED_THRESHOLDS,
+  PUNCTUATION_STAR_THRESHOLDS,
+  PUNCTUATION_GRAND_STAR_THRESHOLDS,
+} from '../monsters.js';
 import { PUNCTUATION_CURRENT_RELEASE_ID } from '../../../subjects/punctuation/service-contract.js';
 import {
   branchForMonster,
-  DEFAULT_SYSTEM_ID,
+  buildRewardMonsterEvent,
   ensureMonsterBranches,
   isPlainObject,
   masteredList,
@@ -11,7 +18,6 @@ import {
   PUNCTUATION_RESERVED_MONSTER_IDS,
   releaseIdForEntry,
   saveMonsterState,
-  toastBodyFor,
 } from './shared.js';
 
 // Pre-flip monster ids that should be unioned into the grand view after the
@@ -153,7 +159,7 @@ export function reservedPunctuationMonsterEntries(state = {}) {
 
 export function activePunctuationMonsterSummaryFromState(state = {}) {
   return punctuationMonsterSummaryFromState(state)
-    .filter((entry) => entry.progress.caught || entry.progress.mastered > 0);
+    .filter((entry) => entry.progress.displayState !== 'not-found' || entry.progress.caught || entry.progress.mastered > 0);
 }
 
 export function progressForPunctuationMonster(state, monsterId, { publishedTotal = null, releaseId = PUNCTUATION_CURRENT_RELEASE_ID } = {}) {
@@ -166,31 +172,42 @@ export function progressForPunctuationMonster(state, monsterId, { publishedTotal
   const fallback = publishedTotal || MONSTERS[monsterId]?.masteredMax || 1;
   const total = punctuationTotal(entry, fallback, { monsterId });
 
+  const masteredStage = stageFor(mastered, PUNCTUATION_MASTERED_THRESHOLDS);
+
   // Persisted high-water mark. Corrupted values (NaN, negative) → 0.
   const rawHW = Number(entry.starHighWater);
   const persistedHW = Number.isFinite(rawHW) && rawHW > 0 ? Math.floor(rawHW + 1e-9) : 0;
+  const legacyDisplayFloor = entry.starHighWater === undefined || entry.starHighWater === null
+    ? punctuationLegacyStarFloor(masteredStage)
+    : 0;
+  const displayStars = Math.max(persistedHW, legacyDisplayFloor);
+  const starThresholds = monsterId === PUNCTUATION_GRAND_MONSTER_ID
+    ? PUNCTUATION_GRAND_STAR_THRESHOLDS
+    : PUNCTUATION_STAR_THRESHOLDS;
+  const starStage = stageFor(displayStars, starThresholds);
+  const maxStageEver = Math.max(0, Math.min(4, Math.floor(Number(entry.maxStageEver) || 0)));
+  const displayStage = Math.max(starStage, maxStageEver, masteredStage);
+  const displayState = punctuationDisplayStateForStars(displayStars, displayStage);
 
   return {
     mastered,
     publishedTotal: total,
-    stage: stageFor(mastered, PUNCTUATION_MASTERED_THRESHOLDS),
+    stage: masteredStage,
     level: Math.min(10, Math.round((mastered / Math.max(1, total)) * 10)),
     caught: mastered >= 1,
     branch: branchForMonster(normalised, monsterId),
     masteredList: punctuationMasteredList(entry, releaseId),
     starHighWater: persistedHW,
+    displayStars,
+    displayStage,
+    displayState,
     // Star-derived stage from the monotonic starHighWater latch.
     // Used by punctuationEventFromTransition to align toast events
     // with the Star surface so a child never sees a toast that
     // contradicts the Star-derived stage.
     // Quoral (grand monster) uses GRAND thresholds [1,10,25,50,100]
     // while direct monsters use STAR thresholds [1,10,30,60,100].
-    starStage: stageFor(
-      persistedHW,
-      monsterId === PUNCTUATION_GRAND_MONSTER_ID
-        ? PUNCTUATION_GRAND_STAR_THRESHOLDS
-        : PUNCTUATION_STAR_THRESHOLDS,
-    ),
+    starStage,
   };
 }
 
@@ -206,28 +223,22 @@ function buildPunctuationEvent({
   masteryKey,
   createdAt = Date.now(),
 } = {}) {
-  const monster = MONSTERS[monsterId];
-  return {
+  return buildRewardMonsterEvent({
     id: `reward.monster:${learnerId || 'default'}:punctuation:${releaseId}:${clusterId}:${rewardUnitId}:${monsterId}:${kind}`,
-    type: 'reward.monster',
+    subjectId: 'punctuation',
     kind,
     learnerId,
-    subjectId: 'punctuation',
-    systemId: DEFAULT_SYSTEM_ID,
-    releaseId,
-    clusterId,
-    rewardUnitId,
-    masteryKey,
     monsterId,
-    monster,
     previous,
     next,
     createdAt,
-    toast: {
-      title: monster?.name || 'Reward update',
-      body: toastBodyFor(kind),
+    extra: {
+      releaseId,
+      clusterId,
+      rewardUnitId,
+      masteryKey,
     },
-  };
+  });
 }
 
 function punctuationEventFromTransition(payload, previous, next) {
@@ -238,14 +249,18 @@ function punctuationEventFromTransition(payload, previous, next) {
   const prevEffective = Math.max(previous.stage, previous.starStage || 0);
   const nextEffective = Math.max(next.stage, next.starStage || 0);
 
-  if (!previous.caught && next.caught) {
-    return buildPunctuationEvent({ ...payload, kind: 'caught', previous, next });
-  }
   if (nextEffective > prevEffective) {
     return buildPunctuationEvent({ ...payload, kind: nextEffective === 4 ? 'mega' : 'evolve', previous, next });
   }
   if (next.level > previous.level) {
     return buildPunctuationEvent({ ...payload, kind: 'levelup', previous, next });
+  }
+  return null;
+}
+
+function punctuationCaughtEventFromDisplayTransition(payload, previous, next) {
+  if (previous.displayStars < 1 && next.displayStars >= 1) {
+    return buildPunctuationEvent({ ...payload, kind: 'caught', previous, next });
   }
   return null;
 }
@@ -370,8 +385,8 @@ export function recordPunctuationRewardUnitMastery({
  * Also ratchets `maxStageEver = max(existing, derivedStage)` using the
  * appropriate threshold table (GRAND for Quoral, STAR for direct monsters).
  *
- * Returns an array of reward events (empty — latch writes do NOT emit toast
- * events; toast timing stays on reward-unit mastery only).
+ * Returns reward events only when the latch crosses the first-Star
+ * first-found boundary.
  */
 export function updatePunctuationStarHighWater({
   learnerId,
@@ -416,9 +431,17 @@ export function updatePunctuationStarHighWater({
 
   saveMonsterState(learnerId, after, gameStateRepository);
 
-  // Latch writes do NOT emit toast events — toast timing stays on
-  // reward-unit mastery only. Child-facing celebration timing is unchanged.
-  return [];
+  const previousProgress = progressForPunctuationMonster(before, monsterId);
+  const nextProgress = progressForPunctuationMonster(after, monsterId);
+  const event = punctuationCaughtEventFromDisplayTransition({
+    learnerId,
+    monsterId,
+    releaseId: PUNCTUATION_CURRENT_RELEASE_ID,
+    clusterId: 'star-evidence',
+    rewardUnitId: 'caught',
+    masteryKey: `punctuation:${PUNCTUATION_CURRENT_RELEASE_ID}:star-evidence:${monsterId}`,
+  }, previousProgress, nextProgress);
+  return event ? [event] : [];
 }
 
 export function punctuationMonsterSummaryFromState(state = {}, { clusterTotals = {}, aggregateTotal = 1, releaseId = PUNCTUATION_CURRENT_RELEASE_ID } = {}) {

--- a/src/platform/game/mastery/shared.js
+++ b/src/platform/game/mastery/shared.js
@@ -130,14 +130,25 @@ export function toastBodyFor(kind) {
   return 'Level increased.';
 }
 
-export function buildEvent(learnerId, kind, monsterId, previous, next) {
+export function buildRewardMonsterEvent({
+  id = '',
+  learnerId = '',
+  kind = '',
+  monsterId = '',
+  previous = null,
+  next = null,
+  createdAt = Date.now(),
+  subjectId = '',
+  extra = null,
+} = {}) {
   const monster = MONSTERS[monsterId];
-  const createdAt = Date.now();
-  return {
-    id: `reward.monster:${learnerId || 'default'}:${monsterId}:${kind}:${next.stage}:${next.level}`,
+  const fallbackId = `reward.monster:${learnerId || 'default'}:${monsterId}:${kind}:${next?.stage}:${next?.level}`;
+  const event = {
+    id: id || fallbackId,
     type: 'reward.monster',
     kind,
     learnerId,
+    ...(subjectId ? { subjectId } : {}),
     systemId: DEFAULT_SYSTEM_ID,
     monsterId,
     monster,
@@ -149,6 +160,13 @@ export function buildEvent(learnerId, kind, monsterId, previous, next) {
       body: toastBodyFor(kind),
     },
   };
+  return extra && typeof extra === 'object' && !Array.isArray(extra)
+    ? { ...event, ...extra }
+    : event;
+}
+
+export function buildEvent(learnerId, kind, monsterId, previous, next) {
+  return buildRewardMonsterEvent({ learnerId, kind, monsterId, previous, next });
 }
 
 export function eventFromTransition(learnerId, monsterId, previous, next) {

--- a/src/platform/game/monster-celebrations.js
+++ b/src/platform/game/monster-celebrations.js
@@ -77,11 +77,21 @@ export function emptyMonsterCelebrations() {
   };
 }
 
+function subjectIsInSession(subjectId, ui) {
+  const phase = ui?.phase;
+  if (subjectId === 'spelling') return phase === 'session';
+  if (subjectId === 'punctuation') return phase === 'active-item' || phase === 'feedback';
+  return false;
+}
+
+export function subjectSessionEnded(subjectId, previousUi, nextUi) {
+  return subjectIsInSession(subjectId, previousUi) && !subjectIsInSession(subjectId, nextUi);
+}
+
 export function spellingSessionEnded(previousUi, nextUi) {
-  return previousUi?.phase === 'session' && nextUi?.phase !== 'session';
+  return subjectSessionEnded('spelling', previousUi, nextUi);
 }
 
 export function shouldDelayMonsterCelebrations(subjectId, previousUi, nextUi) {
-  if (subjectId !== 'spelling') return false;
-  return previousUi?.phase === 'session' || nextUi?.phase === 'session';
+  return subjectIsInSession(subjectId, previousUi) || subjectIsInSession(subjectId, nextUi);
 }

--- a/src/platform/game/monsters.js
+++ b/src/platform/game/monsters.js
@@ -213,7 +213,7 @@ export const PHAETON_STAGE_THRESHOLDS = Object.freeze([3, 25, 95, 145, 213]);
 export const PUNCTUATION_MASTERED_THRESHOLDS = Object.freeze([1, 1, 2, 4, 14]);
 export const PUNCTUATION_STAR_THRESHOLDS = Object.freeze([1, 10, 30, 60, 100]);
 export const PUNCTUATION_GRAND_STAR_THRESHOLDS = Object.freeze([1, 10, 25, 50, 100]);
-
+const PUNCTUATION_DISPLAY_STATES = Object.freeze(['egg-found', 'hatch', 'evolve', 'strong', 'mega']);
 const DEFAULT_MONSTER_BRANCH = 'b1';
 const MONSTER_ASSET_SIZES = Object.freeze([320, 640, 1280]);
 export const MONSTER_ASSET_VERSION = '20260421-branches';
@@ -229,6 +229,13 @@ export function stageFor(mastered, thresholds = DIRECT_STAGE_THRESHOLDS) {
     if (count >= stageThresholds[stage]) return stage;
   }
   return 0;
+}
+
+export function punctuationDisplayStateForStars(displayStars, displayStage = 0) {
+  const stars = Math.max(0, Math.floor(Number(displayStars) || 0));
+  const stage = Math.max(0, Math.min(4, Math.floor(Number(displayStage) || 0)));
+  if (stars < 1) return 'not-found';
+  return PUNCTUATION_DISPLAY_STATES[stage] || 'mega';
 }
 
 export function levelFor(mastered) {

--- a/src/platform/game/render/effect-templates/particles-burst.js
+++ b/src/platform/game/render/effect-templates/particles-burst.js
@@ -1,7 +1,7 @@
 // `particles-burst` template: covers the transient `caught` and `evolve`
-// celebration overlays. Both share <CelebrationShell> — they only differ in
-// eyebrow, body, and which decorative slots fire. The `kind` discriminator
-// (taken verbatim from the catalog entry) selects the per-mode behaviour.
+// celebration overlays. They share <CelebrationShell> and differ in eyebrow,
+// body, and which decorative slots fire. The `kind` discriminator (taken
+// verbatim from the catalog entry) selects the per-mode behaviour.
 //
 // JSX-bearing: imports CelebrationShell whose body uses JSX. This module
 // only loads via the bundler (esbuild in tests, esbuild in production),

--- a/src/subjects/punctuation/components/PunctuationSetupScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationSetupScene.jsx
@@ -160,11 +160,12 @@ function MonsterStarMeter({ monster }) {
   // never appears to de-evolve after evidence lapse.
   const stars = monster.displayStars ?? monster.totalStars;
   const stage = monster.displayStage ?? monster.starDerivedStage;
+  const displayState = monster.displayState || (stars > 0 ? 'egg-found' : 'not-found');
   const pct = Math.min(100, Math.max(0, Math.round((stars / cap) * 100)));
   const stageText = punctuationStageLabel(stage, stars);
 
   return (
-    <div className="punctuation-monster-meter" data-monster-id={monster.id}>
+    <div className="punctuation-monster-meter" data-monster-id={monster.id} data-display-state={displayState}>
       <div className="punctuation-monster-meter-name">{monster.name}</div>
       <div className="punctuation-monster-meter-stage">{stageText}</div>
       <div className="punctuation-monster-meter-bar" aria-hidden="true">

--- a/src/subjects/punctuation/components/PunctuationSummaryScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationSummaryScene.jsx
@@ -397,7 +397,7 @@ function MonsterProgressStrip({ ui, rewardState: propRewardState }) {
         // Finding 3: rewardState is already resolved at the function top
         // via rewardStateForPunctuation — no redundant re-validation needed.
         const codexEntry = rewardState?.[monsterId];
-        const { displayStars, displayStage } = mergeMonotonicDisplay(totalStars, starDerivedStage, codexEntry);
+        const { displayStars, displayStage, displayState } = mergeMonotonicDisplay(totalStars, starDerivedStage, codexEntry);
         const cap = 100;
         const starsLabel = isGrand ? 'Grand Stars' : 'Stars';
         const stageText = punctuationStageLabel(displayStage, displayStars);
@@ -406,6 +406,7 @@ function MonsterProgressStrip({ ui, rewardState: propRewardState }) {
           <div
             className="punctuation-summary-monster punctuation-monster-meter"
             data-monster-id={monsterId}
+            data-display-state={displayState}
             key={`monster-${monsterId}`}
           >
             <div className="punctuation-monster-meter-name">{name}</div>

--- a/src/subjects/punctuation/components/punctuation-view-model.js
+++ b/src/subjects/punctuation/components/punctuation-view-model.js
@@ -19,6 +19,7 @@
 // future shared extraction must prove Spelling byte-for-byte parity in the PR
 // (AGENTS.md:14).
 
+import { punctuationDisplayStateForStars } from '../../../platform/game/monsters.js';
 import { resolveMonsterVisual } from '../../../platform/game/monster-visual-config.js';
 import {
   PUNCTUATION_CLIENT_SKILLS,
@@ -1123,16 +1124,19 @@ function safeNumber(value, fallback = 0) {
 //   codexEntry     — the rewardState entry for this monster (carries
 //                    maxStageEver + starHighWater)
 //
-// Returns: { displayStars, displayStage } — the monotonic-max values
+// Returns: { displayStars, displayStage, displayState } — the monotonic-max values
 //          safe for child-facing rendering.
 export function mergeMonotonicDisplay(liveStars, liveStage, codexEntry) {
   const stars = safeNumber(liveStars, 0);
   const stage = safeNumber(liveStage, 0);
   const maxStageEver = safeNumber(codexEntry?.maxStageEver, 0);
   const starHighWater = safeNumber(codexEntry?.starHighWater, 0);
+  const displayStars = Math.max(stars, starHighWater);
+  const displayStage = Math.max(stage, maxStageEver);
   return {
-    displayStars: Math.max(stars, starHighWater),
-    displayStage: Math.max(stage, maxStageEver),
+    displayStars,
+    displayStage,
+    displayState: punctuationDisplayStateForStars(displayStars, displayStage),
   };
 }
 
@@ -1172,7 +1176,7 @@ function activeMonsterProgressFromReward(rewardState, starView) {
     // these survive evidence lapse so the child never sees a monster
     // de-evolve. mergeMonotonicDisplay centralises the Math.max merge so
     // Setup, Map, and Summary all use one sanitisation path.
-    const { displayStage, displayStars } = mergeMonotonicDisplay(totalStars, starDerivedStage, entry);
+    const { displayStage, displayStars, displayState } = mergeMonotonicDisplay(totalStars, starDerivedStage, entry);
 
     return Object.freeze({
       id: monsterId,
@@ -1182,6 +1186,7 @@ function activeMonsterProgressFromReward(rewardState, starView) {
       starDerivedStage,
       displayStage,
       displayStars,
+      displayState,
     });
   });
 }

--- a/src/subjects/punctuation/star-projection.js
+++ b/src/subjects/punctuation/star-projection.js
@@ -149,6 +149,7 @@ function computeTryStars(monsterAttempts) {
   // capping same-item repeats at MAX_ATTEMPTS_PER_ITEM.
   const perItem = new Map();
   for (const attempt of monsterAttempts) {
+    if (attempt.meaningful === false) continue;
     const itemId = attempt.itemId || '';
     if (!itemId) continue;
     const count = perItem.get(itemId) || 0;
@@ -159,6 +160,7 @@ function computeTryStars(monsterAttempts) {
   // Cap same-day items.
   const perDay = new Map();
   for (const attempt of monsterAttempts) {
+    if (attempt.meaningful === false) continue;
     const day = dayIndex(attempt.ts);
     const itemId = attempt.itemId || '';
     if (!itemId) continue;
@@ -600,6 +602,7 @@ export function projectPunctuationStars(progress, releaseId, options) {
       itemMode: typeof a.itemMode === 'string' ? a.itemMode : '',
       sessionMode: typeof a.sessionMode === 'string' ? a.sessionMode : 'smart',
       testMode: a.testMode === 'gps' ? 'gps' : null,
+      meaningful: a.meaningful !== false,
     };
   });
 

--- a/src/subjects/spelling/remote-actions.js
+++ b/src/subjects/spelling/remote-actions.js
@@ -9,7 +9,7 @@ import {
 import {
   normaliseMonsterCelebrationEvents,
   shouldDelayMonsterCelebrations,
-  spellingSessionEnded,
+  subjectSessionEnded,
 } from '../../platform/game/monster-celebrations.js';
 import {
   unacknowledgedMonsterCelebrationEvents,
@@ -378,7 +378,7 @@ export function createRemoteSpellingActionHandler({
       store.pushToasts(toastEvents);
     }
 
-    const endedSession = spellingSessionEnded(previousSubjectUi, nextSubjectUi);
+    const endedSession = subjectSessionEnded('spelling', previousSubjectUi, nextSubjectUi);
     let monsterEvents = responseMonsterEvents;
     if (isSelectedLearner && endedSession && !monsterEvents.length) {
       const loggedRewardEvents = spellingRewardEvents(store.repositories?.eventLog?.list?.(learnerId) || []);

--- a/src/surfaces/home/HomeSurface.jsx
+++ b/src/surfaces/home/HomeSurface.jsx
@@ -159,8 +159,18 @@ export function HomeSurface({ model, actions, shellClassName = 'app-shell' }) {
 }
 
 function pickCompanionName(summary) {
-  const caught = summary.find((entry) => entry.progress?.caught && entry.progress.stage >= 1);
-  if (caught) return caught.monster.nameByStage?.[caught.progress.stage] || caught.monster.name;
+  const caught = summary.find((entry) => {
+    const progress = entry.progress || {};
+    const stage = Math.max(0, Math.min(4, Number(progress.displayStage ?? progress.stage) || 0));
+    const found = entry.subjectId === 'punctuation'
+      ? (progress.displayState && progress.displayState !== 'not-found') || progress.caught === true
+      : progress.caught;
+    return found && stage >= 1;
+  });
+  if (caught) {
+    const stage = Math.max(0, Math.min(4, Number(caught.progress?.displayStage ?? caught.progress?.stage) || 0));
+    return caught.monster.nameByStage?.[stage] || caught.monster.name;
+  }
   return null;
 }
 

--- a/src/surfaces/home/data.js
+++ b/src/surfaces/home/data.js
@@ -279,20 +279,32 @@ function variantForMonster(monsterId, stage, catalogueBranch) {
   return pickVariant(seed);
 }
 
+function entryDisplayInfo(entry = {}) {
+  const progress = entry.progress || {};
+  const stage = Math.max(0, Math.min(4, Number(progress?.stage) || 0));
+  if ((entry.subjectId || progress.subjectId) !== 'punctuation') {
+    return { displayStage: stage, found: Boolean(progress.caught) };
+  }
+  const displayStars = Math.max(0, Math.floor(Number(progress.displayStars ?? progress.starHighWater) || 0));
+  const displayStage = Math.max(0, Math.min(4, Number(progress.displayStage ?? progress.starStage ?? stage) || 0));
+  const displayState = typeof progress.displayState === 'string' ? progress.displayState : '';
+  const found = displayState ? displayState !== 'not-found' : progress.caught === true || displayStars > 0 || (Number(progress.mastered) || 0) > 0;
+  return { displayStars, displayStage, displayState, found };
+}
+
 /**
  * Build the meadow monster list from the real monsterSummary payload. Only
- * caught species appear. Stage-1+ monsters and caught-but-unhatched
+ * found species appear. Stage-1+ monsters and found-but-unhatched
  * species are placed through a seeded meadow projection, so their foot
  * points can move around the hero while preserving depth and scale.
- * Uncaught species are hidden until the learner secures their first
- * qualifying word.
+ * Unfound species are hidden until the learner has meaningful evidence.
  */
 export function buildMeadowMonsters(summary = [], { seed = 'default-meadow' } = {}) {
   const caughtEntries = meadowEntriesByPower(
-    summary.filter((entry) => entry.progress?.caught && entry.progress.stage >= 1),
+    summary.filter((entry) => entryDisplayInfo(entry).found && entryDisplayInfo(entry).displayStage >= 1),
   );
   const eggEntries = meadowEntriesByPower(
-    summary.filter((entry) => entry.progress?.caught && entry.progress.stage === 0),
+    summary.filter((entry) => entryDisplayInfo(entry).found && entryDisplayInfo(entry).displayStage === 0),
   );
   const placed = [];
   const monsters = caughtEntries
@@ -315,8 +327,8 @@ function defaultPathForMonster(monsterId) {
 
 function meadowEntriesByPower(entries) {
   return entries.slice().sort((left, right) => {
-    const leftStage = Number(left.progress?.stage) || 0;
-    const rightStage = Number(right.progress?.stage) || 0;
+    const leftStage = entryDisplayInfo(left).displayStage;
+    const rightStage = entryDisplayInfo(right).displayStage;
     if (leftStage !== rightStage) return rightStage - leftStage;
     return codexPowerRank(right.monster?.id) - codexPowerRank(left.monster?.id);
   });
@@ -324,7 +336,7 @@ function meadowEntriesByPower(entries) {
 
 function buildRoamingMeadowEntry(entry, { index, placed, seed }) {
   const { monster, progress } = entry;
-  const stage = Math.max(1, Math.min(4, Number(progress?.stage) || 1));
+  const stage = Math.max(1, Math.min(4, entryDisplayInfo(entry).displayStage || 1));
   const path = defaultPathForMonster(monster.id);
   const slot = randomMeadowSlot({ entry, zoneName: path, index, placed, seed, stage });
   const variant = variantForMonster(monster.id, stage, progress.branch);
@@ -621,16 +633,19 @@ export function buildCodexEntries(summary = []) {
     const max = isUnitSubject
       ? Math.max(1, Number(progress?.publishedTotal) || Number(monster?.masteredMax) || 1)
       : Math.max(1, Number(monster?.masteredMax) || (monster?.id === 'phaeton' ? 213 : 100));
-    const stage = Math.max(0, Math.min(4, Number(progress?.stage) || 0));
-    const caught = Boolean(progress?.caught);
+    const displayInfo = entryDisplayInfo({ subjectId: resolvedSubjectId, monster, progress });
+    const stage = displayInfo.displayStage;
+    const caught = displayInfo.found;
     const displayState = !caught ? 'fresh' : stage === 0 ? 'egg' : 'monster';
     const variant = variantForMonster(monster.id, stage, progress?.branch);
     const displayName = caught && !(monster.id === 'phaeton' && stage === 0)
       ? monster.nameByStage?.[stage] || monster.name
       : caught
         ? monster.name
-      : 'Unknown creature';
-    const pct = Math.max(0, Math.min(1, mastered / max));
+        : 'Unknown creature';
+    const pct = resolvedSubjectId === 'punctuation'
+      ? Math.max(0, Math.min(1, displayInfo.displayStars / 100))
+      : Math.max(0, Math.min(1, mastered / max));
     const nextMilestone = nextCodexMilestone(monster.id, mastered, { subjectId: resolvedSubjectId, max });
     const imageAlt = caught ? displayName : `${monster.name} not caught`;
 
@@ -655,7 +670,7 @@ export function buildCodexEntries(summary = []) {
       srcSet: caught ? monsterAssetSrcset(monster.id, variant, stage) : '',
       imageAlt,
       placeholder: caught ? '' : '?',
-      stageLabel: caught ? (stage === 0 ? 'Egg' : `Stage ${stage}`) : 'Not caught',
+      stageLabel: codexStageLabel(resolvedSubjectId, caught, stage, displayInfo.displayState),
       secureLabel: secureProgressLabel(resolvedSubjectId, mastered),
       nextGoal: codexNextGoal({ subjectId: resolvedSubjectId, caught, nextMilestone }),
       wordBand: codexWordBand(monster.id, resolvedSubjectId),
@@ -863,8 +878,8 @@ function pickSubjectCompanion(monsterSummary, subjectId) {
   let best = null;
   for (const entry of monsterSummary) {
     const monsterId = entry?.monster?.id;
-    const progress = entry?.progress;
-    if (!monsterId || !progress?.caught) continue;
+    const displayInfo = entryDisplayInfo(entry);
+    if (!monsterId || !displayInfo.found) continue;
     // Roster membership is the hard gate — stale state may carry an explicit
     // `entry.subjectId` annotation for a reserved monster id (e.g. pre-flip
     // `{ monster.id:'colisk', subjectId:'punctuation' }`), which would
@@ -878,7 +893,7 @@ function pickSubjectCompanion(monsterSummary, subjectId) {
       ? entry.subjectId === subjectId
       : true;
     if (!isForSubject) continue;
-    const stage = Math.max(0, Math.min(4, Number(progress.stage) || 0));
+    const stage = displayInfo.displayStage;
     if (!best || stage > best.stage) {
       best = { monster: entry.monster, stage };
     }
@@ -903,9 +918,23 @@ function secureProgressLabel(subjectId, mastered) {
   return 'No secure words yet';
 }
 
+function codexStageLabel(subjectId, caught, stage, rewardDisplayState) {
+  if (!caught) return 'Not caught';
+  if (subjectId !== 'punctuation') return stage === 0 ? 'Egg' : `Stage ${stage}`;
+  const label = {
+    'egg-found': 'Egg Found',
+    hatch: 'Hatch',
+    evolve: 'Evolve',
+    strong: 'Strong',
+    mega: 'Mega',
+  }[rewardDisplayState];
+  if (label) return label;
+  return stage === 0 ? 'Egg Found' : `Stage ${stage}`;
+}
+
 function codexNextGoal({ subjectId, caught, nextMilestone }) {
   if (!caught && nextMilestone) {
-    if (subjectId === 'punctuation') return 'Secure punctuation units to catch this creature';
+    if (subjectId === 'punctuation') return 'Find this egg with a punctuation round';
     if (subjectId === 'grammar') return 'Secure grammar units to catch this creature';
     return 'Secure words to catch this creature';
   }

--- a/styles/app.css
+++ b/styles/app.css
@@ -10468,6 +10468,14 @@ html { scroll-behavior: smooth; }
   border: 1px solid var(--line);
   border-radius: var(--radius-sm);
   background: var(--panel-soft);
+  transition: filter var(--dur-med) var(--ease-out), opacity var(--dur-med) var(--ease-out);
+}
+.punctuation-monster-meter[data-display-state="not-found"] {
+  opacity: 0.58;
+  filter: grayscale(0.9);
+}
+.punctuation-monster-meter[data-display-state="not-found"] .punctuation-monster-meter-fill {
+  background: var(--muted);
 }
 .punctuation-monster-meter-name {
   font-weight: 800;

--- a/tests/bundle-byte-budget.test.js
+++ b/tests/bundle-byte-budget.test.js
@@ -16,7 +16,8 @@
 // Node 24's zlib output for the current Hero P2 baseline sits just
 // above that at ~214,020 bytes. Phase 7's Punctuation remote-summary
 // safety and radio-focus accessibility fixes lift the Node 22 build to
-// ~215.1 KB, so the committed ceiling is now `215_500`. That keeps the
+// ~215.1 KB. Punctuation's Star-based display parity added a small first-paint
+// utility footprint, so the committed ceiling is now `216_000`. That keeps the
 // headroom narrow while avoiding a sub-kilobyte compression/runtime false blocker.
 // The audit still fails
 // when ~50 KB of adult-only JS sneaks back into the critical path (the
@@ -59,13 +60,14 @@ const REPO_ROOT = path.resolve(__dirname, '..');
 // rounded up to 214,000. Node 24's zlib output for the current Hero P2
 // baseline sits just above that. Phase 7's Punctuation remote-summary
 // safety and radio-focus accessibility fixes lift the Node 22 build to
-// ~215.1 KB, so the committed ceiling is 215,500
+// ~215.1 KB. Punctuation's Star-based display parity adds a small first-paint
+// utility footprint, so the committed ceiling is 216,000
 // (matches `DEFAULT_MAIN_BUNDLE_GZIP_BUDGET_BYTES` in
 // `scripts/audit-client-bundle.mjs`). The narrow headroom lets the team
 // land small copy / utility growth without an audit bump, but trips the
 // gate when ~50 KB of adult-only JS sneaks back into the critical path.
 const BASELINE_GZIP_BYTES = 203_227;
-const BUDGET_GZIP_BYTES = 215_500;
+const BUDGET_GZIP_BYTES = 216_000;
 const TEST_MODE_BUNDLE_MARKER = '__ks2_capacityMeta__';
 
 function isPlaywrightTestModeBundle(bundleBytes) {

--- a/tests/effect-config-schema.test.js
+++ b/tests/effect-config-schema.test.js
@@ -228,4 +228,3 @@ test('validateEffectConfig: missing celebrationTunables returns error naming the
   assert.equal(result.ok, false);
   assert.ok(result.errors.some((e) => /celebrationTunables/.test(e.message)));
 });
-

--- a/tests/monster-celebrations.test.js
+++ b/tests/monster-celebrations.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  shouldDelayMonsterCelebrations,
+  spellingSessionEnded,
+  subjectSessionEnded,
+} from '../src/platform/game/monster-celebrations.js';
+
+test('monster celebration timing keeps Spelling session-end behaviour', () => {
+  assert.equal(shouldDelayMonsterCelebrations('spelling', { phase: 'session' }, { phase: 'session' }), true);
+  assert.equal(subjectSessionEnded('spelling', { phase: 'session' }, { phase: 'summary' }), true);
+  assert.equal(spellingSessionEnded({ phase: 'session' }, { phase: 'summary' }), true);
+});
+
+test('monster celebration timing defers Punctuation active-question overlays until session end', () => {
+  assert.equal(shouldDelayMonsterCelebrations('punctuation', { phase: 'active-item' }, { phase: 'feedback' }), true);
+  assert.equal(shouldDelayMonsterCelebrations('punctuation', { phase: 'feedback' }, { phase: 'summary' }), true);
+  assert.equal(subjectSessionEnded('punctuation', { phase: 'feedback' }, { phase: 'summary' }), true);
+  assert.equal(subjectSessionEnded('punctuation', { phase: 'setup' }, { phase: 'summary' }), false);
+});
+
+test('monster celebration timing leaves unsupported subjects immediate', () => {
+  assert.equal(shouldDelayMonsterCelebrations('grammar', { phase: 'session' }, { phase: 'session' }), false);
+  assert.equal(subjectSessionEnded('grammar', { phase: 'session' }, { phase: 'summary' }), false);
+});

--- a/tests/punctuation-gps.test.js
+++ b/tests/punctuation-gps.test.js
@@ -3,6 +3,8 @@ import assert from 'node:assert/strict';
 
 import { PUNCTUATION_EVENT_TYPES } from '../shared/punctuation/events.js';
 import { createPunctuationService } from '../shared/punctuation/service.js';
+import { PUNCTUATION_RELEASE_ID } from '../shared/punctuation/content.js';
+import { projectPunctuationStars } from '../src/subjects/punctuation/star-projection.js';
 
 function makeRepository(initialData = null) {
   let data = initialData;
@@ -231,6 +233,24 @@ test('gps completion releases review rows and then writes learning evidence', ()
   assert.equal(data.progress.attempts.every((attempt) => attempt.sessionMode === 'gps'), true);
   assert.equal(data.progress.attempts.every((attempt) => attempt.testMode === 'gps'), true);
   assert.equal(data.progress.sessionsCompleted, 1);
+});
+
+test('gps skip records non-meaningful review evidence and mints no Try Stars', () => {
+  const repository = makeRepository();
+  const service = createPunctuationService({ repository, now: () => 1_800_000_000_000, random: () => 0 });
+  const state = service.startSession('learner-a', { mode: 'gps', roundLength: '1' }).state;
+
+  const finished = skipGpsItem(service, 'learner-a', state);
+
+  assert.equal(finished.state.phase, 'summary');
+  assert.equal(finished.state.summary.total, 1);
+  assert.equal(repository.snapshot().data.progress.attempts.length, 1);
+  assert.equal(repository.snapshot().data.progress.attempts[0].meaningful, false);
+
+  const stars = projectPunctuationStars(repository.snapshot().data.progress, PUNCTUATION_RELEASE_ID);
+  assert.equal(stars.perMonster.pealark.total, 0);
+  assert.equal(stars.perMonster.claspin.total, 0);
+  assert.equal(stars.perMonster.curlune.total, 0);
 });
 
 test('gps end early releases accumulated delayed review and evidence once', () => {

--- a/tests/punctuation-mastery.test.js
+++ b/tests/punctuation-mastery.test.js
@@ -216,7 +216,7 @@ test('maxStageEver does not decrease (defensive)', () => {
 // 4. Event emission — caught, evolve, mega
 // ---------------------------------------------------------------------------
 
-test('recordPunctuationRewardUnitMastery emits caught event on first mastery', () => {
+test('recordPunctuationRewardUnitMastery emits hatch/evolve, not legacy caught, on first secured unit', () => {
   const repository = makeRepository();
   const events = recordPunctuationRewardUnitMastery({
     learnerId: 'learner-a',
@@ -232,15 +232,17 @@ test('recordPunctuationRewardUnitMastery emits caught event on first mastery', (
   });
 
   const caughtEvents = events.filter((e) => e.kind === 'caught');
-  assert.equal(caughtEvents.length, 2, 'caught for direct monster + grand aggregate');
-  assert.ok(caughtEvents.some((e) => e.monsterId === 'pealark'));
-  assert.ok(caughtEvents.some((e) => e.monsterId === 'quoral'));
+  assert.equal(caughtEvents.length, 0, 'Punctuation no longer emits legacy caught for first-secured');
+  const evolveEvents = events.filter((e) => e.kind === 'evolve');
+  assert.equal(evolveEvents.length, 2, 'stage 0 -> 1 hatching uses the shared evolve animation path');
+  assert.ok(evolveEvents.some((e) => e.monsterId === 'pealark'));
+  assert.ok(evolveEvents.some((e) => e.monsterId === 'quoral'));
 });
 
 test('recordPunctuationRewardUnitMastery emits evolve on stage advance', () => {
   const repository = makeRepository();
 
-  // First mastery: caught (stage 0 -> 1)
+  // First mastery: stage 0 -> 1 hatch/evolve
   recordPunctuationRewardUnitMastery({
     learnerId: 'learner-a',
     releaseId: PUNCTUATION_RELEASE_ID,
@@ -897,17 +899,12 @@ test('U8 happy path: mastered stage 1, starHighWater 35 (star stage 2) -> evolve
     gameStateRepository: repo2,
     random: () => 0,
   });
-  // caught fires because !previous.caught && next.caught (checked first)
   const caughtEvents = events.filter((e) => e.kind === 'caught');
-  assert.ok(caughtEvents.length >= 1, 'caught event fires on first mastery');
+  assert.equal(caughtEvents.length, 0, 'Punctuation first-secured no longer emits legacy caught');
   // The previous starStage was stageFor(35, thresholds) = 2 and next starStage is also 2,
-  // but previous mastered stage was 0 and next is 1. The caught check fires first
-  // (before stage comparison), so we get caught. No separate evolve because
-  // effective stage prev = max(0, 2) = 2 and next = max(1, 2) = 2 — equal.
+  // so the shared evolve animation would be a duplicate of a stage the child
+  // has already seen through Stars.
   const evolveEvents = events.filter((e) => e.kind === 'evolve');
-  // With both before and after having starHighWater=35, effective stages
-  // are both 2, so no evolve fires — caught is the only event for the direct
-  // monster. This is correct: the child already sees star stage 2.
   assert.equal(
     evolveEvents.filter((e) => e.monsterId === 'pealark').length, 0,
     'no evolve when star stage is already 2 on both sides',
@@ -996,7 +993,7 @@ test('U8 happy path: mastered stage 2, starHighWater 100 (star stage 4) -> mega 
     'no evolve when effective stage unchanged (4 -> 4)');
 });
 
-test('U8 happy path: mastered stage 1, star stage 1 -> caught fires normally', () => {
+test('U8 happy path: first secured unit below Hatch Star threshold emits hatch/evolve, not caught', () => {
   const repository = makeRepository({
     pealark: {
       mastered: [],
@@ -1026,14 +1023,18 @@ test('U8 happy path: mastered stage 1, star stage 1 -> caught fires normally', (
     random: () => 0,
   });
   const caughtEvents = events.filter((e) => e.kind === 'caught');
-  assert.ok(caughtEvents.some((e) => e.monsterId === 'pealark'), 'caught fires for direct monster');
-  assert.ok(caughtEvents.some((e) => e.monsterId === 'quoral'), 'caught fires for aggregate');
+  assert.equal(caughtEvents.length, 0, 'Punctuation first-secured no longer emits legacy caught');
+  assert.equal(
+    events.filter((e) => e.kind === 'evolve').length,
+    2,
+    'first secured unit below the Hatch Star threshold still queues hatch/evolve for direct + grand',
+  );
 });
 
 test('U8 edge: pre-Star learner (starHighWater 0) -> mastered stage governs', () => {
   const repository = makeRepository();
   // First mastery: stage 0 -> 1, starHighWater 0, starStage 0
-  // effective: max(0, 0) -> max(1, 0) = 1 > 0 -- but caught fires first
+  // effective: max(0, 0) -> max(1, 0) = 1 > 0 -- hatch/evolve fires
   recordPunctuationRewardUnitMastery({
     learnerId: 'learner-u8-4',
     releaseId: PUNCTUATION_RELEASE_ID,
@@ -1313,6 +1314,50 @@ test('P7-U4: updatePunctuationStarHighWater advances starHighWater from 3 to 8',
   const state = repository.state();
   assert.equal(state.pealark.starHighWater, 8, 'starHighWater must advance from 3 to 8');
   assert.deepEqual(events, [], 'latch writes must NOT emit toast events');
+});
+
+test('display state: one Star is Egg Found without secured reward units', () => {
+  const state = {
+    pealark: {
+      mastered: [],
+      caught: false,
+      publishedTotal: 5,
+      starHighWater: 1,
+      branch: 'b1',
+    },
+  };
+  const progress = progressForPunctuationMonster(state, 'pealark', { publishedTotal: 5 });
+
+  assert.equal(progress.mastered, 0);
+  assert.equal(progress.caught, false, 'legacy caught stays first-secured');
+  assert.equal(progress.displayStars, 1);
+  assert.equal(progress.displayStage, 0);
+  assert.equal(progress.displayState, 'egg-found');
+});
+
+test('caught event fires on first Star high-water transition', () => {
+  const repository = makeRepository({
+    pealark: {
+      mastered: [],
+      caught: false,
+      publishedTotal: 5,
+      starHighWater: 0,
+      branch: 'b1',
+    },
+  });
+  const events = updatePunctuationStarHighWater({
+    learnerId: 'learner-caught-first-star',
+    monsterId: 'pealark',
+    computedStars: 1,
+    gameStateRepository: repository,
+    random: () => 0,
+  });
+
+  assert.equal(repository.state().pealark.starHighWater, 1);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].kind, 'caught');
+  assert.equal(events[0].previous.displayState, 'not-found');
+  assert.equal(events[0].next.displayState, 'egg-found');
 });
 
 test('P7-U4: computedStars equals starHighWater -> no latch write', () => {

--- a/tests/punctuation-service.test.js
+++ b/tests/punctuation-service.test.js
@@ -10,6 +10,7 @@ import {
 import { PUNCTUATION_EVENT_TYPES } from '../shared/punctuation/events.js';
 import { createMemoryState, updateMemoryState } from '../shared/punctuation/scheduler.js';
 import { createPunctuationService, PunctuationServiceError } from '../shared/punctuation/service.js';
+import { projectPunctuationStars } from '../src/subjects/punctuation/star-projection.js';
 
 function makeRepository() {
   let data = null;
@@ -94,6 +95,41 @@ test('punctuation service emits misconception events and serialisable feedback',
   assert.equal(result.state.feedback.kind, 'error');
   assert.equal(result.events.some((event) => event.type === PUNCTUATION_EVENT_TYPES.MISCONCEPTION_OBSERVED), true);
   assert.doesNotThrow(() => JSON.stringify(result.state));
+});
+
+test('empty non-GPS submit records non-meaningful evidence and mints no Try Stars', () => {
+  const repository = makeRepository();
+  const service = createPunctuationService({ repository, now: () => 1_800_000_000_000, random: () => 0 });
+  const start = service.startSession('learner-a', { mode: 'smart', roundLength: '1' }).state;
+
+  service.submitAnswer('learner-a', start, start.session.currentItem.inputKind === 'choice'
+    ? { choiceIndex: null }
+    : { typed: '   ' });
+
+  const attempt = repository.snapshot().data.progress.attempts.at(-1);
+  assert.equal(attempt.meaningful, false);
+
+  const stars = projectPunctuationStars(repository.snapshot().data.progress, PUNCTUATION_RELEASE_ID);
+  assert.equal(stars.perMonster.pealark.total, 0);
+  assert.equal(stars.perMonster.claspin.total, 0);
+  assert.equal(stars.perMonster.curlune.total, 0);
+});
+
+test('wrong non-empty submit remains meaningful Try evidence', () => {
+  const repository = makeRepository();
+  const service = createPunctuationService({ repository, now: () => 1_800_000_000_000, random: () => 0 });
+  const start = service.startSession('learner-a', { mode: 'smart', roundLength: '1' }).state;
+
+  service.submitAnswer('learner-a', start, start.session.currentItem.inputKind === 'choice'
+    ? { choiceIndex: 99 }
+    : { typed: 'not sure' });
+
+  const attempt = repository.snapshot().data.progress.attempts.at(-1);
+  assert.equal(attempt.meaningful, true);
+
+  const stars = projectPunctuationStars(repository.snapshot().data.progress, PUNCTUATION_RELEASE_ID);
+  assert.ok(stars.grand.grandStars >= 0);
+  assert.ok(Object.values(stars.perMonster).some((entry) => entry.tryStars > 0));
 });
 
 test('punctuation service rejects illegal transitions with named errors and no mutation', () => {

--- a/tests/punctuation-star-projection.test.js
+++ b/tests/punctuation-star-projection.test.js
@@ -115,6 +115,35 @@ test('one meaningful attempt in Pealark cluster — Try Stars increase, total > 
   assert.equal(result.perMonster.claspin.total, 0, 'Claspin must remain at 0');
 });
 
+test('non-meaningful attempts do not mint Try Stars', () => {
+  const progress = freshProgress();
+  progress.attempts.push(makeAttempt({
+    itemId: 'se_empty_submit',
+    skillIds: ['sentence_endings'],
+    rewardUnitId: 'sentence-endings-core',
+    meaningful: false,
+    correct: false,
+  }));
+
+  const result = projectPunctuationStars(progress, CURRENT_RELEASE_ID);
+  assert.equal(result.perMonster.pealark.tryStars, 0);
+  assert.equal(result.perMonster.pealark.total, 0);
+});
+
+test('legacy attempts without meaningful flag still count as meaningful', () => {
+  const progress = freshProgress();
+  const attempt = makeAttempt({
+    itemId: 'se_legacy_submit',
+    skillIds: ['sentence_endings'],
+    rewardUnitId: 'sentence-endings-core',
+  });
+  delete attempt.meaningful;
+  progress.attempts.push(attempt);
+
+  const result = projectPunctuationStars(progress, CURRENT_RELEASE_ID);
+  assert.equal(result.perMonster.pealark.tryStars, 1);
+});
+
 test('3+ independent correct in Claspin — Practice Stars accumulate', () => {
   const progress = freshProgress();
   for (let i = 0; i < 5; i++) {

--- a/tests/react-punctuation-assets.test.js
+++ b/tests/react-punctuation-assets.test.js
@@ -73,13 +73,14 @@ test('Codex entries describe Punctuation as secure units rather than spelling wo
   assert.equal(pealark.subjectId, 'punctuation');
   assert.equal(pealark.secureLabel, '1 secure unit');
   assert.equal(pealark.wordBand, 'Endmarks, speech and boundary');
-  // 1 of 5 secured = stage 1 (one-fifth of the way).
-  assert.equal(pealark.progressPct, 20);
+  // Display progress now follows the monotonic Star display floor, not the
+  // mastered-unit denominator.
+  assert.equal(pealark.progressPct, 10);
 
   assert.equal(quoral.subjectId, 'punctuation');
   assert.equal(quoral.secureLabel, '1 secure unit');
   assert.equal(quoral.wordBand, 'Published punctuation release');
-  assert.equal(quoral.progressPct, 7);
+  assert.equal(quoral.progressPct, 10);
 });
 
 test('Codex entry defaults remain spelling-compatible', () => {

--- a/tests/render-effect-caught.test.js
+++ b/tests/render-effect-caught.test.js
@@ -82,6 +82,30 @@ test('caught effect: happy path — reward.monster event renders with toast text
   assert.equal(warnings.length, 0, `unexpected warnings: ${JSON.stringify(warnings)}`);
 });
 
+test('caught effect: first-Star Punctuation event uses the shared caught celebration kind', async () => {
+  const event = makeRewardEvent({
+    id: 'reward.monster:learner-a:inklet:caught:first-star',
+    kind: 'caught',
+    previous: { mastered: 0, stage: 0, displayState: 'not-found', caught: false, branch: 'b1' },
+    next: { mastered: 0, stage: 0, displayState: 'egg-found', caught: false, branch: 'b1' },
+  });
+  const out = await renderCelebrationLayerFixture({
+    registrations: REGISTER_CAUGHT,
+    setup: `
+      store.pushMonsterCelebrations([${JSON.stringify(event)}]);
+    `,
+  });
+  const { html, before, after, warnings } = JSON.parse(out);
+
+  assert.equal(before.queue.length, 1);
+  assert.equal(after.queue.length, 1, 'render alone must not advance the queue');
+  assert.match(html, /Inklet Egg/);
+  assert.match(html, /You caught a new friend!/);
+  assert.match(html, /New friend/);
+  assert.match(html, /class="monster-celebration-overlay caught"/);
+  assert.equal(warnings.length, 0, `unexpected warnings: ${JSON.stringify(warnings)}`);
+});
+
 test('caught effect: dismissal — onComplete drains the queue and persists an ack', async () => {
   // Wrap the registered effect so its render fires onComplete the first
   // time it sees one. <CelebrationLayer> evaluates render() during SSR,

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -75,6 +75,54 @@ test('home meadow shows all eggs once every species has been caught but stays in
   }
 });
 
+test('home meadow uses punctuation displayState instead of legacy caught for Egg Found', async () => {
+  const { buildMeadowMonsters } = await import('../src/surfaces/home/data.js');
+  const summary = [
+    {
+      subjectId: 'punctuation',
+      monster: MONSTERS.pealark,
+      progress: {
+        caught: false,
+        stage: 0,
+        displayStars: 1,
+        displayStage: 0,
+        displayState: 'egg-found',
+        branch: 'b1',
+      },
+    },
+  ];
+  const meadow = buildMeadowMonsters(summary);
+
+  assert.equal(meadow.length, 1);
+  assert.equal(meadow[0].species, 'pealark');
+  assert.equal(meadow[0].stage, 0);
+  assert.equal(meadow[0].path, 'none');
+});
+
+test('home meadow uses punctuation displayStage for evolved display', async () => {
+  const { buildMeadowMonsters } = await import('../src/surfaces/home/data.js');
+  const summary = [
+    {
+      subjectId: 'punctuation',
+      monster: MONSTERS.curlune,
+      progress: {
+        caught: false,
+        stage: 0,
+        displayStars: 30,
+        displayStage: 2,
+        displayState: 'evolve',
+        branch: 'b2',
+      },
+    },
+  ];
+  const meadow = buildMeadowMonsters(summary);
+
+  assert.equal(meadow.length, 1);
+  assert.equal(meadow[0].species, 'curlune');
+  assert.equal(meadow[0].stage, 2);
+  assert.notEqual(meadow[0].path, 'none');
+});
+
 test('home meadow uses seeded random foot positions for eggs', async () => {
   const { buildMeadowMonsters } = await import('../src/surfaces/home/data.js');
   const summary = [
@@ -320,6 +368,60 @@ test('codex entries show fresh creatures as unknown and caught stage-zero creatu
   assert.equal(egg.secureLabel, '1 secure word');
   assert.equal(egg.nextGoal, 'Keep securing words for the next change');
   assert.match(egg.img, /glimmerbug-b2-0\.640\.webp/);
+});
+
+test('codex entries use punctuation displayState for first-Star Egg Found', async () => {
+  const { buildCodexEntries } = await import('../src/surfaces/home/data.js');
+  const [entry] = buildCodexEntries([
+    {
+      subjectId: 'punctuation',
+      monster: MONSTERS.pealark,
+      progress: {
+        caught: false,
+        mastered: 0,
+        stage: 0,
+        displayStars: 1,
+        displayStage: 0,
+        displayState: 'egg-found',
+        level: 0,
+        branch: 'b1',
+      },
+    },
+  ]);
+
+  assert.equal(entry.caught, true);
+  assert.equal(entry.displayState, 'egg');
+  assert.equal(entry.stageLabel, 'Egg Found');
+  assert.equal(entry.secureLabel, 'No secure units yet');
+  assert.equal(entry.progressPct, 1);
+  assert.match(entry.img, /pealark-b1-0\.640\.webp/);
+});
+
+test('codex entries use punctuation displayStage for evolved visual state', async () => {
+  const { buildCodexEntries } = await import('../src/surfaces/home/data.js');
+  const [entry] = buildCodexEntries([
+    {
+      subjectId: 'punctuation',
+      monster: MONSTERS.curlune,
+      progress: {
+        caught: false,
+        mastered: 0,
+        stage: 0,
+        displayStars: 30,
+        displayStage: 2,
+        displayState: 'evolve',
+        level: 0,
+        branch: 'b2',
+      },
+    },
+  ]);
+
+  assert.equal(entry.caught, true);
+  assert.equal(entry.displayState, 'monster');
+  assert.equal(entry.stage, 2);
+  assert.equal(entry.stageLabel, 'Evolve');
+  assert.equal(entry.progressPct, 30);
+  assert.match(entry.img, /curlune-b2-2\.640\.webp/);
 });
 
 test('codex progress copy omits total and remaining counts', async () => {


### PR DESCRIPTION
## Summary
- Align Punctuation monster display around Star-derived display state so Subject landing, Summary, Home, and Codex use the same found/evolved truth.
- Keep `caught` as the shared first-found reward event kind while removing the Punctuation legacy first-secured celebration path.
- Add meaningful-attempt guards for Punctuation Try Stars and queue monster celebration overlays until session end.
- Document the Punctuation display-state and cross-subject event naming contract.

## Test Plan
- `npm test` — 5749 pass, 6 skipped, 0 fail
- `npm run check`
- `git diff --check`