### PR TITLE
feat(seo): add KS2 public discovery foundation

### DIFF
--- a/_headers
+++ b/_headers
@@ -75,6 +75,32 @@
   Reporting-Endpoints: csp-endpoint="/api/security/csp-report"
   Cache-Control: public, max-age=3600
 
+/robots.txt
+  Strict-Transport-Security: max-age=63072000; includeSubDomains
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(), geolocation=(), payment=(), usb=(), bluetooth=(), serial=(), hid=(), midi=(), microphone=(), accelerometer=(), gyroscope=(), magnetometer=(), autoplay=(), encrypted-media=(), fullscreen=(self), picture-in-picture=(), interest-cohort=(), browsing-topics=()
+  X-Frame-Options: DENY
+  Cross-Origin-Opener-Policy: same-origin-allow-popups
+  Cross-Origin-Resource-Policy: same-site
+  Content-Security-Policy-Report-Only: default-src 'none'; script-src 'self' 'sha256-BUILD_TIME_HASH' 'strict-dynamic' https://challenges.cloudflare.com; script-src-elem 'self' 'sha256-BUILD_TIME_HASH' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com; media-src 'self' blob:; form-action 'self'; frame-ancestors 'none'; frame-src https://challenges.cloudflare.com; base-uri 'none'; object-src 'none'; manifest-src 'self'; worker-src 'none'; report-uri /api/security/csp-report; report-to csp-endpoint
+  Report-To: {"group":"csp-endpoint","max_age":10886400,"endpoints":[{"url":"/api/security/csp-report"}]}
+  Reporting-Endpoints: csp-endpoint="/api/security/csp-report"
+  Cache-Control: public, max-age=3600
+
+/sitemap.xml
+  Strict-Transport-Security: max-age=63072000; includeSubDomains
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(), geolocation=(), payment=(), usb=(), bluetooth=(), serial=(), hid=(), midi=(), microphone=(), accelerometer=(), gyroscope=(), magnetometer=(), autoplay=(), encrypted-media=(), fullscreen=(self), picture-in-picture=(), interest-cohort=(), browsing-topics=()
+  X-Frame-Options: DENY
+  Cross-Origin-Opener-Policy: same-origin-allow-popups
+  Cross-Origin-Resource-Policy: same-site
+  Content-Security-Policy-Report-Only: default-src 'none'; script-src 'self' 'sha256-BUILD_TIME_HASH' 'strict-dynamic' https://challenges.cloudflare.com; script-src-elem 'self' 'sha256-BUILD_TIME_HASH' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com; media-src 'self' blob:; form-action 'self'; frame-ancestors 'none'; frame-src https://challenges.cloudflare.com; base-uri 'none'; object-src 'none'; manifest-src 'self'; worker-src 'none'; report-uri /api/security/csp-report; report-to csp-endpoint
+  Report-To: {"group":"csp-endpoint","max_age":10886400,"endpoints":[{"url":"/api/security/csp-report"}]}
+  Reporting-Endpoints: csp-endpoint="/api/security/csp-report"
+  Cache-Control: public, max-age=3600
+
 /
   Strict-Transport-Security: max-age=63072000; includeSubDomains
   X-Content-Type-Options: nosniff

--- a/docs/brainstorms/2026-04-28-ks2-seo-foundation-requirements.md
+++ b/docs/brainstorms/2026-04-28-ks2-seo-foundation-requirements.md
@@ -1,0 +1,175 @@
+---
+date: 2026-04-28
+topic: ks2-seo-foundation
+---
+
+# KS2 SEO Foundation
+
+## Summary
+
+Define a crawlable, AI-readable SEO foundation for KS2 Mastery that can attract organic users, explain the product clearly to search and answer engines, and support later content expansion across practice-tool, subject/problem, and parent-support search intent.
+
+---
+
+## Problem Frame
+
+KS2 Mastery currently behaves like a production app first and a public discovery surface second. The live site has an app shell, product title, manifest, icons, and strong operational/security headers, but the public HTML does not yet give search engines or AI assistants enough plain-language product identity to understand what the site is for, who it helps, and which KS2 practice areas it covers.
+
+This matters because James wants organic user growth and wants AI search or assistant systems to have enough trustworthy page content to consider KS2 Mastery when answering relevant KS2 practice queries. Without a clear crawlable identity layer, the site can work well for direct users while remaining weak as a discovery target.
+
+Evidence used during the brainstorm:
+
+- `index.html`
+- `manifest.webmanifest`
+- `wrangler.jsonc`
+- `worker/src/security-headers.js`
+- `docs/plans/2026-04-22-001-refactor-full-stack-react-conversion-plan.md`
+- Production checks against `https://ks2.eugnel.uk/`, `/robots.txt`, and `/sitemap.xml`
+- Google Search Central guidance on sitemaps, JavaScript SEO, and Search Console / Analytics measurement
+- Cloudflare guidance on Web Analytics, Zaraz, and Google Analytics integration
+
+---
+
+## Actors
+
+- A1. Prospective KS2 learner or supporting adult: Finds the site through organic search or AI-assisted discovery and decides whether to try it.
+- A2. Search crawler: Discovers, fetches, and indexes public pages and metadata.
+- A3. AI search or assistant system: Reads public pages and available metadata to understand whether KS2 Mastery is a relevant recommendation.
+- A4. James / product operator: Reviews discoverability, indexing, and organic traffic signals to decide where to invest next.
+- A5. KS2 Mastery app: Provides the existing authenticated and demo product experience that public SEO surfaces should introduce without exposing private learner data.
+
+---
+
+## Key Flows
+
+- F1. Public discovery and product understanding
+  - **Trigger:** A crawler, AI search system, or prospective user reaches the public site.
+  - **Actors:** A1, A2, A3, A5
+  - **Steps:** The visitor or crawler receives a crawlable public identity surface, sees clear UK English copy describing the product and KS2 subjects covered, can identify the canonical public URL, and can move into the app or demo experience.
+  - **Outcome:** The site is understandable without requiring a private login or relying only on JavaScript-rendered app state.
+  - **Covered by:** R1, R2, R3, R4, R5, R6
+
+- F2. Search engine discovery and validation
+  - **Trigger:** Google or another crawler requests discovery files or follows known URLs.
+  - **Actors:** A2, A4
+  - **Steps:** The crawler can fetch valid discovery files, identify the intended canonical public pages, avoid private or non-public app surfaces where appropriate, and report indexing status through search tooling.
+  - **Outcome:** James can verify whether the core public pages are discoverable and indexable.
+  - **Covered by:** R7, R8, R9, R10, R15
+
+- F3. Organic measurement and next-slice selection
+  - **Trigger:** Public SEO foundation is live and traffic begins to appear.
+  - **Actors:** A1, A3, A4
+  - **Steps:** Measurement tools capture aggregate visitor and organic search signals, James reviews which search intents or pages show promise, and the next content slice is chosen from the documented acquisition lanes.
+  - **Outcome:** Future SEO work is guided by observed demand rather than speculative content volume.
+  - **Covered by:** R11, R12, R13, R14
+
+---
+
+## Requirements
+
+**Public Product Identity**
+
+- R1. The first release must create a public, crawlable identity layer that explains KS2 Mastery in plain UK English without requiring sign-in.
+- R2. The public identity layer must clearly state that KS2 Mastery supports KS2 practice and currently covers spelling, grammar, and punctuation.
+- R3. The public copy must describe the product by learner value and practice outcome, not only by app features or internal module names.
+- R4. The public identity layer must be useful to both humans and AI systems: it should contain enough direct text for an assistant to summarise what the product does, who it helps, and when it is relevant.
+- R5. The public entry must provide a clear path into the existing product experience, such as the app home or demo flow, without exposing private learner state or authenticated content.
+- R6. The first release should prioritise one strong public identity surface over many thin pages.
+
+**Technical SEO Foundation**
+
+- R7. The site must expose valid crawler discovery files for the public SEO surface, including a valid robots policy and sitemap discovery path.
+- R8. The core public page or pages must have search-friendly metadata, including descriptive titles, descriptions, canonical identity, and social/share preview metadata where relevant.
+- R9. The public SEO surface must avoid accidental duplicate identities for the same content.
+- R10. The SEO foundation must account for the existing single-page app shape so crawlers are not forced to infer product identity from a sparse app shell alone.
+- R11. The foundation must preserve existing app security, privacy, authentication, demo, and learner-state boundaries.
+
+**Measurement and Validation**
+
+- R12. The release must make Search Console-style validation possible for discovery, indexing, and organic query performance.
+- R13. The release must include or prepare for privacy-conscious aggregate visitor analytics so James can distinguish organic traffic from other traffic sources.
+- R14. Measurement must be treated as decision support for SEO, not as a ranking mechanism in itself.
+- R15. Production validation must verify that the live site returns the intended public SEO files and metadata, not only that local build output looks correct.
+
+**Future Content Lanes**
+
+- R16. The requirements must preserve four future acquisition lanes: practice-tool intent, subject/problem intent, parent-support intent, and AI-readable product identity.
+- R17. The first release must not commit to a large content programme, but it must leave a clear path for adding focused content pages later.
+- R18. Later content pages should be selected based on likely organic value, product fit, and observed measurement signals rather than broad keyword coverage alone.
+- R19. Future SEO content must stay aligned with the product's actual capabilities and avoid overstating coverage, outcomes, or recommendation guarantees.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R2, R3, R4.** Given a user or AI assistant opens the public site without signing in, when it reads the public page content, it can identify KS2 Mastery as a KS2 spelling, grammar, and punctuation practice product and explain who it is for.
+- AE2. **Covers R5, R11.** Given a prospective visitor reaches the public identity surface, when they choose to try the product, they can move into the existing app or demo path without seeing private learner data.
+- AE3. **Covers R7, R8, R9, R15.** Given a crawler requests the site's discovery and core public pages in production, when the responses are inspected, they return valid SEO resources and metadata rather than only the generic app shell.
+- AE4. **Covers R10.** Given a crawler does not rely on completing an authenticated app flow, when it fetches the public site, it still receives enough crawlable text to understand the product's purpose.
+- AE5. **Covers R12, R13, R14.** Given the SEO foundation is live, when James reviews search and visitor data, he can see whether organic discovery is beginning to work without treating analytics installation as an SEO ranking factor.
+- AE6. **Covers R16, R17, R18, R19.** Given the first release is complete, when the next SEO slice is planned, the team can choose a focused practice-tool, subject/problem, or parent-support page without rewriting the identity foundation.
+
+---
+
+## Success Criteria
+
+- Search engines can fetch and understand the site's core public SEO surface without relying only on the private or interactive app experience.
+- AI search and assistant systems have enough public, direct, accurate text to understand when KS2 Mastery may be relevant.
+- James can submit or inspect the site in search tooling and see a clean foundation for discovery, indexing, and organic query measurement.
+- The first release increases SEO readiness without creating a high-maintenance content backlog.
+- Planning can proceed without inventing the audience, first-release priority, intent lanes, measurement goal, or scope exclusions.
+
+---
+
+## Scope Boundaries
+
+- Do not build a large blog or content farm in the first release.
+- Do not promise that Google, AI search, or assistants will recommend the site; the goal is to improve discoverability and understandability.
+- Do not build paid advertising, school sales funnels, CRM flows, or conversion automation in this release.
+- Do not create separate first-release funnels for parents, tutors, and schools.
+- Do not expose private learner data, authenticated read models, admin surfaces, or internal analytics as public SEO content.
+- Do not treat Google Analytics or any analytics tag as a direct ranking improvement.
+- Do not weaken existing security headers, privacy posture, demo safeguards, learner-state boundaries, or deployment controls for SEO convenience.
+- Do not chase every KS2 keyword in V1; establish the foundation first.
+
+---
+
+## Key Decisions
+
+- Start with AI-readable product identity: This is the highest-leverage first slice because search and AI systems need a clear public explanation before later content pages can compound.
+- Keep the initial audience broad: The first release should support broad KS2 learner support rather than separate parent, tutor, and school funnels.
+- Preserve four acquisition lanes for later: Practice-tool, subject/problem, parent-support, and product-identity intent should all remain future options.
+- Treat technical SEO and measurement as foundation work: Discovery files, metadata, canonical identity, production validation, and search/visitor measurement support growth but do not replace useful content.
+- Prefer one strong public identity surface in V1: A focused, accurate identity layer is more valuable than many thin pages that increase maintenance and quality risk.
+- Keep privacy central: Because the product is education and learner-facing, analytics and public content should be aggregate, cautious, and aligned with the existing production-sensitive boundaries.
+
+---
+
+## Dependencies / Assumptions
+
+- The existing product experience, including demo entry, remains the destination behind the public SEO surface.
+- Google Search Console or equivalent search tooling will be available to validate indexing and query performance after release.
+- Cloudflare-hosted measurement options may be preferable for the first aggregate visitor analytics layer because they can reduce third-party script and privacy overhead, but the exact choice belongs in planning.
+- Any Google Analytics or tag-management setup must be assessed against privacy, consent, and existing CSP/security constraints during planning.
+- Search and AI recommendations depend on external systems; the product can improve crawlability, clarity, and evidence, but cannot guarantee recommendation placement.
+
+---
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+- None.
+
+### Deferred to Planning
+
+- [Affects R1, R5, R10][Technical] Decide whether the first public identity surface should be integrated into the current root experience, served as a distinct public page, or handled through another route shape that preserves the existing app flow.
+- [Affects R7, R8, R9, R15][Technical] Define the exact production validation checks for discovery files, metadata, canonical identity, and crawler-visible text.
+- [Affects R12, R13, R14][Needs research] Choose the first measurement stack and consent/privacy posture, comparing Search Console, Cloudflare Web Analytics, Zaraz, and Google Analytics.
+- [Affects R16, R17, R18][Needs research] Select the first post-foundation content slice using keyword opportunity, product fit, and early measurement evidence.
+
+---
+
+## Next Steps
+
+-> /ce-plan for structured implementation planning.

--- a/docs/operations/seo.md
+++ b/docs/operations/seo.md
@@ -1,0 +1,70 @@
+---
+module: operations
+tags:
+  - seo
+  - analytics
+  - search-console
+problem_type: runbook
+---
+
+# SEO Operations
+
+KS2 Mastery V1 SEO is a foundation layer: one crawlable public identity surface, valid discovery files, production audit coverage, and an operator path for measuring organic discovery. It does not guarantee ranking, search placement, or AI assistant recommendations.
+
+## Public Surface
+
+The canonical public URL is:
+
+- `https://ks2.eugnel.uk/`
+
+The root page should describe KS2 Mastery as an online KS2 spelling, grammar, and punctuation practice product. The copy must stay aligned with the actual app experience and must not expose private learner state, admin surfaces, generated content stores, or internal analytics.
+
+The first sitemap intentionally lists only the canonical root URL. Future practice-tool, subject/problem, or parent-support pages should be added only after they exist as accurate public pages.
+
+## Production Checks
+
+After deployment, verify:
+
+- `https://ks2.eugnel.uk/` returns public identity copy, meta description, canonical URL, share metadata, and JSON-LD product identity.
+- `https://ks2.eugnel.uk/robots.txt` returns a robots policy, not the SPA HTML fallback, and excludes `/api/`, `/admin`, and `/demo` from normal crawler discovery.
+- `https://ks2.eugnel.uk/sitemap.xml` returns an XML sitemap with only the canonical root URL.
+- `npm run audit:production -- --skip-local` passes against the live origin.
+
+Search engines can still take time to crawl and index the site after these checks pass.
+
+## Search Console
+
+Use Google Search Console or equivalent search tooling to:
+
+- Verify ownership for `https://ks2.eugnel.uk/`.
+- Submit `https://ks2.eugnel.uk/sitemap.xml`.
+- Inspect the canonical root URL after deployment.
+- Review indexing status and organic queries before choosing the next SEO content page.
+
+The verification method depends on the external account setup. Do not add placeholder verification tokens to the repo.
+
+## Analytics
+
+Worker observability is infrastructure telemetry. It is useful for errors and runtime health, but it is not visitor analytics and does not answer organic acquisition questions.
+
+For aggregate visitor analytics, prefer Cloudflare Web Analytics first because the site already runs on Cloudflare. GA4 or Zaraz can be added later if James chooses that stack and supplies the real property or site-token configuration.
+
+Any analytics script must be reviewed against:
+
+- CSP script and connect directives.
+- Privacy expectations for an education product.
+- Consent requirements for the chosen analytics provider.
+- Existing security-header and production-audit gates.
+
+Analytics is decision support. It is not a direct ranking mechanism.
+
+## Next Content Choices
+
+Preserve these acquisition lanes for later work:
+
+- Practice-tool intent, such as KS2 spelling practice online or KS2 grammar practice.
+- Subject/problem intent, such as practising apostrophes or Year 5 spelling words.
+- Parent-support intent, such as helping a child with KS2 grammar at home.
+- AI-readable product identity, where assistants can understand what KS2 Mastery is and when it is relevant.
+
+Pick the next content slice from product fit, organic value, and observed measurement signals. Avoid broad keyword chasing or thin pages.

--- a/docs/plans/2026-04-28-002-feat-ks2-seo-foundation-plan.md
+++ b/docs/plans/2026-04-28-002-feat-ks2-seo-foundation-plan.md
@@ -1,0 +1,423 @@
+---
+title: "feat: Add KS2 SEO Foundation"
+type: feat
+status: completed
+date: 2026-04-28
+origin: docs/brainstorms/2026-04-28-ks2-seo-foundation-requirements.md
+---
+
+# feat: Add KS2 SEO Foundation
+
+## Summary
+
+Implement the V1 SEO foundation by enriching the public root experience, shipping valid crawler discovery assets through the existing public build, adding CSP-safe structured identity data, and extending build plus production audits so the live site cannot silently fall back to a sparse SPA shell.
+
+---
+
+## Problem Frame
+
+The origin requirements establish that KS2 Mastery currently behaves like a production app first and a public discovery surface second. This plan keeps the existing app, demo, auth, and deployment boundaries intact while making the public root understandable to search crawlers, AI assistants, and prospective KS2 users.
+
+---
+
+## Requirements
+
+- R1. Create a public, crawlable identity layer that explains KS2 Mastery in plain UK English without requiring sign-in.
+- R2. Clearly state that KS2 Mastery supports KS2 spelling, grammar, and punctuation practice.
+- R3. Describe the product by learner value and practice outcome, not only by internal module names.
+- R4. Provide enough direct public text for humans and AI systems to understand who the product helps and when it is relevant.
+- R5. Preserve a clear path into the existing app or demo experience without exposing private learner state.
+- R6. Prioritise one strong public identity surface over many thin pages.
+- R7. Expose valid crawler discovery files, including robots policy and sitemap discovery.
+- R8. Add search-friendly metadata: title, description, canonical identity, and share-preview metadata.
+- R9. Avoid accidental duplicate identities for the same content.
+- R10. Account for the existing SPA shape so crawlers are not left with only a sparse shell.
+- R11. Preserve security, privacy, authentication, demo, and learner-state boundaries.
+- R12. Make Search Console-style discovery and indexing validation possible.
+- R13. Prepare privacy-conscious aggregate visitor analytics for organic traffic review.
+- R14. Treat analytics as decision support, not as a ranking mechanism.
+- R15. Verify live production SEO resources and metadata, not only local build output.
+- R16. Preserve future acquisition lanes: practice-tool intent, subject/problem intent, parent-support intent, and AI-readable product identity.
+- R17. Leave a clear path for focused content pages later without committing to a content programme now.
+- R18. Select later content pages based on organic value, product fit, and observed measurement signals.
+- R19. Keep public SEO claims aligned with actual product capability and avoid recommendation guarantees.
+
+**Origin actors:** A1 prospective KS2 learner/supporting adult; A2 search crawler; A3 AI search or assistant system; A4 James/product operator; A5 KS2 Mastery app.
+
+**Origin flows:** F1 public discovery and product understanding; F2 search engine discovery and validation; F3 organic measurement and next-slice selection.
+
+**Origin acceptance examples:** AE1 product identity is understandable without sign-in; AE2 app/demo entry preserves private data boundaries; AE3 discovery files and metadata work in production; AE4 public site is understandable without authenticated app flow; AE5 measurement supports decisions; AE6 later content lanes remain open.
+
+---
+
+## Scope Boundaries
+
+- Do not build a blog, content farm, or broad keyword programme in this V1.
+- Do not promise that Google, AI search, or assistants will recommend the site.
+- Do not build paid advertising, school sales funnels, CRM flows, or conversion automation.
+- Do not create separate V1 funnels for parents, tutors, and schools.
+- Do not expose private learner data, authenticated read models, admin surfaces, internal analytics, or generated content stores as public SEO content.
+- Do not add analytics tags as if they improve ranking directly.
+- Do not weaken CSP, security headers, demo safeguards, auth boundaries, deployment controls, or privacy posture for SEO convenience.
+- Do not add placeholder Google Analytics, Cloudflare Web Analytics, or Search Console verification tokens that are not backed by real external configuration.
+
+### Deferred to Follow-Up Work
+
+- Practice-tool landing pages: add focused pages such as KS2 spelling practice or KS2 grammar practice after the root foundation is live and measurable.
+- Subject/problem landing pages: add pages for concrete needs such as apostrophes, punctuation, or Year 5 spelling words after V1 proves the publication path.
+- Parent-support content: add home-support guidance only after the product identity and measurement baseline are stable.
+- GA4 or Zaraz instrumentation: add only if James chooses that stack and supplies the real property/tag configuration.
+- Search Console ownership verification: complete in the external account or a separate code slice when the chosen verification method is known.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `index.html` is the canonical public root HTML and currently contains basic app/PWA metadata, one inline theme bootstrap script, an empty `#app`, and the React bundle entry.
+- `manifest.webmanifest` already carries stronger app description than the HTML shell and should be kept consistent with the public identity copy.
+- `src/surfaces/auth/AuthSurface.jsx` is the unauthenticated rendered destination at the root when no session exists; it should mirror the same product truth the raw HTML exposes.
+- `tests/react-auth-boot.test.js` and `tests/helpers/react-render.js` provide an existing SSR-style fixture for AuthSurface assertions.
+- `wrangler.jsonc` uses Cloudflare Workers Static Assets with SPA not-found handling. Static root files should flow through the existing assets build rather than a new Worker route.
+- `scripts/build-public.mjs` controls which root files are copied into `dist/public`, versions the app bundle in HTML, and substitutes the CSP hash placeholder in `_headers`.
+- `scripts/assert-build-public.mjs` is the local public-output gate and already rejects unexpected public artefacts or raw source leakage.
+- `_headers` and `scripts/lib/headers-drift.mjs` define the deployed static asset security and cache contract.
+- `worker/src/security-headers.js`, `worker/src/generated-csp-hash.js`, `tests/csp-policy.test.js`, and `tests/security-headers.test.js` guard the CSP Report-Only policy and inline-script hash path.
+- `scripts/production-bundle-audit.mjs` and `tests/bundle-audit.test.js` are the right production gate for proving the live site returns SEO resources rather than SPA fallback HTML.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture-patterns/admin-console-section-extraction-pattern-2026-04-27.md`: check existing platform configuration before inventing new routes; extend the established surface when the current platform already has a seam.
+- `docs/solutions/workflow-issues/sys-hardening-p2-13-unit-autonomous-sprint-learnings-2026-04-26.md`: keep coupled build, public-output, audit, and runtime changes atomic so reverting one file cannot leave a silent production gap.
+- `docs/plans/2026-04-23-001-feat-full-lockdown-runtime-plan.md`: public output allowlists and bundle audits are production boundaries; SEO assets must be added deliberately, not by broadening public copy rules.
+
+### External References
+
+- Google Search Central: [Build and submit a sitemap](https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap)
+- Google Search Central: [Control snippets in search results](https://developers.google.com/search/docs/appearance/snippet)
+- Google Search Central: [JavaScript SEO basics](https://developers.google.com/search/docs/crawling-indexing/javascript/javascript-seo-basics)
+- Google Search Central: [Use Search Console with Google Analytics](https://developers.google.com/search/docs/monitor-debug/google-analytics-search-console)
+- Cloudflare Docs: [Get started with Web Analytics](https://developers.cloudflare.com/web-analytics/get-started/)
+- Cloudflare Docs: [Google Analytics reference](https://developers.cloudflare.com/fundamentals/reference/google-analytics/)
+
+---
+
+## Key Technical Decisions
+
+- Integrate V1 into the root public experience: The strongest first surface is `https://ks2.eugnel.uk/`, with raw HTML fallback content for non-JS readers and matching AuthSurface copy for JS-rendered users.
+- Publish discovery assets as static files: `robots.txt` and `sitemap.xml` should be copied by the public build and served by Cloudflare Static Assets, avoiding unnecessary Worker routing.
+- Add structured identity data only through the CSP-safe path: V1 should use inline JSON-LD for machine-readable product identity, and the inline-script hashing pipeline must support it in the same change; SEO must not introduce untracked inline script drift.
+- Keep sitemap scope intentionally narrow: V1 should list the canonical root URL only, because later content pages do not exist yet and private app routes should not be advertised.
+- Prefer Cloudflare Web Analytics as the first visitor-analytics option: It matches the existing hosting stack and can be documented without adding placeholder third-party IDs; GA4/Zaraz remains a later explicit choice.
+- Treat production audit as the release gate: The live audit must prove `/robots.txt`, `/sitemap.xml`, and `/` return the intended SEO content and metadata, because local build success would not catch Cloudflare SPA fallback regressions.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Public route shape: Use the existing root entry rather than a separate mini-site or new Worker route.
+- Discovery file delivery: Use static public assets copied by `scripts/build-public.mjs`.
+- Measurement stack: Document Search Console and Cloudflare Web Analytics readiness in V1; defer real GA4/Zaraz wiring until James chooses a property/tag setup.
+- First post-foundation content slice: Defer until V1 is live and there is indexing or traffic evidence to guide the next page.
+
+### Deferred to Implementation
+
+- Final public copy wording: Implementation should tune concise UK English copy, but it must stay within R1-R5 and R19.
+- Structured data shape: Implementation should choose the smallest accurate schema vocabulary that represents the public product identity without overstating educational outcomes.
+- Exact Web Analytics enablement path: Implementation should document the Cloudflare setup path, but actual dashboard activation or token insertion depends on external configuration.
+- Search Console ownership method: Implementation should document options; the chosen verification method depends on James's Google account/property setup.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart LR
+  sourceHtml["index.html<br/>metadata + raw identity + app mount"] --> publicBuild["scripts/build-public.mjs"]
+  robots["robots.txt"] --> publicBuild
+  sitemap["sitemap.xml"] --> publicBuild
+  headers["_headers<br/>SEO cache groups + CSP hashes"] --> publicBuild
+  publicBuild --> output["dist/public"]
+  output --> assets["Cloudflare Static Assets"]
+  assets --> root["/"]
+  assets --> robotsLive["/robots.txt"]
+  assets --> sitemapLive["/sitemap.xml"]
+  auth["AuthSurface rendered root"] --> root
+  audit["assert-build-public + production-bundle-audit"] --> output
+  audit --> root
+  audit --> robotsLive
+  audit --> sitemapLive
+```
+
+---
+
+## Implementation Units
+
+- U1. **Public Root Identity and Metadata**
+
+**Goal:** Make the root page understandable to raw HTML readers, rendered JS users, search crawlers, and AI assistants without requiring sign-in.
+
+**Requirements:** R1, R2, R3, R4, R5, R6, R8, R9, R10, R11, R19; F1; AE1, AE2, AE4.
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `index.html`
+- Modify: `manifest.webmanifest`
+- Modify: `src/surfaces/auth/AuthSurface.jsx`
+- Modify: `tests/react-auth-boot.test.js`
+- Modify: `tests/build-public.test.js`
+- Modify: `scripts/assert-build-public.mjs`
+
+**Approach:**
+- Replace the generic platform title with a search-readable KS2 Mastery title and description that mention spelling, grammar, and punctuation.
+- Add canonical, Open Graph, and Twitter/share metadata for the root URL.
+- Add concise crawlable root fallback content inside the app mount so non-JS readers can understand the product before React replaces it.
+- Update AuthSurface unauthenticated copy so the rendered root repeats the same product identity and gives a clear path into the existing demo or sign-in flow.
+- Keep the visible copy factual and product-aligned: KS2 practice support, not guaranteed results or broad curriculum coverage.
+
+**Patterns to follow:**
+- Existing PWA metadata in `index.html`.
+- AuthSurface copy and error-state branching in `src/surfaces/auth/AuthSurface.jsx`.
+- SSR-style AuthSurface assertions in `tests/react-auth-boot.test.js`.
+- Public build assertions in `scripts/assert-build-public.mjs`.
+
+**Test scenarios:**
+- Covers AE1. Happy path: reading built `dist/public/index.html` finds the KS2 Mastery product name, KS2 spelling, grammar, punctuation, and a plain-language learner value proposition.
+- Covers AE2. Happy path: rendering AuthSurface without a session shows the product identity plus existing sign-in/social/demo paths, with no private learner data.
+- Covers AE4. Integration: built root HTML contains enough identity text before JavaScript runs, and the rendered AuthSurface still contains matching identity after JavaScript runs.
+- Edge case: metadata contains one canonical root URL and does not introduce duplicate canonical identities.
+- Error path: public build assertion fails if the root HTML regresses to the old sparse app-shell title or loses the required description.
+
+**Verification:**
+- The source and built root HTML both expose accurate product identity, and the unauthenticated React surface mirrors it without changing the authenticated app destination.
+
+---
+
+- U2. **CSP-Safe Structured Identity Data**
+
+**Goal:** Add JSON-LD structured product identity in a way that preserves the existing CSP and inline-script hardening contract.
+
+**Requirements:** R4, R8, R10, R11, R15, R19; F1, F2; AE1, AE3, AE4.
+
+**Dependencies:** U1.
+
+**Files:**
+- Modify: `index.html`
+- Modify: `scripts/compute-inline-script-hash.mjs`
+- Modify: `scripts/build-public.mjs`
+- Modify: `worker/src/generated-csp-hash.js`
+- Modify: `worker/src/security-headers.js`
+- Modify: `_headers`
+- Modify: `scripts/lib/headers-drift.mjs`
+- Modify: `tests/csp-policy.test.js`
+- Modify: `tests/security-headers.test.js`
+- Modify: `tests/build-public.test.js`
+- Modify: `scripts/assert-build-public.mjs`
+
+**Approach:**
+- Add the smallest accurate JSON-LD identity block for the public product, focused on name, URL, audience, practice areas, and application category.
+- Generalise the CSP hash pipeline so every intentional inline script block in `index.html` is hashed or otherwise explicitly classified, instead of assuming a single theme bootstrap script forever.
+- Update the generated hash module, public hash artefact, and CSP tests atomically so no runtime or audit path assumes only one inline hash.
+- Keep `_headers` and `worker/src/security-headers.js` in sync so Static Assets and Worker responses report the same CSP allowance.
+- Keep the pre-build placeholder behaviour that lets a fresh checkout run tests before the public build generates real hashes.
+
+**Execution note:** Add characterization coverage for the current single-inline-script helper before generalising it, because this path is security-sensitive and already has deployment history.
+
+**Patterns to follow:**
+- Existing CSP hash generation in `scripts/build-public.mjs`.
+- CSP policy exports and tests in `worker/src/security-headers.js`, `tests/csp-policy.test.js`, and `tests/security-headers.test.js`.
+- Drift-contract style in `scripts/lib/headers-drift.mjs`.
+
+**Test scenarios:**
+- Happy path: the hash helper accepts the theme bootstrap plus the structured identity block and returns all CSP tokens needed by the source HTML.
+- Covers AE3. Integration: the built `_headers` substitutes real CSP hash tokens and contains no build-time placeholder tokens.
+- Integration: the public CSP hash artefact records every intentional inline hash needed to explain what shipped.
+- Edge case: adding an unexpected third inline script without classification fails loudly rather than silently shipping an untracked CSP gap.
+- Error path: a mismatched `_headers` CSP token fails the existing drift contract.
+- Covers AE1. Happy path: built root HTML contains parseable structured identity data that names KS2 Mastery and does not include private learner or admin terms.
+
+**Verification:**
+- Structured identity is present in public HTML, the CSP policy accounts for it, and no test or audit path needs CSP weakening.
+
+---
+
+- U3. **Crawler Discovery Assets**
+
+**Goal:** Ship valid `/robots.txt` and `/sitemap.xml` responses as first-class public assets rather than SPA fallback HTML.
+
+**Requirements:** R7, R9, R10, R11, R12, R15; F2; AE3.
+
+**Dependencies:** U1.
+
+**Files:**
+- Create: `robots.txt`
+- Create: `sitemap.xml`
+- Modify: `scripts/build-public.mjs`
+- Modify: `scripts/assert-build-public.mjs`
+- Modify: `_headers`
+- Modify: `scripts/lib/headers-drift.mjs`
+- Modify: `tests/build-public.test.js`
+- Modify: `tests/security-headers.test.js`
+
+**Approach:**
+- Add a simple robots policy that allows the public root and advertises the sitemap URL.
+- Add a minimal sitemap containing the canonical root URL only.
+- Include both files in the public-build allowlist and top-level output assertions.
+- Add explicit `_headers` cache groups for text/XML discovery resources so Cloudflare does not merge an unintended wildcard cache policy.
+- Keep private, API, admin, and authenticated app routes out of the sitemap.
+
+**Patterns to follow:**
+- Static asset entry handling in `scripts/build-public.mjs`.
+- Top-level allowlist checks in `scripts/assert-build-public.mjs`.
+- Cache split rules in `scripts/lib/headers-drift.mjs`.
+
+**Test scenarios:**
+- Covers AE3. Happy path: `dist/public/robots.txt` exists, is plain text, references `https://ks2.eugnel.uk/sitemap.xml`, and does not contain app-shell HTML.
+- Covers AE3. Happy path: `dist/public/sitemap.xml` exists, is valid XML, contains only the canonical root URL, and does not include `/api`, `/admin`, private learner routes, or local URLs.
+- Edge case: public output allowlist rejects unexpected top-level files while accepting the two new SEO files.
+- Integration: `_headers` drift tests require cache groups for `/robots.txt` and `/sitemap.xml` without adding `Cache-Control` to the wildcard `/*` block.
+
+**Verification:**
+- Local public output contains real discovery files and the static header contract recognises them as intentional public resources.
+
+---
+
+- U4. **Production SEO Audit Gate**
+
+**Goal:** Extend live production validation so SEO regressions are caught after deployment, especially Cloudflare SPA fallback behaviour.
+
+**Requirements:** R7, R8, R9, R10, R11, R12, R15; F2; AE3, AE4.
+
+**Dependencies:** U1, U2, U3.
+
+**Files:**
+- Modify: `scripts/production-bundle-audit.mjs`
+- Modify: `tests/bundle-audit.test.js`
+
+**Approach:**
+- Add production fetch checks for `/`, `/robots.txt`, and `/sitemap.xml`.
+- Validate response bodies, content types where available, canonical URL consistency, required product identity text, metadata, structured data, and absence of SPA fallback HTML in discovery files.
+- Keep audit errors specific enough for deployment triage, naming the failed URL and missing or malformed SEO contract.
+- Preserve existing forbidden-token, security-header, demo bootstrap, and cache checks.
+
+**Execution note:** Drive the new audit behaviours with stub-origin tests before touching the production audit script, because this script is a release gate and should fail loudly on realistic regressions.
+
+**Patterns to follow:**
+- Stub-origin tests already present in `tests/bundle-audit.test.js`.
+- Existing live header and forbidden-token checks in `scripts/production-bundle-audit.mjs`.
+
+**Test scenarios:**
+- Covers AE3. Happy path: stub production origin with valid root metadata, robots file, and sitemap passes the SEO audit checks.
+- Error path: stub origin returning `index.html` for `/robots.txt` fails with a clear SPA fallback message.
+- Error path: sitemap missing the canonical root URL fails.
+- Error path: root HTML missing canonical URL, meta description, or product identity text fails.
+- Covers AE4. Integration: root audit checks raw HTML identity without requiring authenticated app APIs or demo session setup.
+
+**Verification:**
+- Production audit can distinguish a real SEO foundation from a deployment that only serves the generic SPA shell.
+
+---
+
+- U5. **SEO Operations and Measurement Readiness**
+
+**Goal:** Give James a clear operator path for indexing, analytics selection, and next content decisions without baking unknown external tokens into the repo.
+
+**Requirements:** R12, R13, R14, R16, R17, R18, R19; F3; AE5, AE6.
+
+**Dependencies:** U1, U3, U4.
+
+**Files:**
+- Create: `docs/operations/seo.md`
+
+**Approach:**
+- Document the V1 production validation checklist: root metadata, robots, sitemap, Search Console submission, and production audit outcome.
+- Explain the current analytics state: Worker observability is infrastructure telemetry; Cloudflare Web Analytics is the preferred visitor analytics option; GA4/Zaraz is optional and separate.
+- Capture privacy and CSP considerations for any later analytics script.
+- Record the four future acquisition lanes from the origin requirements and the rule for choosing the next page from evidence, not broad keyword chasing.
+
+**Patterns to follow:**
+- Operational guidance style in `docs/operations/capacity.md`.
+- Origin scope boundaries and future content lanes in `docs/brainstorms/2026-04-28-ks2-seo-foundation-requirements.md`.
+
+**Test scenarios:**
+- Test expectation: none -- this unit is documentation and external-operations guidance only.
+
+**Verification:**
+- The docs give James enough information to validate indexing readiness and decide whether to enable Cloudflare Web Analytics or GA4/Zaraz as a separate configured step.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Root HTML, AuthSurface, public-build copy rules, Static Assets headers, Worker security headers, and production audit now jointly define the public SEO contract.
+- **Error propagation:** Build assertions should catch missing local artefacts; production audit should catch Cloudflare fallback or header/content-type mismatches; documentation should handle dashboard-only setup gaps.
+- **State lifecycle risks:** No learner, session, D1, R2, or generated content state should become public. SEO content is static identity copy only.
+- **API surface parity:** No app API contract changes are planned. The only public surface additions are static root/discovery responses and metadata.
+- **Integration coverage:** Local output tests prove assets exist; production audit proves the deployed domain returns the intended resources.
+- **Unchanged invariants:** Authenticated app flows, demo session behaviour, security headers, CSP Report-Only posture, and deployment scripts remain in place.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `/robots.txt` or `/sitemap.xml` still fall back to `index.html` in production | Add static assets through `scripts/build-public.mjs` and verify live responses in `scripts/production-bundle-audit.mjs`. |
+| JSON-LD or other structured data breaks the CSP hash contract | Treat structured data and CSP hash support as one implementation unit with tests across build, Worker headers, and `_headers`. |
+| Public copy overstates the product | Keep copy limited to KS2 spelling, grammar, and punctuation practice, with tests/audit checks for the core terms and documentation of R19. |
+| Analytics setup creates privacy or CSP drift | Do not add placeholder tags in V1; document Cloudflare Web Analytics first and defer GA4/Zaraz wiring until real configuration is chosen. |
+| Search ranking or AI recommendation expectations become overclaimed | Keep docs and public copy explicit that this improves crawlability and understandability, not guaranteed placement. |
+
+---
+
+## Documentation / Operational Notes
+
+- `docs/operations/seo.md` should be the operator-facing reference for Search Console submission, analytics choices, production checks, and next content planning.
+- Production verification after deployment should inspect the live domain, not only the local `dist/public` output.
+- If James later chooses GA4, Zaraz, or Cloudflare Web Analytics snippet insertion, that work should include a fresh CSP/privacy review rather than editing `index.html` in isolation.
+
+---
+
+## Alternative Approaches Considered
+
+- Separate landing page route: Rejected for V1 because the canonical root is the most valuable identity surface and a second page would add duplicate-identity risk before the product needs multiple public pages.
+- Worker-handled SEO routes: Rejected because Static Assets and the public build already provide the correct seam for root discovery files.
+- Analytics script wiring in V1: Rejected until real property or site-token configuration exists; placeholder IDs would create false confidence and possible CSP/privacy churn.
+- Broad content page launch: Rejected for V1 because the origin requirements prioritise one strong AI-readable product identity surface before ranking specific queries.
+
+---
+
+## Success Metrics
+
+- Live `/robots.txt` returns a robots policy, not HTML.
+- Live `/sitemap.xml` returns a sitemap containing the canonical root URL, not HTML.
+- Live `/` exposes title, meta description, canonical URL, share metadata, public identity text, and structured identity data.
+- Search Console can submit or inspect the sitemap and root URL after release.
+- James can choose the next SEO content slice from measured indexing or organic traffic signals rather than guessing.
+
+---
+
+## Sources & References
+
+- Origin document: [docs/brainstorms/2026-04-28-ks2-seo-foundation-requirements.md](../brainstorms/2026-04-28-ks2-seo-foundation-requirements.md)
+- Public shell: `index.html`
+- Public app manifest: `manifest.webmanifest`
+- Auth surface: `src/surfaces/auth/AuthSurface.jsx`
+- Public build: `scripts/build-public.mjs`
+- Public build assertion: `scripts/assert-build-public.mjs`
+- Static headers: `_headers`
+- Header drift contract: `scripts/lib/headers-drift.mjs`
+- Worker security headers: `worker/src/security-headers.js`
+- Production audit: `scripts/production-bundle-audit.mjs`
+- Google Search Central sitemap guidance: [developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap](https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap)
+- Google Search Central snippet guidance: [developers.google.com/search/docs/appearance/snippet](https://developers.google.com/search/docs/appearance/snippet)
+- Google Search Central JavaScript SEO basics: [developers.google.com/search/docs/crawling-indexing/javascript/javascript-seo-basics](https://developers.google.com/search/docs/crawling-indexing/javascript/javascript-seo-basics)
+- Google Search Console and Analytics guidance: [developers.google.com/search/docs/monitor-debug/google-analytics-search-console](https://developers.google.com/search/docs/monitor-debug/google-analytics-search-console)
+- Cloudflare Web Analytics: [developers.cloudflare.com/web-analytics/get-started](https://developers.cloudflare.com/web-analytics/get-started/)
+- Cloudflare Google Analytics reference: [developers.cloudflare.com/fundamentals/reference/google-analytics](https://developers.cloudflare.com/fundamentals/reference/google-analytics/)

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <meta name="application-name" content="KS2 Mastery" />
+  <meta name="description" content="KS2 Mastery helps learners practise KS2 spelling, grammar and punctuation online with focused demo and sign-in experiences." />
   <meta name="apple-mobile-web-app-title" content="KS2 Mastery" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="mobile-web-app-capable" content="yes" />
@@ -11,7 +12,17 @@
   <meta name="color-scheme" content="light dark" />
   <meta name="theme-color" content="#F6F5F1" media="(prefers-color-scheme: light)" />
   <meta name="theme-color" content="#0F1620" media="(prefers-color-scheme: dark)" />
-  <title>KS2 Mastery Platform v2</title>
+  <meta property="og:site_name" content="KS2 Mastery" />
+  <meta property="og:title" content="KS2 Mastery | KS2 Spelling, Grammar and Punctuation Practice" />
+  <meta property="og:description" content="Online KS2 English practice for spelling, grammar and punctuation, with a demo path for learners and supporting adults." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://ks2.eugnel.uk/" />
+  <meta property="og:locale" content="en_GB" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="KS2 Mastery | KS2 Spelling, Grammar and Punctuation Practice" />
+  <meta name="twitter:description" content="Focused online KS2 spelling, grammar and punctuation practice." />
+  <title>KS2 Mastery | KS2 Spelling, Grammar and Punctuation Practice</title>
+  <link rel="canonical" href="https://ks2.eugnel.uk/" />
   <link rel="manifest" href="/manifest.webmanifest" />
   <link rel="icon" href="/favicon.ico" sizes="any" />
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/app-icons/favicon-32.png" />
@@ -32,9 +43,48 @@
       } catch (err) {}
     })();
   </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": ["WebApplication", "LearningResource"],
+  "name": "KS2 Mastery",
+  "url": "https://ks2.eugnel.uk/",
+  "description": "KS2 Mastery helps learners practise KS2 spelling, grammar and punctuation online.",
+  "applicationCategory": "EducationalApplication",
+  "operatingSystem": "Web",
+  "educationalLevel": "Key Stage 2",
+  "learningResourceType": "Practice tool",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "teaches": [
+    "KS2 spelling",
+    "KS2 grammar",
+    "KS2 punctuation"
+  ]
+}
+  </script>
 </head>
 <body>
-  <div id="app"></div>
+  <div id="app">
+    <main class="seo-public-fallback" aria-label="KS2 Mastery public summary">
+      <section class="seo-public-panel">
+        <p class="eyebrow">KS2 Mastery</p>
+        <h1>KS2 spelling, grammar and punctuation practice</h1>
+        <p>
+          KS2 Mastery helps learners practise key English skills online with focused sessions for
+          spelling, grammar and punctuation.
+        </p>
+        <ul aria-label="Practice areas">
+          <li>Spelling practice for KS2 word confidence</li>
+          <li>Grammar practice for sentence-level accuracy</li>
+          <li>Punctuation practice for clearer written English</li>
+        </ul>
+        <p><a class="btn primary lg" href="/demo">Try demo</a></p>
+      </section>
+    </main>
+  </div>
   <script type="module" src="./src/bundles/app.bundle.js"></script>
 </body>
 </html>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "KS2 Mastery",
   "short_name": "KS2 Mastery",
-  "description": "A KS2 practice web app with spelling, punctuation, grammar and collectible mastery creatures.",
+  "description": "A KS2 practice web app for spelling, grammar and punctuation, with demo access and saved learner progress.",
   "id": "/",
   "start_url": "/",
   "scope": "/",

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,7 @@
+User-agent: *
+Disallow: /api/
+Disallow: /admin
+Disallow: /demo
+Allow: /
+
+Sitemap: https://ks2.eugnel.uk/sitemap.xml

--- a/scripts/assert-build-public.mjs
+++ b/scripts/assert-build-public.mjs
@@ -35,6 +35,34 @@ async function walk(relativeDir = '') {
   return files;
 }
 
+function assertContainsAll(label, value, expectedTokens) {
+  for (const token of expectedTokens) {
+    if (!value.includes(token)) {
+      throw new Error(`${label} must include: ${token}`);
+    }
+  }
+}
+
+function jsonLdBlocks(html) {
+  const blocks = [];
+  const pattern = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
+  let match = pattern.exec(html);
+  while (match) {
+    const attributes = String(match[1] || '');
+    if (!/\btype=["']application\/ld\+json["']/i.test(attributes)) {
+      match = pattern.exec(html);
+      continue;
+    }
+    try {
+      blocks.push(JSON.parse(match[2]));
+    } catch (error) {
+      throw new Error(`Public index.html contains invalid JSON-LD: ${error?.message || error}`);
+    }
+    match = pattern.exec(html);
+  }
+  return blocks;
+}
+
 async function currentMonsterAssetKeys() {
   const monsterRoot = path.join(rootDir, 'assets', 'monsters');
   const keys = new Map();
@@ -58,6 +86,8 @@ async function currentMonsterAssetKeys() {
 
 await mustExist('index.html');
 await mustExist('manifest.webmanifest');
+await mustExist('robots.txt');
+await mustExist('sitemap.xml');
 await mustExist('favicon.ico');
 await mustExist('_headers');
 await mustExist('styles/app.css');
@@ -113,6 +143,8 @@ const allowed = new Set([
   'favicon.ico',
   'index.html',
   'manifest.webmanifest',
+  'robots.txt',
+  'sitemap.xml',
   'styles',
   'src',
   'assets',
@@ -171,6 +203,10 @@ assertCacheSplitRules(publishedHeadersContent);
 
 const indexHtml = await readFile(path.join(publicDir, 'index.html'), 'utf8');
 const appBundle = await readFile(path.join(publicDir, 'src/bundles/app.bundle.js'), 'utf8');
+const robotsTxt = await readFile(path.join(publicDir, 'robots.txt'), 'utf8');
+const sitemapXml = await readFile(path.join(publicDir, 'sitemap.xml'), 'utf8');
+const cspHashArtefact = await readFile(path.join(publicDir, '.csp-theme-hash'), 'utf8');
+const canonicalRoot = 'https://ks2.eugnel.uk/';
 if (!indexHtml.includes('/manifest.webmanifest')) {
   throw new Error('Public index.html must link the web app manifest.');
 }
@@ -187,6 +223,64 @@ if (appBundleVersionMatch[1] !== expectedAppBundleVersion) {
 }
 if (indexHtml.includes('home.bundle.js') || indexHtml.includes('src/main.js')) {
   throw new Error('Public index.html must not load legacy home islands or the raw source entry.');
+}
+
+assertContainsAll('Public index.html SEO identity', indexHtml, [
+  '<title>KS2 Mastery | KS2 Spelling, Grammar and Punctuation Practice</title>',
+  '<meta name="description"',
+  `<link rel="canonical" href="${canonicalRoot}" />`,
+  '<meta property="og:title"',
+  '<meta property="og:description"',
+  `<meta property="og:url" content="${canonicalRoot}" />`,
+  '<meta name="twitter:card" content="summary" />',
+  'KS2 spelling, grammar and punctuation practice',
+  'Spelling practice for KS2 word confidence',
+  'Grammar practice for sentence-level accuracy',
+  'Punctuation practice for clearer written English',
+]);
+
+const productIdentity = jsonLdBlocks(indexHtml).find((entry) => entry?.name === 'KS2 Mastery');
+if (!productIdentity) {
+  throw new Error('Public index.html must include JSON-LD product identity for KS2 Mastery.');
+}
+if (productIdentity.url !== canonicalRoot) {
+  throw new Error(`Public JSON-LD product identity must use canonical URL ${canonicalRoot}.`);
+}
+assertContainsAll('Public JSON-LD product identity', JSON.stringify(productIdentity), [
+  'KS2 spelling',
+  'KS2 grammar',
+  'KS2 punctuation',
+  'Practice tool',
+]);
+
+const cspHashLines = cspHashArtefact.split(/\r?\n/u).filter(Boolean);
+if (cspHashLines.length < 2 || !cspHashLines.every((line) => /^sha256-[A-Za-z0-9+/]+=*$/.test(line))) {
+  throw new Error('Public .csp-theme-hash must list every intentional inline script hash, including JSON-LD.');
+}
+
+if (/<\/?html|<!doctype/i.test(robotsTxt)) {
+  throw new Error('robots.txt must not be the SPA HTML fallback.');
+}
+assertContainsAll('robots.txt', robotsTxt, [
+  'User-agent: *',
+  'Disallow: /api/',
+  'Disallow: /admin',
+  'Disallow: /demo',
+  'Allow: /',
+  `Sitemap: ${canonicalRoot}sitemap.xml`,
+]);
+
+if (/<\/?html|<!doctype/i.test(sitemapXml)) {
+  throw new Error('sitemap.xml must not be the SPA HTML fallback.');
+}
+assertContainsAll('sitemap.xml', sitemapXml, [
+  '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+  `<loc>${canonicalRoot}</loc>`,
+]);
+for (const forbiddenPublicPath of ['/api/', '/admin', 'localhost', '127.0.0.1']) {
+  if (sitemapXml.includes(forbiddenPublicPath)) {
+    throw new Error(`sitemap.xml must not advertise private or local path: ${forbiddenPublicPath}`);
+  }
 }
 
 for (const token of [

--- a/scripts/build-public.mjs
+++ b/scripts/build-public.mjs
@@ -1,7 +1,7 @@
 import { cp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { createHash } from 'node:crypto';
-import { computeInlineScriptHash } from './compute-inline-script-hash.mjs';
+import { computeInlineScriptHashes } from './compute-inline-script-hash.mjs';
 
 const rootDir = process.cwd();
 const outputDir = path.join(rootDir, 'dist', 'public');
@@ -16,7 +16,7 @@ const tmpDir = path.join(rootDir, 'dist', 'public.tmp');
 //    graph (NOT under `src/generated/`, which is excluded below) so
 //    Wrangler bundles it.
 //  - `dist/public/.csp-theme-hash` is a plain-text artefact used by
-//    the drift audit and by operators checking which hash shipped.
+//    the drift audit and by operators checking which inline hashes shipped.
 //  - `dist/public/_headers` carries the CSP line with the hash value
 //    substituted into the `'sha256-BUILD_TIME_HASH'` placeholder.
 const generatedCspHashPath = path.join(rootDir, 'worker', 'src', 'generated-csp-hash.js');
@@ -33,6 +33,8 @@ const entries = [
   'favicon.ico',
   'index.html',
   'manifest.webmanifest',
+  'robots.txt',
+  'sitemap.xml',
   'styles',
   'assets',
 ];
@@ -136,11 +138,14 @@ try {
   await cp(tmpDir, outputDir, { recursive: true, force: true });
   await rm(tmpDir, { recursive: true, force: true });
 
-  // U7: compute the inline theme-script SHA-256 from the canonical
+  // U7/U2 SEO: compute the inline script SHA-256 values from the canonical
   // source (`index.html` at repo root). The public HTML rewrites only the
-  // external module script URL, so the inline theme script hash is unchanged.
+  // external module script URL, so the inline script hashes are unchanged.
   const sourceHtml = await readFile(path.join(rootDir, 'index.html'), 'utf8');
-  const cspThemeHash = computeInlineScriptHash(sourceHtml);
+  const cspInlineScriptHashes = computeInlineScriptHashes(sourceHtml);
+  const cspInlineScriptHashDirectives = cspInlineScriptHashes
+    .map((hash) => `'${hash}'`)
+    .join(' ');
 
   // Write the generated module that `worker/src/security-headers.js`
   // imports. Keep the module tiny so a broken build fails fast with a
@@ -152,18 +157,19 @@ try {
     '// This file is committed so fresh clones can run `npm test` before',
     '// `npm run build` has produced a real hash. Build overwrites this.',
     '',
-    `export const CSP_INLINE_SCRIPT_HASH = '${cspThemeHash}';`,
+    `export const CSP_INLINE_SCRIPT_HASHES = Object.freeze(${JSON.stringify(cspInlineScriptHashes)});`,
+    'export const CSP_INLINE_SCRIPT_HASH = CSP_INLINE_SCRIPT_HASHES[0];',
     '',
   ].join('\n');
   await writeFile(generatedCspHashPath, generatedModule, 'utf8');
-  await writeFile(publicCspHashArtefactPath, `${cspThemeHash}\n`, 'utf8');
+  await writeFile(publicCspHashArtefactPath, `${cspInlineScriptHashes.join('\n')}\n`, 'utf8');
 
-  // Substitute the placeholder token in `_headers`. The source file
-  // carries `'sha256-BUILD_TIME_HASH'` twice (once for `script-src`,
-  // once for `script-src-elem`); both are rewritten to the real value.
+  // Substitute the placeholder token in `_headers`. Each public header block
+  // carries the same placeholder in `script-src` and `script-src-elem`; every
+  // occurrence is rewritten to the current inline-script hash directives.
   const headersContent = await readFile(publicHeadersPath, 'utf8');
-  const substituted = headersContent.replaceAll("'sha256-BUILD_TIME_HASH'", `'${cspThemeHash}'`);
-  if (!substituted.includes(cspThemeHash)) {
+  const substituted = headersContent.replaceAll("'sha256-BUILD_TIME_HASH'", cspInlineScriptHashDirectives);
+  if (!cspInlineScriptHashes.every((hash) => substituted.includes(hash))) {
     throw new Error(
       '_headers must contain a \'sha256-BUILD_TIME_HASH\' placeholder for the CSP rollout (U7). '
       + 'Restore the placeholder or update scripts/build-public.mjs.',

--- a/scripts/compute-inline-script-hash.mjs
+++ b/scripts/compute-inline-script-hash.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-// U7 (sys-hardening p1): compute SHA-256 of the inline theme script
-// block embedded in `index.html` so the CSP `script-src` can list it
+// U7 (sys-hardening p1): compute SHA-256 of the intentional inline script
+// blocks embedded in `index.html` so the CSP `script-src` can list them
 // via `'sha256-<base64>'` instead of falling back to `unsafe-inline`.
 //
 // CLI usage:
@@ -25,22 +25,21 @@ const __dirname = path.dirname(__filename);
 const DEFAULT_HTML_PATH = path.resolve(__dirname, '..', 'index.html');
 
 /**
- * Extract the first `<script>...</script>` block that does NOT carry a
- * `src="..."` attribute (inline script). Returns the raw character data
- * between the opening and closing tags, preserving whitespace.
+ * Extract `<script>...</script>` blocks that do NOT carry a `src="..."`
+ * attribute. Returns each raw character-data body between the opening and
+ * closing tags, preserving whitespace.
  *
- * The app's `index.html` has exactly one such inline block — the theme
- * bootstrapper at lines 25-34 — and one external `<script src=...>`
- * that loads the app bundle. If a future change adds a second inline
- * block we must either hash it too or fail the build; this helper
- * throws when more than one inline block is present.
+ * The app's `index.html` intentionally has more than one inline block now:
+ * the executable theme bootstrapper and non-executing JSON-LD product
+ * identity. CSP still needs to know about every intentional inline script
+ * element, so callers should usually use `computeInlineScriptHashes()`.
  *
  * @param {string} html
- * @returns {string} inline script contents
+ * @returns {string[]} inline script contents
  */
-export function extractInlineScriptContents(html) {
+export function extractInlineScriptContentsList(html) {
   if (typeof html !== 'string') {
-    throw new TypeError('extractInlineScriptContents: html must be a string.');
+    throw new TypeError('extractInlineScriptContentsList: html must be a string.');
   }
   const pattern = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
   const inlineBlocks = [];
@@ -56,13 +55,18 @@ export function extractInlineScriptContents(html) {
   if (inlineBlocks.length === 0) {
     throw new Error('No inline <script> block found in HTML. CSP hash cannot be computed.');
   }
-  if (inlineBlocks.length > 1) {
-    throw new Error(
-      `Expected exactly one inline <script> block, found ${inlineBlocks.length}. `
-      + 'Update scripts/compute-inline-script-hash.mjs if multi-inline support is intentional.',
-    );
-  }
-  return inlineBlocks[0];
+  return inlineBlocks;
+}
+
+/**
+ * Backwards-compatible single-script extractor. This remains for existing
+ * callers and tests that care about the first inline script only.
+ *
+ * @param {string} html
+ * @returns {string} first inline script contents
+ */
+export function extractInlineScriptContents(html) {
+  return extractInlineScriptContentsList(html)[0];
 }
 
 /**
@@ -78,6 +82,19 @@ export function computeInlineScriptHash(html) {
 }
 
 /**
+ * Compute CSP-formatted hashes for every intentional inline script block.
+ *
+ * @param {string} html
+ * @returns {string[]} e.g. [`sha256-abc...=`]
+ */
+export function computeInlineScriptHashes(html) {
+  return extractInlineScriptContentsList(html).map((script) => {
+    const digest = createHash('sha256').update(script, 'utf8').digest('base64');
+    return `sha256-${digest}`;
+  });
+}
+
+/**
  * Read the HTML file at `htmlPath` and return its CSP hash.
  *
  * @param {string} [htmlPath]
@@ -86,6 +103,11 @@ export function computeInlineScriptHash(html) {
 export async function computeInlineScriptHashFromFile(htmlPath = DEFAULT_HTML_PATH) {
   const html = await readFile(htmlPath, 'utf8');
   return computeInlineScriptHash(html);
+}
+
+export async function computeInlineScriptHashesFromFile(htmlPath = DEFAULT_HTML_PATH) {
+  const html = await readFile(htmlPath, 'utf8');
+  return computeInlineScriptHashes(html);
 }
 
 function argValue(name, fallback) {
@@ -101,6 +123,6 @@ const invokedDirectly = process.argv[1]
   && import.meta.url === pathToFileURL(process.argv[1]).href;
 if (invokedDirectly) {
   const htmlPath = argValue('--html', DEFAULT_HTML_PATH);
-  const hash = await computeInlineScriptHashFromFile(htmlPath);
-  process.stdout.write(`${hash}\n`);
+  const hashes = await computeInlineScriptHashesFromFile(htmlPath);
+  process.stdout.write(`${hashes.join('\n')}\n`);
 }

--- a/scripts/compute-inline-script-hash.mjs
+++ b/scripts/compute-inline-script-hash.mjs
@@ -24,6 +24,49 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const DEFAULT_HTML_PATH = path.resolve(__dirname, '..', 'index.html');
 
+function extractInlineScriptBlocks(html) {
+  const pattern = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
+  const inlineBlocks = [];
+  let match = pattern.exec(html);
+  while (match) {
+    const attributes = String(match[1] || '');
+    const body = match[2] || '';
+    if (!/\bsrc\s*=/i.test(attributes)) {
+      inlineBlocks.push({ attributes, body });
+    }
+    match = pattern.exec(html);
+  }
+  return inlineBlocks;
+}
+
+function assertExpectedIndexInlineScripts(blocks) {
+  if (blocks.length !== 2) {
+    throw new Error(
+      `Expected exactly two intentional inline <script> blocks in index.html, found ${blocks.length}. `
+      + 'Only the theme bootstrapper and JSON-LD product identity may be inline.',
+    );
+  }
+
+  const [themeBootstrap, jsonLdIdentity] = blocks;
+  if (themeBootstrap.attributes.trim() !== '') {
+    throw new Error('The first inline <script> in index.html must be the attribute-free theme bootstrapper.');
+  }
+
+  const jsonLdAttributes = jsonLdIdentity.attributes.trim();
+  if (!/^type\s*=\s*["']application\/ld\+json["']$/i.test(jsonLdAttributes)) {
+    throw new Error(
+      'The second inline <script> in index.html must be the JSON-LD product identity. '
+      + `Found attributes: ${jsonLdAttributes || '(none)'}`,
+    );
+  }
+
+  try {
+    JSON.parse(jsonLdIdentity.body);
+  } catch (error) {
+    throw new Error(`The JSON-LD inline script in index.html must contain valid JSON: ${error?.message || error}`);
+  }
+}
+
 /**
  * Extract `<script>...</script>` blocks that do NOT carry a `src="..."`
  * attribute. Returns each raw character-data body between the opening and
@@ -41,17 +84,7 @@ export function extractInlineScriptContentsList(html) {
   if (typeof html !== 'string') {
     throw new TypeError('extractInlineScriptContentsList: html must be a string.');
   }
-  const pattern = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
-  const inlineBlocks = [];
-  let match = pattern.exec(html);
-  while (match) {
-    const attributes = String(match[1] || '');
-    const body = match[2] || '';
-    if (!/\bsrc\s*=/i.test(attributes)) {
-      inlineBlocks.push(body);
-    }
-    match = pattern.exec(html);
-  }
+  const inlineBlocks = extractInlineScriptBlocks(html).map((block) => block.body);
   if (inlineBlocks.length === 0) {
     throw new Error('No inline <script> block found in HTML. CSP hash cannot be computed.');
   }
@@ -88,8 +121,16 @@ export function computeInlineScriptHash(html) {
  * @returns {string[]} e.g. [`sha256-abc...=`]
  */
 export function computeInlineScriptHashes(html) {
-  return extractInlineScriptContentsList(html).map((script) => {
-    const digest = createHash('sha256').update(script, 'utf8').digest('base64');
+  if (typeof html !== 'string') {
+    throw new TypeError('computeInlineScriptHashes: html must be a string.');
+  }
+  const blocks = extractInlineScriptBlocks(html);
+  if (blocks.length === 0) {
+    throw new Error('No inline <script> block found in HTML. CSP hash cannot be computed.');
+  }
+  assertExpectedIndexInlineScripts(blocks);
+  return blocks.map(({ body }) => {
+    const digest = createHash('sha256').update(body, 'utf8').digest('base64');
     return `sha256-${digest}`;
   });
 }

--- a/scripts/lib/headers-drift.mjs
+++ b/scripts/lib/headers-drift.mjs
@@ -129,6 +129,8 @@ export const CACHE_SPLIT_RULES = Object.freeze([
   { path: '/styles/*', cacheControl: 'public, max-age=31536000, immutable' },
   { path: '/favicon.ico', cacheControl: 'public, max-age=86400' },
   { path: '/manifest.webmanifest', cacheControl: 'public, max-age=3600' },
+  { path: '/robots.txt', cacheControl: 'public, max-age=3600' },
+  { path: '/sitemap.xml', cacheControl: 'public, max-age=3600' },
   { path: '/', cacheControl: 'no-store' },
   { path: '/index.html', cacheControl: 'no-store' },
 ]);

--- a/scripts/production-bundle-audit.mjs
+++ b/scripts/production-bundle-audit.mjs
@@ -3,6 +3,8 @@ import { createDemoSession, loadBootstrap } from './lib/production-smoke.mjs';
 import { FORBIDDEN_KEYS_EVERYWHERE } from '../tests/helpers/forbidden-keys.mjs';
 
 const DEFAULT_ORIGIN = 'https://ks2.eugnel.uk';
+const SEO_CANONICAL_ROOT = 'https://ks2.eugnel.uk/';
+const SEO_SITEMAP_URL = `${SEO_CANONICAL_ROOT}sitemap.xml`;
 
 // U13 redaction matrix forbidden-key check: these keys must never appear in any
 // authenticated response surface reached via the demo session. The set is
@@ -124,6 +126,112 @@ function scriptSources(html) {
   return sources;
 }
 
+function extractJsonLdBlocks(html, failures) {
+  const blocks = [];
+  const pattern = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
+  let match = pattern.exec(html);
+  while (match) {
+    const attributes = String(match[1] || '');
+    if (!/\btype=["']application\/ld\+json["']/i.test(attributes)) {
+      match = pattern.exec(html);
+      continue;
+    }
+    try {
+      blocks.push(JSON.parse(match[2]));
+    } catch (error) {
+      failures.push(`Production HTML JSON-LD is invalid: ${error?.message || error}`);
+    }
+    match = pattern.exec(html);
+  }
+  return blocks;
+}
+
+function assertSeoRootHtml(index, failures) {
+  if (!/text\/html/i.test(index.contentType)) {
+    failures.push(`Production SEO root expected text/html, got: ${index.contentType || 'absent'}`);
+  }
+
+  const requiredTokens = [
+    '<title>KS2 Mastery | KS2 Spelling, Grammar and Punctuation Practice</title>',
+    '<meta name="description"',
+    `<link rel="canonical" href="${SEO_CANONICAL_ROOT}"`,
+    '<meta property="og:title"',
+    '<meta property="og:description"',
+    `<meta property="og:url" content="${SEO_CANONICAL_ROOT}"`,
+    '<meta name="twitter:card" content="summary"',
+    'KS2 spelling, grammar and punctuation practice',
+    'Spelling practice for KS2 word confidence',
+    'Grammar practice for sentence-level accuracy',
+    'Punctuation practice for clearer written English',
+  ];
+  for (const token of requiredTokens) {
+    if (!index.text.includes(token)) {
+      failures.push(`Production SEO root is missing required public identity token: ${token}`);
+    }
+  }
+
+  const productIdentity = extractJsonLdBlocks(index.text, failures)
+    .find((entry) => entry?.name === 'KS2 Mastery');
+  if (!productIdentity) {
+    failures.push('Production SEO root is missing JSON-LD product identity for KS2 Mastery.');
+    return;
+  }
+  if (productIdentity.url !== SEO_CANONICAL_ROOT) {
+    failures.push(
+      `Production SEO JSON-LD must use canonical URL ${SEO_CANONICAL_ROOT}, got: ${productIdentity.url || 'absent'}`,
+    );
+  }
+  const json = JSON.stringify(productIdentity);
+  for (const token of ['KS2 spelling', 'KS2 grammar', 'KS2 punctuation', 'Practice tool']) {
+    if (!json.includes(token)) {
+      failures.push(`Production SEO JSON-LD is missing product identity token: ${token}`);
+    }
+  }
+}
+
+async function assertSeoDiscoveryResources(base, failures) {
+  const robots = await fetchText(new URL('/robots.txt', base).href);
+  if (robots.status < 200 || robots.status >= 300) {
+    failures.push(`Production robots.txt fetch failed: ${robots.status} ${robots.url}`);
+  }
+  if (/text\/html/i.test(robots.contentType) || /<!doctype|<\/?html/i.test(robots.text)) {
+    failures.push('Production robots.txt appears to be SPA fallback HTML, not a robots policy.');
+  }
+  for (const token of [
+    'User-agent: *',
+    'Disallow: /api/',
+    'Disallow: /admin',
+    'Disallow: /demo',
+    'Allow: /',
+    `Sitemap: ${SEO_SITEMAP_URL}`,
+  ]) {
+    if (!robots.text.includes(token)) {
+      failures.push(`Production robots.txt is missing required token: ${token}`);
+    }
+  }
+
+  const sitemap = await fetchText(new URL('/sitemap.xml', base).href);
+  if (sitemap.status < 200 || sitemap.status >= 300) {
+    failures.push(`Production sitemap.xml fetch failed: ${sitemap.status} ${sitemap.url}`);
+  }
+  if (/text\/html/i.test(sitemap.contentType) || /<!doctype|<\/?html/i.test(sitemap.text)) {
+    failures.push('Production sitemap.xml appears to be SPA fallback HTML, not a sitemap.');
+  }
+  for (const token of [
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    `<loc>${SEO_CANONICAL_ROOT}</loc>`,
+  ]) {
+    if (!sitemap.text.includes(token)) {
+      failures.push(`Production sitemap.xml is missing required token: ${token}`);
+    }
+  }
+  for (const forbiddenPath of ['/api/', '/admin', 'localhost', '127.0.0.1']) {
+    if (sitemap.text.includes(forbiddenPath)) {
+      failures.push(`Production sitemap.xml must not advertise private or local path: ${forbiddenPath}`);
+    }
+  }
+}
+
 // SH2-U10 (S-01 mirror): extract the set of same-origin chunk paths that a
 // shipped ES-module chunk imports. Esbuild splitting emits
 // `import("./chunk-XXXX.js")` for lazy-loaded entries and shared chunks,
@@ -222,6 +330,8 @@ async function auditProduction(origin) {
     failures.push(`Production HTML fetch failed: ${index.status} ${base.href}`);
   }
   assertNoForbiddenText('Production HTML', index.text, failures);
+  assertSeoRootHtml(index, failures);
+  await assertSeoDiscoveryResources(base, failures);
 
   const scripts = scriptSources(index.text)
     .filter((src) => !/^https?:\/\//i.test(src) || new URL(src, base).origin === base.origin);
@@ -434,6 +544,8 @@ async function auditProduction(origin) {
       : null,
     { path: '/assets/app-icons/favicon-32.png', label: 'ASSETS app icon', expected: 'public, max-age=31536000, immutable' },
     { path: '/manifest.webmanifest', label: 'web app manifest', expected: 'public, max-age=3600' },
+    { path: '/robots.txt', label: 'robots policy', expected: 'public, max-age=3600' },
+    { path: '/sitemap.xml', label: 'sitemap', expected: 'public, max-age=3600' },
   ].filter(Boolean);
   let cacheChecksPassed = 0;
   for (const check of CACHE_SPLIT_CHECKS) {

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://ks2.eugnel.uk/</loc>
+  </url>
+</urlset>

--- a/src/surfaces/auth/AuthSurface.jsx
+++ b/src/surfaces/auth/AuthSurface.jsx
@@ -217,7 +217,14 @@ function AuthSurfaceStandard({ initialMode = 'login', initialError = '', onSubmi
       <section className="auth-panel card">
         <div className="eyebrow">KS2 Mastery</div>
         <h1 className="title">{isRegister ? 'Create your parent account' : 'Sign in to continue'}</h1>
-        <p className="subtitle">Your learner profiles and spelling progress sync through the KS2 Mastery cloud backend.</p>
+        <p className="subtitle">
+          Practise KS2 spelling, grammar and punctuation online, then save learner profiles and progress when you sign in.
+        </p>
+        <ul className="auth-product-summary" aria-label="KS2 Mastery practice areas">
+          <li>Focused spelling practice for KS2 word confidence</li>
+          <li>Grammar practice for sentence-level accuracy</li>
+          <li>Punctuation practice for clearer written English</li>
+        </ul>
         {/* SH2-U8: inline style prop migrated to `.auth-standard-error` class
             (see docs/hardening/csp-inline-style-inventory.md). */}
         {error && (

--- a/styles/app.css
+++ b/styles/app.css
@@ -201,11 +201,65 @@ textarea:focus-visible {
   width: min(100%, 460px);
 }
 
+.seo-public-fallback {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 28px;
+}
+
+.seo-public-panel {
+  width: min(100%, 620px);
+}
+
+.seo-public-panel h1 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 3.2rem;
+  line-height: 0.98;
+  color: var(--ink);
+}
+
+@media (max-width: 640px) {
+  .seo-public-panel h1 {
+    font-size: 2.2rem;
+  }
+}
+
+.seo-public-panel p,
+.seo-public-panel ul {
+  margin-top: 16px;
+  color: var(--ink-2);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.seo-public-panel ul,
+.auth-product-summary {
+  padding-left: 20px;
+}
+
+.seo-public-panel li + li,
+.auth-product-summary li + li {
+  margin-top: 6px;
+}
+
+.seo-public-panel .btn {
+  margin-top: 4px;
+}
+
 .auth-form,
 .auth-social {
   display: grid;
   gap: 12px;
   margin-top: 18px;
+}
+
+.auth-product-summary {
+  margin-top: 16px;
+  color: var(--ink-2);
+  font-size: 0.95rem;
+  line-height: 1.45;
 }
 
 .auth-switch {

--- a/tests/build-public.test.js
+++ b/tests/build-public.test.js
@@ -11,6 +11,9 @@ test('public build emits the React app bundle entrypoint', () => {
   execFileSync(process.execPath, ['./scripts/audit-client-bundle.mjs'], { stdio: 'ignore' });
 
   const indexHtml = readFileSync('dist/public/index.html', 'utf8');
+  const robotsTxt = readFileSync('dist/public/robots.txt', 'utf8');
+  const sitemapXml = readFileSync('dist/public/sitemap.xml', 'utf8');
+  const cspHashArtefact = readFileSync('dist/public/.csp-theme-hash', 'utf8');
   const appBundle = readFileSync('dist/public/src/bundles/app.bundle.js', 'utf8');
   const expectedAppBundleVersion = createHash('sha256').update(appBundle).digest('hex').slice(0, 12);
   assert.match(
@@ -19,6 +22,21 @@ test('public build emits the React app bundle entrypoint', () => {
   );
   assert.doesNotMatch(indexHtml, /home\.bundle\.js/);
   assert.doesNotMatch(indexHtml, /src\/main\.js/);
+  assert.match(indexHtml, /KS2 Mastery \| KS2 Spelling, Grammar and Punctuation Practice/);
+  assert.match(indexHtml, /<link rel="canonical" href="https:\/\/ks2\.eugnel\.uk\/" \/>/);
+  assert.match(indexHtml, /application\/ld\+json/);
+  assert.match(indexHtml, /KS2 spelling, grammar and punctuation practice/);
+  assert.match(robotsTxt, /Disallow: \/api\//);
+  assert.match(robotsTxt, /Disallow: \/admin/);
+  assert.match(robotsTxt, /Disallow: \/demo/);
+  assert.match(robotsTxt, /Sitemap: https:\/\/ks2\.eugnel\.uk\/sitemap\.xml/);
+  assert.doesNotMatch(robotsTxt, /<!doctype html|<html/i);
+  assert.match(sitemapXml, /<loc>https:\/\/ks2\.eugnel\.uk\/<\/loc>/);
+  assert.doesNotMatch(sitemapXml, /\/api\/|\/admin|localhost|127\.0\.0\.1/);
+  assert.ok(
+    cspHashArtefact.split(/\r?\n/u).filter(Boolean).length >= 2,
+    'CSP hash artefact should list both theme and JSON-LD inline script hashes',
+  );
 
   assert.equal(existsSync('dist/public/src/bundles/home.bundle.js'), false);
   assert.equal(existsSync('dist/public/src/main.js'), false);

--- a/tests/bundle-audit.test.js
+++ b/tests/bundle-audit.test.js
@@ -635,6 +635,233 @@ function normaliseCacheControl(value) {
   return String(value || '').replace(/\s+/gu, ' ').replace(/,\s*/gu, ', ').trim();
 }
 
+const SEO_AUDIT_SECURITY_HEADERS = {
+  'strict-transport-security': 'max-age=63072000; includeSubDomains',
+  'x-content-type-options': 'nosniff',
+  'referrer-policy': 'strict-origin-when-cross-origin',
+  'permissions-policy': 'microphone=()',
+  'x-frame-options': 'DENY',
+  'cross-origin-opener-policy': 'same-origin-allow-popups',
+  'cross-origin-resource-policy': 'same-site',
+  'content-security-policy-report-only': "default-src 'none'; script-src 'self' 'sha256-abc=' 'strict-dynamic'; report-uri /api/security/csp-report; report-to csp-endpoint",
+  'report-to': '{"group":"csp-endpoint","max_age":10886400,"endpoints":[{"url":"/api/security/csp-report"}]}',
+  'reporting-endpoints': 'csp-endpoint="/api/security/csp-report"',
+};
+
+function seoAuditRootHtml({ omitCanonical = false } = {}) {
+  return [
+    '<!doctype html><html lang="en-GB"><head>',
+    '<title>KS2 Mastery | KS2 Spelling, Grammar and Punctuation Practice</title>',
+    '<meta name="description" content="KS2 Mastery helps learners practise KS2 spelling, grammar and punctuation online." />',
+    omitCanonical ? '' : '<link rel="canonical" href="https://ks2.eugnel.uk/" />',
+    '<meta property="og:title" content="KS2 Mastery | KS2 Spelling, Grammar and Punctuation Practice" />',
+    '<meta property="og:description" content="Online KS2 English practice for spelling, grammar and punctuation." />',
+    '<meta property="og:url" content="https://ks2.eugnel.uk/" />',
+    '<meta name="twitter:card" content="summary" />',
+    '<script type="application/ld+json">',
+    JSON.stringify({
+      '@context': 'https://schema.org',
+      '@type': ['WebApplication', 'LearningResource'],
+      name: 'KS2 Mastery',
+      url: 'https://ks2.eugnel.uk/',
+      description: 'KS2 Mastery helps learners practise KS2 spelling, grammar and punctuation online.',
+      learningResourceType: 'Practice tool',
+      teaches: ['KS2 spelling', 'KS2 grammar', 'KS2 punctuation'],
+    }),
+    '</script>',
+    '</head><body>',
+    '<main><h1>KS2 spelling, grammar and punctuation practice</h1>',
+    '<p>Spelling practice for KS2 word confidence</p>',
+    '<p>Grammar practice for sentence-level accuracy</p>',
+    '<p>Punctuation practice for clearer written English</p></main>',
+    '<script type="module" src="/src/bundles/app.bundle.js?v=test"></script>',
+    '</body></html>',
+  ].join('');
+}
+
+function createSeoAuditStubServer(options = {}) {
+  const server = createServer((request, response) => {
+    const url = request.url || '/';
+    const method = request.method || 'GET';
+    const write = (status, headers, body = '') => {
+      response.writeHead(status, { ...SEO_AUDIT_SECURITY_HEADERS, ...headers });
+      response.end(method === 'HEAD' ? '' : body);
+    };
+
+    if (url === '/' || url === '/index.html') {
+      write(200, { 'content-type': 'text/html', 'cache-control': 'no-store' }, seoAuditRootHtml(options));
+      return;
+    }
+    if (url === '/robots.txt') {
+      if (options.robotsFallback) {
+        write(200, { 'content-type': 'text/html', 'cache-control': 'no-store' }, seoAuditRootHtml());
+        return;
+      }
+      write(200, { 'content-type': 'text/plain; charset=utf-8', 'cache-control': 'public, max-age=3600' }, [
+        'User-agent: *',
+        'Disallow: /api/',
+        'Disallow: /admin',
+        'Disallow: /demo',
+        'Allow: /',
+        '',
+        'Sitemap: https://ks2.eugnel.uk/sitemap.xml',
+        '',
+      ].join('\n'));
+      return;
+    }
+    if (url === '/sitemap.xml') {
+      write(200, { 'content-type': 'application/xml', 'cache-control': 'public, max-age=3600' }, [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+        '  <url>',
+        '    <loc>https://ks2.eugnel.uk/</loc>',
+        '  </url>',
+        '</urlset>',
+        '',
+      ].join('\n'));
+      return;
+    }
+    if (url === '/src/bundles/app.bundle.js' || url === '/src/bundles/app.bundle.js?v=test') {
+      write(200, { 'content-type': 'application/javascript', 'cache-control': 'no-store' }, 'import"./chunk-CLEAN.js"; console.log("ok");');
+      return;
+    }
+    if (url === '/src/bundles/chunk-CLEAN.js') {
+      write(200, {
+        'content-type': 'application/javascript',
+        'cache-control': 'public, max-age=31536000, immutable',
+      }, 'console.log("clean");');
+      return;
+    }
+    if (url === '/assets/app-icons/favicon-32.png') {
+      write(200, {
+        'content-type': 'image/png',
+        'cache-control': 'public, max-age=31536000, immutable',
+      });
+      return;
+    }
+    if (url === '/manifest.webmanifest') {
+      write(200, {
+        'content-type': 'application/manifest+json',
+        'cache-control': 'public, max-age=3600',
+      }, '{}');
+      return;
+    }
+    if (url === '/api/demo/session') {
+      write(200, {
+        'content-type': 'application/json',
+        'cache-control': 'no-store',
+        'set-cookie': 'ks2_session=demo-cookie; Path=/; HttpOnly',
+      }, JSON.stringify({
+        ok: true,
+        session: { demo: true, accountId: 'acct-demo', learnerId: 'learner-demo' },
+      }));
+      return;
+    }
+    if (url === '/api/bootstrap') {
+      write(200, { 'content-type': 'application/json', 'cache-control': 'no-store' }, JSON.stringify({
+        ok: true,
+        session: { demo: true, accountId: 'acct-demo', learnerId: 'learner-demo' },
+        learners: {
+          selectedId: 'learner-demo',
+          byId: { 'learner-demo': { stateRevision: 0 } },
+        },
+      }));
+      return;
+    }
+    if (url === '/api/auth/logout') {
+      write(200, {
+        'content-type': 'application/json',
+        'cache-control': 'no-store',
+        'clear-site-data': '"cache", "cookies", "storage"',
+      }, '{}');
+      return;
+    }
+    if (url === '/api/tts') {
+      write(401, { 'content-type': 'application/json', 'cache-control': 'no-store' }, '{}');
+      return;
+    }
+    write(404, { 'content-type': 'text/plain', 'cache-control': 'no-store' }, 'not found');
+  });
+  return server;
+}
+
+async function closeServer(server) {
+  server.closeAllConnections?.();
+  await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+}
+
+test('production bundle audit passes with SEO root, robots, and sitemap resources', async () => {
+  const server = createSeoAuditStubServer();
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+  try {
+    const { port } = server.address();
+    const { stdout } = await execFileAsync(process.execPath, [
+      './scripts/production-bundle-audit.mjs',
+      '--skip-local',
+      '--url',
+      `http://127.0.0.1:${port}/`,
+    ], {
+      cwd: process.cwd(),
+      timeout: 8000,
+    });
+    assert.match(stdout, /Production bundle audit passed/);
+    assert.match(stdout, /cache-split checks: 7\/7/);
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test('production bundle audit fails when robots.txt is SPA fallback HTML', async () => {
+  const server = createSeoAuditStubServer({ robotsFallback: true });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+  try {
+    const { port } = server.address();
+    await assert.rejects(async () => {
+      await execFileAsync(process.execPath, [
+        './scripts/production-bundle-audit.mjs',
+        '--skip-local',
+        '--url',
+        `http://127.0.0.1:${port}/`,
+      ], {
+        cwd: process.cwd(),
+        timeout: 8000,
+      });
+    }, (error) => {
+      assert.match(error.stderr, /Production robots\.txt appears to be SPA fallback HTML/);
+      return true;
+    });
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test('production bundle audit fails when the root canonical URL disappears', async () => {
+  const server = createSeoAuditStubServer({ omitCanonical: true });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+  try {
+    const { port } = server.address();
+    await assert.rejects(async () => {
+      await execFileAsync(process.execPath, [
+        './scripts/production-bundle-audit.mjs',
+        '--skip-local',
+        '--url',
+        `http://127.0.0.1:${port}/`,
+      ], {
+        cwd: process.cwd(),
+        timeout: 8000,
+      });
+    }, (error) => {
+      assert.match(error.stderr, /Production SEO root is missing required public identity token: <link rel="canonical"/);
+      return true;
+    });
+  } finally {
+    await closeServer(server);
+  }
+});
+
 test('_headers carries the U8 cache-split rule set for every path group', async () => {
   const content = await readFile(path.join(REPO_ROOT, '_headers'), 'utf8');
   // The pure contract must not throw on the checked-in _headers.

--- a/tests/csp-policy.test.js
+++ b/tests/csp-policy.test.js
@@ -16,6 +16,7 @@ import assert from 'node:assert/strict';
 
 import {
   CSP_INLINE_SCRIPT_HASH,
+  CSP_INLINE_SCRIPT_HASHES,
   CSP_POLICY_VALUE,
 } from '../worker/src/security-headers.js';
 
@@ -38,18 +39,22 @@ test("policy defines default-src 'none' (deny-by-default)", () => {
   assert.deepEqual(directives.get('default-src'), ["'none'"]);
 });
 
-test('policy script-src lists self, the inline theme-script hash, strict-dynamic, and Turnstile', () => {
+test('policy script-src lists self, every inline script hash, strict-dynamic, and Turnstile', () => {
   const value = directives.get('script-src')?.[0] || '';
   assert.match(value, /'self'/, "script-src must include 'self'");
-  assert.ok(value.includes(`'${CSP_INLINE_SCRIPT_HASH}'`), 'script-src must list the inline theme-script hash');
+  for (const hash of CSP_INLINE_SCRIPT_HASHES) {
+    assert.ok(value.includes(`'${hash}'`), `script-src must list inline script hash ${hash}`);
+  }
   assert.match(value, /'strict-dynamic'/, "script-src must enable 'strict-dynamic'");
   assert.match(value, /https:\/\/challenges\.cloudflare\.com/, 'script-src must allow Turnstile');
 });
 
-test('policy script-src-elem mirrors script-src without strict-dynamic (HTML element form)', () => {
+test('policy script-src-elem mirrors script-src hashes without strict-dynamic (HTML element form)', () => {
   const value = directives.get('script-src-elem')?.[0] || '';
   assert.match(value, /'self'/);
-  assert.ok(value.includes(`'${CSP_INLINE_SCRIPT_HASH}'`));
+  for (const hash of CSP_INLINE_SCRIPT_HASHES) {
+    assert.ok(value.includes(`'${hash}'`), `script-src-elem must list inline script hash ${hash}`);
+  }
   assert.match(value, /https:\/\/challenges\.cloudflare\.com/);
 });
 

--- a/tests/csp-policy.test.js
+++ b/tests/csp-policy.test.js
@@ -13,7 +13,9 @@
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 
+import { computeInlineScriptHashes } from '../scripts/compute-inline-script-hash.mjs';
 import {
   CSP_INLINE_SCRIPT_HASH,
   CSP_INLINE_SCRIPT_HASHES,
@@ -56,6 +58,22 @@ test('policy script-src-elem mirrors script-src hashes without strict-dynamic (H
     assert.ok(value.includes(`'${hash}'`), `script-src-elem must list inline script hash ${hash}`);
   }
   assert.match(value, /https:\/\/challenges\.cloudflare\.com/);
+});
+
+test('index inline-script CSP hashes are limited to the expected theme and JSON-LD blocks', async () => {
+  const indexHtml = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+  assert.deepEqual(
+    computeInlineScriptHashes(indexHtml),
+    CSP_INLINE_SCRIPT_HASHES,
+    'generated CSP hashes must match the current index.html inline script allowlist',
+  );
+
+  const driftedHtml = indexHtml.replace('</head>', '<script>console.log("unexpected inline script")</script></head>');
+  assert.throws(
+    () => computeInlineScriptHashes(driftedHtml),
+    /Expected exactly two intentional inline <script> blocks/,
+    'unexpected inline scripts must fail the CSP hash generator instead of being auto-allowed',
+  );
 });
 
 test('policy style-src allows self plus unsafe-inline and Google Fonts', () => {

--- a/tests/react-auth-boot.test.js
+++ b/tests/react-auth-boot.test.js
@@ -7,6 +7,10 @@ test('auth surface renders through React with credential and social sign-in stat
   const html = await renderAuthSurfaceFixture();
 
   assert.match(html, /Sign in to continue/);
+  assert.match(html, /KS2 spelling, grammar and punctuation/);
+  assert.match(html, /Focused spelling practice/);
+  assert.match(html, /Grammar practice/);
+  assert.match(html, /Punctuation practice/);
   assert.match(html, /expired/);
   assert.match(html, /autoComplete="email"/);
   assert.match(html, /Social sign-in/);

--- a/tests/security-headers.test.js
+++ b/tests/security-headers.test.js
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 import {
   CSP_ENFORCEMENT_MODE,
   CSP_INLINE_SCRIPT_HASH,
+  CSP_INLINE_SCRIPT_HASHES,
   CSP_POLICY_VALUE,
   HSTS_PRELOAD_ENABLED,
   HSTS_VALUE,
@@ -479,6 +480,8 @@ test('_headers repo file contains expected security header block', async () => {
   assert.match(content, /Cross-Origin-Opener-Policy: same-origin-allow-popups/);
   assert.match(content, /Cross-Origin-Resource-Policy: same-site/);
   assert.match(content, /\/assets\/bundles\/\*/);
+  assert.match(content, /\/robots\.txt/);
+  assert.match(content, /\/sitemap\.xml/);
   assert.match(content, /\/\*/);
   assert.match(content, /public, max-age=31536000, immutable/);
 });
@@ -773,11 +776,26 @@ test('CSP_INLINE_SCRIPT_HASH is a well-formed sha256 CSP token or the pre-build 
   );
 });
 
+test('CSP_INLINE_SCRIPT_HASHES lists every intentional inline script hash', () => {
+  const placeholder = 'sha256-PLACEHOLDER_PRE_BUILD_HASH=';
+  assert.ok(Array.isArray(CSP_INLINE_SCRIPT_HASHES), 'CSP_INLINE_SCRIPT_HASHES must be an array.');
+  assert.ok(CSP_INLINE_SCRIPT_HASHES.length >= 1, 'At least the theme bootstrap hash must be present.');
+  for (const hash of CSP_INLINE_SCRIPT_HASHES) {
+    const wellFormed = /^sha256-[A-Za-z0-9+/]+=*$/.test(hash);
+    assert.ok(
+      wellFormed || hash === placeholder,
+      `Expected sha256-<base64> token or the pre-build placeholder, got: ${hash}`,
+    );
+  }
+});
+
 test('CSP_POLICY_VALUE includes all baseline directives', () => {
   const policy = CSP_POLICY_VALUE;
   assert.match(policy, /default-src 'none'/, 'default-src must deny-by-default');
   assert.match(policy, /'strict-dynamic'/, 'script-src must carry strict-dynamic');
-  assert.ok(policy.includes(`'${CSP_INLINE_SCRIPT_HASH}'`), 'CSP must list the inline theme-script hash');
+  for (const hash of CSP_INLINE_SCRIPT_HASHES) {
+    assert.ok(policy.includes(`'${hash}'`), `CSP must list inline script hash ${hash}`);
+  }
   assert.match(policy, /manifest-src 'self'/, 'manifest-src must be explicit (F-06)');
   assert.match(policy, /worker-src 'none'/, 'worker-src must deny Service Workers (F-06)');
   assert.match(policy, /connect-src[^;]*https:\/\/fonts\.googleapis\.com/, 'connect-src must list Google Fonts CSS origin');

--- a/tests/worker-capacity-overhead.test.js
+++ b/tests/worker-capacity-overhead.test.js
@@ -76,6 +76,42 @@ async function timeIt(fn) {
   return summarise(timings);
 }
 
+async function timePaired(leftFn, rightFn) {
+  const leftTimings = [];
+  const rightTimings = [];
+
+  for (let i = 0; i < WARM; i += 1) {
+    await leftFn();
+    await rightFn();
+  }
+
+  for (let i = 0; i < ITER; i += 1) {
+    if (i % 2 === 0) {
+      const leftStart = performance.now();
+      await leftFn();
+      leftTimings.push(performance.now() - leftStart);
+
+      const rightStart = performance.now();
+      await rightFn();
+      rightTimings.push(performance.now() - rightStart);
+      continue;
+    }
+
+    const rightStart = performance.now();
+    await rightFn();
+    rightTimings.push(performance.now() - rightStart);
+
+    const leftStart = performance.now();
+    await leftFn();
+    leftTimings.push(performance.now() - leftStart);
+  }
+
+  return {
+    left: summarise(leftTimings),
+    right: summarise(rightTimings),
+  };
+}
+
 // U11 follow-up: under full-suite parallel `node --test` load (40+ test
 // files spawning subprocesses) the macro benchmark's ~10-20 ms/call
 // regime picks up significant scheduler-jitter on busy hosts. The
@@ -98,21 +134,23 @@ test('U3 overhead benchmark — capacity proxy mean ≤+30%, p95 ≤+80%', async
   console.log = () => {};
 
   try {
-    // 1) Baseline: repository.bootstrap() with NO collector. Zero
-    //    proxy overhead; the short-circuit in withCapacityCollector
-    //    returns the raw DB handle when capacity is null.
-    const baseline = await timeIt(async () => {
+    const runBaseline = async () => {
       const repo = createWorkerRepository({ env: { DB }, now: () => NOW, capacity: null });
       await repo.bootstrap('adult-bench', { publicReadModels: false });
-    });
+    };
 
-    // 2) Proxied: same call path with a CapacityCollector. Measures
-    //    the pure per-query proxy overhead + collector allocation.
-    const proxied = await timeIt(async () => {
+    const runProxied = async () => {
       const capacity = new CapacityCollector({ requestId: 'ks2_req_00000000-0000-4000-8000-000000000000' });
       const repo = createWorkerRepository({ env: { DB }, now: () => NOW, capacity });
       await repo.bootstrap('adult-bench', { publicReadModels: false });
-    });
+    };
+
+    // 1/2) Baseline vs proxied repository.bootstrap(). Measure them
+    //      as adjacent alternating pairs so full-suite CPU jitter does
+    //      not turn phase changes into fake proxy overhead.
+    const paired = await timePaired(runBaseline, runProxied);
+    const baseline = paired.left;
+    const proxied = paired.right;
 
     // 3) Full-stack: end-to-end app.fetch('/api/bootstrap'). Includes
     //    request parsing, auth boundary, JSON rewrite, meta.capacity

--- a/worker/src/generated-csp-hash.js
+++ b/worker/src/generated-csp-hash.js
@@ -2,4 +2,5 @@
 // This file is committed so fresh clones can run `npm test` before
 // `npm run build` has produced a real hash. Build overwrites this.
 
-export const CSP_INLINE_SCRIPT_HASH = 'sha256-d5B0kdrkvmMBHcWJ8TUVFkTDTxk/ACGS+ezi8RwKeZE=';
+export const CSP_INLINE_SCRIPT_HASHES = Object.freeze(["sha256-d5B0kdrkvmMBHcWJ8TUVFkTDTxk/ACGS+ezi8RwKeZE=","sha256-D+GmWcLVxQQZeIPhTA9mNi9o4hfbpB6+00cTSVAMOOg="]);
+export const CSP_INLINE_SCRIPT_HASH = CSP_INLINE_SCRIPT_HASHES[0];

--- a/worker/src/security-headers.js
+++ b/worker/src/security-headers.js
@@ -15,7 +15,7 @@
 //   per F-01). It uses `headers.set()` to force path-specific cache rules on
 //   bundles that arrive from `env.ASSETS.fetch` with `no-store` applied.
 
-import { CSP_INLINE_SCRIPT_HASH } from './generated-csp-hash.js';
+import { CSP_INLINE_SCRIPT_HASH, CSP_INLINE_SCRIPT_HASHES } from './generated-csp-hash.js';
 
 // Placeholder hash shipped with `worker/src/generated-csp-hash.js` before
 // the first build. `scripts/build-public.mjs` overwrites the module with
@@ -28,7 +28,7 @@ let cspPlaceholderWarningEmitted = false;
 
 function warnOnPlaceholderHashOnce() {
   if (cspPlaceholderWarningEmitted) return;
-  if (CSP_INLINE_SCRIPT_HASH !== CSP_PLACEHOLDER_HASH) return;
+  if (!CSP_INLINE_SCRIPT_HASHES.includes(CSP_PLACEHOLDER_HASH)) return;
   cspPlaceholderWarningEmitted = true;
   // eslint-disable-next-line no-console
   console.error(
@@ -65,6 +65,10 @@ export const HSTS_VALUE = buildHstsValue(HSTS_PRELOAD_ENABLED);
 // observation window documented in docs/hardening/csp-enforcement-decision.md.
 export const CSP_ENFORCEMENT_MODE = 'report-only';
 
+const CSP_INLINE_SCRIPT_HASH_DIRECTIVES = CSP_INLINE_SCRIPT_HASHES
+  .map((hash) => `'${hash}'`)
+  .join(' ');
+
 export const PERMISSIONS_POLICY = [
   'camera=()',
   'geolocation=()',
@@ -91,8 +95,8 @@ export const PERMISSIONS_POLICY = [
 // to produce the header value.
 const CSP_DIRECTIVES = Object.freeze([
   "default-src 'none'",
-  `script-src 'self' '${CSP_INLINE_SCRIPT_HASH}' 'strict-dynamic' https://challenges.cloudflare.com`,
-  `script-src-elem 'self' '${CSP_INLINE_SCRIPT_HASH}' https://challenges.cloudflare.com`,
+  `script-src 'self' ${CSP_INLINE_SCRIPT_HASH_DIRECTIVES} 'strict-dynamic' https://challenges.cloudflare.com`,
+  `script-src-elem 'self' ${CSP_INLINE_SCRIPT_HASH_DIRECTIVES} https://challenges.cloudflare.com`,
   "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
   "style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com",
   "img-src 'self' data: blob:",
@@ -128,7 +132,7 @@ export const REPORTING_ENDPOINTS_VALUE = 'csp-endpoint="/api/security/csp-report
 
 // Export the CSP hash so tests can assert the same value is substituted
 // into `_headers` by the build step.
-export { CSP_INLINE_SCRIPT_HASH };
+export { CSP_INLINE_SCRIPT_HASH, CSP_INLINE_SCRIPT_HASHES };
 
 export const SECURITY_HEADERS = Object.freeze({
   'Strict-Transport-Security': HSTS_VALUE,


### PR DESCRIPTION
## Summary
- Gives the public root a crawlable KS2 Mastery identity: title, description, canonical/share metadata, raw HTML fallback copy, AuthSurface copy, and JSON-LD for KS2 spelling, grammar, and punctuation practice.
- Ships `robots.txt` and `sitemap.xml` through the existing public build, with crawler exclusions for `/api/`, `/admin`, and `/demo` so discovery stays focused on the canonical root.
- Extends the CSP inline-script hash path to support JSON-LD safely, then adds local build assertions, production SEO audit checks, and an SEO operations runbook for Search Console and analytics decisions.

## Verification
- `node scripts/worktree-setup.mjs`
- `npm run build`
- `npm run assert:build-public`
- `node --test tests/build-public.test.js tests/bundle-audit.test.js tests/csp-policy.test.js tests/security-headers.test.js tests/react-auth-boot.test.js`
- `npm test`
- `npm run check`
- `git diff --check`

## Post-Deploy Monitoring & Validation
After deployment, run `npm run audit:production -- --skip-local` against `https://ks2.eugnel.uk`. Healthy signals: `/` returns the KS2 public identity, canonical URL, share metadata, and JSON-LD; `/robots.txt` returns text with the sitemap plus `/api/`, `/admin`, and `/demo` exclusions; `/sitemap.xml` returns XML with only the canonical root URL; cache-split checks pass for the discovery assets.

Watch Cloudflare Worker analytics and logs for `/`, `/robots.txt`, `/sitemap.xml`, `/demo`, and `/api/security/csp-report` for the first 24 hours. Failure signals: discovery assets returning SPA fallback HTML, missing canonical/JSON-LD, private paths appearing in the sitemap, elevated 4xx/5xx on the discovery assets, or a new CSP report burst tied to inline scripts. Roll back or redeploy the previous Worker if the root or discovery assets regress.

Submit `https://ks2.eugnel.uk/sitemap.xml` in Search Console after the deploy and inspect the canonical root URL once Google has crawled it. Cloudflare Web Analytics or GA4/Zaraz remain follow-up configuration choices; this PR does not add placeholder analytics tags.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
