### PR TITLE
feat(grammar): migrate constructed responses to answer specs

### DIFF
--- a/docs/plans/james/grammar/grammar-answer-spec-audit.md
+++ b/docs/plans/james/grammar/grammar-answer-spec-audit.md
@@ -1,32 +1,30 @@
 ---
-title: "Grammar answer-spec migration audit (inventory only)"
+title: "Grammar answer-spec migration audit"
 type: audit
-status: inventory
-date: 2026-04-26
-plan: docs/plans/2026-04-26-001-feat-grammar-phase4-learning-hardening-plan.md
-unit: U11
+status: implemented
+date: 2026-04-28
+plan: docs/plans/james/grammar/questions-generator/grammar-qg-p2.md
+unit: QG-P2
 ---
 
-# Grammar answer-spec migration audit (inventory only)
+# Grammar answer-spec migration audit
 
-This document is the per-template classification Phase 5/P1 executes against. It inventories every one of the 57 Grammar templates (37 selected-response + 20 constructed-response) with the target `answerSpec.kind`, a golden accepted answer, near-miss examples that must be rejected, and migration priority. Phase 4 shipped **zero** template code changes and did **not** bump `contentReleaseId`; the P1 generated templates add typed `answerSpec` data from day one, while the legacy constructed-response migration remains paired with future oracle-fixture refreshes and `contentReleaseId` bumps.
+This document is the per-template classification and shipped-state audit for the Grammar answer-spec migration. It inventories every one of the 57 Grammar templates (37 selected-response + 20 constructed-response) with the target `answerSpec.kind`, a golden accepted answer, near-miss examples that must be rejected, and migration priority. QG P2 ships the legacy constructed-response migration under `grammar-qg-p2-2026-04-28`; the previous QG P1 baseline remains frozen for regression comparison.
 
 The authoritative answer-spec kind list lives at `worker/src/subjects/grammar/answer-spec.js` (`ANSWER_SPEC_KINDS`). The six kinds are: `exact`, `normalisedText`, `acceptedSet`, `punctuationPattern`, `multiField`, `manualReviewOnly`. Every row below proposes one of those kinds; the gate test asserts the set membership.
 
-This audit is a read-only pass over `worker/src/subjects/grammar/content.js`. It does not modify `content.js`, does not touch `answer-spec.js`, and does not touch any oracle fixture.
-
-Phase 5 and later generated templates now have an opt-in enforcement path: template metadata can set `requiresAnswerSpec: true` and `answerSpecKind`, and each generated question must emit hidden `question.answerSpec` data that passes `validateAnswerSpec()`. Legacy templates keep the adapter path until their own content-release migration, but new generated content must not add fresh marking debt.
+QG P2 makes this audit executable: every constructed-response template now sets `requiresAnswerSpec: true` and `answerSpecKind`, and each generated question emits hidden `question.answerSpec` data that passes `validateAnswerSpec()`. Legacy `markStringAnswer` remains as a compatibility adapter, but the shipped P2 release has zero constructed-response templates left on that adapter path.
 
 ---
 
 ## 1. Scope and ground rules
 
 - **57 templates total.** Confirmed by `GRAMMAR_TEMPLATES.length === 57` in `worker/src/subjects/grammar/content.js`. Split: 37 `isSelectedResponse: true`, 20 `isSelectedResponse: false`.
-- **Zero template code changes.** Proposed specs are Phase 5 backlog only.
-- **Zero `contentReleaseId` bump.** Any Phase 5 PR that changes marking behaviour (new accepted variants, stricter near-miss rejection, migration from `acceptedSet` adapter to declarative `punctuationPattern`) bumps `contentReleaseId` and refreshes the paired oracle fixture. Phase 4 touches neither.
+- **P2 template migration shipped.** The 20 constructed-response templates now emit hidden answer specs directly.
+- **`contentReleaseId` bumped.** QG P2 uses `grammar-qg-p2-2026-04-28` and adds separate P2 fixtures. The QG P1 fixtures remain unchanged.
 - **P1 focus concepts drive priority.** Six concepts were the confirmed thin-pool backlog before P1 expansion: `pronouns_cohesion`, `formality`, `active_passive`, `subject_object`, `modal_verbs`, `hyphen_ambiguity`. Every template carrying one of these concept ids in `skillIds` inherits **high** priority, so reliability work continues to land on the concepts that were previously fragile.
 - **Selected-response default is `exact`, except classify-table specs.** 35 selected-response rows use `exact`. Two new P1 classify-table templates use `multiField` because they have per-row answers. These are additive migrations: the marking result is deterministic and no stored constructed-response evidence changes.
-- **Constructed-response triage is per-concept.** Rewrite templates for `active_passive` and `tense_aspect` migrate to `normalisedText` (whitespace + case tolerance, single golden). Punctuation-surgery templates migrate to `punctuationPattern` (the marker keeps the punctuation characters literal and can opt into `optionalCommas`). Multi-way rewrites (`clauses` combine / join) stay `acceptedSet` until Phase 5 has time to enumerate equivalence classes. Open-ended builders and ambiguous rewrites flag as `manualReviewOnly` candidates for Phase 5 to re-evaluate once the thin-pool concepts have expanded.
+- **Constructed-response triage is per-concept.** Rewrite templates for `active_passive` and `tense_aspect` migrate to `normalisedText` (whitespace + case tolerance, single golden). Punctuation-surgery templates migrate to `punctuationPattern` (the marker keeps the punctuation characters literal and can opt into `optionalCommas`). Multi-way rewrites (`clauses` combine / join) use explicit `acceptedSet` alternatives. Open-ended builders and ambiguous rewrites are `manualReviewOnly` in P2, with neutral feedback and no auto-scored mastery or reward progression.
 
 ---
 
@@ -138,7 +136,7 @@ Totals: 35 + 5 + 2 + 9 + 2 + 4 = 57.
 
 ## 3. Manual-review-only candidates (≥ 5)
 
-Phase 5 should land `manualReviewOnly` for at least these candidates before enabling a declarative-only content-release PR. The doc-gate test asserts this list contains **at least 5** entries.
+P2 lands `manualReviewOnly` for the four open constructed-response candidates. The two selected-response explain templates remain future re-evaluation candidates if they ever become free text. The doc-gate test asserts this list contains **at least 5** entries so the future free-text risk stays visible.
 
 1. `build_noun_phrase` — open-ended builder; any syntactically valid expanded noun phrase with three+ words should count, but the fixture cannot enumerate every adjective/post-modifier combination.
 2. `proc2_fronted_adverbial_build` — free-form sentence building; many valid rewrites preserve the fronted-adverbial target.
@@ -170,10 +168,10 @@ Why high priority on thin-pool concepts specifically: each concept has fewer tem
 
 Every row where marking behaviour changes bumps `contentReleaseId` and invalidates stored attempt evidence against the prior release. Rows that are purely declarative (selected-response → `exact`, where the mark result is byte-identical for every stored attempt) do not bump.
 
-- **Rows requiring `contentReleaseId` bump: 20.** Every row marked `YES` in the table — all 20 legacy constructed-response templates. Phase 5 should batch these per-concept so one content-release PR covers all templates for a given skill (e.g. one PR for `punctuation_*` surgery, one for `active_passive`, one for `standard_english`). Every such PR pairs with a `tests/fixtures/oracle-grammar-*.json` refresh.
+- **Rows requiring `contentReleaseId` bump: 20.** Every row marked `YES` in the table — all 20 legacy constructed-response templates. QG P2 batches these as one content release and pairs them with separate QG P2 fixtures.
 - **Rows NOT requiring `contentReleaseId` bump: 37.** Every selected-response row marked `NO` — legacy selected-response rows preserve option-value equality, and the new P1 rows emit typed `answerSpec` data from day one. The P1 content itself bumps the Grammar content release because the pool changed, but the answer-spec marking contract does not add a separate marking-behaviour bump.
 - **`explain_reason_choice` and `proc2_boundary_punctuation_explain`:** flagged `medium` priority and `NO` bump because today they are selected-response. If Phase 5 migrates them to free-text explanation, that migration **is** a marking-behaviour change and bumps `contentReleaseId` at that time.
-- **`build_noun_phrase`, `standard_fix_sentence`, `proc2_fronted_adverbial_build`, `proc3_noun_phrase_build`:** `manualReviewOnly` migration **always** bumps `contentReleaseId`: the mark result shifts from `correct: true/false, score: 0..2` (adapter path) to `correct: false, score: 0, maxScore: 0` (manual-review path). Every stored attempt would need a mastery-signal downgrade, so the release-id bump is non-negotiable.
+- **`build_noun_phrase`, `standard_fix_sentence`, `proc2_fronted_adverbial_build`, `proc3_noun_phrase_build`:** `manualReviewOnly` migration **always** bumps `contentReleaseId`: the mark result shifts from `correct: true/false, score: 0..2` (adapter path) to `correct: false, score: 0, maxScore: 0, nonScored: true` (manual-review path). Stored attempt evidence must not be replayed as P2 mastery evidence.
 
 ---
 
@@ -192,12 +190,12 @@ The test file does **not** touch `content.js`, `answer-spec.js`, or any oracle f
 
 ---
 
-## 7. Phase 5 execution notes (out of scope for this PR)
+## 7. Migration notes and future boundaries
 
-These notes guide the Phase 5 backlog and are not enforced by this doc gate:
+These notes are now historical migration guidance plus future backlog boundaries:
 
-- **One template per content-release PR** unless the PR batches templates under the same concept with an identical marking-behaviour change. Paired oracle-fixture refresh per PR.
-- **Migration ordering suggestion.**
+- **QG P2 batching.** P2 intentionally shipped all 20 constructed-response migrations in one release so the answer-spec denominator, release id, redaction gate, smoke family coverage, and reward safety moved together.
+- **Historical migration ordering suggestion.**
   1. Thin-pool `active_passive` rewrites (`normalisedText`) — 2 templates.
   2. Thin-pool `hyphen_ambiguity` surgery (`punctuationPattern`) — 1 template (`proc3_hyphen_fix_meaning`).
   3. Remaining punctuation-surgery templates (`punctuationPattern`) — 7 templates.
@@ -205,15 +203,15 @@ These notes guide the Phase 5 backlog and are not enforced by this doc gate:
   5. Clause combine/join (`acceptedSet`) — 2 templates.
   6. Builders + ambiguous fixes (`manualReviewOnly`) — 4 templates.
   7. Selected-response batch (`exact`/`multiField`) — 37 templates in one PR, with the two P1 classify tables already carrying `multiField`.
-  8. Explain-template re-evaluation (potential `manualReviewOnly` migration if they move to free-text) — deferred to Phase 6+ content-expansion work.
-- **Each Phase 5 PR** must land a new row in `tests/fixtures/grammar-phase5-answer-spec-migration/*.json` (per-template migration evidence) plus an `ownerUnit` + `landedIn: "PR #<num>"` row in the Phase 5 baseline. Phase 4's completeness gate (U13) does **not** read these; a new Phase 5 gate will.
-- **`params` usage.** Reserved parameters flagged above (`params.optionalCommas`, `params.acceptHyphenMinus`, `params.acceptQuoteStyle`) are Phase 5 enhancements. None are required for the first migration wave — drop them and rely on declared golden strings matching fixture output byte-for-byte.
+  8. Explain-template re-evaluation (potential `manualReviewOnly` migration if they move to free-text) — still deferred to future content-expansion work.
+- **`params` usage.** Reserved parameters flagged above (`params.optionalCommas`, `params.acceptHyphenMinus`, `params.acceptQuoteStyle`) remain future enhancements. P2 relies on declared golden strings matching fixture output byte-for-byte.
 
 ---
 
 ## 8. References
 
-- Plan: `docs/plans/2026-04-26-001-feat-grammar-phase4-learning-hardening-plan.md` — U11 section.
+- Plan: `docs/plans/james/grammar/questions-generator/grammar-qg-p2.md`.
+- Historical plan: `docs/plans/2026-04-26-001-feat-grammar-phase4-learning-hardening-plan.md` — U11 section.
 - Source of truth: `worker/src/subjects/grammar/content.js` (`GRAMMAR_TEMPLATES`).
 - Answer-spec module: `worker/src/subjects/grammar/answer-spec.js` (`ANSWER_SPEC_KINDS`, `markByAnswerSpec`, `validateAnswerSpec`).
 - Phase 3 deferral of record: `docs/plans/james/grammar/grammar-phase3-implementation-report.md` §5 item 5.

--- a/docs/plans/james/grammar/grammar-content-expansion-audit.md
+++ b/docs/plans/james/grammar/grammar-content-expansion-audit.md
@@ -1,19 +1,19 @@
 ---
 title: "Grammar content-expansion audit (Phase 5 backlog)"
 type: audit
-status: p1-updated
+status: p2-updated
 date: 2026-04-28
 plan: docs/plans/2026-04-26-001-feat-grammar-phase4-learning-hardening-plan.md
 unit: U12
-contentReleaseId: grammar-qg-p1-2026-04-28
+contentReleaseId: grammar-qg-p2-2026-04-28
 contentReleaseBump: yes
 ---
 
 # Grammar content-expansion audit (Phase 5 backlog)
 
-This document started as the Phase 5 content-expansion backlog for the Grammar subject. It now records the P1 generator expansion that landed six focused generated templates, each with hidden typed `answerSpec` data. The `GRAMMAR_CONTENT_RELEASE_ID` is bumped to `grammar-qg-p1-2026-04-28`; the legacy `grammar-legacy-reviewed-2026-04-24` fixtures remain frozen for historical compatibility checks.
+This document started as the Phase 5 content-expansion backlog for the Grammar subject. It now records the P1 generator expansion that landed six focused generated templates, each with hidden typed `answerSpec` data, and the P2 constructed-response marking migration that made the current 57-template release fully declarative. The `GRAMMAR_CONTENT_RELEASE_ID` is bumped to `grammar-qg-p2-2026-04-28`; the legacy `grammar-legacy-reviewed-2026-04-24` and QG P1 fixtures remain frozen for historical compatibility checks.
 
-The audit is produced by reading `worker/src/subjects/grammar/content.js` at release id `grammar-qg-p1-2026-04-28` and cross-referencing `GRAMMAR_AGGREGATE_CONCEPTS` in `src/platform/game/mastery/grammar.js`. There are 18 aggregate concepts and 57 templates in the pool at the time of the audit.
+The audit is produced by reading `worker/src/subjects/grammar/content.js` at release id `grammar-qg-p2-2026-04-28` and cross-referencing `GRAMMAR_AGGREGATE_CONCEPTS` in `src/platform/game/mastery/grammar.js`. There are 18 aggregate concepts and 57 templates in the pool at the time of the audit.
 
 An executable generator audit now backs this document:
 
@@ -164,7 +164,7 @@ Each P1 focus concept below keeps five proposed follow-up templates. P1 has alre
 
 ## Release-id discipline
 
-Every future proposal above is a content-release candidate. P1 touches `content.js`, adds generated templates with typed `answerSpec`, and bumps `GRAMMAR_CONTENT_RELEASE_ID` to `grammar-qg-p1-2026-04-28`. The previous `grammar-legacy-reviewed-2026-04-24` oracle remains frozen rather than overwritten.
+Every future proposal above is a content-release candidate. P1 touched `content.js`, added generated templates with typed `answerSpec`, and bumped `GRAMMAR_CONTENT_RELEASE_ID` to `grammar-qg-p1-2026-04-28`. P2 keeps the same 57-template denominator, migrates every constructed-response template to explicit declarative marking, and bumps the active release id to `grammar-qg-p2-2026-04-28`. The previous `grammar-legacy-reviewed-2026-04-24` oracle and QG P1 baseline remain frozen rather than overwritten.
 
 When a later phase lands any of the remaining proposals, the PR author must:
 
@@ -203,7 +203,7 @@ When a later phase lands any of the remaining proposals, the PR author must:
 - Concepts with an `explain` template today: **5 (represented by 4 templates)** — `adverbials` and `standard_english` both via `explain_reason_choice`; `boundary_punctuation` via `proc2_boundary_punctuation_explain`; `modal_verbs` via `qg_modal_verb_explain`; `hyphen_ambiguity` via `qg_hyphen_ambiguity_explain`.
 - Future template ideas proposed: **30** (five per P1 focus concept × six concepts)
 - Phase 5 release-id bumps implied (one per new-template PR landed, assuming each ships atomically): up to **30**
-- `contentReleaseId` bumps produced by P1: **1** (`grammar-qg-p1-2026-04-28`)
+- `contentReleaseId` bumps produced by QG work so far: **2** (`grammar-qg-p1-2026-04-28`, `grammar-qg-p2-2026-04-28`)
 
 ---
 
@@ -212,5 +212,5 @@ When a later phase lands any of the remaining proposals, the PR author must:
 - Plan: `docs/plans/2026-04-26-001-feat-grammar-phase4-learning-hardening-plan.md` §U12 (~line 929).
 - Invariants: `docs/plans/james/grammar/grammar-phase4-invariants.md`.
 - Answer-spec audit (sibling Phase 5 backlog): `docs/plans/james/grammar/grammar-answer-spec-audit.md`.
-- Content source: `worker/src/subjects/grammar/content.js` at `GRAMMAR_CONTENT_RELEASE_ID = 'grammar-qg-p1-2026-04-28'`.
+- Content source: `worker/src/subjects/grammar/content.js` at `GRAMMAR_CONTENT_RELEASE_ID = 'grammar-qg-p2-2026-04-28'`.
 - Concept list: `src/platform/game/mastery/grammar.js` — `GRAMMAR_AGGREGATE_CONCEPTS`.

--- a/docs/plans/james/grammar/questions-generator/grammar-qg-p2-completion-report.md
+++ b/docs/plans/james/grammar/questions-generator/grammar-qg-p2-completion-report.md
@@ -1,0 +1,73 @@
+---
+title: "Grammar QG P2 completion report"
+type: report
+status: completed
+date: 2026-04-28
+plan: docs/plans/james/grammar/questions-generator/grammar-qg-p2.md
+release_id: grammar-qg-p2-2026-04-28
+---
+
+# Grammar QG P2 completion report
+
+## Summary
+
+Grammar QG P2 closes the constructed-response marking migration for the 57-template Grammar release. All 20 constructed-response templates now emit explicit Worker-private `answerSpec` data, the legacy constructed-response adapter count is zero, and open creative responses are captured as manual-review-only rather than being auto-scored.
+
+The shipped release keeps the QG P1 denominator stable:
+
+- 18 concepts.
+- 57 templates.
+- 37 selected-response templates.
+- 20 constructed-response templates.
+- 31 generated templates.
+- 26 fixed templates.
+- Zero thin-pool concepts.
+- Zero single-question-type concepts.
+
+## Marking coverage
+
+The current audit reports 26 answer-spec templates:
+
+- `acceptedSet`: 2 templates.
+- `exact`: 4 templates.
+- `manualReviewOnly`: 4 templates.
+- `multiField`: 2 templates.
+- `normalisedText`: 5 templates.
+- `punctuationPattern`: 9 templates.
+
+Every constructed-response template now declares `requiresAnswerSpec`, `answerSpecKind`, and hidden emitted `answerSpec` data. `manualReviewOnly` responses save the learner response with `correct: false`, `score: 0`, `maxScore: 0`, `nonScored: true`, and `manualReviewOnly: true`.
+
+## Runtime behaviour
+
+Score-bearing constructed responses still use deterministic marking only. No AI path can award marks, mastery, concept-secured evidence, Star evidence, or monster reward progress.
+
+Manual-review-only attempts are deliberately non-scored:
+
+- They do not mutate concept, template, question-type, or item mastery.
+- They do not enqueue retry work.
+- They do not emit misconception, answer-submitted, concept-secured, Star-evidence, or reward events.
+- They emit `grammar.manual-review-saved` so the response can be replayed and audited.
+- The child UI renders the saved response as neutral feedback and hides repair or enrichment actions for that result.
+
+Reward and Star evidence now carries the active Grammar content release id, `grammar-qg-p2-2026-04-28`.
+
+## Release evidence
+
+The audit fixture split preserves QG P1 as the previous release and adds a QG P2 baseline for the current release. The production smoke now has visible-data probes for every answer-spec family: `exact`, `multiField`, `normalisedText`, `punctuationPattern`, `acceptedSet`, and `manualReviewOnly`.
+
+Verification run during implementation:
+
+- `node scripts/worktree-setup.mjs`
+- `node --check worker/src/subjects/grammar/content.js`
+- `node --check worker/src/subjects/grammar/answer-spec.js`
+- `node --check worker/src/subjects/grammar/engine.js`
+- `node --check worker/src/subjects/grammar/read-models.js`
+- `node --check worker/src/subjects/grammar/commands.js`
+- `node --check scripts/grammar-production-smoke.mjs`
+- `node --test tests/grammar-answer-spec.test.js tests/grammar-answer-spec-audit.test.js tests/grammar-question-generator-audit.test.js tests/grammar-ui-model.test.js tests/grammar-engine.test.js tests/grammar-functionality-completeness.test.js tests/grammar-production-smoke.test.js tests/worker-grammar-subject-runtime.test.js tests/grammar-rewards.test.js tests/grammar-star-persistence.test.js tests/react-grammar-surface.test.js`
+
+Repository-level gates are recorded on the PR once the branch is ready for review.
+
+## Follow-up boundary
+
+P2 intentionally does not expand the catalogue or add runtime AI marking. The next sensible content slice is QG P3, focused on explanation-template depth for the remaining weaker concepts, after the declarative marking foundation has landed.

--- a/docs/plans/james/grammar/questions-generator/grammar-qg-p2.md
+++ b/docs/plans/james/grammar/questions-generator/grammar-qg-p2.md
@@ -1,431 +1,653 @@
-# Grammar QG P2 — Declarative Marking Migration
+---
+title: "feat: Grammar QG P2 declarative marking migration"
+type: feat
+status: completed
+date: 2026-04-28
+origin: docs/plans/james/grammar/questions-generator/grammar-qg-p1-final-completion-report-2026-04-28.md
+source_plan: docs/plans/james/grammar/questions-generator/grammar-qg-p1.md
+deepened: 2026-04-28
+---
 
-Status: proposed next implementation phase  
-Owner: KS2 Mastery / Grammar  
-Previous release baseline: `grammar-qg-p1-2026-04-28`  
-Target release: use a new `GRAMMAR_CONTENT_RELEASE_ID` when the P2 migration lands, for example `grammar-qg-p2-YYYY-MM-DD`.
+# feat: Grammar QG P2 declarative marking migration
 
-## 1. Context
+## Summary
 
-Grammar QG P1 successfully moved the Grammar question bank from the legacy 51-template baseline to a 57-template release. It added six deterministic question-generator templates, removed the previously thin concept pools, introduced answer-safe generated variant signatures, and added a first audit path for question-generator coverage and production read-model safety.
+Grammar QG P2 migrates every legacy constructed-response Grammar template onto explicit, validated, Worker-private `answerSpec` data while preserving deterministic marking, P1's 57-template denominator, answer-safe generated variant signatures, and child-facing read-model redaction. The plan treats marking governance as the release goal: it bumps the Grammar content release, adds a separate P2 fixture, extends the executable audit, and proves that manual-review-only content cannot award mastery, Stars, or reward progress.
 
-P1 deliberately did not finish the full marking migration. The six new QG P1 templates declare typed `answerSpec` data, but the legacy constructed-response templates still rely on older accepted-answer or ad-hoc marking paths. P2 should therefore focus on declarative marking governance, not broad content expansion.
+---
 
-The central P2 goal is:
+## Problem Frame
 
-> Every Grammar constructed-response template should have an explicit, validated, Worker-private `answerSpec`, while preserving deterministic, non-AI marking and avoiding hidden answer leakage to child-facing read models.
+QG P1 moved Grammar from the legacy 51-template pool to a governed 57-template release with six new deterministic generated templates and typed answer specs for the new content. That release deliberately left the 20 older constructed-response templates on the migration-window adapter path: their `evaluate` closures still rely on inline accepted answers or older ad hoc marking shapes.
 
-## 2. Product and learning position
+P2 closes that trust gap before the team expands the catalogue again. The learner-facing product should stay simple; the engineering change is that every constructed-response template has an explicit declarative marking contract that can be audited, redacted, replayed, and release-scoped.
 
-P2 is a quality and trust phase. It should make the engine safer before the team expands the question catalogue further.
+---
 
-The learner-facing experience should not become more complex in this phase. P2 should not add a new mode, a new dashboard, or a new reward surface. It should make the existing Grammar engine more auditable, more consistent, and less dependent on fragile string checks.
+## Requirements
 
-The team should continue to avoid runtime AI for production question generation or marking. AI may be used outside production as a review assistant, but no AI-generated question, explanation, answer key, or mark decision should be shipped without deterministic teacher-authored validation.
+- R1. Preserve the QG P1 denominator unless an explicit P2 release note says otherwise: 18 concepts, 57 templates, 37 selected-response templates, 20 constructed-response templates, 31 generated templates, 26 fixed templates, zero thin-pool concepts, and zero single-question-type concepts.
+- R2. Bump `GRAMMAR_CONTENT_RELEASE_ID` for the constructed-response marking migration and keep the P1 fixture immutable.
+- R3. Add a separate QG P2 fixture that records the shipped P2 audit state and remains distinct from the QG P1 fixture.
+- R4. Require all 20 legacy constructed-response templates to declare explicit `requiresAnswerSpec`, `answerSpecKind`, and hidden emitted `answerSpec` data, unless a template is intentionally `manualReviewOnly`.
+- R5. Keep all score-bearing marking deterministic and non-AI; no runtime AI question generation, explanation generation, answer-key generation, or AI marking enters the production scoring path.
+- R6. Migrate the five normalised rewrite templates to `normalisedText` with parity tests for intended answers and wrong-target rejections.
+- R7. Migrate the nine punctuation-surgery templates to `punctuationPattern` without making punctuation matching overly permissive.
+- R8. Migrate the two finite rewrite templates to `acceptedSet` with small teacher-reviewable accepted alternatives and comma-splice / wrong-join rejections.
+- R9. Mark genuinely open creative responses as `manualReviewOnly` unless they are redesigned into constrained deterministic responses in a separate reviewed content slice.
+- R10. Prove `manualReviewOnly` responses can be collected and replayed without auto-scoring, mastery mutation, secure concept evidence, Star evidence, or reward progression.
+- R11. Preserve child-facing redaction: no `answerSpec`, `correctResponses`, accepted answers, generator family ids, variant signatures, hidden correctness flags, or raw validators leak through start, feedback, summary, mini-test, support, AI-enrichment, adult, or admin read models.
+- R12. Extend production smoke so each answer-spec family is covered from production-visible data, and the smoke keeps deriving answers from visible options or visible prompts rather than hidden local objects.
+- R13. Preserve generated variant governance: stable generator family ids, answer-safe variant signatures, strict QG P1 repeated-variant failures, advisory legacy repeated-variant reporting, and selector freshness.
+- R14. Verify Grammar reward and Star paths use the active P2 content release id for new concept-secured and Star-evidence events, while old release data remains readable but cannot be mistaken for current evidence.
 
-## 3. Non-goals
+**Origin actors:** KS2 learner, parent/adult, Grammar Worker engine, game/reward layer, release operator.
 
-P2 must not:
+**Origin flows:** Deterministic Grammar practice, production-visible answer derivation, read-model redaction, reward projection from committed learning evidence, content release audit.
 
-- add broad new Grammar skills or concepts;
-- rely on runtime AI generation or AI marking;
-- expose `answerSpec`, hidden accepted answers, generator family IDs, variant signatures, or correctness flags in child-facing read models;
-- change subject Stars, monster progression, or reward semantics except where a release-id alignment bug is explicitly fixed;
-- award mastery for creative open-response templates that cannot be marked deterministically;
-- replace subject scheduling with a new external scheduler;
-- overwrite the P1 baseline fixture without adding a distinct P2 fixture.
+**Origin acceptance examples:** QG P1 generated items keep typed hidden answer specs; production smoke answers from visible options only; server-only Grammar keys are scanned across start, feedback, and summary models; reward progress derives from active release evidence.
 
-## 4. Validated P1 baseline to preserve
+---
 
-Unless a deliberate P2 release change says otherwise, the following denominator should remain stable:
+## Scope Boundaries
 
-| Measure | P1 baseline |
-|---|---:|
-| Concepts | 18 |
-| Templates | 57 |
-| Selected-response templates | 37 |
-| Constructed-response templates | 20 |
-| Generated templates | 31 |
-| Fixed templates | 26 |
-| QG P1 answer-spec templates | 6 |
-| Thin-pool concepts | 0 |
-| Single-question-type concepts | 0 |
+- Do not add broad new Grammar skills, concepts, modes, dashboard features, reward surfaces, or child-facing generator diagnostics.
+- Do not use runtime AI for score-bearing Grammar content or marking.
+- Do not expose hidden marking data, accepted alternatives, variant signatures, generator family ids, or correctness flags to child-facing read models.
+- Do not alter subject Stars, monster thresholds, or reward semantics except for fixing active release-id alignment where P2 evidence would otherwise use a stale id.
+- Do not award mastery for creative open-response templates that cannot be deterministically marked.
+- Do not replace subject scheduling or create an external scheduler.
+- Do not overwrite the QG P1 baseline fixture in place.
+- Do not broaden this phase into explanation coverage, full catalogue expansion, or an admin content CMS.
 
-P2 is expected to keep the same 57-template denominator. The main expected denominator change is the answer-spec migration count.
+### Deferred to Follow-Up Work
 
-Target after P2:
+- Explanation-template expansion for the fourteen concepts that still lack strong explain coverage: QG P3.
+- Broader deterministic generated catalogue depth: later QG expansion phase after P2 marking governance is safe.
+- Redesigning open creative templates into constrained score-bearing prompts: separate reviewed content-release slice if product value justifies it.
+- Automating production Grammar smoke into a release pipeline: follow-up release-gate hardening; P2 keeps the smoke stronger but may remain manual.
 
-| Measure | P2 target |
-|---|---:|
-| Templates | 57 |
-| Constructed-response templates | 20 |
-| Templates requiring explicit `answerSpec` | 26 |
-| Constructed-response templates without explicit `answerSpec` | 0 |
-| Thin-pool concepts | 0 |
-| Single-question-type concepts | 0 |
+---
 
-Why 26? The six QG P1 templates already require typed `answerSpec`. P2 should add explicit `answerSpec` coverage for the 20 legacy constructed-response templates.
+## Context & Research
 
-## 5. Main deliverables
+### Relevant Code and Patterns
 
-P2 should ship the following deliverables:
+- `worker/src/subjects/grammar/content.js` is the template source of truth. It currently exports `GRAMMAR_CONTENT_RELEASE_ID = 'grammar-qg-p1-2026-04-28'`, `GRAMMAR_TEMPLATE_METADATA`, generated family metadata, answer-safe variant signatures, and the migration-window adapter comments for constructed-response marking.
+- `worker/src/subjects/grammar/answer-spec.js` already defines the six answer-spec kinds, `markByAnswerSpec`, and `validateAnswerSpec`. `manualReviewOnly` already returns `correct: false`, `score: 0`, and `maxScore: 0`, but engine-level no-mastery semantics still need explicit integration coverage.
+- `scripts/audit-grammar-question-generator.mjs` already reports template counts, generated/fixed split, signature collisions, repeated variants, and answer-spec templates. P2 extends this audit rather than creating a second inventory script.
+- `docs/plans/james/grammar/grammar-answer-spec-audit.md` classifies all 57 templates by target answer-spec kind and release-id impact. It is the per-template migration map for P2.
+- `tests/grammar-answer-spec.test.js` covers the marker and validator contract for all six kinds.
+- `tests/grammar-answer-spec-audit.test.js` currently gates the audit document and validates new opt-in templates. P2 should turn constructed-response coverage from planned inventory into executable migration enforcement.
+- `tests/grammar-question-generator-audit.test.js`, `tests/grammar-engine.test.js`, and `tests/grammar-functionality-completeness.test.js` already pin QG P1 denominator, release fixture, answer specs, and generated signatures.
+- `scripts/grammar-production-smoke.mjs` and `tests/grammar-production-smoke.test.js` are the API-contract smoke pattern. They derive selected-response answers from the production-visible option set and scan forbidden keys in multiple read-model phases.
+- `worker/src/subjects/grammar/engine.js` rejects stale content release attempts, applies marking results to mastery, emits `grammar.answer-submitted`, `grammar.concept-secured`, generator family ids, variant signatures, and content release ids.
+- `worker/src/subjects/grammar/commands.js`, `src/subjects/grammar/event-hooks.js`, and `src/platform/game/mastery/grammar.js` are the command/reward boundary for Star evidence and monster progress.
+- `tests/helpers/forbidden-keys.mjs` is the shared forbidden-key oracle for Grammar read-model redaction.
 
-1. A new Grammar content release ID.
-2. Explicit typed `answerSpec` declarations for all 20 constructed-response templates.
-3. A P2 audit fixture, separate from the P1 fixture.
-4. Audit output that distinguishes between QG template coverage and constructed-response answer-spec migration coverage.
-5. Parity tests showing that migrated templates accept the intended answers and reject clear wrong answers.
-6. Production smoke coverage for each constructed-response answer-spec family.
-7. Read-model redaction tests proving hidden specs and answer keys do not leak.
-8. Manual-review handling for genuinely open creative responses.
-9. A reward/release-id alignment check for Grammar concept and Star events.
+### Institutional Learnings
 
-## 6. Workstream A — Baseline and release hygiene
+- Grammar production smoke must behave like an API-contract test: answers come from production-visible data, and forbidden-key scans cover start, feedback, and summary models, not only the current item.
+- Grammar Star and reward work must use production-faithful Worker state shapes. Idealised fixtures can pass while production displays zero progress or inflates progress.
+- Reward state now separates secure concept analytics from Star high-water persistence. P2 must not let manual-review-only or non-scored responses emit either secure concept evidence or Star evidence.
+- Content-release changes are production-sensitive: release ids, oracle fixtures, stale-attempt rejection, mastery keys, and production smoke expectations must move together.
+- P1 proved that answer-safe variant signatures should not include hidden answer specs or answer ordering; P2 must preserve that split while expanding answer-spec coverage.
 
-### A1. Keep P1 immutable
+### External References
 
-Do not mutate the P1 fixture in place. Add a new P2 fixture, for example:
+- No external research was used. The repo already has direct local patterns for deterministic marking, answer-spec validation, content-release fixtures, redaction, production smoke, and reward projection.
 
-```text
-tests/fixtures/grammar-legacy-oracle/grammar-qg-p2-baseline.json
+---
+
+## Key Technical Decisions
+
+- **Extend the existing `answerSpec` seam, not a new marking framework:** P2 should make legacy templates emit the same hidden answer-spec shape that QG P1 templates use, then keep `markByAnswerSpec` as the single marking entry point. This avoids another migration layer and lets existing validator and redaction tests become stronger gates.
+- **Treat P2 as one content release with a new fixture:** All 20 constructed-response migrations change the marking contract or scoring semantics, so the release id bump and QG P2 fixture are part of the same release boundary. The QG P1 fixture stays frozen for regression comparison.
+- **Use per-family migration units:** Normalised rewrites, punctuation fixes, finite accepted sets, and manual-review-only items have different failure modes. Splitting by answer-spec family keeps review focused and makes test coverage specific rather than padded.
+- **Manual-review-only is an engine/reward concern, not only a marker kind:** Returning `correct: false` and `score: 0` is insufficient if the engine still increments mastery nodes, queues retries, or emits Star evidence. P2 must add explicit no-auto-score behaviour at the engine/command boundary for `manualReviewOnly`.
+- **Manual-review-only needs a neutral learner presentation:** Existing feedback helpers treat `correct: false` as an incorrect answer. P2 should thread a safe non-scored/manual-review signal through the Worker result/read model so the client renders saved-for-review practice neutrally rather than telling the learner they were wrong.
+- **Keep punctuation strict by default:** Quote style, dash spacing, hyphen-minus, final punctuation, and optional comma tolerance can be supported only through explicit `params` on the spec. The default must reject missing target punctuation, wrong punctuation families, and unrelated wording changes.
+- **Production smoke grows by answer-spec family:** The smoke should cover at least one template each from `normalisedText`, `punctuationPattern`, `acceptedSet`, `multiField`, `exact`, and `manualReviewOnly`. For constructed-response families, the smoke must derive responses from visible prompt structure or a declared smoke fixture that mirrors production-visible input, never from hidden `answerSpec`.
+- **Reward/release-id alignment is an explicit P2 gate:** New concept-secured and Star-evidence paths should prefer the event-level active release id and mastery key. Any fallback release constant remains backward-compatible only, with tests proving active P2 events do not regress to a stale release id.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should P2 expand Grammar content?** No. P2 keeps the 57-template denominator and focuses on marking governance.
+- **Should selected-response templates migrate too?** No active selected-response migration is required in P2. The six QG P1 answer-spec templates remain covered; selected-response exact migration can stay outside this constructed-response phase unless implementation discovers a small additive parity cleanup that is clearly non-behavioural.
+- **Should open creative builder templates auto-score through a permissive matcher?** No. They become `manualReviewOnly` unless separately redesigned into constrained deterministic prompts.
+- **Should production smoke read hidden answer specs locally for constructed-response probes?** No. The smoke must preserve the production-visible-data principle from QG P1.
+- **Should P2 introduce new reward semantics for manual-review writing practice?** No. Manual-review-only items can be collected as practice evidence but must not affect mastery, secure concepts, Stars, or reward progression in this phase.
+
+### Deferred to Implementation
+
+- Exact P2 release id string: choose the landing date when the migration lands.
+- Exact helper names and whether `content.js` needs a small local answer-spec builder helper: only extract if it reduces real duplication across migrated templates.
+- Whether punctuation `params` need quote-style or hyphen-minus tolerance immediately: decide per template from existing accepted answers and tests; do not broaden globally.
+- Whether `standard_fix_sentence` stays `manualReviewOnly` or is redesigned as constrained response: default to `manualReviewOnly`; redesign needs explicit content-review justification.
+- Exact smoke probe seeds: choose stable seeds during implementation so visible prompts are deterministic and representative.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+  A["Template generator in content.js"] --> B["Hidden question.answerSpec"]
+  B --> C["validateAnswerSpec gate"]
+  B --> D["evaluate via markByAnswerSpec"]
+  A --> E["serialiseGrammarQuestion"]
+  E --> F["Worker read model"]
+  F --> G["Forbidden-key scans"]
+  D --> H{"manualReviewOnly?"}
+  H -->|no| I["Mastery / retry / Star evidence"]
+  H -->|yes| J["Saved response, no auto-score"]
+  I --> K["Reward projection with active release id"]
+  J --> K
+  A --> L["QG audit and P2 fixture"]
 ```
 
-The P1 fixture should remain available for regression comparison.
+The key boundary is that `answerSpec` exists only inside Worker-private question objects and tests. Serialised learner items and subject read models must remain redacted. `manualReviewOnly` takes a separate no-auto-score path after marking so the engine can save the response without treating it as wrong mastery evidence.
 
-### A2. Bump content release ID
+---
 
-When the constructed-response marking migration lands, update:
+## Implementation Units
 
-```text
-worker/src/subjects/grammar/content.js
+```mermaid
+flowchart TB
+  U1["U1 Audit and P2 baseline"]
+  U2["U2 Shared marking contract"]
+  U3["U3 normalisedText rewrites"]
+  U4["U4 punctuationPattern fixes"]
+  U5["U5 acceptedSet rewrites"]
+  U6["U6 manualReviewOnly safety"]
+  U7["U7 Redaction and smoke"]
+  U8["U8 Variant and selector preservation"]
+  U9["U9 Reward release-id alignment"]
+  U10["U10 Release docs"]
+
+  U1 --> U2
+  U2 --> U3
+  U2 --> U4
+  U2 --> U5
+  U2 --> U6
+  U3 --> U7
+  U4 --> U7
+  U5 --> U7
+  U6 --> U7
+  U6 --> U9
+  U7 --> U10
+  U8 --> U10
+  U9 --> U10
 ```
 
-from:
+- U1. **Audit and P2 Baseline Contract**
 
-```ts
-export const GRAMMAR_CONTENT_RELEASE_ID = 'grammar-qg-p1-2026-04-28';
-```
+**Goal:** Turn the current P2 intent into executable audit output and frozen fixture structure before any template migration changes behaviour.
 
-to a new P2 release ID.
+**Requirements:** R1, R2, R3, R4, R13
 
-Use the actual landing date rather than hard-coding an old date.
+**Dependencies:** None
 
-### A3. Strengthen audit output
+**Files:**
+- Modify: `scripts/audit-grammar-question-generator.mjs`
+- Modify: `tests/grammar-question-generator-audit.test.js`
+- Modify: `tests/grammar-functionality-completeness.test.js`
+- Modify: `tests/helpers/grammar-legacy-oracle.js`
+
+**Approach:**
+- Extend the audit JSON with constructed-response migration fields: answer-spec template count, constructed-response template count, constructed-response rows without explicit answer specs, legacy-adapter template count, manual-review-only template count, answer-spec kind counts, and a boolean P2 migration-complete flag.
+- Keep QG P1 fixture readers intact and add P2 reader support rather than repointing the existing helper to a different file. The final P2 fixture contents land in U10 after the migration units have completed.
+- Make the audit fail only when P2 is in migration-complete mode, or when a template explicitly opts in but fails validation. This lets U1 land the shape before all U3-U6 template migrations are complete.
+- Add baseline tests that preserve the QG P1 denominator and assert the future P2 target: 57 total templates, 20 constructed-response templates, 26 answer-spec templates or higher if deliberately documented, and no constructed-response templates without explicit answer specs at release gate.
 
-Extend `scripts/audit-grammar-question-generator.mjs` so its JSON output includes:
+**Execution note:** Start with characterisation coverage for QG P1 counts before enabling the stricter P2 release gate.
 
-```ts
-{
-  answerSpecTemplateCount,
-  constructedResponseTemplateCount,
-  constructedResponseWithoutAnswerSpec,
-  legacyAdapterTemplateCount,
-  manualReviewOnlyTemplateCount,
-  answerSpecKindCounts,
-  p2MigrationComplete
-}
-```
+**Patterns to follow:**
+- `scripts/audit-grammar-question-generator.mjs` existing `buildAnswerSpecAudit` and signature audit structure.
+- `tests/grammar-functionality-completeness.test.js` QG P1 baseline assertions.
+- `tests/helpers/grammar-legacy-oracle.js` existing frozen-fixture helper pattern.
 
-The audit should fail when a constructed-response template lacks an explicit `answerSpec`, except where the template is intentionally marked as `manualReviewOnly`.
+**Test scenarios:**
+- Happy path: current QG P1 audit still reports 18 concepts, 57 templates, 37 selected-response templates, 20 constructed-response templates, 31 generated templates, 26 fixed templates, and six answer-spec templates.
+- Happy path: P2 fixture reader support targets a separate baseline path without changing the QG P1 baseline path.
+- Edge case: a constructed-response template marked `manualReviewOnly` counts as explicitly migrated, not missing.
+- Error path: a constructed-response template that sets `requiresAnswerSpec` but emits no `answerSpec` is named in the audit failure.
+- Error path: an emitted answer spec whose kind differs from `answerSpecKind` fails with template id and seed.
+- Integration: strict QG P1 repeated variants still fail, while legacy repeated variants remain advisory until separately migrated.
 
-## 7. Workstream B — Migrate normalised text rewrites
+**Verification:**
+- The repo has a P2-aware audit contract before template behaviour changes.
+- QG P1 fixture immutability is mechanically protected.
 
-Migrate these templates first because they are the lowest-risk constructed-response group:
+---
 
-| Template ID | Target answer-spec kind |
-|---|---|
-| `tense_rewrite` | `normalisedText` |
-| `active_passive_rewrite` | `normalisedText` |
-| `proc2_standard_english_fix` | `normalisedText` |
-| `proc2_passive_to_active` | `normalisedText` |
-| `proc3_apostrophe_rewrite` | `normalisedText` |
+- U2. **Shared Marking Contract and Punctuation Parameters**
 
-For each template:
+**Goal:** Prepare the shared marker and validation contract so all migrated template families can express their intent without per-template ad hoc logic.
 
-- add `requiresAnswerSpec: true`;
-- add `answerSpecKind: 'normalisedText'`;
-- emit a Worker-private `answerSpec` from the question builder;
-- mark through `markByAnswerSpec`;
-- keep expected child-facing feedback stable;
-- add positive and negative tests.
+**Requirements:** R4, R5, R7, R8, R9
 
-Minimum tests per template:
+**Dependencies:** U1
 
-- exact expected answer passes;
-- harmless whitespace/case variation passes where appropriate;
-- an answer with the wrong grammar target fails;
-- the generated question serialisation does not expose `answerSpec` or hidden accepted responses.
+**Files:**
+- Modify: `worker/src/subjects/grammar/answer-spec.js`
+- Modify: `worker/src/subjects/grammar/content.js`
+- Modify: `tests/grammar-answer-spec.test.js`
+- Modify: `tests/grammar-answer-spec-audit.test.js`
+
+**Approach:**
+- Preserve the existing six answer-spec kinds; do not add a new kind unless implementation proves one of the 20 templates cannot be expressed safely.
+- Add only the punctuation parameters that real migrated templates require, such as explicit quote-style tolerance or dash/hyphen-minus tolerance. Each parameter must be opt-in and tested with negative examples.
+- Ensure `validateAnswerSpec` continues to require non-empty `golden` and explicit `nearMiss` arrays for score-bearing specs, while `manualReviewOnly` remains valid without golden answers.
+- If `content.js` needs helper builders for common spec shapes, keep them local and small; prefer readability over a broad DSL.
+- Add an assertion path that migrated templates evaluate through `markByAnswerSpec`, even when the result shape matches the old adapter.
 
-## 8. Workstream C — Migrate punctuation-pattern fixes
+**Patterns to follow:**
+- `worker/src/subjects/grammar/answer-spec.js` existing marker functions and validator.
+- `tests/grammar-answer-spec.test.js` exact, normalisedText, acceptedSet, punctuationPattern, multiField, manualReviewOnly coverage.
+- `docs/plans/james/grammar/grammar-answer-spec-audit.md` proposed kind distribution.
 
-Migrate these templates next:
+**Test scenarios:**
+- Happy path: `normalisedText` accepts harmless whitespace and case differences and preserves the golden answer text.
+- Happy path: `acceptedSet` accepts all enumerated teacher-reviewed alternatives and rejects unlisted near misses.
+- Happy path: `punctuationPattern` accepts an explicitly allowed quote or dash variant only when the spec opts in.
+- Edge case: punctuation matching rejects missing target punctuation, wrong punctuation family, over-hyphenation, and unrelated wording changes by default.
+- Error path: invalid spec kind, empty score-bearing golden array, missing score-bearing nearMiss array, and malformed multiField sub-specs all fail validation.
+- Integration: migrated template metadata, emitted `answerSpec.kind`, and validator output agree over multiple seeds.
 
-| Template ID | Target answer-spec kind |
-|---|---|
-| `fix_fronted_adverbial` | `punctuationPattern` |
-| `parenthesis_fix_sentence` | `punctuationPattern` |
-| `speech_punctuation_fix` | `punctuationPattern` |
-| `proc_fronted_adverbial_fix` | `punctuationPattern` |
-| `proc_colon_list_fix` | `punctuationPattern` |
-| `proc_dash_boundary_fix` | `punctuationPattern` |
-| `proc_speech_punctuation_fix` | `punctuationPattern` |
-| `proc3_parenthesis_commas_fix` | `punctuationPattern` |
-| `proc3_hyphen_fix_meaning` | `punctuationPattern` |
+**Verification:**
+- The shared marker is strong enough for all four P2 migration families without broadening default acceptance.
+- No new score-bearing ad hoc marking path is introduced.
 
-Before migrating these, check whether `punctuationPattern` needs small extensions for:
+---
 
-- quote style normalisation;
-- spacing around dashes;
-- hyphen-minus handling;
-- final punctuation tolerance;
-- optional comma tolerance only where explicitly intended.
+- U3. **Migrate Normalised Text Rewrites**
 
-Do not make the punctuation matcher too permissive. It should accept legitimate formatting variation, not incorrect punctuation.
+**Goal:** Move the five lowest-risk constructed-response rewrites to explicit `normalisedText` answer specs.
 
-Minimum tests per template:
+**Requirements:** R4, R5, R6, R11
 
-- expected answer passes;
-- answer with missing target punctuation fails;
-- answer with wrong punctuation type fails;
-- answer with unrelated wording changes fails unless the original template already accepted that behaviour;
-- hidden answer data is absent from the read model.
+**Dependencies:** U2
 
-## 9. Workstream D — Migrate accepted-set rewrites
+**Files:**
+- Modify: `worker/src/subjects/grammar/content.js`
+- Modify: `tests/grammar-answer-spec-audit.test.js`
+- Modify: `tests/grammar-engine.test.js`
+- Create or modify: `tests/grammar-answer-spec-migration-p2.test.js`
 
-Migrate these templates:
+**Approach:**
+- Migrate `tense_rewrite`, `active_passive_rewrite`, `proc2_standard_english_fix`, `proc2_passive_to_active`, and `proc3_apostrophe_rewrite`.
+- Each template should declare `requiresAnswerSpec: true`, `answerSpecKind: 'normalisedText'`, emit hidden `answerSpec`, and evaluate through `markByAnswerSpec`.
+- Keep learner copy, prompts, feedback tone, and deterministic template ids stable unless a test proves the current text is tied to an unsafe marking assumption.
+- For `proc2_standard_english_fix`, do not silently accept broad paraphrases; if full-form alternatives such as contraction expansion are educationally valid, list them deliberately or defer to acceptedSet redesign.
 
-| Template ID | Target answer-spec kind |
-|---|---|
-| `combine_clauses_rewrite` | `acceptedSet` |
-| `proc3_clause_join_rewrite` | `acceptedSet` |
+**Patterns to follow:**
+- QG P1 answer-spec templates in `worker/src/subjects/grammar/content.js`.
+- `tests/grammar-engine.test.js` QG P1 answer-spec scoring test.
+- `docs/plans/james/grammar/grammar-answer-spec-audit.md` normalisedText rows.
 
-For each template:
+**Test scenarios:**
+- Happy path: for each migrated template, the exact expected answer for a representative seed marks correct and scores full marks.
+- Happy path: harmless whitespace and case variation marks correct where normalisedText is intended.
+- Edge case: wrong grammar target rejects, such as simple past instead of past progressive, passive instead of active, or singular apostrophe instead of plural possession.
+- Edge case: response with correct words but wrong tense or wrong possession meaning rejects.
+- Error path: missing answer or malformed response remains a safe incorrect result, not a thrown runtime error.
+- Integration: serialised questions, start read model, feedback read model, and summary read model do not expose `answerSpec`, golden answers, near misses, or accepted alternatives.
 
-- enumerate the accepted alternatives explicitly;
-- keep the accepted set small and teacher-reviewable;
-- add tests for each accepted answer;
-- add tests for common wrong joins and comma-splice errors;
-- ensure option-free constructed responses do not leak hidden accepted alternatives before marking.
-
-## 10. Workstream E — Handle manual-review-only templates safely
-
-The following templates are open enough that deterministic auto-marking may be educationally unsafe:
-
-| Template ID | Target answer-spec kind |
-|---|---|
-| `build_noun_phrase` | `manualReviewOnly` |
-| `standard_fix_sentence` | `manualReviewOnly` or redesigned constrained response |
-| `proc2_fronted_adverbial_build` | `manualReviewOnly` |
-| `proc3_noun_phrase_build` | `manualReviewOnly` |
-
-For these templates, choose one of two routes.
-
-### Route 1: Keep as manual-review-only
-
-Use this route where the response is genuinely creative or has many valid answers.
-
-Required behaviour:
-
-- the item can collect a response;
-- the response can be shown to the learner after submission;
-- the response is not auto-scored as correct;
-- the response does not increase concept mastery, secure status, Stars, or reward progression;
-- the result clearly communicates that this is a writing/practice item rather than an automatically marked mastery item.
-
-### Route 2: Redesign as constrained response
-
-Use this route only if the team can make the item deterministic without making it educationally weak.
-
-Examples:
-
-- provide a fixed word bank;
-- require choosing from labelled phrases;
-- ask for one controlled transformation;
-- mark against a finite accepted set.
-
-If a template is redesigned this way, document the change and test the new constraints thoroughly.
-
-## 11. Workstream F — Production read-model and command safety
-
-P2 must preserve the P1 safety boundary:
-
-- `answerSpec` must remain Worker-private;
-- `correctResponses` must not leak before marking;
-- generated variant signatures must not appear in child-facing read models;
-- generator family IDs must not appear in child-facing read models;
-- option objects must not include hidden `correct` flags;
-- production smoke should derive correct and incorrect responses only from visible item data, not local hidden objects.
-
-Extend production smoke so it covers at least one template from each answer-spec family:
-
-| Kind | Suggested smoke template |
-|---|---|
-| `normalisedText` | `active_passive_rewrite` or `tense_rewrite` |
-| `punctuationPattern` | `speech_punctuation_fix` or `proc_speech_punctuation_fix` |
-| `acceptedSet` | `combine_clauses_rewrite` |
-| `multiField` | `qg_subject_object_classify_table` |
-| `exact` | `qg_modal_verb_explain` |
-| `manualReviewOnly` | one selected manual-review template |
-
-For `manualReviewOnly`, the smoke should prove that the item does not grant mastery or reward progression.
-
-## 12. Workstream G — Selector and variant-quality checks
-
-P1 added generated variant signatures and selector freshness. P2 should not regress that work.
-
-Add or preserve checks that:
-
-- generated templates declare stable `generatorFamilyId` values;
-- generated variant signatures ignore answer order and hidden answer specs;
-- repeated QG P1 variants remain a strict failure;
-- legacy repeated generated variants remain visible in advisory output until fixed;
-- the selector does not repeatedly serve the same generated structure merely because surface words changed;
-- focus sessions still preserve question-type variety where possible.
-
-P2 should also increase audit sampling for generated templates. The current small seed sample is useful, but it is too shallow to prove broad generator health.
-
-Recommended P2 sampling:
-
-```text
-seeds: 1, 2, 3, 7, 11, 19, 29, 37
-```
-
-Do not make the sampling set so large that normal development becomes slow. Keep a fast default gate and allow a deeper optional audit command for release candidates.
-
-## 13. Workstream H — Reward and release-id alignment
-
-Check the reward path before shipping P2.
-
-Required checks:
-
-- `grammar.concept-secured` events carry the active `GRAMMAR_CONTENT_RELEASE_ID`;
-- reward mastery keys use the active content release ID, not a stale legacy default;
-- Star evidence events do not emit reward events under an older release ID unless that is explicitly intended and documented;
-- manual-review-only items cannot create secure concept evidence;
-- non-scored writing/transfer events remain outside the reward projection pipeline.
-
-If a legacy reward release constant is still used as a fallback, keep it only for backward compatibility and add tests proving active events prefer the event-level release ID.
-
-## 14. Test plan
-
-Add or update tests in these areas:
-
-```text
-tests/grammar-answer-spec.test.js
-tests/grammar-answer-spec-audit.test.js
-tests/grammar-question-generator-audit.test.js
-tests/grammar-functionality-completeness.test.js
-tests/grammar-production-smoke.test.js
-tests/grammar-selection.test.js
-tests/grammar-engine.test.js
-```
-
-Add a new P2-specific migration test file if the existing files become too crowded:
-
-```text
-tests/grammar-answer-spec-migration-p2.test.js
-```
-
-Suggested assertions:
-
-- every constructed-response template has explicit answer-spec handling;
-- every emitted answer spec validates over multiple seeds;
-- migrated templates preserve intended correct-answer behaviour;
-- common wrong answers are rejected;
-- manual-review-only items do not mutate mastery;
-- production read models do not expose hidden answers;
-- P2 baseline fixture matches the shipped denominator;
-- old P1 fixture remains readable and unchanged.
-
-## 15. Suggested verification commands
-
-Run the targeted gates first:
-
-```bash
-node scripts/audit-grammar-question-generator.mjs --json
-node --test tests/grammar-question-generator-audit.test.js
-node --test tests/grammar-answer-spec.test.js
-node --test tests/grammar-answer-spec-audit.test.js
-node --test tests/grammar-functionality-completeness.test.js
-node --test tests/grammar-production-smoke.test.js
-node --test tests/grammar-selection.test.js
-node --test tests/grammar-engine.test.js
-```
-
-After the P2 fixture is intentionally created or refreshed:
-
-```bash
-node scripts/audit-grammar-question-generator.mjs \
-  --write-fixture tests/fixtures/grammar-legacy-oracle/grammar-qg-p2-baseline.json
-```
-
-Before opening the PR:
-
-```bash
-npm test
-npm run check
-git diff --check
-```
-
-## 16. Acceptance criteria
-
-P2 is complete only when all of the following are true:
-
-- the Grammar content release ID has been bumped for the migration;
-- the shipped denominator remains 18 concepts and 57 templates unless a deliberate content change is documented;
-- all 20 constructed-response templates have explicit answer-spec handling;
-- `answerSpecTemplateCount` is 26 or higher, with the difference explained if higher;
-- `constructedResponseWithoutAnswerSpec` is empty;
-- no hidden answer data leaks into child-facing read models;
-- manual-review-only templates do not award mastery, Stars, or reward events;
-- the production smoke covers each answer-spec family;
-- the P2 fixture is separate from the P1 fixture;
-- full tests and static checks pass;
-- the PR description states whether marking behaviour changed for any template.
-
-## 17. Known risks
-
-### Risk: over-permissive punctuation marking
-
-A punctuation matcher that accepts too much will create false mastery.
-
-Mitigation: add negative tests for missing punctuation, wrong punctuation, and unrelated wording changes.
-
-### Risk: exact-string marking remains hidden inside migrated templates
-
-A template might technically emit `answerSpec` while still bypassing the shared marker.
-
-Mitigation: tests should assert that migrated templates mark through shared answer-spec code.
-
-### Risk: manual-review-only items become dead content
-
-If manual-review-only items never contribute to progress, learners may experience them as unrewarded work.
-
-Mitigation: position them as practice/writing items, or redesign the most important ones into constrained deterministic templates in a later phase.
-
-### Risk: release-id mismatch between content and rewards
-
-If concept evidence and reward events disagree on release ID, learners may see confusing replay, duplicate reward, or missing reward behaviour.
-
-Mitigation: test concept-secured and Star-evidence reward paths with the active P2 release ID.
-
-### Risk: P2 becomes content expansion by accident
-
-The team may be tempted to add more templates while touching content.
-
-Mitigation: keep P2 focused on marking migration. Defer broad expansion to P3/P4.
-
-## 18. Expected next phases after P2
-
-The recommended total Grammar QG programme is six phases:
-
-| Phase | Theme | Purpose |
-|---|---|---|
-| P1 | Generator foundation | Add first six deterministic QG templates, coverage audit, signatures, selector freshness, smoke safety. |
-| P2 | Declarative marking migration | Move constructed-response marking to explicit answer specs and harden release/read-model safety. |
-| P3 | Explanation coverage | Add explain templates for the remaining under-covered concepts so mastery is not mostly recognition/fix. |
-| P4 | Generator depth expansion | Increase high-quality deterministic variant depth, especially for broader transfer and mixed grammar use. |
-| P5 | Release automation and QA dashboard | Make audits, smoke tests, denominator diffs, and quality metrics part of the normal release gate. |
-| P6 | Learning calibration and telemetry | Use live evidence to tune mastery thresholds, scheduler balance, template retirement, and misconception repair. |
-
-After P2, the engine should be safe enough for more content expansion. P3 should then attack the biggest remaining learning gap: too few explanation templates across the Grammar subject.
+**Verification:**
+- All five normalised rewrites are explicit answer-spec templates.
+- Their migrated results preserve intended correct-answer behaviour and reject the documented wrong-target responses.
+
+---
+
+- U4. **Migrate Punctuation Pattern Fixes**
+
+**Goal:** Move the nine punctuation-surgery templates to explicit `punctuationPattern` specs with strict negative coverage.
+
+**Requirements:** R4, R5, R7, R11
+
+**Dependencies:** U2
+
+**Files:**
+- Modify: `worker/src/subjects/grammar/content.js`
+- Modify: `worker/src/subjects/grammar/answer-spec.js` if a required punctuation parameter was not already added in U2
+- Modify: `tests/grammar-answer-spec.test.js`
+- Modify: `tests/grammar-engine.test.js`
+- Create or modify: `tests/grammar-answer-spec-migration-p2.test.js`
+
+**Approach:**
+- Migrate `fix_fronted_adverbial`, `parenthesis_fix_sentence`, `speech_punctuation_fix`, `proc_fronted_adverbial_fix`, `proc_colon_list_fix`, `proc_dash_boundary_fix`, `proc_speech_punctuation_fix`, `proc3_parenthesis_commas_fix`, and `proc3_hyphen_fix_meaning`.
+- Keep `punctuationPattern` literal by default. Add opt-in tolerance only for explicitly intended variants, and keep every parameter template-local.
+- Treat quote style and dash/hyphen-minus tolerance as separate questions. Accepting one must not accidentally accept missing quotes, missing dashes, or comma splices.
+- Ensure punctuation-only partial-credit paths do not accidentally turn into full correctness unless the spec says so.
+
+**Patterns to follow:**
+- `markPunctuationPattern` in `worker/src/subjects/grammar/answer-spec.js`.
+- Punctuation rows and near-miss examples in `docs/plans/james/grammar/grammar-answer-spec-audit.md`.
+- Existing read-model forbidden-key scan from `tests/grammar-production-smoke.test.js`.
+
+**Test scenarios:**
+- Happy path: each migrated template accepts the expected punctuation-correct answer for at least one stable seed.
+- Happy path: explicitly allowed quote or dash variants are accepted only on templates that opt in.
+- Edge case: missing target punctuation rejects for all nine templates.
+- Edge case: wrong punctuation type rejects, such as commas instead of brackets, semicolon instead of colon, comma splice instead of dash, or missing quotation marks.
+- Edge case: unrelated wording changes reject even if punctuation is close.
+- Error path: a spec with punctuation tolerance accidentally enabled globally is caught by a template that should reject that variant.
+- Integration: mini-test review and worked-solution read models do not leak golden punctuation strings before marking.
+
+**Verification:**
+- The punctuation migration is strict enough to avoid false mastery from formatting-adjacent wrong answers.
+- Each punctuation template has both positive and wrong-punctuation regression coverage.
+
+---
+
+- U5. **Migrate Accepted-Set Rewrites**
+
+**Goal:** Move the two finite clause rewrite templates to explicit `acceptedSet` specs with small, teacher-reviewable alternative lists.
+
+**Requirements:** R4, R5, R8, R11
+
+**Dependencies:** U2
+
+**Files:**
+- Modify: `worker/src/subjects/grammar/content.js`
+- Modify: `tests/grammar-answer-spec.test.js`
+- Modify: `tests/grammar-engine.test.js`
+- Create or modify: `tests/grammar-answer-spec-migration-p2.test.js`
+
+**Approach:**
+- Migrate `combine_clauses_rewrite` and `proc3_clause_join_rewrite`.
+- Enumerate accepted alternatives explicitly per generated item; keep the list small enough for teacher review.
+- Preserve partial-credit semantics only if they are intentionally part of the existing learning contract; otherwise record any narrowing as a release-id-scoped behaviour change.
+- Reject common wrong joins, comma splices, ellipted-subject rewrites, coordination when subordination is targeted, and truncated responses.
+
+**Patterns to follow:**
+- Existing `acceptedSet` marker tests in `tests/grammar-answer-spec.test.js`.
+- Clause rows in `docs/plans/james/grammar/grammar-answer-spec-audit.md`.
+- Existing `markStringAnswer` adapter behaviour, used only as a parity reference during migration.
+
+**Test scenarios:**
+- Happy path: every accepted alternative for the representative seed marks correct and returns full marks.
+- Happy path: answer ordering alternatives are accepted only when explicitly listed.
+- Edge case: comma-splice answer rejects or receives only the intended non-correct partial result.
+- Edge case: coordination answer rejects when the prompt targets subordination.
+- Edge case: missing subject, missing comma/full stop, or truncated sentence does not mark correct.
+- Integration: constructed-response item serialisation does not expose hidden accepted alternatives before marking.
+
+**Verification:**
+- Both finite rewrite templates no longer depend on inline accepted arrays.
+- Accepted alternatives are visible to reviewers in code/tests but not to learners before marking.
+
+---
+
+- U6. **Manual-Review-Only Safety Path**
+
+**Goal:** Convert genuinely open creative constructed-response templates into safe practice items that collect responses without granting auto-scored learning evidence.
+
+**Requirements:** R4, R5, R9, R10, R11, R14
+
+**Dependencies:** U2
+
+**Files:**
+- Modify: `worker/src/subjects/grammar/content.js`
+- Modify: `worker/src/subjects/grammar/engine.js`
+- Modify: `worker/src/subjects/grammar/read-models.js`
+- Modify: `worker/src/subjects/grammar/commands.js` if Star-evidence suppression needs command-layer reinforcement
+- Modify: `src/subjects/grammar/session-ui.js`
+- Modify: `src/subjects/grammar/components/GrammarSessionScene.jsx`
+- Modify: `tests/grammar-engine.test.js`
+- Modify: `tests/grammar-rewards.test.js`
+- Modify: `tests/grammar-star-persistence.test.js`
+- Modify: `tests/react-grammar-surface.test.js`
+- Create or modify: `tests/grammar-answer-spec-migration-p2.test.js`
+
+**Approach:**
+- Default these templates to `manualReviewOnly`: `build_noun_phrase`, `standard_fix_sentence`, `proc2_fronted_adverbial_build`, and `proc3_noun_phrase_build`.
+- Make the engine distinguish manual-review-only results from ordinary wrong answers. The response may be saved and shown back after submission, but it must not update concept mastery, template mastery, question-type mastery, retry queues, misconception counts, `grammar.concept-secured`, or `grammar.star-evidence-updated`.
+- Thread a redacted non-scored/manual-review marker to the client so `grammarFeedbackTone` and the session feedback panel can render the outcome as neutral saved-for-review practice instead of an incorrect answer.
+- Keep the learner-facing communication clear that the item is writing/practice, not auto-marked mastery. Product copy remains UK English.
+- If implementation redesigns any of the four as constrained response, document why it is deterministic and move that template into the relevant scored family with full tests.
+
+**Patterns to follow:**
+- `manualReviewOnly` result shape in `worker/src/subjects/grammar/answer-spec.js`.
+- Non-scored Grammar transfer and AI enrichment boundaries from existing Grammar tests.
+- `src/subjects/grammar/event-hooks.js` reward subscriber contract: only committed scoring evidence should change reward state.
+
+**Test scenarios:**
+- Happy path: manual-review-only item accepts a typed response, returns saved-for-review feedback, and can show the learner's response after submission.
+- Happy path: manual-review-only feedback renders with neutral saved-for-review tone in the React Grammar session surface, not as "wrong" feedback.
+- Happy path: no concept mastery node, template mastery node, question-type mastery node, retry queue, or misconception count changes after a manual-review-only response.
+- Happy path: no `grammar.concept-secured`, no `grammar.star-evidence-updated`, and no `reward.monster` event is emitted.
+- Edge case: an empty response still follows existing answer-required behaviour and does not create a review record.
+- Edge case: repeated manual-review-only submissions do not create mastery progress by accumulation.
+- Error path: malformed manual-review-only spec fails validation rather than entering auto-marking.
+- Integration: command read model remains redacted while still exposing only the post-submit safe response/feedback needed by the learner.
+
+**Verification:**
+- Open creative templates are no longer false-negative auto-marked as mastery failures or false-positive auto-marked as wins.
+- Manual-review-only practice cannot affect Stars, secure concepts, or reward progression.
+
+---
+
+- U7. **Read-Model Redaction and Production Smoke Family Coverage**
+
+**Goal:** Prove the migrated answer specs remain Worker-private and the production smoke covers every answer-spec family without hidden-answer shortcuts.
+
+**Requirements:** R11, R12
+
+**Dependencies:** U3, U4, U5, U6
+
+**Files:**
+- Modify: `tests/helpers/forbidden-keys.mjs`
+- Modify: `worker/src/subjects/grammar/read-models.js`
+- Modify: `scripts/grammar-production-smoke.mjs`
+- Modify: `tests/grammar-production-smoke.test.js`
+- Modify: `tests/worker-grammar-subject-runtime.test.js`
+- Modify: `docs/full-lockdown-runtime.md`
+
+**Approach:**
+- Keep the forbidden-key oracle as the single shared list for Grammar read-model scans. Add any newly discovered server-only field there first.
+- Extend the production smoke template matrix to include one representative each for `normalisedText`, `punctuationPattern`, `acceptedSet`, `multiField`, `exact`, and `manualReviewOnly`.
+- For selected-response probes, keep the existing visible-option derivation.
+- For constructed-response probes, derive responses from production-visible prompt/input data or a fixed smoke fixture that mirrors visible prompt content. Do not read hidden `answerSpec`, accepted arrays, or local-only question internals to answer production.
+- For manual-review-only, smoke should assert saved-for-review behaviour and no reward/mastery progression rather than correctness.
+
+**Patterns to follow:**
+- `scripts/grammar-production-smoke.mjs` `correctResponseFor` / `incorrectResponseFor` visible-option contract.
+- `tests/grammar-production-smoke.test.js` forbidden-key phase scans.
+- `tests/helpers/forbidden-keys.mjs` redaction oracle.
+
+**Test scenarios:**
+- Happy path: production smoke selected-response probe answers from visible options and still rejects option-set mismatch.
+- Happy path: constructed-response smoke probes submit visible deterministic answers for normalisedText, punctuationPattern, and acceptedSet families.
+- Happy path: manual-review-only smoke proves saved response and no auto-score.
+- Edge case: start, feedback, summary, mini-test review, support, AI-enrichment, adult/admin diagnostics, and recent attempts are scanned for `answerSpec`, golden answers, near misses, accepted alternatives, generator family ids, variant signatures, and hidden correctness flags.
+- Error path: adding a hidden field to any scanned read-model phase fails with the field path named.
+- Integration: smoke summary reports which answer-spec families were covered so release operators can see family parity.
+
+**Verification:**
+- Production smoke remains an API-contract test rather than a local hidden-answer oracle.
+- All migrated answer-spec families are covered by at least one production-visible flow.
+
+---
+
+- U8. **Generated Variant and Selector Governance Preservation**
+
+**Goal:** Ensure P2's marking migration does not regress QG P1 variant signatures, generated family ids, selector freshness, or strict/advisory duplicate handling.
+
+**Requirements:** R1, R13
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `scripts/audit-grammar-question-generator.mjs`
+- Modify: `tests/grammar-question-generator-audit.test.js`
+- Modify: `tests/grammar-selection.test.js`
+- Modify: `tests/grammar-engine.test.js`
+
+**Approach:**
+- Increase the audit seed sample for generated templates to the P2 release sample set while preserving a fast default. If a deeper release-candidate mode is added, keep it opt-in.
+- Preserve the answer-safe signature rule: hidden answer specs, answer ordering, and hidden alternatives must not change visible variant signatures.
+- Keep strict repeated-variant failure for QG P1 templates and advisory reporting for older legacy generated families unless P2 intentionally migrates a legacy family.
+- Ensure selector freshness still penalises repeated generated structures and planned mini-pack variants.
+
+**Patterns to follow:**
+- `grammarQuestionVariantSignature` and `grammarTemplateGeneratorFamilyId` in `worker/src/subjects/grammar/content.js`.
+- Existing QG P1 variant tests in `tests/grammar-question-generator-audit.test.js`.
+- Existing selector freshness tests in `tests/grammar-selection.test.js`.
+
+**Test scenarios:**
+- Happy path: QG P1 generated templates have stable generator family ids over the expanded seed sample.
+- Happy path: changing only option order or hidden answer-spec data does not change the visible variant signature.
+- Edge case: repeated strict QG P1 variants fail the audit with template id and seeds named.
+- Edge case: legacy repeated generated variants remain visible in advisory output without blocking unrelated P2 migration.
+- Integration: focus sessions preserve question-type variety where possible and do not repeatedly serve the same generated structure merely because surface words changed.
+
+**Verification:**
+- P2 increases marking governance without weakening QG P1's generated-variant guarantees.
+
+---
+
+- U9. **Reward and Release-Id Alignment**
+
+**Goal:** Prove that P2 content-release evidence, secure concept events, Star evidence, and reward mastery keys use the active Grammar release id and ignore manual-review-only practice.
+
+**Requirements:** R2, R10, R14
+
+**Dependencies:** U6
+
+**Files:**
+- Modify: `worker/src/subjects/grammar/engine.js`
+- Modify: `worker/src/subjects/grammar/commands.js`
+- Modify: `src/subjects/grammar/event-hooks.js`
+- Modify: `src/platform/game/mastery/grammar.js`
+- Modify: `tests/grammar-rewards.test.js`
+- Modify: `tests/grammar-star-persistence.test.js`
+- Modify: `tests/grammar-star-events.test.js`
+- Modify: `tests/worker-grammar-subject-runtime.test.js`
+
+**Approach:**
+- Audit the path from `applyGrammarAttemptToState` through `grammar.concept-secured`, `grammar.star-evidence-updated`, `rewardEventsFromGrammarEvents`, `recordGrammarConceptMastery`, and `updateGrammarStarHighWater`.
+- Ensure active P2 events carry `contentReleaseId` and `masteryKey` based on the active Grammar content release id.
+- Keep backward-compatible reward release fallbacks only for older event shapes; new active events should not fall back to a stale constant.
+- Assert manual-review-only attempts emit no secure concept event, no Star-evidence event, no reward event, and no mastery key.
+
+**Patterns to follow:**
+- `worker/src/subjects/grammar/engine.js` active release check and existing `masteryKey` shape.
+- `src/subjects/grammar/event-hooks.js` existing event-level release-id preference for concept-secured.
+- Grammar Phase 6 Star persistence tests around targeted high-water updates.
+
+**Test scenarios:**
+- Happy path: a scored P2 correct attempt emits `grammar.answer-submitted` and later concept-secured evidence with active P2 `contentReleaseId`.
+- Happy path: `grammar.concept-secured` produces a mastery key scoped to the active P2 release id.
+- Happy path: Star-evidence high-water events do not downgrade or duplicate reward state when release ids move from P1 to P2.
+- Edge case: legacy P1 reward state remains readable but does not satisfy a new active P2 mastery key.
+- Edge case: manual-review-only response emits no secure concept, Star evidence, mastery key, or reward event.
+- Error path: event with missing or stale release id uses fallback only in backward-compatible tests, never in the active P2 scored path.
+- Integration: production-shaped command response includes reward projections that agree with the active P2 content release id.
+
+**Verification:**
+- P2 release identity is consistent across content, attempts, secure concept events, Star evidence, and reward projection.
+- Manual-review-only content remains outside reward progression.
+
+---
+
+- U10. **Release Documentation and Completion Evidence**
+
+**Goal:** Record what P2 changed, what remained intentionally deferred, and how future phases should build on the migration.
+
+**Requirements:** R1, R2, R3, R11, R12, R13, R14
+
+**Dependencies:** U7, U8, U9
+
+**Files:**
+- Modify: `docs/plans/james/grammar/questions-generator/grammar-qg-p2.md`
+- Create: `docs/plans/james/grammar/questions-generator/grammar-qg-p2-completion-report.md`
+- Create: `tests/fixtures/grammar-legacy-oracle/grammar-qg-p2-baseline.json`
+- Create: `tests/fixtures/grammar-functionality-completeness/grammar-qg-p2-baseline.json`
+- Modify: `docs/plans/james/grammar/grammar-answer-spec-audit.md`
+- Modify: `docs/full-lockdown-runtime.md`
+
+**Approach:**
+- Record final counts, P2 release id, migrated template ids by answer-spec family, manual-review-only decisions, fixture paths, smoke family coverage, and residual risks.
+- Generate the final QG P2 oracle and functionality-completeness fixtures only after U3-U9 have established the migrated runtime and release-id behaviour.
+- Update `grammar-answer-spec-audit.md` so inventory status matches landed reality rather than planned classification.
+- Preserve the next-phase roadmap: P3 explanation coverage, later generated depth, and release-gate automation.
+- Make clear that P2 is not a broad content expansion and does not add runtime AI or new reward mechanics.
+
+**Patterns to follow:**
+- `docs/plans/james/grammar/questions-generator/grammar-qg-p1-final-completion-report-2026-04-28.md`.
+- Existing Grammar phase completion reports under `docs/plans/james/grammar/`.
+
+**Test scenarios:**
+- Test expectation: none for the prose completion report itself; machine-checked parts are covered by U1, U7, U8, and U9.
+
+**Verification:**
+- A future implementer can see the final P2 denominator, release id, migrated templates, proof points, and follow-up boundaries without rediscovering them from git history.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** `content.js` template metadata and hidden `answerSpec` feed `answer-spec.js`, `engine.js`, `commands.js`, `read-models.js`, QG audit fixtures, production smoke, and reward projection.
+- **Error propagation:** invalid specs should fail in audit/unit tests; stale content release attempts should fail closed in the Worker; hidden-key leaks should fail redaction scans with exact paths.
+- **State lifecycle risks:** content release id changes alter future evidence identity. P1 and P2 fixtures must both remain readable, while active scored attempts use only the P2 release id.
+- **API surface parity:** start, feedback, summary, mini-test review, support guidance, AI enrichment, recent attempts, adult/admin diagnostics, and production smoke must share the same redaction boundary.
+- **Reward lifecycle:** manual-review-only responses must not be treated as wrong mastery evidence, secure concept evidence, Star evidence, or reward progress.
+- **Integration coverage:** marker unit tests prove family semantics; Worker tests prove session/mutation behaviour; reward tests prove event boundaries; smoke tests prove deployed API contracts.
+- **Unchanged invariants:** deterministic score-bearing Grammar, no runtime AI marking, no hidden answers in read models, QG P1 variant signature safety, English Spelling parity, and package-script deployment practice remain unchanged.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Punctuation matcher becomes too permissive and creates false mastery. | Keep tolerance opt-in per template, add wrong-punctuation and unrelated-wording tests for every punctuation template. |
+| A template emits `answerSpec` but still bypasses shared marking. | Add migration tests that exercise `evaluate` through the declared spec and validate emitted specs over multiple seeds. |
+| Manual-review-only responses still mutate mastery as wrong answers. | Add engine and reward tests proving no mastery node, retry queue, secure event, Star event, or reward event changes. |
+| Production smoke false-passes by using hidden local answer data. | Derive probe responses from production-visible options/prompts and keep redaction scans across all phases. |
+| Release-id mismatch creates duplicate or missing reward progress. | Test active P2 content release id through attempts, concept-secured events, Star evidence, and reward mastery keys. |
+| P2 grows into content expansion by accident. | Scope boundaries explicitly defer explanation coverage, generated depth, constrained redesigns, and admin tooling. |
+| Fixture churn hides regressions. | Keep QG P1 fixtures immutable, add separate P2 fixtures, and require counts to reconcile across audit, runtime metadata, and completeness fixtures. |
+
+---
+
+## Documentation / Operational Notes
+
+- Before deployment, implementation should follow repo verification expectations from `AGENTS.md`: full test suite and static/build checks through package scripts.
+- After deployment, run the strengthened Grammar production smoke against `https://ks2.eugnel.uk` with a logged-in browser session because the change affects user-facing Grammar flows and read-model contracts.
+- Do not introduce raw Wrangler deploy or remote D1 commands; normal operations should keep using the repo package scripts that route through `scripts/wrangler-oauth.mjs`.
+- PR descriptions for P2 should explicitly state whether marking behaviour changed for each migrated family and how manual-review-only responses are treated.
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/plans/james/grammar/questions-generator/grammar-qg-p1-final-completion-report-2026-04-28.md](docs/plans/james/grammar/questions-generator/grammar-qg-p1-final-completion-report-2026-04-28.md)
+- Source plan: `docs/plans/james/grammar/questions-generator/grammar-qg-p1.md`
+- Related audit: `docs/plans/james/grammar/grammar-answer-spec-audit.md`
+- Related completion report: `docs/plans/james/grammar/questions-generator/grammar-qg-p1-completion-report.md`
+- Related code: `worker/src/subjects/grammar/content.js`
+- Related code: `worker/src/subjects/grammar/answer-spec.js`
+- Related code: `scripts/audit-grammar-question-generator.mjs`
+- Related code: `scripts/grammar-production-smoke.mjs`
+- Related code: `worker/src/subjects/grammar/engine.js`
+- Related code: `worker/src/subjects/grammar/commands.js`
+- Related code: `worker/src/subjects/grammar/read-models.js`
+- Related code: `src/subjects/grammar/event-hooks.js`
+- Related code: `src/platform/game/mastery/grammar.js`
+- Related tests: `tests/grammar-answer-spec.test.js`
+- Related tests: `tests/grammar-answer-spec-audit.test.js`
+- Related tests: `tests/grammar-question-generator-audit.test.js`
+- Related tests: `tests/grammar-engine.test.js`
+- Related tests: `tests/grammar-production-smoke.test.js`
+- Related tests: `tests/grammar-rewards.test.js`
+- Institutional learning: `docs/solutions/architecture-patterns/grammar-p6-star-derivation-trust-and-server-owned-persistence-2026-04-27.md`
+- Institutional learning: `docs/solutions/architecture-patterns/grammar-p7-quality-trust-consolidation-and-autonomous-sdlc-2026-04-27.md`

--- a/scripts/audit-grammar-question-generator.mjs
+++ b/scripts/audit-grammar-question-generator.mjs
@@ -63,7 +63,7 @@ function buildSignatureAudit(seeds) {
   for (const template of GRAMMAR_TEMPLATE_METADATA) {
     if (!template.generative) continue;
     if (!template.generatorFamilyId) missing.push(template.id);
-    const strictVariantTemplate = Boolean(template.requiresAnswerSpec || (template.tags || []).includes('qg-p1'));
+    const strictVariantTemplate = (template.tags || []).includes('qg-p1');
     for (const seed of seeds) {
       const question = createGrammarQuestion({ templateId: template.id, seed });
       const signature = grammarQuestionVariantSignature(question);
@@ -105,8 +105,14 @@ function buildSignatureAudit(seeds) {
 
 function buildAnswerSpecAudit(seeds) {
   const required = GRAMMAR_TEMPLATE_METADATA.filter((template) => template.requiresAnswerSpec);
+  const constructed = GRAMMAR_TEMPLATE_METADATA.filter((template) => !template.isSelectedResponse);
   const missing = [];
   const invalid = [];
+  const kindCounts = {};
+  for (const template of required) {
+    const kind = template.answerSpecKind || 'missing';
+    kindCounts[kind] = (kindCounts[kind] || 0) + 1;
+  }
 
   for (const template of required) {
     for (const seed of seeds) {
@@ -137,6 +143,12 @@ function buildAnswerSpecAudit(seeds) {
 
   return {
     answerSpecTemplateCount: required.length,
+    answerSpecKindCounts: Object.fromEntries(Object.entries(kindCounts).sort(([a], [b]) => a.localeCompare(b))),
+    constructedResponseTemplateCount: constructed.length,
+    constructedResponseAnswerSpecTemplateCount: constructed.filter((template) => template.requiresAnswerSpec).length,
+    legacyAdapterTemplateCount: constructed.filter((template) => !template.requiresAnswerSpec).length,
+    manualReviewOnlyTemplateCount: required.filter((template) => template.answerSpecKind === 'manualReviewOnly').length,
+    p2MigrationComplete: constructed.every((template) => template.requiresAnswerSpec),
     templatesMissingAnswerSpecs: uniqueSorted(missing),
     invalidAnswerSpecs: invalid,
   };
@@ -181,6 +193,9 @@ function formatSummary(audit) {
     `Repeated strict P1 variants within a template: ${audit.repeatedGeneratedVariants.length}`,
     `Legacy/advisory repeated variants within a template: ${audit.legacyRepeatedGeneratedVariants.length}`,
     `Answer-spec templates: ${audit.answerSpecTemplateCount}`,
+    `Constructed-response answer-spec templates: ${audit.constructedResponseAnswerSpecTemplateCount}/${audit.constructedResponseTemplateCount}`,
+    `Legacy adapter templates: ${audit.legacyAdapterTemplateCount}`,
+    `Manual-review-only templates: ${audit.manualReviewOnlyTemplateCount}`,
   ];
   if (audit.duplicateTemplateIds.length) lines.push(`Duplicate template ids: ${audit.duplicateTemplateIds.join(', ')}`);
   if (audit.missingGeneratorMetadata.length) lines.push(`Missing generator metadata: ${audit.missingGeneratorMetadata.join(', ')}`);

--- a/scripts/grammar-production-smoke.mjs
+++ b/scripts/grammar-production-smoke.mjs
@@ -29,6 +29,48 @@ const GRAMMAR_MINI_TEST_ITEM = Object.freeze({
   seed: 11,
 });
 
+export const GRAMMAR_ANSWER_SPEC_FAMILY_SMOKE_ITEMS = Object.freeze([
+  Object.freeze({
+    family: 'exact',
+    templateId: 'qg_modal_verb_explain',
+    seed: 7,
+  }),
+  Object.freeze({
+    family: 'multiField',
+    templateId: 'qg_subject_object_classify_table',
+    seed: 7,
+    response: Object.freeze({ row0: 'subject', row1: 'object' }),
+  }),
+  Object.freeze({
+    family: 'normalisedText',
+    templateId: 'tense_rewrite',
+    seed: 0,
+    response: Object.freeze({ answer: 'The dog was chasing the cat.' }),
+  }),
+  Object.freeze({
+    family: 'punctuationPattern',
+    templateId: 'fix_fronted_adverbial',
+    seed: 0,
+    response: Object.freeze({ answer: 'Before sunrise, the campers packed their bags.' }),
+  }),
+  Object.freeze({
+    family: 'acceptedSet',
+    templateId: 'combine_clauses_rewrite',
+    seed: 0,
+    response: Object.freeze({ answer: 'Although Mia was tired, she finished the race.' }),
+  }),
+  Object.freeze({
+    family: 'manualReviewOnly',
+    templateId: 'build_noun_phrase',
+    seed: 0,
+    response: Object.freeze({
+      part1: 'The tall',
+      part2: 'captain',
+      part3: 'with curly hair',
+    }),
+  }),
+]);
+
 // Sets are built at module load from the shared Array exports so the single
 // source of truth in tests/helpers/forbidden-keys.mjs cannot drift from this
 // smoke test's checks.
@@ -91,6 +133,15 @@ export function incorrectResponseFor(readItem) {
   }
 
   throw new Error(`Grammar production options did not contain an incorrect answer for ${readItem?.templateId}.`);
+}
+
+export function visibleResponseForAnswerSpecFamily(readItem) {
+  const fixture = GRAMMAR_ANSWER_SPEC_FAMILY_SMOKE_ITEMS.find((item) => (
+    item.templateId === readItem?.templateId && Number(item.seed) === Number(readItem?.seed)
+  ));
+  if (!fixture) return correctResponseFor(readItem);
+  if (!fixture.response) return correctResponseFor(readItem);
+  return { ...fixture.response };
 }
 
 async function smokeGrammarNormalRound({ origin, cookie, learnerId, revision }) {
@@ -320,6 +371,68 @@ async function smokeGrammarRepairAndAi({ origin, cookie, learnerId, revision }) 
   };
 }
 
+async function smokeGrammarAnswerSpecFamilies({ origin, cookie, learnerId, revision }) {
+  const covered = [];
+  for (const fixture of GRAMMAR_ANSWER_SPEC_FAMILY_SMOKE_ITEMS) {
+    let step = await subjectCommand({
+      origin,
+      cookie,
+      subjectId: 'grammar',
+      learnerId,
+      revision,
+      command: 'start-session',
+      payload: {
+        mode: 'smart',
+        roundLength: 1,
+        templateId: fixture.templateId,
+        seed: fixture.seed,
+      },
+    });
+    revision = step.revision;
+    const startModel = step.payload.subjectReadModel;
+    assert.equal(startModel?.phase, 'session', `Grammar ${fixture.family} smoke did not start in session phase.`);
+    assert.equal(startModel?.session?.currentItem?.templateId, fixture.templateId);
+    assertNoForbiddenGrammarReadModelKeys(startModel, `grammar.${fixture.family}.startModel`);
+
+    const response = visibleResponseForAnswerSpecFamily(startModel.session.currentItem);
+    step = await subjectCommand({
+      origin,
+      cookie,
+      subjectId: 'grammar',
+      learnerId,
+      revision,
+      command: 'submit-answer',
+      payload: { response },
+    });
+    revision = step.revision;
+    const feedbackModel = step.payload.subjectReadModel;
+    assert.equal(feedbackModel?.phase, 'feedback', `Grammar ${fixture.family} submit did not return feedback.`);
+    if (fixture.family === 'manualReviewOnly') {
+      assert.equal(feedbackModel?.feedback?.result?.correct, false, 'Manual-review smoke must not auto-correct.');
+      assert.equal(feedbackModel?.feedback?.result?.nonScored, true, 'Manual-review smoke must be non-scored.');
+      assert.equal(feedbackModel?.feedback?.result?.manualReviewOnly, true, 'Manual-review smoke must carry manual-review marker.');
+    } else {
+      assert.equal(feedbackModel?.feedback?.result?.correct, true, `Grammar ${fixture.family} smoke answer was not accepted.`);
+    }
+    assertNoForbiddenGrammarReadModelKeys(feedbackModel, `grammar.${fixture.family}.feedbackModel`);
+
+    step = await subjectCommand({
+      origin,
+      cookie,
+      subjectId: 'grammar',
+      learnerId,
+      revision,
+      command: 'continue-session',
+    });
+    revision = step.revision;
+    assert.equal(step.payload.subjectReadModel?.phase, 'summary', `Grammar ${fixture.family} smoke did not reach summary.`);
+    assertNoForbiddenGrammarReadModelKeys(step.payload.subjectReadModel, `grammar.${fixture.family}.summaryModel`);
+    covered.push(fixture.family);
+  }
+
+  return { revision, covered };
+}
+
 async function smokeGrammar({ origin, cookie, learnerId, revision }) {
   const normal = await smokeGrammarNormalRound({ origin, cookie, learnerId, revision });
   const miniTest = await smokeGrammarMiniTest({
@@ -334,12 +447,19 @@ async function smokeGrammar({ origin, cookie, learnerId, revision }) {
     learnerId,
     revision: miniTest.revision,
   });
+  const answerSpecFamilies = await smokeGrammarAnswerSpecFamilies({
+    origin,
+    cookie,
+    learnerId,
+    revision: repairAi.revision,
+  });
 
   return {
-    revision: repairAi.revision,
+    revision: answerSpecFamilies.revision,
     normal,
     miniTest,
     repairAi,
+    answerSpecFamilies,
   };
 }
 
@@ -400,6 +520,7 @@ async function main() {
       miniTestReviewSize: grammar.miniTest.reviewSize,
       repairSupportKind: grammar.repairAi.supportKind,
       aiKind: grammar.repairAi.aiKind,
+      answerSpecFamilies: grammar.answerSpecFamilies.covered,
     },
     spelling: {
       progressTotal: spelling.progressTotal,

--- a/src/subjects/grammar/components/GrammarSessionScene.jsx
+++ b/src/subjects/grammar/components/GrammarSessionScene.jsx
@@ -10,6 +10,7 @@ import {
   grammarSessionSubmitLabel,
   grammarSessionProgressLabel,
   grammarSessionInfoChips,
+  grammarFeedbackTone,
 } from '../session-ui.js';
 import { translateGrammarSessionError } from '../module.js';
 
@@ -229,6 +230,8 @@ function GrammarInput({ inputSpec, required = true, response = {}, describedBy =
 function FeedbackPanel({ feedback }) {
   if (!feedback?.result) return null;
   const result = feedback.result;
+  const tone = grammarFeedbackTone(result);
+  const toneClass = tone === 'good' ? 'good' : tone === 'bad' ? 'warn' : 'neutral';
   // SH2-U7 review follow-up (FIX-3): `data-grammar-session-feedback-live`
   // mirrors Punctuation's `data-punctuation-session-feedback-live` anchor
   // so agent-native / a11y scenes can query the live region deterministically
@@ -236,12 +239,12 @@ function FeedbackPanel({ feedback }) {
   // surface uses for many other panels).
   return (
     <div
-      className={`feedback ${result.correct ? 'good' : 'warn'}`}
+      className={`feedback ${toneClass}`}
       role="status"
       aria-live="polite"
       data-grammar-session-feedback-live
     >
-      <strong>{result.feedbackShort || (result.correct ? 'Correct.' : 'Not quite.')}</strong>
+      <strong>{result.feedbackShort || (tone === 'good' ? 'Correct.' : tone === 'bad' ? 'Not quite.' : 'Saved for review')}</strong>
       <div>{result.feedbackLong || result.minimalHint || ''}</div>
       {result.answerText ? <div className="small muted">Answer: {result.answerText}</div> : null}
     </div>
@@ -448,9 +451,9 @@ function RepairActions({ isMiniTest, isFeedback, help, feedback, pending, runtim
   // answer. A correct answer funnels the learner to the single `Next question`
   // primary action — no retry / worked solution / similar problem clutter.
   if (isFeedback) {
+    const tone = grammarFeedbackTone(feedback?.result);
     if (!help?.showRepairActions) return null;
-    const isCorrect = Boolean(feedback?.result?.correct);
-    if (isCorrect) return null;
+    if (tone !== 'bad') return null;
     return (
       <div className="grammar-repair-actions" aria-label="Grammar repair actions">
         <button
@@ -648,7 +651,7 @@ export function GrammarSessionScene({ grammar, actions, runtimeReadOnly }) {
         {item.checkLine ? <p className="grammar-check-line">{item.checkLine}</p> : null}
         <ReadAloudControls grammar={grammar} />
         {!isMiniTest ? <GuidancePanel support={session.supportGuidance} /> : null}
-        {help.showAiActions && !(isFeedback && grammar.feedback?.result?.correct === true) ? (
+        {help.showAiActions && !(isFeedback && grammarFeedbackTone(grammar.feedback?.result) !== 'bad') ? (
           <AiEnrichmentActions
             isMiniTest={isMiniTest}
             isFeedback={isFeedback}

--- a/src/subjects/grammar/components/grammar-view-model.js
+++ b/src/subjects/grammar/components/grammar-view-model.js
@@ -803,13 +803,20 @@ export function buildGrammarMonsterStripModel(rewardState, masteryConceptNodes, 
 export function grammarSummaryCards(summary, rewardState, masteryConceptNodes = null, recentAttempts = null) {
   const safeSummary = summary && typeof summary === 'object' && !Array.isArray(summary) ? summary : {};
   const answered = safeNumber(safeSummary.answered, 0);
+  const nonScoredAnswered = safeNumber(safeSummary.nonScoredAnswered, 0);
+  const scoredAnswered = Object.prototype.hasOwnProperty.call(safeSummary, 'scoredAnswered')
+    ? safeNumber(safeSummary.scoredAnswered, 0)
+    : Math.max(0, answered - nonScoredAnswered);
   const correct = safeNumber(safeSummary.correct, 0);
   const troubleSpotsFound = safeNumber(safeSummary.troubleSpotsFound ?? safeSummary.weakConceptsSurfaced, 0);
   const newSecure = safeNumber(safeSummary.conceptsNewlySecured ?? safeSummary.newSecure, 0);
+  const correctDetail = scoredAnswered
+    ? `${Math.round((correct / scoredAnswered) * 100)}% accuracy`
+    : (nonScoredAnswered ? 'Saved for review' : 'No answers yet');
 
   return Object.freeze([
     Object.freeze({ id: 'answered', label: 'Answered', value: answered, detail: 'Questions this round' }),
-    Object.freeze({ id: 'correct', label: 'Correct', value: correct, detail: answered ? `${Math.round((correct / answered) * 100)}% accuracy` : 'No answers yet' }),
+    Object.freeze({ id: 'correct', label: 'Correct', value: correct, detail: correctDetail }),
     Object.freeze({ id: 'trouble', label: 'Trouble spots found', value: troubleSpotsFound, detail: 'We will come back to these' }),
     Object.freeze({ id: 'new-secure', label: 'New secure', value: newSecure, detail: 'Concepts you just locked in' }),
     Object.freeze({

--- a/src/subjects/grammar/read-model.js
+++ b/src/subjects/grammar/read-model.js
@@ -101,10 +101,19 @@ function recentAttemptsWindow(recentAttempts) {
     : [];
 }
 
+function isScoredAttempt(attempt) {
+  const result = isPlainObject(attempt?.result) ? attempt.result : {};
+  return attempt?.nonScored !== true
+    && attempt?.manualReviewOnly !== true
+    && result.nonScored !== true
+    && result.manualReviewOnly !== true;
+}
+
 function recentMissCountForConceptId(recentAttempts, conceptId) {
   if (!conceptId) return 0;
   let count = 0;
   for (const attempt of recentAttemptsWindow(recentAttempts)) {
+    if (!isScoredAttempt(attempt)) continue;
     const conceptIds = Array.isArray(attempt?.conceptIds) ? attempt.conceptIds : [];
     const result = isPlainObject(attempt?.result) ? attempt.result : {};
     if (conceptIds.includes(conceptId) && result.correct === false) count += 1;
@@ -116,6 +125,7 @@ function distinctTemplatesForConceptId(recentAttempts, conceptId) {
   if (!conceptId) return 0;
   const seen = new Set();
   for (const attempt of recentAttemptsWindow(recentAttempts)) {
+    if (!isScoredAttempt(attempt)) continue;
     const conceptIds = Array.isArray(attempt?.conceptIds) ? attempt.conceptIds : [];
     if (conceptIds.includes(conceptId) && typeof attempt?.templateId === 'string' && attempt.templateId) {
       seen.add(attempt.templateId);
@@ -435,6 +445,11 @@ function recentGrammarSessions(practiceSessions = []) {
     .map((record) => {
       const answered = Number(record?.summary?.answered) || 0;
       const correct = Number(record?.summary?.correct) || 0;
+      const scoredAnswered = Number(record?.summary?.scoredAnswered);
+      const nonScoredAnswered = Number(record?.summary?.nonScoredAnswered);
+      const scoringDenominator = Number.isFinite(scoredAnswered)
+        ? scoredAnswered
+        : Math.max(0, answered - (Number.isFinite(nonScoredAnswered) ? nonScoredAnswered : 0));
       return {
         id: record.id,
         subjectId: 'grammar',
@@ -442,8 +457,8 @@ function recentGrammarSessions(practiceSessions = []) {
         sessionKind: record.sessionKind || record.summary?.mode || 'practice',
         label: record?.summary?.mode ? `Grammar ${record.summary.mode}` : 'Grammar practice',
         updatedAt: asTs(record.updatedAt, asTs(record.createdAt, 0)),
-        mistakeCount: Math.max(0, answered - correct),
-        headline: answered ? `${correct}/${answered}` : '',
+        mistakeCount: Math.max(0, scoringDenominator - correct),
+        headline: scoringDenominator ? `${correct}/${scoringDenominator}` : (nonScoredAnswered ? 'Saved for review' : ''),
       };
     });
 }

--- a/src/subjects/grammar/session-ui.js
+++ b/src/subjects/grammar/session-ui.js
@@ -146,6 +146,7 @@ export function grammarSessionFooterNote(session) {
  */
 export function grammarFeedbackTone(result) {
   if (!result || typeof result !== 'object') return 'neutral';
+  if (result.nonScored) return 'neutral';
   if (result.correct === true) return 'good';
   if (result.correct === false) return 'bad';
   return 'neutral';

--- a/tests/fixtures/grammar-functionality-completeness/grammar-qg-p2-baseline.json
+++ b/tests/fixtures/grammar-functionality-completeness/grammar-qg-p2-baseline.json
@@ -1,0 +1,57 @@
+{
+  "contentReleaseId": "grammar-qg-p2-2026-04-28",
+  "contentBaseline": {
+    "conceptCount": 18,
+    "templateCount": 57,
+    "selectedResponseCount": 37,
+    "constructedResponseCount": 20,
+    "generatedTemplateCount": 31,
+    "fixedTemplateCount": 26,
+    "answerSpecTemplateCount": 26,
+    "constructedResponseAnswerSpecTemplateCount": 20,
+    "legacyAdapterTemplateCount": 0,
+    "manualReviewOnlyTemplateCount": 4,
+    "p2MigrationComplete": true,
+    "thinPoolConcepts": [],
+    "questionTypes": [
+      "build",
+      "choose",
+      "classify",
+      "explain",
+      "fill",
+      "fix",
+      "identify",
+      "rewrite"
+    ],
+    "perQuestionType": {
+      "classify": 3,
+      "identify": 8,
+      "choose": 18,
+      "build": 4,
+      "fix": 11,
+      "rewrite": 6,
+      "fill": 3,
+      "explain": 4
+    },
+    "perConcept": {
+      "sentence_functions": 3,
+      "speech_punctuation": 3,
+      "word_classes": 3,
+      "noun_phrases": 3,
+      "adverbials": 5,
+      "clauses": 3,
+      "relative_clauses": 3,
+      "tense_aspect": 3,
+      "standard_english": 5,
+      "pronouns_cohesion": 3,
+      "formality": 3,
+      "active_passive": 3,
+      "subject_object": 3,
+      "modal_verbs": 3,
+      "parenthesis_commas": 3,
+      "apostrophes_possession": 3,
+      "boundary_punctuation": 4,
+      "hyphen_ambiguity": 3
+    }
+  }
+}

--- a/tests/fixtures/grammar-legacy-oracle/grammar-qg-p2-baseline.json
+++ b/tests/fixtures/grammar-legacy-oracle/grammar-qg-p2-baseline.json
@@ -1,0 +1,1110 @@
+{
+  "releaseId": "grammar-qg-p2-2026-04-28",
+  "conceptCount": 18,
+  "templateCount": 57,
+  "selectedResponseCount": 37,
+  "constructedResponseCount": 20,
+  "generatedTemplateCount": 31,
+  "fixedTemplateCount": 26,
+  "questionTypes": [
+    "build",
+    "choose",
+    "classify",
+    "explain",
+    "fill",
+    "fix",
+    "identify",
+    "rewrite"
+  ],
+  "duplicateTemplateIds": [],
+  "thinPoolConcepts": [],
+  "singleQuestionTypeConcepts": [],
+  "conceptCoverage": [
+    {
+      "conceptId": "active_passive",
+      "total": 3,
+      "generated": 2,
+      "fixed": 1,
+      "selectedResponse": 1,
+      "constructedResponse": 2,
+      "questionTypes": [
+        "choose",
+        "rewrite"
+      ],
+      "templateIds": [
+        "active_passive_rewrite",
+        "proc2_passive_to_active",
+        "qg_active_passive_choice"
+      ]
+    },
+    {
+      "conceptId": "adverbials",
+      "total": 5,
+      "generated": 2,
+      "fixed": 3,
+      "selectedResponse": 2,
+      "constructedResponse": 3,
+      "questionTypes": [
+        "build",
+        "choose",
+        "explain",
+        "fix"
+      ],
+      "templateIds": [
+        "explain_reason_choice",
+        "fix_fronted_adverbial",
+        "fronted_adverbial_choose",
+        "proc2_fronted_adverbial_build",
+        "proc_fronted_adverbial_fix"
+      ]
+    },
+    {
+      "conceptId": "apostrophes_possession",
+      "total": 3,
+      "generated": 2,
+      "fixed": 1,
+      "selectedResponse": 2,
+      "constructedResponse": 1,
+      "questionTypes": [
+        "choose",
+        "rewrite"
+      ],
+      "templateIds": [
+        "apostrophe_possession_choice",
+        "proc3_apostrophe_rewrite",
+        "proc_apostrophe_possession_choice"
+      ]
+    },
+    {
+      "conceptId": "boundary_punctuation",
+      "total": 4,
+      "generated": 4,
+      "fixed": 0,
+      "selectedResponse": 2,
+      "constructedResponse": 2,
+      "questionTypes": [
+        "choose",
+        "explain",
+        "fix"
+      ],
+      "templateIds": [
+        "proc2_boundary_punctuation_explain",
+        "proc_colon_list_fix",
+        "proc_dash_boundary_fix",
+        "proc_semicolon_choice"
+      ]
+    },
+    {
+      "conceptId": "clauses",
+      "total": 3,
+      "generated": 1,
+      "fixed": 2,
+      "selectedResponse": 1,
+      "constructedResponse": 2,
+      "questionTypes": [
+        "identify",
+        "rewrite"
+      ],
+      "templateIds": [
+        "combine_clauses_rewrite",
+        "proc3_clause_join_rewrite",
+        "subordinate_clause_choice"
+      ]
+    },
+    {
+      "conceptId": "formality",
+      "total": 3,
+      "generated": 2,
+      "fixed": 1,
+      "selectedResponse": 3,
+      "constructedResponse": 0,
+      "questionTypes": [
+        "choose",
+        "classify"
+      ],
+      "templateIds": [
+        "formality_pairs",
+        "proc2_formality_choice",
+        "qg_formality_classify_table"
+      ]
+    },
+    {
+      "conceptId": "hyphen_ambiguity",
+      "total": 3,
+      "generated": 3,
+      "fixed": 0,
+      "selectedResponse": 2,
+      "constructedResponse": 1,
+      "questionTypes": [
+        "choose",
+        "explain",
+        "fix"
+      ],
+      "templateIds": [
+        "proc3_hyphen_fix_meaning",
+        "proc_hyphen_ambiguity_choice",
+        "qg_hyphen_ambiguity_explain"
+      ]
+    },
+    {
+      "conceptId": "modal_verbs",
+      "total": 3,
+      "generated": 2,
+      "fixed": 1,
+      "selectedResponse": 3,
+      "constructedResponse": 0,
+      "questionTypes": [
+        "choose",
+        "explain",
+        "fill"
+      ],
+      "templateIds": [
+        "modal_verb_choice",
+        "proc2_modal_choice",
+        "qg_modal_verb_explain"
+      ]
+    },
+    {
+      "conceptId": "noun_phrases",
+      "total": 3,
+      "generated": 1,
+      "fixed": 2,
+      "selectedResponse": 1,
+      "constructedResponse": 2,
+      "questionTypes": [
+        "build",
+        "choose"
+      ],
+      "templateIds": [
+        "build_noun_phrase",
+        "expanded_noun_phrase_choice",
+        "proc3_noun_phrase_build"
+      ]
+    },
+    {
+      "conceptId": "parenthesis_commas",
+      "total": 3,
+      "generated": 1,
+      "fixed": 2,
+      "selectedResponse": 1,
+      "constructedResponse": 2,
+      "questionTypes": [
+        "choose",
+        "fix"
+      ],
+      "templateIds": [
+        "parenthesis_fix_sentence",
+        "parenthesis_replace_choice",
+        "proc3_parenthesis_commas_fix"
+      ]
+    },
+    {
+      "conceptId": "pronouns_cohesion",
+      "total": 3,
+      "generated": 2,
+      "fixed": 1,
+      "selectedResponse": 3,
+      "constructedResponse": 0,
+      "questionTypes": [
+        "choose",
+        "identify"
+      ],
+      "templateIds": [
+        "proc2_pronoun_cohesion_choice",
+        "pronoun_cohesion_choice",
+        "qg_pronoun_referent_identify"
+      ]
+    },
+    {
+      "conceptId": "relative_clauses",
+      "total": 3,
+      "generated": 1,
+      "fixed": 2,
+      "selectedResponse": 3,
+      "constructedResponse": 0,
+      "questionTypes": [
+        "build",
+        "choose",
+        "identify"
+      ],
+      "templateIds": [
+        "proc2_relative_clause_choice",
+        "relative_clause_complete",
+        "relative_clause_identify"
+      ]
+    },
+    {
+      "conceptId": "sentence_functions",
+      "total": 3,
+      "generated": 1,
+      "fixed": 2,
+      "selectedResponse": 3,
+      "constructedResponse": 0,
+      "questionTypes": [
+        "choose",
+        "classify",
+        "identify"
+      ],
+      "templateIds": [
+        "proc3_sentence_function_choice",
+        "question_mark_select",
+        "sentence_type_table"
+      ]
+    },
+    {
+      "conceptId": "speech_punctuation",
+      "total": 3,
+      "generated": 1,
+      "fixed": 2,
+      "selectedResponse": 1,
+      "constructedResponse": 2,
+      "questionTypes": [
+        "fix",
+        "identify"
+      ],
+      "templateIds": [
+        "proc_speech_punctuation_fix",
+        "question_mark_select",
+        "speech_punctuation_fix"
+      ]
+    },
+    {
+      "conceptId": "standard_english",
+      "total": 5,
+      "generated": 2,
+      "fixed": 3,
+      "selectedResponse": 3,
+      "constructedResponse": 2,
+      "questionTypes": [
+        "choose",
+        "explain",
+        "fix"
+      ],
+      "templateIds": [
+        "explain_reason_choice",
+        "proc2_standard_english_choice",
+        "proc2_standard_english_fix",
+        "standard_english_pairs",
+        "standard_fix_sentence"
+      ]
+    },
+    {
+      "conceptId": "subject_object",
+      "total": 3,
+      "generated": 2,
+      "fixed": 1,
+      "selectedResponse": 3,
+      "constructedResponse": 0,
+      "questionTypes": [
+        "classify",
+        "identify"
+      ],
+      "templateIds": [
+        "proc2_subject_object_identify",
+        "qg_subject_object_classify_table",
+        "subject_object_choice"
+      ]
+    },
+    {
+      "conceptId": "tense_aspect",
+      "total": 3,
+      "generated": 1,
+      "fixed": 2,
+      "selectedResponse": 2,
+      "constructedResponse": 1,
+      "questionTypes": [
+        "fill",
+        "rewrite"
+      ],
+      "templateIds": [
+        "proc2_tense_aspect_choice",
+        "tense_form_choice",
+        "tense_rewrite"
+      ]
+    },
+    {
+      "conceptId": "word_classes",
+      "total": 3,
+      "generated": 1,
+      "fixed": 2,
+      "selectedResponse": 3,
+      "constructedResponse": 0,
+      "questionTypes": [
+        "choose",
+        "identify"
+      ],
+      "templateIds": [
+        "identify_words_in_sentence",
+        "proc3_word_class_contrast_choice",
+        "word_class_underlined_choice"
+      ]
+    }
+  ],
+  "sampledSeeds": [
+    1,
+    2,
+    3
+  ],
+  "missingGeneratorMetadata": [],
+  "generatedSignatureCollisions": [],
+  "repeatedGeneratedVariants": [],
+  "legacyRepeatedGeneratedVariants": [
+    {
+      "signature": "grammar-v1:0e49r89",
+      "first": {
+        "templateId": "proc_semicolon_choice",
+        "generatorFamilyId": "proc_semicolon_choice",
+        "seed": 1,
+        "signature": "grammar-v1:0e49r89"
+      },
+      "second": {
+        "templateId": "proc_semicolon_choice",
+        "generatorFamilyId": "proc_semicolon_choice",
+        "seed": 2,
+        "signature": "grammar-v1:0e49r89"
+      }
+    },
+    {
+      "signature": "grammar-v1:0e49r89",
+      "first": {
+        "templateId": "proc_semicolon_choice",
+        "generatorFamilyId": "proc_semicolon_choice",
+        "seed": 1,
+        "signature": "grammar-v1:0e49r89"
+      },
+      "second": {
+        "templateId": "proc_semicolon_choice",
+        "generatorFamilyId": "proc_semicolon_choice",
+        "seed": 3,
+        "signature": "grammar-v1:0e49r89"
+      }
+    },
+    {
+      "signature": "grammar-v1:1ssolv6",
+      "first": {
+        "templateId": "proc_colon_list_fix",
+        "generatorFamilyId": "proc_colon_list_fix",
+        "seed": 1,
+        "signature": "grammar-v1:1ssolv6"
+      },
+      "second": {
+        "templateId": "proc_colon_list_fix",
+        "generatorFamilyId": "proc_colon_list_fix",
+        "seed": 2,
+        "signature": "grammar-v1:1ssolv6"
+      }
+    },
+    {
+      "signature": "grammar-v1:1ssolv6",
+      "first": {
+        "templateId": "proc_colon_list_fix",
+        "generatorFamilyId": "proc_colon_list_fix",
+        "seed": 1,
+        "signature": "grammar-v1:1ssolv6"
+      },
+      "second": {
+        "templateId": "proc_colon_list_fix",
+        "generatorFamilyId": "proc_colon_list_fix",
+        "seed": 3,
+        "signature": "grammar-v1:1ssolv6"
+      }
+    },
+    {
+      "signature": "grammar-v1:0xnqnjq",
+      "first": {
+        "templateId": "proc_dash_boundary_fix",
+        "generatorFamilyId": "proc_dash_boundary_fix",
+        "seed": 1,
+        "signature": "grammar-v1:0xnqnjq"
+      },
+      "second": {
+        "templateId": "proc_dash_boundary_fix",
+        "generatorFamilyId": "proc_dash_boundary_fix",
+        "seed": 2,
+        "signature": "grammar-v1:0xnqnjq"
+      }
+    },
+    {
+      "signature": "grammar-v1:0xnqnjq",
+      "first": {
+        "templateId": "proc_dash_boundary_fix",
+        "generatorFamilyId": "proc_dash_boundary_fix",
+        "seed": 1,
+        "signature": "grammar-v1:0xnqnjq"
+      },
+      "second": {
+        "templateId": "proc_dash_boundary_fix",
+        "generatorFamilyId": "proc_dash_boundary_fix",
+        "seed": 3,
+        "signature": "grammar-v1:0xnqnjq"
+      }
+    },
+    {
+      "signature": "grammar-v1:1ybsdcd",
+      "first": {
+        "templateId": "proc_hyphen_ambiguity_choice",
+        "generatorFamilyId": "proc_hyphen_ambiguity_choice",
+        "seed": 1,
+        "signature": "grammar-v1:1ybsdcd"
+      },
+      "second": {
+        "templateId": "proc_hyphen_ambiguity_choice",
+        "generatorFamilyId": "proc_hyphen_ambiguity_choice",
+        "seed": 3,
+        "signature": "grammar-v1:1ybsdcd"
+      }
+    },
+    {
+      "signature": "grammar-v1:1skcwev",
+      "first": {
+        "templateId": "proc2_modal_choice",
+        "generatorFamilyId": "proc2_modal_choice",
+        "seed": 1,
+        "signature": "grammar-v1:1skcwev"
+      },
+      "second": {
+        "templateId": "proc2_modal_choice",
+        "generatorFamilyId": "proc2_modal_choice",
+        "seed": 2,
+        "signature": "grammar-v1:1skcwev"
+      }
+    },
+    {
+      "signature": "grammar-v1:1skcwev",
+      "first": {
+        "templateId": "proc2_modal_choice",
+        "generatorFamilyId": "proc2_modal_choice",
+        "seed": 1,
+        "signature": "grammar-v1:1skcwev"
+      },
+      "second": {
+        "templateId": "proc2_modal_choice",
+        "generatorFamilyId": "proc2_modal_choice",
+        "seed": 3,
+        "signature": "grammar-v1:1skcwev"
+      }
+    },
+    {
+      "signature": "grammar-v1:19yg7s1",
+      "first": {
+        "templateId": "proc2_formality_choice",
+        "generatorFamilyId": "proc2_formality_choice",
+        "seed": 2,
+        "signature": "grammar-v1:19yg7s1"
+      },
+      "second": {
+        "templateId": "proc2_formality_choice",
+        "generatorFamilyId": "proc2_formality_choice",
+        "seed": 3,
+        "signature": "grammar-v1:19yg7s1"
+      }
+    },
+    {
+      "signature": "grammar-v1:1kaxixs",
+      "first": {
+        "templateId": "proc3_clause_join_rewrite",
+        "generatorFamilyId": "proc3_clause_join_rewrite",
+        "seed": 1,
+        "signature": "grammar-v1:1kaxixs"
+      },
+      "second": {
+        "templateId": "proc3_clause_join_rewrite",
+        "generatorFamilyId": "proc3_clause_join_rewrite",
+        "seed": 2,
+        "signature": "grammar-v1:1kaxixs"
+      }
+    },
+    {
+      "signature": "grammar-v1:1kaxixs",
+      "first": {
+        "templateId": "proc3_clause_join_rewrite",
+        "generatorFamilyId": "proc3_clause_join_rewrite",
+        "seed": 1,
+        "signature": "grammar-v1:1kaxixs"
+      },
+      "second": {
+        "templateId": "proc3_clause_join_rewrite",
+        "generatorFamilyId": "proc3_clause_join_rewrite",
+        "seed": 3,
+        "signature": "grammar-v1:1kaxixs"
+      }
+    }
+  ],
+  "sampleCount": 93,
+  "samples": [
+    {
+      "templateId": "proc_fronted_adverbial_fix",
+      "generatorFamilyId": "proc_fronted_adverbial_fix",
+      "seed": 1,
+      "signature": "grammar-v1:1g8xl3q"
+    },
+    {
+      "templateId": "proc_fronted_adverbial_fix",
+      "generatorFamilyId": "proc_fronted_adverbial_fix",
+      "seed": 2,
+      "signature": "grammar-v1:04pr4gm"
+    },
+    {
+      "templateId": "proc_fronted_adverbial_fix",
+      "generatorFamilyId": "proc_fronted_adverbial_fix",
+      "seed": 3,
+      "signature": "grammar-v1:1tgszjy"
+    },
+    {
+      "templateId": "proc_semicolon_choice",
+      "generatorFamilyId": "proc_semicolon_choice",
+      "seed": 1,
+      "signature": "grammar-v1:0e49r89"
+    },
+    {
+      "templateId": "proc_semicolon_choice",
+      "generatorFamilyId": "proc_semicolon_choice",
+      "seed": 2,
+      "signature": "grammar-v1:0e49r89"
+    },
+    {
+      "templateId": "proc_semicolon_choice",
+      "generatorFamilyId": "proc_semicolon_choice",
+      "seed": 3,
+      "signature": "grammar-v1:0e49r89"
+    },
+    {
+      "templateId": "proc_colon_list_fix",
+      "generatorFamilyId": "proc_colon_list_fix",
+      "seed": 1,
+      "signature": "grammar-v1:1ssolv6"
+    },
+    {
+      "templateId": "proc_colon_list_fix",
+      "generatorFamilyId": "proc_colon_list_fix",
+      "seed": 2,
+      "signature": "grammar-v1:1ssolv6"
+    },
+    {
+      "templateId": "proc_colon_list_fix",
+      "generatorFamilyId": "proc_colon_list_fix",
+      "seed": 3,
+      "signature": "grammar-v1:1ssolv6"
+    },
+    {
+      "templateId": "proc_dash_boundary_fix",
+      "generatorFamilyId": "proc_dash_boundary_fix",
+      "seed": 1,
+      "signature": "grammar-v1:0xnqnjq"
+    },
+    {
+      "templateId": "proc_dash_boundary_fix",
+      "generatorFamilyId": "proc_dash_boundary_fix",
+      "seed": 2,
+      "signature": "grammar-v1:0xnqnjq"
+    },
+    {
+      "templateId": "proc_dash_boundary_fix",
+      "generatorFamilyId": "proc_dash_boundary_fix",
+      "seed": 3,
+      "signature": "grammar-v1:0xnqnjq"
+    },
+    {
+      "templateId": "proc_hyphen_ambiguity_choice",
+      "generatorFamilyId": "proc_hyphen_ambiguity_choice",
+      "seed": 1,
+      "signature": "grammar-v1:1ybsdcd"
+    },
+    {
+      "templateId": "proc_hyphen_ambiguity_choice",
+      "generatorFamilyId": "proc_hyphen_ambiguity_choice",
+      "seed": 2,
+      "signature": "grammar-v1:0g3sftt"
+    },
+    {
+      "templateId": "proc_hyphen_ambiguity_choice",
+      "generatorFamilyId": "proc_hyphen_ambiguity_choice",
+      "seed": 3,
+      "signature": "grammar-v1:1ybsdcd"
+    },
+    {
+      "templateId": "proc_speech_punctuation_fix",
+      "generatorFamilyId": "proc_speech_punctuation_fix",
+      "seed": 1,
+      "signature": "grammar-v1:1sx0xyf"
+    },
+    {
+      "templateId": "proc_speech_punctuation_fix",
+      "generatorFamilyId": "proc_speech_punctuation_fix",
+      "seed": 2,
+      "signature": "grammar-v1:0u4a176"
+    },
+    {
+      "templateId": "proc_speech_punctuation_fix",
+      "generatorFamilyId": "proc_speech_punctuation_fix",
+      "seed": 3,
+      "signature": "grammar-v1:00fedhb"
+    },
+    {
+      "templateId": "proc_apostrophe_possession_choice",
+      "generatorFamilyId": "proc_apostrophe_possession_choice",
+      "seed": 1,
+      "signature": "grammar-v1:0nk933s"
+    },
+    {
+      "templateId": "proc_apostrophe_possession_choice",
+      "generatorFamilyId": "proc_apostrophe_possession_choice",
+      "seed": 2,
+      "signature": "grammar-v1:0kntphw"
+    },
+    {
+      "templateId": "proc_apostrophe_possession_choice",
+      "generatorFamilyId": "proc_apostrophe_possession_choice",
+      "seed": 3,
+      "signature": "grammar-v1:1n4zmgj"
+    },
+    {
+      "templateId": "proc2_standard_english_choice",
+      "generatorFamilyId": "proc2_standard_english_choice",
+      "seed": 1,
+      "signature": "grammar-v1:00pzz42"
+    },
+    {
+      "templateId": "proc2_standard_english_choice",
+      "generatorFamilyId": "proc2_standard_english_choice",
+      "seed": 2,
+      "signature": "grammar-v1:0o72ars"
+    },
+    {
+      "templateId": "proc2_standard_english_choice",
+      "generatorFamilyId": "proc2_standard_english_choice",
+      "seed": 3,
+      "signature": "grammar-v1:17g2hf2"
+    },
+    {
+      "templateId": "proc2_standard_english_fix",
+      "generatorFamilyId": "proc2_standard_english_fix",
+      "seed": 1,
+      "signature": "grammar-v1:01lzmgr"
+    },
+    {
+      "templateId": "proc2_standard_english_fix",
+      "generatorFamilyId": "proc2_standard_english_fix",
+      "seed": 2,
+      "signature": "grammar-v1:1vudeac"
+    },
+    {
+      "templateId": "proc2_standard_english_fix",
+      "generatorFamilyId": "proc2_standard_english_fix",
+      "seed": 3,
+      "signature": "grammar-v1:0yjg2u2"
+    },
+    {
+      "templateId": "proc2_tense_aspect_choice",
+      "generatorFamilyId": "proc2_tense_aspect_choice",
+      "seed": 1,
+      "signature": "grammar-v1:1izoc9g"
+    },
+    {
+      "templateId": "proc2_tense_aspect_choice",
+      "generatorFamilyId": "proc2_tense_aspect_choice",
+      "seed": 2,
+      "signature": "grammar-v1:01bbuh3"
+    },
+    {
+      "templateId": "proc2_tense_aspect_choice",
+      "generatorFamilyId": "proc2_tense_aspect_choice",
+      "seed": 3,
+      "signature": "grammar-v1:0bybprq"
+    },
+    {
+      "templateId": "proc2_modal_choice",
+      "generatorFamilyId": "proc2_modal_choice",
+      "seed": 1,
+      "signature": "grammar-v1:1skcwev"
+    },
+    {
+      "templateId": "proc2_modal_choice",
+      "generatorFamilyId": "proc2_modal_choice",
+      "seed": 2,
+      "signature": "grammar-v1:1skcwev"
+    },
+    {
+      "templateId": "proc2_modal_choice",
+      "generatorFamilyId": "proc2_modal_choice",
+      "seed": 3,
+      "signature": "grammar-v1:1skcwev"
+    },
+    {
+      "templateId": "proc2_formality_choice",
+      "generatorFamilyId": "proc2_formality_choice",
+      "seed": 1,
+      "signature": "grammar-v1:1dhp26a"
+    },
+    {
+      "templateId": "proc2_formality_choice",
+      "generatorFamilyId": "proc2_formality_choice",
+      "seed": 2,
+      "signature": "grammar-v1:19yg7s1"
+    },
+    {
+      "templateId": "proc2_formality_choice",
+      "generatorFamilyId": "proc2_formality_choice",
+      "seed": 3,
+      "signature": "grammar-v1:19yg7s1"
+    },
+    {
+      "templateId": "proc2_pronoun_cohesion_choice",
+      "generatorFamilyId": "proc2_pronoun_cohesion_choice",
+      "seed": 1,
+      "signature": "grammar-v1:1roa1tw"
+    },
+    {
+      "templateId": "proc2_pronoun_cohesion_choice",
+      "generatorFamilyId": "proc2_pronoun_cohesion_choice",
+      "seed": 2,
+      "signature": "grammar-v1:0grnzk8"
+    },
+    {
+      "templateId": "proc2_pronoun_cohesion_choice",
+      "generatorFamilyId": "proc2_pronoun_cohesion_choice",
+      "seed": 3,
+      "signature": "grammar-v1:1kyjjvc"
+    },
+    {
+      "templateId": "proc2_subject_object_identify",
+      "generatorFamilyId": "proc2_subject_object_identify",
+      "seed": 1,
+      "signature": "grammar-v1:116hzis"
+    },
+    {
+      "templateId": "proc2_subject_object_identify",
+      "generatorFamilyId": "proc2_subject_object_identify",
+      "seed": 2,
+      "signature": "grammar-v1:0pghuqx"
+    },
+    {
+      "templateId": "proc2_subject_object_identify",
+      "generatorFamilyId": "proc2_subject_object_identify",
+      "seed": 3,
+      "signature": "grammar-v1:0wj1y6r"
+    },
+    {
+      "templateId": "proc2_passive_to_active",
+      "generatorFamilyId": "proc2_passive_to_active",
+      "seed": 1,
+      "signature": "grammar-v1:1i2byea"
+    },
+    {
+      "templateId": "proc2_passive_to_active",
+      "generatorFamilyId": "proc2_passive_to_active",
+      "seed": 2,
+      "signature": "grammar-v1:0917idq"
+    },
+    {
+      "templateId": "proc2_passive_to_active",
+      "generatorFamilyId": "proc2_passive_to_active",
+      "seed": 3,
+      "signature": "grammar-v1:0uogei8"
+    },
+    {
+      "templateId": "proc2_relative_clause_choice",
+      "generatorFamilyId": "proc2_relative_clause_choice",
+      "seed": 1,
+      "signature": "grammar-v1:0774huc"
+    },
+    {
+      "templateId": "proc2_relative_clause_choice",
+      "generatorFamilyId": "proc2_relative_clause_choice",
+      "seed": 2,
+      "signature": "grammar-v1:0vqd1u8"
+    },
+    {
+      "templateId": "proc2_relative_clause_choice",
+      "generatorFamilyId": "proc2_relative_clause_choice",
+      "seed": 3,
+      "signature": "grammar-v1:1m9mwdk"
+    },
+    {
+      "templateId": "proc2_fronted_adverbial_build",
+      "generatorFamilyId": "proc2_fronted_adverbial_build",
+      "seed": 1,
+      "signature": "grammar-v1:06pt6ej"
+    },
+    {
+      "templateId": "proc2_fronted_adverbial_build",
+      "generatorFamilyId": "proc2_fronted_adverbial_build",
+      "seed": 2,
+      "signature": "grammar-v1:1u8yvq1"
+    },
+    {
+      "templateId": "proc2_fronted_adverbial_build",
+      "generatorFamilyId": "proc2_fronted_adverbial_build",
+      "seed": 3,
+      "signature": "grammar-v1:1hx02vd"
+    },
+    {
+      "templateId": "proc2_boundary_punctuation_explain",
+      "generatorFamilyId": "proc2_boundary_punctuation_explain",
+      "seed": 1,
+      "signature": "grammar-v1:0df99d8"
+    },
+    {
+      "templateId": "proc2_boundary_punctuation_explain",
+      "generatorFamilyId": "proc2_boundary_punctuation_explain",
+      "seed": 2,
+      "signature": "grammar-v1:0203lyc"
+    },
+    {
+      "templateId": "proc2_boundary_punctuation_explain",
+      "generatorFamilyId": "proc2_boundary_punctuation_explain",
+      "seed": 3,
+      "signature": "grammar-v1:0vvu6s8"
+    },
+    {
+      "templateId": "proc3_sentence_function_choice",
+      "generatorFamilyId": "proc3_sentence_function_choice",
+      "seed": 1,
+      "signature": "grammar-v1:1haufxw"
+    },
+    {
+      "templateId": "proc3_sentence_function_choice",
+      "generatorFamilyId": "proc3_sentence_function_choice",
+      "seed": 2,
+      "signature": "grammar-v1:0t4x2ao"
+    },
+    {
+      "templateId": "proc3_sentence_function_choice",
+      "generatorFamilyId": "proc3_sentence_function_choice",
+      "seed": 3,
+      "signature": "grammar-v1:0p5p7iu"
+    },
+    {
+      "templateId": "proc3_word_class_contrast_choice",
+      "generatorFamilyId": "proc3_word_class_contrast_choice",
+      "seed": 1,
+      "signature": "grammar-v1:0fok8e6"
+    },
+    {
+      "templateId": "proc3_word_class_contrast_choice",
+      "generatorFamilyId": "proc3_word_class_contrast_choice",
+      "seed": 2,
+      "signature": "grammar-v1:1lvmipt"
+    },
+    {
+      "templateId": "proc3_word_class_contrast_choice",
+      "generatorFamilyId": "proc3_word_class_contrast_choice",
+      "seed": 3,
+      "signature": "grammar-v1:0z27pnh"
+    },
+    {
+      "templateId": "proc3_noun_phrase_build",
+      "generatorFamilyId": "proc3_noun_phrase_build",
+      "seed": 1,
+      "signature": "grammar-v1:1itl27l"
+    },
+    {
+      "templateId": "proc3_noun_phrase_build",
+      "generatorFamilyId": "proc3_noun_phrase_build",
+      "seed": 2,
+      "signature": "grammar-v1:1yo6k4j"
+    },
+    {
+      "templateId": "proc3_noun_phrase_build",
+      "generatorFamilyId": "proc3_noun_phrase_build",
+      "seed": 3,
+      "signature": "grammar-v1:0wid472"
+    },
+    {
+      "templateId": "proc3_clause_join_rewrite",
+      "generatorFamilyId": "proc3_clause_join_rewrite",
+      "seed": 1,
+      "signature": "grammar-v1:1kaxixs"
+    },
+    {
+      "templateId": "proc3_clause_join_rewrite",
+      "generatorFamilyId": "proc3_clause_join_rewrite",
+      "seed": 2,
+      "signature": "grammar-v1:1kaxixs"
+    },
+    {
+      "templateId": "proc3_clause_join_rewrite",
+      "generatorFamilyId": "proc3_clause_join_rewrite",
+      "seed": 3,
+      "signature": "grammar-v1:1kaxixs"
+    },
+    {
+      "templateId": "proc3_parenthesis_commas_fix",
+      "generatorFamilyId": "proc3_parenthesis_commas_fix",
+      "seed": 1,
+      "signature": "grammar-v1:05d0k6e"
+    },
+    {
+      "templateId": "proc3_parenthesis_commas_fix",
+      "generatorFamilyId": "proc3_parenthesis_commas_fix",
+      "seed": 2,
+      "signature": "grammar-v1:09jdm1d"
+    },
+    {
+      "templateId": "proc3_parenthesis_commas_fix",
+      "generatorFamilyId": "proc3_parenthesis_commas_fix",
+      "seed": 3,
+      "signature": "grammar-v1:09mrgre"
+    },
+    {
+      "templateId": "proc3_hyphen_fix_meaning",
+      "generatorFamilyId": "proc3_hyphen_fix_meaning",
+      "seed": 1,
+      "signature": "grammar-v1:0w1vwh6"
+    },
+    {
+      "templateId": "proc3_hyphen_fix_meaning",
+      "generatorFamilyId": "proc3_hyphen_fix_meaning",
+      "seed": 2,
+      "signature": "grammar-v1:0jqvzv1"
+    },
+    {
+      "templateId": "proc3_hyphen_fix_meaning",
+      "generatorFamilyId": "proc3_hyphen_fix_meaning",
+      "seed": 3,
+      "signature": "grammar-v1:0a4q3mu"
+    },
+    {
+      "templateId": "qg_active_passive_choice",
+      "generatorFamilyId": "qg_active_passive_choice",
+      "seed": 1,
+      "signature": "grammar-v1:0c2fs0d"
+    },
+    {
+      "templateId": "qg_active_passive_choice",
+      "generatorFamilyId": "qg_active_passive_choice",
+      "seed": 2,
+      "signature": "grammar-v1:0yyt0w3"
+    },
+    {
+      "templateId": "qg_active_passive_choice",
+      "generatorFamilyId": "qg_active_passive_choice",
+      "seed": 3,
+      "signature": "grammar-v1:0lusrid"
+    },
+    {
+      "templateId": "qg_subject_object_classify_table",
+      "generatorFamilyId": "qg_subject_object_classify_table",
+      "seed": 1,
+      "signature": "grammar-v1:1rbp6tf"
+    },
+    {
+      "templateId": "qg_subject_object_classify_table",
+      "generatorFamilyId": "qg_subject_object_classify_table",
+      "seed": 2,
+      "signature": "grammar-v1:1bse0ww"
+    },
+    {
+      "templateId": "qg_subject_object_classify_table",
+      "generatorFamilyId": "qg_subject_object_classify_table",
+      "seed": 3,
+      "signature": "grammar-v1:1o2o9cl"
+    },
+    {
+      "templateId": "qg_pronoun_referent_identify",
+      "generatorFamilyId": "qg_pronoun_referent_identify",
+      "seed": 1,
+      "signature": "grammar-v1:1r6g1le"
+    },
+    {
+      "templateId": "qg_pronoun_referent_identify",
+      "generatorFamilyId": "qg_pronoun_referent_identify",
+      "seed": 2,
+      "signature": "grammar-v1:1d1js0x"
+    },
+    {
+      "templateId": "qg_pronoun_referent_identify",
+      "generatorFamilyId": "qg_pronoun_referent_identify",
+      "seed": 3,
+      "signature": "grammar-v1:0jyvdnk"
+    },
+    {
+      "templateId": "qg_formality_classify_table",
+      "generatorFamilyId": "qg_formality_classify_table",
+      "seed": 1,
+      "signature": "grammar-v1:1vr1alu"
+    },
+    {
+      "templateId": "qg_formality_classify_table",
+      "generatorFamilyId": "qg_formality_classify_table",
+      "seed": 2,
+      "signature": "grammar-v1:1akzwrd"
+    },
+    {
+      "templateId": "qg_formality_classify_table",
+      "generatorFamilyId": "qg_formality_classify_table",
+      "seed": 3,
+      "signature": "grammar-v1:0ghas69"
+    },
+    {
+      "templateId": "qg_modal_verb_explain",
+      "generatorFamilyId": "qg_modal_verb_explain",
+      "seed": 1,
+      "signature": "grammar-v1:1sj4s6u"
+    },
+    {
+      "templateId": "qg_modal_verb_explain",
+      "generatorFamilyId": "qg_modal_verb_explain",
+      "seed": 2,
+      "signature": "grammar-v1:1e4bzev"
+    },
+    {
+      "templateId": "qg_modal_verb_explain",
+      "generatorFamilyId": "qg_modal_verb_explain",
+      "seed": 3,
+      "signature": "grammar-v1:1oz9per"
+    },
+    {
+      "templateId": "qg_hyphen_ambiguity_explain",
+      "generatorFamilyId": "qg_hyphen_ambiguity_explain",
+      "seed": 1,
+      "signature": "grammar-v1:11dzz0d"
+    },
+    {
+      "templateId": "qg_hyphen_ambiguity_explain",
+      "generatorFamilyId": "qg_hyphen_ambiguity_explain",
+      "seed": 2,
+      "signature": "grammar-v1:014cofb"
+    },
+    {
+      "templateId": "qg_hyphen_ambiguity_explain",
+      "generatorFamilyId": "qg_hyphen_ambiguity_explain",
+      "seed": 3,
+      "signature": "grammar-v1:1gvf2nb"
+    },
+    {
+      "templateId": "proc3_apostrophe_rewrite",
+      "generatorFamilyId": "proc3_apostrophe_rewrite",
+      "seed": 1,
+      "signature": "grammar-v1:0aiqzup"
+    },
+    {
+      "templateId": "proc3_apostrophe_rewrite",
+      "generatorFamilyId": "proc3_apostrophe_rewrite",
+      "seed": 2,
+      "signature": "grammar-v1:1t2yk8d"
+    },
+    {
+      "templateId": "proc3_apostrophe_rewrite",
+      "generatorFamilyId": "proc3_apostrophe_rewrite",
+      "seed": 3,
+      "signature": "grammar-v1:13s7nkl"
+    }
+  ],
+  "answerSpecTemplateCount": 26,
+  "answerSpecKindCounts": {
+    "acceptedSet": 2,
+    "exact": 4,
+    "manualReviewOnly": 4,
+    "multiField": 2,
+    "normalisedText": 5,
+    "punctuationPattern": 9
+  },
+  "constructedResponseTemplateCount": 20,
+  "constructedResponseAnswerSpecTemplateCount": 20,
+  "legacyAdapterTemplateCount": 0,
+  "manualReviewOnlyTemplateCount": 4,
+  "p2MigrationComplete": true,
+  "templatesMissingAnswerSpecs": [],
+  "invalidAnswerSpecs": []
+}

--- a/tests/grammar-answer-spec.test.js
+++ b/tests/grammar-answer-spec.test.js
@@ -126,6 +126,10 @@ test('manualReviewOnly: never auto-scores correct', () => {
   const result = markByAnswerSpec(spec, { answer: 'My storm paragraph with a relative clause...' });
   assert.equal(result.correct, false, 'manualReviewOnly must never auto-correct');
   assert.equal(result.score, 0);
+  assert.equal(result.maxScore, 0);
+  assert.equal(result.nonScored, true);
+  assert.equal(result.manualReviewOnly, true);
+  assert.equal(result.feedbackShort, 'Saved for review.');
 });
 
 test('markByAnswerSpec preserves spec-owned answer text and hint metadata', () => {

--- a/tests/grammar-engine.test.js
+++ b/tests/grammar-engine.test.js
@@ -23,6 +23,7 @@ import { buildGrammarReadModel } from '../worker/src/subjects/grammar/read-model
 import {
   readGrammarLegacyOracle,
   readGrammarQuestionGeneratorBaseline,
+  readGrammarQuestionGeneratorP2Baseline,
 } from './helpers/grammar-legacy-oracle.js';
 import { assertNoForbiddenGrammarReadModelKeys } from '../scripts/grammar-production-smoke.mjs';
 
@@ -38,8 +39,27 @@ test('Grammar legacy oracle fixture remains frozen for the reviewed denominator'
   assert.equal(oracle.constructedResponseCount, 20);
 });
 
-test('Grammar QG P1 baseline pins the shipped content denominator', () => {
+test('Grammar QG P1 baseline remains frozen for the previous content release', () => {
   const baseline = readGrammarQuestionGeneratorBaseline();
+
+  assert.equal(baseline.releaseId, 'grammar-qg-p1-2026-04-28');
+  assert.equal(baseline.conceptCount, 18);
+  assert.equal(baseline.templateCount, 57);
+  assert.equal(baseline.selectedResponseCount, 37);
+  assert.equal(baseline.constructedResponseCount, 20);
+  assert.equal(baseline.generatedTemplateCount, 31);
+  assert.equal(baseline.fixedTemplateCount, 26);
+  assert.equal(baseline.answerSpecTemplateCount, 6);
+  assert.deepEqual(baseline.thinPoolConcepts, []);
+  assert.deepEqual(baseline.singleQuestionTypeConcepts, []);
+  assert.equal(GRAMMAR_CONCEPTS.length, 18);
+  assert.equal(GRAMMAR_TEMPLATE_METADATA.length, 57);
+  assert.equal(GRAMMAR_TEMPLATE_METADATA.filter((template) => template.isSelectedResponse).length, 37);
+  assert.equal(GRAMMAR_TEMPLATE_METADATA.filter((template) => !template.isSelectedResponse).length, 20);
+});
+
+test('Grammar QG P2 baseline pins the shipped declarative marking denominator', () => {
+  const baseline = readGrammarQuestionGeneratorP2Baseline();
 
   assert.equal(baseline.releaseId, GRAMMAR_CONTENT_RELEASE_ID);
   assert.equal(baseline.conceptCount, 18);
@@ -48,7 +68,11 @@ test('Grammar QG P1 baseline pins the shipped content denominator', () => {
   assert.equal(baseline.constructedResponseCount, 20);
   assert.equal(baseline.generatedTemplateCount, 31);
   assert.equal(baseline.fixedTemplateCount, 26);
-  assert.equal(baseline.answerSpecTemplateCount, 6);
+  assert.equal(baseline.answerSpecTemplateCount, 26);
+  assert.equal(baseline.constructedResponseAnswerSpecTemplateCount, 20);
+  assert.equal(baseline.legacyAdapterTemplateCount, 0);
+  assert.equal(baseline.manualReviewOnlyTemplateCount, 4);
+  assert.equal(baseline.p2MigrationComplete, true);
   assert.deepEqual(baseline.thinPoolConcepts, []);
   assert.deepEqual(baseline.singleQuestionTypeConcepts, []);
   assert.equal(GRAMMAR_CONCEPTS.length, 18);
@@ -80,8 +104,28 @@ test('Grammar legacy content still generates serialisable questions matching fro
     assert.equal(serialised.promptText, sample.sample.promptText, sample.id);
     assert.equal(typeof question.evaluate, 'function', sample.id);
 
-    const correct = evaluateGrammarQuestion(question, sample.correctResponse);
-    assert.deepEqual(correct, sample.correctResult, sample.id);
+    const template = grammarTemplateById(sample.id);
+    const migratedAnswerSpecResponse = (
+      !template?.isSelectedResponse
+      && question.answerSpec?.kind !== 'manualReviewOnly'
+      && Array.isArray(question.answerSpec.golden)
+    )
+      ? { answer: question.answerSpec.golden[0] }
+      : sample.correctResponse;
+    const correct = evaluateGrammarQuestion(question, migratedAnswerSpecResponse);
+    if (question.answerSpec?.kind === 'manualReviewOnly') {
+      assert.equal(correct.correct, false, sample.id);
+      assert.equal(correct.nonScored, true, sample.id);
+      assert.equal(correct.manualReviewOnly, true, sample.id);
+      assert.equal(correct.score, 0, sample.id);
+      assert.equal(correct.maxScore, 0, sample.id);
+    } else if (!template?.isSelectedResponse && question.answerSpec) {
+      assert.equal(correct.correct, true, sample.id);
+      assert.equal(correct.score, correct.maxScore, sample.id);
+      assert.equal(typeof correct.feedbackShort, 'string', sample.id);
+    } else {
+      assert.deepEqual(correct, sample.correctResult, sample.id);
+    }
     assert.doesNotThrow(() => evaluateGrammarQuestion(question, {}), sample.id);
   }
 });
@@ -138,6 +182,126 @@ test('Grammar generated attempts store safe variant metadata without exposing it
   assert.match(attempt.variantSignature, /^grammar-v1:[a-z0-9]+$/);
   assert.equal(applied.events[0].generatorFamilyId, 'qg_modal_verb_explain');
   assert.equal(applied.events[0].variantSignature, attempt.variantSignature);
+});
+
+test('Grammar manual-review-only attempts save responses without scoring or reward evidence', () => {
+  const state = createInitialGrammarState();
+  const question = createGrammarQuestion({ templateId: 'build_noun_phrase', seed: 1 });
+  const item = serialiseGrammarQuestion(question);
+  const before = JSON.parse(JSON.stringify({
+    mastery: state.mastery,
+    retryQueue: state.retryQueue,
+    misconceptions: state.misconceptions,
+  }));
+
+  const applied = applyGrammarAttemptToState(state, {
+    learnerId: 'learner-a',
+    item,
+    response: {
+      part1: 'The nervous',
+      part2: 'young explorer',
+      part3: 'from our class',
+    },
+    supportLevel: 0,
+    attempts: 1,
+    requestId: 'manual-review',
+    now: 1_777_000_000_000,
+  });
+
+  assert.equal(applied.result.correct, false);
+  assert.equal(applied.result.nonScored, true);
+  assert.equal(applied.result.manualReviewOnly, true);
+  assert.equal(applied.quality, 0);
+  assert.deepEqual(state.mastery, before.mastery);
+  assert.deepEqual(state.retryQueue, before.retryQueue);
+  assert.deepEqual(state.misconceptions, before.misconceptions);
+  assert.equal(state.recentAttempts.length, 1);
+  assert.equal(state.recentAttempts[0].nonScored, true);
+  const readModel = buildGrammarReadModel({ state, now: 1_777_000_000_000 });
+  const nounPhraseConcept = readModel.analytics.concepts.find((concept) => concept.id === 'noun_phrases');
+  assert.equal(nounPhraseConcept.confidence.recentMisses, 0);
+  assert.equal(nounPhraseConcept.confidence.distinctTemplates, 0);
+  assert.deepEqual(applied.events.map((event) => event.type), ['grammar.manual-review-saved']);
+  assert.equal(applied.events.some((event) => event.type === 'grammar.answer-submitted'), false);
+  assert.equal(applied.events.some((event) => event.type === 'grammar.concept-secured'), false);
+});
+
+test('Grammar manual-review-only practice summary separates answered from scored answers', () => {
+  const engine = createServerGrammarEngine({ now: () => 1_777_000_000_000 });
+  const start = engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: {},
+    command: 'start-session',
+    requestId: 'manual-review-summary-start',
+    payload: {
+      roundLength: 1,
+      templateId: 'build_noun_phrase',
+      seed: 1,
+    },
+  });
+
+  const submit = engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: { ui: start.state, data: start.data },
+    latestSession: start.practiceSession,
+    command: 'submit-answer',
+    requestId: 'manual-review-summary-submit',
+    payload: {
+      response: {
+        part1: 'The nervous young',
+        part2: 'explorer',
+        part3: 'from our class',
+      },
+    },
+  });
+  assert.equal(submit.state.session.answered, 1);
+  assert.equal(submit.state.session.scoredAnswered, 0);
+  assert.equal(submit.state.session.nonScoredAnswered, 1);
+
+  const finished = engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: { ui: submit.state, data: submit.data },
+    latestSession: submit.practiceSession,
+    command: 'continue-session',
+    requestId: 'manual-review-summary-finish',
+    payload: {},
+  });
+
+  assert.equal(finished.state.phase, 'summary');
+  assert.equal(finished.state.summary.answered, 1);
+  assert.equal(finished.state.summary.scoredAnswered, 0);
+  assert.equal(finished.state.summary.nonScoredAnswered, 1);
+  assert.equal(finished.state.summary.correct, 0);
+  const completed = finished.events.find((event) => event.type === 'grammar.session-completed');
+  assert.equal(completed.scoredAnswered, 0);
+  assert.equal(completed.nonScoredAnswered, 1);
+});
+
+test('Grammar mini-test packs exclude manual-review-only templates', () => {
+  for (let seed = 1; seed <= 200; seed += 1) {
+    const items = buildGrammarMiniSet({ size: 8, seed });
+    assert.equal(items.length, 8, `seed ${seed}`);
+    for (const item of items) {
+      const template = grammarTemplateById(item.templateId);
+      assert.notEqual(template?.answerSpecKind, 'manualReviewOnly', `${item.templateId} in seed ${seed}`);
+    }
+  }
+});
+
+test('Grammar strict mini-test rejects forced manual-review-only templates', () => {
+  const engine = createServerGrammarEngine({ now: () => 1_777_000_000_000 });
+
+  assert.throws(() => engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: {},
+    command: 'start-session',
+    requestId: 'manual-review-mini-test',
+    payload: {
+      mode: 'satsset',
+      templateId: 'build_noun_phrase',
+      seed: 1,
+    },
+  }), (error) => error?.extra?.code === 'grammar_template_unavailable_for_mode');
 });
 
 test('Grammar mini-set generation covers mixed and focused pools without looping', () => {
@@ -237,6 +401,48 @@ test('Grammar engine rejects stale content release evidence', () => {
     item,
     response: {},
   }), (error) => error?.extra?.code === 'grammar_content_release_mismatch');
+});
+
+test('Grammar command engine clears active sessions from an older content release', () => {
+  const now = 1_777_000_000_000;
+  const engine = createServerGrammarEngine({ now: () => now });
+  const started = engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: {},
+    command: 'start-session',
+    requestId: 'stale-release-start',
+    payload: {
+      templateId: 'fronted_adverbial_choose',
+      seed: 1,
+      roundLength: 1,
+    },
+  });
+  const staleState = JSON.parse(JSON.stringify(started.state));
+  staleState.contentReleaseId = 'grammar-qg-p1-2026-04-28';
+  staleState.session.currentItem.contentReleaseId = 'grammar-qg-p1-2026-04-28';
+
+  const cleared = engine.apply({
+    learnerId: 'learner-a',
+    subjectRecord: {
+      ui: staleState,
+      data: {
+        ...started.data,
+        contentReleaseId: 'grammar-qg-p1-2026-04-28',
+      },
+    },
+    latestSession: started.practiceSession,
+    command: 'submit-answer',
+    requestId: 'stale-release-submit',
+    payload: { response: { answer: 'Before the match' } },
+  });
+
+  assert.equal(cleared.changed, true);
+  assert.equal(cleared.state.contentReleaseId, GRAMMAR_CONTENT_RELEASE_ID);
+  assert.equal(cleared.state.phase, 'dashboard');
+  assert.equal(cleared.state.session, null);
+  assert.equal(cleared.practiceSession.status, 'abandoned');
+  assert.equal(cleared.practiceSession.id, started.practiceSession.id);
+  assert.deepEqual(cleared.events, []);
 });
 
 test('Grammar retry queue de-duplicates repeated misses for the same template and seed', () => {

--- a/tests/grammar-functionality-completeness.test.js
+++ b/tests/grammar-functionality-completeness.test.js
@@ -19,6 +19,7 @@ import {
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const baselinePath = path.join(rootDir, 'tests/fixtures/grammar-functionality-completeness/legacy-baseline.json');
 const qgP1BaselinePath = path.join(rootDir, 'tests/fixtures/grammar-functionality-completeness/grammar-qg-p1-baseline.json');
+const qgP2BaselinePath = path.join(rootDir, 'tests/fixtures/grammar-functionality-completeness/grammar-qg-p2-baseline.json');
 const perfectionPassBaselinePath = path.join(rootDir, 'tests/fixtures/grammar-functionality-completeness/perfection-pass-baseline.json');
 const phase3BaselinePath = path.join(rootDir, 'tests/fixtures/grammar-phase3-baseline.json');
 const phase4BaselinePath = path.join(rootDir, 'tests/fixtures/grammar-phase4-baseline.json');
@@ -40,6 +41,10 @@ function readPerfectionPassBaseline() {
 
 function readQgP1Baseline() {
   return JSON.parse(fs.readFileSync(qgP1BaselinePath, 'utf8'));
+}
+
+function readQgP2Baseline() {
+  return JSON.parse(fs.readFileSync(qgP2BaselinePath, 'utf8'));
 }
 
 function readPhase3Baseline() {
@@ -89,8 +94,23 @@ test('Grammar functionality completeness baseline is internally owned', () => {
   }
 });
 
-test('Grammar QG P1 baseline matches the shipped content denominator', () => {
+test('Grammar QG P1 baseline remains frozen for the previous question-generator release', () => {
   const baseline = readQgP1Baseline();
+  const content = baseline.contentBaseline;
+
+  assert.equal(baseline.contentReleaseId, 'grammar-qg-p1-2026-04-28');
+  assert.equal(content.conceptCount, 18);
+  assert.equal(content.templateCount, 57);
+  assert.equal(content.selectedResponseCount, 37);
+  assert.equal(content.constructedResponseCount, 20);
+  assert.equal(content.generatedTemplateCount, 31);
+  assert.equal(content.fixedTemplateCount, 26);
+  assert.equal(content.answerSpecTemplateCount, 6);
+  assert.deepEqual(content.thinPoolConcepts, []);
+});
+
+test('Grammar QG P2 baseline matches the shipped declarative marking denominator', () => {
+  const baseline = readQgP2Baseline();
   const content = baseline.contentBaseline;
 
   assert.equal(baseline.contentReleaseId, GRAMMAR_CONTENT_RELEASE_ID);
@@ -100,7 +120,11 @@ test('Grammar QG P1 baseline matches the shipped content denominator', () => {
   assert.equal(content.constructedResponseCount, 20);
   assert.equal(content.generatedTemplateCount, 31);
   assert.equal(content.fixedTemplateCount, 26);
-  assert.equal(content.answerSpecTemplateCount, 6);
+  assert.equal(content.answerSpecTemplateCount, 26);
+  assert.equal(content.constructedResponseAnswerSpecTemplateCount, 20);
+  assert.equal(content.legacyAdapterTemplateCount, 0);
+  assert.equal(content.manualReviewOnlyTemplateCount, 4);
+  assert.equal(content.p2MigrationComplete, true);
   assert.deepEqual(content.thinPoolConcepts, []);
   assert.equal(GRAMMAR_CONCEPTS.length, content.conceptCount);
   assert.equal(GRAMMAR_CLIENT_CONCEPTS.length, content.conceptCount);

--- a/tests/grammar-parent-hub-confidence.test.js
+++ b/tests/grammar-parent-hub-confidence.test.js
@@ -121,6 +121,68 @@ test('U7 parity: client Parent-Hub read-model label matches Worker label for eve
   }
 });
 
+test('P2 manual-review-only attempts do not count as recent misses or distinct templates', () => {
+  const nowTs = 1_780_000_000_000;
+  const state = {
+    mastery: {
+      concepts: {
+        noun_phrases: {
+          attempts: 4, correct: 3, wrong: 1, strength: 0.65,
+          intervalDays: 2, dueAt: nowTs + 86_400_000, correctStreak: 2,
+        },
+      },
+    },
+    recentAttempts: [
+      {
+        templateId: 'build_noun_phrase',
+        conceptIds: ['noun_phrases'],
+        result: { correct: false, nonScored: true, manualReviewOnly: true },
+        nonScored: true,
+        manualReviewOnly: true,
+        createdAt: nowTs - 1_000,
+      },
+    ],
+  };
+
+  const workerConcept = workerConceptsById(state, nowTs).get('noun_phrases');
+  const clientModel = buildGrammarLearnerReadModel({
+    subjectStateRecord: { data: state, updatedAt: nowTs },
+    now: () => nowTs,
+  });
+  const clientConcept = clientModel.conceptStatus.find((concept) => concept.id === 'noun_phrases');
+
+  assert.equal(workerConcept.confidence.recentMisses, 0);
+  assert.equal(workerConcept.confidence.distinctTemplates, 0);
+  assert.equal(clientConcept.confidence.recentMisses, 0);
+  assert.equal(clientConcept.confidence.distinctTemplates, 0);
+});
+
+test('P2 client Parent-Hub read-model does not count manual-review saves as mistakes', () => {
+  const nowTs = 1_780_000_000_000;
+  const model = buildGrammarLearnerReadModel({
+    subjectStateRecord: { data: {}, updatedAt: nowTs },
+    practiceSessions: [{
+      id: 'grammar-manual-review',
+      subjectId: 'grammar',
+      status: 'completed',
+      sessionKind: 'practice',
+      summary: {
+        mode: 'practice',
+        answered: 1,
+        scoredAnswered: 0,
+        nonScoredAnswered: 1,
+        correct: 0,
+      },
+      createdAt: nowTs - 1000,
+      updatedAt: nowTs,
+    }],
+    now: () => nowTs,
+  });
+
+  assert.equal(model.recentSessions[0].mistakeCount, 0);
+  assert.equal(model.recentSessions[0].headline, 'Saved for review');
+});
+
 test('U7: client read-model includes the full confidence projection shape on every concept', () => {
   const nowTs = 1_780_000_000_000;
   const state = seededGrammarState(nowTs);

--- a/tests/grammar-production-smoke.test.js
+++ b/tests/grammar-production-smoke.test.js
@@ -6,9 +6,11 @@ import {
   evaluateGrammarQuestion,
 } from '../worker/src/subjects/grammar/content.js';
 import {
+  GRAMMAR_ANSWER_SPEC_FAMILY_SMOKE_ITEMS,
   assertNoForbiddenGrammarReadModelKeys,
   correctResponseFor,
   incorrectResponseFor,
+  visibleResponseForAnswerSpecFamily,
 } from '../scripts/grammar-production-smoke.mjs';
 
 function smokeQuestion() {
@@ -24,6 +26,7 @@ function readItemFromQuestion(question) {
   return {
     templateId: question.templateId,
     seed: question.seed,
+    promptText: question.promptText,
     inputSpec: question.inputSpec,
   };
 }
@@ -186,4 +189,23 @@ test('Grammar production smoke scans mini-test, support, and AI enrichment read 
     }, 'grammar.miniReviewModel'),
     /grammar\.miniReviewModel\.summary\.miniTestReview\.questions\[0\]\.marked\.result\.answers exposed a server-only field/,
   );
+});
+
+test('Grammar production smoke has visible-data probes for every answer-spec family', () => {
+  const expectedFamilies = new Set(['exact', 'multiField', 'normalisedText', 'punctuationPattern', 'acceptedSet', 'manualReviewOnly']);
+  assert.deepEqual(new Set(GRAMMAR_ANSWER_SPEC_FAMILY_SMOKE_ITEMS.map((item) => item.family)), expectedFamilies);
+
+  for (const fixture of GRAMMAR_ANSWER_SPEC_FAMILY_SMOKE_ITEMS) {
+    const question = createGrammarQuestion({ templateId: fixture.templateId, seed: fixture.seed });
+    const readItem = readItemFromQuestion(question);
+    const response = visibleResponseForAnswerSpecFamily(readItem);
+    const result = evaluateGrammarQuestion(question, response);
+    if (fixture.family === 'manualReviewOnly') {
+      assert.equal(result.correct, false, fixture.family);
+      assert.equal(result.nonScored, true, fixture.family);
+      assert.equal(result.manualReviewOnly, true, fixture.family);
+    } else {
+      assert.equal(result.correct, true, fixture.family);
+    }
+  }
 });

--- a/tests/grammar-question-generator-audit.test.js
+++ b/tests/grammar-question-generator-audit.test.js
@@ -19,6 +19,20 @@ test('Grammar question-generator audit covers the current template inventory', (
   assert.deepEqual(audit.templatesMissingAnswerSpecs, []);
   assert.deepEqual(audit.invalidAnswerSpecs, []);
   assert.equal(audit.conceptCoverage.length, GRAMMAR_CONCEPTS.length);
+  assert.equal(audit.answerSpecTemplateCount, 26);
+  assert.equal(audit.constructedResponseTemplateCount, 20);
+  assert.equal(audit.constructedResponseAnswerSpecTemplateCount, 20);
+  assert.equal(audit.legacyAdapterTemplateCount, 0);
+  assert.equal(audit.manualReviewOnlyTemplateCount, 4);
+  assert.equal(audit.p2MigrationComplete, true);
+  assert.deepEqual(audit.answerSpecKindCounts, {
+    acceptedSet: 2,
+    exact: 4,
+    manualReviewOnly: 4,
+    multiField: 2,
+    normalisedText: 5,
+    punctuationPattern: 9,
+  });
 });
 
 test('Grammar generated variants have stable answer-safe signatures', () => {
@@ -26,6 +40,10 @@ test('Grammar generated variants have stable answer-safe signatures', () => {
   assert.deepEqual(audit.missingGeneratorMetadata, []);
   assert.deepEqual(audit.generatedSignatureCollisions, []);
   assert.deepEqual(audit.repeatedGeneratedVariants, []);
+  assert.ok(
+    audit.legacyRepeatedGeneratedVariants.length >= 1,
+    'Legacy generated repeated variants stay advisory rather than blocking P2 marking migration.',
+  );
   assert.ok(audit.sampleCount > 0);
 
   const sample = createGrammarQuestion({ templateId: 'proc2_subject_object_identify', seed: 7 });

--- a/tests/grammar-ui-model.test.js
+++ b/tests/grammar-ui-model.test.js
@@ -257,6 +257,10 @@ test('U8 session-ui: grammarFeedbackTone neutral returns neutral', () => {
   assert.equal(grammarFeedbackTone({}), 'neutral');
 });
 
+test('P2 session-ui: grammarFeedbackTone treats non-scored manual-review feedback as neutral', () => {
+  assert.equal(grammarFeedbackTone({ correct: false, nonScored: true, manualReviewOnly: true }), 'neutral');
+});
+
 // -----------------------------------------------------------------------------
 // GRAMMAR_PRIMARY_MODE_CARDS — roster + shape contract
 // -----------------------------------------------------------------------------
@@ -768,6 +772,27 @@ test('U8 view-model: grammarSummaryCards accuracy detail is computed from answer
   const correctCard = cards.find((card) => card.id === 'correct');
   assert.equal(correctCard.value, 3);
   assert.ok(correctCard.detail.includes('75%'));
+});
+
+test('U8 view-model: grammarSummaryCards excludes manual-review saves from accuracy', () => {
+  const manualOnlyCards = grammarSummaryCards({
+    answered: 1,
+    scoredAnswered: 0,
+    nonScoredAnswered: 1,
+    correct: 0,
+  }, null);
+  const manualOnlyCorrect = manualOnlyCards.find((card) => card.id === 'correct');
+  assert.equal(manualOnlyCorrect.value, 0);
+  assert.equal(manualOnlyCorrect.detail, 'Saved for review');
+
+  const mixedCards = grammarSummaryCards({
+    answered: 2,
+    scoredAnswered: 1,
+    nonScoredAnswered: 1,
+    correct: 1,
+  }, null);
+  const mixedCorrect = mixedCards.find((card) => card.id === 'correct');
+  assert.equal(mixedCorrect.detail, '100% accuracy');
 });
 
 // =============================================================================

--- a/tests/helpers/grammar-legacy-oracle.js
+++ b/tests/helpers/grammar-legacy-oracle.js
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 const fixturePath = path.join(rootDir, 'tests/fixtures/grammar-legacy-oracle/legacy-baseline.json');
 const qgP1FixturePath = path.join(rootDir, 'tests/fixtures/grammar-legacy-oracle/grammar-qg-p1-baseline.json');
+const qgP2FixturePath = path.join(rootDir, 'tests/fixtures/grammar-legacy-oracle/grammar-qg-p2-baseline.json');
 
 export function readGrammarLegacyOracle() {
   return JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
@@ -12,6 +13,10 @@ export function readGrammarLegacyOracle() {
 
 export function readGrammarQuestionGeneratorBaseline() {
   return JSON.parse(fs.readFileSync(qgP1FixturePath, 'utf8'));
+}
+
+export function readGrammarQuestionGeneratorP2Baseline() {
+  return JSON.parse(fs.readFileSync(qgP2FixturePath, 'utf8'));
 }
 
 export function oracleTemplateById(templateId) {

--- a/tests/react-grammar-surface.test.js
+++ b/tests/react-grammar-surface.test.js
@@ -788,6 +788,49 @@ test('Grammar session exposes non-scored AI enrichment triggers after marking', 
   assert.match(html, /Spot the fronted adverbial/);
 });
 
+test('Grammar manual-review feedback is neutral and hides repair actions', () => {
+  const storage = installMemoryStorage();
+  const harness = createGrammarHarness({ storage });
+
+  harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-start', {
+    payload: {
+      roundLength: 1,
+      templateId: 'build_noun_phrase',
+      seed: 1,
+    },
+  });
+
+  harness.dispatch('grammar-submit-form', {
+    formData: grammarResponseFormData({
+      part1: 'The nervous young',
+      part2: 'explorer',
+      part3: 'from our class',
+    }),
+  });
+
+  const grammar = harness.store.getState().subjectUi.grammar;
+  assert.equal(grammar.phase, 'feedback');
+  assert.equal(grammar.feedback.result.nonScored, true);
+  assert.equal(grammar.feedback.result.manualReviewOnly, true);
+
+  let html = harness.render();
+  assert.match(html, /class="feedback neutral"/);
+  assert.match(html, /Saved for review\./);
+  assert.match(html, /not auto-marked for mastery/i);
+  assert.doesNotMatch(html, /Retry/);
+  assert.doesNotMatch(html, /Worked solution/);
+  assert.doesNotMatch(html, /Similar problem/);
+  assert.doesNotMatch(html, /Explain another way/);
+  assert.doesNotMatch(html, /Revision cards/);
+
+  harness.dispatch('grammar-continue');
+  assert.equal(harness.store.getState().subjectUi.grammar.phase, 'summary');
+  html = harness.render();
+  assert.match(html, /Saved for review/);
+  assert.doesNotMatch(html, /0% accuracy/);
+});
+
 test('Grammar analytics exposes parent summary draft enrichment', () => {
   const storage = installMemoryStorage();
   const harness = createGrammarHarness({ storage });

--- a/tests/react-parent-hub-grammar.test.js
+++ b/tests/react-parent-hub-grammar.test.js
@@ -35,7 +35,7 @@ function nodePaths() {
   ].filter((entry) => entry && existsSync(entry));
 }
 
-async function renderParentHub({ conceptStatus }) {
+async function renderParentHub({ conceptStatus = [], recentSessions = [] }) {
   const tmpDir = await mkdtemp(path.join(tmpdir(), 'ks2-parent-grammar-'));
   const entryPath = path.join(tmpDir, 'entry.jsx');
   const bundlePath = path.join(tmpDir, 'entry.cjs');
@@ -46,6 +46,7 @@ async function renderParentHub({ conceptStatus }) {
       import { ParentHubSurface } from ${JSON.stringify(path.join(rootDir, 'src/surfaces/hubs/ParentHubSurface.jsx'))};
 
       const conceptStatus = ${JSON.stringify(conceptStatus)};
+      const recentSessions = ${JSON.stringify(recentSessions)};
       const model = {
         learner: { id: 'learner-a', name: 'Ava', lastActivityAt: 0 },
         learnerOverview: {
@@ -57,7 +58,7 @@ async function renderParentHub({ conceptStatus }) {
           accuracyPercent: null,
         },
         dueWork: [],
-        recentSessions: [],
+        recentSessions,
         strengths: [],
         weaknesses: [],
         misconceptionPatterns: [],
@@ -241,4 +242,25 @@ test('U7: Parent Hub — single recent miss uses singular "miss" (not "misses")'
   const html = await renderParentHub({ conceptStatus });
   assert.match(html, /1 recent miss</);
   assert.doesNotMatch(html, /1 recent misses/);
+});
+
+test('P2: Parent Hub renders Grammar manual-review sessions without mistake warning', async () => {
+  const html = await renderParentHub({
+    recentSessions: [{
+      id: 'grammar-manual-review',
+      subjectId: 'grammar',
+      status: 'completed',
+      sessionKind: 'practice',
+      label: 'Grammar practice',
+      updatedAt: Date.UTC(2026, 3, 28, 12, 0),
+      mistakeCount: 0,
+      headline: 'Saved for review',
+    }],
+  });
+
+  assert.match(html, /Grammar practice/);
+  assert.match(html, /Saved for review/);
+  assert.match(html, /0 mistakes/);
+  assert.doesNotMatch(html, /1 mistake/);
+  assert.doesNotMatch(html, /chip warn">0 mistakes/);
 });

--- a/tests/worker-grammar-subject-runtime.test.js
+++ b/tests/worker-grammar-subject-runtime.test.js
@@ -3,6 +3,12 @@ import assert from 'node:assert/strict';
 
 import { createWorkerApp } from '../worker/src/app.js';
 import { createWorkerSubjectRuntime } from '../worker/src/subjects/runtime.js';
+import {
+  createGrammarQuestion,
+  GRAMMAR_CONTENT_RELEASE_ID,
+  serialiseGrammarQuestion,
+} from '../worker/src/subjects/grammar/content.js';
+import { createInitialGrammarState } from '../worker/src/subjects/grammar/engine.js';
 import { readGrammarLegacyOracle } from './helpers/grammar-legacy-oracle.js';
 import { createMigratedSqliteD1Database } from './helpers/sqlite-d1.js';
 
@@ -219,6 +225,11 @@ test('Grammar command route persists subject state, practice session, and events
   assert.equal(submit.body.subjectReadModel.feedback.result.correct, true);
   assert.equal(submit.body.mutation.appliedRevision, 2);
   assert.equal(submit.body.domainEvents.some((event) => event.type === 'grammar.answer-submitted'), true);
+  const answerEvent = submit.body.domainEvents.find((event) => event.type === 'grammar.answer-submitted');
+  assert.equal(answerEvent.contentReleaseId, GRAMMAR_CONTENT_RELEASE_ID);
+  for (const event of submit.body.domainEvents.filter((row) => row.type === 'grammar.star-evidence-updated')) {
+    assert.equal(event.contentReleaseId, GRAMMAR_CONTENT_RELEASE_ID);
+  }
 
   const subject = DB.db.prepare(`
     SELECT ui_json, data_json
@@ -232,6 +243,165 @@ test('Grammar command route persists subject state, practice session, and events
   assert.equal(data.mastery.concepts.speech_punctuation.attempts, 1);
   assert.equal(DB.db.prepare("SELECT COUNT(*) AS count FROM practice_sessions WHERE subject_id = 'grammar'").get().count, 1);
   assert.equal(DB.db.prepare("SELECT COUNT(*) AS count FROM event_log WHERE subject_id = 'grammar' AND event_type = 'grammar.answer-submitted'").get().count, 1);
+
+  DB.close();
+});
+
+test('Grammar command route saves manual-review-only responses without scored events', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const app = createWorkerApp({ now: () => 1_777_000_000_000 });
+  seedAccountLearner(DB);
+
+  const start = await postCommand(app, DB, {
+    command: 'start-session',
+    learnerId: 'learner-a',
+    requestId: 'grammar-manual-start',
+    expectedLearnerRevision: 0,
+    payload: {
+      mode: 'smart',
+      roundLength: 1,
+      templateId: 'build_noun_phrase',
+      seed: 0,
+    },
+  });
+  assert.equal(start.response.status, 200, JSON.stringify(start.body));
+
+  const submit = await postCommand(app, DB, {
+    command: 'submit-answer',
+    learnerId: 'learner-a',
+    requestId: 'grammar-manual-submit',
+    expectedLearnerRevision: 1,
+    payload: {
+      response: {
+        part1: 'The tall',
+        part2: 'captain',
+        part3: 'with curly hair',
+      },
+    },
+  });
+  assert.equal(submit.response.status, 200, JSON.stringify(submit.body));
+  assert.equal(submit.body.subjectReadModel.feedback.result.correct, false);
+  assert.equal(submit.body.subjectReadModel.feedback.result.nonScored, true);
+  assert.equal(submit.body.subjectReadModel.feedback.result.manualReviewOnly, true);
+  assert.deepEqual(submit.body.domainEvents.map((event) => event.type), ['grammar.manual-review-saved']);
+  assert.equal(submit.body.reactionEvents.some((event) => event.type === 'reward.monster'), false);
+
+  const subject = DB.db.prepare(`
+    SELECT data_json
+    FROM child_subject_state
+    WHERE learner_id = 'learner-a' AND subject_id = 'grammar'
+  `).get();
+  const data = JSON.parse(subject.data_json);
+  assert.equal(data.mastery.concepts.noun_phrases?.attempts || 0, 0);
+  assert.equal(data.retryQueue.length, 0);
+  assert.equal(DB.db.prepare("SELECT COUNT(*) AS count FROM event_log WHERE subject_id = 'grammar' AND event_type = 'grammar.answer-submitted'").get().count, 0);
+  assert.equal(DB.db.prepare("SELECT COUNT(*) AS count FROM event_log WHERE subject_id = 'grammar' AND event_type = 'grammar.manual-review-saved'").get().count, 1);
+
+  DB.close();
+});
+
+test('Grammar command route clears active sessions from an older content release', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const now = 1_777_000_000_000;
+  const app = createWorkerApp({ now: () => now });
+  const staleReleaseId = 'grammar-qg-p1-2026-04-28';
+  seedAccountLearner(DB);
+
+  const staleItem = serialiseGrammarQuestion(createGrammarQuestion({
+    templateId: 'fronted_adverbial_choose',
+    seed: 10,
+  }));
+  staleItem.contentReleaseId = staleReleaseId;
+
+  const staleState = createInitialGrammarState({ contentReleaseId: staleReleaseId });
+  staleState.phase = 'session';
+  staleState.session = {
+    id: 'grammar-stale-release-session',
+    type: 'practice',
+    mode: 'smart',
+    focusConceptId: '',
+    startedAt: now - 10_000,
+    targetCount: 1,
+    answered: 0,
+    correct: 0,
+    totalScore: 0,
+    totalMarks: 1,
+    seed: 10,
+    currentIndex: 0,
+    currentItem: staleItem,
+    attemptsForCurrent: 0,
+    supportLevel: 0,
+    supportContractVersion: 2,
+    goal: { type: 'round', targetCount: 1 },
+    repair: { retryingCurrent: false, similarProblems: 0 },
+    heroContext: null,
+    serverAuthority: 'worker',
+  };
+
+  const staleData = {
+    contentReleaseId: staleReleaseId,
+    prefs: staleState.prefs,
+    mastery: staleState.mastery,
+    retryQueue: staleState.retryQueue,
+    misconceptions: staleState.misconceptions,
+    recentAttempts: staleState.recentAttempts,
+  };
+  DB.db.prepare(`
+    INSERT INTO child_subject_state (learner_id, subject_id, ui_json, data_json, updated_at, updated_by_account_id)
+    VALUES (?, 'grammar', ?, ?, ?, 'adult-a')
+  `).run('learner-a', JSON.stringify(staleState), JSON.stringify(staleData), now - 10_000);
+  DB.db.prepare(`
+    INSERT INTO practice_sessions (
+      id,
+      learner_id,
+      subject_id,
+      session_kind,
+      status,
+      session_state_json,
+      summary_json,
+      created_at,
+      updated_at,
+      updated_by_account_id
+    )
+    VALUES (?, 'learner-a', 'grammar', 'smart', 'active', ?, NULL, ?, ?, 'adult-a')
+  `).run(staleState.session.id, JSON.stringify(staleState.session), now - 10_000, now - 10_000);
+
+  const submit = await postCommand(app, DB, {
+    command: 'submit-answer',
+    learnerId: 'learner-a',
+    requestId: 'grammar-stale-release-submit',
+    expectedLearnerRevision: 0,
+    payload: { response: { answer: 'Before the match' } },
+  });
+
+  assert.equal(submit.response.status, 200, JSON.stringify(submit.body));
+  assert.equal(submit.body.subjectReadModel.phase, 'dashboard');
+  assert.equal(submit.body.subjectReadModel.session, null);
+  assert.equal(submit.body.subjectReadModel.content.releaseId, GRAMMAR_CONTENT_RELEASE_ID);
+  assert.deepEqual(submit.body.domainEvents, []);
+  assert.equal(submit.body.mutation.appliedRevision, 1);
+
+  const subject = DB.db.prepare(`
+    SELECT ui_json, data_json
+    FROM child_subject_state
+    WHERE learner_id = 'learner-a' AND subject_id = 'grammar'
+  `).get();
+  const ui = JSON.parse(subject.ui_json);
+  const data = JSON.parse(subject.data_json);
+  assert.equal(ui.contentReleaseId, GRAMMAR_CONTENT_RELEASE_ID);
+  assert.equal(ui.phase, 'dashboard');
+  assert.equal(ui.session, null);
+  assert.equal(data.contentReleaseId, GRAMMAR_CONTENT_RELEASE_ID);
+
+  const session = DB.db.prepare(`
+    SELECT status, session_state_json
+    FROM practice_sessions
+    WHERE id = 'grammar-stale-release-session'
+  `).get();
+  assert.equal(session.status, 'abandoned');
+  assert.equal(JSON.parse(session.session_state_json).currentItem.contentReleaseId, staleReleaseId);
+  assert.equal(DB.db.prepare("SELECT COUNT(*) AS count FROM event_log WHERE subject_id = 'grammar'").get().count, 0);
+  assert.equal(DB.db.prepare('SELECT state_revision FROM learner_profiles WHERE id = ?').get('learner-a').state_revision, 1);
 
   DB.close();
 });
@@ -836,10 +1006,10 @@ test('Grammar concept-secured events project monster rewards atomically', async 
     && event.monsterId === 'concordium'
   )), true);
   assert.ok(submit.body.projections.rewards.state.bracehart.mastered.includes(
-    'grammar:grammar-qg-p1-2026-04-28:sentence_functions',
+    `grammar:${GRAMMAR_CONTENT_RELEASE_ID}:sentence_functions`,
   ));
   assert.ok(submit.body.projections.rewards.state.concordium.mastered.includes(
-    'grammar:grammar-qg-p1-2026-04-28:speech_punctuation',
+    `grammar:${GRAMMAR_CONTENT_RELEASE_ID}:speech_punctuation`,
   ));
   assert.equal(submit.body.projections.rewards.state.quoral, undefined);
 
@@ -849,7 +1019,7 @@ test('Grammar concept-secured events project monster rewards atomically', async 
     WHERE learner_id = 'learner-a' AND system_id = 'monster-codex'
   `).get();
   const gameState = JSON.parse(gameRow.state_json);
-  assert.ok(gameState.bracehart.mastered.includes('grammar:grammar-qg-p1-2026-04-28:sentence_functions'));
+  assert.ok(gameState.bracehart.mastered.includes(`grammar:${GRAMMAR_CONTENT_RELEASE_ID}:sentence_functions`));
   assert.equal(gameState.quoral, undefined);
 
   DB.close();

--- a/tests/worker-history-api.test.js
+++ b/tests/worker-history-api.test.js
@@ -34,25 +34,30 @@ function seedAccount(server, {
 function insertSession(server, {
   id,
   learnerId = 'learner-history',
+  subjectId = 'spelling',
+  sessionKind = 'learning',
+  summary = {
+    label: 'Smart review',
+    cards: [{ label: 'Correct', value: '6/8' }],
+    mistakes: [{ word: 'secret-word', year: '5-6' }],
+  },
   updatedAt,
 }) {
   runSql(server, `
     INSERT INTO practice_sessions (id, learner_id, subject_id, session_kind, status, session_state_json, summary_json, created_at, updated_at, updated_by_account_id)
-    VALUES (?, ?, 'spelling', 'learning', 'completed', ?, ?, ?, ?, 'adult-parent')
+    VALUES (?, ?, ?, ?, 'completed', ?, ?, ?, ?, 'adult-parent')
   `, [
     id,
     learnerId,
+    subjectId,
+    sessionKind,
     JSON.stringify({
       currentCard: {
         word: { word: 'secret-word' },
         prompt: { sentence: 'secret-prompt-sentence' },
       },
     }),
-    JSON.stringify({
-      label: 'Smart review',
-      cards: [{ label: 'Correct', value: '6/8' }],
-      mistakes: [{ word: 'secret-word', year: '5-6' }],
-    }),
+    JSON.stringify(summary),
     updatedAt - 1,
     updatedAt,
   ]);
@@ -128,6 +133,38 @@ test('parent recent sessions route is paginated, scoped, and redacted', async ()
   assert.equal(secondResponse.status, 200);
   assert.deepEqual(secondPayload.sessions.map((session) => session.id), ['session-4', 'session-3', 'session-2']);
   assert.equal(secondPayload.sessions.some((session) => firstPayload.sessions.some((first) => first.id === session.id)), false);
+
+  server.close();
+});
+
+test('parent recent sessions route treats Grammar manual-review saves as non-scored', async () => {
+  const server = createWorkerRepositoryServer();
+  seedAccount(server, { accountId: 'adult-parent' });
+
+  insertSession(server, {
+    id: 'grammar-manual-review',
+    subjectId: 'grammar',
+    sessionKind: 'practice',
+    summary: {
+      mode: 'practice',
+      answered: 1,
+      scoredAnswered: 0,
+      nonScoredAnswered: 1,
+      correct: 0,
+    },
+    updatedAt: NOW + 1,
+  });
+
+  const response = await server.fetchAs(
+    'adult-parent',
+    `${BASE_URL}/api/hubs/parent/recent-sessions?learnerId=learner-history&limit=1`,
+  );
+  const payload = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(payload.recentSessions[0].id, 'grammar-manual-review');
+  assert.equal(payload.recentSessions[0].mistakeCount, 0);
+  assert.equal(payload.recentSessions[0].headline, 'Saved for review');
 
   server.close();
 });

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -738,11 +738,38 @@ function recentSessionHeadline(record) {
   const correctCard = cards.find((card) => String(card?.label || '').toLowerCase().includes('correct'));
   if (correctCard?.value != null) return String(correctCard.value);
   const answered = Number(summary.answered);
+  const scoredAnswered = Number(summary.scoredAnswered);
+  const nonScoredAnswered = Number(summary.nonScoredAnswered);
   const correct = Number(summary.correct);
+  const scoringDenominator = Number.isFinite(scoredAnswered)
+    ? scoredAnswered
+    : (Number.isFinite(answered) ? Math.max(0, answered - (Number.isFinite(nonScoredAnswered) ? nonScoredAnswered : 0)) : NaN);
+  if (Number.isFinite(scoringDenominator) && scoringDenominator > 0 && Number.isFinite(correct)) {
+    return `${correct}/${scoringDenominator}`;
+  }
+  if (Number.isFinite(nonScoredAnswered) && nonScoredAnswered > 0) {
+    return 'Saved for review';
+  }
   if (Number.isFinite(answered) && answered > 0 && Number.isFinite(correct)) {
     return `${correct}/${answered}`;
   }
   return '';
+}
+
+function recentSessionMistakeCount(record) {
+  const summary = record?.summary || {};
+  if (Array.isArray(summary.mistakes)) return summary.mistakes.length;
+  const correct = Number(summary.correct);
+  const scoredAnswered = Number(summary.scoredAnswered);
+  if (Number.isFinite(scoredAnswered)) {
+    return Math.max(0, scoredAnswered - (Number.isFinite(correct) ? correct : 0));
+  }
+  const answered = Number(summary.answered);
+  const nonScoredAnswered = Number(summary.nonScoredAnswered);
+  if (Number.isFinite(answered) && Number.isFinite(nonScoredAnswered)) {
+    return Math.max(0, answered - nonScoredAnswered - (Number.isFinite(correct) ? correct : 0));
+  }
+  return Math.max(0, (Number.isFinite(answered) ? answered : 0) - (Number.isFinite(correct) ? correct : 0));
 }
 
 function parentRecentSessionFromRecord(record) {
@@ -753,9 +780,7 @@ function parentRecentSessionFromRecord(record) {
     sessionKind: record.sessionKind,
     label: recentSessionLabel(record),
     updatedAt: Number(record.updatedAt) || Number(record.createdAt) || 0,
-    mistakeCount: Array.isArray(record?.summary?.mistakes)
-      ? record.summary.mistakes.length
-      : Math.max(0, (Number(record?.summary?.answered) || 0) - (Number(record?.summary?.correct) || 0)),
+    mistakeCount: recentSessionMistakeCount(record),
     headline: recentSessionHeadline(record),
   };
 }

--- a/worker/src/subjects/grammar/answer-spec.js
+++ b/worker/src/subjects/grammar/answer-spec.js
@@ -80,13 +80,25 @@ function comparePunctuationPattern(response, accepted, { optionalCommas = false 
   return false;
 }
 
-function mkMarkResult({ correct, score, maxScore, misconception, feedbackShort, feedbackLong, answerText, minimalHint }) {
+function mkMarkResult({
+  correct,
+  score,
+  maxScore,
+  misconception,
+  feedbackShort,
+  feedbackLong,
+  answerText,
+  minimalHint,
+  nonScored,
+  manualReviewOnly,
+}) {
+  const normalisedCorrect = Boolean(correct);
   return {
-    correct: Boolean(correct),
+    correct: normalisedCorrect,
     score: Number.isFinite(Number(score)) ? Number(score) : 0,
     maxScore: Number.isFinite(Number(maxScore)) ? Number(maxScore) : 1,
     misconception: misconception || null,
-    feedbackShort: feedbackShort || (correct ? 'Correct.' : 'Not quite.'),
+    feedbackShort: feedbackShort || (normalisedCorrect ? 'Correct.' : 'Not quite.'),
     feedbackLong: feedbackLong || '',
     answerText: safeString(answerText),
     // Default hint so direct callers (U7 transfer lane, future content-release
@@ -94,6 +106,8 @@ function mkMarkResult({ correct, score, maxScore, misconception, feedbackShort, 
     // legacy content.js mkResult guarantees. Adapter paths can still inject
     // a concept-specific hint via content.js markStringAnswer.
     minimalHint: minimalHint ?? DEFAULT_MINIMAL_HINT,
+    ...(nonScored ? { nonScored: true } : {}),
+    ...(manualReviewOnly ? { manualReviewOnly: true } : {}),
   };
 }
 
@@ -112,15 +126,17 @@ function markExact(spec, response) {
 }
 
 function markNormalisedText(spec, response) {
-  const accepted = Array.isArray(spec.golden) && spec.golden.length ? spec.golden[0] : '';
-  const correct = compareNormalisedText(response, accepted);
+  const accepted = Array.isArray(spec.golden) && spec.golden.length ? spec.golden : [];
+  const matched = accepted.find((entry) => compareNormalisedText(response, entry)) || null;
+  const answerText = spec.answerText || matched || accepted[0] || '';
+  const correct = Boolean(matched);
   return mkMarkResult({
     correct,
     score: correct ? (spec.maxScore || 1) : 0,
     maxScore: spec.maxScore || 1,
     misconception: correct ? null : (spec.misconception || 'misread_question'),
-    feedbackLong: spec.feedbackLong || (correct ? '' : `Correct answer: ${accepted}`),
-    answerText: spec.answerText || accepted,
+    feedbackLong: spec.feedbackLong || (correct ? '' : `Correct answer: ${accepted[0] || ''}`),
+    answerText,
     minimalHint: spec.minimalHint,
   });
 }
@@ -182,17 +198,19 @@ function markAcceptedSet(spec, response) {
 }
 
 function markPunctuationPattern(spec, response) {
-  const accepted = Array.isArray(spec.golden) && spec.golden.length ? spec.golden[0] : '';
-  const correct = comparePunctuationPattern(response, accepted, {
+  const accepted = Array.isArray(spec.golden) && spec.golden.length ? spec.golden : [];
+  const compareParams = {
     optionalCommas: Boolean(spec.params?.optionalCommas),
-  });
+  };
+  const matched = accepted.find((entry) => comparePunctuationPattern(response, entry, compareParams)) || null;
+  const correct = Boolean(matched);
   return mkMarkResult({
     correct,
     score: correct ? (spec.maxScore || 1) : 0,
     maxScore: spec.maxScore || 1,
     misconception: correct ? null : (spec.misconception || 'punctuation_precision'),
-    feedbackLong: spec.feedbackLong || (correct ? '' : `Correct answer: ${accepted}`),
-    answerText: spec.answerText || accepted,
+    feedbackLong: spec.feedbackLong || (correct ? '' : `Correct answer: ${accepted[0] || ''}`),
+    answerText: spec.answerText || matched || accepted[0] || '',
     minimalHint: spec.minimalHint,
   });
 }
@@ -241,6 +259,8 @@ function markManualReviewOnly(spec) {
     feedbackLong: spec.feedbackLong || 'This response is saved for teacher or parent review and is not auto-marked.',
     answerText: '',
     minimalHint: spec.minimalHint,
+    nonScored: true,
+    manualReviewOnly: true,
   });
 }
 

--- a/worker/src/subjects/grammar/commands.js
+++ b/worker/src/subjects/grammar/commands.js
@@ -4,6 +4,7 @@ import { buildCommandProjectionReadModel } from '../../projections/read-models.j
 import { projectGrammarRewards } from '../../projections/rewards.js';
 import { createServerGrammarEngine } from './engine.js';
 import { buildGrammarReadModel } from './read-models.js';
+import { GRAMMAR_CONTENT_RELEASE_ID } from './content.js';
 import { resolveProjectionInput } from '../projection-input.js';
 import {
   deriveGrammarConceptStarEvidence,
@@ -123,6 +124,7 @@ function deriveStarEvidenceEvents({ domainEvents, engineState, learnerId, gameSt
         type: GRAMMAR_EVENT_TYPES.STAR_EVIDENCE_UPDATED,
         subjectId: 'grammar',
         learnerId,
+        contentReleaseId: GRAMMAR_CONTENT_RELEASE_ID,
         conceptId: representativeConcept,
         monsterId,
         computedStars: starResult.stars,

--- a/worker/src/subjects/grammar/content.js
+++ b/worker/src/subjects/grammar/content.js
@@ -1901,6 +1901,8 @@ const TEMPLATES = [
     difficulty: 2,
     satsFriendly: true,
     isSelectedResponse: false,
+    requiresAnswerSpec: true,
+    answerSpecKind: "manualReviewOnly",
     tags: [
       "builder"
     ],
@@ -1931,28 +1933,19 @@ const TEMPLATES = [
             }
           ];
           const item = variants[seed % variants.length];
+          const answerSpec = manualReviewOnlyAnswerSpec({
+            feedbackLong:"Your noun phrase has been saved for review. It is not auto-marked for mastery."
+          });
           return makeBaseQuestion(this, seed, {
             marks:2,
+            answerSpec,
             stemHtml:`<p>Build a noun phrase of at least three words to complete the sentence below.</p><p><strong>${escapeHtml(item.sentence)}</strong></p>`,
             inputSpec:{ type:"multi", fields:item.fields },
             solutionLines:[
               "Choose a sensible determiner/adjective opening, then a noun, then extra detail attached to that noun.",
               `A strong answer is: ${item.final}.`
             ],
-            evaluate:(resp)=>{
-              const got = [resp.part1 || "", resp.part2 || "", resp.part3 || ""];
-              const correctBits = got.filter((x,i)=>x===item.answerParts[i]).length;
-              const score = correctBits === 3 ? 2 : correctBits >= 2 ? 1 : 0;
-              return mkResult({
-                correct: correctBits === 3,
-                score,
-                maxScore:2,
-                misconception: correctBits === 3 ? null : "noun_phrase_confusion",
-                feedbackShort: correctBits === 3 ? "Correct." : (score ? "Close, but not all the parts build a full noun phrase." : "Not quite."),
-                feedbackLong:`A strong answer is: ${item.final}.`,
-                answerText:item.final
-              });
-            }
+            evaluate:(resp)=>markByAnswerSpec(answerSpec, resp)
           });
         }
   },
@@ -2000,6 +1993,8 @@ const TEMPLATES = [
     difficulty: 2,
     satsFriendly: true,
     isSelectedResponse: false,
+    requiresAnswerSpec: true,
+    answerSpecKind: "punctuationPattern",
     tags: [
       "surgery"
     ],
@@ -2008,8 +2003,15 @@ const TEMPLATES = [
     ],
     generator(seed) {
           const item = FRONTED_FIX_ITEMS[seed % FRONTED_FIX_ITEMS.length];
+          const answerSpec = punctuationPatternAnswerSpec([item.answer], [item.raw], {
+            maxScore:2,
+            misconception:"fronted_adverbial_confusion",
+            feedbackLong:`The correct sentence is: ${item.answer}`,
+            answerText:item.answer
+          });
           return makeBaseQuestion(this, seed, {
             marks:2,
+            answerSpec,
             stemHtml:`<p>${item.prompt}</p><p><strong>${escapeHtml(item.raw)}</strong></p>`,
             inputSpec:{ type:"textarea", label:"Corrected sentence", placeholder:"Type the corrected sentence here." },
             solutionLines:[
@@ -2017,12 +2019,7 @@ const TEMPLATES = [
               "Add a comma after that opening phrase.",
               `Correct answer: ${item.answer}`
             ],
-            evaluate:(resp)=>markStringAnswer(resp.answer||"", [item.answer], {
-              maxScore:2,
-              misconception:"fronted_adverbial_confusion",
-              punctuationMisconception:"punctuation_precision",
-              feedbackLong:`The correct sentence is: ${item.answer}`
-            })
+            evaluate:(resp)=>markByAnswerSpec(answerSpec, resp)
           });
         }
   },
@@ -2071,6 +2068,8 @@ const TEMPLATES = [
     difficulty: 3,
     satsFriendly: true,
     isSelectedResponse: false,
+    requiresAnswerSpec: true,
+    answerSpecKind: "acceptedSet",
     tags: [
       "builder",
       "surgery"
@@ -2080,17 +2079,20 @@ const TEMPLATES = [
     ],
     generator(seed) {
           const item = CLAUSE_COMBINE_ITEMS[seed % CLAUSE_COMBINE_ITEMS.length];
+          const answerSpec = acceptedSetAnswerSpec(item.accepted, [], {
+            maxScore:2,
+            misconception:"subordinate_clause_confusion",
+            punctuationMisconception:"punctuation_precision",
+            feedbackLong:`A correct answer is: ${item.accepted[0]}`,
+            answerText:item.accepted[0]
+          });
           return makeBaseQuestion(this, seed, {
             marks:2,
+            answerSpec,
             stemHtml:`<p>${item.instruction}</p><p><strong>${item.parts[0]}</strong><br><strong>${item.parts[1]}</strong></p>`,
             inputSpec:{ type:"textarea", label:"Combined sentence", placeholder:"Write one complete sentence." },
             solutionLines:item.solution,
-            evaluate:(resp)=>markStringAnswer(resp.answer||"", item.accepted, {
-              maxScore:2,
-              misconception:"subordinate_clause_confusion",
-              punctuationMisconception:"punctuation_precision",
-              feedbackLong:`A correct answer is: ${item.accepted[0]}`
-            })
+            evaluate:(resp)=>markByAnswerSpec(answerSpec, resp)
           });
         }
   },
@@ -2210,6 +2212,8 @@ const TEMPLATES = [
     difficulty: 3,
     satsFriendly: true,
     isSelectedResponse: false,
+    requiresAnswerSpec: true,
+    answerSpecKind: "normalisedText",
     tags: [
       "surgery",
       "builder"
@@ -2219,17 +2223,19 @@ const TEMPLATES = [
     ],
     generator(seed) {
           const item = TENSE_REWRITE_ITEMS[seed % TENSE_REWRITE_ITEMS.length];
+          const answerSpec = normalisedTextAnswerSpec(item.accepted, [], {
+            maxScore:2,
+            misconception:"tense_confusion",
+            feedbackLong:`A correct answer is: ${item.accepted[0]}`,
+            answerText:item.accepted[0]
+          });
           return makeBaseQuestion(this, seed, {
             marks:2,
+            answerSpec,
             stemHtml:`<p>${item.instruction}</p><p><strong>${escapeHtml(item.raw)}</strong></p>`,
             inputSpec:{ type:"textarea", label:"Rewritten sentence", placeholder:"Write the full sentence." },
             solutionLines:item.solution,
-            evaluate:(resp)=>markStringAnswer(resp.answer||"", item.accepted, {
-              maxScore:2,
-              misconception:"tense_confusion",
-              punctuationMisconception:"punctuation_precision",
-              feedbackLong:`A correct answer is: ${item.accepted[0]}`
-            })
+            evaluate:(resp)=>markByAnswerSpec(answerSpec, resp)
           });
         }
   },
@@ -2361,6 +2367,8 @@ const TEMPLATES = [
     difficulty: 3,
     satsFriendly: true,
     isSelectedResponse: false,
+    requiresAnswerSpec: true,
+    answerSpecKind: "normalisedText",
     tags: [
       "builder",
       "surgery"
@@ -2370,17 +2378,19 @@ const TEMPLATES = [
     ],
     generator(seed) {
           const item = ACTIVE_PASSIVE_ITEMS[seed % ACTIVE_PASSIVE_ITEMS.length];
+          const answerSpec = normalisedTextAnswerSpec(item.accepted, [], {
+            maxScore:2,
+            misconception:"active_passive_confusion",
+            feedbackLong:`A correct answer is: ${item.accepted[0]}`,
+            answerText:item.accepted[0]
+          });
           return makeBaseQuestion(this, seed, {
             marks:2,
+            answerSpec,
             stemHtml:`<p>${item.instruction}</p><p><strong>${escapeHtml(item.raw)}</strong></p>`,
             inputSpec:{ type:"textarea", label:"Rewritten sentence", placeholder:"Write the full transformed sentence." },
             solutionLines:item.solution,
-            evaluate:(resp)=>markStringAnswer(resp.answer||"", item.accepted, {
-              maxScore:2,
-              misconception:"active_passive_confusion",
-              punctuationMisconception:"punctuation_precision",
-              feedbackLong:`A correct answer is: ${item.accepted[0]}`
-            })
+            evaluate:(resp)=>markByAnswerSpec(answerSpec, resp)
           });
         }
   },
@@ -2500,6 +2510,8 @@ const TEMPLATES = [
     difficulty: 3,
     satsFriendly: true,
     isSelectedResponse: false,
+    requiresAnswerSpec: true,
+    answerSpecKind: "punctuationPattern",
     tags: [
       "surgery"
     ],
@@ -2508,17 +2520,19 @@ const TEMPLATES = [
     ],
     generator(seed) {
           const item = PARENTHESIS_FIX_ITEMS[seed % PARENTHESIS_FIX_ITEMS.length];
+          const answerSpec = punctuationPatternAnswerSpec(item.accepted, [item.raw], {
+            maxScore:2,
+            misconception:"parenthesis_confusion",
+            feedbackLong:`A correct answer is: ${item.accepted[0]}`,
+            answerText:item.accepted[0]
+          });
           return makeBaseQuestion(this, seed, {
             marks:2,
+            answerSpec,
             stemHtml:`<p>${item.prompt}</p><p><strong>${escapeHtml(item.raw)}</strong></p>`,
             inputSpec:{ type:"textarea", label:"Corrected sentence", placeholder:"Type the corrected sentence." },
             solutionLines:item.solution,
-            evaluate:(resp)=>markStringAnswer(resp.answer||"", item.accepted, {
-              maxScore:2,
-              misconception:"parenthesis_confusion",
-              punctuationMisconception:"punctuation_precision",
-              feedbackLong:`A correct answer is: ${item.accepted[0]}`
-            })
+            evaluate:(resp)=>markByAnswerSpec(answerSpec, resp)
           });
         }
   },
@@ -2530,6 +2544,8 @@ const TEMPLATES = [
     difficulty: 3,
     satsFriendly: true,
     isSelectedResponse: false,
+    requiresAnswerSpec: true,
+    answerSpecKind: "punctuationPattern",
     tags: [
       "surgery"
     ],
@@ -2538,17 +2554,19 @@ const TEMPLATES = [
     ],
     generator(seed) {
           const item = SPEECH_FIX_ITEMS[seed % SPEECH_FIX_ITEMS.length];
+          const answerSpec = punctuationPatternAnswerSpec(item.accepted, [item.raw], {
+            maxScore:2,
+            misconception:"speech_punctuation_confusion",
+            feedbackLong:`A correct answer is: ${item.accepted[0]}`,
+            answerText:item.accepted[0]
+          });
           return makeBaseQuestion(this, seed, {
             marks:2,
+            answerSpec,
             stemHtml:`<p>${item.prompt}</p><p><strong>${escapeHtml(item.raw)}</strong></p>`,
             inputSpec:{ type:"textarea", label:"Correctly punctuated sentence", placeholder:"Type the corrected sentence." },
             solutionLines:item.solution,
-            evaluate:(resp)=>markStringAnswer(resp.answer||"", item.accepted, {
-              maxScore:2,
-              misconception:"speech_punctuation_confusion",
-              punctuationMisconception:"punctuation_precision",
-              feedbackLong:`A correct answer is: ${item.accepted[0]}`
-            })
+            evaluate:(resp)=>markByAnswerSpec(answerSpec, resp)
           });
         }
   },
@@ -2633,6 +2651,8 @@ const TEMPLATES = [
     difficulty: 2,
     satsFriendly: true,
     isSelectedResponse: false,
+    requiresAnswerSpec: true,
+    answerSpecKind: "manualReviewOnly",
     tags: [
       "surgery"
     ],
@@ -2641,17 +2661,16 @@ const TEMPLATES = [
     ],
     generator(seed) {
           const item = STANDARD_FIX_ITEMS[seed % STANDARD_FIX_ITEMS.length];
+          const answerSpec = manualReviewOnlyAnswerSpec({
+            feedbackLong:"Your Standard English rewrite has been saved for review. It is not auto-marked for mastery."
+          });
           return makeBaseQuestion(this, seed, {
             marks:2,
+            answerSpec,
             stemHtml:`<p>${item.instruction}</p><p><strong>${escapeHtml(item.raw)}</strong></p>`,
             inputSpec:{ type:"textarea", label:"Corrected sentence", placeholder:"Write the corrected sentence." },
             solutionLines:item.solution,
-            evaluate:(resp)=>markStringAnswer(resp.answer||"", item.accepted, {
-              maxScore:2,
-              misconception:"standard_english_confusion",
-              punctuationMisconception:"punctuation_precision",
-              feedbackLong:`A correct answer is: ${item.accepted[0]}`
-            })
+            evaluate:(resp)=>markByAnswerSpec(answerSpec, resp)
           });
         }
   },
@@ -2664,6 +2683,8 @@ const TEMPLATES = [
     satsFriendly: true,
     isSelectedResponse: false,
     generative: true,
+    requiresAnswerSpec: true,
+    answerSpecKind: "punctuationPattern",
     tags: [
       "surgery"
     ],
@@ -2676,8 +2697,15 @@ const TEMPLATES = [
           const clause = proceduralSubjectObject(rng).clause;
           const raw = ensureSentenceEnd(`${adv} ${clause}`);
           const accepted = [ensureSentenceEnd(`${adv}, ${clause}`)];
+          const answerSpec = punctuationPatternAnswerSpec(accepted, [raw], {
+            maxScore:2,
+            misconception:"fronted_adverbial_confusion",
+            feedbackLong:`A correct answer is: ${accepted[0]}`,
+            answerText:accepted[0]
+          });
           return makeBaseQuestion(this, seed, {
             marks:2,
+            answerSpec,
             stemHtml:`<p>Rewrite the sentence with the punctuation corrected.</p><p><strong>${escapeHtml(raw)}</strong></p>`,
             inputSpec:{ type:"textarea", label:"Corrected sentence", placeholder:"Write the corrected sentence." },
             solutionLines:[
@@ -2686,12 +2714,7 @@ const TEMPLATES = [
               `A correct answer is: ${accepted[0]}`
             ],
             contrastHtml:`<div class="contrast-card"><strong>Useful contrast</strong><p style="margin:8px 0 4px;">${escapeHtml(accepted[0])}</p><p style="margin:0 0 4px;">${escapeHtml(raw)}</p><p style="margin:0;">The comma separates the opening adverbial from the main clause.</p></div>`,
-            evaluate:(resp)=>markStringAnswer(resp.answer || "", accepted, {
-              maxScore:2,
-              misconception:"fronted_adverbial_confusion",
-              punctuationMisconception:"punctuation_precision",
-              feedbackLong:`A correct answer is: ${accepted[0]}`
-            })
+            evaluate:(resp)=>markByAnswerSpec(answerSpec, resp)
           });
         }
   },
@@ -2750,6 +2773,8 @@ const TEMPLATES = [
     satsFriendly: true,
     isSelectedResponse: false,
     generative: true,
+    requiresAnswerSpec: true,
+    answerSpecKind: "punctuationPattern",
     tags: [
       "surgery"
     ],
@@ -2761,8 +2786,15 @@ const TEMPLATES = [
           const item = pick(rng, EXTRA_LEXICON.colonLists);
           const raw = ensureSentenceEnd(`${item.intro} ${item.items.join(", ")}`);
           const accepted = [ensureSentenceEnd(`${item.intro}: ${item.items.join(", ")}`)];
+          const answerSpec = punctuationPatternAnswerSpec(accepted, [raw], {
+            maxScore:2,
+            misconception:"boundary_punctuation_confusion",
+            feedbackLong:`A correct answer is: ${accepted[0]}`,
+            answerText:accepted[0]
+          });
           return makeBaseQuestion(this, seed, {
             marks:2,
+            answerSpec,
             stemHtml:`<p>Rewrite the sentence with a colon in the correct place.</p><p><strong>${escapeHtml(raw)}</strong></p>`,
             inputSpec:{ type:"textarea", label:"Corrected sentence", placeholder:"Write the corrected sentence." },
             solutionLines:[
@@ -2770,12 +2802,7 @@ const TEMPLATES = [
               "A colon can introduce the list that follows.",
               `A correct answer is: ${accepted[0]}`
             ],
-            evaluate:(resp)=>markStringAnswer(resp.answer || "", accepted, {
-              maxScore:2,
-              misconception:"boundary_punctuation_confusion",
-              punctuationMisconception:"punctuation_precision",
-              feedbackLong:`A correct answer is: ${accepted[0]}`
-            })
+            evaluate:(resp)=>markByAnswerSpec(answerSpec, resp)
           });
         }
   },
@@ -2788,6 +2815,8 @@ const TEMPLATES = [
     satsFriendly: true,
     isSelectedResponse: false,
     generative: true,
+    requiresAnswerSpec: true,
+    answerSpecKind: "punctuationPattern",
     tags: [
       "surgery"
     ],
@@ -2803,8 +2832,15 @@ const TEMPLATES = [
             `${pair[0]} — ${pair[1]}.`,
             `${pair[0]} - ${pair[1]}.`
           ]);
+          const answerSpec = punctuationPatternAnswerSpec(accepted, [raw], {
+            maxScore:2,
+            misconception:"boundary_punctuation_confusion",
+            feedbackLong:`A correct answer is: ${accepted[0]}`,
+            answerText:accepted[0]
+          });
           return makeBaseQuestion(this, seed, {
             marks:2,
+            answerSpec,
             stemHtml:`<p>Rewrite the sentence with a dash in the correct place.</p><p><strong>${escapeHtml(raw)}</strong></p>`,
             inputSpec:{ type:"textarea", label:"Corrected sentence", placeholder:"Write the corrected sentence." },
             solutionLines:[
@@ -2812,12 +2848,7 @@ const TEMPLATES = [
               "A dash can mark that strong break.",
               `A correct answer is: ${accepted[0]}`
             ],
-            evaluate:(resp)=>markStringAnswer(resp.answer || "", accepted, {
-              maxScore:2,
-              misconception:"boundary_punctuation_confusion",
-              punctuationMisconception:"punctuation_precision",
-              feedbackLong:`A correct answer is: ${accepted[0]}`
-            })
+            evaluate:(resp)=>markByAnswerSpec(answerSpec, resp)
           });
         }
   },
@@ -2869,6 +2900,8 @@ const TEMPLATES = [
     satsFriendly: true,
     isSelectedResponse: false,
     generative: true,
+    requiresAnswerSpec: true,
+    answerSpecKind: "punctuationPattern",
     tags: [
       "surgery"
     ],
@@ -2911,17 +2944,19 @@ const TEMPLATES = [
               `A correct answer is: ${accepted[0]}`
             ];
           }
+          const answerSpec = punctuationPatternAnswerSpec(accepted, [raw], {
+            maxScore:2,
+            misconception:"speech_punctuation_confusion",
+            feedbackLong:`A correct answer is: ${accepted[0]}`,
+            answerText:accepted[0]
+          });
           return makeBaseQuestion(this, seed, {
             marks:2,
+            answerSpec,
             stemHtml:`<p>Punctuate the direct speech correctly.</p><p><strong>${escapeHtml(raw)}</strong></p>`,
             inputSpec:{ type:"textarea", label:"Correctly punctuated sentence", placeholder:"Type the corrected sentence." },
             solutionLines,
-            evaluate:(resp)=>markStringAnswer(resp.answer || "", accepted, {
-              maxScore:2,
-              misconception:"speech_punctuation_confusion",
-              punctuationMisconception:"punctuation_precision",
-              feedbackLong:`A correct answer is: ${accepted[0]}`
-            })
+            evaluate:(resp)=>markByAnswerSpec(answerSpec, resp)
           });
         }
   },
@@ -3023,6 +3058,8 @@ const TEMPLATES = [
     satsFriendly: true,
     isSelectedResponse: false,
     generative: true,
+    requiresAnswerSpec: true,
+    answerSpecKind: "normalisedText",
     tags: [
       "surgery"
     ],
@@ -3032,8 +3069,15 @@ const TEMPLATES = [
     generator(seed) {
           const rng = mulberry32(seed);
           const item = generateStandardEnglishCase(rng);
+          const answerSpec = normalisedTextAnswerSpec([item.correct], [item.raw], {
+            maxScore:2,
+            misconception:"standard_english_confusion",
+            feedbackLong:`A correct answer is: ${item.correct}`,
+            answerText:item.correct
+          });
           return makeBaseQuestion(this, seed, {
             marks:2,
+            answerSpec,
             stemHtml:`<p>Rewrite the sentence in Standard English.</p><p><strong>${escapeHtml(item.raw)}</strong></p>`,
             inputSpec:{ type:"textarea", label:"Corrected sentence", placeholder:"Write the corrected sentence." },
             solutionLines:[
@@ -3041,11 +3085,7 @@ const TEMPLATES = [
               "Replace it with the Standard English verb form.",
               `A correct answer is: ${item.correct}`
             ],
-            evaluate:(resp)=>markStringAnswer(resp.answer || "", [item.correct], {
-              maxScore:2,
-              misconception:"standard_english_confusion",
-              feedbackLong:`A correct answer is: ${item.correct}`
-            })
+            evaluate:(resp)=>markByAnswerSpec(answerSpec, resp)
           });
         }
   },
@@ -3198,6 +3238,8 @@ const TEMPLATES = [
     satsFriendly: true,
     isSelectedResponse: false,
     generative: true,
+    requiresAnswerSpec: true,
+    answerSpecKind: "normalisedText",
     tags: [
       "builder"
     ],
@@ -3207,8 +3249,15 @@ const TEMPLATES = [
     generator(seed) {
           const rng = mulberry32(seed);
           const item = generatePassiveCase(rng);
+          const answerSpec = normalisedTextAnswerSpec(item.accepted, [item.raw], {
+            maxScore:2,
+            misconception:"active_passive_confusion",
+            feedbackLong:`A correct answer is: ${item.accepted[0]}`,
+            answerText:item.accepted[0]
+          });
           return makeBaseQuestion(this, seed, {
             marks:2,
+            answerSpec,
             stemHtml:`<p>Rewrite the sentence in the active voice.</p><p><strong>${escapeHtml(item.raw)}</strong></p>`,
             inputSpec:{ type:"textarea", label:"Rewritten sentence", placeholder:"Write the full sentence." },
             solutionLines:[
@@ -3216,11 +3265,7 @@ const TEMPLATES = [
               "Move that doer into the subject position and keep the tense steady.",
               `A correct answer is: ${item.accepted[0]}`
             ],
-            evaluate:(resp)=>markStringAnswer(resp.answer || "", item.accepted, {
-              maxScore:2,
-              misconception:"active_passive_confusion",
-              feedbackLong:`A correct answer is: ${item.accepted[0]}`
-            })
+            evaluate:(resp)=>markByAnswerSpec(answerSpec, resp)
           });
         }
   },
@@ -3261,6 +3306,8 @@ const TEMPLATES = [
     satsFriendly: true,
     isSelectedResponse: false,
     generative: true,
+    requiresAnswerSpec: true,
+    answerSpecKind: "manualReviewOnly",
     tags: [
       "builder"
     ],
@@ -3273,8 +3320,12 @@ const TEMPLATES = [
           const adv = pick(rng, EXTRA_LEXICON.fronted);
           const clause = proceduralSubjectObject(rng).clause;
           const accepted = [ensureSentenceEnd(`${adv}, ${clause}`)];
+          const answerSpec = manualReviewOnlyAnswerSpec({
+            feedbackLong:"Your fronted-adverbial sentence has been saved for review. It is not auto-marked for mastery."
+          });
           return makeBaseQuestion(this, seed, {
             marks:2,
+            answerSpec,
             stemHtml:`<p>Use this opening phrase and clause to build one correct sentence.</p><p><strong>Opening phrase:</strong> ${escapeHtml(adv)}</p><p><strong>Main clause:</strong> ${escapeHtml(capFirst(clause))}</p>`,
             inputSpec:{ type:"textarea", label:"Your sentence", placeholder:"Write one complete sentence." },
             solutionLines:[
@@ -3282,12 +3333,7 @@ const TEMPLATES = [
               "Add a comma after it before the main clause begins.",
               `A correct answer is: ${accepted[0]}`
             ],
-            evaluate:(resp)=>markStringAnswer(resp.answer || "", accepted, {
-              maxScore:2,
-              misconception:"fronted_adverbial_confusion",
-              punctuationMisconception:"punctuation_precision",
-              feedbackLong:`A correct answer is: ${accepted[0]}`
-            })
+            evaluate:(resp)=>markByAnswerSpec(answerSpec, resp)
           });
         }
   },
@@ -3494,6 +3540,8 @@ const TEMPLATES = [
     satsFriendly: true,
     isSelectedResponse: false,
     generative: true,
+    requiresAnswerSpec: true,
+    answerSpecKind: "manualReviewOnly",
     tags: [
       "builder"
     ],
@@ -3516,8 +3564,12 @@ const TEMPLATES = [
             const noun = pick(rng, nouns);
             const sentence = pick(rng, endings);
             const correct = `the ${sizeWord} ${colourWord} ${noun}`;
+            const answerSpec = manualReviewOnlyAnswerSpec({
+              feedbackLong:"Your expanded noun phrase has been saved for review. It is not auto-marked for mastery."
+            });
             return makeBaseQuestion(this, seed, {
               marks:2,
+              answerSpec,
               stemHtml:`<p>Use all the words to build an <strong>expanded noun phrase</strong> that could complete the sentence.</p><p><strong>Words:</strong> the / ${sizeWord} / ${colourWord} / ${noun}</p><p><strong>${sentence}</strong></p>`,
               inputSpec:{ type:"text", label:"Expanded noun phrase", placeholder:"Type the noun phrase." },
               solutionLines:[
@@ -3525,12 +3577,7 @@ const TEMPLATES = [
                 `A clear expanded noun phrase is: ${correct}.`,
                 "The whole phrase centres on the noun at the end."
               ],
-              evaluate:(resp)=>markStringAnswer(resp.answer || "", [correct], {
-                maxScore:2,
-                misconception:"noun_phrase_confusion",
-                punctuationMisconception:"punctuation_precision",
-                feedbackLong:`A correct expanded noun phrase is: ${correct}.`
-              })
+              evaluate:(resp)=>markByAnswerSpec(answerSpec, resp)
             });
           }
   },
@@ -3543,6 +3590,8 @@ const TEMPLATES = [
     satsFriendly: true,
     isSelectedResponse: false,
     generative: true,
+    requiresAnswerSpec: true,
+    answerSpecKind: "acceptedSet",
     tags: [
       "builder"
     ],
@@ -3599,8 +3648,16 @@ const TEMPLATES = [
                 `${capFirst(sub)} if ${main}.`
               ]);
             }
+            const answerSpec = acceptedSetAnswerSpec(accepted, [], {
+              maxScore:2,
+              misconception:"subordinate_clause_confusion",
+              punctuationMisconception:"punctuation_precision",
+              feedbackLong:`A correct answer is: ${accepted[0]}`,
+              answerText:accepted[0]
+            });
             return makeBaseQuestion(this, seed, {
               marks:2,
+              answerSpec,
               stemHtml:`<p>Combine these ideas into one sentence using <strong>${conjunction}</strong>.</p><ul><li>${capFirst(main)}.</li><li>${capFirst(sub)}.</li></ul>`,
               inputSpec:{ type:"textarea", label:"Combined sentence", placeholder:"Write one combined sentence." },
               solutionLines:[
@@ -3608,12 +3665,7 @@ const TEMPLATES = [
                 accepted[0],
                 "Check that the sentence is complete and punctuated as one whole sentence."
               ],
-              evaluate:(resp)=>markStringAnswer(resp.answer || "", accepted, {
-                maxScore:2,
-                misconception:"subordinate_clause_confusion",
-                punctuationMisconception:"punctuation_precision",
-                feedbackLong:`A correct answer is: ${accepted[0]}`
-              })
+              evaluate:(resp)=>markByAnswerSpec(answerSpec, resp)
             });
           }
   },
@@ -3627,6 +3679,8 @@ const TEMPLATES = [
     isSelectedResponse: false,
     generative: true,
     punctStage: "repair",
+    requiresAnswerSpec: true,
+    answerSpecKind: "punctuationPattern",
     tags: [
       "surgery"
     ],
@@ -3657,8 +3711,15 @@ const TEMPLATES = [
               }
             ];
             const item = items[seed % items.length];
+            const answerSpec = punctuationPatternAnswerSpec([item.accepted], [item.raw], {
+              maxScore:2,
+              misconception:"parenthesis_confusion",
+              feedbackLong:`A correct answer is: ${item.accepted}`,
+              answerText:item.accepted
+            });
             return makeBaseQuestion(this, seed, {
               marks:2,
+              answerSpec,
               stemHtml:`<p>Add commas to show the <strong>parenthesis</strong>.</p><p><strong>${escapeHtml(item.raw)}</strong></p>`,
               inputSpec:{ type:"textarea", label:"Corrected sentence", placeholder:"Type the corrected sentence." },
               solutionLines:[
@@ -3666,12 +3727,7 @@ const TEMPLATES = [
                 item.why,
                 `A correct answer is: ${item.accepted}`
               ],
-              evaluate:(resp)=>markStringAnswer(resp.answer || "", [item.accepted], {
-                maxScore:2,
-                misconception:"parenthesis_confusion",
-                punctuationMisconception:"punctuation_precision",
-                feedbackLong:`A correct answer is: ${item.accepted}`
-              })
+              evaluate:(resp)=>markByAnswerSpec(answerSpec, resp)
             });
           }
   },
@@ -3685,6 +3741,8 @@ const TEMPLATES = [
     isSelectedResponse: false,
     generative: true,
     punctStage: "produce",
+    requiresAnswerSpec: true,
+    answerSpecKind: "punctuationPattern",
     tags: [
       "surgery"
     ],
@@ -3715,8 +3773,15 @@ const TEMPLATES = [
               }
             ];
             const item = items[seed % items.length];
+            const answerSpec = punctuationPatternAnswerSpec([item.accepted], [item.raw], {
+              maxScore:2,
+              misconception:"punctuation_precision",
+              feedbackLong:`A correct answer is: ${item.accepted}`,
+              answerText:item.accepted
+            });
             return makeBaseQuestion(this, seed, {
               marks:2,
+              answerSpec,
               stemHtml:`<p>Rewrite the sentence with a <strong>hyphen</strong> to make the meaning clear.</p><p><strong>${escapeHtml(item.raw)}</strong></p>`,
               inputSpec:{ type:"textarea", label:"Corrected sentence", placeholder:"Type the corrected sentence." },
               solutionLines:[
@@ -3724,12 +3789,7 @@ const TEMPLATES = [
                 item.why,
                 `A correct answer is: ${item.accepted}`
               ],
-              evaluate:(resp)=>markStringAnswer(resp.answer || "", [item.accepted], {
-                maxScore:2,
-                misconception:"punctuation_precision",
-                punctuationMisconception:"punctuation_precision",
-                feedbackLong:`A correct answer is: ${item.accepted}`
-              })
+              evaluate:(resp)=>markByAnswerSpec(answerSpec, resp)
             });
           }
   },
@@ -4140,6 +4200,8 @@ const TEMPLATES = [
     isSelectedResponse: false,
     generative: true,
     punctStage: "produce",
+    requiresAnswerSpec: true,
+    answerSpecKind: "normalisedText",
     tags: [
       "builder"
     ],
@@ -4167,8 +4229,15 @@ const TEMPLATES = [
               accepted = `the ${owner}'s ${item}`;
               why = "An irregular plural owner that does not end in s usually takes apostrophe + s.";
             }
+            const answerSpec = normalisedTextAnswerSpec([accepted], [prompt], {
+              maxScore:2,
+              misconception:"apostrophe_possession_confusion",
+              feedbackLong:`A correct answer is: ${accepted}`,
+              answerText:accepted
+            });
             return makeBaseQuestion(this, seed, {
               marks:2,
+              answerSpec,
               stemHtml:`<p>Rewrite this phrase using the correct <strong>possessive apostrophe</strong>.</p><p><strong>${escapeHtml(prompt)}</strong></p>`,
               inputSpec:{ type:"text", label:"Rewritten phrase", placeholder:"Type the rewritten phrase." },
               solutionLines:[
@@ -4176,12 +4245,7 @@ const TEMPLATES = [
                 why,
                 `A correct answer is: ${accepted}`
               ],
-              evaluate:(resp)=>markStringAnswer(resp.answer || "", [accepted], {
-                maxScore:2,
-                misconception:"apostrophe_possession_confusion",
-                punctuationMisconception:"punctuation_precision",
-                feedbackLong:`A correct answer is: ${accepted}`
-              })
+              evaluate:(resp)=>markByAnswerSpec(answerSpec, resp)
             });
           }
   }
@@ -4385,6 +4449,46 @@ function choiceResult(resp, correct, maxScore, why, misconception, answerText) {
     feedbackLong: why,
     answerText: answerText || correct
   });
+}
+
+function answerSpecBase(kind, golden, nearMiss, opts = {}) {
+  const misconception = opts.misconception || "misread_question";
+  return {
+    kind,
+    golden: dedupePlain(Array.isArray(golden) ? golden : [golden]),
+    nearMiss: dedupePlain(nearMiss || []),
+    maxScore: opts.maxScore || 1,
+    misconception,
+    feedbackLong: opts.feedbackLong || "",
+    answerText: opts.answerText || (Array.isArray(golden) ? golden[0] : golden) || "",
+    minimalHint: MINIMAL_HINTS[misconception] || "Check the sentence structure and the instruction again.",
+    ...(opts.punctuationMisconception ? { punctuationMisconception: opts.punctuationMisconception } : {}),
+    ...(opts.params ? { params: opts.params } : {})
+  };
+}
+
+function normalisedTextAnswerSpec(correct, nearMiss, opts = {}) {
+  return answerSpecBase("normalisedText", correct, nearMiss, opts);
+}
+
+function acceptedSetAnswerSpec(accepted, nearMiss, opts = {}) {
+  return answerSpecBase("acceptedSet", accepted, nearMiss, {
+    maxScore: 2,
+    ...opts
+  });
+}
+
+function punctuationPatternAnswerSpec(accepted, nearMiss, opts = {}) {
+  return answerSpecBase("punctuationPattern", accepted, nearMiss, opts);
+}
+
+function manualReviewOnlyAnswerSpec(opts = {}) {
+  return {
+    kind: "manualReviewOnly",
+    maxScore: 0,
+    feedbackLong: opts.feedbackLong || "Your response has been saved for teacher or parent review.",
+    minimalHint: opts.minimalHint || "This writing response is for review, not automatic marking."
+  };
 }
 
 function exactAnswerSpec(correct, nearMiss, opts = {}) {
@@ -4692,7 +4796,7 @@ export function grammarQuestionVariantSignature(question) {
   return `grammar-v1:${stableStringHash(JSON.stringify(payload))}`;
 }
 
-export const GRAMMAR_CONTENT_RELEASE_ID = 'grammar-qg-p1-2026-04-28';
+export const GRAMMAR_CONTENT_RELEASE_ID = 'grammar-qg-p2-2026-04-28';
 export const GRAMMAR_MISCONCEPTIONS = Object.freeze(MISCONCEPTIONS);
 export const GRAMMAR_MINIMAL_HINTS = Object.freeze(MINIMAL_HINTS);
 export const GRAMMAR_QUESTION_TYPES = Object.freeze(QUESTION_TYPES);

--- a/worker/src/subjects/grammar/engine.js
+++ b/worker/src/subjects/grammar/engine.js
@@ -578,7 +578,7 @@ function enqueueRetry(state, item, result, nowTs) {
 
 function templateFitsMode(template, mode) {
   if (!template) return false;
-  if (mode === 'satsset' && !template.satsFriendly) return false;
+  if (mode === 'satsset' && (!template.satsFriendly || template.answerSpecKind === 'manualReviewOnly')) return false;
   if (mode === 'surgery' && !(template.tags || []).includes('surgery')) return false;
   if (mode === 'builder' && !(template.tags || []).includes('builder')) return false;
   return true;
@@ -858,6 +858,45 @@ function practiceSessionRecord(learnerId, state, latestSession, nowTs) {
   return buildActiveRecord(learnerId, state, nowTs) || buildCompletedRecord(learnerId, state, latestSession, nowTs);
 }
 
+function buildAbandonedRecord(learnerId, latestSession, nowTs) {
+  if (!latestSession?.id || latestSession.status !== 'active') return null;
+  return normalisePracticeSessionRecord({
+    id: latestSession.id,
+    learnerId,
+    subjectId: SUBJECT_ID,
+    sessionKind: latestSession.sessionKind || latestSession.mode || 'smart',
+    status: 'abandoned',
+    sessionState: latestSession.sessionState || null,
+    summary: latestSession.summary || null,
+    createdAt: latestSession.createdAt || nowTs,
+    updatedAt: nowTs,
+  });
+}
+
+function isStaleGrammarItem(item) {
+  if (!item) return false;
+  return item.contentReleaseId !== GRAMMAR_CONTENT_RELEASE_ID;
+}
+
+function hasStaleActiveContentRelease(state) {
+  if (!state?.session || !['session', 'feedback'].includes(state.phase)) return false;
+  if (isStaleGrammarItem(state.session.currentItem)) return true;
+  const questions = state.session.miniTest?.questions;
+  if (!Array.isArray(questions)) return false;
+  return questions.some((entry) => isStaleGrammarItem(entry?.item));
+}
+
+function clearStaleContentSession(state) {
+  state.contentReleaseId = GRAMMAR_CONTENT_RELEASE_ID;
+  state.phase = 'dashboard';
+  state.awaitingAdvance = false;
+  state.session = null;
+  state.feedback = null;
+  state.summary = null;
+  state.error = '';
+  return [];
+}
+
 function miniSetSeeds(baseSeed, size) {
   return Array.from({ length: size }, (_, index) => (baseSeed + index * 104729) >>> 0);
 }
@@ -1003,6 +1042,8 @@ function startSession(state, payload, nowTs, learnerId) {
       startedAt: nowTs,
       targetCount: questions.length,
       answered: 0,
+      scoredAnswered: 0,
+      nonScoredAnswered: 0,
       correct: 0,
       totalScore: 0,
       totalMarks: items.reduce((sum, item) => sum + (Number(item.marks) || 1), 0),
@@ -1060,6 +1101,8 @@ function startSession(state, payload, nowTs, learnerId) {
     startedAt: nowTs,
     targetCount: sessionGoal.targetCount,
     answered: 0,
+    scoredAnswered: 0,
+    nonScoredAnswered: 0,
     correct: 0,
     totalScore: 0,
     totalMarks: 0,
@@ -1082,12 +1125,19 @@ function startSession(state, payload, nowTs, learnerId) {
 
 function completionSummary(state, nowTs) {
   const session = state.session || {};
+  const answered = Number(session.answered) || 0;
+  const nonScoredAnswered = clamp(Math.floor(Number(session.nonScoredAnswered) || 0), 0, answered);
+  const scoredAnswered = Object.prototype.hasOwnProperty.call(session, 'scoredAnswered')
+    ? clamp(Math.floor(Number(session.scoredAnswered) || 0), 0, answered)
+    : Math.max(0, answered - nonScoredAnswered);
   return {
     sessionId: session.id || `grammar-${nowTs}`,
     mode: session.mode || 'smart',
     startedAt: session.startedAt || nowTs,
     completedAt: nowTs,
-    answered: Number(session.answered) || 0,
+    answered,
+    scoredAnswered,
+    nonScoredAnswered,
     correct: Number(session.correct) || 0,
     totalScore: Number(session.totalScore) || 0,
     totalMarks: Number(session.totalMarks) || 0,
@@ -1120,6 +1170,8 @@ function completeSession(state, nowTs, command) {
     sessionId: summary.sessionId,
     mode: summary.mode,
     answered: summary.answered,
+    scoredAnswered: summary.scoredAnswered,
+    nonScoredAnswered: summary.nonScoredAnswered,
     correct: summary.correct,
     totalScore: summary.totalScore,
     totalMarks: summary.totalMarks,
@@ -1211,6 +1263,10 @@ function unansweredMiniTestResult(item) {
   };
 }
 
+function isNonScoredGrammarResult(result) {
+  return Boolean(result && (result.nonScored === true || result.manualReviewOnly === true));
+}
+
 function finishMiniTest(state, nowTs, command, { timedOut = false } = {}) {
   if (!isActiveMiniTestSession(state)) {
     throw new BadRequestError('This Grammar mini-test is no longer active.', {
@@ -1222,14 +1278,14 @@ function finishMiniTest(state, nowTs, command, { timedOut = false } = {}) {
   const questions = Array.isArray(session.miniTest?.questions) ? session.miniTest.questions : [];
   const events = [];
   let answered = 0;
+  let scoredAnswered = 0;
+  let nonScoredAnswered = 0;
   let correct = 0;
   let totalScore = 0;
   let totalMarks = 0;
 
   questions.forEach((entry, index) => {
     const item = entry?.item;
-    const maxMarks = Number(item?.marks) || 1;
-    totalMarks += maxMarks;
     if (entry?.answered && item) {
       const applied = applyGrammarAttemptToState(state, {
         learnerId: command.learnerId,
@@ -1246,10 +1302,20 @@ function finishMiniTest(state, nowTs, command, { timedOut = false } = {}) {
         result: cloneSerialisable(applied.result) || {},
       };
       answered += 1;
-      if (applied.result.correct) correct += 1;
-      totalScore += Number(applied.result.score) || 0;
+      if (!isNonScoredGrammarResult(applied.result)) {
+        scoredAnswered += 1;
+        const maxMarks = Number(item?.marks) || 1;
+        if (applied.result.correct) correct += 1;
+        totalScore += Number(applied.result.score) || 0;
+        totalMarks += Number(applied.result.maxScore) || maxMarks;
+      } else {
+        nonScoredAnswered += 1;
+      }
       events.push(...applied.events);
     } else {
+      const question = item ? createGrammarQuestion({ templateId: item.templateId, seed: item.seed }) : null;
+      const isNonScoredQuestion = question?.answerSpec?.kind === 'manualReviewOnly';
+      if (!isNonScoredQuestion) totalMarks += Number(item?.marks) || 1;
       entry.marked = {
         response: cloneSerialisable(entry?.response) || {},
         result: unansweredMiniTestResult(item),
@@ -1261,6 +1327,8 @@ function finishMiniTest(state, nowTs, command, { timedOut = false } = {}) {
   session.miniTest.finishedAt = nowTs;
   session.miniTest.timedOut = Boolean(timedOut);
   session.answered = answered;
+  session.scoredAnswered = scoredAnswered;
+  session.nonScoredAnswered = nonScoredAnswered;
   session.correct = correct;
   session.totalScore = totalScore;
   session.totalMarks = totalMarks;
@@ -1268,6 +1336,8 @@ function finishMiniTest(state, nowTs, command, { timedOut = false } = {}) {
   const summary = {
     ...completionSummary(state, nowTs),
     answered,
+    scoredAnswered,
+    nonScoredAnswered,
     correct,
     totalScore,
     totalMarks,
@@ -1300,6 +1370,8 @@ function finishMiniTest(state, nowTs, command, { timedOut = false } = {}) {
     sessionId: summary.sessionId,
     mode: summary.mode,
     answered: summary.answered,
+    scoredAnswered: summary.scoredAnswered,
+    nonScoredAnswered: summary.nonScoredAnswered,
     correct: summary.correct,
     totalScore: summary.totalScore,
     totalMarks: summary.totalMarks,
@@ -1546,6 +1618,8 @@ export function applyGrammarAttemptToState(state, {
     supportLevel: attemptSupport.supportLevelAtScoring,
     attempts,
   });
+  const nonScoredAttempt = isNonScoredGrammarResult(result);
+  const scoringQuality = nonScoredAttempt ? 0 : quality;
   const conceptIds = (question.skillIds || []).slice();
   const template = grammarTemplateById(question.templateId);
   const generatorFamilyId = grammarTemplateGeneratorFamilyId(template || { id: question.templateId });
@@ -1555,15 +1629,17 @@ export function applyGrammarAttemptToState(state, {
     grammarConceptStatus(state.mastery.concepts[conceptId] || defaultMasteryNode(), nowTs),
   ]));
 
-  for (const conceptId of conceptIds) {
-    updateNodeFromQuality(ensureNode(state.mastery.concepts, conceptId), quality, nowTs);
-  }
-  updateNodeFromQuality(ensureNode(state.mastery.templates, question.templateId), quality, nowTs);
-  updateNodeFromQuality(ensureNode(state.mastery.questionTypes, question.questionType), quality, nowTs);
-  updateNodeFromQuality(ensureNode(state.mastery.items, question.itemId), quality, nowTs);
+  if (!nonScoredAttempt) {
+    for (const conceptId of conceptIds) {
+      updateNodeFromQuality(ensureNode(state.mastery.concepts, conceptId), quality, nowTs);
+    }
+    updateNodeFromQuality(ensureNode(state.mastery.templates, question.templateId), quality, nowTs);
+    updateNodeFromQuality(ensureNode(state.mastery.questionTypes, question.questionType), quality, nowTs);
+    updateNodeFromQuality(ensureNode(state.mastery.items, question.itemId), quality, nowTs);
 
-  if (result.misconception) bumpMisconception(state, result.misconception, nowTs);
-  if (!result.correct || quality < 4) enqueueRetry(state, serialiseGrammarQuestion(question), result, nowTs);
+    if (result.misconception) bumpMisconception(state, result.misconception, nowTs);
+    if (!result.correct || quality < 4) enqueueRetry(state, serialiseGrammarQuestion(question), result, nowTs);
+  }
 
   const attempt = {
     contentReleaseId: GRAMMAR_CONTENT_RELEASE_ID,
@@ -1576,6 +1652,7 @@ export function applyGrammarAttemptToState(state, {
     conceptIds,
     response: cloneSerialisable(normalisedResponse) || {},
     result: cloneSerialisable(result) || {},
+    ...(nonScoredAttempt ? { nonScored: true, manualReviewOnly: result.manualReviewOnly === true } : {}),
     // Legacy fields (kept for one release for event-log / backcompat readers).
     supportLevel: attemptSupport.supportLevelAtScoring,
     attempts,
@@ -1589,8 +1666,10 @@ export function applyGrammarAttemptToState(state, {
   state.recentAttempts = [...(state.recentAttempts || []), attempt].slice(-80);
 
   const events = [{
-    id: `grammar.answer.${learnerId || 'learner'}.${requestId}.${question.itemId}`,
-    type: 'grammar.answer-submitted',
+    id: nonScoredAttempt
+      ? `grammar.manual-review.${learnerId || 'learner'}.${requestId}.${question.itemId}`
+      : `grammar.answer.${learnerId || 'learner'}.${requestId}.${question.itemId}`,
+    type: nonScoredAttempt ? 'grammar.manual-review-saved' : 'grammar.answer-submitted',
     subjectId: SUBJECT_ID,
     learnerId,
     contentReleaseId: GRAMMAR_CONTENT_RELEASE_ID,
@@ -1604,6 +1683,7 @@ export function applyGrammarAttemptToState(state, {
     score: result.score,
     maxScore: result.maxScore,
     correct: Boolean(result.correct),
+    ...(nonScoredAttempt ? { nonScored: true, manualReviewOnly: result.manualReviewOnly === true } : {}),
     misconception: result.misconception || null,
     // Dual-write: legacy `supportLevel` plus the new U3 item-level fields so
     // pre-U3 and post-U3 event-log readers both see consistent projections.
@@ -1616,7 +1696,7 @@ export function applyGrammarAttemptToState(state, {
     supportContractVersion: SUPPORT_CONTRACT_VERSION,
     createdAt: nowTs,
   }];
-  if (result.misconception) {
+  if (!nonScoredAttempt && result.misconception) {
     events.push({
       id: `grammar.misconception.${learnerId || 'learner'}.${requestId}.${question.itemId}`,
       type: 'grammar.misconception-seen',
@@ -1627,24 +1707,26 @@ export function applyGrammarAttemptToState(state, {
       createdAt: nowTs,
     });
   }
-  for (const conceptId of conceptIds) {
-    const after = grammarConceptStatus(state.mastery.concepts[conceptId], nowTs);
-    if (statusesBefore.get(conceptId) !== 'secured' && after === 'secured') {
-      events.push({
-        id: `grammar.secured.${learnerId || 'learner'}.${conceptId}.${requestId}`,
-        type: 'grammar.concept-secured',
-        subjectId: SUBJECT_ID,
-        learnerId,
-        contentReleaseId: GRAMMAR_CONTENT_RELEASE_ID,
-        conceptId,
-        masteryKey: `grammar:${GRAMMAR_CONTENT_RELEASE_ID}:${conceptId}`,
-        templateId: question.templateId,
-        itemId: question.itemId,
-        createdAt: nowTs,
-      });
+  if (!nonScoredAttempt) {
+    for (const conceptId of conceptIds) {
+      const after = grammarConceptStatus(state.mastery.concepts[conceptId], nowTs);
+      if (statusesBefore.get(conceptId) !== 'secured' && after === 'secured') {
+        events.push({
+          id: `grammar.secured.${learnerId || 'learner'}.${conceptId}.${requestId}`,
+          type: 'grammar.concept-secured',
+          subjectId: SUBJECT_ID,
+          learnerId,
+          contentReleaseId: GRAMMAR_CONTENT_RELEASE_ID,
+          conceptId,
+          masteryKey: `grammar:${GRAMMAR_CONTENT_RELEASE_ID}:${conceptId}`,
+          templateId: question.templateId,
+          itemId: question.itemId,
+          createdAt: nowTs,
+        });
+      }
     }
   }
-  return { result, quality, events, attempt, response: normalisedResponse };
+  return { result, quality: scoringQuality, events, attempt, response: normalisedResponse };
 }
 
 function submitAnswer(state, payload, command, nowTs) {
@@ -1700,10 +1782,16 @@ function submitAnswer(state, payload, command, nowTs) {
     mode: session.mode,
   });
   if (!retryingCurrent) {
+    const nonScoredResult = isNonScoredGrammarResult(applied.result);
     session.answered += 1;
-    session.correct += applied.result.correct ? 1 : 0;
-    session.totalScore += Number(applied.result.score) || 0;
-    session.totalMarks += Number(applied.result.maxScore) || Number(session.currentItem.marks) || 1;
+    if (nonScoredResult) {
+      session.nonScoredAnswered = (Number(session.nonScoredAnswered) || 0) + 1;
+    } else {
+      session.scoredAnswered = (Number(session.scoredAnswered) || 0) + 1;
+      session.correct += applied.result.correct ? 1 : 0;
+      session.totalScore += Number(applied.result.score) || 0;
+      session.totalMarks += Number(applied.result.maxScore) || Number(session.currentItem.marks) || 1;
+    }
   }
   repair.retryingCurrent = false;
   state.phase = 'feedback';
@@ -2077,9 +2165,13 @@ export function createServerGrammarEngine({ now = Date.now } = {}) {
       let events = [];
       let changed = true;
       let aiEnrichment = null;
+      let practiceSessionOverride = null;
 
       if (command === 'start-session') {
         events = startSession(state, { ...payload, requestId }, nowTs, learnerId);
+      } else if (hasStaleActiveContentRelease(state)) {
+        practiceSessionOverride = buildAbandonedRecord(learnerId, latestSession, nowTs);
+        events = clearStaleContentSession(state);
       } else if (state.phase === 'session' && !rawUiWasServerOwned) {
         throw new BadRequestError('This Grammar session is no longer active on the server.', {
           code: 'grammar_session_stale',
@@ -2133,7 +2225,9 @@ export function createServerGrammarEngine({ now = Date.now } = {}) {
       return {
         ...transition(state, { events, changed }),
         aiEnrichment,
-        practiceSession: changed ? practiceSessionRecord(learnerId, state, latestSession, nowTs) : null,
+        practiceSession: changed
+          ? (practiceSessionOverride || practiceSessionRecord(learnerId, state, latestSession, nowTs))
+          : null,
       };
     },
   };

--- a/worker/src/subjects/grammar/read-models.js
+++ b/worker/src/subjects/grammar/read-models.js
@@ -103,6 +103,8 @@ function safeMiniTestQuestion(entry, index, currentIndex, { includeItem = false,
         feedbackLong: typeof result.feedbackLong === 'string' ? result.feedbackLong : '',
         answerText: typeof result.answerText === 'string' ? result.answerText : '',
         minimalHint: typeof result.minimalHint === 'string' ? result.minimalHint : '',
+        ...(result.nonScored === true ? { nonScored: true } : {}),
+        ...(result.manualReviewOnly === true ? { manualReviewOnly: true } : {}),
       },
     };
   }
@@ -171,12 +173,19 @@ function safeGoal(goal, now = Date.now()) {
 
 function safeSummary(summary) {
   if (!isPlainObject(summary)) return null;
+  const answered = Number.isFinite(Number(summary.answered)) ? Number(summary.answered) : 0;
+  const nonScoredAnswered = Number.isFinite(Number(summary.nonScoredAnswered)) ? Number(summary.nonScoredAnswered) : 0;
+  const scoredAnswered = Object.prototype.hasOwnProperty.call(summary, 'scoredAnswered') && Number.isFinite(Number(summary.scoredAnswered))
+    ? Number(summary.scoredAnswered)
+    : Math.max(0, answered - nonScoredAnswered);
   const output = {
     sessionId: typeof summary.sessionId === 'string' ? summary.sessionId : '',
     mode: typeof summary.mode === 'string' ? summary.mode : 'smart',
     startedAt: asTs(summary.startedAt, 0),
     completedAt: asTs(summary.completedAt, 0),
-    answered: Number.isFinite(Number(summary.answered)) ? Number(summary.answered) : 0,
+    answered,
+    scoredAnswered,
+    nonScoredAnswered,
     correct: Number.isFinite(Number(summary.correct)) ? Number(summary.correct) : 0,
     totalScore: Number.isFinite(Number(summary.totalScore)) ? Number(summary.totalScore) : 0,
     totalMarks: Number.isFinite(Number(summary.totalMarks)) ? Number(summary.totalMarks) : 0,
@@ -367,6 +376,8 @@ function safeSession(session, now = Date.now()) {
     startedAt: Number.isFinite(Number(session.startedAt)) ? Number(session.startedAt) : 0,
     targetCount: Number.isFinite(Number(session.targetCount)) ? Number(session.targetCount) : 0,
     answered: Number.isFinite(Number(session.answered)) ? Number(session.answered) : 0,
+    scoredAnswered: Number.isFinite(Number(session.scoredAnswered)) ? Number(session.scoredAnswered) : 0,
+    nonScoredAnswered: Number.isFinite(Number(session.nonScoredAnswered)) ? Number(session.nonScoredAnswered) : 0,
     correct: Number.isFinite(Number(session.correct)) ? Number(session.correct) : 0,
     totalScore: Number.isFinite(Number(session.totalScore)) ? Number(session.totalScore) : 0,
     totalMarks: Number.isFinite(Number(session.totalMarks)) ? Number(session.totalMarks) : 0,
@@ -410,10 +421,19 @@ function recentWindow(recentAttempts) {
   return Array.isArray(recentAttempts) ? recentAttempts.slice(-GRAMMAR_RECENT_ATTEMPT_HORIZON) : [];
 }
 
+function isScoredAttempt(attempt) {
+  const result = isPlainObject(attempt?.result) ? attempt.result : {};
+  return attempt?.nonScored !== true
+    && attempt?.manualReviewOnly !== true
+    && result.nonScored !== true
+    && result.manualReviewOnly !== true;
+}
+
 function recentMissCountForConcept(recentAttempts, conceptId) {
   if (!conceptId) return 0;
   let count = 0;
   for (const attempt of recentWindow(recentAttempts)) {
+    if (!isScoredAttempt(attempt)) continue;
     const conceptIds = Array.isArray(attempt?.conceptIds) ? attempt.conceptIds : [];
     const result = isPlainObject(attempt?.result) ? attempt.result : {};
     if (conceptIds.includes(conceptId) && result.correct === false) count += 1;
@@ -425,6 +445,7 @@ function recentMissCountForQuestionType(recentAttempts, questionType) {
   if (!questionType) return 0;
   let count = 0;
   for (const attempt of recentWindow(recentAttempts)) {
+    if (!isScoredAttempt(attempt)) continue;
     const result = isPlainObject(attempt?.result) ? attempt.result : {};
     if (attempt?.questionType === questionType && result.correct === false) count += 1;
   }
@@ -436,6 +457,7 @@ function recentMissCountForQuestionType(recentAttempts, questionType) {
 function distinctTemplatesFor(recentAttempts, matcher) {
   const seen = new Set();
   for (const attempt of recentWindow(recentAttempts)) {
+    if (!isScoredAttempt(attempt)) continue;
     if (matcher(attempt) && typeof attempt?.templateId === 'string' && attempt.templateId) {
       seen.add(attempt.templateId);
     }
@@ -656,8 +678,10 @@ function recentActivityFromAttempts(attempts = []) {
         conceptIds: Array.isArray(attempt?.conceptIds) ? attempt.conceptIds.filter(Boolean).map(String) : [],
         correct: Boolean(result.correct),
         score: Number(result.score) || 0,
-        maxScore: Number(result.maxScore) || 1,
+        maxScore: Number.isFinite(Number(result.maxScore)) ? Number(result.maxScore) : 1,
         misconception: typeof result.misconception === 'string' ? result.misconception : '',
+        ...(result.nonScored === true ? { nonScored: true } : {}),
+        ...(result.manualReviewOnly === true ? { manualReviewOnly: true } : {}),
         // U3 item-level support attribution. Older attempts have been
         // normalised at load time so these fields are always present.
         firstAttemptIndependent: Boolean(attempt?.firstAttemptIndependent),
@@ -682,6 +706,8 @@ function safeRecentAttempt(attempt = {}) {
       score: Number.isFinite(Number(result.score)) ? Number(result.score) : 0,
       maxScore: Number.isFinite(Number(result.maxScore)) ? Number(result.maxScore) : 1,
       misconception: typeof result.misconception === 'string' ? result.misconception : '',
+      ...(result.nonScored === true ? { nonScored: true } : {}),
+      ...(result.manualReviewOnly === true ? { manualReviewOnly: true } : {}),
     },
     supportLevel: Number.isFinite(Number(attempt?.supportLevel)) ? Math.max(0, Math.min(2, Number(attempt.supportLevel))) : 0,
     attempts: Number.isFinite(Number(attempt?.attempts)) ? Math.max(1, Number(attempt.attempts)) : 1,

--- a/worker/src/subjects/grammar/selection.js
+++ b/worker/src/subjects/grammar/selection.js
@@ -72,7 +72,7 @@ function conceptStatus(node, nowTs) {
 
 function templateFitsMode(template, mode) {
   if (!template) return false;
-  if (mode === 'satsset' && !template.satsFriendly) return false;
+  if (mode === 'satsset' && (!template.satsFriendly || template.answerSpecKind === 'manualReviewOnly')) return false;
   if (mode === 'surgery' && !(template.tags || []).includes('surgery')) return false;
   if (mode === 'builder' && !(template.tags || []).includes('builder')) return false;
   return true;
@@ -91,6 +91,14 @@ function normaliseRecentAttempts(recentAttempts) {
     .slice(-40);
 }
 
+function isScoredAttempt(attempt) {
+  const result = isPlainObject(attempt?.result) ? attempt.result : {};
+  return attempt?.nonScored !== true
+    && attempt?.manualReviewOnly !== true
+    && result.nonScored !== true
+    && result.manualReviewOnly !== true;
+}
+
 function recentTemplateIndex(recentAttempts) {
   const index = new Map();
   const attempts = normaliseRecentAttempts(recentAttempts);
@@ -101,7 +109,7 @@ function recentTemplateIndex(recentAttempts) {
     entry.count += 1;
     if (distance < entry.lastDistance) entry.lastDistance = distance;
     const result = isPlainObject(attempt.result) ? attempt.result : {};
-    if (result.correct === false && distance < entry.lastMissDistance) {
+    if (isScoredAttempt(attempt) && result.correct === false && distance < entry.lastMissDistance) {
       entry.lastMissDistance = distance;
     }
     index.set(attempt.templateId, entry);
@@ -121,7 +129,7 @@ function recentConceptIndex(recentAttempts) {
       const existing = index.get(conceptId) || { lastDistance: Infinity, count: 0, lastMissDistance: Infinity };
       existing.count += 1;
       if (distance < existing.lastDistance) existing.lastDistance = distance;
-      if (result.correct === false && distance < existing.lastMissDistance) {
+      if (isScoredAttempt(attempt) && result.correct === false && distance < existing.lastMissDistance) {
         existing.lastMissDistance = distance;
       }
       index.set(conceptId, existing);
@@ -158,7 +166,7 @@ function recentVariantIndex(recentAttempts) {
     entry.count += 1;
     if (distance < entry.lastDistance) entry.lastDistance = distance;
     const result = isPlainObject(attempt.result) ? attempt.result : {};
-    if (result.correct === false && distance < entry.lastMissDistance) {
+    if (isScoredAttempt(attempt) && result.correct === false && distance < entry.lastMissDistance) {
       entry.lastMissDistance = distance;
     }
     index.set(key, entry);


### PR DESCRIPTION
## Summary

Grammar constructed-response marking is now explicit and auditable for the P2 content release. The 57-template denominator stays fixed while all 20 constructed-response templates declare an `answerSpec` path: deterministic items are marked through `normalisedText`, `acceptedSet`, or `punctuationPattern`, and open creative responses are saved as non-scored `manualReviewOnly` attempts.

This keeps answer keys Worker-private, gives production smoke visible-data probes for every answer-spec family, and prevents manual-review saves from mutating mastery, Stars, reward progress, confidence, recent-miss analytics, or Parent Hub mistake counters.

## What changed

| Area | Result |
| --- | --- |
| Content governance | Bumped the Grammar P2 release id, kept the P1 fixtures immutable, and added separate P2 audit/completeness baselines. |
| Marking contract | Added multi-golden support for normalised text and punctuation patterns, plus a non-scored manual-review result shape. |
| Runtime behaviour | Excluded manual-review-only templates from SATS mini-tests, preserved stale-release recovery for active sessions, and separated scored from non-scored answer counts. |
| Read models and UI | Redacted answer specs, rendered manual-review feedback neutrally, hid repair/enrichment actions for non-scored saves, and showed Parent Hub `0 mistakes` / `Saved for review`. |
| Release evidence | Extended the generator audit, production smoke fixtures, and P2 completion report. |

## Verification

- `npm test` passed after rebasing onto latest `origin/main`: 5831 pass, 0 fail, 6 skipped.
- `npm run check` passed after the final bundle-gate trim, including build, public asset assertion, and client bundle audit.
- `npm run build && npm run audit:client` passed after the final bundle-gate trim: main bundle 216477 / 216500 bytes gzip.
- `node --test tests/grammar-ui-model.test.js tests/react-grammar-surface.test.js` passed after the final UI bundle trim: 245 pass, 0 fail.
- `git diff --check origin/main...HEAD` and `git diff --check` passed.
- Independent blocker re-review found no remaining blockers after the Parent Hub manual-review counter fix.

## Post-Deploy Monitoring & Validation

- Log queries/search terms: `grammar.manual-review-saved`, `grammar.session-completed`, `grammar_content_release_mismatch`, `grammar_session_stale`, `manualReviewOnly`, `/api/subjects/grammar/command`.
- Watch Worker request error rate and 4xx/5xx spikes for Grammar command routes, especially start, submit, continue, and mini-test finish commands.
- Healthy signals: production Grammar smoke passes; manual-review responses return saved/non-scored feedback; Parent Hub recent sessions show `Saved for review` without mistake inflation; no answer-spec or oracle fields appear in child-facing payloads.
- Failure signals: content-release mismatch errors persist after refresh, SATS mini-tests include manual-review-only templates, manual-review attempts create mastery/reward events, or client bundle audit flags hidden Grammar content.
- Validation window and owner: monitor the first post-merge deployment and the next production Grammar smoke run. Owner: James/Codex release steward.
- Rollback trigger: revert this PR or redeploy the previous Worker build if production smoke catches answer leakage, stale-session lockout, or score-bearing manual-review behaviour.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-10a37f?logo=openai&logoColor=white)