### PR TITLE
feat(punctuation): add generator guardrails audit

### DIFF
--- a/docs/plans/2026-04-28-001-feat-punctuation-generator-guardrails-expansion-plan.md
+++ b/docs/plans/2026-04-28-001-feat-punctuation-generator-guardrails-expansion-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Punctuation Generator Guardrails and Thin-Skill Expansion"
 type: feat
-status: active
+status: completed
 date: 2026-04-28
 deepened: 2026-04-28
 origin: docs/plans/james/punctuation/questions-generator/punctuation-qg-p1.md

--- a/docs/plans/2026-04-28-001-feat-punctuation-generator-guardrails-expansion-plan.md
+++ b/docs/plans/2026-04-28-001-feat-punctuation-generator-guardrails-expansion-plan.md
@@ -1,0 +1,551 @@
+---
+title: "feat: Punctuation Generator Guardrails and Thin-Skill Expansion"
+type: feat
+status: active
+date: 2026-04-28
+deepened: 2026-04-28
+origin: docs/plans/james/punctuation/questions-generator/punctuation-qg-p1.md
+source_plans:
+  - docs/plans/james/punctuation/punctuation-p7-completion-report.md
+  - docs/plans/james/punctuation/punctuation-p6-completion-report.md
+---
+
+# feat: Punctuation Generator Guardrails and Thin-Skill Expansion
+
+## Summary
+
+This plan turns the Punctuation question-generator audit into the next implementation slice: lock the deterministic generator's identity and quality gates first, then expand the thinnest skills with teacher-authored templates and sibling retry coverage. It keeps runtime AI out of learner question generation, preserves the existing 14-skill reward contract, and treats generator expansion as content-quality work rather than another reward or landing-page hardening phase.
+
+---
+
+## Problem Frame
+
+The current Punctuation subject is production-capable, Worker-backed, and heavily hardened through Phases 5-7, but the question pool is still shallow: the local manifest still has 71 fixed items, 25 published generator families, and one generated item per family at runtime, giving a practical pool of 96 items. That is enough for a first release, but too thin for long-term spaced mastery because learners can see repeated surfaces before they have proved transferable punctuation knowledge.
+
+The risky part is not only quantity. `shared/punctuation/generators.js` currently derives generated item ids from seed, family, and variant index, while template selection depends on template-bank length. Expanding a bank without guardrails can make an existing generated item id point at a different stem/model, corrupting item-level learning evidence. The next phase therefore has to stabilise generated-item identity before adding more templates.
+
+---
+
+## Assumptions
+
+*This plan was authored from the provided audit brief and current repo research without a synchronous scope-confirmation round. The items below are agent inferences that should be reviewed before implementation proceeds.*
+
+- This is the first implementation slice for the `questions-generator` audit, so it should cover P0 guardrails and the highest-value P1 template expansion, not the entire P0-P4 roadmap in one release.
+- Existing Punctuation reward, Star, telemetry, Doctor, and landing-page work from Phases 6-7 is treated as complete baseline infrastructure and is not reopened.
+- The default runtime should stay at one generated item per family until generator identity, duplicate detection, and scheduler signature handling are proven.
+- Runtime learner-facing AI generation remains out of scope; context packs stay deterministic, sanitised compiler input.
+
+---
+
+## Requirements
+
+- R1. The Punctuation runtime must remain deterministic and must not use AI to generate learner-facing questions, model answers, validators, or marking behaviour at runtime.
+- R2. Existing runtime generated items must not silently change stem/model under the same item id when template banks expand.
+- R3. Every generated item must expose a stable template identity and a normalised variant signature suitable for duplicate detection, scheduler avoidance, audit output, and evidence variety checks.
+- R4. A repo-native content audit must report fixed item count, generator-family count, runtime item count, per-skill/mode/readiness coverage, validator coverage, duplicate stems/models/signatures, and generated identity drift.
+- R5. Audit thresholds must fail tests or CI-facing checks when a published skill lacks enough item variety, transfer/misconception/negative-test coverage, validator coverage, or signature diversity.
+- R6. The first expansion must prioritise thin or repetition-prone skills: `sentence_endings`, `apostrophe_contractions`, `comma_clarity`, `semicolon_list`, `hyphen`, and `dash_clause`.
+- R7. Expanded templates must be teacher-authored, deterministic, child-register safe, and backed by deterministic marking golden paths for accepted and rejected answers.
+- R8. Dash and list-comma policy must be explicit in tests and audit output: valid dash variants are accepted for dash-boundary answers, and an otherwise correct Oxford-comma answer is accepted in free-text list-comma prompts unless the prompt explicitly forbids the final comma.
+- R9. Scheduler and attempt evidence must prefer sibling templates with the same misconception/facet after an error, rather than simply repeating the same surface item.
+- R10. Generated variant diversity must support near-term growth toward 150-200 runtime items without changing reward-unit denominators or claiming a broader curriculum release.
+- R11. Context-pack support may expand only as sanitised, deterministic template input; context-pack atoms must never bypass validators, expose hidden answers, or weaken learner read-model redaction.
+- R12. No Punctuation content-release id or reward-unit mastery-key format changes unless implementation proves generated identity cannot be preserved safely without an explicit release migration.
+
+---
+
+## Scope Boundaries
+
+- Do not add runtime AI-authored questions, runtime AI marking, or learner-visible AI explanations.
+- Do not redesign the Punctuation landing page, reward model, Doctor diagnostic, telemetry contract, or Monster Codex projection.
+- Do not add new Punctuation skills, monsters, practice modes, or a new subject route.
+- Do not change deterministic marking semantics beyond the explicitly scoped dash/list-comma policy hardening.
+- Do not increase `generatedPerFamily` in production runtime until the audit, identity, duplicate, and scheduler-signature gates are in place.
+- Do not change published reward-unit denominators; generated template expansion must not make Stars or Mega easier by adding repeated evidence under new ids.
+- Do not weaken Spelling or Grammar parity, bundle-audit restrictions, or Worker-owned subject-command boundaries.
+
+### Deferred to Follow-Up Work
+
+- **Full slot-builder DSL rewrite:** This plan adds template identity and structured builder expectations, but a complete DSL conversion for all families can follow after the first expansion proves the contract.
+- **Full context-pack coverage across every family:** This plan extends coverage where it helps the P1 expansion. Universal context-pack coverage is a later phase.
+- **Production increase of generated items per family:** Keep the runtime default unchanged until P1 audit results show enough unique signatures per family.
+- **Parent/Admin content-authoring UI:** The plan improves source files and audit scripts only; operator UI for authoring templates remains future work.
+- **Star-economy rebalancing:** Extra generator variety should feed evidence quality, not change the P6/P7 Star thresholds in this slice.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `shared/punctuation/content.js` defines the 14 published skills, six clusters, 14 reward units, 71 fixed evidence items, and 25 generator families.
+- `shared/punctuation/generators.js` builds generated items with deterministic seeds and currently assigns ids from seed/family/index while selecting templates from the bank length.
+- `shared/punctuation/context-packs.js` already sanitises context-pack atoms and returns deterministic templates for a subset of generator families.
+- `shared/punctuation/marking.js` contains deterministic validators and rubric handling. The audit's dash/list-comma concerns belong here and in focused marking tests.
+- `shared/punctuation/scheduler.js` already keeps candidate windows bounded, weights weak/due/new evidence, and avoids recent item ids; it does not yet avoid repeated variant signatures.
+- `shared/punctuation/service.js` records attempts and updates item/facet/reward-unit memory. Scheduler-signature evidence should flow through this existing progress shape rather than a new table.
+- `src/subjects/punctuation/punctuation-manifest.js` is the P7 canonical client-safe manifest pattern; generator audit code should avoid duplicating client-safe constants when that module already provides them.
+- `tests/punctuation-generators.test.js` covers deterministic generation, model-answer marking, reward-denominator stability, and scheduler selection of generated practice.
+- `tests/punctuation-content.test.js` already validates the 14-skill map, readiness matrix, reward-key stability, and child-register rule strings.
+- `tests/punctuation-scheduler.test.js` already covers weak/due selection, focus modes, bounded candidate windows, and generated-item selection.
+- `tests/punctuation-marking.test.js`, `tests/punctuation-combine.test.js`, and `tests/punctuation-paragraph.test.js` provide the golden-path pattern for accepted/rejected deterministic answers.
+- `docs/plans/james/punctuation/punctuation-p6-completion-report.md` confirms Phase 6 added Star truth and anti-grinding but intentionally did not touch generator/content files.
+- `docs/plans/james/punctuation/punctuation-p7-completion-report.md` confirms Phase 7 stabilised diagnostics, manifest drift, telemetry, and Worker-backed journeys with zero engine or marking changes.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture-patterns/punctuation-p7-stabilisation-contract-and-autonomous-sdlc-2026-04-28.md` says client-safe metadata should have one canonical source and drift tests should pin exact values. This plan follows that by adding generator identity/audit outputs instead of scattering new constants.
+- `docs/solutions/architecture-patterns/punctuation-p6-star-truth-monotonic-hardening-2026-04-27.md` warns that reward and child-visible progress code needs adversarial review because threshold and evidence mismatches become learner-trust failures. Generator expansion has the same risk profile for false mastery evidence.
+- Prior Punctuation phases repeatedly found test-harness-vs-production drift. This plan therefore requires generator compatibility fixtures and scheduler integration tests, not only isolated template unit tests.
+
+### External References
+
+- No external framework research is required. The work is repo-native JavaScript, Node `node:test`, deterministic Worker-owned subject logic, and existing Punctuation content patterns.
+
+---
+
+## Key Technical Decisions
+
+| Decision | Rationale |
+|---|---|
+| Stabilise generated identity before adding templates | Current ids do not include template identity. Expanding a template bank can otherwise reuse an old item id for a different learner-visible question. |
+| Add `templateId` and `variantSignature` as generated-item metadata | Item ids are persistence-facing, while signatures are scheduler/evidence-facing. Keeping both avoids overloading ids and gives audit tooling a stable duplicate detector. |
+| Preserve current runtime output as a compatibility fixture | The safest first gate is proving that `generatedPerFamily: 1` keeps today's generated ids, stems, models, validators, and marking results unless an explicit release migration is chosen. |
+| Use audit thresholds before production runtime expansion | Counting after the fact is too late; CI-facing audit failures should stop thin skills, duplicate signatures, hidden-answer transfer gaps, and missing validators before learners see them. |
+| Expand hand-authored template banks before raising `generatedPerFamily` | More generated ids are not more learning if they repeat the same shape. The plan increases template diversity first and defers runtime count changes. |
+| Treat dash and Oxford-comma policy as explicit product/marking policy | The audit flagged both because ambiguity becomes unfair marking. The plan accepts valid dash variants for dash-boundary answers and accepts Oxford comma in free-text list-comma prompts unless the prompt explicitly forbids it, while allowing choice/discrimination items to keep teaching the KS2 house style when the prompt says so. |
+| Keep signatures internal or opaque in read models | `variantSignature` may be derived from prompt/model shape, so it must not expose answer-bearing material to the learner. Runtime code can use the full signature internally; any client/debug output should expose only an opaque hash or safe duplicate category. |
+| Add sibling retry by signature/misconception, not by item id alone | After an error, the learner needs another surface for the same misconception. Repeating the same id or same signature encourages memorisation rather than repair. |
+| Keep context packs as deterministic compiler input | Context packs are useful for fresh surface contexts, but they must stay sanitised, bounded, and validator-backed. They are not a shortcut around teacher-authored templates. |
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should this plan use external AI generation?** No. The audit explicitly recommends deterministic teacher-authored templates, and the existing Punctuation production boundary forbids runtime AI question or marking authority.
+- **Are the audit's pool counts still current?** Yes. Local source inspection confirms 71 fixed items, 25 generator families, one generated item per family at runtime, and 96 runtime items.
+- **Should reward denominators change with generated expansion?** No. Existing tests already assert generator-family expansion does not change published reward mastery keys.
+- **Should Phases 6-7 reward hardening be reopened?** No. Completion reports show those phases shipped without generator/contentRelease changes; this plan should sit on top of that baseline.
+- **Should production `generatedPerFamily` increase in the same slice?** No. First prove identity, signatures, audit thresholds, and scheduler behaviour. Runtime increase is deferred until audit data supports it.
+
+### Deferred to Implementation
+
+- **Exact signature normalisation fields:** The plan requires enough identity to detect repeated item shapes. Implementation should choose the smallest stable field set that catches duplicate learner-visible stems/models without leaking hidden answers.
+- **Exact audit threshold numbers for each skill:** Start from the audit's target of 8-12 meaningful variants per generator family and 150-200 near-term runtime items, then tune thresholds after the first audit report shows current gaps.
+- **Exact learner-facing wording for Oxford-comma feedback:** The policy is fixed for planning: accept otherwise correct Oxford-comma free-text answers unless the prompt explicitly forbids the final comma. Implementation should settle the shortest child-safe feedback wording for house-style teaching cases.
+- **Exact template count per thin skill:** The expansion should prioritise diversity and validator coverage over hitting a round number.
+- **Whether a content release id bump is necessary:** Default is no bump. If compatibility fixtures prove existing generated ids cannot be preserved safely, implementation must surface the migration choice before changing release ids.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+  Manifest["Punctuation content manifest"]
+  Families["Published generator families"]
+  Templates["Teacher-authored templates with templateId"]
+  Builder["Deterministic generated-item builder"]
+  Signature["variantSignature and identity guard"]
+  Audit["Content audit and threshold tests"]
+  Scheduler["Scheduler sibling/duplicate avoidance"]
+  Attempts["Attempt evidence and Star projection inputs"]
+
+  Manifest --> Families
+  Families --> Templates
+  Templates --> Builder
+  Builder --> Signature
+  Signature --> Audit
+  Signature --> Scheduler
+  Scheduler --> Attempts
+  Attempts --> Audit
+```
+
+The active implementation shape is: generated templates become explicitly identifiable, generated items carry signatures, audit tooling verifies compatibility and coverage, and scheduler/service evidence starts using signatures to avoid repeated surfaces. Template-bank expansion then happens behind those gates.
+
+---
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+  U1["U1 Audit baseline"]
+  U2["U2 Identity and signatures"]
+  U3["U3 Marking policy hardening"]
+  U4["U4 Thin-skill templates"]
+  U5["U5 Scheduler signature variety"]
+  U6["U6 Context-pack extension"]
+  U7["U7 Docs and release evidence"]
+
+  U1 --> U2
+  U2 --> U4
+  U3 --> U4
+  U2 --> U5
+  U4 --> U5
+  U2 --> U6
+  U4 --> U6
+  U5 --> U7
+  U6 --> U7
+```
+
+- U1. **Add Punctuation Content Audit Baseline**
+
+**Goal:** Create a repo-native audit that reports the current question-bank and generator health before any expansion changes are made.
+
+**Requirements:** R4, R5, R10
+
+**Dependencies:** None
+
+**Files:**
+- Create: `scripts/audit-punctuation-content.mjs`
+- Modify: `package.json`
+- Test: `tests/punctuation-content-audit.test.js`
+- Reference: `shared/punctuation/content.js`
+- Reference: `shared/punctuation/generators.js`
+
+**Approach:**
+- Add a read-only audit module/script that imports the manifest and generated runtime manifest, then emits both human-readable and machine-checkable summaries.
+- Report counts by skill, mode, readiness row, source, validator/rubric presence, generated family, duplicate stem/model, and duplicate generated signature once U2 lands.
+- Keep the first version descriptive, with thresholds represented as data so U4 can tighten them after expansion.
+- Do not run the audit from production code paths. It is a development and CI-facing guard only.
+
+**Execution note:** Add the current audit snapshot before changing generator logic, so the compatibility baseline is objective.
+
+**Patterns to follow:**
+- `tests/punctuation-content.test.js` manifest validation style.
+- `tests/punctuation-generators.test.js` deterministic generated-item checks.
+- Existing `scripts/*audit*.mjs` scripts for CLI shape and package-script integration.
+
+**Test scenarios:**
+- Happy path: current manifest audit reports 71 fixed items, 25 generated families, 25 generated items at `generatedPerFamily: 1`, 96 runtime items, and 14 published reward units.
+- Happy path: every published skill appears in the audit with fixed, generated, readiness, and validator counts.
+- Edge case: adding a duplicate fixed stem/model in a fixture produces a duplicate warning or failure in the machine-readable result.
+- Edge case: adding a published generator family with no templates appears as a generator coverage failure.
+- Error path: malformed manifest fixture returns a non-zero audit failure result without throwing an unstructured stack trace.
+- Integration: package script output can be consumed by Node tests without depending on terminal formatting.
+
+**Verification:**
+- The audit can be run locally and produces stable counts for the current repo.
+- Tests prove the audit detects duplicate and missing-template fixtures.
+
+---
+
+- U2. **Stabilise Generated Item Identity and Signatures**
+
+**Goal:** Add stable template metadata and generated variant signatures without breaking the existing runtime generated-item compatibility contract.
+
+**Requirements:** R2, R3, R5, R10, R12
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `shared/punctuation/generators.js`
+- Modify: `shared/punctuation/content.js`
+- Modify: `shared/punctuation/context-packs.js`
+- Modify: `scripts/audit-punctuation-content.mjs`
+- Test: `tests/punctuation-generators.test.js`
+- Test: `tests/punctuation-content-audit.test.js`
+
+**Approach:**
+- Add explicit template identity metadata to generated-template definitions, including context-pack templates.
+- Add a normalised `variantSignature` to generated items based on stable learner-visible shape and template identity.
+- Preserve the current `generatedPerFamily: 1` runtime ids/stems/models as a compatibility fixture unless implementation proves an explicit migration is needed.
+- Update audit output to distinguish item id uniqueness from signature uniqueness; both are required.
+- Keep full signatures internal to the generator/scheduler/audit path. If any read model or diagnostic needs to reference them, expose only an opaque hash or safe duplicate label.
+- Ensure generated model answers still pass deterministic marking after metadata is attached.
+
+**Technical design:** Directional identity model:
+
+```text
+generator family + seed + variant index -> stable item id
+template id + normalised prompt/stem/model/mode/validator type -> variantSignature
+
+item id answers "which persisted item is this?"
+variantSignature answers "is this effectively the same learner surface?"
+```
+
+**Patterns to follow:**
+- Existing generated-item shape in `shared/punctuation/generators.js`.
+- P7 canonical manifest/drift-test pattern from `src/subjects/punctuation/punctuation-manifest.js` and `tests/punctuation-manifest-drift.test.js`.
+
+**Test scenarios:**
+- Happy path: current `generatedPerFamily: 1` generated ids, stems, models, and marking results remain unchanged after adding template metadata.
+- Happy path: every generated item has `generatorFamilyId`, `templateId`, and `variantSignature`.
+- Happy path: two generated items with different ids but the same learner-visible shape share the same signature and are reported by the audit.
+- Edge case: adding new templates to a fixture does not change the existing first runtime generated item for each family.
+- Error path: a generated template without `templateId` fails validation with a targeted message.
+- Error path: a generated template whose model answer no longer passes deterministic marking fails the generator test.
+- Integration: context-pack generated items receive template ids and signatures without exposing raw context-pack atoms beyond the existing safe output.
+
+**Verification:**
+- Existing runtime generated compatibility is pinned by tests.
+- Audit output now includes generated identity and signature health.
+
+---
+
+- U3. **Make Dash and List-Comma Marking Policy Explicit**
+
+**Goal:** Turn the audit's dash and Oxford-comma concerns into deterministic marking policy tests before expanded templates depend on them.
+
+**Requirements:** R7, R8
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `shared/punctuation/marking.js`
+- Modify: `shared/punctuation/content.js`
+- Test: `tests/punctuation-marking.test.js`
+- Test: `tests/punctuation-combine.test.js`
+- Test: `tests/punctuation-paragraph.test.js`
+- Test: `tests/punctuation-generators.test.js`
+
+**Approach:**
+- Audit current dash validators for transfer, combine, and parenthesis contexts, then align tests around the accepted dash forms: spaced hyphen, spaced en dash, and spaced em dash where the prompt asks for a dash boundary.
+- Encode the Oxford-comma stance for list-comma free-text prompts: otherwise correct Oxford-comma answers are accepted unless the prompt explicitly forbids the final comma. Where the app is teaching KS2 house style, prompts and feedback should make that distinction explicit.
+- Keep policy changes narrow. Do not refactor unrelated marking logic or rewrite rubrics.
+- Add generator-model tests that cover the chosen policy so new templates cannot introduce inconsistent answer expectations.
+
+**Patterns to follow:**
+- `tests/punctuation-marking.test.js` accepted/rejected answer matrix.
+- `tests/punctuation-combine.test.js` boundary combine tests.
+- `shared/punctuation/marking.js` validator-specific misconception tag handling.
+
+**Test scenarios:**
+- Happy path: dash-clause transfer accepts a spaced hyphen, spaced en dash, and spaced em dash when all required clauses are preserved.
+- Happy path: parenthesis with dashes continues to accept matched dash variants only around the intended parenthetical phrase.
+- Edge case: unspaced dash or dash attached to a conjunction remains rejected when spacing is required by the validator.
+- Happy path: list-comma free-text answer following the chosen KS2 policy is marked correct.
+- Edge case: an otherwise correct Oxford-comma answer is accepted in a free-text prompt, while the same final comma can be rejected only when the prompt explicitly forbids it.
+- Error path: list answers with missing separators or changed list items still fail with the existing misconception tags.
+- Integration: generated list/dash templates inherit the same marking policy as fixed items.
+
+**Verification:**
+- Marking policy is explicit in tests and no longer depends on reader interpretation of copy.
+- Existing speech, paragraph, and transfer marking tests remain green.
+
+---
+
+- U4. **Expand Thin-Skill Generator Template Banks**
+
+**Goal:** Add high-quality deterministic templates for the skills most likely to repeat under the current runtime pool.
+
+**Requirements:** R1, R6, R7, R10
+
+**Dependencies:** U2, U3
+
+**Files:**
+- Modify: `shared/punctuation/generators.js`
+- Modify: `shared/punctuation/content.js`
+- Modify: `tests/punctuation-generators.test.js`
+- Modify: `tests/punctuation-content.test.js`
+- Modify: `tests/punctuation-marking.test.js`
+- Modify: `tests/punctuation-combine.test.js`
+- Modify: `tests/punctuation-paragraph.test.js`
+
+**Approach:**
+- Prioritise the audit's thin/repetition-prone skills: `sentence_endings`, `apostrophe_contractions`, `comma_clarity`, `semicolon_list`, `hyphen`, and `dash_clause`.
+- Add teacher-authored templates with varied stems, modes, misconception tags, readiness rows, and validators. Favour meaningful variation over superficial noun swaps.
+- Keep generated models rule-built or structurally derived where practical, so model answer and validator do not drift.
+- Avoid production runtime count increase in this unit; the benefit is a richer bank ready for safe expansion.
+- Update audit thresholds from descriptive to fail-capable for the newly covered families.
+
+**Patterns to follow:**
+- Existing template banks in `shared/punctuation/generators.js`.
+- Existing fixed-item evidence and reward-unit mapping in `shared/punctuation/content.js`.
+- Existing generator smoke test that marks every generated model answer.
+
+**Test scenarios:**
+- Happy path: each target skill has materially more unique generated signatures than before, and the audit reports no duplicate generated signatures for the newly expanded families.
+- Happy path: generated model answers for all expanded templates pass deterministic marking.
+- Happy path: expanded templates include misconception and negative-test coverage, not only happy-path insert items.
+- Edge case: semicolon-list templates preserve complex list item words and reject comma-only separators.
+- Edge case: hyphen templates reject missing hyphens without rejecting unrelated correct sentence punctuation.
+- Edge case: comma-clarity templates distinguish clarity comma placement from list comma placement.
+- Error path: a template with a hidden validator requirement not present in the prompt fails the existing hidden-transfer validation pattern.
+- Integration: the content audit fails if any target skill remains below the agreed signature-diversity floor.
+
+**Verification:**
+- The generated bank is materially richer for the target skills.
+- Runtime default remains unchanged while the expanded bank is available for future controlled `generatedPerFamily` increases.
+
+---
+
+- U5. **Use Variant Signatures for Scheduler Variety and Retry Repair**
+
+**Goal:** Make scheduling and attempt evidence prefer varied generated surfaces, especially after mistakes, without changing reward denominators.
+
+**Requirements:** R3, R5, R9, R10
+
+**Dependencies:** U2, U4
+
+**Files:**
+- Modify: `shared/punctuation/scheduler.js`
+- Modify: `shared/punctuation/service.js`
+- Modify: `src/subjects/punctuation/read-model.js`
+- Test: `tests/punctuation-scheduler.test.js`
+- Test: `tests/punctuation-service.test.js`
+- Test: `tests/punctuation-read-model.test.js`
+- Test: `tests/punctuation-star-projection.test.js`
+
+**Approach:**
+- Thread generated `variantSignature` into progress attempts where an item has one, keeping old attempts valid when the field is absent.
+- Penalise recent signatures in the scheduler as well as recent item ids.
+- After an incorrect answer, prefer a sibling item with the same skill/misconception/facet but a different signature when one exists.
+- Ensure Star and Practice evidence can recognise variety by signature without letting repeated generated variants count as independent deep evidence.
+- Keep candidate-window bounds intact; signature checks must not require scanning the whole expanded manifest on every selection.
+
+**Patterns to follow:**
+- Recent-item avoidance and weak/due weighting in `shared/punctuation/scheduler.js`.
+- Attempt recording and memory-state updates in `shared/punctuation/service.js`.
+- P6/P7 anti-grinding and Star evidence lessons from `docs/solutions/architecture-patterns/punctuation-p6-star-truth-monotonic-hardening-2026-04-27.md`.
+
+**Test scenarios:**
+- Happy path: after a miss on a generated dash-clause item, weak mode selects a same-skill sibling with a different signature when available.
+- Happy path: recent signature suppression avoids selecting two generated ids with the same signature in the same short session.
+- Edge case: fixed items without `variantSignature` continue using item-id recentness and are not dropped from scheduling.
+- Edge case: old progress attempts without signatures still hydrate and contribute to existing memory buckets.
+- Error path: if no sibling signature exists, scheduler falls back to the best existing weak/due candidate rather than returning null.
+- Integration: Practice/Star evidence rewards varied generated signatures but does not treat repeated same-signature attempts as independent deep evidence.
+- Performance: expanded manifest candidate-window tests still inspect only the bounded window expected by existing scheduler tests.
+
+**Verification:**
+- Learners get repair variety after mistakes.
+- Scheduler remains deterministic and bounded under expanded manifests.
+
+---
+
+- U6. **Extend Deterministic Context-Pack Template Coverage**
+
+**Goal:** Expand context-pack support for the P1 generator families while preserving the teacher/admin-only, sanitised compiler-input boundary.
+
+**Requirements:** R1, R7, R11
+
+**Dependencies:** U2, U4
+
+**Files:**
+- Modify: `shared/punctuation/context-packs.js`
+- Modify: `shared/punctuation/generators.js`
+- Modify: `worker/src/subjects/punctuation/ai-enrichment.js`
+- Modify: `worker/src/subjects/punctuation/read-models.js`
+- Test: `tests/punctuation-ai-context-pack.test.js`
+- Test: `tests/punctuation-generators.test.js`
+- Test: `tests/punctuation-read-models.test.js`
+
+**Approach:**
+- Add deterministic context-pack template adapters for the same target families where safe atoms can produce genuinely fresh surfaces.
+- Keep atom validation strict: bounded count, safe characters, no punctuation-bearing strings, no answer-bearing atoms, no unknown kinds accepted silently.
+- Ensure context-generated templates carry `templateId`, `variantSignature`, validators, and marking golden coverage like static templates.
+- Preserve learner read-model redaction; context-pack summaries may describe accepted/rejected atom counts but must not expose hidden answer banks or raw unsafe atoms.
+
+**Patterns to follow:**
+- Existing `normalisePunctuationContextPack` sanitisation.
+- Existing `contextPackTemplatesForFamily` adapter style.
+- P7 redaction/Doctor forbidden-key scan discipline.
+
+**Test scenarios:**
+- Happy path: a safe context pack can generate list-comma, dash, hyphen, or sentence-ending variants for a covered family with valid signatures and validators.
+- Happy path: context-generated model answers pass deterministic marking.
+- Edge case: duplicate, too-long, punctuation-bearing, or unsafe atoms are rejected and listed only in safe summary form.
+- Edge case: an atom pack that cannot satisfy a family returns no template for that family rather than a partial unsafe template.
+- Error path: unknown atom kinds do not influence generated templates.
+- Integration: Worker read-model forbidden-key scan still passes when a context pack is requested.
+
+**Verification:**
+- Context packs create deterministic variety for covered families without becoming runtime AI generation.
+- Redaction and sanitisation tests prove learner-safe boundaries remain intact.
+
+---
+
+- U7. **Document Release Evidence and Safe Runtime Expansion Criteria**
+
+**Goal:** Make the new generator contract operationally clear and define the evidence required before increasing production generated counts.
+
+**Requirements:** R4, R5, R10, R12
+
+**Dependencies:** U5, U6
+
+**Files:**
+- Modify: `docs/punctuation-production.md`
+- Reference: `docs/plans/james/punctuation/questions-generator/punctuation-qg-p1.md`
+- Modify: `package.json`
+- Test: `tests/punctuation-doc-static-checks.test.js`
+- Test: `tests/punctuation-content-audit.test.js`
+
+**Approach:**
+- Document the generated item identity contract, `templateId`, `variantSignature`, audit thresholds, and runtime expansion criteria.
+- State clearly that one generated item per family remains the runtime default until a later release explicitly raises it.
+- Add doc/static checks that keep the production documentation aligned with the actual generator contract and audit command.
+- Record release-id guidance: reward keys stay stable by default; content release id changes require explicit migration rationale if generated identity compatibility cannot be preserved.
+
+**Patterns to follow:**
+- P7 doc static checks in `tests/punctuation-doc-static-checks.test.js`.
+- `docs/punctuation-production.md` as the production truth source for Punctuation behaviour.
+
+**Test scenarios:**
+- Happy path: docs mention deterministic generator templates, template identity, variant signatures, audit command, and no runtime AI question generation.
+- Happy path: docs state generated template expansion does not change reward-unit denominators.
+- Edge case: stale doc text claiming the pool is only 96 items after the expansion plan lands is rejected or clearly labelled as historical baseline.
+- Error path: docs that mention increasing runtime generated count without audit criteria fail the static check.
+- Integration: content audit output and documentation refer to the same package script name.
+
+**Verification:**
+- A future implementer knows exactly what evidence is needed before turning up `generatedPerFamily`.
+- Production docs match the shipped generator contract.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** `shared/punctuation/generators.js` feeds `shared/punctuation/service.js`, `shared/punctuation/scheduler.js`, Worker command read models, and client Star/read-model projections. The plan keeps generated metadata additive so existing consumers continue to work.
+- **Error propagation:** Template validation and audit failures should fail tests/scripts with targeted messages. Runtime scheduling should degrade to existing item-id behaviour when signatures are absent.
+- **State lifecycle risks:** Existing learner progress may contain generated item ids and attempts without signatures. U2/U5 must preserve hydration and avoid reassigning old item ids to different stems/models.
+- **API surface parity:** Worker read models should not expose hidden generator internals. Client-facing metadata may include safe signatures only when needed for display/debug; otherwise signatures can remain internal to scheduling/evidence.
+- **Integration coverage:** Unit tests alone are not enough for U5 because the risk crosses generator -> scheduler -> service -> Star evidence. Integration tests must prove attempts and scheduler variety work together.
+- **Unchanged invariants:** Published reward mastery keys, Punctuation release id, 14-skill map, Star thresholds, Monster Codex routing, and Worker subject-command ownership do not change in this plan unless an explicit release migration decision is made.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Existing generated ids silently change content after template expansion | U2 compatibility fixtures pin current runtime generated ids, stems, models, and marking results before U4 expands banks. |
+| More templates create superficial variety but not learning variety | U1/U4 audit thresholds require unique signatures, readiness coverage, validators, and negative/misconception cases. |
+| Scheduler repeats same generated surface under different ids | U5 uses `variantSignature` for recentness and sibling retry logic. |
+| Oxford-comma policy creates unfair free-text marking | U3 fixes the policy up front: accept otherwise correct free-text Oxford-comma answers unless the prompt explicitly forbids the final comma, and test that distinction before list-comma templates expand. |
+| Context packs become an unsafe quasi-AI path | U6 keeps strict atom sanitisation, deterministic builders, validators, and read-model forbidden-key scans. |
+| Generated expansion inflates Stars or Mega too easily | U5 keeps signature variety as an evidence signal and does not change reward-unit denominators or Star thresholds. |
+| Audit script drifts from production manifest shape | U1/U7 tests consume actual manifest exports and package-script names rather than hard-coded fixture-only data. |
+| Plan is too large for one PR | Units are ordered for separate reviewable PRs; U1/U2/U3 are guardrails, U4/U5/U6 are feature-bearing, U7 is documentation/release evidence. |
+
+---
+
+## Documentation / Operational Notes
+
+- Keep `npm test` and `npm run check` as the pre-deployment verification baseline per repo policy.
+- In a fresh worktree, run `node scripts/worktree-setup.mjs` before tests/checks.
+- Treat `scripts/audit-punctuation-content.mjs` as a release-gate input for future generator count increases.
+- If implementation chooses to raise runtime `generatedPerFamily`, that should be a separate release note with before/after audit counts and compatibility evidence.
+- Any PR that touches generated template banks should state whether it changes generated item identity, reward denominators, or content release id.
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/plans/james/punctuation/questions-generator/punctuation-qg-p1.md](docs/plans/james/punctuation/questions-generator/punctuation-qg-p1.md)
+- Related plan/report: [docs/plans/james/punctuation/punctuation-p7-completion-report.md](docs/plans/james/punctuation/punctuation-p7-completion-report.md)
+- Related plan/report: [docs/plans/james/punctuation/punctuation-p6-completion-report.md](docs/plans/james/punctuation/punctuation-p6-completion-report.md)
+- Related code: [shared/punctuation/content.js](shared/punctuation/content.js)
+- Related code: [shared/punctuation/generators.js](shared/punctuation/generators.js)
+- Related code: [shared/punctuation/context-packs.js](shared/punctuation/context-packs.js)
+- Related code: [shared/punctuation/marking.js](shared/punctuation/marking.js)
+- Related code: [shared/punctuation/scheduler.js](shared/punctuation/scheduler.js)
+- Related tests: [tests/punctuation-generators.test.js](tests/punctuation-generators.test.js)
+- Related tests: [tests/punctuation-content.test.js](tests/punctuation-content.test.js)
+- Related tests: [tests/punctuation-scheduler.test.js](tests/punctuation-scheduler.test.js)
+- Institutional learning: [docs/solutions/architecture-patterns/punctuation-p7-stabilisation-contract-and-autonomous-sdlc-2026-04-28.md](docs/solutions/architecture-patterns/punctuation-p7-stabilisation-contract-and-autonomous-sdlc-2026-04-28.md)
+- Institutional learning: [docs/solutions/architecture-patterns/punctuation-p6-star-truth-monotonic-hardening-2026-04-27.md](docs/solutions/architecture-patterns/punctuation-p6-star-truth-monotonic-hardening-2026-04-27.md)

--- a/docs/punctuation-production.md
+++ b/docs/punctuation-production.md
@@ -84,7 +84,7 @@ Generated item guardrails:
 - The production default remains `generatedPerFamily: 1`; wider banks are exercised by tests and audits before any runtime increase.
 - Each generated item carries a stable `templateId` and opaque `variantSignature`. The scheduler uses recent signatures to avoid equivalent retries, and Star evidence uses signatures before item ids when a generated surface has an available signature.
 - Template-bank expansion appends new templates after the first two legacy templates. The first generated runtime variant is preserved when the bank grows.
-- The audit command `npm run audit:punctuation-content -- --strict --generated-per-family 4` checks generated family coverage, validator coverage, distinct signature counts, and generated model-answer marking. Add `--fail-on-duplicate-generated-signatures` only when the requested generated-per-family count is within every family's available template count.
+- The audit command `npm run audit:punctuation-content -- --strict --generated-per-family 4` checks generated family coverage, validator coverage, duplicate variant signatures, distinct signature counts, and generated model-answer marking. Duplicate stems/models remain reported for content review; add `--fail-on-duplicate-generated-content` when a review specifically wants those surfaced as hard failures.
 
 Sentence-combining practice is now ported as a Worker-owned item mode rather than a separate browser session. Smart review and focused cluster sessions include `combine` at controlled frequency, weak spots can target weak `skill::combine` facets, and unsupported clusters fall back to their available item modes instead of exposing an empty queue.
 

--- a/docs/punctuation-production.md
+++ b/docs/punctuation-production.md
@@ -77,7 +77,14 @@ Published practice modes include:
 - combine: join notes, clauses, or extra detail into one score-bearing punctuated sentence
 - paragraph: proofread a short passage where several punctuation skills can be exercised together
 
-Generated practice now runs through a deterministic compiler. Each published generator family can add extra practice items to the runtime manifest under a fixed release seed, so the Worker can broaden practice without using browser-owned random generation or changing the published reward denominator. Generated items carry `source: generated` internally, but the browser still receives only the redacted live-item read model.
+Generated practice now runs through a deterministic compiler. Each published generator family can add extra practice items to the runtime manifest under a fixed release seed, so the Worker can broaden practice without using browser-owned random generation, runtime AI, or changing the published reward denominator. Generated items carry `source: generated` internally, but the browser still receives only the redacted live-item read model.
+
+Generated item guardrails:
+
+- The production default remains `generatedPerFamily: 1`; wider banks are exercised by tests and audits before any runtime increase.
+- Each generated item carries a stable `templateId` and opaque `variantSignature`. The scheduler uses recent signatures to avoid equivalent retries, and Star evidence uses signatures before item ids when a generated surface has an available signature.
+- Template-bank expansion appends new templates after the first two legacy templates. The first generated runtime variant is preserved when the bank grows.
+- The audit command `npm run audit:punctuation-content -- --strict --generated-per-family 4` checks generated family coverage, validator coverage, distinct signature counts, and generated model-answer marking. Add `--fail-on-duplicate-generated-signatures` only when the requested generated-per-family count is within every family's available template count.
 
 Sentence-combining practice is now ported as a Worker-owned item mode rather than a separate browser session. Smart review and focused cluster sessions include `combine` at controlled frequency, weak spots can target weak `skill::combine` facets, and unsupported clusters fall back to their available item modes instead of exposing an empty queue.
 
@@ -94,7 +101,7 @@ The first Speech rubric is deliberately strict:
 
 Comma / Flow marking adds deterministic transfer validators for:
 
-- ordered KS2 list-comma patterns without an unnecessary final comma before `and`
+- ordered KS2 list-comma patterns; an otherwise-correct Oxford comma before `and` is accepted unless the item explicitly forbids the final comma
 - opening phrase commas after fronted adverbials such as `After lunch,`
 - opening phrase commas that make meaning clearer, such as `In the morning,`
 
@@ -113,7 +120,7 @@ Structure marking adds deterministic transfer validators for:
 
 Combine marking adds stricter one-sentence validators for the first legacy-shaped rewrite families:
 
-- list-comma note combination without an unnecessary final comma
+- list-comma note combination; an otherwise-correct Oxford comma before `and` is accepted unless the item explicitly forbids the final comma
 - fronted-adverbial rewrites with the opening comma
 - parenthesis rewrites with matched commas, brackets, or dashes
 - colon-list combinations after a complete opening clause

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "node ./scripts/build-bundles.mjs && node ./scripts/build-public.mjs",
     "build:bundles": "node ./scripts/build-bundles.mjs",
     "audit:client": "node ./scripts/audit-client-bundle.mjs",
+    "audit:punctuation-content": "node ./scripts/audit-punctuation-content.mjs",
     "audit:production": "node ./scripts/production-bundle-audit.mjs",
     "assert:build-public": "node ./scripts/assert-build-public.mjs",
     "assets:monsters": "node ./scripts/generate-monster-assets.mjs",

--- a/scripts/audit-punctuation-content.mjs
+++ b/scripts/audit-punctuation-content.mjs
@@ -90,6 +90,12 @@ function buildFailures({ validation, generatorFamilies, generatedDuplicates, byS
   if (thresholds?.failOnDuplicateGeneratedSignatures && generatedDuplicates.signatures.length) {
     failures.push(`Duplicate generated variant signatures: ${generatedDuplicates.signatures.length}.`);
   }
+  if (thresholds?.failOnDuplicateGeneratedStems && generatedDuplicates.stems.length) {
+    failures.push(`Duplicate generated stems: ${generatedDuplicates.stems.length}.`);
+  }
+  if (thresholds?.failOnDuplicateGeneratedModels && generatedDuplicates.models.length) {
+    failures.push(`Duplicate generated models: ${generatedDuplicates.models.length}.`);
+  }
   const minGeneratedSignatures = thresholdValue(thresholds, 'minGeneratedSignaturesPerPublishedSkill', 0);
   const minValidatorCoverage = thresholdValue(thresholds, 'minValidatorCoveragePerPublishedSkill', 0);
   for (const row of bySkill) {
@@ -231,7 +237,9 @@ function parseArgs(argv) {
   return {
     json: args.has('--json'),
     strict: args.has('--strict'),
-    failOnDuplicateGeneratedSignatures: args.has('--fail-on-duplicate-generated-signatures'),
+    failOnDuplicateGeneratedSignatures: args.has('--fail-on-duplicate-generated-signatures')
+      || args.has('--fail-on-duplicate-generated-content'),
+    failOnDuplicateGeneratedContent: args.has('--fail-on-duplicate-generated-content'),
     generatedPerFamily: Number(valueAfter('--generated-per-family', 1)) || 1,
   };
 }
@@ -242,12 +250,16 @@ async function main() {
     generatedPerFamily: args.generatedPerFamily,
     thresholds: args.strict
       ? {
-          failOnDuplicateGeneratedSignatures: args.failOnDuplicateGeneratedSignatures,
+          failOnDuplicateGeneratedSignatures: true,
+          failOnDuplicateGeneratedStems: args.failOnDuplicateGeneratedContent,
+          failOnDuplicateGeneratedModels: args.failOnDuplicateGeneratedContent,
           minGeneratedSignaturesPerPublishedSkill: 1,
           minValidatorCoveragePerPublishedSkill: 1,
         }
       : {
           failOnDuplicateGeneratedSignatures: args.failOnDuplicateGeneratedSignatures,
+          failOnDuplicateGeneratedStems: args.failOnDuplicateGeneratedContent,
+          failOnDuplicateGeneratedModels: args.failOnDuplicateGeneratedContent,
         },
   });
   process.stdout.write(args.json

--- a/scripts/audit-punctuation-content.mjs
+++ b/scripts/audit-punctuation-content.mjs
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from 'node:url';
+
+import {
+  createPunctuationContentIndexes,
+  PUNCTUATION_CONTENT_MANIFEST,
+  validatePunctuationManifest,
+} from '../shared/punctuation/content.js';
+import {
+  createPunctuationGeneratedItems,
+  createPunctuationRuntimeManifest,
+} from '../shared/punctuation/generators.js';
+import { markPunctuationAnswer } from '../shared/punctuation/marking.js';
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normaliseAuditText(value) {
+  return String(value ?? '')
+    .replace(/\u00a0/g, ' ')
+    .replace(/[“”]/g, '"')
+    .replace(/[‘’]/g, "'")
+    .replace(/[–—]/g, '-')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+function groupDuplicates(rows, keyFn) {
+  const groups = new Map();
+  for (const row of rows) {
+    const key = keyFn(row);
+    if (!key) continue;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(row.id);
+  }
+  return [...groups.entries()]
+    .filter(([, ids]) => ids.length > 1)
+    .map(([key, ids]) => ({ key, ids: ids.sort() }))
+    .sort((a, b) => a.key.localeCompare(b.key));
+}
+
+function hasValidatorCoverage(item) {
+  if (item.mode === 'choose') return true;
+  return isPlainObject(item.validator) || isPlainObject(item.rubric);
+}
+
+function readinessRowsFor(items) {
+  const rows = new Set();
+  for (const item of items) {
+    for (const row of Array.isArray(item.readiness) ? item.readiness : []) rows.add(row);
+    if (Array.isArray(item.misconceptionTags) && item.misconceptionTags.length) rows.add('misconception');
+  }
+  return [...rows].sort();
+}
+
+function generatedModelFailures(generatedItems) {
+  const failures = [];
+  for (const item of generatedItems) {
+    const result = markPunctuationAnswer({ item, answer: { typed: item.model } });
+    if (!result.correct) {
+      failures.push({
+        id: item.id,
+        familyId: item.generatorFamilyId || '',
+        templateId: item.templateId || '',
+        variantSignature: item.variantSignature || '',
+        misconceptionTags: result.misconceptionTags || [],
+      });
+    }
+  }
+  return failures;
+}
+
+function thresholdValue(thresholds, key, fallback = 0) {
+  const value = Number(thresholds?.[key]);
+  return Number.isFinite(value) ? value : fallback;
+}
+
+function buildFailures({ validation, generatorFamilies, generatedDuplicates, bySkill, generatedFailures, thresholds }) {
+  const failures = [...validation.errors];
+  if (thresholds?.requireTemplatesForPublishedFamilies !== false) {
+    for (const family of generatorFamilies) {
+      if (family.published && family.generatedItemCount === 0) {
+        failures.push(`Published generator family ${family.id} produced no generated items.`);
+      }
+    }
+  }
+  if (thresholds?.failOnDuplicateGeneratedSignatures && generatedDuplicates.signatures.length) {
+    failures.push(`Duplicate generated variant signatures: ${generatedDuplicates.signatures.length}.`);
+  }
+  const minGeneratedSignatures = thresholdValue(thresholds, 'minGeneratedSignaturesPerPublishedSkill', 0);
+  const minValidatorCoverage = thresholdValue(thresholds, 'minValidatorCoveragePerPublishedSkill', 0);
+  for (const row of bySkill) {
+    if (!row.published) continue;
+    if (row.generatedSignatureCount < minGeneratedSignatures) {
+      failures.push(`Published skill ${row.skillId} has ${row.generatedSignatureCount} generated signatures; expected at least ${minGeneratedSignatures}.`);
+    }
+    if (row.validatorCoverageCount < minValidatorCoverage) {
+      failures.push(`Published skill ${row.skillId} has ${row.validatorCoverageCount} validator-covered runtime items; expected at least ${minValidatorCoverage}.`);
+    }
+  }
+  for (const failure of generatedFailures) {
+    failures.push(`Generated model answer does not pass marking: ${failure.id} (${failure.familyId}/${failure.templateId}).`);
+  }
+  return failures;
+}
+
+export function runPunctuationContentAudit({
+  manifest = PUNCTUATION_CONTENT_MANIFEST,
+  seed = manifest.releaseId || 'punctuation-audit',
+  generatedPerFamily = 1,
+  thresholds = {},
+} = {}) {
+  const validation = validatePunctuationManifest(manifest);
+  const fixedIndexes = createPunctuationContentIndexes(manifest);
+  const generatedItems = createPunctuationGeneratedItems({ manifest, seed, perFamily: generatedPerFamily });
+  const runtimeManifest = createPunctuationRuntimeManifest({ manifest, seed, generatedPerFamily });
+  const runtimeIndexes = createPunctuationContentIndexes(runtimeManifest);
+  const fixedItems = fixedIndexes.items;
+  const runtimeItems = runtimeIndexes.items;
+  const generatedByFamily = new Map();
+  for (const item of generatedItems) {
+    const familyId = item.generatorFamilyId || '';
+    if (!generatedByFamily.has(familyId)) generatedByFamily.set(familyId, []);
+    generatedByFamily.get(familyId).push(item);
+  }
+
+  const bySkill = fixedIndexes.skills.map((skill) => {
+    const fixedSkillItems = fixedItems.filter((item) => item.skillIds?.includes(skill.id));
+    const runtimeSkillItems = runtimeItems.filter((item) => item.skillIds?.includes(skill.id));
+    const generatedSkillItems = generatedItems.filter((item) => item.skillIds?.includes(skill.id));
+    return {
+      skillId: skill.id,
+      published: skill.published === true,
+      fixedItemCount: fixedSkillItems.length,
+      runtimeItemCount: runtimeSkillItems.length,
+      generatedItemCount: generatedSkillItems.length,
+      generatedFamilyCount: fixedIndexes.generatorFamilies.filter((family) => family.published && family.skillId === skill.id).length,
+      generatedSignatureCount: new Set(generatedSkillItems.map((item) => item.variantSignature).filter(Boolean)).size,
+      modeCoverage: [...new Set(runtimeSkillItems.map((item) => item.mode).filter(Boolean))].sort(),
+      readinessCoverage: readinessRowsFor(runtimeSkillItems),
+      validatorCoverageCount: runtimeSkillItems.filter(hasValidatorCoverage).length,
+    };
+  });
+
+  const generatorFamilies = fixedIndexes.generatorFamilies.map((family) => {
+    const rows = generatedByFamily.get(family.id) || [];
+    return {
+      id: family.id,
+      skillId: family.skillId,
+      rewardUnitId: family.rewardUnitId,
+      mode: family.mode,
+      published: family.published === true,
+      generatedItemCount: rows.length,
+      templateIds: [...new Set(rows.map((item) => item.templateId).filter(Boolean))].sort(),
+      variantSignatures: [...new Set(rows.map((item) => item.variantSignature).filter(Boolean))].sort(),
+    };
+  });
+
+  const fixedDuplicates = {
+    stems: groupDuplicates(fixedItems, (item) => normaliseAuditText(item.stem)),
+    models: groupDuplicates(fixedItems, (item) => normaliseAuditText(item.model)),
+  };
+  const generatedDuplicates = {
+    stems: groupDuplicates(generatedItems, (item) => normaliseAuditText(item.stem)),
+    models: groupDuplicates(generatedItems, (item) => normaliseAuditText(item.model)),
+    signatures: groupDuplicates(generatedItems, (item) => item.variantSignature || ''),
+  };
+  const generatedFailures = generatedModelFailures(generatedItems);
+  const failures = buildFailures({
+    validation,
+    generatorFamilies,
+    generatedDuplicates,
+    bySkill,
+    generatedFailures,
+    thresholds,
+  });
+
+  return {
+    ok: failures.length === 0,
+    failures,
+    seed,
+    generatedPerFamily,
+    summary: {
+      fixedItemCount: fixedItems.length,
+      generatorFamilyCount: fixedIndexes.generatorFamilies.length,
+      generatedItemCount: generatedItems.length,
+      runtimeItemCount: runtimeItems.length,
+      publishedRewardUnitCount: fixedIndexes.publishedRewardUnits.length,
+      publishedSkillCount: fixedIndexes.publishedSkillIds.length,
+    },
+    bySkill,
+    generatorFamilies,
+    duplicates: {
+      fixed: fixedDuplicates,
+      generated: generatedDuplicates,
+    },
+    generatedModelFailures: generatedFailures,
+  };
+}
+
+export function formatPunctuationContentAudit(audit) {
+  const lines = [
+    'Punctuation content audit',
+    `fixed items: ${audit.summary.fixedItemCount}`,
+    `generator families: ${audit.summary.generatorFamilyCount}`,
+    `generated items: ${audit.summary.generatedItemCount}`,
+    `runtime items: ${audit.summary.runtimeItemCount}`,
+    `published reward units: ${audit.summary.publishedRewardUnitCount}`,
+    '',
+    'Per-skill coverage:',
+  ];
+  for (const row of audit.bySkill) {
+    lines.push(`- ${row.skillId}: fixed=${row.fixedItemCount}, generated=${row.generatedItemCount}, signatures=${row.generatedSignatureCount}, modes=${row.modeCoverage.join('|') || 'none'}, readiness=${row.readinessCoverage.join('|') || 'none'}, validators=${row.validatorCoverageCount}`);
+  }
+  if (audit.failures.length) {
+    lines.push('', 'Failures:');
+    for (const failure of audit.failures) lines.push(`- ${failure}`);
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+function parseArgs(argv) {
+  const args = new Set(argv);
+  const valueAfter = (name, fallback) => {
+    const index = argv.indexOf(name);
+    return index >= 0 && index + 1 < argv.length ? argv[index + 1] : fallback;
+  };
+  return {
+    json: args.has('--json'),
+    strict: args.has('--strict'),
+    failOnDuplicateGeneratedSignatures: args.has('--fail-on-duplicate-generated-signatures'),
+    generatedPerFamily: Number(valueAfter('--generated-per-family', 1)) || 1,
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const audit = runPunctuationContentAudit({
+    generatedPerFamily: args.generatedPerFamily,
+    thresholds: args.strict
+      ? {
+          failOnDuplicateGeneratedSignatures: args.failOnDuplicateGeneratedSignatures,
+          minGeneratedSignaturesPerPublishedSkill: 1,
+          minValidatorCoveragePerPublishedSkill: 1,
+        }
+      : {
+          failOnDuplicateGeneratedSignatures: args.failOnDuplicateGeneratedSignatures,
+        },
+  });
+  process.stdout.write(args.json
+    ? `${JSON.stringify(audit, null, 2)}\n`
+    : formatPunctuationContentAudit(audit));
+  if (!audit.ok) process.exitCode = 1;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/shared/punctuation/context-packs.js
+++ b/shared/punctuation/context-packs.js
@@ -198,6 +198,14 @@ function mainClause(pack, fallback = 'the crew checked the ropes') {
   return first(pack.acceptedAtoms.stems, fallback).toLowerCase();
 }
 
+function clausePair(pack, fallbackLeft = 'the crew checked the ropes', fallbackRight = 'we found another path') {
+  const stems = Array.isArray(pack.acceptedAtoms.stems) ? pack.acceptedAtoms.stems : [];
+  const left = (stems[0] || fallbackLeft).toLowerCase();
+  const rightCandidate = (stems[1] || '').toLowerCase();
+  const right = rightCandidate && rightCandidate !== left ? rightCandidate : fallbackRight;
+  return { left, right };
+}
+
 function placeSubject(pack, fallback = 'harbour') {
   const place = first(pack.acceptedAtoms.places, fallback);
   return `The ${place}`;
@@ -269,6 +277,60 @@ function frontedCombineTemplate(pack) {
       mainClause: clause,
     },
     misconceptionTags: ['comma.fronted_adverbial_missing'],
+    readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+  };
+}
+
+function commaClarityTemplate(pack) {
+  const phrase = first(pack.acceptedAtoms.frontedAdverbialPhrases, null);
+  if (!phrase) return null;
+  const clause = clausePair(pack, 'the harbour was quiet', 'the harbour was quiet').right;
+  return {
+    prompt: 'Add the comma that makes the meaning clear.',
+    stem: `${capitaliseSentence(phrase)} ${clause}.`,
+    model: `${capitaliseSentence(phrase)}, ${clause}.`,
+    validator: {
+      type: 'startsWithPhraseComma',
+      phrase: capitaliseSentence(phrase),
+    },
+    misconceptionTags: ['comma.clarity_missing'],
+    readiness: ['insertion', 'misconception', 'negative_test'],
+  };
+}
+
+function boundaryFixTemplate(pack, mark, prompt, misconceptionTag) {
+  const { left, right } = clausePair(pack);
+  const unpunctuatedJoin = mark === ';' ? ', ' : ' ';
+  const modelJoin = mark === ';' ? '; ' : ` ${mark} `;
+  return {
+    prompt,
+    stem: `${capitaliseSentence(left)}${unpunctuatedJoin}${right}.`,
+    model: `${capitaliseSentence(left)}${modelJoin}${right}.`,
+    validator: {
+      type: 'requiresBoundaryBetweenClauses',
+      left: capitaliseSentence(left),
+      right,
+      mark,
+    },
+    misconceptionTags: [misconceptionTag],
+    readiness: ['proofreading', 'misconception', 'negative_test'],
+  };
+}
+
+function boundaryCombineTemplate(pack, mark, prompt, misconceptionTag) {
+  const { left, right } = clausePair(pack);
+  const modelJoin = mark === ';' ? '; ' : ` ${mark} `;
+  return {
+    prompt,
+    stem: `${capitaliseSentence(left)}.\n${capitaliseSentence(right)}.`,
+    model: `${capitaliseSentence(left)}${modelJoin}${right}.`,
+    validator: {
+      type: 'combineBoundaryBetweenClauses',
+      left: capitaliseSentence(left),
+      right,
+      mark,
+    },
+    misconceptionTags: [misconceptionTag],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   };
 }
@@ -378,6 +440,31 @@ export function contextPackTemplatesForFamily(familyId, contextPack = {}) {
     gen_list_commas_combine: listCombineTemplate,
     gen_fronted_adverbial_fix: frontedFixTemplate,
     gen_fronted_adverbial_combine: frontedCombineTemplate,
+    gen_comma_clarity_insert: commaClarityTemplate,
+    gen_semicolon_fix: (normalisedPack) => boundaryFixTemplate(
+      normalisedPack,
+      ';',
+      'Replace the comma splice with a semi-colon.',
+      'boundary.semicolon_missing',
+    ),
+    gen_semicolon_combine: (normalisedPack) => boundaryCombineTemplate(
+      normalisedPack,
+      ';',
+      'Combine the two related clauses into one sentence with a semi-colon.',
+      'boundary.semicolon_missing',
+    ),
+    gen_dash_clause_fix: (normalisedPack) => boundaryFixTemplate(
+      normalisedPack,
+      '-',
+      'Add a dash between the related clauses.',
+      'boundary.dash_missing',
+    ),
+    gen_dash_clause_combine: (normalisedPack) => boundaryCombineTemplate(
+      normalisedPack,
+      '-',
+      'Combine the two related clauses into one sentence with a dash.',
+      'boundary.dash_missing',
+    ),
     gen_parenthesis_combine: parenthesisCombineTemplate,
     gen_hyphen_insert: hyphenTemplate,
   }[familyId]?.(pack);
@@ -393,6 +480,11 @@ export function affectedGeneratorFamiliesForContextPack(contextPack = {}) {
     'gen_list_commas_combine',
     'gen_fronted_adverbial_fix',
     'gen_fronted_adverbial_combine',
+    'gen_comma_clarity_insert',
+    'gen_semicolon_fix',
+    'gen_semicolon_combine',
+    'gen_dash_clause_fix',
+    'gen_dash_clause_combine',
     'gen_parenthesis_combine',
     'gen_hyphen_insert',
   ].filter((familyId) => contextPackTemplatesForFamily(familyId, pack).length > 0);

--- a/shared/punctuation/events.js
+++ b/shared/punctuation/events.js
@@ -60,6 +60,7 @@ export function createPunctuationItemAttemptedEvent({
       [learnerId || 'default', session?.id || 'session', item.id, Number(session?.answeredCount) || 0],
     ),
     itemId: item.id,
+    variantSignature: item.variantSignature || '',
     mode: item.mode,
     skillIds: Array.isArray(item.skillIds) ? [...item.skillIds] : [],
     clusterId: item.clusterId || null,

--- a/shared/punctuation/generators.js
+++ b/shared/punctuation/generators.js
@@ -23,10 +23,63 @@ function shortHash(value) {
   return hashString(value).toString(36).padStart(6, '0').slice(0, 8);
 }
 
-function pickTemplate(templates, seed, familyId, variantIndex) {
+function normaliseSignatureText(value) {
+  return String(value ?? '')
+    .replace(/\u00a0/g, ' ')
+    .replace(/[“”]/g, '"')
+    .replace(/[‘’]/g, "'")
+    .replace(/[–—]/g, '-')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+function stableJson(value) {
+  if (Array.isArray(value)) return value.map(stableJson);
+  if (!isPlainObject(value)) return value;
+  return Object.fromEntries(Object.keys(value)
+    .sort()
+    .map((key) => [key, stableJson(value[key])]));
+}
+
+function templateIdFor(familyId, template, templateIndex = 0) {
+  const explicit = typeof template?.templateId === 'string' ? template.templateId.trim() : '';
+  return explicit || `${familyId}_template_${templateIndex + 1}`;
+}
+
+function variantSignatureFor({ family, template, templateId, model }) {
+  const signaturePayload = {
+    familyId: family.id,
+    mode: family.mode,
+    templateId,
+    prompt: normaliseSignatureText(template.prompt || ''),
+    stem: normaliseSignatureText(template.stem || ''),
+    model: normaliseSignatureText(model || ''),
+    skillIds: uniqueStrings(template.skillIds).sort(),
+    clusterId: template.clusterId || '',
+    validatorType: isPlainObject(template.validator) ? template.validator.type || '' : '',
+    rubricType: isPlainObject(template.rubric) ? template.rubric.type || '' : '',
+  };
+  return `puncsig_${shortHash(JSON.stringify(stableJson(signaturePayload)))}`;
+}
+
+function pickTemplate(templates, seed, familyId, variantIndex, { legacyTemplateCount = 2 } = {}) {
   if (!templates.length) return null;
-  const offset = hashString(`${seed}:${familyId}`) % templates.length;
-  return templates[(offset + variantIndex) % templates.length];
+  const legacyCount = Math.max(0, Math.min(Number(legacyTemplateCount) || 0, templates.length));
+  const expandedPool = templates.slice(legacyCount);
+  const pool = variantIndex < legacyCount || !expandedPool.length
+    ? templates.slice(0, legacyCount || templates.length)
+    : expandedPool;
+  const offset = hashString(`${seed}:${familyId}`) % pool.length;
+  const poolVariantIndex = variantIndex < legacyCount || !expandedPool.length
+    ? variantIndex
+    : variantIndex - legacyCount;
+  const poolIndex = (offset + poolVariantIndex) % pool.length;
+  const template = pool[poolIndex];
+  return {
+    template,
+    templateIndex: Math.max(0, templates.indexOf(template)),
+  };
 }
 
 function uniqueStrings(values = []) {
@@ -49,6 +102,20 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
       misconceptionTags: ['endmarks.exclamation_mark_missing', 'endmarks.capitalisation_missing'],
       readiness: ['insertion', 'misconception', 'negative_test'],
     },
+    {
+      prompt: 'Add the capital letter and end punctuation.',
+      stem: 'did the crew check the lanterns',
+      model: 'Did the crew check the lanterns?',
+      misconceptionTags: ['endmarks.question_mark_missing', 'endmarks.capitalisation_missing'],
+      readiness: ['insertion', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Add the capital letter and end punctuation.',
+      stem: 'how quickly the fog cleared',
+      model: 'How quickly the fog cleared!',
+      misconceptionTags: ['endmarks.exclamation_mark_missing', 'endmarks.capitalisation_missing'],
+      readiness: ['insertion', 'misconception', 'negative_test'],
+    },
   ]),
   gen_apostrophe_contractions_fix: Object.freeze([
     {
@@ -62,6 +129,20 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
       prompt: 'Correct the apostrophes in the contractions.',
       stem: 'Theyre sure we wont be late.',
       model: "They're sure we won't be late.",
+      misconceptionTags: ['apostrophe.contraction_missing'],
+      readiness: ['proofreading', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Correct the apostrophes in the contractions.',
+      stem: 'I dont think theyve finished.',
+      model: "I don't think they've finished.",
+      misconceptionTags: ['apostrophe.contraction_missing'],
+      readiness: ['proofreading', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Correct the apostrophes in the contractions.',
+      stem: 'Youre sure he isnt coming.',
+      model: "You're sure he isn't coming.",
       misconceptionTags: ['apostrophe.contraction_missing'],
       readiness: ['proofreading', 'misconception', 'negative_test'],
     },
@@ -335,6 +416,28 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
       misconceptionTags: ['comma.clarity_missing'],
       readiness: ['insertion', 'misconception', 'negative_test'],
     },
+    {
+      prompt: 'Add the comma that makes the meaning clear.',
+      stem: 'Without a map the walkers lost time.',
+      model: 'Without a map, the walkers lost time.',
+      validator: {
+        type: 'startsWithPhraseComma',
+        phrase: 'Without a map',
+      },
+      misconceptionTags: ['comma.clarity_missing'],
+      readiness: ['insertion', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Add the comma that makes the meaning clear.',
+      stem: 'As the whistle blew the teams lined up.',
+      model: 'As the whistle blew, the teams lined up.',
+      validator: {
+        type: 'startsWithPhraseComma',
+        phrase: 'As the whistle blew',
+      },
+      misconceptionTags: ['comma.clarity_missing'],
+      readiness: ['insertion', 'misconception', 'negative_test'],
+    },
   ]),
   gen_semicolon_fix: Object.freeze([
     {
@@ -477,6 +580,32 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
       misconceptionTags: ['boundary.dash_missing'],
       readiness: ['proofreading', 'misconception', 'negative_test'],
     },
+    {
+      prompt: 'Add a dash between the related clauses.',
+      stem: 'The torch failed we used the lantern.',
+      model: 'The torch failed - we used the lantern.',
+      validator: {
+        type: 'requiresBoundaryBetweenClauses',
+        left: 'The torch failed',
+        right: 'we used the lantern',
+        mark: '-',
+      },
+      misconceptionTags: ['boundary.dash_missing'],
+      readiness: ['proofreading', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Add a dash between the related clauses.',
+      stem: 'The bridge was closed the buses turned back.',
+      model: 'The bridge was closed - the buses turned back.',
+      validator: {
+        type: 'requiresBoundaryBetweenClauses',
+        left: 'The bridge was closed',
+        right: 'the buses turned back',
+        mark: '-',
+      },
+      misconceptionTags: ['boundary.dash_missing'],
+      readiness: ['proofreading', 'misconception', 'negative_test'],
+    },
   ]),
   gen_dash_clause_combine: Object.freeze([
     {
@@ -505,6 +634,32 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
       misconceptionTags: ['boundary.dash_missing'],
       readiness: ['constrained_transfer', 'misconception', 'negative_test'],
     },
+    {
+      prompt: 'Combine the two related clauses into one sentence with a dash.',
+      stem: 'The torch failed.\nWe used the lantern.',
+      model: 'The torch failed - we used the lantern.',
+      validator: {
+        type: 'combineBoundaryBetweenClauses',
+        left: 'The torch failed',
+        right: 'we used the lantern',
+        mark: '-',
+      },
+      misconceptionTags: ['boundary.dash_missing'],
+      readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Combine the two related clauses into one sentence with a dash.',
+      stem: 'The bridge was closed.\nThe buses turned back.',
+      model: 'The bridge was closed - the buses turned back.',
+      validator: {
+        type: 'combineBoundaryBetweenClauses',
+        left: 'The bridge was closed',
+        right: 'the buses turned back',
+        mark: '-',
+      },
+      misconceptionTags: ['boundary.dash_missing'],
+      readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    },
   ]),
   gen_hyphen_insert: Object.freeze([
     {
@@ -525,6 +680,28 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
       validator: {
         type: 'requiresHyphenatedPhrase',
         phrase: 'fast-moving tide',
+      },
+      misconceptionTags: ['boundary.hyphen_missing'],
+      readiness: ['insertion', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Add the hyphen that avoids ambiguity.',
+      stem: 'The well known guide led us.',
+      model: 'The well-known guide led us.',
+      validator: {
+        type: 'requiresHyphenatedPhrase',
+        phrase: 'well-known guide',
+      },
+      misconceptionTags: ['boundary.hyphen_missing'],
+      readiness: ['insertion', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Add the hyphen that avoids ambiguity.',
+      stem: 'The cold blooded reptile rested.',
+      model: 'The cold-blooded reptile rested.',
+      validator: {
+        type: 'requiresHyphenatedPhrase',
+        phrase: 'cold-blooded reptile',
       },
       misconceptionTags: ['boundary.hyphen_missing'],
       readiness: ['insertion', 'misconception', 'negative_test'],
@@ -717,6 +894,28 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
       misconceptionTags: ['structure.semicolon_list_missing'],
       readiness: ['proofreading', 'misconception', 'negative_test'],
     },
+    {
+      prompt: 'Use semi-colons to separate the complex list items.',
+      stem: 'The stalls sold apples, Kent, pears, Devon and berries, Wales.',
+      model: 'The stalls sold apples, Kent; pears, Devon; and berries, Wales.',
+      validator: {
+        type: 'requiresSemicolonList',
+        items: ['apples, Kent', 'pears, Devon', 'berries, Wales'],
+      },
+      misconceptionTags: ['structure.semicolon_list_missing'],
+      readiness: ['proofreading', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Use semi-colons to separate the complex list items.',
+      stem: 'The clubs met in Leeds, Monday, York, Tuesday and Bath, Friday.',
+      model: 'The clubs met in Leeds, Monday; York, Tuesday; and Bath, Friday.',
+      validator: {
+        type: 'requiresSemicolonList',
+        items: ['Leeds, Monday', 'York, Tuesday', 'Bath, Friday'],
+      },
+      misconceptionTags: ['structure.semicolon_list_missing'],
+      readiness: ['proofreading', 'misconception', 'negative_test'],
+    },
   ]),
   gen_bullet_points_fix: Object.freeze([
     {
@@ -794,14 +993,17 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
   ]),
 });
 
-function buildGeneratedItem({ family, skill, template, seed, variantIndex }) {
+function buildGeneratedItem({ family, skill, template, templateIndex, seed, variantIndex }) {
   const idSeed = `${seed}:${family.id}:${variantIndex}`;
   const model = typeof template.model === 'string' ? template.model : '';
   const templateSkillIds = uniqueStrings(template.skillIds);
   const skillIds = templateSkillIds.length ? templateSkillIds : [family.skillId];
+  const templateId = templateIdFor(family.id, template, templateIndex);
   return {
     id: `${family.id}_${shortHash(idSeed)}_${variantIndex + 1}`,
     mode: family.mode,
+    templateId,
+    variantSignature: variantSignatureFor({ family, template, templateId, model }),
     skillIds,
     clusterId: template.clusterId || skill.clusterId,
     rewardUnitId: family.rewardUnitId,
@@ -838,8 +1040,18 @@ export function createPunctuationGeneratedItems({
     const templates = contextTemplates.length ? contextTemplates : (GENERATED_TEMPLATE_BANK[family.id] || []);
     if (!skill || !templates.length) continue;
     for (let index = 0; index < limit; index += 1) {
-      const template = pickTemplate(templates, seed, family.id, index);
-      items.push(buildGeneratedItem({ family, skill, template, seed, variantIndex: index }));
+      const picked = pickTemplate(templates, seed, family.id, index, {
+        legacyTemplateCount: contextTemplates.length ? templates.length : 2,
+      });
+      if (!picked?.template) continue;
+      items.push(buildGeneratedItem({
+        family,
+        skill,
+        template: picked.template,
+        templateIndex: picked.templateIndex,
+        seed,
+        variantIndex: index,
+      }));
     }
   }
   return items;

--- a/shared/punctuation/generators.js
+++ b/shared/punctuation/generators.js
@@ -42,9 +42,22 @@ function stableJson(value) {
     .map((key) => [key, stableJson(value[key])]));
 }
 
-function templateIdFor(familyId, template, templateIndex = 0) {
+function templateIdFor(familyId, template) {
   const explicit = typeof template?.templateId === 'string' ? template.templateId.trim() : '';
-  return explicit || `${familyId}_template_${templateIndex + 1}`;
+  if (explicit) return explicit;
+  const payload = {
+    prompt: normaliseSignatureText(template.prompt || ''),
+    stem: normaliseSignatureText(template.stem || ''),
+    model: normaliseSignatureText(template.model || ''),
+    accepted: Array.isArray(template.accepted)
+      ? template.accepted.map(normaliseSignatureText).sort()
+      : [],
+    skillIds: uniqueStrings(template.skillIds).sort(),
+    clusterId: template.clusterId || '',
+    validator: stableJson(template.validator || {}),
+    rubric: stableJson(template.rubric || {}),
+  };
+  return `${familyId}_template_${shortHash(JSON.stringify(stableJson(payload)))}`;
 }
 
 function variantSignatureFor({ family, template, templateId, model }) {

--- a/shared/punctuation/generators.js
+++ b/shared/punctuation/generators.js
@@ -183,6 +183,28 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
       misconceptionTags: ['apostrophe.possession_missing'],
       readiness: ['insertion', 'misconception', 'negative_test'],
     },
+    {
+      prompt: 'Add apostrophes to show possession.',
+      stem: 'The artists brush was near the museums door.',
+      model: "The artist's brush was near the museum's door.",
+      validator: {
+        type: 'requiresTokens',
+        tokens: ["artist's", "museum's"],
+      },
+      misconceptionTags: ['apostrophe.possession_missing'],
+      readiness: ['insertion', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Add apostrophes to show possession.',
+      stem: 'The sailors flag was near the harbours gate.',
+      model: "The sailor's flag was near the harbour's gate.",
+      validator: {
+        type: 'requiresTokens',
+        tokens: ["sailor's", "harbour's"],
+      },
+      misconceptionTags: ['apostrophe.possession_missing'],
+      readiness: ['insertion', 'misconception', 'negative_test'],
+    },
   ]),
   gen_apostrophe_mix_paragraph: Object.freeze([
     {
@@ -225,6 +247,46 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
       misconceptionTags: ['apostrophe.contraction_missing', 'apostrophe.possession_missing', 'apostrophe.possession_number'],
       readiness: ['constrained_transfer', 'misconception', 'negative_test'],
     },
+    {
+      prompt: 'Repair the apostrophes in the short passage.',
+      stem: 'Theyre checking the captains map. We dont know the teams plan.',
+      model: "They're checking the captain's map. We don't know the team's plan.",
+      skillIds: ['apostrophe_contractions', 'apostrophe_possession'],
+      clusterId: 'apostrophe',
+      validator: {
+        type: 'paragraphRepair',
+        checks: [
+          {
+            type: 'requiresApostropheForms',
+            tokens: ["they're", "captain's", "don't", "team's"],
+            forbidden: ['theyre', 'captains', 'dont', 'teams plan'],
+            misconceptionTags: ['apostrophe.contraction_missing', 'apostrophe.possession_missing'],
+          },
+        ],
+      },
+      misconceptionTags: ['apostrophe.contraction_missing', 'apostrophe.possession_missing'],
+      readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Repair the apostrophes in the short passage.',
+      stem: 'She wont borrow the girls pencil. Its on the teachers shelf.',
+      model: "She won't borrow the girl's pencil. It's on the teacher's shelf.",
+      skillIds: ['apostrophe_contractions', 'apostrophe_possession'],
+      clusterId: 'apostrophe',
+      validator: {
+        type: 'paragraphRepair',
+        checks: [
+          {
+            type: 'requiresApostropheForms',
+            tokens: ["won't", "girl's", "it's", "teacher's"],
+            forbidden: ['wont', 'girls pencil', 'its', 'teachers shelf'],
+            misconceptionTags: ['apostrophe.contraction_missing', 'apostrophe.possession_missing'],
+          },
+        ],
+      },
+      misconceptionTags: ['apostrophe.contraction_missing', 'apostrophe.possession_missing'],
+      readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    },
   ]),
   gen_speech_insert: Object.freeze([
     {
@@ -253,6 +315,32 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
       misconceptionTags: ['speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
       readiness: ['insertion', 'misconception', 'negative_test'],
     },
+    {
+      prompt: 'Add the direct-speech punctuation.',
+      stem: 'Lena whispered, keep the gate closed.',
+      model: 'Lena whispered, "Keep the gate closed."',
+      rubric: {
+        type: 'speech',
+        reportingPosition: 'before',
+        spokenWords: 'keep the gate closed',
+        requiredTerminal: '.',
+      },
+      misconceptionTags: ['speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
+      readiness: ['insertion', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Add the direct-speech punctuation.',
+      stem: 'Tom asked, where did the map go?',
+      model: 'Tom asked, "Where did the map go?"',
+      rubric: {
+        type: 'speech',
+        reportingPosition: 'before',
+        spokenWords: 'where did the map go',
+        requiredTerminal: '?',
+      },
+      misconceptionTags: ['speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
+      readiness: ['insertion', 'misconception', 'negative_test'],
+    },
   ]),
   gen_list_commas_insert: Object.freeze([
     {
@@ -273,6 +361,28 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
       validator: {
         type: 'requiresListCommas',
         items: ['shells', 'bells', 'chalk'],
+      },
+      misconceptionTags: ['comma.list_separator_missing', 'comma.unnecessary_final_comma'],
+      readiness: ['insertion', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Add commas to separate the list items.',
+      stem: 'The shelf held paints brushes and paper.',
+      model: 'The shelf held paints, brushes and paper.',
+      validator: {
+        type: 'requiresListCommas',
+        items: ['paints', 'brushes', 'paper'],
+      },
+      misconceptionTags: ['comma.list_separator_missing', 'comma.unnecessary_final_comma'],
+      readiness: ['insertion', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Add commas to separate the list items.',
+      stem: 'We saw gulls seals and dolphins.',
+      model: 'We saw gulls, seals and dolphins.',
+      validator: {
+        type: 'requiresListCommas',
+        items: ['gulls', 'seals', 'dolphins'],
       },
       misconceptionTags: ['comma.list_separator_missing', 'comma.unnecessary_final_comma'],
       readiness: ['insertion', 'misconception', 'negative_test'],
@@ -303,6 +413,30 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
       misconceptionTags: ['comma.list_separator_missing', 'comma.unnecessary_final_comma'],
       readiness: ['constrained_transfer', 'misconception', 'negative_test'],
     },
+    {
+      prompt: 'Combine the notes into one correctly punctuated sentence.',
+      stem: 'The bag contained\n- chalk\n- string\n- tape',
+      model: 'The bag contained chalk, string and tape.',
+      validator: {
+        type: 'combineListSentence',
+        opening: 'The bag contained',
+        items: ['chalk', 'string', 'tape'],
+      },
+      misconceptionTags: ['comma.list_separator_missing', 'comma.unnecessary_final_comma'],
+      readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Combine the notes into one correctly punctuated sentence.',
+      stem: 'Our lunch included\n- apples\n- sandwiches\n- juice',
+      model: 'Our lunch included apples, sandwiches and juice.',
+      validator: {
+        type: 'combineListSentence',
+        opening: 'Our lunch included',
+        items: ['apples', 'sandwiches', 'juice'],
+      },
+      misconceptionTags: ['comma.list_separator_missing', 'comma.unnecessary_final_comma'],
+      readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    },
   ]),
   gen_fronted_adverbial_fix: Object.freeze([
     {
@@ -323,6 +457,28 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
       validator: {
         type: 'startsWithPhraseComma',
         phrase: 'Before sunrise',
+      },
+      misconceptionTags: ['comma.fronted_adverbial_missing'],
+      readiness: ['proofreading', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Correct the comma after the fronted adverbial.',
+      stem: 'During the concert the hall became silent.',
+      model: 'During the concert, the hall became silent.',
+      validator: {
+        type: 'startsWithPhraseComma',
+        phrase: 'During the concert',
+      },
+      misconceptionTags: ['comma.fronted_adverbial_missing'],
+      readiness: ['proofreading', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Correct the comma after the fronted adverbial.',
+      stem: 'At the edge of the field the coach waited.',
+      model: 'At the edge of the field, the coach waited.',
+      validator: {
+        type: 'startsWithPhraseComma',
+        phrase: 'At the edge of the field',
       },
       misconceptionTags: ['comma.fronted_adverbial_missing'],
       readiness: ['proofreading', 'misconception', 'negative_test'],
@@ -349,6 +505,30 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
         type: 'combineFrontedAdverbial',
         phrase: 'After the rehearsal',
         mainClause: 'the cast packed away the props',
+      },
+      misconceptionTags: ['comma.fronted_adverbial_missing'],
+      readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Combine the adverbial and main clause into one sentence.',
+      stem: 'During the concert\nThe hall became silent.',
+      model: 'During the concert, the hall became silent.',
+      validator: {
+        type: 'combineFrontedAdverbial',
+        phrase: 'During the concert',
+        mainClause: 'the hall became silent',
+      },
+      misconceptionTags: ['comma.fronted_adverbial_missing'],
+      readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Combine the adverbial and main clause into one sentence.',
+      stem: 'At the edge of the field\nThe coach waited.',
+      model: 'At the edge of the field, the coach waited.',
+      validator: {
+        type: 'combineFrontedAdverbial',
+        phrase: 'At the edge of the field',
+        mainClause: 'the coach waited',
       },
       misconceptionTags: ['comma.fronted_adverbial_missing'],
       readiness: ['constrained_transfer', 'misconception', 'negative_test'],
@@ -398,6 +578,56 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
             type: 'speechWithWords',
             words: 'the props are packed',
             requiredTerminal: '.',
+            misconceptionTags: ['speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
+          },
+        ],
+      },
+      misconceptionTags: ['comma.fronted_adverbial_missing', 'speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
+      readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Repair the punctuation in the short passage.',
+      stem: 'During assembly Lina whispered please sit down',
+      model: 'During assembly, Lina whispered, "Please sit down."',
+      skillIds: ['fronted_adverbial', 'speech'],
+      clusterId: 'speech',
+      validator: {
+        type: 'paragraphRepair',
+        checks: [
+          {
+            type: 'startsWithPhraseComma',
+            phrase: 'During assembly',
+            misconceptionTags: ['comma.fronted_adverbial_missing'],
+          },
+          {
+            type: 'speechWithWords',
+            words: 'please sit down',
+            requiredTerminal: '.',
+            misconceptionTags: ['speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
+          },
+        ],
+      },
+      misconceptionTags: ['comma.fronted_adverbial_missing', 'speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
+      readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Repair the punctuation in the short passage.',
+      stem: 'At the gate Ben asked are we late',
+      model: 'At the gate, Ben asked, "Are we late?"',
+      skillIds: ['fronted_adverbial', 'speech'],
+      clusterId: 'speech',
+      validator: {
+        type: 'paragraphRepair',
+        checks: [
+          {
+            type: 'startsWithPhraseComma',
+            phrase: 'At the gate',
+            misconceptionTags: ['comma.fronted_adverbial_missing'],
+          },
+          {
+            type: 'speechWithWords',
+            words: 'are we late',
+            requiredTerminal: '?',
             misconceptionTags: ['speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
           },
         ],
@@ -479,6 +709,32 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
       misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
       readiness: ['proofreading', 'misconception', 'negative_test'],
     },
+    {
+      prompt: 'Replace the comma splice with a semi-colon.',
+      stem: 'The clock stopped, the class kept working.',
+      model: 'The clock stopped; the class kept working.',
+      validator: {
+        type: 'requiresBoundaryBetweenClauses',
+        left: 'The clock stopped',
+        right: 'the class kept working',
+        mark: ';',
+      },
+      misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
+      readiness: ['proofreading', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Replace the comma splice with a semi-colon.',
+      stem: 'The path was narrow, the hikers walked slowly.',
+      model: 'The path was narrow; the hikers walked slowly.',
+      validator: {
+        type: 'requiresBoundaryBetweenClauses',
+        left: 'The path was narrow',
+        right: 'the hikers walked slowly',
+        mark: ';',
+      },
+      misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
+      readiness: ['proofreading', 'misconception', 'negative_test'],
+    },
   ]),
   gen_semicolon_combine: Object.freeze([
     {
@@ -502,6 +758,32 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
         type: 'combineBoundaryBetweenClauses',
         left: 'The rain eased',
         right: 'the match could continue',
+        mark: ';',
+      },
+      misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
+      readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Combine the two related clauses into one sentence with a semi-colon.',
+      stem: 'The clock stopped.\nThe class kept working.',
+      model: 'The clock stopped; the class kept working.',
+      validator: {
+        type: 'combineBoundaryBetweenClauses',
+        left: 'The clock stopped',
+        right: 'the class kept working',
+        mark: ';',
+      },
+      misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
+      readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Combine the two related clauses into one sentence with a semi-colon.',
+      stem: 'The path was narrow.\nThe hikers walked slowly.',
+      model: 'The path was narrow; the hikers walked slowly.',
+      validator: {
+        type: 'combineBoundaryBetweenClauses',
+        left: 'The path was narrow',
+        right: 'the hikers walked slowly',
         mark: ';',
       },
       misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
@@ -558,6 +840,62 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
             mark: ';',
             left: 'The rain stopped',
             right: 'the match continued',
+            misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
+          },
+        ],
+      },
+      misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing', 'boundary.comma_splice', 'boundary.semicolon_missing'],
+      readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Repair the punctuation in the short passage.',
+      stem: 'The box contained three items, a scarf, a medal and a badge. The door opened, the crowd cheered.',
+      model: 'The box contained three items: a scarf, a medal and a badge. The door opened; the crowd cheered.',
+      skillIds: ['colon_list', 'semicolon'],
+      clusterId: 'boundary',
+      validator: {
+        type: 'paragraphRepair',
+        checks: [
+          {
+            type: 'requiresColonBeforeList',
+            opening: 'The box contained three items',
+            items: ['a scarf', 'a medal', 'a badge'],
+            allowTrailingText: true,
+            misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing'],
+          },
+          {
+            type: 'requiresBoundaryBetweenClauses',
+            mark: ';',
+            left: 'The door opened',
+            right: 'the crowd cheered',
+            misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
+          },
+        ],
+      },
+      misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing', 'boundary.comma_splice', 'boundary.semicolon_missing'],
+      readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Repair the punctuation in the short passage.',
+      stem: 'Our display needed three labels, rivers, mountains and coasts. The lights dimmed, the film began.',
+      model: 'Our display needed three labels: rivers, mountains and coasts. The lights dimmed; the film began.',
+      skillIds: ['colon_list', 'semicolon'],
+      clusterId: 'boundary',
+      validator: {
+        type: 'paragraphRepair',
+        checks: [
+          {
+            type: 'requiresColonBeforeList',
+            opening: 'Our display needed three labels',
+            items: ['rivers', 'mountains', 'coasts'],
+            allowTrailingText: true,
+            misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing'],
+          },
+          {
+            type: 'requiresBoundaryBetweenClauses',
+            mark: ';',
+            left: 'The lights dimmed',
+            right: 'the film began',
             misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
           },
         ],
@@ -747,6 +1085,32 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
       misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced'],
       readiness: ['proofreading', 'misconception', 'negative_test'],
     },
+    {
+      prompt: 'Correct the parenthesis punctuation.',
+      stem: 'The library a quiet room closed early.',
+      model: 'The library, a quiet room, closed early.',
+      validator: {
+        type: 'requiresParentheticalPhrase',
+        before: 'The library',
+        phrase: 'a quiet room',
+        after: 'closed early',
+      },
+      misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced'],
+      readiness: ['proofreading', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Correct the parenthesis punctuation.',
+      stem: 'Mr Patel our maths teacher smiled proudly.',
+      model: 'Mr Patel, our maths teacher, smiled proudly.',
+      validator: {
+        type: 'requiresParentheticalPhrase',
+        before: 'Mr Patel',
+        phrase: 'our maths teacher',
+        after: 'smiled proudly',
+      },
+      misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced'],
+      readiness: ['proofreading', 'misconception', 'negative_test'],
+    },
   ]),
   gen_parenthesis_combine: Object.freeze([
     {
@@ -771,6 +1135,32 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
         before: 'The tower',
         phrase: 'a useful lookout',
         after: 'stood above the bay',
+      },
+      misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced'],
+      readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Combine the sentence and extra detail using parenthesis.',
+      stem: 'The library closed early.\nExtra detail: a quiet room',
+      model: 'The library, a quiet room, closed early.',
+      validator: {
+        type: 'combineParentheticalPhrase',
+        before: 'The library',
+        phrase: 'a quiet room',
+        after: 'closed early',
+      },
+      misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced'],
+      readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Combine the sentence and extra detail using parenthesis.',
+      stem: 'Mr Patel smiled proudly.\nExtra detail: our maths teacher',
+      model: 'Mr Patel, our maths teacher, smiled proudly.',
+      validator: {
+        type: 'combineParentheticalPhrase',
+        before: 'Mr Patel',
+        phrase: 'our maths teacher',
+        after: 'smiled proudly',
       },
       misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced'],
       readiness: ['constrained_transfer', 'misconception', 'negative_test'],
@@ -831,6 +1221,60 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
       misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced', 'speech.quote_missing', 'speech.reporting_comma_missing'],
       readiness: ['constrained_transfer', 'misconception', 'negative_test'],
     },
+    {
+      prompt: 'Repair the punctuation in the short passage.',
+      stem: 'The library a quiet room closed early. Nina said we can come back tomorrow',
+      model: 'The library, a quiet room, closed early. Nina said, "We can come back tomorrow."',
+      skillIds: ['parenthesis', 'speech'],
+      clusterId: 'structure',
+      validator: {
+        type: 'paragraphRepair',
+        checks: [
+          {
+            type: 'requiresParentheticalPhrase',
+            before: 'The library',
+            phrase: 'a quiet room',
+            after: 'closed early',
+            misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced'],
+          },
+          {
+            type: 'speechWithWords',
+            words: 'we can come back tomorrow',
+            requiredTerminal: '.',
+            misconceptionTags: ['speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
+          },
+        ],
+      },
+      misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced', 'speech.quote_missing', 'speech.reporting_comma_missing'],
+      readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Repair the punctuation in the short passage.',
+      stem: 'Mr Patel our maths teacher smiled proudly. Leo asked did we win',
+      model: 'Mr Patel, our maths teacher, smiled proudly. Leo asked, "Did we win?"',
+      skillIds: ['parenthesis', 'speech'],
+      clusterId: 'structure',
+      validator: {
+        type: 'paragraphRepair',
+        checks: [
+          {
+            type: 'requiresParentheticalPhrase',
+            before: 'Mr Patel',
+            phrase: 'our maths teacher',
+            after: 'smiled proudly',
+            misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced'],
+          },
+          {
+            type: 'speechWithWords',
+            words: 'did we win',
+            requiredTerminal: '?',
+            misconceptionTags: ['speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
+          },
+        ],
+      },
+      misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced', 'speech.quote_missing', 'speech.reporting_comma_missing'],
+      readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    },
   ]),
   gen_colon_list_insert: Object.freeze([
     {
@@ -857,6 +1301,30 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
       misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing'],
       readiness: ['insertion', 'misconception', 'negative_test'],
     },
+    {
+      prompt: 'Add the colon before the list.',
+      stem: 'The drawer held three supplies pens, rulers and tape.',
+      model: 'The drawer held three supplies: pens, rulers and tape.',
+      validator: {
+        type: 'requiresColonBeforeList',
+        opening: 'The drawer held three supplies',
+        items: ['pens', 'rulers', 'tape'],
+      },
+      misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing'],
+      readiness: ['insertion', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Add the colon before the list.',
+      stem: 'We chose three activities swimming, cycling and climbing.',
+      model: 'We chose three activities: swimming, cycling and climbing.',
+      validator: {
+        type: 'requiresColonBeforeList',
+        opening: 'We chose three activities',
+        items: ['swimming', 'cycling', 'climbing'],
+      },
+      misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing'],
+      readiness: ['insertion', 'misconception', 'negative_test'],
+    },
   ]),
   gen_colon_list_combine: Object.freeze([
     {
@@ -879,6 +1347,30 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
         type: 'combineColonList',
         opening: 'The kit included three things',
         items: ['a lantern', 'a compass', 'a notebook'],
+      },
+      misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing'],
+      readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Combine the opening clause and list using a colon.',
+      stem: 'The drawer held three supplies\npens / rulers / tape',
+      model: 'The drawer held three supplies: pens, rulers and tape.',
+      validator: {
+        type: 'combineColonList',
+        opening: 'The drawer held three supplies',
+        items: ['pens', 'rulers', 'tape'],
+      },
+      misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing'],
+      readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Combine the opening clause and list using a colon.',
+      stem: 'We chose three activities\nswimming / cycling / climbing',
+      model: 'We chose three activities: swimming, cycling and climbing.',
+      validator: {
+        type: 'combineColonList',
+        opening: 'We chose three activities',
+        items: ['swimming', 'cycling', 'climbing'],
       },
       misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing'],
       readiness: ['constrained_transfer', 'misconception', 'negative_test'],
@@ -955,6 +1447,30 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
       misconceptionTags: ['structure.bullet_punctuation_inconsistent'],
       readiness: ['proofreading', 'misconception', 'negative_test'],
     },
+    {
+      prompt: 'Make the bullet punctuation consistent.',
+      stem: 'Take:\n- water\n- snacks.\n- a hat',
+      model: 'Take:\n- water\n- snacks\n- a hat',
+      validator: {
+        type: 'requiresBulletStemAndItems',
+        stem: 'Take',
+        items: ['water', 'snacks', 'a hat'],
+      },
+      misconceptionTags: ['structure.bullet_punctuation_inconsistent'],
+      readiness: ['proofreading', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Make the bullet punctuation consistent.',
+      stem: 'Check:\n- doors.\n- windows\n- lights.',
+      model: 'Check:\n- doors.\n- windows.\n- lights.',
+      validator: {
+        type: 'requiresBulletStemAndItems',
+        stem: 'Check',
+        items: ['doors', 'windows', 'lights'],
+      },
+      misconceptionTags: ['structure.bullet_punctuation_inconsistent'],
+      readiness: ['proofreading', 'misconception', 'negative_test'],
+    },
   ]),
   gen_bullet_points_paragraph: Object.freeze([
     {
@@ -996,6 +1512,52 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
             type: 'requiresBulletStemAndItems',
             stem: 'Bring',
             items: ['a coat', 'a torch', 'a notebook'],
+            misconceptionTags: ['structure.bullet_colon_missing', 'structure.bullet_marker_missing', 'structure.bullet_punctuation_inconsistent'],
+          },
+        ],
+      },
+      misconceptionTags: ['structure.bullet_colon_missing', 'structure.bullet_marker_missing', 'structure.bullet_punctuation_inconsistent'],
+      readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Repair the bullet-list punctuation.',
+      stem: 'Take\n- water\n- snacks.\n- a hat',
+      model: 'Take:\n- water\n- snacks\n- a hat',
+      accepted: [
+        'Take:\n- water.\n- snacks.\n- a hat.',
+      ],
+      skillIds: ['bullet_points'],
+      clusterId: 'structure',
+      validator: {
+        type: 'paragraphRepair',
+        checks: [
+          {
+            type: 'requiresBulletStemAndItems',
+            stem: 'Take',
+            items: ['water', 'snacks', 'a hat'],
+            misconceptionTags: ['structure.bullet_colon_missing', 'structure.bullet_marker_missing', 'structure.bullet_punctuation_inconsistent'],
+          },
+        ],
+      },
+      misconceptionTags: ['structure.bullet_colon_missing', 'structure.bullet_marker_missing', 'structure.bullet_punctuation_inconsistent'],
+      readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Repair the bullet-list punctuation.',
+      stem: 'Check\n- doors.\n- windows\n- lights.',
+      model: 'Check:\n- doors.\n- windows.\n- lights.',
+      accepted: [
+        'Check:\n- doors\n- windows\n- lights',
+      ],
+      skillIds: ['bullet_points'],
+      clusterId: 'structure',
+      validator: {
+        type: 'paragraphRepair',
+        checks: [
+          {
+            type: 'requiresBulletStemAndItems',
+            stem: 'Check',
+            items: ['doors', 'windows', 'lights'],
             misconceptionTags: ['structure.bullet_colon_missing', 'structure.bullet_marker_missing', 'structure.bullet_punctuation_inconsistent'],
           },
         ],

--- a/shared/punctuation/marking.js
+++ b/shared/punctuation/marking.js
@@ -258,18 +258,19 @@ function listCommaPattern(words = [], { finalComma = false } = {}) {
   for (let index = 1; index < escaped.length - 1; index += 1) {
     body += `,\\s*${escaped[index]}`;
   }
-  body += `${finalComma ? ',?' : ''}\\s+and\\s+${escaped[escaped.length - 1]}\\b`;
+  body += `${finalComma ? ',\\s+' : '\\s+'}and\\s+${escaped[escaped.length - 1]}\\b`;
   return new RegExp(body, 'i');
 }
 
-function listCommaOk(text, words = []) {
+function listCommaOk(text, words = [], { allowFinalComma = true } = {}) {
   const clean = canonicalPunctuationText(text).toLowerCase();
   const expected = listCommaPattern(words, { finalComma: false });
   const withFinalComma = listCommaPattern(words, { finalComma: true });
-  const commaPlacement = expected ? expected.test(clean) : false;
+  const noFinalCommaOk = expected ? expected.test(clean) : false;
+  const finalCommaOk = withFinalComma ? withFinalComma.test(clean) : false;
   return {
-    commaPlacement,
-    hasFinalComma: !commaPlacement && withFinalComma ? withFinalComma.test(clean) : false,
+    commaPlacement: noFinalCommaOk || (allowFinalComma && finalCommaOk),
+    hasFinalComma: finalCommaOk,
   };
 }
 
@@ -290,7 +291,7 @@ function openingPhraseMainClause(text, phrase) {
   };
 }
 
-function listCommaShapePattern(words = []) {
+function listCommaShapePattern(words = [], { allowFinalComma = true } = {}) {
   const items = words.map((word) => canonicalPunctuationText(word).toLowerCase()).filter(Boolean);
   if (items.length < 2) return null;
   const escaped = items.map(escapeRegExp);
@@ -299,7 +300,7 @@ function listCommaShapePattern(words = []) {
   for (let index = 1; index < escaped.length - 1; index += 1) {
     body += `,\\s*${escaped[index]}`;
   }
-  body += `\\s+and\\s+${escaped[escaped.length - 1]}`;
+  body += `${allowFinalComma ? ',?' : ''}\\s+and\\s+${escaped[escaped.length - 1]}`;
   return body;
 }
 
@@ -329,7 +330,7 @@ function boundaryBetweenClauses(text, validator = {}) {
   const mark = String(validator.mark || ';');
   const markOk = mark.trim() === ';'
     ? /^\s*;\s*$/.test(between)
-    : /^\s+-\s+$/.test(between);
+    : /^\s+[-–—]\s+$/.test(between);
   return { wordsOk, markOk, between, mark };
 }
 
@@ -378,7 +379,7 @@ function colonBeforeList(text, validator = {}) {
     && wordSequencePreserved(clean, [opening, ...items]);
   const afterOpening = wordsOk ? clean.slice(opening.length) : '';
   const colonOk = /^\s*:\s*/.test(afterOpening);
-  const expectedList = listCommaShapePattern(items);
+  const expectedList = listCommaShapePattern(items, { allowFinalComma: validator.allowFinalComma !== false });
   const tailPattern = validator.allowTrailingText === true
     ? '[.?!](?:\\s+\\S.*)?$'
     : '[.?!]?["\']?$';
@@ -507,7 +508,7 @@ function anchoredListSentence(text, validator = {}, requiredTerminal = null) {
   const items = (Array.isArray(validator.items) ? validator.items : [])
     .map((entry) => canonicalPunctuationText(entry))
     .filter(Boolean);
-  const expectedList = listCommaShapePattern(items);
+  const expectedList = listCommaShapePattern(items, { allowFinalComma: validator.allowFinalComma !== false });
   const wordsOk = Boolean(opening && expectedList) && wordSequencePreserved(clean, [opening, ...items]);
   const sentenceOk = singleSentenceOk(clean, requiredTerminal);
   const listOk = Boolean(opening && expectedList) && new RegExp(
@@ -556,7 +557,7 @@ function anchoredBoundarySentence(text, validator = {}, requiredTerminal = null)
   const wordsOk = Boolean(left && right)
     && clean.toLowerCase().startsWith(left.toLowerCase())
     && wordSequencePreserved(clean, [left, right]);
-  const markPattern = mark === ';' ? '\\s*;\\s*' : '\\s+-\\s+';
+  const markPattern = mark === ';' ? '\\s*;\\s*' : '\\s+[-–—]\\s+';
   const markOk = Boolean(left && right) && new RegExp(
     `^${escapeRegExp(left)}${markPattern}${escapeRegExp(right)}${terminalSuffixPattern(requiredTerminal)}`,
     'i',
@@ -678,7 +679,9 @@ function markTransfer(item, answer) {
     const clean = canonicalPunctuationText(text);
     const openingOk = !opening || clean.toLowerCase().startsWith(opening.toLowerCase());
     const wordsOk = words.length >= 2 && openingOk && wordSequencePreserved(text, opening ? [opening, ...words] : words);
-    const { commaPlacement, hasFinalComma } = listCommaOk(text, words);
+    const { commaPlacement, hasFinalComma } = listCommaOk(text, words, {
+      allowFinalComma: validator.allowFinalComma !== false,
+    });
     const capitalOk = sentenceStartsWithCapital(text);
     const terminalOk = sentenceEnds(text);
     const sentenceOk = transferSentenceOk(item, text);

--- a/shared/punctuation/scheduler.js
+++ b/shared/punctuation/scheduler.js
@@ -341,6 +341,22 @@ function recentSignatureSet(indexes, session = {}, progress = {}) {
   return signatures;
 }
 
+function avoidRecentSignatureRows(rows, recentSignatures) {
+  const freshRows = rows.filter((row) => {
+    const signature = row.item?.variantSignature;
+    return !signature || !recentSignatures.has(signature);
+  });
+  return freshRows.length ? freshRows : rows;
+}
+
+function avoidRecentSignatureItems(items, recentSignatures) {
+  const freshItems = items.filter((item) => {
+    const signature = item?.variantSignature;
+    return !signature || !recentSignatures.has(signature);
+  });
+  return freshItems.length ? freshItems : items;
+}
+
 function weakRows(indexes, progress, session, now, maxWindow) {
   const recent = new Set(Array.isArray(session?.recentItemIds) ? session.recentItemIds.slice(-6) : []);
   const recentSignatures = recentSignatureSet(indexes, session, progress);
@@ -371,7 +387,8 @@ function weakRows(indexes, progress, session, now, maxWindow) {
     if (rows.length >= limit) break;
   }
 
-  return rows.sort((a, b) => b.priority - a.priority || a.order - b.order);
+  const sortedRows = rows.sort((a, b) => b.priority - a.priority || a.order - b.order);
+  return avoidRecentSignatureRows(sortedRows, recentSignatures);
 }
 
 export function selectPunctuationItem({
@@ -417,10 +434,11 @@ export function selectPunctuationItem({
       const candidates = modeSuppressed
         ? []
         : candidateItems(indexes, { mode: candidateMode, clusterId, skillId: guidedSkillId });
+      const nonRepeatCandidates = candidates.filter((item) => item.id !== previousItemId);
       return {
         mode: candidateMode,
         candidates,
-        nonRepeatCandidates: candidates.filter((item) => item.id !== previousItemId),
+        nonRepeatCandidates: avoidRecentSignatureItems(nonRepeatCandidates, recentSignatures),
       };
     });
   const selectedMode = modeRows.find((row) => row.nonRepeatCandidates.length)

--- a/shared/punctuation/scheduler.js
+++ b/shared/punctuation/scheduler.js
@@ -213,6 +213,7 @@ function recentMissForItem(progress, item) {
   return attempts.slice(-12).reverse().find((attempt) => {
     if (!attempt || attempt.correct === true) return false;
     if (attempt.itemId === item.id) return true;
+    if (item.variantSignature && attempt.variantSignature === item.variantSignature) return true;
     if (attempt.mode !== item.mode) return false;
     const attemptSkills = Array.isArray(attempt.skillIds) ? attempt.skillIds : [];
     return item.skillIds?.some((skillId) => attemptSkills.includes(skillId));
@@ -237,7 +238,7 @@ function strongestFacet(indexes, progress, item, now) {
     .sort((a, b) => b.rank - a.rank || a.mastery - b.mastery || a.skillId.localeCompare(b.skillId))[0] || null;
 }
 
-function weakCandidateRow(indexes, progress, item, now, order, recent) {
+function weakCandidateRow(indexes, progress, item, now, order, recent, recentSignatures) {
   const itemSnap = memorySnapshot(progressForItem(progress, item.id), now);
   const facet = strongestFacet(indexes, progress, item, now);
   const recentMiss = recentMissForItem(progress, item);
@@ -276,6 +277,7 @@ function weakCandidateRow(indexes, progress, item, now, order, recent) {
   }
 
   if (recent.has(item.id)) priority *= 0.08;
+  else if (item.variantSignature && recentSignatures.has(item.variantSignature)) priority *= 0.18;
 
   const focusSkillId = facet?.skillId || item.skillIds?.[0] || '';
   return {
@@ -320,15 +322,35 @@ function itemEvidenceRows(progress, now, bucket) {
     .sort((a, b) => a.snap.mastery - b.snap.mastery || a.itemId.localeCompare(b.itemId));
 }
 
+function recentSignatureSet(indexes, session = {}, progress = {}) {
+  const signatures = new Set();
+  const recentIds = Array.isArray(session?.recentItemIds) ? session.recentItemIds.slice(-8) : [];
+  for (const itemId of recentIds) {
+    const signature = indexes.itemById.get(itemId)?.variantSignature;
+    if (signature) signatures.add(signature);
+  }
+  const attempts = Array.isArray(progress?.attempts) ? progress.attempts.slice(-8) : [];
+  for (const attempt of attempts) {
+    if (typeof attempt?.variantSignature === 'string' && attempt.variantSignature) {
+      signatures.add(attempt.variantSignature);
+      continue;
+    }
+    const signature = indexes.itemById.get(attempt?.itemId)?.variantSignature;
+    if (signature) signatures.add(signature);
+  }
+  return signatures;
+}
+
 function weakRows(indexes, progress, session, now, maxWindow) {
   const recent = new Set(Array.isArray(session?.recentItemIds) ? session.recentItemIds.slice(-6) : []);
+  const recentSignatures = recentSignatureSet(indexes, session, progress);
   const rows = [];
   const seen = new Set();
   const limit = Math.max(1, maxWindow);
   const addItem = (item) => {
     if (rows.length >= limit || !publishedItem(indexes, item) || seen.has(item.id)) return;
     seen.add(item.id);
-    rows.push(weakCandidateRow(indexes, progress, item, now, rows.length, recent));
+    rows.push(weakCandidateRow(indexes, progress, item, now, rows.length, recent, recentSignatures));
   };
   const addFacet = ({ skillId, mode }) => {
     for (const item of indexes.itemsByMode.get(mode) || []) {
@@ -384,6 +406,7 @@ export function selectPunctuationItem({
 
   const recentIds = Array.isArray(session?.recentItemIds) ? session.recentItemIds.slice(-6) : [];
   const recent = new Set(recentIds);
+  const recentSignatures = recentSignatureSet(indexes, session, progress);
   const previousItemId = typeof session?.currentItemId === 'string' && session.currentItemId
     ? session.currentItemId
     : recentIds.at(-1) || null;
@@ -413,6 +436,7 @@ export function selectPunctuationItem({
     if (snap.bucket === 'new') weight *= 1.35;
     if (snap.bucket === 'secure') weight *= 0.25;
     if (recent.has(item.id)) weight *= 0.12;
+    else if (item.variantSignature && recentSignatures.has(item.variantSignature)) weight *= 0.2;
     return { item, weight };
   }).filter((row) => row.weight > 0);
 

--- a/shared/punctuation/service.js
+++ b/shared/punctuation/service.js
@@ -252,7 +252,6 @@ function normaliseGpsResponse(value) {
   if (!itemId) return null;
   return {
     itemId,
-    variantSignature: typeof value.variantSignature === 'string' ? value.variantSignature : '',
     mode: typeof value.mode === 'string' ? value.mode : '',
     skillIds: normaliseStringArray(value.skillIds),
     rewardUnitId: typeof value.rewardUnitId === 'string' ? value.rewardUnitId : '',
@@ -813,7 +812,6 @@ function isMeaningfulPunctuationAnswer(item, answer = {}) {
 function reviewItemFromResult({ item, answer, result }) {
   return {
     itemId: item.id,
-    variantSignature: item.variantSignature || '',
     mode: item.mode,
     skillIds: Array.isArray(item.skillIds) ? [...item.skillIds] : [],
     rewardUnitId: item.rewardUnitId || '',

--- a/shared/punctuation/service.js
+++ b/shared/punctuation/service.js
@@ -173,6 +173,7 @@ export function normalisePunctuationData(value) {
               ts: normaliseTimestamp(attempt.ts, 0),
               sessionId: typeof attempt.sessionId === 'string' ? attempt.sessionId : null,
               itemId: typeof attempt.itemId === 'string' ? attempt.itemId : '',
+              variantSignature: typeof attempt.variantSignature === 'string' ? attempt.variantSignature : '',
               mode: typeof attempt.mode === 'string' ? attempt.mode : '',
               itemMode: typeof attempt.itemMode === 'string'
                 ? attempt.itemMode
@@ -214,6 +215,9 @@ function normaliseItemForState(item) {
     model: item.model || '',
     source: item.source || 'fixed',
   };
+  if (typeof item.variantSignature === 'string' && item.variantSignature) {
+    safe.variantSignature = item.variantSignature;
+  }
   if (item.mode === 'choose') {
     safe.options = Array.isArray(item.options)
       ? item.options.map((option, index) => {
@@ -248,6 +252,7 @@ function normaliseGpsResponse(value) {
   if (!itemId) return null;
   return {
     itemId,
+    variantSignature: typeof value.variantSignature === 'string' ? value.variantSignature : '',
     mode: typeof value.mode === 'string' ? value.mode : '',
     skillIds: normaliseStringArray(value.skillIds),
     rewardUnitId: typeof value.rewardUnitId === 'string' ? value.rewardUnitId : '',
@@ -808,6 +813,7 @@ function isMeaningfulPunctuationAnswer(item, answer = {}) {
 function reviewItemFromResult({ item, answer, result }) {
   return {
     itemId: item.id,
+    variantSignature: item.variantSignature || '',
     mode: item.mode,
     skillIds: Array.isArray(item.skillIds) ? [...item.skillIds] : [],
     rewardUnitId: item.rewardUnitId || '',
@@ -874,6 +880,7 @@ function applyMarkedAttemptToProgress({
     ts: nowValue,
     sessionId: session.id,
     itemId: item.id,
+    variantSignature: item.variantSignature || '',
     mode: item.mode,
     itemMode: item.mode,
     skillIds: item.skillIds || [],

--- a/src/subjects/punctuation/read-model.js
+++ b/src/subjects/punctuation/read-model.js
@@ -132,6 +132,7 @@ function normaliseAttempt(rawValue) {
     ts: asTs(raw.ts, 0),
     sessionId: typeof raw.sessionId === 'string' ? raw.sessionId : null,
     itemId: typeof raw.itemId === 'string' ? raw.itemId : '',
+    variantSignature: typeof raw.variantSignature === 'string' ? raw.variantSignature : '',
     itemMode,
     mode: itemMode,
     skillIds: normaliseStringArray(raw.skillIds),

--- a/src/subjects/punctuation/star-projection.js
+++ b/src/subjects/punctuation/star-projection.js
@@ -140,6 +140,10 @@ function monsterForCluster(clusterId) {
   return PUNCTUATION_CLIENT_CLUSTER_TO_MONSTER[clusterId] || null;
 }
 
+function attemptEvidenceKey(attempt) {
+  return attempt?.variantSignature || attempt?.itemId || '';
+}
+
 // ---------------------------------------------------------------------------
 // Per-monster Star computations
 // ---------------------------------------------------------------------------
@@ -150,11 +154,11 @@ function computeTryStars(monsterAttempts) {
   const perItem = new Map();
   for (const attempt of monsterAttempts) {
     if (attempt.meaningful === false) continue;
-    const itemId = attempt.itemId || '';
-    if (!itemId) continue;
-    const count = perItem.get(itemId) || 0;
+    const evidenceKey = attemptEvidenceKey(attempt);
+    if (!evidenceKey) continue;
+    const count = perItem.get(evidenceKey) || 0;
     if (count >= MAX_ATTEMPTS_PER_ITEM) continue;
-    perItem.set(itemId, count + 1);
+    perItem.set(evidenceKey, count + 1);
   }
 
   // Cap same-day items.
@@ -162,10 +166,10 @@ function computeTryStars(monsterAttempts) {
   for (const attempt of monsterAttempts) {
     if (attempt.meaningful === false) continue;
     const day = dayIndex(attempt.ts);
-    const itemId = attempt.itemId || '';
-    if (!itemId) continue;
+    const evidenceKey = attemptEvidenceKey(attempt);
+    if (!evidenceKey) continue;
     if (!perDay.has(day)) perDay.set(day, new Set());
-    perDay.get(day).add(itemId);
+    perDay.get(day).add(evidenceKey);
   }
 
   let totalCapped = 0;
@@ -194,11 +198,11 @@ function computePracticeStars(monsterAttempts) {
   let independentCorrect = 0;
 
   for (const attempt of monsterAttempts) {
-    const itemId = attempt.itemId || '';
-    if (!itemId) continue;
-    const count = perItem.get(itemId) || 0;
+    const evidenceKey = attemptEvidenceKey(attempt);
+    if (!evidenceKey) continue;
+    const count = perItem.get(evidenceKey) || 0;
     if (count >= MAX_ATTEMPTS_PER_ITEM) continue;
-    perItem.set(itemId, count + 1);
+    perItem.set(evidenceKey, count + 1);
 
     const supportLevel = Math.max(0, Number(attempt.supportLevel) || 0);
     if (supportLevel === 0 && attempt.correct === true) {
@@ -206,8 +210,8 @@ function computePracticeStars(monsterAttempts) {
       if (!perDayCorrectItems.has(day)) perDayCorrectItems.set(day, new Set());
       const dayItems = perDayCorrectItems.get(day);
       // Only count this item if the day hasn't hit the daily cap yet.
-      if (dayItems.size < MAX_SAME_DAY_PRACTICE_ITEMS || dayItems.has(itemId)) {
-        dayItems.add(itemId);
+      if (dayItems.size < MAX_SAME_DAY_PRACTICE_ITEMS || dayItems.has(evidenceKey)) {
+        dayItems.add(evidenceKey);
         independentCorrect += 1;
       }
     }
@@ -230,16 +234,16 @@ function computePracticeStars(monsterAttempts) {
   let nearRetryCorrections = 0;
   const itemAttemptOrder = new Map();
   for (const attempt of monsterAttempts) {
-    const itemId = attempt.itemId || '';
-    if (!itemId) continue;
-    if (!itemAttemptOrder.has(itemId)) itemAttemptOrder.set(itemId, []);
-    itemAttemptOrder.get(itemId).push(attempt);
+    const evidenceKey = attemptEvidenceKey(attempt);
+    if (!evidenceKey) continue;
+    if (!itemAttemptOrder.has(evidenceKey)) itemAttemptOrder.set(evidenceKey, []);
+    itemAttemptOrder.get(evidenceKey).push(attempt);
   }
-  for (const [itemId, attempts] of itemAttemptOrder) {
+  for (const [evidenceKey, attempts] of itemAttemptOrder) {
     for (let i = 1; i < attempts.length && i < MAX_ATTEMPTS_PER_ITEM; i++) {
       if (!attempts[i - 1].correct && attempts[i].correct && (attempts[i].supportLevel || 0) === 0) {
         const day = dayIndex(attempts[i].ts);
-        if (perDayCorrectItems.get(day)?.has(itemId)) {
+        if (perDayCorrectItems.get(day)?.has(evidenceKey)) {
           nearRetryCorrections += 1;
         }
       }
@@ -594,6 +598,7 @@ export function projectPunctuationStars(progress, releaseId, options) {
     return {
       ts: Math.max(0, Number(a.ts) || 0),
       itemId: typeof a.itemId === 'string' ? a.itemId : '',
+      variantSignature: typeof a.variantSignature === 'string' ? a.variantSignature : '',
       skillIds: Array.isArray(a.skillIds) ? a.skillIds.filter((s) => typeof s === 'string') : [],
       rewardUnitId: typeof a.rewardUnitId === 'string' ? a.rewardUnitId : '',
       correct: a.correct === true,

--- a/src/subjects/punctuation/star-projection.js
+++ b/src/subjects/punctuation/star-projection.js
@@ -141,7 +141,47 @@ function monsterForCluster(clusterId) {
 }
 
 function attemptEvidenceKey(attempt) {
-  return attempt?.variantSignature || attempt?.itemId || '';
+  return attempt?.evidenceKey || attempt?.variantSignature || attempt?.itemId || '';
+}
+
+function itemVariantSignatureAliasMap(attempts) {
+  const signaturesByItemId = new Map();
+  for (const attempt of attempts) {
+    if (!attempt.itemId || !attempt.variantSignature) continue;
+    if (!signaturesByItemId.has(attempt.itemId)) signaturesByItemId.set(attempt.itemId, new Set());
+    signaturesByItemId.get(attempt.itemId).add(attempt.variantSignature);
+  }
+
+  const aliases = new Map();
+  for (const [itemId, signatures] of signaturesByItemId) {
+    if (signatures.size === 1) aliases.set(itemId, [...signatures][0]);
+  }
+  return aliases;
+}
+
+function normaliseAttempts(rawAttempts) {
+  const attempts = rawAttempts.map((raw) => {
+    const a = isPlainObject(raw) ? raw : {};
+    return {
+      ts: Math.max(0, Number(a.ts) || 0),
+      itemId: typeof a.itemId === 'string' ? a.itemId : '',
+      variantSignature: typeof a.variantSignature === 'string' ? a.variantSignature : '',
+      skillIds: Array.isArray(a.skillIds) ? a.skillIds.filter((s) => typeof s === 'string') : [],
+      rewardUnitId: typeof a.rewardUnitId === 'string' ? a.rewardUnitId : '',
+      correct: a.correct === true,
+      supportLevel: Math.max(0, Number(a.supportLevel) || 0),
+      supportKind: typeof a.supportKind === 'string' ? a.supportKind : null,
+      itemMode: typeof a.itemMode === 'string' ? a.itemMode : '',
+      sessionMode: typeof a.sessionMode === 'string' ? a.sessionMode : 'smart',
+      testMode: a.testMode === 'gps' ? 'gps' : null,
+      meaningful: a.meaningful !== false,
+    };
+  });
+  const itemSignatureAliases = itemVariantSignatureAliasMap(attempts);
+  return attempts.map((attempt) => ({
+    ...attempt,
+    evidenceKey: attempt.variantSignature || itemSignatureAliases.get(attempt.itemId) || attempt.itemId,
+  }));
 }
 
 // ---------------------------------------------------------------------------
@@ -255,14 +295,17 @@ function computePracticeStars(monsterAttempts) {
   return Math.min(PRACTICE_CAP, Math.floor(rawScore));
 }
 
-function computeSecureStars(monsterClusterIds, items, rewardUnits, releaseId, monsterId) {
+function computeSecureStars(monsterClusterIds, items, rewardUnits, releaseId, monsterId, itemSignatureAliases) {
   // Count items that have reached the secure bucket.
-  let secureItemCount = 0;
+  const secureEvidenceKeys = new Set();
   const itemEntries = isPlainObject(items) ? items : {};
-  for (const [, itemState] of Object.entries(itemEntries)) {
+  for (const [itemId, itemState] of Object.entries(itemEntries)) {
     const snap = memorySnapshot(itemState);
-    if (snap.secure) secureItemCount += 1;
+    if (snap.secure) {
+      secureEvidenceKeys.add(itemSignatureAliases.get(itemId) || itemId);
+    }
   }
+  const secureItemCount = secureEvidenceKeys.size;
 
   // Count secured reward units for this monster's clusters.
   let securedUnitCount = 0;
@@ -591,25 +634,8 @@ export function projectPunctuationStars(progress, releaseId, options) {
   const facets = isPlainObject(safeProgress.facets) ? safeProgress.facets : {};
   const rewardUnits = isPlainObject(safeProgress.rewardUnits) ? safeProgress.rewardUnits : {};
   const rawAttempts = Array.isArray(safeProgress.attempts) ? safeProgress.attempts : [];
-
-  // Normalise attempts: ensure required fields are present.
-  const attempts = rawAttempts.map((raw) => {
-    const a = isPlainObject(raw) ? raw : {};
-    return {
-      ts: Math.max(0, Number(a.ts) || 0),
-      itemId: typeof a.itemId === 'string' ? a.itemId : '',
-      variantSignature: typeof a.variantSignature === 'string' ? a.variantSignature : '',
-      skillIds: Array.isArray(a.skillIds) ? a.skillIds.filter((s) => typeof s === 'string') : [],
-      rewardUnitId: typeof a.rewardUnitId === 'string' ? a.rewardUnitId : '',
-      correct: a.correct === true,
-      supportLevel: Math.max(0, Number(a.supportLevel) || 0),
-      supportKind: typeof a.supportKind === 'string' ? a.supportKind : null,
-      itemMode: typeof a.itemMode === 'string' ? a.itemMode : '',
-      sessionMode: typeof a.sessionMode === 'string' ? a.sessionMode : 'smart',
-      testMode: a.testMode === 'gps' ? 'gps' : null,
-      meaningful: a.meaningful !== false,
-    };
-  });
+  const attempts = normaliseAttempts(rawAttempts);
+  const itemSignatureAliases = itemVariantSignatureAliasMap(attempts);
 
   // Build per-monster attempt arrays.
   const monsterAttempts = new Map();
@@ -635,7 +661,7 @@ export function projectPunctuationStars(progress, releaseId, options) {
 
     const tryStars = computeTryStars(mAttempts);
     const practiceStars = computePracticeStars(mAttempts);
-    const secureStars = computeSecureStars(clusterIds, mItems, rewardUnits, releaseId, monsterId);
+    const secureStars = computeSecureStars(clusterIds, mItems, rewardUnits, releaseId, monsterId, itemSignatureAliases);
     const masteryStars = computeMasteryStars(clusterIds, facets, rewardUnits, monsterId);
     const total = tryStars + practiceStars + secureStars + masteryStars;
 

--- a/tests/punctuation-ai-context-pack.test.js
+++ b/tests/punctuation-ai-context-pack.test.js
@@ -62,6 +62,11 @@ test('context packs affect only deterministic generator families', () => {
     'gen_list_commas_combine',
     'gen_fronted_adverbial_fix',
     'gen_fronted_adverbial_combine',
+    'gen_comma_clarity_insert',
+    'gen_semicolon_fix',
+    'gen_semicolon_combine',
+    'gen_dash_clause_fix',
+    'gen_dash_clause_combine',
     'gen_parenthesis_combine',
     'gen_hyphen_insert',
   ]);
@@ -81,6 +86,9 @@ test('context-pack generated items still pass deterministic marking', () => {
   assert.match(generatedText, /Maya asked/);
   assert.match(generatedText, /ropes, maps and snacks/);
   assert.match(generatedText, /Before sunrise/);
+  assert.match(generatedText, /Before sunrise, the harbour was quiet/);
+  assert.match(generatedText, /The crew checked the ropes; we found another path/);
+  assert.match(generatedText, /The crew checked the ropes - we found another path/);
   assert.match(generatedText, /The harbour, our meeting place, was busy/);
   assert.match(generatedText, /well-known author/);
   for (const item of generatedItems) {

--- a/tests/punctuation-combine.test.js
+++ b/tests/punctuation-combine.test.js
@@ -63,8 +63,22 @@ test('combine validators cover list commas, fronted adverbials, and colon lists'
     item: item('lc_combine_trip_list'),
     answer: { typed: 'We packed torches, maps, and water.' },
   });
-  assert.equal(finalComma.correct, false);
-  assert.equal(finalComma.misconceptionTags.includes('comma.unnecessary_final_comma'), true);
+  assert.equal(finalComma.correct, true);
+  assert.deepEqual(finalComma.misconceptionTags, []);
+
+  const strictListItem = {
+    ...item('lc_combine_trip_list'),
+    validator: {
+      ...item('lc_combine_trip_list').validator,
+      allowFinalComma: false,
+    },
+  };
+  const strictFinalComma = markPunctuationAnswer({
+    item: strictListItem,
+    answer: { typed: 'We packed torches, maps, and water.' },
+  });
+  assert.equal(strictFinalComma.correct, false);
+  assert.equal(strictFinalComma.misconceptionTags.includes('comma.unnecessary_final_comma'), true);
 
   const fronted = markPunctuationAnswer({
     item: item('fa_combine_after_storm'),
@@ -122,6 +136,17 @@ test('dash combine requires a spaced dash between preserved clauses', () => {
     answer: { typed: 'The path was flooded - we took the longer route.' },
   });
   assert.equal(dash.correct, true);
+
+  for (const typed of [
+    'The path was flooded – we took the longer route.',
+    'The path was flooded — we took the longer route.',
+  ]) {
+    const variant = markPunctuationAnswer({
+      item: item('dc_combine_flooded_route'),
+      answer: { typed },
+    });
+    assert.equal(variant.correct, true, typed);
+  }
 
   const unpunctuated = markPunctuationAnswer({
     item: item('dc_combine_flooded_route'),

--- a/tests/punctuation-content-audit.test.js
+++ b/tests/punctuation-content-audit.test.js
@@ -1,0 +1,105 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  PUNCTUATION_CONTENT_MANIFEST,
+} from '../shared/punctuation/content.js';
+import {
+  runPunctuationContentAudit,
+} from '../scripts/audit-punctuation-content.mjs';
+
+test('punctuation content audit reports the current fixed and generated baseline', () => {
+  const audit = runPunctuationContentAudit({
+    seed: 'audit-baseline',
+    generatedPerFamily: 1,
+  });
+
+  assert.equal(audit.ok, true, audit.failures.join('\n'));
+  assert.deepEqual(audit.summary, {
+    fixedItemCount: 71,
+    generatorFamilyCount: 25,
+    generatedItemCount: 25,
+    runtimeItemCount: 96,
+    publishedRewardUnitCount: 14,
+    publishedSkillCount: 14,
+  });
+  assert.equal(audit.bySkill.length, 14);
+  assert.equal(audit.bySkill.every((row) => row.generatedFamilyCount >= 1), true);
+});
+
+test('punctuation content audit reports per-skill coverage and generated signatures', () => {
+  const audit = runPunctuationContentAudit({
+    seed: 'audit-coverage',
+    generatedPerFamily: 1,
+  });
+  const sentenceEndings = audit.bySkill.find((row) => row.skillId === 'sentence_endings');
+  const speech = audit.bySkill.find((row) => row.skillId === 'speech');
+
+  assert.equal(sentenceEndings.fixedItemCount, 4);
+  assert.equal(sentenceEndings.generatedItemCount, 1);
+  assert.equal(sentenceEndings.generatedSignatureCount, 1);
+  assert.ok(sentenceEndings.readinessCoverage.includes('insertion'));
+  assert.ok(speech.generatedItemCount >= 2);
+  assert.ok(speech.validatorCoverageCount > 0);
+});
+
+test('punctuation content audit can prove expanded deterministic bank variety', () => {
+  const audit = runPunctuationContentAudit({
+    seed: 'audit-expanded-bank',
+    generatedPerFamily: 4,
+  });
+  const targetFamilies = [
+    'gen_sentence_endings_insert',
+    'gen_apostrophe_contractions_fix',
+    'gen_comma_clarity_insert',
+    'gen_dash_clause_fix',
+    'gen_dash_clause_combine',
+    'gen_hyphen_insert',
+    'gen_semicolon_list_fix',
+  ];
+
+  assert.equal(audit.ok, true, audit.failures.join('\n'));
+  for (const familyId of targetFamilies) {
+    const row = audit.generatorFamilies.find((entry) => entry.id === familyId);
+    assert.equal(row.generatedItemCount, 4, familyId);
+    assert.equal(row.variantSignatures.length, 4, familyId);
+    assert.equal(row.templateIds.length, 4, familyId);
+  }
+});
+
+test('punctuation content audit detects missing generated family coverage', () => {
+  const manifest = {
+    ...PUNCTUATION_CONTENT_MANIFEST,
+    generatorFamilies: [
+      ...PUNCTUATION_CONTENT_MANIFEST.generatorFamilies,
+      {
+        id: 'gen_sentence_endings_missing_templates',
+        skillId: 'sentence_endings',
+        rewardUnitId: 'sentence-endings-core',
+        published: true,
+        mode: 'insert',
+        deterministicSeedFields: ['learnerId', 'sessionId', 'itemIndex'],
+      },
+    ],
+  };
+  const audit = runPunctuationContentAudit({ manifest, seed: 'missing-family', generatedPerFamily: 1 });
+
+  assert.equal(audit.ok, false);
+  assert.match(audit.failures.join('\n'), /gen_sentence_endings_missing_templates produced no generated items/);
+});
+
+test('punctuation content audit threshold failures are machine-readable', () => {
+  const audit = runPunctuationContentAudit({
+    seed: 'strict-audit',
+    generatedPerFamily: 1,
+    thresholds: {
+      minGeneratedSignaturesPerPublishedSkill: 3,
+      minValidatorCoveragePerPublishedSkill: 1,
+    },
+  });
+
+  assert.equal(audit.ok, false);
+  assert.match(audit.failures.join('\n'), /sentence_endings has 1 generated signatures/);
+  assert.equal(Array.isArray(audit.bySkill), true);
+  assert.equal(Array.isArray(audit.generatorFamilies), true);
+});

--- a/tests/punctuation-content-audit.test.js
+++ b/tests/punctuation-content-audit.test.js
@@ -47,24 +47,30 @@ test('punctuation content audit can prove expanded deterministic bank variety', 
   const audit = runPunctuationContentAudit({
     seed: 'audit-expanded-bank',
     generatedPerFamily: 4,
+    thresholds: {
+      failOnDuplicateGeneratedSignatures: true,
+    },
   });
-  const targetFamilies = [
-    'gen_sentence_endings_insert',
-    'gen_apostrophe_contractions_fix',
-    'gen_comma_clarity_insert',
-    'gen_dash_clause_fix',
-    'gen_dash_clause_combine',
-    'gen_hyphen_insert',
-    'gen_semicolon_list_fix',
-  ];
 
   assert.equal(audit.ok, true, audit.failures.join('\n'));
-  for (const familyId of targetFamilies) {
-    const row = audit.generatorFamilies.find((entry) => entry.id === familyId);
-    assert.equal(row.generatedItemCount, 4, familyId);
-    assert.equal(row.variantSignatures.length, 4, familyId);
-    assert.equal(row.templateIds.length, 4, familyId);
+  for (const row of audit.generatorFamilies.filter((entry) => entry.published)) {
+    assert.equal(row.generatedItemCount, 4, row.id);
+    assert.equal(row.variantSignatures.length, 4, row.id);
+    assert.equal(row.templateIds.length, 4, row.id);
   }
+});
+
+test('punctuation content audit can fail when generated variants exceed unique bank capacity', () => {
+  const audit = runPunctuationContentAudit({
+    seed: 'audit-over-capacity',
+    generatedPerFamily: 5,
+    thresholds: {
+      failOnDuplicateGeneratedSignatures: true,
+    },
+  });
+
+  assert.equal(audit.ok, false);
+  assert.match(audit.failures.join('\n'), /Duplicate generated variant signatures/);
 });
 
 test('punctuation content audit detects missing generated family coverage', () => {

--- a/tests/punctuation-doc-static-checks.test.js
+++ b/tests/punctuation-doc-static-checks.test.js
@@ -197,6 +197,19 @@ test('punctuation-production.md documents the Punctuation Doctor diagnostic', ()
   );
 });
 
+test('punctuation-production.md documents generated practice guardrails', () => {
+  for (const pattern of [
+    /generatedPerFamily:\s*1/,
+    /templateId/,
+    /variantSignature/,
+    /runtime AI/,
+    /audit:punctuation-content/,
+    /generated-per-family 4/,
+  ]) {
+    assert.match(docContent, pattern);
+  }
+});
+
 test('punctuation-production.md documents time-windowed telemetry caps', () => {
   const hits = grepLines(/rolling.*7-day|7-day.*window|time-windowed/i);
   assert.ok(

--- a/tests/punctuation-generators.test.js
+++ b/tests/punctuation-generators.test.js
@@ -22,11 +22,57 @@ test('generated punctuation items are deterministic, unique, and family-scoped',
   assert.equal(new Set(first.map((item) => item.id)).size, first.length);
   assert.equal(first.every((item) => item.source === 'generated'), true);
   assert.equal(first.every((item) => item.generatorFamilyId), true);
+  assert.equal(first.every((item) => item.templateId), true);
+  assert.equal(first.every((item) => /^puncsig_[a-z0-9]+$/.test(item.variantSignature)), true);
   assert.notDeepEqual(differentSeed.map((item) => item.id), first.map((item) => item.id));
 });
 
+test('generated punctuation first variants preserve legacy runtime surfaces when banks expand', () => {
+  const baseline = createPunctuationGeneratedItems({ seed: 'legacy-runtime', perFamily: 1 });
+  const expanded = {
+    ...PUNCTUATION_CONTENT_MANIFEST,
+    generatorFamilies: PUNCTUATION_CONTENT_MANIFEST.generatorFamilies,
+  };
+  const after = createPunctuationGeneratedItems({ manifest: expanded, seed: 'legacy-runtime', perFamily: 1 });
+
+  assert.deepEqual(
+    after.map((item) => ({ id: item.id, stem: item.stem, model: item.model, templateId: item.templateId })),
+    baseline.map((item) => ({ id: item.id, stem: item.stem, model: item.model, templateId: item.templateId })),
+  );
+});
+
+test('generated punctuation signatures detect duplicate learner-visible surfaces', () => {
+  const items = createPunctuationGeneratedItems({ seed: 'signature', perFamily: 3 });
+  const clone = {
+    ...items[0],
+    id: `${items[0].id}_copy`,
+  };
+
+  assert.equal(clone.variantSignature, items[0].variantSignature);
+});
+
+test('expanded generated banks add distinct signatures after legacy variants', () => {
+  const targetFamilies = [
+    'gen_sentence_endings_insert',
+    'gen_apostrophe_contractions_fix',
+    'gen_comma_clarity_insert',
+    'gen_dash_clause_fix',
+    'gen_dash_clause_combine',
+    'gen_hyphen_insert',
+    'gen_semicolon_list_fix',
+  ];
+  const items = createPunctuationGeneratedItems({ seed: 'expanded-bank', perFamily: 4 });
+
+  for (const familyId of targetFamilies) {
+    const familyItems = items.filter((item) => item.generatorFamilyId === familyId);
+    assert.equal(familyItems.length, 4, familyId);
+    assert.equal(new Set(familyItems.map((item) => item.variantSignature)).size, 4, familyId);
+    assert.equal(new Set(familyItems.map((item) => item.templateId)).size, 4, familyId);
+  }
+});
+
 test('generated punctuation model answers pass deterministic marking', () => {
-  const generatedItems = createPunctuationGeneratedItems({ seed: 'marking-smoke', perFamily: 2 });
+  const generatedItems = createPunctuationGeneratedItems({ seed: 'marking-smoke', perFamily: 4 });
   for (const item of generatedItems) {
     const result = markPunctuationAnswer({ item, answer: { typed: item.model } });
     assert.equal(result.correct, true, item.id);

--- a/tests/punctuation-generators.test.js
+++ b/tests/punctuation-generators.test.js
@@ -12,6 +12,209 @@ import {
 import { markPunctuationAnswer } from '../shared/punctuation/marking.js';
 import { selectPunctuationItem } from '../shared/punctuation/scheduler.js';
 
+const LEGACY_RUNTIME_GENERATED_FIXTURE = Object.freeze([
+  {
+    id: 'gen_sentence_endings_insert_2skj48_1',
+    generatorFamilyId: 'gen_sentence_endings_insert',
+    stem: 'where is the tide bell',
+    model: 'Where is the tide bell?',
+    templateId: 'gen_sentence_endings_insert_template_xsusve',
+    variantSignature: 'puncsig_rqywyf',
+  },
+  {
+    id: 'gen_apostrophe_contractions_fix_1lwc3r9_1',
+    generatorFamilyId: 'gen_apostrophe_contractions_fix',
+    stem: 'Theyre sure we wont be late.',
+    model: "They're sure we won't be late.",
+    templateId: 'gen_apostrophe_contractions_fix_template_vcqv1j',
+    variantSignature: 'puncsig_1l2jy9t',
+  },
+  {
+    id: 'gen_apostrophe_possession_insert_7pl3be_1',
+    generatorFamilyId: 'gen_apostrophe_possession_insert',
+    stem: 'The captains whistle was beside the teams coats.',
+    model: "The captain's whistle was beside the team's coats.",
+    templateId: 'gen_apostrophe_possession_insert_template_100dwn',
+    variantSignature: 'puncsig_17nx2qt',
+  },
+  {
+    id: 'gen_apostrophe_mix_paragraph_16ngaez_1',
+    generatorFamilyId: 'gen_apostrophe_mix_paragraph',
+    stem: 'I cant find the mens boots. The boys jackets are drying.',
+    model: "I can't find the men's boots. The boys' jackets are drying.",
+    templateId: 'gen_apostrophe_mix_paragraph_template_1l5nlo5',
+    variantSignature: 'puncsig_aco1pd',
+  },
+  {
+    id: 'gen_speech_insert_1yxvgr8_1',
+    generatorFamilyId: 'gen_speech_insert',
+    stem: 'Maya asked, can we start now?',
+    model: 'Maya asked, "Can we start now?"',
+    templateId: 'gen_speech_insert_template_1s39sn2',
+    variantSignature: 'puncsig_xihz5d',
+  },
+  {
+    id: 'gen_list_commas_insert_1ge2lrh_1',
+    generatorFamilyId: 'gen_list_commas_insert',
+    stem: 'The box held shells bells and chalk.',
+    model: 'The box held shells, bells and chalk.',
+    templateId: 'gen_list_commas_insert_template_1xvy2rf',
+    variantSignature: 'puncsig_1aonvno',
+  },
+  {
+    id: 'gen_list_commas_combine_16m0xx5_1',
+    generatorFamilyId: 'gen_list_commas_combine',
+    stem: 'We collected\n- leaves\n- twigs\n- acorns',
+    model: 'We collected leaves, twigs and acorns.',
+    templateId: 'gen_list_commas_combine_template_qmva3q',
+    variantSignature: 'puncsig_1e11bmr',
+  },
+  {
+    id: 'gen_fronted_adverbial_fix_c1486l_1',
+    generatorFamilyId: 'gen_fronted_adverbial_fix',
+    stem: 'Before sunrise the crew checked the ropes.',
+    model: 'Before sunrise, the crew checked the ropes.',
+    templateId: 'gen_fronted_adverbial_fix_template_18k5e78',
+    variantSignature: 'puncsig_823nwf',
+  },
+  {
+    id: 'gen_fronted_adverbial_combine_1p2zww7_1',
+    generatorFamilyId: 'gen_fronted_adverbial_combine',
+    stem: 'After the rehearsal\nThe cast packed away the props.',
+    model: 'After the rehearsal, the cast packed away the props.',
+    templateId: 'gen_fronted_adverbial_combine_template_7tnqjq',
+    variantSignature: 'puncsig_5xqw3g',
+  },
+  {
+    id: 'gen_fronted_speech_paragraph_54jzze_1',
+    generatorFamilyId: 'gen_fronted_speech_paragraph',
+    stem: 'Before lunch Zara asked can we start now',
+    model: 'Before lunch, Zara asked, "Can we start now?"',
+    templateId: 'gen_fronted_speech_paragraph_template_ey0omc',
+    variantSignature: 'puncsig_145vp3p',
+  },
+  {
+    id: 'gen_comma_clarity_insert_1ka6sw6_1',
+    generatorFamilyId: 'gen_comma_clarity_insert',
+    stem: 'In the evening the harbour was quiet.',
+    model: 'In the evening, the harbour was quiet.',
+    templateId: 'gen_comma_clarity_insert_template_i1jwnt',
+    variantSignature: 'puncsig_1czkw5m',
+  },
+  {
+    id: 'gen_semicolon_fix_cpxxn3_1',
+    generatorFamilyId: 'gen_semicolon_fix',
+    stem: 'The rain eased, the match could continue.',
+    model: 'The rain eased; the match could continue.',
+    templateId: 'gen_semicolon_fix_template_s0pvzh',
+    variantSignature: 'puncsig_7av6n9',
+  },
+  {
+    id: 'gen_semicolon_combine_1po28rx_1',
+    generatorFamilyId: 'gen_semicolon_combine',
+    stem: 'The rain eased.\nThe match could continue.',
+    model: 'The rain eased; the match could continue.',
+    templateId: 'gen_semicolon_combine_template_1dp84xe',
+    variantSignature: 'puncsig_1n25ezp',
+  },
+  {
+    id: 'gen_colon_semicolon_paragraph_16u70qu_1',
+    generatorFamilyId: 'gen_colon_semicolon_paragraph',
+    stem: 'We needed three tools, a lantern, a compass and a notebook. The tide rose, the group moved inland.',
+    model: 'We needed three tools: a lantern, a compass and a notebook. The tide rose; the group moved inland.',
+    templateId: 'gen_colon_semicolon_paragraph_template_1mtafqy',
+    variantSignature: 'puncsig_1lx0h8v',
+  },
+  {
+    id: 'gen_dash_clause_fix_kwbiay_1',
+    generatorFamilyId: 'gen_dash_clause_fix',
+    stem: 'The gate was stuck we found another path.',
+    model: 'The gate was stuck - we found another path.',
+    templateId: 'gen_dash_clause_fix_template_11ejvfc',
+    variantSignature: 'puncsig_erog6d',
+  },
+  {
+    id: 'gen_dash_clause_combine_n82560_1',
+    generatorFamilyId: 'gen_dash_clause_combine',
+    stem: 'The gate was stuck.\nWe found another path.',
+    model: 'The gate was stuck - we found another path.',
+    templateId: 'gen_dash_clause_combine_template_1o45ea6',
+    variantSignature: 'puncsig_5qqk8w',
+  },
+  {
+    id: 'gen_hyphen_insert_1hy8roa_1',
+    generatorFamilyId: 'gen_hyphen_insert',
+    stem: 'The little used path was hidden.',
+    model: 'The little-used path was hidden.',
+    templateId: 'gen_hyphen_insert_template_1cjtd6l',
+    variantSignature: 'puncsig_1lmq2gq',
+  },
+  {
+    id: 'gen_parenthesis_fix_9wagle_1',
+    generatorFamilyId: 'gen_parenthesis_fix',
+    stem: 'The harbour, an old fishing port was busy.',
+    model: 'The harbour, an old fishing port, was busy.',
+    templateId: 'gen_parenthesis_fix_template_1afsvei',
+    variantSignature: 'puncsig_1c9v5hl',
+  },
+  {
+    id: 'gen_parenthesis_combine_16f6gao_1',
+    generatorFamilyId: 'gen_parenthesis_combine',
+    stem: 'The harbour was busy.\nExtra detail: an old fishing port',
+    model: 'The harbour, an old fishing port, was busy.',
+    templateId: 'gen_parenthesis_combine_template_zw0cs4',
+    variantSignature: 'puncsig_17xfcox',
+  },
+  {
+    id: 'gen_parenthesis_speech_paragraph_1qpmi5o_1',
+    generatorFamilyId: 'gen_parenthesis_speech_paragraph',
+    stem: 'The harbour an old fishing port was busy. Ravi said the bell is ringing',
+    model: 'The harbour, an old fishing port, was busy. Ravi said, "The bell is ringing."',
+    templateId: 'gen_parenthesis_speech_paragraph_template_188l1dz',
+    variantSignature: 'puncsig_1odmcb7',
+  },
+  {
+    id: 'gen_colon_list_insert_1paxk8a_1',
+    generatorFamilyId: 'gen_colon_list_insert',
+    stem: 'We needed three tools a torch, a rope and a map.',
+    model: 'We needed three tools: a torch, a rope and a map.',
+    templateId: 'gen_colon_list_insert_template_drw7oh',
+    variantSignature: 'puncsig_10m4u9s',
+  },
+  {
+    id: 'gen_colon_list_combine_1whlzxk_1',
+    generatorFamilyId: 'gen_colon_list_combine',
+    stem: 'We needed three tools\na torch / a rope / a map',
+    model: 'We needed three tools: a torch, a rope and a map.',
+    templateId: 'gen_colon_list_combine_template_lti8wz',
+    variantSignature: 'puncsig_k5t5fh',
+  },
+  {
+    id: 'gen_semicolon_list_fix_nhuyyk_1',
+    generatorFamilyId: 'gen_semicolon_list_fix',
+    stem: 'We visited Dover, England, Lyon, France and Porto, Portugal.',
+    model: 'We visited Dover, England; Lyon, France; and Porto, Portugal.',
+    templateId: 'gen_semicolon_list_fix_template_zurnf7',
+    variantSignature: 'puncsig_1gq3mzq',
+  },
+  {
+    id: 'gen_bullet_points_fix_1rwpig0_1',
+    generatorFamilyId: 'gen_bullet_points_fix',
+    stem: 'Bring:\n- a coat.\n- a torch\n- a notebook.',
+    model: 'Bring:\n- a coat.\n- a torch.\n- a notebook.',
+    templateId: 'gen_bullet_points_fix_template_3tfe0s',
+    variantSignature: 'puncsig_8wrlau',
+  },
+  {
+    id: 'gen_bullet_points_paragraph_ovdjqh_1',
+    generatorFamilyId: 'gen_bullet_points_paragraph',
+    stem: 'Bring\n- a coat.\n- a torch\n- a notebook.',
+    model: 'Bring:\n- a coat\n- a torch\n- a notebook',
+    templateId: 'gen_bullet_points_paragraph_template_1pn0ihi',
+    variantSignature: 'puncsig_1n9pc7n',
+  },
+]);
+
 test('generated punctuation items are deterministic, unique, and family-scoped', () => {
   const first = createPunctuationGeneratedItems({ seed: 'release-a', perFamily: 2 });
   const second = createPunctuationGeneratedItems({ seed: 'release-a', perFamily: 2 });
@@ -28,17 +231,20 @@ test('generated punctuation items are deterministic, unique, and family-scoped',
 });
 
 test('generated punctuation first variants preserve legacy runtime surfaces when banks expand', () => {
-  const baseline = createPunctuationGeneratedItems({ seed: 'legacy-runtime', perFamily: 1 });
-  const expanded = {
-    ...PUNCTUATION_CONTENT_MANIFEST,
-    generatorFamilies: PUNCTUATION_CONTENT_MANIFEST.generatorFamilies,
-  };
-  const after = createPunctuationGeneratedItems({ manifest: expanded, seed: 'legacy-runtime', perFamily: 1 });
+  const generated = createPunctuationGeneratedItems({ seed: 'legacy-runtime', perFamily: 1 });
 
   assert.deepEqual(
-    after.map((item) => ({ id: item.id, stem: item.stem, model: item.model, templateId: item.templateId })),
-    baseline.map((item) => ({ id: item.id, stem: item.stem, model: item.model, templateId: item.templateId })),
+    generated.map(({ id, generatorFamilyId, stem, model, templateId, variantSignature }) => ({
+      id,
+      generatorFamilyId,
+      stem,
+      model,
+      templateId,
+      variantSignature,
+    })),
+    LEGACY_RUNTIME_GENERATED_FIXTURE,
   );
+  assert.equal(generated.every((item) => !/_template_\\d+$/.test(item.templateId)), true);
 });
 
 test('generated punctuation signatures detect duplicate learner-visible surfaces', () => {

--- a/tests/punctuation-gps.test.js
+++ b/tests/punctuation-gps.test.js
@@ -224,6 +224,7 @@ test('gps completion releases review rows and then writes learning evidence', ()
   assert.equal(finished.state.summary.gps.reviewItems.length, 3);
   assert.equal(finished.state.summary.gps.reviewItems[1].correct, false);
   assert.equal(finished.state.summary.gps.reviewItems[1].displayCorrection.length > 0, true);
+  assert.equal(finished.state.summary.gps.reviewItems.every((entry) => !('variantSignature' in entry)), true);
   assert.equal(finished.state.summary.gps.recommendedMode, 'weak');
   assert.equal(finished.events.filter((event) => event.type === PUNCTUATION_EVENT_TYPES.ITEM_ATTEMPTED).length, 3);
   assert.equal(finished.events.some((event) => event.type === PUNCTUATION_EVENT_TYPES.SESSION_COMPLETED), true);

--- a/tests/punctuation-marking.test.js
+++ b/tests/punctuation-marking.test.js
@@ -120,8 +120,22 @@ test('comma list transfer requires preserved items and KS2 list comma placement'
     item: item('lc_transfer_trip'),
     answer: { typed: 'For the trip, we packed torches, maps, and water.' },
   });
-  assert.equal(finalComma.correct, false);
-  assert.equal(finalComma.misconceptionTags.includes('comma.unnecessary_final_comma'), true);
+  assert.equal(finalComma.correct, true);
+  assert.deepEqual(finalComma.misconceptionTags, []);
+
+  const strictListItem = {
+    ...item('lc_transfer_trip'),
+    validator: {
+      ...item('lc_transfer_trip').validator,
+      allowFinalComma: false,
+    },
+  };
+  const strictFinalComma = markPunctuationAnswer({
+    item: strictListItem,
+    answer: { typed: 'For the trip, we packed torches, maps, and water.' },
+  });
+  assert.equal(strictFinalComma.correct, false);
+  assert.equal(strictFinalComma.misconceptionTags.includes('comma.unnecessary_final_comma'), true);
 
   const anchored = markPunctuationAnswer({
     item: item('lc_transfer_bake_sale'),
@@ -193,6 +207,17 @@ test('boundary transfer validators require target marks between preserved clause
     answer: { typed: 'The path was flooded - we took the longer route.' },
   });
   assert.equal(dash.correct, true);
+
+  for (const typed of [
+    'The path was flooded – we took the longer route.',
+    'The path was flooded — we took the longer route.',
+  ]) {
+    const variant = markPunctuationAnswer({
+      item: item('dc_transfer_flooded_route'),
+      answer: { typed },
+    });
+    assert.equal(variant.correct, true, typed);
+  }
 
   const missingDash = markPunctuationAnswer({
     item: item('dc_transfer_flooded_route'),
@@ -311,8 +336,22 @@ test('mixed transfer validators constrain fronted speech and colon-list stems', 
     item: item('cl_lc_transfer_toolkit'),
     answer: { typed: 'Our toolkit contained three items: glue, card, and scissors.' },
   });
-  assert.equal(finalComma.correct, false);
-  assert.equal(finalComma.misconceptionTags.includes('comma.unnecessary_final_comma'), true);
+  assert.equal(finalComma.correct, true);
+  assert.deepEqual(finalComma.misconceptionTags, []);
+
+  const strictColonListItem = {
+    ...item('cl_lc_transfer_toolkit'),
+    validator: {
+      ...item('cl_lc_transfer_toolkit').validator,
+      allowFinalComma: false,
+    },
+  };
+  const strictFinalComma = markPunctuationAnswer({
+    item: strictColonListItem,
+    answer: { typed: 'Our toolkit contained three items: glue, card, and scissors.' },
+  });
+  assert.equal(strictFinalComma.correct, false);
+  assert.equal(strictFinalComma.misconceptionTags.includes('comma.unnecessary_final_comma'), true);
 });
 
 test('structure transfer validators require explicit punctuation roles', () => {

--- a/tests/punctuation-scheduler.test.js
+++ b/tests/punctuation-scheduler.test.js
@@ -86,6 +86,44 @@ test('weak mode avoids repeating a recent item when another weak alternative exi
   assert.equal(result.weakFocus.source, 'weak_facet');
 });
 
+test('scheduler suppresses recently seen generated variant signatures', () => {
+  const signatureItem = (id, variantSignature) => ({
+    id,
+    mode: 'choose',
+    skillIds: ['sentence_endings'],
+    clusterId: 'endmarks',
+    rewardUnitId: 'sentence-endings-core',
+    prompt: 'Choose the best punctuated sentence.',
+    options: [{ text: 'Where is the tide bell?', index: 0 }, { text: 'where is the tide bell', index: 1 }],
+    correctIndex: 0,
+    explanation: 'Capitalise the first word and use a question mark.',
+    model: 'Where is the tide bell?',
+    source: 'generated',
+    variantSignature,
+  });
+  const previous = signatureItem('generated_previous_same', 'puncsig_same');
+  const sameSignature = signatureItem('generated_same_signature', 'puncsig_same');
+  const differentSignature = signatureItem('generated_different_signature', 'puncsig_different');
+  const items = [sameSignature, differentSignature, previous];
+  const indexes = {
+    items,
+    itemById: new Map(items.map((item) => [item.id, item])),
+    itemsByMode: new Map([['choose', [sameSignature, differentSignature]]]),
+    skillById: new Map([['sentence_endings', { id: 'sentence_endings', name: 'Capital letters and sentence endings', published: true }]]),
+  };
+
+  const result = selectPunctuationItem({
+    indexes,
+    progress: { items: {}, facets: {}, rewardUnits: {}, attempts: [], sessionsCompleted: 0 },
+    session: { answeredCount: 0, recentItemIds: [previous.id] },
+    prefs: { mode: 'smart' },
+    now: 0,
+    random: () => 0.2,
+  });
+
+  assert.equal(result.item.id, differentSignature.id);
+});
+
 test('weak mode falls back to mixed review when no weak evidence exists', () => {
   const result = selectPunctuationItem({
     progress: { items: {}, facets: {}, rewardUnits: {}, attempts: [], sessionsCompleted: 0 },

--- a/tests/punctuation-scheduler.test.js
+++ b/tests/punctuation-scheduler.test.js
@@ -86,7 +86,7 @@ test('weak mode avoids repeating a recent item when another weak alternative exi
   assert.equal(result.weakFocus.source, 'weak_facet');
 });
 
-test('scheduler suppresses recently seen generated variant signatures', () => {
+test('scheduler avoids recently seen generated variant signatures when alternatives exist', () => {
   const signatureItem = (id, variantSignature) => ({
     id,
     mode: 'choose',
@@ -112,16 +112,18 @@ test('scheduler suppresses recently seen generated variant signatures', () => {
     skillById: new Map([['sentence_endings', { id: 'sentence_endings', name: 'Capital letters and sentence endings', published: true }]]),
   };
 
-  const result = selectPunctuationItem({
-    indexes,
-    progress: { items: {}, facets: {}, rewardUnits: {}, attempts: [], sessionsCompleted: 0 },
-    session: { answeredCount: 0, recentItemIds: [previous.id] },
-    prefs: { mode: 'smart' },
-    now: 0,
-    random: () => 0.2,
-  });
+  for (const randomValue of [0, 0.05, 0.2, 0.99]) {
+    const result = selectPunctuationItem({
+      indexes,
+      progress: { items: {}, facets: {}, rewardUnits: {}, attempts: [], sessionsCompleted: 0 },
+      session: { answeredCount: 0, recentItemIds: [previous.id] },
+      prefs: { mode: 'smart' },
+      now: 0,
+      random: () => randomValue,
+    });
 
-  assert.equal(result.item.id, differentSignature.id);
+    assert.equal(result.item.id, differentSignature.id, `random=${randomValue}`);
+  }
 });
 
 test('weak mode falls back to mixed review when no weak evidence exists', () => {

--- a/tests/punctuation-service.test.js
+++ b/tests/punctuation-service.test.js
@@ -8,6 +8,7 @@ import {
   PUNCTUATION_RELEASE_ID,
 } from '../shared/punctuation/content.js';
 import { PUNCTUATION_EVENT_TYPES } from '../shared/punctuation/events.js';
+import { createPunctuationRuntimeManifest } from '../shared/punctuation/generators.js';
 import { createMemoryState, updateMemoryState } from '../shared/punctuation/scheduler.js';
 import { createPunctuationService, PunctuationServiceError } from '../shared/punctuation/service.js';
 import { projectPunctuationStars } from '../src/subjects/punctuation/star-projection.js';
@@ -81,6 +82,33 @@ test('punctuation service uses injected randomness for stable session ids and ge
 
   assert.equal(secondStart.session.id, firstStart.session.id);
   assert.equal(firstGenerated.session.currentItem.source, 'generated');
+});
+
+test('punctuation service carries generated variant signatures into state and attempts', () => {
+  const manifest = createPunctuationRuntimeManifest({
+    seed: 'service-signature',
+    generatedPerFamily: 1,
+  });
+  const repository = makeRepository();
+  const service = createPunctuationService({
+    repository,
+    now: () => 1_800_000_000_000,
+    random: () => 0.99,
+    manifest,
+    indexes: createPunctuationContentIndexes(manifest),
+  });
+  const start = service.startSession('learner-a', { mode: 'endmarks', roundLength: '2' }).state;
+  const first = service.submitAnswer('learner-a', start, correctAnswerFor(start.session.currentItem)).state;
+  const generated = service.continueSession('learner-a', first).state;
+
+  assert.equal(generated.session.currentItem.source, 'generated');
+  assert.match(generated.session.currentItem.variantSignature, /^puncsig_[a-z0-9]+$/);
+
+  const submitted = service.submitAnswer('learner-a', generated, correctAnswerFor(generated.session.currentItem));
+  const attempt = repository.snapshot().data.progress.attempts.at(-1);
+  const event = submitted.events.find((entry) => entry.type === PUNCTUATION_EVENT_TYPES.ITEM_ATTEMPTED);
+  assert.equal(attempt.variantSignature, generated.session.currentItem.variantSignature);
+  assert.equal(event.variantSignature, generated.session.currentItem.variantSignature);
 });
 
 test('punctuation service emits misconception events and serialisable feedback', () => {

--- a/tests/punctuation-star-projection.test.js
+++ b/tests/punctuation-star-projection.test.js
@@ -210,6 +210,31 @@ test('10 same-item repeated attempts — Try/Practice Stars capped', () => {
   assert.ok(pealark.practiceStars <= 5, `Practice Stars should be capped for single item, got ${pealark.practiceStars}`);
 });
 
+test('generated variant signatures group equivalent surfaces for Try evidence', () => {
+  const progress = freshProgress();
+  progress.attempts.push(makeAttempt({
+    itemId: 'generated_sentence_1',
+    variantSignature: 'puncsig_equivalent',
+    skillIds: ['sentence_endings'],
+    correct: true,
+  }));
+  progress.attempts.push(makeAttempt({
+    itemId: 'generated_sentence_2',
+    variantSignature: 'puncsig_equivalent',
+    skillIds: ['sentence_endings'],
+    correct: true,
+  }));
+  progress.attempts.push(makeAttempt({
+    itemId: 'generated_sentence_3',
+    variantSignature: 'puncsig_distinct',
+    skillIds: ['sentence_endings'],
+    correct: true,
+  }));
+
+  const result = projectPunctuationStars(progress, CURRENT_RELEASE_ID);
+  assert.equal(result.perMonster.pealark.tryStars, 2);
+});
+
 test('supported-only answers (supportLevel > 0) — Try/Practice only, Secure/Mastery blocked', () => {
   const progress = freshProgress();
 

--- a/tests/punctuation-star-projection.test.js
+++ b/tests/punctuation-star-projection.test.js
@@ -235,6 +235,52 @@ test('generated variant signatures group equivalent surfaces for Try evidence', 
   assert.equal(result.perMonster.pealark.tryStars, 2);
 });
 
+test('legacy unsigned attempts coalesce with signed attempts for the same generated item', () => {
+  const progress = freshProgress();
+  for (let i = 0; i < 3; i++) {
+    progress.attempts.push(makeAttempt({
+      ts: Date.UTC(2026, 3, 20 + i, 10, 0, 0),
+      itemId: 'generated_sentence_legacy',
+      skillIds: ['sentence_endings'],
+      correct: true,
+    }));
+  }
+  for (let i = 0; i < 3; i++) {
+    progress.attempts.push(makeAttempt({
+      ts: Date.UTC(2026, 3, 23 + i, 10, 0, 0),
+      itemId: 'generated_sentence_legacy',
+      variantSignature: 'puncsig_legacy_surface',
+      skillIds: ['sentence_endings'],
+      correct: true,
+    }));
+  }
+
+  const result = projectPunctuationStars(progress, CURRENT_RELEASE_ID);
+  assert.equal(result.perMonster.pealark.tryStars, 3);
+  assert.equal(result.perMonster.pealark.practiceStars, 3);
+});
+
+test('secure Stars dedupe generated items with the same variant signature', () => {
+  const progress = freshProgress();
+  progress.items.generated_sentence_a = secureItemState();
+  progress.items.generated_sentence_b = secureItemState();
+  progress.attempts.push(makeAttempt({
+    itemId: 'generated_sentence_a',
+    variantSignature: 'puncsig_same_surface',
+    skillIds: ['sentence_endings'],
+    correct: true,
+  }));
+  progress.attempts.push(makeAttempt({
+    itemId: 'generated_sentence_b',
+    variantSignature: 'puncsig_same_surface',
+    skillIds: ['sentence_endings'],
+    correct: true,
+  }));
+
+  const result = projectPunctuationStars(progress, CURRENT_RELEASE_ID);
+  assert.equal(result.perMonster.pealark.secureStars, 2);
+});
+
 test('supported-only answers (supportLevel > 0) — Try/Practice only, Secure/Mastery blocked', () => {
   const progress = freshProgress();
 


### PR DESCRIPTION
## Summary

- Add a repo-native Punctuation content audit and package script for generated-bank coverage, duplicate-signature detection, validator coverage, and generated model-answer marking.
- Stabilise generated item identity with `templateId` and opaque `variantSignature`, preserving legacy first-variant runtime surfaces.
- Expand every published generator family to four unique generated signatures while keeping production runtime at `generatedPerFamily: 1`.
- Carry signatures through internal attempt/event evidence, hard-avoid recent equivalent signatures in the scheduler, and coalesce legacy unsigned attempts for Star caps.
- Keep learner-facing GPS summaries free of internal `variantSignature` details and mark the implementation plan complete.

## Review Follow-Up

- Fixed mixed legacy/new Star cap bypass by aliasing unsigned attempts to the signed evidence key for the same generated item.
- Fixed Secure Star over-counting by deduping secure item evidence by signature where available.
- Made `--strict --generated-per-family 4` fail duplicate generated variant signatures; `--generated-per-family 5` now fails as an over-capacity tripwire.
- Converted scheduler same-signature handling from a soft weight penalty to a hard avoid-when-alternative-exists filter.
- Removed `variantSignature` from GPS delayed-review rows.

## Verification

- `node --test tests/punctuation-generators.test.js tests/punctuation-content-audit.test.js tests/punctuation-scheduler.test.js tests/punctuation-star-projection.test.js tests/punctuation-gps.test.js tests/punctuation-service.test.js tests/worker-punctuation-runtime.test.js` (135 pass)
- `npm run audit:punctuation-content -- --strict --generated-per-family 4`
- `npm test` (5765 pass, 0 fail, 6 skipped)
- `npm run check`
- `git diff --check origin/main...HEAD && git diff --check`
- Final independent reviewer: no blockers; targeted tests 93/93; strict audit at 4 passed and at 5 correctly failed duplicate signatures