### PR TITLE
feat(rewards): route presentation celebrations through queue

### DIFF
--- a/scripts/audit-client-bundle.mjs
+++ b/scripts/audit-client-bundle.mjs
@@ -28,14 +28,14 @@ const DEFAULT_PUBLIC_DIR = 'dist/public';
 // safety and radio-focus accessibility fixes lift the Node 22 build to
 // ~215.1 KB. Punctuation's Star-based display parity added a small
 // first-paint utility footprint. Grammar's matching display-state parity
-// adds another tiny cross-subject utility slice; Node 22's CI gzip output
-// measures about 216.4 KB for the PR merge commit, so the committed ceiling is
-// 216,500: still tight enough to catch an adult-surface re-import, without
-// blocking on sub-kilobyte compression/runtime drift. Override via CLI
+// adds another tiny cross-subject utility slice. The reward presentation
+// queue compatibility layer keeps Node 22's CI gzip output near 216.8 KB, so
+// the committed ceiling is 217,000: still tight enough to catch an adult-surface
+// re-import, without blocking on sub-kilobyte compression/runtime drift. Override via CLI
 // `--main-bundle-budget-bytes` for experimentation. See
 // `tests/bundle-byte-budget.test.js` for the committed baseline +
 // rationale.
-const DEFAULT_MAIN_BUNDLE_GZIP_BUDGET_BYTES = 216_500;
+const DEFAULT_MAIN_BUNDLE_GZIP_BUDGET_BYTES = 217_000;
 
 const FORBIDDEN_MODULES = [
   { pattern: /^src\/subjects\/spelling\/data\//, reason: 'full spelling content dataset' },

--- a/src/platform/game/monster-celebration-acks.js
+++ b/src/platform/game/monster-celebration-acks.js
@@ -1,5 +1,6 @@
 import {
   isMonsterCelebrationEvent,
+  normaliseMonsterCelebrationEvent,
   normaliseMonsterCelebrationEvents,
 } from './monster-celebrations.js';
 
@@ -10,8 +11,14 @@ function storage() {
   return globalThis.localStorage || null;
 }
 
-function eventId(event) {
-  return typeof event?.id === 'string' && event.id ? event.id : '';
+function acknowledgementIdsForEvent(event) {
+  const normalised = normaliseMonsterCelebrationEvent(event);
+  if (!normalised) return [];
+  return [
+    normalised.id,
+    normalised.sourceEventId,
+    normalised.presentationAckKey,
+  ].filter(Boolean);
 }
 
 function readSnapshot(store = storage()) {
@@ -106,8 +113,7 @@ export function acknowledgeMonsterCelebrationEvents(events, { learnerId = '', st
   const current = normaliseLearnerAckEntry(snapshot[key]);
   const ids = new Set(current.ids);
   for (const event of validEvents) {
-    const id = eventId(event);
-    if (id) ids.add(id);
+    for (const id of acknowledgementIdsForEvent(event)) ids.add(id);
   }
   saveLearnerAckEntry(snapshot, key, {
     ...current,
@@ -130,10 +136,10 @@ function baselineExistingEvents(events, {
   const baselineIds = normaliseIdSet(baselineEventIds);
   const existingIds = (Array.isArray(events) ? events : [])
     .filter((event) => {
-      const id = eventId(event);
-      return id && (!baselineIds || baselineIds.has(id));
+      const ids = acknowledgementIdsForEvent(event);
+      return ids.length && (!baselineIds || ids.some((id) => baselineIds.has(id)));
     })
-    .map(eventId);
+    .flatMap(acknowledgementIdsForEvent);
 
   saveLearnerAckEntry(snapshot, learnerId, {
     ids: [...new Set([...entry.ids, ...existingIds])],
@@ -169,8 +175,9 @@ export function unacknowledgedMonsterCelebrationEvents(events, {
   const excluded = normaliseIdSet(excludeEventIds);
   const candidates = scopedEvents
     .filter((event) => {
-      const id = eventId(event);
-      return id && !acknowledgedIds.has(id) && !ignored.has(id) && (!excluded || !excluded.has(id));
+      const ids = acknowledgementIdsForEvent(event);
+      return ids.length
+        && ids.every((id) => !acknowledgedIds.has(id) && !ignored.has(id) && (!excluded || !excluded.has(id)));
     })
     .sort((a, b) => (Number(a.createdAt) || 0) - (Number(b.createdAt) || 0));
 

--- a/src/platform/game/monster-celebrations.js
+++ b/src/platform/game/monster-celebrations.js
@@ -1,8 +1,13 @@
 import { normaliseMonsterBranch } from './monsters.js';
 
 const OVERLAY_KINDS = new Set(['caught', 'evolve', 'mega']);
+const REWARD_PRESENTATION_TYPE = 'reward.presentation';
 
-export function isMonsterCelebrationEvent(event) {
+function isPlainObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isLegacyMonsterCelebrationEvent(event) {
   return event?.type === 'reward.monster'
     && OVERLAY_KINDS.has(event.kind)
     && typeof event.monsterId === 'string'
@@ -23,12 +28,21 @@ function normaliseProgressSnapshot(value) {
 }
 
 export function normaliseMonsterCelebrationEvent(event) {
-  if (!isMonsterCelebrationEvent(event)) return null;
+  if (isLegacyMonsterCelebrationEvent(event)) return normaliseLegacyMonsterCelebrationEvent(event);
+  return normalisePresentationCelebrationEvent(event);
+}
+
+export function isMonsterCelebrationEvent(event) {
+  return Boolean(normaliseMonsterCelebrationEvent(event));
+}
+
+function normaliseLegacyMonsterCelebrationEvent(event) {
   const monster = event.monster;
+  const id = typeof event.id === 'string' && event.id
+    ? event.id
+    : `reward.monster:${event.learnerId || 'default'}:${event.monsterId}:${event.kind}`;
   return {
-    id: typeof event.id === 'string' && event.id
-      ? event.id
-      : `reward.monster:${event.learnerId || 'default'}:${event.monsterId}:${event.kind}`,
+    id,
     type: 'reward.monster',
     kind: event.kind,
     learnerId: typeof event.learnerId === 'string' ? event.learnerId : 'default',
@@ -54,6 +68,44 @@ export function normaliseMonsterCelebrationEvent(event) {
           body: typeof event.toast.body === 'string' ? event.toast.body : '',
         }
       : null,
+    presentationAckKey: `reward:reward.presentation:${id}:celebration:0`,
+  };
+}
+
+function normalisePresentationCelebrationEvent(event) {
+  if (!isPlainObject(event) || event.type !== REWARD_PRESENTATION_TYPE) return null;
+  const celebrationIntent = Array.isArray(event.presentations?.celebration)
+    ? event.presentations.celebration.find(isPlainObject)
+    : null;
+  if (!celebrationIntent) return null;
+
+  const payload = isPlainObject(event.payload) ? event.payload : {};
+  const monster = isPlainObject(payload.monster) ? payload.monster : {};
+  const monsterId = payload.monsterId || celebrationIntent.assetRef?.monsterId || monster.id || '';
+  const normalisedMonster = {
+    ...monster,
+    id: monster.id || monsterId,
+    name: monster.name || celebrationIntent.title || 'Reward',
+  };
+  const previous = event.fromState || {};
+  const next = {
+    ...(event.toState || {}),
+    branch: event.toState?.branch || celebrationIntent.assetRef?.branch || previous.branch,
+    stage: event.toState?.stage ?? celebrationIntent.assetRef?.stage,
+  };
+
+  return {
+    id: event.id,
+    type: REWARD_PRESENTATION_TYPE,
+    kind: celebrationIntent.visualKind || event.kind,
+    learnerId: event.learnerId,
+    monsterId,
+    monster: normalisedMonster,
+    previous: normaliseProgressSnapshot(previous),
+    next: normaliseProgressSnapshot(next),
+    createdAt: Math.max(0, Number(event.occurredAt) || Date.now()),
+    sourceEventId: event.sourceEventId || '',
+    presentationAckKey: celebrationIntent.dedupeKey || '',
   };
 }
 

--- a/tests/bundle-byte-budget.test.js
+++ b/tests/bundle-byte-budget.test.js
@@ -18,10 +18,10 @@
 // safety and radio-focus accessibility fixes lift the Node 22 build to
 // ~215.1 KB. Punctuation's Star-based display parity added a small first-paint
 // utility footprint; Grammar's matching display-state parity adds another
-// tiny cross-subject utility slice. Node 22's CI gzip output measures about
-// 216.4 KB for the PR merge commit. The committed ceiling is now `216_500`,
-// keeping the headroom narrow while avoiding a sub-kilobyte
-// compression/runtime false blocker.
+// tiny cross-subject utility slice. The reward presentation queue
+// compatibility layer keeps Node 22's CI gzip output near 216.8 KB. The
+// committed ceiling is now `217_000`, keeping the headroom narrow while
+// avoiding a sub-kilobyte compression/runtime false blocker.
 // The audit still fails
 // when ~50 KB of adult-only JS sneaks back into the critical path (the
 // exact regression the code-split protects against). The audit driver re-reads
@@ -65,14 +65,14 @@ const REPO_ROOT = path.resolve(__dirname, '..');
 // safety and radio-focus accessibility fixes lift the Node 22 build to
 // ~215.1 KB. Punctuation's Star-based display parity adds a small first-paint
 // utility footprint; Grammar's matching display-state parity adds another
-// tiny cross-subject utility slice. Node 22's CI gzip output measures about
-// 216.4 KB for the PR merge commit, so the committed ceiling is 216,500
+// tiny cross-subject utility slice. The reward presentation queue compatibility
+// layer keeps Node 22's CI gzip output near 216.8 KB, so the committed ceiling is 217,000
 // (matches `DEFAULT_MAIN_BUNDLE_GZIP_BUDGET_BYTES` in
 // `scripts/audit-client-bundle.mjs`). The narrow headroom lets the team
 // land small copy / utility growth without an audit bump, but trips the
 // gate when ~50 KB of adult-only JS sneaks back into the critical path.
 const BASELINE_GZIP_BYTES = 203_227;
-const BUDGET_GZIP_BYTES = 216_500;
+const BUDGET_GZIP_BYTES = 217_000;
 const TEST_MODE_BUNDLE_MARKER = '__ks2_capacityMeta__';
 
 function isPlaywrightTestModeBundle(bundleBytes) {

--- a/tests/monster-celebrations.test.js
+++ b/tests/monster-celebrations.test.js
@@ -2,10 +2,18 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  isMonsterCelebrationEvent,
+  normaliseMonsterCelebrationEvent,
   shouldDelayMonsterCelebrations,
   spellingSessionEnded,
   subjectSessionEnded,
 } from '../src/platform/game/monster-celebrations.js';
+import {
+  acknowledgeMonsterCelebrationEvents,
+  acknowledgedMonsterCelebrationIds,
+  unacknowledgedMonsterCelebrationEvents,
+} from '../src/platform/game/monster-celebration-acks.js';
+import { installMemoryStorage } from './helpers/memory-storage.js';
 
 test('monster celebration timing keeps Spelling session-end behaviour', () => {
   assert.equal(shouldDelayMonsterCelebrations('spelling', { phase: 'session' }, { phase: 'session' }), true);
@@ -30,4 +38,118 @@ test('monster celebration timing defers Grammar session overlays until session e
 test('monster celebration timing leaves unknown subjects immediate', () => {
   assert.equal(shouldDelayMonsterCelebrations('reading', { phase: 'session' }, { phase: 'session' }), false);
   assert.equal(subjectSessionEnded('reading', { phase: 'session' }, { phase: 'summary' }), false);
+});
+
+test('reward.presentation celebration intents can enter the legacy monster celebration queue', () => {
+  const event = {
+    id: 'reward.presentation:subject:grammar:reward.monster:evolve:bracehart:hatch',
+    type: 'reward.presentation',
+    producerType: 'subject',
+    producerId: 'grammar',
+    rewardType: 'reward.monster',
+    kind: 'evolve',
+    learnerId: 'learner-a',
+    occurredAt: 1777399200000,
+    fromState: { stage: 0, level: 0, caught: true, branch: 'b1' },
+    toState: { stage: 1, level: 0, caught: true, branch: 'b1' },
+    payload: {
+      monsterId: 'bracehart',
+      monster: { id: 'bracehart', name: 'Bracehart', accent: '#8B5CF6' },
+    },
+    presentations: {
+      toast: [],
+      celebration: [{
+        id: 'reward.presentation:subject:grammar:reward.monster:evolve:bracehart:hatch:celebration:hatch',
+        intentId: 'hatch',
+        dedupeKey: 'reward:reward.presentation:subject:grammar:reward.monster:evolve:bracehart:hatch:celebration:hatch',
+        visualKind: 'evolve',
+        timing: 'session-end',
+        title: 'Hatched',
+        assetRef: { family: 'monster', monsterId: 'bracehart', branch: 'b1', stage: 1 },
+      }],
+    },
+  };
+
+  assert.equal(isMonsterCelebrationEvent(event), true);
+  const normalised = normaliseMonsterCelebrationEvent(event);
+  assert.equal(normalised.type, 'reward.presentation');
+  assert.equal(normalised.kind, 'evolve');
+  assert.equal(normalised.monsterId, 'bracehart');
+  assert.equal(normalised.monster.name, 'Bracehart');
+  assert.equal(normalised.next.stage, 1);
+  assert.equal(
+    normalised.presentationAckKey,
+    'reward:reward.presentation:subject:grammar:reward.monster:evolve:bracehart:hatch:celebration:hatch',
+  );
+});
+
+test('monster celebration acknowledgement writes legacy id and presentation intent key', () => {
+  const storage = installMemoryStorage();
+  const legacyEvent = {
+    id: 'reward.monster:learner-a:punctuation:r4:speech:unit-1:pealark:caught',
+    type: 'reward.monster',
+    kind: 'caught',
+    learnerId: 'learner-a',
+    monsterId: 'pealark',
+    monster: { id: 'pealark', name: 'Pealark' },
+    previous: { stage: 0, level: 0, caught: false, branch: 'b1' },
+    next: { stage: 0, level: 0, caught: true, branch: 'b1' },
+    createdAt: 1777399200000,
+    toast: { title: 'Egg Found', body: 'You found Pealark.' },
+  };
+
+  assert.equal(acknowledgeMonsterCelebrationEvents(legacyEvent, { learnerId: 'learner-a', store: storage }), true);
+  const ids = acknowledgedMonsterCelebrationIds('learner-a', { store: storage });
+  assert.equal(ids.has(legacyEvent.id), true);
+  assert.equal(
+    ids.has('reward:reward.presentation:reward.monster:learner-a:punctuation:r4:speech:unit-1:pealark:caught:celebration:0'),
+    true,
+  );
+  assert.deepEqual(unacknowledgedMonsterCelebrationEvents([legacyEvent], { learnerId: 'learner-a', store: storage }), []);
+});
+
+test('presentation celebration acknowledgement still honours old legacy event ids', () => {
+  const storage = installMemoryStorage();
+  const sourceEventId = 'reward.monster:learner-a:grammar:r4:word_classes:bracehart:evolve';
+  const presentationEvent = {
+    id: `reward.presentation:${sourceEventId}`,
+    type: 'reward.presentation',
+    producerType: 'subject',
+    producerId: 'grammar',
+    rewardType: 'reward.monster',
+    kind: 'evolve',
+    learnerId: 'learner-a',
+    sourceEventId,
+    occurredAt: 1777399200000,
+    fromState: { stage: 0, level: 0, caught: true, branch: 'b1' },
+    toState: { stage: 1, level: 0, caught: true, branch: 'b1' },
+    payload: {
+      monsterId: 'bracehart',
+      monster: { id: 'bracehart', name: 'Bracehart' },
+    },
+    presentations: {
+      celebration: [{
+        visualKind: 'evolve',
+        timing: 'session-end',
+        title: 'Hatched',
+      }],
+    },
+  };
+
+  acknowledgeMonsterCelebrationEvents({
+    id: sourceEventId,
+    type: 'reward.monster',
+    kind: 'evolve',
+    learnerId: 'learner-a',
+    monsterId: 'bracehart',
+    monster: { id: 'bracehart', name: 'Bracehart' },
+    previous: { stage: 0, level: 0, caught: true, branch: 'b1' },
+    next: { stage: 1, level: 0, caught: true, branch: 'b1' },
+    createdAt: 1777399200000,
+  }, { learnerId: 'learner-a', store: storage });
+
+  assert.deepEqual(
+    unacknowledgedMonsterCelebrationEvents([presentationEvent], { learnerId: 'learner-a', store: storage }),
+    [],
+  );
 });


### PR DESCRIPTION
## Summary
- let the existing monster celebration queue accept canonical `reward.presentation` celebration intents while preserving legacy `reward.monster` events
- persist acknowledgement compatibility across legacy event ids, canonical presentation ids, and presentation intent ack keys
- add regression coverage for canonical celebration queueing and legacy/canonical acknowledgement replay safety
- raise the committed client bundle ceiling to `217000` bytes after Linux CI measured this compatibility layer at ~216.8 KB gzip; the gate still catches adult-surface re-imports while avoiding sub-kilobyte compression drift

## Verification
- `node --test tests/monster-celebrations.test.js tests/reward-presentations.test.js tests/bundle-byte-budget.test.js tests/store.test.js tests/render-celebration-layer.test.js tests/app-controller.test.js tests/spelling-remote-actions.test.js` (96 pass / 0 fail)
- `npm test` (5817 pass / 6 skipped / 0 fail, before final budget-ceiling comment/update pass)
- `npm run check` (bundle audit: main bundle 216422 / 217000 bytes gzip)
- `git diff --check`

## Notes
- Rebased onto `origin/main` after PR #497; kept the queue hot path lightweight rather than importing the whole PR2 helper module into the app bundle, while preserving the same `reward:<eventId>:<presentationKind>:<intent>` acknowledgement key shape.
- No ToastShelf migration and no Hero economy changes in this slice.