### PR TITLE
feat(admin): add Production Evidence panel with closed certification taxonomy (P5 U4)

### DIFF
--- a/reports/capacity/latest-evidence-summary.json
+++ b/reports/capacity/latest-evidence-summary.json
@@ -1,0 +1,1 @@
+{ "schema": 2, "metrics": {}, "generatedAt": null }

--- a/scripts/generate-evidence-summary.mjs
+++ b/scripts/generate-evidence-summary.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+// generate-evidence-summary.mjs
+//
+// Reads evidence files from reports/capacity/evidence/ and emits a summary
+// at reports/capacity/latest-evidence-summary.json.  Uses the schema version
+// from scripts/lib/capacity-evidence.mjs for forward-compatibility.
+//
+// Usage:  node scripts/generate-evidence-summary.mjs [--verbose]
+
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import { EVIDENCE_SCHEMA_VERSION } from './lib/capacity-evidence.mjs';
+
+const ROOT = resolve(import.meta.url.startsWith('file://')
+  ? new URL('..', import.meta.url).pathname.replace(/^\/([A-Z]:)/i, '$1')
+  : process.cwd());
+
+const EVIDENCE_DIR = join(ROOT, 'reports', 'capacity', 'evidence');
+const OUTPUT_PATH = join(ROOT, 'reports', 'capacity', 'latest-evidence-summary.json');
+
+const verbose = process.argv.includes('--verbose');
+
+function log(...args) {
+  if (verbose) console.error('[evidence-summary]', ...args);
+}
+
+function readEvidenceFiles() {
+  let entries;
+  try {
+    entries = readdirSync(EVIDENCE_DIR).filter((f) => f.endsWith('.json'));
+  } catch {
+    log('No evidence directory found at', EVIDENCE_DIR);
+    return [];
+  }
+  const files = [];
+  for (const name of entries) {
+    try {
+      const content = readFileSync(join(EVIDENCE_DIR, name), 'utf8');
+      const parsed = JSON.parse(content);
+      files.push({ name, data: parsed });
+    } catch (err) {
+      log(`Skipping ${name}: ${err.message}`);
+    }
+  }
+  return files;
+}
+
+function classifyTier(fileName) {
+  if (/100[_-]plus|100[_-]learner/i.test(fileName)) return 'certified_100_plus';
+  if (/60[_-]learner/i.test(fileName)) return 'certified_60_learner_stretch';
+  if (/30[_-]learner/i.test(fileName)) return 'certified_30_learner_beta';
+  if (/small[_-]pilot/i.test(fileName)) return 'small_pilot_provisional';
+  if (/smoke/i.test(fileName)) return 'smoke_pass';
+  return 'unknown';
+}
+
+function buildMetrics(files) {
+  const metrics = {};
+  for (const { name, data } of files) {
+    const tier = classifyTier(name);
+    const key = tier === 'unknown' ? name.replace(/\.json$/, '') : tier;
+
+    const existing = metrics[key];
+    const finishedAt = data?.reportMeta?.finishedAt
+      || data?.reportMeta?.startedAt
+      || null;
+
+    // Keep the most recent run per tier.
+    if (existing && existing.finishedAt && finishedAt && existing.finishedAt >= finishedAt) {
+      continue;
+    }
+
+    metrics[key] = {
+      tier: key,
+      ok: Boolean(data?.ok),
+      dryRun: Boolean(data?.dryRun),
+      learners: data?.reportMeta?.learners ?? data?.safety?.learners ?? null,
+      finishedAt,
+      commit: data?.reportMeta?.commit || null,
+      failures: Array.isArray(data?.failures) ? data.failures : [],
+      thresholdsPassed: data?.failures ? data.failures.length === 0 : null,
+      fileName: name,
+    };
+  }
+  return metrics;
+}
+
+function run() {
+  const files = readEvidenceFiles();
+  log(`Found ${files.length} evidence file(s).`);
+
+  const metrics = buildMetrics(files);
+  const now = new Date().toISOString();
+
+  const summary = {
+    schema: EVIDENCE_SCHEMA_VERSION,
+    metrics,
+    generatedAt: now,
+  };
+
+  writeFileSync(OUTPUT_PATH, JSON.stringify(summary, null, 2) + '\n');
+  log(`Written summary to ${OUTPUT_PATH}`);
+  if (!verbose) {
+    console.log(OUTPUT_PATH);
+  }
+}
+
+run();

--- a/src/platform/hubs/admin-production-evidence.js
+++ b/src/platform/hubs/admin-production-evidence.js
@@ -1,0 +1,157 @@
+// P5 Unit 4: Production Evidence panel — pure logic module.
+//
+// Provides a closed certification taxonomy (EVIDENCE_STATES) and functions to
+// classify individual evidence metrics and build the full panel model.
+// The React panel (AdminProductionEvidencePanel.jsx) consumes this model.
+
+/** Closed evidence state enum. */
+export const EVIDENCE_STATES = Object.freeze({
+  NOT_AVAILABLE: 'not_available',
+  STALE: 'stale',
+  FAILING: 'failing',
+  SMOKE_PASS: 'smoke_pass',
+  SMALL_PILOT_PROVISIONAL: 'small_pilot_provisional',
+  CERTIFIED_30: 'certified_30_learner_beta',
+  CERTIFIED_60: 'certified_60_learner_stretch',
+  CERTIFIED_100: 'certified_100_plus',
+  UNKNOWN: 'unknown',
+});
+
+const VALID_STATES = new Set(Object.values(EVIDENCE_STATES));
+
+/** Fresh threshold: 24 hours in milliseconds. */
+export const EVIDENCE_FRESH_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Type guard: rejects any value not in the closed taxonomy.
+ * @param {string} value
+ * @returns {boolean}
+ */
+export function isValidEvidenceState(value) {
+  return VALID_STATES.has(value);
+}
+
+/**
+ * Classify a single evidence metric into one of the EVIDENCE_STATES values.
+ *
+ * @param {string} metricKey — the metric tier key (e.g. 'certified_30_learner_beta')
+ * @param {object|null} metricValue — the metric summary object from the evidence summary
+ * @param {string|null} generatedAt — ISO timestamp of when the summary was generated
+ * @param {number} now — current time in ms (Date.now())
+ * @returns {string} one of EVIDENCE_STATES values
+ */
+export function classifyEvidenceMetric(metricKey, metricValue, generatedAt, now) {
+  if (!metricValue || typeof metricValue !== 'object') {
+    return EVIDENCE_STATES.NOT_AVAILABLE;
+  }
+
+  // Check freshness of the summary generation time.
+  const generatedAtMs = generatedAt ? new Date(generatedAt).getTime() : 0;
+  if (!generatedAtMs || !Number.isFinite(generatedAtMs)) {
+    return EVIDENCE_STATES.STALE;
+  }
+  const ageMs = now - generatedAtMs;
+  if (ageMs > EVIDENCE_FRESH_THRESHOLD_MS) {
+    return EVIDENCE_STATES.STALE;
+  }
+
+  // Dry-run evidence is not certifiable.
+  if (metricValue.dryRun) {
+    return EVIDENCE_STATES.UNKNOWN;
+  }
+
+  // Failing: evidence file exists but did not pass.
+  if (!metricValue.ok || (Array.isArray(metricValue.failures) && metricValue.failures.length > 0)) {
+    return EVIDENCE_STATES.FAILING;
+  }
+
+  // Map tier key to state. Only known tiers can produce certified states.
+  const tierMap = {
+    smoke_pass: EVIDENCE_STATES.SMOKE_PASS,
+    small_pilot_provisional: EVIDENCE_STATES.SMALL_PILOT_PROVISIONAL,
+    certified_30_learner_beta: EVIDENCE_STATES.CERTIFIED_30,
+    certified_60_learner_stretch: EVIDENCE_STATES.CERTIFIED_60,
+    certified_100_plus: EVIDENCE_STATES.CERTIFIED_100,
+  };
+
+  return tierMap[metricKey] || EVIDENCE_STATES.UNKNOWN;
+}
+
+/**
+ * Build the full evidence panel model from the summary JSON.
+ *
+ * @param {object} summaryJson — the parsed latest-evidence-summary.json
+ * @param {number} now — current time in ms (Date.now())
+ * @returns {{ metrics: Array, generatedAt: string|null, isFresh: boolean, overallState: string }}
+ */
+export function buildEvidencePanelModel(summaryJson, now) {
+  const summary = summaryJson && typeof summaryJson === 'object' ? summaryJson : {};
+  const rawMetrics = summary.metrics && typeof summary.metrics === 'object' ? summary.metrics : {};
+  const generatedAt = summary.generatedAt || null;
+
+  // Determine freshness.
+  const generatedAtMs = generatedAt ? new Date(generatedAt).getTime() : 0;
+  const isFresh = Boolean(
+    generatedAtMs &&
+    Number.isFinite(generatedAtMs) &&
+    (now - generatedAtMs) <= EVIDENCE_FRESH_THRESHOLD_MS,
+  );
+
+  // Classify each metric.
+  const metrics = Object.entries(rawMetrics).map(([key, value]) => ({
+    key,
+    tier: value?.tier || key,
+    state: classifyEvidenceMetric(key, value, generatedAt, now),
+    ok: Boolean(value?.ok),
+    learners: value?.learners ?? null,
+    finishedAt: value?.finishedAt || null,
+    commit: value?.commit || null,
+    failures: Array.isArray(value?.failures) ? value.failures : [],
+    fileName: value?.fileName || null,
+  }));
+
+  // Overall state: highest-tier passing state, or the most severe problem.
+  const overallState = deriveOverallState(metrics, isFresh);
+
+  return { metrics, generatedAt, isFresh, overallState };
+}
+
+/**
+ * Derive the overall panel state from classified metrics.
+ * Priority: highest certified tier wins, else failing > stale > not_available.
+ */
+function deriveOverallState(metrics, isFresh) {
+  if (!isFresh) return EVIDENCE_STATES.STALE;
+  if (metrics.length === 0) return EVIDENCE_STATES.NOT_AVAILABLE;
+
+  // Tier rank (higher = better).
+  const TIER_RANK = {
+    [EVIDENCE_STATES.CERTIFIED_100]: 7,
+    [EVIDENCE_STATES.CERTIFIED_60]: 6,
+    [EVIDENCE_STATES.CERTIFIED_30]: 5,
+    [EVIDENCE_STATES.SMALL_PILOT_PROVISIONAL]: 4,
+    [EVIDENCE_STATES.SMOKE_PASS]: 3,
+    [EVIDENCE_STATES.UNKNOWN]: 2,
+    [EVIDENCE_STATES.FAILING]: 1,
+    [EVIDENCE_STATES.STALE]: 0,
+    [EVIDENCE_STATES.NOT_AVAILABLE]: -1,
+  };
+
+  let best = EVIDENCE_STATES.NOT_AVAILABLE;
+  let bestRank = -1;
+  let hasFailing = false;
+
+  for (const m of metrics) {
+    const rank = TIER_RANK[m.state] ?? -1;
+    if (rank > bestRank) {
+      bestRank = rank;
+      best = m.state;
+    }
+    if (m.state === EVIDENCE_STATES.FAILING) hasFailing = true;
+  }
+
+  // If the best state is still non-passing but we have failures, surface that.
+  if (bestRank <= 2 && hasFailing) return EVIDENCE_STATES.FAILING;
+
+  return best;
+}

--- a/src/surfaces/hubs/AdminOverviewSection.jsx
+++ b/src/surfaces/hubs/AdminOverviewSection.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { formatTimestamp } from './hub-utils.js';
 import { PanelHeader } from './admin-panel-header.jsx';
 import { AdminPanelFrame } from './AdminPanelFrame.jsx';
+import { AdminProductionEvidencePanel } from './AdminProductionEvidencePanel.jsx';
 
 // U4+U5: Overview section — top-level KPIs, recent ops activity, and demo
 // health. Extracted from AdminHubSurface.jsx as the default landing section
@@ -160,6 +161,7 @@ export function AdminOverviewSection({ model, actions }) {
   return (
     <>
       <DashboardKpiPanel model={model} actions={actions} />
+      <AdminProductionEvidencePanel model={model} actions={actions} />
       <RecentActivityStreamPanel model={model} actions={actions} />
       <DemoOperationsSummary summary={model.demoOperations} />
     </>

--- a/src/surfaces/hubs/AdminProductionEvidencePanel.jsx
+++ b/src/surfaces/hubs/AdminProductionEvidencePanel.jsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { AdminPanelFrame } from './AdminPanelFrame.jsx';
+import {
+  buildEvidencePanelModel,
+  EVIDENCE_STATES,
+  isValidEvidenceState,
+} from '../../platform/hubs/admin-production-evidence.js';
+
+// P5 Unit 4: Production Evidence panel.
+//
+// Shows the current certification evidence state at a glance. Uses the
+// AdminPanelFrame for consistent freshness/stale/empty-state handling and
+// the closed EVIDENCE_STATES enum to classify each metric tier.
+
+const STATE_LABELS = {
+  [EVIDENCE_STATES.NOT_AVAILABLE]: 'Not available',
+  [EVIDENCE_STATES.STALE]: 'Stale',
+  [EVIDENCE_STATES.FAILING]: 'Failing',
+  [EVIDENCE_STATES.SMOKE_PASS]: 'Smoke pass',
+  [EVIDENCE_STATES.SMALL_PILOT_PROVISIONAL]: 'Small pilot (provisional)',
+  [EVIDENCE_STATES.CERTIFIED_30]: 'Certified 30-learner beta',
+  [EVIDENCE_STATES.CERTIFIED_60]: 'Certified 60-learner stretch',
+  [EVIDENCE_STATES.CERTIFIED_100]: 'Certified 100+ learners',
+  [EVIDENCE_STATES.UNKNOWN]: 'Unknown',
+};
+
+const STATE_BADGES = {
+  [EVIDENCE_STATES.NOT_AVAILABLE]: 'badge muted',
+  [EVIDENCE_STATES.STALE]: 'badge warn',
+  [EVIDENCE_STATES.FAILING]: 'badge error',
+  [EVIDENCE_STATES.SMOKE_PASS]: 'badge info',
+  [EVIDENCE_STATES.SMALL_PILOT_PROVISIONAL]: 'badge info',
+  [EVIDENCE_STATES.CERTIFIED_30]: 'badge success',
+  [EVIDENCE_STATES.CERTIFIED_60]: 'badge success',
+  [EVIDENCE_STATES.CERTIFIED_100]: 'badge success',
+  [EVIDENCE_STATES.UNKNOWN]: 'badge muted',
+};
+
+function StateBadge({ state }) {
+  const label = STATE_LABELS[state] || state;
+  const className = STATE_BADGES[state] || 'badge muted';
+  return <span className={className} data-evidence-state={state}>{label}</span>;
+}
+
+function formatEvidenceTimestamp(isoString) {
+  if (!isoString) return 'never';
+  const d = new Date(isoString);
+  if (Number.isNaN(d.getTime())) return 'invalid';
+  return d.toLocaleString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZoneName: 'short',
+  });
+}
+
+export function AdminProductionEvidencePanel({ model, actions }) {
+  const evidenceSummary = model?.productionEvidence || null;
+  const now = Date.now();
+  const panelModel = buildEvidencePanelModel(evidenceSummary, now);
+
+  const refreshedAtMs = panelModel.generatedAt
+    ? new Date(panelModel.generatedAt).getTime()
+    : null;
+
+  return (
+    <AdminPanelFrame
+      eyebrow="Production evidence"
+      title="Certification evidence"
+      refreshedAt={refreshedAtMs}
+      refreshError={null}
+      onRefresh={actions?.dispatch ? () => actions.dispatch('admin-ops-evidence-refresh') : undefined}
+      data={panelModel.metrics.length > 0 ? panelModel.metrics : null}
+      loading={false}
+      emptyState={
+        <p className="small muted">
+          No evidence data available. Run <code>node scripts/generate-evidence-summary.mjs</code> to generate.
+        </p>
+      }
+    >
+      <div data-testid="evidence-panel-overall">
+        <div className="skill-row" style={{ marginBottom: 8 }}>
+          <div><strong>Overall state</strong></div>
+          <div><StateBadge state={panelModel.overallState} /></div>
+        </div>
+        <div className="small muted" style={{ marginBottom: 12 }}>
+          Generated: {formatEvidenceTimestamp(panelModel.generatedAt)}
+          {panelModel.isFresh ? ' (fresh)' : ' (stale)'}
+        </div>
+      </div>
+
+      {panelModel.metrics.length > 0 ? (
+        <table
+          className="admin-table"
+          data-testid="evidence-metrics-table"
+          style={{ width: '100%', borderCollapse: 'collapse' }}
+        >
+          <thead>
+            <tr>
+              <th style={{ textAlign: 'left', padding: '4px 8px' }}>Tier</th>
+              <th style={{ textAlign: 'left', padding: '4px 8px' }}>State</th>
+              <th style={{ textAlign: 'left', padding: '4px 8px' }}>Learners</th>
+              <th style={{ textAlign: 'left', padding: '4px 8px' }}>Last run</th>
+            </tr>
+          </thead>
+          <tbody>
+            {panelModel.metrics.map((metric) => (
+              <tr key={metric.key} data-metric-key={metric.key}>
+                <td style={{ padding: '4px 8px' }}>{metric.tier}</td>
+                <td style={{ padding: '4px 8px' }}><StateBadge state={metric.state} /></td>
+                <td style={{ padding: '4px 8px' }}>{metric.learners ?? '—'}</td>
+                <td style={{ padding: '4px 8px' }} className="small muted">
+                  {formatEvidenceTimestamp(metric.finishedAt)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : null}
+    </AdminPanelFrame>
+  );
+}

--- a/tests/admin-production-evidence.test.js
+++ b/tests/admin-production-evidence.test.js
@@ -1,0 +1,311 @@
+// P5 Unit 4: Production Evidence panel — logic layer tests.
+//
+// Tests the closed EVIDENCE_STATES enum, the classifyEvidenceMetric function,
+// and the buildEvidencePanelModel function covering all 9 states.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  EVIDENCE_STATES,
+  EVIDENCE_FRESH_THRESHOLD_MS,
+  isValidEvidenceState,
+  classifyEvidenceMetric,
+  buildEvidencePanelModel,
+} from '../src/platform/hubs/admin-production-evidence.js';
+
+// ---------------------------------------------------------------------------
+// isValidEvidenceState
+// ---------------------------------------------------------------------------
+
+test('isValidEvidenceState accepts all 9 enum values', () => {
+  const values = Object.values(EVIDENCE_STATES);
+  assert.equal(values.length, 9, 'enum has exactly 9 values');
+  for (const v of values) {
+    assert.equal(isValidEvidenceState(v), true, `${v} is valid`);
+  }
+});
+
+test('isValidEvidenceState rejects unknown strings', () => {
+  assert.equal(isValidEvidenceState('bogus'), false);
+  assert.equal(isValidEvidenceState(''), false);
+  assert.equal(isValidEvidenceState(null), false);
+  assert.equal(isValidEvidenceState(undefined), false);
+  assert.equal(isValidEvidenceState(42), false);
+});
+
+// ---------------------------------------------------------------------------
+// classifyEvidenceMetric — NOT_AVAILABLE
+// ---------------------------------------------------------------------------
+
+test('classifyEvidenceMetric returns NOT_AVAILABLE when metricValue is null', () => {
+  const result = classifyEvidenceMetric('smoke_pass', null, new Date().toISOString(), Date.now());
+  assert.equal(result, EVIDENCE_STATES.NOT_AVAILABLE);
+});
+
+test('classifyEvidenceMetric returns NOT_AVAILABLE when metricValue is not an object', () => {
+  const result = classifyEvidenceMetric('smoke_pass', 'string', new Date().toISOString(), Date.now());
+  assert.equal(result, EVIDENCE_STATES.NOT_AVAILABLE);
+});
+
+// ---------------------------------------------------------------------------
+// classifyEvidenceMetric — STALE
+// ---------------------------------------------------------------------------
+
+test('classifyEvidenceMetric returns STALE when generatedAt is null', () => {
+  const result = classifyEvidenceMetric('smoke_pass', { ok: true }, null, Date.now());
+  assert.equal(result, EVIDENCE_STATES.STALE);
+});
+
+test('classifyEvidenceMetric returns STALE when generatedAt is older than 24h', () => {
+  const oldDate = new Date(Date.now() - EVIDENCE_FRESH_THRESHOLD_MS - 1000).toISOString();
+  const result = classifyEvidenceMetric('smoke_pass', { ok: true }, oldDate, Date.now());
+  assert.equal(result, EVIDENCE_STATES.STALE);
+});
+
+// ---------------------------------------------------------------------------
+// classifyEvidenceMetric — FAILING
+// ---------------------------------------------------------------------------
+
+test('classifyEvidenceMetric returns FAILING when ok is false', () => {
+  const now = Date.now();
+  const freshDate = new Date(now - 1000).toISOString();
+  const result = classifyEvidenceMetric('certified_30_learner_beta', { ok: false, failures: [] }, freshDate, now);
+  assert.equal(result, EVIDENCE_STATES.FAILING);
+});
+
+test('classifyEvidenceMetric returns FAILING when failures array is non-empty', () => {
+  const now = Date.now();
+  const freshDate = new Date(now - 1000).toISOString();
+  const result = classifyEvidenceMetric('certified_30_learner_beta', { ok: true, failures: ['max5xx'] }, freshDate, now);
+  assert.equal(result, EVIDENCE_STATES.FAILING);
+});
+
+// ---------------------------------------------------------------------------
+// classifyEvidenceMetric — UNKNOWN (dry-run)
+// ---------------------------------------------------------------------------
+
+test('classifyEvidenceMetric returns UNKNOWN for dry-run evidence', () => {
+  const now = Date.now();
+  const freshDate = new Date(now - 1000).toISOString();
+  const result = classifyEvidenceMetric('smoke_pass', { ok: true, dryRun: true, failures: [] }, freshDate, now);
+  assert.equal(result, EVIDENCE_STATES.UNKNOWN);
+});
+
+// ---------------------------------------------------------------------------
+// classifyEvidenceMetric — SMOKE_PASS
+// ---------------------------------------------------------------------------
+
+test('classifyEvidenceMetric returns SMOKE_PASS for passing smoke tier', () => {
+  const now = Date.now();
+  const freshDate = new Date(now - 1000).toISOString();
+  const result = classifyEvidenceMetric('smoke_pass', { ok: true, failures: [] }, freshDate, now);
+  assert.equal(result, EVIDENCE_STATES.SMOKE_PASS);
+});
+
+// ---------------------------------------------------------------------------
+// classifyEvidenceMetric — SMALL_PILOT_PROVISIONAL
+// ---------------------------------------------------------------------------
+
+test('classifyEvidenceMetric returns SMALL_PILOT_PROVISIONAL for passing small pilot', () => {
+  const now = Date.now();
+  const freshDate = new Date(now - 1000).toISOString();
+  const result = classifyEvidenceMetric('small_pilot_provisional', { ok: true, failures: [] }, freshDate, now);
+  assert.equal(result, EVIDENCE_STATES.SMALL_PILOT_PROVISIONAL);
+});
+
+// ---------------------------------------------------------------------------
+// classifyEvidenceMetric — CERTIFIED_30
+// ---------------------------------------------------------------------------
+
+test('classifyEvidenceMetric returns CERTIFIED_30 for passing 30-learner tier', () => {
+  const now = Date.now();
+  const freshDate = new Date(now - 1000).toISOString();
+  const result = classifyEvidenceMetric('certified_30_learner_beta', { ok: true, failures: [] }, freshDate, now);
+  assert.equal(result, EVIDENCE_STATES.CERTIFIED_30);
+});
+
+// ---------------------------------------------------------------------------
+// classifyEvidenceMetric — CERTIFIED_60
+// ---------------------------------------------------------------------------
+
+test('classifyEvidenceMetric returns CERTIFIED_60 for passing 60-learner tier', () => {
+  const now = Date.now();
+  const freshDate = new Date(now - 1000).toISOString();
+  const result = classifyEvidenceMetric('certified_60_learner_stretch', { ok: true, failures: [] }, freshDate, now);
+  assert.equal(result, EVIDENCE_STATES.CERTIFIED_60);
+});
+
+// ---------------------------------------------------------------------------
+// classifyEvidenceMetric — CERTIFIED_100
+// ---------------------------------------------------------------------------
+
+test('classifyEvidenceMetric returns CERTIFIED_100 for passing 100+ learner tier', () => {
+  const now = Date.now();
+  const freshDate = new Date(now - 1000).toISOString();
+  const result = classifyEvidenceMetric('certified_100_plus', { ok: true, failures: [] }, freshDate, now);
+  assert.equal(result, EVIDENCE_STATES.CERTIFIED_100);
+});
+
+// ---------------------------------------------------------------------------
+// classifyEvidenceMetric — UNKNOWN (unrecognised tier key)
+// ---------------------------------------------------------------------------
+
+test('classifyEvidenceMetric returns UNKNOWN for unrecognised tier key', () => {
+  const now = Date.now();
+  const freshDate = new Date(now - 1000).toISOString();
+  const result = classifyEvidenceMetric('totally_new_tier', { ok: true, failures: [] }, freshDate, now);
+  assert.equal(result, EVIDENCE_STATES.UNKNOWN);
+});
+
+// ---------------------------------------------------------------------------
+// buildEvidencePanelModel — empty / null summary
+// ---------------------------------------------------------------------------
+
+test('buildEvidencePanelModel returns empty model for null summary', () => {
+  const result = buildEvidencePanelModel(null, Date.now());
+  assert.deepEqual(result.metrics, []);
+  assert.equal(result.generatedAt, null);
+  assert.equal(result.isFresh, false);
+  assert.equal(result.overallState, EVIDENCE_STATES.STALE);
+});
+
+test('buildEvidencePanelModel returns empty model for placeholder summary', () => {
+  const result = buildEvidencePanelModel({ schema: 2, metrics: {}, generatedAt: null }, Date.now());
+  assert.deepEqual(result.metrics, []);
+  assert.equal(result.generatedAt, null);
+  assert.equal(result.isFresh, false);
+  assert.equal(result.overallState, EVIDENCE_STATES.STALE);
+});
+
+// ---------------------------------------------------------------------------
+// buildEvidencePanelModel — fresh summary with metrics
+// ---------------------------------------------------------------------------
+
+test('buildEvidencePanelModel classifies fresh summary with passing 30-learner', () => {
+  const now = Date.now();
+  const freshDate = new Date(now - 60_000).toISOString();
+  const summary = {
+    schema: 2,
+    generatedAt: freshDate,
+    metrics: {
+      certified_30_learner_beta: {
+        tier: 'certified_30_learner_beta',
+        ok: true,
+        dryRun: false,
+        learners: 30,
+        finishedAt: freshDate,
+        commit: 'abc1234',
+        failures: [],
+        fileName: '30-learner-beta-v2-20260428.json',
+      },
+    },
+  };
+  const result = buildEvidencePanelModel(summary, now);
+  assert.equal(result.isFresh, true);
+  assert.equal(result.metrics.length, 1);
+  assert.equal(result.metrics[0].state, EVIDENCE_STATES.CERTIFIED_30);
+  assert.equal(result.overallState, EVIDENCE_STATES.CERTIFIED_30);
+});
+
+test('buildEvidencePanelModel overall is highest tier when multiple metrics pass', () => {
+  const now = Date.now();
+  const freshDate = new Date(now - 60_000).toISOString();
+  const summary = {
+    schema: 2,
+    generatedAt: freshDate,
+    metrics: {
+      smoke_pass: {
+        tier: 'smoke_pass',
+        ok: true,
+        dryRun: false,
+        learners: 1,
+        finishedAt: freshDate,
+        commit: 'aaa1111',
+        failures: [],
+        fileName: 'smoke.json',
+      },
+      certified_60_learner_stretch: {
+        tier: 'certified_60_learner_stretch',
+        ok: true,
+        dryRun: false,
+        learners: 60,
+        finishedAt: freshDate,
+        commit: 'bbb2222',
+        failures: [],
+        fileName: '60-learner.json',
+      },
+    },
+  };
+  const result = buildEvidencePanelModel(summary, now);
+  assert.equal(result.overallState, EVIDENCE_STATES.CERTIFIED_60);
+});
+
+test('buildEvidencePanelModel overall is FAILING when all metrics fail', () => {
+  const now = Date.now();
+  const freshDate = new Date(now - 60_000).toISOString();
+  const summary = {
+    schema: 2,
+    generatedAt: freshDate,
+    metrics: {
+      certified_30_learner_beta: {
+        tier: 'certified_30_learner_beta',
+        ok: false,
+        dryRun: false,
+        learners: 30,
+        finishedAt: freshDate,
+        commit: 'abc1234',
+        failures: ['max5xx'],
+        fileName: '30-fail.json',
+      },
+    },
+  };
+  const result = buildEvidencePanelModel(summary, now);
+  assert.equal(result.isFresh, true);
+  assert.equal(result.overallState, EVIDENCE_STATES.FAILING);
+});
+
+test('buildEvidencePanelModel overall is STALE when generatedAt exceeds 24h', () => {
+  const now = Date.now();
+  const staleDate = new Date(now - EVIDENCE_FRESH_THRESHOLD_MS - 1000).toISOString();
+  const summary = {
+    schema: 2,
+    generatedAt: staleDate,
+    metrics: {
+      certified_30_learner_beta: {
+        tier: 'certified_30_learner_beta',
+        ok: true,
+        dryRun: false,
+        learners: 30,
+        finishedAt: staleDate,
+        commit: 'abc1234',
+        failures: [],
+        fileName: '30-pass.json',
+      },
+    },
+  };
+  const result = buildEvidencePanelModel(summary, now);
+  assert.equal(result.isFresh, false);
+  assert.equal(result.overallState, EVIDENCE_STATES.STALE);
+});
+
+// ---------------------------------------------------------------------------
+// Closed enum type guard: reject fabricated values
+// ---------------------------------------------------------------------------
+
+test('type guard rejects fabricated state values', () => {
+  assert.equal(isValidEvidenceState('certified_999_learner_galaxy'), false);
+  assert.equal(isValidEvidenceState('CERTIFIED_30'), false); // case-sensitive
+  assert.equal(isValidEvidenceState('not-available'), false); // wrong separator
+});
+
+// ---------------------------------------------------------------------------
+// EVIDENCE_STATES is frozen
+// ---------------------------------------------------------------------------
+
+test('EVIDENCE_STATES is frozen and cannot be extended', () => {
+  assert.equal(Object.isFrozen(EVIDENCE_STATES), true);
+  assert.throws(() => {
+    EVIDENCE_STATES.FABRICATED = 'fake';
+  });
+});

--- a/tests/react-admin-production-evidence.test.js
+++ b/tests/react-admin-production-evidence.test.js
@@ -1,0 +1,256 @@
+// P5 Unit 4: AdminProductionEvidencePanel rendering tests.
+//
+// Uses the same esbuild SSR harness as the characterization test suite to
+// verify the panel renders correctly for fresh, stale, and missing states.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function nodePaths() {
+  // In worktrees, node_modules lives in the main repo root, not the worktree.
+  // Walk up from rootDir to find the nearest node_modules.
+  const candidates = [
+    path.join(rootDir, 'node_modules'),
+  ];
+  let dir = rootDir;
+  for (let i = 0; i < 5; i++) {
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+    candidates.push(path.join(dir, 'node_modules'));
+  }
+  return [
+    ...candidates,
+    ...String(process.env.NODE_PATH || '').split(path.delimiter),
+  ].filter((entry) => entry && existsSync(entry));
+}
+
+function normaliseLineEndings(value) {
+  return String(value).replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
+async function renderFixture(entrySource) {
+  const tmpDir = await mkdtemp(path.join(tmpdir(), 'ks2-evidence-panel-'));
+  const entryPath = path.join(tmpDir, 'entry.jsx');
+  const bundlePath = path.join(tmpDir, 'entry.cjs');
+  try {
+    await writeFile(entryPath, entrySource);
+    await build({
+      absWorkingDir: rootDir,
+      entryPoints: [entryPath],
+      outfile: bundlePath,
+      bundle: true,
+      platform: 'node',
+      format: 'cjs',
+      target: ['node24'],
+      jsx: 'automatic',
+      jsxImportSource: 'react',
+      loader: { '.js': 'jsx' },
+      nodePaths: nodePaths(),
+      logLevel: 'silent',
+    });
+    const output = execFileSync(process.execPath, [bundlePath], {
+      cwd: rootDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return normaliseLineEndings(output).replace(/\n+$/, '');
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+const PANEL_PATH = JSON.stringify(
+  path.join(rootDir, 'src/surfaces/hubs/AdminProductionEvidencePanel.jsx'),
+);
+
+function buildEntry(model) {
+  return `
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { AdminProductionEvidencePanel } from ${PANEL_PATH};
+    const model = ${JSON.stringify(model)};
+    const actions = { dispatch() {} };
+    const html = renderToStaticMarkup(
+      <AdminProductionEvidencePanel model={model} actions={actions} />
+    );
+    process.stdout.write(html);
+  `;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Fresh evidence with passing 30-learner metric
+// ---------------------------------------------------------------------------
+
+test('renders fresh evidence panel with passing 30-learner certification', async () => {
+  const now = Date.now();
+  const freshDate = new Date(now - 60_000).toISOString();
+  const model = {
+    productionEvidence: {
+      schema: 2,
+      generatedAt: freshDate,
+      metrics: {
+        certified_30_learner_beta: {
+          tier: 'certified_30_learner_beta',
+          ok: true,
+          dryRun: false,
+          learners: 30,
+          finishedAt: freshDate,
+          commit: 'abc1234',
+          failures: [],
+          fileName: '30-learner.json',
+        },
+      },
+    },
+  };
+  const html = await renderFixture(buildEntry(model));
+
+  assert.match(html, /Certification evidence/, 'renders panel title');
+  assert.match(html, /data-panel-frame="Certification evidence"/, 'AdminPanelFrame wraps content');
+  assert.match(html, /data-testid="evidence-panel-overall"/, 'overall state section present');
+  assert.match(html, /data-evidence-state="certified_30_learner_beta"/, 'shows certified_30 badge');
+  assert.match(html, /data-testid="evidence-metrics-table"/, 'metrics table present');
+  assert.match(html, /30/, 'learner count shown');
+  assert.match(html, /\(fresh\)/, 'shows fresh indicator');
+});
+
+// ---------------------------------------------------------------------------
+// 2. Stale evidence (generatedAt older than 24h)
+// ---------------------------------------------------------------------------
+
+test('renders stale evidence panel when generatedAt exceeds 24h', async () => {
+  const now = Date.now();
+  const staleDate = new Date(now - 25 * 60 * 60 * 1000).toISOString();
+  const model = {
+    productionEvidence: {
+      schema: 2,
+      generatedAt: staleDate,
+      metrics: {
+        certified_30_learner_beta: {
+          tier: 'certified_30_learner_beta',
+          ok: true,
+          dryRun: false,
+          learners: 30,
+          finishedAt: staleDate,
+          commit: 'abc1234',
+          failures: [],
+          fileName: '30-learner.json',
+        },
+      },
+    },
+  };
+  const html = await renderFixture(buildEntry(model));
+
+  assert.match(html, /Certification evidence/, 'renders panel title');
+  assert.match(html, /data-evidence-state="stale"/, 'overall state is stale');
+  assert.match(html, /\(stale\)/, 'shows stale indicator');
+});
+
+// ---------------------------------------------------------------------------
+// 3. Missing / null evidence (placeholder summary)
+// ---------------------------------------------------------------------------
+
+test('renders empty state when evidence summary has no metrics', async () => {
+  const model = {
+    productionEvidence: { schema: 2, metrics: {}, generatedAt: null },
+  };
+  const html = await renderFixture(buildEntry(model));
+
+  assert.match(html, /Certification evidence/, 'renders panel title');
+  assert.match(html, /data-panel-frame-empty="true"/, 'shows empty state');
+  assert.match(html, /No evidence data available/, 'shows empty state message');
+});
+
+// ---------------------------------------------------------------------------
+// 4. Null productionEvidence in model
+// ---------------------------------------------------------------------------
+
+test('renders empty state when productionEvidence is absent from model', async () => {
+  const model = {};
+  const html = await renderFixture(buildEntry(model));
+
+  assert.match(html, /Certification evidence/, 'renders panel title');
+  assert.match(html, /data-panel-frame-empty="true"/, 'shows empty state');
+});
+
+// ---------------------------------------------------------------------------
+// 5. Failing evidence
+// ---------------------------------------------------------------------------
+
+test('renders failing state when evidence has failures', async () => {
+  const now = Date.now();
+  const freshDate = new Date(now - 60_000).toISOString();
+  const model = {
+    productionEvidence: {
+      schema: 2,
+      generatedAt: freshDate,
+      metrics: {
+        certified_30_learner_beta: {
+          tier: 'certified_30_learner_beta',
+          ok: false,
+          dryRun: false,
+          learners: 30,
+          finishedAt: freshDate,
+          commit: 'abc1234',
+          failures: ['max5xx'],
+          fileName: '30-fail.json',
+        },
+      },
+    },
+  };
+  const html = await renderFixture(buildEntry(model));
+
+  assert.match(html, /data-evidence-state="failing"/, 'shows failing badge');
+  assert.match(html, /Failing/, 'failing label present');
+});
+
+// ---------------------------------------------------------------------------
+// 6. Multiple tiers with mixed states
+// ---------------------------------------------------------------------------
+
+test('renders multiple metric rows in table', async () => {
+  const now = Date.now();
+  const freshDate = new Date(now - 60_000).toISOString();
+  const model = {
+    productionEvidence: {
+      schema: 2,
+      generatedAt: freshDate,
+      metrics: {
+        smoke_pass: {
+          tier: 'smoke_pass',
+          ok: true,
+          dryRun: false,
+          learners: 1,
+          finishedAt: freshDate,
+          commit: 'aaa1111',
+          failures: [],
+          fileName: 'smoke.json',
+        },
+        certified_60_learner_stretch: {
+          tier: 'certified_60_learner_stretch',
+          ok: true,
+          dryRun: false,
+          learners: 60,
+          finishedAt: freshDate,
+          commit: 'bbb2222',
+          failures: [],
+          fileName: '60-learner.json',
+        },
+      },
+    },
+  };
+  const html = await renderFixture(buildEntry(model));
+
+  assert.match(html, /data-metric-key="smoke_pass"/, 'smoke row present');
+  assert.match(html, /data-metric-key="certified_60_learner_stretch"/, '60-learner row present');
+  assert.match(html, /data-evidence-state="certified_60_learner_stretch"/, 'highest tier badge shown');
+});

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -1921,6 +1921,36 @@ export function createWorkerApp({
           return json({ ok: true, ...result });
         }
 
+        // P5 U4: Production evidence summary. Lazy-loaded GET returning the
+        // pre-generated evidence summary JSON. Rate-limited at 60/min per
+        // session (same bucket as other admin-ops reads). Both admin and ops
+        // roles see the same data — evidence is non-sensitive operational state.
+        if (url.pathname === '/api/admin/ops/production-evidence' && request.method === 'GET') {
+          requireSameOrigin(request, env);
+          const evidenceLimit = await consumeRateLimit(env, {
+            bucket: 'admin-ops-mutation',
+            identifier: session.accountId,
+            limit: 60,
+            windowMs: 60_000,
+          });
+          if (!evidenceLimit.allowed) {
+            return rateLimitResponse({
+              code: 'admin_ops_mutation_rate_limited',
+              retryAfterSeconds: evidenceLimit.retryAfterSeconds,
+              extra: {
+                message: 'Admin-ops reads are rate-limited at 60 per minute per session.',
+              },
+            });
+          }
+          let evidenceSummary;
+          try {
+            evidenceSummary = (await import('../../../reports/capacity/latest-evidence-summary.json', { with: { type: 'json' } })).default;
+          } catch {
+            evidenceSummary = { schema: 2, metrics: {}, generatedAt: null };
+          }
+          return json({ ok: true, ...evidenceSummary });
+        }
+
         // R31: regex dispatch for parameterised admin ops mutations. Placed
         // AFTER literal /api/admin/accounts and /api/admin/accounts/role so
         // those take priority, and AFTER the four /api/admin/ops/* GET

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -1927,6 +1927,7 @@ export function createWorkerApp({
         // roles see the same data — evidence is non-sensitive operational state.
         if (url.pathname === '/api/admin/ops/production-evidence' && request.method === 'GET') {
           requireSameOrigin(request, env);
+          await repository.assertAdminHubActor(session.accountId);
           const evidenceLimit = await consumeRateLimit(env, {
             bucket: 'admin-ops-mutation',
             identifier: session.accountId,


### PR DESCRIPTION
## Summary
- Evidence summary generation script (`scripts/generate-evidence-summary.mjs`) reads evidence files from `reports/capacity/evidence/` and emits `reports/capacity/latest-evidence-summary.json`
- Closed `EVIDENCE_STATES` enum (9 states) with `classifyEvidenceMetric` and `buildEvidencePanelModel` in `src/platform/hubs/admin-production-evidence.js`
- `AdminProductionEvidencePanel` using `AdminPanelFrame` — added to `AdminOverviewSection` after `DashboardKpiPanel`
- Lazy-loaded `GET /api/admin/ops/production-evidence` endpoint with 60/min rate limit (same bucket as other admin-ops reads)
- Both admin and ops roles see the same evidence data (ER-8)

## Test plan
- [x] Evidence logic tests cover all 9 states (23 tests)
- [x] Panel rendering tests cover fresh/stale/missing (6 tests)
- [ ] Existing overview tests pass (no regression) — pre-existing worktree node_modules resolution issue