### PR TITLE
feat(rewards): add presentation adapters

### DIFF
--- a/src/platform/rewards/reward-presentations.js
+++ b/src/platform/rewards/reward-presentations.js
@@ -1,0 +1,301 @@
+export const REWARD_PRESENTATION_TYPE = 'reward.presentation';
+export const LEGACY_REWARD_MONSTER_TYPE = 'reward.monster';
+export const LEGACY_REWARD_TOAST_TYPE = 'reward.toast';
+
+const MONSTER_CELEBRATION_KINDS = new Set(['caught', 'evolve', 'mega']);
+
+function isPlainObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function cleanString(value, fallback = '') {
+  if (typeof value !== 'string') return fallback;
+  const trimmed = value.trim();
+  return trimmed || fallback;
+}
+
+function nonNegativeNumber(value, fallback = 0) {
+  const number = Number(value);
+  return Number.isFinite(number) && number >= 0 ? number : fallback;
+}
+
+function compactObject(value) {
+  const output = {};
+  for (const [key, entry] of Object.entries(value || {})) {
+    if (entry === undefined) continue;
+    output[key] = entry;
+  }
+  return output;
+}
+
+function legacySourceId(event, fallbackType) {
+  const explicit = cleanString(event?.id);
+  if (explicit) return explicit;
+  return [
+    fallbackType,
+    cleanString(event?.learnerId, 'default'),
+    cleanString(event?.subjectId || event?.producerId, 'unknown'),
+    cleanString(event?.monsterId || event?.sessionId || event?.sourceEventId, 'event'),
+    cleanString(event?.kind, 'update'),
+    nonNegativeNumber(event?.createdAt || event?.occurredAt, 0),
+  ].join(':');
+}
+
+function presentationIdForLegacy(event, fallbackType) {
+  return `reward.presentation:${legacySourceId(event, fallbackType)}`;
+}
+
+export function presentationAckKey(eventOrId, presentationKind, intentIdOrIndex = 0) {
+  const eventId = cleanString(
+    typeof eventOrId === 'string' ? eventOrId : eventOrId?.id,
+  );
+  const kind = cleanString(presentationKind);
+  if (!eventId || !kind) return '';
+  const suffix = intentIdOrIndex == null ? 0 : String(intentIdOrIndex).trim();
+  return `reward:${eventId}:${kind}:${suffix || '0'}`;
+}
+
+function presentationIntentId(eventId, presentationKind, index) {
+  return `${eventId}:${presentationKind}:${index}`;
+}
+
+function normalisePresentationIntent(intent, {
+  eventId,
+  presentationKind,
+  index = 0,
+  fallbackTiming = 'producer-controlled',
+} = {}) {
+  if (!isPlainObject(intent)) return null;
+  const id = cleanString(intent.id, presentationIntentId(eventId, presentationKind, index));
+  const intentKey = cleanString(intent.intentId, index);
+  return {
+    ...intent,
+    id,
+    dedupeKey: cleanString(
+      intent.dedupeKey,
+      presentationAckKey(eventId, presentationKind, intentKey),
+    ),
+    timing: cleanString(intent.timing, fallbackTiming),
+  };
+}
+
+function normaliseToastIntent(intent, options) {
+  const normalised = normalisePresentationIntent(intent, {
+    ...options,
+    presentationKind: 'toast',
+    fallbackTiming: 'immediate',
+  });
+  if (!normalised) return null;
+  return compactObject({
+    ...normalised,
+    title: cleanString(normalised.title),
+    body: cleanString(normalised.body),
+    tone: cleanString(normalised.tone, 'neutral'),
+    ariaLive: cleanString(normalised.ariaLive, 'polite'),
+    autoDismissMs: normalised.autoDismissMs == null
+      ? undefined
+      : nonNegativeNumber(normalised.autoDismissMs, 0),
+  });
+}
+
+function normaliseCelebrationIntent(intent, options) {
+  const normalised = normalisePresentationIntent(intent, {
+    ...options,
+    presentationKind: 'celebration',
+    fallbackTiming: 'producer-controlled',
+  });
+  if (!normalised) return null;
+  return compactObject({
+    ...normalised,
+    visualKind: cleanString(normalised.visualKind, cleanString(normalised.kind)),
+    title: cleanString(normalised.title),
+    body: cleanString(normalised.body),
+    priority: normalised.priority == null
+      ? undefined
+      : nonNegativeNumber(normalised.priority, 0),
+  });
+}
+
+function normalisePresentationIntentList(value, {
+  eventId,
+  presentationKind,
+} = {}) {
+  const entries = Array.isArray(value)
+    ? value
+    : (isPlainObject(value) ? [value] : []);
+  const normalise = presentationKind === 'toast'
+    ? normaliseToastIntent
+    : (presentationKind === 'celebration' ? normaliseCelebrationIntent : normalisePresentationIntent);
+  return entries
+    .map((intent, index) => normalise(intent, { eventId, presentationKind, index }))
+    .filter(Boolean);
+}
+
+function normalisePresentations(value, eventId) {
+  const raw = isPlainObject(value) ? value : {};
+  const output = {};
+  const keys = new Set(['toast', 'celebration', ...Object.keys(raw)]);
+  for (const key of keys) {
+    output[key] = normalisePresentationIntentList(raw[key], {
+      eventId,
+      presentationKind: key,
+    });
+  }
+  return output;
+}
+
+function legacyToastIntent(event) {
+  if (isPlainObject(event?.toast)) {
+    return {
+      title: cleanString(event.toast.title),
+      body: cleanString(event.toast.body),
+    };
+  }
+  if (isPlainObject(event?.monster)) {
+    return {
+      title: cleanString(event.monster.name, 'Reward update'),
+      body: '',
+    };
+  }
+  return null;
+}
+
+function legacyMonsterPayload(event) {
+  return compactObject({
+    monsterId: cleanString(event.monsterId),
+    monster: isPlainObject(event.monster) ? event.monster : undefined,
+    previous: isPlainObject(event.previous) ? event.previous : undefined,
+    next: isPlainObject(event.next) ? event.next : undefined,
+    releaseId: cleanString(event.releaseId) || undefined,
+    clusterId: cleanString(event.clusterId) || undefined,
+    rewardUnitId: cleanString(event.rewardUnitId) || undefined,
+    masteryKey: cleanString(event.masteryKey) || undefined,
+    conceptId: cleanString(event.conceptId) || undefined,
+  });
+}
+
+function adaptLegacyMonsterEvent(event) {
+  const sourceEventId = legacySourceId(event, LEGACY_REWARD_MONSTER_TYPE);
+  const id = presentationIdForLegacy(event, LEGACY_REWARD_MONSTER_TYPE);
+  const kind = cleanString(event.kind, 'update');
+  const toast = legacyToastIntent(event);
+  const celebration = MONSTER_CELEBRATION_KINDS.has(kind)
+    ? [{
+        visualKind: kind,
+        timing: 'producer-controlled',
+        title: cleanString(toast?.title || event?.monster?.name),
+        body: cleanString(toast?.body),
+        assetRef: compactObject({
+          family: 'monster',
+          monsterId: cleanString(event.monsterId) || undefined,
+          branch: cleanString(event?.next?.branch || event?.previous?.branch) || undefined,
+          stage: event?.next?.stage,
+        }),
+      }]
+    : [];
+
+  return normaliseCanonicalPresentationEvent({
+    id,
+    type: REWARD_PRESENTATION_TYPE,
+    producerType: 'subject',
+    producerId: cleanString(event.subjectId, 'spelling'),
+    rewardType: LEGACY_REWARD_MONSTER_TYPE,
+    kind,
+    learnerId: cleanString(event.learnerId, 'default'),
+    occurredAt: nonNegativeNumber(event.occurredAt ?? event.createdAt, 0),
+    sourceEventId,
+    fromState: isPlainObject(event.previous) ? event.previous : null,
+    toState: isPlainObject(event.next) ? event.next : null,
+    payload: legacyMonsterPayload(event),
+    presentations: {
+      toast: toast ? [toast] : [],
+      celebration,
+    },
+  });
+}
+
+function legacyToastPayload(event) {
+  return compactObject({
+    sourceEventId: cleanString(event.sourceEventId) || undefined,
+    sessionId: cleanString(event.sessionId) || undefined,
+    achievementId: cleanString(event.achievementId) || undefined,
+    achievementKey: cleanString(event.achievementKey) || undefined,
+  });
+}
+
+function adaptLegacyToastEvent(event) {
+  const sourceEventId = legacySourceId(event, LEGACY_REWARD_TOAST_TYPE);
+  const id = presentationIdForLegacy(event, LEGACY_REWARD_TOAST_TYPE);
+  const toast = legacyToastIntent(event);
+  return normaliseCanonicalPresentationEvent({
+    id,
+    type: REWARD_PRESENTATION_TYPE,
+    producerType: 'subject',
+    producerId: cleanString(event.subjectId, 'spelling'),
+    rewardType: LEGACY_REWARD_TOAST_TYPE,
+    kind: cleanString(event.kind, 'toast'),
+    learnerId: cleanString(event.learnerId, 'default'),
+    occurredAt: nonNegativeNumber(event.occurredAt ?? event.createdAt, 0),
+    sourceEventId,
+    payload: legacyToastPayload(event),
+    presentations: {
+      toast: toast ? [toast] : [],
+      celebration: [],
+    },
+  });
+}
+
+function normaliseCanonicalPresentationEvent(event) {
+  if (!isPlainObject(event)) return null;
+  const id = cleanString(event.id);
+  if (!id) return null;
+  const producerType = cleanString(event.producerType, event.subjectId ? 'subject' : 'platform');
+  const producerId = cleanString(event.producerId || event.subjectId || event.moduleId, 'unknown');
+  const kind = cleanString(event.kind, 'update');
+  const presentations = normalisePresentations(
+    event.presentations || {
+      toast: event.toast,
+      celebration: event.celebration,
+    },
+    id,
+  );
+  return compactObject({
+    id,
+    type: REWARD_PRESENTATION_TYPE,
+    producerType,
+    producerId,
+    rewardType: cleanString(event.rewardType, REWARD_PRESENTATION_TYPE),
+    kind,
+    learnerId: cleanString(event.learnerId, 'default'),
+    occurredAt: nonNegativeNumber(event.occurredAt ?? event.createdAt, 0),
+    sourceEventId: cleanString(event.sourceEventId) || undefined,
+    fromState: event.fromState ?? null,
+    toState: event.toState ?? null,
+    milestoneRankBefore: event.milestoneRankBefore == null ? undefined : nonNegativeNumber(event.milestoneRankBefore, 0),
+    milestoneRankAfter: event.milestoneRankAfter == null ? undefined : nonNegativeNumber(event.milestoneRankAfter, 0),
+    payload: isPlainObject(event.payload) ? event.payload : {},
+    presentations,
+    analytics: isPlainObject(event.analytics) ? event.analytics : undefined,
+  });
+}
+
+export function normaliseRewardPresentationEvent(event) {
+  if (!isPlainObject(event)) return null;
+  if (event.type === REWARD_PRESENTATION_TYPE) return normaliseCanonicalPresentationEvent(event);
+  if (event.type === LEGACY_REWARD_MONSTER_TYPE) return adaptLegacyMonsterEvent(event);
+  if (event.type === LEGACY_REWARD_TOAST_TYPE) return adaptLegacyToastEvent(event);
+  return null;
+}
+
+export function presentationEventsFromLegacyRewardEvents(events) {
+  const entries = Array.isArray(events) ? events : [events];
+  return entries.map(normaliseRewardPresentationEvent).filter(Boolean);
+}
+
+export function resolveRewardToast(event) {
+  return normaliseRewardPresentationEvent(event)?.presentations?.toast || [];
+}
+
+export function resolveRewardCelebration(event) {
+  return normaliseRewardPresentationEvent(event)?.presentations?.celebration || [];
+}

--- a/tests/reward-presentations.test.js
+++ b/tests/reward-presentations.test.js
@@ -1,0 +1,196 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  normaliseRewardPresentationEvent,
+  presentationAckKey,
+  presentationEventsFromLegacyRewardEvents,
+  resolveRewardCelebration,
+  resolveRewardToast,
+} from '../src/platform/rewards/reward-presentations.js';
+
+const monster = Object.freeze({
+  id: 'pealark',
+  name: 'Pealark',
+  accent: '#3E6FA8',
+});
+
+function legacyMonsterEvent(overrides = {}) {
+  return {
+    id: 'reward.monster:learner-a:punctuation:r4:speech:unit-1:pealark:caught',
+    type: 'reward.monster',
+    kind: 'caught',
+    subjectId: 'punctuation',
+    learnerId: 'learner-a',
+    monsterId: 'pealark',
+    monster,
+    previous: { stage: 0, level: 0, caught: false, branch: 'a' },
+    next: { stage: 0, level: 0, caught: true, branch: 'a' },
+    createdAt: 1777399200000,
+    toast: {
+      title: 'Egg Found',
+      body: 'You found Pealark.',
+    },
+    releaseId: 'r4',
+    clusterId: 'speech',
+    rewardUnitId: 'unit-1',
+    masteryKey: 'punctuation:r4:speech:unit-1',
+    ...overrides,
+  };
+}
+
+test('legacy reward.monster adapts to source-agnostic toast and celebration presentations', () => {
+  const presentation = normaliseRewardPresentationEvent(legacyMonsterEvent());
+
+  assert.equal(presentation.type, 'reward.presentation');
+  assert.equal(presentation.producerType, 'subject');
+  assert.equal(presentation.producerId, 'punctuation');
+  assert.equal(presentation.rewardType, 'reward.monster');
+  assert.equal(presentation.kind, 'caught');
+  assert.equal(presentation.learnerId, 'learner-a');
+  assert.equal(presentation.sourceEventId, 'reward.monster:learner-a:punctuation:r4:speech:unit-1:pealark:caught');
+  assert.equal(presentation.payload.monsterId, 'pealark');
+  assert.equal(presentation.payload.masteryKey, 'punctuation:r4:speech:unit-1');
+
+  assert.equal(presentation.presentations.toast.length, 1);
+  assert.equal(presentation.presentations.toast[0].title, 'Egg Found');
+  assert.equal(presentation.presentations.toast[0].body, 'You found Pealark.');
+  assert.equal(presentation.presentations.toast[0].timing, 'immediate');
+  assert.equal(
+    presentation.presentations.toast[0].dedupeKey,
+    `reward:${presentation.id}:toast:0`,
+  );
+
+  assert.equal(presentation.presentations.celebration.length, 1);
+  assert.equal(presentation.presentations.celebration[0].visualKind, 'caught');
+  assert.equal(presentation.presentations.celebration[0].timing, 'producer-controlled');
+  assert.equal(presentation.presentations.celebration[0].assetRef.monsterId, 'pealark');
+  assert.equal(
+    presentation.presentations.celebration[0].dedupeKey,
+    `reward:${presentation.id}:celebration:0`,
+  );
+});
+
+test('legacy reward.monster levelup adapts to toast-only unless explicitly promoted later', () => {
+  const presentation = normaliseRewardPresentationEvent(legacyMonsterEvent({
+    id: 'reward.monster:learner-a:pealark:levelup:1:2',
+    kind: 'levelup',
+    toast: {
+      title: 'Pealark',
+      body: 'Level increased.',
+    },
+  }));
+
+  assert.equal(presentation.kind, 'levelup');
+  assert.equal(presentation.presentations.toast.length, 1);
+  assert.equal(presentation.presentations.toast[0].body, 'Level increased.');
+  assert.deepEqual(presentation.presentations.celebration, []);
+});
+
+test('legacy reward.toast adapts to toast-only presentation without monster payload', () => {
+  const presentation = normaliseRewardPresentationEvent({
+    id: 'reward.toast:guardian.renewed:learner-a:session-1:word-1',
+    type: 'reward.toast',
+    kind: 'guardian.renewed',
+    subjectId: 'spelling',
+    learnerId: 'learner-a',
+    sessionId: 'session-1',
+    sourceEventId: 'spelling.guardian.renewed:word-1',
+    createdAt: 1777399300000,
+    toast: {
+      title: 'Word renewed.',
+      body: '"because" held steady.',
+    },
+  });
+
+  assert.equal(presentation.type, 'reward.presentation');
+  assert.equal(presentation.producerType, 'subject');
+  assert.equal(presentation.producerId, 'spelling');
+  assert.equal(presentation.rewardType, 'reward.toast');
+  assert.equal(presentation.payload.sessionId, 'session-1');
+  assert.equal(presentation.payload.sourceEventId, 'spelling.guardian.renewed:word-1');
+  assert.equal(presentation.presentations.toast.length, 1);
+  assert.equal(presentation.presentations.toast[0].title, 'Word renewed.');
+  assert.deepEqual(presentation.presentations.celebration, []);
+});
+
+test('canonical presentation event preserves plural presentation arrays and unknown future keys', () => {
+  const presentation = normaliseRewardPresentationEvent({
+    id: 'reward.presentation:module:hero-mode:reward.hero:purchase:txn-1',
+    type: 'reward.presentation',
+    producerType: 'module',
+    producerId: 'hero-mode',
+    rewardType: 'reward.hero',
+    kind: 'purchase',
+    learnerId: 'learner-a',
+    occurredAt: 1777399400000,
+    payload: {
+      transactionId: 'txn-1',
+      inventoryItemId: 'cape-blue',
+    },
+    presentations: {
+      toast: [
+        { title: 'New outfit unlocked', body: 'Blue Cape is ready.' },
+        { intentId: 'first-time-help', title: 'Try it on later', body: 'Open Hero Camp when you are ready.' },
+      ],
+      celebration: [
+        { visualKind: 'hero-purchase', timing: 'immediate', title: 'New outfit unlocked' },
+      ],
+      audio: [
+        { intentId: 'soft-chime', src: '/audio/chime.mp3' },
+      ],
+    },
+  });
+
+  assert.equal(presentation.producerType, 'module');
+  assert.equal(presentation.producerId, 'hero-mode');
+  assert.equal(presentation.presentations.toast.length, 2);
+  assert.equal(presentation.presentations.toast[1].dedupeKey, `reward:${presentation.id}:toast:first-time-help`);
+  assert.equal(presentation.presentations.celebration.length, 1);
+  assert.equal(presentation.presentations.celebration[0].visualKind, 'hero-purchase');
+  assert.equal(presentation.presentations.audio.length, 1);
+  assert.equal(presentation.presentations.audio[0].dedupeKey, `reward:${presentation.id}:audio:soft-chime`);
+});
+
+test('presentation helpers resolve intents from both canonical and legacy shapes', () => {
+  const legacy = legacyMonsterEvent();
+  const canonical = normaliseRewardPresentationEvent(legacy);
+
+  assert.equal(resolveRewardToast(legacy).length, 1);
+  assert.equal(resolveRewardCelebration(legacy).length, 1);
+  assert.equal(resolveRewardToast(canonical).length, 1);
+  assert.equal(resolveRewardCelebration(canonical).length, 1);
+});
+
+test('presentationEventsFromLegacyRewardEvents filters invalid entries and keeps stable order', () => {
+  const events = presentationEventsFromLegacyRewardEvents([
+    null,
+    { type: 'unknown.reward' },
+    legacyMonsterEvent({ monsterId: 'pealark' }),
+    {
+      id: 'reward.toast:mission:learner-a:session-1',
+      type: 'reward.toast',
+      kind: 'guardian.mission-completed',
+      subjectId: 'spelling',
+      learnerId: 'learner-a',
+      toast: { title: 'Mission complete.', body: '3 renewed, 1 recovered.' },
+    },
+  ]);
+
+  assert.equal(events.length, 2);
+  assert.equal(events[0].rewardType, 'reward.monster');
+  assert.equal(events[1].rewardType, 'reward.toast');
+});
+
+test('presentationAckKey is deterministic per event, presentation kind, and intent id', () => {
+  assert.equal(
+    presentationAckKey('reward.presentation:subject:grammar:reward.monster:evolve:1', 'celebration', 'hatch'),
+    'reward:reward.presentation:subject:grammar:reward.monster:evolve:1:celebration:hatch',
+  );
+  assert.equal(
+    presentationAckKey({ id: 'reward.presentation:subject:spelling:reward.toast:guardian:1' }, 'toast', 0),
+    'reward:reward.presentation:subject:spelling:reward.toast:guardian:1:toast:0',
+  );
+  assert.equal(presentationAckKey('', 'toast', 0), '');
+  assert.equal(presentationAckKey('event-1', '', 0), '');
+});


### PR DESCRIPTION
## Summary
- add the shared reward presentation helper module from PR2 of the contract plan
- adapt legacy `reward.monster` and `reward.toast` events into canonical `reward.presentation` envelopes
- add plural `presentations` map support, deterministic per-intent ack keys, and toast / celebration resolver helpers

## Scope
- Behaviour-preserving foundation only: no runtime routing is switched to the new schema in this PR.
- Keeps legacy events readable while preparing PR3+ to move consumers behind the adapter.

## Verification
- `node --test tests/reward-presentations.test.js`
- `npm test` — 5800 pass / 6 skipped / 0 fail
- `npm run check` — client bundle 216001 / 216500 bytes gzip
- `git diff --check`
