### PR TITLE
feat(grammar): add verify:grammar-qg release gate command

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build:bundles": "node ./scripts/build-bundles.mjs",
     "audit:client": "node ./scripts/audit-client-bundle.mjs",
     "audit:punctuation-content": "node ./scripts/audit-punctuation-content.mjs",
+    "audit:grammar-qg": "node scripts/audit-grammar-question-generator.mjs --json",
+    "audit:grammar-qg:deep": "node scripts/audit-grammar-question-generator.mjs --deep --json",
     "audit:production": "node ./scripts/production-bundle-audit.mjs",
     "assert:build-public": "node ./scripts/assert-build-public.mjs",
     "assets:monsters": "node ./scripts/generate-monster-assets.mjs",
@@ -56,7 +58,8 @@
     "test:mega-invariant:nightly": "node --test tests/spelling-mega-invariant.test.js",
     "test:playwright": "npx playwright test",
     "journey": "node tests/journeys/_runner.mjs",
-    "verify": "npm test && npm run check && npm run capacity:verify-evidence"
+    "verify": "npm test && npm run check && npm run capacity:verify-evidence",
+    "verify:grammar-qg": "npm run audit:grammar-qg && npm run audit:grammar-qg:deep && node --test tests/grammar-question-generator-audit.test.js tests/grammar-functionality-completeness.test.js tests/grammar-production-smoke.test.js tests/grammar-selection.test.js tests/grammar-engine.test.js"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",


### PR DESCRIPTION
## Summary

Grammar QG P5 Unit 1: adds first-class verification scripts for the Grammar Question Generator.

- `audit:grammar-qg` — runs the audit script in JSON mode
- `audit:grammar-qg:deep` — runs the deep audit (cross-concept overlap, depth coverage)
- `verify:grammar-qg` — full release gate: both audits + all Grammar QG test suites (audit, functionality-completeness, production-smoke, selection, engine)

## Test plan

- [x] `npm run audit:grammar-qg` exits 0 with valid JSON output
- [ ] `npm run audit:grammar-qg:deep` exits 0
- [ ] `npm run verify:grammar-qg` runs full pipeline end-to-end