### PR TITLE
feat(capacity): add session-manifest mode to classroom load driver

### DIFF
--- a/docs/operations/capacity.md
+++ b/docs/operations/capacity.md
@@ -10,7 +10,7 @@ This runbook records how capacity is certified for `/api/bootstrap`, subject com
 | --- | --- | --- |
 | Family demo | Ready for bounded-bootstrap smoke checks | `npm run smoke:production:bootstrap` passes with a logged-in or demo session and no redaction failures. |
 | Small pilot | Provisional | High-history bootstrap fixture passes, production bootstrap probe stays below the configured byte/count caps, and no `exceededCpu` or D1 overload appears during a small load run. |
-| 30-learner classroom beta | Not certified — P95 regression (+12.6%) under investigation (P5) | `npm run capacity:classroom -- --production --confirm-production-load ...` passes for 30 active learners, including cold-bootstrap burst and human-paced Grammar command rounds. |
+| 30-learner classroom beta | Not certified — P5 warm-cache re-run FAIL (P95 1,167 ms vs 1,000 ms ceiling, +16.7%). D1 tail latency variance, not query/payload regression. Investigation required. | `npm run capacity:classroom -- --production --confirm-production-load ...` passes for 30 active learners, including cold-bootstrap burst and human-paced Grammar command rounds. |
 | 60-learner stretch | Not certified | Same evidence as classroom beta, with acceptable P95 wall time and zero 5xx across repeated runs. |
 | 100+ school-ready target | Not certified | Requires repeated 100+ learner runs, D1 row metrics, operational tail evidence, and a rollback/degrade drill. |
 

--- a/reports/capacity/evidence/30-learner-beta-v2-20260428-p5-warm.json
+++ b/reports/capacity/evidence/30-learner-beta-v2-20260428-p5-warm.json
@@ -1,0 +1,294 @@
+{
+  "ok": false,
+  "dryRun": false,
+  "plan": {
+    "mode": "production",
+    "origin": "https://ks2.eugnel.uk",
+    "virtualLearners": [
+      {
+        "index": 0,
+        "label": "learner-01"
+      },
+      {
+        "index": 1,
+        "label": "learner-02"
+      },
+      {
+        "index": 2,
+        "label": "learner-03"
+      },
+      {
+        "index": 3,
+        "label": "learner-04"
+      },
+      {
+        "index": 4,
+        "label": "learner-05"
+      },
+      {
+        "index": 5,
+        "label": "learner-06"
+      },
+      {
+        "index": 6,
+        "label": "learner-07"
+      },
+      {
+        "index": 7,
+        "label": "learner-08"
+      },
+      {
+        "index": 8,
+        "label": "learner-09"
+      },
+      {
+        "index": 9,
+        "label": "learner-10"
+      },
+      {
+        "index": 10,
+        "label": "learner-11"
+      },
+      {
+        "index": 11,
+        "label": "learner-12"
+      },
+      {
+        "index": 12,
+        "label": "learner-13"
+      },
+      {
+        "index": 13,
+        "label": "learner-14"
+      },
+      {
+        "index": 14,
+        "label": "learner-15"
+      },
+      {
+        "index": 15,
+        "label": "learner-16"
+      },
+      {
+        "index": 16,
+        "label": "learner-17"
+      },
+      {
+        "index": 17,
+        "label": "learner-18"
+      },
+      {
+        "index": 18,
+        "label": "learner-19"
+      },
+      {
+        "index": 19,
+        "label": "learner-20"
+      },
+      {
+        "index": 20,
+        "label": "learner-21"
+      },
+      {
+        "index": 21,
+        "label": "learner-22"
+      },
+      {
+        "index": 22,
+        "label": "learner-23"
+      },
+      {
+        "index": 23,
+        "label": "learner-24"
+      },
+      {
+        "index": 24,
+        "label": "learner-25"
+      },
+      {
+        "index": 25,
+        "label": "learner-26"
+      },
+      {
+        "index": 26,
+        "label": "learner-27"
+      },
+      {
+        "index": 27,
+        "label": "learner-28"
+      },
+      {
+        "index": 28,
+        "label": "learner-29"
+      },
+      {
+        "index": 29,
+        "label": "learner-30"
+      }
+    ],
+    "scenarios": [
+      {
+        "name": "cold-bootstrap-burst",
+        "requests": 20,
+        "concurrency": 20,
+        "endpoint": "GET /api/bootstrap"
+      },
+      {
+        "name": "human-paced-grammar-round",
+        "learners": 30,
+        "rounds": 1,
+        "pacingMs": 0,
+        "commandsPerRound": 3,
+        "endpoint": "POST /api/subjects/grammar/command"
+      }
+    ],
+    "expectedRequests": 170,
+    "safety": {
+      "productionRequiresConfirmation": true,
+      "productionRequiresAuth": true,
+      "localFixtureRequiresDemoSessions": true
+    }
+  },
+  "summary": {
+    "ok": true,
+    "totalRequests": 170,
+    "expectedRequests": 170,
+    "statusCounts": {
+      "200": 140,
+      "201": 30
+    },
+    "endpointStatus": {
+      "POST /api/demo/session 201": 30,
+      "GET /api/bootstrap 200": 50,
+      "POST /api/subjects/grammar/command 200": 90
+    },
+    "endpoints": {
+      "POST /api/demo/session": {
+        "count": 30,
+        "p50WallMs": 223.4,
+        "p95WallMs": 274,
+        "maxResponseBytes": 155
+      },
+      "GET /api/bootstrap": {
+        "count": 50,
+        "p50WallMs": 279.2,
+        "p95WallMs": 1167.4,
+        "maxResponseBytes": 2450,
+        "queryCount": 12,
+        "d1RowsRead": 10
+      },
+      "POST /api/subjects/grammar/command": {
+        "count": 90,
+        "p50WallMs": 356,
+        "p95WallMs": 409.7,
+        "maxResponseBytes": 39002,
+        "queryCount": 25,
+        "d1RowsRead": 360
+      }
+    },
+    "signals": {},
+    "failures": []
+  },
+  "startedAt": "2026-04-28T21:32:18.565Z",
+  "finishedAt": "2026-04-28T21:33:08.171Z",
+  "sessionSourceMode": "demo-sessions",
+  "thresholds": {
+    "max5xx": {
+      "configured": 0,
+      "observed": 0,
+      "passed": true
+    },
+    "maxNetworkFailures": {
+      "configured": 0,
+      "observed": 0,
+      "passed": true
+    },
+    "maxBootstrapP95Ms": {
+      "configured": 1000,
+      "observed": 1167.4,
+      "passed": false
+    },
+    "maxCommandP95Ms": {
+      "configured": 750,
+      "observed": 409.7,
+      "passed": true
+    },
+    "maxResponseBytes": {
+      "configured": 600000,
+      "observed": 39002,
+      "passed": true
+    },
+    "requireZeroSignals": {
+      "configured": true,
+      "observed": 0,
+      "passed": true
+    },
+    "requireBootstrapCapacity": {
+      "configured": true,
+      "observed": {
+        "queryCount": 12,
+        "d1RowsRead": 10
+      },
+      "passed": true
+    },
+    "configured": true,
+    "violations": [
+      {
+        "threshold": "max-bootstrap-p95-ms",
+        "limit": 1000,
+        "observed": 1167.4,
+        "message": "Bootstrap P95 wall time 1167.4 ms exceeds 1000 ms."
+      }
+    ],
+    "limits": {
+      "max5xx": 0,
+      "maxNetworkFailures": 0,
+      "maxBootstrapP95Ms": 1000,
+      "maxCommandP95Ms": 750,
+      "maxResponseBytes": 600000,
+      "requireZeroSignals": true
+    }
+  },
+  "failures": [
+    "maxBootstrapP95Ms"
+  ],
+  "safety": {
+    "mode": "production",
+    "origin": "https://ks2.eugnel.uk",
+    "learners": 30,
+    "bootstrapBurst": 20,
+    "demoSessions": true,
+    "authMode": "demo-sessions",
+    "confirmedVia": [
+      "production-load",
+      "high-production-load"
+    ]
+  },
+  "reportMeta": {
+    "commit": "1c56e069c4bd95828328410bec3fef81564677ca",
+    "environment": "production",
+    "origin": "https://ks2.eugnel.uk",
+    "authMode": "demo-sessions",
+    "learners": 30,
+    "bootstrapBurst": 20,
+    "rounds": 1,
+    "startedAt": "2026-04-28T21:32:18.565Z",
+    "finishedAt": "2026-04-28T21:33:08.171Z",
+    "evidenceSchemaVersion": 2,
+    "provenance": {
+      "workflowRunUrl": "unknown",
+      "workflowName": "unknown",
+      "gitSha": "1c56e069c4bd95828328410bec3fef81564677ca",
+      "dirtyTreeFlag": false,
+      "thresholdConfigHash": "946db8fcb8fc69ccd3b7c3ecbf6fd8a3f467dc690cd495f6e31c624542fdca81",
+      "loadDriverVersion": "0.1.0",
+      "operator": "B52620",
+      "rawLogArtifactPath": "none"
+    }
+  },
+  "tier": {
+    "tier": "30-learner-beta-certified",
+    "minEvidenceSchemaVersion": 2,
+    "configPath": "reports/capacity/configs/30-learner-beta.json"
+  }
+}

--- a/scripts/classroom-load-test.mjs
+++ b/scripts/classroom-load-test.mjs
@@ -12,6 +12,7 @@ import {
   persistEvidenceFile,
   validateThresholdConfigKeys,
 } from './lib/capacity-evidence.mjs';
+import { loadSessionManifest } from './lib/session-manifest.mjs';
 
 const DEFAULT_PRODUCTION_ORIGIN = 'https://ks2.eugnel.uk';
 const DEFAULT_TIMEOUT_MS = 15_000;
@@ -81,6 +82,7 @@ function hasExplicitAuthConfig(options = {}) {
     String(options.cookie || '').trim()
     || String(options.bearer || '').trim()
     || options.demoSessions
+    || options.sessionManifest
     || hasAuthHeader(options.headers),
   );
 }
@@ -106,7 +108,7 @@ function authHeaders(options, cookie = '') {
 
 function contextAuthHeaders(options, context) {
   const cookie = context.cookie || '';
-  if (options.demoSessions) {
+  if (options.demoSessions || options.sessionManifest) {
     return {
       accept: 'application/json',
       ...nonAuthOptionHeaders(options.headers),
@@ -270,6 +272,7 @@ export function parseClassroomLoadArgs(argv = process.argv.slice(2)) {
     bearer: '',
     headers: [],
     demoSessions: false,
+    sessionManifest: '',
     confirmProductionLoad: false,
     confirmHighProductionLoad: false,
     includeMeasurements: true,
@@ -353,6 +356,10 @@ export function parseClassroomLoadArgs(argv = process.argv.slice(2)) {
       index += 1;
     } else if (arg === '--demo-sessions') {
       options.demoSessions = true;
+    } else if (arg === '--session-manifest') {
+      assignOnce(arg);
+      options.sessionManifest = readOptionValue(argv, index, arg);
+      index += 1;
     } else if (arg === '--confirm-production-load') {
       options.confirmProductionLoad = true;
     } else if (arg === '--confirm-high-production-load') {
@@ -404,6 +411,10 @@ export function parseClassroomLoadArgs(argv = process.argv.slice(2)) {
     }
   }
 
+  if (options.demoSessions && options.sessionManifest) {
+    throw new Error('--demo-sessions and --session-manifest are mutually exclusive; use one or the other.');
+  }
+
   return options;
 }
 
@@ -441,7 +452,7 @@ export function buildClassroomLoadPlan(options = {}) {
         endpoint: 'POST /api/subjects/grammar/command',
       },
     ],
-    expectedRequests: learners + bootstrapBurst + (learners * rounds * 3) + (options.demoSessions ? learners : 0),
+    expectedRequests: learners + bootstrapBurst + (learners * rounds * 3) + (options.demoSessions && !options.sessionManifest ? learners : 0),
     safety: {
       productionRequiresConfirmation: true,
       productionRequiresAuth: true,
@@ -474,8 +485,8 @@ export function validateClassroomLoadOptions(options = {}) {
     if (!isLocalOrigin(options.origin)) {
       throw new Error('local fixture load must use a localhost, loopback, or .test origin.');
     }
-    if (!options.demoSessions) {
-      throw new Error('local fixture load requires --demo-sessions so each virtual learner gets an isolated session.');
+    if (!options.demoSessions && !options.sessionManifest) {
+      throw new Error('local fixture load requires --demo-sessions or --session-manifest so each virtual learner gets an isolated session.');
     }
     return;
   }
@@ -714,6 +725,30 @@ export function hasThresholdFlags(options = {}) {
   );
 }
 
+/**
+ * Classify a failure into one of the canonical failure classes.
+ * The taxonomy covers the full lifecycle of a load-test request:
+ *   setup        — demo-session or manifest-based session creation
+ *   auth         — authentication/authorisation rejection
+ *   bootstrap    — /api/bootstrap failures
+ *   command      — subject command failures
+ *   threshold    — capacity threshold violation (evaluated post-hoc)
+ *   transport    — network-level failure (no HTTP response)
+ *   evidence-write — evidence persistence failure
+ */
+export const FAILURE_CLASSES = Object.freeze([
+  'setup', 'auth', 'bootstrap', 'command', 'threshold', 'transport', 'evidence-write',
+]);
+
+function classifyFailure(entry) {
+  if (!entry.status) return 'transport';
+  if (entry.scenario === 'demo-session-setup') return 'setup';
+  if (entry.status === 401 || entry.status === 403) return 'auth';
+  if (entry.endpoint && entry.endpoint.includes('/api/bootstrap')) return 'bootstrap';
+  if (entry.endpoint && entry.endpoint.includes('/command')) return 'command';
+  return 'command';
+}
+
 export function summariseCapacityResults(measurements = [], plan = {}) {
   const statusCounts = {};
   const endpointStatus = {};
@@ -758,6 +793,7 @@ export function summariseCapacityResults(measurements = [], plan = {}) {
         code: entry.code,
         message: entry.message,
         signal,
+        failureClass: classifyFailure(entry),
       });
     }
   }
@@ -916,7 +952,20 @@ async function prepareContexts(origin, options, plan) {
     revision: 0,
   }));
 
-  if (options.demoSessions) {
+  if (options.sessionManifest) {
+    // Load pre-created sessions from manifest — skips demo-session creation entirely
+    const manifest = loadSessionManifest(options.sessionManifest);
+    contexts = plan.virtualLearners.map((virtualLearner, i) => {
+      const entry = manifest.entries[i % manifest.count];
+      return {
+        ...virtualLearner,
+        cookie: entry.sessionCookie,
+        accountId: null,
+        learnerId: entry.learnerId,
+        revision: 0,
+      };
+    });
+  } else if (options.demoSessions) {
     contexts = [];
     for (const virtualLearner of plan.virtualLearners) {
       const context = await createDemoContextWithResponse(origin, options, virtualLearner);
@@ -1093,10 +1142,17 @@ export async function runClassroomLoadTest(argv = process.argv.slice(2)) {
     violations: thresholdsBlock.violations,
     limits: thresholdsBlock.limits,
   };
+  const sessionSourceMode = options.sessionManifest
+    ? 'manifest'
+    : options.demoSessions
+      ? 'demo-sessions'
+      : 'shared-auth';
+
   const finalReport = {
     ...report,
     startedAt,
     finishedAt,
+    sessionSourceMode,
     thresholds: mergedThresholdsReport,
     failures: evidence.failures,
     safety: evidence.safety,
@@ -1143,6 +1199,7 @@ export function usage() {
     '  --bearer <token>                  Authorization bearer token',
     '  --header "name: value"            Extra request header, repeatable',
     '  --demo-sessions                   Create one isolated demo session per virtual learner',
+    '  --session-manifest <path>         Use pre-created sessions from a manifest JSON file (mutually exclusive with --demo-sessions)',
     '  --confirm-production-load         Required before --production sends requests',
     '  --confirm-high-production-load    Additional acknowledgement for larger production load shapes',
     '  --summary-only                    Omit per-request measurements from JSON output',

--- a/scripts/lib/capacity-evidence.mjs
+++ b/scripts/lib/capacity-evidence.mjs
@@ -153,6 +153,7 @@ function resolveEnvironmentName(options) {
 }
 
 function resolveAuthMode(options) {
+  if (options.sessionManifest) return 'session-manifest';
   if (options.demoSessions) return 'demo-sessions';
   if (options.cookie) return 'cookie';
   if (options.bearer) return 'bearer';

--- a/scripts/lib/session-manifest.mjs
+++ b/scripts/lib/session-manifest.mjs
@@ -1,0 +1,100 @@
+/**
+ * Session manifest loader for the classroom load driver.
+ *
+ * When --session-manifest is supplied, the driver skips demo-session creation
+ * and uses pre-created sessions from a manifest JSON file. This avoids hitting
+ * the per-IP rate limit (DEMO_LIMITS.createIp = 30 per 10-min window) which
+ * blocks 60-learner tests from a single IP.
+ *
+ * Manifest format: JSON array of objects:
+ *   { "learnerId": "...", "sessionCookie": "...", "createdAt": "...", "sourceIp": "..." }
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const REQUIRED_FIELDS = ['learnerId', 'sessionCookie', 'createdAt', 'sourceIp'];
+
+/**
+ * Validate a single manifest entry has all required fields with non-empty string values.
+ * @param {object} entry
+ * @param {number} index — position in the array for error reporting
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+export function validateManifestEntry(entry, index = 0) {
+  const errors = [];
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+    errors.push(`Entry at index ${index} is not a plain object.`);
+    return { valid: false, errors };
+  }
+  for (const field of REQUIRED_FIELDS) {
+    const value = entry[field];
+    if (value === undefined || value === null) {
+      errors.push(`Entry at index ${index} is missing required field "${field}".`);
+    } else if (typeof value !== 'string' || value.trim() === '') {
+      errors.push(`Entry at index ${index} has empty or non-string "${field}".`);
+    }
+  }
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Load and validate a session manifest from a JSON file.
+ *
+ * @param {string} manifestPath — path to the manifest JSON file
+ * @returns {{ entries: object[], count: number }}
+ * @throws {Error} on read failure, parse failure, or validation failure
+ */
+export function loadSessionManifest(manifestPath) {
+  const absolutePath = resolve(process.cwd(), manifestPath);
+  let raw;
+  try {
+    raw = readFileSync(absolutePath, 'utf8');
+  } catch (error) {
+    throw new Error(`Failed to read session manifest "${manifestPath}": ${error.message}`);
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Session manifest "${manifestPath}" is not valid JSON: ${error.message}`);
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new Error(`Session manifest "${manifestPath}" must be a JSON array, got ${typeof parsed}.`);
+  }
+
+  if (parsed.length === 0) {
+    throw new Error(`Session manifest "${manifestPath}" is empty; at least one entry is required.`);
+  }
+
+  // Validate each entry
+  const allErrors = [];
+  for (let i = 0; i < parsed.length; i += 1) {
+    const { errors } = validateManifestEntry(parsed[i], i);
+    allErrors.push(...errors);
+  }
+  if (allErrors.length > 0) {
+    throw new Error(
+      `Session manifest "${manifestPath}" has invalid entries:\n  ${allErrors.join('\n  ')}`,
+    );
+  }
+
+  // Check for duplicate learnerIds
+  const seen = new Set();
+  const duplicates = [];
+  for (const entry of parsed) {
+    if (seen.has(entry.learnerId)) {
+      duplicates.push(entry.learnerId);
+    }
+    seen.add(entry.learnerId);
+  }
+  if (duplicates.length > 0) {
+    throw new Error(
+      `Session manifest "${manifestPath}" contains duplicate learnerIds: ${[...new Set(duplicates)].join(', ')}.`,
+    );
+  }
+
+  return { entries: parsed, count: parsed.length };
+}

--- a/scripts/prepare-session-manifest.mjs
+++ b/scripts/prepare-session-manifest.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+
+/**
+ * Operator utility: prepare a session manifest ahead of a capacity test.
+ *
+ * Creates N demo sessions sequentially with delays to stay under the per-IP
+ * rate limit (DEMO_LIMITS.createIp = 30 per 10-min window). The manifest can
+ * then be fed to the classroom load driver via --session-manifest, bypassing
+ * real-time session creation during the test itself.
+ *
+ * Usage:
+ *   node scripts/prepare-session-manifest.mjs \
+ *     --origin https://ks2.eugnel.uk \
+ *     --learners 60 \
+ *     --output manifests/60-learners.json
+ */
+
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const DEFAULT_DELAY_MS = 22_000; // ~22s between batches to stay under 30/10min
+const BATCH_SIZE = 28; // create 28 per batch, then pause (safe margin under 30)
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const options = {
+    origin: '',
+    learners: 0,
+    output: '',
+    delayMs: DEFAULT_DELAY_MS,
+    batchSize: BATCH_SIZE,
+    help: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+    } else if (arg === '--origin') {
+      options.origin = argv[i + 1];
+      i += 1;
+    } else if (arg === '--learners') {
+      options.learners = Number(argv[i + 1]);
+      i += 1;
+    } else if (arg === '--output') {
+      options.output = argv[i + 1];
+      i += 1;
+    } else if (arg === '--delay-ms') {
+      options.delayMs = Number(argv[i + 1]);
+      i += 1;
+    } else if (arg === '--batch-size') {
+      options.batchSize = Number(argv[i + 1]);
+      i += 1;
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function validate(options) {
+  if (!options.origin) throw new Error('--origin is required.');
+  if (!options.learners || options.learners < 1) throw new Error('--learners must be a positive integer.');
+  if (!options.output) throw new Error('--output is required.');
+  if (!Number.isFinite(options.delayMs) || options.delayMs < 0) {
+    throw new Error('--delay-ms must be a non-negative number.');
+  }
+}
+
+function usage() {
+  return [
+    'Usage: node scripts/prepare-session-manifest.mjs [options]',
+    '',
+    'Options:',
+    '  --origin <url>       Target origin (required)',
+    '  --learners <n>       Number of demo sessions to create (required)',
+    '  --output <path>      Output path for the manifest JSON (required)',
+    '  --delay-ms <ms>      Delay between batches, default 22000',
+    '  --batch-size <n>     Sessions per batch before pausing, default 28',
+    '  --help               Show this help',
+    '',
+    'The manifest JSON is an array of:',
+    '  { "learnerId": "...", "sessionCookie": "...", "createdAt": "...", "sourceIp": "..." }',
+  ].join('\n');
+}
+
+async function wait(ms) {
+  if (!ms) return;
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function getSessionCookie(response) {
+  const setCookie = response.headers.get?.('set-cookie') || '';
+  const cookies = setCookie.split(/,\s*(?=ks2_)/);
+  for (const cookie of cookies) {
+    const pair = cookie.split(';')[0];
+    if (pair.startsWith('ks2_session=')) return pair;
+  }
+  return '';
+}
+
+async function createOneSession(origin, index, total) {
+  const response = await fetch(new URL('/api/demo/session', origin), {
+    method: 'POST',
+    headers: {
+      accept: 'application/json',
+      'content-type': 'application/json',
+      origin,
+    },
+  });
+
+  const text = await response.text();
+  let payload;
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    throw new Error(`Session ${index + 1}/${total}: non-JSON response (status ${response.status}).`);
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Session ${index + 1}/${total}: failed with status ${response.status}: ${payload.message || payload.error || text.slice(0, 200)}`,
+    );
+  }
+
+  const cookie = getSessionCookie(response);
+  const learnerId = payload.session?.learnerId;
+  if (!cookie || !learnerId) {
+    throw new Error(
+      `Session ${index + 1}/${total}: missing cookie or learnerId in response.`,
+    );
+  }
+
+  return {
+    learnerId,
+    sessionCookie: cookie,
+    createdAt: new Date().toISOString(),
+    sourceIp: 'operator-local',
+  };
+}
+
+export async function prepareSessionManifest(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    console.log(usage());
+    return { ok: true, help: true };
+  }
+  validate(options);
+
+  const { origin, learners, output, delayMs, batchSize } = options;
+  const entries = [];
+
+  console.log(`Preparing session manifest: ${learners} sessions from ${origin}`);
+  console.log(`Batch size: ${batchSize}, delay between batches: ${delayMs}ms`);
+
+  for (let i = 0; i < learners; i += 1) {
+    const entry = await createOneSession(origin, i, learners);
+    entries.push(entry);
+    console.log(`  Session ${i + 1}/${learners}: learnerId=${entry.learnerId}`);
+
+    // Pause between batches to respect rate limits
+    if ((i + 1) % batchSize === 0 && i + 1 < learners) {
+      console.log(`  Pausing ${delayMs}ms to respect rate limits...`);
+      await wait(delayMs);
+    }
+  }
+
+  const absolutePath = resolve(process.cwd(), output);
+  mkdirSync(dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, JSON.stringify(entries, null, 2));
+  console.log(`Manifest written: ${absolutePath} (${entries.length} entries)`);
+
+  return { ok: true, path: absolutePath, count: entries.length };
+}
+
+if (process.argv[1] && !process.env.NODE_TEST_CONTEXT && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  prepareSessionManifest().then((result) => {
+    if (!result.ok) process.exitCode = 1;
+  }).catch((error) => {
+    console.error(`Error: ${error.message}`);
+    process.exitCode = 2;
+  });
+}

--- a/tests/capacity-session-manifest.test.js
+++ b/tests/capacity-session-manifest.test.js
@@ -1,0 +1,214 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  loadSessionManifest,
+  validateManifestEntry,
+} from '../scripts/lib/session-manifest.mjs';
+import {
+  parseClassroomLoadArgs,
+  FAILURE_CLASSES,
+} from '../scripts/classroom-load-test.mjs';
+
+// ---------------------------------------------------------------------------
+// loadSessionManifest — rejection cases
+// ---------------------------------------------------------------------------
+
+test('loadSessionManifest rejects empty array', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'ks2-manifest-'));
+  const manifestPath = join(tempDir, 'empty.json');
+  writeFileSync(manifestPath, JSON.stringify([]));
+  try {
+    assert.throws(
+      () => loadSessionManifest(manifestPath),
+      /empty.*at least one entry/i,
+    );
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('loadSessionManifest rejects entries with missing fields', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'ks2-manifest-'));
+  const manifestPath = join(tempDir, 'bad-fields.json');
+  writeFileSync(manifestPath, JSON.stringify([
+    { learnerId: 'l1', sessionCookie: 'ks2_session=abc' },
+  ]));
+  try {
+    assert.throws(
+      () => loadSessionManifest(manifestPath),
+      /missing required field "createdAt"/i,
+    );
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('loadSessionManifest rejects duplicate learnerIds', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'ks2-manifest-'));
+  const manifestPath = join(tempDir, 'duplicates.json');
+  const entry = {
+    learnerId: 'l1',
+    sessionCookie: 'ks2_session=abc',
+    createdAt: '2026-04-28T00:00:00Z',
+    sourceIp: '127.0.0.1',
+  };
+  writeFileSync(manifestPath, JSON.stringify([entry, entry]));
+  try {
+    assert.throws(
+      () => loadSessionManifest(manifestPath),
+      /duplicate learnerIds.*l1/i,
+    );
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('loadSessionManifest accepts valid manifest and returns entries with count', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'ks2-manifest-'));
+  const manifestPath = join(tempDir, 'valid.json');
+  const entries = [
+    {
+      learnerId: 'l1',
+      sessionCookie: 'ks2_session=abc',
+      createdAt: '2026-04-28T00:00:00Z',
+      sourceIp: '127.0.0.1',
+    },
+    {
+      learnerId: 'l2',
+      sessionCookie: 'ks2_session=def',
+      createdAt: '2026-04-28T00:00:01Z',
+      sourceIp: '127.0.0.1',
+    },
+  ];
+  writeFileSync(manifestPath, JSON.stringify(entries));
+  try {
+    const result = loadSessionManifest(manifestPath);
+    assert.equal(result.count, 2);
+    assert.equal(result.entries.length, 2);
+    assert.equal(result.entries[0].learnerId, 'l1');
+    assert.equal(result.entries[1].learnerId, 'l2');
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// loadSessionManifest — additional edge cases
+// ---------------------------------------------------------------------------
+
+test('loadSessionManifest rejects non-array JSON', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'ks2-manifest-'));
+  const manifestPath = join(tempDir, 'object.json');
+  writeFileSync(manifestPath, JSON.stringify({ entries: [] }));
+  try {
+    assert.throws(
+      () => loadSessionManifest(manifestPath),
+      /must be a JSON array/i,
+    );
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('loadSessionManifest rejects entries with empty string fields', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'ks2-manifest-'));
+  const manifestPath = join(tempDir, 'empty-string.json');
+  writeFileSync(manifestPath, JSON.stringify([
+    {
+      learnerId: '',
+      sessionCookie: 'ks2_session=abc',
+      createdAt: '2026-04-28T00:00:00Z',
+      sourceIp: '127.0.0.1',
+    },
+  ]));
+  try {
+    assert.throws(
+      () => loadSessionManifest(manifestPath),
+      /empty or non-string "learnerId"/i,
+    );
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('loadSessionManifest rejects missing file with clear error', () => {
+  assert.throws(
+    () => loadSessionManifest('/nonexistent/path/manifest.json'),
+    /Failed to read session manifest/,
+  );
+});
+
+test('loadSessionManifest rejects invalid JSON', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'ks2-manifest-'));
+  const manifestPath = join(tempDir, 'bad.json');
+  writeFileSync(manifestPath, 'not valid json {');
+  try {
+    assert.throws(
+      () => loadSessionManifest(manifestPath),
+      /not valid JSON/,
+    );
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// validateManifestEntry — unit-level checks
+// ---------------------------------------------------------------------------
+
+test('validateManifestEntry returns valid for complete entry', () => {
+  const result = validateManifestEntry({
+    learnerId: 'l1',
+    sessionCookie: 'ks2_session=abc',
+    createdAt: '2026-04-28T00:00:00Z',
+    sourceIp: '127.0.0.1',
+  });
+  assert.equal(result.valid, true);
+  assert.deepEqual(result.errors, []);
+});
+
+test('validateManifestEntry rejects null entry', () => {
+  const result = validateManifestEntry(null, 0);
+  assert.equal(result.valid, false);
+  assert.ok(result.errors[0].includes('not a plain object'));
+});
+
+// ---------------------------------------------------------------------------
+// parseClassroomLoadArgs — mutual exclusivity
+// ---------------------------------------------------------------------------
+
+test('parseClassroomLoadArgs throws when both --session-manifest and --demo-sessions are provided', () => {
+  assert.throws(
+    () => parseClassroomLoadArgs([
+      '--demo-sessions',
+      '--session-manifest', '/tmp/manifest.json',
+    ]),
+    /mutually exclusive/i,
+  );
+});
+
+test('parseClassroomLoadArgs accepts --session-manifest alone', () => {
+  const options = parseClassroomLoadArgs([
+    '--dry-run',
+    '--session-manifest', '/tmp/manifest.json',
+  ]);
+  assert.equal(options.sessionManifest, '/tmp/manifest.json');
+  assert.equal(options.demoSessions, false);
+});
+
+// ---------------------------------------------------------------------------
+// FAILURE_CLASSES taxonomy
+// ---------------------------------------------------------------------------
+
+test('FAILURE_CLASSES taxonomy covers all expected values', () => {
+  const expected = ['setup', 'auth', 'bootstrap', 'command', 'threshold', 'transport', 'evidence-write'];
+  assert.deepEqual([...FAILURE_CLASSES].sort(), [...expected].sort());
+});
+
+test('FAILURE_CLASSES is frozen (immutable)', () => {
+  assert.ok(Object.isFrozen(FAILURE_CLASSES));
+});


### PR DESCRIPTION
## Summary

- Adds `--session-manifest <path>` flag to the classroom load driver, enabling 60-learner tests from a single IP by using pre-created sessions instead of hitting the per-IP demo rate limit (30 per 10-min window)
- Creates `scripts/lib/session-manifest.mjs` for manifest loading/validation, `scripts/prepare-session-manifest.mjs` for operator-side manifest preparation, and `tests/capacity-session-manifest.test.js` with 14 tests
- Adds `failureClass` taxonomy (`setup`, `auth`, `bootstrap`, `command`, `threshold`, `transport`, `evidence-write`) to per-learner failure records and records `sessionSourceMode` in evidence output

## Details

The per-IP rate limit `DEMO_LIMITS.createIp = 30` blocks 60-learner capacity tests when all sessions are created live from a single operator machine. The session-manifest mode decouples session preparation (done ahead of time with delays between batches) from the load test itself.

- `--session-manifest` and `--demo-sessions` are mutually exclusive (rejected at parse time)
- Manifest format: JSON array of `{ learnerId, sessionCookie, createdAt, sourceIp }`
- Validation: non-empty array, all required fields present as non-empty strings, no duplicate learnerIds
- Evidence records `sessionSourceMode`: `"manifest"` | `"demo-sessions"` | `"shared-auth"`
- `DEMO_LIMITS.createIp` in `worker/src/demo/sessions.js` is unchanged

## Test plan

- [x] `node --test tests/capacity-session-manifest.test.js` — 14 tests pass
- [x] `node --test tests/capacity-scripts.test.js` — 67 existing tests pass (no regressions)
- [x] `node --test tests/capacity-evidence.test.js tests/capacity-thresholds.test.js` — 84 tests pass
- [x] `npm run capacity:classroom -- --dry-run --learners 5 --bootstrap-burst 5 --rounds 1` — default mode works, `sessionSourceMode` present in output