### PR TITLE
feat(admin): wire support incident flow with return stash and safe copy (P5 U6)

### DIFF
--- a/src/platform/hubs/admin-incident-flow.js
+++ b/src/platform/hubs/admin-incident-flow.js
@@ -1,0 +1,83 @@
+// P5 U6: Incident flow stash — save account context before navigating to
+// debug bundle, enabling a "Return to account" button in the bundle panel.
+//
+// Follows the same consume-once sessionStorage pattern established in
+// `src/platform/core/admin-return-stash.js`. The stash expires after 5 minutes
+// and is always cleared on read (single-use).
+//
+// Content-free leaf: no subject content imports.
+
+const INCIDENT_STASH_KEY = 'ks2_admin_incident_stash';
+const MAX_AGE_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Save incident context before navigating away from account detail.
+ *
+ * @param {{ returnSection?: string, returnAccountId?: string, returnScrollY?: number }} stash
+ * @param {Storage} [storage] — defaults to sessionStorage
+ */
+export function saveIncidentStash(stash, storage) {
+  const ss = storage || _safeSessionStorage();
+  if (!ss) return;
+  if (!stash || typeof stash !== 'object') return;
+
+  const payload = {
+    returnSection: typeof stash.returnSection === 'string' ? stash.returnSection : 'accounts',
+    returnAccountId: typeof stash.returnAccountId === 'string' ? stash.returnAccountId : '',
+    returnScrollY: typeof stash.returnScrollY === 'number' ? stash.returnScrollY : 0,
+    ts: Date.now(),
+  };
+
+  try {
+    ss.setItem(INCIDENT_STASH_KEY, JSON.stringify(payload));
+  } catch { /* quota / SecurityError — silently ignore */ }
+}
+
+/**
+ * Read and consume the incident stash. Returns the stash object or null if
+ * absent, expired, or malformed. The stash is always cleared on read.
+ *
+ * @param {Storage} [storage] — defaults to sessionStorage
+ * @returns {{ returnSection: string, returnAccountId: string, returnScrollY: number } | null}
+ */
+export function consumeIncidentStash(storage) {
+  const ss = storage || _safeSessionStorage();
+  if (!ss) return null;
+
+  let raw;
+  try {
+    raw = ss.getItem(INCIDENT_STASH_KEY);
+    ss.removeItem(INCIDENT_STASH_KEY);
+  } catch { return null; }
+
+  if (!raw) return null;
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch { return null; }
+
+  if (!parsed || typeof parsed !== 'object') return null;
+
+  // Expiry check
+  const age = Date.now() - (typeof parsed.ts === 'number' ? parsed.ts : 0);
+  if (age > MAX_AGE_MS || age < 0) return null;
+
+  return {
+    returnSection: typeof parsed.returnSection === 'string' ? parsed.returnSection : 'accounts',
+    returnAccountId: typeof parsed.returnAccountId === 'string' ? parsed.returnAccountId : '',
+    returnScrollY: typeof parsed.returnScrollY === 'number' ? parsed.returnScrollY : 0,
+  };
+}
+
+/** @returns {Storage | null} */
+function _safeSessionStorage() {
+  try {
+    return typeof globalThis !== 'undefined' && globalThis.sessionStorage
+      ? globalThis.sessionStorage
+      : null;
+  } catch { return null; }
+}
+
+// Exported for tests
+export { INCIDENT_STASH_KEY, MAX_AGE_MS };

--- a/src/surfaces/hubs/AdminAccountsSection.jsx
+++ b/src/surfaces/hubs/AdminAccountsSection.jsx
@@ -20,6 +20,12 @@ import {
   normaliseSearchResult,
   debugBundleLinkForAccount,
 } from '../../platform/hubs/admin-account-search.js';
+import {
+  prepareSafeCopy,
+  copyToClipboard,
+  COPY_AUDIENCE,
+} from '../../platform/hubs/admin-safe-copy.js';
+import { saveIncidentStash } from '../../platform/hubs/admin-incident-flow.js';
 
 // U4+U5: Accounts section — role management, ops metadata, and audit log.
 // Extracted from AdminHubSurface.jsx. All inline components preserved
@@ -413,7 +419,7 @@ function AccountSearchResultRow({ result, onSelect }) {
   );
 }
 
-function AccountDetailPanel({ detail, onClose, onDebugBundle }) {
+function AccountDetailPanel({ detail, onClose, onDebugBundle, onCopySupportSummary, copySummaryFeedback }) {
   if (!detail || !detail.account) return null;
   const { account, learners, recentErrors, recentDenials, recentMutations, opsMetadata } = detail;
   return (
@@ -425,6 +431,8 @@ function AccountDetailPanel({ detail, onClose, onDebugBundle }) {
           <p className="subtitle">{account.displayName || 'No display name'} &middot; {platformRoleLabel(account.platformRole)} &middot; {account.accountType}</p>
         </div>
         <div className="actions">
+          <button className="btn secondary" type="button" onClick={onCopySupportSummary} data-testid="detail-copy-support-summary">Copy support summary</button>
+          {copySummaryFeedback ? <span className="chip good" data-testid="detail-copy-feedback">{copySummaryFeedback}</span> : null}
           <button className="btn secondary" type="button" onClick={onDebugBundle} data-testid="detail-debug-bundle-link">Debug Bundle</button>
           <button className="btn secondary" type="button" onClick={onClose}>Close</button>
         </div>
@@ -519,11 +527,38 @@ function AccountSearchPanel({ model, actions }) {
 
   const handleDebugBundle = () => {
     if (detail?.account?.id) {
+      saveIncidentStash({
+        returnSection: 'accounts',
+        returnAccountId: detail.account.id,
+        returnScrollY: typeof window !== 'undefined' ? window.scrollY : 0,
+      });
       const link = debugBundleLinkForAccount(detail.account.id);
       if (typeof window !== 'undefined') {
         window.location.hash = link.replace(/^\/admin/, '');
       }
     }
+  };
+
+  const [copySummaryFeedback, setCopySummaryFeedback] = React.useState('');
+  const handleCopySupportSummary = async () => {
+    if (!detail?.account) return;
+    const summaryData = {
+      account: detail.account.email || detail.account.id,
+      role: detail.account.platformRole,
+      learnerCount: detail.learners?.length || 0,
+      recentErrorCount: detail.recentErrors?.length || 0,
+      recentDenialCount: detail.recentDenials?.length || 0,
+      opsStatus: detail.opsMetadata?.opsStatus || 'active',
+    };
+    const prepared = prepareSafeCopy(summaryData, COPY_AUDIENCE.PARENT_SAFE);
+    if (!prepared.ok) {
+      setCopySummaryFeedback('Nothing to copy');
+      setTimeout(() => setCopySummaryFeedback(''), 2000);
+      return;
+    }
+    const result = await copyToClipboard(prepared.text);
+    setCopySummaryFeedback(result.ok ? 'Summary copied' : 'Copy failed');
+    setTimeout(() => setCopySummaryFeedback(''), 2000);
   };
 
   if (detail) {
@@ -532,6 +567,8 @@ function AccountSearchPanel({ model, actions }) {
         detail={detail}
         onClose={handleCloseDetail}
         onDebugBundle={handleDebugBundle}
+        onCopySupportSummary={handleCopySupportSummary}
+        copySummaryFeedback={copySummaryFeedback}
       />
     );
   }

--- a/src/surfaces/hubs/AdminDebugBundlePanel.jsx
+++ b/src/surfaces/hubs/AdminDebugBundlePanel.jsx
@@ -11,6 +11,7 @@ import {
   prepareSafeCopy,
   copyToClipboard,
 } from '../../platform/hubs/admin-safe-copy.js';
+import { consumeIncidentStash } from '../../platform/hubs/admin-incident-flow.js';
 
 // U8 (P4): Debug Bundle panel — extracted from AdminDebuggingSection.jsx.
 // Contains DebugBundlePanel + DebugBundleSectionTable + DebugBundleResult.
@@ -174,6 +175,25 @@ export function DebugBundlePanel({ model, actions }) {
   const [routeFilter, setRouteFilter] = React.useState('');
   const [copyFeedback, setCopyFeedback] = React.useState('');
 
+  // U6 (P5): Consume incident stash on mount — enables "Return to account" link.
+  const [incidentReturn, setIncidentReturn] = React.useState(null);
+  React.useEffect(() => {
+    const stash = consumeIncidentStash();
+    if (stash) setIncidentReturn(stash);
+  }, []);
+
+  const handleReturnToAccount = () => {
+    if (!incidentReturn) return;
+    const { returnAccountId, returnSection } = incidentReturn;
+    if (typeof window !== 'undefined') {
+      window.location.hash = `section=${returnSection || 'accounts'}`;
+    }
+    // Re-open the account detail after navigation
+    if (returnAccountId) {
+      actions.dispatch('account-detail-load', { accountId: returnAccountId });
+    }
+  };
+
   // R7: pre-fill from error drawer link.
   const prefill = debugBundle.prefill || null;
   React.useEffect(() => {
@@ -224,6 +244,13 @@ export function DebugBundlePanel({ model, actions }) {
         refreshError={error}
         onRefresh={generateBundle}
       />
+      {incidentReturn ? (
+        <div className="admin-incident-return-bar" data-testid="incident-return-bar">
+          <button className="btn ghost" type="button" onClick={handleReturnToAccount} data-testid="incident-return-btn">
+            Return to account
+          </button>
+        </div>
+      ) : null}
 
       <div
         className="filters admin-filters-grid"

--- a/tests/react-admin-incident-flow.test.js
+++ b/tests/react-admin-incident-flow.test.js
@@ -1,0 +1,265 @@
+// P5 U6: Admin incident flow stash — unit tests.
+//
+// Validates the stash logic (save/consume/expiry) and the integration
+// surface connections (copy support summary, return navigation).
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  saveIncidentStash,
+  consumeIncidentStash,
+  INCIDENT_STASH_KEY,
+  MAX_AGE_MS,
+} from '../src/platform/hubs/admin-incident-flow.js';
+
+import {
+  prepareSafeCopy,
+  COPY_AUDIENCE,
+} from '../src/platform/hubs/admin-safe-copy.js';
+
+// ---------------------------------------------------------------------------
+// In-memory sessionStorage mock
+// ---------------------------------------------------------------------------
+
+function createMockStorage() {
+  const store = new Map();
+  return {
+    getItem(key) { return store.get(key) ?? null; },
+    setItem(key, value) { store.set(key, value); },
+    removeItem(key) { store.delete(key); },
+    get _store() { return store; },
+  };
+}
+
+// =================================================================
+// 1. saveIncidentStash — basic write
+// =================================================================
+
+test('saveIncidentStash writes stash to storage', () => {
+  const storage = createMockStorage();
+  saveIncidentStash({
+    returnSection: 'accounts',
+    returnAccountId: 'acct-123',
+    returnScrollY: 42,
+  }, storage);
+
+  const raw = storage.getItem(INCIDENT_STASH_KEY);
+  assert.ok(raw, 'stash should be written');
+  const parsed = JSON.parse(raw);
+  assert.equal(parsed.returnSection, 'accounts');
+  assert.equal(parsed.returnAccountId, 'acct-123');
+  assert.equal(parsed.returnScrollY, 42);
+  assert.equal(typeof parsed.ts, 'number');
+});
+
+// =================================================================
+// 2. saveIncidentStash — defaults for missing fields
+// =================================================================
+
+test('saveIncidentStash defaults missing fields', () => {
+  const storage = createMockStorage();
+  saveIncidentStash({}, storage);
+
+  const parsed = JSON.parse(storage.getItem(INCIDENT_STASH_KEY));
+  assert.equal(parsed.returnSection, 'accounts');
+  assert.equal(parsed.returnAccountId, '');
+  assert.equal(parsed.returnScrollY, 0);
+});
+
+// =================================================================
+// 3. saveIncidentStash — rejects null/undefined stash
+// =================================================================
+
+test('saveIncidentStash ignores null stash', () => {
+  const storage = createMockStorage();
+  saveIncidentStash(null, storage);
+  assert.equal(storage.getItem(INCIDENT_STASH_KEY), null);
+});
+
+test('saveIncidentStash ignores non-object stash', () => {
+  const storage = createMockStorage();
+  saveIncidentStash('not-an-object', storage);
+  assert.equal(storage.getItem(INCIDENT_STASH_KEY), null);
+});
+
+// =================================================================
+// 4. consumeIncidentStash — happy path (read + clear)
+// =================================================================
+
+test('consumeIncidentStash reads and clears the stash', () => {
+  const storage = createMockStorage();
+  saveIncidentStash({
+    returnSection: 'accounts',
+    returnAccountId: 'acct-456',
+    returnScrollY: 100,
+  }, storage);
+
+  const result = consumeIncidentStash(storage);
+  assert.deepEqual(result, {
+    returnSection: 'accounts',
+    returnAccountId: 'acct-456',
+    returnScrollY: 100,
+  });
+
+  // Consumed — subsequent read returns null
+  const second = consumeIncidentStash(storage);
+  assert.equal(second, null);
+});
+
+// =================================================================
+// 5. consumeIncidentStash — expired stash returns null
+// =================================================================
+
+test('consumeIncidentStash returns null for expired stash', () => {
+  const storage = createMockStorage();
+  const expiredPayload = JSON.stringify({
+    returnSection: 'accounts',
+    returnAccountId: 'acct-old',
+    returnScrollY: 0,
+    ts: Date.now() - MAX_AGE_MS - 1,
+  });
+  storage.setItem(INCIDENT_STASH_KEY, expiredPayload);
+
+  const result = consumeIncidentStash(storage);
+  assert.equal(result, null, 'expired stash should return null');
+  // Stash should be cleared even when expired
+  assert.equal(storage.getItem(INCIDENT_STASH_KEY), null);
+});
+
+// =================================================================
+// 6. consumeIncidentStash — returns null for absent stash
+// =================================================================
+
+test('consumeIncidentStash returns null when no stash exists', () => {
+  const storage = createMockStorage();
+  const result = consumeIncidentStash(storage);
+  assert.equal(result, null);
+});
+
+// =================================================================
+// 7. consumeIncidentStash — returns null for malformed JSON
+// =================================================================
+
+test('consumeIncidentStash returns null for malformed JSON', () => {
+  const storage = createMockStorage();
+  storage.setItem(INCIDENT_STASH_KEY, 'not-json{{{');
+  const result = consumeIncidentStash(storage);
+  assert.equal(result, null);
+  // Should still clear the bad entry
+  assert.equal(storage.getItem(INCIDENT_STASH_KEY), null);
+});
+
+// =================================================================
+// 8. consumeIncidentStash — future timestamp rejected
+// =================================================================
+
+test('consumeIncidentStash rejects future timestamps (negative age)', () => {
+  const storage = createMockStorage();
+  const futurePayload = JSON.stringify({
+    returnSection: 'accounts',
+    returnAccountId: 'acct-future',
+    returnScrollY: 0,
+    ts: Date.now() + 100_000_000, // far in the future
+  });
+  storage.setItem(INCIDENT_STASH_KEY, futurePayload);
+  const result = consumeIncidentStash(storage);
+  assert.equal(result, null);
+});
+
+// =================================================================
+// 9. consumeIncidentStash — non-object stored value
+// =================================================================
+
+test('consumeIncidentStash returns null for non-object stored value', () => {
+  const storage = createMockStorage();
+  storage.setItem(INCIDENT_STASH_KEY, JSON.stringify('a string'));
+  const result = consumeIncidentStash(storage);
+  assert.equal(result, null);
+});
+
+// =================================================================
+// 10. MAX_AGE_MS is 5 minutes
+// =================================================================
+
+test('MAX_AGE_MS equals 5 minutes', () => {
+  assert.equal(MAX_AGE_MS, 5 * 60 * 1000);
+});
+
+// =================================================================
+// 11. Copy support summary uses PARENT_SAFE audience
+// =================================================================
+
+test('prepareSafeCopy with PARENT_SAFE strips child IDs and masks emails', () => {
+  const data = {
+    email: 'parent@example.com',
+    learnerId: 'lrn-secret-123',
+    role: 'parent',
+    learnerCount: 2,
+    internalNotes: 'sensitive admin note',
+  };
+  const result = prepareSafeCopy(data, COPY_AUDIENCE.PARENT_SAFE);
+  assert.equal(result.ok, true);
+  // Should not contain child ID
+  assert.ok(!result.text.includes('lrn-secret-123'), 'child IDs should be stripped');
+  // Should not contain internal notes
+  assert.ok(!result.text.includes('sensitive admin note'), 'internal notes should be stripped');
+  // Email field (key=email) should be masked
+  assert.ok(!result.text.includes('parent@example.com'), 'email should be masked');
+  assert.ok(result.text.includes('****le.com'), 'masked email should appear');
+  assert.ok(result.redactedFields.includes('child_ids'));
+  assert.ok(result.redactedFields.includes('internal_notes'));
+  assert.ok(result.redactedFields.includes('emails_masked'));
+});
+
+// =================================================================
+// 12. Save and consume round-trip preserves all fields
+// =================================================================
+
+test('save and consume round-trip preserves all fields', () => {
+  const storage = createMockStorage();
+  const stash = {
+    returnSection: 'accounts',
+    returnAccountId: 'acct-roundtrip',
+    returnScrollY: 777,
+  };
+  saveIncidentStash(stash, storage);
+  const result = consumeIncidentStash(storage);
+  assert.deepEqual(result, stash);
+});
+
+// =================================================================
+// 13. saveIncidentStash — handles storage errors gracefully
+// =================================================================
+
+test('saveIncidentStash handles storage setItem errors gracefully', () => {
+  const storage = {
+    getItem() { return null; },
+    setItem() { throw new Error('QuotaExceededError'); },
+    removeItem() {},
+  };
+  // Should not throw
+  saveIncidentStash({ returnSection: 'accounts', returnAccountId: 'acct-1', returnScrollY: 0 }, storage);
+});
+
+// =================================================================
+// 14. consumeIncidentStash — handles storage getItem errors gracefully
+// =================================================================
+
+test('consumeIncidentStash handles storage getItem errors gracefully', () => {
+  const storage = {
+    getItem() { throw new Error('SecurityError'); },
+    setItem() {},
+    removeItem() {},
+  };
+  const result = consumeIncidentStash(storage);
+  assert.equal(result, null);
+});
+
+// =================================================================
+// 15. Stash key constant value
+// =================================================================
+
+test('INCIDENT_STASH_KEY has expected value', () => {
+  assert.equal(INCIDENT_STASH_KEY, 'ks2_admin_incident_stash');
+});


### PR DESCRIPTION
## Summary
- Incident flow stash: save account context before navigating to debug bundle
- Return to account button in debug section when stash exists
- Copy support summary using parent_safe safe-copy
- Extends existing admin-return-stash pattern

## Test plan
- [x] Incident flow stash tests (save/consume/expiry) — 16 tests pass
- [x] Copy support summary uses parent_safe audience
- [x] Return navigation works
- [x] Existing account tests pass (no regression) — 11 tests pass