### PR TITLE
feat(punctuation): codify generated metadata transport policy

### DIFF
--- a/docs/punctuation-production.md
+++ b/docs/punctuation-production.md
@@ -82,7 +82,7 @@ Generated practice now runs through a deterministic compiler. Each published gen
 Generated item guardrails:
 
 - The production runtime service uses `generatedPerFamily: 4`, giving 171 runtime items while keeping the published reward denominator unchanged. Lower-level generator and audit compatibility fixtures still exercise `generatedPerFamily: 1`.
-- Each generated item carries a stable `templateId` and opaque `variantSignature`. The scheduler uses recent signatures to avoid equivalent retries, and Star evidence uses signatures before item ids when a generated surface has an available signature.
+- Each generated item carries a stable internal `templateId` and opaque `variantSignature`. The scheduler uses recent signatures to avoid equivalent retries, and Star evidence uses signatures before item ids when a generated surface has an available signature. The `templateId` stays server-only; only the opaque signature may cross to the active generated item read model.
 - Template-bank expansion appends new templates after the first two legacy templates. The first generated runtime variant is preserved when the bank grows.
 - The audit command `npm run audit:punctuation-content -- --strict --generated-per-family 4` checks generated family coverage, validator coverage, duplicate variant signatures, distinct signature counts, and generated model-answer marking. Duplicate stems/models remain reported for content review; add `--fail-on-duplicate-generated-content` when a review specifically wants those surfaced as hard failures.
 
@@ -260,15 +260,19 @@ Writes are monster-targeted (each monster updates independently) and idempotent 
 
 The Worker plumbing for an AI-assisted context-pack compiler stays in place, but the learner React surface deliberately ignores the field in Phase 2. The existing `safeContextPackSummary` allowlist ensures any future upstream field addition trips the fail-closed redaction guard added in Phase 2 U2. Phase 3 will decide whether to productise the context pack as a post-feedback learner surface or keep it teacher/admin-only; until then, the Parent / Admin evidence path is the only surface that consumes it.
 
-## Read-Model Redaction (Phase 2)
+## Generated Metadata Transport And Read-Model Redaction (Phase 2 / P2 U4)
 
 Every phase output (active item, feedback, summary, GPS review, analytics, Parent / Admin evidence, context-pack summary) is built from explicit allowlists. A recursive `assertNoForbiddenReadModelKeys` scan runs on the assembled payload before it leaves the Worker so a forbidden field added at any depth of any branch (e.g. `summary.metadata.rawGenerator`, `reviewRow.validator`, `analytics.byItemMode[].rubric`) throws in `NODE_ENV=test` and emits a structured warning + strips the field in production.
 
-The forbidden-key set is kept aligned between `worker/src/subjects/punctuation/read-models.js` (`FORBIDDEN_READ_MODEL_KEYS`) and `scripts/punctuation-production-smoke.mjs` (`FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS`). Adding a new forbidden key means editing both files in the same PR; CI will fail with a clear "server-only field: &lt;key&gt;" message if drift is introduced.
+Generated metadata has one deliberate transport exception. A generated active `session.currentItem` may expose `variantSignature` when it matches the opaque `puncsig_*` shape. It is used only for submission/evidence binding and equivalent-surface de-duplication. The active item must not expose `templateId`, generator family ids, validators, accepted answers, raw responses, raw generator payloads, or template internals. Fixed active items do not expose `variantSignature`.
+
+Every other surface treats `variantSignature` as forbidden. GPS delayed review rows, Smart Review feedback/summary payloads, Parent Hub Punctuation evidence, Admin learner diagnostics, progress snapshots, and misconception-pattern evidence must omit `variantSignature` alongside generated internals and answer-bearing fields such as `acceptedAnswers`, `validator(s)`, `rawResponse`, `response`, `typed`, `attemptedAnswer`, `model`, and `displayCorrection`.
+
+The forbidden-key set is kept aligned between `tests/helpers/forbidden-keys.mjs`, `worker/src/subjects/punctuation/read-models.js` (`FORBIDDEN_READ_MODEL_KEYS`), and `scripts/punctuation-production-smoke.mjs` (`FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS`). Adding a new forbidden key means editing the shared helper first, then the Worker/smoke enforcement in the same PR; CI will fail with a clear "server-only field: &lt;key&gt;" message if drift is introduced.
 
 ## Browser Read Model And Lockdown
 
-The browser read model is an allowlist. It may show the current prompt, stem, safe answer choices, feedback, correction copy, rubric facets, and summary data.
+The browser read model is an allowlist. It may show the current prompt, stem, safe answer choices, feedback, correction copy, rubric facets, summary data, and the opaque generated active-item `variantSignature` exception described above.
 
 It must not expose server-only fields such as accepted answer lists, `correctIndex`, validators, raw rubric definitions, content generators, hidden queues, unpublished items, or the domain engine.
 

--- a/scripts/punctuation-production-smoke.mjs
+++ b/scripts/punctuation-production-smoke.mjs
@@ -34,22 +34,60 @@ const FORBIDDEN_PUNCTUATION_ADULT_EVIDENCE_KEYS = new Set(SHARED_FORBIDDEN_PUNCT
 const ALLOWED_PUNCTUATION_ACTIVE_ITEM_METADATA_KEYS = new Set(SHARED_ALLOWED_PUNCTUATION_ACTIVE_ITEM_METADATA_KEYS);
 const OPAQUE_VARIANT_SIGNATURE_PATTERN = /^puncsig_[a-z0-9]+$/;
 
-export function assertNoForbiddenPunctuationReadModelKeys(value, path = 'punctuation.subjectReadModel') {
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isAllowedActiveCurrentItemMetadata({ key, child, parent, pathSegments, rootPhase }) {
+  return ALLOWED_PUNCTUATION_ACTIVE_ITEM_METADATA_KEYS.has(key)
+    && rootPhase === 'active-item'
+    && pathSegments.length === 2
+    && pathSegments[0] === 'session'
+    && pathSegments[1] === 'currentItem'
+    && isPlainObject(parent)
+    && parent.source === 'generated'
+    && typeof child === 'string'
+    && OPAQUE_VARIANT_SIGNATURE_PATTERN.test(child);
+}
+
+function assertNoForbiddenPunctuationReadModelKeysAt(value, { path, pathSegments, rootPhase }) {
   if (value == null || typeof value !== 'object') return;
   if (Array.isArray(value)) {
-    value.forEach((entry, index) => assertNoForbiddenPunctuationReadModelKeys(entry, `${path}[${index}]`));
+    value.forEach((entry, index) => assertNoForbiddenPunctuationReadModelKeysAt(entry, {
+      path: `${path}[${index}]`,
+      pathSegments: [...pathSegments, `[${index}]`],
+      rootPhase,
+    }));
     return;
   }
   for (const [key, child] of Object.entries(value)) {
-    const allowedActiveItemMetadata = ALLOWED_PUNCTUATION_ACTIVE_ITEM_METADATA_KEYS.has(key)
-      && path.endsWith('.session.currentItem');
+    const allowedActiveItemMetadata = isAllowedActiveCurrentItemMetadata({
+      key,
+      child,
+      parent: value,
+      pathSegments,
+      rootPhase,
+    });
     assert.equal(
       FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS.has(key) && !allowedActiveItemMetadata,
       false,
       `${path}.${key} exposed a server-only field.`,
     );
-    assertNoForbiddenPunctuationReadModelKeys(child, `${path}.${key}`);
+    assertNoForbiddenPunctuationReadModelKeysAt(child, {
+      path: `${path}.${key}`,
+      pathSegments: [...pathSegments, key],
+      rootPhase,
+    });
   }
+}
+
+export function assertNoForbiddenPunctuationReadModelKeys(value, path = 'punctuation.subjectReadModel', context = {}) {
+  const rootPhase = context.rootPhase || (isPlainObject(value) && typeof value.phase === 'string' ? value.phase : null);
+  assertNoForbiddenPunctuationReadModelKeysAt(value, {
+    path,
+    pathSegments: [],
+    rootPhase,
+  });
 }
 
 export function assertNoForbiddenPunctuationAdultEvidenceKeys(value, path = 'punctuation.adultEvidence') {

--- a/scripts/punctuation-production-smoke.mjs
+++ b/scripts/punctuation-production-smoke.mjs
@@ -18,6 +18,7 @@ import {
   subjectCommand,
 } from './lib/production-smoke.mjs';
 import {
+  ALLOWED_PUNCTUATION_ACTIVE_ITEM_METADATA_KEYS as SHARED_ALLOWED_PUNCTUATION_ACTIVE_ITEM_METADATA_KEYS,
   FORBIDDEN_PUNCTUATION_ADULT_EVIDENCE_KEYS as SHARED_FORBIDDEN_PUNCTUATION_ADULT_EVIDENCE_KEYS,
   FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS as SHARED_FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS,
 } from '../tests/helpers/forbidden-keys.mjs';
@@ -30,9 +31,25 @@ import {
 // deploy time.
 const FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS = new Set(SHARED_FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS);
 const FORBIDDEN_PUNCTUATION_ADULT_EVIDENCE_KEYS = new Set(SHARED_FORBIDDEN_PUNCTUATION_ADULT_EVIDENCE_KEYS);
+const ALLOWED_PUNCTUATION_ACTIVE_ITEM_METADATA_KEYS = new Set(SHARED_ALLOWED_PUNCTUATION_ACTIVE_ITEM_METADATA_KEYS);
+const OPAQUE_VARIANT_SIGNATURE_PATTERN = /^puncsig_[a-z0-9]+$/;
 
 export function assertNoForbiddenPunctuationReadModelKeys(value, path = 'punctuation.subjectReadModel') {
-  assertNoForbiddenObjectKeys(value, FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS, path);
+  if (value == null || typeof value !== 'object') return;
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => assertNoForbiddenPunctuationReadModelKeys(entry, `${path}[${index}]`));
+    return;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    const allowedActiveItemMetadata = ALLOWED_PUNCTUATION_ACTIVE_ITEM_METADATA_KEYS.has(key)
+      && path.endsWith('.session.currentItem');
+    assert.equal(
+      FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS.has(key) && !allowedActiveItemMetadata,
+      false,
+      `${path}.${key} exposed a server-only field.`,
+    );
+    assertNoForbiddenPunctuationReadModelKeys(child, `${path}.${key}`);
+  }
 }
 
 export function assertNoForbiddenPunctuationAdultEvidenceKeys(value, path = 'punctuation.adultEvidence') {
@@ -74,6 +91,15 @@ function assertVisiblePunctuationItemMatchesSource(readItem, source, path = 'pun
   assert.equal(readItem?.clusterId || null, source.clusterId || null, `${path}.clusterId did not match the source item.`);
   assert.deepEqual(readItem?.skillIds || [], Array.isArray(source.skillIds) ? source.skillIds : [], `${path}.skillIds did not match the source item.`);
   assert.equal(readItem?.source, source.source === 'generated' ? 'generated' : 'fixed', `${path}.source did not match the source item.`);
+  if (source.source === 'generated') {
+    assert.equal(readItem?.variantSignature, source.variantSignature, `${path}.variantSignature did not match the generated source item.`);
+    assert.match(readItem.variantSignature, OPAQUE_VARIANT_SIGNATURE_PATTERN, `${path}.variantSignature was not opaque.`);
+  } else {
+    assert.equal(Object.hasOwn(readItem || {}, 'variantSignature'), false, `${path}.variantSignature was exposed for a fixed item.`);
+  }
+  for (const forbiddenKey of ['templateId', 'generatorFamilyId', 'validator', 'validators', 'accepted', 'acceptedAnswers', 'answers', 'rawResponse']) {
+    assert.equal(Object.hasOwn(readItem || {}, forbiddenKey), false, `${path}.${forbiddenKey} exposed generated internals.`);
+  }
 
   if (readItem.inputKind === 'choice') {
     const expectedOptions = (Array.isArray(source.options) ? source.options : []).map(normaliseSourceOption);

--- a/shared/punctuation/service.js
+++ b/shared/punctuation/service.js
@@ -39,6 +39,7 @@ const GENERATED_ITEMS_PER_FAMILY = 4;
 const MAX_GPS_QUEUE_LENGTH = 12;
 const DAY_MS = 24 * 60 * 60 * 1000;
 const DAILY_TARGET_ATTEMPTS = 4;
+const OPAQUE_VARIANT_SIGNATURE_PATTERN = /^puncsig_[a-z0-9]+$/;
 const ITEM_MODE_LABELS = Object.freeze({
   choose: 'Choice',
   insert: 'Insert punctuation',
@@ -67,6 +68,12 @@ function isPlainObject(value) {
 function timestamp(now = Date.now) {
   const value = typeof now === 'function' ? Number(now()) : Number(now);
   return Number.isFinite(value) ? value : Date.now();
+}
+
+function normaliseOpaqueVariantSignature(value) {
+  if (typeof value !== 'string') return '';
+  const signature = value.trim();
+  return OPAQUE_VARIANT_SIGNATURE_PATTERN.test(signature) ? signature : '';
 }
 
 function randomSuffix(random = Math.random) {
@@ -215,8 +222,9 @@ function normaliseItemForState(item) {
     model: item.model || '',
     source: item.source || 'fixed',
   };
-  if (typeof item.variantSignature === 'string' && item.variantSignature) {
-    safe.variantSignature = item.variantSignature;
+  const variantSignature = normaliseOpaqueVariantSignature(item.variantSignature);
+  if (safe.source === 'generated' && variantSignature) {
+    safe.variantSignature = variantSignature;
   }
   if (item.mode === 'choose') {
     safe.options = Array.isArray(item.options)

--- a/tests/helpers/forbidden-keys.mjs
+++ b/tests/helpers/forbidden-keys.mjs
@@ -67,19 +67,34 @@ export const FORBIDDEN_GRAMMAR_ITEM_KEYS = Object.freeze([
 // validator, seed, rawGenerator, hiddenQueue, queueItemIds, responses,
 // unpublished) is disjoint from grammar's. The overlap with the universal
 // floor covers the shared concerns ('accepted', 'answers', 'generator').
+//
+// `variantSignature` has one narrow exception: a generated active
+// session.currentItem may carry it as an opaque submission/evidence token. It
+// remains forbidden everywhere else, especially GPS review rows and adult
+// evidence surfaces.
+export const ALLOWED_PUNCTUATION_ACTIVE_ITEM_METADATA_KEYS = Object.freeze([
+  'variantSignature',
+]);
+
 export const FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS = Object.freeze([
   'accepted',
+  'acceptedAnswers',
   'answers',
   'correctIndex',
+  'generatorFamilyId',
   'rubric',
   'validator',
+  'validators',
   'seed',
   'generator',
   'rawGenerator',
+  'rawResponse',
   'hiddenQueue',
   'queueItemIds',
   'responses',
+  'templateId',
   'unpublished',
+  'variantSignature',
 ]);
 
 // Punctuation adult evidence surface extends the read-model surface with

--- a/tests/punctuation-gps.test.js
+++ b/tests/punctuation-gps.test.js
@@ -5,6 +5,7 @@ import { PUNCTUATION_EVENT_TYPES } from '../shared/punctuation/events.js';
 import { createPunctuationService } from '../shared/punctuation/service.js';
 import { PUNCTUATION_RELEASE_ID } from '../shared/punctuation/content.js';
 import { projectPunctuationStars } from '../src/subjects/punctuation/star-projection.js';
+import { FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS } from './helpers/forbidden-keys.mjs';
 
 function makeRepository(initialData = null) {
   let data = initialData;
@@ -224,7 +225,15 @@ test('gps completion releases review rows and then writes learning evidence', ()
   assert.equal(finished.state.summary.gps.reviewItems.length, 3);
   assert.equal(finished.state.summary.gps.reviewItems[1].correct, false);
   assert.equal(finished.state.summary.gps.reviewItems[1].displayCorrection.length > 0, true);
-  assert.equal(finished.state.summary.gps.reviewItems.every((entry) => !('variantSignature' in entry)), true);
+  for (const [index, reviewItem] of finished.state.summary.gps.reviewItems.entries()) {
+    for (const key of FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS) {
+      assert.equal(
+        Object.hasOwn(reviewItem, key),
+        false,
+        `GPS review item ${index + 1} must not expose ${key}`,
+      );
+    }
+  }
   assert.equal(finished.state.summary.gps.recommendedMode, 'weak');
   assert.equal(finished.events.filter((event) => event.type === PUNCTUATION_EVENT_TYPES.ITEM_ATTEMPTED).length, 3);
   assert.equal(finished.events.some((event) => event.type === PUNCTUATION_EVENT_TYPES.SESSION_COMPLETED), true);

--- a/tests/punctuation-map-redaction.test.js
+++ b/tests/punctuation-map-redaction.test.js
@@ -19,7 +19,8 @@
 //   (a) plumbing a forbidden key from the Worker payload through the Map /
 //       Modal render path, or
 //   (b) introducing a child-facing copy string that literally reads the
-//       internal key name `validator` / `rubric` / `correctIndex` / etc.
+//       internal key name `validator` / `rubric` / `correctIndex` /
+//       `variantSignature` / etc.
 //
 // The forbidden list comes from `tests/helpers/forbidden-keys.mjs` — the
 // single source of truth for the Punctuation read-model key universe
@@ -31,11 +32,11 @@
 //   `tests/react-punctuation-scene.test.js:1022` (word-boundary regex) but
 //   fanned out across both key families:
 //     * CAMELCASE_KEYS — `correctIndex` / `hiddenQueue` / `rawGenerator` /
-//       `queueItemIds` / `unpublished`. JS `\b` treats the internal
+//       `queueItemIds` / `variantSignature` / `unpublished`. JS `\b` treats the internal
 //       case-boundary oddly, so substring match is the correct probe — a
 //       camelCase identifier has no legitimate child-copy analogue.
 //     * WORDBOUNDARY_KEYS — `accepted` / `answers` / `generator` / `responses`
-//       / `rubric` / `seed` / `validator`. These are English words that
+//       / `rubric` / `seed` / `validator` / `validators`. These are English words that
 //       appear legitimately in unrelated copy (e.g. "seed" inside "seeded",
 //       "answers" as a child-facing label on the GPS chip row) so a naive
 //       substring probe false-positives. Word-boundary regex lets legitimate
@@ -138,11 +139,16 @@ function applyMapFilters(harness, { statusFilter, monsterFilter }) {
 // in ways that surprise). These identifiers have no legitimate child-copy
 // analogue, so a plain substring probe is both correct and strictest.
 const CAMELCASE_KEYS = Object.freeze([
+  'acceptedAnswers',
   'correctIndex',
+  'generatorFamilyId',
   'hiddenQueue',
   'rawGenerator',
+  'rawResponse',
   'queueItemIds',
+  'templateId',
   'unpublished',
+  'variantSignature',
 ]);
 
 // English-word keys: word-boundary regex so legitimate copy like "seeded"
@@ -157,6 +163,7 @@ const WORDBOUNDARY_KEYS = Object.freeze([
   'rubric',
   'seed',
   'validator',
+  'validators',
 ]);
 
 function findForbiddenHits(html) {
@@ -271,39 +278,43 @@ test('U7: Skill Detail modal SSR is clean across 14 skills × 2 tabs (28 combina
 });
 
 // ---------------------------------------------------------------------------
-// Phase 2 redaction contract unchanged — the universal forbidden key list
-// shape hasn't widened nor narrowed. Pairs with the characterisation-only
-// claim in the PR body: U7 does not weaken Phase 2 redaction.
+// U4 redaction contract — generated metadata is forbidden everywhere except
+// the active generated currentItem's opaque variantSignature transport.
 // ---------------------------------------------------------------------------
 
-test('U7: FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS is unchanged at 12 entries (Phase 2 contract)', () => {
-  // Phase 2 U2 shipped the 12-entry list. U7 is characterisation-only —
-  // we confirm alignment rather than extend the list. A future unit that
-  // introduces a new Worker projection must extend
-  // `tests/helpers/forbidden-keys.mjs` first (the single source of truth)
-  // and this assertion forces that discipline.
-  assert.equal(FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS.length, 12);
+test('U4: FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS pins generated metadata redaction', () => {
+  // U4 intentionally extends the Phase 2 U2 list so GPS review rows and
+  // adult evidence cannot expose generated metadata or raw response fields.
+  // A future unit introducing a new Worker projection must extend
+  // `tests/helpers/forbidden-keys.mjs` first (the single source of truth).
+  assert.equal(FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS.length, 18);
   assert.equal(Object.isFrozen(FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS), true);
 
   // Content-lock — a rename like `rubric` → `rubricSpec` keeps the length
-  // at 12 but silently narrows the sweep's coverage (the renamed key is no
+  // stable but silently narrows the sweep's coverage (the renamed key is no
   // longer probed). Pinning the sorted contents forces any rename to land
   // here as a paired update, keeping the oracle and the probe aligned.
   assert.deepEqual(
     [...FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS].sort(),
     [
       'accepted',
+      'acceptedAnswers',
       'answers',
       'correctIndex',
       'generator',
+      'generatorFamilyId',
       'hiddenQueue',
       'queueItemIds',
       'rawGenerator',
+      'rawResponse',
       'responses',
       'rubric',
       'seed',
+      'templateId',
       'unpublished',
       'validator',
+      'validators',
+      'variantSignature',
     ],
     'FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS sorted contents must not drift silently',
   );

--- a/tests/punctuation-read-models.test.js
+++ b/tests/punctuation-read-models.test.js
@@ -360,12 +360,58 @@ test('active generated currentItem exposes only an opaque variant signature', ()
   }
 });
 
+test('feedback generated currentItem omits the active-item variant signature transport', () => {
+  const result = buildPunctuationReadModel({
+    learnerId: 'learner-a',
+    state: {
+      phase: 'feedback',
+      session: {
+        id: 'session-generated',
+        releaseId: 'punctuation-r4-full-14-skill-structure',
+        mode: 'smart',
+        length: 1,
+        phase: 'feedback',
+        startedAt: 1_777_000_000_000,
+        answeredCount: 1,
+        correctCount: 1,
+        currentItem: {
+          id: 'generated-speech-insert',
+          mode: 'insert',
+          source: 'generated',
+          prompt: 'Add the direct-speech punctuation.',
+          stem: 'Maya said, hello.',
+          inputKind: 'text',
+          skillIds: ['speech'],
+          clusterId: 'speech',
+          variantSignature: 'puncsig_abc123',
+        },
+        serverAuthority: 'worker',
+      },
+      feedback: {
+        kind: 'success',
+        headline: 'Nice work',
+        body: 'The answer was accepted.',
+      },
+      availability: { status: 'ready', code: null, message: '' },
+    },
+    prefs: {},
+    stats: {},
+  });
+  const currentItem = result.session.currentItem;
+
+  assert.equal(result.phase, 'feedback');
+  assert.equal(currentItem.source, 'generated');
+  assert.equal(Object.hasOwn(currentItem, 'variantSignature'), false);
+  assertNoForbiddenPunctuationReadModelKeys(result, 'punctuation.smart.feedbackModel');
+});
+
 test('shared punctuation metadata policy allows variantSignature only on active currentItem', () => {
   assert.deepEqual(ALLOWED_PUNCTUATION_ACTIVE_ITEM_METADATA_KEYS, ['variantSignature']);
   assert.equal(FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS.includes('variantSignature'), true);
   assert.equal(FORBIDDEN_PUNCTUATION_ADULT_EVIDENCE_KEYS.includes('variantSignature'), true);
 
   assert.doesNotThrow(() => assertNoForbiddenPunctuationReadModelKeys({
+    phase: 'active-item',
     session: {
       currentItem: {
         source: 'generated',
@@ -373,6 +419,70 @@ test('shared punctuation metadata policy allows variantSignature only on active 
       },
     },
   }, 'punctuation.smart.startModel'));
+  assert.throws(
+    () => assertNoForbiddenPunctuationReadModelKeys({
+      phase: 'feedback',
+      session: {
+        currentItem: {
+          source: 'generated',
+          variantSignature: 'puncsig_abc123',
+        },
+      },
+    }, 'punctuation.smart.feedbackModel'),
+    /variantSignature exposed a server-only field/,
+  );
+  assert.throws(
+    () => assertNoForbiddenPunctuationReadModelKeys({
+      phase: 'active-item',
+      session: {
+        currentItem: {
+          source: 'fixed',
+          variantSignature: 'puncsig_abc123',
+        },
+      },
+    }, 'punctuation.smart.startModel'),
+    /variantSignature exposed a server-only field/,
+  );
+  assert.throws(
+    () => assertNoForbiddenPunctuationReadModelKeys({
+      phase: 'active-item',
+      session: {
+        currentItem: {
+          source: 'generated',
+          variantSignature: 'not-opaque',
+        },
+      },
+    }, 'punctuation.smart.startModel'),
+    /variantSignature exposed a server-only field/,
+  );
+  assert.throws(
+    () => assertNoForbiddenPunctuationReadModelKeys({
+      phase: 'active-item',
+      analytics: {
+        session: {
+          currentItem: {
+            variantSignature: 'puncsig_abc123',
+          },
+        },
+      },
+    }, 'punctuation.smart.startModel'),
+    /variantSignature exposed a server-only field/,
+  );
+  assert.throws(
+    () => assertNoForbiddenPunctuationReadModelKeys({
+      phase: 'active-item',
+      rows: [
+        {
+          session: {
+            currentItem: {
+              variantSignature: 'puncsig_abc123',
+            },
+          },
+        },
+      ],
+    }, 'punctuation.smart.startModel'),
+    /variantSignature exposed a server-only field/,
+  );
   assert.throws(
     () => assertNoForbiddenPunctuationReadModelKeys({
       summary: {

--- a/tests/punctuation-read-models.test.js
+++ b/tests/punctuation-read-models.test.js
@@ -1,9 +1,20 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
+import {
+  assertNoForbiddenPunctuationAdultEvidenceKeys,
+  assertNoForbiddenPunctuationReadModelKeys,
+} from '../scripts/punctuation-production-smoke.mjs';
+import { buildAdminHubReadModel } from '../src/platform/hubs/admin-read-model.js';
+import { buildParentHubReadModel } from '../src/platform/hubs/parent-read-model.js';
 import { buildPunctuationReadModel } from '../worker/src/subjects/punctuation/read-models.js';
 import { buildPunctuationLearnerReadModel } from '../src/subjects/punctuation/read-model.js';
 import { createPunctuationReadModelService } from '../src/subjects/punctuation/client-read-models.js';
+import {
+  ALLOWED_PUNCTUATION_ACTIVE_ITEM_METADATA_KEYS,
+  FORBIDDEN_PUNCTUATION_ADULT_EVIDENCE_KEYS,
+  FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS,
+} from './helpers/forbidden-keys.mjs';
 
 const BASE_STATE = {
   phase: 'summary',
@@ -30,6 +41,82 @@ const BASE_STATE = {
   },
   availability: { status: 'ready', code: null, message: '' },
 };
+
+const GENERATED_ACTIVE_ITEM_FORBIDDEN_KEYS = Object.freeze([
+  'templateId',
+  'generatorFamilyId',
+  'validator',
+  'validators',
+  'accepted',
+  'acceptedAnswers',
+  'answers',
+  'rawResponse',
+  'rawGenerator',
+  'model',
+]);
+
+function generatedPunctuationSubjectState(now = 1_777_000_000_000) {
+  return {
+    data: {
+      progress: {
+        items: {
+          gen_speech_insert_1: {
+            attempts: 1,
+            correct: 0,
+            incorrect: 1,
+            streak: 0,
+            lapses: 1,
+            dueAt: now,
+            firstCorrectAt: null,
+            lastCorrectAt: null,
+            lastSeen: now,
+          },
+        },
+        facets: {},
+        rewardUnits: {},
+        attempts: [
+          {
+            ts: now,
+            sessionId: 'punctuation-generated-session',
+            itemId: 'gen_speech_insert_1',
+            variantSignature: 'puncsig_parent1',
+            templateId: 'gen_speech_insert_template_secret',
+            generatorFamilyId: 'gen_speech_insert',
+            acceptedAnswers: ['Maya said, "Hello."'],
+            validator: { type: 'speech' },
+            rawResponse: { typed: 'maya said hello' },
+            response: 'maya said hello',
+            typed: 'maya said hello',
+            attemptedAnswer: 'maya said hello',
+            model: 'Maya said, "Hello."',
+            displayCorrection: 'Maya said, "Hello."',
+            mode: 'insert',
+            itemMode: 'insert',
+            skillIds: ['speech'],
+            rewardUnitId: 'speech-core',
+            sessionMode: 'smart',
+            correct: false,
+            misconceptionTags: ['speech.quote_missing'],
+            facetOutcomes: [{ id: 'speech::insert', label: 'Speech - Insert punctuation', ok: false }],
+          },
+        ],
+        sessionsCompleted: 1,
+      },
+    },
+    updatedAt: now,
+  };
+}
+
+function makeLearner(id = 'learner-punctuation-u4') {
+  return {
+    id,
+    name: 'Ava',
+    yearGroup: 'Y5',
+    goal: 'sats',
+    dailyMinutes: 15,
+    createdAt: 1000,
+  };
+}
 
 test('safeSummary passes a clean payload through redaction without throwing', () => {
   const result = buildPunctuationReadModel({
@@ -210,7 +297,7 @@ test('availability payload fails closed on forbidden fields', () => {
 });
 
 test('scan catches rawGenerator, queueItemIds, and responses at any depth', () => {
-  for (const key of ['rawGenerator', 'queueItemIds', 'responses']) {
+  for (const key of ['acceptedAnswers', 'generatorFamilyId', 'rawGenerator', 'rawResponse', 'queueItemIds', 'responses', 'templateId', 'validators', 'variantSignature']) {
     const leaky = {
       ...BASE_STATE,
       summary: {
@@ -229,6 +316,126 @@ test('scan catches rawGenerator, queueItemIds, and responses at any depth', () =
       `forbidden key ${key} must trip the recursive scan`,
     );
   }
+});
+
+test('active generated currentItem exposes only an opaque variant signature', () => {
+  const result = buildPunctuationReadModel({
+    learnerId: 'learner-a',
+    state: {
+      phase: 'active-item',
+      session: {
+        id: 'session-generated',
+        releaseId: 'punctuation-r4-full-14-skill-structure',
+        mode: 'smart',
+        length: 1,
+        phase: 'active-item',
+        startedAt: 1_777_000_000_000,
+        answeredCount: 0,
+        correctCount: 0,
+        currentItem: {
+          id: 'generated-speech-insert',
+          mode: 'insert',
+          source: 'generated',
+          prompt: 'Add the direct-speech punctuation.',
+          stem: 'Maya said, hello.',
+          inputKind: 'text',
+          skillIds: ['speech'],
+          clusterId: 'speech',
+          variantSignature: 'puncsig_abc123',
+        },
+        serverAuthority: 'worker',
+      },
+      availability: { status: 'ready', code: null, message: '' },
+    },
+    prefs: {},
+    stats: {},
+  });
+  const currentItem = result.session.currentItem;
+
+  assert.equal(currentItem.source, 'generated');
+  assert.equal(currentItem.variantSignature, 'puncsig_abc123');
+  assertNoForbiddenPunctuationReadModelKeys(result, 'punctuation.active.startModel');
+  for (const key of GENERATED_ACTIVE_ITEM_FORBIDDEN_KEYS) {
+    assert.equal(Object.hasOwn(currentItem, key), false, `active generated currentItem must not expose ${key}`);
+  }
+});
+
+test('shared punctuation metadata policy allows variantSignature only on active currentItem', () => {
+  assert.deepEqual(ALLOWED_PUNCTUATION_ACTIVE_ITEM_METADATA_KEYS, ['variantSignature']);
+  assert.equal(FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS.includes('variantSignature'), true);
+  assert.equal(FORBIDDEN_PUNCTUATION_ADULT_EVIDENCE_KEYS.includes('variantSignature'), true);
+
+  assert.doesNotThrow(() => assertNoForbiddenPunctuationReadModelKeys({
+    session: {
+      currentItem: {
+        source: 'generated',
+        variantSignature: 'puncsig_abc123',
+      },
+    },
+  }, 'punctuation.smart.startModel'));
+  assert.throws(
+    () => assertNoForbiddenPunctuationReadModelKeys({
+      summary: {
+        gps: {
+          reviewItems: [{ itemId: 'generated-speech-insert', variantSignature: 'puncsig_abc123' }],
+        },
+      },
+    }, 'punctuation.gps.summaryModel'),
+    /variantSignature exposed a server-only field/,
+  );
+  assert.throws(
+    () => assertNoForbiddenPunctuationAdultEvidenceKeys({
+      recentMistakes: [{ itemId: 'generated-speech-insert', variantSignature: 'puncsig_abc123' }],
+    }, 'parentHub.punctuationEvidence'),
+    /variantSignature exposed a server-only field/,
+  );
+});
+
+test('Parent Hub and Admin punctuation evidence omit generated metadata and answer fields', () => {
+  const now = 1_777_000_000_000;
+  const learner = makeLearner();
+  const subjectState = generatedPunctuationSubjectState(now);
+  const parentModel = buildParentHubReadModel({
+    learner,
+    platformRole: 'parent',
+    membershipRole: 'owner',
+    subjectStates: { punctuation: subjectState },
+    practiceSessions: [],
+    eventLog: [],
+    now: () => now,
+  });
+
+  assert.equal(parentModel.punctuationEvidence.hasEvidence, true);
+  assertNoForbiddenPunctuationAdultEvidenceKeys(parentModel.punctuationEvidence, 'parentHub.punctuationEvidence');
+  assertNoForbiddenPunctuationAdultEvidenceKeys(parentModel.progressSnapshots, 'parentHub.progressSnapshots');
+  assertNoForbiddenPunctuationAdultEvidenceKeys(parentModel.misconceptionPatterns, 'parentHub.misconceptionPatterns');
+  for (const key of ['variantSignature', 'templateId', 'generatorFamilyId', 'acceptedAnswers', 'validator', 'rawResponse', 'response', 'typed', 'attemptedAnswer', 'model', 'displayCorrection']) {
+    assert.equal(
+      Object.hasOwn(parentModel.punctuationEvidence.recentMistakes[0], key),
+      false,
+      `Parent Hub recent mistake must not expose ${key}`,
+    );
+  }
+
+  const adminModel = buildAdminHubReadModel({
+    account: { id: 'adult-admin', selectedLearnerId: learner.id, repoRevision: 7, platformRole: 'admin' },
+    platformRole: 'admin',
+    memberships: [{ learnerId: learner.id, learner, role: 'owner' }],
+    learnerBundles: {
+      [learner.id]: {
+        subjectStates: { punctuation: subjectState },
+        practiceSessions: [],
+        eventLog: [],
+        gameState: {},
+      },
+    },
+    selectedLearnerId: learner.id,
+    now: () => now,
+  });
+  const diagnostics = adminModel.learnerSupport.selectedDiagnostics;
+
+  assert.equal(diagnostics.punctuationEvidence.hasEvidence, true);
+  assertNoForbiddenPunctuationAdultEvidenceKeys(diagnostics.punctuationEvidence, 'adminHub.selectedDiagnostics.punctuationEvidence');
 });
 
 test('client normaliser drops contextPack if the worker ever re-adds it (U8 belt-and-braces)', () => {

--- a/tests/punctuation-service.test.js
+++ b/tests/punctuation-service.test.js
@@ -13,6 +13,18 @@ import { createMemoryState, updateMemoryState } from '../shared/punctuation/sche
 import { createPunctuationService, PunctuationServiceError } from '../shared/punctuation/service.js';
 import { projectPunctuationStars } from '../src/subjects/punctuation/star-projection.js';
 
+const GENERATED_METADATA_FORBIDDEN_ON_ACTIVE_ITEM = Object.freeze([
+  'templateId',
+  'generatorFamilyId',
+  'validator',
+  'validators',
+  'accepted',
+  'acceptedAnswers',
+  'answers',
+  'rawResponse',
+  'rawGenerator',
+]);
+
 function makeRepository() {
   let data = null;
   let practiceSession = null;
@@ -123,6 +135,13 @@ test('punctuation service carries generated variant signatures into state and at
 
   assert.equal(generated.session.currentItem.source, 'generated');
   assert.match(generated.session.currentItem.variantSignature, /^puncsig_[a-z0-9]+$/);
+  for (const key of GENERATED_METADATA_FORBIDDEN_ON_ACTIVE_ITEM) {
+    assert.equal(
+      Object.hasOwn(generated.session.currentItem, key),
+      false,
+      `generated active currentItem must not expose ${key}`,
+    );
+  }
 
   const submitted = service.submitAnswer('learner-a', generated, correctAnswerFor(generated.session.currentItem));
   const attempt = repository.snapshot().data.progress.attempts.at(-1);

--- a/tests/react-punctuation-scene.test.js
+++ b/tests/react-punctuation-scene.test.js
@@ -1372,7 +1372,7 @@ test('punctuation Skill Detail modal rejects invalid tab value (handler regressi
   );
 });
 
-test('punctuation Skill Detail modal SSR contains none of the 12 FORBIDDEN_PUNCTUATION_READ_MODEL_KEYS', () => {
+test('punctuation Skill Detail modal SSR contains none of the forbidden Punctuation read-model keys', () => {
   const harness = createPunctuationHarness();
   openSkillDetailForSpeech(harness);
   const html = harness.render();

--- a/worker/src/subjects/punctuation/read-models.js
+++ b/worker/src/subjects/punctuation/read-models.js
@@ -7,13 +7,18 @@ import {
 
 const FORBIDDEN_ITEM_FIELDS = new Set([
   'accepted',
+  'acceptedAnswers',
   'answers',
   'correctIndex',
+  'generatorFamilyId',
   'rubric',
   'validator',
+  'validators',
   'seed',
   'generator',
   'hiddenQueue',
+  'rawResponse',
+  'templateId',
   'unpublished',
 ]);
 
@@ -26,10 +31,18 @@ const FORBIDDEN_READ_MODEL_KEYS = new Set([
   'rawGenerator',
   'queueItemIds',
   'responses',
+  'variantSignature',
 ]);
+const OPAQUE_VARIANT_SIGNATURE_PATTERN = /^puncsig_[a-z0-9]+$/;
 
 function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normaliseOpaqueVariantSignature(value) {
+  if (typeof value !== 'string') return '';
+  const signature = value.trim();
+  return OPAQUE_VARIANT_SIGNATURE_PATTERN.test(signature) ? signature : '';
 }
 
 function safeCurrentItem(item) {
@@ -51,6 +64,10 @@ function safeCurrentItem(item) {
         text: typeof option.text === 'string' ? option.text : '',
         index: Number.isInteger(Number(option.index)) ? Number(option.index) : 0,
       }));
+  }
+  const variantSignature = normaliseOpaqueVariantSignature(item.variantSignature);
+  if (safe.source === 'generated' && variantSignature) {
+    safe.variantSignature = variantSignature;
   }
   return safe;
 }
@@ -218,7 +235,8 @@ function assertNoForbiddenReadModelKeys(value, path = 'punctuation') {
     return;
   }
   for (const [key, child] of Object.entries(value)) {
-    if (FORBIDDEN_READ_MODEL_KEYS.has(key)) {
+    const allowedActiveItemSignature = key === 'variantSignature' && path.endsWith('.session.currentItem');
+    if (FORBIDDEN_READ_MODEL_KEYS.has(key) && !allowedActiveItemSignature) {
       throw new Error(`Punctuation read model attempted to expose server-only ${path}.${key} field: ${key}`);
     }
     assertNoForbiddenReadModelKeys(child, `${path}.${key}`);

--- a/worker/src/subjects/punctuation/read-models.js
+++ b/worker/src/subjects/punctuation/read-models.js
@@ -45,7 +45,7 @@ function normaliseOpaqueVariantSignature(value) {
   return OPAQUE_VARIANT_SIGNATURE_PATTERN.test(signature) ? signature : '';
 }
 
-function safeCurrentItem(item) {
+function safeCurrentItem(item, { includeVariantSignature = false } = {}) {
   if (!isPlainObject(item)) return null;
   const safe = {
     id: typeof item.id === 'string' ? item.id : '',
@@ -66,7 +66,7 @@ function safeCurrentItem(item) {
       }));
   }
   const variantSignature = normaliseOpaqueVariantSignature(item.variantSignature);
-  if (safe.source === 'generated' && variantSignature) {
+  if (includeVariantSignature && safe.source === 'generated' && variantSignature) {
     safe.variantSignature = variantSignature;
   }
   return safe;
@@ -138,6 +138,7 @@ function safeGpsSession(session) {
 function safeSession(session, phase) {
   if (!isPlainObject(session)) return null;
   const hideGpsInterimResults = session.mode === 'gps';
+  const includeCurrentItemSignature = phase === 'active-item';
   const safe = {
     id: typeof session.id === 'string' ? session.id : '',
     releaseId: typeof session.releaseId === 'string' ? session.releaseId : PUNCTUATION_RELEASE_ID,
@@ -149,7 +150,9 @@ function safeSession(session, phase) {
     correctCount: hideGpsInterimResults
       ? 0
       : (Number.isFinite(Number(session.correctCount)) ? Number(session.correctCount) : 0),
-    currentItem: phase === 'active-item' || phase === 'feedback' ? safeCurrentItem(session.currentItem) : null,
+    currentItem: phase === 'active-item' || phase === 'feedback'
+      ? safeCurrentItem(session.currentItem, { includeVariantSignature: includeCurrentItemSignature })
+      : null,
     securedUnits: Array.isArray(session.securedUnits) ? session.securedUnits.filter((entry) => typeof entry === 'string') : [],
     misconceptionTags: hideGpsInterimResults
       ? []
@@ -226,20 +229,55 @@ function assertNoForbiddenItemFields(item) {
   }
 }
 
-function assertNoForbiddenReadModelKeys(value, path = 'punctuation') {
+function isAllowedActiveCurrentItemMetadata({ key, child, parent, pathSegments, rootPhase }) {
+  return key === 'variantSignature'
+    && rootPhase === 'active-item'
+    && pathSegments.length === 2
+    && pathSegments[0] === 'session'
+    && pathSegments[1] === 'currentItem'
+    && isPlainObject(parent)
+    && parent.source === 'generated'
+    && typeof child === 'string'
+    && OPAQUE_VARIANT_SIGNATURE_PATTERN.test(child);
+}
+
+function assertNoForbiddenReadModelKeys(value, {
+  path = 'punctuation',
+  pathSegments = [],
+  rootPhase = null,
+} = {}) {
   if (value == null || typeof value !== 'object') return;
+  const resolvedRootPhase = rootPhase || (
+    pathSegments.length === 0 && isPlainObject(value) && typeof value.phase === 'string'
+      ? value.phase
+      : null
+  );
   if (Array.isArray(value)) {
     for (let index = 0; index < value.length; index += 1) {
-      assertNoForbiddenReadModelKeys(value[index], `${path}[${index}]`);
+      assertNoForbiddenReadModelKeys(value[index], {
+        path: `${path}[${index}]`,
+        pathSegments: [...pathSegments, `[${index}]`],
+        rootPhase: resolvedRootPhase,
+      });
     }
     return;
   }
   for (const [key, child] of Object.entries(value)) {
-    const allowedActiveItemSignature = key === 'variantSignature' && path.endsWith('.session.currentItem');
+    const allowedActiveItemSignature = isAllowedActiveCurrentItemMetadata({
+      key,
+      child,
+      parent: value,
+      pathSegments,
+      rootPhase: resolvedRootPhase,
+    });
     if (FORBIDDEN_READ_MODEL_KEYS.has(key) && !allowedActiveItemSignature) {
       throw new Error(`Punctuation read model attempted to expose server-only ${path}.${key} field: ${key}`);
     }
-    assertNoForbiddenReadModelKeys(child, `${path}.${key}`);
+    assertNoForbiddenReadModelKeys(child, {
+      path: `${path}.${key}`,
+      pathSegments: [...pathSegments, key],
+      rootPhase: resolvedRootPhase,
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- Allow generated active Punctuation `session.currentItem` payloads to carry only an opaque `variantSignature` for submission/evidence binding at the exact active-item read-model root.
- Strip/reject `variantSignature` from Smart Review feedback, summary/read-model branches, analytics-style nested payloads, GPS review rows, and Parent/Admin evidence surfaces.
- Document the generated metadata transport policy in `docs/punctuation-production.md`.

## Verification
- `node scripts/worktree-setup.mjs` — node_modules already present
- `node --test tests/punctuation-read-models.test.js tests/punctuation-service.test.js tests/punctuation-gps.test.js tests/punctuation-map-redaction.test.js tests/react-punctuation-scene.test.js tests/punctuation-release-smoke.test.js` — 225 pass
- `npm run check`
- `git diff --check`

## Post-Deploy Monitoring & Validation
- Run `npm run smoke:production:punctuation` against `https://ks2.eugnel.uk` after deploy with an authenticated production demo flow.
- Confirm Smart Review, GPS delayed review, and Parent Hub Punctuation evidence remain clean of `variantSignature`, generator internals, validators, accepted answers, and raw responses except for the allowed generated active `session.currentItem.variantSignature` transport.
- Watch Worker command/error telemetry for `server-only field` failures and Punctuation command validation errors during the first production smoke pass.