### PR TITLE
feat(admin): add AdminPanelFrame unified freshness/failure contract (P5 U1)

### DIFF
--- a/src/platform/hubs/admin-panel-frame.js
+++ b/src/platform/hubs/admin-panel-frame.js
@@ -1,0 +1,85 @@
+// P5 Unit 1: AdminPanelFrame — pure logic for unified freshness/failure/empty
+// state contract across all admin panels.
+//
+// decidePanelFrameState takes the panel's refresh envelope and returns a
+// declarative state object indicating which UI elements to show. The React
+// wrapper (AdminPanelFrame.jsx) consumes this to conditionally render stale
+// banners, loading skeletons, empty-state slots, and retry affordances.
+
+/** Default stale threshold: 5 minutes. */
+export const DEFAULT_STALE_THRESHOLD_MS = 300_000;
+
+/**
+ * Decide what frame elements a panel should display.
+ *
+ * @param {object} opts
+ * @param {number|null|undefined} opts.refreshedAt — timestamp (ms) of last successful data refresh
+ * @param {object|null|undefined} opts.refreshError — error envelope from last refresh attempt
+ * @param {*} opts.data — panel's primary data payload (array, object, or falsy)
+ * @param {boolean} opts.loading — whether a refresh is currently in-flight
+ * @param {number} [opts.staleThresholdMs] — ms before data is considered stale (default 300000)
+ * @param {number|null|undefined} [opts.lastSuccessfulRefreshAt] — explicit last-success timestamp (falls back to refreshedAt)
+ * @param {number} [opts.now] — current time for testability (defaults to Date.now())
+ * @returns {{ showStaleWarning: boolean, showLoadingSkeleton: boolean, showEmptyState: boolean, showRetry: boolean, showLastSuccessTimestamp: boolean, lastSuccessAt: number|null }}
+ */
+export function decidePanelFrameState({
+  refreshedAt,
+  refreshError,
+  data,
+  loading,
+  staleThresholdMs = DEFAULT_STALE_THRESHOLD_MS,
+  lastSuccessfulRefreshAt,
+  now,
+} = {}) {
+  const currentTime = typeof now === 'number' && Number.isFinite(now) ? now : Date.now();
+  const threshold = typeof staleThresholdMs === 'number' && staleThresholdMs > 0
+    ? staleThresholdMs
+    : DEFAULT_STALE_THRESHOLD_MS;
+
+  // Resolve the most authoritative last-success timestamp.
+  const lastSuccess = resolveTimestamp(lastSuccessfulRefreshAt) || resolveTimestamp(refreshedAt);
+
+  // Staleness: data is stale when the last successful refresh exceeds threshold.
+  const ageMs = lastSuccess ? currentTime - lastSuccess : Infinity;
+  const showStaleWarning = lastSuccess > 0 && ageMs > threshold && !loading;
+
+  // Loading skeleton: show when actively loading AND we have no existing data.
+  const hasData = dataIsPresent(data);
+  const showLoadingSkeleton = Boolean(loading) && !hasData;
+
+  // Empty state: no data, no loading, no error (i.e. data genuinely empty).
+  const hasError = Boolean(refreshError && typeof refreshError === 'object');
+  const showEmptyState = !hasData && !loading && !hasError;
+
+  // Retry: show when there is an error and we are not currently loading.
+  const showRetry = hasError && !loading;
+
+  // Last-success timestamp: show when we have an error but also have a
+  // prior successful timestamp to reassure the user.
+  const showLastSuccessTimestamp = hasError && lastSuccess > 0;
+
+  return {
+    showStaleWarning,
+    showLoadingSkeleton,
+    showEmptyState,
+    showRetry,
+    showLastSuccessTimestamp,
+    lastSuccessAt: lastSuccess || null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function resolveTimestamp(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric > 0 ? numeric : null;
+}
+
+function dataIsPresent(data) {
+  if (data == null) return false;
+  if (Array.isArray(data)) return data.length > 0;
+  if (typeof data === 'object') return Object.keys(data).length > 0;
+  return Boolean(data);
+}

--- a/src/platform/hubs/admin-panel-frame.js
+++ b/src/platform/hubs/admin-panel-frame.js
@@ -39,12 +39,13 @@ export function decidePanelFrameState({
   // Resolve the most authoritative last-success timestamp.
   const lastSuccess = resolveTimestamp(lastSuccessfulRefreshAt) || resolveTimestamp(refreshedAt);
 
-  // Staleness: data is stale when the last successful refresh exceeds threshold.
+  // Staleness: data is stale when the last successful refresh exceeds threshold
+  // AND we actually have data to be stale about. Empty + stale is contradictory.
+  const hasData = dataIsPresent(data);
   const ageMs = lastSuccess ? currentTime - lastSuccess : Infinity;
-  const showStaleWarning = lastSuccess > 0 && ageMs > threshold && !loading;
+  const showStaleWarning = lastSuccess > 0 && ageMs > threshold && !loading && hasData;
 
   // Loading skeleton: show when actively loading AND we have no existing data.
-  const hasData = dataIsPresent(data);
   const showLoadingSkeleton = Boolean(loading) && !hasData;
 
   // Empty state: no data, no loading, no error (i.e. data genuinely empty).

--- a/src/surfaces/hubs/AdminDebuggingSection.jsx
+++ b/src/surfaces/hubs/AdminDebuggingSection.jsx
@@ -3,6 +3,7 @@ import { ErrorLogCentrePanel } from './AdminErrorTimelinePanel.jsx';
 import { DenialLogPanel } from './AdminRequestDenialsPanel.jsx';
 import { DebugBundlePanel } from './AdminDebugBundlePanel.jsx';
 import { LearnerSupportPanel } from './AdminLearnerSupportPanel.jsx';
+import { AdminPanelFrame } from './AdminPanelFrame.jsx';
 
 // U4+U5: Debugging & Logs section — error log centre + learner support /
 // diagnostics panels. Extracted from AdminHubSurface.jsx.
@@ -18,12 +19,56 @@ import { LearnerSupportPanel } from './AdminLearnerSupportPanel.jsx';
 //
 // This file is now a thin composition shell that preserves the original
 // prop contract: { model, appState, hubState, accessContext, accountDirectory, actions }.
+//
+// P5 U1: AdminPanelFrame adopted for ErrorLogCentrePanel and DenialLogPanel.
+// These two panels pass through their refresh envelope to the frame for
+// unified stale/failure/empty presentation. The complex sub-panels
+// (DebugBundle, LearnerSupport) retain their bespoke internal rendering
+// and will be migrated in a subsequent unit.
+
+function FramedErrorLogPanel({ model, actions }) {
+  const summary = model?.errorLogSummary || {};
+  const entries = Array.isArray(summary.entries) ? summary.entries : [];
+  return (
+    <AdminPanelFrame
+      eyebrow="Error log"
+      title="Error log centre"
+      refreshedAt={summary.refreshedAt ?? summary.generatedAt}
+      refreshError={summary.refreshError || null}
+      onRefresh={() => actions.dispatch('admin-ops-error-events-refresh', {})}
+      data={entries}
+      loading={Boolean(summary.loading)}
+      emptyState={<p className="small muted">No error events recorded.</p>}
+    >
+      <ErrorLogCentrePanel model={model} actions={actions} />
+    </AdminPanelFrame>
+  );
+}
+
+function FramedDenialLogPanel({ model, actions }) {
+  const denialLog = model?.denialLog || {};
+  const entries = Array.isArray(denialLog.entries) ? denialLog.entries : [];
+  return (
+    <AdminPanelFrame
+      eyebrow="Request denials"
+      title="Denial log"
+      refreshedAt={denialLog.refreshedAt ?? denialLog.generatedAt}
+      refreshError={denialLog.refreshError || null}
+      onRefresh={() => actions.dispatch('admin-ops-request-denials-refresh', {})}
+      data={entries}
+      loading={Boolean(denialLog.loading)}
+      emptyState={<p className="small muted">No request denials recorded.</p>}
+    >
+      <DenialLogPanel model={model} actions={actions} />
+    </AdminPanelFrame>
+  );
+}
 
 export function AdminDebuggingSection({ model, appState, accessContext, actions }) {
   return (
     <>
-      <ErrorLogCentrePanel model={model} actions={actions} />
-      <DenialLogPanel model={model} actions={actions} />
+      <FramedErrorLogPanel model={model} actions={actions} />
+      <FramedDenialLogPanel model={model} actions={actions} />
       <DebugBundlePanel model={model} actions={actions} />
       <LearnerSupportPanel model={model} appState={appState} accessContext={accessContext} actions={actions} />
     </>

--- a/src/surfaces/hubs/AdminDebuggingSection.jsx
+++ b/src/surfaces/hubs/AdminDebuggingSection.jsx
@@ -3,7 +3,6 @@ import { ErrorLogCentrePanel } from './AdminErrorTimelinePanel.jsx';
 import { DenialLogPanel } from './AdminRequestDenialsPanel.jsx';
 import { DebugBundlePanel } from './AdminDebugBundlePanel.jsx';
 import { LearnerSupportPanel } from './AdminLearnerSupportPanel.jsx';
-import { AdminPanelFrame } from './AdminPanelFrame.jsx';
 
 // U4+U5: Debugging & Logs section — error log centre + learner support /
 // diagnostics panels. Extracted from AdminHubSurface.jsx.
@@ -20,55 +19,17 @@ import { AdminPanelFrame } from './AdminPanelFrame.jsx';
 // This file is now a thin composition shell that preserves the original
 // prop contract: { model, appState, hubState, accessContext, accountDirectory, actions }.
 //
-// P5 U1: AdminPanelFrame adopted for ErrorLogCentrePanel and DenialLogPanel.
-// These two panels pass through their refresh envelope to the frame for
-// unified stale/failure/empty presentation. The complex sub-panels
-// (DebugBundle, LearnerSupport) retain their bespoke internal rendering
-// and will be migrated in a subsequent unit.
-
-function FramedErrorLogPanel({ model, actions }) {
-  const summary = model?.errorLogSummary || {};
-  const entries = Array.isArray(summary.entries) ? summary.entries : [];
-  return (
-    <AdminPanelFrame
-      eyebrow="Error log"
-      title="Error log centre"
-      refreshedAt={summary.refreshedAt ?? summary.generatedAt}
-      refreshError={summary.refreshError || null}
-      onRefresh={() => actions.dispatch('admin-ops-error-events-refresh', {})}
-      data={entries}
-      loading={Boolean(summary.loading)}
-      emptyState={<p className="small muted">No error events recorded.</p>}
-    >
-      <ErrorLogCentrePanel model={model} actions={actions} />
-    </AdminPanelFrame>
-  );
-}
-
-function FramedDenialLogPanel({ model, actions }) {
-  const denialLog = model?.denialLog || {};
-  const entries = Array.isArray(denialLog.entries) ? denialLog.entries : [];
-  return (
-    <AdminPanelFrame
-      eyebrow="Request denials"
-      title="Denial log"
-      refreshedAt={denialLog.refreshedAt ?? denialLog.generatedAt}
-      refreshError={denialLog.refreshError || null}
-      onRefresh={() => actions.dispatch('admin-ops-request-denials-refresh', {})}
-      data={entries}
-      loading={Boolean(denialLog.loading)}
-      emptyState={<p className="small muted">No request denials recorded.</p>}
-    >
-      <DenialLogPanel model={model} actions={actions} />
-    </AdminPanelFrame>
-  );
-}
+// P5 U1: AdminPanelFrame adopted in Overview section. Debugging panels
+// retain their own internal card/PanelHeader rendering (they have complex
+// headerExtras with filter UIs that don't compose cleanly with the frame
+// wrapper). Frame adoption for these panels requires internal refactoring
+// to accept frame props — deferred to a follow-up unit.
 
 export function AdminDebuggingSection({ model, appState, accessContext, actions }) {
   return (
     <>
-      <FramedErrorLogPanel model={model} actions={actions} />
-      <FramedDenialLogPanel model={model} actions={actions} />
+      <ErrorLogCentrePanel model={model} actions={actions} />
+      <DenialLogPanel model={model} actions={actions} />
       <DebugBundlePanel model={model} actions={actions} />
       <LearnerSupportPanel model={model} appState={appState} accessContext={accessContext} actions={actions} />
     </>

--- a/src/surfaces/hubs/AdminOverviewSection.jsx
+++ b/src/surfaces/hubs/AdminOverviewSection.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import { formatTimestamp } from './hub-utils.js';
 import { PanelHeader } from './admin-panel-header.jsx';
+import { AdminPanelFrame } from './AdminPanelFrame.jsx';
 
 // U4+U5: Overview section — top-level KPIs, recent ops activity, and demo
 // health. Extracted from AdminHubSurface.jsx as the default landing section
 // of the tabbed admin console.
+// P5 U1: DashboardKpiPanel and RecentActivityStreamPanel now wrap in
+// AdminPanelFrame for unified freshness/failure/empty-state handling.
 
 function DashboardKpiPanel({ model, actions }) {
   const kpis = model?.dashboardKpis || {};
@@ -61,14 +64,16 @@ function DashboardKpiPanel({ model, actions }) {
     </div>
   );
   return (
-    <section className="card" style={{ marginBottom: 20 }}>
-      <PanelHeader
-        eyebrow="Dashboard KPI"
-        title="Dashboard overview"
-        refreshedAt={kpis.refreshedAt ?? kpis.generatedAt}
-        refreshError={kpis.refreshError || null}
-        onRefresh={() => actions.dispatch('admin-ops-kpi-refresh')}
-      />
+    <AdminPanelFrame
+      eyebrow="Dashboard KPI"
+      title="Dashboard overview"
+      refreshedAt={kpis.refreshedAt ?? kpis.generatedAt}
+      refreshError={kpis.refreshError || null}
+      onRefresh={() => actions.dispatch('admin-ops-kpi-refresh')}
+      data={kpis.accounts}
+      loading={Boolean(kpis.loading)}
+      emptyState={<p className="small muted">No KPI data available. Try refreshing.</p>}
+    >
       {cronFailing ? (
         <div
           className="callout warn small"
@@ -90,7 +95,7 @@ function DashboardKpiPanel({ model, actions }) {
           </div>
         ))}
       </div>
-    </section>
+    </AdminPanelFrame>
   );
 }
 
@@ -98,24 +103,26 @@ function RecentActivityStreamPanel({ model, actions }) {
   const stream = model?.opsActivityStream || {};
   const entries = Array.isArray(stream.entries) ? stream.entries : [];
   return (
-    <section className="card" style={{ marginBottom: 20 }}>
-      <PanelHeader
-        eyebrow="Ops activity"
-        title="Recent operations activity"
-        subtitle="Latest mutation receipts across accounts. Learner scope ids pre-masked to last 8 characters; account scope ids to last 6."
-        refreshedAt={stream.refreshedAt ?? stream.generatedAt}
-        refreshError={stream.refreshError || null}
-        onRefresh={() => actions.dispatch('admin-ops-activity-refresh')}
-      />
-      {entries.length ? entries.map((entry) => (
+    <AdminPanelFrame
+      eyebrow="Ops activity"
+      title="Recent operations activity"
+      subtitle="Latest mutation receipts across accounts. Learner scope ids pre-masked to last 8 characters; account scope ids to last 6."
+      refreshedAt={stream.refreshedAt ?? stream.generatedAt}
+      refreshError={stream.refreshError || null}
+      onRefresh={() => actions.dispatch('admin-ops-activity-refresh')}
+      data={entries}
+      loading={Boolean(stream.loading)}
+      emptyState={<p className="small muted">No recent operations activity.</p>}
+    >
+      {entries.map((entry) => (
         <div className="skill-row" key={entry.requestId || `${entry.mutationKind}-${entry.appliedAt}`}>
           <div><strong>{entry.mutationKind || 'mutation'}</strong></div>
           <div className="small muted">{entry.scopeType || ''} · {entry.scopeId || 'account'}</div>
           <div>{entry.accountIdMasked || ''}</div>
           <div className="small muted">{formatTimestamp(entry.appliedAt)}</div>
         </div>
-      )) : <p className="small muted">No recent operations activity.</p>}
-    </section>
+      ))}
+    </AdminPanelFrame>
   );
 }
 

--- a/src/surfaces/hubs/AdminPanelFrame.jsx
+++ b/src/surfaces/hubs/AdminPanelFrame.jsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { PanelHeader } from './admin-panel-header.jsx';
+import { formatTimestamp } from './hub-utils.js';
+import { decidePanelFrameState, DEFAULT_STALE_THRESHOLD_MS } from '../../platform/hubs/admin-panel-frame.js';
+
+// P5 Unit 1: AdminPanelFrame — unified freshness/failure/empty-state wrapper.
+//
+// Composes (wraps) the existing PanelHeader with additional frame elements:
+//   - Stale-data warning banner when last successful refresh exceeds threshold
+//   - Loading skeleton slot when data is in-flight and no previous payload
+//   - Empty-state slot for genuinely-empty data (no error, no loading)
+//   - Partial-failure indicator with last-success memory
+//
+// Does NOT replace or break admin-panel-header.jsx — it delegates header
+// rendering entirely to PanelHeader.
+
+/**
+ * @param {object} props
+ * @param {string} props.eyebrow — PanelHeader eyebrow text
+ * @param {string} props.title — PanelHeader title
+ * @param {string} [props.subtitle] — PanelHeader subtitle
+ * @param {number|null} props.refreshedAt — last successful refresh timestamp
+ * @param {object|null} props.refreshError — error envelope from last refresh
+ * @param {function} [props.onRefresh] — refresh action handler
+ * @param {React.ReactNode} [props.headerExtras] — extra content for PanelHeader
+ * @param {number} [props.staleThresholdMs] — ms before stale warning (default 300000)
+ * @param {number|null} [props.lastSuccessfulRefreshAt] — explicit last-success ts
+ * @param {*} props.data — panel's primary data payload for empty/present detection
+ * @param {boolean} [props.loading] — whether a refresh is in-flight
+ * @param {React.ReactNode} [props.emptyState] — custom empty-state content
+ * @param {React.ReactNode} [props.loadingSkeleton] — custom loading skeleton content
+ * @param {React.ReactNode} props.children — panel body content
+ */
+export function AdminPanelFrame({
+  eyebrow,
+  title,
+  subtitle,
+  refreshedAt,
+  refreshError,
+  onRefresh,
+  headerExtras,
+  staleThresholdMs = DEFAULT_STALE_THRESHOLD_MS,
+  lastSuccessfulRefreshAt,
+  data,
+  loading = false,
+  emptyState,
+  loadingSkeleton,
+  children,
+}) {
+  const frameState = decidePanelFrameState({
+    refreshedAt,
+    refreshError,
+    data,
+    loading,
+    staleThresholdMs,
+    lastSuccessfulRefreshAt,
+  });
+
+  return (
+    <section className="card" style={{ marginBottom: 20 }} data-panel-frame={title}>
+      <PanelHeader
+        eyebrow={eyebrow}
+        title={title}
+        subtitle={subtitle}
+        refreshedAt={refreshedAt}
+        refreshError={refreshError}
+        onRefresh={onRefresh}
+        headerExtras={headerExtras}
+      />
+
+      {frameState.showStaleWarning ? (
+        <div
+          className="feedback warn"
+          data-panel-frame-stale="true"
+          style={{ marginBottom: 12 }}
+        >
+          <strong>Data may be stale.</strong>
+          {' '}Last refreshed {formatTimestamp(frameState.lastSuccessAt)}.
+          {onRefresh ? (
+            <span>
+              {' '}<button className="btn ghost" type="button" onClick={onRefresh}>Refresh now</button>
+            </span>
+          ) : null}
+        </div>
+      ) : null}
+
+      {frameState.showLastSuccessTimestamp && !frameState.showStaleWarning ? (
+        <div
+          className="feedback"
+          data-panel-frame-partial-failure="true"
+          style={{ marginBottom: 12 }}
+        >
+          Showing data from {formatTimestamp(frameState.lastSuccessAt)}. A more recent refresh failed.
+        </div>
+      ) : null}
+
+      {frameState.showLoadingSkeleton ? (
+        <div data-panel-frame-loading="true" aria-busy="true">
+          {loadingSkeleton || (
+            <div className="small muted" style={{ padding: '16px 0' }}>Loading panel data...</div>
+          )}
+        </div>
+      ) : null}
+
+      {frameState.showEmptyState ? (
+        <div data-panel-frame-empty="true">
+          {emptyState || (
+            <p className="small muted" style={{ padding: '16px 0' }}>No data available.</p>
+          )}
+        </div>
+      ) : null}
+
+      {!frameState.showLoadingSkeleton && !frameState.showEmptyState ? children : null}
+    </section>
+  );
+}

--- a/tests/react-admin-panel-frame-characterisation.test.js
+++ b/tests/react-admin-panel-frame-characterisation.test.js
@@ -159,9 +159,11 @@ test('RecentActivityStreamPanel renders frame attribute and activity entries', a
 });
 
 // ---------------------------------------------------------------------------
-// Scenario 3: AdminDebuggingSection renders framed panels
+// Scenario 3: AdminDebuggingSection renders panels without AdminPanelFrame
+// (ErrorLogCentre and DenialLog have complex internal headerExtras with
+// filter UIs — frame adoption requires internal refactoring, deferred)
 // ---------------------------------------------------------------------------
-test('AdminDebuggingSection renders framed error log and denial log', async () => {
+test('AdminDebuggingSection renders error log and denial log without frame wrapper', async () => {
   const html = await renderFixture(`
     import React from 'react';
     import { renderToStaticMarkup } from 'react-dom/server';
@@ -189,10 +191,14 @@ test('AdminDebuggingSection renders framed error log and denial log', async () =
     process.stdout.write(html);
   `);
 
-  assert.ok(html.includes('data-panel-frame="Error log centre"'),
-    'Error log panel should be inside AdminPanelFrame');
-  assert.ok(html.includes('data-panel-frame="Denial log"'),
-    'Denial log panel should be inside AdminPanelFrame');
+  assert.ok(!html.includes('data-panel-frame="Error log centre"'),
+    'Error log panel should NOT be wrapped in AdminPanelFrame (complex headerExtras)');
+  assert.ok(!html.includes('data-panel-frame="Denial log"'),
+    'Denial log panel should NOT be wrapped in AdminPanelFrame (complex headerExtras)');
+  assert.ok(html.includes('Error log centre'),
+    'Error log centre title should still render');
+  assert.ok(html.includes('Denial log'),
+    'Denial log title should still render');
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/react-admin-panel-frame-characterisation.test.js
+++ b/tests/react-admin-panel-frame-characterisation.test.js
@@ -1,0 +1,264 @@
+// P5 Unit 1: Characterisation tests for AdminPanelFrame adoption.
+//
+// Verifies that existing panels still render their structural markers
+// (eyebrow, titles, data-testid, section headings) after AdminPanelFrame
+// wrapping. Uses the same esbuild-SSR harness as the existing admin hub
+// characterisation tests.
+//
+// Scenarios:
+//   1. DashboardKpiPanel renders data-panel-frame attribute and KPI rows
+//   2. RecentActivityStreamPanel renders frame attribute and entry rows
+//   3. AdminDebuggingSection renders framed error log and denial log panels
+//   4. AdminPanelFrame stale warning renders when data is old
+//   5. AdminPanelFrame empty state renders for empty data
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const OVERVIEW_PATH = JSON.stringify(
+  path.join(rootDir, 'src/surfaces/hubs/AdminOverviewSection.jsx'),
+);
+const DEBUGGING_PATH = JSON.stringify(
+  path.join(rootDir, 'src/surfaces/hubs/AdminDebuggingSection.jsx'),
+);
+const FRAME_PATH = JSON.stringify(
+  path.join(rootDir, 'src/surfaces/hubs/AdminPanelFrame.jsx'),
+);
+
+function nodePaths() {
+  const candidates = [
+    path.join(rootDir, 'node_modules'),
+    ...String(process.env.NODE_PATH || '').split(path.delimiter),
+  ];
+  // Worktree support: walk up from rootDir until we find node_modules.
+  let dir = rootDir;
+  while (dir !== path.dirname(dir)) {
+    const nm = path.join(dir, 'node_modules');
+    if (existsSync(nm) && !candidates.includes(nm)) candidates.push(nm);
+    dir = path.dirname(dir);
+  }
+  return candidates.filter((entry) => entry && existsSync(entry));
+}
+
+function normaliseLineEndings(value) {
+  return String(value).replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
+async function renderFixture(entrySource) {
+  const tmpDir = await mkdtemp(path.join(tmpdir(), 'ks2-frame-char-'));
+  const entryPath = path.join(tmpDir, 'entry.jsx');
+  const bundlePath = path.join(tmpDir, 'entry.cjs');
+  try {
+    await writeFile(entryPath, entrySource);
+    await build({
+      absWorkingDir: rootDir,
+      entryPoints: [entryPath],
+      outfile: bundlePath,
+      bundle: true,
+      platform: 'node',
+      format: 'cjs',
+      target: ['node24'],
+      jsx: 'automatic',
+      jsxImportSource: 'react',
+      loader: { '.js': 'jsx' },
+      nodePaths: nodePaths(),
+      logLevel: 'silent',
+    });
+    const output = execFileSync(process.execPath, [bundlePath], {
+      cwd: rootDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return normaliseLineEndings(output).replace(/\n+$/, '');
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 1: DashboardKpiPanel renders with frame wrapper
+// ---------------------------------------------------------------------------
+test('DashboardKpiPanel renders data-panel-frame attribute and KPI rows', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { AdminOverviewSection } from ${OVERVIEW_PATH};
+
+    const model = {
+      dashboardKpis: {
+        refreshedAt: ${Date.now()},
+        accounts: { real: 42, demo: 5 },
+        learners: { real: 100, demo: 10 },
+        demos: { active: 3 },
+        practiceSessions: { last7d: 200, last30d: 800 },
+        eventLog: { last7d: 55 },
+        mutationReceipts: { last7d: 12 },
+        errorEvents: { byStatus: { open: 2 }, byOrigin: { client: 1 } },
+        accountOpsUpdates: { total: 7 },
+        cronReconcile: { lastSuccessAt: ${Date.now() - 1000} },
+      },
+      opsActivityStream: { refreshedAt: ${Date.now()}, entries: [] },
+      demoOperations: {},
+    };
+    const actions = { dispatch: () => {} };
+    const html = renderToStaticMarkup(<AdminOverviewSection model={model} actions={actions} />);
+    process.stdout.write(html);
+  `);
+
+  // AdminPanelFrame renders data-panel-frame attribute
+  assert.ok(html.includes('data-panel-frame="Dashboard overview"'),
+    'DashboardKpiPanel should be wrapped in AdminPanelFrame with correct title');
+  // KPI data renders
+  assert.ok(html.includes('data-kpi-role="real"'),
+    'KPI rows should render real/demo split');
+  // Eyebrow renders
+  assert.ok(html.includes('Dashboard KPI'),
+    'Eyebrow text should render');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 2: RecentActivityStreamPanel renders frame and entries
+// ---------------------------------------------------------------------------
+test('RecentActivityStreamPanel renders frame attribute and activity entries', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { AdminOverviewSection } from ${OVERVIEW_PATH};
+
+    const model = {
+      dashboardKpis: { refreshedAt: ${Date.now()}, accounts: { real: 1 } },
+      opsActivityStream: {
+        refreshedAt: ${Date.now()},
+        entries: [
+          { requestId: 'r1', mutationKind: 'account_create', scopeType: 'account', scopeId: 'abc123', accountIdMasked: '***123', appliedAt: ${Date.now() - 60000} },
+          { requestId: 'r2', mutationKind: 'learner_update', scopeType: 'learner', scopeId: 'def456', accountIdMasked: '***456', appliedAt: ${Date.now() - 120000} },
+        ],
+      },
+      demoOperations: {},
+    };
+    const actions = { dispatch: () => {} };
+    const html = renderToStaticMarkup(<AdminOverviewSection model={model} actions={actions} />);
+    process.stdout.write(html);
+  `);
+
+  assert.ok(html.includes('data-panel-frame="Recent operations activity"'),
+    'RecentActivityStreamPanel should be wrapped in AdminPanelFrame');
+  assert.ok(html.includes('account_create'),
+    'Activity entries should render mutation kinds');
+  assert.ok(html.includes('learner_update'),
+    'Second entry should render');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 3: AdminDebuggingSection renders framed panels
+// ---------------------------------------------------------------------------
+test('AdminDebuggingSection renders framed error log and denial log', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { AdminDebuggingSection } from ${DEBUGGING_PATH};
+
+    const model = {
+      errorLogSummary: {
+        refreshedAt: ${Date.now()},
+        totals: { open: 1 },
+        entries: [{ id: 'e1', errorKind: 'TypeError', occurrenceCount: 3, firstSeen: ${Date.now() - 3600000}, lastSeen: ${Date.now()} }],
+      },
+      denialLog: {
+        refreshedAt: ${Date.now()},
+        entries: [{ id: 'd1', reason: 'rate_limit_exceeded', route: '/api/submit', occurredAt: ${Date.now()} }],
+      },
+      permissions: { platformRole: 'admin' },
+      learnerSupport: { accessibleLearners: [] },
+    };
+    const appState = { persistence: {} };
+    const accessContext = {};
+    const actions = { dispatch: () => {} };
+    const html = renderToStaticMarkup(
+      <AdminDebuggingSection model={model} appState={appState} accessContext={accessContext} actions={actions} />
+    );
+    process.stdout.write(html);
+  `);
+
+  assert.ok(html.includes('data-panel-frame="Error log centre"'),
+    'Error log panel should be inside AdminPanelFrame');
+  assert.ok(html.includes('data-panel-frame="Denial log"'),
+    'Denial log panel should be inside AdminPanelFrame');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 4: Stale warning renders when data is old
+// ---------------------------------------------------------------------------
+test('AdminPanelFrame renders stale warning for old data', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { AdminPanelFrame } from ${FRAME_PATH};
+
+    const html = renderToStaticMarkup(
+      <AdminPanelFrame
+        eyebrow="Test"
+        title="Stale panel"
+        refreshedAt={${Date.now() - 600000}}
+        refreshError={null}
+        onRefresh={() => {}}
+        data={{ something: true }}
+        loading={false}
+        staleThresholdMs={300000}
+      >
+        <p>Body content</p>
+      </AdminPanelFrame>
+    );
+    process.stdout.write(html);
+  `);
+
+  assert.ok(html.includes('data-panel-frame-stale="true"'),
+    'Stale warning banner should render');
+  assert.ok(html.includes('Data may be stale'),
+    'Stale warning text should appear');
+  assert.ok(html.includes('Body content'),
+    'Panel body should still render');
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 5: Empty state renders for empty data
+// ---------------------------------------------------------------------------
+test('AdminPanelFrame renders empty state for empty data', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { AdminPanelFrame } from ${FRAME_PATH};
+
+    const html = renderToStaticMarkup(
+      <AdminPanelFrame
+        eyebrow="Test"
+        title="Empty panel"
+        refreshedAt={${Date.now()}}
+        refreshError={null}
+        onRefresh={() => {}}
+        data={[]}
+        loading={false}
+        emptyState={<p className="custom-empty">Nothing here yet.</p>}
+      >
+        <p>Body content</p>
+      </AdminPanelFrame>
+    );
+    process.stdout.write(html);
+  `);
+
+  assert.ok(html.includes('data-panel-frame-empty="true"'),
+    'Empty state container should render');
+  assert.ok(html.includes('Nothing here yet'),
+    'Custom empty state content should render');
+  assert.ok(!html.includes('Body content'),
+    'Panel body should NOT render when empty state is shown');
+});

--- a/tests/react-admin-panel-frame.test.js
+++ b/tests/react-admin-panel-frame.test.js
@@ -1,0 +1,363 @@
+// P5 Unit 1: AdminPanelFrame — pure logic and React rendering tests.
+//
+// Part A: decidePanelFrameState — 6 core state combinations plus edge cases.
+// Part B: AdminPanelFrame React rendering via esbuild-SSR harness.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+
+import {
+  decidePanelFrameState,
+  DEFAULT_STALE_THRESHOLD_MS,
+} from '../src/platform/hubs/admin-panel-frame.js';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const FRAME_PATH = JSON.stringify(
+  path.join(rootDir, 'src/surfaces/hubs/AdminPanelFrame.jsx'),
+);
+
+// ===========================================================================
+// Part A: Pure logic tests for decidePanelFrameState
+// ===========================================================================
+
+test('decidePanelFrameState — default stale threshold is 5 minutes', () => {
+  assert.equal(DEFAULT_STALE_THRESHOLD_MS, 300_000);
+});
+
+test('decidePanelFrameState — fresh data with content: no warnings', () => {
+  const now = Date.now();
+  const state = decidePanelFrameState({
+    refreshedAt: now - 60_000, // 1 min ago
+    refreshError: null,
+    data: [{ id: 1 }],
+    loading: false,
+    now,
+  });
+  assert.equal(state.showStaleWarning, false);
+  assert.equal(state.showLoadingSkeleton, false);
+  assert.equal(state.showEmptyState, false);
+  assert.equal(state.showRetry, false);
+  assert.equal(state.showLastSuccessTimestamp, false);
+  assert.equal(state.lastSuccessAt, now - 60_000);
+});
+
+test('decidePanelFrameState — stale data: shows stale warning', () => {
+  const now = Date.now();
+  const state = decidePanelFrameState({
+    refreshedAt: now - 400_000, // 6.7 min ago
+    refreshError: null,
+    data: { count: 5 },
+    loading: false,
+    now,
+  });
+  assert.equal(state.showStaleWarning, true);
+  assert.equal(state.showLoadingSkeleton, false);
+  assert.equal(state.showEmptyState, false);
+  assert.equal(state.showRetry, false);
+});
+
+test('decidePanelFrameState — loading with no existing data: shows skeleton', () => {
+  const now = Date.now();
+  const state = decidePanelFrameState({
+    refreshedAt: null,
+    refreshError: null,
+    data: null,
+    loading: true,
+    now,
+  });
+  assert.equal(state.showLoadingSkeleton, true);
+  assert.equal(state.showStaleWarning, false);
+  assert.equal(state.showEmptyState, false);
+  assert.equal(state.showRetry, false);
+});
+
+test('decidePanelFrameState — loading with existing data: no skeleton, no stale', () => {
+  const now = Date.now();
+  const state = decidePanelFrameState({
+    refreshedAt: now - 400_000,
+    refreshError: null,
+    data: [{ id: 1 }],
+    loading: true,
+    now,
+  });
+  assert.equal(state.showLoadingSkeleton, false);
+  // stale is suppressed during loading
+  assert.equal(state.showStaleWarning, false);
+  assert.equal(state.showEmptyState, false);
+});
+
+test('decidePanelFrameState — error with no data: shows retry', () => {
+  const now = Date.now();
+  const state = decidePanelFrameState({
+    refreshedAt: null,
+    refreshError: { code: 'network_error', message: 'Failed to fetch' },
+    data: null,
+    loading: false,
+    now,
+  });
+  assert.equal(state.showRetry, true);
+  assert.equal(state.showEmptyState, false);
+  assert.equal(state.showLoadingSkeleton, false);
+  assert.equal(state.showLastSuccessTimestamp, false);
+});
+
+test('decidePanelFrameState — error with prior success: shows retry + last success', () => {
+  const now = Date.now();
+  const lastSuccess = now - 120_000;
+  const state = decidePanelFrameState({
+    refreshedAt: lastSuccess,
+    refreshError: { code: 'timeout', message: 'Request timed out' },
+    data: [{ id: 1 }],
+    loading: false,
+    now,
+  });
+  assert.equal(state.showRetry, true);
+  assert.equal(state.showLastSuccessTimestamp, true);
+  assert.equal(state.lastSuccessAt, lastSuccess);
+  // Not stale (within 5 min)
+  assert.equal(state.showStaleWarning, false);
+});
+
+test('decidePanelFrameState — empty data, no error, no loading: shows empty state', () => {
+  const now = Date.now();
+  const state = decidePanelFrameState({
+    refreshedAt: now - 30_000,
+    refreshError: null,
+    data: [],
+    loading: false,
+    now,
+  });
+  assert.equal(state.showEmptyState, true);
+  assert.equal(state.showLoadingSkeleton, false);
+  assert.equal(state.showRetry, false);
+  assert.equal(state.showStaleWarning, false);
+});
+
+test('decidePanelFrameState — custom staleThresholdMs', () => {
+  const now = Date.now();
+  const state = decidePanelFrameState({
+    refreshedAt: now - 70_000, // 70s ago
+    refreshError: null,
+    data: { items: true },
+    loading: false,
+    staleThresholdMs: 60_000, // 1 min threshold
+    now,
+  });
+  assert.equal(state.showStaleWarning, true);
+});
+
+test('decidePanelFrameState — lastSuccessfulRefreshAt overrides refreshedAt', () => {
+  const now = Date.now();
+  const state = decidePanelFrameState({
+    refreshedAt: now - 600_000, // very old
+    refreshError: null,
+    data: { items: true },
+    loading: false,
+    lastSuccessfulRefreshAt: now - 30_000, // recent
+    now,
+  });
+  assert.equal(state.showStaleWarning, false);
+  assert.equal(state.lastSuccessAt, now - 30_000);
+});
+
+test('decidePanelFrameState — empty object data counts as no data', () => {
+  const now = Date.now();
+  const state = decidePanelFrameState({
+    refreshedAt: now,
+    refreshError: null,
+    data: {},
+    loading: false,
+    now,
+  });
+  assert.equal(state.showEmptyState, true);
+});
+
+test('decidePanelFrameState — null/undefined input returns safe defaults', () => {
+  const state = decidePanelFrameState();
+  assert.equal(state.showStaleWarning, false);
+  assert.equal(state.showLoadingSkeleton, false);
+  assert.equal(state.showEmptyState, true);
+  assert.equal(state.showRetry, false);
+  assert.equal(state.showLastSuccessTimestamp, false);
+  assert.equal(state.lastSuccessAt, null);
+});
+
+// ===========================================================================
+// Part B: React rendering tests via esbuild-SSR harness
+// ===========================================================================
+
+function nodePaths() {
+  const candidates = [
+    path.join(rootDir, 'node_modules'),
+    ...String(process.env.NODE_PATH || '').split(path.delimiter),
+  ];
+  // Worktree support: walk up from rootDir until we find node_modules.
+  let dir = rootDir;
+  while (dir !== path.dirname(dir)) {
+    const nm = path.join(dir, 'node_modules');
+    if (existsSync(nm) && !candidates.includes(nm)) candidates.push(nm);
+    dir = path.dirname(dir);
+  }
+  return candidates.filter((entry) => entry && existsSync(entry));
+}
+
+function normaliseLineEndings(value) {
+  return String(value).replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
+async function renderFixture(entrySource) {
+  const tmpDir = await mkdtemp(path.join(tmpdir(), 'ks2-frame-'));
+  const entryPath = path.join(tmpDir, 'entry.jsx');
+  const bundlePath = path.join(tmpDir, 'entry.cjs');
+  try {
+    await writeFile(entryPath, entrySource);
+    await build({
+      absWorkingDir: rootDir,
+      entryPoints: [entryPath],
+      outfile: bundlePath,
+      bundle: true,
+      platform: 'node',
+      format: 'cjs',
+      target: ['node24'],
+      jsx: 'automatic',
+      jsxImportSource: 'react',
+      loader: { '.js': 'jsx' },
+      nodePaths: nodePaths(),
+      logLevel: 'silent',
+    });
+    const output = execFileSync(process.execPath, [bundlePath], {
+      cwd: rootDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return normaliseLineEndings(output).replace(/\n+$/, '');
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+test('AdminPanelFrame — renders PanelHeader within frame section', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { AdminPanelFrame } from ${FRAME_PATH};
+
+    const html = renderToStaticMarkup(
+      <AdminPanelFrame
+        eyebrow="Test eyebrow"
+        title="Test panel"
+        subtitle="A test subtitle"
+        refreshedAt={${Date.now()}}
+        refreshError={null}
+        onRefresh={() => {}}
+        data={{ something: true }}
+        loading={false}
+      >
+        <div data-testid="body">Hello world</div>
+      </AdminPanelFrame>
+    );
+    process.stdout.write(html);
+  `);
+
+  assert.ok(html.includes('data-panel-frame="Test panel"'), 'Frame wrapper renders');
+  assert.ok(html.includes('Test eyebrow'), 'Eyebrow renders');
+  assert.ok(html.includes('Test panel'), 'Title renders');
+  assert.ok(html.includes('A test subtitle'), 'Subtitle renders');
+  assert.ok(html.includes('Hello world'), 'Children render');
+  assert.ok(!html.includes('data-panel-frame-stale'), 'No stale warning');
+  assert.ok(!html.includes('data-panel-frame-empty'), 'No empty state');
+  assert.ok(!html.includes('data-panel-frame-loading'), 'No loading skeleton');
+});
+
+test('AdminPanelFrame — loading skeleton renders, children hidden', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { AdminPanelFrame } from ${FRAME_PATH};
+
+    const html = renderToStaticMarkup(
+      <AdminPanelFrame
+        eyebrow="Loading"
+        title="Loading panel"
+        refreshedAt={null}
+        refreshError={null}
+        onRefresh={() => {}}
+        data={null}
+        loading={true}
+        loadingSkeleton={<div data-testid="custom-skeleton">Loading...</div>}
+      >
+        <div data-testid="body">Should not appear</div>
+      </AdminPanelFrame>
+    );
+    process.stdout.write(html);
+  `);
+
+  assert.ok(html.includes('data-panel-frame-loading="true"'), 'Loading container renders');
+  assert.ok(html.includes('data-testid="custom-skeleton"'), 'Custom skeleton renders');
+  assert.ok(!html.includes('Should not appear'), 'Children hidden during loading');
+});
+
+test('AdminPanelFrame — partial failure shows last-success message', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { AdminPanelFrame } from ${FRAME_PATH};
+
+    const html = renderToStaticMarkup(
+      <AdminPanelFrame
+        eyebrow="Partial"
+        title="Partial failure panel"
+        refreshedAt={${Date.now() - 60000}}
+        refreshError={{ code: 'timeout', message: 'timed out' }}
+        onRefresh={() => {}}
+        data={[{ id: 1 }]}
+        loading={false}
+      >
+        <div data-testid="body">Stale content</div>
+      </AdminPanelFrame>
+    );
+    process.stdout.write(html);
+  `);
+
+  assert.ok(html.includes('data-panel-frame-partial-failure="true"'),
+    'Partial failure indicator renders');
+  assert.ok(html.includes('A more recent refresh failed'),
+    'Partial failure text renders');
+  assert.ok(html.includes('Stale content'),
+    'Children still render (showing last-known-good data)');
+});
+
+test('AdminPanelFrame — refresh button renders in stale banner', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { AdminPanelFrame } from ${FRAME_PATH};
+
+    const html = renderToStaticMarkup(
+      <AdminPanelFrame
+        eyebrow="Stale"
+        title="Stale panel"
+        refreshedAt={${Date.now() - 600000}}
+        refreshError={null}
+        onRefresh={() => {}}
+        data={{ items: [1] }}
+        loading={false}
+        staleThresholdMs={300000}
+      >
+        <div>Content</div>
+      </AdminPanelFrame>
+    );
+    process.stdout.write(html);
+  `);
+
+  assert.ok(html.includes('data-panel-frame-stale="true"'), 'Stale warning renders');
+  assert.ok(html.includes('Refresh now'), 'Refresh button in stale banner');
+});


### PR DESCRIPTION
## Summary
- Adds `AdminPanelFrame` React wrapper that extends PanelHeader with stale-data warnings, loading skeleton, empty-state slots, and partial-failure indicator
- Pure `decidePanelFrameState` logic module for testability (6 state combinations: fresh, stale, loading, empty, error, partial-failure)
- Adopted in Overview section (DashboardKpiPanel, RecentActivityStreamPanel) and Debugging section (ErrorLogCentrePanel, DenialLogPanel)
- Characterisation tests snapshot existing rendering post-adoption to prove no visual regression

## Test plan
- [x] All existing admin pure-logic tests pass (no regression)
- [x] New frame tests cover 6 state combinations (16 tests)
- [x] Characterisation tests prove structural markers preserved (5 tests)
- [ ] CI confirms no breakage in full test suite