### PR TITLE
feat(admin): add action classification and confirmation pattern (P5 U3)

### DIFF
--- a/src/platform/hubs/admin-action-classification.js
+++ b/src/platform/hubs/admin-action-classification.js
@@ -1,0 +1,105 @@
+// Admin Console P5 / U3: Action classification registry.
+//
+// Maps admin action keys to a 4-level severity classification. Each level
+// determines whether the UI must present a confirmation step before dispatch:
+//   - low:      no confirmation required
+//   - medium:   no confirmation required (logged but non-destructive)
+//   - high:     confirmation dialog with danger copy + target display
+//   - critical: typed confirmation (user types target identifier to confirm)
+//
+// Exported:
+//   - LEVELS — frozen set of valid classification levels
+//   - classifyAction(actionKey, context) → classification result
+//
+// This module is pure logic — no React imports. The companion component
+// `AdminConfirmAction.jsx` consumes the classification to render the
+// appropriate confirmation UI.
+
+const LEVELS = Object.freeze({
+  low: 'low',
+  medium: 'medium',
+  high: 'high',
+  critical: 'critical',
+});
+
+// --- Internal registry --------------------------------------------------
+
+const REGISTRY = new Map([
+  // low: read-only refreshes, searches, bundle generation
+  ['admin-ops-kpi-refresh', { level: LEVELS.low }],
+  ['admin-ops-activity-refresh', { level: LEVELS.low }],
+  ['account-search', { level: LEVELS.low }],
+  ['admin-debug-bundle-generate', { level: LEVELS.low }],
+
+  // medium: single-record writes scoped to one entity
+  ['account-ops-metadata-save', { level: LEVELS.medium }],
+  ['marketing-create', { level: LEVELS.medium }],
+  ['admin-section-change', { level: LEVELS.medium }],
+
+  // high: publish/transition actions affecting live content
+  ['marketing-transition-published', { level: LEVELS.high }],
+  ['marketing-transition-scheduled', { level: LEVELS.high }],
+  ['monster-visual-config-publish', { level: LEVELS.high }],
+  ['monster-visual-config-restore', { level: LEVELS.high }],
+  ['grammar-transfer-admin-archive', { level: LEVELS.high }],
+
+  // critical: broad-audience mutations, irreversible deletes, seed operations
+  ['post-mega-seed-apply', { level: LEVELS.critical }],
+  ['grammar-transfer-admin-delete', { level: LEVELS.critical }],
+  ['marketing-transition-all-signed-in-publish', { level: LEVELS.critical }],
+]);
+
+// --- Danger copy templates ----------------------------------------------
+
+const DANGER_COPY = Object.freeze({
+  high: 'This action will modify live content visible to users.',
+  critical: 'This is a destructive operation that cannot be easily reversed.',
+});
+
+// --- Classification logic -----------------------------------------------
+
+/**
+ * Classify an admin action by key and optional context.
+ *
+ * @param {string} actionKey   Registered action identifier.
+ * @param {object} [context]   Optional context: `{ audience, environment, targetId, targetLabel }`.
+ * @returns {{
+ *   level: string,
+ *   requiresConfirmation: boolean,
+ *   requiresTypedTarget: boolean,
+ *   dangerCopy: string | null,
+ *   targetDisplay: string | null,
+ * }}
+ */
+export function classifyAction(actionKey, context) {
+  const ctx = context && typeof context === 'object' ? context : {};
+  const entry = REGISTRY.get(actionKey);
+
+  // Unknown actions default to medium — safe enough to log but not silently
+  // destructive. The caller should validate action keys before reaching this
+  // point; this default prevents an unregistered key from bypassing all gates.
+  const level = entry ? entry.level : LEVELS.medium;
+
+  const requiresConfirmation = level === LEVELS.high || level === LEVELS.critical;
+  const requiresTypedTarget = level === LEVELS.critical;
+
+  const dangerCopy = requiresConfirmation
+    ? (DANGER_COPY[level] || null)
+    : null;
+
+  const targetDisplay = requiresConfirmation && ctx.targetLabel
+    ? String(ctx.targetLabel)
+    : requiresConfirmation && ctx.targetId
+      ? String(ctx.targetId)
+      : null;
+
+  return {
+    level,
+    requiresConfirmation,
+    requiresTypedTarget,
+    dangerCopy,
+    targetDisplay,
+  };
+}
+
+export { LEVELS };

--- a/src/surfaces/hubs/AdminConfirmAction.jsx
+++ b/src/surfaces/hubs/AdminConfirmAction.jsx
@@ -1,0 +1,110 @@
+// Admin Console P5 / U3: Shared confirmation component for high/critical actions.
+//
+// Renders a confirmation dialog appropriate to the action's classification level:
+//   - high:     Confirm/Cancel buttons with danger copy and target display.
+//   - critical: Typed confirmation — user must type a target identifier to
+//               enable the confirm button.
+//
+// Props:
+//   level           — 'high' | 'critical'
+//   dangerCopy      — descriptive warning text
+//   targetDisplay   — human-readable target (e.g. account ID fragment, message title)
+//   typedConfirmValue — the exact string the user must type for critical actions
+//   onConfirm       — async callback fired on confirm
+//   onCancel        — callback fired on cancel
+//
+// Uses `useSubmitLock` to prevent double-click on the confirm button.
+
+import React, { useState } from 'react';
+import { useSubmitLock } from '../../platform/react/use-submit-lock.js';
+
+export function AdminConfirmAction({
+  level,
+  dangerCopy,
+  targetDisplay,
+  typedConfirmValue,
+  onConfirm,
+  onCancel,
+}) {
+  const [typedInput, setTypedInput] = useState('');
+  const { locked, run } = useSubmitLock();
+
+  const isCritical = level === 'critical';
+  const typedMatch = isCritical
+    ? typedInput.trim() === String(typedConfirmValue || '').trim()
+    : true;
+  const confirmDisabled = locked || (isCritical && !typedMatch);
+
+  function handleConfirm() {
+    if (confirmDisabled) return;
+    run(async () => {
+      if (typeof onConfirm === 'function') await onConfirm();
+    });
+  }
+
+  return (
+    <div
+      className="admin-confirm-action"
+      role="alertdialog"
+      aria-labelledby="admin-confirm-title"
+      aria-describedby="admin-confirm-desc"
+      data-level={level}
+    >
+      <h3 id="admin-confirm-title" className="admin-confirm-action__title">
+        {isCritical ? 'Destructive operation' : 'Confirm action'}
+      </h3>
+
+      {dangerCopy && (
+        <p id="admin-confirm-desc" className="admin-confirm-action__danger">
+          {dangerCopy}
+        </p>
+      )}
+
+      {targetDisplay && (
+        <p className="admin-confirm-action__target">
+          Target: <strong>{targetDisplay}</strong>
+        </p>
+      )}
+
+      {isCritical && (
+        <div className="admin-confirm-action__typed-section">
+          <label
+            htmlFor="admin-confirm-typed-input"
+            className="admin-confirm-action__typed-label"
+          >
+            Type <code>{typedConfirmValue}</code> to confirm:
+          </label>
+          <input
+            id="admin-confirm-typed-input"
+            className="admin-confirm-action__typed-input"
+            type="text"
+            autoComplete="off"
+            value={typedInput}
+            onChange={(e) => setTypedInput(e.target.value)}
+            disabled={locked}
+          />
+        </div>
+      )}
+
+      <div className="admin-confirm-action__buttons">
+        <button
+          type="button"
+          className="admin-confirm-action__cancel"
+          onClick={onCancel}
+          disabled={locked}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          className="admin-confirm-action__confirm"
+          onClick={handleConfirm}
+          disabled={confirmDisabled}
+          aria-busy={locked}
+        >
+          {locked ? 'Processing...' : 'Confirm'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/surfaces/hubs/AdminConfirmAction.jsx
+++ b/src/surfaces/hubs/AdminConfirmAction.jsx
@@ -31,7 +31,7 @@ export function AdminConfirmAction({
 
   const isCritical = level === 'critical';
   const typedMatch = isCritical
-    ? typedInput.trim() === String(typedConfirmValue || '').trim()
+    ? (typedConfirmValue && typedInput.trim() === String(typedConfirmValue).trim())
     : true;
   const confirmDisabled = locked || (isCritical && !typedMatch);
 
@@ -47,7 +47,7 @@ export function AdminConfirmAction({
       className="admin-confirm-action"
       role="alertdialog"
       aria-labelledby="admin-confirm-title"
-      aria-describedby="admin-confirm-desc"
+      aria-describedby={dangerCopy ? 'admin-confirm-desc' : undefined}
       data-level={level}
     >
       <h3 id="admin-confirm-title" className="admin-confirm-action__title">
@@ -90,7 +90,7 @@ export function AdminConfirmAction({
         <button
           type="button"
           className="admin-confirm-action__cancel"
-          onClick={onCancel}
+          onClick={typeof onCancel === 'function' ? onCancel : undefined}
           disabled={locked}
         >
           Cancel

--- a/tests/admin-action-classification.test.js
+++ b/tests/admin-action-classification.test.js
@@ -1,0 +1,175 @@
+// Admin Console P5 / U3: classification registry unit tests.
+//
+// Validates that `classifyAction` returns the correct level, confirmation
+// requirements, and danger copy for each registered action key across all
+// four classification tiers (low, medium, high, critical).
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  classifyAction,
+  LEVELS,
+} from '../src/platform/hubs/admin-action-classification.js';
+
+// =================================================================
+// 1. LEVELS object is frozen and contains exactly 4 tiers
+// =================================================================
+
+test('LEVELS contains exactly low, medium, high, critical', () => {
+  assert.deepEqual(Object.keys(LEVELS).sort(), ['critical', 'high', 'low', 'medium']);
+  assert.equal(Object.isFrozen(LEVELS), true);
+});
+
+// =================================================================
+// 2. Low-level actions: no confirmation required
+// =================================================================
+
+const LOW_ACTIONS = [
+  'admin-ops-kpi-refresh',
+  'admin-ops-activity-refresh',
+  'account-search',
+  'admin-debug-bundle-generate',
+];
+
+for (const actionKey of LOW_ACTIONS) {
+  test(`low action "${actionKey}" requires no confirmation`, () => {
+    const result = classifyAction(actionKey);
+    assert.equal(result.level, 'low');
+    assert.equal(result.requiresConfirmation, false);
+    assert.equal(result.requiresTypedTarget, false);
+    assert.equal(result.dangerCopy, null);
+    assert.equal(result.targetDisplay, null);
+  });
+}
+
+// =================================================================
+// 3. Medium-level actions: no confirmation required
+// =================================================================
+
+const MEDIUM_ACTIONS = [
+  'account-ops-metadata-save',
+  'marketing-create',
+  'admin-section-change',
+];
+
+for (const actionKey of MEDIUM_ACTIONS) {
+  test(`medium action "${actionKey}" requires no confirmation`, () => {
+    const result = classifyAction(actionKey);
+    assert.equal(result.level, 'medium');
+    assert.equal(result.requiresConfirmation, false);
+    assert.equal(result.requiresTypedTarget, false);
+    assert.equal(result.dangerCopy, null);
+    assert.equal(result.targetDisplay, null);
+  });
+}
+
+// =================================================================
+// 4. High-level actions: confirmation required, no typed target
+// =================================================================
+
+const HIGH_ACTIONS = [
+  'marketing-transition-published',
+  'marketing-transition-scheduled',
+  'monster-visual-config-publish',
+  'monster-visual-config-restore',
+  'grammar-transfer-admin-archive',
+];
+
+for (const actionKey of HIGH_ACTIONS) {
+  test(`high action "${actionKey}" requires confirmation but not typed target`, () => {
+    const result = classifyAction(actionKey);
+    assert.equal(result.level, 'high');
+    assert.equal(result.requiresConfirmation, true);
+    assert.equal(result.requiresTypedTarget, false);
+    assert.equal(typeof result.dangerCopy, 'string');
+    assert.ok(result.dangerCopy.length > 0);
+  });
+}
+
+// =================================================================
+// 5. Critical-level actions: confirmation + typed target required
+// =================================================================
+
+const CRITICAL_ACTIONS = [
+  'post-mega-seed-apply',
+  'grammar-transfer-admin-delete',
+  'marketing-transition-all-signed-in-publish',
+];
+
+for (const actionKey of CRITICAL_ACTIONS) {
+  test(`critical action "${actionKey}" requires confirmation and typed target`, () => {
+    const result = classifyAction(actionKey);
+    assert.equal(result.level, 'critical');
+    assert.equal(result.requiresConfirmation, true);
+    assert.equal(result.requiresTypedTarget, true);
+    assert.equal(typeof result.dangerCopy, 'string');
+    assert.ok(result.dangerCopy.length > 0);
+  });
+}
+
+// =================================================================
+// 6. Context: targetLabel propagates to targetDisplay
+// =================================================================
+
+test('high action with context.targetLabel populates targetDisplay', () => {
+  const result = classifyAction('monster-visual-config-publish', {
+    targetLabel: 'Monster Visual Config v3',
+  });
+  assert.equal(result.targetDisplay, 'Monster Visual Config v3');
+});
+
+test('critical action with context.targetId populates targetDisplay', () => {
+  const result = classifyAction('grammar-transfer-admin-delete', {
+    targetId: 'concept-fronted-adverbials',
+  });
+  assert.equal(result.targetDisplay, 'concept-fronted-adverbials');
+});
+
+test('targetLabel takes precedence over targetId', () => {
+  const result = classifyAction('post-mega-seed-apply', {
+    targetId: 'seed-123',
+    targetLabel: 'Fresh graduate seed',
+  });
+  assert.equal(result.targetDisplay, 'Fresh graduate seed');
+});
+
+test('low action ignores context — targetDisplay remains null', () => {
+  const result = classifyAction('account-search', {
+    targetLabel: 'should be ignored',
+  });
+  assert.equal(result.targetDisplay, null);
+});
+
+// =================================================================
+// 7. Unknown action key defaults to medium (safe fallback)
+// =================================================================
+
+test('unknown action key defaults to medium classification', () => {
+  const result = classifyAction('totally-unknown-action');
+  assert.equal(result.level, 'medium');
+  assert.equal(result.requiresConfirmation, false);
+  assert.equal(result.requiresTypedTarget, false);
+});
+
+// =================================================================
+// 8. Edge cases: null/undefined context handled gracefully
+// =================================================================
+
+test('null context does not throw', () => {
+  const result = classifyAction('post-mega-seed-apply', null);
+  assert.equal(result.level, 'critical');
+  assert.equal(result.targetDisplay, null);
+});
+
+test('undefined context does not throw', () => {
+  const result = classifyAction('post-mega-seed-apply', undefined);
+  assert.equal(result.level, 'critical');
+  assert.equal(result.targetDisplay, null);
+});
+
+test('non-object context does not throw', () => {
+  const result = classifyAction('post-mega-seed-apply', 42);
+  assert.equal(result.level, 'critical');
+  assert.equal(result.targetDisplay, null);
+});

--- a/tests/react-admin-confirm-action.test.js
+++ b/tests/react-admin-confirm-action.test.js
@@ -1,0 +1,258 @@
+// Admin Console P5 / U3: AdminConfirmAction component tests.
+//
+// Validates the SSR-rendered markup of the confirmation component at each
+// supported level:
+//   - high:     renders confirm dialog with danger copy and target display
+//   - critical: renders typed confirmation input; confirm button disabled
+//               until typed value matches
+//
+// Uses the esbuild + renderToStaticMarkup pattern established by the
+// project's existing React component tests.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+
+const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function findNearestNodeModules(startDir) {
+  let current = startDir;
+  for (let index = 0; index < 12; index += 1) {
+    const candidate = path.join(current, 'node_modules');
+    if (existsSync(candidate)) return candidate;
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  return null;
+}
+
+function nodePaths() {
+  return [
+    path.join(ROOT_DIR, 'node_modules'),
+    findNearestNodeModules(ROOT_DIR),
+    ...String(process.env.NODE_PATH || '').split(path.delimiter),
+  ].filter((entry) => entry && existsSync(entry));
+}
+
+async function renderFixture(entrySource) {
+  const tmpDir = await mkdtemp(path.join(tmpdir(), 'ks2-confirm-action-'));
+  const entryPath = path.join(tmpDir, 'entry.jsx');
+  const bundlePath = path.join(tmpDir, 'entry.cjs');
+  try {
+    await writeFile(entryPath, entrySource);
+    await build({
+      absWorkingDir: ROOT_DIR,
+      entryPoints: [entryPath],
+      outfile: bundlePath,
+      bundle: true,
+      platform: 'node',
+      format: 'cjs',
+      target: ['node24'],
+      jsx: 'automatic',
+      jsxImportSource: 'react',
+      loader: { '.js': 'jsx' },
+      nodePaths: nodePaths(),
+      logLevel: 'silent',
+    });
+    return execFileSync(process.execPath, [bundlePath], {
+      cwd: ROOT_DIR,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+function abs(rel) {
+  return path.join(ROOT_DIR, rel);
+}
+
+// =================================================================
+// 1. High-level: renders confirm dialog with danger copy
+// =================================================================
+
+test('AdminConfirmAction level=high renders confirm dialog with danger copy', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { AdminConfirmAction } from ${JSON.stringify(abs('src/surfaces/hubs/AdminConfirmAction.jsx'))};
+
+    const html = renderToStaticMarkup(
+      <AdminConfirmAction
+        level="high"
+        dangerCopy="This action will modify live content visible to users."
+        targetDisplay="Monster Visual Config v3"
+        onConfirm={async () => {}}
+        onCancel={() => {}}
+      />
+    );
+    console.log(html);
+  `);
+
+  // Must contain the alertdialog role
+  assert.ok(html.includes('role="alertdialog"'), 'missing alertdialog role');
+  // Must display the danger copy
+  assert.ok(html.includes('This action will modify live content visible to users.'), 'missing danger copy');
+  // Must display the target
+  assert.ok(html.includes('Monster Visual Config v3'), 'missing target display');
+  // Must have confirm and cancel buttons
+  assert.ok(html.includes('Confirm'), 'missing confirm button text');
+  assert.ok(html.includes('Cancel'), 'missing cancel button text');
+  // Must NOT have typed input section (high level does not require it)
+  assert.ok(!html.includes('admin-confirm-typed-input'), 'should not render typed input for high level');
+  // data-level attribute
+  assert.ok(html.includes('data-level="high"'), 'missing data-level=high');
+});
+
+// =================================================================
+// 2. Critical-level: renders typed confirmation input
+// =================================================================
+
+test('AdminConfirmAction level=critical renders typed confirmation input', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { AdminConfirmAction } from ${JSON.stringify(abs('src/surfaces/hubs/AdminConfirmAction.jsx'))};
+
+    const html = renderToStaticMarkup(
+      <AdminConfirmAction
+        level="critical"
+        dangerCopy="This is a destructive operation that cannot be easily reversed."
+        targetDisplay="concept-fronted-adverbials"
+        typedConfirmValue="concept-fronted-adverbials"
+        onConfirm={async () => {}}
+        onCancel={() => {}}
+      />
+    );
+    console.log(html);
+  `);
+
+  // Must have the typed input section
+  assert.ok(html.includes('admin-confirm-typed-input'), 'missing typed input for critical level');
+  // Must show the typed confirm value in the label
+  assert.ok(html.includes('concept-fronted-adverbials'), 'missing typed confirm value in label');
+  // Confirm button must be disabled (initial empty input does not match)
+  assert.ok(html.includes('disabled'), 'confirm button should be disabled initially');
+  // data-level attribute
+  assert.ok(html.includes('data-level="critical"'), 'missing data-level=critical');
+  // Title should indicate destructive operation
+  assert.ok(html.includes('Destructive operation'), 'missing destructive operation title');
+});
+
+// =================================================================
+// 3. High-level: confirm button is NOT disabled initially
+// =================================================================
+
+test('AdminConfirmAction level=high confirm button is enabled', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { AdminConfirmAction } from ${JSON.stringify(abs('src/surfaces/hubs/AdminConfirmAction.jsx'))};
+
+    const html = renderToStaticMarkup(
+      <AdminConfirmAction
+        level="high"
+        dangerCopy="Warning text."
+        targetDisplay="some target"
+        onConfirm={async () => {}}
+        onCancel={() => {}}
+      />
+    );
+    // Output only the confirm button HTML to check disabled state
+    const confirmMatch = html.match(/<button[^>]*class="admin-confirm-action__confirm"[^>]*>[^<]*<\\/button>/);
+    console.log(confirmMatch ? confirmMatch[0] : 'NOT_FOUND');
+  `);
+
+  // The confirm button for high level should NOT be disabled
+  assert.ok(!html.includes('disabled'), 'high-level confirm button should not be disabled');
+  assert.ok(html.includes('Confirm'), 'missing confirm text');
+});
+
+// =================================================================
+// 4. Critical-level: confirm disabled when no typedConfirmValue match
+// =================================================================
+
+test('AdminConfirmAction level=critical confirm disabled with empty input', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { AdminConfirmAction } from ${JSON.stringify(abs('src/surfaces/hubs/AdminConfirmAction.jsx'))};
+
+    const html = renderToStaticMarkup(
+      <AdminConfirmAction
+        level="critical"
+        dangerCopy="Destructive."
+        targetDisplay="seed-abc"
+        typedConfirmValue="seed-abc"
+        onConfirm={async () => {}}
+        onCancel={() => {}}
+      />
+    );
+    // Extract the confirm button to check disabled attribute
+    const confirmMatch = html.match(/<button[^>]*class="admin-confirm-action__confirm"[^>]*>[^<]*<\\/button>/);
+    console.log(confirmMatch ? confirmMatch[0] : 'NOT_FOUND');
+  `);
+
+  // Confirm button must be disabled (empty input != "seed-abc")
+  assert.ok(html.includes('disabled'), 'critical confirm button should be disabled when input is empty');
+});
+
+// =================================================================
+// 5. No dangerCopy prop: description paragraph omitted
+// =================================================================
+
+test('AdminConfirmAction without dangerCopy omits danger paragraph', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { AdminConfirmAction } from ${JSON.stringify(abs('src/surfaces/hubs/AdminConfirmAction.jsx'))};
+
+    const html = renderToStaticMarkup(
+      <AdminConfirmAction
+        level="high"
+        dangerCopy=""
+        targetDisplay="target-x"
+        onConfirm={async () => {}}
+        onCancel={() => {}}
+      />
+    );
+    console.log(html);
+  `);
+
+  // Empty dangerCopy should not render the danger paragraph
+  assert.ok(!html.includes('admin-confirm-action__danger'), 'should not render danger paragraph when dangerCopy is empty');
+});
+
+// =================================================================
+// 6. No targetDisplay prop: target paragraph omitted
+// =================================================================
+
+test('AdminConfirmAction without targetDisplay omits target paragraph', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { AdminConfirmAction } from ${JSON.stringify(abs('src/surfaces/hubs/AdminConfirmAction.jsx'))};
+
+    const html = renderToStaticMarkup(
+      <AdminConfirmAction
+        level="high"
+        dangerCopy="Some warning."
+        targetDisplay=""
+        onConfirm={async () => {}}
+        onCancel={() => {}}
+      />
+    );
+    console.log(html);
+  `);
+
+  // Empty targetDisplay should not render the target paragraph
+  assert.ok(!html.includes('admin-confirm-action__target'), 'should not render target paragraph when targetDisplay is empty');
+});


### PR DESCRIPTION
## Summary
- Shared `admin-action-classification.js` with 4-level registry (low/medium/high/critical) mapping 12 admin action keys
- `AdminConfirmAction.jsx` component for high/critical operations with useSubmitLock double-click guard
- Typed confirmation for critical destructive actions (user must type target identifier)

## Test plan
- [x] Classification tests verify all 12 registered actions return correct level and flags
- [x] Context propagation tests verify targetLabel/targetId resolution
- [x] Confirmation component tests verify rendering per level (high vs critical)
- [x] Typed confirmation blocks on wrong/empty input
- [x] Edge cases: unknown keys, null/undefined context