### PR TITLE
test(rewards): validate hero presentation fixture

### DIFF
--- a/src/platform/game/monster-celebrations.js
+++ b/src/platform/game/monster-celebrations.js
@@ -7,6 +7,12 @@ function isPlainObject(value) {
   return value && typeof value === 'object' && !Array.isArray(value);
 }
 
+function cleanString(value, fallback = '') {
+  if (typeof value !== 'string') return fallback;
+  const trimmed = value.trim();
+  return trimmed || fallback;
+}
+
 function isLegacyMonsterCelebrationEvent(event) {
   return event?.type === 'reward.monster'
     && OVERLAY_KINDS.has(event.kind)
@@ -29,7 +35,7 @@ function normaliseProgressSnapshot(value) {
 
 export function normaliseMonsterCelebrationEvent(event) {
   if (isLegacyMonsterCelebrationEvent(event)) return normaliseLegacyMonsterCelebrationEvent(event);
-  return normalisePresentationCelebrationEvent(event);
+  return normalisePresentationCelebrationEvent(event) || normaliseQueuedPresentationCelebrationEvent(event);
 }
 
 export function isMonsterCelebrationEvent(event) {
@@ -72,11 +78,22 @@ function normaliseLegacyMonsterCelebrationEvent(event) {
   };
 }
 
+function presentationAckKey(eventId, intent, index = 0) {
+  const id = cleanString(eventId);
+  if (!id) return '';
+  const explicit = cleanString(intent?.dedupeKey);
+  if (explicit) return explicit;
+  const suffix = cleanString(intent?.intentId, String(index));
+  return `reward:${id}:celebration:${suffix}`;
+}
+
 function normalisePresentationCelebrationEvent(event) {
   if (!isPlainObject(event) || event.type !== REWARD_PRESENTATION_TYPE) return null;
-  const celebrationIntent = Array.isArray(event.presentations?.celebration)
-    ? event.presentations.celebration.find(isPlainObject)
-    : null;
+  const celebrationIntents = Array.isArray(event.presentations?.celebration)
+    ? event.presentations.celebration
+    : [];
+  const celebrationIndex = celebrationIntents.findIndex(isPlainObject);
+  const celebrationIntent = celebrationIndex >= 0 ? celebrationIntents[celebrationIndex] : null;
   if (!celebrationIntent) return null;
 
   const payload = isPlainObject(event.payload) ? event.payload : {};
@@ -105,7 +122,32 @@ function normalisePresentationCelebrationEvent(event) {
     next: normaliseProgressSnapshot(next),
     createdAt: Math.max(0, Number(event.occurredAt) || Date.now()),
     sourceEventId: event.sourceEventId || '',
-    presentationAckKey: celebrationIntent.dedupeKey || '',
+    presentationAckKey: presentationAckKey(event.id, celebrationIntent, celebrationIndex),
+  };
+}
+
+function normaliseQueuedPresentationCelebrationEvent(event) {
+  if (!isPlainObject(event) || event.type !== REWARD_PRESENTATION_TYPE) return null;
+  if (!isPlainObject(event.monster)) return null;
+  const id = cleanString(event.id);
+  const kind = cleanString(event.kind);
+  if (!id || !kind) return null;
+  return {
+    id,
+    type: REWARD_PRESENTATION_TYPE,
+    kind,
+    learnerId: cleanString(event.learnerId, 'default'),
+    monsterId: cleanString(event.monsterId),
+    monster: {
+      ...event.monster,
+      id: cleanString(event.monster.id, cleanString(event.monsterId)),
+      name: cleanString(event.monster.name, 'Reward'),
+    },
+    previous: normaliseProgressSnapshot(event.previous),
+    next: normaliseProgressSnapshot(event.next),
+    createdAt: Math.max(0, Number(event.createdAt) || Date.now()),
+    sourceEventId: cleanString(event.sourceEventId),
+    presentationAckKey: cleanString(event.presentationAckKey),
   };
 }
 

--- a/tests/reward-presentation-hero-validation.test.js
+++ b/tests/reward-presentation-hero-validation.test.js
@@ -1,0 +1,139 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  normaliseMonsterCelebrationEvent,
+} from '../src/platform/game/monster-celebrations.js';
+import {
+  acknowledgeMonsterCelebrationEvents,
+  acknowledgedMonsterCelebrationIds,
+  unacknowledgedMonsterCelebrationEvents,
+} from '../src/platform/game/monster-celebration-acks.js';
+import {
+  normaliseRewardToastEvents,
+} from '../src/platform/rewards/reward-toast-events.js';
+import {
+  normaliseRewardPresentationEvent,
+  resolveRewardCelebration,
+  resolveRewardToast,
+} from '../src/platform/rewards/reward-presentations.js';
+import { installMemoryStorage } from './helpers/memory-storage.js';
+
+function heroPurchasePresentation(overrides = {}) {
+  const id = overrides.id || 'reward.presentation:module:hero-mode:reward.hero:purchase:txn-hero-1';
+  return {
+    id,
+    type: 'reward.presentation',
+    producerType: 'module',
+    producerId: 'hero-mode',
+    rewardType: 'reward.hero',
+    kind: 'purchase',
+    learnerId: 'learner-a',
+    occurredAt: 1777399500000,
+    sourceEventId: 'hero-mode:transaction:txn-hero-1',
+    payload: {
+      transactionId: 'txn-hero-1',
+      inventoryItemId: 'cape-blue',
+      heroItemId: 'cape-blue',
+      price: 20,
+      currency: 'hero-coin',
+    },
+    presentations: {
+      toast: [],
+      celebration: [{
+        intentId: 'purchase-reveal',
+        visualKind: 'hero-purchase',
+        timing: 'immediate',
+        title: 'New outfit unlocked',
+        body: 'Blue Cape is ready.',
+        priority: 50,
+        assetRef: {
+          family: 'hero',
+          itemId: 'cape-blue',
+        },
+      }],
+    },
+    ...overrides,
+  };
+}
+
+test('synthetic Hero purchase stays module-scoped and celebration-only', () => {
+  const event = normaliseRewardPresentationEvent(heroPurchasePresentation());
+
+  assert.equal(event.type, 'reward.presentation');
+  assert.equal(event.producerType, 'module');
+  assert.equal(event.producerId, 'hero-mode');
+  assert.equal(event.rewardType, 'reward.hero');
+  assert.equal(event.kind, 'purchase');
+  assert.equal(event.payload.transactionId, 'txn-hero-1');
+  assert.equal(event.payload.inventoryItemId, 'cape-blue');
+
+  assert.deepEqual(resolveRewardToast(event), []);
+  assert.equal(resolveRewardCelebration(event).length, 1);
+  assert.equal(event.presentations.celebration[0].visualKind, 'hero-purchase');
+  assert.equal(event.presentations.celebration[0].timing, 'immediate');
+  assert.equal(
+    event.presentations.celebration[0].dedupeKey,
+    'reward:reward.presentation:module:hero-mode:reward.hero:purchase:txn-hero-1:celebration:purchase-reveal',
+  );
+});
+
+test('synthetic Hero purchase creates no ToastShelf rows', () => {
+  const rows = normaliseRewardToastEvents(heroPurchasePresentation());
+
+  assert.deepEqual(rows, []);
+});
+
+test('synthetic Hero purchase can enter the celebration queue without subject state', () => {
+  const queued = normaliseMonsterCelebrationEvent(heroPurchasePresentation());
+
+  assert.ok(queued);
+  assert.equal(queued.type, 'reward.presentation');
+  assert.equal(queued.kind, 'hero-purchase');
+  assert.equal(queued.learnerId, 'learner-a');
+  assert.equal(queued.sourceEventId, 'hero-mode:transaction:txn-hero-1');
+  assert.equal(queued.monsterId, '');
+  assert.equal(queued.monster.name, 'New outfit unlocked');
+  assert.equal(
+    queued.presentationAckKey,
+    'reward:reward.presentation:module:hero-mode:reward.hero:purchase:txn-hero-1:celebration:purchase-reveal',
+  );
+});
+
+test('synthetic Hero purchase acknowledgement dedupes replay without mutating event payload', () => {
+  const storage = installMemoryStorage();
+  const event = heroPurchasePresentation();
+  const originalPayload = structuredClone(event.payload);
+
+  const first = unacknowledgedMonsterCelebrationEvents([event], {
+    learnerId: 'learner-a',
+    store: storage,
+  });
+
+  assert.equal(first.length, 1);
+  assert.equal(first[0].kind, 'hero-purchase');
+
+  assert.equal(
+    acknowledgeMonsterCelebrationEvents(first[0], {
+      learnerId: 'learner-a',
+      store: storage,
+    }),
+    true,
+  );
+
+  const acknowledged = acknowledgedMonsterCelebrationIds('learner-a', { store: storage });
+  assert.equal(acknowledged.has(event.id), true);
+  assert.equal(acknowledged.has('hero-mode:transaction:txn-hero-1'), true);
+  assert.equal(
+    acknowledged.has('reward:reward.presentation:module:hero-mode:reward.hero:purchase:txn-hero-1:celebration:purchase-reveal'),
+    true,
+  );
+  assert.deepEqual(
+    unacknowledgedMonsterCelebrationEvents([event], {
+      learnerId: 'learner-a',
+      store: storage,
+    }),
+    [],
+  );
+  assert.deepEqual(event.payload, originalPayload);
+});


### PR DESCRIPTION
## Summary
- add a synthetic Hero Mode `reward.presentation` fixture that validates `module:hero-mode` can produce celebration-only presentations without ToastShelf rows
- preserve producer/payload fields for future Hero shop events while keeping the current work independent of Hero economy, shop, currency, inventory, or ledger code
- fix the presentation celebration compatibility facade so raw canonical events get a deterministic celebration ack key and already-queued canonical events remain acknowledgeable on replay/dismiss

## Verification
- `node --test tests/reward-presentation-hero-validation.test.js tests/reward-presentations.test.js tests/reward-toast-events.test.js tests/monster-celebrations.test.js tests/store.test.js`
- `NODE_PATH=/Users/jamesto/Coding/ks2-mastery/node_modules node --test $(find tests -name '*.test.js' | sort)`
- `npm run check`
- `git diff --check`