### PR TITLE
feat(punctuation): expand deterministic generator capacity

### DIFF
--- a/shared/punctuation/context-packs.js
+++ b/shared/punctuation/context-packs.js
@@ -1,6 +1,7 @@
 const MAX_ATOM_LENGTH = 48;
 const MAX_ATOMS_PER_KIND = 6;
 const MAX_TOTAL_ATOMS = 32;
+const MAX_CONTEXT_TEMPLATE_VARIANTS = 2;
 
 const STRING_ATOM_KINDS = Object.freeze([
   'names',
@@ -185,34 +186,50 @@ function asNormalisedPack(pack = {}) {
   return isPlainObject(pack?.acceptedAtoms) ? pack : normalisePunctuationContextPack(pack);
 }
 
-function first(values, fallback) {
-  return Array.isArray(values) && values.length ? values[0] : fallback;
+function valueAt(values, index, fallback) {
+  return Array.isArray(values) && values.length ? values[index % values.length] : fallback;
 }
 
-function listItems(pack) {
+function templateVariants(pack, builder) {
+  const seen = new Set();
+  const templates = [];
+  for (let index = 0; index < MAX_CONTEXT_TEMPLATE_VARIANTS; index += 1) {
+    const template = builder(pack, index);
+    if (!template) continue;
+    const key = `${template.prompt || ''}\n${template.stem || ''}\n${template.model || ''}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    templates.push(template);
+  }
+  return templates;
+}
+
+function listItems(pack, variantIndex = 0) {
   const nouns = pack.acceptedAtoms.listNouns || [];
-  return nouns.length >= 3 ? nouns.slice(0, 3) : null;
+  if (nouns.length < 3) return null;
+  const start = Math.min(variantIndex * 3, Math.max(0, nouns.length - 3));
+  return nouns.slice(start, start + 3);
 }
 
-function mainClause(pack, fallback = 'the crew checked the ropes') {
-  return first(pack.acceptedAtoms.stems, fallback).toLowerCase();
+function mainClause(pack, fallback = 'the crew checked the ropes', variantIndex = 0) {
+  return valueAt(pack.acceptedAtoms.stems, variantIndex, fallback).toLowerCase();
 }
 
-function clausePair(pack, fallbackLeft = 'the crew checked the ropes', fallbackRight = 'we found another path') {
+function clausePair(pack, fallbackLeft = 'the crew checked the ropes', fallbackRight = 'we found another path', variantIndex = 0) {
   const stems = Array.isArray(pack.acceptedAtoms.stems) ? pack.acceptedAtoms.stems : [];
-  const left = (stems[0] || fallbackLeft).toLowerCase();
-  const rightCandidate = (stems[1] || '').toLowerCase();
+  const left = (stems[variantIndex * 2] || fallbackLeft).toLowerCase();
+  const rightCandidate = (stems[(variantIndex * 2) + 1] || '').toLowerCase();
   const right = rightCandidate && rightCandidate !== left ? rightCandidate : fallbackRight;
   return { left, right };
 }
 
-function placeSubject(pack, fallback = 'harbour') {
-  const place = first(pack.acceptedAtoms.places, fallback);
+function placeSubject(pack, fallback = 'harbour', variantIndex = 0) {
+  const place = valueAt(pack.acceptedAtoms.places, variantIndex, fallback);
   return `The ${place}`;
 }
 
-function listInsertTemplate(pack) {
-  const items = listItems(pack);
+function listInsertTemplate(pack, variantIndex = 0) {
+  const items = listItems(pack, variantIndex);
   if (!items) return null;
   const [firstItem, secondItem, thirdItem] = items;
   return {
@@ -228,8 +245,8 @@ function listInsertTemplate(pack) {
   };
 }
 
-function listCombineTemplate(pack) {
-  const items = listItems(pack);
+function listCombineTemplate(pack, variantIndex = 0) {
+  const items = listItems(pack, variantIndex);
   if (!items) return null;
   const [firstItem, secondItem, thirdItem] = items;
   return {
@@ -246,10 +263,10 @@ function listCombineTemplate(pack) {
   };
 }
 
-function frontedFixTemplate(pack) {
-  const phrase = first(pack.acceptedAtoms.frontedAdverbialPhrases, null);
+function frontedFixTemplate(pack, variantIndex = 0) {
+  const phrase = valueAt(pack.acceptedAtoms.frontedAdverbialPhrases, variantIndex, null);
   if (!phrase) return null;
-  const clause = mainClause(pack);
+  const clause = mainClause(pack, 'the crew checked the ropes', variantIndex);
   return {
     prompt: 'Correct the comma after the fronted adverbial.',
     stem: `${capitaliseSentence(phrase)} ${clause}.`,
@@ -263,10 +280,10 @@ function frontedFixTemplate(pack) {
   };
 }
 
-function frontedCombineTemplate(pack) {
-  const phrase = first(pack.acceptedAtoms.frontedAdverbialPhrases, null);
+function frontedCombineTemplate(pack, variantIndex = 0) {
+  const phrase = valueAt(pack.acceptedAtoms.frontedAdverbialPhrases, variantIndex, null);
   if (!phrase) return null;
-  const clause = mainClause(pack);
+  const clause = mainClause(pack, 'the crew checked the ropes', variantIndex);
   return {
     prompt: 'Combine the adverbial and main clause into one sentence.',
     stem: `${capitaliseSentence(phrase)}\n${capitaliseSentence(clause)}.`,
@@ -281,10 +298,10 @@ function frontedCombineTemplate(pack) {
   };
 }
 
-function commaClarityTemplate(pack) {
-  const phrase = first(pack.acceptedAtoms.frontedAdverbialPhrases, null);
+function commaClarityTemplate(pack, variantIndex = 0) {
+  const phrase = valueAt(pack.acceptedAtoms.frontedAdverbialPhrases, variantIndex, null);
   if (!phrase) return null;
-  const clause = clausePair(pack, 'the harbour was quiet', 'the harbour was quiet').right;
+  const clause = clausePair(pack, 'the harbour was quiet', 'the harbour was quiet', variantIndex).right;
   return {
     prompt: 'Add the comma that makes the meaning clear.',
     stem: `${capitaliseSentence(phrase)} ${clause}.`,
@@ -298,8 +315,8 @@ function commaClarityTemplate(pack) {
   };
 }
 
-function boundaryFixTemplate(pack, mark, prompt, misconceptionTag) {
-  const { left, right } = clausePair(pack);
+function boundaryFixTemplate(pack, mark, prompt, misconceptionTag, variantIndex = 0) {
+  const { left, right } = clausePair(pack, 'the crew checked the ropes', 'we found another path', variantIndex);
   const unpunctuatedJoin = mark === ';' ? ', ' : ' ';
   const modelJoin = mark === ';' ? '; ' : ` ${mark} `;
   return {
@@ -317,8 +334,8 @@ function boundaryFixTemplate(pack, mark, prompt, misconceptionTag) {
   };
 }
 
-function boundaryCombineTemplate(pack, mark, prompt, misconceptionTag) {
-  const { left, right } = clausePair(pack);
+function boundaryCombineTemplate(pack, mark, prompt, misconceptionTag, variantIndex = 0) {
+  const { left, right } = clausePair(pack, 'the crew checked the ropes', 'we found another path', variantIndex);
   const modelJoin = mark === ';' ? '; ' : ` ${mark} `;
   return {
     prompt,
@@ -335,9 +352,9 @@ function boundaryCombineTemplate(pack, mark, prompt, misconceptionTag) {
   };
 }
 
-function speechTemplate(pack) {
-  const name = first(pack.acceptedAtoms.names, 'Maya');
-  const question = first(pack.acceptedAtoms.speechQuestions, null);
+function speechTemplate(pack, variantIndex = 0) {
+  const name = valueAt(pack.acceptedAtoms.names, variantIndex, 'Maya');
+  const question = valueAt(pack.acceptedAtoms.speechQuestions, variantIndex, null);
   if (question) {
     return {
       prompt: 'Add the direct-speech punctuation.',
@@ -353,7 +370,7 @@ function speechTemplate(pack) {
       readiness: ['insertion', 'misconception', 'negative_test'],
     };
   }
-  const command = first(pack.acceptedAtoms.speechCommands, null);
+  const command = valueAt(pack.acceptedAtoms.speechCommands, variantIndex, null);
   if (!command) return null;
   return {
     prompt: 'Add the direct-speech punctuation.',
@@ -370,8 +387,8 @@ function speechTemplate(pack) {
   };
 }
 
-function sentenceEndingTemplate(pack) {
-  const question = first(pack.acceptedAtoms.speechQuestions, null);
+function sentenceEndingTemplate(pack, variantIndex = 0) {
+  const question = valueAt(pack.acceptedAtoms.speechQuestions, variantIndex, null);
   if (question) {
     return {
       prompt: 'Add the capital letter and end punctuation.',
@@ -381,7 +398,7 @@ function sentenceEndingTemplate(pack) {
       readiness: ['insertion', 'misconception', 'negative_test'],
     };
   }
-  const stem = first(pack.acceptedAtoms.stems, null);
+  const stem = valueAt(pack.acceptedAtoms.stems, variantIndex, null);
   if (!stem) return null;
   return {
     prompt: 'Add the capital letter and end punctuation.',
@@ -392,10 +409,10 @@ function sentenceEndingTemplate(pack) {
   };
 }
 
-function parenthesisCombineTemplate(pack) {
-  const phrase = first(pack.acceptedAtoms.parenthesisPhrases, null);
+function parenthesisCombineTemplate(pack, variantIndex = 0) {
+  const phrase = valueAt(pack.acceptedAtoms.parenthesisPhrases, variantIndex, null);
   if (!phrase) return null;
-  const before = placeSubject(pack);
+  const before = placeSubject(pack, 'harbour', variantIndex);
   const after = 'was busy';
   return {
     prompt: 'Combine the sentence and extra detail using parenthesis.',
@@ -412,8 +429,8 @@ function parenthesisCombineTemplate(pack) {
   };
 }
 
-function hyphenTemplate(pack) {
-  const row = first(pack.acceptedAtoms.hyphenCompoundRows, null);
+function hyphenTemplate(pack, variantIndex = 0) {
+  const row = valueAt(pack.acceptedAtoms.hyphenCompoundRows, variantIndex, null);
   if (!row) return null;
   const openPhrase = `${row.left} ${row.right} ${row.noun}`;
   const hyphenatedPhrase = `${row.left}-${row.right} ${row.noun}`;
@@ -433,42 +450,46 @@ function hyphenTemplate(pack) {
 export function contextPackTemplatesForFamily(familyId, contextPack = {}) {
   const pack = asNormalisedPack(contextPack);
   if (!pack.summary.acceptedCount) return [];
-  const template = {
-    gen_sentence_endings_insert: sentenceEndingTemplate,
-    gen_speech_insert: speechTemplate,
-    gen_list_commas_insert: listInsertTemplate,
-    gen_list_commas_combine: listCombineTemplate,
-    gen_fronted_adverbial_fix: frontedFixTemplate,
-    gen_fronted_adverbial_combine: frontedCombineTemplate,
-    gen_comma_clarity_insert: commaClarityTemplate,
-    gen_semicolon_fix: (normalisedPack) => boundaryFixTemplate(
+  const templates = {
+    gen_sentence_endings_insert: () => templateVariants(pack, sentenceEndingTemplate),
+    gen_speech_insert: () => templateVariants(pack, speechTemplate),
+    gen_list_commas_insert: () => templateVariants(pack, listInsertTemplate),
+    gen_list_commas_combine: () => templateVariants(pack, listCombineTemplate),
+    gen_fronted_adverbial_fix: () => templateVariants(pack, frontedFixTemplate),
+    gen_fronted_adverbial_combine: () => templateVariants(pack, frontedCombineTemplate),
+    gen_comma_clarity_insert: () => templateVariants(pack, commaClarityTemplate),
+    gen_semicolon_fix: () => templateVariants(pack, (normalisedPack, variantIndex) => boundaryFixTemplate(
       normalisedPack,
       ';',
       'Replace the comma splice with a semi-colon.',
       'boundary.semicolon_missing',
-    ),
-    gen_semicolon_combine: (normalisedPack) => boundaryCombineTemplate(
+      variantIndex,
+    )),
+    gen_semicolon_combine: () => templateVariants(pack, (normalisedPack, variantIndex) => boundaryCombineTemplate(
       normalisedPack,
       ';',
       'Combine the two related clauses into one sentence with a semi-colon.',
       'boundary.semicolon_missing',
-    ),
-    gen_dash_clause_fix: (normalisedPack) => boundaryFixTemplate(
+      variantIndex,
+    )),
+    gen_dash_clause_fix: () => templateVariants(pack, (normalisedPack, variantIndex) => boundaryFixTemplate(
       normalisedPack,
       '-',
       'Add a dash between the related clauses.',
       'boundary.dash_missing',
-    ),
-    gen_dash_clause_combine: (normalisedPack) => boundaryCombineTemplate(
+      variantIndex,
+    )),
+    gen_dash_clause_combine: () => templateVariants(pack, (normalisedPack, variantIndex) => boundaryCombineTemplate(
       normalisedPack,
       '-',
       'Combine the two related clauses into one sentence with a dash.',
       'boundary.dash_missing',
-    ),
-    gen_parenthesis_combine: parenthesisCombineTemplate,
-    gen_hyphen_insert: hyphenTemplate,
-  }[familyId]?.(pack);
-  return template ? [template] : [];
+      variantIndex,
+    )),
+    gen_parenthesis_combine: () => templateVariants(pack, parenthesisCombineTemplate),
+    gen_hyphen_insert: () => templateVariants(pack, hyphenTemplate),
+  }[familyId]?.();
+  return Array.isArray(templates) ? templates : [];
 }
 
 export function affectedGeneratorFamiliesForContextPack(contextPack = {}) {

--- a/shared/punctuation/context-packs.js
+++ b/shared/punctuation/context-packs.js
@@ -315,10 +315,14 @@ function commaClarityTemplate(pack, variantIndex = 0) {
   };
 }
 
+function modelJoinForBoundaryMark(mark) {
+  return mark === ';' ? '; ' : ` ${mark === '-' ? '–' : mark} `;
+}
+
 function boundaryFixTemplate(pack, mark, prompt, misconceptionTag, variantIndex = 0) {
   const { left, right } = clausePair(pack, 'the crew checked the ropes', 'we found another path', variantIndex);
   const unpunctuatedJoin = mark === ';' ? ', ' : ' ';
-  const modelJoin = mark === ';' ? '; ' : ` ${mark} `;
+  const modelJoin = modelJoinForBoundaryMark(mark);
   return {
     prompt,
     stem: `${capitaliseSentence(left)}${unpunctuatedJoin}${right}.`,
@@ -336,7 +340,7 @@ function boundaryFixTemplate(pack, mark, prompt, misconceptionTag, variantIndex 
 
 function boundaryCombineTemplate(pack, mark, prompt, misconceptionTag, variantIndex = 0) {
   const { left, right } = clausePair(pack, 'the crew checked the ropes', 'we found another path', variantIndex);
-  const modelJoin = mark === ';' ? '; ' : ` ${mark} `;
+  const modelJoin = modelJoinForBoundaryMark(mark);
   return {
     prompt,
     stem: `${capitaliseSentence(left)}.\n${capitaliseSentence(right)}.`,

--- a/shared/punctuation/generators.js
+++ b/shared/punctuation/generators.js
@@ -76,17 +76,33 @@ function variantSignatureFor({ family, template, templateId, model }) {
   return `puncsig_${shortHash(JSON.stringify(stableJson(signaturePayload)))}`;
 }
 
-function pickTemplate(templates, seed, familyId, variantIndex, { legacyTemplateCount = 2 } = {}) {
+function pickTemplate(templates, seed, familyId, variantIndex, {
+  legacyTemplateCount = 2,
+  runtimeStableTemplateCount = legacyTemplateCount,
+} = {}) {
   if (!templates.length) return null;
   const legacyCount = Math.max(0, Math.min(Number(legacyTemplateCount) || 0, templates.length));
-  const expandedPool = templates.slice(legacyCount);
-  const pool = variantIndex < legacyCount || !expandedPool.length
-    ? templates.slice(0, legacyCount || templates.length)
-    : expandedPool;
+  const stableCount = Math.max(
+    legacyCount,
+    Math.min(Number(runtimeStableTemplateCount) || legacyCount, templates.length),
+  );
+  const stableExpansionPool = templates.slice(legacyCount, stableCount);
+  const capacityExpansionPool = templates.slice(stableCount);
+  const pool = (() => {
+    if (variantIndex < legacyCount) return templates.slice(0, legacyCount || templates.length);
+    if (variantIndex < stableCount && stableExpansionPool.length) return stableExpansionPool;
+    if (capacityExpansionPool.length) return capacityExpansionPool;
+    if (stableExpansionPool.length) return stableExpansionPool;
+    return templates.slice(0, legacyCount || templates.length);
+  })();
   const offset = hashString(`${seed}:${familyId}`) % pool.length;
-  const poolVariantIndex = variantIndex < legacyCount || !expandedPool.length
-    ? variantIndex
-    : variantIndex - legacyCount;
+  const poolVariantIndex = (() => {
+    if (variantIndex < legacyCount) return variantIndex;
+    if (variantIndex < stableCount && stableExpansionPool.length) return variantIndex - legacyCount;
+    if (capacityExpansionPool.length) return variantIndex - stableCount;
+    if (stableExpansionPool.length) return variantIndex - legacyCount;
+    return variantIndex;
+  })();
   const poolIndex = (offset + poolVariantIndex) % pool.length;
   const template = pool[poolIndex];
   return {
@@ -129,6 +145,34 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
       misconceptionTags: ['endmarks.exclamation_mark_missing', 'endmarks.capitalisation_missing'],
       readiness: ['insertion', 'misconception', 'negative_test'],
     },
+    {
+      prompt: 'Rewrite this as a correctly punctuated question.',
+      stem: 'can the rescue team hear us',
+      model: 'Can the rescue team hear us?',
+      misconceptionTags: ['endmarks.question_mark_missing', 'endmarks.capitalisation_missing'],
+      readiness: ['insertion', 'transfer', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Rewrite the excited sentence with its capital letter and end mark.',
+      stem: 'what an amazing view',
+      model: 'What an amazing view!',
+      misconceptionTags: ['endmarks.exclamation_mark_missing', 'endmarks.capitalisation_missing'],
+      readiness: ['insertion', 'transfer', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Correct the sentence ending and capital letter.',
+      stem: 'the lights went out',
+      model: 'The lights went out.',
+      misconceptionTags: ['endmarks.terminal_missing', 'endmarks.capitalisation_missing'],
+      readiness: ['proofreading', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Add the capital letter and the calm command ending.',
+      stem: 'please close the safety gate',
+      model: 'Please close the safety gate.',
+      misconceptionTags: ['endmarks.terminal_missing', 'endmarks.capitalisation_missing'],
+      readiness: ['insertion', 'misconception', 'negative_test'],
+    },
   ]),
   gen_apostrophe_contractions_fix: Object.freeze([
     {
@@ -158,6 +202,34 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
       model: "You're sure he isn't coming.",
       misconceptionTags: ['apostrophe.contraction_missing'],
       readiness: ['proofreading', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Correct the missing apostrophes in the contractions.',
+      stem: 'We havent checked because the phones arent working.',
+      model: "We haven't checked because the phones aren't working.",
+      misconceptionTags: ['apostrophe.contraction_missing'],
+      readiness: ['proofreading', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Fix only the contraction apostrophes.',
+      stem: 'Itll be easier if youre ready.',
+      model: "It'll be easier if you're ready.",
+      misconceptionTags: ['apostrophe.contraction_missing'],
+      readiness: ['proofreading', 'transfer', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Proofread the sentence and repair the contractions.',
+      stem: 'They didnt know we couldnt see.',
+      model: "They didn't know we couldn't see.",
+      misconceptionTags: ['apostrophe.contraction_missing'],
+      readiness: ['proofreading', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Rewrite with standard contraction punctuation.',
+      stem: 'Shes sure it doesnt matter.',
+      model: "She's sure it doesn't matter.",
+      misconceptionTags: ['apostrophe.contraction_missing'],
+      readiness: ['proofreading', 'transfer', 'misconception', 'negative_test'],
     },
   ]),
   gen_apostrophe_possession_insert: Object.freeze([
@@ -681,6 +753,50 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
       misconceptionTags: ['comma.clarity_missing'],
       readiness: ['insertion', 'misconception', 'negative_test'],
     },
+    {
+      prompt: 'Add the comma after the opening phrase to avoid a misread.',
+      stem: 'After the final whistle the crowd cheered.',
+      model: 'After the final whistle, the crowd cheered.',
+      validator: {
+        type: 'startsWithPhraseComma',
+        phrase: 'After the final whistle',
+      },
+      misconceptionTags: ['comma.clarity_missing'],
+      readiness: ['insertion', 'transfer', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Correct the missing clarity comma.',
+      stem: 'If the alarm sounds the class will line up.',
+      model: 'If the alarm sounds, the class will line up.',
+      validator: {
+        type: 'startsWithPhraseComma',
+        phrase: 'If the alarm sounds',
+      },
+      misconceptionTags: ['comma.clarity_missing'],
+      readiness: ['proofreading', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Rewrite with the clarity comma in the right place.',
+      stem: 'Near the old bridge the lane narrows.',
+      model: 'Near the old bridge, the lane narrows.',
+      validator: {
+        type: 'startsWithPhraseComma',
+        phrase: 'Near the old bridge',
+      },
+      misconceptionTags: ['comma.clarity_missing'],
+      readiness: ['insertion', 'transfer', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Add the comma that separates the opening clause from the main clause.',
+      stem: 'Because the path flooded the cyclists turned back.',
+      model: 'Because the path flooded, the cyclists turned back.',
+      validator: {
+        type: 'startsWithPhraseComma',
+        phrase: 'Because the path flooded',
+      },
+      misconceptionTags: ['comma.clarity_missing'],
+      readiness: ['insertion', 'misconception', 'negative_test'],
+    },
   ]),
   gen_semicolon_fix: Object.freeze([
     {
@@ -957,6 +1073,58 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
       misconceptionTags: ['boundary.dash_missing'],
       readiness: ['proofreading', 'misconception', 'negative_test'],
     },
+    {
+      prompt: 'Add a dash to mark the sudden shift.',
+      stem: 'The waves grew louder we stepped back.',
+      model: 'The waves grew louder – we stepped back.',
+      validator: {
+        type: 'requiresBoundaryBetweenClauses',
+        left: 'The waves grew louder',
+        right: 'we stepped back',
+        mark: '-',
+      },
+      misconceptionTags: ['boundary.dash_missing'],
+      readiness: ['proofreading', 'transfer', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Replace the run-on join with a dash.',
+      stem: 'The door opened nobody spoke.',
+      model: 'The door opened – nobody spoke.',
+      validator: {
+        type: 'requiresBoundaryBetweenClauses',
+        left: 'The door opened',
+        right: 'nobody spoke',
+        mark: '-',
+      },
+      misconceptionTags: ['boundary.dash_missing'],
+      readiness: ['proofreading', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Use a dash to connect the surprise.',
+      stem: 'The signal vanished the team waited.',
+      model: 'The signal vanished – the team waited.',
+      validator: {
+        type: 'requiresBoundaryBetweenClauses',
+        left: 'The signal vanished',
+        right: 'the team waited',
+        mark: '-',
+      },
+      misconceptionTags: ['boundary.dash_missing'],
+      readiness: ['proofreading', 'transfer', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Add the dash between the two related ideas.',
+      stem: 'The path ended we climbed over the stile.',
+      model: 'The path ended – we climbed over the stile.',
+      validator: {
+        type: 'requiresBoundaryBetweenClauses',
+        left: 'The path ended',
+        right: 'we climbed over the stile',
+        mark: '-',
+      },
+      misconceptionTags: ['boundary.dash_missing'],
+      readiness: ['proofreading', 'misconception', 'negative_test'],
+    },
   ]),
   gen_dash_clause_combine: Object.freeze([
     {
@@ -1011,6 +1179,58 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
       misconceptionTags: ['boundary.dash_missing'],
       readiness: ['constrained_transfer', 'misconception', 'negative_test'],
     },
+    {
+      prompt: 'Combine the sudden shift into one sentence with a dash.',
+      stem: 'The waves grew louder.\nWe stepped back.',
+      model: 'The waves grew louder – we stepped back.',
+      validator: {
+        type: 'combineBoundaryBetweenClauses',
+        left: 'The waves grew louder',
+        right: 'we stepped back',
+        mark: '-',
+      },
+      misconceptionTags: ['boundary.dash_missing'],
+      readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Join the surprise with a dash.',
+      stem: 'The door opened.\nNobody spoke.',
+      model: 'The door opened – nobody spoke.',
+      validator: {
+        type: 'combineBoundaryBetweenClauses',
+        left: 'The door opened',
+        right: 'nobody spoke',
+        mark: '-',
+      },
+      misconceptionTags: ['boundary.dash_missing'],
+      readiness: ['constrained_transfer', 'transfer', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Use one dash to combine the clauses.',
+      stem: 'The signal vanished.\nThe team waited.',
+      model: 'The signal vanished – the team waited.',
+      validator: {
+        type: 'combineBoundaryBetweenClauses',
+        left: 'The signal vanished',
+        right: 'the team waited',
+        mark: '-',
+      },
+      misconceptionTags: ['boundary.dash_missing'],
+      readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Combine the two ideas with a dash.',
+      stem: 'The path ended.\nWe climbed over the stile.',
+      model: 'The path ended – we climbed over the stile.',
+      validator: {
+        type: 'combineBoundaryBetweenClauses',
+        left: 'The path ended',
+        right: 'we climbed over the stile',
+        mark: '-',
+      },
+      misconceptionTags: ['boundary.dash_missing'],
+      readiness: ['constrained_transfer', 'transfer', 'misconception', 'negative_test'],
+    },
   ]),
   gen_hyphen_insert: Object.freeze([
     {
@@ -1056,6 +1276,50 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
       },
       misconceptionTags: ['boundary.hyphen_missing'],
       readiness: ['insertion', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Add the hyphen that avoids ambiguity.',
+      stem: 'The sugar free snack was popular.',
+      model: 'The sugar-free snack was popular.',
+      validator: {
+        type: 'requiresHyphenatedPhrase',
+        phrase: 'sugar-free snack',
+      },
+      misconceptionTags: ['boundary.hyphen_missing'],
+      readiness: ['insertion', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Rewrite the age phrase with the needed hyphens.',
+      stem: 'The ten year old pupil read aloud.',
+      model: 'The ten-year-old pupil read aloud.',
+      validator: {
+        type: 'requiresHyphenatedPhrase',
+        phrase: 'ten-year-old pupil',
+      },
+      misconceptionTags: ['boundary.hyphen_missing'],
+      readiness: ['insertion', 'transfer', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Add the hyphen to clarify the compound modifier.',
+      stem: 'The last minute change surprised us.',
+      model: 'The last-minute change surprised us.',
+      validator: {
+        type: 'requiresHyphenatedPhrase',
+        phrase: 'last-minute change',
+      },
+      misconceptionTags: ['boundary.hyphen_missing'],
+      readiness: ['insertion', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Fix the compound adjective before the noun.',
+      stem: 'The short term plan worked.',
+      model: 'The short-term plan worked.',
+      validator: {
+        type: 'requiresHyphenatedPhrase',
+        phrase: 'short-term plan',
+      },
+      misconceptionTags: ['boundary.hyphen_missing'],
+      readiness: ['proofreading', 'transfer', 'misconception', 'negative_test'],
     },
   ]),
   gen_parenthesis_fix: Object.freeze([
@@ -1421,6 +1685,50 @@ const GENERATED_TEMPLATE_BANK = Object.freeze({
       misconceptionTags: ['structure.semicolon_list_missing'],
       readiness: ['proofreading', 'misconception', 'negative_test'],
     },
+    {
+      prompt: 'Use semi-colons to separate the complex list items.',
+      stem: 'The survey covered Cardiff, Wales, Belfast, Northern Ireland and Truro, Cornwall.',
+      model: 'The survey covered Cardiff, Wales; Belfast, Northern Ireland; and Truro, Cornwall.',
+      validator: {
+        type: 'requiresSemicolonList',
+        items: ['Cardiff, Wales', 'Belfast, Northern Ireland', 'Truro, Cornwall'],
+      },
+      misconceptionTags: ['structure.semicolon_list_missing'],
+      readiness: ['proofreading', 'transfer', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Correct the separators in the complex list.',
+      stem: 'The teams were Falcons, Year 5, Otters, Year 6 and Kites, Year 4.',
+      model: 'The teams were Falcons, Year 5; Otters, Year 6; and Kites, Year 4.',
+      validator: {
+        type: 'requiresSemicolonList',
+        items: ['Falcons, Year 5', 'Otters, Year 6', 'Kites, Year 4'],
+      },
+      misconceptionTags: ['structure.semicolon_list_missing'],
+      readiness: ['proofreading', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Rewrite the complex list with semi-colons between the larger items.',
+      stem: 'The boxes contained shells, blue, pebbles, grey and glass, green.',
+      model: 'The boxes contained shells, blue; pebbles, grey; and glass, green.',
+      validator: {
+        type: 'requiresSemicolonList',
+        items: ['shells, blue', 'pebbles, grey', 'glass, green'],
+      },
+      misconceptionTags: ['structure.semicolon_list_missing'],
+      readiness: ['proofreading', 'transfer', 'misconception', 'negative_test'],
+    },
+    {
+      prompt: 'Add semi-colons so each complex list item stays clear.',
+      stem: 'The route stopped at Exeter, station one, Bristol, station two and Reading, station three.',
+      model: 'The route stopped at Exeter, station one; Bristol, station two; and Reading, station three.',
+      validator: {
+        type: 'requiresSemicolonList',
+        items: ['Exeter, station one', 'Bristol, station two', 'Reading, station three'],
+      },
+      misconceptionTags: ['structure.semicolon_list_missing'],
+      readiness: ['proofreading', 'misconception', 'negative_test'],
+    },
   ]),
   gen_bullet_points_fix: Object.freeze([
     {
@@ -1616,7 +1924,8 @@ export function createPunctuationGeneratedItems({
     if (!skill || !templates.length) continue;
     for (let index = 0; index < limit; index += 1) {
       const picked = pickTemplate(templates, seed, family.id, index, {
-        legacyTemplateCount: contextTemplates.length ? templates.length : 2,
+        legacyTemplateCount: contextTemplates.length ? 1 : 2,
+        runtimeStableTemplateCount: contextTemplates.length ? templates.length : 4,
       });
       if (!picked?.template) continue;
       items.push(buildGeneratedItem({

--- a/tests/punctuation-ai-context-pack.test.js
+++ b/tests/punctuation-ai-context-pack.test.js
@@ -108,9 +108,23 @@ test('context-pack generated items still pass deterministic marking', () => {
   assert.match(generatedText, /Before sunrise/);
   assert.match(generatedText, /Before sunrise, the harbour was quiet/);
   assert.match(generatedText, /The crew checked the ropes; we found another path/);
-  assert.match(generatedText, /The crew checked the ropes - we found another path/);
+  assert.match(generatedText, /The crew checked the ropes – we found another path/);
   assert.match(generatedText, /The harbour, our meeting place, was busy/);
   assert.match(generatedText, /well-known author/);
+  const dashItems = generatedItems.filter((item) => item.generatorFamilyId.startsWith('gen_dash_clause_'));
+  assert.equal(dashItems.length, 2);
+  for (const item of dashItems) {
+    assert.match(item.model, /\s–\s/, item.id);
+    assert.doesNotMatch(item.model, /\s-\s/, item.id);
+    for (const typed of [
+      item.model.replace(' – ', ' - '),
+      item.model,
+      item.model.replace(' – ', ' — '),
+    ]) {
+      const result = markPunctuationAnswer({ item, answer: { typed } });
+      assert.equal(result.correct, true, `${item.id}: ${typed}`);
+    }
+  }
   for (const item of generatedItems) {
     const result = markPunctuationAnswer({ item, answer: { typed: item.model } });
     assert.equal(result.correct, true, item.id);

--- a/tests/punctuation-ai-context-pack.test.js
+++ b/tests/punctuation-ai-context-pack.test.js
@@ -26,6 +26,26 @@ const VALID_CONTEXT_PACK = Object.freeze({
   ],
 });
 
+const VARIANT_CONTEXT_PACK = Object.freeze({
+  names: ['Maya', 'Ravi'],
+  places: ['harbour', 'library'],
+  listNouns: ['ropes', 'maps', 'snacks', 'shells', 'bells', 'chalk'],
+  frontedAdverbialPhrases: ['before sunrise', 'after lunch'],
+  speechCommands: ['bring the rope', 'close the gate'],
+  speechQuestions: ['can we start now', 'where is the map'],
+  parenthesisPhrases: ['our meeting place', 'the quiet room'],
+  stems: [
+    'the crew checked the ropes',
+    'we found another path',
+    'the class packed the kit',
+    'the bus arrived early',
+  ],
+  hyphenCompoundRows: [
+    { left: 'well', right: 'known', noun: 'author' },
+    { left: 'fast', right: 'moving', noun: 'tide' },
+  ],
+});
+
 test('punctuation context-pack compiler sanitises atoms deterministically', () => {
   const result = normalisePunctuationContextPack({
     ...VALID_CONTEXT_PACK,
@@ -95,6 +115,42 @@ test('context-pack generated items still pass deterministic marking', () => {
     const result = markPunctuationAnswer({ item, answer: { typed: item.model } });
     assert.equal(result.correct, true, item.id);
   }
+});
+
+test('context-pack variants keep stable signatures while safe atoms vary', () => {
+  const contextPack = normalisePunctuationContextPack(VARIANT_CONTEXT_PACK);
+  const first = createPunctuationGeneratedItems({
+    seed: 'context-pack-variant-capacity',
+    perFamily: 2,
+    contextPack,
+  }).filter((item) => contextPack.summary.affectedGeneratorFamilies.includes(item.generatorFamilyId));
+  const second = createPunctuationGeneratedItems({
+    seed: 'context-pack-variant-capacity',
+    perFamily: 2,
+    contextPack,
+  }).filter((item) => contextPack.summary.affectedGeneratorFamilies.includes(item.generatorFamilyId));
+
+  assert.deepEqual(second, first);
+  assert.equal(first.length, contextPack.summary.affectedGeneratorFamilies.length * 2);
+
+  for (const familyId of contextPack.summary.affectedGeneratorFamilies) {
+    const familyItems = first.filter((item) => item.generatorFamilyId === familyId);
+    assert.equal(familyItems.length, 2, familyId);
+    assert.equal(new Set(familyItems.map((item) => item.templateId)).size, 2, familyId);
+    assert.equal(new Set(familyItems.map((item) => item.variantSignature)).size, 2, familyId);
+    for (const item of familyItems) {
+      const result = markPunctuationAnswer({ item, answer: { typed: item.model } });
+      assert.equal(result.correct, true, item.id);
+    }
+  }
+
+  const generatedText = first.map((item) => `${item.stem}\n${item.model}`).join('\n');
+  assert.match(generatedText, /ropes, maps and snacks/);
+  assert.match(generatedText, /shells, bells and chalk/);
+  assert.match(generatedText, /The crew checked the ropes; we found another path/);
+  assert.match(generatedText, /The class packed the kit; the bus arrived early/);
+  assert.match(generatedText, /well-known author/);
+  assert.match(generatedText, /fast-moving tide/);
 });
 
 test('context-pack runtime manifest keeps reward denominators stable', () => {

--- a/tests/punctuation-content-audit.test.js
+++ b/tests/punctuation-content-audit.test.js
@@ -25,6 +25,16 @@ const P2_U3_FIXED_THRESHOLDS = Object.freeze({
   dash_clause: 8,
 });
 
+const P2_U6_PRIORITY_CAPACITY_FAMILIES = Object.freeze([
+  'gen_sentence_endings_insert',
+  'gen_apostrophe_contractions_fix',
+  'gen_comma_clarity_insert',
+  'gen_dash_clause_fix',
+  'gen_dash_clause_combine',
+  'gen_hyphen_insert',
+  'gen_semicolon_list_fix',
+]);
+
 function fixedThresholdArg(thresholds = P2_U3_FIXED_THRESHOLDS) {
   return Object.entries(thresholds)
     .map(([skillId, count]) => `${skillId}=${count}`)
@@ -123,6 +133,40 @@ test('punctuation content audit can prove expanded deterministic bank variety', 
     assert.equal(row.generatedItemCount, 4, row.id);
     assert.equal(row.variantSignatures.length, 4, row.id);
     assert.equal(row.templateIds.length, 4, row.id);
+  }
+});
+
+test('punctuation content audit proves spare priority capacity without raising production runtime', () => {
+  const capacityThresholds = Object.fromEntries(P2_U6_PRIORITY_CAPACITY_FAMILIES.map((familyId) => [familyId, 8]));
+  const productionAudit = runPunctuationContentAudit({
+    seed: 'audit-p2-u6-production-runtime',
+    generatedPerFamily: 4,
+  });
+  const capacityAudit = runPunctuationContentAudit({
+    seed: 'audit-p2-u6-priority-capacity',
+    generatedPerFamily: 8,
+    thresholds: {
+      minGeneratedItemsByFamily: capacityThresholds,
+      minTemplatesByFamily: capacityThresholds,
+      minSignaturesByFamily: capacityThresholds,
+    },
+  });
+
+  assert.equal(productionAudit.ok, true, productionAudit.failures.join('\n'));
+  assert.equal(productionAudit.summary.generatedItemCount, 100);
+  assert.equal(productionAudit.summary.runtimeItemCount, 192);
+  assert.equal(capacityAudit.ok, true, capacityAudit.failures.join('\n'));
+  assert.deepEqual(
+    capacityAudit.failureDetails.filter((failure) => failure.code === 'generated_model_marking'),
+    [],
+  );
+  assert.equal(capacityAudit.summary.generatedItemCount, 200);
+  assert.equal(capacityAudit.summary.runtimeItemCount, 292);
+  for (const familyId of P2_U6_PRIORITY_CAPACITY_FAMILIES) {
+    const row = capacityAudit.generatorFamilies.find((entry) => entry.id === familyId);
+    assert.equal(row.generatedItemCount, 8, familyId);
+    assert.equal(row.templateIds.length, 8, familyId);
+    assert.equal(row.variantSignatures.length, 8, familyId);
   }
 });
 

--- a/tests/punctuation-content-audit.test.js
+++ b/tests/punctuation-content-audit.test.js
@@ -35,10 +35,128 @@ const P2_U6_PRIORITY_CAPACITY_FAMILIES = Object.freeze([
   'gen_semicolon_list_fix',
 ]);
 
+const P2_U6_PRIORITY_CAPACITY_FAMILY_IDS = new Set(P2_U6_PRIORITY_CAPACITY_FAMILIES);
+
+const P2_U6_EXPECTED_CAPACITY_DUPLICATE_RESIDUALS = Object.freeze({
+  stems: {
+    groupCount: 35,
+    priorityGroupCount: 0,
+    priorityFamilies: [],
+    familyGroupCounts: {
+      gen_apostrophe_mix_paragraph: 2,
+      gen_apostrophe_possession_insert: 2,
+      gen_bullet_points_fix: 2,
+      gen_bullet_points_paragraph: 2,
+      gen_colon_list_combine: 2,
+      gen_colon_list_insert: 2,
+      gen_colon_semicolon_paragraph: 2,
+      gen_fronted_adverbial_combine: 3,
+      gen_fronted_adverbial_fix: 3,
+      gen_fronted_speech_paragraph: 2,
+      gen_list_commas_combine: 2,
+      gen_list_commas_insert: 2,
+      gen_parenthesis_combine: 2,
+      gen_parenthesis_fix: 2,
+      gen_parenthesis_speech_paragraph: 2,
+      gen_semicolon_combine: 2,
+      gen_semicolon_fix: 2,
+      gen_speech_insert: 2,
+    },
+  },
+  models: {
+    groupCount: 34,
+    priorityGroupCount: 8,
+    priorityFamilies: [
+      'gen_dash_clause_combine',
+      'gen_dash_clause_fix',
+    ],
+    familyGroupCounts: {
+      gen_apostrophe_mix_paragraph: 2,
+      gen_apostrophe_possession_insert: 2,
+      gen_bullet_points_fix: 3,
+      gen_bullet_points_paragraph: 3,
+      gen_colon_list_combine: 4,
+      gen_colon_list_insert: 4,
+      gen_colon_semicolon_paragraph: 2,
+      gen_fronted_adverbial_combine: 3,
+      gen_fronted_adverbial_fix: 3,
+      gen_fronted_speech_paragraph: 2,
+      gen_list_commas_combine: 2,
+      gen_list_commas_insert: 2,
+      gen_parenthesis_combine: 4,
+      gen_parenthesis_fix: 4,
+      gen_parenthesis_speech_paragraph: 2,
+      gen_semicolon_combine: 4,
+      gen_semicolon_fix: 4,
+      gen_speech_insert: 2,
+    },
+  },
+  signatures: {
+    groupCount: 36,
+    priorityGroupCount: 0,
+    priorityFamilies: [],
+    familyGroupCounts: {
+      gen_apostrophe_mix_paragraph: 2,
+      gen_apostrophe_possession_insert: 2,
+      gen_bullet_points_fix: 2,
+      gen_bullet_points_paragraph: 2,
+      gen_colon_list_combine: 2,
+      gen_colon_list_insert: 2,
+      gen_colon_semicolon_paragraph: 2,
+      gen_fronted_adverbial_combine: 2,
+      gen_fronted_adverbial_fix: 2,
+      gen_fronted_speech_paragraph: 2,
+      gen_list_commas_combine: 2,
+      gen_list_commas_insert: 2,
+      gen_parenthesis_combine: 2,
+      gen_parenthesis_fix: 2,
+      gen_parenthesis_speech_paragraph: 2,
+      gen_semicolon_combine: 2,
+      gen_semicolon_fix: 2,
+      gen_speech_insert: 2,
+    },
+  },
+});
+
 function fixedThresholdArg(thresholds = P2_U3_FIXED_THRESHOLDS) {
   return Object.entries(thresholds)
     .map(([skillId, count]) => `${skillId}=${count}`)
     .join(',');
+}
+
+function generatedFamilyIdFromItemId(id) {
+  return String(id || '').replace(/_[a-z0-9]+_\d+$/, '');
+}
+
+function capacityDuplicateResidualSummary(groups = []) {
+  const familyGroupCounts = {};
+  const priorityFamilies = new Set();
+  let groupCount = 0;
+  let priorityGroupCount = 0;
+
+  for (const group of groups) {
+    const families = [...new Set((group.ids || []).map(generatedFamilyIdFromItemId))].sort();
+    const nonPriorityFamilies = families.filter((familyId) => !P2_U6_PRIORITY_CAPACITY_FAMILY_IDS.has(familyId));
+    const groupPriorityFamilies = families.filter((familyId) => P2_U6_PRIORITY_CAPACITY_FAMILY_IDS.has(familyId));
+
+    if (nonPriorityFamilies.length) {
+      groupCount += 1;
+      for (const familyId of nonPriorityFamilies) {
+        familyGroupCounts[familyId] = (familyGroupCounts[familyId] || 0) + 1;
+      }
+    }
+    if (groupPriorityFamilies.length) {
+      priorityGroupCount += 1;
+      for (const familyId of groupPriorityFamilies) priorityFamilies.add(familyId);
+    }
+  }
+
+  return {
+    groupCount,
+    priorityGroupCount,
+    priorityFamilies: [...priorityFamilies].sort(),
+    familyGroupCounts: Object.fromEntries(Object.entries(familyGroupCounts).sort()),
+  };
 }
 
 function runAuditCli(args) {
@@ -168,6 +286,23 @@ test('punctuation content audit proves spare priority capacity without raising p
     assert.equal(row.templateIds.length, 8, familyId);
     assert.equal(row.variantSignatures.length, 8, familyId);
   }
+});
+
+test('punctuation content audit guards expected capacity duplicate residuals', () => {
+  const capacityAudit = runPunctuationContentAudit({
+    seed: 'audit-p2-u6-priority-capacity',
+    generatedPerFamily: 8,
+  });
+  const duplicateResiduals = Object.fromEntries(
+    Object.entries(capacityAudit.duplicates.generated)
+      .map(([kind, groups]) => [kind, capacityDuplicateResidualSummary(groups)]),
+  );
+
+  assert.equal(capacityAudit.ok, true, capacityAudit.failures.join('\n'));
+  assert.deepEqual(
+    duplicateResiduals,
+    P2_U6_EXPECTED_CAPACITY_DUPLICATE_RESIDUALS,
+  );
 });
 
 test('punctuation content audit guards dash display and strict final-comma copy', () => {

--- a/tests/punctuation-generators.test.js
+++ b/tests/punctuation-generators.test.js
@@ -215,6 +215,61 @@ const LEGACY_RUNTIME_GENERATED_FIXTURE = Object.freeze([
   },
 ]);
 
+const P2_PRIORITY_CAPACITY_FAMILIES = Object.freeze([
+  'gen_sentence_endings_insert',
+  'gen_apostrophe_contractions_fix',
+  'gen_comma_clarity_insert',
+  'gen_dash_clause_fix',
+  'gen_dash_clause_combine',
+  'gen_hyphen_insert',
+  'gen_semicolon_list_fix',
+]);
+
+const P2_RELEASE_PRIORITY_RUNTIME_FOUR = Object.freeze({
+  gen_sentence_endings_insert: [
+    ['gen_sentence_endings_insert_template_ojehq4', 'puncsig_16hqza'],
+    ['gen_sentence_endings_insert_template_xsusve', 'puncsig_rqywyf'],
+    ['gen_sentence_endings_insert_template_fce7xq', 'puncsig_1uxeibz'],
+    ['gen_sentence_endings_insert_template_1030eck', 'puncsig_1et5kmk'],
+  ],
+  gen_apostrophe_contractions_fix: [
+    ['gen_apostrophe_contractions_fix_template_1x2iyq1', 'puncsig_7ipffv'],
+    ['gen_apostrophe_contractions_fix_template_vcqv1j', 'puncsig_1l2jy9t'],
+    ['gen_apostrophe_contractions_fix_template_1bwdvbz', 'puncsig_1ny1ioc'],
+    ['gen_apostrophe_contractions_fix_template_zq96k9', 'puncsig_irs7ic'],
+  ],
+  gen_comma_clarity_insert: [
+    ['gen_comma_clarity_insert_template_410pln', 'puncsig_m24dve'],
+    ['gen_comma_clarity_insert_template_i1jwnt', 'puncsig_1czkw5m'],
+    ['gen_comma_clarity_insert_template_1iru80y', 'puncsig_1yp62hb'],
+    ['gen_comma_clarity_insert_template_2c385o', 'puncsig_1g84wrh'],
+  ],
+  gen_dash_clause_fix: [
+    ['gen_dash_clause_fix_template_172ndjv', 'puncsig_ynmwrz'],
+    ['gen_dash_clause_fix_template_11ejvfc', 'puncsig_erog6d'],
+    ['gen_dash_clause_fix_template_1h1bmqa', 'puncsig_0gz5fc'],
+    ['gen_dash_clause_fix_template_1jrdtf5', 'puncsig_7hfpqd'],
+  ],
+  gen_dash_clause_combine: [
+    ['gen_dash_clause_combine_template_1y5wkx', 'puncsig_cntndu'],
+    ['gen_dash_clause_combine_template_1o45ea6', 'puncsig_5qqk8w'],
+    ['gen_dash_clause_combine_template_1l9y3bg', 'puncsig_16braa6'],
+    ['gen_dash_clause_combine_template_128nltn', 'puncsig_lin61y'],
+  ],
+  gen_hyphen_insert: [
+    ['gen_hyphen_insert_template_1sq39kj', 'puncsig_jymsjm'],
+    ['gen_hyphen_insert_template_1cjtd6l', 'puncsig_1lmq2gq'],
+    ['gen_hyphen_insert_template_9wwl7p', 'puncsig_043436'],
+    ['gen_hyphen_insert_template_1s9zvda', 'puncsig_1bp2lu0'],
+  ],
+  gen_semicolon_list_fix: [
+    ['gen_semicolon_list_fix_template_im9cuv', 'puncsig_16xjpox'],
+    ['gen_semicolon_list_fix_template_zurnf7', 'puncsig_1gq3mzq'],
+    ['gen_semicolon_list_fix_template_1ssfry4', 'puncsig_plkjc8'],
+    ['gen_semicolon_list_fix_template_u5ri7n', 'puncsig_j0zb2u'],
+  ],
+});
+
 test('generated punctuation items are deterministic, unique, and family-scoped', () => {
   const first = createPunctuationGeneratedItems({ seed: 'release-a', perFamily: 2 });
   const second = createPunctuationGeneratedItems({ seed: 'release-a', perFamily: 2 });
@@ -257,31 +312,46 @@ test('generated punctuation signatures detect duplicate learner-visible surfaces
   assert.equal(clone.variantSignature, items[0].variantSignature);
 });
 
-test('expanded generated banks add distinct signatures after legacy variants', () => {
-  const targetFamilies = [
-    'gen_sentence_endings_insert',
-    'gen_apostrophe_contractions_fix',
-    'gen_comma_clarity_insert',
-    'gen_dash_clause_fix',
-    'gen_dash_clause_combine',
-    'gen_hyphen_insert',
-    'gen_semicolon_list_fix',
-  ];
-  const items = createPunctuationGeneratedItems({ seed: 'expanded-bank', perFamily: 4 });
+test('expanded priority generated banks add spare distinct capacity after runtime variants', () => {
+  const items = createPunctuationGeneratedItems({ seed: 'expanded-bank', perFamily: 8 });
 
-  for (const familyId of targetFamilies) {
+  for (const familyId of P2_PRIORITY_CAPACITY_FAMILIES) {
     const familyItems = items.filter((item) => item.generatorFamilyId === familyId);
-    assert.equal(familyItems.length, 4, familyId);
-    assert.equal(new Set(familyItems.map((item) => item.variantSignature)).size, 4, familyId);
-    assert.equal(new Set(familyItems.map((item) => item.templateId)).size, 4, familyId);
+    assert.equal(familyItems.length, 8, familyId);
+    assert.equal(new Set(familyItems.map((item) => item.variantSignature)).size, 8, familyId);
+    assert.equal(new Set(familyItems.map((item) => item.templateId)).size, 8, familyId);
   }
 });
 
 test('generated punctuation model answers pass deterministic marking', () => {
-  const generatedItems = createPunctuationGeneratedItems({ seed: 'marking-smoke', perFamily: 4 });
+  const generatedItems = createPunctuationGeneratedItems({ seed: 'marking-smoke', perFamily: 8 });
   for (const item of generatedItems) {
     const result = markPunctuationAnswer({ item, answer: { typed: item.model } });
     assert.equal(result.correct, true, item.id);
+  }
+});
+
+test('priority capacity expansion preserves production four-variant generated surfaces', () => {
+  const generatedItems = createPunctuationGeneratedItems({
+    seed: PUNCTUATION_CONTENT_MANIFEST.releaseId,
+    perFamily: 4,
+  });
+  const generatedRuntime = generatedItems.filter((item) => item.source === 'generated');
+  const runtimeManifest = createPunctuationRuntimeManifest({
+    seed: PUNCTUATION_CONTENT_MANIFEST.releaseId,
+    generatedPerFamily: 4,
+  });
+  const runtimeIndexes = createPunctuationContentIndexes(runtimeManifest);
+
+  assert.equal(generatedRuntime.length, 100);
+  assert.equal(runtimeIndexes.items.length, 192);
+  assert.equal(runtimeIndexes.items.filter((item) => item.source === 'generated').length, 100);
+
+  for (const [familyId, expected] of Object.entries(P2_RELEASE_PRIORITY_RUNTIME_FOUR)) {
+    const actual = generatedItems
+      .filter((item) => item.generatorFamilyId === familyId)
+      .map((item) => [item.templateId, item.variantSignature]);
+    assert.deepEqual(actual, expected, familyId);
   }
 });
 


### PR DESCRIPTION
## Summary
- Expands the P2 priority deterministic generator families to eight distinct template and signature variants each without changing the production `generatedPerFamily` setting.
- Preserves the existing production four-variant generated surfaces by separating the runtime-stable template window from the spare capacity pool.
- Adds safe context-pack variant capacity when multiple sanitised atoms are available, with deterministic signatures and model answers derived from the same slots as validators.
- Addresses review follow-up by rendering context-pack dash model answers with spaced en dashes while keeping permissive dash validators, and by pinning expected capacity-mode duplicate residuals in tests.

## Verification
- `node scripts/worktree-setup.mjs` (`node_modules already present — skipping.`)
- `npm test -- tests/punctuation-generators.test.js tests/punctuation-ai-context-pack.test.js tests/punctuation-content-audit.test.js` (35 tests passed)
- `npm run audit:punctuation-content -- --strict --generated-per-family 4 --min-fixed-items-by-skill sentence_endings=8,apostrophe_contractions=8,comma_clarity=8,semicolon_list=8,hyphen=8,dash_clause=8`
- `npm run audit:punctuation-content -- --generated-per-family 8 --min-generated-by-family gen_sentence_endings_insert=8,gen_apostrophe_contractions_fix=8,gen_comma_clarity_insert=8,gen_dash_clause_fix=8,gen_dash_clause_combine=8,gen_hyphen_insert=8,gen_semicolon_list_fix=8 --min-templates-by-family gen_sentence_endings_insert=8,gen_apostrophe_contractions_fix=8,gen_comma_clarity_insert=8,gen_dash_clause_fix=8,gen_dash_clause_combine=8,gen_hyphen_insert=8,gen_semicolon_list_fix=8 --min-signatures-by-family gen_sentence_endings_insert=8,gen_apostrophe_contractions_fix=8,gen_comma_clarity_insert=8,gen_dash_clause_fix=8,gen_dash_clause_combine=8,gen_hyphen_insert=8,gen_semicolon_list_fix=8`
- `npm test` (5873 tests: 5867 passed, 6 skipped, 0 failed)
- `npm run check`
- `git diff --check`

## Generated and Runtime Counts
- Production audit: `generatedPerFamily=4`, generated items `100`, runtime items `192`, published reward units `14`, generated duplicate signatures `0`.
- Capacity audit: `generatedPerFamily=8`, generated items `200`, runtime items `292`, generated duplicate signatures/stems/models `36`/`35`/`42` in audit-only mode.
- Expected capacity duplicate residuals are machine-guarded in `tests/punctuation-content-audit.test.js`: non-priority duplicate groups are stems `35`, models `34`, signatures `36`; the remaining `8` duplicate model groups are the paired priority dash fix/combine display models.
- Priority capacity achieved: `gen_sentence_endings_insert`, `gen_apostrophe_contractions_fix`, `gen_comma_clarity_insert`, `gen_dash_clause_fix`, `gen_dash_clause_combine`, `gen_hyphen_insert`, and `gen_semicolon_list_fix` each produce 8 generated items, 8 distinct templates, and 8 distinct variant signatures.

## Post-Deploy Monitoring & Validation
- After deployment, confirm the production Punctuation runtime still reports generated items `100`, runtime items `192`, and published reward units `14`.
- Watch the dedicated Punctuation content-audit workflow for duplicate generated signatures and generated model-answer marking failures.
- In production smoke, confirm generated attempts still carry opaque active-item `variantSignature` values only and that review/adult evidence remains redacted.

## Residual Risks
- Audit-only `generatedPerFamily=8` still has expected duplicate stems/models/signatures outside the priority U6 capacity target; these are now pinned by an explicit duplicate residual guard so unexpected non-priority growth fails tests.
- The capacity audit still reports 8 duplicate model groups for the priority dash fix/combine pair because both families intentionally share the same child-visible model answers while using distinct signatures and templates.
- Context-pack capacity is intentionally capped at two variants per affected family for now to keep sanitised atom variation conservative.
