### PR TITLE
feat(admin): add safe-copy framework with audience-aware redaction (P5 U2)

### DIFF
--- a/src/platform/hubs/admin-safe-copy.js
+++ b/src/platform/hubs/admin-safe-copy.js
@@ -69,7 +69,7 @@ function stripRequestBodies(obj) {
     return obj;
   }
   for (const key of Object.keys(obj)) {
-    if (key === 'requestBody' || key === 'rawBody' || key === 'body') {
+    if (key === 'requestBody' || key === 'rawBody') {
       delete obj[key];
     } else if (typeof obj[key] === 'object') {
       stripRequestBodies(obj[key]);

--- a/src/platform/hubs/admin-safe-copy.js
+++ b/src/platform/hubs/admin-safe-copy.js
@@ -1,0 +1,275 @@
+// P5 U2: Safe-copy framework — audience-aware clipboard with redaction.
+//
+// Provides `prepareSafeCopy(data, audience)` which strips or masks sensitive
+// fields according to the target audience, and `copyToClipboard(text)` which
+// wraps `navigator.clipboard.writeText` with graceful failure handling.
+//
+// All Admin*.jsx files MUST use this helper rather than raw navigator.clipboard.
+
+// ---------------------------------------------------------------------------
+// Audience enum
+// ---------------------------------------------------------------------------
+
+export const COPY_AUDIENCE = Object.freeze({
+  ADMIN_ONLY: 'admin_only',
+  OPS_SAFE: 'ops_safe',
+  PARENT_SAFE: 'parent_safe',
+  PUBLIC_PREVIEW: 'public_preview',
+});
+
+// ---------------------------------------------------------------------------
+// Internal redaction utilities
+// ---------------------------------------------------------------------------
+
+const SENSITIVE_HEADER_KEYS = ['cookie', 'authorization', 'x-auth-token', 'set-cookie'];
+
+function isSensitiveHeaderKey(key) {
+  return SENSITIVE_HEADER_KEYS.includes(String(key).toLowerCase());
+}
+
+/** Mask email to last 6 characters: `****ple.com` */
+export function maskEmail(email) {
+  if (!email || typeof email !== 'string') return '';
+  if (email.length <= 6) return '******';
+  return '****' + email.slice(-6);
+}
+
+/** Mask ID to last 8 characters: `****ef123456` */
+export function maskId(id) {
+  if (!id || typeof id !== 'string') return '';
+  if (id.length <= 8) return '********';
+  return '****' + id.slice(-8);
+}
+
+/**
+ * Recursively strip keys whose names imply auth tokens or cookies.
+ * Mutates in-place for performance on large bundles.
+ */
+function stripAuthTokens(obj) {
+  if (obj == null || typeof obj !== 'object') return obj;
+  if (Array.isArray(obj)) {
+    obj.forEach(stripAuthTokens);
+    return obj;
+  }
+  for (const key of Object.keys(obj)) {
+    if (isSensitiveHeaderKey(key)) {
+      delete obj[key];
+    } else if (typeof obj[key] === 'object') {
+      stripAuthTokens(obj[key]);
+    }
+  }
+  return obj;
+}
+
+/** Strip raw request bodies from bundle data. */
+function stripRequestBodies(obj) {
+  if (obj == null || typeof obj !== 'object') return obj;
+  if (Array.isArray(obj)) {
+    obj.forEach(stripRequestBodies);
+    return obj;
+  }
+  for (const key of Object.keys(obj)) {
+    if (key === 'requestBody' || key === 'rawBody' || key === 'body') {
+      delete obj[key];
+    } else if (typeof obj[key] === 'object') {
+      stripRequestBodies(obj[key]);
+    }
+  }
+  return obj;
+}
+
+/** Strip stack traces (any string value containing multi-line "at " frames). */
+function stripStackTraces(obj) {
+  if (obj == null || typeof obj !== 'object') return obj;
+  if (Array.isArray(obj)) {
+    obj.forEach(stripStackTraces);
+    return obj;
+  }
+  for (const key of Object.keys(obj)) {
+    const val = obj[key];
+    if (typeof val === 'string' && /^\s+at\s/m.test(val)) {
+      obj[key] = '[stack trace redacted]';
+    } else if (key === 'stack' || key === 'stackTrace' || key === 'firstFrame') {
+      obj[key] = '[stack trace redacted]';
+    } else if (typeof val === 'object') {
+      stripStackTraces(val);
+    }
+  }
+  return obj;
+}
+
+/** Strip internal notes fields. */
+function stripInternalNotes(obj) {
+  if (obj == null || typeof obj !== 'object') return obj;
+  if (Array.isArray(obj)) {
+    obj.forEach(stripInternalNotes);
+    return obj;
+  }
+  for (const key of Object.keys(obj)) {
+    if (key === 'internalNotes' || key === 'internal_notes' || key === 'adminNotes') {
+      delete obj[key];
+    } else if (typeof obj[key] === 'object') {
+      stripInternalNotes(obj[key]);
+    }
+  }
+  return obj;
+}
+
+/** Mask emails throughout object graph. */
+function maskAllEmails(obj) {
+  if (obj == null || typeof obj !== 'object') return obj;
+  if (Array.isArray(obj)) {
+    obj.forEach(maskAllEmails);
+    return obj;
+  }
+  for (const key of Object.keys(obj)) {
+    if (key === 'email' && typeof obj[key] === 'string') {
+      obj[key] = maskEmail(obj[key]);
+    } else if (typeof obj[key] === 'object') {
+      maskAllEmails(obj[key]);
+    }
+  }
+  return obj;
+}
+
+/** Mask account IDs throughout object graph. */
+function maskAllAccountIds(obj) {
+  if (obj == null || typeof obj !== 'object') return obj;
+  if (Array.isArray(obj)) {
+    obj.forEach(maskAllAccountIds);
+    return obj;
+  }
+  for (const key of Object.keys(obj)) {
+    if (key === 'accountId' && typeof obj[key] === 'string') {
+      obj[key] = maskId(obj[key]);
+    } else if (typeof obj[key] === 'object') {
+      maskAllAccountIds(obj[key]);
+    }
+  }
+  return obj;
+}
+
+/** Strip child/learner IDs entirely. */
+function stripChildIds(obj) {
+  if (obj == null || typeof obj !== 'object') return obj;
+  if (Array.isArray(obj)) {
+    obj.forEach(stripChildIds);
+    return obj;
+  }
+  for (const key of Object.keys(obj)) {
+    if (key === 'learnerId' || key === 'learner_id' || key === 'childId') {
+      delete obj[key];
+    } else if (typeof obj[key] === 'object') {
+      stripChildIds(obj[key]);
+    }
+  }
+  return obj;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Prepare data for safe copying to the clipboard.
+ *
+ * @param {*} data — the raw bundle/summary to copy (object or string).
+ * @param {string} audience — one of COPY_AUDIENCE values.
+ * @returns {{ ok: boolean, text: string, redactedFields: string[] }}
+ */
+export function prepareSafeCopy(data, audience) {
+  if (data == null || (typeof data === 'object' && Object.keys(data).length === 0)) {
+    return { ok: false, text: '', redactedFields: [] };
+  }
+  if (typeof data === 'string' && data.trim() === '') {
+    return { ok: false, text: '', redactedFields: [] };
+  }
+
+  const redactedFields = [];
+
+  // Deep clone so we never mutate the source.
+  let working = typeof data === 'string' ? data : JSON.parse(JSON.stringify(data));
+
+  // All audiences: strip cookies, auth tokens, raw request bodies.
+  if (typeof working === 'object') {
+    stripAuthTokens(working);
+    redactedFields.push('auth_tokens');
+
+    stripRequestBodies(working);
+    redactedFields.push('request_bodies');
+  }
+
+  // admin_only — pass through after stripping auth tokens / request bodies.
+  if (audience === COPY_AUDIENCE.ADMIN_ONLY) {
+    const text = typeof working === 'string' ? working : JSON.stringify(working, null, 2);
+    return { ok: true, text, redactedFields };
+  }
+
+  // ops_safe — mask email (last 6), mask account ID (last 8), strip internal notes.
+  if (audience === COPY_AUDIENCE.OPS_SAFE) {
+    if (typeof working === 'object') {
+      maskAllEmails(working);
+      redactedFields.push('emails_masked');
+
+      maskAllAccountIds(working);
+      redactedFields.push('account_ids_masked');
+
+      stripInternalNotes(working);
+      redactedFields.push('internal_notes');
+    }
+    const text = typeof working === 'string' ? working : JSON.stringify(working, null, 2);
+    return { ok: true, text, redactedFields };
+  }
+
+  // parent_safe — strip child IDs, stack traces, internal notes, request bodies, mask email.
+  if (audience === COPY_AUDIENCE.PARENT_SAFE) {
+    if (typeof working === 'object') {
+      stripChildIds(working);
+      redactedFields.push('child_ids');
+
+      stripStackTraces(working);
+      redactedFields.push('stack_traces');
+
+      stripInternalNotes(working);
+      redactedFields.push('internal_notes');
+
+      maskAllEmails(working);
+      redactedFields.push('emails_masked');
+    }
+    const text = typeof working === 'string' ? working : JSON.stringify(working, null, 2);
+    return { ok: true, text, redactedFields };
+  }
+
+  // public_preview — strip everything except title and sanitised body text.
+  if (audience === COPY_AUDIENCE.PUBLIC_PREVIEW) {
+    if (typeof working === 'object') {
+      const title = working.title || working.humanSummary || '';
+      const body = typeof working.body === 'string'
+        ? working.body
+        : (typeof working.humanSummary === 'string' ? working.humanSummary : '');
+      working = { title, body };
+      redactedFields.push('all_except_title_body');
+    }
+    const text = typeof working === 'string' ? working : JSON.stringify(working, null, 2);
+    return { ok: true, text, redactedFields };
+  }
+
+  // Unknown audience — reject.
+  return { ok: false, text: '', redactedFields: [] };
+}
+
+/**
+ * Copy text to clipboard. Browser-only — call site must be in a user-gesture
+ * context. Returns `{ ok: boolean, error?: string }`.
+ *
+ * @param {string} text
+ * @returns {Promise<{ ok: boolean, error?: string }>}
+ */
+export async function copyToClipboard(text) {
+  try {
+    await navigator.clipboard.writeText(text);
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err?.message || 'Clipboard write failed' };
+  }
+}

--- a/src/surfaces/hubs/AdminDebugBundlePanel.jsx
+++ b/src/surfaces/hubs/AdminDebugBundlePanel.jsx
@@ -6,6 +6,11 @@ import {
   isSectionEmpty,
   formatBundleTimestamp,
 } from '../../platform/hubs/admin-debug-bundle-panel.js';
+import {
+  COPY_AUDIENCE,
+  prepareSafeCopy,
+  copyToClipboard,
+} from '../../platform/hubs/admin-safe-copy.js';
 
 // U8 (P4): Debug Bundle panel — extracted from AdminDebuggingSection.jsx.
 // Contains DebugBundlePanel + DebugBundleSectionTable + DebugBundleResult.
@@ -194,26 +199,20 @@ export function DebugBundlePanel({ model, actions }) {
 
   const copyJson = async () => {
     if (!canExportJson || !bundleData?.bundle) return;
-    try {
-      await navigator.clipboard.writeText(JSON.stringify(bundleData.bundle, null, 2));
-      setCopyFeedback('JSON copied');
-      setTimeout(() => setCopyFeedback(''), 2000);
-    } catch {
-      setCopyFeedback('Copy failed');
-      setTimeout(() => setCopyFeedback(''), 2000);
-    }
+    const prepared = prepareSafeCopy(bundleData.bundle, COPY_AUDIENCE.ADMIN_ONLY);
+    if (!prepared.ok) { setCopyFeedback('Nothing to copy'); setTimeout(() => setCopyFeedback(''), 2000); return; }
+    const result = await copyToClipboard(prepared.text);
+    setCopyFeedback(result.ok ? 'JSON copied' : 'Copy failed');
+    setTimeout(() => setCopyFeedback(''), 2000);
   };
 
   const copySummary = async () => {
     if (!humanSummary) return;
-    try {
-      await navigator.clipboard.writeText(humanSummary);
-      setCopyFeedback('Summary copied');
-      setTimeout(() => setCopyFeedback(''), 2000);
-    } catch {
-      setCopyFeedback('Copy failed');
-      setTimeout(() => setCopyFeedback(''), 2000);
-    }
+    const prepared = prepareSafeCopy(bundleData, COPY_AUDIENCE.PARENT_SAFE);
+    const text = prepared.ok ? (JSON.parse(prepared.text).body || humanSummary) : humanSummary;
+    const result = await copyToClipboard(text);
+    setCopyFeedback(result.ok ? 'Summary copied' : 'Copy failed');
+    setTimeout(() => setCopyFeedback(''), 2000);
   };
 
   return (

--- a/src/surfaces/hubs/AdminDebugBundlePanel.jsx
+++ b/src/surfaces/hubs/AdminDebugBundlePanel.jsx
@@ -208,9 +208,9 @@ export function DebugBundlePanel({ model, actions }) {
 
   const copySummary = async () => {
     if (!humanSummary) return;
-    const prepared = prepareSafeCopy(bundleData, COPY_AUDIENCE.PARENT_SAFE);
-    const text = prepared.ok ? (JSON.parse(prepared.text).body || humanSummary) : humanSummary;
-    const result = await copyToClipboard(text);
+    const prepared = prepareSafeCopy(humanSummary, COPY_AUDIENCE.PARENT_SAFE);
+    if (!prepared.ok) { setCopyFeedback('Nothing to copy'); setTimeout(() => setCopyFeedback(''), 2000); return; }
+    const result = await copyToClipboard(prepared.text);
     setCopyFeedback(result.ok ? 'Summary copied' : 'Copy failed');
     setTimeout(() => setCopyFeedback(''), 2000);
   };

--- a/tests/admin-safe-copy.test.js
+++ b/tests/admin-safe-copy.test.js
@@ -1,0 +1,300 @@
+// P5 U2: Safe-copy framework test suite.
+//
+// Validates audience-aware redaction logic in admin-safe-copy.js.
+//
+// Test scenarios:
+//   1. admin_only audience passes full bundle JSON through (minus auth tokens)
+//   2. ops_safe masks email to last 6 chars, strips internal notes
+//   3. parent_safe strips child IDs, stack traces, internal notes, request bodies
+//   4. public_preview strips everything except title and sanitised body
+//   5. Empty data returns { ok: false }
+//   6. Data with auth tokens (cookie header) stripped regardless of audience
+//   7. Clipboard failure returns { ok: false } gracefully
+//   8. maskEmail and maskId edge cases
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  COPY_AUDIENCE,
+  prepareSafeCopy,
+  copyToClipboard,
+  maskEmail,
+  maskId,
+} from '../src/platform/hubs/admin-safe-copy.js';
+
+// ---------------------------------------------------------------------------
+// 1. admin_only — full passthrough (minus auth tokens + request bodies)
+// ---------------------------------------------------------------------------
+
+test('admin_only audience passes full bundle JSON through', () => {
+  const data = {
+    title: 'Debug Bundle',
+    accountSummary: { accountId: 'acct-abcdef123456', email: 'admin@longdomain.test.com' },
+    linkedLearners: [{ learnerId: 'lrn-xyz789', learnerName: 'Alice' }],
+    internalNotes: 'Some internal note',
+    stack: 'Error\n  at fn (/path/file.js:10:5)',
+  };
+
+  const result = prepareSafeCopy(data, COPY_AUDIENCE.ADMIN_ONLY);
+
+  assert.equal(result.ok, true);
+  const parsed = JSON.parse(result.text);
+  // Core data preserved.
+  assert.equal(parsed.accountSummary.accountId, 'acct-abcdef123456');
+  assert.equal(parsed.accountSummary.email, 'admin@longdomain.test.com');
+  assert.equal(parsed.linkedLearners[0].learnerId, 'lrn-xyz789');
+  assert.equal(parsed.internalNotes, 'Some internal note');
+  // Stack preserved for admin.
+  assert.equal(parsed.stack, 'Error\n  at fn (/path/file.js:10:5)');
+});
+
+// ---------------------------------------------------------------------------
+// 2. ops_safe — masked email, masked account ID, no internal notes
+// ---------------------------------------------------------------------------
+
+test('ops_safe masks email to last 6 and strips internal notes', () => {
+  const data = {
+    accountSummary: {
+      accountId: 'acct-abcdef123456',
+      email: 'admin@longdomain.test.com',
+    },
+    internalNotes: 'Secret internal info',
+    details: { internal_notes: 'Also secret', adminNotes: 'Admin note' },
+  };
+
+  const result = prepareSafeCopy(data, COPY_AUDIENCE.OPS_SAFE);
+
+  assert.equal(result.ok, true);
+  const parsed = JSON.parse(result.text);
+  // Email masked to last 6.
+  assert.equal(parsed.accountSummary.email, '****st.com');
+  // Account ID masked to last 8.
+  assert.equal(parsed.accountSummary.accountId, '****ef123456');
+  // Internal notes stripped.
+  assert.equal(parsed.internalNotes, undefined);
+  assert.equal(parsed.details.internal_notes, undefined);
+  assert.equal(parsed.details.adminNotes, undefined);
+  // Redacted fields recorded.
+  assert.ok(result.redactedFields.includes('emails_masked'));
+  assert.ok(result.redactedFields.includes('account_ids_masked'));
+  assert.ok(result.redactedFields.includes('internal_notes'));
+});
+
+// ---------------------------------------------------------------------------
+// 3. parent_safe — strips child IDs, stacks, internal notes, request bodies
+// ---------------------------------------------------------------------------
+
+test('parent_safe strips child IDs, stack traces, and internal notes', () => {
+  const data = {
+    accountSummary: { email: 'parent@example.com' },
+    linkedLearners: [{ learnerId: 'lrn-abc', learnerName: 'Child', learner_id: 'lrn-abc-alt' }],
+    recentErrors: [{
+      id: 'e1',
+      firstFrame: '  at handler (/app/index.js:42:3)',
+      stack: 'Error: oops\n  at x (/y.js:1:1)',
+      requestBody: '{"password":"secret"}',
+    }],
+    internalNotes: 'Admin-only context',
+    childId: 'child-999',
+  };
+
+  const result = prepareSafeCopy(data, COPY_AUDIENCE.PARENT_SAFE);
+
+  assert.equal(result.ok, true);
+  const parsed = JSON.parse(result.text);
+  // Child IDs stripped.
+  assert.equal(parsed.linkedLearners[0].learnerId, undefined);
+  assert.equal(parsed.linkedLearners[0].learner_id, undefined);
+  assert.equal(parsed.childId, undefined);
+  // Learner name preserved.
+  assert.equal(parsed.linkedLearners[0].learnerName, 'Child');
+  // Stack traces redacted.
+  assert.equal(parsed.recentErrors[0].firstFrame, '[stack trace redacted]');
+  assert.equal(parsed.recentErrors[0].stack, '[stack trace redacted]');
+  // Request body stripped.
+  assert.equal(parsed.recentErrors[0].requestBody, undefined);
+  // Internal notes stripped.
+  assert.equal(parsed.internalNotes, undefined);
+  // Email masked.
+  assert.equal(parsed.accountSummary.email, '****le.com');
+  // Redacted fields.
+  assert.ok(result.redactedFields.includes('child_ids'));
+  assert.ok(result.redactedFields.includes('stack_traces'));
+  assert.ok(result.redactedFields.includes('internal_notes'));
+  assert.ok(result.redactedFields.includes('emails_masked'));
+});
+
+// ---------------------------------------------------------------------------
+// 4. public_preview — only title and body
+// ---------------------------------------------------------------------------
+
+test('public_preview strips everything except title and body', () => {
+  const data = {
+    title: 'Support Case #1234',
+    humanSummary: 'Summary for display',
+    accountSummary: { email: 'user@test.com', accountId: 'acct-123' },
+    linkedLearners: [{ learnerId: 'lrn-1' }],
+  };
+
+  const result = prepareSafeCopy(data, COPY_AUDIENCE.PUBLIC_PREVIEW);
+
+  assert.equal(result.ok, true);
+  const parsed = JSON.parse(result.text);
+  assert.equal(parsed.title, 'Support Case #1234');
+  // Body falls back to humanSummary if no explicit body.
+  assert.equal(parsed.body, 'Summary for display');
+  // No other fields.
+  assert.equal(parsed.accountSummary, undefined);
+  assert.equal(parsed.linkedLearners, undefined);
+  assert.ok(result.redactedFields.includes('all_except_title_body'));
+});
+
+// ---------------------------------------------------------------------------
+// 5. Empty data returns { ok: false }
+// ---------------------------------------------------------------------------
+
+test('empty/null data returns ok: false', () => {
+  assert.equal(prepareSafeCopy(null, COPY_AUDIENCE.ADMIN_ONLY).ok, false);
+  assert.equal(prepareSafeCopy(undefined, COPY_AUDIENCE.ADMIN_ONLY).ok, false);
+  assert.equal(prepareSafeCopy({}, COPY_AUDIENCE.ADMIN_ONLY).ok, false);
+  assert.equal(prepareSafeCopy('', COPY_AUDIENCE.ADMIN_ONLY).ok, false);
+  assert.equal(prepareSafeCopy('   ', COPY_AUDIENCE.ADMIN_ONLY).ok, false);
+});
+
+// ---------------------------------------------------------------------------
+// 6. Auth tokens (cookie header) stripped regardless of audience
+// ---------------------------------------------------------------------------
+
+test('auth tokens stripped for all audiences', () => {
+  const data = {
+    title: 'Bundle',
+    headers: {
+      cookie: 'session=abc123',
+      authorization: 'Bearer xyz',
+      'x-auth-token': 'tok-secret',
+      'content-type': 'application/json',
+    },
+    nested: { 'set-cookie': 'val=1' },
+  };
+
+  for (const audience of Object.values(COPY_AUDIENCE)) {
+    const result = prepareSafeCopy(data, audience);
+    assert.equal(result.ok, true, `Failed for audience: ${audience}`);
+    // public_preview reduces to title+body, so check non-public audiences.
+    if (audience !== COPY_AUDIENCE.PUBLIC_PREVIEW) {
+      const parsed = JSON.parse(result.text);
+      assert.equal(parsed.headers.cookie, undefined, `cookie not stripped for ${audience}`);
+      assert.equal(parsed.headers.authorization, undefined, `auth not stripped for ${audience}`);
+      assert.equal(parsed.headers['x-auth-token'], undefined, `x-auth-token not stripped for ${audience}`);
+      assert.equal(parsed.nested['set-cookie'], undefined, `set-cookie not stripped for ${audience}`);
+      // Non-sensitive header preserved.
+      assert.equal(parsed.headers['content-type'], 'application/json');
+    }
+    assert.ok(result.redactedFields.includes('auth_tokens'));
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 7. Clipboard failure returns { ok: false } gracefully
+// ---------------------------------------------------------------------------
+
+test('copyToClipboard returns ok: false on failure', async () => {
+  // Mock navigator.clipboard in non-browser environment.
+  const original = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
+  Object.defineProperty(globalThis, 'navigator', {
+    value: { clipboard: { writeText: () => Promise.reject(new Error('Not allowed')) } },
+    writable: true,
+    configurable: true,
+  });
+
+  const result = await copyToClipboard('test text');
+  assert.equal(result.ok, false);
+  assert.equal(result.error, 'Not allowed');
+
+  // Restore.
+  if (original) {
+    Object.defineProperty(globalThis, 'navigator', original);
+  } else {
+    delete globalThis.navigator;
+  }
+});
+
+test('copyToClipboard returns ok: true on success', async () => {
+  let captured = '';
+  const original = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
+  Object.defineProperty(globalThis, 'navigator', {
+    value: { clipboard: { writeText: (text) => { captured = text; return Promise.resolve(); } } },
+    writable: true,
+    configurable: true,
+  });
+
+  const result = await copyToClipboard('hello world');
+  assert.equal(result.ok, true);
+  assert.equal(result.error, undefined);
+  assert.equal(captured, 'hello world');
+
+  // Restore.
+  if (original) {
+    Object.defineProperty(globalThis, 'navigator', original);
+  } else {
+    delete globalThis.navigator;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 8. maskEmail and maskId edge cases
+// ---------------------------------------------------------------------------
+
+test('maskEmail edge cases', () => {
+  assert.equal(maskEmail('ab@c.d'), '******'); // length <= 6
+  assert.equal(maskEmail('a@b.co'), '******'); // exactly 6
+  assert.equal(maskEmail('test@example.com'), '****le.com'); // last 6
+  assert.equal(maskEmail(null), '');
+  assert.equal(maskEmail(''), '');
+});
+
+test('maskId edge cases', () => {
+  assert.equal(maskId('acct-12'), '********'); // length <= 8
+  assert.equal(maskId('acct-1234'), '****cct-1234'); // length 9; last 8 = 'cct-1234'
+  assert.equal(maskId('acct-abcdef123456'), '****ef123456'); // standard; last 8 = 'ef123456'
+  assert.equal(maskId(null), '');
+  assert.equal(maskId(''), '');
+});
+
+// ---------------------------------------------------------------------------
+// 9. Unknown audience returns { ok: false }
+// ---------------------------------------------------------------------------
+
+test('unknown audience returns ok: false', () => {
+  const data = { title: 'test' };
+  const result = prepareSafeCopy(data, 'invalid_audience');
+  assert.equal(result.ok, false);
+});
+
+// ---------------------------------------------------------------------------
+// 10. String input handling
+// ---------------------------------------------------------------------------
+
+test('string input passes through for admin_only', () => {
+  const result = prepareSafeCopy('Some summary text', COPY_AUDIENCE.ADMIN_ONLY);
+  assert.equal(result.ok, true);
+  assert.equal(result.text, 'Some summary text');
+});
+
+// ---------------------------------------------------------------------------
+// 11. Does not mutate original data
+// ---------------------------------------------------------------------------
+
+test('prepareSafeCopy does not mutate original data', () => {
+  const data = {
+    accountSummary: { email: 'user@test.com', accountId: 'acct-abc123456789' },
+    cookie: 'session=secret',
+    internalNotes: 'secret',
+  };
+  const frozen = JSON.stringify(data);
+
+  prepareSafeCopy(data, COPY_AUDIENCE.OPS_SAFE);
+
+  assert.equal(JSON.stringify(data), frozen, 'Original data was mutated');
+});

--- a/tests/ci-no-raw-clipboard-admin.test.js
+++ b/tests/ci-no-raw-clipboard-admin.test.js
@@ -1,0 +1,41 @@
+// P5 U2: CI invariant — no direct navigator.clipboard usage in Admin panels.
+//
+// All Admin*.jsx files in src/surfaces/hubs/ MUST use the safe-copy helper
+// (admin-safe-copy.js) rather than calling navigator.clipboard directly.
+// The only permitted exception is the safe-copy helper itself.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execSync } from 'node:child_process';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = resolve(__dirname, '..');
+const searchDir = resolve(rootDir, 'src', 'surfaces', 'hubs');
+
+test('no direct navigator.clipboard usage in Admin*.jsx files', () => {
+  let output = '';
+  try {
+    // grep -rn for navigator.clipboard in Admin*.jsx files.
+    output = execSync(
+      `grep -rn "navigator\\.clipboard" "${searchDir}"/Admin*.jsx`,
+      { encoding: 'utf8', cwd: rootDir },
+    );
+  } catch (err) {
+    // grep exits 1 when no matches found — that is the expected success case.
+    if (err.status === 1) {
+      output = '';
+    } else {
+      throw err;
+    }
+  }
+
+  if (output.trim()) {
+    assert.fail(
+      'Direct navigator.clipboard usage found in Admin panel files. ' +
+      'Use the safe-copy helper (admin-safe-copy.js) instead.\n\n' +
+      'Violations:\n' + output,
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- New `admin-safe-copy.js` helper with 4 audience levels (`admin_only`, `ops_safe`, `parent_safe`, `public_preview`) and progressive redaction policy
- AdminDebugBundlePanel migrated from raw `navigator.clipboard` to the safe-copy helper — Copy Summary uses `parent_safe`, Copy JSON uses `admin_only`
- CI grep test prevents future direct `navigator.clipboard` usage in `Admin*.jsx` panel files

## Test plan
- [x] 13 redaction tests cover all 4 audiences, sensitive field stripping, edge cases, and clipboard mocking
- [x] Existing debug bundle tests pass (no regression): 11/11 panel + 12/12 worker redaction
- [x] CI grep test confirms zero raw clipboard violations in admin panels