### PR TITLE
test(admin): classify support labels and refresh CI gates

### DIFF
--- a/scripts/audit-client-bundle.mjs
+++ b/scripts/audit-client-bundle.mjs
@@ -29,13 +29,14 @@ const DEFAULT_PUBLIC_DIR = 'dist/public';
 // ~215.1 KB. Punctuation's Star-based display parity added a small
 // first-paint utility footprint. Grammar's matching display-state parity
 // adds another tiny cross-subject utility slice. The reward presentation
-// queue and toast compatibility layers keep Node 22's gzip output near
-// 217.4 KB, so the committed ceiling is 218,000: still tight enough to catch
-// an adult-surface re-import, without blocking on sub-kilobyte compression/runtime drift. Override via CLI
+// queue, toast compatibility layers, and Hero Mode P3 daily-progress shell
+// keep Node 22/24 gzip output near 219.4 KB, so the committed ceiling is
+// 220,000: still tight enough to catch an adult-surface re-import, without
+// blocking on sub-kilobyte compression/runtime drift. Override via CLI
 // `--main-bundle-budget-bytes` for experimentation. See
 // `tests/bundle-byte-budget.test.js` for the committed baseline +
 // rationale.
-const DEFAULT_MAIN_BUNDLE_GZIP_BUDGET_BYTES = 218_000;
+const DEFAULT_MAIN_BUNDLE_GZIP_BUDGET_BYTES = 220_000;
 
 const FORBIDDEN_MODULES = [
   { pattern: /^src\/subjects\/spelling\/data\//, reason: 'full spelling content dataset' },

--- a/tests/bundle-byte-budget.test.js
+++ b/tests/bundle-byte-budget.test.js
@@ -18,10 +18,11 @@
 // safety and radio-focus accessibility fixes lift the Node 22 build to
 // ~215.1 KB. Punctuation's Star-based display parity added a small first-paint
 // utility footprint; Grammar's matching display-state parity adds another
-// tiny cross-subject utility slice. The reward presentation queue and toast
-// compatibility layers keep Node 22's gzip output near 217.4 KB. The
-// committed ceiling is now `218_000`, keeping the headroom narrow while
-// avoiding a sub-kilobyte compression/runtime false blocker.
+// tiny cross-subject utility slice. The reward presentation queue, toast
+// compatibility layers, and Hero Mode P3 daily-progress shell keep Node 22/24
+// gzip output near 219.4 KB. The committed ceiling is now `220_000`, keeping
+// the headroom narrow while avoiding a sub-kilobyte compression/runtime false
+// blocker.
 // The audit still fails
 // when ~50 KB of adult-only JS sneaks back into the critical path (the
 // exact regression the code-split protects against). The audit driver re-reads
@@ -65,14 +66,15 @@ const REPO_ROOT = path.resolve(__dirname, '..');
 // safety and radio-focus accessibility fixes lift the Node 22 build to
 // ~215.1 KB. Punctuation's Star-based display parity adds a small first-paint
 // utility footprint; Grammar's matching display-state parity adds another
-// tiny cross-subject utility slice. The reward presentation queue and toast
-// compatibility layers keep Node 22's gzip output near 217.4 KB, so the committed ceiling is 218,000
+// tiny cross-subject utility slice. The reward presentation queue, toast
+// compatibility layers, and Hero Mode P3 daily-progress shell keep Node 22/24
+// gzip output near 219.4 KB, so the committed ceiling is 220,000
 // (matches `DEFAULT_MAIN_BUNDLE_GZIP_BUDGET_BYTES` in
 // `scripts/audit-client-bundle.mjs`). The narrow headroom lets the team
 // land small copy / utility growth without an audit bump, but trips the
 // gate when ~50 KB of adult-only JS sneaks back into the critical path.
 const BASELINE_GZIP_BYTES = 203_227;
-const BUDGET_GZIP_BYTES = 218_000;
+const BUDGET_GZIP_BYTES = 220_000;
 const TEST_MODE_BUNDLE_MARKER = '__ks2_capacityMeta__';
 
 function isPlaywrightTestModeBundle(bundleBytes) {

--- a/tests/button-label-consistency.test.js
+++ b/tests/button-label-consistency.test.js
@@ -493,10 +493,14 @@ test('button labels: every statically extractable label is classified', () => {
     // scanner after the button-label completeness gate tightened. "Debug
     // Bundle" navigates from the account detail drawer to the debug panel;
     // "Copy JSON" / "Copy Summary" are clipboard-copy actions scoped to the
-    // generated bundle output.
+    // generated bundle output. "Copy support summary" is the parent-safe
+    // account-detail export, while "Return to account" is the incident-flow
+    // back-navigation affordance after opening a debug bundle.
     'Debug Bundle',
     'Copy JSON',
     'Copy Summary',
+    'Copy support summary',
+    'Return to account',
     // U11 Marketing/Live Ops: AdminMarketingSection broad-publish confirm
     // dialog uses a contextual confirm CTA ("Yes, publish to all users" or
     // "Yes, schedule to all users"); the static prefix the scanner extracts

--- a/tests/hero-context-passthrough.test.js
+++ b/tests/hero-context-passthrough.test.js
@@ -68,6 +68,45 @@ function baseContext() {
   };
 }
 
+function grammarOptionValue(option) {
+  if (Array.isArray(option)) return String(option[0] ?? '');
+  if (typeof option === 'string' || typeof option === 'number') return String(option);
+  return String(option?.value ?? '');
+}
+
+function firstGrammarOptionValue(options, fallback = 'a') {
+  const values = Array.isArray(options) ? options.map(grammarOptionValue).filter(Boolean) : [];
+  return values[0] || fallback;
+}
+
+function grammarAnswerPayloadFromInputSpec(spec) {
+  if (spec?.type === 'single_choice' && Array.isArray(spec.options) && spec.options.length > 0) {
+    return { response: { answer: firstGrammarOptionValue(spec.options) } };
+  }
+  if (spec?.type === 'checkbox_list' && Array.isArray(spec.options) && spec.options.length > 0) {
+    return { response: { selected: [firstGrammarOptionValue(spec.options)] } };
+  }
+  if (spec?.type === 'table_choice') {
+    const rows = Array.isArray(spec.rows) ? spec.rows : [];
+    const choice = firstGrammarOptionValue(spec.columns, 'A');
+    const response = {};
+    for (const row of rows) {
+      if (typeof row?.key === 'string' && row.key) response[row.key] = choice;
+    }
+    return { response: Object.keys(response).length > 0 ? response : { answer: choice } };
+  }
+  if (spec?.type === 'multi') {
+    const fields = Array.isArray(spec.fields) ? spec.fields : [];
+    const response = {};
+    for (const field of fields) {
+      if (typeof field?.key !== 'string' || !field.key) continue;
+      response[field.key] = firstGrammarOptionValue(field.options, 'test answer');
+    }
+    return { response: Object.keys(response).length > 0 ? response : { answer: 'test answer' } };
+  }
+  return { response: { answer: 'test answer' } };
+}
+
 // ── Spelling ─────────────────────────────────────────────────────────────
 
 test('spelling start-session with heroContext stores it on persisted session state', async () => {
@@ -500,9 +539,7 @@ test('grammar completed session summary contains heroContext fields', async () =
 
   // Submit an answer to complete the session.
   const item = sessionState.session.currentItem;
-  const answerPayload = item.inputSpec?.type === 'single_choice'
-    ? { response: { answer: item.inputSpec.options?.[0]?.value || item.inputSpec.options?.[0] || 'a' } }
-    : { response: { answer: 'test' } };
+  const answerPayload = grammarAnswerPayloadFromInputSpec(item.inputSpec);
 
   const submitCtx = {
     ...grammarContext,

--- a/tests/worker-hero-command.test.js
+++ b/tests/worker-hero-command.test.js
@@ -239,7 +239,7 @@ test('hero command: unsupported command returns 400 hero_command_unsupported', a
   await seedLearner(server, 'adult-a', 'learner-a');
 
   const response = await postHeroCommand(server, {
-    command: 'claim-task',
+    command: 'unsupported-command',
     learnerId: 'learner-a',
     questId: 'q-1',
     taskId: 't-1',


### PR DESCRIPTION
## Summary
- classify the new admin support and incident-flow button labels in the button-label consistency gate
- refresh the Hero P3 unsupported-command regression test now that `claim-task` is a supported command path
- rebaseline the client bundle gzip budget to 220,000 bytes after Hero P3, keeping the budget narrow and documented
- stabilise the hero-context grammar summary test so it submits a response that matches the generated `inputSpec`

## Tests
- node --test tests/button-label-consistency.test.js
- npm run build
- node --test tests/worker-hero-command.test.js
- npm run audit:client
- node --test tests/bundle-byte-budget.test.js tests/worker-hero-command.test.js tests/button-label-consistency.test.js
- node --test tests/hero-context-passthrough.test.js
- npm test
- npm run check
- git diff --check