### PR TITLE
feat(seo): add AI-readable identity and measurement checks

### DIFF
--- a/_headers
+++ b/_headers
@@ -101,6 +101,19 @@
   Reporting-Endpoints: csp-endpoint="/api/security/csp-report"
   Cache-Control: public, max-age=3600
 
+/llms.txt
+  Strict-Transport-Security: max-age=63072000; includeSubDomains
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(), geolocation=(), payment=(), usb=(), bluetooth=(), serial=(), hid=(), midi=(), microphone=(), accelerometer=(), gyroscope=(), magnetometer=(), autoplay=(), encrypted-media=(), fullscreen=(self), picture-in-picture=(), interest-cohort=(), browsing-topics=()
+  X-Frame-Options: DENY
+  Cross-Origin-Opener-Policy: same-origin-allow-popups
+  Cross-Origin-Resource-Policy: same-site
+  Content-Security-Policy-Report-Only: default-src 'none'; script-src 'self' 'sha256-BUILD_TIME_HASH' 'strict-dynamic' https://challenges.cloudflare.com; script-src-elem 'self' 'sha256-BUILD_TIME_HASH' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com; media-src 'self' blob:; form-action 'self'; frame-ancestors 'none'; frame-src https://challenges.cloudflare.com; base-uri 'none'; object-src 'none'; manifest-src 'self'; worker-src 'none'; report-uri /api/security/csp-report; report-to csp-endpoint
+  Report-To: {"group":"csp-endpoint","max_age":10886400,"endpoints":[{"url":"/api/security/csp-report"}]}
+  Reporting-Endpoints: csp-endpoint="/api/security/csp-report"
+  Cache-Control: public, max-age=3600
+
 /ks2-spelling-practice/
   Strict-Transport-Security: max-age=63072000; includeSubDomains
   X-Content-Type-Options: nosniff
@@ -128,6 +141,19 @@
   Cache-Control: no-store
 
 /ks2-punctuation-practice/
+  Strict-Transport-Security: max-age=63072000; includeSubDomains
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(), geolocation=(), payment=(), usb=(), bluetooth=(), serial=(), hid=(), midi=(), microphone=(), accelerometer=(), gyroscope=(), magnetometer=(), autoplay=(), encrypted-media=(), fullscreen=(self), picture-in-picture=(), interest-cohort=(), browsing-topics=()
+  X-Frame-Options: DENY
+  Cross-Origin-Opener-Policy: same-origin-allow-popups
+  Cross-Origin-Resource-Policy: same-site
+  Content-Security-Policy-Report-Only: default-src 'none'; script-src 'self' 'sha256-BUILD_TIME_HASH' 'strict-dynamic' https://challenges.cloudflare.com; script-src-elem 'self' 'sha256-BUILD_TIME_HASH' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com; media-src 'self' blob:; form-action 'self'; frame-ancestors 'none'; frame-src https://challenges.cloudflare.com; base-uri 'none'; object-src 'none'; manifest-src 'self'; worker-src 'none'; report-uri /api/security/csp-report; report-to csp-endpoint
+  Report-To: {"group":"csp-endpoint","max_age":10886400,"endpoints":[{"url":"/api/security/csp-report"}]}
+  Reporting-Endpoints: csp-endpoint="/api/security/csp-report"
+  Cache-Control: no-store
+
+/about/
   Strict-Transport-Security: max-age=63072000; includeSubDomains
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin

--- a/docs/operations/seo.md
+++ b/docs/operations/seo.md
@@ -9,29 +9,38 @@ problem_type: runbook
 
 # SEO Operations
 
-KS2 Mastery SEO is a staged discovery layer: one crawlable public identity surface, focused practice-tool landing pages, valid discovery files, production audit coverage, and an operator path for measuring organic discovery. It does not guarantee ranking, search placement, or AI assistant recommendations.
+KS2 Mastery SEO is a staged discovery layer: crawlable public product identity, focused practice-tool landing pages, valid discovery files, production audit coverage, and an operator path for measuring organic discovery. It does not guarantee ranking, search placement, or AI assistant recommendations.
 
 ## Public Surface
 
-The canonical public URLs are:
+The canonical public HTML URLs intended for search results are:
 
 - `https://ks2.eugnel.uk/`
+- `https://ks2.eugnel.uk/about/`
 - `https://ks2.eugnel.uk/ks2-spelling-practice/`
 - `https://ks2.eugnel.uk/ks2-grammar-practice/`
 - `https://ks2.eugnel.uk/ks2-punctuation-practice/`
 
-The root page should describe KS2 Mastery as an online KS2 spelling, grammar, and punctuation practice product. The copy must stay aligned with the actual app experience and must not expose private learner state, admin surfaces, generated content stores, or internal analytics.
+The supplementary AI-readable summary is:
 
-The practice-tool landing pages should stay focused on the product's real subject areas. Future subject/problem or parent-support pages should be added only after they exist as accurate public pages and there is measurement evidence to guide the next slice.
+- `https://ks2.eugnel.uk/llms.txt`
+
+The root and about pages should describe KS2 Mastery as an online KS2 spelling, grammar, and punctuation practice product. The copy must stay aligned with the actual app experience and must not expose private learner state, admin surfaces, generated content stores, or internal analytics.
+
+The practice-tool landing pages should stay focused on the product's real subject areas. `llms.txt` is a short factual summary for AI agents, not a replacement for crawlable HTML, sitemap coverage, robots access, or Search Console validation.
+
+Future subject/problem or parent-support pages should be added only after they exist as accurate public pages and there is measurement evidence to guide the next slice.
 
 ## Production Checks
 
 After deployment, verify:
 
 - `https://ks2.eugnel.uk/` returns public identity copy, meta description, canonical URL, share metadata, and JSON-LD product identity.
+- `https://ks2.eugnel.uk/about/` returns page-specific static public HTML, not the root SPA shell.
 - `https://ks2.eugnel.uk/ks2-spelling-practice/`, `https://ks2.eugnel.uk/ks2-grammar-practice/`, and `https://ks2.eugnel.uk/ks2-punctuation-practice/` each return page-specific public HTML, not the root SPA shell.
+- `https://ks2.eugnel.uk/llms.txt` returns plain text with the product identity, canonical public pages, subject coverage, and privacy boundary. It must not include private paths, internal implementation tokens, secret names, or recommendation guarantees.
 - `https://ks2.eugnel.uk/robots.txt` returns a robots policy, not the SPA HTML fallback, and excludes `/api/`, `/admin`, and `/demo` from normal crawler discovery.
-- `https://ks2.eugnel.uk/sitemap.xml` returns an XML sitemap with the root plus the three canonical practice-tool page URLs, and no `/api/`, `/admin`, `/demo`, local, or `.html` variants.
+- `https://ks2.eugnel.uk/sitemap.xml` returns an XML sitemap with exactly the root, about page, and three canonical practice-tool page URLs. It must not list `llms.txt`, `/api/`, `/admin`, `/demo`, local, or `.html` variants.
 - `npm run audit:production -- --skip-local` passes against the live origin.
 
 Search engines can still take time to crawl and index the site after these checks pass.
@@ -42,10 +51,18 @@ Use Google Search Console or equivalent search tooling to:
 
 - Verify ownership for `https://ks2.eugnel.uk/`.
 - Submit `https://ks2.eugnel.uk/sitemap.xml`.
-- Inspect the canonical root URL and each practice-tool URL after deployment.
-- Review indexing status, impressions, clicks, CTR, queries, and landing pages before choosing the next SEO content page.
+- Inspect all five canonical public HTML URLs after deployment: root, about, spelling practice, grammar practice, and punctuation practice.
+- Review indexing status, impressions, clicks, CTR, average position, queries, and landing pages before choosing the next SEO content page.
 
 The verification method depends on the external account setup. Do not add placeholder verification tokens to the repo.
+
+Track the first baseline after deployment, then review again once Search Console has enough crawl and query data to show signal. Record:
+
+- Which canonical URLs are indexed.
+- Which queries produce impressions.
+- Clicks, CTR, average position, and landing page per query.
+- Pages with impressions but no clicks.
+- Pages with no indexing or crawl errors.
 
 ## Analytics
 
@@ -53,9 +70,11 @@ Worker observability is infrastructure telemetry. It is useful for errors and ru
 
 For aggregate visitor analytics, prefer Cloudflare Web Analytics first because the site already runs on Cloudflare.
 
-For a proxied Cloudflare hostname, enable Web Analytics from the Cloudflare dashboard by adding the hostname in Web Analytics and using automatic setup when available. If the dashboard requires manual snippet installation instead, treat that as a code change: use the real site token only, review CSP `script-src` and `connect-src`, and update production audit coverage in the same PR.
+For a proxied Cloudflare hostname, enable Web Analytics from the Cloudflare dashboard by adding the hostname in Web Analytics and using automatic setup when available. Record whether the dashboard shows automatic setup as active for `ks2.eugnel.uk`.
 
-Cloudflare Web Analytics can track SPA interactions, but the V2 SEO landing pages are static pages and should first be measured as page views and landing pages.
+If the dashboard requires manual snippet installation instead, treat that as a code change: use the real site token only, review CSP `script-src` and `connect-src`, and update production audit coverage in the same PR. Do not commit placeholder analytics tokens.
+
+Cloudflare Web Analytics can track SPA interactions, but the V3 SEO landing pages are static pages and should first be measured as page views, landing pages, referrers, and search traffic trends.
 
 GA4 or Zaraz can be added later if James chooses that stack and supplies the real property or site-token configuration.
 
@@ -75,9 +94,11 @@ AI-search visibility depends on crawlable public pages, external systems, and us
 Operational checks:
 
 - Keep public SEO pages available under the generic `User-agent: *` robots policy.
-- Do not add an `OAI-SearchBot`, `GPTBot`, or `ChatGPT-User` robots group unless the private-path disallows are repeated deliberately.
-- Check Cloudflare security, bot, and WAF settings if AI-search crawler access looks blocked despite `robots.txt`.
-- Treat `OAI-SearchBot` as search visibility related; do not assume `GPTBot` training access is required for ChatGPT search recommendations.
+- Do not add an `OAI-SearchBot`, `GPTBot`, or `ChatGPT-User` robots group unless the private-path disallows are repeated deliberately in that specific group.
+- Treat `OAI-SearchBot` as search visibility related. The production audit fails if effective robots policy blocks it from the public HTML URLs.
+- Treat `GPTBot` as a separate training-crawler policy choice. Disallowing `GPTBot` is not, by itself, a failed search-visibility audit if `OAI-SearchBot` remains able to fetch public SEO pages.
+- Check Cloudflare security, bot, and WAF settings if AI-search crawler access looks blocked despite the repo `robots.txt`.
+- In Cloudflare, check `Block AI bots`, managed `robots.txt`, AI Crawl Control, verified bot handling, and custom WAF rules before changing repo robots policy.
 - Do not treat `llms.txt` or AI-only summary files as a replacement for normal crawlable pages and sitemap coverage.
 
 ## Next Content Choices
@@ -90,3 +111,18 @@ Preserve these acquisition lanes for later work:
 - AI-readable product identity, where assistants can understand what KS2 Mastery is and when it is relevant.
 
 Pick the next content slice from product fit, organic value, and observed measurement signals. Avoid broad keyword chasing or thin pages.
+
+Use one of these gates before adding the next public content slice:
+
+- Search Console shows impressions or queries that map cleanly to a subject/problem page.
+- Existing indexed pages show impressions but weak clicks, suggesting copy or page intent needs refinement before expansion.
+- Existing public pages are indexed but have no meaningful impressions after a reasonable observation window, suggesting a more specific intent page is needed.
+- Product direction needs a durable support page that can also serve organic intent.
+
+Likely next candidates:
+
+- `how to practise apostrophes KS2`
+- `Year 5 spelling words practice`
+- `relative clauses KS2 practice`
+- `commas in a list KS2`
+- `help my child with KS2 grammar at home`

--- a/docs/plans/2026-04-28-004-feat-ks2-seo-ai-measurement-plan.md
+++ b/docs/plans/2026-04-28-004-feat-ks2-seo-ai-measurement-plan.md
@@ -1,0 +1,410 @@
+---
+title: "feat: Add KS2 SEO AI Identity and Measurement Baseline"
+type: feat
+status: completed
+date: 2026-04-28
+origin: docs/brainstorms/2026-04-28-ks2-seo-foundation-requirements.md
+---
+
+# feat: Add KS2 SEO AI Identity and Measurement Baseline
+
+## Summary
+
+Build the V3 SEO slice by adding a stronger crawlable product-identity page, a supplementary AI-readable site summary, crawler-policy production checks, and a measurement operating path that lets the next content page be chosen from evidence rather than guesswork.
+
+---
+
+## Problem Frame
+
+V1 made the root public surface understandable, and V2 added practice-tool landing pages for spelling, grammar, and punctuation. The remaining gap is trust and measurement: search engines and AI assistants need a clearer site identity beyond short landing-page copy, and James needs a reliable way to see whether the public pages are being crawled, indexed, visited, and worth extending.
+
+---
+
+## Assumptions
+
+*This plan was authored without synchronous user confirmation for the V3 shape. The items below are agent inferences that should be reviewed before implementation proceeds.*
+
+- V3 should strengthen AI-readable product identity and measurement before adding subject/problem or parent-support pages.
+- A public `llms.txt` summary is useful as a supplementary AI-readable resource, but it must not replace normal crawlable HTML, sitemap, robots policy, or Search Console validation.
+- Cloudflare Web Analytics remains dashboard-first for V3; manual snippet injection is deferred unless James supplies a real token and accepts the CSP, consent, and privacy review.
+- OAI-SearchBot search visibility should be protected; GPTBot training access remains a separate policy choice and should not be treated as required for ChatGPT search visibility.
+
+---
+
+## Requirements
+
+- R1. Add a crawlable public identity page that explains what KS2 Mastery is, who it helps, what subjects it currently supports, and how demo/sign-in paths relate to saved progress.
+- R2. Keep public copy in plain UK English, accurate to current product capability, and useful to humans, search crawlers, and AI assistants.
+- R3. Add a supplementary AI-readable text resource that summarises the public product identity, canonical URLs, subject coverage, and privacy boundaries without exposing private app state.
+- R4. Update the public discovery graph so the root, practice pages, and new identity page link to each other coherently and only canonical public URLs are advertised.
+- R5. Strengthen local and production validation so `/about/`, `llms.txt`, `robots.txt`, `sitemap.xml`, and existing public pages cannot silently become SPA fallback HTML or leak private implementation details.
+- R6. Detect production robots or Cloudflare-managed crawler-policy changes that block OAI-SearchBot from public SEO pages, while keeping private API, admin, and demo paths out of crawler discovery.
+- R7. Expand the SEO runbook into a measurement baseline covering Search Console, Cloudflare Web Analytics, AI crawler checks, and the decision gate for the next content slice.
+- R8. Preserve the future acquisition lanes from the origin document: practice-tool intent, subject/problem intent, parent-support intent, and AI-readable product identity.
+- R9. Do not commit fake verification tags, placeholder analytics tokens, broad curriculum claims, recommendation guarantees, or code-injected third-party scripts without real configuration and privacy/security review.
+
+**Origin actors:** A1 prospective KS2 learner/supporting adult; A2 search crawler; A3 AI search or assistant system; A4 James/product operator; A5 KS2 Mastery app.
+
+**Origin flows:** F1 public discovery and product understanding; F2 search engine discovery and validation; F3 organic measurement and next-slice selection.
+
+**Origin acceptance examples:** AE1 product identity is understandable without sign-in; AE2 app/demo entry preserves private data boundaries; AE3 discovery files and metadata work in production; AE4 public site is understandable without authenticated app flow; AE5 measurement supports decisions; AE6 later content lanes remain open.
+
+---
+
+## Scope Boundaries
+
+- Do not add subject/problem pages such as apostrophes, relative clauses, or Year 5 spelling words in this V3 slice.
+- Do not add parent-support pages in this V3 slice.
+- Do not build a blog, broad content library, or keyword-volume programme.
+- Do not promise that Google, ChatGPT, or any AI assistant will recommend KS2 Mastery.
+- Do not treat `llms.txt` as a substitute for useful public pages, sitemap coverage, or normal crawler access.
+- Do not commit GA4, Zaraz, or a manual Cloudflare Web Analytics snippet without a real configured token and a separate CSP/consent review.
+- Do not expose authenticated read models, learner progress, generated content stores, D1 rows, R2 objects, admin content, internal analytics, or API responses as public SEO content.
+- Do not weaken existing CSP, security headers, production audit gates, demo safeguards, auth boundaries, or deployment scripts for SEO convenience.
+
+### Deferred to Follow-Up Work
+
+- Search Console ownership verification: complete when James chooses the Google account/property and verification method.
+- Cloudflare Web Analytics dashboard activation: complete externally and record the result in the runbook; only code manual snippet support if automatic setup is unavailable or unsuitable.
+- Subject/problem pages: plan after public pages have indexing or query evidence, with likely candidates such as apostrophes, Year 5 spelling words, and sentence-level grammar topics.
+- Parent-support pages: plan after product identity and practice-tool pages show enough demand to justify a home-support content slice.
+- Explicit bot-specific robots groups: add only if production evidence shows generic `User-agent: *` access is insufficient, and repeat private-path disallows in every specific group.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `index.html` contains the canonical root metadata, raw public fallback copy, practice-page links, and JSON-LD product identity from V1/V2.
+- `scripts/lib/seo-practice-pages.mjs` is the current source of truth for generated static practice pages and canonical practice URLs.
+- `scripts/build-public.mjs` copies public root assets, versions the React bundle, renders static practice pages, and writes CSP hash artefacts.
+- `scripts/assert-build-public.mjs` enforces the public-output allowlist, sitemap contract, robots contract, JSON-LD expectations, and forbidden public SEO text.
+- `_headers`, `scripts/lib/headers-drift.mjs`, and `tests/security-headers.test.js` define the static asset cache/security contract for generated HTML pages.
+- `scripts/production-bundle-audit.mjs` and `tests/bundle-audit.test.js` are the production gate for proving live public URLs are real SEO resources rather than Cloudflare SPA fallback output.
+- `src/surfaces/auth/AuthSurface.jsx` and `tests/react-auth-boot.test.js` are the rendered unauthenticated root surface and should link to any new public identity page without changing private app flows.
+- `docs/operations/seo.md` already distinguishes public SEO surfaces, Search Console, Cloudflare Web Analytics, AI crawler posture, and next-content choices.
+
+### Institutional Learnings
+
+- `docs/solutions/workflow-issues/sys-hardening-p2-13-unit-autonomous-sprint-learnings-2026-04-26.md`: coupled build-output, public allowlist, headers, and audit changes should land atomically when reverting one file could leave production silently wrong.
+- `docs/solutions/architecture-patterns/admin-console-section-extraction-pattern-2026-04-27.md`: check existing Cloudflare/static routing before inventing Worker routes; this repo already has Static Assets plus SPA fallback, so public SEO pages should remain static assets unless evidence says otherwise.
+
+### External References
+
+- Google Search Central helpful content guidance: [developers.google.com/search/docs/fundamentals/creating-helpful-content](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+- Google Search Central sitemap guidance: [developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap](https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap)
+- Google structured data introduction: [developers.google.com/search/docs/appearance/structured-data/intro-structured-data](https://developers.google.com/search/docs/appearance/structured-data/intro-structured-data)
+- Google Search Console overview: [search.google.com/search-console/about](https://search.google.com/search-console/about)
+- Cloudflare Web Analytics overview: [developers.cloudflare.com/web-analytics](https://developers.cloudflare.com/web-analytics/)
+- Cloudflare Web Analytics setup: [developers.cloudflare.com/web-analytics/get-started](https://developers.cloudflare.com/web-analytics/get-started/)
+- Cloudflare Web Analytics SPA tracking: [developers.cloudflare.com/web-analytics/get-started/web-analytics-spa](https://developers.cloudflare.com/web-analytics/get-started/web-analytics-spa/)
+- Cloudflare bot custom rules and managed bot settings: [developers.cloudflare.com/bots/additional-configurations/custom-rules](https://developers.cloudflare.com/bots/additional-configurations/custom-rules/)
+- Cloudflare verified bots: [developers.cloudflare.com/bots/concepts/bot/verified-bots](https://developers.cloudflare.com/bots/concepts/bot/verified-bots/)
+- OpenAI crawler guidance: [developers.openai.com/api/docs/bots](https://developers.openai.com/api/docs/bots)
+
+---
+
+## Key Technical Decisions
+
+- Add one strong identity page before subject/problem pages: `/about/` gives search and AI systems the product background, audience, capability boundary, and trust context that would be too dense for the root or practice landing pages.
+- Keep the new identity page static and script-free: generated folder-index HTML follows the V2 practice-page pattern, avoids extra Worker routing, and keeps CSP risk low.
+- Add `llms.txt` only as a supplementary public summary: it can help AI agents quickly understand the site, but the authoritative discovery path remains HTML pages, sitemap, robots, and Search Console.
+- Keep sitemap scope to canonical HTML pages: root, three practice-tool pages, and `/about/`; do not list `llms.txt` as a page intended for search results.
+- Protect OAI-SearchBot without opening private paths: production audit should fail if public search visibility is blocked, but any bot-specific policy must still preserve `/api/`, `/admin`, and `/demo` exclusions.
+- Keep measurement split by purpose: Search Console answers search impressions, queries, indexing, and URL inspection; Cloudflare Web Analytics answers aggregate on-site page views and visitor behaviour.
+- Defer manual analytics script injection: Cloudflare's dashboard automatic setup for proxied hostnames should be tried first, and manual snippet work is a separate security/privacy slice when real configuration exists.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- V3 content lane: deepen AI-readable product identity and measurement before subject/problem pages.
+- Public route shape: use static folder-index `/about/` rather than a Worker-rendered route.
+- AI-readable resource shape: add a small public text summary as a supplement, not a replacement for HTML.
+- Analytics posture: prefer Search Console plus Cloudflare Web Analytics; do not commit placeholder GA4, Zaraz, Search Console, or Cloudflare tokens.
+- OpenAI crawler posture: prioritise OAI-SearchBot access for search visibility; keep GPTBot training access a separate policy decision.
+
+### Deferred to Implementation
+
+- Final `/about/` copy: implementation should tune concise UK English copy within R1-R2 and avoid broad or unproven claims.
+- Exact shared renderer shape: implementation may extend `scripts/lib/seo-practice-pages.mjs` or introduce a clearer shared public-page module if that reduces duplication without creating a large refactor.
+- Exact `llms.txt` wording: implementation should keep it short, factual, and linked to canonical public pages.
+- External dashboard state: Search Console ownership and Cloudflare Web Analytics activation depend on James's external accounts and cannot be proven by repo changes alone.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+  source["Public SEO source data<br/>practice pages + identity page + AI summary"] --> build["scripts/build-public.mjs"]
+  root["index.html / AuthSurface links"] --> build
+  sitemap["sitemap.xml canonical HTML URLs"] --> build
+  robots["robots.txt crawler policy"] --> build
+  headers["_headers cache/security groups"] --> build
+  build --> output["dist/public"]
+  output --> about["/about/"]
+  output --> llms["/llms.txt"]
+  output --> practice["/ks2-*-practice/"]
+  output --> discovery["/robots.txt + /sitemap.xml"]
+  discovery --> audit["assert-build-public + production-bundle-audit"]
+  about --> audit
+  llms --> audit
+  audit --> ops["docs/operations/seo.md measurement + next-slice gate"]
+```
+
+---
+
+## Implementation Units
+
+- U1. **Static About Page and Public Identity Links**
+
+**Goal:** Add a crawlable `/about/` page that explains KS2 Mastery as a KS2 spelling, grammar, and punctuation practice product, with clear audience, capability, demo, sign-in, saved-progress, and privacy boundaries.
+
+**Requirements:** R1, R2, R4, R5, R7, R8, R9; F1, F2; AE1, AE2, AE4, AE6.
+
+**Dependencies:** None.
+
+**Files:**
+- Create: `scripts/lib/seo-identity-pages.mjs`
+- Modify: `scripts/build-public.mjs`
+- Modify: `scripts/assert-build-public.mjs`
+- Modify: `_headers`
+- Modify: `scripts/lib/headers-drift.mjs`
+- Modify: `styles/app.css`
+- Modify: `index.html`
+- Modify: `src/surfaces/auth/AuthSurface.jsx`
+- Modify: `tests/build-public.test.js`
+- Modify: `tests/security-headers.test.js`
+- Modify: `tests/react-auth-boot.test.js`
+
+**Approach:**
+- Generate `dist/public/about/index.html` as a static folder-index page with a canonical `https://ks2.eugnel.uk/about/` URL.
+- Keep the page JavaScript-free and app-state-free, reusing the V2 static landing-page pattern for metadata, canonical links, static styles, and no-store HTML headers.
+- Cover the product identity questions AI assistants and prospective users need: what the site is, who it is for, current subjects, what the demo does, why signing in matters for saved progress, and what remains private.
+- Link to `/about/` from the raw root fallback, rendered unauthenticated surface, and generated practice pages where it fits without turning the app into a marketing site.
+- Avoid duplicating root JSON-LD on the about page unless implementation also updates CSP hash handling and visible-content parity; visible HTML content is sufficient for V3.
+
+**Execution note:** Start with build-output assertions for `/about/` before wiring the generator so Cloudflare SPA fallback regressions are easy to catch.
+
+**Patterns to follow:**
+- Static page data/rendering in `scripts/lib/seo-practice-pages.mjs`.
+- Public output allowlist and forbidden-text checks in `scripts/assert-build-public.mjs`.
+- Existing practice-page styles in `styles/app.css`.
+- AuthSurface link assertions in `tests/react-auth-boot.test.js`.
+
+**Test scenarios:**
+- Covers AE1. Happy path: built `dist/public/about/index.html` contains the product name, KS2 spelling, grammar, punctuation, intended users, demo path, sign-in/saved-progress explanation, and privacy boundary copy.
+- Covers AE4. Integration: `/about/` built HTML does not include the React bundle, `id="app"`, inline scripts, private app state, or generated content stores.
+- Happy path: `/about/` has a unique title, meta description, canonical trailing-slash URL, Open Graph URL, and H1.
+- Integration: root fallback, AuthSurface, and generated practice pages expose crawlable links to `/about/` using canonical `href` values.
+- Edge case: public-output allowlist fails if `/about/` is missing or if unexpected top-level public entries appear.
+- Error path: assertions fail if the about page overclaims broad curriculum coverage, assessment outcomes, AI tutor behaviour, or guaranteed recommendations.
+
+**Verification:**
+- The public build emits a real `/about/` page, internal discovery links point to it, and the page is understandable without JavaScript or sign-in.
+
+---
+
+- U2. **Supplementary AI-Readable Site Summary**
+
+**Goal:** Add a public `llms.txt` summary that gives AI agents a short, accurate map of KS2 Mastery's public pages, product identity, subject coverage, and privacy boundaries.
+
+**Requirements:** R2, R3, R4, R5, R7, R8, R9; F1, F2; AE1, AE3, AE4, AE6.
+
+**Dependencies:** U1.
+
+**Files:**
+- Create: `llms.txt`
+- Modify: `scripts/build-public.mjs`
+- Modify: `scripts/assert-build-public.mjs`
+- Modify: `_headers`
+- Modify: `scripts/lib/headers-drift.mjs`
+- Modify: `index.html`
+- Modify: `tests/build-public.test.js`
+- Modify: `tests/security-headers.test.js`
+
+**Approach:**
+- Keep `llms.txt` short and factual: site name, canonical root, `/about/`, three practice pages, supported subjects, audience, and public/private boundaries.
+- Do not include private/demo/admin/API URLs as recommended crawl targets; mention demo and sign-in only as product concepts when necessary.
+- Add the file to the public build entries and public-output allowlist with a conservative text cache policy.
+- Add an optional discoverability hint from root HTML, such as a non-blocking text alternate link, only if it does not create invalid metadata or sitemap noise.
+- Keep `llms.txt` out of `sitemap.xml` because the sitemap should advertise canonical public HTML pages intended for search results.
+
+**Patterns to follow:**
+- Public asset copying in `scripts/build-public.mjs`.
+- Existing robots and sitemap assertions in `scripts/assert-build-public.mjs`.
+- Cache-split tests for static public resources in `scripts/lib/headers-drift.mjs`.
+
+**Test scenarios:**
+- Happy path: `dist/public/llms.txt` exists and includes `KS2 Mastery`, the canonical root URL, `/about/`, and the three canonical practice URLs.
+- Happy path: `llms.txt` names spelling, grammar, and punctuation as current coverage and does not claim wider KS2 curriculum support.
+- Edge case: `llms.txt` is not included as a sitemap `<loc>` entry.
+- Error path: public-output assertions fail if `llms.txt` includes `/api/`, `/admin`, internal generated-content tokens, local URLs, secret names, or recommendation guarantees.
+- Integration: headers/cache tests cover the `llms.txt` public resource without weakening HTML or bundle cache rules.
+
+**Verification:**
+- AI-readable summary text ships as a public resource while normal HTML pages and sitemap remain the authoritative discovery surface.
+
+---
+
+- U3. **Crawler Policy and Production Audit Hardening**
+
+**Goal:** Extend production validation so the live site proves `/about/`, `llms.txt`, and crawler policy are behaving as intended, including detection of Cloudflare-managed changes that would block OAI-SearchBot from public SEO pages.
+
+**Requirements:** R4, R5, R6, R7, R8, R9; F2, F3; AE3, AE4, AE5, AE6.
+
+**Dependencies:** U1, U2.
+
+**Files:**
+- Create: `scripts/lib/seo-crawler-policy.mjs`
+- Modify: `sitemap.xml`
+- Modify: `scripts/assert-build-public.mjs`
+- Modify: `scripts/production-bundle-audit.mjs`
+- Modify: `tests/build-public.test.js`
+- Modify: `tests/bundle-audit.test.js`
+
+**Approach:**
+- Add `/about/` to `sitemap.xml` and keep the exact sitemap set to root, three practice pages, and about.
+- Keep `robots.txt` simple unless implementation evidence requires a bot-specific group; generic public access plus private disallows remains the safest default.
+- Add a small crawler-policy parser/helper so local and production checks reason about user-agent groups rather than brittle substring-only checks.
+- Fail production audit if the effective live robots text blocks `OAI-SearchBot` from `/`, `/about/`, or the practice pages, including Cloudflare-managed robots injections.
+- Do not fail solely because `GPTBot` is disallowed; document that GPTBot is for model training and is not required for ChatGPT search visibility.
+- Preserve existing forbidden-text, direct-denial, cache-split, security-header, demo bootstrap, and bundle-walk checks.
+
+**Execution note:** Use stub-origin production-audit tests for both valid crawler policy and Cloudflare-managed blocking examples before changing the audit script.
+
+**Patterns to follow:**
+- Existing exact sitemap checks in `scripts/assert-build-public.mjs` and `scripts/production-bundle-audit.mjs`.
+- Existing production SEO page assertions in `scripts/production-bundle-audit.mjs`.
+- OpenAI crawler separation between `OAI-SearchBot`, `GPTBot`, and `ChatGPT-User`.
+
+**Test scenarios:**
+- Covers AE3. Happy path: a stub origin serving valid root, practice pages, `/about/`, `llms.txt`, robots, and sitemap passes production audit.
+- Happy path: sitemap contains exactly five canonical HTML URLs: root, three practice pages, and `/about/`.
+- Error path: `/about/` returning the root SPA shell fails with a page-specific fallback or canonical mismatch message.
+- Error path: `llms.txt` returning HTML fallback or private/internal tokens fails.
+- Error path: production robots that explicitly disallow `OAI-SearchBot` from `/` fail with a message pointing to robots or Cloudflare bot settings.
+- Edge case: production robots that disallows `GPTBot` for training while leaving `OAI-SearchBot` available does not fail the search-visibility audit.
+- Integration: if any future bot-specific group is added for an allowed crawler, the helper requires private-path disallows to remain present for that group.
+
+**Verification:**
+- Local and production gates prove the expanded public discovery surface is real, canonical, private-safe, and not accidentally blocked from OpenAI search crawling.
+
+---
+
+- U4. **Measurement Runbook and Next-Slice Decision Gate**
+
+**Goal:** Turn the SEO runbook into an operating baseline James can use to submit, inspect, measure, and decide the next organic-growth slice.
+
+**Requirements:** R7, R8, R9; F3; AE5, AE6.
+
+**Dependencies:** U1, U2, U3.
+
+**Files:**
+- Modify: `docs/operations/seo.md`
+
+**Approach:**
+- Update the canonical public URL list to include `/about/` and `llms.txt`, clearly separating search-result HTML pages from supplementary AI-readable resources.
+- Add a Search Console checklist for ownership, sitemap submission, URL inspection, indexing status, impressions, clicks, CTR, average position, query, and landing-page review.
+- Add a Cloudflare Web Analytics section that records dashboard automatic setup as the preferred path for proxied hostnames and manual snippet injection as a separate code change only with a real token.
+- Add a crawler visibility checklist covering live `robots.txt`, Cloudflare `Block AI bots`, managed `robots.txt`, WAF/custom rules, verified bot handling, and OAI-SearchBot versus GPTBot policy.
+- Add a next-slice decision gate: choose subject/problem or parent-support pages only after the public pages have indexing data, query impressions/clicks, or an explicit no-signal review window.
+- Record candidate follow-up intents without implementing them: apostrophes, Year 5 spelling words, relative clauses, punctuation problem pages, and parent home-support guidance.
+
+**Patterns to follow:**
+- Current `docs/operations/seo.md` structure and cautious wording.
+- Existing operations docs that separate repo-verifiable checks from external dashboard actions.
+
+**Test scenarios:**
+- Test expectation: none -- this unit is documentation and external-operations guidance only.
+
+**Verification:**
+- The runbook tells James what is live, what to submit, what to inspect, what Cloudflare settings may matter, what to measure, and when to plan the next content page.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Public page source data, `scripts/build-public.mjs`, root/AuthSurface links, generated HTML pages, `llms.txt`, sitemap, robots, `_headers`, local assertions, production audit, and SEO operations docs jointly define the V3 discovery contract.
+- **Error propagation:** Build-output assertions catch missing artefacts and static-output drift; production audit catches Cloudflare fallback, crawler-policy, and sitemap regressions after deploy.
+- **State lifecycle risks:** No learner state, D1 data, R2 objects, session cookies, generated content stores, admin data, or API payloads should be read or exposed by V3 public resources.
+- **API surface parity:** No Worker API route, subject engine, database, authentication, demo-session, or learner-state contract should change.
+- **Integration coverage:** Unit-level HTML checks are not enough; live production audit must fetch the same URLs and crawler resources that search and AI systems see.
+- **Unchanged invariants:** Existing root identity, practice-tool pages, app bundle delivery, CSP Report-Only path, security headers, private route disallows, and deployment scripts remain in place unless the new public resource requires an explicit allowlist/header update.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `/about/` becomes thin marketing copy instead of useful product identity | Require concrete copy about audience, subjects, demo/sign-in, saved progress, and privacy boundaries; assert no broad claims or guarantees. |
+| `llms.txt` creates false confidence about AI recommendation | Document it as supplementary only and keep HTML, sitemap, robots, and Search Console as the authoritative discovery path. |
+| Cloudflare managed robots or bot settings block AI-search crawlers despite repo robots being correct | Add production audit detection for OAI-SearchBot blocking and document Cloudflare dashboard checks. |
+| Bot-specific robots groups accidentally drop private disallows | Avoid specific groups by default; if added later, shared crawler-policy assertions must require private disallows per group. |
+| Measurement work depends on external accounts | Keep repo changes focused on runbook, auditability, and no-placeholder-token rules; record dashboard setup separately when James completes it. |
+| Manual analytics snippet weakens CSP or privacy posture | Defer until a real token exists and require same-slice CSP, consent, and production audit updates. |
+| New top-level public files broaden the deployment allowlist too far | Add only `/about/` and `llms.txt` with explicit allowlist, header, forbidden-token, and production checks. |
+
+---
+
+## Documentation / Operational Notes
+
+- After deployment, production verification should cover root, three practice pages, `/about/`, `llms.txt`, `robots.txt`, and `sitemap.xml`.
+- Search Console should inspect all five canonical HTML URLs after the sitemap is submitted.
+- Cloudflare Web Analytics activation should be recorded as external dashboard state; a code-injected snippet remains deferred until real configuration exists.
+- If production audit flags OAI-SearchBot blocking, first inspect Cloudflare Security Settings for `Block AI bots`, managed `robots.txt`, AI Crawl Control, and WAF/custom rules before changing repo robots.
+
+---
+
+## Alternative Approaches Considered
+
+- Add subject/problem pages immediately: deferred because V3 should first add trust/identity and measurement so the first topic page is chosen from evidence.
+- Add parent-support pages immediately: deferred for the same reason, and because parent guidance needs more careful support copy than the current practice-tool pages.
+- Wire GA4 first: rejected because there is no real property configuration and analytics scripts create CSP, consent, and privacy work that should not be guessed.
+- Inject Cloudflare Web Analytics manually in V3: deferred because Cloudflare supports dashboard automatic setup for proxied hostnames, and manual snippets should only land with a real token.
+- Add explicit `OAI-SearchBot` robots groups now: deferred because the generic group already leaves public pages crawlable, and specific groups increase the risk of forgetting private disallows.
+- Make `llms.txt` the AI-search strategy: rejected because official crawler visibility still depends on crawlable pages, robots access, and search indexing.
+
+---
+
+## Success Metrics
+
+- Live `/about/` returns page-specific public HTML with accurate product identity and no app-shell fallback.
+- Live `llms.txt` returns a short factual AI-readable summary and no private/internal tokens.
+- `sitemap.xml` lists exactly the canonical root, three practice pages, and `/about/`.
+- Production audit fails clearly if OAI-SearchBot is blocked from public SEO pages.
+- Search Console can inspect the five canonical HTML URLs and report indexing/query data.
+- Cloudflare Web Analytics or the chosen visitor analytics layer can show aggregate public-page traffic after external setup.
+- The runbook gives a concrete basis for choosing the next subject/problem or parent-support content slice.
+
+---
+
+## Sources & References
+
+- Origin document: [docs/brainstorms/2026-04-28-ks2-seo-foundation-requirements.md](../brainstorms/2026-04-28-ks2-seo-foundation-requirements.md)
+- V1 SEO plan: [docs/plans/2026-04-28-002-feat-ks2-seo-foundation-plan.md](2026-04-28-002-feat-ks2-seo-foundation-plan.md)
+- V2 SEO plan: [docs/plans/2026-04-28-003-feat-ks2-seo-measurement-practice-pages-plan.md](2026-04-28-003-feat-ks2-seo-measurement-practice-pages-plan.md)
+- SEO runbook: [docs/operations/seo.md](../operations/seo.md)
+- Public root shell: `index.html`
+- Practice-page source: `scripts/lib/seo-practice-pages.mjs`
+- Public build: `scripts/build-public.mjs`
+- Public build assertion: `scripts/assert-build-public.mjs`
+- Production audit: `scripts/production-bundle-audit.mjs`
+- Static headers: `_headers`
+- Google helpful content guidance: [developers.google.com/search/docs/fundamentals/creating-helpful-content](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+- Google sitemap guidance: [developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap](https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap)
+- Google structured data guidance: [developers.google.com/search/docs/appearance/structured-data/intro-structured-data](https://developers.google.com/search/docs/appearance/structured-data/intro-structured-data)
+- Google Search Console overview: [search.google.com/search-console/about](https://search.google.com/search-console/about)
+- Cloudflare Web Analytics overview: [developers.cloudflare.com/web-analytics](https://developers.cloudflare.com/web-analytics/)
+- Cloudflare Web Analytics setup: [developers.cloudflare.com/web-analytics/get-started](https://developers.cloudflare.com/web-analytics/get-started/)
+- Cloudflare Web Analytics SPA tracking: [developers.cloudflare.com/web-analytics/get-started/web-analytics-spa](https://developers.cloudflare.com/web-analytics/get-started/web-analytics-spa/)
+- Cloudflare bot custom rules and managed settings: [developers.cloudflare.com/bots/additional-configurations/custom-rules](https://developers.cloudflare.com/bots/additional-configurations/custom-rules/)
+- Cloudflare verified bots: [developers.cloudflare.com/bots/concepts/bot/verified-bots](https://developers.cloudflare.com/bots/concepts/bot/verified-bots/)
+- OpenAI crawler guidance: [developers.openai.com/api/docs/bots](https://developers.openai.com/api/docs/bots)

--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
   <meta name="twitter:description" content="Focused online KS2 spelling, grammar and punctuation practice." />
   <title>KS2 Mastery | KS2 Spelling, Grammar and Punctuation Practice</title>
   <link rel="canonical" href="https://ks2.eugnel.uk/" />
+  <link rel="alternate" type="text/plain" href="/llms.txt" title="AI-readable KS2 Mastery summary" />
   <link rel="manifest" href="/manifest.webmanifest" />
   <link rel="icon" href="/favicon.ico" sizes="any" />
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/app-icons/favicon-32.png" />
@@ -85,6 +86,7 @@
           <a href="/ks2-spelling-practice/">KS2 spelling practice online</a>
           <a href="/ks2-grammar-practice/">KS2 grammar practice online</a>
           <a href="/ks2-punctuation-practice/">KS2 punctuation practice online</a>
+          <a href="/about/">About KS2 Mastery</a>
         </nav>
         <p><a class="btn primary lg" href="/demo">Try demo</a></p>
       </section>

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,22 @@
+# KS2 Mastery
+
+KS2 Mastery is an online KS2 spelling, grammar and punctuation practice product for learners and supporting adults.
+
+Canonical public pages:
+- https://ks2.eugnel.uk/
+- https://ks2.eugnel.uk/about/
+- https://ks2.eugnel.uk/ks2-spelling-practice/
+- https://ks2.eugnel.uk/ks2-grammar-practice/
+- https://ks2.eugnel.uk/ks2-punctuation-practice/
+
+Current subject coverage:
+- KS2 spelling practice for word confidence and recall
+- KS2 grammar practice for sentence-level accuracy
+- KS2 punctuation practice for clearer written English
+
+Product notes:
+- Learners can try the product before creating or using a signed-in account.
+- Signed-in accounts can save learner profiles and practice progress.
+- Public pages describe the product at a high level for humans, search crawlers and AI assistants.
+- Private learner progress, account state, operator tools and generated content stores are not public SEO content.
+- KS2 Mastery does not promise search placement, AI recommendations or fixed learning results.

--- a/scripts/assert-build-public.mjs
+++ b/scripts/assert-build-public.mjs
@@ -4,6 +4,8 @@ import { pathToFileURL } from 'node:url';
 import { createHash } from 'node:crypto';
 import { assertCacheSplitRules, assertHeadersBlockIsFresh } from './lib/headers-drift.mjs';
 import { PRACTICE_SEO_PAGES, canonicalPracticePageUrl } from './lib/seo-practice-pages.mjs';
+import { IDENTITY_SEO_PAGES, canonicalIdentityPageUrl } from './lib/seo-identity-pages.mjs';
+import { crawlerPolicyFailures } from './lib/seo-crawler-policy.mjs';
 
 const rootDir = process.cwd();
 const publicDir = path.join(rootDir, 'dist', 'public');
@@ -151,10 +153,14 @@ async function currentMonsterAssetKeys() {
 }
 
 await mustExist('index.html');
+await mustExist('llms.txt');
 await mustExist('manifest.webmanifest');
 await mustExist('robots.txt');
 await mustExist('sitemap.xml');
 for (const page of PRACTICE_SEO_PAGES) {
+  await mustExist(`${page.slug}/index.html`);
+}
+for (const page of IDENTITY_SEO_PAGES) {
   await mustExist(`${page.slug}/index.html`);
 }
 await mustExist('favicon.ico');
@@ -211,10 +217,12 @@ const allowed = new Set([
   '_headers',
   'favicon.ico',
   'index.html',
+  'llms.txt',
   'manifest.webmanifest',
   'robots.txt',
   'sitemap.xml',
   ...PRACTICE_SEO_PAGES.map((page) => page.slug),
+  ...IDENTITY_SEO_PAGES.map((page) => page.slug),
   'styles',
   'src',
   'assets',
@@ -273,11 +281,16 @@ assertCacheSplitRules(publishedHeadersContent);
 
 const indexHtml = await readFile(path.join(publicDir, 'index.html'), 'utf8');
 const appBundle = await readFile(path.join(publicDir, 'src/bundles/app.bundle.js'), 'utf8');
+const llmsTxt = await readFile(path.join(publicDir, 'llms.txt'), 'utf8');
 const robotsTxt = await readFile(path.join(publicDir, 'robots.txt'), 'utf8');
 const sitemapXml = await readFile(path.join(publicDir, 'sitemap.xml'), 'utf8');
 const practicePageHtml = new Map();
 for (const page of PRACTICE_SEO_PAGES) {
   practicePageHtml.set(page.slug, await readFile(path.join(publicDir, page.slug, 'index.html'), 'utf8'));
+}
+const identityPageHtml = new Map();
+for (const page of IDENTITY_SEO_PAGES) {
+  identityPageHtml.set(page.slug, await readFile(path.join(publicDir, page.slug, 'index.html'), 'utf8'));
 }
 const cspHashArtefact = await readFile(path.join(publicDir, '.csp-theme-hash'), 'utf8');
 const canonicalRoot = 'https://ks2.eugnel.uk/';
@@ -307,6 +320,7 @@ assertContainsAll('Public index.html SEO identity', indexHtml, [
   '<meta property="og:description"',
   `<meta property="og:url" content="${canonicalRoot}" />`,
   '<meta name="twitter:card" content="summary" />',
+  '<link rel="alternate" type="text/plain" href="/llms.txt"',
   'KS2 spelling, grammar and punctuation practice',
   'Spelling practice for KS2 word confidence',
   'Grammar practice for sentence-level accuracy',
@@ -314,6 +328,7 @@ assertContainsAll('Public index.html SEO identity', indexHtml, [
   'href="/ks2-spelling-practice/"',
   'href="/ks2-grammar-practice/"',
   'href="/ks2-punctuation-practice/"',
+  'href="/about/"',
 ]);
 
 const productIdentity = jsonLdBlocks(indexHtml).find((entry) => entry?.name === 'KS2 Mastery');
@@ -346,6 +361,18 @@ assertContainsAll('robots.txt', robotsTxt, [
   'Allow: /',
   `Sitemap: ${canonicalRoot}sitemap.xml`,
 ]);
+const crawlerFailures = crawlerPolicyFailures(robotsTxt, {
+  userAgent: 'OAI-SearchBot',
+  publicPaths: [
+    '/',
+    ...PRACTICE_SEO_PAGES.map((page) => `/${page.slug}/`),
+    ...IDENTITY_SEO_PAGES.map((page) => `/${page.slug}/`),
+  ],
+  privatePaths: ['/api/', '/admin', '/demo'],
+});
+if (crawlerFailures.length) {
+  throw new Error(crawlerFailures.join('\n'));
+}
 
 if (/<\/?html|<!doctype/i.test(sitemapXml)) {
   throw new Error('sitemap.xml must not be the SPA HTML fallback.');
@@ -354,11 +381,16 @@ assertContainsAll('sitemap.xml', sitemapXml, [
   '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
   `<loc>${canonicalRoot}</loc>`,
   ...PRACTICE_SEO_PAGES.map((page) => `<loc>${canonicalPracticePageUrl(page)}</loc>`),
+  ...IDENTITY_SEO_PAGES.map((page) => `<loc>${canonicalIdentityPageUrl(page)}</loc>`),
 ]);
 assertExactSitemapLocs('sitemap.xml', sitemapXml, [
   canonicalRoot,
   ...PRACTICE_SEO_PAGES.map((page) => canonicalPracticePageUrl(page)),
+  ...IDENTITY_SEO_PAGES.map((page) => canonicalIdentityPageUrl(page)),
 ]);
+if (sitemapXml.includes('llms.txt')) {
+  throw new Error('sitemap.xml must not advertise llms.txt as a search-result page.');
+}
 for (const forbiddenPublicPath of ['/api/', '/admin', '/demo', '.html', 'localhost', '127.0.0.1']) {
   if (sitemapXml.includes(forbiddenPublicPath)) {
     throw new Error(`sitemap.xml must not advertise private or local path: ${forbiddenPublicPath}`);
@@ -388,8 +420,70 @@ for (const page of PRACTICE_SEO_PAGES) {
       throw new Error(`Public ${page.slug} SEO page must not include app-shell or inline-script token: ${forbiddenToken}`);
     }
   }
+  if (!html.includes('href="/about/"')) {
+    throw new Error(`Public ${page.slug} SEO page must link to the about page.`);
+  }
   assertNoPublicSeoForbiddenText(`Public ${page.slug} SEO page`, html);
 }
+
+for (const page of IDENTITY_SEO_PAGES) {
+  const html = identityPageHtml.get(page.slug);
+  const canonicalUrl = canonicalIdentityPageUrl(page);
+  assertContainsAll(`Public ${page.slug} SEO page`, html, [
+    `<title>${page.title}</title>`,
+    `<meta name="description" content="${page.description}" />`,
+    `<link rel="canonical" href="${canonicalUrl}" />`,
+    `<meta property="og:url" content="${canonicalUrl}" />`,
+    `<h1>${page.heading}</h1>`,
+    page.intro,
+    'KS2 spelling, grammar and punctuation practice',
+    'Learners can try a demo before signing in',
+    'Signing in saves learner profiles and progress',
+    'Private learner progress, admin tools and generated content stores are not public SEO content',
+    'href="/ks2-spelling-practice/"',
+    'href="/ks2-grammar-practice/"',
+    'href="/ks2-punctuation-practice/"',
+    'href="/demo"',
+  ]);
+  for (const forbiddenToken of ['app.bundle.js', 'id="app"', 'application/ld+json', '<script']) {
+    if (html.includes(forbiddenToken)) {
+      throw new Error(`Public ${page.slug} SEO page must not include app-shell or inline-script token: ${forbiddenToken}`);
+    }
+  }
+  for (const overclaim of ['guaranteed', 'full curriculum', 'AI tutor', 'exam results']) {
+    if (html.toLowerCase().includes(overclaim.toLowerCase())) {
+      throw new Error(`Public ${page.slug} SEO page must not overclaim with token: ${overclaim}`);
+    }
+  }
+  assertNoPublicSeoForbiddenText(`Public ${page.slug} SEO page`, html);
+}
+
+assertContainsAll('Public llms.txt', llmsTxt, [
+  'KS2 Mastery',
+  canonicalRoot,
+  ...IDENTITY_SEO_PAGES.map((page) => canonicalIdentityPageUrl(page)),
+  ...PRACTICE_SEO_PAGES.map((page) => canonicalPracticePageUrl(page)),
+  'KS2 spelling',
+  'KS2 grammar',
+  'KS2 punctuation',
+  'Private learner progress, account state, operator tools and generated content stores are not public SEO content',
+]);
+for (const forbiddenToken of [
+  '/api/',
+  '/admin',
+  'OPENAI_API_KEY',
+  'GEMINI_API_KEY',
+  'ANTHROPIC_API_KEY',
+  'guaranteed',
+  'full curriculum',
+  'AI tutor',
+  'exam results',
+]) {
+  if (llmsTxt.toLowerCase().includes(forbiddenToken.toLowerCase())) {
+    throw new Error(`Public llms.txt must not include forbidden token: ${forbiddenToken}`);
+  }
+}
+assertNoPublicSeoForbiddenText('Public llms.txt', llmsTxt);
 
 for (const token of [
   '__ks2HomeSurface',

--- a/scripts/build-public.mjs
+++ b/scripts/build-public.mjs
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { createHash } from 'node:crypto';
 import { computeInlineScriptHashes } from './compute-inline-script-hash.mjs';
 import { PRACTICE_SEO_PAGES, renderPracticeSeoPage } from './lib/seo-practice-pages.mjs';
+import { IDENTITY_SEO_PAGES, renderIdentitySeoPage } from './lib/seo-identity-pages.mjs';
 
 const rootDir = process.cwd();
 const outputDir = path.join(rootDir, 'dist', 'public');
@@ -33,6 +34,7 @@ const entries = [
   '_headers',
   'favicon.ico',
   'index.html',
+  'llms.txt',
   'manifest.webmanifest',
   'robots.txt',
   'sitemap.xml',
@@ -139,6 +141,11 @@ try {
     const pageDir = path.join(tmpDir, page.slug);
     await mkdir(pageDir, { recursive: true });
     await writeFile(path.join(pageDir, 'index.html'), renderPracticeSeoPage(page), 'utf8');
+  }
+  for (const page of IDENTITY_SEO_PAGES) {
+    const pageDir = path.join(tmpDir, page.slug);
+    await mkdir(pageDir, { recursive: true });
+    await writeFile(path.join(pageDir, 'index.html'), renderIdentitySeoPage(page), 'utf8');
   }
 
   await rm(outputDir, { recursive: true, force: true });

--- a/scripts/lib/headers-drift.mjs
+++ b/scripts/lib/headers-drift.mjs
@@ -131,9 +131,11 @@ export const CACHE_SPLIT_RULES = Object.freeze([
   { path: '/manifest.webmanifest', cacheControl: 'public, max-age=3600' },
   { path: '/robots.txt', cacheControl: 'public, max-age=3600' },
   { path: '/sitemap.xml', cacheControl: 'public, max-age=3600' },
+  { path: '/llms.txt', cacheControl: 'public, max-age=3600' },
   { path: '/ks2-spelling-practice/', cacheControl: 'no-store' },
   { path: '/ks2-grammar-practice/', cacheControl: 'no-store' },
   { path: '/ks2-punctuation-practice/', cacheControl: 'no-store' },
+  { path: '/about/', cacheControl: 'no-store' },
   { path: '/', cacheControl: 'no-store' },
   { path: '/index.html', cacheControl: 'no-store' },
 ]);

--- a/scripts/lib/seo-crawler-policy.mjs
+++ b/scripts/lib/seo-crawler-policy.mjs
@@ -1,0 +1,152 @@
+function stripComment(line) {
+  const hashIndex = line.indexOf('#');
+  return (hashIndex === -1 ? line : line.slice(0, hashIndex)).trim();
+}
+
+function finishGroup(groups, group) {
+  if (group && (group.agents.length || group.rules.length)) {
+    groups.push({
+      agents: Object.freeze([...group.agents]),
+      rules: Object.freeze([...group.rules]),
+    });
+  }
+}
+
+export function parseRobotsGroups(robotsText) {
+  if (typeof robotsText !== 'string') {
+    throw new Error('parseRobotsGroups: robotsText must be a string.');
+  }
+
+  const groups = [];
+  let group = null;
+  for (const rawLine of robotsText.split(/\r?\n/u)) {
+    const line = stripComment(rawLine);
+    if (!line) continue;
+
+    const match = line.match(/^([A-Za-z][A-Za-z-]*)\s*:\s*(.*)$/u);
+    if (!match) continue;
+
+    const directive = match[1].toLowerCase();
+    const value = match[2].trim();
+    if (directive === 'user-agent') {
+      if (!group || group.rules.length) {
+        finishGroup(groups, group);
+        group = { agents: [], rules: [] };
+      }
+      group.agents.push(value);
+      continue;
+    }
+
+    if (directive !== 'allow' && directive !== 'disallow') continue;
+    if (!group) continue;
+    if (!value) continue;
+    group.rules.push({ directive, value });
+  }
+  finishGroup(groups, group);
+
+  return Object.freeze(groups);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+}
+
+function normalisePath(path) {
+  const value = String(path || '/');
+  const withoutHash = value.split('#')[0];
+  const withoutQuery = withoutHash.split('?')[0];
+  return withoutQuery.startsWith('/') ? withoutQuery : `/${withoutQuery}`;
+}
+
+function agentMatchLength(agent, userAgent) {
+  const normalisedAgent = String(agent || '').trim().toLowerCase();
+  if (!normalisedAgent) return -1;
+  if (normalisedAgent === '*') return 0;
+  const normalisedUserAgent = String(userAgent || '').toLowerCase();
+  return normalisedUserAgent.includes(normalisedAgent) ? normalisedAgent.length : -1;
+}
+
+function matchingGroups(groups, userAgent) {
+  const matches = [];
+  let bestLength = -1;
+  for (const group of groups) {
+    const groupBest = Math.max(...group.agents.map((agent) => agentMatchLength(agent, userAgent)));
+    if (groupBest < 0) continue;
+    if (groupBest > bestLength) {
+      matches.length = 0;
+      bestLength = groupBest;
+    }
+    if (groupBest === bestLength) matches.push(group);
+  }
+  return matches;
+}
+
+function ruleMatchesPath(ruleValue, path) {
+  if (!ruleValue) return false;
+  if (ruleValue.includes('*') || ruleValue.endsWith('$')) {
+    const anchoredEnd = ruleValue.endsWith('$');
+    const pattern = escapeRegExp(anchoredEnd ? ruleValue.slice(0, -1) : ruleValue)
+      .replace(/\\\*/gu, '.*');
+    const regex = new RegExp(`^${pattern}${anchoredEnd ? '$' : ''}`, 'u');
+    return regex.test(path);
+  }
+  return path.startsWith(ruleValue);
+}
+
+export function hasSpecificCrawlerGroup(robotsText, userAgent) {
+  const groups = parseRobotsGroups(robotsText);
+  return groups.some((group) => group.agents.some((agent) => {
+    const matchLength = agentMatchLength(agent, userAgent);
+    return matchLength > 0;
+  }));
+}
+
+export function isCrawlerPathAllowed(robotsText, userAgent, path) {
+  const groups = matchingGroups(parseRobotsGroups(robotsText), userAgent);
+  if (!groups.length) return true;
+
+  const targetPath = normalisePath(path);
+  let winner = null;
+  for (const group of groups) {
+    for (const rule of group.rules) {
+      if (!ruleMatchesPath(rule.value, targetPath)) continue;
+      if (!winner || rule.value.length > winner.value.length) {
+        winner = rule;
+        continue;
+      }
+      if (rule.value.length === winner.value.length && rule.directive === 'allow') {
+        winner = rule;
+      }
+    }
+  }
+
+  return !winner || winner.directive === 'allow';
+}
+
+export function crawlerPolicyFailures(robotsText, {
+  userAgent = 'OAI-SearchBot',
+  publicPaths = [],
+  privatePaths = [],
+  label = 'robots.txt',
+} = {}) {
+  const failures = [];
+  for (const publicPath of publicPaths) {
+    if (!isCrawlerPathAllowed(robotsText, userAgent, publicPath)) {
+      failures.push(
+        `${label} must allow ${userAgent} to fetch public SEO path ${publicPath}. Check robots.txt and Cloudflare bot/crawler settings.`,
+      );
+    }
+  }
+
+  const hasSpecificGroup = hasSpecificCrawlerGroup(robotsText, userAgent);
+  for (const privatePath of privatePaths) {
+    if (isCrawlerPathAllowed(robotsText, userAgent, privatePath)) {
+      const reason = hasSpecificGroup
+        ? `has a bot-specific ${userAgent} group, so it must repeat the private-path disallow for ${privatePath}`
+        : `must disallow ${userAgent} from private crawler path ${privatePath}`;
+      failures.push(`${label} ${reason}. Check robots.txt and Cloudflare bot/crawler settings.`);
+    }
+  }
+
+  return failures;
+}

--- a/scripts/lib/seo-identity-pages.mjs
+++ b/scripts/lib/seo-identity-pages.mjs
@@ -1,0 +1,124 @@
+import { CANONICAL_ROOT, escapeHtml } from './seo-practice-pages.mjs';
+
+export const IDENTITY_SEO_PAGES = Object.freeze([
+  Object.freeze({
+    slug: 'about',
+    title: 'About KS2 Mastery | KS2 Spelling, Grammar and Punctuation Practice',
+    description: 'Learn what KS2 Mastery is, who it helps, and how learners can practise KS2 spelling, grammar and punctuation online.',
+    eyebrow: 'About KS2 Mastery',
+    heading: 'About KS2 Mastery',
+    intro: 'KS2 Mastery is an online KS2 spelling, grammar and punctuation practice product for learners and supporting adults.',
+    sections: [
+      Object.freeze({
+        heading: 'What KS2 Mastery helps with',
+        body: 'The public practice pages explain the current subject areas: spelling for word confidence, grammar for sentence-level accuracy, and punctuation for clearer written English.',
+        points: [
+          'KS2 spelling, grammar and punctuation practice in focused online sessions',
+          'Plain practice routes that can be understood before a learner signs in',
+          'A demo path for trying the product before saving learner progress',
+        ],
+      }),
+      Object.freeze({
+        heading: 'Demo and saved progress',
+        body: 'Learners can try a demo before signing in. Signing in saves learner profiles and progress so practice can continue across sessions.',
+        points: [
+          'The demo is a public way to try the practice flow',
+          'Signed-in accounts can save learner profiles and progress',
+          'The public pages introduce the product without exposing learner records',
+        ],
+      }),
+      Object.freeze({
+        heading: 'Public and private content',
+        body: 'Private learner progress, admin tools and generated content stores are not public SEO content. Public pages describe the product only at a high level.',
+        points: [
+          'Search and AI systems should use the root, about page and practice pages for public product identity',
+          'Private app data, account state and operator tools stay behind the app boundary',
+          'KS2 Mastery does not promise search placement, AI recommendations or fixed learning results',
+        ],
+      }),
+    ],
+  }),
+]);
+
+function renderPoint(point) {
+  return `              <li>${escapeHtml(point)}</li>`;
+}
+
+function renderSection(section) {
+  return `        <section class="practice-public-section">
+          <h2>${escapeHtml(section.heading)}</h2>
+          <p>${escapeHtml(section.body)}</p>
+          <ul class="practice-public-list">
+${section.points.map(renderPoint).join('\n')}
+          </ul>
+        </section>`;
+}
+
+export function canonicalIdentityPageUrl(page) {
+  return `${CANONICAL_ROOT}${page.slug}/`;
+}
+
+export function renderIdentitySeoPage(page) {
+  const canonicalUrl = canonicalIdentityPageUrl(page);
+  const escapedTitle = escapeHtml(page.title);
+  const escapedDescription = escapeHtml(page.description);
+  const escapedHeading = escapeHtml(page.heading);
+  const escapedEyebrow = escapeHtml(page.eyebrow);
+  const escapedIntro = escapeHtml(page.intro);
+  return `<!DOCTYPE html>
+<html lang="en-GB">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <meta name="application-name" content="KS2 Mastery" />
+  <meta name="description" content="${escapedDescription}" />
+  <meta name="color-scheme" content="light dark" />
+  <meta name="theme-color" content="#F6F5F1" media="(prefers-color-scheme: light)" />
+  <meta name="theme-color" content="#0F1620" media="(prefers-color-scheme: dark)" />
+  <meta property="og:site_name" content="KS2 Mastery" />
+  <meta property="og:title" content="${escapedTitle}" />
+  <meta property="og:description" content="${escapedDescription}" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="${canonicalUrl}" />
+  <meta property="og:locale" content="en_GB" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="${escapedTitle}" />
+  <meta name="twitter:description" content="${escapedDescription}" />
+  <title>${escapedTitle}</title>
+  <link rel="canonical" href="${canonicalUrl}" />
+  <link rel="manifest" href="/manifest.webmanifest" />
+  <link rel="icon" href="/favicon.ico" sizes="any" />
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/app-icons/favicon-32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/assets/app-icons/favicon-16.png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/assets/app-icons/apple-touch-icon.png" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Inter:wght@400;500;600;700&display=swap" />
+  <link rel="stylesheet" href="/styles/app.css" />
+</head>
+<body class="practice-public-page identity-public-page">
+  <header class="practice-public-nav" aria-label="Site">
+    <a href="/">KS2 Mastery</a>
+    <a href="/about/">About</a>
+  </header>
+  <main class="practice-public-shell">
+    <article class="practice-public-panel identity-public-panel">
+      <p class="eyebrow">${escapedEyebrow}</p>
+      <h1>${escapedHeading}</h1>
+      <p class="practice-public-intro">${escapedIntro}</p>
+${page.sections.map(renderSection).join('\n')}
+      <nav class="seo-practice-links identity-public-links" aria-label="KS2 Mastery public pages">
+        <a href="/ks2-spelling-practice/">KS2 spelling practice online</a>
+        <a href="/ks2-grammar-practice/">KS2 grammar practice online</a>
+        <a href="/ks2-punctuation-practice/">KS2 punctuation practice online</a>
+      </nav>
+      <div class="actions practice-public-actions">
+        <a class="btn primary lg" href="/demo">Try demo</a>
+        <a class="btn secondary lg" href="/">KS2 Mastery home</a>
+      </div>
+    </article>
+  </main>
+</body>
+</html>
+`;
+}

--- a/scripts/lib/seo-practice-pages.mjs
+++ b/scripts/lib/seo-practice-pages.mjs
@@ -1,4 +1,4 @@
-const CANONICAL_ROOT = 'https://ks2.eugnel.uk/';
+export const CANONICAL_ROOT = 'https://ks2.eugnel.uk/';
 
 export const PRACTICE_SEO_PAGES = Object.freeze([
   Object.freeze({
@@ -42,7 +42,7 @@ export const PRACTICE_SEO_PAGES = Object.freeze([
   }),
 ]);
 
-function escapeHtml(value) {
+export function escapeHtml(value) {
   return String(value)
     .replaceAll('&', '&amp;')
     .replaceAll('<', '&lt;')
@@ -100,6 +100,7 @@ export function renderPracticeSeoPage(page) {
 <body class="practice-public-page">
   <header class="practice-public-nav" aria-label="Site">
     <a href="/">KS2 Mastery</a>
+    <a href="/about/">About</a>
   </header>
   <main class="practice-public-shell">
     <section class="practice-public-panel">
@@ -112,6 +113,7 @@ ${page.points.map(renderPoint).join('\n')}
       <div class="actions practice-public-actions">
         <a class="btn primary lg" href="/demo">Try demo</a>
         <a class="btn secondary lg" href="/">KS2 Mastery home</a>
+        <a class="btn secondary lg" href="/about/">About KS2 Mastery</a>
       </div>
     </section>
   </main>

--- a/scripts/production-bundle-audit.mjs
+++ b/scripts/production-bundle-audit.mjs
@@ -1,11 +1,30 @@
 import { runClientBundleAudit } from './audit-client-bundle.mjs';
 import { createDemoSession, loadBootstrap } from './lib/production-smoke.mjs';
 import { PRACTICE_SEO_PAGES, canonicalPracticePageUrl } from './lib/seo-practice-pages.mjs';
+import { IDENTITY_SEO_PAGES, canonicalIdentityPageUrl } from './lib/seo-identity-pages.mjs';
+import { crawlerPolicyFailures } from './lib/seo-crawler-policy.mjs';
 import { FORBIDDEN_KEYS_EVERYWHERE } from '../tests/helpers/forbidden-keys.mjs';
 
 const DEFAULT_ORIGIN = 'https://ks2.eugnel.uk';
 const SEO_CANONICAL_ROOT = 'https://ks2.eugnel.uk/';
 const SEO_SITEMAP_URL = `${SEO_CANONICAL_ROOT}sitemap.xml`;
+const SEO_PRIVATE_CRAWLER_PATHS = Object.freeze(['/api/', '/admin', '/demo']);
+
+function seoPublicPaths() {
+  return [
+    '/',
+    ...PRACTICE_SEO_PAGES.map((page) => `/${page.slug}/`),
+    ...IDENTITY_SEO_PAGES.map((page) => `/${page.slug}/`),
+  ];
+}
+
+function seoSitemapLocs() {
+  return [
+    SEO_CANONICAL_ROOT,
+    ...PRACTICE_SEO_PAGES.map((page) => canonicalPracticePageUrl(page)),
+    ...IDENTITY_SEO_PAGES.map((page) => canonicalIdentityPageUrl(page)),
+  ];
+}
 
 // U13 redaction matrix forbidden-key check: these keys must never appear in any
 // authenticated response surface reached via the demo session. The set is
@@ -160,10 +179,12 @@ function assertSeoRootHtml(index, failures) {
     '<meta property="og:description"',
     `<meta property="og:url" content="${SEO_CANONICAL_ROOT}"`,
     '<meta name="twitter:card" content="summary"',
+    '<link rel="alternate" type="text/plain" href="/llms.txt"',
     'KS2 spelling, grammar and punctuation practice',
     'Spelling practice for KS2 word confidence',
     'Grammar practice for sentence-level accuracy',
     'Punctuation practice for clearer written English',
+    'href="/about/"',
   ];
   for (const token of requiredTokens) {
     if (!index.text.includes(token)) {
@@ -217,6 +238,8 @@ function assertSeoPracticePageHtml(page, response, failures) {
     page.intro,
     '/demo',
     'KS2 Mastery home',
+    'About KS2 Mastery',
+    'href="/about/"',
     ...page.points,
   ]) {
     if (!response.text.includes(token)) {
@@ -236,6 +259,108 @@ async function assertSeoPracticePages(base, failures) {
     const response = await fetchText(new URL(`/${page.slug}/`, base).href);
     assertSeoPracticePageHtml(page, response, failures);
   }
+}
+
+function assertSeoIdentityPageHtml(page, response, failures) {
+  const path = `/${page.slug}/`;
+  const canonicalUrl = canonicalIdentityPageUrl(page);
+  if (response.status < 200 || response.status >= 300) {
+    failures.push(`Production SEO page ${path} fetch failed: ${response.status} ${response.url}`);
+    return;
+  }
+  if (!/text\/html/i.test(response.contentType)) {
+    failures.push(`Production SEO page ${path} expected text/html, got: ${response.contentType || 'absent'}`);
+  }
+  if (
+    response.text.includes('<title>KS2 Mastery | KS2 Spelling, Grammar and Punctuation Practice</title>')
+    || response.text.includes(`<link rel="canonical" href="${SEO_CANONICAL_ROOT}"`)
+    || response.text.includes('app.bundle.js')
+    || response.text.includes('id="app"')
+  ) {
+    failures.push(`Production SEO page ${path} appears to be the root SPA shell, not page-specific public HTML.`);
+  }
+  for (const token of [
+    `<title>${page.title}</title>`,
+    `<meta name="description" content="${page.description}"`,
+    `<link rel="canonical" href="${canonicalUrl}"`,
+    `<meta property="og:url" content="${canonicalUrl}"`,
+    `<h1>${page.heading}</h1>`,
+    page.intro,
+    'KS2 spelling, grammar and punctuation practice',
+    'Learners can try a demo before signing in',
+    'Signing in saves learner profiles and progress',
+    'Private learner progress, admin tools and generated content stores are not public SEO content',
+    'href="/ks2-spelling-practice/"',
+    'href="/ks2-grammar-practice/"',
+    'href="/ks2-punctuation-practice/"',
+    'href="/demo"',
+  ]) {
+    if (!response.text.includes(token)) {
+      failures.push(`Production SEO page ${path} is missing required token: ${token}`);
+    }
+  }
+  for (const forbiddenToken of ['application/ld+json', '<script']) {
+    if (response.text.includes(forbiddenToken)) {
+      failures.push(`Production SEO page ${path} must remain static and script-free; found token: ${forbiddenToken}`);
+    }
+  }
+  for (const overclaim of ['guaranteed', 'full curriculum', 'AI tutor', 'exam results']) {
+    if (response.text.toLowerCase().includes(overclaim.toLowerCase())) {
+      failures.push(`Production SEO page ${path} must not overclaim with token: ${overclaim}`);
+    }
+  }
+  assertNoForbiddenText(`Production SEO page ${path}`, response.text, failures);
+}
+
+async function assertSeoIdentityPages(base, failures) {
+  for (const page of IDENTITY_SEO_PAGES) {
+    const response = await fetchText(new URL(`/${page.slug}/`, base).href);
+    assertSeoIdentityPageHtml(page, response, failures);
+  }
+}
+
+function assertSeoLlmsText(response, failures) {
+  const path = '/llms.txt';
+  if (response.status < 200 || response.status >= 300) {
+    failures.push(`Production ${path} fetch failed: ${response.status} ${response.url}`);
+    return;
+  }
+  if (!/text\/plain/i.test(response.contentType)) {
+    failures.push(`Production ${path} expected text/plain, got: ${response.contentType || 'absent'}`);
+  }
+  if (/text\/html/i.test(response.contentType) || /<!doctype|<\/?html/i.test(response.text)) {
+    failures.push('Production llms.txt appears to be SPA fallback HTML, not an AI-readable text summary.');
+  }
+  for (const token of [
+    'KS2 Mastery',
+    SEO_CANONICAL_ROOT,
+    ...IDENTITY_SEO_PAGES.map((page) => canonicalIdentityPageUrl(page)),
+    ...PRACTICE_SEO_PAGES.map((page) => canonicalPracticePageUrl(page)),
+    'KS2 spelling',
+    'KS2 grammar',
+    'KS2 punctuation',
+    'Private learner progress, account state, operator tools and generated content stores are not public SEO content',
+  ]) {
+    if (!response.text.includes(token)) {
+      failures.push(`Production ${path} is missing required token: ${token}`);
+    }
+  }
+  for (const forbiddenToken of [
+    '/api/',
+    '/admin',
+    'OPENAI_API_KEY',
+    'GEMINI_API_KEY',
+    'ANTHROPIC_API_KEY',
+    'guaranteed',
+    'full curriculum',
+    'AI tutor',
+    'exam results',
+  ]) {
+    if (response.text.toLowerCase().includes(forbiddenToken.toLowerCase())) {
+      failures.push(`Production ${path} must not include forbidden token: ${forbiddenToken}`);
+    }
+  }
+  assertNoForbiddenText(`Production ${path}`, response.text, failures);
 }
 
 async function assertSeoDiscoveryResources(base, failures) {
@@ -258,9 +383,12 @@ async function assertSeoDiscoveryResources(base, failures) {
       failures.push(`Production robots.txt is missing required token: ${token}`);
     }
   }
-  if (/User-agent:\s*OAI-SearchBot[\s\S]*?Disallow:\s*\//i.test(robots.text)) {
-    failures.push('Production robots.txt must not explicitly disallow OAI-SearchBot from public SEO pages.');
-  }
+  failures.push(...crawlerPolicyFailures(robots.text, {
+    userAgent: 'OAI-SearchBot',
+    publicPaths: seoPublicPaths(),
+    privatePaths: SEO_PRIVATE_CRAWLER_PATHS,
+    label: 'Production robots.txt',
+  }));
 
   const sitemap = await fetchText(new URL('/sitemap.xml', base).href);
   if (sitemap.status < 200 || sitemap.status >= 300) {
@@ -271,18 +399,14 @@ async function assertSeoDiscoveryResources(base, failures) {
   }
   for (const token of [
     '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
-    `<loc>${SEO_CANONICAL_ROOT}</loc>`,
-    ...PRACTICE_SEO_PAGES.map((page) => `<loc>${canonicalPracticePageUrl(page)}</loc>`),
+    ...seoSitemapLocs().map((url) => `<loc>${url}</loc>`),
   ]) {
     if (!sitemap.text.includes(token)) {
       failures.push(`Production sitemap.xml is missing required token: ${token}`);
     }
   }
-  assertExactSitemapLocs('Production sitemap.xml', sitemap.text, [
-    SEO_CANONICAL_ROOT,
-    ...PRACTICE_SEO_PAGES.map((page) => canonicalPracticePageUrl(page)),
-  ], failures);
-  for (const forbiddenPath of ['/api/', '/admin', '/demo', '.html', 'localhost', '127.0.0.1']) {
+  assertExactSitemapLocs('Production sitemap.xml', sitemap.text, seoSitemapLocs(), failures);
+  for (const forbiddenPath of ['/api/', '/admin', '/demo', '.html', 'localhost', '127.0.0.1', 'llms.txt']) {
     if (sitemap.text.includes(forbiddenPath)) {
       failures.push(`Production sitemap.xml must not advertise private or local path: ${forbiddenPath}`);
     }
@@ -411,6 +535,8 @@ async function auditProduction(origin) {
   assertSeoRootHtml(index, failures);
   await assertSeoDiscoveryResources(base, failures);
   await assertSeoPracticePages(base, failures);
+  await assertSeoIdentityPages(base, failures);
+  assertSeoLlmsText(await fetchText(new URL('/llms.txt', base).href), failures);
 
   const scripts = scriptSources(index.text)
     .filter((src) => !/^https?:\/\//i.test(src) || new URL(src, base).origin === base.origin);
@@ -625,7 +751,13 @@ async function auditProduction(origin) {
     { path: '/manifest.webmanifest', label: 'web app manifest', expected: 'public, max-age=3600' },
     { path: '/robots.txt', label: 'robots policy', expected: 'public, max-age=3600' },
     { path: '/sitemap.xml', label: 'sitemap', expected: 'public, max-age=3600' },
+    { path: '/llms.txt', label: 'AI-readable text summary', expected: 'public, max-age=3600' },
     ...PRACTICE_SEO_PAGES.map((page) => ({
+      path: `/${page.slug}/`,
+      label: `${page.slug} SEO page`,
+      expected: 'no-store',
+    })),
+    ...IDENTITY_SEO_PAGES.map((page) => ({
       path: `/${page.slug}/`,
       label: `${page.slug} SEO page`,
       expected: 'no-store',

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -12,4 +12,7 @@
   <url>
     <loc>https://ks2.eugnel.uk/ks2-punctuation-practice/</loc>
   </url>
+  <url>
+    <loc>https://ks2.eugnel.uk/about/</loc>
+  </url>
 </urlset>

--- a/src/surfaces/auth/AuthSurface.jsx
+++ b/src/surfaces/auth/AuthSurface.jsx
@@ -225,10 +225,11 @@ function AuthSurfaceStandard({ initialMode = 'login', initialError = '', onSubmi
           <li>Grammar practice for sentence-level accuracy</li>
           <li>Punctuation practice for clearer written English</li>
         </ul>
-        <nav className="auth-practice-links" aria-label="KS2 practice pages">
+        <nav className="auth-practice-links" aria-label="KS2 practice and site pages">
           <a href="/ks2-spelling-practice/">KS2 spelling practice online</a>
           <a href="/ks2-grammar-practice/">KS2 grammar practice online</a>
           <a href="/ks2-punctuation-practice/">KS2 punctuation practice online</a>
+          <a href="/about/">About KS2 Mastery</a>
         </nav>
         {/* SH2-U8: inline style prop migrated to `.auth-standard-error` class
             (see docs/hardening/csp-inline-style-inventory.md). */}

--- a/styles/app.css
+++ b/styles/app.css
@@ -292,6 +292,9 @@ textarea:focus-visible {
 }
 
 .practice-public-nav {
+  display: flex;
+  align-items: center;
+  gap: 18px;
   width: min(100%, 960px);
   margin: 0 auto;
   padding: 24px 28px 0;
@@ -351,6 +354,31 @@ textarea:focus-visible {
 
 .practice-public-list li + li {
   margin-top: 8px;
+}
+
+.practice-public-section {
+  margin-top: 28px;
+}
+
+.practice-public-section h2 {
+  margin: 0;
+  color: var(--ink);
+  font-family: var(--font-display);
+  font-size: 1.7rem;
+}
+
+.practice-public-section p {
+  margin: 12px 0 0;
+  color: var(--ink-2);
+  line-height: 1.65;
+}
+
+.identity-public-panel {
+  max-width: 780px;
+}
+
+.identity-public-links {
+  margin-top: 24px;
 }
 
 .practice-public-actions {

--- a/tests/build-public.test.js
+++ b/tests/build-public.test.js
@@ -12,8 +12,10 @@ test('public build emits the React app bundle entrypoint', () => {
   execFileSync(process.execPath, ['./scripts/audit-client-bundle.mjs'], { stdio: 'ignore' });
 
   const indexHtml = readFileSync('dist/public/index.html', 'utf8');
+  const llmsTxt = readFileSync('dist/public/llms.txt', 'utf8');
   const robotsTxt = readFileSync('dist/public/robots.txt', 'utf8');
   const sitemapXml = readFileSync('dist/public/sitemap.xml', 'utf8');
+  const aboutHtml = readFileSync('dist/public/about/index.html', 'utf8');
   const practicePages = new Map(PRACTICE_SEO_PAGES.map((page) => [
     page.slug,
     readFileSync(`dist/public/${page.slug}/index.html`, 'utf8'),
@@ -29,11 +31,13 @@ test('public build emits the React app bundle entrypoint', () => {
   assert.doesNotMatch(indexHtml, /src\/main\.js/);
   assert.match(indexHtml, /KS2 Mastery \| KS2 Spelling, Grammar and Punctuation Practice/);
   assert.match(indexHtml, /<link rel="canonical" href="https:\/\/ks2\.eugnel\.uk\/" \/>/);
+  assert.match(indexHtml, /<link rel="alternate" type="text\/plain" href="\/llms\.txt"/);
   assert.match(indexHtml, /application\/ld\+json/);
   assert.match(indexHtml, /KS2 spelling, grammar and punctuation practice/);
   assert.match(indexHtml, /href="\/ks2-spelling-practice\/"/);
   assert.match(indexHtml, /href="\/ks2-grammar-practice\/"/);
   assert.match(indexHtml, /href="\/ks2-punctuation-practice\/"/);
+  assert.match(indexHtml, /href="\/about\/"/);
   assert.match(robotsTxt, /Disallow: \/api\//);
   assert.match(robotsTxt, /Disallow: \/admin/);
   assert.match(robotsTxt, /Disallow: \/demo/);
@@ -45,11 +49,27 @@ test('public build emits the React app bundle entrypoint', () => {
   assert.deepEqual(sitemapLocs, [
     'https://ks2.eugnel.uk/',
     ...PRACTICE_SEO_PAGES.map((page) => canonicalPracticePageUrl(page)),
+    'https://ks2.eugnel.uk/about/',
   ]);
   for (const page of PRACTICE_SEO_PAGES) {
     assert.match(sitemapXml, new RegExp(`<loc>${canonicalPracticePageUrl(page).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}</loc>`));
   }
   assert.doesNotMatch(sitemapXml, /\/api\/|\/admin|\/demo|\.html|localhost|127\.0\.0\.1/);
+  assert.doesNotMatch(sitemapXml, /llms\.txt/);
+  assert.match(llmsTxt, /KS2 Mastery/);
+  assert.match(llmsTxt, /https:\/\/ks2\.eugnel\.uk\//);
+  assert.match(llmsTxt, /https:\/\/ks2\.eugnel\.uk\/about\//);
+  assert.match(llmsTxt, /https:\/\/ks2\.eugnel\.uk\/ks2-spelling-practice\//);
+  assert.match(llmsTxt, /https:\/\/ks2\.eugnel\.uk\/ks2-grammar-practice\//);
+  assert.match(llmsTxt, /https:\/\/ks2\.eugnel\.uk\/ks2-punctuation-practice\//);
+  assert.match(llmsTxt, /KS2 spelling/);
+  assert.match(llmsTxt, /KS2 grammar/);
+  assert.match(llmsTxt, /KS2 punctuation/);
+  assert.match(llmsTxt, /Private learner progress, account state, operator tools and generated content stores are not public SEO content/);
+  assert.doesNotMatch(
+    llmsTxt,
+    /\/api\/|\/admin|OPENAI_API_KEY|GEMINI_API_KEY|ANTHROPIC_API_KEY|SEEDED_SPELLING_CONTENT_BUNDLE|PUNCTUATION_CONTENT_MANIFEST|generativelanguage\.googleapis\.com|api\.openai\.com\/v1|guaranteed|full curriculum|AI tutor|exam results/i,
+  );
   for (const page of PRACTICE_SEO_PAGES) {
     const html = practicePages.get(page.slug);
     assert.ok(html, `${page.slug} should be emitted as a static page`);
@@ -62,7 +82,21 @@ test('public build emits the React app bundle entrypoint', () => {
       assert.match(html, new RegExp(point.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
     }
     assert.doesNotMatch(html, /app\.bundle\.js|id="app"|application\/ld\+json|<script/i);
+    assert.match(html, /href="\/about\/"/);
   }
+  assert.match(aboutHtml, /<title>About KS2 Mastery \| KS2 Spelling, Grammar and Punctuation Practice<\/title>/);
+  assert.match(aboutHtml, /<link rel="canonical" href="https:\/\/ks2\.eugnel\.uk\/about\/" \/>/);
+  assert.match(aboutHtml, /<h1>About KS2 Mastery<\/h1>/);
+  assert.match(aboutHtml, /KS2 spelling, grammar and punctuation practice/);
+  assert.match(aboutHtml, /Learners can try a demo before signing in/);
+  assert.match(aboutHtml, /Signing in saves learner profiles and progress/);
+  assert.match(aboutHtml, /Private learner progress, admin tools and generated content stores are not public SEO content/);
+  assert.match(aboutHtml, /href="\/ks2-spelling-practice\/"/);
+  assert.match(aboutHtml, /href="\/ks2-grammar-practice\/"/);
+  assert.match(aboutHtml, /href="\/ks2-punctuation-practice\/"/);
+  assert.match(aboutHtml, /href="\/demo"/);
+  assert.doesNotMatch(aboutHtml, /app\.bundle\.js|id="app"|application\/ld\+json|<script/i);
+  assert.doesNotMatch(aboutHtml, /guaranteed|full curriculum|AI tutor|exam results/i);
   assert.ok(
     cspHashArtefact.split(/\r?\n/u).filter(Boolean).length >= 2,
     'CSP hash artefact should list both theme and JSON-LD inline script hashes',

--- a/tests/bundle-audit.test.js
+++ b/tests/bundle-audit.test.js
@@ -17,6 +17,15 @@ import {
   PRACTICE_SEO_PAGES,
   canonicalPracticePageUrl,
 } from '../scripts/lib/seo-practice-pages.mjs';
+import {
+  IDENTITY_SEO_PAGES,
+  canonicalIdentityPageUrl,
+} from '../scripts/lib/seo-identity-pages.mjs';
+import {
+  crawlerPolicyFailures,
+  isCrawlerPathAllowed,
+  parseRobotsGroups,
+} from '../scripts/lib/seo-crawler-policy.mjs';
 
 const execFileAsync = promisify(execFile);
 
@@ -639,6 +648,68 @@ function normaliseCacheControl(value) {
   return String(value || '').replace(/\s+/gu, ' ').replace(/,\s*/gu, ', ').trim();
 }
 
+test('SEO crawler policy helper keeps OAI public access separate from GPTBot training policy', () => {
+  const robots = [
+    'User-agent: *',
+    'Disallow: /api/',
+    'Disallow: /admin',
+    'Disallow: /demo',
+    'Allow: /',
+    '',
+    'User-agent: GPTBot',
+    'Disallow: /',
+  ].join('\n');
+
+  assert.equal(parseRobotsGroups(robots).length, 2);
+  assert.equal(isCrawlerPathAllowed(robots, 'OAI-SearchBot', '/about/'), true);
+  assert.equal(isCrawlerPathAllowed(robots, 'OAI-SearchBot', '/api/bootstrap'), false);
+  assert.equal(isCrawlerPathAllowed(robots, 'GPTBot', '/about/'), false);
+  assert.deepEqual(crawlerPolicyFailures(robots, {
+    userAgent: 'OAI-SearchBot',
+    publicPaths: ['/', '/about/'],
+    privatePaths: ['/api/', '/admin', '/demo'],
+  }), []);
+});
+
+test('SEO crawler policy helper requires private disallows in bot-specific OAI groups', () => {
+  const robots = [
+    'User-agent: *',
+    'Disallow: /api/',
+    'Disallow: /admin',
+    'Disallow: /demo',
+    'Allow: /',
+    '',
+    'User-agent: OAI-SearchBot',
+    'Allow: /',
+  ].join('\n');
+
+  assert.equal(isCrawlerPathAllowed(robots, 'OAI-SearchBot', '/about/'), true);
+  assert.equal(isCrawlerPathAllowed(robots, 'OAI-SearchBot', '/api/bootstrap'), true);
+  assert.match(crawlerPolicyFailures(robots, {
+    userAgent: 'OAI-SearchBot',
+    publicPaths: ['/', '/about/'],
+    privatePaths: ['/api/', '/admin', '/demo'],
+  }).join('\n'), /must repeat the private-path disallow for \/api\//);
+});
+
+test('SEO crawler policy helper rejects generic private-path allow overrides', () => {
+  const robots = [
+    'User-agent: *',
+    'Disallow: /api/',
+    'Allow: /api/',
+    'Disallow: /admin',
+    'Disallow: /demo',
+    'Allow: /',
+  ].join('\n');
+
+  assert.equal(isCrawlerPathAllowed(robots, 'OAI-SearchBot', '/api/bootstrap'), true);
+  assert.match(crawlerPolicyFailures(robots, {
+    userAgent: 'OAI-SearchBot',
+    publicPaths: ['/', '/about/'],
+    privatePaths: ['/api/', '/admin', '/demo'],
+  }).join('\n'), /must disallow OAI-SearchBot from private crawler path \/api\//);
+});
+
 const SEO_AUDIT_SECURITY_HEADERS = {
   'strict-transport-security': 'max-age=63072000; includeSubDomains',
   'x-content-type-options': 'nosniff',
@@ -662,6 +733,7 @@ function seoAuditRootHtml({ omitCanonical = false } = {}) {
     '<meta property="og:description" content="Online KS2 English practice for spelling, grammar and punctuation." />',
     '<meta property="og:url" content="https://ks2.eugnel.uk/" />',
     '<meta name="twitter:card" content="summary" />',
+    '<link rel="alternate" type="text/plain" href="/llms.txt" title="AI-readable KS2 Mastery summary" />',
     '<script type="application/ld+json">',
     JSON.stringify({
       '@context': 'https://schema.org',
@@ -677,7 +749,8 @@ function seoAuditRootHtml({ omitCanonical = false } = {}) {
     '<main><h1>KS2 spelling, grammar and punctuation practice</h1>',
     '<p>Spelling practice for KS2 word confidence</p>',
     '<p>Grammar practice for sentence-level accuracy</p>',
-    '<p>Punctuation practice for clearer written English</p></main>',
+    '<p>Punctuation practice for clearer written English</p>',
+    '<a href="/about/">About KS2 Mastery</a></main>',
     '<script type="module" src="/src/bundles/app.bundle.js?v=test"></script>',
     '</body></html>',
   ].join('');
@@ -702,10 +775,62 @@ function seoAuditPracticePageHtml(page, { omitCanonical = false, forbiddenToken 
     '</ul>',
     forbiddenToken ? `<p>${forbiddenToken}</p>` : '',
     '<a href="/demo">Try demo</a>',
+    '<a href="/about/">About KS2 Mastery</a>',
     '<a href="/">KS2 Mastery home</a>',
     '</main>',
     '</body></html>',
   ].join('');
+}
+
+function seoAuditIdentityPageHtml(page, { forbiddenToken = '' } = {}) {
+  const canonicalUrl = canonicalIdentityPageUrl(page);
+  return [
+    '<!doctype html><html lang="en-GB"><head>',
+    `<title>${page.title}</title>`,
+    `<meta name="description" content="${page.description}" />`,
+    `<link rel="canonical" href="${canonicalUrl}" />`,
+    `<meta property="og:title" content="${page.title}" />`,
+    `<meta property="og:description" content="${page.description}" />`,
+    `<meta property="og:url" content="${canonicalUrl}" />`,
+    '<meta name="twitter:card" content="summary" />',
+    '</head><body>',
+    `<main><h1>${page.heading}</h1>`,
+    `<p>${page.intro}</p>`,
+    '<p>KS2 spelling, grammar and punctuation practice</p>',
+    '<p>Learners can try a demo before signing in</p>',
+    '<p>Signing in saves learner profiles and progress</p>',
+    '<p>Private learner progress, admin tools and generated content stores are not public SEO content</p>',
+    forbiddenToken ? `<p>${forbiddenToken}</p>` : '',
+    '<a href="/ks2-spelling-practice/">KS2 spelling practice online</a>',
+    '<a href="/ks2-grammar-practice/">KS2 grammar practice online</a>',
+    '<a href="/ks2-punctuation-practice/">KS2 punctuation practice online</a>',
+    '<a href="/demo">Try demo</a>',
+    '</main>',
+    '</body></html>',
+  ].join('');
+}
+
+function seoAuditLlmsTxt({ forbiddenToken = '' } = {}) {
+  return [
+    '# KS2 Mastery',
+    '',
+    'KS2 Mastery is an online KS2 spelling, grammar and punctuation practice product for learners and supporting adults.',
+    '',
+    'Canonical public pages:',
+    '- https://ks2.eugnel.uk/',
+    ...IDENTITY_SEO_PAGES.map((page) => `- ${canonicalIdentityPageUrl(page)}`),
+    ...PRACTICE_SEO_PAGES.map((page) => `- ${canonicalPracticePageUrl(page)}`),
+    '',
+    'Current subject coverage:',
+    '- KS2 spelling practice for word confidence and recall',
+    '- KS2 grammar practice for sentence-level accuracy',
+    '- KS2 punctuation practice for clearer written English',
+    '',
+    'Product notes:',
+    '- Private learner progress, account state, operator tools and generated content stores are not public SEO content.',
+    forbiddenToken ? `- ${forbiddenToken}` : '',
+    '',
+  ].join('\n');
 }
 
 function createSeoAuditStubServer(options = {}) {
@@ -736,21 +861,65 @@ function createSeoAuditStubServer(options = {}) {
         return;
       }
     }
+    for (const page of IDENTITY_SEO_PAGES) {
+      if (url === `/${page.slug}/`) {
+        if (options.identityFallbackSlug === page.slug) {
+          write(200, { 'content-type': 'text/html', 'cache-control': 'no-store' }, seoAuditRootHtml());
+          return;
+        }
+        write(200, { 'content-type': 'text/html', 'cache-control': 'no-store' }, seoAuditIdentityPageHtml(page, {
+          forbiddenToken: options.identityForbiddenTokenSlug === page.slug
+            ? 'OPENAI_API_KEY'
+            : '',
+        }));
+        return;
+      }
+    }
     if (url === '/robots.txt') {
       if (options.robotsFallback) {
         write(200, { 'content-type': 'text/html', 'cache-control': 'no-store' }, seoAuditRootHtml());
         return;
       }
-      write(200, { 'content-type': 'text/plain; charset=utf-8', 'cache-control': 'public, max-age=3600' }, [
+      const robotsLines = [
         'User-agent: *',
         'Disallow: /api/',
         'Disallow: /admin',
         'Disallow: /demo',
         'Allow: /',
         '',
+      ];
+      if (options.robotsGenericAllowPrivate) {
+        robotsLines.push(
+          `Allow: ${options.robotsGenericAllowPrivate}`,
+          '',
+        );
+      }
+      if (options.robotsOaiDisallowRoot) {
+        robotsLines.push(
+          'User-agent: OAI-SearchBot',
+          'Disallow: /',
+          '',
+        );
+      }
+      if (options.robotsOaiSpecificMissingPrivate) {
+        robotsLines.push(
+          'User-agent: OAI-SearchBot',
+          'Allow: /',
+          '',
+        );
+      }
+      if (options.robotsGptbotDisallowRoot) {
+        robotsLines.push(
+          'User-agent: GPTBot',
+          'Disallow: /',
+          '',
+        );
+      }
+      robotsLines.push(
         'Sitemap: https://ks2.eugnel.uk/sitemap.xml',
         '',
-      ].join('\n'));
+      );
+      write(200, { 'content-type': 'text/plain; charset=utf-8', 'cache-control': 'public, max-age=3600' }, robotsLines.join('\n'));
       return;
     }
     if (url === '/sitemap.xml') {
@@ -759,6 +928,9 @@ function createSeoAuditStubServer(options = {}) {
         ...PRACTICE_SEO_PAGES
           .filter((page) => page.slug !== options.omitSitemapPageSlug)
           .map((page) => canonicalPracticePageUrl(page)),
+        ...IDENTITY_SEO_PAGES
+          .filter((page) => page.slug !== options.omitSitemapIdentitySlug)
+          .map((page) => canonicalIdentityPageUrl(page)),
       ];
       if (options.sitemapForbiddenPath) {
         sitemapUrls.push(`https://ks2.eugnel.uk${options.sitemapForbiddenPath}`);
@@ -777,6 +949,16 @@ function createSeoAuditStubServer(options = {}) {
         '</urlset>',
         '',
       ].join('\n'));
+      return;
+    }
+    if (url === '/llms.txt') {
+      if (options.llmsFallback) {
+        write(200, { 'content-type': 'text/html', 'cache-control': 'no-store' }, seoAuditRootHtml());
+        return;
+      }
+      write(200, { 'content-type': 'text/plain; charset=utf-8', 'cache-control': 'public, max-age=3600' }, seoAuditLlmsTxt({
+        forbiddenToken: options.llmsForbiddenToken || '',
+      }));
       return;
     }
     if (url === '/src/bundles/app.bundle.js' || url === '/src/bundles/app.bundle.js?v=test') {
@@ -864,7 +1046,7 @@ test('production bundle audit passes with SEO root, robots, and sitemap resource
       timeout: 8000,
     });
     assert.match(stdout, /Production bundle audit passed/);
-    assert.match(stdout, /cache-split checks: 10\/10/);
+    assert.match(stdout, /cache-split checks: 12\/12/);
   } finally {
     await closeServer(server);
   }
@@ -942,6 +1124,79 @@ test('production bundle audit fails when a practice page leaks forbidden deploye
     });
   } finally {
     await closeServer(server);
+  }
+});
+
+test('production bundle audit fails when the about page is SPA fallback HTML', async () => {
+  const server = createSeoAuditStubServer({ identityFallbackSlug: 'about' });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+  try {
+    const { port } = server.address();
+    await assert.rejects(async () => {
+      await execFileAsync(process.execPath, [
+        './scripts/production-bundle-audit.mjs',
+        '--skip-local',
+        '--url',
+        `http://127.0.0.1:${port}/`,
+      ], {
+        cwd: process.cwd(),
+        timeout: 8000,
+      });
+    }, (error) => {
+      assert.match(error.stderr, /Production SEO page \/about\/ appears to be the root SPA shell/);
+      return true;
+    });
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test('production bundle audit fails when llms.txt is SPA fallback HTML or leaks private text', async () => {
+  const fallbackServer = createSeoAuditStubServer({ llmsFallback: true });
+  await new Promise((resolve) => fallbackServer.listen(0, '127.0.0.1', resolve));
+
+  try {
+    const { port } = fallbackServer.address();
+    await assert.rejects(async () => {
+      await execFileAsync(process.execPath, [
+        './scripts/production-bundle-audit.mjs',
+        '--skip-local',
+        '--url',
+        `http://127.0.0.1:${port}/`,
+      ], {
+        cwd: process.cwd(),
+        timeout: 8000,
+      });
+    }, (error) => {
+      assert.match(error.stderr, /Production llms\.txt appears to be SPA fallback HTML/);
+      return true;
+    });
+  } finally {
+    await closeServer(fallbackServer);
+  }
+
+  const leakServer = createSeoAuditStubServer({ llmsForbiddenToken: 'OPENAI_API_KEY' });
+  await new Promise((resolve) => leakServer.listen(0, '127.0.0.1', resolve));
+
+  try {
+    const { port } = leakServer.address();
+    await assert.rejects(async () => {
+      await execFileAsync(process.execPath, [
+        './scripts/production-bundle-audit.mjs',
+        '--skip-local',
+        '--url',
+        `http://127.0.0.1:${port}/`,
+      ], {
+        cwd: process.cwd(),
+        timeout: 8000,
+      });
+    }, (error) => {
+      assert.match(error.stderr, /Production \/llms\.txt must not include forbidden token: OPENAI_API_KEY/);
+      return true;
+    });
+  } finally {
+    await closeServer(leakServer);
   }
 });
 
@@ -1035,6 +1290,104 @@ test('production bundle audit fails when robots.txt is SPA fallback HTML', async
       });
     }, (error) => {
       assert.match(error.stderr, /Production robots\.txt appears to be SPA fallback HTML/);
+      return true;
+    });
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test('production bundle audit fails when OAI-SearchBot is blocked from public SEO pages', async () => {
+  const server = createSeoAuditStubServer({ robotsOaiDisallowRoot: true });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+  try {
+    const { port } = server.address();
+    await assert.rejects(async () => {
+      await execFileAsync(process.execPath, [
+        './scripts/production-bundle-audit.mjs',
+        '--skip-local',
+        '--url',
+        `http://127.0.0.1:${port}/`,
+      ], {
+        cwd: process.cwd(),
+        timeout: 8000,
+      });
+    }, (error) => {
+      assert.match(error.stderr, /Production robots\.txt must allow OAI-SearchBot to fetch public SEO path \//);
+      assert.match(error.stderr, /Cloudflare bot\/crawler settings/);
+      return true;
+    });
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test('production bundle audit fails when generic robots allows private paths for OAI-SearchBot', async () => {
+  const server = createSeoAuditStubServer({ robotsGenericAllowPrivate: '/api/' });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+  try {
+    const { port } = server.address();
+    await assert.rejects(async () => {
+      await execFileAsync(process.execPath, [
+        './scripts/production-bundle-audit.mjs',
+        '--skip-local',
+        '--url',
+        `http://127.0.0.1:${port}/`,
+      ], {
+        cwd: process.cwd(),
+        timeout: 8000,
+      });
+    }, (error) => {
+      assert.match(error.stderr, /Production robots\.txt must disallow OAI-SearchBot from private crawler path \/api\//);
+      return true;
+    });
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test('production bundle audit allows GPTBot training disallow when OAI search remains crawlable', async () => {
+  const server = createSeoAuditStubServer({ robotsGptbotDisallowRoot: true });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+  try {
+    const { port } = server.address();
+    const { stdout } = await execFileAsync(process.execPath, [
+      './scripts/production-bundle-audit.mjs',
+      '--skip-local',
+      '--url',
+      `http://127.0.0.1:${port}/`,
+    ], {
+      cwd: process.cwd(),
+      timeout: 8000,
+    });
+    assert.match(stdout, /Production bundle audit passed/);
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test('production bundle audit fails when OAI-specific robots group omits private disallows', async () => {
+  const server = createSeoAuditStubServer({ robotsOaiSpecificMissingPrivate: true });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+  try {
+    const { port } = server.address();
+    await assert.rejects(async () => {
+      await execFileAsync(process.execPath, [
+        './scripts/production-bundle-audit.mjs',
+        '--skip-local',
+        '--url',
+        `http://127.0.0.1:${port}/`,
+      ], {
+        cwd: process.cwd(),
+        timeout: 8000,
+      });
+    }, (error) => {
+      assert.match(error.stderr, /Production robots\.txt has a bot-specific OAI-SearchBot group, so it must repeat the private-path disallow for \/api\//);
+      assert.match(error.stderr, /Cloudflare bot\/crawler settings/);
       return true;
     });
   } finally {

--- a/tests/react-auth-boot.test.js
+++ b/tests/react-auth-boot.test.js
@@ -14,6 +14,7 @@ test('auth surface renders through React with credential and social sign-in stat
   assert.match(html, /href="\/ks2-spelling-practice\/"/);
   assert.match(html, /href="\/ks2-grammar-practice\/"/);
   assert.match(html, /href="\/ks2-punctuation-practice\/"/);
+  assert.match(html, /href="\/about\/"/);
   assert.match(html, /expired/);
   assert.match(html, /autoComplete="email"/);
   assert.match(html, /Social sign-in/);


### PR DESCRIPTION
## Summary
- add a crawlable `/about/` identity page plus root/auth/public-page links
- add `/llms.txt` as a supplementary AI-readable product summary
- strengthen build and production audit coverage for sitemap, robots, OAI-SearchBot access, `/about/`, and `/llms.txt`
- update the SEO operations runbook with Search Console, Cloudflare Web Analytics, AI crawler checks, and next-slice gates

## Verification
- `node scripts/worktree-setup.mjs`
- `node --test tests/bundle-audit.test.js tests/react-auth-boot.test.js` (subagent review pass)
- `node --test tests/grammar-transfer-admin-security.test.js` (isolated rerun after full-suite timing failure)
- `node --test tests/worker-capacity-overhead.test.js` (isolated rerun after full-suite benchmark timing failure)
- `npm test` (latest full rerun after rebase: 5872 pass, 6 skipped, 0 fail)
- `npm run check`
- `git diff --check`