### PR TITLE
fix(punctuation): ignore epoch-zero memory timestamps

### DIFF
--- a/shared/punctuation/scheduler.js
+++ b/shared/punctuation/scheduler.js
@@ -28,6 +28,11 @@ function timestamp(now = Date.now) {
   return Number.isFinite(value) ? value : Date.now();
 }
 
+function positiveTimestamp(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric > 0 ? numeric : null;
+}
+
 export function createMemoryState() {
   return {
     attempts: 0,
@@ -57,8 +62,8 @@ export function normaliseMemoryState(value) {
     ease: Math.max(1.25, Math.min(3.2, Number(raw.ease) || 2.3)),
     intervalDays: Math.max(0, Number(raw.intervalDays) || 0),
     dueAt: Math.max(0, Number(raw.dueAt) || 0),
-    firstCorrectAt: Number.isFinite(Number(raw.firstCorrectAt)) ? Number(raw.firstCorrectAt) : null,
-    lastCorrectAt: Number.isFinite(Number(raw.lastCorrectAt)) ? Number(raw.lastCorrectAt) : null,
+    firstCorrectAt: positiveTimestamp(raw.firstCorrectAt),
+    lastCorrectAt: positiveTimestamp(raw.lastCorrectAt),
     lastSeen: Math.max(0, Number(raw.lastSeen) || 0),
     lastCorrect: raw.lastCorrect === true || raw.lastCorrect === false ? raw.lastCorrect : null,
     recent: Array.isArray(raw.recent) ? raw.recent.map((entry) => (entry ? 1 : 0)).slice(-12) : [],
@@ -69,7 +74,7 @@ export function memorySnapshot(value, now = Date.now) {
   const state = normaliseMemoryState(value);
   const attempts = state.attempts;
   const accuracy = attempts ? state.correct / attempts : 0;
-  const correctSpanDays = state.firstCorrectAt != null && state.lastCorrectAt != null
+  const correctSpanDays = state.firstCorrectAt != null && state.lastCorrectAt != null && state.lastCorrectAt >= state.firstCorrectAt
     ? Math.floor((state.lastCorrectAt - state.firstCorrectAt) / DAY_MS)
     : 0;
   let bucket = 'new';

--- a/src/subjects/punctuation/read-model.js
+++ b/src/subjects/punctuation/read-model.js
@@ -38,6 +38,11 @@ function asTs(value, fallback = 0) {
   return Number.isFinite(numeric) && numeric >= 0 ? numeric : fallback;
 }
 
+function positiveTs(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric > 0 ? numeric : null;
+}
+
 function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
@@ -70,8 +75,8 @@ function normaliseMemoryState(value) {
     streak: Math.max(0, Number(raw.streak) || 0),
     lapses: Math.max(0, Number(raw.lapses) || 0),
     dueAt: Math.max(0, Number(raw.dueAt) || 0),
-    firstCorrectAt: Number.isFinite(Number(raw.firstCorrectAt)) ? Number(raw.firstCorrectAt) : null,
-    lastCorrectAt: Number.isFinite(Number(raw.lastCorrectAt)) ? Number(raw.lastCorrectAt) : null,
+    firstCorrectAt: positiveTs(raw.firstCorrectAt),
+    lastCorrectAt: positiveTs(raw.lastCorrectAt),
     lastSeen: Math.max(0, Number(raw.lastSeen) || 0),
   };
 }
@@ -80,7 +85,7 @@ function memorySnapshot(value, nowTs) {
   const state = normaliseMemoryState(value);
   const attempts = state.attempts;
   const accuracy = attempts ? state.correct / attempts : 0;
-  const correctSpanDays = state.firstCorrectAt != null && state.lastCorrectAt != null
+  const correctSpanDays = state.firstCorrectAt != null && state.lastCorrectAt != null && state.lastCorrectAt >= state.firstCorrectAt
     ? Math.floor((state.lastCorrectAt - state.firstCorrectAt) / DAY_MS)
     : 0;
   let bucket = 'new';

--- a/src/subjects/punctuation/star-projection.js
+++ b/src/subjects/punctuation/star-projection.js
@@ -94,6 +94,11 @@ function dayIndex(ts) {
   return Math.floor(Math.max(0, Number(ts) || 0) / DAY_MS);
 }
 
+function positiveTimestamp(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric > 0 ? numeric : null;
+}
+
 /** Mirror of `memorySnapshot` from read-model.js:118-139 */
 function memorySnapshot(value) {
   const raw = isPlainObject(value) ? value : {};
@@ -101,10 +106,10 @@ function memorySnapshot(value) {
   const correct = Math.max(0, Number(raw.correct) || 0);
   const streak = Math.max(0, Number(raw.streak) || 0);
   const lapses = Math.max(0, Number(raw.lapses) || 0);
-  const firstCorrectAt = Number.isFinite(Number(raw.firstCorrectAt)) ? Number(raw.firstCorrectAt) : null;
-  const lastCorrectAt = Number.isFinite(Number(raw.lastCorrectAt)) ? Number(raw.lastCorrectAt) : null;
+  const firstCorrectAt = positiveTimestamp(raw.firstCorrectAt);
+  const lastCorrectAt = positiveTimestamp(raw.lastCorrectAt);
   const accuracy = attempts ? correct / attempts : 0;
-  const correctSpanDays = firstCorrectAt != null && lastCorrectAt != null
+  const correctSpanDays = firstCorrectAt != null && lastCorrectAt != null && lastCorrectAt >= firstCorrectAt
     ? Math.floor((lastCorrectAt - firstCorrectAt) / DAY_MS)
     : 0;
   const secure = streak >= 3 && accuracy >= 0.8 && correctSpanDays >= 7;

--- a/tests/punctuation-read-model.test.js
+++ b/tests/punctuation-read-model.test.js
@@ -730,6 +730,40 @@ test('U7: facet in learning bucket with zero lapses is NOT deep-secured', () => 
     'reward unit itself is still secured');
 });
 
+test('U7: epoch-zero firstCorrectAt does not deep-secure reward units', () => {
+  const now = Date.UTC(2026, 3, 25);
+  const subjectState = freshSubjectState();
+
+  const key = masteryKey('endmarks', 'sentence-endings-core');
+  subjectState.data.progress.rewardUnits[key] = {
+    masteryKey: key,
+    releaseId: CURRENT_RELEASE_ID,
+    clusterId: 'endmarks',
+    rewardUnitId: 'sentence-endings-core',
+    securedAt: now - 10_000,
+  };
+  subjectState.data.progress.facets['sentence_endings::choose'] = {
+    attempts: 4,
+    correct: 4,
+    incorrect: 0,
+    streak: 4,
+    lapses: 0,
+    dueAt: 0,
+    firstCorrectAt: 0,
+    lastCorrectAt: now,
+    lastSeen: now,
+  };
+
+  const model = buildPunctuationLearnerReadModel({
+    subjectStateRecord: subjectState,
+    practiceSessions: [],
+    now: () => now,
+  });
+
+  assert.equal(model.progressSnapshot.deepSecuredRewardUnits, 0);
+  assert.equal(model.progressSnapshot.securedRewardUnits, 1);
+});
+
 test('U7: multiple reward units in same cluster — shared deep-secure facet promotes both', () => {
   const now = Date.UTC(2026, 3, 25);
   const subjectState = freshSubjectState();

--- a/tests/punctuation-scheduler.test.js
+++ b/tests/punctuation-scheduler.test.js
@@ -13,16 +13,37 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 
 test('secure status requires repeated clean spaced evidence', () => {
   let state = createMemoryState();
-  state = updateMemoryState(state, true, 0);
-  assert.equal(memorySnapshot(state, 0).secure, false);
-  state = updateMemoryState(state, true, 4 * DAY_MS);
-  assert.equal(memorySnapshot(state, 4 * DAY_MS).secure, false);
-  state = updateMemoryState(state, true, 8 * DAY_MS);
-  const secure = memorySnapshot(state, 8 * DAY_MS);
+  state = updateMemoryState(state, true, DAY_MS);
+  assert.equal(memorySnapshot(state, DAY_MS).secure, false);
+  state = updateMemoryState(state, true, 5 * DAY_MS);
+  assert.equal(memorySnapshot(state, 5 * DAY_MS).secure, false);
+  state = updateMemoryState(state, true, 9 * DAY_MS);
+  const secure = memorySnapshot(state, 9 * DAY_MS);
   assert.equal(secure.secure, true);
   assert.equal(secure.bucket, 'secure');
   assert.ok(secure.accuracy >= 0.8);
   assert.ok(secure.correctSpanDays >= 7);
+});
+
+test('secure status ignores epoch-zero firstCorrectAt sentinels', () => {
+  const now = Date.UTC(2026, 3, 25);
+  const state = {
+    attempts: 4,
+    correct: 4,
+    incorrect: 0,
+    streak: 4,
+    lapses: 0,
+    dueAt: 0,
+    firstCorrectAt: 0,
+    lastCorrectAt: now,
+    lastSeen: now,
+  };
+
+  const snap = memorySnapshot(state, now);
+
+  assert.equal(snap.correctSpanDays, 0);
+  assert.equal(snap.secure, false);
+  assert.equal(snap.bucket, 'learning');
 });
 
 test('scheduler is deterministic under fixed state and random input', () => {

--- a/tests/punctuation-service.test.js
+++ b/tests/punctuation-service.test.js
@@ -332,10 +332,10 @@ test('previous release reward units do not count towards the current release den
 
 test('spaced clean attempts emit a secure-unit event once', () => {
   const repository = makeRepository();
-  let now = 0;
+  let now = 24 * 60 * 60 * 1000;
   const service = createPunctuationService({ repository, now: () => now, random: () => 0 });
   let unitEvents = [];
-  for (const day of [0, 4, 8]) {
+  for (const day of [1, 5, 9]) {
     now = day * 24 * 60 * 60 * 1000;
     const start = service.startSession('learner-a', { mode: 'endmarks', roundLength: '1' }).state;
     const submit = service.submitAnswer('learner-a', start, { choiceIndex: 1 });

--- a/tests/punctuation-star-projection.test.js
+++ b/tests/punctuation-star-projection.test.js
@@ -86,6 +86,31 @@ function securedRewardUnitForRelease(releaseId, clusterId, rewardUnitId) {
   };
 }
 
+test('Secure Stars ignore epoch-zero firstCorrectAt sentinels', () => {
+  const now = Date.UTC(2026, 3, 25);
+  const progress = freshProgress();
+  progress.items['epoch-sentinel-item'] = {
+    attempts: 4,
+    correct: 4,
+    incorrect: 0,
+    streak: 4,
+    lapses: 0,
+    firstCorrectAt: 0,
+    lastCorrectAt: now,
+    lastSeen: now,
+  };
+  progress.attempts.push(makeAttempt({
+    itemId: 'epoch-sentinel-item',
+    ts: now,
+    skillIds: ['sentence_endings'],
+    rewardUnitId: 'sentence-endings-core',
+  }));
+
+  const view = projectPunctuationStars(progress, CURRENT_RELEASE_ID);
+
+  assert.equal(view.perMonster.pealark.secureStars, 0);
+});
+
 function richCurrentReleaseProgress() {
   const progress = freshProgress();
   const units = [


### PR DESCRIPTION
## Summary
- Treat `firstCorrectAt` / `lastCorrectAt` values <= 0 as missing in Punctuation memory normalisation.
- Guard `correctSpanDays` against reversed timestamps across scheduler, read-model, and Star projection paths.
- Add regression coverage so epoch-zero sentinels cannot unlock Secure Stars or deep-secure reward units.

## Testing
- `node --test tests/punctuation-scheduler.test.js tests/punctuation-star-projection.test.js tests/punctuation-read-model.test.js tests/punctuation-service.test.js` ✅
- `node --test tests/bundle-audit.test.js` ✅
- `npm run check` ✅
- `git diff --check` ✅
- `npm test` ⚠️ rerun after rebase: 6055 pass / 6 skipped / 4 fail.
  - `tests/button-label-consistency.test.js` and `tests/csp-inline-style-budget.test.js` fail on untouched `main` (`9c15b933`) with the same admin label / CSP inline-style budget issues.
  - `tests/worker-capacity-overhead.test.js` failed once on full-suite timing noise; isolated rerun passed ✅.