### PR TITLE
fix(punctuation): project live stars into Codex

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2381,17 +2381,26 @@ function buildHomeDashboardStats(appState, context) {
   return out;
 }
 
-function buildHomeMonsterSummary(learnerId, context) {
+function punctuationStarViewForMonsterSummary(appState) {
+  const starView = appState?.subjectUi?.punctuation?.starView;
+  return starView && typeof starView === 'object' && !Array.isArray(starView)
+    ? starView
+    : null;
+}
+
+function buildHomeMonsterSummary(learnerId, context, appState = null) {
   if (!learnerId) return [];
+  const punctuationStarView = punctuationStarViewForMonsterSummary(appState);
   const spelling = context.services?.spelling;
   if (spelling?.getAnalyticsSnapshot) {
     return monsterSummaryFromSpellingAnalytics(spelling.getAnalyticsSnapshot(learnerId), {
       learnerId,
       gameStateRepository: context.repositories?.gameState,
+      punctuationStarView,
       persistBranches: false,
     });
   }
-  return monsterSummary(learnerId, context.repositories?.gameState);
+  return monsterSummary(learnerId, context.repositories?.gameState, { punctuationStarView });
 }
 
 function buildHomeDueTotal(learnerId, context) {
@@ -2451,7 +2460,7 @@ function buildHomeModel(appState, context) {
 
   return {
     ...buildSurfaceChromeModel(appState),
-    monsterSummary: buildHomeMonsterSummary(learnerId, context),
+    monsterSummary: buildHomeMonsterSummary(learnerId, context, appState),
     subjects: visibleSubjects,
     dashboardStats: buildHomeDashboardStats(appState, context),
     dueTotal: buildHomeDueTotal(learnerId, context),
@@ -2467,7 +2476,7 @@ function buildCodexModel(appState, context) {
 
   return {
     ...buildSurfaceChromeModel(appState),
-    monsterSummary: buildHomeMonsterSummary(learnerId, context),
+    monsterSummary: buildHomeMonsterSummary(learnerId, context, appState),
     now: new Date(),
   };
 }

--- a/src/platform/game/mastery/punctuation.js
+++ b/src/platform/game/mastery/punctuation.js
@@ -157,9 +157,48 @@ export function reservedPunctuationMonsterEntries(state = {}) {
   return reserved;
 }
 
-export function activePunctuationMonsterSummaryFromState(state = {}) {
-  return punctuationMonsterSummaryFromState(state)
+export function activePunctuationMonsterSummaryFromState(state = {}, options = {}) {
+  return punctuationMonsterSummaryFromState(state, options)
     .filter((entry) => entry.progress.displayState !== 'not-found' || entry.progress.caught || entry.progress.mastered > 0);
+}
+
+function punctuationStarViewProgress(starView, monsterId) {
+  const safeStarView = isPlainObject(starView) ? starView : null;
+  if (!safeStarView) return null;
+  if (monsterId === PUNCTUATION_GRAND_MONSTER_ID) {
+    const grand = isPlainObject(safeStarView.grand) ? safeStarView.grand : null;
+    if (!grand) return null;
+    return {
+      stars: safeStarHighWater(grand.grandStars),
+      stage: Math.max(0, Math.min(4, Math.floor(Number(grand.starDerivedStage) || 0))),
+    };
+  }
+  const perMonster = isPlainObject(safeStarView.perMonster) ? safeStarView.perMonster : {};
+  const entry = isPlainObject(perMonster[monsterId]) ? perMonster[monsterId] : null;
+  if (!entry) return null;
+  return {
+    stars: safeStarHighWater(entry.total),
+    stage: Math.max(0, Math.min(4, Math.floor(Number(entry.starDerivedStage) || 0))),
+  };
+}
+
+function mergePunctuationProgressWithStarView(progress, monsterId, starView) {
+  const live = punctuationStarViewProgress(starView, monsterId);
+  if (!live) return progress;
+  const displayStars = Math.max(safeStarHighWater(progress?.displayStars), safeStarHighWater(progress?.starHighWater), live.stars);
+  const displayStage = Math.max(
+    Math.max(0, Math.min(4, Math.floor(Number(progress?.displayStage) || 0))),
+    Math.max(0, Math.min(4, Math.floor(Number(progress?.starStage) || 0))),
+    Math.max(0, Math.min(4, Math.floor(Number(progress?.stage) || 0))),
+    live.stage,
+  );
+  return {
+    ...progress,
+    displayStars,
+    displayStage,
+    displayState: punctuationDisplayStateForStars(displayStars, displayStage),
+    starStage: Math.max(Math.max(0, Math.min(4, Math.floor(Number(progress?.starStage) || 0))), live.stage),
+  };
 }
 
 export function progressForPunctuationMonster(state, monsterId, { publishedTotal = null, releaseId = PUNCTUATION_CURRENT_RELEASE_ID } = {}) {
@@ -444,15 +483,19 @@ export function updatePunctuationStarHighWater({
   return event ? [event] : [];
 }
 
-export function punctuationMonsterSummaryFromState(state = {}, { clusterTotals = {}, aggregateTotal = 1, releaseId = PUNCTUATION_CURRENT_RELEASE_ID } = {}) {
+export function punctuationMonsterSummaryFromState(state = {}, { clusterTotals = {}, aggregateTotal = 1, releaseId = PUNCTUATION_CURRENT_RELEASE_ID, starView = null } = {}) {
   return PUNCTUATION_MONSTER_IDS.map((monsterId) => ({
     subjectId: 'punctuation',
     monster: MONSTERS[monsterId],
-    progress: progressForPunctuationMonster(state, monsterId, {
-      publishedTotal: monsterId === PUNCTUATION_GRAND_MONSTER_ID
-        ? aggregateTotal
-        : (clusterTotals[monsterId] || MONSTERS[monsterId]?.masteredMax || 1),
-      releaseId,
-    }),
+    progress: mergePunctuationProgressWithStarView(
+      progressForPunctuationMonster(state, monsterId, {
+        publishedTotal: monsterId === PUNCTUATION_GRAND_MONSTER_ID
+          ? aggregateTotal
+          : (clusterTotals[monsterId] || MONSTERS[monsterId]?.masteredMax || 1),
+        releaseId,
+      }),
+      monsterId,
+      starView,
+    ),
   }));
 }

--- a/src/platform/game/mastery/spelling.js
+++ b/src/platform/game/mastery/spelling.js
@@ -127,14 +127,14 @@ export function recordMonsterMastery(learnerId, monsterId, wordSlug, gameStateRe
   return events;
 }
 
-export function monsterSummary(learnerId, gameStateRepository) {
+export function monsterSummary(learnerId, gameStateRepository, { punctuationStarView = null } = {}) {
   const state = ensureMonsterBranches(learnerId, gameStateRepository, {
     monsterIds: SPELLING_MONSTER_IDS,
   });
-  return monsterSummaryFromState(state);
+  return monsterSummaryFromState(state, { punctuationStarView });
 }
 
-export function monsterSummaryFromState(state = {}) {
+export function monsterSummaryFromState(state = {}, { punctuationStarView = null } = {}) {
   const spelling = SPELLING_MONSTER_IDS.map((monsterId) => ({
     subjectId: 'spelling',
     monster: MONSTERS[monsterId],
@@ -148,7 +148,7 @@ export function monsterSummaryFromState(state = {}) {
   const normalisedGrammarState = normaliseGrammarRewardState(state);
   return [
     ...spelling,
-    ...activePunctuationMonsterSummaryFromState(state),
+    ...activePunctuationMonsterSummaryFromState(state, { starView: punctuationStarView }),
     ...activeGrammarMonsterSummaryFromState(normalisedGrammarState),
   ];
 }
@@ -156,6 +156,7 @@ export function monsterSummaryFromState(state = {}) {
 export function monsterSummaryFromSpellingAnalytics(analytics, {
   learnerId = null,
   gameStateRepository = null,
+  punctuationStarView = null,
   random = Math.random,
   persistBranches = true,
 } = {}) {
@@ -167,7 +168,7 @@ export function monsterSummaryFromSpellingAnalytics(analytics, {
   }
 
   if (!analyticsHasWordRows(analytics) && hasMonsterMasteryProgress(branchState)) {
-    return monsterSummaryFromState(branchState);
+    return monsterSummaryFromState(branchState, { punctuationStarView });
   }
 
   const state = secureWordsFromAnalytics(analytics, branchState);
@@ -177,7 +178,7 @@ export function monsterSummaryFromSpellingAnalytics(analytics, {
   const normalisedBranchState = normaliseGrammarRewardState(branchState);
   return [
     ...monsterSummaryFromState(state),
-    ...activePunctuationMonsterSummaryFromState(branchState),
+    ...activePunctuationMonsterSummaryFromState(branchState, { starView: punctuationStarView }),
     ...activeGrammarMonsterSummaryFromState(normalisedBranchState),
   ];
 }

--- a/tests/monster-system.test.js
+++ b/tests/monster-system.test.js
@@ -276,6 +276,36 @@ test('analytics summaries can project branches without writing during render', (
   assert.equal(summary.find((entry) => entry.monster.id === 'vellhorn').progress.mastered, 0);
 });
 
+test('analytics summaries project Punctuation live Star eggs before codex high-water backfill', () => {
+  const repository = makeGameStateRepository({
+    pealark: { branch: 'b2', mastered: [], caught: false },
+  });
+  const punctuationStarView = {
+    perMonster: {
+      pealark: { total: 1, starDerivedStage: 0 },
+      curlune: { total: 0, starDerivedStage: 0 },
+      claspin: { total: 0, starDerivedStage: 0 },
+    },
+    grand: { grandStars: 0, total: 100, starDerivedStage: 0 },
+  };
+
+  const summary = monsterSummaryFromSpellingAnalytics({ wordGroups: [] }, {
+    learnerId: 'James',
+    gameStateRepository: repository,
+    punctuationStarView,
+    persistBranches: false,
+  });
+
+  const pealarkEntries = summary.filter((entry) => entry.subjectId === 'punctuation' && entry.monster.id === 'pealark');
+  assert.equal(pealarkEntries.length, 1);
+  const pealark = pealarkEntries[0];
+  assert.equal(pealark.progress.caught, false, 'secure reward state stays decoupled from monster display');
+  assert.equal(pealark.progress.branch, 'b2');
+  assert.equal(pealark.progress.displayStars, 1);
+  assert.equal(pealark.progress.displayStage, 0);
+  assert.equal(pealark.progress.displayState, 'egg-found');
+});
+
 test('redacted analytics uses public monster projection state without writing during render', () => {
   const repository = makeGameStateRepository({
     inklet: { masteredCount: 12, caught: true, branch: 'b1' },


### PR DESCRIPTION
## Summary
- Thread Punctuation live `starView` into the Home/Codex monster summary projection.
- Preserve secure reward state: `caught` remains decoupled while `displayState` reflects Egg Found from Stars.
- Add regression coverage for existing learners whose subject evidence exists before `monster-codex.starHighWater` is backfilled.

## Tests
- `node --test tests/monster-system.test.js tests/render.test.js tests/punctuation-mastery.test.js`
- `npm test`
- `npm run check`
- `git diff --check`
