### PR TITLE
fix(punctuation): scope stars to current release

### DIFF
--- a/src/subjects/punctuation/read-model.js
+++ b/src/subjects/punctuation/read-model.js
@@ -1,8 +1,7 @@
-import { projectPunctuationStars } from './star-projection.js';
+import { currentReleaseRewardEntries, projectPunctuationStars } from './star-projection.js';
 import { stageFor, PUNCTUATION_STAR_THRESHOLDS, PUNCTUATION_GRAND_STAR_THRESHOLDS } from '../../platform/game/monsters.js';
 import {
   PUNCTUATION_CLIENT_SKILLS,
-  PUNCTUATION_CLIENT_REWARD_UNITS,
 } from './punctuation-manifest.js';
 
 export { PUNCTUATION_CLIENT_SKILLS };
@@ -11,14 +10,6 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 const CURRENT_RELEASE_ID = 'punctuation-r4-full-14-skill-structure';
 const TOTAL_REWARD_UNITS = 14;
 const DAILY_TARGET_ATTEMPTS = 4;
-
-function clientMasteryKey({ clusterId, rewardUnitId } = {}) {
-  return `punctuation:${CURRENT_RELEASE_ID}:${clusterId}:${rewardUnitId}`;
-}
-
-const PUNCTUATION_CLIENT_REWARD_UNIT_KEYS = new Set(
-  PUNCTUATION_CLIENT_REWARD_UNITS.map(clientMasteryKey),
-);
 
 const ITEM_MODE_LABELS = Object.freeze({
   choose: 'Choice',
@@ -152,17 +143,6 @@ function normaliseAttempt(rawValue) {
       }))
       .filter((facet) => facet.id),
   };
-}
-
-function currentPublishedRewardUnits(rewardUnits) {
-  const rows = new Map();
-  for (const [key, value] of Object.entries(isPlainObject(rewardUnits) ? rewardUnits : {})) {
-    if (!isPlainObject(value)) continue;
-    const masteryKey = typeof value.masteryKey === 'string' && value.masteryKey ? value.masteryKey : key;
-    if (!PUNCTUATION_CLIENT_REWARD_UNIT_KEYS.has(masteryKey)) continue;
-    rows.set(masteryKey, value);
-  }
-  return [...rows.values()];
 }
 
 function groupAttemptAccuracy(attempts, keyFn, labelFn) {
@@ -406,7 +386,7 @@ export function buildPunctuationLearnerReadModel({
   const secureItems = itemSnapshots.filter((entry) => entry.bucket === 'secure').length;
   const dueItems = itemSnapshots.filter((entry) => entry.bucket === 'due').length;
   const weakItems = itemSnapshots.filter((entry) => entry.bucket === 'weak').length;
-  const trackedRewardUnitEntries = currentPublishedRewardUnits(rewardUnits);
+  const trackedRewardUnitEntries = currentReleaseRewardEntries(rewardUnits, CURRENT_RELEASE_ID);
   const trackedRewardUnitCount = trackedRewardUnitEntries.length;
   const securedRewardUnitCount = trackedRewardUnitEntries.filter(
     (entry) => asTs(entry.securedAt, 0) > 0,

--- a/src/subjects/punctuation/star-projection.js
+++ b/src/subjects/punctuation/star-projection.js
@@ -184,6 +184,47 @@ function normaliseAttempts(rawAttempts) {
   }));
 }
 
+function normaliseReleaseId(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : '';
+}
+
+function releaseIdFromMasteryKey(masteryKey) {
+  if (typeof masteryKey !== 'string' || !masteryKey) return '';
+  const parts = masteryKey.split(':');
+  if (parts.length < 4 || parts[0] !== 'punctuation') return '';
+  return normaliseReleaseId(parts[1]);
+}
+
+function rewardEntryMasteryKey(storageKey, entry) {
+  if (typeof entry.masteryKey === 'string' && entry.masteryKey) return entry.masteryKey;
+  return typeof storageKey === 'string' && storageKey ? storageKey : '';
+}
+
+function isCurrentReleaseRewardEntry(storageKey, entry, releaseId) {
+  const currentReleaseId = normaliseReleaseId(releaseId);
+  if (!currentReleaseId) return false;
+
+  const explicitReleaseId = normaliseReleaseId(entry.releaseId);
+  const masteryKeyReleaseId = releaseIdFromMasteryKey(rewardEntryMasteryKey(storageKey, entry));
+
+  if (explicitReleaseId) {
+    if (masteryKeyReleaseId && masteryKeyReleaseId !== explicitReleaseId) return false;
+    return explicitReleaseId === currentReleaseId;
+  }
+
+  return masteryKeyReleaseId === currentReleaseId;
+}
+
+function currentReleaseRewardEntries(rewardUnits, releaseId) {
+  const rows = new Map();
+  for (const [storageKey, entry] of Object.entries(isPlainObject(rewardUnits) ? rewardUnits : {})) {
+    if (!isPlainObject(entry)) continue;
+    if (!isCurrentReleaseRewardEntry(storageKey, entry, releaseId)) continue;
+    rows.set(rewardEntryMasteryKey(storageKey, entry) || storageKey, entry);
+  }
+  return [...rows.values()];
+}
+
 // ---------------------------------------------------------------------------
 // Per-monster Star computations
 // ---------------------------------------------------------------------------
@@ -295,7 +336,7 @@ function computePracticeStars(monsterAttempts) {
   return Math.min(PRACTICE_CAP, Math.floor(rawScore));
 }
 
-function computeSecureStars(monsterClusterIds, items, rewardUnits, releaseId, monsterId, itemSignatureAliases) {
+function computeSecureStars(monsterClusterIds, items, rewardUnitEntries, monsterId, itemSignatureAliases) {
   // Count items that have reached the secure bucket.
   const secureEvidenceKeys = new Set();
   const itemEntries = isPlainObject(items) ? items : {};
@@ -309,8 +350,7 @@ function computeSecureStars(monsterClusterIds, items, rewardUnits, releaseId, mo
 
   // Count secured reward units for this monster's clusters.
   let securedUnitCount = 0;
-  const rewardEntries = isPlainObject(rewardUnits) ? rewardUnits : {};
-  for (const [, entry] of Object.entries(rewardEntries)) {
+  for (const entry of rewardUnitEntries) {
     if (!isPlainObject(entry)) continue;
     const entryClusterId = typeof entry.clusterId === 'string' ? entry.clusterId : '';
     if (!monsterClusterIds.has(entryClusterId)) continue;
@@ -328,13 +368,12 @@ function computeSecureStars(monsterClusterIds, items, rewardUnits, releaseId, mo
   return Math.min(SECURE_CAP, Math.round(rawScore));
 }
 
-function computeMasteryStars(monsterClusterIds, facets, rewardUnits, monsterId) {
+function computeMasteryStars(monsterClusterIds, facets, rewardUnitEntries, monsterId) {
   // Mastery requires deep-secure evidence:
   //   - Secured reward units with facet coverage across multiple item modes
   //   - No recent lapse in any facet for this cluster
 
   const facetEntries = isPlainObject(facets) ? facets : {};
-  const rewardEntries = isPlainObject(rewardUnits) ? rewardUnits : {};
 
   // Check for recent lapse in any facet belonging to this monster's clusters.
   let hasRecentLapse = false;
@@ -372,7 +411,7 @@ function computeMasteryStars(monsterClusterIds, facets, rewardUnits, monsterId) 
 
   // Count secured units for this monster's clusters.
   let securedUnitCount = 0;
-  for (const [, entry] of Object.entries(rewardEntries)) {
+  for (const entry of rewardUnitEntries) {
     if (!isPlainObject(entry)) continue;
     const entryClusterId = typeof entry.clusterId === 'string' ? entry.clusterId : '';
     if (!monsterClusterIds.has(entryClusterId)) continue;
@@ -510,15 +549,14 @@ const GRAND_TIERS = Object.freeze([
 // Total reward units across all clusters.
 const TOTAL_REWARD_UNITS = 14;
 
-function computeGrandStars(progress, releaseId) {
-  const rewardEntries = isPlainObject(progress.rewardUnits) ? progress.rewardUnits : {};
+function computeGrandStars(progress, rewardUnitEntries) {
   const facetEntries = isPlainObject(progress.facets) ? progress.facets : {};
 
   // Count total secured units and deep-secured units across all clusters.
   let totalSecured = 0;
   const monstersWithSecured = new Set();
 
-  for (const [, entry] of Object.entries(rewardEntries)) {
+  for (const entry of rewardUnitEntries) {
     if (!isPlainObject(entry)) continue;
     const securedAt = Number(entry.securedAt);
     if (!Number.isFinite(securedAt) || securedAt <= 0) continue;
@@ -636,6 +674,7 @@ export function projectPunctuationStars(progress, releaseId, options) {
   const rawAttempts = Array.isArray(safeProgress.attempts) ? safeProgress.attempts : [];
   const attempts = normaliseAttempts(rawAttempts);
   const itemSignatureAliases = itemVariantSignatureAliasMap(attempts);
+  const rewardUnitEntries = currentReleaseRewardEntries(rewardUnits, releaseId);
 
   // Build per-monster attempt arrays.
   const monsterAttempts = new Map();
@@ -661,8 +700,8 @@ export function projectPunctuationStars(progress, releaseId, options) {
 
     const tryStars = computeTryStars(mAttempts);
     const practiceStars = computePracticeStars(mAttempts);
-    const secureStars = computeSecureStars(clusterIds, mItems, rewardUnits, releaseId, monsterId, itemSignatureAliases);
-    const masteryStars = computeMasteryStars(clusterIds, facets, rewardUnits, monsterId);
+    const secureStars = computeSecureStars(clusterIds, mItems, rewardUnitEntries, monsterId, itemSignatureAliases);
+    const masteryStars = computeMasteryStars(clusterIds, facets, rewardUnitEntries, monsterId);
     const total = tryStars + practiceStars + secureStars + masteryStars;
 
     perMonster[monsterId] = {
@@ -675,7 +714,7 @@ export function projectPunctuationStars(progress, releaseId, options) {
   }
 
   // Grand Stars.
-  const grand = computeGrandStars(safeProgress, releaseId);
+  const grand = computeGrandStars(safeProgress, rewardUnitEntries);
 
   const result = { perMonster, grand };
 

--- a/src/subjects/punctuation/star-projection.js
+++ b/src/subjects/punctuation/star-projection.js
@@ -20,6 +20,7 @@ import {
   CLASPIN_REQUIRED_SKILLS,
   SKILL_TO_CLUSTER,
   RU_TO_CLUSTERS,
+  PUNCTUATION_CLIENT_REWARD_UNITS,
   MONSTER_CLUSTERS,
   MONSTER_UNIT_COUNT,
   DIRECT_PUNCTUATION_MONSTER_IDS,
@@ -188,41 +189,140 @@ function normaliseReleaseId(value) {
   return typeof value === 'string' && value.trim() ? value.trim() : '';
 }
 
-function releaseIdFromMasteryKey(masteryKey) {
-  if (typeof masteryKey !== 'string' || !masteryKey) return '';
-  const parts = masteryKey.split(':');
-  if (parts.length < 4 || parts[0] !== 'punctuation') return '';
-  return normaliseReleaseId(parts[1]);
+function exactString(value) {
+  return typeof value === 'string' && value && value === value.trim() ? value : '';
 }
 
-function rewardEntryMasteryKey(storageKey, entry) {
-  if (typeof entry.masteryKey === 'string' && entry.masteryKey) return entry.masteryKey;
-  return typeof storageKey === 'string' && storageKey ? storageKey : '';
+function canonicalRewardUnitKey(releaseId, clusterId, rewardUnitId) {
+  return `punctuation:${releaseId}:${clusterId}:${rewardUnitId}`;
 }
 
-function isCurrentReleaseRewardEntry(storageKey, entry, releaseId) {
+function publishedRewardUnitByKey(releaseId) {
   const currentReleaseId = normaliseReleaseId(releaseId);
-  if (!currentReleaseId) return false;
+  const rows = new Map();
+  if (!currentReleaseId) return rows;
+  for (const unit of PUNCTUATION_CLIENT_REWARD_UNITS) {
+    rows.set(
+      canonicalRewardUnitKey(currentReleaseId, unit.clusterId, unit.rewardUnitId),
+      unit,
+    );
+  }
+  return rows;
+}
 
-  const explicitReleaseId = normaliseReleaseId(entry.releaseId);
-  const masteryKeyReleaseId = releaseIdFromMasteryKey(rewardEntryMasteryKey(storageKey, entry));
+export function parsePunctuationRewardMasteryKey(masteryKey) {
+  if (!exactString(masteryKey)) return null;
+  const parts = masteryKey.split(':');
+  if (parts.length !== 4 || parts[0] !== 'punctuation') return null;
+  const [, releaseId, clusterId, rewardUnitId] = parts;
+  if (!releaseId || !clusterId || !rewardUnitId) return null;
+  return {
+    releaseId,
+    clusterId,
+    rewardUnitId,
+    canonicalKey: masteryKey,
+  };
+}
 
-  if (explicitReleaseId) {
-    if (masteryKeyReleaseId && masteryKeyReleaseId !== explicitReleaseId) return false;
-    return explicitReleaseId === currentReleaseId;
+function parseMaybePunctuationKey(value) {
+  if (typeof value !== 'string' || !value) return { parsed: null, malformed: false };
+  if (value !== value.trim()) {
+    return { parsed: null, malformed: value.trim().startsWith('punctuation:') };
+  }
+  if (!value.startsWith('punctuation:')) return { parsed: null, malformed: false };
+  const parsed = parsePunctuationRewardMasteryKey(value);
+  return { parsed, malformed: parsed == null };
+}
+
+function metadataValue(entry, key) {
+  return typeof entry[key] === 'string' && entry[key] ? entry[key] : '';
+}
+
+function canonicalUnitForMetadata(publishedUnits, releaseId, entry) {
+  const clusterId = metadataValue(entry, 'clusterId');
+  const rewardUnitId = metadataValue(entry, 'rewardUnitId');
+  if (!clusterId || !rewardUnitId) return null;
+  const canonicalKey = canonicalRewardUnitKey(releaseId, clusterId, rewardUnitId);
+  const unit = publishedUnits.get(canonicalKey);
+  return unit ? { unit, canonicalKey } : null;
+}
+
+function canonicalUnitForParsedKey(publishedUnits, parsed) {
+  if (!parsed) return null;
+  const unit = publishedUnits.get(parsed.canonicalKey);
+  return unit ? { unit, canonicalKey: parsed.canonicalKey } : null;
+}
+
+function parsedKeyMatchesMetadata(parsed, entry) {
+  if (!parsed) return true;
+  const clusterId = metadataValue(entry, 'clusterId');
+  const rewardUnitId = metadataValue(entry, 'rewardUnitId');
+  if (clusterId && clusterId !== parsed.clusterId) return false;
+  if (rewardUnitId && rewardUnitId !== parsed.rewardUnitId) return false;
+  return true;
+}
+
+function canonicalCurrentReleaseRewardEntry(storageKey, entry, releaseId, publishedUnits) {
+  const currentReleaseId = normaliseReleaseId(releaseId);
+  if (!currentReleaseId) return null;
+
+  const storage = typeof storageKey === 'string' ? storageKey : '';
+  const masteryKey = typeof entry.masteryKey === 'string' ? entry.masteryKey : '';
+  const storageKeyParse = parseMaybePunctuationKey(storage);
+  const entryKey = parseMaybePunctuationKey(masteryKey);
+  if (storageKeyParse.malformed || entryKey.malformed) return null;
+
+  if (
+    storageKeyParse.parsed &&
+    entryKey.parsed &&
+    storageKeyParse.parsed.canonicalKey !== entryKey.parsed.canonicalKey
+  ) {
+    return null;
   }
 
-  return masteryKeyReleaseId === currentReleaseId;
+  const parsed = entryKey.parsed || storageKeyParse.parsed;
+  const explicitReleaseId = normaliseReleaseId(entry.releaseId);
+
+  if (explicitReleaseId && explicitReleaseId !== currentReleaseId) return null;
+  if (parsed && parsed.releaseId !== currentReleaseId) return null;
+  if (!parsedKeyMatchesMetadata(parsed, entry)) return null;
+
+  const parsedCanonical = canonicalUnitForParsedKey(publishedUnits, parsed);
+  const metadataCanonical = canonicalUnitForMetadata(publishedUnits, currentReleaseId, entry);
+
+  if (parsedCanonical && metadataCanonical && parsedCanonical.canonicalKey !== metadataCanonical.canonicalKey) {
+    return null;
+  }
+
+  const canonical = parsedCanonical || metadataCanonical;
+  if (!canonical) return null;
+  if (!explicitReleaseId && !parsedCanonical) return null;
+
+  return {
+    ...entry,
+    masteryKey: canonical.canonicalKey,
+    releaseId: currentReleaseId,
+    clusterId: canonical.unit.clusterId,
+    rewardUnitId: canonical.unit.rewardUnitId,
+  };
 }
 
-function currentReleaseRewardEntries(rewardUnits, releaseId) {
+export function currentReleaseRewardEntries(rewardUnits, releaseId) {
+  const publishedUnits = publishedRewardUnitByKey(releaseId);
   const rows = new Map();
   for (const [storageKey, entry] of Object.entries(isPlainObject(rewardUnits) ? rewardUnits : {})) {
     if (!isPlainObject(entry)) continue;
-    if (!isCurrentReleaseRewardEntry(storageKey, entry, releaseId)) continue;
-    rows.set(rewardEntryMasteryKey(storageKey, entry) || storageKey, entry);
+    const canonicalEntry = canonicalCurrentReleaseRewardEntry(storageKey, entry, releaseId, publishedUnits);
+    if (!canonicalEntry) continue;
+    const hasExactKey =
+      exactString(storageKey) === canonicalEntry.masteryKey ||
+      exactString(entry.masteryKey) === canonicalEntry.masteryKey;
+    const existing = rows.get(canonicalEntry.masteryKey);
+    if (!existing || (hasExactKey && !existing.hasExactKey)) {
+      rows.set(canonicalEntry.masteryKey, { entry: canonicalEntry, hasExactKey });
+    }
   }
-  return [...rows.values()];
+  return [...rows.values()].map((row) => row.entry);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/punctuation-read-model.test.js
+++ b/tests/punctuation-read-model.test.js
@@ -123,6 +123,32 @@ test('old-release reward units do not inflate current starView through the read-
   assert.equal(model.starView.grand.grandStars, 0);
 });
 
+test('mismatched current storage key and old release metadata do not split counters from starView', () => {
+  const now = Date.UTC(2026, 3, 25);
+  const subjectState = freshSubjectState();
+  const currentStorageKey = masteryKey('endmarks', 'sentence-endings-core');
+  subjectState.data.progress.rewardUnits[currentStorageKey] = {
+    releaseId: OLD_RELEASE_ID,
+    clusterId: 'endmarks',
+    rewardUnitId: 'sentence-endings-core',
+    securedAt: now - 10_000,
+  };
+
+  const model = buildPunctuationLearnerReadModel({
+    subjectStateRecord: subjectState,
+    practiceSessions: [],
+    now: () => now,
+  });
+
+  assert.equal(model.progressSnapshot.trackedRewardUnits, 0);
+  assert.equal(model.progressSnapshot.securedRewardUnits, 0);
+  assert.equal(model.overview.securedRewardUnits, 0);
+  assert.equal(model.releaseDiagnostics.trackedRewardUnitCount, 0);
+  assert.equal(model.starView.perMonster.pealark.secureStars, 0);
+  assert.equal(model.starView.perMonster.pealark.total, 0);
+  assert.equal(model.starView.grand.grandStars, 0);
+});
+
 test('hasEvidence is true when sessions exist even with zero attempts', () => {
   const now = Date.UTC(2026, 3, 25);
   const model = buildPunctuationLearnerReadModel({

--- a/tests/punctuation-read-model.test.js
+++ b/tests/punctuation-read-model.test.js
@@ -4,9 +4,14 @@ import assert from 'node:assert/strict';
 import { buildPunctuationLearnerReadModel } from '../src/subjects/punctuation/read-model.js';
 
 const CURRENT_RELEASE_ID = 'punctuation-r4-full-14-skill-structure';
+const OLD_RELEASE_ID = 'punctuation-r3-endmarks-apostrophe-speech-comma-flow-boundary';
+
+function masteryKeyForRelease(releaseId, clusterId, rewardUnitId) {
+  return `punctuation:${releaseId}:${clusterId}:${rewardUnitId}`;
+}
 
 function masteryKey(clusterId, rewardUnitId) {
-  return `punctuation:${CURRENT_RELEASE_ID}:${clusterId}:${rewardUnitId}`;
+  return masteryKeyForRelease(CURRENT_RELEASE_ID, clusterId, rewardUnitId);
 }
 
 function freshSubjectState() {
@@ -91,6 +96,31 @@ test('learner with one secured reward unit reads as having one secured and attem
   assert.equal(model.progressSnapshot.securedRewardUnits, 1);
   assert.equal(model.overview.securedRewardUnits, 1);
   assert.equal(model.progressSnapshot.trackedRewardUnits, 1);
+});
+
+test('old-release reward units do not inflate current starView through the read-model', () => {
+  const now = Date.UTC(2026, 3, 25);
+  const subjectState = freshSubjectState();
+  const oldKey = masteryKeyForRelease(OLD_RELEASE_ID, 'endmarks', 'sentence-endings-core');
+  subjectState.data.progress.rewardUnits[oldKey] = {
+    masteryKey: oldKey,
+    releaseId: OLD_RELEASE_ID,
+    clusterId: 'endmarks',
+    rewardUnitId: 'sentence-endings-core',
+    securedAt: now - 10_000,
+  };
+
+  const model = buildPunctuationLearnerReadModel({
+    subjectStateRecord: subjectState,
+    practiceSessions: [],
+    now: () => now,
+  });
+
+  assert.equal(model.progressSnapshot.securedRewardUnits, 0);
+  assert.equal(model.releaseDiagnostics.trackedRewardUnitCount, 0);
+  assert.equal(model.starView.perMonster.pealark.secureStars, 0);
+  assert.equal(model.starView.perMonster.pealark.total, 0);
+  assert.equal(model.starView.grand.grandStars, 0);
 });
 
 test('hasEvidence is true when sessions exist even with zero attempts', () => {

--- a/tests/punctuation-star-projection.test.js
+++ b/tests/punctuation-star-projection.test.js
@@ -86,6 +86,26 @@ function securedRewardUnitForRelease(releaseId, clusterId, rewardUnitId) {
   };
 }
 
+function richCurrentReleaseProgress() {
+  const progress = freshProgress();
+  const units = [
+    { cluster: 'endmarks', ru: 'sentence-endings-core', skill: 'sentence_endings' },
+    { cluster: 'apostrophe', ru: 'apostrophe-contractions-core', skill: 'apostrophe_contractions' },
+    { cluster: 'comma_flow', ru: 'list-commas-core', skill: 'list_commas' },
+  ];
+
+  for (const { cluster, ru, skill } of units) {
+    progress.rewardUnits = {
+      ...progress.rewardUnits,
+      ...securedRewardUnit(cluster, ru),
+    };
+    progress.facets[`${skill}::choose`] = secureItemState({ lapses: 0 });
+    progress.facets[`${skill}::insert`] = secureItemState({ lapses: 0 });
+  }
+
+  return progress;
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -444,6 +464,132 @@ test('mixed old and current release reward units count only current-release entr
   assert.equal(result.perMonster.claspin.masteryStars, 0, 'old paired unit must not unlock Mastery evidence');
   assert.equal(result.perMonster.pealark.total, 0);
   assert.equal(result.perMonster.curlune.total, 0);
+});
+
+test('canonical duplicate and current-looking loose rows cannot inflate Secure or Grand Stars', () => {
+  const baselineProgress = richCurrentReleaseProgress();
+  const progress = richCurrentReleaseProgress();
+  const now = Date.UTC(2026, 3, 24);
+
+  progress.rewardUnits.looseDuplicateEndmarks = {
+    releaseId: CURRENT_RELEASE_ID,
+    clusterId: 'endmarks',
+    rewardUnitId: 'sentence-endings-core',
+    securedAt: now,
+  };
+  progress.rewardUnits.looseDuplicateApostrophe = {
+    releaseId: CURRENT_RELEASE_ID,
+    clusterId: 'apostrophe',
+    rewardUnitId: 'apostrophe-contractions-core',
+    securedAt: now,
+  };
+  progress.rewardUnits.looseDuplicateCommaFlow = {
+    releaseId: CURRENT_RELEASE_ID,
+    clusterId: 'comma_flow',
+    rewardUnitId: 'list-commas-core',
+    securedAt: now,
+  };
+
+  const baseline = projectPunctuationStars(baselineProgress, CURRENT_RELEASE_ID);
+  const result = projectPunctuationStars(progress, CURRENT_RELEASE_ID);
+
+  assert.ok(baseline.grand.grandStars > 0, 'baseline must exercise Grand Stars');
+  for (const monsterId of ['pealark', 'claspin', 'curlune']) {
+    assert.equal(
+      result.perMonster[monsterId].secureStars,
+      baseline.perMonster[monsterId].secureStars,
+      `${monsterId} duplicate loose row must not add Secure Stars`,
+    );
+  }
+  assert.equal(result.grand.grandStars, baseline.grand.grandStars,
+    'duplicate loose rows must not add Grand Stars');
+});
+
+test('malformed current-looking mastery keys with extra segments do not count', () => {
+  const progress = freshProgress();
+  const malformedKey = `${masteryKey('endmarks', 'sentence-endings-core')}:extra`;
+  progress.rewardUnits[malformedKey] = {
+    masteryKey: malformedKey,
+    releaseId: CURRENT_RELEASE_ID,
+    clusterId: 'endmarks',
+    rewardUnitId: 'sentence-endings-core',
+    securedAt: Date.UTC(2026, 3, 24),
+  };
+  progress.facets = {
+    'sentence_endings::choose': secureItemState({ lapses: 0 }),
+    'sentence_endings::insert': secureItemState({ lapses: 0 }),
+  };
+
+  const result = projectPunctuationStars(progress, CURRENT_RELEASE_ID);
+
+  assert.equal(result.perMonster.pealark.secureStars, 0);
+  assert.equal(result.perMonster.pealark.masteryStars, 0);
+  assert.equal(result.grand.grandStars, 0);
+});
+
+test('unknown current-release rewardUnitId and clusterId entries do not count', () => {
+  const progress = freshProgress();
+  const unknownRewardKey = masteryKey('endmarks', 'not-published-core');
+  const unknownClusterKey = masteryKey('unknown_cluster', 'sentence-endings-core');
+  progress.rewardUnits[unknownRewardKey] = {
+    masteryKey: unknownRewardKey,
+    releaseId: CURRENT_RELEASE_ID,
+    clusterId: 'endmarks',
+    rewardUnitId: 'not-published-core',
+    securedAt: Date.UTC(2026, 3, 24),
+  };
+  progress.rewardUnits[unknownClusterKey] = {
+    masteryKey: unknownClusterKey,
+    releaseId: CURRENT_RELEASE_ID,
+    clusterId: 'unknown_cluster',
+    rewardUnitId: 'sentence-endings-core',
+    securedAt: Date.UTC(2026, 3, 24),
+  };
+
+  const result = projectPunctuationStars(progress, CURRENT_RELEASE_ID);
+
+  assert.equal(result.perMonster.pealark.secureStars, 0);
+  assert.equal(result.perMonster.claspin.secureStars, 0);
+  assert.equal(result.perMonster.curlune.secureStars, 0);
+  assert.equal(result.grand.grandStars, 0);
+});
+
+test('mixed old and current projection matches a current-only baseline for Mastery and Grand Stars', () => {
+  const baselineProgress = richCurrentReleaseProgress();
+  const progress = richCurrentReleaseProgress();
+  progress.rewardUnits = {
+    ...progress.rewardUnits,
+    ...securedRewardUnitForRelease(OLD_RELEASE_ID, 'speech', 'speech-core'),
+    ...securedRewardUnitForRelease(OLD_RELEASE_ID, 'boundary', 'semicolons-core'),
+  };
+  progress.rewardUnits.currentLookingUnknown = {
+    masteryKey: masteryKey('endmarks', 'not-published-core'),
+    releaseId: CURRENT_RELEASE_ID,
+    clusterId: 'endmarks',
+    rewardUnitId: 'not-published-core',
+    securedAt: Date.UTC(2026, 3, 24),
+  };
+
+  const baseline = projectPunctuationStars(baselineProgress, CURRENT_RELEASE_ID);
+  const result = projectPunctuationStars(progress, CURRENT_RELEASE_ID);
+
+  assert.ok(baseline.perMonster.pealark.masteryStars > 0, 'baseline must exercise Pealark Mastery Stars');
+  assert.ok(baseline.perMonster.claspin.masteryStars > 0, 'baseline must exercise Claspin Mastery Stars');
+  assert.ok(baseline.perMonster.curlune.masteryStars > 0, 'baseline must exercise Curlune Mastery Stars');
+  assert.ok(baseline.grand.grandStars > 0, 'baseline must exercise Grand Stars');
+  for (const monsterId of ['pealark', 'claspin', 'curlune']) {
+    assert.equal(
+      result.perMonster[monsterId].secureStars,
+      baseline.perMonster[monsterId].secureStars,
+      `${monsterId} Secure Stars must match current-only baseline`,
+    );
+    assert.equal(
+      result.perMonster[monsterId].masteryStars,
+      baseline.perMonster[monsterId].masteryStars,
+      `${monsterId} Mastery Stars must match current-only baseline`,
+    );
+  }
+  assert.equal(result.grand.grandStars, baseline.grand.grandStars);
 });
 
 test('release metadata falls back only to mastery keys that clearly belong to the current release', () => {

--- a/tests/punctuation-star-projection.test.js
+++ b/tests/punctuation-star-projection.test.js
@@ -13,14 +13,19 @@ import {
 } from '../src/subjects/punctuation/components/punctuation-view-model.js';
 
 const CURRENT_RELEASE_ID = 'punctuation-r4-full-14-skill-structure';
+const OLD_RELEASE_ID = 'punctuation-r3-endmarks-apostrophe-speech-comma-flow-boundary';
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
+function masteryKeyForRelease(releaseId, clusterId, rewardUnitId) {
+  return `punctuation:${releaseId}:${clusterId}:${rewardUnitId}`;
+}
+
 function masteryKey(clusterId, rewardUnitId) {
-  return `punctuation:${CURRENT_RELEASE_ID}:${clusterId}:${rewardUnitId}`;
+  return masteryKeyForRelease(CURRENT_RELEASE_ID, clusterId, rewardUnitId);
 }
 
 function freshProgress() {
@@ -65,11 +70,15 @@ function secureItemState(overrides = {}) {
 }
 
 function securedRewardUnit(clusterId, rewardUnitId) {
-  const key = masteryKey(clusterId, rewardUnitId);
+  return securedRewardUnitForRelease(CURRENT_RELEASE_ID, clusterId, rewardUnitId);
+}
+
+function securedRewardUnitForRelease(releaseId, clusterId, rewardUnitId) {
+  const key = masteryKeyForRelease(releaseId, clusterId, rewardUnitId);
   return {
     [key]: {
       masteryKey: key,
-      releaseId: CURRENT_RELEASE_ID,
+      releaseId,
       clusterId,
       rewardUnitId,
       securedAt: Date.UTC(2026, 3, 24),
@@ -394,6 +403,86 @@ test('Grand Stars: increase with multi-monster secured units', () => {
   const result = projectPunctuationStars(progress, CURRENT_RELEASE_ID);
   assert.ok(result.grand.grandStars > 15, `Grand Stars should be > 15 with 3-monster breadth, got ${result.grand.grandStars}`);
   assert.ok(result.grand.grandStars > 0, 'Grand Stars must be positive');
+});
+
+test('old-release reward units cannot project current Secure, Mastery, or Grand Stars', () => {
+  const progress = freshProgress();
+  progress.rewardUnits = {
+    ...securedRewardUnitForRelease(OLD_RELEASE_ID, 'endmarks', 'sentence-endings-core'),
+    ...securedRewardUnitForRelease(OLD_RELEASE_ID, 'apostrophe', 'apostrophe-contractions-core'),
+    ...securedRewardUnitForRelease(OLD_RELEASE_ID, 'comma_flow', 'list-commas-core'),
+  };
+  progress.facets = {
+    'sentence_endings::choose': secureItemState({ lapses: 0 }),
+    'sentence_endings::insert': secureItemState({ lapses: 0 }),
+    'apostrophe_contractions::choose': secureItemState({ lapses: 0 }),
+    'apostrophe_contractions::insert': secureItemState({ lapses: 0 }),
+    'list_commas::choose': secureItemState({ lapses: 0 }),
+    'list_commas::insert': secureItemState({ lapses: 0 }),
+  };
+
+  const result = projectPunctuationStars(progress, CURRENT_RELEASE_ID);
+
+  for (const monsterId of ['pealark', 'claspin', 'curlune']) {
+    assert.equal(result.perMonster[monsterId].secureStars, 0, `${monsterId} secureStars`);
+    assert.equal(result.perMonster[monsterId].masteryStars, 0, `${monsterId} masteryStars`);
+    assert.equal(result.perMonster[monsterId].total, 0, `${monsterId} total`);
+  }
+  assert.equal(result.grand.grandStars, 0, 'old-release reward units must not lift Grand Stars');
+});
+
+test('mixed old and current release reward units count only current-release entries', () => {
+  const progress = freshProgress();
+  progress.rewardUnits = {
+    ...securedRewardUnit('apostrophe', 'apostrophe-contractions-core'),
+    ...securedRewardUnitForRelease(OLD_RELEASE_ID, 'apostrophe', 'apostrophe-possession-core'),
+  };
+
+  const result = projectPunctuationStars(progress, CURRENT_RELEASE_ID);
+
+  assert.equal(result.perMonster.claspin.secureStars, 20, 'one current Claspin unit should count');
+  assert.equal(result.perMonster.claspin.masteryStars, 0, 'old paired unit must not unlock Mastery evidence');
+  assert.equal(result.perMonster.pealark.total, 0);
+  assert.equal(result.perMonster.curlune.total, 0);
+});
+
+test('release metadata falls back only to mastery keys that clearly belong to the current release', () => {
+  const progress = freshProgress();
+  const currentKey = masteryKey('endmarks', 'sentence-endings-core');
+  const oldKey = masteryKeyForRelease(OLD_RELEASE_ID, 'endmarks', 'speech-core');
+  const currentEntry = {
+    masteryKey: currentKey,
+    clusterId: 'endmarks',
+    rewardUnitId: 'sentence-endings-core',
+    securedAt: Date.UTC(2026, 3, 24),
+  };
+  progress.rewardUnits = {
+    [currentKey]: currentEntry,
+    [oldKey]: {
+      masteryKey: oldKey,
+      clusterId: 'speech',
+      rewardUnitId: 'speech-core',
+      securedAt: Date.UTC(2026, 3, 24),
+    },
+    ambiguousLooseEntry: {
+      clusterId: 'boundary',
+      rewardUnitId: 'semicolons-core',
+      securedAt: Date.UTC(2026, 3, 24),
+    },
+  };
+  const currentOnly = freshProgress();
+  currentOnly.rewardUnits = { [currentKey]: currentEntry };
+
+  const result = projectPunctuationStars(progress, CURRENT_RELEASE_ID);
+  const baseline = projectPunctuationStars(currentOnly, CURRENT_RELEASE_ID);
+
+  assert.equal(
+    result.perMonster.pealark.secureStars,
+    baseline.perMonster.pealark.secureStars,
+    'only the clearly current mastery key should count',
+  );
+  assert.equal(result.perMonster.pealark.masteryStars, 0);
+  assert.equal(result.grand.grandStars, baseline.grand.grandStars);
 });
 
 test('pure function: calling twice with same input returns identical output', () => {


### PR DESCRIPTION
## Summary

- Filter Punctuation reward-unit evidence to the active release before projecting Secure Stars, Mastery Stars, and Grand Stars.
- Reject old, mismatched, or ambiguous reward-unit release evidence unless the mastery key clearly belongs to the current release.
- Preserve generated `variantSignature` attempt coalescing and legacy unsigned/signed generated attempt semantics by leaving item, facet, and attempt evidence paths unchanged.
- Add projection and read-model regressions for old-release, mixed-release, and missing-release metadata cases.

## Verification

- Red first: `node --test tests/punctuation-star-projection.test.js tests/punctuation-read-model.test.js` failed on the new old-release regressions before implementation.
- `node --test tests/punctuation-star-projection.test.js tests/punctuation-read-model.test.js` passes: 93 pass / 0 fail.
- `npm test` passes: 5797 pass / 0 fail / 6 skip.
- `git diff --check origin/main...HEAD` passes.

## Post-Deploy Monitoring & Validation

Expected healthy signals:
- Current-release Punctuation learners keep earning Secure, Mastery, and Grand Stars from current reward units.
- Learners with only retired/old-release reward-unit rows no longer show inflated current-release Star projections.
- No increase in Punctuation read-model/bootstrap errors around `projectPunctuationStars` or `starView` payload shape.

Failure signals to watch:
- Direct monster or Quoral Star totals drop for learners whose reward-unit rows carry the current release id or a clearly current mastery key.
- Reports that mixed old/current release histories show more Secure/Mastery/Grand Stars than the current-release entries alone justify.
- Production logs surface malformed `starView` or Punctuation read-model projection exceptions after deploy.
