### PR TITLE
feat(grammar): add P5 reviewer sample pack generator

### DIFF
--- a/reports/grammar/grammar-qg-p5-review-pack.md
+++ b/reports/grammar/grammar-qg-p5-review-pack.md
@@ -1,0 +1,3551 @@
+# Grammar QG P5 — Reviewer Sample Pack
+
+Generated from commit: cf9a70c8d15e4874d7bd87e8da273a2eb5a6691f
+Release: grammar-qg-p5-2026-04-28
+Seed window: 1..30
+Total generated families: 52
+
+---
+
+## Family: proc_apostrophe_possession_choice
+
+- **Template ID(s):** proc_apostrophe_possession_choice
+- **Skill IDs:** apostrophes_possession
+- **Answer-spec kind:** inline
+- **Question type:** choose
+- **Tags:** identify
+- **Unique variants (seeds 1..30):** 26
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** choose
+**Stem:** Choose the correct phrase for more than one girl and their coats.
+**Options:** A) the girl's coats, B) the girls' coats, C) the girls coats, D) the girls's coats
+
+#### Seed 2
+**Question type:** choose
+**Stem:** Choose the correct phrase for people and their tickets.
+**Options:** A) the peoples tickets, B) the people's tickets, C) the people' tickets, D) the people tickets
+
+#### Seed 3
+**Question type:** choose
+**Stem:** Choose the correct phrase for one dog and its tickets.
+**Options:** A) the dogs tickets, B) the dog's tickets, C) the dogs' tickets, D) the dogs's tickets
+
+#### Seed 4
+**Question type:** choose
+**Stem:** Choose the correct phrase for more than one boy and their lunchboxes.
+**Options:** A) the boy's lunchboxes, B) the boys' lunchboxes, C) the boys lunchboxes, D) the boys's lunchboxes
+
+#### Seed 5
+**Question type:** choose
+**Stem:** Choose the correct phrase for women and their coats.
+**Options:** A) the womens coats, B) the women's coats, C) the women' coats, D) the women coats
+
+---
+
+## Family: proc_colon_list_fix
+
+- **Template ID(s):** proc_colon_list_fix
+- **Skill IDs:** boundary_punctuation
+- **Answer-spec kind:** punctuationPattern
+- **Question type:** fix
+- **Tags:** qg-p5, surgery
+- **Unique variants (seeds 1..30):** 9
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** fix
+**Stem:** Rewrite the sentence with a colon in the correct place.For the picnic we packed three things bread, fruit, juice.
+**Input:** textarea — Corrected sentence
+
+#### Seed 2
+**Question type:** fix
+**Stem:** Rewrite the sentence with a colon in the correct place.The museum displayed four objects a helmet, a shield, a sword, a coin.
+**Input:** textarea — Corrected sentence
+
+#### Seed 3
+**Question type:** fix
+**Stem:** Rewrite the sentence with a colon in the correct place.We still needed two items for camp a torch, a sleeping bag.
+**Input:** textarea — Corrected sentence
+
+#### Seed 4
+**Question type:** fix
+**Stem:** Rewrite the sentence with a colon in the correct place.The club offered three prizes a medal, a certificate, a book token.
+**Input:** textarea — Corrected sentence
+
+#### Seed 5
+**Question type:** fix
+**Stem:** Rewrite the sentence with a colon in the correct place.The recipe called for five ingredients flour, butter, eggs, sugar, milk.
+**Input:** textarea — Corrected sentence
+
+---
+
+## Family: proc_dash_boundary_fix
+
+- **Template ID(s):** proc_dash_boundary_fix
+- **Skill IDs:** boundary_punctuation
+- **Answer-spec kind:** punctuationPattern
+- **Question type:** fix
+- **Tags:** qg-p5, surgery
+- **Unique variants (seeds 1..30):** 9
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** fix
+**Stem:** Rewrite the sentence with a dash in the correct place.I had one worry the batteries were flat.
+**Input:** textarea — Corrected sentence
+
+#### Seed 2
+**Question type:** fix
+**Stem:** Rewrite the sentence with a dash in the correct place.The plan was simple follow the red arrows.
+**Input:** textarea — Corrected sentence
+
+#### Seed 3
+**Question type:** fix
+**Stem:** Rewrite the sentence with a dash in the correct place.There was only one answer turn back at once.
+**Input:** textarea — Corrected sentence
+
+#### Seed 4
+**Question type:** fix
+**Stem:** Rewrite the sentence with a dash in the correct place.One thought filled my mind where had the key gone.
+**Input:** textarea — Corrected sentence
+
+#### Seed 5
+**Question type:** fix
+**Stem:** Rewrite the sentence with a dash in the correct place.She had made her decision the letter would be posted today.
+**Input:** textarea — Corrected sentence
+
+---
+
+## Family: proc_fronted_adverbial_fix
+
+- **Template ID(s):** proc_fronted_adverbial_fix
+- **Skill IDs:** adverbials
+- **Answer-spec kind:** punctuationPattern
+- **Question type:** fix
+- **Tags:** surgery
+- **Unique variants (seeds 1..30):** 30
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** fix
+**Stem:** Rewrite the sentence with the punctuation corrected.With great care Ava locked the window.
+**Input:** textarea — Corrected sentence
+
+#### Seed 2
+**Question type:** fix
+**Stem:** Rewrite the sentence with the punctuation corrected.With great care Noah found the map.
+**Input:** textarea — Corrected sentence
+
+#### Seed 3
+**Question type:** fix
+**Stem:** Rewrite the sentence with the punctuation corrected.With great care Ava carried the trophy.
+**Input:** textarea — Corrected sentence
+
+#### Seed 4
+**Question type:** fix
+**Stem:** Rewrite the sentence with the punctuation corrected.After the final whistle Noah carried the gate.
+**Input:** textarea — Corrected sentence
+
+#### Seed 5
+**Question type:** fix
+**Stem:** Rewrite the sentence with the punctuation corrected.With great care Nora found the gate.
+**Input:** textarea — Corrected sentence
+
+---
+
+## Family: proc_hyphen_ambiguity_choice
+
+- **Template ID(s):** proc_hyphen_ambiguity_choice
+- **Skill IDs:** hyphen_ambiguity
+- **Answer-spec kind:** inline
+- **Question type:** choose
+- **Tags:** identify, qg-p5
+- **Unique variants (seeds 1..30):** 9
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** choose
+**Stem:** Which sentence means the shark eats people?
+**Options:** A) We saw a man-eating shark near the rocks., B) We saw a man eating shark near the rocks., C) We saw a hungry shark near the rocks., D) We saw a shark near a man on the rocks.
+
+#### Seed 2
+**Question type:** choose
+**Stem:** Which sentence means the hospital treats small animals?
+**Options:** A) We visited the small-animal hospital after lunch., B) We visited the small animal hospital after lunch., C) We visited the hospital after lunch with small animals., D) We visited a small hospital for lunch animals.
+
+#### Seed 3
+**Question type:** choose
+**Stem:** Which sentence means the cabinet is used for drying clothes?
+**Options:** A) Dad opened the clothes-drying cabinet in the hall., B) Dad opened the clothes drying cabinet in the hall., C) Dad opened the cabinet for the hall clothes., D) Dad opened the drying clothes in the cabinet.
+
+#### Seed 4
+**Question type:** choose
+**Stem:** Which sentence means the test is well known?
+**Options:** A) The teacher set a well-known test for the class., B) The teacher set a well known test for the class., C) The teacher knew the test well for the class., D) The teacher set a known well test for the class.
+
+#### Seed 5
+**Question type:** choose
+**Stem:** Which sentence means the building has ten storeys?
+**Options:** A) We looked up at the ten-storey building., B) We looked up at the ten storey building., C) We looked up at ten buildings in a storey., D) We looked up at the storey with ten buildings.
+
+---
+
+## Family: proc_semicolon_choice
+
+- **Template ID(s):** proc_semicolon_choice
+- **Skill IDs:** boundary_punctuation
+- **Answer-spec kind:** inline
+- **Question type:** choose
+- **Tags:** identify, qg-p5
+- **Unique variants (seeds 1..30):** 9
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** choose
+**Stem:** Which punctuation mark best completes the sentence below?The rain stopped ___ the playground began to fill.
+**Options:** A) ;, B) :, C) ,, D) ?
+
+#### Seed 2
+**Question type:** choose
+**Stem:** Which punctuation mark best completes the sentence below?The lights went out ___ the hall fell silent.
+**Options:** A) ;, B) :, C) ,, D) ?
+
+#### Seed 3
+**Question type:** choose
+**Stem:** Which punctuation mark best completes the sentence below?The bell rang ___ the pupils hurried inside.
+**Options:** A) ;, B) :, C) ,, D) ?
+
+#### Seed 4
+**Question type:** choose
+**Stem:** Which punctuation mark best completes the sentence below?The wind strengthened ___ the tent flapped wildly.
+**Options:** A) ;, B) :, C) ,, D) ?
+
+#### Seed 5
+**Question type:** choose
+**Stem:** Which punctuation mark best completes the sentence below?The bus arrived ___ everyone grabbed their bags.
+**Options:** A) ;, B) :, C) ,, D) ?
+
+---
+
+## Family: proc_speech_punctuation_fix
+
+- **Template ID(s):** proc_speech_punctuation_fix
+- **Skill IDs:** speech_punctuation
+- **Answer-spec kind:** punctuationPattern
+- **Question type:** fix
+- **Tags:** surgery
+- **Unique variants (seeds 1..30):** 29
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** fix
+**Stem:** Punctuate the direct speech correctly.Ben said "Shut the gate behind you!"
+**Input:** textarea — Correctly punctuated sentence
+
+#### Seed 2
+**Question type:** fix
+**Stem:** Punctuate the direct speech correctly."What a huge wave that was" asked Ava.
+**Input:** textarea — Correctly punctuated sentence
+
+#### Seed 3
+**Question type:** fix
+**Stem:** Punctuate the direct speech correctly."Why are your boots muddy" said Ava.
+**Input:** textarea — Correctly punctuated sentence
+
+#### Seed 4
+**Question type:** fix
+**Stem:** Punctuate the direct speech correctly.the guide asked "Bring the torch with you!"
+**Input:** textarea — Correctly punctuated sentence
+
+#### Seed 5
+**Question type:** fix
+**Stem:** Punctuate the direct speech correctly."What a huge wave that was" whispered Ben.
+**Input:** textarea — Correctly punctuated sentence
+
+---
+
+## Family: proc2_boundary_punctuation_explain
+
+- **Template ID(s):** proc2_boundary_punctuation_explain
+- **Skill IDs:** boundary_punctuation
+- **Answer-spec kind:** inline
+- **Question type:** explain
+- **Tags:** none
+- **Unique variants (seeds 1..30):** 15
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** explain
+**Stem:** Why is the punctuation in this sentence effective?Three countries were represented at the fair: France, Japan, Brazil.
+**Options:** A) The colon replaces speech marks., B) The colon shows a question., C) The colon marks possession., D) The words before the colon make a complete clause and the colon introduces a list.
+
+#### Seed 2
+**Question type:** explain
+**Stem:** Why is the punctuation in this sentence effective?He remembered just one rule – never open the gate after dark.
+**Options:** A) The dash turns the sentence into a question., B) The dash marks a direct speech tag., C) The dash creates a strong break before an explanation or afterthought., D) The dash shows plural possession.
+
+#### Seed 3
+**Question type:** explain
+**Stem:** Why is the punctuation in this sentence effective?The tide was rising quickly; the fishermen hauled in their nets.
+**Options:** A) A semi-colon marks a fronted adverbial., B) A semi-colon shows possession., C) A semi-colon introduces direct speech., D) A semi-colon can join two closely related main clauses.
+
+#### Seed 4
+**Question type:** explain
+**Stem:** Why is the punctuation in this sentence effective?The gardener planted four types of vegetable: carrots, beans, potatoes, onions.
+**Options:** A) The colon replaces speech marks., B) The colon shows a question., C) The words before the colon make a complete clause and the colon introduces a list., D) The colon marks possession.
+
+#### Seed 6
+**Question type:** explain
+**Stem:** Why is the punctuation in this sentence effective?The bus arrived; everyone grabbed their bags.
+**Options:** A) A semi-colon marks a fronted adverbial., B) A semi-colon shows possession., C) A semi-colon introduces direct speech., D) A semi-colon can join two closely related main clauses.
+
+---
+
+## Family: proc2_formality_choice
+
+- **Template ID(s):** proc2_formality_choice
+- **Skill IDs:** formality
+- **Answer-spec kind:** inline
+- **Question type:** choose
+- **Tags:** qg-p5
+- **Unique variants (seeds 1..30):** 9
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** choose
+**Stem:** Which sentence would be most suitable for a formal letter to the headteacher?
+**Options:** A) I just wanted to ask if we could maybe have extra chairs., B) Can we get a couple more chairs for the hall?, C) I am writing to request two extra chairs for the hall., D) We really need some more chairs for the hall, please.
+
+#### Seed 2
+**Question type:** choose
+**Stem:** Which sentence sounds most formal?
+**Options:** A) The club got set up last year., B) Last year was when the club got going., C) The club was established last year., D) The club was started up last year, really.
+
+#### Seed 3
+**Question type:** choose
+**Stem:** Choose the sentence that best fits a formal report.
+**Options:** A) A few pupils were off for the visit., B) Quite a few pupils were missing from it., C) Several pupils were absent from the visit., D) Some pupils didn't come on the trip.
+
+#### Seed 4
+**Question type:** choose
+**Stem:** Which sentence is most appropriate for a school newsletter?
+**Options:** A) We're so excited about the new library opening!, B) The new library is opening and it's going to be great., C) We are delighted to announce the opening of the new library., D) Guess what – there's a new library starting up.
+
+#### Seed 5
+**Question type:** choose
+**Stem:** Choose the sentence that fits best in a formal invitation.
+**Options:** A) Can everyone turn up by half six?, B) Guests are kindly requested to arrive by half past six., C) Everyone should come at like half six., D) Please try to get there by about six-thirty.
+
+---
+
+## Family: proc2_fronted_adverbial_build
+
+- **Template ID(s):** proc2_fronted_adverbial_build
+- **Skill IDs:** adverbials
+- **Answer-spec kind:** manualReviewOnly
+- **Question type:** build
+- **Tags:** builder
+- **Unique variants (seeds 1..30):** 30
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** build
+**Stem:** Use this opening phrase and clause to build one correct sentence.Opening phrase: With great careMain clause: Ava locked the window
+**Input:** textarea — Your sentence
+
+#### Seed 2
+**Question type:** build
+**Stem:** Use this opening phrase and clause to build one correct sentence.Opening phrase: With great careMain clause: Noah found the map
+**Input:** textarea — Your sentence
+
+#### Seed 3
+**Question type:** build
+**Stem:** Use this opening phrase and clause to build one correct sentence.Opening phrase: With great careMain clause: Ava carried the trophy
+**Input:** textarea — Your sentence
+
+#### Seed 4
+**Question type:** build
+**Stem:** Use this opening phrase and clause to build one correct sentence.Opening phrase: After the final whistleMain clause: Noah carried the gate
+**Input:** textarea — Your sentence
+
+#### Seed 5
+**Question type:** build
+**Stem:** Use this opening phrase and clause to build one correct sentence.Opening phrase: With great careMain clause: Nora found the gate
+**Input:** textarea — Your sentence
+
+---
+
+## Family: proc2_modal_choice
+
+- **Template ID(s):** proc2_modal_choice
+- **Skill IDs:** modal_verbs
+- **Answer-spec kind:** inline
+- **Question type:** fill
+- **Tags:** qg-p5
+- **Unique variants (seeds 1..30):** 9
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** fill
+**Stem:** Choose the modal verb that best fits the meaning: This is a rule on the climbing wall. You ___ wear a helmet.
+**Options:** A) should, B) might, C) must, D) could
+
+#### Seed 2
+**Question type:** fill
+**Stem:** Choose the modal verb that best fits the meaning: The clouds are dark, but the rain has not started. It ___ rain later.
+**Options:** A) must, B) will, C) might, D) should
+
+#### Seed 3
+**Question type:** fill
+**Stem:** Choose the modal verb that best fits the meaning: You are giving advice to a friend. You ___ begin with the easier question.
+**Options:** A) must, B) will, C) should, D) might
+
+#### Seed 4
+**Question type:** fill
+**Stem:** Choose the modal verb that best fits the meaning: The timetable is fixed. The coach ___ leave at 9 o’clock.
+**Options:** A) might, B) should, C) will, D) must
+
+#### Seed 5
+**Question type:** fill
+**Stem:** Choose the modal verb that best fits the meaning: The teacher says this is allowed. You ___ use a dictionary during the test.
+**Options:** A) must, B) may, C) might, D) will
+
+---
+
+## Family: proc2_passive_to_active
+
+- **Template ID(s):** proc2_passive_to_active
+- **Skill IDs:** active_passive
+- **Answer-spec kind:** normalisedText
+- **Question type:** rewrite
+- **Tags:** builder
+- **Unique variants (seeds 1..30):** 30
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** rewrite
+**Stem:** Rewrite the sentence in the active voice.The lantern is lifted by Amira this morning.
+**Input:** textarea — Rewritten sentence
+
+#### Seed 2
+**Question type:** rewrite
+**Stem:** Rewrite the sentence in the active voice.The map is packed by Jay after the match.
+**Input:** textarea — Rewritten sentence
+
+#### Seed 3
+**Question type:** rewrite
+**Stem:** Rewrite the sentence in the active voice.The lantern is lifted by Jay.
+**Input:** textarea — Rewritten sentence
+
+#### Seed 4
+**Question type:** rewrite
+**Stem:** Rewrite the sentence in the active voice.The map was packed by Ruby.
+**Input:** textarea — Rewritten sentence
+
+#### Seed 5
+**Question type:** rewrite
+**Stem:** Rewrite the sentence in the active voice.The picnic basket was packed by Jay after the match.
+**Input:** textarea — Rewritten sentence
+
+---
+
+## Family: proc2_pronoun_cohesion_choice
+
+- **Template ID(s):** proc2_pronoun_cohesion_choice
+- **Skill IDs:** pronouns_cohesion
+- **Answer-spec kind:** inline
+- **Question type:** choose
+- **Tags:** none
+- **Unique variants (seeds 1..30):** 30
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** choose
+**Stem:** Which version keeps the meaning clearest?
+**Options:** A) Amira gave Ava it because Amira was carrying too many bags., B) Amira gave Ava the ticket because she was carrying too many bags., C) Amira gave Ava the ticket because Amira was carrying too many bags., D) Amira gave the ticket to Ava because she was carrying too many bags.
+
+#### Seed 2
+**Question type:** choose
+**Stem:** Which version keeps the meaning clearest?
+**Options:** A) Jay gave Noah it because Noah needed it for the next lesson., B) Jay gave Noah the torch because Noah needed it for the next lesson., C) Jay gave Noah the torch because she needed it for the next lesson., D) Jay gave the torch to her because Noah needed it for the next lesson.
+
+#### Seed 3
+**Question type:** choose
+**Stem:** Which version keeps the meaning clearest?
+**Options:** A) Jay gave Ava it because Ava was leaving first., B) Jay gave Ava the ticket because Ava was leaving first., C) Jay gave Ava the ticket because she was leaving first., D) Jay gave the ticket to her because Ava was leaving first.
+
+#### Seed 4
+**Question type:** choose
+**Stem:** Which version keeps the meaning clearest?
+**Options:** A) Ruby gave Noah it because Noah was leaving first., B) Ruby gave the torch to her because Noah was leaving first., C) Ruby gave Noah the torch because she was leaving first., D) Ruby gave Noah the torch because Noah was leaving first.
+
+#### Seed 5
+**Question type:** choose
+**Stem:** Which version keeps the meaning clearest?
+**Options:** A) Jay gave the torch to her because Nora needed it for the next lesson., B) Jay gave Nora it because Nora needed it for the next lesson., C) Jay gave Nora the torch because she needed it for the next lesson., D) Jay gave Nora the torch because Nora needed it for the next lesson.
+
+---
+
+## Family: proc2_relative_clause_choice
+
+- **Template ID(s):** proc2_relative_clause_choice
+- **Skill IDs:** relative_clauses
+- **Answer-spec kind:** inline
+- **Question type:** identify
+- **Tags:** none
+- **Unique variants (seeds 1..30):** 21
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** identify
+**Stem:** Which sentence contains a relative clause?
+**Options:** A) When everyone wanted the book, it was easy to spot., B) The book that belonged to the club was easy to spot., C) The club book was easy to spot., D) The book was easy to spot outside.
+
+#### Seed 2
+**Question type:** identify
+**Stem:** Which sentence contains a relative clause?
+**Options:** A) The bag which Ben packed carefully was easy to spot., B) When everyone wanted the bag, it was easy to spot., C) The bag was easy to spot outside., D) The club bag was easy to spot.
+
+#### Seed 3
+**Question type:** identify
+**Stem:** Which sentence contains a relative clause?
+**Options:** A) When everyone wanted the book, it was easy to spot., B) The book was easy to spot outside., C) The club book was easy to spot., D) The book which Ben packed carefully was easy to spot.
+
+#### Seed 4
+**Question type:** identify
+**Stem:** Which sentence contains a relative clause?
+**Options:** A) The club bag was easy to spot., B) When everyone wanted the bag, it was easy to spot., C) The bag was easy to spot outside., D) The bag that everyone wanted was easy to spot.
+
+#### Seed 5
+**Question type:** identify
+**Stem:** Which sentence contains a relative clause?
+**Options:** A) The coat was easy to spot outside., B) When everyone wanted the coat, it was easy to spot., C) The coat that everyone wanted was easy to spot., D) The club coat was easy to spot.
+
+---
+
+## Family: proc2_standard_english_choice
+
+- **Template ID(s):** proc2_standard_english_choice
+- **Skill IDs:** standard_english
+- **Answer-spec kind:** inline
+- **Question type:** choose
+- **Tags:** none
+- **Unique variants (seeds 1..30):** 25
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** choose
+**Stem:** Which sentence is written in Standard English?
+**Options:** A) Ava don't know why the gate is locked., B) Ava doesn't know why the gate is locked., C) Ava didn't know why the gate is locked., D) Ava not know why the gate is locked.
+
+#### Seed 2
+**Question type:** choose
+**Stem:** Which sentence is written in Standard English?
+**Options:** A) Noah doesn't know where the hall is., B) Noah don't know where the hall is., C) Noah not know where the hall is., D) Noah didn't know where the hall is.
+
+#### Seed 3
+**Question type:** choose
+**Stem:** Which sentence is written in Standard English?
+**Options:** A) Ava don't know where the hall is., B) Ava not know where the hall is., C) Ava didn't know where the hall is., D) Ava doesn't know where the hall is.
+
+#### Seed 4
+**Question type:** choose
+**Stem:** Which sentence is written in Standard English?
+**Options:** A) Noah has saw the comet last night., B) Noah see the comet last night., C) Noah seen the comet last night., D) Noah saw the comet last night.
+
+#### Seed 5
+**Question type:** choose
+**Stem:** Which sentence is written in Standard English?
+**Options:** A) Nora not know the answer yet., B) Nora don't know the answer yet., C) Nora doesn't know the answer yet., D) Nora didn't know the answer yet.
+
+---
+
+## Family: proc2_standard_english_fix
+
+- **Template ID(s):** proc2_standard_english_fix
+- **Skill IDs:** standard_english
+- **Answer-spec kind:** normalisedText
+- **Question type:** fix
+- **Tags:** surgery
+- **Unique variants (seeds 1..30):** 25
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** fix
+**Stem:** Rewrite the sentence in Standard English.Ava don't know why the gate is locked.
+**Input:** textarea — Corrected sentence
+
+#### Seed 2
+**Question type:** fix
+**Stem:** Rewrite the sentence in Standard English.Noah don't know where the hall is.
+**Input:** textarea — Corrected sentence
+
+#### Seed 3
+**Question type:** fix
+**Stem:** Rewrite the sentence in Standard English.Ava don't know where the hall is.
+**Input:** textarea — Corrected sentence
+
+#### Seed 4
+**Question type:** fix
+**Stem:** Rewrite the sentence in Standard English.Noah seen the comet last night.
+**Input:** textarea — Corrected sentence
+
+#### Seed 5
+**Question type:** fix
+**Stem:** Rewrite the sentence in Standard English.Nora don't know the answer yet.
+**Input:** textarea — Corrected sentence
+
+---
+
+## Family: proc2_subject_object_identify
+
+- **Template ID(s):** proc2_subject_object_identify
+- **Skill IDs:** subject_object
+- **Answer-spec kind:** inline
+- **Question type:** identify
+- **Tags:** none
+- **Unique variants (seeds 1..30):** 30
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** identify
+**Stem:** Which words are the object in this sentence?With great care, Ava lifted the sketchbook into the hall.
+**Options:** A) Ava, B) the sketchbook, C) into the hall, D) With great care
+
+#### Seed 2
+**Question type:** identify
+**Stem:** Which word or words are the subject in this sentence?With great care, Noah packed the window into the hall.
+**Options:** A) Noah, B) With great care, C) into the hall, D) the window
+
+#### Seed 3
+**Question type:** identify
+**Stem:** Which words are the object in this sentence?With great care, Ava lifted the lantern into the hall.
+**Options:** A) into the hall, B) With great care, C) the lantern, D) Ava
+
+#### Seed 4
+**Question type:** identify
+**Stem:** Which word or words are the subject in this sentence?After the final whistle, Noah packed the lantern across the yard.
+**Options:** A) across the yard, B) the lantern, C) After the final whistle, D) Noah
+
+#### Seed 5
+**Question type:** identify
+**Stem:** Which word or words are the subject in this sentence?With great care, Nora packed the window across the yard.
+**Options:** A) Nora, B) across the yard, C) the window, D) With great care
+
+---
+
+## Family: proc2_tense_aspect_choice
+
+- **Template ID(s):** proc2_tense_aspect_choice
+- **Skill IDs:** tense_aspect
+- **Answer-spec kind:** inline
+- **Question type:** fill
+- **Tags:** none
+- **Unique variants (seeds 1..30):** 30
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** fill
+**Stem:** Choose the verb form that best completes the sentence: By the time the coach arrived, The pupils ___ the project.
+**Options:** A) finished, B) had finished, C) are finishing, D) have finished
+
+#### Seed 2
+**Question type:** fill
+**Stem:** Choose the verb form that best completes the sentence: last night, He ___ the bag.
+**Options:** A) is starting, B) started, C) had started, D) has started
+
+#### Seed 3
+**Question type:** fill
+**Stem:** Choose the verb form that best completes the sentence: last night, He ___ the project.
+**Options:** A) had started, B) has started, C) is starting, D) started
+
+#### Seed 4
+**Question type:** fill
+**Stem:** Choose the verb form that best completes the sentence: yesterday, Ava ___ the bag.
+**Options:** A) visited, B) had visited, C) has visited, D) is visiting
+
+#### Seed 5
+**Question type:** fill
+**Stem:** Choose the verb form that best completes the sentence: on Monday, Amira ___ the display.
+**Options:** A) is starting, B) started, C) had started, D) has started
+
+---
+
+## Family: proc3_apostrophe_rewrite
+
+- **Template ID(s):** proc3_apostrophe_rewrite
+- **Skill IDs:** apostrophes_possession
+- **Answer-spec kind:** normalisedText
+- **Question type:** rewrite
+- **Tags:** builder
+- **Unique variants (seeds 1..30):** 27
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** rewrite
+**Stem:** Rewrite this phrase using the correct possessive apostrophe.the coats belonging to Luca
+**Input:** text — Rewritten phrase
+
+#### Seed 2
+**Question type:** rewrite
+**Stem:** Rewrite this phrase using the correct possessive apostrophe.the tickets belonging to Noah
+**Input:** text — Rewritten phrase
+
+#### Seed 3
+**Question type:** rewrite
+**Stem:** Rewrite this phrase using the correct possessive apostrophe.the tickets belonging to Zac
+**Input:** text — Rewritten phrase
+
+#### Seed 4
+**Question type:** rewrite
+**Stem:** Rewrite this phrase using the correct possessive apostrophe.the lunchboxes belonging to Mia
+**Input:** text — Rewritten phrase
+
+#### Seed 5
+**Question type:** rewrite
+**Stem:** Rewrite this phrase using the correct possessive apostrophe.the coats belonging to the children
+**Input:** text — Rewritten phrase
+
+---
+
+## Family: proc3_clause_join_rewrite
+
+- **Template ID(s):** proc3_clause_join_rewrite
+- **Skill IDs:** clauses
+- **Answer-spec kind:** acceptedSet
+- **Question type:** rewrite
+- **Tags:** builder
+- **Unique variants (seeds 1..30):** 12
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** rewrite
+**Stem:** Combine these ideas into one sentence using because.We stayed inside.It was raining.
+**Input:** textarea — Combined sentence
+
+#### Seed 2
+**Question type:** rewrite
+**Stem:** Combine these ideas into one sentence using because.Ben hurried home.He had forgotten his kit.
+**Input:** textarea — Combined sentence
+
+#### Seed 3
+**Question type:** rewrite
+**Stem:** Combine these ideas into one sentence using because.Mia smiled.She had found the missing map.
+**Input:** textarea — Combined sentence
+
+#### Seed 4
+**Question type:** rewrite
+**Stem:** Combine these ideas into one sentence using although.Mia was tired.She finished the race.
+**Input:** textarea — Combined sentence
+
+#### Seed 5
+**Question type:** rewrite
+**Stem:** Combine these ideas into one sentence using although.The path was muddy.The walkers kept going.
+**Input:** textarea — Combined sentence
+
+---
+
+## Family: proc3_hyphen_fix_meaning
+
+- **Template ID(s):** proc3_hyphen_fix_meaning
+- **Skill IDs:** hyphen_ambiguity
+- **Answer-spec kind:** punctuationPattern
+- **Question type:** fix
+- **Tags:** qg-p5, surgery
+- **Unique variants (seeds 1..30):** 9
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** fix
+**Stem:** Rewrite the sentence with a hyphen to make the meaning clear.We saw a man eating shark near the rocks.
+**Input:** textarea — Corrected sentence
+
+#### Seed 2
+**Question type:** fix
+**Stem:** Rewrite the sentence with a hyphen to make the meaning clear.The class made a last minute poster for the hall.
+**Input:** textarea — Corrected sentence
+
+#### Seed 3
+**Question type:** fix
+**Stem:** Rewrite the sentence with a hyphen to make the meaning clear.She bought a sugar free drink for the journey.
+**Input:** textarea — Corrected sentence
+
+#### Seed 4
+**Question type:** fix
+**Stem:** Rewrite the sentence with a hyphen to make the meaning clear.The team needed a well earned break after the match.
+**Input:** textarea — Corrected sentence
+
+#### Seed 5
+**Question type:** fix
+**Stem:** Rewrite the sentence with a hyphen to make the meaning clear.Ben wore his brand new trainers to the park.
+**Input:** textarea — Corrected sentence
+
+---
+
+## Family: proc3_noun_phrase_build
+
+- **Template ID(s):** proc3_noun_phrase_build
+- **Skill IDs:** noun_phrases
+- **Answer-spec kind:** manualReviewOnly
+- **Question type:** build
+- **Tags:** builder
+- **Unique variants (seeds 1..30):** 30
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** build
+**Stem:** Use all the words to build an expanded noun phrase that could complete the sentence.Words: the / heavy / silver / bucket___ was still on the shelf.
+**Input:** text — Expanded noun phrase
+
+#### Seed 2
+**Question type:** build
+**Stem:** Use all the words to build an expanded noun phrase that could complete the sentence.Words: the / bright / blue / lantern___ rested near the gate.
+**Input:** text — Expanded noun phrase
+
+#### Seed 3
+**Question type:** build
+**Stem:** Use all the words to build an expanded noun phrase that could complete the sentence.Words: the / bright / silver / scarf___ was hidden under the bench.
+**Input:** text — Expanded noun phrase
+
+#### Seed 4
+**Question type:** build
+**Stem:** Use all the words to build an expanded noun phrase that could complete the sentence.Words: the / narrow / blue / lantern___ was hidden under the bench.
+**Input:** text — Expanded noun phrase
+
+#### Seed 5
+**Question type:** build
+**Stem:** Use all the words to build an expanded noun phrase that could complete the sentence.Words: the / bright / golden / lantern___ rested near the gate.
+**Input:** text — Expanded noun phrase
+
+---
+
+## Family: proc3_parenthesis_commas_fix
+
+- **Template ID(s):** proc3_parenthesis_commas_fix
+- **Skill IDs:** parenthesis_commas
+- **Answer-spec kind:** punctuationPattern
+- **Question type:** fix
+- **Tags:** qg-p5, surgery
+- **Unique variants (seeds 1..30):** 9
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** fix
+**Stem:** Add commas to show the parenthesis.The map in my opinion needs replacing.
+**Input:** textarea — Corrected sentence
+
+#### Seed 2
+**Question type:** fix
+**Stem:** Add commas to show the parenthesis.Our new puppy to my surprise slept through the storm.
+**Input:** textarea — Corrected sentence
+
+#### Seed 3
+**Question type:** fix
+**Stem:** Add commas to show the parenthesis.The coach without any warning changed the teams.
+**Input:** textarea — Corrected sentence
+
+#### Seed 4
+**Question type:** fix
+**Stem:** Add commas to show the parenthesis.The old bridge as everyone knew was unsafe.
+**Input:** textarea — Corrected sentence
+
+#### Seed 5
+**Question type:** fix
+**Stem:** Add commas to show the parenthesis.The visitors despite the rain stayed until the end.
+**Input:** textarea — Corrected sentence
+
+---
+
+## Family: proc3_sentence_function_choice
+
+- **Template ID(s):** proc3_sentence_function_choice
+- **Skill IDs:** sentence_functions
+- **Answer-spec kind:** inline
+- **Question type:** choose
+- **Tags:** identify
+- **Unique variants (seeds 1..30):** 28
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** choose
+**Stem:** Which sentence is a command?
+**Options:** A) Close the gate before the dog runs out., B) Why is the gate still open?, C) Our team practised in the hall today., D) How quickly the clouds moved!
+
+#### Seed 2
+**Question type:** choose
+**Stem:** Which sentence is a command?
+**Options:** A) The choir begins at nine o'clock., B) Bring the blue folder to the hall., C) Why is the gate still open?, D) How bright the lantern looked!
+
+#### Seed 3
+**Question type:** choose
+**Stem:** Which sentence is a command?
+**Options:** A) The choir begins at nine o'clock., B) How bright the lantern looked!, C) When does the match begin?, D) Close the gate before the dog runs out.
+
+#### Seed 4
+**Question type:** choose
+**Stem:** Which sentence is a grammatical exclamation?
+**Options:** A) How quickly the clouds moved!, B) Wait by the door for the coach., C) Where is the missing torch?, D) The lantern was still on the bench.
+
+#### Seed 5
+**Question type:** choose
+**Stem:** Which sentence is a command?
+**Options:** A) The path beside the stream was muddy., B) Put the wet boots on the mat., C) Why is the gate still open?, D) What a noisy drum that is!
+
+---
+
+## Family: proc3_word_class_contrast_choice
+
+- **Template ID(s):** proc3_word_class_contrast_choice
+- **Skill IDs:** word_classes
+- **Answer-spec kind:** inline
+- **Question type:** choose
+- **Tags:** identify, qg-p5
+- **Unique variants (seeds 1..30):** 9
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** choose
+**Stem:** In the sentence Afterwards, Ben hurried inside., what is the word Afterwards?
+**Options:** A) determiner, B) preposition, C) adverb, D) conjunction
+
+#### Seed 2
+**Question type:** choose
+**Stem:** In the sentence The muddy boots were by the door., what is the word The?
+**Options:** A) pronoun, B) preposition, C) determiner, D) adverb
+
+#### Seed 3
+**Question type:** choose
+**Stem:** In the sentence Those are muddy., what is the word Those?
+**Options:** A) determiner, B) conjunction, C) pronoun, D) adjective
+
+#### Seed 4
+**Question type:** choose
+**Stem:** In the sentence We stayed inside because it was raining., what is the word because?
+**Options:** A) preposition, B) adverb, C) conjunction, D) determiner
+
+#### Seed 5
+**Question type:** choose
+**Stem:** In the sentence We stayed inside during the storm., what is the word during?
+**Options:** A) conjunction, B) preposition, C) pronoun, D) adverb
+
+---
+
+## Family: qg_active_passive_choice
+
+- **Template ID(s):** qg_active_passive_choice
+- **Skill IDs:** active_passive
+- **Answer-spec kind:** exact
+- **Question type:** choose
+- **Tags:** identify, qg-p1, qg-p5
+- **Unique variants (seeds 1..30):** 9
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** choose
+**Stem:** Which sentence is written in the passive voice?
+**Options:** A) Before assembly, the caretaker locked the hall., B) The caretaker locked the hall before assembly., C) The hall was locked by the caretaker before assembly., D) The caretaker was locking the hall before assembly.
+
+#### Seed 2
+**Question type:** choose
+**Stem:** Which sentence is written in the passive voice?
+**Options:** A) Aisha painted the scenery for the play., B) For the play, Aisha painted the scenery., C) The scenery was painted by Aisha for the play., D) Aisha was painting the scenery for the play.
+
+#### Seed 3
+**Question type:** choose
+**Stem:** Which sentence is written in the passive voice?
+**Options:** A) The gardener trimmed the hedges on Monday., B) On Monday, the gardener trimmed the hedges., C) The hedges were trimmed by the gardener on Monday., D) The gardener was trimming the hedges on Monday.
+
+#### Seed 4
+**Question type:** choose
+**Stem:** Which sentence is written in the passive voice?
+**Options:** A) Noah carried the boxes to the office., B) Noah was carrying the boxes to the office., C) The boxes were carried by Noah to the office., D) To the office, Noah carried the boxes.
+
+#### Seed 5
+**Question type:** choose
+**Stem:** Which sentence is written in the passive voice?
+**Options:** A) The chef prepared the meal before noon., B) The meal was prepared by the chef before noon., C) Before noon, the chef prepared the meal., D) The chef was preparing the meal before noon.
+
+---
+
+## Family: qg_formality_classify_table
+
+- **Template ID(s):** qg_formality_classify_table
+- **Skill IDs:** formality
+- **Answer-spec kind:** multiField
+- **Question type:** classify
+- **Tags:** identify, qg-p1, qg-p5
+- **Unique variants (seeds 1..30):** 9
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** classify
+**Stem:** Classify each sentence as formal or informal.
+**Input:** table_choice — 
+
+#### Seed 2
+**Question type:** classify
+**Stem:** Classify each sentence as formal or informal.
+**Input:** table_choice — 
+
+#### Seed 3
+**Question type:** classify
+**Stem:** Classify each sentence as formal or informal.
+**Input:** table_choice — 
+
+#### Seed 4
+**Question type:** classify
+**Stem:** Classify each sentence as formal or informal.
+**Input:** table_choice — 
+
+#### Seed 5
+**Question type:** classify
+**Stem:** Classify each sentence as formal or informal.
+**Input:** table_choice — 
+
+---
+
+## Family: qg_hyphen_ambiguity_explain
+
+- **Template ID(s):** qg_hyphen_ambiguity_explain
+- **Skill IDs:** hyphen_ambiguity
+- **Answer-spec kind:** exact
+- **Question type:** explain
+- **Tags:** explain, qg-p1
+- **Unique variants (seeds 1..30):** 8
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** explain
+**Stem:** Why does the hyphen matter in small-animal hospital rather than small animal hospital?
+**Options:** A) The hyphen shows a missing letter., B) The hyphen shows that the hospital building is small., C) The hyphen shows that the hospital is for small animals., D) The hyphen marks a fronted adverbial.
+
+#### Seed 2
+**Question type:** explain
+**Stem:** Why does the hyphen matter in last-minute poster rather than last minute poster?
+**Options:** A) The hyphen shows that the poster is the final minute., B) The hyphen marks direct speech., C) The hyphen shows that 'last-minute' is one describing idea before 'poster'., D) The hyphen joins two complete clauses.
+
+#### Seed 3
+**Question type:** explain
+**Stem:** Why does the hyphen matter in well-known author rather than well known author?
+**Options:** A) The hyphen shows the author owns a well., B) The hyphen separates two independent clauses., C) The hyphen shows that 'well-known' is one describing idea before 'author'., D) The hyphen turns well into a noun.
+
+#### Seed 4
+**Question type:** explain
+**Stem:** Why does the hyphen matter in twenty-four children rather than twenty four children?
+**Options:** A) The hyphen separates two different groups of children., B) The hyphen shows possession by the number., C) The hyphen links twenty and four as a single compound number., D) The hyphen marks a question.
+
+#### Seed 5
+**Question type:** explain
+**Stem:** Why does the hyphen matter in re-cover the book rather than recover the book?
+**Options:** A) The hyphen shows that the book belongs to someone., B) The hyphen shows cover again, not get back., C) The hyphen means the same as a comma here., D) The hyphen marks a subordinate clause.
+
+---
+
+## Family: qg_modal_verb_explain
+
+- **Template ID(s):** qg_modal_verb_explain
+- **Skill IDs:** modal_verbs
+- **Answer-spec kind:** exact
+- **Question type:** explain
+- **Tags:** explain, qg-p1
+- **Unique variants (seeds 1..30):** 8
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** explain
+**Stem:** In this sentence, what does the modal verb might show?The clouds are dark, so it might rain later.
+**Options:** A) It names the person doing the action., B) It shows a fixed rule., C) It shows possibility, not certainty., D) It shows the action is happening now.
+
+#### Seed 2
+**Question type:** explain
+**Stem:** In this sentence, what does the modal verb should show?You should check your work before handing it in.
+**Options:** A) It shows something is impossible., B) It turns the verb into the past tense., C) It gives advice., D) It marks direct speech.
+
+#### Seed 3
+**Question type:** explain
+**Stem:** In this sentence, what does the modal verb may show?May I borrow the scissors, please?
+**Options:** A) It shows that the action is certain to happen., B) It shows that the scissors belong to the speaker., C) It asks for permission politely., D) It names the month of the year.
+
+#### Seed 4
+**Question type:** explain
+**Stem:** In this sentence, what does the modal verb could show?She could swim before she started school.
+**Options:** A) It shows a future obligation., B) It makes the sentence passive., C) It shows past ability., D) It replaces the subject she.
+
+#### Seed 5
+**Question type:** explain
+**Stem:** In this sentence, what does the modal verb will show?The package will arrive tomorrow morning.
+**Options:** A) It shows that the action is only a weak possibility., B) It shows certainty about a future event., C) It turns the sentence into a command., D) It gives advice about what to do.
+
+---
+
+## Family: qg_p3_active_passive_explain
+
+- **Template ID(s):** qg_p3_active_passive_explain
+- **Skill IDs:** active_passive
+- **Answer-spec kind:** exact
+- **Question type:** explain
+- **Tags:** explain, qg-p3
+- **Unique variants (seeds 1..30):** 8
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** explain
+**Stem:** Why is this sentence active?The caretaker cleaned the hall.
+**Options:** A) It is active because it hides who did the cleaning., B) It is active because the hall comes first., C) The doer, the caretaker, is the subject before the verb., D) It is active because it uses was plus a past participle.
+
+#### Seed 2
+**Question type:** explain
+**Stem:** Why might a writer choose the passive voice here?The window was broken during lunch.
+**Options:** A) It proves that the action is still happening now., B) It shows that the window did the breaking., C) It foregrounds the broken window and does not name the doer., D) It makes the sentence a command.
+
+#### Seed 3
+**Question type:** explain
+**Stem:** Why is this not passive voice?Maya was carrying the heavy box.
+**Options:** A) It is passive because every sentence with was is passive., B) It is passive because the action happened in the past., C) Was carrying is progressive; Maya is still the doer before the verb., D) It is passive because box is an object.
+
+#### Seed 4
+**Question type:** explain
+**Stem:** Why does this passive sentence keep the meaning of the active one?The scenery was painted by Aisha.
+**Options:** A) The scenery becomes the person doing the painting., B) The tense changes from past to future., C) Aisha is still the doer, but the scenery has been moved to the subject position., D) The sentence becomes a question about Aisha.
+
+#### Seed 5
+**Question type:** explain
+**Stem:** Why is this passive sentence missing the doer?The medals were presented after assembly.
+**Options:** A) The medals must be the doers because they come first., B) Passive voice can leave out the by-phrase when the doer is unknown or less important., C) The sentence is informal because the doer is hidden., D) The sentence is active because no by-phrase appears.
+
+---
+
+## Family: qg_p3_apostrophe_possession_explain
+
+- **Template ID(s):** qg_p3_apostrophe_possession_explain
+- **Skill IDs:** apostrophes_possession
+- **Answer-spec kind:** exact
+- **Question type:** explain
+- **Tags:** explain, qg-p3
+- **Unique variants (seeds 1..30):** 8
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** explain
+**Stem:** Why is the apostrophe after the s?the girls' bags
+**Options:** A) The apostrophe turns bags into a verb., B) One girl owns the bags, so the apostrophe must come after s., C) More than one girl owns the bags, and girls is a regular plural ending in s., D) The apostrophe shows the bags are missing letters.
+
+#### Seed 2
+**Question type:** explain
+**Stem:** Why is this apostrophe + s?the children's coats
+**Options:** A) Children is singular, so only one child owns the coats., B) The apostrophe shows a contraction of children is., C) Children is an irregular plural that does not end in s, so it takes apostrophe + s., D) The apostrophe comes after an s that is missing from children.
+
+#### Seed 3
+**Question type:** explain
+**Stem:** Why does this phrase show possession, not omission?the teacher's desk
+**Options:** A) The apostrophe replaces letters from teacher is., B) The apostrophe marks a direct speech break., C) The apostrophe shows the desk belongs to the teacher., D) The apostrophe makes desk plural.
+
+#### Seed 4
+**Question type:** explain
+**Stem:** Why is 'the boys' changing room' plural possession?the boys' changing room
+**Options:** A) The room belongs to one boy, so the apostrophe follows the plural s., B) The apostrophe shows that changing is missing letters., C) The room belongs to more than one boy, so the apostrophe follows the plural s., D) The apostrophe is needed because room is singular.
+
+#### Seed 5
+**Question type:** explain
+**Stem:** Why is 'the dog's bowls' singular possession?the dog's bowls
+**Options:** A) More than one dog owns one bowl, so the apostrophe is before s., B) One dog owns more than one bowl, so the apostrophe is before s in dog's., C) The apostrophe shows dog is a verb., D) The apostrophe belongs after bowls because bowls is plural.
+
+---
+
+## Family: qg_p3_clauses_explain
+
+- **Template ID(s):** qg_p3_clauses_explain
+- **Skill IDs:** clauses
+- **Answer-spec kind:** exact
+- **Question type:** explain
+- **Tags:** explain, qg-p3
+- **Unique variants (seeds 1..30):** 8
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** explain
+**Stem:** Why does the conjunction 'although' fit this sentence?Although Mia was tired, she finished the race.
+**Options:** A) It shows that the two clauses mean exactly the same thing., B) It joins two noun phrases in a list., C) It introduces a subordinate clause showing contrast with the main clause., D) It introduces direct speech.
+
+#### Seed 2
+**Question type:** explain
+**Stem:** Why is this a main clause?The class cheered when the curtain rose.Focus: The class cheered
+**Options:** A) It is main because it begins with when., B) It is main because it only adds extra information about a noun., C) It can stand alone as a complete clause in the intended meaning., D) It is main because it has no verb.
+
+#### Seed 3
+**Question type:** explain
+**Stem:** Why is the clause beginning with 'if' subordinate?If the gate is locked, wait by the office.
+**Options:** A) It is subordinate because it is a question., B) It is subordinate because it has no subject or verb., C) It gives a condition and needs the main clause to complete the instruction., D) It is subordinate because it contains direct speech.
+
+#### Seed 4
+**Question type:** explain
+**Stem:** Why does 'and' join these clauses safely?The bell rang and the pupils lined up.
+**Options:** A) It makes the second clause subordinate., B) It introduces a relative clause about bell., C) It links two related main clauses of equal importance., D) It shows possession between the two nouns.
+
+#### Seed 5
+**Question type:** explain
+**Stem:** Why is this not a complete sentence by itself?When the coach arrived
+**Options:** A) It is complete because it starts with When., B) It is a subordinate time clause that leaves the main action unfinished., C) It is complete because coach is a noun., D) It is complete because it has no conjunction.
+
+---
+
+## Family: qg_p3_formality_explain
+
+- **Template ID(s):** qg_p3_formality_explain
+- **Skill IDs:** formality
+- **Answer-spec kind:** exact
+- **Question type:** explain
+- **Tags:** explain, qg-p3
+- **Unique variants (seeds 1..30):** 8
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** explain
+**Stem:** Why is this sentence informal?Hang on a minute while we get started.
+**Options:** A) It is informal because it contains a noun phrase., B) It is informal because it uses Standard English., C) It uses chatty wording that suits speech more than formal writing., D) It is informal because it has no subject.
+
+#### Seed 2
+**Question type:** explain
+**Stem:** Why is 'request' the more formal choice?We request that pupils return the form by Friday.
+**Options:** A) Request is more formal because it is a modal verb., B) Request is more formal because it makes the sentence a question., C) Request is more precise and formal than ask for in this context., D) Request is more formal because it is shorter.
+
+#### Seed 3
+**Question type:** explain
+**Stem:** Why is this version more formal?The equipment was inspected before use.
+**Options:** A) It is more formal because passive voice is always required., B) It is more formal because it uses the word got., C) It uses impersonal, precise wording instead of chatty phrasing., D) It is more formal because it has fewer syllables.
+
+#### Seed 4
+**Question type:** explain
+**Stem:** Why is this ending too informal for an official letter?Send it back by Friday, OK?
+**Options:** A) OK is too formal for any letter., B) The sentence is informal because Friday is a noun., C) OK is a chatty tag that does not suit an official letter., D) The sentence is informal because it has an object.
+
+#### Seed 5
+**Question type:** explain
+**Stem:** Why is this not automatically formal?The club got set up last year.
+**Options:** A) It is formal because every past-tense sentence is formal., B) Got set up is conversational; established would be more formal., C) It is formal because got is always the most precise verb., D) It is formal because club is a noun.
+
+---
+
+## Family: qg_p3_noun_phrases_explain
+
+- **Template ID(s):** qg_p3_noun_phrases_explain
+- **Skill IDs:** noun_phrases
+- **Answer-spec kind:** exact
+- **Question type:** explain
+- **Tags:** explain, qg-p3
+- **Unique variants (seeds 1..30):** 8
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** explain
+**Stem:** Why is this an expanded noun phrase?the book with a torn cover
+**Options:** A) It is direct speech because it names an object., B) It is a sentence because it has a subject and a verb., C) It is centred on the noun book and expanded by the phrase with a torn cover., D) It is a fronted adverbial because it starts with the.
+
+#### Seed 2
+**Question type:** explain
+**Stem:** Why is this not a noun phrase?quickly opened the gate
+**Options:** A) It is a noun phrase because it has four words., B) It is a determiner phrase because it ends with gate., C) It contains a verb phrase, so it is part of a clause rather than a noun phrase., D) It is a noun phrase because quickly describes a noun.
+
+#### Seed 3
+**Question type:** explain
+**Stem:** Why is the underlined group a noun phrase?The nervous goalkeeper from Year 6 saved the penalty.Focus: The nervous goalkeeper from Year 6
+**Options:** A) The whole group is the verb phrase., B) It is an adverbial because it tells where the saving happened., C) The whole group is centred on the noun goalkeeper., D) It is a subordinate clause because it has extra information.
+
+#### Seed 4
+**Question type:** explain
+**Stem:** Why is this an expanded noun phrase rather than a clause?the lighthouse on the cliff
+**Options:** A) It is a clause because every phrase with on has a verb., B) It is a clause because cliff is a subject., C) It has no verb; it is a noun phrase centred on lighthouse., D) It is a sentence because it begins with the.
+
+#### Seed 5
+**Question type:** explain
+**Stem:** Why is this not the full noun phrase?the old oak tree beside the libraryFocus: old oak
+**Options:** A) Old oak is the full noun phrase because adjectives can stand alone here., B) Old oak describes the noun, but the full noun phrase must include tree., C) Old oak is the object because it comes before tree., D) Old oak is a clause because it has two words.
+
+---
+
+## Family: qg_p3_parenthesis_commas_explain
+
+- **Template ID(s):** qg_p3_parenthesis_commas_explain
+- **Skill IDs:** parenthesis_commas
+- **Answer-spec kind:** exact
+- **Question type:** explain
+- **Tags:** explain, qg-p3
+- **Unique variants (seeds 1..30):** 8
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** explain
+**Stem:** Why do the dashes mark parenthesis here?The hall - usually quiet - was full of music.
+**Options:** A) The dashes introduce a list after a complete clause., B) The dashes join two equal main clauses., C) Usually quiet is extra information inserted into the sentence., D) The dashes show plural possession.
+
+#### Seed 2
+**Question type:** explain
+**Stem:** Why do the brackets mark parenthesis here?The trip (which had been delayed) finally began.
+**Options:** A) The brackets show direct speech., B) The brackets show that trip is plural., C) The bracketed clause adds extra information about the trip., D) The brackets make which into a question word.
+
+#### Seed 3
+**Question type:** explain
+**Stem:** Why are these commas not marking parenthesis?We packed pencils, rulers, glue and card.
+**Options:** A) They mark a relative clause about pencils., B) They show that the nouns own the card., C) The commas separate items in a list, not removable extra information., D) They show direct speech punctuation.
+
+#### Seed 4
+**Question type:** explain
+**Stem:** Why is a pair of commas needed here?The museum, which opened last year, is near the river.
+**Options:** A) Only one comma is needed after museum because the rest is a list., B) The commas show that the museum owns the river., C) The parenthetical relative clause sits in the middle of the main sentence., D) The commas turn the sentence into direct speech.
+
+#### Seed 5
+**Question type:** explain
+**Stem:** Why is the phrase after the comma not parenthesis?After the storm, the path was muddy.
+**Options:** A) It is parenthesis because every comma marks parenthesis., B) After the storm is a fronted adverbial telling when, not extra information in the middle., C) It is direct speech because the comma comes early., D) It is parenthesis because storm is a noun.
+
+---
+
+## Family: qg_p3_pronouns_cohesion_explain
+
+- **Template ID(s):** qg_p3_pronouns_cohesion_explain
+- **Skill IDs:** pronouns_cohesion
+- **Answer-spec kind:** exact
+- **Question type:** explain
+- **Tags:** explain, qg-p3
+- **Unique variants (seeds 1..30):** 8
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** explain
+**Stem:** Why is the pronoun 'she' unclear here?Maya gave Priya the note because she needed it.
+**Options:** A) She is unclear because it is an adjective., B) She clearly refers to the note., C) She could refer to Maya or Priya, so the reference is ambiguous., D) She is unclear because pronouns can never refer to people.
+
+#### Seed 2
+**Question type:** explain
+**Stem:** Why is repeating 'the trophy' clearer here?The shelf was above the trophy, but the trophy was too heavy to move.
+**Options:** A) Repeating the noun always makes writing more formal., B) The noun must be repeated because trophies are plural., C) Repeating the trophy avoids confusing it with the shelf., D) A pronoun would be clearer because it could only mean shelf.
+
+#### Seed 3
+**Question type:** explain
+**Stem:** Why does 'they' work in this sentence?The pupils packed the benches after they finished lunch.
+**Options:** A) They refers to the benches because benches are nearby., B) They makes the sentence a direct question., C) They clearly refers to the pupils, the group who finished lunch., D) They is wrong because pupils is singular.
+
+#### Seed 4
+**Question type:** explain
+**Stem:** Why is 'this' cohesive here?The gate was locked. This delayed the match.
+**Options:** A) This can only refer to a person., B) This refers forward to the match only., C) This refers back to the whole situation of the gate being locked., D) This is a verb because it shows an action.
+
+#### Seed 5
+**Question type:** explain
+**Stem:** Why is the pronoun 'him' clear here?Oliver dropped the baton, so Sam passed it back to him.
+**Options:** A) Him refers to the baton because it receives the action., B) Him refers to Oliver, the person who dropped the baton., C) Him is unclear because it is plural., D) Him refers to Sam because Sam is nearest to the pronoun.
+
+---
+
+## Family: qg_p3_relative_clauses_explain
+
+- **Template ID(s):** qg_p3_relative_clauses_explain
+- **Skill IDs:** relative_clauses
+- **Answer-spec kind:** exact
+- **Question type:** explain
+- **Tags:** explain, qg-p3
+- **Unique variants (seeds 1..30):** 8
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** explain
+**Stem:** Why is the clause 'which stood by the window' a relative clause?The plant which stood by the window needed water.
+**Options:** A) It is an adverbial telling how the plant needed water., B) It is a question because it starts with which., C) It adds information about the noun plant., D) It shows possession by the window.
+
+#### Seed 2
+**Question type:** explain
+**Stem:** Why is the clause 'that everyone wanted' a relative clause?The book that everyone wanted was on the shelf.
+**Options:** A) It gives the time when the book was on the shelf., B) It is a main clause that can stand alone here., C) It identifies the noun book more precisely., D) It is a command telling everyone to want the book.
+
+#### Seed 3
+**Question type:** explain
+**Stem:** Why is this not a relative clause?When the show ended, the actors bowed.
+**Options:** A) It is relative because every clause at the start is relative., B) It is relative because it tells who bowed., C) When the show ended is a time clause, not extra information about a noun., D) It is relative because it contains the noun show.
+
+#### Seed 4
+**Question type:** explain
+**Stem:** Why does 'whose' introduce a relative clause here?The girl whose boots were muddy waited outside.
+**Options:** A) Whose introduces a direct question here., B) The clause tells where the girl waited., C) The clause adds information about the girl by saying whose boots were muddy., D) The clause is a command about cleaning boots.
+
+#### Seed 5
+**Question type:** explain
+**Stem:** Why does this relative clause need commas?Mr Patel, who runs the chess club, opened the hall.
+**Options:** A) The commas show a list of teachers., B) The clause adds extra information about Mr Patel and can be lifted out., C) The commas mark possession by the chess club., D) The commas show that the sentence is a question.
+
+---
+
+## Family: qg_p3_sentence_functions_explain
+
+- **Template ID(s):** qg_p3_sentence_functions_explain
+- **Skill IDs:** sentence_functions
+- **Answer-spec kind:** exact
+- **Question type:** explain
+- **Tags:** explain, qg-p3
+- **Unique variants (seeds 1..30):** 8
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** explain
+**Stem:** Why is this sentence a question?Where did the caretaker leave the keys?
+**Options:** A) It is a grammatical exclamation because it ends with a question mark., B) It tells the caretaker to leave the keys somewhere., C) It asks for information directly, so it is a question., D) It gives information about where the keys are.
+
+#### Seed 2
+**Question type:** explain
+**Stem:** Why is this sentence a statement?The caretaker left the keys beside the office door.
+**Options:** A) It asks where the keys are., B) It begins with What or How to show strong feeling., C) It gives information, so it is a statement., D) It orders someone to move the keys.
+
+#### Seed 3
+**Question type:** explain
+**Stem:** Why is this a grammatical exclamation?What an enormous wave that was!
+**Options:** A) It is a question because it uses the word what., B) It is a statement because it gives calm information only., C) It begins with What and expresses strong feeling about a noun phrase., D) It is a command because it tells someone to look at the wave.
+
+#### Seed 4
+**Question type:** explain
+**Stem:** Why is this a statement rather than a question?I wonder where the missing torch is.
+**Options:** A) It is a question because it contains the word where., B) It is a command because it tells the reader to find the torch., C) It reports someone wondering; it does not ask the reader directly., D) It is an exclamation because it shows strong feeling with What or How.
+
+#### Seed 5
+**Question type:** explain
+**Stem:** Why is this not a grammatical exclamation?The drums sounded very loud!
+**Options:** A) Any sentence with an exclamation mark is a grammatical exclamation., B) It shows excitement, but it does not use the What or How exclamation pattern., C) It is a question because it ends with strong punctuation., D) It is a command because the drums are making noise.
+
+---
+
+## Family: qg_p3_speech_punctuation_explain
+
+- **Template ID(s):** qg_p3_speech_punctuation_explain
+- **Skill IDs:** speech_punctuation
+- **Answer-spec kind:** exact
+- **Question type:** explain
+- **Tags:** explain, qg-p3
+- **Unique variants (seeds 1..30):** 8
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** explain
+**Stem:** Why is there a comma before the closing speech mark?"I found the map," said Priya.
+**Options:** A) The comma marks a list of speakers., B) The comma shows that map is plural., C) The comma separates the spoken words from the reporting clause., D) The comma belongs outside the speech marks in this pattern.
+
+#### Seed 2
+**Question type:** explain
+**Stem:** Why is there a comma after the reporting clause?Priya said, "I found the map."
+**Options:** A) The comma shows that Priya is in a list., B) The comma shows plural possession., C) The comma introduces the direct speech after the reporting clause., D) The comma marks a subordinate clause beginning with I.
+
+#### Seed 3
+**Question type:** explain
+**Stem:** Why is the exclamation mark inside the speech marks?"Watch out!" shouted Sam.
+**Options:** A) The exclamation mark belongs after shouted because Sam is loud., B) The exclamation mark shows that Sam owns the warning., C) The spoken words are an exclamation or warning, so the mark belongs inside., D) The exclamation mark turns shouted into a noun.
+
+#### Seed 4
+**Question type:** explain
+**Stem:** Why does the spoken sentence start with a capital letter?Mum asked, "Are you ready?"
+**Options:** A) Every word after a comma must have a capital letter., B) Are is capitalised because it is a noun., C) The direct speech starts a new spoken sentence., D) The capital letter shows possession.
+
+#### Seed 5
+**Question type:** explain
+**Stem:** Why is the full stop not outside the speech marks?"The bus is here."
+**Options:** A) The full stop belongs outside because speech marks are only decoration., B) The full stop finishes the spoken sentence, so it belongs inside the speech marks., C) The full stop should be replaced by an apostrophe., D) The full stop belongs before the opening speech mark.
+
+---
+
+## Family: qg_p3_subject_object_explain
+
+- **Template ID(s):** qg_p3_subject_object_explain
+- **Skill IDs:** subject_object
+- **Answer-spec kind:** exact
+- **Question type:** explain
+- **Tags:** explain, qg-p3
+- **Unique variants (seeds 1..30):** 8
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** explain
+**Stem:** Why is 'the soup' the object?The chef tasted the soup.
+**Options:** A) The soup is an adverbial because it tells when., B) The soup does the action., C) The soup receives the action of tasting., D) The soup is the subject because it is at the end.
+
+#### Seed 2
+**Question type:** explain
+**Stem:** Why is 'Before lunch' not the subject?Before lunch, Aisha packed the kit.
+**Options:** A) Before lunch is the subject because it comes first., B) Before lunch is the verb phrase., C) Before lunch is an adverbial; Aisha does the action., D) Before lunch is the object because it receives packing.
+
+#### Seed 3
+**Question type:** explain
+**Stem:** Why is the expanded noun phrase the subject?The tall goalkeeper with red gloves caught the ball.
+**Options:** A) Only red gloves can be the subject., B) The ball is the subject because it is affected by the verb., C) The whole noun phrase names who did the catching., D) The whole noun phrase is the object because it is long.
+
+#### Seed 4
+**Question type:** explain
+**Stem:** Why is 'the trophy' the subject in this passive sentence?The trophy was lifted by Aisha.
+**Options:** A) Aisha must be the subject because she is the doer., B) The trophy is the object because every affected thing is always the object., C) The trophy is before the verb phrase and the sentence is about what happened to it., D) By Aisha is the subject because it comes after by.
+
+#### Seed 5
+**Question type:** explain
+**Stem:** Why is 'the letters' the object?The pupils sorted the letters carefully.
+**Options:** A) The letters are the subject because they are plural., B) The letters receive the action of sorting., C) The letters are the verb because sorting happens to them., D) The letters are an adverbial because they tell how.
+
+---
+
+## Family: qg_p3_tense_aspect_explain
+
+- **Template ID(s):** qg_p3_tense_aspect_explain
+- **Skill IDs:** tense_aspect
+- **Answer-spec kind:** exact
+- **Question type:** explain
+- **Tags:** explain, qg-p3
+- **Unique variants (seeds 1..30):** 8
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** explain
+**Stem:** Why is 'had packed' past perfect?By the time the coach arrived, Sam had packed the bags.
+**Options:** A) It is simple past because had is always optional., B) It is present perfect because it uses have in the present., C) It shows one past action completed before another past action., D) It is progressive because packing was in progress at that moment.
+
+#### Seed 2
+**Question type:** explain
+**Stem:** Why is 'was reading' past progressive?Maya was reading when the bell rang.
+**Options:** A) It shows an action completed before another past action., B) It is passive because it uses was., C) It shows an action that was in progress in the past., D) It is present tense because reading ends in ing.
+
+#### Seed 3
+**Question type:** explain
+**Stem:** Why is 'are building' present progressive?The pupils are building a model bridge.
+**Options:** A) It shows an action finished yesterday., B) It is a modal verb phrase showing obligation., C) It shows an action in progress now using are plus an -ing verb., D) It is past perfect because it has two verbs.
+
+#### Seed 4
+**Question type:** explain
+**Stem:** Why is 'walked' simple past here?Yesterday, the team walked to the museum.
+**Options:** A) It is present perfect because it happened before now., B) It is progressive because the team kept moving., C) It uses a past verb form for a finished action at a finished time., D) It is passive because the team receives the action.
+
+#### Seed 5
+**Question type:** explain
+**Stem:** Why is 'have been practising' a perfect progressive form?We have been practising all week.
+**Options:** A) It is simple present because the action is a habit only., B) It links earlier practice to now and shows the action continuing over time., C) It is simple past because all week is always finished., D) It is passive because it uses been.
+
+---
+
+## Family: qg_p3_word_classes_explain
+
+- **Template ID(s):** qg_p3_word_classes_explain
+- **Skill IDs:** word_classes
+- **Answer-spec kind:** exact
+- **Question type:** explain
+- **Tags:** explain, qg-p3
+- **Unique variants (seeds 1..30):** 8
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** explain
+**Stem:** Why is the word 'carefully' an adverb here?Maya carefully folded the map.
+**Options:** A) It joins the two parts of the sentence., B) It names the person doing the folding., C) It modifies the verb folded by saying how Maya folded., D) It comes before a noun to identify it.
+
+#### Seed 2
+**Question type:** explain
+**Stem:** Why is the word 'before' a preposition here?The pupils waited before assembly.
+**Options:** A) It replaces the noun pupils., B) It names the action of waiting., C) It begins the phrase before assembly and shows a time relationship., D) It describes the noun assembly.
+
+#### Seed 3
+**Question type:** explain
+**Stem:** Why is the word 'because' a conjunction here?Luca whispered because the baby was asleep.
+**Options:** A) It describes the noun baby., B) It replaces the name Luca., C) It joins the reason clause to the main clause., D) It shows where Luca whispered.
+
+#### Seed 4
+**Question type:** explain
+**Stem:** Why is the word 'Those' a determiner here?Those birds nested under the roof.
+**Options:** A) It tells how the birds nested., B) It names the action in the sentence., C) It comes before the noun birds and helps identify which birds., D) It joins two clauses together.
+
+#### Seed 5
+**Question type:** explain
+**Stem:** Why is the word 'it' a pronoun here?Aisha found the compass and put it in her bag.
+**Options:** A) It describes the compass., B) It replaces the noun phrase the compass., C) It joins the two clauses because it means and., D) It shows the time of the action.
+
+---
+
+## Family: qg_p4_adverbial_clause_boundary_transfer
+
+- **Template ID(s):** qg_p4_adverbial_clause_boundary_transfer
+- **Skill IDs:** adverbials, boundary_punctuation, clauses
+- **Answer-spec kind:** exact
+- **Question type:** choose
+- **Tags:** mixed-transfer, qg-p4
+- **Unique variants (seeds 1..30):** 8
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** choose
+**Stem:** Which option correctly joins a fronted adverbial to a main clause AND uses the right boundary punctuation?before the bell rang / the children lined up quietly
+**Options:** A) Before the bell rang; the children lined up quietly., B) Before the bell rang the children lined up quietly., C) Before the bell rang, the children lined up quietly., D) Before, the bell rang the children lined up quietly.
+
+#### Seed 2
+**Question type:** choose
+**Stem:** Which option correctly punctuates the sentence with a fronted adverbial AND identifies the main clause boundary?after the storm cleared / we inspected the damage
+**Options:** A) After the storm cleared we inspected the damage., B) After the storm cleared: we inspected the damage., C) After the storm cleared, we inspected the damage., D) After the storm, cleared we inspected the damage.
+
+#### Seed 3
+**Question type:** choose
+**Stem:** Which option places the comma correctly when the adverbial clause appears at the front?although the path was icy / nobody slipped
+**Options:** A) Although the path was icy nobody slipped., B) Although the path was icy; nobody slipped., C) Although the path was icy, nobody slipped., D) Although, the path was icy nobody slipped.
+
+#### Seed 4
+**Question type:** choose
+**Stem:** Which option uses the correct boundary punctuation when two independent clauses follow a fronted adverbial?during the assembly / the head announced sports day; parents are invited
+**Options:** A) During the assembly the head announced sports day; parents are invited., B) During the assembly, the head announced sports day, parents are invited., C) During the assembly, the head announced sports day; parents are invited., D) During the assembly; the head announced sports day; parents are invited.
+
+#### Seed 5
+**Question type:** choose
+**Stem:** Which option correctly punctuates the fronted adverbial and the clause boundary after it?when the museum opened / visitors rushed to the dinosaur hall
+**Options:** A) When the museum opened visitors rushed to the dinosaur hall., B) When the museum opened, visitors rushed to the dinosaur hall., C) When the museum opened; visitors rushed to the dinosaur hall., D) When, the museum opened visitors rushed to the dinosaur hall.
+
+---
+
+## Family: qg_p4_cohesion_formality_transfer
+
+- **Template ID(s):** qg_p4_cohesion_formality_transfer
+- **Skill IDs:** formality, pronouns_cohesion
+- **Answer-spec kind:** exact
+- **Question type:** choose
+- **Tags:** mixed-transfer, qg-p4
+- **Unique variants (seeds 1..30):** 8
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** choose
+**Stem:** Which option replaces the repeated noun with a pronoun AND maintains formal register?The council has approved the plans. The council will begin work in September.
+**Options:** A) The council has approved the plans. Them lot will begin work in September., B) The council has approved the plans. They're gonna start work in September., C) The council has approved the plans. It will begin work in September., D) The council has approved the plans. The council will begin work in September.
+
+#### Seed 2
+**Question type:** choose
+**Stem:** Which option improves cohesion AND keeps the writing formal?The museum opens at nine. The museum closes at five. Visitors must book online.
+**Options:** A) The museum opens at nine. It shuts at five. Visitors have gotta book online., B) It opens at nine and shuts at five. People gotta book online., C) The museum opens at nine and closes at five. Visitors must book online., D) The museum opens at nine. The museum closes at five. You lot must book online.
+
+#### Seed 3
+**Question type:** choose
+**Stem:** Which option uses a pronoun for cohesion AND keeps formal vocabulary?Dr Patel presented the findings. Dr Patel explained the next steps.
+**Options:** A) Dr Patel presented the findings. She then chatted about what's next., B) Patel presented the findings. She banged on about what comes next., C) Dr Patel presented the findings. She then explained the next steps., D) Dr Patel presented the findings. Dr Patel explained the next steps.
+
+#### Seed 4
+**Question type:** choose
+**Stem:** Which option links the ideas cohesively AND keeps a formal tone?The project was completed on time. The project received praise from the governors.
+**Options:** A) The project was done on time and the governors were well chuffed., B) The project was completed on time. The project received praise from the governors., C) The project was completed on time and received praise from the governors., D) It got done on time and the governors loved it.
+
+#### Seed 5
+**Question type:** choose
+**Stem:** Which option improves pronoun cohesion AND keeps the tone suitable for a school report?James has improved his reading. James now reads chapter books independently.
+**Options:** A) James has improved his reading. The lad now reads chapter books on his own., B) James has improved his reading. He now reads chapter books independently., C) He's got better at reading. He reads chapter books by himself now., D) James has improved his reading. James now reads chapter books independently.
+
+---
+
+## Family: qg_p4_possession_hyphen_clarity_transfer
+
+- **Template ID(s):** qg_p4_possession_hyphen_clarity_transfer
+- **Skill IDs:** apostrophes_possession, hyphen_ambiguity
+- **Answer-spec kind:** exact
+- **Question type:** choose
+- **Tags:** mixed-transfer, qg-p4
+- **Unique variants (seeds 1..30):** 8
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** choose
+**Stem:** Which option correctly uses both the possessive apostrophe AND a hyphen to avoid ambiguity?The well known author's latest book topped the charts.
+**Options:** A) The well-known authors' latest book topped the charts., B) The well known authors latest book topped the charts., C) The well-known author's latest book topped the charts., D) The well known author's latest book topped the charts.
+
+#### Seed 2
+**Question type:** choose
+**Stem:** Which option uses the apostrophe for possession AND the hyphen to clarify meaning?The children's long awaited trip finally arrived.
+**Options:** A) The childrens long-awaited trip finally arrived., B) The childrens' long-awaited trip finally arrived., C) The children's long-awaited trip finally arrived., D) The children's long awaited trip finally arrived.
+
+#### Seed 3
+**Question type:** choose
+**Stem:** Which option correctly shows plural possession AND uses a hyphen to avoid misreading?The players hard earned medals were displayed in the cabinet.
+**Options:** A) The player's hard-earned medals were displayed in the cabinet., B) The players hard-earned medals were displayed in the cabinet., C) The players' hard-earned medals were displayed in the cabinet., D) The players' hard earned medals were displayed in the cabinet.
+
+#### Seed 4
+**Question type:** choose
+**Stem:** Which option uses both the possessive apostrophe AND the hyphen correctly?The school's state of the art science lab impressed visitors.
+**Options:** A) The schools state-of-the-art science lab impressed visitors., B) The school's state of the art science lab impressed visitors., C) The school's state-of-the-art science lab impressed visitors., D) The schools' state-of-the-art science lab impressed visitors.
+
+#### Seed 5
+**Question type:** choose
+**Stem:** Which option uses the possessive apostrophe AND the hyphen to prevent a misreading?My sister's hand painted vase sits on the shelf.
+**Options:** A) My sisters hand-painted vase sits on the shelf., B) My sister's hand-painted vase sits on the shelf., C) My sisters' hand-painted vase sits on the shelf., D) My sister's hand painted vase sits on the shelf.
+
+---
+
+## Family: qg_p4_relative_parenthesis_transfer
+
+- **Template ID(s):** qg_p4_relative_parenthesis_transfer
+- **Skill IDs:** parenthesis_commas, relative_clauses
+- **Answer-spec kind:** exact
+- **Question type:** choose
+- **Tags:** mixed-transfer, qg-p4
+- **Unique variants (seeds 1..30):** 8
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** choose
+**Stem:** Which option correctly adds a relative clause as parenthesis with commas?The oak tree ___ has stood for two hundred years.
+**Options:** A) The oak tree which, was planted by the village founders, has stood for two hundred years., B) The oak tree which was planted by the village founders has stood for two hundred years., C) The oak tree, which was planted by the village founders, has stood for two hundred years., D) The oak tree, which was planted by the village founders has stood for two hundred years.
+
+#### Seed 2
+**Question type:** choose
+**Stem:** Which option correctly punctuates the non-defining relative clause as parenthesis?Mrs Patel ___ organised the whole event.
+**Options:** A) Mrs Patel who teaches Year 6 organised the whole event., B) Mrs Patel who, teaches Year 6, organised the whole event., C) Mrs Patel, who teaches Year 6, organised the whole event., D) Mrs Patel, who teaches Year 6 organised the whole event.
+
+#### Seed 3
+**Question type:** choose
+**Stem:** Which option correctly uses commas around the relative clause as parenthesis?The River Thames ___ flows through London.
+**Options:** A) The River Thames which is over 200 miles long flows through London., B) The River Thames which is over 200 miles long, flows through London., C) The River Thames, which is over 200 miles long, flows through London., D) The River Thames, which is over 200 miles long flows through London.
+
+#### Seed 4
+**Question type:** choose
+**Stem:** Which option correctly places the relative clause within commas?The head teacher ___ congratulated the team.
+**Options:** A) The head teacher who had been watching from the sideline congratulated the team., B) The head teacher, who had been watching from the sideline congratulated the team., C) The head teacher, who had been watching from the sideline, congratulated the team., D) The head teacher who had been watching, from the sideline, congratulated the team.
+
+#### Seed 5
+**Question type:** choose
+**Stem:** Which option correctly uses parenthesis commas for the relative clause?The school hall ___ was packed with parents.
+**Options:** A) The school hall which had been decorated overnight was packed with parents., B) The school hall, which had been decorated overnight, was packed with parents., C) The school hall which had been decorated, overnight, was packed with parents., D) The school hall, which had been decorated overnight was packed with parents.
+
+---
+
+## Family: qg_p4_sentence_speech_transfer
+
+- **Template ID(s):** qg_p4_sentence_speech_transfer
+- **Skill IDs:** sentence_functions, speech_punctuation
+- **Answer-spec kind:** exact
+- **Question type:** choose
+- **Tags:** mixed-transfer, qg-p4
+- **Unique variants (seeds 1..30):** 8
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** choose
+**Stem:** Which option correctly punctuates the direct speech AND keeps the whole sentence as a question?Did Mum really say ___
+**Options:** A) Did Mum really say "Pack your bag now"?, B) Did Mum really say, "Pack your bag now"?, C) Did Mum really say, "Pack your bag now?"
+
+#### Seed 2
+**Question type:** choose
+**Stem:** Which option correctly punctuates the speech AND makes the sentence a statement?The teacher told us ___
+**Options:** A) The teacher told us "Open your books to page twelve.", B) The teacher told us, "Open your books to page twelve.", C) The teacher told us, "Open your books to page twelve".
+
+#### Seed 3
+**Question type:** choose
+**Stem:** Which option correctly punctuates the direct speech AND identifies the sentence as an exclamation?What a surprise it was when Grandad announced ___
+**Options:** A) What a surprise it was when Grandad announced, "We are moving to Wales"!, B) What a surprise it was when Grandad announced, "We are moving to Wales!", C) What a surprise it was when Grandad announced "We are moving to Wales!"
+
+#### Seed 4
+**Question type:** choose
+**Stem:** Which option keeps the reported command inside speech marks AND makes the whole sentence a question?Did the coach shout ___
+**Options:** A) Did the coach shout, "Run faster?", B) Did the coach shout, "Run faster"?, C) Did the coach shout "Run faster"?
+
+#### Seed 5
+**Question type:** choose
+**Stem:** Which option correctly punctuates the question inside speech marks within a statement?Lena asked ___
+**Options:** A) Lena asked, "Where is the library?", B) Lena asked, "Where is the library"?, C) Lena asked "Where is the library?"
+
+---
+
+## Family: qg_p4_verb_form_register_transfer
+
+- **Template ID(s):** qg_p4_verb_form_register_transfer
+- **Skill IDs:** modal_verbs, standard_english, tense_aspect
+- **Answer-spec kind:** exact
+- **Question type:** choose
+- **Tags:** mixed-transfer, qg-p4
+- **Unique variants (seeds 1..30):** 8
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** choose
+**Stem:** Which option uses the correct tense, an appropriate modal verb, AND Standard English?A letter to parents about a school trip that will happen next week.
+**Options:** A) Your child will need a packed lunch and must of worn comfortable shoes., B) Your child will need a packed lunch and should of wore comfortable shoes., C) Your child will need a packed lunch and should wear comfortable shoes., D) Your child needed a packed lunch and should wear comfortable shoes.
+
+#### Seed 2
+**Question type:** choose
+**Stem:** Which option combines the correct past tense, a modal showing possibility, AND Standard English?A report about what happened during a science experiment yesterday.
+**Options:** A) The mixture changed colour, which could of indicated a chemical reaction., B) The mixture changed colour, which can indicate a chemical reaction., C) The mixture changed colour, which could indicate a chemical reaction., D) The mixture changes colour, which could indicate a chemical reaction.
+
+#### Seed 3
+**Question type:** choose
+**Stem:** Which option uses the present perfect tense, a modal of certainty, AND Standard English?A notice about lost property that has been found.
+**Options:** A) A blue coat has been found; it must of belonged to someone in Year 5., B) A blue coat has been found; it might of belonged to someone in Year 5., C) A blue coat has been found; it must belong to someone in Year 5., D) A blue coat was found; it must belong to someone in Year 5.
+
+#### Seed 4
+**Question type:** choose
+**Stem:** Which option uses the correct future tense, an appropriate modal, AND Standard English?An announcement about a visitor coming to school tomorrow.
+**Options:** A) An author will visit tomorrow; pupils may of asked questions afterwards., B) An author visited tomorrow; pupils may ask questions afterwards., C) An author will visit tomorrow; pupils may ask questions afterwards., D) An author will visit tomorrow; pupils might of ask questions afterwards.
+
+#### Seed 5
+**Question type:** choose
+**Stem:** Which option combines past progressive tense, a modal of obligation, AND Standard English?A note explaining what happened when the fire alarm sounded.
+**Options:** A) Children were lining up when the alarm rang; they had of left calmly., B) Children were lining up when the alarm rang; they had to leave calmly., C) Children were lining up when the alarm rang; they should of left calmly., D) Children are lining up when the alarm rang; they had to leave calmly.
+
+---
+
+## Family: qg_p4_voice_roles_transfer
+
+- **Template ID(s):** qg_p4_voice_roles_transfer
+- **Skill IDs:** active_passive, subject_object
+- **Answer-spec kind:** multiField
+- **Question type:** classify
+- **Tags:** mixed-transfer, qg-p4
+- **Unique variants (seeds 1..30):** 8
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** classify
+**Stem:** Identify the voice and the grammatical role of the underlined noun phrase.The trophy was awarded to Amir by the head teacher.
+**Input:** table_choice — 
+
+#### Seed 2
+**Question type:** classify
+**Stem:** Identify the voice and the grammatical role of the underlined noun phrase.The goalkeeper saved the penalty brilliantly.
+**Input:** table_choice — 
+
+#### Seed 3
+**Question type:** classify
+**Stem:** Identify the voice and the grammatical role of the underlined noun phrase.The cake was eaten by the children before lunch.
+**Input:** table_choice — 
+
+#### Seed 4
+**Question type:** classify
+**Stem:** Identify the voice and the grammatical role of the underlined noun phrase.Lena painted the scenery for the school play.
+**Input:** table_choice — 
+
+#### Seed 5
+**Question type:** classify
+**Stem:** Identify the voice and the grammatical role of the underlined noun phrase.The windows were smashed by the hailstones during the storm.
+**Input:** table_choice — 
+
+---
+
+## Family: qg_p4_word_class_noun_phrase_transfer
+
+- **Template ID(s):** qg_p4_word_class_noun_phrase_transfer
+- **Skill IDs:** noun_phrases, word_classes
+- **Answer-spec kind:** multiField
+- **Question type:** classify
+- **Tags:** mixed-transfer, qg-p4
+- **Unique variants (seeds 1..30):** 8
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** classify
+**Stem:** Identify the head noun and its word class in this expanded noun phrase.the rusty old bicycle
+**Input:** table_choice — 
+
+#### Seed 2
+**Question type:** classify
+**Stem:** Identify the head noun and the word class of the modifier before it.a terrifying mountain storm
+**Input:** table_choice — 
+
+#### Seed 3
+**Question type:** classify
+**Stem:** Identify the head noun and the word class of the underlined word in this noun phrase.those incredibly brave firefighters
+**Input:** table_choice — 
+
+#### Seed 4
+**Question type:** classify
+**Stem:** Identify the head noun and the word class of the first word in this noun phrase.every single morning lesson
+**Input:** table_choice — 
+
+#### Seed 5
+**Question type:** classify
+**Stem:** Identify the head noun and the word class of the describing word.the brightly painted fence
+**Input:** table_choice — 
+
+---
+
+## Family: qg_pronoun_referent_identify
+
+- **Template ID(s):** qg_pronoun_referent_identify
+- **Skill IDs:** pronouns_cohesion
+- **Answer-spec kind:** exact
+- **Question type:** identify
+- **Tags:** identify, qg-p1, qg-p5
+- **Unique variants (seeds 1..30):** 9
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** identify
+**Stem:** In this sentence, what does the pronoun he refer to?Sam thanked Oliver after he returned the library book.
+**Options:** A) the library, B) Sam, C) Oliver, D) the library book
+
+#### Seed 2
+**Question type:** identify
+**Stem:** In this sentence, what does the pronoun they refer to?The pupils moved the benches after they finished lunch.
+**Options:** A) the benches, B) the hall, C) The pupils, D) lunch
+
+#### Seed 3
+**Question type:** identify
+**Stem:** In this sentence, what does the pronoun she refer to?Mia handed the trophy to Ava because she had won the race.
+**Options:** A) Mia, B) the race, C) Ava, D) the trophy
+
+#### Seed 4
+**Question type:** identify
+**Stem:** In this sentence, what does the pronoun it refer to?The dog chased the cat until it climbed over the fence.
+**Options:** A) the dog, B) the fence, C) the cat, D) the garden
+
+#### Seed 5
+**Question type:** identify
+**Stem:** In this sentence, what does the pronoun he refer to?Jay told Noah that he needed to finish the project today.
+**Options:** A) Jay, B) Noah, C) the teacher, D) the project
+
+---
+
+## Family: qg_subject_object_classify_table
+
+- **Template ID(s):** qg_subject_object_classify_table
+- **Skill IDs:** subject_object
+- **Answer-spec kind:** multiField
+- **Question type:** classify
+- **Tags:** identify, qg-p1
+- **Unique variants (seeds 1..30):** 30
+
+### Sample Prompts
+
+#### Seed 1
+**Question type:** classify
+**Stem:** Classify each named noun phrase as the subject or object.
+**Input:** table_choice — 
+
+#### Seed 2
+**Question type:** classify
+**Stem:** Classify each named noun phrase as the subject or object.
+**Input:** table_choice — 
+
+#### Seed 3
+**Question type:** classify
+**Stem:** Classify each named noun phrase as the subject or object.
+**Input:** table_choice — 
+
+#### Seed 4
+**Question type:** classify
+**Stem:** Classify each named noun phrase as the subject or object.
+**Input:** table_choice — 
+
+#### Seed 5
+**Question type:** classify
+**Stem:** Classify each named noun phrase as the subject or object.
+**Input:** table_choice — 
+
+---
+
+## Reviewer Answer Appendix
+
+> ⚠️ This section contains correct answers. Do not share with learners.
+
+| Family | Seed | Correct Answer |
+|---|---|---|
+| proc_apostrophe_possession_choice | 1 | the girls' coats |
+| proc_apostrophe_possession_choice | 2 | the people's tickets |
+| proc_apostrophe_possession_choice | 3 | the dog's tickets |
+| proc_apostrophe_possession_choice | 4 | the boys' lunchboxes |
+| proc_apostrophe_possession_choice | 5 | the women's coats |
+| proc_apostrophe_possession_choice | 6 | the dog's bags |
+| proc_apostrophe_possession_choice | 7 | the girls' boots |
+| proc_apostrophe_possession_choice | 8 | the men's books |
+| proc_apostrophe_possession_choice | 9 | the farmer's books |
+| proc_apostrophe_possession_choice | 10 | the farmers' bags |
+| proc_apostrophe_possession_choice | 11 | the men's bags |
+| proc_apostrophe_possession_choice | 12 | the dog's bikes |
+| proc_apostrophe_possession_choice | 13 | the players' bags |
+| proc_apostrophe_possession_choice | 14 | the people's bags |
+| proc_apostrophe_possession_choice | 15 | the teacher's books |
+| proc_apostrophe_possession_choice | 16 | the girls' coats |
+| proc_apostrophe_possession_choice | 17 | the children's coats |
+| proc_apostrophe_possession_choice | 18 | the player's bikes |
+| proc_apostrophe_possession_choice | 19 | the boys' boots |
+| proc_apostrophe_possession_choice | 20 | the people's tickets |
+| proc_apostrophe_possession_choice | 21 | the teacher's bags |
+| proc_apostrophe_possession_choice | 22 | the boys' coats |
+| proc_apostrophe_possession_choice | 23 | the children's boots |
+| proc_apostrophe_possession_choice | 24 | the farmer's bikes |
+| proc_apostrophe_possession_choice | 25 | the visitors' coats |
+| proc_apostrophe_possession_choice | 26 | the men's bags |
+| proc_apostrophe_possession_choice | 27 | the dog's bikes |
+| proc_apostrophe_possession_choice | 28 | the visitors' bikes |
+| proc_apostrophe_possession_choice | 29 | the children's books |
+| proc_apostrophe_possession_choice | 30 | the farmer's lunchboxes |
+| proc_colon_list_fix | 1 | For the picnic we packed three things: bread, fruit, juice. |
+| proc_colon_list_fix | 2 | The museum displayed four objects: a helmet, a shield, a sword, a coin. |
+| proc_colon_list_fix | 3 | We still needed two items for camp: a torch, a sleeping bag. |
+| proc_colon_list_fix | 4 | The club offered three prizes: a medal, a certificate, a book token. |
+| proc_colon_list_fix | 5 | The recipe called for five ingredients: flour, butter, eggs, sugar, milk. |
+| proc_colon_list_fix | 6 | Three countries were represented at the fair: France, Japan, Brazil. |
+| proc_colon_list_fix | 7 | The explorer carried four essential supplies: a compass, a water bottle, a rope, a first-aid kit. |
+| proc_colon_list_fix | 8 | The school banned three items from the playground: skateboards, glass bottles, footballs. |
+| proc_colon_list_fix | 9 | The gardener planted four types of vegetable: carrots, beans, potatoes, onions. |
+| proc_colon_list_fix | 10 | For the picnic we packed three things: bread, fruit, juice. |
+| proc_colon_list_fix | 11 | The museum displayed four objects: a helmet, a shield, a sword, a coin. |
+| proc_colon_list_fix | 12 | We still needed two items for camp: a torch, a sleeping bag. |
+| proc_colon_list_fix | 13 | The club offered three prizes: a medal, a certificate, a book token. |
+| proc_colon_list_fix | 14 | The recipe called for five ingredients: flour, butter, eggs, sugar, milk. |
+| proc_colon_list_fix | 15 | Three countries were represented at the fair: France, Japan, Brazil. |
+| proc_colon_list_fix | 16 | The explorer carried four essential supplies: a compass, a water bottle, a rope, a first-aid kit. |
+| proc_colon_list_fix | 17 | The school banned three items from the playground: skateboards, glass bottles, footballs. |
+| proc_colon_list_fix | 18 | The gardener planted four types of vegetable: carrots, beans, potatoes, onions. |
+| proc_colon_list_fix | 19 | For the picnic we packed three things: bread, fruit, juice. |
+| proc_colon_list_fix | 20 | The museum displayed four objects: a helmet, a shield, a sword, a coin. |
+| proc_colon_list_fix | 21 | We still needed two items for camp: a torch, a sleeping bag. |
+| proc_colon_list_fix | 22 | The club offered three prizes: a medal, a certificate, a book token. |
+| proc_colon_list_fix | 23 | The recipe called for five ingredients: flour, butter, eggs, sugar, milk. |
+| proc_colon_list_fix | 24 | Three countries were represented at the fair: France, Japan, Brazil. |
+| proc_colon_list_fix | 25 | The explorer carried four essential supplies: a compass, a water bottle, a rope, a first-aid kit. |
+| proc_colon_list_fix | 26 | The school banned three items from the playground: skateboards, glass bottles, footballs. |
+| proc_colon_list_fix | 27 | The gardener planted four types of vegetable: carrots, beans, potatoes, onions. |
+| proc_colon_list_fix | 28 | For the picnic we packed three things: bread, fruit, juice. |
+| proc_colon_list_fix | 29 | The museum displayed four objects: a helmet, a shield, a sword, a coin. |
+| proc_colon_list_fix | 30 | We still needed two items for camp: a torch, a sleeping bag. |
+| proc_dash_boundary_fix | 1 | I had one worry – the batteries were flat. |
+| proc_dash_boundary_fix | 2 | The plan was simple – follow the red arrows. |
+| proc_dash_boundary_fix | 3 | There was only one answer – turn back at once. |
+| proc_dash_boundary_fix | 4 | One thought filled my mind – where had the key gone. |
+| proc_dash_boundary_fix | 5 | She had made her decision – the letter would be posted today. |
+| proc_dash_boundary_fix | 6 | The message was clear – everyone must leave the building at once. |
+| proc_dash_boundary_fix | 7 | He remembered just one rule – never open the gate after dark. |
+| proc_dash_boundary_fix | 8 | The result surprised us all – the youngest team had won. |
+| proc_dash_boundary_fix | 9 | Only one thing could save us – the map in her rucksack. |
+| proc_dash_boundary_fix | 10 | I had one worry – the batteries were flat. |
+| proc_dash_boundary_fix | 11 | The plan was simple – follow the red arrows. |
+| proc_dash_boundary_fix | 12 | There was only one answer – turn back at once. |
+| proc_dash_boundary_fix | 13 | One thought filled my mind – where had the key gone. |
+| proc_dash_boundary_fix | 14 | She had made her decision – the letter would be posted today. |
+| proc_dash_boundary_fix | 15 | The message was clear – everyone must leave the building at once. |
+| proc_dash_boundary_fix | 16 | He remembered just one rule – never open the gate after dark. |
+| proc_dash_boundary_fix | 17 | The result surprised us all – the youngest team had won. |
+| proc_dash_boundary_fix | 18 | Only one thing could save us – the map in her rucksack. |
+| proc_dash_boundary_fix | 19 | I had one worry – the batteries were flat. |
+| proc_dash_boundary_fix | 20 | The plan was simple – follow the red arrows. |
+| proc_dash_boundary_fix | 21 | There was only one answer – turn back at once. |
+| proc_dash_boundary_fix | 22 | One thought filled my mind – where had the key gone. |
+| proc_dash_boundary_fix | 23 | She had made her decision – the letter would be posted today. |
+| proc_dash_boundary_fix | 24 | The message was clear – everyone must leave the building at once. |
+| proc_dash_boundary_fix | 25 | He remembered just one rule – never open the gate after dark. |
+| proc_dash_boundary_fix | 26 | The result surprised us all – the youngest team had won. |
+| proc_dash_boundary_fix | 27 | Only one thing could save us – the map in her rucksack. |
+| proc_dash_boundary_fix | 28 | I had one worry – the batteries were flat. |
+| proc_dash_boundary_fix | 29 | The plan was simple – follow the red arrows. |
+| proc_dash_boundary_fix | 30 | There was only one answer – turn back at once. |
+| proc_fronted_adverbial_fix | 1 | With great care, Ava locked the window. |
+| proc_fronted_adverbial_fix | 2 | With great care, Noah found the map. |
+| proc_fronted_adverbial_fix | 3 | With great care, Ava carried the trophy. |
+| proc_fronted_adverbial_fix | 4 | After the final whistle, Noah carried the gate. |
+| proc_fronted_adverbial_fix | 5 | With great care, Nora found the gate. |
+| proc_fronted_adverbial_fix | 6 | Without warning, Ava opened the rucksack. |
+| proc_fronted_adverbial_fix | 7 | Before sunrise, Ava lifted the sketchbook. |
+| proc_fronted_adverbial_fix | 8 | After lunch, Amira lifted the map. |
+| proc_fronted_adverbial_fix | 9 | After lunch, Sam cleaned the gate. |
+| proc_fronted_adverbial_fix | 10 | Without warning, Ruby cleaned the rucksack. |
+| proc_fronted_adverbial_fix | 11 | Without warning, Luca found the window. |
+| proc_fronted_adverbial_fix | 12 | Later that day, Ava locked the window. |
+| proc_fronted_adverbial_fix | 13 | Without warning, Elsie carried the lantern. |
+| proc_fronted_adverbial_fix | 14 | At the edge of the field, Zac packed the window. |
+| proc_fronted_adverbial_fix | 15 | After lunch, Elsie dropped the trophy. |
+| proc_fronted_adverbial_fix | 16 | With great care, Ben dropped the picnic basket. |
+| proc_fronted_adverbial_fix | 17 | With great care, Mia opened the window. |
+| proc_fronted_adverbial_fix | 18 | At the edge of the field, Amira opened the window. |
+| proc_fronted_adverbial_fix | 19 | Before sunrise, Noah cleaned the trophy. |
+| proc_fronted_adverbial_fix | 20 | On Friday morning, Elsie packed the window. |
+| proc_fronted_adverbial_fix | 21 | At the edge of the field, Zac dropped the map. |
+| proc_fronted_adverbial_fix | 22 | Without warning, Mia opened the gate. |
+| proc_fronted_adverbial_fix | 23 | Before sunrise, Ava packed the rucksack. |
+| proc_fronted_adverbial_fix | 24 | Later that day, Ruby carried the map. |
+| proc_fronted_adverbial_fix | 25 | Without warning, Nora lifted the window. |
+| proc_fronted_adverbial_fix | 26 | Without warning, Jay carried the window. |
+| proc_fronted_adverbial_fix | 27 | At the edge of the field, Ava opened the lantern. |
+| proc_fronted_adverbial_fix | 28 | At the edge of the field, Jay lifted the rucksack. |
+| proc_fronted_adverbial_fix | 29 | After lunch, Ben opened the map. |
+| proc_fronted_adverbial_fix | 30 | On Friday morning, Sam opened the trophy. |
+| proc_hyphen_ambiguity_choice | 1 | We saw a man-eating shark near the rocks. |
+| proc_hyphen_ambiguity_choice | 2 | We visited the small-animal hospital after lunch. |
+| proc_hyphen_ambiguity_choice | 3 | Dad opened the clothes-drying cabinet in the hall. |
+| proc_hyphen_ambiguity_choice | 4 | The teacher set a well-known test for the class. |
+| proc_hyphen_ambiguity_choice | 5 | We looked up at the ten-storey building. |
+| proc_hyphen_ambiguity_choice | 6 | Sam ran in the three-mile race on Saturday. |
+| proc_hyphen_ambiguity_choice | 7 | Mum found a bargain at the second-hand shop. |
+| proc_hyphen_ambiguity_choice | 8 | The six-year-old child ran across the park. |
+| proc_hyphen_ambiguity_choice | 9 | Jay chose the sugar-free ice cream from the van. |
+| proc_hyphen_ambiguity_choice | 10 | We saw a man-eating shark near the rocks. |
+| proc_hyphen_ambiguity_choice | 11 | We visited the small-animal hospital after lunch. |
+| proc_hyphen_ambiguity_choice | 12 | Dad opened the clothes-drying cabinet in the hall. |
+| proc_hyphen_ambiguity_choice | 13 | The teacher set a well-known test for the class. |
+| proc_hyphen_ambiguity_choice | 14 | We looked up at the ten-storey building. |
+| proc_hyphen_ambiguity_choice | 15 | Sam ran in the three-mile race on Saturday. |
+| proc_hyphen_ambiguity_choice | 16 | Mum found a bargain at the second-hand shop. |
+| proc_hyphen_ambiguity_choice | 17 | The six-year-old child ran across the park. |
+| proc_hyphen_ambiguity_choice | 18 | Jay chose the sugar-free ice cream from the van. |
+| proc_hyphen_ambiguity_choice | 19 | We saw a man-eating shark near the rocks. |
+| proc_hyphen_ambiguity_choice | 20 | We visited the small-animal hospital after lunch. |
+| proc_hyphen_ambiguity_choice | 21 | Dad opened the clothes-drying cabinet in the hall. |
+| proc_hyphen_ambiguity_choice | 22 | The teacher set a well-known test for the class. |
+| proc_hyphen_ambiguity_choice | 23 | We looked up at the ten-storey building. |
+| proc_hyphen_ambiguity_choice | 24 | Sam ran in the three-mile race on Saturday. |
+| proc_hyphen_ambiguity_choice | 25 | Mum found a bargain at the second-hand shop. |
+| proc_hyphen_ambiguity_choice | 26 | The six-year-old child ran across the park. |
+| proc_hyphen_ambiguity_choice | 27 | Jay chose the sugar-free ice cream from the van. |
+| proc_hyphen_ambiguity_choice | 28 | We saw a man-eating shark near the rocks. |
+| proc_hyphen_ambiguity_choice | 29 | We visited the small-animal hospital after lunch. |
+| proc_hyphen_ambiguity_choice | 30 | Dad opened the clothes-drying cabinet in the hall. |
+| proc_semicolon_choice | 1 | ; |
+| proc_semicolon_choice | 2 | ; |
+| proc_semicolon_choice | 3 | ; |
+| proc_semicolon_choice | 4 | ; |
+| proc_semicolon_choice | 5 | ; |
+| proc_semicolon_choice | 6 | ; |
+| proc_semicolon_choice | 7 | ; |
+| proc_semicolon_choice | 8 | ; |
+| proc_semicolon_choice | 9 | ; |
+| proc_semicolon_choice | 10 | ; |
+| proc_semicolon_choice | 11 | ; |
+| proc_semicolon_choice | 12 | ; |
+| proc_semicolon_choice | 13 | ; |
+| proc_semicolon_choice | 14 | ; |
+| proc_semicolon_choice | 15 | ; |
+| proc_semicolon_choice | 16 | ; |
+| proc_semicolon_choice | 17 | ; |
+| proc_semicolon_choice | 18 | ; |
+| proc_semicolon_choice | 19 | ; |
+| proc_semicolon_choice | 20 | ; |
+| proc_semicolon_choice | 21 | ; |
+| proc_semicolon_choice | 22 | ; |
+| proc_semicolon_choice | 23 | ; |
+| proc_semicolon_choice | 24 | ; |
+| proc_semicolon_choice | 25 | ; |
+| proc_semicolon_choice | 26 | ; |
+| proc_semicolon_choice | 27 | ; |
+| proc_semicolon_choice | 28 | ; |
+| proc_semicolon_choice | 29 | ; |
+| proc_semicolon_choice | 30 | ; |
+| proc_speech_punctuation_fix | 1 | Ben said, "Shut the gate behind you!" |
+| proc_speech_punctuation_fix | 2 | "What a huge wave that was!" asked Ava. |
+| proc_speech_punctuation_fix | 3 | "Why are your boots muddy?" said Ava. |
+| proc_speech_punctuation_fix | 4 | the guide asked, "Bring the torch with you!" |
+| proc_speech_punctuation_fix | 5 | "What a huge wave that was!" whispered Ben. |
+| proc_speech_punctuation_fix | 6 | "Have you packed the torch?" said Miss Patel. |
+| proc_speech_punctuation_fix | 7 | Mum said, "Hold the ladder steady!" |
+| proc_speech_punctuation_fix | 8 | "What a huge wave that was!" whispered Dad. |
+| proc_speech_punctuation_fix | 9 | "Where is the spare key?" called Dad. |
+| proc_speech_punctuation_fix | 10 | Miss Patel called, "Shut the gate behind you!" |
+| proc_speech_punctuation_fix | 11 | "Look out for the puddle!" shouted Miss Patel. |
+| proc_speech_punctuation_fix | 12 | "Have you packed the torch?" said the coach. |
+| proc_speech_punctuation_fix | 13 | Miss Patel asked, "Bring the torch with you!" |
+| proc_speech_punctuation_fix | 14 | "Look out for the puddle!" shouted Miss Patel. |
+| proc_speech_punctuation_fix | 15 | "Why are your boots muddy?" shouted Dad. |
+| proc_speech_punctuation_fix | 16 | Ben said, "Hold the ladder steady!" |
+| proc_speech_punctuation_fix | 17 | "Look out for the puddle!" said Ben. |
+| proc_speech_punctuation_fix | 18 | "Have you packed the torch?" whispered the coach. |
+| proc_speech_punctuation_fix | 19 | Mum asked, "Wait by the hall doors!" |
+| proc_speech_punctuation_fix | 20 | "Look out for the puddle!" asked Ava. |
+| proc_speech_punctuation_fix | 21 | "Why are your boots muddy?" shouted Miss Patel. |
+| proc_speech_punctuation_fix | 22 | Ben asked, "Bring the torch with you!" |
+| proc_speech_punctuation_fix | 23 | "Look out for the puddle!" said Mum. |
+| proc_speech_punctuation_fix | 24 | "Why are your boots muddy?" called the coach. |
+| proc_speech_punctuation_fix | 25 | Ben called, "Shut the gate behind you!" |
+| proc_speech_punctuation_fix | 26 | "Look out for the puddle!" whispered Miss Patel. |
+| proc_speech_punctuation_fix | 27 | "Where is the spare key?" said the coach. |
+| proc_speech_punctuation_fix | 28 | the coach whispered, "Shut the gate behind you!" |
+| proc_speech_punctuation_fix | 29 | "What a huge wave that was!" said Dad. |
+| proc_speech_punctuation_fix | 30 | "Why are your boots muddy?" called the guide. |
+| proc2_boundary_punctuation_explain | 1 | The words before the colon make a complete clause and the colon introduces a list. |
+| proc2_boundary_punctuation_explain | 2 | The dash creates a strong break before an explanation or afterthought. |
+| proc2_boundary_punctuation_explain | 3 | A semi-colon can join two closely related main clauses. |
+| proc2_boundary_punctuation_explain | 4 | The words before the colon make a complete clause and the colon introduces a list. |
+| proc2_boundary_punctuation_explain | 5 | The dash creates a strong break before an explanation or afterthought. |
+| proc2_boundary_punctuation_explain | 6 | A semi-colon can join two closely related main clauses. |
+| proc2_boundary_punctuation_explain | 7 | The words before the colon make a complete clause and the colon introduces a list. |
+| proc2_boundary_punctuation_explain | 8 | The dash creates a strong break before an explanation or afterthought. |
+| proc2_boundary_punctuation_explain | 9 | A semi-colon can join two closely related main clauses. |
+| proc2_boundary_punctuation_explain | 10 | The words before the colon make a complete clause and the colon introduces a list. |
+| proc2_boundary_punctuation_explain | 11 | The dash creates a strong break before an explanation or afterthought. |
+| proc2_boundary_punctuation_explain | 12 | A semi-colon can join two closely related main clauses. |
+| proc2_boundary_punctuation_explain | 13 | The words before the colon make a complete clause and the colon introduces a list. |
+| proc2_boundary_punctuation_explain | 14 | The dash creates a strong break before an explanation or afterthought. |
+| proc2_boundary_punctuation_explain | 15 | A semi-colon can join two closely related main clauses. |
+| proc2_boundary_punctuation_explain | 16 | The words before the colon make a complete clause and the colon introduces a list. |
+| proc2_boundary_punctuation_explain | 17 | The dash creates a strong break before an explanation or afterthought. |
+| proc2_boundary_punctuation_explain | 18 | A semi-colon can join two closely related main clauses. |
+| proc2_boundary_punctuation_explain | 19 | The words before the colon make a complete clause and the colon introduces a list. |
+| proc2_boundary_punctuation_explain | 20 | The dash creates a strong break before an explanation or afterthought. |
+| proc2_boundary_punctuation_explain | 21 | A semi-colon can join two closely related main clauses. |
+| proc2_boundary_punctuation_explain | 22 | The words before the colon make a complete clause and the colon introduces a list. |
+| proc2_boundary_punctuation_explain | 23 | The dash creates a strong break before an explanation or afterthought. |
+| proc2_boundary_punctuation_explain | 24 | A semi-colon can join two closely related main clauses. |
+| proc2_boundary_punctuation_explain | 25 | The words before the colon make a complete clause and the colon introduces a list. |
+| proc2_boundary_punctuation_explain | 26 | The dash creates a strong break before an explanation or afterthought. |
+| proc2_boundary_punctuation_explain | 27 | A semi-colon can join two closely related main clauses. |
+| proc2_boundary_punctuation_explain | 28 | The words before the colon make a complete clause and the colon introduces a list. |
+| proc2_boundary_punctuation_explain | 29 | The dash creates a strong break before an explanation or afterthought. |
+| proc2_boundary_punctuation_explain | 30 | A semi-colon can join two closely related main clauses. |
+| proc2_formality_choice | 1 | I am writing to request two extra chairs for the hall. |
+| proc2_formality_choice | 2 | The club was established last year. |
+| proc2_formality_choice | 3 | Several pupils were absent from the visit. |
+| proc2_formality_choice | 4 | We are delighted to announce the opening of the new library. |
+| proc2_formality_choice | 5 | Guests are kindly requested to arrive by half past six. |
+| proc2_formality_choice | 6 | The experiment was conducted under controlled conditions. |
+| proc2_formality_choice | 7 | I wish to draw your attention to the unsatisfactory service we received. |
+| proc2_formality_choice | 8 | It is with great pleasure that I introduce our guest speaker. |
+| proc2_formality_choice | 9 | I am writing to express my gratitude for your generous donation. |
+| proc2_formality_choice | 10 | I am writing to request two extra chairs for the hall. |
+| proc2_formality_choice | 11 | The club was established last year. |
+| proc2_formality_choice | 12 | Several pupils were absent from the visit. |
+| proc2_formality_choice | 13 | We are delighted to announce the opening of the new library. |
+| proc2_formality_choice | 14 | Guests are kindly requested to arrive by half past six. |
+| proc2_formality_choice | 15 | The experiment was conducted under controlled conditions. |
+| proc2_formality_choice | 16 | I wish to draw your attention to the unsatisfactory service we received. |
+| proc2_formality_choice | 17 | It is with great pleasure that I introduce our guest speaker. |
+| proc2_formality_choice | 18 | I am writing to express my gratitude for your generous donation. |
+| proc2_formality_choice | 19 | I am writing to request two extra chairs for the hall. |
+| proc2_formality_choice | 20 | The club was established last year. |
+| proc2_formality_choice | 21 | Several pupils were absent from the visit. |
+| proc2_formality_choice | 22 | We are delighted to announce the opening of the new library. |
+| proc2_formality_choice | 23 | Guests are kindly requested to arrive by half past six. |
+| proc2_formality_choice | 24 | The experiment was conducted under controlled conditions. |
+| proc2_formality_choice | 25 | I wish to draw your attention to the unsatisfactory service we received. |
+| proc2_formality_choice | 26 | It is with great pleasure that I introduce our guest speaker. |
+| proc2_formality_choice | 27 | I am writing to express my gratitude for your generous donation. |
+| proc2_formality_choice | 28 | I am writing to request two extra chairs for the hall. |
+| proc2_formality_choice | 29 | The club was established last year. |
+| proc2_formality_choice | 30 | Several pupils were absent from the visit. |
+| proc2_fronted_adverbial_build | 1 | A correct answer is: With great care, Ava locked the window. |
+| proc2_fronted_adverbial_build | 2 | A correct answer is: With great care, Noah found the map. |
+| proc2_fronted_adverbial_build | 3 | A correct answer is: With great care, Ava carried the trophy. |
+| proc2_fronted_adverbial_build | 4 | A correct answer is: After the final whistle, Noah carried the gate. |
+| proc2_fronted_adverbial_build | 5 | A correct answer is: With great care, Nora found the gate. |
+| proc2_fronted_adverbial_build | 6 | A correct answer is: Without warning, Ava opened the rucksack. |
+| proc2_fronted_adverbial_build | 7 | A correct answer is: Before sunrise, Ava lifted the sketchbook. |
+| proc2_fronted_adverbial_build | 8 | A correct answer is: After lunch, Amira lifted the map. |
+| proc2_fronted_adverbial_build | 9 | A correct answer is: After lunch, Sam cleaned the gate. |
+| proc2_fronted_adverbial_build | 10 | A correct answer is: Without warning, Ruby cleaned the rucksack. |
+| proc2_fronted_adverbial_build | 11 | A correct answer is: Without warning, Luca found the window. |
+| proc2_fronted_adverbial_build | 12 | A correct answer is: Later that day, Ava locked the window. |
+| proc2_fronted_adverbial_build | 13 | A correct answer is: Without warning, Elsie carried the lantern. |
+| proc2_fronted_adverbial_build | 14 | A correct answer is: At the edge of the field, Zac packed the window. |
+| proc2_fronted_adverbial_build | 15 | A correct answer is: After lunch, Elsie dropped the trophy. |
+| proc2_fronted_adverbial_build | 16 | A correct answer is: With great care, Ben dropped the picnic basket. |
+| proc2_fronted_adverbial_build | 17 | A correct answer is: With great care, Mia opened the window. |
+| proc2_fronted_adverbial_build | 18 | A correct answer is: At the edge of the field, Amira opened the window. |
+| proc2_fronted_adverbial_build | 19 | A correct answer is: Before sunrise, Noah cleaned the trophy. |
+| proc2_fronted_adverbial_build | 20 | A correct answer is: On Friday morning, Elsie packed the window. |
+| proc2_fronted_adverbial_build | 21 | A correct answer is: At the edge of the field, Zac dropped the map. |
+| proc2_fronted_adverbial_build | 22 | A correct answer is: Without warning, Mia opened the gate. |
+| proc2_fronted_adverbial_build | 23 | A correct answer is: Before sunrise, Ava packed the rucksack. |
+| proc2_fronted_adverbial_build | 24 | A correct answer is: Later that day, Ruby carried the map. |
+| proc2_fronted_adverbial_build | 25 | A correct answer is: Without warning, Nora lifted the window. |
+| proc2_fronted_adverbial_build | 26 | A correct answer is: Without warning, Jay carried the window. |
+| proc2_fronted_adverbial_build | 27 | A correct answer is: At the edge of the field, Ava opened the lantern. |
+| proc2_fronted_adverbial_build | 28 | A correct answer is: At the edge of the field, Jay lifted the rucksack. |
+| proc2_fronted_adverbial_build | 29 | A correct answer is: After lunch, Ben opened the map. |
+| proc2_fronted_adverbial_build | 30 | A correct answer is: On Friday morning, Sam opened the trophy. |
+| proc2_modal_choice | 1 | must |
+| proc2_modal_choice | 2 | might |
+| proc2_modal_choice | 3 | should |
+| proc2_modal_choice | 4 | will |
+| proc2_modal_choice | 5 | may |
+| proc2_modal_choice | 6 | could |
+| proc2_modal_choice | 7 | must |
+| proc2_modal_choice | 8 | should |
+| proc2_modal_choice | 9 | might |
+| proc2_modal_choice | 10 | must |
+| proc2_modal_choice | 11 | might |
+| proc2_modal_choice | 12 | should |
+| proc2_modal_choice | 13 | will |
+| proc2_modal_choice | 14 | may |
+| proc2_modal_choice | 15 | could |
+| proc2_modal_choice | 16 | must |
+| proc2_modal_choice | 17 | should |
+| proc2_modal_choice | 18 | might |
+| proc2_modal_choice | 19 | must |
+| proc2_modal_choice | 20 | might |
+| proc2_modal_choice | 21 | should |
+| proc2_modal_choice | 22 | will |
+| proc2_modal_choice | 23 | may |
+| proc2_modal_choice | 24 | could |
+| proc2_modal_choice | 25 | must |
+| proc2_modal_choice | 26 | should |
+| proc2_modal_choice | 27 | might |
+| proc2_modal_choice | 28 | must |
+| proc2_modal_choice | 29 | might |
+| proc2_modal_choice | 30 | should |
+| proc2_passive_to_active | 1 | Amira lifts the lantern this morning. |
+| proc2_passive_to_active | 2 | Jay packs the map after the match. |
+| proc2_passive_to_active | 3 | Jay lifts the lantern. |
+| proc2_passive_to_active | 4 | Ruby packed the map. |
+| proc2_passive_to_active | 5 | Jay packed the picnic basket after the match. |
+| proc2_passive_to_active | 6 | Luca paints the lantern. |
+| proc2_passive_to_active | 7 | Ava washes the lantern after the match. |
+| proc2_passive_to_active | 8 | Ben carries the rucksack after the match. |
+| proc2_passive_to_active | 9 | Mia opens the picnic basket this morning. |
+| proc2_passive_to_active | 10 | Luca painted the sketchbook this morning. |
+| proc2_passive_to_active | 11 | Luca paints the window after the match. |
+| proc2_passive_to_active | 12 | Noah painted the lantern this morning. |
+| proc2_passive_to_active | 13 | Luca opened the map. |
+| proc2_passive_to_active | 14 | Zac lifted the trophy before lunch. |
+| proc2_passive_to_active | 15 | Mia carried the trophy before lunch. |
+| proc2_passive_to_active | 16 | Amira cleaned the gate before lunch. |
+| proc2_passive_to_active | 17 | Jay lifted the gate. |
+| proc2_passive_to_active | 18 | Elsie lifts the window. |
+| proc2_passive_to_active | 19 | Ava lifts the map this morning. |
+| proc2_passive_to_active | 20 | Nora painted the trophy before lunch. |
+| proc2_passive_to_active | 21 | Zac packed the trophy before lunch. |
+| proc2_passive_to_active | 22 | Amira packed the gate. |
+| proc2_passive_to_active | 23 | Ben painted the lantern before lunch. |
+| proc2_passive_to_active | 24 | Noah carries the sketchbook. |
+| proc2_passive_to_active | 25 | Amira painted the picnic basket after the match. |
+| proc2_passive_to_active | 26 | Luca lifts the rucksack. |
+| proc2_passive_to_active | 27 | Elsie opens the lantern. |
+| proc2_passive_to_active | 28 | Zac cleaned the rucksack after the match. |
+| proc2_passive_to_active | 29 | Mia carried the gate. |
+| proc2_passive_to_active | 30 | Sam lifted the picnic basket. |
+| proc2_pronoun_cohesion_choice | 1 | Amira gave Ava the ticket because Amira was carrying too many bags. |
+| proc2_pronoun_cohesion_choice | 2 | Jay gave Noah the torch because Noah needed it for the next lesson. |
+| proc2_pronoun_cohesion_choice | 3 | Jay gave Ava the ticket because Ava was leaving first. |
+| proc2_pronoun_cohesion_choice | 4 | Ruby gave Noah the torch because Noah was leaving first. |
+| proc2_pronoun_cohesion_choice | 5 | Jay gave Nora the torch because Nora needed it for the next lesson. |
+| proc2_pronoun_cohesion_choice | 6 | Luca gave Ava the glove because Ava was leaving first. |
+| proc2_pronoun_cohesion_choice | 7 | Ava gave Ben the note because Ben needed it for the next lesson. |
+| proc2_pronoun_cohesion_choice | 8 | Ben gave Amira the torch because Amira needed it for the next lesson. |
+| proc2_pronoun_cohesion_choice | 9 | Mia gave Sam the map because Mia was carrying too many bags. |
+| proc2_pronoun_cohesion_choice | 10 | Luca gave Ruby the glove because Luca was carrying too many bags. |
+| proc2_pronoun_cohesion_choice | 11 | Luca gave Zac the glove because Zac needed it for the next lesson. |
+| proc2_pronoun_cohesion_choice | 12 | Noah gave Ava the ticket because Noah was carrying too many bags. |
+| proc2_pronoun_cohesion_choice | 13 | Luca gave Noah the map because Noah was leaving first. |
+| proc2_pronoun_cohesion_choice | 14 | Zac gave Elsie the ticket because Zac had found it earlier. |
+| proc2_pronoun_cohesion_choice | 15 | Mia gave Zac the ticket because Mia had found it earlier. |
+| proc2_pronoun_cohesion_choice | 16 | Amira gave Ben the glove because Amira had found it earlier. |
+| proc2_pronoun_cohesion_choice | 17 | Jay gave Mia the ticket because Mia was leaving first. |
+| proc2_pronoun_cohesion_choice | 18 | Elsie gave Amira the ticket because Amira was leaving first. |
+| proc2_pronoun_cohesion_choice | 19 | Ava gave Elsie the ticket because Ava was carrying too many bags. |
+| proc2_pronoun_cohesion_choice | 20 | Nora gave Elsie the ticket because Nora had found it earlier. |
+| proc2_pronoun_cohesion_choice | 21 | Zac gave Elsie the torch because Zac had found it earlier. |
+| proc2_pronoun_cohesion_choice | 22 | Amira gave Mia the torch because Mia was leaving first. |
+| proc2_pronoun_cohesion_choice | 23 | Ben gave Ava the glove because Ben had found it earlier. |
+| proc2_pronoun_cohesion_choice | 24 | Noah gave Ruby the torch because Ruby was leaving first. |
+| proc2_pronoun_cohesion_choice | 25 | Amira gave Sam the ticket because Sam needed it for the next lesson. |
+| proc2_pronoun_cohesion_choice | 26 | Luca gave Nora the ticket because Nora was leaving first. |
+| proc2_pronoun_cohesion_choice | 27 | Elsie gave Ava the map because Ava was leaving first. |
+| proc2_pronoun_cohesion_choice | 28 | Zac gave Jay the glove because Jay needed it for the next lesson. |
+| proc2_pronoun_cohesion_choice | 29 | Mia gave Ben the torch because Ben was leaving first. |
+| proc2_pronoun_cohesion_choice | 30 | Sam gave Nora the ticket because Nora was leaving first. |
+| proc2_relative_clause_choice | 1 | The book that belonged to the club was easy to spot. |
+| proc2_relative_clause_choice | 2 | The bag which Ben packed carefully was easy to spot. |
+| proc2_relative_clause_choice | 3 | The book which Ben packed carefully was easy to spot. |
+| proc2_relative_clause_choice | 4 | The bag that everyone wanted was easy to spot. |
+| proc2_relative_clause_choice | 5 | The coat that everyone wanted was easy to spot. |
+| proc2_relative_clause_choice | 6 | The book that belonged to the club was easy to spot. |
+| proc2_relative_clause_choice | 7 | The runner who carried the flag waved to the crowd. |
+| proc2_relative_clause_choice | 8 | The boy who was first in line waved to the crowd. |
+| proc2_relative_clause_choice | 9 | The girl who wore a blue cap waved to the crowd. |
+| proc2_relative_clause_choice | 10 | The coat that belonged to the club was easy to spot. |
+| proc2_relative_clause_choice | 11 | The tent that belonged to the club was easy to spot. |
+| proc2_relative_clause_choice | 12 | The runner who had lost a glove waved to the crowd. |
+| proc2_relative_clause_choice | 13 | The bag that everyone wanted was easy to spot. |
+| proc2_relative_clause_choice | 14 | The teacher who had lost a glove waved to the crowd. |
+| proc2_relative_clause_choice | 15 | The teacher who was first in line waved to the crowd. |
+| proc2_relative_clause_choice | 16 | The book which stood by the window was easy to spot. |
+| proc2_relative_clause_choice | 17 | The book that belonged to the club was easy to spot. |
+| proc2_relative_clause_choice | 18 | The boy who had lost a glove waved to the crowd. |
+| proc2_relative_clause_choice | 19 | The teacher who was first in line waved to the crowd. |
+| proc2_relative_clause_choice | 20 | The bag that belonged to the club was easy to spot. |
+| proc2_relative_clause_choice | 21 | The teacher who was first in line waved to the crowd. |
+| proc2_relative_clause_choice | 22 | The book that everyone wanted was easy to spot. |
+| proc2_relative_clause_choice | 23 | The runner who had lost a glove waved to the crowd. |
+| proc2_relative_clause_choice | 24 | The girl who was first in line waved to the crowd. |
+| proc2_relative_clause_choice | 25 | The coat that belonged to the club was easy to spot. |
+| proc2_relative_clause_choice | 26 | The tent that belonged to the club was easy to spot. |
+| proc2_relative_clause_choice | 27 | The runner who wore a blue cap waved to the crowd. |
+| proc2_relative_clause_choice | 28 | The boy who had lost a glove waved to the crowd. |
+| proc2_relative_clause_choice | 29 | The runner who was first in line waved to the crowd. |
+| proc2_relative_clause_choice | 30 | The coat which Ben packed carefully was easy to spot. |
+| proc2_standard_english_choice | 1 | Ava doesn't know why the gate is locked. |
+| proc2_standard_english_choice | 2 | Noah doesn't know where the hall is. |
+| proc2_standard_english_choice | 3 | Ava doesn't know where the hall is. |
+| proc2_standard_english_choice | 4 | Noah saw the comet last night. |
+| proc2_standard_english_choice | 5 | Nora doesn't know the answer yet. |
+| proc2_standard_english_choice | 6 | Ava doesn't know why the gate is locked. |
+| proc2_standard_english_choice | 7 | The visitors were waiting by the gate. |
+| proc2_standard_english_choice | 8 | They were standing near the hall. |
+| proc2_standard_english_choice | 9 | We were ready for the start. |
+| proc2_standard_english_choice | 10 | Ruby doesn't know why the gate is locked. |
+| proc2_standard_english_choice | 11 | Luca doesn't know why the gate is locked. |
+| proc2_standard_english_choice | 12 | I did my homework before tea. |
+| proc2_standard_english_choice | 13 | Elsie doesn't know the answer yet. |
+| proc2_standard_english_choice | 14 | I did the poster before tea. |
+| proc2_standard_english_choice | 15 | They were walking home after lunch. |
+| proc2_standard_english_choice | 16 | Ben doesn't know how to fold the map. |
+| proc2_standard_english_choice | 17 | Mia doesn't know why the gate is locked. |
+| proc2_standard_english_choice | 18 | I did my reading record before tea. |
+| proc2_standard_english_choice | 19 | They were walking home after lunch. |
+| proc2_standard_english_choice | 20 | Elsie saw the trophy yesterday. |
+| proc2_standard_english_choice | 21 | I did the poster before tea. |
+| proc2_standard_english_choice | 22 | Mia doesn't know the answer yet. |
+| proc2_standard_english_choice | 23 | The players were waiting by the gate. |
+| proc2_standard_english_choice | 24 | I did the map work before tea. |
+| proc2_standard_english_choice | 25 | Nora doesn't know why the gate is locked. |
+| proc2_standard_english_choice | 26 | Jay doesn't know why the gate is locked. |
+| proc2_standard_english_choice | 27 | I did my homework before tea. |
+| proc2_standard_english_choice | 28 | I did my reading record before tea. |
+| proc2_standard_english_choice | 29 | They were waiting by the gate. |
+| proc2_standard_english_choice | 30 | Sam saw the notice last night. |
+| proc2_standard_english_fix | 1 | Ava doesn't know why the gate is locked. |
+| proc2_standard_english_fix | 2 | Noah doesn't know where the hall is. |
+| proc2_standard_english_fix | 3 | Ava doesn't know where the hall is. |
+| proc2_standard_english_fix | 4 | Noah saw the comet last night. |
+| proc2_standard_english_fix | 5 | Nora doesn't know the answer yet. |
+| proc2_standard_english_fix | 6 | Ava doesn't know why the gate is locked. |
+| proc2_standard_english_fix | 7 | The visitors were waiting by the gate. |
+| proc2_standard_english_fix | 8 | They were standing near the hall. |
+| proc2_standard_english_fix | 9 | We were ready for the start. |
+| proc2_standard_english_fix | 10 | Ruby doesn't know why the gate is locked. |
+| proc2_standard_english_fix | 11 | Luca doesn't know why the gate is locked. |
+| proc2_standard_english_fix | 12 | I did my homework before tea. |
+| proc2_standard_english_fix | 13 | Elsie doesn't know the answer yet. |
+| proc2_standard_english_fix | 14 | I did the poster before tea. |
+| proc2_standard_english_fix | 15 | They were walking home after lunch. |
+| proc2_standard_english_fix | 16 | Ben doesn't know how to fold the map. |
+| proc2_standard_english_fix | 17 | Mia doesn't know why the gate is locked. |
+| proc2_standard_english_fix | 18 | I did my reading record before tea. |
+| proc2_standard_english_fix | 19 | They were walking home after lunch. |
+| proc2_standard_english_fix | 20 | Elsie saw the trophy yesterday. |
+| proc2_standard_english_fix | 21 | I did the poster before tea. |
+| proc2_standard_english_fix | 22 | Mia doesn't know the answer yet. |
+| proc2_standard_english_fix | 23 | The players were waiting by the gate. |
+| proc2_standard_english_fix | 24 | I did the map work before tea. |
+| proc2_standard_english_fix | 25 | Nora doesn't know why the gate is locked. |
+| proc2_standard_english_fix | 26 | Jay doesn't know why the gate is locked. |
+| proc2_standard_english_fix | 27 | I did my homework before tea. |
+| proc2_standard_english_fix | 28 | I did my reading record before tea. |
+| proc2_standard_english_fix | 29 | They were waiting by the gate. |
+| proc2_standard_english_fix | 30 | Sam saw the notice last night. |
+| proc2_subject_object_identify | 1 | the sketchbook |
+| proc2_subject_object_identify | 2 | Noah |
+| proc2_subject_object_identify | 3 | the lantern |
+| proc2_subject_object_identify | 4 | Noah |
+| proc2_subject_object_identify | 5 | Nora |
+| proc2_subject_object_identify | 6 | the gate |
+| proc2_subject_object_identify | 7 | the rucksack |
+| proc2_subject_object_identify | 8 | the rucksack |
+| proc2_subject_object_identify | 9 | Sam |
+| proc2_subject_object_identify | 10 | the picnic basket |
+| proc2_subject_object_identify | 11 | Luca |
+| proc2_subject_object_identify | 12 | the sketchbook |
+| proc2_subject_object_identify | 13 | the lantern |
+| proc2_subject_object_identify | 14 | the map |
+| proc2_subject_object_identify | 15 | Elsie |
+| proc2_subject_object_identify | 16 | the trophy |
+| proc2_subject_object_identify | 17 | Mia |
+| proc2_subject_object_identify | 18 | Amira |
+| proc2_subject_object_identify | 19 | the picnic basket |
+| proc2_subject_object_identify | 20 | the map |
+| proc2_subject_object_identify | 21 | Zac |
+| proc2_subject_object_identify | 22 | Mia |
+| proc2_subject_object_identify | 23 | the map |
+| proc2_subject_object_identify | 24 | the lantern |
+| proc2_subject_object_identify | 25 | the rucksack |
+| proc2_subject_object_identify | 26 | Jay |
+| proc2_subject_object_identify | 27 | the gate |
+| proc2_subject_object_identify | 28 | the rucksack |
+| proc2_subject_object_identify | 29 | the gate |
+| proc2_subject_object_identify | 30 | the gate |
+| proc2_tense_aspect_choice | 1 | had finished |
+| proc2_tense_aspect_choice | 2 | started |
+| proc2_tense_aspect_choice | 3 | started |
+| proc2_tense_aspect_choice | 4 | visited |
+| proc2_tense_aspect_choice | 5 | started |
+| proc2_tense_aspect_choice | 6 | cleaned |
+| proc2_tense_aspect_choice | 7 | opened |
+| proc2_tense_aspect_choice | 8 | packed |
+| proc2_tense_aspect_choice | 9 | had packed |
+| proc2_tense_aspect_choice | 10 | cleaned |
+| proc2_tense_aspect_choice | 11 | had cleaned |
+| proc2_tense_aspect_choice | 12 | have lifted |
+| proc2_tense_aspect_choice | 13 | has finished |
+| proc2_tense_aspect_choice | 14 | have cleaned |
+| proc2_tense_aspect_choice | 15 | lifted |
+| proc2_tense_aspect_choice | 16 | finished |
+| proc2_tense_aspect_choice | 17 | have started |
+| proc2_tense_aspect_choice | 18 | had painted |
+| proc2_tense_aspect_choice | 19 | has opened |
+| proc2_tense_aspect_choice | 20 | started |
+| proc2_tense_aspect_choice | 21 | had painted |
+| proc2_tense_aspect_choice | 22 | had finished |
+| proc2_tense_aspect_choice | 23 | have opened |
+| proc2_tense_aspect_choice | 24 | has lifted |
+| proc2_tense_aspect_choice | 25 | have finished |
+| proc2_tense_aspect_choice | 26 | had cleaned |
+| proc2_tense_aspect_choice | 27 | has painted |
+| proc2_tense_aspect_choice | 28 | have painted |
+| proc2_tense_aspect_choice | 29 | packed |
+| proc2_tense_aspect_choice | 30 | washed |
+| proc3_apostrophe_rewrite | 1 | Luca's coats |
+| proc3_apostrophe_rewrite | 2 | Noah's tickets |
+| proc3_apostrophe_rewrite | 3 | Zac's tickets |
+| proc3_apostrophe_rewrite | 4 | Mia's lunchboxes |
+| proc3_apostrophe_rewrite | 5 | the children's coats |
+| proc3_apostrophe_rewrite | 6 | Amira's bags |
+| proc3_apostrophe_rewrite | 7 | Ruby's boots |
+| proc3_apostrophe_rewrite | 8 | the boys' books |
+| proc3_apostrophe_rewrite | 9 | the children's books |
+| proc3_apostrophe_rewrite | 10 | the men's bags |
+| proc3_apostrophe_rewrite | 11 | the teachers' bags |
+| proc3_apostrophe_rewrite | 12 | Luca's bikes |
+| proc3_apostrophe_rewrite | 13 | the girls' bags |
+| proc3_apostrophe_rewrite | 14 | the teachers' bags |
+| proc3_apostrophe_rewrite | 15 | the players' books |
+| proc3_apostrophe_rewrite | 16 | Nora's coats |
+| proc3_apostrophe_rewrite | 17 | Luca's coats |
+| proc3_apostrophe_rewrite | 18 | the teachers' bikes |
+| proc3_apostrophe_rewrite | 19 | Zac's boots |
+| proc3_apostrophe_rewrite | 20 | the teachers' tickets |
+| proc3_apostrophe_rewrite | 21 | the boys' bags |
+| proc3_apostrophe_rewrite | 22 | Mia's coats |
+| proc3_apostrophe_rewrite | 23 | Amira's boots |
+| proc3_apostrophe_rewrite | 24 | the people's bikes |
+| proc3_apostrophe_rewrite | 25 | the men's coats |
+| proc3_apostrophe_rewrite | 26 | the men's bags |
+| proc3_apostrophe_rewrite | 27 | Ava's bikes |
+| proc3_apostrophe_rewrite | 28 | the men's bikes |
+| proc3_apostrophe_rewrite | 29 | Noah's books |
+| proc3_apostrophe_rewrite | 30 | the people's lunchboxes |
+| proc3_clause_join_rewrite | 1 | We stayed inside because it was raining. |
+| proc3_clause_join_rewrite | 2 | Ben hurried home because he had forgotten his kit. |
+| proc3_clause_join_rewrite | 3 | Mia smiled because she had found the missing map. |
+| proc3_clause_join_rewrite | 4 | Although Mia was tired, she finished the race. |
+| proc3_clause_join_rewrite | 5 | Although the path was muddy, the walkers kept going. |
+| proc3_clause_join_rewrite | 6 | Although the room was noisy, Jay carried on reading. |
+| proc3_clause_join_rewrite | 7 | When the bell rang, the pupils lined up. |
+| proc3_clause_join_rewrite | 8 | When the gate opened, the crowd cheered. |
+| proc3_clause_join_rewrite | 9 | When the lights went out, everyone fell silent. |
+| proc3_clause_join_rewrite | 10 | If you need help, call the office. |
+| proc3_clause_join_rewrite | 11 | If the rain starts, go inside the tent. |
+| proc3_clause_join_rewrite | 12 | If the torch stops working, fetch the spare one. |
+| proc3_clause_join_rewrite | 13 | We stayed inside because it was raining. |
+| proc3_clause_join_rewrite | 14 | Ben hurried home because he had forgotten his kit. |
+| proc3_clause_join_rewrite | 15 | Mia smiled because she had found the missing map. |
+| proc3_clause_join_rewrite | 16 | Although Mia was tired, she finished the race. |
+| proc3_clause_join_rewrite | 17 | Although the path was muddy, the walkers kept going. |
+| proc3_clause_join_rewrite | 18 | Although the room was noisy, Jay carried on reading. |
+| proc3_clause_join_rewrite | 19 | When the bell rang, the pupils lined up. |
+| proc3_clause_join_rewrite | 20 | When the gate opened, the crowd cheered. |
+| proc3_clause_join_rewrite | 21 | When the lights went out, everyone fell silent. |
+| proc3_clause_join_rewrite | 22 | If you need help, call the office. |
+| proc3_clause_join_rewrite | 23 | If the rain starts, go inside the tent. |
+| proc3_clause_join_rewrite | 24 | If the torch stops working, fetch the spare one. |
+| proc3_clause_join_rewrite | 25 | We stayed inside because it was raining. |
+| proc3_clause_join_rewrite | 26 | Ben hurried home because he had forgotten his kit. |
+| proc3_clause_join_rewrite | 27 | Mia smiled because she had found the missing map. |
+| proc3_clause_join_rewrite | 28 | Although Mia was tired, she finished the race. |
+| proc3_clause_join_rewrite | 29 | Although the path was muddy, the walkers kept going. |
+| proc3_clause_join_rewrite | 30 | Although the room was noisy, Jay carried on reading. |
+| proc3_hyphen_fix_meaning | 1 | We saw a man-eating shark near the rocks. |
+| proc3_hyphen_fix_meaning | 2 | The class made a last-minute poster for the hall. |
+| proc3_hyphen_fix_meaning | 3 | She bought a sugar-free drink for the journey. |
+| proc3_hyphen_fix_meaning | 4 | The team needed a well-earned break after the match. |
+| proc3_hyphen_fix_meaning | 5 | Ben wore his brand-new trainers to the park. |
+| proc3_hyphen_fix_meaning | 6 | We crossed the narrow, fast-flowing stream. |
+| proc3_hyphen_fix_meaning | 7 | The school held a fun-filled sports day on Friday. |
+| proc3_hyphen_fix_meaning | 8 | Mia drew a life-size portrait of her brother. |
+| proc3_hyphen_fix_meaning | 9 | We visited the small-animal hospital after lunch. |
+| proc3_hyphen_fix_meaning | 10 | We saw a man-eating shark near the rocks. |
+| proc3_hyphen_fix_meaning | 11 | The class made a last-minute poster for the hall. |
+| proc3_hyphen_fix_meaning | 12 | She bought a sugar-free drink for the journey. |
+| proc3_hyphen_fix_meaning | 13 | The team needed a well-earned break after the match. |
+| proc3_hyphen_fix_meaning | 14 | Ben wore his brand-new trainers to the park. |
+| proc3_hyphen_fix_meaning | 15 | We crossed the narrow, fast-flowing stream. |
+| proc3_hyphen_fix_meaning | 16 | The school held a fun-filled sports day on Friday. |
+| proc3_hyphen_fix_meaning | 17 | Mia drew a life-size portrait of her brother. |
+| proc3_hyphen_fix_meaning | 18 | We visited the small-animal hospital after lunch. |
+| proc3_hyphen_fix_meaning | 19 | We saw a man-eating shark near the rocks. |
+| proc3_hyphen_fix_meaning | 20 | The class made a last-minute poster for the hall. |
+| proc3_hyphen_fix_meaning | 21 | She bought a sugar-free drink for the journey. |
+| proc3_hyphen_fix_meaning | 22 | The team needed a well-earned break after the match. |
+| proc3_hyphen_fix_meaning | 23 | Ben wore his brand-new trainers to the park. |
+| proc3_hyphen_fix_meaning | 24 | We crossed the narrow, fast-flowing stream. |
+| proc3_hyphen_fix_meaning | 25 | The school held a fun-filled sports day on Friday. |
+| proc3_hyphen_fix_meaning | 26 | Mia drew a life-size portrait of her brother. |
+| proc3_hyphen_fix_meaning | 27 | We visited the small-animal hospital after lunch. |
+| proc3_hyphen_fix_meaning | 28 | We saw a man-eating shark near the rocks. |
+| proc3_hyphen_fix_meaning | 29 | The class made a last-minute poster for the hall. |
+| proc3_hyphen_fix_meaning | 30 | She bought a sugar-free drink for the journey. |
+| proc3_noun_phrase_build | 1 | The whole phrase centres on the noun at the end. |
+| proc3_noun_phrase_build | 2 | The whole phrase centres on the noun at the end. |
+| proc3_noun_phrase_build | 3 | The whole phrase centres on the noun at the end. |
+| proc3_noun_phrase_build | 4 | The whole phrase centres on the noun at the end. |
+| proc3_noun_phrase_build | 5 | The whole phrase centres on the noun at the end. |
+| proc3_noun_phrase_build | 6 | The whole phrase centres on the noun at the end. |
+| proc3_noun_phrase_build | 7 | The whole phrase centres on the noun at the end. |
+| proc3_noun_phrase_build | 8 | The whole phrase centres on the noun at the end. |
+| proc3_noun_phrase_build | 9 | The whole phrase centres on the noun at the end. |
+| proc3_noun_phrase_build | 10 | The whole phrase centres on the noun at the end. |
+| proc3_noun_phrase_build | 11 | The whole phrase centres on the noun at the end. |
+| proc3_noun_phrase_build | 12 | The whole phrase centres on the noun at the end. |
+| proc3_noun_phrase_build | 13 | The whole phrase centres on the noun at the end. |
+| proc3_noun_phrase_build | 14 | The whole phrase centres on the noun at the end. |
+| proc3_noun_phrase_build | 15 | The whole phrase centres on the noun at the end. |
+| proc3_noun_phrase_build | 16 | The whole phrase centres on the noun at the end. |
+| proc3_noun_phrase_build | 17 | The whole phrase centres on the noun at the end. |
+| proc3_noun_phrase_build | 18 | The whole phrase centres on the noun at the end. |
+| proc3_noun_phrase_build | 19 | The whole phrase centres on the noun at the end. |
+| proc3_noun_phrase_build | 20 | The whole phrase centres on the noun at the end. |
+| proc3_noun_phrase_build | 21 | The whole phrase centres on the noun at the end. |
+| proc3_noun_phrase_build | 22 | The whole phrase centres on the noun at the end. |
+| proc3_noun_phrase_build | 23 | The whole phrase centres on the noun at the end. |
+| proc3_noun_phrase_build | 24 | The whole phrase centres on the noun at the end. |
+| proc3_noun_phrase_build | 25 | The whole phrase centres on the noun at the end. |
+| proc3_noun_phrase_build | 26 | The whole phrase centres on the noun at the end. |
+| proc3_noun_phrase_build | 27 | The whole phrase centres on the noun at the end. |
+| proc3_noun_phrase_build | 28 | The whole phrase centres on the noun at the end. |
+| proc3_noun_phrase_build | 29 | The whole phrase centres on the noun at the end. |
+| proc3_noun_phrase_build | 30 | The whole phrase centres on the noun at the end. |
+| proc3_parenthesis_commas_fix | 1 | The map, in my opinion, needs replacing. |
+| proc3_parenthesis_commas_fix | 2 | Our new puppy, to my surprise, slept through the storm. |
+| proc3_parenthesis_commas_fix | 3 | The coach, without any warning, changed the teams. |
+| proc3_parenthesis_commas_fix | 4 | The old bridge, as everyone knew, was unsafe. |
+| proc3_parenthesis_commas_fix | 5 | The visitors, despite the rain, stayed until the end. |
+| proc3_parenthesis_commas_fix | 6 | Her answer, I think, was correct. |
+| proc3_parenthesis_commas_fix | 7 | The new path, believe it or not, was finished in a day. |
+| proc3_parenthesis_commas_fix | 8 | The hall, to be honest, needed a new coat of paint. |
+| proc3_parenthesis_commas_fix | 9 | Ben, after a short pause, opened the gate. |
+| proc3_parenthesis_commas_fix | 10 | The map, in my opinion, needs replacing. |
+| proc3_parenthesis_commas_fix | 11 | Our new puppy, to my surprise, slept through the storm. |
+| proc3_parenthesis_commas_fix | 12 | The coach, without any warning, changed the teams. |
+| proc3_parenthesis_commas_fix | 13 | The old bridge, as everyone knew, was unsafe. |
+| proc3_parenthesis_commas_fix | 14 | The visitors, despite the rain, stayed until the end. |
+| proc3_parenthesis_commas_fix | 15 | Her answer, I think, was correct. |
+| proc3_parenthesis_commas_fix | 16 | The new path, believe it or not, was finished in a day. |
+| proc3_parenthesis_commas_fix | 17 | The hall, to be honest, needed a new coat of paint. |
+| proc3_parenthesis_commas_fix | 18 | Ben, after a short pause, opened the gate. |
+| proc3_parenthesis_commas_fix | 19 | The map, in my opinion, needs replacing. |
+| proc3_parenthesis_commas_fix | 20 | Our new puppy, to my surprise, slept through the storm. |
+| proc3_parenthesis_commas_fix | 21 | The coach, without any warning, changed the teams. |
+| proc3_parenthesis_commas_fix | 22 | The old bridge, as everyone knew, was unsafe. |
+| proc3_parenthesis_commas_fix | 23 | The visitors, despite the rain, stayed until the end. |
+| proc3_parenthesis_commas_fix | 24 | Her answer, I think, was correct. |
+| proc3_parenthesis_commas_fix | 25 | The new path, believe it or not, was finished in a day. |
+| proc3_parenthesis_commas_fix | 26 | The hall, to be honest, needed a new coat of paint. |
+| proc3_parenthesis_commas_fix | 27 | Ben, after a short pause, opened the gate. |
+| proc3_parenthesis_commas_fix | 28 | The map, in my opinion, needs replacing. |
+| proc3_parenthesis_commas_fix | 29 | Our new puppy, to my surprise, slept through the storm. |
+| proc3_parenthesis_commas_fix | 30 | The coach, without any warning, changed the teams. |
+| proc3_sentence_function_choice | 1 | Close the gate before the dog runs out. |
+| proc3_sentence_function_choice | 2 | Bring the blue folder to the hall. |
+| proc3_sentence_function_choice | 3 | Close the gate before the dog runs out. |
+| proc3_sentence_function_choice | 4 | How quickly the clouds moved! |
+| proc3_sentence_function_choice | 5 | Put the wet boots on the mat. |
+| proc3_sentence_function_choice | 6 | Close the gate before the dog runs out. |
+| proc3_sentence_function_choice | 7 | The lantern was still on the bench. |
+| proc3_sentence_function_choice | 8 | The path beside the stream was muddy. |
+| proc3_sentence_function_choice | 9 | Our team practised in the hall today. |
+| proc3_sentence_function_choice | 10 | Put the wet boots on the mat. |
+| proc3_sentence_function_choice | 11 | Wait by the door for the coach. |
+| proc3_sentence_function_choice | 12 | Where is the missing torch? |
+| proc3_sentence_function_choice | 13 | Bring the blue folder to the hall. |
+| proc3_sentence_function_choice | 14 | When does the match begin? |
+| proc3_sentence_function_choice | 15 | The choir begins at nine o'clock. |
+| proc3_sentence_function_choice | 16 | Close the gate before the dog runs out. |
+| proc3_sentence_function_choice | 17 | Close the gate before the dog runs out. |
+| proc3_sentence_function_choice | 18 | Why is the gate still open? |
+| proc3_sentence_function_choice | 19 | The choir begins at nine o'clock. |
+| proc3_sentence_function_choice | 20 | How quickly the clouds moved! |
+| proc3_sentence_function_choice | 21 | When does the match begin? |
+| proc3_sentence_function_choice | 22 | Close the gate before the dog runs out. |
+| proc3_sentence_function_choice | 23 | The lantern was still on the bench. |
+| proc3_sentence_function_choice | 24 | Who packed the blue folder? |
+| proc3_sentence_function_choice | 25 | Put the wet boots on the mat. |
+| proc3_sentence_function_choice | 26 | Wait by the door for the coach. |
+| proc3_sentence_function_choice | 27 | Where is the missing torch? |
+| proc3_sentence_function_choice | 28 | Why is the gate still open? |
+| proc3_sentence_function_choice | 29 | The lantern was still on the bench. |
+| proc3_sentence_function_choice | 30 | How bright the lantern looked! |
+| proc3_word_class_contrast_choice | 1 | adverb |
+| proc3_word_class_contrast_choice | 2 | determiner |
+| proc3_word_class_contrast_choice | 3 | pronoun |
+| proc3_word_class_contrast_choice | 4 | conjunction |
+| proc3_word_class_contrast_choice | 5 | preposition |
+| proc3_word_class_contrast_choice | 6 | adverb |
+| proc3_word_class_contrast_choice | 7 | conjunction |
+| proc3_word_class_contrast_choice | 8 | determiner |
+| proc3_word_class_contrast_choice | 9 | preposition |
+| proc3_word_class_contrast_choice | 10 | adverb |
+| proc3_word_class_contrast_choice | 11 | determiner |
+| proc3_word_class_contrast_choice | 12 | pronoun |
+| proc3_word_class_contrast_choice | 13 | conjunction |
+| proc3_word_class_contrast_choice | 14 | preposition |
+| proc3_word_class_contrast_choice | 15 | adverb |
+| proc3_word_class_contrast_choice | 16 | conjunction |
+| proc3_word_class_contrast_choice | 17 | determiner |
+| proc3_word_class_contrast_choice | 18 | preposition |
+| proc3_word_class_contrast_choice | 19 | adverb |
+| proc3_word_class_contrast_choice | 20 | determiner |
+| proc3_word_class_contrast_choice | 21 | pronoun |
+| proc3_word_class_contrast_choice | 22 | conjunction |
+| proc3_word_class_contrast_choice | 23 | preposition |
+| proc3_word_class_contrast_choice | 24 | adverb |
+| proc3_word_class_contrast_choice | 25 | conjunction |
+| proc3_word_class_contrast_choice | 26 | determiner |
+| proc3_word_class_contrast_choice | 27 | preposition |
+| proc3_word_class_contrast_choice | 28 | adverb |
+| proc3_word_class_contrast_choice | 29 | determiner |
+| proc3_word_class_contrast_choice | 30 | pronoun |
+| qg_active_passive_choice | 1 | The hall was locked by the caretaker before assembly. |
+| qg_active_passive_choice | 2 | The scenery was painted by Aisha for the play. |
+| qg_active_passive_choice | 3 | The hedges were trimmed by the gardener on Monday. |
+| qg_active_passive_choice | 4 | The boxes were carried by Noah to the office. |
+| qg_active_passive_choice | 5 | The meal was prepared by the chef before noon. |
+| qg_active_passive_choice | 6 | The poster was designed by Lena for the fair. |
+| qg_active_passive_choice | 7 | The returned books were sorted by the librarian. |
+| qg_active_passive_choice | 8 | The puncture was repaired by Sam during break. |
+| qg_active_passive_choice | 9 | The heavy gate was opened by Maya after lunch. |
+| qg_active_passive_choice | 10 | The hall was locked by the caretaker before assembly. |
+| qg_active_passive_choice | 11 | The scenery was painted by Aisha for the play. |
+| qg_active_passive_choice | 12 | The hedges were trimmed by the gardener on Monday. |
+| qg_active_passive_choice | 13 | The boxes were carried by Noah to the office. |
+| qg_active_passive_choice | 14 | The meal was prepared by the chef before noon. |
+| qg_active_passive_choice | 15 | The poster was designed by Lena for the fair. |
+| qg_active_passive_choice | 16 | The returned books were sorted by the librarian. |
+| qg_active_passive_choice | 17 | The puncture was repaired by Sam during break. |
+| qg_active_passive_choice | 18 | The heavy gate was opened by Maya after lunch. |
+| qg_active_passive_choice | 19 | The hall was locked by the caretaker before assembly. |
+| qg_active_passive_choice | 20 | The scenery was painted by Aisha for the play. |
+| qg_active_passive_choice | 21 | The hedges were trimmed by the gardener on Monday. |
+| qg_active_passive_choice | 22 | The boxes were carried by Noah to the office. |
+| qg_active_passive_choice | 23 | The meal was prepared by the chef before noon. |
+| qg_active_passive_choice | 24 | The poster was designed by Lena for the fair. |
+| qg_active_passive_choice | 25 | The returned books were sorted by the librarian. |
+| qg_active_passive_choice | 26 | The puncture was repaired by Sam during break. |
+| qg_active_passive_choice | 27 | The heavy gate was opened by Maya after lunch. |
+| qg_active_passive_choice | 28 | The hall was locked by the caretaker before assembly. |
+| qg_active_passive_choice | 29 | The scenery was painted by Aisha for the play. |
+| qg_active_passive_choice | 30 | The hedges were trimmed by the gardener on Monday. |
+| qg_formality_classify_table | 1 | The equipment was inspected before use. -> formal \| The kit got checked before we used it. -> informal |
+| qg_formality_classify_table | 2 | Pupils are required to return the form by Friday. -> formal \| Bring the form back by Friday, OK? -> informal |
+| qg_formality_classify_table | 3 | The committee has resolved to postpone the event. -> formal \| We've decided to put the event off for now. -> informal |
+| qg_formality_classify_table | 4 | Residents are advised to secure their windows. -> formal \| You should probably shut your windows. -> informal |
+| qg_formality_classify_table | 5 | The headteacher wishes to commend the volunteers. -> formal \| The head wants to say well done to the helpers. -> informal |
+| qg_formality_classify_table | 6 | All participants must register prior to the deadline. -> formal \| Everyone needs to sign up before it's too late. -> informal |
+| qg_formality_classify_table | 7 | The council has undertaken to repair the footpath. -> formal \| The council said they'd fix the path. -> informal |
+| qg_formality_classify_table | 8 | Visitors are respectfully reminded to switch off mobile devices. -> formal \| Can everyone turn their phones off, please? -> informal |
+| qg_formality_classify_table | 9 | We request that visitors remain seated. -> formal \| Please hang on until we get started. -> informal |
+| qg_formality_classify_table | 10 | The equipment was inspected before use. -> formal \| The kit got checked before we used it. -> informal |
+| qg_formality_classify_table | 11 | Pupils are required to return the form by Friday. -> formal \| Bring the form back by Friday, OK? -> informal |
+| qg_formality_classify_table | 12 | The committee has resolved to postpone the event. -> formal \| We've decided to put the event off for now. -> informal |
+| qg_formality_classify_table | 13 | Residents are advised to secure their windows. -> formal \| You should probably shut your windows. -> informal |
+| qg_formality_classify_table | 14 | The headteacher wishes to commend the volunteers. -> formal \| The head wants to say well done to the helpers. -> informal |
+| qg_formality_classify_table | 15 | All participants must register prior to the deadline. -> formal \| Everyone needs to sign up before it's too late. -> informal |
+| qg_formality_classify_table | 16 | The council has undertaken to repair the footpath. -> formal \| The council said they'd fix the path. -> informal |
+| qg_formality_classify_table | 17 | Visitors are respectfully reminded to switch off mobile devices. -> formal \| Can everyone turn their phones off, please? -> informal |
+| qg_formality_classify_table | 18 | We request that visitors remain seated. -> formal \| Please hang on until we get started. -> informal |
+| qg_formality_classify_table | 19 | The equipment was inspected before use. -> formal \| The kit got checked before we used it. -> informal |
+| qg_formality_classify_table | 20 | Pupils are required to return the form by Friday. -> formal \| Bring the form back by Friday, OK? -> informal |
+| qg_formality_classify_table | 21 | The committee has resolved to postpone the event. -> formal \| We've decided to put the event off for now. -> informal |
+| qg_formality_classify_table | 22 | Residents are advised to secure their windows. -> formal \| You should probably shut your windows. -> informal |
+| qg_formality_classify_table | 23 | The headteacher wishes to commend the volunteers. -> formal \| The head wants to say well done to the helpers. -> informal |
+| qg_formality_classify_table | 24 | All participants must register prior to the deadline. -> formal \| Everyone needs to sign up before it's too late. -> informal |
+| qg_formality_classify_table | 25 | The council has undertaken to repair the footpath. -> formal \| The council said they'd fix the path. -> informal |
+| qg_formality_classify_table | 26 | Visitors are respectfully reminded to switch off mobile devices. -> formal \| Can everyone turn their phones off, please? -> informal |
+| qg_formality_classify_table | 27 | We request that visitors remain seated. -> formal \| Please hang on until we get started. -> informal |
+| qg_formality_classify_table | 28 | The equipment was inspected before use. -> formal \| The kit got checked before we used it. -> informal |
+| qg_formality_classify_table | 29 | Pupils are required to return the form by Friday. -> formal \| Bring the form back by Friday, OK? -> informal |
+| qg_formality_classify_table | 30 | The committee has resolved to postpone the event. -> formal \| We've decided to put the event off for now. -> informal |
+| qg_hyphen_ambiguity_explain | 1 | The hyphen shows that the hospital is for small animals. |
+| qg_hyphen_ambiguity_explain | 2 | The hyphen shows that 'last-minute' is one describing idea before 'poster'. |
+| qg_hyphen_ambiguity_explain | 3 | The hyphen shows that 'well-known' is one describing idea before 'author'. |
+| qg_hyphen_ambiguity_explain | 4 | The hyphen links twenty and four as a single compound number. |
+| qg_hyphen_ambiguity_explain | 5 | The hyphen shows cover again, not get back. |
+| qg_hyphen_ambiguity_explain | 6 | The hyphen shows that 'old-fashioned' is one describing idea before 'clock'. |
+| qg_hyphen_ambiguity_explain | 7 | The hyphen shows that 'long-term' is one describing idea before 'plan'. |
+| qg_hyphen_ambiguity_explain | 8 | The hyphen shows that the shark eats people. |
+| qg_hyphen_ambiguity_explain | 9 | The hyphen shows that the hospital is for small animals. |
+| qg_hyphen_ambiguity_explain | 10 | The hyphen shows that 'last-minute' is one describing idea before 'poster'. |
+| qg_hyphen_ambiguity_explain | 11 | The hyphen shows that 'well-known' is one describing idea before 'author'. |
+| qg_hyphen_ambiguity_explain | 12 | The hyphen links twenty and four as a single compound number. |
+| qg_hyphen_ambiguity_explain | 13 | The hyphen shows cover again, not get back. |
+| qg_hyphen_ambiguity_explain | 14 | The hyphen shows that 'old-fashioned' is one describing idea before 'clock'. |
+| qg_hyphen_ambiguity_explain | 15 | The hyphen shows that 'long-term' is one describing idea before 'plan'. |
+| qg_hyphen_ambiguity_explain | 16 | The hyphen shows that the shark eats people. |
+| qg_hyphen_ambiguity_explain | 17 | The hyphen shows that the hospital is for small animals. |
+| qg_hyphen_ambiguity_explain | 18 | The hyphen shows that 'last-minute' is one describing idea before 'poster'. |
+| qg_hyphen_ambiguity_explain | 19 | The hyphen shows that 'well-known' is one describing idea before 'author'. |
+| qg_hyphen_ambiguity_explain | 20 | The hyphen links twenty and four as a single compound number. |
+| qg_hyphen_ambiguity_explain | 21 | The hyphen shows cover again, not get back. |
+| qg_hyphen_ambiguity_explain | 22 | The hyphen shows that 'old-fashioned' is one describing idea before 'clock'. |
+| qg_hyphen_ambiguity_explain | 23 | The hyphen shows that 'long-term' is one describing idea before 'plan'. |
+| qg_hyphen_ambiguity_explain | 24 | The hyphen shows that the shark eats people. |
+| qg_hyphen_ambiguity_explain | 25 | The hyphen shows that the hospital is for small animals. |
+| qg_hyphen_ambiguity_explain | 26 | The hyphen shows that 'last-minute' is one describing idea before 'poster'. |
+| qg_hyphen_ambiguity_explain | 27 | The hyphen shows that 'well-known' is one describing idea before 'author'. |
+| qg_hyphen_ambiguity_explain | 28 | The hyphen links twenty and four as a single compound number. |
+| qg_hyphen_ambiguity_explain | 29 | The hyphen shows cover again, not get back. |
+| qg_hyphen_ambiguity_explain | 30 | The hyphen shows that 'old-fashioned' is one describing idea before 'clock'. |
+| qg_modal_verb_explain | 1 | It shows possibility, not certainty. |
+| qg_modal_verb_explain | 2 | It gives advice. |
+| qg_modal_verb_explain | 3 | It asks for permission politely. |
+| qg_modal_verb_explain | 4 | It shows past ability. |
+| qg_modal_verb_explain | 5 | It shows certainty about a future event. |
+| qg_modal_verb_explain | 6 | It expresses a rule or prohibition. |
+| qg_modal_verb_explain | 7 | It shows possibility or uncertainty. |
+| qg_modal_verb_explain | 8 | It shows a rule or strong obligation. |
+| qg_modal_verb_explain | 9 | It shows possibility, not certainty. |
+| qg_modal_verb_explain | 10 | It gives advice. |
+| qg_modal_verb_explain | 11 | It asks for permission politely. |
+| qg_modal_verb_explain | 12 | It shows past ability. |
+| qg_modal_verb_explain | 13 | It shows certainty about a future event. |
+| qg_modal_verb_explain | 14 | It expresses a rule or prohibition. |
+| qg_modal_verb_explain | 15 | It shows possibility or uncertainty. |
+| qg_modal_verb_explain | 16 | It shows a rule or strong obligation. |
+| qg_modal_verb_explain | 17 | It shows possibility, not certainty. |
+| qg_modal_verb_explain | 18 | It gives advice. |
+| qg_modal_verb_explain | 19 | It asks for permission politely. |
+| qg_modal_verb_explain | 20 | It shows past ability. |
+| qg_modal_verb_explain | 21 | It shows certainty about a future event. |
+| qg_modal_verb_explain | 22 | It expresses a rule or prohibition. |
+| qg_modal_verb_explain | 23 | It shows possibility or uncertainty. |
+| qg_modal_verb_explain | 24 | It shows a rule or strong obligation. |
+| qg_modal_verb_explain | 25 | It shows possibility, not certainty. |
+| qg_modal_verb_explain | 26 | It gives advice. |
+| qg_modal_verb_explain | 27 | It asks for permission politely. |
+| qg_modal_verb_explain | 28 | It shows past ability. |
+| qg_modal_verb_explain | 29 | It shows certainty about a future event. |
+| qg_modal_verb_explain | 30 | It expresses a rule or prohibition. |
+| qg_p3_active_passive_explain | 1 | The doer, the caretaker, is the subject before the verb. |
+| qg_p3_active_passive_explain | 2 | It foregrounds the broken window and does not name the doer. |
+| qg_p3_active_passive_explain | 3 | Was carrying is progressive; Maya is still the doer before the verb. |
+| qg_p3_active_passive_explain | 4 | Aisha is still the doer, but the scenery has been moved to the subject position. |
+| qg_p3_active_passive_explain | 5 | Passive voice can leave out the by-phrase when the doer is unknown or less important. |
+| qg_p3_active_passive_explain | 6 | The storm is the subject that does the action of destroying. |
+| qg_p3_active_passive_explain | 7 | Passive voice foregrounds the report and backgrounds who wrote it. |
+| qg_p3_active_passive_explain | 8 | The thing affected comes first and the doer comes after by. |
+| qg_p3_active_passive_explain | 9 | The doer, the caretaker, is the subject before the verb. |
+| qg_p3_active_passive_explain | 10 | It foregrounds the broken window and does not name the doer. |
+| qg_p3_active_passive_explain | 11 | Was carrying is progressive; Maya is still the doer before the verb. |
+| qg_p3_active_passive_explain | 12 | Aisha is still the doer, but the scenery has been moved to the subject position. |
+| qg_p3_active_passive_explain | 13 | Passive voice can leave out the by-phrase when the doer is unknown or less important. |
+| qg_p3_active_passive_explain | 14 | The storm is the subject that does the action of destroying. |
+| qg_p3_active_passive_explain | 15 | Passive voice foregrounds the report and backgrounds who wrote it. |
+| qg_p3_active_passive_explain | 16 | The thing affected comes first and the doer comes after by. |
+| qg_p3_active_passive_explain | 17 | The doer, the caretaker, is the subject before the verb. |
+| qg_p3_active_passive_explain | 18 | It foregrounds the broken window and does not name the doer. |
+| qg_p3_active_passive_explain | 19 | Was carrying is progressive; Maya is still the doer before the verb. |
+| qg_p3_active_passive_explain | 20 | Aisha is still the doer, but the scenery has been moved to the subject position. |
+| qg_p3_active_passive_explain | 21 | Passive voice can leave out the by-phrase when the doer is unknown or less important. |
+| qg_p3_active_passive_explain | 22 | The storm is the subject that does the action of destroying. |
+| qg_p3_active_passive_explain | 23 | Passive voice foregrounds the report and backgrounds who wrote it. |
+| qg_p3_active_passive_explain | 24 | The thing affected comes first and the doer comes after by. |
+| qg_p3_active_passive_explain | 25 | The doer, the caretaker, is the subject before the verb. |
+| qg_p3_active_passive_explain | 26 | It foregrounds the broken window and does not name the doer. |
+| qg_p3_active_passive_explain | 27 | Was carrying is progressive; Maya is still the doer before the verb. |
+| qg_p3_active_passive_explain | 28 | Aisha is still the doer, but the scenery has been moved to the subject position. |
+| qg_p3_active_passive_explain | 29 | Passive voice can leave out the by-phrase when the doer is unknown or less important. |
+| qg_p3_active_passive_explain | 30 | The storm is the subject that does the action of destroying. |
+| qg_p3_apostrophe_possession_explain | 1 | More than one girl owns the bags, and girls is a regular plural ending in s. |
+| qg_p3_apostrophe_possession_explain | 2 | Children is an irregular plural that does not end in s, so it takes apostrophe + s. |
+| qg_p3_apostrophe_possession_explain | 3 | The apostrophe shows the desk belongs to the teacher. |
+| qg_p3_apostrophe_possession_explain | 4 | The room belongs to more than one boy, so the apostrophe follows the plural s. |
+| qg_p3_apostrophe_possession_explain | 5 | One dog owns more than one bowl, so the apostrophe is before s in dog's. |
+| qg_p3_apostrophe_possession_explain | 6 | Names ending in s can take apostrophe + s to show singular possession. |
+| qg_p3_apostrophe_possession_explain | 7 | Tables here is a simple plural, not a possessive, so no apostrophe is needed. |
+| qg_p3_apostrophe_possession_explain | 8 | One girl owns the bag, so singular possession uses apostrophe + s. |
+| qg_p3_apostrophe_possession_explain | 9 | More than one girl owns the bags, and girls is a regular plural ending in s. |
+| qg_p3_apostrophe_possession_explain | 10 | Children is an irregular plural that does not end in s, so it takes apostrophe + s. |
+| qg_p3_apostrophe_possession_explain | 11 | The apostrophe shows the desk belongs to the teacher. |
+| qg_p3_apostrophe_possession_explain | 12 | The room belongs to more than one boy, so the apostrophe follows the plural s. |
+| qg_p3_apostrophe_possession_explain | 13 | One dog owns more than one bowl, so the apostrophe is before s in dog's. |
+| qg_p3_apostrophe_possession_explain | 14 | Names ending in s can take apostrophe + s to show singular possession. |
+| qg_p3_apostrophe_possession_explain | 15 | Tables here is a simple plural, not a possessive, so no apostrophe is needed. |
+| qg_p3_apostrophe_possession_explain | 16 | One girl owns the bag, so singular possession uses apostrophe + s. |
+| qg_p3_apostrophe_possession_explain | 17 | More than one girl owns the bags, and girls is a regular plural ending in s. |
+| qg_p3_apostrophe_possession_explain | 18 | Children is an irregular plural that does not end in s, so it takes apostrophe + s. |
+| qg_p3_apostrophe_possession_explain | 19 | The apostrophe shows the desk belongs to the teacher. |
+| qg_p3_apostrophe_possession_explain | 20 | The room belongs to more than one boy, so the apostrophe follows the plural s. |
+| qg_p3_apostrophe_possession_explain | 21 | One dog owns more than one bowl, so the apostrophe is before s in dog's. |
+| qg_p3_apostrophe_possession_explain | 22 | Names ending in s can take apostrophe + s to show singular possession. |
+| qg_p3_apostrophe_possession_explain | 23 | Tables here is a simple plural, not a possessive, so no apostrophe is needed. |
+| qg_p3_apostrophe_possession_explain | 24 | One girl owns the bag, so singular possession uses apostrophe + s. |
+| qg_p3_apostrophe_possession_explain | 25 | More than one girl owns the bags, and girls is a regular plural ending in s. |
+| qg_p3_apostrophe_possession_explain | 26 | Children is an irregular plural that does not end in s, so it takes apostrophe + s. |
+| qg_p3_apostrophe_possession_explain | 27 | The apostrophe shows the desk belongs to the teacher. |
+| qg_p3_apostrophe_possession_explain | 28 | The room belongs to more than one boy, so the apostrophe follows the plural s. |
+| qg_p3_apostrophe_possession_explain | 29 | One dog owns more than one bowl, so the apostrophe is before s in dog's. |
+| qg_p3_apostrophe_possession_explain | 30 | Names ending in s can take apostrophe + s to show singular possession. |
+| qg_p3_clauses_explain | 1 | It introduces a subordinate clause showing contrast with the main clause. |
+| qg_p3_clauses_explain | 2 | It can stand alone as a complete clause in the intended meaning. |
+| qg_p3_clauses_explain | 3 | It gives a condition and needs the main clause to complete the instruction. |
+| qg_p3_clauses_explain | 4 | It links two related main clauses of equal importance. |
+| qg_p3_clauses_explain | 5 | It is a subordinate time clause that leaves the main action unfinished. |
+| qg_p3_clauses_explain | 6 | It introduces a time clause that depends on the main clause for full meaning. |
+| qg_p3_clauses_explain | 7 | Both parts carry independent meaning and are joined by a coordinating conjunction. |
+| qg_p3_clauses_explain | 8 | Because the rain stopped depends on the main clause to complete the meaning. |
+| qg_p3_clauses_explain | 9 | It introduces a subordinate clause showing contrast with the main clause. |
+| qg_p3_clauses_explain | 10 | It can stand alone as a complete clause in the intended meaning. |
+| qg_p3_clauses_explain | 11 | It gives a condition and needs the main clause to complete the instruction. |
+| qg_p3_clauses_explain | 12 | It links two related main clauses of equal importance. |
+| qg_p3_clauses_explain | 13 | It is a subordinate time clause that leaves the main action unfinished. |
+| qg_p3_clauses_explain | 14 | It introduces a time clause that depends on the main clause for full meaning. |
+| qg_p3_clauses_explain | 15 | Both parts carry independent meaning and are joined by a coordinating conjunction. |
+| qg_p3_clauses_explain | 16 | Because the rain stopped depends on the main clause to complete the meaning. |
+| qg_p3_clauses_explain | 17 | It introduces a subordinate clause showing contrast with the main clause. |
+| qg_p3_clauses_explain | 18 | It can stand alone as a complete clause in the intended meaning. |
+| qg_p3_clauses_explain | 19 | It gives a condition and needs the main clause to complete the instruction. |
+| qg_p3_clauses_explain | 20 | It links two related main clauses of equal importance. |
+| qg_p3_clauses_explain | 21 | It is a subordinate time clause that leaves the main action unfinished. |
+| qg_p3_clauses_explain | 22 | It introduces a time clause that depends on the main clause for full meaning. |
+| qg_p3_clauses_explain | 23 | Both parts carry independent meaning and are joined by a coordinating conjunction. |
+| qg_p3_clauses_explain | 24 | Because the rain stopped depends on the main clause to complete the meaning. |
+| qg_p3_clauses_explain | 25 | It introduces a subordinate clause showing contrast with the main clause. |
+| qg_p3_clauses_explain | 26 | It can stand alone as a complete clause in the intended meaning. |
+| qg_p3_clauses_explain | 27 | It gives a condition and needs the main clause to complete the instruction. |
+| qg_p3_clauses_explain | 28 | It links two related main clauses of equal importance. |
+| qg_p3_clauses_explain | 29 | It is a subordinate time clause that leaves the main action unfinished. |
+| qg_p3_clauses_explain | 30 | It introduces a time clause that depends on the main clause for full meaning. |
+| qg_p3_formality_explain | 1 | It uses chatty wording that suits speech more than formal writing. |
+| qg_p3_formality_explain | 2 | Request is more precise and formal than ask for in this context. |
+| qg_p3_formality_explain | 3 | It uses impersonal, precise wording instead of chatty phrasing. |
+| qg_p3_formality_explain | 4 | OK is a chatty tag that does not suit an official letter. |
+| qg_p3_formality_explain | 5 | Got set up is conversational; established would be more formal. |
+| qg_p3_formality_explain | 6 | It uses slang ('loads of kids', 'gonna') that does not suit an official notice. |
+| qg_p3_formality_explain | 7 | It removes a personal subject and uses impersonal, official wording. |
+| qg_p3_formality_explain | 8 | It uses precise, polite wording suitable for official information. |
+| qg_p3_formality_explain | 9 | It uses chatty wording that suits speech more than formal writing. |
+| qg_p3_formality_explain | 10 | Request is more precise and formal than ask for in this context. |
+| qg_p3_formality_explain | 11 | It uses impersonal, precise wording instead of chatty phrasing. |
+| qg_p3_formality_explain | 12 | OK is a chatty tag that does not suit an official letter. |
+| qg_p3_formality_explain | 13 | Got set up is conversational; established would be more formal. |
+| qg_p3_formality_explain | 14 | It uses slang ('loads of kids', 'gonna') that does not suit an official notice. |
+| qg_p3_formality_explain | 15 | It removes a personal subject and uses impersonal, official wording. |
+| qg_p3_formality_explain | 16 | It uses precise, polite wording suitable for official information. |
+| qg_p3_formality_explain | 17 | It uses chatty wording that suits speech more than formal writing. |
+| qg_p3_formality_explain | 18 | Request is more precise and formal than ask for in this context. |
+| qg_p3_formality_explain | 19 | It uses impersonal, precise wording instead of chatty phrasing. |
+| qg_p3_formality_explain | 20 | OK is a chatty tag that does not suit an official letter. |
+| qg_p3_formality_explain | 21 | Got set up is conversational; established would be more formal. |
+| qg_p3_formality_explain | 22 | It uses slang ('loads of kids', 'gonna') that does not suit an official notice. |
+| qg_p3_formality_explain | 23 | It removes a personal subject and uses impersonal, official wording. |
+| qg_p3_formality_explain | 24 | It uses precise, polite wording suitable for official information. |
+| qg_p3_formality_explain | 25 | It uses chatty wording that suits speech more than formal writing. |
+| qg_p3_formality_explain | 26 | Request is more precise and formal than ask for in this context. |
+| qg_p3_formality_explain | 27 | It uses impersonal, precise wording instead of chatty phrasing. |
+| qg_p3_formality_explain | 28 | OK is a chatty tag that does not suit an official letter. |
+| qg_p3_formality_explain | 29 | Got set up is conversational; established would be more formal. |
+| qg_p3_formality_explain | 30 | It uses slang ('loads of kids', 'gonna') that does not suit an official notice. |
+| qg_p3_noun_phrases_explain | 1 | It is centred on the noun book and expanded by the phrase with a torn cover. |
+| qg_p3_noun_phrases_explain | 2 | It contains a verb phrase, so it is part of a clause rather than a noun phrase. |
+| qg_p3_noun_phrases_explain | 3 | The whole group is centred on the noun goalkeeper. |
+| qg_p3_noun_phrases_explain | 4 | It has no verb; it is a noun phrase centred on lighthouse. |
+| qg_p3_noun_phrases_explain | 5 | Old oak describes the noun, but the full noun phrase must include tree. |
+| qg_p3_noun_phrases_explain | 6 | It is centred on the noun bicycle and expanded with an adjective and a prepositional phrase. |
+| qg_p3_noun_phrases_explain | 7 | The whole group is centred on the noun kitten and gives detail about it. |
+| qg_p3_noun_phrases_explain | 8 | It is centred on the noun key and expanded with describing words. |
+| qg_p3_noun_phrases_explain | 9 | It is centred on the noun book and expanded by the phrase with a torn cover. |
+| qg_p3_noun_phrases_explain | 10 | It contains a verb phrase, so it is part of a clause rather than a noun phrase. |
+| qg_p3_noun_phrases_explain | 11 | The whole group is centred on the noun goalkeeper. |
+| qg_p3_noun_phrases_explain | 12 | It has no verb; it is a noun phrase centred on lighthouse. |
+| qg_p3_noun_phrases_explain | 13 | Old oak describes the noun, but the full noun phrase must include tree. |
+| qg_p3_noun_phrases_explain | 14 | It is centred on the noun bicycle and expanded with an adjective and a prepositional phrase. |
+| qg_p3_noun_phrases_explain | 15 | The whole group is centred on the noun kitten and gives detail about it. |
+| qg_p3_noun_phrases_explain | 16 | It is centred on the noun key and expanded with describing words. |
+| qg_p3_noun_phrases_explain | 17 | It is centred on the noun book and expanded by the phrase with a torn cover. |
+| qg_p3_noun_phrases_explain | 18 | It contains a verb phrase, so it is part of a clause rather than a noun phrase. |
+| qg_p3_noun_phrases_explain | 19 | The whole group is centred on the noun goalkeeper. |
+| qg_p3_noun_phrases_explain | 20 | It has no verb; it is a noun phrase centred on lighthouse. |
+| qg_p3_noun_phrases_explain | 21 | Old oak describes the noun, but the full noun phrase must include tree. |
+| qg_p3_noun_phrases_explain | 22 | It is centred on the noun bicycle and expanded with an adjective and a prepositional phrase. |
+| qg_p3_noun_phrases_explain | 23 | The whole group is centred on the noun kitten and gives detail about it. |
+| qg_p3_noun_phrases_explain | 24 | It is centred on the noun key and expanded with describing words. |
+| qg_p3_noun_phrases_explain | 25 | It is centred on the noun book and expanded by the phrase with a torn cover. |
+| qg_p3_noun_phrases_explain | 26 | It contains a verb phrase, so it is part of a clause rather than a noun phrase. |
+| qg_p3_noun_phrases_explain | 27 | The whole group is centred on the noun goalkeeper. |
+| qg_p3_noun_phrases_explain | 28 | It has no verb; it is a noun phrase centred on lighthouse. |
+| qg_p3_noun_phrases_explain | 29 | Old oak describes the noun, but the full noun phrase must include tree. |
+| qg_p3_noun_phrases_explain | 30 | It is centred on the noun bicycle and expanded with an adjective and a prepositional phrase. |
+| qg_p3_parenthesis_commas_explain | 1 | Usually quiet is extra information inserted into the sentence. |
+| qg_p3_parenthesis_commas_explain | 2 | The bracketed clause adds extra information about the trip. |
+| qg_p3_parenthesis_commas_explain | 3 | The commas separate items in a list, not removable extra information. |
+| qg_p3_parenthesis_commas_explain | 4 | The parenthetical relative clause sits in the middle of the main sentence. |
+| qg_p3_parenthesis_commas_explain | 5 | After the storm is a fronted adverbial telling when, not extra information in the middle. |
+| qg_p3_parenthesis_commas_explain | 6 | Dashes give a stronger visual break for the parenthetical information. |
+| qg_p3_parenthesis_commas_explain | 7 | The bracketed phrase adds optional extra detail and the sentence still makes sense without it. |
+| qg_p3_parenthesis_commas_explain | 8 | A keen drummer is extra information that could be lifted out. |
+| qg_p3_parenthesis_commas_explain | 9 | Usually quiet is extra information inserted into the sentence. |
+| qg_p3_parenthesis_commas_explain | 10 | The bracketed clause adds extra information about the trip. |
+| qg_p3_parenthesis_commas_explain | 11 | The commas separate items in a list, not removable extra information. |
+| qg_p3_parenthesis_commas_explain | 12 | The parenthetical relative clause sits in the middle of the main sentence. |
+| qg_p3_parenthesis_commas_explain | 13 | After the storm is a fronted adverbial telling when, not extra information in the middle. |
+| qg_p3_parenthesis_commas_explain | 14 | Dashes give a stronger visual break for the parenthetical information. |
+| qg_p3_parenthesis_commas_explain | 15 | The bracketed phrase adds optional extra detail and the sentence still makes sense without it. |
+| qg_p3_parenthesis_commas_explain | 16 | A keen drummer is extra information that could be lifted out. |
+| qg_p3_parenthesis_commas_explain | 17 | Usually quiet is extra information inserted into the sentence. |
+| qg_p3_parenthesis_commas_explain | 18 | The bracketed clause adds extra information about the trip. |
+| qg_p3_parenthesis_commas_explain | 19 | The commas separate items in a list, not removable extra information. |
+| qg_p3_parenthesis_commas_explain | 20 | The parenthetical relative clause sits in the middle of the main sentence. |
+| qg_p3_parenthesis_commas_explain | 21 | After the storm is a fronted adverbial telling when, not extra information in the middle. |
+| qg_p3_parenthesis_commas_explain | 22 | Dashes give a stronger visual break for the parenthetical information. |
+| qg_p3_parenthesis_commas_explain | 23 | The bracketed phrase adds optional extra detail and the sentence still makes sense without it. |
+| qg_p3_parenthesis_commas_explain | 24 | A keen drummer is extra information that could be lifted out. |
+| qg_p3_parenthesis_commas_explain | 25 | Usually quiet is extra information inserted into the sentence. |
+| qg_p3_parenthesis_commas_explain | 26 | The bracketed clause adds extra information about the trip. |
+| qg_p3_parenthesis_commas_explain | 27 | The commas separate items in a list, not removable extra information. |
+| qg_p3_parenthesis_commas_explain | 28 | The parenthetical relative clause sits in the middle of the main sentence. |
+| qg_p3_parenthesis_commas_explain | 29 | After the storm is a fronted adverbial telling when, not extra information in the middle. |
+| qg_p3_parenthesis_commas_explain | 30 | Dashes give a stronger visual break for the parenthetical information. |
+| qg_p3_pronouns_cohesion_explain | 1 | She could refer to Maya or Priya, so the reference is ambiguous. |
+| qg_p3_pronouns_cohesion_explain | 2 | Repeating the trophy avoids confusing it with the shelf. |
+| qg_p3_pronouns_cohesion_explain | 3 | They clearly refers to the pupils, the group who finished lunch. |
+| qg_p3_pronouns_cohesion_explain | 4 | This refers back to the whole situation of the gate being locked. |
+| qg_p3_pronouns_cohesion_explain | 5 | Him refers to Oliver, the person who dropped the baton. |
+| qg_p3_pronouns_cohesion_explain | 6 | Their links clearly to the team, keeping both sentences connected. |
+| qg_p3_pronouns_cohesion_explain | 7 | It could refer to the cage or the hutch, so a noun would remove ambiguity. |
+| qg_p3_pronouns_cohesion_explain | 8 | It clearly refers back to the map and avoids repeating the noun. |
+| qg_p3_pronouns_cohesion_explain | 9 | She could refer to Maya or Priya, so the reference is ambiguous. |
+| qg_p3_pronouns_cohesion_explain | 10 | Repeating the trophy avoids confusing it with the shelf. |
+| qg_p3_pronouns_cohesion_explain | 11 | They clearly refers to the pupils, the group who finished lunch. |
+| qg_p3_pronouns_cohesion_explain | 12 | This refers back to the whole situation of the gate being locked. |
+| qg_p3_pronouns_cohesion_explain | 13 | Him refers to Oliver, the person who dropped the baton. |
+| qg_p3_pronouns_cohesion_explain | 14 | Their links clearly to the team, keeping both sentences connected. |
+| qg_p3_pronouns_cohesion_explain | 15 | It could refer to the cage or the hutch, so a noun would remove ambiguity. |
+| qg_p3_pronouns_cohesion_explain | 16 | It clearly refers back to the map and avoids repeating the noun. |
+| qg_p3_pronouns_cohesion_explain | 17 | She could refer to Maya or Priya, so the reference is ambiguous. |
+| qg_p3_pronouns_cohesion_explain | 18 | Repeating the trophy avoids confusing it with the shelf. |
+| qg_p3_pronouns_cohesion_explain | 19 | They clearly refers to the pupils, the group who finished lunch. |
+| qg_p3_pronouns_cohesion_explain | 20 | This refers back to the whole situation of the gate being locked. |
+| qg_p3_pronouns_cohesion_explain | 21 | Him refers to Oliver, the person who dropped the baton. |
+| qg_p3_pronouns_cohesion_explain | 22 | Their links clearly to the team, keeping both sentences connected. |
+| qg_p3_pronouns_cohesion_explain | 23 | It could refer to the cage or the hutch, so a noun would remove ambiguity. |
+| qg_p3_pronouns_cohesion_explain | 24 | It clearly refers back to the map and avoids repeating the noun. |
+| qg_p3_pronouns_cohesion_explain | 25 | She could refer to Maya or Priya, so the reference is ambiguous. |
+| qg_p3_pronouns_cohesion_explain | 26 | Repeating the trophy avoids confusing it with the shelf. |
+| qg_p3_pronouns_cohesion_explain | 27 | They clearly refers to the pupils, the group who finished lunch. |
+| qg_p3_pronouns_cohesion_explain | 28 | This refers back to the whole situation of the gate being locked. |
+| qg_p3_pronouns_cohesion_explain | 29 | Him refers to Oliver, the person who dropped the baton. |
+| qg_p3_pronouns_cohesion_explain | 30 | Their links clearly to the team, keeping both sentences connected. |
+| qg_p3_relative_clauses_explain | 1 | It adds information about the noun plant. |
+| qg_p3_relative_clauses_explain | 2 | It identifies the noun book more precisely. |
+| qg_p3_relative_clauses_explain | 3 | When the show ended is a time clause, not extra information about a noun. |
+| qg_p3_relative_clauses_explain | 4 | The clause adds information about the girl by saying whose boots were muddy. |
+| qg_p3_relative_clauses_explain | 5 | The clause adds extra information about Mr Patel and can be lifted out. |
+| qg_p3_relative_clauses_explain | 6 | The clause gives more information about the noun park. |
+| qg_p3_relative_clauses_explain | 7 | It identifies which boy is meant and cannot be removed without losing meaning. |
+| qg_p3_relative_clauses_explain | 8 | It adds information about the noun pupil. |
+| qg_p3_relative_clauses_explain | 9 | It adds information about the noun plant. |
+| qg_p3_relative_clauses_explain | 10 | It identifies the noun book more precisely. |
+| qg_p3_relative_clauses_explain | 11 | When the show ended is a time clause, not extra information about a noun. |
+| qg_p3_relative_clauses_explain | 12 | The clause adds information about the girl by saying whose boots were muddy. |
+| qg_p3_relative_clauses_explain | 13 | The clause adds extra information about Mr Patel and can be lifted out. |
+| qg_p3_relative_clauses_explain | 14 | The clause gives more information about the noun park. |
+| qg_p3_relative_clauses_explain | 15 | It identifies which boy is meant and cannot be removed without losing meaning. |
+| qg_p3_relative_clauses_explain | 16 | It adds information about the noun pupil. |
+| qg_p3_relative_clauses_explain | 17 | It adds information about the noun plant. |
+| qg_p3_relative_clauses_explain | 18 | It identifies the noun book more precisely. |
+| qg_p3_relative_clauses_explain | 19 | When the show ended is a time clause, not extra information about a noun. |
+| qg_p3_relative_clauses_explain | 20 | The clause adds information about the girl by saying whose boots were muddy. |
+| qg_p3_relative_clauses_explain | 21 | The clause adds extra information about Mr Patel and can be lifted out. |
+| qg_p3_relative_clauses_explain | 22 | The clause gives more information about the noun park. |
+| qg_p3_relative_clauses_explain | 23 | It identifies which boy is meant and cannot be removed without losing meaning. |
+| qg_p3_relative_clauses_explain | 24 | It adds information about the noun pupil. |
+| qg_p3_relative_clauses_explain | 25 | It adds information about the noun plant. |
+| qg_p3_relative_clauses_explain | 26 | It identifies the noun book more precisely. |
+| qg_p3_relative_clauses_explain | 27 | When the show ended is a time clause, not extra information about a noun. |
+| qg_p3_relative_clauses_explain | 28 | The clause adds information about the girl by saying whose boots were muddy. |
+| qg_p3_relative_clauses_explain | 29 | The clause adds extra information about Mr Patel and can be lifted out. |
+| qg_p3_relative_clauses_explain | 30 | The clause gives more information about the noun park. |
+| qg_p3_sentence_functions_explain | 1 | It asks for information directly, so it is a question. |
+| qg_p3_sentence_functions_explain | 2 | It gives information, so it is a statement. |
+| qg_p3_sentence_functions_explain | 3 | It begins with What and expresses strong feeling about a noun phrase. |
+| qg_p3_sentence_functions_explain | 4 | It reports someone wondering; it does not ask the reader directly. |
+| qg_p3_sentence_functions_explain | 5 | It shows excitement, but it does not use the What or How exclamation pattern. |
+| qg_p3_sentence_functions_explain | 6 | It tells someone to do something; the polite word does not change the function. |
+| qg_p3_sentence_functions_explain | 7 | It begins with How and expresses strong feeling about an adverb. |
+| qg_p3_sentence_functions_explain | 8 | It tells someone to do something, so it is a command. |
+| qg_p3_sentence_functions_explain | 9 | It asks for information directly, so it is a question. |
+| qg_p3_sentence_functions_explain | 10 | It gives information, so it is a statement. |
+| qg_p3_sentence_functions_explain | 11 | It begins with What and expresses strong feeling about a noun phrase. |
+| qg_p3_sentence_functions_explain | 12 | It reports someone wondering; it does not ask the reader directly. |
+| qg_p3_sentence_functions_explain | 13 | It shows excitement, but it does not use the What or How exclamation pattern. |
+| qg_p3_sentence_functions_explain | 14 | It tells someone to do something; the polite word does not change the function. |
+| qg_p3_sentence_functions_explain | 15 | It begins with How and expresses strong feeling about an adverb. |
+| qg_p3_sentence_functions_explain | 16 | It tells someone to do something, so it is a command. |
+| qg_p3_sentence_functions_explain | 17 | It asks for information directly, so it is a question. |
+| qg_p3_sentence_functions_explain | 18 | It gives information, so it is a statement. |
+| qg_p3_sentence_functions_explain | 19 | It begins with What and expresses strong feeling about a noun phrase. |
+| qg_p3_sentence_functions_explain | 20 | It reports someone wondering; it does not ask the reader directly. |
+| qg_p3_sentence_functions_explain | 21 | It shows excitement, but it does not use the What or How exclamation pattern. |
+| qg_p3_sentence_functions_explain | 22 | It tells someone to do something; the polite word does not change the function. |
+| qg_p3_sentence_functions_explain | 23 | It begins with How and expresses strong feeling about an adverb. |
+| qg_p3_sentence_functions_explain | 24 | It tells someone to do something, so it is a command. |
+| qg_p3_sentence_functions_explain | 25 | It asks for information directly, so it is a question. |
+| qg_p3_sentence_functions_explain | 26 | It gives information, so it is a statement. |
+| qg_p3_sentence_functions_explain | 27 | It begins with What and expresses strong feeling about a noun phrase. |
+| qg_p3_sentence_functions_explain | 28 | It reports someone wondering; it does not ask the reader directly. |
+| qg_p3_sentence_functions_explain | 29 | It shows excitement, but it does not use the What or How exclamation pattern. |
+| qg_p3_sentence_functions_explain | 30 | It tells someone to do something; the polite word does not change the function. |
+| qg_p3_speech_punctuation_explain | 1 | The comma separates the spoken words from the reporting clause. |
+| qg_p3_speech_punctuation_explain | 2 | The comma introduces the direct speech after the reporting clause. |
+| qg_p3_speech_punctuation_explain | 3 | The spoken words are an exclamation or warning, so the mark belongs inside. |
+| qg_p3_speech_punctuation_explain | 4 | The direct speech starts a new spoken sentence. |
+| qg_p3_speech_punctuation_explain | 5 | The full stop finishes the spoken sentence, so it belongs inside the speech marks. |
+| qg_p3_speech_punctuation_explain | 6 | The reporting clause continues the same sentence after the spoken words. |
+| qg_p3_speech_punctuation_explain | 7 | The question mark already ends the spoken sentence, so a full stop is not needed. |
+| qg_p3_speech_punctuation_explain | 8 | The spoken words are a question, so the question mark belongs inside them. |
+| qg_p3_speech_punctuation_explain | 9 | The comma separates the spoken words from the reporting clause. |
+| qg_p3_speech_punctuation_explain | 10 | The comma introduces the direct speech after the reporting clause. |
+| qg_p3_speech_punctuation_explain | 11 | The spoken words are an exclamation or warning, so the mark belongs inside. |
+| qg_p3_speech_punctuation_explain | 12 | The direct speech starts a new spoken sentence. |
+| qg_p3_speech_punctuation_explain | 13 | The full stop finishes the spoken sentence, so it belongs inside the speech marks. |
+| qg_p3_speech_punctuation_explain | 14 | The reporting clause continues the same sentence after the spoken words. |
+| qg_p3_speech_punctuation_explain | 15 | The question mark already ends the spoken sentence, so a full stop is not needed. |
+| qg_p3_speech_punctuation_explain | 16 | The spoken words are a question, so the question mark belongs inside them. |
+| qg_p3_speech_punctuation_explain | 17 | The comma separates the spoken words from the reporting clause. |
+| qg_p3_speech_punctuation_explain | 18 | The comma introduces the direct speech after the reporting clause. |
+| qg_p3_speech_punctuation_explain | 19 | The spoken words are an exclamation or warning, so the mark belongs inside. |
+| qg_p3_speech_punctuation_explain | 20 | The direct speech starts a new spoken sentence. |
+| qg_p3_speech_punctuation_explain | 21 | The full stop finishes the spoken sentence, so it belongs inside the speech marks. |
+| qg_p3_speech_punctuation_explain | 22 | The reporting clause continues the same sentence after the spoken words. |
+| qg_p3_speech_punctuation_explain | 23 | The question mark already ends the spoken sentence, so a full stop is not needed. |
+| qg_p3_speech_punctuation_explain | 24 | The spoken words are a question, so the question mark belongs inside them. |
+| qg_p3_speech_punctuation_explain | 25 | The comma separates the spoken words from the reporting clause. |
+| qg_p3_speech_punctuation_explain | 26 | The comma introduces the direct speech after the reporting clause. |
+| qg_p3_speech_punctuation_explain | 27 | The spoken words are an exclamation or warning, so the mark belongs inside. |
+| qg_p3_speech_punctuation_explain | 28 | The direct speech starts a new spoken sentence. |
+| qg_p3_speech_punctuation_explain | 29 | The full stop finishes the spoken sentence, so it belongs inside the speech marks. |
+| qg_p3_speech_punctuation_explain | 30 | The reporting clause continues the same sentence after the spoken words. |
+| qg_p3_subject_object_explain | 1 | The soup receives the action of tasting. |
+| qg_p3_subject_object_explain | 2 | Before lunch is an adverbial; Aisha does the action. |
+| qg_p3_subject_object_explain | 3 | The whole noun phrase names who did the catching. |
+| qg_p3_subject_object_explain | 4 | The trophy is before the verb phrase and the sentence is about what happened to it. |
+| qg_p3_subject_object_explain | 5 | The letters receive the action of sorting. |
+| qg_p3_subject_object_explain | 6 | The audience performs the action of returning; the opening phrase is an adverbial. |
+| qg_p3_subject_object_explain | 7 | Slept does not pass action onto another noun; no noun receives the action. |
+| qg_p3_subject_object_explain | 8 | The chef does the action of tasting. |
+| qg_p3_subject_object_explain | 9 | The soup receives the action of tasting. |
+| qg_p3_subject_object_explain | 10 | Before lunch is an adverbial; Aisha does the action. |
+| qg_p3_subject_object_explain | 11 | The whole noun phrase names who did the catching. |
+| qg_p3_subject_object_explain | 12 | The trophy is before the verb phrase and the sentence is about what happened to it. |
+| qg_p3_subject_object_explain | 13 | The letters receive the action of sorting. |
+| qg_p3_subject_object_explain | 14 | The audience performs the action of returning; the opening phrase is an adverbial. |
+| qg_p3_subject_object_explain | 15 | Slept does not pass action onto another noun; no noun receives the action. |
+| qg_p3_subject_object_explain | 16 | The chef does the action of tasting. |
+| qg_p3_subject_object_explain | 17 | The soup receives the action of tasting. |
+| qg_p3_subject_object_explain | 18 | Before lunch is an adverbial; Aisha does the action. |
+| qg_p3_subject_object_explain | 19 | The whole noun phrase names who did the catching. |
+| qg_p3_subject_object_explain | 20 | The trophy is before the verb phrase and the sentence is about what happened to it. |
+| qg_p3_subject_object_explain | 21 | The letters receive the action of sorting. |
+| qg_p3_subject_object_explain | 22 | The audience performs the action of returning; the opening phrase is an adverbial. |
+| qg_p3_subject_object_explain | 23 | Slept does not pass action onto another noun; no noun receives the action. |
+| qg_p3_subject_object_explain | 24 | The chef does the action of tasting. |
+| qg_p3_subject_object_explain | 25 | The soup receives the action of tasting. |
+| qg_p3_subject_object_explain | 26 | Before lunch is an adverbial; Aisha does the action. |
+| qg_p3_subject_object_explain | 27 | The whole noun phrase names who did the catching. |
+| qg_p3_subject_object_explain | 28 | The trophy is before the verb phrase and the sentence is about what happened to it. |
+| qg_p3_subject_object_explain | 29 | The letters receive the action of sorting. |
+| qg_p3_subject_object_explain | 30 | The audience performs the action of returning; the opening phrase is an adverbial. |
+| qg_p3_tense_aspect_explain | 1 | It shows one past action completed before another past action. |
+| qg_p3_tense_aspect_explain | 2 | It shows an action that was in progress in the past. |
+| qg_p3_tense_aspect_explain | 3 | It shows an action in progress now using are plus an -ing verb. |
+| qg_p3_tense_aspect_explain | 4 | It uses a past verb form for a finished action at a finished time. |
+| qg_p3_tense_aspect_explain | 5 | It links earlier practice to now and shows the action continuing over time. |
+| qg_p3_tense_aspect_explain | 6 | It uses will plus a base verb to refer to a time ahead. |
+| qg_p3_tense_aspect_explain | 7 | It shows a continuing action in the past that happened before another past event. |
+| qg_p3_tense_aspect_explain | 8 | It uses has plus a past participle to link a completed action to now. |
+| qg_p3_tense_aspect_explain | 9 | It shows one past action completed before another past action. |
+| qg_p3_tense_aspect_explain | 10 | It shows an action that was in progress in the past. |
+| qg_p3_tense_aspect_explain | 11 | It shows an action in progress now using are plus an -ing verb. |
+| qg_p3_tense_aspect_explain | 12 | It uses a past verb form for a finished action at a finished time. |
+| qg_p3_tense_aspect_explain | 13 | It links earlier practice to now and shows the action continuing over time. |
+| qg_p3_tense_aspect_explain | 14 | It uses will plus a base verb to refer to a time ahead. |
+| qg_p3_tense_aspect_explain | 15 | It shows a continuing action in the past that happened before another past event. |
+| qg_p3_tense_aspect_explain | 16 | It uses has plus a past participle to link a completed action to now. |
+| qg_p3_tense_aspect_explain | 17 | It shows one past action completed before another past action. |
+| qg_p3_tense_aspect_explain | 18 | It shows an action that was in progress in the past. |
+| qg_p3_tense_aspect_explain | 19 | It shows an action in progress now using are plus an -ing verb. |
+| qg_p3_tense_aspect_explain | 20 | It uses a past verb form for a finished action at a finished time. |
+| qg_p3_tense_aspect_explain | 21 | It links earlier practice to now and shows the action continuing over time. |
+| qg_p3_tense_aspect_explain | 22 | It uses will plus a base verb to refer to a time ahead. |
+| qg_p3_tense_aspect_explain | 23 | It shows a continuing action in the past that happened before another past event. |
+| qg_p3_tense_aspect_explain | 24 | It uses has plus a past participle to link a completed action to now. |
+| qg_p3_tense_aspect_explain | 25 | It shows one past action completed before another past action. |
+| qg_p3_tense_aspect_explain | 26 | It shows an action that was in progress in the past. |
+| qg_p3_tense_aspect_explain | 27 | It shows an action in progress now using are plus an -ing verb. |
+| qg_p3_tense_aspect_explain | 28 | It uses a past verb form for a finished action at a finished time. |
+| qg_p3_tense_aspect_explain | 29 | It links earlier practice to now and shows the action continuing over time. |
+| qg_p3_tense_aspect_explain | 30 | It uses will plus a base verb to refer to a time ahead. |
+| qg_p3_word_classes_explain | 1 | It modifies the verb folded by saying how Maya folded. |
+| qg_p3_word_classes_explain | 2 | It begins the phrase before assembly and shows a time relationship. |
+| qg_p3_word_classes_explain | 3 | It joins the reason clause to the main clause. |
+| qg_p3_word_classes_explain | 4 | It comes before the noun birds and helps identify which birds. |
+| qg_p3_word_classes_explain | 5 | It replaces the noun phrase the compass. |
+| qg_p3_word_classes_explain | 6 | It modifies the verb flowed by telling how the river moved. |
+| qg_p3_word_classes_explain | 7 | It begins a phrase showing the place relationship between ran and playground. |
+| qg_p3_word_classes_explain | 8 | It describes the noun lantern. |
+| qg_p3_word_classes_explain | 9 | It modifies the verb folded by saying how Maya folded. |
+| qg_p3_word_classes_explain | 10 | It begins the phrase before assembly and shows a time relationship. |
+| qg_p3_word_classes_explain | 11 | It joins the reason clause to the main clause. |
+| qg_p3_word_classes_explain | 12 | It comes before the noun birds and helps identify which birds. |
+| qg_p3_word_classes_explain | 13 | It replaces the noun phrase the compass. |
+| qg_p3_word_classes_explain | 14 | It modifies the verb flowed by telling how the river moved. |
+| qg_p3_word_classes_explain | 15 | It begins a phrase showing the place relationship between ran and playground. |
+| qg_p3_word_classes_explain | 16 | It describes the noun lantern. |
+| qg_p3_word_classes_explain | 17 | It modifies the verb folded by saying how Maya folded. |
+| qg_p3_word_classes_explain | 18 | It begins the phrase before assembly and shows a time relationship. |
+| qg_p3_word_classes_explain | 19 | It joins the reason clause to the main clause. |
+| qg_p3_word_classes_explain | 20 | It comes before the noun birds and helps identify which birds. |
+| qg_p3_word_classes_explain | 21 | It replaces the noun phrase the compass. |
+| qg_p3_word_classes_explain | 22 | It modifies the verb flowed by telling how the river moved. |
+| qg_p3_word_classes_explain | 23 | It begins a phrase showing the place relationship between ran and playground. |
+| qg_p3_word_classes_explain | 24 | It describes the noun lantern. |
+| qg_p3_word_classes_explain | 25 | It modifies the verb folded by saying how Maya folded. |
+| qg_p3_word_classes_explain | 26 | It begins the phrase before assembly and shows a time relationship. |
+| qg_p3_word_classes_explain | 27 | It joins the reason clause to the main clause. |
+| qg_p3_word_classes_explain | 28 | It comes before the noun birds and helps identify which birds. |
+| qg_p3_word_classes_explain | 29 | It replaces the noun phrase the compass. |
+| qg_p3_word_classes_explain | 30 | It modifies the verb flowed by telling how the river moved. |
+| qg_p4_adverbial_clause_boundary_transfer | 1 | Before the bell rang, the children lined up quietly. |
+| qg_p4_adverbial_clause_boundary_transfer | 2 | After the storm cleared, we inspected the damage. |
+| qg_p4_adverbial_clause_boundary_transfer | 3 | Although the path was icy, nobody slipped. |
+| qg_p4_adverbial_clause_boundary_transfer | 4 | During the assembly, the head announced sports day; parents are invited. |
+| qg_p4_adverbial_clause_boundary_transfer | 5 | When the museum opened, visitors rushed to the dinosaur hall. |
+| qg_p4_adverbial_clause_boundary_transfer | 6 | As soon as the whistle blew, the players sprinted; the crowd cheered. |
+| qg_p4_adverbial_clause_boundary_transfer | 7 | By the time we arrived, the cake had already been eaten. |
+| qg_p4_adverbial_clause_boundary_transfer | 8 | Despite the heavy rain, the match continued; nobody complained. |
+| qg_p4_adverbial_clause_boundary_transfer | 9 | Before the bell rang, the children lined up quietly. |
+| qg_p4_adverbial_clause_boundary_transfer | 10 | After the storm cleared, we inspected the damage. |
+| qg_p4_adverbial_clause_boundary_transfer | 11 | Although the path was icy, nobody slipped. |
+| qg_p4_adverbial_clause_boundary_transfer | 12 | During the assembly, the head announced sports day; parents are invited. |
+| qg_p4_adverbial_clause_boundary_transfer | 13 | When the museum opened, visitors rushed to the dinosaur hall. |
+| qg_p4_adverbial_clause_boundary_transfer | 14 | As soon as the whistle blew, the players sprinted; the crowd cheered. |
+| qg_p4_adverbial_clause_boundary_transfer | 15 | By the time we arrived, the cake had already been eaten. |
+| qg_p4_adverbial_clause_boundary_transfer | 16 | Despite the heavy rain, the match continued; nobody complained. |
+| qg_p4_adverbial_clause_boundary_transfer | 17 | Before the bell rang, the children lined up quietly. |
+| qg_p4_adverbial_clause_boundary_transfer | 18 | After the storm cleared, we inspected the damage. |
+| qg_p4_adverbial_clause_boundary_transfer | 19 | Although the path was icy, nobody slipped. |
+| qg_p4_adverbial_clause_boundary_transfer | 20 | During the assembly, the head announced sports day; parents are invited. |
+| qg_p4_adverbial_clause_boundary_transfer | 21 | When the museum opened, visitors rushed to the dinosaur hall. |
+| qg_p4_adverbial_clause_boundary_transfer | 22 | As soon as the whistle blew, the players sprinted; the crowd cheered. |
+| qg_p4_adverbial_clause_boundary_transfer | 23 | By the time we arrived, the cake had already been eaten. |
+| qg_p4_adverbial_clause_boundary_transfer | 24 | Despite the heavy rain, the match continued; nobody complained. |
+| qg_p4_adverbial_clause_boundary_transfer | 25 | Before the bell rang, the children lined up quietly. |
+| qg_p4_adverbial_clause_boundary_transfer | 26 | After the storm cleared, we inspected the damage. |
+| qg_p4_adverbial_clause_boundary_transfer | 27 | Although the path was icy, nobody slipped. |
+| qg_p4_adverbial_clause_boundary_transfer | 28 | During the assembly, the head announced sports day; parents are invited. |
+| qg_p4_adverbial_clause_boundary_transfer | 29 | When the museum opened, visitors rushed to the dinosaur hall. |
+| qg_p4_adverbial_clause_boundary_transfer | 30 | As soon as the whistle blew, the players sprinted; the crowd cheered. |
+| qg_p4_cohesion_formality_transfer | 1 | The council has approved the plans. It will begin work in September. |
+| qg_p4_cohesion_formality_transfer | 2 | The museum opens at nine and closes at five. Visitors must book online. |
+| qg_p4_cohesion_formality_transfer | 3 | Dr Patel presented the findings. She then explained the next steps. |
+| qg_p4_cohesion_formality_transfer | 4 | The project was completed on time and received praise from the governors. |
+| qg_p4_cohesion_formality_transfer | 5 | James has improved his reading. He now reads chapter books independently. |
+| qg_p4_cohesion_formality_transfer | 6 | The charity raised three thousand pounds, which it will donate to the hospital. |
+| qg_p4_cohesion_formality_transfer | 7 | The headteacher addressed the assembly. She reminded pupils about uniform expectations. |
+| qg_p4_cohesion_formality_transfer | 8 | The experiment was successful. It will be repeated next term. |
+| qg_p4_cohesion_formality_transfer | 9 | The council has approved the plans. It will begin work in September. |
+| qg_p4_cohesion_formality_transfer | 10 | The museum opens at nine and closes at five. Visitors must book online. |
+| qg_p4_cohesion_formality_transfer | 11 | Dr Patel presented the findings. She then explained the next steps. |
+| qg_p4_cohesion_formality_transfer | 12 | The project was completed on time and received praise from the governors. |
+| qg_p4_cohesion_formality_transfer | 13 | James has improved his reading. He now reads chapter books independently. |
+| qg_p4_cohesion_formality_transfer | 14 | The charity raised three thousand pounds, which it will donate to the hospital. |
+| qg_p4_cohesion_formality_transfer | 15 | The headteacher addressed the assembly. She reminded pupils about uniform expectations. |
+| qg_p4_cohesion_formality_transfer | 16 | The experiment was successful. It will be repeated next term. |
+| qg_p4_cohesion_formality_transfer | 17 | The council has approved the plans. It will begin work in September. |
+| qg_p4_cohesion_formality_transfer | 18 | The museum opens at nine and closes at five. Visitors must book online. |
+| qg_p4_cohesion_formality_transfer | 19 | Dr Patel presented the findings. She then explained the next steps. |
+| qg_p4_cohesion_formality_transfer | 20 | The project was completed on time and received praise from the governors. |
+| qg_p4_cohesion_formality_transfer | 21 | James has improved his reading. He now reads chapter books independently. |
+| qg_p4_cohesion_formality_transfer | 22 | The charity raised three thousand pounds, which it will donate to the hospital. |
+| qg_p4_cohesion_formality_transfer | 23 | The headteacher addressed the assembly. She reminded pupils about uniform expectations. |
+| qg_p4_cohesion_formality_transfer | 24 | The experiment was successful. It will be repeated next term. |
+| qg_p4_cohesion_formality_transfer | 25 | The council has approved the plans. It will begin work in September. |
+| qg_p4_cohesion_formality_transfer | 26 | The museum opens at nine and closes at five. Visitors must book online. |
+| qg_p4_cohesion_formality_transfer | 27 | Dr Patel presented the findings. She then explained the next steps. |
+| qg_p4_cohesion_formality_transfer | 28 | The project was completed on time and received praise from the governors. |
+| qg_p4_cohesion_formality_transfer | 29 | James has improved his reading. He now reads chapter books independently. |
+| qg_p4_cohesion_formality_transfer | 30 | The charity raised three thousand pounds, which it will donate to the hospital. |
+| qg_p4_possession_hyphen_clarity_transfer | 1 | The well-known author's latest book topped the charts. |
+| qg_p4_possession_hyphen_clarity_transfer | 2 | The children's long-awaited trip finally arrived. |
+| qg_p4_possession_hyphen_clarity_transfer | 3 | The players' hard-earned medals were displayed in the cabinet. |
+| qg_p4_possession_hyphen_clarity_transfer | 4 | The school's state-of-the-art science lab impressed visitors. |
+| qg_p4_possession_hyphen_clarity_transfer | 5 | My sister's hand-painted vase sits on the shelf. |
+| qg_p4_possession_hyphen_clarity_transfer | 6 | The teacher's well-prepared lesson plan impressed the inspector. |
+| qg_p4_possession_hyphen_clarity_transfer | 7 | The company's award-winning product sold out quickly. |
+| qg_p4_possession_hyphen_clarity_transfer | 8 | The dog's bright-orange collar stood out. |
+| qg_p4_possession_hyphen_clarity_transfer | 9 | The well-known author's latest book topped the charts. |
+| qg_p4_possession_hyphen_clarity_transfer | 10 | The children's long-awaited trip finally arrived. |
+| qg_p4_possession_hyphen_clarity_transfer | 11 | The players' hard-earned medals were displayed in the cabinet. |
+| qg_p4_possession_hyphen_clarity_transfer | 12 | The school's state-of-the-art science lab impressed visitors. |
+| qg_p4_possession_hyphen_clarity_transfer | 13 | My sister's hand-painted vase sits on the shelf. |
+| qg_p4_possession_hyphen_clarity_transfer | 14 | The teacher's well-prepared lesson plan impressed the inspector. |
+| qg_p4_possession_hyphen_clarity_transfer | 15 | The company's award-winning product sold out quickly. |
+| qg_p4_possession_hyphen_clarity_transfer | 16 | The dog's bright-orange collar stood out. |
+| qg_p4_possession_hyphen_clarity_transfer | 17 | The well-known author's latest book topped the charts. |
+| qg_p4_possession_hyphen_clarity_transfer | 18 | The children's long-awaited trip finally arrived. |
+| qg_p4_possession_hyphen_clarity_transfer | 19 | The players' hard-earned medals were displayed in the cabinet. |
+| qg_p4_possession_hyphen_clarity_transfer | 20 | The school's state-of-the-art science lab impressed visitors. |
+| qg_p4_possession_hyphen_clarity_transfer | 21 | My sister's hand-painted vase sits on the shelf. |
+| qg_p4_possession_hyphen_clarity_transfer | 22 | The teacher's well-prepared lesson plan impressed the inspector. |
+| qg_p4_possession_hyphen_clarity_transfer | 23 | The company's award-winning product sold out quickly. |
+| qg_p4_possession_hyphen_clarity_transfer | 24 | The dog's bright-orange collar stood out. |
+| qg_p4_possession_hyphen_clarity_transfer | 25 | The well-known author's latest book topped the charts. |
+| qg_p4_possession_hyphen_clarity_transfer | 26 | The children's long-awaited trip finally arrived. |
+| qg_p4_possession_hyphen_clarity_transfer | 27 | The players' hard-earned medals were displayed in the cabinet. |
+| qg_p4_possession_hyphen_clarity_transfer | 28 | The school's state-of-the-art science lab impressed visitors. |
+| qg_p4_possession_hyphen_clarity_transfer | 29 | My sister's hand-painted vase sits on the shelf. |
+| qg_p4_possession_hyphen_clarity_transfer | 30 | The teacher's well-prepared lesson plan impressed the inspector. |
+| qg_p4_relative_parenthesis_transfer | 1 | The oak tree, which was planted by the village founders, has stood for two hundred years. |
+| qg_p4_relative_parenthesis_transfer | 2 | Mrs Patel, who teaches Year 6, organised the whole event. |
+| qg_p4_relative_parenthesis_transfer | 3 | The River Thames, which is over 200 miles long, flows through London. |
+| qg_p4_relative_parenthesis_transfer | 4 | The head teacher, who had been watching from the sideline, congratulated the team. |
+| qg_p4_relative_parenthesis_transfer | 5 | The school hall, which had been decorated overnight, was packed with parents. |
+| qg_p4_relative_parenthesis_transfer | 6 | My grandfather, who served in the navy, loves telling stories about the war. |
+| qg_p4_relative_parenthesis_transfer | 7 | The old bridge, which had been damaged in the flood, was finally repaired last summer. |
+| qg_p4_relative_parenthesis_transfer | 8 | The library book, which Amir borrowed last week, must be returned by Friday. |
+| qg_p4_relative_parenthesis_transfer | 9 | The oak tree, which was planted by the village founders, has stood for two hundred years. |
+| qg_p4_relative_parenthesis_transfer | 10 | Mrs Patel, who teaches Year 6, organised the whole event. |
+| qg_p4_relative_parenthesis_transfer | 11 | The River Thames, which is over 200 miles long, flows through London. |
+| qg_p4_relative_parenthesis_transfer | 12 | The head teacher, who had been watching from the sideline, congratulated the team. |
+| qg_p4_relative_parenthesis_transfer | 13 | The school hall, which had been decorated overnight, was packed with parents. |
+| qg_p4_relative_parenthesis_transfer | 14 | My grandfather, who served in the navy, loves telling stories about the war. |
+| qg_p4_relative_parenthesis_transfer | 15 | The old bridge, which had been damaged in the flood, was finally repaired last summer. |
+| qg_p4_relative_parenthesis_transfer | 16 | The library book, which Amir borrowed last week, must be returned by Friday. |
+| qg_p4_relative_parenthesis_transfer | 17 | The oak tree, which was planted by the village founders, has stood for two hundred years. |
+| qg_p4_relative_parenthesis_transfer | 18 | Mrs Patel, who teaches Year 6, organised the whole event. |
+| qg_p4_relative_parenthesis_transfer | 19 | The River Thames, which is over 200 miles long, flows through London. |
+| qg_p4_relative_parenthesis_transfer | 20 | The head teacher, who had been watching from the sideline, congratulated the team. |
+| qg_p4_relative_parenthesis_transfer | 21 | The school hall, which had been decorated overnight, was packed with parents. |
+| qg_p4_relative_parenthesis_transfer | 22 | My grandfather, who served in the navy, loves telling stories about the war. |
+| qg_p4_relative_parenthesis_transfer | 23 | The old bridge, which had been damaged in the flood, was finally repaired last summer. |
+| qg_p4_relative_parenthesis_transfer | 24 | The library book, which Amir borrowed last week, must be returned by Friday. |
+| qg_p4_relative_parenthesis_transfer | 25 | The oak tree, which was planted by the village founders, has stood for two hundred years. |
+| qg_p4_relative_parenthesis_transfer | 26 | Mrs Patel, who teaches Year 6, organised the whole event. |
+| qg_p4_relative_parenthesis_transfer | 27 | The River Thames, which is over 200 miles long, flows through London. |
+| qg_p4_relative_parenthesis_transfer | 28 | The head teacher, who had been watching from the sideline, congratulated the team. |
+| qg_p4_relative_parenthesis_transfer | 29 | The school hall, which had been decorated overnight, was packed with parents. |
+| qg_p4_relative_parenthesis_transfer | 30 | My grandfather, who served in the navy, loves telling stories about the war. |
+| qg_p4_sentence_speech_transfer | 1 | Did Mum really say, "Pack your bag now"? |
+| qg_p4_sentence_speech_transfer | 2 | The teacher told us, "Open your books to page twelve." |
+| qg_p4_sentence_speech_transfer | 3 | What a surprise it was when Grandad announced, "We are moving to Wales!" |
+| qg_p4_sentence_speech_transfer | 4 | Did the coach shout, "Run faster"? |
+| qg_p4_sentence_speech_transfer | 5 | Lena asked, "Where is the library?" |
+| qg_p4_sentence_speech_transfer | 6 | Ben shouted, "What a fantastic goal that was!" |
+| qg_p4_sentence_speech_transfer | 7 | Did the head teacher really announce, "School closes early on Friday"? |
+| qg_p4_sentence_speech_transfer | 8 | How loudly the sergeant bellowed, "Stand to attention!" |
+| qg_p4_sentence_speech_transfer | 9 | Did Mum really say, "Pack your bag now"? |
+| qg_p4_sentence_speech_transfer | 10 | The teacher told us, "Open your books to page twelve." |
+| qg_p4_sentence_speech_transfer | 11 | What a surprise it was when Grandad announced, "We are moving to Wales!" |
+| qg_p4_sentence_speech_transfer | 12 | Did the coach shout, "Run faster"? |
+| qg_p4_sentence_speech_transfer | 13 | Lena asked, "Where is the library?" |
+| qg_p4_sentence_speech_transfer | 14 | Ben shouted, "What a fantastic goal that was!" |
+| qg_p4_sentence_speech_transfer | 15 | Did the head teacher really announce, "School closes early on Friday"? |
+| qg_p4_sentence_speech_transfer | 16 | How loudly the sergeant bellowed, "Stand to attention!" |
+| qg_p4_sentence_speech_transfer | 17 | Did Mum really say, "Pack your bag now"? |
+| qg_p4_sentence_speech_transfer | 18 | The teacher told us, "Open your books to page twelve." |
+| qg_p4_sentence_speech_transfer | 19 | What a surprise it was when Grandad announced, "We are moving to Wales!" |
+| qg_p4_sentence_speech_transfer | 20 | Did the coach shout, "Run faster"? |
+| qg_p4_sentence_speech_transfer | 21 | Lena asked, "Where is the library?" |
+| qg_p4_sentence_speech_transfer | 22 | Ben shouted, "What a fantastic goal that was!" |
+| qg_p4_sentence_speech_transfer | 23 | Did the head teacher really announce, "School closes early on Friday"? |
+| qg_p4_sentence_speech_transfer | 24 | How loudly the sergeant bellowed, "Stand to attention!" |
+| qg_p4_sentence_speech_transfer | 25 | Did Mum really say, "Pack your bag now"? |
+| qg_p4_sentence_speech_transfer | 26 | The teacher told us, "Open your books to page twelve." |
+| qg_p4_sentence_speech_transfer | 27 | What a surprise it was when Grandad announced, "We are moving to Wales!" |
+| qg_p4_sentence_speech_transfer | 28 | Did the coach shout, "Run faster"? |
+| qg_p4_sentence_speech_transfer | 29 | Lena asked, "Where is the library?" |
+| qg_p4_sentence_speech_transfer | 30 | Ben shouted, "What a fantastic goal that was!" |
+| qg_p4_verb_form_register_transfer | 1 | Your child will need a packed lunch and should wear comfortable shoes. |
+| qg_p4_verb_form_register_transfer | 2 | The mixture changed colour, which could indicate a chemical reaction. |
+| qg_p4_verb_form_register_transfer | 3 | A blue coat has been found; it must belong to someone in Year 5. |
+| qg_p4_verb_form_register_transfer | 4 | An author will visit tomorrow; pupils may ask questions afterwards. |
+| qg_p4_verb_form_register_transfer | 5 | Children were lining up when the alarm rang; they had to leave calmly. |
+| qg_p4_verb_form_register_transfer | 6 | Plastic takes hundreds of years to break down; we can reduce waste by recycling. |
+| qg_p4_verb_form_register_transfer | 7 | Grandma had hidden the present before I arrived; she might have planned it for weeks. |
+| qg_p4_verb_form_register_transfer | 8 | Pupils read silently for twenty minutes; they may choose their own book. |
+| qg_p4_verb_form_register_transfer | 9 | Your child will need a packed lunch and should wear comfortable shoes. |
+| qg_p4_verb_form_register_transfer | 10 | The mixture changed colour, which could indicate a chemical reaction. |
+| qg_p4_verb_form_register_transfer | 11 | A blue coat has been found; it must belong to someone in Year 5. |
+| qg_p4_verb_form_register_transfer | 12 | An author will visit tomorrow; pupils may ask questions afterwards. |
+| qg_p4_verb_form_register_transfer | 13 | Children were lining up when the alarm rang; they had to leave calmly. |
+| qg_p4_verb_form_register_transfer | 14 | Plastic takes hundreds of years to break down; we can reduce waste by recycling. |
+| qg_p4_verb_form_register_transfer | 15 | Grandma had hidden the present before I arrived; she might have planned it for weeks. |
+| qg_p4_verb_form_register_transfer | 16 | Pupils read silently for twenty minutes; they may choose their own book. |
+| qg_p4_verb_form_register_transfer | 17 | Your child will need a packed lunch and should wear comfortable shoes. |
+| qg_p4_verb_form_register_transfer | 18 | The mixture changed colour, which could indicate a chemical reaction. |
+| qg_p4_verb_form_register_transfer | 19 | A blue coat has been found; it must belong to someone in Year 5. |
+| qg_p4_verb_form_register_transfer | 20 | An author will visit tomorrow; pupils may ask questions afterwards. |
+| qg_p4_verb_form_register_transfer | 21 | Children were lining up when the alarm rang; they had to leave calmly. |
+| qg_p4_verb_form_register_transfer | 22 | Plastic takes hundreds of years to break down; we can reduce waste by recycling. |
+| qg_p4_verb_form_register_transfer | 23 | Grandma had hidden the present before I arrived; she might have planned it for weeks. |
+| qg_p4_verb_form_register_transfer | 24 | Pupils read silently for twenty minutes; they may choose their own book. |
+| qg_p4_verb_form_register_transfer | 25 | Your child will need a packed lunch and should wear comfortable shoes. |
+| qg_p4_verb_form_register_transfer | 26 | The mixture changed colour, which could indicate a chemical reaction. |
+| qg_p4_verb_form_register_transfer | 27 | A blue coat has been found; it must belong to someone in Year 5. |
+| qg_p4_verb_form_register_transfer | 28 | An author will visit tomorrow; pupils may ask questions afterwards. |
+| qg_p4_verb_form_register_transfer | 29 | Children were lining up when the alarm rang; they had to leave calmly. |
+| qg_p4_verb_form_register_transfer | 30 | Plastic takes hundreds of years to break down; we can reduce waste by recycling. |
+| qg_p4_voice_roles_transfer | 1 | Voice of the sentence: passive \| Role of 'the trophy': subject |
+| qg_p4_voice_roles_transfer | 2 | Voice of the sentence: active \| Role of 'the penalty': object |
+| qg_p4_voice_roles_transfer | 3 | Voice of the sentence: passive \| Role of 'the cake': subject |
+| qg_p4_voice_roles_transfer | 4 | Voice of the sentence: active \| Role of 'the scenery': object |
+| qg_p4_voice_roles_transfer | 5 | Voice of the sentence: passive \| Role of 'the windows': subject |
+| qg_p4_voice_roles_transfer | 6 | Voice of the sentence: active \| Role of 'the new books': object |
+| qg_p4_voice_roles_transfer | 7 | Voice of the sentence: passive \| Role of 'the letter': subject |
+| qg_p4_voice_roles_transfer | 8 | Voice of the sentence: active \| Role of 'the heavy equipment': object |
+| qg_p4_voice_roles_transfer | 9 | Voice of the sentence: passive \| Role of 'the trophy': subject |
+| qg_p4_voice_roles_transfer | 10 | Voice of the sentence: active \| Role of 'the penalty': object |
+| qg_p4_voice_roles_transfer | 11 | Voice of the sentence: passive \| Role of 'the cake': subject |
+| qg_p4_voice_roles_transfer | 12 | Voice of the sentence: active \| Role of 'the scenery': object |
+| qg_p4_voice_roles_transfer | 13 | Voice of the sentence: passive \| Role of 'the windows': subject |
+| qg_p4_voice_roles_transfer | 14 | Voice of the sentence: active \| Role of 'the new books': object |
+| qg_p4_voice_roles_transfer | 15 | Voice of the sentence: passive \| Role of 'the letter': subject |
+| qg_p4_voice_roles_transfer | 16 | Voice of the sentence: active \| Role of 'the heavy equipment': object |
+| qg_p4_voice_roles_transfer | 17 | Voice of the sentence: passive \| Role of 'the trophy': subject |
+| qg_p4_voice_roles_transfer | 18 | Voice of the sentence: active \| Role of 'the penalty': object |
+| qg_p4_voice_roles_transfer | 19 | Voice of the sentence: passive \| Role of 'the cake': subject |
+| qg_p4_voice_roles_transfer | 20 | Voice of the sentence: active \| Role of 'the scenery': object |
+| qg_p4_voice_roles_transfer | 21 | Voice of the sentence: passive \| Role of 'the windows': subject |
+| qg_p4_voice_roles_transfer | 22 | Voice of the sentence: active \| Role of 'the new books': object |
+| qg_p4_voice_roles_transfer | 23 | Voice of the sentence: passive \| Role of 'the letter': subject |
+| qg_p4_voice_roles_transfer | 24 | Voice of the sentence: active \| Role of 'the heavy equipment': object |
+| qg_p4_voice_roles_transfer | 25 | Voice of the sentence: passive \| Role of 'the trophy': subject |
+| qg_p4_voice_roles_transfer | 26 | Voice of the sentence: active \| Role of 'the penalty': object |
+| qg_p4_voice_roles_transfer | 27 | Voice of the sentence: passive \| Role of 'the cake': subject |
+| qg_p4_voice_roles_transfer | 28 | Voice of the sentence: active \| Role of 'the scenery': object |
+| qg_p4_voice_roles_transfer | 29 | Voice of the sentence: passive \| Role of 'the windows': subject |
+| qg_p4_voice_roles_transfer | 30 | Voice of the sentence: active \| Role of 'the new books': object |
+| qg_p4_word_class_noun_phrase_transfer | 1 | Head noun: bicycle \| Word class of 'rusty': adjective |
+| qg_p4_word_class_noun_phrase_transfer | 2 | Head noun: storm \| Word class of 'mountain': noun |
+| qg_p4_word_class_noun_phrase_transfer | 3 | Head noun: firefighters \| Word class of 'incredibly': adverb |
+| qg_p4_word_class_noun_phrase_transfer | 4 | Head noun: lesson \| Word class of 'every': determiner |
+| qg_p4_word_class_noun_phrase_transfer | 5 | Head noun: fence \| Word class of 'painted': adjective |
+| qg_p4_word_class_noun_phrase_transfer | 6 | Head noun: crates \| Word class of 'several': determiner |
+| qg_p4_word_class_noun_phrase_transfer | 7 | Head noun: costume \| Word class of 'swimming': adjective |
+| qg_p4_word_class_noun_phrase_transfer | 8 | Head noun: castle \| Word class of 'their': determiner |
+| qg_p4_word_class_noun_phrase_transfer | 9 | Head noun: bicycle \| Word class of 'rusty': adjective |
+| qg_p4_word_class_noun_phrase_transfer | 10 | Head noun: storm \| Word class of 'mountain': noun |
+| qg_p4_word_class_noun_phrase_transfer | 11 | Head noun: firefighters \| Word class of 'incredibly': adverb |
+| qg_p4_word_class_noun_phrase_transfer | 12 | Head noun: lesson \| Word class of 'every': determiner |
+| qg_p4_word_class_noun_phrase_transfer | 13 | Head noun: fence \| Word class of 'painted': adjective |
+| qg_p4_word_class_noun_phrase_transfer | 14 | Head noun: crates \| Word class of 'several': determiner |
+| qg_p4_word_class_noun_phrase_transfer | 15 | Head noun: costume \| Word class of 'swimming': adjective |
+| qg_p4_word_class_noun_phrase_transfer | 16 | Head noun: castle \| Word class of 'their': determiner |
+| qg_p4_word_class_noun_phrase_transfer | 17 | Head noun: bicycle \| Word class of 'rusty': adjective |
+| qg_p4_word_class_noun_phrase_transfer | 18 | Head noun: storm \| Word class of 'mountain': noun |
+| qg_p4_word_class_noun_phrase_transfer | 19 | Head noun: firefighters \| Word class of 'incredibly': adverb |
+| qg_p4_word_class_noun_phrase_transfer | 20 | Head noun: lesson \| Word class of 'every': determiner |
+| qg_p4_word_class_noun_phrase_transfer | 21 | Head noun: fence \| Word class of 'painted': adjective |
+| qg_p4_word_class_noun_phrase_transfer | 22 | Head noun: crates \| Word class of 'several': determiner |
+| qg_p4_word_class_noun_phrase_transfer | 23 | Head noun: costume \| Word class of 'swimming': adjective |
+| qg_p4_word_class_noun_phrase_transfer | 24 | Head noun: castle \| Word class of 'their': determiner |
+| qg_p4_word_class_noun_phrase_transfer | 25 | Head noun: bicycle \| Word class of 'rusty': adjective |
+| qg_p4_word_class_noun_phrase_transfer | 26 | Head noun: storm \| Word class of 'mountain': noun |
+| qg_p4_word_class_noun_phrase_transfer | 27 | Head noun: firefighters \| Word class of 'incredibly': adverb |
+| qg_p4_word_class_noun_phrase_transfer | 28 | Head noun: lesson \| Word class of 'every': determiner |
+| qg_p4_word_class_noun_phrase_transfer | 29 | Head noun: fence \| Word class of 'painted': adjective |
+| qg_p4_word_class_noun_phrase_transfer | 30 | Head noun: crates \| Word class of 'several': determiner |
+| qg_pronoun_referent_identify | 1 | Oliver |
+| qg_pronoun_referent_identify | 2 | The pupils |
+| qg_pronoun_referent_identify | 3 | Ava |
+| qg_pronoun_referent_identify | 4 | the cat |
+| qg_pronoun_referent_identify | 5 | Noah |
+| qg_pronoun_referent_identify | 6 | the choir |
+| qg_pronoun_referent_identify | 7 | the book |
+| qg_pronoun_referent_identify | 8 | Ben |
+| qg_pronoun_referent_identify | 9 | the map |
+| qg_pronoun_referent_identify | 10 | Oliver |
+| qg_pronoun_referent_identify | 11 | The pupils |
+| qg_pronoun_referent_identify | 12 | Ava |
+| qg_pronoun_referent_identify | 13 | the cat |
+| qg_pronoun_referent_identify | 14 | Noah |
+| qg_pronoun_referent_identify | 15 | the choir |
+| qg_pronoun_referent_identify | 16 | the book |
+| qg_pronoun_referent_identify | 17 | Ben |
+| qg_pronoun_referent_identify | 18 | the map |
+| qg_pronoun_referent_identify | 19 | Oliver |
+| qg_pronoun_referent_identify | 20 | The pupils |
+| qg_pronoun_referent_identify | 21 | Ava |
+| qg_pronoun_referent_identify | 22 | the cat |
+| qg_pronoun_referent_identify | 23 | Noah |
+| qg_pronoun_referent_identify | 24 | the choir |
+| qg_pronoun_referent_identify | 25 | the book |
+| qg_pronoun_referent_identify | 26 | Ben |
+| qg_pronoun_referent_identify | 27 | the map |
+| qg_pronoun_referent_identify | 28 | Oliver |
+| qg_pronoun_referent_identify | 29 | The pupils |
+| qg_pronoun_referent_identify | 30 | Ava |
+| qg_subject_object_classify_table | 1 | In "Amira found the lantern.", what is "Amira"? subject \| In "Ruby packed the sketchbook.", what is "the sketchbook"? object |
+| qg_subject_object_classify_table | 2 | In "Jay packed the map.", what is "Jay"? subject \| In "Luca lifted the sketchbook.", what is "the sketchbook"? object |
+| qg_subject_object_classify_table | 3 | In "Jay dropped the lantern.", what is "Jay"? subject \| In "Ava dropped the picnic basket.", what is "the picnic basket"? object |
+| qg_subject_object_classify_table | 4 | In "Ruby opened the map.", what is "Ruby"? subject \| In "Ava found the gate.", what is "the gate"? object |
+| qg_subject_object_classify_table | 5 | In "Jay opened the picnic basket.", what is "Jay"? subject \| In "Amira found the lantern.", what is "the lantern"? object |
+| qg_subject_object_classify_table | 6 | In "Luca lifted the lantern.", what is "Luca"? subject \| In "Mia carried the window.", what is "the window"? object |
+| qg_subject_object_classify_table | 7 | In "Ava locked the lantern.", what is "Ava"? subject \| In "Jay dropped the window.", what is "the window"? object |
+| qg_subject_object_classify_table | 8 | In "Ben packed the rucksack.", what is "Ben"? subject \| In "Jay dropped the window.", what is "the window"? object |
+| qg_subject_object_classify_table | 9 | In "Mia opened the picnic basket.", what is "Mia"? subject \| In "Nora lifted the rucksack.", what is "the rucksack"? object |
+| qg_subject_object_classify_table | 10 | In "Luca lifted the sketchbook.", what is "Luca"? subject \| In "Nora dropped the trophy.", what is "the trophy"? object |
+| qg_subject_object_classify_table | 11 | In "Luca found the window.", what is "Luca"? subject \| In "Amira found the picnic basket.", what is "the picnic basket"? object |
+| qg_subject_object_classify_table | 12 | In "Noah found the lantern.", what is "Noah"? subject \| In "Ruby carried the gate.", what is "the gate"? object |
+| qg_subject_object_classify_table | 13 | In "Luca carried the map.", what is "Luca"? subject \| In "Ava carried the lantern.", what is "the lantern"? object |
+| qg_subject_object_classify_table | 14 | In "Zac found the trophy.", what is "Zac"? subject \| In "Elsie dropped the gate.", what is "the gate"? object |
+| qg_subject_object_classify_table | 15 | In "Mia dropped the trophy.", what is "Mia"? subject \| In "Zac lifted the gate.", what is "the gate"? object |
+| qg_subject_object_classify_table | 16 | In "Amira cleaned the gate.", what is "Amira"? subject \| In "Elsie carried the map.", what is "the map"? object |
+| qg_subject_object_classify_table | 17 | In "Jay found the gate.", what is "Jay"? subject \| In "Ben cleaned the lantern.", what is "the lantern"? object |
+| qg_subject_object_classify_table | 18 | In "Elsie found the window.", what is "Elsie"? subject \| In "Mia found the picnic basket.", what is "the picnic basket"? object |
+| qg_subject_object_classify_table | 19 | In "Ava dropped the map.", what is "Ava"? subject \| In "Nora packed the sketchbook.", what is "the sketchbook"? object |
+| qg_subject_object_classify_table | 20 | In "Nora found the trophy.", what is "Nora"? subject \| In "Noah opened the trophy.", what is "the trophy"? object |
+| qg_subject_object_classify_table | 21 | In "Zac packed the trophy.", what is "Zac"? subject \| In "Elsie locked the trophy.", what is "the trophy"? object |
+| qg_subject_object_classify_table | 22 | In "Amira opened the gate.", what is "Amira"? subject \| In "Mia locked the map.", what is "the map"? object |
+| qg_subject_object_classify_table | 23 | In "Ben lifted the lantern.", what is "Ben"? subject \| In "Noah opened the map.", what is "the map"? object |
+| qg_subject_object_classify_table | 24 | In "Noah packed the sketchbook.", what is "Noah"? subject \| In "Ben carried the window.", what is "the window"? object |
+| qg_subject_object_classify_table | 25 | In "Amira found the picnic basket.", what is "Amira"? subject \| In "Jay carried the map.", what is "the map"? object |
+| qg_subject_object_classify_table | 26 | In "Luca found the rucksack.", what is "Luca"? subject \| In "Ava found the picnic basket.", what is "the picnic basket"? object |
+| qg_subject_object_classify_table | 27 | In "Elsie carried the lantern.", what is "Elsie"? subject \| In "Mia opened the picnic basket.", what is "the picnic basket"? object |
+| qg_subject_object_classify_table | 28 | In "Zac lifted the rucksack.", what is "Zac"? subject \| In "Jay packed the map.", what is "the map"? object |
+| qg_subject_object_classify_table | 29 | In "Mia packed the gate.", what is "Mia"? subject \| In "Mia packed the trophy.", what is "the trophy"? object |
+| qg_subject_object_classify_table | 30 | In "Sam dropped the picnic basket.", what is "Sam"? subject \| In "Mia dropped the gate.", what is "the gate"? object |

--- a/scripts/generate-grammar-review-pack.mjs
+++ b/scripts/generate-grammar-review-pack.mjs
@@ -1,0 +1,264 @@
+#!/usr/bin/env node
+/**
+ * Grammar QG P5 — Reviewer Sample Pack Generator
+ *
+ * Produces a deterministic reviewer-friendly markdown document showing
+ * sample prompts (without answer keys) for each generated template family,
+ * with a separate Reviewer Answer Appendix at the bottom.
+ *
+ * Usage:  node scripts/generate-grammar-review-pack.mjs
+ * Output: reports/grammar/grammar-qg-p5-review-pack.md
+ */
+import { execSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  GRAMMAR_TEMPLATE_METADATA,
+  createGrammarQuestion,
+  grammarQuestionVariantSignature,
+} from '../worker/src/subjects/grammar/content.js';
+
+const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const OUTPUT_DIR = path.join(ROOT_DIR, 'reports', 'grammar');
+const OUTPUT_FILE = path.join(OUTPUT_DIR, 'grammar-qg-p5-review-pack.md');
+
+const SEED_WINDOW_START = 1;
+const SEED_WINDOW_END = 30;
+const MAX_SAMPLE_PROMPTS = 5;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getCommitSha() {
+  try {
+    return execSync('git rev-parse HEAD', { cwd: ROOT_DIR, encoding: 'utf8' }).trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
+function stripHtml(html) {
+  if (!html) return '';
+  return String(html)
+    .replace(/<[^>]*>/g, '')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function escapeMarkdown(text) {
+  return String(text || '').replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
+function formatOptions(inputSpec) {
+  if (!inputSpec || !inputSpec.options) return '';
+  const labels = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
+  return inputSpec.options
+    .map((opt, i) => `${labels[i] || String(i + 1)}) ${opt.label || opt.value || ''}`)
+    .join(', ');
+}
+
+function extractCorrectAnswer(question) {
+  // Use the evaluate function with an empty response to get answerText
+  if (typeof question.evaluate === 'function') {
+    try {
+      const result = question.evaluate({});
+      if (result && result.answerText) return result.answerText;
+    } catch { /* fall through */ }
+  }
+  // Fallback: last solutionLine often contains the answer
+  if (Array.isArray(question.solutionLines) && question.solutionLines.length > 0) {
+    return stripHtml(question.solutionLines[question.solutionLines.length - 1]);
+  }
+  return '(see solution)';
+}
+
+// ---------------------------------------------------------------------------
+// Core generation
+// ---------------------------------------------------------------------------
+
+function buildFamilies() {
+  // Group templates by generatorFamilyId
+  const familyMap = new Map();
+
+  for (const meta of GRAMMAR_TEMPLATE_METADATA) {
+    if (!meta.generative) continue;
+    const familyId = meta.generatorFamilyId;
+    if (!familyMap.has(familyId)) {
+      familyMap.set(familyId, {
+        familyId,
+        templateIds: [],
+        skillIds: new Set(),
+        answerSpecKind: null,
+        questionType: null,
+        tags: new Set(),
+      });
+    }
+    const family = familyMap.get(familyId);
+    family.templateIds.push(meta.id);
+    for (const s of meta.skillIds) family.skillIds.add(s);
+    if (meta.answerSpecKind) family.answerSpecKind = meta.answerSpecKind;
+    if (meta.questionType) family.questionType = meta.questionType;
+    for (const t of meta.tags) family.tags.add(t);
+  }
+
+  return Array.from(familyMap.values())
+    .map((f) => ({
+      ...f,
+      skillIds: Array.from(f.skillIds).sort(),
+      templateIds: Array.from(new Set(f.templateIds)).sort(),
+      tags: Array.from(f.tags).sort(),
+    }))
+    .sort((a, b) => a.familyId.localeCompare(b.familyId));
+}
+
+function generateFamilyData(family) {
+  const primaryTemplateId = family.templateIds[0];
+  const signatures = new Set();
+  const samples = [];
+  const answers = [];
+
+  for (let seed = SEED_WINDOW_START; seed <= SEED_WINDOW_END; seed++) {
+    const question = createGrammarQuestion({ templateId: primaryTemplateId, seed });
+    if (!question) continue;
+
+    const sig = grammarQuestionVariantSignature(question);
+    signatures.add(sig || `seed-${seed}`);
+
+    const correctAnswer = extractCorrectAnswer(question);
+    answers.push({ seed, correctAnswer });
+
+    // Collect distinct samples (by signature)
+    if (samples.length < MAX_SAMPLE_PROMPTS) {
+      const alreadySampled = samples.some(
+        (s) => grammarQuestionVariantSignature(s.question) === sig
+      );
+      if (!alreadySampled) {
+        samples.push({ seed, question });
+      }
+    }
+  }
+
+  return {
+    uniqueVariants: signatures.size,
+    samples,
+    answers,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Markdown rendering
+// ---------------------------------------------------------------------------
+
+function renderFamilySection(family, data) {
+  const lines = [];
+  lines.push(`## Family: ${family.familyId}`);
+  lines.push('');
+  lines.push(`- **Template ID(s):** ${family.templateIds.join(', ')}`);
+  lines.push(`- **Skill IDs:** ${family.skillIds.join(', ')}`);
+  lines.push(`- **Answer-spec kind:** ${family.answerSpecKind || 'inline'}`);
+  lines.push(`- **Question type:** ${family.questionType || 'unknown'}`);
+  lines.push(`- **Tags:** ${family.tags.join(', ') || 'none'}`);
+  lines.push(`- **Unique variants (seeds 1..30):** ${data.uniqueVariants}`);
+  lines.push('');
+  lines.push('### Sample Prompts');
+  lines.push('');
+
+  for (const { seed, question } of data.samples) {
+    lines.push(`#### Seed ${seed}`);
+    lines.push(`**Question type:** ${question.questionType}`);
+    lines.push(`**Stem:** ${stripHtml(question.stemHtml)}`);
+    if (question.inputSpec && question.inputSpec.options) {
+      lines.push(`**Options:** ${formatOptions(question.inputSpec)}`);
+    } else if (question.inputSpec && question.inputSpec.type) {
+      lines.push(`**Input:** ${question.inputSpec.type} — ${question.inputSpec.label || ''}`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+function renderAnswerAppendix(families, familyDataMap) {
+  const lines = [];
+  lines.push('## Reviewer Answer Appendix');
+  lines.push('');
+  lines.push('> ⚠️ This section contains correct answers. Do not share with learners.');
+  lines.push('');
+  lines.push('| Family | Seed | Correct Answer |');
+  lines.push('|---|---|---|');
+
+  for (const family of families) {
+    const data = familyDataMap.get(family.familyId);
+    if (!data) continue;
+    for (const { seed, correctAnswer } of data.answers) {
+      lines.push(`| ${family.familyId} | ${seed} | ${escapeMarkdown(correctAnswer)} |`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function renderDocument(families, familyDataMap, commitSha) {
+  const lines = [];
+  lines.push('# Grammar QG P5 — Reviewer Sample Pack');
+  lines.push('');
+  lines.push(`Generated from commit: ${commitSha}`);
+  lines.push('Release: grammar-qg-p5-2026-04-28');
+  lines.push(`Seed window: ${SEED_WINDOW_START}..${SEED_WINDOW_END}`);
+  lines.push(`Total generated families: ${families.length}`);
+  lines.push('');
+  lines.push('---');
+  lines.push('');
+
+  for (const family of families) {
+    const data = familyDataMap.get(family.familyId);
+    if (!data) continue;
+    lines.push(renderFamilySection(family, data));
+    lines.push('---');
+    lines.push('');
+  }
+
+  lines.push(renderAnswerAppendix(families, familyDataMap));
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+  const commitSha = getCommitSha();
+  const families = buildFamilies();
+
+  const familyDataMap = new Map();
+  for (const family of families) {
+    familyDataMap.set(family.familyId, generateFamilyData(family));
+  }
+
+  const markdown = renderDocument(families, familyDataMap, commitSha);
+
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  writeFileSync(OUTPUT_FILE, markdown, 'utf8');
+
+  // Summary
+  const totalFamilies = families.length;
+  const p5Families = families.filter((f) => f.tags.includes('qg-p5')).length;
+  console.log(`Grammar QG P5 Review Pack generated.`);
+  console.log(`  Commit: ${commitSha}`);
+  console.log(`  Total generated families: ${totalFamilies}`);
+  console.log(`  P5-tagged families: ${p5Families}`);
+  console.log(`  Output: ${OUTPUT_FILE}`);
+}
+
+main();


### PR DESCRIPTION
## Summary

- Adds `scripts/generate-grammar-review-pack.mjs` — deterministic script that generates a reviewer-friendly markdown sample pack for all generated grammar template families
- Generates `reports/grammar/grammar-qg-p5-review-pack.md` covering all 52 generated families (including the 12 P5-expanded ones) across seed window 1..30
- Answer keys are strictly isolated in a "Reviewer Answer Appendix" section at the bottom — prompt sections show stemHtml, options (labels only), and question type without leaking correct answers

## Design

- **Deterministic**: fixed seed window (1..30), no Date.now or Math.random — output is reproducible for same commit
- **No-answer-leak**: prompt sections show only what a learner would see; correct answers appear only in the clearly-labelled appendix
- **Comprehensive**: covers all generative families grouped by `generatorFamilyId`, with unique variant counts and up to 5 distinct sample prompts per family

## Test plan

- [x] Script runs without error: `node scripts/generate-grammar-review-pack.mjs`
- [x] Output exists at `reports/grammar/grammar-qg-p5-review-pack.md` (3551 lines)
- [x] Prompt sections contain no `correctAnswer`, `answerSpec`, `golden`, or answer text
- [x] Answer appendix table is populated with all 52 families x 30 seeds
- [x] Re-running script produces identical output (deterministic)