### PR TITLE
fix(punctuation): clarify dash and list comma policy

### DIFF
--- a/docs/punctuation-production.md
+++ b/docs/punctuation-production.md
@@ -101,7 +101,7 @@ The first Speech rubric is deliberately strict:
 
 Comma / Flow marking adds deterministic transfer validators for:
 
-- ordered KS2 list-comma patterns; an otherwise-correct Oxford comma before `and` is accepted unless the item explicitly forbids the final comma with visible house-style context
+- ordered KS2 list-comma patterns; an otherwise-correct Oxford comma before `and` is accepted unless the item explicitly forbids the final comma with visible no-final-comma context
 - opening phrase commas after fronted adverbials such as `After lunch,`
 - opening phrase commas that make meaning clearer, such as `In the morning,`
 
@@ -120,7 +120,7 @@ Structure marking adds deterministic transfer validators for:
 
 Combine marking adds stricter one-sentence validators for the first legacy-shaped rewrite families:
 
-- list-comma note combination; an otherwise-correct Oxford comma before `and` is accepted unless the item explicitly forbids the final comma with visible house-style context
+- list-comma note combination; an otherwise-correct Oxford comma before `and` is accepted unless the item explicitly forbids the final comma with visible no-final-comma context
 - fronted-adverbial rewrites with the opening comma
 - parenthesis rewrites with matched commas, brackets, or dashes
 - colon-list combinations after a complete opening clause

--- a/docs/punctuation-production.md
+++ b/docs/punctuation-production.md
@@ -101,14 +101,14 @@ The first Speech rubric is deliberately strict:
 
 Comma / Flow marking adds deterministic transfer validators for:
 
-- ordered KS2 list-comma patterns; an otherwise-correct Oxford comma before `and` is accepted unless the item explicitly forbids the final comma
+- ordered KS2 list-comma patterns; an otherwise-correct Oxford comma before `and` is accepted unless the item explicitly forbids the final comma with visible house-style context
 - opening phrase commas after fronted adverbials such as `After lunch,`
 - opening phrase commas that make meaning clearer, such as `In the morning,`
 
 Boundary marking adds deterministic transfer validators for:
 
 - semi-colons between preserved related clauses
-- spaced hyphen, en dash, or em dash marks between preserved related clauses
+- spaced hyphen, en dash, or em dash marks between preserved related clauses; model answers display a spaced en dash when the item is teaching a dash
 - exact hyphenated phrases that avoid ambiguity, such as `well-known author`
 
 Structure marking adds deterministic transfer validators for:
@@ -120,12 +120,12 @@ Structure marking adds deterministic transfer validators for:
 
 Combine marking adds stricter one-sentence validators for the first legacy-shaped rewrite families:
 
-- list-comma note combination; an otherwise-correct Oxford comma before `and` is accepted unless the item explicitly forbids the final comma
+- list-comma note combination; an otherwise-correct Oxford comma before `and` is accepted unless the item explicitly forbids the final comma with visible house-style context
 - fronted-adverbial rewrites with the opening comma
 - parenthesis rewrites with matched commas, brackets, or dashes
 - colon-list combinations after a complete opening clause
 - semi-colon clause combinations that reject comma splices
-- spaced hyphen, en dash, or em dash clause combinations that reject unpunctuated joins
+- spaced hyphen, en dash, or em dash clause combinations that reject unpunctuated joins while displaying the spaced en dash as the canonical model
 
 Paragraph marking composes the deterministic validators across a short passage for the first legacy-shaped proofreading families:
 

--- a/shared/punctuation/content.js
+++ b/shared/punctuation/content.js
@@ -441,6 +441,11 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     accepted: ['We needed pencils, rulers and glue.'],
     explanation: 'Use a comma between pencils and rulers to separate the list items.',
     model: 'We needed pencils, rulers and glue.',
+    validator: {
+      type: 'requiresListCommas',
+      opening: 'We needed',
+      items: ['pencils', 'rulers', 'glue'],
+    },
     misconceptionTags: ['comma.list_separator_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
     source: 'fixed',
@@ -454,8 +459,13 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     prompt: 'Correct the list punctuation in this sentence.',
     stem: 'The display showed shells pebbles, and fossils.',
     accepted: ['The display showed shells, pebbles and fossils.'],
-    explanation: 'The comma belongs between shells and pebbles. The final comma before and is not needed here.',
+    explanation: 'The comma belongs between shells and pebbles. A final comma before and is accepted here too.',
     model: 'The display showed shells, pebbles and fossils.',
+    validator: {
+      type: 'requiresListCommas',
+      opening: 'The display showed',
+      items: ['shells', 'pebbles', 'fossils'],
+    },
     misconceptionTags: ['comma.list_separator_missing', 'comma.unnecessary_final_comma'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
     source: 'fixed',
@@ -482,10 +492,10 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     skillIds: ['list_commas'],
     clusterId: 'comma_flow',
     rewardUnitId: 'list-commas-core',
-    prompt: 'Write one sentence using this exact stem and list, following the house style with no final comma before and: For the bake sale we needed eggs, flour, butter and sugar.',
+    prompt: 'Write one sentence using this exact stem and list: For the bake sale we needed eggs, flour, butter and sugar. For this question, do not put a comma before the final and.',
     stem: '',
     accepted: ['For the bake sale we needed eggs, flour, butter and sugar.'],
-    explanation: 'The sentence keeps the stem and separates the list items with commas. This item uses the house style: no final comma before the final and.',
+    explanation: 'The sentence keeps the exact stem and list items, with commas between the list items. For this question, there is no comma before the final and.',
     model: 'For the bake sale we needed eggs, flour, butter and sugar.',
     validator: {
       type: 'requiresListCommas',
@@ -2501,8 +2511,9 @@ function dashClauseDisplayUsesEnDash(item) {
   const displayTexts = [
     item.model,
     item.mode === 'choose' ? asArray(item.options)[Number(item.correctIndex)] : '',
-  ].filter((entry) => typeof entry === 'string' && /[-–—]/.test(entry));
-  return displayTexts.every((text) => text.includes(' – ') && !text.includes(' - '));
+  ].filter((entry) => typeof entry === 'string' && entry.trim());
+  return displayTexts.length > 0
+    && displayTexts.every((text) => text.includes(' – ') && !text.includes(' - '));
 }
 
 function pushIndexed(map, key, value) {
@@ -2643,7 +2654,7 @@ export function validatePunctuationManifest(manifest = PUNCTUATION_CONTENT_MANIF
       }
     }
     if (!strictFinalCommaPolicyVisible(item)) {
-      errors.push(`List-comma item ${item.id} forbids the final comma without visible house-style context.`);
+      errors.push(`List-comma item ${item.id} forbids the final comma without visible no-final-comma context.`);
     }
     if (!dashClauseDisplayUsesEnDash(item)) {
       errors.push(`Dash-clause item ${item.id} must use a spaced en dash in model display.`);

--- a/shared/punctuation/content.js
+++ b/shared/punctuation/content.js
@@ -152,9 +152,9 @@ export const PUNCTUATION_SKILLS = Object.freeze([
     published: true,
     rule: 'A dash can mark a sharp boundary between two closely related ideas.',
     workedBad: 'The path was flooded, we took the longer route.',
-    workedGood: 'The path was flooded - we took the longer route.',
-    contrastBad: 'The path was flooded -and we took the longer route.',
-    contrastGood: 'The path was flooded - we took the longer route.',
+    workedGood: 'The path was flooded – we took the longer route.',
+    contrastBad: 'The path was flooded –and we took the longer route.',
+    contrastGood: 'The path was flooded – we took the longer route.',
   },
   {
     id: 'semicolon_list',
@@ -482,15 +482,16 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     skillIds: ['list_commas'],
     clusterId: 'comma_flow',
     rewardUnitId: 'list-commas-core',
-    prompt: 'Write one sentence using this exact stem and list: For the bake sale we needed eggs, flour, butter and sugar.',
+    prompt: 'Write one sentence using this exact stem and list, following the house style with no final comma before and: For the bake sale we needed eggs, flour, butter and sugar.',
     stem: '',
     accepted: ['For the bake sale we needed eggs, flour, butter and sugar.'],
-    explanation: 'The sentence keeps the stem and separates the list items with commas.',
+    explanation: 'The sentence keeps the stem and separates the list items with commas. This item uses the house style: no final comma before the final and.',
     model: 'For the bake sale we needed eggs, flour, butter and sugar.',
     validator: {
       type: 'requiresListCommas',
       opening: 'For the bake sale we needed',
       items: ['eggs', 'flour', 'butter', 'sugar'],
+      allowFinalComma: false,
     },
     misconceptionTags: ['comma.list_separator_missing', 'comma.list_words_changed', 'comma.unnecessary_final_comma'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
@@ -1126,13 +1127,13 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     prompt: 'Choose the best punctuated sentence.',
     options: [
       'The path was flooded, we took the longer route.',
-      'The path was flooded - we took the longer route.',
-      'The path was flooded -and we took the longer route.',
+      'The path was flooded – we took the longer route.',
+      'The path was flooded –and we took the longer route.',
       'The path was flooded we took the longer route.',
     ],
     correctIndex: 1,
     explanation: 'The dash marks a sharp boundary between two related clauses.',
-    model: 'The path was flooded - we took the longer route.',
+    model: 'The path was flooded – we took the longer route.',
     misconceptionTags: ['boundary.comma_splice', 'boundary.dash_missing', 'boundary.dash_spacing'],
     readiness: ['retrieve_discriminate', 'misconception', 'negative_test'],
     source: 'fixed',
@@ -1146,12 +1147,12 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     prompt: 'Add the punctuation between the related clauses.',
     stem: 'The door creaked open we froze.',
     accepted: [
-      'The door creaked open - we froze.',
       'The door creaked open – we froze.',
+      'The door creaked open - we froze.',
       'The door creaked open — we froze.',
     ],
     explanation: 'The dash creates a clear break between the two related clauses.',
-    model: 'The door creaked open - we froze.',
+    model: 'The door creaked open – we froze.',
     misconceptionTags: ['boundary.dash_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
     source: 'fixed',
@@ -1163,14 +1164,14 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     clusterId: 'boundary',
     rewardUnitId: 'dash-clauses-core',
     prompt: 'Correct the dash punctuation in this sentence.',
-    stem: 'The signal failed -and the team waited.',
+    stem: 'The signal failed –and the team waited.',
     accepted: [
-      'The signal failed - the team waited.',
       'The signal failed – the team waited.',
+      'The signal failed - the team waited.',
       'The signal failed — the team waited.',
     ],
     explanation: 'Leave a space either side of the dash and avoid attaching it to and.',
-    model: 'The signal failed - the team waited.',
+    model: 'The signal failed – the team waited.',
     misconceptionTags: ['boundary.dash_spacing', 'boundary.extra_conjunction'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
     source: 'fixed',
@@ -1183,9 +1184,13 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     rewardUnitId: 'dash-clauses-core',
     prompt: 'Write one sentence that links these clauses with a dash: The path was flooded / we took the longer route.',
     stem: '',
-    accepted: ['The path was flooded - we took the longer route.'],
+    accepted: [
+      'The path was flooded – we took the longer route.',
+      'The path was flooded - we took the longer route.',
+      'The path was flooded — we took the longer route.',
+    ],
     explanation: 'The dash sits between the two related clauses.',
-    model: 'The path was flooded - we took the longer route.',
+    model: 'The path was flooded – we took the longer route.',
     validator: {
       type: 'requiresBoundaryBetweenClauses',
       mark: ' - ',
@@ -1204,9 +1209,13 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     rewardUnitId: 'dash-clauses-core',
     prompt: 'Combine the two related clauses into one sentence with a dash.',
     stem: 'The path was flooded.\nWe took the longer route.',
-    accepted: ['The path was flooded - we took the longer route.'],
+    accepted: [
+      'The path was flooded – we took the longer route.',
+      'The path was flooded - we took the longer route.',
+      'The path was flooded — we took the longer route.',
+    ],
     explanation: 'A spaced dash marks the sharp boundary between the related clauses.',
-    model: 'The path was flooded - we took the longer route.',
+    model: 'The path was flooded – we took the longer route.',
     validator: {
       type: 'combineBoundaryBetweenClauses',
       mark: '-',
@@ -1226,13 +1235,13 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     prompt: 'Choose the sentence where the dash marks a clear break between ideas.',
     options: [
       'The lights went out, everyone stayed still.',
-      'The lights went out - everyone stayed still.',
-      'The lights went out -and everyone stayed still.',
+      'The lights went out – everyone stayed still.',
+      'The lights went out –and everyone stayed still.',
       'The lights went out everyone stayed still.',
     ],
     correctIndex: 1,
     explanation: 'The dash marks a sharp break between two closely related ideas.',
-    model: 'The lights went out - everyone stayed still.',
+    model: 'The lights went out – everyone stayed still.',
     misconceptionTags: ['boundary.comma_splice', 'boundary.dash_missing', 'boundary.dash_spacing'],
     readiness: ['retrieve_discriminate', 'misconception', 'negative_test'],
     source: 'fixed',
@@ -1246,12 +1255,12 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     prompt: 'Add the dash between the related ideas.',
     stem: 'The alarm rang everyone lined up.',
     accepted: [
-      'The alarm rang - everyone lined up.',
       'The alarm rang – everyone lined up.',
+      'The alarm rang - everyone lined up.',
       'The alarm rang — everyone lined up.',
     ],
     explanation: 'The dash creates a clear break between the two ideas.',
-    model: 'The alarm rang - everyone lined up.',
+    model: 'The alarm rang – everyone lined up.',
     misconceptionTags: ['boundary.dash_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
     source: 'fixed',
@@ -1264,9 +1273,13 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     rewardUnitId: 'dash-clauses-core',
     prompt: 'Write one sentence that links these ideas with a dash: The curtain rose / the hall fell silent.',
     stem: '',
-    accepted: ['The curtain rose - the hall fell silent.'],
+    accepted: [
+      'The curtain rose – the hall fell silent.',
+      'The curtain rose - the hall fell silent.',
+      'The curtain rose — the hall fell silent.',
+    ],
     explanation: 'The dash sits between the two related ideas.',
-    model: 'The curtain rose - the hall fell silent.',
+    model: 'The curtain rose – the hall fell silent.',
     validator: {
       type: 'requiresBoundaryBetweenClauses',
       mark: '-',
@@ -2464,6 +2477,34 @@ function transferValidatorRequirements(item) {
   }
 }
 
+const STRICT_FINAL_COMMA_VALIDATORS = new Set([
+  'requiresListCommas',
+  'combineListSentence',
+  'requiresColonBeforeList',
+  'combineColonList',
+]);
+
+function strictFinalCommaPolicyVisible(item) {
+  const validator = item?.validator || {};
+  if (validator.allowFinalComma !== false || !STRICT_FINAL_COMMA_VALIDATORS.has(validator.type)) {
+    return true;
+  }
+  const visibleText = normaliseVisibleContractText(`${item.prompt || ''} ${item.explanation || ''}`);
+  const mentionsComma = /\bcomma\b/.test(visibleText);
+  const mentionsFinalAnd = /\bfinal\b.*\band\b|\bbefore\b.*\band\b/.test(visibleText);
+  const forbidsComma = /\b(no|not|without|avoid|unneeded|unnecessary)\b|do not|not needed/.test(visibleText);
+  return mentionsComma && mentionsFinalAnd && forbidsComma;
+}
+
+function dashClauseDisplayUsesEnDash(item) {
+  if (!asArray(item?.skillIds).includes('dash_clause')) return true;
+  const displayTexts = [
+    item.model,
+    item.mode === 'choose' ? asArray(item.options)[Number(item.correctIndex)] : '',
+  ].filter((entry) => typeof entry === 'string' && /[-–—]/.test(entry));
+  return displayTexts.every((text) => text.includes(' – ') && !text.includes(' - '));
+}
+
 function pushIndexed(map, key, value) {
   if (!map.has(key)) map.set(key, []);
   map.get(key).push(value);
@@ -2600,6 +2641,12 @@ export function validatePunctuationManifest(manifest = PUNCTUATION_CONTENT_MANIF
       if (!visibleContractIncludes(visibleContract, requirement)) {
         errors.push(`Transfer item ${item.id} hides validator requirement ${requirement}.`);
       }
+    }
+    if (!strictFinalCommaPolicyVisible(item)) {
+      errors.push(`List-comma item ${item.id} forbids the final comma without visible house-style context.`);
+    }
+    if (!dashClauseDisplayUsesEnDash(item)) {
+      errors.push(`Dash-clause item ${item.id} must use a spaced en dash in model display.`);
     }
   }
 

--- a/shared/punctuation/generators.js
+++ b/shared/punctuation/generators.js
@@ -908,7 +908,7 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
     {
       prompt: 'Add a dash between the related clauses.',
       stem: 'The gate was stuck we found another path.',
-      model: 'The gate was stuck - we found another path.',
+      model: 'The gate was stuck – we found another path.',
       validator: {
         type: 'requiresBoundaryBetweenClauses',
         left: 'The gate was stuck',
@@ -921,7 +921,7 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
     {
       prompt: 'Add a dash between the related clauses.',
       stem: 'The bell rang everyone hurried inside.',
-      model: 'The bell rang - everyone hurried inside.',
+      model: 'The bell rang – everyone hurried inside.',
       validator: {
         type: 'requiresBoundaryBetweenClauses',
         left: 'The bell rang',
@@ -934,7 +934,7 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
     {
       prompt: 'Add a dash between the related clauses.',
       stem: 'The torch failed we used the lantern.',
-      model: 'The torch failed - we used the lantern.',
+      model: 'The torch failed – we used the lantern.',
       validator: {
         type: 'requiresBoundaryBetweenClauses',
         left: 'The torch failed',
@@ -947,7 +947,7 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
     {
       prompt: 'Add a dash between the related clauses.',
       stem: 'The bridge was closed the buses turned back.',
-      model: 'The bridge was closed - the buses turned back.',
+      model: 'The bridge was closed – the buses turned back.',
       validator: {
         type: 'requiresBoundaryBetweenClauses',
         left: 'The bridge was closed',
@@ -962,7 +962,7 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
     {
       prompt: 'Combine the two related clauses into one sentence with a dash.',
       stem: 'The gate was stuck.\nWe found another path.',
-      model: 'The gate was stuck - we found another path.',
+      model: 'The gate was stuck – we found another path.',
       validator: {
         type: 'combineBoundaryBetweenClauses',
         left: 'The gate was stuck',
@@ -975,7 +975,7 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
     {
       prompt: 'Combine the two related clauses into one sentence with a dash.',
       stem: 'The bell rang.\nEveryone hurried inside.',
-      model: 'The bell rang - everyone hurried inside.',
+      model: 'The bell rang – everyone hurried inside.',
       validator: {
         type: 'combineBoundaryBetweenClauses',
         left: 'The bell rang',
@@ -988,7 +988,7 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
     {
       prompt: 'Combine the two related clauses into one sentence with a dash.',
       stem: 'The torch failed.\nWe used the lantern.',
-      model: 'The torch failed - we used the lantern.',
+      model: 'The torch failed – we used the lantern.',
       validator: {
         type: 'combineBoundaryBetweenClauses',
         left: 'The torch failed',
@@ -1001,7 +1001,7 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
     {
       prompt: 'Combine the two related clauses into one sentence with a dash.',
       stem: 'The bridge was closed.\nThe buses turned back.',
-      model: 'The bridge was closed - the buses turned back.',
+      model: 'The bridge was closed – the buses turned back.',
       validator: {
         type: 'combineBoundaryBetweenClauses',
         left: 'The bridge was closed',

--- a/shared/punctuation/marking.js
+++ b/shared/punctuation/marking.js
@@ -285,6 +285,13 @@ function listCommaOk(text, words = [], { allowFinalComma = true } = {}) {
   };
 }
 
+function listCommaRejectionNote(validator = {}, hasFinalComma = false, fallback = '') {
+  if (validator.allowFinalComma === false && hasFinalComma) {
+    return 'This item uses the house style: no final comma before the final and.';
+  }
+  return fallback;
+}
+
 function openingPhraseMainClause(text, phrase) {
   const clean = canonicalPunctuationText(text);
   const canonicalPhrase = canonicalPunctuationText(phrase || '');
@@ -709,7 +716,9 @@ function markTransfer(item, answer) {
     return {
       correct,
       expected: item.model || '',
-      note: correct ? 'The list items are preserved and separated clearly.' : 'Keep the list items in order and add the list comma before the final and phrase.',
+      note: correct
+        ? 'The list items are preserved and separated clearly.'
+        : listCommaRejectionNote(validator, hasFinalComma, 'Keep the list items in order and add the list comma before the final and phrase.'),
       misconceptionTags: correct ? [] : [...new Set(tags.length ? tags : itemTags(item))],
       facets: [
         facet('preservation', wordsOk),
@@ -904,7 +913,9 @@ function markTransfer(item, answer) {
     return {
       correct,
       expected: item.model || '',
-      note: correct ? 'The colon introduces the list after a complete opening clause.' : 'Use the colon after the opening clause and keep the list items in order.',
+      note: correct
+        ? 'The colon introduces the list after a complete opening clause.'
+        : listCommaRejectionNote(validator, hasFinalComma, 'Use the colon after the opening clause and keep the list items in order.'),
       misconceptionTags: correct ? [] : [...new Set(tags.length ? tags : itemTags(item))],
       facets: [
         facet('preservation', wordsOk),
@@ -1083,7 +1094,9 @@ function markCombine(item, answer) {
     return {
       correct,
       expected,
-      note: correct ? 'The notes have been combined into one clear list sentence.' : 'Keep the list words in order and separate the list with the expected comma.',
+      note: correct
+        ? 'The notes have been combined into one clear list sentence.'
+        : listCommaRejectionNote(validator, hasFinalComma, 'Keep the list words in order and separate the list with the expected comma.'),
       misconceptionTags: correct ? [] : [...new Set(tags.length ? tags : itemTags(item))],
       facets: [
         facet('preservation', wordsOk),
@@ -1157,7 +1170,9 @@ function markCombine(item, answer) {
     return {
       correct,
       expected,
-      note: correct ? 'The opening clause and list are combined with a colon.' : 'Use the colon after the opening clause and keep the list items in order.',
+      note: correct
+        ? 'The opening clause and list are combined with a colon.'
+        : listCommaRejectionNote(validator, hasFinalComma, 'Use the colon after the opening clause and keep the list items in order.'),
       misconceptionTags: correct ? [] : [...new Set(tags.length ? tags : itemTags(item))],
       facets: [
         facet('preservation', wordsOk),

--- a/shared/punctuation/marking.js
+++ b/shared/punctuation/marking.js
@@ -285,11 +285,13 @@ function listCommaOk(text, words = [], { allowFinalComma = true } = {}) {
   };
 }
 
-function listCommaRejectionNote(validator = {}, hasFinalComma = false, fallback = '') {
-  if (validator.allowFinalComma === false && hasFinalComma) {
-    return 'This item uses the house style: no final comma before the final and.';
-  }
-  return fallback;
+const STRICT_FINAL_COMMA_NOTE = 'For this question, do not put a comma before the final and.';
+
+function listCommaRejectionNote(validator = {}, { hasFinalComma = false, tags = [] } = {}, fallback = '') {
+  if (validator.allowFinalComma !== false || !hasFinalComma) return fallback;
+  const otherIssues = uniqueStrings(tags).filter((tag) => tag !== 'comma.unnecessary_final_comma');
+  if (!otherIssues.length) return STRICT_FINAL_COMMA_NOTE;
+  return `${fallback} ${STRICT_FINAL_COMMA_NOTE}`.trim();
 }
 
 function openingPhraseMainClause(text, phrase) {
@@ -713,12 +715,19 @@ function markTransfer(item, answer) {
     if (!capitalOk) tags.push('comma.capitalisation_missing');
     if (!terminalOk) tags.push('comma.terminal_missing');
     if (terminalOk && !sentenceOk) tags.push('transfer.extra_sentence');
+    const fallbackNote = opening
+      ? 'Keep the exact stem and list items in order, and use commas between the list items.'
+      : 'Keep the list items in order and use commas between the list items.';
     return {
       correct,
       expected: item.model || '',
       note: correct
         ? 'The list items are preserved and separated clearly.'
-        : listCommaRejectionNote(validator, hasFinalComma, 'Keep the list items in order and add the list comma before the final and phrase.'),
+        : listCommaRejectionNote(
+            validator,
+            { hasFinalComma, tags },
+            fallbackNote,
+          ),
       misconceptionTags: correct ? [] : [...new Set(tags.length ? tags : itemTags(item))],
       facets: [
         facet('preservation', wordsOk),
@@ -915,7 +924,11 @@ function markTransfer(item, answer) {
       expected: item.model || '',
       note: correct
         ? 'The colon introduces the list after a complete opening clause.'
-        : listCommaRejectionNote(validator, hasFinalComma, 'Use the colon after the opening clause and keep the list items in order.'),
+        : listCommaRejectionNote(
+            validator,
+            { hasFinalComma, tags },
+            'Use the colon after the opening clause and keep the list items in order.',
+          ),
       misconceptionTags: correct ? [] : [...new Set(tags.length ? tags : itemTags(item))],
       facets: [
         facet('preservation', wordsOk),
@@ -1096,7 +1109,11 @@ function markCombine(item, answer) {
       expected,
       note: correct
         ? 'The notes have been combined into one clear list sentence.'
-        : listCommaRejectionNote(validator, hasFinalComma, 'Keep the list words in order and separate the list with the expected comma.'),
+        : listCommaRejectionNote(
+            validator,
+            { hasFinalComma, tags },
+            'Keep the list words in order and separate the list with the expected comma.',
+          ),
       misconceptionTags: correct ? [] : [...new Set(tags.length ? tags : itemTags(item))],
       facets: [
         facet('preservation', wordsOk),
@@ -1172,7 +1189,11 @@ function markCombine(item, answer) {
       expected,
       note: correct
         ? 'The opening clause and list are combined with a colon.'
-        : listCommaRejectionNote(validator, hasFinalComma, 'Use the colon after the opening clause and keep the list items in order.'),
+        : listCommaRejectionNote(
+            validator,
+            { hasFinalComma, tags },
+            'Use the colon after the opening clause and keep the list items in order.',
+          ),
       misconceptionTags: correct ? [] : [...new Set(tags.length ? tags : itemTags(item))],
       facets: [
         facet('preservation', wordsOk),

--- a/src/subjects/punctuation/components/punctuation-view-model.js
+++ b/src/subjects/punctuation/components/punctuation-view-model.js
@@ -1001,9 +1001,9 @@ export const PUNCTUATION_SKILL_MODAL_CONTENT = Object.freeze({
   }),
   dash_clause: Object.freeze({
     rule: 'A dash shows a sharp pause between two closely related ideas.',
-    workedGood: 'The bus was late - we walked instead.',
-    contrastGood: 'The bus was late - we walked instead.',
-    contrastBad: 'The path was flooded -and we took the longer route.',
+    workedGood: 'The bus was late – we walked instead.',
+    contrastGood: 'The bus was late – we walked instead.',
+    contrastBad: 'The path was flooded –and we took the longer route.',
   }),
   semicolon_list: Object.freeze({
     rule: 'Use semi-colons to separate list items when each item already contains commas.',

--- a/tests/punctuation-content-audit.test.js
+++ b/tests/punctuation-content-audit.test.js
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 
 import {
   PUNCTUATION_CONTENT_MANIFEST,
+  validatePunctuationManifest,
 } from '../shared/punctuation/content.js';
 import {
   runPunctuationContentAudit,
@@ -89,6 +90,10 @@ test('punctuation content audit proves P2 U3 runtime growth comes from fixed anc
   });
 
   assert.equal(audit.ok, true, audit.failures.join('\n'));
+  assert.deepEqual(
+    audit.failureDetails.filter((failure) => failure.code === 'generated_model_marking'),
+    [],
+  );
   assert.equal(audit.summary.fixedItemCount, 92);
   assert.equal(audit.summary.generatedItemCount, 100);
   assert.equal(audit.summary.runtimeItemCount, 192);
@@ -119,6 +124,50 @@ test('punctuation content audit can prove expanded deterministic bank variety', 
     assert.equal(row.variantSignatures.length, 4, row.id);
     assert.equal(row.templateIds.length, 4, row.id);
   }
+});
+
+test('punctuation content audit guards dash display and strict final-comma copy', () => {
+  const validation = validatePunctuationManifest(PUNCTUATION_CONTENT_MANIFEST);
+  assert.equal(validation.ok, true, validation.errors.join('\n'));
+
+  const dashItems = PUNCTUATION_CONTENT_MANIFEST.items.filter((item) => item.skillIds?.includes('dash_clause'));
+  assert.ok(dashItems.length > 0);
+  for (const item of dashItems) {
+    assert.match(item.model, /\s–\s/, item.id);
+    assert.doesNotMatch(item.model, /\s-\s/, item.id);
+  }
+
+  const strictFinalCommaItems = PUNCTUATION_CONTENT_MANIFEST.items.filter((item) => (
+    item.validator?.allowFinalComma === false
+  ));
+  assert.ok(strictFinalCommaItems.length > 0);
+  for (const item of strictFinalCommaItems) {
+    assert.match(`${item.prompt} ${item.explanation}`, /house style/i, item.id);
+    assert.match(`${item.prompt} ${item.explanation}`, /no final comma before (?:the final )?and/i, item.id);
+  }
+});
+
+test('punctuation content audit rejects strict final-comma items without visible policy context', () => {
+  const manifest = {
+    ...PUNCTUATION_CONTENT_MANIFEST,
+    items: PUNCTUATION_CONTENT_MANIFEST.items.map((item) => (
+      item.id === 'lc_transfer_bake_sale'
+        ? {
+            ...item,
+            prompt: 'Write one sentence using this exact stem and list: For the bake sale we needed eggs, flour, butter and sugar.',
+            explanation: 'The sentence keeps the stem and separates the list items with commas.',
+          }
+        : item
+    )),
+  };
+  const audit = runPunctuationContentAudit({
+    manifest,
+    seed: 'strict-final-comma-policy-copy',
+    generatedPerFamily: 1,
+  });
+
+  assert.equal(audit.ok, false);
+  assert.match(audit.failures.join('\n'), /lc_transfer_bake_sale forbids the final comma without visible house-style context/);
 });
 
 test('punctuation content audit detects crafted duplicate generated signatures', () => {

--- a/tests/punctuation-content-audit.test.js
+++ b/tests/punctuation-content-audit.test.js
@@ -142,8 +142,18 @@ test('punctuation content audit guards dash display and strict final-comma copy'
   ));
   assert.ok(strictFinalCommaItems.length > 0);
   for (const item of strictFinalCommaItems) {
-    assert.match(`${item.prompt} ${item.explanation}`, /house style/i, item.id);
-    assert.match(`${item.prompt} ${item.explanation}`, /no final comma before (?:the final )?and/i, item.id);
+    assert.doesNotMatch(`${item.prompt} ${item.explanation}`, /house style/i, item.id);
+    assert.match(`${item.prompt} ${item.explanation}`, /do not put a comma before the final and/i, item.id);
+  }
+
+  const fixedFreeTextListCommaItems = PUNCTUATION_CONTENT_MANIFEST.items.filter((item) => (
+    item.skillIds?.includes('list_commas')
+      && ['insert', 'fix'].includes(item.mode)
+      && item.validator?.allowFinalComma !== false
+  ));
+  assert.ok(fixedFreeTextListCommaItems.length > 0);
+  for (const item of fixedFreeTextListCommaItems) {
+    assert.equal(item.validator?.type, 'requiresListCommas', item.id);
   }
 });
 
@@ -167,7 +177,47 @@ test('punctuation content audit rejects strict final-comma items without visible
   });
 
   assert.equal(audit.ok, false);
-  assert.match(audit.failures.join('\n'), /lc_transfer_bake_sale forbids the final comma without visible house-style context/);
+  assert.match(audit.failures.join('\n'), /lc_transfer_bake_sale forbids the final comma without visible no-final-comma context/);
+});
+
+test('punctuation content audit rejects dash-clause items without dash-teaching display text', () => {
+  const manifest = {
+    ...PUNCTUATION_CONTENT_MANIFEST,
+    items: PUNCTUATION_CONTENT_MANIFEST.items.map((item) => (
+      item.id === 'dc_insert_door_froze'
+        ? {
+            ...item,
+            model: 'The door creaked open we froze.',
+          }
+        : item
+    )),
+  };
+  const validation = validatePunctuationManifest(manifest);
+
+  assert.equal(validation.ok, false);
+  assert.match(validation.errors.join('\n'), /dc_insert_door_froze must use a spaced en dash in model display/);
+});
+
+test('punctuation content audit rejects dash-clause display with spaced hyphen', () => {
+  const manifest = {
+    ...PUNCTUATION_CONTENT_MANIFEST,
+    items: PUNCTUATION_CONTENT_MANIFEST.items.map((item) => (
+      item.id === 'dc_choose_flooded_route'
+        ? {
+            ...item,
+            options: item.options.map((option, index) => (
+              index === item.correctIndex
+                ? 'The path was flooded - we took the longer route.'
+                : option
+            )),
+          }
+        : item
+    )),
+  };
+  const validation = validatePunctuationManifest(manifest);
+
+  assert.equal(validation.ok, false);
+  assert.match(validation.errors.join('\n'), /dc_choose_flooded_route must use a spaced en dash in model display/);
 });
 
 test('punctuation content audit detects crafted duplicate generated signatures', () => {

--- a/tests/punctuation-generators.test.js
+++ b/tests/punctuation-generators.test.js
@@ -129,7 +129,7 @@ const LEGACY_RUNTIME_GENERATED_FIXTURE = Object.freeze([
     id: 'gen_dash_clause_fix_kwbiay_1',
     generatorFamilyId: 'gen_dash_clause_fix',
     stem: 'The gate was stuck we found another path.',
-    model: 'The gate was stuck - we found another path.',
+    model: 'The gate was stuck – we found another path.',
     templateId: 'gen_dash_clause_fix_template_11ejvfc',
     variantSignature: 'puncsig_erog6d',
   },
@@ -137,7 +137,7 @@ const LEGACY_RUNTIME_GENERATED_FIXTURE = Object.freeze([
     id: 'gen_dash_clause_combine_n82560_1',
     generatorFamilyId: 'gen_dash_clause_combine',
     stem: 'The gate was stuck.\nWe found another path.',
-    model: 'The gate was stuck - we found another path.',
+    model: 'The gate was stuck – we found another path.',
     templateId: 'gen_dash_clause_combine_template_1o45ea6',
     variantSignature: 'puncsig_5qqk8w',
   },
@@ -282,6 +282,36 @@ test('generated punctuation model answers pass deterministic marking', () => {
   for (const item of generatedItems) {
     const result = markPunctuationAnswer({ item, answer: { typed: item.model } });
     assert.equal(result.correct, true, item.id);
+  }
+});
+
+test('generated dash and list-comma model answers stay aligned with deterministic marking', () => {
+  const generatedItems = createPunctuationGeneratedItems({ seed: 'dash-list-policy', perFamily: 4 });
+  const policyItems = generatedItems.filter((item) => [
+    'gen_dash_clause_fix',
+    'gen_dash_clause_combine',
+    'gen_list_commas_insert',
+    'gen_list_commas_combine',
+  ].includes(item.generatorFamilyId));
+
+  assert.equal(policyItems.length, 16);
+  for (const item of policyItems) {
+    const result = markPunctuationAnswer({ item, answer: { typed: item.model } });
+    assert.equal(result.correct, true, item.id);
+  }
+
+  const dashItems = policyItems.filter((item) => item.generatorFamilyId.startsWith('gen_dash_clause_'));
+  for (const item of dashItems) {
+    assert.match(item.model, /\s–\s/, item.id);
+    assert.doesNotMatch(item.model, /\s-\s/, item.id);
+    for (const typed of [
+      item.model.replace(' – ', ' - '),
+      item.model,
+      item.model.replace(' – ', ' — '),
+    ]) {
+      const result = markPunctuationAnswer({ item, answer: { typed } });
+      assert.equal(result.correct, true, `${item.id}: ${typed}`);
+    }
   }
 });
 

--- a/tests/punctuation-marking.test.js
+++ b/tests/punctuation-marking.test.js
@@ -116,6 +116,27 @@ test('comma list transfer requires preserved items and KS2 list comma placement'
   assert.equal(missingComma.correct, false);
   assert.equal(missingComma.misconceptionTags.includes('comma.list_separator_missing'), true);
 
+  const insertOxfordComma = markPunctuationAnswer({
+    item: item('lc_insert_supplies'),
+    answer: { typed: 'We needed pencils, rulers, and glue.' },
+  });
+  assert.equal(insertOxfordComma.correct, true);
+  assert.deepEqual(insertOxfordComma.misconceptionTags, []);
+
+  const fixOxfordComma = markPunctuationAnswer({
+    item: item('lc_fix_display'),
+    answer: { typed: 'The display showed shells, pebbles, and fossils.' },
+  });
+  assert.equal(fixOxfordComma.correct, true);
+  assert.deepEqual(fixOxfordComma.misconceptionTags, []);
+
+  const changedInsertStem = markPunctuationAnswer({
+    item: item('lc_insert_supplies'),
+    answer: { typed: 'We packed pencils, rulers, and glue.' },
+  });
+  assert.equal(changedInsertStem.correct, false);
+  assert.equal(changedInsertStem.misconceptionTags.includes('comma.list_words_changed'), true);
+
   const finalComma = markPunctuationAnswer({
     item: item('lc_transfer_trip'),
     answer: { typed: 'For the trip, we packed torches, maps, and water.' },
@@ -131,15 +152,15 @@ test('comma list transfer requires preserved items and KS2 list comma placement'
 
   const strictFinalCommaItem = item('lc_transfer_bake_sale');
   assert.equal(strictFinalCommaItem.validator.allowFinalComma, false);
-  assert.match(`${strictFinalCommaItem.prompt} ${strictFinalCommaItem.explanation}`, /house style/i);
-  assert.match(`${strictFinalCommaItem.prompt} ${strictFinalCommaItem.explanation}`, /no final comma before (?:the final )?and/i);
+  assert.doesNotMatch(`${strictFinalCommaItem.prompt} ${strictFinalCommaItem.explanation}`, /house style/i);
+  assert.match(`${strictFinalCommaItem.prompt} ${strictFinalCommaItem.explanation}`, /do not put a comma before the final and/i);
   const strictFinalComma = markPunctuationAnswer({
     item: strictFinalCommaItem,
     answer: { typed: 'For the bake sale we needed eggs, flour, butter, and sugar.' },
   });
   assert.equal(strictFinalComma.correct, false);
   assert.equal(strictFinalComma.misconceptionTags.includes('comma.unnecessary_final_comma'), true);
-  assert.match(strictFinalComma.note, /house style: no final comma before the final and/i);
+  assert.equal(strictFinalComma.note, 'For this question, do not put a comma before the final and.');
 
   const changedStem = markPunctuationAnswer({
     item: item('lc_transfer_bake_sale'),
@@ -147,6 +168,16 @@ test('comma list transfer requires preserved items and KS2 list comma placement'
   });
   assert.equal(changedStem.correct, false);
   assert.equal(changedStem.misconceptionTags.includes('comma.list_words_changed'), true);
+
+  const changedStemWithFinalComma = markPunctuationAnswer({
+    item: item('lc_transfer_bake_sale'),
+    answer: { typed: 'At the bake sale we needed eggs, flour, butter, and sugar.' },
+  });
+  assert.equal(changedStemWithFinalComma.correct, false);
+  assert.equal(changedStemWithFinalComma.misconceptionTags.includes('comma.list_words_changed'), true);
+  assert.equal(changedStemWithFinalComma.misconceptionTags.includes('comma.unnecessary_final_comma'), true);
+  assert.match(changedStemWithFinalComma.note, /Keep the exact stem and list items in order/i);
+  assert.match(changedStemWithFinalComma.note, /do not put a comma before the final and/i);
 });
 
 test('fronted adverbial and clarity transfers require the opening phrase comma', () => {

--- a/tests/punctuation-marking.test.js
+++ b/tests/punctuation-marking.test.js
@@ -123,25 +123,23 @@ test('comma list transfer requires preserved items and KS2 list comma placement'
   assert.equal(finalComma.correct, true);
   assert.deepEqual(finalComma.misconceptionTags, []);
 
-  const strictListItem = {
-    ...item('lc_transfer_trip'),
-    validator: {
-      ...item('lc_transfer_trip').validator,
-      allowFinalComma: false,
-    },
-  };
-  const strictFinalComma = markPunctuationAnswer({
-    item: strictListItem,
-    answer: { typed: 'For the trip, we packed torches, maps, and water.' },
-  });
-  assert.equal(strictFinalComma.correct, false);
-  assert.equal(strictFinalComma.misconceptionTags.includes('comma.unnecessary_final_comma'), true);
-
   const anchored = markPunctuationAnswer({
     item: item('lc_transfer_bake_sale'),
     answer: { typed: 'For the bake sale we needed eggs, flour, butter and sugar.' },
   });
   assert.equal(anchored.correct, true);
+
+  const strictFinalCommaItem = item('lc_transfer_bake_sale');
+  assert.equal(strictFinalCommaItem.validator.allowFinalComma, false);
+  assert.match(`${strictFinalCommaItem.prompt} ${strictFinalCommaItem.explanation}`, /house style/i);
+  assert.match(`${strictFinalCommaItem.prompt} ${strictFinalCommaItem.explanation}`, /no final comma before (?:the final )?and/i);
+  const strictFinalComma = markPunctuationAnswer({
+    item: strictFinalCommaItem,
+    answer: { typed: 'For the bake sale we needed eggs, flour, butter, and sugar.' },
+  });
+  assert.equal(strictFinalComma.correct, false);
+  assert.equal(strictFinalComma.misconceptionTags.includes('comma.unnecessary_final_comma'), true);
+  assert.match(strictFinalComma.note, /house style: no final comma before the final and/i);
 
   const changedStem = markPunctuationAnswer({
     item: item('lc_transfer_bake_sale'),
@@ -202,13 +200,8 @@ test('boundary transfer validators require target marks between preserved clause
   assert.equal(commaSplice.correct, false);
   assert.equal(commaSplice.misconceptionTags.includes('boundary.comma_splice'), true);
 
-  const dash = markPunctuationAnswer({
-    item: item('dc_transfer_flooded_route'),
-    answer: { typed: 'The path was flooded - we took the longer route.' },
-  });
-  assert.equal(dash.correct, true);
-
   for (const typed of [
+    'The path was flooded - we took the longer route.',
     'The path was flooded – we took the longer route.',
     'The path was flooded — we took the longer route.',
   ]) {
@@ -225,6 +218,29 @@ test('boundary transfer validators require target marks between preserved clause
   });
   assert.equal(missingDash.correct, false);
   assert.equal(missingDash.misconceptionTags.includes('boundary.dash_missing'), true);
+});
+
+test('dash-clause model display teaches a spaced en dash', () => {
+  const dashItemIds = [
+    'dc_choose_flooded_route',
+    'dc_insert_door_froze',
+    'dc_fix_signal_team',
+    'dc_transfer_flooded_route',
+    'dc_combine_flooded_route',
+    'dc_choose_lights_out',
+    'dc_insert_alarm_rang',
+    'dc_transfer_curtain_rose',
+  ];
+
+  for (const itemId of dashItemIds) {
+    const currentItem = item(itemId);
+    assert.match(currentItem.model, /\s–\s/, `${itemId} model`);
+    assert.doesNotMatch(currentItem.model, /\s-\s/, `${itemId} model`);
+    if (currentItem.mode === 'choose') {
+      assert.match(currentItem.options[currentItem.correctIndex], /\s–\s/, `${itemId} correct option`);
+      assert.doesNotMatch(currentItem.options[currentItem.correctIndex], /\s-\s/, `${itemId} correct option`);
+    }
+  }
 });
 
 test('fixed dash-clause exact items accept spaced hyphen, en dash, and em dash answers', () => {


### PR DESCRIPTION
## Summary

- Display dash-clause model answers with a spaced en dash while preserving permissive marking for spaced hyphen, en dash, and em dash learner answers.
- Make strict no-final-comma list-comma policy visible in the prompt, explanation, rejection note, and audit guard using child-facing wording.
- Gate strict final-comma feedback so it is only the standalone note when the final comma is the sole meaningful issue; combined feedback now also tells learners to keep the exact stem/list when wording changed.
- Fail the manifest/audit guard when a `dash_clause` item has no dash-teaching display text, or when any dash-teaching display text uses a spaced hyphen instead of a spaced en dash.
- Add deterministic validators to fixed list-comma insert/fix free-text items so otherwise-correct Oxford-comma answers are accepted by default unless an item explicitly forbids the final comma.

## Verification

- `node --test tests/punctuation-marking.test.js tests/punctuation-generators.test.js tests/punctuation-content-audit.test.js tests/punctuation-view-model.test.js` — 156/156 passed.
- `npm run audit:punctuation-content -- --strict --generated-per-family 4` — passed.
- `npm run check` — completed the Wrangler dry-run build and client bundle audit successfully.
- `git diff --check` — passed.
- `git diff --cached --check` — passed before commit.

Notes:
- `npm run audit:punctuation-content` and `npm run check` emitted the existing npm `playwright_skip_browser_download` / `playwright-skip-browser-download` config warnings.
- Earlier verification from the first commit remains valid: a previous full `npm test` run exposed a volatile `tests/worker-capacity-overhead.test.js` overhead failure, a focused rerun passed, and the subsequent full `npm test` run passed.

## Post-Deploy Monitoring & Validation

- After deployment, verify the production punctuation flow on `https://ks2.eugnel.uk` with a logged-in browser session.
- Spot-check dash-clause answer review copy to confirm learner-facing model answers show a spaced en dash.
- Spot-check list-comma free-text items to confirm default Oxford-comma acceptance remains permissive, and strict no-final-comma items explain the final-comma rule without hiding stem/list mistakes.
- Watch normal post-deploy worker logs and subject telemetry for unexpected punctuation marking failures or audit regressions.
