### PR TITLE
feat(admin): harden destructive QA tools with confirmation pattern (P5 U10)

### DIFF
--- a/src/surfaces/hubs/AdminContentSection.jsx
+++ b/src/surfaces/hubs/AdminContentSection.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import { formatTimestamp, isBlocked } from './hub-utils.js';
 import { MonsterVisualConfigPanel } from './MonsterVisualConfigPanel.jsx';
+import { AdminConfirmAction } from './AdminConfirmAction.jsx';
 import { AdultConfidenceChip } from '../../subjects/grammar/components/AdultConfidenceChip.jsx';
 import { GRAMMAR_RECENT_ATTEMPT_HORIZON } from '../../../shared/grammar/confidence.js';
 import { buildAssetRegistry } from '../../platform/hubs/admin-asset-registry.js';
+import { classifyAction } from '../../platform/hubs/admin-action-classification.js';
+import { useSubmitLock } from '../../platform/react/use-submit-lock.js';
 import {
   buildSubjectContentOverview,
   statusBadgeClass,
@@ -236,6 +239,8 @@ function PostMegaSeedHarnessPanel({ model, actions }) {
   const [shapeName, setShapeName] = React.useState(shapes[0] || '');
   const [learnerId, setLearnerId] = React.useState(defaultLearnerId);
   const [manualLearnerId, setManualLearnerId] = React.useState('');
+  const [showConfirm, setShowConfirm] = React.useState(false);
+  const { locked, run } = useSubmitLock();
 
   React.useEffect(() => {
     if (!shapeName && shapes.length) setShapeName(shapes[0]);
@@ -256,6 +261,7 @@ function PostMegaSeedHarnessPanel({ model, actions }) {
 
   const effectiveLearnerId = manualLearnerId.trim() || learnerId;
   const canApply = Boolean(effectiveLearnerId) && Boolean(shapeName);
+  const classification = classifyAction('post-mega-seed-apply', { targetId: effectiveLearnerId });
 
   return (
     <section className="card admin-card-spaced" data-panel="post-mega-seed-harness">
@@ -312,22 +318,39 @@ function PostMegaSeedHarnessPanel({ model, actions }) {
           />
         </label>
         <div>
-          <button
-            className="btn secondary"
-            type="button"
-            disabled={!canApply}
-            onClick={() => actions.dispatch('post-mega-seed-apply', {
-              learnerId: effectiveLearnerId,
-              shapeName,
-            })}
-          >
-            Apply seed
-          </button>
-          <div className="small muted admin-note-spaced">
-            {canApply
-              ? `Will write ${shapeName} → ${effectiveLearnerId}.`
-              : 'Choose a shape and learner to apply.'}
-          </div>
+          {!showConfirm ? (
+            <>
+              <button
+                className="btn secondary"
+                type="button"
+                disabled={!canApply || locked}
+                data-action="post-mega-seed-apply"
+                onClick={() => setShowConfirm(true)}
+              >
+                Apply seed
+              </button>
+              <div className="small muted admin-note-spaced">
+                {canApply
+                  ? `Will write ${shapeName} → ${effectiveLearnerId}.`
+                  : 'Choose a shape and learner to apply.'}
+              </div>
+            </>
+          ) : (
+            <AdminConfirmAction
+              level={classification.level}
+              dangerCopy={classification.dangerCopy}
+              targetDisplay={`${shapeName} → ${effectiveLearnerId}`}
+              typedConfirmValue={effectiveLearnerId}
+              onConfirm={() => run(async () => {
+                actions.dispatch('post-mega-seed-apply', {
+                  learnerId: effectiveLearnerId,
+                  shapeName,
+                });
+                setShowConfirm(false);
+              })}
+              onCancel={() => setShowConfirm(false)}
+            />
+          )}
         </div>
       </div>
     </section>
@@ -371,6 +394,10 @@ function GrammarConceptConfidencePanel({ evidence }) {
 
 function GrammarWritingTryAdminPanel({ learnerId, transfer, actions }) {
   const [archiveOpen, setArchiveOpen] = React.useState(false);
+  const [confirmingArchive, setConfirmingArchive] = React.useState(null);
+  const [confirmingDelete, setConfirmingDelete] = React.useState(null);
+  const { locked: archiveLocked, run: runArchive } = useSubmitLock();
+  const { locked: deleteLocked, run: runDelete } = useSubmitLock();
   const liveEntries = Array.isArray(transfer?.evidence) ? transfer.evidence : [];
   const archivedEntries = Array.isArray(transfer?.archive) ? transfer.archive : [];
   if (!learnerId) {
@@ -409,18 +436,32 @@ function GrammarWritingTryAdminPanel({ learnerId, transfer, actions }) {
                   </div>
                 </div>
                 <div>
-                  <button
-                    className="btn secondary"
-                    type="button"
-                    data-action="grammar-transfer-admin-archive"
-                    data-prompt-id={entry.promptId}
-                    onClick={() => actions.dispatch('grammar-transfer-admin-archive', {
-                      learnerId,
-                      promptId: entry.promptId,
-                    })}
-                  >
-                    Archive
-                  </button>
+                  {confirmingArchive === entry.promptId ? (
+                    <AdminConfirmAction
+                      level="high"
+                      dangerCopy="This will remove the entry from the learner's active list."
+                      targetDisplay={entry.promptId}
+                      onConfirm={() => runArchive(async () => {
+                        actions.dispatch('grammar-transfer-admin-archive', {
+                          learnerId,
+                          promptId: entry.promptId,
+                        });
+                        setConfirmingArchive(null);
+                      })}
+                      onCancel={() => setConfirmingArchive(null)}
+                    />
+                  ) : (
+                    <button
+                      className="btn secondary"
+                      type="button"
+                      data-action="grammar-transfer-admin-archive"
+                      data-prompt-id={entry.promptId}
+                      disabled={archiveLocked}
+                      onClick={() => setConfirmingArchive(entry.promptId)}
+                    >
+                      Archive
+                    </button>
+                  )}
                 </div>
               </li>
             ))}
@@ -463,18 +504,33 @@ function GrammarWritingTryAdminPanel({ learnerId, transfer, actions }) {
                     </div>
                   </div>
                   <div>
-                    <button
-                      className="btn warn"
-                      type="button"
-                      data-action="grammar-transfer-admin-delete"
-                      data-prompt-id={entry.promptId}
-                      onClick={() => actions.dispatch('grammar-transfer-admin-delete', {
-                        learnerId,
-                        promptId: entry.promptId,
-                      })}
-                    >
-                      Delete permanently
-                    </button>
+                    {confirmingDelete === entry.promptId ? (
+                      <AdminConfirmAction
+                        level="critical"
+                        dangerCopy="This will permanently delete the archived entry. This cannot be undone."
+                        targetDisplay={entry.promptId}
+                        typedConfirmValue={entry.promptId}
+                        onConfirm={() => runDelete(async () => {
+                          actions.dispatch('grammar-transfer-admin-delete', {
+                            learnerId,
+                            promptId: entry.promptId,
+                          });
+                          setConfirmingDelete(null);
+                        })}
+                        onCancel={() => setConfirmingDelete(null)}
+                      />
+                    ) : (
+                      <button
+                        className="btn warn"
+                        type="button"
+                        data-action="grammar-transfer-admin-delete"
+                        data-prompt-id={entry.promptId}
+                        disabled={deleteLocked}
+                        onClick={() => setConfirmingDelete(entry.promptId)}
+                      >
+                        Delete permanently
+                      </button>
+                    )}
                   </div>
                 </li>
               ))}
@@ -495,6 +551,12 @@ function GrammarWritingTryAdminPanel({ learnerId, transfer, actions }) {
 // delegate to existing mutation dispatch keys. Designed so multiple cards
 // can be stacked when future asset categories are added.
 function AssetRegistryCard({ entry, model, actions }) {
+  const [selectedRestoreVersion, setSelectedRestoreVersion] = React.useState(null);
+  const [showRestoreConfirm, setShowRestoreConfirm] = React.useState(false);
+  const [showPublishConfirm, setShowPublishConfirm] = React.useState(false);
+  const { locked: publishLocked, run: runPublish } = useSubmitLock();
+  const { locked: restoreLocked, run: runRestore } = useSubmitLock();
+
   if (!entry) return null;
 
   const publishedLabel = entry.publishedVersion > 0
@@ -551,40 +613,80 @@ function AssetRegistryCard({ entry, model, actions }) {
           </div>
         </div>
         <div className="actions admin-registry-actions-end">
-          <button
-            className="btn good"
-            type="button"
-            disabled={!entry.canManage || !entry.validationState.ok || !entry.hasDraft}
-            data-action="registry-publish"
-            onClick={() => actions.dispatch('monster-visual-config-publish', {
-              expectedDraftRevision: status.draftRevision,
-            })}
-          >
-            Publish
-          </button>
-          <select
-            className="select"
-            disabled={!entry.canManage || !entry.versions.length}
-            data-action="registry-restore"
-            onChange={(event) => {
-              const version = Number(event.target.value) || 0;
-              if (!version) return;
-              actions.dispatch('monster-visual-config-restore', {
-                version,
-                expectedDraftRevision: status.draftRevision,
-              });
-              event.target.value = '';
-            }}
-            defaultValue=""
-            aria-label="Restore version"
-          >
-            <option value="">Restore version</option>
-            {entry.versions.map((version) => (
-              <option value={version.version} key={version.version}>
-                Version {version.version} - {formatTimestamp(version.publishedAt)}
-              </option>
-            ))}
-          </select>
+          {showPublishConfirm ? (
+            <AdminConfirmAction
+              level="high"
+              dangerCopy="This will publish the current draft to all users."
+              targetDisplay={`Monster Visual Config rev ${String(status.draftRevision)}`}
+              onConfirm={() => runPublish(async () => {
+                actions.dispatch('monster-visual-config-publish', {
+                  expectedDraftRevision: status.draftRevision,
+                });
+                setShowPublishConfirm(false);
+              })}
+              onCancel={() => setShowPublishConfirm(false)}
+            />
+          ) : (
+            <button
+              className="btn good"
+              type="button"
+              disabled={!entry.canManage || !entry.validationState.ok || !entry.hasDraft || publishLocked}
+              data-action="registry-publish"
+              onClick={() => setShowPublishConfirm(true)}
+            >
+              Publish
+            </button>
+          )}
+          <div className="admin-registry-restore-flow">
+            <select
+              className="select"
+              disabled={!entry.canManage || !entry.versions.length || restoreLocked}
+              data-action="registry-restore"
+              value={selectedRestoreVersion != null ? String(selectedRestoreVersion) : ''}
+              onChange={(event) => {
+                const version = Number(event.target.value) || 0;
+                setSelectedRestoreVersion(version || null);
+                setShowRestoreConfirm(false);
+              }}
+              aria-label="Restore version"
+            >
+              <option value="">Restore version</option>
+              {entry.versions.map((version) => (
+                <option value={version.version} key={version.version}>
+                  Version {version.version} - {formatTimestamp(version.publishedAt)}
+                </option>
+              ))}
+            </select>
+            {selectedRestoreVersion && !showRestoreConfirm ? (
+              <button
+                className="btn secondary"
+                type="button"
+                data-action="registry-restore-confirm-trigger"
+                disabled={restoreLocked}
+                onClick={() => setShowRestoreConfirm(true)}
+              >
+                Restore to v{selectedRestoreVersion}
+              </button>
+            ) : null}
+            {showRestoreConfirm && selectedRestoreVersion ? (
+              <AdminConfirmAction
+                level="high"
+                dangerCopy="This will overwrite the current draft with a previous version."
+                targetDisplay={`Restore to v${selectedRestoreVersion}`}
+                onConfirm={() => runRestore(async () => {
+                  actions.dispatch('monster-visual-config-restore', {
+                    version: selectedRestoreVersion,
+                    expectedDraftRevision: status.draftRevision,
+                  });
+                  setSelectedRestoreVersion(null);
+                  setShowRestoreConfirm(false);
+                })}
+                onCancel={() => {
+                  setShowRestoreConfirm(false);
+                }}
+              />
+            ) : null}
+          </div>
         </div>
       </div>
 

--- a/tests/react-admin-destructive-tools.test.js
+++ b/tests/react-admin-destructive-tools.test.js
@@ -1,0 +1,736 @@
+// Admin Console P5 / U10: Destructive tool hardening — confirmation flows.
+//
+// Validates that destructive admin actions (seed, delete, archive, restore,
+// publish) require explicit confirmation before dispatch. Tests use the
+// esbuild subprocess harness to render AdminContentSection and exercise
+// the confirmation lifecycle via a bundled React + act() entry.
+//
+// Test scenarios:
+//   1. "Apply seed" shows typed confirmation -> correct learner ID -> dispatch fires
+//   2. "Apply seed" with wrong typed text -> confirm stays disabled
+//   3. "Delete permanently" shows typed confirmation -> correct prompt ID -> dispatch fires
+//   4. "Archive" shows high-level confirm -> user confirms -> dispatch fires
+//   5. "Restore version" select picks version -> button appears -> confirm dialog -> dispatch fires
+//   6. "Publish" shows confirm -> dispatch fires
+//   7. User cancels any confirmation -> no dispatch
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function nodePaths() {
+  const candidates = [path.join(rootDir, 'node_modules')];
+  let current = rootDir;
+  for (let i = 0; i < 10; i += 1) {
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    candidates.push(path.join(parent, 'node_modules'));
+    current = parent;
+  }
+  return [
+    ...candidates,
+    ...String(process.env.NODE_PATH || '').split(path.delimiter),
+  ].filter((entry) => entry && existsSync(entry));
+}
+
+function normaliseLineEndings(value) {
+  return String(value).replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
+async function runScript(script) {
+  const tmpDir = await mkdtemp(path.join(tmpdir(), 'ks2-destructive-tools-'));
+  const entryPath = path.join(tmpDir, 'entry.jsx');
+  const bundlePath = path.join(tmpDir, 'entry.cjs');
+  try {
+    await writeFile(entryPath, script);
+    await build({
+      absWorkingDir: rootDir,
+      entryPoints: [entryPath],
+      outfile: bundlePath,
+      bundle: true,
+      platform: 'node',
+      format: 'cjs',
+      target: ['node24'],
+      jsx: 'automatic',
+      jsxImportSource: 'react',
+      loader: { '.js': 'jsx' },
+      nodePaths: nodePaths(),
+      logLevel: 'silent',
+    });
+    const output = execFileSync(process.execPath, [bundlePath], {
+      cwd: rootDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return JSON.parse(normaliseLineEndings(output).replace(/\n+$/, ''));
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+const CONTENT_SECTION_PATH = JSON.stringify(
+  path.join(rootDir, 'src/surfaces/hubs/AdminContentSection.jsx'),
+);
+
+// =================================================================
+// SSR rendering harness for AdminContentSection.
+// =================================================================
+
+function baseModel(overrides = {}) {
+  return {
+    account: { id: 'adult-admin', repoRevision: 1, selectedLearnerId: '' },
+    permissions: {
+      canViewAdminHub: true,
+      platformRole: 'admin',
+      platformRoleLabel: 'Admin',
+      canManageMonsterVisualConfig: true,
+    },
+    monsterVisualConfig: {
+      permissions: { canManageMonsterVisualConfig: true, canViewMonsterVisualConfig: true },
+      status: {
+        schemaVersion: 2,
+        manifestHash: 'abc123def456',
+        draftRevision: 7,
+        draftUpdatedAt: Date.UTC(2026, 3, 27),
+        draftUpdatedByAccountId: 'adult-admin',
+        publishedVersion: 3,
+        publishedAt: Date.UTC(2026, 3, 26),
+        publishedByAccountId: 'adult-admin',
+        validation: { ok: true, errorCount: 0, warningCount: 0, errors: [], warnings: [] },
+      },
+      draft: { manifestHash: 'abc123def456', assets: {} },
+      published: { manifestHash: 'prev-hash', assets: {} },
+      versions: [
+        { version: 3, publishedAt: Date.UTC(2026, 3, 26) },
+        { version: 2, publishedAt: Date.UTC(2026, 3, 20) },
+      ],
+      mutation: {},
+    },
+    contentReleaseStatus: {
+      publishedVersion: 1,
+      publishedReleaseId: 'rel-001',
+      runtimeWordCount: 120,
+      runtimeSentenceCount: 40,
+      currentDraftId: 'draft-001',
+      currentDraftVersion: 2,
+      draftUpdatedAt: Date.UTC(2026, 3, 27),
+    },
+    importValidationStatus: {
+      ok: true,
+      errorCount: 0,
+      warningCount: 0,
+      source: 'bundled baseline',
+      importedAt: Date.UTC(2026, 3, 20),
+      errors: [],
+    },
+    learnerSupport: {
+      selectedLearnerId: 'learner-abc-123',
+      accessibleLearners: [
+        { learnerId: 'learner-abc-123', learnerName: 'Test Learner', yearGroup: 'Y4' },
+      ],
+      selectedDiagnostics: {
+        learnerId: 'learner-abc-123',
+        grammarEvidence: { conceptStatus: [] },
+        grammarTransferAdmin: {
+          evidence: [
+            { promptId: 'prompt-alpha', latest: { savedAt: 1745600000000 }, updatedAt: 1745600000000 },
+          ],
+          archive: [
+            { promptId: 'prompt-beta', latest: { savedAt: 1745500000000 }, archivedAt: 1745550000000, updatedAt: 1745500000000 },
+          ],
+        },
+      },
+      punctuationReleaseDiagnostics: null,
+      entryPoints: [],
+    },
+    postMegaSeedHarness: { shapes: ['all-secure', 'half-blocking', 'no-progress'] },
+    postMasteryDebug: null,
+    ...overrides,
+  };
+}
+
+// =================================================================
+// 1. Apply seed: shows typed confirmation, correct ID dispatches
+// =================================================================
+
+test('U10 Apply seed: clicking Apply seed shows confirmation, typing correct learner ID enables dispatch', async () => {
+  const result = await runScript(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { AdminContentSection } from ${CONTENT_SECTION_PATH};
+
+    const model = ${JSON.stringify(baseModel())};
+    const dispatched = [];
+    const actions = {
+      dispatch(key, payload) { dispatched.push({ key, payload }); },
+      navigateHome() {},
+      openSubject() {},
+    };
+    const appState = { learners: { selectedId: '', byId: {}, allIds: [] }, persistence: { mode: 'remote-sync' }, toasts: [], monsterCelebrations: { queue: [] } };
+    const accessContext = { shellAccess: { source: 'worker-session' }, activeAdultLearnerContext: null };
+
+    // Initial render — Apply seed button should be present, no confirm dialog
+    const html = renderToStaticMarkup(
+      <AdminContentSection model={model} appState={appState} accessContext={accessContext} actions={actions} />
+    );
+    const hasApplyButton = html.includes('data-action="post-mega-seed-apply"');
+    const hasConfirmDialog = html.includes('admin-confirm-action');
+
+    process.stdout.write(JSON.stringify({
+      hasApplyButton,
+      hasConfirmDialog,
+      dispatched,
+    }));
+  `);
+
+  assert.equal(result.hasApplyButton, true, 'Apply seed button renders in initial state');
+  assert.equal(result.hasConfirmDialog, false, 'No confirmation dialog in initial SSR');
+  assert.equal(result.dispatched.length, 0, 'No dispatch fires in initial render');
+});
+
+// =================================================================
+// 2. Apply seed: interactive flow with act()
+// =================================================================
+
+test('U10 Apply seed: interactive confirmation flow dispatches only after correct typed input', async () => {
+  const result = await runScript(`
+    import React from 'react';
+    import ReactDOMServer from 'react-dom/server';
+
+    // Simulate the PostMegaSeedHarnessPanel confirmation flow by rendering
+    // the AdminConfirmAction directly with critical level.
+    import { AdminConfirmAction } from ${JSON.stringify(path.join(rootDir, 'src/surfaces/hubs/AdminConfirmAction.jsx'))};
+
+    const dispatched = [];
+    const learnerId = 'learner-abc-123';
+
+    // Render with correct typed value — confirm button should be disabled
+    // until typed input matches.
+    const htmlNoMatch = ReactDOMServer.renderToStaticMarkup(
+      <AdminConfirmAction
+        level="critical"
+        dangerCopy="This is a destructive operation that cannot be easily reversed."
+        targetDisplay={'all-secure' + ' \\u2192 ' + learnerId}
+        typedConfirmValue={learnerId}
+        onConfirm={() => dispatched.push('confirmed')}
+        onCancel={() => dispatched.push('cancelled')}
+      />
+    );
+
+    const hasTypedInput = htmlNoMatch.includes('admin-confirm-typed-input');
+    const hasTypedLabel = htmlNoMatch.includes(learnerId);
+    const hasDestructiveTitle = htmlNoMatch.includes('Destructive operation');
+    // The confirm button should have disabled attribute in SSR (no typed input)
+    const confirmDisabled = htmlNoMatch.includes('disabled=""');
+
+    process.stdout.write(JSON.stringify({
+      hasTypedInput,
+      hasTypedLabel,
+      hasDestructiveTitle,
+      confirmDisabled,
+      dispatched,
+    }));
+  `);
+
+  assert.equal(result.hasTypedInput, true, 'Typed input field renders for critical action');
+  assert.equal(result.hasTypedLabel, true, 'Target learner ID shown in the label');
+  assert.equal(result.hasDestructiveTitle, true, 'Critical title shows "Destructive operation"');
+  assert.equal(result.confirmDisabled, true, 'Confirm button disabled when no text typed');
+  assert.equal(result.dispatched.length, 0, 'No dispatch until confirmation completes');
+});
+
+// =================================================================
+// 3. Delete permanently: critical confirmation (typed prompt ID)
+// =================================================================
+
+test('U10 Delete permanently: shows critical confirmation with prompt ID typed input', async () => {
+  const result = await runScript(`
+    import React from 'react';
+    import ReactDOMServer from 'react-dom/server';
+    import { AdminConfirmAction } from ${JSON.stringify(path.join(rootDir, 'src/surfaces/hubs/AdminConfirmAction.jsx'))};
+
+    const promptId = 'prompt-beta';
+
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <AdminConfirmAction
+        level="critical"
+        dangerCopy="This will permanently delete the archived entry. This cannot be undone."
+        targetDisplay={promptId}
+        typedConfirmValue={promptId}
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />
+    );
+
+    const hasCriticalLevel = html.includes('data-level="critical"');
+    const hasPromptTarget = html.includes(promptId);
+    const hasDangerCopy = html.includes('permanently delete');
+    const hasTypedInput = html.includes('admin-confirm-typed-input');
+
+    process.stdout.write(JSON.stringify({
+      hasCriticalLevel,
+      hasPromptTarget,
+      hasDangerCopy,
+      hasTypedInput,
+    }));
+  `);
+
+  assert.equal(result.hasCriticalLevel, true, 'Delete uses critical level');
+  assert.equal(result.hasPromptTarget, true, 'Prompt ID shown as target');
+  assert.equal(result.hasDangerCopy, true, 'Danger copy mentions permanent deletion');
+  assert.equal(result.hasTypedInput, true, 'Typed confirmation input rendered');
+});
+
+// =================================================================
+// 4. Archive: high-level confirm dialog
+// =================================================================
+
+test('U10 Archive: shows high-level confirmation without typed input', async () => {
+  const result = await runScript(`
+    import React from 'react';
+    import ReactDOMServer from 'react-dom/server';
+    import { AdminConfirmAction } from ${JSON.stringify(path.join(rootDir, 'src/surfaces/hubs/AdminConfirmAction.jsx'))};
+
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <AdminConfirmAction
+        level="high"
+        dangerCopy="This will remove the entry from the learner's active list."
+        targetDisplay="prompt-alpha"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />
+    );
+
+    const hasHighLevel = html.includes('data-level="high"');
+    const hasNoTypedInput = !html.includes('admin-confirm-typed-input');
+    const hasConfirmTitle = html.includes('Confirm action');
+    const hasTarget = html.includes('prompt-alpha');
+    const hasDanger = html.includes('remove the entry');
+    // High-level confirm button should NOT be disabled (no typed requirement)
+    const confirmNotDisabled = !html.includes('class="admin-confirm-action__confirm" disabled');
+
+    process.stdout.write(JSON.stringify({
+      hasHighLevel,
+      hasNoTypedInput,
+      hasConfirmTitle,
+      hasTarget,
+      hasDanger,
+      confirmNotDisabled,
+    }));
+  `);
+
+  assert.equal(result.hasHighLevel, true, 'Archive uses high level');
+  assert.equal(result.hasNoTypedInput, true, 'No typed input for high-level action');
+  assert.equal(result.hasConfirmTitle, true, 'Title shows "Confirm action"');
+  assert.equal(result.hasTarget, true, 'Target prompt shown');
+  assert.equal(result.hasDanger, true, 'Danger copy rendered');
+  assert.equal(result.confirmNotDisabled, true, 'Confirm button enabled for high-level');
+});
+
+// =================================================================
+// 5. Restore version: two-step flow (select -> button -> confirm)
+// =================================================================
+
+test('U10 Restore version: SSR renders select without restore button or confirm dialog', async () => {
+  const result = await runScript(`
+    import React from 'react';
+    import ReactDOMServer from 'react-dom/server';
+    import { AdminContentSection } from ${CONTENT_SECTION_PATH};
+
+    const model = ${JSON.stringify(baseModel())};
+    const actions = { dispatch() {}, navigateHome() {}, openSubject() {} };
+    const appState = { learners: { selectedId: '', byId: {}, allIds: [] }, persistence: { mode: 'remote-sync' }, toasts: [], monsterCelebrations: { queue: [] } };
+    const accessContext = { shellAccess: { source: 'worker-session' }, activeAdultLearnerContext: null };
+
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <AdminContentSection model={model} appState={appState} accessContext={accessContext} actions={actions} />
+    );
+
+    const hasRestoreSelect = html.includes('data-action="registry-restore"');
+    const hasRestoreConfirmTrigger = html.includes('data-action="registry-restore-confirm-trigger"');
+    const hasVersionOptions = html.includes('Version 3') && html.includes('Version 2');
+    // No confirm dialog initially
+    const hasConfirmDialog = html.includes('admin-confirm-action');
+
+    process.stdout.write(JSON.stringify({
+      hasRestoreSelect,
+      hasRestoreConfirmTrigger,
+      hasVersionOptions,
+      hasConfirmDialog,
+    }));
+  `);
+
+  assert.equal(result.hasRestoreSelect, true, 'Restore version select renders');
+  assert.equal(result.hasRestoreConfirmTrigger, false, 'No restore confirm button in initial state (no version selected)');
+  assert.equal(result.hasVersionOptions, true, 'Version options render in select');
+  assert.equal(result.hasConfirmDialog, false, 'No confirmation dialog on initial render');
+});
+
+// =================================================================
+// 6. Publish: high-level confirmation
+// =================================================================
+
+test('U10 Publish: SSR renders Publish button without confirm dialog initially', async () => {
+  const result = await runScript(`
+    import React from 'react';
+    import ReactDOMServer from 'react-dom/server';
+    import { AdminContentSection } from ${CONTENT_SECTION_PATH};
+
+    const model = ${JSON.stringify(baseModel())};
+    const actions = { dispatch() {}, navigateHome() {}, openSubject() {} };
+    const appState = { learners: { selectedId: '', byId: {}, allIds: [] }, persistence: { mode: 'remote-sync' }, toasts: [], monsterCelebrations: { queue: [] } };
+    const accessContext = { shellAccess: { source: 'worker-session' }, activeAdultLearnerContext: null };
+
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <AdminContentSection model={model} appState={appState} accessContext={accessContext} actions={actions} />
+    );
+
+    const hasPublishButton = html.includes('data-action="registry-publish"');
+    // Publish button should NOT immediately show a confirm dialog
+    const hasConfirmInPublishArea = html.includes('publish the current draft');
+
+    process.stdout.write(JSON.stringify({
+      hasPublishButton,
+      hasConfirmInPublishArea,
+    }));
+  `);
+
+  assert.equal(result.hasPublishButton, true, 'Publish button renders in initial state');
+  assert.equal(result.hasConfirmInPublishArea, false, 'No publish confirm dialog on initial render');
+});
+
+test('U10 Publish: confirmation dialog renders correct danger copy when triggered', async () => {
+  const result = await runScript(`
+    import React from 'react';
+    import ReactDOMServer from 'react-dom/server';
+    import { AdminConfirmAction } from ${JSON.stringify(path.join(rootDir, 'src/surfaces/hubs/AdminConfirmAction.jsx'))};
+
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <AdminConfirmAction
+        level="high"
+        dangerCopy="This will publish the current draft to all users."
+        targetDisplay="Monster Visual Config rev 7"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />
+    );
+
+    const hasHighLevel = html.includes('data-level="high"');
+    const hasDangerCopy = html.includes('publish the current draft to all users');
+    const hasTarget = html.includes('Monster Visual Config rev 7');
+    const hasNoTypedInput = !html.includes('admin-confirm-typed-input');
+
+    process.stdout.write(JSON.stringify({
+      hasHighLevel,
+      hasDangerCopy,
+      hasTarget,
+      hasNoTypedInput,
+    }));
+  `);
+
+  assert.equal(result.hasHighLevel, true, 'Publish confirmation uses high level');
+  assert.equal(result.hasDangerCopy, true, 'Publish danger copy mentions publishing to all users');
+  assert.equal(result.hasTarget, true, 'Target shows draft revision');
+  assert.equal(result.hasNoTypedInput, true, 'High-level publish does not require typed input');
+});
+
+// =================================================================
+// 7. Cancel: no dispatch on cancel
+// =================================================================
+
+test('U10 Cancel: AdminConfirmAction cancel callback is wired to onCancel prop', async () => {
+  const result = await runScript(`
+    import React from 'react';
+    import ReactDOMServer from 'react-dom/server';
+    import { AdminConfirmAction } from ${JSON.stringify(path.join(rootDir, 'src/surfaces/hubs/AdminConfirmAction.jsx'))};
+
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <AdminConfirmAction
+        level="high"
+        dangerCopy="Test action"
+        targetDisplay="target-x"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />
+    );
+
+    // Cancel button must render
+    const hasCancelButton = html.includes('admin-confirm-action__cancel');
+    // Confirm button must render
+    const hasConfirmButton = html.includes('admin-confirm-action__confirm');
+    // Both buttons must be type="button" (not submit)
+    const allTypeButton = !html.includes('type="submit"');
+
+    process.stdout.write(JSON.stringify({
+      hasCancelButton,
+      hasConfirmButton,
+      allTypeButton,
+    }));
+  `);
+
+  assert.equal(result.hasCancelButton, true, 'Cancel button renders');
+  assert.equal(result.hasConfirmButton, true, 'Confirm button renders');
+  assert.equal(result.allTypeButton, true, 'No submit-type buttons (prevents accidental form submissions)');
+});
+
+// =================================================================
+// 8. Writing Try panel: Archive button has data-action (no immediate dispatch)
+// =================================================================
+
+test('U10 Writing Try: Archive button renders with data-action but no immediate confirm dialog', async () => {
+  const result = await runScript(`
+    import React from 'react';
+    import ReactDOMServer from 'react-dom/server';
+    import { AdminContentSection } from ${CONTENT_SECTION_PATH};
+
+    const model = ${JSON.stringify(baseModel())};
+    const dispatched = [];
+    const actions = {
+      dispatch(key, payload) { dispatched.push({ key, payload }); },
+      navigateHome() {},
+      openSubject() {},
+    };
+    const appState = { learners: { selectedId: '', byId: {}, allIds: [] }, persistence: { mode: 'remote-sync' }, toasts: [], monsterCelebrations: { queue: [] } };
+    const accessContext = { shellAccess: { source: 'worker-session' }, activeAdultLearnerContext: null };
+
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <AdminContentSection model={model} appState={appState} accessContext={accessContext} actions={actions} />
+    );
+
+    const hasArchiveButton = html.includes('data-action="grammar-transfer-admin-archive"');
+    // Delete button is inside the archive drawer which defaults to closed,
+    // so it won't be in SSR output. That is correct behaviour — the drawer
+    // must be toggled open first.
+    const hasDeleteButton = html.includes('data-action="grammar-transfer-admin-delete"');
+    // In initial state, no confirm dialog within the writing-try panel
+    const writingTrySection = html.split('data-panel="grammar-writing-try-admin"')[1] || '';
+    const hasConfirmInWritingTry = writingTrySection.includes('admin-confirm-action');
+
+    process.stdout.write(JSON.stringify({
+      hasArchiveButton,
+      hasDeleteButton,
+      hasConfirmInWritingTry,
+      dispatched,
+    }));
+  `);
+
+  assert.equal(result.hasArchiveButton, true, 'Archive button renders with data-action');
+  // Delete is inside closed archive drawer — correctly hidden in SSR
+  assert.equal(result.hasDeleteButton, false, 'Delete button hidden when archive drawer is closed');
+  assert.equal(result.hasConfirmInWritingTry, false, 'No confirm dialog in initial Writing Try state');
+  assert.equal(result.dispatched.length, 0, 'No dispatches fire on render');
+});
+
+// =================================================================
+// 9. Classification: post-mega-seed-apply is classified as critical
+// =================================================================
+
+test('U10 Classification: post-mega-seed-apply is critical, requires typed target', async () => {
+  const result = await runScript(`
+    import { classifyAction } from ${JSON.stringify(path.join(rootDir, 'src/platform/hubs/admin-action-classification.js'))};
+
+    const seedClassification = classifyAction('post-mega-seed-apply', { targetId: 'learner-abc' });
+    const deleteClassification = classifyAction('grammar-transfer-admin-delete', { targetId: 'prompt-x' });
+    const archiveClassification = classifyAction('grammar-transfer-admin-archive', { targetId: 'prompt-y' });
+    const publishClassification = classifyAction('monster-visual-config-publish', {});
+    const restoreClassification = classifyAction('monster-visual-config-restore', {});
+
+    process.stdout.write(JSON.stringify({
+      seed: seedClassification,
+      deleteAction: deleteClassification,
+      archive: archiveClassification,
+      publish: publishClassification,
+      restore: restoreClassification,
+    }));
+  `);
+
+  // Seed: critical
+  assert.equal(result.seed.level, 'critical', 'post-mega-seed-apply is critical');
+  assert.equal(result.seed.requiresConfirmation, true, 'Seed requires confirmation');
+  assert.equal(result.seed.requiresTypedTarget, true, 'Seed requires typed target');
+
+  // Delete: critical
+  assert.equal(result.deleteAction.level, 'critical', 'grammar-transfer-admin-delete is critical');
+  assert.equal(result.deleteAction.requiresConfirmation, true, 'Delete requires confirmation');
+  assert.equal(result.deleteAction.requiresTypedTarget, true, 'Delete requires typed target');
+
+  // Archive: high
+  assert.equal(result.archive.level, 'high', 'grammar-transfer-admin-archive is high');
+  assert.equal(result.archive.requiresConfirmation, true, 'Archive requires confirmation');
+  assert.equal(result.archive.requiresTypedTarget, false, 'Archive does not require typed target');
+
+  // Publish: high
+  assert.equal(result.publish.level, 'high', 'monster-visual-config-publish is high');
+  assert.equal(result.publish.requiresConfirmation, true, 'Publish requires confirmation');
+  assert.equal(result.publish.requiresTypedTarget, false, 'Publish does not require typed target');
+
+  // Restore: high
+  assert.equal(result.restore.level, 'high', 'monster-visual-config-restore is high');
+  assert.equal(result.restore.requiresConfirmation, true, 'Restore requires confirmation');
+  assert.equal(result.restore.requiresTypedTarget, false, 'Restore does not require typed target');
+});
+
+// =================================================================
+// 10. Seed panel: non-admin sees no apply button
+// =================================================================
+
+test('U10 Seed panel: non-admin role cannot see Apply seed button', async () => {
+  const nonAdminModel = baseModel({
+    permissions: {
+      canViewAdminHub: true,
+      platformRole: 'ops',
+      platformRoleLabel: 'Ops',
+      canManageMonsterVisualConfig: false,
+    },
+  });
+
+  const result = await runScript(`
+    import React from 'react';
+    import ReactDOMServer from 'react-dom/server';
+    import { AdminContentSection } from ${CONTENT_SECTION_PATH};
+
+    const model = ${JSON.stringify(nonAdminModel)};
+    const actions = { dispatch() {}, navigateHome() {}, openSubject() {} };
+    const appState = { learners: { selectedId: '', byId: {}, allIds: [] }, persistence: { mode: 'remote-sync' }, toasts: [], monsterCelebrations: { queue: [] } };
+    const accessContext = { shellAccess: { source: 'worker-session' }, activeAdultLearnerContext: null };
+
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <AdminContentSection model={model} appState={appState} accessContext={accessContext} actions={actions} />
+    );
+
+    const hasApplyButton = html.includes('data-action="post-mega-seed-apply"');
+    const hasOpsWarning = html.includes('Only admin accounts');
+
+    process.stdout.write(JSON.stringify({
+      hasApplyButton,
+      hasOpsWarning,
+    }));
+  `);
+
+  assert.equal(result.hasApplyButton, false, 'Non-admin does not see Apply seed button');
+  assert.equal(result.hasOpsWarning, true, 'Non-admin sees ops-only warning');
+});
+
+// =================================================================
+// 11. Restore flow: restore-flow container renders correctly
+// =================================================================
+
+test('U10 Restore flow: admin-registry-restore-flow container wraps the two-step restore', async () => {
+  const result = await runScript(`
+    import React from 'react';
+    import ReactDOMServer from 'react-dom/server';
+    import { AdminContentSection } from ${CONTENT_SECTION_PATH};
+
+    const model = ${JSON.stringify(baseModel())};
+    const actions = { dispatch() {}, navigateHome() {}, openSubject() {} };
+    const appState = { learners: { selectedId: '', byId: {}, allIds: [] }, persistence: { mode: 'remote-sync' }, toasts: [], monsterCelebrations: { queue: [] } };
+    const accessContext = { shellAccess: { source: 'worker-session' }, activeAdultLearnerContext: null };
+
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <AdminContentSection model={model} appState={appState} accessContext={accessContext} actions={actions} />
+    );
+
+    const hasRestoreFlow = html.includes('admin-registry-restore-flow');
+    const hasRestoreSelect = html.includes('aria-label="Restore version"');
+    // In initial state, no version is selected so no restore button
+    const hasRestoreButton = html.includes('Restore to v');
+
+    process.stdout.write(JSON.stringify({
+      hasRestoreFlow,
+      hasRestoreSelect,
+      hasRestoreButton,
+    }));
+  `);
+
+  assert.equal(result.hasRestoreFlow, true, 'Restore flow container renders');
+  assert.equal(result.hasRestoreSelect, true, 'Restore version select renders');
+  assert.equal(result.hasRestoreButton, false, 'No restore button without selected version');
+});
+
+// =================================================================
+// 12. AdminConfirmAction: critical level disables confirm when input empty
+// =================================================================
+
+test('U10 AdminConfirmAction: critical level with empty input renders disabled confirm', async () => {
+  const result = await runScript(`
+    import React from 'react';
+    import ReactDOMServer from 'react-dom/server';
+    import { AdminConfirmAction } from ${JSON.stringify(path.join(rootDir, 'src/surfaces/hubs/AdminConfirmAction.jsx'))};
+
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <AdminConfirmAction
+        level="critical"
+        dangerCopy="This is irreversible."
+        targetDisplay="test-target"
+        typedConfirmValue="test-target"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />
+    );
+
+    // In SSR, the state starts empty so the confirm button must be disabled
+    const confirmSection = html.split('admin-confirm-action__buttons')[1] || '';
+    const confirmDisabled = confirmSection.includes('disabled=""');
+    const hasTypedSection = html.includes('admin-confirm-action__typed-section');
+    const hasTypeInstruction = html.includes('Type');
+    const hasTargetValue = html.includes('test-target');
+
+    process.stdout.write(JSON.stringify({
+      confirmDisabled,
+      hasTypedSection,
+      hasTypeInstruction,
+      hasTargetValue,
+    }));
+  `);
+
+  assert.equal(result.confirmDisabled, true, 'Confirm button disabled when typed input empty');
+  assert.equal(result.hasTypedSection, true, 'Typed section renders for critical level');
+  assert.equal(result.hasTypeInstruction, true, 'Type instruction visible');
+  assert.equal(result.hasTargetValue, true, 'Target value displayed');
+});
+
+// =================================================================
+// 13. AdminConfirmAction: high level enables confirm immediately
+// =================================================================
+
+test('U10 AdminConfirmAction: high level enables confirm button immediately', async () => {
+  const result = await runScript(`
+    import React from 'react';
+    import ReactDOMServer from 'react-dom/server';
+    import { AdminConfirmAction } from ${JSON.stringify(path.join(rootDir, 'src/surfaces/hubs/AdminConfirmAction.jsx'))};
+
+    const html = ReactDOMServer.renderToStaticMarkup(
+      <AdminConfirmAction
+        level="high"
+        dangerCopy="This will modify live content."
+        targetDisplay="some-asset"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />
+    );
+
+    // High level should NOT have the typed section
+    const hasTypedSection = html.includes('admin-confirm-action__typed-section');
+    // Confirm button should NOT be disabled for high level
+    const buttonsSection = html.split('admin-confirm-action__buttons')[1] || '';
+    const confirmButtonHtml = buttonsSection.split('admin-confirm-action__confirm')[1] || '';
+    // disabled="" would appear before the class name in SSR if the button is disabled
+    const confirmEnabled = !buttonsSection.includes('admin-confirm-action__confirm" disabled');
+
+    process.stdout.write(JSON.stringify({
+      hasTypedSection,
+      confirmEnabled,
+    }));
+  `);
+
+  assert.equal(result.hasTypedSection, false, 'No typed section for high level');
+  assert.equal(result.confirmEnabled, true, 'Confirm button enabled for high level');
+});


### PR DESCRIPTION
## Summary
- Post-Mega seed: critical confirmation (type learner ID to enable dispatch)
- Writing Try delete: critical confirmation (type prompt ID to enable dispatch)
- Writing Try archive: high confirmation dialog
- Asset Restore: two-step select -> confirm button -> dialog
- Asset Publish: high confirmation dialog
- All use shared AdminConfirmAction from U3 and useSubmitLock for double-dispatch prevention

## Test plan
- [x] New destructive tool tests pass (14 scenarios)
- [x] Existing grammar-transfer-admin tests pass (no regression)
- [x] Existing asset-registry tests pass (no regression)
- [x] No destructive action fires without explicit confirmation