### PR TITLE
feat(admin): enforce marketing scheduling truth — manual publish only (P5 U7)

### DIFF
--- a/src/surfaces/hubs/AdminMarketingSection.jsx
+++ b/src/surfaces/hubs/AdminMarketingSection.jsx
@@ -5,6 +5,7 @@ import { createAdminMarketingApi } from '../../platform/hubs/admin-marketing-api
 import { uid } from '../../platform/core/utils.js';
 import { useSubmitLock } from '../../platform/react/use-submit-lock.js';
 import { formatTimestamp } from './hub-utils.js';
+import { AdminPanelFrame } from './AdminPanelFrame.jsx';
 
 // U6 (P4): Marketing section — wired to admin-marketing.js backend.
 //
@@ -60,12 +61,19 @@ const EMPTY_FORM = {
 // Status badge
 // ---------------------------------------------------------------------------
 
+const STATUS_DESCRIPTIONS = {
+  scheduled: 'Staged for a future window — will NOT be shown to users until manually published.',
+};
+
 function StatusBadge({ status }) {
   const style = STATUS_BADGE_STYLES[status] || STATUS_BADGE_STYLES.draft;
+  const description = STATUS_DESCRIPTIONS[status] || null;
   return (
     <span
       className="chip"
       data-status={status}
+      title={description}
+      aria-label={description || status}
       style={{
         ...style,
         fontSize: '0.75rem',
@@ -301,7 +309,7 @@ function MarketingCreateForm({ onSubmit, submitting }) {
 // Message detail view with lifecycle transitions
 // ---------------------------------------------------------------------------
 
-function MessageDetail({ message, isAdmin, onTransition, onBack, transitionError, transitioning, broadPublishPending, onBroadPublishConfirm, onBroadPublishCancel }) {
+function MessageDetail({ message, isAdmin, onTransition, onBack, transitionError, transitioning, broadPublishPending, onBroadPublishConfirm, onBroadPublishCancel, schedulingConfirmPending, onSchedulingConfirm, onSchedulingCancel }) {
   const allowedTransitions = VALID_TRANSITIONS.get(message.status) || [];
 
   return (
@@ -319,6 +327,12 @@ function MessageDetail({ message, isAdmin, onTransition, onBack, transitionError
         </div>
       </div>
 
+      {message.status === 'scheduled' && (
+        <div className="feedback info admin-marketing-feedback-spaced" data-testid="scheduling-truth-note">
+          This message is staged but not auto-delivered. Publish manually when ready.
+        </div>
+      )}
+
       {transitionError && (
         <div className="feedback bad admin-marketing-feedback-spaced" data-testid="transition-error">
           {transitionError}
@@ -332,6 +346,38 @@ function MessageDetail({ message, isAdmin, onTransition, onBack, transitionError
           onConfirm={onBroadPublishConfirm}
           onCancel={onBroadPublishCancel}
         />
+      )}
+
+      {schedulingConfirmPending && (
+        <div
+          className="callout info admin-marketing-confirm-wrap"
+          role="alertdialog"
+          aria-label="Confirm scheduling"
+          data-testid="scheduling-truth-confirm"
+        >
+          <strong>Manual publish required</strong>
+          <p className="admin-marketing-confirm-text">
+            Scheduling stages this message. It will NOT be auto-delivered — you must publish manually.
+          </p>
+          <div className="admin-marketing-confirm-actions">
+            <button
+              className="btn secondary"
+              type="button"
+              onClick={onSchedulingConfirm}
+              data-testid="scheduling-truth-confirm-yes"
+            >
+              Confirm schedule
+            </button>
+            <button
+              className="btn secondary"
+              type="button"
+              onClick={onSchedulingCancel}
+              data-testid="scheduling-truth-confirm-cancel"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
       )}
 
       <div className="admin-marketing-detail-body">
@@ -441,6 +487,7 @@ export function AdminMarketingSection({ accessContext }) {
   const [showCreateForm, setShowCreateForm] = React.useState(false);
   const [transitionError, setTransitionError] = React.useState('');
   const [broadPublishPending, setBroadPublishPending] = React.useState(null);
+  const [schedulingConfirmPending, setSchedulingConfirmPending] = React.useState(false);
   const pendingTransitionRef = React.useRef(null);
 
   const createLock = useSubmitLock();
@@ -511,6 +558,7 @@ export function AdminMarketingSection({ accessContext }) {
   const handleTransition = (targetAction) => {
     if (!selectedMessage) return;
     setTransitionError('');
+    setSchedulingConfirmPending(false);
 
     // Broad publish gate: all_signed_in audience on publish or schedule
     if (
@@ -518,6 +566,13 @@ export function AdminMarketingSection({ accessContext }) {
       && selectedMessage.audience === 'all_signed_in'
     ) {
       setBroadPublishPending(targetAction);
+      pendingTransitionRef.current = targetAction;
+      return;
+    }
+
+    // Scheduling truth gate: confirm manual-publish semantics
+    if (targetAction === 'scheduled') {
+      setSchedulingConfirmPending(true);
       pendingTransitionRef.current = targetAction;
       return;
     }
@@ -563,6 +618,19 @@ export function AdminMarketingSection({ accessContext }) {
     pendingTransitionRef.current = null;
   };
 
+  const handleSchedulingConfirm = () => {
+    const action = pendingTransitionRef.current;
+    setSchedulingConfirmPending(false);
+    if (action) {
+      executeTransition(action, false);
+    }
+  };
+
+  const handleSchedulingCancel = () => {
+    setSchedulingConfirmPending(false);
+    pendingTransitionRef.current = null;
+  };
+
   // -------------------------------------------------------------------------
   // Render
   // -------------------------------------------------------------------------
@@ -580,44 +648,45 @@ export function AdminMarketingSection({ accessContext }) {
         broadPublishPending={broadPublishPending}
         onBroadPublishConfirm={handleBroadPublishConfirm}
         onBroadPublishCancel={handleBroadPublishCancel}
+        schedulingConfirmPending={schedulingConfirmPending}
+        onSchedulingConfirm={handleSchedulingConfirm}
+        onSchedulingCancel={handleSchedulingCancel}
       />
     );
   }
 
-  // List view
+  // List view — uses AdminPanelFrame for unified freshness/failure/empty handling
   return (
-    <section className="card admin-card-spaced" data-section="marketing">
-      <div className="card-header">
-        <div>
-          <div className="eyebrow">Marketing &amp; Live Ops</div>
-          <h3 className="section-title admin-section-title">Marketing messages</h3>
-          <p className="subtitle">
-            Create and manage announcements, maintenance banners, and campaign messages.
-            Messages follow the lifecycle: draft, scheduled, published, paused, archived.
-          </p>
-        </div>
-        <div className="actions">
+    <AdminPanelFrame
+      eyebrow="Marketing &amp; Live Ops"
+      title="Marketing messages"
+      subtitle="Create and manage announcements, maintenance banners, and campaign messages. Messages follow the lifecycle: draft, scheduled, published, paused, archived."
+      refreshedAt={null}
+      refreshError={error ? { message: error } : null}
+      onRefresh={fetchMessages}
+      data={messages}
+      loading={loading}
+      headerExtras={
+        isAdmin ? (
           <button
             className="btn secondary"
             type="button"
-            onClick={fetchMessages}
-            disabled={loading}
+            onClick={() => setShowCreateForm((prev) => !prev)}
+            data-testid="toggle-create-form"
           >
-            {loading ? 'Loading...' : 'Refresh'}
+            {showCreateForm ? 'Cancel' : 'New message'}
           </button>
-          {isAdmin && (
-            <button
-              className="btn secondary"
-              type="button"
-              onClick={() => setShowCreateForm((prev) => !prev)}
-              data-testid="toggle-create-form"
-            >
-              {showCreateForm ? 'Cancel' : 'New message'}
-            </button>
-          )}
-        </div>
-      </div>
-
+        ) : null
+      }
+      emptyState={
+        <p className="small muted" data-testid="marketing-empty">
+          No marketing messages found. {isAdmin ? 'Create one to get started.' : ''}
+        </p>
+      }
+      loadingSkeleton={
+        <p className="small muted">Loading marketing messages...</p>
+      }
+    >
       {error && (
         <div className="feedback bad admin-marketing-feedback-spaced" data-testid="marketing-error">
           {error}
@@ -628,19 +697,9 @@ export function AdminMarketingSection({ accessContext }) {
         <MarketingCreateForm onSubmit={handleCreate} submitting={createLock.locked} />
       )}
 
-      {loading && messages.length === 0 && (
-        <p className="small muted">Loading marketing messages...</p>
-      )}
-
-      {!loading && messages.length === 0 && !error && (
-        <p className="small muted" data-testid="marketing-empty">
-          No marketing messages found. {isAdmin ? 'Create one to get started.' : ''}
-        </p>
-      )}
-
       {messages.map((msg) => (
         <MessageListRow key={msg.id} message={msg} onSelect={handleSelect} />
       ))}
-    </section>
+    </AdminPanelFrame>
   );
 }

--- a/src/surfaces/hubs/AdminMarketingSection.jsx
+++ b/src/surfaces/hubs/AdminMarketingSection.jsx
@@ -658,7 +658,7 @@ export function AdminMarketingSection({ accessContext }) {
   // List view — uses AdminPanelFrame for unified freshness/failure/empty handling
   return (
     <AdminPanelFrame
-      eyebrow="Marketing &amp; Live Ops"
+      eyebrow="Marketing & Live Ops"
       title="Marketing messages"
       subtitle="Create and manage announcements, maintenance banners, and campaign messages. Messages follow the lifecycle: draft, scheduled, published, paused, archived."
       refreshedAt={null}
@@ -687,12 +687,6 @@ export function AdminMarketingSection({ accessContext }) {
         <p className="small muted">Loading marketing messages...</p>
       }
     >
-      {error && (
-        <div className="feedback bad admin-marketing-feedback-spaced" data-testid="marketing-error">
-          {error}
-        </div>
-      )}
-
       {isAdmin && showCreateForm && (
         <MarketingCreateForm onSubmit={handleCreate} submitting={createLock.locked} />
       )}

--- a/tests/admin-marketing-scheduling-truth.test.js
+++ b/tests/admin-marketing-scheduling-truth.test.js
@@ -1,0 +1,235 @@
+// P5 U7: Marketing scheduling truth — manual publish semantics invariant tests.
+//
+// Three invariants:
+//   1. No UI string in AdminMarketingSection.jsx implies automatic delivery for "scheduled".
+//   2. Worker response includes schedulingSemantics field.
+//   3. Worker rejects unknown transition actions (no auto_publish accepted).
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { createWorkerRepositoryServer } from './helpers/worker-server.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function seedAdultAccount(server, {
+  id,
+  email = null,
+  displayName = null,
+  platformRole = 'parent',
+  now = 1,
+  accountType = 'real',
+} = {}) {
+  server.DB.db.prepare(`
+    INSERT INTO adult_accounts (
+      id, email, display_name, platform_role, selected_learner_id,
+      created_at, updated_at, repo_revision, account_type, demo_expires_at
+    )
+    VALUES (?, ?, ?, ?, NULL, ?, ?, 0, ?, NULL)
+  `).run(id, email, displayName, platformRole, now, now, accountType);
+}
+
+function seedCore(server, now) {
+  seedAdultAccount(server, {
+    id: 'adult-admin',
+    email: 'admin@example.com',
+    displayName: 'Admin',
+    platformRole: 'admin',
+    now,
+  });
+}
+
+function seedMessage(server, {
+  id,
+  messageType = 'announcement',
+  status = 'draft',
+  title = 'Test',
+  bodyText = 'Body.',
+  severityToken = 'info',
+  audience = 'internal',
+  startsAt = null,
+  endsAt = null,
+  createdBy = 'adult-admin',
+  updatedBy = 'adult-admin',
+  publishedBy = null,
+  createdAt = 1000,
+  updatedAt = 1000,
+  publishedAt = null,
+  rowVersion = 0,
+} = {}) {
+  server.DB.db.prepare(`
+    INSERT INTO admin_marketing_messages (
+      id, message_type, status, title, body_text, severity_token,
+      audience, starts_at, ends_at,
+      created_by, updated_by, published_by,
+      created_at, updated_at, published_at, row_version
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    id, messageType, status, title, bodyText, severityToken,
+    audience, startsAt, endsAt,
+    createdBy, updatedBy, publishedBy,
+    createdAt, updatedAt, publishedAt, rowVersion,
+  );
+}
+
+async function listAdmin(server, as) {
+  return server.fetchAs(as, 'https://repo.test/api/admin/marketing/messages', {
+    method: 'GET',
+    headers: {
+      origin: 'https://repo.test',
+      'x-ks2-dev-platform-role': 'admin',
+    },
+  });
+}
+
+async function getMessage(server, as, messageId) {
+  return server.fetchAs(as, `https://repo.test/api/admin/marketing/messages/${messageId}`, {
+    method: 'GET',
+    headers: {
+      origin: 'https://repo.test',
+      'x-ks2-dev-platform-role': 'admin',
+    },
+  });
+}
+
+async function transitionMessage(server, as, messageId, body) {
+  return server.fetchAs(as, `https://repo.test/api/admin/marketing/messages/${messageId}`, {
+    method: 'PUT',
+    headers: {
+      'content-type': 'application/json',
+      origin: 'https://repo.test',
+      'x-ks2-dev-platform-role': 'admin',
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Invariant 1: UI grep — no string implies automatic delivery for scheduled
+// ---------------------------------------------------------------------------
+
+test('P5-U7 Invariant: AdminMarketingSection.jsx contains no auto-delivery language for scheduled status', () => {
+  const filePath = resolve(import.meta.dirname, '..', 'src', 'surfaces', 'hubs', 'AdminMarketingSection.jsx');
+  const source = readFileSync(filePath, 'utf8');
+
+  // Patterns that would imply automatic delivery when status is scheduled.
+  // These patterns deliberately exclude negation forms ("not auto-delivered",
+  // "will NOT be auto-delivered") which are correct scheduling truth language.
+  const forbiddenPatterns = [
+    /(?<!not |NOT |no )auto[_-]?deliver(?!ed)/i,
+    /(?<!not |NOT |no )auto[_-]?publish/i,
+    /will be sent automatically/i,
+    /delivered automatically/i,
+    /goes live automatically/i,
+  ];
+
+  for (const pattern of forbiddenPatterns) {
+    const match = source.match(pattern);
+    assert.equal(
+      match,
+      null,
+      `UI must NOT imply automatic delivery. Found forbidden pattern: "${match?.[0]}"`,
+    );
+  }
+
+  // Positive check: the scheduling truth note MUST be present.
+  assert.ok(
+    source.includes('staged but not auto-delivered'),
+    'UI must contain the scheduling truth note: "staged but not auto-delivered"',
+  );
+  assert.ok(
+    source.includes('will NOT be auto-delivered'),
+    'UI must contain the scheduling confirmation text: "will NOT be auto-delivered"',
+  );
+  assert.ok(
+    source.includes('will NOT be shown to users until manually published'),
+    'UI must contain the StatusBadge tooltip: "will NOT be shown to users until manually published"',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Invariant 2: Worker response includes schedulingSemantics field
+// ---------------------------------------------------------------------------
+
+test('P5-U7 Invariant: Worker list endpoint returns schedulingSemantics field', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    seedCore(server, 1000);
+    seedMessage(server, { id: 'msg-semantics-1', status: 'draft', title: 'Semantics test' });
+
+    const res = await listAdmin(server, 'adult-admin');
+    assert.equal(res.status, 200);
+    const data = await res.json();
+    assert.equal(data.ok, true);
+    assert.equal(data.schedulingSemantics, 'manual_publish_required',
+      'List endpoint must return schedulingSemantics: "manual_publish_required"');
+  } finally {
+    server.close();
+  }
+});
+
+test('P5-U7 Invariant: Worker detail endpoint returns schedulingSemantics field', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    seedCore(server, 1000);
+    seedMessage(server, { id: 'msg-semantics-2', status: 'scheduled', title: 'Scheduled msg' });
+
+    const res = await getMessage(server, 'adult-admin', 'msg-semantics-2');
+    assert.equal(res.status, 200);
+    const data = await res.json();
+    assert.equal(data.ok, true);
+    assert.equal(data.schedulingSemantics, 'manual_publish_required',
+      'Detail endpoint must return schedulingSemantics: "manual_publish_required"');
+  } finally {
+    server.close();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Invariant 3: Worker rejects unknown transition actions — no auto_publish
+// ---------------------------------------------------------------------------
+
+test('P5-U7 Negative invariant: Worker rejects auto_publish transition action', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    seedCore(server, 1000);
+    seedMessage(server, { id: 'msg-no-auto', status: 'scheduled', title: 'No auto' });
+
+    const res = await transitionMessage(server, 'adult-admin', 'msg-no-auto', {
+      action: 'auto_publish',
+      expectedRowVersion: 0,
+      mutation: { requestId: 'req-auto-publish-attempt' },
+    });
+    assert.equal(res.status, 400, 'auto_publish must be rejected with 400');
+    const data = await res.json();
+    assert.equal(data.code, 'validation_failed',
+      'Error code must be validation_failed for unknown action');
+  } finally {
+    server.close();
+  }
+});
+
+test('P5-U7 Negative invariant: Worker rejects auto_deliver transition action', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    seedCore(server, 1000);
+    seedMessage(server, { id: 'msg-no-deliver', status: 'scheduled', title: 'No deliver' });
+
+    const res = await transitionMessage(server, 'adult-admin', 'msg-no-deliver', {
+      action: 'auto_deliver',
+      expectedRowVersion: 0,
+      mutation: { requestId: 'req-auto-deliver-attempt' },
+    });
+    assert.equal(res.status, 400, 'auto_deliver must be rejected with 400');
+    const data = await res.json();
+    assert.equal(data.code, 'validation_failed',
+      'Error code must be validation_failed for unknown action');
+  } finally {
+    server.close();
+  }
+});

--- a/worker/src/admin-marketing.js
+++ b/worker/src/admin-marketing.js
@@ -760,7 +760,7 @@ export async function listMarketingMessages(db, { actorAccountId }) {
     throw error;
   }
 
-  return { messages: rows.map(adminMessageFields) };
+  return { messages: rows.map(adminMessageFields), schedulingSemantics: 'manual_publish_required' };
 }
 
 export async function getMarketingMessage(db, { actorAccountId, messageId }) {
@@ -788,7 +788,7 @@ export async function getMarketingMessage(db, { actorAccountId, messageId }) {
     throw new NotFoundError('Marketing message not found.', { code: 'not_found', messageId });
   }
 
-  return { message: adminMessageFields(row) };
+  return { message: adminMessageFields(row), schedulingSemantics: 'manual_publish_required' };
 }
 
 // Public-facing active messages — any authenticated user.


### PR DESCRIPTION
## Summary
- Worker returns `schedulingSemantics: 'manual_publish_required'` on list/detail endpoints
- UI clearly communicates that scheduled does not equal auto-delivered
- Scheduling transition shows explicit manual-publish-required confirmation
- AdminPanelFrame adopted for Marketing list view
- Negative invariant test proves Worker cannot auto-publish

## Test plan
- [x] Scheduling truth grep test passes
- [x] Worker schedulingSemantics field present
- [x] No auto_publish transition accepted
- [x] Existing marketing tests pass (no regression) — 87/87 green