### PR TITLE
test(security): add CSP enforcement mode cross-assertion guard

### DIFF
--- a/docs/hardening/csp-enforcement-decision.md
+++ b/docs/hardening/csp-enforcement-decision.md
@@ -119,3 +119,9 @@ The 7-day window gives us:
 - Signal on whether production traffic hits any `'none'`-directive violation we missed.
 - Confidence that `challenges.cloudflare.com` / `fonts.googleapis.com` / `fonts.gstatic.com` third-party allowances are sufficient for the actual request mix (not just the test fixture mix).
 - An operator log that later SH2-U8-style migration PRs can cite when they reduce the `'unsafe-inline'` surface further.
+
+## P5 Cross-Assertion (2026-04-28)
+
+Added mechanical test in `tests/security-headers.test.js` that enforces agreement between `CSP_ENFORCEMENT_MODE` and the header key in `SECURITY_HEADERS`. The mode constant is no longer dead — if the flip PR changes the mode without updating the header key (or vice versa), tests fail.
+
+**Observation window status:** Open (2026-04-27 to 2026-05-04). Daily log remains unpopulated. The enforcement flip or dated deferral will be executed after the window closes.

--- a/docs/hardening/hsts-preload-audit.md
+++ b/docs/hardening/hsts-preload-audit.md
@@ -212,3 +212,14 @@ _To be completed by the operator at the time of flipping `HSTS_PRELOAD_ENABLED` 
 ---
 
 **End of audit skeleton.** Any change to this file after operator sign-off requires a new dated sign-off block appended below (never rewrite a signed block).
+
+---
+
+## P5 Status Update (2026-04-28)
+
+No new operator DNS audit information available. All `TBD-operator` cells remain unfilled.
+`HSTS_PRELOAD_ENABLED` remains `false` in `worker/src/security-headers.js`.
+
+**Decision:** Deferred; operator DNS audit incomplete. HSTS preload activation is not blocked by engineering — it is blocked by the DNS zone enumeration and operator sign-off checklist.
+
+**Next review:** When operator completes DNS zone enumeration and verifies all subdomains HTTPS-only.

--- a/docs/plans/james/sys-hardening/sys-hardening-p5-baseline.md
+++ b/docs/plans/james/sys-hardening/sys-hardening-p5-baseline.md
@@ -82,3 +82,28 @@ P5 is a **certification closure** phase. Its purpose is to:
 4. Revalidate capacity claims against the post-P4 drift surfaces listed above.
 
 P5 does NOT introduce new hardening infrastructure, new circuit breakers, new telemetry surfaces, or new operational runbooks. Any such work discovered during P5 execution is captured as a P6 residual.
+
+## Admin Capacity Residual Triage
+
+### Certification-Critical Admin Routes (P5)
+
+These Admin routes could theoretically affect learner-route performance if they share D1 connection pools or trigger heavy queries during capacity runs:
+
+- `/api/admin/ops/kpi` — manual-refresh pattern (operator clicks to refresh, not live on every page load). Indexed queries via `readDashboardKpis`. Not blocking learner routes.
+- `/api/admin/debug-bundle` — read-only diagnostic. Rate-limited at 10/min per session. Limitations: capacity collector bypass is documented but not fixed. Explicitly carried to P6.
+
+### Routes NOT Certification-Critical (P5)
+
+All other admin endpoints operate independently of learner routes during capacity certification runs (learner load uses demo sessions, not admin sessions).
+
+### P6 Deferrals
+
+- Full Admin KPI pre-aggregation (replace live counters with pre-computed values)
+- Budget ceiling tests for all 14+ admin endpoints with `meta.capacity`
+- Debug-bundle capacity collector instrumentation for raw DB aggregation
+- Admin endpoint response-time budgets beyond the certification-critical set
+
+### Verification
+
+- No Admin route touched by P5 lacks access tests (verified by `tests/redaction-access-matrix.test.js` — covers parent, admin, ops roles across all route axes)
+- Admin KPI live-count cost does not affect learner-route certification (admin sessions are not used during capacity runs)

--- a/tests/security-headers.test.js
+++ b/tests/security-headers.test.js
@@ -894,6 +894,44 @@ test('_headers repo file contains the CSP Report-Only line (pre-substitution via
 });
 
 // ---------------------------------------------------------------------------
+// P5-U6: CSP enforcement mode cross-assertion guard.
+// ---------------------------------------------------------------------------
+
+test('CSP_ENFORCEMENT_MODE cross-asserts the actual header key in SECURITY_HEADERS', () => {
+  const hasReportOnly = 'Content-Security-Policy-Report-Only' in SECURITY_HEADERS;
+  const hasEnforced = 'Content-Security-Policy' in SECURITY_HEADERS;
+
+  if (CSP_ENFORCEMENT_MODE === 'report-only') {
+    assert.equal(
+      hasReportOnly,
+      true,
+      'When CSP_ENFORCEMENT_MODE is "report-only", SECURITY_HEADERS must have key "Content-Security-Policy-Report-Only".',
+    );
+    assert.equal(
+      hasEnforced,
+      false,
+      'When CSP_ENFORCEMENT_MODE is "report-only", SECURITY_HEADERS must NOT have key "Content-Security-Policy".',
+    );
+  } else if (CSP_ENFORCEMENT_MODE === 'enforced') {
+    assert.equal(
+      hasEnforced,
+      true,
+      'When CSP_ENFORCEMENT_MODE is "enforced", SECURITY_HEADERS must have key "Content-Security-Policy".',
+    );
+    assert.equal(
+      hasReportOnly,
+      false,
+      'When CSP_ENFORCEMENT_MODE is "enforced", SECURITY_HEADERS must NOT have key "Content-Security-Policy-Report-Only".',
+    );
+  } else {
+    assert.fail(
+      `CSP_ENFORCEMENT_MODE has unexpected value "${CSP_ENFORCEMENT_MODE}". `
+        + 'Only "report-only" and "enforced" are valid. Dead constant guard tripped.',
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
 // P4-U4: CSP enforcement decision gate — mode constant and header assertions.
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds a mechanical cross-assertion test that enforces agreement between `CSP_ENFORCEMENT_MODE` and the actual header key present in `SECURITY_HEADERS`. If the flip PR changes the mode constant without updating the header key (or vice versa), tests fail immediately.
- Appends a P5 status note to `docs/hardening/csp-enforcement-decision.md` recording the guard and confirming the observation window remains open (2026-04-27 to 2026-05-04).

## Test plan

- [x] `node --test tests/security-headers.test.js` passes (50/50 tests, including the new cross-assertion)
- [ ] Verify the test would fail if `CSP_ENFORCEMENT_MODE` were changed to `'enforced'` without updating the header key (manual spot-check)
- [ ] Verify the test would fail on an invalid mode value like `'unknown'` (dead constant guard)