### PR TITLE
feat(rewards): migrate toast shelf to presentation rows

### DIFF
--- a/scripts/audit-client-bundle.mjs
+++ b/scripts/audit-client-bundle.mjs
@@ -29,13 +29,13 @@ const DEFAULT_PUBLIC_DIR = 'dist/public';
 // ~215.1 KB. Punctuation's Star-based display parity added a small
 // first-paint utility footprint. Grammar's matching display-state parity
 // adds another tiny cross-subject utility slice. The reward presentation
-// queue compatibility layer keeps Node 22's CI gzip output near 216.8 KB, so
-// the committed ceiling is 217,000: still tight enough to catch an adult-surface
-// re-import, without blocking on sub-kilobyte compression/runtime drift. Override via CLI
+// queue and toast compatibility layers keep Node 22's gzip output near
+// 217.4 KB, so the committed ceiling is 218,000: still tight enough to catch
+// an adult-surface re-import, without blocking on sub-kilobyte compression/runtime drift. Override via CLI
 // `--main-bundle-budget-bytes` for experimentation. See
 // `tests/bundle-byte-budget.test.js` for the committed baseline +
 // rationale.
-const DEFAULT_MAIN_BUNDLE_GZIP_BUDGET_BYTES = 217_000;
+const DEFAULT_MAIN_BUNDLE_GZIP_BUDGET_BYTES = 218_000;
 
 const FORBIDDEN_MODULES = [
   { pattern: /^src\/subjects\/spelling\/data\//, reason: 'full spelling content dataset' },

--- a/src/platform/core/store.js
+++ b/src/platform/core/store.js
@@ -11,6 +11,7 @@ import {
   normaliseMonsterCelebrationEvents,
   normaliseMonsterCelebrations,
 } from '../game/monster-celebrations.js';
+import { normaliseRewardToastEvents } from '../rewards/reward-toast-events.js';
 
 const DEFAULT_ROUTE = {
   screen: 'dashboard',
@@ -137,9 +138,7 @@ function normaliseRoute(rawRoute, subjects) {
 }
 
 function normaliseToasts(rawValue) {
-  return (Array.isArray(rawValue) ? rawValue : [])
-    .filter((entry) => entry && typeof entry === 'object' && !Array.isArray(entry))
-    .slice(-25);
+  return normaliseRewardToastEvents(rawValue);
 }
 
 const VALID_SPELLING_WORD_BANK_FILTERS = new Set([
@@ -705,8 +704,7 @@ export function createStore(
     updateSubjectUi,
     updateSubjectUiForLearner,
     pushToasts(events) {
-      const entries = Array.isArray(events) ? events : [events];
-      const validEvents = entries.filter((entry) => entry && typeof entry === 'object' && !Array.isArray(entry));
+      const validEvents = normaliseRewardToastEvents(events);
       if (!validEvents.length) return;
       setState((current) => ({
         ...current,

--- a/src/platform/rewards/reward-toast-events.js
+++ b/src/platform/rewards/reward-toast-events.js
@@ -1,0 +1,141 @@
+export const REWARD_TOAST_PRESENTATION_TYPE = 'reward.presentation.toast';
+
+const REWARD_PRESENTATION_TYPE = 'reward.presentation';
+const LEGACY_REWARD_MONSTER_TYPE = 'reward.monster';
+const LEGACY_REWARD_TOAST_TYPE = 'reward.toast';
+
+const isObject = (value) => value && typeof value === 'object' && !Array.isArray(value);
+const text = (value, fallback = '') => (typeof value === 'string' && value.trim()) || fallback;
+
+function ackKey(eventId, intentId = 0) {
+  const id = text(eventId);
+  if (!id) return '';
+  const suffix = intentId == null ? '0' : text(String(intentId), '0');
+  return `reward:${id}:toast:${suffix}`;
+}
+
+function presentationId(event) {
+  const id = text(event?.id || event?.sourceEventId);
+  return id ? `reward.presentation:${id}` : '';
+}
+
+function monsterCopy(event) {
+  const name = text(event?.monster?.name, 'Monster');
+  if (event?.kind === 'caught') return [`${name} joined your Codex`, 'You caught a new friend!'];
+  if (event?.kind === 'evolve') return [`${name} evolved`, `${name} grew stronger after that mastery milestone.`];
+  if (event?.kind === 'mega') return [`${name} reached its final form`, `${name} reached its mega form.`];
+  return [
+    text(event?.toast?.title || event?.title || event?.monster?.name, 'Notification'),
+    text(event?.toast?.body || event?.body || event?.message),
+  ];
+}
+
+function plainCopy(event) {
+  return [
+    text(event?.toast?.title || event?.title || event?.monster?.name, 'Notification'),
+    text(event?.toast?.body || event?.body || event?.message),
+  ];
+}
+
+function monsterAssetRef(event) {
+  return {
+    family: 'monster',
+    monsterId: text(event?.monsterId || event?.monster?.id),
+    branch: text(event?.next?.branch || event?.previous?.branch),
+    stage: event?.next?.stage,
+  };
+}
+
+function toastRow(intent, event, {
+  eventId = '',
+  index = 0,
+  title = '',
+  body = '',
+  tone = 'neutral',
+  assetRef = undefined,
+  monster = undefined,
+} = {}) {
+  if (!isObject(intent)) return null;
+  const intentId = text(intent.intentId, index);
+  const dedupeKey = text(intent.dedupeKey, ackKey(eventId, intentId));
+  return {
+    id: text(intent.id || dedupeKey || eventId),
+    type: REWARD_TOAST_PRESENTATION_TYPE,
+    rewardType: text(event?.rewardType || event?.type),
+    kind: text(event?.kind || intent.kind, 'toast'),
+    title: text(intent.title, text(title, 'Notification')),
+    body: text(intent.body, body),
+    tone: text(intent.tone, tone),
+    dedupeKey,
+    assetRef: isObject(intent.assetRef) ? intent.assetRef : assetRef,
+    monster: isObject(monster) ? monster : undefined,
+  };
+}
+
+function canonicalToastRows(event) {
+  if (event?.type !== REWARD_PRESENTATION_TYPE) return [];
+  const eventId = text(event.id);
+  const intents = Array.isArray(event.presentations?.toast) ? event.presentations.toast : [];
+  return intents
+    .map((intent, index) => toastRow(intent, event, {
+      eventId,
+      index,
+      title: event.kind,
+      assetRef: isObject(intent?.assetRef) ? intent.assetRef : undefined,
+      monster: isObject(event.payload?.monster) ? event.payload.monster : undefined,
+    }))
+    .filter(Boolean);
+}
+
+function legacyMonsterToastRows(event) {
+  if (event?.type !== LEGACY_REWARD_MONSTER_TYPE) return [];
+  const [title, body] = monsterCopy(event);
+  return [toastRow({ title, body, assetRef: monsterAssetRef(event) }, event, {
+    eventId: presentationId(event),
+    title,
+    body,
+    tone: event.kind === 'caught' ? 'positive' : 'neutral',
+    assetRef: monsterAssetRef(event),
+    monster: event.monster,
+  })].filter(Boolean);
+}
+
+function legacyRewardToastRows(event) {
+  if (event?.type !== LEGACY_REWARD_TOAST_TYPE) return [];
+  const [title, body] = plainCopy(event);
+  return [toastRow({ title, body }, event, {
+    eventId: presentationId(event),
+    title,
+    body,
+    tone: event.kind === 'reward.achievement' ? 'achievement' : 'neutral',
+  })].filter(Boolean);
+}
+
+function genericToastRows(event) {
+  if (!isObject(event) || (!isObject(event.toast) && !event.title && !event.body && !event.message && !isObject(event.monster))) return [];
+  const [title, body] = plainCopy(event);
+  return [toastRow({ title, body }, event, {
+    eventId: text(event.id),
+    title,
+    body,
+    tone: event.kind === 'reward.achievement' ? 'achievement' : 'neutral',
+    assetRef: event.assetRef,
+    monster: event.monster,
+  })].filter(Boolean);
+}
+
+export function normaliseRewardToastEvent(event) {
+  if (!isObject(event)) return [];
+  if (event.type === REWARD_TOAST_PRESENTATION_TYPE) return [event];
+  if (event.type === REWARD_PRESENTATION_TYPE) return canonicalToastRows(event);
+  if (event.type === LEGACY_REWARD_MONSTER_TYPE) return legacyMonsterToastRows(event);
+  if (event.type === LEGACY_REWARD_TOAST_TYPE) return legacyRewardToastRows(event);
+  return genericToastRows(event);
+}
+
+export function normaliseRewardToastEvents(events) {
+  return (Array.isArray(events) ? events : [events])
+    .flatMap(normaliseRewardToastEvent)
+    .filter(Boolean)
+    .slice(-25);
+}

--- a/src/surfaces/shell/ToastShelf.jsx
+++ b/src/surfaces/shell/ToastShelf.jsx
@@ -22,41 +22,26 @@ function portraitStyle(visual) {
 }
 
 function toastTitle(toast) {
-  if (toast?.type === 'reward.monster') {
-    if (toast.kind === 'caught') return `${toast.monster?.name || 'Monster'} joined your Codex`;
-    if (toast.kind === 'evolve') return `${toast.monster?.name || 'Monster'} evolved`;
-    if (toast.kind === 'mega') return `${toast.monster?.name || 'Monster'} reached its final form`;
-  }
-  // P2 U12: reward.achievement surfaces the toast.title directly — the
-  // subscriber (event-hooks.js) already pre-composes from the achievement
-  // definition. Keeping the title verbatim avoids double-wrapping the
-  // "Achievement unlocked:" phrasing.
-  if (toast?.type === 'reward.toast' && toast?.kind === 'reward.achievement') {
-    return toast.toast?.title || toast.title || 'Achievement unlocked';
-  }
-  return toast?.toast?.title || toast?.title || 'Notification';
+  return toast?.title || 'Notification';
 }
 
 function toastBody(toast) {
-  if (toast?.type === 'reward.monster') {
-    if (toast.kind === 'caught') return 'You caught a new friend!';
-    if (toast.kind === 'evolve') return `${toast.monster?.name || 'A monster'} grew stronger after that mastery milestone.`;
-    if (toast.kind === 'mega') return `${toast.monster?.name || 'A monster'} reached its mega form.`;
-  }
-  if (toast?.type === 'reward.toast' && toast?.kind === 'reward.achievement') {
-    // Body comes pre-composed from the subscriber. MVP copy: "Achievement
-    // unlocked: <title>". No SVG badge art per F3; text-only styling.
-    return toast.toast?.body || toast.body || '';
-  }
-  return toast?.toast?.body || toast?.body || toast?.message || '';
+  return toast?.body || '';
+}
+
+function toastMonster(toast) {
+  if (toast?.monster?.id) return toast.monster;
+  const monsterId = toast?.assetRef?.family === 'monster' ? toast.assetRef.monsterId : '';
+  return monsterId ? { id: monsterId, name: toast.title || 'Monster' } : null;
 }
 
 function ToastContent({ toast }) {
   const monsterVisualConfig = useMonsterVisualConfig();
-  if (toast?.type === 'reward.monster' && toast.monster?.id) {
-    const stage = Math.max(0, Math.min(4, Number(toast.next?.stage) || 0));
-    const branch = toast.next?.branch || toast.previous?.branch;
-    const visual = imageVisual(toast.monster.id, stage, branch, monsterVisualConfig?.config);
+  const monster = toastMonster(toast);
+  if (monster?.id) {
+    const stage = Math.max(0, Math.min(4, Number(toast.assetRef?.stage ?? toast.next?.stage) || 0));
+    const branch = toast.assetRef?.branch || toast.next?.branch || toast.previous?.branch;
+    const visual = imageVisual(monster.id, stage, branch, monsterVisualConfig?.config);
     return (
       <>
         <div className="cm-port" aria-hidden="true">
@@ -65,7 +50,7 @@ function ToastContent({ toast }) {
               value reserves the box so the toast does not jump while
               the .webp decodes. */}
           <img
-            alt={`${toast.monster.name || 'Monster'} portrait`}
+            alt={`${monster.name || 'Monster'} portrait`}
             src={visual.src}
             srcSet={visual.srcSet}
             sizes="56px"
@@ -89,17 +74,15 @@ function ToastContent({ toast }) {
   );
 }
 
-// P2 U12: kind class mapping. `catch` for monster caught (existing), new
-// `achievement` for reward.achievement kind (distinct CSS hook without
-// changing the DOM structure — still the same single-live-region container).
 function toastKindClass(toast) {
-  if (toast?.type === 'reward.monster' && toast?.kind === 'caught') return 'catch';
-  if (toast?.type === 'reward.toast' && toast?.kind === 'reward.achievement') return 'achievement';
+  if (toast?.rewardType === 'reward.monster' && toast?.kind === 'caught') return 'catch';
+  if (toast?.tone === 'achievement' || toast?.kind === 'reward.achievement') return 'achievement';
   return 'info';
 }
 
 export function ToastShelf({ toasts = [], onDismiss }) {
-  if (!toasts.length) return null;
+  const toastRows = Array.isArray(toasts) ? toasts : [];
+  if (!toastRows.length) return null;
   // U10 (sys-hardening p1): the container is the single live region.
   // `role="status"` + `aria-live="polite"` announce new toast inserts
   // once. The inner `<aside>` elements are plain containers — nesting
@@ -116,7 +99,7 @@ export function ToastShelf({ toasts = [], onDismiss }) {
   // `data-testid="toast-shelf"` anchors the accessibility scene.
   return (
     <div className="toast-shelf" role="status" aria-live="polite" aria-label="Notifications" data-testid="toast-shelf">
-      {toasts.map((toast, index) => {
+      {toastRows.map((toast, index) => {
         const kind = toastKindClass(toast);
         return (
           <aside

--- a/tests/bundle-byte-budget.test.js
+++ b/tests/bundle-byte-budget.test.js
@@ -18,9 +18,9 @@
 // safety and radio-focus accessibility fixes lift the Node 22 build to
 // ~215.1 KB. Punctuation's Star-based display parity added a small first-paint
 // utility footprint; Grammar's matching display-state parity adds another
-// tiny cross-subject utility slice. The reward presentation queue
-// compatibility layer keeps Node 22's CI gzip output near 216.8 KB. The
-// committed ceiling is now `217_000`, keeping the headroom narrow while
+// tiny cross-subject utility slice. The reward presentation queue and toast
+// compatibility layers keep Node 22's gzip output near 217.4 KB. The
+// committed ceiling is now `218_000`, keeping the headroom narrow while
 // avoiding a sub-kilobyte compression/runtime false blocker.
 // The audit still fails
 // when ~50 KB of adult-only JS sneaks back into the critical path (the
@@ -65,14 +65,14 @@ const REPO_ROOT = path.resolve(__dirname, '..');
 // safety and radio-focus accessibility fixes lift the Node 22 build to
 // ~215.1 KB. Punctuation's Star-based display parity adds a small first-paint
 // utility footprint; Grammar's matching display-state parity adds another
-// tiny cross-subject utility slice. The reward presentation queue compatibility
-// layer keeps Node 22's CI gzip output near 216.8 KB, so the committed ceiling is 217,000
+// tiny cross-subject utility slice. The reward presentation queue and toast
+// compatibility layers keep Node 22's gzip output near 217.4 KB, so the committed ceiling is 218,000
 // (matches `DEFAULT_MAIN_BUNDLE_GZIP_BUDGET_BYTES` in
 // `scripts/audit-client-bundle.mjs`). The narrow headroom lets the team
 // land small copy / utility growth without an audit bump, but trips the
 // gate when ~50 KB of adult-only JS sneaks back into the critical path.
 const BASELINE_GZIP_BYTES = 203_227;
-const BUDGET_GZIP_BYTES = 217_000;
+const BUDGET_GZIP_BYTES = 218_000;
 const TEST_MODE_BUNDLE_MARKER = '__ks2_capacityMeta__';
 
 function isPlaywrightTestModeBundle(bundleBytes) {

--- a/tests/helpers/react-render.js
+++ b/tests/helpers/react-render.js
@@ -87,7 +87,16 @@ export function renderSharedSurfaceFixture() {
       inFlightWriteCount: 0,
       lastError: { message: 'remote unavailable', code: 'remote_error', phase: 'remote-write' },
     };
-    const toast = { id: 'toast-1', type: 'reward.monster', kind: 'caught', monster, next: { stage: 0, branch: 'b1' } };
+    const toast = {
+      id: 'toast-1',
+      type: 'reward.presentation.toast',
+      rewardType: 'reward.monster',
+      kind: 'caught',
+      title: 'Inklet joined your Codex',
+      body: 'You caught a new friend!',
+      monster,
+      assetRef: { family: 'monster', monsterId: 'inklet', stage: 0, branch: 'b1' },
+    };
     const celebration = { kind: 'caught', monster, previous: null, next: { stage: 0, branch: 'b1' } };
     const html = renderToStaticMarkup(
       <>
@@ -371,10 +380,13 @@ export function renderMonsterVisualRendererFixture() {
           <ToastShelf
             toasts={[{
               id: 'toast-a',
-              type: 'reward.monster',
+              type: 'reward.presentation.toast',
+              rewardType: 'reward.monster',
               kind: 'caught',
+              title: 'Inklet joined your Codex',
+              body: 'You caught a new friend!',
               monster: { id: 'inklet', name: 'Inklet' },
-              next: { stage: 1, branch: 'b1' },
+              assetRef: { family: 'monster', monsterId: 'inklet', stage: 1, branch: 'b1' },
             }]}
             onDismiss={() => {}}
           />

--- a/tests/reward-toast-events.test.js
+++ b/tests/reward-toast-events.test.js
@@ -1,0 +1,95 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  normaliseRewardToastEvent,
+  normaliseRewardToastEvents,
+  REWARD_TOAST_PRESENTATION_TYPE,
+} from '../src/platform/rewards/reward-toast-events.js';
+
+test('legacy reward.toast events become explicit toast presentation rows', () => {
+  const rows = normaliseRewardToastEvent({
+    id: 'reward.toast:guardian.renewed:learner-a:session-1:word-1',
+    type: 'reward.toast',
+    kind: 'guardian.renewed',
+    subjectId: 'spelling',
+    learnerId: 'learner-a',
+    toast: {
+      title: 'Word renewed.',
+      body: '"because" held steady.',
+    },
+  });
+
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].type, REWARD_TOAST_PRESENTATION_TYPE);
+  assert.equal(rows[0].rewardType, 'reward.toast');
+  assert.equal(rows[0].kind, 'guardian.renewed');
+  assert.equal(rows[0].title, 'Word renewed.');
+  assert.equal(rows[0].body, '"because" held steady.');
+  assert.equal(rows[0].dedupeKey, 'reward:reward.presentation:reward.toast:guardian.renewed:learner-a:session-1:word-1:toast:0');
+});
+
+test('legacy monster reward toasts preserve current shelf copy and portrait metadata', () => {
+  const rows = normaliseRewardToastEvent({
+    id: 'reward.monster:learner-a:inklet:caught:1:0',
+    type: 'reward.monster',
+    kind: 'caught',
+    subjectId: 'spelling',
+    learnerId: 'learner-a',
+    monsterId: 'inklet',
+    monster: { id: 'inklet', name: 'Inklet' },
+    previous: { stage: 0, branch: 'b1' },
+    next: { stage: 1, branch: 'b1' },
+    toast: { title: 'Inklet', body: 'New creature unlocked.' },
+  });
+
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].rewardType, 'reward.monster');
+  assert.equal(rows[0].kind, 'caught');
+  assert.equal(rows[0].title, 'Inklet joined your Codex');
+  assert.equal(rows[0].body, 'You caught a new friend!');
+  assert.equal(rows[0].assetRef.monsterId, 'inklet');
+  assert.equal(rows[0].assetRef.stage, 1);
+  assert.equal(rows[0].monster.name, 'Inklet');
+});
+
+test('canonical celebration-only presentation events do not create toast rows', () => {
+  const rows = normaliseRewardToastEvents({
+    id: 'reward.presentation:module:hero-mode:reward.hero:purchase:txn-1',
+    type: 'reward.presentation',
+    producerType: 'module',
+    producerId: 'hero-mode',
+    rewardType: 'reward.hero',
+    kind: 'purchase',
+    learnerId: 'learner-a',
+    presentations: {
+      toast: [],
+      celebration: [{ visualKind: 'hero-purchase', title: 'Unlocked' }],
+    },
+  });
+
+  assert.deepEqual(rows, []);
+});
+
+test('canonical presentation events preserve multiple toast intents independently', () => {
+  const rows = normaliseRewardToastEvents({
+    id: 'reward.presentation:module:hero-mode:reward.hero:purchase:txn-2',
+    type: 'reward.presentation',
+    producerType: 'module',
+    producerId: 'hero-mode',
+    rewardType: 'reward.hero',
+    kind: 'purchase',
+    learnerId: 'learner-a',
+    presentations: {
+      toast: [
+        { title: 'New outfit unlocked', body: 'Blue Cape is ready.' },
+        { intentId: 'first-time-help', title: 'Try it on later', body: 'Open Hero Camp when you are ready.' },
+      ],
+    },
+  });
+
+  assert.equal(rows.length, 2);
+  assert.equal(rows[0].dedupeKey, 'reward:reward.presentation:module:hero-mode:reward.hero:purchase:txn-2:toast:0');
+  assert.equal(rows[1].dedupeKey, 'reward:reward.presentation:module:hero-mode:reward.hero:purchase:txn-2:toast:first-time-help');
+  assert.equal(rows[1].title, 'Try it on later');
+});

--- a/tests/spelling-parity.test.js
+++ b/tests/spelling-parity.test.js
@@ -175,7 +175,7 @@ test('monster caught celebrations wait until the live spelling session ends', ()
     const liveState = harness.store.getState();
     assert.equal(liveState.subjectUi.spelling.phase, 'session');
     assert.equal(liveState.subjectUi.spelling.awaitingAdvance, true);
-    assert.ok(liveState.toasts.some((event) => event.type === 'reward.monster' && event.kind === 'caught'));
+    assert.ok(liveState.toasts.some((event) => event.type === 'reward.presentation.toast' && event.rewardType === 'reward.monster' && event.kind === 'caught'));
     assert.doesNotMatch(harness.render(), /monster-celebration-overlay/);
 
     globalThis.confirm = () => true;

--- a/tests/store.test.js
+++ b/tests/store.test.js
@@ -64,6 +64,42 @@ test('shared store can preserve transient monster celebrations across command re
   assert.equal(store.getState().monsterCelebrations.queue.length, 0);
 });
 
+test('shared store normalises reward toast events into presentation toast rows', () => {
+  const storage = installMemoryStorage();
+  const repositories = createLocalPlatformRepositories({ storage });
+  const store = createStore(SUBJECTS, { repositories });
+
+  store.pushToasts([
+    {
+      id: 'reward.toast:guardian.renewed:learner-a:session-1:word-1',
+      type: 'reward.toast',
+      kind: 'guardian.renewed',
+      subjectId: 'spelling',
+      learnerId: store.getState().learners.selectedId,
+      toast: { title: 'Word renewed.', body: '"because" held steady.' },
+    },
+    {
+      id: 'reward.presentation:module:hero-mode:reward.hero:purchase:txn-1',
+      type: 'reward.presentation',
+      producerType: 'module',
+      producerId: 'hero-mode',
+      rewardType: 'reward.hero',
+      kind: 'purchase',
+      learnerId: store.getState().learners.selectedId,
+      presentations: {
+        toast: [],
+        celebration: [{ visualKind: 'hero-purchase', title: 'Unlocked' }],
+      },
+    },
+  ]);
+
+  const { toasts } = store.getState();
+  assert.equal(toasts.length, 1);
+  assert.equal(toasts[0].type, 'reward.presentation.toast');
+  assert.equal(toasts[0].rewardType, 'reward.toast');
+  assert.equal(toasts[0].title, 'Word renewed.');
+});
+
 test('shared store caches subject setup reset when runtime UI writes are cached', () => {
   const storage = installMemoryStorage();
   const repositories = createLocalPlatformRepositories({ storage });


### PR DESCRIPTION
## Summary
- normalise legacy `reward.toast`, legacy `reward.monster`, and canonical `reward.presentation` toast intents into explicit `reward.presentation.toast` rows at the store boundary
- simplify `ToastShelf` so it renders explicit toast rows instead of hardcoded reward-event copy, while preserving existing monster and achievement toast wording
- keep celebration-only presentation events out of ToastShelf, and cover multiple toast intents per canonical event
- raise the client bundle gzip ceiling to `218000` after PR3/PR4 reward presentation compatibility layers; rebased local dry-run measured `217407 / 218000`

## Scope notes
- Rebases onto `origin/main` (`f369d7e7`) so PR #501 and PR #503 are not reverted
- No Hero economy wiring in this slice
- No producer migration to canonical `reward.presentation` yet; this PR keeps legacy producers compatible while moving the toast consumer boundary
- Full `npm test` script cannot run directly in this dependency-light worktree because its preflight requires local `node_modules`; I ran the full Node suite with `NODE_PATH` pointed at the main checkout dependency tree instead

## Verification
- `node --test tests/reward-toast-events.test.js tests/reward-presentations.test.js tests/monster-celebrations.test.js tests/store.test.js tests/app-controller.test.js tests/spelling-remote-actions.test.js tests/toast-positioning-contract.test.js` — 92 pass
- `NODE_PATH=/Users/jamesto/Coding/ks2-mastery/node_modules node --test tests/react-shared-surfaces.test.js tests/spelling-parity.test.js tests/runtime-boundary.test.js` — 35 pass
- `NODE_PATH=/Users/jamesto/Coding/ks2-mastery/node_modules node --test $(find tests -name '*.test.js' | sort)` — 5841 pass / 12 skipped / 0 fail
- `npm run check` — passed, client bundle `217407 / 218000` bytes gzip
- `git diff --check` — passed