### PR TITLE
feat(seo): add KS2 practice landing pages

### DIFF
--- a/_headers
+++ b/_headers
@@ -101,6 +101,45 @@
   Reporting-Endpoints: csp-endpoint="/api/security/csp-report"
   Cache-Control: public, max-age=3600
 
+/ks2-spelling-practice/
+  Strict-Transport-Security: max-age=63072000; includeSubDomains
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(), geolocation=(), payment=(), usb=(), bluetooth=(), serial=(), hid=(), midi=(), microphone=(), accelerometer=(), gyroscope=(), magnetometer=(), autoplay=(), encrypted-media=(), fullscreen=(self), picture-in-picture=(), interest-cohort=(), browsing-topics=()
+  X-Frame-Options: DENY
+  Cross-Origin-Opener-Policy: same-origin-allow-popups
+  Cross-Origin-Resource-Policy: same-site
+  Content-Security-Policy-Report-Only: default-src 'none'; script-src 'self' 'sha256-BUILD_TIME_HASH' 'strict-dynamic' https://challenges.cloudflare.com; script-src-elem 'self' 'sha256-BUILD_TIME_HASH' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com; media-src 'self' blob:; form-action 'self'; frame-ancestors 'none'; frame-src https://challenges.cloudflare.com; base-uri 'none'; object-src 'none'; manifest-src 'self'; worker-src 'none'; report-uri /api/security/csp-report; report-to csp-endpoint
+  Report-To: {"group":"csp-endpoint","max_age":10886400,"endpoints":[{"url":"/api/security/csp-report"}]}
+  Reporting-Endpoints: csp-endpoint="/api/security/csp-report"
+  Cache-Control: no-store
+
+/ks2-grammar-practice/
+  Strict-Transport-Security: max-age=63072000; includeSubDomains
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(), geolocation=(), payment=(), usb=(), bluetooth=(), serial=(), hid=(), midi=(), microphone=(), accelerometer=(), gyroscope=(), magnetometer=(), autoplay=(), encrypted-media=(), fullscreen=(self), picture-in-picture=(), interest-cohort=(), browsing-topics=()
+  X-Frame-Options: DENY
+  Cross-Origin-Opener-Policy: same-origin-allow-popups
+  Cross-Origin-Resource-Policy: same-site
+  Content-Security-Policy-Report-Only: default-src 'none'; script-src 'self' 'sha256-BUILD_TIME_HASH' 'strict-dynamic' https://challenges.cloudflare.com; script-src-elem 'self' 'sha256-BUILD_TIME_HASH' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com; media-src 'self' blob:; form-action 'self'; frame-ancestors 'none'; frame-src https://challenges.cloudflare.com; base-uri 'none'; object-src 'none'; manifest-src 'self'; worker-src 'none'; report-uri /api/security/csp-report; report-to csp-endpoint
+  Report-To: {"group":"csp-endpoint","max_age":10886400,"endpoints":[{"url":"/api/security/csp-report"}]}
+  Reporting-Endpoints: csp-endpoint="/api/security/csp-report"
+  Cache-Control: no-store
+
+/ks2-punctuation-practice/
+  Strict-Transport-Security: max-age=63072000; includeSubDomains
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(), geolocation=(), payment=(), usb=(), bluetooth=(), serial=(), hid=(), midi=(), microphone=(), accelerometer=(), gyroscope=(), magnetometer=(), autoplay=(), encrypted-media=(), fullscreen=(self), picture-in-picture=(), interest-cohort=(), browsing-topics=()
+  X-Frame-Options: DENY
+  Cross-Origin-Opener-Policy: same-origin-allow-popups
+  Cross-Origin-Resource-Policy: same-site
+  Content-Security-Policy-Report-Only: default-src 'none'; script-src 'self' 'sha256-BUILD_TIME_HASH' 'strict-dynamic' https://challenges.cloudflare.com; script-src-elem 'self' 'sha256-BUILD_TIME_HASH' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com; media-src 'self' blob:; form-action 'self'; frame-ancestors 'none'; frame-src https://challenges.cloudflare.com; base-uri 'none'; object-src 'none'; manifest-src 'self'; worker-src 'none'; report-uri /api/security/csp-report; report-to csp-endpoint
+  Report-To: {"group":"csp-endpoint","max_age":10886400,"endpoints":[{"url":"/api/security/csp-report"}]}
+  Reporting-Endpoints: csp-endpoint="/api/security/csp-report"
+  Cache-Control: no-store
+
 /
   Strict-Transport-Security: max-age=63072000; includeSubDomains
   X-Content-Type-Options: nosniff

--- a/docs/operations/seo.md
+++ b/docs/operations/seo.md
@@ -9,25 +9,29 @@ problem_type: runbook
 
 # SEO Operations
 
-KS2 Mastery V1 SEO is a foundation layer: one crawlable public identity surface, valid discovery files, production audit coverage, and an operator path for measuring organic discovery. It does not guarantee ranking, search placement, or AI assistant recommendations.
+KS2 Mastery SEO is a staged discovery layer: one crawlable public identity surface, focused practice-tool landing pages, valid discovery files, production audit coverage, and an operator path for measuring organic discovery. It does not guarantee ranking, search placement, or AI assistant recommendations.
 
 ## Public Surface
 
-The canonical public URL is:
+The canonical public URLs are:
 
 - `https://ks2.eugnel.uk/`
+- `https://ks2.eugnel.uk/ks2-spelling-practice/`
+- `https://ks2.eugnel.uk/ks2-grammar-practice/`
+- `https://ks2.eugnel.uk/ks2-punctuation-practice/`
 
 The root page should describe KS2 Mastery as an online KS2 spelling, grammar, and punctuation practice product. The copy must stay aligned with the actual app experience and must not expose private learner state, admin surfaces, generated content stores, or internal analytics.
 
-The first sitemap intentionally lists only the canonical root URL. Future practice-tool, subject/problem, or parent-support pages should be added only after they exist as accurate public pages.
+The practice-tool landing pages should stay focused on the product's real subject areas. Future subject/problem or parent-support pages should be added only after they exist as accurate public pages and there is measurement evidence to guide the next slice.
 
 ## Production Checks
 
 After deployment, verify:
 
 - `https://ks2.eugnel.uk/` returns public identity copy, meta description, canonical URL, share metadata, and JSON-LD product identity.
+- `https://ks2.eugnel.uk/ks2-spelling-practice/`, `https://ks2.eugnel.uk/ks2-grammar-practice/`, and `https://ks2.eugnel.uk/ks2-punctuation-practice/` each return page-specific public HTML, not the root SPA shell.
 - `https://ks2.eugnel.uk/robots.txt` returns a robots policy, not the SPA HTML fallback, and excludes `/api/`, `/admin`, and `/demo` from normal crawler discovery.
-- `https://ks2.eugnel.uk/sitemap.xml` returns an XML sitemap with only the canonical root URL.
+- `https://ks2.eugnel.uk/sitemap.xml` returns an XML sitemap with the root plus the three canonical practice-tool page URLs, and no `/api/`, `/admin`, `/demo`, local, or `.html` variants.
 - `npm run audit:production -- --skip-local` passes against the live origin.
 
 Search engines can still take time to crawl and index the site after these checks pass.
@@ -38,8 +42,8 @@ Use Google Search Console or equivalent search tooling to:
 
 - Verify ownership for `https://ks2.eugnel.uk/`.
 - Submit `https://ks2.eugnel.uk/sitemap.xml`.
-- Inspect the canonical root URL after deployment.
-- Review indexing status and organic queries before choosing the next SEO content page.
+- Inspect the canonical root URL and each practice-tool URL after deployment.
+- Review indexing status, impressions, clicks, CTR, queries, and landing pages before choosing the next SEO content page.
 
 The verification method depends on the external account setup. Do not add placeholder verification tokens to the repo.
 
@@ -47,7 +51,13 @@ The verification method depends on the external account setup. Do not add placeh
 
 Worker observability is infrastructure telemetry. It is useful for errors and runtime health, but it is not visitor analytics and does not answer organic acquisition questions.
 
-For aggregate visitor analytics, prefer Cloudflare Web Analytics first because the site already runs on Cloudflare. GA4 or Zaraz can be added later if James chooses that stack and supplies the real property or site-token configuration.
+For aggregate visitor analytics, prefer Cloudflare Web Analytics first because the site already runs on Cloudflare.
+
+For a proxied Cloudflare hostname, enable Web Analytics from the Cloudflare dashboard by adding the hostname in Web Analytics and using automatic setup when available. If the dashboard requires manual snippet installation instead, treat that as a code change: use the real site token only, review CSP `script-src` and `connect-src`, and update production audit coverage in the same PR.
+
+Cloudflare Web Analytics can track SPA interactions, but the V2 SEO landing pages are static pages and should first be measured as page views and landing pages.
+
+GA4 or Zaraz can be added later if James chooses that stack and supplies the real property or site-token configuration.
 
 Any analytics script must be reviewed against:
 
@@ -58,11 +68,23 @@ Any analytics script must be reviewed against:
 
 Analytics is decision support. It is not a direct ranking mechanism.
 
+## AI Search and Crawlers
+
+AI-search visibility depends on crawlable public pages, external systems, and user queries. KS2 Mastery can improve clarity and access, but it cannot force recommendations.
+
+Operational checks:
+
+- Keep public SEO pages available under the generic `User-agent: *` robots policy.
+- Do not add an `OAI-SearchBot`, `GPTBot`, or `ChatGPT-User` robots group unless the private-path disallows are repeated deliberately.
+- Check Cloudflare security, bot, and WAF settings if AI-search crawler access looks blocked despite `robots.txt`.
+- Treat `OAI-SearchBot` as search visibility related; do not assume `GPTBot` training access is required for ChatGPT search recommendations.
+- Do not treat `llms.txt` or AI-only summary files as a replacement for normal crawlable pages and sitemap coverage.
+
 ## Next Content Choices
 
 Preserve these acquisition lanes for later work:
 
-- Practice-tool intent, such as KS2 spelling practice online or KS2 grammar practice.
+- Practice-tool intent, such as extra subject pages only after the current spelling, grammar, and punctuation landing pages show useful signal.
 - Subject/problem intent, such as practising apostrophes or Year 5 spelling words.
 - Parent-support intent, such as helping a child with KS2 grammar at home.
 - AI-readable product identity, where assistants can understand what KS2 Mastery is and when it is relevant.

--- a/docs/plans/2026-04-28-003-feat-ks2-seo-measurement-practice-pages-plan.md
+++ b/docs/plans/2026-04-28-003-feat-ks2-seo-measurement-practice-pages-plan.md
@@ -1,0 +1,424 @@
+---
+title: "feat: Add KS2 SEO Measurement and Practice Landing Pages"
+type: feat
+status: completed
+date: 2026-04-28
+origin: docs/brainstorms/2026-04-28-ks2-seo-foundation-requirements.md
+---
+
+# feat: Add KS2 SEO Measurement and Practice Landing Pages
+
+## Summary
+
+Build the V2 SEO slice on top of the completed root foundation by adding three crawlable practice-tool landing pages, wiring them into the public discovery graph, and strengthening production validation plus operations guidance so organic and AI-assisted discovery can be measured without weakening privacy or security.
+
+---
+
+## Problem Frame
+
+The V1 SEO foundation made `https://ks2.eugnel.uk/` understandable as a public product identity surface. James now wants organic users and AI/search systems to have more specific, accurate public pages to discover and recommend, while still keeping analytics, crawler access, private learner state, and app routing under control.
+
+---
+
+## Assumptions
+
+*This plan makes a few implementation bets from the prior discussion and repo research. They should be reviewed before execution starts.*
+
+- Practice-tool intent is the right V2 content slice, ahead of subject/problem pages and parent-support guidance.
+- Public practice pages should be static Cloudflare Static Assets pages with canonical trailing-slash URLs, not Worker-rendered routes or `.html` URLs.
+- Search Console and Cloudflare Web Analytics are the first measurement path; GA4, Zaraz, or a repo-injected analytics snippet stays deferred until real configuration exists.
+- OpenAI and other AI-search visibility should be improved through crawlable public pages and robots access, not through recommendation guarantees or speculative AI-only files.
+
+---
+
+## Requirements
+
+- R1. Add focused public pages for practice-tool intent: KS2 spelling practice, KS2 grammar practice, and KS2 punctuation practice.
+- R2. Each page must be crawlable without sign-in or JavaScript execution and must contain direct UK English text that explains the practice value.
+- R3. Page claims must stay aligned with actual KS2 Mastery capability and avoid broad curriculum, assessment, or outcome guarantees.
+- R4. Each page must provide a clear path into the existing public root and demo/app experience without exposing private learner data.
+- R5. The sitemap must list only canonical public URLs, using absolute `https://ks2.eugnel.uk/...` URLs.
+- R6. Robots/discovery policy must keep public pages crawlable while excluding API, admin, demo, and private app surfaces from normal crawler discovery.
+- R7. The production audit must prove the new landing pages are real page responses, not SPA fallback copies of the root shell.
+- R8. Measurement guidance must make Search Console and privacy-conscious visitor analytics usable for choosing the next SEO slice.
+- R9. No placeholder Search Console, GA4, Zaraz, or Cloudflare analytics tokens should be committed.
+- R10. Security headers, CSP posture, auth/demo boundaries, D1/R2 state, and deployment scripts must remain unchanged unless a change is explicitly required for the new public pages.
+
+**Origin actors:** A1 prospective KS2 learner/supporting adult; A2 search crawler; A3 AI search or assistant system; A4 James/product operator; A5 KS2 Mastery app.
+
+**Origin flows:** F1 public discovery and product understanding; F2 search engine discovery and validation; F3 organic measurement and next-slice selection.
+
+**Origin acceptance examples:** AE1 public identity is understandable without sign-in; AE2 app/demo entry preserves private data boundaries; AE3 discovery files and metadata work in production; AE4 public site is understandable without authenticated app flow; AE5 measurement supports decisions; AE6 later content lanes remain open.
+
+---
+
+## Scope Boundaries
+
+- Do not build a blog, content farm, or broad keyword programme in this slice.
+- Do not add subject/problem pages such as apostrophes or Year 5 spelling words yet.
+- Do not add parent-support guidance pages yet.
+- Do not promise that Google, ChatGPT, or any AI assistant will recommend the site.
+- Do not add fake verification meta tags, fake analytics IDs, or dormant third-party snippets.
+- Do not expose authenticated read models, admin content, generated content stores, internal analytics, D1 rows, R2 objects, or learner state as public SEO content.
+- Do not change the app's authenticated routing, demo session semantics, or subject engines for SEO.
+- Do not make Cloudflare Workers run for public landing pages unless Static Assets cannot satisfy the route contract.
+
+### Deferred to Follow-Up Work
+
+- Search Console ownership verification: complete when James chooses the real Google account/property and verification method.
+- Cloudflare Web Analytics activation: complete in the dashboard or a separate configured code slice once the real hostname/site setup is confirmed.
+- GA4 or Zaraz instrumentation: add only if James chooses that stack and accepts the CSP, consent, and privacy implications.
+- Subject/problem content pages: plan after the practice-tool pages have indexing or traffic evidence.
+- Parent-support content pages: plan after the product and practice-tool identity pages have enough measurement signal.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `index.html` now carries the canonical root metadata, raw public identity copy, and JSON-LD product identity from V1.
+- `robots.txt` and `sitemap.xml` are copied as public assets by `scripts/build-public.mjs` and asserted by `scripts/assert-build-public.mjs`.
+- `wrangler.jsonc` serves `dist/public` through Cloudflare Workers Static Assets with `not_found_handling: "single-page-application"`.
+- `scripts/build-public.mjs` is the public-output assembly seam; it already versions the app bundle and writes the generated CSP hash artefact.
+- `scripts/assert-build-public.mjs` enforces the public-output allowlist and should be extended for any new top-level landing-page directories.
+- `_headers`, `scripts/lib/headers-drift.mjs`, and `tests/security-headers.test.js` define the static asset cache/security contract.
+- `scripts/production-bundle-audit.mjs` and `tests/bundle-audit.test.js` are the production-facing checks that should catch SPA fallback or sitemap drift.
+- `docs/operations/seo.md` is the operator runbook for Search Console, analytics posture, production checks, and next content choices.
+- `src/surfaces/auth/AuthSurface.jsx` and `tests/react-auth-boot.test.js` are the rendered unauthenticated root surface and test path if internal links to practice pages are added there.
+
+### Institutional Learnings
+
+- `docs/solutions/workflow-issues/sys-hardening-p2-13-unit-autonomous-sprint-learnings-2026-04-26.md`: public build, Worker allowlists, audit logic, and deployment assertions should land atomically when reverting one file could leave production silently wrong.
+- `docs/solutions/architecture-patterns/admin-console-section-extraction-pattern-2026-04-27.md`: check hosting/platform routing before inventing Worker routes; this repo already uses Cloudflare SPA fallback and Static Assets.
+- Prior release-gate work shows `npm test`, `npm run check`, and `scripts/production-bundle-audit.mjs` are meaningful gates for public-surface changes.
+
+### External References
+
+- Google Search Central sitemap guidance: [developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap](https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap)
+- Google Search Central JavaScript SEO basics: [developers.google.com/search/docs/crawling-indexing/javascript/javascript-seo-basics](https://developers.google.com/search/docs/crawling-indexing/javascript/javascript-seo-basics)
+- Google Search Console and Analytics guidance: [developers.google.com/search/docs/monitor-debug/google-analytics-search-console](https://developers.google.com/search/docs/monitor-debug/google-analytics-search-console)
+- Cloudflare Web Analytics overview: [developers.cloudflare.com/web-analytics](https://developers.cloudflare.com/web-analytics/)
+- Cloudflare Web Analytics setup: [developers.cloudflare.com/web-analytics/get-started](https://developers.cloudflare.com/web-analytics/get-started/)
+- Cloudflare Web Analytics SPA tracking: [developers.cloudflare.com/web-analytics/get-started/web-analytics-spa](https://developers.cloudflare.com/web-analytics/get-started/web-analytics-spa/)
+- Cloudflare Workers Static Assets SPA routing: [developers.cloudflare.com/workers/static-assets/routing/single-page-application](https://developers.cloudflare.com/workers/static-assets/routing/single-page-application/)
+- Cloudflare Workers Static Assets HTML handling: [developers.cloudflare.com/workers/static-assets/routing/advanced/html-handling](https://developers.cloudflare.com/workers/static-assets/routing/advanced/html-handling/)
+- OpenAI crawler guidance: [platform.openai.com/docs/bots](https://platform.openai.com/docs/bots)
+
+---
+
+## Key Technical Decisions
+
+- Start V2 with practice-tool intent: These pages map directly to real product capability and to likely searches such as "KS2 spelling practice online", "KS2 grammar practice", and "KS2 punctuation practice".
+- Use static folder-index pages: Generate `dist/public/ks2-spelling-practice/index.html`, `dist/public/ks2-grammar-practice/index.html`, and `dist/public/ks2-punctuation-practice/index.html`, with canonical URLs ending in `/`.
+- Keep the route in Static Assets: Cloudflare's HTML handling supports folder `index.html` pages and avoids Worker execution for public content, while production audit catches fallback regressions.
+- Keep landing pages JavaScript-free in this slice: Page-specific titles, descriptions, canonical links, semantic headings, and visible copy give crawlers and AI systems readable content without expanding the inline-script/CSP surface.
+- Treat robots as a public/private boundary, not an AI-ranking lever: the existing `User-agent: *` model should keep public pages available to OAI-SearchBot and other compliant crawlers while private paths stay disallowed.
+- Prefer Search Console plus Cloudflare Web Analytics first: Search Console answers pre-visit search discovery; Cloudflare Web Analytics answers aggregate on-site visitor behaviour. GA4/Zaraz remains an explicit later choice.
+- Make production audit authoritative: The live domain must prove each new URL returns the intended page, metadata, canonical URL, and sitemap entry.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- First content lane: choose practice-tool intent for V2.
+- Route shape: use static folder-index pages with canonical trailing slashes.
+- Analytics posture: document Search Console and Cloudflare Web Analytics first; defer GA4/Zaraz and repo-injected snippets until real configuration exists.
+- AI search posture: keep public pages crawlable and avoid bot-specific robots groups that could accidentally override private-path disallows.
+
+### Deferred to Implementation
+
+- Final page copy: implementation should write concise UK English copy, but it must stay within R1-R4 and avoid unproven outcomes.
+- Exact static page source shape: implementation may use a small registry plus renderer or checked-in source HTML, as long as it stays DRY for shared metadata and assertions.
+- Final Cloudflare Web Analytics activation path: depends on the live dashboard setting for the proxied hostname.
+- Search Console verification method: depends on James's Google property setup.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+  data["Practice page source data"] --> build["scripts/build-public.mjs"]
+  root["index.html / AuthSurface links"] --> build
+  sitemap["sitemap.xml"] --> build
+  headers["_headers cache/security groups"] --> build
+  build --> pages["dist/public/<practice-slug>/index.html"]
+  build --> discovery["dist/public/robots.txt + sitemap.xml"]
+  pages --> assets["Cloudflare Static Assets"]
+  discovery --> assets
+  assets --> audit["production-bundle-audit"]
+  audit --> ops["docs/operations/seo.md measurement checklist"]
+```
+
+---
+
+## Implementation Units
+
+- U1. **Static Practice Page Generation**
+
+**Goal:** Add a maintainable source of truth for the three practice-tool pages and emit real static HTML pages into public output.
+
+**Requirements:** R1, R2, R3, R4, R7, R10; F1, F2; AE1, AE2, AE4.
+
+**Dependencies:** None.
+
+**Files:**
+- Create: `scripts/lib/seo-practice-pages.mjs`
+- Modify: `scripts/build-public.mjs`
+- Modify: `scripts/assert-build-public.mjs`
+- Modify: `_headers`
+- Modify: `scripts/lib/headers-drift.mjs`
+- Modify: `tests/build-public.test.js`
+- Modify: `tests/security-headers.test.js`
+
+**Approach:**
+- Add a small page registry for slug, title, description, canonical URL, heading, subject-specific copy, and CTA links.
+- Generate three static folder-index pages under `dist/public`, one per practice-tool intent.
+- Keep the generated pages JavaScript-free and app-state-free; they should link into the product rather than boot the product.
+- Extend the public-output allowlist for the three page directories and assert that no raw source, worker source, private routes, or unexpected top-level files ship.
+- Add explicit `_headers` cache/security blocks for the canonical practice-page HTML paths so they do not fall through to browser heuristic caching.
+- Extend the cache-split drift rules for those page paths, keeping HTML `no-store` consistent with the root page.
+
+**Patterns to follow:**
+- Existing public asset assembly in `scripts/build-public.mjs`.
+- Public output assertions in `scripts/assert-build-public.mjs`.
+- Current SEO assertions in `tests/build-public.test.js`.
+
+**Test scenarios:**
+- Happy path: build output contains `ks2-spelling-practice/index.html`, `ks2-grammar-practice/index.html`, and `ks2-punctuation-practice/index.html`.
+- Happy path: each generated page has a unique title, meta description, canonical trailing-slash URL, H1, and subject-specific KS2 practice copy.
+- Integration: generated pages do not load the React app bundle, do not contain `#app` private state, and do not expose API/admin/demo payloads.
+- Integration: static header drift tests require explicit no-store cache blocks for each generated HTML page.
+- Edge case: a page registry entry with a mismatched slug/canonical pairing fails the public assertion.
+- Error path: deleting one generated page or changing it into root app-shell HTML fails the build-public assertion.
+
+**Verification:**
+- The public build produces three standalone, crawler-readable landing pages from one maintainable source of truth.
+
+---
+
+- U2. **Practice Copy and Internal Discovery Links**
+
+**Goal:** Make the new pages discoverable from the root and useful to humans, crawlers, and AI assistants without creating thin or overclaimed content.
+
+**Requirements:** R1, R2, R3, R4, R6, R10; F1; AE1, AE2, AE4, AE6.
+
+**Dependencies:** U1.
+
+**Files:**
+- Modify: `index.html`
+- Modify: `src/surfaces/auth/AuthSurface.jsx`
+- Modify: `styles/app.css`
+- Modify: `tests/react-auth-boot.test.js`
+- Modify: `tests/build-public.test.js`
+- Modify: `scripts/assert-build-public.mjs`
+
+**Approach:**
+- Add crawlable root links to the three practice pages, so crawlers can discover them through HTML links as well as the sitemap.
+- Add rendered AuthSurface links only if they fit the existing unauthenticated surface without turning it into a marketing page.
+- Write page copy around the concrete practice outcome for each subject: spelling word confidence, grammar sentence accuracy, and punctuation clarity.
+- Keep internal links plain `<a href>` links, not hash routes or JavaScript-only navigation.
+- Keep CTAs pointed at the existing root/demo entry points and never reveal private learner state.
+
+**Patterns to follow:**
+- Existing root fallback content in `index.html`.
+- Existing unauthenticated copy and action layout in `src/surfaces/auth/AuthSurface.jsx`.
+- AuthSurface render tests in `tests/react-auth-boot.test.js`.
+
+**Test scenarios:**
+- Covers AE1. Happy path: root HTML exposes links to all three practice pages with crawlable `href` attributes.
+- Covers AE2. Happy path: rendered AuthSurface still shows the existing sign-in/demo paths and does not require a session to see practice page links.
+- Edge case: internal links use canonical trailing-slash URLs and do not advertise non-canonical `.html` variants.
+- Error path: page copy or assertions fail if a page drops the subject-specific KS2 wording needed for AI-readable product understanding.
+
+**Verification:**
+- The root and unauthenticated public surface create a coherent discovery graph from product identity to practice-tool pages.
+
+---
+
+- U3. **Sitemap, Robots, and AI-Crawler Discovery Contract**
+
+**Goal:** Publish the new pages through discovery files while preserving private route exclusions and avoiding crawler-specific policy mistakes.
+
+**Requirements:** R5, R6, R7, R9, R10; F2; AE3, AE5, AE6.
+
+**Dependencies:** U1, U2.
+
+**Files:**
+- Modify: `sitemap.xml`
+- Modify: `robots.txt`
+- Modify: `scripts/assert-build-public.mjs`
+- Modify: `tests/build-public.test.js`
+
+**Approach:**
+- Add the three canonical practice-page URLs to the sitemap using fully-qualified absolute URLs.
+- Keep the root URL in the sitemap and keep private/demo/admin/API surfaces out.
+- Preserve the generic `User-agent: *` policy with private path disallows so compliant search and AI crawlers can fetch public pages.
+- Avoid adding bot-specific groups for `OAI-SearchBot`, `GPTBot`, or `ChatGPT-User` unless every private-path disallow is repeated correctly in those groups.
+- Keep the `Sitemap:` directive in `robots.txt`.
+
+**Patterns to follow:**
+- Current V1 robots and sitemap assertions in `scripts/assert-build-public.mjs`.
+- Google Search Central sitemap rules for absolute canonical URLs.
+- OpenAI crawler guidance that `OAI-SearchBot` is the search crawler and can be managed independently through robots.txt.
+
+**Test scenarios:**
+- Covers AE3. Happy path: sitemap contains exactly the canonical root plus the three practice-page URLs.
+- Happy path: every sitemap URL is absolute, uses `https://ks2.eugnel.uk/`, and uses the canonical trailing-slash form for practice pages.
+- Edge case: sitemap assertions fail if `/demo`, `/admin`, `/api`, `.html`, localhost, or non-canonical duplicate variants appear.
+- Error path: robots assertions fail if the sitemap directive disappears or private path disallows are removed.
+- Integration: robots policy does not explicitly disallow `OAI-SearchBot` or other AI-search crawlers from the public pages.
+
+**Verification:**
+- Discovery files accurately advertise only the intended public pages and keep crawler access aligned with the product privacy boundary.
+
+---
+
+- U4. **Production Audit for Practice Pages**
+
+**Goal:** Extend the live production audit so deployment cannot silently serve SPA fallback HTML, duplicate root metadata, or stale sitemap data for the new pages.
+
+**Requirements:** R2, R3, R5, R6, R7, R10; F2; AE3, AE4.
+
+**Dependencies:** U1, U2, U3.
+
+**Files:**
+- Modify: `scripts/production-bundle-audit.mjs`
+- Modify: `tests/bundle-audit.test.js`
+
+**Approach:**
+- Fetch each practice page from the configured production URL and validate status, content type where available, title, meta description, canonical URL, H1, and subject-specific content.
+- Fail if a practice page returns the root page's title/canonical or a generic SPA shell.
+- Validate sitemap coverage for all four public URLs and no private URL leakage.
+- Validate the expected no-store cache policy for the practice-page HTML responses.
+- Keep failures specific enough to name the affected URL and missing contract.
+- Preserve the existing forbidden-token, cache-split, security-header, demo bootstrap, and root SEO checks.
+
+**Execution note:** Start with stub-origin tests for valid pages and fallback failures before changing the audit script, because this is a release gate.
+
+**Patterns to follow:**
+- Existing SEO stub server and audit tests in `tests/bundle-audit.test.js`.
+- Current production SEO checks in `scripts/production-bundle-audit.mjs`.
+
+**Test scenarios:**
+- Happy path: a stub origin serving valid root, robots, sitemap, and three practice pages passes the production audit.
+- Error path: `/ks2-spelling-practice/` returning the root app shell fails with a page-specific SPA fallback or canonical mismatch message.
+- Error path: a practice page missing its canonical URL fails.
+- Error path: sitemap missing one practice page fails.
+- Error path: sitemap includes `/demo`, `/api`, `/admin`, localhost, or a non-canonical `.html` variant and fails.
+- Integration: practice-page audit works without authenticated app APIs or demo session setup.
+
+**Verification:**
+- The production audit distinguishes a real V2 public discovery surface from a deployment that only serves the V1 root shell everywhere.
+
+---
+
+- U5. **Measurement and SEO Operations Runbook**
+
+**Goal:** Give James a concrete measurement and crawler-visibility path for the V2 pages without committing unknown analytics configuration.
+
+**Requirements:** R8, R9, R10; F3; AE5, AE6.
+
+**Dependencies:** U1, U3, U4.
+
+**Files:**
+- Modify: `docs/operations/seo.md`
+
+**Approach:**
+- Update the runbook with the four public URLs, Search Console sitemap submission, URL inspection steps, and the first metrics to monitor: impressions, clicks, CTR, queries, indexed status, and landing pages.
+- Document Cloudflare Web Analytics as the preferred first visitor-analytics layer, including the dashboard automatic setup path for proxied sites and the manual snippet path only when a real token is available.
+- Record that Cloudflare Web Analytics can track SPA interactions, but the V2 landing pages themselves are static and should be measured as page views.
+- Add an AI crawler check section: keep `OAI-SearchBot` publicly allowed through robots, verify Cloudflare security/bot settings are not blocking desired AI search crawlers, and avoid interpreting crawler access as recommendation certainty.
+- Keep GA4/Zaraz as a deferred explicit stack decision with consent/CSP review.
+
+**Patterns to follow:**
+- Existing `docs/operations/seo.md` tone and structure.
+- Existing capacity and deployment runbooks that distinguish code checks from dashboard/operator actions.
+
+**Test scenarios:**
+- Test expectation: none -- this unit is documentation and external-operations guidance only.
+
+**Verification:**
+- The runbook tells an operator what to submit, what to inspect, what to measure, and which analytics work is intentionally not in this PR.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Public page source data, `scripts/build-public.mjs`, static asset output, sitemap/robots, root/AuthSurface links, `_headers`, and production audit jointly define the V2 SEO contract.
+- **Error propagation:** Local build assertions catch missing artefacts and copy drift; production audit catches Cloudflare fallback, canonical, and sitemap regressions after deploy.
+- **State lifecycle risks:** No learner state, D1 data, R2 objects, session cookies, generated content stores, or admin data should be read or exposed by the new pages.
+- **API surface parity:** No Worker API route, subject command, database, or authenticated app contract should change.
+- **Integration coverage:** Unit-level HTML assertions are not enough; the production audit must fetch the deployed URLs that crawlers and AI systems will see.
+- **Unchanged invariants:** Existing root identity, demo entry, app bundle delivery, CSP Report-Only mode, security headers, and deployment scripts remain in place.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Static practice URLs fall through to the root SPA shell | Generate real folder-index pages and add live production audit checks for page-specific canonical URLs and copy. |
+| Trailing-slash and non-trailing-slash variants create duplicate identity | Use one canonical trailing-slash URL per practice page and list only that form in sitemap and links. |
+| Pages become thin or overclaim product capability | Keep copy scoped to real spelling, grammar, and punctuation practice outcomes and assert subject-specific text. |
+| AI crawler robots changes accidentally open or block the wrong paths | Avoid bot-specific groups unless private disallows are repeated; audit the generic policy and document external Cloudflare bot settings. |
+| Analytics wiring creates false confidence or privacy/CSP drift | Do not commit placeholder tags; document Search Console and Cloudflare Web Analytics setup with real configuration as a prerequisite. |
+| Public output allowlist broadens too far | Add only the three intended page directories and keep existing raw-source/private-output assertions. |
+
+---
+
+## Documentation / Operational Notes
+
+- After deployment, run the production audit against `https://ks2.eugnel.uk/` and inspect all four sitemap URLs.
+- Submit or resubmit `https://ks2.eugnel.uk/sitemap.xml` in Search Console after deployment.
+- If Cloudflare Web Analytics is enabled through automatic dashboard setup, record that external state in `docs/operations/seo.md` during the same release handoff.
+- If a manual Cloudflare or GA snippet is later required, treat it as a separate code change touching CSP `script-src`/`connect-src`, consent posture, and production audit.
+
+---
+
+## Alternative Approaches Considered
+
+- Worker-rendered SEO pages: rejected for V2 because Static Assets can serve folder-index pages and avoids extra Worker invocations or auth-route blast radius.
+- `.html` practice URLs: rejected because extensionless canonical landing pages are cleaner and Cloudflare HTML handling supports folder `index.html` routes.
+- Subject/problem pages first: rejected because practice-tool pages map more directly to current product capability and are safer before traffic evidence exists.
+- GA4 first: rejected because there is no real property configuration yet and Cloudflare Web Analytics is a lower-friction fit with the current hosting stack.
+- `llms.txt` as the main AI-search mechanism: deferred because official crawler control still depends on crawlable public pages and robots policy; a text summary can be considered later but should not replace normal web discovery.
+
+---
+
+## Success Metrics
+
+- Live `/ks2-spelling-practice/`, `/ks2-grammar-practice/`, and `/ks2-punctuation-practice/` return page-specific public HTML, not the root app shell.
+- `sitemap.xml` lists the root plus the three practice pages and no private or duplicate URLs.
+- `robots.txt` continues to advertise the sitemap and disallow private surfaces while leaving public pages crawlable.
+- Search Console can inspect the four public URLs and report indexing/query data.
+- James can review Cloudflare Web Analytics or the chosen visitor analytics layer to see aggregate page traffic after setup.
+
+---
+
+## Sources & References
+
+- Origin document: [docs/brainstorms/2026-04-28-ks2-seo-foundation-requirements.md](../brainstorms/2026-04-28-ks2-seo-foundation-requirements.md)
+- V1 SEO plan: [docs/plans/2026-04-28-002-feat-ks2-seo-foundation-plan.md](2026-04-28-002-feat-ks2-seo-foundation-plan.md)
+- SEO runbook: [docs/operations/seo.md](../operations/seo.md)
+- Public root shell: `index.html`
+- Public discovery files: `robots.txt`, `sitemap.xml`
+- Public build: `scripts/build-public.mjs`
+- Public build assertion: `scripts/assert-build-public.mjs`
+- Production audit: `scripts/production-bundle-audit.mjs`
+- Static headers: `_headers`
+- Worker deployment config: `wrangler.jsonc`
+- Google sitemap guidance: [developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap](https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap)
+- Google JavaScript SEO basics: [developers.google.com/search/docs/crawling-indexing/javascript/javascript-seo-basics](https://developers.google.com/search/docs/crawling-indexing/javascript/javascript-seo-basics)
+- Google Search Console and Analytics guidance: [developers.google.com/search/docs/monitor-debug/google-analytics-search-console](https://developers.google.com/search/docs/monitor-debug/google-analytics-search-console)
+- Cloudflare Web Analytics: [developers.cloudflare.com/web-analytics](https://developers.cloudflare.com/web-analytics/)
+- Cloudflare Web Analytics setup: [developers.cloudflare.com/web-analytics/get-started](https://developers.cloudflare.com/web-analytics/get-started/)
+- Cloudflare Web Analytics SPA tracking: [developers.cloudflare.com/web-analytics/get-started/web-analytics-spa](https://developers.cloudflare.com/web-analytics/get-started/web-analytics-spa/)
+- Cloudflare Workers Static Assets SPA routing: [developers.cloudflare.com/workers/static-assets/routing/single-page-application](https://developers.cloudflare.com/workers/static-assets/routing/single-page-application/)
+- Cloudflare Workers Static Assets HTML handling: [developers.cloudflare.com/workers/static-assets/routing/advanced/html-handling](https://developers.cloudflare.com/workers/static-assets/routing/advanced/html-handling/)
+- OpenAI crawler guidance: [platform.openai.com/docs/bots](https://platform.openai.com/docs/bots)

--- a/index.html
+++ b/index.html
@@ -81,6 +81,11 @@
           <li>Grammar practice for sentence-level accuracy</li>
           <li>Punctuation practice for clearer written English</li>
         </ul>
+        <nav class="seo-practice-links" aria-label="KS2 practice pages">
+          <a href="/ks2-spelling-practice/">KS2 spelling practice online</a>
+          <a href="/ks2-grammar-practice/">KS2 grammar practice online</a>
+          <a href="/ks2-punctuation-practice/">KS2 punctuation practice online</a>
+        </nav>
         <p><a class="btn primary lg" href="/demo">Try demo</a></p>
       </section>
     </main>

--- a/scripts/assert-build-public.mjs
+++ b/scripts/assert-build-public.mjs
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { createHash } from 'node:crypto';
 import { assertCacheSplitRules, assertHeadersBlockIsFresh } from './lib/headers-drift.mjs';
+import { PRACTICE_SEO_PAGES, canonicalPracticePageUrl } from './lib/seo-practice-pages.mjs';
 
 const rootDir = process.cwd();
 const publicDir = path.join(rootDir, 'dist', 'public');
@@ -39,6 +40,71 @@ function assertContainsAll(label, value, expectedTokens) {
   for (const token of expectedTokens) {
     if (!value.includes(token)) {
       throw new Error(`${label} must include: ${token}`);
+    }
+  }
+}
+
+function sitemapLocs(xml) {
+  return Array.from(xml.matchAll(/<loc>([^<]+)<\/loc>/giu), (match) => match[1]);
+}
+
+function assertExactSitemapLocs(label, xml, expectedLocs) {
+  const actual = sitemapLocs(xml);
+  const expected = new Set(expectedLocs);
+  const actualSet = new Set(actual);
+  const duplicates = actual.filter((loc, index) => actual.indexOf(loc) !== index);
+  const missing = expectedLocs.filter((loc) => !actualSet.has(loc));
+  const unexpected = actual.filter((loc) => !expected.has(loc));
+  if (
+    actual.length !== expectedLocs.length
+    || actualSet.size !== actual.length
+    || missing.length
+    || unexpected.length
+  ) {
+    throw new Error(`${label} must contain exactly ${expectedLocs.join(', ')}. Missing: ${missing.join(', ') || 'none'}. Unexpected: ${unexpected.join(', ') || 'none'}. Duplicates: ${duplicates.join(', ') || 'none'}.`);
+  }
+}
+
+const PUBLIC_SEO_PAGE_FORBIDDEN_TEXT = Object.freeze([
+  'SEEDED_SPELLING_CONTENT_BUNDLE',
+  'SEEDED_SPELLING_PUBLISHED_SNAPSHOT',
+  'Legacy vendor seed for Pass 11 content model',
+  'createLegacySpellingEngine',
+  'KS2_WORDS_ENRICHED',
+  'spelling-prompt-v1',
+  'PUNCTUATION_CONTENT_MANIFEST',
+  'PUNCTUATION_CONTEXT_PACK_LIMITS',
+  'createPunctuationContentIndexes',
+  'createPunctuationGeneratedItems',
+  'createPunctuationRuntimeManifest',
+  'normalisePunctuationContextPack',
+  'createPunctuationService',
+  'PunctuationServiceError',
+  'punctuation-r1-endmarks-apostrophe-speech',
+  '/api/child-subject-state',
+  '/api/practice-sessions',
+  '/api/child-game-state',
+  '/api/event-log',
+  '/api/debug/reset',
+  'OPENAI_API_KEY',
+  'GEMINI_API_KEY',
+  'ANTHROPIC_API_KEY',
+  'PUNCTUATION_AI_CONTEXT_PACK_JSON',
+  'PUNCTUATION_AI_CONTEXT_PACK_KEY',
+  'generativelanguage.googleapis.com',
+  'api.openai.com/v1',
+  '?local=1',
+  'data-home-mount',
+  'data-subject-mount',
+  'home.bundle.js',
+  '__ks2_injectFault_TESTS_ONLY__',
+  '__ks2_capacityMeta__',
+]);
+
+function assertNoPublicSeoForbiddenText(label, html) {
+  for (const token of PUBLIC_SEO_PAGE_FORBIDDEN_TEXT) {
+    if (html.includes(token)) {
+      throw new Error(`${label} includes forbidden public SEO token: ${token}`);
     }
   }
 }
@@ -88,6 +154,9 @@ await mustExist('index.html');
 await mustExist('manifest.webmanifest');
 await mustExist('robots.txt');
 await mustExist('sitemap.xml');
+for (const page of PRACTICE_SEO_PAGES) {
+  await mustExist(`${page.slug}/index.html`);
+}
 await mustExist('favicon.ico');
 await mustExist('_headers');
 await mustExist('styles/app.css');
@@ -145,6 +214,7 @@ const allowed = new Set([
   'manifest.webmanifest',
   'robots.txt',
   'sitemap.xml',
+  ...PRACTICE_SEO_PAGES.map((page) => page.slug),
   'styles',
   'src',
   'assets',
@@ -205,6 +275,10 @@ const indexHtml = await readFile(path.join(publicDir, 'index.html'), 'utf8');
 const appBundle = await readFile(path.join(publicDir, 'src/bundles/app.bundle.js'), 'utf8');
 const robotsTxt = await readFile(path.join(publicDir, 'robots.txt'), 'utf8');
 const sitemapXml = await readFile(path.join(publicDir, 'sitemap.xml'), 'utf8');
+const practicePageHtml = new Map();
+for (const page of PRACTICE_SEO_PAGES) {
+  practicePageHtml.set(page.slug, await readFile(path.join(publicDir, page.slug, 'index.html'), 'utf8'));
+}
 const cspHashArtefact = await readFile(path.join(publicDir, '.csp-theme-hash'), 'utf8');
 const canonicalRoot = 'https://ks2.eugnel.uk/';
 if (!indexHtml.includes('/manifest.webmanifest')) {
@@ -237,6 +311,9 @@ assertContainsAll('Public index.html SEO identity', indexHtml, [
   'Spelling practice for KS2 word confidence',
   'Grammar practice for sentence-level accuracy',
   'Punctuation practice for clearer written English',
+  'href="/ks2-spelling-practice/"',
+  'href="/ks2-grammar-practice/"',
+  'href="/ks2-punctuation-practice/"',
 ]);
 
 const productIdentity = jsonLdBlocks(indexHtml).find((entry) => entry?.name === 'KS2 Mastery');
@@ -276,11 +353,42 @@ if (/<\/?html|<!doctype/i.test(sitemapXml)) {
 assertContainsAll('sitemap.xml', sitemapXml, [
   '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
   `<loc>${canonicalRoot}</loc>`,
+  ...PRACTICE_SEO_PAGES.map((page) => `<loc>${canonicalPracticePageUrl(page)}</loc>`),
 ]);
-for (const forbiddenPublicPath of ['/api/', '/admin', 'localhost', '127.0.0.1']) {
+assertExactSitemapLocs('sitemap.xml', sitemapXml, [
+  canonicalRoot,
+  ...PRACTICE_SEO_PAGES.map((page) => canonicalPracticePageUrl(page)),
+]);
+for (const forbiddenPublicPath of ['/api/', '/admin', '/demo', '.html', 'localhost', '127.0.0.1']) {
   if (sitemapXml.includes(forbiddenPublicPath)) {
     throw new Error(`sitemap.xml must not advertise private or local path: ${forbiddenPublicPath}`);
   }
+}
+
+for (const page of PRACTICE_SEO_PAGES) {
+  const html = practicePageHtml.get(page.slug);
+  const canonicalUrl = canonicalPracticePageUrl(page);
+  assertContainsAll(`Public ${page.slug} SEO page`, html, [
+    `<title>${page.title}</title>`,
+    `<meta name="description" content="${page.description}" />`,
+    `<link rel="canonical" href="${canonicalUrl}" />`,
+    `<meta property="og:url" content="${canonicalUrl}" />`,
+    `<h1>${page.heading}</h1>`,
+    page.intro,
+    '/demo',
+    'KS2 Mastery home',
+  ]);
+  for (const point of page.points) {
+    if (!html.includes(point)) {
+      throw new Error(`Public ${page.slug} SEO page must include practice point: ${point}`);
+    }
+  }
+  for (const forbiddenToken of ['app.bundle.js', 'id="app"', 'application/ld+json', '<script']) {
+    if (html.includes(forbiddenToken)) {
+      throw new Error(`Public ${page.slug} SEO page must not include app-shell or inline-script token: ${forbiddenToken}`);
+    }
+  }
+  assertNoPublicSeoForbiddenText(`Public ${page.slug} SEO page`, html);
 }
 
 for (const token of [

--- a/scripts/build-public.mjs
+++ b/scripts/build-public.mjs
@@ -2,6 +2,7 @@ import { cp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { createHash } from 'node:crypto';
 import { computeInlineScriptHashes } from './compute-inline-script-hash.mjs';
+import { PRACTICE_SEO_PAGES, renderPracticeSeoPage } from './lib/seo-practice-pages.mjs';
 
 const rootDir = process.cwd();
 const outputDir = path.join(rootDir, 'dist', 'public');
@@ -133,6 +134,12 @@ try {
     tmpIndexHtml.replaceAll(appBundleScriptSrc, `${appBundleScriptSrc}?v=${appBundleVersion}`),
     'utf8',
   );
+
+  for (const page of PRACTICE_SEO_PAGES) {
+    const pageDir = path.join(tmpDir, page.slug);
+    await mkdir(pageDir, { recursive: true });
+    await writeFile(path.join(pageDir, 'index.html'), renderPracticeSeoPage(page), 'utf8');
+  }
 
   await rm(outputDir, { recursive: true, force: true });
   await cp(tmpDir, outputDir, { recursive: true, force: true });

--- a/scripts/lib/headers-drift.mjs
+++ b/scripts/lib/headers-drift.mjs
@@ -131,6 +131,9 @@ export const CACHE_SPLIT_RULES = Object.freeze([
   { path: '/manifest.webmanifest', cacheControl: 'public, max-age=3600' },
   { path: '/robots.txt', cacheControl: 'public, max-age=3600' },
   { path: '/sitemap.xml', cacheControl: 'public, max-age=3600' },
+  { path: '/ks2-spelling-practice/', cacheControl: 'no-store' },
+  { path: '/ks2-grammar-practice/', cacheControl: 'no-store' },
+  { path: '/ks2-punctuation-practice/', cacheControl: 'no-store' },
   { path: '/', cacheControl: 'no-store' },
   { path: '/index.html', cacheControl: 'no-store' },
 ]);

--- a/scripts/lib/seo-practice-pages.mjs
+++ b/scripts/lib/seo-practice-pages.mjs
@@ -1,0 +1,121 @@
+const CANONICAL_ROOT = 'https://ks2.eugnel.uk/';
+
+export const PRACTICE_SEO_PAGES = Object.freeze([
+  Object.freeze({
+    slug: 'ks2-spelling-practice',
+    title: 'KS2 Spelling Practice Online | KS2 Mastery',
+    description: 'Practise KS2 spelling online with focused word work for confidence, accuracy and independent English practice.',
+    eyebrow: 'KS2 spelling practice',
+    heading: 'KS2 spelling practice online',
+    intro: 'Build word confidence with short, focused KS2 spelling practice. KS2 Mastery helps learners practise words online and move into a demo or signed-in session when they are ready.',
+    points: [
+      'Practise KS2 spelling words with focused online sessions',
+      'Strengthen accuracy, recall and independent word confidence',
+      'Try the demo before signing in to save learner progress',
+    ],
+  }),
+  Object.freeze({
+    slug: 'ks2-grammar-practice',
+    title: 'KS2 Grammar Practice Online | KS2 Mastery',
+    description: 'Practise KS2 grammar online with focused sentence-level work for clearer, more accurate English.',
+    eyebrow: 'KS2 grammar practice',
+    heading: 'KS2 grammar practice online',
+    intro: 'KS2 Mastery supports grammar practice through focused online sessions that help learners work on sentence accuracy and understand how English fits together.',
+    points: [
+      'Practise KS2 grammar through short online activities',
+      'Build sentence-level accuracy and language confidence',
+      'Use the demo path to try the practice flow before signing in',
+    ],
+  }),
+  Object.freeze({
+    slug: 'ks2-punctuation-practice',
+    title: 'KS2 Punctuation Practice Online | KS2 Mastery',
+    description: 'Practise KS2 punctuation online with focused activities for clearer written English.',
+    eyebrow: 'KS2 punctuation practice',
+    heading: 'KS2 punctuation practice online',
+    intro: 'KS2 Mastery helps learners practise punctuation online so they can build clearer written English through focused, repeatable practice.',
+    points: [
+      'Practise KS2 punctuation in focused online sessions',
+      'Work on clearer sentence meaning and written accuracy',
+      'Start with the demo, then sign in when you want saved progress',
+    ],
+  }),
+]);
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function renderPoint(point) {
+  return `          <li>${escapeHtml(point)}</li>`;
+}
+
+export function canonicalPracticePageUrl(page) {
+  return `${CANONICAL_ROOT}${page.slug}/`;
+}
+
+export function renderPracticeSeoPage(page) {
+  const canonicalUrl = canonicalPracticePageUrl(page);
+  const escapedTitle = escapeHtml(page.title);
+  const escapedDescription = escapeHtml(page.description);
+  const escapedHeading = escapeHtml(page.heading);
+  const escapedEyebrow = escapeHtml(page.eyebrow);
+  const escapedIntro = escapeHtml(page.intro);
+  return `<!DOCTYPE html>
+<html lang="en-GB">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <meta name="application-name" content="KS2 Mastery" />
+  <meta name="description" content="${escapedDescription}" />
+  <meta name="color-scheme" content="light dark" />
+  <meta name="theme-color" content="#F6F5F1" media="(prefers-color-scheme: light)" />
+  <meta name="theme-color" content="#0F1620" media="(prefers-color-scheme: dark)" />
+  <meta property="og:site_name" content="KS2 Mastery" />
+  <meta property="og:title" content="${escapedTitle}" />
+  <meta property="og:description" content="${escapedDescription}" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="${canonicalUrl}" />
+  <meta property="og:locale" content="en_GB" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="${escapedTitle}" />
+  <meta name="twitter:description" content="${escapedDescription}" />
+  <title>${escapedTitle}</title>
+  <link rel="canonical" href="${canonicalUrl}" />
+  <link rel="manifest" href="/manifest.webmanifest" />
+  <link rel="icon" href="/favicon.ico" sizes="any" />
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/app-icons/favicon-32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/assets/app-icons/favicon-16.png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/assets/app-icons/apple-touch-icon.png" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Inter:wght@400;500;600;700&display=swap" />
+  <link rel="stylesheet" href="/styles/app.css" />
+</head>
+<body class="practice-public-page">
+  <header class="practice-public-nav" aria-label="Site">
+    <a href="/">KS2 Mastery</a>
+  </header>
+  <main class="practice-public-shell">
+    <section class="practice-public-panel">
+      <p class="eyebrow">${escapedEyebrow}</p>
+      <h1>${escapedHeading}</h1>
+      <p class="practice-public-intro">${escapedIntro}</p>
+      <ul class="practice-public-list" aria-label="${escapedEyebrow} benefits">
+${page.points.map(renderPoint).join('\n')}
+      </ul>
+      <div class="actions practice-public-actions">
+        <a class="btn primary lg" href="/demo">Try demo</a>
+        <a class="btn secondary lg" href="/">KS2 Mastery home</a>
+      </div>
+    </section>
+  </main>
+</body>
+</html>
+`;
+}

--- a/scripts/production-bundle-audit.mjs
+++ b/scripts/production-bundle-audit.mjs
@@ -1,5 +1,6 @@
 import { runClientBundleAudit } from './audit-client-bundle.mjs';
 import { createDemoSession, loadBootstrap } from './lib/production-smoke.mjs';
+import { PRACTICE_SEO_PAGES, canonicalPracticePageUrl } from './lib/seo-practice-pages.mjs';
 import { FORBIDDEN_KEYS_EVERYWHERE } from '../tests/helpers/forbidden-keys.mjs';
 
 const DEFAULT_ORIGIN = 'https://ks2.eugnel.uk';
@@ -189,6 +190,54 @@ function assertSeoRootHtml(index, failures) {
   }
 }
 
+function assertSeoPracticePageHtml(page, response, failures) {
+  const path = `/${page.slug}/`;
+  const canonicalUrl = canonicalPracticePageUrl(page);
+  if (response.status < 200 || response.status >= 300) {
+    failures.push(`Production SEO page ${path} fetch failed: ${response.status} ${response.url}`);
+    return;
+  }
+  if (!/text\/html/i.test(response.contentType)) {
+    failures.push(`Production SEO page ${path} expected text/html, got: ${response.contentType || 'absent'}`);
+  }
+  if (
+    response.text.includes('<title>KS2 Mastery | KS2 Spelling, Grammar and Punctuation Practice</title>')
+    || response.text.includes(`<link rel="canonical" href="${SEO_CANONICAL_ROOT}"`)
+    || response.text.includes('app.bundle.js')
+    || response.text.includes('id="app"')
+  ) {
+    failures.push(`Production SEO page ${path} appears to be the root SPA shell, not page-specific public HTML.`);
+  }
+  for (const token of [
+    `<title>${page.title}</title>`,
+    `<meta name="description" content="${page.description}"`,
+    `<link rel="canonical" href="${canonicalUrl}"`,
+    `<meta property="og:url" content="${canonicalUrl}"`,
+    `<h1>${page.heading}</h1>`,
+    page.intro,
+    '/demo',
+    'KS2 Mastery home',
+    ...page.points,
+  ]) {
+    if (!response.text.includes(token)) {
+      failures.push(`Production SEO page ${path} is missing required token: ${token}`);
+    }
+  }
+  for (const forbiddenToken of ['application/ld+json', '<script']) {
+    if (response.text.includes(forbiddenToken)) {
+      failures.push(`Production SEO page ${path} must remain static and script-free; found token: ${forbiddenToken}`);
+    }
+  }
+  assertNoForbiddenText(`Production SEO page ${path}`, response.text, failures);
+}
+
+async function assertSeoPracticePages(base, failures) {
+  for (const page of PRACTICE_SEO_PAGES) {
+    const response = await fetchText(new URL(`/${page.slug}/`, base).href);
+    assertSeoPracticePageHtml(page, response, failures);
+  }
+}
+
 async function assertSeoDiscoveryResources(base, failures) {
   const robots = await fetchText(new URL('/robots.txt', base).href);
   if (robots.status < 200 || robots.status >= 300) {
@@ -209,6 +258,9 @@ async function assertSeoDiscoveryResources(base, failures) {
       failures.push(`Production robots.txt is missing required token: ${token}`);
     }
   }
+  if (/User-agent:\s*OAI-SearchBot[\s\S]*?Disallow:\s*\//i.test(robots.text)) {
+    failures.push('Production robots.txt must not explicitly disallow OAI-SearchBot from public SEO pages.');
+  }
 
   const sitemap = await fetchText(new URL('/sitemap.xml', base).href);
   if (sitemap.status < 200 || sitemap.status >= 300) {
@@ -220,12 +272,17 @@ async function assertSeoDiscoveryResources(base, failures) {
   for (const token of [
     '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
     `<loc>${SEO_CANONICAL_ROOT}</loc>`,
+    ...PRACTICE_SEO_PAGES.map((page) => `<loc>${canonicalPracticePageUrl(page)}</loc>`),
   ]) {
     if (!sitemap.text.includes(token)) {
       failures.push(`Production sitemap.xml is missing required token: ${token}`);
     }
   }
-  for (const forbiddenPath of ['/api/', '/admin', 'localhost', '127.0.0.1']) {
+  assertExactSitemapLocs('Production sitemap.xml', sitemap.text, [
+    SEO_CANONICAL_ROOT,
+    ...PRACTICE_SEO_PAGES.map((page) => canonicalPracticePageUrl(page)),
+  ], failures);
+  for (const forbiddenPath of ['/api/', '/admin', '/demo', '.html', 'localhost', '127.0.0.1']) {
     if (sitemap.text.includes(forbiddenPath)) {
       failures.push(`Production sitemap.xml must not advertise private or local path: ${forbiddenPath}`);
     }
@@ -312,6 +369,27 @@ function assertNoForbiddenText(label, text, failures) {
   }
 }
 
+function sitemapLocs(xml) {
+  return Array.from(xml.matchAll(/<loc>([^<]+)<\/loc>/giu), (match) => match[1]);
+}
+
+function assertExactSitemapLocs(label, xml, expectedLocs, failures) {
+  const actual = sitemapLocs(xml);
+  const expected = new Set(expectedLocs);
+  const actualSet = new Set(actual);
+  const duplicates = actual.filter((loc, index) => actual.indexOf(loc) !== index);
+  const missing = expectedLocs.filter((loc) => !actualSet.has(loc));
+  const unexpected = actual.filter((loc) => !expected.has(loc));
+  if (
+    actual.length !== expectedLocs.length
+    || actualSet.size !== actual.length
+    || missing.length
+    || unexpected.length
+  ) {
+    failures.push(`${label} must contain exactly ${expectedLocs.join(', ')}. Missing: ${missing.join(', ') || 'none'}. Unexpected: ${unexpected.join(', ') || 'none'}. Duplicates: ${duplicates.join(', ') || 'none'}.`);
+  }
+}
+
 function firstSourceSplitChunkPath(paths) {
   return Array.from(paths)
     .sort()
@@ -332,6 +410,7 @@ async function auditProduction(origin) {
   assertNoForbiddenText('Production HTML', index.text, failures);
   assertSeoRootHtml(index, failures);
   await assertSeoDiscoveryResources(base, failures);
+  await assertSeoPracticePages(base, failures);
 
   const scripts = scriptSources(index.text)
     .filter((src) => !/^https?:\/\//i.test(src) || new URL(src, base).origin === base.origin);
@@ -546,6 +625,11 @@ async function auditProduction(origin) {
     { path: '/manifest.webmanifest', label: 'web app manifest', expected: 'public, max-age=3600' },
     { path: '/robots.txt', label: 'robots policy', expected: 'public, max-age=3600' },
     { path: '/sitemap.xml', label: 'sitemap', expected: 'public, max-age=3600' },
+    ...PRACTICE_SEO_PAGES.map((page) => ({
+      path: `/${page.slug}/`,
+      label: `${page.slug} SEO page`,
+      expected: 'no-store',
+    })),
   ].filter(Boolean);
   let cacheChecksPassed = 0;
   for (const check of CACHE_SPLIT_CHECKS) {

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -3,4 +3,13 @@
   <url>
     <loc>https://ks2.eugnel.uk/</loc>
   </url>
+  <url>
+    <loc>https://ks2.eugnel.uk/ks2-spelling-practice/</loc>
+  </url>
+  <url>
+    <loc>https://ks2.eugnel.uk/ks2-grammar-practice/</loc>
+  </url>
+  <url>
+    <loc>https://ks2.eugnel.uk/ks2-punctuation-practice/</loc>
+  </url>
 </urlset>

--- a/src/surfaces/auth/AuthSurface.jsx
+++ b/src/surfaces/auth/AuthSurface.jsx
@@ -225,6 +225,11 @@ function AuthSurfaceStandard({ initialMode = 'login', initialError = '', onSubmi
           <li>Grammar practice for sentence-level accuracy</li>
           <li>Punctuation practice for clearer written English</li>
         </ul>
+        <nav className="auth-practice-links" aria-label="KS2 practice pages">
+          <a href="/ks2-spelling-practice/">KS2 spelling practice online</a>
+          <a href="/ks2-grammar-practice/">KS2 grammar practice online</a>
+          <a href="/ks2-punctuation-practice/">KS2 punctuation practice online</a>
+        </nav>
         {/* SH2-U8: inline style prop migrated to `.auth-standard-error` class
             (see docs/hardening/csp-inline-style-inventory.md). */}
         {error && (

--- a/styles/app.css
+++ b/styles/app.css
@@ -239,6 +239,28 @@ textarea:focus-visible {
   padding-left: 20px;
 }
 
+.seo-practice-links,
+.auth-practice-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.seo-practice-links a,
+.auth-practice-links a {
+  color: var(--brand);
+  font-size: 0.95rem;
+  font-weight: 700;
+  text-decoration: none;
+  border-bottom: 1px solid color-mix(in oklab, var(--brand) 36%, transparent);
+}
+
+.seo-practice-links a:hover,
+.auth-practice-links a:hover {
+  border-bottom-color: currentColor;
+}
+
 .seo-public-panel li + li,
 .auth-product-summary li + li {
   margin-top: 6px;
@@ -260,6 +282,79 @@ textarea:focus-visible {
   color: var(--ink-2);
   font-size: 0.95rem;
   line-height: 1.45;
+}
+
+.practice-public-page {
+  min-height: 100vh;
+  background:
+    linear-gradient(180deg, color-mix(in oklab, var(--panel-soft) 72%, transparent), transparent 46%),
+    var(--bg);
+}
+
+.practice-public-nav {
+  width: min(100%, 960px);
+  margin: 0 auto;
+  padding: 24px 28px 0;
+}
+
+.practice-public-nav a {
+  color: var(--ink);
+  font-family: var(--font-display);
+  font-size: 1.1rem;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.practice-public-shell {
+  min-height: calc(100vh - 64px);
+  display: grid;
+  align-items: center;
+  width: min(100%, 960px);
+  margin: 0 auto;
+  padding: 28px;
+}
+
+.practice-public-panel {
+  max-width: 720px;
+}
+
+.practice-public-panel h1 {
+  margin: 0;
+  color: var(--ink);
+  font-family: var(--font-display);
+  font-size: 4.2rem;
+  line-height: 0.98;
+}
+
+@media (max-width: 640px) {
+  .practice-public-panel h1 {
+    font-size: 2.45rem;
+  }
+}
+
+.practice-public-intro,
+.practice-public-list {
+  color: var(--ink-2);
+  font-size: 1.05rem;
+  line-height: 1.65;
+}
+
+.practice-public-intro {
+  margin-top: 20px;
+  max-width: 680px;
+}
+
+.practice-public-list {
+  margin-top: 18px;
+  padding-left: 22px;
+}
+
+.practice-public-list li + li {
+  margin-top: 8px;
+}
+
+.practice-public-actions {
+  margin-top: 24px;
 }
 
 .auth-switch {

--- a/tests/build-public.test.js
+++ b/tests/build-public.test.js
@@ -3,6 +3,7 @@ import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { PRACTICE_SEO_PAGES, canonicalPracticePageUrl } from '../scripts/lib/seo-practice-pages.mjs';
 
 test('public build emits the React app bundle entrypoint', () => {
   execFileSync(process.execPath, ['./scripts/build-bundles.mjs'], { stdio: 'ignore' });
@@ -13,6 +14,10 @@ test('public build emits the React app bundle entrypoint', () => {
   const indexHtml = readFileSync('dist/public/index.html', 'utf8');
   const robotsTxt = readFileSync('dist/public/robots.txt', 'utf8');
   const sitemapXml = readFileSync('dist/public/sitemap.xml', 'utf8');
+  const practicePages = new Map(PRACTICE_SEO_PAGES.map((page) => [
+    page.slug,
+    readFileSync(`dist/public/${page.slug}/index.html`, 'utf8'),
+  ]));
   const cspHashArtefact = readFileSync('dist/public/.csp-theme-hash', 'utf8');
   const appBundle = readFileSync('dist/public/src/bundles/app.bundle.js', 'utf8');
   const expectedAppBundleVersion = createHash('sha256').update(appBundle).digest('hex').slice(0, 12);
@@ -26,13 +31,38 @@ test('public build emits the React app bundle entrypoint', () => {
   assert.match(indexHtml, /<link rel="canonical" href="https:\/\/ks2\.eugnel\.uk\/" \/>/);
   assert.match(indexHtml, /application\/ld\+json/);
   assert.match(indexHtml, /KS2 spelling, grammar and punctuation practice/);
+  assert.match(indexHtml, /href="\/ks2-spelling-practice\/"/);
+  assert.match(indexHtml, /href="\/ks2-grammar-practice\/"/);
+  assert.match(indexHtml, /href="\/ks2-punctuation-practice\/"/);
   assert.match(robotsTxt, /Disallow: \/api\//);
   assert.match(robotsTxt, /Disallow: \/admin/);
   assert.match(robotsTxt, /Disallow: \/demo/);
+  assert.doesNotMatch(robotsTxt, /User-agent:\s*OAI-SearchBot[\s\S]*?Disallow:\s*\//i);
   assert.match(robotsTxt, /Sitemap: https:\/\/ks2\.eugnel\.uk\/sitemap\.xml/);
   assert.doesNotMatch(robotsTxt, /<!doctype html|<html/i);
   assert.match(sitemapXml, /<loc>https:\/\/ks2\.eugnel\.uk\/<\/loc>/);
-  assert.doesNotMatch(sitemapXml, /\/api\/|\/admin|localhost|127\.0\.0\.1/);
+  const sitemapLocs = Array.from(sitemapXml.matchAll(/<loc>([^<]+)<\/loc>/giu), (match) => match[1]);
+  assert.deepEqual(sitemapLocs, [
+    'https://ks2.eugnel.uk/',
+    ...PRACTICE_SEO_PAGES.map((page) => canonicalPracticePageUrl(page)),
+  ]);
+  for (const page of PRACTICE_SEO_PAGES) {
+    assert.match(sitemapXml, new RegExp(`<loc>${canonicalPracticePageUrl(page).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}</loc>`));
+  }
+  assert.doesNotMatch(sitemapXml, /\/api\/|\/admin|\/demo|\.html|localhost|127\.0\.0\.1/);
+  for (const page of PRACTICE_SEO_PAGES) {
+    const html = practicePages.get(page.slug);
+    assert.ok(html, `${page.slug} should be emitted as a static page`);
+    assert.match(html, new RegExp(`<title>${page.title.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}</title>`));
+    assert.match(html, new RegExp(`<link rel="canonical" href="${canonicalPracticePageUrl(page).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}" \\/>`));
+    assert.match(html, new RegExp(`<h1>${page.heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}</h1>`));
+    assert.match(html, /href="\/demo"/);
+    assert.match(html, /KS2 Mastery home/);
+    for (const point of page.points) {
+      assert.match(html, new RegExp(point.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    }
+    assert.doesNotMatch(html, /app\.bundle\.js|id="app"|application\/ld\+json|<script/i);
+  }
   assert.ok(
     cspHashArtefact.split(/\r?\n/u).filter(Boolean).length >= 2,
     'CSP hash artefact should list both theme and JSON-LD inline script hashes',

--- a/tests/bundle-audit.test.js
+++ b/tests/bundle-audit.test.js
@@ -13,6 +13,10 @@ import {
   assertCacheSplitRules,
   parseHeadersBlocks,
 } from '../scripts/lib/headers-drift.mjs';
+import {
+  PRACTICE_SEO_PAGES,
+  canonicalPracticePageUrl,
+} from '../scripts/lib/seo-practice-pages.mjs';
 
 const execFileAsync = promisify(execFile);
 
@@ -679,6 +683,31 @@ function seoAuditRootHtml({ omitCanonical = false } = {}) {
   ].join('');
 }
 
+function seoAuditPracticePageHtml(page, { omitCanonical = false, forbiddenToken = '' } = {}) {
+  const canonicalUrl = canonicalPracticePageUrl(page);
+  return [
+    '<!doctype html><html lang="en-GB"><head>',
+    `<title>${page.title}</title>`,
+    `<meta name="description" content="${page.description}" />`,
+    omitCanonical ? '' : `<link rel="canonical" href="${canonicalUrl}" />`,
+    `<meta property="og:title" content="${page.title}" />`,
+    `<meta property="og:description" content="${page.description}" />`,
+    `<meta property="og:url" content="${canonicalUrl}" />`,
+    '<meta name="twitter:card" content="summary" />',
+    '</head><body>',
+    `<main><h1>${page.heading}</h1>`,
+    `<p>${page.intro}</p>`,
+    '<ul>',
+    ...page.points.map((point) => `<li>${point}</li>`),
+    '</ul>',
+    forbiddenToken ? `<p>${forbiddenToken}</p>` : '',
+    '<a href="/demo">Try demo</a>',
+    '<a href="/">KS2 Mastery home</a>',
+    '</main>',
+    '</body></html>',
+  ].join('');
+}
+
 function createSeoAuditStubServer(options = {}) {
   const server = createServer((request, response) => {
     const url = request.url || '/';
@@ -691,6 +720,21 @@ function createSeoAuditStubServer(options = {}) {
     if (url === '/' || url === '/index.html') {
       write(200, { 'content-type': 'text/html', 'cache-control': 'no-store' }, seoAuditRootHtml(options));
       return;
+    }
+    for (const page of PRACTICE_SEO_PAGES) {
+      if (url === `/${page.slug}/`) {
+        if (options.practiceFallbackSlug === page.slug) {
+          write(200, { 'content-type': 'text/html', 'cache-control': 'no-store' }, seoAuditRootHtml());
+          return;
+        }
+        write(200, { 'content-type': 'text/html', 'cache-control': 'no-store' }, seoAuditPracticePageHtml(page, {
+          omitCanonical: options.omitPracticeCanonicalSlug === page.slug,
+          forbiddenToken: options.practiceForbiddenTokenSlug === page.slug
+            ? 'OPENAI_API_KEY'
+            : '',
+        }));
+        return;
+      }
     }
     if (url === '/robots.txt') {
       if (options.robotsFallback) {
@@ -710,12 +754,26 @@ function createSeoAuditStubServer(options = {}) {
       return;
     }
     if (url === '/sitemap.xml') {
+      const sitemapUrls = [
+        'https://ks2.eugnel.uk/',
+        ...PRACTICE_SEO_PAGES
+          .filter((page) => page.slug !== options.omitSitemapPageSlug)
+          .map((page) => canonicalPracticePageUrl(page)),
+      ];
+      if (options.sitemapForbiddenPath) {
+        sitemapUrls.push(`https://ks2.eugnel.uk${options.sitemapForbiddenPath}`);
+      }
+      if (options.sitemapExtraUrl) {
+        sitemapUrls.push(options.sitemapExtraUrl);
+      }
       write(200, { 'content-type': 'application/xml', 'cache-control': 'public, max-age=3600' }, [
         '<?xml version="1.0" encoding="UTF-8"?>',
         '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
-        '  <url>',
-        '    <loc>https://ks2.eugnel.uk/</loc>',
-        '  </url>',
+        ...sitemapUrls.flatMap((url) => [
+          '  <url>',
+          `    <loc>${url}</loc>`,
+          '  </url>',
+        ]),
         '</urlset>',
         '',
       ].join('\n'));
@@ -806,9 +864,156 @@ test('production bundle audit passes with SEO root, robots, and sitemap resource
       timeout: 8000,
     });
     assert.match(stdout, /Production bundle audit passed/);
-    assert.match(stdout, /cache-split checks: 7\/7/);
+    assert.match(stdout, /cache-split checks: 10\/10/);
   } finally {
     await closeServer(server);
+  }
+});
+
+test('production bundle audit fails when a practice page is SPA fallback HTML', async () => {
+  const server = createSeoAuditStubServer({ practiceFallbackSlug: 'ks2-spelling-practice' });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+  try {
+    const { port } = server.address();
+    await assert.rejects(async () => {
+      await execFileAsync(process.execPath, [
+        './scripts/production-bundle-audit.mjs',
+        '--skip-local',
+        '--url',
+        `http://127.0.0.1:${port}/`,
+      ], {
+        cwd: process.cwd(),
+        timeout: 8000,
+      });
+    }, (error) => {
+      assert.match(error.stderr, /Production SEO page \/ks2-spelling-practice\/ appears to be the root SPA shell/);
+      return true;
+    });
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test('production bundle audit fails when a practice page canonical URL disappears', async () => {
+  const server = createSeoAuditStubServer({ omitPracticeCanonicalSlug: 'ks2-grammar-practice' });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+  try {
+    const { port } = server.address();
+    await assert.rejects(async () => {
+      await execFileAsync(process.execPath, [
+        './scripts/production-bundle-audit.mjs',
+        '--skip-local',
+        '--url',
+        `http://127.0.0.1:${port}/`,
+      ], {
+        cwd: process.cwd(),
+        timeout: 8000,
+      });
+    }, (error) => {
+      assert.match(error.stderr, /Production SEO page \/ks2-grammar-practice\/ is missing required token: <link rel="canonical"/);
+      return true;
+    });
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test('production bundle audit fails when a practice page leaks forbidden deployed text', async () => {
+  const server = createSeoAuditStubServer({ practiceForbiddenTokenSlug: 'ks2-punctuation-practice' });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+  try {
+    const { port } = server.address();
+    await assert.rejects(async () => {
+      await execFileAsync(process.execPath, [
+        './scripts/production-bundle-audit.mjs',
+        '--skip-local',
+        '--url',
+        `http://127.0.0.1:${port}/`,
+      ], {
+        cwd: process.cwd(),
+        timeout: 8000,
+      });
+    }, (error) => {
+      assert.match(error.stderr, /Production SEO page \/ks2-punctuation-practice\/ includes forbidden deployed token: OPENAI_API_KEY/);
+      return true;
+    });
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test('production bundle audit fails when sitemap misses or leaks practice-page URLs', async () => {
+  const missingServer = createSeoAuditStubServer({ omitSitemapPageSlug: 'ks2-punctuation-practice' });
+  await new Promise((resolve) => missingServer.listen(0, '127.0.0.1', resolve));
+
+  try {
+    const { port } = missingServer.address();
+    await assert.rejects(async () => {
+      await execFileAsync(process.execPath, [
+        './scripts/production-bundle-audit.mjs',
+        '--skip-local',
+        '--url',
+        `http://127.0.0.1:${port}/`,
+      ], {
+        cwd: process.cwd(),
+        timeout: 8000,
+      });
+    }, (error) => {
+      assert.match(error.stderr, /Production sitemap.xml is missing required token: <loc>https:\/\/ks2\.eugnel\.uk\/ks2-punctuation-practice\/<\/loc>/);
+      return true;
+    });
+  } finally {
+    await closeServer(missingServer);
+  }
+
+  const leakServer = createSeoAuditStubServer({ sitemapForbiddenPath: '/demo' });
+  await new Promise((resolve) => leakServer.listen(0, '127.0.0.1', resolve));
+
+  try {
+    const { port } = leakServer.address();
+    await assert.rejects(async () => {
+      await execFileAsync(process.execPath, [
+        './scripts/production-bundle-audit.mjs',
+        '--skip-local',
+        '--url',
+        `http://127.0.0.1:${port}/`,
+      ], {
+        cwd: process.cwd(),
+        timeout: 8000,
+      });
+    }, (error) => {
+      assert.match(error.stderr, /Production sitemap.xml must not advertise private or local path: \/demo/);
+      return true;
+    });
+  } finally {
+    await closeServer(leakServer);
+  }
+
+  const extraServer = createSeoAuditStubServer({ sitemapExtraUrl: 'https://ks2.eugnel.uk/unplanned-public-page/' });
+  await new Promise((resolve) => extraServer.listen(0, '127.0.0.1', resolve));
+
+  try {
+    const { port } = extraServer.address();
+    await assert.rejects(async () => {
+      await execFileAsync(process.execPath, [
+        './scripts/production-bundle-audit.mjs',
+        '--skip-local',
+        '--url',
+        `http://127.0.0.1:${port}/`,
+      ], {
+        cwd: process.cwd(),
+        timeout: 8000,
+      });
+    }, (error) => {
+      assert.match(error.stderr, /Production sitemap\.xml must contain exactly/);
+      assert.match(error.stderr, /Unexpected: https:\/\/ks2\.eugnel\.uk\/unplanned-public-page\//);
+      return true;
+    });
+  } finally {
+    await closeServer(extraServer);
   }
 });
 

--- a/tests/react-auth-boot.test.js
+++ b/tests/react-auth-boot.test.js
@@ -11,6 +11,9 @@ test('auth surface renders through React with credential and social sign-in stat
   assert.match(html, /Focused spelling practice/);
   assert.match(html, /Grammar practice/);
   assert.match(html, /Punctuation practice/);
+  assert.match(html, /href="\/ks2-spelling-practice\/"/);
+  assert.match(html, /href="\/ks2-grammar-practice\/"/);
+  assert.match(html, /href="\/ks2-punctuation-practice\/"/);
   assert.match(html, /expired/);
   assert.match(html, /autoComplete="email"/);
   assert.match(html, /Social sign-in/);

--- a/tests/security-headers.test.js
+++ b/tests/security-headers.test.js
@@ -482,6 +482,9 @@ test('_headers repo file contains expected security header block', async () => {
   assert.match(content, /\/assets\/bundles\/\*/);
   assert.match(content, /\/robots\.txt/);
   assert.match(content, /\/sitemap\.xml/);
+  assert.match(content, /\/ks2-spelling-practice\//);
+  assert.match(content, /\/ks2-grammar-practice\//);
+  assert.match(content, /\/ks2-punctuation-practice\//);
   assert.match(content, /\/\*/);
   assert.match(content, /public, max-age=31536000, immutable/);
 });


### PR DESCRIPTION
## Summary

KS2 Mastery now has crawlable, page-specific practice landing pages for spelling, grammar, and punctuation. The pages are static assets with canonical trailing-slash URLs, linked from the public root and auth surface, listed in the sitemap, and guarded by build and production audits so search and AI-search crawlers receive product-specific public HTML rather than the SPA fallback.

## What Changed

- Added a shared SEO practice-page registry and static build output for `/ks2-spelling-practice/`, `/ks2-grammar-practice/`, and `/ks2-punctuation-practice/`.
- Linked the practice pages from public discovery surfaces and added no-store `_headers` coverage for each landing page.
- Tightened sitemap validation to the exact public URL set: root plus the 3 canonical practice pages, with private-path and duplicate/unexpected URL guards.
- Extended production audit coverage to reject SPA fallback pages, missing canonical metadata, private/internal token leaks, and sitemap drift.
- Updated the SEO runbook with Search Console, Cloudflare Web Analytics, and AI crawler guidance.

## Validation

- `npm test` (5850 tests, 5844 pass, 6 skip, 0 fail)
- `npm run check` (build, `assert:build-public`, `audit:client`, Wrangler dry-run)
- Reviewer sidecar completed; exact sitemap and forbidden-token findings were fixed and covered by regression tests.

## Post-Deploy Monitoring & Validation

- Run `npm run audit:production -- --skip-local` after deployment. Expected: page-specific practice HTML, sitemap exact set, and cache-split checks `10/10`.
- In Google Search Console, inspect `https://ks2.eugnel.uk/` plus the 3 practice URLs, submit `https://ks2.eugnel.uk/sitemap.xml`, then track indexed status, impressions, clicks, CTR, queries, and landing pages.
- In Cloudflare Web Analytics, track page views and landing-page share for the 4 public URLs. If the dashboard requires a manual analytics snippet, ship that as a separate reviewed PR with CSP and audit coverage.
- Watch for fallback/regression signals: practice pages serving the root title or app bundle, sitemap private leaks, unexpected `.html` variants, crawler blocking in robots/WAF, or elevated 404/redirect noise.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000)