### PR TITLE
refactor(admin): migrate ≥20 inline styles to CSS classes (P5 U11)

### DIFF
--- a/docs/hardening/csp-inline-style-inventory.md
+++ b/docs/hardening/csp-inline-style-inventory.md
@@ -49,11 +49,11 @@ Future migration PRs should:
 
 | Category | Count |
 | --- | --- |
-| `shared-pattern-available` | 150 |
+| `shared-pattern-available` | 116 |
 | `dynamic-content-driven` | 108 |
 | `css-var-ready` | 3 |
 | `third-party-boundary` | 2 |
-| **TOTAL** | **263** |
+| **TOTAL** | **229** |
 
 ## Per-file inventory
 
@@ -61,10 +61,10 @@ Future migration PRs should:
 | --- | --- | --- | --- |
 | `src/subjects/punctuation/components/PunctuationSessionScene.jsx` | 27 | `dynamic-content-driven` | no |
 | `src/surfaces/hubs/AdminErrorTimelinePanel.jsx` | 23 | `shared-pattern-available` | no |
-| `src/surfaces/hubs/AdminMarketingSection.jsx` | 22 | `shared-pattern-available` | no |
+| `src/surfaces/hubs/AdminMarketingSection.jsx` | 1 | `shared-pattern-available` | yes |
 | `src/subjects/punctuation/components/PunctuationSummaryScene.jsx` | 20 | `dynamic-content-driven` | no |
 | `src/surfaces/hubs/MonsterEffectCatalogPanel.jsx` | 19 | `shared-pattern-available` | no |
-| `src/surfaces/hubs/AdminDebugBundlePanel.jsx` | 14 | `shared-pattern-available` | no |
+| `src/surfaces/hubs/AdminDebugBundlePanel.jsx` | 1 | `shared-pattern-available` | yes |
 | `src/surfaces/hubs/AdminLearnerSupportPanel.jsx` | 12 | `shared-pattern-available` | no |
 | `src/surfaces/hubs/MonsterEffectBindingsPanel.jsx` | 12 | `shared-pattern-available` | no |
 | `src/surfaces/hubs/MonsterVisualConfigPanel.jsx` | 10 | `dynamic-content-driven` | no |

--- a/scripts/inventory-inline-styles.mjs
+++ b/scripts/inventory-inline-styles.mjs
@@ -230,9 +230,12 @@ export const MIGRATED_THIS_PR = Object.freeze(new Set([
 // The U8 invariant (POST_MIGRATION_TOTAL = PRE_MIGRATION_TOTAL - SITES_MIGRATED_THIS_PR)
 // is preserved by raising PRE_MIGRATION_TOTAL by the same 72; the new panels
 // remain `shared-pattern-available` candidates for a future migration slice.
+//
+// P5-U11: Migrated 34 inline styles (21 AdminMarketingSection + 13 AdminDebugBundlePanel)
+// to CSS classes. Only dynamic-content-driven styles remain (1 each).
 export const PRE_MIGRATION_TOTAL = 418;
-export const SITES_MIGRATED_THIS_PR = 155;
-export const POST_MIGRATION_TOTAL = PRE_MIGRATION_TOTAL - SITES_MIGRATED_THIS_PR; // 263
+export const SITES_MIGRATED_THIS_PR = 189;
+export const POST_MIGRATION_TOTAL = PRE_MIGRATION_TOTAL - SITES_MIGRATED_THIS_PR; // 229
 
 function classifyFile(relativePath) {
   return CLASSIFICATION[relativePath] || 'unclassified';

--- a/src/surfaces/hubs/AdminDebugBundlePanel.jsx
+++ b/src/surfaces/hubs/AdminDebugBundlePanel.jsx
@@ -21,11 +21,11 @@ function DebugBundleSectionTable({ label, rows, columns }) {
     return <p className="small muted">No data.</p>;
   }
   return (
-    <table className="small" style={{ width: '100%', borderCollapse: 'collapse', marginTop: 4 }}>
+    <table className="small admin-bundle-table">
       <thead>
         <tr>
           {columns.map((col) => (
-            <th key={col.key} style={{ textAlign: 'left', padding: '2px 6px' }}>{col.label}</th>
+            <th key={col.key} className="admin-bundle-th">{col.label}</th>
           ))}
         </tr>
       </thead>
@@ -49,8 +49,8 @@ function DebugBundleResult({ bundleData }) {
   const bundle = bundleData.bundle || {};
 
   return (
-    <div data-testid="debug-bundle-result" style={{ marginTop: 12 }}>
-      <div className="small muted" style={{ marginBottom: 8 }}>
+    <div data-testid="debug-bundle-result" className="admin-bundle-result-spaced">
+      <div className="small muted admin-bundle-meta">
         Generated: {formatBundleTimestamp(bundle.generatedAt)}
         {bundle.buildHash ? ` · Build: ${String(bundle.buildHash).slice(0, 7)}` : ''}
       </div>
@@ -60,13 +60,13 @@ function DebugBundleResult({ bundleData }) {
         const isEmpty = isSectionEmpty(bundle, sectionKey);
         const value = bundle[sectionKey];
         return (
-          <details key={sectionKey} data-testid={`bundle-section-${sectionKey}`} style={{ marginBottom: 8 }}>
-            <summary className="small" style={{ cursor: 'pointer', fontWeight: 600 }}>
+          <details key={sectionKey} data-testid={`bundle-section-${sectionKey}`} className="admin-bundle-section-details">
+            <summary className="small admin-bundle-section-summary">
               {label} {isEmpty ? <span className="muted">(empty)</span> : null}
             </summary>
-            <div style={{ padding: '4px 0 4px 12px' }}>
+            <div className="admin-bundle-section-body">
               {sectionKey === 'accountSummary' && value ? (
-                <dl className="small" style={{ display: 'grid', gridTemplateColumns: '120px 1fr', rowGap: 2 }}>
+                <dl className="small admin-bundle-account-dl">
                   <dt className="muted">Account ID</dt><dd>{value.accountId || '—'}</dd>
                   <dt className="muted">Email</dt><dd>{value.email || '—'}</dd>
                   <dt className="muted">Name</dt><dd>{value.displayName || '—'}</dd>
@@ -217,7 +217,7 @@ export function DebugBundlePanel({ model, actions }) {
   };
 
   return (
-    <section className="card" style={{ marginBottom: 20 }} data-testid="debug-bundle-panel">
+    <section className="card admin-card-spaced" data-testid="debug-bundle-panel">
       <PanelHeader
         eyebrow="Debug tools"
         title="Debug Bundle"
@@ -227,8 +227,7 @@ export function DebugBundlePanel({ model, actions }) {
       />
 
       <div
-        className="filters"
-        style={{ marginTop: 10, display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))', gap: 8 }}
+        className="filters admin-filters-grid"
         data-testid="debug-bundle-search-form"
       >
         <label className="field">
@@ -261,7 +260,7 @@ export function DebugBundlePanel({ model, actions }) {
         </label>
       </div>
 
-      <div className="chip-row" style={{ marginTop: 10 }}>
+      <div className="chip-row admin-bundle-gen-actions">
         <button className="btn" type="button" disabled={loading} onClick={generateBundle} data-testid="bundle-generate-btn">
           {loading ? 'Generating...' : 'Generate Debug Bundle'}
         </button>
@@ -281,13 +280,13 @@ export function DebugBundlePanel({ model, actions }) {
       </div>
 
       {error && !bundleData ? (
-        <div className="feedback warn" style={{ marginTop: 10 }} data-testid="debug-bundle-error">
+        <div className="feedback warn admin-bundle-error-spaced" data-testid="debug-bundle-error">
           {typeof error === 'string' ? error : 'Failed to generate debug bundle.'}
         </div>
       ) : null}
 
       {!bundleData && !loading && !error ? (
-        <p className="small muted" style={{ marginTop: 10 }} data-testid="debug-bundle-empty-state">
+        <p className="small muted admin-bundle-empty" data-testid="debug-bundle-empty-state">
           Enter search criteria and click Generate to create a debug evidence bundle.
         </p>
       ) : null}

--- a/src/surfaces/hubs/AdminMarketingSection.jsx
+++ b/src/surfaces/hubs/AdminMarketingSection.jsx
@@ -88,7 +88,7 @@ function BodyTextPreview({ text }) {
   if (!text) return <span className="small muted">No body text</span>;
   const rendered = renderRestrictedMarkdown(text);
   return (
-    <div className="marketing-body-preview" style={{ fontSize: '0.9rem', lineHeight: 1.5 }}>
+    <div className="marketing-body-preview admin-marketing-body-preview">
       {rendered || text}
     </div>
   );
@@ -101,22 +101,21 @@ function BodyTextPreview({ text }) {
 function BroadPublishConfirmDialog({ message, targetAction, onConfirm, onCancel }) {
   return (
     <div
-      className="callout warn"
+      className="callout warn admin-marketing-confirm-wrap"
       role="alertdialog"
       aria-label="Confirm broad publish"
       data-testid="broad-publish-confirm"
-      style={{ marginBottom: 12, padding: 16 }}
     >
       <strong>Confirm broad publish</strong>
-      <p style={{ margin: '8px 0' }}>
+      <p className="admin-marketing-confirm-text">
         You are about to {targetAction === 'published' ? 'publish' : 'schedule'} a message
         to <strong>all signed-in users</strong>.
         This will display a banner to every user of the platform.
       </p>
-      <p className="small muted" style={{ margin: '4px 0 12px' }}>
+      <p className="small muted admin-marketing-confirm-meta">
         Message: &ldquo;{message.title}&rdquo; ({message.message_type}, {message.severity_token})
       </p>
-      <div style={{ display: 'flex', gap: 8 }}>
+      <div className="admin-marketing-confirm-actions">
         <button
           className="btn secondary"
           type="button"
@@ -192,14 +191,14 @@ function MarketingCreateForm({ onSubmit, submitting }) {
   };
 
   return (
-    <form onSubmit={handleSubmit} data-testid="marketing-create-form" style={{ marginBottom: 16 }}>
+    <form onSubmit={handleSubmit} data-testid="marketing-create-form" className="admin-marketing-form">
       {validationError && (
-        <div className="feedback bad" style={{ marginBottom: 8 }} data-testid="create-form-validation-error">
+        <div className="feedback bad admin-marketing-form-feedback" data-testid="create-form-validation-error">
           {validationError}
         </div>
       )}
-      <div style={{ display: 'grid', gap: 10, gridTemplateColumns: '1fr 1fr' }}>
-        <label className="field" style={{ gridColumn: '1 / -1' }}>
+      <div className="admin-marketing-form-grid">
+        <label className="field admin-marketing-form-grid-full">
           <span>Title</span>
           <input
             className="input"
@@ -212,7 +211,7 @@ function MarketingCreateForm({ onSubmit, submitting }) {
             data-testid="create-form-title"
           />
         </label>
-        <label className="field" style={{ gridColumn: '1 / -1' }}>
+        <label className="field admin-marketing-form-grid-full">
           <span>Body text (restricted Markdown: **bold**, *italic*, [text](https://url))</span>
           <textarea
             className="input"
@@ -284,7 +283,7 @@ function MarketingCreateForm({ onSubmit, submitting }) {
           />
         </label>
       </div>
-      <div style={{ marginTop: 12 }}>
+      <div className="admin-marketing-form-submit">
         <button
           className="btn secondary"
           type="submit"
@@ -306,11 +305,11 @@ function MessageDetail({ message, isAdmin, onTransition, onBack, transitionError
   const allowedTransitions = VALID_TRANSITIONS.get(message.status) || [];
 
   return (
-    <section className="card" style={{ marginBottom: 20 }} data-testid="marketing-message-detail">
+    <section className="card admin-card-spaced" data-testid="marketing-message-detail">
       <div className="card-header">
         <div>
           <div className="eyebrow">Marketing message</div>
-          <h3 className="section-title" style={{ fontSize: '1.2rem' }}>{message.title}</h3>
+          <h3 className="section-title admin-section-title">{message.title}</h3>
           <p className="subtitle">
             {message.message_type} &middot; {message.audience} &middot; <StatusBadge status={message.status} />
           </p>
@@ -321,7 +320,7 @@ function MessageDetail({ message, isAdmin, onTransition, onBack, transitionError
       </div>
 
       {transitionError && (
-        <div className="feedback bad" style={{ marginBottom: 12 }} data-testid="transition-error">
+        <div className="feedback bad admin-marketing-feedback-spaced" data-testid="transition-error">
           {transitionError}
         </div>
       )}
@@ -335,12 +334,12 @@ function MessageDetail({ message, isAdmin, onTransition, onBack, transitionError
         />
       )}
 
-      <div style={{ marginBottom: 12 }}>
+      <div className="admin-marketing-detail-body">
         <div className="eyebrow">Body text</div>
         <BodyTextPreview text={message.body_text} />
       </div>
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))', gap: 8, marginBottom: 12 }}>
+      <div className="admin-marketing-detail-grid">
         <div>
           <div className="small muted">Severity</div>
           <strong>{message.severity_token}</strong>
@@ -374,7 +373,7 @@ function MessageDetail({ message, isAdmin, onTransition, onBack, transitionError
       </div>
 
       {isAdmin && allowedTransitions.length > 0 && (
-        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+        <div className="admin-marketing-transition-row">
           {allowedTransitions.map((target) => (
             <button
               key={target}
@@ -401,14 +400,13 @@ function MessageDetail({ message, isAdmin, onTransition, onBack, transitionError
 function MessageListRow({ message, onSelect }) {
   return (
     <div
-      className="skill-row"
+      className="skill-row admin-marketing-row-pointer"
       data-testid="marketing-message-row"
       data-message-id={message.id}
       role="button"
       tabIndex={0}
       onClick={() => onSelect(message.id)}
       onKeyDown={(e) => { if (e.key === 'Enter') onSelect(message.id); }}
-      style={{ cursor: 'pointer' }}
     >
       <div>
         <strong>{message.title || 'Untitled'}</strong>
@@ -588,11 +586,11 @@ export function AdminMarketingSection({ accessContext }) {
 
   // List view
   return (
-    <section className="card" style={{ marginBottom: 20 }} data-section="marketing">
+    <section className="card admin-card-spaced" data-section="marketing">
       <div className="card-header">
         <div>
           <div className="eyebrow">Marketing &amp; Live Ops</div>
-          <h3 className="section-title" style={{ fontSize: '1.2rem' }}>Marketing messages</h3>
+          <h3 className="section-title admin-section-title">Marketing messages</h3>
           <p className="subtitle">
             Create and manage announcements, maintenance banners, and campaign messages.
             Messages follow the lifecycle: draft, scheduled, published, paused, archived.
@@ -621,7 +619,7 @@ export function AdminMarketingSection({ accessContext }) {
       </div>
 
       {error && (
-        <div className="feedback bad" style={{ marginBottom: 12 }} data-testid="marketing-error">
+        <div className="feedback bad admin-marketing-feedback-spaced" data-testid="marketing-error">
           {error}
         </div>
       )}

--- a/styles/app.css
+++ b/styles/app.css
@@ -11644,6 +11644,78 @@ html { scroll-behavior: smooth; }
   margin-top: 10px;
 }
 
+/* -- marketing section patterns ------------------------------------------- */
+
+.admin-marketing-body-preview {
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.admin-marketing-confirm-wrap {
+  margin-bottom: 12px;
+  padding: 16px;
+}
+
+.admin-marketing-confirm-text {
+  margin: 8px 0;
+}
+
+.admin-marketing-confirm-meta {
+  margin: 4px 0 12px;
+}
+
+.admin-marketing-confirm-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.admin-marketing-form {
+  margin-bottom: 16px;
+}
+
+.admin-marketing-form-feedback {
+  margin-bottom: 8px;
+}
+
+.admin-marketing-form-grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: 1fr 1fr;
+}
+
+.admin-marketing-form-grid-full {
+  grid-column: 1 / -1;
+}
+
+.admin-marketing-form-submit {
+  margin-top: 12px;
+}
+
+.admin-marketing-feedback-spaced {
+  margin-bottom: 12px;
+}
+
+.admin-marketing-detail-body {
+  margin-bottom: 12px;
+}
+
+.admin-marketing-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.admin-marketing-transition-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.admin-marketing-row-pointer {
+  cursor: pointer;
+}
+
 /* -- occurrence timeline -------------------------------------------------- */
 
 .admin-occurrence-spaced {


### PR DESCRIPTION
## Summary
- Migrated 21 shared-pattern-available inline styles from AdminMarketingSection to semantic CSS classes
- Migrated 13 shared-pattern-available inline styles from AdminDebugBundlePanel to existing CSS classes
- Added 14 new marketing-specific admin CSS classes to styles/app.css
- No dynamic-content-driven styles touched (StatusBadge status colours, col.mono ternary remain)
- Inline style count reduced from 263 to 229 (34 sites eliminated)

## Test plan
- [x] Marketing section tests pass (36/36)
- [x] Debug bundle tests pass (11/11)
- [x] CSP budget test shows reduced count (8/8)
- [x] No new inline styles introduced